### PR TITLE
Persist Catty saved outputs across app restarts

### DIFF
--- a/application/state/aiStateSnapshots.test.ts
+++ b/application/state/aiStateSnapshots.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  cleanupClosedTerminalSessions,
+  cleanupDeletedAIChatSessions,
+  cleanupSdkAgentSessions,
+} from './aiStateSnapshots';
+
+test('orphan cleanup keeps durable Catty output while explicit deletion removes it', async () => {
+  const sdkCleanups: string[] = [];
+  const outputCleanups: string[] = [];
+  const terminalOutputCleanups: string[] = [];
+  const previousWindow = globalThis.window;
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      netcatty: {
+        aiSdkAgentCleanup: async (chatSessionId: string) => {
+          sdkCleanups.push(chatSessionId);
+          return { ok: true };
+        },
+        deleteChatToolOutputsTemp: async (chatSessionId: string) => {
+          outputCleanups.push(chatSessionId);
+          return { deletedCount: 1 };
+        },
+        deleteTerminalToolOutputsEverywhereTemp: async (terminalSessionId: string) => {
+          terminalOutputCleanups.push(terminalSessionId);
+          return { deletedCount: 1 };
+        },
+      },
+    },
+  });
+
+  try {
+    cleanupSdkAgentSessions(['history-kept']);
+    cleanupDeletedAIChatSessions(['history-deleted']);
+    cleanupClosedTerminalSessions(['terminal-closed', 'terminal-closed']);
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    assert.deepEqual(sdkCleanups, ['history-kept', 'history-deleted']);
+    assert.deepEqual(outputCleanups, ['history-deleted']);
+    assert.deepEqual(terminalOutputCleanups, ['terminal-closed']);
+  } finally {
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: previousWindow,
+    });
+  }
+});

--- a/application/state/aiStateSnapshots.ts
+++ b/application/state/aiStateSnapshots.ts
@@ -20,10 +20,13 @@ import {
   pruneInactiveScopedTransientState,
 } from './aiScopeCleanup';
 import { emitAIStateChanged } from './aiStateEvents';
