### PR TITLE
fix(terminal): limit disk capacity precision

### DIFF
--- a/components/terminal/TerminalServerStats.tsx
+++ b/components/terminal/TerminalServerStats.tsx
@@ -7,6 +7,7 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from '../ui/hover-card'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { formatNetSpeed } from './terminalHelpers';
 import { useServerStats } from './hooks/useServerStats';
+import { formatDiskCapacityGb } from './serverStatsFormat';
 
 interface TerminalServerStatsProps {
   sessionId: string;
@@ -261,7 +262,7 @@ export const TerminalServerStats: React.FC<TerminalServerStatsProps> = ({
                         serverStats.diskPercent !== null && serverStats.diskPercent >= 80 && serverStats.diskPercent < 90 && "text-amber-400"
                       )}>
                         {serverStats.diskUsed !== null && serverStats.diskTotal !== null && serverStats.diskPercent !== null
-                          ? `${serverStats.diskUsed}/${serverStats.diskTotal}G (${serverStats.diskPercent}%)`
+                          ? `${formatDiskCapacityGb(serverStats.diskUsed)}/${formatDiskCapacityGb(serverStats.diskTotal)}G (${serverStats.diskPercent}%)`
                           : serverStats.diskPercent !== null
                             ? `${serverStats.diskPercent}%`
                             : '--'}
@@ -293,7 +294,7 @@ export const TerminalServerStats: React.FC<TerminalServerStatsProps> = ({
                                   "text-[11px] font-medium whitespace-nowrap",
                                   disk.percent >= 90 ? "text-red-400" : disk.percent >= 80 ? "text-amber-400" : "text-emerald-400"
                                 )}>
-                                  {disk.used}/{disk.total}G ({disk.percent}%)
+                                  {formatDiskCapacityGb(disk.used)}/{formatDiskCapacityGb(disk.total)}G ({disk.percent}%)
                                 </span>
                               </div>
                               <div className="w-full h-1.5 bg-muted rounded-full overflow-hidden">

--- a/components/terminal/serverStatsFormat.test.ts
+++ b/components/terminal/serverStatsFormat.test.ts
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { formatDiskCapacityGb } from "./serverStatsFormat.ts";
+
+test("disk capacity uses at most two decimal places", () => {
+  assert.equal(formatDiskCapacityGb(5.964138), "5.96");
+  assert.equal(formatDiskCapacityGb(28.893616), "28.89");
+  assert.equal(formatDiskCapacityGb(0.005907), "0.01");
+  assert.equal(formatDiskCapacityGb(10), "10");
+  assert.equal(formatDiskCapacityGb(10.5), "10.5");
+});

--- a/components/terminal/serverStatsFormat.ts
+++ b/components/terminal/serverStatsFormat.ts
@@ -1,0 +1,3 @@
+export function formatDiskCapacityGb(value: number): string {
+  return Number(value.toFixed(2)).toString();
+}


### PR DESCRIPTION
## Summary

- limit terminal disk capacity values to at most two decimal places
- apply the same formatting to the top summary and mounted-disk details
- preserve compact integer and one-decimal values

## Validation

- targeted disk formatting tests pass
- lint passes
- production build passes
- full test suite: 5926 passed; one unrelated existing SSH auth retry test fails consistently