### PR TITLE
feat(sync): add convergent CRDT core

### DIFF
--- a/docs/designs/convergent-sync-crdt.md
+++ b/docs/designs/convergent-sync-crdt.md
@@ -122,6 +122,13 @@ Resolving a conflict creates a new write whose causal context covers all
 observed candidates, so the resolution remains stable when stale replicas
 return.
 
+Internal field and position conflicts are emitted only while their parent
+entity or string entry is materialized. An accepted parent deletion retains
+the underlying causal metadata for future explicit recreation but suppresses
+non-actionable child conflicts from the current conflict list. A concurrent
+delete/update whose selected presence remains visible still exposes both the
+presence conflict and all active internal conflicts.
+
 ## Complexity
 
 State validation and canonical serialization are linear in registers,

--- a/docs/designs/convergent-sync-crdt.md
+++ b/docs/designs/convergent-sync-crdt.md
@@ -39,10 +39,13 @@ tombstone only when its new dot causally observes the deletion.
 
 Settings writes keep the active leaf set prefix-free. Replacing an object leaf
 with an atomic parent (or the reverse) causally tombstones the overlapping
-paths. Independent replicas can still create a parent/descendant shape
-conflict; materialization then selects a deterministic maximal prefix-free set,
-keeps non-overlapping siblings, and reports the competing paths and candidates
-for explicit resolution.
+paths. Deleting a settings path tombstones that path and every causally observed
+descendant, so deleting a subtree cannot leave stale leaf registers visible;
+deleting a nested path does not implicitly remove an atomic ancestor.
+Independent replicas can still create a parent/descendant shape conflict;
+materialization then selects a deterministic maximal prefix-free set, keeps
+non-overlapping siblings, and reports the competing paths and candidates for
+explicit resolution.
 
 Entity field updates also write a fresh present candidate. Consequently, an
 offline deletion racing an offline edit becomes a presence conflict; it cannot

--- a/docs/designs/convergent-sync-crdt.md
+++ b/docs/designs/convergent-sync-crdt.md
@@ -50,6 +50,10 @@ position: unchanged conflict-free registers are preserved, while accepting a
 currently selected conflicted value emits a new candidate that dominates every
 retained alternative.
 
+String-entry add mutations likewise resolve visible presence and position
+conflicts even when the selected values are unchanged; conflict-free repeated
+adds remain no-ops.
+
 Deletion is a register candidate, not absence from the serialized structure.
 Tombstones are retained indefinitely in v2. A later recreation replaces a
 tombstone only when its new dot causally observes the deletion.

--- a/docs/designs/convergent-sync-crdt.md
+++ b/docs/designs/convergent-sync-crdt.md
@@ -66,7 +66,10 @@ also reduce 2-20 randomly generated offline replicas using reordered,
 partitioned, and duplicated joins.
 
 Reusing a dot for different data or different register addresses is an
-invariant violation and fails closed.
+invariant violation and fails closed. Every global vector counter must also be
+witnessed by a retained candidate dot or candidate context. Hydration rejects
+dangling observations so a malformed or partial state cannot use an
+unsubstantiated vector to discard local candidates during join.
 
 ## Materialization and conflicts
 

--- a/docs/designs/convergent-sync-crdt.md
+++ b/docs/designs/convergent-sync-crdt.md
@@ -52,7 +52,9 @@ explicit resolution.
 
 Entity field updates also write a fresh present candidate. Consequently, an
 offline deletion racing an offline edit becomes a presence conflict; it cannot
-silently hide the edit.
+silently hide the edit. No-op field writes allocate no dot and do not refresh
+presence. Deleting a field from a non-present entity may tombstone stale field
+data but never recreates the entity.
 
 ## Join
 

--- a/docs/designs/convergent-sync-crdt.md
+++ b/docs/designs/convergent-sync-crdt.md
@@ -40,6 +40,11 @@ A string-entry remove is emitted only after the replica has observed a currently
 visible add. Deleting a locally absent entry is a no-op, so a concurrent add on
 another replica survives without creating an artificial value/tombstone conflict.
 
+Mutation application is idempotent for already-selected entity fields, string
+entries, and settings. A same-value settings write still tombstones active
+ancestor or descendant paths, and a same-value write against an MV-register
+conflict still emits a causally dominating resolution.
+
 Deletion is a register candidate, not absence from the serialized structure.
 Tombstones are retained indefinitely in v2. A later recreation replaces a
 tombstone only when its new dot causally observes the deletion.

--- a/docs/designs/convergent-sync-crdt.md
+++ b/docs/designs/convergent-sync-crdt.md
@@ -16,6 +16,10 @@ This first change intentionally contains only pure domain logic. Encryption,
 legacy migration, provider verification, persistence, and UI are separate
 follow-up changes after this core is reviewed.
 
+Mutation callers must provide the wall-clock sample used to advance the HLC.
+The domain layer never reads `Date.now()`, so replaying the same state, device,
+mutation batch, and timestamp produces identical serialized state.
+
 ## State model
 
 Each device owns a monotonically increasing counter. A write allocates a unique

--- a/docs/designs/convergent-sync-crdt.md
+++ b/docs/designs/convergent-sync-crdt.md
@@ -29,6 +29,7 @@ ordering hint without defining causality.
 The replica contains:
 
 - one global dotted version vector and HLC;
+- a compact dot-origin index mapping every device counter to its register;
 - an MV-register for entity presence;
 - an MV-register for collection position;
 - an MV-register for every top-level entity field;
@@ -98,7 +99,10 @@ Hydration rejects dangling observations so a malformed or partial state cannot
 use an unsubstantiated vector to discard local candidates during join. It also
 rejects a context that references any currently retained candidate dot: exact
 contexts contain dominated history only, so retained references would represent
-invalid causal dominance or a cycle.
+invalid causal dominance or a cycle. The permanent dot-origin index proves that
+each candidate and context dot belongs to the register claiming it, so copying
+an omitted register's dot into unrelated context cannot satisfy validation.
+Origin indexes join by dot and reject conflicting register identities.
 
 ## Materialization and conflicts
 

--- a/docs/designs/convergent-sync-crdt.md
+++ b/docs/designs/convergent-sync-crdt.md
@@ -37,6 +37,13 @@ Deletion is a register candidate, not absence from the serialized structure.
 Tombstones are retained indefinitely in v2. A later recreation replaces a
 tombstone only when its new dot causally observes the deletion.
 
+Settings writes keep the active leaf set prefix-free. Replacing an object leaf
+with an atomic parent (or the reverse) causally tombstones the overlapping
+paths. Independent replicas can still create a parent/descendant shape
+conflict; materialization then selects a deterministic maximal prefix-free set,
+keeps non-overlapping siblings, and reports the competing paths and candidates
+for explicit resolution.
+
 Entity field updates also write a fresh present candidate. Consequently, an
 offline deletion racing an offline edit becomes a presence conflict; it cannot
 silently hide the edit.
@@ -69,8 +76,10 @@ snapshot is selected for legacy readers and immediate application:
 4. then device counter.
 
 Candidate ordering in canonical serialization uses the dot, not the selected
-winner order. Conflicts are emitted in collection, entity, field-path, and dot
-order. Resolving a conflict creates a new write whose causal context covers all
+winner order. Dot and HLC objects are rebuilt with fixed property order so
+provider JSON key ordering cannot change identity or serialized bytes.
+Conflicts are emitted in collection, entity, field-path, and dot order.
+Resolving a conflict creates a new write whose causal context covers all
 observed candidates, so the resolution remains stable when stale replicas
 return.
 

--- a/docs/designs/convergent-sync-crdt.md
+++ b/docs/designs/convergent-sync-crdt.md
@@ -78,7 +78,9 @@ invariant violation and fails closed. Every global vector counter must also be
 witnessed by a retained candidate dot or same-register candidate context.
 Hydration rejects dangling observations so a malformed or partial state cannot
 use an unsubstantiated vector to discard local candidates during join. It also
-rejects a context that references a currently retained dot in another register.
+rejects a context that references any currently retained candidate dot: exact
+contexts contain dominated history only, so retained references would represent
+invalid causal dominance or a cycle.
 
 ## Materialization and conflicts
 

--- a/docs/designs/convergent-sync-crdt.md
+++ b/docs/designs/convergent-sync-crdt.md
@@ -45,6 +45,11 @@ entries, and settings. A same-value settings write still tombstones active
 ancestor or descendant paths, and a same-value write against an MV-register
 conflict still emits a causally dominating resolution.
 
+A full entity upsert follows the same rule for presence, fields, and collection
+position: unchanged conflict-free registers are preserved, while accepting a
+currently selected conflicted value emits a new candidate that dominates every
+retained alternative.
+
 Deletion is a register candidate, not absence from the serialized structure.
 Tombstones are retained indefinitely in v2. A later recreation replaces a
 tombstone only when its new dot causally observes the deletion.

--- a/docs/designs/convergent-sync-crdt.md
+++ b/docs/designs/convergent-sync-crdt.md
@@ -19,9 +19,12 @@ follow-up changes after this core is reviewed.
 ## State model
 
 Each device owns a monotonically increasing counter. A write allocates a unique
-dot `(deviceId, counter)` and records the version vector observed immediately
-before that dot. A Hybrid Logical Clock (HLC) supplies a user-facing ordering
-hint without defining causality.
+dot `(deviceId, counter)`. The global version vector allocates collision-free
+dots, while each candidate records the exact prior dots observed in its own
+register. The register context is an exact dot set rather than another compact
+version vector because one device's global counters can interleave writes to
+different registers. A Hybrid Logical Clock (HLC) supplies a user-facing
+ordering hint without defining causality.
 
 The replica contains:
 
@@ -56,20 +59,24 @@ silently hide the edit.
 For each register, the join keeps:
 
 1. candidates present on both sides;
-2. left-only candidates not covered by the right causal context;
-3. right-only candidates not covered by the left causal context.
+2. left-only candidates not covered by the right register's causal context;
+3. right-only candidates not covered by the left register's causal context.
 
 Candidates causally dominated by another surviving candidate are removed. The
-replica vector is the pointwise maximum. This makes join commutative,
-associative, and idempotent. Property tests exercise those laws directly and
-also reduce 2-20 randomly generated offline replicas using reordered,
-partitioned, and duplicated joins.
+replica vector is the pointwise maximum. A global vector is never used as proof
+that a candidate from an absent register was superseded; only a candidate in
+that same register can carry such proof. This makes partial provider states
+fail validation instead of silently deleting unrelated local data. Join remains
+commutative, associative, and idempotent. Property tests exercise those laws
+directly and also reduce 2-20 randomly generated offline replicas using
+reordered, partitioned, and duplicated joins.
 
 Reusing a dot for different data or different register addresses is an
 invariant violation and fails closed. Every global vector counter must also be
-witnessed by a retained candidate dot or candidate context. Hydration rejects
-dangling observations so a malformed or partial state cannot use an
-unsubstantiated vector to discard local candidates during join.
+witnessed by a retained candidate dot or same-register candidate context.
+Hydration rejects dangling observations so a malformed or partial state cannot
+use an unsubstantiated vector to discard local candidates during join. It also
+rejects a context that references a currently retained dot in another register.
 
 ## Materialization and conflicts
 
@@ -78,7 +85,7 @@ snapshot is selected for legacy readers and immediate application:
 
 1. a value sorts after a tombstone;
 2. then HLC wall time and logical counter;
-3. then device ID;
+3. then device ID using locale-independent UTF-16 code-unit order;
 4. then device counter.
 
 Candidate ordering in canonical serialization uses the dot, not the selected
@@ -91,12 +98,13 @@ return.
 
 ## Complexity
 
-State validation, canonical serialization, and join are linear in the number
-of registers plus candidates, with sorting bounded by keys within each map.
-Batch mutation clones the replica once, avoiding a full-state copy per imported
-entity. `npm run bench:sync-crdt` reports non-gating measurements for 1,000,
-5,000, and 10,000 entities so accidental quadratic behavior is visible during
-review.
+State validation and canonical serialization are linear in registers,
+candidates, and retained context dots. Join additionally compares the bounded
+set of concurrent candidates within each register. Sorting is bounded by keys
+within each map. Batch mutation clones the replica once, avoiding a full-state
+copy per imported entity. `npm run bench:sync-crdt` reports non-gating
+measurements for 1,000, 5,000, and 10,000 entities so accidental quadratic
+behavior is visible during review.
 
 ## Follow-up boundaries
 

--- a/docs/designs/convergent-sync-crdt.md
+++ b/docs/designs/convergent-sync-crdt.md
@@ -1,0 +1,91 @@
+# Convergent Sync CRDT Core
+
+Status: experimental core; not connected to persistence or cloud providers yet.
+
+Issue: [#2245](https://github.com/binaricat/Netcatty/issues/2245)
+
+## Goal
+
+The existing sync engine compares local and remote snapshots against a stored
+base. That is useful for two replicas, but folding more replicas or providers in
+different orders is not algebraically safe. The v2 core defines a state-based
+join so every replica reaches the same state regardless of message order,
+duplication, or grouping.
+
+This first change intentionally contains only pure domain logic. Encryption,
+legacy migration, provider verification, persistence, and UI are separate
+follow-up changes after this core is reviewed.
+
+## State model
+
+Each device owns a monotonically increasing counter. A write allocates a unique
+dot `(deviceId, counter)` and records the version vector observed immediately
+before that dot. A Hybrid Logical Clock (HLC) supplies a user-facing ordering
+hint without defining causality.
+
+The replica contains:
+
+- one global dotted version vector and HLC;
+- an MV-register for entity presence;
+- an MV-register for collection position;
+- an MV-register for every top-level entity field;
+- an MV-register for every settings leaf path (arrays are atomic leaves);
+- observed-remove string entries with their own presence and position
+  registers.
+
+Deletion is a register candidate, not absence from the serialized structure.
+Tombstones are retained indefinitely in v2. A later recreation replaces a
+tombstone only when its new dot causally observes the deletion.
+
+Entity field updates also write a fresh present candidate. Consequently, an
+offline deletion racing an offline edit becomes a presence conflict; it cannot
+silently hide the edit.
+
+## Join
+
+For each register, the join keeps:
+
+1. candidates present on both sides;
+2. left-only candidates not covered by the right causal context;
+3. right-only candidates not covered by the left causal context.
+
+Candidates causally dominated by another surviving candidate are removed. The
+replica vector is the pointwise maximum. This makes join commutative,
+associative, and idempotent. Property tests exercise those laws directly and
+also reduce 2-20 randomly generated offline replicas using reordered,
+partitioned, and duplicated joins.
+
+Reusing a dot for different data or different register addresses is an
+invariant violation and fails closed.
+
+## Materialization and conflicts
+
+Concurrent candidates remain in the CRDT state. A deterministic materialized
+snapshot is selected for legacy readers and immediate application:
+
+1. a value sorts after a tombstone;
+2. then HLC wall time and logical counter;
+3. then device ID;
+4. then device counter.
+
+Candidate ordering in canonical serialization uses the dot, not the selected
+winner order. Conflicts are emitted in collection, entity, field-path, and dot
+order. Resolving a conflict creates a new write whose causal context covers all
+observed candidates, so the resolution remains stable when stale replicas
+return.
+
+## Complexity
+
+State validation, canonical serialization, and join are linear in the number
+of registers plus candidates, with sorting bounded by keys within each map.
+Batch mutation clones the replica once, avoiding a full-state copy per imported
+entity. `npm run bench:sync-crdt` reports non-gating measurements for 1,000,
+5,000, and 10,000 entities so accidental quadratic behavior is visible during
+review.
+
+## Follow-up boundaries
+
+The next change will define the encrypted v2 envelope, legacy baselines,
+migration preview, protection snapshots, key rotation, and fail-closed protocol
+rules. The final change will integrate provider read-merge-write-verify loops,
+multi-window locking, conflict resolution state, and localized settings UI.

--- a/docs/designs/convergent-sync-crdt.md
+++ b/docs/designs/convergent-sync-crdt.md
@@ -36,6 +36,10 @@ The replica contains:
 - observed-remove string entries with their own presence and position
   registers.
 
+A string-entry remove is emitted only after the replica has observed a currently
+visible add. Deleting a locally absent entry is a no-op, so a concurrent add on
+another replica survives without creating an artificial value/tombstone conflict.
+
 Deletion is a register candidate, not absence from the serialized structure.
 Tombstones are retained indefinitely in v2. A later recreation replaces a
 tombstone only when its new dot causally observes the deletion.

--- a/domain/convergentSync/clock.ts
+++ b/domain/convergentSync/clock.ts
@@ -1,0 +1,70 @@
+import type {
+  Dot,
+  HybridLogicalClock,
+  VersionVector,
+} from './types';
+import { ConvergentSyncInvariantError } from './types';
+import { getOwnRecordValue, setOwnRecordValue } from './record';
+
+export function compareDots(left: Dot, right: Dot): number {
+  const deviceOrder = left.deviceId.localeCompare(right.deviceId);
+  return deviceOrder !== 0 ? deviceOrder : left.counter - right.counter;
+}
+
+export function dotKey(dot: Dot): string {
+  return `${dot.deviceId}:${dot.counter}`;
+}
+
+export function observesDot(vector: VersionVector, dot: Dot): boolean {
+  return (getOwnRecordValue(vector, dot.deviceId) ?? 0) >= dot.counter;
+}
+
+export function mergeVersionVectors(
+  left: VersionVector,
+  right: VersionVector,
+): VersionVector {
+  const merged: VersionVector = {};
+  const deviceIds = new Set([...Object.keys(left), ...Object.keys(right)]);
+  for (const deviceId of [...deviceIds].sort()) {
+    const counter = Math.max(
+      getOwnRecordValue(left, deviceId) ?? 0,
+      getOwnRecordValue(right, deviceId) ?? 0,
+    );
+    if (counter > 0) setOwnRecordValue(merged, deviceId, counter);
+  }
+  return merged;
+}
+
+export function compareHybridLogicalClocks(
+  left: HybridLogicalClock,
+  right: HybridLogicalClock,
+): number {
+  if (left.wallTime !== right.wallTime) return left.wallTime - right.wallTime;
+  return left.logical - right.logical;
+}
+
+export function maxHybridLogicalClock(
+  left: HybridLogicalClock,
+  right: HybridLogicalClock,
+): HybridLogicalClock {
+  return compareHybridLogicalClocks(left, right) >= 0
+    ? { ...left }
+    : { ...right };
+}
+
+export function tickHybridLogicalClock(
+  current: HybridLogicalClock,
+  now: number,
+): HybridLogicalClock {
+  const safeNow = Number.isFinite(now) ? Math.max(0, Math.floor(now)) : 0;
+  if (!Number.isSafeInteger(safeNow)) {
+    throw new ConvergentSyncInvariantError('Hybrid logical clock wall time is out of range');
+  }
+  if (safeNow > current.wallTime) {
+    return { wallTime: safeNow, logical: 0 };
+  }
+  if (current.logical >= Number.MAX_SAFE_INTEGER) {
+    throw new ConvergentSyncInvariantError('Hybrid logical clock counter exhausted');
+  }
+  return { wallTime: current.wallTime, logical: current.logical + 1 };
+}

--- a/domain/convergentSync/clock.ts
+++ b/domain/convergentSync/clock.ts
@@ -6,8 +6,14 @@ import type {
 import { ConvergentSyncInvariantError } from './types';
 import { getOwnRecordValue, setOwnRecordValue } from './record';
 
+export function compareStrings(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
 export function compareDots(left: Dot, right: Dot): number {
-  const deviceOrder = left.deviceId.localeCompare(right.deviceId);
+  const deviceOrder = compareStrings(left.deviceId, right.deviceId);
   return deviceOrder !== 0 ? deviceOrder : left.counter - right.counter;
 }
 

--- a/domain/convergentSync/convergentSync.property.test.ts
+++ b/domain/convergentSync/convergentSync.property.test.ts
@@ -134,6 +134,48 @@ test('merge is idempotent', () => {
   }), { numRuns: 150 });
 });
 
