### PR TITLE
refactor(terminal): dedupe password-prompt regex in onTerminalOutput

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -194,6 +194,10 @@ import { terminalPropsAreEqual } from "./terminal/terminalMemo";
 
 const HIBERNATE_RETRY_AFTER_DRAIN_MS = 250;
 const EMPTY_CHAIN_HOSTS: Host[] = [];
+// Detect password/passphrase prompts in output so the next keystroke is treated
+// as sensitive. Hoisted to module scope + shared by the onTerminalOutput branch
+// so the pattern is compiled once and not duplicated per chunk.
+const PASSWORD_PROMPT_PATTERN = /password|passphrase|口令/i;
 
 const TerminalComponent: React.FC<TerminalProps> = ({
   host,
@@ -1628,20 +1632,15 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       scheduleAutoReconnect({ evt });
     },
     onTerminalDataCapture: handleTerminalDataCaptureOnce,
-    onTerminalOutput: onTerminalOutput
-      ? (chunk: string, meta?: TerminalSessionDataMeta) => {
-          if (/password|passphrase|口令/i.test(chunk)) {
-            passwordPromptActiveRef.current = true;
-          }
-          appendOutputTriggerOutputRef.current(chunk, meta);
-          onTerminalOutput(sessionId, chunk);
-        }
-      : (chunk: string, meta?: TerminalSessionDataMeta) => {
-          if (/password|passphrase|口令/i.test(chunk)) {
-            passwordPromptActiveRef.current = true;
-          }
-          appendOutputTriggerOutputRef.current(chunk, meta);
-        },
+    onTerminalOutput: (chunk: string, meta?: TerminalSessionDataMeta) => {
+      if (PASSWORD_PROMPT_PATTERN.test(chunk)) {
+        passwordPromptActiveRef.current = true;
+      }
+      appendOutputTriggerOutputRef.current(chunk, meta);
+      if (onTerminalOutput) {
+        onTerminalOutput(sessionId, chunk);
+      }
+    },
     onTerminalLogData: captureTerminalLogData,
     onProgrammaticCommandLogRewrite: queueProgrammaticCommandLogRewrite,
     onOsDetected,


### PR DESCRIPTION
# PR: refactor(terminal): dedupe password-prompt regex in onTerminalOutput

## What

`onTerminalOutput` had two near-identical branches (with / without an external
`onTerminalOutput` callback), each inlining the same `/password|passphrase|口令/i`
test that runs on **every** output chunk. This collapses them into a single handler
and hoists the pattern to a module-level constant.

## Why

- Removes duplicated logic and a per-chunk duplicated regex literal on a hot path
  (every terminal output chunk).
- Small, behavior-preserving cleanup; part of reducing per-chunk work during heavy
  output (e.g. `apt upgrade`). See the linked performance issue for the full picture.

## Change

```tsx
// module scope
const PASSWORD_PROMPT_PATTERN = /password|passphrase|口令/i;

// single handler (was two duplicated branches)
onTerminalOutput: (chunk, meta) => {
  if (PASSWORD_PROMPT_PATTERN.test(chunk)) passwordPromptActiveRef.current = true;
  appendOutputTriggerOutputRef.current(chunk, meta);
  if (onTerminalOutput) onTerminalOutput(sessionId, chunk);
},
```

## Testing

- `npx eslint components/Terminal.tsx` → clean.
- Behavior is identical (the callback is now called conditionally inside one branch
  instead of selecting between two otherwise-identical branches).

Diff: 1 file changed, +13 / −14.


Refs #2272
