### PR TITLE
perf(terminal): coalesce network-dribbled output bursts

### DIFF
--- a/electron/bridges/ptyOutputBuffer.cjs
+++ b/electron/bridges/ptyOutputBuffer.cjs
@@ -23,6 +23,8 @@
  *   maxBufferSize?: number,
  *   shouldAcceptOutput?: () => boolean,
  *   floodFlushDelayMs?: number,
+ *   burstCoalesceDelayMs?: number,
+ *   burstDetectionWindowMs?: number,
  *   maxFloodBufferSize?: number,
  *   maxPendingBytes?: number,
  *   onPendingBytesChange?: (bytes: number) => void,
@@ -39,6 +41,11 @@ function createPtyOutputBuffer(sendFn, options = {}) {
     options.maxPendingBytes ?? defaultMaxPendingBytes,
   );
   const floodFlushDelayMs = options.floodFlushDelayMs ?? 1;
+  const burstCoalesceDelayMs = Math.max(0, options.burstCoalesceDelayMs ?? 3);
+  const burstDetectionWindowMs = Math.max(
+    burstCoalesceDelayMs,
+    options.burstDetectionWindowMs ?? 8,
+  );
   const maxDroppedStateScanBytes = Math.max(256, options.maxDroppedStateScanBytes ?? 2048);
   const shouldAcceptOutput = options.shouldAcceptOutput ?? (() => true);
   const onPendingBytesChange = typeof options.onPendingBytesChange === "function"
