### PR TITLE
fix(ui): replace native confirms in system manager panels

### DIFF
--- a/components/systemManager/DockerContainersPanel.tsx
+++ b/components/systemManager/DockerContainersPanel.tsx
@@ -26,6 +26,7 @@ import {
   SystemPanelStatusBadge,
   SystemPanelToolbar,
 } from './SystemPanelUi';
+import { SystemPanelConfirmDialog } from './SystemPanelConfirmDialog';
 import { useAsyncRecordCache } from './hooks/useAsyncRecordCache';
 import { usePolling, useStableTranslate } from './hooks/useSystemManager';
 import { openInteractiveTerminal } from './openInteractiveTerminal';
@@ -33,6 +34,10 @@ import { showSystemManagerError } from './systemManagerToast';
 
 type Backend = ReturnType<typeof useSystemManagerBackend>;
 type ContainerFilter = 'all' | 'running' | 'stopped' | 'paused';
+type PendingContainerConfirm = {
+  containerId: string;
+  action: 'rm' | 'kill';
+};
 
 async function buildContainerPopupIcon(image: string): Promise<TerminalPopupIcon> {
   const {
@@ -166,6 +171,7 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
   // Spinner feedback while a container action (stop/restart/…) runs;
   // cleared only after the follow-up list refresh lands.
   const [pendingAction, setPendingAction] = useState<{ id: string; action: DockerContainerAction } | null>(null);
+  const [confirmAction, setConfirmAction] = useState<PendingContainerConfirm | null>(null);
 
   const containersFetcher = useCallback(async () => {
     const result = await backend.listDockerContainers(sessionId);
@@ -283,14 +289,11 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
     containerId: string,
     action: DockerContainerAction,
     newName?: string,
+    options?: { skipConfirm?: boolean },
   ) => {
-    if (action === 'rm') {
-      const ok = globalThis.confirm(t('systemManager.docker.confirmRemove'));
-      if (!ok) return;
-    }
-    if (action === 'kill') {
-      const ok = globalThis.confirm(t('systemManager.docker.confirmKill'));
-      if (!ok) return;
+    if (!options?.skipConfirm && (action === 'rm' || action === 'kill')) {
+      setConfirmAction({ containerId, action });
+      return;
     }
     setPendingAction({ id: containerId, action });
     try {
@@ -471,6 +474,28 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
           );
         })}
       </SystemPanelList>
+
+      <SystemPanelConfirmDialog
+        open={confirmAction !== null}
+        title={confirmAction?.action === 'kill'
+          ? t('systemManager.docker.kill')
+          : t('action.remove')}
+        message={confirmAction?.action === 'kill'
+          ? t('systemManager.docker.confirmKill')
+          : t('systemManager.docker.confirmRemove')}
+        confirmLabel={confirmAction?.action === 'kill'
+          ? t('systemManager.docker.kill')
+          : t('action.remove')}
+        destructive
+        busy={pendingAction !== null}
+        onOpenChange={(open) => { if (!open) setConfirmAction(null); }}
+        onConfirm={() => {
+          const target = confirmAction;
+          setConfirmAction(null);
+          if (!target) return;
+          void runAction(target.containerId, target.action, undefined, { skipConfirm: true });
+        }}
+      />
     </div>
   );
 });

--- a/components/systemManager/DockerContainersPanel.tsx
+++ b/components/systemManager/DockerContainersPanel.tsx
@@ -1,5 +1,5 @@
 import { Box, FileText, Play, RotateCcw, Square, Terminal } from 'lucide-react';
