### PR TITLE
fix(ai): preserve UTF-8 across stream chunks

### DIFF
--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -591,6 +591,10 @@ async function streamRequest(url, options, event, requestId, skipTLS) {
 
     const req = lib.request(parsedUrl, reqOpts,
       (res) => {
+        // Decode the response as one continuous UTF-8 stream. Calling
+        // Buffer#toString() on each network chunk corrupts multi-byte
+        // characters when a chunk boundary falls in the middle of one.
+        res.setEncoding("utf8");
         const statusCode = res.statusCode || 0;
         const statusText = res.statusMessage || "";
 

--- a/electron/bridges/aiBridge.test.cjs
+++ b/electron/bridges/aiBridge.test.cjs
@@ -260,8 +260,27 @@ test("command timeout handler accepts one-day timeout values", async () => {
 
 test("streaming AI responses preserve UTF-8 characters split across network chunks", async (t) => {
   const sentEvents = [];
+  let handleStreamEvent;
+  const streamFinished = new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error("Timed out waiting for the AI stream to finish")),
+      2_000,
+    );
+    handleStreamEvent = (channel, payload) => {
+      if (channel === "netcatty:ai:stream:end") {
+        clearTimeout(timeout);
+        resolve();
+      } else if (channel === "netcatty:ai:stream:error") {
+        clearTimeout(timeout);
+        reject(new Error(payload.error));
+      }
+    };
+  });
   const { bridge, restore } = loadBridgeWithMocks({
-    safeSend: (_sender, channel, payload) => sentEvents.push({ channel, payload }),
+    safeSend: (_sender, channel, payload) => {
+      sentEvents.push({ channel, payload });
+      handleStreamEvent(channel, payload);
+    },
   });
   const ipcMain = createIpcMainStub();
   const server = require("node:http").createServer((req, res) => {
@@ -298,13 +317,6 @@ test("streaming AI responses preserve UTF-8 characters split across network chun
       { providers: [{ id: "split-utf8", baseURL }] },
     );
 
-    const ended = new Promise((resolve) => {
-      const poll = () => {
-        if (sentEvents.some(({ channel }) => channel === "netcatty:ai:stream:end")) resolve();
-        else setImmediate(poll);
-      };
-      poll();
-    });
     const result = await ipcMain.handlers.get("netcatty:ai:chat:stream")(
       { sender },
       {
@@ -315,7 +327,7 @@ test("streaming AI responses preserve UTF-8 characters split across network chun
         providerId: "split-utf8",
       },
     );
-    await ended;
+    await streamFinished;
 
     assert.equal(result.ok, true);
     const dataEvent = sentEvents.find(({ channel }) => channel === "netcatty:ai:stream:data");

--- a/electron/bridges/aiBridge.test.cjs
+++ b/electron/bridges/aiBridge.test.cjs
@@ -148,7 +148,9 @@ function loadBridgeWithMocks(options = {}) {
       },
     },
     "./ipcUtils.cjs": {
-      safeSend() {},
+      safeSend: (...args) => {
+        if (typeof options.safeSend === "function") options.safeSend(...args);
+      },
     },
     "./windowManager.cjs": {
       getMainWindow() {
@@ -251,6 +253,73 @@ test("command timeout handler accepts one-day timeout values", async () => {
 
     assert.deepEqual(result, { ok: true });
     assert.deepEqual(calls, [86_400]);
+  } finally {
+    restore();
+  }
+});
+
+test("streaming AI responses preserve UTF-8 characters split across network chunks", async (t) => {
+  const sentEvents = [];
+  const { bridge, restore } = loadBridgeWithMocks({
+    safeSend: (_sender, channel, payload) => sentEvents.push({ channel, payload }),
+  });
+  const ipcMain = createIpcMainStub();
+  const server = require("node:http").createServer((req, res) => {
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      const message = Buffer.from('data: {"choices":[{"delta":{"content":"环境正常"}}]}\n\n');
+      const splitAt = message.indexOf(Buffer.from("环")) + 1;
+      res.write(message.subarray(0, splitAt));
+      setImmediate(() => res.end(message.subarray(splitAt)));
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    const baseURL = `http://127.0.0.1:${address.port}`;
+    const sender = { id: 1 };
+    await ipcMain.handlers.get("netcatty:ai:sync-providers")(
+      { sender },
+      { providers: [{ id: "split-utf8", baseURL }] },
+    );
+
+    const ended = new Promise((resolve) => {
+      const poll = () => {
+        if (sentEvents.some(({ channel }) => channel === "netcatty:ai:stream:end")) resolve();
+        else setImmediate(poll);
+      };
+      poll();
+    });
+    const result = await ipcMain.handlers.get("netcatty:ai:chat:stream")(
+      { sender },
+      {
+        requestId: "split-utf8-request",
+        url: `${baseURL}/v1/chat/completions`,
+        headers: { "content-type": "application/json" },
+        body: '{"stream":true}',
+        providerId: "split-utf8",
+      },
+    );
+    await ended;
+
+    assert.equal(result.ok, true);
+    const dataEvent = sentEvents.find(({ channel }) => channel === "netcatty:ai:stream:data");
+    assert.equal(dataEvent?.payload.data, '{"choices":[{"delta":{"content":"环境正常"}}]}');
   } finally {
     restore();
   }

--- a/electron/bridges/aiBridge.test.cjs
+++ b/electron/bridges/aiBridge.test.cjs
@@ -258,24 +258,9 @@ test("command timeout handler accepts one-day timeout values", async () => {
   }
 });
 
-test("streaming AI responses preserve UTF-8 characters split across network chunks", async (t) => {
+test("streaming AI responses preserve UTF-8 characters split across network chunks", { timeout: 5_000 }, async (t) => {
   const sentEvents = [];
-  let handleStreamEvent;
-  const streamFinished = new Promise((resolve, reject) => {
-    const timeout = setTimeout(
-      () => reject(new Error("Timed out waiting for the AI stream to finish")),
-      2_000,
-    );
-    handleStreamEvent = (channel, payload) => {
-      if (channel === "netcatty:ai:stream:end") {
-        clearTimeout(timeout);
-        resolve();
-      } else if (channel === "netcatty:ai:stream:error") {
-        clearTimeout(timeout);
-        reject(new Error(payload.error));
-      }
-    };
-  });
+  let handleStreamEvent = () => {};
   const { bridge, restore } = loadBridgeWithMocks({
     safeSend: (_sender, channel, payload) => {
       sentEvents.push({ channel, payload });
@@ -316,6 +301,13 @@ test("streaming AI responses preserve UTF-8 characters split across network chun
       { sender },
       { providers: [{ id: "split-utf8", baseURL }] },
     );
+
+    const streamFinished = new Promise((resolve, reject) => {
+      handleStreamEvent = (channel, payload) => {
+        if (channel === "netcatty:ai:stream:end") resolve();
+        else if (channel === "netcatty:ai:stream:error") reject(new Error(payload.error));
+      };
+    });
 
     const result = await ipcMain.handlers.get("netcatty:ai:chat:stream")(
       { sender },


### PR DESCRIPTION
Closes #2260

## Summary
- decode provider responses as a continuous UTF-8 stream
- preserve multi-byte characters when network chunk boundaries split them
- add an end-to-end regression test using a deliberately split Chinese character

## Validation
- `node --test electron/bridges/aiBridge.test.cjs`
- `npm run lint`
- `npm run build`
- `npm test` (5659 passed, 7 skipped, 1 unrelated pre-existing SSH auth fallback test failed: `failed keyboard-interactive retry still offers encrypted default key fallback`)
- the unrelated failing test was rerun directly and remains outside the changed AI streaming path