### PR TITLE
fix(portforward): keep runtime status accurate

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -412,6 +412,7 @@ function App({ settings }: { settings: SettingsState }) {
     startTunnel,
     stopTunnel,
     stopRuleTunnels,
+    hasRuntimeTunnel,
   } = usePortForwardingState();
 
   // App-level External MCP session sync (before TerminalLayer lazy-mount).
@@ -627,7 +628,7 @@ function App({ settings }: { settings: SettingsState }) {
   // Window controls - must be before update toast effect which uses openSettingsWindow
   const { openSettingsWindow } = useWindowControls();
   const _handleTrayJumpToSession = useEffectEvent((sessionId: string) => { return handleTrayJumpToSessionImpl(() => ({ sessionId, sessions, setActiveTabId, setWorkspaceFocusedSession }), sessionId); });
-  const _handleTrayTogglePortForward = useEffectEvent((ruleId: string, start: boolean) => { return handleTrayTogglePortForwardImpl(() => ({ hosts, identities, keys, knownHosts: effectiveKnownHosts, portForwardingRules, resolveEffectiveHost, ruleId, start, startTunnel, stopTunnel, t, terminalSettings, toast, undefined }), ruleId, start); });
+  const _handleTrayTogglePortForward = useEffectEvent((ruleId: string, start: boolean) => { return handleTrayTogglePortForwardImpl(() => ({ hasRuntimeTunnel, hosts, identities, keys, knownHosts: effectiveKnownHosts, portForwardingRules, resolveEffectiveHost, ruleId, start, startTunnel, stopTunnel, t, terminalSettings, toast, undefined }), ruleId, start); });
   const _handleTrayPanelConnect = useEffectEvent((hostId: string) => { return handleTrayPanelConnectImpl(() => ({ addConnectionLog, connectToHost, hostId, hosts, identities, keys, resolveEffectiveHost, resolveHostAuth, systemInfoRef, t, toast }), hostId); });
   const _handleTrayPanelConnectRequest = useEffectEvent((hostId: string) => { return handleTrayPanelConnectRequestImpl(() => ({ connectNow: _handleTrayPanelConnect, hostId, isVaultInitialized, queueConnect: (queuedHostId: string) => setPendingTrayPanelConnectHostIds((prev) => [...prev, queuedHostId]) }), hostId); });
   const _handleGlobalHotkeyKeyDown = useEffectEvent((e: KeyboardEvent) => { return handleGlobalHotkeyKeyDownImpl(() => ({ HOTKEY_DEBUG, closeTabKeyStr, e, executeHotkeyAction, hotkeyScheme, keyBindings, matchesKeyBinding }), e); });

--- a/App.tsx
+++ b/App.tsx
@@ -634,7 +634,7 @@ function App({ settings }: { settings: SettingsState }) {
   const _handleGlobalHotkeyKeyDown = useEffectEvent((e: KeyboardEvent) => { return handleGlobalHotkeyKeyDownImpl(() => ({ HOTKEY_DEBUG, closeTabKeyStr, e, executeHotkeyAction, hotkeyScheme, keyBindings, matchesKeyBinding }), e); });
   const _handleEscapeKeyDown = useEffectEvent((e: KeyboardEvent) => { return handleEscapeKeyDownImpl(() => ({ e, isQuickSwitcherOpen, setIsQuickSwitcherOpen }), e); });
 
-  useAppStartupEffects({ dismissUpdate, enabled: !isPeerSessionWindow, groupConfigs, hosts, identities, installUpdate, isVaultInitialized, keys, knownHosts: effectiveKnownHosts, openSettingsWindow, portForwardingRules, proxyProfiles, sessions, setKeyboardInteractiveQueue, t, terminalSettings, updateState, workspaces });
+  useAppStartupEffects({ dismissUpdate, enabled: !isPeerSessionWindow, groupConfigs, hasRuntimeTunnel, hosts, identities, installUpdate, isVaultInitialized, keys, knownHosts: effectiveKnownHosts, openSettingsWindow, portForwardingRules, proxyProfiles, sessions, setKeyboardInteractiveQueue, t, terminalSettings, updateState, workspaces });
 
   useEffect(() => {
     if (isPeerSessionWindow) return;

--- a/application/app/AppHandlers.portForwarding.test.ts
+++ b/application/app/AppHandlers.portForwarding.test.ts
@@ -32,12 +32,17 @@ function createContext(options: { requestedStart: boolean; hasRuntimeTunnel: boo
   return calls;
 }
 
-test('tray retries stop when a failed cleanup left a runtime tunnel', () => {
+test('tray ignores a stale start request when the tunnel is already running', () => {
   const calls = createContext({ requestedStart: true, hasRuntimeTunnel: true });
-  assert.deepEqual(calls, { start: 0, stop: 1 });
+  assert.deepEqual(calls, { start: 0, stop: 0 });
 });
 
 test('tray starts an inactive rule when no runtime tunnel exists', () => {
   const calls = createContext({ requestedStart: true, hasRuntimeTunnel: false });
   assert.deepEqual(calls, { start: 1, stop: 0 });
+});
+
+test('tray stop requests remain idempotent', () => {
+  const calls = createContext({ requestedStart: false, hasRuntimeTunnel: false });
+  assert.deepEqual(calls, { start: 0, stop: 1 });
 });

--- a/application/app/AppHandlers.portForwarding.test.ts
+++ b/application/app/AppHandlers.portForwarding.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { handleTrayTogglePortForwardImpl } from './AppHandlers';
+
+const rule = { id: 'rule-1', hostId: 'host-1' };
+const host = { id: 'host-1' };
+
+function createContext(options: { requestedStart: boolean; hasRuntimeTunnel: boolean }) {
+  const calls = { start: 0, stop: 0 };
+  const context = {
+    hasRuntimeTunnel: () => options.hasRuntimeTunnel,
+    hosts: [host],
+    identities: [],
+    keys: [],
+    knownHosts: [],
+    portForwardingRules: [rule],
+    resolveEffectiveHost: (value: unknown) => value,
+    startTunnel: () => {
+      calls.start += 1;
+      return Promise.resolve();
+    },
+    stopTunnel: () => {
+      calls.stop += 1;
+      return Promise.resolve({ success: true });
+    },
+    t: (key: string) => key,
+    terminalSettings: {},
+    toast: { error: () => undefined },
+  };
+
+  handleTrayTogglePortForwardImpl(() => context, rule.id, options.requestedStart);
+  return calls;
+}
+
+test('tray retries stop when a failed cleanup left a runtime tunnel', () => {
+  const calls = createContext({ requestedStart: true, hasRuntimeTunnel: true });
+  assert.deepEqual(calls, { start: 0, stop: 1 });
+});
+
+test('tray starts an inactive rule when no runtime tunnel exists', () => {
+  const calls = createContext({ requestedStart: true, hasRuntimeTunnel: false });
+  assert.deepEqual(calls, { start: 1, stop: 0 });
+});

--- a/application/app/AppHandlers.ts
+++ b/application/app/AppHandlers.ts
@@ -47,11 +47,13 @@ export function handleTrayTogglePortForwardImpl(getCtx: AppContextGetter, ruleId
       return;
     }
 
-    if (start && !hasRuntimeTunnel(ruleId)) {
-      const effectiveHost = resolveEffectiveHost(host);
-      void startTunnel(rule, effectiveHost, hosts.map(resolveEffectiveHost), keys, identities, (status, error) => {
-        if (status === "error" && error) toast.error(error);
-      }, rule.autoStart, terminalSettings, knownHosts);
+    if (start) {
+      if (!hasRuntimeTunnel(ruleId)) {
+        const effectiveHost = resolveEffectiveHost(host);
+        void startTunnel(rule, effectiveHost, hosts.map(resolveEffectiveHost), keys, identities, (status, error) => {
+          if (status === "error" && error) toast.error(error);
+        }, rule.autoStart, terminalSettings, knownHosts);
+      }
       return;
     }
 

--- a/application/app/AppHandlers.ts
+++ b/application/app/AppHandlers.ts
@@ -37,7 +37,7 @@ export function handleTrayJumpToSessionImpl(getCtx: AppContextGetter, sessionId:
 }
 
 export function handleTrayTogglePortForwardImpl(getCtx: AppContextGetter, ruleId: string, start: boolean) {
-  const { hosts, identities, keys, knownHosts, portForwardingRules, resolveEffectiveHost, startTunnel, stopTunnel, t, terminalSettings, toast } = getCtx();
+  const { hasRuntimeTunnel, hosts, identities, keys, knownHosts, portForwardingRules, resolveEffectiveHost, startTunnel, stopTunnel, t, terminalSettings, toast } = getCtx();
 {
     const rule = portForwardingRules.find((item) => item.id === ruleId);
     if (!rule) return;
@@ -47,7 +47,7 @@ export function handleTrayTogglePortForwardImpl(getCtx: AppContextGetter, ruleId
       return;
     }
 
-    if (start) {
+    if (start && !hasRuntimeTunnel(ruleId)) {
       const effectiveHost = resolveEffectiveHost(host);
       void startTunnel(rule, effectiveHost, hosts.map(resolveEffectiveHost), keys, identities, (status, error) => {
         if (status === "error" && error) toast.error(error);

--- a/application/app/AppHandlers.ts
+++ b/application/app/AppHandlers.ts
@@ -55,7 +55,9 @@ export function handleTrayTogglePortForwardImpl(getCtx: AppContextGetter, ruleId
       return;
     }
 
-    void stopTunnel(ruleId);
+    void stopTunnel(ruleId).then((result) => {
+      if (!result.success && result.error) toast.error(result.error);
+    });
   }
 }
 

--- a/application/app/useAppStartupEffects.ts
+++ b/application/app/useAppStartupEffects.ts
@@ -27,7 +27,7 @@ export function shouldQueueKeyboardInteractiveRequest(
 
 export function useAppStartupEffects(ctx: StartupEffectsContext) {
   const {dismissUpdate, enabled = true, groupConfigs, hosts, identities,
-    installUpdate, isVaultInitialized, keys, knownHosts, openSettingsWindow, portForwardingRules, proxyProfiles, sessions, setKeyboardInteractiveQueue,
+    hasRuntimeTunnel, installUpdate, isVaultInitialized, keys, knownHosts, openSettingsWindow, portForwardingRules, proxyProfiles, sessions, setKeyboardInteractiveQueue,
     t, terminalSettings, updateState, workspaces,
   } = ctx;
   const sessionsRef = useRef(sessions);
@@ -146,7 +146,10 @@ export function useAppStartupEffects(ctx: StartupEffectsContext) {
 
       void bridge.updateTrayMenuData({
         sessions: sessionsForTray,
-        portForwardRules: portForwardingRules,
+        portForwardRules: portForwardingRules.map((rule: any) => ({
+          ...rule,
+          canStop: hasRuntimeTunnel(rule.id),
+        })),
         hosts: hostsForSystemMenu,
       });
     }, 250);
@@ -155,7 +158,7 @@ export function useAppStartupEffects(ctx: StartupEffectsContext) {
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [enabled, hosts, sessions, portForwardingRules, workspaces]);
+  }, [enabled, hasRuntimeTunnel, hosts, sessions, portForwardingRules, workspaces]);
 
   // Quit guard: block app exit while any editor tab has unsaved changes.
   // Main process sends "app:query-dirty-editors"; we respond with the result.

--- a/application/state/usePortForwardingAutoStart.test.ts
+++ b/application/state/usePortForwardingAutoStart.test.ts
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { getAutoStartRuleBlockReason, isAutoStartProxyReady } from "./usePortForwardingAutoStart.ts";
+import {
+  getAutoStartRuleBlockReason,
+  isAutoStartProxyReady,
+  isPortForwardingAutoStartEnabled,
+} from "./usePortForwardingAutoStart.ts";
 import type { GroupConfig, Host, PortForwardingRule, ProxyProfile } from "../../domain/models.ts";
 
 const host = (overrides: Partial<Host> = {}): Host => ({
@@ -114,4 +118,10 @@ test("getAutoStartRuleBlockReason marks rules without a host", () => {
     getAutoStartRuleBlockReason(rule({ hostId: undefined }), [], [], [], () => true),
     "Rule host is not configured",
   );
+});
+
+test("reconnect eligibility follows the current auto-start setting", () => {
+  assert.equal(isPortForwardingAutoStartEnabled([rule({ autoStart: true })], "rule-1"), true);
+  assert.equal(isPortForwardingAutoStartEnabled([rule({ autoStart: false })], "rule-1"), false);
+  assert.equal(isPortForwardingAutoStartEnabled([], "rule-1"), false);
 });

--- a/application/state/usePortForwardingAutoStart.ts
+++ b/application/state/usePortForwardingAutoStart.ts
@@ -277,11 +277,6 @@ export const usePortForwardingAutoStart = ({
     autoStartExecutedRef.current = true;
 
     const runAutoStart = async () => {
-      // Load rules from storage
-      const rules = localStorageAdapter.read<PortForwardingRule[]>(
-        STORAGE_KEY_PORT_FORWARDING,
-      ) ?? [];
-
       // First sync with backend to get any active tunnels and subscribe this
       // renderer to their later disconnect/error events.
       await syncWithBackend({
@@ -293,6 +288,12 @@ export const usePortForwardingAutoStart = ({
           updateStoredRuleStatus(ruleId, status, error);
         },
       });
+
+      // Re-read after the async sync so another window's delete or auto-start
+      // change cannot launch a stale rule.
+      const rules = localStorageAdapter.read<PortForwardingRule[]>(
+        STORAGE_KEY_PORT_FORWARDING,
+      ) ?? [];
 
       // Only start rules that are not already active
       const autoStartRules = rules.filter((r) => {

--- a/application/state/usePortForwardingAutoStart.ts
+++ b/application/state/usePortForwardingAutoStart.ts
@@ -272,13 +272,20 @@ export const usePortForwardingAutoStart = ({
     autoStartExecutedRef.current = true;
 
     const runAutoStart = async () => {
-      // First sync with backend to get any active tunnels
-      await syncWithBackend();
-
       // Load rules from storage
       const rules = localStorageAdapter.read<PortForwardingRule[]>(
         STORAGE_KEY_PORT_FORWARDING,
       ) ?? [];
+
+      // First sync with backend to get any active tunnels and subscribe this
+      // renderer to their later disconnect/error events.
+      const rulesById = new Map(rules.map((rule) => [rule.id, rule]));
+      await syncWithBackend({
+        shouldReconnect: (ruleId) => rulesById.get(ruleId)?.autoStart === true,
+        onStatusChange: (ruleId, status, error) => {
+          updateStoredRuleStatus(ruleId, status, error);
+        },
+      });
 
       // Only start rules that are not already active
       const autoStartRules = rules.filter((r) => {

--- a/application/state/usePortForwardingAutoStart.ts
+++ b/application/state/usePortForwardingAutoStart.ts
@@ -95,6 +95,11 @@ export const getAutoStartRuleBlockReason = (
   return undefined;
 };
 
+export const isPortForwardingAutoStartEnabled = (
+  rules: PortForwardingRule[],
+  ruleId: string,
+): boolean => rules.some((rule) => rule.id === ruleId && rule.autoStart === true);
+
 /**
  * Auto-starts port forwarding rules that have autoStart enabled.
  * This hook should be called at the App level to run on app launch.
@@ -279,9 +284,11 @@ export const usePortForwardingAutoStart = ({
 
       // First sync with backend to get any active tunnels and subscribe this
       // renderer to their later disconnect/error events.
-      const rulesById = new Map(rules.map((rule) => [rule.id, rule]));
       await syncWithBackend({
-        shouldReconnect: (ruleId) => rulesById.get(ruleId)?.autoStart === true,
+        shouldReconnect: (ruleId) => isPortForwardingAutoStartEnabled(
+          localStorageAdapter.read<PortForwardingRule[]>(STORAGE_KEY_PORT_FORWARDING) ?? [],
+          ruleId,
+        ),
         onStatusChange: (ruleId, status, error) => {
           updateStoredRuleStatus(ruleId, status, error);
         },

--- a/application/state/usePortForwardingState.storageSync.test.ts
+++ b/application/state/usePortForwardingState.storageSync.test.ts
@@ -189,6 +189,18 @@ test("heartbeat normalization preserves an error without a runtime tunnel", () =
   assert.equal(normalized[0]?.error, "Authentication failed");
 });
 
+test("heartbeat normalization clears an error for a reconciled-away tunnel", () => {
+  const normalized = normalizeRulesWithConnections([{
+    ...rule,
+    id: "cleanup-error-rule",
+    status: "error",
+    error: "Failed to stop tunnel",
+  }], new Set(["cleanup-error-rule"]));
+
+  assert.equal(normalized[0]?.status, "inactive");
+  assert.equal(normalized[0]?.error, undefined);
+});
+
 test("heartbeat writes only when a visible runtime state changes", () => {
   const current = [{ ...rule, status: "inactive" as const }];
   const unchanged = [{ ...rule, status: "inactive" as const }];

--- a/application/state/usePortForwardingState.storageSync.test.ts
+++ b/application/state/usePortForwardingState.storageSync.test.ts
@@ -7,7 +7,10 @@ import {
   startPortForward,
   stopAndCleanupRuleAndWait,
 } from "../../infrastructure/services/portForwardingService.ts";
-import { createPortForwardingStorageSyncHandlers } from "./usePortForwardingState.ts";
+import {
+  createPortForwardingStorageSyncHandlers,
+  normalizeRulesWithConnections,
+} from "./usePortForwardingState.ts";
 
 const rule: PortForwardingRule = {
   id: "startup-rule",
@@ -171,4 +174,16 @@ test("same-window synchronization preserves an error without a runtime tunnel", 
 
   assert.equal(snapshots[0]?.[0]?.status, "error");
   assert.equal(snapshots[0]?.[0]?.error, "Host not found");
+});
+
+test("heartbeat normalization preserves an error without a runtime tunnel", () => {
+  const normalized = normalizeRulesWithConnections([{
+    ...rule,
+    id: "heartbeat-error-rule",
+    status: "error",
+    error: "Authentication failed",
+  }]);
+
+  assert.equal(normalized[0]?.status, "error");
+  assert.equal(normalized[0]?.error, "Authentication failed");
 });

--- a/application/state/usePortForwardingState.storageSync.test.ts
+++ b/application/state/usePortForwardingState.storageSync.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   createPortForwardingStorageSyncHandlers,
   havePortForwardingRuntimeStatesChanged,
+  hasPortForwardingRuntimePresenceChanged,
   normalizeRulesWithConnections,
 } from "./usePortForwardingState.ts";
 
@@ -208,4 +209,15 @@ test("heartbeat writes only when a visible runtime state changes", () => {
 
   assert.equal(havePortForwardingRuntimeStatesChanged(current, unchanged), false);
   assert.equal(havePortForwardingRuntimeStatesChanged(current, repaired), true);
+});
+
+test("heartbeat notifies when only runtime tunnel presence changes", () => {
+  assert.equal(hasPortForwardingRuntimePresenceChanged({
+    gone: [],
+    appeared: ["cleanup-error-rule"],
+  }), true);
+  assert.equal(hasPortForwardingRuntimePresenceChanged({
+    gone: [],
+    appeared: [],
+  }), false);
 });

--- a/application/state/usePortForwardingState.storageSync.test.ts
+++ b/application/state/usePortForwardingState.storageSync.test.ts
@@ -149,3 +149,26 @@ test("cross-window stale status cannot override a known live tunnel", async (t) 
 
   assert.equal(snapshots[0]?.[0]?.status, "active");
 });
+
+test("same-window synchronization preserves an error without a runtime tunnel", (t) => {
+  const env = installEnvironment();
+  t.after(() => env.restore());
+  env.storage.setItem(STORAGE_KEY_PORT_FORWARDING, JSON.stringify([{
+    ...rule,
+    id: "failed-start-rule",
+    status: "error",
+    error: "Host not found",
+  }]));
+  const snapshots: PortForwardingRule[][] = [];
+  const handlers = createPortForwardingStorageSyncHandlers({
+    onRules: (rules) => snapshots.push(rules),
+  });
+
+  handlers.handleAdapterChange({
+    type: "netcatty:local-storage-adapter-changed",
+    detail: { key: STORAGE_KEY_PORT_FORWARDING },
+  } as unknown as CustomEvent<{ key: string }>);
+
+  assert.equal(snapshots[0]?.[0]?.status, "error");
+  assert.equal(snapshots[0]?.[0]?.error, "Host not found");
+});

--- a/application/state/usePortForwardingState.storageSync.test.ts
+++ b/application/state/usePortForwardingState.storageSync.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../infrastructure/services/portForwardingService.ts";
 import {
   createPortForwardingStorageSyncHandlers,
+  havePortForwardingRuntimeStatesChanged,
   normalizeRulesWithConnections,
 } from "./usePortForwardingState.ts";
 
@@ -186,4 +187,13 @@ test("heartbeat normalization preserves an error without a runtime tunnel", () =
 
   assert.equal(normalized[0]?.status, "error");
   assert.equal(normalized[0]?.error, "Authentication failed");
+});
+
+test("heartbeat writes only when a visible runtime state changes", () => {
+  const current = [{ ...rule, status: "inactive" as const }];
+  const unchanged = [{ ...rule, status: "inactive" as const }];
+  const repaired = [{ ...rule, status: "active" as const }];
+
+  assert.equal(havePortForwardingRuntimeStatesChanged(current, unchanged), false);
+  assert.equal(havePortForwardingRuntimeStatesChanged(current, repaired), true);
 });

--- a/application/state/usePortForwardingState.storageSync.test.ts
+++ b/application/state/usePortForwardingState.storageSync.test.ts
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { Host, PortForwardingRule } from "../../domain/models.ts";
+import { STORAGE_KEY_PORT_FORWARDING } from "../../infrastructure/config/storageKeys.ts";
+import {
+  startPortForward,
+  stopAndCleanupRuleAndWait,
+} from "../../infrastructure/services/portForwardingService.ts";
+import { createPortForwardingStorageSyncHandlers } from "./usePortForwardingState.ts";
+
+const rule: PortForwardingRule = {
+  id: "startup-rule",
+  label: "Startup tunnel",
+  type: "local",
+  localPort: 18080,
+  remoteHost: "127.0.0.1",
+  remotePort: 8080,
+  hostId: "host-1",
+  autoStart: true,
+  createdAt: 1,
+  status: "inactive",
+};
+
+const host: Host = {
+  id: "host-1",
+  label: "Host",
+  hostname: "example.com",
+  username: "root",
+  tags: [],
+  os: "linux",
+};
+
+function installEnvironment() {
+  const previousLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const backing = new Map<string, string>();
+  let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
+
+  const storage: Storage = {
+    get length() { return backing.size; },
+    clear() { backing.clear(); },
+    getItem(key) { return backing.get(key) ?? null; },
+    key(index) { return Array.from(backing.keys())[index] ?? null; },
+    removeItem(key) { backing.delete(key); },
+    setItem(key, value) { backing.set(key, value); },
+  };
+
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        startPortForward: async () => ({ success: true }),
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+        onPortForwardStatus: (_tunnelId: string, listener: typeof statusListener) => {
+          statusListener = listener;
+          return () => undefined;
+        },
+      },
+    },
+  });
+
+  return {
+    storage,
+    emitStatus(status: PortForwardingRule["status"]) {
+      statusListener?.(status);
+    },
+    restore() {
+      if (previousLocalStorage) Object.defineProperty(globalThis, "localStorage", previousLocalStorage);
+      else Reflect.deleteProperty(globalThis, "localStorage");
+      if (previousWindow) Object.defineProperty(globalThis, "window", previousWindow);
+      else Reflect.deleteProperty(globalThis, "window");
+    },
+  };
+}
+
+test("same-window auto-start status writes refresh the visible rule from the live tunnel", async (t) => {
+  const env = installEnvironment();
+  t.after(async () => {
+    await stopAndCleanupRuleAndWait(rule.id);
+    env.restore();
+  });
+
+  env.storage.setItem(STORAGE_KEY_PORT_FORWARDING, JSON.stringify([rule]));
+  await startPortForward(rule, host, [host], [], [], () => undefined, true);
+  env.emitStatus("active");
+
+  const snapshots: PortForwardingRule[][] = [];
+  const handlers = createPortForwardingStorageSyncHandlers({
+    onRules: (rules) => snapshots.push(rules),
+  });
+
+  handlers.handleAdapterChange({
+    type: "netcatty:local-storage-adapter-changed",
+    detail: { key: STORAGE_KEY_PORT_FORWARDING },
+  } as unknown as CustomEvent<{ key: string }>);
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.[0]?.status, "active");
+});

--- a/application/state/usePortForwardingState.storageSync.test.ts
+++ b/application/state/usePortForwardingState.storageSync.test.ts
@@ -122,3 +122,30 @@ test("cross-window status writes stay active before this window discovers the tu
   assert.equal(snapshots.length, 1);
   assert.equal(snapshots[0]?.[0]?.status, "active");
 });
+
+test("cross-window stale status cannot override a known live tunnel", async (t) => {
+  const env = installEnvironment();
+  const liveRule = { ...rule, id: "known-live-rule" };
+  t.after(async () => {
+    await stopAndCleanupRuleAndWait(liveRule.id);
+    env.restore();
+  });
+
+  await startPortForward(liveRule, host, [host], [], [], () => undefined, true);
+  env.emitStatus("active");
+  env.storage.setItem(STORAGE_KEY_PORT_FORWARDING, JSON.stringify([{
+    ...liveRule,
+    status: "inactive",
+  }]));
+  const snapshots: PortForwardingRule[][] = [];
+  const handlers = createPortForwardingStorageSyncHandlers({
+    onRules: (rules) => snapshots.push(rules),
+  });
+
+  handlers.handleBrowserStorage({
+    type: "storage",
+    key: STORAGE_KEY_PORT_FORWARDING,
+  } as StorageEvent);
+
+  assert.equal(snapshots[0]?.[0]?.status, "active");
+});

--- a/application/state/usePortForwardingState.storageSync.test.ts
+++ b/application/state/usePortForwardingState.storageSync.test.ts
@@ -99,3 +99,26 @@ test("same-window auto-start status writes refresh the visible rule from the liv
   assert.equal(snapshots.length, 1);
   assert.equal(snapshots[0]?.[0]?.status, "active");
 });
+
+test("cross-window status writes stay active before this window discovers the tunnel", (t) => {
+  const env = installEnvironment();
+  t.after(() => env.restore());
+
+  env.storage.setItem(STORAGE_KEY_PORT_FORWARDING, JSON.stringify([{
+    ...rule,
+    id: "other-window-rule",
+    status: "active",
+  }]));
+  const snapshots: PortForwardingRule[][] = [];
+  const handlers = createPortForwardingStorageSyncHandlers({
+    onRules: (rules) => snapshots.push(rules),
+  });
+
+  handlers.handleBrowserStorage({
+    type: "storage",
+    key: STORAGE_KEY_PORT_FORWARDING,
+  } as StorageEvent);
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.[0]?.status, "active");
+});

--- a/application/state/usePortForwardingState.ts
+++ b/application/state/usePortForwardingState.ts
@@ -549,7 +549,10 @@ export const usePortForwardingState = (): UsePortForwardingStateResult => {
     startTunnel,
     stopTunnel,
     stopRuleTunnels: stopAndCleanupRuleAndWait,
-    hasRuntimeTunnel: (ruleId) => getActiveConnection(ruleId) !== undefined,
+    hasRuntimeTunnel: (ruleId) => {
+      const connection = getActiveConnection(ruleId);
+      return connection !== undefined && connection.status !== "inactive";
+    },
 
     filteredRules,
     selectedRule,

--- a/application/state/usePortForwardingState.ts
+++ b/application/state/usePortForwardingState.ts
@@ -104,7 +104,10 @@ const setGlobalRules = (newRules: PortForwardingRule[]) => {
   localStorageAdapter.write(STORAGE_KEY_PORT_FORWARDING, globalRules);
 };
 
-export const normalizeRulesWithConnections = (rules: PortForwardingRule[]): PortForwardingRule[] => {
+export const normalizeRulesWithConnections = (
+  rules: PortForwardingRule[],
+  reconciledGoneRuleIds: ReadonlySet<string> = new Set(),
+): PortForwardingRule[] => {
   return rules.map((rule): PortForwardingRule => {
     const connection = getActiveConnection(rule.id);
     if (connection) {
@@ -112,6 +115,14 @@ export const normalizeRulesWithConnections = (rules: PortForwardingRule[]): Port
         ...rule,
         status: connection.status,
         error: connection.error,
+      };
+    }
+
+    if (reconciledGoneRuleIds.has(rule.id)) {
+      return {
+        ...rule,
+        status: "inactive" as const,
+        error: undefined,
       };
     }
 
@@ -296,10 +307,13 @@ export const usePortForwardingState = (): UsePortForwardingStateResult => {
       const HEARTBEAT_INTERVAL_MS = 4_000;
 
       const tick = async () => {
-        await reconcileWithBackend();
+        const reconciliation = await reconcileWithBackend();
         // Always re-derive the visible state. This also repairs a stale
         // cross-window storage write when the backend map itself did not change.
-        const normalizedRules = normalizeRulesWithConnections(globalRules);
+        const normalizedRules = normalizeRulesWithConnections(
+          globalRules,
+          new Set(reconciliation.gone),
+        );
         if (havePortForwardingRuntimeStatesChanged(globalRules, normalizedRules)) {
           setGlobalRules(normalizedRules);
         }

--- a/application/state/usePortForwardingState.ts
+++ b/application/state/usePortForwardingState.ts
@@ -313,6 +313,7 @@ export const usePortForwardingState = (): UsePortForwardingStateResult => {
 
       const tick = async () => {
         const reconciliation = await reconcileWithBackend();
+        if (!reconciliation.snapshotAvailable) return;
         // Always re-derive the visible state. This also repairs a stale
         // cross-window storage write when the backend map itself did not change.
         const normalizedRules = normalizeRulesWithConnections(

--- a/application/state/usePortForwardingState.ts
+++ b/application/state/usePortForwardingState.ts
@@ -6,7 +6,10 @@ import {
   STORAGE_KEY_PF_VIEW_MODE,
   STORAGE_KEY_PORT_FORWARDING,
 } from "../../infrastructure/config/storageKeys";
-import { localStorageAdapter } from "../../infrastructure/persistence/localStorageAdapter";
+import {
+  LOCAL_STORAGE_ADAPTER_CHANGED_EVENT,
+  localStorageAdapter,
+} from "../../infrastructure/persistence/localStorageAdapter";
 import {
   clearReconnectTimer,
   getActiveConnection,
@@ -119,6 +122,37 @@ const normalizeRulesWithConnections = (rules: PortForwardingRule[]): PortForward
   });
 };
 
+const isPortForwardingStorageEvent = (event: Event): boolean => {
+  const key = event.type === "storage"
+    ? (event as StorageEvent).key
+    : (event as CustomEvent<{ key?: string }>).detail?.key;
+  return key === STORAGE_KEY_PORT_FORWARDING;
+};
+
+export const createPortForwardingStorageSyncHandlers = ({
+  onRules,
+}: {
+  onRules: (rules: PortForwardingRule[]) => void;
+}) => {
+  const syncFromStorage = () => {
+    const storedRules = localStorageAdapter.read<PortForwardingRule[]>(
+      STORAGE_KEY_PORT_FORWARDING,
+    );
+    if (storedRules && Array.isArray(storedRules)) {
+      onRules(normalizeRulesWithConnections(storedRules));
+    }
+  };
+
+  const handleChange = (event: Event) => {
+    if (isPortForwardingStorageEvent(event)) syncFromStorage();
+  };
+
+  return {
+    handleAdapterChange: handleChange,
+    handleBrowserStorage: handleChange,
+  };
+};
+
 // Initialization Logic
 const initializeStore = async () => {
   if (isInitialized) return;
@@ -173,29 +207,35 @@ export const usePortForwardingState = (): UsePortForwardingStateResult => {
     };
   }, [rules]);
 
-  // Listen for storage events for cross-window sync (main window <-> tray panel)
+  // Listen for both browser storage events (other windows) and adapter
+  // events (this window). Auto-start writes statuses outside this hook, so
+  // relying on the browser event alone leaves the launching window stale.
   useEffect(() => {
-    const handleStorageChange = (e: StorageEvent) => {
-      // Only handle changes from our specific key
-      if (e.key !== STORAGE_KEY_PORT_FORWARDING) return;
-
-      // Parse the new value
-      if (e.newValue) {
-        try {
-          const newRules = JSON.parse(e.newValue) as PortForwardingRule[];
-          if (Array.isArray(newRules)) {
-            // Update global state without triggering another localStorage write
-            globalRules = normalizeRulesWithConnections(newRules);
-            notifyListeners();
-          }
-        } catch {
-          // ignore parse errors
-        }
-      }
+    const target = globalThis as typeof globalThis & {
+      addEventListener?: (type: string, listener: EventListener) => void;
+      removeEventListener?: (type: string, listener: EventListener) => void;
     };
+    if (typeof target.addEventListener !== "function") return;
 
-    window.addEventListener("storage", handleStorageChange);
-    return () => window.removeEventListener("storage", handleStorageChange);
+    const handlers = createPortForwardingStorageSyncHandlers({
+      onRules: (newRules) => {
+        globalRules = newRules;
+        notifyListeners();
+      },
+    });
+
+    target.addEventListener(
+      LOCAL_STORAGE_ADAPTER_CHANGED_EVENT,
+      handlers.handleAdapterChange,
+    );
+    target.addEventListener("storage", handlers.handleBrowserStorage);
+    return () => {
+      target.removeEventListener?.(
+        LOCAL_STORAGE_ADAPTER_CHANGED_EVENT,
+        handlers.handleAdapterChange,
+      );
+      target.removeEventListener?.("storage", handlers.handleBrowserStorage);
+    };
   }, []);
 
   // Listen for cross-window reconnect cancellation events.

--- a/application/state/usePortForwardingState.ts
+++ b/application/state/usePortForwardingState.ts
@@ -158,7 +158,7 @@ export const createPortForwardingStorageSyncHandlers = ({
     handleAdapterChange(event: Event) {
       if (!isPortForwardingStorageEvent(event)) return;
       const storedRules = readStoredRules();
-      if (storedRules) onRules(normalizeRulesWithConnections(storedRules));
+      if (storedRules) onRules(mergeRulesWithKnownConnections(storedRules));
     },
     handleBrowserStorage(event: Event) {
       if (!isPortForwardingStorageEvent(event)) return;

--- a/application/state/usePortForwardingState.ts
+++ b/application/state/usePortForwardingState.ts
@@ -149,6 +149,11 @@ export const havePortForwardingRuntimeStatesChanged = (
   });
 };
 
+export const hasPortForwardingRuntimePresenceChanged = (reconciliation: {
+  gone: string[];
+  appeared: string[];
+}): boolean => reconciliation.gone.length > 0 || reconciliation.appeared.length > 0;
+
 const mergeRulesWithKnownConnections = (rules: PortForwardingRule[]): PortForwardingRule[] => {
   return rules.map((rule): PortForwardingRule => {
     const connection = getActiveConnection(rule.id);
@@ -316,6 +321,12 @@ export const usePortForwardingState = (): UsePortForwardingStateResult => {
         );
         if (havePortForwardingRuntimeStatesChanged(globalRules, normalizedRules)) {
           setGlobalRules(normalizedRules);
+        } else if (hasPortForwardingRuntimePresenceChanged(reconciliation)) {
+          // Runtime presence affects Start/Stop actions even when the visible
+          // status and error already match. Notify React without rewriting the
+          // unchanged persisted configuration.
+          globalRules = normalizedRules;
+          notifyListeners();
         }
       };
 

--- a/application/state/usePortForwardingState.ts
+++ b/application/state/usePortForwardingState.ts
@@ -125,6 +125,19 @@ export const normalizeRulesWithConnections = (rules: PortForwardingRule[]): Port
   });
 };
 
+export const havePortForwardingRuntimeStatesChanged = (
+  current: PortForwardingRule[],
+  next: PortForwardingRule[],
+): boolean => {
+  if (current.length !== next.length) return true;
+  return next.some((rule, index) => {
+    const existing = current[index];
+    return existing?.id !== rule.id
+      || existing.status !== rule.status
+      || existing.error !== rule.error;
+  });
+};
+
 const mergeRulesWithKnownConnections = (rules: PortForwardingRule[]): PortForwardingRule[] => {
   return rules.map((rule): PortForwardingRule => {
     const connection = getActiveConnection(rule.id);
@@ -286,7 +299,10 @@ export const usePortForwardingState = (): UsePortForwardingStateResult => {
         await reconcileWithBackend();
         // Always re-derive the visible state. This also repairs a stale
         // cross-window storage write when the backend map itself did not change.
-        setGlobalRules(normalizeRulesWithConnections(globalRules));
+        const normalizedRules = normalizeRulesWithConnections(globalRules);
+        if (havePortForwardingRuntimeStatesChanged(globalRules, normalizedRules)) {
+          setGlobalRules(normalizedRules);
+        }
       };
 
       intervalId = setInterval(tick, HEARTBEAT_INTERVAL_MS);

--- a/application/state/usePortForwardingState.ts
+++ b/application/state/usePortForwardingState.ts
@@ -104,7 +104,7 @@ const setGlobalRules = (newRules: PortForwardingRule[]) => {
   localStorageAdapter.write(STORAGE_KEY_PORT_FORWARDING, globalRules);
 };
 
-const normalizeRulesWithConnections = (rules: PortForwardingRule[]): PortForwardingRule[] => {
+export const normalizeRulesWithConnections = (rules: PortForwardingRule[]): PortForwardingRule[] => {
   return rules.map((rule): PortForwardingRule => {
     const connection = getActiveConnection(rule.id);
     if (connection) {
@@ -114,6 +114,8 @@ const normalizeRulesWithConnections = (rules: PortForwardingRule[]): PortForward
         error: connection.error,
       };
     }
+
+    if (rule.status === "error") return rule;
 
     return {
       ...rule,

--- a/application/state/usePortForwardingState.ts
+++ b/application/state/usePortForwardingState.ts
@@ -123,6 +123,18 @@ const normalizeRulesWithConnections = (rules: PortForwardingRule[]): PortForward
   });
 };
 
+const mergeRulesWithKnownConnections = (rules: PortForwardingRule[]): PortForwardingRule[] => {
+  return rules.map((rule): PortForwardingRule => {
+    const connection = getActiveConnection(rule.id);
+    if (!connection) return rule;
+    return {
+      ...rule,
+      status: connection.status,
+      error: connection.error,
+    };
+  });
+};
+
 const isPortForwardingStorageEvent = (event: Event): boolean => {
   const key = event.type === "storage"
     ? (event as StorageEvent).key
@@ -151,7 +163,7 @@ export const createPortForwardingStorageSyncHandlers = ({
     handleBrowserStorage(event: Event) {
       if (!isPortForwardingStorageEvent(event)) return;
       const storedRules = readStoredRules();
-      if (storedRules) onRules(storedRules);
+      if (storedRules) onRules(mergeRulesWithKnownConnections(storedRules));
     },
   };
 };
@@ -269,10 +281,9 @@ export const usePortForwardingState = (): UsePortForwardingStateResult => {
       const HEARTBEAT_INTERVAL_MS = 4_000;
 
       const tick = async () => {
-        const { gone, appeared } = await reconcileWithBackend();
-        if (gone.length === 0 && appeared.length === 0) return;
-
-        // Re-derive statuses from the now-updated activeConnections map
+        await reconcileWithBackend();
+        // Always re-derive the visible state. This also repairs a stale
+        // cross-window storage write when the backend map itself did not change.
         setGlobalRules(normalizeRulesWithConnections(globalRules));
       };
 

--- a/application/state/usePortForwardingState.ts
+++ b/application/state/usePortForwardingState.ts
@@ -527,6 +527,11 @@ export const usePortForwardingState = (): UsePortForwardingStateResult => {
     [setRuleStatus],
   );
 
+  const hasRuntimeTunnel = useCallback((ruleId: string) => {
+    const connection = getActiveConnection(ruleId);
+    return connection !== undefined && connection.status !== "inactive";
+  }, []);
+
   // Filter and sort rules
   const filteredRules = useMemo(() => {
     let result = [...rules];
@@ -593,10 +598,7 @@ export const usePortForwardingState = (): UsePortForwardingStateResult => {
     startTunnel,
     stopTunnel,
     stopRuleTunnels: stopAndCleanupRuleAndWait,
-    hasRuntimeTunnel: (ruleId) => {
-      const connection = getActiveConnection(ruleId);
-      return connection !== undefined && connection.status !== "inactive";
-    },
+    hasRuntimeTunnel,
 
     filteredRules,
     selectedRule,

--- a/application/state/usePortForwardingState.ts
+++ b/application/state/usePortForwardingState.ts
@@ -79,9 +79,10 @@ export interface UsePortForwardingStateResult {
   ) => Promise<{ success: boolean; error?: string }>;
   stopTunnel: (
     ruleId: string,
-    onStatusChange?: (status: PortForwardingRule["status"]) => void,
+    onStatusChange?: (status: PortForwardingRule["status"], error?: string) => void,
   ) => Promise<{ success: boolean; error?: string }>;
   stopRuleTunnels: (ruleId: string) => Promise<{ success: boolean; error?: string }>;
+  hasRuntimeTunnel: (ruleId: string) => boolean;
 
   filteredRules: PortForwardingRule[];
   selectedRule: PortForwardingRule | undefined;
@@ -134,22 +135,24 @@ export const createPortForwardingStorageSyncHandlers = ({
 }: {
   onRules: (rules: PortForwardingRule[]) => void;
 }) => {
-  const syncFromStorage = () => {
+  const readStoredRules = (): PortForwardingRule[] | null => {
     const storedRules = localStorageAdapter.read<PortForwardingRule[]>(
       STORAGE_KEY_PORT_FORWARDING,
     );
-    if (storedRules && Array.isArray(storedRules)) {
-      onRules(normalizeRulesWithConnections(storedRules));
-    }
-  };
-
-  const handleChange = (event: Event) => {
-    if (isPortForwardingStorageEvent(event)) syncFromStorage();
+    return storedRules && Array.isArray(storedRules) ? storedRules : null;
   };
 
   return {
-    handleAdapterChange: handleChange,
-    handleBrowserStorage: handleChange,
+    handleAdapterChange(event: Event) {
+      if (!isPortForwardingStorageEvent(event)) return;
+      const storedRules = readStoredRules();
+      if (storedRules) onRules(normalizeRulesWithConnections(storedRules));
+    },
+    handleBrowserStorage(event: Event) {
+      if (!isPortForwardingStorageEvent(event)) return;
+      const storedRules = readStoredRules();
+      if (storedRules) onRules(storedRules);
+    },
   };
 };
 
@@ -457,13 +460,13 @@ export const usePortForwardingState = (): UsePortForwardingStateResult => {
   const stopTunnel = useCallback(
     async (
       ruleId: string,
-      onStatusChange?: (status: PortForwardingRule["status"]) => void,
+      onStatusChange?: (status: PortForwardingRule["status"], error?: string) => void,
     ) => {
       // Clear any pending reconnect timer when manually stopping
       clearReconnectTimer(ruleId);
-      return stopPortForward(ruleId, (status) => {
-        setRuleStatus(ruleId, status);
-        onStatusChange?.(status);
+      return stopPortForward(ruleId, (status, error) => {
+        setRuleStatus(ruleId, status, error);
+        onStatusChange?.(status, error);
       });
     },
     [setRuleStatus],
@@ -535,6 +538,7 @@ export const usePortForwardingState = (): UsePortForwardingStateResult => {
     startTunnel,
     stopTunnel,
     stopRuleTunnels: stopAndCleanupRuleAndWait,
+    hasRuntimeTunnel: (ruleId) => getActiveConnection(ruleId) !== undefined,
 
     filteredRules,
     selectedRule,

--- a/application/state/useTrayPanelBackend.ts
+++ b/application/state/useTrayPanelBackend.ts
@@ -50,6 +50,7 @@ export const useTrayPanelBackend = () => {
           remotePort?: number;
           status: "inactive" | "connecting" | "active" | "error";
           hostId?: string;
+          canStop?: boolean;
         }>;
       }) => void,
     ) => {

--- a/components/PortForwardingNew.tsx
+++ b/components/PortForwardingNew.tsx
@@ -51,6 +51,7 @@ import {
   getTypeMenuLabel,
   NewFormPanel,
   RuleCard,
+  stopRuntimeTunnelBeforeDelete,
   WizardContent,
 } from "./port-forwarding";
 
@@ -450,9 +451,12 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
 
     setIsDeleting(true);
     try {
-      if (ruleToDelete.status === "active" || ruleToDelete.status === "connecting") {
-        await stopTunnel(ruleToDelete.id);
-      }
+      const stopped = await stopRuntimeTunnelBeforeDelete(
+        ruleToDelete.id,
+        hasRuntimeTunnel,
+        stopTunnel,
+      );
+      if (!stopped) return;
       if (editingRule?.id === ruleToDelete.id) {
         closeEditPanel();
       }
@@ -462,9 +466,11 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
       setShowDeleteConfirm(false);
       setRuleToDelete(null);
     }
-  }, [ruleToDelete, stopTunnel, deleteRule, editingRule, closeEditPanel]);
+  }, [ruleToDelete, hasRuntimeTunnel, stopTunnel, deleteRule, editingRule, closeEditPanel]);
 
-  const deleteTargetIsActive = ruleToDelete?.status === "active" || ruleToDelete?.status === "connecting";
+  const deleteTargetIsActive = Boolean(
+    ruleToDelete && hasRuntimeTunnel(ruleToDelete.id),
+  );
 
   // Handle wizard navigation
   // Flow for local: type -> local-config -> destination -> host-selection

--- a/components/PortForwardingNew.tsx
+++ b/components/PortForwardingNew.tsx
@@ -453,7 +453,6 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
     try {
       const stopped = await stopRuntimeTunnelBeforeDelete(
         ruleToDelete.id,
-        hasRuntimeTunnel,
         stopTunnel,
       );
       if (!stopped) return;
@@ -466,7 +465,7 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
       setShowDeleteConfirm(false);
       setRuleToDelete(null);
     }
-  }, [ruleToDelete, hasRuntimeTunnel, stopTunnel, deleteRule, editingRule, closeEditPanel]);
+  }, [ruleToDelete, stopTunnel, deleteRule, editingRule, closeEditPanel]);
 
   const deleteTargetIsActive = Boolean(
     ruleToDelete && hasRuntimeTunnel(ruleToDelete.id),

--- a/components/PortForwardingNew.tsx
+++ b/components/PortForwardingNew.tsx
@@ -111,6 +111,7 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
     setRuleStatus,
     startTunnel,
     stopTunnel,
+    hasRuntimeTunnel,
     filteredRules,
     selectedRule: _selectedRule,
     preferFormMode,
@@ -215,7 +216,13 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
       setPendingOperations((prev) => new Set([...prev, rule.id]));
 
       try {
-        await stopTunnel(rule.id);
+        const result = await stopTunnel(rule.id);
+        if (!result.success && result.error) {
+          toast.error(
+            result.error,
+            t("pf.toast.titleWithLabel", { label: rule.label }),
+          );
+        }
       } finally {
         setPendingOperations((prev) => {
           const next = new Set(prev);
@@ -224,7 +231,7 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
         });
       }
     },
-    [stopTunnel],
+    [stopTunnel, t],
   );
 
   // Wizard state
@@ -741,6 +748,7 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
                     viewMode={viewMode}
                     isSelected={selectedRuleId === rule.id}
                     isPending={pendingOperations.has(rule.id)}
+                    canStop={hasRuntimeTunnel(rule.id)}
                     reorderProps={ruleReorder.getItemReorderProps(rule.id, `rule:${rule.id}`)}
                     onSelect={() => {
                       setSelectedRuleId(rule.id);

--- a/components/TrayPanel.tsx
+++ b/components/TrayPanel.tsx
@@ -132,7 +132,12 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
 
   const { hosts, keys, identities, proxyProfiles, groupConfigs, knownHosts, updateKnownHosts } = useVaultState();
   useSessionState({ persistSessionRestore: false });
-  const { rules: portForwardingRules, startTunnel, stopTunnel } = usePortForwardingState();
+  const {
+    rules: portForwardingRules,
+    startTunnel,
+    stopTunnel,
+    hasRuntimeTunnel,
+  } = usePortForwardingState();
   const activeTabId = useActiveTabId();
   const proxyProfileIdSet = useMemo(
     () => new Set(proxyProfiles.map((profile) => profile.id)),
@@ -359,6 +364,7 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
               {portForwardingRules.map((rule) => {
                 const isConnecting = rule.status === "connecting";
                 const isActive = rule.status === "active";
+                const isStoppable = isConnecting || isActive || hasRuntimeTunnel(rule.id);
                 const label = rule.label || (rule.type === "dynamic"
                   ? `SOCKS:${rule.localPort}`
                   : `${rule.localPort} → ${rule.remoteHost}:${rule.remotePort}`);
@@ -374,8 +380,10 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
                             toast.error(t("pf.error.hostNotFound"));
                             return;
                           }
-                          if (isActive) {
-                            void stopTunnel(rule.id);
+                          if (isStoppable) {
+                            void stopTunnel(rule.id).then((result) => {
+                              if (!result.success && result.error) toast.error(result.error);
+                            });
                           } else {
                             const resolveEffectiveHost = (host: Host) => {
                               const withGroupDefaults = host.group

--- a/components/port-forwarding/RuleCard.tsx
+++ b/components/port-forwarding/RuleCard.tsx
@@ -21,6 +21,7 @@ export interface RuleCardProps {
     viewMode: ViewMode;
     isSelected: boolean;
     isPending: boolean;
+    canStop: boolean;
     reorderProps?: React.HTMLAttributes<HTMLDivElement>;
     onSelect: () => void;
     onEdit: () => void;
@@ -36,6 +37,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
     viewMode,
     isSelected,
     isPending,
+    canStop,
     reorderProps,
     onSelect,
     onEdit,
@@ -46,7 +48,8 @@ export const RuleCard: React.FC<RuleCardProps> = ({
 }) => {
     const { t } = useI18n();
     const isActive = rule.status === 'active';
-    const isInactive = rule.status === 'inactive' || rule.status === 'error';
+    const isStoppable = canStop || rule.status === 'active' || rule.status === 'connecting';
+    const isStartable = !isStoppable && (rule.status === 'inactive' || rule.status === 'error');
 
     return (
         <ContextMenu>
@@ -139,7 +142,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
                                 >
                                     <Loader2 size={12} className="animate-spin" />
                                 </Button>
-                            ) : isInactive ? (
+                            ) : isStartable ? (
                                 <Button
                                     size="icon"
                                     variant="ghost"
@@ -151,7 +154,7 @@ export const RuleCard: React.FC<RuleCardProps> = ({
                                 >
                                     <Play size={12} />
                                 </Button>
-                            ) : (rule.status === 'active' || rule.status === 'connecting') ? (
+                            ) : isStoppable ? (
                                 <Button
                                     size="icon"
                                     variant="ghost"
@@ -176,12 +179,12 @@ export const RuleCard: React.FC<RuleCardProps> = ({
                     <Copy className="mr-2 h-4 w-4" /> {t('action.duplicate')}
                 </ContextMenuItem>
                 <ContextMenuSeparator />
-                {isInactive && (
+                {isStartable && (
                     <ContextMenuItem onClick={onStart}>
                         <Play className="mr-2 h-4 w-4" /> {t('action.start')}
                     </ContextMenuItem>
                 )}
-                {(rule.status === 'active' || rule.status === 'connecting') && (
+                {isStoppable && (
                     <ContextMenuItem onClick={onStop}>
                         <Square className="mr-2 h-4 w-4" /> {t('action.stop')}
                     </ContextMenuItem>

--- a/components/port-forwarding/index.ts
+++ b/components/port-forwarding/index.ts
@@ -6,6 +6,7 @@
 export {
   generateRuleLabel,
   getTypeMenuLabel,
+  stopRuntimeTunnelBeforeDelete,
 } from './utils';
 
 export { RuleCard } from './RuleCard';

--- a/components/port-forwarding/utils.tsx
+++ b/components/port-forwarding/utils.tsx
@@ -65,6 +65,15 @@ export function buildRuleSummary(
   }
 }
 
+export async function stopRuntimeTunnelBeforeDelete(
+  ruleId: string,
+  hasRuntimeTunnel: (ruleId: string) => boolean,
+  stopTunnel: (ruleId: string) => Promise<{ success: boolean }>,
+): Promise<boolean> {
+  if (!hasRuntimeTunnel(ruleId)) return true;
+  return (await stopTunnel(ruleId)).success;
+}
+
 /**
  * Get status color class for a rule
  */

--- a/components/port-forwarding/utils.tsx
+++ b/components/port-forwarding/utils.tsx
@@ -67,10 +67,8 @@ export function buildRuleSummary(
 
 export async function stopRuntimeTunnelBeforeDelete(
   ruleId: string,
-  hasRuntimeTunnel: (ruleId: string) => boolean,
   stopTunnel: (ruleId: string) => Promise<{ success: boolean }>,
 ): Promise<boolean> {
-  if (!hasRuntimeTunnel(ruleId)) return true;
   return (await stopTunnel(ruleId)).success;
 }
 

--- a/components/portForwardingUtils.test.ts
+++ b/components/portForwardingUtils.test.ts
@@ -5,7 +5,7 @@ import type { PortForwardingRule } from "../domain/models";
 import en from "../application/i18n/locales/en";
 import zhCN from "../application/i18n/locales/zh-CN";
 import ru from "../application/i18n/locales/ru";
-import { buildRuleSummary } from "./port-forwarding/utils";
+import { buildRuleSummary, stopRuntimeTunnelBeforeDelete } from "./port-forwarding/utils";
 
 const interpolate = (template: string, vars?: Record<string, unknown>) =>
   template.replace(/\{(\w+)\}/g, (_, key) => String(vars?.[key] ?? ""));
@@ -55,4 +55,27 @@ test("bundled locales include port forwarding summary copy for every forwarding 
       assert.notEqual(messages[key], "", `${locale} has empty ${key}`);
     }
   }
+});
+
+test("delete waits for runtime cleanup and retains the rule on failure", async () => {
+  let stopCalls = 0;
+  assert.equal(await stopRuntimeTunnelBeforeDelete(
+    "rule-1",
+    () => true,
+    async () => {
+      stopCalls++;
+      return { success: false };
+    },
+  ), false);
+  assert.equal(stopCalls, 1);
+
+  assert.equal(await stopRuntimeTunnelBeforeDelete(
+    "rule-1",
+    () => false,
+    async () => {
+      stopCalls++;
+      return { success: true };
+    },
+  ), true);
+  assert.equal(stopCalls, 1);
 });

--- a/components/portForwardingUtils.test.ts
+++ b/components/portForwardingUtils.test.ts
@@ -57,11 +57,10 @@ test("bundled locales include port forwarding summary copy for every forwarding 
   }
 });
 
-test("delete waits for runtime cleanup and retains the rule on failure", async () => {
+test("delete always verifies backend cleanup and retains the rule on failure", async () => {
   let stopCalls = 0;
   assert.equal(await stopRuntimeTunnelBeforeDelete(
     "rule-1",
-    () => true,
     async () => {
       stopCalls++;
       return { success: false };
@@ -71,11 +70,10 @@ test("delete waits for runtime cleanup and retains the rule on failure", async (
 
   assert.equal(await stopRuntimeTunnelBeforeDelete(
     "rule-1",
-    () => false,
     async () => {
       stopCalls++;
       return { success: true };
     },
   ), true);
-  assert.equal(stopCalls, 1);
+  assert.equal(stopCalls, 2);
 });

--- a/docs/research/issue-2280-port-forward-runtime-state.md
+++ b/docs/research/issue-2280-port-forward-runtime-state.md
@@ -1,0 +1,102 @@
+# Issue #2280：端口转发运行状态调研
+
+调研日期：2026-07-17
+范围：Netcatty `v1.1.68` 与当前 `main` 的端口转发启动、停止、自动启动、跨窗口同步和后端生命周期；外部对照只采用官方源码或文档。
+
+## 结论
+
+Issue #2280 的现象可以由当前代码完整解释，并非单纯的显示延迟：**自动启动成功后，真实连接状态只写入了 localStorage，没有更新当前窗口正在订阅的内存状态。** 浏览器的 `storage` 事件不会回送给发起写入的同一窗口，因此页面仍显示 `inactive`；同时，后台连接表已经是 `active`，现有 4 秒核对逻辑看不到“后台连接表发生变化”，也就不会刷新页面。用户再次点“启动”时，服务层又把已有连接视为幂等成功并直接返回，但不会补发 `active`，所以页面无法自愈。
+
+这条链路与 issue 中“自动启动后实际已经开启、界面显示未开启、无法停止”逐项一致。原始复现和截图见 [Issue #2280](https://github.com/binaricat/Netcatty/issues/2280)。报告使用的 `v1.1.68` 源码与当前 `main` 在这条链路上相同。
+
+## 现有机制
+
+### 1. 两套状态同时存在
+
+- Electron 主进程的 `portForwardingTunnels` 保存真实 SSH 连接、监听端口和当前阶段；`listPortForwards()` 从这里返回运行中的隧道。[主进程实现](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/electron/bridges/portForwardingBridge.cjs#L28-L29) / [列表接口](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/electron/bridges/portForwardingBridge.cjs#L741-L753)
+- Renderer 的 `activeConnections` 又维护一份连接表；React 页面显示的则是 `globalRules[].status`。页面状态只在 `setGlobalRules()` 通知订阅者后才会变化。[连接表](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/infrastructure/services/portForwardingService.ts#L48-L56) / [页面 store](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/application/state/usePortForwardingState.ts#L87-L120)
+- `status` 和 `error` 还被放进持久化的规则对象；启动时再用 renderer 连接表覆盖它们。[规则模型](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/domain/models/portForwarding.ts#L5-L24) / [初始化](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/application/state/usePortForwardingState.ts#L122-L135)
+
+因此当前不是“一个真相来源”，而是主进程、renderer 连接表、React 规则列表和 localStorage 四处互相同步。
+
+### 2. Issue #2280 的确定性断点
+
+自动启动绕过了 `usePortForwardingState.startTunnel()`，直接调用底层 `startPortForward()`；它的状态回调 `updateStoredRuleStatus()` 只执行 localStorage 写入。[自动启动回调](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/application/state/usePortForwardingAutoStart.ts#L190-L210) / [直接启动](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/application/state/usePortForwardingAutoStart.ts#L274-L327)
+
+同一窗口的规则 store 只监听原生 `storage` 事件来接收外部窗口写入，没有同窗口通知通道。[storage 监听](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/application/state/usePortForwardingState.ts#L176-L199)
+
+随后会出现一个稳定的错误状态：
+
+1. 主进程隧道为 `active`；renderer `activeConnections` 也已被状态事件更新为 `active`。[状态事件处理](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/infrastructure/services/portForwardingService.ts#L674-L703)
+2. React 的 `globalRules` 仍为 `inactive`，所以卡片只显示“启动”，不显示“停止”。[按钮条件](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/components/port-forwarding/RuleCard.tsx#L48-L49) / [启停按钮](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/components/port-forwarding/RuleCard.tsx#L132-L166)
+3. 定时核对只在 renderer 连接表相对后端出现、消失或阶段改变时返回变化；此时两边都已经是 `active`，所以不会刷新 React store。[核对实现](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/infrastructure/services/portForwardingService.ts#L415-L499) / [页面刷新条件](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/application/state/usePortForwardingState.ts#L220-L246)
+4. 用户点“启动”时，底层发现连接已存在便直接返回成功，但不调用状态回调，因此页面仍然无法恢复。[幂等早退](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/infrastructure/services/portForwardingService.ts#L519-L529)
+
+### 3. 深挖后发现的其他准确性风险
+
+这些不一定是本 issue 的首要触发条件，但如果目标是“状态准确无误”，应一起纳入修复边界：
+
+- **停止失败仍显示已停止。** renderer 调用后端停止后，无论 `result.success` 是真是假，都会删除本地连接并通知 `inactive`；而主进程在清理失败时会返回 `success: false` 并保留隧道。两边会再次分叉。[renderer 停止](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/infrastructure/services/portForwardingService.ts#L788-L824) / [主进程失败语义](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/electron/bridges/portForwardingBridge.cjs#L46-L91)
+- **跨窗口可能为同一规则创建多个隧道。** renderer 的幂等判断只看本窗口内存；主进程 `startPortForward` 不按 `ruleId` 去重。两个窗口在同步前并发启动时，主进程 Map 可留下多个 tunnel。普通停止只按单个 `tunnelId` 停止，虽然另有 `stopPortForwardByRuleId` 能全部清理。[启动登记](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/electron/bridges/portForwardingBridge.cjs#L99-L205) / [单 tunnel 停止](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/electron/bridges/portForwardingBridge.cjs#L704-L724) / [按规则停止](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/electron/bridges/portForwardingBridge.cjs#L771-L794)
+- **恢复依赖从 tunnelId 反解 UUID。** 后端对象本身已有 `ruleId`，但列表接口不返回它；renderer 只能解析 `pf-{UUID}-{timestamp}`。导入或旧数据若不是标准 UUID，就无法恢复和核对。[反解逻辑](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/infrastructure/services/portForwardingService.ts#L346-L378) / [列表缺少 ruleId](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/electron/bridges/portForwardingBridge.cjs#L741-L753)
+- **核对失败被当作“无需变化”。** bridge 不可用或查询抛错时返回空变化，页面会继续展示旧状态；目前没有 `unknown`/`unavailable` 阶段来表达“暂时无法确认”。[失败处理](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/infrastructure/services/portForwardingService.ts#L427-L499)
+
+## 成熟项目的做法
+
+### OpenSSH：只有监听建立成功才算启动成功
+
+OpenSSH 的 `ExitOnForwardFailure=yes` 会在任一动态、本地、远程转发无法建立监听时终止连接；与后台运行配合时，也会等待转发建立成功后才进入后台。[OpenBSD 官方 ssh_config(5)](https://man.openbsd.org/ssh_config.5#ExitOnForwardFailure)
+
+可借鉴点：`active` 必须来自端口监听/远端 forward 确认，而不是来自“用户点过启动”或持久化标记；启动失败必须保留为可见错误。
+
+### Tabby：运行集合只在资源真的建立后加入，停止后立即移除
+
+Tabby 的本地/动态转发先等待 listener 的 `listening`，成功后才把 `ForwardedPort` 放进 `forwardedPorts`；失败则抛错，不登记为运行中。远程转发也只有服务器确认 `forwardTCPPort` 后才加入集合。停止时关闭真实 listener 或发出远程取消，然后从同一个运行集合移除。[Tabby `addPortForward` / `removePortForward`](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-ssh/src/session/ssh.ts#L786-L845) 转发对象本身持有 listener，SSH session 销毁时统一关闭所有 listener。[ForwardedPort](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-ssh/src/session/forwards.ts#L6-L54) / [session 清理](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-ssh/src/session/ssh.ts#L146-L150)
+
+可借鉴点：配置列表与“当前运行集合”分开；运行集合里的对象就是可停止的真实资源，不需要再从配置状态猜测。
+
+### VS Code：服务持有唯一运行表，并通过 opened/closed 事件驱动所有消费者
+
+VS Code 的 tunnel service 暴露 `tunnels`、`onTunnelOpened`、`onTunnelClosed`、`openTunnel` 和 `closeTunnel`；内部 Map 保存真实 tunnel Promise，并对同一 tunnel 做引用计数。[接口与运行表](https://github.com/microsoft/vscode/blob/b1b978c118c517376df3d95696201265e0d84264/src/vs/platform/tunnel/common/tunnel.ts#L120-L144) / [内部 Map](https://github.com/microsoft/vscode/blob/b1b978c118c517376df3d95696201265e0d84264/src/vs/platform/tunnel/common/tunnel.ts#L224-L238) 只有 provider 成功返回真实 tunnel 后才发 `onTunnelOpened`；失败对象会从 Map 清除。最后一个引用释放或强制关闭时，先等待资源 dispose，再从 Map 删除并发 `onTunnelClosed`。[打开流程](https://github.com/microsoft/vscode/blob/b1b978c118c517376df3d95696201265e0d84264/src/vs/platform/tunnel/common/tunnel.ts#L352-L399) / [关闭流程](https://github.com/microsoft/vscode/blob/b1b978c118c517376df3d95696201265e0d84264/src/vs/platform/tunnel/common/tunnel.ts#L401-L466)
+
+可借鉴点：真实资源由一个服务统一拥有；页面和其他窗口订阅同一组 opened/closed 事件，不能各自维护一个“差不多同步”的状态副本。
+
+### Electerm：连接关闭直接关闭监听资源
+
+Electerm 在本地监听的 `listen` 回调后才 resolve 启动；监听失败则 reject。SSH 连接关闭时，它会销毁所有活跃 socket 并关闭本地 listener；动态转发也在 SSH close 时关闭 SOCKS server。[Electerm 官方源码](https://github.com/electerm/electerm/blob/6fbddfe55c66bffcb5aaad23676c0dd006e16367/src/app/server/ssh-tunnel.js#L78-L139) / [SOCKS 生命周期](https://github.com/electerm/electerm/blob/6fbddfe55c66bffcb5aaad23676c0dd006e16367/src/app/server/ssh-tunnel.js#L142-L202)
+
+可借鉴点：transport 生命周期直接决定转发是否存在；SSH close 与 listener close 是同一条清理链，而不是靠页面心跳推断。
+
+## 建议的修复方向
+
+### P0：修复 issue 的最小闭环
+
+1. 自动启动必须走与手动启动相同的状态发布路径，成功、失败、重连都更新当前窗口的规则 store；不能只写 localStorage。
+2. 已存在连接的幂等启动必须把当前真实状态回传给调用者，至少补发 `connecting`/`active`，让错误页面能自愈。
+3. 后台核对后应以完整快照重新派生页面状态，不能只看 renderer 连接表是否变化；或者直接比较“后台快照”和“页面显示值”。
+4. 停止只有在后端确认成功后才能发布 `inactive`；失败时保留原状态和可重试的停止按钮，并展示错误。
+
+### P1：收敛为单一真相来源
+
+1. 让主进程按 `ruleId` 持有且唯一化运行实例，列表接口直接返回 `ruleId`、`tunnelId`、明确阶段和错误，不再解析 tunnelId。
+2. 把规则配置和运行状态拆开：持久化只保存配置与 `autoStart`；`status/error` 只由主进程运行快照和事件生成。
+3. 主进程广播规则级状态变化给所有窗口；新窗口先取一次完整快照，再订阅增量事件，避免订阅与快照之间的竞态。
+4. 正常停止也按 `ruleId` 操作，确保历史重复实例能一次收干净；主进程 start 对同一规则做幂等或串行化。
+5. 查询失败时不要显示确定的“已停止”，应保持最后已知状态并标记“状态待确认”，直到重新取得后台快照。
+
+## 必须覆盖的验证矩阵
+
+- 自动启动：`inactive → connecting → active`，当前窗口不用切页或等待 storage 事件即可显示“停止”。
+- Issue 原路径：启动自动启动规则，关闭主窗口但保留托盘进程，再打开窗口；页面状态与端口监听一致，且可停止。
+- 完整退出后重启：旧连接已经清理，自动启动只创建一个新实例。
+- 同规则双窗口同时启动：主进程最终只有一个运行实例；两个窗口都显示 active。
+- 从另一窗口启动/停止：本窗口及时收到状态；漏掉事件后用完整快照仍能恢复。
+- 启动监听失败（端口占用）、SSH 握手失败、远程 forward 被拒绝：不得显示 active。
+- 停止时 listener/SSH 清理失败：不得显示 inactive；再次停止仍可操作。
+- SSH 异常断开和自动重连：`active → connecting → active/error` 顺序一致，不出现幽灵 active。
+- 非 UUID 的导入规则：仍能按显式 `ruleId` 恢复、核对和停止。
+- 后台列表查询暂时失败后恢复：不得把未知误判成 inactive，恢复后与后台快照一致。
+
+## 修复判定标准
+
+不能只断言 localStorage 里的 `status` 变了。测试至少同时证明：主进程运行实例、renderer 收到的运行快照、页面规则状态、按钮动作四者一致；并用真实 TCP listener 验证 active 时端口可连接、inactive 时端口已释放。

--- a/docs/research/issue-2280-port-forward-runtime-state.md
+++ b/docs/research/issue-2280-port-forward-runtime-state.md
@@ -1,102 +1,152 @@
-# Issue #2280：端口转发运行状态调研
+# Issue #2280: Port forwarding runtime state research
 
-调研日期：2026-07-17
-范围：Netcatty `v1.1.68` 与当前 `main` 的端口转发启动、停止、自动启动、跨窗口同步和后端生命周期；外部对照只采用官方源码或文档。
+Research date: 2026-07-17
 
-## 结论
+Scope: Netcatty v1.1.68 and the current main branch, including start, stop,
+auto-start, multi-window synchronization, and backend lifecycle behavior.
+External comparisons use official source code or documentation only.
 
-Issue #2280 的现象可以由当前代码完整解释，并非单纯的显示延迟：**自动启动成功后，真实连接状态只写入了 localStorage，没有更新当前窗口正在订阅的内存状态。** 浏览器的 `storage` 事件不会回送给发起写入的同一窗口，因此页面仍显示 `inactive`；同时，后台连接表已经是 `active`，现有 4 秒核对逻辑看不到“后台连接表发生变化”，也就不会刷新页面。用户再次点“启动”时，服务层又把已有连接视为幂等成功并直接返回，但不会补发 `active`，所以页面无法自愈。
+## Conclusion
 
-这条链路与 issue 中“自动启动后实际已经开启、界面显示未开启、无法停止”逐项一致。原始复现和截图见 [Issue #2280](https://github.com/binaricat/Netcatty/issues/2280)。报告使用的 `v1.1.68` 源码与当前 `main` 在这条链路上相同。
+Issue #2280 was not a display delay. After auto-start succeeded, the real
+connection status was written to localStorage but did not update the in-memory
+state observed by the current window. A browser storage event is not delivered
+back to the window that made the write. The page therefore remained inactive
+while both the backend tunnel and the renderer connection record were active.
 
-## 现有机制
+The four-second reconciliation also could not repair the page because the
+backend and renderer connection maps already agreed. A second Start click was
+treated as an idempotent success, but it did not republish the active status.
+This exactly matches the report: the tunnel was running, the page showed it as
+stopped, and the user could not stop it from that page.
 
-### 1. 两套状态同时存在
+Original reproduction and screenshots: [Issue #2280](https://github.com/binaricat/Netcatty/issues/2280).
+The relevant lifecycle was unchanged between v1.1.68 and the inspected main
+branch.
 
-- Electron 主进程的 `portForwardingTunnels` 保存真实 SSH 连接、监听端口和当前阶段；`listPortForwards()` 从这里返回运行中的隧道。[主进程实现](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/electron/bridges/portForwardingBridge.cjs#L28-L29) / [列表接口](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/electron/bridges/portForwardingBridge.cjs#L741-L753)
-- Renderer 的 `activeConnections` 又维护一份连接表；React 页面显示的则是 `globalRules[].status`。页面状态只在 `setGlobalRules()` 通知订阅者后才会变化。[连接表](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/infrastructure/services/portForwardingService.ts#L48-L56) / [页面 store](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/application/state/usePortForwardingState.ts#L87-L120)
-- `status` 和 `error` 还被放进持久化的规则对象；启动时再用 renderer 连接表覆盖它们。[规则模型](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/domain/models/portForwarding.ts#L5-L24) / [初始化](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/application/state/usePortForwardingState.ts#L122-L135)
+## Existing state model
 
-因此当前不是“一个真相来源”，而是主进程、renderer 连接表、React 规则列表和 localStorage 四处互相同步。
+Four state copies were involved:
 
-### 2. Issue #2280 的确定性断点
+1. The Electron main process owned real SSH connections and listeners in
+   `portForwardingTunnels`.
+2. Each renderer kept another runtime map in `activeConnections`.
+3. React rendered `globalRules[].status`.
+4. The persisted rule objects also contained `status` and `error`.
 
-自动启动绕过了 `usePortForwardingState.startTunnel()`，直接调用底层 `startPortForward()`；它的状态回调 `updateStoredRuleStatus()` 只执行 localStorage 写入。[自动启动回调](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/application/state/usePortForwardingAutoStart.ts#L190-L210) / [直接启动](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/application/state/usePortForwardingAutoStart.ts#L274-L327)
+The system therefore depended on synchronization among four copies instead of
+one runtime source of truth.
 
-同一窗口的规则 store 只监听原生 `storage` 事件来接收外部窗口写入，没有同窗口通知通道。[storage 监听](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/application/state/usePortForwardingState.ts#L176-L199)
+## Deterministic failure path
 
-随后会出现一个稳定的错误状态：
+Auto-start called the low-level start service directly. Its status callback
+only updated localStorage. The current window listened to native storage events,
+which only arrive for writes made by other windows.
 
-1. 主进程隧道为 `active`；renderer `activeConnections` 也已被状态事件更新为 `active`。[状态事件处理](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/infrastructure/services/portForwardingService.ts#L674-L703)
-2. React 的 `globalRules` 仍为 `inactive`，所以卡片只显示“启动”，不显示“停止”。[按钮条件](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/components/port-forwarding/RuleCard.tsx#L48-L49) / [启停按钮](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/components/port-forwarding/RuleCard.tsx#L132-L166)
-3. 定时核对只在 renderer 连接表相对后端出现、消失或阶段改变时返回变化；此时两边都已经是 `active`，所以不会刷新 React store。[核对实现](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/infrastructure/services/portForwardingService.ts#L415-L499) / [页面刷新条件](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/application/state/usePortForwardingState.ts#L220-L246)
-4. 用户点“启动”时，底层发现连接已存在便直接返回成功，但不调用状态回调，因此页面仍然无法恢复。[幂等早退](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/infrastructure/services/portForwardingService.ts#L519-L529)
+The stable broken state was:
 
-### 3. 深挖后发现的其他准确性风险
+1. The main-process tunnel was active.
+2. The renderer runtime connection was active.
+3. The React rule remained inactive, so the card offered Start instead of Stop.
+4. Reconciliation saw no backend-to-renderer difference and skipped the UI
+   refresh.
+5. Another Start call reused the existing tunnel without repairing the UI.
 
-这些不一定是本 issue 的首要触发条件，但如果目标是“状态准确无误”，应一起纳入修复边界：
+## Additional accuracy risks found during investigation
 
-- **停止失败仍显示已停止。** renderer 调用后端停止后，无论 `result.success` 是真是假，都会删除本地连接并通知 `inactive`；而主进程在清理失败时会返回 `success: false` 并保留隧道。两边会再次分叉。[renderer 停止](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/infrastructure/services/portForwardingService.ts#L788-L824) / [主进程失败语义](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/electron/bridges/portForwardingBridge.cjs#L46-L91)
-- **跨窗口可能为同一规则创建多个隧道。** renderer 的幂等判断只看本窗口内存；主进程 `startPortForward` 不按 `ruleId` 去重。两个窗口在同步前并发启动时，主进程 Map 可留下多个 tunnel。普通停止只按单个 `tunnelId` 停止，虽然另有 `stopPortForwardByRuleId` 能全部清理。[启动登记](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/electron/bridges/portForwardingBridge.cjs#L99-L205) / [单 tunnel 停止](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/electron/bridges/portForwardingBridge.cjs#L704-L724) / [按规则停止](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/electron/bridges/portForwardingBridge.cjs#L771-L794)
-- **恢复依赖从 tunnelId 反解 UUID。** 后端对象本身已有 `ruleId`，但列表接口不返回它；renderer 只能解析 `pf-{UUID}-{timestamp}`。导入或旧数据若不是标准 UUID，就无法恢复和核对。[反解逻辑](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/infrastructure/services/portForwardingService.ts#L346-L378) / [列表缺少 ruleId](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/electron/bridges/portForwardingBridge.cjs#L741-L753)
-- **核对失败被当作“无需变化”。** bridge 不可用或查询抛错时返回空变化，页面会继续展示旧状态；目前没有 `unknown`/`unavailable` 阶段来表达“暂时无法确认”。[失败处理](https://github.com/binaricat/Netcatty/blob/892f3f6ff90157922cbcbdedb4aea055b6e00bd9/infrastructure/services/portForwardingService.ts#L427-L499)
+- A failed stop could be displayed as inactive even when backend cleanup failed.
+- Two windows could race to create duplicate tunnels for the same rule.
+- Recovery depended on parsing a rule ID from a generated tunnel ID even though
+  the backend already stored the explicit rule ID.
+- A backend query failure could leave stale state with no way to express that
+  the current state was unknown.
+- A newly opened window could adopt an existing tunnel but miss a status event
+  during the reply-to-subscription handoff.
+- Cleanup errors, reconnect timers, storage writes, and heartbeat reconciliation
+  could overwrite one another and produce false active, inactive, or connecting
+  states.
 
-## 成熟项目的做法
+## Comparison with mature projects
 
-### OpenSSH：只有监听建立成功才算启动成功
+### OpenSSH
 
-OpenSSH 的 `ExitOnForwardFailure=yes` 会在任一动态、本地、远程转发无法建立监听时终止连接；与后台运行配合时，也会等待转发建立成功后才进入后台。[OpenBSD 官方 ssh_config(5)](https://man.openbsd.org/ssh_config.5#ExitOnForwardFailure)
+OpenSSH `ExitOnForwardFailure=yes` treats listener setup failure as connection
+failure. When backgrounding is requested, it waits for forwarding setup before
+entering the background. This supports a strict rule: active must come from a
+confirmed listener or remote-forward result, never from a persisted flag or a
+button click.
 
-可借鉴点：`active` 必须来自端口监听/远端 forward 确认，而不是来自“用户点过启动”或持久化标记；启动失败必须保留为可见错误。
+Source: [OpenBSD ssh_config(5)](https://man.openbsd.org/ssh_config.5#ExitOnForwardFailure).
 
-### Tabby：运行集合只在资源真的建立后加入，停止后立即移除
+### Tabby
 
-Tabby 的本地/动态转发先等待 listener 的 `listening`，成功后才把 `ForwardedPort` 放进 `forwardedPorts`；失败则抛错，不登记为运行中。远程转发也只有服务器确认 `forwardTCPPort` 后才加入集合。停止时关闭真实 listener 或发出远程取消，然后从同一个运行集合移除。[Tabby `addPortForward` / `removePortForward`](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-ssh/src/session/ssh.ts#L786-L845) 转发对象本身持有 listener，SSH session 销毁时统一关闭所有 listener。[ForwardedPort](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-ssh/src/session/forwards.ts#L6-L54) / [session 清理](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-ssh/src/session/ssh.ts#L146-L150)
+Tabby adds a local or dynamic forward to its runtime collection only after the
+listener emits `listening`. A remote forward is added only after the server
+confirms it. Stop closes the real resource and removes it from the same runtime
+collection. Session teardown closes all remaining listeners.
 
-可借鉴点：配置列表与“当前运行集合”分开；运行集合里的对象就是可停止的真实资源，不需要再从配置状态猜测。
+Sources: [addPortForward and removePortForward](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-ssh/src/session/ssh.ts#L786-L845),
+[ForwardedPort](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-ssh/src/session/forwards.ts#L6-L54),
+and [session cleanup](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-ssh/src/session/ssh.ts#L146-L150).
 
-### VS Code：服务持有唯一运行表，并通过 opened/closed 事件驱动所有消费者
+### VS Code
 
-VS Code 的 tunnel service 暴露 `tunnels`、`onTunnelOpened`、`onTunnelClosed`、`openTunnel` 和 `closeTunnel`；内部 Map 保存真实 tunnel Promise，并对同一 tunnel 做引用计数。[接口与运行表](https://github.com/microsoft/vscode/blob/b1b978c118c517376df3d95696201265e0d84264/src/vs/platform/tunnel/common/tunnel.ts#L120-L144) / [内部 Map](https://github.com/microsoft/vscode/blob/b1b978c118c517376df3d95696201265e0d84264/src/vs/platform/tunnel/common/tunnel.ts#L224-L238) 只有 provider 成功返回真实 tunnel 后才发 `onTunnelOpened`；失败对象会从 Map 清除。最后一个引用释放或强制关闭时，先等待资源 dispose，再从 Map 删除并发 `onTunnelClosed`。[打开流程](https://github.com/microsoft/vscode/blob/b1b978c118c517376df3d95696201265e0d84264/src/vs/platform/tunnel/common/tunnel.ts#L352-L399) / [关闭流程](https://github.com/microsoft/vscode/blob/b1b978c118c517376df3d95696201265e0d84264/src/vs/platform/tunnel/common/tunnel.ts#L401-L466)
+VS Code's tunnel service owns one runtime map and exposes tunnel-opened and
+tunnel-closed events to consumers. It publishes opened only after a provider
+returns a real tunnel. Failed opens are removed from the map. Final release
+waits for disposal, removes the runtime entry, and then publishes closed.
 
-可借鉴点：真实资源由一个服务统一拥有；页面和其他窗口订阅同一组 opened/closed 事件，不能各自维护一个“差不多同步”的状态副本。
+Sources: [service contract](https://github.com/microsoft/vscode/blob/b1b978c118c517376df3d95696201265e0d84264/src/vs/platform/tunnel/common/tunnel.ts#L120-L144),
+[runtime map](https://github.com/microsoft/vscode/blob/b1b978c118c517376df3d95696201265e0d84264/src/vs/platform/tunnel/common/tunnel.ts#L224-L238),
+[open flow](https://github.com/microsoft/vscode/blob/b1b978c118c517376df3d95696201265e0d84264/src/vs/platform/tunnel/common/tunnel.ts#L352-L399),
+and [close flow](https://github.com/microsoft/vscode/blob/b1b978c118c517376df3d95696201265e0d84264/src/vs/platform/tunnel/common/tunnel.ts#L401-L466).
 
-### Electerm：连接关闭直接关闭监听资源
+### Electerm
 
-Electerm 在本地监听的 `listen` 回调后才 resolve 启动；监听失败则 reject。SSH 连接关闭时，它会销毁所有活跃 socket 并关闭本地 listener；动态转发也在 SSH close 时关闭 SOCKS server。[Electerm 官方源码](https://github.com/electerm/electerm/blob/6fbddfe55c66bffcb5aaad23676c0dd006e16367/src/app/server/ssh-tunnel.js#L78-L139) / [SOCKS 生命周期](https://github.com/electerm/electerm/blob/6fbddfe55c66bffcb5aaad23676c0dd006e16367/src/app/server/ssh-tunnel.js#L142-L202)
+Electerm resolves local forwarding only after the listener starts and rejects
+listener failures. SSH close destroys active sockets and closes the listener;
+dynamic forwarding similarly closes its SOCKS server with the SSH connection.
 
-可借鉴点：transport 生命周期直接决定转发是否存在；SSH close 与 listener close 是同一条清理链，而不是靠页面心跳推断。
+Sources: [SSH tunnel lifecycle](https://github.com/electerm/electerm/blob/6fbddfe55c66bffcb5aaad23676c0dd006e16367/src/app/server/ssh-tunnel.js#L78-L139)
+and [SOCKS lifecycle](https://github.com/electerm/electerm/blob/6fbddfe55c66bffcb5aaad23676c0dd006e16367/src/app/server/ssh-tunnel.js#L142-L202).
 
-## 建议的修复方向
+## Applied design direction
 
-### P0：修复 issue 的最小闭环
+The fix follows these principles:
 
-1. 自动启动必须走与手动启动相同的状态发布路径，成功、失败、重连都更新当前窗口的规则 store；不能只写 localStorage。
-2. 已存在连接的幂等启动必须把当前真实状态回传给调用者，至少补发 `connecting`/`active`，让错误页面能自愈。
-3. 后台核对后应以完整快照重新派生页面状态，不能只看 renderer 连接表是否变化；或者直接比较“后台快照”和“页面显示值”。
-4. 停止只有在后端确认成功后才能发布 `inactive`；失败时保留原状态和可重试的停止按钮，并展示错误。
+1. The rule ID is the durable identity. Tunnel IDs identify attempts only.
+2. The backend owns and deduplicates real runtime tunnels by rule ID.
+3. Existing tunnels can be adopted by another window, which receives later
+   status changes and verifies a fresh snapshot after subscribing.
+4. Same-window and cross-window writes merge configuration with known runtime
+   state instead of blindly replacing it.
+5. Stop publishes inactive only after successful backend cleanup. Failure stays
+   visible and retryable.
+6. Reconnect timers survive the expected error-close-reconcile sequence but are
+   suppressed after a manual stop attempt.
+7. Reconciliation repairs displayed state even when the renderer runtime map did
+   not otherwise change.
 
-### P1：收敛为单一真相来源
+## Required validation matrix
 
-1. 让主进程按 `ruleId` 持有且唯一化运行实例，列表接口直接返回 `ruleId`、`tunnelId`、明确阶段和错误，不再解析 tunnelId。
-2. 把规则配置和运行状态拆开：持久化只保存配置与 `autoStart`；`status/error` 只由主进程运行快照和事件生成。
-3. 主进程广播规则级状态变化给所有窗口；新窗口先取一次完整快照，再订阅增量事件，避免订阅与快照之间的竞态。
-4. 正常停止也按 `ruleId` 操作，确保历史重复实例能一次收干净；主进程 start 对同一规则做幂等或串行化。
-5. 查询失败时不要显示确定的“已停止”，应保持最后已知状态并标记“状态待确认”，直到重新取得后台快照。
+- Auto-start: inactive -> connecting -> active is visible in the same window.
+- Close the main window while keeping the tray process, reopen it, and verify the
+  page matches the listener and can stop it.
+- Full exit and restart creates only one new auto-start instance.
+- Two windows starting the same rule result in one backend tunnel and matching
+  active state in both windows.
+- A missed cross-window event is repaired by a fresh backend snapshot.
+- Port conflicts, SSH handshake failures, and rejected remote forwards never
+  display active.
+- Cleanup failure never displays inactive and Stop remains retryable.
+- Unexpected SSH close with auto-reconnect follows active -> connecting ->
+  active/error without a ghost active state.
+- Imported non-UUID rule IDs can be recovered, reconciled, and stopped.
+- Temporary backend-list failure does not turn unknown state into inactive.
 
-## 必须覆盖的验证矩阵
+## Completion criteria
 
-- 自动启动：`inactive → connecting → active`，当前窗口不用切页或等待 storage 事件即可显示“停止”。
-- Issue 原路径：启动自动启动规则，关闭主窗口但保留托盘进程，再打开窗口；页面状态与端口监听一致，且可停止。
-- 完整退出后重启：旧连接已经清理，自动启动只创建一个新实例。
-- 同规则双窗口同时启动：主进程最终只有一个运行实例；两个窗口都显示 active。
-- 从另一窗口启动/停止：本窗口及时收到状态；漏掉事件后用完整快照仍能恢复。
-- 启动监听失败（端口占用）、SSH 握手失败、远程 forward 被拒绝：不得显示 active。
-- 停止时 listener/SSH 清理失败：不得显示 inactive；再次停止仍可操作。
-- SSH 异常断开和自动重连：`active → connecting → active/error` 顺序一致，不出现幽灵 active。
-- 非 UUID 的导入规则：仍能按显式 `ruleId` 恢复、核对和停止。
-- 后台列表查询暂时失败后恢复：不得把未知误判成 inactive，恢复后与后台快照一致。
-
-## 修复判定标准
-
-不能只断言 localStorage 里的 `status` 变了。测试至少同时证明：主进程运行实例、renderer 收到的运行快照、页面规则状态、按钮动作四者一致；并用真实 TCP listener 验证 active 时端口可连接、inactive 时端口已释放。
+Validation must prove agreement among the main-process runtime instance, the
+renderer runtime snapshot, the visible rule state, and the available button
+action. A real TCP listener should be reachable while active and released while
+inactive. A localStorage status assertion alone is not sufficient.

--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -31,7 +31,7 @@ const STATUS_TEXT = {
 // Dynamic tray menu data (synced from renderer)
 let trayMenuData = {
   sessions: [],        // { id, label, hostLabel, status }
-  portForwardRules: [], // { id, label, type, localPort, remoteHost, remotePort, status, hostId }
+  portForwardRules: [], // { id, label, type, localPort, remoteHost, remotePort, status, hostId, canStop }
   hosts: [],           // { id, label, hostname, group, pinned, lastConnectedAt }
 };
 
@@ -754,6 +754,7 @@ function buildTrayMenuTemplate() {
     for (const rule of trayMenuData.portForwardRules) {
       const isActive = rule.status === "active";
       const isConnecting = rule.status === "connecting";
+      const isStoppable = isActive || isConnecting || rule.canStop === true;
       const statusText =
         rule.status === "active"
           ? STATUS_TEXT.portForward.active
@@ -773,7 +774,7 @@ function buildTrayMenuTemplate() {
         click: () => {
           const win = getMainWindow();
           if (win) {
-            win.webContents?.send("netcatty:tray:togglePortForward", rule.id, !isActive);
+            win.webContents?.send("netcatty:tray:togglePortForward", rule.id, !isStoppable);
           }
         },
       });

--- a/electron/bridges/globalShortcutBridge.test.cjs
+++ b/electron/bridges/globalShortcutBridge.test.cjs
@@ -567,6 +567,47 @@ test("tray icon event registration is platform-dependent", async () => {
   });
 });
 
+test("native tray sends an explicit stop for a runtime-present error rule", async () => {
+  await withPlatform("linux", async () => {
+    const bridge = loadBridge();
+    const electronModule = createElectronStub();
+    const sentMessages = [];
+    const win = new FakeWindow();
+    win.webContents = {
+      send(channel, ...args) {
+        sentMessages.push([channel, ...args]);
+      },
+    };
+    electronModule.BrowserWindow.getAllWindows = () => [win];
+    const { ipcMain } = await enableCloseToTray(bridge, electronModule);
+
+    await ipcMain.handlers.get("netcatty:tray:updateMenuData")(null, {
+      portForwardRules: [{
+        id: "cleanup-failed-rule",
+        label: "Cleanup failed",
+        type: "local",
+        localPort: 8080,
+        remoteHost: "127.0.0.1",
+        remotePort: 80,
+        status: "error",
+        canStop: true,
+      }],
+    });
+
+    const ruleItem = bridge.getTray().contextMenu.template.find(
+      (item) => item.label?.includes("Cleanup failed"),
+    );
+    assert.ok(ruleItem);
+    ruleItem.click();
+    assert.deepEqual(sentMessages, [[
+      "netcatty:tray:togglePortForward",
+      "cleanup-failed-rule",
+      false,
+    ]]);
+    bridge.cleanup();
+  });
+});
+
 test("mac dock menu lists saved hosts and forwards connect actions", async () => {
   await withPlatform("darwin", async () => {
     const bridge = loadBridge();

--- a/electron/bridges/portForwardingBridge.cancel.test.cjs
+++ b/electron/bridges/portForwardingBridge.cancel.test.cjs
@@ -210,11 +210,18 @@ test("concurrent starts reuse the existing tunnel for the same rule", async (t) 
       }
     }),
   };
-  const secondWindowEvents = [];
   const secondEvent = {
-    sender: createCapturingSender((channel, payload) => {
-      secondWindowEvents.push({ channel, payload });
+    sender: createCapturingSender((channel) => {
+      if (channel === "netcatty:portforward:status") {
+        throw new Error("renderer closed during send");
+      }
     }, 2),
+  };
+  const thirdWindowEvents = [];
+  const thirdEvent = {
+    sender: createCapturingSender((channel, payload) => {
+      thirdWindowEvents.push({ channel, payload });
+    }, 3),
   };
   const payload = {
     ruleId: "shared-rule",
@@ -239,8 +246,18 @@ test("concurrent starts reuse the existing tunnel for the same rule", async (t) 
     ...payload,
     tunnelId: "pf-shared-rule-second",
   });
+  const thirdStart = await startPortForward(thirdEvent, {
+    ...payload,
+    tunnelId: "pf-shared-rule-third",
+  });
 
   assert.deepEqual(secondStart, {
+    tunnelId: "pf-shared-rule-first",
+    success: true,
+    reused: true,
+    status: "connecting",
+  });
+  assert.deepEqual(thirdStart, {
     tunnelId: "pf-shared-rule-first",
     success: true,
     reused: true,
@@ -255,7 +272,7 @@ test("concurrent starts reuse the existing tunnel for the same rule", async (t) 
   }]);
 
   assert.equal(stopPortForwardByRuleId(event, { ruleId: "shared-rule" }).stopped, 1);
-  assert.ok(secondWindowEvents.some(({ channel, payload }) => (
+  assert.ok(thirdWindowEvents.some(({ channel, payload }) => (
     channel === "netcatty:portforward:status" &&
     payload.tunnelId === "pf-shared-rule-first" &&
     payload.status === "inactive"

--- a/electron/bridges/portForwardingBridge.cancel.test.cjs
+++ b/electron/bridges/portForwardingBridge.cancel.test.cjs
@@ -16,6 +16,7 @@ const {
   cancelTunnel,
   publishTunnelStatus,
   shouldFinalizeTunnelClose,
+  isReusableTunnelStatus,
 } = require("./portForwardingBridge.cjs");
 
 function createEncryptedKey(t) {
@@ -56,6 +57,13 @@ function createCapturingSender(onSend = () => {}, id = 1) {
     send: (channel, payload) => onSend(channel, payload),
   };
 }
+
+test("only live or connecting tunnels are reusable", () => {
+  assert.equal(isReusableTunnelStatus("active"), true);
+  assert.equal(isReusableTunnelStatus("connecting"), true);
+  assert.equal(isReusableTunnelStatus("error"), false);
+  assert.equal(isReusableTunnelStatus("inactive"), false);
+});
 
 test("status publication removes destroyed renderer subscribers", () => {
   const received = [];

--- a/electron/bridges/portForwardingBridge.cancel.test.cjs
+++ b/electron/bridges/portForwardingBridge.cancel.test.cjs
@@ -11,6 +11,7 @@ const {
   stopPortForward,
   stopPortForwardByRuleId,
   getPortForwardStatus,
+  listPortForwards,
   cancelTunnel,
   shouldFinalizeTunnelClose,
 } = require("./portForwardingBridge.cjs");
@@ -100,6 +101,7 @@ test("port forwarding can be stopped while waiting for a key passphrase", async 
     }),
   };
   const startPromise = startPortForward(event, {
+    ruleId: "rule-cancel-1",
     tunnelId,
     type: "local",
     localPort: 0,
@@ -118,6 +120,12 @@ test("port forwarding can be stopped while waiting for a key passphrase", async 
     status: "connecting",
     type: "local",
   });
+  assert.deepEqual(await listPortForwards(), [{
+    ruleId: "rule-cancel-1",
+    tunnelId,
+    type: "local",
+    status: "connecting",
+  }]);
 
   assert.deepEqual(await stopPortForward(event, { tunnelId }), {
     tunnelId,
@@ -178,6 +186,66 @@ test("port forwarding stops when the key passphrase prompt is cancelled", async 
     tunnelId,
     status: "inactive",
   });
+});
+
+test("concurrent starts reuse the existing tunnel for the same rule", async (t) => {
+  const keyPath = createEncryptedKey(t);
+  if (!keyPath) return;
+  const privateKey = fs.readFileSync(keyPath, "utf8");
+
+  let promptCount = 0;
+  let firstPromptStarted;
+  const promptStarted = new Promise((resolve) => {
+    firstPromptStarted = resolve;
+  });
+  const event = {
+    sender: createCapturingSender((channel) => {
+      if (channel === "netcatty:passphrase-request") {
+        promptCount++;
+        firstPromptStarted();
+      }
+    }),
+  };
+  const payload = {
+    ruleId: "shared-rule",
+    type: "local",
+    localPort: 0,
+    bindAddress: "127.0.0.1",
+    remoteHost: "127.0.0.1",
+    remotePort: 80,
+    hostname: "example.test",
+    username: "alice",
+    privateKey,
+    keyId: "key-shared",
+  };
+
+  const firstStart = startPortForward(event, {
+    ...payload,
+    tunnelId: "pf-shared-rule-first",
+  });
+  await promptStarted;
+
+  const secondStart = await startPortForward(event, {
+    ...payload,
+    tunnelId: "pf-shared-rule-second",
+  });
+
+  assert.deepEqual(secondStart, {
+    tunnelId: "pf-shared-rule-first",
+    success: true,
+    reused: true,
+    status: "connecting",
+  });
+  assert.equal(promptCount, 1);
+  assert.deepEqual(await listPortForwards(), [{
+    ruleId: "shared-rule",
+    tunnelId: "pf-shared-rule-first",
+    type: "local",
+    status: "connecting",
+  }]);
+
+  assert.equal(stopPortForwardByRuleId(event, { ruleId: "shared-rule" }).stopped, 1);
+  assert.equal((await firstStart).cancelled, true);
 });
 
 test("stop by rule id only cancels the matching passphrase prompt", async (t) => {

--- a/electron/bridges/portForwardingBridge.cancel.test.cjs
+++ b/electron/bridges/portForwardingBridge.cancel.test.cjs
@@ -11,6 +11,7 @@ const {
   stopPortForward,
   stopPortForwardByRuleId,
   getPortForwardStatus,
+  subscribePortForward,
   listPortForwards,
   cancelTunnel,
   publishTunnelStatus,
@@ -156,10 +157,23 @@ test("port forwarding can be stopped while waiting for a key passphrase", async 
     status: "connecting",
   }]);
 
+  const adoptedStatuses = [];
+  const adoptedEvent = {
+    sender: createCapturingSender((channel, payload) => {
+      if (channel === "netcatty:portforward:status") adoptedStatuses.push(payload);
+    }, 2),
+  };
+  assert.deepEqual(await subscribePortForward(adoptedEvent, { tunnelId }), {
+    tunnelId,
+    status: "connecting",
+    type: "local",
+  });
+
   assert.deepEqual(await stopPortForward(event, { tunnelId }), {
     tunnelId,
     success: true,
   });
+  assert.deepEqual(adoptedStatuses, [{ tunnelId, status: "inactive", error: null }]);
   assert.deepEqual(await getPortForwardStatus(event, { tunnelId }), {
     tunnelId,
     status: "inactive",

--- a/electron/bridges/portForwardingBridge.cancel.test.cjs
+++ b/electron/bridges/portForwardingBridge.cancel.test.cjs
@@ -47,16 +47,17 @@ function createSender() {
   return createCapturingSender();
 }
 
-function createCapturingSender(onSend = () => {}) {
+function createCapturingSender(onSend = () => {}, id = 1) {
   return {
-    id: 1,
+    id,
     isDestroyed: () => false,
     send: (channel, payload) => onSend(channel, payload),
   };
 }
 
-test("failed active tunnel cleanup never publishes an inactive close", () => {
+test("failed active tunnel cleanup publishes an error instead of a false inactive state", () => {
   let wouldPublishDuringCleanup;
+  const statuses = [];
   const tunnel = {
     status: "active",
     server: {
@@ -72,12 +73,15 @@ test("failed active tunnel cleanup never publishes an inactive close", () => {
   };
 
   assert.throws(
-    () => cancelTunnel("pf-active-cleanup-failure", tunnel, () => {}),
+    () => cancelTunnel("pf-active-cleanup-failure", tunnel, (status, error) => {
+      statuses.push({ status, error });
+    }),
     /server close failed/,
   );
   assert.equal(wouldPublishDuringCleanup, false);
   assert.equal(shouldFinalizeTunnelClose(tunnel), false);
-  assert.equal(tunnel.status, "active");
+  assert.equal(tunnel.status, "error");
+  assert.deepEqual(statuses, [{ status: "error", error: "server: server close failed" }]);
 });
 
 test("port forwarding can be stopped while waiting for a key passphrase", async (t) => {
@@ -206,6 +210,12 @@ test("concurrent starts reuse the existing tunnel for the same rule", async (t) 
       }
     }),
   };
+  const secondWindowEvents = [];
+  const secondEvent = {
+    sender: createCapturingSender((channel, payload) => {
+      secondWindowEvents.push({ channel, payload });
+    }, 2),
+  };
   const payload = {
     ruleId: "shared-rule",
     type: "local",
@@ -225,7 +235,7 @@ test("concurrent starts reuse the existing tunnel for the same rule", async (t) 
   });
   await promptStarted;
 
-  const secondStart = await startPortForward(event, {
+  const secondStart = await startPortForward(secondEvent, {
     ...payload,
     tunnelId: "pf-shared-rule-second",
   });
@@ -245,6 +255,11 @@ test("concurrent starts reuse the existing tunnel for the same rule", async (t) 
   }]);
 
   assert.equal(stopPortForwardByRuleId(event, { ruleId: "shared-rule" }).stopped, 1);
+  assert.ok(secondWindowEvents.some(({ channel, payload }) => (
+    channel === "netcatty:portforward:status" &&
+    payload.tunnelId === "pf-shared-rule-first" &&
+    payload.status === "inactive"
+  )));
   assert.equal((await firstStart).cancelled, true);
 });
 
@@ -385,8 +400,28 @@ test("stop by rule id reports cleanup failures and keeps the tunnel retryable", 
   });
   assert.deepEqual(await getPortForwardStatus(event, { tunnelId }), {
     tunnelId,
-    status: "connecting",
+    status: "error",
     type: "local",
+    error: "passphrase prompt: abort failed",
+  });
+
+  assert.deepEqual(await startPortForward(event, {
+    ruleId: "cleanup-failure-rule",
+    tunnelId: "pf-rule-cleanup-failure-retry",
+    type: "local",
+    localPort: 0,
+    bindAddress: "127.0.0.1",
+    remoteHost: "127.0.0.1",
+    remotePort: 80,
+    hostname: "cleanup-failure.example",
+    username: "alice",
+    privateKey,
+    keyId: "cleanup-failure-key",
+  }), {
+    tunnelId,
+    success: false,
+    blockedByCleanup: true,
+    error: "The existing tunnel could not be cleaned up. Stop it successfully before restarting.",
   });
 
   AbortController.prototype.abort = originalAbort;

--- a/electron/bridges/portForwardingBridge.cancel.test.cjs
+++ b/electron/bridges/portForwardingBridge.cancel.test.cjs
@@ -13,6 +13,7 @@ const {
   getPortForwardStatus,
   listPortForwards,
   cancelTunnel,
+  publishTunnelStatus,
   shouldFinalizeTunnelClose,
 } = require("./portForwardingBridge.cjs");
 
@@ -54,6 +55,30 @@ function createCapturingSender(onSend = () => {}, id = 1) {
     send: (channel, payload) => onSend(channel, payload),
   };
 }
+
+test("status publication removes destroyed renderer subscribers", () => {
+  const received = [];
+  const destroyed = {
+    id: 1,
+    isDestroyed: () => true,
+    send: () => assert.fail("destroyed renderer must not receive status"),
+  };
+  const healthy = createCapturingSender((channel, payload) => {
+    received.push({ channel, payload });
+  }, 2);
+  const tunnel = {
+    subscribers: new Map([
+      [destroyed.id, destroyed],
+      [healthy.id, healthy],
+    ]),
+  };
+
+  publishTunnelStatus("pf-prune-subscribers", tunnel, "active");
+
+  assert.deepEqual(Array.from(tunnel.subscribers.keys()), [healthy.id]);
+  assert.equal(received.length, 1);
+  assert.equal(received[0]?.payload.status, "active");
+});
 
 test("failed active tunnel cleanup publishes an error instead of a false inactive state", () => {
   let wouldPublishDuringCleanup;

--- a/electron/bridges/portForwardingBridge.cjs
+++ b/electron/bridges/portForwardingBridge.cjs
@@ -47,9 +47,7 @@ function publishTunnelStatus(tunnelId, tunnel, status, error = null) {
     ? Array.from(tunnel.subscribers.values())
     : [];
   for (const subscriber of subscribers) {
-    if (!subscriber?.isDestroyed?.()) {
-      subscriber.send("netcatty:portforward:status", { tunnelId, status, error });
-    }
+    safeSend(subscriber, "netcatty:portforward:status", { tunnelId, status, error });
   }
 }
 

--- a/electron/bridges/portForwardingBridge.cjs
+++ b/electron/bridges/portForwardingBridge.cjs
@@ -39,6 +39,10 @@ function isTunnelCancelled(tunnelState) {
   return Boolean(tunnelState?.cancelled);
 }
 
+function isReusableTunnelStatus(status) {
+  return status === 'active' || status === 'connecting';
+}
+
 function publishTunnelStatus(tunnelId, tunnel, status, error = null) {
   if (!tunnel) return;
   tunnel.status = status;
@@ -169,6 +173,13 @@ async function startPortForward(event, payload) {
           };
         }
         continue;
+      }
+      if (!isReusableTunnelStatus(existingTunnel.status)) {
+        return {
+          tunnelId: existingTunnelId,
+          success: false,
+          error: existingTunnel.error || 'The existing tunnel is no longer reusable.',
+        };
       }
       if (!(existingTunnel.subscribers instanceof Map)) {
         existingTunnel.subscribers = new Map();
@@ -909,4 +920,5 @@ module.exports = {
   cancelTunnel,
   publishTunnelStatus,
   shouldFinalizeTunnelClose,
+  isReusableTunnelStatus,
 };

--- a/electron/bridges/portForwardingBridge.cjs
+++ b/electron/bridges/portForwardingBridge.cjs
@@ -793,6 +793,30 @@ async function getPortForwardStatus(event, payload) {
 }
 
 /**
+ * Register the calling renderer for status events from an existing tunnel and
+ * return the status from the same main-process turn.
+ */
+async function subscribePortForward(event, payload) {
+  const { tunnelId } = payload;
+  const tunnel = portForwardingTunnels.get(tunnelId);
+
+  if (!tunnel) {
+    return { tunnelId, status: 'inactive' };
+  }
+
+  if (!(tunnel.subscribers instanceof Map)) {
+    tunnel.subscribers = new Map();
+  }
+  tunnel.subscribers.set(event.sender.id, event.sender);
+  return {
+    tunnelId,
+    status: tunnel.status || 'active',
+    type: tunnel.type,
+    ...(tunnel.error ? { error: tunnel.error } : {}),
+  };
+}
+
+/**
  * List all active port forwards
  */
 async function listPortForwards() {
@@ -867,6 +891,7 @@ function registerHandlers(ipcMain) {
   ipcMain.handle("netcatty:portforward:start", startPortForward);
   ipcMain.handle("netcatty:portforward:stop", stopPortForward);
   ipcMain.handle("netcatty:portforward:status", getPortForwardStatus);
+  ipcMain.handle("netcatty:portforward:subscribe", subscribePortForward);
   ipcMain.handle("netcatty:portforward:list", listPortForwards);
   ipcMain.handle("netcatty:portforward:stopAll", () => stopAllPortForwards());
   ipcMain.handle("netcatty:portforward:stopByRuleId", stopPortForwardByRuleId);
@@ -877,6 +902,7 @@ module.exports = {
   startPortForward,
   stopPortForward,
   getPortForwardStatus,
+  subscribePortForward,
   listPortForwards,
   stopAllPortForwards,
   stopPortForwardByRuleId,

--- a/electron/bridges/portForwardingBridge.cjs
+++ b/electron/bridges/portForwardingBridge.cjs
@@ -134,6 +134,23 @@ async function startPortForward(event, payload) {
     sshTcpConnectTimeoutMs,
     sshAuthReadyTimeoutMs,
   } = payload;
+
+  // The rule is the durable identity; tunnelId is only one renderer's
+  // attempt. Reuse an in-flight/live tunnel so two windows cannot create
+  // duplicate listeners for the same saved rule.
+  if (ruleId) {
+    for (const [existingTunnelId, existingTunnel] of portForwardingTunnels) {
+      if (existingTunnel.ruleId !== ruleId) continue;
+      if (existingTunnel.cancelled && !existingTunnel.cleanupFailed) continue;
+      return {
+        tunnelId: existingTunnelId,
+        success: true,
+        reused: true,
+        status: existingTunnel.status || 'active',
+      };
+    }
+  }
+
   const connectionTimeouts = resolveSshConnectionTimeouts({
     sshTcpConnectTimeoutMs,
     sshAuthReadyTimeoutMs,
@@ -744,6 +761,7 @@ async function listPortForwards() {
   const list = [];
   for (const [tunnelId, tunnel] of portForwardingTunnels) {
     list.push({
+      ruleId: tunnel.ruleId,
       tunnelId,
       type: tunnel.type,
       status: tunnel.status || 'active',

--- a/electron/bridges/portForwardingBridge.cjs
+++ b/electron/bridges/portForwardingBridge.cjs
@@ -39,13 +39,26 @@ function isTunnelCancelled(tunnelState) {
   return Boolean(tunnelState?.cancelled);
 }
 
+function publishTunnelStatus(tunnelId, tunnel, status, error = null) {
+  if (!tunnel) return;
+  tunnel.status = status;
+  tunnel.error = error || undefined;
+  const subscribers = tunnel.subscribers instanceof Map
+    ? Array.from(tunnel.subscribers.values())
+    : [];
+  for (const subscriber of subscribers) {
+    if (!subscriber?.isDestroyed?.()) {
+      subscriber.send("netcatty:portforward:status", { tunnelId, status, error });
+    }
+  }
+}
+
 function shouldFinalizeTunnelClose(tunnel) {
   return !tunnel?.cleanupFailed && !tunnel?.cleanupInProgress;
 }
 
 function cancelTunnel(tunnelId, tunnel, sendStatus, { deleteEntry = false } = {}) {
   if (!tunnel) return;
-  const previousStatus = tunnel.status;
   const errors = [];
   const cleanup = (label, action) => {
     try {
@@ -77,10 +90,13 @@ function cancelTunnel(tunnelId, tunnel, sendStatus, { deleteEntry = false } = {}
     if (cleanup('SSH connection', () => tunnel.conn.end())) tunnel.conn = null;
   }
   if (errors.length > 0) {
-    tunnel.status = previousStatus;
+    const error = errors.join('; ');
+    tunnel.status = 'error';
+    tunnel.error = error;
     tunnel.cleanupFailed = true;
     tunnel.cleanupInProgress = false;
-    throw new Error(errors.join('; '));
+    sendStatus?.('error', error);
+    throw new Error(error);
   }
   tunnel.status = 'inactive';
   tunnel.cleanupFailed = false;
@@ -141,7 +157,21 @@ async function startPortForward(event, payload) {
   if (ruleId) {
     for (const [existingTunnelId, existingTunnel] of portForwardingTunnels) {
       if (existingTunnel.ruleId !== ruleId) continue;
-      if (existingTunnel.cancelled && !existingTunnel.cleanupFailed) continue;
+      if (existingTunnel.cancelled) {
+        if (existingTunnel.cleanupFailed) {
+          return {
+            tunnelId: existingTunnelId,
+            success: false,
+            blockedByCleanup: true,
+            error: 'The existing tunnel could not be cleaned up. Stop it successfully before restarting.',
+          };
+        }
+        continue;
+      }
+      if (!(existingTunnel.subscribers instanceof Map)) {
+        existingTunnel.subscribers = new Map();
+      }
+      existingTunnel.subscribers.set(event.sender.id, event.sender);
       return {
         tunnelId: existingTunnelId,
         success: true,
@@ -173,13 +203,12 @@ async function startPortForward(event, payload) {
     ruleId,
     status: 'connecting',
     webContentsId: sender.id,
+    subscribers: new Map([[sender.id, sender]]),
     cancelled: false,
   };
 
   const sendStatus = (status, error = null) => {
-    if (!sender.isDestroyed()) {
-      sender.send("netcatty:portforward:status", { tunnelId, status, error });
-    }
+    publishTunnelStatus(tunnelId, tunnelState, status, error);
   };
 
   // Keepalive policy:
@@ -730,10 +759,12 @@ async function stopPortForward(event, payload) {
   }
 
   try {
-    cancelTunnel(tunnelId, tunnel, null, { deleteEntry: true });
-    if (!event.sender.isDestroyed()) {
-      event.sender.send("netcatty:portforward:status", { tunnelId, status: 'inactive', error: null });
-    }
+    cancelTunnel(
+      tunnelId,
+      tunnel,
+      (status, error) => publishTunnelStatus(tunnelId, tunnel, status, error),
+      { deleteEntry: true },
+    );
     return { tunnelId, success: true };
   } catch (err) {
     return { tunnelId, success: false, error: err.message };
@@ -751,7 +782,12 @@ async function getPortForwardStatus(event, payload) {
     return { tunnelId, status: 'inactive' };
   }
 
-  return { tunnelId, status: tunnel.status || 'active', type: tunnel.type };
+  return {
+    tunnelId,
+    status: tunnel.status || 'active',
+    type: tunnel.type,
+    ...(tunnel.error ? { error: tunnel.error } : {}),
+  };
 }
 
 /**
@@ -765,6 +801,7 @@ async function listPortForwards() {
       tunnelId,
       type: tunnel.type,
       status: tunnel.status || 'active',
+      ...(tunnel.error ? { error: tunnel.error } : {}),
     });
   }
   return list;
@@ -777,7 +814,12 @@ function stopAllPortForwards() {
   console.log(`[PortForward] Stopping all ${portForwardingTunnels.size} active tunnels...`);
   for (const [tunnelId, tunnel] of portForwardingTunnels) {
       try {
-        cancelTunnel(tunnelId, tunnel, null, { deleteEntry: true });
+        cancelTunnel(
+          tunnelId,
+          tunnel,
+          (status, error) => publishTunnelStatus(tunnelId, tunnel, status, error),
+          { deleteEntry: true },
+        );
         console.log(`[PortForward] Stopped tunnel ${tunnelId}`);
     } catch (err) {
       console.warn(`[PortForward] Failed to stop tunnel ${tunnelId}:`, err.message);
@@ -798,7 +840,12 @@ function stopPortForwardByRuleId(_event, { ruleId }) {
   for (const [tunnelId, tunnel] of portForwardingTunnels) {
     if (tunnel.ruleId === ruleId) {
       try {
-        cancelTunnel(tunnelId, tunnel, null, { deleteEntry: true });
+        cancelTunnel(
+          tunnelId,
+          tunnel,
+          (status, error) => publishTunnelStatus(tunnelId, tunnel, status, error),
+          { deleteEntry: true },
+        );
         console.log(`[PortForward] Stopped tunnel ${tunnelId} for rule ${ruleId}`);
         stopped++;
       } catch (err) {

--- a/electron/bridges/portForwardingBridge.cjs
+++ b/electron/bridges/portForwardingBridge.cjs
@@ -44,9 +44,13 @@ function publishTunnelStatus(tunnelId, tunnel, status, error = null) {
   tunnel.status = status;
   tunnel.error = error || undefined;
   const subscribers = tunnel.subscribers instanceof Map
-    ? Array.from(tunnel.subscribers.values())
+    ? Array.from(tunnel.subscribers.entries())
     : [];
-  for (const subscriber of subscribers) {
+  for (const [subscriberId, subscriber] of subscribers) {
+    if (subscriber?.isDestroyed?.()) {
+      tunnel.subscribers.delete(subscriberId);
+      continue;
+    }
     safeSend(subscriber, "netcatty:portforward:status", { tunnelId, status, error });
   }
 }
@@ -877,5 +881,6 @@ module.exports = {
   stopAllPortForwards,
   stopPortForwardByRuleId,
   cancelTunnel,
+  publishTunnelStatus,
   shouldFinalizeTunnelClose,
 };

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -762,6 +762,9 @@ function createPreloadApi(ctx) {
   getPortForwardStatus: async (tunnelId) => {
     return ipcRenderer.invoke("netcatty:portforward:status", { tunnelId });
   },
+  subscribePortForward: async (tunnelId) => {
+    return ipcRenderer.invoke("netcatty:portforward:subscribe", { tunnelId });
+  },
   listPortForwards: async () => {
     return ipcRenderer.invoke("netcatty:portforward:list");
   },

--- a/global.d.ts
+++ b/global.d.ts
@@ -234,6 +234,8 @@ declare global {
     tunnelId: string;
     success: boolean;
     cancelled?: boolean;
+    reused?: boolean;
+    status?: 'inactive' | 'connecting' | 'active' | 'error';
     error?: string;
   }
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -234,6 +234,7 @@ declare global {
     tunnelId: string;
     success: boolean;
     cancelled?: boolean;
+    blockedByCleanup?: boolean;
     reused?: boolean;
     status?: 'inactive' | 'connecting' | 'active' | 'error';
     error?: string;

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -643,6 +643,67 @@ test("startPortForward does not keep an adopted tunnel that stopped before subsc
   assert.deepEqual(statuses, ["connecting", "inactive"]);
 });
 
+test("startPortForward does not revive an adopted tunnel stopped during its snapshot", async () => {
+  let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
+  let resolveSnapshot!: (snapshot: {
+    tunnelId: string;
+    status: PortForwardingRule["status"];
+  }) => void;
+  let markSnapshotRequested!: () => void;
+  const snapshotRequested = new Promise<void>((resolve) => {
+    markSnapshotRequested = resolve;
+  });
+  const snapshot = new Promise<{
+    tunnelId: string;
+    status: PortForwardingRule["status"];
+  }>((resolve) => {
+    resolveSnapshot = resolve;
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        startPortForward: async () => ({
+          success: true,
+          tunnelId: "stopped-during-snapshot-tunnel",
+          reused: true,
+          status: "active",
+        }),
+        getPortForwardStatus: () => {
+          markSnapshotRequested();
+          return snapshot;
+        },
+        onPortForwardStatus: (_tunnelId: string, listener: typeof statusListener) => {
+          statusListener = listener;
+          return () => undefined;
+        },
+      },
+    },
+  });
+  const statuses: string[] = [];
+  const stoppedRule = rule({ id: "stopped-during-snapshot-rule" });
+
+  const resultPromise = startPortForward(
+    stoppedRule,
+    host(),
+    [],
+    [],
+    [],
+    (status) => statuses.push(status),
+  );
+  await snapshotRequested;
+  statusListener?.("inactive");
+  resolveSnapshot({
+    tunnelId: "stopped-during-snapshot-tunnel",
+    status: "active",
+  });
+  const result = await resultPromise;
+
+  assert.equal(result.success, false);
+  assert.equal(getActiveConnection(stoppedRule.id), undefined);
+  assert.deepEqual(statuses, ["connecting", "inactive"]);
+});
+
 test("startPortForward keeps cleanup-blocked backend tunnels in an error state", async () => {
   Object.defineProperty(globalThis, "window", {
     configurable: true,

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -474,6 +474,30 @@ test("startPortForward treats repeated active starts as idempotent", async () =>
   await new Promise<void>((resolve) => setImmediate(resolve));
 });
 
+test("inactive backend events remove the runtime tunnel immediately", async () => {
+  let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        startPortForward: async () => ({ success: true }),
+        onPortForwardStatus: (_tunnelId: string, listener: typeof statusListener) => {
+          statusListener = listener;
+          return () => undefined;
+        },
+      },
+    },
+  });
+  const disconnectedRule = rule({ id: "inactive-event-rule" });
+
+  await startPortForward(disconnectedRule, host(), [], [], [], () => undefined);
+  assert.ok(getActiveConnection(disconnectedRule.id));
+
+  statusListener?.("inactive");
+
+  assert.equal(getActiveConnection(disconnectedRule.id), undefined);
+});
+
 test("startPortForward adopts a tunnel reused by the backend", async () => {
   let unsubscribed = false;
   const statusListeners = new Map<string, (status: PortForwardingRule["status"], error?: string | null) => void>();

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -244,6 +244,54 @@ test("heartbeat subscribes newly discovered auto-start tunnels for reconnect", a
   assert.deepEqual(statuses, ["connecting"]);
 });
 
+test("heartbeat replaces subscriptions when a rule gets a new backend tunnel", async (t) => {
+  let tunnelId = "replacement-old-tunnel";
+  const listeners = new Map<string, (status: PortForwardingRule["status"]) => void>();
+  const unsubscribedTunnelIds: string[] = [];
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        listPortForwards: async () => [{
+          ruleId: "replacement-rule",
+          tunnelId,
+          type: "local",
+          status: "active",
+        }],
+        onPortForwardStatus: (
+          subscribedTunnelId: string,
+          listener: (status: PortForwardingRule["status"]) => void,
+        ) => {
+          listeners.set(subscribedTunnelId, listener);
+          return () => unsubscribedTunnelIds.push(subscribedTunnelId);
+        },
+        subscribePortForward: async (subscribedTunnelId: string) => ({
+          tunnelId: subscribedTunnelId,
+          status: "active",
+        }),
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+      },
+    },
+  });
+  t.after(async () => {
+    await stopAndCleanupRuleAndWait("replacement-rule");
+  });
+
+  await syncWithBackend({ shouldReconnect: () => false });
+  const oldListener = listeners.get("replacement-old-tunnel");
+  assert.ok(oldListener);
+
+  tunnelId = "replacement-new-tunnel";
+  const reconciliation = await reconcileWithBackend();
+  assert.deepEqual(reconciliation.appeared, ["replacement-rule"]);
+  assert.deepEqual(unsubscribedTunnelIds, ["replacement-old-tunnel"]);
+  assert.ok(listeners.get("replacement-new-tunnel"));
+  assert.equal(getActiveConnection("replacement-rule")?.tunnelId, "replacement-new-tunnel");
+
+  oldListener("inactive");
+  assert.equal(getActiveConnection("replacement-rule")?.tunnelId, "replacement-new-tunnel");
+});
+
 test("syncWithBackend registers adopted tunnels without a status callback", async (t) => {
   const subscribedTunnelIds: string[] = [];
   Object.defineProperty(globalThis, "window", {

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -488,6 +488,10 @@ test("startPortForward adopts a tunnel reused by the backend", async () => {
           status: "active",
         }),
         stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+        getPortForwardStatus: async () => ({
+          tunnelId: "existing-backend-tunnel",
+          status: "active",
+        }),
         onPortForwardStatus: (tunnelId: string, listener: (status: PortForwardingRule["status"], error?: string | null) => void) => {
           statusListeners.set(tunnelId, listener);
           return () => {
@@ -519,6 +523,42 @@ test("startPortForward adopts a tunnel reused by the backend", async () => {
   assert.equal(getActiveConnection(reusedRule.id)?.status, "error");
   assert.deepEqual(statuses, ["connecting", "active", "error"]);
   await stopAndCleanupRuleAndWait(reusedRule.id);
+});
+
+test("startPortForward does not keep an adopted tunnel that stopped before subscription", async () => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        startPortForward: async () => ({
+          success: true,
+          tunnelId: "already-stopped-tunnel",
+          reused: true,
+          status: "connecting",
+        }),
+        getPortForwardStatus: async () => ({
+          tunnelId: "already-stopped-tunnel",
+          status: "inactive",
+        }),
+        onPortForwardStatus: () => () => undefined,
+      },
+    },
+  });
+  const statuses: string[] = [];
+  const stoppedRule = rule({ id: "stopped-before-adoption-rule" });
+
+  const result = await startPortForward(
+    stoppedRule,
+    host(),
+    [],
+    [],
+    [],
+    (status) => statuses.push(status),
+  );
+
+  assert.equal(result.success, false);
+  assert.equal(getActiveConnection(stoppedRule.id), undefined);
+  assert.deepEqual(statuses, ["connecting", "inactive"]);
 });
 
 test("startPortForward keeps cleanup-blocked backend tunnels in an error state", async () => {

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -506,6 +506,7 @@ test("inactive close events preserve an already scheduled reconnect", async (t) 
     value: {
       netcatty: {
         startPortForward: async () => ({ success: true }),
+        listPortForwards: async () => [],
         stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
         onPortForwardStatus: (_tunnelId: string, listener: typeof statusListener) => {
           statusListener = listener;
@@ -532,6 +533,11 @@ test("inactive close events preserve an already scheduled reconnect", async (t) 
   assert.equal(getActiveConnection(reconnectRule.id), scheduled);
   assert.ok(scheduled.reconnectTimerCallback);
   assert.equal(scheduled.status, "connecting");
+
+  await syncWithBackend();
+
+  assert.equal(getActiveConnection(reconnectRule.id), scheduled);
+  assert.ok(scheduled.reconnectTimerCallback);
 });
 
 test("startPortForward adopts a tunnel reused by the backend", async () => {

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -158,6 +158,37 @@ test("syncWithBackend subscribes adopted auto-start tunnels for reconnect", asyn
   assert.ok(connection.reconnectTimerCallback);
 });
 
+test("syncWithBackend registers adopted tunnels without a status callback", async (t) => {
+  const subscribedTunnelIds: string[] = [];
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        listPortForwards: async () => [{
+          ruleId: "plain-synced-rule",
+          tunnelId: "plain-synced-tunnel",
+          type: "local",
+          status: "active",
+        }],
+        onPortForwardStatus: () => () => undefined,
+        subscribePortForward: async (tunnelId: string) => {
+          subscribedTunnelIds.push(tunnelId);
+          return { tunnelId, status: "active" };
+        },
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+      },
+    },
+  });
+  t.after(async () => {
+    await stopAndCleanupRuleAndWait("plain-synced-rule");
+  });
+
+  await syncWithBackend();
+
+  assert.deepEqual(subscribedTunnelIds, ["plain-synced-tunnel"]);
+  assert.equal(getActiveConnection("plain-synced-rule")?.status, "active");
+});
+
 test("stopPortForward asks the backend to stop a rule even without local tracking", async () => {
   let stoppedRuleId: string | undefined;
   Object.defineProperty(globalThis, "window", {

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -108,6 +108,7 @@ test("syncWithBackend binds backend tunnels by explicit rule id", async () => {
 
 test("syncWithBackend subscribes adopted auto-start tunnels for reconnect", async (t) => {
   let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
+  const subscribedTunnelIds: string[] = [];
   Object.defineProperty(globalThis, "window", {
     configurable: true,
     value: {
@@ -121,6 +122,10 @@ test("syncWithBackend subscribes adopted auto-start tunnels for reconnect", asyn
         onPortForwardStatus: (_tunnelId: string, listener: typeof statusListener) => {
           statusListener = listener;
           return () => undefined;
+        },
+        subscribePortForward: async (tunnelId: string) => {
+          subscribedTunnelIds.push(tunnelId);
+          return { tunnelId, status: "active" };
         },
         stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
       },
@@ -137,6 +142,7 @@ test("syncWithBackend subscribes adopted auto-start tunnels for reconnect", asyn
     shouldReconnect: () => true,
     onStatusChange: (_ruleId, status, error) => statuses.push({ status, error }),
   });
+  assert.deepEqual(subscribedTunnelIds, ["synced-auto-start-tunnel"]);
   statusListener?.("error", "connection lost");
 
   const connection = getActiveConnection("synced-auto-start-rule");

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -5,6 +5,7 @@ import type { Host, PortForwardingRule, SSHKey } from "../../domain/models.ts";
 import { STORAGE_KEY_PF_RECONNECT_CANCEL } from "../config/storageKeys.ts";
 import {
   getActiveConnection,
+  reconcileWithBackend,
   setReconnectCallback,
   startPortForward,
   stopAndCleanupRule,
@@ -104,6 +105,35 @@ test("syncWithBackend binds backend tunnels by explicit rule id", async () => {
   assert.equal(result.success, true);
   assert.equal(stoppedTunnelId, "opaque-backend-tunnel-id");
   assert.deepEqual(statuses, ["inactive"]);
+});
+
+test("reconcileWithBackend reports an unavailable snapshot on query failure", async () => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        listPortForwards: async () => {
+          throw new Error("backend temporarily unavailable");
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(await reconcileWithBackend(), {
+    snapshotAvailable: false,
+    gone: [],
+    appeared: [],
+  });
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        listPortForwards: async () => [],
+      },
+    },
+  });
+  assert.equal((await reconcileWithBackend()).snapshotAvailable, true);
 });
 
 test("syncWithBackend subscribes adopted auto-start tunnels for reconnect", async (t) => {

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -173,19 +173,33 @@ test("stopPortForward keeps the live status when backend cleanup fails", async (
           statusListener = listener;
           return () => undefined;
         },
-        stopPortForwardByRuleId: async () => ({
-          stopped: 0,
-          failed: 1,
-          errors: ["listener close failed"],
-        }),
+        stopPortForwardByRuleId: async () => {
+          statusListener?.("error", "listener close failed");
+          return {
+            stopped: 0,
+            failed: 1,
+            errors: ["listener close failed"],
+          };
+        },
       },
     },
   });
 
   const liveRule = rule({ id: "stop-failure-rule" });
-  await startPortForward(liveRule, host(), [], [], [], () => undefined);
+  const runtimeStatuses: string[] = [];
+  setReconnectCallback(async () => ({ success: true }));
+  await startPortForward(
+    liveRule,
+    host(),
+    [],
+    [],
+    [],
+    (status) => runtimeStatuses.push(status),
+    true,
+  );
   statusListener?.("active");
   t.after(async () => {
+    setReconnectCallback(null);
     Object.defineProperty(globalThis, "window", {
       configurable: true,
       value: {
@@ -202,7 +216,9 @@ test("stopPortForward keeps the live status when backend cleanup fails", async (
 
   assert.equal(result.success, false);
   assert.match(result.error ?? "", /listener close failed/);
+  assert.equal(runtimeStatuses.at(-1), "connecting");
   assert.equal(getActiveConnection(liveRule.id)?.status, "error");
+  assert.equal(getActiveConnection(liveRule.id)?.reconnectTimeoutId, undefined);
   assert.deepEqual(statuses, ["error"]);
 });
 

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -463,6 +463,40 @@ test("stopPortForward preserves an untracked backend tunnel after cleanup fails"
   await stopAndCleanupRuleAndWait("untracked-failed-stop-rule");
 });
 
+test("stopPortForward preserves an untracked backend tunnel when cleanup rejects", async () => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        stopPortForwardByRuleId: async () => {
+          throw new Error("backend stop request rejected");
+        },
+      },
+    },
+  });
+
+  const statuses: string[] = [];
+  const result = await stopPortForward(
+    "untracked-rejected-stop-rule",
+    (status) => statuses.push(status),
+  );
+
+  assert.equal(result.success, false);
+  assert.match(result.error ?? "", /request rejected/);
+  assert.equal(getActiveConnection("untracked-rejected-stop-rule")?.status, "error");
+  assert.deepEqual(statuses, ["error"]);
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+      },
+    },
+  });
+  await stopAndCleanupRuleAndWait("untracked-rejected-stop-rule");
+});
+
 test("stopPortForward cancels reconnects scheduled in other windows", async (t) => {
   const previousLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
   const writes: Array<[string, string]> = [];

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -5,6 +5,7 @@ import type { Host, PortForwardingRule, SSHKey } from "../../domain/models.ts";
 import { STORAGE_KEY_PF_RECONNECT_CANCEL } from "../config/storageKeys.ts";
 import {
   getActiveConnection,
+  setReconnectCallback,
   startPortForward,
   stopAndCleanupRule,
   stopAndCleanupRuleAndWait,
@@ -496,6 +497,41 @@ test("inactive backend events remove the runtime tunnel immediately", async () =
   statusListener?.("inactive");
 
   assert.equal(getActiveConnection(disconnectedRule.id), undefined);
+});
+
+test("inactive close events preserve an already scheduled reconnect", async (t) => {
+  let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        startPortForward: async () => ({ success: true }),
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+        onPortForwardStatus: (_tunnelId: string, listener: typeof statusListener) => {
+          statusListener = listener;
+          return () => undefined;
+        },
+      },
+    },
+  });
+  const reconnectRule = rule({ id: "error-close-reconnect-rule" });
+  setReconnectCallback(async () => ({ success: true }));
+  t.after(async () => {
+    setReconnectCallback(null);
+    await stopAndCleanupRuleAndWait(reconnectRule.id);
+  });
+
+  await startPortForward(reconnectRule, host(), [], [], [], () => undefined, true);
+  statusListener?.("error", "connection failed");
+  const scheduled = getActiveConnection(reconnectRule.id);
+  assert.ok(scheduled?.reconnectTimerCallback);
+  assert.equal(scheduled.status, "connecting");
+
+  statusListener?.("inactive");
+
+  assert.equal(getActiveConnection(reconnectRule.id), scheduled);
+  assert.ok(scheduled.reconnectTimerCallback);
+  assert.equal(scheduled.status, "connecting");
 });
 
 test("startPortForward adopts a tunnel reused by the backend", async () => {

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -106,6 +106,52 @@ test("syncWithBackend binds backend tunnels by explicit rule id", async () => {
   assert.deepEqual(statuses, ["inactive"]);
 });
 
+test("syncWithBackend subscribes adopted auto-start tunnels for reconnect", async (t) => {
+  let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        listPortForwards: async () => [{
+          ruleId: "synced-auto-start-rule",
+          tunnelId: "synced-auto-start-tunnel",
+          type: "local",
+          status: "active",
+        }],
+        onPortForwardStatus: (_tunnelId: string, listener: typeof statusListener) => {
+          statusListener = listener;
+          return () => undefined;
+        },
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+      },
+    },
+  });
+  const statuses: Array<{ status: PortForwardingRule["status"]; error?: string }> = [];
+  setReconnectCallback(async () => ({ success: true }));
+  t.after(async () => {
+    setReconnectCallback(null);
+    await stopAndCleanupRuleAndWait("synced-auto-start-rule");
+  });
+
+  await syncWithBackend({
+    shouldReconnect: () => true,
+    onStatusChange: (_ruleId, status, error) => statuses.push({ status, error }),
+  });
+  statusListener?.("error", "connection lost");
+
+  const connection = getActiveConnection("synced-auto-start-rule");
+  assert.ok(connection?.reconnectTimerCallback);
+  assert.equal(connection.status, "connecting");
+  assert.deepEqual(statuses, [{
+    status: "connecting",
+    error: "Reconnecting (1/5)...",
+  }]);
+
+  statusListener?.("inactive");
+  assert.equal(getActiveConnection("synced-auto-start-rule"), connection);
+  assert.ok(connection.reconnectTimerCallback);
+});
+
 test("stopPortForward asks the backend to stop a rule even without local tracking", async () => {
   let stoppedRuleId: string | undefined;
   Object.defineProperty(globalThis, "window", {

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -188,6 +188,62 @@ test("syncWithBackend subscribes adopted auto-start tunnels for reconnect", asyn
   assert.ok(connection.reconnectTimerCallback);
 });
 
+test("heartbeat subscribes newly discovered auto-start tunnels for reconnect", async (t) => {
+  const statuses: string[] = [];
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        listPortForwards: async () => [],
+      },
+    },
+  });
+  await syncWithBackend({
+    shouldReconnect: () => true,
+    onStatusChange: (_ruleId, status) => statuses.push(status),
+  });
+
+  let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
+  const subscribedTunnelIds: string[] = [];
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        listPortForwards: async () => [{
+          ruleId: "heartbeat-auto-start-rule",
+          tunnelId: "heartbeat-auto-start-tunnel",
+          type: "local",
+          status: "active",
+        }],
+        onPortForwardStatus: (_tunnelId: string, listener: typeof statusListener) => {
+          statusListener = listener;
+          return () => undefined;
+        },
+        subscribePortForward: async (tunnelId: string) => {
+          subscribedTunnelIds.push(tunnelId);
+          return { tunnelId, status: "active" };
+        },
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+      },
+    },
+  });
+  setReconnectCallback(async () => ({ success: true }));
+  t.after(async () => {
+    setReconnectCallback(null);
+    await stopAndCleanupRuleAndWait("heartbeat-auto-start-rule");
+  });
+
+  const reconciliation = await reconcileWithBackend();
+  assert.deepEqual(reconciliation.appeared, ["heartbeat-auto-start-rule"]);
+  assert.deepEqual(subscribedTunnelIds, ["heartbeat-auto-start-tunnel"]);
+
+  statusListener?.("inactive");
+  const connection = getActiveConnection("heartbeat-auto-start-rule");
+  assert.ok(connection?.reconnectTimerCallback);
+  assert.equal(connection.status, "connecting");
+  assert.deepEqual(statuses, ["connecting"]);
+});
+
 test("syncWithBackend registers adopted tunnels without a status callback", async (t) => {
   const subscribedTunnelIds: string[] = [];
   Object.defineProperty(globalThis, "window", {

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -189,6 +189,88 @@ test("syncWithBackend registers adopted tunnels without a status callback", asyn
   assert.equal(getActiveConnection("plain-synced-rule")?.status, "active");
 });
 
+test("synced auto-start tunnels reconnect after an unexpected inactive event", async (t) => {
+  let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        listPortForwards: async () => [{
+          ruleId: "inactive-reconnect-rule",
+          tunnelId: "inactive-reconnect-tunnel",
+          type: "local",
+          status: "active",
+        }],
+        onPortForwardStatus: (_tunnelId: string, listener: typeof statusListener) => {
+          statusListener = listener;
+          return () => undefined;
+        },
+        subscribePortForward: async (tunnelId: string) => ({ tunnelId, status: "active" }),
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+      },
+    },
+  });
+  const statuses: string[] = [];
+  setReconnectCallback(async () => ({ success: true }));
+  t.after(async () => {
+    setReconnectCallback(null);
+    await stopAndCleanupRuleAndWait("inactive-reconnect-rule");
+  });
+
+  await syncWithBackend({
+    shouldReconnect: () => true,
+    onStatusChange: (_ruleId, status) => statuses.push(status),
+  });
+  statusListener?.("inactive");
+
+  const connection = getActiveConnection("inactive-reconnect-rule");
+  assert.ok(connection?.reconnectTimerCallback);
+  assert.equal(connection.status, "connecting");
+  assert.deepEqual(statuses, ["connecting"]);
+});
+
+test("manual stop of a synced tunnel does not schedule reconnect", async () => {
+  let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        listPortForwards: async () => [{
+          ruleId: "manual-synced-stop-rule",
+          tunnelId: "manual-synced-stop-tunnel",
+          type: "local",
+          status: "active",
+        }],
+        onPortForwardStatus: (_tunnelId: string, listener: typeof statusListener) => {
+          statusListener = listener;
+          return () => undefined;
+        },
+        subscribePortForward: async (tunnelId: string) => ({ tunnelId, status: "active" }),
+        stopPortForwardByRuleId: async () => {
+          statusListener?.("inactive");
+          return { stopped: 1, failed: 0, errors: [] };
+        },
+      },
+    },
+  });
+  const statuses: string[] = [];
+  setReconnectCallback(async () => ({ success: true }));
+
+  await syncWithBackend({
+    shouldReconnect: () => true,
+    onStatusChange: (_ruleId, status) => statuses.push(status),
+  });
+  const result = await stopPortForward(
+    "manual-synced-stop-rule",
+    (status) => statuses.push(status),
+  );
+  setReconnectCallback(null);
+
+  assert.equal(result.success, true);
+  assert.equal(getActiveConnection("manual-synced-stop-rule"), undefined);
+  assert.deepEqual(statuses, ["inactive", "inactive"]);
+});
+
 test("stopPortForward asks the backend to stop a rule even without local tracking", async () => {
   let stoppedRuleId: string | undefined;
   Object.defineProperty(globalThis, "window", {

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -7,6 +7,8 @@ import {
   startPortForward,
   stopAndCleanupRule,
   stopAndCleanupRuleAndWait,
+  stopPortForward,
+  syncWithBackend,
 } from "./portForwardingService.ts";
 
 const host = (overrides: Partial<Host> = {}): Host => ({
@@ -71,6 +73,101 @@ test("stopAndCleanupRuleAndWait stops backend tunnels without a renderer connect
 
   assert.equal(result.success, true);
   assert.equal(stoppedRuleId, "backend-only-rule");
+});
+
+test("syncWithBackend binds backend tunnels by explicit rule id", async () => {
+  let stoppedTunnelId: string | undefined;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        listPortForwards: async () => [{
+          ruleId: "imported-rule-id",
+          tunnelId: "opaque-backend-tunnel-id",
+          type: "local",
+          status: "active",
+        }],
+        stopPortForward: async (tunnelId: string) => {
+          stoppedTunnelId = tunnelId;
+          return { tunnelId, success: true };
+        },
+      },
+    },
+  });
+
+  await syncWithBackend();
+  const statuses: string[] = [];
+  const result = await stopPortForward("imported-rule-id", (status) => statuses.push(status));
+
+  assert.equal(result.success, true);
+  assert.equal(stoppedTunnelId, "opaque-backend-tunnel-id");
+  assert.deepEqual(statuses, ["inactive"]);
+});
+
+test("stopPortForward asks the backend to stop a rule even without local tracking", async () => {
+  let stoppedRuleId: string | undefined;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        stopPortForwardByRuleId: async (ruleId: string) => {
+          stoppedRuleId = ruleId;
+          return { stopped: 1, failed: 0, errors: [] };
+        },
+      },
+    },
+  });
+
+  const statuses: string[] = [];
+  const result = await stopPortForward("backend-only-stop-rule", (status) => statuses.push(status));
+
+  assert.equal(result.success, true);
+  assert.equal(stoppedRuleId, "backend-only-stop-rule");
+  assert.deepEqual(statuses, ["inactive"]);
+});
+
+test("stopPortForward keeps the live status when backend cleanup fails", async (t) => {
+  let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        startPortForward: async () => ({ success: true }),
+        onPortForwardStatus: (_tunnelId: string, listener: typeof statusListener) => {
+          statusListener = listener;
+          return () => undefined;
+        },
+        stopPortForwardByRuleId: async () => ({
+          stopped: 0,
+          failed: 1,
+          errors: ["listener close failed"],
+        }),
+      },
+    },
+  });
+
+  const liveRule = rule({ id: "stop-failure-rule" });
+  await startPortForward(liveRule, host(), [], [], [], () => undefined);
+  statusListener?.("active");
+  t.after(async () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        netcatty: {
+          stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+        },
+      },
+    });
+    await stopAndCleanupRuleAndWait(liveRule.id);
+  });
+
+  const statuses: string[] = [];
+  const result = await stopPortForward(liveRule.id, (status) => statuses.push(status));
+
+  assert.equal(result.success, false);
+  assert.match(result.error ?? "", /listener close failed/);
+  assert.equal(getActiveConnection(liveRule.id)?.status, "active");
+  assert.deepEqual(statuses, []);
 });
 
 test("stopAndCleanupRuleAndWait reports backend stop failures", async () => {
@@ -302,6 +399,7 @@ test("startPortForward rejects starts while the rule is pending cleanup", async 
 
 test("startPortForward treats repeated active starts as idempotent", async () => {
   let startCalls = 0;
+  let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
   Object.defineProperty(globalThis, "window", {
     configurable: true,
     value: {
@@ -311,21 +409,73 @@ test("startPortForward treats repeated active starts as idempotent", async () =>
           return { success: true };
         },
         stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
-        onPortForwardStatus: () => undefined,
+        onPortForwardStatus: (_tunnelId: string, listener: typeof statusListener) => {
+          statusListener = listener;
+          return () => undefined;
+        },
       },
     },
   });
   const repeatedRule = rule({ id: "repeated-rule" });
 
   const first = await startPortForward(repeatedRule, host(), [], [], [], () => undefined);
-  const second = await startPortForward(repeatedRule, host(), [], [], [], () => undefined);
+  statusListener?.("active");
+  const repeatedStatuses: string[] = [];
+  const second = await startPortForward(
+    repeatedRule,
+    host(),
+    [],
+    [],
+    [],
+    (status) => repeatedStatuses.push(status),
+  );
 
   assert.equal(first.success, true);
   assert.equal(second.success, true);
   assert.equal(startCalls, 1);
   assert.ok(getActiveConnection("repeated-rule"));
+  assert.deepEqual(repeatedStatuses, ["active"]);
   stopAndCleanupRule("repeated-rule");
   await new Promise<void>((resolve) => setImmediate(resolve));
+});
+
+test("startPortForward adopts a tunnel reused by the backend", async () => {
+  let unsubscribed = false;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        startPortForward: async () => ({
+          success: true,
+          tunnelId: "existing-backend-tunnel",
+          reused: true,
+          status: "active",
+        }),
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+        onPortForwardStatus: () => () => {
+          unsubscribed = true;
+        },
+      },
+    },
+  });
+  const statuses: string[] = [];
+  const reusedRule = rule({ id: "backend-reused-rule" });
+
+  const result = await startPortForward(
+    reusedRule,
+    host(),
+    [],
+    [],
+    [],
+    (status) => statuses.push(status),
+  );
+
+  assert.equal(result.success, true);
+  assert.equal(unsubscribed, true);
+  assert.equal(getActiveConnection(reusedRule.id)?.tunnelId, "existing-backend-tunnel");
+  assert.equal(getActiveConnection(reusedRule.id)?.status, "active");
+  assert.deepEqual(statuses, ["connecting", "active"]);
+  await stopAndCleanupRuleAndWait(reusedRule.id);
 });
 
 test("stopAndCleanupRule still clears local reconnect state after backend stop failures", async () => {

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import type { Host, PortForwardingRule, SSHKey } from "../../domain/models.ts";
+import { STORAGE_KEY_PF_RECONNECT_CANCEL } from "../config/storageKeys.ts";
 import {
   getActiveConnection,
   startPortForward,
@@ -126,6 +127,40 @@ test("stopPortForward asks the backend to stop a rule even without local trackin
   assert.deepEqual(statuses, ["inactive"]);
 });
 
+test("stopPortForward cancels reconnects scheduled in other windows", async (t) => {
+  const previousLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  const writes: Array<[string, string]> = [];
+  const backing = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => backing.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        writes.push([key, value]);
+        backing.set(key, value);
+      },
+      removeItem: (key: string) => backing.delete(key),
+    },
+  });
+  t.after(() => {
+    if (previousLocalStorage) Object.defineProperty(globalThis, "localStorage", previousLocalStorage);
+    else Reflect.deleteProperty(globalThis, "localStorage");
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+      },
+    },
+  });
+
+  const result = await stopPortForward("cross-window-reconnect-rule", () => undefined);
+
+  assert.equal(result.success, true);
+  assert.deepEqual(writes, [[STORAGE_KEY_PF_RECONNECT_CANCEL, "cross-window-reconnect-rule"]]);
+});
+
 test("stopPortForward keeps the live status when backend cleanup fails", async (t) => {
   let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
   Object.defineProperty(globalThis, "window", {
@@ -166,8 +201,8 @@ test("stopPortForward keeps the live status when backend cleanup fails", async (
 
   assert.equal(result.success, false);
   assert.match(result.error ?? "", /listener close failed/);
-  assert.equal(getActiveConnection(liveRule.id)?.status, "active");
-  assert.deepEqual(statuses, []);
+  assert.equal(getActiveConnection(liveRule.id)?.status, "error");
+  assert.deepEqual(statuses, ["error"]);
 });
 
 test("stopAndCleanupRuleAndWait reports backend stop failures", async () => {
@@ -441,6 +476,7 @@ test("startPortForward treats repeated active starts as idempotent", async () =>
 
 test("startPortForward adopts a tunnel reused by the backend", async () => {
   let unsubscribed = false;
+  const statusListeners = new Map<string, (status: PortForwardingRule["status"], error?: string | null) => void>();
   Object.defineProperty(globalThis, "window", {
     configurable: true,
     value: {
@@ -452,8 +488,12 @@ test("startPortForward adopts a tunnel reused by the backend", async () => {
           status: "active",
         }),
         stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
-        onPortForwardStatus: () => () => {
-          unsubscribed = true;
+        onPortForwardStatus: (tunnelId: string, listener: (status: PortForwardingRule["status"], error?: string | null) => void) => {
+          statusListeners.set(tunnelId, listener);
+          return () => {
+            unsubscribed = true;
+            statusListeners.delete(tunnelId);
+          };
         },
       },
     },
@@ -475,7 +515,47 @@ test("startPortForward adopts a tunnel reused by the backend", async () => {
   assert.equal(getActiveConnection(reusedRule.id)?.tunnelId, "existing-backend-tunnel");
   assert.equal(getActiveConnection(reusedRule.id)?.status, "active");
   assert.deepEqual(statuses, ["connecting", "active"]);
+  statusListeners.get("existing-backend-tunnel")?.("error", "connection lost");
+  assert.equal(getActiveConnection(reusedRule.id)?.status, "error");
+  assert.deepEqual(statuses, ["connecting", "active", "error"]);
   await stopAndCleanupRuleAndWait(reusedRule.id);
+});
+
+test("startPortForward keeps cleanup-blocked backend tunnels in an error state", async () => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        startPortForward: async () => ({
+          success: false,
+          tunnelId: "cleanup-blocked-tunnel",
+          blockedByCleanup: true,
+          error: "cleanup still required",
+        }),
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+        onPortForwardStatus: () => () => undefined,
+      },
+    },
+  });
+  const statuses: string[] = [];
+  const blockedRule = rule({ id: "cleanup-blocked-rule" });
+
+  const result = await startPortForward(
+    blockedRule,
+    host(),
+    [],
+    [],
+    [],
+    (status) => statuses.push(status),
+    true,
+  );
+
+  assert.equal(result.success, false);
+  assert.equal(getActiveConnection(blockedRule.id)?.tunnelId, "cleanup-blocked-tunnel");
+  assert.equal(getActiveConnection(blockedRule.id)?.status, "error");
+  assert.equal(getActiveConnection(blockedRule.id)?.reconnectTimeoutId, undefined);
+  assert.deepEqual(statuses, ["connecting", "error"]);
+  await stopAndCleanupRuleAndWait(blockedRule.id);
 });
 
 test("stopAndCleanupRule still clears local reconnect state after backend stop failures", async () => {

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -323,6 +323,42 @@ test("stopPortForward asks the backend to stop a rule even without local trackin
   assert.deepEqual(statuses, ["inactive"]);
 });
 
+test("stopPortForward preserves an untracked backend tunnel after cleanup fails", async () => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        stopPortForwardByRuleId: async () => ({
+          stopped: 0,
+          failed: 1,
+          errors: ["backend tunnel is still running"],
+        }),
+      },
+    },
+  });
+
+  const statuses: string[] = [];
+  const result = await stopPortForward(
+    "untracked-failed-stop-rule",
+    (status) => statuses.push(status),
+  );
+
+  assert.equal(result.success, false);
+  assert.match(result.error ?? "", /still running/);
+  assert.equal(getActiveConnection("untracked-failed-stop-rule")?.status, "error");
+  assert.deepEqual(statuses, ["error"]);
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+      },
+    },
+  });
+  await stopAndCleanupRuleAndWait("untracked-failed-stop-rule");
+});
+
 test("stopPortForward cancels reconnects scheduled in other windows", async (t) => {
   const previousLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
   const writes: Array<[string, string]> = [];

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -835,7 +835,13 @@ export const startPortForward = async (
       }
 
       const current = activeConnections.get(rule.id);
-      onStatusChange(current?.status ?? adoptedStatus, current?.error);
+      if (!current) {
+        return {
+          success: false,
+          error: 'Port forwarding tunnel stopped before adoption completed',
+        };
+      }
+      onStatusChange(current.status, current.error);
       return { success: true };
     }
     

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -690,6 +690,13 @@ export const startPortForward = async (
     // Subscribe to status updates first
     const handleTunnelStatus = (status: PortForwardingRule['status'], error?: string | null) => {
       const conn = activeConnections.get(rule.id);
+      if (status === 'inactive') {
+        conn?.unsubscribe?.();
+        clearReconnectTimer(rule.id);
+        activeConnections.delete(rule.id);
+        onStatusChange('inactive');
+        return;
+      }
       if (conn) {
         conn.status = status;
         conn.error = error ?? undefined;

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -615,10 +615,27 @@ export const reconcileWithBackend = async (): Promise<{
           // in another window).
           const existing = activeConnections.get(ruleId)!;
           const backendStatus = resolveBackendStatus(tunnel.status);
+          if (existing.tunnelId !== tunnel.tunnelId) {
+            existing.unsubscribe?.();
+            const replacement: PortForwardingConnection = {
+              ruleId,
+              tunnelId: tunnel.tunnelId,
+              status: backendStatus,
+              error: tunnel.error,
+              reconnectAttempts: existing.reconnectAttempts ?? 0,
+            };
+            configureSyncedConnection(replacement, ruleId);
+            activeConnections.set(ruleId, replacement);
+            if (!await subscribeSyncedConnection(ruleId, replacement)) {
+              result.gone.push(ruleId);
+              continue;
+            }
+            result.appeared.push(ruleId);
+            continue;
+          }
           if (existing.status !== backendStatus || existing.error !== tunnel.error) {
             existing.status = backendStatus;
             existing.error = tunnel.error;
-            existing.tunnelId = tunnel.tunnelId;
             result.appeared.push(ruleId);
           }
         }

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -212,7 +212,10 @@ const scheduleReconnectIfNeeded = (
     currentConn.reconnectTimerCallback = runReconnect;
     currentConn.reconnectTimeoutId = setTimeout(runReconnect, RECONNECT_DELAY_MS);
 
-    onStatusChange('connecting', `Reconnecting (${attempts}/${MAX_RECONNECT_ATTEMPTS})...`);
+    const reconnectMessage = `Reconnecting (${attempts}/${MAX_RECONNECT_ATTEMPTS})...`;
+    currentConn.status = 'connecting';
+    currentConn.error = reconnectMessage;
+    onStatusChange('connecting', reconnectMessage);
     return true;
   }
 
@@ -691,6 +694,12 @@ export const startPortForward = async (
     const handleTunnelStatus = (status: PortForwardingRule['status'], error?: string | null) => {
       const conn = activeConnections.get(rule.id);
       if (status === 'inactive') {
+        if (conn?.reconnectTimerCallback) {
+          conn.unsubscribe?.();
+          conn.unsubscribe = undefined;
+          conn.locallyInitiated = false;
+          return;
+        }
         conn?.unsubscribe?.();
         clearReconnectTimer(rule.id);
         activeConnections.delete(rule.id);

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -44,6 +44,11 @@ export interface PortForwardingConnection {
   reconnectDueAt?: number;
   reconnectTimerCallback?: () => void;
   reconnectStartAuthorized?: boolean;
+  syncedShouldReconnect?: () => boolean;
+  syncedOnStatusChange?: (
+    status: PortForwardingRule['status'],
+    error?: string,
+  ) => void;
 }
 
 // Map to track active connections
@@ -436,11 +441,19 @@ export const syncWithBackend = async (
             };
         connection.status = resolveBackendStatus(tunnel.status);
         connection.error = tunnel.error;
+        if (options.shouldReconnect) {
+          connection.syncedShouldReconnect = () => options.shouldReconnect?.(ruleId) ?? false;
+        }
+        if (options.onStatusChange) {
+          connection.syncedOnStatusChange = (status, error) => {
+            options.onStatusChange?.(ruleId, status, error);
+          };
+        }
         activeConnections.set(ruleId, connection);
 
-        if (!connection.unsubscribe && options.onStatusChange) {
+        if (!connection.unsubscribe) {
           const onStatusChange = (status: PortForwardingRule['status'], error?: string) => {
-            options.onStatusChange?.(ruleId, status, error);
+            connection.syncedOnStatusChange?.(status, error);
           };
           const unsubscribe = bridge.onPortForwardStatus?.(
             tunnel.tunnelId,
@@ -466,7 +479,7 @@ export const syncWithBackend = async (
               if (status === 'error') {
                 const reconnectScheduled = scheduleReconnectIfNeeded(
                   ruleId,
-                  options.shouldReconnect?.(ruleId) ?? false,
+                  connection.syncedShouldReconnect?.() ?? false,
                   onStatusChange,
                 );
                 if (reconnectScheduled) return;
@@ -480,18 +493,19 @@ export const syncWithBackend = async (
             unsubscribe?.();
           }
 
-          const snapshot = await bridge.subscribePortForward?.(tunnel.tunnelId);
-          if (activeConnections.get(ruleId) !== connection) continue;
-          if (snapshot?.status === 'inactive') {
-            connection.unsubscribe?.();
-            activeConnections.delete(ruleId);
-            onStatusChange('inactive');
-            continue;
-          }
-          if (snapshot) {
-            connection.status = resolveBackendStatus(snapshot.status);
-            connection.error = snapshot.error;
-          }
+        }
+
+        const snapshot = await bridge.subscribePortForward?.(tunnel.tunnelId);
+        if (activeConnections.get(ruleId) !== connection) continue;
+        if (snapshot?.status === 'inactive') {
+          connection.unsubscribe?.();
+          activeConnections.delete(ruleId);
+          connection.syncedOnStatusChange?.('inactive');
+          continue;
+        }
+        if (snapshot) {
+          connection.status = resolveBackendStatus(snapshot.status);
+          connection.error = snapshot.error;
         }
         
         logger.info(`[PortForwardingService] Synced active tunnel for rule ${ruleId}`);

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -411,9 +411,112 @@ export interface PortForwardingBackendSyncOptions {
   ) => void;
 }
 
+const backendSyncOptions: PortForwardingBackendSyncOptions = {};
+
+const rememberBackendSyncOptions = (options: PortForwardingBackendSyncOptions): void => {
+  if (options.shouldReconnect) backendSyncOptions.shouldReconnect = options.shouldReconnect;
+  if (options.onStatusChange) backendSyncOptions.onStatusChange = options.onStatusChange;
+};
+
+const configureSyncedConnection = (
+  connection: PortForwardingConnection,
+  ruleId: string,
+): void => {
+  if (backendSyncOptions.shouldReconnect) {
+    connection.syncedShouldReconnect = () =>
+      backendSyncOptions.shouldReconnect?.(ruleId) ?? false;
+  }
+  if (backendSyncOptions.onStatusChange) {
+    connection.syncedOnStatusChange = (status, error) => {
+      backendSyncOptions.onStatusChange?.(ruleId, status, error);
+    };
+  }
+};
+
+const subscribeSyncedConnection = async (
+  ruleId: string,
+  connection: PortForwardingConnection,
+): Promise<boolean> => {
+  const bridge = netcattyBridge.get();
+  if (!bridge) return activeConnections.get(ruleId) === connection;
+
+  if (!connection.unsubscribe) {
+    const onStatusChange = (status: PortForwardingRule['status'], error?: string) => {
+      connection.syncedOnStatusChange?.(status, error);
+    };
+    const unsubscribe = bridge.onPortForwardStatus?.(
+      connection.tunnelId,
+      (status, error) => {
+        const current = activeConnections.get(ruleId);
+        if (current !== connection) return;
+
+        if (status === 'inactive') {
+          if (current.reconnectTimerCallback) {
+            current.unsubscribe?.();
+            current.unsubscribe = undefined;
+            return;
+          }
+          if (
+            !manualStopsInProgress.has(ruleId)
+            && !rulesPendingCleanup.has(ruleId)
+          ) {
+            const reconnectScheduled = scheduleReconnectIfNeeded(
+              ruleId,
+              connection.syncedShouldReconnect?.() ?? false,
+              onStatusChange,
+            );
+            if (reconnectScheduled) {
+              current.unsubscribe?.();
+              current.unsubscribe = undefined;
+              return;
+            }
+          }
+          current.unsubscribe?.();
+          clearReconnectTimer(ruleId);
+          activeConnections.delete(ruleId);
+          onStatusChange('inactive');
+          return;
+        }
+
+        current.status = status;
+        current.error = error ?? undefined;
+        if (status === 'error') {
+          const reconnectScheduled = scheduleReconnectIfNeeded(
+            ruleId,
+            connection.syncedShouldReconnect?.() ?? false,
+            onStatusChange,
+          );
+          if (reconnectScheduled) return;
+        }
+        onStatusChange(status, error ?? undefined);
+      },
+    );
+    if (activeConnections.get(ruleId) === connection) {
+      connection.unsubscribe = unsubscribe;
+    } else {
+      unsubscribe?.();
+    }
+  }
+
+  const snapshot = await bridge.subscribePortForward?.(connection.tunnelId);
+  if (activeConnections.get(ruleId) !== connection) return false;
+  if (snapshot?.status === 'inactive') {
+    connection.unsubscribe?.();
+    activeConnections.delete(ruleId);
+    connection.syncedOnStatusChange?.('inactive');
+    return false;
+  }
+  if (snapshot) {
+    connection.status = resolveBackendStatus(snapshot.status);
+    connection.error = snapshot.error;
+  }
+  return true;
+};
+
 export const syncWithBackend = async (
   options: PortForwardingBackendSyncOptions = {},
 ): Promise<void> => {
+  rememberBackendSyncOptions(options);
   const bridge = netcattyBridge.get();
   
   if (!bridge?.listPortForwards) {
@@ -442,87 +545,10 @@ export const syncWithBackend = async (
             };
         connection.status = resolveBackendStatus(tunnel.status);
         connection.error = tunnel.error;
-        if (options.shouldReconnect) {
-          connection.syncedShouldReconnect = () => options.shouldReconnect?.(ruleId) ?? false;
-        }
-        if (options.onStatusChange) {
-          connection.syncedOnStatusChange = (status, error) => {
-            options.onStatusChange?.(ruleId, status, error);
-          };
-        }
+        configureSyncedConnection(connection, ruleId);
         activeConnections.set(ruleId, connection);
 
-        if (!connection.unsubscribe) {
-          const onStatusChange = (status: PortForwardingRule['status'], error?: string) => {
-            connection.syncedOnStatusChange?.(status, error);
-          };
-          const unsubscribe = bridge.onPortForwardStatus?.(
-            tunnel.tunnelId,
-            (status, error) => {
-              const current = activeConnections.get(ruleId);
-              if (current !== connection) return;
-
-              if (status === 'inactive') {
-                if (current.reconnectTimerCallback) {
-                  current.unsubscribe?.();
-                  current.unsubscribe = undefined;
-                  return;
-                }
-                if (
-                  !manualStopsInProgress.has(ruleId)
-                  && !rulesPendingCleanup.has(ruleId)
-                ) {
-                  const reconnectScheduled = scheduleReconnectIfNeeded(
-                    ruleId,
-                    connection.syncedShouldReconnect?.() ?? false,
-                    onStatusChange,
-                  );
-                  if (reconnectScheduled) {
-                    current.unsubscribe?.();
-                    current.unsubscribe = undefined;
-                    return;
-                  }
-                }
-                current.unsubscribe?.();
-                clearReconnectTimer(ruleId);
-                activeConnections.delete(ruleId);
-                onStatusChange('inactive');
-                return;
-              }
-
-              current.status = status;
-              current.error = error ?? undefined;
-              if (status === 'error') {
-                const reconnectScheduled = scheduleReconnectIfNeeded(
-                  ruleId,
-                  connection.syncedShouldReconnect?.() ?? false,
-                  onStatusChange,
-                );
-                if (reconnectScheduled) return;
-              }
-              onStatusChange(status, error ?? undefined);
-            },
-          );
-          if (activeConnections.get(ruleId) === connection) {
-            connection.unsubscribe = unsubscribe;
-          } else {
-            unsubscribe?.();
-          }
-
-        }
-
-        const snapshot = await bridge.subscribePortForward?.(tunnel.tunnelId);
-        if (activeConnections.get(ruleId) !== connection) continue;
-        if (snapshot?.status === 'inactive') {
-          connection.unsubscribe?.();
-          activeConnections.delete(ruleId);
-          connection.syncedOnStatusChange?.('inactive');
-          continue;
-        }
-        if (snapshot) {
-          connection.status = resolveBackendStatus(snapshot.status);
-          connection.error = snapshot.error;
-        }
+        if (!await subscribeSyncedConnection(ruleId, connection)) continue;
         
         logger.info(`[PortForwardingService] Synced active tunnel for rule ${ruleId}`);
       }
@@ -570,12 +596,18 @@ export const reconcileWithBackend = async (): Promise<{
 
         // Case 2: backend has it, renderer doesn't — insert it
         if (!activeConnections.has(ruleId)) {
-          activeConnections.set(ruleId, {
+          const connection: PortForwardingConnection = {
             ruleId,
             tunnelId: tunnel.tunnelId,
             status: resolveBackendStatus(tunnel.status),
             error: tunnel.error,
-          });
+          };
+          configureSyncedConnection(connection, ruleId);
+          activeConnections.set(ruleId, connection);
+          if (!await subscribeSyncedConnection(ruleId, connection)) {
+            result.gone.push(ruleId);
+            continue;
+          }
           result.appeared.push(ruleId);
         } else {
           // Case 3: renderer tracks it, but status may have changed

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -479,6 +479,19 @@ export const syncWithBackend = async (
           } else {
             unsubscribe?.();
           }
+
+          const snapshot = await bridge.subscribePortForward?.(tunnel.tunnelId);
+          if (activeConnections.get(ruleId) !== connection) continue;
+          if (snapshot?.status === 'inactive') {
+            connection.unsubscribe?.();
+            activeConnections.delete(ruleId);
+            onStatusChange('inactive');
+            continue;
+          }
+          if (snapshot) {
+            connection.status = resolveBackendStatus(snapshot.status);
+            connection.error = snapshot.error;
+          }
         }
         
         logger.info(`[PortForwardingService] Synced active tunnel for rule ${ruleId}`);

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -377,6 +377,11 @@ const parseRuleIdFromTunnelId = (tunnelId: string): string | null => {
   return ruleId;
 };
 
+const resolveBackendRuleId = (tunnel: { ruleId?: string; tunnelId: string }): string | null => {
+  const explicitRuleId = tunnel.ruleId?.trim();
+  return explicitRuleId || parseRuleIdFromTunnelId(tunnel.tunnelId);
+};
+
 /**
  * Sync active connections with backend
  * Called on app startup to restore state of tunnels that may still be running
@@ -395,7 +400,7 @@ export const syncWithBackend = async (): Promise<void> => {
     logger.info(`[PortForwardingService] Backend reports ${activeTunnels.length} active tunnels`);
     
     for (const tunnel of activeTunnels) {
-      const ruleId = parseRuleIdFromTunnelId(tunnel.tunnelId);
+      const ruleId = resolveBackendRuleId(tunnel);
       if (ruleId) {
         // Update local connection tracking
         activeConnections.set(ruleId, {
@@ -438,7 +443,7 @@ export const reconcileWithBackend = async (): Promise<{
     const backendRuleIds = new Set<string>();
 
     for (const tunnel of backendTunnels) {
-      const ruleId = parseRuleIdFromTunnelId(tunnel.tunnelId);
+      const ruleId = resolveBackendRuleId(tunnel);
       if (ruleId) {
         backendRuleIds.add(ruleId);
 
@@ -525,6 +530,7 @@ export const startPortForward = async (
     && (existingConnection.status === 'active' || existingConnection.status === 'connecting')
     && !existingConnection.reconnectStartAuthorized
   ) {
+    onStatusChange(existingConnection.status, existingConnection.error);
     return { success: true };
   }
   if (existingConnection) existingConnection.reconnectStartAuthorized = false;
@@ -758,6 +764,21 @@ export const startPortForward = async (
       onStatusChange('error', result.error);
       return { success: false, error: result.error };
     }
+
+    if (result.reused && result.tunnelId) {
+      // A different window won the start race. Adopt the backend's durable
+      // tunnel instead of keeping this renderer's unused attempt id.
+      unsubscribe?.();
+      const adoptedStatus = result.status === 'active' ? 'active' : 'connecting';
+      activeConnections.set(rule.id, {
+        ruleId: rule.id,
+        tunnelId: result.tunnelId,
+        status: adoptedStatus,
+        reconnectAttempts: existingConn?.reconnectAttempts ?? 0,
+      });
+      onStatusChange(adoptedStatus);
+      return { success: true };
+    }
     
     // Reset reconnect attempts on successful connection
     const conn = activeConnections.get(rule.id);
@@ -795,29 +816,37 @@ export const stopPortForward = async (
   // Clear any pending reconnect timer
   clearReconnectTimer(ruleId);
   
-  if (!conn) {
+  if (!bridge?.stopPortForwardByRuleId && !conn) {
     onStatusChange('inactive');
     return { success: true };
   }
-  
-  if (!bridge?.stopPortForward) {
+
+  if (!bridge?.stopPortForwardByRuleId && !bridge?.stopPortForward) {
     // Fallback for browser/dev mode
     logger.warn('[PortForwardingService] Backend not available, simulating stop...');
-    conn.unsubscribe?.();
+    conn?.unsubscribe?.();
     activeConnections.delete(ruleId);
     onStatusChange('inactive');
     return { success: true };
   }
-  
+
   try {
-    const result = await bridge.stopPortForward(conn.tunnelId);
-    
-    conn.unsubscribe?.();
+    if (bridge.stopPortForwardByRuleId) {
+      const result = await bridge.stopPortForwardByRuleId(ruleId);
+      if ((result.failed ?? 0) > 0) {
+        const error = result.errors?.filter(Boolean).join('; ') ||
+          `Failed to stop ${result.failed} port forwarding tunnel(s)`;
+        return { success: false, error };
+      }
+    } else if (conn && bridge.stopPortForward) {
+      const result = await bridge.stopPortForward(conn.tunnelId);
+      if (!result.success) return result;
+    }
+
+    conn?.unsubscribe?.();
     activeConnections.delete(ruleId);
     onStatusChange('inactive');
-    
-    return result;
-    
+    return { success: true };
   } catch (err) {
     const error = err instanceof Error ? err.message : 'Unknown error';
     return { success: false, error };

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -259,6 +259,22 @@ const finishRuleCleanup = (ruleId: string): void => {
   broadcastReconnectCancel(ruleId);
 };
 
+const preserveFailedStopConnection = (
+  ruleId: string,
+  connection: PortForwardingConnection | undefined,
+  error: string,
+): void => {
+  const failedConnection = connection ?? {
+    ruleId,
+    tunnelId: `untracked-${ruleId}`,
+    status: 'error' as const,
+  };
+  failedConnection.reconnectStartAuthorized = false;
+  failedConnection.status = 'error';
+  failedConnection.error = error;
+  activeConnections.set(ruleId, failedConnection);
+};
+
 const resumeReconnectAfterFailedCleanup = (
   ruleId: string,
   pausedReconnect?: PausedReconnectTimer,
@@ -1063,15 +1079,7 @@ export const stopPortForward = async (
         const error = result.errors?.filter(Boolean).join('; ') ||
           `Failed to stop ${result.failed} port forwarding tunnel(s)`;
         clearReconnectTimer(ruleId);
-        const failedConnection = conn ?? {
-          ruleId,
-          tunnelId: `untracked-${ruleId}`,
-          status: 'error' as const,
-        };
-        failedConnection.reconnectStartAuthorized = false;
-        failedConnection.status = 'error';
-        failedConnection.error = error;
-        activeConnections.set(ruleId, failedConnection);
+        preserveFailedStopConnection(ruleId, conn, error);
         onStatusChange('error', error);
         return { success: false, error };
       }
@@ -1086,11 +1094,7 @@ export const stopPortForward = async (
   } catch (err) {
     const error = err instanceof Error ? err.message : 'Unknown error';
     clearReconnectTimer(ruleId);
-    if (conn) {
-      conn.reconnectStartAuthorized = false;
-      conn.status = 'error';
-      conn.error = error;
-    }
+    preserveFailedStopConnection(ruleId, conn, error);
     onStatusChange('error', error);
     return { success: false, error };
   } finally {

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -482,20 +482,15 @@ export const reconcileWithBackend = async (): Promise<{
       }
     }
 
-    // Case 1: renderer thinks tunnel is active/connecting, but backend
-    // says it's gone.  For 'connecting' entries seeded by a previous
-    // reconcile (observing another window's handshake), also evict if the
-    // backend no longer reports them — the handshake failed or was
-    // cancelled.  Only skip 'connecting' entries that this renderer
-    // initiated itself (they have an unsubscribe callback because this
-    // renderer called startPortForward and registered a status listener).
+    // Case 1: renderer thinks a tunnel is active/connecting, but backend
+    // says it's gone. Preserve only a local handshake that has not appeared
+    // in the backend yet, or a reconnect that is already scheduled.
     for (const [ruleId, conn] of activeConnections) {
       if (!backendRuleIds.has(ruleId)) {
-        // Skip only the short gap before a tunnel initiated by this renderer
-        // is first visible in the backend list.
-        // — the backend hasn't reported them yet because the handshake
-        // is still in progress.
-        if (conn.status === 'connecting' && conn.locallyInitiated) {
+        if (
+          conn.status === 'connecting'
+          && (conn.locallyInitiated || conn.reconnectTimerCallback)
+        ) {
           continue;
         }
         conn.unsubscribe?.();

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -545,16 +545,22 @@ export const syncWithBackend = async (
  *    → add to activeConnections, return ruleId as "appeared"
  */
 export const reconcileWithBackend = async (): Promise<{
+  snapshotAvailable: boolean;
   gone: string[];
   appeared: string[];
 }> => {
-  const result = { gone: [] as string[], appeared: [] as string[] };
+  const result = {
+    snapshotAvailable: false,
+    gone: [] as string[],
+    appeared: [] as string[],
+  };
   const bridge = netcattyBridge.get();
 
   if (!bridge?.listPortForwards) return result;
 
   try {
     const backendTunnels = await bridge.listPortForwards();
+    result.snapshotAvailable = true;
     const backendRuleIds = new Set<string>();
 
     for (const tunnel of backendTunnels) {

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -54,6 +54,7 @@ export interface PortForwardingConnection {
 // Map to track active connections
 const activeConnections = new Map<string, PortForwardingConnection>();
 const rulesPendingCleanup = new Set<string>();
+const manualStopsInProgress = new Set<string>();
 const ruleCleanupPromises = new Map<string, Promise<{ success: boolean; error?: string }>>();
 const deferredReconnects = new Map<string, {
   enableReconnect: boolean;
@@ -466,6 +467,21 @@ export const syncWithBackend = async (
                   current.unsubscribe?.();
                   current.unsubscribe = undefined;
                   return;
+                }
+                if (
+                  !manualStopsInProgress.has(ruleId)
+                  && !rulesPendingCleanup.has(ruleId)
+                ) {
+                  const reconnectScheduled = scheduleReconnectIfNeeded(
+                    ruleId,
+                    connection.syncedShouldReconnect?.() ?? false,
+                    onStatusChange,
+                  );
+                  if (reconnectScheduled) {
+                    current.unsubscribe?.();
+                    current.unsubscribe = undefined;
+                    return;
+                  }
                 }
                 current.unsubscribe?.();
                 clearReconnectTimer(ruleId);
@@ -984,6 +1000,7 @@ export const stopPortForward = async (
     return { success: true };
   }
 
+  manualStopsInProgress.add(ruleId);
   try {
     if (bridge.stopPortForwardByRuleId) {
       const result = await bridge.stopPortForwardByRuleId(ruleId);
@@ -1017,6 +1034,8 @@ export const stopPortForward = async (
     }
     onStatusChange('error', error);
     return { success: false, error };
+  } finally {
+    manualStopsInProgress.delete(ruleId);
   }
 };
 

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -37,6 +37,7 @@ export interface PortForwardingConnection {
   status: 'inactive' | 'connecting' | 'active' | 'error';
   error?: string;
   unsubscribe?: () => void;
+  locallyInitiated?: boolean;
   // Reconnect state
   reconnectAttempts?: number;
   reconnectTimeoutId?: ReturnType<typeof setTimeout>;
@@ -487,10 +488,11 @@ export const reconcileWithBackend = async (): Promise<{
     // renderer called startPortForward and registered a status listener).
     for (const [ruleId, conn] of activeConnections) {
       if (!backendRuleIds.has(ruleId)) {
-        // Skip locally-initiated connecting tunnels (have unsubscribe)
+        // Skip only the short gap before a tunnel initiated by this renderer
+        // is first visible in the backend list.
         // — the backend hasn't reported them yet because the handshake
         // is still in progress.
-        if (conn.status === 'connecting' && conn.unsubscribe) {
+        if (conn.status === 'connecting' && conn.locallyInitiated) {
           continue;
         }
         conn.unsubscribe?.();
@@ -691,6 +693,7 @@ export const startPortForward = async (
       if (conn) {
         conn.status = status;
         conn.error = error ?? undefined;
+        if (status !== 'connecting') conn.locallyInitiated = false;
       }
       
       // Handle auto-reconnect on error/disconnect
@@ -712,6 +715,7 @@ export const startPortForward = async (
       tunnelId,
       status: 'connecting',
       unsubscribe,
+      locallyInitiated: true,
       reconnectAttempts: existingConn?.reconnectAttempts ?? 0,
     });
     
@@ -800,9 +804,27 @@ export const startPortForward = async (
         tunnelId: result.tunnelId,
         status: adoptedStatus,
         unsubscribe: adoptedUnsubscribe,
+        locallyInitiated: false,
         reconnectAttempts: existingConn?.reconnectAttempts ?? 0,
       });
-      onStatusChange(adoptedStatus);
+
+      // Close the reply/listener race: an adopted tunnel may have stopped
+      // after the backend replied but before this renderer subscribed.
+      const snapshot = await bridge.getPortForwardStatus?.(result.tunnelId);
+      const adoptedConnection = activeConnections.get(rule.id);
+      if (snapshot && adoptedConnection?.tunnelId === result.tunnelId) {
+        if (snapshot.status === 'inactive') {
+          adoptedUnsubscribe?.();
+          activeConnections.delete(rule.id);
+          onStatusChange('inactive');
+          return { success: false, error: 'Port forwarding tunnel stopped before adoption completed' };
+        }
+        adoptedConnection.status = snapshot.status;
+        adoptedConnection.error = snapshot.error;
+      }
+
+      const current = activeConnections.get(rule.id);
+      onStatusChange(current?.status ?? adoptedStatus, current?.error);
       return { success: true };
     }
     

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -396,7 +396,18 @@ const resolveBackendStatus = (status: string): PortForwardingConnection['status'
  * Called on app startup to restore state of tunnels that may still be running
  * This updates the local activeConnections map to match the backend state.
  */
-export const syncWithBackend = async (): Promise<void> => {
+export interface PortForwardingBackendSyncOptions {
+  shouldReconnect?: (ruleId: string) => boolean;
+  onStatusChange?: (
+    ruleId: string,
+    status: PortForwardingRule['status'],
+    error?: string,
+  ) => void;
+}
+
+export const syncWithBackend = async (
+  options: PortForwardingBackendSyncOptions = {},
+): Promise<void> => {
   const bridge = netcattyBridge.get();
   
   if (!bridge?.listPortForwards) {
@@ -411,13 +422,64 @@ export const syncWithBackend = async (): Promise<void> => {
     for (const tunnel of activeTunnels) {
       const ruleId = resolveBackendRuleId(tunnel);
       if (ruleId) {
+        const existing = activeConnections.get(ruleId);
+        if (existing?.tunnelId !== tunnel.tunnelId) existing?.unsubscribe?.();
+
         // Update local connection tracking
-        activeConnections.set(ruleId, {
-          ruleId,
-          tunnelId: tunnel.tunnelId,
-          status: resolveBackendStatus(tunnel.status),
-          error: tunnel.error,
-        });
+        const connection: PortForwardingConnection = existing?.tunnelId === tunnel.tunnelId
+          ? existing
+          : {
+              ruleId,
+              tunnelId: tunnel.tunnelId,
+              status: resolveBackendStatus(tunnel.status),
+              reconnectAttempts: existing?.reconnectAttempts ?? 0,
+            };
+        connection.status = resolveBackendStatus(tunnel.status);
+        connection.error = tunnel.error;
+        activeConnections.set(ruleId, connection);
+
+        if (!connection.unsubscribe && options.onStatusChange) {
+          const onStatusChange = (status: PortForwardingRule['status'], error?: string) => {
+            options.onStatusChange?.(ruleId, status, error);
+          };
+          const unsubscribe = bridge.onPortForwardStatus?.(
+            tunnel.tunnelId,
+            (status, error) => {
+              const current = activeConnections.get(ruleId);
+              if (current !== connection) return;
+
+              if (status === 'inactive') {
+                if (current.reconnectTimerCallback) {
+                  current.unsubscribe?.();
+                  current.unsubscribe = undefined;
+                  return;
+                }
+                current.unsubscribe?.();
+                clearReconnectTimer(ruleId);
+                activeConnections.delete(ruleId);
+                onStatusChange('inactive');
+                return;
+              }
+
+              current.status = status;
+              current.error = error ?? undefined;
+              if (status === 'error') {
+                const reconnectScheduled = scheduleReconnectIfNeeded(
+                  ruleId,
+                  options.shouldReconnect?.(ruleId) ?? false,
+                  onStatusChange,
+                );
+                if (reconnectScheduled) return;
+              }
+              onStatusChange(status, error ?? undefined);
+            },
+          );
+          if (activeConnections.get(ruleId) === connection) {
+            connection.unsubscribe = unsubscribe;
+          } else {
+            unsubscribe?.();
+          }
+        }
         
         logger.info(`[PortForwardingService] Synced active tunnel for rule ${ruleId}`);
       }

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -895,7 +895,9 @@ export const stopPortForward = async (
       if ((result.failed ?? 0) > 0) {
         const error = result.errors?.filter(Boolean).join('; ') ||
           `Failed to stop ${result.failed} port forwarding tunnel(s)`;
+        clearReconnectTimer(ruleId);
         if (conn) {
+          conn.reconnectStartAuthorized = false;
           conn.status = 'error';
           conn.error = error;
         }
@@ -912,6 +914,13 @@ export const stopPortForward = async (
     return { success: true };
   } catch (err) {
     const error = err instanceof Error ? err.message : 'Unknown error';
+    clearReconnectTimer(ruleId);
+    if (conn) {
+      conn.reconnectStartAuthorized = false;
+      conn.status = 'error';
+      conn.error = error;
+    }
+    onStatusChange('error', error);
     return { success: false, error };
   }
 };

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -382,6 +382,11 @@ const resolveBackendRuleId = (tunnel: { ruleId?: string; tunnelId: string }): st
   return explicitRuleId || parseRuleIdFromTunnelId(tunnel.tunnelId);
 };
 
+const resolveBackendStatus = (status: string): PortForwardingConnection['status'] => {
+  if (status === 'active' || status === 'connecting' || status === 'error') return status;
+  return 'connecting';
+};
+
 /**
  * Sync active connections with backend
  * Called on app startup to restore state of tunnels that may still be running
@@ -406,7 +411,8 @@ export const syncWithBackend = async (): Promise<void> => {
         activeConnections.set(ruleId, {
           ruleId,
           tunnelId: tunnel.tunnelId,
-          status: (tunnel.status === 'active' ? 'active' : 'connecting') as 'active' | 'connecting',
+          status: resolveBackendStatus(tunnel.status),
+          error: tunnel.error,
         });
         
         logger.info(`[PortForwardingService] Synced active tunnel for rule ${ruleId}`);
@@ -452,7 +458,8 @@ export const reconcileWithBackend = async (): Promise<{
           activeConnections.set(ruleId, {
             ruleId,
             tunnelId: tunnel.tunnelId,
-            status: (tunnel.status === 'active' ? 'active' : 'connecting') as 'active' | 'connecting',
+            status: resolveBackendStatus(tunnel.status),
+            error: tunnel.error,
           });
           result.appeared.push(ruleId);
         } else {
@@ -460,9 +467,10 @@ export const reconcileWithBackend = async (): Promise<{
           // (e.g. connecting → active after SSH handshake completed
           // in another window).
           const existing = activeConnections.get(ruleId)!;
-          const backendStatus = (tunnel.status === 'active' ? 'active' : 'connecting') as 'active' | 'connecting';
-          if (existing.status !== backendStatus) {
+          const backendStatus = resolveBackendStatus(tunnel.status);
+          if (existing.status !== backendStatus || existing.error !== tunnel.error) {
             existing.status = backendStatus;
+            existing.error = tunnel.error;
             existing.tunnelId = tunnel.tunnelId;
             result.appeared.push(ruleId);
           }
@@ -678,11 +686,11 @@ export const startPortForward = async (
     }
 
     // Subscribe to status updates first
-    const unsubscribe = bridge.onPortForwardStatus?.(tunnelId, (status, error) => {
+    const handleTunnelStatus = (status: PortForwardingRule['status'], error?: string | null) => {
       const conn = activeConnections.get(rule.id);
       if (conn) {
         conn.status = status;
-        conn.error = error;
+        conn.error = error ?? undefined;
       }
       
       // Handle auto-reconnect on error/disconnect
@@ -694,7 +702,8 @@ export const startPortForward = async (
       }
       
       onStatusChange(status, error ?? undefined);
-    });
+    };
+    const unsubscribe = bridge.onPortForwardStatus?.(tunnelId, handleTunnelStatus);
     
     // Store connection info (preserve reconnect attempts if this is a reconnect)
     const existingConn = activeConnections.get(rule.id);
@@ -753,6 +762,18 @@ export const startPortForward = async (
         return { success: false, error: undefined };
       }
 
+      if (result.blockedByCleanup && result.tunnelId) {
+        unsubscribe?.();
+        activeConnections.set(rule.id, {
+          ruleId: rule.id,
+          tunnelId: result.tunnelId,
+          status: 'error',
+          error: result.error,
+        });
+        onStatusChange('error', result.error);
+        return { success: false, error: result.error };
+      }
+
       // Check if we should attempt reconnect
       const reconnectScheduled = scheduleReconnectIfNeeded(rule.id, enableReconnect, onStatusChange);
       if (reconnectScheduled) {
@@ -770,10 +791,15 @@ export const startPortForward = async (
       // tunnel instead of keeping this renderer's unused attempt id.
       unsubscribe?.();
       const adoptedStatus = result.status === 'active' ? 'active' : 'connecting';
+      const adoptedUnsubscribe = bridge.onPortForwardStatus?.(
+        result.tunnelId,
+        handleTunnelStatus,
+      );
       activeConnections.set(rule.id, {
         ruleId: rule.id,
         tunnelId: result.tunnelId,
         status: adoptedStatus,
+        unsubscribe: adoptedUnsubscribe,
         reconnectAttempts: existingConn?.reconnectAttempts ?? 0,
       });
       onStatusChange(adoptedStatus);
@@ -808,7 +834,7 @@ export const startPortForward = async (
  */
 export const stopPortForward = async (
   ruleId: string,
-  onStatusChange: (status: PortForwardingRule['status']) => void
+  onStatusChange: (status: PortForwardingRule['status'], error?: string) => void
 ): Promise<{ success: boolean; error?: string }> => {
   const bridge = netcattyBridge.get();
   const conn = activeConnections.get(ruleId);
@@ -836,6 +862,11 @@ export const stopPortForward = async (
       if ((result.failed ?? 0) > 0) {
         const error = result.errors?.filter(Boolean).join('; ') ||
           `Failed to stop ${result.failed} port forwarding tunnel(s)`;
+        if (conn) {
+          conn.status = 'error';
+          conn.error = error;
+        }
+        onStatusChange('error', error);
         return { success: false, error };
       }
     } else if (conn && bridge.stopPortForward) {
@@ -843,8 +874,7 @@ export const stopPortForward = async (
       if (!result.success) return result;
     }
 
-    conn?.unsubscribe?.();
-    activeConnections.delete(ruleId);
+    finishRuleCleanup(ruleId);
     onStatusChange('inactive');
     return { success: true };
   } catch (err) {

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -1014,11 +1014,15 @@ export const stopPortForward = async (
         const error = result.errors?.filter(Boolean).join('; ') ||
           `Failed to stop ${result.failed} port forwarding tunnel(s)`;
         clearReconnectTimer(ruleId);
-        if (conn) {
-          conn.reconnectStartAuthorized = false;
-          conn.status = 'error';
-          conn.error = error;
-        }
+        const failedConnection = conn ?? {
+          ruleId,
+          tunnelId: `untracked-${ruleId}`,
+          status: 'error' as const,
+        };
+        failedConnection.reconnectStartAuthorized = false;
+        failedConnection.status = 'error';
+        failedConnection.error = error;
+        activeConnections.set(ruleId, failedConnection);
         onStatusChange('error', error);
         return { success: false, error };
       }

--- a/types/global/netcatty-bridge-sync.d.ts
+++ b/types/global/netcatty-bridge-sync.d.ts
@@ -66,6 +66,12 @@ declare global {
     stopPortForward?(tunnelId: string): Promise<PortForwardResult>;
     getPortForwardStatus?(tunnelId: string): Promise<PortForwardStatusResult>;
     listPortForwards?(): Promise<{ ruleId?: string; tunnelId: string; type: string; status: string; error?: string }[]>;
+    subscribePortForward?(tunnelId: string): Promise<{
+      tunnelId: string;
+      type?: string;
+      status: 'inactive' | 'connecting' | 'active' | 'error';
+      error?: string;
+    }>;
     stopAllPortForwards?(): Promise<void>;
     stopPortForwardByRuleId?(ruleId: string): Promise<{
       stopped: number;

--- a/types/global/netcatty-bridge-sync.d.ts
+++ b/types/global/netcatty-bridge-sync.d.ts
@@ -65,7 +65,7 @@ declare global {
     startPortForward?(options: PortForwardOptions): Promise<PortForwardResult>;
     stopPortForward?(tunnelId: string): Promise<PortForwardResult>;
     getPortForwardStatus?(tunnelId: string): Promise<PortForwardStatusResult>;
-    listPortForwards?(): Promise<{ tunnelId: string; type: string; status: string }[]>;
+    listPortForwards?(): Promise<{ ruleId?: string; tunnelId: string; type: string; status: string }[]>;
     stopAllPortForwards?(): Promise<void>;
     stopPortForwardByRuleId?(ruleId: string): Promise<{
       stopped: number;

--- a/types/global/netcatty-bridge-sync.d.ts
+++ b/types/global/netcatty-bridge-sync.d.ts
@@ -65,7 +65,7 @@ declare global {
     startPortForward?(options: PortForwardOptions): Promise<PortForwardResult>;
     stopPortForward?(tunnelId: string): Promise<PortForwardResult>;
     getPortForwardStatus?(tunnelId: string): Promise<PortForwardStatusResult>;
-    listPortForwards?(): Promise<{ ruleId?: string; tunnelId: string; type: string; status: string }[]>;
+    listPortForwards?(): Promise<{ ruleId?: string; tunnelId: string; type: string; status: string; error?: string }[]>;
     stopAllPortForwards?(): Promise<void>;
     stopPortForwardByRuleId?(ruleId: string): Promise<{
       stopped: number;


### PR DESCRIPTION
Closes #2280.

## What changed

- keep the visible port-forward status synchronized with the tunnel that is actually running, including auto-start in the same window
- let a reopened or second window adopt an existing tunnel and continue receiving later status changes without missing the handoff window
- stop tunnels by rule even when the current window has no local connection record
- keep failed cleanup visible and retryable from the page, tray panel, and native tray instead of falsely showing the rule as stopped
- make repeated starts reuse the same live tunnel safely
- repair stale cross-window status writes from the backend snapshot
- add focused regression coverage for same-window, cross-window, adopted-tunnel, cleanup-failure, tray, and concurrent-start cases

## Research

The repository includes `docs/research/issue-2280-port-forward-runtime-state.md`, comparing the current lifecycle with OpenSSH, Tabby, VS Code, and Electerm.

## Validation

- focused port-forwarding tests: 52 passed
- lint: passed
- production build: passed
- full test suite: 5777 passed, 7 skipped, 1 unrelated existing SSH authentication retry test failed; the same test fails on the unchanged base branch and no SSH authentication files are touched here
