### PR TITLE
Improve SFTP sorting and keyboard navigation

### DIFF
--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -176,6 +176,7 @@ export const enVaultMessages: Messages = {
   'sftp.columns.kind': 'Kind',
   'sftp.columns.configure': 'Choose visible columns',
   'sftp.columns.actions': 'Actions',
+  'sftp.sort.directoriesFirst': 'Folders first',
   'sftp.emptyDirectory': 'Empty directory',
   'sftp.nav.up': 'Go up',
   'sftp.nav.home': 'Go to home',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -211,6 +211,7 @@ export const ruVaultMessages: Messages = {
   'sftp.columns.kind': 'Тип',
   'sftp.columns.configure': 'Выбрать видимые столбцы',
   'sftp.columns.actions': 'Действия',
+  'sftp.sort.directoriesFirst': 'Папки сверху',
   'sftp.emptyDirectory': 'Пустой каталог',
   'sftp.nav.up': 'Наверх',
   'sftp.nav.home': 'Перейти в домашний каталог',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -744,6 +744,7 @@ export const zhCNCoreMessages: Messages = {
   'sftp.columns.size': '大小',
   'sftp.columns.kind': '类型',
   'sftp.columns.actions': '操作',
+  'sftp.sort.directoriesFirst': '目录置顶',
   'sftp.emptyDirectory': '空目录',
   'sftp.nav.up': '返回上层',
   'sftp.nav.home': '返回主目录',

--- a/application/i18n/locales/zh-TW/core.ts
+++ b/application/i18n/locales/zh-TW/core.ts
@@ -744,6 +744,7 @@ export const zhTWCoreMessages: Messages = {
   'sftp.columns.size': '大小',
   'sftp.columns.kind': '型別',
   'sftp.columns.actions': '操作',
+  'sftp.sort.directoriesFirst': '資料夾置頂',
   'sftp.emptyDirectory': '空目錄',
   'sftp.nav.up': '返回上層',
   'sftp.nav.home': '返回主目錄',

--- a/application/state/sftp/sftpPaneViewModeStore.test.ts
+++ b/application/state/sftp/sftpPaneViewModeStore.test.ts
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { sftpPaneViewModeStore } from './sftpPaneViewModeStore.ts';
+
+test('SFTP pane view mode store distinguishes an empty list from tree view', () => {
+  const paneId = 'empty-list-pane';
+  assert.equal(sftpPaneViewModeStore.get(paneId), 'list');
+
+  sftpPaneViewModeStore.set(paneId, 'tree');
+  assert.equal(sftpPaneViewModeStore.get(paneId), 'tree');
+
+  sftpPaneViewModeStore.set(paneId, 'list');
+  assert.equal(sftpPaneViewModeStore.get(paneId), 'list');
+  sftpPaneViewModeStore.clear(paneId);
+});

--- a/application/state/sftp/sftpPaneViewModeStore.ts
+++ b/application/state/sftp/sftpPaneViewModeStore.ts
@@ -1,0 +1,13 @@
+import type { SftpViewMode } from '../../../domain/sftpTypeahead';
+
+const paneViewModes = new Map<string, SftpViewMode>();
+
+export const sftpPaneViewModeStore = {
+  get: (paneId: string): SftpViewMode => paneViewModes.get(paneId) ?? 'list',
+  set: (paneId: string, viewMode: SftpViewMode) => {
+    paneViewModes.set(paneId, viewMode);
+  },
+  clear: (paneId: string) => {
+    paneViewModes.delete(paneId);
+  },
+};

--- a/application/state/sftp/useSftpDirectoriesFirst.ts
+++ b/application/state/sftp/useSftpDirectoriesFirst.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useState } from "react";
+import { STORAGE_KEY_SFTP_DIRECTORIES_FIRST } from "../../../infrastructure/config/storageKeys";
+import {
+  LOCAL_STORAGE_ADAPTER_CHANGED_EVENT,
+  localStorageAdapter,
+} from "../../../infrastructure/persistence/localStorageAdapter";
+
+export const useSftpDirectoriesFirst = () => {
+  const [directoriesFirst, setDirectoriesFirst] = useState(
+    () => localStorageAdapter.readBoolean(STORAGE_KEY_SFTP_DIRECTORIES_FIRST) ?? true,
+  );
+
+  useEffect(() => {
+    const syncDirectoriesFirst = (event: Event) => {
+      if (event instanceof StorageEvent && event.key !== STORAGE_KEY_SFTP_DIRECTORIES_FIRST) return;
+      if (event instanceof CustomEvent && event.detail?.key !== STORAGE_KEY_SFTP_DIRECTORIES_FIRST) return;
+      setDirectoriesFirst(
+        localStorageAdapter.readBoolean(STORAGE_KEY_SFTP_DIRECTORIES_FIRST) ?? true,
+      );
+    };
+
+    window.addEventListener("storage", syncDirectoriesFirst);
+    window.addEventListener(LOCAL_STORAGE_ADAPTER_CHANGED_EVENT, syncDirectoriesFirst);
+    return () => {
+      window.removeEventListener("storage", syncDirectoriesFirst);
+      window.removeEventListener(LOCAL_STORAGE_ADAPTER_CHANGED_EVENT, syncDirectoriesFirst);
+    };
+  }, []);
+
+  const toggleDirectoriesFirst = useCallback(() => {
+    setDirectoriesFirst((current) => {
+      const next = !current;
+      localStorageAdapter.writeBoolean(STORAGE_KEY_SFTP_DIRECTORIES_FIRST, next);
+      return next;
+    });
+  }, []);
+
+  return { directoriesFirst, toggleDirectoriesFirst };
+};

--- a/components/sftp/SftpColumnMenuItems.tsx
+++ b/components/sftp/SftpColumnMenuItems.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useI18n } from '../../application/i18n/I18nProvider';
+import {
+  ContextMenuCheckboxItem,
+  ContextMenuSeparator,
+} from '../ui/context-menu';
+import type { ColumnWidths, SftpColumnVisibility } from './utils';
+
+interface SftpColumnMenuItemsProps {
+  visibleColumns: SftpColumnVisibility;
+  directoriesFirst: boolean;
+  toggleColumnVisibility: (field: keyof ColumnWidths) => void;
+  toggleDirectoriesFirst: () => void;
+}
+
+export const SftpColumnMenuItems: React.FC<SftpColumnMenuItemsProps> = ({
+  visibleColumns,
+  directoriesFirst,
+  toggleColumnVisibility,
+  toggleDirectoriesFirst,
+}) => {
+  const { t } = useI18n();
+
+  return (
+    <>
+      <ContextMenuCheckboxItem checked disabled>
+        {t('sftp.columns.name')}
+      </ContextMenuCheckboxItem>
+      {(['modified', 'size', 'type'] as const).map((field) => (
+        <ContextMenuCheckboxItem
+          key={field}
+          checked={visibleColumns[field]}
+          onCheckedChange={() => toggleColumnVisibility(field)}
+        >
+          {t(field === 'type' ? 'sftp.columns.kind' : `sftp.columns.${field}`)}
+        </ContextMenuCheckboxItem>
+      ))}
+      <ContextMenuSeparator />
+      <ContextMenuCheckboxItem
+        checked={directoriesFirst}
+        onCheckedChange={toggleDirectoriesFirst}
+      >
+        {t('sftp.sort.directoriesFirst')}
+      </ContextMenuCheckboxItem>
+    </>
+  );
+};

--- a/components/sftp/SftpPaneFileList.tsx
+++ b/components/sftp/SftpPaneFileList.tsx
@@ -5,6 +5,7 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuSeparator,
   ContextMenuTrigger,
 } from "../ui/context-menu";
 import { cn } from "../../lib/utils";

--- a/components/sftp/SftpPaneFileList.tsx
+++ b/components/sftp/SftpPaneFileList.tsx
@@ -3,10 +3,8 @@ import { AppWindow, ArrowDown, ArrowRight, ArrowUp, ChevronDown, ClipboardCopy, 
 import { Button } from "../ui/button";
 import {
   ContextMenu,
-  ContextMenuCheckboxItem,
   ContextMenuContent,
   ContextMenuItem,
-  ContextMenuSeparator,
   ContextMenuTrigger,
 } from "../ui/context-menu";
 import { cn } from "../../lib/utils";
@@ -15,9 +13,12 @@ import type { SftpFileEntry } from "../../types";
 import type { SftpPane } from "../../application/state/sftp/types";
 import type { SftpTransferSource } from "./SftpContext";
 import { sftpListOrderStore } from "./hooks/useSftpListOrderStore";
-import { buildSftpColumnTemplate, isNavigableDirectory, isSftpColumnMenuKey, type ColumnWidths, type SftpColumnVisibility, type SortField, type SortOrder } from "./utils";
+import type { UseSftpPaneSortingResult } from "./hooks/useSftpPaneSorting";
+import { buildSftpColumnTemplate, isNavigableDirectory, isSftpColumnMenuKey } from "./utils";
 import { isKnownBinaryFile } from "../../lib/sftpFileUtils";
 import { SftpFileRow } from "./SftpFileRow";
+import { SftpColumnMenuItems } from "./SftpColumnMenuItems";
+import { getSftpVirtualListScrollTop } from "../../domain/sftpVirtualList";
 import {
   getSftpListUploadFilesTargetPath,
   getSftpUploadFilesLabelKey,
@@ -31,13 +32,7 @@ interface SftpPaneFileListProps {
   pane: SftpPane;
   side: "left" | "right";
   isPaneFocused: boolean;
-  columnWidths: ColumnWidths;
-  visibleColumns: SftpColumnVisibility;
-  sortField: SortField;
-  sortOrder: SortOrder;
-  handleSort: (field: SortField) => void;
-  handleResizeStart: (field: keyof ColumnWidths, e: React.MouseEvent) => void;
-  toggleColumnVisibility: (field: keyof ColumnWidths) => void;
+  sorting: UseSftpPaneSortingResult;
   fileListRef: React.RefObject<HTMLDivElement>;
   handleFileListScroll: (e: React.UIEvent<HTMLDivElement>) => void;
   shouldVirtualize: boolean;
@@ -126,13 +121,7 @@ export const SftpPaneFileList: React.FC<SftpPaneFileListProps> = React.memo(({
   pane,
   side,
   isPaneFocused,
-  columnWidths,
-  visibleColumns,
-  sortField,
-  sortOrder,
-  handleSort,
-  handleResizeStart,
-  toggleColumnVisibility,
+  sorting,
   fileListRef,
   handleFileListScroll,
   shouldVirtualize,
@@ -172,6 +161,17 @@ export const SftpPaneFileList: React.FC<SftpPaneFileListProps> = React.memo(({
   rowHeight,
   visibleRows,
 }) => {
+  const {
+    columnWidths,
+    visibleColumns,
+    directoriesFirst,
+    sortField,
+    sortOrder,
+    handleSort,
+    handleResizeStart,
+    toggleColumnVisibility,
+    toggleDirectoriesFirst,
+  } = sorting;
   const filesByName = useMemo(() => {
     const map = new Map<string, SftpFileEntry>();
     sortedDisplayFiles.forEach((entry) => {
@@ -199,8 +199,21 @@ export const SftpPaneFileList: React.FC<SftpPaneFileListProps> = React.memo(({
 
     const row = Array.from(container.querySelectorAll<HTMLElement>('[data-sftp-row="true"]'))
       .find((element) => element.dataset.entryName === selectedName);
-    row?.scrollIntoView({ block: "nearest" });
-  }, [fileListRef, pane.selectedFiles]);
+    if (row) {
+      row.scrollIntoView({ block: "nearest" });
+      return;
+    }
+
+    if (!shouldVirtualize || rowHeight <= 0) return;
+    const itemIndex = sortedDisplayFiles.findIndex((entry) => entry.name === selectedName);
+    if (itemIndex < 0) return;
+    container.scrollTop = getSftpVirtualListScrollTop({
+      itemIndex,
+      rowHeight,
+      currentScrollTop: container.scrollTop,
+      viewportHeight: container.clientHeight,
+    });
+  }, [fileListRef, pane.selectedFiles, rowHeight, shouldVirtualize, sortedDisplayFiles]);
 
   // Use refs for frequently-changing values in context-menu actions
   const selectedFilesRef = useRef(pane.selectedFiles);
@@ -597,18 +610,12 @@ export const SftpPaneFileList: React.FC<SftpPaneFileListProps> = React.memo(({
         </div>
       </ContextMenuTrigger>
       <ContextMenuContent>
-        <ContextMenuCheckboxItem checked disabled>
-          {t("sftp.columns.name")}
-        </ContextMenuCheckboxItem>
-        {(["modified", "size", "type"] as const).map((field) => (
-          <ContextMenuCheckboxItem
-            key={field}
-            checked={visibleColumns[field]}
-            onCheckedChange={() => toggleColumnVisibility(field)}
-          >
-            {t(field === "type" ? "sftp.columns.kind" : `sftp.columns.${field}`)}
-          </ContextMenuCheckboxItem>
-        ))}
+        <SftpColumnMenuItems
+          visibleColumns={visibleColumns}
+          directoriesFirst={directoriesFirst}
+          toggleColumnVisibility={toggleColumnVisibility}
+          toggleDirectoriesFirst={toggleDirectoriesFirst}
+        />
       </ContextMenuContent>
     </ContextMenu>
 

--- a/components/sftp/SftpPaneTreeView.tsx
+++ b/components/sftp/SftpPaneTreeView.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { AlertCircle, Loader2, RefreshCw } from 'lucide-react';
 import { Button } from '../ui/button';
-import { ContextMenu, ContextMenuCheckboxItem, ContextMenuContent, ContextMenuTrigger } from '../ui/context-menu';
-import { type NodeDescriptor } from './SftpPaneTreeNode';
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from '../ui/context-menu';
+import { TREE_ROW_HEIGHT, type NodeDescriptor } from './SftpPaneTreeNode';
 import { INITIAL_TREE_PATHS_STATE, treePathsReducer } from './sftpTreePathsReducer';
 import { useSftpPaneTreeContextMenu } from './useSftpPaneTreeContextMenu';
 import { useSftpPaneTreeRows } from './useSftpPaneTreeRows';
@@ -15,6 +15,7 @@ import type { SftpPaneTreeViewProps } from './SftpPaneTreeView.types';
 import { sftpTreeSelectionStore, useSftpTreeSelectionState } from './hooks/useSftpTreeSelectionStore';
 import { sftpKeyboardSelectionStore, sftpTreeEnterStore } from './hooks/useSftpKeyboardShortcuts';
 import { useI18n } from '../../application/i18n/I18nProvider';
+import { SftpColumnMenuItems } from './SftpColumnMenuItems';
 import {
   shouldShowSftpUploadFolderMenu,
   shouldShowSftpUploadFilesMenu,
@@ -50,15 +51,20 @@ export const SftpPaneTreeView = React.memo<SftpPaneTreeViewProps>(({
   onUploadExternalFiles,
   onUploadExternalFileList,
   onUploadExternalFolder,
-  columnWidths,
-  visibleColumns,
-  handleSort,
-  handleResizeStart,
-  toggleColumnVisibility,
-  sortField,
-  sortOrder,
+  sorting,
   reloadRequest,
 }) => {
+  const {
+    columnWidths,
+    visibleColumns,
+    directoriesFirst,
+    handleSort,
+    handleResizeStart,
+    toggleColumnVisibility,
+    toggleDirectoriesFirst,
+    sortField,
+    sortOrder,
+  } = sorting;
   const { t } = useI18n();
   const columnTemplate = buildSftpColumnTemplate(columnWidths, visibleColumns);
   const tRef = useRef(t);
@@ -219,8 +225,8 @@ export const SftpPaneTreeView = React.memo<SftpPaneTreeViewProps>(({
     childrenCacheRef.current.delete(targetPath);
     sortedChildrenCacheRef.current.delete(targetPath);
   }, []);
-  const prevSortKeyRef = useRef(`${sortField}:${sortOrder}:${pane.showHiddenFiles}`);
-  const sortKey = `${sortField}:${sortOrder}:${pane.showHiddenFiles}`;
+  const prevSortKeyRef = useRef(`${sortField}:${sortOrder}:${directoriesFirst}:${pane.showHiddenFiles}`);
+  const sortKey = `${sortField}:${sortOrder}:${directoriesFirst}:${pane.showHiddenFiles}`;
   if (prevSortKeyRef.current !== sortKey) {
     prevSortKeyRef.current = sortKey;
     sortedChildrenCacheRef.current.clear();
@@ -470,7 +476,12 @@ export const SftpPaneTreeView = React.memo<SftpPaneTreeViewProps>(({
     const getSortedEntries = (entries: SftpFileEntry[], parentPath: string): SftpFileEntry[] => {
       const cached = sortedChildrenCacheRef.current.get(parentPath);
       if (cached) return cached;
-      const sorted = sortSftpEntries(filterHiddenFiles(entries, pane.showHiddenFiles), sortField, sortOrder);
+      const sorted = sortSftpEntries(
+        filterHiddenFiles(entries, pane.showHiddenFiles),
+        sortField,
+        sortOrder,
+        directoriesFirst,
+      );
       sortedChildrenCacheRef.current.set(parentPath, sorted);
       return sorted;
     };
@@ -507,12 +518,31 @@ export const SftpPaneTreeView = React.memo<SftpPaneTreeViewProps>(({
     pane.showHiddenFiles,
     sortField,
     sortOrder,
+    directoriesFirst,
     expandedPaths,
     loadingPaths,
     errorPaths,
   ]);
   const entryByPathRef = useRef(entryByPath);
   entryByPathRef.current = entryByPath;
+  useEffect(() => {
+    if (selectedPaths.size !== 1) return;
+    const selectedPath = selectedPaths.values().next().value;
+    if (!selectedPath) return;
+    const selectedIndex = nodeDescriptors.findIndex(
+      (descriptor) => descriptor.type === 'node' && descriptor.entryPath === selectedPath,
+    );
+    const container = scrollContainerRef.current;
+    if (selectedIndex < 0 || !container) return;
+
+    const rowTop = selectedIndex * TREE_ROW_HEIGHT;
+    const rowBottom = rowTop + TREE_ROW_HEIGHT;
+    if (rowTop < container.scrollTop) {
+      container.scrollTop = rowTop;
+    } else if (rowBottom > container.scrollTop + container.clientHeight) {
+      container.scrollTop = rowBottom - container.clientHeight;
+    }
+  }, [nodeDescriptors, selectedPaths]);
   const prevVisiblePathsRef = useRef<string[]>([]);
   useEffect(() => {
     const currentPaths = flatVisibleNodes
@@ -929,18 +959,12 @@ export const SftpPaneTreeView = React.memo<SftpPaneTreeViewProps>(({
           </div>
         </ContextMenuTrigger>
         <ContextMenuContent>
-          <ContextMenuCheckboxItem checked disabled>
-            {t('sftp.columns.name')}
-          </ContextMenuCheckboxItem>
-          {(['modified', 'size', 'type'] as const).map((field) => (
-            <ContextMenuCheckboxItem
-              key={field}
-              checked={visibleColumns[field]}
-              onCheckedChange={() => toggleColumnVisibility(field)}
-            >
-              {t(field === 'type' ? 'sftp.columns.kind' : `sftp.columns.${field}`)}
-            </ContextMenuCheckboxItem>
-          ))}
+          <SftpColumnMenuItems
+            visibleColumns={visibleColumns}
+            directoriesFirst={directoriesFirst}
+            toggleColumnVisibility={toggleColumnVisibility}
+            toggleDirectoriesFirst={toggleDirectoriesFirst}
+          />
         </ContextMenuContent>
       </ContextMenu>
       <ContextMenu>

--- a/components/sftp/SftpPaneTreeView.types.ts
+++ b/components/sftp/SftpPaneTreeView.types.ts
@@ -1,8 +1,7 @@
-import type React from 'react';
 import type { SftpFileEntry } from '../../types';
 import type { SftpPane } from '../../application/state/sftp/types';
 import type { SftpTransferSource } from './SftpContext';
-import type { ColumnWidths, SftpColumnVisibility, SortField, SortOrder } from './utils';
+import type { UseSftpPaneSortingResult } from './hooks/useSftpPaneSorting';
 
 export interface SftpPaneTreeViewProps {
   pane: SftpPane;
@@ -31,12 +30,6 @@ export interface SftpPaneTreeViewProps {
   onUploadExternalFiles?: (dataTransfer: DataTransfer, targetPath?: string) => Promise<void>;
   onUploadExternalFileList?: (fileList: FileList, targetPath?: string) => Promise<void>;
   onUploadExternalFolder?: (targetPath?: string) => Promise<void>;
-  columnWidths: ColumnWidths;
-  visibleColumns: SftpColumnVisibility;
-  handleSort: (field: SortField) => void;
-  handleResizeStart: (field: keyof ColumnWidths, e: React.MouseEvent) => void;
-  toggleColumnVisibility: (field: keyof ColumnWidths) => void;
-  sortField: SortField;
-  sortOrder: SortOrder;
+  sorting: UseSftpPaneSortingResult;
   reloadRequest: { token: number; paths?: string[]; full?: boolean };
 }

--- a/components/sftp/SftpPaneView.tsx
+++ b/components/sftp/SftpPaneView.tsx
@@ -25,7 +25,7 @@ import { useSftpPaneDialogs } from "./hooks/useSftpPaneDialogs";
 import { useSftpPaneDragAndSelect } from "./hooks/useSftpPaneDragAndSelect";
 import { useSftpPaneFiles } from "./hooks/useSftpPaneFiles";
 import { useSftpPanePath } from "./hooks/useSftpPanePath";
-import { useSftpPaneSorting } from "./hooks/useSftpPaneSorting";
+import { useSftpPaneSorting, type UseSftpPaneSortingResult } from "./hooks/useSftpPaneSorting";
 import { useSftpPaneVirtualList } from "./hooks/useSftpPaneVirtualList";
 import { useSftpDialogActionHandler } from "./hooks/useSftpDialogAction";
 import { useSftpBookmarks } from "./hooks/useSftpBookmarks";
@@ -160,11 +160,13 @@ const SftpPaneViewInner: React.FC<SftpPaneViewProps> = ({
   const {
     sortField,
     sortOrder,
+    directoriesFirst,
     columnWidths,
     visibleColumns,
     handleSort,
     handleResizeStart,
     toggleColumnVisibility,
+    toggleDirectoriesFirst,
   } = useSftpPaneSorting();
 
   // Bookmark support
@@ -224,6 +226,7 @@ const SftpPaneViewInner: React.FC<SftpPaneViewProps> = ({
     enableListView: viewMode === 'list',
     sortField,
     sortOrder,
+    directoriesFirst,
   });
   const {
     isEditingPath,
@@ -407,9 +410,30 @@ const SftpPaneViewInner: React.FC<SftpPaneViewProps> = ({
 
   useSftpDialogActionHandler(side, dialogActionScopeId, dialogActionHandlers, isActive);
 
-  const handleSortWithTransition = (field: typeof sortField) => {
+  const handleSortWithTransition = useCallback((field: typeof sortField) => {
     startTransition(() => handleSort(field));
-  };
+  }, [handleSort, startTransition]);
+  const sortingControls = useMemo<UseSftpPaneSortingResult>(() => ({
+    sortField,
+    sortOrder,
+    directoriesFirst,
+    columnWidths,
+    visibleColumns,
+    handleSort: handleSortWithTransition,
+    handleResizeStart,
+    toggleColumnVisibility,
+    toggleDirectoriesFirst,
+  }), [
+    columnWidths,
+    directoriesFirst,
+    handleResizeStart,
+    handleSortWithTransition,
+    sortField,
+    sortOrder,
+    toggleColumnVisibility,
+    toggleDirectoriesFirst,
+    visibleColumns,
+  ]);
 
   const handleRefresh = useCallback(() => {
     callbacks.onRefresh();
@@ -580,13 +604,7 @@ const SftpPaneViewInner: React.FC<SftpPaneViewProps> = ({
             onUploadExternalFiles={handleUploadExternalFiles}
             onUploadExternalFileList={handleUploadExternalFileList}
             onUploadExternalFolder={handleUploadExternalFolder}
-            columnWidths={columnWidths}
-            visibleColumns={visibleColumns}
-            handleSort={handleSortWithTransition}
-            handleResizeStart={handleResizeStart}
-            toggleColumnVisibility={toggleColumnVisibility}
-            sortField={sortField}
-            sortOrder={sortOrder}
+            sorting={sortingControls}
             reloadRequest={treeReloadRequest}
           />
         </div>
@@ -599,13 +617,7 @@ const SftpPaneViewInner: React.FC<SftpPaneViewProps> = ({
           pane={pane}
           side={side}
           isPaneFocused={isPaneFocused}
-          columnWidths={columnWidths}
-          visibleColumns={visibleColumns}
-          sortField={sortField}
-          sortOrder={sortOrder}
-          handleSort={handleSortWithTransition}
-          handleResizeStart={handleResizeStart}
-          toggleColumnVisibility={toggleColumnVisibility}
+          sorting={sortingControls}
           fileListRef={fileListRef}
           handleFileListScroll={handleFileListScroll}
           shouldVirtualize={shouldVirtualize}

--- a/components/sftp/SftpPaneView.tsx
+++ b/components/sftp/SftpPaneView.tsx
@@ -27,6 +27,7 @@ import { useSftpPaneFiles } from "./hooks/useSftpPaneFiles";
 import { useSftpPanePath } from "./hooks/useSftpPanePath";
 import { useSftpPaneSorting, type UseSftpPaneSortingResult } from "./hooks/useSftpPaneSorting";
 import { useSftpPaneVirtualList } from "./hooks/useSftpPaneVirtualList";
+import { sftpPaneViewModeStore } from "../../application/state/sftp/sftpPaneViewModeStore";
 import { useSftpDialogActionHandler } from "./hooks/useSftpDialogAction";
 import { useSftpBookmarks } from "./hooks/useSftpBookmarks";
 import { useLocalSftpBookmarks } from "./hooks/useLocalSftpBookmarks";
@@ -458,11 +459,13 @@ const SftpPaneViewInner: React.FC<SftpPaneViewProps> = ({
   }, [saveHostViewMode]);
 
   useEffect(() => {
+    sftpPaneViewModeStore.set(pane.id, viewMode);
     if (viewMode === 'list') {
       sftpTreeSelectionStore.clearPane(pane.id);
-      return;
+    } else {
+      sftpListOrderStore.clearPane(pane.id);
     }
-    sftpListOrderStore.clearPane(pane.id);
+    return () => sftpPaneViewModeStore.clear(pane.id);
   }, [pane.id, viewMode]);
 
   // When connecting to a host, restore its saved view mode preference

--- a/components/sftp/hooks/useSftpKeyboardShortcuts.ts
+++ b/components/sftp/hooks/useSftpKeyboardShortcuts.ts
@@ -5,7 +5,7 @@
  * Supports copy, cut, paste, select all, rename, delete, refresh, and new folder.
  */
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { MutableRefObject } from "react";
 import { KeyBinding, matchesKeyBinding } from "../../../domain/models";
 import { getParentPath, joinPath } from "../../../application/state/sftp/utils";
@@ -31,6 +31,7 @@ import {
   sftpClipboardUploadStore,
   type ClipboardLocalFile,
 } from "../clipboardUpload";
+import { advanceSftpTypeahead, type SftpTypeaheadState } from "../../../domain/sftpTypeahead";
 
 // SFTP action names that we handle
 const SFTP_ACTIONS = new Set([
@@ -169,6 +170,8 @@ export const useSftpKeyboardShortcuts = ({
   dialogActionScopeId,
   isActive,
 }: UseSftpKeyboardShortcutsParams) => {
+  const typeaheadRef = useRef<{ paneId: string; state: SftpTypeaheadState } | null>(null);
+
   const getFocusedPane = useCallback(() => {
     const sftp = sftpRef.current;
     const focusedSide = sftpFocusStore.getFocusedSide();
@@ -502,6 +505,46 @@ export const useSftpKeyboardShortcuts = ({
       // Skip when a dialog or overlay is open to prevent SFTP shortcuts from
       // firing while interacting with unrelated dialogs (e.g. settings, confirm).
       if (hasOpenDialog()) {
+        return;
+      }
+
+      // ── Printable keys: select the first visible name with this prefix ──
+      if (
+        e.key.length === 1
+        && !e.ctrlKey
+        && !e.metaKey
+        && !e.altKey
+        && !e.isComposing
+        && !/^\s$/u.test(e.key)
+        && !target.closest?.('[role="menu"], [role="listbox"]')
+      ) {
+        const { sftp, focusedSide, pane } = getFocusedPane();
+        if (!pane?.connection) return;
+
+        const listItems = sftpListOrderStore.getItems(pane.id);
+        const treeItems = listItems.length === 0
+          ? sftpTreeSelectionStore.getPaneState(pane.id).visibleItems
+          : [];
+        const names = listItems.length > 0 ? listItems : treeItems.map((item) => item.name);
+        if (names.length === 0) return;
+
+        const previous = typeaheadRef.current?.paneId === pane.id
+          ? typeaheadRef.current.state
+          : null;
+        const result = advanceSftpTypeahead(names, previous, e.key, Date.now());
+        typeaheadRef.current = { paneId: pane.id, state: result.state };
+
+        e.preventDefault();
+        e.stopPropagation();
+        if (result.matchIndex < 0) return;
+
+        keepOnlyPaneSelections(sftp, { side: focusedSide, tabId: pane.id });
+        if (listItems.length > 0) {
+          sftp.rangeSelect(focusedSide, [listItems[result.matchIndex]]);
+        } else {
+          sftpTreeSelectionStore.setSelection(pane.id, [treeItems[result.matchIndex].path]);
+        }
+        sftpKeyboardSelectionStore.set(pane.id, result.matchIndex, result.matchIndex);
         return;
       }
 
@@ -888,7 +931,7 @@ export const useSftpKeyboardShortcuts = ({
         }
       }
     },
-    [dialogActionScopeId, hotkeyScheme, isActive, keyBindings, pasteInternalSftpClipboard, sftpRef]
+    [dialogActionScopeId, getFocusedPane, hotkeyScheme, isActive, keyBindings, pasteInternalSftpClipboard, sftpRef]
   );
 
   useEffect(() => {

--- a/components/sftp/hooks/useSftpKeyboardShortcuts.ts
+++ b/components/sftp/hooks/useSftpKeyboardShortcuts.ts
@@ -15,6 +15,7 @@ import { sftpFocusStore } from "./useSftpFocusedPane";
 import { sftpDialogActionStore } from "./useSftpDialogAction";
 import { sftpTreeSelectionStore } from "./useSftpTreeSelectionStore";
 import { sftpListOrderStore } from "./useSftpListOrderStore";
+import { sftpPaneViewModeStore } from "../../../application/state/sftp/sftpPaneViewModeStore";
 import { keepOnlyPaneSelections } from "./selectionScope";
 import type { SftpStateApi } from "../../../application/state/useSftpState";
 import { filterHiddenFiles, isNavigableDirectory } from "../utils";
@@ -31,7 +32,15 @@ import {
   sftpClipboardUploadStore,
   type ClipboardLocalFile,
 } from "../clipboardUpload";
-import { advanceSftpTypeahead, type SftpTypeaheadState } from "../../../domain/sftpTypeahead";
+import {
+  advanceSftpTypeahead,
+  resolveSftpTypeaheadSource,
+  type SftpTypeaheadState,
+} from "../../../domain/sftpTypeahead";
+import {
+  resolveSftpActiveSelection,
+  resolveSftpSelectAllTarget,
+} from "../../../domain/sftpSelection";
 
 // SFTP action names that we handle
 const SFTP_ACTIONS = new Set([
@@ -182,13 +191,16 @@ export const useSftpKeyboardShortcuts = ({
   }, [sftpRef]);
 
   const getClipboardUploadTarget = useCallback((pane: NonNullable<ReturnType<typeof getFocusedPane>["pane"]>) => {
-    const treeSelection = sftpTreeSelectionStore.getSelectedItems(pane.id);
+    const { selectedFileNames, treeSelection } = resolveSftpActiveSelection(
+      sftpPaneViewModeStore.get(pane.id),
+      Array.from(pane.selectedFiles) as string[],
+      sftpTreeSelectionStore.getSelectedItems(pane.id),
+    );
     const treeActionSelection = treeSelection.filter((entry) => entry.name !== '..');
-    const selectedFiles = Array.from(pane.selectedFiles) as string[];
 
     return resolveSftpClipboardUploadTarget({
       currentPath: pane.connection!.currentPath,
-      selectedFileNames: selectedFiles,
+      selectedFileNames,
       files: pane.files as SftpFileEntry[],
       treeSelection: treeActionSelection,
     });
@@ -521,17 +533,17 @@ export const useSftpKeyboardShortcuts = ({
         const { sftp, focusedSide, pane } = getFocusedPane();
         if (!pane?.connection) return;
 
-        const listItems = sftpListOrderStore.getItems(pane.id);
-        const treeItems = listItems.length === 0
-          ? sftpTreeSelectionStore.getPaneState(pane.id).visibleItems
-          : [];
-        const names = listItems.length > 0 ? listItems : treeItems.map((item) => item.name);
-        if (names.length === 0) return;
+        const source = resolveSftpTypeaheadSource(
+          sftpPaneViewModeStore.get(pane.id),
+          sftpListOrderStore.getItems(pane.id),
+          sftpTreeSelectionStore.getPaneState(pane.id).visibleItems,
+        );
+        if (source.names.length === 0) return;
 
         const previous = typeaheadRef.current?.paneId === pane.id
           ? typeaheadRef.current.state
           : null;
-        const result = advanceSftpTypeahead(names, previous, e.key, Date.now());
+        const result = advanceSftpTypeahead(source.names, previous, e.key, Date.now());
         typeaheadRef.current = { paneId: pane.id, state: result.state };
 
         e.preventDefault();
@@ -539,10 +551,10 @@ export const useSftpKeyboardShortcuts = ({
         if (result.matchIndex < 0) return;
 
         keepOnlyPaneSelections(sftp, { side: focusedSide, tabId: pane.id });
-        if (listItems.length > 0) {
-          sftp.rangeSelect(focusedSide, [listItems[result.matchIndex]]);
+        if (source.kind === 'list') {
+          sftp.rangeSelect(focusedSide, [source.names[result.matchIndex]]);
         } else {
-          sftpTreeSelectionStore.setSelection(pane.id, [treeItems[result.matchIndex].path]);
+          sftpTreeSelectionStore.setSelection(pane.id, [source.items[result.matchIndex].path]);
         }
         sftpKeyboardSelectionStore.set(pane.id, result.matchIndex, result.matchIndex);
         return;
@@ -558,12 +570,13 @@ export const useSftpKeyboardShortcuts = ({
         if (!pane || !pane.connection) return;
 
         const delta = e.key === 'ArrowDown' ? 1 : -1;
+        const viewMode = sftpPaneViewModeStore.get(pane.id);
 
-        // List view: navigate sorted display files.
-        // Prefer the list store when it exists so stale tree selection state
-        // cannot swallow keyboard navigation after switching views.
+        // List view: navigate sorted display files. The explicit view mode is
+        // authoritative even when the active list has no visible items.
         const listItems = sftpListOrderStore.getItems(pane.id);
-        if (listItems.length > 0) {
+        if (viewMode === 'list') {
+          if (listItems.length === 0) return;
           e.preventDefault();
           e.stopPropagation();
 
@@ -681,8 +694,14 @@ export const useSftpKeyboardShortcuts = ({
         : sftp.rightTabs.tabs.find(p => p.id === sftp.rightTabs.activeTabId);
 
       if (!pane || !pane.connection) return;
+      const viewMode = sftpPaneViewModeStore.get(pane.id);
+      const isTreeView = viewMode === 'tree';
       const treeSelectionState = sftpTreeSelectionStore.getPaneState(pane.id);
-      const treeSelection = sftpTreeSelectionStore.getSelectedItems(pane.id);
+      const { selectedFileNames, treeSelection } = resolveSftpActiveSelection(
+        viewMode,
+        Array.from(pane.selectedFiles) as string[],
+        sftpTreeSelectionStore.getSelectedItems(pane.id),
+      );
       const treeActionSelection = treeSelection.filter((entry) => entry.name !== '..');
 
       switch (action) {
@@ -714,12 +733,11 @@ export const useSftpKeyboardShortcuts = ({
           }
 
           // Copy selected files to clipboard
-          const selectedFiles = Array.from(pane.selectedFiles) as string[];
-          if (selectedFiles.length === 0) return;
+          if (selectedFileNames.length === 0) return;
 
           {
             const filesByName = new Map((pane.files as SftpFileEntry[]).map(f => [f.name, f]));
-            const clipboardFiles: SftpClipboardFile[] = selectedFiles.map((name: string) => {
+            const clipboardFiles: SftpClipboardFile[] = selectedFileNames.map((name: string) => {
               const file = filesByName.get(name);
               return {
                 name,
@@ -735,7 +753,7 @@ export const useSftpKeyboardShortcuts = ({
             );
             await replaceSystemClipboardWithSftpPaths(getSftpClipboardSystemTextPaths({
               currentPath: pane.connection.currentPath,
-              selectedFileNames: selectedFiles,
+              selectedFileNames,
               treeSelection: [],
             }));
           }
@@ -770,12 +788,11 @@ export const useSftpKeyboardShortcuts = ({
           }
 
           // Cut selected files to clipboard
-          const selectedFiles = Array.from(pane.selectedFiles) as string[];
-          if (selectedFiles.length === 0) return;
+          if (selectedFileNames.length === 0) return;
 
           {
             const filesByName = new Map((pane.files as SftpFileEntry[]).map(f => [f.name, f]));
-            const clipboardFiles: SftpClipboardFile[] = selectedFiles.map((name: string) => {
+            const clipboardFiles: SftpClipboardFile[] = selectedFileNames.map((name: string) => {
               const file = filesByName.get(name);
               return {
                 name,
@@ -791,7 +808,7 @@ export const useSftpKeyboardShortcuts = ({
             );
             await replaceSystemClipboardWithSftpPaths(getSftpClipboardSystemTextPaths({
               currentPath: pane.connection.currentPath,
-              selectedFileNames: selectedFiles,
+              selectedFileNames,
               treeSelection: [],
             }));
           }
@@ -804,7 +821,12 @@ export const useSftpKeyboardShortcuts = ({
         }
 
         case "sftpSelectAll": {
-          if (treeSelectionState.visibleItems.length > 0) {
+          const selectAllTarget = resolveSftpSelectAllTarget(
+            viewMode,
+            treeSelectionState.visibleItems.length,
+          );
+          if (selectAllTarget === 'none') break;
+          if (selectAllTarget === 'tree') {
             keepOnlyPaneSelections(sftp, { side: focusedSide, tabId: pane.id });
             sftpTreeSelectionStore.selectAllVisible(pane.id);
             break;
@@ -837,9 +859,8 @@ export const useSftpKeyboardShortcuts = ({
           }
 
           // Trigger rename for the first selected file
-          const selectedFiles = Array.from(pane.selectedFiles) as string[];
-          if (selectedFiles.length !== 1) return;
-          sftpDialogActionStore.trigger("rename", dialogActionScopeId, selectedFiles);
+          if (selectedFileNames.length !== 1) return;
+          sftpDialogActionStore.trigger("rename", dialogActionScopeId, selectedFileNames);
           break;
         }
 
@@ -854,9 +875,8 @@ export const useSftpKeyboardShortcuts = ({
           }
 
           // Delete selected files
-          const selectedFiles = Array.from(pane.selectedFiles) as string[];
-          if (selectedFiles.length === 0) return;
-          sftpDialogActionStore.trigger("delete", dialogActionScopeId, selectedFiles);
+          if (selectedFileNames.length === 0) return;
+          sftpDialogActionStore.trigger("delete", dialogActionScopeId, selectedFileNames);
           break;
         }
 
@@ -873,11 +893,8 @@ export const useSftpKeyboardShortcuts = ({
         }
 
         case "sftpOpen": {
-          // Prefer list selection when the list store is active
-          const listItems = sftpListOrderStore.getItems(pane.id);
-          const selectedFiles = Array.from(pane.selectedFiles) as string[];
-          if (listItems.length > 0 && selectedFiles.length === 1) {
-            const fileName = selectedFiles[0];
+          if (!isTreeView && selectedFileNames.length === 1) {
+            const fileName = selectedFileNames[0];
             const entry = (pane.files as SftpFileEntry[]).find(f => f.name === fileName);
             if (entry) {
               if (isNavigableDirectory(entry)) {
@@ -890,11 +907,9 @@ export const useSftpKeyboardShortcuts = ({
             break;
           }
 
-          // Only fall through to tree view if list store is empty (tree view mode)
-          if (listItems.length > 0) break;
-          const treeOpenSelection = sftpTreeSelectionStore.getSelectedItems(pane.id);
-          if (treeOpenSelection.length === 1) {
-            const item = treeOpenSelection[0];
+          if (!isTreeView) break;
+          if (treeActionSelection.length === 1) {
+            const item = treeActionSelection[0];
             if (item.isDirectory) _kbSelectionState.delete(pane.id);
             sftpTreeEnterStore.trigger(pane.id, item.path, item.isDirectory);
           }
@@ -919,9 +934,8 @@ export const useSftpKeyboardShortcuts = ({
             break;
           }
           // In list view, navigate to selected directory
-          const selectedFiles = Array.from(pane.selectedFiles) as string[];
-          if (selectedFiles.length === 1) {
-            const entry = (pane.files as SftpFileEntry[]).find(f => f.name === selectedFiles[0]);
+          if (selectedFileNames.length === 1) {
+            const entry = (pane.files as SftpFileEntry[]).find(f => f.name === selectedFileNames[0]);
             if (entry && isNavigableDirectory(entry)) {
               _kbSelectionState.delete(pane.id);
               sftp.navigateTo(focusedSide, joinPath(pane.connection.currentPath, entry.name));

--- a/components/sftp/hooks/useSftpPaneFiles.ts
+++ b/components/sftp/hooks/useSftpPaneFiles.ts
@@ -12,6 +12,7 @@ interface UseSftpPaneFilesParams {
   enableListView: boolean;
   sortField: SortField;
   sortOrder: SortOrder;
+  directoriesFirst: boolean;
 }
 
 interface UseSftpPaneFilesResult {
@@ -28,6 +29,7 @@ export const useSftpPaneFiles = ({
   enableListView,
   sortField,
   sortOrder,
+  directoriesFirst,
 }: UseSftpPaneFilesParams): UseSftpPaneFilesResult => {
   // Extract ".." once and process the remaining files through filter -> sort
   // in fewer passes, instead of repeatedly filtering/finding ".." entries.
@@ -75,12 +77,12 @@ export const useSftpPaneFiles = ({
 
     const display = parentEntry ? [parentEntry, ...otherFiles] : otherFiles;
     const sorted = otherFiles.length
-      ? sortSftpEntries(otherFiles, sortField, sortOrder)
+      ? sortSftpEntries(otherFiles, sortField, sortOrder, directoriesFirst)
       : otherFiles;
     const sortedDisplay = parentEntry ? [parentEntry, ...sorted] : sorted;
 
     return { displayFiles: display, sortedDisplayFiles: sortedDisplay };
-  }, [connection, enableListView, filteredFiles, sortField, sortOrder]);
+  }, [connection, directoriesFirst, enableListView, filteredFiles, sortField, sortOrder]);
 
   return { filteredFiles, displayFiles, sortedDisplayFiles };
 };

--- a/components/sftp/hooks/useSftpPaneSorting.ts
+++ b/components/sftp/hooks/useSftpPaneSorting.ts
@@ -12,20 +12,24 @@ import {
   LOCAL_STORAGE_ADAPTER_CHANGED_EVENT,
   localStorageAdapter,
 } from "../../../infrastructure/persistence/localStorageAdapter";
+import { useSftpDirectoriesFirst } from "../../../application/state/sftp/useSftpDirectoriesFirst";
 
-interface UseSftpPaneSortingResult {
+export interface UseSftpPaneSortingResult {
   sortField: SortField;
   sortOrder: SortOrder;
+  directoriesFirst: boolean;
   columnWidths: ColumnWidths;
   visibleColumns: SftpColumnVisibility;
   handleSort: (field: SortField) => void;
   handleResizeStart: (field: keyof ColumnWidths, e: React.MouseEvent) => void;
   toggleColumnVisibility: (field: keyof ColumnWidths) => void;
+  toggleDirectoriesFirst: () => void;
 }
 
 export const useSftpPaneSorting = (): UseSftpPaneSortingResult => {
   const [sortField, setSortField] = useState<SortField>("name");
   const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
+  const { directoriesFirst, toggleDirectoriesFirst } = useSftpDirectoriesFirst();
   const [columnWidths, setColumnWidths] = useState<ColumnWidths>({
     name: 56,
     modified: 28,
@@ -82,14 +86,14 @@ export const useSftpPaneSorting = (): UseSftpPaneSortingResult => {
     startWidth: number;
   } | null>(null);
 
-  const handleSort = (field: SortField) => {
+  const handleSort = useCallback((field: SortField) => {
     if (sortField === field) {
       setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"));
     } else {
       setSortField(field);
       setSortOrder("asc");
     }
-  };
+  }, [sortField]);
 
   const rafIdRef = useRef<number | null>(null);
   const lastClientXRef = useRef(0);
@@ -153,10 +157,12 @@ export const useSftpPaneSorting = (): UseSftpPaneSortingResult => {
   return {
     sortField,
     sortOrder,
+    directoriesFirst,
     columnWidths,
     visibleColumns,
     handleSort,
     handleResizeStart,
     toggleColumnVisibility,
+    toggleDirectoriesFirst,
   };
 };

--- a/components/sftp/sftpColumnVisibilityIntegration.test.ts
+++ b/components/sftp/sftpColumnVisibilityIntegration.test.ts
@@ -9,13 +9,16 @@ test('list and tree SFTP views share column visibility and keyboard-accessible m
   const listSource = readSource('./SftpPaneFileList.tsx');
   const treeSource = readSource('./SftpPaneTreeView.tsx');
   const treeNodeSource = readSource('./SftpPaneTreeNode.tsx');
+  const columnMenuSource = readSource('./SftpColumnMenuItems.tsx');
 
   for (const source of [listSource, treeSource]) {
     assert.match(source, /buildSftpColumnTemplate\(columnWidths, visibleColumns\)/);
-    assert.match(source, /ContextMenuCheckboxItem/);
+    assert.match(source, /SftpColumnMenuItems/);
     assert.match(source, /isSftpColumnMenuKey/);
     assert.match(source, /tabIndex=\{0\}/);
   }
+
+  assert.match(columnMenuSource, /ContextMenuCheckboxItem/);
 
   assert.match(treeNodeSource, /visibleColumns\.modified/);
   assert.match(treeNodeSource, /visibleColumns\.size/);

--- a/components/sftp/sftpColumnVisibilityIntegration.test.ts
+++ b/components/sftp/sftpColumnVisibilityIntegration.test.ts
@@ -19,6 +19,10 @@ test('list and tree SFTP views share column visibility and keyboard-accessible m
   }
 
   assert.match(columnMenuSource, /ContextMenuCheckboxItem/);
+  assert.match(
+    listSource,
+    /import\s*\{[^}]*\bContextMenuSeparator\b[^}]*\}\s*from "\.\.\/ui\/context-menu";/,
+  );
 
   assert.match(treeNodeSource, /visibleColumns\.modified/);
   assert.match(treeNodeSource, /visibleColumns\.size/);

--- a/components/sftp/sftpSorting.test.ts
+++ b/components/sftp/sftpSorting.test.ts
@@ -34,3 +34,39 @@ test('SFTP sorting can mix files and directories in the selected order', () => {
 
   assert.deepEqual(sorted.map(({ name }) => name), ['newest.log', 'dir-b', 'dir-a']);
 });
+
+test('SFTP kind sorting keeps directories first when enabled', () => {
+  const kindEntries = [
+    entry('BUILD', 'file', 100),
+    entry('src', 'directory', 100),
+    entry('archive.zip', 'file', 100),
+  ];
+
+  const sorted = sortSftpEntries(kindEntries, 'type', 'asc', true);
+
+  assert.deepEqual(sorted.map(({ name }) => name), ['src', 'BUILD', 'archive.zip']);
+});
+
+test('SFTP descending kind sorting keeps directories first when enabled', () => {
+  const kindEntries = [
+    entry('BUILD', 'file', 100),
+    entry('src', 'directory', 100),
+    entry('archive.zip', 'file', 100),
+  ];
+
+  const sorted = sortSftpEntries(kindEntries, 'type', 'desc', true);
+
+  assert.deepEqual(sorted.map(({ name }) => name), ['src', 'archive.zip', 'BUILD']);
+});
+
+test('SFTP kind sorting can mix files and directories when folders first is disabled', () => {
+  const kindEntries = [
+    entry('BUILD', 'file', 100),
+    entry('src', 'directory', 100),
+    entry('archive.zip', 'file', 100),
+  ];
+
+  const sorted = sortSftpEntries(kindEntries, 'type', 'asc', false);
+
+  assert.deepEqual(sorted.map(({ name }) => name), ['BUILD', 'src', 'archive.zip']);
+});

--- a/components/sftp/sftpSorting.test.ts
+++ b/components/sftp/sftpSorting.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { SftpFileEntry } from '../../types.ts';
+import { sortSftpEntries } from './utils.ts';
+
+const entry = (
+  name: string,
+  type: SftpFileEntry['type'],
+  lastModified: number,
+): SftpFileEntry => ({
+  name,
+  type,
+  size: 0,
+  sizeFormatted: '0 B',
+  lastModified,
+  lastModifiedFormatted: String(lastModified),
+});
+
+const entries = [
+  entry('dir-a', 'directory', 100),
+  entry('newest.log', 'file', 300),
+  entry('dir-b', 'directory', 200),
+];
+
+test('SFTP sorting keeps directories first by default', () => {
+  const sorted = sortSftpEntries(entries, 'modified', 'desc');
+
+  assert.deepEqual(sorted.map(({ name }) => name), ['dir-b', 'dir-a', 'newest.log']);
+});
+
+test('SFTP sorting can mix files and directories in the selected order', () => {
+  const sorted = sortSftpEntries(entries, 'modified', 'desc', false);
+
+  assert.deepEqual(sorted.map(({ name }) => name), ['newest.log', 'dir-b', 'dir-a']);
+});

--- a/components/sftp/utils.ts
+++ b/components/sftp/utils.ts
@@ -298,6 +298,7 @@ export const sortSftpEntries = (
     entries: SftpFileEntry[],
     sortField: SortField,
     sortOrder: SortOrder,
+    directoriesFirst = true,
 ): SftpFileEntry[] => {
     if (!entries.length) return entries;
 
@@ -305,7 +306,7 @@ export const sortSftpEntries = (
         const aIsDir = isNavigableDirectory(a);
         const bIsDir = isNavigableDirectory(b);
 
-        if (sortField !== 'type') {
+        if (directoriesFirst && sortField !== 'type') {
             if (aIsDir && !bIsDir) return -1;
             if (!aIsDir && bIsDir) return 1;
         }

--- a/components/sftp/utils.ts
+++ b/components/sftp/utils.ts
@@ -306,7 +306,7 @@ export const sortSftpEntries = (
         const aIsDir = isNavigableDirectory(a);
         const bIsDir = isNavigableDirectory(b);
 
-        if (directoriesFirst && sortField !== 'type') {
+        if (directoriesFirst) {
             if (aIsDir && !bIsDir) return -1;
             if (!aIsDir && bIsDir) return 1;
         }

--- a/domain/sftpSelection.test.ts
+++ b/domain/sftpSelection.test.ts
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveSftpActiveSelection, resolveSftpSelectAllTarget } from './sftpSelection.ts';
+
+const treeSelection = [{ name: 'tree.log', path: '/tree.log' }];
+
+test('SFTP list view ignores hidden tree selection', () => {
+  assert.deepEqual(resolveSftpActiveSelection('list', ['list.log'], treeSelection), {
+    selectedFileNames: ['list.log'],
+    treeSelection: [],
+  });
+});
+
+test('SFTP tree view ignores hidden list selection even when tree selection is empty', () => {
+  assert.deepEqual(resolveSftpActiveSelection('tree', ['hidden-list.log'], []), {
+    selectedFileNames: [],
+    treeSelection: [],
+  });
+});
+
+test('SFTP select-all does not fall back to hidden list items in an empty tree', () => {
+  assert.equal(resolveSftpSelectAllTarget('tree', 0), 'none');
+  assert.equal(resolveSftpSelectAllTarget('tree', 2), 'tree');
+  assert.equal(resolveSftpSelectAllTarget('list', 0), 'list');
+});

--- a/domain/sftpSelection.ts
+++ b/domain/sftpSelection.ts
@@ -1,0 +1,17 @@
+import type { SftpViewMode } from './sftpTypeahead';
+
+export const resolveSftpActiveSelection = <T>(
+  viewMode: SftpViewMode,
+  selectedFileNames: string[],
+  treeSelection: T[],
+): { selectedFileNames: string[]; treeSelection: T[] } => viewMode === 'list'
+  ? { selectedFileNames, treeSelection: [] }
+  : { selectedFileNames: [], treeSelection };
+
+export const resolveSftpSelectAllTarget = (
+  viewMode: SftpViewMode,
+  visibleTreeItemCount: number,
+): 'list' | 'tree' | 'none' => {
+  if (viewMode === 'list') return 'list';
+  return visibleTreeItemCount > 0 ? 'tree' : 'none';
+};

--- a/domain/sftpTypeahead.test.ts
+++ b/domain/sftpTypeahead.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { advanceSftpTypeahead } from './sftpTypeahead.ts';
+
+const names = ['config', 'Error.log', 'errors.old', 'readme'];
+
+test('SFTP typeahead narrows the match as the user keeps typing', () => {
+  const first = advanceSftpTypeahead(names, null, 'e', 100);
+  const second = advanceSftpTypeahead(names, first.state, 'r', 200);
+  const third = advanceSftpTypeahead(names, second.state, 'r', 300);
+
+  assert.deepEqual(
+    [first.state.query, second.state.query, third.state.query],
+    ['e', 'er', 'err'],
+  );
+  assert.deepEqual(
+    [first.matchIndex, second.matchIndex, third.matchIndex],
+    [1, 1, 1],
+  );
+});
+
+test('SFTP typeahead starts a new search after the typing pause', () => {
+  const first = advanceSftpTypeahead(names, null, 'e', 100);
+  const afterPause = advanceSftpTypeahead(names, first.state, 'r', 1200);
+
+  assert.equal(afterPause.state.query, 'r');
+  assert.equal(afterPause.matchIndex, 3);
+});

--- a/domain/sftpTypeahead.test.ts
+++ b/domain/sftpTypeahead.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { advanceSftpTypeahead } from './sftpTypeahead.ts';
+import { advanceSftpTypeahead, resolveSftpTypeaheadSource } from './sftpTypeahead.ts';
 
 const names = ['config', 'Error.log', 'errors.old', 'readme'];
 
@@ -26,4 +26,13 @@ test('SFTP typeahead starts a new search after the typing pause', () => {
 
   assert.equal(afterPause.state.query, 'r');
   assert.equal(afterPause.matchIndex, 3);
+});
+
+test('SFTP typeahead never falls back to hidden tree items in list view', () => {
+  assert.deepEqual(resolveSftpTypeaheadSource('list', [], [
+    { name: 'hidden-tree-file.log', path: '/hidden-tree-file.log' },
+  ]), {
+    kind: 'list',
+    names: [],
+  });
 });

--- a/domain/sftpTypeahead.ts
+++ b/domain/sftpTypeahead.ts
@@ -8,7 +8,26 @@ export interface SftpTypeaheadResult {
   matchIndex: number;
 }
 
+export type SftpViewMode = 'list' | 'tree';
+
+interface SftpTypeaheadTreeItem {
+  name: string;
+  path: string;
+}
+
+export type SftpTypeaheadSource =
+  | { kind: 'list'; names: string[] }
+  | { kind: 'tree'; names: string[]; items: SftpTypeaheadTreeItem[] };
+
 const SFTP_TYPEAHEAD_RESET_MS = 1000;
+
+export const resolveSftpTypeaheadSource = (
+  viewMode: SftpViewMode,
+  listItems: string[],
+  treeItems: SftpTypeaheadTreeItem[],
+): SftpTypeaheadSource => viewMode === 'list'
+  ? { kind: 'list', names: listItems }
+  : { kind: 'tree', names: treeItems.map((item) => item.name), items: treeItems };
 
 export const advanceSftpTypeahead = (
   names: string[],

--- a/domain/sftpTypeahead.ts
+++ b/domain/sftpTypeahead.ts
@@ -1,0 +1,26 @@
+export interface SftpTypeaheadState {
+  query: string;
+  lastInputAt: number;
+}
+
+export interface SftpTypeaheadResult {
+  state: SftpTypeaheadState;
+  matchIndex: number;
+}
+
+const SFTP_TYPEAHEAD_RESET_MS = 1000;
+
+export const advanceSftpTypeahead = (
+  names: string[],
+  previous: SftpTypeaheadState | null,
+  key: string,
+  now: number,
+): SftpTypeaheadResult => {
+  const continuesPrevious = previous && now - previous.lastInputAt <= SFTP_TYPEAHEAD_RESET_MS;
+  const query = `${continuesPrevious ? previous.query : ''}${key}`.toLocaleLowerCase();
+
+  return {
+    state: { query, lastInputAt: now },
+    matchIndex: names.findIndex((name) => name.toLocaleLowerCase().startsWith(query)),
+  };
+};

--- a/domain/sftpVirtualList.test.ts
+++ b/domain/sftpVirtualList.test.ts
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getSftpVirtualListScrollTop } from './sftpVirtualList';
+
+test('SFTP typeahead can reveal an item outside a large virtualized viewport', () => {
+  assert.equal(getSftpVirtualListScrollTop({
+    itemIndex: 75,
+    rowHeight: 28,
+    currentScrollTop: 0,
+    viewportHeight: 280,
+  }), 1848);
+});
+
+test('SFTP virtualized list keeps an already visible selection in place', () => {
+  assert.equal(getSftpVirtualListScrollTop({
+    itemIndex: 12,
+    rowHeight: 28,
+    currentScrollTop: 280,
+    viewportHeight: 280,
+  }), 280);
+});

--- a/domain/sftpVirtualList.ts
+++ b/domain/sftpVirtualList.ts
@@ -1,0 +1,22 @@
+interface SftpVirtualListScrollInput {
+  itemIndex: number;
+  rowHeight: number;
+  currentScrollTop: number;
+  viewportHeight: number;
+}
+
+export const getSftpVirtualListScrollTop = ({
+  itemIndex,
+  rowHeight,
+  currentScrollTop,
+  viewportHeight,
+}: SftpVirtualListScrollInput): number => {
+  const rowTop = itemIndex * rowHeight;
+  const rowBottom = rowTop + rowHeight;
+
+  if (rowTop < currentScrollTop) return rowTop;
+  if (rowBottom > currentScrollTop + viewportHeight) {
+    return rowBottom - viewportHeight;
+  }
+  return currentScrollTop;
+};

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -121,6 +121,7 @@ export const STORAGE_KEY_SFTP_FOLLOW_TERMINAL_CWD = 'netcatty_sftp_follow_termin
 export const STORAGE_KEY_SFTP_DEFAULT_VIEW_MODE = 'netcatty_sftp_default_view_mode_v1';
 export const STORAGE_KEY_SFTP_HOST_VIEW_MODES = 'netcatty_sftp_host_view_modes_v1';
 export const STORAGE_KEY_SFTP_VISIBLE_COLUMNS = 'netcatty_sftp_visible_columns_v1';
+export const STORAGE_KEY_SFTP_DIRECTORIES_FIRST = 'netcatty_sftp_directories_first_v1';
 /** Dense SFTP toolbar actions: show / collapse / hide + order. */
 export const STORAGE_KEY_SFTP_TOOLBAR_LAYOUT = 'netcatty_sftp_toolbar_layout_v1';
 /** Dense terminal session toolbar actions: show / collapse / hide + order. */


### PR DESCRIPTION
## Summary

- add a persistent "Folders first" option while keeping the current behavior as the default
- allow files and folders to share the selected name or modified-time order
- add incremental keyboard selection in both SFTP list and tree views
- keep the selected item visible in large virtualized folders

Closes #2268

## Validation

- `npm run build`
- `npm run lint`
- 12 focused SFTP sorting, typeahead, large-folder scrolling, and column-menu tests
- local interactive verification for preference persistence and multi-key selection
- two independent review passes found no remaining actionable issues

## Existing unrelated failure

- `failed keyboard-interactive retry still offers encrypted default key fallback` in `electron/bridges/sshBridge.authRetryExit.test.cjs` remains failing on `main`; this change does not touch SSH authentication