-import React, { memo, useCallback, useMemo, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import type { useSystemManagerBackend } from '../../application/state/useSystemManagerBackend';
 import { writeSystemManagerDiagnostic } from '../../application/state/systemManagerDiagnostics';
@@ -172,6 +172,14 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
   // cleared only after the follow-up list refresh lands.
   const [pendingAction, setPendingAction] = useState<{ id: string; action: DockerContainerAction } | null>(null);
   const [confirmAction, setConfirmAction] = useState<PendingContainerConfirm | null>(null);
+
+  useEffect(() => {
+    // Drop pending confirms/selection when the active terminal session changes so
+    // a confirm opened for host A cannot run against host B.
+    setConfirmAction(null);
+    setPendingAction(null);
+    setSelectedId(null);
+  }, [sessionId]);
 
   const containersFetcher = useCallback(async () => {
     const result = await backend.listDockerContainers(sessionId);

--- a/components/systemManager/DockerImagesPanel.tsx
+++ b/components/systemManager/DockerImagesPanel.tsx
@@ -21,12 +21,17 @@ import {
   SystemPanelSearch,
   SystemPanelToolbar,
 } from './SystemPanelUi';
+import { SystemPanelConfirmDialog } from './SystemPanelConfirmDialog';
 import { SystemPanelPromptDialog } from './SystemPanelPromptDialog';
 import { useAsyncRecordCache } from './hooks/useAsyncRecordCache';
 import { usePolling, useStableTranslate } from './hooks/useSystemManager';
 import { showSystemManagerError } from './systemManagerToast';
 
 type Backend = ReturnType<typeof useSystemManagerBackend>;
+
+type PendingImageConfirm =
+  | { kind: 'remove'; image: DockerImageInfo; label: string }
+  | { kind: 'prune'; all: boolean };
 
 interface DockerImagesPanelProps {
   sessionId: string;
@@ -94,10 +99,13 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
   const [query, setQuery] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [tagTarget, setTagTarget] = useState<DockerImageInfo | null>(null);
+  const [confirmTarget, setConfirmTarget] = useState<PendingImageConfirm | null>(null);
+  const [actionBusy, setActionBusy] = useState(false);
 
   useEffect(() => {
     setSelectedId(null);
     setTagTarget(null);
+    setConfirmTarget(null);
   }, [sessionId]);
 
   const imagesFetcher = useCallback(async () => {
@@ -167,39 +175,51 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
     staleTimeMs: 20_000,
   });
 
-  const handleRemove = useCallback(async (image: DockerImageInfo) => {
-    const label = image.name || image.id.slice(0, 12);
-    const ok = window.confirm(t('systemManager.docker.confirmRemoveImage', { name: label }));
-    if (!ok) return;
-    const result = await backend.dockerImageAction({
-      sessionId,
-      action: 'rm',
-      imageId: image.id.slice(0, 12),
-      force: image.tag === '<none>',
-    });
-    if (!result.success) {
-      showSystemManagerError(result.error || t('systemManager.errors.actionFailed'), t('common.error'));
-      return;
+  const executeRemove = useCallback(async (image: DockerImageInfo) => {
+    setActionBusy(true);
+    try {
+      const result = await backend.dockerImageAction({
+        sessionId,
+        action: 'rm',
+        imageId: image.id.slice(0, 12),
+        force: image.tag === '<none>',
+      });
+      if (!result.success) {
+        showSystemManagerError(result.error || t('systemManager.errors.actionFailed'), t('common.error'));
+        return;
+      }
+      if (selectedId === dockerImageRowKey(image)) {
+        setSelectedId(null);
+      }
+      invalidateImageInspect(getImageInspectKey(image));
+      await refresh();
+    } finally {
+      setActionBusy(false);
     }
-    if (selectedId === dockerImageRowKey(image)) {
-      setSelectedId(null);
-    }
-    invalidateImageInspect(getImageInspectKey(image));
-    await refresh();
   }, [backend, getImageInspectKey, invalidateImageInspect, refresh, selectedId, sessionId, t]);
 
-  const handlePrune = async (all: boolean) => {
-    const ok = window.confirm(all
-      ? t('systemManager.docker.confirmPruneAll')
-      : t('systemManager.docker.confirmPrune'));
-    if (!ok) return;
-    const result = await backend.dockerImageAction({ sessionId, action: 'prune', all });
-    if (!result.success) {
-      showSystemManagerError(result.error || t('systemManager.errors.actionFailed'), t('common.error'));
-      return;
+  const handleRemove = useCallback((image: DockerImageInfo) => {
+    const label = image.name || image.id.slice(0, 12);
+    setConfirmTarget({ kind: 'remove', image, label });
+  }, []);
+
+  const executePrune = useCallback(async (all: boolean) => {
+    setActionBusy(true);
+    try {
+      const result = await backend.dockerImageAction({ sessionId, action: 'prune', all });
+      if (!result.success) {
+        showSystemManagerError(result.error || t('systemManager.errors.actionFailed'), t('common.error'));
+        return;
+      }
+      await refresh();
+    } finally {
+      setActionBusy(false);
     }
-    await refresh();
-  };
+  }, [backend, refresh, sessionId, t]);
+
+  const handlePrune = useCallback((all: boolean) => {
+    setConfirmTarget({ kind: 'prune', all });
+  }, []);
 
   const handleTagSubmit = async (image: DockerImageInfo, repository: string, tag: string) => {
     const result = await backend.dockerImageAction({
@@ -235,14 +255,14 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
           <>
             <button
               type="button"
-              onClick={() => void handlePrune(false)}
+              onClick={() => handlePrune(false)}
               className="shrink-0 h-7 px-2 rounded-md text-[10px] text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
             >
               {t('systemManager.docker.prune')}
             </button>
             <button
               type="button"
-              onClick={() => void handlePrune(true)}
+              onClick={() => handlePrune(true)}
               className="shrink-0 h-7 px-2 rounded-md text-[10px] text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
             >
               {t('systemManager.docker.pruneAll')}
@@ -343,6 +363,38 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
           setTagTarget(null);
           if (!image) return;
           void handleTagSubmit(image, values.repository, values.tag);
+        }}
+      />
+
+      <SystemPanelConfirmDialog
+        open={confirmTarget !== null}
+        title={confirmTarget?.kind === 'prune'
+          ? (confirmTarget.all ? t('systemManager.docker.pruneAll') : t('systemManager.docker.prune'))
+          : t('action.remove')}
+        message={confirmTarget?.kind === 'prune'
+          ? (confirmTarget.all
+            ? t('systemManager.docker.confirmPruneAll')
+            : t('systemManager.docker.confirmPrune'))
+          : t('systemManager.docker.confirmRemoveImage', {
+            name: confirmTarget?.kind === 'remove' ? confirmTarget.label : '',
+          })}
+        confirmLabel={confirmTarget?.kind === 'prune'
+          ? (confirmTarget.all ? t('systemManager.docker.pruneAll') : t('systemManager.docker.prune'))
+          : t('action.remove')}
+        destructive
+        busy={actionBusy}
+        onOpenChange={(open) => {
+          if (!open && !actionBusy) setConfirmTarget(null);
+        }}
+        onConfirm={() => {
+          const target = confirmTarget;
+          setConfirmTarget(null);
+          if (!target) return;
+          if (target.kind === 'remove') {
+            void executeRemove(target.image);
+            return;
+          }
+          void executePrune(target.all);
         }}
       />
     </div>

--- a/components/systemManager/DockerImagesPanel.tsx
+++ b/components/systemManager/DockerImagesPanel.tsx
@@ -1,5 +1,5 @@
 import { Layers, Loader2, Tag, Trash2 } from 'lucide-react';
-import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import type { useSystemManagerBackend } from '../../application/state/useSystemManagerBackend';
 import { dockerImageRowKey, type DockerImageInfo } from '../../domain/systemManager/types';
@@ -101,11 +101,16 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
   const [tagTarget, setTagTarget] = useState<DockerImageInfo | null>(null);
   const [confirmTarget, setConfirmTarget] = useState<PendingImageConfirm | null>(null);
   const [actionBusy, setActionBusy] = useState(false);
+  const actionGenerationRef = useRef(0);
 
   useEffect(() => {
+    actionGenerationRef.current += 1;
     setSelectedId(null);
     setTagTarget(null);
     setConfirmTarget(null);
+    // Clear busy so a hung/in-flight action from the previous session cannot
+    // leave the new session's confirm dialog permanently disabled.
+    setActionBusy(false);
   }, [sessionId]);
 
   const imagesFetcher = useCallback(async () => {
@@ -176,6 +181,7 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
   });
 
   const executeRemove = useCallback(async (image: DockerImageInfo) => {
+    const actionGeneration = actionGenerationRef.current;
     setActionBusy(true);
     try {
       const result = await backend.dockerImageAction({
@@ -184,6 +190,7 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
         imageId: image.id.slice(0, 12),
         force: image.tag === '<none>',
       });
+      if (actionGenerationRef.current !== actionGeneration) return;
       if (!result.success) {
         showSystemManagerError(result.error || t('systemManager.errors.actionFailed'), t('common.error'));
         return;
@@ -194,7 +201,9 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
       invalidateImageInspect(getImageInspectKey(image));
       await refresh();
     } finally {
-      setActionBusy(false);
+      if (actionGenerationRef.current === actionGeneration) {
+        setActionBusy(false);
+      }
     }
   }, [backend, getImageInspectKey, invalidateImageInspect, refresh, selectedId, sessionId, t]);
 
@@ -204,16 +213,20 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
   }, []);
 
   const executePrune = useCallback(async (all: boolean) => {
+    const actionGeneration = actionGenerationRef.current;
     setActionBusy(true);
     try {
       const result = await backend.dockerImageAction({ sessionId, action: 'prune', all });
+      if (actionGenerationRef.current !== actionGeneration) return;
       if (!result.success) {
         showSystemManagerError(result.error || t('systemManager.errors.actionFailed'), t('common.error'));
         return;
       }
       await refresh();
     } finally {
-      setActionBusy(false);
+      if (actionGenerationRef.current === actionGeneration) {
+        setActionBusy(false);
+      }
     }
   }, [backend, refresh, sessionId, t]);
 

--- a/components/systemManager/ProcessManagerTab.tsx
+++ b/components/systemManager/ProcessManagerTab.tsx
@@ -31,12 +31,28 @@ import {
   SystemPanelStatusBadge,
   SystemPanelToolbar,
 } from './SystemPanelUi';
+import { SystemPanelConfirmDialog } from './SystemPanelConfirmDialog';
 import { SystemPanelPromptDialog } from './SystemPanelPromptDialog';
 import { usePolling, useStableTranslate } from './hooks/useSystemManager';
 
 type Backend = ReturnType<typeof useSystemManagerBackend>;
 type SortKey = 'cpuPercent' | 'memPercent' | 'pid' | 'command' | 'user';
 type ProcessFilter = 'all' | 'running';
+type ProcessSignal = 'STOP' | 'CONT' | 'TERM' | 'KILL';
+
+interface PendingProcessSignal {
+  pid: number;
+  signal: ProcessSignal;
+}
+
+function processSignalTitleKey(signal: ProcessSignal): string {
+  switch (signal) {
+    case 'STOP': return 'systemManager.processes.stop';
+    case 'CONT': return 'systemManager.processes.cont';
+    case 'TERM': return 'systemManager.processes.term';
+    case 'KILL': return 'systemManager.processes.kill';
+  }
+}
 
 const PROCESS_CACHE_TTL_MS = 30_000;
 const PROCESS_ROW_HEIGHT = 56;
@@ -255,6 +271,8 @@ export const ProcessManagerTab = memo(function ProcessManagerTab({
   const [filter, setFilter] = useState<ProcessFilter>('all');
   const [selectedPid, setSelectedPid] = useState<number | null>(null);
   const [reniceTarget, setReniceTarget] = useState<number | null>(null);
+  const [pendingSignal, setPendingSignal] = useState<PendingProcessSignal | null>(null);
+  const [signalBusy, setSignalBusy] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [cachedProcesses, setCachedProcesses] = useState<SystemProcessInfo[] | null>(() => getCachedProcesses(sessionId));
   const [cachedProcessesSessionId, setCachedProcessesSessionId] = useState(sessionId);
@@ -377,19 +395,24 @@ export const ProcessManagerTab = memo(function ProcessManagerTab({
     setSelectedPid((cur) => (cur === pid ? null : pid));
   }, []);
 
-  const signalProcess = useCallback(async (pid: number, signal: string) => {
-    const confirmKey = signal === 'KILL'
-      ? 'systemManager.processes.confirmKill'
-      : 'systemManager.processes.confirmSignal';
-    const ok = window.confirm(t(confirmKey, { pid: String(pid), signal }));
-    if (!ok) return;
+  const requestSignal = useCallback((pid: number, signal: string) => {
+    if (signal !== 'STOP' && signal !== 'CONT' && signal !== 'TERM' && signal !== 'KILL') return;
+    setPendingSignal({ pid, signal });
+  }, []);
+
+  const executeSignal = useCallback(async (pid: number, signal: ProcessSignal) => {
+    setSignalBusy(true);
     setActionError(null);
-    const result = await backend.signalSystemProcess({ sessionId, pid, signal });
-    if (!result.success) {
-      setActionError(result.error || t('systemManager.errors.actionFailed'));
-      return;
+    try {
+      const result = await backend.signalSystemProcess({ sessionId, pid, signal });
+      if (!result.success) {
+        setActionError(result.error || t('systemManager.errors.actionFailed'));
+        return;
+      }
+      void refresh();
+    } finally {
+      setSignalBusy(false);
     }
-    void refresh();
   }, [backend, refresh, sessionId, t]);
 
   const reniceProcess = useCallback(async (pid: number, nice: number) => {
@@ -478,10 +501,35 @@ export const ProcessManagerTab = memo(function ProcessManagerTab({
           processes={displayList}
           selectedPid={selectedPid}
           onToggle={togglePid}
-          onSignal={signalProcess}
+          onSignal={requestSignal}
           onRenice={openRenicePrompt}
         />
       )}
+
+      <SystemPanelConfirmDialog
+        open={pendingSignal !== null}
+        title={pendingSignal ? t(processSignalTitleKey(pendingSignal.signal)) : ''}
+        message={pendingSignal
+          ? t(
+            pendingSignal.signal === 'KILL'
+              ? 'systemManager.processes.confirmKill'
+              : 'systemManager.processes.confirmSignal',
+            { pid: String(pendingSignal.pid), signal: pendingSignal.signal },
+          )
+          : ''}
+        confirmLabel={pendingSignal ? t(processSignalTitleKey(pendingSignal.signal)) : ''}
+        destructive={pendingSignal?.signal === 'KILL' || pendingSignal?.signal === 'TERM'}
+        busy={signalBusy}
+        onOpenChange={(open) => {
+          if (!open && !signalBusy) setPendingSignal(null);
+        }}
+        onConfirm={() => {
+          const target = pendingSignal;
+          if (!target) return;
+          setPendingSignal(null);
+          void executeSignal(target.pid, target.signal);
+        }}
+      />
 
       <SystemPanelPromptDialog
         open={reniceTarget !== null}

--- a/components/systemManager/ProcessManagerTab.tsx
+++ b/components/systemManager/ProcessManagerTab.tsx
@@ -290,6 +290,12 @@ export const ProcessManagerTab = memo(function ProcessManagerTab({
     setCachedProcesses(getCachedProcesses(sessionId));
     setCachedProcessesSessionId(sessionId);
     setProcessListPending(false);
+    // Drop in-flight dialogs so a confirm cannot act on a different host/session.
+    setPendingSignal(null);
+    setSignalBusy(false);
+    setReniceTarget(null);
+    setSelectedPid(null);
+    setActionError(null);
   }, [sessionId]);
 
   useEffect(() => () => {

--- a/components/systemManager/TmuxSessionCard.tsx
+++ b/components/systemManager/TmuxSessionCard.tsx
@@ -88,6 +88,11 @@ export const TmuxSessionCard = memo(function TmuxSessionCard({
   const [expanded, setExpanded] = useState(false);
   const [renamePrompt, setRenamePrompt] = useState<RenamePromptTarget | null>(null);
   const [detachConfirmOpen, setDetachConfirmOpen] = useState(false);
+  const [killSessionConfirmOpen, setKillSessionConfirmOpen] = useState(false);
+  const [killWindowConfirm, setKillWindowConfirm] = useState<{
+    windowIndex: number;
+    windowName: string;
+  } | null>(null);
   const [newWindowOpen, setNewWindowOpen] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -206,11 +211,7 @@ export const TmuxSessionCard = memo(function TmuxSessionCard({
               destructive
               disabled={busy}
               loading={isPending('killSession')}
-              onClick={() => {
-                if (globalThis.confirm(t('systemManager.tmux.confirmKillSession', { name: session.name }))) {
-                  void runAction({ action: 'killSession', sessionName: session.name });
-                }
-              }}
+              onClick={() => setKillSessionConfirmOpen(true)}
             >
               <Trash2 size={12} />
             </SystemPanelRoundButton>
@@ -282,17 +283,10 @@ export const TmuxSessionCard = memo(function TmuxSessionCard({
                   destructive
                   disabled={busy}
                   loading={isPending('killWindow', tmuxWindow.index)}
-                  onClick={() => {
-                    if (globalThis.confirm(t('systemManager.tmux.confirmKillWindow', {
-                      name: tmuxWindow.name || String(tmuxWindow.index),
-                    }))) {
-                      void runAction({
-                        action: 'killWindow',
-                        sessionName: session.name,
-                        windowIndex: tmuxWindow.index,
-                      });
-                    }
-                  }}
+                  onClick={() => setKillWindowConfirm({
+                    windowIndex: tmuxWindow.index,
+                    windowName: tmuxWindow.name || String(tmuxWindow.index),
+                  })}
                 >
                   <Trash2 size={11} />
                 </SystemPanelRoundButton>
@@ -319,6 +313,42 @@ export const TmuxSessionCard = memo(function TmuxSessionCard({
         onConfirm={() => {
           setDetachConfirmOpen(false);
           void runAction({ action: 'detachSession', sessionName: session.name });
+        }}
+      />
+
+      <SystemPanelConfirmDialog
+        open={killSessionConfirmOpen}
+        title={t('systemManager.tmux.killSession')}
+        message={t('systemManager.tmux.confirmKillSession', { name: session.name })}
+        confirmLabel={t('systemManager.tmux.killSession')}
+        destructive
+        busy={busy}
+        onOpenChange={setKillSessionConfirmOpen}
+        onConfirm={() => {
+          setKillSessionConfirmOpen(false);
+          void runAction({ action: 'killSession', sessionName: session.name });
+        }}
+      />
+
+      <SystemPanelConfirmDialog
+        open={killWindowConfirm !== null}
+        title={t('systemManager.tmux.killWindow')}
+        message={t('systemManager.tmux.confirmKillWindow', {
+          name: killWindowConfirm?.windowName ?? '',
+        })}
+        confirmLabel={t('systemManager.tmux.killWindow')}
+        destructive
+        busy={busy}
+        onOpenChange={(open) => { if (!open) setKillWindowConfirm(null); }}
+        onConfirm={() => {
+          const target = killWindowConfirm;
+          setKillWindowConfirm(null);
+          if (!target) return;
+          void runAction({
+            action: 'killWindow',
+            sessionName: session.name,
+            windowIndex: target.windowIndex,
+          });
         }}
       />
 

--- a/components/systemManager/systemPanelConfirmDialogRegression.test.ts
+++ b/components/systemManager/systemPanelConfirmDialogRegression.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+
+function readProjectFile(path: string): string {
+  return readFileSync(join(root, path), "utf8");
+}
+
+const SYSTEM_MANAGER_PANELS = [
+  "components/systemManager/ProcessManagerTab.tsx",
+  "components/systemManager/TmuxSessionCard.tsx",
+  "components/systemManager/DockerContainersPanel.tsx",
+  "components/systemManager/DockerImagesPanel.tsx",
+] as const;
+
+test("system manager destructive actions use in-app confirm dialogs", () => {
+  for (const path of SYSTEM_MANAGER_PANELS) {
+    const source = readProjectFile(path);
+    assert.match(
+      source,
+      /import \{ SystemPanelConfirmDialog \} from ['"]\.\/SystemPanelConfirmDialog['"]/,
+      `${path} should import SystemPanelConfirmDialog`,
+    );
+    assert.match(
+      source,
+      /<SystemPanelConfirmDialog/,
+      `${path} should render SystemPanelConfirmDialog`,
+    );
+    assert.doesNotMatch(
+      source,
+      /window\.confirm|globalThis\.confirm/,
+      `${path} must not use native confirm dialogs`,
+    );
+  }
+});

--- a/components/systemManager/systemPanelConfirmDialogRegression.test.ts
+++ b/components/systemManager/systemPanelConfirmDialogRegression.test.ts
@@ -50,5 +50,6 @@ test("process and docker confirm dialogs reset when sessionId changes", () => {
   assert.match(containersSource, /}, \[sessionId\]\);/);
 
   assert.match(imagesSource, /setConfirmTarget\(null\)/);
+  assert.match(imagesSource, /setActionBusy\(false\)/);
   assert.match(imagesSource, /}, \[sessionId\]\);/);
 });

--- a/components/systemManager/systemPanelConfirmDialogRegression.test.ts
+++ b/components/systemManager/systemPanelConfirmDialogRegression.test.ts
@@ -37,3 +37,18 @@ test("system manager destructive actions use in-app confirm dialogs", () => {
     );
   }
 });
+
+test("process and docker confirm dialogs reset when sessionId changes", () => {
+  const processSource = readProjectFile("components/systemManager/ProcessManagerTab.tsx");
+  const containersSource = readProjectFile("components/systemManager/DockerContainersPanel.tsx");
+  const imagesSource = readProjectFile("components/systemManager/DockerImagesPanel.tsx");
+
+  assert.match(processSource, /setPendingSignal\(null\)/);
+  assert.match(processSource, /}, \[sessionId\]\);/);
+
+  assert.match(containersSource, /setConfirmAction\(null\)/);
+  assert.match(containersSource, /}, \[sessionId\]\);/);
+
+  assert.match(imagesSource, /setConfirmTarget\(null\)/);
+  assert.match(imagesSource, /}, \[sessionId\]\);/);
+});


### PR DESCRIPTION
## Summary
- Replace `window.confirm` / `globalThis.confirm` in System Manager process, tmux, and Docker panels with the in-app `SystemPanelConfirmDialog`.
- Fixes Windows focus loss after confirming/canceling process pause/terminate/kill and tmux delete (issue #2242).
- Add a regression test so these panels do not regress to native confirms.

## Test plan
- [ ] On Windows: System page → Processes → pause/terminate/force-kill → confirm and cancel → search box still accepts input and caret blinks
- [ ] Tmux → kill session / kill window → confirm and cancel → inputs remain usable
- [ ] Docker containers/images remove/kill/prune use in-app dialogs (same focus behavior)
- [ ] `node --test --import tsx components/systemManager/systemPanelConfirmDialogRegression.test.ts components/systemManager/tmuxActionFocus.test.ts`

Fixes #2242