### PR TITLE
Harden Catty terminal context handling

### DIFF
--- a/components/ai/cattyHistoryReplay.test.ts
+++ b/components/ai/cattyHistoryReplay.test.ts
@@ -75,6 +75,22 @@ test("buildHistoricalToolResultReplayText replaces historical terminal output wi
   assert.match(replay, /command=npm run build/);
   assert.match(replay, /status=error/);
   assert.doesNotMatch(replay, /BUILD BUILD BUILD/);
+  assert.doesNotMatch(replay, /Re-run terminal_execute/);
+  assert.match(replay, /do not execute the command again/i);
+});
+
+test("buildHistoricalToolResultReplayText omits terminal poll output too", () => {
+  const replay = buildHistoricalToolResultReplayText({
+    toolCallId: "poll-1",
+    content: "streamed output".repeat(5_000),
+  }, {
+    id: "poll-1",
+    name: "terminal_poll",
+    arguments: { jobId: "job-1", offset: 100 },
+  });
+
+  assert.match(replay, /Historical terminal output omitted from replay/);
+  assert.doesNotMatch(replay, /streamed output/);
 });
 
 test("buildHistoricalToolResultReplayText keeps non-terminal tool results intact", () => {
@@ -106,6 +122,15 @@ test("buildHistoricalToolResultReplayText can preserve terminal output for 413 r
     buildHistoricalToolResultReplayText(result, toolCall, { preserveTerminalOutput: true }),
     "real terminal output",
   );
+});
+
+test("buildHistoricalToolResultReplayText redacts credentials from omitted command details", () => {
+  const replay = buildHistoricalToolResultReplayText(
+    { toolCallId: "call-secret", content: "output" },
+    { id: "call-secret", name: "terminal_execute", arguments: { command: "curl --password swordfish -H 'Authorization: Bearer secret_token_123456'" } },
+  );
+  assert.doesNotMatch(replay, /swordfish|secret_token/);
+  assert.match(replay, /REDACTED/);
 });
 
 test("buildHistoricalToolReplayMaps pairs reused tool ids with the nearest preceding call", () => {

--- a/components/ai/cattyHistoryReplay.test.ts
+++ b/components/ai/cattyHistoryReplay.test.ts
@@ -57,7 +57,7 @@ test("buildHistoricalUserReplayContent replaces historical terminal selections w
   assert.doesNotMatch(result, /long terminal selection/);
 });
 
-test("buildHistoricalToolResultReplayText replaces historical terminal output with a replay placeholder", () => {
+test("buildHistoricalToolResultReplayText keeps bounded historical terminal evidence", () => {
   const toolCall: ToolCall = {
     id: "call-1",
     name: "terminal_execute",
@@ -74,12 +74,14 @@ test("buildHistoricalToolResultReplayText replaces historical terminal output wi
   assert.match(replay, /Historical terminal output omitted from replay/);
   assert.match(replay, /command=npm run build/);
   assert.match(replay, /status=error/);
-  assert.doesNotMatch(replay, /BUILD BUILD BUILD/);
+  assert.match(replay, /BUILD BUILD BUILD/);
+  assert.match(replay, /shortened for replay/);
+  assert.ok(replay.length < 4_600);
   assert.doesNotMatch(replay, /Re-run terminal_execute/);
   assert.match(replay, /do not execute the command again/i);
 });
 
-test("buildHistoricalToolResultReplayText omits terminal poll output too", () => {
+test("buildHistoricalToolResultReplayText bounds terminal poll output and keeps its job pointer", () => {
   const replay = buildHistoricalToolResultReplayText({
     toolCallId: "poll-1",
     content: "streamed output".repeat(5_000),
@@ -90,7 +92,40 @@ test("buildHistoricalToolResultReplayText omits terminal poll output too", () =>
   });
 
   assert.match(replay, /Historical terminal output omitted from replay/);
-  assert.doesNotMatch(replay, /streamed output/);
+  assert.match(replay, /streamed output/);
+  assert.match(replay, /jobId=job-1/);
+  assert.ok(replay.length < 4_600);
+});
+
+test("buildHistoricalToolResultReplayText preserves small output that has no saved handle", () => {
+  const replay = buildHistoricalToolResultReplayText({
+    toolCallId: "small-1",
+    content: "exit 1: configuration file is missing",
+    isError: true,
+  }, {
+    id: "small-1",
+    name: "terminal_execute",
+    arguments: { command: "deploy" },
+  });
+
+  assert.match(replay, /configuration file is missing/);
+  assert.match(replay, /Only the bounded historical output below is available/);
+  assert.doesNotMatch(replay, /saved output/i);
+});
+
+test("buildHistoricalToolResultReplayText preserves a large output handle from the tail", () => {
+  const handleId = "tool-output-stable-handle-123";
+  const replay = buildHistoricalToolResultReplayText({
+    toolCallId: "large-1",
+    content: `${"build line\n".repeat(2_000)}[output handle: stdout truncated for model context handleId=${handleId}]`,
+  }, {
+    id: "large-1",
+    name: "terminal_execute",
+    arguments: { command: "npm run build" },
+  });
+
+  assert.match(replay, new RegExp(`tool_output_read with handleId=${handleId}`));
+  assert.match(replay, new RegExp(`handleId=${handleId}`));
 });
 
 test("buildHistoricalToolResultReplayText keeps non-terminal tool results intact", () => {

--- a/components/ai/cattyHistoryReplay.ts
+++ b/components/ai/cattyHistoryReplay.ts
@@ -1,5 +1,6 @@
 import type { ChatMessage, ChatMessageAttachment, ToolCall, ToolResult } from "../../infrastructure/ai/types";
 import { isTerminalSelectionAttachment } from "../../application/state/terminalSelectionAttachment";
+import { redactSecretsForModel } from "../../infrastructure/ai/harness/modelSecretRedaction";
 
 const MAX_ATTACHMENT_PLACEHOLDER_DETAIL_CHARS = 120;
 const MAX_TOOL_COMMAND_CHARS = 220;
@@ -125,14 +126,19 @@ export function buildHistoricalToolResultReplayText(
 
   const details = [
     `toolCallId=${result.toolCallId}`,
-    getToolCommand(toolCall) ? `command=${truncateInline(getToolCommand(toolCall) ?? "", MAX_TOOL_COMMAND_CHARS)}` : undefined,
+    getToolCommand(toolCall) ? `command=${truncateInline(redactSecretsForModel(getToolCommand(toolCall) ?? ""), MAX_TOOL_COMMAND_CHARS)}` : undefined,
     `outputChars=${result.content.length}`,
     result.isError ? "status=error" : "status=success",
   ].filter(Boolean).join(", ");
 
-  return `[Historical terminal output omitted from replay: ${details}. Re-run terminal_execute if exact output is needed.]`;
+  return `[Historical terminal output omitted from replay: ${details}. This tool call already completed; do not execute the command again. Read the saved output or poll the existing job if more detail is needed.]`;
 }
 
 function isTerminalToolName(toolName: string): boolean {
-  return toolName === "terminal" || toolName === "terminal_exec" || toolName === "terminal_execute";
+  return toolName === "terminal"
+    || toolName === "terminal_exec"
+    || toolName === "terminal_execute"
+    || toolName === "terminal_start"
+    || toolName === "terminal_poll"
+    || toolName === "terminal_read_context";
 }

--- a/components/ai/cattyHistoryReplay.ts
+++ b/components/ai/cattyHistoryReplay.ts
@@ -4,6 +4,8 @@ import { redactSecretsForModel } from "../../infrastructure/ai/harness/modelSecr
 
 const MAX_ATTACHMENT_PLACEHOLDER_DETAIL_CHARS = 120;
 const MAX_TOOL_COMMAND_CHARS = 220;
+const MAX_HISTORICAL_TERMINAL_OUTPUT_CHARS = 4_000;
+const HISTORICAL_TERMINAL_OUTPUT_HEAD_CHARS = 2_800;
 
 function truncateInline(value: string, maxChars: number): string {
   const normalized = value.replace(/\s+/g, " ").trim();
@@ -64,6 +66,21 @@ function getToolCommand(toolCall?: ToolCall): string | undefined {
   if (typeof args.command === "string") return args.command;
   const serialized = JSON.stringify(args);
   return serialized && serialized !== "{}" ? serialized : undefined;
+}
+
+function fitHistoricalTerminalOutput(content: string): string {
+  const safeContent = redactSecretsForModel(content);
+  if (safeContent.length <= MAX_HISTORICAL_TERMINAL_OUTPUT_CHARS) return safeContent;
+  const marker = "\n\n[... historical terminal output shortened for replay ...]\n\n";
+  const tailChars = Math.max(
+    0,
+    MAX_HISTORICAL_TERMINAL_OUTPUT_CHARS - HISTORICAL_TERMINAL_OUTPUT_HEAD_CHARS - marker.length,
+  );
+  return `${safeContent.slice(0, HISTORICAL_TERMINAL_OUTPUT_HEAD_CHARS)}${marker}${safeContent.slice(-tailChars)}`;
+}
+
+function findOutputHandleId(content: string): string | undefined {
+  return content.match(/\bhandleId=(tool-output-[A-Za-z0-9-]+)/)?.[1];
 }
 
 export function buildHistoricalToolReplayMaps(messages: ChatMessage[]): {
@@ -131,7 +148,21 @@ export function buildHistoricalToolResultReplayText(
     result.isError ? "status=error" : "status=success",
   ].filter(Boolean).join(", ");
 
-  return `[Historical terminal output omitted from replay: ${details}. This tool call already completed; do not execute the command again. Read the saved output or poll the existing job if more detail is needed.]`;
+  const fittedOutput = fitHistoricalTerminalOutput(result.content);
+  const handleId = findOutputHandleId(fittedOutput);
+  const jobId = typeof toolCall?.arguments?.jobId === "string"
+    ? toolCall.arguments.jobId
+    : undefined;
+  const recovery = handleId
+    ? `Use tool_output_read with handleId=${handleId} for omitted details.`
+    : jobId
+      ? `Poll the existing jobId=${jobId} if it is still running and more detail is needed.`
+      : "Only the bounded historical output below is available.";
+
+  return [
+    `[Historical terminal output omitted from replay beyond the bounded evidence below: ${details}. This tool call already completed; do not execute the command again. ${recovery}]`,
+    fittedOutput || "[No terminal output was returned.]",
+  ].join("\n");
 }
 
 function isTerminalToolName(toolName: string): boolean {

--- a/components/ai/externalAgentHistory.test.ts
+++ b/components/ai/externalAgentHistory.test.ts
@@ -292,9 +292,9 @@ test("buildExternalAgentHistoryMessages still drops one-word filler user message
   }
 });
 
-test("buildExternalAgentHistoryMessages replaces recent terminal tool output with a replay placeholder", () => {
-  // Historical terminal output should remain self-describing without
-  // replaying the actual bytes on every follow-up.
+test("buildExternalAgentHistoryMessages keeps bounded recent terminal evidence", () => {
+  // Historical terminal output stays self-describing and useful while
+  // remaining bounded on every follow-up.
   const bigToolOutput = "DATA ".repeat(300); // ~1500 chars — bigger than summary cap but smaller than raw cap
   const messages: ChatMessage[] = [
     message("u1", "user", "cat /etc/hosts"),
@@ -314,13 +314,13 @@ test("buildExternalAgentHistoryMessages replaces recent terminal tool output wit
 
   assert.match(flat, /Tool result \[from terminal.*?cat \/etc\/hosts.*?\] \(call1\): \[Historical terminal output omitted from replay/);
   assert.match(flat, /outputChars=1500/);
-  assert.doesNotMatch(flat, /DATA DATA DATA/);
+  assert.match(flat, /DATA DATA DATA/);
   const toolResultIdx = flat.indexOf("Tool result [from terminal");
   assert.ok(toolResultIdx >= 0, "tool result line must appear in raw window");
   const toolResultChunk = flat.slice(toolResultIdx);
   assert.ok(
-    toolResultChunk.length < 500,
-    `expected terminal result placeholder to stay compact, got ${toolResultChunk.length}`,
+    toolResultChunk.length < 2_100,
+    `expected terminal result evidence to stay bounded, got ${toolResultChunk.length}`,
   );
 });
 
@@ -648,8 +648,8 @@ test("buildExternalAgentHistoryMessages resolves tool_call provenance correctly 
   // args. Use non-greedy .*? — the args JSON can contain parentheses.
   const hostsMatch = flat.match(/Tool result \[from [^\]]*?cat \/etc\/hosts[^\]]*?\][^\n]*Historical terminal output omitted from replay[^\n]*cat \/etc\/hosts/);
   const resolvMatch = flat.match(/Tool result \[from [^\]]*?cat \/etc\/resolv\.conf[^\]]*?\][^\n]*Historical terminal output omitted from replay[^\n]*cat \/etc\/resolv\.conf/);
-  assert.doesNotMatch(flat, /HOSTS_BYTES/);
-  assert.doesNotMatch(flat, /RESOLV_BYTES/);
+  assert.match(flat, /HOSTS_BYTES/);
+  assert.match(flat, /RESOLV_BYTES/);
 
   assert.ok(hostsMatch, "hosts result must still be labeled with cat /etc/hosts despite later id reuse");
   assert.ok(resolvMatch, "resolv result must be labeled with cat /etc/resolv.conf");

--- a/docs/research/grok-build-context-engineering-source-notes.md
+++ b/docs/research/grok-build-context-engineering-source-notes.md
@@ -1,0 +1,188 @@
+# Grok Build 上下文工程与 Agent Runtime 源码笔记
+
+> 研究对象：官方 `xai-org/grok-build` 本地源码快照，`SOURCE_REV=2ec0f0c8488842da03a71eeee3c61154957ca919`。
+> 范围：提示词与上下文装配、token 预算、历史裁剪/压缩、工具结果、缓存、会话恢复、子 agent、hooks/skills、可观测性与离线评估。
+> 方法：只使用仓库内第一方源码和仓库自带的第三方归属声明，不以 README 宣传文字代替实现证据。
+
+## 结论先行
+
+Grok Build 最值得 Catty 学的不是某一个 prompt，而是以下 8 个机制组成的闭环：
+
+1. **把上下文做成可检查、可持久化的数据结构，而不是散落的字符串拼接。** `PromptContext` 明确记录 audience、prompt mode、AGENTS.md、memory、role/persona、运行环境和构建时间，再统一渲染；父 agent 与子 agent 使用不同模板和目录信息，但项目指令保持一致。[`prompt/context.rs:79-151`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-agent/src/prompt/context.rs#L79-L151) [`prompt/context.rs:160-171`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-agent/src/prompt/context.rs#L160-L171) [`prompt/context.rs:251-297`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-agent/src/prompt/context.rs#L251-L297)
+2. **在真正压缩前先做分层、可逆的减负。** 超过 50% 才对请求副本裁剪旧工具结果；近 3 轮不动，较老大结果保留头尾，10 轮以前的结果只留占位；原始事件流仍保留用于重放。[`request_builder.rs:20-108`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/actor/request_builder.rs#L20-L108) [`request_builder.rs:155-208`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/actor/request_builder.rs#L155-L208) [`types.rs:67-97`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/types.rs#L67-L97) [`mutations.rs:165-205`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/actor/mutations.rs#L165-L205)
+3. **把两段式压缩的第一段放到后台提前跑。** 达到正式压缩阈值前 10 个百分点时，后台总结约 95% 的历史；真正触发压缩时只需把 NOTE1 与最近约 5% 合并成最终摘要。缓存带前缀指纹与 model 标识，历史编辑、回退、分叉或切模型后自动失效。[`compaction.rs:34-63`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L34-L63) [`compaction.rs:219-340`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L219-L340) [`compaction.rs:342-429`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L342-L429) [`two_pass.rs:1-20`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/two_pass.rs#L1-L20)
+4. **压缩不是不可逆删除：摘要之外保留可检索的分段档案。** `Summary`、原始 transcript、Markdown segments 三种模式可选；segments 模式给后继 agent 一个索引和只读恢复路径，摘要不够时再按需读取精确代码、错误和工具输出。[`compaction_mode.rs:7-20`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/compaction_mode.rs#L7-L20) [`compaction_mode.rs:51-77`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/compaction_mode.rs#L51-L77) [`fork.rs:92-106`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/fork.rs#L92-L106)
+5. **压缩后显式重新注入运行状态，而不是赌摘要记住一切。** 新上下文重建时单独采集正在运行的终端任务、子 agent、改过的文件、MCP 服务、todo、skills、AGENTS.md、plan mode 和 memory，再生成 system reminder；这比把所有责任交给总结模型更可靠。[`compaction.rs:1205-1350`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L1205-L1350) [`compaction.rs:1381-1499`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L1381-L1499)
+6. **所有工具调用历史都做结构完整性修复。** 在恢复、下一轮写入和发请求边界去重重复 ToolResult、为悬空 tool call 补合成结果；另有显式 repair 路径移除会导致 provider 400 的孤儿结果。[`mutations.rs:26-70`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/actor/mutations.rs#L26-L70) [`mutations.rs:80-109`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/actor/mutations.rs#L80-L109)
+7. **子 agent 是独立可恢复会话，不只是一次函数调用。** 子 agent 有独立 session id、原始 transcript、tool state、model、cwd、能力与隔离模式；支持继续以前的子 agent、后台运行、父轮取消隔离、进度/用量拉取，并把用量按 model 汇总回父账单。[`task/types.rs:29-68`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/task/types.rs#L29-L68) [`task/types.rs:84-108`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/task/types.rs#L84-L108) [`task/types.rs:304-335`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/task/types.rs#L304-L335) [`usage.rs:100-146`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/usage.rs#L100-L146)
+8. **压缩路径本身是可观测、可离线重放的产品功能。** 每次压缩记录触发比例、阈值、输入/输出 token、重试阶段、失败类别、TTFT、流耗时、最大 token 间隔、两段式命中/失效等；同时把“实际送给压缩模型的历史 + 返回摘要/错误”保存成 artifact，供离线迭代 prompt。[`compaction.rs:800-864`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L800-L864) [`session_compact.rs:219-310`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/helpers/session_compact.rs#L219-L310) [`persistence.rs:360-374`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/persistence.rs#L360-L374)
+
+对 Catty 的优先级建议：先做 **压缩后状态再注入 + 工具历史完整性修复 + 压缩 artifact/eval**；随后做 **可恢复 segments**；最后用实验开关验证 **后台两段式压缩**。这些项的收益与风险边界最清晰。
+
+## 1. 提示词与上下文装配
+
+### 1.1 PromptContext 是正式协议
+
+`PromptContext` 是可序列化的第一等对象，而不是最终 prompt 的临时参数。它包含 schema version、prompt mode、父/子 audience、可覆盖的基础模板、AGENTS.md 列表、memory 路径、role/persona、OS/shell/cwd/date 和 non-interactive 状态。[`prompt/context.rs:79-151`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-agent/src/prompt/context.rs#L79-L151)
+
+渲染统一走 ToolBridge 的模板引擎，因此工具名不是写死在 prompt 中，换工具集或兼容模式时仍能解析正确名称；`Extend` 支持基础模板 + 自定义 body，`Full` 支持完全替换。[`prompt/context.rs:233-297`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-agent/src/prompt/context.rs#L233-L297)
+
+父/子 agent 的差异被显式建模：子 agent 用紧凑模板、不接收 persona catalog，但仍接收完整 AGENTS.md，避免验证型子任务绕过项目约束。[`prompt/context.rs:68-77`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-agent/src/prompt/context.rs#L68-L77) [`prompt/context.rs:160-170`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-agent/src/prompt/context.rs#L160-L170) [`prompt/context.rs:205-220`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-agent/src/prompt/context.rs#L205-L220)
+
+**Catty 可借鉴：** 给现有 system prompt/context manager 增加一个可 dump、可版本化的 `PromptContextSnapshot`，让问题排查能回答“这轮究竟注入了什么、来自哪里、为何出现”。
+
+### 1.2 项目规则有顺序、来源和幂等性
+
+AGENTS.md/rules 的查找顺序是 global → repo root → cwd，越深的文件越晚出现、冲突时优先；兼容 Claude/Cursor 规则目录，并受 gitignore 过滤，最终按 canonical path 去重。[`agents_md.rs:66-77`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-agent/src/prompt/agents_md.rs#L66-L77) [`agents_md.rs:87-168`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-agent/src/prompt/agents_md.rs#L87-L168)
+
+每段规则保留源文件路径，rules frontmatter 被剥离；恢复会话时通过结构标签或 legacy 前缀识别已有项目指令，避免重复注入。[`agents_md.rs:186-229`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-agent/src/prompt/agents_md.rs#L186-L229) [`prompt_build.rs:65-90`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/acp_session_impl/prompt_build.rs#L65-L90)
+
+### 1.3 大用户输入采用“内联摘要 + 文件指针”
+
+首轮大 prompt 超过 25 KB 时，不直接粗暴截掉尾部：会把全文写到 session 文件，内联内容按 query 80%、context 余量、skills 独立 4 KB 预算分配，并保留 head + tail，确保结尾真正问题仍在；写盘失败则改成无路径的诚实提示，避免模型追逐不存在的文件。[`prompt_build.rs:185-202`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/acp_session_impl/prompt_build.rs#L185-L202) [`prompt_build.rs:203-276`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/acp_session_impl/prompt_build.rs#L203-L276) [`prompt_build.rs:278-309`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/acp_session_impl/prompt_build.rs#L278-L309)
+
+这和 Catty 已有的 tool output handle 思路相似，但 Grok 把同一模式也用于用户输入。值得统一成通用的“上下文外置对象”：有稳定 handle、摘要、大小、来源、读取工具和生命周期。
+
+## 2. Token 预算与上下文计量
+
+Grok 把 bytes/4 估算、图片固定成本、百分比、剩余量和阈值判断放在共享 crate，所有 UI、预检和自动压缩使用同一套整数语义；阈值是 `>=`，边界行为有测试固定。[`xai-token-estimation/src/lib.rs:1-32`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-token-estimation/src/lib.rs#L1-L32) [`xai-token-estimation/src/lib.rs:35-104`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-token-estimation/src/lib.rs#L35-L104) [`xai-token-estimation/src/lib.rs:188-207`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-token-estimation/src/lib.rs#L188-L207)
+
+运行时不是只信模型上次返回的 usage：`get_estimated_total_tokens` 会把上次模型总量与之后新增的工具结果估算相加，用于下一次请求前的 overflow 检查。[`handle.rs:403-419`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/handle.rs#L403-L419) [`mutations.rs:112-127`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/actor/mutations.rs#L112-L127)
+
+工具 schema 本身也进入压缩预算；输入溢出时采用 `verbatim → fitted verbatim → lossy` 的降级阶梯，fitted 为摘要预留 32,768 token，再扣除工具 schema token；lossy 最多使用窗口 70%。[`compaction.rs:879-890`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L879-L890) [`compaction.rs:931-946`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L931-L946) [`compaction.rs:1062-1116`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L1062-L1116)
+
+**Catty 可借鉴：** 统一 `tokenEstimator`、UI context 指示、step pruning 与 413 预检的边界语义；把 tool schema、pending tool output、图片字节都纳入“下一请求成本”，而不是只看上一响应 usage。
+
+## 3. 历史裁剪、压缩与可恢复性
+
+### 3.1 三层减负
+
+第一层是工具本身输出限额：一般工具默认 40 KB，终端结果默认 20,000 字符；完整终端输出写文件，模型收到头尾预览和文件路径。[`xai-grok-tools/src/lib.rs:5-16`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/lib.rs#L5-L16) [`types/output.rs:413-432`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/types/output.rs#L413-L432) [`types/output.rs:1217-1238`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/types/output.rs#L1217-L1238)
+
+第二层是请求副本 pruning：只在窗口超过 50% 后运行，近 3 个用户轮不动；较老且超过 4,000 字符的结果保留头尾各 1,500；10 轮以前只留 placeholder。[`request_builder.rs:155-208`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/actor/request_builder.rs#L155-L208) [`types.rs:67-97`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/types.rs#L67-L97)
+
+第三层才是整段 compaction。默认阈值 85%，可配模型、memory flush、5 分钟 wall-clock backstop，并可启用两段式模式。[`xai-grok-agent/src/compaction.rs:3-44`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-agent/src/compaction.rs#L3-L44)
+
+这种分层优于“每轮都压缩工具结果”：它刻意保护稳定前缀，避免频繁改写旧消息导致 KV cache miss。[`request_builder.rs:64-85`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/actor/request_builder.rs#L64-L85)
+
+### 3.2 两段式后台预压缩
+
+两段式先按估算 token 权重切分约 95%/5%，且切点会避开 assistant tool_calls 与对应 ToolResult，保证结构合法。[`two_pass.rs:29-50`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/two_pass.rs#L29-L50) [`two_pass.rs:52-139`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/two_pass.rs#L52-L139)
+
+NOTE1 最多 12,000 字符；优先取完整、足够长的 `<summary>`，否则使用原始输出。正式压缩前缓存必须同时满足 prefix_len、model slug、前缀 fingerprint 三项，任何不一致都退回单段压缩。[`two_pass.rs:14-20`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/two_pass.rs#L14-L20) [`two_pass.rs:141-187`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/two_pass.rs#L141-L187) [`compaction.rs:379-415`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L379-L415)
+
+它还区分“后台已经完成的延迟”和“用户实际等待的延迟”，只有后者计入最终 TTFT；这是评估 speculative work 是否真的降低用户等待的正确方法。[`compaction.rs:342-355`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L342-L355) [`compaction.rs:416-428`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L416-L428)
+
+**风险：** 后台 pass1 会额外花 token，且 prefix fingerprint 目前只 hash item 类型和 text_content，没有显式 hash tool call arguments；如果 tool calls 的参数不在 `text_content()` 中，理论上可能出现缓存误命中。Catty 若实现，应使用完整 canonical serialization fingerprint，并先用命中率、浪费 token、同步等待下降三项实验数据验证。
+
+### 3.3 压缩后恢复精确细节
+
+`CompactionMode` 提供 summary-only、指向原始 `updates.jsonl`、以及 clean Markdown segment store 三种模式。后两者在摘要尾部告诉后继 agent 如何用 read/grep 找回精确内容。[`compaction_mode.rs:7-20`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/compaction_mode.rs#L7-L20) [`compaction_mode.rs:51-77`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/compaction_mode.rs#L51-L77)
+
+segment 有独立索引、关键词、turn/tool/file/error 统计和不同细节级别；fork 时连同 segments 一起复制，因此子分支不会因为父会话压缩失去早期证据。[`compaction_transcript.rs:75-140`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/compaction_transcript.rs#L75-L140) [`compaction_transcript.rs:184-267`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/compaction_transcript.rs#L184-L267) [`fork.rs:92-106`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/fork.rs#L92-L106)
+
+**Catty 可借鉴：** `ToolOutputStore` 解决的是大工具输出，segments 解决的是“摘要后整个旧对话”。两者可共用 handle/read 基础设施：压缩摘要携带结构化 archive manifest，按 segment/turn/tool/file 查询，而非只给一个巨大 transcript 路径。
+
+### 3.4 压缩后重新建立“工作现场”
+
+压缩成功后，Grok 不直接只留下 system + summary。它重新构造 AGENTS.md、skills、memory、计划模式、运行中的后台命令、活跃子 agent、改过的文件、MCP 和 todo，再对 compacted history 做 orphan ToolResult 清理与验证；若仍不合法，退回更小的安全历史。[`compaction.rs:1205-1350`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L1205-L1350) [`compaction.rs:1425-1499`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L1425-L1499) [`compaction.rs:1504-1548`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L1504-L1548)
+
+这是对 Catty 最直接的改进点：现有 SessionState reinjection 可以扩展为正式的 `ContinuationState`，明确包含 active jobs、subagents、todo/plan、edited files、MCP/tool catalog version、skills/AGENTS snapshot、外置输出 handles，并有 schema/version 和恢复测试。
+
+## 4. 工具结果与缓存
+
+Grok 明确区分 `ToolRunResult.output`（干净、协议/序列化/追踪用）和 `prompt_text`（可附 reminder、专供模型），避免 UI/协议数据被模型提示加工污染。[`types/output.rs:128-145`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/types/output.rs#L128-L145)
+
+对话完整性修复发生在确定的写边界，不在任意读取时运行，避免把仍在执行中的并行工具误判为悬空；修复会持久化，因而恢复后不会重复撞 provider 400。[`mutations.rs:26-43`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/actor/mutations.rs#L26-L43) [`mutations.rs:47-70`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/actor/mutations.rs#L47-L70)
+
+图片处理也考虑 cache：只有请求体接近 50 MB 才批量移除最旧图片，并一次降到 25 MB，形成迟滞区，避免每轮移一张、每轮破坏 KV 前缀；占位文案明确告诉模型图片已不可见，避免凭“记忆”幻觉描述。[`request_builder.rs:215-265`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/actor/request_builder.rs#L215-L265)
+
+**Catty 可借鉴：** 所有会改写历史前缀的策略都应有 cache-cost 意识；用 high-water/low-water 批处理，而不是刚过线就做最小改写。并将“干净工具结果”和“给模型看的文本”拆为两个字段，防止 reminder、裁剪标记污染恢复/审计数据。
+
+## 5. 会话恢复与分叉
+
+本地会话只有存在 `summary.json` 才算可恢复，避免只有 images 的残缺目录劫持 resume；远端恢复会寻找同 cwd 下最新的本地 child，避免重复恢复。[`persistence.rs:395-419`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/persistence.rs#L395-L419) [`persistence.rs:422-453`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/persistence.rs#L422-L453)
+
+分叉会复制 chat、updates、plan state 和 compaction segments，记录 parent_session_id，并可指定 prompt index/model/cwd；磁盘复制放到 blocking pool，后台注册服务端，不阻塞本地 fork 的关键路径。[`fork.rs:64-113`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/fork.rs#L64-L113) [`fork.rs:115-163`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/fork.rs#L115-L163)
+
+恢复/子 agent spawn 对 system prompt 的策略不同：顶层 resume 保留历史 system；子 agent resume 继承 raw transcript 和 tool state，但用当前定义重新渲染 system，避免旧 persona/工具目录永久冻结。[`prompt_build.rs:92-110`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/acp_session_impl/prompt_build.rs#L92-L110) [`task/types.rs:44-47`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/task/types.rs#L44-L47)
+
+## 6. 子 agents
+
+子 agent channel protocol 把身份、parent prompt、resume_from、cwd、runtime overrides、是否后台、是否向父模型展示完成事件、是否 fork parent context 都作为明确字段。[`task/types.rs:29-68`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/task/types.rs#L29-L68)
+
+能力不是简单的“全工具/无工具”，而是 ReadOnly、ReadWrite、Execute、All 四档，并在移除所有能产生后台任务的工具时同步移除无意义的 get/kill 生命周期工具。[`task/types.rs:139-174`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/task/types.rs#L139-L174) [`task/types.rs:189-300`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/task/types.rs#L189-L300)
+
+父子共享 filesystem、terminal backend、memory、scheduler、hunk tracker、hooks 等运行资源，但子会话有独立的 model/context threshold/usage/session signals；背景子 agent 在父轮取消时继续，前台子 agent 才按 parent_prompt_id 取消。[`subagent/mod.rs:135-214`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/agent/subagent/mod.rs#L135-L214) [`task/types.rs:39-58`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/task/types.rs#L39-L58)
+
+用量账本区分 main-loop calls 与 subagent calls，能按 model 汇总 input/output/cached/reasoning/cost，并显式标记 incomplete；后台仍在跑时不伪造精确账单。[`usage.rs:1-26`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/usage.rs#L1-L26) [`usage.rs:31-89`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/usage.rs#L31-L89) [`usage.rs:100-146`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/usage.rs#L100-L146)
+
+**Catty 可借鉴：** 将 subagent completion 从一段自由文本提升为结构化结果：status、session id、turn/tool count、duration、tokens、worktree、archive handles；父上下文仅保留短摘要，细节通过 resume/read 获取。
+
+## 7. Hooks 与 Skills
+
+Hook 生命周期覆盖 session、turn stop/failure、pre/post tool、permission denied、prompt submit、notification、subagent 和 pre/post compact；envelope 包含 session/cwd/workspace/transcript/prompt id，tool payload 限制为 128 KB。[`event.rs:3-49`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-hooks/src/event.rs#L3-L49) [`event.rs:152-172`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-hooks/src/event.rs#L152-L172) [`event.rs:201-240`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-hooks/src/event.rs#L201-L240) [`event.rs:322-340`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-hooks/src/event.rs#L322-L340)
+
+只有 PreToolUse 是阻塞决策；hook 超时/崩溃采取 fail-open，并把失败展示与记录，而不是默默吞掉。[`event.rs:127-149`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-hooks/src/event.rs#L127-L149) [`dispatcher.rs:15-35`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-hooks/src/dispatcher.rs#L15-L35)
+
+Skills 采用渐进披露：启动时仅列名称/说明/路径，单条说明上限 400 bytes，整个 listing 预算由 context window 推导；实际 body 调用时再载入。[`skill_discovery_tracker/listing.rs:1-20`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/types/skill_discovery_tracker/listing.rs#L1-L20) [`skill_discovery_tracker/listing.rs:79-120`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/types/skill_discovery_tracker/listing.rs#L79-L120)
+
+运行期还会根据 read/list/edit/apply_patch 实际触达路径发现或激活 skills；I/O 在资源锁外执行，checked_dirs 回写避免重复 stat，公告由 session 统一排队去重。[`skill_discovery.rs:27-45`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/reminders/skill_discovery.rs#L27-L45) [`skill_discovery.rs:109-155`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/reminders/skill_discovery.rs#L109-L155) [`skill_discovery.rs:159-218`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/reminders/skill_discovery.rs#L159-L218)
+
+**Catty 可借鉴：** hook 应进入统一 AgentEvent trace；skill announcement 需要预算和去重，并在压缩后恢复“已宣布/已激活”状态，避免每次 compaction 后重复灌入。
+
+## 8. 可观测性与离线评估
+
+压缩 span 记录 trigger、使用比例、阈值、tokens before、attempts、degenerate/input-overflow/deterministic/transient rejection、TTFT、stream time、delta count、最大 inter-token gap、两段式是否使用、prefire hit/wait/stale 和 prefix release。[`compaction.rs:800-864`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L800-L864) [`compaction.rs:1150-1202`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs#L1150-L1202)
+
+compaction streaming timing 是 O(1) accumulator，不保存每 token 时间戳；能直接算 TTFT、流持续时间、delta 数和最大间隔。[`session_compact.rs:256-310`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/helpers/session_compact.rs#L256-L310)
+
+更关键的是持久化 `compaction_requests/{id}.json`：包含精确输入 ConversationItem、工具定义、模型、用户额外上下文、摘要或错误和每次尝试细节，注释明确说用于 offline prompt iteration。[`persistence.rs:360-368`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/persistence.rs#L360-L368)
+
+这使“摘要质量”可以离线回放，而不是靠线上主观反馈。Catty 应补一套固定 eval：
+
+- continuation state recall：active task/subagent/todo/edited file 是否完整；
+- exact-detail recovery：摘要缺失时能否从 archive 找回具体错误、命令、路径；
+- tool-call integrity：压缩/取消/恢复后无 dangling/orphan/duplicate；
+- instruction retention：用户约束、AGENTS.md、skill 触发在多次压缩后仍有效；
+- latency/cost：同步压缩等待、prefire 命中率、浪费 token、cached input 比例；
+- continuation success：后继 agent 在不看原始 transcript 时能否完成下一步。
+
+## 9. 原创实现与移植部分的边界
+
+仓库的正式归属声明非常明确：从 OpenAI Codex 移植的是 `xai-grok-tools/src/implementations/codex/` 下的 apply_patch、grep_files、list_dir、read_file；从 sst/opencode 移植的是 `implementations/opencode/` 下 bash、edit、glob、grep、read、skill、todowrite、write。[`THIRD_PARTY_NOTICES.md:1-12`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/THIRD_PARTY_NOTICES.md#L1-L12) [`THIRD_PARTY_NOTICES.md:14-42`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/THIRD_PARTY_NOTICES.md#L14-L42)
+
+因此本笔记讨论的 `PromptContext`、chat-state actor、分层 pruning、图片迟滞、两段式 prefire compaction、segment archive、ContinuationState 重建、session fork/resume、subagent coordinator、usage ledger、hook runtime、compaction telemetry/artifacts，均不在声明的 Codex/OpenCode 移植目录中，应视为 Grok Build 自己的 runtime/context-engineering 实现。这里的“原创”只表示**仓库归属证据显示不是那两组移植文件**，不主张它在思想史上从未受其他 agent 产品启发。
+
+需要特别避免误判：Grok 可以配置 `Codex` prompt profile，也能组合 OpenCode 工具集；这表示兼容/复用工具行为，不等于它的上下文 runtime 来自 Codex/OpenCode。[`prompt/context.rs:15-29`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-agent/src/prompt/context.rs#L15-L29) [`xai-grok-agent/src/config.rs:518-528`](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-agent/src/config.rs#L518-L528)
+
+## 10. 给 Catty 的落地计划建议
+
+### P0：先补正确性与评估底座
+
+1. 定义版本化 `ContinuationState`，压缩后确定性重注入 active jobs、subagents、todo/plan、edited paths、MCP、skills/AGENTS、tool-output handles。
+2. 在开始新轮、取消完成、恢复、压缩替换四个边界运行 conversation integrity repair，并记录修复数与原因。
+3. 保存每次 compaction 的精确输入、输出、模型、token、重试与错误 artifact；建立 20–50 条真实长会话的离线 continuation eval。
+
+### P1：增加可恢复的压缩档案
+
+4. 在现有 ToolOutputStore 上增加 conversation segment handles 和索引；摘要只带 manifest/恢复提示，不塞回全文。
+5. 对工具结果采用“近轮保护、旧结果头尾裁剪、极旧占位”的分层策略，并保证原始 trace 仍可重放。
+6. 给大用户输入使用同一套外置 handle，不让首轮超长需求在进入 agent 前就丢失尾部。
+
+### P2：在实验开关下优化延迟与缓存
+
+7. 实现带完整 canonical fingerprint 的后台两段式 compaction；记录 hit/stale/wasted tokens/sync wait saved。
+8. 对会破坏 prompt cache 的历史改写采用 high-water/low-water 批处理，并比较 cached input tokens 的变化。
+9. 将 skill listing、tool catalog、MCP announcement 都纳入独立预算和持久化去重状态。
+
+### 不建议直接照搬
+
+- 不应直接采用 bytes/4 作为唯一 token 估算器；Catty 已有模型相关估算基础，应保留实际 tokenizer/usage 校正，只统一边界语义。
+- 不应未经 eval 就开启后台 pass1；它可能增加费用且缓存失效会造成纯浪费。
+- 不应把 50%/85%/95%、40 KB、10 轮等常数照抄；这些是 Grok 的模型和服务约束，应由 Catty 的 trace 分布校准。
+- Hook 的 fail-open 是 Grok 明示的威胁模型选择，不适合作为所有安全策略的默认值；Catty 需要按 hook 类型区分“工作流扩展”和“安全门禁”。
+
+## 最终判断
+
+Catty 现有架构已经有 pre-turn compaction、step pruning、413 retry、SessionState reinjection、ToolOutputStore 和统一 AgentEvent，方向是对的。Grok Build 显示下一阶段最有价值的不是再加一种总结 prompt，而是把这些模块连成一个**可恢复、可验证、可观测的上下文生命周期**：压缩前分层减负，压缩时保存证据，压缩后重建现场，细节按需恢复，所有路径都能离线重放和量化。

--- a/docs/research/grok-build-terminal-context-comparison.md
+++ b/docs/research/grok-build-terminal-context-comparison.md
@@ -1,0 +1,211 @@
+# Grok Build 终端上下文工程研究：给 Catty 的对照结论
+
+## 研究范围与结论口径
+
+- Grok Build 本地源码：`/Users/chenqi/.codex/external-sources/grok-build`
+- 仓库当前提交：`8adf9013a0929e5c7f1d4e849492d2387837a28d`
+- 仓库内 `SOURCE_REV`：`2ec0f0c8488842da03a71eeee3c61154957ca919`
+- Catty 源码：本报告所在 Netcatty 工作树
+- **已验证**：可直接由源码或本地只读实跑证明。
+- **推断**：由多处实现拼合出的行为判断，尚未做完整产品级端到端复现。
+
+一句话结论：**Grok 最值得 Catty 学的不是“多截一点输出”，而是把终端分成三层：原始输出单独保存、给模型的内容严格限额、持续日志进入对话前先做限流和抑制。Catty 的增量轮询和远程编码处理其实更好，但当前有两个入口能绕过限额，另有一个入口会稳定累积重复输出；这三个确定性问题都足以直接塞满上下文，必须先修。**
+
+## 一、Grok 的终端输出怎样流动
+
+```text
+命令进程
+  ├─ 原始 stdout/stderr ──> session/terminal/<tool_call_id>.log
+  │                           ├─ 运行期最多 5 GiB，超过则杀进程
+  │                           └─ 退出后只留文件前 64 MiB
+  ├─ 模型结果内存 ────────> 默认约 20k 字符：前半冻结 + 后半滚动
+  │                           └─ 去 ANSI、超长行每 2000 字符软换行
+  └─ 后台读取 ────────────> get_task_output
+                              └─ 超限时只回前 2k 预览 + 文件路径
+
+交互 PTY 是另一条通道：256 KiB 环形缓冲 + offset + base64 推送，
+不会自动把整个终端画面塞进模型对话。
+```
+
+### 1. 原始输出与模型输出分开
+
+- **已验证**：每次 Bash 调用都会把输出写入会话目录下的 `terminal/<tool_call_id>.log`，而不是只留在对话消息里。[bash/mod.rs:1915](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/bash/mod.rs:1915)
+- **已验证**：模型侧默认终端预算为 20,000 字符；超出后冻结前半、滚动保留后半，再插入截断提示。[bash/mod.rs:156](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/bash/mod.rs:156) [terminal.rs:346](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/computer/local/terminal.rs:346)
+- **已验证**：原始字节转模型文本时用 UTF-8 容错解码；非法字节会被替换，因此二进制输出和错误编码并不是无损的。[terminal.rs:308](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/computer/local/terminal.rs:308)
+- **已验证**：模型看到的文本会去掉 ANSI 控制码，超长单行按 2,000 字符软换行；磁盘文件仍保存原始字节。[bash/mod.rs:406](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/bash/mod.rs:406) [output.rs:413](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/types/output.rs:413)
+- **已验证**：stdout 与 stderr 被收进同一个输出流和文件；每次轮询先读完当前 stdout，再读 stderr，所以二者的相对时间顺序并不精确。[terminal.rs:1528](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/computer/local/terminal.rs:1528)
+
+这套设计最重要的价值是：**模型消息只是有界索引，原始输出是独立资产。** Catty 目前成功命令也有类似“预览 + handle”，但全文仍在渲染进程内存中，没有磁盘配额、TTL 或范围读取。
+
+### 2. 长任务和失控输出有多层保险
+
+- **已验证**：前台可自动转后台的命令默认最多阻塞当前轮 15 秒；后台任务最长运行 10 小时。[terminal.rs:47](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/computer/local/terminal.rs:47)
+- **已验证**：运行中输出文件默认最多 5 GiB，超出会终止进程；进程结束后文件被 `set_len(64 MiB)`。[terminal.rs:65](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/computer/local/terminal.rs:65) [terminal.rs:382](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/computer/local/terminal.rs:382) [terminal.rs:1236](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/computer/local/terminal.rs:1236)
+- **已验证**：退出后仍会最多等待 2 秒排空管道，避免子进程继承管道导致永久卡住。[terminal.rs:77](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/computer/local/terminal.rs:77)
+- **已验证**：完成的后台任务在内存中保留 5 分钟，之后只保留最多 100 条轻量元数据；输出仍指向磁盘文件。[terminal.rs:42](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/computer/local/terminal.rs:42) [terminal.rs:1432](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/computer/local/terminal.rs:1432)
+- **已验证**：会话文件默认 30 天后清理，可配置；当前会话目录会跳过。[persistence.rs:2600](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/persistence.rs:2600)
+
+需要注意两个不能照搬的点：
+
+1. 5 GiB 对桌面应用太大；Catty 应采用更小的默认值和全局总配额。
+2. Grok 提示模型“完整输出在文件”，但退出后只保留**文件开头** 64 MiB，因此对更大输出这句话不准确；末尾错误甚至可能丢失。
+
+### 3. 后台读取并不是真正的增量读取
+
+- **已验证**：`get_task_output` 每次读取当前完整快照；若超过预算，只回前 2,000 字符预览并给出文件路径。[task_output/tool.rs:11](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/task_output/tool.rs:11)
+- **已验证**：多任务读取允许最多 20 个任务，各自独立套用默认约 40 KiB 上限，没有统一总预算。[task.rs:318](/Users/chenqi/.codex/external-sources/grok-build/crates/common/xai-tool-types/src/task.rs:318) [task_output/mod.rs:205](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/task_output/mod.rs:205)
+- **推断**：一次多任务调用最坏仍可能向上下文注入约 800 KiB，而且重复轮询会把相同预览反复写进历史。Grok 的模型读取没有 Catty 的 `nextOffset` 语义。
+
+因此，**Catty 的 `terminal_start` / `terminal_poll` 设计更好**：它有 256 KiB 滚动尾窗、`outputBaseOffset`、`totalOutputChars`、`outputTruncated` 和 `nextOffset`，并按聊天会话隔离任务。[aiExec.cjs:16](/Users/chenqi/.codex/worktrees/de5f/netcatty/electron/terminalWorker/aiExec.cjs:16) [aiExec.cjs:165](/Users/chenqi/.codex/worktrees/de5f/netcatty/electron/terminalWorker/aiExec.cjs:165) [aiExec.cjs:196](/Users/chenqi/.codex/worktrees/de5f/netcatty/electron/terminalWorker/aiExec.cjs:196)
+
+Catty 当前的问题不是底层没有增量，而是上层没有利用好它：相同 offset 的重复 poll 不会被历史裁剪，SessionState 也不记录 jobId、nextOffset 和已读位置。由于该问题已实测可在一次短循环内稳定累积近 50k 字符，本文将它列为 P0，而不是一般优化。
+
+### 4. 持续日志先限流，再进入对话
+
+Grok 为 monitor 单独做了一条“事件入口”，这是最值得 Catty 借鉴的部分：
+
+- **已验证**：单行最多 500 字符，一个事件批次最多 3,000 字符，原始行缓冲最多 1 MiB，200ms 合批。[monitor/types.rs:1](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/monitor/types.rs:1)
+- **已验证**：令牌桶初始允许 10 个事件，之后每 2 秒补 1 个；被抑制的事件只累计数量，恢复时发一条摘要。[rate_limiter.rs:5](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/monitor/rate_limiter.rs:5)
+- **已验证**：持续 30 秒过载后停止向对话发送该监控流，并提示改写为更精确的 grep/awk 过滤。[rate_limiter.rs:121](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/monitor/rate_limiter.rs:121)
+- **推断**：该“自动停止”只中断事件管线，没有在同一路径调用终端 kill；底层命令可能继续运行到超时或会话清理。因此 Catty 借鉴时应同时停止进程或明确标为“仅静音”。[monitor/tool.rs:321](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/monitor/tool.rs:321) [monitor/tool.rs:360](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/implementations/grok_build/monitor/tool.rs:360)
+
+对于 Catty，正确做法不是让每个终端刷新都成为一条消息，而是把它们变成：`时间窗口内合批 -> 单行/单批上限 -> 总速率限制 -> 被抑制数量摘要 -> 必要时停流/停进程`。
+
+### 5. 交互终端和模型上下文彻底分开
+
+- **已验证**：Grok 的交互 PTY 是独立客户端通道，使用 256 KiB 环形缓冲、单调 offset、16ms 合批，并以 base64 传输原始字节。[pty_session.rs:1](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/terminal/pty_session.rs:1) [pty_session.rs:186](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/terminal/pty_session.rs:186) [pty_session.rs:366](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/terminal/pty_session.rs:366)
+- **已验证**：重连时只回放这 256 KiB 环形缓冲，重建客户端终端画面；这不是模型工具结果。[pty_session.rs:530](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/terminal/pty_session.rs:530)
+
+这一边界对 Catty 尤其重要：**用户看到的终端画面可以高频、完整；模型读取必须显式、有界、可增量、可审计。** 不应把终端 UI 的 scrollback 直接当模型记忆。
+
+## 二、上下文裁剪、压缩与恢复
+
+### 1. 普通旧工具结果先做便宜裁剪
+
+- **已验证**：Grok 在上下文使用超过 50% 后，构造请求时裁剪旧工具结果；最近 3 轮不动，超过 4,000 字符的旧结果保留 1,500 头 + 1,500 尾，10 轮前直接替换为占位。[request_builder.rs:155](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/actor/request_builder.rs:155) [types.rs:67](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/types.rs:67)
+- **已验证**：这一步发生在请求副本上，不会先破坏完整会话记录；更深层的 compaction 另有归档与重建流程。[request_builder.rs:20](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-chat-state/src/actor/request_builder.rs:20) [compaction.rs:219](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs:219)
+
+Catty 已经会在预算压力下按终端 session 只保留最近两次成功的 `terminal_execute`，方向正确。[staleContextPruner.ts:184](/Users/chenqi/.codex/worktrees/de5f/netcatty/infrastructure/ai/harness/staleContextPruner.ts:184) 但它没有覆盖 `terminal_poll` 和 `terminal_read_context`，所以 6 次相同 offset 的本地实跑仍累计约 49.6k 字符且未触发调整。
+
+### 2. 压缩后要恢复“可继续工作”的状态，而不是恢复大段日志
+
+- **已验证**：Grok compaction 后会重新注入正在运行的终端任务、子代理、已编辑文件、待办和工具状态，而不是重新塞入任务输出。[compaction.rs:1205](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-shell/src/session/compaction.rs:1205)
+- **推断**：它注入运行任务 ID/命令/状态，但没有“模型上次读到哪个 offset”；加上 `get_task_output` 是全快照，压缩后仍可能重复读取。
+- **推断**：终端任务表是进程内 Map，新建 actor 时为空，未发现从磁盘恢复活进程的路径。重启后旧日志文件可能还在，但旧 taskId 不能继续作为真实运行任务读取。[terminal.rs:543](/Users/chenqi/.codex/external-sources/grok-build/crates/codegen/xai-grok-tools/src/computer/local/terminal.rs:543)
+
+Catty 应保存的是结构化任务续读状态：`jobId + sessionId + command + status + nextOffset + outputBaseOffset + handleId + sideEffectClass`。恢复时先向后端核实任务是否仍存在，再注入“仍运行 / 已完成 / 已失联”，不能假装恢复，也不能建议盲目重跑。
+
+## 三、Catty 当前最危险的三个确定性漏洞
+
+### P0-1：失败或超时输出绕过终端压缩
+
+- **已验证**：工具执行器把失败命令的完整 stdout/stderr 拼进 error。[toolExecutors.ts:96](/Users/chenqi/.codex/worktrees/de5f/netcatty/infrastructure/ai/shared/toolExecutors.ts:96)
+- **已验证**：`capabilityTools` 对失败结果直接返回，只有成功结果进入 `fitTerminalExecuteResultForModel`。[capabilityTools.ts:328](/Users/chenqi/.codex/worktrees/de5f/netcatty/infrastructure/ai/harness/capabilityTools.ts:328)
+- **已验证**：前台 PTY 默认 `maxBufferedChars=0`，而 helper 将 0 解释为不限长度。[ptyExec.cjs:27](/Users/chenqi/.codex/worktrees/de5f/netcatty/electron/bridges/ai/ptyExec.cjs:27) [ptyExecHelpers.cjs:277](/Users/chenqi/.codex/worktrees/de5f/netcatty/electron/bridges/ai/ptyExecHelpers.cjs:277)
+- **实跑已验证**：构造约 200k 字符后超时，进入模型的 error 长度为 200,035，handle 数为 0；同等大小的成功输出会被截断并生成 handle。
+
+这意味着最容易产生巨量日志的“失败、超时、构建报错”恰好绕过保护。修复标准必须是：**无论成功、失败、超时、取消、桥接异常，所有 stdout/stderr 都先经过同一个终端输出封装器，模型只拿有界预览。**
+
+### P0-2：`tool_output_read` 可以把全文重新灌回上下文
+
+- **已验证**：handle 默认读 12k，但调用方可传任意 `maxChars`；`full` 模式只是从头截到调用值，没有硬上限。[toolOutputStore.ts:67](/Users/chenqi/.codex/worktrees/de5f/netcatty/infrastructure/ai/harness/toolOutputStore.ts:67) [toolInputs.cjs:345](/Users/chenqi/.codex/worktrees/de5f/netcatty/electron/capabilities/schemas/toolInputs.cjs:345)
+- **已验证**：`tool_output_read` 被明确排除在二次 fitting 之外，因此模型可以用一个巨大 `maxChars` 将原文一次性拉回。[capabilityTools.ts:126](/Users/chenqi/.codex/worktrees/de5f/netcatty/infrastructure/ai/harness/capabilityTools.ts:126)
+
+修复标准：服务端写死单次硬上限，支持 `offset/range/search/head/tail`，返回 `nextOffset/hasMore/totalChars`；每一轮所有 handle 读取还要共享总预算，不能只限制单次调用。
+
+### P0-3：重复 poll/read_context 不参与终端历史去重
+
+- **已验证**：跨轮历史省略只识别 `terminal_execute` 的几个别名，不覆盖 `terminal_poll` 与 `terminal_read_context`。[cattyHistoryReplay.ts:112](/Users/chenqi/.codex/worktrees/de5f/netcatty/components/ai/cattyHistoryReplay.ts:112)
+- **已验证**：预算压力下的终端特化裁剪同样只识别 `terminal_execute`。[staleContextPruner.ts:98](/Users/chenqi/.codex/worktrees/de5f/netcatty/infrastructure/ai/harness/staleContextPruner.ts:98)
+- **实跑已验证**：连续 6 次使用相同 offset 读取约 8k 内容，预算压力下 `didAdjust=false`，约 49.6k 重复文本全部保留。
+
+修复标准：把每次读取标识为 `chatSessionId + sessionId/jobId + requestedOffset + nextOffset + snapshotVersion`；完全相同的读取只保留一次，后续增量可合并为一个范围。`terminal_read_context` 当前的行号会随 scrollback 淘汰或 reflow 漂移，不能假装成可靠日志 cursor；需要单独的输出版本或快照 ID。
+
+## 四、逐项对比
+
+| 维度 | Grok Build | Catty 现状 | 判断 |
+|---|---|---|---|
+| 成功命令预览 | 默认约 20k，头尾 | stdout 24k / stderr 12k，重复行压缩、头尾 + handle | Catty 不弱 |
+| 失败/超时输出 | 同一终端结果路径，仍受预算约束 | **绕过 fit，可无上限** | Catty P0 |
+| 原文保存 | 会话磁盘文件，有运行/完成/TTL上限 | JS 内存全文，无总量/TTL/LRU | Grok 更完整 |
+| 后台读取 | 全快照，超限前 2k + 文件；无 offset | `nextOffset` 增量 + 256 KiB 尾窗 | Catty 更好 |
+| 重复读取去重 | 无真正 cursor，可能重复 | 底层有 cursor，上下文层不按 job+offset 去重 | Catty 应补上层 |
+| handle 读取 | 通过有界工具读文件 | head/tail/full，但 `maxChars` 无硬上限 | Catty P0 |
+| ANSI/进度条 | 模型预览去 ANSI，monitor 合批限流 | PTY normalize 去 ANSI/CR，但各工具路径不统一 | Grok 更一致 |
+| UTF-8/远程编码 | UTF-8 lossy | Stateful decoder，支持 GBK/GB18030 分块 | Catty 更强 |
+| 持续日志 | monitor 专用入口：批次、速率、抑制 | 主要依赖模型谨慎 poll | Grok 值得学 |
+| 交互 PTY | 与模型工具分离，256 KiB 环形缓冲 | UI 终端与 AI 能力分层，但 read_context 仍是屏幕行语义 | 原则一致 |
+| 历史裁剪 | 通用旧 tool result 分层裁剪 | terminal_execute 特化，poll/read_context 未覆盖 | Grok 更完整 |
+| 压缩后任务状态 | 注入运行任务，但无已读 offset | SessionState 只记 lastCommand | 两边都有缺口 |
+| 敏感信息 | 未发现通用终端 secret redaction | 未发现；catalog 还标为 `sensitiveRead:false` | 两边都缺 |
+| 会话/跨聊天隔离 | 任务有 owner session | 后台 job 按 chatSessionId 校验 | 两边都有基础 |
+
+## 五、建议实施顺序
+
+### P0：先堵住能直接撑爆上下文或泄密的入口
+
+1. **统一终端输出封装**：成功、失败、超时、取消、异常全部走同一预算器；先保存原文，再只回结构化预览。
+2. **锁死 `tool_output_read`**：单次和单轮双重硬上限；增加 offset/range/search；禁止调用参数放大服务端上限。
+3. **让 poll/read_context 真正去重**：相同范围不得重复进入历史；只保存已读区间、摘要和下次 offset。
+4. **终端敏感信息处理**：在进入模型前识别并遮罩常见 token、私钥、密码、连接串；原文只留本地受控存储，并明确生命周期。
+5. **写命令 413 只执行一次**：压缩或重试只能重放已记录结果，不能重新执行有副作用的命令。历史提示也不应默认写“Re-run terminal_execute”。[cattyHistoryReplay.ts:112](/Users/chenqi/.codex/worktrees/de5f/netcatty/components/ai/cattyHistoryReplay.ts:112)
+
+### P1：把现有增量能力变成真正的上下文能力
+
+1. SessionState 保存运行任务和最后已读 offset；compaction 后先核实真实状态，再恢复续读位置。
+2. ToolOutputStore 增加每 handle、每 chat、全局总字节数、条数、TTL、LRU；关闭终端和删除聊天时精确清理。
+3. 大输出从 JS heap 移到 Netcatty 专用临时目录；以不可猜 handle 访问，使用受限权限，支持字节范围读取和搜索。
+4. 统一 ANSI、CR 进度、超长单行、重复行、binary/base64/高熵文本处理；保留 `encoding` 与是否 lossy 的元数据。
+5. 为 follow/watch/log tail 增加 Grok monitor 式入口：200ms 合批、单行/单批预算、速率限制、抑制计数和明确的停流/停进程行为。
+
+### P2：长期上下文质量
+
+1. 通用工具历史裁剪覆盖 terminal_execute、terminal_poll、terminal_read_context 和 tool_output_read，而不是按工具名漏补。
+2. 结构化保存命令 outcome：命令、退出码、时间、是否有副作用、摘要、handle、任务状态；旧历史删原文但保留事实。
+3. 建立离线终端上下文基准，记录峰值上下文占比、重复率、错误定位率、秘密暴露数和写命令执行次数。
+
+## 六、交付前硬门槛与 13 个压测场景
+
+以下门槛建议作为合并前必须通过的条件：
+
+- 写命令遇到 413：`WriteCount = 1`。
+- 并发任务串线、跨聊天读取：`crossTalk = 0`、`crossChatRead = 0`。
+- 模型可见内容里的测试密钥：`SecretExposure = 0`。
+- UTF-8 分块边界不损坏；Catty 原有 GBK/GB18030 能力不退化。[ptyExecHelpers.cjs:8](/Users/chenqi/.codex/worktrees/de5f/netcatty/electron/bridges/ai/ptyExecHelpers.cjs:8)
+- 任一场景不得把上下文推到窗口的 90% 以上。
+
+建议自动化 13 场景：
+
+1. 持续高速日志；
+2. 超长单行；
+3. 关键错误位于输出中段；
+4. ANSI 颜色与 `\r` 进度刷新；
+5. UTF-8 多字节字符跨 chunk；
+6. 二进制与高熵 base64；
+7. 四个并发终端；
+8. 后台任务多次轮询；
+9. 相同 offset 重复读取；
+10. 有副作用命令执行后触发 413；
+11. 应用重启 / session resume；
+12. 输出包含 token、密码、私钥片段；
+13. handle 过期、淘汰和跨聊天访问。
+
+每个场景至少采集：进入模型字符数、原始输出字符数、压缩比、重复字符比例、峰值上下文占比、handle 数和内存/磁盘占用；涉及命令的再采集执行次数、任务归属和最终状态。
+
+## 七、不建议照搬 Grok 的地方
+
+1. 不照搬 5 GiB 运行文件默认上限；桌面产品应更保守并有全局配额。
+2. 不照搬“完成后截文件开头 64 MiB”；应保留头尾或分块索引，否则真正错误常在末尾。
+3. 不照搬 `get_task_output` 全快照；Catty 已有 offset，应把它贯彻到上下文历史。
+4. 不照搬多任务各自限额却没有聚合限额。
+5. 不照搬 monitor “显示已停止但未确认进程已杀”的含糊语义。
+6. 不照搬仅 UTF-8 lossy；Catty 的 stateful decoder 和远程编码支持必须保留。
+7. 不把“文件路径”直接当安全 handle；路径泄露、权限和生命周期都需要单独设计。
+
+## 最终判断
+
+Catty 不需要复制 Grok 的终端系统。Catty 已经有更适合真实终端代理的底座：远程会话、增量 offset、尾窗、跨聊天隔离和多编码解码。真正需要补的是模型入口治理：
+
+> 任何终端字节进入模型前都必须经过同一个有界入口；任何大输出只能通过有额度、有游标、可过期的句柄读取；任何持续日志都先限流再入对话；任何压缩与恢复都保存任务事实和已读位置，而不是保存或重放大段日志。
+
+先修三个 P0，再补句柄生命周期和 monitor 式限流，Catty 在“会真正操控终端”的场景里会比 Grok 当前实现更稳，也更不容易因一次失败命令把整个上下文窗口打满。

--- a/electron/bridges/tempDirBridge.cjs
+++ b/electron/bridges/tempDirBridge.cjs
@@ -11,9 +11,16 @@ const os = require("node:os");
 
 // Netcatty temp directory name
 const NETCATTY_TEMP_DIR_NAME = "Netcatty";
+const MAX_TOOL_OUTPUT_TEMP_CHARS = 4_000_000;
+const MAX_TOOL_OUTPUT_TEMP_BYTES = 8_000_000;
+const TOOL_OUTPUT_TEMP_TTL_MS = 30 * 60 * 1_000;
+const TOOL_OUTPUT_READ_MAX_CHARS = 12_000;
+const TOOL_OUTPUT_SEARCH_CONTEXT_CHARS = 320;
+const TOOL_OUTPUT_SEARCH_MAX_MATCHES = 20;
 
 // Cached temp directory path
 let cachedTempDir = null;
+let cachedTempDirIdentity = null;
 let tempFileCounter = 0;
 
 /**
@@ -22,14 +29,8 @@ let tempFileCounter = 0;
  */
 function getTempDir() {
   if (cachedTempDir) {
-    // Verify it still exists
-    try {
-      if (fs.existsSync(cachedTempDir)) {
-        return cachedTempDir;
-      }
-    } catch {
-      // Directory was deleted, recreate it
-    }
+    assertSafeTempDir(cachedTempDir, cachedTempDirIdentity);
+    return cachedTempDir;
   }
   
   const systemTempDir = os.tmpdir();
@@ -37,16 +38,34 @@ function getTempDir() {
   
   try {
     if (!fs.existsSync(netcattyTempDir)) {
-      fs.mkdirSync(netcattyTempDir, { recursive: true });
+      fs.mkdirSync(netcattyTempDir, { recursive: true, mode: 0o700 });
       console.log(`[TempDir] Created Netcatty temp directory: ${netcattyTempDir}`);
     }
+    const safeStat = assertSafeTempDir(netcattyTempDir);
     cachedTempDir = netcattyTempDir;
+    cachedTempDirIdentity = { dev: safeStat.dev, ino: safeStat.ino };
     return netcattyTempDir;
   } catch (err) {
     console.error(`[TempDir] Failed to create temp directory:`, err.message);
-    // Fallback to system temp dir
-    return systemTempDir;
+    throw err;
   }
+}
+
+function assertSafeTempDir(tempDir, expectedIdentity) {
+  const stat = fs.lstatSync(tempDir);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("Netcatty temp path is not a safe directory.");
+  if (typeof process.getuid === "function" && stat.uid !== process.getuid()) {
+    throw new Error("Netcatty temp directory is not owned by the current user.");
+  }
+  if (expectedIdentity && (stat.dev !== expectedIdentity.dev || stat.ino !== expectedIdentity.ino)) {
+    throw new Error("Netcatty temp directory identity changed during this process.");
+  }
+  fs.chmodSync(tempDir, 0o700);
+  const expectedRealPath = path.join(fs.realpathSync(path.dirname(tempDir)), path.basename(tempDir));
+  if (fs.realpathSync(tempDir) !== expectedRealPath) {
+    throw new Error("Netcatty temp directory must not traverse symbolic links.");
+  }
+  return stat;
 }
 
 /**
@@ -149,10 +168,137 @@ function getTempFilePath(fileName) {
   return path.join(tempDir, `${timestamp}_${tempFileCounter}_${safeFileName}`);
 }
 
+function isNetcattyTempPath(filePath) {
+  if (typeof filePath !== "string" || !filePath) return false;
+  const tempDir = path.resolve(getTempDir());
+  const resolved = path.resolve(filePath);
+  const relative = path.relative(tempDir, resolved);
+  return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+async function openSafeToolOutputFile(filePath) {
+  if (!isNetcattyTempPath(filePath)) return null;
+  let file;
+  try {
+    const noFollow = fs.constants.O_NOFOLLOW ?? 0;
+    file = await fs.promises.open(filePath, fs.constants.O_RDONLY | noFollow);
+    const stat = await file.stat();
+    assertSafeTempDir(getTempDir(), cachedTempDirIdentity);
+    const pathStat = await fs.promises.lstat(filePath);
+    if (pathStat.isSymbolicLink() || pathStat.dev !== stat.dev || pathStat.ino !== stat.ino) {
+      await file.close();
+      return null;
+    }
+    if (!stat.isFile() || stat.size > MAX_TOOL_OUTPUT_TEMP_BYTES) {
+      await file.close();
+      return null;
+    }
+    return { file, stat };
+  } catch {
+    await file?.close().catch(() => {});
+    return null;
+  }
+}
+
+async function cleanupExpiredToolOutputFiles(now = Date.now()) {
+  const tempDir = getTempDir();
+  let deletedCount = 0;
+  try {
+    const files = await fs.promises.readdir(tempDir);
+    for (const file of files) {
+      if (!file.includes("_tool-output-") || !file.endsWith(".log")) continue;
+      const filePath = path.join(tempDir, file);
+      try {
+        const stat = await fs.promises.lstat(filePath);
+        if (stat.isSymbolicLink() || !stat.isFile()) continue;
+        if (now - stat.mtimeMs < TOOL_OUTPUT_TEMP_TTL_MS) continue;
+        await fs.promises.unlink(filePath);
+        deletedCount += 1;
+      } catch {
+        // Best-effort startup cleanup.
+      }
+    }
+  } catch {
+    // Temp persistence is optional; keep startup resilient.
+  }
+  return deletedCount;
+}
+
+function safeUtf16SliceBounds(content, requestedStart, requestedEnd) {
+  let start = Math.min(content.length, Math.max(0, requestedStart));
+  let end = Math.min(content.length, Math.max(start, requestedEnd));
+  const isHigh = value => value >= 0xd800 && value <= 0xdbff;
+  const isLow = value => value >= 0xdc00 && value <= 0xdfff;
+  if (start > 0 && start < content.length && isLow(content.charCodeAt(start))) start -= 1;
+  if (end > start && end < content.length && isHigh(content.charCodeAt(end - 1))) end -= 1;
+  return [start, end];
+}
+
+async function readToolOutputChunk(file, request, stat) {
+  const storedChars = Math.floor(stat.size / 2);
+  const requestedMax = Number.isFinite(request?.maxChars) ? Math.floor(request.maxChars) : TOOL_OUTPUT_READ_MAX_CHARS;
+  const maxChars = Math.min(TOOL_OUTPUT_READ_MAX_CHARS, Math.max(1, requestedMax));
+  const mode = request?.mode ?? "head";
+
+  if (mode === "search") {
+    const query = String(request?.query ?? "");
+    if (!query) {
+      return { mode, content: "Search query is required.", totalChars: storedChars, startOffset: 0, endOffset: 0, nextOffset: 0, hasMore: false, matchOffsets: [] };
+    }
+    const content = await file.readFile({ encoding: "utf16le" });
+    const haystack = content.toLocaleLowerCase();
+    const needle = query.toLocaleLowerCase();
+    const offsets = [];
+    let cursor = Math.max(0, Math.floor(request?.offset ?? 0));
+    while (offsets.length < TOOL_OUTPUT_SEARCH_MAX_MATCHES) {
+      const match = haystack.indexOf(needle, cursor);
+      if (match < 0) break;
+      offsets.push(match);
+      cursor = match + Math.max(1, needle.length);
+    }
+    const excerpts = [];
+    let renderedChars = 0;
+    for (const match of offsets) {
+      const [start, end] = safeUtf16SliceBounds(content, match - TOOL_OUTPUT_SEARCH_CONTEXT_CHARS, match + query.length + TOOL_OUTPUT_SEARCH_CONTEXT_CHARS);
+      const excerpt = `[match offset=${match}]\n${content.slice(start, end)}`;
+      if (renderedChars + excerpt.length > maxChars) break;
+      excerpts.push(excerpt);
+      renderedChars += excerpt.length + 2;
+    }
+    const nextOffset = offsets.length ? offsets[offsets.length - 1] + Math.max(1, query.length) : storedChars;
+    return {
+      mode,
+      content: excerpts.join("\n\n") || `No matches found for "${query}".`,
+      totalChars: storedChars,
+      startOffset: Math.max(0, Math.floor(request?.offset ?? 0)),
+      endOffset: nextOffset,
+      nextOffset,
+      hasMore: haystack.indexOf(needle, nextOffset) >= 0,
+      matchOffsets: offsets,
+    };
+  }
+
+  let startOffset = mode === "tail"
+    ? Math.max(0, storedChars - maxChars)
+    : mode === "range" ? Math.min(storedChars, Math.max(0, Math.floor(request?.offset ?? 0))) : 0;
+  const readStart = Math.max(0, startOffset - 1);
+  const readChars = Math.min(storedChars - readStart, maxChars + 2);
+  const buffer = Buffer.alloc(Math.max(0, readChars * 2));
+  const { bytesRead } = await file.read(buffer, 0, buffer.length, readStart * 2);
+  const window = buffer.subarray(0, bytesRead).toString("utf16le");
+  const relativeStart = startOffset - readStart;
+  const [safeStart, safeEnd] = safeUtf16SliceBounds(window, relativeStart, relativeStart + maxChars);
+  startOffset = readStart + safeStart;
+  const content = window.slice(safeStart, safeEnd);
+  const endOffset = startOffset + content.length;
+  return { mode, content, totalChars: storedChars, startOffset, endOffset, nextOffset: endOffset, hasMore: endOffset < storedChars };
+}
+
 /**
  * Register IPC handlers
  */
 function registerHandlers(ipcMain, shell) {
+  void cleanupExpiredToolOutputFiles();
   ipcMain.handle("netcatty:tempdir:getInfo", async () => {
     return getTempDirInfo();
   });
@@ -173,6 +319,43 @@ function registerHandlers(ipcMain, shell) {
     }
     return { success: false };
   });
+
+  ipcMain.handle("netcatty:tempdir:toolOutputWrite", async (_event, payload = {}) => {
+    const content = String(payload.content ?? "");
+    if (content.length > MAX_TOOL_OUTPUT_TEMP_CHARS) {
+      return { ok: false, error: "Tool output exceeds the temp-file limit." };
+    }
+    const handleId = String(payload.handleId ?? "tool-output").replace(/[^A-Za-z0-9_.-]/g, "_");
+    const filePath = getTempFilePath(`${handleId}.log`);
+    await fs.promises.writeFile(filePath, content, { encoding: "utf16le", mode: 0o600, flag: "wx" });
+    return { ok: true, path: filePath };
+  });
+
+  ipcMain.handle("netcatty:tempdir:toolOutputRead", async (_event, payload = {}) => {
+    const filePath = payload.path;
+    const opened = await openSafeToolOutputFile(filePath);
+    if (!opened) return null;
+    try {
+      if (!payload.request) return await opened.file.readFile({ encoding: "utf16le" });
+      return await readToolOutputChunk(opened.file, payload.request, opened.stat);
+    } finally {
+      await opened.file.close();
+    }
+  });
+
+  ipcMain.handle("netcatty:tempdir:toolOutputDelete", async (_event, payload = {}) => {
+    const filePath = payload.path;
+    if (!isNetcattyTempPath(filePath)) return { ok: false };
+    try {
+      const stat = await fs.promises.lstat(filePath);
+      if (!stat.isFile() || stat.isSymbolicLink()) return { ok: false };
+      await fs.promises.unlink(filePath);
+      return { ok: true };
+    } catch (error) {
+      if (error?.code === "ENOENT") return { ok: true };
+      return { ok: false };
+    }
+  });
 }
 
 module.exports = {
@@ -181,5 +364,6 @@ module.exports = {
   getTempDirInfo,
   clearTempDir,
   getTempFilePath,
+  cleanupExpiredToolOutputFiles,
   registerHandlers,
 };

--- a/electron/bridges/tempDirBridge.cjs
+++ b/electron/bridges/tempDirBridge.cjs
@@ -39,7 +39,7 @@ function resolvePrivateTempDir(systemTempDir = os.tmpdir(), homeDir = os.homedir
   } catch {
     // Fall through to the stable per-user directory.
   }
-  return path.join(homeDir, ".netcatty", "tmp");
+  return path.join(homeDir, ".netcatty", "tmp", NETCATTY_TEMP_DIR_NAME);
 }
 
 /**

--- a/electron/bridges/tempDirBridge.cjs
+++ b/electron/bridges/tempDirBridge.cjs
@@ -48,8 +48,14 @@ function resolvePrivateTempDir(systemTempDir = os.tmpdir(), homeDir = os.homedir
  */
 function getTempDir() {
   if (cachedTempDir) {
-    assertSafeTempDir(cachedTempDir, cachedTempDirIdentity);
-    return cachedTempDir;
+    try {
+      assertSafeTempDir(cachedTempDir, cachedTempDirIdentity);
+      return cachedTempDir;
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+      cachedTempDir = null;
+      cachedTempDirIdentity = null;
+    }
   }
   
   const netcattyTempDir = resolvePrivateTempDir();

--- a/electron/bridges/tempDirBridge.cjs
+++ b/electron/bridges/tempDirBridge.cjs
@@ -9,7 +9,9 @@ const fs = require("node:fs");
 const path = require("node:path");
 const os = require("node:os");
 
-// Netcatty temp directory name
+// Keep the legacy name when the OS already provides a private per-user temp
+// root. Shared temp roots fall back to a stable directory under the user's home
+// so another OS user cannot claim Netcatty's path before startup.
 const NETCATTY_TEMP_DIR_NAME = "Netcatty";
 const MAX_TOOL_OUTPUT_TEMP_CHARS = 4_000_000;
 const MAX_TOOL_OUTPUT_TEMP_BYTES = 8_000_000;
@@ -23,6 +25,23 @@ let cachedTempDir = null;
 let cachedTempDirIdentity = null;
 let tempFileCounter = 0;
 
+function resolvePrivateTempDir(systemTempDir = os.tmpdir(), homeDir = os.homedir()) {
+  if (typeof process.getuid !== "function") {
+    return path.join(systemTempDir, NETCATTY_TEMP_DIR_NAME);
+  }
+  try {
+    const stat = fs.lstatSync(systemTempDir);
+    const isPrivate = stat.isDirectory()
+      && !stat.isSymbolicLink()
+      && stat.uid === process.getuid()
+      && (stat.mode & 0o077) === 0;
+    if (isPrivate) return path.join(systemTempDir, NETCATTY_TEMP_DIR_NAME);
+  } catch {
+    // Fall through to the stable per-user directory.
+  }
+  return path.join(homeDir, ".netcatty", "tmp");
+}
+
 /**
  * Get the Netcatty temp directory path
  * Creates the directory if it doesn't exist
@@ -33,8 +52,7 @@ function getTempDir() {
     return cachedTempDir;
   }
   
-  const systemTempDir = os.tmpdir();
-  const netcattyTempDir = path.join(systemTempDir, NETCATTY_TEMP_DIR_NAME);
+  const netcattyTempDir = resolvePrivateTempDir();
   
   try {
     if (!fs.existsSync(netcattyTempDir)) {
@@ -257,15 +275,29 @@ async function readToolOutputChunk(file, request, stat) {
       cursor = match + Math.max(1, needle.length);
     }
     const excerpts = [];
+    const renderedOffsets = [];
     let renderedChars = 0;
     for (const match of offsets) {
       const [start, end] = safeUtf16SliceBounds(content, match - TOOL_OUTPUT_SEARCH_CONTEXT_CHARS, match + query.length + TOOL_OUTPUT_SEARCH_CONTEXT_CHARS);
       const excerpt = `[match offset=${match}]\n${content.slice(start, end)}`;
-      if (renderedChars + excerpt.length > maxChars) break;
+      const separator = excerpts.length > 0 ? "\n\n" : "";
+      const available = maxChars - renderedChars - separator.length;
+      if (available <= 0) break;
+      if (excerpt.length > available) {
+        if (excerpts.length > 0) break;
+        const [, safeEnd] = safeUtf16SliceBounds(excerpt, 0, available);
+        excerpts.push(excerpt.slice(0, safeEnd));
+        renderedOffsets.push(match);
+        renderedChars += safeEnd;
+        break;
+      }
       excerpts.push(excerpt);
-      renderedChars += excerpt.length + 2;
+      renderedOffsets.push(match);
+      renderedChars += separator.length + excerpt.length;
     }
-    const nextOffset = offsets.length ? offsets[offsets.length - 1] + Math.max(1, query.length) : storedChars;
+    const nextOffset = renderedOffsets.length
+      ? renderedOffsets[renderedOffsets.length - 1] + Math.max(1, query.length)
+      : storedChars;
     return {
       mode,
       content: excerpts.join("\n\n") || `No matches found for "${query}".`,
@@ -274,7 +306,7 @@ async function readToolOutputChunk(file, request, stat) {
       endOffset: nextOffset,
       nextOffset,
       hasMore: haystack.indexOf(needle, nextOffset) >= 0,
-      matchOffsets: offsets,
+      matchOffsets: renderedOffsets,
     };
   }
 
@@ -366,4 +398,5 @@ module.exports = {
   getTempFilePath,
   cleanupExpiredToolOutputFiles,
   registerHandlers,
+  resolvePrivateTempDir,
 };

--- a/electron/bridges/tempDirBridge.test.cjs
+++ b/electron/bridges/tempDirBridge.test.cjs
@@ -1,6 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const path = require("node:path");
+const fs = require("node:fs");
 const tempDirBridge = require("./tempDirBridge.cjs");
 
 test("getTempFilePath is unique for duplicate names in the same millisecond", () => {
@@ -16,4 +17,67 @@ test("getTempFilePath is unique for duplicate names in the same millisecond", ()
   } finally {
     Date.now = originalNow;
   }
+});
+
+test("Netcatty temp root is a private directory owned by the current user", () => {
+  const tempRoot = tempDirBridge.getTempDir();
+  const stat = fs.lstatSync(tempRoot);
+  assert.equal(stat.isDirectory(), true);
+  assert.equal(stat.isSymbolicLink(), false);
+  assert.equal(stat.mode & 0o777, 0o700);
+  if (typeof process.getuid === "function") assert.equal(stat.uid, process.getuid());
+});
+
+test("tool output temp handlers write, read, and delete only Netcatty temp files", async () => {
+  const handlers = new Map();
+  tempDirBridge.registerHandlers({
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  });
+
+  const write = handlers.get("netcatty:tempdir:toolOutputWrite");
+  const read = handlers.get("netcatty:tempdir:toolOutputRead");
+  const remove = handlers.get("netcatty:tempdir:toolOutputDelete");
+  const saved = await write({}, { handleId: "tool-output-1", content: "large terminal output" });
+
+  assert.equal(saved.ok, true);
+  assert.equal(await read({}, { path: saved.path }), "large terminal output");
+  assert.deepEqual(await read({}, {
+    path: saved.path,
+    request: { mode: "range", offset: 6, maxChars: 8 },
+  }), {
+    mode: "range",
+    content: "terminal",
+    totalChars: 21,
+    startOffset: 6,
+    endOffset: 14,
+    nextOffset: 14,
+    hasMore: true,
+  });
+  assert.deepEqual(await remove({}, { path: saved.path }), { ok: true });
+  assert.equal(await read({}, { path: saved.path }), null);
+  assert.deepEqual(await read({}, { path: "/etc/passwd" }), null);
+});
+
+test("tool output temp reader rejects symlinks that point outside Netcatty temp", async () => {
+  const handlers = new Map();
+  tempDirBridge.registerHandlers({ handle(channel, handler) { handlers.set(channel, handler); } });
+  const linkPath = tempDirBridge.getTempFilePath("tool-output-link.log");
+  await fs.promises.symlink("/etc/hosts", linkPath);
+  try {
+    assert.equal(await handlers.get("netcatty:tempdir:toolOutputRead")({}, { path: linkPath }), null);
+  } finally {
+    await fs.promises.unlink(linkPath);
+  }
+});
+
+test("startup cleanup removes expired orphaned tool output files", async () => {
+  const filePath = tempDirBridge.getTempFilePath("tool-output-expired.log");
+  await fs.promises.writeFile(filePath, "secret");
+  const old = new Date(Date.now() - 31 * 60 * 1_000);
+  await fs.promises.utimes(filePath, old, old);
+  const deleted = await tempDirBridge.cleanupExpiredToolOutputFiles();
+  assert.equal(deleted >= 1, true);
+  assert.equal(fs.existsSync(filePath), false);
 });

--- a/electron/bridges/tempDirBridge.test.cjs
+++ b/electron/bridges/tempDirBridge.test.cjs
@@ -37,7 +37,7 @@ test("shared system temp roots resolve to a stable path under the user's home", 
   await fs.promises.chmod(root, 0o777);
   try {
     if (typeof process.getuid === "function") {
-      assert.equal(tempDirBridge.resolvePrivateTempDir(root, fakeHome), path.join(fakeHome, ".netcatty", "tmp"));
+      assert.equal(tempDirBridge.resolvePrivateTempDir(root, fakeHome), path.join(fakeHome, ".netcatty", "tmp", "Netcatty"));
     }
   } finally {
     await fs.promises.rm(root, { recursive: true, force: true });

--- a/electron/bridges/tempDirBridge.test.cjs
+++ b/electron/bridges/tempDirBridge.test.cjs
@@ -2,6 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const path = require("node:path");
 const fs = require("node:fs");
+const { spawnSync } = require("node:child_process");
 const tempDirBridge = require("./tempDirBridge.cjs");
 
 test("getTempFilePath is unique for duplicate names in the same millisecond", () => {
@@ -38,6 +39,31 @@ test("shared system temp roots resolve to a stable path under the user's home", 
     if (typeof process.getuid === "function") {
       assert.equal(tempDirBridge.resolvePrivateTempDir(root, fakeHome), path.join(fakeHome, ".netcatty", "tmp"));
     }
+  } finally {
+    await fs.promises.rm(root, { recursive: true, force: true });
+  }
+});
+
+test("cached temp root is recreated after OS cleanup", async () => {
+  const root = await fs.promises.mkdtemp(path.join(require("node:os").tmpdir(), "netcatty-private-root-"));
+  const fakeHome = path.join(root, "home");
+  await fs.promises.mkdir(fakeHome);
+  await fs.promises.chmod(root, 0o700);
+  try {
+    const script = [
+      'const fs = require("node:fs");',
+      'const bridge = require("./electron/bridges/tempDirBridge.cjs");',
+      'const first = bridge.getTempDir();',
+      'fs.rmSync(first, { recursive: true, force: true });',
+      'const second = bridge.getTempDir();',
+      'if (first !== second || !fs.statSync(second).isDirectory()) process.exit(2);',
+    ].join("\n");
+    const result = spawnSync(process.execPath, ["-e", script], {
+      cwd: path.resolve(__dirname, "../.."),
+      env: { ...process.env, TMPDIR: root, HOME: fakeHome },
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
   } finally {
     await fs.promises.rm(root, { recursive: true, force: true });
   }

--- a/electron/bridges/tempDirBridge.test.cjs
+++ b/electron/bridges/tempDirBridge.test.cjs
@@ -26,6 +26,21 @@ test("Netcatty temp root is a private directory owned by the current user", () =
   assert.equal(stat.isSymbolicLink(), false);
   assert.equal(stat.mode & 0o777, 0o700);
   if (typeof process.getuid === "function") assert.equal(stat.uid, process.getuid());
+  assert.equal(tempDirBridge.getTempDir(), tempRoot);
+});
+
+test("shared system temp roots resolve to a stable path under the user's home", async () => {
+  const root = await fs.promises.mkdtemp(path.join(require("node:os").tmpdir(), "netcatty-shared-root-"));
+  const fakeHome = path.join(root, "home");
+  await fs.promises.mkdir(fakeHome);
+  await fs.promises.chmod(root, 0o777);
+  try {
+    if (typeof process.getuid === "function") {
+      assert.equal(tempDirBridge.resolvePrivateTempDir(root, fakeHome), path.join(fakeHome, ".netcatty", "tmp"));
+    }
+  } finally {
+    await fs.promises.rm(root, { recursive: true, force: true });
+  }
 });
 
 test("tool output temp handlers write, read, and delete only Netcatty temp files", async () => {
@@ -80,4 +95,32 @@ test("startup cleanup removes expired orphaned tool output files", async () => {
   const deleted = await tempDirBridge.cleanupExpiredToolOutputFiles();
   assert.equal(deleted >= 1, true);
   assert.equal(fs.existsSync(filePath), false);
+});
+
+test("persisted tool output search advances only past rendered matches", async () => {
+  const handlers = new Map();
+  tempDirBridge.registerHandlers({ handle(channel, handler) { handlers.set(channel, handler); } });
+  const write = handlers.get("netcatty:tempdir:toolOutputWrite");
+  const read = handlers.get("netcatty:tempdir:toolOutputRead");
+  const remove = handlers.get("netcatty:tempdir:toolOutputDelete");
+  const saved = await write({}, { handleId: "search-pagination", content: "match middle match tail" });
+
+  try {
+    const first = await read({}, {
+      path: saved.path,
+      request: { mode: "search", query: "match", maxChars: 1 },
+    });
+    assert.doesNotMatch(first.content, /No matches found/);
+    assert.deepEqual(first.matchOffsets, [0]);
+    assert.equal(first.nextOffset, 5);
+    assert.equal(first.hasMore, true);
+
+    const second = await read({}, {
+      path: saved.path,
+      request: { mode: "search", query: "match", offset: first.nextOffset, maxChars: 30 },
+    });
+    assert.deepEqual(second.matchOffsets, [13]);
+  } finally {
+    await remove({}, { path: saved.path });
+  }
 });

--- a/electron/capabilities/schemas/toolInputs.cjs
+++ b/electron/capabilities/schemas/toolInputs.cjs
@@ -344,8 +344,10 @@ const TOOL_INPUT_FIELDS = Object.freeze({
   },
   "harness.tool_output.read": {
     handleId: { type: "string", description: "Tool output handle id from a prior truncated result." },
-    mode: { type: "string", optional: true, description: "Which portion to read: head, tail, or full." },
-    maxChars: { type: "number", optional: true, description: "Maximum characters to return." },
+    mode: { type: "string", optional: true, description: "Which portion to read: head, tail, range, search, or bounded full." },
+    maxChars: { type: "number", optional: true, description: "Requested characters to return. The service enforces a hard upper bound." },
+    offset: { type: "number", optional: true, description: "Zero-based character offset for range reads or search continuation." },
+    query: { type: "string", optional: true, description: "Case-insensitive search text when mode is search." },
   },
   "harness.workspace.get_info": {},
   "harness.workspace.get_session_info": {

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -915,6 +915,12 @@ function createPreloadApi(ctx) {
     ipcRenderer.invoke("netcatty:tempdir:getPath"),
   openTempDir: () =>
     ipcRenderer.invoke("netcatty:tempdir:open"),
+  writeToolOutputTemp: (handleId, content) =>
+    ipcRenderer.invoke("netcatty:tempdir:toolOutputWrite", { handleId, content }),
+  readToolOutputTemp: (filePath, request) =>
+    ipcRenderer.invoke("netcatty:tempdir:toolOutputRead", { path: filePath, request }),
+  deleteToolOutputTemp: (filePath) =>
+    ipcRenderer.invoke("netcatty:tempdir:toolOutputDelete", { path: filePath }),
 
   // Session Logs
   exportSessionLog: (payload) =>

--- a/infrastructure/ai/cattyAgent/executor.ts
+++ b/infrastructure/ai/cattyAgent/executor.ts
@@ -11,6 +11,7 @@ import {
   type ToolDeps,
   type ToolExecResult,
 } from '../shared/toolExecutors';
+import { fitTerminalExecuteResultForModel } from '../harness/terminalCompression';
 
 /**
  * Bridge interface for Catty Agent to interact with the Electron main process.
@@ -68,6 +69,25 @@ export interface ExecutorContext {
 /** Convert a shared ToolExecResult into the executor's ToolResult format. */
 function toToolResult(toolCallId: string, r: ToolExecResult): ToolResult {
   if (r.ok === false) {
+    if (
+      typeof r.data === 'object'
+      && r.data !== null
+      && 'stdout' in r.data
+      && 'stderr' in r.data
+      && 'exitCode' in r.data
+    ) {
+      const fitted = fitTerminalExecuteResultForModel(r.data as {
+        stdout: string;
+        stderr: string;
+        exitCode: number | null;
+      });
+      const output = [
+        r.error,
+        fitted.stdout ? `Partial output:\n${fitted.stdout}` : '',
+        fitted.stderr ? `Stderr:\n${fitted.stderr}` : '',
+      ].filter(Boolean).join('\n\n');
+      return { toolCallId, content: output, isError: true };
+    }
     return { toolCallId, content: r.error, isError: true };
   }
   // For terminal_execute, format as the legacy STDOUT/STDERR/exitCode text block

--- a/infrastructure/ai/contextCompaction.ts
+++ b/infrastructure/ai/contextCompaction.ts
@@ -8,6 +8,7 @@ import {
   estimateModelMessagesTokensWithKind,
   estimateUnknownTokens,
 } from "./harness/tokenEstimator";
+import { redactSecretsForModel } from "./harness/modelSecretRedaction";
 
 const REDACTED_PAYLOAD_PREVIEW_CHARS = 80;
 
@@ -206,8 +207,8 @@ function endsWithToolCall(message: ModelMessage | undefined): boolean {
 }
 
 function formatMessageContent(content: ModelMessage["content"]): string {
-  if (typeof content === "string") return content;
-  return JSON.stringify(sanitizeContentForCompaction(content), null, 2);
+  if (typeof content === "string") return redactSecretsForModel(content);
+  return redactSecretsForModel(JSON.stringify(sanitizeContentForCompaction(content), null, 2));
 }
 
 function sanitizeContentForCompaction(content: Exclude<ModelMessage["content"], string>): unknown {

--- a/infrastructure/ai/harness/agentRuntime.test.ts
+++ b/infrastructure/ai/harness/agentRuntime.test.ts
@@ -67,6 +67,13 @@ test('AgentRuntime records session state from tool call and result events', asyn
     readonly backend = 'catty' as const;
     async run(_input: TurnInput, ctx: TurnDriverContext): Promise<void> {
       ctx.emit({
+        id: 'secret-call',
+        type: 'tool_call',
+        toolCallId: 'call-secret',
+        toolName: 'terminal_execute',
+        args: { sessionId: 'sess-1', command: 'curl -H "Authorization: Bearer secret_token_123456" https://example.test --password swordfish' },
+      } as import('./types').AgentEvent);
+      ctx.emit({
         id: 'tool-call-1',
         type: 'tool_call',
         toolCallId: 'call-1',
@@ -115,6 +122,52 @@ test('AgentRuntime records session state from tool call and result events', asyn
   const text = sessionStateStore.toReinjectionText('chat-tool');
   assert.ok(text?.includes('uptime'));
   assert.ok(text?.includes('check uptime'));
+});
+
+test('AgentRuntime redacts secrets before trace and listener fan-out', async () => {
+  class SecretDriver implements TurnDriver {
+    readonly backend = 'catty' as const;
+    async run(_input: TurnInput, ctx: TurnDriverContext): Promise<void> {
+      ctx.emit({
+        id: 'secret-result',
+        type: 'tool_result',
+        toolCallId: 'call-secret',
+        toolName: 'terminal_execute',
+        result: 'API_TOKEN=tok_live_1234567890',
+      } as import('./types').AgentEvent);
+    }
+  }
+  const traceStore = new TraceStore();
+  const runtime = new AgentRuntime({ drivers: [new SecretDriver()], traceStore });
+  const heard: string[] = [];
+  runtime.subscribe(event => {
+    if (event.type === 'tool_result') heard.push(event.result);
+  });
+  await runtime.runTurn({
+    backend: 'catty',
+    chatSessionId: 'chat-secret',
+    sendScopeKey: 'chat-secret',
+    userText: 'check',
+    signal: new AbortController().signal,
+    assistantMsgId: 'assistant-1',
+    context: {
+      activeProvider: undefined,
+      activeModelId: '',
+      scopeType: 'terminal',
+      globalPermissionMode: 'confirm',
+      terminalSessions: [],
+      autoTitleSession: () => {},
+    },
+    maxIterations: 1,
+    ui: {
+      addMessageToSession: () => {}, updateLastMessage: () => {}, updateMessageById: () => {},
+      reportStreamError: () => {}, setStreamingForScope: () => {},
+    },
+  });
+
+  assert.doesNotMatch(JSON.stringify(traceStore.exportTrace('chat-secret')), /tok_live/);
+  assert.doesNotMatch(JSON.stringify(traceStore.exportTrace('chat-secret')), /secret_token|swordfish/);
+  assert.deepEqual(heard, ['API_TOKEN=[REDACTED]']);
 });
 
 test('AgentRuntime stopTurn delegates to active driver', async () => {

--- a/infrastructure/ai/harness/agentRuntime.ts
+++ b/infrastructure/ai/harness/agentRuntime.ts
@@ -11,6 +11,9 @@ import type {
   TurnSteerInput,
   TurnSteerResult,
 } from './turnDrivers/types';
+import { globalTwoPassCompactionCache } from './twoPassCompaction';
+import { redactSecretsForModel, redactSecretsInValueForModel } from './modelSecretRedaction';
+import { globalTerminalMonitorGuard } from './terminalMonitorGuard';
 
 let turnCounter = 0;
 
@@ -36,7 +39,7 @@ export class AgentRuntime {
   private readonly listeners = new Set<AgentEventListener>();
   private readonly activeTurns = new Map<string, ActiveTurn>();
   private readonly activeTurnPromises = new Map<string, Promise<TurnResult>>();
-  private readonly toolOutputStores = new Map<string, ToolOutputStore>();
+  private readonly toolOutputStore = new ToolOutputStore();
   private readonly sessionStateStore: SessionStateStore;
   private readonly traceStore: typeof globalTraceStore;
 
@@ -49,12 +52,8 @@ export class AgentRuntime {
   }
 
   getToolOutputStore(chatSessionId: string): ToolOutputStore {
-    let store = this.toolOutputStores.get(chatSessionId);
-    if (!store) {
-      store = new ToolOutputStore();
-      this.toolOutputStores.set(chatSessionId, store);
-    }
-    return store;
+    void chatSessionId;
+    return this.toolOutputStore;
   }
 
   getSessionStateStore(): SessionStateStore {
@@ -62,9 +61,10 @@ export class AgentRuntime {
   }
 
   clearChatSession(chatSessionId: string): void {
-    this.toolOutputStores.get(chatSessionId)?.prune(chatSessionId);
-    this.toolOutputStores.delete(chatSessionId);
+    this.toolOutputStore.prune(chatSessionId);
     this.sessionStateStore.clear(chatSessionId);
+    globalTwoPassCompactionCache.clear(chatSessionId);
+    globalTerminalMonitorGuard.clearPrefix(`${chatSessionId}:`);
   }
 
   async waitForActiveTurn(chatSessionId: string): Promise<void> {
@@ -125,7 +125,7 @@ export class AgentRuntime {
       partial: Omit<AgentEvent, 'turnId' | 'sessionId' | 'chatSessionId' | 'backend' | 'timestamp'>
         & Partial<Pick<AgentEvent, 'turnId' | 'sessionId' | 'chatSessionId' | 'backend' | 'timestamp'>>,
     ) => {
-      const event = {
+      let event = {
         id: partial.id,
         type: partial.type,
         sessionId: partial.sessionId ?? chatSessionId,
@@ -136,7 +136,18 @@ export class AgentRuntime {
         ...partial,
       } as AgentEvent;
 
+      if (event.type === 'tool_result') {
+        event = {
+          ...event,
+          result: redactSecretsForModel(event.result),
+        };
+      }
+
       if (event.type === 'tool_call') {
+        event = {
+          ...event,
+          args: redactSecretsInValueForModel(event.args),
+        };
         toolCallMeta.set(event.toolCallId, {
           toolName: event.toolName,
           args: event.args,
@@ -153,10 +164,26 @@ export class AgentRuntime {
             event.result,
             event.isError,
           );
+          if (
+            !event.isError
+            && (toolName === 'session_close' || toolName === 'session.close')
+            && typeof meta?.args.sessionId === 'string'
+          ) {
+            toolOutputStore.pruneTerminalSession(chatSessionId, meta.args.sessionId);
+          }
         }
       }
       if (event.type === 'model_delta' && event.text) {
         sessionStateStore.mergeFromAssistantContent(chatSessionId, event.text);
+      }
+      if (event.type === 'file_change' && event.status === 'completed') {
+        sessionStateStore.mergeFileChanges(
+          chatSessionId,
+          event.changes.map(change => change.path),
+        );
+      }
+      if (event.type === 'plan_update') {
+        sessionStateStore.mergePlan(chatSessionId, event.items);
       }
 
       this.traceStore.append(event);

--- a/infrastructure/ai/harness/capabilityTools.test.ts
+++ b/infrastructure/ai/harness/capabilityTools.test.ts
@@ -6,6 +6,7 @@ import {
   withCattyToolContext,
 } from './capabilityTools';
 import { ToolOutputStore } from './toolOutputStore';
+import { ToolResultDedup } from './toolResultDedup';
 
 describe('capabilityTools session queue keys', () => {
   it('does not queue read-only harness tools behind terminal session writes', () => {
@@ -36,6 +37,59 @@ describe('capabilityTools session queue keys', () => {
 });
 
 describe('capabilityTools result fitting', () => {
+  it('bounds failed terminal output and stores the original partial output behind a handle', async () => {
+    const store = new ToolOutputStore();
+    const partialOutput = `${'build output\n'.repeat(20_000)}FATAL_MID=E_CONN_RESET_7319`;
+    const longError = `API_TOKEN=tok_live_1234567890 ${'diagnostic '.repeat(2_000)}`;
+    const { tools, toolsContext } = createCattyToolsFromCatalog(
+      {
+        aiExec: async () => ({
+          ok: false,
+          error: longError,
+          stdout: partialOutput,
+          stderr: '',
+          exitCode: -1,
+        }),
+      },
+      {
+        sessions: [{
+          sessionId: 'session-1',
+          hostId: 'host-1',
+          hostname: 'prod.internal',
+          label: 'prod',
+          protocol: 'ssh',
+          connected: true,
+        }],
+      },
+      [],
+      'auto',
+      undefined,
+      'chat-1',
+      store,
+    );
+
+    const result = await withCattyToolContext(
+      tools.terminal_execute,
+      toolsContext.terminal_execute,
+      'call-1',
+    ).execute({ sessionId: 'session-1', command: 'npm test' }) as {
+      error: string;
+      stdout?: string;
+    };
+
+    assert.ok(result.error.length < 10_000);
+    assert.doesNotMatch(result.error, /tok_live/);
+    assert.match(result.error, /tool output handle/);
+    assert.ok((result.stdout?.length ?? 0) < 30_000);
+    assert.match(result.stdout ?? '', /output handle/);
+    const handleId = result.stdout?.match(/handleId=(tool-output-[^\]\s]+)/)?.[1];
+    assert.ok(handleId);
+    assert.match(
+      store.read({ handleId, mode: 'tail', maxChars: 1_000 }, 'chat-1') ?? '',
+      /FATAL_MID=E_CONN_RESET_7319/,
+    );
+  });
+
   it('truncates large vault note content and stores the full note body behind a handle', async () => {
     const store = new ToolOutputStore();
     const body = `${'note line\n'.repeat(1000)}important ending`;
@@ -70,10 +124,15 @@ describe('capabilityTools result fitting', () => {
     assert.match(result.note.content, /tool output handle/);
     const handleId = result.note.content.match(/handleId=(tool-output-[^\]\s]+)/)?.[1];
     assert.ok(handleId);
-    assert.equal(store.read({ handleId, mode: 'full', maxChars: body.length + 100 }, 'chat-1'), body);
+    const recovered = store.readChunk({
+      handleId,
+      mode: 'search',
+      query: 'important ending',
+    }, 'chat-1');
+    assert.match(recovered?.content ?? '', /important ending/);
   });
 
-  it('does not refit explicit tool output read-back content', async () => {
+  it('hard-caps explicit tool output reads and returns a continuation cursor', async () => {
     const store = new ToolOutputStore();
     const body = `${'full note line\n'.repeat(1000)}important ending`;
     const handle = store.store({
@@ -97,9 +156,97 @@ describe('capabilityTools result fitting', () => {
       'call-1',
     ).execute(
       { handleId: handle.id, mode: 'full', maxChars: body.length + 100 },
-    ) as { content: string };
+    ) as { content: string; nextOffset: number; hasMore: boolean; totalChars: number };
 
-    assert.equal(result.content, body);
+    assert.ok(result.content.length <= 12_000);
+    assert.equal(result.nextOffset, result.content.length);
+    assert.equal(result.hasMore, true);
+    assert.equal(result.totalChars, body.length);
+  });
+
+  it('enforces a shared saved-output read budget across one turn', async () => {
+    const store = new ToolOutputStore();
+    const dedup = new ToolResultDedup();
+    dedup.beginTurn();
+    const handle = store.store({
+      chatSessionId: 'chat-1',
+      capabilityId: 'terminal.execute',
+      content: 'x'.repeat(50_000),
+    });
+    const { tools, toolsContext } = createCattyToolsFromCatalog(
+      {}, { sessions: [] }, [], 'auto', undefined, 'chat-1', store, dedup,
+    );
+    const reader = withCattyToolContext(tools.tool_output_read, toolsContext.tool_output_read);
+
+    const first = await reader.execute({ handleId: handle.id, mode: 'range', offset: 0, maxChars: 12_000 });
+    const second = await reader.execute({ handleId: handle.id, mode: 'range', offset: 12_000, maxChars: 12_000 });
+    const third = await reader.execute({ handleId: handle.id, mode: 'range', offset: 24_000, maxChars: 12_000 }) as { error?: string };
+
+    assert.equal((first as { content: string }).content.length, 12_000);
+    assert.equal((second as { content: string }).content.length, 12_000);
+    assert.match(third.error ?? '', /read budget/);
+  });
+
+  it('replays a completed terminal command instead of executing it again after retry compaction', async () => {
+    let executions = 0;
+    const dedup = new ToolResultDedup();
+    dedup.beginTurn();
+    const { tools, toolsContext } = createCattyToolsFromCatalog(
+      {
+        aiExec: async () => {
+          executions += 1;
+          return { ok: true, stdout: 'deployed once', stderr: '', exitCode: 0 };
+        },
+      },
+      {
+        sessions: [{
+          sessionId: 'session-1',
+          hostId: 'host-1',
+          hostname: 'prod',
+          label: 'prod',
+          connected: true,
+        }],
+      },
+      [], 'auto', undefined, 'chat-1', undefined, dedup,
+    );
+    const execute = withCattyToolContext(tools.terminal_execute, toolsContext.terminal_execute);
+    await execute.execute({ sessionId: 'session-1', command: 'deploy production' });
+    dedup.enableWriteReplay();
+    const replay = await execute.execute({ sessionId: 'session-1', command: 'deploy production' }) as {
+      replayedCompletedResult?: boolean;
+    };
+
+    assert.equal(executions, 1);
+    assert.equal(replay.replayedCompletedResult, true);
+  });
+
+  it('replays a started background job instead of starting it twice after retry compaction', async () => {
+    let starts = 0;
+    const dedup = new ToolResultDedup();
+    const { tools, toolsContext } = createCattyToolsFromCatalog(
+      { aiCapability: async () => ({
+        ok: true,
+        jobId: `job-${++starts}`,
+        status: 'running',
+        command: 'deploy --password swordfish',
+        output: 'x'.repeat(30_000),
+      }) },
+      { sessions: [] }, [], 'auto', undefined, 'chat-start', undefined, dedup,
+    );
+    const start = withCattyToolContext(tools.terminal_start, toolsContext.terminal_start);
+    await start.execute({ sessionId: 'session-1', command: 'npm run build' });
+    dedup.enableWriteReplay();
+    const replay = await start.execute({ sessionId: 'session-1', command: 'npm run build' }) as {
+      replayedCompletedResult?: boolean;
+      jobId?: string;
+      command?: string;
+      output?: string;
+    };
+    assert.equal(starts, 1);
+    assert.equal(replay.jobId, 'job-1');
+    assert.equal(replay.replayedCompletedResult, true);
+    assert.doesNotMatch(replay.command ?? '', /swordfish/);
+    assert.match(replay.output ?? '', /tool output handle/);
   });
 });
 
@@ -196,7 +343,12 @@ describe('capabilityTools terminal context reader', () => {
     assert.match(result.content, /tool output handle/);
     const handleId = result.content.match(/handleId=(tool-output-[^\]\s]+)/)?.[1];
     assert.ok(handleId);
-    assert.equal(store.read({ handleId, mode: 'full', maxChars: body.length + 100 }, 'chat-1'), body);
+    const recovered = store.readChunk({
+      handleId,
+      mode: 'search',
+      query: 'important ending',
+    }, 'chat-1');
+    assert.match(recovered?.content ?? '', /important ending/);
   });
 
   it('asks for sessionId when multiple scoped terminals are available', async () => {
@@ -223,5 +375,134 @@ describe('capabilityTools terminal context reader', () => {
     ) as { error?: string };
 
     assert.match(result.error ?? '', /sessionId/);
+  });
+
+  it('returns a small cached notice for an unchanged terminal context range', async () => {
+    const dedup = new ToolResultDedup();
+    dedup.beginTurn();
+    const { tools, toolsContext } = createCattyToolsFromCatalog(
+      {},
+      {
+        sessions: [{
+          sessionId: 'session-1',
+          hostId: 'host-1',
+          hostname: 'prod.internal',
+          label: 'prod',
+          connected: true,
+        }],
+        readTerminalContext: async () => ({
+          ok: true,
+          sessionId: 'session-1',
+          range: 'tail',
+          content: 'same terminal screen',
+          totalLines: 1,
+          startLine: 0,
+          endLine: 0,
+          returnedLines: 1,
+          hasMoreBefore: false,
+          hasMoreAfter: false,
+          source: 'live',
+        }),
+      },
+      [],
+      'auto',
+      undefined,
+      'chat-1',
+      undefined,
+      dedup,
+    );
+
+    const reader = withCattyToolContext(
+      tools.terminal_read_context,
+      toolsContext.terminal_read_context,
+    );
+    const first = await reader.execute({ sessionId: 'session-1', range: 'tail' });
+    const second = await reader.execute({ sessionId: 'session-1', range: 'tail' });
+
+    assert.equal(typeof first, 'object');
+    assert.match(String(second), /^\[cached\]/);
+  });
+});
+
+describe('capabilityTools terminal polling', () => {
+  it('tags polled output handles with the owning terminal for close cleanup', async () => {
+    const store = new ToolOutputStore();
+    const dedup = new ToolResultDedup();
+    const { tools, toolsContext } = createCattyToolsFromCatalog(
+      {
+        aiCapability: async (method: string) => method.includes('jobStart')
+          ? { ok: true, jobId: 'job-owned', status: 'running', nextOffset: 0 }
+          : { ok: true, jobId: 'job-owned', status: 'running', output: 'x'.repeat(30_000), nextOffset: 30_000 },
+      },
+      { sessions: [] }, [], 'auto', undefined, 'chat-owned', store, dedup,
+    );
+    await withCattyToolContext(tools.terminal_start, toolsContext.terminal_start)
+      .execute({ sessionId: 'session-owned', command: 'npm run dev' });
+    const result = await withCattyToolContext(tools.terminal_poll, toolsContext.terminal_poll)
+      .execute({ jobId: 'job-owned', offset: 0 }) as { output: string };
+    const handleId = result.output.match(/handleId=(tool-output-[^\]\s]+)/)?.[1];
+    assert.ok(handleId);
+    store.pruneTerminalSession('chat-owned', 'session-owned');
+    assert.equal(store.get(handleId, 'chat-owned'), undefined);
+  });
+
+  it('deduplicates an unchanged job output range', async () => {
+    const dedup = new ToolResultDedup();
+    dedup.beginTurn();
+    const { tools, toolsContext } = createCattyToolsFromCatalog(
+      {
+        aiCapability: async () => ({
+          ok: true,
+          jobId: 'job-1',
+          sessionId: 'session-1',
+          status: 'running',
+          output: 'same build output',
+          outputBaseOffset: 0,
+          nextOffset: 17,
+          totalOutputChars: 17,
+        }),
+      },
+      { sessions: [] },
+      [],
+      'auto',
+      undefined,
+      'chat-1',
+      undefined,
+      dedup,
+    );
+
+    const poll = withCattyToolContext(tools.terminal_poll, toolsContext.terminal_poll);
+    const first = await poll.execute({ jobId: 'job-1', offset: 0 });
+    const second = await poll.execute({ jobId: 'job-1', offset: 0 });
+
+    assert.equal(typeof first, 'object');
+    assert.match(String(second), /^\[cached\]/);
+  });
+
+  it('bounds follow-style monitor output before it reaches the model', async () => {
+    const { tools, toolsContext } = createCattyToolsFromCatalog(
+      {
+        aiCapability: async () => ({
+          ok: true,
+          jobId: 'monitor-job-unique',
+          command: 'tail -f /var/log/app.log',
+          status: 'running',
+          output: `${'x'.repeat(800)}\n${'log line\n'.repeat(1_000)}`,
+          nextOffset: 9_000,
+        }),
+      },
+      { sessions: [] },
+      [],
+      'auto',
+      undefined,
+      'chat-monitor',
+    );
+    const result = await withCattyToolContext(
+      tools.terminal_poll,
+      toolsContext.terminal_poll,
+    ).execute({ jobId: 'monitor-job-unique', offset: 0 }) as { output: string };
+
+    assert.ok(result.output.length <= 3_000);
+    assert.ok(result.output.split('\n')[0].length <= 500);
   });
 });

--- a/infrastructure/ai/harness/capabilityTools.test.ts
+++ b/infrastructure/ai/harness/capabilityTools.test.ts
@@ -603,4 +603,32 @@ describe('capabilityTools terminal polling', () => {
     assert.ok(result.output.length <= 3_000);
     assert.ok(result.output.split('\n')[0].length <= 500);
   });
+
+  it('does not count empty monitor polls as output bursts', async () => {
+    let polls = 0;
+    const { tools, toolsContext } = createCattyToolsFromCatalog(
+      {
+        aiCapability: async () => ({
+          ok: true,
+          jobId: 'quiet-monitor-job',
+          command: 'tail -f /var/log/app.log',
+          status: 'running',
+          output: polls++ < 12 ? '' : 'first new line',
+          nextOffset: 0,
+        }),
+      },
+      { sessions: [] },
+      [],
+      'auto',
+      undefined,
+      'chat-quiet-monitor',
+    );
+    const poll = withCattyToolContext(tools.terminal_poll, toolsContext.terminal_poll);
+    for (let index = 0; index < 12; index += 1) {
+      await poll.execute({ jobId: 'quiet-monitor-job', offset: 0 });
+    }
+    const result = await poll.execute({ jobId: 'quiet-monitor-job', offset: 0 }) as { output: string };
+
+    assert.equal(result.output, 'first new line');
+  });
 });

--- a/infrastructure/ai/harness/capabilityTools.test.ts
+++ b/infrastructure/ai/harness/capabilityTools.test.ts
@@ -7,6 +7,7 @@ import {
 } from './capabilityTools';
 import { ToolOutputStore } from './toolOutputStore';
 import { ToolResultDedup } from './toolResultDedup';
+import { collectPreservedTerminalWriteFingerprints } from './turnDrivers/cattyMessageBuilder';
 
 describe('capabilityTools session queue keys', () => {
   it('does not queue read-only harness tools behind terminal session writes', () => {
@@ -224,6 +225,58 @@ describe('capabilityTools result fitting', () => {
     };
     assert.equal(executions, 2);
     assert.equal(intentionalRepeat.replayedCompletedResult, undefined);
+  });
+
+  it('executes an intentional repeat when the completed result is already in retry history', async () => {
+    let executions = 0;
+    const dedup = new ToolResultDedup();
+    dedup.beginTurn();
+    const { tools, toolsContext } = createCattyToolsFromCatalog(
+      {
+        aiExec: async () => {
+          executions += 1;
+          return { ok: true, stdout: `run ${executions}`, stderr: '', exitCode: 0 };
+        },
+      },
+      {
+        sessions: [{
+          sessionId: 'session-1',
+          hostId: 'host-1',
+          hostname: 'prod',
+          label: 'prod',
+          connected: true,
+        }],
+      },
+      [], 'auto', undefined, 'chat-1', undefined, dedup,
+    );
+    const execute = withCattyToolContext(tools.terminal_execute, toolsContext.terminal_execute);
+    const args = { sessionId: 'session-1', command: 'npm test' };
+    await execute.execute(args);
+    const retryHistory = [
+      {
+        id: 'assistant-progress',
+        role: 'assistant' as const,
+        content: '',
+        timestamp: 1,
+        toolCalls: [{ id: 'call-1', name: 'terminal_execute', arguments: args }],
+      },
+      {
+        id: 'tool-progress',
+        role: 'tool' as const,
+        content: '',
+        timestamp: 2,
+        toolResults: [{ toolCallId: 'call-1', content: 'run 1' }],
+      },
+    ];
+    dedup.enableWriteReplay(collectPreservedTerminalWriteFingerprints(
+      retryHistory,
+      'assistant-progress',
+      'chat-1',
+    ));
+
+    const repeat = await execute.execute(args) as { replayedCompletedResult?: boolean };
+    assert.equal(executions, 2);
+    assert.equal(repeat.replayedCompletedResult, undefined);
   });
 
   it('replays a started background job instead of starting it twice after retry compaction', async () => {

--- a/infrastructure/ai/harness/capabilityTools.test.ts
+++ b/infrastructure/ai/harness/capabilityTools.test.ts
@@ -6,7 +6,7 @@ import {
   withCattyToolContext,
 } from './capabilityTools';
 import { ToolOutputStore } from './toolOutputStore';
-import { ToolResultDedup } from './toolResultDedup';
+import { buildTerminalWriteFingerprint, ToolResultDedup } from './toolResultDedup';
 import { collectPreservedTerminalWriteFingerprints } from './turnDrivers/cattyMessageBuilder';
 
 describe('capabilityTools session queue keys', () => {
@@ -277,6 +277,37 @@ describe('capabilityTools result fitting', () => {
     const repeat = await execute.execute(args) as { replayedCompletedResult?: boolean };
     assert.equal(executions, 2);
     assert.equal(repeat.replayedCompletedResult, undefined);
+  });
+
+  it('pairs reused tool call IDs with the nearest preceding terminal command', () => {
+    const commandA = { sessionId: 'session-1', command: 'npm test a' };
+    const commandB = { sessionId: 'session-1', command: 'npm test b' };
+    const retryHistory = [
+      {
+        id: 'assistant-a', role: 'assistant' as const, content: '', timestamp: 1,
+        toolCalls: [{ id: 'reused-call', name: 'terminal_execute', arguments: commandA }],
+      },
+      {
+        id: 'tool-a', role: 'tool' as const, content: '', timestamp: 2,
+        toolResults: [{ toolCallId: 'reused-call', content: 'result a' }],
+      },
+      {
+        id: 'assistant-b', role: 'assistant' as const, content: '', timestamp: 3,
+        toolCalls: [{ id: 'reused-call', name: 'terminal_execute', arguments: commandB }],
+      },
+      {
+        id: 'tool-b', role: 'tool' as const, content: '', timestamp: 4,
+        toolResults: [{ toolCallId: 'reused-call', content: 'result b' }],
+      },
+    ];
+
+    assert.deepEqual(
+      collectPreservedTerminalWriteFingerprints(retryHistory, 'assistant-a', 'chat-1'),
+      [
+        buildTerminalWriteFingerprint('terminal_execute', 'chat-1', commandA),
+        buildTerminalWriteFingerprint('terminal_execute', 'chat-1', commandB),
+      ],
+    );
   });
 
   it('replays a started background job instead of starting it twice after retry compaction', async () => {

--- a/infrastructure/ai/harness/capabilityTools.test.ts
+++ b/infrastructure/ai/harness/capabilityTools.test.ts
@@ -218,6 +218,12 @@ describe('capabilityTools result fitting', () => {
 
     assert.equal(executions, 1);
     assert.equal(replay.replayedCompletedResult, true);
+
+    const intentionalRepeat = await execute.execute({ sessionId: 'session-1', command: 'deploy production' }) as {
+      replayedCompletedResult?: boolean;
+    };
+    assert.equal(executions, 2);
+    assert.equal(intentionalRepeat.replayedCompletedResult, undefined);
   });
 
   it('replays a started background job instead of starting it twice after retry compaction', async () => {
@@ -247,6 +253,14 @@ describe('capabilityTools result fitting', () => {
     assert.equal(replay.replayedCompletedResult, true);
     assert.doesNotMatch(replay.command ?? '', /swordfish/);
     assert.match(replay.output ?? '', /tool output handle/);
+
+    const intentionalRestart = await start.execute({ sessionId: 'session-1', command: 'npm run build' }) as {
+      replayedCompletedResult?: boolean;
+      jobId?: string;
+    };
+    assert.equal(starts, 2);
+    assert.equal(intentionalRestart.jobId, 'job-2');
+    assert.equal(intentionalRestart.replayedCompletedResult, undefined);
   });
 });
 

--- a/infrastructure/ai/harness/capabilityTools.test.ts
+++ b/infrastructure/ai/harness/capabilityTools.test.ts
@@ -578,6 +578,8 @@ describe('capabilityTools terminal polling', () => {
   });
 
   it('bounds follow-style monitor output before it reaches the model', async () => {
+    const store = new ToolOutputStore();
+    const rawOutput = `${'x '.repeat(400)}\n${'log line\n'.repeat(500)}MONITOR_MIDDLE_EVIDENCE_7319\n${'tail line\n'.repeat(500)}`;
     const { tools, toolsContext } = createCattyToolsFromCatalog(
       {
         aiCapability: async () => ({
@@ -585,7 +587,7 @@ describe('capabilityTools terminal polling', () => {
           jobId: 'monitor-job-unique',
           command: 'tail -f /var/log/app.log',
           status: 'running',
-          output: `${'x'.repeat(800)}\n${'log line\n'.repeat(1_000)}`,
+          output: rawOutput,
           nextOffset: 9_000,
         }),
       },
@@ -594,14 +596,21 @@ describe('capabilityTools terminal polling', () => {
       'auto',
       undefined,
       'chat-monitor',
+      store,
     );
     const result = await withCattyToolContext(
       tools.terminal_poll,
       toolsContext.terminal_poll,
     ).execute({ jobId: 'monitor-job-unique', offset: 0 }) as { output: string };
 
-    assert.ok(result.output.length <= 3_000);
+    assert.ok(result.output.length < 3_500);
     assert.ok(result.output.split('\n')[0].length <= 500);
+    const handleId = result.output.match(/handleId=(tool-output-[^\]\s]+)/)?.[1];
+    assert.ok(handleId);
+    assert.match(
+      store.read({ handleId, mode: 'search', query: 'MONITOR_MIDDLE_EVIDENCE_7319' }, 'chat-monitor') ?? '',
+      /MONITOR_MIDDLE_EVIDENCE_7319/,
+    );
   });
 
   it('does not count empty monitor polls as output bursts', async () => {

--- a/infrastructure/ai/harness/capabilityTools.ts
+++ b/infrastructure/ai/harness/capabilityTools.ts
@@ -543,7 +543,11 @@ function createCatalogTool(spec: CattyToolSpec) {
         ) {
           let poll = raw as Record<string, unknown>;
           const monitorKey = `${deps.chatSessionId ?? 'global'}:${String(poll.jobId ?? args.jobId ?? '')}`;
-          if (isStreamingMonitorCommand(poll.command) && typeof poll.output === 'string') {
+          if (
+            isStreamingMonitorCommand(poll.command)
+            && typeof poll.output === 'string'
+            && poll.output.trim().length > 0
+          ) {
             const guarded = globalTerminalMonitorGuard.process(monitorKey, poll.output);
             if (guarded.action === 'stop') {
               const stopResult = await invokeCapabilityRpc(

--- a/infrastructure/ai/harness/capabilityTools.ts
+++ b/infrastructure/ai/harness/capabilityTools.ts
@@ -1,6 +1,6 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import type { NetcattyBridge } from '../cattyAgent/executor';
+import type { ExecutorContext, NetcattyBridge } from '../cattyAgent/executor';
 import type { TerminalContextReadRange } from '../../../domain/terminalContextRead';
 import type { AIPermissionMode } from '../types';
 import type { WebSearchConfig } from '../types';
@@ -17,9 +17,16 @@ import {
 import { reserveSessionSlot } from '../shared/sessionExecutionQueue';
 import { fitTerminalExecuteResultForModel } from './terminalCompression';
 import { fitLargeToolResultForModel } from './toolResultFitting';
+import { redactSecretsForModel } from './modelSecretRedaction';
+import {
+  globalTerminalMonitorGuard,
+  isStreamingMonitorCommand,
+} from './terminalMonitorGuard';
 import type { ToolOutputStore } from './toolOutputStore';
+import { TOOL_OUTPUT_READ_MAX_CHARS } from './toolOutputStore';
 import {
   hashScopeKey,
+  hashToolResult,
   previewToolResult,
   type ToolResultDedup,
 } from './toolResultDedup';
@@ -128,17 +135,61 @@ function fitCapabilityResultForModel(
   spec: CattyToolSpec,
   chatSessionId?: string,
   toolOutputStore?: ToolOutputStore,
+  args?: Record<string, unknown>,
+  toolResultDedup?: ToolResultDedup,
 ): unknown {
   if (spec.capabilityId === 'harness.tool_output.read') {
     return result;
   }
+
+  const resultRecord = result && typeof result === 'object'
+    ? result as Record<string, unknown>
+    : undefined;
+  const jobId = typeof args?.jobId === 'string'
+    ? args.jobId
+    : typeof resultRecord?.jobId === 'string' ? resultRecord.jobId : undefined;
+  const terminalSessionId = typeof args?.sessionId === 'string'
+    ? args.sessionId
+    : typeof resultRecord?.sessionId === 'string'
+      ? resultRecord.sessionId
+      : jobId ? toolResultDedup?.terminalSessionForJob(jobId) : undefined;
 
   return fitLargeToolResultForModel({
     result,
     capabilityId: spec.capabilityId,
     chatSessionId,
     toolOutputStore,
+    terminalSessionId,
+    normalizeStrings: spec.capabilityId.startsWith('terminal.')
+      || spec.capabilityId === 'harness.terminal.read_context',
   });
+}
+
+export function applyMonitorStopResult(
+  poll: Record<string, unknown>,
+  stopResult: unknown,
+  suppressedCount: number,
+): Record<string, unknown> {
+  const stopFailed = Boolean(
+    stopResult && typeof stopResult === 'object'
+    && (
+      (stopResult as { ok?: boolean }).ok === false
+      || (
+        typeof (stopResult as { error?: unknown }).error === 'string'
+        && (stopResult as { error: string }).error.trim().length > 0
+      )
+    ),
+  );
+  return stopFailed
+    ? {
+        ...poll,
+        output: `[automatic monitor stop failed after sustained overload; ${suppressedCount} batches were suppressed. The job may still be running; poll/stop it explicitly and narrow the command before continuing.]`,
+      }
+    : {
+        ...poll,
+        status: 'stopping',
+        output: `[monitor stop requested after sustained overload; ${suppressedCount} batches were suppressed. Narrow the command with grep/awk before restarting it.]`,
+      };
 }
 
 interface LocalExecutionContext {
@@ -156,19 +207,38 @@ async function executeLocalCattyCapability(ctx: LocalExecutionContext): Promise<
 
   switch (spec.capabilityId) {
     case 'harness.tool_output.read': {
-      const { handleId, mode, maxChars } = args as {
+      const { handleId, mode, maxChars, offset, query } = args as {
         handleId: string;
-        mode?: 'head' | 'tail' | 'full';
+        mode?: 'head' | 'tail' | 'full' | 'range' | 'search';
         maxChars?: number;
+        offset?: number;
+        query?: string;
       };
       if (!toolOutputStore || !chatSessionId) {
         return { error: 'Tool output store is unavailable.' };
       }
-      const content = toolOutputStore.read({ handleId, mode, maxChars }, chatSessionId);
-      if (content == null) {
+      const requestedChars = Math.min(
+        TOOL_OUTPUT_READ_MAX_CHARS,
+        typeof maxChars === 'number' && Number.isFinite(maxChars)
+          ? Math.max(1, Math.floor(maxChars))
+          : TOOL_OUTPUT_READ_MAX_CHARS,
+      );
+      const grantedChars = toolResultDedup
+        ? toolResultDedup.takeBudget('tool-output-read', requestedChars, TOOL_OUTPUT_READ_MAX_CHARS * 2)
+        : requestedChars;
+      if (grantedChars <= 0) {
+        return {
+          error: `This turn has reached its ${TOOL_OUTPUT_READ_MAX_CHARS * 2}-character saved-output read budget. Continue in the next turn or narrow the search.`,
+        };
+      }
+      const result = await toolOutputStore.readChunkAsync(
+        { handleId, mode, maxChars: grantedChars, offset, query },
+        chatSessionId,
+      );
+      if (result == null) {
         return { error: `Handle "${handleId}" was not found for this chat session.` };
       }
-      return { handleId, mode: mode ?? 'head', content };
+      return { ...result, content: redactSecretsForModel(result.content) };
     }
     case 'harness.workspace.get_info': {
       const scopeCtx = resolveContext();
@@ -250,12 +320,27 @@ async function executeLocalCattyCapability(ctx: LocalExecutionContext): Promise<
         };
       }
 
-      return scopeCtx.readTerminalContext({
+      const result = await scopeCtx.readTerminalContext({
         sessionId,
         range: typeof args.range === 'string' ? args.range as TerminalContextReadRange : undefined,
         startLine: typeof args.startLine === 'number' ? args.startLine : undefined,
         maxLines: typeof args.maxLines === 'number' ? args.maxLines : undefined,
       });
+      if (result.ok === false) return result;
+      const normalizedResult = result;
+      const fingerprint = toolResultDedup?.fingerprintFor(
+        spec.toolName,
+        hashScopeKey([
+          sessionId,
+          String(normalizedResult.startLine),
+          String(normalizedResult.endLine),
+          normalizedResult.range,
+          hashToolResult(normalizedResult.content),
+        ]),
+      );
+      return fingerprint
+        ? applyToolDedup(spec.toolName, fingerprint, normalizedResult, toolResultDedup)
+        : normalizedResult;
     }
     case 'harness.web.search': {
       const { query, maxResults } = args as { query: string; maxResults?: number };
@@ -327,6 +412,20 @@ function createCatalogTool(spec: CattyToolSpec) {
 
         if (spec.capabilityId === 'terminal.execute') {
           const { sessionId: sid, command } = args as { sessionId: string; command: string };
+          const writeFingerprint = toolResultDedup?.fingerprintFor(
+            spec.toolName,
+            hashScopeKey([deps.chatSessionId, sid, command]),
+          );
+          const replay = writeFingerprint
+            ? toolResultDedup?.replayCompletedWrite(writeFingerprint)
+            : undefined;
+          if (replay !== undefined) {
+            return {
+              ...(typeof replay === 'object' && replay !== null ? replay : { result: replay }),
+              replayedCompletedResult: true,
+              note: 'The command already executed before request compaction; its recorded result was replayed and the command was not executed again.',
+            };
+          }
           const cancelOnAbort = () => {
             if (deps.chatSessionId) {
               void deps.bridge.aiCattyCancelExec?.(deps.chatSessionId);
@@ -335,8 +434,30 @@ function createCatalogTool(spec: CattyToolSpec) {
           abortSignal?.addEventListener('abort', cancelOnAbort, { once: true });
           try {
             const result = await executeTerminalExecute(deps, { sessionId: sid, command });
-            if (result.ok === false) return unwrap(result);
-            return fitTerminalExecuteResultForModel({
+            if (result.ok === false) {
+              if (!result.data) return unwrap(result);
+              const fittedFailure = {
+                error: fitLargeToolResultForModel({
+                  result: result.error,
+                  capabilityId: 'terminal.execute.error',
+                  chatSessionId: deps.chatSessionId,
+                  toolOutputStore,
+                  terminalSessionId: sid,
+                  normalizeStrings: true,
+                }),
+                ...fitTerminalExecuteResultForModel({
+                  ...result.data,
+                  command,
+                  sessionId: sid,
+                }, {
+                  chatSessionId: deps.chatSessionId,
+                  toolOutputStore,
+                }),
+              };
+              if (writeFingerprint) toolResultDedup?.rememberCompletedWrite(writeFingerprint, fittedFailure);
+              return fittedFailure;
+            }
+            const fitted = fitTerminalExecuteResultForModel({
               ...result.data,
               command,
               sessionId: sid,
@@ -344,6 +465,8 @@ function createCatalogTool(spec: CattyToolSpec) {
               chatSessionId: deps.chatSessionId,
               toolOutputStore,
             });
+            if (writeFingerprint) toolResultDedup?.rememberCompletedWrite(writeFingerprint, fitted);
+            return fitted;
           } finally {
             abortSignal?.removeEventListener('abort', cancelOnAbort);
           }
@@ -358,19 +481,113 @@ function createCatalogTool(spec: CattyToolSpec) {
             toolResultDedup,
             chatSessionId: deps.chatSessionId,
           });
-          return fitCapabilityResultForModel(result, spec, deps.chatSessionId, toolOutputStore);
+          return fitCapabilityResultForModel(
+            result,
+            spec,
+            deps.chatSessionId,
+            toolOutputStore,
+            args as Record<string, unknown>,
+            toolResultDedup,
+          );
         }
 
         if (!spec.rpcMethod) {
           return { error: `Capability "${spec.capabilityId}" has no RPC binding.` };
         }
 
-        const raw = await invokeCapabilityRpc(
+        const terminalStartFingerprint = spec.capabilityId === 'terminal.start'
+          ? toolResultDedup?.fingerprintFor(
+              'terminal.start:write',
+              hashScopeKey([
+                deps.chatSessionId,
+                String((args as { sessionId?: unknown }).sessionId ?? ''),
+                String((args as { command?: unknown }).command ?? ''),
+              ]),
+            )
+          : undefined;
+        const terminalStartReplay = terminalStartFingerprint
+          ? toolResultDedup?.replayCompletedWrite(terminalStartFingerprint)
+          : undefined;
+        if (terminalStartReplay !== undefined) {
+          return {
+            ...(typeof terminalStartReplay === 'object' && terminalStartReplay !== null
+              ? terminalStartReplay
+              : { result: terminalStartReplay }),
+            replayedCompletedResult: true,
+            note: 'The background command already started before request compaction; its recorded job was replayed and no second job was created.',
+          };
+        }
+
+        let raw = await invokeCapabilityRpc(
           deps.bridge,
           spec.rpcMethod,
           args as Record<string, unknown>,
           deps.chatSessionId,
         );
+        if (
+          spec.capabilityId === 'terminal.start'
+          && raw && typeof raw === 'object'
+          && typeof (raw as { jobId?: unknown }).jobId === 'string'
+          && typeof (args as { sessionId?: unknown }).sessionId === 'string'
+        ) {
+          toolResultDedup?.rememberTerminalJobSession(
+            (raw as { jobId: string }).jobId,
+            (args as { sessionId: string }).sessionId,
+          );
+        }
+
+        if (
+          spec.capabilityId === 'terminal.poll'
+          && raw
+          && typeof raw === 'object'
+          && (raw as { ok?: boolean }).ok !== false
+        ) {
+          let poll = raw as Record<string, unknown>;
+          const monitorKey = `${deps.chatSessionId ?? 'global'}:${String(poll.jobId ?? args.jobId ?? '')}`;
+          if (isStreamingMonitorCommand(poll.command) && typeof poll.output === 'string') {
+            const guarded = globalTerminalMonitorGuard.process(monitorKey, poll.output);
+            if (guarded.action === 'stop') {
+              const stopResult = await invokeCapabilityRpc(
+                deps.bridge,
+                'netcatty/jobStop',
+                { jobId: poll.jobId ?? args.jobId },
+                deps.chatSessionId,
+              );
+              poll = applyMonitorStopResult(poll, stopResult, guarded.suppressedCount);
+            } else if (guarded.action === 'suppress') {
+              poll = {
+                ...poll,
+                output: `[monitor batch suppressed by rate limit; suppressed=${guarded.suppressedCount}]`,
+              };
+            } else {
+              poll = { ...poll, output: guarded.content };
+            }
+          }
+          if (poll.status !== 'running' && poll.status !== 'stopping') {
+            globalTerminalMonitorGuard.clear(monitorKey);
+          }
+          raw = poll;
+          const fingerprint = toolResultDedup?.fingerprintFor(
+            spec.toolName,
+            hashScopeKey([
+              String(poll.jobId ?? args.jobId ?? ''),
+              String(poll.outputBaseOffset ?? ''),
+              String(poll.nextOffset ?? ''),
+              String(poll.status ?? ''),
+              hashToolResult(poll.output ?? ''),
+            ]),
+          );
+          if (fingerprint) {
+            return fitCapabilityResultForModel(
+              applyToolDedup(spec.toolName, fingerprint, poll, toolResultDedup),
+              spec,
+              deps.chatSessionId,
+              toolOutputStore,
+              args as Record<string, unknown>,
+              toolResultDedup,
+            );
+          }
+        }
 
         if (spec.toolName === 'get_environment' || spec.capabilityId === 'session.environment') {
           const ctx = typeof deps.context === 'function' ? deps.context() : deps.context;
@@ -384,6 +601,8 @@ function createCatalogTool(spec: CattyToolSpec) {
               spec,
               deps.chatSessionId,
               toolOutputStore,
+              args as Record<string, unknown>,
+              toolResultDedup,
             );
           }
         }
@@ -400,6 +619,8 @@ function createCatalogTool(spec: CattyToolSpec) {
               spec,
               deps.chatSessionId,
               toolOutputStore,
+              args as Record<string, unknown>,
+              toolResultDedup,
             );
           }
 
@@ -431,7 +652,23 @@ function createCatalogTool(spec: CattyToolSpec) {
           }
         }
 
-        return fitCapabilityResultForModel(raw, spec, deps.chatSessionId, toolOutputStore);
+        const fittedRaw = fitCapabilityResultForModel(
+          raw,
+          spec,
+          deps.chatSessionId,
+          toolOutputStore,
+          args as Record<string, unknown>,
+          toolResultDedup,
+        );
+        if (
+          terminalStartFingerprint
+          && raw && typeof raw === 'object'
+          && (raw as { ok?: boolean }).ok !== false
+          && typeof (raw as { jobId?: unknown }).jobId === 'string'
+        ) {
+          toolResultDedup?.rememberCompletedWrite(terminalStartFingerprint, fittedRaw);
+        }
+        return fittedRaw;
       } finally {
         slot?.release();
       }
@@ -456,8 +693,8 @@ export function buildCattyToolContext(input: {
     commandBlocklist: input.commandBlocklist,
     webSearchConfig: input.webSearchConfig,
     getExecutorContext: typeof input.context === 'function'
-      ? input.context
-      : () => input.context,
+      ? input.context as () => ExecutorContext
+      : () => input.context as ExecutorContext,
     toolOutputStore: input.toolOutputStore,
     toolResultDedup: input.toolResultDedup,
   };

--- a/infrastructure/ai/harness/capabilityTools.ts
+++ b/infrastructure/ai/harness/capabilityTools.ts
@@ -25,6 +25,7 @@ import {
 import type { ToolOutputStore } from './toolOutputStore';
 import { TOOL_OUTPUT_READ_MAX_CHARS } from './toolOutputStore';
 import {
+  buildTerminalWriteFingerprint,
   hashScopeKey,
   hashToolResult,
   previewToolResult,
@@ -412,9 +413,10 @@ function createCatalogTool(spec: CattyToolSpec) {
 
         if (spec.capabilityId === 'terminal.execute') {
           const { sessionId: sid, command } = args as { sessionId: string; command: string };
-          const writeFingerprint = toolResultDedup?.fingerprintFor(
-            spec.toolName,
-            hashScopeKey([deps.chatSessionId, sid, command]),
+          const writeFingerprint = buildTerminalWriteFingerprint(
+            'terminal_execute',
+            deps.chatSessionId,
+            { sessionId: sid, command },
           );
           const replay = writeFingerprint
             ? toolResultDedup?.replayCompletedWrite(writeFingerprint)
@@ -496,13 +498,10 @@ function createCatalogTool(spec: CattyToolSpec) {
         }
 
         const terminalStartFingerprint = spec.capabilityId === 'terminal.start'
-          ? toolResultDedup?.fingerprintFor(
-              'terminal.start:write',
-              hashScopeKey([
-                deps.chatSessionId,
-                String((args as { sessionId?: unknown }).sessionId ?? ''),
-                String((args as { command?: unknown }).command ?? ''),
-              ]),
+          ? buildTerminalWriteFingerprint(
+              'terminal_start',
+              deps.chatSessionId,
+              args as { sessionId?: unknown; command?: unknown },
             )
           : undefined;
         const terminalStartReplay = terminalStartFingerprint

--- a/infrastructure/ai/harness/capabilityTools.ts
+++ b/infrastructure/ai/harness/capabilityTools.ts
@@ -563,7 +563,22 @@ function createCatalogTool(spec: CattyToolSpec) {
                 output: `[monitor batch suppressed by rate limit; suppressed=${guarded.suppressedCount}]`,
               };
             } else {
-              poll = { ...poll, output: guarded.content };
+              let output = guarded.content;
+              if (guarded.sourceTruncated && toolOutputStore && deps.chatSessionId) {
+                const jobId = String(poll.jobId ?? args.jobId ?? '');
+                const handle = toolOutputStore.store({
+                  chatSessionId: deps.chatSessionId,
+                  capabilityId: 'terminal.poll.monitor-batch',
+                  content: poll.output,
+                  sessionId: jobId ? toolResultDedup?.terminalSessionForJob(jobId) : undefined,
+                });
+                output += [
+                  '',
+                  `[monitor batch archived before shortening: rawChars=${poll.output.length} handleId=${handle.id}]`,
+                  'Use tool_output_read with this handleId to search/read omitted details; the terminal nextOffset already advances past the raw batch.',
+                ].join('\n');
+              }
+              poll = { ...poll, output };
             }
           }
           if (poll.status !== 'running' && poll.status !== 'stopping') {

--- a/infrastructure/ai/harness/cattyRuntime.ts
+++ b/infrastructure/ai/harness/cattyRuntime.ts
@@ -11,15 +11,20 @@ import {
   extractLatestUserGoal,
   prepareTurnContext,
 } from './contextManager';
-import type { AgentEventListener, CompactionTrace } from './types';
+import type { CompactionTrace } from './types';
 import { buildCattyCompactionTimeout } from './streamTimeouts';
 import {
   COMPACTION_PROMPT_RESERVE,
   COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS,
   DEFAULT_MAX_OUTPUT_TOKENS,
   resolveEffectiveMaxOutputTokens,
+  computeCompactionThreshold,
+  computeTotalInputTokens,
 } from './contextBudget';
 import { pruneUntilFitsCompaction } from './compactionPruner';
+import type { ToolOutputStore } from './toolOutputStore';
+import { storeCompactionArchive, storeCompactionArtifact } from './compactionArtifacts';
+import { globalTwoPassCompactionCache } from './twoPassCompaction';
 
 export interface CompactCattyMessagesInput {
   messages: ModelMessage[];
@@ -36,6 +41,7 @@ export interface CompactCattyMessagesInput {
   maxOutputTokens?: number;
   onCompactionStart?: (trigger: 'pre-turn' | '413-retry' | 'force') => void;
   onCompaction?: (trace: CompactionTrace) => void;
+  toolOutputStore?: ToolOutputStore;
   reinjection?: {
     permissionMode?: import('../types').AIPermissionMode;
     sessionScopeSummary?: string;
@@ -48,15 +54,13 @@ export interface CompactCattyMessagesResult {
   trace?: CompactionTrace;
 }
 
-function createEventListener(
-  input: CompactCattyMessagesInput,
-): AgentEventListener | undefined {
-  if (!input.onCompaction) return undefined;
-  return (event) => {
-    if (event.type === 'compaction') {
-      input.onCompaction?.(event.trace);
-    }
-  };
+export function buildCompactionFailureArchiveNotice(
+  archiveHandleId: string | undefined,
+  sourceTruncated: boolean,
+): string | undefined {
+  return archiveHandleId
+    ? `Compaction summary failed. Earlier ${sourceTruncated ? 'bounded' : 'exact'} conversation remains available at tool output handle ${archiveHandleId}; search/read it before guessing missing details.`
+    : undefined;
 }
 
 export async function compactCattyMessages(
@@ -70,6 +74,49 @@ export async function compactCattyMessages(
     ?? input.provider?.advancedParams?.maxTokens
     ?? DEFAULT_MAX_OUTPUT_TOKENS;
   const providerId = input.provider?.providerId;
+  let archiveHandleId: string | undefined;
+  let archiveSourceTruncated = false;
+  let artifactHandleId: string | undefined;
+  let archiveChars: number | undefined;
+  let twoPassCacheHit = false;
+  let twoPassPrefixMessages: number | undefined;
+  const reservedTokens = input.reservedTokens?.() ?? 0;
+  const threshold = computeCompactionThreshold({ contextWindow, maxOutputTokens });
+  const estimatedInput = computeTotalInputTokens({
+    messages: input.messages,
+    providerId,
+    reservedTokens,
+  });
+  const prewarmThreshold = Math.max(1, threshold - Math.ceil(contextWindow * 0.1));
+  if (
+    !input.force
+    && input.trigger !== '413-retry'
+    && estimatedInput >= prewarmThreshold
+    && estimatedInput < threshold
+    && input.chatSessionId
+    && input.modelId
+  ) {
+    globalTwoPassCompactionCache.start(
+      input.chatSessionId,
+      input.modelId,
+      input.messages,
+      async prefix => {
+        const result = await generateText({
+          model: input.model,
+          instructions: CONTEXT_COMPACTION_SYSTEM_PROMPT,
+          messages: [{
+            role: 'user',
+            content: `Create the first-pass note for this stable earlier prefix. Preserve exact decisions, paths, commands, errors, and unfinished work:\n\n${formatMessagesForCompaction(prefix)}`,
+          }],
+          abortSignal: input.abortSignal,
+          maxOutputTokens: COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS,
+          temperature: 0,
+          timeout: buildCattyCompactionTimeout(),
+        });
+        return result.text;
+      },
+    );
+  }
 
   const summarize = async (messagesToSummarize: ModelMessage[]) => {
     const summarizeTrigger = input.trigger === '413-retry' || input.compressForRequestTooLargeRetry
@@ -92,19 +139,57 @@ export async function compactCattyMessages(
       availableForInput: Math.max(1, availableForInput),
       providerId,
     });
+    const cached = input.chatSessionId && input.modelId
+      ? await globalTwoPassCompactionCache.consume(input.chatSessionId, input.modelId, pruned)
+      : undefined;
+    twoPassCacheHit = Boolean(cached);
+    twoPassPrefixMessages = cached?.prefixLength;
+    const formattedHistory = cached
+      ? [
+          `[FIRST-PASS NOTE FOR ${cached.prefixLength} EARLIER MESSAGES]\n${cached.note}`,
+          `[REMAINING EXACT MESSAGES]\n${formatMessagesForCompaction(pruned.slice(cached.prefixLength))}`,
+        ].join('\n\n')
+      : formatMessagesForCompaction(pruned);
+    const exactFormattedHistory = formatMessagesForCompaction(messagesToSummarize);
+    archiveChars = exactFormattedHistory.length;
+    if (input.toolOutputStore && input.chatSessionId) {
+      const archive = storeCompactionArchive(
+        input.toolOutputStore,
+        input.chatSessionId,
+        exactFormattedHistory,
+      );
+      archiveHandleId = archive.id;
+      archiveSourceTruncated = archive.sourceTruncated;
+    }
     const result = await generateText({
       model: input.model,
       instructions: CONTEXT_COMPACTION_SYSTEM_PROMPT,
       messages: [{
         role: 'user',
-        content: `Summarize this earlier conversation context for the next model turn:\n\n${formatMessagesForCompaction(pruned)}`,
+        content: `Summarize this earlier conversation context for the next model turn:\n\n${formattedHistory}`,
       }],
       abortSignal: input.abortSignal,
       maxOutputTokens: COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS,
       temperature: 0,
       timeout: buildCattyCompactionTimeout(),
     });
-    return result.text;
+    if (input.toolOutputStore && input.chatSessionId) {
+      artifactHandleId = storeCompactionArtifact(
+        input.toolOutputStore,
+        input.chatSessionId,
+        {
+          trigger: summarizeTrigger,
+          modelId: input.modelId,
+          archiveHandleId,
+          formattedHistory,
+          summary: result.text,
+        },
+      ).id;
+    }
+    const archiveNotice = archiveHandleId
+      ? `\n\n[Earlier ${archiveSourceTruncated ? 'bounded conversation archive (source exceeded the local archive cap)' : 'exact conversation'} archived locally: handleId=${archiveHandleId}. Use tool_output_read search/range only when the summary lacks a needed exact detail.]`
+      : '';
+    return `${result.text}${archiveNotice}`;
   };
 
   const trigger = input.trigger ?? (input.force ? 'force' : 'pre-turn');
@@ -123,14 +208,23 @@ export async function compactCattyMessages(
       summarize,
       sessionId: input.sessionId,
       chatSessionId: input.chatSessionId,
-      onEvent: createEventListener(input),
+      onEvent: undefined,
       reinjection: {
         ...input.reinjection,
         userGoal: extractLatestUserGoal(input.messages),
       },
       providerId,
     });
-    return { messages: prepared.messages, trace: prepared.trace };
+    const trace = prepared.trace ? {
+      ...prepared.trace,
+      archiveHandleId,
+      artifactHandleId,
+      archiveChars,
+      twoPassCacheHit,
+      twoPassPrefixMessages,
+    } : undefined;
+    if (trace) input.onCompaction?.(trace);
+    return { messages: prepared.messages, trace };
   } catch (err) {
     if (input.abortSignal.aborted) throw err;
     console.warn('[Harness] Context compaction failed; falling back to recent messages only:', err);
@@ -144,9 +238,26 @@ export async function compactCattyMessages(
       protectRecentMessages: DEFAULT_PROTECT_RECENT_MESSAGES,
       sessionId: input.sessionId,
       chatSessionId: input.chatSessionId,
-      onEvent: createEventListener(input),
+      onEvent: undefined,
+      reinjection: {
+        ...input.reinjection,
+        sessionScopeSummary: [
+          input.reinjection?.sessionScopeSummary,
+          buildCompactionFailureArchiveNotice(archiveHandleId, archiveSourceTruncated),
+        ].filter(Boolean).join('\n') || undefined,
+        userGoal: extractLatestUserGoal(input.messages),
+      },
     });
-    return { messages: fallback.messages, trace: fallback.trace };
+    const trace = fallback.trace ? {
+      ...fallback.trace,
+      archiveHandleId,
+      artifactHandleId,
+      archiveChars,
+      twoPassCacheHit,
+      twoPassPrefixMessages,
+    } : undefined;
+    if (trace) input.onCompaction?.(trace);
+    return { messages: fallback.messages, trace };
   }
 }
 

--- a/infrastructure/ai/harness/cattyRuntime.ts
+++ b/infrastructure/ai/harness/cattyRuntime.ts
@@ -150,7 +150,10 @@ export async function compactCattyMessages(
           `[REMAINING EXACT MESSAGES]\n${formatMessagesForCompaction(pruned.slice(cached.prefixLength))}`,
         ].join('\n\n')
       : formatMessagesForCompaction(pruned);
-    const exactFormattedHistory = formatMessagesForCompaction(messagesToSummarize);
+    // Archive the untouched turn input. messagesToSummarize has already passed
+    // through integrity repair and stale-result pruning, so it is not an exact
+    // recovery source even though it is the right input for the summary model.
+    const exactFormattedHistory = formatMessagesForCompaction(input.messages);
     archiveChars = exactFormattedHistory.length;
     if (input.toolOutputStore && input.chatSessionId) {
       const archive = storeCompactionArchive(
@@ -187,7 +190,7 @@ export async function compactCattyMessages(
       ).id;
     }
     const archiveNotice = archiveHandleId
-      ? `\n\n[Earlier ${archiveSourceTruncated ? 'bounded conversation archive (source exceeded the local archive cap)' : 'exact conversation'} archived locally: handleId=${archiveHandleId}. Use tool_output_read search/range only when the summary lacks a needed exact detail.]`
+      ? `\n\n[${archiveSourceTruncated ? 'Bounded conversation snapshot (source exceeded the local archive cap)' : 'Exact conversation snapshot'} archived locally: handleId=${archiveHandleId}. Use tool_output_read search/range only when the summary lacks a needed exact detail.]`
       : '';
     return `${result.text}${archiveNotice}`;
   };

--- a/infrastructure/ai/harness/cattyRuntimeContext.ts
+++ b/infrastructure/ai/harness/cattyRuntimeContext.ts
@@ -6,6 +6,7 @@ import type { ToolOutputStore } from './toolOutputStore';
 import type { ToolResultDedup } from './toolResultDedup';
 import type { CompactionTrace } from './types';
 import type { AgentKind } from '../agentKinds';
+import type { PromptContextSnapshot } from './promptContextSnapshot';
 
 export const cattyRuntimeContextSchema = z.object({
   chatSessionId: z.string(),
@@ -19,6 +20,7 @@ export const cattyRuntimeContextSchema = z.object({
   scopeLabel: z.string().optional(),
   lastCompaction: z.custom<CompactionTrace>().optional(),
   lastStepAdjusted: z.boolean().optional(),
+  promptContext: z.custom<PromptContextSnapshot>().optional(),
 });
 
 export type CattyRuntimeContext = z.infer<typeof cattyRuntimeContextSchema>;
@@ -46,6 +48,7 @@ export function createInitialCattyRuntimeContext(input: {
   permissionMode: AIPermissionMode;
   scopeType: 'terminal' | 'workspace';
   scopeLabel?: string;
+  promptContext?: PromptContextSnapshot;
 }): CattyRuntimeContext {
   return {
     chatSessionId: input.chatSessionId,
@@ -57,6 +60,7 @@ export function createInitialCattyRuntimeContext(input: {
     permissionMode: input.permissionMode,
     scopeType: input.scopeType,
     scopeLabel: input.scopeLabel,
+    promptContext: input.promptContext,
   };
 }
 

--- a/infrastructure/ai/harness/compactionArtifacts.test.ts
+++ b/infrastructure/ai/harness/compactionArtifacts.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { ToolOutputStore } from './toolOutputStore';
+import { storeCompactionArchive, storeCompactionArtifact } from './compactionArtifacts';
+import { buildCompactionFailureArchiveNotice } from './cattyRuntime';
+
+test('compaction artifacts retain exact searchable history and summary output', () => {
+  const store = new ToolOutputStore();
+  const archive = storeCompactionArchive(store, 'chat-1', 'exact E_CONN_RESET_7319 evidence');
+  const artifact = storeCompactionArtifact(store, 'chat-1', {
+    trigger: '413-retry',
+    modelId: 'model-1',
+    archiveHandleId: archive.id,
+    formattedHistory: 'exact E_CONN_RESET_7319 evidence',
+    summary: 'network failure found',
+  });
+
+  assert.match(store.read({ handleId: archive.id, mode: 'search', query: 'E_CONN_RESET_7319' }, 'chat-1') ?? '', /E_CONN_RESET_7319/);
+  assert.match(store.read({ handleId: artifact.id, mode: 'full' }, 'chat-1') ?? '', /network failure found/);
+});
+
+test('compaction failure notice keeps the newly created archive discoverable', () => {
+  assert.match(
+    buildCompactionFailureArchiveNotice('tool-output-archive', false) ?? '',
+    /tool-output-archive/,
+  );
+  assert.equal(buildCompactionFailureArchiveNotice(undefined, false), undefined);
+});

--- a/infrastructure/ai/harness/compactionArtifacts.test.ts
+++ b/infrastructure/ai/harness/compactionArtifacts.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import type { ModelMessage } from 'ai';
+import { MockLanguageModelV4 } from 'ai/test';
 import { ToolOutputStore } from './toolOutputStore';
 import { storeCompactionArchive, storeCompactionArtifact } from './compactionArtifacts';
-import { buildCompactionFailureArchiveNotice } from './cattyRuntime';
+import { buildCompactionFailureArchiveNotice, compactCattyMessages } from './cattyRuntime';
 
 test('compaction artifacts retain exact searchable history and summary output', () => {
   const store = new ToolOutputStore();
@@ -25,4 +27,62 @@ test('compaction failure notice keeps the newly created archive discoverable', (
     /tool-output-archive/,
   );
   assert.equal(buildCompactionFailureArchiveNotice(undefined, false), undefined);
+});
+
+test('compaction archive preserves tool evidence from before stale-result pruning', async () => {
+  const evidence = 'UNIQUE_OLD_TOOL_EVIDENCE_7319';
+  const messages: ModelMessage[] = [
+    { role: 'user', content: 'inspect the old failure' },
+    {
+      role: 'assistant',
+      content: [{
+        type: 'tool-call',
+        toolCallId: 'old-call',
+        toolName: 'terminal_execute',
+        input: { sessionId: 'session-1', command: 'inspect failure' },
+      }],
+    },
+    {
+      role: 'tool',
+      content: [{
+        type: 'tool-result',
+        toolCallId: 'old-call',
+        toolName: 'terminal_execute',
+        output: { type: 'text', value: evidence },
+      }],
+    },
+    ...Array.from({ length: 24 }, (_, index) => ({
+      role: index % 2 === 0 ? 'user' : 'assistant',
+      content: `later message ${index}`,
+    } as ModelMessage)),
+  ];
+  const store = new ToolOutputStore();
+  const model = new MockLanguageModelV4({
+    doGenerate: async () => ({
+      content: [{ type: 'text', text: 'summary' }],
+      finishReason: { unified: 'stop', raw: undefined },
+      usage: {
+        inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+        outputTokens: { total: 2, text: 2, reasoning: undefined },
+      },
+      warnings: [],
+    }),
+  });
+
+  const result = await compactCattyMessages({
+    messages,
+    sessionId: 'chat-archive',
+    chatSessionId: 'chat-archive',
+    model,
+    abortSignal: new AbortController().signal,
+    force: true,
+    trigger: 'force',
+    toolOutputStore: store,
+  });
+  const handleId = result.trace?.archiveHandleId;
+  assert.ok(handleId);
+  assert.match(
+    store.read({ handleId, mode: 'search', query: evidence }, 'chat-archive') ?? '',
+    new RegExp(evidence),
+  );
 });

--- a/infrastructure/ai/harness/compactionArtifacts.ts
+++ b/infrastructure/ai/harness/compactionArtifacts.ts
@@ -1,0 +1,37 @@
+import type { ToolOutputStore, ToolOutputHandle } from './toolOutputStore';
+
+export function storeCompactionArchive(
+  store: ToolOutputStore,
+  chatSessionId: string,
+  formattedHistory: string,
+): ToolOutputHandle {
+  return store.store({
+    chatSessionId,
+    capabilityId: 'conversation.archive',
+    content: formattedHistory,
+  });
+}
+
+export function storeCompactionArtifact(
+  store: ToolOutputStore,
+  chatSessionId: string,
+  input: {
+    trigger: string;
+    modelId?: string | null;
+    archiveHandleId?: string;
+    formattedHistory: string;
+    summary: string;
+  },
+): ToolOutputHandle {
+  return store.store({
+    chatSessionId,
+    capabilityId: 'compaction.artifact',
+    content: [
+      `trigger: ${input.trigger}`,
+      `model: ${input.modelId ?? 'unknown'}`,
+      `archiveHandleId: ${input.archiveHandleId ?? 'unavailable'}`,
+      `\n[compaction input]\n${input.formattedHistory}`,
+      `\n[compaction output]\n${input.summary}`,
+    ].join('\n'),
+  });
+}

--- a/infrastructure/ai/harness/compactionPruner.test.ts
+++ b/infrastructure/ai/harness/compactionPruner.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import type { ModelMessage } from 'ai';
-import { pruneLastModelMessage, pruneUntilFitsCompaction } from './compactionPruner.ts';
+import { pruneFirstModelMessage, pruneLastModelMessage, pruneUntilFitsCompaction } from './compactionPruner.ts';
 
 test('pruneLastModelMessage removes trailing user and assistant pair', () => {
   const messages: ModelMessage[] = [
@@ -31,6 +31,35 @@ test('pruneLastModelMessage removes trailing user and assistant pair', () => {
   assert.equal(pruned.length, 3);
   assert.equal(pruned[0]?.content, 'old');
   assert.equal(pruned.at(-1)?.role, 'tool');
+});
+
+test('message pruning removes complete parallel tool-result batches', () => {
+  const calls = ['a', 'b', 'c'].map((toolCallId) => ({
+    type: 'tool-call' as const,
+    toolCallId,
+    toolName: 'terminal_poll',
+    input: { jobId: toolCallId },
+  }));
+  const results = calls.map((call) => ({
+    role: 'tool' as const,
+    content: [{
+      type: 'tool-result' as const,
+      toolCallId: call.toolCallId,
+      toolName: call.toolName,
+      output: { type: 'text' as const, value: `result ${call.toolCallId}` },
+    }],
+  }));
+  const batch: ModelMessage[] = [
+    { role: 'assistant', content: calls },
+    ...results,
+  ];
+
+  assert.deepEqual(pruneFirstModelMessage([...batch, { role: 'user', content: 'next' }]), [
+    { role: 'user', content: 'next' },
+  ]);
+  assert.deepEqual(pruneLastModelMessage([{ role: 'user', content: 'before' }, ...batch]), [
+    { role: 'user', content: 'before' },
+  ]);
 });
 
 test('pruneUntilFitsCompaction shrinks history to fit budget', () => {

--- a/infrastructure/ai/harness/compactionPruner.ts
+++ b/infrastructure/ai/harness/compactionPruner.ts
@@ -17,10 +17,30 @@ function startsWithToolResult(message: ModelMessage | undefined): boolean {
   });
 }
 
+function skipToolResultsForward(messages: ModelMessage[], startIndex: number): number {
+  let index = startIndex;
+  while (index < messages.length && startsWithToolResult(messages[index])) index += 1;
+  return index;
+}
+
+function findToolResultsStart(messages: ModelMessage[]): number {
+  let index = messages.length;
+  while (index > 0 && startsWithToolResult(messages[index - 1])) index -= 1;
+  return index;
+}
+
 /** Prune from the tail while preserving valid tool-call/tool-result pairing. */
 export function pruneLastModelMessage(messages: ModelMessage[]): ModelMessage[] {
   if (messages.length === 0) return messages;
   if (messages.length === 1) return [];
+
+  const trailingToolStart = findToolResultsStart(messages);
+  if (trailingToolStart < messages.length) {
+    const preceding = messages[trailingToolStart - 1];
+    return preceding?.role === 'assistant' && endsWithToolCall(preceding)
+      ? messages.slice(0, trailingToolStart - 1)
+      : messages.slice(0, trailingToolStart);
+  }
 
   const secondToLastIndex = messages.length - 2;
   const secondToLast = messages[secondToLastIndex];
@@ -31,10 +51,6 @@ export function pruneLastModelMessage(messages: ModelMessage[]): ModelMessage[] 
   if (secondToLast.role === 'user') {
     return messages.slice(0, -2);
   }
-  if (startsWithToolResult(messages[messages.length - 1])) {
-    return messages.slice(0, -1);
-  }
-
   return messages.slice(0, -1);
 }
 
@@ -46,17 +62,17 @@ export function pruneFirstModelMessage(messages: ModelMessage[]): ModelMessage[]
   const first = messages[0];
   const second = messages[1];
 
-  if (first.role === 'assistant' && endsWithToolCall(first) && second?.role === 'tool') {
-    return messages.slice(2);
+  if (first.role === 'assistant' && endsWithToolCall(first)) {
+    return messages.slice(skipToolResultsForward(messages, 1));
   }
-  if (first.role === 'user' && second?.role === 'assistant' && endsWithToolCall(second) && messages[2]?.role === 'tool') {
-    return messages.slice(3);
+  if (first.role === 'user' && second?.role === 'assistant' && endsWithToolCall(second)) {
+    return messages.slice(skipToolResultsForward(messages, 2));
   }
   if (first.role === 'user' && second?.role === 'assistant') {
     return messages.slice(2);
   }
   if (startsWithToolResult(first)) {
-    return messages.slice(1);
+    return messages.slice(skipToolResultsForward(messages, 0));
   }
 
   return messages.slice(1);

--- a/infrastructure/ai/harness/contextManager.test.ts
+++ b/infrastructure/ai/harness/contextManager.test.ts
@@ -238,6 +238,61 @@ test('prepareStepContext retains handle notice after step budget guard', async (
   assert.match(String(notices[0]?.content), /\[step 2\]/);
 });
 
+test('prepareStepContext never leaves orphan results from a parallel tool batch', async () => {
+  const toolCallIds = ['a', 'b', 'c', 'd', 'e', 'f'];
+  const messages: ModelMessage[] = [
+    {
+      role: 'assistant',
+      content: toolCallIds.map((toolCallId) => ({
+        type: 'tool-call' as const,
+        toolCallId,
+        toolName: 'terminal_poll',
+        input: { jobId: toolCallId },
+      })),
+    },
+    ...toolCallIds.map((toolCallId) => ({
+      role: 'tool' as const,
+      content: [{
+        type: 'tool-result' as const,
+        toolCallId,
+        toolName: 'terminal_poll',
+        output: { type: 'text' as const, value: `${toolCallId}:${'output '.repeat(4_000)}` },
+      }],
+    })),
+    { role: 'user', content: 'summarize the completed jobs' },
+  ];
+
+  const prepared = await prepareStepContext({
+    messages,
+    stepNumber: 4,
+    sessionId: 'chat-parallel',
+    chatSessionId: 'chat-parallel',
+    contextWindow: 8_000,
+    reservedTokens: 500,
+    maxOutputTokens: 512,
+    runtimeContext: createInitialCattyRuntimeContext({
+      chatSessionId: 'chat-parallel',
+      turnId: 'turn-parallel',
+      permissionMode: 'confirm',
+      scopeType: 'terminal',
+    }),
+  });
+
+  const knownCalls = new Set<string>();
+  for (const message of prepared.messages) {
+    if (message.role === 'assistant' && Array.isArray(message.content)) {
+      for (const part of message.content as Array<{ type?: string; toolCallId?: string }>) {
+        if (part.type === 'tool-call' && part.toolCallId) knownCalls.add(part.toolCallId);
+      }
+    }
+    if (message.role === 'tool' && Array.isArray(message.content)) {
+      for (const part of message.content as Array<{ type?: string; toolCallId?: string }>) {
+        if (part.type === 'tool-result') assert.equal(knownCalls.has(part.toolCallId ?? ''), true);
+      }
+    }
+  }
+});
+
 test('prepareTurnContext calls summarize when over dynamic threshold', async () => {
   let summarizeCalls = 0;
   const messages: ModelMessage[] = Array.from({ length: 24 }, (_, index) => ({

--- a/infrastructure/ai/harness/contextManager.ts
+++ b/infrastructure/ai/harness/contextManager.ts
@@ -26,6 +26,8 @@ import type {
   ExternalBridgeHistoryMessage,
 } from './types';
 import { buildExternalBridgeContextMessages } from './externalBridgeContext';
+import { repairToolMessageIntegrity } from './toolMessageIntegrity';
+import { pruneFirstModelMessage } from './compactionPruner';
 
 export interface PrepareTurnContextInput {
   messages: ModelMessage[];
@@ -186,9 +188,10 @@ export async function prepareTurnContext(
   const protectRecent = input.protectRecentMessages ?? DEFAULT_PROTECT_RECENT_MESSAGES;
   const maxOutputTokens = input.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
   const messagesBeforeCount = input.messages.length;
+  const integrity = repairToolMessageIntegrity(input.messages);
 
   const underBudgetPressure = isContextUnderBudgetPressure({
-    messages: input.messages,
+    messages: integrity.messages,
     contextWindow,
     maxOutputTokens,
     providerId: input.providerId,
@@ -196,11 +199,11 @@ export async function prepareTurnContext(
     force: input.force,
     trigger: input.trigger,
   });
-  const stale = pruneStaleToolContext(input.messages, {
+  const stale = pruneStaleToolContext(integrity.messages, {
     underBudgetPressure,
   });
   let working = stale.messages;
-  let didAdjust = stale.didAdjust;
+  let didAdjust = integrity.didAdjust || stale.didAdjust;
 
   const tokensBeforeResult = estimateModelMessagesTokensWithKind({
     messages: working,
@@ -263,7 +266,19 @@ export async function prepareTurnContext(
 
   const reinjection = buildReinjectionMessages(input.reinjection);
   if (reinjection.length > 0 && didAdjust) {
-    working = [...reinjection, ...working];
+    const reinjectionTokens = estimateModelMessagesTokensWithKind({
+      messages: reinjection,
+      providerId: input.providerId,
+    }).tokens;
+    const finalGuard = applyStepBudgetGuard(working, {
+      contextWindow,
+      reservedTokens: (input.reservedTokens ?? 0) + reinjectionTokens,
+      maxOutputTokens,
+      providerId: input.providerId,
+      protectRecentMessages: protectRecent,
+    });
+    working = [...reinjection, ...finalGuard.messages];
+    didAdjust = didAdjust || finalGuard.didAdjust;
   }
 
   const tokensAfter = estimateModelMessagesTokensWithKind({
@@ -349,6 +364,22 @@ function applyStepBudgetGuard(
   if (afterTotal >= threshold && splitAt > 0) {
     next = keepRecentContextMessages(next, input.protectRecentMessages);
     didAdjust = true;
+    afterTotal = computeTotalInputTokens({
+      messages: next,
+      providerId: input.providerId,
+      reservedTokens: input.reservedTokens,
+    });
+  }
+  while (afterTotal >= threshold && next.length > 2) {
+    const pruned = pruneFirstModelMessage(next);
+    if (pruned.length === next.length) break;
+    next = pruned;
+    didAdjust = true;
+    afterTotal = computeTotalInputTokens({
+      messages: next,
+      providerId: input.providerId,
+      reservedTokens: input.reservedTokens,
+    });
   }
 
   return {
@@ -366,15 +397,16 @@ export async function prepareStepContext(
   const maxOutputTokens = input.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
   const protectRecent = input.protectRecentMessages ?? DEFAULT_PROTECT_RECENT_MESSAGES;
   const messagesBeforeCount = input.messages.length;
+  const integrity = repairToolMessageIntegrity(input.messages);
 
   const underBudgetPressure = isContextUnderBudgetPressure({
-    messages: input.messages,
+    messages: integrity.messages,
     contextWindow,
     maxOutputTokens,
     providerId: input.providerId,
     reservedTokens: input.reservedTokens,
   });
-  const stale = pruneStaleToolContext(input.messages, {
+  const stale = pruneStaleToolContext(integrity.messages, {
     underBudgetPressure,
   });
   let working = stale.messages;
@@ -417,7 +449,28 @@ export async function prepareStepContext(
       }, ...working];
     }
   }
-  const didBudgetAdjust = stale.didAdjust || typed.didAdjust || budgetGuard.didAdjust;
+  if (didHandleNotice) {
+    const notices = working.filter(
+      message => message.role === 'user' && isStepHandleNoticeMessage(message.content),
+    );
+    const body = working.filter(
+      message => !(message.role === 'user' && isStepHandleNoticeMessage(message.content)),
+    );
+    const noticeTokens = estimateModelMessagesTokensWithKind({
+      messages: notices,
+      providerId: input.providerId,
+    }).tokens;
+    const finalGuard = applyStepBudgetGuard(body, {
+      contextWindow,
+      reservedTokens: (input.reservedTokens ?? 0) + noticeTokens,
+      maxOutputTokens,
+      providerId: input.providerId,
+      protectRecentMessages: protectRecent,
+    });
+    working = [...notices, ...finalGuard.messages];
+    budgetGuard.didAdjust = budgetGuard.didAdjust || finalGuard.didAdjust;
+  }
+  const didBudgetAdjust = integrity.didAdjust || stale.didAdjust || typed.didAdjust || budgetGuard.didAdjust;
   const didAdjust = didBudgetAdjust || didHandleNotice;
 
   const before = estimateModelMessagesTokensWithKind({

--- a/infrastructure/ai/harness/generated/cattyToolSpecs.json
+++ b/infrastructure/ai/harness/generated/cattyToolSpecs.json
@@ -2148,12 +2148,22 @@
       "mode": {
         "type": "string",
         "optional": true,
-        "description": "Which portion to read: head, tail, or full."
+        "description": "Which portion to read: head, tail, range, search, or bounded full."
       },
       "maxChars": {
         "type": "number",
         "optional": true,
-        "description": "Maximum characters to return."
+        "description": "Requested characters to return. The service enforces a hard upper bound."
+      },
+      "offset": {
+        "type": "number",
+        "optional": true,
+        "description": "Zero-based character offset for range reads or search continuation."
+      },
+      "query": {
+        "type": "string",
+        "optional": true,
+        "description": "Case-insensitive search text when mode is search."
       }
     },
     "policy": {

--- a/infrastructure/ai/harness/index.ts
+++ b/infrastructure/ai/harness/index.ts
@@ -39,7 +39,14 @@ export {
 export type { EstimateModelMessagesTokensInput, EstimateModelMessagesTokensResult } from './tokenEstimator';
 
 export { ToolOutputStore, globalToolOutputStore } from './toolOutputStore';
-export type { ToolOutputHandle, StoreToolOutputInput, ReadToolOutputInput } from './toolOutputStore';
+export type {
+  ToolOutputHandle,
+  StoreToolOutputInput,
+  ReadToolOutputInput,
+  ToolOutputReadResult,
+  ToolOutputPersistence,
+  ToolOutputStoreOptions,
+} from './toolOutputStore';
 
 export { ToolResultDedup, hashScopeKey, previewToolResult } from './toolResultDedup';
 export type { ToolResultDedupEntry } from './toolResultDedup';
@@ -73,6 +80,11 @@ export {
 
 export { SessionStateStore, globalSessionStateStore } from './sessionState';
 export type { CattySessionState } from './sessionState';
+
+export { repairToolMessageIntegrity } from './toolMessageIntegrity';
+export { redactSecretsForModel } from './modelSecretRedaction';
+export { buildPromptContextSnapshot } from './promptContextSnapshot';
+export type { PromptContextSnapshot } from './promptContextSnapshot';
 
 export { pruneStaleToolContext } from './staleContextPruner';
 export { pruneUntilFitsCompaction } from './compactionPruner';

--- a/infrastructure/ai/harness/largeUserInput.test.ts
+++ b/infrastructure/ai/harness/largeUserInput.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { ToolOutputStore } from './toolOutputStore';
+import { fitLargeUserInputForModel } from './largeUserInput';
+
+test('fitLargeUserInputForModel keeps both ends and stores the full prompt', () => {
+  const store = new ToolOutputStore();
+  const input = `START-${'middle '.repeat(8_000)}-FINAL QUESTION`;
+  const fitted = fitLargeUserInputForModel(input, 'chat-1', store);
+
+  assert.match(fitted, /^START-/);
+  assert.match(fitted, /FINAL QUESTION/);
+  assert.match(fitted, /handleId=tool-output-/);
+  assert.ok(fitted.length < input.length);
+  const handle = store.listPendingHandles('chat-1')[0];
+  assert.equal(handle.fullContent, input);
+});

--- a/infrastructure/ai/harness/largeUserInput.test.ts
+++ b/infrastructure/ai/harness/largeUserInput.test.ts
@@ -2,6 +2,10 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { ToolOutputStore } from './toolOutputStore';
 import { fitLargeUserInputForModel } from './largeUserInput';
+import {
+  buildCattySdkMessages,
+  createContinuationContext,
+} from './turnDrivers/cattyMessageBuilder';
 
 test('fitLargeUserInputForModel keeps both ends and stores the full prompt', () => {
   const store = new ToolOutputStore();
@@ -14,4 +18,49 @@ test('fitLargeUserInputForModel keeps both ends and stores the full prompt', () 
   assert.ok(fitted.length < input.length);
   const handle = store.listPendingHandles('chat-1')[0];
   assert.equal(handle.fullContent, input);
+});
+
+test('fitLargeUserInputForModel reuses one stable handle across history replays', () => {
+  const store = new ToolOutputStore();
+  const input = `START-${'history '.repeat(8_000)}-FINAL QUESTION`;
+
+  const firstReplay = fitLargeUserInputForModel(input, 'chat-1', store);
+  const secondReplay = fitLargeUserInputForModel(input, 'chat-1', store);
+
+  assert.equal(secondReplay, firstReplay);
+  assert.equal(store.listPendingHandles('chat-1').length, 1);
+});
+
+test('a large user message remains bounded with the same handle on the next turn', () => {
+  const store = new ToolOutputStore();
+  const input = `START-${'history '.repeat(8_000)}-FINAL QUESTION`;
+  const firstTurnContent = fitLargeUserInputForModel(input, 'chat-1', store);
+  const firstHandleId = firstTurnContent.match(/handleId=(tool-output-[A-Za-z0-9-]+)/)?.[1];
+  assert.ok(firstHandleId);
+
+  const buildHistory = () => buildCattySdkMessages({
+    allMessages: [{
+      id: 'user-1',
+      role: 'user',
+      content: input,
+      timestamp: 1,
+    }],
+    includeCurrentUserMessage: true,
+    trimmed: 'continue',
+    continuationContext: createContinuationContext('provider-1', 'openai', 'model-1'),
+    chatSessionId: 'chat-1',
+    toolOutputStore: store,
+    fieldsByMessage: new Map(),
+  });
+
+  const secondTurn = buildHistory();
+  const retry = buildHistory();
+  const replayContent = secondTurn[0]?.content;
+  const retryContent = retry[0]?.content;
+  assert.ok(typeof replayContent === 'string');
+  assert.ok(typeof retryContent === 'string');
+  assert.equal(replayContent, retryContent);
+  assert.match(replayContent, new RegExp(`handleId=${firstHandleId}`));
+  assert.ok(replayContent.length < input.length);
+  assert.equal(store.listPendingHandles('chat-1').length, 1);
 });

--- a/infrastructure/ai/harness/largeUserInput.ts
+++ b/infrastructure/ai/harness/largeUserInput.ts
@@ -1,0 +1,23 @@
+import type { ToolOutputStore } from './toolOutputStore';
+
+const LARGE_USER_INPUT_THRESHOLD_CHARS = 25_000;
+const LARGE_USER_INPUT_HEAD_CHARS = 12_000;
+const LARGE_USER_INPUT_TAIL_CHARS = 4_000;
+
+export function fitLargeUserInputForModel(
+  input: string,
+  chatSessionId: string,
+  toolOutputStore: ToolOutputStore,
+): string {
+  if (input.length <= LARGE_USER_INPUT_THRESHOLD_CHARS) return input;
+  const handle = toolOutputStore.store({
+    chatSessionId,
+    capabilityId: 'user.input',
+    content: input,
+  });
+  return [
+    input.slice(0, LARGE_USER_INPUT_HEAD_CHARS),
+    `\n\n[... large user input moved to saved output: ${input.length} chars, handleId=${handle.id}. Use tool_output_read with range or search for omitted details ...]\n\n`,
+    input.slice(-LARGE_USER_INPUT_TAIL_CHARS),
+  ].join('');
+}

--- a/infrastructure/ai/harness/largeUserInput.ts
+++ b/infrastructure/ai/harness/largeUserInput.ts
@@ -4,20 +4,47 @@ const LARGE_USER_INPUT_THRESHOLD_CHARS = 25_000;
 const LARGE_USER_INPUT_HEAD_CHARS = 12_000;
 const LARGE_USER_INPUT_TAIL_CHARS = 4_000;
 
+const handlesByStore = new WeakMap<ToolOutputStore, Map<string, string>>();
+
+function hashInput(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function getStableHandleId(
+  input: string,
+  chatSessionId: string,
+  toolOutputStore: ToolOutputStore,
+): string {
+  const handles = handlesByStore.get(toolOutputStore) ?? new Map<string, string>();
+  handlesByStore.set(toolOutputStore, handles);
+  const key = `${chatSessionId}:${input.length}:${hashInput(input)}`;
+  const existingId = handles.get(key);
+  if (existingId && toolOutputStore.get(existingId, chatSessionId)) return existingId;
+
+  const handleId = toolOutputStore.store({
+    chatSessionId,
+    capabilityId: 'user.input',
+    content: input,
+  }).id;
+  handles.set(key, handleId);
+  return handleId;
+}
+
 export function fitLargeUserInputForModel(
   input: string,
   chatSessionId: string,
   toolOutputStore: ToolOutputStore,
 ): string {
   if (input.length <= LARGE_USER_INPUT_THRESHOLD_CHARS) return input;
-  const handle = toolOutputStore.store({
-    chatSessionId,
-    capabilityId: 'user.input',
-    content: input,
-  });
+  const handleId = getStableHandleId(input, chatSessionId, toolOutputStore);
   return [
     input.slice(0, LARGE_USER_INPUT_HEAD_CHARS),
-    `\n\n[... large user input moved to saved output: ${input.length} chars, handleId=${handle.id}. Use tool_output_read with range or search for omitted details ...]\n\n`,
+    `\n\n[... large user input moved to saved output: ${input.length} chars, handleId=${handleId}. Use tool_output_read with range or search for omitted details ...]\n\n`,
     input.slice(-LARGE_USER_INPUT_TAIL_CHARS),
   ].join('');
 }

--- a/infrastructure/ai/harness/modelSecretRedaction.test.ts
+++ b/infrastructure/ai/harness/modelSecretRedaction.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { fitTerminalExecuteResultForModel } from './terminalCompression';
+import { fitLargeToolResultForModel } from './toolResultFitting';
+import { ToolOutputStore } from './toolOutputStore';
+import { redactSecretsForModel, redactSecretsInValueForModel } from './modelSecretRedaction';
+
+test('redactSecretsForModel removes common terminal secrets', () => {
+  const input = [
+    'API_TOKEN=tok_live_1234567890',
+    'Authorization: Bearer abc.def.very-secret',
+    'postgres://admin:p4ssw0rd@db.internal/app',
+    '-----BEGIN PRIVATE KEY-----',
+    'super-secret-private-key-body',
+    '-----END PRIVATE KEY-----',
+  ].join('\n');
+  const output = redactSecretsForModel(input);
+
+  assert.doesNotMatch(output, /tok_live|abc\.def|p4ssw0rd|private-key-body/);
+  assert.match(output, /\[REDACTED\]/);
+});
+
+test('redactSecretsInValueForModel recursively redacts tool arguments', () => {
+  const value = redactSecretsInValueForModel({
+    command: 'curl --password swordfish',
+    nested: ['Authorization: Bearer secret_token_123456'],
+  });
+  assert.doesNotMatch(JSON.stringify(value), /swordfish|secret_token/);
+});
+
+test('terminal fitting keeps raw output in the local handle but redacts model-visible text', () => {
+  const store = new ToolOutputStore();
+  const secret = 'API_TOKEN=tok_live_1234567890';
+  const fitted = fitTerminalExecuteResultForModel({
+    stdout: `${secret}\n${'build line\n'.repeat(10_000)}`,
+    stderr: '',
+    exitCode: 1,
+    command: `deploy --token tok_live_1234567890`,
+    sessionId: 'session-1',
+  }, {
+    chatSessionId: 'chat-1',
+    toolOutputStore: store,
+  });
+
+  assert.doesNotMatch(fitted.stdout, /tok_live/);
+  assert.doesNotMatch(fitted.command ?? '', /tok_live/);
+  const handle = store.listPendingHandles('chat-1')[0];
+  assert.match(handle.fullContent, /tok_live/);
+});
+
+test('generic tool fitting redacts short strings even when truncation is unnecessary', () => {
+  const fitted = fitLargeToolResultForModel({
+    result: { message: 'password=hunter2' },
+    capabilityId: 'example.read',
+  }) as { message: string };
+
+  assert.equal(fitted.message, 'password=[REDACTED]');
+});

--- a/infrastructure/ai/harness/modelSecretRedaction.test.ts
+++ b/infrastructure/ai/harness/modelSecretRedaction.test.ts
@@ -23,9 +23,37 @@ test('redactSecretsForModel removes common terminal secrets', () => {
 test('redactSecretsInValueForModel recursively redacts tool arguments', () => {
   const value = redactSecretsInValueForModel({
     command: 'curl --password swordfish',
-    nested: ['Authorization: Bearer secret_token_123456'],
+    nested: [
+      'Authorization: Bearer secret_token_123456',
+      {
+        password: 'short',
+        telnetPassword: 'telnet-secret',
+        passphrase: 'key-passphrase',
+        privateKey: 'not-a-pem-but-still-private',
+        apiKey: 'tiny-api-key',
+        clientSecret: 'client-secret',
+        authToken: 'auth-token',
+        username: 'operator',
+      },
+    ],
   });
-  assert.doesNotMatch(JSON.stringify(value), /swordfish|secret_token/);
+  const serialized = JSON.stringify(value);
+  assert.doesNotMatch(serialized, /swordfish|secret_token|short|telnet-secret|key-passphrase|not-a-pem|tiny-api-key|client-secret|auth-token/);
+  assert.match(serialized, /operator/);
+});
+
+test('redactSecretsForModel redacts JSON and quoted shell assignments', () => {
+  const input = [
+    '{"password":"short value","apiKey":"tiny","username":"operator"}',
+    "passphrase='two words'",
+    'client_secret = "quoted secret"',
+    'PRIVATE_KEY=one-line-key',
+  ].join('\n');
+
+  const output = redactSecretsForModel(input);
+  assert.doesNotMatch(output, /short value|tiny|two words|quoted secret|one-line-key/);
+  assert.match(output, /"username":"operator"/);
+  assert.equal((output.match(/\[REDACTED\]/g) ?? []).length, 5);
 });
 
 test('terminal fitting keeps raw output in the local handle but redacts model-visible text', () => {

--- a/infrastructure/ai/harness/modelSecretRedaction.ts
+++ b/infrastructure/ai/harness/modelSecretRedaction.ts
@@ -1,0 +1,31 @@
+const REDACTED = '[REDACTED]';
+
+const PRIVATE_KEY_PATTERN = /-----BEGIN ([A-Z0-9 ]*PRIVATE KEY)-----[\s\S]*?-----END \1-----/g;
+const BEARER_PATTERN = /\b(Bearer)\s+[A-Za-z0-9._~+/=-]{8,}/gi;
+const URL_CREDENTIAL_PATTERN = /([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+:)([^\s@]+)(@)/gi;
+const SECRET_ASSIGNMENT_PATTERN = /\b([A-Za-z0-9_.-]*(?:password|passwd|pwd|token|secret|api[_-]?key|access[_-]?key)[A-Za-z0-9_.-]*)\s*([:=])\s*(["']?)([^\s"',;]+)\3/gi;
+const SECRET_CLI_FLAG_PATTERN = /(--(?:password|passwd|token|secret|api-key|access-key))\s+(?:["']([^"']+)["']|([^\s]+))/gi;
+const WELL_KNOWN_TOKEN_PATTERN = /\b(?:gh[pousr]_[A-Za-z0-9]{20,}|sk-[A-Za-z0-9_-]{20,})\b/g;
+
+/** Redacts likely credentials only on data that is about to become model-visible. */
+export function redactSecretsForModel(value: string): string {
+  if (!value) return value;
+  return value
+    .replace(PRIVATE_KEY_PATTERN, REDACTED)
+    .replace(BEARER_PATTERN, '$1 [REDACTED]')
+    .replace(URL_CREDENTIAL_PATTERN, `$1${REDACTED}$3`)
+    .replace(SECRET_ASSIGNMENT_PATTERN, '$1$2[REDACTED]')
+    .replace(SECRET_CLI_FLAG_PATTERN, '$1 [REDACTED]')
+    .replace(WELL_KNOWN_TOKEN_PATTERN, REDACTED);
+}
+
+/** Recursively redacts model-visible event arguments without mutating the source value. */
+export function redactSecretsInValueForModel<T>(value: T): T {
+  if (typeof value === 'string') return redactSecretsForModel(value) as T;
+  if (Array.isArray(value)) return value.map(redactSecretsInValueForModel) as T;
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .map(([key, entry]) => [key, redactSecretsInValueForModel(entry)]),
+  ) as T;
+}

--- a/infrastructure/ai/harness/modelSecretRedaction.ts
+++ b/infrastructure/ai/harness/modelSecretRedaction.ts
@@ -3,9 +3,16 @@ const REDACTED = '[REDACTED]';
 const PRIVATE_KEY_PATTERN = /-----BEGIN ([A-Z0-9 ]*PRIVATE KEY)-----[\s\S]*?-----END \1-----/g;
 const BEARER_PATTERN = /\b(Bearer)\s+[A-Za-z0-9._~+/=-]{8,}/gi;
 const URL_CREDENTIAL_PATTERN = /([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+:)([^\s@]+)(@)/gi;
-const SECRET_ASSIGNMENT_PATTERN = /\b([A-Za-z0-9_.-]*(?:password|passwd|pwd|token|secret|api[_-]?key|access[_-]?key)[A-Za-z0-9_.-]*)\s*([:=])\s*(["']?)([^\s"',;]+)\3/gi;
-const SECRET_CLI_FLAG_PATTERN = /(--(?:password|passwd|token|secret|api-key|access-key))\s+(?:["']([^"']+)["']|([^\s]+))/gi;
+const QUOTED_SECRET_ASSIGNMENT_PATTERN = /(["'])([A-Za-z0-9_.-]*(?:password|passwd|passphrase|pwd|token|secret|api[_-]?key|access[_-]?key|secret[_-]?key|private[_-]?key|credential)[A-Za-z0-9_.-]*)\1\s*([:=])\s*(["'])((?:\\.|(?!\4)[\s\S])*?)\4/gi;
+const QUOTED_VALUE_SECRET_ASSIGNMENT_PATTERN = /\b([A-Za-z0-9_.-]*(?:password|passwd|passphrase|pwd|token|secret|api[_-]?key|access[_-]?key|secret[_-]?key|private[_-]?key|credential)[A-Za-z0-9_.-]*)\s*([:=])\s*(["'])((?:\\.|(?!\3)[\s\S])*?)\3/gi;
+const SECRET_ASSIGNMENT_PATTERN = /\b([A-Za-z0-9_.-]*(?:password|passwd|passphrase|pwd|token|secret|api[_-]?key|access[_-]?key|secret[_-]?key|private[_-]?key|credential)[A-Za-z0-9_.-]*)\s*([:=])\s*(["']?)([^\s"',;]+)\3/gi;
+const SECRET_CLI_FLAG_PATTERN = /(--(?:password|passwd|passphrase|token|secret|api-key|access-key|secret-key|private-key))\s+(?:["']([^"']+)["']|([^\s]+))/gi;
 const WELL_KNOWN_TOKEN_PATTERN = /\b(?:gh[pousr]_[A-Za-z0-9]{20,}|sk-[A-Za-z0-9_-]{20,})\b/g;
+
+function isSecretKey(key: string): boolean {
+  const normalized = key.replace(/[^A-Za-z0-9]/g, '').toLocaleLowerCase();
+  return /(?:password|passwd|passphrase|pwd|token|secret|apikey|accesskey|secretkey|privatekey|credential|credentials)$/.test(normalized);
+}
 
 /** Redacts likely credentials only on data that is about to become model-visible. */
 export function redactSecretsForModel(value: string): string {
@@ -14,6 +21,8 @@ export function redactSecretsForModel(value: string): string {
     .replace(PRIVATE_KEY_PATTERN, REDACTED)
     .replace(BEARER_PATTERN, '$1 [REDACTED]')
     .replace(URL_CREDENTIAL_PATTERN, `$1${REDACTED}$3`)
+    .replace(QUOTED_SECRET_ASSIGNMENT_PATTERN, '$1$2$1$3$4[REDACTED]$4')
+    .replace(QUOTED_VALUE_SECRET_ASSIGNMENT_PATTERN, '$1$2$3[REDACTED]$3')
     .replace(SECRET_ASSIGNMENT_PATTERN, '$1$2[REDACTED]')
     .replace(SECRET_CLI_FLAG_PATTERN, '$1 [REDACTED]')
     .replace(WELL_KNOWN_TOKEN_PATTERN, REDACTED);
@@ -26,6 +35,9 @@ export function redactSecretsInValueForModel<T>(value: T): T {
   if (!value || typeof value !== 'object') return value;
   return Object.fromEntries(
     Object.entries(value as Record<string, unknown>)
-      .map(([key, entry]) => [key, redactSecretsInValueForModel(entry)]),
+      .map(([key, entry]) => [
+        key,
+        isSecretKey(key) ? REDACTED : redactSecretsInValueForModel(entry),
+      ]),
   ) as T;
 }

--- a/infrastructure/ai/harness/promptContextSnapshot.test.ts
+++ b/infrastructure/ai/harness/promptContextSnapshot.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildPromptContextSnapshot } from './promptContextSnapshot';
+
+test('buildPromptContextSnapshot records inspectable prompt inputs without credentials', () => {
+  const snapshot = buildPromptContextSnapshot({
+    providerId: 'openai',
+    modelId: 'gpt-test',
+    permissionMode: 'confirm',
+    scopeType: 'terminal',
+    scopeLabel: 'production',
+    toolNames: ['terminal_execute', 'terminal_poll'],
+    selectedSkillSlugs: ['diagnosing-bugs'],
+    systemPrompt: 'secret-free rendered prompt',
+    webSearchEnabled: false,
+    hostSessionIds: ['session-1'],
+    builtAt: 123,
+  });
+
+  assert.equal(snapshot.version, 2);
+  assert.deepEqual(snapshot.toolNames, ['terminal_execute', 'terminal_poll']);
+  assert.equal(snapshot.systemPromptChars, 27);
+  assert.match(snapshot.systemPromptHash, /^fnv1a-/);
+  assert.deepEqual(snapshot.injections.map(item => item.source), [
+    'system-prompt', 'capability-catalog', 'user-skills', 'terminal-scope', 'web-search',
+  ]);
+  assert.equal(JSON.stringify(snapshot).includes('secret-free rendered prompt'), false);
+});

--- a/infrastructure/ai/harness/promptContextSnapshot.ts
+++ b/infrastructure/ai/harness/promptContextSnapshot.ts
@@ -1,0 +1,82 @@
+import type { AIPermissionMode } from '../types';
+
+export interface PromptContextSnapshot {
+  version: 2;
+  audience: 'sidebar';
+  providerId?: string;
+  modelId?: string;
+  permissionMode: AIPermissionMode;
+  scopeType: 'terminal' | 'workspace';
+  scopeLabel?: string;
+  toolNames: string[];
+  selectedSkillSlugs: string[];
+  systemPromptChars: number;
+  systemPromptHash: string;
+  injections: Array<{
+    order: number;
+    source: 'system-prompt' | 'capability-catalog' | 'user-skills' | 'terminal-scope' | 'web-search';
+    itemCount: number;
+    chars?: number;
+    hash: string;
+  }>;
+  webSearchEnabled: boolean;
+  hostSessionIds: string[];
+  builtAt: number;
+}
+
+export function buildPromptContextSnapshot(input: {
+  providerId?: string;
+  modelId?: string;
+  permissionMode: AIPermissionMode;
+  scopeType: 'terminal' | 'workspace';
+  scopeLabel?: string;
+  toolNames: string[];
+  selectedSkillSlugs?: string[];
+  systemPrompt: string;
+  webSearchEnabled: boolean;
+  hostSessionIds: string[];
+  builtAt?: number;
+}): PromptContextSnapshot {
+  const toolNames = [...input.toolNames].sort();
+  const selectedSkillSlugs = [...(input.selectedSkillSlugs ?? [])].sort();
+  const hostSessionIds = [...input.hostSessionIds];
+  const injectionValues = [
+    { source: 'system-prompt' as const, values: [input.systemPrompt], chars: input.systemPrompt.length },
+    { source: 'capability-catalog' as const, values: toolNames },
+    { source: 'user-skills' as const, values: selectedSkillSlugs },
+    { source: 'terminal-scope' as const, values: hostSessionIds },
+    { source: 'web-search' as const, values: [String(input.webSearchEnabled)] },
+  ];
+  return {
+    version: 2,
+    audience: 'sidebar',
+    providerId: input.providerId,
+    modelId: input.modelId,
+    permissionMode: input.permissionMode,
+    scopeType: input.scopeType,
+    scopeLabel: input.scopeLabel,
+    toolNames,
+    selectedSkillSlugs,
+    systemPromptChars: input.systemPrompt.length,
+    systemPromptHash: hashPromptPart(input.systemPrompt),
+    injections: injectionValues.map((entry, order) => ({
+      order,
+      source: entry.source,
+      itemCount: entry.values.length,
+      ...(entry.chars != null ? { chars: entry.chars } : {}),
+      hash: hashPromptPart(entry.values.join('\n')),
+    })),
+    webSearchEnabled: input.webSearchEnabled,
+    hostSessionIds,
+    builtAt: input.builtAt ?? Date.now(),
+  };
+}
+
+function hashPromptPart(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `fnv1a-${(hash >>> 0).toString(16).padStart(8, '0')}`;
+}

--- a/infrastructure/ai/harness/sessionState.test.ts
+++ b/infrastructure/ai/harness/sessionState.test.ts
@@ -72,6 +72,24 @@ test('SessionStateStore drops a remembered job after poll reports it missing', (
   assert.doesNotMatch(store.toReinjectionText('chat-1') ?? '', /Remembered terminal jobs/);
 });
 
+test('SessionStateStore preserves a running job after a transient poll error', () => {
+  const store = new SessionStateStore();
+  store.updateFromToolResult(
+    'chat-1', 'terminal_start', { sessionId: 'sess-1', command: 'npm run dev' },
+    JSON.stringify({ jobId: 'job-running', status: 'running', nextOffset: 420 }), false,
+  );
+  store.updateFromToolResult(
+    'chat-1', 'terminal_poll', { jobId: 'job-running', offset: 420 },
+    JSON.stringify({ error: 'temporary IPC timeout' }), true,
+  );
+
+  const job = store.get('chat-1').activeJobs['job-running'];
+  assert.equal(job.status, 'unverified');
+  assert.equal(job.nextOffset, 420);
+  assert.match(store.toReinjectionText('chat-1') ?? '', /job-running/);
+  assert.match(store.toReinjectionText('chat-1') ?? '', /do not restart/i);
+});
+
 test('SessionStateStore records the last terminal screen range read', () => {
   const store = new SessionStateStore();
   store.updateFromToolResult(

--- a/infrastructure/ai/harness/sessionState.test.ts
+++ b/infrastructure/ai/harness/sessionState.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { SessionStateStore } from './sessionState.ts';
+import { refreshRememberedTerminalJobs } from './turnDrivers/cattyTurnDriver.ts';
 
 test('SessionStateStore tracks terminal commands and reinjection text', () => {
   const store = new SessionStateStore();
@@ -30,4 +31,93 @@ test('SessionStateStore records tool errors as blockers', () => {
   );
   const text = store.toReinjectionText('chat-1');
   assert.ok(text?.includes('Open blockers'));
+});
+
+test('SessionStateStore restores active background jobs and poll cursors', () => {
+  const store = new SessionStateStore();
+  store.updateFromToolResult(
+    'chat-1',
+    'terminal_start',
+    { sessionId: 'sess-1', command: 'npm run dev' },
+    JSON.stringify({ ok: true, jobId: 'job-1', status: 'running', nextOffset: 0 }),
+  );
+  store.updateFromToolResult(
+    'chat-1',
+    'terminal_poll',
+    { jobId: 'job-1', offset: 0 },
+    JSON.stringify({ ok: true, jobId: 'job-1', status: 'running', nextOffset: 420 }),
+  );
+
+  const state = store.get('chat-1');
+  assert.equal(state.version, 1);
+  assert.equal(state.activeJobs['job-1'].nextOffset, 420);
+  const text = store.toReinjectionText('chat-1') ?? '';
+  assert.match(text, /job-1/);
+  assert.match(text, /offset=420/);
+  assert.match(text, /poll the existing job/i);
+  assert.match(text, /do not restart/i);
+  assert.match(text, /unverified after compaction/i);
+});
+
+test('SessionStateStore drops a remembered job after poll reports it missing', () => {
+  const store = new SessionStateStore();
+  store.updateFromToolResult(
+    'chat-1', 'terminal_start', { sessionId: 'sess-1', command: 'npm run dev' },
+    JSON.stringify({ jobId: 'job-lost', status: 'running' }), false,
+  );
+  store.updateFromToolResult(
+    'chat-1', 'terminal_poll', { jobId: 'job-lost', offset: 0 },
+    JSON.stringify({ error: 'Job not found' }), true,
+  );
+  assert.equal(store.get('chat-1').activeJobs['job-lost'], undefined);
+  assert.doesNotMatch(store.toReinjectionText('chat-1') ?? '', /Remembered terminal jobs/);
+});
+
+test('refreshRememberedTerminalJobs verifies saved offsets before compaction', async () => {
+  const store = new SessionStateStore();
+  store.updateFromToolResult(
+    'chat-1', 'terminal_start', { sessionId: 'sess-1', command: 'npm run dev' },
+    JSON.stringify({ jobId: 'job-live', status: 'running', nextOffset: 12 }), false,
+  );
+  const polls: Array<{ jobId: string; offset: number }> = [];
+  await refreshRememberedTerminalJobs({
+    chatSessionId: 'chat-1',
+    sessionStateStore: store,
+    poll: async (jobId, offset) => {
+      polls.push({ jobId, offset });
+      return { ok: true, jobId, status: 'running', nextOffset: 44, error: undefined };
+    },
+  });
+  assert.deepEqual(polls, [{ jobId: 'job-live', offset: 12 }]);
+  assert.equal(store.get('chat-1').activeJobs['job-live'].nextOffset, 12);
+});
+
+test('SessionStateStore records the last terminal screen range read', () => {
+  const store = new SessionStateStore();
+  store.updateFromToolResult(
+    'chat-1',
+    'terminal_read_context',
+    { sessionId: 'sess-1', range: 'tail', startLine: 80, maxLines: 20 },
+    JSON.stringify({ ok: true, sessionId: 'sess-1', startLine: 80, endLine: 99 }),
+  );
+
+  assert.deepEqual(store.get('chat-1').terminalReadCursors['sess-1'], {
+    range: 'tail',
+    startLine: 80,
+    endLine: 99,
+  });
+});
+
+test('SessionStateStore reinjects edited files and unfinished plan items', () => {
+  const store = new SessionStateStore();
+  store.mergeFileChanges('chat-1', ['/repo/src/a.ts', '/repo/src/b.ts']);
+  store.mergePlan('chat-1', [
+    { text: 'inspect failure', completed: true },
+    { text: 'run regression tests', completed: false },
+  ]);
+
+  const text = store.toReinjectionText('chat-1') ?? '';
+  assert.match(text, /\/repo\/src\/a\.ts/);
+  assert.match(text, /\[done\] inspect failure/);
+  assert.match(text, /\[todo\] run regression tests/);
 });

--- a/infrastructure/ai/harness/sessionState.test.ts
+++ b/infrastructure/ai/harness/sessionState.test.ts
@@ -90,6 +90,20 @@ test('SessionStateStore preserves a running job after a transient poll error', (
   assert.match(store.toReinjectionText('chat-1') ?? '', /do not restart/i);
 });
 
+test('SessionStateStore drops a job after poll confirms cancellation', () => {
+  const store = new SessionStateStore();
+  store.updateFromToolResult(
+    'chat-1', 'terminal_start', { sessionId: 'sess-1', command: 'npm run dev' },
+    JSON.stringify({ jobId: 'job-cancelled', status: 'running' }), false,
+  );
+  store.updateFromToolResult(
+    'chat-1', 'terminal_poll', { jobId: 'job-cancelled', offset: 0 },
+    JSON.stringify({ jobId: 'job-cancelled', status: 'cancelled', error: 'Cancelled' }), true,
+  );
+
+  assert.equal(store.get('chat-1').activeJobs['job-cancelled'], undefined);
+});
+
 test('SessionStateStore records the last terminal screen range read', () => {
   const store = new SessionStateStore();
   store.updateFromToolResult(

--- a/infrastructure/ai/harness/sessionState.test.ts
+++ b/infrastructure/ai/harness/sessionState.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { SessionStateStore } from './sessionState.ts';
-import { refreshRememberedTerminalJobs } from './turnDrivers/cattyTurnDriver.ts';
 
 test('SessionStateStore tracks terminal commands and reinjection text', () => {
   const store = new SessionStateStore();
@@ -71,25 +70,6 @@ test('SessionStateStore drops a remembered job after poll reports it missing', (
   );
   assert.equal(store.get('chat-1').activeJobs['job-lost'], undefined);
   assert.doesNotMatch(store.toReinjectionText('chat-1') ?? '', /Remembered terminal jobs/);
-});
-
-test('refreshRememberedTerminalJobs verifies saved offsets before compaction', async () => {
-  const store = new SessionStateStore();
-  store.updateFromToolResult(
-    'chat-1', 'terminal_start', { sessionId: 'sess-1', command: 'npm run dev' },
-    JSON.stringify({ jobId: 'job-live', status: 'running', nextOffset: 12 }), false,
-  );
-  const polls: Array<{ jobId: string; offset: number }> = [];
-  await refreshRememberedTerminalJobs({
-    chatSessionId: 'chat-1',
-    sessionStateStore: store,
-    poll: async (jobId, offset) => {
-      polls.push({ jobId, offset });
-      return { ok: true, jobId, status: 'running', nextOffset: 44, error: undefined };
-    },
-  });
-  assert.deepEqual(polls, [{ jobId: 'job-live', offset: 12 }]);
-  assert.equal(store.get('chat-1').activeJobs['job-live'].nextOffset, 12);
 });
 
 test('SessionStateStore records the last terminal screen range read', () => {

--- a/infrastructure/ai/harness/sessionState.ts
+++ b/infrastructure/ai/harness/sessionState.ts
@@ -60,7 +60,7 @@ function parseResultObject(resultText: string): Record<string, unknown> | undefi
 
 function terminalJobDefinitelyGone(result: Record<string, unknown> | undefined, resultText: string): boolean {
   const status = typeof result?.status === 'string' ? result.status.toLowerCase() : '';
-  if (['completed', 'failed', 'stopped', 'exited', 'not_found'].includes(status)) return true;
+  if (['completed', 'failed', 'stopped', 'exited', 'cancelled', 'canceled', 'not_found'].includes(status)) return true;
   const error = typeof result?.error === 'string' ? result.error : resultText;
   return /\b(?:job|task)\b.{0,40}\b(?:not found|does not exist|no longer exists|already (?:finished|completed|exited|stopped))\b/i.test(error)
     || /\b(?:unknown|no such)\s+(?:job|task)\b/i.test(error);

--- a/infrastructure/ai/harness/sessionState.ts
+++ b/infrastructure/ai/harness/sessionState.ts
@@ -58,6 +58,14 @@ function parseResultObject(resultText: string): Record<string, unknown> | undefi
   }
 }
 
+function terminalJobDefinitelyGone(result: Record<string, unknown> | undefined, resultText: string): boolean {
+  const status = typeof result?.status === 'string' ? result.status.toLowerCase() : '';
+  if (['completed', 'failed', 'stopped', 'exited', 'not_found'].includes(status)) return true;
+  const error = typeof result?.error === 'string' ? result.error : resultText;
+  return /\b(?:job|task)\b.{0,40}\b(?:not found|does not exist|no longer exists|already (?:finished|completed|exited|stopped))\b/i.test(error)
+    || /\b(?:unknown|no such)\s+(?:job|task)\b/i.test(error);
+}
+
 export class SessionStateStore {
   private readonly bySession = new Map<string, CattySessionState>();
 
@@ -179,8 +187,15 @@ export class SessionStateStore {
           delete state.activeJobs[jobId];
         }
       } else if (jobId && state.activeJobs[jobId]) {
-        state.activeJobs = { ...state.activeJobs };
-        delete state.activeJobs[jobId];
+        if (terminalJobDefinitelyGone(result, resultText)) {
+          state.activeJobs = { ...state.activeJobs };
+          delete state.activeJobs[jobId];
+        } else {
+          state.activeJobs = {
+            ...state.activeJobs,
+            [jobId]: { ...state.activeJobs[jobId], status: 'unverified' },
+          };
+        }
       }
     }
 

--- a/infrastructure/ai/harness/sessionState.ts
+++ b/infrastructure/ai/harness/sessionState.ts
@@ -1,18 +1,43 @@
+import { redactSecretsForModel } from './modelSecretRedaction';
+
 const MAX_DECISIONS = 15;
 const MAX_BLOCKERS = 10;
 
+export interface ActiveTerminalJobState {
+  sessionId?: string;
+  command?: string;
+  status: string;
+  nextOffset: number;
+}
+
+export interface TerminalReadCursorState {
+  range: string;
+  startLine?: number;
+  endLine?: number;
+}
+
 export interface CattySessionState {
+  version: 1;
   userGoal?: string;
   decisions: string[];
   activeHosts: Record<string, { hostname?: string; lastCommand?: string }>;
+  activeJobs: Record<string, ActiveTerminalJobState>;
+  terminalReadCursors: Record<string, TerminalReadCursorState>;
+  editedFiles: string[];
+  planItems: Array<{ text: string; completed: boolean }>;
   blockers: string[];
   updatedAt: number;
 }
 
 function emptyState(): CattySessionState {
   return {
+    version: 1,
     decisions: [],
     activeHosts: {},
+    activeJobs: {},
+    terminalReadCursors: {},
+    editedFiles: [],
+    planItems: [],
     blockers: [],
     updatedAt: Date.now(),
   };
@@ -22,6 +47,15 @@ function pushUnique(list: string[], value: string, cap: number): string[] {
   const trimmed = value.trim();
   if (!trimmed || list.includes(trimmed)) return list;
   return [...list, trimmed].slice(-cap);
+}
+
+function parseResultObject(resultText: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(resultText);
+    return parsed && typeof parsed === 'object' ? parsed as Record<string, unknown> : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export class SessionStateStore {
@@ -63,6 +97,26 @@ export class SessionStateStore {
     this.bySession.set(chatSessionId, state);
   }
 
+  mergeFileChanges(chatSessionId: string, paths: string[]): void {
+    const state = { ...this.get(chatSessionId) };
+    state.editedFiles = paths.reduce(
+      (files, path) => pushUnique(files, path, 50),
+      state.editedFiles,
+    );
+    state.updatedAt = Date.now();
+    this.bySession.set(chatSessionId, state);
+  }
+
+  mergePlan(chatSessionId: string, items: Array<{ text: string; completed: boolean }>): void {
+    const state = { ...this.get(chatSessionId) };
+    state.planItems = items.slice(-30).map(item => ({
+      text: item.text.slice(0, 300),
+      completed: item.completed,
+    }));
+    state.updatedAt = Date.now();
+    this.bySession.set(chatSessionId, state);
+  }
+
   updateFromToolResult(
     chatSessionId: string,
     toolName: string,
@@ -72,6 +126,7 @@ export class SessionStateStore {
   ): void {
     const state = { ...this.get(chatSessionId) };
     const name = toolName.toLowerCase();
+    const result = parseResultObject(resultText);
 
     if (name === 'terminal_execute' || name === 'terminal.execute') {
       const sessionId = typeof args?.sessionId === 'string' ? args.sessionId : undefined;
@@ -84,6 +139,89 @@ export class SessionStateStore {
             lastCommand: command,
           },
         };
+      }
+    }
+
+    if (name === 'terminal_start' || name === 'terminal.start') {
+      const jobId = typeof result?.jobId === 'string' ? result.jobId : undefined;
+      if (jobId && !isError) {
+        state.activeJobs = {
+          ...state.activeJobs,
+          [jobId]: {
+            sessionId: typeof args?.sessionId === 'string' ? args.sessionId : undefined,
+            command: typeof args?.command === 'string' ? args.command : undefined,
+            status: typeof result?.status === 'string' ? result.status : 'running',
+            nextOffset: typeof result?.nextOffset === 'number' ? result.nextOffset : 0,
+          },
+        };
+      }
+    }
+
+    if (name === 'terminal_poll' || name === 'terminal.poll') {
+      const jobId = typeof args?.jobId === 'string'
+        ? args.jobId
+        : typeof result?.jobId === 'string' ? result.jobId : undefined;
+      if (jobId && !isError) {
+        const status = typeof result?.status === 'string' ? result.status : 'running';
+        if (status === 'running' || status === 'stopping') {
+          state.activeJobs = {
+            ...state.activeJobs,
+            [jobId]: {
+              ...state.activeJobs[jobId],
+              status,
+              nextOffset: typeof result?.nextOffset === 'number'
+                ? result.nextOffset
+                : state.activeJobs[jobId]?.nextOffset ?? 0,
+            },
+          };
+        } else if (state.activeJobs[jobId]) {
+          state.activeJobs = { ...state.activeJobs };
+          delete state.activeJobs[jobId];
+        }
+      } else if (jobId && state.activeJobs[jobId]) {
+        state.activeJobs = { ...state.activeJobs };
+        delete state.activeJobs[jobId];
+      }
+    }
+
+    if (name === 'terminal_stop' || name === 'terminal.stop') {
+      const jobId = typeof args?.jobId === 'string' ? args.jobId : undefined;
+      if (jobId && state.activeJobs[jobId]) {
+        state.activeJobs = {
+          ...state.activeJobs,
+          [jobId]: { ...state.activeJobs[jobId], status: 'stopping' },
+        };
+      }
+    }
+
+    if (name === 'terminal_read_context' || name === 'terminal.read_context') {
+      const sessionId = typeof args?.sessionId === 'string'
+        ? args.sessionId
+        : typeof result?.sessionId === 'string' ? result.sessionId : undefined;
+      if (sessionId && !isError) {
+        state.terminalReadCursors = {
+          ...state.terminalReadCursors,
+          [sessionId]: {
+            range: typeof args?.range === 'string' ? args.range : 'viewport',
+            startLine: typeof result?.startLine === 'number'
+              ? result.startLine
+              : typeof args?.startLine === 'number' ? args.startLine : undefined,
+            endLine: typeof result?.endLine === 'number' ? result.endLine : undefined,
+          },
+        };
+      }
+    }
+
+    if ((name === 'session_close' || name === 'session.close') && !isError) {
+      const sessionId = typeof args?.sessionId === 'string' ? args.sessionId : undefined;
+      if (sessionId) {
+        state.activeHosts = { ...state.activeHosts };
+        state.terminalReadCursors = { ...state.terminalReadCursors };
+        delete state.activeHosts[sessionId];
+        delete state.terminalReadCursors[sessionId];
+        state.activeJobs = Object.fromEntries(
+          Object.entries(state.activeJobs).filter(([, job]) => job.sessionId !== sessionId),
+        );
       }
     }
 
@@ -109,9 +247,26 @@ export class SessionStateStore {
     if (hosts.length) {
       const hostSummary = hosts
         .slice(-5)
-        .map(([id, host]) => `${id}${host.lastCommand ? ` (last: ${host.lastCommand})` : ''}`)
+        .map(([id, host]) => `${id}${host.lastCommand ? ` (last: ${redactSecretsForModel(host.lastCommand)})` : ''}`)
         .join(', ');
       lines.push(`Active hosts: ${hostSummary}`);
+    }
+    const jobs = Object.entries(state.activeJobs);
+    if (jobs.length) {
+      const jobSummary = jobs.slice(-5).map(([jobId, job]) => (
+        `${jobId} (status=${job.status}, offset=${job.nextOffset}${job.sessionId ? `, session=${job.sessionId}` : ''}${job.command ? `, command=${redactSecretsForModel(job.command)}` : ''})`
+      )).join('; ');
+      lines.push(`Remembered terminal jobs (status is unverified after compaction): ${jobSummary}. Poll the existing job from its saved offset to verify current status; do not restart its command.`);
+    }
+    const cursors = Object.entries(state.terminalReadCursors);
+    if (cursors.length) {
+      lines.push(`Terminal read cursors: ${cursors.slice(-5).map(([id, cursor]) => `${id} (${cursor.range}, lines=${cursor.startLine ?? '?'}-${cursor.endLine ?? '?'})`).join(', ')}`);
+    }
+    if (state.editedFiles.length) {
+      lines.push(`Edited files: ${state.editedFiles.slice(-20).join(', ')}`);
+    }
+    if (state.planItems.length) {
+      lines.push(`Plan: ${state.planItems.map(item => `${item.completed ? '[done]' : '[todo]'} ${item.text}`).join('; ')}`);
     }
     if (state.blockers.length) {
       lines.push(`Open blockers: ${state.blockers.slice(-3).join('; ')}`);

--- a/infrastructure/ai/harness/staleContextPruner.test.ts
+++ b/infrastructure/ai/harness/staleContextPruner.test.ts
@@ -424,6 +424,35 @@ test('pruneStaleToolContext tiers generic old tool results while protecting rece
   assert.match(serialized, /tail-11/);
 });
 
+test('pruneStaleToolContext retains old successful write outcomes', () => {
+  const messages: ModelMessage[] = [
+    {
+      role: 'assistant',
+      content: [{
+        type: 'tool-call',
+        toolCallId: 'write-1',
+        toolName: 'sftp_write',
+        input: { sessionId: 'sess-1', path: '/etc/app.conf', content: 'enabled=true' },
+      }],
+    },
+    {
+      role: 'tool',
+      content: [{
+        type: 'tool-result',
+        toolCallId: 'write-1',
+        toolName: 'sftp_write',
+        output: { type: 'text', value: 'write succeeded: /etc/app.conf' },
+      }],
+    },
+    ...Array.from({ length: 11 }, (_, index) => ({ role: 'user' as const, content: `later ${index}` })),
+  ];
+
+  const result = pruneStaleToolContext(messages, { underBudgetPressure: true });
+  const serialized = JSON.stringify(result.messages);
+  assert.match(serialized, /write succeeded: \/etc\/app\.conf/);
+  assert.doesNotMatch(serialized, /older tool result omitted/);
+});
+
 test('pruneStaleToolContext redacts commands in old terminal placeholders', () => {
   const messages: ModelMessage[] = [
     ...terminalExecutePair('t1', 'sess-1', 'curl --password swordfish', 'old-output'),

--- a/infrastructure/ai/harness/staleContextPruner.test.ts
+++ b/infrastructure/ai/harness/staleContextPruner.test.ts
@@ -145,6 +145,37 @@ test('pruneStaleToolContext keeps sftp reads for same path on different sessions
   assert.doesNotMatch(serialized, /superseded read/);
 });
 
+test('pruneStaleToolContext supersedes repeated terminal polls and context reads', () => {
+  const pair = (callId: string, toolName: string, input: Record<string, unknown>, output: string): ModelMessage[] => [
+    {
+      role: 'assistant',
+      content: [{ type: 'tool-call', toolCallId: callId, toolName, input }],
+    },
+    {
+      role: 'tool',
+      content: [{
+        type: 'tool-result',
+        toolCallId: callId,
+        toolName,
+        output: { type: 'text', value: output },
+      }],
+    },
+  ];
+  const messages: ModelMessage[] = [
+    ...pair('p1', 'terminal_poll', { jobId: 'job-1', offset: 0 }, 'old poll'),
+    ...pair('p2', 'terminal_poll', { jobId: 'job-1', offset: 0 }, 'new poll'),
+    ...pair('r1', 'terminal_read_context', { sessionId: 's1', range: 'tail', maxLines: 20 }, 'old screen'),
+    ...pair('r2', 'terminal_read_context', { sessionId: 's1', range: 'tail', maxLines: 20 }, 'new screen'),
+  ];
+
+  const result = pruneStaleToolContext(messages, { underBudgetPressure: true });
+  const serialized = JSON.stringify(result.messages);
+  assert.equal(result.didAdjust, true);
+  assert.doesNotMatch(serialized, /old poll|old screen/);
+  assert.match(serialized, /new poll/);
+  assert.match(serialized, /new screen/);
+});
+
 function terminalExecutePair(
   callId: string,
   sessionId: string,
@@ -361,4 +392,46 @@ test('pruneStaleToolContext preserves terminal output without budget pressure fl
   assert.match(serialized, /uptime-1/);
   assert.match(serialized, /df-2/);
   assert.match(serialized, /free-3/);
+});
+
+test('pruneStaleToolContext tiers generic old tool results while protecting recent turns', () => {
+  const messages: ModelMessage[] = [];
+  for (let turn = 0; turn < 12; turn += 1) {
+    const callId = `call-${turn}`;
+    messages.push(
+      { role: 'user', content: `turn ${turn}` },
+      {
+        role: 'assistant',
+        content: [{ type: 'tool-call', toolCallId: callId, toolName: 'custom_read', input: { turn } }],
+      },
+      {
+        role: 'tool',
+        content: [{
+          type: 'tool-result',
+          toolCallId: callId,
+          toolName: 'custom_read',
+          output: { type: 'text', value: `result-${turn}-${'x'.repeat(5_000)}-tail-${turn}` },
+        }],
+      },
+    );
+  }
+
+  const result = pruneStaleToolContext(messages, { underBudgetPressure: true });
+  const serialized = JSON.stringify(result.messages);
+  assert.match(serialized, /older tool result omitted/);
+  assert.match(serialized, /tool result shortened/);
+  assert.match(serialized, /result-11-/);
+  assert.match(serialized, /tail-11/);
+});
+
+test('pruneStaleToolContext redacts commands in old terminal placeholders', () => {
+  const messages: ModelMessage[] = [
+    ...terminalExecutePair('t1', 'sess-1', 'curl --password swordfish', 'old-output'),
+    ...terminalExecutePair('t2', 'sess-1', 'uptime', 'newer-output'),
+    ...terminalExecutePair('t3', 'sess-1', 'df -h', 'latest-output'),
+  ];
+  const result = pruneStaleToolContext(messages, { underBudgetPressure: true });
+  const serialized = JSON.stringify(result.messages);
+  assert.doesNotMatch(serialized, /swordfish/);
+  assert.match(serialized, /REDACTED/);
 });

--- a/infrastructure/ai/harness/staleContextPruner.ts
+++ b/infrastructure/ai/harness/staleContextPruner.ts
@@ -1,4 +1,5 @@
 import type { ModelMessage } from 'ai';
+import { redactSecretsForModel, redactSecretsInValueForModel } from './modelSecretRedaction';
 
 const SUPERSEDED_READ_PREFIX = '[superseded read:';
 const EARLIER_TERMINAL_PREFIX = '[earlier terminal output omitted:';
@@ -11,7 +12,7 @@ function getToolCallMap(messages: ModelMessage[]): Map<string, { toolName: strin
   const map = new Map<string, { toolName: string; input: unknown }>();
   for (const message of messages) {
     if (message.role !== 'assistant' || !Array.isArray(message.content)) continue;
-    for (const part of message.content) {
+    for (const part of message.content as unknown[]) {
       if (!isRecord(part) || part.type !== 'tool-call') continue;
       const toolCallId = typeof part.toolCallId === 'string' ? part.toolCallId : '';
       const toolName = typeof part.toolName === 'string' ? part.toolName : '';
@@ -25,7 +26,7 @@ function getToolCallMap(messages: ModelMessage[]): Map<string, { toolName: strin
 
 function getToolResultParts(message: ModelMessage): Array<Record<string, unknown>> {
   if (message.role !== 'tool' || !Array.isArray(message.content)) return [];
-  return message.content.filter((part) => {
+  return (message.content as unknown[]).filter((part) => {
     return isRecord(part) && part.type === 'tool-result';
   }) as Array<Record<string, unknown>>;
 }
@@ -81,6 +82,22 @@ function isSftpReadTool(toolName: string): boolean {
 
 function readFingerprint(toolName: string, args: unknown): string | null {
   if (!isRecord(args)) return null;
+  if (toolName === 'terminal_poll' || toolName === 'terminal.poll') {
+    const jobId = args.jobId;
+    if (typeof jobId !== 'string') return null;
+    return `terminal-poll:${jobId}:${String(args.offset ?? 0)}`;
+  }
+  if (toolName === 'terminal_read_context' || toolName === 'terminal.read_context') {
+    const sessionId = args.sessionId;
+    if (typeof sessionId !== 'string') return null;
+    return [
+      'terminal-context',
+      sessionId,
+      String(args.range ?? 'viewport'),
+      String(args.startLine ?? ''),
+      String(args.maxLines ?? ''),
+    ].join(':');
+  }
   if (isSftpReadTool(toolName)) {
     const path = args.path ?? args.remotePath;
     if (typeof path !== 'string') return null;
@@ -110,6 +127,19 @@ function replaceToolResultText(part: Record<string, unknown>, text: string): Rec
   return { ...part, output: { type: 'text', value: text } };
 }
 
+function redactToolCallInputs(message: ModelMessage): ModelMessage {
+  if (message.role !== 'assistant' || !Array.isArray(message.content)) return message;
+  let changed = false;
+  const content = (message.content as unknown[]).map(part => {
+    if (!isRecord(part) || part.type !== 'tool-call' || !('input' in part)) return part;
+    const redacted = redactSecretsInValueForModel(part.input);
+    if (JSON.stringify(redacted) === JSON.stringify(part.input)) return part;
+    changed = true;
+    return { ...part, input: redacted };
+  });
+  return changed ? ({ ...message, content } as ModelMessage) : message;
+}
+
 function compressMessageToolResults(
   message: ModelMessage,
   updater: (toolName: string, args: unknown, text: string, isError: boolean) => string | null,
@@ -134,7 +164,7 @@ function compressMessageToolResults(
     return replaceToolResultText(part, replacement);
   });
 
-  return changed ? { ...message, content: nextContent as ModelMessage['content'] } : message;
+  return changed ? ({ ...message, content: nextContent } as ModelMessage) : message;
 }
 
 export interface PruneStaleToolContextOptions {
@@ -153,6 +183,12 @@ export function pruneStaleToolContext(
   const latestReadByKey = new Map<string, number>();
   const terminalExecutionsBySession = new Map<string, Array<{ index: number; command?: string }>>();
   const underBudgetPressure = options.underBudgetPressure === true;
+  const userTurnsAfter = new Array<number>(messages.length).fill(0);
+  let laterUserTurns = 0;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    userTurnsAfter[index] = laterUserTurns;
+    if (messages[index].role === 'user') laterUserTurns += 1;
+  }
 
   messages.forEach((message, index) => {
     for (const part of getToolResultParts(message)) {
@@ -196,7 +232,7 @@ export function pruneStaleToolContext(
         if (keepTerminalIndices.has(entry.index)) continue;
         terminalOmitByIndex.set(
           entry.index,
-          `${EARLIER_TERMINAL_PREFIX} command=${entry.command ?? 'unknown'}]`,
+          `${EARLIER_TERMINAL_PREFIX} command=${redactSecretsForModel(entry.command ?? 'unknown')}]`,
         );
       }
     }
@@ -204,7 +240,8 @@ export function pruneStaleToolContext(
 
   let didAdjust = false;
   const next = messages.map((message, index) => {
-    const updated = compressMessageToolResults(message, (toolName, args, text, isError) => {
+    const redactedMessage = redactToolCallInputs(message);
+    const updated = compressMessageToolResults(redactedMessage, (toolName, args, text, isError) => {
       if (isError) return null;
       const readKey = readFingerprint(toolName, args);
       if (underBudgetPressure && readKey) {
@@ -216,6 +253,15 @@ export function pruneStaleToolContext(
       const termKey = terminalFingerprint(toolName, args);
       if (underBudgetPressure && termKey && terminalOmitByIndex.has(index)) {
         return terminalOmitByIndex.get(index)!;
+      }
+      if (underBudgetPressure) {
+        const age = userTurnsAfter[index];
+        if (age > 10 && !isError) {
+          return `[older tool result omitted: tool=${toolName || 'unknown'}, chars=${text.length}]`;
+        }
+        if (age >= 3 && text.length > 4_000) {
+          return `${text.slice(0, 1_500)}\n\n[... tool result shortened: ${text.length - 3_000} chars omitted ...]\n\n${text.slice(-1_500)}`;
+        }
       }
       return null;
     }, toolCallMap);

--- a/infrastructure/ai/harness/staleContextPruner.ts
+++ b/infrastructure/ai/harness/staleContextPruner.ts
@@ -80,6 +80,17 @@ function isSftpReadTool(toolName: string): boolean {
     || toolName === 'sftp_read_file';
 }
 
+function isSafeReadOnlyToolName(toolName: string): boolean {
+  const segments = toolName.toLowerCase().split(/[._-]+/);
+  const readMarkers = new Set(['read', 'get', 'list', 'search', 'fetch', 'inspect', 'status', 'info', 'poll']);
+  const writeMarkers = new Set([
+    'write', 'set', 'update', 'create', 'delete', 'remove', 'start', 'stop', 'close',
+    'execute', 'exec', 'run', 'upload', 'download', 'move', 'copy', 'rename', 'kill',
+  ]);
+  return segments.some(segment => readMarkers.has(segment))
+    && !segments.some(segment => writeMarkers.has(segment));
+}
+
 function readFingerprint(toolName: string, args: unknown): string | null {
   if (!isRecord(args)) return null;
   if (toolName === 'terminal_poll' || toolName === 'terminal.poll') {
@@ -256,7 +267,7 @@ export function pruneStaleToolContext(
       }
       if (underBudgetPressure) {
         const age = userTurnsAfter[index];
-        if (age > 10 && !isError) {
+        if (age > 10 && !isError && isSafeReadOnlyToolName(toolName)) {
           return `[older tool result omitted: tool=${toolName || 'unknown'}, chars=${text.length}]`;
         }
         if (age >= 3 && text.length > 4_000) {

--- a/infrastructure/ai/harness/terminalCompression.ts
+++ b/infrastructure/ai/harness/terminalCompression.ts
@@ -1,5 +1,6 @@
 import { compressVerboseText, truncateTextWithHeadAndTail } from '../requestPayloadCompression';
 import type { ToolOutputStore } from './toolOutputStore';
+import { redactSecretsForModel } from './modelSecretRedaction';
 
 export const MAX_LIVE_TERMINAL_STDOUT_CHARS = 24_000;
 export const MAX_LIVE_TERMINAL_STDERR_CHARS = 12_000;
@@ -31,16 +32,17 @@ export function fitTerminalExecuteResultForModel(
   options?: FitTerminalExecuteResultOptions,
 ): TerminalExecuteResult {
   const stdout = truncateTextWithHeadAndTail(
-    compressVerboseText(result.stdout),
+    redactSecretsForModel(compressVerboseText(result.stdout)),
     MAX_LIVE_TERMINAL_STDOUT_CHARS,
   );
   const stderr = truncateTextWithHeadAndTail(
-    compressVerboseText(result.stderr),
+    redactSecretsForModel(compressVerboseText(result.stderr)),
     MAX_LIVE_TERMINAL_STDERR_CHARS,
   );
 
   const fitted: TerminalExecuteResult = {
     ...result,
+    command: result.command ? redactSecretsForModel(result.command) : result.command,
     stdout,
     stderr,
   };
@@ -68,7 +70,7 @@ export function fitTerminalExecuteResultForModel(
     const handle: TerminalOutputHandle = {
       kind: 'terminal-output',
       sessionId: result.sessionId ?? 'unknown',
-      command: result.command,
+      command: result.command ? redactSecretsForModel(result.command) : result.command,
       totalStdoutChars: result.stdout.length,
       totalStderrChars: result.stderr.length,
       handleId,

--- a/infrastructure/ai/harness/terminalMonitorGuard.test.ts
+++ b/infrastructure/ai/harness/terminalMonitorGuard.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { TerminalMonitorGuard } from './terminalMonitorGuard';
+import { applyMonitorStopResult } from './capabilityTools';
+
+test('TerminalMonitorGuard bounds lines and batches', () => {
+  const guard = new TerminalMonitorGuard();
+  const result = guard.process('chat:job', `${'x'.repeat(800)}\n${'line\n'.repeat(1_000)}`);
+
+  assert.equal(result.action, 'deliver');
+  assert.ok((result.content?.length ?? Infinity) <= 3_000);
+  assert.ok((result.content?.split('\n')[0].length ?? Infinity) <= 500);
+});
+
+test('TerminalMonitorGuard suppresses bursts and stops a sustained overload', () => {
+  let now = 0;
+  const guard = new TerminalMonitorGuard({ now: () => now });
+  for (let index = 0; index < 10; index += 1) {
+    assert.equal(guard.process('chat:job', `line ${index}`).action, 'deliver');
+  }
+  assert.equal(guard.process('chat:job', 'burst').action, 'suppress');
+  let action = guard.process('chat:job', 'still flooding').action;
+  for (now = 1_000; now <= 31_000 && action !== 'stop'; now += 1_000) {
+    action = guard.process('chat:job', 'still flooding').action;
+  }
+  assert.equal(action, 'stop');
+});
+
+test('monitor stop result does not claim success when the backend stop failed', () => {
+  const failed = applyMonitorStopResult(
+    { jobId: 'job-1', status: 'running' },
+    { ok: false, error: 'lost worker' },
+    12,
+  );
+  assert.equal(failed.status, 'running');
+  assert.match(String(failed.output), /stop failed/);
+  assert.match(String(failed.output), /may still be running/);
+
+  const accepted = applyMonitorStopResult(
+    { jobId: 'job-1', status: 'running' },
+    { ok: true },
+    12,
+  );
+  assert.equal(accepted.status, 'stopping');
+  assert.match(String(accepted.output), /stop requested/);
+});

--- a/infrastructure/ai/harness/terminalMonitorGuard.test.ts
+++ b/infrastructure/ai/harness/terminalMonitorGuard.test.ts
@@ -56,3 +56,14 @@ test('isStreamingMonitorCommand requires an actual follow option', () => {
   assert.equal(isStreamingMonitorCommand('kubectl logs --follow pod/api'), true);
   assert.equal(isStreamingMonitorCommand('cd /srv && watch npm test'), true);
 });
+
+test('isStreamingMonitorCommand recognizes common wrappers and compose logs', () => {
+  assert.equal(isStreamingMonitorCommand('sudo journalctl -f -u nginx'), true);
+  assert.equal(isStreamingMonitorCommand('sudo -u root tail -f /var/log/syslog'), true);
+  assert.equal(isStreamingMonitorCommand('env LANG=C tail --follow app.log'), true);
+  assert.equal(isStreamingMonitorCommand('stdbuf -oL kubectl logs -f pod/api'), true);
+  assert.equal(isStreamingMonitorCommand('timeout 60s tail -f app.log'), true);
+  assert.equal(isStreamingMonitorCommand('docker compose logs -f api'), true);
+  assert.equal(isStreamingMonitorCommand('sudo tail -n 10 app.log'), false);
+  assert.equal(isStreamingMonitorCommand('timeout 60s journalctl --since 5m'), false);
+});

--- a/infrastructure/ai/harness/terminalMonitorGuard.test.ts
+++ b/infrastructure/ai/harness/terminalMonitorGuard.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { TerminalMonitorGuard } from './terminalMonitorGuard';
+import { isStreamingMonitorCommand, TerminalMonitorGuard } from './terminalMonitorGuard';
 import { applyMonitorStopResult } from './capabilityTools';
 
 test('TerminalMonitorGuard bounds lines and batches', () => {
@@ -43,4 +43,16 @@ test('monitor stop result does not claim success when the backend stop failed', 
   );
   assert.equal(accepted.status, 'stopping');
   assert.match(String(accepted.output), /stop requested/);
+});
+
+test('isStreamingMonitorCommand requires an actual follow option', () => {
+  assert.equal(isStreamingMonitorCommand('tail app-file.log'), false);
+  assert.equal(isStreamingMonitorCommand('tail -n 10 foo.log'), false);
+  assert.equal(isStreamingMonitorCommand('journalctl --since 5m foo'), false);
+  assert.equal(isStreamingMonitorCommand('tail -f app.log'), true);
+  assert.equal(isStreamingMonitorCommand('tail -n0F app.log'), true);
+  assert.equal(isStreamingMonitorCommand('journalctl --follow -u nginx'), true);
+  assert.equal(isStreamingMonitorCommand('docker logs -f api'), true);
+  assert.equal(isStreamingMonitorCommand('kubectl logs --follow pod/api'), true);
+  assert.equal(isStreamingMonitorCommand('cd /srv && watch npm test'), true);
 });

--- a/infrastructure/ai/harness/terminalMonitorGuard.test.ts
+++ b/infrastructure/ai/harness/terminalMonitorGuard.test.ts
@@ -64,6 +64,12 @@ test('isStreamingMonitorCommand recognizes common wrappers and compose logs', ()
   assert.equal(isStreamingMonitorCommand('stdbuf -oL kubectl logs -f pod/api'), true);
   assert.equal(isStreamingMonitorCommand('timeout 60s tail -f app.log'), true);
   assert.equal(isStreamingMonitorCommand('docker compose logs -f api'), true);
+  assert.equal(isStreamingMonitorCommand('sudo -H journalctl -f -u nginx'), true);
+  assert.equal(isStreamingMonitorCommand('kubectl -n production logs -f pod/api'), true);
+  assert.equal(isStreamingMonitorCommand('kubectl --context prod logs --follow pod/api'), true);
+  assert.equal(isStreamingMonitorCommand('docker --context prod logs -f api'), true);
+  assert.equal(isStreamingMonitorCommand('docker compose -f compose.prod.yml logs -f api'), true);
+  assert.equal(isStreamingMonitorCommand('docker compose -p demo logs -f api'), true);
   assert.equal(isStreamingMonitorCommand('sudo tail -n 10 app.log'), false);
   assert.equal(isStreamingMonitorCommand('timeout 60s journalctl --since 5m'), false);
 });

--- a/infrastructure/ai/harness/terminalMonitorGuard.ts
+++ b/infrastructure/ai/harness/terminalMonitorGuard.ts
@@ -1,0 +1,100 @@
+import { compressVerboseText } from '../requestPayloadCompression';
+
+const MONITOR_LINE_MAX_CHARS = 500;
+const MONITOR_BATCH_MAX_CHARS = 3_000;
+const MONITOR_BURST = 10;
+const MONITOR_REFILL_MS = 2_000;
+const MONITOR_OVERLOAD_STOP_MS = 30_000;
+
+interface MonitorState {
+  tokens: number;
+  lastRefillAt: number;
+  overloadedAt?: number;
+  lastSuppressedAt?: number;
+  suppressedCount: number;
+}
+
+export type MonitorGuardResult =
+  | { action: 'deliver'; content: string; suppressedCount: number }
+  | { action: 'suppress'; suppressedCount: number }
+  | { action: 'stop'; suppressedCount: number };
+
+export class TerminalMonitorGuard {
+  private readonly states = new Map<string, MonitorState>();
+  private readonly now: () => number;
+
+  constructor(options: { now?: () => number } = {}) {
+    this.now = options.now ?? Date.now;
+  }
+
+  process(key: string, output: string): MonitorGuardResult {
+    const now = this.now();
+    const state = this.states.get(key) ?? {
+      tokens: MONITOR_BURST,
+      lastRefillAt: now,
+      suppressedCount: 0,
+    };
+    if (state.lastSuppressedAt != null && now - state.lastSuppressedAt > MONITOR_REFILL_MS * 2) {
+      state.overloadedAt = undefined;
+      state.lastSuppressedAt = undefined;
+      state.suppressedCount = 0;
+    }
+    if (state.overloadedAt != null && now - state.overloadedAt >= MONITOR_OVERLOAD_STOP_MS) {
+      this.states.delete(key);
+      return { action: 'stop', suppressedCount: state.suppressedCount + 1 };
+    }
+
+    const refill = Math.floor((now - state.lastRefillAt) / MONITOR_REFILL_MS);
+    if (refill > 0) {
+      state.tokens = Math.min(MONITOR_BURST, state.tokens + refill);
+      state.lastRefillAt += refill * MONITOR_REFILL_MS;
+    }
+    if (state.tokens <= 0) {
+      state.suppressedCount += 1;
+      state.overloadedAt ??= now;
+      state.lastSuppressedAt = now;
+      this.states.set(key, state);
+      return { action: 'suppress', suppressedCount: state.suppressedCount };
+    }
+
+    state.tokens -= 1;
+    const suppressedCount = state.suppressedCount;
+    state.suppressedCount = 0;
+    this.states.set(key, state);
+    const prefix = suppressedCount > 0 ? `[${suppressedCount} monitor batches suppressed]\n` : '';
+    return {
+      action: 'deliver',
+      content: fitMonitorBatch(`${prefix}${output}`),
+      suppressedCount,
+    };
+  }
+
+  clear(key: string): void {
+    this.states.delete(key);
+  }
+
+  clearPrefix(prefix: string): void {
+    for (const key of this.states.keys()) {
+      if (key.startsWith(prefix)) this.states.delete(key);
+    }
+  }
+}
+
+export function isStreamingMonitorCommand(command: unknown): boolean {
+  if (typeof command !== 'string') return false;
+  return /(?:^|[;&|]\s*)(?:tail\s+[^\n]*-[^\n]*f|watch\s+|journalctl\s+[^\n]*-[^\n]*f|docker\s+logs\s+[^\n]*-[^\n]*f|kubectl\s+logs\s+[^\n]*-[^\n]*f)/i.test(command.trim());
+}
+
+function fitMonitorBatch(output: string): string {
+  const normalized = compressVerboseText(output);
+  const lines = normalized.split('\n').map(line => {
+    if (line.length <= MONITOR_LINE_MAX_CHARS) return line;
+    return `${line.slice(0, MONITOR_LINE_MAX_CHARS - 28)}[... line shortened ...]`;
+  });
+  const content = lines.join('\n');
+  if (content.length <= MONITOR_BATCH_MAX_CHARS) return content;
+  const marker = '\n[... monitor batch shortened ...]';
+  return `${content.slice(0, MONITOR_BATCH_MAX_CHARS - marker.length)}${marker}`;
+}
+
+export const globalTerminalMonitorGuard = new TerminalMonitorGuard();

--- a/infrastructure/ai/harness/terminalMonitorGuard.ts
+++ b/infrastructure/ai/harness/terminalMonitorGuard.ts
@@ -82,7 +82,14 @@ export class TerminalMonitorGuard {
 
 export function isStreamingMonitorCommand(command: unknown): boolean {
   if (typeof command !== 'string') return false;
-  return /(?:^|[;&|]\s*)(?:tail\s+[^\n]*-[^\n]*f|watch\s+|journalctl\s+[^\n]*-[^\n]*f|docker\s+logs\s+[^\n]*-[^\n]*f|kubectl\s+logs\s+[^\n]*-[^\n]*f)/i.test(command.trim());
+  return command.split(/[;&|]+/).some((rawSegment) => {
+    const segment = rawSegment.trim();
+    if (/^watch(?:\s|$)/i.test(segment)) return true;
+    const match = segment.match(/^(?:tail|journalctl|(?:docker|kubectl)\s+logs)(?:\s+(.*))?$/i);
+    if (!match) return false;
+    const args = match[1] ?? '';
+    return /(?:^|\s)(?:--follow(?:=[^\s]+)?|-[^-\s]*[fF][^\s]*)(?=\s|$)/.test(args);
+  });
 }
 
 function fitMonitorBatch(output: string): string {

--- a/infrastructure/ai/harness/terminalMonitorGuard.ts
+++ b/infrastructure/ai/harness/terminalMonitorGuard.ts
@@ -87,19 +87,50 @@ export function isStreamingMonitorCommand(command: unknown): boolean {
     if (tokens.length === 0) return false;
     if (tokens[0]?.toLowerCase() === 'watch') return true;
 
-    const commandTokens = tokens.map(token => token.toLowerCase());
-    const argsStart = commandTokens[0] === 'tail' || commandTokens[0] === 'journalctl'
-      ? 1
-      : commandTokens[0] === 'docker' && commandTokens[1] === 'logs'
-        ? 2
-        : commandTokens[0] === 'docker' && commandTokens[1] === 'compose' && commandTokens[2] === 'logs'
-          ? 3
-          : commandTokens[0] === 'kubectl' && commandTokens[1] === 'logs'
-            ? 2
-            : -1;
+    const argsStart = findMonitorArgsStart(tokens);
     if (argsStart < 0) return false;
     return tokens.slice(argsStart).some(arg => /^--follow(?:=.+)?$/i.test(arg) || /^-[^-\s]*[fF]/.test(arg));
   });
+}
+
+function findMonitorArgsStart(tokens: string[]): number {
+  const command = tokens[0]?.toLowerCase();
+  if (command === 'tail' || command === 'journalctl') return 1;
+  if (command === 'kubectl') {
+    const logsIndex = skipCommandOptions(tokens, 1, new Set([
+      '-n', '--namespace', '--context', '--kubeconfig', '--cluster', '--user',
+      '--request-timeout', '-s', '--server', '--token', '--as', '--as-group',
+      '--cache-dir', '--certificate-authority', '--client-certificate', '--client-key',
+      '--tls-server-name',
+    ]));
+    return tokens[logsIndex]?.toLowerCase() === 'logs' ? logsIndex + 1 : -1;
+  }
+  if (command === 'docker') {
+    const subcommandIndex = skipCommandOptions(tokens, 1, new Set([
+      '--config', '-c', '--context', '-H', '--host', '-l', '--log-level',
+    ]));
+    const subcommand = tokens[subcommandIndex]?.toLowerCase();
+    if (subcommand === 'logs') return subcommandIndex + 1;
+    if (subcommand !== 'compose') return -1;
+    const logsIndex = skipCommandOptions(tokens, subcommandIndex + 1, new Set([
+      '-f', '--file', '-p', '--project-name', '--profile', '--project-directory',
+      '--env-file', '--parallel', '--progress', '--ansi',
+    ]));
+    return tokens[logsIndex]?.toLowerCase() === 'logs' ? logsIndex + 1 : -1;
+  }
+  return -1;
+}
+
+function skipCommandOptions(tokens: string[], start: number, optionsWithValues: ReadonlySet<string>): number {
+  let index = start;
+  while (tokens[index]?.startsWith('-')) {
+    const option = tokens[index]!;
+    index += 1;
+    if (option === '--') break;
+    const optionName = canonicalOptionName(option);
+    if (optionsWithValues.has(optionName) && !option.includes('=') && index < tokens.length) index += 1;
+  }
+  return index;
 }
 
 function tokenizeCommandSegment(segment: string): string[] {
@@ -114,14 +145,14 @@ function unwrapMonitorCommandPrefixes(input: string[]): string[] {
       tokens.shift();
       consumeWrapperOptions(tokens, new Set([
         '-u', '--user', '-g', '--group', '-h', '--host', '-p', '--prompt',
-        '-c', '--close-from', '-r', '--chroot', '-d', '--chdir', '-t', '--command-timeout',
+        '-C', '--close-from', '-R', '--chroot', '-D', '--chdir', '-T', '--command-timeout',
         '-r', '--role', '-t', '--type',
       ]));
       continue;
     }
     if (wrapper === 'env') {
       tokens.shift();
-      consumeWrapperOptions(tokens, new Set(['-u', '--unset', '-c', '--chdir', '-s', '--split-string']));
+      consumeWrapperOptions(tokens, new Set(['-u', '--unset', '-C', '--chdir', '-S', '--split-string']));
       while (tokens[0] && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0])) tokens.shift();
       continue;
     }
@@ -145,9 +176,14 @@ function consumeWrapperOptions(tokens: string[], optionsWithValues: ReadonlySet<
   while (tokens[0]?.startsWith('-')) {
     const option = tokens.shift()!;
     if (option === '--') break;
-    const optionName = option.split('=', 1)[0]!.toLowerCase();
+    const optionName = canonicalOptionName(option);
     if (optionsWithValues.has(optionName) && !option.includes('=') && tokens.length > 0) tokens.shift();
   }
+}
+
+function canonicalOptionName(option: string): string {
+  const optionName = option.split('=', 1)[0]!;
+  return optionName.startsWith('--') ? optionName.toLowerCase() : optionName;
 }
 
 function fitMonitorBatch(output: string): string {

--- a/infrastructure/ai/harness/terminalMonitorGuard.ts
+++ b/infrastructure/ai/harness/terminalMonitorGuard.ts
@@ -83,13 +83,71 @@ export class TerminalMonitorGuard {
 export function isStreamingMonitorCommand(command: unknown): boolean {
   if (typeof command !== 'string') return false;
   return command.split(/[;&|]+/).some((rawSegment) => {
-    const segment = rawSegment.trim();
-    if (/^watch(?:\s|$)/i.test(segment)) return true;
-    const match = segment.match(/^(?:tail|journalctl|(?:docker|kubectl)\s+logs)(?:\s+(.*))?$/i);
-    if (!match) return false;
-    const args = match[1] ?? '';
-    return /(?:^|\s)(?:--follow(?:=[^\s]+)?|-[^-\s]*[fF][^\s]*)(?=\s|$)/.test(args);
+    const tokens = unwrapMonitorCommandPrefixes(tokenizeCommandSegment(rawSegment));
+    if (tokens.length === 0) return false;
+    if (tokens[0]?.toLowerCase() === 'watch') return true;
+
+    const commandTokens = tokens.map(token => token.toLowerCase());
+    const argsStart = commandTokens[0] === 'tail' || commandTokens[0] === 'journalctl'
+      ? 1
+      : commandTokens[0] === 'docker' && commandTokens[1] === 'logs'
+        ? 2
+        : commandTokens[0] === 'docker' && commandTokens[1] === 'compose' && commandTokens[2] === 'logs'
+          ? 3
+          : commandTokens[0] === 'kubectl' && commandTokens[1] === 'logs'
+            ? 2
+            : -1;
+    if (argsStart < 0) return false;
+    return tokens.slice(argsStart).some(arg => /^--follow(?:=.+)?$/i.test(arg) || /^-[^-\s]*[fF]/.test(arg));
   });
+}
+
+function tokenizeCommandSegment(segment: string): string[] {
+  return segment.trim().match(/(?:[^\s"'\\]+|"(?:\\.|[^"])*"|'[^']*')+/g) ?? [];
+}
+
+function unwrapMonitorCommandPrefixes(input: string[]): string[] {
+  const tokens = [...input];
+  for (let pass = 0; pass < 8 && tokens.length > 0; pass += 1) {
+    const wrapper = tokens[0]?.toLowerCase();
+    if (wrapper === 'sudo') {
+      tokens.shift();
+      consumeWrapperOptions(tokens, new Set([
+        '-u', '--user', '-g', '--group', '-h', '--host', '-p', '--prompt',
+        '-c', '--close-from', '-r', '--chroot', '-d', '--chdir', '-t', '--command-timeout',
+        '-r', '--role', '-t', '--type',
+      ]));
+      continue;
+    }
+    if (wrapper === 'env') {
+      tokens.shift();
+      consumeWrapperOptions(tokens, new Set(['-u', '--unset', '-c', '--chdir', '-s', '--split-string']));
+      while (tokens[0] && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0])) tokens.shift();
+      continue;
+    }
+    if (wrapper === 'stdbuf') {
+      tokens.shift();
+      consumeWrapperOptions(tokens, new Set(['-i', '--input', '-o', '--output', '-e', '--error']));
+      continue;
+    }
+    if (wrapper === 'timeout') {
+      tokens.shift();
+      consumeWrapperOptions(tokens, new Set(['-k', '--kill-after', '-s', '--signal']));
+      if (tokens.length > 0) tokens.shift();
+      continue;
+    }
+    break;
+  }
+  return tokens;
+}
+
+function consumeWrapperOptions(tokens: string[], optionsWithValues: ReadonlySet<string>): void {
+  while (tokens[0]?.startsWith('-')) {
+    const option = tokens.shift()!;
+    if (option === '--') break;
+    const optionName = option.split('=', 1)[0]!.toLowerCase();
+    if (optionsWithValues.has(optionName) && !option.includes('=') && tokens.length > 0) tokens.shift();
+  }
 }
 
 function fitMonitorBatch(output: string): string {

--- a/infrastructure/ai/harness/terminalMonitorGuard.ts
+++ b/infrastructure/ai/harness/terminalMonitorGuard.ts
@@ -15,7 +15,7 @@ interface MonitorState {
 }
 
 export type MonitorGuardResult =
-  | { action: 'deliver'; content: string; suppressedCount: number }
+  | { action: 'deliver'; content: string; suppressedCount: number; sourceTruncated: boolean }
   | { action: 'suppress'; suppressedCount: number }
   | { action: 'stop'; suppressedCount: number };
 
@@ -62,10 +62,12 @@ export class TerminalMonitorGuard {
     state.suppressedCount = 0;
     this.states.set(key, state);
     const prefix = suppressedCount > 0 ? `[${suppressedCount} monitor batches suppressed]\n` : '';
+    const fitted = fitMonitorBatch(`${prefix}${output}`);
     return {
       action: 'deliver',
-      content: fitMonitorBatch(`${prefix}${output}`),
+      content: fitted.content,
       suppressedCount,
+      sourceTruncated: fitted.sourceTruncated,
     };
   }
 
@@ -186,16 +188,21 @@ function canonicalOptionName(option: string): string {
   return optionName.startsWith('--') ? optionName.toLowerCase() : optionName;
 }
 
-function fitMonitorBatch(output: string): string {
+function fitMonitorBatch(output: string): { content: string; sourceTruncated: boolean } {
   const normalized = compressVerboseText(output);
+  let sourceTruncated = false;
   const lines = normalized.split('\n').map(line => {
     if (line.length <= MONITOR_LINE_MAX_CHARS) return line;
+    sourceTruncated = true;
     return `${line.slice(0, MONITOR_LINE_MAX_CHARS - 28)}[... line shortened ...]`;
   });
   const content = lines.join('\n');
-  if (content.length <= MONITOR_BATCH_MAX_CHARS) return content;
+  if (content.length <= MONITOR_BATCH_MAX_CHARS) return { content, sourceTruncated };
   const marker = '\n[... monitor batch shortened ...]';
-  return `${content.slice(0, MONITOR_BATCH_MAX_CHARS - marker.length)}${marker}`;
+  return {
+    content: `${content.slice(0, MONITOR_BATCH_MAX_CHARS - marker.length)}${marker}`,
+    sourceTruncated: true,
+  };
 }
 
 export const globalTerminalMonitorGuard = new TerminalMonitorGuard();

--- a/infrastructure/ai/harness/toolMessageIntegrity.test.ts
+++ b/infrastructure/ai/harness/toolMessageIntegrity.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { ModelMessage } from 'ai';
+import { repairToolMessageIntegrity } from './toolMessageIntegrity';
+
+test('repairToolMessageIntegrity drops orphan and duplicate tool results', () => {
+  const messages: ModelMessage[] = [
+    {
+      role: 'assistant',
+      content: [{ type: 'tool-call', toolCallId: 'call-1', toolName: 'terminal_poll', input: {} }],
+    },
+    {
+      role: 'tool',
+      content: [
+        { type: 'tool-result', toolCallId: 'call-1', toolName: 'terminal_poll', output: { type: 'text', value: 'first' } },
+        { type: 'tool-result', toolCallId: 'orphan', toolName: 'terminal_poll', output: { type: 'text', value: 'orphan' } },
+      ],
+    },
+    {
+      role: 'tool',
+      content: [{ type: 'tool-result', toolCallId: 'call-1', toolName: 'terminal_poll', output: { type: 'text', value: 'duplicate' } }],
+    },
+  ];
+
+  const result = repairToolMessageIntegrity(messages);
+  const serialized = JSON.stringify(result.messages);
+  assert.equal(result.didAdjust, true);
+  assert.match(serialized, /first/);
+  assert.doesNotMatch(serialized, /orphan|duplicate/);
+});
+
+test('repairToolMessageIntegrity completes interrupted tool calls with a synthetic result', () => {
+  const messages: ModelMessage[] = [{
+    role: 'assistant',
+    content: [{ type: 'tool-call', toolCallId: 'call-1', toolName: 'terminal_execute', input: { command: 'deploy' } }],
+  }];
+
+  const result = repairToolMessageIntegrity(messages);
+  assert.equal(result.messages.length, 2);
+  assert.match(JSON.stringify(result.messages[1]), /interrupted before a result was recorded/);
+});

--- a/infrastructure/ai/harness/toolMessageIntegrity.test.ts
+++ b/infrastructure/ai/harness/toolMessageIntegrity.test.ts
@@ -66,3 +66,26 @@ test('repairToolMessageIntegrity pairs reused tool call ids by occurrence order'
   assert.match(JSON.stringify(result.messages), /first result/);
   assert.match(JSON.stringify(result.messages), /second result/);
 });
+
+test('repairToolMessageIntegrity pairs a reused id with the nearest preceding call', () => {
+  const messages: ModelMessage[] = [
+    {
+      role: 'assistant',
+      content: [{ type: 'tool-call', toolCallId: 'reused', toolName: 'terminal_execute', input: { command: 'old' } }],
+    },
+    {
+      role: 'assistant',
+      content: [{ type: 'tool-call', toolCallId: 'reused', toolName: 'terminal_execute', input: { command: 'new' } }],
+    },
+    {
+      role: 'tool',
+      content: [{ type: 'tool-result', toolCallId: 'reused', toolName: 'terminal_execute', output: { type: 'text', value: 'new result' } }],
+    },
+  ];
+
+  const result = repairToolMessageIntegrity(messages);
+  assert.equal(result.didAdjust, true);
+  assert.deepEqual(result.messages.map(message => message.role), ['assistant', 'tool', 'assistant', 'tool']);
+  assert.match(JSON.stringify(result.messages[1]), /interrupted before a result was recorded/);
+  assert.match(JSON.stringify(result.messages[3]), /new result/);
+});

--- a/infrastructure/ai/harness/toolMessageIntegrity.test.ts
+++ b/infrastructure/ai/harness/toolMessageIntegrity.test.ts
@@ -39,3 +39,30 @@ test('repairToolMessageIntegrity completes interrupted tool calls with a synthet
   assert.equal(result.messages.length, 2);
   assert.match(JSON.stringify(result.messages[1]), /interrupted before a result was recorded/);
 });
+
+test('repairToolMessageIntegrity pairs reused tool call ids by occurrence order', () => {
+  const messages: ModelMessage[] = [
+    {
+      role: 'assistant',
+      content: [{ type: 'tool-call', toolCallId: 'reused', toolName: 'terminal_poll', input: { jobId: 'first' } }],
+    },
+    {
+      role: 'tool',
+      content: [{ type: 'tool-result', toolCallId: 'reused', toolName: 'terminal_poll', output: { type: 'text', value: 'first result' } }],
+    },
+    {
+      role: 'assistant',
+      content: [{ type: 'tool-call', toolCallId: 'reused', toolName: 'terminal_poll', input: { jobId: 'second' } }],
+    },
+    {
+      role: 'tool',
+      content: [{ type: 'tool-result', toolCallId: 'reused', toolName: 'terminal_poll', output: { type: 'text', value: 'second result' } }],
+    },
+  ];
+
+  const result = repairToolMessageIntegrity(messages);
+  assert.equal(result.didAdjust, false);
+  assert.equal(result.messages, messages);
+  assert.match(JSON.stringify(result.messages), /first result/);
+  assert.match(JSON.stringify(result.messages), /second result/);
+});

--- a/infrastructure/ai/harness/toolMessageIntegrity.ts
+++ b/infrastructure/ai/harness/toolMessageIntegrity.ts
@@ -1,0 +1,77 @@
+import type { ModelMessage } from 'ai';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function repairToolMessageIntegrity(messages: ModelMessage[]): {
+  messages: ModelMessage[];
+  didAdjust: boolean;
+} {
+  const calls = new Map<string, string>();
+  for (const message of messages) {
+    if (message.role !== 'assistant' || !Array.isArray(message.content)) continue;
+    for (const part of message.content as unknown[]) {
+      if (!isRecord(part) || part.type !== 'tool-call' || typeof part.toolCallId !== 'string') continue;
+      calls.set(part.toolCallId, typeof part.toolName === 'string' ? part.toolName : 'unknown');
+    }
+  }
+
+  const seenResults = new Set<string>();
+  let didAdjust = false;
+  const sanitized: ModelMessage[] = [];
+  for (const message of messages) {
+    if (message.role !== 'tool' || !Array.isArray(message.content)) {
+      sanitized.push(message);
+      continue;
+    }
+    const content = (message.content as unknown[]).filter(part => {
+      if (!isRecord(part) || part.type !== 'tool-result' || typeof part.toolCallId !== 'string') {
+        return true;
+      }
+      if (!calls.has(part.toolCallId) || seenResults.has(part.toolCallId)) {
+        didAdjust = true;
+        return false;
+      }
+      seenResults.add(part.toolCallId);
+      return true;
+    });
+    if (content.length === 0) {
+      didAdjust = true;
+      continue;
+    }
+    sanitized.push(content.length === message.content.length ? message : {
+      ...message,
+      content,
+    } as ModelMessage);
+  }
+
+  const repaired: ModelMessage[] = [];
+  for (const message of sanitized) {
+    repaired.push(message);
+    if (message.role !== 'assistant' || !Array.isArray(message.content)) continue;
+    const missing = (message.content as unknown[]).filter(part => (
+      isRecord(part)
+      && part.type === 'tool-call'
+      && typeof part.toolCallId === 'string'
+      && !seenResults.has(part.toolCallId)
+    )) as Array<Record<string, unknown>>;
+    if (missing.length === 0) continue;
+    repaired.push({
+      role: 'tool',
+      content: missing.map(part => ({
+        type: 'tool-result' as const,
+        toolCallId: String(part.toolCallId),
+        toolName: typeof part.toolName === 'string' ? part.toolName : 'unknown',
+        output: {
+          type: 'text' as const,
+          value: '[Tool call interrupted before a result was recorded. Do not assume it succeeded or repeat a write automatically; verify current state first.]',
+        },
+        isError: true,
+      })),
+    });
+    didAdjust = true;
+  }
+
+  return { messages: didAdjust ? repaired : messages, didAdjust };
+}

--- a/infrastructure/ai/harness/toolMessageIntegrity.ts
+++ b/infrastructure/ai/harness/toolMessageIntegrity.ts
@@ -32,7 +32,10 @@ export function repairToolMessageIntegrity(messages: ModelMessage[]): {
         return true;
       }
       const pending = pendingCalls.get(part.toolCallId);
-      const matchingCall = pending?.shift();
+      // Reused provider IDs are paired with the nearest preceding unresolved
+      // call. This also handles an older interrupted call followed by a new
+      // call that reused the same ID.
+      const matchingCall = pending?.pop();
       if (!matchingCall) {
         didAdjust = true;
         return false;

--- a/infrastructure/ai/harness/toolMessageIntegrity.ts
+++ b/infrastructure/ai/harness/toolMessageIntegrity.ts
@@ -8,19 +8,21 @@ export function repairToolMessageIntegrity(messages: ModelMessage[]): {
   messages: ModelMessage[];
   didAdjust: boolean;
 } {
-  const calls = new Map<string, string>();
-  for (const message of messages) {
-    if (message.role !== 'assistant' || !Array.isArray(message.content)) continue;
-    for (const part of message.content as unknown[]) {
-      if (!isRecord(part) || part.type !== 'tool-call' || typeof part.toolCallId !== 'string') continue;
-      calls.set(part.toolCallId, typeof part.toolName === 'string' ? part.toolName : 'unknown');
-    }
-  }
-
-  const seenResults = new Set<string>();
+  const pendingCalls = new Map<string, Array<Record<string, unknown>>>();
+  const matchedCalls = new Set<Record<string, unknown>>();
   let didAdjust = false;
   const sanitized: ModelMessage[] = [];
   for (const message of messages) {
+    if (message.role === 'assistant' && Array.isArray(message.content)) {
+      for (const part of message.content as unknown[]) {
+        if (!isRecord(part) || part.type !== 'tool-call' || typeof part.toolCallId !== 'string') continue;
+        const pending = pendingCalls.get(part.toolCallId) ?? [];
+        pending.push(part);
+        pendingCalls.set(part.toolCallId, pending);
+      }
+      sanitized.push(message);
+      continue;
+    }
     if (message.role !== 'tool' || !Array.isArray(message.content)) {
       sanitized.push(message);
       continue;
@@ -29,11 +31,13 @@ export function repairToolMessageIntegrity(messages: ModelMessage[]): {
       if (!isRecord(part) || part.type !== 'tool-result' || typeof part.toolCallId !== 'string') {
         return true;
       }
-      if (!calls.has(part.toolCallId) || seenResults.has(part.toolCallId)) {
+      const pending = pendingCalls.get(part.toolCallId);
+      const matchingCall = pending?.shift();
+      if (!matchingCall) {
         didAdjust = true;
         return false;
       }
-      seenResults.add(part.toolCallId);
+      matchedCalls.add(matchingCall);
       return true;
     });
     if (content.length === 0) {
@@ -54,7 +58,7 @@ export function repairToolMessageIntegrity(messages: ModelMessage[]): {
       isRecord(part)
       && part.type === 'tool-call'
       && typeof part.toolCallId === 'string'
-      && !seenResults.has(part.toolCallId)
+      && !matchedCalls.has(part)
     )) as Array<Record<string, unknown>>;
     if (missing.length === 0) continue;
     repaired.push({

--- a/infrastructure/ai/harness/toolOutputStore.test.ts
+++ b/infrastructure/ai/harness/toolOutputStore.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { ToolOutputStore } from './toolOutputStore';
+import { TOOL_OUTPUT_READ_MAX_CHARS, ToolOutputStore } from './toolOutputStore';
+import { ToolResultDedup } from './toolResultDedup';
 
 test('ToolOutputStore stores and reads truncated output by handle', () => {
   const store = new ToolOutputStore();
@@ -23,4 +24,169 @@ test('ToolOutputStore stores and reads truncated output by handle', () => {
 
   store.prune('chat-1');
   assert.equal(store.read({ handleId: handle.id }, 'chat-1'), null);
+});
+
+test('ToolOutputStore pages large output with a hard per-read cap', () => {
+  const store = new ToolOutputStore();
+  const content = `${'0123456789'.repeat(3_000)}END`;
+  const handle = store.store({
+    chatSessionId: 'chat-1',
+    capabilityId: 'terminal.execute',
+    content,
+  });
+
+  const first = store.readChunk({
+    handleId: handle.id,
+    mode: 'range',
+    maxChars: content.length,
+  }, 'chat-1');
+  assert.equal(first?.content.length, TOOL_OUTPUT_READ_MAX_CHARS);
+  assert.equal(first?.nextOffset, TOOL_OUTPUT_READ_MAX_CHARS);
+  assert.equal(first?.hasMore, true);
+
+  const second = store.readChunk({
+    handleId: handle.id,
+    mode: 'range',
+    offset: first?.nextOffset,
+  }, 'chat-1');
+  assert.equal(second?.startOffset, first?.nextOffset);
+});
+
+test('ToolOutputStore searches stored output without returning the whole body', () => {
+  const store = new ToolOutputStore();
+  const handle = store.store({
+    chatSessionId: 'chat-1',
+    capabilityId: 'terminal.execute',
+    content: `${'noise\n'.repeat(10_000)}Unique Failure Marker\n${'more noise\n'.repeat(10_000)}`,
+  });
+
+  const result = store.readChunk({
+    handleId: handle.id,
+    mode: 'search',
+    query: 'unique failure marker',
+  }, 'chat-1');
+  assert.deepEqual(result?.matchOffsets.length, 1);
+  assert.match(result?.content ?? '', /Unique Failure Marker/);
+  assert.ok((result?.content.length ?? Infinity) < TOOL_OUTPUT_READ_MAX_CHARS);
+});
+
+test('ToolOutputStore never splits a Unicode surrogate pair at page boundaries', () => {
+  const store = new ToolOutputStore();
+  const content = `${'a'.repeat(11_999)}😀中文结尾`;
+  const handle = store.store({
+    chatSessionId: 'chat-1',
+    capabilityId: 'terminal.execute',
+    content,
+  });
+
+  const first = store.readChunk({ handleId: handle.id, mode: 'range' }, 'chat-1');
+  assert.equal(first?.content.endsWith('\ud83d'), false);
+  const second = store.readChunk({
+    handleId: handle.id,
+    mode: 'range',
+    offset: first?.nextOffset,
+  }, 'chat-1');
+  assert.equal(`${first?.content}${second?.content}`, content);
+});
+
+test('ToolOutputStore enforces per-handle, session count, and TTL limits', () => {
+  let now = 1_000;
+  const store = new ToolOutputStore({
+    maxHandleChars: 20,
+    maxHandlesPerSession: 2,
+    maxCharsPerSession: 30,
+    ttlMs: 100,
+    now: () => now,
+  });
+  const first = store.store({ chatSessionId: 'chat-1', capabilityId: 'test', content: 'a'.repeat(15) });
+  const second = store.store({ chatSessionId: 'chat-1', capabilityId: 'test', content: 'b'.repeat(15) });
+  const third = store.store({ chatSessionId: 'chat-1', capabilityId: 'test', content: 'c'.repeat(100) });
+
+  assert.equal(store.get(first.id, 'chat-1'), undefined);
+  assert.equal(store.get(second.id, 'chat-1'), undefined);
+  assert.equal(store.get(third.id, 'chat-1')?.storedChars, 20);
+  assert.equal(store.get(third.id, 'chat-1')?.sourceTruncated, true);
+
+  now += 101;
+  assert.equal(store.get(third.id, 'chat-1'), undefined);
+});
+
+test('ToolOutputStore spills retained output through its persistence adapter', async () => {
+  const files = new Map<string, string>();
+  const deleted: string[] = [];
+  const store = new ToolOutputStore({
+    spillThresholdChars: 10,
+    persistence: {
+      write: async (_handleId, content) => {
+        files.set('/netcatty/tool-output.log', content);
+        return '/netcatty/tool-output.log';
+      },
+      read: async (path, input) => {
+        const content = files.get(path);
+        if (content == null) return null;
+        const startOffset = input.mode === 'tail'
+          ? Math.max(0, content.length - (input.maxChars ?? 12_000))
+          : Math.max(0, input.offset ?? 0);
+        const selected = content.slice(startOffset, startOffset + (input.maxChars ?? 12_000));
+        const endOffset = startOffset + selected.length;
+        return {
+          mode: input.mode ?? 'head',
+          content: selected,
+          totalChars: content.length,
+          startOffset,
+          endOffset,
+          nextOffset: endOffset,
+          hasMore: endOffset < content.length,
+        };
+      },
+      delete: async path => {
+        deleted.push(path);
+        files.delete(path);
+      },
+    },
+  });
+  const handle = store.store({
+    chatSessionId: 'chat-1',
+    capabilityId: 'terminal.execute',
+    content: 'persist this terminal output',
+  });
+
+  const result = await store.readChunkAsync({ handleId: handle.id, mode: 'full' }, 'chat-1');
+  assert.equal(result?.content, 'persist this terminal output');
+  assert.equal(store.get(handle.id, 'chat-1')?.fullContent, undefined);
+  store.prune('chat-1');
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert.deepEqual(deleted, ['/netcatty/tool-output.log']);
+});
+
+test('ToolOutputStore enforces a shared quota across chat sessions', () => {
+  const store = new ToolOutputStore({
+    maxCharsGlobal: 25,
+    maxHandlesGlobal: 2,
+  });
+  const first = store.store({ chatSessionId: 'chat-1', capabilityId: 'test', content: 'a'.repeat(15) });
+  const second = store.store({ chatSessionId: 'chat-2', capabilityId: 'test', content: 'b'.repeat(15) });
+
+  assert.equal(store.get(first.id, 'chat-1'), undefined);
+  assert.ok(store.get(second.id, 'chat-2'));
+});
+
+test('ToolOutputStore rejects cross-chat handle reads', async () => {
+  const store = new ToolOutputStore();
+  const handle = store.store({
+    chatSessionId: 'chat-owner',
+    capabilityId: 'terminal.execute',
+    content: 'private output',
+  });
+
+  assert.equal(await store.readChunkAsync({ handleId: handle.id }, 'chat-other'), null);
+});
+
+test('saved-output read budgets reset at the start of each turn', () => {
+  const dedup = new ToolResultDedup();
+  dedup.beginTurn();
+  assert.equal(dedup.takeBudget('read', 24_000, 24_000), 24_000);
+  assert.equal(dedup.takeBudget('read', 1, 24_000), 0);
+  dedup.beginTurn();
+  assert.equal(dedup.takeBudget('read', 24_000, 24_000), 24_000);
 });

--- a/infrastructure/ai/harness/toolOutputStore.test.ts
+++ b/infrastructure/ai/harness/toolOutputStore.test.ts
@@ -70,6 +70,35 @@ test('ToolOutputStore searches stored output without returning the whole body', 
   assert.ok((result?.content.length ?? Infinity) < TOOL_OUTPUT_READ_MAX_CHARS);
 });
 
+test('ToolOutputStore search advances only past matches included in the response', () => {
+  const store = new ToolOutputStore();
+  const handle = store.store({
+    chatSessionId: 'chat-1',
+    capabilityId: 'terminal.execute',
+    content: 'match middle match tail',
+  });
+
+  const first = store.readChunk({
+    handleId: handle.id,
+    mode: 'search',
+    query: 'match',
+    maxChars: 1,
+  }, 'chat-1');
+  assert.doesNotMatch(first?.content ?? '', /No matches found/);
+  assert.deepEqual(first?.matchOffsets, [0]);
+  assert.equal(first?.nextOffset, 5);
+  assert.equal(first?.hasMore, true);
+
+  const second = store.readChunk({
+    handleId: handle.id,
+    mode: 'search',
+    query: 'match',
+    offset: first?.nextOffset,
+    maxChars: 30,
+  }, 'chat-1');
+  assert.deepEqual(second?.matchOffsets, [13]);
+});
+
 test('ToolOutputStore never splits a Unicode surrogate pair at page boundaries', () => {
   const store = new ToolOutputStore();
   const content = `${'a'.repeat(11_999)}😀中文结尾`;

--- a/infrastructure/ai/harness/toolOutputStore.ts
+++ b/infrastructure/ai/harness/toolOutputStore.ts
@@ -3,9 +3,15 @@ export interface ToolOutputHandle {
   capabilityId: string;
   sessionId?: string;
   totalChars: number;
+  storedChars: number;
+  sourceTruncated: boolean;
   preview: string;
   storedAt: number;
-  fullContent: string;
+  accessedAt: number;
+  fullContent?: string;
+  filePath?: string;
+  spillPromise?: Promise<void>;
+  evicted?: boolean;
 }
 
 export interface StoreToolOutputInput {
@@ -18,70 +24,373 @@ export interface StoreToolOutputInput {
 
 export interface ReadToolOutputInput {
   handleId: string;
-  mode?: 'head' | 'tail' | 'full';
+  mode?: 'head' | 'tail' | 'full' | 'range' | 'search';
   maxChars?: number;
+  offset?: number;
+  query?: string;
 }
 
-let handleCounter = 0;
+export interface ToolOutputReadResult {
+  handleId: string;
+  mode: NonNullable<ReadToolOutputInput['mode']>;
+  content: string;
+  totalChars: number;
+  storedChars: number;
+  sourceTruncated: boolean;
+  startOffset: number;
+  endOffset: number;
+  nextOffset: number;
+  hasMore: boolean;
+  matchOffsets?: number[];
+}
+
+export const TOOL_OUTPUT_READ_MAX_CHARS = 12_000;
+export const TOOL_OUTPUT_MAX_HANDLE_CHARS = 4_000_000;
+export const TOOL_OUTPUT_MAX_HANDLES_PER_SESSION = 64;
+export const TOOL_OUTPUT_MAX_CHARS_PER_SESSION = 8_000_000;
+export const TOOL_OUTPUT_MAX_HANDLES_GLOBAL = 256;
+export const TOOL_OUTPUT_MAX_CHARS_GLOBAL = 32_000_000;
+export const TOOL_OUTPUT_TTL_MS = 30 * 60 * 1_000;
+export const TOOL_OUTPUT_SPILL_THRESHOLD_CHARS = 128_000;
+const TOOL_OUTPUT_SEARCH_CONTEXT_CHARS = 320;
+const TOOL_OUTPUT_SEARCH_MAX_MATCHES = 20;
+
+export interface ToolOutputPersistence {
+  write(handleId: string, content: string): Promise<string>;
+  read(path: string, input: ReadToolOutputInput): Promise<Omit<ToolOutputReadResult, 'handleId' | 'storedChars' | 'sourceTruncated'> | null>;
+  delete(path: string): Promise<void>;
+}
+
+export interface ToolOutputStoreOptions {
+  maxHandleChars?: number;
+  maxHandlesPerSession?: number;
+  maxCharsPerSession?: number;
+  maxHandlesGlobal?: number;
+  maxCharsGlobal?: number;
+  ttlMs?: number;
+  spillThresholdChars?: number;
+  now?: () => number;
+  persistence?: ToolOutputPersistence;
+}
 
 function nextHandleId(): string {
-  handleCounter += 1;
-  return `tool-output-${Date.now()}-${handleCounter}`;
+  const randomId = globalThis.crypto?.randomUUID?.()
+    ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  return `tool-output-${randomId}`;
+}
+
+function isHighSurrogate(value: number): boolean {
+  return value >= 0xd800 && value <= 0xdbff;
+}
+
+function isLowSurrogate(value: number): boolean {
+  return value >= 0xdc00 && value <= 0xdfff;
+}
+
+function safeSliceBounds(content: string, requestedStart: number, requestedEnd: number): [number, number] {
+  let start = Math.min(content.length, Math.max(0, requestedStart));
+  let end = Math.min(content.length, Math.max(start, requestedEnd));
+  if (start > 0 && start < content.length && isLowSurrogate(content.charCodeAt(start))) {
+    start -= 1;
+  }
+  if (end > start && end < content.length && isHighSurrogate(content.charCodeAt(end - 1))) {
+    end -= 1;
+  }
+  return [start, end];
 }
 
 export class ToolOutputStore {
   private readonly bySession = new Map<string, Map<string, ToolOutputHandle>>();
+  private readonly maxHandleChars: number;
+  private readonly maxHandlesPerSession: number;
+  private readonly maxCharsPerSession: number;
+  private readonly maxHandlesGlobal: number;
+  private readonly maxCharsGlobal: number;
+  private readonly ttlMs: number;
+  private readonly spillThresholdChars: number;
+  private readonly now: () => number;
+  private persistence?: ToolOutputPersistence;
+
+  constructor(options: ToolOutputStoreOptions = {}) {
+    this.maxHandleChars = options.maxHandleChars ?? TOOL_OUTPUT_MAX_HANDLE_CHARS;
+    this.maxHandlesPerSession = options.maxHandlesPerSession ?? TOOL_OUTPUT_MAX_HANDLES_PER_SESSION;
+    this.maxCharsPerSession = options.maxCharsPerSession ?? TOOL_OUTPUT_MAX_CHARS_PER_SESSION;
+    this.maxHandlesGlobal = options.maxHandlesGlobal ?? TOOL_OUTPUT_MAX_HANDLES_GLOBAL;
+    this.maxCharsGlobal = options.maxCharsGlobal ?? TOOL_OUTPUT_MAX_CHARS_GLOBAL;
+    this.ttlMs = options.ttlMs ?? TOOL_OUTPUT_TTL_MS;
+    this.spillThresholdChars = options.spillThresholdChars ?? TOOL_OUTPUT_SPILL_THRESHOLD_CHARS;
+    this.now = options.now ?? Date.now;
+    this.persistence = options.persistence;
+  }
+
+  setPersistence(persistence: ToolOutputPersistence | undefined): void {
+    this.persistence = persistence;
+  }
 
   store(input: StoreToolOutputInput): ToolOutputHandle {
     const previewChars = input.previewChars ?? 240;
+    const retainedContent = retainBoundedContent(input.content, this.maxHandleChars);
+    const now = this.now();
     const handle: ToolOutputHandle = {
       id: nextHandleId(),
       capabilityId: input.capabilityId,
       sessionId: input.sessionId,
       totalChars: input.content.length,
-      preview: input.content.slice(0, previewChars),
-      storedAt: Date.now(),
-      fullContent: input.content,
+      storedChars: retainedContent.length,
+      sourceTruncated: retainedContent.length < input.content.length,
+      preview: retainedContent.slice(0, previewChars),
+      storedAt: now,
+      accessedAt: now,
+      fullContent: retainedContent,
     };
     const sessionMap = this.bySession.get(input.chatSessionId) ?? new Map<string, ToolOutputHandle>();
     sessionMap.set(handle.id, handle);
     this.bySession.set(input.chatSessionId, sessionMap);
+    this.enforceSessionLimits(input.chatSessionId, sessionMap);
+    this.enforceGlobalLimits();
+    if (sessionMap.has(handle.id)) this.startSpill(handle);
     return handle;
   }
 
   get(handleId: string, chatSessionId?: string): ToolOutputHandle | undefined {
+    this.pruneExpired();
     if (chatSessionId) {
-      return this.bySession.get(chatSessionId)?.get(handleId);
+      const handle = this.bySession.get(chatSessionId)?.get(handleId);
+      if (handle) handle.accessedAt = this.now();
+      return handle;
     }
     for (const sessionMap of this.bySession.values()) {
       const handle = sessionMap.get(handleId);
-      if (handle) return handle;
+      if (handle) {
+        handle.accessedAt = this.now();
+        return handle;
+      }
     }
     return undefined;
   }
 
   listPendingHandles(chatSessionId: string): ToolOutputHandle[] {
+    this.pruneExpired();
     return [...(this.bySession.get(chatSessionId)?.values() ?? [])];
   }
 
   read(input: ReadToolOutputInput, chatSessionId?: string): string | null {
+    return this.readChunk(input, chatSessionId)?.content ?? null;
+  }
+
+  readChunk(input: ReadToolOutputInput, chatSessionId?: string): ToolOutputReadResult | null {
     const handle = this.get(input.handleId, chatSessionId);
     if (!handle) return null;
-    const maxChars = input.maxChars ?? 12_000;
-    const mode = input.mode ?? 'head';
-    const content = handle.fullContent;
-    if (mode === 'full') {
-      return content.length <= maxChars ? content : content.slice(0, maxChars);
-    }
-    if (mode === 'tail') {
-      return content.length <= maxChars ? content : content.slice(-maxChars);
-    }
-    return content.slice(0, maxChars);
+    if (handle.fullContent == null) return null;
+    return buildReadResult(handle, handle.fullContent, input);
+  }
+
+  async readChunkAsync(input: ReadToolOutputInput, chatSessionId?: string): Promise<ToolOutputReadResult | null> {
+    const handle = this.get(input.handleId, chatSessionId);
+    if (!handle) return null;
+    await handle.spillPromise;
+    if (handle.fullContent != null) return buildReadResult(handle, handle.fullContent, input);
+    if (!handle.filePath || !this.persistence) return null;
+    const persisted = await this.persistence.read(handle.filePath, input);
+    if (!persisted) return null;
+    return {
+      ...persisted,
+      handleId: handle.id,
+      totalChars: handle.totalChars,
+      storedChars: handle.storedChars,
+      sourceTruncated: handle.sourceTruncated,
+    };
   }
 
   prune(chatSessionId: string): void {
+    const sessionMap = this.bySession.get(chatSessionId);
+    if (sessionMap) {
+      for (const handle of sessionMap.values()) this.evictHandle(handle);
+    }
     this.bySession.delete(chatSessionId);
   }
+
+  pruneTerminalSession(chatSessionId: string, terminalSessionId: string): void {
+    const sessionMap = this.bySession.get(chatSessionId);
+    if (!sessionMap) return;
+    for (const [handleId, handle] of sessionMap) {
+      if (handle.sessionId !== terminalSessionId) continue;
+      sessionMap.delete(handleId);
+      this.evictHandle(handle);
+    }
+    if (sessionMap.size === 0) this.bySession.delete(chatSessionId);
+  }
+
+  private startSpill(handle: ToolOutputHandle): void {
+    if (!this.persistence || (handle.fullContent?.length ?? 0) < this.spillThresholdChars) return;
+    const persistence = this.persistence;
+    const content = handle.fullContent!;
+    handle.spillPromise = persistence.write(handle.id, content).then(async path => {
+      if (handle.evicted) {
+        await persistence.delete(path);
+        return;
+      }
+      handle.filePath = path;
+      handle.fullContent = undefined;
+    }).catch(() => {
+      // Keep the in-memory copy if persistence is temporarily unavailable.
+    });
+  }
+
+  private enforceSessionLimits(chatSessionId: string, sessionMap: Map<string, ToolOutputHandle>): void {
+    const totalChars = () => [...sessionMap.values()].reduce((sum, item) => sum + item.storedChars, 0);
+    while (
+      sessionMap.size > this.maxHandlesPerSession
+      || totalChars() > this.maxCharsPerSession
+    ) {
+      const oldest = [...sessionMap.values()].sort((a, b) => a.accessedAt - b.accessedAt)[0];
+      if (!oldest) break;
+      sessionMap.delete(oldest.id);
+      this.evictHandle(oldest);
+    }
+    if (sessionMap.size === 0) this.bySession.delete(chatSessionId);
+  }
+
+  private pruneExpired(): void {
+    const cutoff = this.now() - this.ttlMs;
+    for (const [chatSessionId, sessionMap] of this.bySession) {
+      for (const [handleId, handle] of sessionMap) {
+        if (handle.accessedAt > cutoff) continue;
+        sessionMap.delete(handleId);
+        this.evictHandle(handle);
+      }
+      if (sessionMap.size === 0) this.bySession.delete(chatSessionId);
+    }
+  }
+
+  private enforceGlobalLimits(): void {
+    const allHandles = () => [...this.bySession.entries()].flatMap(([chatSessionId, sessionMap]) => (
+      [...sessionMap.values()].map(handle => ({ chatSessionId, sessionMap, handle }))
+    ));
+    while (true) {
+      const entries = allHandles();
+      const totalChars = entries.reduce((sum, entry) => sum + entry.handle.storedChars, 0);
+      if (entries.length <= this.maxHandlesGlobal && totalChars <= this.maxCharsGlobal) break;
+      const oldest = entries.sort((a, b) => a.handle.accessedAt - b.handle.accessedAt)[0];
+      if (!oldest) break;
+      oldest.sessionMap.delete(oldest.handle.id);
+      this.evictHandle(oldest.handle);
+      if (oldest.sessionMap.size === 0) this.bySession.delete(oldest.chatSessionId);
+    }
+  }
+
+  private evictHandle(handle: ToolOutputHandle): void {
+    handle.evicted = true;
+    if (handle.filePath && this.persistence) {
+      void this.persistence.delete(handle.filePath).catch(() => {});
+    }
+  }
+}
+
+function retainBoundedContent(content: string, maxChars: number): string {
+  if (content.length <= maxChars) return content;
+  const marker = `\n\n[... source output exceeded local handle limit; ${content.length - maxChars} chars omitted ...]\n\n`;
+  if (marker.length >= maxChars) return content.slice(0, maxChars);
+  const budget = Math.max(0, maxChars - marker.length);
+  const head = Math.floor(budget / 2);
+  const tail = budget - head;
+  return `${content.slice(0, head)}${marker}${content.slice(-tail)}`;
+}
+
+function buildReadResult(
+  handle: ToolOutputHandle,
+  content: string,
+  input: ReadToolOutputInput,
+): ToolOutputReadResult {
+    const requestedMax = Number.isFinite(input.maxChars)
+      ? Math.floor(input.maxChars!)
+      : TOOL_OUTPUT_READ_MAX_CHARS;
+    const maxChars = Math.min(TOOL_OUTPUT_READ_MAX_CHARS, Math.max(1, requestedMax));
+    const mode = input.mode ?? 'head';
+
+    if (mode === 'search') {
+      const query = input.query ?? '';
+      if (!query) {
+        return {
+          handleId: handle.id,
+          mode,
+          content: 'Search query is required.',
+          totalChars: handle.totalChars,
+          storedChars: handle.storedChars,
+          sourceTruncated: handle.sourceTruncated,
+          startOffset: 0,
+          endOffset: 0,
+          nextOffset: 0,
+          hasMore: false,
+          matchOffsets: [],
+        };
+      }
+      const haystack = content.toLocaleLowerCase();
+      const needle = query.toLocaleLowerCase();
+      const offsets: number[] = [];
+      let cursor = Math.max(0, Math.floor(input.offset ?? 0));
+      while (offsets.length < TOOL_OUTPUT_SEARCH_MAX_MATCHES) {
+        const match = haystack.indexOf(needle, cursor);
+        if (match < 0) break;
+        offsets.push(match);
+        cursor = match + Math.max(1, needle.length);
+      }
+      const excerpts: string[] = [];
+      for (const match of offsets) {
+        const [start, end] = safeSliceBounds(
+          content,
+          match - TOOL_OUTPUT_SEARCH_CONTEXT_CHARS,
+          match + query.length + TOOL_OUTPUT_SEARCH_CONTEXT_CHARS,
+        );
+        const excerpt = `[match offset=${match}]\n${content.slice(start, end)}`;
+        if (excerpts.join('\n\n').length + excerpt.length > maxChars) break;
+        excerpts.push(excerpt);
+      }
+      const rendered = excerpts.join('\n\n');
+      const nextOffset = offsets.length > 0
+        ? offsets[offsets.length - 1] + Math.max(1, query.length)
+        : content.length;
+      return {
+        handleId: handle.id,
+        mode,
+        content: rendered || `No matches found for "${query}".`,
+        totalChars: handle.totalChars,
+        storedChars: handle.storedChars,
+        sourceTruncated: handle.sourceTruncated,
+        startOffset: Math.max(0, Math.floor(input.offset ?? 0)),
+        endOffset: nextOffset,
+        nextOffset,
+        hasMore: haystack.indexOf(needle, nextOffset) >= 0,
+        matchOffsets: offsets,
+      };
+    }
+
+    let startOffset = 0;
+    if (mode === 'tail') {
+      startOffset = Math.max(0, content.length - maxChars);
+    } else if (mode === 'range') {
+      startOffset = Math.min(content.length, Math.max(0, Math.floor(input.offset ?? 0)));
+    }
+    const [safeStartOffset, safeEndOffset] = safeSliceBounds(
+      content,
+      startOffset,
+      startOffset + maxChars,
+    );
+    startOffset = safeStartOffset;
+    const selected = content.slice(startOffset, safeEndOffset);
+    const endOffset = safeEndOffset;
+    return {
+      handleId: handle.id,
+      mode,
+      content: selected,
+      totalChars: handle.totalChars,
+      storedChars: handle.storedChars,
+      sourceTruncated: handle.sourceTruncated,
+      startOffset,
+      endOffset,
+      nextOffset: endOffset,
+      hasMore: endOffset < content.length,
+    };
 }
 
 export const globalToolOutputStore = new ToolOutputStore();

--- a/infrastructure/ai/harness/toolOutputStore.ts
+++ b/infrastructure/ai/harness/toolOutputStore.ts
@@ -336,6 +336,8 @@ function buildReadResult(
         cursor = match + Math.max(1, needle.length);
       }
       const excerpts: string[] = [];
+      const renderedOffsets: number[] = [];
+      let renderedChars = 0;
       for (const match of offsets) {
         const [start, end] = safeSliceBounds(
           content,
@@ -343,12 +345,24 @@ function buildReadResult(
           match + query.length + TOOL_OUTPUT_SEARCH_CONTEXT_CHARS,
         );
         const excerpt = `[match offset=${match}]\n${content.slice(start, end)}`;
-        if (excerpts.join('\n\n').length + excerpt.length > maxChars) break;
+        const separator = excerpts.length > 0 ? '\n\n' : '';
+        const available = maxChars - renderedChars - separator.length;
+        if (available <= 0) break;
+        if (excerpt.length > available) {
+          if (excerpts.length > 0) break;
+          const [, safeEnd] = safeSliceBounds(excerpt, 0, available);
+          excerpts.push(excerpt.slice(0, safeEnd));
+          renderedOffsets.push(match);
+          renderedChars += safeEnd;
+          break;
+        }
         excerpts.push(excerpt);
+        renderedOffsets.push(match);
+        renderedChars += separator.length + excerpt.length;
       }
       const rendered = excerpts.join('\n\n');
-      const nextOffset = offsets.length > 0
-        ? offsets[offsets.length - 1] + Math.max(1, query.length)
+      const nextOffset = renderedOffsets.length > 0
+        ? renderedOffsets[renderedOffsets.length - 1] + Math.max(1, query.length)
         : content.length;
       return {
         handleId: handle.id,
@@ -361,7 +375,7 @@ function buildReadResult(
         endOffset: nextOffset,
         nextOffset,
         hasMore: haystack.indexOf(needle, nextOffset) >= 0,
-        matchOffsets: offsets,
+        matchOffsets: renderedOffsets,
       };
     }
 

--- a/infrastructure/ai/harness/toolResultDedup.test.ts
+++ b/infrastructure/ai/harness/toolResultDedup.test.ts
@@ -21,3 +21,12 @@ test('completed write replay is ordered, one-shot, and scoped to the current tur
   assert.equal(dedup.replayCompletedWrite('same-command'), undefined);
   assert.equal(dedup.replayCompletedWrite('later-command'), undefined);
 });
+
+test('completed writes already present in retry history are not replayed', () => {
+  const dedup = new ToolResultDedup();
+  dedup.beginTurn();
+  dedup.rememberCompletedWrite('preserved-command', 'old result');
+  dedup.enableWriteReplay(['preserved-command']);
+
+  assert.equal(dedup.replayCompletedWrite('preserved-command'), undefined);
+});

--- a/infrastructure/ai/harness/toolResultDedup.test.ts
+++ b/infrastructure/ai/harness/toolResultDedup.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { ToolResultDedup } from './toolResultDedup';
+
+test('completed write replay is ordered, one-shot, and scoped to the current turn', () => {
+  const dedup = new ToolResultDedup();
+  dedup.beginTurn();
+  dedup.rememberCompletedWrite('same-command', 'first');
+  dedup.rememberCompletedWrite('same-command', 'second');
+  dedup.enableWriteReplay();
+
+  assert.equal(dedup.replayCompletedWrite('same-command'), 'first');
+  assert.equal(dedup.replayCompletedWrite('same-command'), 'second');
+  assert.equal(dedup.replayCompletedWrite('same-command'), undefined);
+
+  dedup.rememberCompletedWrite('later-command', 'later');
+  assert.equal(dedup.replayCompletedWrite('later-command'), undefined);
+
+  dedup.beginTurn();
+  dedup.enableWriteReplay();
+  assert.equal(dedup.replayCompletedWrite('same-command'), undefined);
+  assert.equal(dedup.replayCompletedWrite('later-command'), undefined);
+});

--- a/infrastructure/ai/harness/toolResultDedup.ts
+++ b/infrastructure/ai/harness/toolResultDedup.ts
@@ -8,14 +8,51 @@ export interface ToolResultDedupEntry {
 export class ToolResultDedup {
   private turnNumber = 0;
   private readonly cache = new Map<string, ToolResultDedupEntry>();
+  private readonly consumedBudgets = new Map<string, number>();
+  private readonly completedWrites = new Map<string, unknown>();
+  private readonly terminalJobSessions = new Map<string, string>();
+  private writeReplayEnabled = false;
 
   beginTurn(): void {
     this.turnNumber += 1;
+    this.consumedBudgets.clear();
   }
 
   reset(): void {
     this.cache.clear();
     this.turnNumber = 0;
+    this.consumedBudgets.clear();
+    this.completedWrites.clear();
+    this.terminalJobSessions.clear();
+    this.writeReplayEnabled = false;
+  }
+
+  rememberCompletedWrite(fingerprint: string, result: unknown): void {
+    this.completedWrites.set(fingerprint, result);
+  }
+
+  rememberTerminalJobSession(jobId: string, sessionId: string): void {
+    this.terminalJobSessions.set(jobId, sessionId);
+  }
+
+  terminalSessionForJob(jobId: string): string | undefined {
+    return this.terminalJobSessions.get(jobId);
+  }
+
+  enableWriteReplay(): void {
+    this.writeReplayEnabled = true;
+  }
+
+  replayCompletedWrite(fingerprint: string): unknown | undefined {
+    if (!this.writeReplayEnabled) return undefined;
+    return this.completedWrites.get(fingerprint);
+  }
+
+  takeBudget(key: string, requested: number, limit: number): number {
+    const consumed = this.consumedBudgets.get(key) ?? 0;
+    const granted = Math.max(0, Math.min(requested, limit - consumed));
+    this.consumedBudgets.set(key, consumed + granted);
+    return granted;
   }
 
   fingerprintFor(toolName: string, key: string): string {
@@ -51,4 +88,19 @@ export function previewToolResult(result: unknown): string {
   } catch {
     return String(result).slice(0, 160);
   }
+}
+
+export function hashToolResult(result: unknown): string {
+  let value: string;
+  try {
+    value = typeof result === 'string' ? result : JSON.stringify(result);
+  } catch {
+    value = String(result);
+  }
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
 }

--- a/infrastructure/ai/harness/toolResultDedup.ts
+++ b/infrastructure/ai/harness/toolResultDedup.ts
@@ -46,15 +46,22 @@ export class ToolResultDedup {
     return this.terminalJobSessions.get(jobId);
   }
 
-  enableWriteReplay(): void {
+  enableWriteReplay(preservedFingerprints: Iterable<string> = []): void {
     this.replayableWrites = new Map(
       Array.from(this.completedWrites, ([fingerprint, results]) => [fingerprint, [...results]]),
     );
     this.writeReplayEnabled = true;
+    for (const fingerprint of preservedFingerprints) {
+      this.consumeReplay(fingerprint);
+    }
   }
 
   replayCompletedWrite(fingerprint: string): unknown | undefined {
     if (!this.writeReplayEnabled) return undefined;
+    return this.consumeReplay(fingerprint);
+  }
+
+  private consumeReplay(fingerprint: string): unknown | undefined {
     const results = this.replayableWrites.get(fingerprint);
     const result = results?.shift();
     if (results?.length === 0) this.replayableWrites.delete(fingerprint);
@@ -92,6 +99,16 @@ export class ToolResultDedup {
 
 export function hashScopeKey(parts: Array<string | undefined>): string {
   return parts.filter(Boolean).join('|');
+}
+
+export function buildTerminalWriteFingerprint(
+  toolName: 'terminal_execute' | 'terminal_start',
+  chatSessionId: string | undefined,
+  args: { sessionId?: unknown; command?: unknown },
+): string | undefined {
+  if (typeof args.sessionId !== 'string' || typeof args.command !== 'string') return undefined;
+  const fingerprintToolName = toolName === 'terminal_start' ? 'terminal.start:write' : toolName;
+  return `${fingerprintToolName}:${hashScopeKey([chatSessionId, args.sessionId, args.command])}`;
 }
 
 export function previewToolResult(result: unknown): string {

--- a/infrastructure/ai/harness/toolResultDedup.ts
+++ b/infrastructure/ai/harness/toolResultDedup.ts
@@ -9,13 +9,17 @@ export class ToolResultDedup {
   private turnNumber = 0;
   private readonly cache = new Map<string, ToolResultDedupEntry>();
   private readonly consumedBudgets = new Map<string, number>();
-  private readonly completedWrites = new Map<string, unknown>();
+  private readonly completedWrites = new Map<string, unknown[]>();
+  private replayableWrites = new Map<string, unknown[]>();
   private readonly terminalJobSessions = new Map<string, string>();
   private writeReplayEnabled = false;
 
   beginTurn(): void {
     this.turnNumber += 1;
     this.consumedBudgets.clear();
+    this.completedWrites.clear();
+    this.replayableWrites.clear();
+    this.writeReplayEnabled = false;
   }
 
   reset(): void {
@@ -23,12 +27,15 @@ export class ToolResultDedup {
     this.turnNumber = 0;
     this.consumedBudgets.clear();
     this.completedWrites.clear();
+    this.replayableWrites.clear();
     this.terminalJobSessions.clear();
     this.writeReplayEnabled = false;
   }
 
   rememberCompletedWrite(fingerprint: string, result: unknown): void {
-    this.completedWrites.set(fingerprint, result);
+    const results = this.completedWrites.get(fingerprint) ?? [];
+    results.push(result);
+    this.completedWrites.set(fingerprint, results);
   }
 
   rememberTerminalJobSession(jobId: string, sessionId: string): void {
@@ -40,12 +47,18 @@ export class ToolResultDedup {
   }
 
   enableWriteReplay(): void {
+    this.replayableWrites = new Map(
+      Array.from(this.completedWrites, ([fingerprint, results]) => [fingerprint, [...results]]),
+    );
     this.writeReplayEnabled = true;
   }
 
   replayCompletedWrite(fingerprint: string): unknown | undefined {
     if (!this.writeReplayEnabled) return undefined;
-    return this.completedWrites.get(fingerprint);
+    const results = this.replayableWrites.get(fingerprint);
+    const result = results?.shift();
+    if (results?.length === 0) this.replayableWrites.delete(fingerprint);
+    return result;
   }
 
   takeBudget(key: string, requested: number, limit: number): number {

--- a/infrastructure/ai/harness/toolResultFitting.ts
+++ b/infrastructure/ai/harness/toolResultFitting.ts
@@ -1,5 +1,6 @@
 import { compressVerboseText, truncateTextWithHeadAndTail } from '../requestPayloadCompression';
 import type { ToolOutputStore } from './toolOutputStore';
+import { redactSecretsForModel } from './modelSecretRedaction';
 
 export const MAX_LIVE_TOOL_STRING_CHARS = 8_000;
 
@@ -8,7 +9,9 @@ export interface FitLargeToolResultForModelInput {
   capabilityId: string;
   chatSessionId?: string;
   toolOutputStore?: ToolOutputStore;
+  terminalSessionId?: string;
   maxStringChars?: number;
+  normalizeStrings?: boolean;
 }
 
 export function fitLargeToolResultForModel({
@@ -16,13 +19,17 @@ export function fitLargeToolResultForModel({
   capabilityId,
   chatSessionId,
   toolOutputStore,
+  terminalSessionId,
   maxStringChars = MAX_LIVE_TOOL_STRING_CHARS,
+  normalizeStrings = false,
 }: FitLargeToolResultForModelInput): unknown {
   return fitValue(result, {
     capabilityId,
     chatSessionId,
     toolOutputStore,
+    terminalSessionId,
     maxStringChars,
+    normalizeStrings,
     path: [],
   });
 }
@@ -31,7 +38,9 @@ interface FitValueContext {
   capabilityId: string;
   chatSessionId?: string;
   toolOutputStore?: ToolOutputStore;
+  terminalSessionId?: string;
   maxStringChars: number;
+  normalizeStrings: boolean;
   path: string[];
 }
 
@@ -72,13 +81,17 @@ function fitValue(value: unknown, ctx: FitValueContext): unknown {
 }
 
 function fitString(value: string, ctx: FitValueContext): string {
-  if (value.length <= ctx.maxStringChars) return value;
+  const safeValue = redactSecretsForModel(value);
+  const normalizedValue = ctx.normalizeStrings ? compressVerboseText(safeValue) : safeValue;
+  if (safeValue.length <= ctx.maxStringChars && normalizedValue.length <= ctx.maxStringChars) {
+    return normalizedValue;
+  }
 
   const fitted = truncateTextWithHeadAndTail(
-    compressVerboseText(value),
+    ctx.normalizeStrings ? normalizedValue : compressVerboseText(safeValue),
     ctx.maxStringChars,
   );
-  if (fitted === value) return value;
+  if (fitted === safeValue) return safeValue;
 
   let handleId: string | undefined;
   if (ctx.toolOutputStore && ctx.chatSessionId) {
@@ -86,6 +99,7 @@ function fitString(value: string, ctx: FitValueContext): string {
       chatSessionId: ctx.chatSessionId,
       capabilityId: ctx.capabilityId,
       content: value,
+      sessionId: ctx.terminalSessionId,
     }).id;
   }
 

--- a/infrastructure/ai/harness/turnDrivers/cattyMessageBuilder.ts
+++ b/infrastructure/ai/harness/turnDrivers/cattyMessageBuilder.ts
@@ -20,6 +20,7 @@ import {
   type AssistantContentPart,
   type CattyProviderContinuationContext,
 } from '../../../../components/ai/hooks/aiChatStreamingSupport';
+import { redactSecretsInValueForModel } from '../modelSecretRedaction';
 
 const OPENAI_CHAT_ASSISTANT_FIELDS = Symbol('netcatty.openAIChatAssistantFields');
 
@@ -140,7 +141,7 @@ export function buildCattySdkMessages(input: BuildCattySdkMessagesInput): ModelM
             type: 'tool-call' as const,
             toolCallId: tc.id,
             toolName: tc.name,
-            input: tc.arguments ?? {},
+            input: redactSecretsInValueForModel(tc.arguments ?? {}),
             ...(providerOptions ? { providerOptions } : {}),
           });
         }

--- a/infrastructure/ai/harness/turnDrivers/cattyMessageBuilder.ts
+++ b/infrastructure/ai/harness/turnDrivers/cattyMessageBuilder.ts
@@ -1,5 +1,6 @@
 import type { ModelMessage } from 'ai';
 import type { ChatMessage, ChatMessageAttachment, ToolResult } from '../../types';
+import { buildTerminalWriteFingerprint } from '../toolResultDedup';
 import {
   buildHistoricalToolReplayMaps,
   buildHistoricalToolResultReplayText,
@@ -254,6 +255,25 @@ export function collectToolResultsAfterMessage(
     }
   }
   return results;
+}
+
+export function collectPreservedTerminalWriteFingerprints(
+  messages: ChatMessage[],
+  messageId: string,
+  chatSessionId: string,
+): string[] {
+  const preservedResults = collectToolResultsAfterMessage(messages, messageId);
+  const callsById = new Map(
+    messages.flatMap(message => message.toolCalls ?? []).map(call => [call.id, call] as const),
+  );
+  const fingerprints: string[] = [];
+  for (const result of preservedResults) {
+    const call = callsById.get(result.toolCallId);
+    if (call?.name !== 'terminal_execute' && call?.name !== 'terminal_start') continue;
+    const fingerprint = buildTerminalWriteFingerprint(call.name, chatSessionId, call.arguments);
+    if (fingerprint) fingerprints.push(fingerprint);
+  }
+  return fingerprints;
 }
 
 export function createContinuationContext(

--- a/infrastructure/ai/harness/turnDrivers/cattyMessageBuilder.ts
+++ b/infrastructure/ai/harness/turnDrivers/cattyMessageBuilder.ts
@@ -263,12 +263,10 @@ export function collectPreservedTerminalWriteFingerprints(
   chatSessionId: string,
 ): string[] {
   const preservedResults = collectToolResultsAfterMessage(messages, messageId);
-  const callsById = new Map(
-    messages.flatMap(message => message.toolCalls ?? []).map(call => [call.id, call] as const),
-  );
+  const { toolCallByToolResult } = buildHistoricalToolReplayMaps(messages);
   const fingerprints: string[] = [];
   for (const result of preservedResults) {
-    const call = callsById.get(result.toolCallId);
+    const call = toolCallByToolResult.get(result);
     if (call?.name !== 'terminal_execute' && call?.name !== 'terminal_start') continue;
     const fingerprint = buildTerminalWriteFingerprint(call.name, chatSessionId, call.arguments);
     if (fingerprint) fingerprints.push(fingerprint);

--- a/infrastructure/ai/harness/turnDrivers/cattyMessageBuilder.ts
+++ b/infrastructure/ai/harness/turnDrivers/cattyMessageBuilder.ts
@@ -21,6 +21,8 @@ import {
   type CattyProviderContinuationContext,
 } from '../../../../components/ai/hooks/aiChatStreamingSupport';
 import { redactSecretsInValueForModel } from '../modelSecretRedaction';
+import { fitLargeUserInputForModel } from '../largeUserInput';
+import type { ToolOutputStore } from '../toolOutputStore';
 
 const OPENAI_CHAT_ASSISTANT_FIELDS = Symbol('netcatty.openAIChatAssistantFields');
 
@@ -74,6 +76,8 @@ export interface BuildCattySdkMessagesInput {
   attachments?: ChatMessageAttachment[];
   continuationContext: CattyProviderContinuationContext;
   preserveTerminalToolResults?: ReadonlySet<ToolResult>;
+  chatSessionId: string;
+  toolOutputStore: ToolOutputStore;
   fieldsByMessage: Map<ModelMessage, OpenAIChatAssistantFields | undefined>;
 }
 
@@ -85,6 +89,8 @@ export function buildCattySdkMessages(input: BuildCattySdkMessagesInput): ModelM
     attachments,
     continuationContext,
     preserveTerminalToolResults = new Set<ToolResult>(),
+    chatSessionId,
+    toolOutputStore,
     fieldsByMessage,
   } = input;
 
@@ -97,9 +103,10 @@ export function buildCattySdkMessages(input: BuildCattySdkMessagesInput): ModelM
     const currentMessageFollowsToolResult = previousHistoryMessageWasToolResult;
     if (m.role === 'user') {
       const messageAttachments = m.attachments ?? m.images;
+      const boundedContent = fitLargeUserInputForModel(m.content, chatSessionId, toolOutputStore);
       sdkMessages.push({
         role: 'user',
-        content: buildHistoricalUserReplayContent(m.content, messageAttachments ?? []),
+        content: buildHistoricalUserReplayContent(boundedContent, messageAttachments ?? []),
       });
     } else if (m.role === 'assistant') {
       const activeContinuation = isProviderContinuationForSource(

--- a/infrastructure/ai/harness/turnDrivers/cattyTurnDriver.ts
+++ b/infrastructure/ai/harness/turnDrivers/cattyTurnDriver.ts
@@ -27,6 +27,47 @@ import {
 } from './cattyMessageBuilder';
 import { hadToolProgressBeforeRequestTooLarge, processCattyStream } from './cattyStreamProcessor';
 import type { CattyTurnInput, TurnDriver, TurnDriverContext } from './types';
+import { fitLargeUserInputForModel } from '../largeUserInput';
+import { buildPromptContextSnapshot } from '../promptContextSnapshot';
+import type { SessionStateStore } from '../sessionState';
+
+export async function refreshRememberedTerminalJobs(input: {
+  chatSessionId: string;
+  sessionStateStore: SessionStateStore;
+  poll: (jobId: string, offset: number) => Promise<unknown>;
+}): Promise<void> {
+  const rememberedJobs = Object.entries(
+    input.sessionStateStore.get(input.chatSessionId).activeJobs,
+  ).slice(-5);
+  for (const [jobId, job] of rememberedJobs) {
+    try {
+      const refreshed = await input.poll(jobId, job.nextOffset);
+      const refreshedRecord = refreshed && typeof refreshed === 'object'
+        ? refreshed as Record<string, unknown>
+        : undefined;
+      const isError = Boolean(
+        refreshedRecord
+        && (
+          refreshedRecord.ok === false
+          || (typeof refreshedRecord.error === 'string' && refreshedRecord.error.trim().length > 0)
+        ),
+      );
+      input.sessionStateStore.updateFromToolResult(
+        input.chatSessionId,
+        'terminal_poll',
+        { jobId, offset: job.nextOffset },
+        JSON.stringify(
+          !isError && refreshed && typeof refreshed === 'object'
+            ? { ...refreshed as Record<string, unknown>, nextOffset: job.nextOffset }
+            : refreshed,
+        ),
+        isError,
+      );
+    } catch {
+      // Preserve the unverified job on transient bridge errors.
+    }
+  }
+}
 
 export class CattyTurnDriver implements TurnDriver {
   readonly backend = 'catty' as const;
@@ -57,7 +98,34 @@ async function runCattyTurn(input: CattyTurnInput, ctx: TurnDriverContext): Prom
     ui,
   } = input;
 
-  const netcattyBridge = bridge ?? getNetcattyBridge();
+  const netcattyBridge = (bridge ?? getNetcattyBridge()) as NonNullable<ReturnType<typeof getNetcattyBridge>>;
+  const toolOutputTempBridge = netcattyBridge as typeof netcattyBridge & {
+    writeToolOutputTemp?: (handleId: string, content: string) => Promise<{ ok: boolean; path?: string; error?: string }>;
+    readToolOutputTemp?: (
+      path: string,
+      request: import('../toolOutputStore').ReadToolOutputInput,
+    ) => Promise<Omit<import('../toolOutputStore').ToolOutputReadResult, 'handleId' | 'storedChars' | 'sourceTruncated'> | null>;
+    deleteToolOutputTemp?: (path: string) => Promise<{ ok: boolean }>;
+  };
+  if (
+    toolOutputTempBridge.writeToolOutputTemp
+    && toolOutputTempBridge.readToolOutputTemp
+    && toolOutputTempBridge.deleteToolOutputTemp
+  ) {
+    ctx.toolOutputStore.setPersistence({
+      write: async (handleId, content) => {
+        const result = await toolOutputTempBridge.writeToolOutputTemp!(handleId, content);
+        if (!result.ok || !result.path) {
+          throw new Error(result.error || 'Unable to persist tool output.');
+        }
+        return result.path;
+      },
+      read: (path, request) => toolOutputTempBridge.readToolOutputTemp!(path, request),
+      delete: async path => {
+        await toolOutputTempBridge.deleteToolOutputTemp!(path);
+      },
+    });
+  }
   await clearChatSessionCancelled(sessionId, netcattyBridge);
   if (netcattyBridge.aiMcpUpdateSessions) {
     await netcattyBridge.aiMcpUpdateSessions(context.terminalSessions, sessionId);
@@ -70,6 +138,7 @@ async function runCattyTurn(input: CattyTurnInput, ctx: TurnDriverContext): Prom
     trimmed,
     context.selectedUserSkillSlugs,
   );
+  const modelUserText = fitLargeUserInputForModel(trimmed, sessionId, ctx.toolOutputStore);
   const getExecutorContext = context.getExecutorContext ?? (() => ({
     sessions: context.terminalSessions,
     workspaceId: context.scopeType === 'workspace' ? context.scopeTargetId : undefined,
@@ -102,6 +171,23 @@ async function runCattyTurn(input: CattyTurnInput, ctx: TurnDriverContext): Prom
   }
 
   const activeModelId = context.activeModelId || context.activeProvider.defaultModel || '';
+  const promptContext = buildPromptContextSnapshot({
+    providerId: context.activeProvider.providerId,
+    modelId: activeModelId,
+    permissionMode: context.permissionMode ?? context.globalPermissionMode,
+    scopeType: context.scopeType,
+    scopeLabel: context.scopeLabel,
+    toolNames: Object.keys(tools),
+    selectedSkillSlugs: context.selectedUserSkillSlugs,
+    systemPrompt,
+    webSearchEnabled: isWebSearchReady(context.webSearchConfig),
+    hostSessionIds: context.terminalSessions.map(session => session.sessionId),
+  });
+  ctx.emit({
+    id: `context-snapshot-${ctx.turnId}`,
+    type: 'context_snapshot',
+    snapshot: promptContext,
+  } as import('../types').AgentEvent);
   const continuationContext = createContinuationContext(
     context.activeProvider.id,
     context.activeProvider.providerId,
@@ -120,7 +206,7 @@ async function runCattyTurn(input: CattyTurnInput, ctx: TurnDriverContext): Prom
     ) => buildCattySdkMessages({
       allMessages,
       includeCurrentUserMessage,
-      trimmed,
+      trimmed: modelUserText,
       attachments: includeCurrentUserMessage ? attachments : undefined,
       continuationContext,
       preserveTerminalToolResults: options.preserveTerminalToolResults,
@@ -174,6 +260,17 @@ async function runCattyTurn(input: CattyTurnInput, ctx: TurnDriverContext): Prom
         compressForRequestTooLargeRetry?: boolean;
       },
     ): Promise<ModelMessage[]> => {
+      if (netcattyBridge.aiCapability) {
+        await refreshRememberedTerminalJobs({
+          chatSessionId: sessionId,
+          sessionStateStore: ctx.sessionStateStore,
+          poll: (jobId, offset) => netcattyBridge.aiCapability!(
+              'netcatty/jobPoll',
+              { jobId, offset },
+              sessionId,
+          ),
+        });
+      }
       const pendingHandles = ctx.toolOutputStore.listPendingHandles(sessionId);
       const sessionStateText = ctx.sessionStateStore.toReinjectionText(sessionId);
       const result = await compactCattyMessages({
@@ -185,6 +282,7 @@ async function runCattyTurn(input: CattyTurnInput, ctx: TurnDriverContext): Prom
         reservedTokens: getRequestReserveTokens,
         maxOutputTokens,
         model,
+        toolOutputStore: ctx.toolOutputStore,
         abortSignal: signal,
         trigger: options.force ? 'force' : options.compressForRequestTooLargeRetry ? '413-retry' : 'pre-turn',
         force: options.force,
@@ -234,6 +332,7 @@ async function runCattyTurn(input: CattyTurnInput, ctx: TurnDriverContext): Prom
       scopeType: context.scopeType,
       scopeLabel: context.scopeLabel,
       userGoal: extractLatestUserGoal(messagesForStream),
+      promptContext,
     });
     const commandTimeoutSeconds =
       Number.isFinite(context.commandTimeout) && context.commandTimeout > 0
@@ -295,6 +394,7 @@ async function runCattyTurn(input: CattyTurnInput, ctx: TurnDriverContext): Prom
       }
 
       console.warn('[Catty] Request hit HTTP 413; forcing context compaction and retrying once.', streamErr);
+      ctx.toolResultDedup.enableWriteReplay();
       const hadToolProgress = hadToolProgressBeforeRequestTooLarge(streamErr);
       let retryBaseMessages = messagesForStream;
       let retryAssistantMsgId = assistantMsgId;

--- a/infrastructure/ai/harness/turnDrivers/cattyTurnDriver.ts
+++ b/infrastructure/ai/harness/turnDrivers/cattyTurnDriver.ts
@@ -22,6 +22,7 @@ import { getNetcattyBridge, generateId, resolveUserSkillsContext } from '../../.
 import {
   buildCattySdkMessages,
   collectOpenAIChatAssistantFieldsForMessages,
+  collectPreservedTerminalWriteFingerprints,
   collectToolResultsAfterMessage,
   createContinuationContext,
 } from './cattyMessageBuilder';
@@ -346,13 +347,18 @@ async function runCattyTurn(input: CattyTurnInput, ctx: TurnDriverContext): Prom
       }
 
       console.warn('[Catty] Request hit HTTP 413; forcing context compaction and retrying once.', streamErr);
-      ctx.toolResultDedup.enableWriteReplay();
       const hadToolProgress = hadToolProgressBeforeRequestTooLarge(streamErr);
       let retryBaseMessages = messagesForStream;
       let retryAssistantMsgId = assistantMsgId;
+      let preservedWriteFingerprints: string[] = [];
       if (hadToolProgress) {
         const latestSession = ui.getLatestSession?.(sessionId);
         if (latestSession) {
+          preservedWriteFingerprints = collectPreservedTerminalWriteFingerprints(
+            latestSession.messages,
+            assistantMsgId,
+            sessionId,
+          );
           retryBaseMessages = buildSdkMessages(latestSession.messages, false, {
             preserveTerminalToolResults: collectToolResultsAfterMessage(
               latestSession.messages,
@@ -382,6 +388,7 @@ async function runCattyTurn(input: CattyTurnInput, ctx: TurnDriverContext): Prom
           pendingApproval: undefined,
         }));
       }
+      ctx.toolResultDedup.enableWriteReplay(preservedWriteFingerprints);
       const retryMessages = prepareMessagesForStream(await compactMessages(retryBaseMessages, {
         force: true,
         compressForRequestTooLargeRetry: true,

--- a/infrastructure/ai/harness/turnDrivers/cattyTurnDriver.ts
+++ b/infrastructure/ai/harness/turnDrivers/cattyTurnDriver.ts
@@ -29,45 +29,6 @@ import { hadToolProgressBeforeRequestTooLarge, processCattyStream } from './catt
 import type { CattyTurnInput, TurnDriver, TurnDriverContext } from './types';
 import { fitLargeUserInputForModel } from '../largeUserInput';
 import { buildPromptContextSnapshot } from '../promptContextSnapshot';
-import type { SessionStateStore } from '../sessionState';
-
-export async function refreshRememberedTerminalJobs(input: {
-  chatSessionId: string;
-  sessionStateStore: SessionStateStore;
-  poll: (jobId: string, offset: number) => Promise<unknown>;
-}): Promise<void> {
-  const rememberedJobs = Object.entries(
-    input.sessionStateStore.get(input.chatSessionId).activeJobs,
-  ).slice(-5);
-  for (const [jobId, job] of rememberedJobs) {
-    try {
-      const refreshed = await input.poll(jobId, job.nextOffset);
-      const refreshedRecord = refreshed && typeof refreshed === 'object'
-        ? refreshed as Record<string, unknown>
-        : undefined;
-      const isError = Boolean(
-        refreshedRecord
-        && (
-          refreshedRecord.ok === false
-          || (typeof refreshedRecord.error === 'string' && refreshedRecord.error.trim().length > 0)
-        ),
-      );
-      input.sessionStateStore.updateFromToolResult(
-        input.chatSessionId,
-        'terminal_poll',
-        { jobId, offset: job.nextOffset },
-        JSON.stringify(
-          !isError && refreshed && typeof refreshed === 'object'
-            ? { ...refreshed as Record<string, unknown>, nextOffset: job.nextOffset }
-            : refreshed,
-        ),
-        isError,
-      );
-    } catch {
-      // Preserve the unverified job on transient bridge errors.
-    }
-  }
-}
 
 export class CattyTurnDriver implements TurnDriver {
   readonly backend = 'catty' as const;
@@ -210,6 +171,8 @@ async function runCattyTurn(input: CattyTurnInput, ctx: TurnDriverContext): Prom
       attachments: includeCurrentUserMessage ? attachments : undefined,
       continuationContext,
       preserveTerminalToolResults: options.preserveTerminalToolResults,
+      chatSessionId: sessionId,
+      toolOutputStore: ctx.toolOutputStore,
       fieldsByMessage: openAIChatAssistantFieldsByMessage,
     });
 
@@ -260,17 +223,6 @@ async function runCattyTurn(input: CattyTurnInput, ctx: TurnDriverContext): Prom
         compressForRequestTooLargeRetry?: boolean;
       },
     ): Promise<ModelMessage[]> => {
-      if (netcattyBridge.aiCapability) {
-        await refreshRememberedTerminalJobs({
-          chatSessionId: sessionId,
-          sessionStateStore: ctx.sessionStateStore,
-          poll: (jobId, offset) => netcattyBridge.aiCapability!(
-              'netcatty/jobPoll',
-              { jobId, offset },
-              sessionId,
-          ),
-        });
-      }
       const pendingHandles = ctx.toolOutputStore.listPendingHandles(sessionId);
       const sessionStateText = ctx.sessionStateStore.toReinjectionText(sessionId);
       const result = await compactCattyMessages({

--- a/infrastructure/ai/harness/twoPassCompaction.test.ts
+++ b/infrastructure/ai/harness/twoPassCompaction.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { ModelMessage } from 'ai';
+import { TwoPassCompactionCache, fingerprintMessages } from './twoPassCompaction';
+
+test('fingerprintMessages includes complete tool arguments canonically', () => {
+  const a: ModelMessage[] = [{
+    role: 'assistant',
+    content: [{ type: 'tool-call', toolCallId: '1', toolName: 'terminal_execute', input: { b: 2, a: 1 } }],
+  }];
+  const reordered: ModelMessage[] = [{
+    role: 'assistant',
+    content: [{ type: 'tool-call', toolCallId: '1', toolName: 'terminal_execute', input: { a: 1, b: 2 } }],
+  }];
+  const changed: ModelMessage[] = [{
+    role: 'assistant',
+    content: [{ type: 'tool-call', toolCallId: '1', toolName: 'terminal_execute', input: { a: 9, b: 2 } }],
+  }];
+
+  assert.equal(fingerprintMessages(a), fingerprintMessages(reordered));
+  assert.notEqual(fingerprintMessages(a), fingerprintMessages(changed));
+});
+
+test('TwoPassCompactionCache reuses only an unchanged model and prefix', async () => {
+  const cache = new TwoPassCompactionCache();
+  const messages = Array.from({ length: 20 }, (_, index) => ({
+    role: index % 2 ? 'assistant' : 'user',
+    content: `message ${index}`,
+  })) as ModelMessage[];
+  cache.start('chat-1', 'model-a', messages, async () => 'NOTE1');
+
+  const hit = await cache.consume('chat-1', 'model-a', messages);
+  assert.equal(hit?.note, 'NOTE1');
+  assert.ok((hit?.prefixLength ?? 0) < messages.length);
+  assert.equal(await cache.consume('chat-1', 'model-b', messages), undefined);
+});

--- a/infrastructure/ai/harness/twoPassCompaction.ts
+++ b/infrastructure/ai/harness/twoPassCompaction.ts
@@ -1,0 +1,95 @@
+import type { ModelMessage } from 'ai';
+import { findSafeCompactionSplitIndex } from '../contextCompaction';
+
+interface CacheEntry {
+  modelId: string;
+  prefixLength: number;
+  fingerprint: string;
+  notePromise: Promise<string>;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, canonicalize(entry)]),
+  );
+}
+
+export function fingerprintMessages(messages: ModelMessage[]): string {
+  const value = JSON.stringify(canonicalize(messages));
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+export class TwoPassCompactionCache {
+  private readonly entries = new Map<string, CacheEntry>();
+
+  start(
+    chatSessionId: string,
+    modelId: string,
+    messages: ModelMessage[],
+    producer: (prefix: ModelMessage[]) => Promise<string>,
+  ): boolean {
+    const current = this.entries.get(chatSessionId);
+    if (
+      current
+      && current.modelId === modelId
+      && messages.length >= current.prefixLength
+      && fingerprintMessages(messages.slice(0, current.prefixLength)) === current.fingerprint
+    ) {
+      return false;
+    }
+    const protectedTail = Math.max(10, Math.ceil(messages.length * 0.05));
+    const prefixLength = findSafeCompactionSplitIndex(messages, protectedTail);
+    if (prefixLength <= 0) return false;
+    const prefix = messages.slice(0, prefixLength);
+    const fingerprint = fingerprintMessages(prefix);
+    if (
+      current
+      && current.modelId === modelId
+      && current.prefixLength === prefixLength
+      && current.fingerprint === fingerprint
+    ) {
+      return false;
+    }
+    this.entries.set(chatSessionId, {
+      modelId,
+      prefixLength,
+      fingerprint,
+      notePromise: producer(prefix).then(note => note.slice(0, 12_000)).catch(() => ''),
+    });
+    return true;
+  }
+
+  async consume(
+    chatSessionId: string,
+    modelId: string,
+    messages: ModelMessage[],
+  ): Promise<{ note: string; prefixLength: number } | undefined> {
+    const entry = this.entries.get(chatSessionId);
+    if (!entry || entry.modelId !== modelId || messages.length < entry.prefixLength) {
+      this.entries.delete(chatSessionId);
+      return undefined;
+    }
+    const prefix = messages.slice(0, entry.prefixLength);
+    if (fingerprintMessages(prefix) !== entry.fingerprint) {
+      this.entries.delete(chatSessionId);
+      return undefined;
+    }
+    const note = await entry.notePromise;
+    return note ? { note, prefixLength: entry.prefixLength } : undefined;
+  }
+
+  clear(chatSessionId: string): void {
+    this.entries.delete(chatSessionId);
+  }
+}
+
+export const globalTwoPassCompactionCache = new TwoPassCompactionCache();

--- a/infrastructure/ai/harness/types.ts
+++ b/infrastructure/ai/harness/types.ts
@@ -20,6 +20,7 @@ export type AgentEventType =
   | 'performance'
   | 'model_call_start'
   | 'step_end'
+  | 'context_snapshot'
   | 'error'
   | 'turn_end';
 
@@ -41,6 +42,11 @@ export interface AgentEventBase {
 export interface TurnStartEvent extends AgentEventBase {
   type: 'turn_start';
   backendLabel?: string;
+}
+
+export interface ContextSnapshotEvent extends AgentEventBase {
+  type: 'context_snapshot';
+  snapshot: import('./promptContextSnapshot').PromptContextSnapshot;
 }
 
 export interface ModelDeltaEvent extends AgentEventBase {
@@ -119,6 +125,11 @@ export interface CompactionTrace {
   didLlmSummarize: boolean;
   did413Fallback: boolean;
   estimatorKind?: TokenEstimatorKind;
+  archiveHandleId?: string;
+  artifactHandleId?: string;
+  archiveChars?: number;
+  twoPassCacheHit?: boolean;
+  twoPassPrefixMessages?: number;
 }
 
 export interface CompactionEvent extends AgentEventBase {
@@ -180,6 +191,7 @@ export interface TurnEndEvent extends AgentEventBase {
 
 export type AgentEvent =
   | TurnStartEvent
+  | ContextSnapshotEvent
   | ModelDeltaEvent
   | ReasoningDeltaEvent
   | ToolCallEvent

--- a/infrastructure/ai/requestPayloadCompression.test.ts
+++ b/infrastructure/ai/requestPayloadCompression.test.ts
@@ -15,6 +15,20 @@ test("compressVerboseText collapses repeated blank lines and duplicate runs", ()
   assert.ok(output.split("\nsame\n").length <= 3);
 });
 
+test("compressVerboseText normalizes terminal control noise and huge payload lines", () => {
+  const ansiProgress = "\u001b[31mstarting\u001b[0m\r10%\r20%\r100%\n";
+  const longLine = "x".repeat(8_000);
+  const base64 = "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo=".repeat(100);
+  const output = compressVerboseText(`${ansiProgress}${longLine}\n${base64}`);
+
+  assert.equal(output.includes("\u001b["), false);
+  assert.doesNotMatch(output, /10%|20%/);
+  assert.match(output, /100%/);
+  assert.match(output, /long line shortened/);
+  assert.match(output, /base64-like payload omitted/);
+  assert.ok(output.length < 5_000);
+});
+
 test("truncateTextWithHeadAndTail keeps both ends of long terminal output", () => {
   const value = `${"A".repeat(500)}${"B".repeat(20_000)}${"C".repeat(500)}`;
   const truncated = truncateTextWithHeadAndTail(value, 2_000);

--- a/infrastructure/ai/requestPayloadCompression.test.ts
+++ b/infrastructure/ai/requestPayloadCompression.test.ts
@@ -29,6 +29,10 @@ test("compressVerboseText normalizes terminal control noise and huge payload lin
   assert.ok(output.length < 5_000);
 });
 
+test("compressVerboseText preserves CRLF-delimited lines", () => {
+  assert.equal(compressVerboseText("alpha\r\nbeta\r\n"), "alpha\nbeta\n");
+});
+
 test("truncateTextWithHeadAndTail keeps both ends of long terminal output", () => {
   const value = `${"A".repeat(500)}${"B".repeat(20_000)}${"C".repeat(500)}`;
   const truncated = truncateTextWithHeadAndTail(value, 2_000);

--- a/infrastructure/ai/requestPayloadCompression.ts
+++ b/infrastructure/ai/requestPayloadCompression.ts
@@ -5,6 +5,11 @@ const RETRY_MAX_MESSAGE_TEXT_CHARS = 8_000;
 const TRUNCATION_MARKER = "\n\n[... output truncated for request size ...]\n\n";
 const HEAD_CHARS = 800;
 const TAIL_CHARS = 4_000;
+const MAX_VERBOSE_LINE_CHARS = 2_000;
+// Terminal streams contain control bytes by design; these patterns remove them before model use.
+// eslint-disable-next-line no-control-regex
+const ANSI_ESCAPE_PATTERN = /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[-a-zA-Z\d/#&.:=?%@~_]+)*)?\u0007)|(?:(?:\d{1,4}(?:[;:]\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/g;
+const LARGE_BASE64_PATTERN = /(?:[A-Za-z0-9+/]{4}){125,}(?:==|=)?/g;
 
 export interface CompressMessagesForRequestTooLargeRetryResult {
   messages: ModelMessage[];
@@ -18,10 +23,15 @@ export interface CompressMessagesForRequestTooLargeRetryResult {
 export function compressVerboseText(value: string): string {
   if (!value) return value;
 
-  let compressed = value.replace(/\r\n/g, "\n");
+  let compressed = value.replace(ANSI_ESCAPE_PATTERN, "");
+  compressed = collapseCarriageReturnFrames(compressed);
+  // eslint-disable-next-line no-control-regex
+  compressed = compressed.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "");
+  compressed = compressed.replace(LARGE_BASE64_PATTERN, match => `[base64-like payload omitted: ${match.length} chars]`);
+  compressed = compressed.replace(/\r\n/g, "\n");
   compressed = compressed.replace(/\n{4,}/g, "\n\n\n");
 
-  const lines = compressed.split("\n");
+  const lines = compressed.split("\n").map(shortenVerboseLine);
   const deduped: string[] = [];
   let repeatCount = 0;
   for (const line of lines) {
@@ -36,6 +46,30 @@ export function compressVerboseText(value: string): string {
   }
 
   return deduped.join("\n");
+}
+
+function collapseCarriageReturnFrames(value: string): string {
+  if (!value.includes("\r")) return value;
+  const output: string[] = [];
+  let current = "";
+  for (const char of value) {
+    if (char === "\r") {
+      current = "";
+    } else if (char === "\n") {
+      output.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  output.push(current);
+  return output.join("\n");
+}
+
+function shortenVerboseLine(line: string): string {
+  if (line.length <= MAX_VERBOSE_LINE_CHARS) return line;
+  const edge = Math.floor((MAX_VERBOSE_LINE_CHARS - 80) / 2);
+  return `${line.slice(0, edge)}[... long line shortened: ${line.length} chars ...]${line.slice(-edge)}`;
 }
 
 export function truncateTextWithHeadAndTail(
@@ -91,7 +125,7 @@ export function compressMessagesForRequestTooLargeRetry(
 function compressModelMessageForRequestRetry(message: ModelMessage): ModelMessage {
   if (typeof message.content === "string") {
     const content = compressAndTruncateText(message.content, RETRY_MAX_MESSAGE_TEXT_CHARS);
-    return content === message.content ? message : { ...message, content };
+    return content === message.content ? message : ({ ...message, content } as ModelMessage);
   }
 
   if (!Array.isArray(message.content)) return message;
@@ -103,7 +137,7 @@ function compressModelMessageForRequestRetry(message: ModelMessage): ModelMessag
     return compressed;
   });
 
-  return didAdjust ? { ...message, content } : message;
+  return didAdjust ? ({ ...message, content } as ModelMessage) : message;
 }
 
 function compressContentPartForRequestRetry(part: unknown): unknown {

--- a/infrastructure/ai/requestPayloadCompression.ts
+++ b/infrastructure/ai/requestPayloadCompression.ts
@@ -24,11 +24,11 @@ export function compressVerboseText(value: string): string {
   if (!value) return value;
 
   let compressed = value.replace(ANSI_ESCAPE_PATTERN, "");
+  compressed = compressed.replace(/\r\n/g, "\n");
   compressed = collapseCarriageReturnFrames(compressed);
   // eslint-disable-next-line no-control-regex
   compressed = compressed.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "");
   compressed = compressed.replace(LARGE_BASE64_PATTERN, match => `[base64-like payload omitted: ${match.length} chars]`);
-  compressed = compressed.replace(/\r\n/g, "\n");
   compressed = compressed.replace(/\n{4,}/g, "\n\n\n");
 
   const lines = compressed.split("\n").map(shortenVerboseLine);

--- a/infrastructure/ai/shared/toolExecutors.ts
+++ b/infrastructure/ai/shared/toolExecutors.ts
@@ -19,7 +19,7 @@ import { executeWebSearchProvider } from './webSearchProviders';
 /** Discriminated union returned by every shared executor. */
 export type ToolExecResult<T = unknown> =
   | { ok: true; data: T }
-  | { ok: false; error: string };
+  | { ok: false; error: string; data?: T };
 
 // ---------------------------------------------------------------------------
 // Dependencies bundle
@@ -96,10 +96,15 @@ export async function executeTerminalExecute(
   const result = await bridge.aiExec(sessionId, command, deps.chatSessionId);
   // Real execution failures (timeout, disconnect, no stream) have an `error` field
   if (!result.ok && result.error) {
-    const parts = [result.error];
-    if (result.stdout) parts.push(`Partial output:\n${result.stdout}`);
-    if (result.stderr) parts.push(`Stderr:\n${result.stderr}`);
-    return { ok: false, error: parts.join('\n\n') };
+    return {
+      ok: false,
+      error: result.error,
+      data: {
+        stdout: result.stdout || '',
+        stderr: result.stderr || '',
+        exitCode: isNetworkDevice ? (result.exitCode ?? null) : (result.exitCode ?? -1),
+      },
+    };
   }
   // Command ran (even if exit code is non-zero) — always return stdout+exitCode for LLM to judge.
   // Network device / serial sessions return exitCode: null because vendor CLIs don't expose

--- a/types/global/netcatty-bridge-files.d.ts
+++ b/types/global/netcatty-bridge-files.d.ts
@@ -62,6 +62,14 @@ declare global {
     clearTempDir?(): Promise<{ deletedCount: number; failedCount: number; error?: string }>;
     getTempDirPath?(): Promise<string>;
     openTempDir?(): Promise<{ success: boolean }>;
+    writeToolOutputTemp?(handleId: string, content: string): Promise<{ ok: boolean; path?: string; error?: string }>;
+    readToolOutputTemp?(filePath: string, request?: {
+      mode?: 'head' | 'tail' | 'full' | 'range' | 'search';
+      maxChars?: number;
+      offset?: number;
+      query?: string;
+    }): Promise<unknown | null>;
+    deleteToolOutputTemp?(filePath: string): Promise<{ ok: boolean }>;
 
     // Session Logs
     exportSessionLog?(payload: {


### PR DESCRIPTION
## What changed

- Bound terminal command, polling, and failure output before it enters Catty's model context, while keeping the full result available through paged local handles.
- Add per-turn read quotas, expiry, secure spill-to-disk, session cleanup, and duplicate-read protection for saved tool output.
- Make request-too-large recovery safe after terminal side effects, including exact replay of completed commands and background jobs.
- Strengthen context compaction with secret redaction, integrity repair, reusable two-pass summaries, snapshots, and compact activity restoration.
- Document the Grok CLI source study and the resulting Netcatty comparison and recommendations.

## Why

Terminal output is unbounded and can fill the context window in a single tool call. Failures, long-running monitors, repeated reads, and request retries were especially risky because they could either re-inject the same output or repeat a command with side effects. This change makes those paths bounded and recoverable without losing access to the original output.

## User impact

Catty should remain responsive during noisy terminal sessions, recover more reliably when a model request is too large, avoid repeating terminal actions during recovery, and retain useful history without exposing saved secrets to the model.

## Verification

- `node --import tsx --test infrastructure/ai/harness/*.test.ts infrastructure/ai/harness/turnDrivers/*.test.ts infrastructure/ai/*.test.ts` (329 passed)
- `node --test electron/bridges/tempDirBridge.test.cjs` (5 passed)
- `npm run lint -- --quiet`
- `npm run build`
- `git diff --check origin/main...HEAD`

The full repository suite still has one unrelated pre-existing SSH authentication retry failure; all tests covering this change pass.
