### PR TITLE
fix(sync): apply cloud settings on initial merge

### DIFF
--- a/domain/syncMerge.test.ts
+++ b/domain/syncMerge.test.ts
@@ -257,6 +257,129 @@ test("mergeSyncPayloads carries deletion records forward after applying a tombst
   }]);
 });
 
+test("mergeSyncPayloads adopts cloud settings on the first merge without a base", () => {
+  const result = mergeSyncPayloads(
+    null,
+    payload({
+      settings: {
+        theme: "dark",
+        terminalFontSize: 14,
+        terminalSettings: {
+          cursorBlink: true,
+          copyOnSelect: false,
+        },
+      },
+    }),
+    payload({
+      settings: {
+        theme: "light",
+        terminalFontSize: 18,
+        terminalSettings: {
+          cursorBlink: false,
+          copyOnSelect: true,
+        },
+      },
+    }),
+  );
+
+  assert.deepEqual(result.payload.settings, {
+    theme: "light",
+    terminalFontSize: 18,
+    terminalSettings: {
+      cursorBlink: false,
+      copyOnSelect: true,
+    },
+  });
+});
+
+test("mergeSyncPayloads preserves one-sided settings on the first merge", () => {
+  const result = mergeSyncPayloads(
+    null,
+    payload({
+      settings: {
+        customCSS: ".terminal { opacity: 0.9; }",
+        terminalSettings: { copyOnSelect: true },
+      },
+    }),
+    payload({
+      settings: {
+        theme: "system",
+        terminalSettings: { cursorBlink: false },
+      },
+    }),
+  );
+
+  assert.deepEqual(result.payload.settings, {
+    customCSS: ".terminal { opacity: 0.9; }",
+    theme: "system",
+    terminalSettings: {
+      copyOnSelect: true,
+      cursorBlink: false,
+    },
+  });
+});
+
+test("mergeSyncPayloads retains unique nested setting entries while cloud wins duplicate ids", () => {
+  const result = mergeSyncPayloads(
+    null,
+    payload({
+      settings: {
+        ai: {
+          providers: [
+            { id: "shared", name: "Local shared" },
+            { id: "local-only", name: "Local only" },
+          ],
+        },
+      },
+    }),
+    payload({
+      settings: {
+        ai: {
+          providers: [
+            { id: "shared", name: "Cloud shared" },
+            { id: "cloud-only", name: "Cloud only" },
+          ],
+        },
+      },
+    }),
+  );
+
+  assert.deepEqual(result.payload.settings?.ai?.providers, [
+    { id: "shared", name: "Cloud shared" },
+    { id: "cloud-only", name: "Cloud only" },
+    { id: "local-only", name: "Local only" },
+  ]);
+});
+
+test("mergeSyncPayloads keeps local settings conflict policy when a base exists", () => {
+  const base = payload({
+    settings: {
+      theme: "system",
+      terminalSettings: { cursorBlink: true },
+    },
+  });
+  const result = mergeSyncPayloads(
+    base,
+    payload({
+      settings: {
+        theme: "dark",
+        terminalSettings: { cursorBlink: false },
+      },
+    }),
+    payload({
+      settings: {
+        theme: "light",
+        terminalSettings: { cursorBlink: true },
+      },
+    }),
+  );
+
+  assert.deepEqual(result.payload.settings, {
+    theme: "dark",
+    terminalSettings: { cursorBlink: false },
+  });
+});
+
 test("mergeSyncPayloads treats missing optional arrays as legacy payloads, not deletions", () => {
   const identity = {
     id: "identity-1",

--- a/domain/syncMerge.test.ts
+++ b/domain/syncMerge.test.ts
@@ -319,6 +319,44 @@ test("mergeSyncPayloads preserves one-sided settings on the first merge", () => 
   });
 });
 