+test('causal parent deletion removes every generated descendant', () => {
+  fc.assert(fc.property(
+    fc.array(
+      fc.tuple(
+        fc.constantFrom('fontSize', 'fontFamily', 'palette', 'cursor'),
+        jsonValueArbitrary,
+      ),
+      { minLength: 1, maxLength: 12 },
+    ),
+    (leaves) => {
+      const populated = applyConvergentMutations(
+        createConvergentSyncState(),
+        'device-a',
+        leaves.map(([leaf, value]) => ({
+          kind: 'setting-set' as const,
+          path: ['terminal', leaf],
+          value,
+        })),
+        100,
+      );
+      const deleted = applyConvergentMutations(populated, 'device-a', [{
+        kind: 'setting-delete',
+        path: ['terminal'],
+      }], 101);
+
+      assert.equal(
+        Object.hasOwn(materializeConvergentSyncState(deleted).settings, 'terminal'),
+        false,
+      );
+      assert.equal(
+        Object.hasOwn(
+          materializeConvergentSyncState(
+            mergeConvergentSyncStates(populated, deleted),
+          ).settings,
+          'terminal',
+        ),
+        false,
+      );
+    },
+  ), { numRuns: 100 });
+});
+
 test('2-20 offline replicas converge across reordering, partitions, and duplicates', () => {
   fc.assert(fc.property(
     fc.array(mutationListArbitrary, { minLength: 2, maxLength: 20 }),

--- a/domain/convergentSync/convergentSync.property.test.ts
+++ b/domain/convergentSync/convergentSync.property.test.ts
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import fc from 'fast-check';
+
+import {
+  applyConvergentMutations,
+  createConvergentSyncState,
+  mergeConvergentSyncStates,
+  serializeConvergentSyncState,
+  type ConvergentMutation,
+  type JsonValue,
+} from './index.ts';
+
+const jsonValueArbitrary: fc.Arbitrary<JsonValue> = fc.oneof(
+  fc.string({ maxLength: 20 }),
+  fc.integer({ min: -1_000, max: 1_000 }),
+  fc.boolean(),
+  fc.array(fc.integer({ min: 0, max: 20 }), { maxLength: 5 }),
+  fc.record({ enabled: fc.boolean(), label: fc.string({ maxLength: 10 }) }),
+);
+
+const settingPathArbitrary: fc.Arbitrary<string[]> = fc.constantFrom(
+  'theme',
+  'fontSize',
+  'palette',
+).map((value) => value === 'theme' ? ['theme'] : ['terminal', value]);
+
+const mutationArbitrary: fc.Arbitrary<ConvergentMutation> = fc.oneof(
+  fc.record({
+    kind: fc.constant<'setting-set'>('setting-set'),
+    path: settingPathArbitrary,
+    value: jsonValueArbitrary,
+  }),
+  fc.record({
+    kind: fc.constant<'setting-delete'>('setting-delete'),
+    path: settingPathArbitrary,
+  }),
+  fc.record({
+    kind: fc.constant<'entity-field-set'>('entity-field-set'),
+    collection: fc.constant('hosts'),
+    entityId: fc.constantFrom('host-0', 'host-1', 'host-2'),
+    field: fc.constantFrom('label', 'hostname', 'tags'),
+    value: jsonValueArbitrary,
+  }),
+  fc.record({
+    kind: fc.constant<'entity-delete'>('entity-delete'),
+    collection: fc.constant('hosts'),
+    entityId: fc.constantFrom('host-0', 'host-1', 'host-2'),
+  }),
+  fc.record({
+    kind: fc.constant<'string-entry-add'>('string-entry-add'),
+    collection: fc.constant('customGroups'),
+    value: fc.constantFrom('alpha', 'beta', 'gamma'),
+    position: fc.integer({ min: 0, max: 10 }),
+  }),
+  fc.record({
+    kind: fc.constant<'string-entry-delete'>('string-entry-delete'),
+    collection: fc.constant('customGroups'),
+    value: fc.constantFrom('alpha', 'beta', 'gamma'),
+  }),
+);
+
+const mutationListArbitrary = fc.array(mutationArbitrary, { maxLength: 16 });
+
+function replica(deviceId: string, mutations: ConvergentMutation[], time: number) {
+  return applyConvergentMutations(
+    createConvergentSyncState(),
+    deviceId,
+    mutations,
+    time,
+  );
+}
+
+test('merge is commutative', () => {
+  fc.assert(fc.property(
+    mutationListArbitrary,
+    mutationListArbitrary,
+    (leftMutations, rightMutations) => {
+      const left = replica('device-a', leftMutations, 100);
+      const right = replica('device-b', rightMutations, 100);
+      assert.equal(
+        serializeConvergentSyncState(mergeConvergentSyncStates(left, right)),
+        serializeConvergentSyncState(mergeConvergentSyncStates(right, left)),
+      );
+    },
+  ), { numRuns: 150 });
+});
+
+test('merge is associative', () => {
+  fc.assert(fc.property(
+    mutationListArbitrary,
+    mutationListArbitrary,
+    mutationListArbitrary,
+    (aMutations, bMutations, cMutations) => {
+      const a = replica('device-a', aMutations, 100);
+      const b = replica('device-b', bMutations, 100);
+      const c = replica('device-c', cMutations, 100);
+      const leftGrouped = mergeConvergentSyncStates(
+        mergeConvergentSyncStates(a, b),
+        c,
+      );
+      const rightGrouped = mergeConvergentSyncStates(
+        a,
+        mergeConvergentSyncStates(b, c),
+      );
+      assert.equal(
+        serializeConvergentSyncState(leftGrouped),
+        serializeConvergentSyncState(rightGrouped),
+      );
+    },
+  ), { numRuns: 120 });
+});
+
+test('merge is idempotent', () => {
+  fc.assert(fc.property(mutationListArbitrary, (mutations) => {
+    const state = replica('device-a', mutations, 100);
+    assert.equal(
+      serializeConvergentSyncState(mergeConvergentSyncStates(state, state)),
+      serializeConvergentSyncState(state),
+    );
+  }), { numRuns: 150 });
+});
+
+test('2-20 offline replicas converge across reordering, partitions, and duplicates', () => {
+  fc.assert(fc.property(
+    fc.array(mutationListArbitrary, { minLength: 2, maxLength: 20 }),
+    fc.array(fc.integer(), { minLength: 20, maxLength: 20 }),
+    (replicaMutations, orderKeys) => {
+      const replicas = replicaMutations.map((mutations, index) =>
+        replica(`device-${index.toString().padStart(2, '0')}`, mutations, 100 + index),
+      );
+      const baseline = replicas.reduce(mergeConvergentSyncStates);
+      const order = replicas
+        .map((state, index) => ({ state, key: orderKeys[index] ?? index }))
+        .sort((left, right) => left.key - right.key)
+        .map((item) => item.state);
+      const reordered = order.reduce(mergeConvergentSyncStates);
+      const split = Math.max(1, Math.floor(order.length / 2));
+      const leftPartition = order.slice(0, split).reduce(mergeConvergentSyncStates);
+      const rightPartition = order.slice(split).reduce(mergeConvergentSyncStates);
+      const partitioned = mergeConvergentSyncStates(
+        mergeConvergentSyncStates(leftPartition, leftPartition),
+        mergeConvergentSyncStates(rightPartition, rightPartition),
+      );
+
+      assert.equal(
+        serializeConvergentSyncState(reordered),
+        serializeConvergentSyncState(baseline),
+      );
+      assert.equal(
+        serializeConvergentSyncState(partitioned),
+        serializeConvergentSyncState(baseline),
+      );
+    },
+  ), { numRuns: 60 });
+});

--- a/domain/convergentSync/convergentSync.property.test.ts
+++ b/domain/convergentSync/convergentSync.property.test.ts
@@ -6,6 +6,7 @@ import fc from 'fast-check';
 import {
   applyConvergentMutations,
   createConvergentSyncState,
+  materializeConvergentSyncState,
   mergeConvergentSyncStates,
   serializeConvergentSyncState,
   type ConvergentMutation,
@@ -22,9 +23,14 @@ const jsonValueArbitrary: fc.Arbitrary<JsonValue> = fc.oneof(
 
 const settingPathArbitrary: fc.Arbitrary<string[]> = fc.constantFrom(
   'theme',
+  'terminalRoot',
   'fontSize',
   'palette',
-).map((value) => value === 'theme' ? ['theme'] : ['terminal', value]);
+).map((value) => {
+  if (value === 'theme') return ['theme'];
+  if (value === 'terminalRoot') return ['terminal'];
+  return ['terminal', value];
+});
 
 const mutationArbitrary: fc.Arbitrary<ConvergentMutation> = fc.oneof(
   fc.record({
@@ -79,9 +85,15 @@ test('merge is commutative', () => {
     (leftMutations, rightMutations) => {
       const left = replica('device-a', leftMutations, 100);
       const right = replica('device-b', rightMutations, 100);
+      const leftRight = mergeConvergentSyncStates(left, right);
+      const rightLeft = mergeConvergentSyncStates(right, left);
       assert.equal(
-        serializeConvergentSyncState(mergeConvergentSyncStates(left, right)),
-        serializeConvergentSyncState(mergeConvergentSyncStates(right, left)),
+        serializeConvergentSyncState(leftRight),
+        serializeConvergentSyncState(rightLeft),
+      );
+      assert.deepEqual(
+        materializeConvergentSyncState(leftRight),
+        materializeConvergentSyncState(rightLeft),
       );
     },
   ), { numRuns: 150 });

--- a/domain/convergentSync/convergentSync.test.ts
+++ b/domain/convergentSync/convergentSync.test.ts
@@ -121,6 +121,75 @@ test('concurrent delete and update remains visible as a presence conflict', () =
   ));
 });
 
+test('no-op field sets do not resurrect concurrent entity deletions', () => {
+  const base = hostBase();
+  const unchanged = applyConvergentMutations(base, 'device-b', [{
+    kind: 'entity-field-set',
+    collection: 'hosts',
+    entityId: 'host-1',
+    field: 'label',
+    value: 'Production',
+  }], BASE_TIME + 1);
+  const deleted = applyConvergentMutations(base, 'device-a', [{
+    kind: 'entity-delete',
+    collection: 'hosts',
+    entityId: 'host-1',
+  }], BASE_TIME + 1);
+
+  assert.equal(
+    serializeConvergentSyncState(unchanged),
+    serializeConvergentSyncState(base),
+  );
+  assert.deepEqual(
+    materializeConvergentSyncState(
+      mergeConvergentSyncStates(deleted, unchanged),
+    ).collections.hosts,
+    [],
+  );
+});
+
+test('deleting an absent field is a no-op and does not refresh presence', () => {
+  const base = hostBase();
+  const unchanged = applyConvergentMutations(base, 'device-b', [{
+    kind: 'entity-field-delete',
+    collection: 'hosts',
+    entityId: 'host-1',
+    field: 'description',
+  }], BASE_TIME + 1);
+
+  assert.equal(
+    serializeConvergentSyncState(unchanged),
+    serializeConvergentSyncState(base),
+  );
+});
+
+test('field deletion on a non-present entity does not recreate it', () => {
+  const deleted = applyConvergentMutations(hostBase(), 'device-a', [{
+    kind: 'entity-delete',
+    collection: 'hosts',
+    entityId: 'host-1',
+  }], BASE_TIME + 1);
+  const fieldDeleted = applyConvergentMutations(deleted, 'device-b', [{
+    kind: 'entity-field-delete',
+    collection: 'hosts',
+    entityId: 'host-1',
+    field: 'label',
+  }], BASE_TIME + 2);
+
+  assert.deepEqual(
+    materializeConvergentSyncState(fieldDeleted).collections.hosts,
+    [],
+  );
+  assert.equal(
+    fieldDeleted.collections.hosts.entities['host-1'].presence.candidates[0]?.tombstone,
+    true,
+  );
+  assert.equal(
+    fieldDeleted.collections.hosts.entities['host-1'].fields.label.candidates[0]?.tombstone,
+    true,
+  );
+});
+
 test('causal deletion is not resurrected by a stale replica', () => {
   const base = hostBase();
   const deleted = applyConvergentMutations(base, 'device-a', [{

--- a/domain/convergentSync/convergentSync.test.ts
+++ b/domain/convergentSync/convergentSync.test.ts
@@ -122,6 +122,82 @@ test('concurrent delete and update remains visible as a presence conflict', () =
   ));
 });
 
+test('deleted entities suppress stale field and position conflicts', () => {
+  const base = hostBase();
+  const left = applyConvergentMutations(base, 'device-a', [{
+    kind: 'entity-upsert',
+    collection: 'hosts',
+    entityId: 'host-1',
+    value: {
+      id: 'host-1',
+      label: 'Left',
+      hostname: 'old.example.com',
+      tags: ['prod'],
+    },
+    position: 1,
+  }], BASE_TIME + 1);
+  const right = applyConvergentMutations(base, 'device-b', [{
+    kind: 'entity-upsert',
+    collection: 'hosts',
+    entityId: 'host-1',
+    value: {
+      id: 'host-1',
+      label: 'Right',
+      hostname: 'old.example.com',
+      tags: ['prod'],
+    },
+    position: 2,
+  }], BASE_TIME + 1);
+  const conflicted = mergeConvergentSyncStates(left, right);
+  const deleted = applyConvergentMutations(conflicted, 'device-c', [{
+    kind: 'entity-delete',
+    collection: 'hosts',
+    entityId: 'host-1',
+  }], BASE_TIME + 2);
+  const entity = deleted.collections.hosts.entities['host-1'];
+  const materialized = materializeConvergentSyncState(deleted);
+
+  assert.equal(entity.fields.label.candidates.length, 2);
+  assert.equal(entity.position?.candidates.length, 2);
+  assert.deepEqual(materialized.collections.hosts, []);
+  assert.deepEqual(materialized.conflicts, []);
+});
+
+test('visible entities retain internal conflicts during a presence conflict', () => {
+  const base = hostBase();
+  const left = applyConvergentMutations(base, 'device-a', [{
+    kind: 'entity-field-set',
+    collection: 'hosts',
+    entityId: 'host-1',
+    field: 'label',
+    value: 'Left',
+  }], BASE_TIME + 1);
+  const right = applyConvergentMutations(base, 'device-b', [{
+    kind: 'entity-field-set',
+    collection: 'hosts',
+    entityId: 'host-1',
+    field: 'label',
+    value: 'Right',
+  }], BASE_TIME + 1);
+  const deleted = applyConvergentMutations(base, 'device-c', [{
+    kind: 'entity-delete',
+    collection: 'hosts',
+    entityId: 'host-1',
+  }], BASE_TIME + 1);
+  const materialized = materializeConvergentSyncState(
+    mergeConvergentSyncStates(mergeConvergentSyncStates(left, right), deleted),
+  );
+
+  assert.equal(materialized.collections.hosts.length, 1);
+  assert.ok(materialized.conflicts.some(
+    (conflict) => conflict.address.kind === 'entity-presence',
+  ));
+  assert.ok(materialized.conflicts.some(
+    (conflict) => conflict.address.kind === 'entity-field'
+      && conflict.address.field === 'label',
+  ));
+});
+
 test('full entity upserts resolve an accepted presence conflict', () => {
   const base = hostBase();
   const deleted = applyConvergentMutations(base, 'device-a', [{
@@ -455,6 +531,39 @@ test('string-entry adds resolve a same-value position conflict', () => {
   assert.deepEqual(materialized.stringCollections.customGroups, ['Alpha']);
   assert.equal(materialized.conflicts.length, 0);
   assert.equal(resolved.vector.resolver, 2);
+});
+
+test('deleted string entries suppress stale position conflicts', () => {
+  const seeded = applyConvergentMutations(createConvergentSyncState(), 'seed', [{
+    kind: 'string-entry-add',
+    collection: 'customGroups',
+    value: 'Alpha',
+    position: 0,
+  }], BASE_TIME);
+  const left = applyConvergentMutations(seeded, 'device-a', [{
+    kind: 'string-entry-add',
+    collection: 'customGroups',
+    value: 'Alpha',
+    position: 1,
+  }], BASE_TIME + 1);
+  const right = applyConvergentMutations(seeded, 'device-b', [{
+    kind: 'string-entry-add',
+    collection: 'customGroups',
+    value: 'Alpha',
+    position: 2,
+  }], BASE_TIME + 1);
+  const conflicted = mergeConvergentSyncStates(left, right);
+  const deleted = applyConvergentMutations(conflicted, 'device-c', [{
+    kind: 'string-entry-delete',
+    collection: 'customGroups',
+    value: 'Alpha',
+  }], BASE_TIME + 2);
+  const entry = deleted.stringCollections.customGroups.entries.Alpha;
+  const materialized = materializeConvergentSyncState(deleted);
+
+  assert.equal(entry.position?.candidates.length, 2);
+  assert.deepEqual(materialized.stringCollections.customGroups, []);
+  assert.deepEqual(materialized.conflicts, []);
 });
 
 test('unchanged string-entry adds do not advance the replica clock', () => {

--- a/domain/convergentSync/convergentSync.test.ts
+++ b/domain/convergentSync/convergentSync.test.ts
@@ -377,6 +377,97 @@ test('settings are leaf registers while arrays remain atomic values', () => {
   assert.deepEqual(decodeSettingPath('/key~1with~0escapes'), ['key/with~escapes']);
 });
 
+test('unchanged setting writes do not advance the replica clock', () => {
+  const initial = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'dark',
+  }], BASE_TIME);
+  const unchanged = applyConvergentMutations(initial, 'device-a', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'dark',
+  }], BASE_TIME + 1);
+
+  assert.equal(
+    serializeConvergentSyncState(unchanged),
+    serializeConvergentSyncState(initial),
+  );
+});
+
+test('setting writes matching the selected conflict candidate still resolve the conflict', () => {
+  const dark = applyConvergentMutations(createConvergentSyncState(), 'device-z', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'dark',
+  }], BASE_TIME);
+  const light = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'light',
+  }], BASE_TIME);
+  const conflicted = mergeConvergentSyncStates(dark, light);
+  const resolved = applyConvergentMutations(conflicted, 'resolver', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'dark',
+  }], BASE_TIME + 1);
+  const materialized = materializeConvergentSyncState(resolved);
+
+  assert.equal(materialized.settings.theme, 'dark');
+  assert.equal(materialized.conflicts.length, 0);
+  assert.equal(resolved.vector.resolver, 1);
+});
+
+test('unchanged setting writes still tombstone overlapping active paths', () => {
+  const parent = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
+    kind: 'setting-set',
+    path: ['terminal'],
+    value: 'atomic',
+  }], BASE_TIME);
+  const child = applyConvergentMutations(createConvergentSyncState(), 'device-z', [{
+    kind: 'setting-set',
+    path: ['terminal', 'fontSize'],
+    value: 14,
+  }], BASE_TIME);
+  const conflicted = mergeConvergentSyncStates(parent, child);
+  const normalized = applyConvergentMutations(conflicted, 'resolver', [{
+    kind: 'setting-set',
+    path: ['terminal', 'fontSize'],
+    value: 14,
+  }], BASE_TIME + 1);
+  const materialized = materializeConvergentSyncState(normalized);
+
+  assert.deepEqual(materialized.settings, { terminal: { fontSize: 14 } });
+  assert.equal(materialized.conflicts.length, 0);
+  assert.equal(normalized.vector.resolver, 1);
+  assert.deepEqual(
+    normalized.settings['/terminal/fontSize'].candidates[0]?.dot,
+    child.settings['/terminal/fontSize'].candidates[0]?.dot,
+  );
+});
+
+test('repeated setting deletes do not advance the replica clock', () => {
+  const initial = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'dark',
+  }], BASE_TIME);
+  const deleted = applyConvergentMutations(initial, 'device-a', [{
+    kind: 'setting-delete',
+    path: ['theme'],
+  }], BASE_TIME + 1);
+  const repeated = applyConvergentMutations(deleted, 'device-a', [{
+    kind: 'setting-delete',
+    path: ['theme'],
+  }], BASE_TIME + 2);
+
+  assert.equal(
+    serializeConvergentSyncState(repeated),
+    serializeConvergentSyncState(deleted),
+  );
+});
+
 test('causal setting shape changes tombstone overlapping leaf paths', () => {
   const nested = applyConvergentMutations(createConvergentSyncState(), 'device-a', [
     { kind: 'setting-set', path: ['terminal'], value: ['atomic'] },

--- a/domain/convergentSync/convergentSync.test.ts
+++ b/domain/convergentSync/convergentSync.test.ts
@@ -396,6 +396,54 @@ test('canonical serialization is stable and hydration validates the state', () =
   );
 });
 
+test('validation rejects vector counters without a retained causal witness', () => {
+  const local = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'dark',
+  }], BASE_TIME);
+  const missingCandidate = createConvergentSyncState();
+  missingCandidate.vector['device-a'] = 1;
+  const inflatedVector = JSON.parse(
+    serializeConvergentSyncState(local),
+  ) as ConvergentSyncStateV2;
+  inflatedVector.vector['device-a'] = 2;
+
+  assert.throws(
+    () => hydrateConvergentSyncState(JSON.stringify(missingCandidate)),
+    /vector\.device-a is not witnessed/,
+  );
+  assert.throws(
+    () => mergeConvergentSyncStates(local, missingCandidate),
+    /vector\.device-a is not witnessed/,
+  );
+  assert.throws(
+    () => hydrateConvergentSyncState(JSON.stringify(inflatedVector)),
+    /vector\.device-a is not witnessed/,
+  );
+});
+
+test('candidate context can witness causally dominated vector counters', () => {
+  const first = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'dark',
+  }], BASE_TIME);
+  const overwritten = applyConvergentMutations(first, 'device-b', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'light',
+  }], BASE_TIME + 1);
+
+  assert.deepEqual(overwritten.settings['/theme'].candidates[0]?.context, {
+    'device-a': 1,
+  });
+  assert.deepEqual(
+    hydrateConvergentSyncState(serializeConvergentSyncState(overwritten)),
+    overwritten,
+  );
+});
+
 test('candidate metadata key order cannot change canonical serialization or merge identity', () => {
   const state = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
     kind: 'setting-set',

--- a/domain/convergentSync/convergentSync.test.ts
+++ b/domain/convergentSync/convergentSync.test.ts
@@ -1,0 +1,327 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  ConvergentSyncInvariantError,
+  applyConvergentMutations,
+  createConvergentSyncState,
+  decodeSettingPath,
+  encodeSettingPath,
+  hydrateConvergentSyncState,
+  materializeConvergentSyncState,
+  mergeConvergentSyncStates,
+  serializeConvergentSyncState,
+  tickHybridLogicalClock,
+  type ConvergentSyncStateV2,
+} from './index.ts';
+
+const BASE_TIME = 1_700_000_000_000;
+
+function hostBase() {
+  return applyConvergentMutations(createConvergentSyncState(), 'seed', [{
+    kind: 'entity-upsert',
+    collection: 'hosts',
+    entityId: 'host-1',
+    value: {
+      id: 'host-1',
+      label: 'Production',
+      hostname: 'old.example.com',
+      tags: ['prod'],
+    },
+    position: 0,
+  }], BASE_TIME);
+}
+
+test('independent entity fields merge without conflict', () => {
+  const base = hostBase();
+  const left = applyConvergentMutations(base, 'device-a', [{
+    kind: 'entity-field-set',
+    collection: 'hosts',
+    entityId: 'host-1',
+    field: 'label',
+    value: 'Primary',
+  }], BASE_TIME + 1);
+  const right = applyConvergentMutations(base, 'device-b', [{
+    kind: 'entity-field-set',
+    collection: 'hosts',
+    entityId: 'host-1',
+    field: 'hostname',
+    value: 'new.example.com',
+  }], BASE_TIME + 1);
+
+  const materialized = materializeConvergentSyncState(
+    mergeConvergentSyncStates(left, right),
+  );
+
+  assert.deepEqual(materialized.collections.hosts, [{
+    id: 'host-1',
+    hostname: 'new.example.com',
+    label: 'Primary',
+    tags: ['prod'],
+  }]);
+  assert.deepEqual(materialized.conflicts, []);
+});
+
+test('same-field concurrent values are retained with a deterministic winner', () => {
+  const base = hostBase();
+  const left = applyConvergentMutations(base, 'device-a', [{
+    kind: 'entity-field-set',
+    collection: 'hosts',
+    entityId: 'host-1',
+    field: 'label',
+    value: 'Left',
+  }], BASE_TIME + 1);
+  const right = applyConvergentMutations(base, 'device-z', [{
+    kind: 'entity-field-set',
+    collection: 'hosts',
+    entityId: 'host-1',
+    field: 'label',
+    value: 'Right',
+  }], BASE_TIME + 1);
+
+  const materialized = materializeConvergentSyncState(
+    mergeConvergentSyncStates(right, left),
+  );
+  const conflict = materialized.conflicts.find(
+    (item) => item.address.kind === 'entity-field' && item.address.field === 'label',
+  );
+
+  assert.equal(materialized.collections.hosts[0]?.label, 'Right');
+  assert.equal(conflict?.candidates.length, 2);
+  assert.deepEqual(
+    conflict?.candidates.map((candidate) => candidate.value).sort(),
+    ['Left', 'Right'],
+  );
+  assert.equal(conflict?.candidates.filter((candidate) => candidate.selected).length, 1);
+});
+
+test('concurrent delete and update remains visible as a presence conflict', () => {
+  const base = hostBase();
+  const deleted = applyConvergentMutations(base, 'device-a', [{
+    kind: 'entity-delete',
+    collection: 'hosts',
+    entityId: 'host-1',
+  }], BASE_TIME + 1);
+  const updated = applyConvergentMutations(base, 'device-b', [{
+    kind: 'entity-field-set',
+    collection: 'hosts',
+    entityId: 'host-1',
+    field: 'hostname',
+    value: 'edited.example.com',
+  }], BASE_TIME + 1);
+
+  const materialized = materializeConvergentSyncState(
+    mergeConvergentSyncStates(deleted, updated),
+  );
+
+  assert.equal(materialized.collections.hosts.length, 1);
+  assert.equal(materialized.collections.hosts[0]?.hostname, 'edited.example.com');
+  assert.ok(materialized.conflicts.some(
+    (conflict) => conflict.address.kind === 'entity-presence',
+  ));
+});
+
+test('causal deletion is not resurrected by a stale replica', () => {
+  const base = hostBase();
+  const deleted = applyConvergentMutations(base, 'device-a', [{
+    kind: 'entity-delete',
+    collection: 'hosts',
+    entityId: 'host-1',
+  }], BASE_TIME + 1);
+
+  const merged = mergeConvergentSyncStates(base, deleted);
+  assert.deepEqual(materializeConvergentSyncState(merged).collections.hosts, []);
+  assert.equal(
+    merged.collections.hosts.entities['host-1'].presence.candidates[0]?.tombstone,
+    true,
+  );
+});
+
+test('explicit recreation causally dominates a tombstone', () => {
+  const deleted = applyConvergentMutations(hostBase(), 'device-a', [{
+    kind: 'entity-delete',
+    collection: 'hosts',
+    entityId: 'host-1',
+  }], BASE_TIME + 1);
+  const recreated = applyConvergentMutations(deleted, 'device-b', [{
+    kind: 'entity-upsert',
+    collection: 'hosts',
+    entityId: 'host-1',
+    value: {
+      id: 'host-1',
+      label: 'Recreated',
+      hostname: 'new.example.com',
+      tags: [],
+    },
+  }], BASE_TIME + 2);
+
+  const materialized = materializeConvergentSyncState(
+    mergeConvergentSyncStates(deleted, recreated),
+  );
+  assert.equal(materialized.collections.hosts[0]?.label, 'Recreated');
+  assert.equal(materialized.conflicts.length, 0);
+});
+
+test('conflict resolution dominates all candidates and survives stale joins', () => {
+  const base = hostBase();
+  const left = applyConvergentMutations(base, 'device-a', [{
+    kind: 'entity-field-set',
+    collection: 'hosts',
+    entityId: 'host-1',
+    field: 'label',
+    value: 'Left',
+  }], BASE_TIME + 1);
+  const right = applyConvergentMutations(base, 'device-b', [{
+    kind: 'entity-field-set',
+    collection: 'hosts',
+    entityId: 'host-1',
+    field: 'label',
+    value: 'Right',
+  }], BASE_TIME + 1);
+  const conflicted = mergeConvergentSyncStates(left, right);
+  const resolved = applyConvergentMutations(conflicted, 'resolver', [{
+    kind: 'resolve-register',
+    address: {
+      kind: 'entity-field',
+      collection: 'hosts',
+      entityId: 'host-1',
+      field: 'label',
+    },
+    value: 'Reviewed',
+  }], BASE_TIME + 2);
+
+  const afterStaleJoin = materializeConvergentSyncState(
+    mergeConvergentSyncStates(resolved, conflicted),
+  );
+  assert.equal(afterStaleJoin.collections.hosts[0]?.label, 'Reviewed');
+  assert.equal(afterStaleJoin.conflicts.length, 0);
+});
+
+test('string collections use observed-remove presence and stable positions', () => {
+  const base = applyConvergentMutations(createConvergentSyncState(), 'seed', [
+    { kind: 'string-entry-add', collection: 'customGroups', value: 'Beta', position: 2 },
+    { kind: 'string-entry-add', collection: 'customGroups', value: 'Alpha', position: 1 },
+  ], BASE_TIME);
+  const deleted = applyConvergentMutations(base, 'device-a', [{
+    kind: 'string-entry-delete',
+    collection: 'customGroups',
+    value: 'Alpha',
+  }], BASE_TIME + 1);
+
+  assert.deepEqual(
+    materializeConvergentSyncState(mergeConvergentSyncStates(base, deleted))
+      .stringCollections.customGroups,
+    ['Beta'],
+  );
+});
+
+test('settings are leaf registers while arrays remain atomic values', () => {
+  const state = applyConvergentMutations(createConvergentSyncState(), 'device-a', [
+    { kind: 'setting-set', path: ['terminal', 'fontSize'], value: 14 },
+    { kind: 'setting-set', path: ['terminal', 'fallbackFonts'], value: ['A', 'B'] },
+    { kind: 'setting-set', path: ['key/with~escapes'], value: true },
+  ], BASE_TIME);
+
+  assert.deepEqual(materializeConvergentSyncState(state).settings, {
+    'key/with~escapes': true,
+    terminal: {
+      fallbackFonts: ['A', 'B'],
+      fontSize: 14,
+    },
+  });
+  assert.equal(encodeSettingPath(['key/with~escapes']), '/key~1with~0escapes');
+  assert.deepEqual(decodeSettingPath('/key~1with~0escapes'), ['key/with~escapes']);
+});
+
+test('canonical serialization is stable and hydration validates the state', () => {
+  const first = applyConvergentMutations(createConvergentSyncState(), 'device-a', [
+    { kind: 'setting-set', path: ['z'], value: { b: 2, a: 1 } },
+    { kind: 'setting-set', path: ['a'], value: ['x'] },
+  ], BASE_TIME);
+  const second = hydrateConvergentSyncState(serializeConvergentSyncState(first));
+
+  assert.equal(serializeConvergentSyncState(first), serializeConvergentSyncState(second));
+  assert.throws(
+    () => hydrateConvergentSyncState('{"schemaVersion":3}'),
+    ConvergentSyncInvariantError,
+  );
+});
+
+test('device counters are monotonic across different register kinds', () => {
+  const state = applyConvergentMutations(createConvergentSyncState(), 'device-a', [
+    {
+      kind: 'entity-field-set',
+      collection: 'hosts',
+      entityId: 'host-1',
+      field: 'label',
+      value: 'Host',
+    },
+    { kind: 'setting-set', path: ['theme'], value: 'dark' },
+    { kind: 'string-entry-add', collection: 'customGroups', value: 'prod' },
+  ], BASE_TIME);
+  const counters = [
+    state.collections.hosts.entities['host-1'].fields.label.candidates[0].dot.counter,
+    state.collections.hosts.entities['host-1'].presence.candidates[0].dot.counter,
+    state.settings['/theme'].candidates[0].dot.counter,
+    state.stringCollections.customGroups.entries.prod.presence.candidates[0].dot.counter,
+  ];
+
+  assert.deepEqual(counters, [1, 2, 3, 4]);
+  assert.equal(state.vector['device-a'], 4);
+});
+
+test('hydration fails closed when a dot is reused by two registers', () => {
+  const state = applyConvergentMutations(createConvergentSyncState(), 'device-a', [
+    { kind: 'setting-set', path: ['a'], value: 1 },
+    { kind: 'setting-set', path: ['b'], value: 2 },
+  ], BASE_TIME);
+  const corrupted = JSON.parse(
+    serializeConvergentSyncState(state),
+  ) as ConvergentSyncStateV2;
+  corrupted.settings['/b'].candidates[0].dot = {
+    ...corrupted.settings['/a'].candidates[0].dot,
+  };
+  corrupted.settings['/b'].candidates[0].context = {
+    ...corrupted.settings['/a'].candidates[0].context,
+  };
+
+  assert.throws(
+    () => hydrateConvergentSyncState(JSON.stringify(corrupted)),
+    /Dot device-a:1 is reused/,
+  );
+});
+
+test('record identifiers cannot escape into the object prototype chain', () => {
+  const state = applyConvergentMutations(createConvergentSyncState(), '__proto__', [
+    {
+      kind: 'entity-field-set',
+      collection: 'constructor',
+      entityId: '__proto__',
+      field: 'constructor',
+      value: 'safe',
+    },
+    { kind: 'setting-set', path: ['__proto__'], value: 'safe-setting' },
+    {
+      kind: 'string-entry-add',
+      collection: '__proto__',
+      value: 'constructor',
+    },
+  ], BASE_TIME);
+  const materialized = materializeConvergentSyncState(state);
+
+  assert.equal(Object.hasOwn(state.vector, '__proto__'), true);
+  assert.equal(materialized.collections.constructor[0]?.constructor, 'safe');
+  assert.equal(materialized.settings.__proto__, 'safe-setting');
+  assert.deepEqual(materialized.stringCollections.__proto__, ['constructor']);
+  assert.equal(Object.getPrototypeOf(materialized.settings), Object.prototype);
+});
+
+test('HLC stays monotonic when wall time moves backwards', () => {
+  const first = tickHybridLogicalClock({ wallTime: 100, logical: 4 }, 90);
+  const second = tickHybridLogicalClock(first, 100);
+  const third = tickHybridLogicalClock(second, 101);
+
+  assert.deepEqual(first, { wallTime: 100, logical: 5 });
+  assert.deepEqual(second, { wallTime: 100, logical: 6 });
+  assert.deepEqual(third, { wallTime: 101, logical: 0 });
+});

--- a/domain/convergentSync/convergentSync.test.ts
+++ b/domain/convergentSync/convergentSync.test.ts
@@ -233,6 +233,92 @@ test('settings are leaf registers while arrays remain atomic values', () => {
   assert.deepEqual(decodeSettingPath('/key~1with~0escapes'), ['key/with~escapes']);
 });
 
+test('causal setting shape changes tombstone overlapping leaf paths', () => {
+  const nested = applyConvergentMutations(createConvergentSyncState(), 'device-a', [
+    { kind: 'setting-set', path: ['terminal'], value: ['atomic'] },
+    { kind: 'setting-set', path: ['terminal', 'fontSize'], value: 14 },
+  ], BASE_TIME);
+  const atomic = applyConvergentMutations(nested, 'device-a', [{
+    kind: 'setting-set',
+    path: ['terminal'],
+    value: ['replacement'],
+  }], BASE_TIME + 1);
+
+  assert.deepEqual(materializeConvergentSyncState(nested).settings, {
+    terminal: { fontSize: 14 },
+  });
+  assert.deepEqual(materializeConvergentSyncState(atomic).settings, {
+    terminal: ['replacement'],
+  });
+  assert.equal(
+    atomic.settings['/terminal/fontSize'].candidates[0]?.tombstone,
+    true,
+  );
+});
+
+test('concurrent setting shape changes materialize deterministically and remain resolvable', () => {
+  const parent = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
+    kind: 'setting-set',
+    path: ['terminal'],
+    value: ['atomic'],
+  }], BASE_TIME);
+  const child = applyConvergentMutations(createConvergentSyncState(), 'device-z', [{
+    kind: 'setting-set',
+    path: ['terminal', 'fontSize'],
+    value: 14,
+  }], BASE_TIME);
+  const merged = mergeConvergentSyncStates(parent, child);
+  const materialized = materializeConvergentSyncState(merged);
+  const structureConflict = materialized.conflicts.find(
+    (conflict) => conflict.address.kind === 'setting-structure',
+  );
+
+  assert.deepEqual(materialized.settings, { terminal: { fontSize: 14 } });
+  assert.deepEqual(
+    structureConflict?.address.kind === 'setting-structure'
+      ? structureConflict.address.paths
+      : [],
+    [['terminal'], ['terminal', 'fontSize']],
+  );
+  assert.equal(structureConflict?.candidates.length, 2);
+  assert.deepEqual(
+    structureConflict?.candidates.filter((candidate) => candidate.selected)
+      .map((candidate) => candidate.settingPath),
+    [['terminal', 'fontSize']],
+  );
+
+  const resolved = applyConvergentMutations(merged, 'resolver', [{
+    kind: 'resolve-register',
+    address: { kind: 'setting', path: ['terminal'] },
+    value: ['reviewed'],
+  }], BASE_TIME + 1);
+  const resolvedMaterialized = materializeConvergentSyncState(resolved);
+  assert.deepEqual(resolvedMaterialized.settings, { terminal: ['reviewed'] });
+  assert.equal(
+    resolvedMaterialized.conflicts.some(
+      (conflict) => conflict.address.kind === 'setting-structure',
+    ),
+    false,
+  );
+});
+
+test('setting structure selection keeps non-overlapping siblings', () => {
+  const parent = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
+    kind: 'setting-set',
+    path: ['terminal'],
+    value: 'atomic',
+  }], BASE_TIME);
+  const children = applyConvergentMutations(createConvergentSyncState(), 'device-z', [
+    { kind: 'setting-set', path: ['terminal', 'fontSize'], value: 14 },
+    { kind: 'setting-set', path: ['terminal', 'fontFamily'], value: 'Mono' },
+  ], BASE_TIME);
+
+  assert.deepEqual(
+    materializeConvergentSyncState(mergeConvergentSyncStates(parent, children)).settings,
+    { terminal: { fontFamily: 'Mono', fontSize: 14 } },
+  );
+});
+
 test('canonical serialization is stable and hydration validates the state', () => {
   const first = applyConvergentMutations(createConvergentSyncState(), 'device-a', [
     { kind: 'setting-set', path: ['z'], value: { b: 2, a: 1 } },
@@ -244,6 +330,39 @@ test('canonical serialization is stable and hydration validates the state', () =
   assert.throws(
     () => hydrateConvergentSyncState('{"schemaVersion":3}'),
     ConvergentSyncInvariantError,
+  );
+});
+
+test('candidate metadata key order cannot change canonical serialization or merge identity', () => {
+  const state = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'dark',
+  }], BASE_TIME);
+  const reordered = JSON.parse(
+    serializeConvergentSyncState(state),
+  ) as ConvergentSyncStateV2;
+  const candidate = reordered.settings['/theme'].candidates[0];
+  candidate.dot = {
+    counter: candidate.dot.counter,
+    deviceId: candidate.dot.deviceId,
+  };
+  candidate.hlc = {
+    logical: candidate.hlc.logical,
+    wallTime: candidate.hlc.wallTime,
+  };
+  reordered.hlc = {
+    logical: reordered.hlc.logical,
+    wallTime: reordered.hlc.wallTime,
+  };
+
+  assert.equal(
+    serializeConvergentSyncState(reordered),
+    serializeConvergentSyncState(state),
+  );
+  assert.equal(
+    serializeConvergentSyncState(mergeConvergentSyncStates(state, reordered)),
+    serializeConvergentSyncState(state),
   );
 });
 

