### PR TITLE
fix(sftp): retry keyboard-interactive when password removes KI

### DIFF
--- a/electron/bridges/sftpBridge.authRetry.test.cjs
+++ b/electron/bridges/sftpBridge.authRetry.test.cjs
@@ -1,5 +1,5 @@
-// 创建时间: 2026-07-17
-// 功能说明: 验证 SFTP 在 EDR 移除 keyboard-interactive 后会改走 KI 优先重试。
+// Created: 2026-07-17
+// Purpose: Verify SFTP retries KI first after EDR removes keyboard-interactive.
 
 const test = require("node:test");
 const assert = require("node:assert/strict");

--- a/electron/bridges/sftpBridge.authRetry.test.cjs
+++ b/electron/bridges/sftpBridge.authRetry.test.cjs
@@ -1,0 +1,150 @@
+// 创建时间: 2026-07-17
+// 功能说明: 验证 SFTP 在 EDR 移除 keyboard-interactive 后会改走 KI 优先重试。
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const Module = require("node:module");
+
+/** Build a minimal renderer sender for SFTP progress and auth prompt IPC. */
+function makeSender() {
+  return {
+    id: 1,
+    isDestroyed: () => false,
+    sent: [],
+    send(channel, payload) {
+      this.sent.push({ channel, payload });
+    },
+  };
+}
+
+/** Load the SFTP bridge with ssh2-sftp-client mocked for auth retry scenarios. */
+function loadSftpBridgeWithAuthRetryMocks(t) {
+  const bridgePath = require.resolve("./sftpBridge.cjs");
+  const authHelperPath = require.resolve("./sshAuthHelper.cjs");
+  const originalLoad = Module._load;
+  const realAuthHelper = require(authHelperPath);
+
+  /** Mock SFTP client that simulates password rejection removing KI, then KI-first success. */
+  class MockSftpClient extends EventEmitter {
+    /** Create a mock ssh2-sftp-client instance with an embedded ssh2 client emitter. */
+    constructor() {
+      super();
+      MockSftpClient.instances.push(this);
+      this.sftp = null;
+      this.client = new EventEmitter();
+      this.client.setMaxListeners = () => {};
+      this.client._sock = { setTimeout() {} };
+      this.client.connect = (opts) => {
+        this.client.connectOpts = opts;
+        this.connect(opts);
+      };
+      this.client.sftp = (cb) => {
+        setImmediate(() => cb(null, new EventEmitter()));
+      };
+      this.client.end = () => {
+        this.client.ended = true;
+      };
+      this.client.destroy = () => {
+        this.client.destroyed = true;
+      };
+    }
+
+    /** Drive the fake server-side auth flow for each connection attempt. */
+    connect(opts) {
+      const attemptIndex = MockSftpClient.instances.length;
+      const offered = [];
+      this.authMethodsOffered = offered;
+      setImmediate(() => {
+        this.client.emit("connect");
+        this.client.emit("handshake");
+        const offerNext = (methodsLeft, partialSuccess) => {
+          let nextMethod;
+          opts.authHandler(methodsLeft, partialSuccess, (method) => {
+            nextMethod = method;
+            offered.push(method);
+          });
+          return nextMethod;
+        };
+
+        offerNext(null, null);
+        const first = offerNext(["password", "keyboard-interactive"], false);
+        if (attemptIndex === 1) {
+          assert.equal(first, "password");
+          offerNext(["publickey"], false);
+          const err = new Error("All configured authentication methods failed");
+          err.level = "client-authentication";
+          this.client.emit("error", err);
+          return;
+        }
+
+        assert.equal(first, "keyboard-interactive");
+        this.client.emit("ready");
+      });
+    }
+
+    /** Mark the high-level SFTP client as ended. */
+    end() {
+      this.ended = true;
+    }
+  }
+  MockSftpClient.instances = [];
+
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === "ssh2-sftp-client") {
+      return MockSftpClient;
+    }
+    if (request === "./sshAuthHelper.cjs") {
+      return {
+        ...realAuthHelper,
+        findAllDefaultPrivateKeys: async () => [],
+        getAvailableAgentSocket: async () => null,
+        prepareSystemSshAgentForAuth: async () => null,
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[bridgePath];
+  const bridge = require("./sftpBridge.cjs");
+
+  t.after(() => {
+    delete require.cache[bridgePath];
+    Module._load = originalLoad;
+  });
+
+  return { bridge, MockSftpClient };
+}
+
+test("openSftp retries keyboard-interactive first when password rejection removes KI", async (t) => {
+  const { bridge, MockSftpClient } = loadSftpBridgeWithAuthRetryMocks(t);
+  const sftpClients = new Map();
+  bridge.init({ sftpClients, sessions: new Map(), electronModule: {} });
+
+  const result = await bridge.openSftp(
+    { sender: makeSender() },
+    {
+      sessionId: "sftp-edr-mfa",
+      hostname: "192.168.9.138",
+      port: 22,
+      username: "root",
+      authMethod: "password",
+      password: "saved-login-password",
+      sshTcpConnectTimeoutMs: 45_000,
+      sshAuthReadyTimeoutMs: 300_000,
+    },
+  );
+
+  assert.equal(result.sftpId, "sftp-edr-mfa");
+  assert.equal(MockSftpClient.instances.length, 2);
+  assert.deepEqual(MockSftpClient.instances[0].authMethodsOffered, [
+    "none",
+    "password",
+    false,
+  ]);
+  assert.deepEqual(MockSftpClient.instances[1].authMethodsOffered, [
+    "none",
+    "keyboard-interactive",
+  ]);
+  assert.equal(sftpClients.has("sftp-edr-mfa"), true);
+});

--- a/electron/bridges/sftpBridge.authRetry.test.cjs
+++ b/electron/bridges/sftpBridge.authRetry.test.cjs
@@ -19,13 +19,13 @@ function makeSender() {
 }
 
 /** Load the SFTP bridge with ssh2-sftp-client mocked for auth retry scenarios. */
-function loadSftpBridgeWithAuthRetryMocks(t) {
+function loadSftpBridgeWithAuthRetryMocks(t, options = {}) {
   const bridgePath = require.resolve("./sftpBridge.cjs");
   const authHelperPath = require.resolve("./sshAuthHelper.cjs");
   const originalLoad = Module._load;
   const realAuthHelper = require(authHelperPath);
 
-  /** Mock SFTP client that simulates password rejection removing KI, then KI-first success. */
+  /** Mock SFTP client that simulates password rejection removing KI, then KI retry success. */
   class MockSftpClient extends EventEmitter {
     /** Create a mock ssh2-sftp-client instance with an embedded ssh2 client emitter. */
     constructor() {
@@ -68,7 +68,20 @@ function loadSftpBridgeWithAuthRetryMocks(t) {
         };
 
         offerNext(null, null);
-        const first = offerNext(["password", "keyboard-interactive"], false);
+        const firstMethods = options.dynamicAuth
+          ? ["publickey", "password", "keyboard-interactive"]
+          : ["password", "keyboard-interactive"];
+        const first = offerNext(firstMethods, false);
+        if (attemptIndex === 1 && options.dynamicAuth) {
+          assert.equal(first?.type, "publickey");
+          const password = offerNext(["password", "keyboard-interactive"], false);
+          assert.equal(password?.type, "password");
+          offerNext(["publickey"], false);
+          const err = new Error("All configured authentication methods failed");
+          err.level = "client-authentication";
+          this.client.emit("error", err);
+          return;
+        }
         if (attemptIndex === 1) {
           assert.equal(first, "password");
           offerNext(["publickey"], false);
@@ -78,7 +91,13 @@ function loadSftpBridgeWithAuthRetryMocks(t) {
           return;
         }
 
-        assert.equal(first, "keyboard-interactive");
+        if (options.dynamicAuth) {
+          assert.equal(first?.type, "publickey");
+          const keyboardInteractive = offerNext(["keyboard-interactive"], false);
+          assert.equal(keyboardInteractive, "keyboard-interactive");
+        } else {
+          assert.equal(first, "keyboard-interactive");
+        }
         this.client.emit("ready");
       });
     }
@@ -97,7 +116,7 @@ function loadSftpBridgeWithAuthRetryMocks(t) {
     if (request === "./sshAuthHelper.cjs") {
       return {
         ...realAuthHelper,
-        findAllDefaultPrivateKeys: async () => [],
+        findAllDefaultPrivateKeys: async () => options.defaultKeys || [],
         getAvailableAgentSocket: async () => null,
         prepareSystemSshAgentForAuth: async () => null,
       };
@@ -147,4 +166,47 @@ test("openSftp retries keyboard-interactive first when password rejection remove
     "keyboard-interactive",
   ]);
   assert.equal(sftpClients.has("sftp-edr-mfa"), true);
+});
+
+test("openSftp retries keyboard-interactive after dynamic auth password rejection removes KI", async (t) => {
+  const { bridge, MockSftpClient } = loadSftpBridgeWithAuthRetryMocks(t, {
+    dynamicAuth: true,
+    defaultKeys: [{
+      privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nmock-default-key\n-----END OPENSSH PRIVATE KEY-----",
+      keyPath: "id_ed25519",
+      keyName: "id_ed25519",
+    }],
+  });
+  const sftpClients = new Map();
+  bridge.init({ sftpClients, sessions: new Map(), electronModule: {} });
+
+  const result = await bridge.openSftp(
+    { sender: makeSender() },
+    {
+      sessionId: "sftp-edr-mfa-auto",
+      hostname: "192.168.9.138",
+      port: 22,
+      username: "root",
+      authMethod: "auto",
+      password: "saved-login-password",
+      sshTcpConnectTimeoutMs: 45_000,
+      sshAuthReadyTimeoutMs: 300_000,
+    },
+  );
+
+  assert.equal(result.sftpId, "sftp-edr-mfa-auto");
+  assert.equal(MockSftpClient.instances.length, 2);
+  assert.deepEqual(
+    MockSftpClient.instances[0].authMethodsOffered.map((method) => (
+      method?.type === "publickey" ? "publickey" : method?.type || method
+    )),
+    ["none", "publickey", "password", false],
+  );
+  assert.deepEqual(
+    MockSftpClient.instances[1].authMethodsOffered.map((method) => (
+      method?.type === "publickey" ? "publickey" : method?.type || method
+    )),
+    ["none", "publickey", "keyboard-interactive"],
+  );
+  assert.equal(sftpClients.has("sftp-edr-mfa-auto"), true);
 });

--- a/electron/bridges/sftpBridge/openConnection.cjs
+++ b/electron/bridges/sftpBridge/openConnection.cjs
@@ -44,6 +44,23 @@ function createBoundedProbeSignal(parentSignal = null, timeoutMs = SCP_PROBE_TIM
   };
 }
 
+/** Return true when ssh2 reports an authentication-stage failure. */
+function isSftpAuthError(err) {
+  const level = String(err?.level || "").toLowerCase();
+  const message = String(err?.message || "").toLowerCase();
+  return level.includes("authentication") || message.includes("authentication");
+}
+
+/** Decide whether the SFTP target should retry with keyboard-interactive before password. */
+function shouldRetrySftpKeyboardInteractiveFirst(options, authConfig, err) {
+  return Boolean(
+    options?.password &&
+    !options?._skipPasswordMethod &&
+    isSftpAuthError(err) &&
+    authConfig?.authPhase?.retryKeyboardInteractiveFirst,
+  );
+}
+
 function createOpenConnectionApi(ctx) {
   with (ctx) {
     /**
@@ -991,6 +1008,7 @@ function createOpenConnectionApi(ctx) {
         agent: connectOpts.agent,
         username: connectOpts.username,
         logPrefix: "[SFTP]",
+        skipPasswordMethod: options._skipPasswordMethod === true,
         defaultKeys: systemAuthAgent && options.identitiesOnly ? [] : defaultKeys,
         sshAgentSocketOverride: agentSocket,
         allowAgentFallback: options.useSshAgent !== false,
@@ -1235,6 +1253,15 @@ function createOpenConnectionApi(ctx) {
       } catch (err) {
         // Cleanup jump connections on error
         cleanupPendingConnection();
+        if (shouldRetrySftpKeyboardInteractiveFirst(options, authConfig, err)) {
+          try { client.client?.end?.(); } catch { /* ignore */ }
+          try { client.client?.destroy?.(); } catch { /* ignore */ }
+          console.log("[SFTP] Password auth removed keyboard-interactive; retrying with keyboard-interactive first...");
+          return openSftp(event, {
+            ...options,
+            _skipPasswordMethod: true,
+          });
+        }
         throw err;
       }
     }

