### PR TITLE
fix(session logs): honor configured format for manual logs

### DIFF
--- a/application/state/useSessionLogBackend.ts
+++ b/application/state/useSessionLogBackend.ts
@@ -5,6 +5,8 @@ type ManualStartPayload = {
   sessionId: string;
   sessionName?: string;
   preferredDirectory?: string;
+  format?: "txt" | "raw" | "html";
+  timestampsEnabled?: boolean;
   initialLine?: string;
 };
 

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -2570,6 +2570,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         sessionId: currentSessionId,
         sessionName: host.label || host.hostname || currentSessionId,
         preferredDirectory: sessionLog?.directory,
+        format: sessionLog?.format,
+        timestampsEnabled: sessionLog?.timestampsEnabled,
         initialLine: termRef.current ? getSessionLogInitialLine(termRef.current) : "",
       });
       if (startResult?.success) {
@@ -2588,6 +2590,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     host.label,
     sessionId,
     sessionLog?.directory,
+    sessionLog?.format,
+    sessionLog?.timestampsEnabled,
     startManualSessionLog,
     stopManualSessionLog,
   ]);

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -2558,9 +2558,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       const currentStatus = await getManualSessionLogStatus({ sessionId: currentSessionId });
       if (currentStatus?.isLogging) {
         const stopResult = await stopManualSessionLog({ sessionId: currentSessionId });
-        if (stopResult?.success) {
+        if (stopResult?.stopped) {
           setIsSessionLogging(false);
-        } else {
+        }
+        if (!stopResult?.success) {
           toast.error(stopResult?.error || "Failed to stop session log");
         }
         return;

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -1564,10 +1564,12 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   }, [isBroadcastEnabled, terminalBackend]);
 
   const sessionLogConfig = useMemo(
-    () =>
-      sessionLogsEnabled && sessionLogsDir
-        ? { enabled: true as const, directory: sessionLogsDir, format: sessionLogsFormat || 'txt', timestampsEnabled: sessionLogsTimestampsEnabled }
-        : undefined,
+    () => ({
+      enabled: Boolean(sessionLogsEnabled && sessionLogsDir),
+      directory: sessionLogsDir,
+      format: sessionLogsFormat || 'txt',
+      timestampsEnabled: sessionLogsTimestampsEnabled,
+    }),
     [sessionLogsDir, sessionLogsEnabled, sessionLogsFormat, sessionLogsTimestampsEnabled],
   );
 

--- a/components/settings/tabs/SettingsSystemTab.tsx
+++ b/components/settings/tabs/SettingsSystemTab.tsx
@@ -966,7 +966,6 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
                   options={formatOptions}
                   onChange={(val) => setSessionLogsFormat(val as SessionLogFormat)}
                   className="w-44"
-                  disabled={!sessionLogsEnabled}
                 />
               </SettingRow>
 
@@ -977,7 +976,6 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
                 <Toggle
                   checked={sessionLogsTimestampsEnabled}
                   onChange={setSessionLogsTimestampsEnabled}
-                  disabled={!sessionLogsEnabled}
                 />
               </SettingRow>
             </SettingCard>

--- a/components/terminal/terminalHelpers.ts
+++ b/components/terminal/terminalHelpers.ts
@@ -205,7 +205,7 @@ export interface TerminalProps {
     sessionId: string,
     queueRewrite: ((rewrite: ProgrammaticCommandLogRewrite) => void) | null,
   ) => void;