--- a/domain/convergentSync/convergentSync.test.ts
+++ b/domain/convergentSync/convergentSync.test.ts
@@ -394,6 +394,88 @@ test('string collections use observed-remove presence and stable positions', () 
   );
 });
 
+test('string-entry adds resolve a visible add/delete conflict', () => {
+  const seeded = applyConvergentMutations(createConvergentSyncState(), 'seed', [{
+    kind: 'string-entry-add',
+    collection: 'customGroups',
+    value: 'Alpha',
+  }], BASE_TIME);
+  const removed = applyConvergentMutations(seeded, 'device-a', [{
+    kind: 'string-entry-delete',
+    collection: 'customGroups',
+    value: 'Alpha',
+  }], BASE_TIME + 1);
+  const concurrentAdd = applyConvergentMutations(createConvergentSyncState(), 'device-b', [{
+    kind: 'string-entry-add',
+    collection: 'customGroups',
+    value: 'Alpha',
+  }], BASE_TIME + 1);
+  const conflicted = mergeConvergentSyncStates(removed, concurrentAdd);
+  const resolved = applyConvergentMutations(conflicted, 'resolver', [{
+    kind: 'string-entry-add',
+    collection: 'customGroups',
+    value: 'Alpha',
+  }], BASE_TIME + 2);
+  const materialized = materializeConvergentSyncState(resolved);
+
+  assert.deepEqual(materialized.stringCollections.customGroups, ['Alpha']);
+  assert.equal(materialized.conflicts.length, 0);
+  assert.equal(resolved.vector.resolver, 1);
+});
+
+test('string-entry adds resolve a same-value position conflict', () => {
+  const seeded = applyConvergentMutations(createConvergentSyncState(), 'seed', [{
+    kind: 'string-entry-add',
+    collection: 'customGroups',
+    value: 'Alpha',
+    position: 0,
+  }], BASE_TIME);
+  const left = applyConvergentMutations(seeded, 'device-a', [{
+    kind: 'string-entry-add',
+    collection: 'customGroups',
+    value: 'Alpha',
+    position: 1,
+  }], BASE_TIME + 1);
+  const right = applyConvergentMutations(seeded, 'device-z', [{
+    kind: 'string-entry-add',
+    collection: 'customGroups',
+    value: 'Alpha',
+    position: 2,
+  }], BASE_TIME + 1);
+  const conflicted = mergeConvergentSyncStates(left, right);
+  const resolved = applyConvergentMutations(conflicted, 'resolver', [{
+    kind: 'string-entry-add',
+    collection: 'customGroups',
+    value: 'Alpha',
+    position: 2,
+  }], BASE_TIME + 2);
+  const materialized = materializeConvergentSyncState(resolved);
+
+  assert.deepEqual(materialized.stringCollections.customGroups, ['Alpha']);
+  assert.equal(materialized.conflicts.length, 0);
+  assert.equal(resolved.vector.resolver, 2);
+});
+
+test('unchanged string-entry adds do not advance the replica clock', () => {
+  const initial = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
+    kind: 'string-entry-add',
+    collection: 'customGroups',
+    value: 'Alpha',
+    position: 0,
+  }], BASE_TIME);
+  const unchanged = applyConvergentMutations(initial, 'device-a', [{
+    kind: 'string-entry-add',
+    collection: 'customGroups',
+    value: 'Alpha',
+    position: 0,
+  }], BASE_TIME + 1);
+
+  assert.equal(
+    serializeConvergentSyncState(unchanged),
+    serializeConvergentSyncState(initial),
+  );
+});
+
 test('unobserved string-entry deletes are no-ops and do not conflict with concurrent adds', () => {
   const empty = createConvergentSyncState();
   const deleted = applyConvergentMutations(empty, 'device-a', [{

--- a/domain/convergentSync/convergentSync.test.ts
+++ b/domain/convergentSync/convergentSync.test.ts
@@ -256,6 +256,69 @@ test('causal setting shape changes tombstone overlapping leaf paths', () => {
   );
 });
 
+test('causal setting deletion tombstones the complete subtree', () => {
+  const nested = applyConvergentMutations(createConvergentSyncState(), 'device-a', [
+    { kind: 'setting-set', path: ['terminal', 'fontSize'], value: 14 },
+    { kind: 'setting-set', path: ['terminal', 'fontFamily'], value: 'Mono' },
+    { kind: 'setting-set', path: ['theme'], value: 'dark' },
+  ], BASE_TIME);
+  const deleted = applyConvergentMutations(nested, 'device-a', [{
+    kind: 'setting-delete',
+    path: ['terminal'],
+  }], BASE_TIME + 1);
+
+  assert.deepEqual(materializeConvergentSyncState(deleted).settings, {
+    theme: 'dark',
+  });
+  assert.equal(deleted.settings['/terminal'].candidates[0]?.tombstone, true);
+  assert.equal(
+    deleted.settings['/terminal/fontFamily'].candidates[0]?.tombstone,
+    true,
+  );
+  assert.equal(
+    deleted.settings['/terminal/fontSize'].candidates[0]?.tombstone,
+    true,
+  );
+  assert.deepEqual(
+    materializeConvergentSyncState(
+      mergeConvergentSyncStates(nested, deleted),
+    ).settings,
+    { theme: 'dark' },
+  );
+});
+
+test('concurrent subtree deletion and descendant update remain a conflict', () => {
+  const base = applyConvergentMutations(createConvergentSyncState(), 'seed', [{
+    kind: 'setting-set',
+    path: ['terminal', 'fontSize'],
+    value: 14,
+  }], BASE_TIME);
+  const deleted = applyConvergentMutations(base, 'device-a', [{
+    kind: 'setting-delete',
+    path: ['terminal'],
+  }], BASE_TIME + 1);
+  const updated = applyConvergentMutations(base, 'device-b', [{
+    kind: 'setting-set',
+    path: ['terminal', 'fontSize'],
+    value: 16,
+  }], BASE_TIME + 1);
+
+  const materialized = materializeConvergentSyncState(
+    mergeConvergentSyncStates(deleted, updated),
+  );
+  const conflict = materialized.conflicts.find(
+    (item) => item.address.kind === 'setting'
+      && item.address.path.join('/') === 'terminal/fontSize',
+  );
+
+  assert.deepEqual(materialized.settings, { terminal: { fontSize: 16 } });
+  assert.equal(conflict?.candidates.length, 2);
+  assert.equal(
+    conflict?.candidates.some((candidate) => candidate.tombstone),
+    true,
+  );
+});
+
 test('concurrent setting shape changes materialize deterministically and remain resolvable', () => {
   const parent = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
     kind: 'setting-set',

--- a/domain/convergentSync/convergentSync.test.ts
+++ b/domain/convergentSync/convergentSync.test.ts
@@ -284,6 +284,81 @@ test('string collections use observed-remove presence and stable positions', () 
   );
 });
 
+test('unobserved string-entry deletes are no-ops and do not conflict with concurrent adds', () => {
+  const empty = createConvergentSyncState();
+  const deleted = applyConvergentMutations(empty, 'device-a', [{
+    kind: 'string-entry-delete',
+    collection: 'customGroups',
+    value: 'Alpha',
+  }], BASE_TIME);
+  const added = applyConvergentMutations(empty, 'device-b', [{
+    kind: 'string-entry-add',
+    collection: 'customGroups',
+    value: 'Alpha',
+  }], BASE_TIME);
+  const merged = materializeConvergentSyncState(
+    mergeConvergentSyncStates(deleted, added),
+  );
+
+  assert.equal(
+    serializeConvergentSyncState(deleted),
+    serializeConvergentSyncState(empty),
+  );
+  assert.deepEqual(merged.stringCollections.customGroups, ['Alpha']);
+  assert.equal(merged.conflicts.length, 0);
+});
+
+test('string-entry deletes dominate a currently visible add/tombstone conflict', () => {
+  const seeded = applyConvergentMutations(createConvergentSyncState(), 'seed', [{
+    kind: 'string-entry-add',
+    collection: 'customGroups',
+    value: 'Alpha',
+  }], BASE_TIME);
+  const removed = applyConvergentMutations(seeded, 'device-a', [{
+    kind: 'string-entry-delete',
+    collection: 'customGroups',
+    value: 'Alpha',
+  }], BASE_TIME + 1);
+  const concurrentAdd = applyConvergentMutations(createConvergentSyncState(), 'device-b', [{
+    kind: 'string-entry-add',
+    collection: 'customGroups',
+    value: 'Alpha',
+  }], BASE_TIME + 1);
+  const conflicted = mergeConvergentSyncStates(removed, concurrentAdd);
+  const resolved = applyConvergentMutations(conflicted, 'device-c', [{
+    kind: 'string-entry-delete',
+    collection: 'customGroups',
+    value: 'Alpha',
+  }], BASE_TIME + 2);
+  const materialized = materializeConvergentSyncState(resolved);
+
+  assert.deepEqual(materialized.stringCollections.customGroups, []);
+  assert.equal(materialized.conflicts.length, 0);
+});
+
+test('repeated string-entry deletes do not advance the replica clock', () => {
+  const added = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
+    kind: 'string-entry-add',
+    collection: 'customGroups',
+    value: 'Alpha',
+  }], BASE_TIME);
+  const deleted = applyConvergentMutations(added, 'device-a', [{
+    kind: 'string-entry-delete',
+    collection: 'customGroups',
+    value: 'Alpha',
+  }], BASE_TIME + 1);
+  const repeated = applyConvergentMutations(deleted, 'device-a', [{
+    kind: 'string-entry-delete',
+    collection: 'customGroups',
+    value: 'Alpha',
+  }], BASE_TIME + 2);
+
+  assert.equal(
+    serializeConvergentSyncState(repeated),
+    serializeConvergentSyncState(deleted),
+  );
+});
+
 test('settings are leaf registers while arrays remain atomic values', () => {
   const state = applyConvergentMutations(createConvergentSyncState(), 'device-a', [
     { kind: 'setting-set', path: ['terminal', 'fontSize'], value: 14 },

--- a/domain/convergentSync/convergentSync.test.ts
+++ b/domain/convergentSync/convergentSync.test.ts
@@ -576,7 +576,33 @@ test('validation rejects a context dot retained in another register', () => {
 
   assert.throws(
     () => hydrateConvergentSyncState(JSON.stringify(corrupted)),
-    /references dot device-a:1 retained in another register/,
+    /references candidate dot device-a:1 retained in another register/,
+  );
+});
+
+test('validation rejects causal cycles between retained candidates', () => {
+  const left = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'left',
+  }], BASE_TIME);
+  const right = applyConvergentMutations(createConvergentSyncState(), 'device-b', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'right',
+  }], BASE_TIME);
+  const corrupted = mergeConvergentSyncStates(left, right);
+  const [first, second] = corrupted.settings['/theme'].candidates;
+  first.context = [{ ...second.dot }];
+  second.context = [{ ...first.dot }];
+
+  assert.throws(
+    () => hydrateConvergentSyncState(JSON.stringify(corrupted)),
+    /references candidate dot device-b:1 retained in the same register/,
+  );
+  assert.throws(
+    () => mergeConvergentSyncStates(corrupted, corrupted),
+    /references candidate dot device-b:1 retained in the same register/,
   );
 });
 

--- a/domain/convergentSync/convergentSync.test.ts
+++ b/domain/convergentSync/convergentSync.test.ts
@@ -435,21 +435,113 @@ test('candidate context can witness causally dominated vector counters', () => {
     value: 'light',
   }], BASE_TIME + 1);
 
-  assert.deepEqual(overwritten.settings['/theme'].candidates[0]?.context, {
-    'device-a': 1,
-  });
+  assert.deepEqual(overwritten.settings['/theme'].candidates[0]?.context, [{
+    deviceId: 'device-a',
+    counter: 1,
+  }]);
   assert.deepEqual(
     hydrateConvergentSyncState(serializeConvergentSyncState(overwritten)),
     overwritten,
   );
 });
 
-test('candidate metadata key order cannot change canonical serialization or merge identity', () => {
-  const state = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
+test('unrelated register context cannot witness an omitted register', () => {
+  const local = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
     kind: 'setting-set',
     path: ['theme'],
     value: 'dark',
   }], BASE_TIME);
+  const remote = applyConvergentMutations(local, 'device-b', [{
+    kind: 'setting-set',
+    path: ['terminal', 'fontSize'],
+    value: 14,
+  }], BASE_TIME + 1);
+  delete remote.settings['/theme'];
+
+  assert.deepEqual(
+    remote.settings['/terminal/fontSize'].candidates[0]?.context,
+    [],
+  );
+  assert.throws(
+    () => hydrateConvergentSyncState(JSON.stringify(remote)),
+    /vector\.device-a is not witnessed/,
+  );
+  assert.throws(
+    () => mergeConvergentSyncStates(local, remote),
+    /vector\.device-a is not witnessed/,
+  );
+});
+
+test('exact contexts detect missing dots between writes to the same register', () => {
+  const state = applyConvergentMutations(createConvergentSyncState(), 'device-a', [
+    { kind: 'setting-set', path: ['theme'], value: 'dark' },
+    { kind: 'setting-set', path: ['terminal', 'fontSize'], value: 14 },
+    { kind: 'setting-set', path: ['theme'], value: 'light' },
+  ], BASE_TIME);
+  const partial = JSON.parse(
+    serializeConvergentSyncState(state),
+  ) as ConvergentSyncStateV2;
+  delete partial.settings['/terminal/fontSize'];
+
+  assert.deepEqual(state.settings['/theme'].candidates[0]?.context, [{
+    deviceId: 'device-a',
+    counter: 1,
+  }]);
+  assert.throws(
+    () => hydrateConvergentSyncState(JSON.stringify(partial)),
+    /vector\.device-a is not witnessed/,
+  );
+});
+
+test('validation rejects a context dot retained in another register', () => {
+  const state = applyConvergentMutations(createConvergentSyncState(), 'device-a', [
+    { kind: 'setting-set', path: ['theme'], value: 'dark' },
+    { kind: 'setting-set', path: ['terminal', 'fontSize'], value: 14 },
+  ], BASE_TIME);
+  const corrupted = JSON.parse(
+    serializeConvergentSyncState(state),
+  ) as ConvergentSyncStateV2;
+  corrupted.settings['/terminal/fontSize'].candidates[0].context = [{
+    ...corrupted.settings['/theme'].candidates[0].dot,
+  }];
+
+  assert.throws(
+    () => hydrateConvergentSyncState(JSON.stringify(corrupted)),
+    /references dot device-a:1 retained in another register/,
+  );
+});
+
+test('candidate ordering uses locale-independent code-unit comparison', () => {
+  const ascii = applyConvergentMutations(createConvergentSyncState(), 'device-z', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'ascii',
+  }], BASE_TIME);
+  const nonAscii = applyConvergentMutations(createConvergentSyncState(), 'device-ä', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'non-ascii',
+  }], BASE_TIME);
+  const merged = mergeConvergentSyncStates(ascii, nonAscii);
+
+  assert.deepEqual(
+    merged.settings['/theme'].candidates.map((candidate) => candidate.dot.deviceId),
+    ['device-z', 'device-ä'],
+  );
+  assert.equal(materializeConvergentSyncState(merged).settings.theme, 'non-ascii');
+});
+
+test('candidate metadata key order cannot change canonical serialization or merge identity', () => {
+  const first = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'dark',
+  }], BASE_TIME);
+  const state = applyConvergentMutations(first, 'device-b', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'light',
+  }], BASE_TIME + 1);
   const reordered = JSON.parse(
     serializeConvergentSyncState(state),
   ) as ConvergentSyncStateV2;
@@ -461,6 +553,10 @@ test('candidate metadata key order cannot change canonical serialization or merg
   candidate.hlc = {
     logical: candidate.hlc.logical,
     wallTime: candidate.hlc.wallTime,
+  };
+  candidate.context[0] = {
+    counter: candidate.context[0].counter,
+    deviceId: candidate.context[0].deviceId,
   };
   reordered.hlc = {
     logical: reordered.hlc.logical,
@@ -511,9 +607,8 @@ test('hydration fails closed when a dot is reused by two registers', () => {
   corrupted.settings['/b'].candidates[0].dot = {
     ...corrupted.settings['/a'].candidates[0].dot,
   };
-  corrupted.settings['/b'].candidates[0].context = {
-    ...corrupted.settings['/a'].candidates[0].context,
-  };
+  corrupted.settings['/b'].candidates[0].context =
+    corrupted.settings['/a'].candidates[0].context.map((dot) => ({ ...dot }));
 
   assert.throws(
     () => hydrateConvergentSyncState(JSON.stringify(corrupted)),

--- a/domain/convergentSync/convergentSync.test.ts
+++ b/domain/convergentSync/convergentSync.test.ts
@@ -10,6 +10,7 @@ import {
   hydrateConvergentSyncState,
   materializeConvergentSyncState,
   mergeConvergentSyncStates,
+  registerId,
   serializeConvergentSyncState,
   tickHybridLogicalClock,
   type ConvergentSyncStateV2,
@@ -831,10 +832,17 @@ test('validation rejects vector counters without a retained causal witness', () 
   }], BASE_TIME);
   const missingCandidate = createConvergentSyncState();
   missingCandidate.vector['device-a'] = 1;
+  missingCandidate.dotOrigins['device-a'] = {
+    1: registerId({ kind: 'setting', path: ['theme'] }),
+  };
   const inflatedVector = JSON.parse(
     serializeConvergentSyncState(local),
   ) as ConvergentSyncStateV2;
   inflatedVector.vector['device-a'] = 2;
+  inflatedVector.dotOrigins['device-a']['2'] = registerId({
+    kind: 'setting',
+    path: ['theme'],
+  });
 
   assert.throws(
     () => hydrateConvergentSyncState(JSON.stringify(missingCandidate)),
@@ -899,6 +907,28 @@ test('unrelated register context cannot witness an omitted register', () => {
   );
 });
 
+test('copied cross-register context cannot witness an omitted register', () => {
+  const state = applyConvergentMutations(createConvergentSyncState(), 'device-a', [
+    { kind: 'setting-set', path: ['theme'], value: 'dark' },
+    { kind: 'setting-set', path: ['terminal', 'fontSize'], value: 14 },
+  ], BASE_TIME);
+  const corrupted = JSON.parse(
+    serializeConvergentSyncState(state),
+  ) as ConvergentSyncStateV2;
+  const omittedDot = { ...corrupted.settings['/theme'].candidates[0].dot };
+  delete corrupted.settings['/theme'];
+  corrupted.settings['/terminal/fontSize'].candidates[0].context = [omittedDot];
+
+  assert.throws(
+    () => hydrateConvergentSyncState(JSON.stringify(corrupted)),
+    /context\[0\] is assigned to a different register origin/,
+  );
+  assert.throws(
+    () => mergeConvergentSyncStates(state, corrupted),
+    /context\[0\] is assigned to a different register origin/,
+  );
+});
+
 test('exact contexts detect missing dots between writes to the same register', () => {
   const state = applyConvergentMutations(createConvergentSyncState(), 'device-a', [
     { kind: 'setting-set', path: ['theme'], value: 'dark' },
@@ -934,7 +964,7 @@ test('validation rejects a context dot retained in another register', () => {
 
   assert.throws(
     () => hydrateConvergentSyncState(JSON.stringify(corrupted)),
-    /references candidate dot device-a:1 retained in another register/,
+    /context\[0\] is assigned to a different register origin/,
   );
 });
 
@@ -1065,7 +1095,25 @@ test('hydration fails closed when a dot is reused by two registers', () => {
 
   assert.throws(
     () => hydrateConvergentSyncState(JSON.stringify(corrupted)),
-    /Dot device-a:1 is reused/,
+    /dot is assigned to a different register origin/,
+  );
+});
+
+test('merge rejects the same dot allocated to different register origins', () => {
+  const left = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
+    kind: 'setting-set',
+    path: ['theme'],
+    value: 'dark',
+  }], BASE_TIME);
+  const right = applyConvergentMutations(createConvergentSyncState(), 'device-a', [{
+    kind: 'setting-set',
+    path: ['terminal', 'fontSize'],
+    value: 14,
+  }], BASE_TIME);
+
+  assert.throws(
+    () => mergeConvergentSyncStates(left, right),
+    /Dot origin mismatch/,
   );
 });
 

--- a/domain/convergentSync/convergentSync.test.ts
+++ b/domain/convergentSync/convergentSync.test.ts
@@ -121,6 +121,116 @@ test('concurrent delete and update remains visible as a presence conflict', () =
   ));
 });
 
+test('full entity upserts resolve an accepted presence conflict', () => {
+  const base = hostBase();
+  const deleted = applyConvergentMutations(base, 'device-a', [{
+    kind: 'entity-delete',
+    collection: 'hosts',
+    entityId: 'host-1',
+  }], BASE_TIME + 1);
+  const updated = applyConvergentMutations(base, 'device-b', [{
+    kind: 'entity-field-set',
+    collection: 'hosts',
+    entityId: 'host-1',
+    field: 'hostname',
+    value: 'edited.example.com',
+  }], BASE_TIME + 1);
+  const conflicted = mergeConvergentSyncStates(deleted, updated);
+  const selected = materializeConvergentSyncState(conflicted).collections.hosts[0];
+  const resolved = applyConvergentMutations(conflicted, 'resolver', [{
+    kind: 'entity-upsert',
+    collection: 'hosts',
+    entityId: 'host-1',
+    value: selected,
+    position: 0,
+  }], BASE_TIME + 2);
+  const materialized = materializeConvergentSyncState(resolved);
+
+  assert.equal(materialized.collections.hosts[0]?.hostname, 'edited.example.com');
+  assert.equal(materialized.conflicts.length, 0);
+  assert.equal(resolved.vector.resolver, 1);
+});
+
+test('full entity upserts resolve same-value field conflicts', () => {
+  const base = hostBase();
+  const left = applyConvergentMutations(base, 'device-a', [{
+    kind: 'entity-field-set',
+    collection: 'hosts',
+    entityId: 'host-1',
+    field: 'label',
+    value: 'Left',
+  }], BASE_TIME + 1);
+  const right = applyConvergentMutations(base, 'device-z', [{
+    kind: 'entity-field-set',
+    collection: 'hosts',
+    entityId: 'host-1',
+    field: 'label',
+    value: 'Right',
+  }], BASE_TIME + 1);
+  const conflicted = mergeConvergentSyncStates(left, right);
+  const selected = materializeConvergentSyncState(conflicted).collections.hosts[0];
+  const resolved = applyConvergentMutations(conflicted, 'resolver', [{
+    kind: 'entity-upsert',
+    collection: 'hosts',
+    entityId: 'host-1',
+    value: selected,
+    position: 0,
+  }], BASE_TIME + 2);
+  const materialized = materializeConvergentSyncState(resolved);
+
+  assert.equal(materialized.collections.hosts[0]?.label, 'Right');
+  assert.equal(materialized.conflicts.length, 0);
+  assert.equal(resolved.vector.resolver, 2);
+});
+
+test('full entity upserts resolve same-value position conflicts', () => {
+  const base = hostBase();
+  const value = materializeConvergentSyncState(base).collections.hosts[0];
+  const left = applyConvergentMutations(base, 'device-a', [{
+    kind: 'entity-upsert',
+    collection: 'hosts',
+    entityId: 'host-1',
+    value,
+    position: 1,
+  }], BASE_TIME + 1);
+  const right = applyConvergentMutations(base, 'device-z', [{
+    kind: 'entity-upsert',
+    collection: 'hosts',
+    entityId: 'host-1',
+    value,
+    position: 2,
+  }], BASE_TIME + 1);
+  const conflicted = mergeConvergentSyncStates(left, right);
+  const selected = materializeConvergentSyncState(conflicted).collections.hosts[0];
+  const resolved = applyConvergentMutations(conflicted, 'resolver', [{
+    kind: 'entity-upsert',
+    collection: 'hosts',
+    entityId: 'host-1',
+    value: selected,
+    position: 2,
+  }], BASE_TIME + 2);
+
+  assert.equal(materializeConvergentSyncState(resolved).conflicts.length, 0);
+  assert.equal(resolved.vector.resolver, 2);
+});
+
+test('unchanged full entity upserts do not advance the replica clock', () => {
+  const initial = hostBase();
+  const value = materializeConvergentSyncState(initial).collections.hosts[0];
+  const unchanged = applyConvergentMutations(initial, 'seed', [{
+    kind: 'entity-upsert',
+    collection: 'hosts',
+    entityId: 'host-1',
+    value,
+    position: 0,
+  }], BASE_TIME + 1);
+
+  assert.equal(
+    serializeConvergentSyncState(unchanged),
+    serializeConvergentSyncState(initial),
+  );
+});
+
 test('no-op field sets do not resurrect concurrent entity deletions', () => {
   const base = hostBase();
   const unchanged = applyConvergentMutations(base, 'device-b', [{

--- a/domain/convergentSync/index.ts
+++ b/domain/convergentSync/index.ts
@@ -2,6 +2,7 @@ export * from './clock';
 export * from './json';
 export * from './record';
 export * from './register';
+export * from './registerId';
 export * from './serialization';
 export * from './state';
 export * from './types';

--- a/domain/convergentSync/index.ts
+++ b/domain/convergentSync/index.ts
@@ -1,0 +1,7 @@
+export * from './clock';
+export * from './json';
+export * from './record';
+export * from './register';
+export * from './serialization';
+export * from './state';
+export * from './types';

--- a/domain/convergentSync/json.ts
+++ b/domain/convergentSync/json.ts
@@ -1,0 +1,49 @@
+import type { JsonValue } from './types';
+
+export function isJsonValue(value: unknown): value is JsonValue {
+  if (
+    value === null
+    || typeof value === 'string'
+    || typeof value === 'boolean'
+  ) {
+    return true;
+  }
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  if (!value || typeof value !== 'object') return false;
+  return Object.values(value).every(isJsonValue);
+}
+
+export function cloneJson<T extends JsonValue>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneJson(item)) as T;
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [key, cloneJson(nested)]),
+    ) as T;
+  }
+  return value;
+}
+
+export function canonicalizeJson<T extends JsonValue>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalizeJson(item)) as T;
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalizeJson(value[key])]),
+    ) as T;
+  }
+  return value;
+}
+
+export function canonicalJsonString(value: JsonValue): string {
+  return JSON.stringify(canonicalizeJson(value));
+}
+
+export function jsonValuesEqual(left: JsonValue, right: JsonValue): boolean {
+  return canonicalJsonString(left) === canonicalJsonString(right);
+}