@@ -50,6 +57,7 @@ function createPtyOutputBuffer(sendFn, options = {}) {
   let pendingBytes = 0;
   let scheduled = null;
   let scheduledType = null;
+  let lastOutputArrivalAt = null;
   let nextSendMeta = null;
   const drainCallbacks = [];
 
@@ -376,6 +384,12 @@ function createPtyOutputBuffer(sendFn, options = {}) {
     scheduled = setImmediate(flushNow);
   };
 
+  const scheduleBurstFlush = () => {
+    if (scheduled) return;
+    scheduledType = "burst";
+    scheduled = setTimeout(flushNow, burstCoalesceDelayMs);
+  };
+
   const scheduleFloodFlush = () => {
     if (scheduledType === "flood") return;
     cancelScheduled();
@@ -384,6 +398,12 @@ function createPtyOutputBuffer(sendFn, options = {}) {
   };
 
   const bufferData = (data, meta) => {
+    const arrivedAt = Date.now();
+    const followsRecentOutput = data.length > 0
+      && lastOutputArrivalAt !== null
+      && arrivedAt - lastOutputArrivalAt >= 0
+      && arrivedAt - lastOutputArrivalAt <= burstDetectionWindowMs;
+    if (data.length > 0) lastOutputArrivalAt = arrivedAt;
     mergeNextSendMeta(meta);
     appendBoundedData(data);
     if (!shouldAcceptOutput()) {
@@ -398,11 +418,19 @@ function createPtyOutputBuffer(sendFn, options = {}) {
     } else if (dataBuffer.length >= maxBufferSize) {
       scheduleFloodFlush();
     } else if (!scheduled) {
-      scheduleTurnFlush();
+      // Forward the first output immediately. If more network chunks arrive in
+      // adjacent turns, hold only the continuation for a couple of milliseconds
+      // so one remote burst does not fan out into hundreds of IPC messages.
+      if (followsRecentOutput && burstCoalesceDelayMs > 0) {
+        scheduleBurstFlush();
+      } else {
+        scheduleTurnFlush();
+      }
     }
   };
 
   const flush = () => {
+    lastOutputArrivalAt = null;
     cancelScheduled();
     flushNow();
   };
@@ -461,6 +489,7 @@ function createPtyOutputBuffer(sendFn, options = {}) {
   };
 
   const takePendingEntry = () => {
+    lastOutputArrivalAt = null;
     cancelScheduled();
     const pending = `${queuedBuffers.join("")}${dataBuffer}`;
     const meta = takeNextSendMeta();
@@ -477,6 +506,7 @@ function createPtyOutputBuffer(sendFn, options = {}) {
   };
 
   const discard = () => {
+    lastOutputArrivalAt = null;
     cancelScheduled();
     const discardedBytes = clearPendingBuffers();
     nextSendMeta = null;

--- a/electron/bridges/ptyOutputBuffer.test.cjs
+++ b/electron/bridges/ptyOutputBuffer.test.cjs
@@ -16,6 +16,58 @@ const waitFor = async (predicate, timeoutMs = 100) => {
   }
 };
 
+const withFakeOutputScheduler = (run) => {
+  const originalSetImmediate = global.setImmediate;
+  const originalClearImmediate = global.clearImmediate;
+  const originalSetTimeout = global.setTimeout;
+  const originalClearTimeout = global.clearTimeout;
+  const originalDateNow = Date.now;
+  const immediates = [];
+  const timers = [];
+  let now = 0;
+
+  global.setImmediate = (callback) => {
+    const handle = { callback, cleared: false };
+    immediates.push(handle);
+    return handle;
+  };
+  global.clearImmediate = (handle) => {
+    if (handle) handle.cleared = true;
+  };
+  global.setTimeout = (callback, ms) => {
+    const handle = { callback, ms, dueAt: now + ms, cleared: false };
+    timers.push(handle);
+    return handle;
+  };
+  global.clearTimeout = (handle) => {
+    if (handle) handle.cleared = true;
+  };
+  Date.now = () => now;
+
+  try {
+    return run({
+      immediates,
+      timers,
+      setNow(value) { now = value; },
+      advance(ms) {
+        now += ms;
+        for (const timer of timers) {
+          if (!timer.cleared && timer.dueAt <= now) {
+            timer.cleared = true;
+            timer.callback();
+          }
+        }
+      },
+    });
+  } finally {
+    global.setImmediate = originalSetImmediate;
+    global.clearImmediate = originalClearImmediate;
+    global.setTimeout = originalSetTimeout;
+    global.clearTimeout = originalClearTimeout;
+    Date.now = originalDateNow;
+  }
+};
+
 test("coalesces data buffered within the same turn into a single send", async () => {
   const sends = [];
   const buffer = createPtyOutputBuffer((data) => sends.push(data));
@@ -43,6 +95,66 @@ test("flushes within a single event-loop turn (not on a fixed delay)", async () 
   await tick();
 
   assert.deepEqual(sends, ["x"]);
+});
+
+test("coalesces network-dribbled bursts after forwarding the first chunk immediately", () => {
+  const sends = [];
+  withFakeOutputScheduler(({ immediates, timers, setNow }) => {
+    const buffer = createPtyOutputBuffer((data) => sends.push(data));
+
+    buffer.bufferData("Reading database ... 1%");
+    immediates.shift().callback();
+    assert.deepEqual(sends, ["Reading database ... 1%"]);
+
+    setNow(1);
+    buffer.bufferData("\rReading database ... 2%");
+    setNow(2);
+    buffer.bufferData("\rReading database ... 3%");
+
+    assert.deepEqual(sends, ["Reading database ... 1%"]);
+    assert.equal(timers.length, 1);
+    assert.ok(timers[0].ms > 0 && timers[0].ms <= 4);
+
+    timers[0].callback();
+    assert.deepEqual(sends, [
+      "Reading database ... 1%",
+      "\rReading database ... 2%\rReading database ... 3%",
+    ]);
+
+    setNow(20);
+    buffer.bufferData("prompt after idle");
+    assert.equal(immediates.length, 1);
+    immediates.shift().callback();
+    assert.equal(sends.at(-1), "prompt after idle");
+  });
+});
+
+test("cuts IPC sends for a 1ms network-dribbled apt-style burst", () => {
+  let sends = 0;
+  let output = "";
+  withFakeOutputScheduler(({ immediates, advance }) => {
+    const buffer = createPtyOutputBuffer((data) => {
+      sends += 1;
+      output += data;
+    });
+    const chunks = Array.from({ length: 1031 }, (_, index) => (
+      index % 2 === 0
+        ? `\rReading database ... ${index % 101}%`
+        : `Preparing package-${index} for upgrade\n`
+    ));
+
+    for (const chunk of chunks) {
+      buffer.bufferData(chunk);
+      for (const immediate of immediates.splice(0)) {
+        if (!immediate.cleared) immediate.callback();
+      }
+      advance(1);
+    }
+    buffer.flush();
+
+    assert.equal(output, chunks.join(""));
+    assert.ok(sends <= 350, `expected at most 350 IPC sends, got ${sends}`);
+  });
 });
 
 test("paces size-cap flushes with a short flood delay", () => {
@@ -472,7 +584,7 @@ test("keeps batching after a flush", async () => {
   await tick();
 
   buffer.bufferData("second");
-  await tick();
+  await waitFor(() => sends.length === 2);
 
   assert.deepEqual(sends, ["first", "second"]);
 });


### PR DESCRIPTION
## What changed

- Forward the first terminal output chunk immediately.
- When more chunks arrive within the same short burst, coalesce continuations for up to 3 ms before crossing IPC.
- Keep the existing immediate/paced behavior for isolated output and large floods.
- Add deterministic regression and throughput tests using an apt-style 1031-chunk corpus.

## Why

Network-dribbled SSH output currently defeats turn-based coalescing: each tiny chunk can land in a separate event-loop turn and fan out across the process boundary. That makes apt/dpkg progress output pay the full renderer stack hundreds of times.

The adaptive window preserves first-output latency while reducing repeated work during an active burst.

## Validation

- Deterministic apt-style test: 1031 one-millisecond chunks produce at most 350 sends with byte-for-byte identical output.
- Local fast-dribble benchmark: 1031 sends before, 7-8 after across five runs.
- Real SSH benchmark on a remote Linux server, five runs: average sends fell from about 524 to 224 (about 57%) with identical 30,320-byte output.
- Focused flow/output tests: 25 consecutive runs passed.
- Focused ESLint passed.
- Production build passed.
- Full suite: 5699 passed, 7 skipped, 1 unrelated existing SSH auth-retry test failed; the same test also fails on unchanged main.

Refs #2272