### PR TITLE
fix(mosh): restore Windows reconnect startup

### DIFF
--- a/application/state/useTerminalBackend.ts
+++ b/application/state/useTerminalBackend.ts
@@ -111,9 +111,9 @@ export const useTerminalBackend = () => {
     bridge?.ackSessionFlow?.(sessionId, bytes);
   }, []);
 
-  const closeSession = useCallback((sessionId: string) => {
+  const closeSession = useCallback(async (sessionId: string) => {
     const bridge = netcattyBridge.get();
-    bridge?.closeSession?.(sessionId);
+    await bridge?.closeSession?.(sessionId);
   }, []);
 
   const setSessionEncoding = useCallback(async (sessionId: string, encoding: string) => {

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1206,7 +1206,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     captureHandler(capturedSessionId, capturedData);
   }, [finalizeTerminalLogData]);
 
-  const cleanupSession = () => {
+  const cleanupSession = async () => {
     const closingSessionId = sessionRef.current;
     disposeDataRef.current?.();
     disposeDataRef.current = null;
@@ -1227,7 +1227,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         clearTerminalSessionFlowAck(closingSessionId);
       }
       try {
-        terminalBackend.closeSession(closingSessionId);
+        await terminalBackend.closeSession(closingSessionId);
       } catch (err) {
         logger.warn("Failed to close SSH session", err);
       }
@@ -1278,7 +1278,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       flushTerminalSessionFlowAck(closingSessionId);
       clearTerminalSessionFlowAck(closingSessionId);
       try {
-        terminalBackend.closeSession(closingSessionId);
+        const closeResult = terminalBackend.closeSession(closingSessionId);
+        void Promise.resolve(closeResult).catch((err) => {
+          logger.warn("Failed to close hibernated session", err);
+        });
       } catch (err) {
         logger.warn("Failed to close hibernated session", err);
       }
@@ -1510,7 +1513,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     suppressHostStartupCommandRef.current = false;
     clearHibernateRetry();
     clearAutoReconnect();
-    cleanupSession();
+    void cleanupSession();
     disposeRuntimeOnly();
   };
 
@@ -2283,7 +2286,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     setPendingHostKeyRequestId(null);
     setError("Connection cancelled");
     setProgressLogs((prev) => [...prev, "Cancelled by user."]);
-    cleanupSession();
+    void cleanupSession();
     updateStatus("disconnected");
     setChainProgress(null);
     setTimeout(() => setIsCancelling(false), 600);
@@ -2338,7 +2341,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     setPendingHostKeyRequestId(null);
   };
 
-  const startReconnect = (mode: "manual" | "auto" = "manual") => {
+  const startReconnect = async (mode: "manual" | "auto" = "manual") => {
     if (!termRef.current && hibernatedRef.current) {
       if (reconnectWakeInFlightRef.current) return;
       const wakeForReconnect = wakeHibernatedRuntimeForReconnectRef.current;
@@ -2381,8 +2384,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       restoreCwdIntentRef.current = null;
       suppressHostStartupCommandRef.current = true;
     }
-    cleanupSession();
-    // closeSession wiped preload ready listeners — re-arm before startMosh so a
+    await cleanupSession();
+    // closeSession wiped preload ready listeners; re-arm before startMosh so a
     // fast handshake cannot emit netcatty:mosh:ready into an empty map.
     prepareMoshReadySubscription();
     const term = termRef.current;

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -2384,18 +2384,24 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       restoreCwdIntentRef.current = null;
       suppressHostStartupCommandRef.current = true;
     }
+    // Claim the retry before awaiting close. A close/cancel/unmount during the
+    // awaited backend cleanup invalidates this token and stops the continuation.
+    const retryToken = Symbol("retry");
+    retryTokenRef.current = retryToken;
+    const retryTokenStillCurrent = () => retryTokenRef.current === retryToken;
+
     await cleanupSession();
+    if (!retryTokenStillCurrent()) return;
+    const term = termRef.current;
+    if (!term) return;
     // closeSession wiped preload ready listeners; re-arm before startMosh so a
     // fast handshake cannot emit netcatty:mosh:ready into an empty map.
     prepareMoshReadySubscription();
-    const term = termRef.current;
-    // Claim a fresh retry token. If the user cancels / closes / unmounts /
-    // kicks off another retry while the chained writes below are still
-    // queued, the token will be invalidated and our callbacks will abort
-    // before opening a ghost backend session with no owning UI.
-    const retryToken = Symbol("retry");
-    retryTokenRef.current = retryToken;
-    const retryStillActive = () => retryTokenRef.current === retryToken && termRef.current === term;
+    // Keep the same retry token through the queued writes. If the user cancels /
+    // closes / unmounts / kicks off another retry while the chained writes are
+    // queued, the token is invalidated and callbacks abort before opening a
+    // ghost backend session with no owning UI.
+    const retryStillActive = () => retryTokenStillCurrent() && termRef.current === term;
 
     isBootActiveRef.current = true;
     auth.resetForRetry();

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -380,6 +380,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const wakeInProgressRef = useRef(false);
   const wakePromiseRef = useRef<Promise<boolean> | null>(null);
   const sessionRef = useRef<string | null>(null);
+  const sessionCleanupPromiseRef = useRef<Promise<void> | null>(null);
   const isBootActiveRef = useRef(false);
   const hasConnectedRef = useRef(false);
   const hasRunStartupCommandRef = useRef(false);
@@ -1208,6 +1209,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const cleanupSession = async () => {
     const closingSessionId = sessionRef.current;
+    sessionRef.current = null;
     disposeDataRef.current?.();
     disposeDataRef.current = null;
     disposeExitRef.current?.();
@@ -1216,7 +1218,14 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     disposeTelnetEchoModeRef.current = null;
     telnetLocalEchoRef.current = false;
 
-    if (closingSessionId) {
+    const pendingCleanup = sessionCleanupPromiseRef.current;
+    if (pendingCleanup) {
+      await pendingCleanup;
+    }
+
+    if (!closingSessionId) return;
+
+    const cleanupPromise = (async () => {
       const activeTerm = termRef.current;
       if (activeTerm) {
         releaseTerminalFlowBeforeHibernate(terminalBackend, activeTerm, closingSessionId, {
@@ -1231,8 +1240,16 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       } catch (err) {
         logger.warn("Failed to close SSH session", err);
       }
+    })();
+
+    sessionCleanupPromiseRef.current = cleanupPromise;
+    try {
+      await cleanupPromise;
+    } finally {
+      if (sessionCleanupPromiseRef.current === cleanupPromise) {
+        sessionCleanupPromiseRef.current = null;
+      }
     }
-    sessionRef.current = null;
   };
 
   const disposeRuntimeOnly = () => {

--- a/components/terminal/runtime/createTerminalSessionStarters.types.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.types.ts
@@ -83,6 +83,7 @@ export type TerminalBackendApi = {
   writeToSession: (sessionId: string, data: string, options?: { automated?: boolean; lineDelayMs?: number; logRewrite?: ProgrammaticCommandLogRewrite }) => void;
   interruptSession?: (sessionId: string, trace?: NetcattyTerminalInterruptTrace) => void;
   resizeSession: (sessionId: string, cols: number, rows: number) => void;
+  closeSession: (sessionId: string) => void | Promise<void>;
   /** Pause/resume the source stream for output back-pressure (optional). */
   setSessionFlowPaused?: (sessionId: string, paused: boolean) => void;
   /** Acknowledge rendered terminal output bytes for main-process IPC back-pressure. */

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -621,7 +621,10 @@ export const closeOrphanBackendSession = (
   sessionBackendId: string,
 ) => {
   try {
-    ctx.terminalBackend.closeSession(sessionBackendId);
+    const closeResult = ctx.terminalBackend.closeSession(sessionBackendId);
+    void Promise.resolve(closeResult).catch((err) => {
+      logger.warn("Failed to close orphan session after terminal unmount", err);
+    });
   } catch (err) {
     logger.warn("Failed to close orphan session after terminal unmount", err);
   }

--- a/electron/bridges/moshHandshake.cjs
+++ b/electron/bridges/moshHandshake.cjs
@@ -36,7 +36,7 @@ const net = require("node:net");
 // offsets so the sniffer can redact the marker from the visible stream.
 // eslint-disable-next-line no-control-regex
 const ANSI_ESCAPE_RE = /\u001b(?:\[[0-9;?]*[ -/]*[@-~]|\][^\u0007\u001b]*(?:\u0007|\u001b\\)|[PX^_][^\u001b]*\u001b\\|.)/g;
-const MOSH_CONNECT_RE = /MOSH CONNECT[ \t]+(\d{1,5})[ \t]+([A-Za-z0-9+/]+={0,2})(?![A-Za-z0-9+/=])/;
+const MOSH_CONNECT_PREFIX_RE = /MOSH CONNECT[ \t]+(\d{1,5})[ \t]+/;
 const MOSH_IP_RE = /MOSH IP[ \t]+(\S+)/;
 const PROTOCOL_MARKERS = ["MOSH CONNECT", "MOSH IP"];
 const MOSH_LOCALE_NAMES = [
@@ -94,19 +94,60 @@ function stripAnsiEscapesWithMap(text) {
 
 function parseConnectLine(line) {
   const { cleaned, cleanToOriginal } = stripAnsiEscapesWithMap(line);
-  const m = MOSH_CONNECT_RE.exec(cleaned);
+  const m = MOSH_CONNECT_PREFIX_RE.exec(cleaned);
   if (!m) return null;
   const port = Number(m[1]);
-  const key = m[2];
   if (!Number.isFinite(port) || port <= 0 || port > 65535) return null;
+
+  const connectIdx = cleanToOriginal[m.index];
+  const keyStartOffset = cleanToOriginal[m.index + m[0].length];
+  if (connectIdx === undefined || keyStartOffset === undefined) return null;
+
+  let key = "";
+  let pos = keyStartOffset;
+  while (pos < line.length && key.length < 22) {
+    const ch = line[pos];
+    if (ch === "\u001b") {
+      ANSI_ESCAPE_RE.lastIndex = pos;
+      const esc = ANSI_ESCAPE_RE.exec(line);
+      if (esc && esc.index === pos) {
+        pos = ANSI_ESCAPE_RE.lastIndex;
+        continue;
+      }
+    }
+    if (!/[A-Za-z0-9+/]/.test(ch)) return null;
+    key += ch;
+    pos += 1;
+  }
+
+  if (key.length !== 22) return null;
+
+  let paddingLookahead = pos;
+  while (paddingLookahead < line.length) {
+    const ch = line[paddingLookahead];
+    if (ch !== "\u001b") break;
+    ANSI_ESCAPE_RE.lastIndex = paddingLookahead;
+    const esc = ANSI_ESCAPE_RE.exec(line);
+    if (!esc || esc.index !== paddingLookahead) break;
+    paddingLookahead = ANSI_ESCAPE_RE.lastIndex;
+  }
+
+  if (line.startsWith("==", paddingLookahead)) {
+    key += "==";
+    pos = paddingLookahead + 2;
+  } else if (paddingLookahead === pos && /[A-Za-z0-9+/=]/.test(line[pos] || "")) {
+    return null;
+  }
+
+  if (/[A-Za-z0-9+/=]/.test(line[pos] || "")) {
+    return null;
+  }
+
   if (!validMoshKey(key)) return null;
 
   // Map the cleaned match back onto the original line so redaction still
   // covers ConPTY CSI that trailed or split the key (e.g. `\x1b[?25h`).
-  const connectIdx = cleanToOriginal[m.index];
-  const cleanMatchEnd = m.index + m[0].length;
-  if (connectIdx === undefined || cleanToOriginal[cleanMatchEnd] === undefined) return null;
-  let matchEndOffset = cleanToOriginal[cleanMatchEnd];
+  let matchEndOffset = pos;
   while (matchEndOffset < line.length) {
     const ch = line[matchEndOffset];
     if (ch === "\u001b") {

--- a/electron/bridges/moshHandshake.cjs
+++ b/electron/bridges/moshHandshake.cjs
@@ -70,8 +70,30 @@ function stripAnsiEscapes(text) {
   return String(text || "").replace(ANSI_ESCAPE_RE, "");
 }
 
+function stripAnsiEscapesWithMap(text) {
+  const source = String(text || "");
+  let cleaned = "";
+  const cleanToOriginal = [];
+  let index = 0;
+  while (index < source.length) {
+    if (source[index] === "\u001b") {
+      ANSI_ESCAPE_RE.lastIndex = index;
+      const esc = ANSI_ESCAPE_RE.exec(source);
+      if (esc && esc.index === index) {
+        index = ANSI_ESCAPE_RE.lastIndex;
+        continue;
+      }
+    }
+    cleanToOriginal.push(index);
+    cleaned += source[index];
+    index += 1;
+  }
+  cleanToOriginal.push(source.length);
+  return { cleaned, cleanToOriginal };
+}
+
 function parseConnectLine(line) {
-  const cleaned = stripAnsiEscapes(line);
+  const { cleaned, cleanToOriginal } = stripAnsiEscapesWithMap(line);
   const m = MOSH_CONNECT_RE.exec(cleaned);
   if (!m) return null;
   const port = Number(m[1]);
@@ -80,12 +102,11 @@ function parseConnectLine(line) {
   if (!validMoshKey(key)) return null;
 
   // Map the cleaned match back onto the original line so redaction still
-  // covers ConPTY CSI that trailed the key (e.g. `\x1b[?25h`).
-  const connectIdx = line.indexOf("MOSH CONNECT");
-  if (connectIdx === -1) return null;
-  const keyIdx = line.indexOf(key, connectIdx);
-  if (keyIdx === -1) return null;
-  let matchEndOffset = keyIdx + key.length;
+  // covers ConPTY CSI that trailed or split the key (e.g. `\x1b[?25h`).
+  const connectIdx = cleanToOriginal[m.index];
+  const cleanMatchEnd = m.index + m[0].length;
+  if (connectIdx === undefined || cleanToOriginal[cleanMatchEnd] === undefined) return null;
+  let matchEndOffset = cleanToOriginal[cleanMatchEnd];
   while (matchEndOffset < line.length) {
     const ch = line[matchEndOffset];
     if (ch === "\u001b") {

--- a/electron/bridges/moshHandshake.cjs
+++ b/electron/bridges/moshHandshake.cjs
@@ -92,6 +92,17 @@ function stripAnsiEscapesWithMap(text) {
   return { cleaned, cleanToOriginal };
 }
 
+function skipAnsiEscapes(text, offset) {
+  let pos = offset;
+  while (pos < text.length && text[pos] === "\u001b") {
+    ANSI_ESCAPE_RE.lastIndex = pos;
+    const esc = ANSI_ESCAPE_RE.exec(text);
+    if (!esc || esc.index !== pos) break;
+    pos = ANSI_ESCAPE_RE.lastIndex;
+  }
+  return pos;
+}
+
 function parseConnectLine(line) {
   const { cleaned, cleanToOriginal } = stripAnsiEscapesWithMap(line);
   const m = MOSH_CONNECT_PREFIX_RE.exec(cleaned);
@@ -122,19 +133,19 @@ function parseConnectLine(line) {
 
   if (key.length !== 22) return null;
 
-  let paddingLookahead = pos;
-  while (paddingLookahead < line.length) {
-    const ch = line[paddingLookahead];
-    if (ch !== "\u001b") break;
-    ANSI_ESCAPE_RE.lastIndex = paddingLookahead;
-    const esc = ANSI_ESCAPE_RE.exec(line);
-    if (!esc || esc.index !== paddingLookahead) break;
-    paddingLookahead = ANSI_ESCAPE_RE.lastIndex;
-  }
+  let paddingLookahead = skipAnsiEscapes(line, pos);
 
   if (line.startsWith("==", paddingLookahead)) {
     key += "==";
     pos = paddingLookahead + 2;
+  } else if (line[paddingLookahead] === "=") {
+    const secondPaddingOffset = skipAnsiEscapes(line, paddingLookahead + 1);
+    if (line[secondPaddingOffset] === "=") {
+      key += "==";
+      pos = secondPaddingOffset + 1;
+    } else if (paddingLookahead === pos) {
+      return null;
+    }
   } else if (paddingLookahead === pos && /[A-Za-z0-9+/=]/.test(line[pos] || "")) {
     return null;
   }

--- a/electron/bridges/moshHandshake.test.cjs
+++ b/electron/bridges/moshHandshake.test.cjs
@@ -66,6 +66,33 @@ test("parseMoshConnect tolerates ConPTY CSI controls inside the key", () => {
   });
 });
 
+test("parseMoshConnect tolerates ConPTY CSI controls inside key padding", () => {
+  const line = "MOSH CONNECT 60031 ABCDEFGHIJKLMNOPQRSTUV=\u001b[?25h=\r\n";
+  const got = parseMoshConnect(line);
+  assert.deepEqual(got && { port: got.port, key: got.key }, {
+    port: 60031,
+    key: "ABCDEFGHIJKLMNOPQRSTUV==",
+  });
+});
+
+test("parseMoshConnect tolerates ConPTY CSI controls around both padding bytes", () => {
+  const line = "MOSH CONNECT 60033 ABCDEFGHIJKLMNOPQRSTUV\u001b[?25h=\u001b[?25h=\r\n";
+  const got = parseMoshConnect(line);
+  assert.deepEqual(got && { port: got.port, key: got.key }, {
+    port: 60033,
+    key: "ABCDEFGHIJKLMNOPQRSTUV==",
+  });
+});
+
+test("parseMoshConnect treats escaped equals after an unpadded key as banner text", () => {
+  const line = "MOSH CONNECT 60032 ABCDEFGHIJKLMNOPQRSTUV\u001b[8;1H= banner\r\n";
+  const got = parseMoshConnect(line);
+  assert.deepEqual(got && { port: got.port, key: got.key }, {
+    port: 60032,
+    key: "ABCDEFGHIJKLMNOPQRSTUV",
+  });
+});
+
 test("createMoshConnectSniffer parses ConPTY-mangled MOSH CONNECT lines", () => {
   const sniffer = createMoshConnectSniffer();
   const r = sniffer.feed(
@@ -84,6 +111,30 @@ test("createMoshConnectSniffer redacts MOSH CONNECT when CSI splits the key", ()
   assert.deepEqual(r.parsed, { port: 60030, key: "nDMmYnfKIKn2yAXiK/34eg" });
   assert.ok(!String(r.visible).includes("MOSH CONNECT"));
   assert.ok(!String(r.visible).includes("34eg"));
+});
+
+test("createMoshConnectSniffer redacts MOSH CONNECT when CSI splits key padding", () => {
+  const sniffer = createMoshConnectSniffer();
+  const r = sniffer.feed("MOSH CONNECT 60031 ABCDEFGHIJKLMNOPQRSTUV=\u001b[?25h=\r\n");
+  assert.deepEqual(r.parsed, { port: 60031, key: "ABCDEFGHIJKLMNOPQRSTUV==" });
+  assert.ok(!String(r.visible).includes("MOSH CONNECT"));
+  assert.ok(!String(r.visible).includes("ABCDEFGHIJKLMNOPQRSTUV"));
+});
+
+test("createMoshConnectSniffer redacts MOSH CONNECT when CSI surrounds padding bytes", () => {
+  const sniffer = createMoshConnectSniffer();
+  const r = sniffer.feed("MOSH CONNECT 60033 ABCDEFGHIJKLMNOPQRSTUV\u001b[?25h=\u001b[?25h=\r\n");
+  assert.deepEqual(r.parsed, { port: 60033, key: "ABCDEFGHIJKLMNOPQRSTUV==" });
+  assert.ok(!String(r.visible).includes("MOSH CONNECT"));
+  assert.ok(!String(r.visible).includes("ABCDEFGHIJKLMNOPQRSTUV"));
+});
+
+test("createMoshConnectSniffer preserves escaped equals banner after an unpadded key", () => {
+  const sniffer = createMoshConnectSniffer();
+  const r = sniffer.feed("MOSH CONNECT 60032 ABCDEFGHIJKLMNOPQRSTUV\u001b[8;1H= banner\r\n");
+  assert.deepEqual(r.parsed, { port: 60032, key: "ABCDEFGHIJKLMNOPQRSTUV" });
+  assert.ok(!String(r.visible).includes("MOSH CONNECT"));
+  assert.ok(String(r.visible).includes("= banner"));
 });
 
 test("createMoshConnectSniffer stops the key at a ConPTY cursor move before banner text", () => {

--- a/electron/bridges/moshHandshake.test.cjs
+++ b/electron/bridges/moshHandshake.test.cjs
@@ -86,6 +86,18 @@ test("createMoshConnectSniffer redacts MOSH CONNECT when CSI splits the key", ()
   assert.ok(!String(r.visible).includes("34eg"));
 });
 
+test("createMoshConnectSniffer stops the key at a ConPTY cursor move before banner text", () => {
+  const sniffer = createMoshConnectSniffer();
+  const r = sniffer.feed(
+    "MOSH IP 207.58.174.82\r\n"
+    + "\u001b[?25l\u001b[6;1HMOSH CONNECT 60030 BArYj8zs1avy+l7+GaHoTg"
+    + "\u001b[8;1Hmosh-server (mosh 1.4.0)\r\n",
+  );
+  assert.deepEqual(r.parsed, { port: 60030, key: "BArYj8zs1avy+l7+GaHoTg", host: "207.58.174.82" });
+  assert.ok(!String(r.visible).includes("MOSH CONNECT"));
+  assert.ok(String(r.visible).includes("mosh-server (mosh 1.4.0)"));
+});
+
 test("createMoshConnectSniffer.flush recovers a trailing MOSH CONNECT without newline", () => {
   // ssh can exit before ConPTY emits the final CRLF. Without an EOF flush
   // the sniffer would leave the CONNECT line in `pending` and the bridge

--- a/electron/bridges/moshHandshake.test.cjs
+++ b/electron/bridges/moshHandshake.test.cjs
@@ -54,6 +54,18 @@ test("parseMoshConnect tolerates ConPTY CSI controls after the key", () => {
   });
 });
 
+test("parseMoshConnect tolerates ConPTY CSI controls inside the key", () => {
+  // ConPTY can inject cursor controls into the byte stream while the terminal
+  // still renders a visually contiguous key. Redaction must map cleaned offsets
+  // back to the original line instead of searching for the cleaned key.
+  const line = "MOSH CONNECT 60030 nDMmYnfKIKn2yAXiK/\u001b[?25h34eg\r\n";
+  const got = parseMoshConnect(line);
+  assert.deepEqual(got && { port: got.port, key: got.key }, {
+    port: 60030,
+    key: "nDMmYnfKIKn2yAXiK/34eg",
+  });
+});
+
 test("createMoshConnectSniffer parses ConPTY-mangled MOSH CONNECT lines", () => {
   const sniffer = createMoshConnectSniffer();
   const r = sniffer.feed(
@@ -64,6 +76,14 @@ test("createMoshConnectSniffer parses ConPTY-mangled MOSH CONNECT lines", () => 
   assert.deepEqual(r.parsed, { port: 60002, key: "ABCDEFGHIJKLMNOPQRSTUV==" });
   assert.ok(!String(r.visible).includes("MOSH CONNECT"));
   assert.ok(String(r.visible).includes("mosh-server detached"));
+});
+
+test("createMoshConnectSniffer redacts MOSH CONNECT when CSI splits the key", () => {
+  const sniffer = createMoshConnectSniffer();
+  const r = sniffer.feed("MOSH CONNECT 60030 nDMmYnfKIKn2yAXiK/\u001b[?25h34eg\r\n");
+  assert.deepEqual(r.parsed, { port: 60030, key: "nDMmYnfKIKn2yAXiK/34eg" });
+  assert.ok(!String(r.visible).includes("MOSH CONNECT"));
+  assert.ok(!String(r.visible).includes("34eg"));
 });
 
 test("createMoshConnectSniffer.flush recovers a trailing MOSH CONNECT without newline", () => {

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -1393,6 +1393,7 @@ function registerHandlers(ipcMain, options = {}) {
       "netcatty:local:validatePath",
       "netcatty:shells:discover",
       "netcatty:terminal:setEncoding",
+      "netcatty:close:await",
     ].forEach((channel) => registerWorkerHandle(ipcMain, terminalWorkerManager, channel));
     ipcMain.on("netcatty:write", (event, payload) => {
       // Session log streams started in the main process (manual/script logs)
@@ -1435,6 +1436,7 @@ function registerHandlers(ipcMain, options = {}) {
   ipcMain.on("netcatty:flow", setSessionFlowPaused);
   ipcMain.on("netcatty:flow:ack", ackSessionFlow);
   ipcMain.on("netcatty:close", closeSession);
+  ipcMain.handle("netcatty:close:await", closeSession);
 }
 
 /**

--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -629,7 +629,9 @@ function createTerminalWorkerManager(options = {}) {
     const promise = new Promise((resolve, reject) => {
       pending.set(requestId, { resolve, reject, webContentsId: optionsForRequest.webContentsId });
     });
-    if (payload?.sessionId) {
+    if (channel === "netcatty:close:await" && payload?.sessionId) {
+      closeOutputSession(payload.sessionId);
+    } else if (payload?.sessionId) {
       closedSessions.delete(payload.sessionId);
     }
     worker.postMessage({

--- a/electron/bridges/terminalWorkerManager.test.cjs
+++ b/electron/bridges/terminalWorkerManager.test.cjs
@@ -863,6 +863,70 @@ test("close immediately clears the output route and drops pending output", async
   assert.deepEqual(routed, []);
 });
 
+test("await close immediately clears the output route and drops pending output", async () => {
+  const child = new FakeChild();
+  const closed = [];
+  const routed = [];
+  let opened = false;
+  const manager = createTerminalWorkerManager({
+    utilityProcess: {
+      fork() {
+        return child;
+      },
+    },
+    terminalOutputChannel: {
+      openSession() {
+        opened = true;
+      },
+      send(sessionId, data) {
+        if (!opened) return false;
+        routed.push({ sessionId, data });
+        return true;
+      },
+      closeSession(sessionId) {
+        closed.push(sessionId);
+        opened = false;
+      },
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  const startPromise = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages[0].requestId,
+    result: { sessionId: "session-1" },
+  });
+  await startPromise;
+  assert.equal(manager.hasOpenSession("session-1"), true);
+
+  const closePromise = manager.request("netcatty:close:await", { sessionId: "session-1" }, { webContentsId: 7 });
+  assert.equal(manager.hasOpenSession("session-1"), false);
+  child.emit("message", {
+    kind: "output",
+    sessionId: "session-1",
+    data: "late",
+  });
+  const closeRequest = child.messages.find((message) => message.channel === "netcatty:close:await");
+  child.emit("message", {
+    kind: "response",
+    requestId: closeRequest.requestId,
+    result: { sessionId: "session-1" },
+  });
+  await closePromise;
+
+  assert.deepEqual(closed, ["session-1"]);
+  assert.deepEqual(routed, []);
+  assert.equal(manager.hasOpenSession("session-1"), false);
+});
+
 test("worker renderer events are forwarded to their original webContents", () => {
   const child = new FakeChild();
   const forwarded = [];

--- a/electron/bridges/terminalWorkerProxyRegistration.test.cjs
+++ b/electron/bridges/terminalWorkerProxyRegistration.test.cjs
@@ -52,6 +52,7 @@ test("terminal worker mode proxies all terminal starts and control commands", as
     "netcatty:mosh:start",
     "netcatty:et:start",
     "netcatty:serial:start",
+    "netcatty:close:await",
   ]) {
     assert.equal(ipcMain.handlers.has(channel), true, `${channel} should be proxied as a request`);
     await ipcMain.handlers.get(channel)(fakeEvent, { sessionId: channel });
@@ -77,6 +78,7 @@ test("terminal worker mode proxies all terminal starts and control commands", as
       "netcatty:mosh:start",
       "netcatty:et:start",
       "netcatty:serial:start",
+      "netcatty:close:await",
     ],
   );
   assert.deepEqual(

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -251,13 +251,17 @@ function createPreloadApi(ctx) {
     if (!sessionId || !Number.isFinite(bytes) || bytes <= 0) return;
     ipcRenderer.send("netcatty:flow:ack", { sessionId, bytes });
   },
-  closeSession: (sessionId) => {
+  closeSession: async (sessionId) => {
     markTerminalDataSessionClosed(sessionId);
     telnetEchoModeListeners.delete(sessionId);
     // closeSession sets session.closed before kill; mosh exit handlers skip
     // the exit event in that case, so clear ready listeners here too.
     moshSessionReadyListeners.delete(sessionId);
-    ipcRenderer.send("netcatty:close", { sessionId });
+    try {
+      await ipcRenderer.invoke("netcatty:close:await", { sessionId });
+    } catch {
+      ipcRenderer.send("netcatty:close", { sessionId });
+    }
   },
   setSessionEncoding: async (sessionId, encoding) => {
     // Try the SSH handler first; it returns { ok: false } for non-SSH

--- a/electron/preloadDataBacklog.test.cjs
+++ b/electron/preloadDataBacklog.test.cjs
@@ -859,7 +859,7 @@ test("onSessionExit unsubscribe removes empty listener set", () => {
   assert.equal(exitListeners.has("session-1"), false);
 });
 
-test("closeSession clears terminal data state and marks the session closed", () => {
+test("closeSession clears terminal data state and waits for close acknowledgement", async () => {
   const listener = () => {};
   const dataListeners = new Map([
     ["session-1", new Set([listener])],
@@ -878,15 +878,18 @@ test("closeSession clears terminal data state and marks the session closed", () 
   const zmodemOverwriteListeners = new Map([
     ["session-1", new Set([listener])],
   ]);
-  const sent = [];
+  const invoked = [];
   const closedPorts = [];
   terminalDataBacklog.append("session-1", "pending");
 
   const api = createPreloadApi({
     ipcRenderer: {
-      invoke() {},
+      invoke(channel, payload) {
+        invoked.push({ channel, payload });
+        return Promise.resolve();
+      },
       send(channel, payload) {
-        sent.push({ channel, payload });
+        throw new Error(`unexpected send ${channel}`);
       },
       on() {},
       removeListener() {},
@@ -908,7 +911,7 @@ test("closeSession clears terminal data state and marks the session closed", () 
     },
   });
 
-  api.closeSession("session-1");
+  await api.closeSession("session-1");
 
   assert.equal(dataListeners.has("session-1"), false);
   assert.equal(displayDataListeners.has("session-1"), false);
@@ -920,6 +923,36 @@ test("closeSession clears terminal data state and marks the session closed", () 
   assert.equal(zmodemListeners.has("session-1"), true);
   assert.equal(zmodemOverwriteListeners.has("session-1"), true);
   assert.deepEqual(closedPorts, ["session-1"]);
+  assert.deepEqual(invoked, [
+    { channel: "netcatty:close:await", payload: { sessionId: "session-1" } },
+  ]);
+});
+
+test("closeSession falls back to fire-and-forget close when acknowledgement is unavailable", async () => {
+  const sent = [];
+  const api = createPreloadApi({
+    ipcRenderer: {
+      invoke() {
+        return Promise.reject(new Error("missing handler"));
+      },
+      send(channel, payload) {
+        sent.push({ channel, payload });
+      },
+      on() {},
+      removeListener() {},
+    },
+    os: {
+      release: () => "10.0.19045",
+    },
+    dataListeners: new Map(),
+    displayDataListeners: new Map(),
+    terminalDataBacklog: createTerminalDataBacklog(),
+    closedTerminalDataSessions: new Set(),
+    telnetEchoModeListeners: new Map(),
+  });
+
+  await api.closeSession("session-1");
+
   assert.deepEqual(sent, [
     { channel: "netcatty:close", payload: { sessionId: "session-1" } },
   ]);

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -310,7 +310,7 @@ declare global {
     resizeSession(sessionId: string, cols: number, rows: number): void;
     setSessionFlowPaused(sessionId: string, paused: boolean): void;
     ackSessionFlow(sessionId: string, bytes: number): void;
-    closeSession(sessionId: string): void;
+    closeSession(sessionId: string): void | Promise<void>;
     // ZMODEM file transfer
     onZmodemEvent?(
       sessionId: string,


### PR DESCRIPTION
## Summary

Fixes the Windows Mosh reconnect failure reported in #2240, where reconnecting to some hosts could surface `Mosh SSH startup failed: no MOSH CONNECT from mosh-server (UDP client not started)` even though the remote `mosh-server` had started.

## Root cause

There were two Windows-specific failure modes in the same reconnect path:

1. The renderer used a fire-and-forget `netcatty:close` before reconnecting with the same `sessionId`. If the old close reached the main process after the new Mosh start, it could kill the replacement SSH bootstrap before `MOSH CONNECT` was parsed.
2. Windows OpenSSH under ConPTY can inject cursor-control CSI sequences into the `mosh-server` startup output. On the reproduced host, `MOSH CONNECT <port> <key>` was immediately followed by a cursor move and the `mosh-server` banner without a CRLF, so the visible terminal showed a valid line while the parser saw key + banner text and rejected the handshake.

## Changes

- Add an acknowledged `netcatty:close:await` IPC path and proxy it in terminal worker mode.
- Make `closeSession` awaitable through the preload and renderer backend wrapper, while keeping the legacy fire-and-forget fallback.
- Await cleanup before manual/auto reconnect starts a replacement backend session.
- Guard the awaited reconnect continuation with a retry token and `termRef.current` re-check so close/cancel/unmount cannot start a ghost reconnect.
- Parse `MOSH CONNECT` from raw ConPTY output by skipping ANSI controls inside the key and stopping cleanly at cursor movement before banner text.
- Add regression coverage for ConPTY-split keys, cursor moves after keys, and Mosh startup session behavior.

## Validation

- `node --test electron\bridges\moshHandshake.test.cjs electron\bridges\terminalBridge.moshHandshakeSession.test.cjs`
- `npm run lint -- --quiet`
- Real Windows SSH bootstrap against the reproduced host now parses `MOSH CONNECT` before visible output is emitted.
- A local `1.1.68` Windows package built from this branch was tested and confirmed to reconnect successfully.