### PR TITLE
fix(mosh): require MoshCatty 0.1.8

### DIFF
--- a/resources/mosh/README.md
+++ b/resources/mosh/README.md
@@ -18,7 +18,7 @@ Netcatty runs SSH + `mosh-server` bootstrap itself, then launches this binary
 Each tarball contains **only** the client binary (no Cygwin DLLs, no terminfo).
 Windows builds static-link the MSVC CRT (`moshcatty-0.1.1+`).
 
-Release tags: `moshcatty-*` (require `moshcatty-0.1.7+`) from
+Release tags: `moshcatty-*` (require `moshcatty-0.1.8+`) from
 `binaricat/MoshCatty`, with `SHA256SUMS`.
 
 ### Linux glibc floors
@@ -37,8 +37,8 @@ were built on Ubuntu runners and require GLIBC 2.34.
 ## Fetch
 
 ```sh
-# Optional pin (0.1.7+ reconstructs parallel remote states before display)
-export MOSH_BIN_RELEASE=moshcatty-0.1.7
+# Optional pin (0.1.8+ disables unsafe local backspace prediction)
+export MOSH_BIN_RELEASE=moshcatty-0.1.8
 npm run fetch:mosh
 
 # Dev: host platform; resolves latest moshcatty-* if unset

--- a/scripts/fetch-mosh-binaries.cjs
+++ b/scripts/fetch-mosh-binaries.cjs
@@ -313,10 +313,10 @@ async function main(argv = process.argv.slice(2), env = process.env) {
     release = await resolveMoshBinRelease(env);
   }
   if (!release) {
-    log("MOSH_BIN_RELEASE is unset - skipping. Set it (e.g. moshcatty-0.1.7) to bundle mosh-client into the package.");
+    log("MOSH_BIN_RELEASE is unset - skipping. Set it (e.g. moshcatty-0.1.8) to bundle mosh-client into the package.");
     return 0;
   }
-  // Reject pre-0.1.7 pins (missing numbered-state reconstruction for #2121) even when MOSH_BIN_RELEASE is set
+  // Reject pre-0.1.8 pins (unsafe local backspace prediction for #2275) even when MOSH_BIN_RELEASE is set
   // without going through --resolve-release.
   release = validateReleaseTag(release);
 

--- a/scripts/fetch-mosh-binaries.test.cjs
+++ b/scripts/fetch-mosh-binaries.test.cjs
@@ -138,7 +138,7 @@ test("fetch-mosh-binaries host mode skips unsupported local targets", async (t) 
     {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.7",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.8",
         MOSH_BIN_BASE_URL: baseUrl,
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",
@@ -151,20 +151,20 @@ test("fetch-mosh-binaries host mode skips unsupported local targets", async (t) 
   assert.equal(fs.existsSync(resDir), false);
 });
 
-test("fetch-mosh-binaries rejects MoshCatty releases before 0.1.7", async (t) => {
+test("fetch-mosh-binaries rejects MoshCatty releases before 0.1.8", async (t) => {
   const resDir = path.join(makeTmp(t), "resources", "mosh");
 
   await assert.rejects(
     execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.6",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.7",
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",
       },
       stdio: "pipe",
     }),
-    /below minimum moshcatty-0\.1\.7/,
+    /below minimum moshcatty-0\.1\.8/,
   );
   assert.equal(fs.existsSync(resDir), false);
 });
@@ -182,7 +182,7 @@ test("fetch-mosh-binaries unpacks pure Windows MoshCatty tarball", async (t) => 
   await execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
     env: {
       ...process.env,
-      MOSH_BIN_RELEASE: "moshcatty-0.1.7",
+      MOSH_BIN_RELEASE: "moshcatty-0.1.8",
       MOSH_BIN_BASE_URL: baseUrl,
       MOSH_BIN_RES_DIR: resDir,
       CI: "true",
@@ -213,7 +213,7 @@ test("fetch-mosh-binaries strips accidental dll/terminfo from Windows tarball", 
   await execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
     env: {
       ...process.env,
-      MOSH_BIN_RELEASE: "moshcatty-0.1.7",
+      MOSH_BIN_RELEASE: "moshcatty-0.1.8",
       MOSH_BIN_BASE_URL: baseUrl,
       MOSH_BIN_RES_DIR: resDir,
       CI: "true",
@@ -239,7 +239,7 @@ test("fetch-mosh-binaries unpacks pure Linux MoshCatty tarball", async (t) => {
   await execFileAsync(process.execPath, [script, "--platform=linux", "--arch=x64"], {
     env: {
       ...process.env,
-      MOSH_BIN_RELEASE: "moshcatty-0.1.7",
+      MOSH_BIN_RELEASE: "moshcatty-0.1.8",
       MOSH_BIN_BASE_URL: baseUrl,
       MOSH_BIN_RES_DIR: resDir,
       CI: "true",
@@ -265,7 +265,7 @@ test("fetch-mosh-binaries rejects tarball without mosh-client", async (t) => {
     execFileAsync(process.execPath, [script, "--platform=linux", "--arch=x64"], {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.7",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.8",
         MOSH_BIN_BASE_URL: baseUrl,
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",
@@ -288,7 +288,7 @@ test("fetch-mosh-binaries fails when SHA256SUMS lacks the asset", async (t) => {
     execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.7",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.8",
         MOSH_BIN_BASE_URL: baseUrl,
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",
@@ -316,7 +316,7 @@ test("fetch-mosh-binaries rejects symlinks inside tarballs", { skip: process.pla
     execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.7",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.8",
         MOSH_BIN_BASE_URL: baseUrl,
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",

--- a/scripts/resolve-mosh-bin-release.cjs
+++ b/scripts/resolve-mosh-bin-release.cjs
@@ -14,13 +14,14 @@ const fs = require("node:fs");
 const https = require("node:https");
 
 // MoshCatty pure-Rust releases only.
-// Minimum 0.1.7: reconstruct numbered remote states before display, preventing
-// duplicate characters when parallel updates share a base on high-RTT links.
-// 0.1.6 added prediction hardening; 0.1.5 introduced the Diff path.
+// Minimum 0.1.8: disable local backspace prediction until the host confirms
+// the resulting screen, preventing stale cursor/character display on latency.
+// 0.1.7 reconstructed numbered remote states before display; 0.1.6 added
+// prediction hardening; 0.1.5 introduced the Diff path.
 // 0.1.4 ConPTY shortcut; 0.1.2+ Linux glibc floors match Netcatty.
 // Allow semver prerelease (-rc1) and build metadata (+meta); no path separators.
 const TAG_RE = /^moshcatty-[A-Za-z0-9._+-]+$/;
-const MIN_VERSION = { major: 0, minor: 1, patch: 7 };
+const MIN_VERSION = { major: 0, minor: 1, patch: 8 };
 const MIN_TAG = `moshcatty-${MIN_VERSION.major}.${MIN_VERSION.minor}.${MIN_VERSION.patch}`;
 
 function log(msg) {
@@ -73,8 +74,8 @@ function validateReleaseTag(tag) {
   if (!isAtLeastMinRelease(value)) {
     throw new Error(
       `mosh binary release ${value} is below minimum ${MIN_TAG} `
-        + "(0.1.7 fixes duplicate display on high-latency parallel state updates; "
-        + "prereleases of the floor e.g. 0.1.7-rc1 are not accepted)",
+        + "(0.1.8 disables unsafe local backspace prediction; "
+        + "prereleases of the floor e.g. 0.1.8-rc1 are not accepted)",
     );
   }
   return value;

--- a/scripts/resolve-mosh-bin-release.test.cjs
+++ b/scripts/resolve-mosh-bin-release.test.cjs
@@ -22,10 +22,10 @@ function makeTmp(t) {
 }
 
 test("validateReleaseTag accepts only moshcatty-* tags at min version", () => {
-  assert.equal(validateReleaseTag("moshcatty-0.1.7"), "moshcatty-0.1.7");
+  assert.equal(validateReleaseTag("moshcatty-0.1.8"), "moshcatty-0.1.8");
   assert.equal(validateReleaseTag("moshcatty-0.2.0"), "moshcatty-0.2.0");
-  assert.equal(validateReleaseTag("moshcatty-0.1.8-rc1"), "moshcatty-0.1.8-rc1");
-  assert.equal(validateReleaseTag("moshcatty-0.1.7+build.1"), "moshcatty-0.1.7+build.1");
+  assert.equal(validateReleaseTag("moshcatty-0.1.9-rc1"), "moshcatty-0.1.9-rc1");
+  assert.equal(validateReleaseTag("moshcatty-0.1.8+build.1"), "moshcatty-0.1.8+build.1");
   assert.throws(() => validateReleaseTag("mosh-bin-1.4.0-1"), /invalid mosh binary release tag/);
   assert.throws(() => validateReleaseTag("v1.2.3"), /invalid mosh binary release tag/);
   assert.throws(() => validateReleaseTag("moshcatty-../bad"), /invalid mosh binary release tag/);
@@ -37,21 +37,22 @@ test("validateReleaseTag accepts only moshcatty-* tags at min version", () => {
   assert.throws(() => validateReleaseTag("moshcatty-0.1.4"), /below minimum/);
   assert.throws(() => validateReleaseTag("moshcatty-0.1.5"), /below minimum/);
   assert.throws(() => validateReleaseTag("moshcatty-0.1.6"), /below minimum/);
-  assert.throws(() => validateReleaseTag("moshcatty-0.1.7-rc1"), /below minimum/);
+  assert.throws(() => validateReleaseTag("moshcatty-0.1.7"), /below minimum/);
+  assert.throws(() => validateReleaseTag("moshcatty-0.1.8-rc1"), /below minimum/);
 });
 
-test("isAtLeastMinRelease enforces moshcatty-0.1.7 floor with semver prerelease rules", () => {
-  assert.equal(MIN_TAG, "moshcatty-0.1.7");
+test("isAtLeastMinRelease enforces moshcatty-0.1.8 floor with semver prerelease rules", () => {
+  assert.equal(MIN_TAG, "moshcatty-0.1.8");
   assert.equal(isAtLeastMinRelease("moshcatty-0.1.3"), false);
   assert.equal(isAtLeastMinRelease("moshcatty-0.1.4"), false);
   assert.equal(isAtLeastMinRelease("moshcatty-0.1.5"), false);
   assert.equal(isAtLeastMinRelease("moshcatty-0.1.6"), false);
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.7"), true);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.7"), false);
   // Prerelease of the floor sorts below the final floor release.
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.7-rc1"), false);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.8-rc1"), false);
   // Above the floor, prereleases are fine.
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.8-rc1"), true);
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.7+build.1"), true);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.9-rc1"), true);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.8+build.1"), true);
   assert.equal(isAtLeastMinRelease("moshcatty-not-a-version"), false);
 });
 
@@ -67,18 +68,19 @@ test("parseRepository defaults to binaricat/MoshCatty (ignores GITHUB_REPOSITORY
   );
 });
 
-test("pickLatestMoshBinRelease ignores non-moshcatty and pre-0.1.7 tags", () => {
+test("pickLatestMoshBinRelease ignores non-moshcatty and pre-0.1.8 tags", () => {
   const got = pickLatestMoshBinRelease([
     { tag_name: "v1.0.0", published_at: "2026-03-01T00:00:00Z" },
     { tag_name: "mosh-bin-1.4.0-2", published_at: "2026-06-01T00:00:00Z" },
-    { tag_name: "moshcatty-0.1.7", draft: true, published_at: "2026-07-13T00:00:00Z" },
+    { tag_name: "moshcatty-0.1.8", draft: true, published_at: "2026-07-13T00:00:00Z" },
     { tag_name: "moshcatty-0.1.2", published_at: "2026-07-10T00:00:00Z" },
     { tag_name: "moshcatty-0.1.5", published_at: "2026-07-10T13:00:00Z" },
     { tag_name: "moshcatty-0.1.6", published_at: "2026-07-13T01:00:00Z" },
     { tag_name: "moshcatty-0.1.7", published_at: "2026-07-14T01:00:00Z" },
+    { tag_name: "moshcatty-0.1.8", published_at: "2026-07-17T01:00:00Z" },
   ]);
 
-  assert.equal(got, "moshcatty-0.1.7");
+  assert.equal(got, "moshcatty-0.1.8");
 });
 
 test("parseNextLink reads the next GitHub pagination URL", () => {
@@ -131,17 +133,17 @@ test("main keeps an explicit MOSH_BIN_RELEASE and exports it", async (t) => {
   const githubEnv = path.join(makeTmp(t), "github-env");
 
   const got = await main({
-    MOSH_BIN_RELEASE: "moshcatty-0.1.7",
+    MOSH_BIN_RELEASE: "moshcatty-0.1.8",
     GITHUB_ENV: githubEnv,
   });
 
-  assert.equal(got, "moshcatty-0.1.7");
-  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=moshcatty-0.1.7\n");
+  assert.equal(got, "moshcatty-0.1.8");
+  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=moshcatty-0.1.8\n");
 });
 
-test("main rejects explicit pre-0.1.7 MOSH_BIN_RELEASE", async () => {
+test("main rejects explicit pre-0.1.8 MOSH_BIN_RELEASE", async () => {
   await assert.rejects(
-    main({ MOSH_BIN_RELEASE: "moshcatty-0.1.6" }),
+    main({ MOSH_BIN_RELEASE: "moshcatty-0.1.7" }),
     /below minimum/,
   );
 });
@@ -156,12 +158,13 @@ test("main resolves the latest moshcatty release from the list and exports it", 
       { tag_name: "moshcatty-0.1.5", published_at: "2026-07-10T13:00:00Z" },
       { tag_name: "moshcatty-0.1.6", published_at: "2026-07-13T01:00:00Z" },
       { tag_name: "moshcatty-0.1.7", published_at: "2026-07-14T01:00:00Z" },
+      { tag_name: "moshcatty-0.1.8", published_at: "2026-07-17T01:00:00Z" },
       { tag_name: "mosh-bin-1.4.0-2", published_at: "2026-08-01T00:00:00Z" },
     ]),
   });
 
-  assert.equal(got, "moshcatty-0.1.7");
-  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=moshcatty-0.1.7\n");
+  assert.equal(got, "moshcatty-0.1.8");
+  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=moshcatty-0.1.8\n");
 });
 
 test("main fails when no usable moshcatty release exists", async () => {
@@ -172,7 +175,8 @@ test("main fails when no usable moshcatty release exists", async () => {
         { tag_name: "mosh-bin-1.4.0-1", published_at: "2026-02-01T00:00:00Z" },
         { tag_name: "moshcatty-0.1.5", published_at: "2026-02-01T00:00:00Z" },
         { tag_name: "moshcatty-0.1.6", published_at: "2026-02-01T00:00:00Z" },
-        { tag_name: "moshcatty-0.1.7", draft: true, published_at: "2026-02-01T00:00:00Z" },
+        { tag_name: "moshcatty-0.1.7", published_at: "2026-02-01T00:00:00Z" },
+        { tag_name: "moshcatty-0.1.8", draft: true, published_at: "2026-02-01T00:00:00Z" },
       ]),
     }),
     /could not find/,


### PR DESCRIPTION
## What changed

- Require MoshCatty 0.1.8 or newer when resolving and downloading bundled Mosh binaries.
- Reject manual pins to 0.1.7 and earlier so packaging cannot bypass the fix.
- Update tests and bundled-binary documentation for the new minimum version.

## Why

MoshCatty 0.1.8 removes unsafe local backspace prediction and waits for the remote host to confirm the resulting screen. Older binaries can temporarily render cursor movement past the prompt under latency, which is the behavior reported in #2275.

## User impact

Future Netcatty builds will bundle a Mosh client that no longer locally echoes backspace movement before the server confirms it.

## Validation

- Verified the published `moshcatty-0.1.8` release and all platform assets.
- Downloaded and checksum-verified the real macOS universal asset through Netcatty's fetch flow; the binary starts successfully.
- 24 focused release-resolution and download tests pass.
- ESLint passes.
- Production build passes.
- Full suite: 5,771 passed, 7 skipped, 1 unrelated existing SSH authentication test fails consistently.
- Two independent code reviews found no blocking issues.

Closes #2275