+import { getAgentRuntime } from '../../infrastructure/ai/harness/globalAgentRuntime';
 
 /** Typed accessor for the Electron IPC bridge exposed on `window.netcatty`. */
 export interface AIBridge {
   aiSdkAgentCleanup?: (chatSessionId: string) => Promise<{ ok: boolean }>;
+  deleteChatToolOutputsTemp?: (chatSessionId: string) => Promise<{ deletedCount: number }>;
+  deleteTerminalToolOutputsEverywhereTemp?: (terminalSessionId: string) => Promise<{ deletedCount: number }>;
   aiMcpSetPermissionMode?: (mode: AIPermissionMode) => Promise<unknown> | unknown;
   aiMcpSetToolIntegrationMode?: (mode: AIToolIntegrationMode) => Promise<unknown> | unknown;
   aiMcpSetCommandBlocklist?: (blocklist: string[]) => Promise<unknown> | unknown;
@@ -44,9 +47,27 @@ export type PanelViewByScope = Partial<Record<string, AIPanelView>>;
 
 export function cleanupSdkAgentSessions(sessionIds: string[]) {
   const bridge = getAIBridge();
-  if (!bridge?.aiSdkAgentCleanup || sessionIds.length === 0) return;
+  if (sessionIds.length === 0) return;
   for (const sessionId of sessionIds) {
-    void bridge.aiSdkAgentCleanup(sessionId).catch(() => {});
+    void bridge?.aiSdkAgentCleanup?.(sessionId).catch(() => {});
+  }
+}
+
+export function cleanupDeletedAIChatSessions(sessionIds: string[]) {
+  const bridge = getAIBridge();
+  if (sessionIds.length === 0) return;
+  for (const sessionId of sessionIds) {
+    getAgentRuntime().clearChatSession(sessionId);
+    void bridge?.aiSdkAgentCleanup?.(sessionId).catch(() => {});
+    void bridge?.deleteChatToolOutputsTemp?.(sessionId).catch(() => {});
+  }
+}
+
+export function cleanupClosedTerminalSessions(terminalSessionIds: string[]) {
+  const bridge = getAIBridge();
+  for (const terminalSessionId of new Set(terminalSessionIds)) {
+    getAgentRuntime().clearTerminalSession(terminalSessionId);
+    void bridge?.deleteTerminalToolOutputsEverywhereTemp?.(terminalSessionId).catch(() => {});
   }
 }
 

--- a/application/state/useAIState.ts
+++ b/application/state/useAIState.ts
@@ -49,12 +49,14 @@ import {
 } from './aiDraftState';
 import { convertFilesToUploads } from './useFileUpload';
 import { removeProviderReferences } from './aiProviderCleanup';
+import { getAgentRuntime } from '../../infrastructure/ai/harness/globalAgentRuntime';
 
 import {
   AI_STATE_CHANGED_DRAFTS_BY_SCOPE,
   AI_STATE_CHANGED_PANEL_VIEW_BY_SCOPE,
   bumpDraftMutationVersion,
   bumpDraftUploadGeneration,
+  cleanupDeletedAIChatSessions,
   cleanupSdkAgentSessions,
   cleanupOrphanedAISessions,
   getAIBridge,
@@ -620,7 +622,7 @@ export function useAIState() {
   }, [defaultAgentId, persistSessions, setActiveSessionId]);
 
   const deleteSession = useCallback((sessionId: string, scopeKey?: string) => {
-    cleanupSdkAgentSessions([sessionId]);
+    cleanupDeletedAIChatSessions([sessionId]);
     if (persistTimerRef.current) {
       clearTimeout(persistTimerRef.current);
       persistTimerRef.current = null;
@@ -662,7 +664,7 @@ export function useAIState() {
     const removedSessionIds = sessionsRef.current
       .filter(s => s.scope.type === scopeType && s.scope.targetId === targetId)
       .map(s => s.id);
-    cleanupSdkAgentSessions(removedSessionIds);
+    cleanupDeletedAIChatSessions(removedSessionIds);
     if (persistTimerRef.current) {
       clearTimeout(persistTimerRef.current);
       persistTimerRef.current = null;
@@ -765,6 +767,8 @@ export function useAIState() {
   }, [debouncedPersistSessions]);
 
   const clearSessionMessages = useCallback((sessionId: string) => {
+    getAgentRuntime().clearChatSession(sessionId);
+    void getAIBridge()?.deleteChatToolOutputsTemp?.(sessionId).catch(() => {});
     if (persistTimerRef.current) {
       clearTimeout(persistTimerRef.current);
       persistTimerRef.current = null;

--- a/application/state/useAIState.ts
+++ b/application/state/useAIState.ts
@@ -57,7 +57,6 @@ import {
   bumpDraftMutationVersion,
   bumpDraftUploadGeneration,
   cleanupDeletedAIChatSessions,
-  cleanupSdkAgentSessions,
   cleanupOrphanedAISessions,
   getAIBridge,
   getDraftUploadGeneration,

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -49,6 +49,7 @@ import {
 import { resolveRestorePreviousSessionSetting } from './sessionRestoreSettings';
 import type { CodingCliProviderId } from '../../domain/codingCliProviders';
 import { normalizeCodingCliDynamicTitleForStorage } from '../../domain/codingCliTitleParse';
+import { cleanupClosedTerminalSessions } from './aiStateSnapshots';
 
 export function addWorkspaceIfMissing(
   workspaces: Workspace[],
@@ -373,6 +374,9 @@ export const useSessionState = ({
   }, []);
 
   const closeWorkspace = useCallback((workspaceId: string) => {
+    cleanupClosedTerminalSessions(
+      sessionsRef.current.filter(session => session.workspaceId === workspaceId).map(session => session.id),
+    );
     setWorkspaces(prevWorkspaces => {
       const remainingWorkspaces = prevWorkspaces.filter(w => w.id !== workspaceId);
 
@@ -392,6 +396,7 @@ export const useSessionState = ({
   }, [setActiveTabId]);
 
   const closeSessions = useCallback((sessionIds: string[]) => {
+    cleanupClosedTerminalSessions(sessionIds);
     const result = closeSessionsState({
       sessions: sessionsRef.current,
       workspaces: workspacesRef.current,

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -1264,7 +1264,6 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       }
 
       deleteSession(sessionId, scopeKey);
-      getAgentRuntime().clearChatSession(sessionId);
 
       if (deletingActiveSession || deletingLastScopedSession) {
         setShowHistory(false);

--- a/electron/bridges/tempDirBridge.cjs
+++ b/electron/bridges/tempDirBridge.cjs
@@ -33,6 +33,7 @@ let cachedTempDir = null;
 let cachedTempDirIdentity = null;
 let tempFileCounter = 0;
 let toolOutputSigningKeyPromise = Promise.resolve(crypto.randomBytes(32));
+let toolOutputSigningKeyRecoveryPromise = null;
 let toolOutputSafeStorage = null;
 const toolOutputSessionDeletions = new Map();
 const toolOutputChatDeletionGenerations = new Map();
@@ -66,7 +67,9 @@ async function loadOrCreateToolOutputSigningKey(safeStorage) {
         const decoded = Buffer.from(safeStorage.decryptString(encrypted), "base64");
         if (decoded.length === 32) return decoded;
       } catch {
-        // Replace a key that the current secure storage can no longer decrypt.
+        // A locked or temporarily unavailable OS keychain must not destroy the
+        // only key capable of verifying previously persisted output.
+        return null;
       }
     }
     if ((stat.isFile() || stat.isSymbolicLink())) {
@@ -101,7 +104,25 @@ async function loadOrCreateToolOutputSigningKey(safeStorage) {
 function configureToolOutputSigningKey(electronModule) {
   if (!electronModule) return;
   toolOutputSafeStorage = electronModule.safeStorage;
+  toolOutputSigningKeyRecoveryPromise = null;
   toolOutputSigningKeyPromise = loadOrCreateToolOutputSigningKey(toolOutputSafeStorage);
+}
+
+async function getToolOutputSigningKey({ retry = true } = {}) {
+  const key = await toolOutputSigningKeyPromise.catch(() => null);
+  if (key || !retry || !toolOutputSafeStorage) return key;
+  if (toolOutputSigningKeyRecoveryPromise) return toolOutputSigningKeyRecoveryPromise;
+  const recovery = loadOrCreateToolOutputSigningKey(toolOutputSafeStorage).catch(() => null);
+  toolOutputSigningKeyRecoveryPromise = recovery;
+  try {
+    const recovered = await recovery;
+    toolOutputSigningKeyPromise = Promise.resolve(recovered);
+    return recovered;
+  } finally {
+    if (toolOutputSigningKeyRecoveryPromise === recovery) {
+      toolOutputSigningKeyRecoveryPromise = null;
+    }
+  }
 }
 
 async function ensureToolOutputSigningKeyFile(key) {
@@ -137,8 +158,8 @@ function signToolOutputManifest(manifest, key) {
     .digest("hex");
 }
 
-async function hasValidToolOutputManifestSignature(manifest) {
-  const key = await toolOutputSigningKeyPromise;
+async function hasValidToolOutputManifestSignature(manifest, signingKey) {
+  const key = signingKey ?? await getToolOutputSigningKey();
   if (!key || !isBoundedString(manifest.signature, 64) || !/^[a-f0-9]{64}$/.test(manifest.signature)) return false;
   const expected = Buffer.from(signToolOutputManifest(manifest, key), "hex");
   const actual = Buffer.from(manifest.signature, "hex");
@@ -269,12 +290,14 @@ async function clearTempDir() {
   const tempDir = getTempDir();
   let deletedCount = 0;
   let failedCount = 0;
+  const resetUnavailableSigningKey = Boolean(toolOutputSafeStorage)
+    && !await getToolOutputSigningKey();
   
   try {
     const files = await fs.promises.readdir(tempDir);
     
     for (const file of files) {
-      if (file === TOOL_OUTPUT_SIGNING_KEY_FILE) continue;
+      if (file === TOOL_OUTPUT_SIGNING_KEY_FILE && !resetUnavailableSigningKey) continue;
       try {
         const filePath = path.join(tempDir, file);
         const stat = await fs.promises.stat(filePath);
@@ -293,6 +316,11 @@ async function clearTempDir() {
         failedCount++;
         console.log(`[TempDir] Could not delete ${file}: ${err.message}`);
       }
+    }
+
+    if (resetUnavailableSigningKey) {
+      toolOutputSigningKeyPromise = Promise.resolve(null);
+      await getToolOutputSigningKey();
     }
     
     console.log(`[TempDir] Cleanup complete: ${deletedCount} deleted, ${failedCount} failed`);
@@ -439,7 +467,7 @@ async function deleteToolOutputPair(filePath) {
   return manifestDeleted && contentDeleted;
 }
 
-async function readSafeManifest(manifestPath) {
+async function readSafeManifest(manifestPath, signingKey) {
   if (!isNetcattyTempPath(manifestPath) || !manifestPath.endsWith(".log.meta.json")) return null;
   let file;
   try {
@@ -460,7 +488,7 @@ async function readSafeManifest(manifestPath) {
     if (!isBoundedString(parsed.contentFile, 512) || path.basename(parsed.contentFile) !== parsed.contentFile) return null;
     if (!Number.isSafeInteger(parsed.contentBytes) || parsed.contentBytes < 0 || parsed.contentBytes > MAX_TOOL_OUTPUT_TEMP_BYTES) return null;
     if (!isBoundedString(parsed.contentSha256, 64) || !/^[a-f0-9]{64}$/.test(parsed.contentSha256)) return null;
-    if (!await hasValidToolOutputManifestSignature(parsed)) return null;
+    if (!await hasValidToolOutputManifestSignature(parsed, signingKey)) return null;
     const contentPath = path.join(getTempDir(), parsed.contentFile);
     if (toolOutputManifestPath(contentPath) !== manifestPath) return null;
     return { manifest: parsed, manifestPath, manifestStat: stat, contentPath };
@@ -492,6 +520,8 @@ async function verifyManifestContent(entry) {
 async function listToolOutputManifestEntries() {
   const tempDir = getTempDir();
   const entries = [];
+  const signingKey = await getToolOutputSigningKey();
+  if (!signingKey) return entries;
   let files = [];
   try {
     files = await fs.promises.readdir(tempDir);
@@ -500,14 +530,14 @@ async function listToolOutputManifestEntries() {
   }
   for (const file of files) {
     if (!file.endsWith(".log.meta.json")) continue;
-    const entry = await readSafeManifest(path.join(tempDir, file));
+    const entry = await readSafeManifest(path.join(tempDir, file), signingKey);
     if (entry) entries.push(entry);
   }
   return entries;
 }
 
 async function touchToolOutputEntry(entry, now = new Date()) {
-  const key = await toolOutputSigningKeyPromise;
+  const key = await getToolOutputSigningKey();
   if (!key) return false;
   const pendingPath = getTempFilePath(`${entry.manifest.record.handleId}.manifest.pending`);
   const manifest = {
@@ -572,7 +602,7 @@ async function cleanupExpiredToolOutputFiles(now = Date.now()) {
   let deletedCount = 0;
   try {
     const files = await fs.promises.readdir(tempDir);
-    const signingKeyAvailable = Boolean(await toolOutputSigningKeyPromise.catch(() => null));
+    const signingKeyAvailable = Boolean(await getToolOutputSigningKey());
     const managedContent = new Set();
     for (const file of files) {
       if (
@@ -647,7 +677,7 @@ async function cleanupExpiredToolOutputFiles(now = Date.now()) {
   } catch {
     // Temp persistence is optional; keep startup resilient.
   }
-  if (await toolOutputSigningKeyPromise.catch(() => null)) {
+  if (await getToolOutputSigningKey()) {
     await enforcePersistedToolOutputLimits();
   }
   return deletedCount;
@@ -760,10 +790,13 @@ function registerHandlers(ipcMain, shell, electronModule) {
     return { success: false };
   });
 
-  ipcMain.handle("netcatty:tempdir:toolOutputPersistenceStatus", async () => ({
-    durable: Boolean(await toolOutputSigningKeyPromise),
-    reason: await toolOutputSigningKeyPromise ? undefined : "Secure local storage is unavailable.",
-  }));
+  ipcMain.handle("netcatty:tempdir:toolOutputPersistenceStatus", async () => {
+    const durable = Boolean(await getToolOutputSigningKey());
+    return {
+      durable,
+      reason: durable ? undefined : "Secure local storage is unavailable.",
+    };
+  });
 
   ipcMain.handle("netcatty:tempdir:toolOutputWrite", async (_event, payload = {}) => {
     const content = String(payload.content ?? "");
@@ -792,7 +825,7 @@ function registerHandlers(ipcMain, shell, electronModule) {
       if (getToolOutputChatDeletionGeneration(record.chatSessionId) !== chatDeletionGeneration) {
         throw new Error("Chat session was cleared while output was being saved.");
       }
-      const signingKey = await toolOutputSigningKeyPromise;
+      const signingKey = await getToolOutputSigningKey();
       if (!signingKey) throw new Error("Secure local storage is unavailable.");
       if (!await ensureToolOutputSigningKeyFile(signingKey)) {
         throw new Error("Unable to prepare secure local storage.");

--- a/electron/bridges/tempDirBridge.cjs
+++ b/electron/bridges/tempDirBridge.cjs
@@ -38,12 +38,19 @@ const toolOutputSessionDeletions = new Map();
 const toolOutputChatDeletionGenerations = new Map();
 const closedToolOutputTerminalSessions = new Set();
 
+function isSecureToolOutputStorageAvailable(safeStorage, platform = process.platform) {
+  if (!safeStorage?.isEncryptionAvailable?.()) return false;
+  if (platform !== "linux" || typeof safeStorage.getSelectedStorageBackend !== "function") return true;
+  const backend = safeStorage.getSelectedStorageBackend();
+  return backend !== "basic_text" && backend !== "unknown";
+}
+
 function getToolOutputChatDeletionGeneration(chatSessionId) {
   return toolOutputChatDeletionGenerations.get(chatSessionId) ?? 0;
 }
 
 async function loadOrCreateToolOutputSigningKey(safeStorage) {
-  if (!safeStorage?.isEncryptionAvailable?.()) return null;
+  if (!isSecureToolOutputStorageAvailable(safeStorage)) return null;
   const keyPath = path.join(getTempDir(), TOOL_OUTPUT_SIGNING_KEY_FILE);
   try {
     const stat = await fs.promises.lstat(keyPath);
@@ -98,7 +105,7 @@ function configureToolOutputSigningKey(electronModule) {
 }
 
 async function ensureToolOutputSigningKeyFile(key) {
-  if (!toolOutputSafeStorage?.isEncryptionAvailable?.()) return true;
+  if (!isSecureToolOutputStorageAvailable(toolOutputSafeStorage)) return true;
   const keyPath = path.join(getTempDir(), TOOL_OUTPUT_SIGNING_KEY_FILE);
   try {
     const stat = await fs.promises.lstat(keyPath);
@@ -983,4 +990,5 @@ module.exports = {
   cleanupExpiredToolOutputFiles,
   registerHandlers,
   resolvePrivateTempDir,
+  isSecureToolOutputStorageAvailable,
 };

--- a/electron/bridges/tempDirBridge.cjs
+++ b/electron/bridges/tempDirBridge.cjs
@@ -35,17 +35,38 @@ let tempFileCounter = 0;
 let toolOutputSigningKeyPromise = Promise.resolve(crypto.randomBytes(32));
 let toolOutputSafeStorage = null;
 const toolOutputSessionDeletions = new Map();
+const toolOutputChatDeletionGenerations = new Map();
 const closedToolOutputTerminalSessions = new Set();
+
+function getToolOutputChatDeletionGeneration(chatSessionId) {
+  return toolOutputChatDeletionGenerations.get(chatSessionId) ?? 0;
+}
 
 async function loadOrCreateToolOutputSigningKey(safeStorage) {
   if (!safeStorage?.isEncryptionAvailable?.()) return null;
   const keyPath = path.join(getTempDir(), TOOL_OUTPUT_SIGNING_KEY_FILE);
   try {
     const stat = await fs.promises.lstat(keyPath);
-    if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || stat.size > 4096) return null;
-    const encrypted = await fs.promises.readFile(keyPath);
-    const decoded = Buffer.from(safeStorage.decryptString(encrypted), "base64");
-    return decoded.length === 32 ? decoded : null;
+    if (stat.isFile() && !stat.isSymbolicLink() && stat.nlink === 1 && stat.size <= 4096) {
+      let encrypted;
+      try {
+        encrypted = await fs.promises.readFile(keyPath);
+      } catch {
+        // A transient read failure must not destroy the only key for existing output.
+        return null;
+      }
+      try {
+        const decoded = Buffer.from(safeStorage.decryptString(encrypted), "base64");
+        if (decoded.length === 32) return decoded;
+      } catch {
+        // Replace a key that the current secure storage can no longer decrypt.
+      }
+    }
+    if ((stat.isFile() || stat.isSymbolicLink())) {
+      await fs.promises.unlink(keyPath);
+    } else {
+      return null;
+    }
   } catch (error) {
     if (error?.code !== "ENOENT") return null;
   }
@@ -562,9 +583,24 @@ async function cleanupExpiredToolOutputFiles(now = Date.now()) {
         }
         continue;
       }
-      if (!signingKeyAvailable) continue;
       if (!file.endsWith(".log.meta.json")) continue;
       const manifestPath = path.join(tempDir, file);
+      if (!signingKeyAvailable) {
+        try {
+          const stat = await fs.promises.lstat(manifestPath);
+          if (stat.isSymbolicLink() || !stat.isFile()) continue;
+          const contentPath = manifestPath.slice(0, -".meta.json".length);
+          if (now - stat.mtimeMs >= TOOL_OUTPUT_PERSISTED_TTL_MS) {
+            if (await safeUnlink(manifestPath)) deletedCount += 1;
+            if (await safeUnlink(contentPath)) deletedCount += 1;
+          } else {
+            managedContent.add(path.basename(contentPath));
+          }
+        } catch {
+          // Best-effort startup cleanup.
+        }
+        continue;
+      }
       const entry = await readSafeManifest(manifestPath);
       if (!entry) {
         try {
@@ -587,7 +623,6 @@ async function cleanupExpiredToolOutputFiles(now = Date.now()) {
       if (await safeUnlink(entry.manifestPath)) deletedCount += 1;
       if (await safeUnlink(entry.contentPath)) deletedCount += 1;
     }
-    if (!signingKeyAvailable) return deletedCount;
     for (const file of files) {
       if (!file.includes("_tool-output-") || !file.endsWith(".log")) continue;
       if (managedContent.has(file)) continue;
@@ -738,6 +773,7 @@ function registerHandlers(ipcMain, shell, electronModule) {
       return { ok: false, error: "Tool output exceeds the temp-file limit." };
     }
     const ownershipMarker = toolOutputOwnershipMarker(record.chatSessionId, record.terminalSessionId);
+    const chatDeletionGeneration = getToolOutputChatDeletionGeneration(record.chatSessionId);
     const filePath = getTempFilePath(`${ownershipMarker.slice(1)}${record.handleId}.log`);
     const manifestPath = toolOutputManifestPath(filePath);
     const pendingManifestPath = getTempFilePath(`${record.handleId}.manifest.pending`);
@@ -746,6 +782,9 @@ function registerHandlers(ipcMain, shell, electronModule) {
         throw new Error("Terminal session is already closed.");
       }
       await toolOutputSessionDeletions.get(record.chatSessionId);
+      if (getToolOutputChatDeletionGeneration(record.chatSessionId) !== chatDeletionGeneration) {
+        throw new Error("Chat session was cleared while output was being saved.");
+      }
       const signingKey = await toolOutputSigningKeyPromise;
       if (!signingKey) throw new Error("Secure local storage is unavailable.");
       if (!await ensureToolOutputSigningKeyFile(signingKey)) {
@@ -765,11 +804,27 @@ function registerHandlers(ipcMain, shell, electronModule) {
         flag: "wx",
       });
       await fs.promises.rename(pendingManifestPath, manifestPath);
+      if (getToolOutputChatDeletionGeneration(record.chatSessionId) !== chatDeletionGeneration) {
+        await deleteToolOutputPair(filePath);
+        throw new Error("Chat session was cleared while output was being saved.");
+      }
       if (record.terminalSessionId && closedToolOutputTerminalSessions.has(record.terminalSessionId)) {
         await deleteToolOutputPair(filePath);
         throw new Error("Terminal session closed while output was being saved.");
       }
       await enforcePersistedToolOutputLimits();
+      const persistedEntry = await readSafeManifest(manifestPath);
+      if (!persistedEntry || path.resolve(persistedEntry.contentPath) !== path.resolve(filePath)) {
+        throw new Error("Saved output was removed while enforcing storage limits.");
+      }
+      if (getToolOutputChatDeletionGeneration(record.chatSessionId) !== chatDeletionGeneration) {
+        await deleteToolOutputPair(filePath);
+        throw new Error("Chat session was cleared while output was being saved.");
+      }
+      if (record.terminalSessionId && closedToolOutputTerminalSessions.has(record.terminalSessionId)) {
+        await deleteToolOutputPair(filePath);
+        throw new Error("Terminal session closed while output was being saved.");
+      }
       return { ok: true, path: filePath, manifestPath };
     } catch (error) {
       await Promise.allSettled([
@@ -785,7 +840,9 @@ function registerHandlers(ipcMain, shell, electronModule) {
     const handleId = String(payload.handleId ?? "");
     const chatSessionId = String(payload.chatSessionId ?? "");
     if (!isBoundedString(handleId, 200) || !isBoundedString(chatSessionId, 512)) return null;
+    const chatDeletionGeneration = getToolOutputChatDeletionGeneration(chatSessionId);
     await toolOutputSessionDeletions.get(chatSessionId);
+    if (getToolOutputChatDeletionGeneration(chatSessionId) !== chatDeletionGeneration) return null;
     const entries = await listToolOutputManifestEntries();
     const entry = entries.find(candidate => (
       candidate.manifest.record.handleId === handleId
@@ -815,6 +872,10 @@ function registerHandlers(ipcMain, shell, electronModule) {
       return null;
     }
     await touchToolOutputEntry(entry);
+    if (getToolOutputChatDeletionGeneration(chatSessionId) !== chatDeletionGeneration) {
+      await deleteToolOutputPair(entry.contentPath);
+      return null;
+    }
     if (
       entry.manifest.record.terminalSessionId
       && closedToolOutputTerminalSessions.has(entry.manifest.record.terminalSessionId)
@@ -832,6 +893,10 @@ function registerHandlers(ipcMain, shell, electronModule) {
     const filePath = payload.path;
     const manifestEntry = await readSafeManifest(toolOutputManifestPath(filePath));
     if (!manifestEntry || path.resolve(manifestEntry.contentPath) !== path.resolve(filePath)) return null;
+    const chatSessionId = manifestEntry.manifest.record.chatSessionId;
+    const chatDeletionGeneration = getToolOutputChatDeletionGeneration(chatSessionId);
+    await toolOutputSessionDeletions.get(chatSessionId);
+    if (getToolOutputChatDeletionGeneration(chatSessionId) !== chatDeletionGeneration) return null;
     if (
       manifestEntry.manifest.record.terminalSessionId
       && closedToolOutputTerminalSessions.has(manifestEntry.manifest.record.terminalSessionId)
@@ -851,6 +916,10 @@ function registerHandlers(ipcMain, shell, electronModule) {
     const content = verified.contentBuffer.toString("utf16le");
     const result = !payload.request ? content : await readToolOutputChunk(content, payload.request);
     await touchToolOutputEntry(manifestEntry);
+    if (getToolOutputChatDeletionGeneration(chatSessionId) !== chatDeletionGeneration) {
+      await deleteToolOutputPair(manifestEntry.contentPath);
+      return null;
+    }
     if (
       manifestEntry.manifest.record.terminalSessionId
       && closedToolOutputTerminalSessions.has(manifestEntry.manifest.record.terminalSessionId)
@@ -870,6 +939,10 @@ function registerHandlers(ipcMain, shell, electronModule) {
   ipcMain.handle("netcatty:tempdir:toolOutputDeleteSession", async (_event, payload = {}) => {
     const chatSessionId = String(payload.chatSessionId ?? "");
     if (!isBoundedString(chatSessionId, 512)) return { deletedCount: 0 };
+    toolOutputChatDeletionGenerations.set(
+      chatSessionId,
+      getToolOutputChatDeletionGeneration(chatSessionId) + 1,
+    );
     const existing = toolOutputSessionDeletions.get(chatSessionId);
     if (existing) return existing;
     const deletion = (async () => {

--- a/electron/bridges/tempDirBridge.cjs
+++ b/electron/bridges/tempDirBridge.cjs
@@ -8,6 +8,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const os = require("node:os");
+const crypto = require("node:crypto");
 
 // Keep the legacy name when the OS already provides a private per-user temp
 // root. Shared temp roots fall back to a stable directory under the user's home
@@ -15,15 +16,106 @@ const os = require("node:os");
 const NETCATTY_TEMP_DIR_NAME = "Netcatty";
 const MAX_TOOL_OUTPUT_TEMP_CHARS = 4_000_000;
 const MAX_TOOL_OUTPUT_TEMP_BYTES = 8_000_000;
-const TOOL_OUTPUT_TEMP_TTL_MS = 30 * 60 * 1_000;
+const TOOL_OUTPUT_ORPHAN_TTL_MS = 30 * 60 * 1_000;
+const TOOL_OUTPUT_PERSISTED_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
+const TOOL_OUTPUT_MANIFEST_MAX_BYTES = 16_384;
+const TOOL_OUTPUT_MAX_HANDLES_PER_SESSION = 64;
+const TOOL_OUTPUT_MAX_CHARS_PER_SESSION = 8_000_000;
+const TOOL_OUTPUT_MAX_HANDLES_GLOBAL = 256;
+const TOOL_OUTPUT_MAX_CHARS_GLOBAL = 32_000_000;
 const TOOL_OUTPUT_READ_MAX_CHARS = 12_000;
 const TOOL_OUTPUT_SEARCH_CONTEXT_CHARS = 320;
 const TOOL_OUTPUT_SEARCH_MAX_MATCHES = 20;
+const TOOL_OUTPUT_SIGNING_KEY_FILE = ".tool-output-signing-key";
 
 // Cached temp directory path
 let cachedTempDir = null;
 let cachedTempDirIdentity = null;
 let tempFileCounter = 0;
+let toolOutputSigningKeyPromise = Promise.resolve(crypto.randomBytes(32));
+let toolOutputSafeStorage = null;
+const toolOutputSessionDeletions = new Map();
+const closedToolOutputTerminalSessions = new Set();
+
+async function loadOrCreateToolOutputSigningKey(safeStorage) {
+  if (!safeStorage?.isEncryptionAvailable?.()) return null;
+  const keyPath = path.join(getTempDir(), TOOL_OUTPUT_SIGNING_KEY_FILE);
+  try {
+    const stat = await fs.promises.lstat(keyPath);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || stat.size > 4096) return null;
+    const encrypted = await fs.promises.readFile(keyPath);
+    const decoded = Buffer.from(safeStorage.decryptString(encrypted), "base64");
+    return decoded.length === 32 ? decoded : null;
+  } catch (error) {
+    if (error?.code !== "ENOENT") return null;
+  }
+
+  const key = crypto.randomBytes(32);
+  const pendingPath = `${keyPath}.${process.pid}.${crypto.randomBytes(6).toString("hex")}.pending`;
+  try {
+    const encrypted = safeStorage.encryptString(key.toString("base64"));
+    await fs.promises.writeFile(pendingPath, encrypted, { mode: 0o600, flag: "wx" });
+    await fs.promises.rename(pendingPath, keyPath);
+    return key;
+  } catch (error) {
+    await safeUnlink(pendingPath);
+    if (error?.code !== "EEXIST") return null;
+    try {
+      const encrypted = await fs.promises.readFile(keyPath);
+      const decoded = Buffer.from(safeStorage.decryptString(encrypted), "base64");
+      return decoded.length === 32 ? decoded : null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function configureToolOutputSigningKey(electronModule) {
+  if (!electronModule) return;
+  toolOutputSafeStorage = electronModule.safeStorage;
+  toolOutputSigningKeyPromise = loadOrCreateToolOutputSigningKey(toolOutputSafeStorage);
+}
+
+async function ensureToolOutputSigningKeyFile(key) {
+  if (!toolOutputSafeStorage?.isEncryptionAvailable?.()) return true;
+  const keyPath = path.join(getTempDir(), TOOL_OUTPUT_SIGNING_KEY_FILE);
+  try {
+    const stat = await fs.promises.lstat(keyPath);
+    return stat.isFile() && !stat.isSymbolicLink() && stat.nlink === 1;
+  } catch (error) {
+    if (error?.code !== "ENOENT") return false;
+  }
+  try {
+    const encrypted = toolOutputSafeStorage.encryptString(key.toString("base64"));
+    await fs.promises.writeFile(keyPath, encrypted, { mode: 0o600, flag: "wx" });
+    return true;
+  } catch (error) {
+    return error?.code === "EEXIST";
+  }
+}
+
+function unsignedToolOutputManifest(manifest) {
+  return {
+    record: manifest.record,
+    contentFile: manifest.contentFile,
+    contentBytes: manifest.contentBytes,
+    contentSha256: manifest.contentSha256,
+  };
+}
+
+function signToolOutputManifest(manifest, key) {
+  return crypto.createHmac("sha256", key)
+    .update(JSON.stringify(unsignedToolOutputManifest(manifest)))
+    .digest("hex");
+}
+
+async function hasValidToolOutputManifestSignature(manifest) {
+  const key = await toolOutputSigningKeyPromise;
+  if (!key || !isBoundedString(manifest.signature, 64) || !/^[a-f0-9]{64}$/.test(manifest.signature)) return false;
+  const expected = Buffer.from(signToolOutputManifest(manifest, key), "hex");
+  const actual = Buffer.from(manifest.signature, "hex");
+  return actual.length === expected.length && crypto.timingSafeEqual(actual, expected);
+}
 
 function resolvePrivateTempDir(systemTempDir = os.tmpdir(), homeDir = os.homedir()) {
   if (typeof process.getuid !== "function") {
@@ -113,6 +205,7 @@ async function getTempDirInfo() {
     let fileCount = 0;
     
     for (const file of files) {
+      if (file === TOOL_OUTPUT_SIGNING_KEY_FILE) continue;
       try {
         const filePath = path.join(tempDir, file);
         const stat = await fs.promises.stat(filePath);
@@ -153,6 +246,7 @@ async function clearTempDir() {
     const files = await fs.promises.readdir(tempDir);
     
     for (const file of files) {
+      if (file === TOOL_OUTPUT_SIGNING_KEY_FILE) continue;
       try {
         const filePath = path.join(tempDir, file);
         const stat = await fs.promises.stat(filePath);
@@ -213,7 +307,7 @@ async function openSafeToolOutputFile(filePath) {
       await file.close();
       return null;
     }
-    if (!stat.isFile() || stat.size > MAX_TOOL_OUTPUT_TEMP_BYTES) {
+    if (!stat.isFile() || stat.nlink !== 1 || stat.size > MAX_TOOL_OUTPUT_TEMP_BYTES || stat.size % 2 !== 0) {
       await file.close();
       return null;
     }
@@ -224,18 +318,284 @@ async function openSafeToolOutputFile(filePath) {
   }
 }
 
+function isBoundedString(value, maxLength, allowEmpty = false) {
+  return typeof value === "string"
+    && value.length <= maxLength
+    && (allowEmpty || value.length > 0);
+}
+
+function isSafeToolOutputRecord(record) {
+  return record
+    && record.schemaVersion === 1
+    && isBoundedString(record.handleId, 200)
+    && /^[A-Za-z0-9_.-]+$/.test(record.handleId)
+    && isBoundedString(record.chatSessionId, 512)
+    && isBoundedString(record.capabilityId, 256)
+    && (record.terminalSessionId == null || isBoundedString(record.terminalSessionId, 512))
+    && Number.isSafeInteger(record.totalChars)
+    && record.totalChars >= 0
+    && Number.isSafeInteger(record.storedChars)
+    && record.storedChars >= 0
+    && record.storedChars <= MAX_TOOL_OUTPUT_TEMP_CHARS
+    && record.totalChars >= record.storedChars
+    && typeof record.sourceTruncated === "boolean"
+    && isBoundedString(record.preview, 2_000, true)
+    && Number.isFinite(record.storedAt)
+    && record.storedAt > 0
+    && Number.isFinite(record.accessedAt)
+    && record.accessedAt > 0;
+}
+
+function toolOutputManifestPath(filePath) {
+  return `${filePath}.meta.json`;
+}
+
+function toolOutputOwnershipMarker(chatSessionId, terminalSessionId) {
+  const digest = value => crypto.createHash("sha256").update(value).digest("hex").slice(0, 24);
+  return `_tool-output-${digest(chatSessionId)}-${digest(terminalSessionId ?? "")}-`;
+}
+
+async function deleteToolOutputsByOwnership(chatSessionId, terminalSessionId) {
+  const tempDir = getTempDir();
+  const marker = terminalSessionId == null
+    ? `_tool-output-${crypto.createHash("sha256").update(chatSessionId).digest("hex").slice(0, 24)}-`
+    : toolOutputOwnershipMarker(chatSessionId, terminalSessionId);
+  let deletedCount = 0;
+  let files = [];
+  try {
+    files = await fs.promises.readdir(tempDir);
+  } catch {
+    return { deletedCount };
+  }
+  for (const file of files) {
+    if (!file.includes(marker) || !file.endsWith(".log")) continue;
+    if (await deleteToolOutputPair(path.join(tempDir, file))) deletedCount += 1;
+  }
+  return { deletedCount };
+}
+
+async function deleteToolOutputsByTerminal(terminalSessionId) {
+  const tempDir = getTempDir();
+  const terminalHash = crypto.createHash("sha256").update(terminalSessionId).digest("hex").slice(0, 24);
+  const marker = new RegExp(`_tool-output-[a-f0-9]{24}-${terminalHash}-`);
+  let deletedCount = 0;
+  let files = [];
+  try {
+    files = await fs.promises.readdir(tempDir);
+  } catch {
+    return { deletedCount };
+  }
+  for (const file of files) {
+    if (!marker.test(file) || !file.endsWith(".log")) continue;
+    if (await deleteToolOutputPair(path.join(tempDir, file))) deletedCount += 1;
+  }
+  return { deletedCount };
+}
+
+async function safeUnlink(filePath) {
+  if (!isNetcattyTempPath(filePath)) return false;
+  try {
+    const stat = await fs.promises.lstat(filePath);
+    if (!stat.isFile() || stat.isSymbolicLink()) return false;
+    await fs.promises.unlink(filePath);
+    return true;
+  } catch (error) {
+    return error?.code === "ENOENT";
+  }
+}
+
+async function deleteToolOutputPair(filePath) {
+  const manifestPath = toolOutputManifestPath(filePath);
+  const manifestDeleted = await safeUnlink(manifestPath);
+  const contentDeleted = await safeUnlink(filePath);
+  return manifestDeleted && contentDeleted;
+}
+
+async function readSafeManifest(manifestPath) {
+  if (!isNetcattyTempPath(manifestPath) || !manifestPath.endsWith(".log.meta.json")) return null;
+  let file;
+  try {
+    const noFollow = fs.constants.O_NOFOLLOW ?? 0;
+    file = await fs.promises.open(manifestPath, fs.constants.O_RDONLY | noFollow);
+    const stat = await file.stat();
+    const pathStat = await fs.promises.lstat(manifestPath);
+    if (
+      !stat.isFile()
+      || stat.nlink !== 1
+      || stat.size > TOOL_OUTPUT_MANIFEST_MAX_BYTES
+      || pathStat.isSymbolicLink()
+      || pathStat.dev !== stat.dev
+      || pathStat.ino !== stat.ino
+    ) return null;
+    const parsed = JSON.parse(await file.readFile({ encoding: "utf8" }));
+    if (!isSafeToolOutputRecord(parsed.record)) return null;
+    if (!isBoundedString(parsed.contentFile, 512) || path.basename(parsed.contentFile) !== parsed.contentFile) return null;
+    if (!Number.isSafeInteger(parsed.contentBytes) || parsed.contentBytes < 0 || parsed.contentBytes > MAX_TOOL_OUTPUT_TEMP_BYTES) return null;
+    if (!isBoundedString(parsed.contentSha256, 64) || !/^[a-f0-9]{64}$/.test(parsed.contentSha256)) return null;
+    if (!await hasValidToolOutputManifestSignature(parsed)) return null;
+    const contentPath = path.join(getTempDir(), parsed.contentFile);
+    if (toolOutputManifestPath(contentPath) !== manifestPath) return null;
+    return { manifest: parsed, manifestPath, manifestStat: stat, contentPath };
+  } catch {
+    return null;
+  } finally {
+    await file?.close().catch(() => {});
+  }
+}
+
+async function readVerifiedManifestContent(entry) {
+  const opened = await openSafeToolOutputFile(entry.contentPath);
+  if (!opened) return null;
+  try {
+    if (opened.stat.size !== entry.manifest.contentBytes) return null;
+    const contentBuffer = await opened.file.readFile();
+    const digest = crypto.createHash("sha256").update(contentBuffer).digest("hex");
+    if (digest !== entry.manifest.contentSha256) return null;
+    return { stat: opened.stat, contentBuffer };
+  } finally {
+    await opened.file.close();
+  }
+}
+
+async function verifyManifestContent(entry) {
+  return Boolean(await readVerifiedManifestContent(entry));
+}
+
+async function listToolOutputManifestEntries() {
+  const tempDir = getTempDir();
+  const entries = [];
+  let files = [];
+  try {
+    files = await fs.promises.readdir(tempDir);
+  } catch {
+    return entries;
+  }
+  for (const file of files) {
+    if (!file.endsWith(".log.meta.json")) continue;
+    const entry = await readSafeManifest(path.join(tempDir, file));
+    if (entry) entries.push(entry);
+  }
+  return entries;
+}
+
+async function touchToolOutputEntry(entry, now = new Date()) {
+  const key = await toolOutputSigningKeyPromise;
+  if (!key) return false;
+  const pendingPath = getTempFilePath(`${entry.manifest.record.handleId}.manifest.pending`);
+  const manifest = {
+    ...unsignedToolOutputManifest(entry.manifest),
+    record: { ...entry.manifest.record, accessedAt: now.getTime() },
+  };
+  manifest.signature = signToolOutputManifest(manifest, key);
+  try {
+    await fs.promises.writeFile(pendingPath, JSON.stringify(manifest), {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    await fs.promises.rename(pendingPath, entry.manifestPath);
+    entry.manifest = manifest;
+    entry.manifestStat = await fs.promises.stat(entry.manifestPath);
+    return true;
+  } catch {
+    await safeUnlink(pendingPath);
+    return false;
+  }
+}
+
+function isToolOutputEntryExpired(entry, now = Date.now()) {
+  return now - entry.manifest.record.accessedAt >= TOOL_OUTPUT_PERSISTED_TTL_MS;
+}
+
+async function enforcePersistedToolOutputLimits() {
+  const entries = await listToolOutputManifestEntries();
+  const active = [...entries].sort((a, b) => (
+    b.manifest.record.accessedAt - a.manifest.record.accessedAt
+  ));
+  const kept = [];
+  const sessionCounts = new Map();
+  const sessionChars = new Map();
+  let globalChars = 0;
+  for (const entry of active) {
+    if (!await verifyManifestContent(entry)) {
+      await deleteToolOutputPair(entry.contentPath);
+      continue;
+    }
+    const { chatSessionId, storedChars } = entry.manifest.record;
+    const sessionCount = sessionCounts.get(chatSessionId) ?? 0;
+    const sessionTotal = sessionChars.get(chatSessionId) ?? 0;
+    const keep = kept.length < TOOL_OUTPUT_MAX_HANDLES_GLOBAL
+      && globalChars + storedChars <= TOOL_OUTPUT_MAX_CHARS_GLOBAL
+      && sessionCount < TOOL_OUTPUT_MAX_HANDLES_PER_SESSION
+      && sessionTotal + storedChars <= TOOL_OUTPUT_MAX_CHARS_PER_SESSION;
+    if (!keep) {
+      await deleteToolOutputPair(entry.contentPath);
+      continue;
+    }
+    kept.push(entry);
+    globalChars += storedChars;
+    sessionCounts.set(chatSessionId, sessionCount + 1);
+    sessionChars.set(chatSessionId, sessionTotal + storedChars);
+  }
+}
+
 async function cleanupExpiredToolOutputFiles(now = Date.now()) {
   const tempDir = getTempDir();
   let deletedCount = 0;
   try {
     const files = await fs.promises.readdir(tempDir);
+    const signingKeyAvailable = Boolean(await toolOutputSigningKeyPromise.catch(() => null));
+    const managedContent = new Set();
+    for (const file of files) {
+      if (
+        file.endsWith(".manifest.pending")
+        || (file.startsWith(`${TOOL_OUTPUT_SIGNING_KEY_FILE}.`) && file.endsWith(".pending"))
+      ) {
+        const pendingPath = path.join(tempDir, file);
+        try {
+          const stat = await fs.promises.lstat(pendingPath);
+          if (stat.isFile() && !stat.isSymbolicLink() && now - stat.mtimeMs >= TOOL_OUTPUT_ORPHAN_TTL_MS) {
+            if (await safeUnlink(pendingPath)) deletedCount += 1;
+          }
+        } catch {
+          // Best-effort startup cleanup.
+        }
+        continue;
+      }
+      if (!signingKeyAvailable) continue;
+      if (!file.endsWith(".log.meta.json")) continue;
+      const manifestPath = path.join(tempDir, file);
+      const entry = await readSafeManifest(manifestPath);
+      if (!entry) {
+        try {
+          const stat = await fs.promises.lstat(manifestPath);
+          if (stat.isFile() && !stat.isSymbolicLink() && now - stat.mtimeMs >= TOOL_OUTPUT_ORPHAN_TTL_MS) {
+            if (await safeUnlink(manifestPath)) deletedCount += 1;
+          }
+        } catch {
+          // Best-effort startup cleanup.
+        }
+        continue;
+      }
+      if (!await verifyManifestContent(entry)) {
+        if (await safeUnlink(entry.manifestPath)) deletedCount += 1;
+        if (await safeUnlink(entry.contentPath)) deletedCount += 1;
+        continue;
+      }
+      managedContent.add(path.basename(entry.contentPath));
+      if (!isToolOutputEntryExpired(entry, now)) continue;
+      if (await safeUnlink(entry.manifestPath)) deletedCount += 1;
+      if (await safeUnlink(entry.contentPath)) deletedCount += 1;
+    }
+    if (!signingKeyAvailable) return deletedCount;
     for (const file of files) {
       if (!file.includes("_tool-output-") || !file.endsWith(".log")) continue;
+      if (managedContent.has(file)) continue;
       const filePath = path.join(tempDir, file);
       try {
         const stat = await fs.promises.lstat(filePath);
         if (stat.isSymbolicLink() || !stat.isFile()) continue;
-        if (now - stat.mtimeMs < TOOL_OUTPUT_TEMP_TTL_MS) continue;
+        if (now - stat.mtimeMs < TOOL_OUTPUT_ORPHAN_TTL_MS) continue;
         await fs.promises.unlink(filePath);
         deletedCount += 1;
       } catch {
@@ -244,6 +604,9 @@ async function cleanupExpiredToolOutputFiles(now = Date.now()) {
     }
   } catch {
     // Temp persistence is optional; keep startup resilient.
+  }
+  if (await toolOutputSigningKeyPromise.catch(() => null)) {
+    await enforcePersistedToolOutputLimits();
   }
   return deletedCount;
 }
@@ -258,8 +621,8 @@ function safeUtf16SliceBounds(content, requestedStart, requestedEnd) {
   return [start, end];
 }
 
-async function readToolOutputChunk(file, request, stat) {
-  const storedChars = Math.floor(stat.size / 2);
+async function readToolOutputChunk(content, request) {
+  const storedChars = content.length;
   const requestedMax = Number.isFinite(request?.maxChars) ? Math.floor(request.maxChars) : TOOL_OUTPUT_READ_MAX_CHARS;
   const maxChars = Math.min(TOOL_OUTPUT_READ_MAX_CHARS, Math.max(1, requestedMax));
   const mode = request?.mode ?? "head";
@@ -269,7 +632,6 @@ async function readToolOutputChunk(file, request, stat) {
     if (!query) {
       return { mode, content: "Search query is required.", totalChars: storedChars, startOffset: 0, endOffset: 0, nextOffset: 0, hasMore: false, matchOffsets: [] };
     }
-    const content = await file.readFile({ encoding: "utf16le" });
     const haystack = content.toLocaleLowerCase();
     const needle = query.toLocaleLowerCase();
     const offsets = [];
@@ -320,22 +682,20 @@ async function readToolOutputChunk(file, request, stat) {
     ? Math.max(0, storedChars - maxChars)
     : mode === "range" ? Math.min(storedChars, Math.max(0, Math.floor(request?.offset ?? 0))) : 0;
   const readStart = Math.max(0, startOffset - 1);
-  const readChars = Math.min(storedChars - readStart, maxChars + 2);
-  const buffer = Buffer.alloc(Math.max(0, readChars * 2));
-  const { bytesRead } = await file.read(buffer, 0, buffer.length, readStart * 2);
-  const window = buffer.subarray(0, bytesRead).toString("utf16le");
+  const window = content.slice(readStart, Math.min(storedChars, readStart + maxChars + 2));
   const relativeStart = startOffset - readStart;
   const [safeStart, safeEnd] = safeUtf16SliceBounds(window, relativeStart, relativeStart + maxChars);
   startOffset = readStart + safeStart;
-  const content = window.slice(safeStart, safeEnd);
-  const endOffset = startOffset + content.length;
-  return { mode, content, totalChars: storedChars, startOffset, endOffset, nextOffset: endOffset, hasMore: endOffset < storedChars };
+  const chunk = window.slice(safeStart, safeEnd);
+  const endOffset = startOffset + chunk.length;
+  return { mode, content: chunk, totalChars: storedChars, startOffset, endOffset, nextOffset: endOffset, hasMore: endOffset < storedChars };
 }
 
 /**
  * Register IPC handlers
  */
-function registerHandlers(ipcMain, shell) {
+function registerHandlers(ipcMain, shell, electronModule) {
+  configureToolOutputSigningKey(electronModule);
   void cleanupExpiredToolOutputFiles();
   ipcMain.handle("netcatty:tempdir:getInfo", async () => {
     return getTempDirInfo();
@@ -358,41 +718,186 @@ function registerHandlers(ipcMain, shell) {
     return { success: false };
   });
 
+  ipcMain.handle("netcatty:tempdir:toolOutputPersistenceStatus", async () => ({
+    durable: Boolean(await toolOutputSigningKeyPromise),
+    reason: await toolOutputSigningKeyPromise ? undefined : "Secure local storage is unavailable.",
+  }));
+
   ipcMain.handle("netcatty:tempdir:toolOutputWrite", async (_event, payload = {}) => {
     const content = String(payload.content ?? "");
-    if (content.length > MAX_TOOL_OUTPUT_TEMP_CHARS) {
+    const record = payload.record;
+    if (
+      !isSafeToolOutputRecord(record)
+      || content.length > MAX_TOOL_OUTPUT_TEMP_CHARS
+      || record.storedChars !== content.length
+    ) {
       return { ok: false, error: "Tool output exceeds the temp-file limit." };
     }
-    const handleId = String(payload.handleId ?? "tool-output").replace(/[^A-Za-z0-9_.-]/g, "_");
-    const filePath = getTempFilePath(`${handleId}.log`);
-    await fs.promises.writeFile(filePath, content, { encoding: "utf16le", mode: 0o600, flag: "wx" });
-    return { ok: true, path: filePath };
+    const contentBuffer = Buffer.from(content, "utf16le");
+    if (contentBuffer.length > MAX_TOOL_OUTPUT_TEMP_BYTES) {
+      return { ok: false, error: "Tool output exceeds the temp-file limit." };
+    }
+    const ownershipMarker = toolOutputOwnershipMarker(record.chatSessionId, record.terminalSessionId);
+    const filePath = getTempFilePath(`${ownershipMarker.slice(1)}${record.handleId}.log`);
+    const manifestPath = toolOutputManifestPath(filePath);
+    const pendingManifestPath = getTempFilePath(`${record.handleId}.manifest.pending`);
+    try {
+      if (record.terminalSessionId && closedToolOutputTerminalSessions.has(record.terminalSessionId)) {
+        throw new Error("Terminal session is already closed.");
+      }
+      await toolOutputSessionDeletions.get(record.chatSessionId);
+      const signingKey = await toolOutputSigningKeyPromise;
+      if (!signingKey) throw new Error("Secure local storage is unavailable.");
+      if (!await ensureToolOutputSigningKeyFile(signingKey)) {
+        throw new Error("Unable to prepare secure local storage.");
+      }
+      await fs.promises.writeFile(filePath, contentBuffer, { mode: 0o600, flag: "wx" });
+      const manifest = {
+        record,
+        contentFile: path.basename(filePath),
+        contentBytes: contentBuffer.length,
+        contentSha256: crypto.createHash("sha256").update(contentBuffer).digest("hex"),
+      };
+      manifest.signature = signToolOutputManifest(manifest, signingKey);
+      await fs.promises.writeFile(pendingManifestPath, JSON.stringify(manifest), {
+        encoding: "utf8",
+        mode: 0o600,
+        flag: "wx",
+      });
+      await fs.promises.rename(pendingManifestPath, manifestPath);
+      if (record.terminalSessionId && closedToolOutputTerminalSessions.has(record.terminalSessionId)) {
+        await deleteToolOutputPair(filePath);
+        throw new Error("Terminal session closed while output was being saved.");
+      }
+      await enforcePersistedToolOutputLimits();
+      return { ok: true, path: filePath, manifestPath };
+    } catch (error) {
+      await Promise.allSettled([
+        safeUnlink(pendingManifestPath),
+        safeUnlink(manifestPath),
+        safeUnlink(filePath),
+      ]);
+      return { ok: false, error: error?.message || "Unable to persist tool output." };
+    }
+  });
+
+  ipcMain.handle("netcatty:tempdir:toolOutputRestore", async (_event, payload = {}) => {
+    const handleId = String(payload.handleId ?? "");
+    const chatSessionId = String(payload.chatSessionId ?? "");
+    if (!isBoundedString(handleId, 200) || !isBoundedString(chatSessionId, 512)) return null;
+    await toolOutputSessionDeletions.get(chatSessionId);
+    const entries = await listToolOutputManifestEntries();
+    const entry = entries.find(candidate => (
+      candidate.manifest.record.handleId === handleId
+      && candidate.manifest.record.chatSessionId === chatSessionId
+    ));
+    if (!entry) return null;
+    if (
+      entry.manifest.record.terminalSessionId
+      && closedToolOutputTerminalSessions.has(entry.manifest.record.terminalSessionId)
+    ) {
+      await deleteToolOutputPair(entry.contentPath);
+      return null;
+    }
+    if (isToolOutputEntryExpired(entry)) {
+      await deleteToolOutputPair(entry.contentPath);
+      return null;
+    }
+    if (!await verifyManifestContent(entry)) {
+      await deleteToolOutputPair(entry.contentPath);
+      return null;
+    }
+    if (
+      entry.manifest.record.terminalSessionId
+      && closedToolOutputTerminalSessions.has(entry.manifest.record.terminalSessionId)
+    ) {
+      await deleteToolOutputPair(entry.contentPath);
+      return null;
+    }
+    await touchToolOutputEntry(entry);
+    if (
+      entry.manifest.record.terminalSessionId
+      && closedToolOutputTerminalSessions.has(entry.manifest.record.terminalSessionId)
+    ) {
+      await deleteToolOutputPair(entry.contentPath);
+      return null;
+    }
+    return {
+      path: entry.contentPath,
+      record: entry.manifest.record,
+    };
   });
 
   ipcMain.handle("netcatty:tempdir:toolOutputRead", async (_event, payload = {}) => {
     const filePath = payload.path;
-    const opened = await openSafeToolOutputFile(filePath);
-    if (!opened) return null;
-    try {
-      if (!payload.request) return await opened.file.readFile({ encoding: "utf16le" });
-      return await readToolOutputChunk(opened.file, payload.request, opened.stat);
-    } finally {
-      await opened.file.close();
+    const manifestEntry = await readSafeManifest(toolOutputManifestPath(filePath));
+    if (!manifestEntry || path.resolve(manifestEntry.contentPath) !== path.resolve(filePath)) return null;
+    if (
+      manifestEntry.manifest.record.terminalSessionId
+      && closedToolOutputTerminalSessions.has(manifestEntry.manifest.record.terminalSessionId)
+    ) {
+      await deleteToolOutputPair(manifestEntry.contentPath);
+      return null;
     }
+    if (isToolOutputEntryExpired(manifestEntry)) {
+      await deleteToolOutputPair(manifestEntry.contentPath);
+      return null;
+    }
+    const verified = await readVerifiedManifestContent(manifestEntry);
+    if (!verified) {
+      await deleteToolOutputPair(manifestEntry.contentPath);
+      return null;
+    }
+    const content = verified.contentBuffer.toString("utf16le");
+    const result = !payload.request ? content : await readToolOutputChunk(content, payload.request);
+    await touchToolOutputEntry(manifestEntry);
+    if (
+      manifestEntry.manifest.record.terminalSessionId
+      && closedToolOutputTerminalSessions.has(manifestEntry.manifest.record.terminalSessionId)
+    ) {
+      await deleteToolOutputPair(manifestEntry.contentPath);
+      return null;
+    }
+    return result;
   });
 
   ipcMain.handle("netcatty:tempdir:toolOutputDelete", async (_event, payload = {}) => {
     const filePath = payload.path;
     if (!isNetcattyTempPath(filePath)) return { ok: false };
-    try {
-      const stat = await fs.promises.lstat(filePath);
-      if (!stat.isFile() || stat.isSymbolicLink()) return { ok: false };
-      await fs.promises.unlink(filePath);
-      return { ok: true };
-    } catch (error) {
-      if (error?.code === "ENOENT") return { ok: true };
-      return { ok: false };
+    return { ok: await deleteToolOutputPair(filePath) };
+  });
+
+  ipcMain.handle("netcatty:tempdir:toolOutputDeleteSession", async (_event, payload = {}) => {
+    const chatSessionId = String(payload.chatSessionId ?? "");
+    if (!isBoundedString(chatSessionId, 512)) return { deletedCount: 0 };
+    const existing = toolOutputSessionDeletions.get(chatSessionId);
+    if (existing) return existing;
+    const deletion = (async () => {
+      return deleteToolOutputsByOwnership(chatSessionId);
+    })().finally(() => {
+      if (toolOutputSessionDeletions.get(chatSessionId) === deletion) {
+        toolOutputSessionDeletions.delete(chatSessionId);
+      }
+    });
+    toolOutputSessionDeletions.set(chatSessionId, deletion);
+    return deletion;
+  });
+
+  ipcMain.handle("netcatty:tempdir:toolOutputDeleteTerminalSession", async (_event, payload = {}) => {
+    const chatSessionId = String(payload.chatSessionId ?? "");
+    const terminalSessionId = String(payload.terminalSessionId ?? "");
+    if (!isBoundedString(chatSessionId, 512) || !isBoundedString(terminalSessionId, 512)) {
+      return { deletedCount: 0 };
     }
+    closedToolOutputTerminalSessions.add(terminalSessionId);
+    return deleteToolOutputsByOwnership(chatSessionId, terminalSessionId);
+  });
+
+  ipcMain.handle("netcatty:tempdir:toolOutputDeleteTerminal", async (_event, payload = {}) => {
+    const terminalSessionId = String(payload.terminalSessionId ?? "");
+    if (!isBoundedString(terminalSessionId, 512)) return { deletedCount: 0 };
+    closedToolOutputTerminalSessions.add(terminalSessionId);
+    return deleteToolOutputsByTerminal(terminalSessionId);
   });
 }
 

--- a/electron/bridges/tempDirBridge.test.cjs
+++ b/electron/bridges/tempDirBridge.test.cjs
@@ -585,10 +585,12 @@ test("tool output signing key survives a real process restart", async () => {
     'const bridge = require("./electron/bridges/tempDirBridge.cjs");',
     'const handlers = new Map();',
     'const secret = process.env.FAKE_SAFE_STORAGE_SECRET;',
+    'let keychainLocked = process.env.PHASE === "unlock";',
     'const safeStorage = {',
     '  isEncryptionAvailable: () => true,',
     '  encryptString: value => Buffer.from(`${secret}:${value}`, "utf8"),',
     '  decryptString: value => {',
+    '    if (keychainLocked) throw new Error("keychain locked");',
     '    const text = value.toString("utf8");',
     '    if (!text.startsWith(`${secret}:`)) throw new Error("wrong key");',
     '    return text.slice(secret.length + 1);',
@@ -619,6 +621,21 @@ test("tool output signing key survives a real process restart", async () => {
     '    console.log(`RESULT:${JSON.stringify(deleted)}`);',
     '    return;',
     '  }',
+    '  if (process.env.PHASE === "clear") {',
+    '    const cleared = await handlers.get("netcatty:tempdir:clear")();',
+    '    const status = await handlers.get("netcatty:tempdir:toolOutputPersistenceStatus")();',
+    '    console.log(`RESULT:${JSON.stringify({ cleared, status })}`);',
+    '    return;',
+    '  }',
+    '  if (process.env.PHASE === "unlock") {',
+    '    const locked = await handlers.get("netcatty:tempdir:toolOutputPersistenceStatus")();',
+    '    keychainLocked = false;',
+    '    const unlocked = await handlers.get("netcatty:tempdir:toolOutputPersistenceStatus")();',
+    '    const restored = await handlers.get("netcatty:tempdir:toolOutputRestore")({}, { handleId: "real-restart", chatSessionId: "restart-chat" });',
+    '    const content = restored ? await handlers.get("netcatty:tempdir:toolOutputRead")({}, { path: restored.path }) : null;',
+    '    console.log(`RESULT:${JSON.stringify({ locked, unlocked, content })}`);',
+    '    return;',
+    '  }',
     '  const restored = await handlers.get("netcatty:tempdir:toolOutputRestore")({}, { handleId: "real-restart", chatSessionId: "restart-chat" });',
     '  const content = restored ? await handlers.get("netcatty:tempdir:toolOutputRead")({}, { path: restored.path }) : null;',
     '  await bridge.cleanupExpiredToolOutputFiles();',
@@ -645,7 +662,13 @@ test("tool output signing key survives a real process restart", async () => {
     assert.equal(reopened.status, 0, reopened.stderr || reopened.stdout);
     assert.match(reopened.stdout, /RESULT:.*"restored":true.*"content":"across restart"/);
 
+    const unlocked = run("unlock", "stable-secret");
+    assert.equal(unlocked.status, 0, unlocked.stderr || unlocked.stdout);
+    assert.match(unlocked.stdout, /RESULT:.*"locked":\{"durable":false.*"unlocked":\{"durable":true\}.*"content":"across restart"/);
+
     const persistedDir = path.join(root, "Netcatty");
+    const signingKeyPath = path.join(persistedDir, ".tool-output-signing-key");
+    const signingKeyBeforeFailure = await fs.promises.readFile(signingKeyPath);
     const old = new Date(Date.now() - 31 * 60 * 1_000);
     for (const file of await fs.promises.readdir(persistedDir)) {
       if (file.endsWith(".log") || file.endsWith(".log.meta.json")) {
@@ -655,13 +678,23 @@ test("tool output signing key survives a real process restart", async () => {
     const wrongKey = run("read", "different-secret");
     assert.equal(wrongKey.status, 0, wrongKey.stderr || wrongKey.stdout);
     assert.match(wrongKey.stdout, /RESULT:\{"restored":false,"content":null\}/);
+    assert.deepEqual(await fs.promises.readFile(signingKeyPath), signingKeyBeforeFailure);
     const remainingFiles = await fs.promises.readdir(persistedDir);
-    assert.equal(remainingFiles.some(file => file.endsWith(".log")), false);
-    assert.equal(remainingFiles.some(file => file.endsWith(".log.meta.json")), false);
+    assert.equal(remainingFiles.filter(file => file.endsWith(".log")).length, 2);
+    assert.equal(remainingFiles.filter(file => file.endsWith(".log.meta.json")).length, 2);
 
-    const recoveredWrite = run("write", "different-secret");
-    assert.equal(recoveredWrite.status, 0, recoveredWrite.stderr || recoveredWrite.stdout);
-    assert.match(recoveredWrite.stdout, /RESULT:.*"ok":true/);
+    const recoveredRead = run("read", "stable-secret");
+    assert.equal(recoveredRead.status, 0, recoveredRead.stderr || recoveredRead.stdout);
+    assert.match(recoveredRead.stdout, /RESULT:.*"restored":true.*"content":"across restart"/);
+
+    const reset = run("clear", "different-secret");
+    assert.equal(reset.status, 0, reset.stderr || reset.stdout);
+    assert.match(reset.stdout, /RESULT:.*"status":\{"durable":true\}/);
+    assert.notDeepEqual(await fs.promises.readFile(signingKeyPath), signingKeyBeforeFailure);
+
+    const rewritten = run("write", "different-secret");
+    assert.equal(rewritten.status, 0, rewritten.stderr || rewritten.stdout);
+    assert.match(rewritten.stdout, /RESULT:.*"ok":true/);
 
     const deletedTerminal = run("delete-terminal", "different-secret");
     assert.equal(deletedTerminal.status, 0, deletedTerminal.stderr || deletedTerminal.stdout);

--- a/electron/bridges/tempDirBridge.test.cjs
+++ b/electron/bridges/tempDirBridge.test.cjs
@@ -692,3 +692,15 @@ test("tool output persistence reports when secure storage is unavailable", async
     { durable: false, reason: "Secure local storage is unavailable." },
   );
 });
+
+test("Linux basic_text and unknown backends are not treated as secure storage", () => {
+  const storage = backend => ({
+    isEncryptionAvailable: () => true,
+    getSelectedStorageBackend: () => backend,
+  });
+
+  assert.equal(tempDirBridge.isSecureToolOutputStorageAvailable(storage("basic_text"), "linux"), false);
+  assert.equal(tempDirBridge.isSecureToolOutputStorageAvailable(storage("unknown"), "linux"), false);
+  assert.equal(tempDirBridge.isSecureToolOutputStorageAvailable(storage("gnome_libsecret"), "linux"), true);
+  assert.equal(tempDirBridge.isSecureToolOutputStorageAvailable(storage("basic_text"), "darwin"), true);
+});

--- a/electron/bridges/tempDirBridge.test.cjs
+++ b/electron/bridges/tempDirBridge.test.cjs
@@ -79,10 +79,28 @@ test("tool output temp handlers write, read, and delete only Netcatty temp files
 
   const write = handlers.get("netcatty:tempdir:toolOutputWrite");
   const read = handlers.get("netcatty:tempdir:toolOutputRead");
+  const restore = handlers.get("netcatty:tempdir:toolOutputRestore");
   const remove = handlers.get("netcatty:tempdir:toolOutputDelete");
-  const saved = await write({}, { handleId: "tool-output-1", content: "large terminal output" });
+  const record = {
+    schemaVersion: 1,
+    handleId: "tool-output-1",
+    chatSessionId: "chat-1",
+    capabilityId: "terminal.execute",
+    totalChars: 21,
+    storedChars: 21,
+    sourceTruncated: false,
+    preview: "large terminal output",
+    storedAt: Date.now(),
+    accessedAt: Date.now(),
+  };
+  const saved = await write({}, { record, content: "large terminal output" });
 
   assert.equal(saved.ok, true);
+  assert.deepEqual(await restore({}, { handleId: "tool-output-1", chatSessionId: "chat-other" }), null);
+  const restored = await restore({}, { handleId: "tool-output-1", chatSessionId: "chat-1" });
+  assert.equal(restored.path, saved.path);
+  assert.deepEqual({ ...restored.record, accessedAt: record.accessedAt }, record);
+  assert.equal(restored.record.accessedAt >= record.accessedAt, true);
   assert.equal(await read({}, { path: saved.path }), "large terminal output");
   assert.deepEqual(await read({}, {
     path: saved.path,
@@ -97,6 +115,7 @@ test("tool output temp handlers write, read, and delete only Netcatty temp files
     hasMore: true,
   });
   assert.deepEqual(await remove({}, { path: saved.path }), { ok: true });
+  assert.equal(await restore({}, { handleId: "tool-output-1", chatSessionId: "chat-1" }), null);
   assert.equal(await read({}, { path: saved.path }), null);
   assert.deepEqual(await read({}, { path: "/etc/passwd" }), null);
 });
@@ -113,6 +132,93 @@ test("tool output temp reader rejects symlinks that point outside Netcatty temp"
   }
 });
 
+test("tool output temp writer rejects output arriving after terminal close", async () => {
+  const handlers = new Map();
+  tempDirBridge.registerHandlers({ handle(channel, handler) { handlers.set(channel, handler); } });
+  const terminalSessionId = "terminal-closed-before-write";
+  await handlers.get("netcatty:tempdir:toolOutputDeleteTerminal")({}, { terminalSessionId });
+  const now = Date.now();
+  const saved = await handlers.get("netcatty:tempdir:toolOutputWrite")({}, {
+    record: {
+      schemaVersion: 1,
+      handleId: "late-terminal-output",
+      chatSessionId: "chat-late-terminal",
+      capabilityId: "terminal.execute",
+      terminalSessionId,
+      totalChars: 4,
+      storedChars: 4,
+      sourceTruncated: false,
+      preview: "late",
+      storedAt: now,
+      accessedAt: now,
+    },
+    content: "late",
+  });
+
+  assert.equal(saved.ok, false);
+  assert.match(saved.error, /already closed/);
+});
+
+test("terminal close wins when a persisted output read is already in flight", async () => {
+  const handlers = new Map();
+  tempDirBridge.registerHandlers({ handle(channel, handler) { handlers.set(channel, handler); } });
+  const terminalSessionId = "terminal-close-during-read";
+  const now = Date.now();
+  const saved = await handlers.get("netcatty:tempdir:toolOutputWrite")({}, {
+    record: {
+      schemaVersion: 1,
+      handleId: "read-close-race",
+      chatSessionId: "chat-read-close-race",
+      capabilityId: "terminal.execute",
+      terminalSessionId,
+      totalChars: 7,
+      storedChars: 7,
+      sourceTruncated: false,
+      preview: "private",
+      storedAt: now,
+      accessedAt: now,
+    },
+    content: "private",
+  });
+  const originalOpen = fs.promises.open;
+  let signalReadStarted;
+  const readStarted = new Promise(resolve => { signalReadStarted = resolve; });
+  let releaseRead;
+  const readReleased = new Promise(resolve => { releaseRead = resolve; });
+  fs.promises.open = async (...args) => {
+    const handle = await originalOpen(...args);
+    if (path.resolve(String(args[0])) !== path.resolve(saved.path)) return handle;
+    return {
+      stat: handle.stat.bind(handle),
+      close: handle.close.bind(handle),
+      read: handle.read.bind(handle),
+      readFile: async (...readArgs) => {
+        signalReadStarted();
+        await readReleased;
+        return handle.readFile(...readArgs);
+      },
+    };
+  };
+
+  try {
+    const reading = handlers.get("netcatty:tempdir:toolOutputRead")({}, { path: saved.path });
+    await readStarted;
+    await handlers.get("netcatty:tempdir:toolOutputDeleteTerminal")({}, { terminalSessionId });
+    releaseRead();
+
+    assert.equal(await reading, null);
+    assert.equal(fs.existsSync(saved.path), false);
+    assert.equal(fs.existsSync(saved.manifestPath), false);
+  } finally {
+    fs.promises.open = originalOpen;
+    releaseRead?.();
+    await Promise.allSettled([
+      fs.promises.unlink(saved.path),
+      fs.promises.unlink(saved.manifestPath),
+    ]);
+  }
+});
+
 test("startup cleanup removes expired orphaned tool output files", async () => {
   const filePath = tempDirBridge.getTempFilePath("tool-output-expired.log");
   await fs.promises.writeFile(filePath, "secret");
@@ -123,13 +229,76 @@ test("startup cleanup removes expired orphaned tool output files", async () => {
   assert.equal(fs.existsSync(filePath), false);
 });
 
+test("startup cleanup removes abandoned pending manifests", async () => {
+  const filePath = tempDirBridge.getTempFilePath("tool-output-abandoned.manifest.pending");
+  await fs.promises.writeFile(filePath, "pending");
+  const old = new Date(Date.now() - 31 * 60 * 1_000);
+  await fs.promises.utimes(filePath, old, old);
+
+  const deleted = await tempDirBridge.cleanupExpiredToolOutputFiles();
+
+  assert.equal(deleted >= 1, true);
+  assert.equal(fs.existsSync(filePath), false);
+});
+
+test("managed tool output survives short restarts and expires after thirty days", async () => {
+  const handlers = new Map();
+  tempDirBridge.registerHandlers({ handle(channel, handler) { handlers.set(channel, handler); } });
+  const now = Date.now();
+  const saved = await handlers.get("netcatty:tempdir:toolOutputWrite")({}, {
+    record: {
+      schemaVersion: 1,
+      handleId: "tool-output-ttl",
+      chatSessionId: "chat-ttl",
+      capabilityId: "terminal.execute",
+      totalChars: 7,
+      storedChars: 7,
+      sourceTruncated: false,
+      preview: "durable",
+      storedAt: now,
+      accessedAt: now,
+    },
+    content: "durable",
+  });
+  const thirtyOneMinutesAgo = new Date(Date.now() - 31 * 60 * 1_000);
+  await Promise.all([
+    fs.promises.utimes(saved.path, thirtyOneMinutesAgo, thirtyOneMinutesAgo),
+    fs.promises.utimes(saved.manifestPath, thirtyOneMinutesAgo, thirtyOneMinutesAgo),
+  ]);
+
+  await tempDirBridge.cleanupExpiredToolOutputFiles();
+  assert.equal(fs.existsSync(saved.path), true);
+  assert.equal(fs.existsSync(saved.manifestPath), true);
+
+  const forgedFutureMtime = new Date(now + 365 * 24 * 60 * 60 * 1_000);
+  await fs.promises.utimes(saved.manifestPath, forgedFutureMtime, forgedFutureMtime);
+  await tempDirBridge.cleanupExpiredToolOutputFiles(now + 31 * 24 * 60 * 60 * 1_000);
+  assert.equal(fs.existsSync(saved.path), false);
+  assert.equal(fs.existsSync(saved.manifestPath), false);
+});
+
 test("persisted tool output search advances only past rendered matches", async () => {
   const handlers = new Map();
   tempDirBridge.registerHandlers({ handle(channel, handler) { handlers.set(channel, handler); } });
   const write = handlers.get("netcatty:tempdir:toolOutputWrite");
   const read = handlers.get("netcatty:tempdir:toolOutputRead");
   const remove = handlers.get("netcatty:tempdir:toolOutputDelete");
-  const saved = await write({}, { handleId: "search-pagination", content: "match middle match tail" });
+  const now = Date.now();
+  const saved = await write({}, {
+    record: {
+      schemaVersion: 1,
+      handleId: "search-pagination",
+      chatSessionId: "chat-search",
+      capabilityId: "terminal.execute",
+      totalChars: 23,
+      storedChars: 23,
+      sourceTruncated: false,
+      preview: "match middle match tail",
+      storedAt: now,
+      accessedAt: now,
+    },
+    content: "match middle match tail",
+  });
 
   try {
     const first = await read({}, {
@@ -149,4 +318,222 @@ test("persisted tool output search advances only past rendered matches", async (
   } finally {
     await remove({}, { path: saved.path });
   }
+});
+
+test("tool output temp restore rejects content tampering and deletes by chat session", async () => {
+  const handlers = new Map();
+  tempDirBridge.registerHandlers({ handle(channel, handler) { handlers.set(channel, handler); } });
+  const now = Date.now();
+  const record = {
+    schemaVersion: 1,
+    handleId: "tool-output-restart",
+    chatSessionId: "chat-restart",
+    capabilityId: "terminal.execute",
+    terminalSessionId: "terminal-1",
+    totalChars: 16,
+    storedChars: 16,
+    sourceTruncated: false,
+    preview: "restart content",
+    storedAt: now,
+    accessedAt: now,
+  };
+  const saved = await handlers.get("netcatty:tempdir:toolOutputWrite")({}, {
+    record,
+    content: "restart content!",
+  });
+
+  assert.ok(saved.manifestPath);
+  assert.equal((await fs.promises.stat(saved.path)).mode & 0o777, 0o600);
+  assert.equal((await fs.promises.stat(saved.manifestPath)).mode & 0o777, 0o600);
+
+  await fs.promises.writeFile(saved.path, "tampered content", { encoding: "utf16le" });
+  assert.equal(await handlers.get("netcatty:tempdir:toolOutputRestore")({}, {
+    handleId: record.handleId,
+    chatSessionId: record.chatSessionId,
+  }), null);
+  assert.equal(fs.existsSync(saved.path), false);
+  assert.equal(fs.existsSync(saved.manifestPath), false);
+
+  const deleted = await handlers.get("netcatty:tempdir:toolOutputDeleteSession")({}, {
+    chatSessionId: record.chatSessionId,
+  });
+  assert.equal(deleted.deletedCount, 0);
+  assert.equal(fs.existsSync(saved.path), false);
+  assert.equal(fs.existsSync(saved.manifestPath), false);
+});
+
+test("tool output ownership metadata cannot be reassigned to another chat", async () => {
+  const handlers = new Map();
+  tempDirBridge.registerHandlers({ handle(channel, handler) { handlers.set(channel, handler); } });
+  const now = Date.now();
+  const saved = await handlers.get("netcatty:tempdir:toolOutputWrite")({}, {
+    record: {
+      schemaVersion: 1,
+      handleId: "tool-output-owned",
+      chatSessionId: "chat-owner",
+      capabilityId: "terminal.execute",
+      totalChars: 7,
+      storedChars: 7,
+      sourceTruncated: false,
+      preview: "private",
+      storedAt: now,
+      accessedAt: now,
+    },
+    content: "private",
+  });
+  const manifest = JSON.parse(await fs.promises.readFile(saved.manifestPath, "utf8"));
+  manifest.record.chatSessionId = "chat-attacker";
+  await fs.promises.writeFile(saved.manifestPath, JSON.stringify(manifest), "utf8");
+
+  assert.equal(await handlers.get("netcatty:tempdir:toolOutputRestore")({}, {
+    handleId: "tool-output-owned",
+    chatSessionId: "chat-attacker",
+  }), null);
+  assert.equal(await handlers.get("netcatty:tempdir:toolOutputRead")({}, { path: saved.path }), null);
+
+  await Promise.allSettled([
+    fs.promises.unlink(saved.path),
+    fs.promises.unlink(saved.manifestPath),
+  ]);
+});
+
+test("tool output verification detects same-size edits even when mtime is restored", async () => {
+  const handlers = new Map();
+  tempDirBridge.registerHandlers({ handle(channel, handler) { handlers.set(channel, handler); } });
+  const now = Date.now();
+  const saved = await handlers.get("netcatty:tempdir:toolOutputWrite")({}, {
+    record: {
+      schemaVersion: 1,
+      handleId: "tool-output-same-mtime",
+      chatSessionId: "chat-same-mtime",
+      capabilityId: "terminal.execute",
+      totalChars: 8,
+      storedChars: 8,
+      sourceTruncated: false,
+      preview: "original",
+      storedAt: now,
+      accessedAt: now,
+    },
+    content: "original",
+  });
+  const originalStat = await fs.promises.stat(saved.path);
+  await fs.promises.writeFile(saved.path, "modified", { encoding: "utf16le" });
+  await fs.promises.utimes(saved.path, originalStat.atime, originalStat.mtime);
+
+  assert.equal(await handlers.get("netcatty:tempdir:toolOutputRead")({}, { path: saved.path }), null);
+  assert.equal(fs.existsSync(saved.path), false);
+  assert.equal(fs.existsSync(saved.manifestPath), false);
+});
+
+test("tool output signing key survives a real process restart", async () => {
+  const root = await fs.promises.mkdtemp(path.join(require("node:os").tmpdir(), "netcatty-tool-output-restart-"));
+  const fakeHome = path.join(root, "home");
+  await fs.promises.mkdir(fakeHome);
+  await fs.promises.chmod(root, 0o700);
+  const script = [
+    'const bridge = require("./electron/bridges/tempDirBridge.cjs");',
+    'const handlers = new Map();',
+    'const secret = process.env.FAKE_SAFE_STORAGE_SECRET;',
+    'const safeStorage = {',
+    '  isEncryptionAvailable: () => true,',
+    '  encryptString: value => Buffer.from(`${secret}:${value}`, "utf8"),',
+    '  decryptString: value => {',
+    '    const text = value.toString("utf8");',
+    '    if (!text.startsWith(`${secret}:`)) throw new Error("wrong key");',
+    '    return text.slice(secret.length + 1);',
+    '  },',
+    '};',
+    'bridge.registerHandlers({ handle: (channel, handler) => handlers.set(channel, handler) }, undefined, { safeStorage });',
+    '(async () => {',
+    '  if (process.env.PHASE === "write") {',
+    '    const now = Date.now();',
+    '    const saved = await handlers.get("netcatty:tempdir:toolOutputWrite")({}, {',
+    '      record: { schemaVersion: 1, handleId: "real-restart", chatSessionId: "restart-chat", capabilityId: "terminal.execute", terminalSessionId: "terminal-one", totalChars: 14, storedChars: 14, sourceTruncated: false, preview: "across restart", storedAt: now, accessedAt: now },',
+    '      content: "across restart",',
+    '    });',
+    '    await handlers.get("netcatty:tempdir:toolOutputWrite")({}, {',
+    '      record: { schemaVersion: 1, handleId: "real-restart-two", chatSessionId: "restart-chat", capabilityId: "terminal.execute", terminalSessionId: "terminal-two", totalChars: 13, storedChars: 13, sourceTruncated: false, preview: "second output", storedAt: now, accessedAt: now },',
+    '      content: "second output",',
+    '    });',
+    '    console.log(`RESULT:${JSON.stringify(saved)}`);',
+    '    return;',
+    '  }',
+    '  if (process.env.PHASE === "delete-terminal") {',
+    '    const deleted = await handlers.get("netcatty:tempdir:toolOutputDeleteTerminal")({}, { terminalSessionId: "terminal-one" });',
+    '    console.log(`RESULT:${JSON.stringify(deleted)}`);',
+    '    return;',
+    '  }',
+    '  if (process.env.PHASE === "delete-chat") {',
+    '    const deleted = await handlers.get("netcatty:tempdir:toolOutputDeleteSession")({}, { chatSessionId: "restart-chat" });',
+    '    console.log(`RESULT:${JSON.stringify(deleted)}`);',
+    '    return;',
+    '  }',
+    '  const restored = await handlers.get("netcatty:tempdir:toolOutputRestore")({}, { handleId: "real-restart", chatSessionId: "restart-chat" });',
+    '  const content = restored ? await handlers.get("netcatty:tempdir:toolOutputRead")({}, { path: restored.path }) : null;',
+    '  await bridge.cleanupExpiredToolOutputFiles();',
+    '  console.log(`RESULT:${JSON.stringify({ restored: Boolean(restored), content })}`);',
+    '})().catch(error => { console.error(error); process.exit(1); });',
+  ].join("\n");
+  const run = (phase, secret) => spawnSync(process.execPath, ["-e", script], {
+    cwd: path.resolve(__dirname, "../.."),
+    env: {
+      ...process.env,
+      TMPDIR: root,
+      HOME: fakeHome,
+      PHASE: phase,
+      FAKE_SAFE_STORAGE_SECRET: secret,
+    },
+    encoding: "utf8",
+  });
+  try {
+    const written = run("write", "stable-secret");
+    assert.equal(written.status, 0, written.stderr || written.stdout);
+    assert.match(written.stdout, /RESULT:.*"ok":true/);
+
+    const reopened = run("read", "stable-secret");
+    assert.equal(reopened.status, 0, reopened.stderr || reopened.stdout);
+    assert.match(reopened.stdout, /RESULT:.*"restored":true.*"content":"across restart"/);
+
+    const persistedDir = path.join(root, "Netcatty");
+    const old = new Date(Date.now() - 31 * 60 * 1_000);
+    for (const file of await fs.promises.readdir(persistedDir)) {
+      if (file.endsWith(".log") || file.endsWith(".log.meta.json")) {
+        await fs.promises.utimes(path.join(persistedDir, file), old, old);
+      }
+    }
+    const wrongKey = run("read", "different-secret");
+    assert.equal(wrongKey.status, 0, wrongKey.stderr || wrongKey.stdout);
+    assert.match(wrongKey.stdout, /RESULT:\{"restored":false,"content":null\}/);
+    const remainingFiles = await fs.promises.readdir(persistedDir);
+    assert.equal(remainingFiles.some(file => file.endsWith(".log")), true);
+    assert.equal(remainingFiles.some(file => file.endsWith(".log.meta.json")), true);
+
+    const deletedTerminal = run("delete-terminal", "different-secret");
+    assert.equal(deletedTerminal.status, 0, deletedTerminal.stderr || deletedTerminal.stdout);
+    assert.match(deletedTerminal.stdout, /RESULT:\{"deletedCount":1\}/);
+    const afterTerminalDelete = await fs.promises.readdir(persistedDir);
+    assert.equal(afterTerminalDelete.filter(file => file.endsWith(".log")).length, 1);
+
+    const deletedChat = run("delete-chat", "different-secret");
+    assert.equal(deletedChat.status, 0, deletedChat.stderr || deletedChat.stdout);
+    assert.match(deletedChat.stdout, /RESULT:\{"deletedCount":1\}/);
+    const afterChatDelete = await fs.promises.readdir(persistedDir);
+    assert.equal(afterChatDelete.some(file => file.endsWith(".log") || file.endsWith(".log.meta.json")), false);
+  } finally {
+    await fs.promises.rm(root, { recursive: true, force: true });
+  }
+});
+
+test("tool output persistence reports when secure storage is unavailable", async () => {
+  const handlers = new Map();
+  tempDirBridge.registerHandlers(
+    { handle(channel, handler) { handlers.set(channel, handler); } },
+    undefined,
+    { safeStorage: { isEncryptionAvailable: () => false } },
+  );
+
+  assert.deepEqual(
+    await handlers.get("netcatty:tempdir:toolOutputPersistenceStatus")(),
+    { durable: false, reason: "Secure local storage is unavailable." },
+  );
 });

--- a/electron/bridges/tempDirBridge.test.cjs
+++ b/electron/bridges/tempDirBridge.test.cjs
@@ -159,6 +159,76 @@ test("tool output temp writer rejects output arriving after terminal close", asy
   assert.match(saved.error, /already closed/);
 });
 
+test("chat deletion wins when a persisted output write is already in flight", async () => {
+  const handlers = new Map();
+  tempDirBridge.registerHandlers({ handle(channel, handler) { handlers.set(channel, handler); } });
+  const chatSessionId = `chat-deleted-during-write-${Date.now()}`;
+  const handleId = `write-delete-race-${Date.now()}`;
+  const originalWriteFile = fs.promises.writeFile;
+  let signalWriteStarted;
+  const writeStarted = new Promise(resolve => { signalWriteStarted = resolve; });
+  let releaseWrite;
+  const writeReleased = new Promise(resolve => { releaseWrite = resolve; });
+  fs.promises.writeFile = async (filePath, ...args) => {
+    if (String(filePath).endsWith('.log')) {
+      signalWriteStarted();
+      await writeReleased;
+    }
+    return originalWriteFile(filePath, ...args);
+  };
+
+  try {
+    const now = Date.now();
+    const writing = handlers.get("netcatty:tempdir:toolOutputWrite")({}, {
+      record: {
+        schemaVersion: 1,
+        handleId,
+        chatSessionId,
+        capabilityId: "terminal.execute",
+        totalChars: 6,
+        storedChars: 6,
+        sourceTruncated: false,
+        preview: "secret",
+        storedAt: now,
+        accessedAt: now,
+      },
+      content: "secret",
+    });
+    await writeStarted;
+    await handlers.get("netcatty:tempdir:toolOutputDeleteSession")({}, { chatSessionId });
+    releaseWrite();
+
+    const saved = await writing;
+    assert.equal(saved.ok, false);
+    assert.match(saved.error, /cleared while output was being saved/);
+    assert.equal(
+      await handlers.get("netcatty:tempdir:toolOutputRestore")({}, { handleId, chatSessionId }),
+      null,
+    );
+
+    const later = await handlers.get("netcatty:tempdir:toolOutputWrite")({}, {
+      record: {
+        schemaVersion: 1,
+        handleId: `${handleId}-later`,
+        chatSessionId,
+        capabilityId: "terminal.execute",
+        totalChars: 5,
+        storedChars: 5,
+        sourceTruncated: false,
+        preview: "later",
+        storedAt: Date.now(),
+        accessedAt: Date.now(),
+      },
+      content: "later",
+    });
+    assert.equal(later.ok, true);
+    await handlers.get("netcatty:tempdir:toolOutputDelete")({}, { path: later.path });
+  } finally {
+    fs.promises.writeFile = originalWriteFile;
+    releaseWrite?.();
+  }
+});
+
 test("terminal close wins when a persisted output read is already in flight", async () => {
   const handlers = new Map();
   tempDirBridge.registerHandlers({ handle(channel, handler) { handlers.set(channel, handler); } });
@@ -239,6 +309,40 @@ test("startup cleanup removes abandoned pending manifests", async () => {
 
   assert.equal(deleted >= 1, true);
   assert.equal(fs.existsSync(filePath), false);
+});
+
+test("startup cleanup still expires tool outputs when secure storage is unavailable", async () => {
+  const root = await fs.promises.mkdtemp(path.join(require("node:os").tmpdir(), "netcatty-key-unavailable-"));
+  const fakeHome = path.join(root, "home");
+  await fs.promises.mkdir(fakeHome);
+  await fs.promises.chmod(root, 0o700);
+  try {
+    const script = [
+      'const fs = require("node:fs");',
+      'const bridge = require("./electron/bridges/tempDirBridge.cjs");',
+      'bridge.registerHandlers({ handle() {} }, undefined, { safeStorage: { isEncryptionAvailable: () => false } });',
+      'const contentPath = bridge.getTempFilePath("tool-output-key-lost.log");',
+      'const manifestPath = `${contentPath}.meta.json`;',
+      'fs.writeFileSync(contentPath, "secret");',
+      'fs.writeFileSync(manifestPath, "unreadable without key");',
+      'const old = new Date(Date.now() - 31 * 24 * 60 * 60 * 1_000);',
+      'fs.utimesSync(contentPath, old, old);',
+      'fs.utimesSync(manifestPath, old, old);',
+      '(async () => {',
+      '  const deleted = await bridge.cleanupExpiredToolOutputFiles();',
+      '  console.log(JSON.stringify({ deleted, contentExists: fs.existsSync(contentPath), manifestExists: fs.existsSync(manifestPath) }));',
+      '})();',
+    ].join("\n");
+    const result = spawnSync(process.execPath, ["-e", script], {
+      cwd: path.resolve(__dirname, "../.."),
+      env: { ...process.env, TMPDIR: root, HOME: fakeHome },
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /"deleted":2,"contentExists":false,"manifestExists":false/);
+  } finally {
+    await fs.promises.rm(root, { recursive: true, force: true });
+  }
 });
 
 test("managed tool output survives short restarts and expires after thirty days", async () => {
@@ -425,6 +529,53 @@ test("tool output verification detects same-size edits even when mtime is restor
   assert.equal(fs.existsSync(saved.manifestPath), false);
 });
 
+test("tool output writer reports when quota enforcement evicts the new output", async () => {
+  const handlers = new Map();
+  tempDirBridge.registerHandlers({ handle(channel, handler) { handlers.set(channel, handler); } });
+  const chatSessionId = `quota-eviction-${Date.now()}`;
+  const write = handlers.get("netcatty:tempdir:toolOutputWrite");
+  try {
+    for (let index = 0; index < 64; index += 1) {
+      const saved = await write({}, {
+        record: {
+          schemaVersion: 1,
+          handleId: `quota-newer-${index}`,
+          chatSessionId,
+          capabilityId: "terminal.execute",
+          totalChars: 1,
+          storedChars: 1,
+          sourceTruncated: false,
+          preview: "x",
+          storedAt: Date.now(),
+          accessedAt: Date.now() + 60_000,
+        },
+        content: "x",
+      });
+      assert.equal(saved.ok, true);
+    }
+
+    const evicted = await write({}, {
+      record: {
+        schemaVersion: 1,
+        handleId: "quota-old-clock",
+        chatSessionId,
+        capabilityId: "terminal.execute",
+        totalChars: 1,
+        storedChars: 1,
+        sourceTruncated: false,
+        preview: "y",
+        storedAt: 1,
+        accessedAt: 1,
+      },
+      content: "y",
+    });
+    assert.equal(evicted.ok, false);
+    assert.match(evicted.error, /removed while enforcing storage limits/);
+  } finally {
+    await handlers.get("netcatty:tempdir:toolOutputDeleteSession")({}, { chatSessionId });
+  }
+});
+
 test("tool output signing key survives a real process restart", async () => {
   const root = await fs.promises.mkdtemp(path.join(require("node:os").tmpdir(), "netcatty-tool-output-restart-"));
   const fakeHome = path.join(root, "home");
@@ -505,8 +656,12 @@ test("tool output signing key survives a real process restart", async () => {
     assert.equal(wrongKey.status, 0, wrongKey.stderr || wrongKey.stdout);
     assert.match(wrongKey.stdout, /RESULT:\{"restored":false,"content":null\}/);
     const remainingFiles = await fs.promises.readdir(persistedDir);
-    assert.equal(remainingFiles.some(file => file.endsWith(".log")), true);
-    assert.equal(remainingFiles.some(file => file.endsWith(".log.meta.json")), true);
+    assert.equal(remainingFiles.some(file => file.endsWith(".log")), false);
+    assert.equal(remainingFiles.some(file => file.endsWith(".log.meta.json")), false);
+
+    const recoveredWrite = run("write", "different-secret");
+    assert.equal(recoveredWrite.status, 0, recoveredWrite.stderr || recoveredWrite.stdout);
+    assert.match(recoveredWrite.stdout, /RESULT:.*"ok":true/);
 
     const deletedTerminal = run("delete-terminal", "different-secret");
     assert.equal(deletedTerminal.status, 0, deletedTerminal.stderr || deletedTerminal.stdout);

--- a/electron/main/registerBridges.cjs
+++ b/electron/main/registerBridges.cjs
@@ -226,7 +226,7 @@ function createBridgeRegistrar(context) {
     onedriveAuthBridge.registerHandlers(ipcMain, electronModule);
     cloudSyncBridge.registerHandlers(ipcMain, electronModule);
     fileWatcherBridge.registerHandlers(ipcMain, { terminalWorkerManager });
-    tempDirBridge.registerHandlers(ipcMain, shell);
+    tempDirBridge.registerHandlers(ipcMain, shell, electronModule);
     sessionLogsBridge.registerHandlers(ipcMain, { terminalWorkerManager });
     compressUploadBridge.registerHandlers(ipcMain, { terminalWorkerManager });
     globalShortcutBridge.registerHandlers(ipcMain);

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -915,12 +915,22 @@ function createPreloadApi(ctx) {
     ipcRenderer.invoke("netcatty:tempdir:getPath"),
   openTempDir: () =>
     ipcRenderer.invoke("netcatty:tempdir:open"),
-  writeToolOutputTemp: (handleId, content) =>
-    ipcRenderer.invoke("netcatty:tempdir:toolOutputWrite", { handleId, content }),
+  getToolOutputPersistenceStatus: () =>
+    ipcRenderer.invoke("netcatty:tempdir:toolOutputPersistenceStatus"),
+  writeToolOutputTemp: (record, content) =>
+    ipcRenderer.invoke("netcatty:tempdir:toolOutputWrite", { record, content }),
+  restoreToolOutputTemp: (handleId, chatSessionId) =>
+    ipcRenderer.invoke("netcatty:tempdir:toolOutputRestore", { handleId, chatSessionId }),
   readToolOutputTemp: (filePath, request) =>
     ipcRenderer.invoke("netcatty:tempdir:toolOutputRead", { path: filePath, request }),
   deleteToolOutputTemp: (filePath) =>
     ipcRenderer.invoke("netcatty:tempdir:toolOutputDelete", { path: filePath }),
+  deleteChatToolOutputsTemp: (chatSessionId) =>
+    ipcRenderer.invoke("netcatty:tempdir:toolOutputDeleteSession", { chatSessionId }),
+  deleteTerminalToolOutputsTemp: (chatSessionId, terminalSessionId) =>
+    ipcRenderer.invoke("netcatty:tempdir:toolOutputDeleteTerminalSession", { chatSessionId, terminalSessionId }),
+  deleteTerminalToolOutputsEverywhereTemp: (terminalSessionId) =>
+    ipcRenderer.invoke("netcatty:tempdir:toolOutputDeleteTerminal", { terminalSessionId }),
 
   // Session Logs
   exportSessionLog: (payload) =>

--- a/infrastructure/ai/harness/agentEventAdapter.ts
+++ b/infrastructure/ai/harness/agentEventAdapter.ts
@@ -93,15 +93,18 @@ export function mapSdkStreamEventToAgentEvents(
         args: (event.args ?? event.input ?? {}) as Record<string, unknown>,
       }];
     case 'tool-result':
+      {
+        const output = event.result ?? event.output ?? '';
       return [{
         ...base,
         id: nextEventId('tool-result'),
         type: 'tool_result',
         toolCallId: String(event.toolCallId ?? ''),
         toolName: typeof event.toolName === 'string' ? event.toolName : undefined,
-        result: String(event.result ?? event.output ?? ''),
-        isError: Boolean(event.isError),
+        result: typeof output === 'string' ? output : JSON.stringify(output),
+        isError: Boolean(event.isError) || isToolResultError(output),
       }];
+      }
     case 'file-change':
       return [{
         ...base,

--- a/infrastructure/ai/harness/agentRuntime.test.ts
+++ b/infrastructure/ai/harness/agentRuntime.test.ts
@@ -124,6 +124,65 @@ test('AgentRuntime records session state from tool call and result events', asyn
   assert.ok(text?.includes('check uptime'));
 });
 
+test('AgentRuntime keeps terminal output when session close reports failure', async () => {
+  class FailedCloseDriver implements TurnDriver {
+    readonly backend = 'external-sdk' as const;
+    async run(_input: TurnInput, ctx: TurnDriverContext): Promise<void> {
+      ctx.emit({
+        id: 'close-call',
+        type: 'tool_call',
+        toolCallId: 'close-1',
+        toolName: 'session_close',
+        args: { sessionId: 'terminal-still-open' },
+      } as import('./types').AgentEvent);
+      ctx.emit({
+        id: 'close-result',
+        type: 'tool_result',
+        toolCallId: 'close-1',
+        result: JSON.stringify({ ok: false, error: 'close rejected' }),
+        isError: false,
+      } as import('./types').AgentEvent);
+    }
+    abort(): void {}
+  }
+
+  const runtime = new AgentRuntime({ drivers: [new FailedCloseDriver()] });
+  const store = runtime.getToolOutputStore('chat-close-failed');
+  const handle = store.store({
+    chatSessionId: 'chat-close-failed',
+    capabilityId: 'terminal.execute',
+    sessionId: 'terminal-still-open',
+    content: 'keep me',
+  });
+  await runtime.runTurn({
+    backend: 'external-sdk',
+    chatSessionId: 'chat-close-failed',
+    sendScopeKey: 'chat-close-failed',
+    userText: 'close it',
+    signal: new AbortController().signal,
+    currentSession: undefined,
+    assistantMsgId: 'assistant-close-failed',
+    context: {
+      activeProvider: undefined,
+      activeModelId: '',
+      scopeType: 'terminal',
+      globalPermissionMode: 'confirm',
+      terminalSessions: [],
+      autoTitleSession: () => {},
+    },
+    maxIterations: 5,
+    ui: {
+      addMessageToSession: () => {},
+      updateLastMessage: () => {},
+      updateMessageById: () => {},
+      reportStreamError: () => {},
+      setStreamingForScope: () => {},
+    },
+  });
+
+  assert.ok(store.get(handle.id, 'chat-close-failed'));
+});
+
 test('AgentRuntime redacts secrets before trace and listener fan-out', async () => {
   class SecretDriver implements TurnDriver {
     readonly backend = 'catty' as const;

--- a/infrastructure/ai/harness/agentRuntime.ts
+++ b/infrastructure/ai/harness/agentRuntime.ts
@@ -22,6 +22,15 @@ function nextTurnId(): string {
   return `turn-${Date.now()}-${turnCounter}`;
 }
 
+function isFailedToolResult(result: string): boolean {
+  try {
+    const parsed = JSON.parse(result) as Record<string, unknown>;
+    return parsed?.ok === false || typeof parsed?.error === 'string';
+  } catch {
+    return false;
+  }
+}
+
 interface ActiveTurn {
   turnId: string;
   backend: AgentBackend;
@@ -158,6 +167,7 @@ export class AgentRuntime {
         });
       }
       if (event.type === 'tool_result') {
+        const toolResultIsError = event.isError || isFailedToolResult(event.result);
         const meta = toolCallMeta.get(event.toolCallId);
         const toolName = event.toolName ?? meta?.toolName;
         if (toolName) {
@@ -166,10 +176,10 @@ export class AgentRuntime {
             toolName,
             meta?.args,
             event.result,
-            event.isError,
+            toolResultIsError,
           );
           if (
-            !event.isError
+            !toolResultIsError
             && (toolName === 'session_close' || toolName === 'session.close')
             && typeof meta?.args.sessionId === 'string'
           ) {

--- a/infrastructure/ai/harness/agentRuntime.ts
+++ b/infrastructure/ai/harness/agentRuntime.ts
@@ -67,6 +67,10 @@ export class AgentRuntime {
     globalTerminalMonitorGuard.clearPrefix(`${chatSessionId}:`);
   }
 
+  clearTerminalSession(terminalSessionId: string): void {
+    this.toolOutputStore.pruneTerminalSessionEverywhere(terminalSessionId);
+  }
+
   async waitForActiveTurn(chatSessionId: string): Promise<void> {
     await this.activeTurnPromises.get(chatSessionId)?.catch(() => {});
   }
@@ -169,7 +173,7 @@ export class AgentRuntime {
             && (toolName === 'session_close' || toolName === 'session.close')
             && typeof meta?.args.sessionId === 'string'
           ) {
-            toolOutputStore.pruneTerminalSession(chatSessionId, meta.args.sessionId);
+            toolOutputStore.pruneTerminalSessionEverywhere(meta.args.sessionId);
           }
         }
       }

--- a/infrastructure/ai/harness/capabilityTools.ts
+++ b/infrastructure/ai/harness/capabilityTools.ts
@@ -405,6 +405,7 @@ function createCatalogTool(spec: CattyToolSpec) {
       const slot = queueKey ? reserveSessionSlot(queueKey) : null;
 
       try {
+        const result = await (async () => {
         if (abortSignal?.aborted) {
           return { error: 'Tool call cancelled before it could start.' };
         }
@@ -576,9 +577,7 @@ function createCatalogTool(spec: CattyToolSpec) {
                   '',
                   `[monitor batch archived before shortening: rawChars=${poll.output.length} handleId=${handle.id}]`,
                   'Use tool_output_read with this handleId to search/read omitted details; the terminal nextOffset already advances past the raw batch.',
-                  ...(!toolOutputStore.isRestartPersistenceAvailable()
-                    ? ['Secure local storage is unavailable, so read this handle before closing the app.']
-                    : []),
+                  'This saved output is available only until the app closes. Read this handle before closing the app.',
                 ].join('\n');
               }
               poll = { ...poll, output };
@@ -667,9 +666,7 @@ function createCatalogTool(spec: CattyToolSpec) {
                 preview: handle.preview,
                 totalChars: handle.totalChars,
                 handleId: handle.id,
-                note: toolOutputStore.isRestartPersistenceAvailable()
-                  ? 'Full file content stored. Use tool_output_read with this handleId to read more.'
-                  : 'Full file content is available only until the app closes because secure local storage is unavailable. Use tool_output_read now.',
+                note: 'Full file content is available only until the app closes. Use tool_output_read now.',
               };
             }
           }
@@ -692,10 +689,13 @@ function createCatalogTool(spec: CattyToolSpec) {
           toolResultDedup?.rememberCompletedWrite(terminalStartFingerprint, fittedRaw);
         }
         return fittedRaw;
-      } finally {
+        })();
         if (toolOutputStore && deps.chatSessionId) {
           await toolOutputStore.flush(deps.chatSessionId);
+          return toolOutputStore.resolveRestartPersistenceNotices(result, deps.chatSessionId);
         }
+        return result;
+      } finally {
         slot?.release();
       }
     },

--- a/infrastructure/ai/harness/capabilityTools.ts
+++ b/infrastructure/ai/harness/capabilityTools.ts
@@ -576,6 +576,9 @@ function createCatalogTool(spec: CattyToolSpec) {
                   '',
                   `[monitor batch archived before shortening: rawChars=${poll.output.length} handleId=${handle.id}]`,
                   'Use tool_output_read with this handleId to search/read omitted details; the terminal nextOffset already advances past the raw batch.',
+                  ...(!toolOutputStore.isRestartPersistenceAvailable()
+                    ? ['Secure local storage is unavailable, so read this handle before closing the app.']
+                    : []),
                 ].join('\n');
               }
               poll = { ...poll, output };
@@ -664,7 +667,9 @@ function createCatalogTool(spec: CattyToolSpec) {
                 preview: handle.preview,
                 totalChars: handle.totalChars,
                 handleId: handle.id,
-                note: 'Full file content stored. Use tool_output_read with this handleId to read more.',
+                note: toolOutputStore.isRestartPersistenceAvailable()
+                  ? 'Full file content stored. Use tool_output_read with this handleId to read more.'
+                  : 'Full file content is available only until the app closes because secure local storage is unavailable. Use tool_output_read now.',
               };
             }
           }
@@ -688,6 +693,9 @@ function createCatalogTool(spec: CattyToolSpec) {
         }
         return fittedRaw;
       } finally {
+        if (toolOutputStore && deps.chatSessionId) {
+          await toolOutputStore.flush(deps.chatSessionId);
+        }
         slot?.release();
       }
     },

--- a/infrastructure/ai/harness/modelSecretRedaction.test.ts
+++ b/infrastructure/ai/harness/modelSecretRedaction.test.ts
@@ -72,6 +72,7 @@ test('terminal fitting keeps raw output in the local handle but redacts model-vi
 
   assert.doesNotMatch(fitted.stdout, /tok_live/);
   assert.doesNotMatch(fitted.command ?? '', /tok_live/);
+  assert.match(fitted.stdout, /restartPersistence=unavailable \(read before closing the app\)/);
   const handle = store.listPendingHandles('chat-1')[0];
   assert.match(handle.fullContent, /tok_live/);
 });

--- a/infrastructure/ai/harness/terminalCompression.ts
+++ b/infrastructure/ai/harness/terminalCompression.ts
@@ -20,6 +20,7 @@ export interface TerminalOutputHandle {
   totalStdoutChars: number;
   totalStderrChars: number;
   handleId?: string;
+  restartPersistenceAvailable?: boolean;
 }
 
 export interface FitTerminalExecuteResultOptions {
@@ -74,6 +75,7 @@ export function fitTerminalExecuteResultForModel(
       totalStdoutChars: result.stdout.length,
       totalStderrChars: result.stderr.length,
       handleId,
+      restartPersistenceAvailable: options?.toolOutputStore?.isRestartPersistenceAvailable(),
     };
     fitted.stdout = appendOutputHandleNotice(stdout, handle, 'stdout');
     if (result.stderr) {
@@ -91,5 +93,8 @@ function appendOutputHandleNotice(
 ): string {
   const totalChars = stream === 'stdout' ? handle.totalStdoutChars : handle.totalStderrChars;
   const handleSuffix = handle.handleId ? ` handleId=${handle.handleId}` : '';
-  return `${truncated}\n\n[output handle: session=${handle.sessionId}${handle.command ? ` command=${handle.command}` : ''} ${stream}=${totalChars} chars truncated for model context${handleSuffix}]`;
+  const restartSuffix = handle.handleId && handle.restartPersistenceAvailable === false
+    ? ' restartPersistence=unavailable (read before closing the app)'
+    : '';
+  return `${truncated}\n\n[output handle: session=${handle.sessionId}${handle.command ? ` command=${handle.command}` : ''} ${stream}=${totalChars} chars truncated for model context${handleSuffix}${restartSuffix}]`;
 }

--- a/infrastructure/ai/harness/terminalCompression.ts
+++ b/infrastructure/ai/harness/terminalCompression.ts
@@ -75,7 +75,7 @@ export function fitTerminalExecuteResultForModel(
       totalStdoutChars: result.stdout.length,
       totalStderrChars: result.stderr.length,
       handleId,
-      restartPersistenceAvailable: options?.toolOutputStore?.isRestartPersistenceAvailable(),
+      restartPersistenceAvailable: false,
     };
     fitted.stdout = appendOutputHandleNotice(stdout, handle, 'stdout');
     if (result.stderr) {

--- a/infrastructure/ai/harness/toolOutputStore.test.ts
+++ b/infrastructure/ai/harness/toolOutputStore.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { TOOL_OUTPUT_READ_MAX_CHARS, ToolOutputStore } from './toolOutputStore';
+import {
+  TOOL_OUTPUT_READ_MAX_CHARS,
+  type PersistedToolOutputRecord,
+  type ToolOutputPersistence,
+  ToolOutputStore,
+} from './toolOutputStore';
 import { ToolResultDedup } from './toolResultDedup';
 
 test('ToolOutputStore stores and reads truncated output by handle', () => {
@@ -146,7 +151,7 @@ test('ToolOutputStore spills retained output through its persistence adapter', a
   const store = new ToolOutputStore({
     spillThresholdChars: 10,
     persistence: {
-      write: async (_handleId, content) => {
+      write: async (_record, content) => {
         files.set('/netcatty/tool-output.log', content);
         return '/netcatty/tool-output.log';
       },
@@ -186,6 +191,381 @@ test('ToolOutputStore spills retained output through its persistence adapter', a
   store.prune('chat-1');
   await new Promise(resolve => setTimeout(resolve, 0));
   assert.deepEqual(deleted, ['/netcatty/tool-output.log']);
+});
+
+test('ToolOutputStore restores a durable handle after a runtime restart', async () => {
+  const files = new Map<string, { record: PersistedToolOutputRecord; content: string }>();
+  const persistence: ToolOutputPersistence = {
+    write: async (record, content) => {
+      const path = `/netcatty/${record.handleId}.log`;
+      files.set(path, { record, content });
+      return path;
+    },
+    restore: async (handleId, chatSessionId) => {
+      for (const [path, entry] of files) {
+        if (entry.record.handleId !== handleId || entry.record.chatSessionId !== chatSessionId) continue;
+        return { path, record: entry.record };
+      }
+      return null;
+    },
+    read: async (path, input) => {
+      const content = files.get(path)?.content;
+      if (content == null) return null;
+      const startOffset = input.mode === 'tail'
+        ? Math.max(0, content.length - (input.maxChars ?? 12_000))
+        : Math.max(0, input.offset ?? 0);
+      const selected = content.slice(startOffset, startOffset + (input.maxChars ?? 12_000));
+      const endOffset = startOffset + selected.length;
+      return {
+        mode: input.mode ?? 'head',
+        content: selected,
+        totalChars: content.length,
+        startOffset,
+        endOffset,
+        nextOffset: endOffset,
+        hasMore: endOffset < content.length,
+      };
+    },
+    delete: async path => {
+      files.delete(path);
+    },
+  };
+
+  const beforeRestart = new ToolOutputStore({ spillThresholdChars: 0, persistence });
+  const saved = beforeRestart.store({
+    chatSessionId: 'chat-restart',
+    capabilityId: 'terminal.execute',
+    sessionId: 'terminal-1',
+    content: 'restart evidence in the middle',
+  });
+  await saved.spillPromise;
+
+  const afterRestart = new ToolOutputStore({ spillThresholdChars: 0, persistence });
+  const restored = await afterRestart.readChunkAsync({
+    handleId: saved.id,
+    mode: 'search',
+    query: 'evidence',
+  }, 'chat-restart');
+
+  assert.match(restored?.content ?? '', /restart evidence/);
+  assert.equal(afterRestart.get(saved.id, 'chat-restart')?.sessionId, 'terminal-1');
+  assert.equal(await afterRestart.readChunkAsync({ handleId: saved.id }, 'chat-other'), null);
+});
+
+test('ToolOutputStore drops a restored handle when its durable file is missing', async () => {
+  const record: PersistedToolOutputRecord = {
+    schemaVersion: 1,
+    handleId: 'tool-output-missing',
+    chatSessionId: 'chat-1',
+    capabilityId: 'terminal.execute',
+    totalChars: 100,
+    storedChars: 100,
+    sourceTruncated: false,
+    preview: 'preview',
+    storedAt: 1,
+    accessedAt: 1,
+  };
+  const store = new ToolOutputStore({
+    persistence: {
+      write: async () => '/unused',
+      restore: async () => ({ path: '/missing.log', record }),
+      read: async () => null,
+      delete: async () => {},
+    },
+  });
+
+  assert.equal(await store.readChunkAsync({ handleId: record.handleId }, 'chat-1'), null);
+  assert.equal(store.listPendingHandles('chat-1').length, 0);
+});
+
+test('ToolOutputStore can delete durable handles for a chat that was never restored', async () => {
+  const deletedSessions: string[] = [];
+  const store = new ToolOutputStore({
+    persistence: {
+      write: async () => '/unused',
+      restore: async () => null,
+      read: async () => null,
+      delete: async () => {},
+      deleteSession: async chatSessionId => {
+        deletedSessions.push(chatSessionId);
+      },
+    },
+  });
+
+  store.prune('chat-after-restart');
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert.deepEqual(deletedSessions, ['chat-after-restart']);
+});
+
+test('ToolOutputStore can delete durable terminal handles that were never restored', async () => {
+  const deletedTerminalSessions: Array<[string, string]> = [];
+  const store = new ToolOutputStore({
+    persistence: {
+      write: async () => '/unused',
+      restore: async () => null,
+      read: async () => null,
+      delete: async () => {},
+      deleteTerminalSession: async (chatSessionId, terminalSessionId) => {
+        deletedTerminalSessions.push([chatSessionId, terminalSessionId]);
+      },
+    },
+  });
+
+  store.pruneTerminalSession('chat-after-restart', 'terminal-closed');
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert.deepEqual(deletedTerminalSessions, [['chat-after-restart', 'terminal-closed']]);
+});
+
+test('ToolOutputStore does not persist output that arrives after its terminal closed', async () => {
+  let writes = 0;
+  const store = new ToolOutputStore({
+    persistence: {
+      write: async () => {
+        writes += 1;
+        return '/late.log';
+      },
+      read: async () => null,
+      delete: async () => {},
+      deleteTerminalSession: async () => {},
+    },
+  });
+
+  store.pruneTerminalSessionEverywhere('terminal-closed-before-output');
+  const lateHandle = store.store({
+    chatSessionId: 'chat-late-output',
+    capabilityId: 'terminal.execute',
+    sessionId: 'terminal-closed-before-output',
+    content: 'late output',
+  });
+  await store.flush('chat-late-output');
+
+  assert.equal(writes, 0);
+  assert.equal(store.listPendingHandles('chat-late-output').length, 0);
+  assert.equal(await store.readChunkAsync({ handleId: lateHandle.id }, 'chat-late-output'), null);
+});
+
+test('ToolOutputStore does not resurrect a handle when its chat is deleted during restore', async () => {
+  let finishRestore!: (value: { path: string; record: PersistedToolOutputRecord }) => void;
+  const restoreFinished = new Promise<{ path: string; record: PersistedToolOutputRecord }>(resolve => {
+    finishRestore = resolve;
+  });
+  const deletedPaths: string[] = [];
+  const record: PersistedToolOutputRecord = {
+    schemaVersion: 1,
+    handleId: 'tool-output-racing-restore',
+    chatSessionId: 'chat-racing-restore',
+    capabilityId: 'terminal.execute',
+    totalChars: 7,
+    storedChars: 7,
+    sourceTruncated: false,
+    preview: 'private',
+    storedAt: 1,
+    accessedAt: 1,
+  };
+  const store = new ToolOutputStore({
+    persistence: {
+      write: async () => '/unused',
+      restore: async () => restoreFinished,
+      read: async () => ({
+        mode: 'head', content: 'private', totalChars: 7, startOffset: 0, endOffset: 7, nextOffset: 7, hasMore: false,
+      }),
+      delete: async path => {
+        deletedPaths.push(path);
+      },
+      deleteSession: async () => {},
+    },
+  });
+
+  const reading = store.readChunkAsync({ handleId: record.handleId }, record.chatSessionId);
+  store.prune(record.chatSessionId);
+  finishRestore({ path: '/netcatty/racing.log', record });
+
+  assert.equal(await reading, null);
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert.deepEqual(deletedPaths, ['/netcatty/racing.log']);
+  assert.equal(store.listPendingHandles(record.chatSessionId).length, 0);
+});
+
+test('ToolOutputStore waits for chat deletion before starting a later restore', async () => {
+  let finishDeletion!: () => void;
+  const deletionFinished = new Promise<void>(resolve => {
+    finishDeletion = resolve;
+  });
+  let restoreCalls = 0;
+  const store = new ToolOutputStore({
+    persistence: {
+      write: async () => '/unused',
+      restore: async () => {
+        restoreCalls += 1;
+        return null;
+      },
+      read: async () => null,
+      delete: async () => {},
+      deleteSession: async () => deletionFinished,
+    },
+  });
+
+  store.prune('chat-delete-window');
+  const reading = store.readChunkAsync({ handleId: 'old-handle' }, 'chat-delete-window');
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert.equal(restoreCalls, 0);
+
+  finishDeletion();
+  assert.equal(await reading, null);
+  assert.equal(restoreCalls, 1);
+});
+
+test('ToolOutputStore does not resurrect an old handle when its terminal is deleted during restore', async () => {
+  let finishRestore!: (value: { path: string; record: PersistedToolOutputRecord }) => void;
+  const restoreFinished = new Promise<{ path: string; record: PersistedToolOutputRecord }>(resolve => {
+    finishRestore = resolve;
+  });
+  const deletedPaths: string[] = [];
+  const record: PersistedToolOutputRecord = {
+    schemaVersion: 1,
+    handleId: 'tool-output-terminal-race',
+    chatSessionId: 'chat-terminal-race',
+    capabilityId: 'terminal.execute',
+    terminalSessionId: 'terminal-race',
+    totalChars: 7,
+    storedChars: 7,
+    sourceTruncated: false,
+    preview: 'private',
+    storedAt: 1,
+    accessedAt: 1,
+  };
+  const store = new ToolOutputStore({
+    persistence: {
+      write: async () => '/new-output.log',
+      restore: async () => restoreFinished,
+      read: async () => null,
+      delete: async path => {
+        deletedPaths.push(path);
+      },
+      deleteTerminalSession: async () => {},
+    },
+  });
+
+  const reading = store.readChunkAsync({ handleId: record.handleId }, record.chatSessionId);
+  store.pruneTerminalSessionEverywhere(record.terminalSessionId!);
+  store.store({
+    chatSessionId: record.chatSessionId,
+    capabilityId: 'terminal.execute',
+    sessionId: record.terminalSessionId,
+    content: 'new output',
+  });
+  finishRestore({ path: '/netcatty/old-output.log', record });
+
+  assert.equal(await reading, null);
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert.ok(deletedPaths.includes('/netcatty/old-output.log'));
+  assert.equal(store.get(record.handleId, record.chatSessionId), undefined);
+});
+
+test('ToolOutputStore keeps restoring one terminal when a different terminal is deleted', async () => {
+  let finishRestore!: (value: { path: string; record: PersistedToolOutputRecord }) => void;
+  const restoreFinished = new Promise<{ path: string; record: PersistedToolOutputRecord }>(resolve => {
+    finishRestore = resolve;
+  });
+  const record: PersistedToolOutputRecord = {
+    schemaVersion: 1,
+    handleId: 'tool-output-terminal-b',
+    chatSessionId: 'chat-two-terminals',
+    capabilityId: 'terminal.execute',
+    terminalSessionId: 'terminal-b',
+    totalChars: 8,
+    storedChars: 8,
+    sourceTruncated: false,
+    preview: 'terminal',
+    storedAt: 1,
+    accessedAt: 1,
+  };
+  const store = new ToolOutputStore({
+    persistence: {
+      write: async () => '/unused',
+      restore: async () => restoreFinished,
+      read: async () => ({
+        mode: 'head', content: 'terminal', totalChars: 8, startOffset: 0, endOffset: 8, nextOffset: 8, hasMore: false,
+      }),
+      delete: async () => {},
+      deleteTerminalSession: async () => {},
+    },
+  });
+
+  const reading = store.readChunkAsync({ handleId: record.handleId }, record.chatSessionId);
+  store.pruneTerminalSession(record.chatSessionId, 'terminal-a');
+  finishRestore({ path: '/netcatty/terminal-b.log', record });
+
+  assert.equal((await reading)?.content, 'terminal');
+});
+
+test('ToolOutputStore can restore a durable handle after its in-memory cache expires', async () => {
+  let now = 1_000;
+  const files = new Map<string, { record: PersistedToolOutputRecord; content: string }>();
+  const persistence: ToolOutputPersistence = {
+    write: async (record, content) => {
+      const path = `/netcatty/${record.handleId}.log`;
+      files.set(path, { record, content });
+      return path;
+    },
+    restore: async (handleId, chatSessionId) => {
+      for (const [path, entry] of files) {
+        if (entry.record.handleId === handleId && entry.record.chatSessionId === chatSessionId) {
+          return { path, record: entry.record };
+        }
+      }
+      return null;
+    },
+    read: async (path, input) => {
+      const content = files.get(path)?.content;
+      if (content == null) return null;
+      return {
+        mode: input.mode ?? 'head',
+        content,
+        totalChars: content.length,
+        startOffset: 0,
+        endOffset: content.length,
+        nextOffset: content.length,
+        hasMore: false,
+      };
+    },
+    delete: async path => {
+      files.delete(path);
+    },
+  };
+  const store = new ToolOutputStore({ ttlMs: 100, now: () => now, persistence });
+  const handle = store.store({ chatSessionId: 'chat-1', capabilityId: 'test', content: 'durable' });
+  await handle.spillPromise;
+  now += 101;
+
+  const restored = await store.readChunkAsync({ handleId: handle.id }, 'chat-1');
+  assert.equal(restored?.content, 'durable');
+});
+
+test('ToolOutputStore flush waits until a handle is durable before a tool can return it', async () => {
+  let finishWrite!: (path: string) => void;
+  const writeFinished = new Promise<string>(resolve => {
+    finishWrite = resolve;
+  });
+  const store = new ToolOutputStore({
+    persistence: {
+      write: async () => writeFinished,
+      restore: async () => null,
+      read: async () => null,
+      delete: async () => {},
+    },
+  });
+  const handle = store.store({ chatSessionId: 'chat-1', capabilityId: 'test', content: 'persist me' });
+  let flushed = false;
+  const flushing = store.flush('chat-1').then(() => {
+    flushed = true;
+  });
+
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert.equal(flushed, false);
+  finishWrite('/netcatty/durable.log');
+  await flushing;
+  assert.equal(handle.filePath, '/netcatty/durable.log');
 });
 
 test('ToolOutputStore enforces a shared quota across chat sessions', () => {

--- a/infrastructure/ai/harness/toolOutputStore.test.ts
+++ b/infrastructure/ai/harness/toolOutputStore.test.ts
@@ -316,6 +316,25 @@ test('ToolOutputStore can delete durable terminal handles that were never restor
   assert.deepEqual(deletedTerminalSessions, [['chat-after-restart', 'terminal-closed']]);
 });
 
+test('ToolOutputStore deletes unopened durable handles when a terminal closes', async () => {
+  const deletedTerminals: string[] = [];
+  const store = new ToolOutputStore({
+    persistence: {
+      write: async () => '/tmp/unused',
+      read: async () => null,
+      delete: async () => {},
+      deleteTerminalEverywhere: async terminalSessionId => {
+        deletedTerminals.push(terminalSessionId);
+      },
+    },
+  });
+
+  store.pruneTerminalSessionEverywhere('terminal-unopened-after-restart');
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  assert.deepEqual(deletedTerminals, ['terminal-unopened-after-restart']);
+});
+
 test('ToolOutputStore does not persist output that arrives after its terminal closed', async () => {
   let writes = 0;
   const store = new ToolOutputStore({
@@ -566,6 +585,34 @@ test('ToolOutputStore flush waits until a handle is durable before a tool can re
   finishWrite('/netcatty/durable.log');
   await flushing;
   assert.equal(handle.filePath, '/netcatty/durable.log');
+});
+
+test('ToolOutputStore reports restart persistence only after the individual spill succeeds', async () => {
+  let failWrite = true;
+  const store = new ToolOutputStore({
+    persistence: {
+      write: async () => {
+        if (failWrite) throw new Error('disk full');
+        return '/netcatty/durable.log';
+      },
+      restore: async () => null,
+      read: async () => null,
+      delete: async () => {},
+    },
+  });
+  const failed = store.store({ chatSessionId: 'chat-1', capabilityId: 'test', content: 'memory only' });
+  const failedNotice = `[output handle: handleId=${failed.id} restartPersistence=unavailable (read before closing the app)]`;
+  await store.flush('chat-1');
+  assert.equal(store.resolveRestartPersistenceNotices(failedNotice, 'chat-1'), failedNotice);
+
+  failWrite = false;
+  const durable = store.store({ chatSessionId: 'chat-1', capabilityId: 'test', content: 'saved' });
+  const durableNotice = `[output handle: handleId=${durable.id} restartPersistence=unavailable (read before closing the app)]`;
+  await store.flush('chat-1');
+  assert.equal(
+    store.resolveRestartPersistenceNotices(durableNotice, 'chat-1'),
+    `[output handle: handleId=${durable.id}]`,
+  );
 });
 
 test('ToolOutputStore enforces a shared quota across chat sessions', () => {

--- a/infrastructure/ai/harness/toolOutputStore.ts
+++ b/infrastructure/ai/harness/toolOutputStore.ts
@@ -80,6 +80,7 @@ export interface ToolOutputPersistence {
   delete(path: string): Promise<void>;
   deleteSession?(chatSessionId: string): Promise<void>;
   deleteTerminalSession?(chatSessionId: string, terminalSessionId: string): Promise<void>;
+  deleteTerminalEverywhere?(terminalSessionId: string): Promise<void>;
 }
 
 export interface ToolOutputStoreOptions {
@@ -137,7 +138,6 @@ export class ToolOutputStore {
   private readonly deletedTerminalSessions = new Set<string>();
   private readonly closedTerminalSessions = new Set<string>();
   private persistence?: ToolOutputPersistence;
-  private restartPersistenceAvailable = false;
 
   constructor(options: ToolOutputStoreOptions = {}) {
     this.maxHandleChars = options.maxHandleChars ?? TOOL_OUTPUT_MAX_HANDLE_CHARS;
@@ -151,13 +151,12 @@ export class ToolOutputStore {
     this.persistence = options.persistence;
   }
 
-  setPersistence(persistence: ToolOutputPersistence | undefined, restartPersistenceAvailable = Boolean(persistence)): void {
+  setPersistence(persistence: ToolOutputPersistence | undefined): void {
     this.persistence = persistence;
-    this.restartPersistenceAvailable = restartPersistenceAvailable;
   }
 
-  isRestartPersistenceAvailable(): boolean {
-    return this.restartPersistenceAvailable;
+  resolveRestartPersistenceNotices<T>(value: T, chatSessionId: string): T {
+    return this.resolveRestartPersistenceNoticesValue(value, chatSessionId) as T;
   }
 
   store(input: StoreToolOutputInput): ToolOutputHandle {
@@ -300,6 +299,7 @@ export class ToolOutputStore {
     for (const chatSessionId of chatSessionIds) {
       this.pruneTerminalSession(chatSessionId, terminalSessionId);
     }
+    void this.persistence?.deleteTerminalEverywhere?.(terminalSessionId).catch(() => {});
   }
 
   private startSpill(handle: ToolOutputHandle): void {
@@ -316,6 +316,38 @@ export class ToolOutputStore {
     }).catch(() => {
       // Keep the in-memory copy if persistence is temporarily unavailable.
     });
+  }
+
+  private resolveRestartPersistenceNoticesValue(value: unknown, chatSessionId: string): unknown {
+    if (typeof value === 'string') {
+      return this.resolveRestartPersistenceNoticeString(value, chatSessionId);
+    }
+    if (Array.isArray(value)) {
+      return value.map(entry => this.resolveRestartPersistenceNoticesValue(entry, chatSessionId));
+    }
+    if (!value || typeof value !== 'object') return value;
+
+    const record = value as Record<string, unknown>;
+    const handleId = typeof record.handleId === 'string' ? record.handleId : undefined;
+    return Object.fromEntries(Object.entries(record).map(([key, entry]) => {
+      if (typeof entry === 'string' && handleId && this.isHandleRestartPersistent(handleId, chatSessionId)) {
+        return [key, removeRestartPersistenceWarning(entry)];
+      }
+      return [key, this.resolveRestartPersistenceNoticesValue(entry, chatSessionId)];
+    }));
+  }
+
+  private resolveRestartPersistenceNoticeString(value: string, chatSessionId: string): string {
+    const handleIds = [...value.matchAll(/handleId=(tool-output-[A-Za-z0-9-]+)/g)]
+      .map(match => match[1]);
+    if (!handleIds.length) return value;
+    return handleIds.every(handleId => this.isHandleRestartPersistent(handleId, chatSessionId))
+      ? removeRestartPersistenceWarning(value)
+      : value;
+  }
+
+  private isHandleRestartPersistent(handleId: string, chatSessionId: string): boolean {
+    return Boolean(this.bySession.get(chatSessionId)?.get(handleId)?.filePath);
   }
 
   private enforceSessionLimits(chatSessionId: string, sessionMap: Map<string, ToolOutputHandle>): void {
@@ -450,6 +482,18 @@ export class ToolOutputStore {
     if (sessionMap?.size === 0) this.bySession.delete(handle.chatSessionId);
     this.evictHandle(handle);
   }
+}
+
+function removeRestartPersistenceWarning(value: string): string {
+  return value
+    .replace(' restartPersistence=unavailable (read before closing the app)', '')
+    .replace('This saved output is available only until the app closes. Read this handle before closing the app.', '')
+    .replace(
+      'Full file content is available only until the app closes. Use tool_output_read now.',
+      'Full file content stored. Use tool_output_read with this handleId to read more.',
+    )
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd();
 }
 
 function toPersistedRecord(handle: ToolOutputHandle): PersistedToolOutputRecord {

--- a/infrastructure/ai/harness/toolOutputStore.ts
+++ b/infrastructure/ai/harness/toolOutputStore.ts
@@ -1,5 +1,6 @@
 export interface ToolOutputHandle {
   id: string;
+  chatSessionId: string;
   capabilityId: string;
   sessionId?: string;
   totalChars: number;
@@ -12,6 +13,20 @@ export interface ToolOutputHandle {
   filePath?: string;
   spillPromise?: Promise<void>;
   evicted?: boolean;
+}
+
+export interface PersistedToolOutputRecord {
+  schemaVersion: 1;
+  handleId: string;
+  chatSessionId: string;
+  capabilityId: string;
+  terminalSessionId?: string;
+  totalChars: number;
+  storedChars: number;
+  sourceTruncated: boolean;
+  preview: string;
+  storedAt: number;
+  accessedAt: number;
 }
 
 export interface StoreToolOutputInput {
@@ -51,14 +66,20 @@ export const TOOL_OUTPUT_MAX_CHARS_PER_SESSION = 8_000_000;
 export const TOOL_OUTPUT_MAX_HANDLES_GLOBAL = 256;
 export const TOOL_OUTPUT_MAX_CHARS_GLOBAL = 32_000_000;
 export const TOOL_OUTPUT_TTL_MS = 30 * 60 * 1_000;
-export const TOOL_OUTPUT_SPILL_THRESHOLD_CHARS = 128_000;
+export const TOOL_OUTPUT_SPILL_THRESHOLD_CHARS = 0;
 const TOOL_OUTPUT_SEARCH_CONTEXT_CHARS = 320;
 const TOOL_OUTPUT_SEARCH_MAX_MATCHES = 20;
 
 export interface ToolOutputPersistence {
-  write(handleId: string, content: string): Promise<string>;
+  write(record: PersistedToolOutputRecord, content: string): Promise<string>;
+  restore?(
+    handleId: string,
+    chatSessionId: string,
+  ): Promise<{ path: string; record: PersistedToolOutputRecord } | null>;
   read(path: string, input: ReadToolOutputInput): Promise<Omit<ToolOutputReadResult, 'handleId' | 'storedChars' | 'sourceTruncated'> | null>;
   delete(path: string): Promise<void>;
+  deleteSession?(chatSessionId: string): Promise<void>;
+  deleteTerminalSession?(chatSessionId: string, terminalSessionId: string): Promise<void>;
 }
 
 export interface ToolOutputStoreOptions {
@@ -109,7 +130,14 @@ export class ToolOutputStore {
   private readonly ttlMs: number;
   private readonly spillThresholdChars: number;
   private readonly now: () => number;
+  private readonly restorePromises = new Map<string, Promise<ToolOutputHandle | undefined>>();
+  private readonly sessionGenerations = new Map<string, number>();
+  private readonly sessionDeletionPromises = new Map<string, Promise<void>>();
+  private readonly terminalMutationGenerations = new Map<string, number>();
+  private readonly deletedTerminalSessions = new Set<string>();
+  private readonly closedTerminalSessions = new Set<string>();
   private persistence?: ToolOutputPersistence;
+  private restartPersistenceAvailable = false;
 
   constructor(options: ToolOutputStoreOptions = {}) {
     this.maxHandleChars = options.maxHandleChars ?? TOOL_OUTPUT_MAX_HANDLE_CHARS;
@@ -123,8 +151,13 @@ export class ToolOutputStore {
     this.persistence = options.persistence;
   }
 
-  setPersistence(persistence: ToolOutputPersistence | undefined): void {
+  setPersistence(persistence: ToolOutputPersistence | undefined, restartPersistenceAvailable = Boolean(persistence)): void {
     this.persistence = persistence;
+    this.restartPersistenceAvailable = restartPersistenceAvailable;
+  }
+
+  isRestartPersistenceAvailable(): boolean {
+    return this.restartPersistenceAvailable;
   }
 
   store(input: StoreToolOutputInput): ToolOutputHandle {
@@ -133,6 +166,7 @@ export class ToolOutputStore {
     const now = this.now();
     const handle: ToolOutputHandle = {
       id: nextHandleId(),
+      chatSessionId: input.chatSessionId,
       capabilityId: input.capabilityId,
       sessionId: input.sessionId,
       totalChars: input.content.length,
@@ -143,6 +177,11 @@ export class ToolOutputStore {
       accessedAt: now,
       fullContent: retainedContent,
     };
+    if (input.sessionId && this.closedTerminalSessions.has(input.sessionId)) {
+      handle.evicted = true;
+      handle.fullContent = undefined;
+      return handle;
+    }
     const sessionMap = this.bySession.get(input.chatSessionId) ?? new Map<string, ToolOutputHandle>();
     sessionMap.set(handle.id, handle);
     this.bySession.set(input.chatSessionId, sessionMap);
@@ -174,6 +213,11 @@ export class ToolOutputStore {
     return [...(this.bySession.get(chatSessionId)?.values() ?? [])];
   }
 
+  async flush(chatSessionId: string): Promise<void> {
+    const handles = [...(this.bySession.get(chatSessionId)?.values() ?? [])];
+    await Promise.allSettled(handles.map(handle => handle.spillPromise));
+  }
+
   read(input: ReadToolOutputInput, chatSessionId?: string): string | null {
     return this.readChunk(input, chatSessionId)?.content ?? null;
   }
@@ -186,13 +230,19 @@ export class ToolOutputStore {
   }
 
   async readChunkAsync(input: ReadToolOutputInput, chatSessionId?: string): Promise<ToolOutputReadResult | null> {
-    const handle = this.get(input.handleId, chatSessionId);
+    let handle = this.get(input.handleId, chatSessionId);
+    if (!handle && chatSessionId) {
+      handle = await this.restoreHandle(input.handleId, chatSessionId);
+    }
     if (!handle) return null;
     await handle.spillPromise;
     if (handle.fullContent != null) return buildReadResult(handle, handle.fullContent, input);
     if (!handle.filePath || !this.persistence) return null;
     const persisted = await this.persistence.read(handle.filePath, input);
-    if (!persisted) return null;
+    if (!persisted) {
+      this.removeHandle(handle);
+      return null;
+    }
     return {
       ...persisted,
       handleId: handle.id,
@@ -203,29 +253,60 @@ export class ToolOutputStore {
   }
 
   prune(chatSessionId: string): void {
+    this.sessionGenerations.set(chatSessionId, (this.sessionGenerations.get(chatSessionId) ?? 0) + 1);
+    for (const key of this.deletedTerminalSessions) {
+      if (key.startsWith(`${chatSessionId}:`)) this.deletedTerminalSessions.delete(key);
+    }
     const sessionMap = this.bySession.get(chatSessionId);
     if (sessionMap) {
       for (const handle of sessionMap.values()) this.evictHandle(handle);
     }
     this.bySession.delete(chatSessionId);
+    const deletion = this.persistence?.deleteSession?.(chatSessionId)
+      .catch(() => {})
+      .then(() => {});
+    if (deletion) {
+      this.sessionDeletionPromises.set(chatSessionId, deletion);
+      void deletion.finally(() => {
+        if (this.sessionDeletionPromises.get(chatSessionId) === deletion) {
+          this.sessionDeletionPromises.delete(chatSessionId);
+        }
+      });
+    }
   }
 
   pruneTerminalSession(chatSessionId: string, terminalSessionId: string): void {
+    const terminalKey = `${chatSessionId}:${terminalSessionId}`;
+    this.deletedTerminalSessions.add(terminalKey);
+    this.terminalMutationGenerations.set(
+      terminalKey,
+      (this.terminalMutationGenerations.get(terminalKey) ?? 0) + 1,
+    );
     const sessionMap = this.bySession.get(chatSessionId);
-    if (!sessionMap) return;
-    for (const [handleId, handle] of sessionMap) {
-      if (handle.sessionId !== terminalSessionId) continue;
-      sessionMap.delete(handleId);
-      this.evictHandle(handle);
+    if (sessionMap) {
+      for (const [handleId, handle] of sessionMap) {
+        if (handle.sessionId !== terminalSessionId) continue;
+        sessionMap.delete(handleId);
+        this.evictHandle(handle);
+      }
+      if (sessionMap.size === 0) this.bySession.delete(chatSessionId);
     }
-    if (sessionMap.size === 0) this.bySession.delete(chatSessionId);
+    void this.persistence?.deleteTerminalSession?.(chatSessionId, terminalSessionId).catch(() => {});
+  }
+
+  pruneTerminalSessionEverywhere(terminalSessionId: string): void {
+    this.closedTerminalSessions.add(terminalSessionId);
+    const chatSessionIds = [...this.bySession.keys()];
+    for (const chatSessionId of chatSessionIds) {
+      this.pruneTerminalSession(chatSessionId, terminalSessionId);
+    }
   }
 
   private startSpill(handle: ToolOutputHandle): void {
     if (!this.persistence || (handle.fullContent?.length ?? 0) < this.spillThresholdChars) return;
     const persistence = this.persistence;
     const content = handle.fullContent!;
-    handle.spillPromise = persistence.write(handle.id, content).then(async path => {
+    handle.spillPromise = persistence.write(toPersistedRecord(handle), content).then(async path => {
       if (handle.evicted) {
         await persistence.delete(path);
         return;
@@ -257,7 +338,7 @@ export class ToolOutputStore {
       for (const [handleId, handle] of sessionMap) {
         if (handle.accessedAt > cutoff) continue;
         sessionMap.delete(handleId);
-        this.evictHandle(handle);
+        if (!handle.filePath) this.evictHandle(handle);
       }
       if (sessionMap.size === 0) this.bySession.delete(chatSessionId);
     }
@@ -285,6 +366,127 @@ export class ToolOutputStore {
       void this.persistence.delete(handle.filePath).catch(() => {});
     }
   }
+
+  private async restoreHandle(handleId: string, chatSessionId: string): Promise<ToolOutputHandle | undefined> {
+    if (!this.persistence?.restore) return undefined;
+    const pendingDeletion = this.sessionDeletionPromises.get(chatSessionId);
+    if (pendingDeletion) await pendingDeletion;
+    const key = `${chatSessionId}:${handleId}`;
+    const pending = this.restorePromises.get(key);
+    if (pending) return pending;
+
+    const generation = this.sessionGenerations.get(chatSessionId) ?? 0;
+    const terminalMutationGenerations = new Map(this.terminalMutationGenerations);
+    const restorePromise = this.restoreHandleImpl(
+      handleId,
+      chatSessionId,
+      generation,
+      terminalMutationGenerations,
+    ).finally(() => {
+      this.restorePromises.delete(key);
+    });
+    this.restorePromises.set(key, restorePromise);
+    return restorePromise;
+  }
+
+  private async restoreHandleImpl(
+    handleId: string,
+    chatSessionId: string,
+    generation: number,
+    terminalMutationGenerations: Map<string, number>,
+  ): Promise<ToolOutputHandle | undefined> {
+    const restored = await this.persistence?.restore?.(handleId, chatSessionId);
+    if (!restored || !isValidPersistedRecord(restored.record, handleId, chatSessionId)) return undefined;
+    const restoredTerminalKey = restored.record.terminalSessionId
+      ? `${chatSessionId}:${restored.record.terminalSessionId}`
+      : undefined;
+    if (
+      (this.sessionGenerations.get(chatSessionId) ?? 0) !== generation
+      || (
+        restoredTerminalKey
+        && (this.terminalMutationGenerations.get(restoredTerminalKey) ?? 0)
+          !== (terminalMutationGenerations.get(restoredTerminalKey) ?? 0)
+      )
+      || (
+        restoredTerminalKey
+        && this.deletedTerminalSessions.has(restoredTerminalKey)
+      )
+      || (
+        restored.record.terminalSessionId
+        && this.closedTerminalSessions.has(restored.record.terminalSessionId)
+      )
+    ) {
+      void this.persistence?.delete(restored.path).catch(() => {});
+      return undefined;
+    }
+
+    const record = restored.record;
+    const handle: ToolOutputHandle = {
+      id: record.handleId,
+      chatSessionId: record.chatSessionId,
+      capabilityId: record.capabilityId,
+      sessionId: record.terminalSessionId,
+      totalChars: record.totalChars,
+      storedChars: record.storedChars,
+      sourceTruncated: record.sourceTruncated,
+      preview: record.preview,
+      storedAt: record.storedAt,
+      accessedAt: this.now(),
+      filePath: restored.path,
+    };
+    const sessionMap = this.bySession.get(chatSessionId) ?? new Map<string, ToolOutputHandle>();
+    const existing = sessionMap.get(handleId);
+    if (existing) return existing;
+    sessionMap.set(handleId, handle);
+    this.bySession.set(chatSessionId, sessionMap);
+    this.enforceSessionLimits(chatSessionId, sessionMap);
+    this.enforceGlobalLimits();
+    return sessionMap.get(handleId);
+  }
+
+  private removeHandle(handle: ToolOutputHandle): void {
+    const sessionMap = this.bySession.get(handle.chatSessionId);
+    sessionMap?.delete(handle.id);
+    if (sessionMap?.size === 0) this.bySession.delete(handle.chatSessionId);
+    this.evictHandle(handle);
+  }
+}
+
+function toPersistedRecord(handle: ToolOutputHandle): PersistedToolOutputRecord {
+  return {
+    schemaVersion: 1,
+    handleId: handle.id,
+    chatSessionId: handle.chatSessionId,
+    capabilityId: handle.capabilityId,
+    terminalSessionId: handle.sessionId,
+    totalChars: handle.totalChars,
+    storedChars: handle.storedChars,
+    sourceTruncated: handle.sourceTruncated,
+    preview: handle.preview,
+    storedAt: handle.storedAt,
+    accessedAt: handle.accessedAt,
+  };
+}
+
+function isValidPersistedRecord(
+  record: PersistedToolOutputRecord,
+  handleId: string,
+  chatSessionId: string,
+): boolean {
+  return record?.schemaVersion === 1
+    && record.handleId === handleId
+    && record.chatSessionId === chatSessionId
+    && typeof record.capabilityId === 'string'
+    && record.capabilityId.length > 0
+    && Number.isFinite(record.totalChars)
+    && record.totalChars >= 0
+    && Number.isFinite(record.storedChars)
+    && record.storedChars >= 0
+    && record.storedChars <= TOOL_OUTPUT_MAX_HANDLE_CHARS
+    && typeof record.sourceTruncated === 'boolean'
+    && typeof record.preview === 'string'
+    && Number.isFinite(record.storedAt)
+    && Number.isFinite(record.accessedAt);
 }
 
 function retainBoundedContent(content: string, maxChars: number): string {

--- a/infrastructure/ai/harness/toolResultFitting.ts
+++ b/infrastructure/ai/harness/toolResultFitting.ts
@@ -108,6 +108,7 @@ function fitString(value: string, ctx: FitValueContext): string {
     fieldPath: formatFieldPath(ctx.path),
     totalChars: value.length,
     handleId,
+    restartPersistenceAvailable: ctx.toolOutputStore?.isRestartPersistenceAvailable(),
   });
 }
 
@@ -128,8 +129,12 @@ function appendToolOutputHandleNotice(
     fieldPath: string;
     totalChars: number;
     handleId?: string;
+    restartPersistenceAvailable?: boolean;
   },
 ): string {
   const handleSuffix = details.handleId ? ` handleId=${details.handleId}` : '';
-  return `${fitted}\n\n[tool output handle: capability=${details.capabilityId} field=${details.fieldPath} chars=${details.totalChars} truncated for model context${handleSuffix}]`;
+  const restartSuffix = details.handleId && details.restartPersistenceAvailable === false
+    ? ' restartPersistence=unavailable (read before closing the app)'
+    : '';
+  return `${fitted}\n\n[tool output handle: capability=${details.capabilityId} field=${details.fieldPath} chars=${details.totalChars} truncated for model context${handleSuffix}${restartSuffix}]`;
 }

--- a/infrastructure/ai/harness/toolResultFitting.ts
+++ b/infrastructure/ai/harness/toolResultFitting.ts
@@ -108,7 +108,7 @@ function fitString(value: string, ctx: FitValueContext): string {
     fieldPath: formatFieldPath(ctx.path),
     totalChars: value.length,
     handleId,
-    restartPersistenceAvailable: ctx.toolOutputStore?.isRestartPersistenceAvailable(),
+    restartPersistenceAvailable: false,
   });
 }
 

--- a/infrastructure/ai/harness/turnDrivers/cattyTurnDriver.ts
+++ b/infrastructure/ai/harness/turnDrivers/cattyTurnDriver.ts
@@ -117,9 +117,14 @@ async function runCattyTurn(input: CattyTurnInput, ctx: TurnDriverContext): Prom
           await toolOutputTempBridge.deleteTerminalToolOutputsTemp!(chatSessionId, terminalSessionId);
         }
         : undefined,
-    }, Boolean(persistenceStatus?.durable));
+      deleteTerminalEverywhere: toolOutputTempBridge.deleteTerminalToolOutputsEverywhereTemp
+        ? async terminalSessionId => {
+          await toolOutputTempBridge.deleteTerminalToolOutputsEverywhereTemp!(terminalSessionId);
+        }
+        : undefined,
+    });
   } else {
-    ctx.toolOutputStore.setPersistence?.(undefined, false);
+    ctx.toolOutputStore.setPersistence?.(undefined);
   }
   await clearChatSessionCancelled(sessionId, netcattyBridge);
   if (netcattyBridge.aiMcpUpdateSessions) {

--- a/infrastructure/ai/harness/turnDrivers/cattyTurnDriver.ts
+++ b/infrastructure/ai/harness/turnDrivers/cattyTurnDriver.ts
@@ -62,31 +62,64 @@ async function runCattyTurn(input: CattyTurnInput, ctx: TurnDriverContext): Prom
 
   const netcattyBridge = (bridge ?? getNetcattyBridge()) as NonNullable<ReturnType<typeof getNetcattyBridge>>;
   const toolOutputTempBridge = netcattyBridge as typeof netcattyBridge & {
-    writeToolOutputTemp?: (handleId: string, content: string) => Promise<{ ok: boolean; path?: string; error?: string }>;
+    getToolOutputPersistenceStatus?: () => Promise<{ durable: boolean; reason?: string }>;
+    writeToolOutputTemp?: (
+      record: import('../toolOutputStore').PersistedToolOutputRecord,
+      content: string,
+    ) => Promise<{ ok: boolean; path?: string; error?: string }>;
+    restoreToolOutputTemp?: (
+      handleId: string,
+      chatSessionId: string,
+    ) => Promise<{ path: string; record: import('../toolOutputStore').PersistedToolOutputRecord } | null>;
     readToolOutputTemp?: (
       path: string,
       request: import('../toolOutputStore').ReadToolOutputInput,
     ) => Promise<Omit<import('../toolOutputStore').ToolOutputReadResult, 'handleId' | 'storedChars' | 'sourceTruncated'> | null>;
     deleteToolOutputTemp?: (path: string) => Promise<{ ok: boolean }>;
+    deleteChatToolOutputsTemp?: (chatSessionId: string) => Promise<{ deletedCount: number }>;
+    deleteTerminalToolOutputsTemp?: (
+      chatSessionId: string,
+      terminalSessionId: string,
+    ) => Promise<{ deletedCount: number }>;
   };
+  const persistenceStatus = await toolOutputTempBridge.getToolOutputPersistenceStatus?.()
+    .catch(() => ({ durable: false }));
   if (
     toolOutputTempBridge.writeToolOutputTemp
     && toolOutputTempBridge.readToolOutputTemp
     && toolOutputTempBridge.deleteToolOutputTemp
   ) {
-    ctx.toolOutputStore.setPersistence({
-      write: async (handleId, content) => {
-        const result = await toolOutputTempBridge.writeToolOutputTemp!(handleId, content);
+    ctx.toolOutputStore.setPersistence?.({
+      write: async (record, content) => {
+        if (!persistenceStatus?.durable) {
+          throw new Error(persistenceStatus?.reason || 'Secure local storage is unavailable.');
+        }
+        const result = await toolOutputTempBridge.writeToolOutputTemp!(record, content);
         if (!result.ok || !result.path) {
           throw new Error(result.error || 'Unable to persist tool output.');
         }
         return result.path;
       },
+      restore: persistenceStatus?.durable && toolOutputTempBridge.restoreToolOutputTemp
+        ? (handleId, chatSessionId) => toolOutputTempBridge.restoreToolOutputTemp!(handleId, chatSessionId)
+        : undefined,
       read: (path, request) => toolOutputTempBridge.readToolOutputTemp!(path, request),
       delete: async path => {
         await toolOutputTempBridge.deleteToolOutputTemp!(path);
       },
-    });
+      deleteSession: toolOutputTempBridge.deleteChatToolOutputsTemp
+        ? async chatSessionId => {
+          await toolOutputTempBridge.deleteChatToolOutputsTemp!(chatSessionId);
+        }
+        : undefined,
+      deleteTerminalSession: toolOutputTempBridge.deleteTerminalToolOutputsTemp
+        ? async (chatSessionId, terminalSessionId) => {
+          await toolOutputTempBridge.deleteTerminalToolOutputsTemp!(chatSessionId, terminalSessionId);
+        }
+        : undefined,
+    }, Boolean(persistenceStatus?.durable));
+  } else {
+    ctx.toolOutputStore.setPersistence?.(undefined, false);
   }
   await clearChatSessionCancelled(sessionId, netcattyBridge);
   if (netcattyBridge.aiMcpUpdateSessions) {

--- a/types/global/netcatty-bridge-files.d.ts
+++ b/types/global/netcatty-bridge-files.d.ts
@@ -62,7 +62,12 @@ declare global {
     clearTempDir?(): Promise<{ deletedCount: number; failedCount: number; error?: string }>;
     getTempDirPath?(): Promise<string>;
     openTempDir?(): Promise<{ success: boolean }>;
-    writeToolOutputTemp?(handleId: string, content: string): Promise<{ ok: boolean; path?: string; error?: string }>;
+    getToolOutputPersistenceStatus?(): Promise<{ durable: boolean; reason?: string }>;
+    writeToolOutputTemp?(record: import('../../infrastructure/ai/harness/toolOutputStore').PersistedToolOutputRecord, content: string): Promise<{ ok: boolean; path?: string; manifestPath?: string; error?: string }>;
+    restoreToolOutputTemp?(handleId: string, chatSessionId: string): Promise<{
+      path: string;
+      record: import('../../infrastructure/ai/harness/toolOutputStore').PersistedToolOutputRecord;
+    } | null>;
     readToolOutputTemp?(filePath: string, request?: {
       mode?: 'head' | 'tail' | 'full' | 'range' | 'search';
       maxChars?: number;
@@ -70,6 +75,9 @@ declare global {
       query?: string;
     }): Promise<unknown | null>;
     deleteToolOutputTemp?(filePath: string): Promise<{ ok: boolean }>;
+    deleteChatToolOutputsTemp?(chatSessionId: string): Promise<{ deletedCount: number }>;
+    deleteTerminalToolOutputsTemp?(chatSessionId: string, terminalSessionId: string): Promise<{ deletedCount: number }>;
+    deleteTerminalToolOutputsEverywhereTemp?(terminalSessionId: string): Promise<{ deletedCount: number }>;
 
     // Session Logs
     exportSessionLog?(payload: {


### PR DESCRIPTION
## Summary

- persist Catty saved-output handles in Netcatty's private temp directory so the same handle remains readable after an app restart
- keep model context bounded: tool results still carry only previews/handles, while range/search reads retain their existing per-read and per-turn limits
- bind every saved output to its chat and terminal, authenticate metadata and content, and reject cross-chat access or local tampering
- clean saved output on chat deletion, message clearing, terminal close, workspace close, TTL expiry, and quota eviction, including close/write/read races
- degrade explicitly to memory-only handles when secure OS storage is unavailable without deleting existing durable output

## Why

This follows the useful part of Grok Build's design—large terminal output becomes a session asset on disk—but preserves Catty's opaque handle API instead of exposing local file paths. Unlike Grok's restart hint, the original Catty handle is restored and remains searchable after a real process restart.

This is a follow-up to #2273, which is already merged. The branch was rebased onto current `main`.

## Validation

- 462 application/AI harness tests passed in the full targeted suite
- 17 temp-directory bridge tests passed
- real two-process restart test: write in process A, restore and read in process B
- wrong-key, cross-chat, tamper, same-mtime replacement, crash residue, TTL/quota, and unavailable-secure-storage coverage
- controlled terminal-close/read interleaving leaves no readable handle or disk files
- `npm run build`
- `npm run lint -- --quiet`
- `git diff --check`
- three independent review tracks completed clean (requirements, correctness, security/persistence)