--- a/domain/convergentSync/record.ts
+++ b/domain/convergentSync/record.ts
@@ -1,0 +1,25 @@
+export function createEmptyRecord<T>(): Record<string, T> {
+  return {};
+}
+
+export function getOwnRecordValue<T>(
+  record: Record<string, T>,
+  key: string,
+): T | undefined {
+  return Object.prototype.hasOwnProperty.call(record, key)
+    ? record[key]
+    : undefined;
+}
+
+export function setOwnRecordValue<T>(
+  record: Record<string, T>,
+  key: string,
+  value: T,
+): void {
+  Object.defineProperty(record, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+}

--- a/domain/convergentSync/register.ts
+++ b/domain/convergentSync/register.ts
@@ -1,8 +1,8 @@
 import {
   compareDots,
   compareHybridLogicalClocks,
+  compareStrings,
   dotKey,
-  observesDot,
 } from './clock';
 import { canonicalJsonString, cloneJson } from './json';
 import {
@@ -12,7 +12,6 @@ import {
   type JsonValue,
   type MultiValueRegister,
   type RegisterCandidate,
-  type VersionVector,
 } from './types';
 
 export function isTombstoneCandidate(
@@ -29,7 +28,10 @@ export function cloneCandidate<T extends JsonValue>(
       deviceId: candidate.dot.deviceId,
       counter: candidate.dot.counter,
     },
-    context: { ...candidate.context },
+    context: candidate.context.map((dot) => ({
+      deviceId: dot.deviceId,
+      counter: dot.counter,
+    })),
     hlc: {
       wallTime: candidate.hlc.wallTime,
       logical: candidate.hlc.logical,
@@ -43,7 +45,7 @@ export function cloneCandidate<T extends JsonValue>(
 
 export function createRegisterCandidate<T extends JsonValue>(options: {
   dot: Dot;
-  context: VersionVector;
+  context: Dot[];
   hlc: HybridLogicalClock;
   value?: T;
   tombstone?: boolean;
@@ -53,7 +55,10 @@ export function createRegisterCandidate<T extends JsonValue>(options: {
       deviceId: options.dot.deviceId,
       counter: options.dot.counter,
     },
-    context: { ...options.context },
+    context: options.context.map((dot) => ({
+      deviceId: dot.deviceId,
+      counter: dot.counter,
+    })),
     hlc: {
       wallTime: options.hlc.wallTime,
       logical: options.hlc.logical,
@@ -71,11 +76,11 @@ export function createRegisterCandidate<T extends JsonValue>(options: {
   return { ...base, value: cloneJson(options.value) };
 }
 
-function canonicalVector(vector: VersionVector): string {
+function canonicalContext(context: Dot[]): string {
   return JSON.stringify(
-    Object.fromEntries(
-      Object.keys(vector).sort().map((deviceId) => [deviceId, vector[deviceId]]),
-    ),
+    context
+      .map((dot) => ({ deviceId: dot.deviceId, counter: dot.counter }))
+      .sort(compareDots),
   );
 }
 
@@ -85,7 +90,7 @@ function candidateFingerprint(candidate: RegisterCandidate): string {
       deviceId: candidate.dot.deviceId,
       counter: candidate.dot.counter,
     },
-    context: canonicalVector(candidate.context),
+    context: canonicalContext(candidate.context),
     hlc: {
       wallTime: candidate.hlc.wallTime,
       logical: candidate.hlc.logical,
@@ -112,7 +117,24 @@ function candidateDominates(
   winner: RegisterCandidate,
   candidate: RegisterCandidate,
 ): boolean {
-  return observesDot(winner.context, candidate.dot);
+  return winner.context.some((dot) => dotKey(dot) === dotKey(candidate.dot));
+}
+
+export function registerCausalContext(
+  register: MultiValueRegister | undefined,
+): Dot[] {
+  const context = new Map<string, Dot>();
+  const observe = (dot: Dot) => {
+    context.set(dotKey(dot), {
+      deviceId: dot.deviceId,
+      counter: dot.counter,
+    });
+  };
+  for (const candidate of register?.candidates ?? []) {
+    candidate.context.forEach(observe);
+    observe(candidate.dot);
+  }
+  return [...context.values()].sort(compareDots);
 }
 
 export function compareRegisterCandidates(
@@ -126,7 +148,7 @@ export function compareRegisterCandidates(
   const clockOrder = compareHybridLogicalClocks(left.hlc, right.hlc);
   if (clockOrder !== 0) return clockOrder;
 
-  const deviceOrder = left.dot.deviceId.localeCompare(right.dot.deviceId);
+  const deviceOrder = compareStrings(left.dot.deviceId, right.dot.deviceId);
   if (deviceOrder !== 0) return deviceOrder;
   return left.dot.counter - right.dot.counter;
 }
@@ -150,11 +172,11 @@ export function selectRegisterWinner<T extends JsonValue>(
 export function mergeMultiValueRegisters<T extends JsonValue>(
   left: MultiValueRegister<T> | undefined,
   right: MultiValueRegister<T> | undefined,
-  leftVector: VersionVector,
-  rightVector: VersionVector,
 ): MultiValueRegister<T> | undefined {
   const leftCandidates = left?.candidates ?? [];
   const rightCandidates = right?.candidates ?? [];
+  const leftContext = registerCausalContext(left);
+  const rightContext = registerCausalContext(right);
   const leftByDot = new Map(leftCandidates.map((candidate) => [dotKey(candidate.dot), candidate]));
   const rightByDot = new Map(rightCandidates.map((candidate) => [dotKey(candidate.dot), candidate]));
   const candidates: RegisterCandidate<T>[] = [];
@@ -166,9 +188,15 @@ export function mergeMultiValueRegisters<T extends JsonValue>(
     if (leftCandidate && rightCandidate) {
       assertEquivalentCandidates(leftCandidate, rightCandidate);
       candidates.push(cloneCandidate(leftCandidate));
-    } else if (leftCandidate && !observesDot(rightVector, leftCandidate.dot)) {
+    } else if (
+      leftCandidate
+      && !rightContext.some((dot) => dotKey(dot) === dotKey(leftCandidate.dot))
+    ) {
       candidates.push(cloneCandidate(leftCandidate));
-    } else if (rightCandidate && !observesDot(leftVector, rightCandidate.dot)) {
+    } else if (
+      rightCandidate
+      && !leftContext.some((dot) => dotKey(dot) === dotKey(rightCandidate.dot))
+    ) {
       candidates.push(cloneCandidate(rightCandidate));
     }
   }

--- a/domain/convergentSync/register.ts
+++ b/domain/convergentSync/register.ts
@@ -25,9 +25,15 @@ export function cloneCandidate<T extends JsonValue>(
   candidate: RegisterCandidate<T>,
 ): RegisterCandidate<T> {
   const base = {
-    dot: { ...candidate.dot },
+    dot: {
+      deviceId: candidate.dot.deviceId,
+      counter: candidate.dot.counter,
+    },
     context: { ...candidate.context },
-    hlc: { ...candidate.hlc },
+    hlc: {
+      wallTime: candidate.hlc.wallTime,
+      logical: candidate.hlc.logical,
+    },
   };
   if (isTombstoneCandidate(candidate)) {
     return { ...base, tombstone: true };
@@ -43,9 +49,15 @@ export function createRegisterCandidate<T extends JsonValue>(options: {
   tombstone?: boolean;
 }): RegisterCandidate<T> {
   const base = {
-    dot: { ...options.dot },
+    dot: {
+      deviceId: options.dot.deviceId,
+      counter: options.dot.counter,
+    },
     context: { ...options.context },
-    hlc: { ...options.hlc },
+    hlc: {
+      wallTime: options.hlc.wallTime,
+      logical: options.hlc.logical,
+    },
   };
   if (options.tombstone) {
     if (options.value !== undefined) {
@@ -69,9 +81,15 @@ function canonicalVector(vector: VersionVector): string {
 
 function candidateFingerprint(candidate: RegisterCandidate): string {
   return JSON.stringify({
-    dot: candidate.dot,
+    dot: {
+      deviceId: candidate.dot.deviceId,
+      counter: candidate.dot.counter,
+    },
     context: canonicalVector(candidate.context),
-    hlc: candidate.hlc,
+    hlc: {
+      wallTime: candidate.hlc.wallTime,
+      logical: candidate.hlc.logical,
+    },
     tombstone: isTombstoneCandidate(candidate),
     value: isTombstoneCandidate(candidate)
       ? undefined

--- a/domain/convergentSync/register.ts
+++ b/domain/convergentSync/register.ts
@@ -1,0 +1,179 @@
+import {
+  compareDots,
+  compareHybridLogicalClocks,
+  dotKey,
+  observesDot,
+} from './clock';
+import { canonicalJsonString, cloneJson } from './json';
+import {
+  ConvergentSyncInvariantError,
+  type Dot,
+  type HybridLogicalClock,
+  type JsonValue,
+  type MultiValueRegister,
+  type RegisterCandidate,
+  type VersionVector,
+} from './types';
+
+export function isTombstoneCandidate(
+  candidate: RegisterCandidate,
+): candidate is Extract<RegisterCandidate, { tombstone: true }> {
+  return candidate.tombstone === true;
+}
+
+export function cloneCandidate<T extends JsonValue>(
+  candidate: RegisterCandidate<T>,
+): RegisterCandidate<T> {
+  const base = {
+    dot: { ...candidate.dot },
+    context: { ...candidate.context },
+    hlc: { ...candidate.hlc },
+  };
+  if (isTombstoneCandidate(candidate)) {
+    return { ...base, tombstone: true };
+  }
+  return { ...base, value: cloneJson(candidate.value) };
+}
+
+export function createRegisterCandidate<T extends JsonValue>(options: {
+  dot: Dot;
+  context: VersionVector;
+  hlc: HybridLogicalClock;
+  value?: T;
+  tombstone?: boolean;
+}): RegisterCandidate<T> {
+  const base = {
+    dot: { ...options.dot },
+    context: { ...options.context },
+    hlc: { ...options.hlc },
+  };
+  if (options.tombstone) {
+    if (options.value !== undefined) {
+      throw new ConvergentSyncInvariantError('A tombstone candidate cannot contain a value');
+    }
+    return { ...base, tombstone: true };
+  }
+  if (options.value === undefined) {
+    throw new ConvergentSyncInvariantError('A non-tombstone candidate requires a value');
+  }
+  return { ...base, value: cloneJson(options.value) };
+}
+
+function canonicalVector(vector: VersionVector): string {
+  return JSON.stringify(
+    Object.fromEntries(
+      Object.keys(vector).sort().map((deviceId) => [deviceId, vector[deviceId]]),
+    ),
+  );
+}
+
+function candidateFingerprint(candidate: RegisterCandidate): string {
+  return JSON.stringify({
+    dot: candidate.dot,
+    context: canonicalVector(candidate.context),
+    hlc: candidate.hlc,
+    tombstone: isTombstoneCandidate(candidate),
+    value: isTombstoneCandidate(candidate)
+      ? undefined
+      : canonicalJsonString(candidate.value),
+  });
+}
+
+function assertEquivalentCandidates(
+  left: RegisterCandidate,
+  right: RegisterCandidate,
+): void {
+  if (candidateFingerprint(left) !== candidateFingerprint(right)) {
+    throw new ConvergentSyncInvariantError(
+      `Dot ${dotKey(left.dot)} has conflicting candidate payloads`,
+    );
+  }
+}
+
+function candidateDominates(
+  winner: RegisterCandidate,
+  candidate: RegisterCandidate,
+): boolean {
+  return observesDot(winner.context, candidate.dot);
+}
+
+export function compareRegisterCandidates(
+  left: RegisterCandidate,
+  right: RegisterCandidate,
+): number {
+  const leftTombstone = isTombstoneCandidate(left);
+  const rightTombstone = isTombstoneCandidate(right);
+  if (leftTombstone !== rightTombstone) return leftTombstone ? -1 : 1;
+
+  const clockOrder = compareHybridLogicalClocks(left.hlc, right.hlc);
+  if (clockOrder !== 0) return clockOrder;
+
+  const deviceOrder = left.dot.deviceId.localeCompare(right.dot.deviceId);
+  if (deviceOrder !== 0) return deviceOrder;
+  return left.dot.counter - right.dot.counter;
+}
+
+export function compareCandidatesByDot(
+  left: RegisterCandidate,
+  right: RegisterCandidate,
+): number {
+  return compareDots(left.dot, right.dot);
+}
+
+export function selectRegisterWinner<T extends JsonValue>(
+  register: MultiValueRegister<T> | undefined,
+): RegisterCandidate<T> | undefined {
+  if (!register || register.candidates.length === 0) return undefined;
+  return register.candidates.reduce((winner, candidate) =>
+    compareRegisterCandidates(candidate, winner) > 0 ? candidate : winner,
+  );
+}
+
+export function mergeMultiValueRegisters<T extends JsonValue>(
+  left: MultiValueRegister<T> | undefined,
+  right: MultiValueRegister<T> | undefined,
+  leftVector: VersionVector,
+  rightVector: VersionVector,
+): MultiValueRegister<T> | undefined {
+  const leftCandidates = left?.candidates ?? [];
+  const rightCandidates = right?.candidates ?? [];
+  const leftByDot = new Map(leftCandidates.map((candidate) => [dotKey(candidate.dot), candidate]));
+  const rightByDot = new Map(rightCandidates.map((candidate) => [dotKey(candidate.dot), candidate]));
+  const candidates: RegisterCandidate<T>[] = [];
+
+  for (const key of new Set([...leftByDot.keys(), ...rightByDot.keys()])) {
+    const leftCandidate = leftByDot.get(key);
+    const rightCandidate = rightByDot.get(key);
+
+    if (leftCandidate && rightCandidate) {
+      assertEquivalentCandidates(leftCandidate, rightCandidate);
+      candidates.push(cloneCandidate(leftCandidate));
+    } else if (leftCandidate && !observesDot(rightVector, leftCandidate.dot)) {
+      candidates.push(cloneCandidate(leftCandidate));
+    } else if (rightCandidate && !observesDot(leftVector, rightCandidate.dot)) {
+      candidates.push(cloneCandidate(rightCandidate));
+    }
+  }
+
+  const maximal = candidates.filter((candidate, index) =>
+    !candidates.some((other, otherIndex) =>
+      index !== otherIndex && candidateDominates(other, candidate),
+    ),
+  );
+
+  if (maximal.length === 0) return undefined;
+  maximal.sort(compareCandidatesByDot);
+  return { candidates: maximal };
+}
+
+export function registerHasConflict(register: MultiValueRegister): boolean {
+  if (register.candidates.length < 2) return false;
+  const distinctValues = new Set(
+    register.candidates.map((candidate) =>
+      isTombstoneCandidate(candidate)
+        ? '<tombstone>'
+        : canonicalJsonString(candidate.value),
+    ),
+  );
+  return distinctValues.size > 1;
+}

--- a/domain/convergentSync/registerId.ts
+++ b/domain/convergentSync/registerId.ts
@@ -1,0 +1,24 @@
+import type { RegisterAddress } from './types';
+
+/** Collision-free identity persisted for causal-origin validation. */
+export function registerId(address: RegisterAddress): string {
+  switch (address.kind) {
+    case 'entity-presence':
+      return JSON.stringify([address.kind, address.collection, address.entityId]);
+    case 'entity-position':
+      return JSON.stringify([address.kind, address.collection, address.entityId]);
+    case 'entity-field':
+      return JSON.stringify([
+        address.kind,
+        address.collection,
+        address.entityId,
+        address.field,
+      ]);
+    case 'setting':
+      return JSON.stringify([address.kind, ...address.path]);
+    case 'string-entry-presence':
+      return JSON.stringify([address.kind, address.collection, address.value]);
+    case 'string-entry-position':
+      return JSON.stringify([address.kind, address.collection, address.value]);
+  }
+}

--- a/domain/convergentSync/serialization.ts
+++ b/domain/convergentSync/serialization.ts
@@ -1,0 +1,318 @@
+import {
+  compareCandidatesByDot,
+  isTombstoneCandidate,
+} from './register';
+import { compareHybridLogicalClocks, dotKey } from './clock';
+import { canonicalizeJson, cloneJson, isJsonValue } from './json';
+import { getOwnRecordValue } from './record';
+import {
+  ConvergentSyncInvariantError,
+  type ConvergentCollectionState,
+  type ConvergentEntityState,
+  type ConvergentStringCollectionState,
+  type ConvergentStringEntryState,
+  type ConvergentSyncStateV2,
+  type JsonValue,
+  type MultiValueRegister,
+  type RegisterCandidate,
+  type VersionVector,
+} from './types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function assertNonNegativeInteger(value: unknown, label: string): asserts value is number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new ConvergentSyncInvariantError(`${label} must be a non-negative integer`);
+  }
+}
+
+function assertPositiveInteger(value: unknown, label: string): asserts value is number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+    throw new ConvergentSyncInvariantError(`${label} must be a positive integer`);
+  }
+}
+
+function assertNonEmptyKey(value: string, label: string): void {
+  if (value.length === 0) {
+    throw new ConvergentSyncInvariantError(`${label} must not be empty`);
+  }
+}
+
+function assertVersionVector(value: unknown, label: string): asserts value is VersionVector {
+  if (!isRecord(value)) {
+    throw new ConvergentSyncInvariantError(`${label} must be an object`);
+  }
+  for (const [deviceId, counter] of Object.entries(value)) {
+    assertNonEmptyKey(deviceId, `${label} device ID`);
+    assertPositiveInteger(counter, `${label}.${deviceId}`);
+  }
+}
+
+function assertClock(value: unknown, label: string): void {
+  if (!isRecord(value)) {
+    throw new ConvergentSyncInvariantError(`${label} must be an object`);
+  }
+  assertNonNegativeInteger(value.wallTime, `${label}.wallTime`);
+  assertNonNegativeInteger(value.logical, `${label}.logical`);
+}
+
+function assertCandidate(
+  value: unknown,
+  state: ConvergentSyncStateV2,
+  label: string,
+  globalDots: Map<string, string>,
+): asserts value is RegisterCandidate {
+  if (!isRecord(value) || !isRecord(value.dot)) {
+    throw new ConvergentSyncInvariantError(`${label} must contain a dot`);
+  }
+  const deviceId = value.dot.deviceId;
+  if (typeof deviceId !== 'string' || deviceId.length === 0) {
+    throw new ConvergentSyncInvariantError(`${label}.dot.deviceId must not be empty`);
+  }
+  assertPositiveInteger(value.dot.counter, `${label}.dot.counter`);
+  if ((getOwnRecordValue(state.vector, deviceId) ?? 0) < value.dot.counter) {
+    throw new ConvergentSyncInvariantError(`${label}.dot is not covered by the state vector`);
+  }
+
+  assertVersionVector(value.context, `${label}.context`);
+  for (const [contextDeviceId, counter] of Object.entries(value.context)) {
+    if ((getOwnRecordValue(state.vector, contextDeviceId) ?? 0) < counter) {
+      throw new ConvergentSyncInvariantError(`${label}.context exceeds the state vector`);
+    }
+  }
+  if ((getOwnRecordValue(value.context, deviceId) ?? 0) >= value.dot.counter) {
+    throw new ConvergentSyncInvariantError(`${label}.context must precede its own dot`);
+  }
+
+  assertClock(value.hlc, `${label}.hlc`);
+  const candidateClock = value.hlc as { wallTime: number; logical: number };
+  if (compareHybridLogicalClocks(candidateClock, state.hlc) > 0) {
+    throw new ConvergentSyncInvariantError(`${label}.hlc exceeds the state clock`);
+  }
+
+  if (
+    value.tombstone !== undefined
+    && value.tombstone !== false
+    && value.tombstone !== true
+  ) {
+    throw new ConvergentSyncInvariantError(`${label}.tombstone must be a boolean`);
+  }
+  const tombstone = value.tombstone === true;
+  if (!tombstone && !isJsonValue(value.value)) {
+    throw new ConvergentSyncInvariantError(`${label}.value must be valid JSON`);
+  }
+  if (tombstone && Object.prototype.hasOwnProperty.call(value, 'value')) {
+    throw new ConvergentSyncInvariantError(`${label} tombstones must not contain a value`);
+  }
+
+  const key = dotKey({ deviceId, counter: value.dot.counter });
+  const previousAddress = globalDots.get(key);
+  if (previousAddress) {
+    throw new ConvergentSyncInvariantError(
+      `Dot ${key} is reused by ${previousAddress} and ${label}`,
+    );
+  }
+  globalDots.set(key, label);
+}
+
+function assertRegister(
+  value: unknown,
+  state: ConvergentSyncStateV2,
+  label: string,
+  globalDots: Map<string, string>,
+  valueValidator?: (candidate: RegisterCandidate, label: string) => void,
+): asserts value is MultiValueRegister {
+  if (!isRecord(value) || !Array.isArray(value.candidates) || value.candidates.length === 0) {
+    throw new ConvergentSyncInvariantError(`${label} must contain at least one candidate`);
+  }
+  value.candidates.forEach((candidate, index) => {
+    const candidateLabel = `${label}.candidates[${index}]`;
+    assertCandidate(candidate, state, candidateLabel, globalDots);
+    valueValidator?.(candidate, candidateLabel);
+  });
+}
+
+function assertPresenceCandidate(candidate: RegisterCandidate, label: string): void {
+  if (!isTombstoneCandidate(candidate) && candidate.value !== true) {
+    throw new ConvergentSyncInvariantError(`${label} presence values must be true`);
+  }
+}
+
+function assertPositionCandidate(candidate: RegisterCandidate, label: string): void {
+  if (
+    !isTombstoneCandidate(candidate)
+    && typeof candidate.value !== 'string'
+    && typeof candidate.value !== 'number'
+  ) {
+    throw new ConvergentSyncInvariantError(`${label} position must be a string or number`);
+  }
+}
+
+export function encodeSettingPath(path: string[]): string {
+  if (path.length === 0 || path.some((segment) => segment.length === 0)) {
+    throw new ConvergentSyncInvariantError('Setting paths require non-empty segments');
+  }
+  return `/${path.map((segment) => segment.replaceAll('~', '~0').replaceAll('/', '~1')).join('/')}`;
+}
+
+export function decodeSettingPath(encoded: string): string[] {
+  if (!encoded.startsWith('/') || encoded.length === 1) {
+    throw new ConvergentSyncInvariantError(`Invalid encoded setting path: ${encoded}`);
+  }
+  const path = encoded.slice(1).split('/').map((segment) =>
+    segment.replaceAll('~1', '/').replaceAll('~0', '~'),
+  );
+  if (encodeSettingPath(path) !== encoded) {
+    throw new ConvergentSyncInvariantError(`Non-canonical setting path: ${encoded}`);
+  }
+  return path;
+}
+
+export function assertValidConvergentSyncState(
+  value: unknown,
+): asserts value is ConvergentSyncStateV2 {
+  if (!isRecord(value) || value.schemaVersion !== 2) {
+    throw new ConvergentSyncInvariantError('Expected convergent sync schema version 2');
+  }
+  assertVersionVector(value.vector, 'vector');
+  assertClock(value.hlc, 'hlc');
+  if (!isRecord(value.collections) || !isRecord(value.settings) || !isRecord(value.stringCollections)) {
+    throw new ConvergentSyncInvariantError('Collections, settings, and stringCollections must be objects');
+  }
+
+  const state = value as unknown as ConvergentSyncStateV2;
+  const globalDots = new Map<string, string>();
+  for (const [collectionName, collection] of Object.entries(state.collections)) {
+    assertNonEmptyKey(collectionName, 'Collection name');
+    if (!isRecord(collection) || !isRecord(collection.entities)) {
+      throw new ConvergentSyncInvariantError(`Collection ${collectionName} must contain entities`);
+    }
+    for (const [entityId, entity] of Object.entries(collection.entities)) {
+      assertNonEmptyKey(entityId, `Entity ID in ${collectionName}`);
+      if (!isRecord(entity) || !isRecord(entity.fields)) {
+        throw new ConvergentSyncInvariantError(`Entity ${collectionName}/${entityId} is invalid`);
+      }
+      const entityLabel = `collections.${collectionName}.${entityId}`;
+      assertRegister(entity.presence, state, `${entityLabel}.presence`, globalDots, assertPresenceCandidate);
+      if (entity.position !== undefined) {
+        assertRegister(entity.position, state, `${entityLabel}.position`, globalDots, assertPositionCandidate);
+      }
+      for (const [field, register] of Object.entries(entity.fields)) {
+        assertNonEmptyKey(field, `${entityLabel} field`);
+        if (field === 'id') {
+          throw new ConvergentSyncInvariantError(`${entityLabel} must not store structural ID as a field`);
+        }
+        assertRegister(register, state, `${entityLabel}.fields.${field}`, globalDots);
+      }
+    }
+  }
+
+  for (const [encodedPath, register] of Object.entries(state.settings)) {
+    decodeSettingPath(encodedPath);
+    assertRegister(register, state, `settings.${encodedPath}`, globalDots);
+  }
+
+  for (const [collectionName, collection] of Object.entries(state.stringCollections)) {
+    assertNonEmptyKey(collectionName, 'String collection name');
+    if (!isRecord(collection) || !isRecord(collection.entries)) {
+      throw new ConvergentSyncInvariantError(`String collection ${collectionName} must contain entries`);
+    }
+    for (const [entryValue, entry] of Object.entries(collection.entries)) {
+      assertNonEmptyKey(entryValue, `Entry value in ${collectionName}`);
+      if (!isRecord(entry)) {
+        throw new ConvergentSyncInvariantError(`String entry ${collectionName}/${entryValue} is invalid`);
+      }
+      const entryLabel = `stringCollections.${collectionName}.${entryValue}`;
+      assertRegister(entry.presence, state, `${entryLabel}.presence`, globalDots, assertPresenceCandidate);
+      if (entry.position !== undefined) {
+        assertRegister(entry.position, state, `${entryLabel}.position`, globalDots, assertPositionCandidate);
+      }
+    }
+  }
+}
+
+function sortRecord<T>(record: Record<string, T>, clone: (value: T) => T): Record<string, T> {
+  return Object.fromEntries(
+    Object.keys(record).sort().map((key) => [key, clone(record[key])]),
+  );
+}
+
+function canonicalCandidate<T extends JsonValue>(
+  candidate: RegisterCandidate<T>,
+): RegisterCandidate<T> {
+  const base = {
+    dot: { ...candidate.dot },
+    context: sortRecord(candidate.context, (counter) => counter),
+    hlc: { ...candidate.hlc },
+  };
+  if (isTombstoneCandidate(candidate)) return { ...base, tombstone: true };
+  return { ...base, value: canonicalizeJson(cloneJson(candidate.value)) };
+}
+
+function canonicalRegister<T extends JsonValue>(
+  register: MultiValueRegister<T>,
+): MultiValueRegister<T> {
+  return {
+    candidates: register.candidates
+      .map(canonicalCandidate)
+      .sort(compareCandidatesByDot),
+  };
+}
+
+function canonicalEntity(entity: ConvergentEntityState): ConvergentEntityState {
+  return {
+    presence: canonicalRegister(entity.presence),
+    ...(entity.position ? { position: canonicalRegister(entity.position) } : {}),
+    fields: sortRecord(entity.fields, canonicalRegister),
+  };
+}
+
+function canonicalCollection(collection: ConvergentCollectionState): ConvergentCollectionState {
+  return { entities: sortRecord(collection.entities, canonicalEntity) };
+}
+
+function canonicalStringEntry(entry: ConvergentStringEntryState): ConvergentStringEntryState {
+  return {
+    presence: canonicalRegister(entry.presence),
+    ...(entry.position ? { position: canonicalRegister(entry.position) } : {}),
+  };
+}
+
+function canonicalStringCollection(
+  collection: ConvergentStringCollectionState,
+): ConvergentStringCollectionState {
+  return { entries: sortRecord(collection.entries, canonicalStringEntry) };
+}
+
+export function canonicalizeConvergentSyncState(
+  state: ConvergentSyncStateV2,
+): ConvergentSyncStateV2 {
+  assertValidConvergentSyncState(state);
+  return {
+    schemaVersion: 2,
+    vector: sortRecord(state.vector, (counter) => counter),
+    hlc: { ...state.hlc },
+    collections: sortRecord(state.collections, canonicalCollection),
+    settings: sortRecord(state.settings, canonicalRegister),
+    stringCollections: sortRecord(state.stringCollections, canonicalStringCollection),
+  };
+}
+
+export function serializeConvergentSyncState(state: ConvergentSyncStateV2): string {
+  return JSON.stringify(canonicalizeConvergentSyncState(state));
+}
+
+export function hydrateConvergentSyncState(serialized: string): ConvergentSyncStateV2 {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serialized) as unknown;
+  } catch (error) {
+    throw new ConvergentSyncInvariantError(
+      `Invalid convergent sync JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  assertValidConvergentSyncState(parsed);
+  return canonicalizeConvergentSyncState(parsed);
+}

--- a/domain/convergentSync/serialization.ts
+++ b/domain/convergentSync/serialization.ts
@@ -243,9 +243,15 @@ function canonicalCandidate<T extends JsonValue>(
   candidate: RegisterCandidate<T>,
 ): RegisterCandidate<T> {
   const base = {
-    dot: { ...candidate.dot },
+    dot: {
+      deviceId: candidate.dot.deviceId,
+      counter: candidate.dot.counter,
+    },
     context: sortRecord(candidate.context, (counter) => counter),
-    hlc: { ...candidate.hlc },
+    hlc: {
+      wallTime: candidate.hlc.wallTime,
+      logical: candidate.hlc.logical,
+    },
   };
   if (isTombstoneCandidate(candidate)) return { ...base, tombstone: true };
   return { ...base, value: canonicalizeJson(cloneJson(candidate.value)) };
@@ -293,7 +299,10 @@ export function canonicalizeConvergentSyncState(
   return {
     schemaVersion: 2,
     vector: sortRecord(state.vector, (counter) => counter),
-    hlc: { ...state.hlc },
+    hlc: {
+      wallTime: state.hlc.wallTime,
+      logical: state.hlc.logical,
+    },
     collections: sortRecord(state.collections, canonicalCollection),
     settings: sortRecord(state.settings, canonicalRegister),
     stringCollections: sortRecord(state.stringCollections, canonicalStringCollection),

--- a/domain/convergentSync/serialization.ts
+++ b/domain/convergentSync/serialization.ts
@@ -5,6 +5,7 @@ import {
 import { compareDots, compareHybridLogicalClocks, dotKey } from './clock';
 import { canonicalizeJson, cloneJson, isJsonValue } from './json';
 import { getOwnRecordValue } from './record';
+import { registerId } from './registerId';
 import {
   ConvergentSyncInvariantError,
   type ConvergentCollectionState,
@@ -13,6 +14,7 @@ import {
   type ConvergentStringEntryState,
   type ConvergentSyncStateV2,
   type Dot,
+  type DotOriginIndex,
   type JsonValue,
   type MultiValueRegister,
   type RegisterCandidate,
@@ -48,6 +50,42 @@ function assertVersionVector(value: unknown, label: string): asserts value is Ve
   for (const [deviceId, counter] of Object.entries(value)) {
     assertNonEmptyKey(deviceId, `${label} device ID`);
     assertPositiveInteger(counter, `${label}.${deviceId}`);
+  }
+}
+
+function assertDotOrigins(
+  value: unknown,
+  vector: VersionVector,
+): asserts value is DotOriginIndex {
+  if (!isRecord(value)) {
+    throw new ConvergentSyncInvariantError('dotOrigins must be an object');
+  }
+  for (const [deviceId, origins] of Object.entries(value)) {
+    assertNonEmptyKey(deviceId, 'dotOrigins device ID');
+    if (!isRecord(origins)) {
+      throw new ConvergentSyncInvariantError(`dotOrigins.${deviceId} must be an object`);
+    }
+    const vectorCounter = getOwnRecordValue(vector, deviceId);
+    if (!vectorCounter || Object.keys(origins).length !== vectorCounter) {
+      throw new ConvergentSyncInvariantError(
+        `dotOrigins.${deviceId} must cover every counter in the state vector`,
+      );
+    }
+    for (let counter = 1; counter <= vectorCounter; counter += 1) {
+      const origin = getOwnRecordValue(origins, String(counter));
+      if (typeof origin !== 'string' || origin.length === 0) {
+        throw new ConvergentSyncInvariantError(
+          `dotOrigins.${deviceId}.${counter} must contain a register identity`,
+        );
+      }
+    }
+  }
+  for (const deviceId of Object.keys(vector)) {
+    if (!Object.hasOwn(value, deviceId)) {
+      throw new ConvergentSyncInvariantError(
+        `dotOrigins.${deviceId} must cover every counter in the state vector`,
+      );
+    }
   }
 }
 
@@ -87,13 +125,30 @@ function recordVectorWitness(
 
 interface DotLocation {
   candidateLabel: string;
-  registerLabel: string;
+  registerIdentity: string;
 }
 
 interface ContextReference {
   key: string;
   label: string;
-  registerLabel: string;
+  registerIdentity: string;
+}
+
+function assertDotOrigin(
+  state: ConvergentSyncStateV2,
+  dot: Dot,
+  expectedRegisterId: string,
+  label: string,
+): void {
+  const deviceOrigins = getOwnRecordValue(state.dotOrigins, dot.deviceId);
+  const origin = deviceOrigins
+    ? getOwnRecordValue(deviceOrigins, String(dot.counter))
+    : undefined;
+  if (origin !== expectedRegisterId) {
+    throw new ConvergentSyncInvariantError(
+      `${label} is assigned to a different register origin`,
+    );
+  }
 }
 
 function assertVectorIsExactlyWitnessed(
@@ -114,7 +169,7 @@ function assertCandidate(
   value: unknown,
   state: ConvergentSyncStateV2,
   label: string,
-  registerLabel: string,
+  registerIdentity: string,
   globalDots: Map<string, DotLocation>,
   witnessedDots: Map<string, Set<number>>,
   contextReferences: ContextReference[],
@@ -124,6 +179,7 @@ function assertCandidate(
   }
   const candidateDot = value.dot;
   assertCoveredDot(candidateDot, state, `${label}.dot`);
+  assertDotOrigin(state, candidateDot, registerIdentity, `${label}.dot`);
   if (!Array.isArray(value.context)) {
     throw new ConvergentSyncInvariantError(`${label}.context must be an array of dots`);
   }
@@ -131,6 +187,7 @@ function assertCandidate(
   value.context.forEach((contextDot, index) => {
     const contextLabel = `${label}.context[${index}]`;
     assertCoveredDot(contextDot, state, contextLabel);
+    assertDotOrigin(state, contextDot, registerIdentity, contextLabel);
     const contextKey = dotKey(contextDot);
     if (contextKeys.has(contextKey)) {
       throw new ConvergentSyncInvariantError(`${label}.context contains duplicate dot ${contextKey}`);
@@ -145,7 +202,7 @@ function assertCandidate(
       throw new ConvergentSyncInvariantError(`${contextLabel} must precede its own device dot`);
     }
     contextKeys.add(contextKey);
-    contextReferences.push({ key: contextKey, label: contextLabel, registerLabel });
+    contextReferences.push({ key: contextKey, label: contextLabel, registerIdentity });
     recordVectorWitness(witnessedDots, contextDot);
   });
 
@@ -179,7 +236,7 @@ function assertCandidate(
       `Dot ${key} is reused by ${previousLocation.candidateLabel} and ${label}`,
     );
   }
-  globalDots.set(key, { candidateLabel: label, registerLabel });
+  globalDots.set(key, { candidateLabel: label, registerIdentity });
   recordVectorWitness(witnessedDots, candidateDot);
 }
 
@@ -187,6 +244,7 @@ function assertRegister(
   value: unknown,
   state: ConvergentSyncStateV2,
   label: string,
+  registerIdentity: string,
   globalDots: Map<string, DotLocation>,
   witnessedDots: Map<string, Set<number>>,
   contextReferences: ContextReference[],
@@ -201,7 +259,7 @@ function assertRegister(
       candidate,
       state,
       candidateLabel,
-      label,
+      registerIdentity,
       globalDots,
       witnessedDots,
       contextReferences,
@@ -253,6 +311,7 @@ export function assertValidConvergentSyncState(
     throw new ConvergentSyncInvariantError('Expected convergent sync schema version 2');
   }
   assertVersionVector(value.vector, 'vector');
+  assertDotOrigins(value.dotOrigins, value.vector);
   assertClock(value.hlc, 'hlc');
   if (!isRecord(value.collections) || !isRecord(value.settings) || !isRecord(value.stringCollections)) {
     throw new ConvergentSyncInvariantError('Collections, settings, and stringCollections must be objects');
@@ -277,6 +336,7 @@ export function assertValidConvergentSyncState(
         entity.presence,
         state,
         `${entityLabel}.presence`,
+        registerId({ kind: 'entity-presence', collection: collectionName, entityId }),
         globalDots,
         witnessedDots,
         contextReferences,
@@ -287,6 +347,7 @@ export function assertValidConvergentSyncState(
           entity.position,
           state,
           `${entityLabel}.position`,
+          registerId({ kind: 'entity-position', collection: collectionName, entityId }),
           globalDots,
           witnessedDots,
           contextReferences,
@@ -302,6 +363,7 @@ export function assertValidConvergentSyncState(
           register,
           state,
           `${entityLabel}.fields.${field}`,
+          registerId({ kind: 'entity-field', collection: collectionName, entityId, field }),
           globalDots,
           witnessedDots,
           contextReferences,
@@ -316,6 +378,7 @@ export function assertValidConvergentSyncState(
       register,
       state,
       `settings.${encodedPath}`,
+      registerId({ kind: 'setting', path: decodeSettingPath(encodedPath) }),
       globalDots,
       witnessedDots,
       contextReferences,
@@ -337,6 +400,11 @@ export function assertValidConvergentSyncState(
         entry.presence,
         state,
         `${entryLabel}.presence`,
+        registerId({
+          kind: 'string-entry-presence',
+          collection: collectionName,
+          value: entryValue,
+        }),
         globalDots,
         witnessedDots,
         contextReferences,
@@ -347,6 +415,11 @@ export function assertValidConvergentSyncState(
           entry.position,
           state,
           `${entryLabel}.position`,
+          registerId({
+            kind: 'string-entry-position',
+            collection: collectionName,
+            value: entryValue,
+          }),
           globalDots,
           witnessedDots,
           contextReferences,
@@ -359,7 +432,7 @@ export function assertValidConvergentSyncState(
   for (const reference of contextReferences) {
     const retainedLocation = globalDots.get(reference.key);
     if (retainedLocation) {
-      const location = retainedLocation.registerLabel === reference.registerLabel
+      const location = retainedLocation.registerIdentity === reference.registerIdentity
         ? 'the same register'
         : 'another register';
       throw new ConvergentSyncInvariantError(
@@ -434,6 +507,18 @@ function canonicalStringCollection(
   return { entries: sortRecord(collection.entries, canonicalStringEntry) };
 }
 
+function canonicalDotOrigins(origins: DotOriginIndex): DotOriginIndex {
+  return Object.fromEntries(
+    Object.keys(origins).sort().map((deviceId) => [
+      deviceId,
+      Object.fromEntries(
+        Object.entries(origins[deviceId])
+          .sort(([left], [right]) => Number(left) - Number(right)),
+      ),
+    ]),
+  );
+}
+
 export function canonicalizeConvergentSyncState(
   state: ConvergentSyncStateV2,
 ): ConvergentSyncStateV2 {
@@ -441,6 +526,7 @@ export function canonicalizeConvergentSyncState(
   return {
     schemaVersion: 2,
     vector: sortRecord(state.vector, (counter) => counter),
+    dotOrigins: canonicalDotOrigins(state.dotOrigins),
     hlc: {
       wallTime: state.hlc.wallTime,
       logical: state.hlc.logical,

--- a/domain/convergentSync/serialization.ts
+++ b/domain/convergentSync/serialization.ts
@@ -358,12 +358,12 @@ export function assertValidConvergentSyncState(
 
   for (const reference of contextReferences) {
     const retainedLocation = globalDots.get(reference.key);
-    if (
-      retainedLocation
-      && retainedLocation.registerLabel !== reference.registerLabel
-    ) {
+    if (retainedLocation) {
+      const location = retainedLocation.registerLabel === reference.registerLabel
+        ? 'the same register'
+        : 'another register';
       throw new ConvergentSyncInvariantError(
-        `${reference.label} references dot ${reference.key} retained in another register`,
+        `${reference.label} references candidate dot ${reference.key} retained in ${location}`,
       );
     }
   }

--- a/domain/convergentSync/serialization.ts
+++ b/domain/convergentSync/serialization.ts
@@ -4,7 +4,7 @@ import {
 } from './register';
 import { compareHybridLogicalClocks, dotKey } from './clock';
 import { canonicalizeJson, cloneJson, isJsonValue } from './json';
-import { getOwnRecordValue } from './record';
+import { getOwnRecordValue, setOwnRecordValue } from './record';
 import {
   ConvergentSyncInvariantError,
   type ConvergentCollectionState,
@@ -58,11 +58,22 @@ function assertClock(value: unknown, label: string): void {
   assertNonNegativeInteger(value.logical, `${label}.logical`);
 }
 
+function recordVectorWitness(
+  witnessedVector: VersionVector,
+  deviceId: string,
+  counter: number,
+): void {
+  if ((getOwnRecordValue(witnessedVector, deviceId) ?? 0) < counter) {
+    setOwnRecordValue(witnessedVector, deviceId, counter);
+  }
+}
+
 function assertCandidate(
   value: unknown,
   state: ConvergentSyncStateV2,
   label: string,
   globalDots: Map<string, string>,
+  witnessedVector: VersionVector,
 ): asserts value is RegisterCandidate {
   if (!isRecord(value) || !isRecord(value.dot)) {
     throw new ConvergentSyncInvariantError(`${label} must contain a dot`);
@@ -115,6 +126,11 @@ function assertCandidate(
     );
   }
   globalDots.set(key, label);
+
+  recordVectorWitness(witnessedVector, deviceId, value.dot.counter);
+  for (const [contextDeviceId, counter] of Object.entries(value.context)) {
+    recordVectorWitness(witnessedVector, contextDeviceId, counter);
+  }
 }
 
 function assertRegister(
@@ -122,6 +138,7 @@ function assertRegister(
   state: ConvergentSyncStateV2,
   label: string,
   globalDots: Map<string, string>,
+  witnessedVector: VersionVector,
   valueValidator?: (candidate: RegisterCandidate, label: string) => void,
 ): asserts value is MultiValueRegister {
   if (!isRecord(value) || !Array.isArray(value.candidates) || value.candidates.length === 0) {
@@ -129,7 +146,7 @@ function assertRegister(
   }
   value.candidates.forEach((candidate, index) => {
     const candidateLabel = `${label}.candidates[${index}]`;
-    assertCandidate(candidate, state, candidateLabel, globalDots);
+    assertCandidate(candidate, state, candidateLabel, globalDots, witnessedVector);
     valueValidator?.(candidate, candidateLabel);
   });
 }
@@ -184,6 +201,7 @@ export function assertValidConvergentSyncState(
 
   const state = value as unknown as ConvergentSyncStateV2;
   const globalDots = new Map<string, string>();
+  const witnessedVector: VersionVector = {};
   for (const [collectionName, collection] of Object.entries(state.collections)) {
     assertNonEmptyKey(collectionName, 'Collection name');
     if (!isRecord(collection) || !isRecord(collection.entities)) {
@@ -195,23 +213,49 @@ export function assertValidConvergentSyncState(
         throw new ConvergentSyncInvariantError(`Entity ${collectionName}/${entityId} is invalid`);
       }
       const entityLabel = `collections.${collectionName}.${entityId}`;
-      assertRegister(entity.presence, state, `${entityLabel}.presence`, globalDots, assertPresenceCandidate);
+      assertRegister(
+        entity.presence,
+        state,
+        `${entityLabel}.presence`,
+        globalDots,
+        witnessedVector,
+        assertPresenceCandidate,
+      );
       if (entity.position !== undefined) {
-        assertRegister(entity.position, state, `${entityLabel}.position`, globalDots, assertPositionCandidate);
+        assertRegister(
+          entity.position,
+          state,
+          `${entityLabel}.position`,
+          globalDots,
+          witnessedVector,
+          assertPositionCandidate,
+        );
       }
       for (const [field, register] of Object.entries(entity.fields)) {
         assertNonEmptyKey(field, `${entityLabel} field`);
         if (field === 'id') {
           throw new ConvergentSyncInvariantError(`${entityLabel} must not store structural ID as a field`);
         }
-        assertRegister(register, state, `${entityLabel}.fields.${field}`, globalDots);
+        assertRegister(
+          register,
+          state,
+          `${entityLabel}.fields.${field}`,
+          globalDots,
+          witnessedVector,
+        );
       }
     }
   }
 
   for (const [encodedPath, register] of Object.entries(state.settings)) {
     decodeSettingPath(encodedPath);
-    assertRegister(register, state, `settings.${encodedPath}`, globalDots);
+    assertRegister(
+      register,
+      state,
+      `settings.${encodedPath}`,
+      globalDots,
+      witnessedVector,
+    );
   }
 
   for (const [collectionName, collection] of Object.entries(state.stringCollections)) {
@@ -225,10 +269,32 @@ export function assertValidConvergentSyncState(
         throw new ConvergentSyncInvariantError(`String entry ${collectionName}/${entryValue} is invalid`);
       }
       const entryLabel = `stringCollections.${collectionName}.${entryValue}`;
-      assertRegister(entry.presence, state, `${entryLabel}.presence`, globalDots, assertPresenceCandidate);
+      assertRegister(
+        entry.presence,
+        state,
+        `${entryLabel}.presence`,
+        globalDots,
+        witnessedVector,
+        assertPresenceCandidate,
+      );
       if (entry.position !== undefined) {
-        assertRegister(entry.position, state, `${entryLabel}.position`, globalDots, assertPositionCandidate);
+        assertRegister(
+          entry.position,
+          state,
+          `${entryLabel}.position`,
+          globalDots,
+          witnessedVector,
+          assertPositionCandidate,
+        );
       }
+    }
+  }
+
+  for (const [deviceId, counter] of Object.entries(state.vector)) {
+    if ((getOwnRecordValue(witnessedVector, deviceId) ?? 0) !== counter) {
+      throw new ConvergentSyncInvariantError(
+        `vector.${deviceId} is not witnessed by any candidate dot or context`,
+      );
     }
   }
 }

--- a/domain/convergentSync/serialization.ts
+++ b/domain/convergentSync/serialization.ts
@@ -2,9 +2,9 @@ import {
   compareCandidatesByDot,
   isTombstoneCandidate,
 } from './register';
-import { compareHybridLogicalClocks, dotKey } from './clock';
+import { compareDots, compareHybridLogicalClocks, dotKey } from './clock';
 import { canonicalizeJson, cloneJson, isJsonValue } from './json';
-import { getOwnRecordValue, setOwnRecordValue } from './record';
+import { getOwnRecordValue } from './record';
 import {
   ConvergentSyncInvariantError,
   type ConvergentCollectionState,
@@ -12,6 +12,7 @@ import {
   type ConvergentStringCollectionState,
   type ConvergentStringEntryState,
   type ConvergentSyncStateV2,
+  type Dot,
   type JsonValue,
   type MultiValueRegister,
   type RegisterCandidate,
@@ -58,13 +59,54 @@ function assertClock(value: unknown, label: string): void {
   assertNonNegativeInteger(value.logical, `${label}.logical`);
 }
 
+function assertCoveredDot(
+  value: unknown,
+  state: ConvergentSyncStateV2,
+  label: string,
+): asserts value is Dot {
+  if (!isRecord(value)) {
+    throw new ConvergentSyncInvariantError(`${label} must be a dot`);
+  }
+  if (typeof value.deviceId !== 'string' || value.deviceId.length === 0) {
+    throw new ConvergentSyncInvariantError(`${label}.deviceId must not be empty`);
+  }
+  assertPositiveInteger(value.counter, `${label}.counter`);
+  if ((getOwnRecordValue(state.vector, value.deviceId) ?? 0) < value.counter) {
+    throw new ConvergentSyncInvariantError(`${label} is not covered by the state vector`);
+  }
+}
+
 function recordVectorWitness(
-  witnessedVector: VersionVector,
-  deviceId: string,
-  counter: number,
+  witnessedDots: Map<string, Set<number>>,
+  dot: Dot,
 ): void {
-  if ((getOwnRecordValue(witnessedVector, deviceId) ?? 0) < counter) {
-    setOwnRecordValue(witnessedVector, deviceId, counter);
+  const counters = witnessedDots.get(dot.deviceId) ?? new Set<number>();
+  counters.add(dot.counter);
+  witnessedDots.set(dot.deviceId, counters);
+}
+
+interface DotLocation {
+  candidateLabel: string;
+  registerLabel: string;
+}
+
+interface ContextReference {
+  key: string;
+  label: string;
+  registerLabel: string;
+}
+
+function assertVectorIsExactlyWitnessed(
+  vector: VersionVector,
+  witnessedDots: Map<string, Set<number>>,
+): void {
+  for (const [deviceId, counter] of Object.entries(vector)) {
+    const counters = witnessedDots.get(deviceId);
+    if (!counters || counters.size !== counter || !counters.has(counter)) {
+      throw new ConvergentSyncInvariantError(
+        `vector.${deviceId} is not witnessed by retained candidate dots and contexts`,
+      );
+    }
   }
 }
 
@@ -72,30 +114,42 @@ function assertCandidate(
   value: unknown,
   state: ConvergentSyncStateV2,
   label: string,
-  globalDots: Map<string, string>,
-  witnessedVector: VersionVector,
+  registerLabel: string,
+  globalDots: Map<string, DotLocation>,
+  witnessedDots: Map<string, Set<number>>,
+  contextReferences: ContextReference[],
 ): asserts value is RegisterCandidate {
-  if (!isRecord(value) || !isRecord(value.dot)) {
+  if (!isRecord(value)) {
     throw new ConvergentSyncInvariantError(`${label} must contain a dot`);
   }
-  const deviceId = value.dot.deviceId;
-  if (typeof deviceId !== 'string' || deviceId.length === 0) {
-    throw new ConvergentSyncInvariantError(`${label}.dot.deviceId must not be empty`);
+  const candidateDot = value.dot;
+  assertCoveredDot(candidateDot, state, `${label}.dot`);
+  if (!Array.isArray(value.context)) {
+    throw new ConvergentSyncInvariantError(`${label}.context must be an array of dots`);
   }
-  assertPositiveInteger(value.dot.counter, `${label}.dot.counter`);
-  if ((getOwnRecordValue(state.vector, deviceId) ?? 0) < value.dot.counter) {
-    throw new ConvergentSyncInvariantError(`${label}.dot is not covered by the state vector`);
-  }
-
-  assertVersionVector(value.context, `${label}.context`);
-  for (const [contextDeviceId, counter] of Object.entries(value.context)) {
-    if ((getOwnRecordValue(state.vector, contextDeviceId) ?? 0) < counter) {
-      throw new ConvergentSyncInvariantError(`${label}.context exceeds the state vector`);
+  const contextKeys = new Set<string>();
+  value.context.forEach((contextDot, index) => {
+    const contextLabel = `${label}.context[${index}]`;
+    assertCoveredDot(contextDot, state, contextLabel);
+    const contextKey = dotKey(contextDot);
+    if (contextKeys.has(contextKey)) {
+      throw new ConvergentSyncInvariantError(`${label}.context contains duplicate dot ${contextKey}`);
     }
-  }
-  if ((getOwnRecordValue(value.context, deviceId) ?? 0) >= value.dot.counter) {
-    throw new ConvergentSyncInvariantError(`${label}.context must precede its own dot`);
-  }
+    if (contextKey === dotKey(candidateDot)) {
+      throw new ConvergentSyncInvariantError(`${label}.context must not contain its own dot`);
+    }
+    if (
+      contextDot.deviceId === candidateDot.deviceId
+      && contextDot.counter >= candidateDot.counter
+    ) {
+      throw new ConvergentSyncInvariantError(`${contextLabel} must precede its own device dot`);
+    }
+    contextKeys.add(contextKey);
+    contextReferences.push({ key: contextKey, label: contextLabel, registerLabel });
+    recordVectorWitness(witnessedDots, contextDot);
+  });
+
+  const deviceId = candidateDot.deviceId;
 
   assertClock(value.hlc, `${label}.hlc`);
   const candidateClock = value.hlc as { wallTime: number; logical: number };
@@ -118,27 +172,24 @@ function assertCandidate(
     throw new ConvergentSyncInvariantError(`${label} tombstones must not contain a value`);
   }
 
-  const key = dotKey({ deviceId, counter: value.dot.counter });
-  const previousAddress = globalDots.get(key);
-  if (previousAddress) {
+  const key = dotKey({ deviceId, counter: candidateDot.counter });
+  const previousLocation = globalDots.get(key);
+  if (previousLocation) {
     throw new ConvergentSyncInvariantError(
-      `Dot ${key} is reused by ${previousAddress} and ${label}`,
+      `Dot ${key} is reused by ${previousLocation.candidateLabel} and ${label}`,
     );
   }
-  globalDots.set(key, label);
-
-  recordVectorWitness(witnessedVector, deviceId, value.dot.counter);
-  for (const [contextDeviceId, counter] of Object.entries(value.context)) {
-    recordVectorWitness(witnessedVector, contextDeviceId, counter);
-  }
+  globalDots.set(key, { candidateLabel: label, registerLabel });
+  recordVectorWitness(witnessedDots, candidateDot);
 }
 
 function assertRegister(
   value: unknown,
   state: ConvergentSyncStateV2,
   label: string,
-  globalDots: Map<string, string>,
-  witnessedVector: VersionVector,
+  globalDots: Map<string, DotLocation>,
+  witnessedDots: Map<string, Set<number>>,
+  contextReferences: ContextReference[],
   valueValidator?: (candidate: RegisterCandidate, label: string) => void,
 ): asserts value is MultiValueRegister {
   if (!isRecord(value) || !Array.isArray(value.candidates) || value.candidates.length === 0) {
@@ -146,7 +197,15 @@ function assertRegister(
   }
   value.candidates.forEach((candidate, index) => {
     const candidateLabel = `${label}.candidates[${index}]`;
-    assertCandidate(candidate, state, candidateLabel, globalDots, witnessedVector);
+    assertCandidate(
+      candidate,
+      state,
+      candidateLabel,
+      label,
+      globalDots,
+      witnessedDots,
+      contextReferences,
+    );
     valueValidator?.(candidate, candidateLabel);
   });
 }
@@ -200,8 +259,9 @@ export function assertValidConvergentSyncState(
   }
 
   const state = value as unknown as ConvergentSyncStateV2;
-  const globalDots = new Map<string, string>();
-  const witnessedVector: VersionVector = {};
+  const globalDots = new Map<string, DotLocation>();
+  const witnessedDots = new Map<string, Set<number>>();
+  const contextReferences: ContextReference[] = [];
   for (const [collectionName, collection] of Object.entries(state.collections)) {
     assertNonEmptyKey(collectionName, 'Collection name');
     if (!isRecord(collection) || !isRecord(collection.entities)) {
@@ -218,7 +278,8 @@ export function assertValidConvergentSyncState(
         state,
         `${entityLabel}.presence`,
         globalDots,
-        witnessedVector,
+        witnessedDots,
+        contextReferences,
         assertPresenceCandidate,
       );
       if (entity.position !== undefined) {
@@ -227,7 +288,8 @@ export function assertValidConvergentSyncState(
           state,
           `${entityLabel}.position`,
           globalDots,
-          witnessedVector,
+          witnessedDots,
+          contextReferences,
           assertPositionCandidate,
         );
       }
@@ -241,7 +303,8 @@ export function assertValidConvergentSyncState(
           state,
           `${entityLabel}.fields.${field}`,
           globalDots,
-          witnessedVector,
+          witnessedDots,
+          contextReferences,
         );
       }
     }
@@ -254,7 +317,8 @@ export function assertValidConvergentSyncState(
       state,
       `settings.${encodedPath}`,
       globalDots,
-      witnessedVector,
+      witnessedDots,
+      contextReferences,
     );
   }
 
@@ -274,7 +338,8 @@ export function assertValidConvergentSyncState(
         state,
         `${entryLabel}.presence`,
         globalDots,
-        witnessedVector,
+        witnessedDots,
+        contextReferences,
         assertPresenceCandidate,
       );
       if (entry.position !== undefined) {
@@ -283,20 +348,26 @@ export function assertValidConvergentSyncState(
           state,
           `${entryLabel}.position`,
           globalDots,
-          witnessedVector,
+          witnessedDots,
+          contextReferences,
           assertPositionCandidate,
         );
       }
     }
   }
 
-  for (const [deviceId, counter] of Object.entries(state.vector)) {
-    if ((getOwnRecordValue(witnessedVector, deviceId) ?? 0) !== counter) {
+  for (const reference of contextReferences) {
+    const retainedLocation = globalDots.get(reference.key);
+    if (
+      retainedLocation
+      && retainedLocation.registerLabel !== reference.registerLabel
+    ) {
       throw new ConvergentSyncInvariantError(
-        `vector.${deviceId} is not witnessed by any candidate dot or context`,
+        `${reference.label} references dot ${reference.key} retained in another register`,
       );
     }
   }
+  assertVectorIsExactlyWitnessed(state.vector, witnessedDots);
 }
 
 function sortRecord<T>(record: Record<string, T>, clone: (value: T) => T): Record<string, T> {
@@ -313,7 +384,12 @@ function canonicalCandidate<T extends JsonValue>(
       deviceId: candidate.dot.deviceId,
       counter: candidate.dot.counter,
     },
-    context: sortRecord(candidate.context, (counter) => counter),
+    context: candidate.context
+      .map((dot) => ({
+        deviceId: dot.deviceId,
+        counter: dot.counter,
+      }))
+      .sort(compareDots),
     hlc: {
       wallTime: candidate.hlc.wallTime,
       logical: candidate.hlc.logical,

--- a/domain/convergentSync/state.ts
+++ b/domain/convergentSync/state.ts
@@ -494,10 +494,16 @@ function applyMutation(
       break;
     case 'string-entry-add': {
       const { entry, created } = ensureStringEntry(state, mutation.collection, mutation.value);
-      let changed = created || !registerIsPresent(entry.presence);
+      let changed = created
+        || !registerIsPresent(entry.presence)
+        || registerHasConflict(entry.presence);
       if (
         mutation.position !== undefined
-        && !candidateValueEquals(entry.position, mutation.position)
+        && (
+          !entry.position
+          || registerHasConflict(entry.position)
+          || !candidateValueEquals(entry.position, mutation.position)
+        )
       ) {
         entry.position = writeRegister(
           state,

--- a/domain/convergentSync/state.ts
+++ b/domain/convergentSync/state.ts
@@ -7,6 +7,8 @@ import {
 import { cloneJson, jsonValuesEqual } from './json';
 import {
   createRegisterCandidate,
+  compareCandidatesByDot,
+  compareRegisterCandidates,
   isTombstoneCandidate,
   mergeMultiValueRegisters,
   registerHasConflict,
@@ -27,6 +29,7 @@ import {
   ConvergentSyncInvariantError,
   type CollectionPosition,
   type ConvergentCollectionState,
+  type ConvergentConflictAddress,
   type ConvergentConflictCandidate,
   type ConvergentEntityState,
   type ConvergentFieldConflict,
@@ -239,6 +242,55 @@ function applyEntityFieldMutation(
   entity.presence = writeRegister(state, deviceId, now, true);
 }
 
+function settingPathIsPrefix(prefix: string[], path: string[]): boolean {
+  return prefix.length <= path.length
+    && prefix.every((segment, index) => segment === path[index]);
+}
+
+function settingPathsOverlap(left: string[], right: string[]): boolean {
+  return settingPathIsPrefix(left, right) || settingPathIsPrefix(right, left);
+}
+
+function tombstoneOverlappingSettingPaths(
+  state: ConvergentSyncStateV2,
+  deviceId: string,
+  path: string[],
+  now: number,
+): void {
+  const encodedPath = encodeSettingPath(path);
+  for (const otherEncodedPath of Object.keys(state.settings).sort()) {
+    if (otherEncodedPath === encodedPath) continue;
+    const otherPath = decodeSettingPath(otherEncodedPath);
+    if (!settingPathsOverlap(path, otherPath)) continue;
+    const register = getOwnRecordValue(state.settings, otherEncodedPath);
+    const winner = selectRegisterWinner(register);
+    if (!winner || isTombstoneCandidate(winner)) continue;
+    setOwnRecordValue(
+      state.settings,
+      otherEncodedPath,
+      writeRegister(state, deviceId, now, undefined, true),
+    );
+  }
+}
+
+function writeSettingRegister(
+  state: ConvergentSyncStateV2,
+  deviceId: string,
+  path: string[],
+  now: number,
+  value?: JsonValue,
+  tombstone = false,
+): void {
+  if (!tombstone) {
+    tombstoneOverlappingSettingPaths(state, deviceId, path, now);
+  }
+  setOwnRecordValue(
+    state.settings,
+    encodeSettingPath(path),
+    writeRegister(state, deviceId, now, value, tombstone),
+  );
+}
+
 function findEntity(
   state: ConvergentSyncStateV2,
   collectionName: string,
@@ -335,21 +387,23 @@ function applyMutation(
       break;
     }
     case 'setting-set':
-      setOwnRecordValue(state.settings, encodeSettingPath(mutation.path), writeRegister(
+      writeSettingRegister(
         state,
         deviceId,
+        mutation.path,
         now,
         mutation.value,
-      ));
+      );
       break;
     case 'setting-delete':
-      setOwnRecordValue(state.settings, encodeSettingPath(mutation.path), writeRegister(
+      writeSettingRegister(
         state,
         deviceId,
+        mutation.path,
         now,
         undefined,
         true,
-      ));
+      );
       break;
     case 'string-entry-add': {
       const { entry, created } = ensureStringEntry(state, mutation.collection, mutation.value);
@@ -378,6 +432,17 @@ function applyMutation(
       }
       if (!mutation.tombstone && mutation.value === undefined) {
         throw new ConvergentSyncInvariantError('A value resolution requires a value');
+      }
+      if (mutation.address.kind === 'setting') {
+        writeSettingRegister(
+          state,
+          deviceId,
+          mutation.address.path,
+          now,
+          mutation.value,
+          mutation.tombstone === true,
+        );
+        break;
       }
       setRegisterAtAddress(
         state,
@@ -525,12 +590,20 @@ function materializedValue(register: MultiValueRegister | undefined): JsonValue 
 function conflictCandidate(
   candidate: RegisterCandidate,
   selectedDot: string,
+  settingPath?: string[],
 ): ConvergentConflictCandidate {
   return {
-    dot: { ...candidate.dot },
-    hlc: { ...candidate.hlc },
+    dot: {
+      deviceId: candidate.dot.deviceId,
+      counter: candidate.dot.counter,
+    },
+    hlc: {
+      wallTime: candidate.hlc.wallTime,
+      logical: candidate.hlc.logical,
+    },
     tombstone: isTombstoneCandidate(candidate),
     ...(!isTombstoneCandidate(candidate) ? { value: cloneJson(candidate.value) } : {}),
+    ...(settingPath ? { settingPath: [...settingPath] } : {}),
     selected: dotKey(candidate.dot) === selectedDot,
   };
 }
@@ -545,13 +618,13 @@ function maybeRecordConflict(
   if (!winner) return;
   conflicts.push({
     address,
-    candidates: register.candidates.map((candidate) =>
-      conflictCandidate(candidate, dotKey(winner.dot)),
-    ),
+    candidates: [...register.candidates]
+      .sort(compareCandidatesByDot)
+      .map((candidate) => conflictCandidate(candidate, dotKey(winner.dot))),
   });
 }
 
-function addressSortKey(address: RegisterAddress): string {
+function addressSortKey(address: ConvergentConflictAddress): string {
   switch (address.kind) {
     case 'entity-presence':
       return `0:${address.collection}:${address.entityId}:0`;
@@ -560,7 +633,9 @@ function addressSortKey(address: RegisterAddress): string {
     case 'entity-field':
       return `0:${address.collection}:${address.entityId}:2:${address.field}`;
     case 'setting':
-      return `1:${encodeSettingPath(address.path)}`;
+      return `1:0:${encodeSettingPath(address.path)}`;
+    case 'setting-structure':
+      return `1:1:${address.paths.map(encodeSettingPath).join('|')}`;
     case 'string-entry-presence':
       return `2:${address.collection}:${address.value}:0`;
     case 'string-entry-position':
@@ -585,6 +660,116 @@ function setNestedSetting(root: JsonObject, path: string[], value: JsonValue): v
     }
   }
   setOwnRecordValue(target, path[path.length - 1], cloneJson(value));
+}
+
+interface ActiveSettingEntry {
+  encodedPath: string;
+  path: string[];
+  register: MultiValueRegister;
+  winner: RegisterCandidate;
+  value: JsonValue;
+}
+
+function selectMaterializedSettingEntries(
+  entries: ActiveSettingEntry[],
+): Set<string> {
+  const selectedPaths = new Set<string>();
+  const selectedPrefixes = new Set<string>();
+  const prioritized = [...entries].sort((left, right) => {
+    const candidateOrder = compareRegisterCandidates(right.winner, left.winner);
+    return candidateOrder !== 0
+      ? candidateOrder
+      : left.encodedPath.localeCompare(right.encodedPath);
+  });
+
+  for (const entry of prioritized) {
+    const hasSelectedAncestor = entry.path.slice(0, -1).some((_, index) =>
+      selectedPaths.has(encodeSettingPath(entry.path.slice(0, index + 1))),
+    );
+    const hasSelectedDescendant = selectedPrefixes.has(entry.encodedPath);
+    if (hasSelectedAncestor || hasSelectedDescendant) continue;
+
+    selectedPaths.add(entry.encodedPath);
+    for (let length = 1; length < entry.path.length; length += 1) {
+      selectedPrefixes.add(encodeSettingPath(entry.path.slice(0, length)));
+    }
+  }
+  return selectedPaths;
+}
+
+function recordSettingStructureConflicts(
+  entries: ActiveSettingEntry[],
+  selectedPaths: Set<string>,
+  conflicts: ConvergentFieldConflict[],
+): void {
+  const byEncodedPath = new Map(entries.map((entry) => [entry.encodedPath, entry]));
+  const groups = new Map<string, ActiveSettingEntry[]>();
+
+  for (const entry of entries) {
+    let rootPath = entry.encodedPath;
+    for (let length = 1; length < entry.path.length; length += 1) {
+      const ancestor = encodeSettingPath(entry.path.slice(0, length));
+      if (byEncodedPath.has(ancestor)) {
+        rootPath = ancestor;
+        break;
+      }
+    }
+    const group = groups.get(rootPath) ?? [];
+    group.push(entry);
+    groups.set(rootPath, group);
+  }
+
+  for (const rootPath of [...groups.keys()].sort()) {
+    const group = groups.get(rootPath);
+    if (!group || group.length < 2) continue;
+    group.sort((left, right) => left.encodedPath.localeCompare(right.encodedPath));
+    conflicts.push({
+      address: {
+        kind: 'setting-structure',
+        paths: group.map((entry) => [...entry.path]),
+      },
+      candidates: group.flatMap((entry) =>
+        [...entry.register.candidates]
+          .sort(compareCandidatesByDot)
+          .map((candidate) => conflictCandidate(
+            candidate,
+            selectedPaths.has(entry.encodedPath) ? dotKey(entry.winner.dot) : '',
+            entry.path,
+          )),
+      ),
+    });
+  }
+}
+
+function materializeSettings(
+  state: ConvergentSyncStateV2,
+  settings: JsonObject,
+  conflicts: ConvergentFieldConflict[],
+): void {
+  const activeEntries: ActiveSettingEntry[] = [];
+  for (const encodedPath of Object.keys(state.settings).sort()) {
+    const register = getOwnRecordValue(state.settings, encodedPath);
+    if (!register) continue;
+    const path = decodeSettingPath(encodedPath);
+    maybeRecordConflict(conflicts, { kind: 'setting', path }, register);
+    const winner = selectRegisterWinner(register);
+    if (!winner || isTombstoneCandidate(winner)) continue;
+    activeEntries.push({
+      encodedPath,
+      path,
+      register,
+      winner,
+      value: cloneJson(winner.value),
+    });
+  }
+
+  const selectedPaths = selectMaterializedSettingEntries(activeEntries);
+  recordSettingStructureConflicts(activeEntries, selectedPaths, conflicts);
+  for (const entry of activeEntries) {
+    if (selectedPaths.has(entry.encodedPath)) {
+      setNestedSetting(settings, entry.path, entry.value);
+    }
+  }
 }
 
 export function materializeConvergentSyncState(
@@ -648,14 +833,7 @@ export function materializeConvergentSyncState(
     );
   }
 
-  for (const encodedPath of Object.keys(state.settings).sort()) {
-    const register = getOwnRecordValue(state.settings, encodedPath);
-    if (!register) continue;
-    const path = decodeSettingPath(encodedPath);
-    maybeRecordConflict(conflicts, { kind: 'setting', path }, register);
-    const value = materializedValue(register);
-    if (value !== undefined) setNestedSetting(settings, path, value);
-  }
+  materializeSettings(state, settings, conflicts);
 
   for (const collectionName of Object.keys(state.stringCollections).sort()) {
     const entries: Array<{ value: string; position?: CollectionPosition }> = [];

--- a/domain/convergentSync/state.ts
+++ b/domain/convergentSync/state.ts
@@ -182,7 +182,9 @@ function applyEntityUpsert(
     mutation.collection,
     mutation.entityId,
   );
-  let changed = created || !registerIsPresent(entity.presence);
+  let changed = created
+    || !registerIsPresent(entity.presence)
+    || registerHasConflict(entity.presence);
   const incomingFields = Object.fromEntries(
     Object.entries(mutation.value).filter(([field]) => field !== 'id'),
   );
@@ -205,7 +207,11 @@ function applyEntityUpsert(
         );
         changed = true;
       }
-    } else if (!candidateValueEquals(currentRegister, incoming)) {
+    } else if (
+      !currentRegister
+      || registerHasConflict(currentRegister)
+      || !candidateValueEquals(currentRegister, incoming)
+    ) {
       setOwnRecordValue(
         entity.fields,
         field,
@@ -217,7 +223,11 @@ function applyEntityUpsert(
 
   if (
     mutation.position !== undefined
-    && !candidateValueEquals(entity.position, mutation.position)
+    && (
+      !entity.position
+      || registerHasConflict(entity.position)
+      || !candidateValueEquals(entity.position, mutation.position)
+    )
   ) {
     entity.position = writeRegister(
       state,

--- a/domain/convergentSync/state.ts
+++ b/domain/convergentSync/state.ts
@@ -1,4 +1,5 @@
 import {
+  compareStrings,
   dotKey,
   maxHybridLogicalClock,
   mergeVersionVectors,
@@ -11,6 +12,7 @@ import {
   compareRegisterCandidates,
   isTombstoneCandidate,
   mergeMultiValueRegisters,
+  registerCausalContext,
   registerHasConflict,
   selectRegisterWinner,
 } from './register';
@@ -66,11 +68,12 @@ function writeRegister<T extends JsonValue>(
   state: ConvergentSyncStateV2,
   deviceId: string,
   now: number,
+  currentRegister: MultiValueRegister<T> | undefined,
   value?: T,
   tombstone = false,
 ): MultiValueRegister<T> {
   requireNonEmpty(deviceId, 'Device ID');
-  const context = { ...state.vector };
+  const context = registerCausalContext(currentRegister);
   const currentCounter = getOwnRecordValue(state.vector, deviceId) ?? 0;
   if (currentCounter >= Number.MAX_SAFE_INTEGER) {
     throw new ConvergentSyncInvariantError(`Device counter exhausted for ${deviceId}`);
@@ -191,18 +194,23 @@ function applyEntityUpsert(
   for (const field of [...fieldNames].sort()) {
     requireNonEmpty(field, 'Entity field');
     const incoming = getOwnRecordValue(incomingFields, field);
+    const currentRegister = getOwnRecordValue(entity.fields, field);
     if (incoming === undefined) {
-      const winner = selectRegisterWinner(getOwnRecordValue(entity.fields, field));
+      const winner = selectRegisterWinner(currentRegister);
       if (winner && !isTombstoneCandidate(winner)) {
         setOwnRecordValue(
           entity.fields,
           field,
-          writeRegister(state, deviceId, now, undefined, true),
+          writeRegister(state, deviceId, now, currentRegister, undefined, true),
         );
         changed = true;
       }
-    } else if (!candidateValueEquals(getOwnRecordValue(entity.fields, field), incoming)) {
-      setOwnRecordValue(entity.fields, field, writeRegister(state, deviceId, now, incoming));
+    } else if (!candidateValueEquals(currentRegister, incoming)) {
+      setOwnRecordValue(
+        entity.fields,
+        field,
+        writeRegister(state, deviceId, now, currentRegister, incoming),
+      );
       changed = true;
     }
   }
@@ -211,14 +219,20 @@ function applyEntityUpsert(
     mutation.position !== undefined
     && !candidateValueEquals(entity.position, mutation.position)
   ) {
-    entity.position = writeRegister(state, deviceId, now, mutation.position);
+    entity.position = writeRegister(
+      state,
+      deviceId,
+      now,
+      entity.position,
+      mutation.position,
+    );
     changed = true;
   }
 
   if (changed) {
     // Refreshing presence makes a concurrent delete/update visible as an
     // MV-register conflict instead of allowing a deletion to hide the edit.
-    entity.presence = writeRegister(state, deviceId, now, true);
+    entity.presence = writeRegister(state, deviceId, now, entity.presence, true);
   }
 }
 
@@ -236,10 +250,11 @@ function applyEntityFieldMutation(
     throw new ConvergentSyncInvariantError('Entity IDs are structural and cannot be field registers');
   }
   const { entity } = ensureEntity(state, mutation.collection, mutation.entityId);
+  const currentRegister = getOwnRecordValue(entity.fields, mutation.field);
   setOwnRecordValue(entity.fields, mutation.field, mutation.kind === 'entity-field-delete'
-    ? writeRegister(state, deviceId, now, undefined, true)
-    : writeRegister(state, deviceId, now, mutation.value));
-  entity.presence = writeRegister(state, deviceId, now, true);
+    ? writeRegister(state, deviceId, now, currentRegister, undefined, true)
+    : writeRegister(state, deviceId, now, currentRegister, mutation.value));
+  entity.presence = writeRegister(state, deviceId, now, entity.presence, true);
 }
 
 function settingPathIsPrefix(prefix: string[], path: string[]): boolean {
@@ -272,7 +287,7 @@ function tombstoneRelatedSettingPaths(
     setOwnRecordValue(
       state.settings,
       otherEncodedPath,
-      writeRegister(state, deviceId, now, undefined, true),
+      writeRegister(state, deviceId, now, register, undefined, true),
     );
   }
 }
@@ -290,10 +305,18 @@ function writeSettingRegister(
   // they remove descendants without erasing an atomic ancestor when a caller
   // targets a path beneath it.
   tombstoneRelatedSettingPaths(state, deviceId, path, now, !tombstone);
+  const encodedPath = encodeSettingPath(path);
   setOwnRecordValue(
     state.settings,
-    encodeSettingPath(path),
-    writeRegister(state, deviceId, now, value, tombstone),
+    encodedPath,
+    writeRegister(
+      state,
+      deviceId,
+      now,
+      getOwnRecordValue(state.settings, encodedPath),
+      value,
+      tombstone,
+    ),
   );
 }
 
@@ -389,7 +412,14 @@ function applyMutation(
       break;
     case 'entity-delete': {
       const { entity } = ensureEntity(state, mutation.collection, mutation.entityId);
-      entity.presence = writeRegister(state, deviceId, now, undefined, true);
+      entity.presence = writeRegister(
+        state,
+        deviceId,
+        now,
+        entity.presence,
+        undefined,
+        true,
+      );
       break;
     }
     case 'setting-set':
@@ -418,19 +448,35 @@ function applyMutation(
         mutation.position !== undefined
         && !candidateValueEquals(entry.position, mutation.position)
       ) {
-        entry.position = writeRegister(state, deviceId, now, mutation.position);
+        entry.position = writeRegister(
+          state,
+          deviceId,
+          now,
+          entry.position,
+          mutation.position,
+        );
         changed = true;
       }
-      if (changed) entry.presence = writeRegister(state, deviceId, now, true);
+      if (changed) {
+        entry.presence = writeRegister(state, deviceId, now, entry.presence, true);
+      }
       break;
     }
     case 'string-entry-delete': {
       const { entry } = ensureStringEntry(state, mutation.collection, mutation.value);
-      entry.presence = writeRegister(state, deviceId, now, undefined, true);
+      entry.presence = writeRegister(
+        state,
+        deviceId,
+        now,
+        entry.presence,
+        undefined,
+        true,
+      );
       break;
     }
     case 'resolve-register': {
-      if (!getRegisterAtAddress(state, mutation.address)) {
+      const currentRegister = getRegisterAtAddress(state, mutation.address);
+      if (!currentRegister) {
         throw new ConvergentSyncInvariantError('Cannot resolve a register that does not exist');
       }
       if (mutation.tombstone && mutation.value !== undefined) {
@@ -457,6 +503,7 @@ function applyMutation(
           state,
           deviceId,
           now,
+          currentRegister,
           mutation.value,
           mutation.tombstone === true,
         ),
@@ -507,8 +554,6 @@ export function mergeConvergentSyncStates(
 ): ConvergentSyncStateV2 {
   assertValidConvergentSyncState(left);
   assertValidConvergentSyncState(right);
-  const leftVector = left.vector;
-  const rightVector = right.vector;
 
   const mergeRegister = <T extends JsonValue>(
     leftRegister: MultiValueRegister<T> | undefined,
@@ -516,8 +561,6 @@ export function mergeConvergentSyncStates(
   ): MultiValueRegister<T> | undefined => mergeMultiValueRegisters(
     leftRegister,
     rightRegister,
-    leftVector,
-    rightVector,
   );
 
   const collections = mergeRecord(
@@ -584,7 +627,7 @@ function comparePositions(
   if (typeof left === 'number' && typeof right === 'number') return left - right;
   if (typeof left === 'number') return -1;
   if (typeof right === 'number') return 1;
-  return left.localeCompare(right);
+  return compareStrings(left, right);
 }
 
 function materializedValue(register: MultiValueRegister | undefined): JsonValue | undefined {
@@ -685,7 +728,7 @@ function selectMaterializedSettingEntries(
     const candidateOrder = compareRegisterCandidates(right.winner, left.winner);
     return candidateOrder !== 0
       ? candidateOrder
-      : left.encodedPath.localeCompare(right.encodedPath);
+      : compareStrings(left.encodedPath, right.encodedPath);
   });
 
   for (const entry of prioritized) {
@@ -728,7 +771,7 @@ function recordSettingStructureConflicts(
   for (const rootPath of [...groups.keys()].sort()) {
     const group = groups.get(rootPath);
     if (!group || group.length < 2) continue;
-    group.sort((left, right) => left.encodedPath.localeCompare(right.encodedPath));
+    group.sort((left, right) => compareStrings(left.encodedPath, right.encodedPath));
     conflicts.push({
       address: {
         kind: 'setting-structure',
@@ -830,7 +873,7 @@ export function materializeConvergentSyncState(
       materializedEntities.push({ id: entityId, position, value });
     }
     materializedEntities.sort((left, right) =>
-      comparePositions(left.position, right.position) || left.id.localeCompare(right.id),
+      comparePositions(left.position, right.position) || compareStrings(left.id, right.id),
     );
     setOwnRecordValue(
       collections,
@@ -866,7 +909,7 @@ export function materializeConvergentSyncState(
       entries.push({ value, position });
     }
     entries.sort((left, right) =>
-      comparePositions(left.position, right.position) || left.value.localeCompare(right.value),
+      comparePositions(left.position, right.position) || compareStrings(left.value, right.value),
     );
     setOwnRecordValue(
       stringCollections,
@@ -876,7 +919,7 @@ export function materializeConvergentSyncState(
   }
 
   conflicts.sort((left, right) =>
-    addressSortKey(left.address).localeCompare(addressSortKey(right.address)),
+    compareStrings(addressSortKey(left.address), addressSortKey(right.address)),
   );
   return { collections, settings, stringCollections, conflicts };
 }

--- a/domain/convergentSync/state.ts
+++ b/domain/convergentSync/state.ts
@@ -335,6 +335,18 @@ function writeSettingRegister(
   // targets a path beneath it.
   tombstoneRelatedSettingPaths(state, deviceId, path, now, !tombstone);
   const encodedPath = encodeSettingPath(path);
+  const currentRegister = getOwnRecordValue(state.settings, encodedPath);
+  const currentWinner = selectRegisterWinner(currentRegister);
+  if (
+    currentRegister
+    && !registerHasConflict(currentRegister)
+    && (
+      (tombstone && currentWinner && isTombstoneCandidate(currentWinner))
+      || (!tombstone && value !== undefined && candidateValueEquals(currentRegister, value))
+    )
+  ) {
+    return;
+  }
   setOwnRecordValue(
     state.settings,
     encodedPath,
@@ -342,7 +354,7 @@ function writeSettingRegister(
       state,
       deviceId,
       now,
-      getOwnRecordValue(state.settings, encodedPath),
+      currentRegister,
       value,
       tombstone,
     ),

--- a/domain/convergentSync/state.ts
+++ b/domain/convergentSync/state.ts
@@ -1,0 +1,698 @@
+import {
+  dotKey,
+  maxHybridLogicalClock,
+  mergeVersionVectors,
+  tickHybridLogicalClock,
+} from './clock';
+import { cloneJson, jsonValuesEqual } from './json';
+import {
+  createRegisterCandidate,
+  isTombstoneCandidate,
+  mergeMultiValueRegisters,
+  registerHasConflict,
+  selectRegisterWinner,
+} from './register';
+import {
+  assertValidConvergentSyncState,
+  canonicalizeConvergentSyncState,
+  decodeSettingPath,
+  encodeSettingPath,
+} from './serialization';
+import {
+  createEmptyRecord,
+  getOwnRecordValue,
+  setOwnRecordValue,
+} from './record';
+import {
+  ConvergentSyncInvariantError,
+  type CollectionPosition,
+  type ConvergentCollectionState,
+  type ConvergentConflictCandidate,
+  type ConvergentEntityState,
+  type ConvergentFieldConflict,
+  type ConvergentMutation,
+  type ConvergentStringCollectionState,
+  type ConvergentStringEntryState,
+  type ConvergentSyncStateV2,
+  type JsonObject,
+  type JsonValue,
+  type MaterializedConvergentSyncState,
+  type MultiValueRegister,
+  type RegisterAddress,
+  type RegisterCandidate,
+} from './types';
+
+export function createConvergentSyncState(): ConvergentSyncStateV2 {
+  return {
+    schemaVersion: 2,
+    vector: createEmptyRecord(),
+    hlc: { wallTime: 0, logical: 0 },
+    collections: createEmptyRecord(),
+    settings: createEmptyRecord(),
+    stringCollections: createEmptyRecord(),
+  };
+}
+
+function requireNonEmpty(value: string, label: string): void {
+  if (value.length === 0) {
+    throw new ConvergentSyncInvariantError(`${label} must not be empty`);
+  }
+}
+
+function writeRegister<T extends JsonValue>(
+  state: ConvergentSyncStateV2,
+  deviceId: string,
+  now: number,
+  value?: T,
+  tombstone = false,
+): MultiValueRegister<T> {
+  requireNonEmpty(deviceId, 'Device ID');
+  const context = { ...state.vector };
+  const currentCounter = getOwnRecordValue(state.vector, deviceId) ?? 0;
+  if (currentCounter >= Number.MAX_SAFE_INTEGER) {
+    throw new ConvergentSyncInvariantError(`Device counter exhausted for ${deviceId}`);
+  }
+  const counter = currentCounter + 1;
+  const dot = { deviceId, counter };
+  setOwnRecordValue(state.vector, deviceId, counter);
+  state.hlc = tickHybridLogicalClock(state.hlc, now);
+  return {
+    candidates: [createRegisterCandidate({
+      dot,
+      context,
+      hlc: state.hlc,
+      value,
+      tombstone,
+    })],
+  };
+}
+
+function candidateValueEquals(
+  register: MultiValueRegister | undefined,
+  value: JsonValue,
+): boolean {
+  const winner = selectRegisterWinner(register);
+  return Boolean(winner)
+    && !isTombstoneCandidate(winner)
+    && jsonValuesEqual(winner.value, value);
+}
+
+function registerIsPresent(register: MultiValueRegister<boolean> | undefined): boolean {
+  const winner = selectRegisterWinner(register);
+  return Boolean(winner) && !isTombstoneCandidate(winner);
+}
+
+function ensureCollection(
+  state: ConvergentSyncStateV2,
+  collectionName: string,
+): ConvergentCollectionState {
+  requireNonEmpty(collectionName, 'Collection name');
+  const existing = getOwnRecordValue(state.collections, collectionName);
+  if (existing) return existing;
+  const collection = { entities: createEmptyRecord<ConvergentEntityState>() };
+  setOwnRecordValue(state.collections, collectionName, collection);
+  return collection;
+}
+
+function ensureEntity(
+  state: ConvergentSyncStateV2,
+  collectionName: string,
+  entityId: string,
+): { entity: ConvergentEntityState; created: boolean } {
+  requireNonEmpty(entityId, 'Entity ID');
+  const collection = ensureCollection(state, collectionName);
+  const existing = getOwnRecordValue(collection.entities, entityId);
+  if (existing) return { entity: existing, created: false };
+
+  const entity: ConvergentEntityState = {
+    // Filled before the batch is returned and validated.
+    presence: { candidates: [] },
+    fields: createEmptyRecord(),
+  };
+  setOwnRecordValue(collection.entities, entityId, entity);
+  return { entity, created: true };
+}
+
+function ensureStringCollection(
+  state: ConvergentSyncStateV2,
+  collectionName: string,
+): ConvergentStringCollectionState {
+  requireNonEmpty(collectionName, 'String collection name');
+  const existing = getOwnRecordValue(state.stringCollections, collectionName);
+  if (existing) return existing;
+  const collection = { entries: createEmptyRecord<ConvergentStringEntryState>() };
+  setOwnRecordValue(state.stringCollections, collectionName, collection);
+  return collection;
+}
+
+function ensureStringEntry(
+  state: ConvergentSyncStateV2,
+  collectionName: string,
+  value: string,
+): { entry: ConvergentStringEntryState; created: boolean } {
+  requireNonEmpty(value, 'String collection value');
+  const collection = ensureStringCollection(state, collectionName);
+  const existing = getOwnRecordValue(collection.entries, value);
+  if (existing) return { entry: existing, created: false };
+
+  const entry: ConvergentStringEntryState = { presence: { candidates: [] } };
+  setOwnRecordValue(collection.entries, value, entry);
+  return { entry, created: true };
+}
+
+function applyEntityUpsert(
+  state: ConvergentSyncStateV2,
+  deviceId: string,
+  mutation: Extract<ConvergentMutation, { kind: 'entity-upsert' }>,
+  now: number,
+): void {
+  const structuralId = mutation.value.id;
+  if (structuralId !== undefined && structuralId !== mutation.entityId) {
+    throw new ConvergentSyncInvariantError('Entity value ID must match its structural ID');
+  }
+
+  const { entity, created } = ensureEntity(
+    state,
+    mutation.collection,
+    mutation.entityId,
+  );
+  let changed = created || !registerIsPresent(entity.presence);
+  const incomingFields = Object.fromEntries(
+    Object.entries(mutation.value).filter(([field]) => field !== 'id'),
+  );
+  const fieldNames = new Set([
+    ...Object.keys(entity.fields),
+    ...Object.keys(incomingFields),
+  ]);
+
+  for (const field of [...fieldNames].sort()) {
+    requireNonEmpty(field, 'Entity field');
+    const incoming = getOwnRecordValue(incomingFields, field);
+    if (incoming === undefined) {
+      const winner = selectRegisterWinner(getOwnRecordValue(entity.fields, field));
+      if (winner && !isTombstoneCandidate(winner)) {
+        setOwnRecordValue(
+          entity.fields,
+          field,
+          writeRegister(state, deviceId, now, undefined, true),
+        );
+        changed = true;
+      }
+    } else if (!candidateValueEquals(getOwnRecordValue(entity.fields, field), incoming)) {
+      setOwnRecordValue(entity.fields, field, writeRegister(state, deviceId, now, incoming));
+      changed = true;
+    }
+  }
+
+  if (
+    mutation.position !== undefined
+    && !candidateValueEquals(entity.position, mutation.position)
+  ) {
+    entity.position = writeRegister(state, deviceId, now, mutation.position);
+    changed = true;
+  }
+
+  if (changed) {
+    // Refreshing presence makes a concurrent delete/update visible as an
+    // MV-register conflict instead of allowing a deletion to hide the edit.
+    entity.presence = writeRegister(state, deviceId, now, true);
+  }
+}
+
+function applyEntityFieldMutation(
+  state: ConvergentSyncStateV2,
+  deviceId: string,
+  mutation: Extract<
+    ConvergentMutation,
+    { kind: 'entity-field-set' | 'entity-field-delete' }
+  >,
+  now: number,
+): void {
+  requireNonEmpty(mutation.field, 'Entity field');
+  if (mutation.field === 'id') {
+    throw new ConvergentSyncInvariantError('Entity IDs are structural and cannot be field registers');
+  }
+  const { entity } = ensureEntity(state, mutation.collection, mutation.entityId);
+  setOwnRecordValue(entity.fields, mutation.field, mutation.kind === 'entity-field-delete'
+    ? writeRegister(state, deviceId, now, undefined, true)
+    : writeRegister(state, deviceId, now, mutation.value));
+  entity.presence = writeRegister(state, deviceId, now, true);
+}
+
+function findEntity(
+  state: ConvergentSyncStateV2,
+  collectionName: string,
+  entityId: string,
+): ConvergentEntityState | undefined {
+  const collection = getOwnRecordValue(state.collections, collectionName);
+  return collection
+    ? getOwnRecordValue(collection.entities, entityId)
+    : undefined;
+}
+
+function findStringEntry(
+  state: ConvergentSyncStateV2,
+  collectionName: string,
+  value: string,
+): ConvergentStringEntryState | undefined {
+  const collection = getOwnRecordValue(state.stringCollections, collectionName);
+  return collection
+    ? getOwnRecordValue(collection.entries, value)
+    : undefined;
+}
+
+function getRegisterAtAddress(
+  state: ConvergentSyncStateV2,
+  address: RegisterAddress,
+): MultiValueRegister | undefined {
+  switch (address.kind) {
+    case 'entity-presence':
+      return findEntity(state, address.collection, address.entityId)?.presence;
+    case 'entity-position':
+      return findEntity(state, address.collection, address.entityId)?.position;
+    case 'entity-field': {
+      const entity = findEntity(state, address.collection, address.entityId);
+      return entity ? getOwnRecordValue(entity.fields, address.field) : undefined;
+    }
+    case 'setting':
+      return getOwnRecordValue(state.settings, encodeSettingPath(address.path));
+    case 'string-entry-presence':
+      return findStringEntry(state, address.collection, address.value)?.presence;
+    case 'string-entry-position':
+      return findStringEntry(state, address.collection, address.value)?.position;
+  }
+}
+
+function setRegisterAtAddress(
+  state: ConvergentSyncStateV2,
+  address: RegisterAddress,
+  register: MultiValueRegister,
+): void {
+  switch (address.kind) {
+    case 'entity-presence':
+      ensureEntity(state, address.collection, address.entityId).entity.presence = register as MultiValueRegister<boolean>;
+      break;
+    case 'entity-position':
+      ensureEntity(state, address.collection, address.entityId).entity.position = register as MultiValueRegister<CollectionPosition>;
+      break;
+    case 'entity-field':
+      requireNonEmpty(address.field, 'Entity field');
+      setOwnRecordValue(
+        ensureEntity(state, address.collection, address.entityId).entity.fields,
+        address.field,
+        register,
+      );
+      break;
+    case 'setting':
+      setOwnRecordValue(state.settings, encodeSettingPath(address.path), register);
+      break;
+    case 'string-entry-presence':
+      ensureStringEntry(state, address.collection, address.value).entry.presence = register as MultiValueRegister<boolean>;
+      break;
+    case 'string-entry-position':
+      ensureStringEntry(state, address.collection, address.value).entry.position = register as MultiValueRegister<CollectionPosition>;
+      break;
+  }
+}
+
+function applyMutation(
+  state: ConvergentSyncStateV2,
+  deviceId: string,
+  mutation: ConvergentMutation,
+  now: number,
+): void {
+  switch (mutation.kind) {
+    case 'entity-upsert':
+      applyEntityUpsert(state, deviceId, mutation, now);
+      break;
+    case 'entity-field-set':
+    case 'entity-field-delete':
+      applyEntityFieldMutation(state, deviceId, mutation, now);
+      break;
+    case 'entity-delete': {
+      const { entity } = ensureEntity(state, mutation.collection, mutation.entityId);
+      entity.presence = writeRegister(state, deviceId, now, undefined, true);
+      break;
+    }
+    case 'setting-set':
+      setOwnRecordValue(state.settings, encodeSettingPath(mutation.path), writeRegister(
+        state,
+        deviceId,
+        now,
+        mutation.value,
+      ));
+      break;
+    case 'setting-delete':
+      setOwnRecordValue(state.settings, encodeSettingPath(mutation.path), writeRegister(
+        state,
+        deviceId,
+        now,
+        undefined,
+        true,
+      ));
+      break;
+    case 'string-entry-add': {
+      const { entry, created } = ensureStringEntry(state, mutation.collection, mutation.value);
+      let changed = created || !registerIsPresent(entry.presence);
+      if (
+        mutation.position !== undefined
+        && !candidateValueEquals(entry.position, mutation.position)
+      ) {
+        entry.position = writeRegister(state, deviceId, now, mutation.position);
+        changed = true;
+      }
+      if (changed) entry.presence = writeRegister(state, deviceId, now, true);
+      break;
+    }
+    case 'string-entry-delete': {
+      const { entry } = ensureStringEntry(state, mutation.collection, mutation.value);
+      entry.presence = writeRegister(state, deviceId, now, undefined, true);
+      break;
+    }
+    case 'resolve-register': {
+      if (!getRegisterAtAddress(state, mutation.address)) {
+        throw new ConvergentSyncInvariantError('Cannot resolve a register that does not exist');
+      }
+      if (mutation.tombstone && mutation.value !== undefined) {
+        throw new ConvergentSyncInvariantError('A tombstone resolution cannot contain a value');
+      }
+      if (!mutation.tombstone && mutation.value === undefined) {
+        throw new ConvergentSyncInvariantError('A value resolution requires a value');
+      }
+      setRegisterAtAddress(
+        state,
+        mutation.address,
+        writeRegister(
+          state,
+          deviceId,
+          now,
+          mutation.value,
+          mutation.tombstone === true,
+        ),
+      );
+      break;
+    }
+  }
+}
+
+/**
+ * Apply a batch with one structural clone. Import and migration can therefore
+ * create thousands of registers without repeatedly copying the full replica.
+ */
+export function applyConvergentMutations(
+  state: ConvergentSyncStateV2,
+  deviceId: string,
+  mutations: ConvergentMutation[],
+  now = Date.now(),
+): ConvergentSyncStateV2 {
+  assertValidConvergentSyncState(state);
+  requireNonEmpty(deviceId, 'Device ID');
+  const next = canonicalizeConvergentSyncState(state);
+  for (const mutation of mutations) applyMutation(next, deviceId, mutation, now);
+  assertValidConvergentSyncState(next);
+  return canonicalizeConvergentSyncState(next);
+}
+
+function mergeRecord<T>(
+  left: Record<string, T>,
+  right: Record<string, T>,
+  merge: (leftValue: T | undefined, rightValue: T | undefined) => T | undefined,
+): Record<string, T> {
+  const result = createEmptyRecord<T>();
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  for (const key of [...keys].sort()) {
+    const merged = merge(
+      getOwnRecordValue(left, key),
+      getOwnRecordValue(right, key),
+    );
+    if (merged !== undefined) setOwnRecordValue(result, key, merged);
+  }
+  return result;
+}
+
+export function mergeConvergentSyncStates(
+  left: ConvergentSyncStateV2,
+  right: ConvergentSyncStateV2,
+): ConvergentSyncStateV2 {
+  assertValidConvergentSyncState(left);
+  assertValidConvergentSyncState(right);
+  const leftVector = left.vector;
+  const rightVector = right.vector;
+
+  const mergeRegister = <T extends JsonValue>(
+    leftRegister: MultiValueRegister<T> | undefined,
+    rightRegister: MultiValueRegister<T> | undefined,
+  ): MultiValueRegister<T> | undefined => mergeMultiValueRegisters(
+    leftRegister,
+    rightRegister,
+    leftVector,
+    rightVector,
+  );
+
+  const collections = mergeRecord(
+    left.collections,
+    right.collections,
+    (leftCollection, rightCollection) => {
+      const entities = mergeRecord(
+        leftCollection?.entities ?? {},
+        rightCollection?.entities ?? {},
+        (leftEntity, rightEntity) => {
+          const presence = mergeRegister(leftEntity?.presence, rightEntity?.presence);
+          if (!presence) return undefined;
+          const position = mergeRegister(leftEntity?.position, rightEntity?.position);
+          const fields = mergeRecord(
+            leftEntity?.fields ?? {},
+            rightEntity?.fields ?? {},
+            mergeRegister,
+          );
+          return { presence, ...(position ? { position } : {}), fields };
+        },
+      );
+      return Object.keys(entities).length > 0 ? { entities } : undefined;
+    },
+  );
+
+  const settings = mergeRecord(left.settings, right.settings, mergeRegister);
+  const stringCollections = mergeRecord(
+    left.stringCollections,
+    right.stringCollections,
+    (leftCollection, rightCollection) => {
+      const entries = mergeRecord(
+        leftCollection?.entries ?? {},
+        rightCollection?.entries ?? {},
+        (leftEntry, rightEntry) => {
+          const presence = mergeRegister(leftEntry?.presence, rightEntry?.presence);
+          if (!presence) return undefined;
+          const position = mergeRegister(leftEntry?.position, rightEntry?.position);
+          return { presence, ...(position ? { position } : {}) };
+        },
+      );
+      return Object.keys(entries).length > 0 ? { entries } : undefined;
+    },
+  );
+
+  const merged: ConvergentSyncStateV2 = {
+    schemaVersion: 2,
+    vector: mergeVersionVectors(left.vector, right.vector),
+    hlc: maxHybridLogicalClock(left.hlc, right.hlc),
+    collections,
+    settings,
+    stringCollections,
+  };
+  assertValidConvergentSyncState(merged);
+  return canonicalizeConvergentSyncState(merged);
+}
+
+function comparePositions(
+  left: CollectionPosition | undefined,
+  right: CollectionPosition | undefined,
+): number {
+  if (left === undefined && right === undefined) return 0;
+  if (left === undefined) return 1;
+  if (right === undefined) return -1;
+  if (typeof left === 'number' && typeof right === 'number') return left - right;
+  if (typeof left === 'number') return -1;
+  if (typeof right === 'number') return 1;
+  return left.localeCompare(right);
+}
+
+function materializedValue(register: MultiValueRegister | undefined): JsonValue | undefined {
+  const winner = selectRegisterWinner(register);
+  if (!winner || isTombstoneCandidate(winner)) return undefined;
+  return cloneJson(winner.value);
+}
+
+function conflictCandidate(
+  candidate: RegisterCandidate,
+  selectedDot: string,
+): ConvergentConflictCandidate {
+  return {
+    dot: { ...candidate.dot },
+    hlc: { ...candidate.hlc },
+    tombstone: isTombstoneCandidate(candidate),
+    ...(!isTombstoneCandidate(candidate) ? { value: cloneJson(candidate.value) } : {}),
+    selected: dotKey(candidate.dot) === selectedDot,
+  };
+}
+
+function maybeRecordConflict(
+  conflicts: ConvergentFieldConflict[],
+  address: RegisterAddress,
+  register: MultiValueRegister | undefined,
+): void {
+  if (!register || !registerHasConflict(register)) return;
+  const winner = selectRegisterWinner(register);
+  if (!winner) return;
+  conflicts.push({
+    address,
+    candidates: register.candidates.map((candidate) =>
+      conflictCandidate(candidate, dotKey(winner.dot)),
+    ),
+  });
+}
+
+function addressSortKey(address: RegisterAddress): string {
+  switch (address.kind) {
+    case 'entity-presence':
+      return `0:${address.collection}:${address.entityId}:0`;
+    case 'entity-position':
+      return `0:${address.collection}:${address.entityId}:1`;
+    case 'entity-field':
+      return `0:${address.collection}:${address.entityId}:2:${address.field}`;
+    case 'setting':
+      return `1:${encodeSettingPath(address.path)}`;
+    case 'string-entry-presence':
+      return `2:${address.collection}:${address.value}:0`;
+    case 'string-entry-position':
+      return `2:${address.collection}:${address.value}:1`;
+  }
+}
+
+function setNestedSetting(root: JsonObject, path: string[], value: JsonValue): void {
+  let target = root;
+  for (const segment of path.slice(0, -1)) {
+    const existing = getOwnRecordValue(target, segment);
+    if (existing === undefined) {
+      const nested = createEmptyRecord<JsonValue>();
+      setOwnRecordValue(target, segment, nested);
+      target = nested;
+    } else if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
+      target = existing;
+    } else {
+      throw new ConvergentSyncInvariantError(
+        `Setting path ${encodeSettingPath(path)} overlaps an atomic parent value`,
+      );
+    }
+  }
+  setOwnRecordValue(target, path[path.length - 1], cloneJson(value));
+}
+
+export function materializeConvergentSyncState(
+  state: ConvergentSyncStateV2,
+): MaterializedConvergentSyncState {
+  assertValidConvergentSyncState(state);
+  const collections = createEmptyRecord<JsonObject[]>();
+  const settings = createEmptyRecord<JsonValue>();
+  const stringCollections = createEmptyRecord<string[]>();
+  const conflicts: ConvergentFieldConflict[] = [];
+
+  for (const collectionName of Object.keys(state.collections).sort()) {
+    const materializedEntities: Array<{
+      id: string;
+      position?: CollectionPosition;
+      value: JsonObject;
+    }> = [];
+    const collection = getOwnRecordValue(state.collections, collectionName);
+    if (!collection) continue;
+    for (const entityId of Object.keys(collection.entities).sort()) {
+      const entity = getOwnRecordValue(collection.entities, entityId);
+      if (!entity) continue;
+      maybeRecordConflict(conflicts, {
+        kind: 'entity-presence',
+        collection: collectionName,
+        entityId,
+      }, entity.presence);
+      maybeRecordConflict(conflicts, {
+        kind: 'entity-position',
+        collection: collectionName,
+        entityId,
+      }, entity.position);
+      for (const field of Object.keys(entity.fields).sort()) {
+        maybeRecordConflict(conflicts, {
+          kind: 'entity-field',
+          collection: collectionName,
+          entityId,
+          field,
+        }, getOwnRecordValue(entity.fields, field));
+      }
+
+      if (!registerIsPresent(entity.presence)) continue;
+      const value: JsonObject = { id: entityId };
+      for (const field of Object.keys(entity.fields).sort()) {
+        const fieldValue = materializedValue(getOwnRecordValue(entity.fields, field));
+        if (fieldValue !== undefined) setOwnRecordValue(value, field, fieldValue);
+      }
+      const rawPosition = materializedValue(entity.position);
+      const position = typeof rawPosition === 'string' || typeof rawPosition === 'number'
+        ? rawPosition
+        : undefined;
+      materializedEntities.push({ id: entityId, position, value });
+    }
+    materializedEntities.sort((left, right) =>
+      comparePositions(left.position, right.position) || left.id.localeCompare(right.id),
+    );
+    setOwnRecordValue(
+      collections,
+      collectionName,
+      materializedEntities.map((entity) => entity.value),
+    );
+  }
+
+  for (const encodedPath of Object.keys(state.settings).sort()) {
+    const register = getOwnRecordValue(state.settings, encodedPath);
+    if (!register) continue;
+    const path = decodeSettingPath(encodedPath);
+    maybeRecordConflict(conflicts, { kind: 'setting', path }, register);
+    const value = materializedValue(register);
+    if (value !== undefined) setNestedSetting(settings, path, value);
+  }
+
+  for (const collectionName of Object.keys(state.stringCollections).sort()) {
+    const entries: Array<{ value: string; position?: CollectionPosition }> = [];
+    const collection = getOwnRecordValue(state.stringCollections, collectionName);
+    if (!collection) continue;
+    for (const value of Object.keys(collection.entries).sort()) {
+      const entry = getOwnRecordValue(collection.entries, value);
+      if (!entry) continue;
+      maybeRecordConflict(conflicts, {
+        kind: 'string-entry-presence',
+        collection: collectionName,
+        value,
+      }, entry.presence);
+      maybeRecordConflict(conflicts, {
+        kind: 'string-entry-position',
+        collection: collectionName,
+        value,
+      }, entry.position);
+      if (!registerIsPresent(entry.presence)) continue;
+      const rawPosition = materializedValue(entry.position);
+      const position = typeof rawPosition === 'string' || typeof rawPosition === 'number'
+        ? rawPosition
+        : undefined;
+      entries.push({ value, position });
+    }
+    entries.sort((left, right) =>
+      comparePositions(left.position, right.position) || left.value.localeCompare(right.value),
+    );
+    setOwnRecordValue(
+      stringCollections,
+      collectionName,
+      entries.map((entry) => entry.value),
+    );
+  }
+
+  conflicts.sort((left, right) =>
+    addressSortKey(left.address).localeCompare(addressSortKey(right.address)),
+  );
+  return { collections, settings, stringCollections, conflicts };
+}

--- a/domain/convergentSync/state.ts
+++ b/domain/convergentSync/state.ts
@@ -1056,6 +1056,7 @@ export function materializeConvergentSyncState(
         collection: collectionName,
         entityId,
       }, entity.presence);
+      if (!registerIsPresent(entity.presence)) continue;
       maybeRecordConflict(conflicts, {
         kind: 'entity-position',
         collection: collectionName,
@@ -1070,7 +1071,6 @@ export function materializeConvergentSyncState(
         }, getOwnRecordValue(entity.fields, field));
       }
 
-      if (!registerIsPresent(entity.presence)) continue;
       const value: JsonObject = { id: entityId };
       for (const field of Object.keys(entity.fields).sort()) {
         const fieldValue = materializedValue(getOwnRecordValue(entity.fields, field));
@@ -1106,12 +1106,12 @@ export function materializeConvergentSyncState(
         collection: collectionName,
         value,
       }, entry.presence);
+      if (!registerIsPresent(entry.presence)) continue;
       maybeRecordConflict(conflicts, {
         kind: 'string-entry-position',
         collection: collectionName,
         value,
       }, entry.position);
-      if (!registerIsPresent(entry.presence)) continue;
       const rawPosition = materializedValue(entry.position);
       const position = typeof rawPosition === 'string' || typeof rawPosition === 'number'
         ? rawPosition

--- a/domain/convergentSync/state.ts
+++ b/domain/convergentSync/state.ts
@@ -710,7 +710,7 @@ export function applyConvergentMutations(
   state: ConvergentSyncStateV2,
   deviceId: string,
   mutations: ConvergentMutation[],
-  now = Date.now(),
+  now: number,
 ): ConvergentSyncStateV2 {
   assertValidConvergentSyncState(state);
   requireNonEmpty(deviceId, 'Device ID');

--- a/domain/convergentSync/state.ts
+++ b/domain/convergentSync/state.ts
@@ -27,6 +27,7 @@ import {
   getOwnRecordValue,
   setOwnRecordValue,
 } from './record';
+import { registerId } from './registerId';
 import {
   ConvergentSyncInvariantError,
   type CollectionPosition,
@@ -39,6 +40,7 @@ import {
   type ConvergentStringCollectionState,
   type ConvergentStringEntryState,
   type ConvergentSyncStateV2,
+  type DotOriginIndex,
   type JsonObject,
   type JsonValue,
   type MaterializedConvergentSyncState,
@@ -51,6 +53,7 @@ export function createConvergentSyncState(): ConvergentSyncStateV2 {
   return {
     schemaVersion: 2,
     vector: createEmptyRecord(),
+    dotOrigins: createEmptyRecord(),
     hlc: { wallTime: 0, logical: 0 },
     collections: createEmptyRecord(),
     settings: createEmptyRecord(),
@@ -68,6 +71,7 @@ function writeRegister<T extends JsonValue>(
   state: ConvergentSyncStateV2,
   deviceId: string,
   now: number,
+  registerIdentity: string,
   currentRegister: MultiValueRegister<T> | undefined,
   value?: T,
   tombstone = false,
@@ -81,6 +85,10 @@ function writeRegister<T extends JsonValue>(
   const counter = currentCounter + 1;
   const dot = { deviceId, counter };
   setOwnRecordValue(state.vector, deviceId, counter);
+  const deviceOrigins = getOwnRecordValue(state.dotOrigins, deviceId)
+    ?? createEmptyRecord<string>();
+  setOwnRecordValue(deviceOrigins, String(counter), registerIdentity);
+  setOwnRecordValue(state.dotOrigins, deviceId, deviceOrigins);
   state.hlc = tickHybridLogicalClock(state.hlc, now);
   return {
     candidates: [createRegisterCandidate({
@@ -182,6 +190,16 @@ function applyEntityUpsert(
     mutation.collection,
     mutation.entityId,
   );
+  const presenceRegisterId = registerId({
+    kind: 'entity-presence',
+    collection: mutation.collection,
+    entityId: mutation.entityId,
+  });
+  const positionRegisterId = registerId({
+    kind: 'entity-position',
+    collection: mutation.collection,
+    entityId: mutation.entityId,
+  });
   let changed = created
     || !registerIsPresent(entity.presence)
     || registerHasConflict(entity.presence);
@@ -195,6 +213,12 @@ function applyEntityUpsert(
 
   for (const field of [...fieldNames].sort()) {
     requireNonEmpty(field, 'Entity field');
+    const fieldRegisterId = registerId({
+      kind: 'entity-field',
+      collection: mutation.collection,
+      entityId: mutation.entityId,
+      field,
+    });
     const incoming = getOwnRecordValue(incomingFields, field);
     const currentRegister = getOwnRecordValue(entity.fields, field);
     if (incoming === undefined) {
@@ -203,7 +227,15 @@ function applyEntityUpsert(
         setOwnRecordValue(
           entity.fields,
           field,
-          writeRegister(state, deviceId, now, currentRegister, undefined, true),
+          writeRegister(
+            state,
+            deviceId,
+            now,
+            fieldRegisterId,
+            currentRegister,
+            undefined,
+            true,
+          ),
         );
         changed = true;
       }
@@ -215,7 +247,14 @@ function applyEntityUpsert(
       setOwnRecordValue(
         entity.fields,
         field,
-        writeRegister(state, deviceId, now, currentRegister, incoming),
+        writeRegister(
+          state,
+          deviceId,
+          now,
+          fieldRegisterId,
+          currentRegister,
+          incoming,
+        ),
       );
       changed = true;
     }
@@ -233,6 +272,7 @@ function applyEntityUpsert(
       state,
       deviceId,
       now,
+      positionRegisterId,
       entity.position,
       mutation.position,
     );
@@ -242,7 +282,14 @@ function applyEntityUpsert(
   if (changed) {
     // Refreshing presence makes a concurrent delete/update visible as an
     // MV-register conflict instead of allowing a deletion to hide the edit.
-    entity.presence = writeRegister(state, deviceId, now, entity.presence, true);
+    entity.presence = writeRegister(
+      state,
+      deviceId,
+      now,
+      presenceRegisterId,
+      entity.presence,
+      true,
+    );
   }
 }
 
@@ -266,6 +313,17 @@ function applyEntityFieldMutation(
   if (mutation.kind === 'entity-field-delete' && !existingEntity) return;
 
   const { entity } = ensureEntity(state, mutation.collection, mutation.entityId);
+  const fieldRegisterId = registerId({
+    kind: 'entity-field',
+    collection: mutation.collection,
+    entityId: mutation.entityId,
+    field: mutation.field,
+  });
+  const presenceRegisterId = registerId({
+    kind: 'entity-presence',
+    collection: mutation.collection,
+    entityId: mutation.entityId,
+  });
   const currentRegister = getOwnRecordValue(entity.fields, mutation.field);
   const currentWinner = selectRegisterWinner(currentRegister);
 
@@ -274,10 +332,25 @@ function applyEntityFieldMutation(
     setOwnRecordValue(
       entity.fields,
       mutation.field,
-      writeRegister(state, deviceId, now, currentRegister, undefined, true),
+      writeRegister(
+        state,
+        deviceId,
+        now,
+        fieldRegisterId,
+        currentRegister,
+        undefined,
+        true,
+      ),
     );
     if (registerIsPresent(entity.presence)) {
-      entity.presence = writeRegister(state, deviceId, now, entity.presence, true);
+      entity.presence = writeRegister(
+        state,
+        deviceId,
+        now,
+        presenceRegisterId,
+        entity.presence,
+        true,
+      );
     }
     return;
   }
@@ -291,9 +364,23 @@ function applyEntityFieldMutation(
   setOwnRecordValue(
     entity.fields,
     mutation.field,
-    writeRegister(state, deviceId, now, currentRegister, mutation.value),
+    writeRegister(
+      state,
+      deviceId,
+      now,
+      fieldRegisterId,
+      currentRegister,
+      mutation.value,
+    ),
   );
-  entity.presence = writeRegister(state, deviceId, now, entity.presence, true);
+  entity.presence = writeRegister(
+    state,
+    deviceId,
+    now,
+    presenceRegisterId,
+    entity.presence,
+    true,
+  );
 }
 
 function settingPathIsPrefix(prefix: string[], path: string[]): boolean {
@@ -326,7 +413,15 @@ function tombstoneRelatedSettingPaths(
     setOwnRecordValue(
       state.settings,
       otherEncodedPath,
-      writeRegister(state, deviceId, now, register, undefined, true),
+      writeRegister(
+        state,
+        deviceId,
+        now,
+        registerId({ kind: 'setting', path: otherPath }),
+        register,
+        undefined,
+        true,
+      ),
     );
   }
 }
@@ -364,6 +459,7 @@ function writeSettingRegister(
       state,
       deviceId,
       now,
+      registerId({ kind: 'setting', path }),
       currentRegister,
       value,
       tombstone,
@@ -467,6 +563,11 @@ function applyMutation(
         state,
         deviceId,
         now,
+        registerId({
+          kind: 'entity-presence',
+          collection: mutation.collection,
+          entityId: mutation.entityId,
+        }),
         entity.presence,
         undefined,
         true,
@@ -509,13 +610,29 @@ function applyMutation(
           state,
           deviceId,
           now,
+          registerId({
+            kind: 'string-entry-position',
+            collection: mutation.collection,
+            value: mutation.value,
+          }),
           entry.position,
           mutation.position,
         );
         changed = true;
       }
       if (changed) {
-        entry.presence = writeRegister(state, deviceId, now, entry.presence, true);
+        entry.presence = writeRegister(
+          state,
+          deviceId,
+          now,
+          registerId({
+            kind: 'string-entry-presence',
+            collection: mutation.collection,
+            value: mutation.value,
+          }),
+          entry.presence,
+          true,
+        );
       }
       break;
     }
@@ -534,6 +651,11 @@ function applyMutation(
         state,
         deviceId,
         now,
+        registerId({
+          kind: 'string-entry-presence',
+          collection: mutation.collection,
+          value: mutation.value,
+        }),
         entry.presence,
         undefined,
         true,
@@ -569,6 +691,7 @@ function applyMutation(
           state,
           deviceId,
           now,
+          registerId(mutation.address),
           currentRegister,
           mutation.value,
           mutation.tombstone === true,
@@ -612,6 +735,26 @@ function mergeRecord<T>(
     if (merged !== undefined) setOwnRecordValue(result, key, merged);
   }
   return result;
+}
+
+function mergeDotOrigins(
+  left: DotOriginIndex,
+  right: DotOriginIndex,
+): DotOriginIndex {
+  return mergeRecord(left, right, (leftDevice, rightDevice) =>
+    mergeRecord(
+      leftDevice ?? createEmptyRecord<string>(),
+      rightDevice ?? createEmptyRecord<string>(),
+      (leftOrigin, rightOrigin) => {
+        if (leftOrigin && rightOrigin && leftOrigin !== rightOrigin) {
+          throw new ConvergentSyncInvariantError(
+            `Dot origin mismatch: ${leftOrigin} !== ${rightOrigin}`,
+          );
+        }
+        return leftOrigin ?? rightOrigin;
+      },
+    ),
+  );
 }
 
 export function mergeConvergentSyncStates(
@@ -674,6 +817,7 @@ export function mergeConvergentSyncStates(
   const merged: ConvergentSyncStateV2 = {
     schemaVersion: 2,
     vector: mergeVersionVectors(left.vector, right.vector),
+    dotOrigins: mergeDotOrigins(left.dotOrigins, right.dotOrigins),
     hlc: maxHybridLogicalClock(left.hlc, right.hlc),
     collections,
     settings,

--- a/domain/convergentSync/state.ts
+++ b/domain/convergentSync/state.ts
@@ -249,11 +249,40 @@ function applyEntityFieldMutation(
   if (mutation.field === 'id') {
     throw new ConvergentSyncInvariantError('Entity IDs are structural and cannot be field registers');
   }
+  const collection = getOwnRecordValue(state.collections, mutation.collection);
+  const existingEntity = collection
+    ? getOwnRecordValue(collection.entities, mutation.entityId)
+    : undefined;
+  if (mutation.kind === 'entity-field-delete' && !existingEntity) return;
+
   const { entity } = ensureEntity(state, mutation.collection, mutation.entityId);
   const currentRegister = getOwnRecordValue(entity.fields, mutation.field);
-  setOwnRecordValue(entity.fields, mutation.field, mutation.kind === 'entity-field-delete'
-    ? writeRegister(state, deviceId, now, currentRegister, undefined, true)
-    : writeRegister(state, deviceId, now, currentRegister, mutation.value));
+  const currentWinner = selectRegisterWinner(currentRegister);
+
+  if (mutation.kind === 'entity-field-delete') {
+    if (!currentWinner || isTombstoneCandidate(currentWinner)) return;
+    setOwnRecordValue(
+      entity.fields,
+      mutation.field,
+      writeRegister(state, deviceId, now, currentRegister, undefined, true),
+    );
+    if (registerIsPresent(entity.presence)) {
+      entity.presence = writeRegister(state, deviceId, now, entity.presence, true);
+    }
+    return;
+  }
+
+  if (
+    (!currentRegister || !registerHasConflict(currentRegister))
+    && candidateValueEquals(currentRegister, mutation.value)
+  ) {
+    return;
+  }
+  setOwnRecordValue(
+    entity.fields,
+    mutation.field,
+    writeRegister(state, deviceId, now, currentRegister, mutation.value),
+  );
   entity.presence = writeRegister(state, deviceId, now, entity.presence, true);
 }
 

--- a/domain/convergentSync/state.ts
+++ b/domain/convergentSync/state.ts
@@ -251,17 +251,21 @@ function settingPathsOverlap(left: string[], right: string[]): boolean {
   return settingPathIsPrefix(left, right) || settingPathIsPrefix(right, left);
 }
 
-function tombstoneOverlappingSettingPaths(
+function tombstoneRelatedSettingPaths(
   state: ConvergentSyncStateV2,
   deviceId: string,
   path: string[],
   now: number,
+  includeAncestors: boolean,
 ): void {
   const encodedPath = encodeSettingPath(path);
   for (const otherEncodedPath of Object.keys(state.settings).sort()) {
     if (otherEncodedPath === encodedPath) continue;
     const otherPath = decodeSettingPath(otherEncodedPath);
-    if (!settingPathsOverlap(path, otherPath)) continue;
+    const isRelated = includeAncestors
+      ? settingPathsOverlap(path, otherPath)
+      : settingPathIsPrefix(path, otherPath);
+    if (!isRelated) continue;
     const register = getOwnRecordValue(state.settings, otherEncodedPath);
     const winner = selectRegisterWinner(register);
     if (!winner || isTombstoneCandidate(winner)) continue;
@@ -281,9 +285,11 @@ function writeSettingRegister(
   value?: JsonValue,
   tombstone = false,
 ): void {
-  if (!tombstone) {
-    tombstoneOverlappingSettingPaths(state, deviceId, path, now);
-  }
+  // Replacements remove both atomic ancestors and nested descendants to keep
+  // the causal leaf set prefix-free. Deletions represent subtree removal, so
+  // they remove descendants without erasing an atomic ancestor when a caller
+  // targets a path beneath it.
+  tombstoneRelatedSettingPaths(state, deviceId, path, now, !tombstone);
   setOwnRecordValue(
     state.settings,
     encodeSettingPath(path),

--- a/domain/convergentSync/state.ts
+++ b/domain/convergentSync/state.ts
@@ -492,7 +492,16 @@ function applyMutation(
       break;
     }
     case 'string-entry-delete': {
-      const { entry } = ensureStringEntry(state, mutation.collection, mutation.value);
+      requireNonEmpty(mutation.collection, 'String collection name');
+      requireNonEmpty(mutation.value, 'String collection value');
+      const collection = getOwnRecordValue(
+        state.stringCollections,
+        mutation.collection,
+      );
+      const entry = collection
+        ? getOwnRecordValue(collection.entries, mutation.value)
+        : undefined;
+      if (!entry || !registerIsPresent(entry.presence)) break;
       entry.presence = writeRegister(
         state,
         deviceId,

--- a/domain/convergentSync/types.ts
+++ b/domain/convergentSync/types.ts
@@ -23,8 +23,8 @@ export interface HybridLogicalClock {
 
 interface RegisterCandidateBase {
   dot: Dot;
-  /** Causal context observed immediately before this dot was allocated. */
-  context: VersionVector;
+  /** Dots observed in this register before this candidate was written. */
+  context: Dot[];
   hlc: HybridLogicalClock;
 }
 

--- a/domain/convergentSync/types.ts
+++ b/domain/convergentSync/types.ts
@@ -1,0 +1,193 @@
+export type JsonPrimitive = string | number | boolean | null;
+
+export type JsonValue =
+  | JsonPrimitive
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export type JsonObject = { [key: string]: JsonValue };
+
+export interface VersionVector {
+  [deviceId: string]: number;
+}
+
+export interface Dot {
+  deviceId: string;
+  counter: number;
+}
+
+export interface HybridLogicalClock {
+  wallTime: number;
+  logical: number;
+}
+
+interface RegisterCandidateBase {
+  dot: Dot;
+  /** Causal context observed immediately before this dot was allocated. */
+  context: VersionVector;
+  hlc: HybridLogicalClock;
+}
+
+export interface RegisterValueCandidate<T extends JsonValue = JsonValue>
+  extends RegisterCandidateBase {
+  value: T;
+  tombstone?: false;
+}
+
+export interface RegisterTombstoneCandidate extends RegisterCandidateBase {
+  tombstone: true;
+}
+
+export type RegisterCandidate<T extends JsonValue = JsonValue> =
+  | RegisterValueCandidate<T>
+  | RegisterTombstoneCandidate;
+
+export interface MultiValueRegister<T extends JsonValue = JsonValue> {
+  candidates: RegisterCandidate<T>[];
+}
+
+export type CollectionPosition = string | number;
+
+export interface ConvergentEntityState {
+  presence: MultiValueRegister<boolean>;
+  position?: MultiValueRegister<CollectionPosition>;
+  fields: Record<string, MultiValueRegister>;
+}
+
+export interface ConvergentCollectionState {
+  entities: Record<string, ConvergentEntityState>;
+}
+
+export interface ConvergentStringEntryState {
+  presence: MultiValueRegister<boolean>;
+  position?: MultiValueRegister<CollectionPosition>;
+}
+
+export interface ConvergentStringCollectionState {
+  entries: Record<string, ConvergentStringEntryState>;
+}
+
+/**
+ * Pure CRDT state. The encrypted protocol envelope is introduced separately;
+ * this type deliberately contains no provider, persistence, or UI concerns.
+ */
+export interface ConvergentSyncStateV2 {
+  schemaVersion: 2;
+  vector: VersionVector;
+  hlc: HybridLogicalClock;
+  collections: Record<string, ConvergentCollectionState>;
+  settings: Record<string, MultiValueRegister>;
+  stringCollections: Record<string, ConvergentStringCollectionState>;
+}
+
+export type RegisterAddress =
+  | {
+    kind: 'entity-presence';
+    collection: string;
+    entityId: string;
+  }
+  | {
+    kind: 'entity-position';
+    collection: string;
+    entityId: string;
+  }
+  | {
+    kind: 'entity-field';
+    collection: string;
+    entityId: string;
+    field: string;
+  }
+  | {
+    kind: 'setting';
+    path: string[];
+  }
+  | {
+    kind: 'string-entry-presence';
+    collection: string;
+    value: string;
+  }
+  | {
+    kind: 'string-entry-position';
+    collection: string;
+    value: string;
+  };
+
+export type ConvergentMutation =
+  | {
+    kind: 'entity-upsert';
+    collection: string;
+    entityId: string;
+    value: JsonObject;
+    position?: CollectionPosition;
+  }
+  | {
+    kind: 'entity-field-set';
+    collection: string;
+    entityId: string;
+    field: string;
+    value: JsonValue;
+  }
+  | {
+    kind: 'entity-field-delete';
+    collection: string;
+    entityId: string;
+    field: string;
+  }
+  | {
+    kind: 'entity-delete';
+    collection: string;
+    entityId: string;
+  }
+  | {
+    kind: 'setting-set';
+    path: string[];
+    value: JsonValue;
+  }
+  | {
+    kind: 'setting-delete';
+    path: string[];
+  }
+  | {
+    kind: 'string-entry-add';
+    collection: string;
+    value: string;
+    position?: CollectionPosition;
+  }
+  | {
+    kind: 'string-entry-delete';
+    collection: string;
+    value: string;
+  }
+  | {
+    kind: 'resolve-register';
+    address: RegisterAddress;
+    value?: JsonValue;
+    tombstone?: boolean;
+  };
+
+export interface ConvergentConflictCandidate {
+  dot: Dot;
+  hlc: HybridLogicalClock;
+  tombstone: boolean;
+  value?: JsonValue;
+  selected: boolean;
+}
+
+export interface ConvergentFieldConflict {
+  address: RegisterAddress;
+  candidates: ConvergentConflictCandidate[];
+}
+
+export interface MaterializedConvergentSyncState {
+  collections: Record<string, JsonObject[]>;
+  settings: JsonObject;
+  stringCollections: Record<string, string[]>;
+  conflicts: ConvergentFieldConflict[];
+}
+
+export class ConvergentSyncInvariantError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConvergentSyncInvariantError';
+  }
+}

--- a/domain/convergentSync/types.ts
+++ b/domain/convergentSync/types.ts
@@ -112,6 +112,11 @@ export type RegisterAddress =
     value: string;
   };
 
+export type ConvergentConflictAddress = RegisterAddress | {
+  kind: 'setting-structure';
+  paths: string[][];
+};
+
 export type ConvergentMutation =
   | {
     kind: 'entity-upsert';
@@ -170,11 +175,13 @@ export interface ConvergentConflictCandidate {
   hlc: HybridLogicalClock;
   tombstone: boolean;
   value?: JsonValue;
+  /** Present when candidates from multiple setting leaf paths conflict. */
+  settingPath?: string[];
   selected: boolean;
 }
 
 export interface ConvergentFieldConflict {
-  address: RegisterAddress;
+  address: ConvergentConflictAddress;
   candidates: ConvergentConflictCandidate[];
 }
 

--- a/domain/convergentSync/types.ts
+++ b/domain/convergentSync/types.ts
@@ -11,6 +11,10 @@ export interface VersionVector {
   [deviceId: string]: number;
 }
 
+export interface DotOriginIndex {
+  [deviceId: string]: Record<string, string>;
+}
+
 export interface Dot {
   deviceId: string;
   counter: number;
@@ -74,6 +78,8 @@ export interface ConvergentStringCollectionState {
 export interface ConvergentSyncStateV2 {
   schemaVersion: 2;
   vector: VersionVector;
+  /** Register identity for every allocated device counter. */
+  dotOrigins: DotOriginIndex;
   hlc: HybridLogicalClock;
   collections: Record<string, ConvergentCollectionState>;
   settings: Record<string, MultiValueRegister>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-unused-imports": "^4.3.0",
+        "fast-check": "^4.9.0",
         "patch-package": "^8.0.0",
         "simple-icons": "^16.23.0",
         "tailwindcss": "^4.1.17",
@@ -11462,6 +11463,29 @@
         "@types/yauzl": "^2.9.1"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -16201,6 +16225,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/pvtsutils": {
       "version": "1.3.6",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "node --test --import tsx electron/*.test.cjs electron/scripts/*.test.cjs electron/terminalWorker/*.test.cjs electron/capabilities/*.test.cjs electron/capabilities/*/*.test.cjs electron/capabilities/*/*/*.test.cjs electron/cli/*.test.cjs electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs electron/bridges/aiBridge/codexAppServer/*.test.cjs electron/bridges/aiBridge/sdk/*.test.cjs scripts/*.test.cjs application/*.test.ts application/app/*.test.ts application/i18n/locales/*.test.ts application/state/*.test.ts application/state/*/*.test.ts components/*.test.ts components/*.test.tsx components/editor/*.test.ts components/editor/*.test.tsx components/notes/*.test.tsx components/port-forwarding/*.test.ts components/scripts/*.test.tsx components/systemManager/*.test.ts components/terminalLayer/*.test.ts components/settings/*.test.tsx components/settings/tabs/*.test.ts components/settings/tabs/ai/*.test.ts components/settings/tabs/ai/*.test.tsx components/ai/*.test.ts components/ai/*.test.tsx components/ai/toolArtifacts/*.test.ts components/ai/toolArtifacts/*.test.tsx components/ai-elements/*.test.tsx components/sftp/*.test.ts components/terminal/*.test.ts components/terminal/*.test.tsx components/terminal/runtime/*.test.ts components/vault/*.test.ts components/vault/*.test.tsx domain/*.test.ts domain/*/*.test.ts infrastructure/ai/*.test.ts infrastructure/ai/*/*.test.ts infrastructure/ai/sdk/*.test.ts infrastructure/config/*.test.ts infrastructure/persistence/*.test.ts infrastructure/services/*.test.ts infrastructure/services/*/*.test.ts lib/*.test.ts",
+    "test:sync-crdt": "node --test --import tsx domain/convergentSync/*.test.ts",
+    "bench:sync-crdt": "tsx scripts/bench-sync-crdt.ts",
     "test:ssh-mfa-models": "node --test electron/bridges/sshMfaModels.live.test.cjs",
     "test:ssh-mfa-models:live": "SSH_MFA_LIVE=1 node --test electron/bridges/sshMfaModels.live.test.cjs"
   },
@@ -118,6 +120,7 @@
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-unused-imports": "^4.3.0",
+    "fast-check": "^4.9.0",
     "patch-package": "^8.0.0",
     "simple-icons": "^16.23.0",
     "tailwindcss": "^4.1.17",

--- a/scripts/bench-sync-crdt.ts
+++ b/scripts/bench-sync-crdt.ts
@@ -1,0 +1,62 @@
+import {
+  applyConvergentMutations,
+  createConvergentSyncState,
+  mergeConvergentSyncStates,
+  type ConvergentMutation,
+} from '../domain/convergentSync/index.ts';
+
+function elapsedMs<T>(operation: () => T): { value: T; duration: number } {
+  const startedAt = performance.now();
+  const value = operation();
+  return { value, duration: performance.now() - startedAt };
+}
+
+function buildMutations(count: number): ConvergentMutation[] {
+  return Array.from({ length: count }, (_, index) => ({
+    kind: 'entity-upsert' as const,
+    collection: 'hosts',
+    entityId: `host-${index.toString().padStart(5, '0')}`,
+    value: {
+      id: `host-${index.toString().padStart(5, '0')}`,
+      label: `Host ${index}`,
+      hostname: `host-${index}.example.com`,
+      tags: [`group-${index % 20}`],
+    },
+    position: index,
+  }));
+}
+
+function run(size: number): void {
+  const created = elapsedMs(() => applyConvergentMutations(
+    createConvergentSyncState(),
+    'seed',
+    buildMutations(size),
+    1_700_000_000_000,
+  ));
+  const left = applyConvergentMutations(created.value, 'device-a', [{
+    kind: 'entity-field-set',
+    collection: 'hosts',
+    entityId: `host-${Math.floor(size / 3).toString().padStart(5, '0')}`,
+    field: 'label',
+    value: 'Edited on A',
+  }], 1_700_000_000_001);
+  const right = applyConvergentMutations(created.value, 'device-b', [{
+    kind: 'entity-field-set',
+    collection: 'hosts',
+    entityId: `host-${Math.floor(size / 2).toString().padStart(5, '0')}`,
+    field: 'hostname',
+    value: 'edited.example.com',
+  }], 1_700_000_000_001);
+  const merged = elapsedMs(() => mergeConvergentSyncStates(left, right));
+
+  console.log(JSON.stringify({
+    entities: size,
+    registers: Object.values(merged.value.collections.hosts.entities)
+      .reduce((total, entity) => total + 1 + (entity.position ? 1 : 0)
+        + Object.keys(entity.fields).length, 0),
+    createMs: Number(created.duration.toFixed(2)),
+    mergeMs: Number(merged.duration.toFixed(2)),
+  }));
+}
+
+for (const size of [1_000, 5_000, 10_000]) run(size);


### PR DESCRIPTION
## Summary

Adds the pure state-based CRDT v2 core for convergent multi-device sync. This is the first of three sequential PRs for #2245; it intentionally contains no persistence, provider, migration, or UI integration.

The core uses device-monotonic dots, dotted version vectors, Hybrid Logical Clocks, multi-value registers, observed-remove presence, deterministic materialization, and canonical serialization. Concurrent values are retained, causal deletions cannot be resurrected by stale replicas, and explicit conflict resolutions dominate all observed candidates.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #2245

## Changes Made

- Add a pure CRDT state model for entity presence, positions, top-level fields, settings leaf paths, and ordered string collections.
- Add commutative, associative, and idempotent state joins with fail-closed dot and schema validation.
- Add deterministic winner selection while preserving all concurrent candidates for later field-level resolution.
- Add canonical serialization and hydration with prototype-safe record handling.
- Add fast-check property tests covering 2-20 offline replicas, reordering, partitions, and duplicate delivery.
- Add a non-gating benchmark and design document describing invariants, complexity, and follow-up boundaries.

## Screenshots / Demo

N/A — this PR is domain-only and does not expose the experimental feature in the UI yet.

## Testing

- [ ] I have tested these changes locally (`npm run dev`) — not applicable to the domain-only core
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable — not applicable
- [x] No new console errors or warnings, if this affects app behavior

Additional verification:

- [x] `npm run test:sync-crdt` — 17 example/property tests
- [x] Isolated TypeScript check for the new domain and benchmark files
- [x] `npm run build`
- [x] `git diff --check`
- [x] `npm run bench:sync-crdt`

Local benchmark on 50,000 registers / 10,000 entities: create 179.78 ms, two-replica merge 265.34 ms. The 1k/5k/10k samples showed near-linear growth.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)