### PR TITLE
Update Nix release metadata for v1.1.68

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,14 +1,14 @@
 {
-  version = "1.1.67";
+  version = "1.1.68";
 
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-DYE1/TwtKh/cW/mnLZRe4dJjrH3KotlqXDn7FjXOpuk=";
+      hash = "sha256-RpOzHwUfv/6KSqO7vCiUahW/n9V0IcnmBqbOvHkI40E=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-SpAQnUQw366XMjj98XB4vE77g8Seuq78DMSF0tqogV4=";
+      hash = "sha256-ZqPQGw6yDf6c4LUsnrFRQaRZdKp21++xdkdlaFvkBwg=";
     };
   };
 }


### PR DESCRIPTION
## What changed

- update Nix release metadata to v1.1.68
- use the published x64 and ARM64 AppImage hashes

## Why

The release job generated this update successfully, but the automatic direct push was rejected because `main` is protected and requires a pull request.

## Impact

Nix users will receive the published v1.1.68 AppImages with hashes that match the release assets.

## Validation

- Nix metadata test passed
- both hashes match the SHA-256 digests on the published v1.1.68 AppImage assets
- `git diff --check` passed
