### PR TITLE
fix(terminal): recover WebGL renderer after context loss

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -484,6 +484,11 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
 
   let webglAddon: WebglAddon | null = null;
   let webglLoaded = false;
+  // Once repeated context losses trip the breaker, this runtime stays on the
+  // DOM renderer. In particular, reveal/resume calls to ensureWebglRenderer and
+  // suspend/resume cycles must not rearm WebGL. A newly-created runtime (for
+  // example after a deliberate renderer preference change) gets a fresh flag.
+  let webglCircuitBroken = false;
   let webglRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
   let runtimeDisposed = false;
   const webglContextLosses: number[] = [];
@@ -515,7 +520,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   };
 
   const loadWebglRenderer = () => {
-    if (webglLoaded || !performanceConfig.useWebGLAddon) return;
+    if (webglLoaded || webglCircuitBroken || !performanceConfig.useWebGLAddon) return;
     let nextWebglAddon: WebglAddon | null = null;
     try {
       // WebglAddon constructor only accepts `preserveDrawingBuffer?: boolean`.
@@ -545,6 +550,8 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         }
         webglContextLosses.push(now);
         if (webglContextLosses.length > WEBGL_MAX_RECOVERIES_PER_WINDOW) {
+          webglCircuitBroken = true;
+          cancelWebglRecovery();
           logger.warn("[XTerm] Repeated WebGL context loss, staying on DOM renderer");
           return;
         }

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -484,6 +484,12 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
 
   let webglAddon: WebglAddon | null = null;
   let webglLoaded = false;
+  let webglRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
+  let runtimeDisposed = false;
+  const webglContextLosses: number[] = [];
+  const WEBGL_RECOVERY_DELAY_MS = 50;
+  const WEBGL_RECOVERY_WINDOW_MS = 10_000;
+  const WEBGL_MAX_RECOVERIES_PER_WINDOW = 2;
   const scopedWindow = window as Window & {
     __xtermWebGLLoaded?: boolean;
     __xtermRendererPreference?: string;
@@ -493,22 +499,79 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   // (or when WebGL is disabled for this device). Panes that mount hidden defer
   // this until they first become visible — see shouldDeferWebglUntilVisible —
   // so batch-connecting many hosts doesn't spin up every WebGL context at once.
+  const repaintTerminal = () => {
+    if (runtimeDisposed || term.rows < 1) return;
+    try {
+      term.refresh(0, term.rows - 1);
+    } catch (err) {
+      logger.warn("[XTerm] renderer repaint failed", err);
+    }
+  };
+
+  const cancelWebglRecovery = () => {
+    if (webglRecoveryTimer === null) return;
+    clearTimeout(webglRecoveryTimer);
+    webglRecoveryTimer = null;
+  };
+
   const loadWebglRenderer = () => {
     if (webglLoaded || !performanceConfig.useWebGLAddon) return;
+    let nextWebglAddon: WebglAddon | null = null;
     try {
       // WebglAddon constructor only accepts `preserveDrawingBuffer?: boolean`.
       // Passing an object here (legacy API assumption) unintentionally enables
       // preserveDrawingBuffer and can cause sporadic glyph artifacts/ghosting.
-      webglAddon = new WebglAddon();
-      webglAddon.onContextLoss(() => {
-        logger.warn("[XTerm] WebGL context loss detected, disposing addon");
-        webglAddon?.dispose();
+      nextWebglAddon = new WebglAddon();
+      nextWebglAddon.onContextLoss(() => {
+        // Ignore a late event from an addon that has already been replaced.
+        if (webglAddon !== nextWebglAddon || runtimeDisposed) return;
+        logger.warn("[XTerm] WebGL context loss detected, rebuilding renderer");
+        try {
+          nextWebglAddon?.dispose();
+        } catch (webglErr) {
+          logger.warn("[XTerm] Failed to dispose lost WebGL renderer", webglErr);
+        }
         webglAddon = null;
         webglLoaded = false;
+        scopedWindow.__xtermWebGLLoaded = false;
+        repaintTerminal();
+
+        const now = Date.now();
+        while (
+          webglContextLosses.length > 0
+          && now - webglContextLosses[0] > WEBGL_RECOVERY_WINDOW_MS
+        ) {
+          webglContextLosses.shift();
+        }
+        webglContextLosses.push(now);
+        if (webglContextLosses.length > WEBGL_MAX_RECOVERIES_PER_WINDOW) {
+          logger.warn("[XTerm] Repeated WebGL context loss, staying on DOM renderer");
+          return;
+        }
+
+        // Context loss events can arrive in bursts. Coalesce them and let xterm
+        // settle on its DOM renderer before attaching a fresh WebGL renderer.
+        cancelWebglRecovery();
+        webglRecoveryTimer = setTimeout(() => {
+          webglRecoveryTimer = null;
+          if (runtimeDisposed) return;
+          loadWebglRenderer();
+          // loadWebglRenderer catches failures, leaving xterm on DOM. Refresh in
+          // either case so the existing viewport never remains black.
+          repaintTerminal();
+        }, WEBGL_RECOVERY_DELAY_MS);
       });
-      term.loadAddon(webglAddon);
+      webglAddon = nextWebglAddon;
+      term.loadAddon(nextWebglAddon);
       webglLoaded = true;
     } catch (webglErr) {
+      try {
+        nextWebglAddon?.dispose();
+      } catch {
+        // The original load error is more useful than a cleanup error.
+      }
+      if (webglAddon === nextWebglAddon) webglAddon = null;
+      webglLoaded = false;
       logger.warn(
         "[XTerm] WebGL addon failed, using DOM renderer. Error:",
         webglErr instanceof Error ? webglErr.message : webglErr,
@@ -518,6 +581,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   };
 
   const suspendWebglRenderer = () => {
+    cancelWebglRecovery();
     if (!webglAddon) {
       webglLoaded = false;
       scopedWindow.__xtermWebGLLoaded = false;
@@ -1496,6 +1560,8 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     ensureWebglRenderer: loadWebglRenderer,
     suspendWebglRenderer,
     dispose: () => {
+      runtimeDisposed = true;
+      cancelWebglRecovery();
       term.element?.removeEventListener("copy", handleNativeCopy, true);
       ctx.container.removeEventListener(
         "wheel",

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -49,6 +49,7 @@ import { terminalAltKeyOptions } from "./altKeyOptions";
 import { optionArrowWordJumpSequence } from "./optionArrowWordJump";
 import { watchDevicePixelRatio } from "./rendererDprWatch";
 import { shouldDeferWebglUntilVisible } from "./webglRendererPolicy";
+import { createWebglRendererController } from "./webglRendererController";
 import {
   captureMiddleClickTerminalMouseEvent,
   markMiddleClickContextMenuEvent,
@@ -482,19 +483,8 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   };
   term.element?.addEventListener("copy", handleNativeCopy, true);
 
-  let webglAddon: WebglAddon | null = null;
   let webglLoaded = false;
-  // Once repeated context losses trip the breaker, this runtime stays on the
-  // DOM renderer. In particular, reveal/resume calls to ensureWebglRenderer and
-  // suspend/resume cycles must not rearm WebGL. A newly-created runtime (for
-  // example after a deliberate renderer preference change) gets a fresh flag.
-  let webglCircuitBroken = false;
-  let webglRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
   let runtimeDisposed = false;
-  const webglContextLosses: number[] = [];
-  const WEBGL_RECOVERY_DELAY_MS = 50;
-  const WEBGL_RECOVERY_WINDOW_MS = 10_000;
-  const WEBGL_MAX_RECOVERIES_PER_WINDOW = 2;
   const scopedWindow = window as Window & {
     __xtermWebGLLoaded?: boolean;
     __xtermRendererPreference?: string;
@@ -513,96 +503,22 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     }
   };
 
-  const cancelWebglRecovery = () => {
-    if (webglRecoveryTimer === null) return;
-    clearTimeout(webglRecoveryTimer);
-    webglRecoveryTimer = null;
-  };
-
-  const loadWebglRenderer = () => {
-    if (webglLoaded || webglCircuitBroken || !performanceConfig.useWebGLAddon) return;
-    let nextWebglAddon: WebglAddon | null = null;
-    try {
-      // WebglAddon constructor only accepts `preserveDrawingBuffer?: boolean`.
-      // Passing an object here (legacy API assumption) unintentionally enables
-      // preserveDrawingBuffer and can cause sporadic glyph artifacts/ghosting.
-      nextWebglAddon = new WebglAddon();
-      nextWebglAddon.onContextLoss(() => {
-        // Ignore a late event from an addon that has already been replaced.
-        if (webglAddon !== nextWebglAddon || runtimeDisposed) return;
-        logger.warn("[XTerm] WebGL context loss detected, rebuilding renderer");
-        try {
-          nextWebglAddon?.dispose();
-        } catch (webglErr) {
-          logger.warn("[XTerm] Failed to dispose lost WebGL renderer", webglErr);
-        }
-        webglAddon = null;
-        webglLoaded = false;
-        scopedWindow.__xtermWebGLLoaded = false;
-        repaintTerminal();
-
-        const now = Date.now();
-        while (
-          webglContextLosses.length > 0
-          && now - webglContextLosses[0] > WEBGL_RECOVERY_WINDOW_MS
-        ) {
-          webglContextLosses.shift();
-        }
-        webglContextLosses.push(now);
-        if (webglContextLosses.length > WEBGL_MAX_RECOVERIES_PER_WINDOW) {
-          webglCircuitBroken = true;
-          cancelWebglRecovery();
-          logger.warn("[XTerm] Repeated WebGL context loss, staying on DOM renderer");
-          return;
-        }
-
-        // Context loss events can arrive in bursts. Coalesce them and let xterm
-        // settle on its DOM renderer before attaching a fresh WebGL renderer.
-        cancelWebglRecovery();
-        webglRecoveryTimer = setTimeout(() => {
-          webglRecoveryTimer = null;
-          if (runtimeDisposed) return;
-          loadWebglRenderer();
-          // loadWebglRenderer catches failures, leaving xterm on DOM. Refresh in
-          // either case so the existing viewport never remains black.
-          repaintTerminal();
-        }, WEBGL_RECOVERY_DELAY_MS);
-      });
-      webglAddon = nextWebglAddon;
-      term.loadAddon(nextWebglAddon);
-      webglLoaded = true;
-    } catch (webglErr) {
-      try {
-        nextWebglAddon?.dispose();
-      } catch {
-        // The original load error is more useful than a cleanup error.
-      }
-      if (webglAddon === nextWebglAddon) webglAddon = null;
-      webglLoaded = false;
-      logger.warn(
-        "[XTerm] WebGL addon failed, using DOM renderer. Error:",
-        webglErr instanceof Error ? webglErr.message : webglErr,
-      );
-    }
-    scopedWindow.__xtermWebGLLoaded = webglLoaded;
-  };
-
-  const suspendWebglRenderer = () => {
-    cancelWebglRecovery();
-    if (!webglAddon) {
-      webglLoaded = false;
-      scopedWindow.__xtermWebGLLoaded = false;
-      return;
-    }
-    try {
-      webglAddon.dispose();
-    } catch (webglErr) {
-      logger.warn("[XTerm] Failed to suspend WebGL renderer", webglErr);
-    }
-    webglAddon = null;
-    webglLoaded = false;
-    scopedWindow.__xtermWebGLLoaded = false;
-  };
+  const webglController = createWebglRendererController({
+    enabled: performanceConfig.useWebGLAddon,
+    createAddon: () => new WebglAddon(),
+    loadAddon: (addon) => term.loadAddon(addon),
+    repaint: repaintTerminal,
+    setLoaded: (loaded) => {
+      webglLoaded = loaded;
+      scopedWindow.__xtermWebGLLoaded = loaded;
+    },
+    warn: (message, error) => {
+      if (error === undefined) logger.warn(message);
+      else logger.warn(message, error);
+    },
+  });
+  const loadWebglRenderer = webglController.ensure;
+  const suspendWebglRenderer = webglController.suspend;
 
   if (!performanceConfig.useWebGLAddon) {
     logger.info(
@@ -632,6 +548,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   // the atlas forces glyphs to re-rasterize at the correct scale on the next
   // frame. No-op for the DOM renderer.
   const clearWebglTextureAtlas = () => {
+    const webglAddon = webglController.getAddon();
     if (!webglAddon) return;
     try {
       webglAddon.clearTextureAtlas();
@@ -1568,7 +1485,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     suspendWebglRenderer,
     dispose: () => {
       runtimeDisposed = true;
-      cancelWebglRecovery();
+      webglController.dispose();
       term.element?.removeEventListener("copy", handleNativeCopy, true);
       ctx.container.removeEventListener(
         "wheel",
@@ -1619,11 +1536,6 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         searchAddon.dispose();
       } catch (err) {
         logger.warn("[XTerm] searchAddon dispose failed", err);
-      }
-      try {
-        webglAddon?.dispose();
-      } catch (err) {
-        logger.warn("[XTerm] webglAddon dispose failed", err);
       }
     },
     get currentCwd() {

--- a/components/terminal/runtime/webglContextLossRecovery.test.ts
+++ b/components/terminal/runtime/webglContextLossRecovery.test.ts
@@ -1,47 +1,160 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import test from "node:test";
+import { createWebglRendererController } from "./webglRendererController";
 
-const source = readFileSync(new URL("./createXTermRuntime.ts", import.meta.url), "utf8");
+class FakeAddon {
+  contextLoss: (() => void) | null = null;
+  disposeCalls = 0;
 
-test("WebGL context loss schedules a coalesced rebuild and viewport repaint", () => {
-  const handlerStart = source.indexOf("nextWebglAddon.onContextLoss");
-  const handlerEnd = source.indexOf("term.loadAddon(nextWebglAddon)", handlerStart);
-  const handler = source.slice(handlerStart, handlerEnd);
+  onContextLoss(callback: () => void) {
+    this.contextLoss = callback;
+  }
 
-  assert.ok(handlerStart >= 0 && handlerEnd > handlerStart);
-  assert.match(handler, /nextWebglAddon\?\.dispose\(\)/);
-  assert.match(handler, /webglLoaded = false/);
-  assert.match(handler, /cancelWebglRecovery\(\)/);
-  assert.match(handler, /webglRecoveryTimer = setTimeout/);
-  assert.match(handler, /loadWebglRenderer\(\);[\s\S]*repaintTerminal\(\)/);
+  dispose() {
+    this.disposeCalls += 1;
+  }
+
+  loseContext() {
+    assert.ok(this.contextLoss, "addon must install a context-loss handler");
+    this.contextLoss();
+  }
+}
+
+function createHarness(options: { failLoads?: Set<number>; enabled?: boolean } = {}) {
+  let time = 0;
+  let nextTimerId = 1;
+  const timers = new Map<number, () => void>();
+  const addons: FakeAddon[] = [];
+  const loadedStates: boolean[] = [];
+  const warnings: string[] = [];
+  let repaintCalls = 0;
+  let loadCalls = 0;
+
+  const controller = createWebglRendererController({
+    enabled: options.enabled ?? true,
+    createAddon: () => {
+      const addon = new FakeAddon();
+      addons.push(addon);
+      return addon;
+    },
+    loadAddon: () => {
+      loadCalls += 1;
+      if (options.failLoads?.has(loadCalls)) throw new Error(`load ${loadCalls} failed`);
+    },
+    repaint: () => {
+      repaintCalls += 1;
+    },
+    setLoaded: (loaded) => loadedStates.push(loaded),
+    warn: (message) => warnings.push(message),
+    now: () => time,
+    setTimer: (callback) => {
+      const id = nextTimerId++;
+      timers.set(id, callback);
+      return id as unknown as ReturnType<typeof setTimeout>;
+    },
+    clearTimer: (id) => timers.delete(id as unknown as number),
+  });
+
+  return {
+    controller,
+    addons,
+    loadedStates,
+    warnings,
+    get repaintCalls() { return repaintCalls; },
+    get loadCalls() { return loadCalls; },
+    get pendingTimers() { return timers.size; },
+    setTime(value: number) { time = value; },
+    runNextTimer() {
+      const entry = timers.entries().next().value as [number, () => void] | undefined;
+      assert.ok(entry, "expected a pending timer");
+      timers.delete(entry[0]);
+      entry[1]();
+    },
+  };
+}
+
+test("context loss schedules one recovery and repaints the DOM fallback", () => {
+  const harness = createHarness();
+  harness.controller.ensure();
+
+  harness.addons[0].loseContext();
+  harness.addons[0].loseContext();
+
+  assert.equal(harness.pendingTimers, 1);
+  assert.equal(harness.addons[0].disposeCalls, 1);
+  assert.equal(harness.repaintCalls, 1);
+  assert.equal(harness.loadedStates.at(-1), false);
+
+  harness.runNextTimer();
+  assert.equal(harness.loadCalls, 2);
+  assert.equal(harness.repaintCalls, 2);
+  assert.equal(harness.loadedStates.at(-1), true);
 });
 
-test("WebGL recovery has a circuit breaker and lifecycle cleanup", () => {
-  assert.match(source, /WEBGL_MAX_RECOVERIES_PER_WINDOW = 2/);
-  assert.match(source, /let webglCircuitBroken = false/);
-  assert.match(
-    source,
-    /webglCircuitBroken = true;\s*cancelWebglRecovery\(\);\s*logger\.warn\("\[XTerm\] Repeated WebGL context loss, staying on DOM renderer"\);\s*return;/,
-  );
-  assert.match(source, /Repeated WebGL context loss, staying on DOM renderer/);
-  assert.match(source, /const suspendWebglRenderer = \(\) => \{\s*cancelWebglRecovery\(\)/);
-  assert.match(source, /dispose: \(\) => \{\s*runtimeDisposed = true;\s*cancelWebglRecovery\(\)/);
+test("burst losses trip a persistent breaker that ensure and suspend cannot rearm", () => {
+  const harness = createHarness();
+  harness.controller.ensure();
+  for (let loss = 0; loss < 3; loss += 1) {
+    harness.setTime(loss * 100);
+    harness.addons[loss].loseContext();
+    if (loss < 2) harness.runNextTimer();
+  }
+
+  assert.equal(harness.pendingTimers, 0);
+  assert.ok(harness.warnings.some((warning) => warning.includes("staying on DOM renderer")));
+  assert.equal(harness.loadCalls, 3);
+
+  harness.controller.ensure();
+  harness.controller.suspend();
+  harness.controller.ensure();
+  assert.equal(harness.loadCalls, 3);
+  assert.equal(harness.loadedStates.at(-1), false);
 });
 
-test("disabled WebGL remains a no-op", () => {
-  assert.match(
-    source,
-    /const loadWebglRenderer = \(\) => \{\s*if \(webglLoaded \|\| webglCircuitBroken \|\| !performanceConfig\.useWebGLAddon\) return;/,
-  );
+test("suspend and dispose cancel pending recovery callbacks", () => {
+  for (const action of ["suspend", "dispose"] as const) {
+    const harness = createHarness();
+    harness.controller.ensure();
+    harness.addons[0].loseContext();
+    assert.equal(harness.pendingTimers, 1);
+
+    harness.controller[action]();
+    assert.equal(harness.pendingTimers, 0);
+    assert.equal(harness.loadCalls, 1);
+  }
 });
 
-test("ensureWebglRenderer remains a no-op after the circuit breaker trips", () => {
-  const loadStart = source.indexOf("const loadWebglRenderer = () => {");
-  const loadGuard = source.indexOf("webglCircuitBroken", loadStart);
-  const addonConstruction = source.indexOf("new WebglAddon()", loadStart);
+test("a stale context-loss callback from a replaced addon is ignored", () => {
+  const harness = createHarness();
+  harness.controller.ensure();
+  const staleAddon = harness.addons[0];
+  staleAddon.loseContext();
+  harness.runNextTimer();
+  const repaintCalls = harness.repaintCalls;
 
-  assert.ok(loadStart >= 0);
-  assert.ok(loadGuard > loadStart && loadGuard < addonConstruction);
-  assert.match(source, /ensureWebglRenderer: loadWebglRenderer/);
+  staleAddon.loseContext();
+  assert.equal(harness.pendingTimers, 0);
+  assert.equal(harness.repaintCalls, repaintCalls);
+  assert.equal(staleAddon.disposeCalls, 1);
+  assert.equal(harness.controller.getAddon(), harness.addons[1]);
+});
+
+test("recovery load failure stays on DOM and still repaints the viewport", () => {
+  const harness = createHarness({ failLoads: new Set([2]) });
+  harness.controller.ensure();
+  harness.addons[0].loseContext();
+  harness.runNextTimer();
+
+  assert.equal(harness.controller.getAddon(), null);
+  assert.equal(harness.loadedStates.at(-1), false);
+  assert.equal(harness.addons[1].disposeCalls, 1);
+  assert.equal(harness.repaintCalls, 2);
+  assert.ok(harness.warnings.some((warning) => warning.includes("using DOM renderer")));
+});
+
+test("disabled WebGL ensure is a no-op", () => {
+  const harness = createHarness({ enabled: false });
+  harness.controller.ensure();
+  assert.equal(harness.loadCalls, 0);
+  assert.equal(harness.addons.length, 0);
 });

--- a/components/terminal/runtime/webglContextLossRecovery.test.ts
+++ b/components/terminal/runtime/webglContextLossRecovery.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync(new URL("./createXTermRuntime.ts", import.meta.url), "utf8");
+
+test("WebGL context loss schedules a coalesced rebuild and viewport repaint", () => {
+  const handlerStart = source.indexOf("nextWebglAddon.onContextLoss");
+  const handlerEnd = source.indexOf("term.loadAddon(nextWebglAddon)", handlerStart);
+  const handler = source.slice(handlerStart, handlerEnd);
+
+  assert.ok(handlerStart >= 0 && handlerEnd > handlerStart);
+  assert.match(handler, /nextWebglAddon\?\.dispose\(\)/);
+  assert.match(handler, /webglLoaded = false/);
+  assert.match(handler, /cancelWebglRecovery\(\)/);
+  assert.match(handler, /webglRecoveryTimer = setTimeout/);
+  assert.match(handler, /loadWebglRenderer\(\);[\s\S]*repaintTerminal\(\)/);
+});
+
+test("WebGL recovery has a circuit breaker and lifecycle cleanup", () => {
+  assert.match(source, /WEBGL_MAX_RECOVERIES_PER_WINDOW = 2/);
+  assert.match(source, /Repeated WebGL context loss, staying on DOM renderer/);
+  assert.match(source, /const suspendWebglRenderer = \(\) => \{\s*cancelWebglRecovery\(\)/);
+  assert.match(source, /dispose: \(\) => \{\s*runtimeDisposed = true;\s*cancelWebglRecovery\(\)/);
+});
+
+test("disabled WebGL remains a no-op", () => {
+  assert.match(
+    source,
+    /const loadWebglRenderer = \(\) => \{\s*if \(webglLoaded \|\| !performanceConfig\.useWebGLAddon\) return;/,
+  );
+});

--- a/components/terminal/runtime/webglContextLossRecovery.test.ts
+++ b/components/terminal/runtime/webglContextLossRecovery.test.ts
@@ -19,6 +19,11 @@ test("WebGL context loss schedules a coalesced rebuild and viewport repaint", ()
 
 test("WebGL recovery has a circuit breaker and lifecycle cleanup", () => {
   assert.match(source, /WEBGL_MAX_RECOVERIES_PER_WINDOW = 2/);
+  assert.match(source, /let webglCircuitBroken = false/);
+  assert.match(
+    source,
+    /webglCircuitBroken = true;\s*cancelWebglRecovery\(\);\s*logger\.warn\("\[XTerm\] Repeated WebGL context loss, staying on DOM renderer"\);\s*return;/,
+  );
   assert.match(source, /Repeated WebGL context loss, staying on DOM renderer/);
   assert.match(source, /const suspendWebglRenderer = \(\) => \{\s*cancelWebglRecovery\(\)/);
   assert.match(source, /dispose: \(\) => \{\s*runtimeDisposed = true;\s*cancelWebglRecovery\(\)/);
@@ -27,6 +32,16 @@ test("WebGL recovery has a circuit breaker and lifecycle cleanup", () => {
 test("disabled WebGL remains a no-op", () => {
   assert.match(
     source,
-    /const loadWebglRenderer = \(\) => \{\s*if \(webglLoaded \|\| !performanceConfig\.useWebGLAddon\) return;/,
+    /const loadWebglRenderer = \(\) => \{\s*if \(webglLoaded \|\| webglCircuitBroken \|\| !performanceConfig\.useWebGLAddon\) return;/,
   );
+});
+
+test("ensureWebglRenderer remains a no-op after the circuit breaker trips", () => {
+  const loadStart = source.indexOf("const loadWebglRenderer = () => {");
+  const loadGuard = source.indexOf("webglCircuitBroken", loadStart);
+  const addonConstruction = source.indexOf("new WebglAddon()", loadStart);
+
+  assert.ok(loadStart >= 0);
+  assert.ok(loadGuard > loadStart && loadGuard < addonConstruction);
+  assert.match(source, /ensureWebglRenderer: loadWebglRenderer/);
 });

--- a/components/terminal/runtime/webglRendererController.ts
+++ b/components/terminal/runtime/webglRendererController.ts
@@ -1,0 +1,142 @@
+export interface WebglRendererAddon {
+  onContextLoss(callback: () => void): unknown;
+  dispose(): void;
+}
+
+export interface WebglRendererController<TAddon extends WebglRendererAddon> {
+  ensure(): void;
+  suspend(): void;
+  dispose(): void;
+  getAddon(): TAddon | null;
+}
+
+interface WebglRendererControllerOptions<TAddon extends WebglRendererAddon> {
+  enabled: boolean;
+  createAddon: () => TAddon;
+  loadAddon: (addon: TAddon) => void;
+  repaint: () => void;
+  setLoaded: (loaded: boolean) => void;
+  warn: (message: string, error?: unknown) => void;
+  now?: () => number;
+  setTimer?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  clearTimer?: (timer: ReturnType<typeof setTimeout>) => void;
+  recoveryDelayMs?: number;
+  recoveryWindowMs?: number;
+  maxRecoveriesPerWindow?: number;
+}
+
+/** Owns WebGL addon recovery without depending on xterm or browser globals. */
+export function createWebglRendererController<TAddon extends WebglRendererAddon>(
+  options: WebglRendererControllerOptions<TAddon>,
+): WebglRendererController<TAddon> {
+  const now = options.now ?? Date.now;
+  const setTimer = options.setTimer ?? setTimeout;
+  const clearTimer = options.clearTimer ?? clearTimeout;
+  const recoveryDelayMs = options.recoveryDelayMs ?? 50;
+  const recoveryWindowMs = options.recoveryWindowMs ?? 10_000;
+  const maxRecoveriesPerWindow = options.maxRecoveriesPerWindow ?? 2;
+  const contextLosses: number[] = [];
+  let addon: TAddon | null = null;
+  let loaded = false;
+  let circuitBroken = false;
+  let disposed = false;
+  let recoveryTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const publishLoaded = (value: boolean) => {
+    loaded = value;
+    options.setLoaded(value);
+  };
+
+  const cancelRecovery = () => {
+    if (recoveryTimer === null) return;
+    clearTimer(recoveryTimer);
+    recoveryTimer = null;
+  };
+
+  const ensure = () => {
+    if (loaded || circuitBroken || disposed || !options.enabled) return;
+    let nextAddon: TAddon | null = null;
+    try {
+      nextAddon = options.createAddon();
+      const ownedAddon = nextAddon;
+      ownedAddon.onContextLoss(() => {
+        if (addon !== ownedAddon || disposed) return;
+        options.warn("[XTerm] WebGL context loss detected, rebuilding renderer");
+        try {
+          ownedAddon.dispose();
+        } catch (error) {
+          options.warn("[XTerm] Failed to dispose lost WebGL renderer", error);
+        }
+        addon = null;
+        publishLoaded(false);
+        options.repaint();
+
+        const lossTime = now();
+        while (contextLosses.length > 0 && lossTime - contextLosses[0] > recoveryWindowMs) {
+          contextLosses.shift();
+        }
+        contextLosses.push(lossTime);
+        if (contextLosses.length > maxRecoveriesPerWindow) {
+          circuitBroken = true;
+          cancelRecovery();
+          options.warn("[XTerm] Repeated WebGL context loss, staying on DOM renderer");
+          return;
+        }
+
+        cancelRecovery();
+        recoveryTimer = setTimer(() => {
+          recoveryTimer = null;
+          if (disposed) return;
+          ensure();
+          options.repaint();
+        }, recoveryDelayMs);
+      });
+      addon = ownedAddon;
+      options.loadAddon(ownedAddon);
+      publishLoaded(true);
+    } catch (error) {
+      try {
+        nextAddon?.dispose();
+      } catch {
+        // Preserve the original load failure.
+      }
+      if (addon === nextAddon) addon = null;
+      publishLoaded(false);
+      options.warn(
+        "[XTerm] WebGL addon failed, using DOM renderer. Error:",
+        error instanceof Error ? error.message : error,
+      );
+    }
+  };
+
+  const suspend = () => {
+    cancelRecovery();
+    const currentAddon = addon;
+    addon = null;
+    publishLoaded(false);
+    if (!currentAddon) return;
+    try {
+      currentAddon.dispose();
+    } catch (error) {
+      options.warn("[XTerm] Failed to suspend WebGL renderer", error);
+    }
+  };
+
+  return {
+    ensure,
+    suspend,
+    dispose: () => {
+      disposed = true;
+      cancelRecovery();
+      const currentAddon = addon;
+      addon = null;
+      publishLoaded(false);
+      try {
+        currentAddon?.dispose();
+      } catch (error) {
+        options.warn("[XTerm] webglAddon dispose failed", error);
+      }
+    },
+    getAddon: () => addon,
+  };
+}


### PR DESCRIPTION
## Summary

- automatically rebuild the xterm WebGL renderer after context loss
- repaint immediately through the DOM fallback and again after the rebuild attempt
- coalesce recovery attempts and stop retrying after repeated context losses
- cancel pending recovery when the renderer is suspended or the runtime is disposed
- add regression coverage for recovery, circuit breaking, cleanup, and disabled-WebGL behavior

## Validation

- `node --test --import tsx components/terminal/runtime/webglContextLossRecovery.test.ts components/terminal/terminalTabVisibilityRecovery.test.ts`
- `npx eslint components/terminal/runtime/createXTermRuntime.ts components/terminal/runtime/webglContextLossRecovery.test.ts`
- `npx tsc --noEmit`

Closes #2296