-  sessionLog?: { enabled: boolean; directory: string; format: string; timestampsEnabled?: boolean };
+  sessionLog?: { enabled: boolean; directory: string; format: "txt" | "raw" | "html"; timestampsEnabled?: boolean };
   sshDebugLogEnabled?: boolean;
   sudoAutofillPassword?: string;
   /** Host + keychain password identities for picker mode (#2156). */

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -687,7 +687,7 @@ export interface TerminalLayerProps {
   // Session log settings for real-time streaming
   sessionLogsEnabled?: boolean;
   sessionLogsDir?: string;
-  sessionLogsFormat?: string;
+  sessionLogsFormat?: "txt" | "raw" | "html";
   sessionLogsTimestampsEnabled?: boolean;
   sshDebugLogsEnabled?: boolean;
   showHostTreeSidebar?: boolean;
@@ -731,7 +731,7 @@ interface TerminalPaneProps {
   keyBindings?: KeyBinding[];
   isResizing: boolean;
   isComposeBarOpen: boolean;
-  sessionLog?: { enabled: true; directory: string; format: string; timestampsEnabled?: boolean };
+  sessionLog?: { enabled: boolean; directory: string; format: "txt" | "raw" | "html"; timestampsEnabled?: boolean };
   sshDebugLogEnabled?: boolean;
   onHotkeyAction?: (action: string, event: KeyboardEvent) => void;
   onTerminalFontSizeChange?: (sessionId: string, fontSize: number) => void;
@@ -1472,7 +1472,7 @@ interface TerminalPanesHostProps {
   keyBindings?: KeyBinding[];
   isResizing: boolean;
   isComposeBarOpen: boolean;
-  sessionLog?: { enabled: true; directory: string; format: string; timestampsEnabled?: boolean };
+  sessionLog?: { enabled: boolean; directory: string; format: "txt" | "raw" | "html"; timestampsEnabled?: boolean };
   sshDebugLogEnabled?: boolean;
   onHotkeyAction?: (action: string, event: KeyboardEvent) => void;
   onTerminalFontSizeChange?: TerminalPaneProps['onTerminalFontSizeChange'];

--- a/electron/bridges/sessionLogStreamManager.cjs
+++ b/electron/bridges/sessionLogStreamManager.cjs
@@ -471,7 +471,7 @@ async function stopStream(sessionId, expectedToken) {
   const finalPath = entry.filePath;
 
   console.log(`[SessionLogStream] Stopped stream for ${sessionId} -> ${finalPath}`);
-  return finalPath;
+  return entry.disabled ? null : finalPath;
 }
 
 /**

--- a/electron/bridges/sessionLogsBridge.cjs
+++ b/electron/bridges/sessionLogsBridge.cjs
@@ -14,6 +14,7 @@ const {
 const FILE_NAME_UNSAFE_CHARS = new Set(["<", ">", ":", "\"", "/", "\\", "|", "?", "*"]);
 const WINDOWS_RESERVED_DEVICE_NAME = /^(con|prn|aux|nul|com[1-9¹²³]|lpt[1-9¹²³])(?:\..*)?$/i;
 const manualSessionLogTokens = new Map();
+const SESSION_LOG_FORMATS = new Set(["txt", "raw", "html"]);
 
 function isControlCharacter(char) {
   const code = char.codePointAt(0);
@@ -266,14 +267,16 @@ async function startManualSessionLog(event, payload = {}) {
   const targetDirectory = typeof preferredDirectory === "string" && preferredDirectory.trim()
     ? preferredDirectory.trim()
     : require("node:os").homedir();
+  const format = SESSION_LOG_FORMATS.has(payload.format) ? payload.format : "raw";
+  const extension = format === "raw" ? "log" : format;
   const safeSessionName = safePathSegment(sessionName || sessionId, "session");
-  const defaultPath = path.join(targetDirectory, `${safeSessionName}_${toLocalISOString(new Date())}.log`);
+  const defaultPath = path.join(targetDirectory, `${safeSessionName}_${toLocalISOString(new Date())}.${extension}`);
 
   try {
     const result = await dialog.showSaveDialog({
       defaultPath,
       filters: [
-        { name: "Log Files", extensions: ["log"] },
+        { name: format === "txt" ? "Text Files" : format === "html" ? "HTML Files" : "Log Files", extensions: [extension] },
         { name: "All Files", extensions: ["*"] },
       ],
     });
@@ -282,16 +285,17 @@ async function startManualSessionLog(event, payload = {}) {
       return { success: true, started: false, canceled: true };
     }
 
-    const filePath = normalizeManualSessionLogFilePath(result.filePath);
+    const filePath = normalizeManualSessionLogFilePath(result.filePath, extension);
     if (filePath !== result.filePath && !(await confirmManualSessionLogOverwrite(filePath))) {
       return { success: true, started: false, canceled: true };
     }
 
     const startResult = sessionLogStreamManager.startStreamToFile(sessionId, {
       filePath,
-      format: "raw",
+      format,
       hostLabel: safeSessionName,
       startTime: Date.now(),
+      timestampsEnabled: Boolean(payload.timestampsEnabled),
       initialLine: typeof initialLine === "string" ? initialLine : "",
       separateInitialLineBeforeLeadingCarriageReturn: true,
       stopRequiresToken: true,
@@ -308,8 +312,8 @@ async function startManualSessionLog(event, payload = {}) {
   }
 }
 
-function normalizeManualSessionLogFilePath(filePath) {
-  return path.extname(filePath).toLowerCase() === ".log" ? filePath : `${filePath}.log`;
+function normalizeManualSessionLogFilePath(filePath, extension = "log") {
+  return path.extname(filePath).toLowerCase() === `.${extension}` ? filePath : `${filePath}.${extension}`;
 }
 
 async function confirmManualSessionLogOverwrite(filePath) {

--- a/electron/bridges/sessionLogsBridge.cjs
+++ b/electron/bridges/sessionLogsBridge.cjs
@@ -356,6 +356,7 @@ async function stopManualSessionLog(event, payload = {}) {
     if (!filePath) {
       if (!sessionLogStreamManager.hasStream(sessionId)) {
         manualSessionLogTokens.delete(sessionId);
+        return { success: false, stopped: false, error: "Failed to finalize session log" };
       }
       return { success: true, stopped: false };
     }

--- a/electron/bridges/sessionLogsBridge.cjs
+++ b/electron/bridges/sessionLogsBridge.cjs
@@ -269,7 +269,8 @@ async function startManualSessionLog(event, payload = {}) {
     : require("node:os").homedir();
   const format = SESSION_LOG_FORMATS.has(payload.format) ? payload.format : "raw";
   const extension = format === "raw" ? "log" : format;
-  const safeSessionName = safePathSegment(sessionName || sessionId, "session");
+  const displaySessionName = sessionName || sessionId;
+  const safeSessionName = safePathSegment(displaySessionName, "session");
   const defaultPath = path.join(targetDirectory, `${safeSessionName}_${toLocalISOString(new Date())}.${extension}`);
 
   try {
@@ -293,7 +294,7 @@ async function startManualSessionLog(event, payload = {}) {
     const startResult = sessionLogStreamManager.startStreamToFile(sessionId, {
       filePath,
       format,
-      hostLabel: safeSessionName,
+      hostLabel: displaySessionName,
       startTime: Date.now(),
       timestampsEnabled: Boolean(payload.timestampsEnabled),
       initialLine: typeof initialLine === "string" ? initialLine : "",

--- a/electron/bridges/sessionLogsBridge.cjs
+++ b/electron/bridges/sessionLogsBridge.cjs
@@ -356,7 +356,7 @@ async function stopManualSessionLog(event, payload = {}) {
     if (!filePath) {
       if (!sessionLogStreamManager.hasStream(sessionId)) {
         manualSessionLogTokens.delete(sessionId);
-        return { success: false, stopped: false, error: "Failed to finalize session log" };
+        return { success: false, stopped: true, error: "Failed to finalize session log" };
       }
       return { success: true, stopped: false };
     }

--- a/electron/bridges/sessionLogsBridge.test.cjs
+++ b/electron/bridges/sessionLogsBridge.test.cjs
@@ -303,11 +303,14 @@ test("manual session logs honor the configured plain-text format", async () => {
     assert.match(dialogOptions.defaultPath, /\.txt$/);
     assert.deepEqual(dialogOptions.filters[0], { name: "Text Files", extensions: ["txt"] });
 
-    sessionLogStreamManager.appendData(sessionId, "\u001b[31mls\u001b[0m\r\nfile\r\n");
+    sessionLogStreamManager.appendData(
+      sessionId,
+      "\u001b[31mdisplay\u001b[0m\r\npage 1\r\n--More--\r        \rpage 2\r\n",
+    );
     const stopResult = await stopManualSessionLog(null, { sessionId });
 
     assert.equal(stopResult.filePath, expectedPath);
-    assert.equal(fs.readFileSync(expectedPath, "utf8"), "root@host:~# ls\nfile");
+    assert.equal(fs.readFileSync(expectedPath, "utf8"), "root@host:~# display\npage 1\npage 2");
   } finally {
     await sessionLogStreamManager.cleanupAll();
     fs.rmSync(directory, { recursive: true, force: true });

--- a/electron/bridges/sessionLogsBridge.test.cjs
+++ b/electron/bridges/sessionLogsBridge.test.cjs
@@ -387,7 +387,7 @@ test("manual rendered logs report final write failures", async () => {
 
     assert.deepEqual(stopResult, {
       success: false,
-      stopped: false,
+      stopped: true,
       error: "Failed to finalize session log",
     });
   } finally {

--- a/electron/bridges/sessionLogsBridge.test.cjs
+++ b/electron/bridges/sessionLogsBridge.test.cjs
@@ -355,6 +355,48 @@ test("manual session logs honor HTML format and timestamps", async () => {
   }
 });
 
+test("manual rendered logs report final write failures", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-write-failure-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const filePath = path.join(directory, "manual.txt");
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const dialogMock = {
+    showSaveDialog: async () => ({ canceled: false, filePath }),
+  };
+  const {
+    startManualSessionLog,
+    stopManualSessionLog,
+  } = loadBridgeWithDialog(dialogMock);
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+  const originalWriteFile = fs.promises.writeFile;
+
+  try {
+    const startResult = await startManualSessionLog(null, {
+      sessionId,
+      sessionName: "failing host",
+      preferredDirectory: directory,
+      format: "txt",
+      initialLine: "",
+    });
+    assert.equal(startResult.success, true);
+    sessionLogStreamManager.appendData(sessionId, "body\r\n");
+
+    fs.promises.writeFile = async () => {
+      throw new Error("disk full");
+    };
+    const stopResult = await stopManualSessionLog(null, { sessionId });
+
+    assert.deepEqual(stopResult, {
+      success: false,
+      stopped: false,
+      error: "Failed to finalize session log",
+    });
+  } finally {
+    fs.promises.writeFile = originalWriteFile;
+    await sessionLogStreamManager.cleanupAll();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("registerHandlers taps terminal worker output into main-process manual session logs", async () => {
   const directory = path.join(TEMP_ROOT, `manual-worker-tap-${Date.now()}-${Math.random().toString(16).slice(2)}`);
   const filePath = path.join(directory, "manual.log");

--- a/electron/bridges/sessionLogsBridge.test.cjs
+++ b/electron/bridges/sessionLogsBridge.test.cjs
@@ -272,6 +272,85 @@ test("manual session log save dialog only offers log files and normalizes extens
   }
 });
 
+test("manual session logs honor the configured plain-text format", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-txt-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const selectedPath = path.join(directory, "manual");
+  const expectedPath = `${selectedPath}.txt`;
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  let dialogOptions;
+  const dialogMock = {
+    showSaveDialog: async (options) => {
+      dialogOptions = options;
+      return { canceled: false, filePath: selectedPath };
+    },
+  };
+  const {
+    startManualSessionLog,
+    stopManualSessionLog,
+  } = loadBridgeWithDialog(dialogMock);
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+
+  try {
+    const startResult = await startManualSessionLog(null, {
+      sessionId,
+      sessionName: "Linux host",
+      preferredDirectory: directory,
+      format: "txt",
+      initialLine: "root@host:~# ",
+    });
+    assert.equal(startResult.success, true);
+    assert.equal(startResult.filePath, expectedPath);
+    assert.match(dialogOptions.defaultPath, /\.txt$/);
+    assert.deepEqual(dialogOptions.filters[0], { name: "Text Files", extensions: ["txt"] });
+
+    sessionLogStreamManager.appendData(sessionId, "\u001b[31mls\u001b[0m\r\nfile\r\n");
+    const stopResult = await stopManualSessionLog(null, { sessionId });
+
+    assert.equal(stopResult.filePath, expectedPath);
+    assert.equal(fs.readFileSync(expectedPath, "utf8"), "root@host:~# ls\nfile");
+  } finally {
+    await sessionLogStreamManager.cleanupAll();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("manual session logs honor HTML format and timestamps", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-html-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const filePath = path.join(directory, "manual.html");
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const dialogMock = {
+    showSaveDialog: async () => ({ canceled: false, filePath }),
+  };
+  const {
+    startManualSessionLog,
+    stopManualSessionLog,
+  } = loadBridgeWithDialog(dialogMock);
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+
+  try {
+    const startResult = await startManualSessionLog(null, {
+      sessionId,
+      sessionName: "HTML host",
+      preferredDirectory: directory,
+      format: "html",
+      timestampsEnabled: true,
+      initialLine: "",
+    });
+    assert.equal(startResult.success, true);
+
+    sessionLogStreamManager.appendData(sessionId, "ready\r\n");
+    await stopManualSessionLog(null, { sessionId });
+
+    const content = fs.readFileSync(filePath, "utf8");
+    assert.match(content, /<!DOCTYPE html>/);
+    assert.match(content, /HTML host/);
+    assert.match(content, /\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] ready/);
+  } finally {
+    await sessionLogStreamManager.cleanupAll();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("registerHandlers taps terminal worker output into main-process manual session logs", async () => {
   const directory = path.join(TEMP_ROOT, `manual-worker-tap-${Date.now()}-${Math.random().toString(16).slice(2)}`);
   const filePath = path.join(directory, "manual.log");

--- a/electron/bridges/sessionLogsBridge.test.cjs
+++ b/electron/bridges/sessionLogsBridge.test.cjs
@@ -333,7 +333,7 @@ test("manual session logs honor HTML format and timestamps", async () => {
   try {
     const startResult = await startManualSessionLog(null, {
       sessionId,
-      sessionName: "HTML host",
+      sessionName: "HTML / host:22",
       preferredDirectory: directory,
       format: "html",
       timestampsEnabled: true,
@@ -346,7 +346,8 @@ test("manual session logs honor HTML format and timestamps", async () => {
 
     const content = fs.readFileSync(filePath, "utf8");
     assert.match(content, /<!DOCTYPE html>/);
-    assert.match(content, /HTML host/);
+    assert.match(content, /HTML \/ host:22/);
+    assert.doesNotMatch(content, /HTML _ host_22/);
     assert.match(content, /\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] ready/);
   } finally {
     await sessionLogStreamManager.cleanupAll();

--- a/types/global/netcatty-bridge-files.d.ts
+++ b/types/global/netcatty-bridge-files.d.ts
@@ -102,6 +102,8 @@ declare global {
       sessionId: string;
       sessionName?: string;
       preferredDirectory?: string;
+      format?: 'txt' | 'raw' | 'html';
+      timestampsEnabled?: boolean;
       initialLine?: string;
     }): Promise<{ success: boolean; started: boolean; canceled?: boolean; error?: string; filePath?: string }>;
     stopManualSessionLog?(payload: {


### PR DESCRIPTION
## Summary

- use the configured session log format for toolbar-started manual logs
- keep format and timestamp settings available when auto-save is disabled
- save manual logs with the matching `.txt`, `.log`, or `.html` extension
- preserve the existing raw format as the fallback for older callers
- surface final file-write failures instead of reporting a successful stop

Closes #2309

## Validation

- `node --test electron/bridges/sessionLogsBridge.test.cjs electron/bridges/sessionLogStreamManager.test.cjs` (42 passed)
- `npm run lint -- --quiet`
- `npm run build`
- `git diff --check`

`npx tsc --noEmit` still reports the repository's existing unrelated type errors; the changed paths introduced no new matching diagnostics.
