### PR TITLE
fix(tabs): close session batches atomically

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -272,6 +272,7 @@ function App({ settings }: { settings: SettingsState }) {
     createSerialSession,
     connectToHost,
     closeSession,
+    closeSessions,
     closeWorkspace,
     updateSessionStatus,
     updateSessionFontSize,
@@ -861,8 +862,8 @@ function App({ settings }: { settings: SettingsState }) {
   // Used by the "Close all / Close others / Close to the right" context-menu
   // actions on tabs (#748).
   const closeTabsBatch = useCallback(
-    async (targetIds: string[]) => { return closeTabsBatchImpl(() => ({ closeLogView, closeSession, closeTabsInFlightRef, closeWorkspace, confirmIfBusyLocalTerminal, logViews, sessions, targetIds, workspaces }), targetIds); },
-    [workspaces, sessions, logViews, confirmIfBusyLocalTerminal, closeWorkspace, closeSession, closeLogView],
+    async (targetIds: string[]) => { return closeTabsBatchImpl(() => ({ closeLogView, closeSessions, closeTabsInFlightRef, closeWorkspace, confirmIfBusyLocalTerminal, logViews, sessions, targetIds, workspaces }), targetIds); },
+    [workspaces, sessions, logViews, confirmIfBusyLocalTerminal, closeWorkspace, closeSessions, closeLogView],
   );
 
   // Shared hotkey action handler - used by both global handler and terminal callback

--- a/application/AppHandlers.closeTabsBatch.test.ts
+++ b/application/AppHandlers.closeTabsBatch.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { closeTabsBatchImpl } from './app/AppHandlers.ts';
+
+test('batch tab close removes standalone sessions in one state update', async () => {
+  const closedSessionBatches: string[][] = [];
+  const probedSessionBatches: string[][] = [];
+  const closeTabsInFlightRef = { current: false };
+  const sessions = [
+    { id: 's1', protocol: 'ssh' },
+    { id: 's2', protocol: 'ssh' },
+    { id: 's3', protocol: 'ssh' },
+  ];
+
+  await closeTabsBatchImpl(
+    () => ({
+      closeLogView: () => {},
+      closeSessions: (sessionIds: string[]) => closedSessionBatches.push(sessionIds),
+      closeTabsInFlightRef,
+      closeWorkspace: () => {},
+      confirmIfBusyLocalTerminal: async (sessionIds: string[]) => {
+        probedSessionBatches.push(sessionIds);
+        return true;
+      },
+      logViews: [],
+      sessions,
+      workspaces: [],
+    }),
+    ['s1', 's2', 's3'],
+  );
+
+  assert.deepEqual(probedSessionBatches, [['s1', 's2', 's3']]);
+  assert.deepEqual(closedSessionBatches, [['s1', 's2', 's3']]);
+  assert.equal(closeTabsInFlightRef.current, false);
+});

--- a/application/app/AppHandlers.ts
+++ b/application/app/AppHandlers.ts
@@ -456,7 +456,7 @@ export async function confirmIfBusyLocalTerminalImpl(getCtx: AppContextGetter, s
 }
 
 export async function closeTabsBatchImpl(getCtx: AppContextGetter, targetIds: string[]) {
-  const { closeLogView, closeSession, closeTabsInFlightRef, closeWorkspace, confirmIfBusyLocalTerminal, logViews, sessions, workspaces } = getCtx();
+  const { closeLogView, closeSessions, closeTabsInFlightRef, closeWorkspace, confirmIfBusyLocalTerminal, logViews, sessions, workspaces } = getCtx();
 {
       if (targetIds.length === 0) return;
       if (closeTabsInFlightRef.current) return;
@@ -479,11 +479,15 @@ export async function closeTabsBatchImpl(getCtx: AppContextGetter, targetIds: st
       try {
         const ok = await confirmIfBusyLocalTerminal(sessionIdsToProbe);
         if (!ok) return;
+        const standaloneSessionIds = targetIds.filter((tabId) => (
+          sessions.some((session) => session.id === tabId)
+        ));
+        if (standaloneSessionIds.length > 0) {
+          closeSessions(standaloneSessionIds);
+        }
         for (const tabId of targetIds) {
           if (workspaces.find((w) => w.id === tabId)) {
             closeWorkspace(tabId);
-          } else if (sessions.find((s) => s.id === tabId)) {
-            closeSession(tabId);
           } else if (logViews.find((lv) => lv.id === tabId)) {
             closeLogView(tabId);
           }

--- a/application/state/sessionWorkspaceDetach.test.ts
+++ b/application/state/sessionWorkspaceDetach.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import type { TerminalSession, Workspace } from "../../domain/models";
 import {
   applyCloseSessionToSessions,
+  closeSessionsState,
   closeSessionWorkspaceLayoutState,
   detachSessionFromWorkspaceState,
   replaceDissolvedWorkspaceTabOrder,
@@ -176,4 +177,41 @@ test("closing the last workspace session does not invent a surviving terminal", 
     }),
     "vault",
   );
+});
+
+test("closing several standalone sessions removes the whole batch", () => {
+  const standaloneSession = (id: string): TerminalSession => ({
+    ...session(id),
+    workspaceId: undefined,
+  });
+
+  const result = closeSessionsState({
+    sessions: [standaloneSession("s1"), standaloneSession("s2"), standaloneSession("s3")],
+    workspaces: [],
+    sessionIds: ["s1", "s2", "s3"],
+    currentActiveTabId: "s1",
+    tabOrder: ["s1", "s2", "s3"],
+  });
+
+  assert.deepEqual(result.sessions, []);
+  assert.deepEqual(result.workspaces, []);
+  assert.equal(result.activeTabId, "vault");
+});
+
+test("closing a subset of standalone sessions keeps tabs outside the batch", () => {
+  const standaloneSession = (id: string): TerminalSession => ({
+    ...session(id),
+    workspaceId: undefined,
+  });
+
+  const result = closeSessionsState({
+    sessions: [standaloneSession("s1"), standaloneSession("s2"), standaloneSession("s3")],
+    workspaces: [],
+    sessionIds: ["s2", "s3"],
+    currentActiveTabId: "s1",
+    tabOrder: ["s1", "s2", "s3"],
+  });
+
+  assert.deepEqual(result.sessions.map((candidate) => candidate.id), ["s1"]);
+  assert.equal(result.activeTabId, undefined);
 });

--- a/application/state/sessionWorkspaceDetach.ts
+++ b/application/state/sessionWorkspaceDetach.ts
@@ -17,6 +17,13 @@ export type CloseSessionWorkspaceLayoutResult = {
   lastRemainingSessionId?: string;
 };
 
+export type CloseSessionsStateResult = {
+  sessions: TerminalSession[];
+  workspaces: Workspace[];
+  tabOrder: string[];
+  activeTabId?: string;
+};
+
 type DetachSessionFromWorkspaceStateOptions = {
   sessions: TerminalSession[];
   workspaces: Workspace[];
@@ -152,6 +159,67 @@ export function resolveActiveTabAfterCloseSession({
   }
 
   return null;
+}
+
+export function closeSessionsState({
+  sessions,
+  workspaces,
+  sessionIds,
+  currentActiveTabId,
+  tabOrder,
+}: {
+  sessions: readonly TerminalSession[];
+  workspaces: readonly Workspace[];
+  sessionIds: readonly string[];
+  currentActiveTabId: string | null;
+  tabOrder: readonly string[];
+}): CloseSessionsStateResult {
+  let nextSessions = [...sessions];
+  let nextWorkspaces = [...workspaces];
+  let nextTabOrder = [...tabOrder];
+  let nextActiveTabId = currentActiveTabId;
+  let resolvedActiveTabId: string | undefined;
+
+  for (const sessionId of new Set(sessionIds)) {
+    const targetSession = nextSessions.find((session) => session.id === sessionId);
+    if (!targetSession) continue;
+
+    const workspaceId = targetSession.workspaceId;
+    const layoutResult = closeSessionWorkspaceLayoutState(
+      nextWorkspaces,
+      workspaceId,
+      sessionId,
+    );
+    nextWorkspaces = layoutResult.workspaces;
+    nextSessions = applyCloseSessionToSessions(nextSessions, sessionId, layoutResult);
+
+    if (layoutResult.dissolvedWorkspaceId && layoutResult.lastRemainingSessionId) {
+      nextTabOrder = replaceDissolvedWorkspaceTabOrder(
+        nextTabOrder,
+        layoutResult.dissolvedWorkspaceId,
+        [layoutResult.lastRemainingSessionId],
+      );
+    }
+
+    const activeTabAfterClose = resolveActiveTabAfterCloseSession({
+      currentActiveTabId: nextActiveTabId,
+      closedSessionId: sessionId,
+      workspaceId,
+      layoutResult,
+      remainingSessions: nextSessions,
+    });
+    if (activeTabAfterClose) {
+      nextActiveTabId = activeTabAfterClose;
+      resolvedActiveTabId = activeTabAfterClose;
+    }
+  }
+
+  return {
+    sessions: nextSessions,
+    workspaces: nextWorkspaces,
+    tabOrder: nextTabOrder,
+    activeTabId: resolvedActiveTabId,
+  };
 }
 
 export function detachSessionFromWorkspaceState({

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -25,11 +25,9 @@ import { clearSessionFontSizeOverride as clearSessionFontSizeOverrideFields } fr
 import { buildOrderedWorkTabIds, reorderWorkTabIds } from '../app/workTabSurface';
 import { activeTabStore } from './activeTabStore';
 import {
-  applyCloseSessionToSessions,
-  closeSessionWorkspaceLayoutState,
+  closeSessionsState,
   detachSessionFromWorkspaceState,
   replaceDissolvedWorkspaceTabOrder,
-  resolveActiveTabAfterCloseSession,
 } from './sessionWorkspaceDetach';
 import {
   createCopiedTerminalSessionClone,
@@ -393,49 +391,27 @@ export const useSessionState = ({
     });
   }, [setActiveTabId]);
 
-  const closeSession = useCallback((sessionId: string, e?: MouseEvent) => {
-    e?.stopPropagation();
-
-    // Compute layout from the latest refs so dissolve/remove cannot desync from
-    // a stale workspaces/sessions render snapshot. Empty workspaces are already
-    // removed by closeSessionWorkspaceLayoutState — do NOT follow up with
-    // closeWorkspace(), which would race and delete remaining terminals that
-    // still briefly carry the old workspaceId.
-    const targetSession = sessionsRef.current.find((session) => session.id === sessionId);
-    const wsId = targetSession?.workspaceId;
-    const layoutResult = closeSessionWorkspaceLayoutState(
-      workspacesRef.current,
-      wsId,
-      sessionId,
-    );
-    const nextSessions = applyCloseSessionToSessions(
-      sessionsRef.current,
-      sessionId,
-      layoutResult,
-    );
-
-    setWorkspaces(layoutResult.workspaces);
-    setSessions(nextSessions);
-
-    if (layoutResult.dissolvedWorkspaceId && layoutResult.lastRemainingSessionId) {
-      setTabOrder((prevTabOrder) => replaceDissolvedWorkspaceTabOrder(
-        prevTabOrder,
-        layoutResult.dissolvedWorkspaceId,
-        [layoutResult.lastRemainingSessionId!],
-      ));
-    }
-
-    const nextActiveTabId = resolveActiveTabAfterCloseSession({
+  const closeSessions = useCallback((sessionIds: string[]) => {
+    const result = closeSessionsState({
+      sessions: sessionsRef.current,
+      workspaces: workspacesRef.current,
+      sessionIds,
       currentActiveTabId: activeTabStore.getActiveTabId(),
-      closedSessionId: sessionId,
-      workspaceId: wsId,
-      layoutResult,
-      remainingSessions: nextSessions,
+      tabOrder: tabOrderRef.current,
     });
-    if (nextActiveTabId) {
-      setActiveTabId(nextActiveTabId);
+
+    setWorkspaces(result.workspaces);
+    setSessions(result.sessions);
+    setTabOrder(result.tabOrder);
+    if (result.activeTabId) {
+      setActiveTabId(result.activeTabId);
     }
   }, [setActiveTabId]);
+
+  const closeSession = useCallback((sessionId: string, e?: MouseEvent) => {
+    e?.stopPropagation();
+    closeSessions([sessionId]);
+  }, [closeSessions]);
 
   const startSessionRename = useCallback((sessionId: string) => {
     setSessions(prevSessions => {
@@ -1156,6 +1132,7 @@ export const useSessionState = ({
     createSerialSession,
     connectToHost,
     closeSession,
+    closeSessions,
     closeWorkspace,
     updateSessionStatus,
     updateSessionFontSize,


### PR DESCRIPTION
## Summary

- close all targeted SSH tabs in one state update
- keep Close All, Close Tabs to the Right, and Close Others from overwriting earlier closes
- use the same close path for single and batch actions
- add regression coverage for full and partial tab batches

Fixes #2256

## Validation

- `node --test --import tsx application/AppHandlers.closeTabsBatch.test.ts application/state/sessionWorkspaceDetach.test.ts`
- `npm run lint`
- `npm run build`