--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -1132,6 +1132,7 @@ function buildAuthHandler(options) {
   const authPhase = createAuthPhase();
   let lastAttemptedType = null;
   let lastAttemptedMethodId = null;
+  let passwordAttemptSawKeyboardInteractive = false;
 
   let triedNone = false;
 
@@ -1153,6 +1154,14 @@ function buildAuthHandler(options) {
     // Log rejection of previous method (authHandler is called again when server rejects)
     if (lastAttemptedLabel && !partialSuccess) {
       onAuthAttempt?.(`${lastAttemptedLabel} rejected`);
+      if (
+        lastAttemptedType === "password" &&
+        passwordAttemptSawKeyboardInteractive &&
+        Array.isArray(methodsLeft) &&
+        !methodsLeft.includes("keyboard-interactive")
+      ) {
+        authPhase.retryKeyboardInteractiveFirst = true;
+      }
       if (lastAttemptedMethodId) {
         failedMethodIds.add(lastAttemptedMethodId);
       }
@@ -1248,6 +1257,7 @@ function buildAuthHandler(options) {
         lastAttemptedLabel = "password";
         lastAttemptedType = "password";
         lastAttemptedMethodId = method.id;
+        passwordAttemptSawKeyboardInteractive = availableMethods.includes("keyboard-interactive");
         onAuthAttempt?.("password");
         return callback({
           type: "password",


### PR DESCRIPTION
## 背景

#2249 已修复终端 SSH 在 EDR 场景下 password 被拒后 keyboard-interactive 被服务器移除的问题，但真实测试发现 SFTP 独立连接路径仍会停在 `none -> password -> All authentication methods exhausted`，没有机会进入二次认证。

## 修复

- 在 SFTP 目标主机认证失败时读取共享 `buildAuthHandler` 的 `authPhase.retryKeyboardInteractiveFirst` 标记。
- 当 password 被拒且服务器移除 keyboard-interactive 时，清理本次 SFTP client，并用 `_skipPasswordMethod: true` 自动重连一次，让第二轮优先走 keyboard-interactive。
- 新增 SFTP 回归测试，模拟第一次 password 失败后 KI 被移除，第二次连接改走 `none -> keyboard-interactive` 并成功。

## 验证

- `node --test electron/bridges/sftpBridge.authRetry.test.cjs electron/bridges/sftpBridge.cleanup.test.cjs electron/bridges/sftpBridge.hostKeyVerification.test.cjs electron/bridges/sftpBridge.relativePaths.test.cjs electron/bridges/sftpBridge.reuseOnly.test.cjs electron/bridges/sshAuthHelper.kbdInteractive.test.cjs electron/bridges/sshBridge.authRetryExit.test.cjs`：103/103 通过
- `npx eslint electron/bridges/sftpBridge/openConnection.cjs electron/bridges/sftpBridge.authRetry.test.cjs --quiet`
- `git diff --check origin/main...HEAD`

关联 #2150，补充 #2249 合并后遗漏的 SFTP 独立连接路径。