### PR TITLE
fix(terminal): avoid redundant redraws after large output

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -16,8 +16,8 @@ import {
 } from "../types";
 import { resolveSnippetCommand } from "./SnippetExecutionProvider";
 import {
+  scrollTerminalToBottomAfterInputIfEnabled,
   shouldEnableNativeUserInputAutoScroll,
-  shouldScrollOnTerminalInput,
 } from "../domain/terminalScroll";
 import {
   applyCustomAccentToTerminalTheme,
@@ -2051,9 +2051,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   normalizeTextOnCopyRef.current = terminalSettings?.normalizeTextOnCopy ?? true;
 
   const scrollToBottomAfterProgrammaticInput = useCallback((data: string) => {
-    if (termRef.current && shouldScrollOnTerminalInput(terminalSettingsRef.current, data)) {
-      termRef.current.scrollToBottom();
-    }
+    if (!termRef.current) return;
+    scrollTerminalToBottomAfterInputIfEnabled(
+      termRef.current,
+      terminalSettingsRef.current,
+      data,
+    );
   }, []);
 
   useEffect(() => {

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -20,8 +20,8 @@ import {
   resolveXTermPerformanceConfig,
 } from "../../../infrastructure/config/xtermPerformance";
 import {
+  scrollTerminalToBottomAfterInputIfEnabled,
   shouldEnableNativeUserInputAutoScroll,
-  shouldScrollOnTerminalInput,
   shouldScrollOnTerminalPaste,
 } from "../../../domain/terminalScroll";
 import {
@@ -629,9 +629,11 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     return false;
   };
   const scrollToBottomAfterInput = (data: string) => {
-    if (shouldScrollOnTerminalInput(ctx.terminalSettingsRef.current, data)) {
-      term.scrollToBottom();
-    }
+    scrollTerminalToBottomAfterInputIfEnabled(
+      term,
+      ctx.terminalSettingsRef.current,
+      data,
+    );
   };
   const currentTerminalFontSize = () => {
     const optionFontSize = term.options.fontSize;

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -641,6 +641,101 @@ test("hidden tab output marks pending scroll without scrolling immediately", () 
   assert.equal(scrollCalls, 0);
 });
 
+test("visible output does not request another scroll when already at the bottom", () => {
+  let scrollCalls = 0;
+  const term = {
+    buffer: {
+      active: {
+        type: "normal",
+        baseY: 10_000,
+        viewportY: 10_000,
+      },
+    },
+    write(_data: string, callback?: () => void) {
+      callback?.();
+    },
+    scrollToBottom() {
+      scrollCalls += 1;
+    },
+  } as unknown as XTerm;
+  const ctx = {
+    ...createContext(false),
+    isVisibleRef: { current: true },
+    terminalSettingsRef: {
+      current: {
+        showLineTimestamps: false,
+        scrollOnOutput: true,
+        forcePromptNewLine: false,
+      },
+    },
+  };
+
+  writeSessionData(ctx as never, term, "fresh output");
+
+  assert.equal(scrollCalls, 0);
+});
+
+test("visible output scrolls when the user is viewing earlier output", () => {
+  let scrollCalls = 0;
+  const term = {
+    buffer: {
+      active: {
+        type: "normal",
+        baseY: 10_000,
+        viewportY: 9_900,
+      },
+    },
+    write(_data: string, callback?: () => void) {
+      callback?.();
+    },
+    scrollToBottom() {
+      scrollCalls += 1;
+    },
+  } as unknown as XTerm;
+  const ctx = {
+    ...createContext(false),
+    isVisibleRef: { current: true },
+    terminalSettingsRef: {
+      current: {
+        showLineTimestamps: false,
+        scrollOnOutput: true,
+        forcePromptNewLine: false,
+      },
+    },
+  };
+
+  writeSessionData(ctx as never, term, "fresh output");
+
+  assert.equal(scrollCalls, 1);
+});
+
+test("visible output does not scroll when output auto-scroll is disabled", () => {
+  let scrollCalls = 0;
+  const term = {
+    buffer: {
+      active: {
+        type: "normal",
+        baseY: 10_000,
+        viewportY: 9_900,
+      },
+    },
+    write(_data: string, callback?: () => void) {
+      callback?.();
+    },
+    scrollToBottom() {
+      scrollCalls += 1;
+    },
+  } as unknown as XTerm;
+  const ctx = {
+    ...createContext(false),
+    isVisibleRef: { current: true },
+  };
+
+  writeSessionData(ctx as never, term, "fresh output");
+
+  assert.equal(scrollCalls, 0);
+});
+
 test("writeSessionData flushes deferred IPC acks before small output can leave the source paused", async () => {
   clearTerminalSessionFlowAck("session-1");
   const term = {

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -1,5 +1,8 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
-import { shouldScrollOnTerminalOutput } from "../../../domain/terminalScroll";
+import {
+  scrollTerminalToBottomIfNeeded,
+  shouldScrollOnTerminalOutput,
+} from "../../../domain/terminalScroll";
 import { logger } from "../../../lib/logger";
 import type { Host, TerminalSettings } from "../../../types";
 import {
@@ -116,7 +119,7 @@ const handleTerminalOutputAutoScroll = (
     return;
   }
 
-  term.scrollToBottom();
+  scrollTerminalToBottomIfNeeded(term);
 };
 
 export const notePendingOutputScrollIfEnabled = (

--- a/domain/terminalScroll.test.ts
+++ b/domain/terminalScroll.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  scrollTerminalToBottomAfterInputIfEnabled,
+  scrollTerminalToBottomIfNeeded,
+} from "./terminalScroll.ts";
+
+test("does not request another scroll when the terminal is already at the bottom", () => {
+  let scrollCalls = 0;
+  const terminal = {
+    buffer: {
+      active: {
+        baseY: 10_000,
+        viewportY: 10_000,
+      },
+    },
+    scrollToBottom() {
+      scrollCalls += 1;
+    },
+  };
+
+  const didScroll = scrollTerminalToBottomIfNeeded(terminal);
+
+  assert.equal(didScroll, false);
+  assert.equal(scrollCalls, 0);
+});
+
+test("scrolls to the bottom when the user is viewing earlier output", () => {
+  let scrollCalls = 0;
+  const terminal = {
+    buffer: {
+      active: {
+        baseY: 10_000,
+        viewportY: 9_900,
+      },
+    },
+    scrollToBottom() {
+      scrollCalls += 1;
+    },
+  };
+
+  const didScroll = scrollTerminalToBottomIfNeeded(terminal);
+
+  assert.equal(didScroll, true);
+  assert.equal(scrollCalls, 1);
+});
+
+test("printable input does not request another scroll when already at the bottom", () => {
+  let scrollCalls = 0;
+  const terminal = {
+    buffer: {
+      active: {
+        baseY: 10_000,
+        viewportY: 10_000,
+      },
+    },
+    scrollToBottom() {
+      scrollCalls += 1;
+    },
+  };
+
+  const didScroll = scrollTerminalToBottomAfterInputIfEnabled(
+    terminal,
+    { scrollOnInput: true },
+    "f",
+  );
+
+  assert.equal(didScroll, false);
+  assert.equal(scrollCalls, 0);
+});
+
+test("printable input still scrolls when the user is viewing earlier output", () => {
+  let scrollCalls = 0;
+  const terminal = {
+    buffer: {
+      active: {
+        baseY: 10_000,
+        viewportY: 9_900,
+      },
+    },
+    scrollToBottom() {
+      scrollCalls += 1;
+    },
+  };
+
+  const didScroll = scrollTerminalToBottomAfterInputIfEnabled(
+    terminal,
+    { scrollOnInput: true },
+    "f",
+  );
+
+  assert.equal(didScroll, true);
+  assert.equal(scrollCalls, 1);
+});

--- a/domain/terminalScroll.ts
+++ b/domain/terminalScroll.ts
@@ -1,5 +1,15 @@
 import type { TerminalSettings } from "./models";
 
+type TerminalScrollTarget = {
+  buffer: {
+    active: {
+      baseY: number;
+      viewportY: number;
+    };
+  };
+  scrollToBottom: () => void;
+};
+
 const hasPrintableTerminalInput = (data: string): boolean => {
   if (data.includes("\x1b")) {
     return false;
@@ -42,3 +52,27 @@ export const shouldScrollOnTerminalOutput = (
 export const shouldScrollOnTerminalPaste = (
   settings?: Partial<TerminalSettings> | null,
 ): boolean => settings?.scrollOnPaste ?? true;
+
+export const scrollTerminalToBottomIfNeeded = (
+  terminal: TerminalScrollTarget,
+): boolean => {
+  const { baseY, viewportY } = terminal.buffer.active;
+  if (viewportY >= baseY) {
+    return false;
+  }
+
+  terminal.scrollToBottom();
+  return true;
+};
+
+export const scrollTerminalToBottomAfterInputIfEnabled = (
+  terminal: TerminalScrollTarget,
+  settings: Partial<TerminalSettings> | null | undefined,
+  data: string,
+): boolean => {
+  if (!shouldScrollOnTerminalInput(settings, data)) {
+    return false;
+  }
+
+  return scrollTerminalToBottomIfNeeded(terminal);
+};


### PR DESCRIPTION
## Summary

Fixes #2306 by avoiding redundant terminal auto-scroll requests when the viewport is already at the bottom.

The reporter confirmed the decisive A/B result: the lag disappears in the affected maximized WebGL tab when **Scroll on input** is disabled. xterm's browser implementation refreshes the full viewport when `scrollToBottom()` is called, even when the scroll delta is zero. Netcatty was making that explicit call for every printable input, so a large maximized WebGL viewport could be redrawn on every keypress.

## Changes

- skip input and output auto-scroll calls when the active buffer is already at the bottom
- preserve the existing behavior when the user is viewing earlier scrollback
- apply the same input behavior to physical and programmatic input paths
- add regression coverage for full scrollback at-bottom, scrolled-up, enabled, and disabled cases

## Validation

- targeted regression tests: 43 passed
- ESLint: passed
- production build: passed
- `git diff --check`: passed
- two independent review rounds; final round clean from correctness, test/compatibility, and performance reviewers
- real Netcatty WebGL session against the provided SSH test host using the reporter's exact 1 MiB / 10,478-line sample:
  - 100-character continuous input displayed immediately after replay
  - manually scrolling into history and typing still returned the viewport to the bottom

The full local test run completed 5,929 passing tests, 7 skips, and one unrelated SSH authentication-retry test failure (`failed keyboard-interactive retry still offers encrypted default key fallback`). The failing SSH implementation and test files are unchanged by this PR; the failure also reproduced when rerun alone.

Fixes #2306