+test("mergeSyncPayloads honors empty cloud setting maps as resets on the first merge", () => {
+  const result = mergeSyncPayloads(
+    null,
+    payload({
+      settings: {
+        customKeyBindings: {
+          copy: { mac: "meta+c", pc: "ctrl+c" },
+        },
+        ai: {
+          agentModelMap: { codex: "gpt-local" },
+          agentProviderMap: { codex: "openai-local" },
+          activeModelId: "local-model",
+        },
+      },
+    }),
+    payload({
+      settings: {
+        customKeyBindings: {},
+        ai: {
+          agentModelMap: {},
+          agentProviderMap: {},
+          activeProviderId: "cloud-provider",
+        },
+      },
+    }),
+  );
+
+  assert.deepEqual(result.payload.settings, {
+    customKeyBindings: {},
+    ai: {
+      agentModelMap: {},
+      agentProviderMap: {},
+      activeModelId: "local-model",
+      activeProviderId: "cloud-provider",
+    },
+  });
+});
+
 test("mergeSyncPayloads retains unique nested setting entries while cloud wins duplicate ids", () => {
   const result = mergeSyncPayloads(
     null,

--- a/domain/syncMerge.ts
+++ b/domain/syncMerge.ts
@@ -262,6 +262,7 @@ function mergeSettingsDeep(
   base: Record<string, unknown>,
   local: Record<string, unknown>,
   remote: Record<string, unknown>,
+  preferRemoteOnConflict: boolean,
 ): Record<string, unknown> {
   const allKeys = new Set([
     ...Object.keys(base),
@@ -293,7 +294,22 @@ function mergeSettingsDeep(
           (bVal && typeof bVal === 'object' && !Array.isArray(bVal) ? bVal : {}) as Record<string, unknown>,
           lVal as Record<string, unknown>,
           rVal as Record<string, unknown>,
+          preferRemoteOnConflict,
         );
+      } else if (
+        preferRemoteOnConflict &&
+        Array.isArray(lVal) && Array.isArray(rVal) &&
+        (isIdArray(lVal) || isIdArray(rVal) || isIdArray(Array.isArray(bVal) ? bVal as unknown[] : []))
+      ) {
+        const bArr = Array.isArray(bVal) ? bVal as Array<{ id: string }> : [];
+        const result = mergeEntityArrays(
+          bArr,
+          rVal as Array<{ id: string }>,
+          lVal as Array<{ id: string }>,
+        );
+        merged[key] = result.merged;
+      } else if (preferRemoteOnConflict && rVal !== undefined) {
+        merged[key] = rVal;
       } else if (lVal !== undefined) {
         merged[key] = lVal;
       }
@@ -306,6 +322,7 @@ function mergeSettings(
   base: SettingsObj | undefined,
   local: SettingsObj | undefined,
   remote: SettingsObj | undefined,
+  preferRemoteOnConflict: boolean,
 ): SettingsObj | undefined {
   if (!local && !remote) return undefined;
   if (!local) return remote;
@@ -345,6 +362,7 @@ function mergeSettings(
           (bVal && typeof bVal === 'object' && !Array.isArray(bVal) ? bVal : {}) as Record<string, unknown>,
           lVal as Record<string, unknown>,
           rVal as Record<string, unknown>,
+          preferRemoteOnConflict,
         );
       } else if (
         Array.isArray(lVal) && Array.isArray(rVal) &&
@@ -352,8 +370,16 @@ function mergeSettings(
       ) {
         // Array of objects with `id` (e.g. customTerminalThemes) — entity merge
         const bArr = Array.isArray(bVal) ? bVal as Array<{ id: string }> : [];
-        const result = mergeEntityArrays(bArr, lVal as Array<{ id: string }>, rVal as Array<{ id: string }>);
+        const preferred = preferRemoteOnConflict ? rVal : lVal;
+        const other = preferRemoteOnConflict ? lVal : rVal;
+        const result = mergeEntityArrays(
+          bArr,
+          preferred as Array<{ id: string }>,
+          other as Array<{ id: string }>,
+        );
         merged[key] = result.merged;
+      } else if (preferRemoteOnConflict && rVal !== undefined) {
+        merged[key] = rVal;
       } else if (lVal !== undefined) {
         merged[key] = lVal;
       }
@@ -488,7 +514,19 @@ export function mergeSyncPayloads(
   );
 
   // Merge settings
-  const settings = mergeSettings(b.settings, local.settings, remote.settings);
+  // With no trusted base, the remote payload represents the established
+  // cloud replica while a newly installed client has already persisted its
+  // initial defaults. Treating both as additions and preferring local would
+  // keep those defaults and make settings appear not to sync at all. Prefer
+  // the cloud value only for same-field conflicts on this first merge; fields
+  // present on just one side are still preserved. Once a base exists, retain
+  // the existing local-wins three-way conflict policy.
+  const settings = mergeSettings(
+    b.settings,
+    local.settings,
+    remote.settings,
+    base === null,
+  );
 
   // Deduplicate global SFTP bookmarks by path (IDs are random per device)
   if (settings?.sftpGlobalBookmarks && settings.sftpGlobalBookmarks.length > 0) {

--- a/domain/syncMerge.ts
+++ b/domain/syncMerge.ts
@@ -257,6 +257,14 @@ function isIdArray(arr: unknown[]): boolean {
   return arr.length > 0 && typeof arr[0] === 'object' && arr[0] !== null && 'id' in arr[0];
 }
 
+/** Treat an explicit empty object as a reset marker during the first cloud merge. */
+function isEmptyPlainObject(value: unknown): value is Record<string, never> {
+  return value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 0;
+}
+
 /** Recursively merge two plain objects against a base using three-way logic. */
 function mergeSettingsDeep(
   base: Record<string, unknown>,
@@ -290,12 +298,14 @@ function mergeSettingsDeep(
         typeof lVal === 'object' && !Array.isArray(lVal) &&
         typeof rVal === 'object' && !Array.isArray(rVal)
       ) {
-        merged[key] = mergeSettingsDeep(
-          (bVal && typeof bVal === 'object' && !Array.isArray(bVal) ? bVal : {}) as Record<string, unknown>,
-          lVal as Record<string, unknown>,
-          rVal as Record<string, unknown>,
-          preferRemoteOnConflict,
-        );
+        merged[key] = preferRemoteOnConflict && isEmptyPlainObject(rVal)
+          ? rVal
+          : mergeSettingsDeep(
+            (bVal && typeof bVal === 'object' && !Array.isArray(bVal) ? bVal : {}) as Record<string, unknown>,
+            lVal as Record<string, unknown>,
+            rVal as Record<string, unknown>,
+            preferRemoteOnConflict,
+          );
       } else if (
         preferRemoteOnConflict &&
         Array.isArray(lVal) && Array.isArray(rVal) &&
@@ -358,12 +368,14 @@ function mergeSettings(
         typeof lVal === 'object' && !Array.isArray(lVal) &&
         typeof rVal === 'object' && !Array.isArray(rVal)
       ) {
-        merged[key] = mergeSettingsDeep(
-          (bVal && typeof bVal === 'object' && !Array.isArray(bVal) ? bVal : {}) as Record<string, unknown>,
-          lVal as Record<string, unknown>,
-          rVal as Record<string, unknown>,
-          preferRemoteOnConflict,
-        );
+        merged[key] = preferRemoteOnConflict && isEmptyPlainObject(rVal)
+          ? rVal
+          : mergeSettingsDeep(
+            (bVal && typeof bVal === 'object' && !Array.isArray(bVal) ? bVal : {}) as Record<string, unknown>,
+            lVal as Record<string, unknown>,
+            rVal as Record<string, unknown>,
+            preferRemoteOnConflict,
+          );
       } else if (
         Array.isArray(lVal) && Array.isArray(rVal) &&
         (isIdArray(lVal) || isIdArray(rVal) || isIdArray(Array.isArray(bVal) ? bVal as unknown[] : []))


### PR DESCRIPTION
## Summary

Netcatty already serializes portable settings into cloud sync payloads, but the first smart merge had no trusted base. A fresh installation persists its default settings before sync, so both local defaults and established cloud values looked like concurrent additions. The existing local-wins fallback kept the defaults, even while hosts and other collections merged successfully.

This change makes the established cloud replica win same-field setting conflicts only when no sync base exists. One-sided settings are retained, nested settings are merged, and ID-addressable entries keep unique values from both sides. Once a trusted base exists, the existing local-wins three-way conflict policy is unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2297

## Changes Made

- Prefer remote setting values for same-field conflicts during the initial base-less smart merge.
- Preserve settings that exist on only one side.
- Merge nested ID-addressable settings such as AI provider entries while preferring the cloud version of duplicate IDs.
- Add regression coverage for scalar, nested, one-sided, ID-addressable, and established-baseline behavior.

## Screenshots / Demo

Not applicable. This changes the pure sync merge policy and has no new UI.

## Security impact

No new data is added to the sync payload. Existing portable-setting allowlists, credential encryption, and device-local exclusions remain unchanged.

## Compatibility and migration

No schema or storage migration is required. Existing sync bases keep their current merge behavior; the change applies only when no trusted base is available.

## Testing

- [ ] I have tested these changes locally (`npm run dev`) — no UI path changed
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`) — 5,842 passed, 11 skipped, and one unchanged upstream SSH authentication retry test failed; the affected files are byte-identical to `upstream/main`
- [x] Generated capability tool specs are updated when applicable — not applicable; no capability catalog changes
- [x] No new console errors or warnings, if this affects app behavior
- [x] Targeted sync suite passes: 103 tests
- [x] Production build passes: `npm run build`
- [x] Diff validation passes: `git diff --check`

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation — merge-policy comments and regression tests document the behavior
- [x] I have not introduced any breaking changes (or I have described them above)
