### PR TITLE
feat: auto-close idle agent sessions

### DIFF
--- a/application/i18n/locales/en/ai.ts
+++ b/application/i18n/locales/en/ai.ts
@@ -234,6 +234,8 @@ export const enAiMessages: Messages = {
   'ai.externalMcp.idleTimeout': 'Idle timeout',
   'ai.externalMcp.idleTimeout.description': 'In temporary mode, disable External MCP after this many minutes with no MCP operations.',
   'ai.externalMcp.idleTimeout.minutes': 'min',
+  'ai.externalMcp.sessionIdleTimeout': 'Opened session idle timeout',
+  'ai.externalMcp.sessionIdleTimeout.description': 'Automatically close sessions opened by an AI after this many minutes without terminal or file activity.',
   'ai.externalMcp.usage.title': 'How to use',
   'ai.externalMcp.usage.keepRunning': '1. Turn on External MCP and keep Netcatty running.',
   'ai.externalMcp.usage.localhost': '2. Clients connect via the local launcher (127.0.0.1 only). Discovery is removed when you disable the switch.',

--- a/application/i18n/locales/ru/ai.ts
+++ b/application/i18n/locales/ru/ai.ts
@@ -202,6 +202,8 @@ export const ruAiMessages: Messages = {
   'ai.externalMcp.idleTimeout': 'Таймаут простоя',
   'ai.externalMcp.idleTimeout.description': 'В временном режиме отключить External MCP после указанного числа минут без MCP-операций.',
   'ai.externalMcp.idleTimeout.minutes': 'мин',
+  'ai.externalMcp.sessionIdleTimeout': 'Тайм-аут открытого сеанса',
+  'ai.externalMcp.sessionIdleTimeout.description': 'Автоматически закрывать сеансы, открытые ИИ, после указанного числа минут без операций терминала или файлов.',
   'ai.externalMcp.usage.title': 'Как пользоваться',
   'ai.externalMcp.usage.keepRunning': '1. Включите External MCP и держите Netcatty запущенным.',
   'ai.externalMcp.usage.localhost': '2. Клиенты подключаются через локальный launcher (только 127.0.0.1). Discovery удаляется при отключении.',

--- a/application/i18n/locales/zh-CN/ai.ts
+++ b/application/i18n/locales/zh-CN/ai.ts
@@ -234,6 +234,8 @@ export const zhCNAiMessages: Messages = {
   'ai.externalMcp.idleTimeout': '空闲超时',
   'ai.externalMcp.idleTimeout.description': '临时模式下，若超过该分钟数没有 MCP 操作，将自动关闭对外 MCP。',
   'ai.externalMcp.idleTimeout.minutes': '分钟',
+  'ai.externalMcp.sessionIdleTimeout': '已打开会话空闲超时',
+  'ai.externalMcp.sessionIdleTimeout.description': 'AI 打开的会话若超过该分钟数没有终端或文件操作，将自动关闭。',
   'ai.externalMcp.usage.title': '使用说明',
   'ai.externalMcp.usage.keepRunning': '1. 打开对外 MCP 开关，并保持 Netcatty 运行。',
   'ai.externalMcp.usage.localhost': '2. 客户端通过本地 launcher 连接（仅 127.0.0.1）。关闭开关后会删除 discovery。',

--- a/application/i18n/locales/zh-TW/ai.ts
+++ b/application/i18n/locales/zh-TW/ai.ts
@@ -233,6 +233,8 @@ export const zhTWAiMessages: Messages = {
   'ai.externalMcp.idleTimeout': '閒置逾時',
   'ai.externalMcp.idleTimeout.description': '暫時模式下，若超過該分鐘數沒有 MCP 操作，將自動關閉對外 MCP。',
   'ai.externalMcp.idleTimeout.minutes': '分鐘',
+  'ai.externalMcp.sessionIdleTimeout': '已開啟工作階段閒置逾時',
+  'ai.externalMcp.sessionIdleTimeout.description': 'AI 開啟的工作階段若超過該分鐘數沒有終端或檔案操作，將自動關閉。',
   'ai.externalMcp.usage.title': '使用說明',
   'ai.externalMcp.usage.keepRunning': '1. 開啟對外 MCP 開關，並保持 Netcatty 執行。',
   'ai.externalMcp.usage.localhost': '2. 用戶端透過本機 launcher 連線（僅 127.0.0.1）。關閉開關後會刪除 discovery。',

--- a/application/state/useExternalMcpToggleState.test.ts
+++ b/application/state/useExternalMcpToggleState.test.ts
@@ -4,6 +4,7 @@ import {
   createExternalMcpStartupSyncPlan,
   normalizeExternalMcpIdleTimeoutMinutes,
   normalizeExternalMcpMode,
+  normalizeSessionIdleTimeoutMinutes,
   shouldStartExternalMcpOnStartup,
 } from './useExternalMcpToggleState.ts';
 
@@ -14,6 +15,8 @@ describe('useExternalMcpToggleState helpers', () => {
     assert.equal(normalizeExternalMcpIdleTimeoutMinutes(null), 10);
     assert.equal(normalizeExternalMcpIdleTimeoutMinutes(0), 1);
     assert.equal(normalizeExternalMcpIdleTimeoutMinutes(99999), 24 * 60);
+    assert.equal(normalizeSessionIdleTimeoutMinutes(null), 30);
+    assert.equal(normalizeSessionIdleTimeoutMinutes(0), 1);
   });
 
   it('only starts on launch for persistent+enabled', () => {
@@ -27,11 +30,13 @@ describe('useExternalMcpToggleState helpers', () => {
       enabled: true,
       mode: 'temporary',
       idleTimeoutMinutes: 15,
+      sessionIdleTimeoutMinutes: 30,
     });
     assert.equal(plan.runtimeEnabled, false);
     assert.equal(plan.storedEnabled, false);
     assert.equal(plan.shouldPersistStoredEnabled, true);
     assert.equal(plan.config.idleTimeoutMinutes, 15);
+    assert.equal(plan.config.sessionIdleTimeoutMinutes, 30);
   });
 
   it('startup sync plan keeps persistent enabled', () => {
@@ -39,6 +44,7 @@ describe('useExternalMcpToggleState helpers', () => {
       enabled: true,
       mode: 'persistent',
       idleTimeoutMinutes: 20,
+      sessionIdleTimeoutMinutes: 45,
     });
     assert.equal(plan.runtimeEnabled, true);
     assert.equal(plan.storedEnabled, true);

--- a/application/state/useExternalMcpToggleState.ts
+++ b/application/state/useExternalMcpToggleState.ts
@@ -3,6 +3,7 @@ import {
   STORAGE_KEY_AI_EXTERNAL_MCP_ENABLED,
   STORAGE_KEY_AI_EXTERNAL_MCP_IDLE_TIMEOUT_MINUTES,
   STORAGE_KEY_AI_EXTERNAL_MCP_MODE,
+  STORAGE_KEY_AI_SESSION_IDLE_TIMEOUT_MINUTES,
 } from '../../infrastructure/config/storageKeys';
 import { localStorageAdapter } from '../../infrastructure/persistence/localStorageAdapter';
 import { netcattyBridge } from '../../infrastructure/services/netcattyBridge';
@@ -13,10 +14,12 @@ export type ExternalMcpMode = 'temporary' | 'persistent';
 const DEFAULT_EXTERNAL_MCP_IDLE_TIMEOUT_MINUTES = 10;
 const MIN_EXTERNAL_MCP_IDLE_TIMEOUT_MINUTES = 1;
 const MAX_EXTERNAL_MCP_IDLE_TIMEOUT_MINUTES = 24 * 60;
+const DEFAULT_SESSION_IDLE_TIMEOUT_MINUTES = 30;
 
 type ExternalMcpConfig = {
   mode: ExternalMcpMode;
   idleTimeoutMinutes: number;
+  sessionIdleTimeoutMinutes: number;
 };
 
 type ExternalMcpBridge = {
@@ -61,6 +64,23 @@ export function readExternalMcpIdleTimeoutMinutes(): number {
   );
 }
 
+export function normalizeSessionIdleTimeoutMinutes(value: number | null): number {
+  if (!Number.isFinite(value)) return DEFAULT_SESSION_IDLE_TIMEOUT_MINUTES;
+  return Math.min(
+    MAX_EXTERNAL_MCP_IDLE_TIMEOUT_MINUTES,
+    Math.max(
+      MIN_EXTERNAL_MCP_IDLE_TIMEOUT_MINUTES,
+      Math.round(value ?? DEFAULT_SESSION_IDLE_TIMEOUT_MINUTES),
+    ),
+  );
+}
+
+export function readSessionIdleTimeoutMinutes(): number {
+  return normalizeSessionIdleTimeoutMinutes(
+    localStorageAdapter.readNumber(STORAGE_KEY_AI_SESSION_IDLE_TIMEOUT_MINUTES),
+  );
+}
+
 export function shouldStartExternalMcpOnStartup({
   enabled,
   mode,
@@ -82,10 +102,12 @@ export function createExternalMcpStartupSyncPlan({
   enabled,
   mode,
   idleTimeoutMinutes,
+  sessionIdleTimeoutMinutes,
 }: {
   enabled: boolean;
   mode: ExternalMcpMode;
   idleTimeoutMinutes: number;
+  sessionIdleTimeoutMinutes: number;
 }): ExternalMcpStartupSyncPlan {
   const runtimeEnabled = shouldStartExternalMcpOnStartup({ enabled, mode });
   const storedEnabled = runtimeEnabled;
@@ -93,6 +115,7 @@ export function createExternalMcpStartupSyncPlan({
     config: {
       mode,
       idleTimeoutMinutes,
+      sessionIdleTimeoutMinutes,
     },
     runtimeEnabled,
     storedEnabled,
@@ -105,6 +128,7 @@ export function readExternalMcpStartupSyncPlan(): ExternalMcpStartupSyncPlan {
     enabled: readExternalMcpStoredEnabled(),
     mode: readExternalMcpMode(),
     idleTimeoutMinutes: readExternalMcpIdleTimeoutMinutes(),
+    sessionIdleTimeoutMinutes: readSessionIdleTimeoutMinutes(),
   });
 }
 
@@ -112,6 +136,7 @@ export function syncExternalMcpConfig(bridge: ExternalMcpBridge | undefined = ne
   void bridge?.externalMcpSetConfig?.({
     mode: readExternalMcpMode(),
     idleTimeoutMinutes: readExternalMcpIdleTimeoutMinutes(),
+    sessionIdleTimeoutMinutes: readSessionIdleTimeoutMinutes(),
   });
 }
 

--- a/components/settings/tabs/ai/ExternalMcpCard.tsx
+++ b/components/settings/tabs/ai/ExternalMcpCard.tsx
@@ -4,14 +4,17 @@ import { useI18n } from "../../../../application/i18n/I18nProvider";
 import {
   normalizeExternalMcpIdleTimeoutMinutes,
   normalizeExternalMcpMode,
+  normalizeSessionIdleTimeoutMinutes,
   readExternalMcpIdleTimeoutMinutes,
   readExternalMcpMode,
+  readSessionIdleTimeoutMinutes,
   type ExternalMcpMode,
   useExternalMcpToggleState,
 } from "../../../../application/state/useExternalMcpToggleState";
 import {
   STORAGE_KEY_AI_EXTERNAL_MCP_IDLE_TIMEOUT_MINUTES,
   STORAGE_KEY_AI_EXTERNAL_MCP_MODE,
+  STORAGE_KEY_AI_SESSION_IDLE_TIMEOUT_MINUTES,
 } from "../../../../infrastructure/config/storageKeys";
 import { localStorageAdapter } from "../../../../infrastructure/persistence/localStorageAdapter";
 import { emitAIStateChanged } from "../../../../application/state/aiStateEvents";
@@ -94,6 +97,7 @@ type ExternalMcpStatus = {
   exposedSessionCount?: number;
   mode?: ExternalMcpMode;
   idleTimeoutMinutes?: number;
+  sessionIdleTimeoutMinutes?: number;
   permissionMode?: string;
   error?: string | null;
 };
@@ -295,6 +299,7 @@ export const ExternalMcpCard: React.FC = () => {
   const { enabled, setEnabled } = useExternalMcpToggleState();
   const [mode, setModeRaw] = useState<ExternalMcpMode>(() => readExternalMcpMode());
   const [idleTimeoutMinutes, setIdleTimeoutRaw] = useState<number>(() => readExternalMcpIdleTimeoutMinutes());
+  const [sessionIdleTimeoutMinutes, setSessionIdleTimeoutRaw] = useState<number>(() => readSessionIdleTimeoutMinutes());
   const [status, setStatus] = useState<ExternalMcpStatus | null>(null);
   const [selectedClient, setSelectedClient] = useState<ExternalMcpClient>("codex");
   const [codexStatus, setCodexStatus] = useState<ClientSetupStatus | null>(null);
@@ -308,10 +313,11 @@ export const ExternalMcpCard: React.FC = () => {
   const [actionMessage, setActionMessage] = useState<{ tone: "error" | "warning" | "success"; text: string } | null>(null);
   const bridgeUnavailableMessage = t("ai.externalMcp.bridgeUnavailable");
 
-  const pushConfig = useCallback((nextMode: ExternalMcpMode, nextIdle: number) => {
+  const pushConfig = useCallback((nextMode: ExternalMcpMode, nextIdle: number, nextSessionIdle: number) => {
     void getBridge()?.externalMcpSetConfig?.({
       mode: nextMode,
       idleTimeoutMinutes: nextIdle,
+      sessionIdleTimeoutMinutes: nextSessionIdle,
     });
   }, []);
 
@@ -320,16 +326,24 @@ export const ExternalMcpCard: React.FC = () => {
     setModeRaw(normalized);
     localStorageAdapter.writeString(STORAGE_KEY_AI_EXTERNAL_MCP_MODE, normalized);
     emitAIStateChanged(STORAGE_KEY_AI_EXTERNAL_MCP_MODE);
-    pushConfig(normalized, idleTimeoutMinutes);
-  }, [idleTimeoutMinutes, pushConfig]);
+    pushConfig(normalized, idleTimeoutMinutes, sessionIdleTimeoutMinutes);
+  }, [idleTimeoutMinutes, pushConfig, sessionIdleTimeoutMinutes]);
 
   const setIdleTimeoutMinutes = useCallback((minutes: number) => {
     const normalized = normalizeExternalMcpIdleTimeoutMinutes(minutes);
     setIdleTimeoutRaw(normalized);
     localStorageAdapter.writeNumber(STORAGE_KEY_AI_EXTERNAL_MCP_IDLE_TIMEOUT_MINUTES, normalized);
     emitAIStateChanged(STORAGE_KEY_AI_EXTERNAL_MCP_IDLE_TIMEOUT_MINUTES);
-    pushConfig(mode, normalized);
-  }, [mode, pushConfig]);
+    pushConfig(mode, normalized, sessionIdleTimeoutMinutes);
+  }, [mode, pushConfig, sessionIdleTimeoutMinutes]);
+
+  const setSessionIdleTimeoutMinutes = useCallback((minutes: number) => {
+    const normalized = normalizeSessionIdleTimeoutMinutes(minutes);
+    setSessionIdleTimeoutRaw(normalized);
+    localStorageAdapter.writeNumber(STORAGE_KEY_AI_SESSION_IDLE_TIMEOUT_MINUTES, normalized);
+    emitAIStateChanged(STORAGE_KEY_AI_SESSION_IDLE_TIMEOUT_MINUTES);
+    pushConfig(mode, idleTimeoutMinutes, normalized);
+  }, [idleTimeoutMinutes, mode, pushConfig]);
 
   const refreshStatus = useCallback(async (options?: { quiet?: boolean; clients?: boolean }) => {
     const bridge = getBridge();
@@ -409,7 +423,7 @@ export const ExternalMcpCard: React.FC = () => {
   }, [enabled, refreshStatus]);
 
   useEffect(() => {
-    pushConfig(mode, idleTimeoutMinutes);
+    pushConfig(mode, idleTimeoutMinutes, sessionIdleTimeoutMinutes);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps -- sync stored config once on mount
 
   const bridgeStatusView = useMemo(() => getBridgeStatusView(status, enabled), [enabled, status]);
@@ -705,6 +719,27 @@ export const ExternalMcpCard: React.FC = () => {
             </div>
           </div>
         ) : null}
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <div className="text-sm font-medium">{t("ai.externalMcp.sessionIdleTimeout")}</div>
+            <div className="text-xs text-muted-foreground">{t("ai.externalMcp.sessionIdleTimeout.description")}</div>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <input
+              type="number"
+              min={1}
+              max={24 * 60}
+              value={sessionIdleTimeoutMinutes}
+              onChange={(event) => {
+                const minutes = Number.parseInt(event.currentTarget.value, 10);
+                if (!Number.isFinite(minutes)) return;
+                setSessionIdleTimeoutMinutes(minutes);
+              }}
+              className="w-20 rounded-md border border-border/60 bg-background px-2 py-1 text-sm"
+            />
+            <span className="text-xs text-muted-foreground">{t("ai.externalMcp.idleTimeout.minutes")}</span>
+          </div>
+        </div>
       </div>
 
       <div className="space-y-2">

--- a/components/settings/tabs/ai/types.ts
+++ b/components/settings/tabs/ai/types.ts
@@ -128,6 +128,7 @@ export interface NetcattyAiBridge {
   externalMcpSetConfig?: (config: {
     mode?: 'temporary' | 'persistent';
     idleTimeoutMinutes?: number;
+    sessionIdleTimeoutMinutes?: number;
   }) => Promise<Record<string, unknown>>;
   externalMcpCodexGetStatus?: () => Promise<Record<string, unknown>>;
   externalMcpCodexAdd?: () => Promise<Record<string, unknown>>;

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -885,10 +885,15 @@ function cleanup() {
   mcpServerBridge.cleanup();
 }
 
+function reportOpenedSessionActivity(event) {
+  return mcpServerBridge.reportOpenedSessionActivity?.(event) ?? false;
+}
+
 module.exports = {
   init,
   registerHandlers,
   cleanup,
+  reportOpenedSessionActivity,
   buildExternalAgentSystemContext,
   buildExternalAgentContextualPrompt,
   getExternalMcpController: () => externalMcpController,

--- a/electron/bridges/emitTerminalSessionData.cjs
+++ b/electron/bridges/emitTerminalSessionData.cjs
@@ -9,6 +9,7 @@ const {
 
 let getSession = null;
 let outputChannel = null;
+let onSessionActivity = null;
 /** @type {Set<(sessionId: string, data: string) => void>} */
 const dataTaps = new Set();
 const emitPerfLogStateBySession = new Map();
@@ -16,6 +17,9 @@ const emitPerfLogStateBySession = new Map();
 function configureTerminalSessionDataEmitter(options = {}) {
   getSession = typeof options.getSession === "function" ? options.getSession : null;
   outputChannel = options.outputChannel || null;
+  onSessionActivity = typeof options.onSessionActivity === "function"
+    ? options.onSessionActivity
+    : null;
 }
 
 function addTerminalDataTap(listener) {
@@ -72,6 +76,13 @@ function getEmitPerfLogDetails(sessionId, terminalPerf, options = {}) {
 }
 
 function emitTerminalSessionData(contents, sessionId, data, options = {}) {
+  if (sessionId && data && onSessionActivity) {
+    try {
+      onSessionActivity({ sessionId, phase: "touch" });
+    } catch {
+      // Session activity tracking is best-effort and must not break output.
+    }
+  }
   if (getSession && sessionId && data) {
     const session = getSession(sessionId);
     if (session) {

--- a/electron/bridges/emitTerminalSessionData.test.cjs
+++ b/electron/bridges/emitTerminalSessionData.test.cjs
@@ -88,3 +88,19 @@ test("emitTerminalSessionData forwards terminal output metadata", () => {
   ]);
   configureTerminalSessionDataEmitter({});
 });
+
+test("emitTerminalSessionData reports terminal output as session activity", () => {
+  const activity = [];
+  configureTerminalSessionDataEmitter({
+    getSession: () => null,
+    outputChannel: { send: () => true },
+    onSessionActivity: (event) => activity.push(event),
+  });
+
+  emitTerminalSessionData(null, "session-activity", "output");
+
+  assert.deepEqual(activity, [
+    { sessionId: "session-activity", phase: "touch" },
+  ]);
+  configureTerminalSessionDataEmitter({});
+});

--- a/electron/bridges/externalMcpController.cjs
+++ b/electron/bridges/externalMcpController.cjs
@@ -15,6 +15,10 @@ const {
 const { createExternalMcpCodexSetup } = require("./externalMcp/codexSetup.cjs");
 const { createExternalMcpClaudeSetup } = require("./externalMcp/claudeSetup.cjs");
 const { createExternalMcpGrokSetup } = require("./externalMcp/grokSetup.cjs");
+const {
+  DEFAULT_SESSION_IDLE_TIMEOUT_MINUTES,
+  normalizeSessionIdleTimeoutMinutes,
+} = require("./mcpServerBridge/sessionIdleManager.cjs");
 
 const EXTERNAL_MCP_MODE_TEMPORARY = "temporary";
 const EXTERNAL_MCP_MODE_PERSISTENT = "persistent";
@@ -60,6 +64,7 @@ function createExternalMcpController(options = {}) {
   let error = null;
   let mode = EXTERNAL_MCP_MODE_TEMPORARY;
   let idleTimeoutMinutes = DEFAULT_IDLE_TIMEOUT_MINUTES;
+  let sessionIdleTimeoutMinutes = DEFAULT_SESSION_IDLE_TIMEOUT_MINUTES;
   let lastActivityAt = null;
   let idleExpiresAt = null;
   let idleTimer = null;
@@ -145,6 +150,7 @@ function createExternalMcpController(options = {}) {
       exposedSessionCount: getExposedSessionCount(),
       mode,
       idleTimeoutMinutes,
+      sessionIdleTimeoutMinutes,
       lastActivityAt,
       idleExpiresAt,
       permissionMode: bridge?.getPermissionMode?.() || "confirm",
@@ -378,11 +384,16 @@ function createExternalMcpController(options = {}) {
     const nextIdleTimeoutMinutes = config.idleTimeoutMinutes == null
       ? idleTimeoutMinutes
       : normalizeIdleTimeoutMinutes(config.idleTimeoutMinutes);
+    const nextSessionIdleTimeoutMinutes = config.sessionIdleTimeoutMinutes == null
+      ? sessionIdleTimeoutMinutes
+      : normalizeSessionIdleTimeoutMinutes(config.sessionIdleTimeoutMinutes);
     const modeChanged = nextMode !== mode;
     const timeoutChanged = nextIdleTimeoutMinutes !== idleTimeoutMinutes;
 
     mode = nextMode;
     idleTimeoutMinutes = nextIdleTimeoutMinutes;
+    sessionIdleTimeoutMinutes = nextSessionIdleTimeoutMinutes;
+    getBridge()?.setSessionIdleTimeoutMinutes?.(sessionIdleTimeoutMinutes);
 
     if ((modeChanged || timeoutChanged) && enabled && state === "running") {
       lastActivityAt = getNow();

--- a/electron/bridges/externalMcpController.test.cjs
+++ b/electron/bridges/externalMcpController.test.cjs
@@ -13,6 +13,7 @@ const {
 
 function createFakeBridge({ port = 45555, token = "tok-1" } = {}) {
   const scoped = new Map();
+  const sessionIdleTimeouts = [];
   return {
     getOrCreateHost: async () => port,
     issueExternalMcpAuthToken: () => token,
@@ -39,7 +40,9 @@ function createFakeBridge({ port = 45555, token = "tok-1" } = {}) {
     setChatSessionCancelled: () => {},
     clearPendingApprovals: () => {},
     disconnectExternalMcpClients: () => {},
+    setSessionIdleTimeoutMinutes: (minutes) => sessionIdleTimeouts.push(minutes),
     _scoped: scoped,
+    _sessionIdleTimeouts: sessionIdleTimeouts,
   };
 }
 
@@ -165,6 +168,14 @@ describe("externalMcpController", () => {
     await controller.setEnabled(true);
     assert.equal(scheduled, 0);
     assert.equal(controller.getStatus().mode, "persistent");
+  });
+
+  it("syncs the opened-session idle timeout to the MCP bridge", () => {
+    const { controller, bridge } = createController();
+    const status = controller.setConfig({ sessionIdleTimeoutMinutes: 45 });
+
+    assert.equal(status.sessionIdleTimeoutMinutes, 45);
+    assert.deepEqual(bridge._sessionIdleTimeouts, [45]);
   });
 
   it("serializes overlapping enable/disable so final enable recovers", async () => {

--- a/electron/bridges/mcpServerBridge.cjs
+++ b/electron/bridges/mcpServerBridge.cjs
@@ -1113,8 +1113,7 @@ function setVaultAgentInvoker(fn) {
 let sessionService = null;
 const sessionIdleManager = createSessionIdleManager({
   onIdle: async ({ chatSessionId, sessionId }) => {
-    const hasWorkerJob = Array.from(workerBackgroundJobs.values())
-      .some((job) => job?.sessionId === sessionId);
+    const hasWorkerJob = await hasActiveWorkerJobForTerminalSession(sessionId);
     if (activeSessionExecutions.has(sessionId) || hasWorkerJob) {
       sessionIdleManager.resume(sessionId);
       return;
@@ -1151,7 +1150,13 @@ sessionService = createSessionService({
   },
   afterClose: (params = {}, outcome = {}) => {
     endTerminalSessionClose(params.sessionId);
-    if (!outcome.closed) sessionIdleManager.resume(params.sessionId);
+    if (outcome.closed) return;
+    if (outcome.notFound) {
+      sessionIdleManager.forgetSession(params.sessionId);
+      openedSessionOwnership.forgetSession(params.sessionId);
+      return;
+    }
+    sessionIdleManager.resume(params.sessionId);
   },
   onClosed: async (sessionId) => {
     await settleBackgroundJobsForTerminalSession(sessionId);
@@ -1438,6 +1443,31 @@ async function handleWorkerJobStop(params = {}) {
   return result;
 }
 
+async function hasActiveWorkerJobForTerminalSession(sessionId) {
+  const matchingJobs = Array.from(workerBackgroundJobs.entries())
+    .filter(([, job]) => job?.sessionId === sessionId);
+  for (const [jobId, job] of matchingJobs) {
+    if (!terminalWorkerManager?.request) return true;
+    try {
+      const result = await terminalWorkerManager.request("netcatty:ai:jobPoll", {
+        jobId,
+        sessionId,
+        chatSessionId: job.chatSessionId || null,
+        offset: 0,
+      }, {});
+      if (result?.completed || (result?.ok === false && /not found/i.test(result?.error || ""))) {
+        workerBackgroundJobs.delete(jobId);
+        continue;
+      }
+      return true;
+    } catch {
+      // A transient worker failure should not close a possibly active session.
+      return true;
+    }
+  }
+  return false;
+}
+
 function cancelWorkerBackgroundJobsForSession(chatSessionId) {
   if (!chatSessionId) return;
   for (const pendingStarts of pendingWorkerJobStarts.values()) {
@@ -1581,6 +1611,18 @@ async function dispatch(method, params) {
     pendingSessionWriteApprovals.set(sessionWriteLockId, method);
   }
 
+  const tracksSessionActivity = Boolean(
+    params?.sessionId
+    && (
+      capability?.id === "terminal.execute"
+      || capability?.id === "terminal.start"
+      || capability?.id?.startsWith("sftp.")
+    )
+  );
+  const activityStarted = tracksSessionActivity
+    ? sessionIdleManager.beginActivity(params?.chatSessionId, params.sessionId)
+    : false;
+
   try {
     // Confirm mode: request user approval for write operations.
     // netcatty/jobStop bypasses approval — it's a stop/cancel action that
@@ -1611,37 +1653,23 @@ async function dispatch(method, params) {
     if (!handler) {
       throw new Error(`Unknown method: ${method}`);
     }
-    const tracksSessionActivity = Boolean(
-      params?.sessionId
-      && (
-        capability?.id === "terminal.execute"
-        || capability?.id === "terminal.start"
-        || capability?.id?.startsWith("sftp.")
-      )
-    );
-    const activityStarted = tracksSessionActivity
-      ? sessionIdleManager.beginActivity(params?.chatSessionId, params.sessionId)
-      : false;
-    try {
-      if (capability?.id === "terminal.execute" && params?.sessionId && !sessions?.get?.(params.sessionId)) {
-        return await handleWorkerTerminalExec(params);
-      }
-      if (capability?.id === "terminal.start" && params?.sessionId && !sessions?.get?.(params.sessionId)) {
-        return await handleWorkerJobStart(params);
-      }
-      if (capability?.id === "terminal.poll" && workerBackgroundJobs.has(params?.jobId)) {
-        return await handleWorkerJobPoll(params);
-      }
-      if (capability?.id === "terminal.stop" && workerBackgroundJobs.has(params?.jobId)) {
-        return await handleWorkerJobStop(params);
-      }
-      return await handler(params);
-    } finally {
-      if (activityStarted) {
-        sessionIdleManager.endActivity(params?.chatSessionId, params.sessionId);
-      }
+    if (capability?.id === "terminal.execute" && params?.sessionId && !sessions?.get?.(params.sessionId)) {
+      return await handleWorkerTerminalExec(params);
     }
+    if (capability?.id === "terminal.start" && params?.sessionId && !sessions?.get?.(params.sessionId)) {
+      return await handleWorkerJobStart(params);
+    }
+    if (capability?.id === "terminal.poll" && workerBackgroundJobs.has(params?.jobId)) {
+      return await handleWorkerJobPoll(params);
+    }
+    if (capability?.id === "terminal.stop" && workerBackgroundJobs.has(params?.jobId)) {
+      return await handleWorkerJobStop(params);
+    }
+    return await handler(params);
   } finally {
+    if (activityStarted) {
+      sessionIdleManager.endActivity(params?.chatSessionId, params.sessionId);
+    }
     if (sessionWriteLockId) {
       pendingSessionWriteApprovals.delete(sessionWriteLockId);
     }
@@ -1914,6 +1942,7 @@ module.exports = {
   cancelPtyExecsForSession,
   cancelWorkerBackgroundJobsForSession,
   cancelWorkerBackgroundJobsForTerminalSession,
+  hasActiveWorkerJobForTerminalSession,
   cancelSftpOpsForSession,
   getSessionMeta,
   cleanupScopedMetadata,

--- a/electron/bridges/mcpServerBridge.cjs
+++ b/electron/bridges/mcpServerBridge.cjs
@@ -1114,6 +1114,9 @@ let sessionService = null;
 const sessionIdleManager = createSessionIdleManager({
   onIdle: async ({ chatSessionId, sessionId }) => {
     const hasWorkerJob = await hasActiveWorkerJobForTerminalSession(sessionId);
+    if (sessionIdleManager.hasActivity(sessionId)) {
+      return;
+    }
     if (activeSessionExecutions.has(sessionId) || hasWorkerJob) {
       sessionIdleManager.resume(sessionId);
       return;

--- a/electron/bridges/mcpServerBridge.cjs
+++ b/electron/bridges/mcpServerBridge.cjs
@@ -1112,18 +1112,33 @@ function setVaultAgentInvoker(fn) {
 
 let sessionService = null;
 const sessionIdleManager = createSessionIdleManager({
-  onIdle: async ({ chatSessionId, sessionId }) => {
+  onIdle: async ({ chatSessionId, sessionId }, activityVersion) => {
     const hasWorkerJob = await hasActiveWorkerJobForTerminalSession(sessionId);
-    if (sessionIdleManager.hasActivity(sessionId)) {
+    if (!sessionIdleManager.isIdleCheckCurrent(sessionId, activityVersion)) {
       return;
     }
     if (activeSessionExecutions.has(sessionId) || hasWorkerJob) {
       sessionIdleManager.resume(sessionId);
       return;
     }
+    if (!sessionIdleManager.beginIdleClose(sessionId, activityVersion)) {
+      return;
+    }
     await sessionService?.closeTracked({ chatSessionId, sessionId });
   },
 });
+
+function reportOpenedSessionActivity(event = {}) {
+  const sessionId = event?.sessionId;
+  if (!sessionId) return false;
+  if (event.phase === "begin") {
+    return sessionIdleManager.beginActivity(null, sessionId);
+  }
+  if (event.phase === "end") {
+    return sessionIdleManager.endActivity(null, sessionId);
+  }
+  return sessionIdleManager.touch(null, sessionId);
+}
 
 sessionService = createSessionService({
   invokeSessionAgent: (...args) => {
@@ -1922,6 +1937,7 @@ module.exports = {
   getCommandTimeoutMs,
   setSessionIdleTimeoutMinutes,
   getSessionIdleTimeoutMinutes,
+  reportOpenedSessionActivity,
   setMaxIterations,
   getMaxIterations,
   setPermissionMode,

--- a/electron/bridges/mcpServerBridge.cjs
+++ b/electron/bridges/mcpServerBridge.cjs
@@ -95,6 +95,10 @@ function disconnectExternalMcpClients() {
 const scopedMetadata = new Map();
 const scopedAttachments = new Map(); // chatSessionId -> Map<filePath, attachment>
 const { createSessionOwnershipRegistry } = require("./mcpServerBridge/sessionOwnership.cjs");
+const {
+  createSessionIdleManager,
+  normalizeSessionIdleTimeoutMinutes,
+} = require("./mcpServerBridge/sessionIdleManager.cjs");
 const openedSessionOwnership = createSessionOwnershipRegistry();
 
 // Command safety checking (reuse from aiBridge)
@@ -392,6 +396,7 @@ function shutdownHost({ preserveScopedMetadata = false } = {}) {
   backgroundJobs.clear();
   pendingWorkerJobStarts.clear();
   activeSessionExecutions.clear();
+  sessionIdleManager.clearAll();
 }
 
 function echoCommandToSession(session, sessionId, command) {
@@ -423,6 +428,16 @@ function setCommandTimeout(seconds) {
 
 function getCommandTimeoutMs() {
   return commandTimeoutMs;
+}
+
+function setSessionIdleTimeoutMinutes(minutes) {
+  return sessionIdleManager.setTimeoutMinutes(
+    normalizeSessionIdleTimeoutMinutes(minutes),
+  );
+}
+
+function getSessionIdleTimeoutMinutes() {
+  return sessionIdleManager.getTimeoutMinutes();
 }
 
 function setMaxIterations(value) {
@@ -1087,12 +1102,67 @@ const {
   UNROUTED,
 } = require("./mcpServerBridge/capabilityRpcDispatch.cjs");
 const { buildBuiltinRpcHandlerRegistry } = require("./mcpServerBridge/builtinRpcHandlers.cjs");
+const { createSessionService } = require("../capabilities/services/sessionService.cjs");
 
 let invokeVaultAgentFn = null;
 
 function setVaultAgentInvoker(fn) {
   invokeVaultAgentFn = typeof fn === "function" ? fn : null;
 }
+
+let sessionService = null;
+const sessionIdleManager = createSessionIdleManager({
+  onIdle: async ({ chatSessionId, sessionId }) => {
+    const hasWorkerJob = Array.from(workerBackgroundJobs.values())
+      .some((job) => job?.sessionId === sessionId);
+    if (activeSessionExecutions.has(sessionId) || hasWorkerJob) {
+      sessionIdleManager.resume(sessionId);
+      return;
+    }
+    await sessionService?.closeTracked({ chatSessionId, sessionId });
+  },
+});
+
+sessionService = createSessionService({
+  invokeSessionAgent: (...args) => {
+    if (typeof invokeVaultAgentFn !== "function") {
+      return Promise.resolve({ ok: false, error: "Vault agent bridge is unavailable." });
+    }
+    return invokeVaultAgentFn(...args);
+  },
+  validateClose: (params = {}) => {
+    const scopeErr = validateSessionScope(
+      params.sessionId,
+      params.chatSessionId,
+      params.scopedSessionIds,
+    );
+    if (scopeErr) return { ok: false, error: scopeErr };
+    if (sessionIdleManager.isClosing(params.sessionId)) {
+      return { ok: false, error: `Session "${params.sessionId}" is closing.` };
+    }
+    return openedSessionOwnership.validate(params.chatSessionId, params.sessionId);
+  },
+  beforeClose: async (params = {}) => {
+    sessionIdleManager.beginClose(params.sessionId);
+    beginTerminalSessionClose(params.sessionId);
+    cancelBackgroundJobsForTerminalSession(params.sessionId);
+    await cancelWorkerBackgroundJobsForTerminalSession(params.sessionId);
+    await cancelSftpOpsForTerminalSession(params.sessionId);
+  },
+  afterClose: (params = {}, outcome = {}) => {
+    endTerminalSessionClose(params.sessionId);
+    if (!outcome.closed) sessionIdleManager.resume(params.sessionId);
+  },
+  onClosed: async (sessionId) => {
+    await settleBackgroundJobsForTerminalSession(sessionId);
+    sessionIdleManager.forgetSession(sessionId);
+    openedSessionOwnership.forgetSession(sessionId);
+    for (const scoped of scopedMetadata.values()) {
+      scoped.sessionIds = scoped.sessionIds.filter((id) => id !== sessionId);
+      scoped.metadata.delete(sessionId);
+    }
+  },
+});
 
 const dispatchCapabilityRpc = createCapabilityRpcDispatcher({
   invokeVaultAgent: (...args) => {
@@ -1111,33 +1181,11 @@ const dispatchCapabilityRpc = createCapabilityRpcDispatcher({
   isChatSessionCancelled,
   requestApprovalFromRenderer,
   USER_DENIED_MESSAGE,
+  sessionService,
   captureHostOpenScope: (chatSessionId) => openedSessionOwnership.captureGeneration(chatSessionId),
   onHostOpened: (chatSessionId, sessionId, generation) => {
     openedSessionOwnership.register(chatSessionId, sessionId, generation);
-  },
-  validateSessionClose: (params = {}) => {
-    const scopeErr = validateSessionScope(
-      params.sessionId,
-      params.chatSessionId,
-      params.scopedSessionIds,
-    );
-    if (scopeErr) return { ok: false, error: scopeErr };
-    return openedSessionOwnership.validate(params.chatSessionId, params.sessionId);
-  },
-  beforeSessionClose: async (params = {}) => {
-    beginTerminalSessionClose(params.sessionId);
-    cancelBackgroundJobsForTerminalSession(params.sessionId);
-    await cancelWorkerBackgroundJobsForTerminalSession(params.sessionId);
-    await cancelSftpOpsForTerminalSession(params.sessionId);
-  },
-  afterSessionClose: (params = {}) => endTerminalSessionClose(params.sessionId),
-  onSessionClosed: async (sessionId) => {
-    await settleBackgroundJobsForTerminalSession(sessionId);
-    openedSessionOwnership.forgetSession(sessionId);
-    for (const scoped of scopedMetadata.values()) {
-      scoped.sessionIds = scoped.sessionIds.filter((id) => id !== sessionId);
-      scoped.metadata.delete(sessionId);
-    }
+    sessionIdleManager.track(chatSessionId, sessionId);
   },
 });
 
@@ -1563,19 +1611,36 @@ async function dispatch(method, params) {
     if (!handler) {
       throw new Error(`Unknown method: ${method}`);
     }
-    if (capability?.id === "terminal.execute" && params?.sessionId && !sessions?.get?.(params.sessionId)) {
-      return handleWorkerTerminalExec(params);
+    const tracksSessionActivity = Boolean(
+      params?.sessionId
+      && (
+        capability?.id === "terminal.execute"
+        || capability?.id === "terminal.start"
+        || capability?.id?.startsWith("sftp.")
+      )
+    );
+    const activityStarted = tracksSessionActivity
+      ? sessionIdleManager.beginActivity(params?.chatSessionId, params.sessionId)
+      : false;
+    try {
+      if (capability?.id === "terminal.execute" && params?.sessionId && !sessions?.get?.(params.sessionId)) {
+        return await handleWorkerTerminalExec(params);
+      }
+      if (capability?.id === "terminal.start" && params?.sessionId && !sessions?.get?.(params.sessionId)) {
+        return await handleWorkerJobStart(params);
+      }
+      if (capability?.id === "terminal.poll" && workerBackgroundJobs.has(params?.jobId)) {
+        return await handleWorkerJobPoll(params);
+      }
+      if (capability?.id === "terminal.stop" && workerBackgroundJobs.has(params?.jobId)) {
+        return await handleWorkerJobStop(params);
+      }
+      return await handler(params);
+    } finally {
+      if (activityStarted) {
+        sessionIdleManager.endActivity(params?.chatSessionId, params.sessionId);
+      }
     }
-    if (capability?.id === "terminal.start" && params?.sessionId && !sessions?.get?.(params.sessionId)) {
-      return handleWorkerJobStart(params);
-    }
-    if (capability?.id === "terminal.poll" && workerBackgroundJobs.has(params?.jobId)) {
-      return handleWorkerJobPoll(params);
-    }
-    if (capability?.id === "terminal.stop" && workerBackgroundJobs.has(params?.jobId)) {
-      return handleWorkerJobStop(params);
-    }
-    return handler(params);
   } finally {
     if (sessionWriteLockId) {
       pendingSessionWriteApprovals.delete(sessionWriteLockId);
@@ -1810,6 +1875,7 @@ const configAndCleanupApi = createConfigAndCleanupApi({
   cancelWorkerBackgroundJobsForSession,
   cancelWorkerBackgroundJobsForTerminalSession,
   clearPendingApprovals, cancelSftpOpsForSession, sftpBridge,
+  preserveIdleSessionCleanup: sessionIdleManager.scopeCleared,
   clearOpenedSessionScope: openedSessionOwnership.clearScope,
 });
 const { resolveMcpServerRuntimeCommand, buildMcpServerConfig, cleanupScopedMetadata } = configAndCleanupApi;
@@ -1823,6 +1889,8 @@ module.exports = {
   setCommandBlocklist,
   setCommandTimeout,
   getCommandTimeoutMs,
+  setSessionIdleTimeoutMinutes,
+  getSessionIdleTimeoutMinutes,
   setMaxIterations,
   getMaxIterations,
   setPermissionMode,

--- a/electron/bridges/mcpServerBridge.workerTerminal.test.cjs
+++ b/electron/bridges/mcpServerBridge.workerTerminal.test.cjs
@@ -423,6 +423,63 @@ test("MCP/Catty terminal_start, poll, and stop proxy worker background jobs", as
   });
 });
 
+test("idle cleanup drops completed worker jobs even when the agent never polled them", async () => {
+  const requests = [];
+  const bridge = loadFreshBridge();
+  bridge.init({
+    sessions: new Map(),
+    electronModule: null,
+    terminalWorkerManager: {
+      request(channel, payload) {
+        requests.push({ channel, payload });
+        if (channel === "netcatty:ai:jobStart") {
+          return Promise.resolve({
+            ok: true,
+            jobId: "worker-job-unpolled",
+            sessionId: payload.sessionId,
+            status: "running",
+          });
+        }
+        if (channel === "netcatty:ai:jobPoll") {
+          return Promise.resolve({
+            ok: true,
+            jobId: payload.jobId,
+            sessionId: payload.sessionId,
+            status: "completed",
+            completed: true,
+          });
+        }
+        return Promise.reject(new Error(`unexpected worker request: ${channel}`));
+      },
+    },
+  });
+  bridge.setPermissionMode("auto");
+  bridge.setCommandBlocklist([]);
+  bridge.updateSessionMetadata([
+    { sessionId: "ssh-unpolled", protocol: "ssh", connected: true },
+  ], "chat-unpolled");
+
+  const started = await bridge.dispatchBuiltinRpc("netcatty/jobStart", {
+    sessionId: "ssh-unpolled",
+    command: "sleep 1",
+    chatSessionId: "chat-unpolled",
+  });
+  assert.equal(started.ok, true);
+
+  assert.equal(await bridge.hasActiveWorkerJobForTerminalSession("ssh-unpolled"), false);
+  assert.deepEqual(requests.map((entry) => entry.channel), [
+    "netcatty:ai:jobStart",
+    "netcatty:ai:jobPoll",
+  ]);
+
+  const stalePoll = await bridge.dispatchBuiltinRpc("netcatty/jobPoll", {
+    jobId: "worker-job-unpolled",
+    chatSessionId: "chat-unpolled",
+  });
+  assert.equal(stalePoll.ok, false);
+  assert.match(stalePoll.error, /not found/i);
+});
+
 test("MCP/Catty chat cancellation forwards to worker background jobs", async () => {
   const requests = [];
   const sends = [];

--- a/electron/bridges/mcpServerBridge/capabilityRpcDispatch.cjs
+++ b/electron/bridges/mcpServerBridge/capabilityRpcDispatch.cjs
@@ -89,7 +89,7 @@ function createCapabilityRpcDispatcher(deps) {
 
   const vaultService = createVaultService({ invokeVaultAgent });
   const portforwardService = createPortForwardService({ invokeVaultAgent });
-  const sessionService = createSessionService({
+  const sessionService = deps.sessionService || createSessionService({
     invokeSessionAgent: invokeVaultAgent,
     validateClose: deps.validateSessionClose,
     beforeClose: deps.beforeSessionClose,

--- a/electron/bridges/mcpServerBridge/configAndCleanup.cjs
+++ b/electron/bridges/mcpServerBridge/configAndCleanup.cjs
@@ -69,6 +69,7 @@ function createConfigAndCleanupApi(ctx) {
       if (chatSessionId) {
         scopedMetadata.delete(chatSessionId);
         scopedAttachments.delete(chatSessionId);
+        preserveIdleSessionCleanup?.(chatSessionId);
         clearOpenedSessionScope?.(chatSessionId);
         cancelledChatSessions.delete(chatSessionId);
         cancelBackgroundJobsForSession(chatSessionId);

--- a/electron/bridges/mcpServerBridge/sessionIdleManager.cjs
+++ b/electron/bridges/mcpServerBridge/sessionIdleManager.cjs
@@ -29,18 +29,18 @@ function createSessionIdleManager(options = {}) {
 
   function schedule(entry) {
     clearTimer(entry);
-    if (entry.activeCount > 0 || entry.closing) return;
+    if (entry.activeCount > 0 || entry.checking || entry.closing) return;
     const expiresAt = entry.lastActivityAt + timeoutMinutes * 60 * 1000;
     const delay = Math.max(0, expiresAt - DateImpl.now());
     entry.timer = setTimeoutImpl(() => {
       entry.timer = null;
       const current = entries.get(entry.sessionId);
-      if (current !== entry || entry.activeCount > 0 || entry.closing) return;
+      if (current !== entry || entry.activeCount > 0 || entry.checking || entry.closing) return;
       if (DateImpl.now() < expiresAt) {
         schedule(entry);
         return;
       }
-      entry.closing = true;
+      entry.checking = true;
       Promise.resolve(onIdle({
         chatSessionId: entry.chatSessionId,
         sessionId: entry.sessionId,
@@ -60,6 +60,7 @@ function createSessionIdleManager(options = {}) {
       sessionId,
       lastActivityAt: DateImpl.now(),
       activeCount: 0,
+      checking: false,
       closing: false,
       timer: null,
     };
@@ -70,7 +71,8 @@ function createSessionIdleManager(options = {}) {
 
   function touch(chatSessionId, sessionId) {
     const entry = entries.get(sessionId);
-    if (!entry || entry.chatSessionId !== chatSessionId || entry.closing) return false;
+    if (!entry || entry.closing) return false;
+    entry.checking = false;
     entry.lastActivityAt = DateImpl.now();
     schedule(entry);
     return true;
@@ -78,7 +80,8 @@ function createSessionIdleManager(options = {}) {
 
   function beginActivity(chatSessionId, sessionId) {
     const entry = entries.get(sessionId);
-    if (!entry || entry.chatSessionId !== chatSessionId || entry.closing) return false;
+    if (!entry || entry.closing) return false;
+    entry.checking = false;
     entry.activeCount += 1;
     entry.lastActivityAt = DateImpl.now();
     clearTimer(entry);
@@ -87,7 +90,7 @@ function createSessionIdleManager(options = {}) {
 
   function endActivity(chatSessionId, sessionId) {
     const entry = entries.get(sessionId);
-    if (!entry || entry.chatSessionId !== chatSessionId || entry.closing) return false;
+    if (!entry || entry.closing) return false;
     entry.activeCount = Math.max(0, entry.activeCount - 1);
     entry.lastActivityAt = DateImpl.now();
     schedule(entry);
@@ -97,6 +100,7 @@ function createSessionIdleManager(options = {}) {
   function beginClose(sessionId) {
     const entry = entries.get(sessionId);
     if (!entry || entry.closing) return false;
+    entry.checking = false;
     entry.closing = true;
     clearTimer(entry);
     return true;
@@ -106,6 +110,7 @@ function createSessionIdleManager(options = {}) {
     const entry = entries.get(sessionId);
     if (!entry) return false;
     entry.closing = false;
+    entry.checking = false;
     entry.activeCount = 0;
     entry.lastActivityAt = DateImpl.now();
     schedule(entry);
@@ -145,6 +150,7 @@ function createSessionIdleManager(options = {}) {
     resume,
     forgetSession,
     isTracked: (sessionId) => entries.has(sessionId),
+    hasActivity: (sessionId) => Boolean(entries.get(sessionId)?.activeCount),
     isClosing: (sessionId) => Boolean(entries.get(sessionId)?.closing),
     setTimeoutMinutes,
     getTimeoutMinutes: () => timeoutMinutes,

--- a/electron/bridges/mcpServerBridge/sessionIdleManager.cjs
+++ b/electron/bridges/mcpServerBridge/sessionIdleManager.cjs
@@ -36,15 +36,17 @@ function createSessionIdleManager(options = {}) {
       entry.timer = null;
       const current = entries.get(entry.sessionId);
       if (current !== entry || entry.activeCount > 0 || entry.checking || entry.closing) return;
-      if (DateImpl.now() < expiresAt) {
+      const latestExpiresAt = entry.lastActivityAt + timeoutMinutes * 60 * 1000;
+      if (DateImpl.now() < latestExpiresAt) {
         schedule(entry);
         return;
       }
       entry.checking = true;
+      const activityVersion = entry.activityVersion;
       Promise.resolve(onIdle({
         chatSessionId: entry.chatSessionId,
         sessionId: entry.sessionId,
-      })).catch(() => {
+      }, activityVersion)).catch(() => {
         resume(entry.sessionId);
       });
     }, delay);
@@ -59,6 +61,7 @@ function createSessionIdleManager(options = {}) {
       chatSessionId,
       sessionId,
       lastActivityAt: DateImpl.now(),
+      activityVersion: 0,
       activeCount: 0,
       checking: false,
       closing: false,
@@ -73,8 +76,11 @@ function createSessionIdleManager(options = {}) {
     const entry = entries.get(sessionId);
     if (!entry || entry.closing) return false;
     entry.checking = false;
+    entry.activityVersion += 1;
     entry.lastActivityAt = DateImpl.now();
-    schedule(entry);
+    // Keep an existing timer instead of recreating it for every output chunk.
+    // Its callback rechecks lastActivityAt and extends the deadline as needed.
+    if (entry.timer == null) schedule(entry);
     return true;
   }
 
@@ -82,6 +88,7 @@ function createSessionIdleManager(options = {}) {
     const entry = entries.get(sessionId);
     if (!entry || entry.closing) return false;
     entry.checking = false;
+    entry.activityVersion += 1;
     entry.activeCount += 1;
     entry.lastActivityAt = DateImpl.now();
     clearTimer(entry);
@@ -91,6 +98,7 @@ function createSessionIdleManager(options = {}) {
   function endActivity(chatSessionId, sessionId) {
     const entry = entries.get(sessionId);
     if (!entry || entry.closing) return false;
+    entry.activityVersion += 1;
     entry.activeCount = Math.max(0, entry.activeCount - 1);
     entry.lastActivityAt = DateImpl.now();
     schedule(entry);
@@ -106,11 +114,28 @@ function createSessionIdleManager(options = {}) {
     return true;
   }
 
+  function beginIdleClose(sessionId, activityVersion) {
+    if (!isIdleCheckCurrent(sessionId, activityVersion)) return false;
+    return beginClose(sessionId);
+  }
+
+  function isIdleCheckCurrent(sessionId, activityVersion) {
+    const entry = entries.get(sessionId);
+    return Boolean(
+      entry
+      && entry.checking
+      && !entry.closing
+      && entry.activeCount === 0
+      && entry.activityVersion === activityVersion
+    );
+  }
+
   function resume(sessionId) {
     const entry = entries.get(sessionId);
     if (!entry) return false;
     entry.closing = false;
     entry.checking = false;
+    entry.activityVersion += 1;
     entry.activeCount = 0;
     entry.lastActivityAt = DateImpl.now();
     schedule(entry);
@@ -147,10 +172,12 @@ function createSessionIdleManager(options = {}) {
     beginActivity,
     endActivity,
     beginClose,
+    beginIdleClose,
     resume,
     forgetSession,
     isTracked: (sessionId) => entries.has(sessionId),
     hasActivity: (sessionId) => Boolean(entries.get(sessionId)?.activeCount),
+    isIdleCheckCurrent,
     isClosing: (sessionId) => Boolean(entries.get(sessionId)?.closing),
     setTimeoutMinutes,
     getTimeoutMinutes: () => timeoutMinutes,

--- a/electron/bridges/mcpServerBridge/sessionIdleManager.cjs
+++ b/electron/bridges/mcpServerBridge/sessionIdleManager.cjs
@@ -1,0 +1,162 @@
+"use strict";
+
+const DEFAULT_SESSION_IDLE_TIMEOUT_MINUTES = 30;
+const MIN_SESSION_IDLE_TIMEOUT_MINUTES = 1;
+const MAX_SESSION_IDLE_TIMEOUT_MINUTES = 24 * 60;
+
+function normalizeSessionIdleTimeoutMinutes(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return DEFAULT_SESSION_IDLE_TIMEOUT_MINUTES;
+  return Math.min(
+    MAX_SESSION_IDLE_TIMEOUT_MINUTES,
+    Math.max(MIN_SESSION_IDLE_TIMEOUT_MINUTES, Math.round(parsed)),
+  );
+}
+
+function createSessionIdleManager(options = {}) {
+  const DateImpl = options.Date || Date;
+  const setTimeoutImpl = options.setTimeout || setTimeout;
+  const clearTimeoutImpl = options.clearTimeout || clearTimeout;
+  const onIdle = typeof options.onIdle === "function" ? options.onIdle : async () => {};
+  const entries = new Map();
+  let timeoutMinutes = normalizeSessionIdleTimeoutMinutes(options.timeoutMinutes);
+
+  function clearTimer(entry) {
+    if (entry.timer == null) return;
+    clearTimeoutImpl(entry.timer);
+    entry.timer = null;
+  }
+
+  function schedule(entry) {
+    clearTimer(entry);
+    if (entry.activeCount > 0 || entry.closing) return;
+    const expiresAt = entry.lastActivityAt + timeoutMinutes * 60 * 1000;
+    const delay = Math.max(0, expiresAt - DateImpl.now());
+    entry.timer = setTimeoutImpl(() => {
+      entry.timer = null;
+      const current = entries.get(entry.sessionId);
+      if (current !== entry || entry.activeCount > 0 || entry.closing) return;
+      if (DateImpl.now() < expiresAt) {
+        schedule(entry);
+        return;
+      }
+      entry.closing = true;
+      Promise.resolve(onIdle({
+        chatSessionId: entry.chatSessionId,
+        sessionId: entry.sessionId,
+      })).catch(() => {
+        resume(entry.sessionId);
+      });
+    }, delay);
+    entry.timer?.unref?.();
+  }
+
+  function track(chatSessionId, sessionId) {
+    if (!chatSessionId || !sessionId) return false;
+    const existing = entries.get(sessionId);
+    if (existing) clearTimer(existing);
+    const entry = {
+      chatSessionId,
+      sessionId,
+      lastActivityAt: DateImpl.now(),
+      activeCount: 0,
+      closing: false,
+      timer: null,
+    };
+    entries.set(sessionId, entry);
+    schedule(entry);
+    return true;
+  }
+
+  function touch(chatSessionId, sessionId) {
+    const entry = entries.get(sessionId);
+    if (!entry || entry.chatSessionId !== chatSessionId || entry.closing) return false;
+    entry.lastActivityAt = DateImpl.now();
+    schedule(entry);
+    return true;
+  }
+
+  function beginActivity(chatSessionId, sessionId) {
+    const entry = entries.get(sessionId);
+    if (!entry || entry.chatSessionId !== chatSessionId || entry.closing) return false;
+    entry.activeCount += 1;
+    entry.lastActivityAt = DateImpl.now();
+    clearTimer(entry);
+    return true;
+  }
+
+  function endActivity(chatSessionId, sessionId) {
+    const entry = entries.get(sessionId);
+    if (!entry || entry.chatSessionId !== chatSessionId || entry.closing) return false;
+    entry.activeCount = Math.max(0, entry.activeCount - 1);
+    entry.lastActivityAt = DateImpl.now();
+    schedule(entry);
+    return true;
+  }
+
+  function beginClose(sessionId) {
+    const entry = entries.get(sessionId);
+    if (!entry || entry.closing) return false;
+    entry.closing = true;
+    clearTimer(entry);
+    return true;
+  }
+
+  function resume(sessionId) {
+    const entry = entries.get(sessionId);
+    if (!entry) return false;
+    entry.closing = false;
+    entry.activeCount = 0;
+    entry.lastActivityAt = DateImpl.now();
+    schedule(entry);
+    return true;
+  }
+
+  function forgetSession(sessionId) {
+    const entry = entries.get(sessionId);
+    if (!entry) return false;
+    clearTimer(entry);
+    entries.delete(sessionId);
+    return true;
+  }
+
+  function setTimeoutMinutes(value) {
+    timeoutMinutes = normalizeSessionIdleTimeoutMinutes(value);
+    for (const entry of entries.values()) schedule(entry);
+    return timeoutMinutes;
+  }
+
+  function clearAll() {
+    for (const entry of entries.values()) clearTimer(entry);
+    entries.clear();
+  }
+
+  function scopeCleared() {
+    // Intentionally keep timers alive. A deleted/interrupted AI scope is one of
+    // the cases where the idle fallback is needed most.
+  }
+
+  return {
+    track,
+    touch,
+    beginActivity,
+    endActivity,
+    beginClose,
+    resume,
+    forgetSession,
+    isTracked: (sessionId) => entries.has(sessionId),
+    isClosing: (sessionId) => Boolean(entries.get(sessionId)?.closing),
+    setTimeoutMinutes,
+    getTimeoutMinutes: () => timeoutMinutes,
+    clearAll,
+    scopeCleared,
+  };
+}
+
+module.exports = {
+  DEFAULT_SESSION_IDLE_TIMEOUT_MINUTES,
+  MIN_SESSION_IDLE_TIMEOUT_MINUTES,
+  MAX_SESSION_IDLE_TIMEOUT_MINUTES,
+  normalizeSessionIdleTimeoutMinutes,
+  createSessionIdleManager,
+};

--- a/electron/bridges/mcpServerBridge/sessionIdleManager.test.cjs
+++ b/electron/bridges/mcpServerBridge/sessionIdleManager.test.cjs
@@ -94,6 +94,59 @@ test("an in-flight operation cannot time out and gets a fresh idle window when i
   assert.deepEqual(closed, [{ chatSessionId: "chat-a", sessionId: "session-1" }]);
 });
 
+test("activity from another authorized scope renews the same terminal session", async () => {
+  const clock = createClock();
+  const closed = [];
+  const manager = createSessionIdleManager({
+    ...clock,
+    timeoutMinutes: 1,
+    onIdle: async (entry) => closed.push(entry),
+  });
+
+  manager.track("chat-owner", "session-1");
+  clock.advance(30_000);
+  assert.equal(manager.beginActivity("chat-other", "session-1"), true);
+  manager.endActivity("chat-other", "session-1");
+
+  clock.advance(59_999);
+  await Promise.resolve();
+  assert.deepEqual(closed, []);
+  clock.advance(1);
+  await Promise.resolve();
+  assert.deepEqual(closed, [{ chatSessionId: "chat-owner", sessionId: "session-1" }]);
+});
+
+test("activity starting while an idle check is pending prevents the close", async () => {
+  const clock = createClock();
+  const closed = [];
+  let releaseIdleCheck;
+  const idleCheck = new Promise((resolve) => {
+    releaseIdleCheck = resolve;
+  });
+  let manager;
+  manager = createSessionIdleManager({
+    ...clock,
+    timeoutMinutes: 1,
+    onIdle: async (entry) => {
+      await idleCheck;
+      if (!manager.hasActivity(entry.sessionId)) closed.push(entry);
+    },
+  });
+
+  manager.track("chat-owner", "session-1");
+  clock.advance(60_000);
+  assert.equal(manager.beginActivity("chat-other", "session-1"), true);
+  releaseIdleCheck();
+  await idleCheck;
+  await Promise.resolve();
+  assert.deepEqual(closed, []);
+
+  manager.endActivity("chat-other", "session-1");
+  clock.advance(60_000);
+  await Promise.resolve();
+  assert.deepEqual(closed, [{ chatSessionId: "chat-owner", sessionId: "session-1" }]);
+});
+
 test("a failed close resumes tracking while a successful close can be forgotten", async () => {
   const clock = createClock();
   let attempts = 0;

--- a/electron/bridges/mcpServerBridge/sessionIdleManager.test.cjs
+++ b/electron/bridges/mcpServerBridge/sessionIdleManager.test.cjs
@@ -147,6 +147,42 @@ test("activity starting while an idle check is pending prevents the close", asyn
   assert.deepEqual(closed, [{ chatSessionId: "chat-owner", sessionId: "session-1" }]);
 });
 
+test("activity that starts and ends during an idle check invalidates the stale check", async () => {
+  const clock = createClock();
+  const closed = [];
+  let releaseIdleCheck;
+  const idleCheck = new Promise((resolve) => {
+    releaseIdleCheck = resolve;
+  });
+  let manager;
+  manager = createSessionIdleManager({
+    ...clock,
+    timeoutMinutes: 1,
+    onIdle: async (entry, activityVersion) => {
+      await idleCheck;
+      if (manager.beginIdleClose(entry.sessionId, activityVersion)) {
+        closed.push(entry);
+      }
+    },
+  });
+
+  manager.track("chat-owner", "session-1");
+  clock.advance(60_000);
+  assert.equal(manager.beginActivity("chat-other", "session-1"), true);
+  assert.equal(manager.endActivity("chat-other", "session-1"), true);
+  releaseIdleCheck();
+  await idleCheck;
+  await Promise.resolve();
+  assert.deepEqual(closed, []);
+
+  clock.advance(59_999);
+  await Promise.resolve();
+  assert.deepEqual(closed, []);
+  clock.advance(1);
+  await Promise.resolve();
+  assert.deepEqual(closed, [{ chatSessionId: "chat-owner", sessionId: "session-1" }]);
+});
+
 test("a failed close resumes tracking while a successful close can be forgotten", async () => {
   const clock = createClock();
   let attempts = 0;

--- a/electron/bridges/mcpServerBridge/sessionIdleManager.test.cjs
+++ b/electron/bridges/mcpServerBridge/sessionIdleManager.test.cjs
@@ -1,0 +1,138 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createSessionIdleManager } = require("./sessionIdleManager.cjs");
+
+function createClock() {
+  let now = 0;
+  let nextId = 1;
+  const timers = new Map();
+
+  function runDueTimers() {
+    while (true) {
+      const due = Array.from(timers.entries())
+        .filter(([, timer]) => timer.at <= now)
+        .sort((a, b) => a[1].at - b[1].at)[0];
+      if (!due) break;
+      timers.delete(due[0]);
+      due[1].callback();
+    }
+  }
+
+  return {
+    Date: { now: () => now },
+    setTimeout(callback, delay) {
+      const id = nextId++;
+      timers.set(id, { callback, at: now + delay });
+      return id;
+    },
+    clearTimeout(id) {
+      timers.delete(id);
+    },
+    advance(ms) {
+      now += ms;
+      runDueTimers();
+    },
+    timerCount() {
+      return timers.size;
+    },
+  };
+}
+
+test("idle sessions close independently and activity renews only the matching session", async () => {
+  const clock = createClock();
+  const closed = [];
+  const manager = createSessionIdleManager({
+    ...clock,
+    timeoutMinutes: 1,
+    onIdle: async (entry) => closed.push(entry),
+  });
+
+  manager.track("chat-a", "session-1");
+  manager.track("chat-a", "session-2");
+
+  clock.advance(30_000);
+  await Promise.resolve();
+  assert.deepEqual(closed, []);
+  manager.touch("chat-a", "session-1");
+
+  clock.advance(30_000);
+  await Promise.resolve();
+  assert.deepEqual(closed, [{ chatSessionId: "chat-a", sessionId: "session-2" }]);
+
+  clock.advance(30_000);
+  await Promise.resolve();
+  assert.deepEqual(closed, [
+    { chatSessionId: "chat-a", sessionId: "session-2" },
+    { chatSessionId: "chat-a", sessionId: "session-1" },
+  ]);
+});
+
+test("an in-flight operation cannot time out and gets a fresh idle window when it ends", async () => {
+  const clock = createClock();
+  const closed = [];
+  const manager = createSessionIdleManager({
+    ...clock,
+    timeoutMinutes: 1,
+    onIdle: async (entry) => closed.push(entry),
+  });
+
+  manager.track("chat-a", "session-1");
+  assert.equal(manager.beginActivity("chat-a", "session-1"), true);
+  clock.advance(120_000);
+  await Promise.resolve();
+  assert.deepEqual(closed, []);
+  assert.equal(clock.timerCount(), 0);
+
+  manager.endActivity("chat-a", "session-1");
+  clock.advance(59_999);
+  await Promise.resolve();
+  assert.deepEqual(closed, []);
+  clock.advance(1);
+  await Promise.resolve();
+  assert.deepEqual(closed, [{ chatSessionId: "chat-a", sessionId: "session-1" }]);
+});
+
+test("a failed close resumes tracking while a successful close can be forgotten", async () => {
+  const clock = createClock();
+  let attempts = 0;
+  const manager = createSessionIdleManager({
+    ...clock,
+    timeoutMinutes: 1,
+    onIdle: async ({ sessionId }) => {
+      attempts += 1;
+      if (attempts === 1) manager.resume(sessionId);
+      else manager.forgetSession(sessionId);
+    },
+  });
+
+  manager.track("chat-a", "session-1");
+  clock.advance(60_000);
+  await Promise.resolve();
+  assert.equal(attempts, 1);
+  assert.equal(manager.isTracked("session-1"), true);
+
+  clock.advance(60_000);
+  await Promise.resolve();
+  assert.equal(attempts, 2);
+  assert.equal(manager.isTracked("session-1"), false);
+  assert.equal(clock.timerCount(), 0);
+});
+
+test("clearing an AI scope does not discard its idle cleanup fallback", async () => {
+  const clock = createClock();
+  const closed = [];
+  const manager = createSessionIdleManager({
+    ...clock,
+    timeoutMinutes: 1,
+    onIdle: async (entry) => closed.push(entry),
+  });
+
+  manager.track("chat-a", "session-1");
+  manager.scopeCleared("chat-a");
+  clock.advance(60_000);
+  await Promise.resolve();
+
+  assert.deepEqual(closed, [{ chatSessionId: "chat-a", sessionId: "session-1" }]);
+});

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -50,6 +50,8 @@ const {
 let sftpClients = null;
 let electronModule = null;
 let sessions = null;
+let reportOpenedSessionActivity = null;
+const rendererSftpSourceSessions = new Map();
 
 // Storage for jump host connections that need to be cleaned up
 const jumpConnectionsMap = new Map(); // connId -> { connections: SSHClient[], socket: stream }
@@ -523,6 +525,10 @@ function init(deps) {
   sftpClients = deps.sftpClients;
   electronModule = deps.electronModule;
   sessions = deps.sessions;
+  reportOpenedSessionActivity = typeof deps.reportOpenedSessionActivity === "function"
+    ? deps.reportOpenedSessionActivity
+    : null;
+  rendererSftpSourceSessions.clear();
 }
 
 function ensureRemoteSftpSupport(sessionId) {
@@ -1136,10 +1142,51 @@ const {
   getSftpHomeDir,
 } = fileOpsApi;
 
+function resolveRendererSftpSourceSession(channel, payload = {}) {
+  if (channel === "netcatty:sftp:openForSession") return payload.sessionId || null;
+  if (channel === "netcatty:sftp:open") return payload.sourceSessionId || null;
+  const sftpId = payload.sftpId;
+  if (!sftpId) return null;
+  return rendererSftpSourceSessions.get(sftpId)
+    || sftpClients?.get?.(sftpId)?.__netcattySourceSessionId
+    || null;
+}
+
+function reportSftpActivity(sessionId, phase) {
+  if (!sessionId) return;
+  try {
+    reportOpenedSessionActivity?.({ sessionId, phase });
+  } catch {
+    // Activity tracking must not interfere with SFTP operations.
+  }
+}
+
+function registerActivityHandle(ipcMain, channel, handler) {
+  ipcMain.handle(channel, async (event, payload) => {
+    const sourceSessionId = resolveRendererSftpSourceSession(channel, payload);
+    reportSftpActivity(sourceSessionId, "begin");
+    try {
+      const result = await handler(event, payload);
+      const sftpId = result?.sftpId;
+      if (sourceSessionId && sftpId) {
+        rendererSftpSourceSessions.set(sftpId, sourceSessionId);
+      }
+      return result;
+    } finally {
+      if (channel === "netcatty:sftp:close" && payload?.sftpId) {
+        rendererSftpSourceSessions.delete(payload.sftpId);
+      }
+      reportSftpActivity(sourceSessionId, "end");
+    }
+  });
+}
+
 function registerWorkerHandle(ipcMain, terminalWorkerManager, channel) {
-  ipcMain.handle(channel, (event, payload) => terminalWorkerManager.request(channel, payload, {
-    webContentsId: event?.sender?.id,
-  }));
+  registerActivityHandle(ipcMain, channel, (event, payload) => (
+    terminalWorkerManager.request(channel, payload, {
+      webContentsId: event?.sender?.id,
+    })
+  ));
 }
 
 /**
@@ -1170,24 +1217,26 @@ function registerHandlers(ipcMain, options = {}) {
     ].forEach((channel) => registerWorkerHandle(ipcMain, terminalWorkerManager, channel));
     return;
   }
-  ipcMain.handle("netcatty:sftp:open", openSftp);
-  ipcMain.handle("netcatty:sftp:openForSession", openSftpForSession);
-  ipcMain.handle("netcatty:sftp:list", listSftp);
-  ipcMain.handle("netcatty:sftp:read", readSftp);
-  ipcMain.handle("netcatty:sftp:readBinary", readSftpBinary);
-  ipcMain.handle("netcatty:sftp:write", writeSftp);
-  ipcMain.handle("netcatty:sftp:writeBinary", writeSftpBinary);
-  ipcMain.handle("netcatty:sftp:writeBinaryWithProgress", writeSftpBinaryWithProgress);
-  ipcMain.handle("netcatty:sftp:downloadToLocal", downloadSftpToLocal);
-  ipcMain.handle("netcatty:sftp:uploadLocal", uploadLocalToSftp);
-  ipcMain.handle("netcatty:sftp:cancelUpload", cancelSftpUpload);
-  ipcMain.handle("netcatty:sftp:close", closeSftp);
-  ipcMain.handle("netcatty:sftp:mkdir", mkdirSftp);
-  ipcMain.handle("netcatty:sftp:delete", deleteSftp);
-  ipcMain.handle("netcatty:sftp:rename", renameSftp);
-  ipcMain.handle("netcatty:sftp:stat", statSftp);
-  ipcMain.handle("netcatty:sftp:chmod", chmodSftp);
-  ipcMain.handle("netcatty:sftp:homeDir", getSftpHomeDir);
+  [
+    ["netcatty:sftp:open", openSftp],
+    ["netcatty:sftp:openForSession", openSftpForSession],
+    ["netcatty:sftp:list", listSftp],
+    ["netcatty:sftp:read", readSftp],
+    ["netcatty:sftp:readBinary", readSftpBinary],
+    ["netcatty:sftp:write", writeSftp],
+    ["netcatty:sftp:writeBinary", writeSftpBinary],
+    ["netcatty:sftp:writeBinaryWithProgress", writeSftpBinaryWithProgress],
+    ["netcatty:sftp:downloadToLocal", downloadSftpToLocal],
+    ["netcatty:sftp:uploadLocal", uploadLocalToSftp],
+    ["netcatty:sftp:cancelUpload", cancelSftpUpload],
+    ["netcatty:sftp:close", closeSftp],
+    ["netcatty:sftp:mkdir", mkdirSftp],
+    ["netcatty:sftp:delete", deleteSftp],
+    ["netcatty:sftp:rename", renameSftp],
+    ["netcatty:sftp:stat", statSftp],
+    ["netcatty:sftp:chmod", chmodSftp],
+    ["netcatty:sftp:homeDir", getSftpHomeDir],
+  ].forEach(([channel, handler]) => registerActivityHandle(ipcMain, channel, handler));
 }
 
 /**

--- a/electron/bridges/sftpBridge.sessionActivity.test.cjs
+++ b/electron/bridges/sftpBridge.sessionActivity.test.cjs
@@ -1,0 +1,53 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const sftpBridge = require("./sftpBridge.cjs");
+
+test("renderer SFTP operations keep their source terminal session active", async () => {
+  const handlers = new Map();
+  const activity = [];
+  const requests = [];
+  const ipcMain = {
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  };
+  const terminalWorkerManager = {
+    async request(channel, payload) {
+      requests.push({ channel, payload });
+      if (channel === "netcatty:sftp:openForSession") {
+        return { sftpId: "sftp-1" };
+      }
+      if (channel === "netcatty:sftp:list") return [];
+      if (channel === "netcatty:sftp:close") return { ok: true };
+      throw new Error(`Unexpected channel: ${channel}`);
+    },
+  };
+  sftpBridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: {},
+    reportOpenedSessionActivity: (event) => activity.push(event),
+  });
+  sftpBridge.registerHandlers(ipcMain, { terminalWorkerManager });
+  const event = { sender: { id: 7 } };
+
+  await handlers.get("netcatty:sftp:openForSession")(event, { sessionId: "terminal-1" });
+  await handlers.get("netcatty:sftp:list")(event, { sftpId: "sftp-1", path: "/tmp" });
+  await handlers.get("netcatty:sftp:close")(event, { sftpId: "sftp-1" });
+
+  assert.deepEqual(requests.map((entry) => entry.channel), [
+    "netcatty:sftp:openForSession",
+    "netcatty:sftp:list",
+    "netcatty:sftp:close",
+  ]);
+  assert.deepEqual(activity, [
+    { sessionId: "terminal-1", phase: "begin" },
+    { sessionId: "terminal-1", phase: "end" },
+    { sessionId: "terminal-1", phase: "begin" },
+    { sessionId: "terminal-1", phase: "end" },
+    { sessionId: "terminal-1", phase: "begin" },
+    { sessionId: "terminal-1", phase: "end" },
+  ]);
+});

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -482,6 +482,7 @@ function init(deps) {
   configureTerminalSessionDataEmitter({
     getSession: (sessionId) => sessions?.get(sessionId),
     outputChannel: terminalOutputChannel,
+    onSessionActivity: deps.reportOpenedSessionActivity,
   });
 }
 

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -77,6 +77,7 @@ let electronModule = null;
 let terminalOutputChannel = null;
 let selectZmodemUploadFiles = null;
 let selectZmodemDownloadDirectory = null;
+let reportOpenedSessionActivity = null;
 
 const DEFAULT_UTF8_LOCALE = "en_US.UTF-8";
 const LOGIN_SHELLS = new Set(["bash", "zsh", "fish", "ksh"]);
@@ -113,9 +114,13 @@ function init(deps) {
   terminalOutputChannel = deps.terminalOutputChannel || null;
   selectZmodemUploadFiles = deps.selectZmodemUploadFiles || null;
   selectZmodemDownloadDirectory = deps.selectZmodemDownloadDirectory || null;
+  reportOpenedSessionActivity = typeof deps.reportOpenedSessionActivity === "function"
+    ? deps.reportOpenedSessionActivity
+    : null;
   configureTerminalSessionDataEmitter({
     getSession: (sessionId) => sessions?.get(sessionId),
     outputChannel: terminalOutputChannel,
+    onSessionActivity: reportOpenedSessionActivity,
   });
   cleanupStaleEtTempDirs();
 }
@@ -990,6 +995,12 @@ function writeToSession(event, payload) {
   const session = sessions.get(payload.sessionId);
   if (!session) return;
 
+  try {
+    reportOpenedSessionActivity?.({ sessionId: payload.sessionId, phase: "touch" });
+  } catch {
+    // Activity tracking must not interfere with terminal input.
+  }
+
   if (!payload.automated && !isTerminalReportSequence(payload.data)) {
     clearPendingAutomatedWrites(session);
   }
@@ -1405,6 +1416,11 @@ function registerHandlers(ipcMain, options = {}) {
       // stream for the session.
       sessionLogStreamManager.registerSudoAutofillInput(payload?.sessionId, payload?.data);
       sessionLogStreamManager.registerProgrammaticCommandLogRewrite(payload?.sessionId, payload?.logRewrite);
+      try {
+        reportOpenedSessionActivity?.({ sessionId: payload?.sessionId, phase: "touch" });
+      } catch {
+        // Activity tracking must not interfere with terminal input.
+      }
       terminalWorkerManager.send("netcatty:write", payload, {
         webContentsId: event?.sender?.id,
       });

--- a/electron/bridges/terminalBridge.sessionActivity.test.cjs
+++ b/electron/bridges/terminalBridge.sessionActivity.test.cjs
@@ -1,0 +1,31 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const terminalBridge = require("./terminalBridge.cjs");
+
+test("renderer terminal input reports activity for the matching session", () => {
+  const writes = [];
+  const activity = [];
+  const sessions = new Map([
+    ["session-1", {
+      proc: { write: (data) => writes.push(data) },
+      webContentsId: 1,
+    }],
+  ]);
+  terminalBridge.init({
+    sessions,
+    electronModule: { webContents: { fromId: () => null } },
+    reportOpenedSessionActivity: (event) => activity.push(event),
+  });
+
+  terminalBridge.writeToSession({ sender: {} }, {
+    sessionId: "session-1",
+    data: "pwd\r",
+  });
+
+  assert.deepEqual(writes, ["pwd\r"]);
+  assert.deepEqual(activity, [
+    { sessionId: "session-1", phase: "touch" },
+  ]);
+});

--- a/electron/capabilities/services/sessionService.cjs
+++ b/electron/capabilities/services/sessionService.cjs
@@ -26,7 +26,11 @@ function createSessionService(ctx = {}) {
       }
       return result;
     } finally {
-      await afterClose?.(params, { closed, result });
+      await afterClose?.(params, {
+        closed,
+        notFound: /\bwas not found\b/i.test(result?.error || ""),
+        result,
+      });
     }
   }
 

--- a/electron/capabilities/services/sessionService.cjs
+++ b/electron/capabilities/services/sessionService.cjs
@@ -3,28 +3,36 @@
 function createSessionService(ctx = {}) {
   const { invokeSessionAgent, validateClose, beforeClose, afterClose, onClosed } = ctx;
 
-  return {
-    close: async (params = {}) => {
-      if (!params.sessionId || typeof params.sessionId !== "string") {
-        return { ok: false, error: "sessionId is required." };
-      }
-      if (typeof validateClose === "function") {
-        const validation = validateClose(params);
-        if (validation && validation.ok === false) return validation;
-      }
-      if (typeof invokeSessionAgent !== "function") {
-        return { ok: false, error: "Session close bridge is unavailable." };
-      }
+  async function close(params = {}, options = {}) {
+    if (!params.sessionId || typeof params.sessionId !== "string") {
+      return { ok: false, error: "sessionId is required." };
+    }
+    if (!options.skipValidation && typeof validateClose === "function") {
+      const validation = validateClose(params);
+      if (validation && validation.ok === false) return validation;
+    }
+    if (typeof invokeSessionAgent !== "function") {
+      return { ok: false, error: "Session close bridge is unavailable." };
+    }
 
-      try {
-        await beforeClose?.(params);
-        const result = await invokeSessionAgent("session.close", { sessionId: params.sessionId });
-        if (result?.ok !== false) await onClosed?.(params.sessionId);
-        return result;
-      } finally {
-        await afterClose?.(params);
+    let result;
+    let closed = false;
+    try {
+      await beforeClose?.(params);
+      result = await invokeSessionAgent("session.close", { sessionId: params.sessionId });
+      if (result?.ok !== false) {
+        await onClosed?.(params.sessionId);
+        closed = true;
       }
-    },
+      return result;
+    } finally {
+      await afterClose?.(params, { closed, result });
+    }
+  }
+
+  return {
+    close: (params = {}) => close(params),
+    closeTracked: (params = {}) => close(params, { skipValidation: true }),
   };
 }
 

--- a/electron/capabilities/services/sessionService.test.cjs
+++ b/electron/capabilities/services/sessionService.test.cjs
@@ -35,5 +35,21 @@ test("failed closes report the outcome so idle tracking can resume", async () =>
   const result = await service.closeTracked({ sessionId: "session-1" });
   assert.equal(result.ok, false);
   assert.equal(outcome.closed, false);
+  assert.equal(outcome.notFound, false);
   assert.deepEqual(outcome.result, result);
+});
+
+test("already-missing sessions are distinguished from retryable close failures", async () => {
+  let outcome = null;
+  const service = createSessionService({
+    invokeSessionAgent: async () => ({ ok: false, error: 'Session "gone" was not found.' }),
+    afterClose: async (_params, value) => {
+      outcome = value;
+    },
+  });
+
+  const result = await service.closeTracked({ sessionId: "gone" });
+  assert.equal(result.ok, false);
+  assert.equal(outcome.closed, false);
+  assert.equal(outcome.notFound, true);
 });

--- a/electron/capabilities/services/sessionService.test.cjs
+++ b/electron/capabilities/services/sessionService.test.cjs
@@ -1,0 +1,39 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createSessionService } = require("./sessionService.cjs");
+
+test("closeTracked uses the same lifecycle while bypassing user-scope validation", async () => {
+  const events = [];
+  const service = createSessionService({
+    validateClose: () => ({ ok: false, error: "scope was cleaned" }),
+    beforeClose: async () => events.push("before"),
+    invokeSessionAgent: async () => ({ ok: true, status: "closed" }),
+    onClosed: async () => events.push("closed"),
+    afterClose: async (_params, outcome) => events.push(outcome.closed ? "success" : "failed"),
+  });
+
+  const manualResult = await service.close({ sessionId: "session-1" });
+  assert.equal(manualResult.ok, false);
+  assert.deepEqual(events, []);
+
+  const idleResult = await service.closeTracked({ sessionId: "session-1" });
+  assert.equal(idleResult.ok, true);
+  assert.deepEqual(events, ["before", "closed", "success"]);
+});
+
+test("failed closes report the outcome so idle tracking can resume", async () => {
+  let outcome = null;
+  const service = createSessionService({
+    invokeSessionAgent: async () => ({ ok: false, error: "renderer unavailable" }),
+    afterClose: async (_params, value) => {
+      outcome = value;
+    },
+  });
+
+  const result = await service.closeTracked({ sessionId: "session-1" });
+  assert.equal(result.ok, false);
+  assert.equal(outcome.closed, false);
+  assert.deepEqual(outcome.result, result);
+});

--- a/electron/main/registerBridges.cjs
+++ b/electron/main/registerBridges.cjs
@@ -158,6 +158,10 @@ function createBridgeRegistrar(context) {
           MessageChannelMain: electronModule.MessageChannelMain,
         })
       : null;
+    const reportOpenedSessionActivity = (event) => aiBridge.reportOpenedSessionActivity?.(event);
+    terminalWorkerManager?.addOutputTap?.((sessionId) => {
+      reportOpenedSessionActivity({ sessionId, phase: "touch" });
+    });
     const deps = {
       sessions,
       sftpClients,
@@ -169,6 +173,7 @@ function createBridgeRegistrar(context) {
       userDataDir,
       terminalOutputChannel,
       terminalWorkerManager,
+      reportOpenedSessionActivity,
     };
   
     sshBridge.init(deps);

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -186,6 +186,8 @@ export const STORAGE_KEY_AI_EXTERNAL_MCP_ENABLED = 'netcatty_ai_external_mcp_ena
 export const STORAGE_KEY_AI_EXTERNAL_MCP_MODE = 'netcatty_ai_external_mcp_mode_v1';
 /** External MCP idle timeout in minutes (temporary mode only). */
 export const STORAGE_KEY_AI_EXTERNAL_MCP_IDLE_TIMEOUT_MINUTES = 'netcatty_ai_external_mcp_idle_timeout_minutes_v1';
+/** Idle timeout for terminal sessions opened by an AI through host_open. */
+export const STORAGE_KEY_AI_SESSION_IDLE_TIMEOUT_MINUTES = 'netcatty_ai_session_idle_timeout_minutes_v1';
 
 // SFTP Transfer Concurrency
 export const STORAGE_KEY_SFTP_TRANSFER_CONCURRENCY = 'netcatty_sftp_transfer_concurrency_v1';

--- a/types/global/netcatty-bridge-ai.d.ts
+++ b/types/global/netcatty-bridge-ai.d.ts
@@ -193,6 +193,7 @@ declare global {
       exposedSessionCount?: number;
       mode?: 'temporary' | 'persistent';
       idleTimeoutMinutes?: number;
+      sessionIdleTimeoutMinutes?: number;
       lastActivityAt?: number | null;
       idleExpiresAt?: number | null;
       permissionMode?: string;
@@ -203,6 +204,7 @@ declare global {
     externalMcpSetConfig?(config: {
       mode?: 'temporary' | 'persistent';
       idleTimeoutMinutes?: number;
+      sessionIdleTimeoutMinutes?: number;
     }): Promise<Record<string, unknown>>;
     externalMcpCodexGetStatus?(): Promise<Record<string, unknown>>;
     externalMcpCodexAdd?(): Promise<Record<string, unknown>>;


### PR DESCRIPTION
## Summary

- automatically close terminal sessions opened by `host_open` after a configurable period without terminal or SFTP activity
- keep independent activity windows per session and avoid closing while a command or file operation is active
- keep the cleanup fallback alive when an AI scope is deleted or External MCP is disabled
- add an External MCP setting for the opened-session idle timeout (30 minutes by default)

## Root cause

Sessions opened by an AI were only tracked for manual `session_close` ownership. Once the agent stopped calling tools—or its scope was cleaned up—there was no per-session lifecycle fallback, so the terminal could remain open indefinitely.

## Validation

- focused idle/session lifecycle tests: 35 passed
- `npm run lint`
- `npm run build`
- `npm test`: 5665 passed, 7 skipped, 1 pre-existing failure; the same SSH auth retry test fails on a clean `origin/main` worktree
- Electron settings UI: verified the new field renders at 30 minutes, changes to 45, updates backend status, and restores to 30

Closes #2246
