### PR TITLE
fix(ssh): retry keyboard-interactive when password removes KI

### DIFF
--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -1395,6 +1395,7 @@ function createAuthPhase() {
     hadPartialSuccess: false,
     passwordAlreadySucceeded: false,
     keyboardInteractiveSuccessCount: 0,
+    retryKeyboardInteractiveFirst: false,
   };
 }
 
@@ -1474,6 +1475,7 @@ function createOrderedStringAuthHandler(order, authPhase, onAuthAttempt) {
   // from an earlier methodsLeft list are intentionally not recorded here.
   const failed = new Set();
   let lastOffered = null;
+  let passwordAttemptSawKeyboardInteractive = false;
 
   const attemptLabel = (method) => {
     if (method === "none") return "none (no credentials)";
@@ -1503,6 +1505,14 @@ function createOrderedStringAuthHandler(order, authPhase, onAuthAttempt) {
       // Server rejected the previous method (or finished a failed factor).
       // Skip the initial methodsLeft===null probe which is not a rejection.
       onAuthAttempt?.(`${attemptLabel(lastOffered)} rejected`);
+      if (
+        lastOffered === "password" &&
+        passwordAttemptSawKeyboardInteractive &&
+        Array.isArray(methodsLeft) &&
+        !methodsLeft.includes("keyboard-interactive")
+      ) {
+        authPhase.retryKeyboardInteractiveFirst = true;
+      }
       failed.add(lastOffered);
     }
 
@@ -1535,6 +1545,11 @@ function createOrderedStringAuthHandler(order, authPhase, onAuthAttempt) {
       }
       attempted.add(method);
       lastOffered = method;
+      if (method === "password") {
+        passwordAttemptSawKeyboardInteractive = Boolean(
+          available && available.includes("keyboard-interactive"),
+        );
+      }
       onAuthAttempt?.(attemptLabel(method));
       return callback(method);
     }

--- a/electron/bridges/sshAuthHelper.kbdInteractive.test.cjs
+++ b/electron/bridges/sshAuthHelper.kbdInteractive.test.cjs
@@ -755,6 +755,21 @@ test("buildAuthHandler prefers password over keyboard-interactive by default", (
   assert.deepEqual(offered, ["none", "password"]);
 });
 
+test("buildAuthHandler skipPasswordMethod retries keyboard-interactive before password", () => {
+  const auth = buildAuthHandler({
+    authMethod: "password",
+    username: "alice",
+    password: "login-password",
+    skipPasswordMethod: true,
+  });
+
+  const offered = [];
+  auth.authHandler(null, null, (method) => offered.push(method));
+  auth.authHandler(["publickey", "password", "keyboard-interactive"], false, (method) => offered.push(method));
+
+  assert.deepEqual(offered, ["none", "keyboard-interactive"]);
+});
+
 test("buildAuthHandler prefers keyboard-interactive after partial success without host MFA flag", () => {
   const auth = buildAuthHandler({
     authMethod: "password",

--- a/electron/bridges/sshBridge.authRetryExit.test.cjs
+++ b/electron/bridges/sshBridge.authRetryExit.test.cjs
@@ -98,6 +98,8 @@ function loadBridgeWithAuthRetryMocks(t, options = {}) {
           eventName === "password-and-keyboard-interactive" ||
           eventName === "password-then-keyboard-interactive" ||
           eventName === "mfa-keyboard-interactive-before-password" ||
+          eventName === "agent-password-removes-keyboard-interactive" ||
+          eventName === "agent-then-keyboard-interactive-after-skip-password" ||
           eventName === "publickey-then-password-and-keyboard-interactive" ||
           eventName === "agent-then-password-and-keyboard-interactive"
         ) {
@@ -122,12 +124,79 @@ function loadBridgeWithAuthRetryMocks(t, options = {}) {
               ? ["password"]
               : eventName === "mfa-keyboard-interactive-before-password"
                 ? ["publickey", "password", "keyboard-interactive"]
-                : eventName === "publickey-then-password-and-keyboard-interactive"
-                  ? ["publickey"]
-                  : eventName === "agent-then-password-and-keyboard-interactive"
-                    ? ["agent"]
-                    : ["keyboard-interactive"];
+                : eventName === "agent-password-removes-keyboard-interactive" ||
+                    eventName === "agent-then-keyboard-interactive-after-skip-password"
+                  ? ["publickey", "password", "keyboard-interactive"]
+                  : eventName === "publickey-then-password-and-keyboard-interactive"
+                    ? ["publickey"]
+                    : eventName === "agent-then-password-and-keyboard-interactive"
+                      ? ["agent"]
+                      : ["keyboard-interactive"];
           const firstInteractive = offerNext(firstMethods, false);
+          if (eventName === "agent-password-removes-keyboard-interactive") {
+            if (firstInteractive !== "agent") {
+              const err = new Error("All configured authentication methods failed");
+              err.level = "client-authentication";
+              this.emit("error", err);
+              return;
+            }
+            const password = offerNext(firstMethods, false);
+            if (password !== "password") {
+              const err = new Error("All configured authentication methods failed");
+              err.level = "client-authentication";
+              this.emit("error", err);
+              return;
+            }
+            offerNext(["publickey"], false);
+            const err = new Error("All configured authentication methods failed");
+            err.level = "client-authentication";
+            this.emit("error", err);
+            return;
+          }
+          if (eventName === "agent-then-keyboard-interactive-after-skip-password") {
+            if (firstInteractive !== "agent") {
+              const err = new Error("All configured authentication methods failed");
+              err.level = "client-authentication";
+              this.emit("error", err);
+              return;
+            }
+            const firstKeyboardInteractive = offerNext(firstMethods, false);
+            if (firstKeyboardInteractive !== "keyboard-interactive") {
+              const err = new Error("All configured authentication methods failed");
+              err.level = "client-authentication";
+              this.emit("error", err);
+              return;
+            }
+            this.emit(
+              "keyboard-interactive",
+              "Login authentication",
+              "",
+              "",
+              [{ prompt: "Password:", echo: false }],
+              (responses) => {
+                this.keyboardInteractiveResponses.push(responses);
+                const secondKeyboardInteractive = offerNext(["keyboard-interactive"], true);
+                if (secondKeyboardInteractive !== "keyboard-interactive") {
+                  const err = new Error("All configured authentication methods failed");
+                  err.level = "client-authentication";
+                  this.emit("error", err);
+                  return;
+                }
+                this.emit(
+                  "keyboard-interactive",
+                  "Keyboard-interactive authentication prompts from server",
+                  "为保障主机安全，请输入二次认证密码，如有疑问，请联系xxx，电话xxx。",
+                  "",
+                  [{ prompt: "Secondary Authentication Password:", echo: false }],
+                  (secondResponses) => {
+                    this.keyboardInteractiveResponses.push(secondResponses);
+                    this.emit("ready");
+                  },
+                );
+              },
+            );
+            return;
+          }
           if (eventName === "mfa-keyboard-interactive-before-password") {
             if (opts._skipPasswordMethod) {
               if (firstInteractive !== "keyboard-interactive") {
@@ -815,6 +884,65 @@ test("terminal SSH certificate auth prefers keyboard-interactive after agent par
   assert.deepEqual(
     MockSSHClient.instances[0].keyboardInteractiveResponses,
     [["secondary-password"]],
+  );
+});
+
+test("terminal SSH certificate auth retries keyboard-interactive when password rejection removes KI", async (t) => {
+  const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: [
+      "agent-password-removes-keyboard-interactive",
+      "agent-then-keyboard-interactive-after-skip-password",
+    ],
+    parseKeyResult: {},
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions: new Map(), electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+  const sender = makeSender();
+  const send = sender.send.bind(sender);
+  sender.send = (channel, payload) => {
+    send(channel, payload);
+    if (channel === "netcatty:keyboard-interactive") {
+      keyboardInteractiveHandler.handleResponse(
+        { sender },
+        {
+          requestId: payload.requestId,
+          responses: ["secondary-password"],
+          cancelled: false,
+        },
+      );
+    }
+  };
+
+  const result = await ipcMain.handlers.get("netcatty:start")(
+    { sender },
+    {
+      sessionId: "certificate-ki-first-retry-session",
+      hostname: "corp-edr.example.com",
+      username: "alice",
+      authMethod: "certificate",
+      certificate: "ssh-rsa-cert-v01@openssh.com AAAA test-cert",
+      privateKey: "INLINE_PRIVATE_KEY",
+      password: "login-password",
+      useSshAgent: false,
+      port: 22,
+      knownHosts: [],
+    },
+  );
+
+  assert.deepEqual(result, { sessionId: "certificate-ki-first-retry-session" });
+  assert.equal(MockSSHClient.instances.length, 2);
+  assert.deepEqual(
+    MockSSHClient.instances[0].authMethodsOffered,
+    ["none", "agent", "password", false],
+  );
+  assert.deepEqual(
+    MockSSHClient.instances[1].authMethodsOffered,
+    ["none", "agent", "keyboard-interactive", "keyboard-interactive"],
+  );
+  assert.deepEqual(
+    MockSSHClient.instances[1].keyboardInteractiveResponses,
+    [["login-password"], ["secondary-password"]],
   );
 });
 

--- a/electron/bridges/sshBridge.authRetryExit.test.cjs
+++ b/electron/bridges/sshBridge.authRetryExit.test.cjs
@@ -579,9 +579,10 @@ test("failed keyboard-interactive retry still offers encrypted default key fallb
   const ipcMain = makeIpcMain();
   bridge.init({ sessions: new Map(), electronModule: {} });
   bridge.registerHandlers(ipcMain);
+  const sender = makeSender(events);
 
   const result = await ipcMain.handlers.get("netcatty:start")(
-    { sender: makeSender(events) },
+    { sender },
     {
       sessionId: "mfa-ki-encrypted-fallback-session",
       hostname: "corp-edr.example.com",
@@ -605,6 +606,13 @@ test("failed keyboard-interactive retry still offers encrypted default key fallb
     ],
   );
   assert.equal(events.includes("passphrase-request"), true);
+  assert.equal(
+    sender.sent.some((message) => (
+      message.channel === "netcatty:exit"
+      && message.payload.sessionId === "mfa-ki-encrypted-fallback-session"
+    )),
+    false,
+  );
 });
 
 test("terminal SSH password-first then keyboard-interactive when both methods are advertised", async (t) => {

--- a/electron/bridges/sshBridge.authRetryExit.test.cjs
+++ b/electron/bridges/sshBridge.authRetryExit.test.cjs
@@ -552,6 +552,61 @@ test("terminal SSH retries keyboard-interactive first when password rejection re
   );
 });
 
+test("failed keyboard-interactive retry still offers encrypted default key fallback", async (t) => {
+  const events = [];
+  const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["mfa-keyboard-interactive-before-password", "auth-error", "ready"],
+    encryptedKeys: [
+      {
+        keyPath: "/Users/test/.ssh/id_ed25519",
+        keyName: "id_ed25519",
+        isEncrypted: true,
+      },
+    ],
+    passphraseResult: {
+      cancelled: false,
+      keys: [
+        {
+          keyPath: "/Users/test/.ssh/id_ed25519",
+          keyName: "id_ed25519",
+          privateKey: "UNLOCKED_PRIVATE_KEY",
+          passphrase: "secret",
+        },
+      ],
+    },
+    onPassphraseRequest: () => events.push("passphrase-request"),
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions: new Map(), electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+
+  const result = await ipcMain.handlers.get("netcatty:start")(
+    { sender: makeSender(events) },
+    {
+      sessionId: "mfa-ki-encrypted-fallback-session",
+      hostname: "corp-edr.example.com",
+      username: "alice",
+      authMethod: "auto",
+      password: "login-password",
+      useSshAgent: false,
+      port: 22,
+      knownHosts: [],
+    },
+  );
+
+  assert.deepEqual(result, { sessionId: "mfa-ki-encrypted-fallback-session" });
+  assert.equal(MockSSHClient.instances.length, 3);
+  assert.deepEqual(
+    MockSSHClient.instances[0].authMethodsOffered,
+    [
+      "none",
+      { type: "password", username: "alice", password: "login-password" },
+      false,
+    ],
+  );
+  assert.equal(events.includes("passphrase-request"), true);
+});
+
 test("terminal SSH password-first then keyboard-interactive when both methods are advertised", async (t) => {
   const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {
     connectEvents: ["password-and-keyboard-interactive"],

--- a/electron/bridges/sshBridge.authRetryExit.test.cjs
+++ b/electron/bridges/sshBridge.authRetryExit.test.cjs
@@ -97,6 +97,7 @@ function loadBridgeWithAuthRetryMocks(t, options = {}) {
           eventName === "excessive-keyboard-interactive" ||
           eventName === "password-and-keyboard-interactive" ||
           eventName === "password-then-keyboard-interactive" ||
+          eventName === "mfa-keyboard-interactive-before-password" ||
           eventName === "publickey-then-password-and-keyboard-interactive" ||
           eventName === "agent-then-password-and-keyboard-interactive"
         ) {
@@ -119,12 +120,68 @@ function loadBridgeWithAuthRetryMocks(t, options = {}) {
             ? ["publickey", "password", "keyboard-interactive"]
             : eventName === "password-then-keyboard-interactive"
               ? ["password"]
-              : eventName === "publickey-then-password-and-keyboard-interactive"
-                ? ["publickey"]
-                : eventName === "agent-then-password-and-keyboard-interactive"
-                  ? ["agent"]
-            : ["keyboard-interactive"];
+              : eventName === "mfa-keyboard-interactive-before-password"
+                ? ["publickey", "password", "keyboard-interactive"]
+                : eventName === "publickey-then-password-and-keyboard-interactive"
+                  ? ["publickey"]
+                  : eventName === "agent-then-password-and-keyboard-interactive"
+                    ? ["agent"]
+                    : ["keyboard-interactive"];
           const firstInteractive = offerNext(firstMethods, false);
+          if (eventName === "mfa-keyboard-interactive-before-password") {
+            if (opts._skipPasswordMethod) {
+              if (firstInteractive !== "keyboard-interactive") {
+                const err = new Error("All configured authentication methods failed");
+                err.level = "client-authentication";
+                this.emit("error", err);
+                return;
+              }
+              this.emit(
+                "keyboard-interactive",
+                "Login authentication",
+                "",
+                "",
+                [{ prompt: "Password:", echo: false }],
+                (responses) => {
+                  this.keyboardInteractiveResponses.push(responses);
+                  const secondInteractive = offerNext(["keyboard-interactive"], true);
+                  if (secondInteractive !== "keyboard-interactive") {
+                    const err = new Error("All configured authentication methods failed");
+                    err.level = "client-authentication";
+                    this.emit("error", err);
+                    return;
+                  }
+                  this.emit(
+                    "keyboard-interactive",
+                    "Keyboard-interactive authentication prompts from server",
+                    "为保障主机安全，请输入二次认证密码，如有疑问，请联系xxx，电话xxx。",
+                    "",
+                    [{ prompt: "Secondary Authentication Password:", echo: false }],
+                    (secondResponses) => {
+                      this.keyboardInteractiveResponses.push(secondResponses);
+                      this.emit("ready");
+                    },
+                  );
+                },
+              );
+              return;
+            }
+            if (firstInteractive?.type === "password") {
+              // Mirrors the live EDR server: after a rejected password attempt,
+              // keyboard-interactive disappears from methodsLeft.
+              offerNext(["publickey"], false);
+              const err = new Error("All configured authentication methods failed");
+              err.level = "client-authentication";
+              this.emit("error", err);
+              return;
+            }
+            if (firstInteractive !== "keyboard-interactive") {
+              const err = new Error("All configured authentication methods failed");
+              err.level = "client-authentication";
+              this.emit("error", err);
+              return;
+            }
+          }
           if (eventName === "password-and-keyboard-interactive") {
             // Password-first: login password method, then KI for secondary factor.
             if (firstInteractive?.type !== "password") {
@@ -436,6 +493,63 @@ test("terminal SSH supports consecutive keyboard-interactive factors (#2150)", a
   assert.equal(promptEvents[0].payload.savedPassword, null);
   assert.equal(promptEvents[0].payload.allowSavePassword, false);
     assert.equal(promptEvents[0].payload.scope, "terminal");
+});
+
+test("terminal SSH retries keyboard-interactive first when password rejection removes KI", async (t) => {
+  const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["mfa-keyboard-interactive-before-password", "mfa-keyboard-interactive-before-password"],
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions: new Map(), electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+  const sender = makeSender();
+  const send = sender.send.bind(sender);
+  sender.send = (channel, payload) => {
+    send(channel, payload);
+    if (channel === "netcatty:keyboard-interactive") {
+      keyboardInteractiveHandler.handleResponse(
+        { sender },
+        {
+          requestId: payload.requestId,
+          responses: ["secondary-password"],
+          cancelled: false,
+        },
+      );
+    }
+  };
+
+  const result = await ipcMain.handlers.get("netcatty:start")(
+    { sender },
+    {
+      sessionId: "mfa-ki-first-session",
+      hostname: "corp-edr.example.com",
+      username: "alice",
+      authMethod: "password",
+      password: "login-password",
+      useSshAgent: false,
+      port: 22,
+      knownHosts: [],
+    },
+  );
+
+  assert.deepEqual(result, { sessionId: "mfa-ki-first-session" });
+  assert.equal(MockSSHClient.instances.length, 2);
+  assert.deepEqual(
+    MockSSHClient.instances[0].authMethodsOffered,
+    [
+      "none",
+      { type: "password", username: "alice", password: "login-password" },
+      false,
+    ],
+  );
+  assert.deepEqual(
+    MockSSHClient.instances[1].authMethodsOffered,
+    ["none", "keyboard-interactive", "keyboard-interactive"],
+  );
+  assert.deepEqual(
+    MockSSHClient.instances[1].keyboardInteractiveResponses,
+    [["login-password"], ["secondary-password"]],
+  );
 });
 
 test("terminal SSH password-first then keyboard-interactive when both methods are advertised", async (t) => {

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -1147,6 +1147,7 @@ async function startSSHSessionWrapper(event, options) {
           return await startSSHSession(event, {
             ...options,
             _skipPasswordMethod: true,
+            _suppressPreShellAuthExit: shouldSuppressInitialAuthExit,
           });
         } catch (retryErr) {
           const isRetryAuthError = isStartAuthError(retryErr);

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -1109,6 +1109,7 @@ async function startSSHSessionWrapper(event, options) {
   let loadedRetryableEncryptedKeys = false;
   let shouldSuppressInitialAuthExit = false;
   const canRetryEncryptedDefaults = canRetryWithEncryptedDefaultKeys(options);
+  const canRetryKeyboardInteractiveFirst = Boolean(options.password && !options._skipPasswordMethod);
   const mayReuseExistingSession = canRetryEncryptedDefaults && canReuseExistingSession(options);
   const loadRetryableEncryptedKeys = async () => {
     const allKeysWithEncrypted = await findAllDefaultPrivateKeysFromHelper({ includeEncrypted: true });
@@ -1119,11 +1120,13 @@ async function startSSHSessionWrapper(event, options) {
 
   if (canRetryEncryptedDefaults && !mayReuseExistingSession) {
     await loadRetryableEncryptedKeys();
-    shouldSuppressInitialAuthExit = retryableEncryptedKeys.length > 0;
+    shouldSuppressInitialAuthExit = retryableEncryptedKeys.length > 0 || canRetryKeyboardInteractiveFirst;
   } else if (mayReuseExistingSession) {
     // Let Copy Tab reuse an authenticated transport without waiting on key
     // discovery. If reuse falls back to a fresh connection and auth fails, the
     // catch path below lazily loads encrypted keys before deciding final failure.
+    shouldSuppressInitialAuthExit = true;
+  } else if (canRetryKeyboardInteractiveFirst) {
     shouldSuppressInitialAuthExit = true;
   }
 
@@ -1136,6 +1139,34 @@ async function startSSHSessionWrapper(event, options) {
     const isAuthError = isStartAuthError(err);
 
     if (isAuthError) {
+      if (canRetryKeyboardInteractiveFirst && err.retryKeyboardInteractiveFirst) {
+        console.log('[SSH] Password auth removed keyboard-interactive; retrying with keyboard-interactive first...');
+        try {
+          return await startSSHSession(event, {
+            ...options,
+            _skipPasswordMethod: true,
+          });
+        } catch (retryErr) {
+          const isRetryAuthError = isStartAuthError(retryErr);
+          if (isRetryAuthError) {
+            const authError = new Error(retryErr.message);
+            authError.level = 'client-authentication';
+            authError.isAuthError = true;
+            if (retryErr.isJumpHostAuthError) {
+              authError.isJumpHostAuthError = true;
+              authError.jumpHostIndex = retryErr.jumpHostIndex;
+              authError.jumpHostLabel = retryErr.jumpHostLabel;
+              authError.jumpHostHostname = retryErr.jumpHostHostname;
+            }
+            throw authError;
+          }
+          const connError = new Error(retryErr.message);
+          connError.level = retryErr.level || 'client-socket';
+          connError.code = retryErr.code;
+          throw connError;
+        }
+      }
+
       // Check if there are encrypted default keys we haven't tried yet
       // Only offer retry if no unlocked keys were provided in this attempt
       if (

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -1139,6 +1139,8 @@ async function startSSHSessionWrapper(event, options) {
     const isAuthError = isStartAuthError(err);
 
     if (isAuthError) {
+      let authErrorSource = err;
+
       if (canRetryKeyboardInteractiveFirst && err.retryKeyboardInteractiveFirst) {
         console.log('[SSH] Password auth removed keyboard-interactive; retrying with keyboard-interactive first...');
         try {
@@ -1149,21 +1151,14 @@ async function startSSHSessionWrapper(event, options) {
         } catch (retryErr) {
           const isRetryAuthError = isStartAuthError(retryErr);
           if (isRetryAuthError) {
-            const authError = new Error(retryErr.message);
-            authError.level = 'client-authentication';
-            authError.isAuthError = true;
-            if (retryErr.isJumpHostAuthError) {
-              authError.isJumpHostAuthError = true;
-              authError.jumpHostIndex = retryErr.jumpHostIndex;
-              authError.jumpHostLabel = retryErr.jumpHostLabel;
-              authError.jumpHostHostname = retryErr.jumpHostHostname;
-            }
-            throw authError;
+            authErrorSource = retryErr;
+            console.log('[SSH] Keyboard-interactive-first retry failed authentication; checking remaining auth fallbacks...');
+          } else {
+            const connError = new Error(retryErr.message);
+            connError.level = retryErr.level || 'client-socket';
+            connError.code = retryErr.code;
+            throw connError;
           }
-          const connError = new Error(retryErr.message);
-          connError.level = retryErr.level || 'client-socket';
-          connError.code = retryErr.code;
-          throw connError;
         }
       }
 
@@ -1171,8 +1166,8 @@ async function startSSHSessionWrapper(event, options) {
       // Only offer retry if no unlocked keys were provided in this attempt
       if (
         canRetryEncryptedDefaults
-        && canFailedHopRetryWithEncryptedDefaultKeys(options, err)
-        && !isStrictAgentAuthFailure(options, err)
+        && canFailedHopRetryWithEncryptedDefaultKeys(options, authErrorSource)
+        && !isStrictAgentAuthFailure(options, authErrorSource)
       ) {
         const encryptedKeys = loadedRetryableEncryptedKeys
           ? retryableEncryptedKeys
@@ -1245,19 +1240,19 @@ async function startSSHSessionWrapper(event, options) {
       }
 
       if (shouldSuppressInitialAuthExit) {
-        sendFinalStartFailureExit(event, options, err);
+        sendFinalStartFailureExit(event, options, authErrorSource);
       }
 
       // Re-throw with a clean error to avoid Electron printing full stack trace
       // The frontend will handle this as a normal auth failure for fallback
-      const authError = new Error(err.message);
+      const authError = new Error(authErrorSource.message);
       authError.level = 'client-authentication';
       authError.isAuthError = true;
-      if (err.isJumpHostAuthError) {
+      if (authErrorSource.isJumpHostAuthError) {
         authError.isJumpHostAuthError = true;
-        authError.jumpHostIndex = err.jumpHostIndex;
-        authError.jumpHostLabel = err.jumpHostLabel;
-        authError.jumpHostHostname = err.jumpHostHostname;
+        authError.jumpHostIndex = authErrorSource.jumpHostIndex;
+        authError.jumpHostLabel = authErrorSource.jumpHostLabel;
+        authError.jumpHostHostname = authErrorSource.jumpHostHostname;
       }
       throw authError;
     }

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -930,7 +930,7 @@ function createStartSessionApi(ctx) {
 
         if (authAgent) {
           const order = ["none", "agent"];
-          if (connectOpts.password) {
+          if (connectOpts.password && !options._skipPasswordMethod) {
             order.push("password");
           }
           // Default key fallback only when this is not password-only (issue #266 / #2079).
@@ -943,6 +943,7 @@ function createStartSessionApi(ctx) {
           // Function form so authPhase.hadPartialSuccess updates for cert/agent
           // first-factor + keyboard-interactive second-factor (#2150).
           connectOpts.authHandler = createOrderedStringAuthHandler(order, authPhase);
+          connectOpts._shouldRetryKeyboardInteractiveFirst = () => Boolean(authPhase.retryKeyboardInteractiveFirst);
           log("Auth order (agent mode)", { order, skipPasswordMethod: !!options._skipPasswordMethod });
         } else {
           // Build dynamic auth handler for fallback support

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -1052,6 +1052,12 @@ function createStartSessionApi(ctx) {
             let firstSuccessfulMethod = null;
             // Track if we've gone through a partialSuccess flow (multi-step auth)
             let hadPartialSuccess = false;
+            // Some EDR servers advertise keyboard-interactive next to password,
+            // then remove it after a rejected password request. The wrapper can
+            // recover by retrying once with the password method omitted so the
+            // login password flows through keyboard-interactive.
+            let passwordAttemptSawKeyboardInteractive = false;
+            let shouldRetryKeyboardInteractiveFirst = false;
 
             connectOpts.authHandler = (methodsLeft, partialSuccess, callback) => {
               log("authHandler called", { methodsLeft, partialSuccess, attemptedMethodIds: Array.from(attemptedMethodIds) });
@@ -1059,6 +1065,17 @@ function createStartSessionApi(ctx) {
               // Log rejection of previous method
               if (lastTriedMethod && !partialSuccess) {
                 sendProgress(totalHops, totalHops, options.hostname, 'auth-attempt', `${lastTriedMethod} rejected`);
+                if (
+                  lastTriedMethod === "password" &&
+                  passwordAttemptSawKeyboardInteractive &&
+                  Array.isArray(methodsLeft) &&
+                  !methodsLeft.includes("keyboard-interactive")
+                ) {
+                  shouldRetryKeyboardInteractiveFirst = true;
+                  log("password rejection removed keyboard-interactive; scheduling KI-first retry", {
+                    methodsLeft,
+                  });
+                }
                 if (lastTriedMethod !== "none") {
                   failedMethodIds.add(lastTriedMethod);
                 }
@@ -1224,6 +1241,7 @@ function createStartSessionApi(ctx) {
                 } else if (method.type === "password") {
                   log("Trying password auth", { id: method.id });
                   sendProgress(totalHops, totalHops, options.hostname, 'auth-attempt', 'password');
+                  passwordAttemptSawKeyboardInteractive = availableMethods.includes("keyboard-interactive");
                   return callback({
                     type: "password",
                     username: connectOpts.username,
@@ -1254,6 +1272,7 @@ function createStartSessionApi(ctx) {
               }
               return lastTriedMethod;
             };
+            connectOpts._shouldRetryKeyboardInteractiveFirst = () => shouldRetryKeyboardInteractiveFirst;
           }
         }
 
@@ -1525,6 +1544,17 @@ function createStartSessionApi(ctx) {
 
             // Clear cached auth method on auth failure so next attempt tries all methods
             if (isAuthError) {
+              if (
+                !options._skipPasswordMethod &&
+                connectOpts.password &&
+                connectOpts._shouldRetryKeyboardInteractiveFirst?.()
+              ) {
+                err.retryKeyboardInteractiveFirst = true;
+                log("auth failure marked for KI-first retry", {
+                  sessionId,
+                  hostname: options.hostname,
+                });
+              }
               clearCachedAuthMethod(connectOpts.username, options.hostname, options.port);
               console.log(`${logPrefix} ${options.hostname} auth failed:`, err.message);
               log("authentication failed", {


### PR DESCRIPTION
## 背景

旧 PR #2217 已经关闭/合并，但 2026-07-15 后续提交 `9a095659 fix(ssh): drop host MFA switch; password-first with automatic KI fallback` 里的最后调整对部分 EDR/二次认证服务器仍然有问题。

现场服务器 `192.168.9.138` 的行为是：初始 `methodsLeft` 同时包含 `password` 和 `keyboard-interactive`，但客户端一旦先尝试 `password` 并被拒绝，下一次服务端只返回 `publickey`，`keyboard-interactive` 已经从 `methodsLeft` 消失。因此 password-first 的自动 KI fallback 没机会触发，最终报 `All configured authentication methods failed`。

## 修复

- 在直连 SSH authHandler 中记录 password 尝试时是否曾经看到 `keyboard-interactive`。
- 如果 password 被拒绝后 `keyboard-interactive` 从服务端方法列表消失，标记该连接需要一次 KI-first 重试。
- wrapper 只自动重试一次，并设置 `_skipPasswordMethod: true`，让登录密码走 keyboard-interactive 自动填第一轮，再正常弹出二次认证密码框。
- 保留普通双方法服务器的默认 password-first 行为。

## 验证

- `node --test electron/bridges/sshAuthHelper.kbdInteractive.test.cjs electron/bridges/sshBridge.authRetryExit.test.cjs`
- `npm run lint -- --quiet`
- `git diff --check`
- 已在真实环境 `192.168.9.138` 观察到 password 失败后自动 KI-first 重试，并触发二次认证弹窗。

Fixes #2150