### PR TITLE
feat(plugins): add permission and security boundary

### DIFF
--- a/docs/plugin-platform/contract-and-sdk.md
+++ b/docs/plugin-platform/contract-and-sdk.md
@@ -3,14 +3,17 @@
 Status: internal preview (`0.1.0-internal`)
 Tracking issue: [#2269](https://github.com/binaricat/Netcatty/issues/2269)
 
-Phase 2 now consumes this contract in the isolated host runtime. See
+Phases 2 and 3 consume this contract in the isolated host runtime and secure
+capability boundary. See
 [isolated-runtime.md](./isolated-runtime.md) for installation transactions,
-runtime placement, RPC routing, lifecycle and crash quarantine.
+runtime placement, RPC routing, lifecycle and crash quarantine, and
+[security-and-permissions.md](./security-and-permissions.md) for grants,
+credentials and host-mediated capabilities.
 
-This document describes the contract delivered by phase 1 of the plugin
-platform. It deliberately does not expose a plugin loader. Package installation,
-runtime isolation, permissions, UI contributions, terminal providers, connection
-providers, synchronization, and distribution are introduced by later phases.
+This document describes the canonical contract first delivered by phase 1 and
+extended before public release. Runtime loading and capability enforcement live
+in the host rather than the schema package. UI contributions, terminal and
+connection Providers, synchronization, and distribution remain later phases.
 
 ## Contract ownership
 
@@ -89,8 +92,9 @@ validation because JSON Schema cannot express these filesystem rules.
 Every entrypoint, view document, package icon, and companion variant must exist
 in the package.
 
-Browser and Node entrypoints express placement, not permission. The future
-runtime still evaluates the manifest permissions, trust level, and user grants
+Browser and Node entrypoints express placement. A Node entrypoint additionally
+requires the explicit high-risk `runtime.advanced` declaration and grant; the
+runtime still evaluates the remaining manifest permissions, trust level, and user grants
 before activating either entrypoint.
 
 Each advanced companion has a stable contribution ID and one or more platform
@@ -336,18 +340,24 @@ lifecycle primitives:
   host abort controllers;
 - `PluginError` carries a stable machine-readable error code and JSON details;
 - `PluginContext` exposes the exact Netcatty/API versions, negotiated feature
-  set, storage, opaque secret references, logging, and subscriptions.
+  set, storage, opaque secret references, credential leases, mediated network
+  and filesystem access, companion handles, logging, and subscriptions.
 
 `PluginSecretStore.get()` never returns plaintext. It returns a host-issued
 `SecretRef`, and `set()` immediately transfers a value already known to the
-plugin into host storage before returning the same kind of reference. Future
-network, authentication, and companion brokers consume the reference while the
-main process revalidates plugin ownership and operation scope. A `SecretRef` is
-an identifier, not a bearer capability, and must never bypass those checks.
+plugin into host storage before returning the same kind of reference. Network,
+authentication, and companion brokers can consume a one-use lease for the
+reference while the main process revalidates plugin ownership and operation
+scope. PR 7 may also supply a host-issued `CredentialRef` for Netcatty-owned
+Vault credentials through the same SDK method; its injected resolver does not
+materialize plaintext until lease consumption. Neither reference kind is a
+bearer capability, and neither may bypass permission, ownership, runtime, and
+operation checks.
 Host-rendered password settings likewise expose only references to plugin code.
 
-The context interfaces are contracts only in phase 1. The isolated host in
-phase 2 and capability brokers in phase 3 provide their implementations.
+The isolated host and phase-3 capability brokers provide these implementations.
+No renderer decision provider means requests fail closed; a manifest declaration
+never grants authority by itself.
 
 Permission names already use the phase-3 enforcement boundaries: clipboard
 read/write, terminal metadata/output/input and input/output interception, Vault
@@ -478,7 +488,7 @@ The cross-phase contract was checked against every planned consumer:
 | Phase | Contract used without importing application internals |
 | --- | --- |
 | PR 2 runtime | manifest header/full validation, `plugin.initialize`, JSON-RPC, progress, cancellation, framing, streams |
-| PR 3 security | plugin identity, permission declarations, RPC error mapping, deadlines and cancellation IDs |
+| PR 3 security | principal-bound grants, canonical resources, permission requests/decisions, `SecretRef`/`CredentialRef`/`SecretLeaseRef`, mediated SDK capabilities, stable failures and cancellation |
 | PR 4 contributions | namespaced settings, commands, menus, views and strict semantic references |
 | PR 5 terminal providers | namespaced provider IDs, provider request/result envelopes and bounded streams |
 | PR 6 data pipeline | MessagePort transfer envelopes, base64 stdio fallback, sequence and receive-window fields |

--- a/docs/plugin-platform/contract-and-sdk.md
+++ b/docs/plugin-platform/contract-and-sdk.md
@@ -102,7 +102,10 @@ variants. A variant binds one package path and SHA-256 digest to one or more
 compatible OS/architecture targets, allowing a universal script to be shared
 while macOS, Linux, and Windows native binaries remain distinct. A companion
 cannot declare the same target platform twice, and no two companion variants
-may claim the same package path.
+may claim the same package path. A manifest with companions must also provide a
+Node utility entrypoint and declare both `runtime.advanced` and a resource-bound
+`companion.execute` permission. An ordinary browser placement cannot authorize
+or launch a companion.
 
 ## Contribution identity
 

--- a/docs/plugin-platform/contract-and-sdk.md
+++ b/docs/plugin-platform/contract-and-sdk.md
@@ -359,6 +359,11 @@ The isolated host and phase-3 capability brokers provide these implementations.
 No renderer decision provider means requests fail closed; a manifest declaration
 never grants authority by itself.
 
+`PluginFilesystemClient.writeFile()` currently requires `{ overwrite: true }`
+and an existing regular file. This preserves one stable SDK method while the
+cross-platform host denies unsafe arbitrary-path creation until it can bind a
+new child to an opened parent directory without a path race.
+
 Permission names already use the phase-3 enforcement boundaries: clipboard
 read/write, terminal metadata/output/input and input/output interception, Vault
 metadata/write/credentials, SFTP read/write, filesystem read/write, network

--- a/docs/plugin-platform/contract-and-sdk.md
+++ b/docs/plugin-platform/contract-and-sdk.md
@@ -104,8 +104,10 @@ while macOS, Linux, and Windows native binaries remain distinct. A companion
 cannot declare the same target platform twice, and no two companion variants
 may claim the same package path. A manifest with companions must also provide a
 Node utility entrypoint and declare both `runtime.advanced` and a resource-bound
-`companion.execute` permission. An ordinary browser placement cannot authorize
-or launch a companion.
+`companion.execute` permission. The first-party placement resolver selects the
+utility entrypoint for companion manifests even when a browser entrypoint is
+also present. An ordinary browser placement cannot authorize or launch a
+companion.
 
 ## Contribution identity
 

--- a/docs/plugin-platform/contract-and-sdk.md
+++ b/docs/plugin-platform/contract-and-sdk.md
@@ -344,8 +344,10 @@ lifecycle primitives:
   and filesystem access, companion handles, logging, and subscriptions.
 
 `PluginSecretStore.get()` never returns plaintext. It returns a host-issued
-`SecretRef`, and `set()` immediately transfers a value already known to the
-plugin into host storage before returning the same kind of reference. Network,
+`SecretRef`. Its random ID stays opaque; its non-secret `key` binds later lease
+authorization to the same manifest resource used by `get()`/`set()`. `set()`
+immediately transfers a value already known to the plugin into host storage
+before returning the same kind of reference. Network,
 authentication, and companion brokers can consume a one-use lease for the
 reference while the main process revalidates plugin ownership and operation
 scope. PR 7 may also supply a host-issued `CredentialRef` for Netcatty-owned
@@ -363,6 +365,9 @@ never grants authority by itself.
 and an existing regular file. This preserves one stable SDK method while the
 cross-platform host denies unsafe arbitrary-path creation until it can bind a
 new child to an opened parent directory without a path race.
+`readDirectory()` likewise keeps its stable SDK/RPC method but fails closed
+unless the main process supplies a native adapter whose inode checks and entry
+enumeration are bound to the same directory handle.
 
 Permission names already use the phase-3 enforcement boundaries: clipboard
 read/write, terminal metadata/output/input and input/output interception, Vault

--- a/docs/plugin-platform/isolated-runtime.md
+++ b/docs/plugin-platform/isolated-runtime.md
@@ -2,10 +2,12 @@
 
 Status: internal preview (`0.1.0-internal`)
 
-This document describes phase 2 of the plugin platform tracked by
+This document describes the isolated runtime introduced in phase 2 and secured
+by phase 3 of the plugin platform tracked by
 [#2269](https://github.com/binaricat/Netcatty/issues/2269). The runtime remains
 hidden behind `NETCATTY_PLUGIN_DEV=1`; there is no public settings entry or
-permission prompt yet.
+permission prompt yet. Without an injected host decision provider, every
+interactive capability request fails closed.
 
 ## Installation transaction
 
@@ -83,8 +85,10 @@ an activation loop.
 `plugins.sqlite` uses WAL, foreign keys, `synchronous=FULL`, explicit schema
 versions, and immediate transactions. It records installed versions, the active
 version, enabled state, runtime state, version-scoped crash history, and
-namespaced JSON key/value storage. Newer unknown database schemas fail closed.
-The plugin host has not shipped to users, so phase 2 defines one complete
+namespaced JSON key/value storage. The complete initial schema also keeps
+permission grants, OS-encrypted secret ciphertext, and bounded security audit
+records in user-owned tables with no package-version cascade. Newer unknown
+database schemas fail closed. The plugin host has not shipped to users, so it defines one complete
 initial schema at version 1 and has no migration chain. Pre-release phases may
 still revise that initial schema (or reset development-only databases); schema
 migrations begin only after a released build can have durable user data.
@@ -98,9 +102,9 @@ prior error/quarantine state.
 Explicit recovery clears only the active version's counter and preserves other
 retained versions' failure history.
 
-Permission grants, encrypted settings and secrets are deliberately absent from
-this phase. Those tables and brokers are introduced with the permission engine
-so phase 2 cannot accidentally treat a manifest declaration as authorization.
+Development databases created by an earlier pre-release schema must be reset;
+the project intentionally does not treat unpublished layouts as released
+migration sources.
 
 ## Runtime selection
 
@@ -139,8 +143,9 @@ arbitrary IPC channel.
 
 Before importing package code, the bootstrap removes direct fetch, XHR,
 WebSocket, WebTransport, WebRTC, beacon and worker globals. These APIs are not a
-substitute for a future network permission: ordinary plugins will use the
-phase-3 host broker when that permission is implemented.
+substitute for network permission: ordinary plugins use the phase-3 host broker,
+which authorizes each HTTP(S) origin, reauthorizes every redirect origin, omits
+ambient cookies, and bounds request and response bytes.
 
 ### Advanced utility runtime
 
@@ -164,10 +169,16 @@ remainder of the application process; a replacement activation is blocked
 until Netcatty restarts.
 
 The utility process is an isolation and failure-containment boundary, not the
-final permission boundary. Node plugins are still advanced code. Publisher
-trust, explicit advanced-runtime consent, resource grants, companion policy and
-quotas arrive in phases 3 and 9. This is one reason the entire runtime remains
-behind the local development gate.
+final permission boundary. Node plugins are still advanced code and must both
+declare and receive `runtime.advanced`. Phase 3 enforces that consent, scoped
+capability grants, companion digest policy and quotas. Phase 9 still adds
+publisher signatures and distribution trust. This is one reason the entire
+runtime remains behind the local development gate.
+
+`runtime.advanced` is consent to ambient Node, filesystem and network APIs in
+the contained utility process. It is not a promise that the fine-grained browser
+brokers can sandbox Node built-ins. Ordinary plugins remain broker-only; public
+advanced activation additionally depends on phase-9 verified publisher trust.
 
 ## RPC and streams
 
@@ -241,8 +252,10 @@ does not expose a permanently rejected manager as usable.
 
 Runtime logs are per-plugin, bounded and rotated. Structured fields whose names
 look like credentials, passwords, tokens, secrets or private keys are redacted.
-Secret storage is not emulated: the phase-2 SDK proxy rejects secret operations
-until the phase-3 secure broker exists.
+Secret values are encrypted through Electron `safeStorage`; the database and
+SDK retain only opaque references. Privileged host consumers receive one-use,
+operation/runtime/plugin-bound `SecretLease` objects rather than plaintext RPC
+results. See [security-and-permissions.md](security-and-permissions.md).
 
 Application quit is coordinated with plugin shutdown after Netcatty's dirty
 editor guard succeeds. Runtimes receive the two-second deactivation deadline;

--- a/docs/plugin-platform/isolated-runtime.md
+++ b/docs/plugin-platform/isolated-runtime.md
@@ -176,6 +176,10 @@ capability grants, companion digest policy and quotas. Phase 9 still adds
 publisher signatures and distribution trust. This is one reason the entire
 runtime remains behind the local development gate.
 
+CPU and memory monitoring attaches when the BrowserWindow renderer or utility
+process is created and samples immediately, so initialization and activation
+run inside the same quota boundary as the steady-state runtime.
+
 `runtime.advanced` is consent to ambient Node, filesystem and network APIs in
 the contained utility process. It is not a promise that the fine-grained browser
 brokers can sandbox Node built-ins. Ordinary plugins remain broker-only; public

--- a/docs/plugin-platform/isolated-runtime.md
+++ b/docs/plugin-platform/isolated-runtime.md
@@ -112,12 +112,17 @@ migration sources.
 An installed manifest can declare browser, Node, or both entrypoints. During
 the internal preview the host uses this deterministic placement rule:
 
-- a browser entrypoint is preferred whenever it exists;
-- a Node entrypoint is used only when no browser entrypoint exists.
+- a manifest that declares native companions is placed in the Node utility
+  runtime, including when it also declares a browser entrypoint; companion
+  manifests must provide the Node entrypoint, `runtime.advanced`, and bounded
+  `companion.execute` resources;
+- otherwise, a browser entrypoint is preferred whenever it exists;
+- a Node entrypoint is used when no browser entrypoint exists.
 
-The rule keeps dual-target plugins on the least-privileged runtime. A later
-trust phase may permit a user to select an advanced Node implementation, but it
-must not silently upgrade an ordinary plugin.
+The rule keeps ordinary dual-target plugins on the least-privileged runtime
+while making the companion exception explicit and fail closed. A later trust
+phase adds verified publisher identity to the advanced Node path; it must not
+silently upgrade an ordinary plugin.
 
 ### Ordinary browser runtime
 

--- a/docs/plugin-platform/isolated-runtime.md
+++ b/docs/plugin-platform/isolated-runtime.md
@@ -6,8 +6,9 @@ This document describes the isolated runtime introduced in phase 2 and secured
 by phase 3 of the plugin platform tracked by
 [#2269](https://github.com/binaricat/Netcatty/issues/2269). The runtime remains
 hidden behind `NETCATTY_PLUGIN_DEV=1`; there is no public settings entry or
-permission prompt yet. Without an injected host decision provider, every
-interactive capability request fails closed.
+renderer permission UI yet. The first-party development bootstrap uses a native
+Electron confirmation dialog. A host without an injected decision provider
+still fails every interactive capability request closed.
 
 ## Installation transaction
 

--- a/docs/plugin-platform/runtime-extension-boundaries.md
+++ b/docs/plugin-platform/runtime-extension-boundaries.md
@@ -1,6 +1,6 @@
 # Plugin runtime extension boundaries
 
-Status: phase 2 internal architecture review
+Status: phase 3 internal architecture review
 
 This document records the host-runtime decisions that later plugin-platform
 phases are allowed to depend on. The goal is to keep permission, contribution,
@@ -14,7 +14,7 @@ remains `0.1.0-internal` until the phase-9 API 1.0 freeze.
 
 Every activation receives a new host-generated runtime ID. The identity used by
 host handlers contains the plugin ID, active version, runtime kind, package
-root, manifest, and logger. It is captured when the runtime starts and cannot be
+root, manifest, logger, and host-resolved security principal. It is captured when the runtime starts and cannot be
 supplied or replaced by plugin messages.
 
 The RPC registry adds this identity to every request, notification, middleware
@@ -25,6 +25,7 @@ grant to all of the following without trusting payload fields:
 - one activation (`runtimeId`) for once/session grants;
 - browser or advanced utility placement;
 - declared manifest permissions and resources;
+- the unsigned or later verified publisher security principal;
 - the request cancellation and deadline context.
 
 Host-to-plugin calls also verify that the recorded activation still matches the
@@ -202,13 +203,13 @@ new protocol route. Plugin packages still cannot add mappings themselves.
 
 ## Downstream phase matrix
 
-| Phase | Depends on phase-2 seam | Work intentionally left to that phase |
+| Phase | Stable seam available to the phase | Work owned by that phase |
 | --- | --- | --- |
-| PR 3 permissions | RPC middleware, immutable runtime identity, raw-message guard, placement resolver, runtime stop events | grants, resource canonicalization, secrets, credentials, companions, quotas |
+| PR 3 permissions | RPC middleware, immutable runtime identity, raw-message guard, placement/principal resolver, runtime stop events | principal-bound grants, resource canonicalization, secrets, credentials, companions, quotas (implemented) |
 | PR 4 contributions | host-to-plugin request/notify, runtime events, host module resources | activation-event policy, command/settings/view registries, UI SDK |
 | PR 5 terminal Providers | validated host requests, cancellation, lifecycle events | Provider ranking, deadlines, snapshots, built-in highlighter/autocomplete adapters |
 | PR 6 terminal pipeline | runtime identity and placement policy | direct MessagePort fast path, sensitive-input bypass, circuit breaker |
-| PR 7 connection/auth/import | requests, validated results, streams, crash containment | profiles, challenges, SecretLease, importer transactions |
+| PR 7 connection/auth/import | requests, validated results, streams, crash containment, `CredentialRef` resolver and `SecretLease` consumer | profiles, challenges, provider lease consumption, importer transactions |
 | PR 8 sync | streams, lifecycle identity, namespaced storage boundary | dynamic providers, encrypted sidecar, CRDT state and account baselines |
 | PR 9 distribution | retained immutable versions, compare-and-set restore, placement resolver, module resources | signatures, trust, health checks, audited update and user rollback policy, API 1.0 |
 
@@ -232,10 +233,11 @@ Phase 9 health checks and rollback must preserve this ordering instead of
 writing the active-version pointer directly.
 
 `plugin_kv` is runtime-owned local data and is removed by explicit uninstall.
-Future user settings, connection profiles, encrypted secrets, grants, and CRDT
-sidecar baselines are different ownership classes. Their tables must not use
-the phase-2 `plugin_kv` cascade when the product requirement says missing plugin
-code must preserve user or synchronized data.
+Phase-3 encrypted secrets, persistent grants and security audit already use
+separate non-cascade tables. Future user settings, connection profiles and CRDT
+sidecar baselines are the same user-owned class and must not be added to the
+`plugin_kv` cascade when missing plugin code must preserve user or synchronized
+data.
 
 Activation events are declared by the public manifest, but phase 2 starts
 enabled plugins eagerly only behind the development gate. Phase 4 owns the

--- a/docs/plugin-platform/security-and-permissions.md
+++ b/docs/plugin-platform/security-and-permissions.md
@@ -12,10 +12,11 @@ inject a decision provider still fail closed.
 
 Every privileged plugin-to-host method is registered in
 `PluginHostRpcRegistry` with one explicit authorization descriptor. Parameters
-are validated first; asynchronous resource resolution then produces canonical
-resources; quota and permission middleware run immediately before the handler.
-An unclassified method is denied. The only current public method is bounded,
-redacted logging.
+are validated first; the descriptor is then built without probing protected
+host state, and quota and permission middleware run immediately before the
+handler. Filesystem and credential existence checks happen only after that
+permission boundary. An unclassified method is denied. The only current public
+method is bounded, redacted logging.
 
 The host supplies immutable plugin ID, version, runtime ID, placement, manifest,
 package root, cancellation signal, active-runtime guard, and security principal.
@@ -90,18 +91,21 @@ replay POST bodies as GET requests.
 ### Filesystem
 
 Read, write, stat and directory listing require an absolute path. Authorization
-uses the real path, and the handler requires the same canonical resource after
-permission middleware. File opens use
-`O_NOFOLLOW` where supported and recheck the opened object. Directory listing
-uses an opened directory handle and inode revalidation, so a path replacement
-cannot redirect a previously authorized list. Reads use the actual handle bytes
-rather than trusting a pre-read size, with a 1 MiB cap. Arbitrary-path writes
-currently require an existing regular file and explicit overwrite; no
-`O_CREAT` path exists because Node cannot portably bind creation to an opened
-parent-directory handle across macOS, Linux, and Windows. A later native
-implementation can add secure relative creation behind the same SDK method.
-Writes recheck runtime activity immediately before mutation, and listing is
-limited to 1,000 entries.
+first uses only the normalized requested path, so an ungranted request cannot
+probe path existence, type, symlink targets or real paths. After permission,
+the handler resolves the real path and requires it to equal the authorized
+resource; callers must therefore supply an already canonical path and symlink
+aliases fail closed. File opens use `O_NOFOLLOW` where supported and bind the
+opened handle to both the pre-open authorized inode and the current path inode.
+Directory listing uses an opened directory handle and inode revalidation, so a
+path replacement cannot redirect a previously authorized list. Reads use the
+actual handle bytes rather than trusting a pre-read size, with a 1 MiB cap.
+Arbitrary-path writes currently require an existing regular file and explicit
+overwrite; no `O_CREAT` path exists because Node cannot portably bind creation
+to an opened parent-directory handle across macOS, Linux, and Windows. A later
+native implementation can add secure relative creation behind the same SDK
+method. Writes recheck runtime activity immediately before mutation, and
+listing is limited to 1,000 entries.
 
 ### Secrets and credentials
 
@@ -116,9 +120,11 @@ single-consumption, opaque, maximum 60 seconds, and bound to plugin, active
 runtime, operation ID, abort signal and secret ownership. Only a host capability
 broker can redeem it. A plugin-owned `SecretRef`, a Netcatty-owned opaque
 `CredentialRef`, or a lease ID alone is not authority. Netcatty credential
-references use an injected main-process resolver that validates the reference
-before prompting and again before lease issue, but resolves plaintext only when
-the one-use lease is consumed. This is the stable credential handoff used by
+references use an injected main-process resolver. Authorization treats both
+secret and credential references as opaque identifiers and does not reveal
+whether they exist; ownership and existence are checked only after permission,
+immediately before lease issue. Plaintext resolves only when the one-use lease
+is consumed. This is the stable credential handoff used by
 connection/authentication Providers in PR 7.
 
 ### Companion executables

--- a/docs/plugin-platform/security-and-permissions.md
+++ b/docs/plugin-platform/security-and-permissions.md
@@ -82,9 +82,11 @@ advanced path can be publicly enabled.
 ### Network
 
 The ordinary browser SDK has no direct network primitive. `network.request` supports
-HTTP(S) only, exact origin authorization, bounded headers, a 1 MiB request and
+HTTP(S) only, exact origin authorization, bounded headers, a 128 KiB request and
 response body, explicit timeout, no URL credentials, no ambient cookies, no
 transport headers, and manual redirects. Every redirect origin is authorized.
+The SDK forwards the validated request timeout as the host RPC deadline, so the
+router cancels stalled broker work at the same boundary.
 Cross-origin redirects strip sensitive headers; 301/302/303 transitions do not
 replay POST bodies as GET requests.
 
@@ -98,9 +100,11 @@ the handler resolves the real path and requires it to equal the authorized
 resource; callers must therefore supply an already canonical path and symlink
 aliases fail closed. File opens use `O_NOFOLLOW` where supported and bind the
 opened handle to both the pre-open authorized inode and the current path inode.
-Directory listing uses an opened directory handle and inode revalidation, so a
-path replacement cannot redirect a previously authorized list. Reads use the
-actual handle bytes rather than trusting a pre-read size, with a 1 MiB cap.
+Directory listing requires a host adapter that can bind both inode checks and
+enumeration to the same native directory handle. Portable Node does not expose
+that primitive, so the default implementation fails closed while preserving
+the SDK/RPC seam for a native adapter. Reads use the actual handle bytes rather
+than trusting a pre-read size, with a 128 KiB cap. Larger payloads use streams.
 Arbitrary-path writes currently require an existing regular file and explicit
 overwrite; no `O_CREAT` path exists because Node cannot portably bind creation
 to an opened parent-directory handle across macOS, Linux, and Windows. A later
@@ -112,8 +116,11 @@ listing is limited to 1,000 entries.
 
 Secret values are encrypted with Electron `safeStorage`; unavailable OS
 encryption or Linux's insecure `basic_text` fallback denies the operation.
-SQLite stores ciphertext plus an opaque random
-`SecretRef`, never plaintext. Secret tables and grants are user-owned security
+SQLite stores ciphertext plus a `SecretRef` containing an opaque random ID and
+the non-secret originating key, never plaintext. The key lets lease permission
+checks use the same manifest resource as `secrets.get`/`set`; post-permission
+lookup revalidates that the random ID still belongs to that key and plugin.
+Secret tables and grants are user-owned security
 data and do not cascade when a package version is removed.
 
 Plugins can ask `PluginCredentialBroker` for a `SecretLeaseRef`. A lease is
@@ -122,8 +129,9 @@ runtime, operation ID, abort signal and secret ownership. Only a host capability
 broker can redeem it. A plugin-owned `SecretRef`, a Netcatty-owned opaque
 `CredentialRef`, or a lease ID alone is not authority. Netcatty credential
 references use an injected main-process resolver. Authorization treats both
-secret and credential references as opaque identifiers and does not reveal
-whether they exist; ownership and existence are checked only after permission,
+secret and credential IDs as opaque identifiers and does not reveal whether
+they exist; secret keys are already plugin-declared resources. Ownership,
+ID-to-key binding, and existence are checked only after permission,
 immediately before lease issue. Plaintext resolves only when the one-use lease
 is consumed. This is the stable credential handoff used by
 connection/authentication Providers in PR 7.
@@ -140,6 +148,8 @@ method-not-found; privileged work remains in the main host brokers.
 Timed-out companion RPC identifiers are retired until one late response is
 discarded, and the runtime SDK retries a failed stop rather than marking the
 handle locally stopped before the host confirms cleanup.
+The validated companion request timeout is also forwarded as its host RPC
+deadline.
 
 On POSIX, companions start in a dedicated process group; shutdown signals the
 whole group, escalates the whole group to `SIGKILL`, and waits until it no longer
@@ -178,12 +188,17 @@ after durable user data can exist.
 ## Downstream contracts
 
 - PR 4 consumes `PermissionRequest`, structured grant lists/revocation, runtime
-  events and the existing RPC registry for settings/commands/views.
+  events and the existing RPC registry for settings/commands/views. Secret
+  settings retain their declared key in `SecretRef` without exposing plaintext.
 - PRs 5-6 reuse immutable caller identity, permission middleware, cancellation,
   quotas and runtime-stop cleanup; the direct terminal fast path remains a
-  separate MessagePort and must still enforce sensitive-input bypass.
-- PR 7 consumes operation-bound secret leases and digest-verified companions.
-- PR 8 stores encrypted sync sidecars separately from package cascade storage.
+  separate MessagePort and must still enforce sensitive-input bypass. Their
+  larger payloads use streams rather than the 128 KiB control-plane budget.
+- PR 7 consumes operation-bound secret leases and digest-verified companions;
+  secret lease authorization uses the declared key while ID ownership remains
+  a post-permission lookup. Importers use bounded streams, not directory walks.
+- PR 8 stores encrypted sync sidecars separately from package cascade storage
+  and transports larger encrypted objects over the existing stream seam.
 - PR 9 supplies signed publisher principals and trust policy through placement;
   signed identity changes force a fresh grant instead of widening an unsigned
   grant silently.

--- a/docs/plugin-platform/security-and-permissions.md
+++ b/docs/plugin-platform/security-and-permissions.md
@@ -1,0 +1,158 @@
+# Plugin security and permission boundary
+
+Status: phase 3 internal preview (`0.1.0-internal`)
+
+This phase is available only with `NETCATTY_PLUGIN_DEV=1`. It is deliberately
+usable by later contribution and Provider phases, but it is not a public plugin
+release. There is no renderer permission UI yet. If the host does not inject a
+decision provider, interactive permission requests fail closed.
+
+## Authority model
+
+Every privileged plugin-to-host method is registered in
+`PluginHostRpcRegistry` with one explicit authorization descriptor. Parameters
+are validated first; asynchronous resource resolution then produces canonical
+resources; quota and permission middleware run immediately before the handler.
+An unclassified method is denied. The only current public method is bounded,
+redacted logging.
+
+The host supplies immutable plugin ID, version, runtime ID, placement, manifest,
+package root, cancellation signal, active-runtime guard, and security principal.
+Plugin payload fields can never replace that identity. The default pre-signature
+principal is a hash of plugin ID, declared publisher, and immutable package
+SHA-256, so changed unsigned code cannot inherit persistent grants. The
+placement seam also accepts a `resolveSecurityPrincipal` function so phase 9 can
+substitute a verified publisher-key fingerprint without changing the permission
+engine.
+
+The grant key includes:
+
+- plugin ID and permission;
+- canonical resource;
+- required-versus-optional declaration semantics and declared resource bounds;
+- the host-resolved security principal.
+
+Changing any declaration boundary or principal invalidates reuse. A renderer
+decision cannot grant a resource broader than the manifest declaration.
+Permission prompts use the canonical contract directly: absent operation and
+session IDs are omitted, long host-generated operation IDs become stable
+SHA-256 identifiers, reasons are bounded, and no request can carry more than
+128 canonical resources.
+Runtime trust/placement resolves before permission prompts. The special
+`runtime.advanced` permission is excluded from generic required-permission
+preflight and requested exactly once only when the host actually selects the
+utility runtime.
+
+## Grant lifetimes
+
+- `once` applies only to the request waiting on that decision and is not stored.
+- `session` is held in memory and requires a host-owned session ID; ending the
+  session removes it.
+- `application` is held in memory until explicit revoke or shutdown.
+- `always` is persisted in `plugin_permission_grants`.
+
+All lifetimes use the same resource-coverage function. A filesystem directory
+grant covers its descendants with path-boundary comparison; an origin or
+companion grant is exact; `*` is valid only when the manifest declaration also
+allows it. Concurrent identical prompts coalesce. Prompt timeout, runtime abort,
+cancel, denial, absence of a decision provider, and stale activation all fail
+closed. Grant/use/deny/revoke events enter the bounded security audit.
+
+`PermissionRequest` is part of the canonical Schema and carries plugin display
+identity, version, runtime placement, permission, canonical resources, reason,
+operation and optional host session. This is the complete PR-4 UI handoff; the
+renderer must return the same request ID and one canonical lifetime decision.
+
+## Host-mediated capabilities
+
+These brokers are the only authority path for ordinary browser plugins. An
+advanced utility entrypoint is intentionally different: `runtime.advanced`
+means explicit consent to ambient Node, filesystem and network APIs in its
+contained process. Fine-grained broker grants do not sandbox that ambient Node
+authority. Phase 9 must also require a verified publisher principal before the
+advanced path can be publicly enabled.
+
+### Network
+
+The ordinary browser SDK has no direct network primitive. `network.request` supports
+HTTP(S) only, exact origin authorization, bounded headers, a 1 MiB request and
+response body, explicit timeout, no URL credentials, no ambient cookies, no
+transport headers, and manual redirects. Every redirect origin is authorized.
+Cross-origin redirects strip sensitive headers; 301/302/303 transitions do not
+replay POST bodies as GET requests.
+
+### Filesystem
+
+Read, write, stat and directory listing require an absolute path. Authorization
+uses the real path (or real parent for a new file), and the handler requires the
+same canonical resource after permission middleware. File opens use
+`O_NOFOLLOW` where supported and recheck the opened object. Reads use the actual
+handle bytes rather than trusting a pre-read size, with a 1 MiB cap. Writes are
+exclusive unless overwrite is explicit, create mode is `0600`, and listing is
+limited to 1,000 entries.
+
+### Secrets and credentials
+
+Secret values are encrypted with Electron `safeStorage`; unavailable OS
+encryption or Linux's insecure `basic_text` fallback denies the operation.
+SQLite stores ciphertext plus an opaque random
+`SecretRef`, never plaintext. Secret tables and grants are user-owned security
+data and do not cascade when a package version is removed.
+
+Plugins can ask `PluginCredentialBroker` for a `SecretLeaseRef`. A lease is
+single-consumption, opaque, maximum 60 seconds, and bound to plugin, active
+runtime, operation ID, abort signal and secret ownership. Only a host capability
+broker can redeem it. A plugin-owned `SecretRef`, a Netcatty-owned opaque
+`CredentialRef`, or a lease ID alone is not authority. Netcatty credential
+references use an injected main-process resolver that validates the reference
+before prompting and again before lease issue, but resolves plaintext only when
+the one-use lease is consumed. This is the stable credential handoff used by
+connection/authentication Providers in PR 7.
+
+### Companion executables
+
+Only the manifest variant matching the current OS/architecture can start. Its
+real path must remain inside the package, be a regular file, and match the
+declared SHA-256 immediately before spawn. The host uses an absolute executable,
+empty argument vector, private plugin data directory, minimal environment,
+`shell:false`, bounded Content-Length JSON-RPC, at most four processes per
+runtime and 64 pending calls per process. Companion-to-host methods receive
+method-not-found; privileged work remains in the main host brokers.
+
+Shutdown requests termination, escalates to SIGKILL, and still waits for exit.
+An unreaped companion is a containment failure and disables its plugin. Runtime
+stop events revoke leases and release all owned companion handles.
+
+## Quotas and failure behavior
+
+The raw-message token bucket runs before schema traversal. Capability
+concurrency/rate, logging rate, per-category byte windows, companion count and
+pending RPC limits bound retained work. Electron process metrics enforce memory
+and sustained-CPU policy for browser/utility runtimes and companion processes.
+A process policy violation disables and stops only its owning plugin.
+
+Network, filesystem, secret, credential and companion handlers recheck the
+active runtime immediately before commits or returned results. Cancellation,
+disable, update, uninstall, quarantine and shutdown therefore cannot resume a
+stale privileged operation.
+
+## Initial database policy
+
+The plugin platform has never shipped. The complete current database remains
+schema version 1 and includes package/runtime tables plus grants, secrets and
+security audit. There is no migration chain. A developer using an older preview
+must reset `userData/plugins/plugins.sqlite`; released migrations begin only
+after durable user data can exist.
+
+## Downstream contracts
+
+- PR 4 consumes `PermissionRequest`, structured grant lists/revocation, runtime
+  events and the existing RPC registry for settings/commands/views.
+- PRs 5-6 reuse immutable caller identity, permission middleware, cancellation,
+  quotas and runtime-stop cleanup; the direct terminal fast path remains a
+  separate MessagePort and must still enforce sensitive-input bypass.
+- PR 7 consumes operation-bound secret leases and digest-verified companions.
+- PR 8 stores encrypted sync sidecars separately from package cascade storage.
+- PR 9 supplies signed publisher principals and trust policy through placement;
+  signed identity changes force a fresh grant instead of widening an unsigned
+  grant silently.

--- a/docs/plugin-platform/security-and-permissions.md
+++ b/docs/plugin-platform/security-and-permissions.md
@@ -79,6 +79,18 @@ contained process. Fine-grained broker grants do not sandbox that ambient Node
 authority. Phase 9 must also require a verified publisher principal before the
 advanced path can be publicly enabled.
 
+Required resource-scoped permissions (`network`, filesystem read/write, and
+companion execution) must declare non-empty activation-time resource bounds.
+The string shorthand remains available only for optional declarations, whose
+concrete resource is approved on first use. A package update therefore cannot
+activate first and defer a newly required resource decision until later.
+
+Native companions are an advanced-runtime capability. Their manifests require
+a Node utility entrypoint plus `runtime.advanced`, and `companion.start` rejects
+browser runtime identities before permission middleware can persist a grant.
+The supervisor repeats the placement check immediately before reserving or
+spawning a process. Phase 9 adds verified publisher trust to this same boundary.
+
 ### Network
 
 The ordinary browser SDK has no direct network primitive. `network.request` supports

--- a/docs/plugin-platform/security-and-permissions.md
+++ b/docs/plugin-platform/security-and-permissions.md
@@ -65,7 +65,9 @@ closed. Grant/use/deny/revoke events enter the bounded security audit.
 identity, version, runtime placement, permission, canonical resources and their
 aligned resource kinds, reason, operation and optional host session. This is
 the complete PR-4 UI handoff; the renderer must return the same request ID and
-one canonical lifetime decision.
+one canonical lifetime decision. The native fallback visibly escapes control,
+line-separator, and bidirectional-control characters in every plugin-controlled
+display field so untrusted text cannot forge labels or resource lines.
 
 ## Host-mediated capabilities
 
@@ -88,14 +90,18 @@ replay POST bodies as GET requests.
 ### Filesystem
 
 Read, write, stat and directory listing require an absolute path. Authorization
-uses the real path (or real parent for a new file), and the handler requires the
-same canonical resource after permission middleware. File opens use
+uses the real path, and the handler requires the same canonical resource after
+permission middleware. File opens use
 `O_NOFOLLOW` where supported and recheck the opened object. Directory listing
 uses an opened directory handle and inode revalidation, so a path replacement
 cannot redirect a previously authorized list. Reads use the actual handle bytes
-rather than trusting a pre-read size, with a 1 MiB cap. Writes are exclusive
-unless overwrite is explicit, create mode is `0600`, recheck runtime activity
-immediately before mutation, and listing is limited to 1,000 entries.
+rather than trusting a pre-read size, with a 1 MiB cap. Arbitrary-path writes
+currently require an existing regular file and explicit overwrite; no
+`O_CREAT` path exists because Node cannot portably bind creation to an opened
+parent-directory handle across macOS, Linux, and Windows. A later native
+implementation can add secure relative creation behind the same SDK method.
+Writes recheck runtime activity immediately before mutation, and listing is
+limited to 1,000 entries.
 
 ### Secrets and credentials
 
@@ -128,9 +134,13 @@ Timed-out companion RPC identifiers are retired until one late response is
 discarded, and the runtime SDK retries a failed stop rather than marking the
 handle locally stopped before the host confirms cleanup.
 
-Shutdown requests termination, escalates to SIGKILL, and still waits for exit.
-An unreaped companion is a containment failure and disables its plugin. Runtime
-stop events revoke leases and release all owned companion handles.
+On POSIX, companions start in a dedicated process group; shutdown signals the
+whole group, escalates the whole group to `SIGKILL`, and waits until it no longer
+exists. Windows uses shell-free `taskkill /T` for both graceful and forced tree
+cleanup. A direct parent exit also starts tree cleanup before the handle or
+quota monitor is released. An unreaped companion tree is a containment failure
+and disables its plugin. Runtime stop events revoke leases and release all owned
+companion handles.
 
 ## Quotas and failure behavior
 
@@ -138,7 +148,10 @@ The raw-message token bucket runs before schema traversal. Capability
 concurrency/rate, logging rate, per-category byte windows, companion count and
 pending RPC limits bound retained work. Electron process metrics enforce memory
 and sustained-CPU policy for browser/utility runtimes and companion processes.
-A process policy violation disables and stops only its owning plugin.
+The runtime monitor is attached and takes its first sample immediately when the
+BrowserWindow renderer or utility process is created, before initialize or
+activation runs. A process policy violation disables and stops only its owning
+plugin.
 
 Network, filesystem, secret, credential and companion handlers recheck the
 active runtime immediately before commits or returned results. Cancellation,

--- a/docs/plugin-platform/security-and-permissions.md
+++ b/docs/plugin-platform/security-and-permissions.md
@@ -91,8 +91,9 @@ replay POST bodies as GET requests.
 ### Filesystem
 
 Read, write, stat and directory listing require an absolute path. Authorization
-first uses only the normalized requested path, so an ungranted request cannot
-probe path existence, type, symlink targets or real paths. After permission,
+first uses only the lexically resolved requested path, including removal of
+redundant trailing separators, so an ungranted request cannot probe path
+existence, type, symlink targets or real paths. After permission,
 the handler resolves the real path and requires it to equal the authorized
 resource; callers must therefore supply an already canonical path and symlink
 aliases fail closed. File opens use `O_NOFOLLOW` where supported and bind the
@@ -146,7 +147,9 @@ exists. Windows uses shell-free `taskkill /T` for both graceful and forced tree
 cleanup. A direct parent exit also starts tree cleanup before the handle or
 quota monitor is released. An unreaped companion tree is a containment failure
 and disables its plugin. Runtime stop events revoke leases and release all owned
-companion handles.
+companion handles. Disable, restart, upgrade and uninstall wait for that tree
+cleanup before returning or mutating package code; a cleanup failure is
+persisted as a containment failure and blocks replacement activation.
 
 ## Quotas and failure behavior
 

--- a/docs/plugin-platform/security-and-permissions.md
+++ b/docs/plugin-platform/security-and-permissions.md
@@ -80,7 +80,8 @@ authority. Phase 9 must also require a verified publisher principal before the
 advanced path can be publicly enabled.
 
 Required resource-scoped permissions (`network`, filesystem read/write, and
-companion execution) must declare non-empty activation-time resource bounds.
+companion execution) must declare non-empty activation-time resource bounds;
+the all-resources `*` wildcard is not a valid bound.
 The string shorthand remains available only for optional declarations, whose
 concrete resource is approved on first use. A package update therefore cannot
 activate first and defer a newly required resource decision until later.
@@ -88,6 +89,8 @@ activate first and defer a newly required resource decision until later.
 Native companions are an advanced-runtime capability. Their manifests require
 a Node utility entrypoint plus `runtime.advanced`, and `companion.start` rejects
 browser runtime identities before permission middleware can persist a grant.
+The first-party placement path selects the utility runtime whenever companions
+are declared, including manifests that also provide a browser entrypoint.
 The supervisor repeats the placement check immediately before reserving or
 spawning a process. Phase 9 adds verified publisher trust to this same boundary.
 

--- a/docs/plugin-platform/security-and-permissions.md
+++ b/docs/plugin-platform/security-and-permissions.md
@@ -4,8 +4,9 @@ Status: phase 3 internal preview (`0.1.0-internal`)
 
 This phase is available only with `NETCATTY_PLUGIN_DEV=1`. It is deliberately
 usable by later contribution and Provider phases, but it is not a public plugin
-release. There is no renderer permission UI yet. If the host does not inject a
-decision provider, interactive permission requests fail closed.
+release. There is no renderer permission UI yet. The first-party development
+bootstrap injects a native Electron confirmation dialog; embedders that do not
+inject a decision provider still fail closed.
 
 ## Authority model
 
@@ -51,17 +52,20 @@ utility runtime.
 - `application` is held in memory until explicit revoke or shutdown.
 - `always` is persisted in `plugin_permission_grants`.
 
-All lifetimes use the same resource-coverage function. A filesystem directory
-grant covers its descendants with path-boundary comparison; an origin or
-companion grant is exact; `*` is valid only when the manifest declaration also
-allows it. Concurrent identical prompts coalesce. Prompt timeout, runtime abort,
+All lifetimes use the same resource-coverage function. Every resource carries
+an explicit `exact` or `directory` kind. Only a filesystem `directory` grant
+covers descendants with path-boundary comparison; a file remains exact even if
+the path is later replaced by a directory. Origins and companions are exact;
+`*` is valid only when the manifest declaration also allows it. Concurrent
+identical prompts coalesce. Prompt timeout, runtime abort,
 cancel, denial, absence of a decision provider, and stale activation all fail
 closed. Grant/use/deny/revoke events enter the bounded security audit.
 
 `PermissionRequest` is part of the canonical Schema and carries plugin display
-identity, version, runtime placement, permission, canonical resources, reason,
-operation and optional host session. This is the complete PR-4 UI handoff; the
-renderer must return the same request ID and one canonical lifetime decision.
+identity, version, runtime placement, permission, canonical resources and their
+aligned resource kinds, reason, operation and optional host session. This is
+the complete PR-4 UI handoff; the renderer must return the same request ID and
+one canonical lifetime decision.
 
 ## Host-mediated capabilities
 
@@ -86,10 +90,12 @@ replay POST bodies as GET requests.
 Read, write, stat and directory listing require an absolute path. Authorization
 uses the real path (or real parent for a new file), and the handler requires the
 same canonical resource after permission middleware. File opens use
-`O_NOFOLLOW` where supported and recheck the opened object. Reads use the actual
-handle bytes rather than trusting a pre-read size, with a 1 MiB cap. Writes are
-exclusive unless overwrite is explicit, create mode is `0600`, and listing is
-limited to 1,000 entries.
+`O_NOFOLLOW` where supported and recheck the opened object. Directory listing
+uses an opened directory handle and inode revalidation, so a path replacement
+cannot redirect a previously authorized list. Reads use the actual handle bytes
+rather than trusting a pre-read size, with a 1 MiB cap. Writes are exclusive
+unless overwrite is explicit, create mode is `0600`, recheck runtime activity
+immediately before mutation, and listing is limited to 1,000 entries.
 
 ### Secrets and credentials
 
@@ -118,6 +124,9 @@ empty argument vector, private plugin data directory, minimal environment,
 `shell:false`, bounded Content-Length JSON-RPC, at most four processes per
 runtime and 64 pending calls per process. Companion-to-host methods receive
 method-not-found; privileged work remains in the main host brokers.
+Timed-out companion RPC identifiers are retired until one late response is
+discarded, and the runtime SDK retries a failed stop rather than marking the
+handle locally stopped before the host confirms cleanup.
 
 Shutdown requests termination, escalates to SIGKILL, and still waits for exit.
 An unreaped companion is a containment failure and disables its plugin. Runtime

--- a/docs/plugin-platform/threat-model.md
+++ b/docs/plugin-platform/threat-model.md
@@ -232,10 +232,12 @@ semantics. A new principal or changed required/resource declaration requires a
 new decision.
 
 Network access is origin-scoped, cookie-free and redirect-by-redirect. File
-access is absolute-realpath scoped and binds the path authorized by middleware
-to the object used by the handler. Arbitrary-path creation is denied until a
-portable opened-parent implementation exists; overwriting an existing regular
-file remains available without exposing a parent-symlink creation race.
+access authorizes a normalized absolute request without probing the filesystem,
+then resolves it after permission and requires the caller to have supplied that
+canonical real path. Opened reads are bound to the authorized pre-open inode and
+the current path inode. Arbitrary-path creation is denied until a portable
+opened-parent implementation exists; overwriting an existing regular file
+remains available without exposing a parent-symlink creation race.
 Companion executables are package-contained, digest-verified immediately before
 shell-free spawn, host-RPC clients only, and their complete process group/tree
 must be reaped before their handle is released. Failure to contain a companion

--- a/docs/plugin-platform/threat-model.md
+++ b/docs/plugin-platform/threat-model.md
@@ -232,7 +232,7 @@ semantics. A new principal or changed required/resource declaration requires a
 new decision.
 
 Network access is origin-scoped, cookie-free and redirect-by-redirect. File
-access authorizes a normalized absolute request without probing the filesystem,
+access authorizes a lexically resolved absolute request without probing the filesystem,
 then resolves it after permission and requires the caller to have supplied that
 canonical real path. Opened reads are bound to the authorized pre-open inode and
 the current path inode. Arbitrary-path creation is denied until a portable
@@ -241,7 +241,8 @@ remains available without exposing a parent-symlink creation race.
 Companion executables are package-contained, digest-verified immediately before
 shell-free spawn, host-RPC clients only, and their complete process group/tree
 must be reaped before their handle is released. Failure to contain a companion
-disables its plugin.
+disables its plugin, persists the containment error, and prevents package
+mutation or replacement activation until containment is restored.
 
 Secret plaintext is encrypted by Electron `safeStorage` and never returned by
 ordinary secret RPC. A credential consumer must redeem a one-use lease bound to

--- a/docs/plugin-platform/threat-model.md
+++ b/docs/plugin-platform/threat-model.md
@@ -1,6 +1,6 @@
 # Plugin platform threat model
 
-Status: phase 2 internal runtime
+Status: phase 3 internal security boundary
 
 Plugins are untrusted code. A useful plugin may parse terminal output, display
 content, call remote services, or ship a native companion; none of those needs
@@ -9,7 +9,8 @@ imply trust in the author's code, update server, dependencies, or account.
 This threat model records the security properties that the nine-stage platform
 must preserve. Phase 1 enforces package-format properties and defines the wire
 types. Phase 2 implements process isolation and lifecycle containment behind a
-development gate; later phases add capability mediation and distribution trust.
+development gate. Phase 3 adds capability mediation, scoped grants, encrypted
+secrets, companion containment and quotas; later phases add distribution trust.
 
 ## Protected assets
 
@@ -111,9 +112,11 @@ protocol with a restrictive Content Security Policy. The bootstrap removes
 direct fetch, socket, WebRTC, transport and worker globals before importing
 plugin code. Its isolated session is also offline behind an unreachable proxy,
 with non-proxied WebRTC disabled, so a fresh iframe global cannot restore
-network authority. Network access can only be added later through a checked
-host broker. Privileged plugins run in separate utility processes rather than
-the Netcatty main process.
+network authority. Ordinary browser plugins access the network only through the
+checked phase-3 host broker. An advanced utility plugin is an explicit high-risk
+exception: `runtime.advanced` consents to ambient Node, filesystem and network
+authority in a contained process. It never runs in the Netcatty main process,
+and phase 9 must additionally require verified publisher trust.
 
 ### Confused deputy
 
@@ -136,16 +139,20 @@ Secret values are never ordinary settings or JSON-RPC results. The credential
 broker uses operation-bound, single-use leases. Terminal sensitive-input mode
 bypasses third-party hooks unconditionally. Logs, diagnostics, synchronization,
 and crash reports redact secret fields before persistence.
-The SDK secret store returns an opaque `SecretRef`, never stored plaintext. The
-reference is not treated as a bearer capability: every privileged use must
-revalidate the calling plugin, resource ownership, permission, and operation.
+The SDK secret store returns an opaque `SecretRef`, never stored plaintext.
+Netcatty-owned Vault material uses a distinct opaque `CredentialRef`; its
+main-process resolver validates availability without materializing plaintext,
+then resolves only while consuming an operation-bound lease. Neither reference
+is treated as a bearer capability: every privileged use must revalidate the
+calling plugin, resource ownership, permission, runtime, and operation.
 
 ### Denial of service
 
 RPC requests have deadlines and cancellation IDs. Streams have explicit byte
-windows. The phase-2 supervisor enforces activation and shutdown deadlines,
-bounded pending work, bounded logs, and crash quarantine. Later permission and
-terminal phases add CPU/memory/rate quotas and interceptor circuit breakers. A
+windows. The supervisor enforces activation and shutdown deadlines, bounded
+pending work, bounded logs, crash quarantine, raw-message/capability/byte
+quotas, and CPU/memory monitoring for runtimes and companions. Later terminal
+phases add interceptor circuit breakers. A
 failed plugin must not stop unrelated plugins or terminal sessions.
 
 RPC control JSON is capped at 1 MiB. Stream frames use a separate 24 MiB JSON
@@ -210,9 +217,31 @@ Phase 2 implements package installation, isolated browser and utility-process
 runtimes, bounded RPC/streams, lifecycle deadlines and crash quarantine. These
 paths remain disabled unless `NETCATTY_PLUGIN_DEV=1` is set. The browser path
 has no ambient Node, Electron, filesystem or network authority. The Node path is
-explicitly an advanced runtime and is not considered safe for public enablement
-until later phases add permission enforcement and signed trust policy.
+explicitly an advanced runtime and remains behind the development gate until
+phase 9 adds signed trust policy.
 
-The phase does not synthesize grants or secret storage. Calls that would need
-those facilities fail closed, preserving the distinction between a manifest
-declaration, a future user grant, and actual host authority.
+## Phase 3 capability boundary
+
+Phase 3 installs the permission engine at the final host RPC boundary. A
+declaration is never a grant. `once`, host-session, application, and persistent
+grants share canonical resource-coverage rules and are bound to a declaration
+hash plus a host-resolved security principal. The current unsigned principal is
+derived from plugin ID, publisher, and immutable package SHA-256; phase 9 can replace it with a verified
+publisher-key identity through the placement resolver without changing grant
+semantics. A new principal or changed required/resource declaration requires a
+new decision.
+
+Network access is origin-scoped, cookie-free and redirect-by-redirect. File
+access is absolute-realpath scoped and binds the path authorized by middleware
+to the object used by the handler. Companion executables are package-contained,
+digest-verified immediately before shell-free spawn, host-RPC clients only, and
+must be reaped before their handle is released. Failure to contain a companion
+disables its plugin.
+
+Secret plaintext is encrypted by Electron `safeStorage` and never returned by
+ordinary secret RPC. A credential consumer must redeem a one-use lease bound to
+plugin, runtime, operation, abort signal and a maximum 60-second lifetime.
+Transport, capability, log, byte, process-count, pending-call, memory and CPU
+quotas contain abusive runtimes and companions. The capability boundary remains
+disabled unless `NETCATTY_PLUGIN_DEV=1` is set, and without a renderer decision
+provider interactive permission requests fail closed.

--- a/docs/plugin-platform/threat-model.md
+++ b/docs/plugin-platform/threat-model.md
@@ -233,8 +233,11 @@ new decision.
 
 Network access is origin-scoped, cookie-free and redirect-by-redirect. File
 access is absolute-realpath scoped and binds the path authorized by middleware
-to the object used by the handler. Companion executables are package-contained,
-digest-verified immediately before shell-free spawn, host-RPC clients only, and
+to the object used by the handler. Arbitrary-path creation is denied until a
+portable opened-parent implementation exists; overwriting an existing regular
+file remains available without exposing a parent-symlink creation race.
+Companion executables are package-contained, digest-verified immediately before
+shell-free spawn, host-RPC clients only, and their complete process group/tree
 must be reaped before their handle is released. Failure to contain a companion
 disables its plugin.
 
@@ -245,4 +248,6 @@ Transport, capability, log, byte, process-count, pending-call, memory and CPU
 quotas contain abusive runtimes and companions. The capability boundary remains
 disabled unless `NETCATTY_PLUGIN_DEV=1` is set. The first-party development path
 injects a native Electron decision provider; any host without a decision
-provider fails interactive permission requests closed.
+provider fails interactive permission requests closed. Runtime CPU/memory
+monitoring begins at process creation rather than after plugin activation, and
+native prompt text escapes control and bidirectional formatting characters.

--- a/docs/plugin-platform/threat-model.md
+++ b/docs/plugin-platform/threat-model.md
@@ -243,5 +243,6 @@ ordinary secret RPC. A credential consumer must redeem a one-use lease bound to
 plugin, runtime, operation, abort signal and a maximum 60-second lifetime.
 Transport, capability, log, byte, process-count, pending-call, memory and CPU
 quotas contain abusive runtimes and companions. The capability boundary remains
-disabled unless `NETCATTY_PLUGIN_DEV=1` is set, and without a renderer decision
-provider interactive permission requests fail closed.
+disabled unless `NETCATTY_PLUGIN_DEV=1` is set. The first-party development path
+injects a native Electron decision provider; any host without a decision
+provider fails interactive permission requests closed.

--- a/electron/main/registerBridges.cjs
+++ b/electron/main/registerBridges.cjs
@@ -98,7 +98,7 @@ function createBridgeRegistrar(context) {
       env: process.env,
       createService: () => {
         const { createPluginHostService } = require("../plugins/hostService.cjs");
-        return createPluginHostService({ app, electron: electronModule });
+        return createPluginHostService({ app, electron: electronModule, safeStorage });
       },
       registerShutdown: (handler) => {
         const { registerPluginShutdown } = require("../plugins/shutdownCoordinator.cjs");

--- a/electron/main/registerBridges.cjs
+++ b/electron/main/registerBridges.cjs
@@ -98,7 +98,18 @@ function createBridgeRegistrar(context) {
       env: process.env,
       createService: () => {
         const { createPluginHostService } = require("../plugins/hostService.cjs");
-        return createPluginHostService({ app, electron: electronModule, safeStorage });
+        const {
+          createNativePermissionDecisionProvider,
+        } = require("../plugins/nativePermissionDecision.cjs");
+        return createPluginHostService({
+          app,
+          electron: electronModule,
+          safeStorage,
+          requestPermissionDecision: createNativePermissionDecisionProvider({
+            dialog: electronModule.dialog,
+            window: win,
+          }),
+        });
       },
       registerShutdown: (handler) => {
         const { registerPluginShutdown } = require("../plugins/shutdownCoordinator.cjs");

--- a/electron/plugins/browserPluginRuntime.cjs
+++ b/electron/plugins/browserPluginRuntime.cjs
@@ -286,6 +286,11 @@ class BrowserPluginRuntime {
     return this.router.streams.openOutgoing(streamId, windowBytes);
   }
 
+  getProcessId() {
+    if (!this.window || this.window.isDestroyed()) return null;
+    return this.window.webContents.getOSProcessId?.() ?? null;
+  }
+
   #handleExit(error) {
     if (!this.router) return;
     const router = this.router;

--- a/electron/plugins/browserPluginRuntime.cjs
+++ b/electron/plugins/browserPluginRuntime.cjs
@@ -54,6 +54,7 @@ class BrowserPluginRuntime {
     this.onIncomingStream = options.onIncomingStream;
     this.onBeforeMessage = options.onBeforeMessage;
     this.onProgress = options.onProgress;
+    this.onProcessReady = options.onProcessReady ?? (() => {});
     this.logger = options.logger ?? { write() {} };
     this.onExit = options.onExit ?? (() => {});
     this.onProtocolError = options.onProtocolError ?? (() => {});
@@ -153,6 +154,7 @@ class BrowserPluginRuntime {
         preload: this.preloadPath,
       },
     });
+    this.onProcessReady();
     const contents = this.window.webContents;
     contents.setWebRTCIPHandlingPolicy("disable_non_proxied_udp");
     contents.on("console-message", (details) => {

--- a/electron/plugins/browserPluginRuntime.test.cjs
+++ b/electron/plugins/browserPluginRuntime.test.cjs
@@ -78,6 +78,7 @@ test("browser host waits for preload and the installed plugin RPC listener", asy
   const port1 = new FakePort();
   const port2 = new FakePort();
   const onBeforeMessage = () => {};
+  let processReadyCalls = 0;
   let sessionDisposed = false;
   const runtime = new BrowserPluginRuntime({
     electron: {
@@ -101,6 +102,7 @@ test("browser host waits for preload and the installed plugin RPC listener", asy
     preloadPath: "/runtime/browserPreload.cjs",
     handlers: {},
     onBeforeMessage,
+    onProcessReady: () => { processReadyCalls += 1; },
   });
 
   const started = runtime.start({
@@ -112,6 +114,7 @@ test("browser host waits for preload and the installed plugin RPC listener", asy
     enabledFeatures: [],
   });
   await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(processReadyCalls, 1);
   contents.emit("ipc-message", {}, "netcatty-plugin:preload-ready");
   resolveLoading();
   await new Promise((resolve) => setImmediate(resolve));

--- a/electron/plugins/companionSupervisor.cjs
+++ b/electron/plugins/companionSupervisor.cjs
@@ -47,6 +47,16 @@ function assertCompanionMethod(value) {
   return value;
 }
 
+function assertAdvancedCompanionContext(context) {
+  if (context?.runtimeKind !== "utility" || typeof context.manifest?.main?.node !== "string") {
+    throw new PluginRpcError(
+      RPC_ERRORS.permissionDenied,
+      "Plugin companions require an advanced utility runtime",
+      { pluginCode: "permission_denied" },
+    );
+  }
+}
+
 function rpcIdKey(id) {
   return `${typeof id}:${String(id)}`;
 }
@@ -357,7 +367,8 @@ class PluginCompanionSupervisor {
     return { handleId: assertHandleId(params.handleId) };
   }
 
-  describeStartAuthorization(params) {
+  describeStartAuthorization(params, context) {
+    assertAdvancedCompanionContext(context);
     const value = this.validateStart(params);
     return {
       permission: "companion.execute",
@@ -399,6 +410,7 @@ class PluginCompanionSupervisor {
 
   async start(params, context) {
     if (this.closed) throw new PluginRpcError(RPC_ERRORS.unavailable, "Plugin companion supervisor is closed");
+    assertAdvancedCompanionContext(context);
     const { companionId } = this.validateStart(params);
     const releaseReservation = this.#reserveStart(context.runtimeId);
     return this.#startReserved(companionId, context).finally(releaseReservation);

--- a/electron/plugins/companionSupervisor.cjs
+++ b/electron/plugins/companionSupervisor.cjs
@@ -1,0 +1,474 @@
+"use strict";
+
+const { createHash, randomUUID } = require("node:crypto");
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const path = require("node:path");
+const { spawn: nodeSpawn } = require("node:child_process");
+
+const { isPathInside } = require("./paths.cjs");
+const { canonicalizeCompanionResource } = require("./permissionResources.cjs");
+const { PluginRpcError, RPC_ERRORS } = require("./rpcRouter.cjs");
+
+const MAX_COMPANIONS_PER_RUNTIME = 4;
+const MAX_COMPANION_PENDING = 64;
+const MAX_COMPANION_STDERR_BYTES = 64 * 1024;
+
+function platformKey(platform = process.platform, arch = process.arch) {
+  return `${platform}-${arch}`;
+}
+
+function assertCompanionId(value) {
+  try {
+    return canonicalizeCompanionResource(value);
+  } catch {
+    throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Plugin companion ID is invalid");
+  }
+}
+
+function assertHandleId(value) {
+  if (typeof value !== "string" || value.length < 16 || value.length > 128) {
+    throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Plugin companion handle is invalid");
+  }
+  return value;
+}
+
+function assertCompanionMethod(value) {
+  if (
+    typeof value !== "string"
+    || value.length < 1
+    || value.length > 256
+    || value.startsWith("$/")
+    || !/^[A-Za-z][A-Za-z0-9_.-]*$/u.test(value)
+  ) throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Plugin companion RPC method is invalid");
+  return value;
+}
+
+function rpcIdKey(id) {
+  return `${typeof id}:${String(id)}`;
+}
+
+async function sha256File(filePath) {
+  const hash = createHash("sha256");
+  const input = fs.createReadStream(filePath);
+  for await (const chunk of input) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+async function resolveCompanionVariant(identity, companionId, targetPlatform = platformKey()) {
+  const companion = identity.manifest.companionExecutables?.find(({ id }) => id === companionId);
+  if (!companion) throw new PluginRpcError(RPC_ERRORS.notFound, "Plugin companion is not declared");
+  const variant = companion.variants.find(({ platforms }) => platforms.includes(targetPlatform));
+  if (!variant) throw new PluginRpcError(RPC_ERRORS.unsupported, "Plugin companion has no compatible binary");
+  const candidate = path.resolve(identity.packageRoot, ...variant.path.split("/"));
+  const [realRoot, realCandidate] = await Promise.all([
+    fsp.realpath(identity.packageRoot),
+    fsp.realpath(candidate),
+  ]);
+  if (!isPathInside(realRoot, realCandidate)) {
+    throw new PluginRpcError(RPC_ERRORS.permissionDenied, "Plugin companion escapes its package");
+  }
+  const stats = await fsp.lstat(realCandidate);
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    throw new PluginRpcError(RPC_ERRORS.failedPrecondition, "Plugin companion is not a regular file");
+  }
+  const digest = await sha256File(realCandidate);
+  if (digest !== variant.sha256) {
+    throw new PluginRpcError(RPC_ERRORS.dataLoss, "Plugin companion digest mismatch");
+  }
+  return { companion, variant, executablePath: realCandidate };
+}
+
+class CompanionRpcPeer {
+  constructor(options) {
+    this.child = options.child;
+    this.contract = options.contract;
+    this.onProtocolError = options.onProtocolError;
+    this.pending = new Map();
+    this.nextId = 0;
+    this.closed = false;
+    this.decoder = new this.contract.ContentLengthFrameDecoder();
+    this.child.stdout.on("data", (chunk) => this.#acceptBytes(chunk));
+    this.child.stdout.on("end", () => {
+      try { this.decoder.finish(); }
+      catch (error) { this.#fail(error); }
+    });
+  }
+
+  #send(value) {
+    if (this.closed || !this.child.stdin.writable) {
+      throw new PluginRpcError(RPC_ERRORS.unavailable, "Plugin companion is closed");
+    }
+    const frame = this.contract.encodeContentLengthFrame(value);
+    this.child.stdin.write(frame);
+  }
+
+  #acceptBytes(chunk) {
+    if (this.closed) return;
+    try {
+      for (const message of this.decoder.push(chunk)) this.#accept(message);
+    } catch (error) {
+      this.#fail(error);
+    }
+  }
+
+  #accept(message) {
+    if (!message || typeof message !== "object" || Array.isArray(message) || message.jsonrpc !== "2.0") {
+      throw new Error("Plugin companion returned a non-RPC message");
+    }
+    if (Object.hasOwn(message, "id") && (Object.hasOwn(message, "result") || Object.hasOwn(message, "error"))) {
+      if (Object.hasOwn(message, "result") === Object.hasOwn(message, "error")) {
+        throw new Error("Plugin companion response must contain exactly one result or error");
+      }
+      const key = rpcIdKey(message.id);
+      const pending = this.pending.get(key);
+      if (!pending) throw new Error("Plugin companion returned an unknown response ID");
+      this.pending.delete(key);
+      clearTimeout(pending.timer);
+      if (message.error) {
+        pending.reject(new PluginRpcError(
+          Number.isInteger(message.error.code) ? message.error.code : RPC_ERRORS.internal,
+          typeof message.error.message === "string" ? message.error.message.slice(0, 2_048) : "Companion request failed",
+          message.error.data,
+        ));
+      } else pending.resolve(message.result ?? null);
+      return;
+    }
+    if (Object.hasOwn(message, "id")) {
+      this.#send({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: { code: -32601, message: "Companion-to-host methods are not exposed" },
+      });
+    }
+  }
+
+  #allocateRequestId() {
+    for (let attempt = 0; attempt <= this.pending.size; attempt += 1) {
+      const id = this.nextId;
+      this.nextId = this.nextId === Number.MAX_SAFE_INTEGER ? 0 : this.nextId + 1;
+      if (!this.pending.has(rpcIdKey(id))) return id;
+    }
+    throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "No companion RPC correlation ID is available");
+  }
+
+  request(method, params, timeoutMs) {
+    if (this.closed) return Promise.reject(new PluginRpcError(RPC_ERRORS.unavailable, "Plugin companion is closed"));
+    if (this.pending.size >= MAX_COMPANION_PENDING) {
+      return Promise.reject(new PluginRpcError(RPC_ERRORS.resourceExhausted, "Too many companion requests"));
+    }
+    const id = this.#allocateRequestId();
+    const key = rpcIdKey(id);
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(key);
+        reject(new PluginRpcError(RPC_ERRORS.deadlineExceeded, `Companion request timed out: ${method}`));
+      }, timeoutMs);
+      timer.unref?.();
+      this.pending.set(key, { resolve, reject, timer });
+      try {
+        this.#send({ jsonrpc: "2.0", id, method, ...(params === undefined ? {} : { params }) });
+      } catch (error) {
+        this.pending.delete(key);
+        clearTimeout(timer);
+        reject(error);
+      }
+    });
+  }
+
+  #fail(error) {
+    if (this.closed) return;
+    this.close(error);
+    this.onProtocolError(error);
+  }
+
+  close(error = new PluginRpcError(RPC_ERRORS.unavailable, "Plugin companion closed")) {
+    if (this.closed) return;
+    this.closed = true;
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+    try { this.child.stdin.end(); } catch {}
+  }
+}
+
+class PluginCompanionSupervisor {
+  constructor(options) {
+    this.paths = options.paths;
+    this.spawn = options.spawn ?? nodeSpawn;
+    this.platform = options.platform ?? process.platform;
+    this.arch = options.arch ?? process.arch;
+    this.quotaManager = options.quotaManager ?? null;
+    this.onContainmentFailure = options.onContainmentFailure ?? (() => {});
+    this.handles = new Map();
+    this.startingCounts = new Map();
+    this.contractPromise = null;
+    this.closed = false;
+  }
+
+  #loadContract() {
+    this.contractPromise ??= import("@netcatty/plugin-contract");
+    return this.contractPromise;
+  }
+
+  validateStart(params) {
+    if (!params || typeof params !== "object" || Array.isArray(params)) {
+      throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Plugin companion start parameters are invalid");
+    }
+    return { companionId: assertCompanionId(params.companionId) };
+  }
+
+  validateRequest(params) {
+    if (!params || typeof params !== "object" || Array.isArray(params)) {
+      throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Plugin companion request parameters are invalid");
+    }
+    const timeoutMs = params.timeoutMs ?? 30_000;
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 60_000) {
+      throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Plugin companion request timeout is invalid");
+    }
+    return {
+      handleId: assertHandleId(params.handleId),
+      method: assertCompanionMethod(params.method),
+      ...(params.params === undefined ? {} : { params: params.params }),
+      timeoutMs,
+    };
+  }
+
+  validateStop(params) {
+    if (!params || typeof params !== "object" || Array.isArray(params)) {
+      throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Plugin companion stop parameters are invalid");
+    }
+    return { handleId: assertHandleId(params.handleId) };
+  }
+
+  describeStartAuthorization(params) {
+    const value = this.validateStart(params);
+    return {
+      permission: "companion.execute",
+      resources: [value.companionId],
+      reason: `Launch companion ${value.companionId}`,
+      operationId: `companion.start:${value.companionId}`,
+    };
+  }
+
+  describeHandleAuthorization(params, context) {
+    const handleId = assertHandleId(params?.handleId);
+    const record = this.#ownedRecord(handleId, context);
+    return {
+      permission: "companion.execute",
+      resources: [record.companionId],
+      reason: `Use companion ${record.companionId}`,
+      operationId: `companion:${handleId}`,
+    };
+  }
+
+  #reserveStart(runtimeId) {
+    const activeCount = [...this.handles.values()].filter((record) => (
+      record.runtimeId === runtimeId
+    )).length;
+    const startingCount = this.startingCounts.get(runtimeId) ?? 0;
+    if (activeCount + startingCount >= MAX_COMPANIONS_PER_RUNTIME) {
+      throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Plugin companion process quota exceeded");
+    }
+    this.startingCounts.set(runtimeId, startingCount + 1);
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const remaining = (this.startingCounts.get(runtimeId) ?? 1) - 1;
+      if (remaining <= 0) this.startingCounts.delete(runtimeId);
+      else this.startingCounts.set(runtimeId, remaining);
+    };
+  }
+
+  async start(params, context) {
+    if (this.closed) throw new PluginRpcError(RPC_ERRORS.unavailable, "Plugin companion supervisor is closed");
+    const { companionId } = this.validateStart(params);
+    const releaseReservation = this.#reserveStart(context.runtimeId);
+    return this.#startReserved(companionId, context).finally(releaseReservation);
+  }
+
+  async #startReserved(companionId, context) {
+    const dataDirectory = path.join(this.paths.data, context.pluginId);
+    await fsp.mkdir(dataDirectory, { recursive: true, mode: 0o700 });
+    const contract = await this.#loadContract();
+    await context.assertActive();
+    const resolved = await resolveCompanionVariant(
+      context,
+      companionId,
+      platformKey(this.platform, this.arch),
+    );
+    context.signal?.throwIfAborted();
+    const child = this.spawn(resolved.executablePath, [], {
+      cwd: dataDirectory,
+      env: {
+        LANG: process.env.LANG ?? "C.UTF-8",
+        LC_ALL: process.env.LC_ALL ?? "",
+      },
+      shell: false,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const handleId = randomUUID();
+    const record = {
+      handleId,
+      companionId,
+      pluginId: context.pluginId,
+      runtimeId: context.runtimeId,
+      child,
+      peer: null,
+      quotaResourceId: `${context.runtimeId}\0companion:${handleId}`,
+      stopping: false,
+      stderrBytes: 0,
+    };
+    const peer = new CompanionRpcPeer({
+      child,
+      contract,
+      onProtocolError: () => { void this.#stopRecord(record); },
+    });
+    record.peer = peer;
+    this.handles.set(handleId, record);
+    child.stderr.on("data", (chunk) => {
+      record.stderrBytes += chunk.byteLength;
+      if (record.stderrBytes > MAX_COMPANION_STDERR_BYTES) void this.#stopRecord(record);
+    });
+    child.once("exit", () => {
+      peer.close();
+      this.quotaManager?.releaseProcess?.(record.quotaResourceId);
+      this.handles.delete(handleId);
+    });
+    try {
+      await new Promise((resolve, reject) => {
+        const onSpawn = () => {
+          child.removeListener("error", onError);
+          resolve();
+        };
+        const onError = (error) => {
+          child.removeListener("spawn", onSpawn);
+          reject(error);
+        };
+        child.once("spawn", onSpawn);
+        child.once("error", onError);
+      });
+    } catch (error) {
+      peer.close();
+      this.handles.delete(handleId);
+      throw new PluginRpcError(
+        RPC_ERRORS.unavailable,
+        `Plugin companion failed to start: ${error?.message ?? String(error)}`,
+      );
+    }
+    this.quotaManager?.trackProcess?.(
+      record.quotaResourceId,
+      Object.freeze({ pluginId: context.pluginId, runtimeId: context.runtimeId }),
+      { getProcessId: () => child.pid },
+    );
+    child.once("error", () => { void this.#stopRecord(record); });
+    try {
+      await context.assertActive();
+    } catch (error) {
+      await this.#stopRecord(record);
+      throw error;
+    }
+    return { handleId };
+  }
+
+  #ownedRecord(handleId, context) {
+    const record = this.handles.get(handleId);
+    if (!record || record.pluginId !== context.pluginId || record.runtimeId !== context.runtimeId) {
+      throw new PluginRpcError(RPC_ERRORS.notFound, "Plugin companion handle was not found");
+    }
+    return record;
+  }
+
+  async request(params, context) {
+    const value = this.validateRequest(params);
+    const record = this.#ownedRecord(value.handleId, context);
+    this.quotaManager?.chargeBytes(
+      context.runtimeId,
+      "companion",
+      Buffer.byteLength(JSON.stringify(value.params ?? null)),
+    );
+    const result = await record.peer.request(value.method, value.params, value.timeoutMs);
+    this.quotaManager?.chargeBytes(context.runtimeId, "companion", Buffer.byteLength(JSON.stringify(result)));
+    await context.assertActive();
+    return result;
+  }
+
+  async stop(params, context) {
+    const value = this.validateStop(params);
+    await this.#stopRecord(this.#ownedRecord(value.handleId, context));
+    return null;
+  }
+
+  async #stopRecord(record) {
+    if (record.stopping) return record.stopPromise;
+    record.stopping = true;
+    record.stopPromise = new Promise((resolve, reject) => {
+      if (record.child.exitCode !== null || record.child.signalCode !== null) {
+        resolve();
+        return;
+      }
+      const onExit = () => {
+        clearTimeout(killTimer);
+        clearTimeout(containmentTimer);
+        resolve();
+      };
+      const killTimer = setTimeout(() => {
+        try { record.child.kill("SIGKILL"); } catch {}
+      }, 500);
+      const containmentTimer = setTimeout(() => {
+        clearTimeout(killTimer);
+        record.child.removeListener("exit", onExit);
+        reject(new PluginRpcError(
+          RPC_ERRORS.failedPrecondition,
+          `Plugin companion could not be reaped: ${record.companionId}`,
+        ));
+      }, 2_000);
+      killTimer.unref?.();
+      containmentTimer.unref?.();
+      record.child.once("exit", onExit);
+      try { record.child.kill(); } catch {}
+    }).then(() => {
+      record.peer.close();
+      this.handles.delete(record.handleId);
+    }, async (error) => {
+      record.peer.close(error);
+      record.stopping = false;
+      record.stopPromise = null;
+      await this.onContainmentFailure(Object.freeze({
+        pluginId: record.pluginId,
+        runtimeId: record.runtimeId,
+      }), error);
+      throw error;
+    });
+    return record.stopPromise;
+  }
+
+  async releaseRuntime(runtimeId) {
+    await Promise.allSettled([...this.handles.values()]
+      .filter((record) => record.runtimeId === runtimeId)
+      .map((record) => this.#stopRecord(record)));
+  }
+
+  async shutdown() {
+    this.closed = true;
+    await Promise.allSettled([...this.handles.values()].map((record) => this.#stopRecord(record)));
+    this.startingCounts.clear();
+  }
+}
+
+module.exports = {
+  CompanionRpcPeer,
+  MAX_COMPANIONS_PER_RUNTIME,
+  MAX_COMPANION_PENDING,
+  PluginCompanionSupervisor,
+  assertCompanionId,
+  assertCompanionMethod,
+  platformKey,
+  resolveCompanionVariant,
+  rpcIdKey,
+  sha256File,
+};

--- a/electron/plugins/companionSupervisor.cjs
+++ b/electron/plugins/companionSupervisor.cjs
@@ -479,7 +479,13 @@ class PluginCompanionSupervisor {
     }
     this.quotaManager?.trackProcess?.(
       record.quotaResourceId,
-      Object.freeze({ pluginId: context.pluginId, runtimeId: context.runtimeId }),
+      Object.freeze({
+        pluginId: record.pluginId,
+        pluginVersion: record.pluginVersion,
+        runtimeId: record.runtimeId,
+        runtimeKind: record.runtimeKind,
+        securityPrincipal: record.securityPrincipal,
+      }),
       { getProcessId: () => child.pid },
     );
     child.once("error", () => { void this.#stopRecord(record); });

--- a/electron/plugins/companionSupervisor.cjs
+++ b/electron/plugins/companionSupervisor.cjs
@@ -4,7 +4,7 @@ const { createHash, randomUUID } = require("node:crypto");
 const fs = require("node:fs");
 const fsp = require("node:fs/promises");
 const path = require("node:path");
-const { spawn: nodeSpawn } = require("node:child_process");
+const { execFile: nodeExecFile, spawn: nodeSpawn } = require("node:child_process");
 
 const { isPathInside } = require("./paths.cjs");
 const { canonicalizeCompanionResource } = require("./permissionResources.cjs");
@@ -13,6 +13,9 @@ const { PluginRpcError, RPC_ERRORS } = require("./rpcRouter.cjs");
 const MAX_COMPANIONS_PER_RUNTIME = 4;
 const MAX_COMPANION_PENDING = 64;
 const MAX_COMPANION_STDERR_BYTES = 64 * 1024;
+const COMPANION_TERMINATION_GRACE_MS = 500;
+const COMPANION_CONTAINMENT_TIMEOUT_MS = 2_000;
+const PROCESS_TREE_POLL_MS = 25;
 
 function platformKey(platform = process.platform, arch = process.arch) {
   return `${platform}-${arch}`;
@@ -46,6 +49,97 @@ function assertCompanionMethod(value) {
 
 function rpcIdKey(id) {
   return `${typeof id}:${String(id)}`;
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function waitUntilStopped(isAlive, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (isAlive()) {
+    if (Date.now() >= deadline) return false;
+    await delay(Math.min(PROCESS_TREE_POLL_MS, Math.max(1, deadline - Date.now())));
+  }
+  return true;
+}
+
+function isPosixProcessGroupAlive(pid, kill = process.kill) {
+  try {
+    kill(-pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    if (error?.code === "EPERM") return true;
+    throw error;
+  }
+}
+
+function signalPosixProcessGroup(pid, signal, kill = process.kill) {
+  try {
+    kill(-pid, signal);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+function runTaskkill(pid, force, execFile = nodeExecFile) {
+  const systemRoot = process.env.SystemRoot || "C:\\Windows";
+  const executable = path.join(systemRoot, "System32", "taskkill.exe");
+  const args = ["/PID", String(pid), "/T", ...(force ? ["/F"] : [])];
+  return new Promise((resolve) => {
+    execFile(executable, args, {
+      windowsHide: true,
+      timeout: force ? COMPANION_CONTAINMENT_TIMEOUT_MS : COMPANION_TERMINATION_GRACE_MS,
+    }, (error) => resolve(error == null));
+  });
+}
+
+async function terminateDirectChild(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  try { child.kill(); } catch {}
+  if (await waitUntilStopped(
+    () => child.exitCode === null && child.signalCode === null,
+    COMPANION_TERMINATION_GRACE_MS,
+  )) return;
+  try { child.kill("SIGKILL"); } catch {}
+  if (await waitUntilStopped(
+    () => child.exitCode === null && child.signalCode === null,
+    COMPANION_CONTAINMENT_TIMEOUT_MS - COMPANION_TERMINATION_GRACE_MS,
+  )) return;
+  throw new Error("Plugin companion direct process did not exit");
+}
+
+async function terminateCompanionProcessTree(child, options = {}) {
+  const platform = options.platform ?? process.platform;
+  const pid = child?.pid;
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    await terminateDirectChild(child);
+    return;
+  }
+  if (platform === "win32") {
+    const graceful = await runTaskkill(pid, false, options.execFile);
+    await (options.delay ?? delay)(COMPANION_TERMINATION_GRACE_MS);
+    const forced = await runTaskkill(pid, true, options.execFile);
+    if (!graceful && !forced && child.exitCode === null && child.signalCode === null) {
+      throw new Error("Plugin companion process tree could not be terminated");
+    }
+    return;
+  }
+  const kill = options.kill ?? process.kill;
+  signalPosixProcessGroup(pid, "SIGTERM", kill);
+  if (await waitUntilStopped(
+    () => isPosixProcessGroupAlive(pid, kill),
+    COMPANION_TERMINATION_GRACE_MS,
+  )) return;
+  signalPosixProcessGroup(pid, "SIGKILL", kill);
+  if (await waitUntilStopped(
+    () => isPosixProcessGroupAlive(pid, kill),
+    COMPANION_CONTAINMENT_TIMEOUT_MS - COMPANION_TERMINATION_GRACE_MS,
+  )) return;
+  throw new Error("Plugin companion process group could not be reaped");
 }
 
 async function sha256File(filePath) {
@@ -220,6 +314,8 @@ class PluginCompanionSupervisor {
     this.arch = options.arch ?? process.arch;
     this.quotaManager = options.quotaManager ?? null;
     this.onContainmentFailure = options.onContainmentFailure ?? (() => {});
+    this.terminateProcessTree = options.terminateProcessTree
+      ?? ((child) => terminateCompanionProcessTree(child, { platform: this.platform }));
     this.handles = new Map();
     this.startingCounts = new Map();
     this.contractPromise = null;
@@ -328,6 +424,7 @@ class PluginCompanionSupervisor {
       shell: false,
       stdio: ["pipe", "pipe", "pipe"],
       windowsHide: true,
+      detached: this.platform !== "win32",
     });
     const handleId = randomUUID();
     const record = {
@@ -354,8 +451,7 @@ class PluginCompanionSupervisor {
     });
     child.once("exit", () => {
       peer.close();
-      this.quotaManager?.releaseProcess?.(record.quotaResourceId);
-      this.handles.delete(handleId);
+      if (!record.stopping) void this.#stopRecord(record).catch(() => {});
     });
     try {
       await new Promise((resolve, reject) => {
@@ -424,43 +520,24 @@ class PluginCompanionSupervisor {
   async #stopRecord(record) {
     if (record.stopping) return record.stopPromise;
     record.stopping = true;
-    record.stopPromise = new Promise((resolve, reject) => {
-      if (record.child.exitCode !== null || record.child.signalCode !== null) {
-        resolve();
-        return;
-      }
-      const onExit = () => {
-        clearTimeout(killTimer);
-        clearTimeout(containmentTimer);
-        resolve();
-      };
-      const killTimer = setTimeout(() => {
-        try { record.child.kill("SIGKILL"); } catch {}
-      }, 500);
-      const containmentTimer = setTimeout(() => {
-        clearTimeout(killTimer);
-        record.child.removeListener("exit", onExit);
-        reject(new PluginRpcError(
-          RPC_ERRORS.failedPrecondition,
-          `Plugin companion could not be reaped: ${record.companionId}`,
-        ));
-      }, 2_000);
-      killTimer.unref?.();
-      containmentTimer.unref?.();
-      record.child.once("exit", onExit);
-      try { record.child.kill(); } catch {}
-    }).then(() => {
+    record.stopPromise = Promise.resolve().then(() => this.terminateProcessTree(record.child)).then(() => {
       record.peer.close();
+      this.quotaManager?.releaseProcess?.(record.quotaResourceId);
       this.handles.delete(record.handleId);
     }, async (error) => {
-      record.peer.close(error);
+      const containmentError = new PluginRpcError(
+        RPC_ERRORS.failedPrecondition,
+        `Plugin companion could not be reaped: ${record.companionId}`,
+        { cause: error?.message ?? String(error) },
+      );
+      record.peer.close(containmentError);
       record.stopping = false;
       record.stopPromise = null;
       await this.onContainmentFailure(Object.freeze({
         pluginId: record.pluginId,
         runtimeId: record.runtimeId,
-      }), error);
-      throw error;
+      }), containmentError);
+      throw containmentError;
     });
     return record.stopPromise;
   }
@@ -479,6 +556,8 @@ class PluginCompanionSupervisor {
 }
 
 module.exports = {
+  COMPANION_CONTAINMENT_TIMEOUT_MS,
+  COMPANION_TERMINATION_GRACE_MS,
   CompanionRpcPeer,
   MAX_COMPANIONS_PER_RUNTIME,
   MAX_COMPANION_PENDING,
@@ -488,5 +567,8 @@ module.exports = {
   platformKey,
   resolveCompanionVariant,
   rpcIdKey,
+  isPosixProcessGroupAlive,
+  signalPosixProcessGroup,
   sha256File,
+  terminateCompanionProcessTree,
 };

--- a/electron/plugins/companionSupervisor.cjs
+++ b/electron/plugins/companionSupervisor.cjs
@@ -431,7 +431,10 @@ class PluginCompanionSupervisor {
       handleId,
       companionId,
       pluginId: context.pluginId,
+      pluginVersion: context.pluginVersion,
       runtimeId: context.runtimeId,
+      runtimeKind: context.runtimeKind,
+      securityPrincipal: context.securityPrincipal,
       child,
       peer: null,
       quotaResourceId: `${context.runtimeId}\0companion:${handleId}`,
@@ -535,7 +538,10 @@ class PluginCompanionSupervisor {
       record.stopPromise = null;
       await this.onContainmentFailure(Object.freeze({
         pluginId: record.pluginId,
+        pluginVersion: record.pluginVersion,
         runtimeId: record.runtimeId,
+        runtimeKind: record.runtimeKind,
+        securityPrincipal: record.securityPrincipal,
       }), containmentError);
       throw containmentError;
     });
@@ -543,9 +549,16 @@ class PluginCompanionSupervisor {
   }
 
   async releaseRuntime(runtimeId) {
-    await Promise.allSettled([...this.handles.values()]
+    const results = await Promise.allSettled([...this.handles.values()]
       .filter((record) => record.runtimeId === runtimeId)
       .map((record) => this.#stopRecord(record)));
+    const failures = results
+      .filter((result) => result.status === "rejected")
+      .map((result) => result.reason);
+    if (failures.length === 1) throw failures[0];
+    if (failures.length > 1) {
+      throw new AggregateError(failures, `Plugin companion cleanup failed for runtime: ${runtimeId}`);
+    }
   }
 
   async shutdown() {

--- a/electron/plugins/companionSupervisor.cjs
+++ b/electron/plugins/companionSupervisor.cjs
@@ -85,6 +85,7 @@ class CompanionRpcPeer {
     this.contract = options.contract;
     this.onProtocolError = options.onProtocolError;
     this.pending = new Map();
+    this.retiredResponseIds = new Set();
     this.nextId = 0;
     this.closed = false;
     this.decoder = new this.contract.ContentLengthFrameDecoder();
@@ -122,7 +123,10 @@ class CompanionRpcPeer {
       }
       const key = rpcIdKey(message.id);
       const pending = this.pending.get(key);
-      if (!pending) throw new Error("Plugin companion returned an unknown response ID");
+      if (!pending) {
+        if (this.retiredResponseIds.delete(key)) return;
+        throw new Error("Plugin companion returned an unknown response ID");
+      }
       this.pending.delete(key);
       clearTimeout(pending.timer);
       if (message.error) {
@@ -144,12 +148,24 @@ class CompanionRpcPeer {
   }
 
   #allocateRequestId() {
-    for (let attempt = 0; attempt <= this.pending.size; attempt += 1) {
+    for (
+      let attempt = 0;
+      attempt <= this.pending.size + this.retiredResponseIds.size;
+      attempt += 1
+    ) {
       const id = this.nextId;
       this.nextId = this.nextId === Number.MAX_SAFE_INTEGER ? 0 : this.nextId + 1;
-      if (!this.pending.has(rpcIdKey(id))) return id;
+      const key = rpcIdKey(id);
+      if (!this.pending.has(key) && !this.retiredResponseIds.has(key)) return id;
     }
     throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "No companion RPC correlation ID is available");
+  }
+
+  #retireResponseId(key) {
+    this.retiredResponseIds.add(key);
+    while (this.retiredResponseIds.size > MAX_COMPANION_PENDING) {
+      this.retiredResponseIds.delete(this.retiredResponseIds.values().next().value);
+    }
   }
 
   request(method, params, timeoutMs) {
@@ -162,6 +178,7 @@ class CompanionRpcPeer {
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(key);
+        this.#retireResponseId(key);
         reject(new PluginRpcError(RPC_ERRORS.deadlineExceeded, `Companion request timed out: ${method}`));
       }, timeoutMs);
       timer.unref?.();
@@ -190,6 +207,7 @@ class CompanionRpcPeer {
       pending.reject(error);
     }
     this.pending.clear();
+    this.retiredResponseIds.clear();
     try { this.child.stdin.end(); } catch {}
   }
 }

--- a/electron/plugins/companionSupervisor.test.cjs
+++ b/electron/plugins/companionSupervisor.test.cjs
@@ -32,6 +32,16 @@ function runtimeContext(packageRoot, digest, overrides = {}) {
     securityPrincipal: "unsigned-package:test",
     packageRoot,
     manifest: {
+      main: { node: "dist/node.js" },
+      permissions: {
+        required: [
+          "runtime.advanced",
+          {
+            permission: "companion.execute",
+            resources: ["com.example.companion.helper"],
+          },
+        ],
+      },
       companionExecutables: [{
         id: "com.example.companion.helper",
         variants: [{ path: "bin/helper", platforms: [`${process.platform}-${process.arch}`], sha256: digest }],
@@ -41,6 +51,50 @@ function runtimeContext(packageRoot, digest, overrides = {}) {
     ...overrides,
   };
 }
+
+test("ordinary browser runtimes cannot authorize or launch native companions", async (context) => {
+  const root = createRoot(context);
+  let spawnCalls = 0;
+  const supervisor = new PluginCompanionSupervisor({
+    paths: { data: path.join(root, "data") },
+    spawn: () => {
+      spawnCalls += 1;
+      throw new Error("browser companion must never spawn");
+    },
+  });
+  const browser = runtimeContext(root, "0".repeat(64), {
+    runtimeKind: "browser",
+    manifest: {
+      main: { browser: "dist/browser.js" },
+      permissions: {
+        required: [{
+          permission: "companion.execute",
+          resources: ["com.example.companion.helper"],
+        }],
+      },
+      companionExecutables: [{
+        id: "com.example.companion.helper",
+        variants: [{
+          path: "bin/helper",
+          platforms: [`${process.platform}-${process.arch}`],
+          sha256: "0".repeat(64),
+        }],
+      }],
+    },
+  });
+  assert.throws(
+    () => supervisor.describeStartAuthorization({
+      companionId: "com.example.companion.helper",
+    }, browser),
+    (error) => error.code === RPC_ERRORS.permissionDenied,
+  );
+  await assert.rejects(
+    supervisor.start({ companionId: "com.example.companion.helper" }, browser),
+    (error) => error.code === RPC_ERRORS.permissionDenied,
+  );
+  assert.equal(spawnCalls, 0);
+  await supervisor.shutdown();
+});
 
 class FakeChild extends EventEmitter {
   constructor(contract, responseId = (id) => id) {

--- a/electron/plugins/companionSupervisor.test.cjs
+++ b/electron/plugins/companionSupervisor.test.cjs
@@ -28,6 +28,8 @@ function runtimeContext(packageRoot, digest, overrides = {}) {
     pluginId: "com.example.companion",
     pluginVersion: "1.0.0",
     runtimeId: "runtime-1",
+    runtimeKind: "utility",
+    securityPrincipal: "unsigned-package:test",
     packageRoot,
     manifest: {
       companionExecutables: [{
@@ -189,6 +191,40 @@ test("companion runs shell-free with sanitized environment and bounded host-only
   await supervisor.shutdown();
 });
 
+test("companion cleanup reports the complete runtime identity and rejects containment failure", async (context) => {
+  const root = createRoot(context);
+  const packageRoot = path.join(root, "package");
+  const executable = path.join(packageRoot, "bin/helper");
+  await fsp.mkdir(path.dirname(executable), { recursive: true });
+  const contents = Buffer.from("binary");
+  await fsp.writeFile(executable, contents);
+  const digest = createHash("sha256").update(contents).digest("hex");
+  const contract = await import("@netcatty/plugin-contract");
+  const failures = [];
+  const supervisor = new PluginCompanionSupervisor({
+    paths: { data: path.join(root, "data") },
+    spawn: () => new FakeChild(contract),
+    terminateProcessTree: async () => { throw new Error("process tree survived"); },
+    onContainmentFailure: (identity, error) => failures.push({ identity, error }),
+  });
+  const runtime = runtimeContext(packageRoot, digest);
+  await supervisor.start({ companionId: "com.example.companion.helper" }, runtime);
+
+  await assert.rejects(
+    supervisor.releaseRuntime(runtime.runtimeId),
+    (error) => error.code === RPC_ERRORS.failedPrecondition,
+  );
+  assert.deepEqual(failures.map(({ identity }) => identity), [{
+    pluginId: runtime.pluginId,
+    pluginVersion: runtime.pluginVersion,
+    runtimeId: runtime.runtimeId,
+    runtimeKind: runtime.runtimeKind,
+    securityPrincipal: runtime.securityPrincipal,
+  }]);
+  assert.match(failures[0].error.message, /could not be reaped/);
+  await supervisor.shutdown();
+});
+
 test("Windows companion termination uses shell-free tree cleanup for both stages", async () => {
   const calls = [];
   await terminateCompanionProcessTree({
@@ -232,7 +268,10 @@ test("companion stop reaps its POSIX descendant process group", {
   const runtime = runtimeContext(packageRoot, digest);
   const handle = await supervisor.start({ companionId: "com.example.companion.helper" }, runtime);
   let descendantPid;
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+  // The complete plugin suite runs many test files in parallel, so process
+  // scheduling can exceed one second on a busy CI host. Treat the PID file as
+  // the explicit readiness barrier and keep a bounded ten-second deadline.
+  for (let attempt = 0; attempt < 1_000; attempt += 1) {
     try {
       descendantPid = Number(await fsp.readFile(pidFile, "utf8"));
       break;

--- a/electron/plugins/companionSupervisor.test.cjs
+++ b/electron/plugins/companionSupervisor.test.cjs
@@ -158,12 +158,18 @@ test("companion runs shell-free with sanitized environment and bounded host-only
   const digest = createHash("sha256").update(contents).digest("hex");
   const contract = await import("@netcatty/plugin-contract");
   const spawns = [];
+  const tracked = [];
   const supervisor = new PluginCompanionSupervisor({
     paths: { data: path.join(root, "data") },
     spawn: (command, args, options) => {
       const child = new FakeChild(contract);
       spawns.push({ command, args, options, child });
       return child;
+    },
+    quotaManager: {
+      trackProcess: (resourceId, identity) => tracked.push({ resourceId, identity }),
+      releaseProcess() {},
+      chargeBytes() {},
     },
   });
   const runtime = runtimeContext(packageRoot, digest);
@@ -173,6 +179,16 @@ test("companion runs shell-free with sanitized environment and bounded host-only
   assert.equal(spawns[0].options.shell, false);
   assert.equal(spawns[0].options.detached, process.platform !== "win32");
   assert.deepEqual(Object.keys(spawns[0].options.env).sort(), ["LANG", "LC_ALL"]);
+  assert.deepEqual(tracked, [{
+    resourceId: `${runtime.runtimeId}\0companion:${handle.handleId}`,
+    identity: {
+      pluginId: runtime.pluginId,
+      pluginVersion: runtime.pluginVersion,
+      runtimeId: runtime.runtimeId,
+      runtimeKind: runtime.runtimeKind,
+      securityPrincipal: runtime.securityPrincipal,
+    },
+  }]);
 
   assert.deepEqual(await supervisor.request({
     handleId: handle.handleId,

--- a/electron/plugins/companionSupervisor.test.cjs
+++ b/electron/plugins/companionSupervisor.test.cjs
@@ -1,0 +1,171 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { createHash } = require("node:crypto");
+const { EventEmitter } = require("node:events");
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { PassThrough } = require("node:stream");
+const test = require("node:test");
+
+const { CompanionRpcPeer, PluginCompanionSupervisor } = require("./companionSupervisor.cjs");
+const { RPC_ERRORS } = require("./rpcRouter.cjs");
+
+function createRoot(context) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-companion-"));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+function runtimeContext(packageRoot, digest, overrides = {}) {
+  return {
+    pluginId: "com.example.companion",
+    pluginVersion: "1.0.0",
+    runtimeId: "runtime-1",
+    packageRoot,
+    manifest: {
+      companionExecutables: [{
+        id: "com.example.companion.helper",
+        variants: [{ path: "bin/helper", platforms: [`${process.platform}-${process.arch}`], sha256: digest }],
+      }],
+    },
+    assertActive: async () => {},
+    ...overrides,
+  };
+}
+
+class FakeChild extends EventEmitter {
+  constructor(contract, responseId = (id) => id) {
+    super();
+    this.stdin = new PassThrough();
+    this.stdout = new PassThrough();
+    this.stderr = new PassThrough();
+    this.exitCode = null;
+    this.signalCode = null;
+    const decoder = new contract.ContentLengthFrameDecoder();
+    this.stdin.on("data", (chunk) => {
+      for (const message of decoder.push(chunk)) {
+        if (!Object.hasOwn(message, "id")) continue;
+        queueMicrotask(() => this.stdout.write(contract.encodeContentLengthFrame({
+          jsonrpc: "2.0",
+          id: responseId(message.id),
+          result: { echoed: message.params ?? null },
+        })));
+      }
+    });
+    queueMicrotask(() => this.emit("spawn"));
+  }
+
+  kill(signal = "SIGTERM") {
+    this.signalCode = signal;
+    queueMicrotask(() => this.emit("exit", null, signal));
+    return true;
+  }
+}
+
+test("companion RPC correlation keeps numeric and string IDs distinct", async () => {
+  const contract = await import("@netcatty/plugin-contract");
+  const child = new FakeChild(contract, (id) => String(id));
+  const errors = [];
+  const peer = new CompanionRpcPeer({
+    child,
+    contract,
+    onProtocolError: (error) => errors.push(error.message),
+  });
+  await assert.rejects(peer.request("echo", null, 1_000), /unknown response ID/);
+  assert.deepEqual(errors, ["Plugin companion returned an unknown response ID"]);
+});
+
+test("companion launch verifies digest immediately and never spawns a mismatch", async (context) => {
+  const root = createRoot(context);
+  const packageRoot = path.join(root, "package");
+  const executable = path.join(packageRoot, "bin/helper");
+  await fsp.mkdir(path.dirname(executable), { recursive: true });
+  await fsp.writeFile(executable, "binary");
+  let spawnCalls = 0;
+  const supervisor = new PluginCompanionSupervisor({
+    paths: { data: path.join(root, "data") },
+    spawn: () => { spawnCalls += 1; throw new Error("must not spawn"); },
+  });
+  await assert.rejects(
+    supervisor.start(
+      { companionId: "com.example.companion.helper" },
+      runtimeContext(packageRoot, "0".repeat(64)),
+    ),
+    (error) => error.code === RPC_ERRORS.dataLoss,
+  );
+  assert.equal(spawnCalls, 0);
+  await supervisor.shutdown();
+});
+
+test("companion runs shell-free with sanitized environment and bounded host-only RPC", async (context) => {
+  const root = createRoot(context);
+  const packageRoot = path.join(root, "package");
+  const executable = path.join(packageRoot, "bin/helper");
+  await fsp.mkdir(path.dirname(executable), { recursive: true });
+  const contents = Buffer.from("binary");
+  await fsp.writeFile(executable, contents);
+  const digest = createHash("sha256").update(contents).digest("hex");
+  const contract = await import("@netcatty/plugin-contract");
+  const spawns = [];
+  const supervisor = new PluginCompanionSupervisor({
+    paths: { data: path.join(root, "data") },
+    spawn: (command, args, options) => {
+      const child = new FakeChild(contract);
+      spawns.push({ command, args, options, child });
+      return child;
+    },
+  });
+  const runtime = runtimeContext(packageRoot, digest);
+  const handle = await supervisor.start({ companionId: "com.example.companion.helper" }, runtime);
+  assert.equal(spawns[0].command, await fsp.realpath(executable));
+  assert.deepEqual(spawns[0].args, []);
+  assert.equal(spawns[0].options.shell, false);
+  assert.deepEqual(Object.keys(spawns[0].options.env).sort(), ["LANG", "LC_ALL"]);
+
+  assert.deepEqual(await supervisor.request({
+    handleId: handle.handleId,
+    method: "echo",
+    params: { value: 1 },
+  }, runtime), { echoed: { value: 1 } });
+  await assert.rejects(
+    supervisor.request({ handleId: handle.handleId, method: "echo" }, {
+      ...runtime,
+      runtimeId: "runtime-2",
+    }),
+    (error) => error.code === RPC_ERRORS.notFound,
+  );
+  await supervisor.stop({ handleId: handle.handleId }, runtime);
+  assert.equal(spawns[0].child.signalCode, "SIGTERM");
+  await supervisor.shutdown();
+});
+
+test("concurrent companion starts reserve the per-runtime process quota", async (context) => {
+  const root = createRoot(context);
+  const packageRoot = path.join(root, "package");
+  const executable = path.join(packageRoot, "bin/helper");
+  await fsp.mkdir(path.dirname(executable), { recursive: true });
+  const contents = Buffer.from("binary");
+  await fsp.writeFile(executable, contents);
+  const digest = createHash("sha256").update(contents).digest("hex");
+  const contract = await import("@netcatty/plugin-contract");
+  let spawns = 0;
+  const supervisor = new PluginCompanionSupervisor({
+    paths: { data: path.join(root, "data") },
+    spawn: () => {
+      spawns += 1;
+      return new FakeChild(contract);
+    },
+  });
+  const runtime = runtimeContext(packageRoot, digest);
+  const results = await Promise.allSettled(Array.from({ length: 5 }, () => (
+    supervisor.start({ companionId: "com.example.companion.helper" }, runtime)
+  )));
+  assert.equal(results.filter(({ status }) => status === "fulfilled").length, 4);
+  assert.equal(results.filter(({ status }) => status === "rejected").length, 1);
+  assert.equal(results.find(({ status }) => status === "rejected").reason.code, RPC_ERRORS.resourceExhausted);
+  assert.equal(spawns, 4);
+  await supervisor.shutdown();
+});

--- a/electron/plugins/companionSupervisor.test.cjs
+++ b/electron/plugins/companionSupervisor.test.cjs
@@ -10,7 +10,11 @@ const path = require("node:path");
 const { PassThrough } = require("node:stream");
 const test = require("node:test");
 
-const { CompanionRpcPeer, PluginCompanionSupervisor } = require("./companionSupervisor.cjs");
+const {
+  CompanionRpcPeer,
+  PluginCompanionSupervisor,
+  terminateCompanionProcessTree,
+} = require("./companionSupervisor.cjs");
 const { RPC_ERRORS } = require("./rpcRouter.cjs");
 
 function createRoot(context) {
@@ -165,6 +169,7 @@ test("companion runs shell-free with sanitized environment and bounded host-only
   assert.equal(spawns[0].command, await fsp.realpath(executable));
   assert.deepEqual(spawns[0].args, []);
   assert.equal(spawns[0].options.shell, false);
+  assert.equal(spawns[0].options.detached, process.platform !== "win32");
   assert.deepEqual(Object.keys(spawns[0].options.env).sort(), ["LANG", "LC_ALL"]);
 
   assert.deepEqual(await supervisor.request({
@@ -181,6 +186,71 @@ test("companion runs shell-free with sanitized environment and bounded host-only
   );
   await supervisor.stop({ handleId: handle.handleId }, runtime);
   assert.equal(spawns[0].child.signalCode, "SIGTERM");
+  await supervisor.shutdown();
+});
+
+test("Windows companion termination uses shell-free tree cleanup for both stages", async () => {
+  const calls = [];
+  await terminateCompanionProcessTree({
+    pid: 1234,
+    exitCode: null,
+    signalCode: null,
+  }, {
+    platform: "win32",
+    delay: async () => {},
+    execFile(executable, args, options, callback) {
+      calls.push({ executable, args, options });
+      callback(null);
+    },
+  });
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls[0].args, ["/PID", "1234", "/T"]);
+  assert.deepEqual(calls[1].args, ["/PID", "1234", "/T", "/F"]);
+  assert.equal(calls[0].options.windowsHide, true);
+});
+
+test("companion stop reaps its POSIX descendant process group", {
+  skip: process.platform === "win32" || /\s/u.test(process.execPath),
+}, async (context) => {
+  const root = createRoot(context);
+  const packageRoot = path.join(root, "package");
+  const executable = path.join(packageRoot, "bin/helper");
+  const dataDirectory = path.join(root, "data", "com.example.companion");
+  const pidFile = path.join(dataDirectory, "descendant.pid");
+  await fsp.mkdir(path.dirname(executable), { recursive: true });
+  const contents = Buffer.from(`#!${process.execPath}\n`
+    + `const fs = require("node:fs");\n`
+    + `const { spawn } = require("node:child_process");\n`
+    + `process.on("SIGTERM", () => {});\n`
+    + `const child = spawn(process.execPath, ["-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"], { stdio: "ignore" });\n`
+    + `fs.writeFileSync("descendant.pid", String(child.pid));\n`
+    + `setInterval(() => {}, 1000);\n`);
+  await fsp.writeFile(executable, contents, { mode: 0o755 });
+  await fsp.chmod(executable, 0o755);
+  const digest = createHash("sha256").update(contents).digest("hex");
+  const supervisor = new PluginCompanionSupervisor({ paths: { data: path.join(root, "data") } });
+  const runtime = runtimeContext(packageRoot, digest);
+  const handle = await supervisor.start({ companionId: "com.example.companion.helper" }, runtime);
+  let descendantPid;
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      descendantPid = Number(await fsp.readFile(pidFile, "utf8"));
+      break;
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  assert.ok(Number.isSafeInteger(descendantPid) && descendantPid > 0);
+  context.after(() => {
+    if (!descendantPid) return;
+    try { process.kill(descendantPid, "SIGKILL"); } catch {}
+  });
+  await supervisor.stop({ handleId: handle.handleId }, runtime);
+  await assert.rejects(
+    Promise.resolve().then(() => process.kill(descendantPid, 0)),
+    (error) => error?.code === "ESRCH",
+  );
   await supervisor.shutdown();
 });
 

--- a/electron/plugins/companionSupervisor.test.cjs
+++ b/electron/plugins/companionSupervisor.test.cjs
@@ -65,6 +65,24 @@ class FakeChild extends EventEmitter {
   }
 }
 
+class ManualChild extends EventEmitter {
+  constructor(contract) {
+    super();
+    this.stdin = new PassThrough();
+    this.stdout = new PassThrough();
+    this.stderr = new PassThrough();
+    this.exitCode = null;
+    this.signalCode = null;
+    this.messages = [];
+    const decoder = new contract.ContentLengthFrameDecoder();
+    this.stdin.on("data", (chunk) => this.messages.push(...decoder.push(chunk)));
+  }
+
+  respond(contract, id, result) {
+    this.stdout.write(contract.encodeContentLengthFrame({ jsonrpc: "2.0", id, result }));
+  }
+}
+
 test("companion RPC correlation keeps numeric and string IDs distinct", async () => {
   const contract = await import("@netcatty/plugin-contract");
   const child = new FakeChild(contract, (id) => String(id));
@@ -76,6 +94,30 @@ test("companion RPC correlation keeps numeric and string IDs distinct", async ()
   });
   await assert.rejects(peer.request("echo", null, 1_000), /unknown response ID/);
   assert.deepEqual(errors, ["Plugin companion returned an unknown response ID"]);
+});
+
+test("companion RPC ignores one late timed-out response and never reuses its ID", async () => {
+  const contract = await import("@netcatty/plugin-contract");
+  const child = new ManualChild(contract);
+  const errors = [];
+  const peer = new CompanionRpcPeer({
+    child,
+    contract,
+    onProtocolError: (error) => errors.push(error.message),
+  });
+  await assert.rejects(
+    peer.request("slow", null, 5),
+    (error) => error.code === RPC_ERRORS.deadlineExceeded,
+  );
+  assert.equal(child.messages[0].id, 0);
+  peer.nextId = 0;
+  const next = peer.request("next", { value: 1 }, 1_000);
+  assert.equal(child.messages[1].id, 1);
+  child.respond(contract, 0, { late: true });
+  child.respond(contract, 1, { ok: true });
+  assert.deepEqual(await next, { ok: true });
+  assert.deepEqual(errors, []);
+  peer.close();
 });
 
 test("companion launch verifies digest immediately and never spawns a mismatch", async (context) => {

--- a/electron/plugins/constants.cjs
+++ b/electron/plugins/constants.cjs
@@ -10,6 +10,10 @@ const PLUGIN_UTILITY_FORCE_EXIT_TIMEOUT_MS = 1_000;
 const PLUGIN_RPC_DEFAULT_TIMEOUT_MS = 30_000;
 const PLUGIN_RPC_MAX_PENDING = 256;
 const PLUGIN_RPC_MAX_JSON_BYTES = 1024 * 1024;
+// Broker payloads live inside the control-plane JSON envelope. Reserve enough
+// room for worst-case JSON string escaping (six wire bytes per raw byte),
+// headers, paths, correlation fields, and future compatible metadata.
+const PLUGIN_RPC_MAX_RAW_BYTES = Math.floor(PLUGIN_RPC_MAX_JSON_BYTES / 8);
 const PLUGIN_STREAM_MAX_FRAME_JSON_BYTES = 24 * 1024 * 1024;
 const PLUGIN_CRASH_WINDOW_MS = 5 * 60_000;
 const PLUGIN_CRASH_QUARANTINE_THRESHOLD = 3;
@@ -31,6 +35,7 @@ module.exports = {
   PLUGIN_LOG_MAX_FILES,
   PLUGIN_PROTOCOL_SCHEME,
   PLUGIN_RPC_DEFAULT_TIMEOUT_MS,
+  PLUGIN_RPC_MAX_RAW_BYTES,
   PLUGIN_RPC_MAX_JSON_BYTES,
   PLUGIN_RPC_MAX_PENDING,
   PLUGIN_STREAM_MAX_FRAME_JSON_BYTES,

--- a/electron/plugins/credentialBroker.cjs
+++ b/electron/plugins/credentialBroker.cjs
@@ -53,20 +53,9 @@ class PluginCredentialBroker {
     )) throw new TypeError("Credential resolver must validate and resolve credential references");
   }
 
-  async describeAuthorization(params, context) {
+  describeAuthorization(params) {
     const validated = assertLeaseParams(params);
     if (validated.secret.kind === "credential") {
-      if (!this.credentialResolver) {
-        throw new PluginRpcError(RPC_ERRORS.unavailable, "Netcatty credential access is unavailable");
-      }
-      await this.credentialResolver.assertReference(validated.secret, {
-        pluginId: context.pluginId,
-        runtimeId: context.runtimeId,
-        operationId: validated.operationId,
-        purpose: validated.purpose,
-        signal: context.signal,
-      });
-      await context.assertActive();
       return {
         permission: "vault.credentials",
         resources: [`credential:${validated.secret.id}`],
@@ -74,10 +63,9 @@ class PluginCredentialBroker {
         operationId: validated.operationId,
       };
     }
-    const secret = this.secretStore.getRecordByReference(context.pluginId, validated.secret);
     return {
       permission: "secrets",
-      resources: [`secret:${secret.key}`],
+      resources: [`secret-ref:${validated.secret.id}`],
       reason: `Use plugin secret for ${validated.purpose}`,
       operationId: validated.operationId,
     };

--- a/electron/plugins/credentialBroker.cjs
+++ b/electron/plugins/credentialBroker.cjs
@@ -1,0 +1,141 @@
+"use strict";
+
+const { PluginRpcError, RPC_ERRORS } = require("./rpcRouter.cjs");
+const { MAX_SECRET_BYTES, assertSecretRef } = require("./secretStore.cjs");
+
+function assertCredentialRef(credential) {
+  if (credential?.kind === "secret") {
+    return { kind: "secret", id: assertSecretRef(credential) };
+  }
+  if (
+    !credential
+    || typeof credential !== "object"
+    || Array.isArray(credential)
+    || credential.kind !== "credential"
+    || typeof credential.id !== "string"
+    || credential.id.length < 16
+    || credential.id.length > 256
+  ) throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Credential reference is invalid");
+  return { kind: "credential", id: credential.id };
+}
+
+function assertLeaseParams(params) {
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Credential lease parameters are invalid");
+  }
+  const credential = assertCredentialRef(params.secret);
+  if (typeof params.operationId !== "string" || params.operationId.length < 1 || params.operationId.length > 128) {
+    throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Credential lease operation ID is invalid");
+  }
+  if (typeof params.purpose !== "string" || params.purpose.length < 1 || params.purpose.length > 256) {
+    throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Credential lease purpose is invalid");
+  }
+  if (
+    params.ttlMs !== undefined
+    && (!Number.isSafeInteger(params.ttlMs) || params.ttlMs < 1 || params.ttlMs > 60_000)
+  ) throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Credential lease lifetime is invalid");
+  return {
+    secret: credential,
+    operationId: params.operationId,
+    purpose: params.purpose,
+    ...(params.ttlMs === undefined ? {} : { ttlMs: params.ttlMs }),
+  };
+}
+
+class PluginCredentialBroker {
+  constructor(options) {
+    this.secretStore = options.secretStore;
+    this.leaseStore = options.leaseStore;
+    this.credentialResolver = options.credentialResolver ?? null;
+    if (this.credentialResolver && (
+      typeof this.credentialResolver.assertReference !== "function"
+      || typeof this.credentialResolver.resolve !== "function"
+    )) throw new TypeError("Credential resolver must validate and resolve credential references");
+  }
+
+  async describeAuthorization(params, context) {
+    const validated = assertLeaseParams(params);
+    if (validated.secret.kind === "credential") {
+      if (!this.credentialResolver) {
+        throw new PluginRpcError(RPC_ERRORS.unavailable, "Netcatty credential access is unavailable");
+      }
+      await this.credentialResolver.assertReference(validated.secret, {
+        pluginId: context.pluginId,
+        runtimeId: context.runtimeId,
+        operationId: validated.operationId,
+        purpose: validated.purpose,
+        signal: context.signal,
+      });
+      await context.assertActive();
+      return {
+        permission: "vault.credentials",
+        resources: [`credential:${validated.secret.id}`],
+        reason: `Use Netcatty credential for ${validated.purpose}`,
+        operationId: validated.operationId,
+      };
+    }
+    const secret = this.secretStore.getRecordByReference(context.pluginId, validated.secret);
+    return {
+      permission: "secrets",
+      resources: [`secret:${secret.key}`],
+      reason: `Use plugin secret for ${validated.purpose}`,
+      operationId: validated.operationId,
+    };
+  }
+
+  async createLease(params, context) {
+    const validated = assertLeaseParams(params);
+    await context.assertActive();
+    let resolveSecret;
+    if (validated.secret.kind === "credential") {
+      if (!this.credentialResolver) {
+        throw new PluginRpcError(RPC_ERRORS.unavailable, "Netcatty credential access is unavailable");
+      }
+      await this.credentialResolver.assertReference(validated.secret, {
+        pluginId: context.pluginId,
+        runtimeId: context.runtimeId,
+        operationId: validated.operationId,
+        purpose: validated.purpose,
+        signal: context.signal,
+      });
+      await context.assertActive();
+      resolveSecret = async (consumeContext) => {
+        const value = await this.credentialResolver.resolve(
+          validated.secret,
+          Object.freeze({ ...consumeContext, purpose: validated.purpose }),
+        );
+        if (typeof value !== "string" || Buffer.byteLength(value, "utf8") > MAX_SECRET_BYTES) {
+          throw new PluginRpcError(RPC_ERRORS.dataLoss, "Resolved credential is invalid or too large");
+        }
+        return value;
+      };
+    } else {
+      this.secretStore.getRecordByReference(context.pluginId, validated.secret);
+    }
+    return this.leaseStore.issue({
+      pluginId: context.pluginId,
+      runtimeId: context.runtimeId,
+      credential: validated.secret,
+      operationId: validated.operationId,
+      purpose: validated.purpose,
+      ttlMs: validated.ttlMs,
+      signal: context.signal,
+      resolveSecret,
+    });
+  }
+
+  async consumeLease(context, lease, operationId) {
+    await context.assertActive();
+    const value = await this.leaseStore.consume({
+      pluginId: context.pluginId,
+      runtimeId: context.runtimeId,
+      lease,
+      operationId,
+      signal: context.signal,
+    });
+    await context.assertActive();
+    return value;
+  }
+}
+
+module.exports = { PluginCredentialBroker, assertCredentialRef, assertLeaseParams };

--- a/electron/plugins/credentialBroker.cjs
+++ b/electron/plugins/credentialBroker.cjs
@@ -5,7 +5,7 @@ const { MAX_SECRET_BYTES, assertSecretRef } = require("./secretStore.cjs");
 
 function assertCredentialRef(credential) {
   if (credential?.kind === "secret") {
-    return { kind: "secret", id: assertSecretRef(credential) };
+    return { kind: "secret", ...assertSecretRef(credential) };
   }
   if (
     !credential
@@ -65,7 +65,7 @@ class PluginCredentialBroker {
     }
     return {
       permission: "secrets",
-      resources: [`secret-ref:${validated.secret.id}`],
+      resources: [`secret:${validated.secret.key}`],
       reason: `Use plugin secret for ${validated.purpose}`,
       operationId: validated.operationId,
     };

--- a/electron/plugins/database.cjs
+++ b/electron/plugins/database.cjs
@@ -1,10 +1,23 @@
 "use strict";
 
+const { createHash } = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
 const { DatabaseSync } = require("node:sqlite");
 
 const SCHEMA_VERSION = 1;
+const MAX_SECURITY_AUDIT_DETAILS_BYTES = 16 * 1024;
+const MAX_SECURITY_AUDIT_RECORDS_PER_PLUGIN = 1_000;
+const REQUIRED_SCHEMA_COLUMNS = Object.freeze({
+  plugins: ["id", "enabled", "active_version", "installed_at", "updated_at"],
+  plugin_versions: ["plugin_id", "version", "manifest_json", "archive_sha256", "package_relative_path", "installed_at"],
+  plugin_runtime_state: ["plugin_id", "plugin_version", "status", "runtime_kind", "last_error", "quarantined_at", "updated_at"],
+  plugin_crashes: ["plugin_id", "plugin_version", "crashed_at"],
+  plugin_kv: ["plugin_id", "key", "value_json", "updated_at"],
+  plugin_permission_grants: ["plugin_id", "permission", "resource", "declaration_hash", "granted_at"],
+  plugin_secrets: ["plugin_id", "key", "secret_ref", "ciphertext", "created_at", "updated_at"],
+  plugin_security_audit: ["id", "plugin_id", "event", "details_json", "created_at"],
+});
 
 function parseJson(text, label) {
   try {
@@ -87,9 +100,49 @@ class PluginDatabase {
             updated_at INTEGER NOT NULL,
             PRIMARY KEY (plugin_id, key)
           );
+          CREATE TABLE plugin_permission_grants (
+            plugin_id TEXT NOT NULL,
+            permission TEXT NOT NULL,
+            resource TEXT NOT NULL,
+            declaration_hash TEXT NOT NULL,
+            granted_at INTEGER NOT NULL,
+            PRIMARY KEY (plugin_id, permission, resource)
+          );
+          CREATE TABLE plugin_secrets (
+            plugin_id TEXT NOT NULL,
+            key TEXT NOT NULL,
+            secret_ref TEXT NOT NULL UNIQUE,
+            ciphertext BLOB NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            PRIMARY KEY (plugin_id, key)
+          );
+          CREATE INDEX plugin_secrets_ref_lookup
+            ON plugin_secrets(plugin_id, secret_ref);
+          CREATE TABLE plugin_security_audit (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            plugin_id TEXT NOT NULL,
+            event TEXT NOT NULL,
+            details_json TEXT NOT NULL,
+            created_at INTEGER NOT NULL
+          );
+          CREATE INDEX plugin_security_audit_lookup
+            ON plugin_security_audit(plugin_id, created_at DESC);
           PRAGMA user_version = 1;
         `);
       });
+    }
+    this.#assertSchemaLayout();
+  }
+
+  #assertSchemaLayout() {
+    for (const [table, columns] of Object.entries(REQUIRED_SCHEMA_COLUMNS)) {
+      const actual = this.db.prepare(`PRAGMA table_info(${table})`).all().map(({ name }) => name);
+      if (JSON.stringify(actual) !== JSON.stringify(columns)) {
+        throw new Error(
+          "Pre-release plugin database schema is obsolete; reset userData/plugins/plugins.sqlite",
+        );
+      }
     }
   }
 
@@ -370,9 +423,152 @@ class PluginDatabase {
     ).all(pluginId).map((row) => row.key);
   }
 
+  listPermissionGrants(pluginId) {
+    return this.db.prepare(`
+      SELECT plugin_id, permission, resource, declaration_hash, granted_at
+      FROM plugin_permission_grants
+      WHERE plugin_id = ?
+      ORDER BY permission COLLATE BINARY, resource COLLATE BINARY
+    `).all(pluginId).map((row) => ({
+      pluginId: row.plugin_id,
+      permission: row.permission,
+      resource: row.resource,
+      declarationHash: row.declaration_hash,
+      grantedAt: Number(row.granted_at),
+    }));
+  }
+
+  upsertPermissionGrant(record) {
+    this.db.prepare(`
+      INSERT INTO plugin_permission_grants(
+        plugin_id, permission, resource, declaration_hash, granted_at
+      ) VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(plugin_id, permission, resource) DO UPDATE SET
+        declaration_hash = excluded.declaration_hash,
+        granted_at = excluded.granted_at
+    `).run(
+      record.pluginId,
+      record.permission,
+      record.resource,
+      record.declarationHash,
+      this.clock(),
+    );
+  }
+
+  deletePermissionGrant(pluginId, permission, resource) {
+    this.db.prepare(`
+      DELETE FROM plugin_permission_grants
+      WHERE plugin_id = ? AND permission = ? AND resource = ?
+    `).run(pluginId, permission, resource);
+  }
+
+  deleteAllPermissionGrants(pluginId) {
+    this.db.prepare("DELETE FROM plugin_permission_grants WHERE plugin_id = ?").run(pluginId);
+  }
+
+  getSecretByKey(pluginId, key) {
+    const row = this.db.prepare(`
+      SELECT plugin_id, key, secret_ref, ciphertext, created_at, updated_at
+      FROM plugin_secrets WHERE plugin_id = ? AND key = ?
+    `).get(pluginId, key);
+    return row ? this.#mapSecret(row) : null;
+  }
+
+  getSecretByRef(pluginId, secretRef) {
+    const row = this.db.prepare(`
+      SELECT plugin_id, key, secret_ref, ciphertext, created_at, updated_at
+      FROM plugin_secrets WHERE plugin_id = ? AND secret_ref = ?
+    `).get(pluginId, secretRef);
+    return row ? this.#mapSecret(row) : null;
+  }
+
+  #mapSecret(row) {
+    return {
+      pluginId: row.plugin_id,
+      key: row.key,
+      secretRef: row.secret_ref,
+      ciphertext: Buffer.from(row.ciphertext),
+      createdAt: Number(row.created_at),
+      updatedAt: Number(row.updated_at),
+    };
+  }
+
+  upsertSecret(record) {
+    const now = this.clock();
+    this.db.prepare(`
+      INSERT INTO plugin_secrets(
+        plugin_id, key, secret_ref, ciphertext, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?)
+      ON CONFLICT(plugin_id, key) DO UPDATE SET
+        secret_ref = excluded.secret_ref,
+        ciphertext = excluded.ciphertext,
+        updated_at = excluded.updated_at
+    `).run(
+      record.pluginId,
+      record.key,
+      record.secretRef,
+      record.ciphertext,
+      now,
+      now,
+    );
+  }
+
+  deleteSecret(pluginId, key) {
+    this.db.prepare("DELETE FROM plugin_secrets WHERE plugin_id = ? AND key = ?")
+      .run(pluginId, key);
+  }
+
+  recordSecurityAudit(pluginId, event, details) {
+    let detailsJson = JSON.stringify(details ?? {});
+    const originalBytes = Buffer.byteLength(detailsJson);
+    if (originalBytes > MAX_SECURITY_AUDIT_DETAILS_BYTES) {
+      detailsJson = JSON.stringify({
+        truncated: true,
+        originalBytes,
+        sha256: createHash("sha256").update(detailsJson).digest("hex"),
+      });
+    }
+    this.transaction(() => {
+      this.db.prepare(`
+        INSERT INTO plugin_security_audit(plugin_id, event, details_json, created_at)
+        VALUES (?, ?, ?, ?)
+      `).run(pluginId, event, detailsJson, this.clock());
+      this.db.prepare(`
+        DELETE FROM plugin_security_audit
+        WHERE plugin_id = ? AND id NOT IN (
+          SELECT id FROM plugin_security_audit
+          WHERE plugin_id = ? ORDER BY id DESC LIMIT ${MAX_SECURITY_AUDIT_RECORDS_PER_PLUGIN}
+        )
+      `).run(pluginId, pluginId);
+    });
+  }
+
+  listSecurityAudit(pluginId, limit = 100) {
+    const requestedLimit = Number(limit);
+    const normalizedLimit = Math.max(1, Math.min(
+      1_000,
+      Number.isFinite(requestedLimit) ? Math.trunc(requestedLimit) : 100,
+    ));
+    return this.db.prepare(`
+      SELECT event, details_json, created_at
+      FROM plugin_security_audit
+      WHERE plugin_id = ? ORDER BY id DESC LIMIT ?
+    `).all(pluginId, normalizedLimit).map((row) => ({
+      event: row.event,
+      details: parseJson(row.details_json, "security audit entry"),
+      createdAt: Number(row.created_at),
+    }));
+  }
+
   close() {
     this.db.close();
   }
 }
 
-module.exports = { PluginDatabase, SCHEMA_VERSION };
+module.exports = {
+  MAX_SECURITY_AUDIT_DETAILS_BYTES,
+  MAX_SECURITY_AUDIT_RECORDS_PER_PLUGIN,
+  PluginDatabase,
+  REQUIRED_SCHEMA_COLUMNS,
+  SCHEMA_VERSION,
+};

--- a/electron/plugins/database.cjs
+++ b/electron/plugins/database.cjs
@@ -14,7 +14,7 @@ const REQUIRED_SCHEMA_COLUMNS = Object.freeze({
   plugin_runtime_state: ["plugin_id", "plugin_version", "status", "runtime_kind", "last_error", "quarantined_at", "updated_at"],
   plugin_crashes: ["plugin_id", "plugin_version", "crashed_at"],
   plugin_kv: ["plugin_id", "key", "value_json", "updated_at"],
-  plugin_permission_grants: ["plugin_id", "permission", "resource", "declaration_hash", "granted_at"],
+  plugin_permission_grants: ["plugin_id", "permission", "resource", "resource_kind", "declaration_hash", "granted_at"],
   plugin_secrets: ["plugin_id", "key", "secret_ref", "ciphertext", "created_at", "updated_at"],
   plugin_security_audit: ["id", "plugin_id", "event", "details_json", "created_at"],
 });
@@ -104,6 +104,7 @@ class PluginDatabase {
             plugin_id TEXT NOT NULL,
             permission TEXT NOT NULL,
             resource TEXT NOT NULL,
+            resource_kind TEXT NOT NULL CHECK (resource_kind IN ('exact', 'directory')),
             declaration_hash TEXT NOT NULL,
             granted_at INTEGER NOT NULL,
             PRIMARY KEY (plugin_id, permission, resource)
@@ -425,7 +426,7 @@ class PluginDatabase {
 
   listPermissionGrants(pluginId) {
     return this.db.prepare(`
-      SELECT plugin_id, permission, resource, declaration_hash, granted_at
+      SELECT plugin_id, permission, resource, resource_kind, declaration_hash, granted_at
       FROM plugin_permission_grants
       WHERE plugin_id = ?
       ORDER BY permission COLLATE BINARY, resource COLLATE BINARY
@@ -433,6 +434,7 @@ class PluginDatabase {
       pluginId: row.plugin_id,
       permission: row.permission,
       resource: row.resource,
+      resourceKind: row.resource_kind,
       declarationHash: row.declaration_hash,
       grantedAt: Number(row.granted_at),
     }));
@@ -441,15 +443,17 @@ class PluginDatabase {
   upsertPermissionGrant(record) {
     this.db.prepare(`
       INSERT INTO plugin_permission_grants(
-        plugin_id, permission, resource, declaration_hash, granted_at
-      ) VALUES (?, ?, ?, ?, ?)
+        plugin_id, permission, resource, resource_kind, declaration_hash, granted_at
+      ) VALUES (?, ?, ?, ?, ?, ?)
       ON CONFLICT(plugin_id, permission, resource) DO UPDATE SET
+        resource_kind = excluded.resource_kind,
         declaration_hash = excluded.declaration_hash,
         granted_at = excluded.granted_at
     `).run(
       record.pluginId,
       record.permission,
       record.resource,
+      record.resourceKind,
       record.declarationHash,
       this.clock(),
     );

--- a/electron/plugins/database.test.cjs
+++ b/electron/plugins/database.test.cjs
@@ -7,7 +7,11 @@ const path = require("node:path");
 const test = require("node:test");
 const { DatabaseSync } = require("node:sqlite");
 
-const { PluginDatabase, SCHEMA_VERSION } = require("./database.cjs");
+const {
+  MAX_SECURITY_AUDIT_DETAILS_BYTES,
+  PluginDatabase,
+  SCHEMA_VERSION,
+} = require("./database.cjs");
 
 function createDatabase(context, clock = () => 1_000) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-db-"));
@@ -42,6 +46,19 @@ test("plugin database initializes atomically and rejects newer schemas", (contex
   assert.throws(() => new PluginDatabase(file), /newer than supported/);
 });
 
+test("obsolete unpublished v1 layouts fail with an explicit reset instruction", (context) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-obsolete-db-"));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const file = path.join(root, "plugins.sqlite");
+  const obsolete = new DatabaseSync(file);
+  obsolete.exec("CREATE TABLE plugins(id TEXT PRIMARY KEY); PRAGMA user_version = 1");
+  obsolete.close();
+  assert.throws(
+    () => new PluginDatabase(file),
+    /reset userData\/plugins\/plugins\.sqlite/,
+  );
+});
+
 test("initial schema scopes runtime and crash state to immutable plugin versions", (context) => {
   const database = createDatabase(context);
   assert.deepEqual(
@@ -60,6 +77,59 @@ test("initial schema scopes runtime and crash state to immutable plugin versions
       "updated_at",
     ],
   );
+  assert.deepEqual(
+    database.db.prepare("PRAGMA table_info(plugin_permission_grants)").all().map(({ name }) => name),
+    ["plugin_id", "permission", "resource", "declaration_hash", "granted_at"],
+  );
+  assert.deepEqual(
+    database.db.prepare("PRAGMA table_info(plugin_secrets)").all().map(({ name }) => name),
+    ["plugin_id", "key", "secret_ref", "ciphertext", "created_at", "updated_at"],
+  );
+  database.close();
+});
+
+test("user-owned security records survive package uninstall in the complete v1 schema", (context) => {
+  const database = createDatabase(context);
+  const pluginManifest = manifest();
+  database.installVersion({
+    pluginId: pluginManifest.id,
+    version: pluginManifest.version,
+    manifest: pluginManifest,
+    archiveSha256: "a".repeat(64),
+    packageRelativePath: `${pluginManifest.id}/${pluginManifest.version}/package`,
+  });
+  database.upsertPermissionGrant({
+    pluginId: pluginManifest.id,
+    permission: "network",
+    resource: "https://example.com",
+    declarationHash: "b".repeat(64),
+  });
+  database.upsertSecret({
+    pluginId: pluginManifest.id,
+    key: "api-key",
+    secretRef: "secret-reference-0000000000000000",
+    ciphertext: Buffer.from("encrypted"),
+  });
+  database.recordSecurityAudit(pluginManifest.id, "permission.granted", { permission: "network" });
+
+  database.removePlugin(pluginManifest.id);
+
+  assert.equal(database.getActivePlugin(pluginManifest.id), null);
+  assert.equal(database.listPermissionGrants(pluginManifest.id).length, 1);
+  assert.equal(database.getSecretByKey(pluginManifest.id, "api-key").secretRef, "secret-reference-0000000000000000");
+  assert.deepEqual(database.listSecurityAudit(pluginManifest.id)[0].details, { permission: "network" });
+  database.close();
+});
+
+test("security audit details are bounded and oversized records retain only a digest", (context) => {
+  const database = createDatabase(context);
+  database.recordSecurityAudit("com.example.test", "permission.denied", {
+    untrusted: "x".repeat(MAX_SECURITY_AUDIT_DETAILS_BYTES + 1),
+  });
+  const record = database.listSecurityAudit("com.example.test")[0];
+  assert.equal(record.details.truncated, true);
+  assert.match(record.details.sha256, /^[a-f0-9]{64}$/u);
+  assert.equal(Object.hasOwn(record.details, "untrusted"), false);
   database.close();
 });
 

--- a/electron/plugins/database.test.cjs
+++ b/electron/plugins/database.test.cjs
@@ -79,7 +79,7 @@ test("initial schema scopes runtime and crash state to immutable plugin versions
   );
   assert.deepEqual(
     database.db.prepare("PRAGMA table_info(plugin_permission_grants)").all().map(({ name }) => name),
-    ["plugin_id", "permission", "resource", "declaration_hash", "granted_at"],
+    ["plugin_id", "permission", "resource", "resource_kind", "declaration_hash", "granted_at"],
   );
   assert.deepEqual(
     database.db.prepare("PRAGMA table_info(plugin_secrets)").all().map(({ name }) => name),
@@ -102,6 +102,7 @@ test("user-owned security records survive package uninstall in the complete v1 s
     pluginId: pluginManifest.id,
     permission: "network",
     resource: "https://example.com",
+    resourceKind: "exact",
     declarationHash: "b".repeat(64),
   });
   database.upsertSecret({
@@ -115,7 +116,10 @@ test("user-owned security records survive package uninstall in the complete v1 s
   database.removePlugin(pluginManifest.id);
 
   assert.equal(database.getActivePlugin(pluginManifest.id), null);
-  assert.equal(database.listPermissionGrants(pluginManifest.id).length, 1);
+  assert.deepEqual(database.listPermissionGrants(pluginManifest.id).map((grant) => ({
+    resource: grant.resource,
+    resourceKind: grant.resourceKind,
+  })), [{ resource: "https://example.com", resourceKind: "exact" }]);
   assert.equal(database.getSecretByKey(pluginManifest.id, "api-key").secretRef, "secret-reference-0000000000000000");
   assert.deepEqual(database.listSecurityAudit(pluginManifest.id)[0].details, { permission: "network" });
   database.close();

--- a/electron/plugins/electronRuntime.live.test.cjs
+++ b/electron/plugins/electronRuntime.live.test.cjs
@@ -50,6 +50,11 @@ if (!process.versions.electron) {
       electron,
       appRoot: runtimeAppRoot,
       runtimeDirectory,
+      requestPermissionDecision: async (request) => ({
+        requestId: request.requestId,
+        decision: "allow",
+        scope: "application",
+      }),
     });
     await service.manager.initialize();
     for (const fixture of fixtures) {

--- a/electron/plugins/filesystemBroker.cjs
+++ b/electron/plugins/filesystemBroker.cjs
@@ -198,32 +198,34 @@ class PluginFilesystemBroker {
   }
   validatePath(params) { return assertPathParams(params); }
 
-  async describeReadAuthorization(params) {
-    const value = assertReadParams(params);
-    const { canonical, stats } = await resolveExistingPath(value.path, this.fileSystem);
+  describeReadAuthorization(params, resourceKind = "exact") {
+    const value = assertPathParams(params);
+    if (resourceKind !== "exact" && resourceKind !== "directory") {
+      throw invalidArgument("Plugin filesystem authorization kind is invalid");
+    }
     return {
       permission: "filesystem.read",
-      resources: [canonical],
-      resourceKinds: [stats.isDirectory() ? "directory" : "exact"],
-      reason: `Read ${canonical}`,
-      operationId: `filesystem.read:${canonical}`,
+      resources: [value.path],
+      resourceKinds: [resourceKind],
+      reason: `Read ${value.path}`,
+      operationId: `filesystem.read:${value.path}`,
     };
   }
 
-  async describeWriteAuthorization(params) {
+  describeWriteAuthorization(params) {
     const value = assertSecureWriteMode(assertWriteParams(params));
-    const canonical = await resolveWritePath(value.path, this.fileSystem);
     return {
       permission: "filesystem.write",
-      resources: [canonical],
+      resources: [value.path],
       resourceKinds: ["exact"],
-      reason: `Write ${canonical}`,
-      operationId: `filesystem.write:${canonical}`,
+      reason: `Write ${value.path}`,
+      operationId: `filesystem.write:${value.path}`,
     };
   }
 
   async readFile(params, context) {
     const value = assertReadParams(params);
+    assertAuthorizedPath(context, "filesystem.read", value.path);
     const { canonical, stats } = await resolveExistingPath(value.path, this.fileSystem);
     assertAuthorizedPath(context, "filesystem.read", canonical);
     if (!stats.isFile()) throw invalidArgument("Plugin filesystem read target is not a file");
@@ -232,8 +234,13 @@ class PluginFilesystemBroker {
     }
     const handle = await this.fileSystem.open(canonical, fs.constants.O_RDONLY | NOFOLLOW);
     try {
-      const openedStats = await handle.stat();
-      if (!openedStats.isFile() || openedStats.size > value.maxBytes) {
+      const [openedStats, pathStats] = await Promise.all([
+        handle.stat(),
+        this.fileSystem.stat(canonical),
+      ]);
+      assertSameOpenedFile(openedStats, stats);
+      assertSameOpenedFile(openedStats, pathStats);
+      if (openedStats.size > value.maxBytes) {
         throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Plugin filesystem file changed or is too large");
       }
       assertAuthorizedPath(context, "filesystem.read", await this.fileSystem.realpath(canonical));
@@ -248,6 +255,7 @@ class PluginFilesystemBroker {
 
   async writeFile(params, context) {
     const value = assertSecureWriteMode(assertWriteParams(params));
+    assertAuthorizedPath(context, "filesystem.write", value.path);
     const canonical = await resolveWritePath(value.path, this.fileSystem);
     assertAuthorizedPath(context, "filesystem.write", canonical);
     this.quotaManager?.chargeBytes(context.runtimeId, "filesystem", value.bytes.byteLength);
@@ -274,6 +282,7 @@ class PluginFilesystemBroker {
 
   async stat(params, context) {
     const value = assertPathParams(params);
+    assertAuthorizedPath(context, "filesystem.read", value.path);
     const { canonical, stats } = await resolveExistingPath(value.path, this.fileSystem);
     assertAuthorizedPath(context, "filesystem.read", canonical);
     await context.assertActive();
@@ -286,6 +295,7 @@ class PluginFilesystemBroker {
 
   async readDirectory(params, context) {
     const value = assertPathParams(params);
+    assertAuthorizedPath(context, "filesystem.read", value.path);
     const { canonical, stats } = await resolveExistingPath(value.path, this.fileSystem);
     assertAuthorizedPath(context, "filesystem.read", canonical);
     if (!stats.isDirectory()) throw invalidArgument("Plugin filesystem directory target is not a directory");

--- a/electron/plugins/filesystemBroker.cjs
+++ b/electron/plugins/filesystemBroker.cjs
@@ -106,7 +106,7 @@ async function resolveWritePath(requestedPath, fileSystem = fsp) {
   try {
     const existing = await resolveExistingPath(requestedPath, fileSystem);
     if (!existing.stats.isFile()) throw invalidArgument("Plugin filesystem write target is not a file");
-    return existing.canonical;
+    return existing;
   } catch (error) {
     if (error?.code === "ENOENT") {
       throw new PluginRpcError(
@@ -264,7 +264,7 @@ class PluginFilesystemBroker {
   async writeFile(params, context) {
     const value = assertSecureWriteMode(assertWriteParams(params));
     assertAuthorizedPath(context, "filesystem.write", value.path);
-    const canonical = await resolveWritePath(value.path, this.fileSystem);
+    const { canonical, stats } = await resolveWritePath(value.path, this.fileSystem);
     assertAuthorizedPath(context, "filesystem.write", canonical);
     this.quotaManager?.chargeBytes(context.runtimeId, "filesystem", value.bytes.byteLength);
     await context.assertActive();
@@ -276,6 +276,7 @@ class PluginFilesystemBroker {
         handle.stat(),
         this.fileSystem.stat(canonical),
       ]);
+      assertSameOpenedFile(openedStats, stats);
       assertSameOpenedFile(openedStats, pathStats);
       await context.assertActive();
       if (value.overwrite) await handle.truncate(0);

--- a/electron/plugins/filesystemBroker.cjs
+++ b/electron/plugins/filesystemBroker.cjs
@@ -74,6 +74,16 @@ function assertWriteParams(params) {
   };
 }
 
+function assertSecureWriteMode(value) {
+  if (!value.overwrite) {
+    throw new PluginRpcError(
+      RPC_ERRORS.failedPrecondition,
+      "Plugin filesystem writes require explicit overwrite of an existing file",
+    );
+  }
+  return value;
+}
+
 function assertPathParams(params) {
   if (!params || typeof params !== "object" || Array.isArray(params)) {
     throw invalidArgument("Plugin filesystem parameters are invalid");
@@ -94,14 +104,14 @@ async function resolveWritePath(requestedPath, fileSystem = fsp) {
     if (!existing.stats.isFile()) throw invalidArgument("Plugin filesystem write target is not a file");
     return existing.canonical;
   } catch (error) {
-    if (error?.code !== "ENOENT") throw error;
+    if (error?.code === "ENOENT") {
+      throw new PluginRpcError(
+        RPC_ERRORS.failedPrecondition,
+        "Plugin filesystem writes require an existing regular file",
+      );
+    }
+    throw error;
   }
-  const parent = await fileSystem.realpath(path.dirname(requestedPath));
-  const parentStats = await fileSystem.lstat(parent);
-  if (!parentStats.isDirectory() || parentStats.isSymbolicLink()) {
-    throw invalidArgument("Plugin filesystem write parent is not a real directory");
-  }
-  return path.join(parent, path.basename(requestedPath));
 }
 
 function entryKind(entry) {
@@ -201,7 +211,7 @@ class PluginFilesystemBroker {
   }
 
   async describeWriteAuthorization(params) {
-    const value = assertWriteParams(params);
+    const value = assertSecureWriteMode(assertWriteParams(params));
     const canonical = await resolveWritePath(value.path, this.fileSystem);
     return {
       permission: "filesystem.write",
@@ -237,15 +247,12 @@ class PluginFilesystemBroker {
   }
 
   async writeFile(params, context) {
-    const value = assertWriteParams(params);
+    const value = assertSecureWriteMode(assertWriteParams(params));
     const canonical = await resolveWritePath(value.path, this.fileSystem);
     assertAuthorizedPath(context, "filesystem.write", canonical);
     this.quotaManager?.chargeBytes(context.runtimeId, "filesystem", value.bytes.byteLength);
     await context.assertActive();
-    const flags = fs.constants.O_WRONLY
-      | fs.constants.O_CREAT
-      | NOFOLLOW
-      | (value.overwrite ? 0 : fs.constants.O_EXCL);
+    const flags = fs.constants.O_WRONLY | NOFOLLOW;
     const handle = await this.fileSystem.open(canonical, flags, 0o600);
     try {
       assertAuthorizedPath(context, "filesystem.write", await this.fileSystem.realpath(canonical));
@@ -321,6 +328,7 @@ module.exports = {
   assertSameOpenedDirectory,
   assertPathParams,
   assertReadParams,
+  assertSecureWriteMode,
   assertWriteParams,
   resolveExistingPath,
   resolveWritePath,

--- a/electron/plugins/filesystemBroker.cjs
+++ b/electron/plugins/filesystemBroker.cjs
@@ -1,0 +1,290 @@
+"use strict";
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const path = require("node:path");
+
+const { PluginRpcError, RPC_ERRORS } = require("./rpcRouter.cjs");
+
+const MAX_FILESYSTEM_BYTES = 1024 * 1024;
+const MAX_DIRECTORY_ENTRIES = 1_000;
+const NOFOLLOW = fs.constants.O_NOFOLLOW ?? 0;
+
+function invalidArgument(message) {
+  return new PluginRpcError(RPC_ERRORS.invalidArgument, message);
+}
+
+function assertAbsolutePath(value) {
+  if (
+    typeof value !== "string"
+    || value.length < 1
+    || value.length > 8_192
+    || value.includes("\0")
+    || !path.isAbsolute(value)
+  ) {
+    throw invalidArgument("Plugin filesystem path must be absolute");
+  }
+  return path.normalize(value);
+}
+
+function assertReadParams(params) {
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    throw invalidArgument("Plugin filesystem read parameters are invalid");
+  }
+  const encoding = params.encoding ?? "utf8";
+  if (encoding !== "utf8" && encoding !== "base64") {
+    throw invalidArgument("Plugin filesystem read encoding is invalid");
+  }
+  const maxBytes = params.maxBytes ?? MAX_FILESYSTEM_BYTES;
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1 || maxBytes > MAX_FILESYSTEM_BYTES) {
+    throw invalidArgument("Plugin filesystem read limit is invalid");
+  }
+  return { path: assertAbsolutePath(params.path), encoding, maxBytes };
+}
+
+function decodeWriteData(params) {
+  const encoding = params.encoding ?? "utf8";
+  if (encoding !== "utf8" && encoding !== "base64") {
+    throw invalidArgument("Plugin filesystem write encoding is invalid");
+  }
+  if (typeof params.data !== "string") throw invalidArgument("Plugin filesystem write data is invalid");
+  const bytes = Buffer.from(params.data, encoding);
+  if (encoding === "base64" && bytes.toString("base64") !== params.data) {
+    throw invalidArgument("Plugin filesystem base64 data is not canonical");
+  }
+  if (bytes.byteLength > MAX_FILESYSTEM_BYTES) {
+    throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Plugin filesystem write is too large");
+  }
+  return { encoding, bytes };
+}
+
+function assertWriteParams(params) {
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    throw invalidArgument("Plugin filesystem write parameters are invalid");
+  }
+  const { encoding, bytes } = decodeWriteData(params);
+  if (params.overwrite !== undefined && typeof params.overwrite !== "boolean") {
+    throw invalidArgument("Plugin filesystem overwrite flag is invalid");
+  }
+  return {
+    path: assertAbsolutePath(params.path),
+    encoding,
+    bytes,
+    overwrite: params.overwrite === true,
+  };
+}
+
+function assertPathParams(params) {
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    throw invalidArgument("Plugin filesystem parameters are invalid");
+  }
+  return { path: assertAbsolutePath(params.path) };
+}
+
+async function resolveExistingPath(requestedPath) {
+  const canonical = await fsp.realpath(requestedPath);
+  const stats = await fsp.lstat(canonical);
+  if (stats.isSymbolicLink()) throw invalidArgument("Plugin filesystem path cannot resolve to a symbolic link");
+  return { canonical, stats };
+}
+
+async function resolveWritePath(requestedPath) {
+  try {
+    const existing = await resolveExistingPath(requestedPath);
+    if (!existing.stats.isFile()) throw invalidArgument("Plugin filesystem write target is not a file");
+    return existing.canonical;
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+  const parent = await fsp.realpath(path.dirname(requestedPath));
+  const parentStats = await fsp.lstat(parent);
+  if (!parentStats.isDirectory() || parentStats.isSymbolicLink()) {
+    throw invalidArgument("Plugin filesystem write parent is not a real directory");
+  }
+  return path.join(parent, path.basename(requestedPath));
+}
+
+function entryKind(entry) {
+  if (entry.isFile()) return "file";
+  if (entry.isDirectory()) return "directory";
+  return "other";
+}
+
+async function readBoundedFileHandle(handle, maxBytes) {
+  const chunks = [];
+  let total = 0;
+  while (total <= maxBytes) {
+    const buffer = Buffer.allocUnsafe(Math.min(64 * 1024, (maxBytes + 1) - total));
+    const { bytesRead } = await handle.read(buffer, 0, buffer.byteLength, null);
+    if (bytesRead === 0) break;
+    chunks.push(buffer.subarray(0, bytesRead));
+    total += bytesRead;
+  }
+  if (total > maxBytes) {
+    throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Plugin filesystem file changed or is too large");
+  }
+  return Buffer.concat(chunks, total);
+}
+
+function assertAuthorizedPath(context, permission, canonical) {
+  const authorization = context?.authorization;
+  if (
+    authorization?.permission !== permission
+    || !Array.isArray(authorization.resources)
+    || authorization.resources.length !== 1
+    || authorization.resources[0] !== canonical
+  ) {
+    throw new PluginRpcError(
+      RPC_ERRORS.permissionDenied,
+      "Plugin filesystem path changed after authorization",
+    );
+  }
+  return canonical;
+}
+
+function assertSameOpenedFile(openedStats, pathStats) {
+  if (
+    !openedStats.isFile()
+    || !pathStats.isFile()
+    || openedStats.dev !== pathStats.dev
+    || openedStats.ino !== pathStats.ino
+  ) {
+    throw new PluginRpcError(
+      RPC_ERRORS.permissionDenied,
+      "Plugin filesystem target changed after it was opened",
+    );
+  }
+}
+
+class PluginFilesystemBroker {
+  constructor(options = {}) {
+    this.quotaManager = options.quotaManager ?? null;
+  }
+
+  validateRead(params) { return assertReadParams(params); }
+  validateWrite(params) {
+    const value = assertWriteParams(params);
+    return {
+      path: value.path,
+      encoding: value.encoding,
+      data: value.bytes.toString(value.encoding),
+      overwrite: value.overwrite,
+    };
+  }
+  validatePath(params) { return assertPathParams(params); }
+
+  async describeReadAuthorization(params) {
+    const value = assertReadParams(params);
+    const { canonical } = await resolveExistingPath(value.path);
+    return {
+      permission: "filesystem.read",
+      resources: [canonical],
+      reason: `Read ${canonical}`,
+      operationId: `filesystem.read:${canonical}`,
+    };
+  }
+
+  async describeWriteAuthorization(params) {
+    const value = assertWriteParams(params);
+    const canonical = await resolveWritePath(value.path);
+    return {
+      permission: "filesystem.write",
+      resources: [canonical],
+      reason: `Write ${canonical}`,
+      operationId: `filesystem.write:${canonical}`,
+    };
+  }
+
+  async readFile(params, context) {
+    const value = assertReadParams(params);
+    const { canonical, stats } = await resolveExistingPath(value.path);
+    assertAuthorizedPath(context, "filesystem.read", canonical);
+    if (!stats.isFile()) throw invalidArgument("Plugin filesystem read target is not a file");
+    if (stats.size > value.maxBytes) {
+      throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Plugin filesystem file is too large");
+    }
+    const handle = await fsp.open(canonical, fs.constants.O_RDONLY | NOFOLLOW);
+    try {
+      const openedStats = await handle.stat();
+      if (!openedStats.isFile() || openedStats.size > value.maxBytes) {
+        throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Plugin filesystem file changed or is too large");
+      }
+      assertAuthorizedPath(context, "filesystem.read", await fsp.realpath(canonical));
+      const bytes = await readBoundedFileHandle(handle, value.maxBytes);
+      this.quotaManager?.chargeBytes(context.runtimeId, "filesystem", bytes.byteLength);
+      await context.assertActive();
+      return { data: bytes.toString(value.encoding) };
+    } finally {
+      await handle.close();
+    }
+  }
+
+  async writeFile(params, context) {
+    const value = assertWriteParams(params);
+    const canonical = await resolveWritePath(value.path);
+    assertAuthorizedPath(context, "filesystem.write", canonical);
+    this.quotaManager?.chargeBytes(context.runtimeId, "filesystem", value.bytes.byteLength);
+    await context.assertActive();
+    const flags = fs.constants.O_WRONLY
+      | fs.constants.O_CREAT
+      | NOFOLLOW
+      | (value.overwrite ? 0 : fs.constants.O_EXCL);
+    const handle = await fsp.open(canonical, flags, 0o600);
+    try {
+      assertAuthorizedPath(context, "filesystem.write", await fsp.realpath(canonical));
+      const [openedStats, pathStats] = await Promise.all([handle.stat(), fsp.stat(canonical)]);
+      assertSameOpenedFile(openedStats, pathStats);
+      if (value.overwrite) await handle.truncate(0);
+      await handle.writeFile(value.bytes);
+      await handle.sync();
+      await context.assertActive();
+    } finally {
+      await handle.close();
+    }
+    return null;
+  }
+
+  async stat(params, context) {
+    const value = assertPathParams(params);
+    const { canonical, stats } = await resolveExistingPath(value.path);
+    assertAuthorizedPath(context, "filesystem.read", canonical);
+    await context.assertActive();
+    return {
+      kind: stats.isFile() ? "file" : stats.isDirectory() ? "directory" : "other",
+      size: Math.min(Number.MAX_SAFE_INTEGER, Number(stats.size)),
+      modifiedAt: Math.max(0, Math.trunc(stats.mtimeMs)),
+    };
+  }
+
+  async readDirectory(params, context) {
+    const value = assertPathParams(params);
+    const { canonical, stats } = await resolveExistingPath(value.path);
+    assertAuthorizedPath(context, "filesystem.read", canonical);
+    if (!stats.isDirectory()) throw invalidArgument("Plugin filesystem directory target is not a directory");
+    const entries = await fsp.readdir(canonical, { withFileTypes: true });
+    if (entries.length > MAX_DIRECTORY_ENTRIES) {
+      throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Plugin filesystem directory has too many entries");
+    }
+    await context.assertActive();
+    return {
+      entries: entries
+        .map((entry) => ({ name: entry.name, kind: entryKind(entry) }))
+        .sort((left, right) => left.name.localeCompare(right.name, "en")),
+    };
+  }
+}
+
+module.exports = {
+  MAX_DIRECTORY_ENTRIES,
+  MAX_FILESYSTEM_BYTES,
+  PluginFilesystemBroker,
+  assertAbsolutePath,
+  assertAuthorizedPath,
+  assertSameOpenedFile,
+  assertPathParams,
+  assertReadParams,
+  assertWriteParams,
+  resolveExistingPath,
+  resolveWritePath,
+  readBoundedFileHandle,
+};

--- a/electron/plugins/filesystemBroker.cjs
+++ b/electron/plugins/filesystemBroker.cjs
@@ -24,7 +24,10 @@ function assertAbsolutePath(value) {
   ) {
     throw invalidArgument("Plugin filesystem path must be absolute");
   }
-  return path.normalize(value);
+  // Resolve absolute paths lexically so permission resources have one stable
+  // spelling. In particular, realpath() drops trailing separators, and the
+  // post-permission equality checks must compare against the same spelling.
+  return path.resolve(value);
 }
 
 function assertReadParams(params) {

--- a/electron/plugins/filesystemBroker.cjs
+++ b/electron/plugins/filesystemBroker.cjs
@@ -4,9 +4,10 @@ const fs = require("node:fs");
 const fsp = require("node:fs/promises");
 const path = require("node:path");
 
+const { PLUGIN_RPC_MAX_RAW_BYTES } = require("./constants.cjs");
 const { PluginRpcError, RPC_ERRORS } = require("./rpcRouter.cjs");
 
-const MAX_FILESYSTEM_BYTES = 1024 * 1024;
+const MAX_FILESYSTEM_BYTES = PLUGIN_RPC_MAX_RAW_BYTES;
 const MAX_DIRECTORY_ENTRIES = 1_000;
 const NOFOLLOW = fs.constants.O_NOFOLLOW ?? 0;
 
@@ -187,6 +188,10 @@ class PluginFilesystemBroker {
   constructor(options = {}) {
     this.quotaManager = options.quotaManager ?? null;
     this.fileSystem = options.fileSystem ?? fsp;
+    this.openDirectoryHandle = options.openDirectoryHandle ?? null;
+    if (this.openDirectoryHandle != null && typeof this.openDirectoryHandle !== "function") {
+      throw new TypeError("Secure plugin directory handle adapter must be a function");
+    }
   }
 
   validateRead(params) { return assertReadParams(params); }
@@ -302,9 +307,21 @@ class PluginFilesystemBroker {
     const { canonical, stats } = await resolveExistingPath(value.path, this.fileSystem);
     assertAuthorizedPath(context, "filesystem.read", canonical);
     if (!stats.isDirectory()) throw invalidArgument("Plugin filesystem directory target is not a directory");
-    const directory = await this.fileSystem.opendir(canonical);
+    if (!this.openDirectoryHandle) {
+      throw new PluginRpcError(
+        RPC_ERRORS.unsupported,
+        "Secure plugin directory enumeration is unavailable on this runtime",
+      );
+    }
+    const directory = await this.openDirectoryHandle(canonical, { signal: context.signal });
+    if (
+      !directory
+      || typeof directory.stat !== "function"
+      || typeof directory.read !== "function"
+      || typeof directory.close !== "function"
+    ) throw new TypeError("Secure plugin directory handle adapter returned an invalid handle");
     try {
-      assertSameOpenedDirectory(stats, await this.fileSystem.stat(canonical));
+      assertSameOpenedDirectory(stats, await directory.stat());
       const entries = [];
       for (;;) {
         const entry = await directory.read();
@@ -317,6 +334,7 @@ class PluginFilesystemBroker {
           );
         }
       }
+      assertSameOpenedDirectory(stats, await directory.stat());
       assertSameOpenedDirectory(stats, await this.fileSystem.stat(canonical));
       await context.assertActive();
       return {
@@ -325,8 +343,7 @@ class PluginFilesystemBroker {
           .sort((left, right) => left.name.localeCompare(right.name, "en")),
       };
     } finally {
-      try { await directory.close(); }
-      catch (error) { if (error?.code !== "ERR_DIR_CLOSED") throw error; }
+      await directory.close();
     }
   }
 }

--- a/electron/plugins/filesystemBroker.cjs
+++ b/electron/plugins/filesystemBroker.cjs
@@ -81,23 +81,23 @@ function assertPathParams(params) {
   return { path: assertAbsolutePath(params.path) };
 }
 
-async function resolveExistingPath(requestedPath) {
-  const canonical = await fsp.realpath(requestedPath);
-  const stats = await fsp.lstat(canonical);
+async function resolveExistingPath(requestedPath, fileSystem = fsp) {
+  const canonical = await fileSystem.realpath(requestedPath);
+  const stats = await fileSystem.lstat(canonical);
   if (stats.isSymbolicLink()) throw invalidArgument("Plugin filesystem path cannot resolve to a symbolic link");
   return { canonical, stats };
 }
 
-async function resolveWritePath(requestedPath) {
+async function resolveWritePath(requestedPath, fileSystem = fsp) {
   try {
-    const existing = await resolveExistingPath(requestedPath);
+    const existing = await resolveExistingPath(requestedPath, fileSystem);
     if (!existing.stats.isFile()) throw invalidArgument("Plugin filesystem write target is not a file");
     return existing.canonical;
   } catch (error) {
     if (error?.code !== "ENOENT") throw error;
   }
-  const parent = await fsp.realpath(path.dirname(requestedPath));
-  const parentStats = await fsp.lstat(parent);
+  const parent = await fileSystem.realpath(path.dirname(requestedPath));
+  const parentStats = await fileSystem.lstat(parent);
   if (!parentStats.isDirectory() || parentStats.isSymbolicLink()) {
     throw invalidArgument("Plugin filesystem write parent is not a real directory");
   }
@@ -156,9 +156,24 @@ function assertSameOpenedFile(openedStats, pathStats) {
   }
 }
 
+function assertSameOpenedDirectory(expectedStats, pathStats) {
+  if (
+    !expectedStats.isDirectory()
+    || !pathStats.isDirectory()
+    || expectedStats.dev !== pathStats.dev
+    || expectedStats.ino !== pathStats.ino
+  ) {
+    throw new PluginRpcError(
+      RPC_ERRORS.permissionDenied,
+      "Plugin filesystem directory changed after authorization",
+    );
+  }
+}
+
 class PluginFilesystemBroker {
   constructor(options = {}) {
     this.quotaManager = options.quotaManager ?? null;
+    this.fileSystem = options.fileSystem ?? fsp;
   }
 
   validateRead(params) { return assertReadParams(params); }
@@ -175,10 +190,11 @@ class PluginFilesystemBroker {
 
   async describeReadAuthorization(params) {
     const value = assertReadParams(params);
-    const { canonical } = await resolveExistingPath(value.path);
+    const { canonical, stats } = await resolveExistingPath(value.path, this.fileSystem);
     return {
       permission: "filesystem.read",
       resources: [canonical],
+      resourceKinds: [stats.isDirectory() ? "directory" : "exact"],
       reason: `Read ${canonical}`,
       operationId: `filesystem.read:${canonical}`,
     };
@@ -186,10 +202,11 @@ class PluginFilesystemBroker {
 
   async describeWriteAuthorization(params) {
     const value = assertWriteParams(params);
-    const canonical = await resolveWritePath(value.path);
+    const canonical = await resolveWritePath(value.path, this.fileSystem);
     return {
       permission: "filesystem.write",
       resources: [canonical],
+      resourceKinds: ["exact"],
       reason: `Write ${canonical}`,
       operationId: `filesystem.write:${canonical}`,
     };
@@ -197,19 +214,19 @@ class PluginFilesystemBroker {
 
   async readFile(params, context) {
     const value = assertReadParams(params);
-    const { canonical, stats } = await resolveExistingPath(value.path);
+    const { canonical, stats } = await resolveExistingPath(value.path, this.fileSystem);
     assertAuthorizedPath(context, "filesystem.read", canonical);
     if (!stats.isFile()) throw invalidArgument("Plugin filesystem read target is not a file");
     if (stats.size > value.maxBytes) {
       throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Plugin filesystem file is too large");
     }
-    const handle = await fsp.open(canonical, fs.constants.O_RDONLY | NOFOLLOW);
+    const handle = await this.fileSystem.open(canonical, fs.constants.O_RDONLY | NOFOLLOW);
     try {
       const openedStats = await handle.stat();
       if (!openedStats.isFile() || openedStats.size > value.maxBytes) {
         throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Plugin filesystem file changed or is too large");
       }
-      assertAuthorizedPath(context, "filesystem.read", await fsp.realpath(canonical));
+      assertAuthorizedPath(context, "filesystem.read", await this.fileSystem.realpath(canonical));
       const bytes = await readBoundedFileHandle(handle, value.maxBytes);
       this.quotaManager?.chargeBytes(context.runtimeId, "filesystem", bytes.byteLength);
       await context.assertActive();
@@ -221,7 +238,7 @@ class PluginFilesystemBroker {
 
   async writeFile(params, context) {
     const value = assertWriteParams(params);
-    const canonical = await resolveWritePath(value.path);
+    const canonical = await resolveWritePath(value.path, this.fileSystem);
     assertAuthorizedPath(context, "filesystem.write", canonical);
     this.quotaManager?.chargeBytes(context.runtimeId, "filesystem", value.bytes.byteLength);
     await context.assertActive();
@@ -229,11 +246,15 @@ class PluginFilesystemBroker {
       | fs.constants.O_CREAT
       | NOFOLLOW
       | (value.overwrite ? 0 : fs.constants.O_EXCL);
-    const handle = await fsp.open(canonical, flags, 0o600);
+    const handle = await this.fileSystem.open(canonical, flags, 0o600);
     try {
-      assertAuthorizedPath(context, "filesystem.write", await fsp.realpath(canonical));
-      const [openedStats, pathStats] = await Promise.all([handle.stat(), fsp.stat(canonical)]);
+      assertAuthorizedPath(context, "filesystem.write", await this.fileSystem.realpath(canonical));
+      const [openedStats, pathStats] = await Promise.all([
+        handle.stat(),
+        this.fileSystem.stat(canonical),
+      ]);
       assertSameOpenedFile(openedStats, pathStats);
+      await context.assertActive();
       if (value.overwrite) await handle.truncate(0);
       await handle.writeFile(value.bytes);
       await handle.sync();
@@ -246,7 +267,7 @@ class PluginFilesystemBroker {
 
   async stat(params, context) {
     const value = assertPathParams(params);
-    const { canonical, stats } = await resolveExistingPath(value.path);
+    const { canonical, stats } = await resolveExistingPath(value.path, this.fileSystem);
     assertAuthorizedPath(context, "filesystem.read", canonical);
     await context.assertActive();
     return {
@@ -258,19 +279,35 @@ class PluginFilesystemBroker {
 
   async readDirectory(params, context) {
     const value = assertPathParams(params);
-    const { canonical, stats } = await resolveExistingPath(value.path);
+    const { canonical, stats } = await resolveExistingPath(value.path, this.fileSystem);
     assertAuthorizedPath(context, "filesystem.read", canonical);
     if (!stats.isDirectory()) throw invalidArgument("Plugin filesystem directory target is not a directory");
-    const entries = await fsp.readdir(canonical, { withFileTypes: true });
-    if (entries.length > MAX_DIRECTORY_ENTRIES) {
-      throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Plugin filesystem directory has too many entries");
+    const directory = await this.fileSystem.opendir(canonical);
+    try {
+      assertSameOpenedDirectory(stats, await this.fileSystem.stat(canonical));
+      const entries = [];
+      for (;;) {
+        const entry = await directory.read();
+        if (entry === null) break;
+        entries.push(entry);
+        if (entries.length > MAX_DIRECTORY_ENTRIES) {
+          throw new PluginRpcError(
+            RPC_ERRORS.resourceExhausted,
+            "Plugin filesystem directory has too many entries",
+          );
+        }
+      }
+      assertSameOpenedDirectory(stats, await this.fileSystem.stat(canonical));
+      await context.assertActive();
+      return {
+        entries: entries
+          .map((entry) => ({ name: entry.name, kind: entryKind(entry) }))
+          .sort((left, right) => left.name.localeCompare(right.name, "en")),
+      };
+    } finally {
+      try { await directory.close(); }
+      catch (error) { if (error?.code !== "ERR_DIR_CLOSED") throw error; }
     }
-    await context.assertActive();
-    return {
-      entries: entries
-        .map((entry) => ({ name: entry.name, kind: entryKind(entry) }))
-        .sort((left, right) => left.name.localeCompare(right.name, "en")),
-    };
   }
 }
 
@@ -281,6 +318,7 @@ module.exports = {
   assertAbsolutePath,
   assertAuthorizedPath,
   assertSameOpenedFile,
+  assertSameOpenedDirectory,
   assertPathParams,
   assertReadParams,
   assertWriteParams,

--- a/electron/plugins/filesystemBroker.test.cjs
+++ b/electron/plugins/filesystemBroker.test.cjs
@@ -13,7 +13,7 @@ const { RPC_ERRORS } = require("./rpcRouter.cjs");
 function createRoot(context) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-filesystem-"));
   context.after(() => fs.rmSync(root, { recursive: true, force: true }));
-  return root;
+  return fs.realpathSync(root);
 }
 
 function runtimeContext(authorization) {
@@ -68,7 +68,7 @@ test("filesystem broker uses canonical authorization for bounded read, write, st
   );
   assert.equal(await fsp.readFile(target, "utf8"), "short");
 
-  const listAuthorization = await broker.describeReadAuthorization({ path: root });
+  const listAuthorization = await broker.describeReadAuthorization({ path: root }, "directory");
   assert.deepEqual(listAuthorization.resourceKinds, ["directory"]);
   const list = await broker.readDirectory({ path: root }, runtimeContext(listAuthorization));
   assert.deepEqual(list.entries.map(({ name }) => name), ["source.txt", "target.txt"]);
@@ -102,6 +102,47 @@ test("filesystem write quota is enforced before mutating the target", async (con
   assert.equal(await fsp.readFile(target, "utf8"), "original");
 });
 
+test("filesystem authorization descriptors never probe path existence before permission", async (context) => {
+  const root = createRoot(context);
+  const missing = path.join(root, "missing.txt");
+  let filesystemCalls = 0;
+  const broker = new PluginFilesystemBroker({
+    fileSystem: new Proxy({}, {
+      get() {
+        return async () => {
+          filesystemCalls += 1;
+          throw new Error("filesystem must not be queried while describing authorization");
+        };
+      },
+    }),
+  });
+  assert.deepEqual(broker.describeReadAuthorization({ path: missing }), {
+    permission: "filesystem.read",
+    resources: [missing],
+    resourceKinds: ["exact"],
+    reason: `Read ${missing}`,
+    operationId: `filesystem.read:${missing}`,
+  });
+  assert.deepEqual(broker.describeReadAuthorization({ path: root }, "directory").resourceKinds, ["directory"]);
+  assert.deepEqual(broker.describeWriteAuthorization({
+    path: missing,
+    data: "blocked",
+    overwrite: true,
+  }).resources, [missing]);
+  await assert.rejects(
+    broker.readFile({ path: missing }, runtimeContext(null)),
+    (error) => error.code === RPC_ERRORS.permissionDenied,
+  );
+  await assert.rejects(
+    broker.writeFile(
+      { path: missing, data: "blocked", overwrite: true },
+      runtimeContext(null),
+    ),
+    (error) => error.code === RPC_ERRORS.permissionDenied,
+  );
+  assert.equal(filesystemCalls, 0);
+});
+
 test("filesystem writes reject missing targets without opening or creating them", async (context) => {
   const root = createRoot(context);
   const target = path.join(root, "missing.txt");
@@ -115,15 +156,16 @@ test("filesystem writes reject missing targets without opening or creating them"
       },
     },
   });
+  const authorization = broker.describeWriteAuthorization({
+    path: target,
+    data: "blocked",
+    overwrite: true,
+  });
   await assert.rejects(
-    broker.describeWriteAuthorization({ path: target, data: "blocked", overwrite: true }),
-    (error) => error.code === RPC_ERRORS.failedPrecondition,
-  );
-  await assert.rejects(
-    broker.writeFile({ path: target, data: "blocked", overwrite: true }, runtimeContext({
-      permission: "filesystem.write",
-      resources: [target],
-    })),
+    broker.writeFile(
+      { path: target, data: "blocked", overwrite: true },
+      runtimeContext(authorization),
+    ),
     (error) => error.code === RPC_ERRORS.failedPrecondition,
   );
   assert.equal(openCalls, 0);
@@ -174,7 +216,7 @@ test("filesystem directory replacement between authorization and open fails clos
       },
     },
   });
-  const authorization = await broker.describeReadAuthorization({ path: selected });
+  const authorization = await broker.describeReadAuthorization({ path: selected }, "directory");
   await assert.rejects(
     broker.readDirectory({ path: selected }, runtimeContext(authorization)),
     (error) => error.code === RPC_ERRORS.permissionDenied,
@@ -212,6 +254,36 @@ test("filesystem writes recheck runtime activity immediately before mutation", a
     assertActive: async () => { if (!active) throw new Error("runtime stopped"); },
   }), /runtime stopped/);
   assert.equal(await fsp.readFile(target, "utf8"), "original");
+});
+
+test("filesystem reads reject a replacement inode opened after authorization", async (context) => {
+  const root = createRoot(context);
+  const target = path.join(root, "selected.txt");
+  const original = path.join(root, "original.txt");
+  const replacement = path.join(root, "replacement.txt");
+  await Promise.all([
+    fsp.writeFile(target, "allowed"),
+    fsp.writeFile(replacement, "secret"),
+  ]);
+  let swapped = false;
+  const broker = new PluginFilesystemBroker({
+    fileSystem: {
+      ...fsp,
+      async open(filePath, flags, mode) {
+        if (!swapped) {
+          swapped = true;
+          await fsp.rename(target, original);
+          await fsp.rename(replacement, target);
+        }
+        return fsp.open(filePath, flags, mode);
+      },
+    },
+  });
+  const authorization = broker.describeReadAuthorization({ path: target });
+  await assert.rejects(
+    broker.readFile({ path: target }, runtimeContext(authorization)),
+    (error) => error.code === RPC_ERRORS.permissionDenied,
+  );
 });
 
 test("filesystem broker rejects oversized and non-canonical payloads", async (context) => {

--- a/electron/plugins/filesystemBroker.test.cjs
+++ b/electron/plugins/filesystemBroker.test.cjs
@@ -24,6 +24,19 @@ function runtimeContext(authorization) {
   };
 }
 
+async function openTestDirectoryHandle(directoryPath) {
+  const stats = await fsp.stat(directoryPath);
+  const directory = await fsp.opendir(directoryPath);
+  return {
+    stat: async () => stats,
+    read: () => directory.read(),
+    close: async () => {
+      try { await directory.close(); }
+      catch (error) { if (error?.code !== "ERR_DIR_CLOSED") throw error; }
+    },
+  };
+}
+
 test("filesystem broker uses canonical authorization for bounded read, write, stat, and list", async (context) => {
   const root = createRoot(context);
   const source = path.join(root, "source.txt");
@@ -35,6 +48,7 @@ test("filesystem broker uses canonical authorization for bounded read, write, st
   const charges = [];
   const broker = new PluginFilesystemBroker({
     quotaManager: { chargeBytes: (...args) => charges.push(args) },
+    openDirectoryHandle: openTestDirectoryHandle,
   });
 
   const readAuthorization = await broker.describeReadAuthorization({ path: source });
@@ -83,7 +97,7 @@ test("filesystem authorization removes trailing directory separators before perm
   const root = createRoot(context);
   const requestedPath = `${root}${path.sep}`;
   await fsp.writeFile(path.join(root, "entry.txt"), "entry");
-  const broker = new PluginFilesystemBroker();
+  const broker = new PluginFilesystemBroker({ openDirectoryHandle: openTestDirectoryHandle });
   const statAuthorization = broker.describeReadAuthorization({ path: requestedPath }, "exact");
   const listAuthorization = broker.describeReadAuthorization({ path: requestedPath }, "directory");
 
@@ -224,22 +238,30 @@ test("filesystem directory replacement between authorization and open fails clos
   ]);
   let swapped = false;
   const broker = new PluginFilesystemBroker({
-    fileSystem: {
-      ...fsp,
-      async opendir(directoryPath, options) {
-        if (!swapped) {
-          swapped = true;
-          await fsp.rename(selected, original);
-          await fsp.rename(replacement, selected);
-        }
-        return fsp.opendir(directoryPath, options);
-      },
+    openDirectoryHandle: async (directoryPath) => {
+      if (!swapped) {
+        swapped = true;
+        await fsp.rename(selected, original);
+        await fsp.rename(replacement, selected);
+      }
+      return openTestDirectoryHandle(directoryPath);
     },
   });
   const authorization = await broker.describeReadAuthorization({ path: selected }, "directory");
   await assert.rejects(
     broker.readDirectory({ path: selected }, runtimeContext(authorization)),
     (error) => error.code === RPC_ERRORS.permissionDenied,
+  );
+});
+
+test("filesystem directory listing fails closed without a handle-bound adapter", async (context) => {
+  const root = createRoot(context);
+  await fsp.writeFile(path.join(root, "entry.txt"), "entry");
+  const broker = new PluginFilesystemBroker();
+  const authorization = broker.describeReadAuthorization({ path: root }, "directory");
+  await assert.rejects(
+    broker.readDirectory({ path: root }, runtimeContext(authorization)),
+    (error) => error.code === RPC_ERRORS.unsupported,
   );
 });
 

--- a/electron/plugins/filesystemBroker.test.cjs
+++ b/electron/plugins/filesystemBroker.test.cjs
@@ -28,7 +28,10 @@ test("filesystem broker uses canonical authorization for bounded read, write, st
   const root = createRoot(context);
   const source = path.join(root, "source.txt");
   const target = path.join(root, "target.txt");
-  await fsp.writeFile(source, "hello");
+  await Promise.all([
+    fsp.writeFile(source, "hello"),
+    fsp.writeFile(target, "prior"),
+  ]);
   const charges = [];
   const broker = new PluginFilesystemBroker({
     quotaManager: { chargeBytes: (...args) => charges.push(args) },
@@ -42,9 +45,17 @@ test("filesystem broker uses canonical authorization for bounded read, write, st
   );
   assert.equal((await broker.stat({ path: source }, runtimeContext(readAuthorization))).kind, "file");
 
-  const writeAuthorization = await broker.describeWriteAuthorization({ path: target, data: "world" });
+  const writeAuthorization = await broker.describeWriteAuthorization({
+    path: target,
+    data: "world",
+    overwrite: true,
+  });
   assert.deepEqual(writeAuthorization.resourceKinds, ["exact"]);
-  await broker.writeFile({ path: target, data: "world" }, runtimeContext(writeAuthorization));
+  await broker.writeFile({
+    path: target,
+    data: "world",
+    overwrite: true,
+  }, runtimeContext(writeAuthorization));
   assert.equal(await fsp.readFile(target, "utf8"), "world");
   const overwriteAuthorization = await broker.describeWriteAuthorization({
     path: target,
@@ -68,17 +79,54 @@ test("filesystem broker uses canonical authorization for bounded read, write, st
   ]);
 });
 
-test("filesystem write quota is enforced before creating the target", async (context) => {
+test("filesystem write quota is enforced before mutating the target", async (context) => {
   const root = createRoot(context);
   const target = path.join(root, "target.txt");
+  await fsp.writeFile(target, "original");
   const broker = new PluginFilesystemBroker({
     quotaManager: { chargeBytes: () => { throw new Error("quota denied"); } },
   });
-  const authorization = await broker.describeWriteAuthorization({ path: target, data: "blocked" });
+  const authorization = await broker.describeWriteAuthorization({
+    path: target,
+    data: "blocked",
+    overwrite: true,
+  });
   await assert.rejects(
-    broker.writeFile({ path: target, data: "blocked" }, runtimeContext(authorization)),
+    broker.writeFile({
+      path: target,
+      data: "blocked",
+      overwrite: true,
+    }, runtimeContext(authorization)),
     /quota denied/,
   );
+  assert.equal(await fsp.readFile(target, "utf8"), "original");
+});
+
+test("filesystem writes reject missing targets without opening or creating them", async (context) => {
+  const root = createRoot(context);
+  const target = path.join(root, "missing.txt");
+  let openCalls = 0;
+  const broker = new PluginFilesystemBroker({
+    fileSystem: {
+      ...fsp,
+      async open(...args) {
+        openCalls += 1;
+        return fsp.open(...args);
+      },
+    },
+  });
+  await assert.rejects(
+    broker.describeWriteAuthorization({ path: target, data: "blocked", overwrite: true }),
+    (error) => error.code === RPC_ERRORS.failedPrecondition,
+  );
+  await assert.rejects(
+    broker.writeFile({ path: target, data: "blocked", overwrite: true }, runtimeContext({
+      permission: "filesystem.write",
+      resources: [target],
+    })),
+    (error) => error.code === RPC_ERRORS.failedPrecondition,
+  );
+  assert.equal(openCalls, 0);
   await assert.rejects(fsp.stat(target), (error) => error.code === "ENOENT");
 });
 

--- a/electron/plugins/filesystemBroker.test.cjs
+++ b/electron/plugins/filesystemBroker.test.cjs
@@ -1,0 +1,120 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { PluginFilesystemBroker, MAX_FILESYSTEM_BYTES } = require("./filesystemBroker.cjs");
+const { RPC_ERRORS } = require("./rpcRouter.cjs");
+
+function createRoot(context) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-filesystem-"));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+function runtimeContext(authorization) {
+  return {
+    runtimeId: "runtime-1",
+    authorization,
+    assertActive: async () => {},
+  };
+}
+
+test("filesystem broker uses canonical authorization for bounded read, write, stat, and list", async (context) => {
+  const root = createRoot(context);
+  const source = path.join(root, "source.txt");
+  const target = path.join(root, "target.txt");
+  await fsp.writeFile(source, "hello");
+  const charges = [];
+  const broker = new PluginFilesystemBroker({
+    quotaManager: { chargeBytes: (...args) => charges.push(args) },
+  });
+
+  const readAuthorization = await broker.describeReadAuthorization({ path: source });
+  assert.deepEqual(
+    await broker.readFile({ path: source }, runtimeContext(readAuthorization)),
+    { data: "hello" },
+  );
+  assert.equal((await broker.stat({ path: source }, runtimeContext(readAuthorization))).kind, "file");
+
+  const writeAuthorization = await broker.describeWriteAuthorization({ path: target, data: "world" });
+  await broker.writeFile({ path: target, data: "world" }, runtimeContext(writeAuthorization));
+  assert.equal(await fsp.readFile(target, "utf8"), "world");
+  const overwriteAuthorization = await broker.describeWriteAuthorization({
+    path: target,
+    data: "short",
+    overwrite: true,
+  });
+  await broker.writeFile(
+    { path: target, data: "short", overwrite: true },
+    runtimeContext(overwriteAuthorization),
+  );
+  assert.equal(await fsp.readFile(target, "utf8"), "short");
+
+  const listAuthorization = await broker.describeReadAuthorization({ path: root });
+  const list = await broker.readDirectory({ path: root }, runtimeContext(listAuthorization));
+  assert.deepEqual(list.entries.map(({ name }) => name), ["source.txt", "target.txt"]);
+  assert.deepEqual(charges, [
+    ["runtime-1", "filesystem", 5],
+    ["runtime-1", "filesystem", 5],
+    ["runtime-1", "filesystem", 5],
+  ]);
+});
+
+test("filesystem write quota is enforced before creating the target", async (context) => {
+  const root = createRoot(context);
+  const target = path.join(root, "target.txt");
+  const broker = new PluginFilesystemBroker({
+    quotaManager: { chargeBytes: () => { throw new Error("quota denied"); } },
+  });
+  const authorization = await broker.describeWriteAuthorization({ path: target, data: "blocked" });
+  await assert.rejects(
+    broker.writeFile({ path: target, data: "blocked" }, runtimeContext(authorization)),
+    /quota denied/,
+  );
+  await assert.rejects(fsp.stat(target), (error) => error.code === "ENOENT");
+});
+
+test("filesystem path swaps after authorization fail closed", async (context) => {
+  const root = createRoot(context);
+  const first = path.join(root, "first.txt");
+  const second = path.join(root, "second.txt");
+  const link = path.join(root, "selected.txt");
+  await Promise.all([fsp.writeFile(first, "first"), fsp.writeFile(second, "second")]);
+  await fsp.symlink(first, link);
+  const broker = new PluginFilesystemBroker();
+  const authorization = await broker.describeReadAuthorization({ path: link });
+  await fsp.unlink(link);
+  await fsp.symlink(second, link);
+  await assert.rejects(
+    broker.readFile({ path: link }, runtimeContext(authorization)),
+    (error) => error.code === RPC_ERRORS.permissionDenied,
+  );
+});
+
+test("filesystem broker rejects oversized and non-canonical payloads", async (context) => {
+  const root = createRoot(context);
+  const target = path.join(root, "target.bin");
+  const broker = new PluginFilesystemBroker();
+  assert.throws(() => broker.validateWrite({
+    path: target,
+    data: "YQ",
+    encoding: "base64",
+  }), /not canonical/);
+  assert.throws(() => broker.validateWrite({
+    path: target,
+    data: "a".repeat(MAX_FILESYSTEM_BYTES + 1),
+  }), (error) => error.code === RPC_ERRORS.resourceExhausted);
+  assert.throws(() => broker.validateRead({ path: `${target}\0suffix` }), /absolute/);
+
+  await fsp.writeFile(target, "12345");
+  const authorization = await broker.describeReadAuthorization({ path: target, maxBytes: 4 });
+  await assert.rejects(
+    broker.readFile({ path: target, maxBytes: 4 }, runtimeContext(authorization)),
+    (error) => error.code === RPC_ERRORS.resourceExhausted,
+  );
+});

--- a/electron/plugins/filesystemBroker.test.cjs
+++ b/electron/plugins/filesystemBroker.test.cjs
@@ -328,6 +328,46 @@ test("filesystem reads reject a replacement inode opened after authorization", a
   );
 });
 
+test("filesystem writes reject a replacement inode opened after authorization", async (context) => {
+  const root = createRoot(context);
+  const target = path.join(root, "selected.txt");
+  const original = path.join(root, "original.txt");
+  const replacement = path.join(root, "replacement.txt");
+  await Promise.all([
+    fsp.writeFile(target, "allowed"),
+    fsp.writeFile(replacement, "secret"),
+  ]);
+  let swapped = false;
+  const broker = new PluginFilesystemBroker({
+    fileSystem: {
+      ...fsp,
+      async open(filePath, flags, mode) {
+        if (!swapped) {
+          swapped = true;
+          await fsp.rename(target, original);
+          await fsp.rename(replacement, target);
+        }
+        return fsp.open(filePath, flags, mode);
+      },
+    },
+  });
+  const authorization = broker.describeWriteAuthorization({
+    path: target,
+    data: "overwritten",
+    overwrite: true,
+  });
+  await assert.rejects(
+    broker.writeFile({
+      path: target,
+      data: "overwritten",
+      overwrite: true,
+    }, runtimeContext(authorization)),
+    (error) => error.code === RPC_ERRORS.permissionDenied,
+  );
+  assert.equal(await fsp.readFile(original, "utf8"), "allowed");
+  assert.equal(await fsp.readFile(target, "utf8"), "secret");
+});
+
 test("filesystem broker rejects oversized and non-canonical payloads", async (context) => {
   const root = createRoot(context);
   const target = path.join(root, "target.bin");

--- a/electron/plugins/filesystemBroker.test.cjs
+++ b/electron/plugins/filesystemBroker.test.cjs
@@ -79,6 +79,26 @@ test("filesystem broker uses canonical authorization for bounded read, write, st
   ]);
 });
 
+test("filesystem authorization removes trailing directory separators before permission", async (context) => {
+  const root = createRoot(context);
+  const requestedPath = `${root}${path.sep}`;
+  await fsp.writeFile(path.join(root, "entry.txt"), "entry");
+  const broker = new PluginFilesystemBroker();
+  const statAuthorization = broker.describeReadAuthorization({ path: requestedPath }, "exact");
+  const listAuthorization = broker.describeReadAuthorization({ path: requestedPath }, "directory");
+
+  assert.deepEqual(statAuthorization.resources, [root]);
+  assert.deepEqual(listAuthorization.resources, [root]);
+  assert.equal(
+    (await broker.stat({ path: requestedPath }, runtimeContext(statAuthorization))).kind,
+    "directory",
+  );
+  assert.deepEqual(
+    (await broker.readDirectory({ path: requestedPath }, runtimeContext(listAuthorization))).entries,
+    [{ name: "entry.txt", kind: "file" }],
+  );
+});
+
 test("filesystem write quota is enforced before mutating the target", async (context) => {
   const root = createRoot(context);
   const target = path.join(root, "target.txt");

--- a/electron/plugins/filesystemBroker.test.cjs
+++ b/electron/plugins/filesystemBroker.test.cjs
@@ -35,6 +35,7 @@ test("filesystem broker uses canonical authorization for bounded read, write, st
   });
 
   const readAuthorization = await broker.describeReadAuthorization({ path: source });
+  assert.deepEqual(readAuthorization.resourceKinds, ["exact"]);
   assert.deepEqual(
     await broker.readFile({ path: source }, runtimeContext(readAuthorization)),
     { data: "hello" },
@@ -42,6 +43,7 @@ test("filesystem broker uses canonical authorization for bounded read, write, st
   assert.equal((await broker.stat({ path: source }, runtimeContext(readAuthorization))).kind, "file");
 
   const writeAuthorization = await broker.describeWriteAuthorization({ path: target, data: "world" });
+  assert.deepEqual(writeAuthorization.resourceKinds, ["exact"]);
   await broker.writeFile({ path: target, data: "world" }, runtimeContext(writeAuthorization));
   assert.equal(await fsp.readFile(target, "utf8"), "world");
   const overwriteAuthorization = await broker.describeWriteAuthorization({
@@ -56,6 +58,7 @@ test("filesystem broker uses canonical authorization for bounded read, write, st
   assert.equal(await fsp.readFile(target, "utf8"), "short");
 
   const listAuthorization = await broker.describeReadAuthorization({ path: root });
+  assert.deepEqual(listAuthorization.resourceKinds, ["directory"]);
   const list = await broker.readDirectory({ path: root }, runtimeContext(listAuthorization));
   assert.deepEqual(list.entries.map(({ name }) => name), ["source.txt", "target.txt"]);
   assert.deepEqual(charges, [
@@ -94,6 +97,73 @@ test("filesystem path swaps after authorization fail closed", async (context) =>
     broker.readFile({ path: link }, runtimeContext(authorization)),
     (error) => error.code === RPC_ERRORS.permissionDenied,
   );
+});
+
+test("filesystem directory replacement between authorization and open fails closed", async (context) => {
+  const root = createRoot(context);
+  const selected = path.join(root, "selected");
+  const replacement = path.join(root, "replacement");
+  const original = path.join(root, "original");
+  await Promise.all([
+    fsp.mkdir(selected),
+    fsp.mkdir(replacement),
+  ]);
+  await Promise.all([
+    fsp.writeFile(path.join(selected, "allowed.txt"), "allowed"),
+    fsp.writeFile(path.join(replacement, "secret.txt"), "secret"),
+  ]);
+  let swapped = false;
+  const broker = new PluginFilesystemBroker({
+    fileSystem: {
+      ...fsp,
+      async opendir(directoryPath, options) {
+        if (!swapped) {
+          swapped = true;
+          await fsp.rename(selected, original);
+          await fsp.rename(replacement, selected);
+        }
+        return fsp.opendir(directoryPath, options);
+      },
+    },
+  });
+  const authorization = await broker.describeReadAuthorization({ path: selected });
+  await assert.rejects(
+    broker.readDirectory({ path: selected }, runtimeContext(authorization)),
+    (error) => error.code === RPC_ERRORS.permissionDenied,
+  );
+});
+
+test("filesystem writes recheck runtime activity immediately before mutation", async (context) => {
+  const root = createRoot(context);
+  const target = path.join(root, "target.txt");
+  await fsp.writeFile(target, "original");
+  let active = true;
+  let armed = false;
+  const broker = new PluginFilesystemBroker({
+    fileSystem: {
+      ...fsp,
+      async stat(filePath, options) {
+        const stats = await fsp.stat(filePath, options);
+        if (armed) active = false;
+        return stats;
+      },
+    },
+  });
+  const authorization = await broker.describeWriteAuthorization({
+    path: target,
+    data: "replacement",
+    overwrite: true,
+  });
+  armed = true;
+  await assert.rejects(broker.writeFile({
+    path: target,
+    data: "replacement",
+    overwrite: true,
+  }, {
+    ...runtimeContext(authorization),
+    assertActive: async () => { if (!active) throw new Error("runtime stopped"); },
+  }), /runtime stopped/);
+  assert.equal(await fsp.readFile(target, "utf8"), "original");
 });
 
 test("filesystem broker rejects oversized and non-canonical payloads", async (context) => {

--- a/electron/plugins/fixtures/browser-runtime-plugin/netcatty.plugin.json
+++ b/electron/plugins/fixtures/browser-runtime-plugin/netcatty.plugin.json
@@ -10,5 +10,8 @@
   },
   "main": {
     "browser": "index.js"
+  },
+  "permissions": {
+    "required": ["storage"]
   }
 }

--- a/electron/plugins/fixtures/utility-runtime-plugin/netcatty.plugin.json
+++ b/electron/plugins/fixtures/utility-runtime-plugin/netcatty.plugin.json
@@ -10,5 +10,8 @@
   },
   "main": {
     "node": "index.js"
+  },
+  "permissions": {
+    "required": ["runtime.advanced", "storage"]
   }
 }

--- a/electron/plugins/generated/plugin-contract.schema.json
+++ b/electron/plugins/generated/plugin-contract.schema.json
@@ -300,11 +300,30 @@
         "provider.importer"
       ]
     },
+    "ResourceScopedPermission": {
+      "description": "A permission whose approval must be constrained to explicit canonical resources.",
+      "type": "string",
+      "enum": [
+        "network",
+        "filesystem.read",
+        "filesystem.write",
+        "companion.execute"
+      ]
+    },
     "PermissionResource": {
       "description": "A host-canonicalized permission resource. Filesystem resources may be absolute platform paths; other permission kinds impose narrower runtime limits.",
       "type": "string",
       "minLength": 1,
       "maxLength": 8192
+    },
+    "BoundedPermissionResource": {
+      "description": "An explicit resource bound; the all-resources wildcard is not an activation-time bound.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 8192,
+      "not": {
+        "const": "*"
+      }
     },
     "PermissionResourceKind": {
       "description": "Whether a canonical resource grant covers only that resource or a filesystem directory subtree.",
@@ -350,6 +369,32 @@
         }
       ]
     },
+    "RequiredPermissionResourceDeclaration": {
+      "type": "object",
+      "required": [
+        "permission",
+        "resources"
+      ],
+      "properties": {
+        "permission": {
+          "$ref": "#/$defs/ResourceScopedPermission"
+        },
+        "resources": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 128,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/BoundedPermissionResource"
+          }
+        },
+        "reason": {
+          "type": "string",
+          "maxLength": 1024
+        }
+      },
+      "additionalProperties": false
+    },
     "RequiredPermissionDeclaration": {
       "description": "Required resource-scoped permissions must name their complete activation-time approval bounds.",
       "oneOf": [
@@ -357,7 +402,7 @@
           "$ref": "#/$defs/NonResourceScopedPermission"
         },
         {
-          "$ref": "#/$defs/PermissionResourceDeclaration"
+          "$ref": "#/$defs/RequiredPermissionResourceDeclaration"
         }
       ]
     },

--- a/electron/plugins/generated/plugin-contract.schema.json
+++ b/electron/plugins/generated/plugin-contract.schema.json
@@ -126,11 +126,12 @@
       "pattern": "^[a-z][a-z0-9-]*(?:\\.[a-z0-9][a-z0-9_-]*)+$"
     },
     "SecretRef": {
-      "description": "An opaque host-issued reference to secret material. The identifier is never sufficient authority on its own; privileged consumers must revalidate plugin ownership and operation scope.",
+      "description": "A host-issued reference to secret material. The random identifier is opaque and never sufficient authority on its own. The non-secret key binds permission authorization to the packaged manifest resource; privileged consumers must revalidate identifier ownership, key binding, and operation scope.",
       "type": "object",
       "required": [
         "kind",
-        "id"
+        "id",
+        "key"
       ],
       "properties": {
         "kind": {
@@ -140,6 +141,12 @@
           "type": "string",
           "minLength": 16,
           "maxLength": 256
+        },
+        "key": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "pattern": "^[^\\u0000]+$"
         }
       },
       "additionalProperties": false

--- a/electron/plugins/generated/plugin-contract.schema.json
+++ b/electron/plugins/generated/plugin-contract.schema.json
@@ -267,6 +267,39 @@
         "provider.importer"
       ]
     },
+    "NonResourceScopedPermission": {
+      "description": "A permission whose complete activation-time scope is represented by the permission name itself.",
+      "type": "string",
+      "enum": [
+        "storage",
+        "runtime.advanced",
+        "settings.read",
+        "settings.write",
+        "commands",
+        "menus",
+        "views",
+        "clipboard.read",
+        "clipboard.write",
+        "terminal.metadata",
+        "terminal.output",
+        "terminal.input",
+        "terminal.decorate",
+        "terminal.complete",
+        "terminal.intercept.input",
+        "terminal.intercept.output",
+        "vault.metadata",
+        "vault.write",
+        "vault.credentials",
+        "sftp.read",
+        "sftp.write",
+        "secrets",
+        "provider.terminal",
+        "provider.connection",
+        "provider.authentication",
+        "provider.sync",
+        "provider.importer"
+      ]
+    },
     "PermissionResource": {
       "description": "A host-canonicalized permission resource. Filesystem resources may be absolute platform paths; other permission kinds impose narrower runtime limits.",
       "type": "string",
@@ -281,36 +314,50 @@
         "directory"
       ]
     },
+    "PermissionResourceDeclaration": {
+      "type": "object",
+      "required": [
+        "permission",
+        "resources"
+      ],
+      "properties": {
+        "permission": {
+          "$ref": "#/$defs/PluginPermission"
+        },
+        "resources": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 128,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/PermissionResource"
+          }
+        },
+        "reason": {
+          "type": "string",
+          "maxLength": 1024
+        }
+      },
+      "additionalProperties": false
+    },
     "PermissionDeclaration": {
       "oneOf": [
         {
           "$ref": "#/$defs/PluginPermission"
         },
         {
-          "type": "object",
-          "required": [
-            "permission",
-            "resources"
-          ],
-          "properties": {
-            "permission": {
-              "$ref": "#/$defs/PluginPermission"
-            },
-            "resources": {
-              "type": "array",
-              "minItems": 1,
-              "maxItems": 128,
-              "uniqueItems": true,
-              "items": {
-                "$ref": "#/$defs/PermissionResource"
-              }
-            },
-            "reason": {
-              "type": "string",
-              "maxLength": 1024
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/$defs/PermissionResourceDeclaration"
+        }
+      ]
+    },
+    "RequiredPermissionDeclaration": {
+      "description": "Required resource-scoped permissions must name their complete activation-time approval bounds.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/NonResourceScopedPermission"
+        },
+        {
+          "$ref": "#/$defs/PermissionResourceDeclaration"
         }
       ]
     },
@@ -321,7 +368,7 @@
           "type": "array",
           "maxItems": 64,
           "items": {
-            "$ref": "#/$defs/PermissionDeclaration"
+            "$ref": "#/$defs/RequiredPermissionDeclaration"
           }
         },
         "optional": {

--- a/electron/plugins/generated/plugin-contract.schema.json
+++ b/electron/plugins/generated/plugin-contract.schema.json
@@ -144,6 +144,54 @@
       },
       "additionalProperties": false
     },
+    "CredentialRef": {
+      "description": "An opaque host-issued reference to a Netcatty-owned credential. The host validates ownership and provider-operation scope before issuing a plaintext lease.",
+      "type": "object",
+      "required": [
+        "kind",
+        "id"
+      ],
+      "properties": {
+        "kind": {
+          "const": "credential"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 16,
+          "maxLength": 256
+        }
+      },
+      "additionalProperties": false
+    },
+    "SecretLeaseRef": {
+      "description": "An opaque, operation-bound, single-consumption lease. Only a host capability broker can consume it after revalidating runtime identity and operation scope.",
+      "type": "object",
+      "required": [
+        "kind",
+        "id",
+        "operationId",
+        "expiresAt"
+      ],
+      "properties": {
+        "kind": {
+          "const": "secret-lease"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 32,
+          "maxLength": 256
+        },
+        "operationId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "expiresAt": {
+          "$ref": "#/$defs/SafePositiveInteger"
+        }
+      },
+      "additionalProperties": false
+    },
     "SemanticVersion": {
       "type": "string",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-(?:0|[1-9]\\d*|\\d*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
@@ -180,6 +228,7 @@
       "type": "string",
       "enum": [
         "storage",
+        "runtime.advanced",
         "settings.read",
         "settings.write",
         "commands",
@@ -211,6 +260,12 @@
         "provider.importer"
       ]
     },
+    "PermissionResource": {
+      "description": "A host-canonicalized permission resource. Filesystem resources may be absolute platform paths; other permission kinds impose narrower runtime limits.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 8192
+    },
     "PermissionDeclaration": {
       "oneOf": [
         {
@@ -232,9 +287,7 @@
               "maxItems": 128,
               "uniqueItems": true,
               "items": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 2048
+                "$ref": "#/$defs/PermissionResource"
               }
             },
             "reason": {
@@ -1737,6 +1790,38 @@
         "pluginId": {
           "$ref": "#/$defs/PluginId"
         },
+        "pluginVersion": {
+          "$ref": "#/$defs/SemanticVersion"
+        },
+        "pluginName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "publisher": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "runtimeId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "runtimeKind": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "browser",
+            "utility",
+            null
+          ]
+        },
         "permission": {
           "$ref": "#/$defs/PluginPermission"
         },
@@ -1745,9 +1830,7 @@
           "maxItems": 128,
           "uniqueItems": true,
           "items": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 2048
+            "$ref": "#/$defs/PermissionResource"
           }
         },
         "reason": {
@@ -1756,6 +1839,11 @@
           "maxLength": 1024
         },
         "operationId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "sessionId": {
           "type": "string",
           "minLength": 1,
           "maxLength": 128
@@ -1789,9 +1877,7 @@
               "maxItems": 128,
               "uniqueItems": true,
               "items": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 2048
+                "$ref": "#/$defs/PermissionResource"
               }
             }
           },

--- a/electron/plugins/generated/plugin-contract.schema.json
+++ b/electron/plugins/generated/plugin-contract.schema.json
@@ -266,6 +266,14 @@
       "minLength": 1,
       "maxLength": 8192
     },
+    "PermissionResourceKind": {
+      "description": "Whether a canonical resource grant covers only that resource or a filesystem directory subtree.",
+      "type": "string",
+      "enum": [
+        "exact",
+        "directory"
+      ]
+    },
     "PermissionDeclaration": {
       "oneOf": [
         {
@@ -1831,6 +1839,13 @@
           "uniqueItems": true,
           "items": {
             "$ref": "#/$defs/PermissionResource"
+          }
+        },
+        "resourceKinds": {
+          "type": "array",
+          "maxItems": 128,
+          "items": {
+            "$ref": "#/$defs/PermissionResourceKind"
           }
         },
         "reason": {

--- a/electron/plugins/hostRpcRegistry.cjs
+++ b/electron/plugins/hostRpcRegistry.cjs
@@ -78,6 +78,7 @@ function normalizeRuntimeIdentity(identity) {
     runtimeId: identity.runtimeId,
     runtimeKind: identity.runtimeKind,
     ...(identity.manifest === undefined ? {} : { manifest: identity.manifest }),
+    ...(identity.securityPrincipal === undefined ? {} : { securityPrincipal: identity.securityPrincipal }),
     ...(identity.packageRoot === undefined ? {} : { packageRoot: identity.packageRoot }),
     ...(identity.logger === undefined ? {} : { logger: identity.logger }),
   });
@@ -109,6 +110,9 @@ class PluginHostRpcRegistry {
     if (options.validateParams != null) {
       assertHandler(options.validateParams, `Plugin host ${kind} parameter validator`);
     }
+    if (typeof options.authorization === "function") {
+      assertHandler(options.authorization, `Plugin host ${kind} authorization resolver`);
+    }
     if (this.requests.has(normalizedMethod) || this.notifications.has(normalizedMethod)) {
       throw new Error(`Plugin host RPC method is already registered: ${normalizedMethod}`);
     }
@@ -116,6 +120,11 @@ class PluginHostRpcRegistry {
       handler,
       metadata: cloneAndFreezeMetadata(options.metadata ?? {}),
       validateParams: options.validateParams ?? null,
+      authorization: typeof options.authorization === "function"
+        ? options.authorization
+        : options.authorization == null
+          ? null
+          : cloneAndFreezeMetadata(options.authorization),
     });
     collection.set(normalizedMethod, registration);
     this.revision += 1;
@@ -173,7 +182,7 @@ class PluginHostRpcRegistry {
       if (validatedParams && typeof validatedParams.then === "function") {
         throw new TypeError("Plugin host RPC parameter validators must be synchronous");
       }
-      const context = Object.freeze({
+      const authorizationContext = Object.freeze({
         ...transportContext,
         ...identity,
         assertActive,
@@ -181,6 +190,17 @@ class PluginHostRpcRegistry {
         method,
         metadata: registration.metadata,
         params: validatedParams,
+      });
+      const resolvedAuthorization = typeof registration.authorization === "function"
+        ? await registration.authorization(validatedParams, authorizationContext)
+        : registration.authorization;
+      const authorization = resolvedAuthorization == null
+        ? null
+        : cloneAndFreezeMetadata(resolvedAuthorization);
+      await assertActive();
+      const context = Object.freeze({
+        ...authorizationContext,
+        authorization,
       });
       let index = -1;
       const dispatch = async (nextIndex) => {
@@ -248,27 +268,31 @@ function createDefaultPluginHostRpcRegistry(options) {
     const value = options.database.getValue(context.pluginId, key);
     return value === undefined ? { found: false } : { found: true, value };
   }, {
-    metadata: { capability: "storage", mutating: false },
+    metadata: { capability: "storage", mutating: false, permission: "storage" },
+    authorization: { permission: "storage", resources: ["*"], reason: "Access plugin storage" },
     validateParams: (params) => options.assertStorageParams(params),
   });
   registry.registerRequest("storage.set", async ({ key, value }, context) => {
     options.database.setValue(context.pluginId, key, value);
     return null;
   }, {
-    metadata: { capability: "storage", mutating: true },
+    metadata: { capability: "storage", mutating: true, permission: "storage" },
+    authorization: { permission: "storage", resources: ["*"], reason: "Modify plugin storage" },
     validateParams: (params) => options.assertStorageParams(params, { value: true }),
   });
   registry.registerRequest("storage.delete", async ({ key }, context) => {
     options.database.deleteValue(context.pluginId, key);
     return null;
   }, {
-    metadata: { capability: "storage", mutating: true },
+    metadata: { capability: "storage", mutating: true, permission: "storage" },
+    authorization: { permission: "storage", resources: ["*"], reason: "Modify plugin storage" },
     validateParams: (params) => options.assertStorageParams(params),
   });
   registry.registerRequest("storage.keys", async (params, context) => {
     return { keys: options.database.listKeys(context.pluginId) };
   }, {
-    metadata: { capability: "storage", mutating: false },
+    metadata: { capability: "storage", mutating: false, permission: "storage" },
+    authorization: { permission: "storage", resources: ["*"], reason: "List plugin storage keys" },
     validateParams: (params) => {
       if (params && (typeof params !== "object" || Array.isArray(params) || Object.keys(params).length > 0)) {
         throw new TypeError("storage.keys does not accept parameters");
@@ -279,7 +303,7 @@ function createDefaultPluginHostRpcRegistry(options) {
   registry.registerNotification("log.write", async (params, context) => {
     if (!params || typeof params !== "object" || Array.isArray(params)) return;
     await context.logger.write(params.level, params.message, params.fields);
-  }, { metadata: { capability: "logging", mutating: false } });
+  }, { metadata: { capability: "logging", mutating: false, public: true } });
   return registry;
 }
 

--- a/electron/plugins/hostService.cjs
+++ b/electron/plugins/hostService.cjs
@@ -4,6 +4,9 @@ const path = require("node:path");
 
 const { PLUGIN_API_VERSION } = require("./constants.cjs");
 const { PluginDatabase } = require("./database.cjs");
+const { PluginCompanionSupervisor } = require("./companionSupervisor.cjs");
+const { PluginCredentialBroker, assertLeaseParams } = require("./credentialBroker.cjs");
+const { PluginFilesystemBroker } = require("./filesystemBroker.cjs");
 const { createDefaultPluginHostRpcRegistry } = require("./hostRpcRegistry.cjs");
 const {
   createDefaultPluginModuleResources,
@@ -13,8 +16,23 @@ const {
 const { PackageStore } = require("./packageStore.cjs");
 const { createPluginPaths } = require("./paths.cjs");
 const { PluginManager } = require("./pluginManager.cjs");
+const { PluginNetworkBroker } = require("./networkBroker.cjs");
+const { PluginPermissionEngine } = require("./permissionEngine.cjs");
 const { PluginProtocol } = require("./pluginProtocol.cjs");
 const { RuntimeSupervisor, assertStorageParams } = require("./runtimeSupervisor.cjs");
+const { PluginQuotaManager } = require("./quotaManager.cjs");
+const { registerSecurePluginCapabilities } = require("./secureCapabilities.cjs");
+const { PluginSecretStore } = require("./secretStore.cjs");
+const { SecretLeaseStore } = require("./secretLease.cjs");
+
+function getElectronProcessMetrics(app, pid) {
+  const metric = app.getAppMetrics?.().find((candidate) => candidate.pid === pid);
+  if (!metric) return null;
+  return {
+    cpuPercent: Number(metric.cpu?.percentCPUUsage ?? 0),
+    memoryBytes: Number(metric.memory?.workingSetSize ?? 0) * 1024,
+  };
+}
 
 function createPluginHostService(options) {
   const paths = createPluginPaths(options.app.getPath("userData"));
@@ -36,15 +54,96 @@ function createPluginHostService(options) {
       runtimeDirectory,
       moduleResources,
     });
+    const permissionEngine = new PluginPermissionEngine({
+      database,
+      requestDecision: options.requestPermissionDecision,
+    });
+    const quotaManager = new PluginQuotaManager({
+      getProcessMetrics: options.getProcessMetrics
+        ?? ((pid) => getElectronProcessMetrics(options.app, pid)),
+      quotas: options.quotas,
+    });
+    const secretStore = new PluginSecretStore({
+      database,
+      safeStorage: options.safeStorage ?? options.electron.safeStorage,
+    });
+    const leaseStore = new SecretLeaseStore({ secretStore });
+    const credentialBroker = new PluginCredentialBroker({
+      secretStore,
+      leaseStore,
+      credentialResolver: options.credentialResolver,
+    });
+    const filesystemBroker = new PluginFilesystemBroker({ quotaManager });
+    const networkBroker = new PluginNetworkBroker({
+      fetch: options.fetch ?? (options.electron.net?.fetch
+        ? (...args) => options.electron.net.fetch(...args)
+        : undefined),
+      permissionEngine,
+      quotaManager,
+    });
+    let runtimeSupervisor;
+    const companionSupervisor = new PluginCompanionSupervisor({
+      paths,
+      quotaManager,
+      spawn: options.spawnCompanion,
+      onContainmentFailure: (identity, error) => (
+        runtimeSupervisor?.enforcePolicyViolation(identity, error)
+      ),
+    });
     const rpcRegistry = options.rpcRegistry ?? createDefaultPluginHostRpcRegistry({
       assertStorageParams,
       database,
+    });
+    registerSecurePluginCapabilities(rpcRegistry, {
+      assertLeaseParams,
+      companionSupervisor,
+      credentialBroker,
+      filesystemBroker,
+      networkBroker,
+      permissionEngine,
+      quotaManager,
+      secretStore,
     });
     const configuredRegistry = options.configureRpcRegistry?.(rpcRegistry);
     if (configuredRegistry && typeof configuredRegistry.then === "function") {
       throw new TypeError("Plugin host RPC registry configuration must be synchronous");
     }
-    const runtimeSupervisor = new RuntimeSupervisor({
+    const requestedRuntimeResolver = options.resolveRuntimeKind ?? (({ plugin }) => (
+      plugin.manifest.main.browser ? "browser" : "utility"
+    ));
+    const resolveRuntimeKind = async (context) => {
+      const kind = await requestedRuntimeResolver(context);
+      if (
+        (kind !== "browser" && kind !== "utility")
+        || !context.availableKinds.includes(kind)
+      ) throw new Error(`Plugin runtime selection is unavailable: ${String(kind)}`);
+      await permissionEngine.authorizeRequired(context.plugin, {
+        securityPrincipal: context.securityPrincipal,
+        signal: context.signal,
+        skipPermissions: ["runtime.advanced"],
+      });
+      if (kind === "utility") {
+        await permissionEngine.authorize({
+          pluginId: context.plugin.id,
+          pluginVersion: context.plugin.activeVersion,
+          runtimeId: null,
+          manifest: context.plugin.manifest,
+          securityPrincipal: context.securityPrincipal,
+          signal: context.signal,
+        }, {
+          permission: "runtime.advanced",
+          resources: ["*"],
+          reason: "Start an advanced runtime with full Node, filesystem, and network authority",
+          operationId: `runtime.advanced:${context.plugin.activeVersion}`,
+        });
+      }
+      return kind;
+    };
+    const runtimeMessageGuard = (identity, message) => {
+      quotaManager.guardMessage(identity, message);
+      return options.runtimeMessageGuard?.(identity, message);
+    };
+    runtimeSupervisor = new RuntimeSupervisor({
       electron: options.electron,
       database,
       packageStore,
@@ -56,20 +155,48 @@ function createPluginHostService(options) {
       runtimeDirectory,
       appRoot,
       rpcRegistry,
-      resolveRuntimeKind: options.resolveRuntimeKind,
-      runtimeMessageGuard: options.runtimeMessageGuard,
+      resolveRuntimeKind,
+      resolveSecurityPrincipal: options.resolveSecurityPrincipal,
+      runtimeMessageGuard,
+      runtimeResourceMonitor: quotaManager,
       utilityModuleMappings: options.utilityModuleMappings ?? createUtilityModuleMappings(moduleResources),
     });
-    const manager = new PluginManager({ database, packageStore, runtimeSupervisor });
-    return {
+    quotaManager.setViolationHandler((identity, error) => (
+      runtimeSupervisor.enforcePolicyViolation(identity, error)
+    ));
+    runtimeSupervisor.onDidChangeRuntime((event) => {
+      if (!event.runtimeId || event.status === "running" || event.status === "starting") return;
+      leaseStore.revokeRuntime(event.runtimeId);
+      void companionSupervisor.releaseRuntime(event.runtimeId);
+    });
+    const manager = new PluginManager({
       database,
+      packageStore,
+      runtimeSupervisor,
+      beforeClose: async () => {
+        await companionSupervisor.shutdown();
+        leaseStore.shutdown();
+        permissionEngine.shutdown();
+        quotaManager.shutdown();
+      },
+    });
+    return {
+      companionSupervisor,
+      credentialBroker,
+      database,
+      filesystemBroker,
+      leaseStore,
       manager,
       moduleResources,
       packageStore,
       paths,
       protocol,
+      networkBroker,
+      permissionEngine,
+      quotaManager,
       rpcRegistry,
       runtimeSupervisor,
+      secretStore,
     };
   } catch (error) {
     database.close();
@@ -77,4 +204,4 @@ function createPluginHostService(options) {
   }
 }
 
-module.exports = { createPluginHostService };
+module.exports = { createPluginHostService, getElectronProcessMetrics };

--- a/electron/plugins/hostService.cjs
+++ b/electron/plugins/hostService.cjs
@@ -19,7 +19,11 @@ const { PluginManager } = require("./pluginManager.cjs");
 const { PluginNetworkBroker } = require("./networkBroker.cjs");
 const { PluginPermissionEngine } = require("./permissionEngine.cjs");
 const { PluginProtocol } = require("./pluginProtocol.cjs");
-const { RuntimeSupervisor, assertStorageParams } = require("./runtimeSupervisor.cjs");
+const {
+  RuntimeSupervisor,
+  assertStorageParams,
+  resolveDefaultRuntimeKind,
+} = require("./runtimeSupervisor.cjs");
 const { PluginQuotaManager } = require("./quotaManager.cjs");
 const { registerSecurePluginCapabilities } = require("./secureCapabilities.cjs");
 const { PluginSecretStore } = require("./secretStore.cjs");
@@ -111,9 +115,7 @@ function createPluginHostService(options) {
     if (configuredRegistry && typeof configuredRegistry.then === "function") {
       throw new TypeError("Plugin host RPC registry configuration must be synchronous");
     }
-    const requestedRuntimeResolver = options.resolveRuntimeKind ?? (({ plugin }) => (
-      plugin.manifest.main.browser ? "browser" : "utility"
-    ));
+    const requestedRuntimeResolver = options.resolveRuntimeKind ?? resolveDefaultRuntimeKind;
     const resolveRuntimeKind = async (context) => {
       const kind = await requestedRuntimeResolver(context);
       if (

--- a/electron/plugins/hostService.cjs
+++ b/electron/plugins/hostService.cjs
@@ -73,7 +73,10 @@ function createPluginHostService(options) {
       leaseStore,
       credentialResolver: options.credentialResolver,
     });
-    const filesystemBroker = new PluginFilesystemBroker({ quotaManager });
+    const filesystemBroker = new PluginFilesystemBroker({
+      quotaManager,
+      openDirectoryHandle: options.openPluginDirectoryHandle,
+    });
     const networkBroker = new PluginNetworkBroker({
       fetch: options.fetch ?? (options.electron.net?.fetch
         ? (...args) => options.electron.net.fetch(...args)

--- a/electron/plugins/hostService.cjs
+++ b/electron/plugins/hostService.cjs
@@ -159,16 +159,15 @@ function createPluginHostService(options) {
       resolveSecurityPrincipal: options.resolveSecurityPrincipal,
       runtimeMessageGuard,
       runtimeResourceMonitor: quotaManager,
+      runtimeCleanup: async (identity) => {
+        leaseStore.revokeRuntime(identity.runtimeId);
+        await companionSupervisor.releaseRuntime(identity.runtimeId);
+      },
       utilityModuleMappings: options.utilityModuleMappings ?? createUtilityModuleMappings(moduleResources),
     });
     quotaManager.setViolationHandler((identity, error) => (
       runtimeSupervisor.enforcePolicyViolation(identity, error)
     ));
-    runtimeSupervisor.onDidChangeRuntime((event) => {
-      if (!event.runtimeId || event.status === "running" || event.status === "starting") return;
-      leaseStore.revokeRuntime(event.runtimeId);
-      void companionSupervisor.releaseRuntime(event.runtimeId);
-    });
     const manager = new PluginManager({
       database,
       packageStore,

--- a/electron/plugins/hostService.test.cjs
+++ b/electron/plugins/hostService.test.cjs
@@ -139,6 +139,54 @@ test("runtime trust placement precedes required and advanced permission prompts"
   ]);
 });
 
+test("first-party placement selects the utility runtime for companion manifests", async (context) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-host-service-"));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const requested = [];
+  const service = createPluginHostService({
+    ...createOptions(root),
+    requestPermissionDecision: async (request) => {
+      requested.push(request.permission);
+      return { requestId: request.requestId, decision: "allow", scope: "application" };
+    },
+  });
+  context.after(() => service.manager.shutdown());
+  const manifest = {
+    manifestVersion: 1,
+    id: "com.example.companion-placement",
+    name: "companion-placement",
+    version: "1.0.0",
+    publisher: "example",
+    engines: { netcatty: ">=0.0.0", api: ">=0.1.0-internal <0.2.0" },
+    main: { browser: "browser.js", node: "node.js" },
+    permissions: {
+      required: [
+        "runtime.advanced",
+        {
+          permission: "companion.execute",
+          resources: ["com.example.companion-placement.helper"],
+        },
+      ],
+    },
+    companionExecutables: [{
+      id: "com.example.companion-placement.helper",
+      variants: [{
+        path: "bin/helper",
+        platforms: [`${process.platform}-${process.arch}`],
+        sha256: "0".repeat(64),
+      }],
+    }],
+  };
+
+  assert.equal(await service.runtimeSupervisor.resolveRuntimeKind({
+    plugin: { id: manifest.id, activeVersion: manifest.version, manifest },
+    availableKinds: ["browser", "utility"],
+    securityPrincipal: "unsigned-package:companion-placement",
+    signal: new AbortController().signal,
+  }), "utility");
+  assert.deepEqual(requested, ["companion.execute", "runtime.advanced"]);
+});
+
 test("secure host methods fail closed without an approver while public logging remains available", async (context) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-host-service-"));
   context.after(() => fs.rmSync(root, { recursive: true, force: true }));

--- a/electron/plugins/hostService.test.cjs
+++ b/electron/plugins/hostService.test.cjs
@@ -2,6 +2,7 @@
 
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const fsp = require("node:fs/promises");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
@@ -205,6 +206,56 @@ test("approved host capabilities reuse application grants through the registry",
     { found: true, value: 42 },
   );
   assert.equal(prompts, 1);
+});
+
+test("host service wires a handle-bound directory adapter without changing the RPC seam", async (context) => {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-host-service-")));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const directoryPath = path.join(root, "enumerate");
+  await fsp.mkdir(directoryPath);
+  await fsp.writeFile(path.join(directoryPath, "entry.txt"), "entry");
+  const service = createPluginHostService({
+    ...createOptions(root),
+    requestPermissionDecision: async (request) => ({
+      requestId: request.requestId,
+      decision: "allow",
+      scope: "once",
+    }),
+    openPluginDirectoryHandle: async (directoryPath) => {
+      const stats = await fsp.stat(directoryPath);
+      const directory = await fsp.opendir(directoryPath);
+      return {
+        stat: async () => stats,
+        read: () => directory.read(),
+        close: async () => {
+          try { await directory.close(); }
+          catch (error) { if (error?.code !== "ERR_DIR_CLOSED") throw error; }
+        },
+      };
+    },
+  });
+  context.after(() => service.manager.shutdown());
+  const pluginManifest = {
+    id: "com.example.directory",
+    name: "directory",
+    version: "1.0.0",
+    publisher: "example",
+    permissions: { optional: [{ permission: "filesystem.read", resources: [directoryPath] }] },
+  };
+  const routes = service.rpcRegistry.createRoutes({
+    pluginId: pluginManifest.id,
+    pluginVersion: pluginManifest.version,
+    runtimeId: "runtime-1",
+    runtimeKind: "browser",
+    manifest: pluginManifest,
+  });
+  assert.deepEqual(
+    await routes.requestHandlers["filesystem.readDirectory"](
+      { path: directoryPath },
+      transportContext(),
+    ),
+    { entries: [{ name: "entry.txt", kind: "file" }] },
+  );
 });
 
 test("custom host methods without an explicit authorization classification are denied", async (context) => {

--- a/electron/plugins/hostService.test.cjs
+++ b/electron/plugins/hostService.test.cjs
@@ -20,6 +20,13 @@ function createOptions(root, configureRpcRegistry) {
   };
 }
 
+function transportContext() {
+  return {
+    signal: new AbortController().signal,
+    logger: { write: async () => {} },
+  };
+}
+
 test("host RPC registry configuration is complete before runtime initialization", (context) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-host-service-"));
   context.after(() => fs.rmSync(root, { recursive: true, force: true }));
@@ -48,11 +55,143 @@ test("async host RPC registry configuration fails before a service can start", (
 test("host service forwards the transport quota guard to the runtime supervisor", (context) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-host-service-"));
   context.after(() => fs.rmSync(root, { recursive: true, force: true }));
-  const runtimeMessageGuard = () => {};
+  let guarded;
+  const runtimeMessageGuard = (identity, message) => { guarded = { identity, message }; };
   const service = createPluginHostService({
     ...createOptions(root),
     runtimeMessageGuard,
   });
   context.after(() => service.database.close());
-  assert.equal(service.runtimeSupervisor.runtimeMessageGuard, runtimeMessageGuard);
+  const identity = { runtimeId: "runtime-1" };
+  const message = { jsonrpc: "2.0" };
+  service.runtimeSupervisor.runtimeMessageGuard(identity, message);
+  assert.deepEqual(guarded, { identity, message });
+});
+
+test("runtime trust placement precedes required and advanced permission prompts", async (context) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-host-service-"));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const events = [];
+  const service = createPluginHostService({
+    ...createOptions(root),
+    resolveRuntimeKind: async () => {
+      events.push("placement");
+      return "utility";
+    },
+    requestPermissionDecision: async (request) => {
+      events.push(`permission:${request.permission}`);
+      return { requestId: request.requestId, decision: "allow", scope: "application" };
+    },
+  });
+  context.after(() => service.manager.shutdown());
+  const manifest = {
+    manifestVersion: 1,
+    id: "com.example.advanced",
+    name: "advanced",
+    version: "1.0.0",
+    publisher: "example",
+    engines: { netcatty: ">=0.0.0", api: ">=0.1.0-internal <0.2.0" },
+    main: { node: "index.js" },
+    permissions: { required: ["runtime.advanced", "storage"] },
+  };
+  assert.equal(await service.runtimeSupervisor.resolveRuntimeKind({
+    plugin: { id: manifest.id, activeVersion: manifest.version, manifest },
+    availableKinds: ["utility"],
+    securityPrincipal: "verified:test-publisher-key",
+    signal: new AbortController().signal,
+  }), "utility");
+  assert.deepEqual(events, [
+    "placement",
+    "permission:storage",
+    "permission:runtime.advanced",
+  ]);
+});
+
+test("secure host methods fail closed without an approver while public logging remains available", async (context) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-host-service-"));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const service = createPluginHostService(createOptions(root));
+  context.after(() => service.manager.shutdown());
+  const routes = service.rpcRegistry.createRoutes({
+    pluginId: "com.example.service",
+    pluginVersion: "1.0.0",
+    runtimeId: "runtime-1",
+    runtimeKind: "browser",
+    manifest: {
+      id: "com.example.service",
+      name: "service",
+      publisher: "example",
+      permissions: { required: ["storage"] },
+    },
+  });
+  await assert.rejects(
+    routes.requestHandlers["storage.set"]({ key: "answer", value: 42 }, transportContext()),
+    /not granted/,
+  );
+  await routes.notificationHandlers["log.write"]({ level: "info", message: "hello" }, transportContext());
+  assert.equal(service.database.getValue("com.example.service", "answer"), undefined);
+});
+
+test("approved host capabilities reuse application grants through the registry", async (context) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-host-service-"));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  let prompts = 0;
+  const service = createPluginHostService({
+    ...createOptions(root),
+    requestPermissionDecision: async (request) => {
+      prompts += 1;
+      return { requestId: request.requestId, decision: "allow", scope: "application" };
+    },
+  });
+  context.after(() => service.manager.shutdown());
+  const pluginManifest = {
+    manifestVersion: 1,
+    id: "com.example.service",
+    name: "service",
+    version: "1.0.0",
+    publisher: "example",
+    engines: { netcatty: ">=0.0.0", api: ">=0.1.0-internal <0.2.0" },
+    main: { browser: "index.js" },
+    permissions: { required: ["storage"] },
+  };
+  service.database.installVersion({
+    pluginId: pluginManifest.id,
+    version: pluginManifest.version,
+    manifest: pluginManifest,
+    archiveSha256: "a".repeat(64),
+    packageRelativePath: "com.example.service/1.0.0/package",
+  });
+  const routes = service.rpcRegistry.createRoutes({
+    pluginId: "com.example.service",
+    pluginVersion: "1.0.0",
+    runtimeId: "runtime-1",
+    runtimeKind: "browser",
+    manifest: pluginManifest,
+  });
+  await routes.requestHandlers["storage.set"]({ key: "answer", value: 42 }, transportContext());
+  assert.deepEqual(
+    await routes.requestHandlers["storage.get"]({ key: "answer" }, transportContext()),
+    { found: true, value: 42 },
+  );
+  assert.equal(prompts, 1);
+});
+
+test("custom host methods without an explicit authorization classification are denied", async (context) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-host-service-"));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const service = createPluginHostService(createOptions(root, (registry) => {
+    registry.registerRequest("settings.get", () => ({ value: true }));
+  }));
+  context.after(() => service.manager.shutdown());
+  const routes = service.rpcRegistry.createRoutes({
+    pluginId: "com.example.service",
+    pluginVersion: "1.0.0",
+    runtimeId: "runtime-1",
+    runtimeKind: "browser",
+    manifest: { permissions: { optional: ["settings.read"] } },
+  });
+  await assert.rejects(
+    routes.requestHandlers["settings.get"]({}, transportContext()),
+    /no authorization policy/,
+  );
 });

--- a/electron/plugins/hostService.test.cjs
+++ b/electron/plugins/hostService.test.cjs
@@ -68,6 +68,37 @@ test("host service forwards the transport quota guard to the runtime supervisor"
   assert.deepEqual(guarded, { identity, message });
 });
 
+test("runtime cleanup revokes leases before awaiting companion teardown", async (context) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-host-service-"));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const service = createPluginHostService(createOptions(root));
+  context.after(() => service.manager.shutdown());
+  const events = [];
+  let releaseCompanions;
+  service.leaseStore.revokeRuntime = (runtimeId) => {
+    events.push(`revoke:${runtimeId}`);
+  };
+  service.companionSupervisor.releaseRuntime = async (runtimeId) => {
+    events.push(`release:${runtimeId}`);
+    await new Promise((resolve) => {
+      releaseCompanions = resolve;
+    });
+  };
+
+  let settled = false;
+  const cleanup = service.runtimeSupervisor.runtimeCleanup({ runtimeId: "runtime-1" })
+    .finally(() => {
+      settled = true;
+    });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(events, ["revoke:runtime-1", "release:runtime-1"]);
+  assert.equal(settled, false);
+  releaseCompanions();
+  await cleanup;
+  assert.equal(settled, true);
+});
+
 test("runtime trust placement precedes required and advanced permission prompts", async (context) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-host-service-"));
   context.after(() => fs.rmSync(root, { recursive: true, force: true }));

--- a/electron/plugins/jsonBoundary.test.cjs
+++ b/electron/plugins/jsonBoundary.test.cjs
@@ -46,3 +46,35 @@ test("main-process JSON boundary enforces an incremental UTF-8 byte budget", () 
   );
   assert.throws(() => assertPluginJsonValue({}, { maxBytes: 0 }), /positive safe integer/);
 });
+
+test("maximum broker raw payloads fit inside JSON-RPC envelopes", () => {
+  const { PLUGIN_RPC_MAX_RAW_BYTES, PLUGIN_RPC_MAX_JSON_BYTES } = require("./constants.cjs");
+  const { assertRpcMessage } = require("./contractValidator.cjs");
+  const data = Buffer.alloc(PLUGIN_RPC_MAX_RAW_BYTES).toString("base64");
+  const response = {
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      url: `https://example.com/${"x".repeat(8_000)}`,
+      status: 200,
+      headers: { "x-budget": "y".repeat(64 * 1024) },
+      body: { encoding: "base64", data },
+    },
+  };
+  assert.ok(Buffer.byteLength(JSON.stringify(response)) < PLUGIN_RPC_MAX_JSON_BYTES);
+  assert.doesNotThrow(() => assertRpcMessage(response));
+  const request = {
+    jsonrpc: "2.0",
+    id: 2,
+    method: "network.request",
+    params: {
+      url: `https://example.com/${"x".repeat(8_000)}`,
+      headers: Object.fromEntries(Array.from({ length: 8 }, (_, index) => (
+        [`x-budget-${index}`, "\\".repeat(8 * 1024)]
+      ))),
+      body: { encoding: "utf8", data: "\0".repeat(PLUGIN_RPC_MAX_RAW_BYTES) },
+    },
+  };
+  assert.ok(Buffer.byteLength(JSON.stringify(request)) < PLUGIN_RPC_MAX_JSON_BYTES);
+  assert.doesNotThrow(() => assertRpcMessage(request));
+});

--- a/electron/plugins/nativePermissionDecision.cjs
+++ b/electron/plugins/nativePermissionDecision.cjs
@@ -1,25 +1,37 @@
 "use strict";
 
 const MAX_VISIBLE_RESOURCES = 20;
+const MAX_VISIBLE_FIELD_LENGTH = 1_024;
+const UNSAFE_DISPLAY_CHARACTERS = /[\u0000-\u001f\u007f-\u009f\u2028\u2029\u202a-\u202e\u2066-\u2069]/gu;
+
+function escapePermissionText(value, maxLength = MAX_VISIBLE_FIELD_LENGTH) {
+  const text = String(value).slice(0, maxLength);
+  return text.replace(UNSAFE_DISPLAY_CHARACTERS, (character) => {
+    if (character === "\n") return "\\n";
+    if (character === "\r") return "\\r";
+    if (character === "\t") return "\\t";
+    return `\\u${character.codePointAt(0).toString(16).padStart(4, "0")}`;
+  });
+}
 
 function describePermissionRequest(request) {
   const identity = request.pluginName
-    ? `${request.pluginName} (${request.pluginId})`
-    : request.pluginId;
+    ? `${escapePermissionText(request.pluginName)} (${escapePermissionText(request.pluginId)})`
+    : escapePermissionText(request.pluginId);
   const resources = request.resources ?? [];
   const resourceKinds = request.resourceKinds ?? [];
   const visibleResources = resources.slice(0, MAX_VISIBLE_RESOURCES).map((resource, index) => {
     const suffix = resourceKinds[index] === "directory" ? " (directory and descendants)" : "";
-    return `- ${resource}${suffix}`;
+    return `- ${escapePermissionText(resource)}${suffix}`;
   });
   if (resources.length > visibleResources.length) {
     visibleResources.push(`- …and ${resources.length - visibleResources.length} more`);
   }
   return [
     `Plugin: ${identity}`,
-    ...(request.publisher ? [`Publisher: ${request.publisher}`] : []),
-    `Permission: ${request.permission}`,
-    `Reason: ${request.reason}`,
+    ...(request.publisher ? [`Publisher: ${escapePermissionText(request.publisher)}`] : []),
+    `Permission: ${escapePermissionText(request.permission)}`,
+    `Reason: ${escapePermissionText(request.reason)}`,
     ...(visibleResources.length ? ["Resources:", ...visibleResources] : []),
   ].join("\n");
 }
@@ -44,7 +56,7 @@ function createNativePermissionDecisionProvider(options) {
     const messageBoxOptions = {
       type: "warning",
       title: "Plugin permission request",
-      message: `${request.pluginName ?? request.pluginId} requests ${request.permission}`,
+      message: `${escapePermissionText(request.pluginName ?? request.pluginId)} requests ${escapePermissionText(request.permission)}`,
       detail: describePermissionRequest(request),
       buttons: choices.map(({ label }) => label),
       defaultId: 0,
@@ -69,7 +81,9 @@ function createNativePermissionDecisionProvider(options) {
 }
 
 module.exports = {
+  MAX_VISIBLE_FIELD_LENGTH,
   MAX_VISIBLE_RESOURCES,
   createNativePermissionDecisionProvider,
   describePermissionRequest,
+  escapePermissionText,
 };

--- a/electron/plugins/nativePermissionDecision.cjs
+++ b/electron/plugins/nativePermissionDecision.cjs
@@ -1,0 +1,75 @@
+"use strict";
+
+const MAX_VISIBLE_RESOURCES = 20;
+
+function describePermissionRequest(request) {
+  const identity = request.pluginName
+    ? `${request.pluginName} (${request.pluginId})`
+    : request.pluginId;
+  const resources = request.resources ?? [];
+  const resourceKinds = request.resourceKinds ?? [];
+  const visibleResources = resources.slice(0, MAX_VISIBLE_RESOURCES).map((resource, index) => {
+    const suffix = resourceKinds[index] === "directory" ? " (directory and descendants)" : "";
+    return `- ${resource}${suffix}`;
+  });
+  if (resources.length > visibleResources.length) {
+    visibleResources.push(`- …and ${resources.length - visibleResources.length} more`);
+  }
+  return [
+    `Plugin: ${identity}`,
+    ...(request.publisher ? [`Publisher: ${request.publisher}`] : []),
+    `Permission: ${request.permission}`,
+    `Reason: ${request.reason}`,
+    ...(visibleResources.length ? ["Resources:", ...visibleResources] : []),
+  ].join("\n");
+}
+
+function createNativePermissionDecisionProvider(options) {
+  if (!options?.dialog || typeof options.dialog.showMessageBox !== "function") {
+    throw new TypeError("Native plugin permission decisions require an Electron dialog");
+  }
+  const dialog = options.dialog;
+  const window = options.window;
+  return async (request, context = {}) => {
+    context.signal?.throwIfAborted();
+    const choices = [
+      { label: "Deny", decision: "deny" },
+      { label: "Allow Once", decision: "allow", scope: "once" },
+      ...(request.sessionId
+        ? [{ label: "Allow for Session", decision: "allow", scope: "session" }]
+        : []),
+      { label: "Allow for Application", decision: "allow", scope: "application" },
+      { label: "Always Allow", decision: "allow", scope: "always" },
+    ];
+    const messageBoxOptions = {
+      type: "warning",
+      title: "Plugin permission request",
+      message: `${request.pluginName ?? request.pluginId} requests ${request.permission}`,
+      detail: describePermissionRequest(request),
+      buttons: choices.map(({ label }) => label),
+      defaultId: 0,
+      cancelId: 0,
+      noLink: true,
+      ...(context.signal ? { signal: context.signal } : {}),
+    };
+    const result = window
+      ? await dialog.showMessageBox(window, messageBoxOptions)
+      : await dialog.showMessageBox(messageBoxOptions);
+    context.signal?.throwIfAborted();
+    const choice = choices[result.response] ?? choices[0];
+    if (choice.decision !== "allow") {
+      return Object.freeze({ requestId: request.requestId, decision: "deny" });
+    }
+    return Object.freeze({
+      requestId: request.requestId,
+      decision: "allow",
+      scope: choice.scope,
+    });
+  };
+}
+
+module.exports = {
+  MAX_VISIBLE_RESOURCES,
+  createNativePermissionDecisionProvider,
+  describePermissionRequest,
+};

--- a/electron/plugins/nativePermissionDecision.test.cjs
+++ b/electron/plugins/nativePermissionDecision.test.cjs
@@ -4,9 +4,11 @@ const assert = require("node:assert/strict");
 const test = require("node:test");
 
 const {
+  MAX_VISIBLE_FIELD_LENGTH,
   MAX_VISIBLE_RESOURCES,
   createNativePermissionDecisionProvider,
   describePermissionRequest,
+  escapePermissionText,
 } = require("./nativePermissionDecision.cjs");
 
 function permissionRequest(overrides = {}) {
@@ -76,4 +78,29 @@ test("native permission request details are bounded and preserve resource kinds"
   }));
   assert.match(detail, /and 5 more/u);
   assert.doesNotMatch(detail, /\/path\/24/u);
+});
+
+test("native permission dialogs visibly escape control and bidi characters", async () => {
+  let captured;
+  const provider = createNativePermissionDecisionProvider({
+    dialog: {
+      async showMessageBox(options) {
+        captured = options;
+        return { response: 0 };
+      },
+    },
+  });
+  await provider(permissionRequest({
+    pluginName: "Plugin\nPermission: vault.credentials",
+    publisher: "publisher\u202e",
+    reason: "Read this\r\nAlways Allow",
+    resources: ["/safe\nPermission: runtime.advanced"],
+    resourceKinds: ["exact"],
+  }));
+  assert.match(captured.message, /Plugin\\nPermission: vault\.credentials/u);
+  assert.match(captured.detail, /publisher\\u202e/u);
+  assert.match(captured.detail, /Read this\\r\\nAlways Allow/u);
+  assert.match(captured.detail, /\/safe\\nPermission: runtime\.advanced/u);
+  assert.equal(captured.detail.split("\n").filter((line) => line.startsWith("Permission:")).length, 1);
+  assert.equal(escapePermissionText("x".repeat(MAX_VISIBLE_FIELD_LENGTH + 20)).length, MAX_VISIBLE_FIELD_LENGTH);
 });

--- a/electron/plugins/nativePermissionDecision.test.cjs
+++ b/electron/plugins/nativePermissionDecision.test.cjs
@@ -1,0 +1,79 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  MAX_VISIBLE_RESOURCES,
+  createNativePermissionDecisionProvider,
+  describePermissionRequest,
+} = require("./nativePermissionDecision.cjs");
+
+function permissionRequest(overrides = {}) {
+  return {
+    requestId: "request-1",
+    pluginId: "com.example.permissions",
+    pluginName: "Permissions",
+    publisher: "example",
+    permission: "filesystem.read",
+    resources: ["/allowed"],
+    resourceKinds: ["directory"],
+    reason: "Read project files",
+    ...overrides,
+  };
+}
+
+test("native permission decisions expose every host-owned grant scope", async () => {
+  for (const { sessionId, response, expected } of [
+    { response: 0, expected: { requestId: "request-1", decision: "deny" } },
+    { response: 1, expected: { requestId: "request-1", decision: "allow", scope: "once" } },
+    { sessionId: "session-1", response: 2, expected: {
+      requestId: "request-1", decision: "allow", scope: "session",
+    } },
+    { response: 2, expected: {
+      requestId: "request-1", decision: "allow", scope: "application",
+    } },
+    { response: 3, expected: {
+      requestId: "request-1", decision: "allow", scope: "always",
+    } },
+  ]) {
+    let captured;
+    const signal = new AbortController().signal;
+    const provider = createNativePermissionDecisionProvider({
+      dialog: {
+        async showMessageBox(_window, options) {
+          captured = options;
+          return { response };
+        },
+      },
+      window: {},
+    });
+    assert.deepEqual(await provider(permissionRequest({ sessionId }), { signal }), expected);
+    assert.equal(captured.signal, signal);
+    assert.equal(captured.cancelId, 0);
+    assert.match(captured.detail, /directory and descendants/u);
+  }
+});
+
+test("native permission decisions fail closed on cancellation and abort", async () => {
+  const provider = createNativePermissionDecisionProvider({
+    dialog: { showMessageBox: async () => ({ response: 999 }) },
+  });
+  assert.deepEqual(await provider(permissionRequest()), {
+    requestId: "request-1",
+    decision: "deny",
+  });
+  const controller = new AbortController();
+  controller.abort(new Error("runtime stopped"));
+  await assert.rejects(provider(permissionRequest(), { signal: controller.signal }), /runtime stopped/);
+});
+
+test("native permission request details are bounded and preserve resource kinds", () => {
+  const resources = Array.from({ length: MAX_VISIBLE_RESOURCES + 5 }, (_, index) => `/path/${index}`);
+  const detail = describePermissionRequest(permissionRequest({
+    resources,
+    resourceKinds: resources.map(() => "exact"),
+  }));
+  assert.match(detail, /and 5 more/u);
+  assert.doesNotMatch(detail, /\/path\/24/u);
+});

--- a/electron/plugins/networkBroker.cjs
+++ b/electron/plugins/networkBroker.cjs
@@ -1,0 +1,282 @@
+"use strict";
+
+const { PluginRpcError, RPC_ERRORS } = require("./rpcRouter.cjs");
+const { canonicalizeNetworkOrigin } = require("./permissionResources.cjs");
+
+const MAX_NETWORK_BODY_BYTES = 1024 * 1024;
+const MAX_NETWORK_HEADERS = 64;
+const MAX_NETWORK_REDIRECTS = 5;
+const FORBIDDEN_REQUEST_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "cookie",
+  "host",
+  "proxy-authorization",
+  "transfer-encoding",
+]);
+const SENSITIVE_REDIRECT_HEADERS = new Set(["authorization", "cookie", "proxy-authorization"]);
+const ENTITY_REDIRECT_HEADERS = new Set(["content-encoding", "content-language", "content-type"]);
+
+function invalidArgument(message) {
+  return new PluginRpcError(RPC_ERRORS.invalidArgument, message);
+}
+
+async function cancelResponseBody(response, reason) {
+  try { await response.body?.cancel?.(reason); }
+  catch {}
+}
+
+function decodeBody(body) {
+  if (body === undefined) return undefined;
+  if (!body || typeof body !== "object" || Array.isArray(body) || typeof body.data !== "string") {
+    throw invalidArgument("Plugin network request body is invalid");
+  }
+  let bytes;
+  if (body.encoding === "utf8") bytes = Buffer.from(body.data, "utf8");
+  else if (body.encoding === "base64") {
+    bytes = Buffer.from(body.data, "base64");
+    if (bytes.toString("base64") !== body.data) throw invalidArgument("Plugin network base64 body is not canonical");
+  } else throw invalidArgument("Plugin network request body encoding is unsupported");
+  if (bytes.byteLength > MAX_NETWORK_BODY_BYTES) {
+    throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Plugin network request body is too large");
+  }
+  return bytes;
+}
+
+function normalizeHeaders(value) {
+  if (value === undefined) return {};
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw invalidArgument("Plugin network headers are invalid");
+  }
+  const entries = Object.entries(value);
+  if (entries.length > MAX_NETWORK_HEADERS) throw invalidArgument("Plugin network request has too many headers");
+  const headers = {};
+  for (const [rawName, rawValue] of entries) {
+    const name = rawName.toLowerCase();
+    if (!/^[!#$%&'*+.^_`|~0-9a-z-]+$/u.test(name) || FORBIDDEN_REQUEST_HEADERS.has(name)) {
+      throw invalidArgument(`Plugin network request header is forbidden: ${rawName}`);
+    }
+    if (typeof rawValue !== "string" || rawValue.length > 8_192 || /[\r\n]/u.test(rawValue)) {
+      throw invalidArgument(`Plugin network request header value is invalid: ${rawName}`);
+    }
+    headers[name] = rawValue;
+  }
+  return headers;
+}
+
+function assertNetworkRequest(params) {
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    throw invalidArgument("Plugin network request is invalid");
+  }
+  let url;
+  try { url = new URL(params.url); }
+  catch { throw invalidArgument("Plugin network URL is invalid"); }
+  const origin = canonicalizeNetworkOrigin(url.origin);
+  if (url.username || url.password) throw invalidArgument("Plugin network URL cannot contain credentials");
+  const method = params.method ?? "GET";
+  if (!["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"].includes(method)) {
+    throw invalidArgument("Plugin network method is unsupported");
+  }
+  const timeoutMs = params.timeoutMs ?? 30_000;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 300_000) {
+    throw invalidArgument("Plugin network timeout is invalid");
+  }
+  const body = decodeBody(params.body);
+  if (body && (method === "GET" || method === "HEAD")) {
+    throw invalidArgument(`Plugin network ${method} requests cannot contain a body`);
+  }
+  return {
+    url,
+    origin,
+    method,
+    headers: normalizeHeaders(params.headers),
+    body,
+    timeoutMs,
+  };
+}
+
+async function readBoundedResponse(response, maxBytes, signal) {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    await cancelResponseBody(response);
+    throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Plugin network response is too large");
+  }
+  if (!response.body) return Buffer.alloc(0);
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    while (true) {
+      signal?.throwIfAborted();
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Plugin network response is too large");
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } catch (error) {
+    try { await reader.cancel(error); } catch {}
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks, total);
+}
+
+function normalizeResponseHeaders(headers) {
+  const responseHeaders = {};
+  let responseHeaderBytes = 0;
+  let responseHeaderCount = 0;
+  for (const [name, value] of headers) {
+    if (name.toLowerCase() === "set-cookie") continue;
+    responseHeaderCount += 1;
+    responseHeaderBytes += Buffer.byteLength(name) + Buffer.byteLength(value);
+    if (responseHeaderCount > MAX_NETWORK_HEADERS || responseHeaderBytes > 64 * 1024) {
+      throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Plugin network response headers are too large");
+    }
+    responseHeaders[name.toLowerCase()] = value;
+  }
+  return responseHeaders;
+}
+
+class PluginNetworkBroker {
+  constructor(options) {
+    this.fetch = options.fetch ?? globalThis.fetch;
+    this.permissionEngine = options.permissionEngine;
+    this.quotaManager = options.quotaManager ?? null;
+    if (typeof this.fetch !== "function") throw new TypeError("Plugin network fetch implementation is required");
+  }
+
+  validate(params) {
+    const request = assertNetworkRequest(params);
+    return {
+      url: request.url.href,
+      method: request.method,
+      headers: request.headers,
+      ...(request.body === undefined ? {} : {
+        body: { encoding: "base64", data: request.body.toString("base64") },
+      }),
+      timeoutMs: request.timeoutMs,
+    };
+  }
+
+  describeAuthorization(params) {
+    const request = assertNetworkRequest(params);
+    return {
+      permission: "network",
+      resources: [request.origin],
+      reason: `Connect to ${request.origin}`,
+      operationId: `network:${request.origin}`,
+    };
+  }
+
+  async request(params, context) {
+    const request = assertNetworkRequest(params);
+    const timeout = AbortSignal.timeout(request.timeoutMs);
+    const signal = context.signal ? AbortSignal.any([context.signal, timeout]) : timeout;
+    let currentUrl = request.url;
+    let currentOrigin = request.origin;
+    let currentMethod = request.method;
+    let currentBody = request.body;
+    let headers = { ...request.headers };
+    try {
+      for (let redirects = 0; redirects <= MAX_NETWORK_REDIRECTS; redirects += 1) {
+        await context.assertActive();
+        if (currentBody) {
+          this.quotaManager?.chargeBytes(context.runtimeId, "network", currentBody.byteLength);
+        }
+        const response = await this.fetch(currentUrl, {
+          method: currentMethod,
+          headers,
+          ...(currentBody === undefined ? {} : { body: currentBody }),
+          credentials: "omit",
+          redirect: "manual",
+          signal,
+        });
+        const effectiveUrl = response.url ? new URL(response.url) : currentUrl;
+        if (
+          effectiveUrl.username
+          || effectiveUrl.password
+          || canonicalizeNetworkOrigin(effectiveUrl.origin) !== currentOrigin
+        ) {
+          await cancelResponseBody(response);
+          throw new PluginRpcError(
+            RPC_ERRORS.permissionDenied,
+            "Plugin network transport followed an unauthorized redirect",
+          );
+        }
+        let responseHeaders;
+        try {
+          responseHeaders = normalizeResponseHeaders(response.headers);
+        } catch (error) {
+          await cancelResponseBody(response, error);
+          throw error;
+        }
+        if (response.status >= 300 && response.status < 400 && response.headers.get("location")) {
+          await cancelResponseBody(response);
+          if (redirects === MAX_NETWORK_REDIRECTS) {
+            throw new PluginRpcError(RPC_ERRORS.outOfRange, "Plugin network redirect limit exceeded");
+          }
+          const nextUrl = new URL(response.headers.get("location"), currentUrl);
+          if (nextUrl.username || nextUrl.password) {
+            throw invalidArgument("Plugin network redirect URL cannot contain credentials");
+          }
+          const nextOrigin = canonicalizeNetworkOrigin(nextUrl.origin);
+          await this.permissionEngine.authorize(context, {
+            permission: "network",
+            resources: [nextOrigin],
+            reason: `Follow network redirect to ${nextOrigin}`,
+            operationId: `network:${nextOrigin}`,
+          });
+          if (nextOrigin !== currentOrigin) {
+            headers = Object.fromEntries(Object.entries(headers).filter(([name]) => (
+              !SENSITIVE_REDIRECT_HEADERS.has(name)
+            )));
+          }
+          if (response.status === 303 || ((response.status === 301 || response.status === 302) && currentMethod === "POST")) {
+            currentMethod = currentMethod === "HEAD" ? "HEAD" : "GET";
+            currentBody = undefined;
+            headers = Object.fromEntries(Object.entries(headers).filter(([name]) => (
+              !ENTITY_REDIRECT_HEADERS.has(name)
+            )));
+          }
+          currentUrl = nextUrl;
+          currentOrigin = nextOrigin;
+          continue;
+        }
+        const bytes = await readBoundedResponse(response, MAX_NETWORK_BODY_BYTES, signal);
+        this.quotaManager?.chargeBytes(context.runtimeId, "network", bytes.byteLength);
+        await context.assertActive();
+        return {
+          url: effectiveUrl.href,
+          status: response.status,
+          headers: responseHeaders,
+          body: { encoding: "base64", data: bytes.toString("base64") },
+        };
+      }
+    } catch (error) {
+      context.signal?.throwIfAborted();
+      if (timeout.aborted) {
+        throw new PluginRpcError(RPC_ERRORS.deadlineExceeded, "Plugin network request timed out");
+      }
+      throw error;
+    }
+    throw new PluginRpcError(RPC_ERRORS.internal, "Plugin network redirect handling failed");
+  }
+}
+
+module.exports = {
+  FORBIDDEN_REQUEST_HEADERS,
+  ENTITY_REDIRECT_HEADERS,
+  MAX_NETWORK_BODY_BYTES,
+  MAX_NETWORK_HEADERS,
+  MAX_NETWORK_REDIRECTS,
+  PluginNetworkBroker,
+  assertNetworkRequest,
+  cancelResponseBody,
+  normalizeResponseHeaders,
+  readBoundedResponse,
+};

--- a/electron/plugins/networkBroker.cjs
+++ b/electron/plugins/networkBroker.cjs
@@ -1,10 +1,12 @@
 "use strict";
 
 const { PluginRpcError, RPC_ERRORS } = require("./rpcRouter.cjs");
+const { PLUGIN_RPC_MAX_RAW_BYTES } = require("./constants.cjs");
 const { canonicalizeNetworkOrigin } = require("./permissionResources.cjs");
 
-const MAX_NETWORK_BODY_BYTES = 1024 * 1024;
+const MAX_NETWORK_BODY_BYTES = PLUGIN_RPC_MAX_RAW_BYTES;
 const MAX_NETWORK_HEADERS = 64;
+const MAX_NETWORK_HEADER_BYTES = 64 * 1024;
 const MAX_NETWORK_REDIRECTS = 5;
 const FORBIDDEN_REQUEST_HEADERS = new Set([
   "connection",
@@ -51,13 +53,22 @@ function normalizeHeaders(value) {
   const entries = Object.entries(value);
   if (entries.length > MAX_NETWORK_HEADERS) throw invalidArgument("Plugin network request has too many headers");
   const headers = {};
+  let headerBytes = 0;
   for (const [rawName, rawValue] of entries) {
     const name = rawName.toLowerCase();
     if (!/^[!#$%&'*+.^_`|~0-9a-z-]+$/u.test(name) || FORBIDDEN_REQUEST_HEADERS.has(name)) {
       throw invalidArgument(`Plugin network request header is forbidden: ${rawName}`);
     }
-    if (typeof rawValue !== "string" || rawValue.length > 8_192 || /[\r\n]/u.test(rawValue)) {
+    if (
+      typeof rawValue !== "string"
+      || rawValue.length > 8_192
+      || /[\u0000-\u0008\u000a-\u001f\u007f]/u.test(rawValue)
+    ) {
       throw invalidArgument(`Plugin network request header value is invalid: ${rawName}`);
+    }
+    headerBytes += Buffer.byteLength(name) + Buffer.byteLength(rawValue);
+    if (headerBytes > MAX_NETWORK_HEADER_BYTES) {
+      throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Plugin network request headers are too large");
     }
     headers[name] = rawValue;
   }
@@ -67,6 +78,9 @@ function normalizeHeaders(value) {
 function assertNetworkRequest(params) {
   if (!params || typeof params !== "object" || Array.isArray(params)) {
     throw invalidArgument("Plugin network request is invalid");
+  }
+  if (typeof params.url !== "string" || params.url.length > 8_192) {
+    throw invalidArgument("Plugin network URL is invalid");
   }
   let url;
   try { url = new URL(params.url); }
@@ -134,7 +148,7 @@ function normalizeResponseHeaders(headers) {
     if (name.toLowerCase() === "set-cookie") continue;
     responseHeaderCount += 1;
     responseHeaderBytes += Buffer.byteLength(name) + Buffer.byteLength(value);
-    if (responseHeaderCount > MAX_NETWORK_HEADERS || responseHeaderBytes > 64 * 1024) {
+    if (responseHeaderCount > MAX_NETWORK_HEADERS || responseHeaderBytes > MAX_NETWORK_HEADER_BYTES) {
       throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Plugin network response headers are too large");
     }
     responseHeaders[name.toLowerCase()] = value;
@@ -272,6 +286,7 @@ module.exports = {
   FORBIDDEN_REQUEST_HEADERS,
   ENTITY_REDIRECT_HEADERS,
   MAX_NETWORK_BODY_BYTES,
+  MAX_NETWORK_HEADER_BYTES,
   MAX_NETWORK_HEADERS,
   MAX_NETWORK_REDIRECTS,
   PluginNetworkBroker,

--- a/electron/plugins/networkBroker.test.cjs
+++ b/electron/plugins/networkBroker.test.cjs
@@ -1,0 +1,157 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { PluginNetworkBroker, MAX_NETWORK_BODY_BYTES } = require("./networkBroker.cjs");
+const { RPC_ERRORS } = require("./rpcRouter.cjs");
+
+function runtimeContext() {
+  return {
+    pluginId: "com.example.network",
+    pluginVersion: "1.0.0",
+    runtimeId: "runtime-1",
+    runtimeKind: "browser",
+    manifest: { permissions: { optional: ["network"] } },
+    signal: new AbortController().signal,
+    assertActive: async () => {},
+  };
+}
+
+test("network broker strips cookies, bounds responses, and charges decoded bytes", async () => {
+  const calls = [];
+  const charged = [];
+  const broker = new PluginNetworkBroker({
+    fetch: async (url, options) => {
+      calls.push({ url: String(url), options });
+      return new Response("hello", {
+        status: 200,
+        headers: { "content-type": "text/plain", "set-cookie": "secret=1" },
+      });
+    },
+    permissionEngine: { authorize: async () => {} },
+    quotaManager: { chargeBytes: (...args) => charged.push(args) },
+  });
+  const response = await broker.request({
+    url: "https://example.com/data",
+    headers: { accept: "text/plain" },
+  }, runtimeContext());
+  assert.equal(calls[0].options.credentials, "omit");
+  assert.equal(calls[0].options.redirect, "manual");
+  assert.equal(response.headers["set-cookie"], undefined);
+  assert.equal(Buffer.from(response.body.data, "base64").toString(), "hello");
+  assert.deepEqual(charged, [["runtime-1", "network", 5]]);
+});
+
+test("every redirect origin is authorized and cross-origin credentials are stripped", async () => {
+  const calls = [];
+  const authorized = [];
+  const broker = new PluginNetworkBroker({
+    fetch: async (url, options) => {
+      calls.push({ url: String(url), options });
+      if (calls.length === 1) {
+        return new Response(null, { status: 302, headers: { location: "https://other.example/final" } });
+      }
+      return new Response("ok", { status: 200 });
+    },
+    permissionEngine: { authorize: async (_context, descriptor) => authorized.push(descriptor) },
+  });
+  await broker.request({
+    url: "https://first.example/start",
+    headers: { authorization: "Bearer host-secret", "x-request-id": "one" },
+  }, runtimeContext());
+  assert.equal(authorized[0].resources[0], "https://other.example");
+  assert.equal(calls[1].options.headers.authorization, undefined);
+  assert.equal(calls[1].options.headers["x-request-id"], "one");
+});
+
+test("HTTP redirect method semantics do not replay POST bodies on 302", async () => {
+  const calls = [];
+  const charges = [];
+  const broker = new PluginNetworkBroker({
+    fetch: async (_url, options) => {
+      calls.push(options);
+      if (calls.length === 1) return new Response(null, { status: 302, headers: { location: "/done" } });
+      return new Response("ok");
+    },
+    permissionEngine: { authorize: async () => {} },
+    quotaManager: { chargeBytes: (...args) => charges.push(args) },
+  });
+  await broker.request({
+    url: "https://example.com/start",
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: { encoding: "utf8", data: "{}" },
+  }, runtimeContext());
+  assert.equal(calls[1].method, "GET");
+  assert.equal(calls[1].body, undefined);
+  assert.equal(calls[1].headers["content-type"], undefined);
+  assert.deepEqual(charges, [
+    ["runtime-1", "network", 2],
+    ["runtime-1", "network", 2],
+  ], "the request body and final response are both charged");
+});
+
+test("network redirects reject embedded credentials before authorization or fetch", async () => {
+  let calls = 0;
+  let authorizations = 0;
+  const broker = new PluginNetworkBroker({
+    fetch: async () => {
+      calls += 1;
+      return new Response(null, {
+        status: 302,
+        headers: { location: "https://user:password@other.example/private" },
+      });
+    },
+    permissionEngine: { authorize: async () => { authorizations += 1; } },
+  });
+  await assert.rejects(
+    broker.request({ url: "https://first.example/start" }, runtimeContext()),
+    /cannot contain credentials/,
+  );
+  assert.equal(calls, 1);
+  assert.equal(authorizations, 0);
+});
+
+test("network request validation rejects transport headers, credentials, and non-canonical bodies", () => {
+  const broker = new PluginNetworkBroker({
+    fetch: async () => new Response(),
+    permissionEngine: { authorize: async () => {} },
+  });
+  assert.throws(() => broker.validate({
+    url: "https://example.com",
+    headers: { cookie: "secret=1" },
+  }), /forbidden/);
+  assert.throws(() => broker.validate({ url: "https://user:pass@example.com" }), /credentials/);
+  assert.throws(() => broker.validate({
+    url: "https://example.com",
+    method: "POST",
+    body: { encoding: "base64", data: "YQ" },
+  }), /not canonical/);
+});
+
+test("network response streaming stops above the byte cap", async () => {
+  const broker = new PluginNetworkBroker({
+    fetch: async () => new Response("small", {
+      headers: { "content-length": String(MAX_NETWORK_BODY_BYTES + 1) },
+    }),
+    permissionEngine: { authorize: async () => {} },
+  });
+  await assert.rejects(
+    broker.request({ url: "https://example.com" }, runtimeContext()),
+    (error) => error.code === RPC_ERRORS.resourceExhausted,
+  );
+});
+
+test("network broker reports its own timeout as a stable deadline error", async () => {
+  const broker = new PluginNetworkBroker({
+    fetch: async (_url, options) => new Promise((_resolve, reject) => {
+      options.signal.addEventListener("abort", () => reject(options.signal.reason), { once: true });
+    }),
+    permissionEngine: { authorize: async () => {} },
+  });
+  await assert.rejects(
+    broker.request({ url: "https://example.com", timeoutMs: 5 }, runtimeContext()),
+    (error) => error.code === RPC_ERRORS.deadlineExceeded,
+  );
+});

--- a/electron/plugins/networkBroker.test.cjs
+++ b/electron/plugins/networkBroker.test.cjs
@@ -3,7 +3,11 @@
 const assert = require("node:assert/strict");
 const test = require("node:test");
 
-const { PluginNetworkBroker, MAX_NETWORK_BODY_BYTES } = require("./networkBroker.cjs");
+const {
+  PluginNetworkBroker,
+  MAX_NETWORK_BODY_BYTES,
+  MAX_NETWORK_HEADER_BYTES,
+} = require("./networkBroker.cjs");
 const { RPC_ERRORS } = require("./rpcRouter.cjs");
 
 function runtimeContext() {
@@ -128,6 +132,16 @@ test("network request validation rejects transport headers, credentials, and non
     method: "POST",
     body: { encoding: "base64", data: "YQ" },
   }), /not canonical/);
+  assert.throws(() => broker.validate({
+    url: "https://example.com",
+    headers: Object.fromEntries(Array.from({ length: 9 }, (_, index) => (
+      [`x-budget-${index}`, "x".repeat(MAX_NETWORK_HEADER_BYTES / 8)]
+    ))),
+  }), /headers are too large/);
+  assert.throws(() => broker.validate({
+    url: "https://example.com",
+    headers: { "x-control": "before\0after" },
+  }), /header value is invalid/);
 });
 
 test("network response streaming stops above the byte cap", async () => {

--- a/electron/plugins/permissionEngine.cjs
+++ b/electron/plugins/permissionEngine.cjs
@@ -558,6 +558,11 @@ class PluginPermissionEngine {
       await this.authorize(context, {
         permission: declaration.permission,
         resources: declaration.resources.length ? declaration.resources : ["*"],
+        ...(declaration.resources.length
+          && (declaration.permission === "filesystem.read"
+            || declaration.permission === "filesystem.write")
+          ? { resourceKinds: declaration.resources.map(() => "directory") }
+          : {}),
         reason: declaration.reason || `Required by ${plugin.id}`,
         operationId: `activation:${plugin.activeVersion}`,
       });

--- a/electron/plugins/permissionEngine.cjs
+++ b/electron/plugins/permissionEngine.cjs
@@ -4,7 +4,6 @@ const { createHash, randomUUID } = require("node:crypto");
 
 const { PluginRpcError, RPC_ERRORS, raceWithAbort } = require("./rpcRouter.cjs");
 const {
-  RESOURCE_SCOPED_PERMISSIONS,
   assertPluginPermission,
   canonicalizePermissionResource,
   declarationAllowsResource,
@@ -552,9 +551,6 @@ class PluginPermissionEngine {
     };
     for (const declaration of declarations.values()) {
       if (!declaration.required || skipPermissions.has(declaration.permission)) continue;
-      if (RESOURCE_SCOPED_PERMISSIONS.has(declaration.permission) && declaration.resources.length === 0) {
-        continue;
-      }
       await this.authorize(context, {
         permission: declaration.permission,
         resources: declaration.resources.length ? declaration.resources : ["*"],

--- a/electron/plugins/permissionEngine.cjs
+++ b/electron/plugins/permissionEngine.cjs
@@ -1,0 +1,534 @@
+"use strict";
+
+const { createHash, randomUUID } = require("node:crypto");
+
+const { PluginRpcError, RPC_ERRORS, raceWithAbort } = require("./rpcRouter.cjs");
+const {
+  RESOURCE_SCOPED_PERMISSIONS,
+  assertPluginPermission,
+  canonicalizePermissionResource,
+  declarationAllowsResource,
+  defaultSecurityPrincipal,
+  normalizePermissionDeclarations,
+  permissionDeclarationHash,
+  permissionResourceCovers,
+} = require("./permissionResources.cjs");
+
+const VALID_SCOPES = new Set(["once", "session", "application", "always"]);
+const AUDITED_PERMISSION_USES = new Set([
+  "runtime.advanced",
+  "network",
+  "filesystem.read",
+  "filesystem.write",
+  "secrets",
+  "companion.execute",
+  "vault.credentials",
+  "terminal.input",
+  "terminal.intercept.input",
+  "terminal.intercept.output",
+]);
+const PROMPT_TIMEOUT_MS = 30_000;
+
+function normalizePermissionOperationId(value) {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string" || value.length < 1 || value.includes("\0")) {
+    throw permissionDenied("Plugin permission operation ID is invalid");
+  }
+  if (value.length <= 128) return value;
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function normalizePermissionReason(value, permission) {
+  const reason = typeof value === "string" && value.length > 0
+    ? value
+    : `Allow ${permission}`;
+  if (reason.length <= 1_024) return reason;
+  const suffix = ` [sha256:${createHash("sha256").update(reason).digest("hex")}]`;
+  return `${reason.slice(0, 1_024 - suffix.length)}${suffix}`;
+}
+
+function normalizePermissionSessionId(value) {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string" || value.length < 1 || value.length > 128 || value.includes("\0")) {
+    throw permissionDenied("Plugin permission session ID is invalid");
+  }
+  return value;
+}
+
+function normalizePermissionResources(permission, values, label = "Plugin permission resources") {
+  try {
+    return [...new Set(values.map((resource) => (
+      canonicalizePermissionResource(permission, resource)
+    )))].sort();
+  } catch {
+    throw permissionDenied(`${label} are invalid`, { permission });
+  }
+}
+
+function permissionDenied(message, details) {
+  return new PluginRpcError(RPC_ERRORS.permissionDenied, message, {
+    pluginCode: "permission_denied",
+    ...(details === undefined ? {} : { details }),
+  });
+}
+
+function normalizeDecision(decision, requestId) {
+  if (!decision || typeof decision !== "object" || Array.isArray(decision)) {
+    throw permissionDenied("Plugin permission request was not approved");
+  }
+  if (decision.requestId !== requestId) {
+    throw permissionDenied("Plugin permission decision does not match the pending request");
+  }
+  if (decision.decision === "deny" || decision.decision === "cancel") {
+    if (Object.keys(decision).some((key) => key !== "requestId" && key !== "decision")) {
+      throw permissionDenied("Plugin permission decision is invalid");
+    }
+    return Object.freeze({ requestId, decision: decision.decision });
+  }
+  if (decision.decision !== "allow" || !VALID_SCOPES.has(decision.scope)) {
+    throw permissionDenied("Plugin permission decision is invalid");
+  }
+  if (Object.keys(decision).some((key) => (
+    key !== "requestId" && key !== "decision" && key !== "scope" && key !== "resources"
+  ))) throw permissionDenied("Plugin permission decision is invalid");
+  if (
+    decision.resources !== undefined
+    && (!Array.isArray(decision.resources) || decision.resources.length > 128)
+  ) throw permissionDenied("Plugin permission decision resources are invalid");
+  return Object.freeze({
+    requestId,
+    decision: "allow",
+    scope: decision.scope,
+    ...(decision.resources === undefined
+      ? {}
+      : { resources: Object.freeze([...decision.resources]) }),
+  });
+}
+
+function immutableRequest(request) {
+  return Object.freeze({
+    ...request,
+    resources: Object.freeze([...request.resources]),
+  });
+}
+
+class PluginPermissionEngine {
+  constructor(options) {
+    this.database = options.database;
+    this.requestDecision = options.requestDecision ?? null;
+    if (this.requestDecision != null && typeof this.requestDecision !== "function") {
+      throw new TypeError("Plugin permission decision provider must be a function");
+    }
+    this.clock = options.clock ?? (() => Date.now());
+    this.promptTimeoutMs = options.promptTimeoutMs ?? PROMPT_TIMEOUT_MS;
+    this.applicationGrants = new Map();
+    this.sessionGrants = new Map();
+    this.pending = new Map();
+    this.closed = false;
+    this.shutdownController = new AbortController();
+  }
+
+  #grantKey(pluginId, permission, declarationHash, resource) {
+    return `${pluginId}\0${permission}\0${declarationHash}\0${resource}`;
+  }
+
+  #sessionGrantKey(sessionId, grantKey) {
+    return `${sessionId}\0${grantKey}`;
+  }
+
+  #createMemoryGrant(context, permission, declarationHash, resource, scope, sessionId) {
+    return Object.freeze({
+      pluginId: context.pluginId,
+      permission,
+      declarationHash,
+      resource,
+      scope,
+      sessionId: sessionId ?? null,
+      grantedAt: this.clock(),
+    });
+  }
+
+  #memoryGrantCovers(grant, context, permission, declarationHash, resource, sessionId) {
+    return grant.pluginId === context.pluginId
+      && grant.permission === permission
+      && grant.declarationHash === declarationHash
+      && (grant.scope !== "session" || grant.sessionId === sessionId)
+      && permissionResourceCovers(permission, grant.resource, resource);
+  }
+
+  #assertDeclared(context, permission, resources) {
+    const declarations = normalizePermissionDeclarations(context.manifest);
+    const declaration = declarations.get(permission);
+    if (!declaration) {
+      throw permissionDenied(`Plugin did not declare permission: ${permission}`, { permission });
+    }
+    for (const resource of resources) {
+      if (!declarationAllowsResource(declaration, resource)) {
+        throw permissionDenied(`Plugin did not declare permission resource: ${permission}`, {
+          permission,
+          resource,
+        });
+      }
+    }
+    const securityPrincipal = context.securityPrincipal ?? defaultSecurityPrincipal(context.manifest);
+    return {
+      declaration,
+      declarationHash: permissionDeclarationHash(declaration, securityPrincipal),
+      securityPrincipal,
+    };
+  }
+
+  #hasGrant(context, permission, declarationHash, resource, sessionId) {
+    if ([...this.applicationGrants.values()].some((grant) => (
+      this.#memoryGrantCovers(grant, context, permission, declarationHash, resource, sessionId)
+    ))) return true;
+    if (sessionId && [...this.sessionGrants.values()].some((grant) => (
+      this.#memoryGrantCovers(grant, context, permission, declarationHash, resource, sessionId)
+    ))) return true;
+    return this.database.listPermissionGrants(context.pluginId).some((grant) => (
+      grant.permission === permission
+      && grant.declarationHash === declarationHash
+      && permissionResourceCovers(permission, grant.resource, resource)
+    ));
+  }
+
+  #hasAllGrants(context, permission, declarationHash, resources, sessionId) {
+    return resources.every((resource) => this.#hasGrant(
+      context,
+      permission,
+      declarationHash,
+      resource,
+      sessionId,
+    ));
+  }
+
+  async authorize(context, descriptor) {
+    if (this.closed) throw permissionDenied("Plugin permission engine is unavailable");
+    context.signal?.throwIfAborted();
+    const permission = descriptor.permission;
+    if (
+      descriptor.resources !== undefined
+      && (!Array.isArray(descriptor.resources) || descriptor.resources.length > 128)
+    ) throw permissionDenied("Plugin permission resources are invalid");
+    descriptor = Object.freeze({
+      ...descriptor,
+      reason: normalizePermissionReason(descriptor.reason, permission),
+      operationId: normalizePermissionOperationId(descriptor.operationId),
+      sessionId: normalizePermissionSessionId(descriptor.sessionId),
+    });
+    const resources = normalizePermissionResources(
+      permission,
+      descriptor.resources?.length ? descriptor.resources : ["*"],
+    );
+    const { declaration, declarationHash } = this.#assertDeclared(context, permission, resources);
+    if (this.#hasAllGrants(context, permission, declarationHash, resources, descriptor.sessionId)) {
+      if (AUDITED_PERMISSION_USES.has(permission)) {
+        this.database.recordSecurityAudit(context.pluginId, "permission.used", {
+          permission,
+          resources,
+          runtimeId: context.runtimeId ?? null,
+          operationId: descriptor.operationId ?? null,
+        });
+      }
+      return Object.freeze({ declaration, resources, scope: "existing" });
+    }
+    if (descriptor.interactive === false || !this.requestDecision) {
+      this.database.recordSecurityAudit(context.pluginId, "permission.denied", {
+        permission,
+        resources,
+        reason: "no-interactive-approver",
+      });
+      throw permissionDenied(`Plugin permission is not granted: ${permission}`, {
+        permission,
+        resources,
+      });
+    }
+    const pendingKey = JSON.stringify([
+      context.pluginId,
+      context.runtimeId ?? null,
+      permission,
+      declarationHash,
+      resources,
+      descriptor.operationId ?? null,
+      descriptor.sessionId ?? null,
+    ]);
+    let pending = this.pending.get(pendingKey);
+    let ownsPrompt = false;
+    if (!pending) {
+      ownsPrompt = true;
+      pending = this.#requestGrant(context, descriptor, resources, declaration, declarationHash)
+        .finally(() => this.pending.delete(pendingKey));
+      this.pending.set(pendingKey, pending);
+    }
+    const grant = await pending;
+    context.signal?.throwIfAborted();
+    if (!ownsPrompt && grant.scope === "once") {
+      return this.authorize(context, descriptor);
+    }
+    return Object.freeze({ declaration, resources, scope: grant.scope });
+  }
+
+  async #requestGrant(context, descriptor, resources, declaration, declarationHash) {
+    const requestId = randomUUID();
+    const request = immutableRequest({
+      requestId,
+      pluginId: context.pluginId,
+      ...(context.pluginVersion === undefined ? {} : { pluginVersion: context.pluginVersion }),
+      ...(context.manifest?.name === undefined ? {} : { pluginName: context.manifest.name }),
+      ...(context.manifest?.publisher === undefined ? {} : { publisher: context.manifest.publisher }),
+      runtimeId: context.runtimeId ?? null,
+      runtimeKind: context.runtimeKind ?? null,
+      permission: descriptor.permission,
+      resources,
+      reason: descriptor.reason,
+      ...(descriptor.operationId === undefined ? {} : { operationId: descriptor.operationId }),
+      ...(descriptor.sessionId === undefined ? {} : { sessionId: descriptor.sessionId }),
+    });
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(permissionDenied(
+      "Plugin permission request timed out",
+    )), this.promptTimeoutMs);
+    timer.unref?.();
+    const onAbort = () => controller.abort(context.signal.reason);
+    const onShutdown = () => controller.abort(this.shutdownController.signal.reason);
+    context.signal?.addEventListener("abort", onAbort, { once: true });
+    this.shutdownController.signal.addEventListener("abort", onShutdown, { once: true });
+    let rawDecision;
+    try {
+      rawDecision = await raceWithAbort(
+        Promise.resolve(this.requestDecision(request, { signal: controller.signal })),
+        controller.signal,
+      );
+    } catch (error) {
+      this.database.recordSecurityAudit(context.pluginId, "permission.denied", {
+        permission: descriptor.permission,
+        resources,
+        reason: controller.signal.aborted ? "prompt-aborted" : "decision-provider-failed",
+      });
+      if (controller.signal.aborted) throw controller.signal.reason;
+      throw permissionDenied("Plugin permission decision provider failed", {
+        permission: descriptor.permission,
+      });
+    } finally {
+      clearTimeout(timer);
+      context.signal?.removeEventListener("abort", onAbort);
+      this.shutdownController.signal.removeEventListener("abort", onShutdown);
+    }
+    if (this.closed) throw permissionDenied("Plugin permission engine is unavailable");
+    let decision;
+    try {
+      decision = normalizeDecision(rawDecision, requestId);
+    } catch (error) {
+      this.database.recordSecurityAudit(context.pluginId, "permission.denied", {
+        permission: descriptor.permission,
+        resources,
+        reason: "invalid-decision",
+      });
+      throw error;
+    }
+    if (decision.decision !== "allow") {
+      this.database.recordSecurityAudit(context.pluginId, "permission.denied", {
+        permission: descriptor.permission,
+        resources,
+        decision: decision.decision,
+      });
+      const outcome = decision.decision === "deny" ? "denied" : "cancelled";
+      throw permissionDenied(`Plugin permission was ${outcome}: ${descriptor.permission}`);
+    }
+    let decisionResources;
+    try {
+      decisionResources = normalizePermissionResources(
+        descriptor.permission,
+        decision.resources?.length ? decision.resources : resources,
+        "Plugin permission decision resources",
+      );
+    } catch (error) {
+      this.database.recordSecurityAudit(context.pluginId, "permission.denied", {
+        permission: descriptor.permission,
+        resources,
+        reason: "invalid-decision-resources",
+      });
+      throw error;
+    }
+    if (!decisionResources.every((resource) => declarationAllowsResource(declaration, resource))) {
+      throw permissionDenied("Plugin permission decision exceeds the manifest declaration");
+    }
+    if (!resources.every((requested) => decisionResources.some((granted) => (
+      permissionResourceCovers(descriptor.permission, granted, requested)
+    )))) {
+      throw permissionDenied("Plugin permission decision does not cover the requested resources");
+    }
+    if (decision.scope === "session" && !descriptor.sessionId) {
+      throw permissionDenied("Session-scoped plugin permission requires a host-owned session");
+    }
+    for (const resource of decisionResources) {
+      const grantKey = this.#grantKey(
+        context.pluginId,
+        descriptor.permission,
+        declarationHash,
+        resource,
+      );
+      if (decision.scope === "application") {
+        this.applicationGrants.set(grantKey, this.#createMemoryGrant(
+          context,
+          descriptor.permission,
+          declarationHash,
+          resource,
+          decision.scope,
+        ));
+      }
+      if (decision.scope === "session") {
+        this.sessionGrants.set(
+          this.#sessionGrantKey(descriptor.sessionId, grantKey),
+          this.#createMemoryGrant(
+            context,
+            descriptor.permission,
+            declarationHash,
+            resource,
+            decision.scope,
+            descriptor.sessionId,
+          ),
+        );
+      }
+      if (decision.scope === "always") {
+        this.database.upsertPermissionGrant({
+          pluginId: context.pluginId,
+          permission: descriptor.permission,
+          resource,
+          declarationHash,
+        });
+      }
+    }
+    this.database.recordSecurityAudit(context.pluginId, "permission.granted", {
+      permission: descriptor.permission,
+      resources: decisionResources,
+      scope: decision.scope,
+      operationId: descriptor.operationId ?? null,
+    });
+    return decision;
+  }
+
+  async authorizeRequired(plugin, options = {}) {
+    const declarations = normalizePermissionDeclarations(plugin.manifest);
+    const skipPermissions = new Set(options.skipPermissions ?? []);
+    const context = {
+      pluginId: plugin.id,
+      pluginVersion: plugin.activeVersion,
+      runtimeId: options.runtimeId ?? null,
+      manifest: plugin.manifest,
+      securityPrincipal: options.securityPrincipal,
+      signal: options.signal,
+    };
+    for (const declaration of declarations.values()) {
+      if (!declaration.required || skipPermissions.has(declaration.permission)) continue;
+      if (RESOURCE_SCOPED_PERMISSIONS.has(declaration.permission) && declaration.resources.length === 0) {
+        continue;
+      }
+      await this.authorize(context, {
+        permission: declaration.permission,
+        resources: declaration.resources.length ? declaration.resources : ["*"],
+        reason: declaration.reason || `Required by ${plugin.id}`,
+        operationId: `activation:${plugin.activeVersion}`,
+      });
+    }
+  }
+
+  createMiddleware() {
+    return async (context, next) => {
+      if (context.metadata.public === true) return next();
+      if (!context.authorization) {
+        throw permissionDenied(`Plugin host method has no authorization policy: ${context.method}`);
+      }
+      await this.authorize(context, context.authorization);
+      return next();
+    };
+  }
+
+  listGrants(pluginId) {
+    return Object.freeze({
+      always: Object.freeze(this.database.listPermissionGrants(pluginId).map((grant) => (
+        Object.freeze({ ...grant, scope: "always", sessionId: null })
+      ))),
+      application: Object.freeze([...this.applicationGrants.values()].filter((grant) => (
+        grant.pluginId === pluginId
+      ))),
+      session: Object.freeze([...this.sessionGrants.values()].filter((grant) => (
+        grant.pluginId === pluginId
+      ))),
+    });
+  }
+
+  revokeAlways(pluginId, permission, resource) {
+    assertPluginPermission(permission);
+    const canonicalResource = canonicalizePermissionResource(permission, resource);
+    this.database.deletePermissionGrant(
+      pluginId,
+      permission,
+      canonicalResource,
+    );
+    this.database.recordSecurityAudit(pluginId, "permission.revoked", {
+      scope: "always",
+      permission,
+      resource: canonicalResource,
+    });
+  }
+
+  revokeApplication(pluginId, permission, resource) {
+    if (permission !== undefined) assertPluginPermission(permission);
+    if (resource !== undefined && permission === undefined) {
+      throw new TypeError("Revoking a permission resource requires a permission name");
+    }
+    const canonicalResource = resource === undefined
+      ? undefined
+      : canonicalizePermissionResource(permission, resource);
+    for (const [key, grant] of [...this.applicationGrants]) {
+      if (
+        grant.pluginId === pluginId
+        && (permission === undefined || grant.permission === permission)
+        && (canonicalResource === undefined || grant.resource === canonicalResource)
+      ) this.applicationGrants.delete(key);
+    }
+    this.database.recordSecurityAudit(pluginId, "permission.revoked", {
+      scope: "application",
+      ...(permission === undefined ? {} : { permission }),
+      ...(canonicalResource === undefined ? {} : { resource: canonicalResource }),
+    });
+  }
+
+  revokeSession(sessionId) {
+    for (const key of [...this.sessionGrants.keys()]) {
+      if (key.startsWith(`${sessionId}\0`)) this.sessionGrants.delete(key);
+    }
+  }
+
+  revokeAll(pluginId) {
+    this.database.deleteAllPermissionGrants(pluginId);
+    for (const [key, grant] of [...this.applicationGrants]) {
+      if (grant.pluginId === pluginId) this.applicationGrants.delete(key);
+    }
+    for (const [key, grant] of [...this.sessionGrants]) {
+      if (grant.pluginId === pluginId) this.sessionGrants.delete(key);
+    }
+    this.database.recordSecurityAudit(pluginId, "permission.revoked", { scope: "all" });
+  }
+
+  shutdown() {
+    if (this.closed) return;
+    this.closed = true;
+    this.shutdownController.abort(permissionDenied("Plugin permission engine is unavailable"));
+    this.applicationGrants.clear();
+    this.sessionGrants.clear();
+  }
+}
+
+module.exports = {
+  AUDITED_PERMISSION_USES,
+  PROMPT_TIMEOUT_MS,
+  PluginPermissionEngine,
+  normalizePermissionOperationId,
+  normalizePermissionReason,
+  normalizePermissionResources,
+  normalizePermissionSessionId,
+  normalizeDecision,
+  permissionDenied,
+};

--- a/electron/plugins/permissionEngine.cjs
+++ b/electron/plugins/permissionEngine.cjs
@@ -453,7 +453,7 @@ class PluginPermissionEngine {
     try {
       decisionResources = normalizePermissionResources(
         descriptor.permission,
-        decision.resources?.length ? decision.resources : resources,
+        decision.resources === undefined ? resources : decision.resources,
         "Plugin permission decision resources",
       );
     } catch (error) {

--- a/electron/plugins/permissionEngine.cjs
+++ b/electron/plugins/permissionEngine.cjs
@@ -56,10 +56,41 @@ function normalizePermissionSessionId(value) {
 }
 
 function normalizePermissionResources(permission, values, label = "Plugin permission resources") {
+  return normalizePermissionResourceDescriptors(permission, values, undefined, label)
+    .map(({ resource }) => resource);
+}
+
+function normalizePermissionResourceDescriptors(
+  permission,
+  values,
+  resourceKinds,
+  label = "Plugin permission resources",
+) {
   try {
-    return [...new Set(values.map((resource) => (
-      canonicalizePermissionResource(permission, resource)
-    )))].sort();
+    if (
+      resourceKinds !== undefined
+      && (!Array.isArray(resourceKinds) || resourceKinds.length !== values.length)
+    ) throw new TypeError("Resource kinds must align with resources");
+    const descriptors = new Map();
+    for (const [index, value] of values.entries()) {
+      const resource = canonicalizePermissionResource(permission, value);
+      const resourceKind = resourceKinds?.[index] ?? "exact";
+      if (
+        (resourceKind !== "exact" && resourceKind !== "directory")
+        || (resourceKind === "directory"
+          && permission !== "filesystem.read"
+          && permission !== "filesystem.write")
+        || (resource === "*" && resourceKind !== "exact")
+      ) throw new TypeError("Resource kind is invalid");
+      const previous = descriptors.get(resource);
+      if (previous && previous.resourceKind !== resourceKind) {
+        throw new TypeError("Duplicate resources cannot have conflicting kinds");
+      }
+      descriptors.set(resource, Object.freeze({ resource, resourceKind }));
+    }
+    return [...descriptors.values()].sort((left, right) => (
+      left.resource.localeCompare(right.resource, "en")
+    ));
   } catch {
     throw permissionDenied(`${label} are invalid`, { permission });
   }
@@ -109,6 +140,7 @@ function immutableRequest(request) {
   return Object.freeze({
     ...request,
     resources: Object.freeze([...request.resources]),
+    resourceKinds: Object.freeze([...request.resourceKinds]),
   });
 }
 
@@ -136,24 +168,47 @@ class PluginPermissionEngine {
     return `${sessionId}\0${grantKey}`;
   }
 
-  #createMemoryGrant(context, permission, declarationHash, resource, scope, sessionId) {
+  #createMemoryGrant(
+    context,
+    permission,
+    declarationHash,
+    resource,
+    resourceKind,
+    scope,
+    sessionId,
+  ) {
     return Object.freeze({
       pluginId: context.pluginId,
       permission,
       declarationHash,
       resource,
+      resourceKind,
       scope,
       sessionId: sessionId ?? null,
       grantedAt: this.clock(),
     });
   }
 
-  #memoryGrantCovers(grant, context, permission, declarationHash, resource, sessionId) {
+  #memoryGrantCovers(
+    grant,
+    context,
+    permission,
+    declarationHash,
+    resource,
+    resourceKind,
+    sessionId,
+  ) {
     return grant.pluginId === context.pluginId
       && grant.permission === permission
       && grant.declarationHash === declarationHash
       && (grant.scope !== "session" || grant.sessionId === sessionId)
-      && permissionResourceCovers(permission, grant.resource, resource);
+      && permissionResourceCovers(
+        permission,
+        grant.resource,
+        resource,
+        grant.resourceKind,
+        resourceKind,
+      );
   }
 
   #assertDeclared(context, permission, resources) {
@@ -178,26 +233,49 @@ class PluginPermissionEngine {
     };
   }
 
-  #hasGrant(context, permission, declarationHash, resource, sessionId) {
+  #hasGrant(context, permission, declarationHash, resource, resourceKind, sessionId) {
     if ([...this.applicationGrants.values()].some((grant) => (
-      this.#memoryGrantCovers(grant, context, permission, declarationHash, resource, sessionId)
+      this.#memoryGrantCovers(
+        grant,
+        context,
+        permission,
+        declarationHash,
+        resource,
+        resourceKind,
+        sessionId,
+      )
     ))) return true;
     if (sessionId && [...this.sessionGrants.values()].some((grant) => (
-      this.#memoryGrantCovers(grant, context, permission, declarationHash, resource, sessionId)
+      this.#memoryGrantCovers(
+        grant,
+        context,
+        permission,
+        declarationHash,
+        resource,
+        resourceKind,
+        sessionId,
+      )
     ))) return true;
     return this.database.listPermissionGrants(context.pluginId).some((grant) => (
       grant.permission === permission
       && grant.declarationHash === declarationHash
-      && permissionResourceCovers(permission, grant.resource, resource)
+      && permissionResourceCovers(
+        permission,
+        grant.resource,
+        resource,
+        grant.resourceKind,
+        resourceKind,
+      )
     ));
   }
 
-  #hasAllGrants(context, permission, declarationHash, resources, sessionId) {
-    return resources.every((resource) => this.#hasGrant(
+  #hasAllGrants(context, permission, declarationHash, resources, resourceKinds, sessionId) {
+    return resources.every((resource, index) => this.#hasGrant(
       context,
       permission,
       declarationHash,
       resource,
+      resourceKinds[index],
       sessionId,
     ));
   }
@@ -210,22 +288,42 @@ class PluginPermissionEngine {
       descriptor.resources !== undefined
       && (!Array.isArray(descriptor.resources) || descriptor.resources.length > 128)
     ) throw permissionDenied("Plugin permission resources are invalid");
+    if (
+      descriptor.resourceKinds !== undefined
+      && (
+        !Array.isArray(descriptor.resourceKinds)
+        || descriptor.resourceKinds.length > 128
+        || !Array.isArray(descriptor.resources)
+        || descriptor.resourceKinds.length !== descriptor.resources.length
+      )
+    ) throw permissionDenied("Plugin permission resource kinds are invalid");
     descriptor = Object.freeze({
       ...descriptor,
       reason: normalizePermissionReason(descriptor.reason, permission),
       operationId: normalizePermissionOperationId(descriptor.operationId),
       sessionId: normalizePermissionSessionId(descriptor.sessionId),
     });
-    const resources = normalizePermissionResources(
+    const resourceDescriptors = normalizePermissionResourceDescriptors(
       permission,
       descriptor.resources?.length ? descriptor.resources : ["*"],
+      descriptor.resources?.length ? descriptor.resourceKinds : undefined,
     );
+    const resources = resourceDescriptors.map(({ resource }) => resource);
+    const resourceKinds = resourceDescriptors.map(({ resourceKind }) => resourceKind);
     const { declaration, declarationHash } = this.#assertDeclared(context, permission, resources);
-    if (this.#hasAllGrants(context, permission, declarationHash, resources, descriptor.sessionId)) {
+    if (this.#hasAllGrants(
+      context,
+      permission,
+      declarationHash,
+      resources,
+      resourceKinds,
+      descriptor.sessionId,
+    )) {
       if (AUDITED_PERMISSION_USES.has(permission)) {
         this.database.recordSecurityAudit(context.pluginId, "permission.used", {
           permission,
           resources,
+          resourceKinds,
           runtimeId: context.runtimeId ?? null,
           operationId: descriptor.operationId ?? null,
         });
@@ -249,6 +347,7 @@ class PluginPermissionEngine {
       permission,
       declarationHash,
       resources,
+      resourceKinds,
       descriptor.operationId ?? null,
       descriptor.sessionId ?? null,
     ]);
@@ -256,7 +355,14 @@ class PluginPermissionEngine {
     let ownsPrompt = false;
     if (!pending) {
       ownsPrompt = true;
-      pending = this.#requestGrant(context, descriptor, resources, declaration, declarationHash)
+      pending = this.#requestGrant(
+        context,
+        descriptor,
+        resources,
+        resourceKinds,
+        declaration,
+        declarationHash,
+      )
         .finally(() => this.pending.delete(pendingKey));
       this.pending.set(pendingKey, pending);
     }
@@ -268,7 +374,14 @@ class PluginPermissionEngine {
     return Object.freeze({ declaration, resources, scope: grant.scope });
   }
 
-  async #requestGrant(context, descriptor, resources, declaration, declarationHash) {
+  async #requestGrant(
+    context,
+    descriptor,
+    resources,
+    resourceKinds,
+    declaration,
+    declarationHash,
+  ) {
     const requestId = randomUUID();
     const request = immutableRequest({
       requestId,
@@ -280,6 +393,7 @@ class PluginPermissionEngine {
       runtimeKind: context.runtimeKind ?? null,
       permission: descriptor.permission,
       resources,
+      resourceKinds,
       reason: descriptor.reason,
       ...(descriptor.operationId === undefined ? {} : { operationId: descriptor.operationId }),
       ...(descriptor.sessionId === undefined ? {} : { sessionId: descriptor.sessionId }),
@@ -353,15 +467,28 @@ class PluginPermissionEngine {
     if (!decisionResources.every((resource) => declarationAllowsResource(declaration, resource))) {
       throw permissionDenied("Plugin permission decision exceeds the manifest declaration");
     }
-    if (!resources.every((requested) => decisionResources.some((granted) => (
-      permissionResourceCovers(descriptor.permission, granted, requested)
+    const decisionResourceDescriptors = decisionResources.map((resource) => {
+      const requestedIndex = resources.indexOf(resource);
+      return Object.freeze({
+        resource,
+        resourceKind: requestedIndex === -1 ? "exact" : resourceKinds[requestedIndex],
+      });
+    });
+    if (!resources.every((requested) => decisionResourceDescriptors.some((granted) => (
+      permissionResourceCovers(
+        descriptor.permission,
+        granted.resource,
+        requested,
+        granted.resourceKind,
+        resourceKinds[resources.indexOf(requested)],
+      )
     )))) {
       throw permissionDenied("Plugin permission decision does not cover the requested resources");
     }
     if (decision.scope === "session" && !descriptor.sessionId) {
       throw permissionDenied("Session-scoped plugin permission requires a host-owned session");
     }
-    for (const resource of decisionResources) {
+    for (const { resource, resourceKind } of decisionResourceDescriptors) {
       const grantKey = this.#grantKey(
         context.pluginId,
         descriptor.permission,
@@ -374,6 +501,7 @@ class PluginPermissionEngine {
           descriptor.permission,
           declarationHash,
           resource,
+          resourceKind,
           decision.scope,
         ));
       }
@@ -385,6 +513,7 @@ class PluginPermissionEngine {
             descriptor.permission,
             declarationHash,
             resource,
+            resourceKind,
             decision.scope,
             descriptor.sessionId,
           ),
@@ -395,6 +524,7 @@ class PluginPermissionEngine {
           pluginId: context.pluginId,
           permission: descriptor.permission,
           resource,
+          resourceKind,
           declarationHash,
         });
       }
@@ -402,6 +532,7 @@ class PluginPermissionEngine {
     this.database.recordSecurityAudit(context.pluginId, "permission.granted", {
       permission: descriptor.permission,
       resources: decisionResources,
+      resourceKinds: decisionResourceDescriptors.map(({ resourceKind }) => resourceKind),
       scope: decision.scope,
       operationId: descriptor.operationId ?? null,
     });
@@ -527,6 +658,7 @@ module.exports = {
   PluginPermissionEngine,
   normalizePermissionOperationId,
   normalizePermissionReason,
+  normalizePermissionResourceDescriptors,
   normalizePermissionResources,
   normalizePermissionSessionId,
   normalizeDecision,

--- a/electron/plugins/permissionEngine.test.cjs
+++ b/electron/plugins/permissionEngine.test.cjs
@@ -470,6 +470,41 @@ test("required preflight grants non-resource permissions but defers concrete res
   database.close();
 });
 
+test("required filesystem preflight preserves declared directory scope", async (context) => {
+  const database = createDatabase(context);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-required-directory-"));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const child = path.join(root, "child.txt");
+  let prompts = 0;
+  const requests = [];
+  const engine = new PluginPermissionEngine({
+    database,
+    requestDecision: async (request) => {
+      prompts += 1;
+      requests.push(request);
+      return { requestId: request.requestId, decision: "allow", scope: "application" };
+    },
+  });
+  const pluginManifest = manifest({ required: [{
+    permission: "filesystem.read",
+    resources: [root],
+  }] });
+  await engine.authorizeRequired({
+    id: pluginManifest.id,
+    activeVersion: pluginManifest.version,
+    manifest: pluginManifest,
+  });
+  assert.deepEqual(requests[0].resourceKinds, ["directory"]);
+  await engine.authorize(runtimeContext(pluginManifest), {
+    permission: "filesystem.read",
+    resources: [child],
+    resourceKinds: ["exact"],
+    reason: "Read declared descendant",
+  });
+  assert.equal(prompts, 1);
+  database.close();
+});
+
 test("permission middleware rejects unclassified methods and permits explicit public methods", async (context) => {
   const database = createDatabase(context);
   const engine = new PluginPermissionEngine({ database });

--- a/electron/plugins/permissionEngine.test.cjs
+++ b/electron/plugins/permissionEngine.test.cjs
@@ -118,6 +118,27 @@ test("permission decisions cannot persist resources broader than the manifest de
   database.close();
 });
 
+test("an explicit empty allow-decision never widens to every requested resource", async (context) => {
+  const database = createDatabase(context);
+  const engine = new PluginPermissionEngine({
+    database,
+    requestDecision: async (request) => ({
+      requestId: request.requestId,
+      decision: "allow",
+      scope: "always",
+      resources: [],
+    }),
+  });
+  const pluginManifest = manifest({ optional: ["storage"] });
+  await assert.rejects(engine.authorize(runtimeContext(pluginManifest), {
+    permission: "storage",
+    resources: ["*"],
+    reason: "Use storage",
+  }), /does not cover the requested resources/);
+  assert.equal(database.listPermissionGrants(pluginManifest.id).length, 0);
+  database.close();
+});
+
 test("application grants can be listed and revoked for the permission UI", async (context) => {
   const database = createDatabase(context);
   let prompts = 0;

--- a/electron/plugins/permissionEngine.test.cjs
+++ b/electron/plugins/permissionEngine.test.cjs
@@ -447,7 +447,7 @@ test("session grants require a host-owned session identifier", async (context) =
   database.close();
 });
 
-test("required preflight rejects resource-scoped permissions without activation bounds", async (context) => {
+test("required preflight rejects missing or wildcard resource-scoped activation bounds", async (context) => {
   const database = createDatabase(context);
   const requested = [];
   const engine = new PluginPermissionEngine({
@@ -463,6 +463,12 @@ test("required preflight rejects resource-scoped permissions without activation 
     activeVersion: pluginManifest.version,
     manifest: pluginManifest,
   }), /must declare resources/u);
+  const wildcardManifest = manifest({ required: [{ permission: "network", resources: ["*"] }] });
+  await assert.rejects(engine.authorizeRequired({
+    id: wildcardManifest.id,
+    activeVersion: wildcardManifest.version,
+    manifest: wildcardManifest,
+  }), /must not use wildcard resources/u);
   assert.deepEqual(requested, []);
   database.close();
 });

--- a/electron/plugins/permissionEngine.test.cjs
+++ b/electron/plugins/permissionEngine.test.cjs
@@ -1,0 +1,411 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { createDefinitionValidator } = require("./contractValidator.cjs");
+const { PluginDatabase } = require("./database.cjs");
+const { PluginPermissionEngine } = require("./permissionEngine.cjs");
+const {
+  canonicalizeNetworkOrigin,
+  defaultSecurityPrincipal,
+  permissionResourceCovers,
+} = require("./permissionResources.cjs");
+const { RPC_ERRORS } = require("./rpcRouter.cjs");
+
+function createDatabase(context) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-permissions-"));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return new PluginDatabase(path.join(root, "plugins.sqlite"));
+}
+
+function manifest(permissions) {
+  return {
+    manifestVersion: 1,
+    id: "com.example.permissions",
+    name: "permissions",
+    version: "1.0.0",
+    publisher: "example",
+    engines: { netcatty: ">=0.0.0", api: ">=0.1.0-internal <0.2.0" },
+    main: { browser: "index.js" },
+    permissions,
+  };
+}
+
+function runtimeContext(pluginManifest, overrides = {}) {
+  return {
+    pluginId: pluginManifest.id,
+    pluginVersion: pluginManifest.version,
+    runtimeId: "runtime-1",
+    runtimeKind: "browser",
+    manifest: pluginManifest,
+    signal: new AbortController().signal,
+    ...overrides,
+  };
+}
+
+test("permission declarations are not grants and no renderer fails closed", async (context) => {
+  const database = createDatabase(context);
+  const engine = new PluginPermissionEngine({ database });
+  const pluginManifest = manifest({ required: ["storage"] });
+  await assert.rejects(
+    engine.authorize(runtimeContext(pluginManifest), {
+      permission: "storage",
+      resources: ["*"],
+      reason: "Use storage",
+    }),
+    (error) => error.code === RPC_ERRORS.permissionDenied,
+  );
+  assert.equal(database.listPermissionGrants(pluginManifest.id).length, 0);
+  assert.equal(database.listSecurityAudit(pluginManifest.id)[0].event, "permission.denied");
+  database.close();
+});
+
+test("always grants are declaration-bound and reusable until permission semantics change", async (context) => {
+  const database = createDatabase(context);
+  let prompts = 0;
+  const engine = new PluginPermissionEngine({
+    database,
+    requestDecision: async (request) => {
+      prompts += 1;
+      return { requestId: request.requestId, decision: "allow", scope: "always" };
+    },
+  });
+  const optional = manifest({ optional: ["storage"] });
+  const descriptor = { permission: "storage", resources: ["*"], reason: "Use storage" };
+  await engine.authorize(runtimeContext(optional), descriptor);
+  await engine.authorize(runtimeContext(optional), descriptor);
+  assert.equal(prompts, 1);
+  assert.equal(database.listPermissionGrants(optional.id).length, 1);
+
+  const required = manifest({ required: ["storage"] });
+  await engine.authorize(runtimeContext(required), descriptor);
+  assert.equal(prompts, 2, "optional-to-required changes require a fresh decision");
+  const newPublisher = { ...required, publisher: "different-publisher" };
+  await engine.authorize(runtimeContext(newPublisher), descriptor);
+  assert.equal(prompts, 3, "a different security principal requires a fresh decision");
+  database.close();
+});
+
+test("permission decisions cannot persist resources broader than the manifest declaration", async (context) => {
+  const database = createDatabase(context);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-declared-root-"));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const file = path.join(root, "file.txt");
+  fs.writeFileSync(file, "hello");
+  const engine = new PluginPermissionEngine({
+    database,
+    requestDecision: async (request) => ({
+      requestId: request.requestId,
+      decision: "allow",
+      scope: "always",
+      resources: [path.dirname(root)],
+    }),
+  });
+  const pluginManifest = manifest({ optional: [{
+    permission: "filesystem.read",
+    resources: [root],
+  }] });
+  await assert.rejects(engine.authorize(runtimeContext(pluginManifest), {
+    permission: "filesystem.read",
+    resources: [file],
+    reason: "Read file",
+  }), /exceeds the manifest declaration/);
+  assert.equal(database.listPermissionGrants(pluginManifest.id).length, 0);
+  database.close();
+});
+
+test("application grants can be listed and revoked for the permission UI", async (context) => {
+  const database = createDatabase(context);
+  let prompts = 0;
+  const engine = new PluginPermissionEngine({
+    database,
+    requestDecision: async (request) => {
+      prompts += 1;
+      return { requestId: request.requestId, decision: "allow", scope: "application" };
+    },
+  });
+  const pluginManifest = manifest({ optional: ["storage"] });
+  const descriptor = { permission: "storage", resources: ["*"], reason: "Storage" };
+  await engine.authorize(runtimeContext(pluginManifest), descriptor);
+  assert.equal(engine.listGrants(pluginManifest.id).application[0].permission, "storage");
+  engine.revokeApplication(pluginManifest.id, "storage", "*");
+  await engine.authorize(runtimeContext(pluginManifest), descriptor);
+  assert.equal(prompts, 2);
+  engine.revokeAll(pluginManifest.id);
+  assert.deepEqual(engine.listGrants(pluginManifest.id), {
+    always: [],
+    application: [],
+    session: [],
+  });
+  database.close();
+});
+
+test("permission decision provider failures are audited and fail closed", async (context) => {
+  const database = createDatabase(context);
+  const engine = new PluginPermissionEngine({
+    database,
+    requestDecision: async () => { throw new Error("renderer crashed"); },
+  });
+  const pluginManifest = manifest({ optional: ["storage"] });
+  await assert.rejects(engine.authorize(runtimeContext(pluginManifest), {
+    permission: "storage",
+    resources: ["*"],
+    reason: "Storage",
+  }), /decision provider failed/);
+  assert.equal(database.listSecurityAudit(pluginManifest.id)[0].details.reason, "decision-provider-failed");
+  database.close();
+});
+
+test("permission decision providers cannot bypass the canonical decision shape", async (context) => {
+  const database = createDatabase(context);
+  const pluginManifest = manifest({ optional: ["storage"] });
+  const descriptor = { permission: "storage", resources: ["*"], reason: "Storage" };
+  for (const decision of [
+    { decision: "allow", scope: "always", resources: { 0: "*", length: 1 } },
+    { decision: "allow", scope: "always", resources: Array(129).fill("*") },
+    { decision: "allow", scope: "always", resources: ["x".repeat(9_000)] },
+    { decision: "deny", scope: "always" },
+  ]) {
+    const engine = new PluginPermissionEngine({
+      database,
+      requestDecision: async (request) => ({ requestId: request.requestId, ...decision }),
+    });
+    await assert.rejects(engine.authorize(runtimeContext(pluginManifest), descriptor), /decision/);
+  }
+  assert.equal(database.listPermissionGrants(pluginManifest.id).length, 0);
+  database.close();
+});
+
+test("permission requests stay inside the canonical UI contract bounds", async (context) => {
+  const database = createDatabase(context);
+  let captured;
+  const engine = new PluginPermissionEngine({
+    database,
+    requestDecision: async (request) => {
+      captured = request;
+      return { requestId: request.requestId, decision: "deny" };
+    },
+  });
+  const pluginManifest = manifest({ optional: ["storage"] });
+  await assert.rejects(engine.authorize(runtimeContext(pluginManifest), {
+    permission: "storage",
+    resources: ["*"],
+    reason: "r".repeat(2_048),
+    operationId: `filesystem:${"p".repeat(2_048)}`,
+  }), /denied/);
+  assert.equal(captured.reason.length, 1_024);
+  assert.match(captured.operationId, /^sha256:[a-f0-9]{64}$/u);
+  assert.equal(Object.hasOwn(captured, "sessionId"), false);
+  assert.equal(Object.isFrozen(captured), true);
+  const validateRequest = createDefinitionValidator("PermissionRequest");
+  assert.equal(validateRequest(captured), true, JSON.stringify(validateRequest.errors));
+  await assert.rejects(engine.authorize(runtimeContext(pluginManifest), {
+    permission: "storage",
+    resources: Array(129).fill("*"),
+    reason: "Too many resources",
+  }), /resources are invalid/);
+  await assert.rejects(engine.authorize(runtimeContext(pluginManifest), {
+    permission: "storage",
+    resources: ["*"],
+    reason: "Invalid session",
+    sessionId: "bad\0session",
+  }), /session ID is invalid/);
+  database.close();
+});
+
+test("coalesced prompts do not widen a once decision to concurrent callers", async (context) => {
+  const database = createDatabase(context);
+  let prompts = 0;
+  const decisions = [];
+  const engine = new PluginPermissionEngine({
+    database,
+    requestDecision: (request) => {
+      prompts += 1;
+      return new Promise((resolve) => decisions.push(() => resolve({
+        requestId: request.requestId,
+        decision: "allow",
+        scope: "once",
+      })));
+    },
+  });
+  const pluginManifest = manifest({ optional: ["storage"] });
+  const descriptor = {
+    permission: "storage",
+    resources: ["*"],
+    reason: "Storage",
+    operationId: "storage:concurrent",
+  };
+  const first = engine.authorize(runtimeContext(pluginManifest), descriptor);
+  const second = engine.authorize(runtimeContext(pluginManifest), descriptor);
+  assert.equal(prompts, 1);
+  decisions.shift()();
+  await first;
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(prompts, 2);
+  decisions.shift()();
+  await second;
+  database.close();
+});
+
+test("permission shutdown aborts pending prompts before grants can persist", async (context) => {
+  const database = createDatabase(context);
+  let resolveDecision;
+  const engine = new PluginPermissionEngine({
+    database,
+    requestDecision: (request) => new Promise((resolve) => {
+      resolveDecision = () => resolve({
+        requestId: request.requestId,
+        decision: "allow",
+        scope: "always",
+      });
+    }),
+  });
+  const pluginManifest = manifest({ optional: ["storage"] });
+  const pending = engine.authorize(runtimeContext(pluginManifest), {
+    permission: "storage",
+    resources: ["*"],
+    reason: "Storage",
+  });
+  engine.shutdown();
+  resolveDecision();
+  await assert.rejects(pending, /unavailable/);
+  assert.equal(database.listPermissionGrants(pluginManifest.id).length, 0);
+  database.close();
+});
+
+for (const scope of ["application", "session", "always"]) {
+test(`${scope} resource grants canonicalize origins and cover filesystem descendants`, async (context) => {
+  const database = createDatabase(context);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-permission-root-"));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const child = path.join(root, "child", "file.txt");
+  fs.mkdirSync(path.dirname(child), { recursive: true });
+  fs.writeFileSync(child, "hello");
+  let prompts = 0;
+  const engine = new PluginPermissionEngine({
+    database,
+    requestDecision: async (request) => {
+      prompts += 1;
+      return {
+        requestId: request.requestId,
+        decision: "allow",
+        scope,
+        resources: request.permission === "filesystem.read" ? [root] : request.resources,
+      };
+    },
+  });
+  const pluginManifest = manifest({ optional: ["network", "filesystem.read"] });
+  await engine.authorize(runtimeContext(pluginManifest), {
+    permission: "network",
+    resources: ["HTTPS://EXAMPLE.COM:443"],
+    reason: "Network",
+    ...(scope === "session" ? { sessionId: "terminal-session-1" } : {}),
+  });
+  if (scope === "always") {
+    assert.equal(database.listPermissionGrants(pluginManifest.id)[0].resource, "https://example.com");
+  }
+  await engine.authorize(runtimeContext(pluginManifest), {
+    permission: "filesystem.read",
+    resources: [child],
+    reason: "Read file",
+    ...(scope === "session" ? { sessionId: "terminal-session-1" } : {}),
+  });
+  const promptsBeforeDescendant = prompts;
+  await engine.authorize(runtimeContext(pluginManifest), {
+    permission: "filesystem.read",
+    resources: [child],
+    reason: "Read descendant again",
+    ...(scope === "session" ? { sessionId: "terminal-session-1" } : {}),
+  });
+  assert.equal(prompts, promptsBeforeDescendant);
+  assert.equal(permissionResourceCovers("filesystem.read", root, child), true);
+  assert.equal(permissionResourceCovers("filesystem.read", root, `${root}-outside`), false);
+  assert.equal(canonicalizeNetworkOrigin("https://example.com/"), "https://example.com");
+  assert.throws(() => canonicalizeNetworkOrigin("https://example.com/path"), /without credentials or a path/);
+  database.close();
+});
+}
+
+test("companion resources accept canonical contribution identifiers", () => {
+  const { canonicalizeCompanionResource } = require("./permissionResources.cjs");
+  assert.equal(
+    canonicalizeCompanionResource("com.example2.plugin.helper.process"),
+    "com.example2.plugin.helper.process",
+  );
+  assert.throws(() => canonicalizeCompanionResource("com.example"));
+  const pluginManifest = manifest({ optional: [] });
+  const firstPackage = defaultSecurityPrincipal(pluginManifest, "a".repeat(64));
+  const secondPackage = defaultSecurityPrincipal(pluginManifest, "b".repeat(64));
+  assert.notEqual(firstPackage, secondPackage, "unsigned package updates cannot inherit grants");
+  assert.match(firstPackage, /^unsigned-package:/u);
+});
+
+test("session grants require a host-owned session identifier", async (context) => {
+  const database = createDatabase(context);
+  const engine = new PluginPermissionEngine({
+    database,
+    requestDecision: async (request) => ({
+      requestId: request.requestId,
+      decision: "allow",
+      scope: "session",
+    }),
+  });
+  const pluginManifest = manifest({ optional: ["terminal.metadata"] });
+  await assert.rejects(engine.authorize(runtimeContext(pluginManifest), {
+    permission: "terminal.metadata",
+    resources: ["*"] ,
+    reason: "Read terminal metadata",
+  }), /host-owned session/);
+  await engine.authorize(runtimeContext(pluginManifest), {
+    permission: "terminal.metadata",
+    resources: ["*"],
+    reason: "Read terminal metadata",
+    sessionId: "terminal-session-1",
+  });
+  engine.revokeSession("terminal-session-1");
+  database.close();
+});
+
+test("required preflight grants non-resource permissions but defers concrete resource choices", async (context) => {
+  const database = createDatabase(context);
+  const requested = [];
+  const engine = new PluginPermissionEngine({
+    database,
+    requestDecision: async (request) => {
+      requested.push(request.permission);
+      return { requestId: request.requestId, decision: "allow", scope: "application" };
+    },
+  });
+  const pluginManifest = {
+    ...manifest({ required: ["runtime.advanced", "network"] }),
+    main: { node: "index.js" },
+  };
+  await engine.authorizeRequired({
+    id: pluginManifest.id,
+    activeVersion: pluginManifest.version,
+    manifest: pluginManifest,
+  });
+  assert.deepEqual(requested, ["runtime.advanced"]);
+  database.close();
+});
+
+test("permission middleware rejects unclassified methods and permits explicit public methods", async (context) => {
+  const database = createDatabase(context);
+  const engine = new PluginPermissionEngine({ database });
+  const middleware = engine.createMiddleware();
+  await assert.rejects(middleware({
+    pluginId: "com.example.permissions",
+    method: "unclassified.method",
+    metadata: {},
+  }, async () => null), /no authorization policy/);
+  assert.equal(await middleware({
+    pluginId: "com.example.permissions",
+    method: "log.write",
+    metadata: { public: true },
+  }, async () => "ok"), "ok");
+  database.close();
+});

--- a/electron/plugins/permissionEngine.test.cjs
+++ b/electron/plugins/permissionEngine.test.cjs
@@ -447,7 +447,7 @@ test("session grants require a host-owned session identifier", async (context) =
   database.close();
 });
 
-test("required preflight grants non-resource permissions but defers concrete resource choices", async (context) => {
+test("required preflight rejects resource-scoped permissions without activation bounds", async (context) => {
   const database = createDatabase(context);
   const requested = [];
   const engine = new PluginPermissionEngine({
@@ -457,8 +457,31 @@ test("required preflight grants non-resource permissions but defers concrete res
       return { requestId: request.requestId, decision: "allow", scope: "application" };
     },
   });
+  const pluginManifest = manifest({ required: ["network"] });
+  await assert.rejects(engine.authorizeRequired({
+    id: pluginManifest.id,
+    activeVersion: pluginManifest.version,
+    manifest: pluginManifest,
+  }), /must declare resources/u);
+  assert.deepEqual(requested, []);
+  database.close();
+});
+
+test("required preflight prompts for non-resource permissions and bounded resources", async (context) => {
+  const database = createDatabase(context);
+  const requested = [];
+  const engine = new PluginPermissionEngine({
+    database,
+    requestDecision: async (request) => {
+      requested.push({ permission: request.permission, resources: request.resources });
+      return { requestId: request.requestId, decision: "allow", scope: "application" };
+    },
+  });
   const pluginManifest = {
-    ...manifest({ required: ["runtime.advanced", "network"] }),
+    ...manifest({ required: [
+      "runtime.advanced",
+      { permission: "network", resources: ["https://example.com"] },
+    ] }),
     main: { node: "index.js" },
   };
   await engine.authorizeRequired({
@@ -466,7 +489,10 @@ test("required preflight grants non-resource permissions but defers concrete res
     activeVersion: pluginManifest.version,
     manifest: pluginManifest,
   });
-  assert.deepEqual(requested, ["runtime.advanced"]);
+  assert.deepEqual(requested, [
+    { permission: "runtime.advanced", resources: ["*"] },
+    { permission: "network", resources: ["https://example.com"] },
+  ]);
   database.close();
 });
 

--- a/electron/plugins/permissionEngine.test.cjs
+++ b/electron/plugins/permissionEngine.test.cjs
@@ -201,6 +201,8 @@ test("permission requests stay inside the canonical UI contract bounds", async (
   assert.match(captured.operationId, /^sha256:[a-f0-9]{64}$/u);
   assert.equal(Object.hasOwn(captured, "sessionId"), false);
   assert.equal(Object.isFrozen(captured), true);
+  assert.deepEqual(captured.resourceKinds, ["exact"]);
+  assert.equal(Object.isFrozen(captured.resourceKinds), true);
   const validateRequest = createDefinitionValidator("PermissionRequest");
   assert.equal(validateRequest(captured), true, JSON.stringify(validateRequest.errors));
   await assert.rejects(engine.authorize(runtimeContext(pluginManifest), {
@@ -208,6 +210,12 @@ test("permission requests stay inside the canonical UI contract bounds", async (
     resources: Array(129).fill("*"),
     reason: "Too many resources",
   }), /resources are invalid/);
+  await assert.rejects(engine.authorize(runtimeContext(pluginManifest), {
+    permission: "storage",
+    resources: ["*"],
+    resourceKinds: [],
+    reason: "Misaligned resource kinds",
+  }), /resource kinds are invalid/);
   await assert.rejects(engine.authorize(runtimeContext(pluginManifest), {
     permission: "storage",
     resources: ["*"],
@@ -278,7 +286,7 @@ test("permission shutdown aborts pending prompts before grants can persist", asy
 });
 
 for (const scope of ["application", "session", "always"]) {
-test(`${scope} resource grants canonicalize origins and cover filesystem descendants`, async (context) => {
+test(`${scope} directory grants canonicalize origins and cover filesystem descendants`, async (context) => {
   const database = createDatabase(context);
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-permission-root-"));
   context.after(() => fs.rmSync(root, { recursive: true, force: true }));
@@ -294,7 +302,6 @@ test(`${scope} resource grants canonicalize origins and cover filesystem descend
         requestId: request.requestId,
         decision: "allow",
         scope,
-        resources: request.permission === "filesystem.read" ? [root] : request.resources,
       };
     },
   });
@@ -310,8 +317,9 @@ test(`${scope} resource grants canonicalize origins and cover filesystem descend
   }
   await engine.authorize(runtimeContext(pluginManifest), {
     permission: "filesystem.read",
-    resources: [child],
-    reason: "Read file",
+    resources: [root],
+    resourceKinds: ["directory"],
+    reason: "Read directory",
     ...(scope === "session" ? { sessionId: "terminal-session-1" } : {}),
   });
   const promptsBeforeDescendant = prompts;
@@ -322,13 +330,61 @@ test(`${scope} resource grants canonicalize origins and cover filesystem descend
     ...(scope === "session" ? { sessionId: "terminal-session-1" } : {}),
   });
   assert.equal(prompts, promptsBeforeDescendant);
-  assert.equal(permissionResourceCovers("filesystem.read", root, child), true);
-  assert.equal(permissionResourceCovers("filesystem.read", root, `${root}-outside`), false);
+  assert.equal(permissionResourceCovers("filesystem.read", root, child), false);
+  assert.equal(permissionResourceCovers("filesystem.read", root, child, "directory"), true);
+  assert.equal(permissionResourceCovers("filesystem.read", root, `${root}-outside`, "directory"), false);
   assert.equal(canonicalizeNetworkOrigin("https://example.com/"), "https://example.com");
   assert.throws(() => canonicalizeNetworkOrigin("https://example.com/path"), /without credentials or a path/);
   database.close();
 });
 }
+
+test("an exact file grant cannot become a directory subtree grant after replacement", async (context) => {
+  const database = createDatabase(context);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-permission-file-"));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const selected = path.join(root, "selected");
+  fs.writeFileSync(selected, "file");
+  let prompts = 0;
+  const engine = new PluginPermissionEngine({
+    database,
+    requestDecision: async (request) => {
+      prompts += 1;
+      return { requestId: request.requestId, decision: "allow", scope: "always" };
+    },
+  });
+  const pluginManifest = manifest({ optional: [{
+    permission: "filesystem.read",
+    resources: [root],
+  }] });
+  await engine.authorize(runtimeContext(pluginManifest), {
+    permission: "filesystem.read",
+    resources: [selected],
+    resourceKinds: ["exact"],
+    reason: "Read file",
+  });
+  fs.rmSync(selected);
+  fs.mkdirSync(selected);
+  const child = path.join(selected, "child.txt");
+  fs.writeFileSync(child, "child");
+  await engine.authorize(runtimeContext(pluginManifest), {
+    permission: "filesystem.read",
+    resources: [selected],
+    resourceKinds: ["directory"],
+    reason: "Read replacement directory",
+  });
+  await engine.authorize(runtimeContext(pluginManifest), {
+    permission: "filesystem.read",
+    resources: [child],
+    resourceKinds: ["exact"],
+    reason: "Read replacement child",
+  });
+  assert.equal(prompts, 2);
+  assert.deepEqual(database.listPermissionGrants(pluginManifest.id).map((grant) => (
+    [grant.resource, grant.resourceKind]
+  )), [[selected, "directory"]]);
+  database.close();
+});
 
 test("companion resources accept canonical contribution identifiers", () => {
   const { canonicalizeCompanionResource } = require("./permissionResources.cjs");

--- a/electron/plugins/permissionResources.cjs
+++ b/electron/plugins/permissionResources.cjs
@@ -6,12 +6,9 @@ const path = require("node:path");
 const contractSchema = require("./generated/plugin-contract.schema.json");
 
 const PLUGIN_PERMISSIONS = new Set(contractSchema.$defs.PluginPermission.enum);
-const RESOURCE_SCOPED_PERMISSIONS = new Set([
-  "network",
-  "filesystem.read",
-  "filesystem.write",
-  "companion.execute",
-]);
+const RESOURCE_SCOPED_PERMISSIONS = new Set(
+  contractSchema.$defs.ResourceScopedPermission.enum,
+);
 
 function assertPluginPermission(permission) {
   if (!PLUGIN_PERMISSIONS.has(permission)) {
@@ -115,8 +112,13 @@ function normalizePermissionDeclarations(manifest) {
         : [...new Set((value.resources ?? []).map((resource) => (
             canonicalizePermissionResource(permission, resource)
           )))].sort();
-      if (required && RESOURCE_SCOPED_PERMISSIONS.has(permission) && resources.length === 0) {
-        throw new TypeError(`Required permission ${permission} must declare resources`);
+      if (required && RESOURCE_SCOPED_PERMISSIONS.has(permission)) {
+        if (resources.length === 0) {
+          throw new TypeError(`Required permission ${permission} must declare resources`);
+        }
+        if (resources.includes("*")) {
+          throw new TypeError(`Required permission ${permission} must not use wildcard resources`);
+        }
       }
       declarations.set(permission, Object.freeze({
         permission,

--- a/electron/plugins/permissionResources.cjs
+++ b/electron/plugins/permissionResources.cjs
@@ -1,0 +1,178 @@
+"use strict";
+
+const { createHash } = require("node:crypto");
+const path = require("node:path");
+
+const contractSchema = require("./generated/plugin-contract.schema.json");
+
+const PLUGIN_PERMISSIONS = new Set(contractSchema.$defs.PluginPermission.enum);
+const RESOURCE_SCOPED_PERMISSIONS = new Set([
+  "network",
+  "filesystem.read",
+  "filesystem.write",
+  "companion.execute",
+]);
+
+function assertPluginPermission(permission) {
+  if (!PLUGIN_PERMISSIONS.has(permission)) {
+    throw new TypeError(`Unknown plugin permission: ${String(permission)}`);
+  }
+  return permission;
+}
+
+function canonicalizeNetworkOrigin(value) {
+  if (typeof value !== "string" || value.length < 1 || value.length > 2_048) {
+    throw new TypeError("Plugin network origin is invalid");
+  }
+  let parsed;
+  try { parsed = new URL(value); }
+  catch { throw new TypeError("Plugin network origin is invalid"); }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new TypeError("Plugin network access supports only HTTP and HTTPS origins");
+  }
+  if (
+    parsed.username
+    || parsed.password
+    || (parsed.pathname !== "" && parsed.pathname !== "/")
+    || parsed.search
+    || parsed.hash
+  ) throw new TypeError("Plugin network grants must contain an origin without credentials or a path");
+  return parsed.origin;
+}
+
+function canonicalizeCompanionResource(value) {
+  if (
+    typeof value !== "string"
+    || value.length < 5
+    || value.length > 192
+    || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+\.[A-Za-z][A-Za-z0-9_-]*(?:\.[A-Za-z][A-Za-z0-9_-]*)*$/u.test(value)
+  ) throw new TypeError("Plugin companion resource is invalid");
+  return value;
+}
+
+function canonicalizeFilesystemResource(value) {
+  if (
+    typeof value !== "string"
+    || value.length < 1
+    || value.length > 8_192
+    || value.includes("\0")
+    || !path.isAbsolute(value)
+  ) {
+    throw new TypeError("Plugin filesystem grants require an absolute canonical path");
+  }
+  return path.normalize(value);
+}
+
+function canonicalizePermissionResource(permission, resource) {
+  assertPluginPermission(permission);
+  if (resource === "*") return resource;
+  if (permission === "network") return canonicalizeNetworkOrigin(resource);
+  if (permission === "companion.execute") return canonicalizeCompanionResource(resource);
+  if (permission === "filesystem.read" || permission === "filesystem.write") {
+    return canonicalizeFilesystemResource(resource);
+  }
+  if (typeof resource !== "string" || resource.length < 1 || resource.length > 2_048) {
+    throw new TypeError("Plugin permission resource is invalid");
+  }
+  return resource;
+}
+
+function normalizeForFilesystemComparison(value) {
+  const normalized = path.resolve(value);
+  return process.platform === "win32" ? normalized.toLocaleLowerCase("en-US") : normalized;
+}
+
+function permissionResourceCovers(permission, grantResource, requestedResource) {
+  if (grantResource === "*") return true;
+  if (permission === "filesystem.read" || permission === "filesystem.write") {
+    const parent = normalizeForFilesystemComparison(grantResource);
+    const candidate = normalizeForFilesystemComparison(requestedResource);
+    const relative = path.relative(parent, candidate);
+    return relative === ""
+      || (!path.isAbsolute(relative) && relative !== ".." && !relative.startsWith(`..${path.sep}`));
+  }
+  return grantResource === requestedResource;
+}
+
+function normalizePermissionDeclarations(manifest) {
+  const declarations = new Map();
+  for (const [required, values] of [
+    [true, manifest?.permissions?.required ?? []],
+    [false, manifest?.permissions?.optional ?? []],
+  ]) {
+    for (const value of values) {
+      const permission = assertPluginPermission(typeof value === "string" ? value : value.permission);
+      const resources = typeof value === "string"
+        ? []
+        : [...new Set((value.resources ?? []).map((resource) => (
+            canonicalizePermissionResource(permission, resource)
+          )))].sort();
+      declarations.set(permission, Object.freeze({
+        permission,
+        required,
+        resources: Object.freeze(resources),
+        reason: typeof value === "string" ? "" : value.reason ?? "",
+      }));
+    }
+  }
+  return declarations;
+}
+
+function defaultSecurityPrincipal(manifest, archiveSha256) {
+  if (!manifest || typeof manifest.id !== "string" || typeof manifest.publisher !== "string") {
+    throw new TypeError("Plugin security principal requires manifest identity");
+  }
+  if (
+    archiveSha256 !== undefined
+    && (typeof archiveSha256 !== "string" || !/^[a-f0-9]{64}$/u.test(archiveSha256))
+  ) throw new TypeError("Plugin security principal package digest is invalid");
+  const digest = createHash("sha256")
+    .update(manifest.id)
+    .update("\0")
+    .update(manifest.publisher)
+    .update("\0")
+    .update(archiveSha256 ?? "unbound-development-package")
+    .digest("hex");
+  return `${archiveSha256 ? "unsigned-package" : "unsigned-development"}:${digest}`;
+}
+
+function assertSecurityPrincipal(value) {
+  if (typeof value !== "string" || value.length < 16 || value.length > 256 || value.includes("\0")) {
+    throw new TypeError("Plugin security principal is invalid");
+  }
+  return value;
+}
+
+function permissionDeclarationHash(declaration, securityPrincipal = "legacy:unbound-principal") {
+  return createHash("sha256").update(JSON.stringify({
+    permission: declaration.permission,
+    required: declaration.required,
+    resources: [...declaration.resources].sort(),
+    securityPrincipal: assertSecurityPrincipal(securityPrincipal),
+  })).digest("hex");
+}
+
+function declarationAllowsResource(declaration, requestedResource) {
+  if (declaration.resources.length === 0) return true;
+  return declaration.resources.some((resource) => permissionResourceCovers(
+    declaration.permission,
+    resource,
+    requestedResource,
+  ));
+}
+
+module.exports = {
+  PLUGIN_PERMISSIONS,
+  RESOURCE_SCOPED_PERMISSIONS,
+  assertPluginPermission,
+  assertSecurityPrincipal,
+  canonicalizeCompanionResource,
+  canonicalizeFilesystemResource,
+  canonicalizeNetworkOrigin,
+  canonicalizePermissionResource,
+  declarationAllowsResource,
+  defaultSecurityPrincipal,
+  normalizePermissionDeclarations,
+  permissionDeclarationHash,
+  permissionResourceCovers,
+};

--- a/electron/plugins/permissionResources.cjs
+++ b/electron/plugins/permissionResources.cjs
@@ -115,6 +115,9 @@ function normalizePermissionDeclarations(manifest) {
         : [...new Set((value.resources ?? []).map((resource) => (
             canonicalizePermissionResource(permission, resource)
           )))].sort();
+      if (required && RESOURCE_SCOPED_PERMISSIONS.has(permission) && resources.length === 0) {
+        throw new TypeError(`Required permission ${permission} must declare resources`);
+      }
       declarations.set(permission, Object.freeze({
         permission,
         required,

--- a/electron/plugins/permissionResources.cjs
+++ b/electron/plugins/permissionResources.cjs
@@ -82,11 +82,19 @@ function normalizeForFilesystemComparison(value) {
   return process.platform === "win32" ? normalized.toLocaleLowerCase("en-US") : normalized;
 }
 
-function permissionResourceCovers(permission, grantResource, requestedResource) {
+function permissionResourceCovers(
+  permission,
+  grantResource,
+  requestedResource,
+  resourceKind = "exact",
+  requestedResourceKind = "exact",
+) {
   if (grantResource === "*") return true;
   if (permission === "filesystem.read" || permission === "filesystem.write") {
+    if (requestedResourceKind === "directory" && resourceKind !== "directory") return false;
     const parent = normalizeForFilesystemComparison(grantResource);
     const candidate = normalizeForFilesystemComparison(requestedResource);
+    if (resourceKind !== "directory") return parent === candidate;
     const relative = path.relative(parent, candidate);
     return relative === ""
       || (!path.isAbsolute(relative) && relative !== ".." && !relative.startsWith(`..${path.sep}`));
@@ -158,6 +166,9 @@ function declarationAllowsResource(declaration, requestedResource) {
     declaration.permission,
     resource,
     requestedResource,
+    declaration.permission === "filesystem.read" || declaration.permission === "filesystem.write"
+      ? "directory"
+      : "exact",
   ));
 }
 

--- a/electron/plugins/pluginManager.cjs
+++ b/electron/plugins/pluginManager.cjs
@@ -5,6 +5,7 @@ class PluginManager {
     this.database = options.database;
     this.packageStore = options.packageStore;
     this.runtimeSupervisor = options.runtimeSupervisor;
+    this.beforeClose = options.beforeClose ?? null;
     this.initialized = false;
     this.initializePromise = null;
     this.mutationTail = Promise.resolve();
@@ -150,8 +151,13 @@ class PluginManager {
       try { await this.initializePromise; } catch {}
     }
     await supervisorShutdown;
-    this.database.close();
-    if (supervisorError) throw supervisorError;
+    const errors = supervisorError ? [supervisorError] : [];
+    try { await this.beforeClose?.(); }
+    catch (error) { errors.push(error); }
+    try { this.database.close(); }
+    catch (error) { errors.push(error); }
+    if (errors.length === 1) throw errors[0];
+    if (errors.length > 1) throw new AggregateError(errors, "Plugin host shutdown failed");
   }
 }
 

--- a/electron/plugins/pluginManager.test.cjs
+++ b/electron/plugins/pluginManager.test.cjs
@@ -374,6 +374,7 @@ test("uninstall disables lazy activation before stopping and removing code", asy
 test("concurrent shutdown callers share one complete shutdown operation", async () => {
   let databaseCloses = 0;
   let supervisorShutdowns = 0;
+  let beforeCloses = 0;
   const manager = new PluginManager({
     database: {
       close() { databaseCloses += 1; },
@@ -384,6 +385,7 @@ test("concurrent shutdown callers share one complete shutdown operation", async 
       async startEnabled() {},
       async shutdown() { supervisorShutdowns += 1; },
     },
+    async beforeClose() { beforeCloses += 1; },
   });
   await manager.initialize();
 
@@ -392,6 +394,23 @@ test("concurrent shutdown callers share one complete shutdown operation", async 
   assert.equal(first, second);
   await Promise.all([first, second]);
   assert.equal(supervisorShutdowns, 1);
+  assert.equal(beforeCloses, 1);
+  assert.equal(databaseCloses, 1);
+});
+
+test("shutdown closes the database even when secure-service cleanup fails", async () => {
+  let databaseCloses = 0;
+  const manager = new PluginManager({
+    database: {
+      close() { databaseCloses += 1; },
+      listPlugins: () => [],
+    },
+    packageStore: { async initialize() {} },
+    runtimeSupervisor: { async startEnabled() {}, async shutdown() {} },
+    async beforeClose() { throw new Error("secure cleanup failed"); },
+  });
+  await manager.initialize();
+  await assert.rejects(manager.shutdown(), /secure cleanup failed/);
   assert.equal(databaseCloses, 1);
 });
 

--- a/electron/plugins/pluginManager.test.cjs
+++ b/electron/plugins/pluginManager.test.cjs
@@ -371,6 +371,33 @@ test("uninstall disables lazy activation before stopping and removing code", asy
   ]);
 });
 
+test("uninstall never removes package code when runtime cleanup fails", async () => {
+  let uninstallCalls = 0;
+  const pluginId = "com.example.contained";
+  const manager = new PluginManager({
+    database: {
+      close() {},
+      getActivePlugin: () => ({ id: pluginId, enabled: true }),
+      listPlugins: () => [],
+      setEnabled() {},
+    },
+    packageStore: {
+      async initialize() {},
+      async uninstall() {
+        uninstallCalls += 1;
+        return true;
+      },
+    },
+    runtimeSupervisor: {
+      async startEnabled() {},
+      async stop() { throw new Error("companion cleanup failed"); },
+    },
+  });
+
+  await assert.rejects(manager.uninstall(pluginId), /companion cleanup failed/);
+  assert.equal(uninstallCalls, 0);
+});
+
 test("concurrent shutdown callers share one complete shutdown operation", async () => {
   let databaseCloses = 0;
   let supervisorShutdowns = 0;

--- a/electron/plugins/quotaManager.cjs
+++ b/electron/plugins/quotaManager.cjs
@@ -177,6 +177,7 @@ class PluginQuotaManager {
       },
     });
     this.monitors.set(resourceId, monitor);
+    void sample();
     return monitor;
   }
 

--- a/electron/plugins/quotaManager.cjs
+++ b/electron/plugins/quotaManager.cjs
@@ -1,0 +1,214 @@
+"use strict";
+
+const { PluginRpcError, RPC_ERRORS } = require("./rpcRouter.cjs");
+
+const DEFAULT_QUOTAS = Object.freeze({
+  messageBurst: 512,
+  messagesPerSecond: 256,
+  concurrentCapabilities: 32,
+  capabilityBurst: 120,
+  capabilitiesPerMinute: 600,
+  logWritesPerMinute: 240,
+  bytesPerMinute: 32 * 1024 * 1024,
+  memoryBytes: 256 * 1024 * 1024,
+  cpuPercent: 80,
+  sustainedCpuSamples: 3,
+  sampleIntervalMs: 5_000,
+});
+
+function quotaError(message) {
+  return new PluginRpcError(RPC_ERRORS.resourceExhausted, message, {
+    pluginCode: "resource_exhausted",
+  });
+}
+
+class TokenBucket {
+  constructor(capacity, refillPerMs, clock) {
+    this.capacity = capacity;
+    this.refillPerMs = refillPerMs;
+    this.clock = clock;
+    this.tokens = capacity;
+    this.updatedAt = clock();
+  }
+
+  consume(amount = 1) {
+    const now = this.clock();
+    this.tokens = Math.min(this.capacity, this.tokens + ((now - this.updatedAt) * this.refillPerMs));
+    this.updatedAt = now;
+    if (this.tokens < amount) return false;
+    this.tokens -= amount;
+    return true;
+  }
+}
+
+class PluginQuotaManager {
+  constructor(options = {}) {
+    this.clock = options.clock ?? (() => Date.now());
+    this.quotas = Object.freeze({ ...DEFAULT_QUOTAS, ...(options.quotas ?? {}) });
+    this.getProcessMetrics = options.getProcessMetrics ?? null;
+    this.onViolation = options.onViolation ?? (() => {});
+    this.setInterval = options.setInterval ?? setInterval;
+    this.clearInterval = options.clearInterval ?? clearInterval;
+    this.messageBuckets = new Map();
+    this.capabilityBuckets = new Map();
+    this.logBuckets = new Map();
+    this.concurrent = new Map();
+    this.byteWindows = new Map();
+    this.monitors = new Map();
+  }
+
+  setViolationHandler(handler) {
+    if (typeof handler !== "function") throw new TypeError("Plugin quota violation handler must be a function");
+    this.onViolation = handler;
+  }
+
+  #bucket(collection, key, capacity, refillPerMs) {
+    let bucket = collection.get(key);
+    if (!bucket) {
+      bucket = new TokenBucket(capacity, refillPerMs, this.clock);
+      collection.set(key, bucket);
+    }
+    return bucket;
+  }
+
+  guardMessage(identity) {
+    const bucket = this.#bucket(
+      this.messageBuckets,
+      identity.runtimeId,
+      this.quotas.messageBurst,
+      this.quotas.messagesPerSecond / 1_000,
+    );
+    if (!bucket.consume()) throw quotaError("Plugin runtime message rate exceeded");
+  }
+
+  createMiddleware() {
+    return async (context, next) => {
+      const runtimeId = context.runtimeId;
+      const current = this.concurrent.get(runtimeId) ?? 0;
+      if (current >= this.quotas.concurrentCapabilities) {
+        throw quotaError("Plugin concurrent capability limit exceeded");
+      }
+      const capabilityBucket = this.#bucket(
+        this.capabilityBuckets,
+        runtimeId,
+        this.quotas.capabilityBurst,
+        this.quotas.capabilitiesPerMinute / 60_000,
+      );
+      if (!capabilityBucket.consume()) throw quotaError("Plugin capability request rate exceeded");
+      if (context.method === "log.write") {
+        const logBucket = this.#bucket(
+          this.logBuckets,
+          runtimeId,
+          this.quotas.logWritesPerMinute,
+          this.quotas.logWritesPerMinute / 60_000,
+        );
+        if (!logBucket.consume()) throw quotaError("Plugin log rate exceeded");
+      }
+      this.concurrent.set(runtimeId, current + 1);
+      try { return await next(); }
+      finally {
+        const remaining = (this.concurrent.get(runtimeId) ?? 1) - 1;
+        if (remaining <= 0) this.concurrent.delete(runtimeId);
+        else this.concurrent.set(runtimeId, remaining);
+      }
+    };
+  }
+
+  chargeBytes(runtimeId, category, byteLength) {
+    if (!Number.isSafeInteger(byteLength) || byteLength < 0) throw new TypeError("Plugin quota bytes are invalid");
+    const key = `${runtimeId}\0${category}`;
+    const now = this.clock();
+    let window = this.byteWindows.get(key);
+    if (!window || now - window.startedAt >= 60_000) {
+      window = { startedAt: now, bytes: 0 };
+      this.byteWindows.set(key, window);
+    }
+    window.bytes += byteLength;
+    if (window.bytes > this.quotas.bytesPerMinute) {
+      throw quotaError(`Plugin ${category} byte quota exceeded`);
+    }
+  }
+
+  trackRuntime(identity, runtime) {
+    return this.trackProcess(identity.runtimeId, identity, runtime);
+  }
+
+  trackProcess(resourceId, identity, processHandle) {
+    this.releaseProcess(resourceId);
+    if (!this.getProcessMetrics || typeof processHandle.getProcessId !== "function") {
+      return Object.freeze({ dispose() {} });
+    }
+    let disposed = false;
+    let sampling = false;
+    let sustainedCpu = 0;
+    const sample = async () => {
+      if (disposed || sampling) return;
+      sampling = true;
+      try {
+        const pid = processHandle.getProcessId();
+        if (!Number.isSafeInteger(pid) || pid <= 0) return;
+        const metrics = await this.getProcessMetrics(pid);
+        if (!metrics) return;
+        if (metrics.memoryBytes > this.quotas.memoryBytes) {
+          disposed = true;
+          this.clearInterval(timer);
+          await this.onViolation(identity, quotaError("Plugin memory quota exceeded"));
+          return;
+        }
+        sustainedCpu = metrics.cpuPercent > this.quotas.cpuPercent ? sustainedCpu + 1 : 0;
+        if (sustainedCpu >= this.quotas.sustainedCpuSamples) {
+          disposed = true;
+          this.clearInterval(timer);
+          await this.onViolation(identity, quotaError("Plugin sustained CPU quota exceeded"));
+        }
+      } catch {
+        // Metrics are advisory. Capability and transport quotas remain fail-closed.
+      } finally {
+        sampling = false;
+      }
+    };
+    const timer = this.setInterval(sample, this.quotas.sampleIntervalMs);
+    timer.unref?.();
+    const monitor = Object.freeze({
+      dispose: () => {
+        if (disposed) return;
+        disposed = true;
+        this.clearInterval(timer);
+      },
+    });
+    this.monitors.set(resourceId, monitor);
+    return monitor;
+  }
+
+  releaseProcess(resourceId) {
+    this.monitors.get(resourceId)?.dispose();
+    this.monitors.delete(resourceId);
+  }
+
+  releaseRuntime(runtimeId) {
+    for (const resourceId of [...this.monitors.keys()]) {
+      if (resourceId === runtimeId || resourceId.startsWith(`${runtimeId}\0`)) {
+        this.releaseProcess(resourceId);
+      }
+    }
+    this.messageBuckets.delete(runtimeId);
+    this.capabilityBuckets.delete(runtimeId);
+    this.logBuckets.delete(runtimeId);
+    this.concurrent.delete(runtimeId);
+    for (const key of [...this.byteWindows.keys()]) {
+      if (key.startsWith(`${runtimeId}\0`)) this.byteWindows.delete(key);
+    }
+  }
+
+  shutdown() {
+    for (const monitor of this.monitors.values()) monitor.dispose();
+    this.monitors.clear();
+    this.messageBuckets.clear();
+    this.capabilityBuckets.clear();
+    this.logBuckets.clear();
+    this.concurrent.clear();
+    this.byteWindows.clear();
+  }
+}
+
+module.exports = { DEFAULT_QUOTAS, PluginQuotaManager, TokenBucket, quotaError };

--- a/electron/plugins/quotaManager.test.cjs
+++ b/electron/plugins/quotaManager.test.cjs
@@ -69,14 +69,14 @@ test("runtime process quotas report sustained CPU and memory violations", async 
   });
   const runtime = { getProcessId: () => 123 };
   manager.trackRuntime({ runtimeId: "runtime-1" }, runtime);
-  await samples[0]();
+  await new Promise((resolve) => setImmediate(resolve));
   await samples[0]();
   assert.deepEqual(violations, ["Plugin sustained CPU quota exceeded"]);
   assert.equal(cleared.length, 1);
 
   metrics = { memoryBytes: 101, cpuPercent: 0 };
   manager.trackRuntime({ runtimeId: "runtime-2" }, runtime);
-  await samples[1]();
+  await new Promise((resolve) => setImmediate(resolve));
   assert.deepEqual(violations, [
     "Plugin sustained CPU quota exceeded",
     "Plugin memory quota exceeded",

--- a/electron/plugins/quotaManager.test.cjs
+++ b/electron/plugins/quotaManager.test.cjs
@@ -1,0 +1,92 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { PluginQuotaManager } = require("./quotaManager.cjs");
+const { RPC_ERRORS } = require("./rpcRouter.cjs");
+
+test("transport, capability, log, concurrency, and byte quotas fail closed and refill", async () => {
+  let now = 0;
+  const manager = new PluginQuotaManager({
+    clock: () => now,
+    quotas: {
+      messageBurst: 2,
+      messagesPerSecond: 1,
+      concurrentCapabilities: 1,
+      capabilityBurst: 2,
+      capabilitiesPerMinute: 1,
+      logWritesPerMinute: 1,
+      bytesPerMinute: 4,
+    },
+  });
+  const identity = { runtimeId: "runtime-1" };
+  manager.guardMessage(identity);
+  manager.guardMessage(identity);
+  assert.throws(() => manager.guardMessage(identity), (error) => error.code === RPC_ERRORS.resourceExhausted);
+  now += 1_000;
+  manager.guardMessage(identity);
+
+  const middleware = manager.createMiddleware();
+  let release;
+  const pending = middleware({ runtimeId: "runtime-1", method: "network.request" }, () => (
+    new Promise((resolve) => { release = resolve; })
+  ));
+  await assert.rejects(
+    middleware({ runtimeId: "runtime-1", method: "network.request" }, async () => null),
+    (error) => error.code === RPC_ERRORS.resourceExhausted,
+  );
+  release();
+  await pending;
+
+  await middleware({ runtimeId: "runtime-log", method: "log.write" }, async () => null);
+  await assert.rejects(
+    middleware({ runtimeId: "runtime-log", method: "log.write" }, async () => null),
+    (error) => error.code === RPC_ERRORS.resourceExhausted,
+  );
+
+  manager.chargeBytes("runtime-1", "network", 4);
+  assert.throws(
+    () => manager.chargeBytes("runtime-1", "network", 1),
+    (error) => error.code === RPC_ERRORS.resourceExhausted,
+  );
+  now += 60_000;
+  manager.chargeBytes("runtime-1", "network", 4);
+  manager.shutdown();
+});
+
+test("runtime process quotas report sustained CPU and memory violations", async () => {
+  const samples = [];
+  const cleared = [];
+  const violations = [];
+  let metrics = { memoryBytes: 0, cpuPercent: 90 };
+  const manager = new PluginQuotaManager({
+    getProcessMetrics: async () => metrics,
+    onViolation: async (_identity, error) => violations.push(error.message),
+    quotas: { sustainedCpuSamples: 2, cpuPercent: 80, memoryBytes: 100 },
+    setInterval: (callback) => { samples.push(callback); return { id: samples.length }; },
+    clearInterval: (timer) => cleared.push(timer),
+  });
+  const runtime = { getProcessId: () => 123 };
+  manager.trackRuntime({ runtimeId: "runtime-1" }, runtime);
+  await samples[0]();
+  await samples[0]();
+  assert.deepEqual(violations, ["Plugin sustained CPU quota exceeded"]);
+  assert.equal(cleared.length, 1);
+
+  metrics = { memoryBytes: 101, cpuPercent: 0 };
+  manager.trackRuntime({ runtimeId: "runtime-2" }, runtime);
+  await samples[1]();
+  assert.deepEqual(violations, [
+    "Plugin sustained CPU quota exceeded",
+    "Plugin memory quota exceeded",
+  ]);
+  manager.trackProcess(
+    "runtime-3\0companion:one",
+    { runtimeId: "runtime-3" },
+    runtime,
+  );
+  manager.releaseRuntime("runtime-3");
+  assert.equal(cleared.length, 3, "runtime release disposes companion process monitors");
+  manager.shutdown();
+});

--- a/electron/plugins/rpcRouter.cjs
+++ b/electron/plugins/rpcRouter.cjs
@@ -18,9 +18,18 @@ const RPC_ERRORS = Object.freeze({
   invalidParams: -32602,
   internal: -32603,
   cancelled: -32001,
+  invalidArgument: -32003,
   deadlineExceeded: -32004,
+  notFound: -32005,
+  permissionDenied: -32007,
   resourceExhausted: -32008,
+  failedPrecondition: -32009,
+  aborted: -32010,
+  outOfRange: -32011,
+  unsupported: -32012,
   unavailable: -32014,
+  dataLoss: -32015,
+  unauthenticated: -32016,
 });
 
 class PluginRpcError extends Error {

--- a/electron/plugins/runtime/runtimePeer.mjs
+++ b/electron/plugins/runtime/runtimePeer.mjs
@@ -123,6 +123,25 @@ function assertStorageKey(key) {
   return key;
 }
 
+function assertCredentialRef(credential) {
+  if (
+    !credential
+    || typeof credential !== "object"
+    || (credential.kind !== "secret" && credential.kind !== "credential")
+    || typeof credential.id !== "string"
+    || credential.id.length < 16
+    || credential.id.length > 256
+  ) throw new PluginError("invalid_argument", "Credential reference is invalid");
+  return { kind: credential.kind, id: credential.id };
+}
+
+function assertCompanionId(companionId) {
+  if (typeof companionId !== "string" || companionId.length < 5 || companionId.length > 192) {
+    throw new PluginError("invalid_argument", "Companion ID is invalid");
+  }
+  return companionId;
+}
+
 function createPluginContext(config, client) {
   const subscriptions = new DisposableStore();
   const storage = {
@@ -135,9 +154,63 @@ function createPluginContext(config, client) {
     keys: () => client.request("storage.keys", {}).then((result) => result?.keys ?? []),
   };
   const secrets = {
-    get: () => Promise.reject(new PluginError("unsupported", "Plugin secrets require the permission runtime")),
-    set: () => Promise.reject(new PluginError("unsupported", "Plugin secrets require the permission runtime")),
-    delete: () => Promise.reject(new PluginError("unsupported", "Plugin secrets require the permission runtime")),
+    get: (key) => client.request("secrets.get", { key: assertStorageKey(key) })
+      .then((result) => result?.found ? result.secret : undefined),
+    set: (key, value) => client.request("secrets.set", {
+      key: assertStorageKey(key),
+      value,
+    }).then((result) => result.secret),
+    delete: (key) => client.request("secrets.delete", { key: assertStorageKey(key) })
+      .then(() => undefined),
+  };
+  const credentials = {
+    createLease: (secret, options) => client.request("credentials.createLease", {
+      secret: assertCredentialRef(secret),
+      operationId: options?.operationId,
+      purpose: options?.purpose,
+      ...(options?.ttlMs === undefined ? {} : { ttlMs: options.ttlMs }),
+    }),
+  };
+  const network = {
+    request: (request) => client.request("network.request", request),
+  };
+  const filesystem = {
+    readFile: (filePath, options = {}) => client.request("filesystem.readFile", {
+      path: filePath,
+      ...options,
+    }).then((result) => result.data),
+    writeFile: (filePath, data, options = {}) => client.request("filesystem.writeFile", {
+      path: filePath,
+      data,
+      ...options,
+    }).then(() => undefined),
+    stat: (filePath) => client.request("filesystem.stat", { path: filePath }),
+    readDirectory: (directoryPath) => client.request("filesystem.readDirectory", { path: directoryPath })
+      .then((result) => result.entries),
+  };
+  const companions = {
+    start: async (companionId) => {
+      const result = await client.request("companion.start", {
+        companionId: assertCompanionId(companionId),
+      });
+      let stopped = false;
+      const stop = async () => {
+        if (stopped) return;
+        stopped = true;
+        await client.request("companion.stop", { handleId: result.handleId });
+      };
+      return Object.freeze({
+        id: result.handleId,
+        request: (method, params, options = {}) => client.request("companion.request", {
+          handleId: result.handleId,
+          method,
+          ...(params === undefined ? {} : { params }),
+          ...options,
+        }),
+        stop,
+        dispose() { void stop().catch(() => {}); },
+      });
+    },
   };
   const logger = Object.fromEntries(["debug", "info", "warn", "error"].map((level) => [
     level,
@@ -155,6 +228,10 @@ function createPluginContext(config, client) {
     subscriptions,
     storage,
     secrets,
+    credentials,
+    network,
+    filesystem,
+    companions,
     logger,
   };
 }

--- a/electron/plugins/runtime/runtimePeer.mjs
+++ b/electron/plugins/runtime/runtimePeer.mjs
@@ -2,6 +2,7 @@ import {
   CancellationTokenSource,
   DisposableStore,
   PluginError,
+  PLUGIN_ERROR_WIRE_CODES,
   pluginErrorToRpcError,
 } from "@netcatty/plugin-sdk";
 import { createMessagePortStreamEnvelope } from "@netcatty/plugin-contract";
@@ -13,6 +14,18 @@ const RPC_ERRORS = {
   cancelled: -32001,
   unsupported: -32012,
 };
+
+const PLUGIN_ERROR_NAMES_BY_WIRE_CODE = new Map(
+  Object.entries(PLUGIN_ERROR_WIRE_CODES).map(([name, code]) => [code, name]),
+);
+
+function pluginErrorNameFromRpcError(error) {
+  if (typeof error?.data?.pluginCode === "string") return error.data.pluginCode;
+  if (error?.code === RPC_ERRORS.methodNotFound) return "unsupported";
+  if (error?.code === RPC_ERRORS.invalidParams) return "invalid_argument";
+  if (error?.code === RPC_ERRORS.internal) return "internal";
+  return PLUGIN_ERROR_NAMES_BY_WIRE_CODE.get(error?.code) ?? "unknown";
+}
 
 function messageData(value) {
   return value && typeof value === "object" && "data" in value ? value.data : value;
@@ -90,7 +103,7 @@ function createHostClient(transport) {
     pending.delete(`${typeof message.id}:${String(message.id)}`);
     if (message.error) {
       request.reject(new PluginError(
-        message.error.data?.pluginCode ?? "unknown",
+        pluginErrorNameFromRpcError(message.error),
         message.error.message,
         message.error.data?.details,
       ));

--- a/electron/plugins/runtime/runtimePeer.mjs
+++ b/electron/plugins/runtime/runtimePeer.mjs
@@ -97,12 +97,18 @@ function createHostClient(transport) {
     } else request.resolve(message.result);
     return true;
   }
-  function request(method, params) {
+  function request(method, params, options = {}) {
     const id = nextId;
     nextId = nextId === Number.MAX_SAFE_INTEGER ? 0 : nextId + 1;
     return new Promise((resolve, reject) => {
       pending.set(`${typeof id}:${String(id)}`, { resolve, reject });
-      transport.post({ jsonrpc: "2.0", id, method, params });
+      transport.post({
+        jsonrpc: "2.0",
+        id,
+        method,
+        params,
+        ...(options.deadlineMs === undefined ? {} : { deadlineMs: options.deadlineMs }),
+      });
     });
   }
   function notify(method, params) {
@@ -132,7 +138,22 @@ function assertCredentialRef(credential) {
     || credential.id.length < 16
     || credential.id.length > 256
   ) throw new PluginError("invalid_argument", "Credential reference is invalid");
-  return { kind: credential.kind, id: credential.id };
+  if (
+    credential.kind === "secret"
+    && (
+      typeof credential.key !== "string"
+      || credential.key.length < 1
+      || credential.key.length > 256
+      || credential.key.includes("\0")
+    )
+  ) throw new PluginError("invalid_argument", "Credential reference is invalid");
+  return credential.kind === "secret"
+    ? { kind: "secret", id: credential.id, key: credential.key }
+    : { kind: "credential", id: credential.id };
+}
+
+function forwardedDeadline(value, maximum) {
+  return Number.isSafeInteger(value) && value >= 1 && value <= maximum ? value : undefined;
 }
 
 function assertCompanionId(companionId) {
@@ -172,7 +193,9 @@ function createPluginContext(config, client) {
     }),
   };
   const network = {
-    request: (request) => client.request("network.request", request),
+    request: (request) => client.request("network.request", request, {
+      deadlineMs: forwardedDeadline(request?.timeoutMs, 300_000),
+    }),
   };
   const filesystem = {
     readFile: (filePath, options = {}) => client.request("filesystem.readFile", {
@@ -205,12 +228,16 @@ function createPluginContext(config, client) {
       };
       return Object.freeze({
         id: result.handleId,
-        request: (method, params, options = {}) => client.request("companion.request", {
-          handleId: result.handleId,
-          method,
-          ...(params === undefined ? {} : { params }),
-          ...options,
-        }),
+        request: (method, params, options = {}) => client.request(
+          "companion.request",
+          {
+            handleId: result.handleId,
+            method,
+            ...(params === undefined ? {} : { params }),
+            ...options,
+          },
+          { deadlineMs: forwardedDeadline(options.timeoutMs, 60_000) },
+        ),
         stop,
         dispose() { void stop().catch(() => {}); },
       });

--- a/electron/plugins/runtime/runtimePeer.mjs
+++ b/electron/plugins/runtime/runtimePeer.mjs
@@ -194,10 +194,14 @@ function createPluginContext(config, client) {
         companionId: assertCompanionId(companionId),
       });
       let stopped = false;
-      const stop = async () => {
-        if (stopped) return;
-        stopped = true;
-        await client.request("companion.stop", { handleId: result.handleId });
+      let stopPromise = null;
+      const stop = () => {
+        if (stopped) return Promise.resolve();
+        if (stopPromise) return stopPromise;
+        stopPromise = client.request("companion.stop", { handleId: result.handleId })
+          .then(() => { stopped = true; })
+          .finally(() => { stopPromise = null; });
+        return stopPromise;
       };
       return Object.freeze({
         id: result.handleId,

--- a/electron/plugins/runtimePeer.test.cjs
+++ b/electron/plugins/runtimePeer.test.cjs
@@ -11,6 +11,7 @@ test("runtime peer exposes secure host capabilities over the canonical RPC trans
   const { port1, port2 } = new MessageChannel();
   const values = new Map();
   const calls = [];
+  const deadlines = [];
   const host = new PluginRpcRouter({
     pluginId: "com.example.peer",
     send(message) { port1.postMessage(message); },
@@ -18,11 +19,13 @@ test("runtime peer exposes secure host capabilities over the canonical RPC trans
       "storage.set": async ({ key, value }) => { values.set(key, value); return null; },
       "secrets.set": async ({ key, value }) => {
         calls.push(["secret", key, value]);
-        return { secret: { kind: "secret", id: "secret-reference-0000000000000000" } };
+        return {
+          secret: { kind: "secret", id: "secret-reference-0000000000000000", key },
+        };
       },
       "secrets.get": async () => ({
         found: true,
-        secret: { kind: "secret", id: "secret-reference-0000000000000000" },
+        secret: { kind: "secret", id: "secret-reference-0000000000000000", key: "api-key" },
       }),
       "credentials.createLease": async ({ operationId }) => ({
         kind: "secret-lease",
@@ -30,18 +33,24 @@ test("runtime peer exposes secure host capabilities over the canonical RPC trans
         operationId,
         expiresAt: 10_000,
       }),
-      "network.request": async ({ url }) => ({
-        url,
-        status: 200,
-        headers: {},
-        body: { encoding: "base64", data: "b2s=" },
-      }),
+      "network.request": async ({ url, timeoutMs }, requestContext) => {
+        deadlines.push(["network", requestContext.deadlineMs, timeoutMs]);
+        return {
+          url,
+          status: 200,
+          headers: {},
+          body: { encoding: "base64", data: "b2s=" },
+        };
+      },
       "filesystem.readFile": async ({ path }) => ({ data: `read:${path}` }),
       "filesystem.writeFile": async ({ path, data }) => { calls.push(["write", path, data]); return null; },
       "filesystem.stat": async () => ({ kind: "file", size: 2, modifiedAt: 1 }),
       "filesystem.readDirectory": async () => ({ entries: [{ name: "file", kind: "file" }] }),
       "companion.start": async () => ({ handleId: "companion-handle-000000000000" }),
-      "companion.request": async ({ method, params }) => ({ method, params }),
+      "companion.request": async ({ method, params, timeoutMs }, requestContext) => {
+        deadlines.push(["companion", requestContext.deadlineMs, timeoutMs]);
+        return { method, params };
+      },
       "companion.stop": async ({ handleId }) => { calls.push(["stop", handleId]); return null; },
       "log.write": async () => null,
     },
@@ -77,13 +86,16 @@ test("runtime peer exposes secure host capabilities over the canonical RPC trans
               purpose: "Authenticate connection",
             });
             assert.equal(vaultLease.operationId, "connection:login");
-            assert.equal((await context.network.request({ url: "https://example.com" })).status, 200);
+            assert.equal((await context.network.request({
+              url: "https://example.com",
+              timeoutMs: 45_000,
+            })).status, 200);
             assert.equal(await context.filesystem.readFile("/tmp/file"), "read:/tmp/file");
             await context.filesystem.writeFile("/tmp/file", "ok", { overwrite: true });
             assert.equal((await context.filesystem.stat("/tmp/file")).kind, "file");
             assert.equal((await context.filesystem.readDirectory("/tmp")).length, 1);
             const companion = await context.companions.start("com.example.peer.helper");
-            assert.deepEqual(await companion.request("echo", { value: 1 }), {
+            assert.deepEqual(await companion.request("echo", { value: 1 }, { timeoutMs: 50_000 }), {
               method: "echo",
               params: { value: 1 },
             });
@@ -113,6 +125,10 @@ test("runtime peer exposes secure host capabilities over the canonical RPC trans
     ["secret", "api-key", "value"],
     ["write", "/tmp/file", "ok"],
     ["stop", "companion-handle-000000000000"],
+  ]);
+  assert.deepEqual(deadlines, [
+    ["network", 45_000, 45_000],
+    ["companion", 50_000, 50_000],
   ]);
   await host.request("plugin.deactivate", {});
   await peer.dispose();

--- a/electron/plugins/runtimePeer.test.cjs
+++ b/electron/plugins/runtimePeer.test.cjs
@@ -79,7 +79,7 @@ test("runtime peer exposes secure host capabilities over the canonical RPC trans
             assert.equal(vaultLease.operationId, "connection:login");
             assert.equal((await context.network.request({ url: "https://example.com" })).status, 200);
             assert.equal(await context.filesystem.readFile("/tmp/file"), "read:/tmp/file");
-            await context.filesystem.writeFile("/tmp/file", "ok");
+            await context.filesystem.writeFile("/tmp/file", "ok", { overwrite: true });
             assert.equal((await context.filesystem.stat("/tmp/file")).kind, "file");
             assert.equal((await context.filesystem.readDirectory("/tmp")).length, 1);
             const companion = await context.companions.start("com.example.peer.helper");

--- a/electron/plugins/runtimePeer.test.cjs
+++ b/electron/plugins/runtimePeer.test.cjs
@@ -6,15 +6,43 @@ const { MessageChannel } = require("node:worker_threads");
 
 const { PluginRpcRouter } = require("./rpcRouter.cjs");
 
-test("runtime peer performs initialize, activation, storage RPC, and disposal over one port", async () => {
+test("runtime peer exposes secure host capabilities over the canonical RPC transport", async () => {
   const { startPluginRuntime } = await import("./runtime/runtimePeer.mjs");
   const { port1, port2 } = new MessageChannel();
   const values = new Map();
+  const calls = [];
   const host = new PluginRpcRouter({
     pluginId: "com.example.peer",
     send(message) { port1.postMessage(message); },
     handlers: {
       "storage.set": async ({ key, value }) => { values.set(key, value); return null; },
+      "secrets.set": async ({ key, value }) => {
+        calls.push(["secret", key, value]);
+        return { secret: { kind: "secret", id: "secret-reference-0000000000000000" } };
+      },
+      "secrets.get": async () => ({
+        found: true,
+        secret: { kind: "secret", id: "secret-reference-0000000000000000" },
+      }),
+      "credentials.createLease": async ({ operationId }) => ({
+        kind: "secret-lease",
+        id: "l".repeat(32),
+        operationId,
+        expiresAt: 10_000,
+      }),
+      "network.request": async ({ url }) => ({
+        url,
+        status: 200,
+        headers: {},
+        body: { encoding: "base64", data: "b2s=" },
+      }),
+      "filesystem.readFile": async ({ path }) => ({ data: `read:${path}` }),
+      "filesystem.writeFile": async ({ path, data }) => { calls.push(["write", path, data]); return null; },
+      "filesystem.stat": async () => ({ kind: "file", size: 2, modifiedAt: 1 }),
+      "filesystem.readDirectory": async () => ({ entries: [{ name: "file", kind: "file" }] }),
+      "companion.start": async () => ({ handleId: "companion-handle-000000000000" }),
+      "companion.request": async ({ method, params }) => ({ method, params }),
+      "companion.stop": async ({ handleId }) => { calls.push(["stop", handleId]); return null; },
       "log.write": async () => null,
     },
   });
@@ -35,6 +63,31 @@ test("runtime peer performs initialize, activation, storage RPC, and disposal ov
           async activate(context) {
             lifecycle.push("activate");
             await context.storage.set("answer", 42);
+            const secret = await context.secrets.set("api-key", "value");
+            const lease = await context.credentials.createLease(secret, {
+              operationId: "network:login",
+              purpose: "Authenticate",
+            });
+            assert.equal(lease.operationId, "network:login");
+            const vaultLease = await context.credentials.createLease({
+              kind: "credential",
+              id: "vault-credential-1",
+            }, {
+              operationId: "connection:login",
+              purpose: "Authenticate connection",
+            });
+            assert.equal(vaultLease.operationId, "connection:login");
+            assert.equal((await context.network.request({ url: "https://example.com" })).status, 200);
+            assert.equal(await context.filesystem.readFile("/tmp/file"), "read:/tmp/file");
+            await context.filesystem.writeFile("/tmp/file", "ok");
+            assert.equal((await context.filesystem.stat("/tmp/file")).kind, "file");
+            assert.equal((await context.filesystem.readDirectory("/tmp")).length, 1);
+            const companion = await context.companions.start("com.example.peer.helper");
+            assert.deepEqual(await companion.request("echo", { value: 1 }), {
+              method: "echo",
+              params: { value: 1 },
+            });
+            await companion.stop();
           },
           async deactivate() { lifecycle.push("deactivate"); },
         },
@@ -56,6 +109,11 @@ test("runtime peer performs initialize, activation, storage RPC, and disposal ov
   );
   await host.request("plugin.activate", {});
   assert.equal(values.get("answer"), 42);
+  assert.deepEqual(calls, [
+    ["secret", "api-key", "value"],
+    ["write", "/tmp/file", "ok"],
+    ["stop", "companion-handle-000000000000"],
+  ]);
   await host.request("plugin.deactivate", {});
   await peer.dispose();
   host.close();

--- a/electron/plugins/runtimePeer.test.cjs
+++ b/electron/plugins/runtimePeer.test.cjs
@@ -4,7 +4,7 @@ const assert = require("node:assert/strict");
 const test = require("node:test");
 const { MessageChannel } = require("node:worker_threads");
 
-const { PluginRpcRouter } = require("./rpcRouter.cjs");
+const { PluginRpcError, PluginRpcRouter, RPC_ERRORS } = require("./rpcRouter.cjs");
 
 test("runtime peer exposes secure host capabilities over the canonical RPC transport", async () => {
   const { startPluginRuntime } = await import("./runtime/runtimePeer.mjs");
@@ -16,6 +16,9 @@ test("runtime peer exposes secure host capabilities over the canonical RPC trans
     pluginId: "com.example.peer",
     send(message) { port1.postMessage(message); },
     handlers: {
+      "storage.get": async () => {
+        throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Invalid storage key");
+      },
       "storage.set": async ({ key, value }) => { values.set(key, value); return null; },
       "secrets.set": async ({ key, value }) => {
         calls.push(["secret", key, value]);
@@ -71,6 +74,11 @@ test("runtime peer exposes secure host capabilities over the canonical RPC trans
         default: {
           async activate(context) {
             lifecycle.push("activate");
+            await assert.rejects(
+              context.storage.get("invalid"),
+              (error) => error?.code === "invalid_argument"
+                && error?.message === "Invalid storage key",
+            );
             await context.storage.set("answer", 42);
             const secret = await context.secrets.set("api-key", "value");
             const lease = await context.credentials.createLease(secret, {

--- a/electron/plugins/runtimePeer.test.cjs
+++ b/electron/plugins/runtimePeer.test.cjs
@@ -119,3 +119,52 @@ test("runtime peer exposes secure host capabilities over the canonical RPC trans
   host.close();
   assert.deepEqual(lifecycle, ["activate", "deactivate"]);
 });
+
+test("runtime companion handles retry a failed stop request", async () => {
+  const { startPluginRuntime } = await import("./runtime/runtimePeer.mjs");
+  const { port1, port2 } = new MessageChannel();
+  let stopCalls = 0;
+  const host = new PluginRpcRouter({
+    pluginId: "com.example.retry-stop",
+    send(message) { port1.postMessage(message); },
+    handlers: {
+      "companion.start": async () => ({ handleId: "companion-handle-000000000001" }),
+      "companion.stop": async () => {
+        stopCalls += 1;
+        if (stopCalls === 1) throw new Error("transient stop failure");
+        return null;
+      },
+    },
+  });
+  port1.on("message", (message) => host.accept(message));
+  const peer = await startPluginRuntime({
+    port: port2,
+    config: {
+      pluginId: "com.example.retry-stop",
+      pluginVersion: "1.0.0",
+      netcattyVersion: "1.0.0",
+      apiVersion: "0.1.0-internal",
+      enabledFeatures: [],
+    },
+    async loadPlugin() {
+      return {
+        default: {
+          async activate(context) {
+            const companion = await context.companions.start("com.example.retry-stop.helper");
+            await assert.rejects(companion.stop());
+            await companion.stop();
+          },
+        },
+      };
+    },
+  });
+  await host.request("plugin.initialize", {
+    netcattyVersion: "1.0.0",
+    apiVersion: "0.1.0-internal",
+    supportedFeatures: [],
+  });
+  await host.request("plugin.activate", {});
+  assert.equal(stopCalls, 2);
+  await peer.dispose();
+  host.close();
+});

--- a/electron/plugins/runtimeSupervisor.cjs
+++ b/electron/plugins/runtimeSupervisor.cjs
@@ -42,6 +42,11 @@ function freezeJson(value) {
   return Object.freeze(value);
 }
 
+function resolveDefaultRuntimeKind({ plugin }) {
+  if (plugin.manifest.companionExecutables?.length) return "utility";
+  return plugin.manifest.main.browser ? "browser" : "utility";
+}
+
 class RuntimeSupervisor {
   constructor(options) {
     this.electron = options.electron;
@@ -62,9 +67,7 @@ class RuntimeSupervisor {
     if (this.runtimeMessageGuard != null && typeof this.runtimeMessageGuard !== "function") {
       throw new TypeError("Plugin runtime message guard must be a function");
     }
-    this.resolveRuntimeKind = options.resolveRuntimeKind ?? (({ plugin }) => (
-      plugin.manifest.main.browser ? "browser" : "utility"
-    ));
+    this.resolveRuntimeKind = options.resolveRuntimeKind ?? resolveDefaultRuntimeKind;
     this.resolveSecurityPrincipal = options.resolveSecurityPrincipal
       ?? (({ plugin }) => defaultSecurityPrincipal(plugin.manifest, plugin.archiveSha256));
     if (typeof this.resolveRuntimeKind !== "function" || typeof this.resolveSecurityPrincipal !== "function") {
@@ -631,4 +634,9 @@ class RuntimeSupervisor {
   }
 }
 
-module.exports = { RuntimeSupervisor, assertStorageParams, freezeJson };
+module.exports = {
+  RuntimeSupervisor,
+  assertStorageParams,
+  freezeJson,
+  resolveDefaultRuntimeKind,
+};

--- a/electron/plugins/runtimeSupervisor.cjs
+++ b/electron/plugins/runtimeSupervisor.cjs
@@ -17,6 +17,10 @@ const {
   createDefaultPluginHostRpcRegistry,
 } = require("./hostRpcRegistry.cjs");
 const {
+  assertSecurityPrincipal,
+  defaultSecurityPrincipal,
+} = require("./permissionResources.cjs");
+const {
   PLUGIN_CONTAINMENT_ERROR_CODE,
   UtilityPluginRuntime,
 } = require("./utilityPluginRuntime.cjs");
@@ -61,6 +65,11 @@ class RuntimeSupervisor {
     this.resolveRuntimeKind = options.resolveRuntimeKind ?? (({ plugin }) => (
       plugin.manifest.main.browser ? "browser" : "utility"
     ));
+    this.resolveSecurityPrincipal = options.resolveSecurityPrincipal
+      ?? (({ plugin }) => defaultSecurityPrincipal(plugin.manifest, plugin.archiveSha256));
+    if (typeof this.resolveRuntimeKind !== "function" || typeof this.resolveSecurityPrincipal !== "function") {
+      throw new TypeError("Plugin runtime placement and security-principal resolvers must be functions");
+    }
     this.utilityModuleMappings = options.utilityModuleMappings ?? {
       "@netcatty/plugin-sdk": pathToFileURL(path.join(
         this.appRoot, "node_modules", "@netcatty", "plugin-sdk", "dist", "index.js",
@@ -73,6 +82,8 @@ class RuntimeSupervisor {
       browser: (runtimeOptions) => new BrowserPluginRuntime(runtimeOptions),
       utility: (runtimeOptions) => new UtilityPluginRuntime(runtimeOptions),
     };
+    this.runtimeResourceMonitor = options.runtimeResourceMonitor ?? null;
+    this.resourceMonitors = new Map();
     this.runtimes = new Map();
     this.runtimeIdentities = new Map();
     this.starting = new Map();
@@ -119,6 +130,7 @@ class RuntimeSupervisor {
       pluginVersion: identity.pluginVersion,
       runtimeId: identity.runtimeId,
       runtimeKind: identity.runtimeKind,
+      securityPrincipal: identity.securityPrincipal,
       token: params.token,
       value: freezeJson(structuredClone(params.value)),
     });
@@ -134,6 +146,7 @@ class RuntimeSupervisor {
       pluginVersion: identity?.pluginVersion ?? details.pluginVersion ?? null,
       runtimeId: identity?.runtimeId ?? null,
       runtimeKind: identity?.runtimeKind ?? details.kind ?? null,
+      securityPrincipal: identity?.securityPrincipal ?? null,
       status,
       error: details.error == null ? null : String(details.error),
       quarantinedAt: details.quarantinedAt ?? null,
@@ -211,9 +224,13 @@ class RuntimeSupervisor {
       ...(plugin.manifest.main.node ? ["utility"] : []),
     ]);
     const placementPlugin = freezeJson(structuredClone(plugin));
+    const securityPrincipal = assertSecurityPrincipal(await raceWithAbort(Promise.resolve(
+      this.resolveSecurityPrincipal(Object.freeze({ plugin: placementPlugin, signal })),
+    ), signal));
     const kind = await raceWithAbort(Promise.resolve(this.resolveRuntimeKind(Object.freeze({
       plugin: placementPlugin,
       availableKinds,
+      securityPrincipal,
       signal,
     }))), signal);
     signal.throwIfAborted();
@@ -235,6 +252,7 @@ class RuntimeSupervisor {
       pluginVersion: plugin.activeVersion,
       runtimeId: randomUUID(),
       runtimeKind: kind,
+      securityPrincipal,
       manifest: freezeJson(structuredClone(plugin.manifest)),
       packageRoot,
       logger,
@@ -313,6 +331,10 @@ class RuntimeSupervisor {
       }
       identity.assertCurrent();
       this.#setRuntimeState(identity, "running");
+      if (this.runtimeResourceMonitor) {
+        const monitor = this.runtimeResourceMonitor.trackRuntime(identity, runtime);
+        this.resourceMonitors.set(identity.runtimeId, monitor);
+      }
       return this.getRuntimeIdentity(pluginId);
     } catch (error) {
       const stillOwned = this.runtimes.get(pluginId) === runtime;
@@ -320,6 +342,7 @@ class RuntimeSupervisor {
       if (stillOwned) {
         this.runtimes.delete(pluginId);
         this.runtimeIdentities.delete(pluginId);
+        this.#releaseRuntimeResources(identity);
         try { await runtime.stop(); } catch (stopError) { cleanupError = stopError; }
       }
       if (stillOwned && cleanupError?.code === PLUGIN_CONTAINMENT_ERROR_CODE) {
@@ -366,6 +389,7 @@ class RuntimeSupervisor {
     if (this.runtimes.get(pluginId) !== runtime) return;
     this.runtimes.delete(pluginId);
     this.runtimeIdentities.delete(pluginId);
+    this.#releaseRuntimeResources(identity);
     if (details.containmentFailed) {
       this.#recordContainmentFailure(identity, details.error);
       return;
@@ -428,6 +452,7 @@ class RuntimeSupervisor {
     }
     this.runtimes.delete(pluginId);
     this.runtimeIdentities.delete(pluginId);
+    this.#releaseRuntimeResources(identity);
     let stopError;
     try {
       await runtime.stop();
@@ -452,6 +477,22 @@ class RuntimeSupervisor {
     return this.start(pluginId);
   }
 
+  #releaseRuntimeResources(identity) {
+    if (!identity) return;
+    this.resourceMonitors.get(identity.runtimeId)?.dispose?.();
+    this.resourceMonitors.delete(identity.runtimeId);
+    this.runtimeResourceMonitor?.releaseRuntime?.(identity.runtimeId);
+  }
+
+  async enforcePolicyViolation(identity, error) {
+    const current = this.runtimeIdentities.get(identity.pluginId);
+    if (!current || current.runtimeId !== identity.runtimeId) return;
+    const plugin = this.database.getActivePlugin(identity.pluginId);
+    if (plugin?.enabled) this.database.setEnabled(identity.pluginId, false);
+    await this.stop(identity.pluginId);
+    this.#setRuntimeState(identity, "error", { error: error?.message ?? String(error) });
+  }
+
   getRuntimeIdentity(pluginId) {
     const identity = this.runtimeIdentities.get(pluginId);
     if (!identity) return null;
@@ -460,6 +501,7 @@ class RuntimeSupervisor {
       pluginVersion: identity.pluginVersion,
       runtimeId: identity.runtimeId,
       runtimeKind: identity.runtimeKind,
+      securityPrincipal: identity.securityPrincipal,
     });
   }
 
@@ -543,6 +585,8 @@ class RuntimeSupervisor {
     await Promise.allSettled([...this.runtimes.keys()].map((pluginId) => this.stop(pluginId)));
     await Promise.allSettled([...this.starting.values()]);
     await Promise.allSettled([...this.stopping.values()]);
+    for (const identity of this.runtimeIdentities.values()) this.#releaseRuntimeResources(identity);
+    this.resourceMonitors.clear();
     this.runtimeListeners.clear();
     this.progressListeners.clear();
   }

--- a/electron/plugins/runtimeSupervisor.cjs
+++ b/electron/plugins/runtimeSupervisor.cjs
@@ -83,6 +83,10 @@ class RuntimeSupervisor {
       utility: (runtimeOptions) => new UtilityPluginRuntime(runtimeOptions),
     };
     this.runtimeResourceMonitor = options.runtimeResourceMonitor ?? null;
+    this.runtimeCleanup = options.runtimeCleanup ?? null;
+    if (this.runtimeCleanup != null && typeof this.runtimeCleanup !== "function") {
+      throw new TypeError("Plugin runtime cleanup must be a function");
+    }
     this.resourceMonitors = new Map();
     this.runtimes = new Map();
     this.runtimeIdentities = new Map();
@@ -337,16 +341,20 @@ class RuntimeSupervisor {
       return this.getRuntimeIdentity(pluginId);
     } catch (error) {
       const stillOwned = this.runtimes.get(pluginId) === runtime;
+      let stopError;
       let cleanupError;
       if (stillOwned) {
         this.runtimes.delete(pluginId);
         this.runtimeIdentities.delete(pluginId);
         this.#releaseRuntimeResources(identity);
-        try { await runtime.stop(); } catch (stopError) { cleanupError = stopError; }
+        try { await runtime.stop(); } catch (caughtError) { stopError = caughtError; }
+        try { await this.#cleanupRuntime(identity); } catch (caughtError) { cleanupError = caughtError; }
       }
-      if (stillOwned && cleanupError?.code === PLUGIN_CONTAINMENT_ERROR_CODE) {
-        this.#recordContainmentFailure(identity, cleanupError);
-        throw cleanupError;
+      const containmentError = cleanupError
+        ?? (stopError?.code === PLUGIN_CONTAINMENT_ERROR_CODE ? stopError : null);
+      if (stillOwned && containmentError) {
+        this.#recordContainmentFailure(identity, containmentError);
+        throw containmentError;
       }
       if (stillOwned) await this.#recordFailure(identity, error);
       throw error;
@@ -389,6 +397,12 @@ class RuntimeSupervisor {
     this.runtimes.delete(pluginId);
     this.runtimeIdentities.delete(pluginId);
     this.#releaseRuntimeResources(identity);
+    try {
+      await this.#cleanupRuntime(identity);
+    } catch (error) {
+      this.#recordContainmentFailure(identity, error);
+      return;
+    }
     if (details.containmentFailed) {
       this.#recordContainmentFailure(identity, details.error);
       return;
@@ -453,13 +467,21 @@ class RuntimeSupervisor {
     this.runtimeIdentities.delete(pluginId);
     this.#releaseRuntimeResources(identity);
     let stopError;
+    let cleanupError;
     try {
       await runtime.stop();
     } catch (error) {
       stopError = error;
+    }
+    try {
+      await this.#cleanupRuntime(identity);
+    } catch (error) {
+      cleanupError = error;
     } finally {
-      if (stopError?.code === PLUGIN_CONTAINMENT_ERROR_CODE) {
-        this.#recordContainmentFailure(identity, stopError);
+      const containmentError = cleanupError
+        ?? (stopError?.code === PLUGIN_CONTAINMENT_ERROR_CODE ? stopError : null);
+      if (containmentError) {
+        this.#recordContainmentFailure(identity, containmentError);
       } else {
         this.#setRuntimeState(identity, "stopped", {
           kind: plugin?.runtime?.kind,
@@ -467,6 +489,7 @@ class RuntimeSupervisor {
         });
       }
     }
+    if (cleanupError) throw cleanupError;
     if (stopError?.code === PLUGIN_CONTAINMENT_ERROR_CODE) throw stopError;
   }
 
@@ -481,6 +504,17 @@ class RuntimeSupervisor {
     this.resourceMonitors.get(identity.runtimeId)?.dispose?.();
     this.resourceMonitors.delete(identity.runtimeId);
     this.runtimeResourceMonitor?.releaseRuntime?.(identity.runtimeId);
+  }
+
+  async #cleanupRuntime(identity) {
+    if (!identity || !this.runtimeCleanup) return;
+    await this.runtimeCleanup(Object.freeze({
+      pluginId: identity.pluginId,
+      pluginVersion: identity.pluginVersion,
+      runtimeId: identity.runtimeId,
+      runtimeKind: identity.runtimeKind,
+      securityPrincipal: identity.securityPrincipal,
+    }));
   }
 
   #installRuntimeResourceMonitor(identity, runtime) {

--- a/electron/plugins/runtimeSupervisor.cjs
+++ b/electron/plugins/runtimeSupervisor.cjs
@@ -287,6 +287,7 @@ class RuntimeSupervisor {
             : undefined,
           onIncomingStream: routes.onIncomingStream,
           onProgress: (params) => this.#emitProgress(identity, params),
+          onProcessReady: () => this.#installRuntimeResourceMonitor(identity, runtime),
           logger,
           onExit,
           onProtocolError,
@@ -304,6 +305,7 @@ class RuntimeSupervisor {
             : undefined,
           onIncomingStream: routes.onIncomingStream,
           onProgress: (params) => this.#emitProgress(identity, params),
+          onProcessReady: () => this.#installRuntimeResourceMonitor(identity, runtime),
           logger,
           onExit,
           onProtocolError,
@@ -331,10 +333,7 @@ class RuntimeSupervisor {
       }
       identity.assertCurrent();
       this.#setRuntimeState(identity, "running");
-      if (this.runtimeResourceMonitor) {
-        const monitor = this.runtimeResourceMonitor.trackRuntime(identity, runtime);
-        this.resourceMonitors.set(identity.runtimeId, monitor);
-      }
+      this.#installRuntimeResourceMonitor(identity, runtime);
       return this.getRuntimeIdentity(pluginId);
     } catch (error) {
       const stillOwned = this.runtimes.get(pluginId) === runtime;
@@ -482,6 +481,12 @@ class RuntimeSupervisor {
     this.resourceMonitors.get(identity.runtimeId)?.dispose?.();
     this.resourceMonitors.delete(identity.runtimeId);
     this.runtimeResourceMonitor?.releaseRuntime?.(identity.runtimeId);
+  }
+
+  #installRuntimeResourceMonitor(identity, runtime) {
+    if (!this.runtimeResourceMonitor || this.resourceMonitors.has(identity.runtimeId)) return;
+    const monitor = this.runtimeResourceMonitor.trackRuntime(identity, runtime);
+    this.resourceMonitors.set(identity.runtimeId, monitor);
   }
 
   async enforcePolicyViolation(identity, error) {

--- a/electron/plugins/runtimeSupervisor.test.cjs
+++ b/electron/plugins/runtimeSupervisor.test.cjs
@@ -619,6 +619,75 @@ test("lazy activation waits until the previous runtime has fully stopped", async
   assert.notEqual(secondIdentity.runtimeId, firstIdentity.runtimeId);
 });
 
+test("runtime stop waits for companion cleanup before it resolves", async (context) => {
+  const events = [];
+  let markCleanupEntered;
+  let releaseCleanup;
+  const cleanupEntered = new Promise((resolve) => { markCleanupEntered = resolve; });
+  const cleanupReleased = new Promise((resolve) => { releaseCleanup = resolve; });
+  const fixture = createFixture(context, () => ({
+    async start(config) {
+      return {
+        pluginId: config.pluginId,
+        pluginVersion: config.pluginVersion,
+        apiVersion: config.apiVersion,
+        enabledFeatures: config.enabledFeatures,
+      };
+    },
+    async stop() { events.push("runtime-stop"); },
+  }), {
+    async runtimeCleanup(identity) {
+      events.push(`cleanup:${identity.runtimeId}`);
+      markCleanupEntered(identity);
+      await cleanupReleased;
+    },
+  });
+  const identity = await fixture.supervisor.start(fixture.manifest.id);
+  let settled = false;
+  const stopping = fixture.supervisor.stop(fixture.manifest.id).finally(() => { settled = true; });
+  const cleanupIdentity = await cleanupEntered;
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(settled, false);
+  assert.deepEqual(cleanupIdentity, identity);
+  assert.deepEqual(events, ["runtime-stop", `cleanup:${identity.runtimeId}`]);
+  releaseCleanup();
+  await stopping;
+  assert.equal(fixture.database.getActivePlugin(fixture.manifest.id).runtime.status, "stopped");
+});
+
+test("companion cleanup containment failure is persisted and blocks restart", async (context) => {
+  const fixture = createFixture(context, () => ({
+    async start(config) {
+      return {
+        pluginId: config.pluginId,
+        pluginVersion: config.pluginVersion,
+        apiVersion: config.apiVersion,
+        enabledFeatures: config.enabledFeatures,
+      };
+    },
+    async stop() {},
+  }), {
+    async runtimeCleanup() { throw new Error("companion process tree survived"); },
+  });
+  await fixture.supervisor.start(fixture.manifest.id);
+
+  await assert.rejects(
+    fixture.supervisor.stop(fixture.manifest.id),
+    /companion process tree survived/,
+  );
+  const plugin = fixture.database.getActivePlugin(fixture.manifest.id);
+  assert.equal(plugin.enabled, false);
+  assert.equal(plugin.runtime.status, "quarantined");
+  assert.match(plugin.runtime.lastError, /companion process tree survived/);
+  assert.notEqual(plugin.runtime.quarantinedAt, null);
+  fixture.database.setEnabled(fixture.manifest.id, true);
+  fixture.database.clearQuarantine(fixture.manifest.id);
+  await assert.rejects(
+    fixture.supervisor.start(fixture.manifest.id),
+    /restart Netcatty before starting it again/,
+  );
+});
+
 test("containment failure disables the plugin and blocks replacement activation until restart", async (context) => {
   let factoryCalls = 0;
   const fixture = createFixture(context, () => {

--- a/electron/plugins/runtimeSupervisor.test.cjs
+++ b/electron/plugins/runtimeSupervisor.test.cjs
@@ -82,6 +82,7 @@ test("supervisor prefers the ordinary browser runtime and enforces negotiated id
 
   const started = await fixture.supervisor.start(fixture.manifest.id);
   assert.deepEqual(started, fixture.supervisor.getRuntimeIdentity(fixture.manifest.id));
+  assert.match(started.securityPrincipal, /^unsigned-package:/u);
   assert.equal(Object.hasOwn(started, "request"), false);
   assert.equal(Object.hasOwn(started, "stop"), false);
   assert.equal(fixture.runtimeOptions[0].plugin.manifest.main.browser, "dist/browser.js");

--- a/electron/plugins/runtimeSupervisor.test.cjs
+++ b/electron/plugins/runtimeSupervisor.test.cjs
@@ -119,12 +119,15 @@ test("supervisor verifies immutable package contents before runtime placement", 
 test("supervisor attaches the runtime quota monitor before activation completes", async (context) => {
   const events = [];
   let releaseActivation;
+  let signalProcessReady;
   const activation = new Promise((resolve) => { releaseActivation = resolve; });
+  const processReady = new Promise((resolve) => { signalProcessReady = resolve; });
   const fixture = createFixture(context, (options) => ({
     async start(config) {
       events.push("start");
       options.onProcessReady();
       events.push("process-ready");
+      signalProcessReady();
       await activation;
       return {
         pluginId: config.pluginId,
@@ -144,9 +147,12 @@ test("supervisor attaches the runtime quota monitor before activation completes"
     },
   });
   const starting = fixture.supervisor.start(fixture.manifest.id);
-  await new Promise((resolve) => setImmediate(resolve));
-  assert.deepEqual(events, ["start", "monitor", "process-ready"]);
-  releaseActivation();
+  await processReady;
+  try {
+    assert.deepEqual(events, ["start", "monitor", "process-ready"]);
+  } finally {
+    releaseActivation();
+  }
   await starting;
   assert.equal(events.filter((event) => event === "monitor").length, 1);
   await fixture.supervisor.stop(fixture.manifest.id);

--- a/electron/plugins/runtimeSupervisor.test.cjs
+++ b/electron/plugins/runtimeSupervisor.test.cjs
@@ -116,6 +116,42 @@ test("supervisor verifies immutable package contents before runtime placement", 
   assert.deepEqual(fixture.runtimeOptions, []);
 });
 
+test("supervisor attaches the runtime quota monitor before activation completes", async (context) => {
+  const events = [];
+  let releaseActivation;
+  const activation = new Promise((resolve) => { releaseActivation = resolve; });
+  const fixture = createFixture(context, (options) => ({
+    async start(config) {
+      events.push("start");
+      options.onProcessReady();
+      events.push("process-ready");
+      await activation;
+      return {
+        pluginId: config.pluginId,
+        pluginVersion: config.pluginVersion,
+        apiVersion: config.apiVersion,
+        enabledFeatures: config.enabledFeatures,
+      };
+    },
+    async stop() {},
+  }), {
+    runtimeResourceMonitor: {
+      trackRuntime() {
+        events.push("monitor");
+        return { dispose() {} };
+      },
+      releaseRuntime() {},
+    },
+  });
+  const starting = fixture.supervisor.start(fixture.manifest.id);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(events, ["start", "monitor", "process-ready"]);
+  releaseActivation();
+  await starting;
+  assert.equal(events.filter((event) => event === "monitor").length, 1);
+  await fixture.supervisor.stop(fixture.manifest.id);
+});
+
 test("repeated activation failures quarantine after the third crash window event", async (context) => {
   const fixture = createFixture(context, () => ({
     async start() { throw new Error("activation failed"); },

--- a/electron/plugins/secretLease.cjs
+++ b/electron/plugins/secretLease.cjs
@@ -1,0 +1,162 @@
+"use strict";
+
+const { randomBytes } = require("node:crypto");
+
+const { PluginRpcError, RPC_ERRORS } = require("./rpcRouter.cjs");
+
+const DEFAULT_SECRET_LEASE_TTL_MS = 30_000;
+const MAX_SECRET_LEASE_TTL_MS = 60_000;
+const MAX_SECRET_LEASES_PER_RUNTIME = 128;
+
+function assertLeaseReference(lease) {
+  if (
+    !lease
+    || typeof lease !== "object"
+    || Array.isArray(lease)
+    || lease.kind !== "secret-lease"
+    || typeof lease.id !== "string"
+    || lease.id.length < 32
+    || lease.id.length > 256
+  ) throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Secret lease reference is invalid");
+  return lease.id;
+}
+
+class SecretLeaseStore {
+  constructor(options) {
+    this.secretStore = options.secretStore;
+    this.clock = options.clock ?? (() => Date.now());
+    this.randomBytes = options.randomBytes ?? randomBytes;
+    this.setTimer = options.setTimeout ?? setTimeout;
+    this.clearTimer = options.clearTimeout ?? clearTimeout;
+    this.leases = new Map();
+    this.closed = false;
+  }
+
+  issue(options) {
+    if (this.closed) throw new PluginRpcError(RPC_ERRORS.unavailable, "Secret lease broker is closed");
+    if (options.signal?.aborted) {
+      throw new PluginRpcError(RPC_ERRORS.cancelled, "Secret lease operation was cancelled");
+    }
+    const activeCount = [...this.leases.values()].filter((lease) => (
+      lease.runtimeId === options.runtimeId
+    )).length;
+    if (activeCount >= MAX_SECRET_LEASES_PER_RUNTIME) {
+      throw new PluginRpcError(RPC_ERRORS.resourceExhausted, "Too many active secret leases");
+    }
+    const ttlMs = options.ttlMs ?? DEFAULT_SECRET_LEASE_TTL_MS;
+    if (!Number.isSafeInteger(ttlMs) || ttlMs < 1 || ttlMs > MAX_SECRET_LEASE_TTL_MS) {
+      throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Secret lease lifetime is invalid");
+    }
+    const id = this.randomBytes(24).toString("base64url");
+    if (options.resolveSecret !== undefined && typeof options.resolveSecret !== "function") {
+      throw new TypeError("Secret lease resolver must be a function");
+    }
+    const credential = options.credential ?? options.secret;
+    if (!credential) throw new TypeError("Secret lease credential is required");
+    const expiresAt = this.clock() + ttlMs;
+    const record = {
+      id,
+      pluginId: options.pluginId,
+      runtimeId: options.runtimeId,
+      credential,
+      resolveSecret: options.resolveSecret ?? null,
+      operationId: options.operationId,
+      purpose: options.purpose,
+      expiresAt,
+      timer: null,
+      abortCleanup: null,
+    };
+    record.timer = this.setTimer(() => this.#delete(id), ttlMs);
+    record.timer?.unref?.();
+    if (options.signal) {
+      const onAbort = () => this.#delete(id);
+      options.signal.addEventListener("abort", onAbort, { once: true });
+      record.abortCleanup = () => options.signal.removeEventListener("abort", onAbort);
+    }
+    this.leases.set(id, record);
+    if (options.signal?.aborted) {
+      this.#delete(id);
+      throw new PluginRpcError(RPC_ERRORS.cancelled, "Secret lease operation was cancelled");
+    }
+    return Object.freeze({
+      kind: "secret-lease",
+      id,
+      operationId: options.operationId,
+      expiresAt,
+    });
+  }
+
+  consume(options) {
+    if (options.signal?.aborted) {
+      throw new PluginRpcError(RPC_ERRORS.cancelled, "Secret lease operation was cancelled");
+    }
+    const id = assertLeaseReference(options.lease);
+    const record = this.leases.get(id);
+    if (!record || record.expiresAt <= this.clock()) {
+      this.#delete(id);
+      throw new PluginRpcError(RPC_ERRORS.notFound, "Secret lease is missing or expired");
+    }
+    if (
+      record.pluginId !== options.pluginId
+      || record.runtimeId !== options.runtimeId
+      || record.operationId !== options.operationId
+    ) throw new PluginRpcError(RPC_ERRORS.permissionDenied, "Secret lease scope does not match the operation");
+    this.#delete(id);
+    const consumeContext = Object.freeze({
+      pluginId: record.pluginId,
+      runtimeId: record.runtimeId,
+      operationId: record.operationId,
+      credential: record.credential,
+      signal: options.signal,
+    });
+    const resolved = record.resolveSecret
+      ? record.resolveSecret(consumeContext)
+      : this.secretStore.resolve(record.pluginId, record.credential);
+    if (!resolved || typeof resolved.then !== "function") {
+      if (options.signal?.aborted) {
+        throw new PluginRpcError(RPC_ERRORS.cancelled, "Secret lease operation was cancelled");
+      }
+      return resolved;
+    }
+    return Promise.resolve(resolved).then((value) => {
+      if (options.signal?.aborted) {
+        throw new PluginRpcError(RPC_ERRORS.cancelled, "Secret lease operation was cancelled");
+      }
+      return value;
+    });
+  }
+
+  #delete(id) {
+    const record = this.leases.get(id);
+    if (!record) return false;
+    this.leases.delete(id);
+    this.clearTimer(record.timer);
+    record.abortCleanup?.();
+    return true;
+  }
+
+  revokeRuntime(runtimeId) {
+    for (const [id, lease] of [...this.leases]) {
+      if (lease.runtimeId === runtimeId) this.#delete(id);
+    }
+  }
+
+  revokeOperation(pluginId, operationId) {
+    for (const [id, lease] of [...this.leases]) {
+      if (lease.pluginId === pluginId && lease.operationId === operationId) this.#delete(id);
+    }
+  }
+
+  shutdown() {
+    this.closed = true;
+    for (const id of [...this.leases.keys()]) this.#delete(id);
+  }
+}
+
+module.exports = {
+  DEFAULT_SECRET_LEASE_TTL_MS,
+  MAX_SECRET_LEASES_PER_RUNTIME,
+  MAX_SECRET_LEASE_TTL_MS,
+  SecretLeaseStore,
+  assertLeaseReference,
+};

--- a/electron/plugins/secretStore.cjs
+++ b/electron/plugins/secretStore.cjs
@@ -1,0 +1,102 @@
+"use strict";
+
+const { randomBytes } = require("node:crypto");
+
+const { PluginRpcError, RPC_ERRORS } = require("./rpcRouter.cjs");
+
+const MAX_SECRET_BYTES = 64 * 1024;
+
+function assertSecretKey(key) {
+  if (typeof key !== "string" || key.length < 1 || key.length > 256 || key.includes("\0")) {
+    throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Plugin secret key is invalid");
+  }
+  return key;
+}
+
+function assertSecretRef(secret) {
+  if (
+    !secret
+    || typeof secret !== "object"
+    || Array.isArray(secret)
+    || secret.kind !== "secret"
+    || typeof secret.id !== "string"
+    || secret.id.length < 16
+    || secret.id.length > 256
+  ) throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Plugin secret reference is invalid");
+  return secret.id;
+}
+
+class PluginSecretStore {
+  constructor(options) {
+    this.database = options.database;
+    this.safeStorage = options.safeStorage ?? null;
+    this.randomBytes = options.randomBytes ?? randomBytes;
+  }
+
+  #assertAvailable() {
+    const backend = this.safeStorage?.getSelectedStorageBackend?.();
+    if (
+      !this.safeStorage?.isEncryptionAvailable?.()
+      || backend === "basic_text"
+      || typeof this.safeStorage.encryptString !== "function"
+      || typeof this.safeStorage.decryptString !== "function"
+    ) {
+      throw new PluginRpcError(
+        RPC_ERRORS.unavailable,
+        "Secure OS-backed encryption is unavailable for plugin secrets",
+      );
+    }
+  }
+
+  getReference(pluginId, key) {
+    assertSecretKey(key);
+    const record = this.database.getSecretByKey(pluginId, key);
+    return record ? Object.freeze({ kind: "secret", id: record.secretRef }) : undefined;
+  }
+
+  getRecordByReference(pluginId, secret) {
+    const secretRef = assertSecretRef(secret);
+    const record = this.database.getSecretByRef(pluginId, secretRef);
+    if (!record) {
+      throw new PluginRpcError(RPC_ERRORS.notFound, "Plugin secret reference was not found");
+    }
+    return record;
+  }
+
+  set(pluginId, key, value) {
+    this.#assertAvailable();
+    assertSecretKey(key);
+    if (typeof value !== "string" || Buffer.byteLength(value, "utf8") > MAX_SECRET_BYTES) {
+      throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Plugin secret value is invalid or too large");
+    }
+    const secretRef = this.randomBytes(24).toString("base64url");
+    const ciphertext = this.safeStorage.encryptString(value);
+    if (!Buffer.isBuffer(ciphertext) || ciphertext.byteLength < 1) {
+      throw new PluginRpcError(RPC_ERRORS.unavailable, "OS-backed plugin secret encryption failed");
+    }
+    this.database.upsertSecret({ pluginId, key, secretRef, ciphertext });
+    return Object.freeze({ kind: "secret", id: secretRef });
+  }
+
+  delete(pluginId, key) {
+    assertSecretKey(key);
+    this.database.deleteSecret(pluginId, key);
+  }
+
+  resolve(pluginId, secret) {
+    this.#assertAvailable();
+    const record = this.getRecordByReference(pluginId, secret);
+    try {
+      return this.safeStorage.decryptString(record.ciphertext);
+    } catch {
+      throw new PluginRpcError(RPC_ERRORS.dataLoss, "Plugin secret could not be decrypted");
+    }
+  }
+}
+
+module.exports = {
+  MAX_SECRET_BYTES,
+  PluginSecretStore,
+  assertSecretKey,
+  assertSecretRef,
+};

--- a/electron/plugins/secretStore.cjs
+++ b/electron/plugins/secretStore.cjs
@@ -22,8 +22,12 @@ function assertSecretRef(secret) {
     || typeof secret.id !== "string"
     || secret.id.length < 16
     || secret.id.length > 256
+    || typeof secret.key !== "string"
+    || secret.key.length < 1
+    || secret.key.length > 256
+    || secret.key.includes("\0")
   ) throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Plugin secret reference is invalid");
-  return secret.id;
+  return { id: secret.id, key: secret.key };
 }
 
 class PluginSecretStore {
@@ -51,13 +55,13 @@ class PluginSecretStore {
   getReference(pluginId, key) {
     assertSecretKey(key);
     const record = this.database.getSecretByKey(pluginId, key);
-    return record ? Object.freeze({ kind: "secret", id: record.secretRef }) : undefined;
+    return record ? Object.freeze({ kind: "secret", id: record.secretRef, key: record.key }) : undefined;
   }
 
   getRecordByReference(pluginId, secret) {
-    const secretRef = assertSecretRef(secret);
-    const record = this.database.getSecretByRef(pluginId, secretRef);
-    if (!record) {
+    const reference = assertSecretRef(secret);
+    const record = this.database.getSecretByRef(pluginId, reference.id);
+    if (!record || record.key !== reference.key) {
       throw new PluginRpcError(RPC_ERRORS.notFound, "Plugin secret reference was not found");
     }
     return record;
@@ -75,7 +79,7 @@ class PluginSecretStore {
       throw new PluginRpcError(RPC_ERRORS.unavailable, "OS-backed plugin secret encryption failed");
     }
     this.database.upsertSecret({ pluginId, key, secretRef, ciphertext });
-    return Object.freeze({ kind: "secret", id: secretRef });
+    return Object.freeze({ kind: "secret", id: secretRef, key });
   }
 
   delete(pluginId, key) {

--- a/electron/plugins/secretStore.test.cjs
+++ b/electron/plugins/secretStore.test.cjs
@@ -157,11 +157,13 @@ test("Netcatty credentials resolve only when a one-use provider lease is consume
   const secretStore = new PluginSecretStore({ database, safeStorage: fakeSafeStorage() });
   const leaseStore = new SecretLeaseStore({ secretStore });
   let resolved = 0;
+  let referenceChecks = 0;
   const broker = new PluginCredentialBroker({
     secretStore,
     leaseStore,
     credentialResolver: {
       assertReference: async (reference, leaseContext) => {
+        referenceChecks += 1;
         assert.equal(reference.id, "vault-credential-1");
         assert.equal(leaseContext.operationId, "connection:open-1");
       },
@@ -185,8 +187,10 @@ test("Netcatty credentials resolve only when a one-use provider lease is consume
     operationId: "connection:open-1",
     purpose: "Authenticate connection",
   };
-  assert.equal((await broker.describeAuthorization(params, runtime)).permission, "vault.credentials");
+  assert.deepEqual(broker.describeAuthorization(params).resources, ["credential:vault-credential-1"]);
+  assert.equal(referenceChecks, 0);
   const lease = await broker.createLease(params, runtime);
+  assert.equal(referenceChecks, 1);
   assert.equal(resolved, 0);
   assert.equal(await broker.consumeLease(runtime, lease, "connection:open-1"), "host-owned-plaintext");
   assert.equal(resolved, 1);
@@ -196,6 +200,58 @@ test("Netcatty credentials resolve only when a one-use provider lease is consume
   );
   leaseStore.shutdown();
   database.close();
+});
+
+test("credential authorization descriptors do not probe opaque references before permission", async () => {
+  let credentialChecks = 0;
+  let secretChecks = 0;
+  const broker = new PluginCredentialBroker({
+    secretStore: {
+      getRecordByReference() {
+        secretChecks += 1;
+        throw new Error("unknown plugin secret");
+      },
+    },
+    leaseStore: { issue: () => { throw new Error("lease must not be issued"); } },
+    credentialResolver: {
+      async assertReference() {
+        credentialChecks += 1;
+        throw new Error("unknown Netcatty credential");
+      },
+      async resolve() { throw new Error("credential must not resolve"); },
+    },
+  });
+  const base = {
+    operationId: "connection:open-1",
+    purpose: "Authenticate connection",
+  };
+  assert.deepEqual(broker.describeAuthorization({
+    ...base,
+    secret: { kind: "credential", id: "unknown-credential" },
+  }).resources, ["credential:unknown-credential"]);
+  assert.deepEqual(broker.describeAuthorization({
+    ...base,
+    secret: { kind: "secret", id: "unknown-secret-reference" },
+  }).resources, ["secret-ref:unknown-secret-reference"]);
+  assert.equal(credentialChecks, 0);
+  assert.equal(secretChecks, 0);
+
+  const runtime = {
+    pluginId: "com.example.provider",
+    runtimeId: "runtime-provider",
+    signal: new AbortController().signal,
+    assertActive: async () => {},
+  };
+  await assert.rejects(broker.createLease({
+    ...base,
+    secret: { kind: "credential", id: "unknown-credential" },
+  }, runtime), /unknown Netcatty credential/);
+  assert.equal(credentialChecks, 1);
+  await assert.rejects(broker.createLease({
+    ...base,
+    secret: { kind: "secret", id: "unknown-secret-reference" },
+  }, runtime), /unknown plugin secret/);
+  assert.equal(secretChecks, 1);
 });
 
 test("credential lease resolution cannot return plaintext after operation cancellation", async (context) => {

--- a/electron/plugins/secretStore.test.cjs
+++ b/electron/plugins/secretStore.test.cjs
@@ -46,6 +46,10 @@ test("plugin secrets are OS-encrypted, opaque, ownership-bound, and uninstall-in
     () => store.resolve("com.example.two", secret),
     (error) => error.code === RPC_ERRORS.notFound,
   );
+  assert.throws(
+    () => store.resolve("com.example.one", { ...secret, key: "different-key" }),
+    (error) => error.code === RPC_ERRORS.notFound,
+  );
   store.delete("com.example.one", "api-key");
   assert.equal(store.getReference("com.example.one", "api-key"), undefined);
   database.close();
@@ -231,8 +235,8 @@ test("credential authorization descriptors do not probe opaque references before
   }).resources, ["credential:unknown-credential"]);
   assert.deepEqual(broker.describeAuthorization({
     ...base,
-    secret: { kind: "secret", id: "unknown-secret-reference" },
-  }).resources, ["secret-ref:unknown-secret-reference"]);
+    secret: { kind: "secret", id: "unknown-secret-reference", key: "api-key" },
+  }).resources, ["secret:api-key"]);
   assert.equal(credentialChecks, 0);
   assert.equal(secretChecks, 0);
 
@@ -249,7 +253,7 @@ test("credential authorization descriptors do not probe opaque references before
   assert.equal(credentialChecks, 1);
   await assert.rejects(broker.createLease({
     ...base,
-    secret: { kind: "secret", id: "unknown-secret-reference" },
+    secret: { kind: "secret", id: "unknown-secret-reference", key: "api-key" },
   }, runtime), /unknown plugin secret/);
   assert.equal(secretChecks, 1);
 });

--- a/electron/plugins/secretStore.test.cjs
+++ b/electron/plugins/secretStore.test.cjs
@@ -1,0 +1,243 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { PluginCredentialBroker } = require("./credentialBroker.cjs");
+const { PluginDatabase } = require("./database.cjs");
+const { RPC_ERRORS } = require("./rpcRouter.cjs");
+const { SecretLeaseStore } = require("./secretLease.cjs");
+const { PluginSecretStore } = require("./secretStore.cjs");
+
+function createDatabase(context) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-secrets-"));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return new PluginDatabase(path.join(root, "plugins.sqlite"));
+}
+
+function fakeSafeStorage() {
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => Buffer.from(`sealed:${Buffer.from(value).toString("base64")}`),
+    decryptString: (value) => {
+      const encoded = value.toString().slice("sealed:".length);
+      return Buffer.from(encoded, "base64").toString();
+    },
+  };
+}
+
+test("plugin secrets are OS-encrypted, opaque, ownership-bound, and uninstall-independent", (context) => {
+  const database = createDatabase(context);
+  let random = 0;
+  const store = new PluginSecretStore({
+    database,
+    safeStorage: fakeSafeStorage(),
+    randomBytes: () => Buffer.alloc(24, ++random),
+  });
+  const secret = store.set("com.example.one", "api-key", "plaintext-token");
+  const record = database.getSecretByKey("com.example.one", "api-key");
+  assert.equal(record.ciphertext.includes(Buffer.from("plaintext-token")), false);
+  assert.deepEqual(store.getReference("com.example.one", "api-key"), secret);
+  assert.equal(store.resolve("com.example.one", secret), "plaintext-token");
+  assert.throws(
+    () => store.resolve("com.example.two", secret),
+    (error) => error.code === RPC_ERRORS.notFound,
+  );
+  store.delete("com.example.one", "api-key");
+  assert.equal(store.getReference("com.example.one", "api-key"), undefined);
+  database.close();
+});
+
+test("plugin secrets fail closed when OS encryption is unavailable or ciphertext is corrupt", (context) => {
+  const database = createDatabase(context);
+  const unavailable = new PluginSecretStore({ database, safeStorage: null });
+  assert.throws(
+    () => unavailable.set("com.example.one", "api-key", "value"),
+    (error) => error.code === RPC_ERRORS.unavailable,
+  );
+  const insecureBackend = new PluginSecretStore({
+    database,
+    safeStorage: {
+      ...fakeSafeStorage(),
+      getSelectedStorageBackend: () => "basic_text",
+    },
+  });
+  assert.throws(
+    () => insecureBackend.set("com.example.one", "api-key", "value"),
+    (error) => error.code === RPC_ERRORS.unavailable,
+  );
+
+  const safeStorage = fakeSafeStorage();
+  const store = new PluginSecretStore({ database, safeStorage });
+  const secret = store.set("com.example.one", "api-key", "value");
+  safeStorage.decryptString = () => { throw new Error("corrupt"); };
+  assert.throws(
+    () => store.resolve("com.example.one", secret),
+    (error) => error.code === RPC_ERRORS.dataLoss,
+  );
+  database.close();
+});
+
+test("credential leases are one-use and bound to plugin, runtime, operation, abort, and expiry", async (context) => {
+  const database = createDatabase(context);
+  let now = 1_000;
+  let random = 0;
+  const secretStore = new PluginSecretStore({
+    database,
+    safeStorage: fakeSafeStorage(),
+    randomBytes: () => Buffer.alloc(24, ++random),
+  });
+  const secret = secretStore.set("com.example.one", "api-key", "credential-value");
+  const leaseStore = new SecretLeaseStore({
+    secretStore,
+    clock: () => now,
+    randomBytes: () => Buffer.alloc(24, ++random),
+    setTimeout: () => ({ timer: true }),
+    clearTimeout: () => {},
+  });
+  const broker = new PluginCredentialBroker({ secretStore, leaseStore });
+  const runtime = {
+    pluginId: "com.example.one",
+    runtimeId: "runtime-1",
+    signal: new AbortController().signal,
+    assertActive: async () => {},
+  };
+  const lease = leaseStore.issue({
+    ...runtime,
+    secret,
+    operationId: "network:login",
+    purpose: "Authenticate",
+    ttlMs: 500,
+  });
+  await assert.rejects(
+    broker.consumeLease({ ...runtime, runtimeId: "runtime-2" }, lease, "network:login"),
+    (error) => error.code === RPC_ERRORS.permissionDenied,
+  );
+  assert.equal(await broker.consumeLease(runtime, lease, "network:login"), "credential-value");
+  await assert.rejects(
+    broker.consumeLease(runtime, lease, "network:login"),
+    (error) => error.code === RPC_ERRORS.notFound,
+  );
+
+  const expired = leaseStore.issue({
+    ...runtime,
+    secret,
+    operationId: "network:expired",
+    purpose: "Expire",
+    ttlMs: 1,
+  });
+  now += 2;
+  await assert.rejects(
+    broker.consumeLease(runtime, expired, "network:expired"),
+    (error) => error.code === RPC_ERRORS.notFound,
+  );
+
+  const controller = new AbortController();
+  const aborted = leaseStore.issue({
+    ...runtime,
+    signal: controller.signal,
+    secret,
+    operationId: "network:aborted",
+    purpose: "Abort",
+  });
+  controller.abort();
+  await assert.rejects(
+    broker.consumeLease(runtime, aborted, "network:aborted"),
+    (error) => error.code === RPC_ERRORS.notFound,
+  );
+  leaseStore.shutdown();
+  database.close();
+});
+
+test("Netcatty credentials resolve only when a one-use provider lease is consumed", async (context) => {
+  const database = createDatabase(context);
+  const secretStore = new PluginSecretStore({ database, safeStorage: fakeSafeStorage() });
+  const leaseStore = new SecretLeaseStore({ secretStore });
+  let resolved = 0;
+  const broker = new PluginCredentialBroker({
+    secretStore,
+    leaseStore,
+    credentialResolver: {
+      assertReference: async (reference, leaseContext) => {
+        assert.equal(reference.id, "vault-credential-1");
+        assert.equal(leaseContext.operationId, "connection:open-1");
+      },
+      resolve: async (reference, consumeContext) => {
+        resolved += 1;
+        assert.equal(reference.id, "vault-credential-1");
+        assert.equal(consumeContext.pluginId, "com.example.provider");
+        assert.equal(consumeContext.purpose, "Authenticate connection");
+        return "host-owned-plaintext";
+      },
+    },
+  });
+  const runtime = {
+    pluginId: "com.example.provider",
+    runtimeId: "runtime-provider",
+    signal: new AbortController().signal,
+    assertActive: async () => {},
+  };
+  const params = {
+    secret: { kind: "credential", id: "vault-credential-1" },
+    operationId: "connection:open-1",
+    purpose: "Authenticate connection",
+  };
+  assert.equal((await broker.describeAuthorization(params, runtime)).permission, "vault.credentials");
+  const lease = await broker.createLease(params, runtime);
+  assert.equal(resolved, 0);
+  assert.equal(await broker.consumeLease(runtime, lease, "connection:open-1"), "host-owned-plaintext");
+  assert.equal(resolved, 1);
+  await assert.rejects(
+    broker.consumeLease(runtime, lease, "connection:open-1"),
+    (error) => error.code === RPC_ERRORS.notFound,
+  );
+  leaseStore.shutdown();
+  database.close();
+});
+
+test("credential lease resolution cannot return plaintext after operation cancellation", async (context) => {
+  const database = createDatabase(context);
+  const secretStore = new PluginSecretStore({ database, safeStorage: fakeSafeStorage() });
+  const leaseStore = new SecretLeaseStore({ secretStore });
+  const controller = new AbortController();
+  let releaseResolution;
+  let resolutionSignal;
+  const broker = new PluginCredentialBroker({
+    secretStore,
+    leaseStore,
+    credentialResolver: {
+      assertReference: async () => {},
+      resolve: async (_reference, consumeContext) => {
+        resolutionSignal = consumeContext.signal;
+        await new Promise((resolve) => { releaseResolution = resolve; });
+        return "must-not-escape-after-cancel";
+      },
+    },
+  });
+  const runtime = {
+    pluginId: "com.example.provider",
+    runtimeId: "runtime-provider",
+    signal: controller.signal,
+    assertActive: async () => controller.signal.throwIfAborted(),
+  };
+  const params = {
+    secret: { kind: "credential", id: "vault-credential-1" },
+    operationId: "connection:open-1",
+    purpose: "Authenticate connection",
+  };
+  const lease = await broker.createLease(params, runtime);
+  const consuming = broker.consumeLease(runtime, lease, "connection:open-1");
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(resolutionSignal, controller.signal);
+  controller.abort();
+  releaseResolution();
+  await assert.rejects(
+    consuming,
+    (error) => error.code === RPC_ERRORS.cancelled,
+  );
+  leaseStore.shutdown();
+  database.close();
+});

--- a/electron/plugins/secureCapabilities.cjs
+++ b/electron/plugins/secureCapabilities.cjs
@@ -62,7 +62,7 @@ function registerSecurePluginCapabilities(registry, options) {
   ), {
     metadata: { capability: "credentials", mutating: true, permission: "secrets" },
     validateParams: options.assertLeaseParams,
-    authorization: (params, context) => options.credentialBroker.describeAuthorization(params, context),
+    authorization: (params) => options.credentialBroker.describeAuthorization(params),
   });
 
   registry.registerRequest("network.request", (params, context) => (
@@ -78,21 +78,21 @@ function registerSecurePluginCapabilities(registry, options) {
   ), {
     metadata: { capability: "filesystem", mutating: false, permission: "filesystem.read" },
     validateParams: (params) => options.filesystemBroker.validateRead(params),
-    authorization: (params) => options.filesystemBroker.describeReadAuthorization(params),
+    authorization: (params) => options.filesystemBroker.describeReadAuthorization(params, "exact"),
   });
   registry.registerRequest("filesystem.stat", (params, context) => (
     options.filesystemBroker.stat(params, context)
   ), {
     metadata: { capability: "filesystem", mutating: false, permission: "filesystem.read" },
     validateParams: (params) => options.filesystemBroker.validatePath(params),
-    authorization: (params) => options.filesystemBroker.describeReadAuthorization(params),
+    authorization: (params) => options.filesystemBroker.describeReadAuthorization(params, "exact"),
   });
   registry.registerRequest("filesystem.readDirectory", (params, context) => (
     options.filesystemBroker.readDirectory(params, context)
   ), {
     metadata: { capability: "filesystem", mutating: false, permission: "filesystem.read" },
     validateParams: (params) => options.filesystemBroker.validatePath(params),
-    authorization: (params) => options.filesystemBroker.describeReadAuthorization(params),
+    authorization: (params) => options.filesystemBroker.describeReadAuthorization(params, "directory"),
   });
   registry.registerRequest("filesystem.writeFile", (params, context) => (
     options.filesystemBroker.writeFile(params, context)

--- a/electron/plugins/secureCapabilities.cjs
+++ b/electron/plugins/secureCapabilities.cjs
@@ -107,7 +107,9 @@ function registerSecurePluginCapabilities(registry, options) {
   ), {
     metadata: { capability: "companion", mutating: true, permission: "companion.execute" },
     validateParams: (params) => options.companionSupervisor.validateStart(params),
-    authorization: (params) => options.companionSupervisor.describeStartAuthorization(params),
+    authorization: (params, context) => (
+      options.companionSupervisor.describeStartAuthorization(params, context)
+    ),
   });
   registry.registerRequest("companion.request", (params, context) => (
     options.companionSupervisor.request(params, context)

--- a/electron/plugins/secureCapabilities.cjs
+++ b/electron/plugins/secureCapabilities.cjs
@@ -1,0 +1,126 @@
+"use strict";
+
+const { PluginRpcError, RPC_ERRORS } = require("./rpcRouter.cjs");
+const { assertSecretKey } = require("./secretStore.cjs");
+
+function assertSecretParams(params, options = {}) {
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Plugin secret parameters are invalid");
+  }
+  const key = assertSecretKey(params.key);
+  if (options.value) {
+    if (typeof params.value !== "string") {
+      throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Plugin secret value is invalid");
+    }
+    return { key, value: params.value };
+  }
+  return { key };
+}
+
+function secretAuthorization(params, action) {
+  const value = assertSecretParams(params);
+  return {
+    permission: "secrets",
+    resources: [`secret:${value.key}`],
+    reason: `${action} plugin secret ${value.key}`,
+    operationId: `secret:${action.toLowerCase()}:${value.key}`,
+  };
+}
+
+function registerSecurePluginCapabilities(registry, options) {
+  registry.use(options.quotaManager.createMiddleware());
+  registry.use(options.permissionEngine.createMiddleware());
+
+  registry.registerRequest("secrets.get", async ({ key }, context) => {
+    const secret = options.secretStore.getReference(context.pluginId, key);
+    return secret ? { found: true, secret } : { found: false };
+  }, {
+    metadata: { capability: "secrets", mutating: false, permission: "secrets" },
+    validateParams: (params) => assertSecretParams(params),
+    authorization: (params) => secretAuthorization(params, "Read"),
+  });
+  registry.registerRequest("secrets.set", async ({ key, value }, context) => ({
+    secret: options.secretStore.set(context.pluginId, key, value),
+  }), {
+    metadata: { capability: "secrets", mutating: true, permission: "secrets" },
+    validateParams: (params) => assertSecretParams(params, { value: true }),
+    authorization: (params) => secretAuthorization(params, "Store"),
+  });
+  registry.registerRequest("secrets.delete", async ({ key }, context) => {
+    options.secretStore.delete(context.pluginId, key);
+    return null;
+  }, {
+    metadata: { capability: "secrets", mutating: true, permission: "secrets" },
+    validateParams: (params) => assertSecretParams(params),
+    authorization: (params) => secretAuthorization(params, "Delete"),
+  });
+
+  registry.registerRequest("credentials.createLease", (params, context) => (
+    options.credentialBroker.createLease(params, context)
+  ), {
+    metadata: { capability: "credentials", mutating: true, permission: "secrets" },
+    validateParams: options.assertLeaseParams,
+    authorization: (params, context) => options.credentialBroker.describeAuthorization(params, context),
+  });
+
+  registry.registerRequest("network.request", (params, context) => (
+    options.networkBroker.request(params, context)
+  ), {
+    metadata: { capability: "network", mutating: true, permission: "network" },
+    validateParams: (params) => options.networkBroker.validate(params),
+    authorization: (params) => options.networkBroker.describeAuthorization(params),
+  });
+
+  registry.registerRequest("filesystem.readFile", (params, context) => (
+    options.filesystemBroker.readFile(params, context)
+  ), {
+    metadata: { capability: "filesystem", mutating: false, permission: "filesystem.read" },
+    validateParams: (params) => options.filesystemBroker.validateRead(params),
+    authorization: (params) => options.filesystemBroker.describeReadAuthorization(params),
+  });
+  registry.registerRequest("filesystem.stat", (params, context) => (
+    options.filesystemBroker.stat(params, context)
+  ), {
+    metadata: { capability: "filesystem", mutating: false, permission: "filesystem.read" },
+    validateParams: (params) => options.filesystemBroker.validatePath(params),
+    authorization: (params) => options.filesystemBroker.describeReadAuthorization(params),
+  });
+  registry.registerRequest("filesystem.readDirectory", (params, context) => (
+    options.filesystemBroker.readDirectory(params, context)
+  ), {
+    metadata: { capability: "filesystem", mutating: false, permission: "filesystem.read" },
+    validateParams: (params) => options.filesystemBroker.validatePath(params),
+    authorization: (params) => options.filesystemBroker.describeReadAuthorization(params),
+  });
+  registry.registerRequest("filesystem.writeFile", (params, context) => (
+    options.filesystemBroker.writeFile(params, context)
+  ), {
+    metadata: { capability: "filesystem", mutating: true, permission: "filesystem.write" },
+    validateParams: (params) => options.filesystemBroker.validateWrite(params),
+    authorization: (params) => options.filesystemBroker.describeWriteAuthorization(params),
+  });
+
+  registry.registerRequest("companion.start", (params, context) => (
+    options.companionSupervisor.start(params, context)
+  ), {
+    metadata: { capability: "companion", mutating: true, permission: "companion.execute" },
+    validateParams: (params) => options.companionSupervisor.validateStart(params),
+    authorization: (params) => options.companionSupervisor.describeStartAuthorization(params),
+  });
+  registry.registerRequest("companion.request", (params, context) => (
+    options.companionSupervisor.request(params, context)
+  ), {
+    metadata: { capability: "companion", mutating: true, permission: "companion.execute" },
+    validateParams: (params) => options.companionSupervisor.validateRequest(params),
+    authorization: (params, context) => options.companionSupervisor.describeHandleAuthorization(params, context),
+  });
+  registry.registerRequest("companion.stop", (params, context) => (
+    options.companionSupervisor.stop(params, context)
+  ), {
+    metadata: { capability: "companion", mutating: true, permission: "companion.execute" },
+    validateParams: (params) => options.companionSupervisor.validateStop(params),
+    authorization: (params, context) => options.companionSupervisor.describeHandleAuthorization(params, context),
+  });
+}
+
+module.exports = { assertSecretParams, registerSecurePluginCapabilities, secretAuthorization };

--- a/electron/plugins/secureCapabilities.cjs
+++ b/electron/plugins/secureCapabilities.cjs
@@ -39,14 +39,16 @@ function registerSecurePluginCapabilities(registry, options) {
     validateParams: (params) => assertSecretParams(params),
     authorization: (params) => secretAuthorization(params, "Read"),
   });
-  registry.registerRequest("secrets.set", async ({ key, value }, context) => ({
-    secret: options.secretStore.set(context.pluginId, key, value),
-  }), {
+  registry.registerRequest("secrets.set", async ({ key, value }, context) => {
+    await context.assertActive();
+    return { secret: options.secretStore.set(context.pluginId, key, value) };
+  }, {
     metadata: { capability: "secrets", mutating: true, permission: "secrets" },
     validateParams: (params) => assertSecretParams(params, { value: true }),
     authorization: (params) => secretAuthorization(params, "Store"),
   });
   registry.registerRequest("secrets.delete", async ({ key }, context) => {
+    await context.assertActive();
     options.secretStore.delete(context.pluginId, key);
     return null;
   }, {

--- a/electron/plugins/secureCapabilities.test.cjs
+++ b/electron/plugins/secureCapabilities.test.cjs
@@ -58,3 +58,57 @@ test("secret mutations recheck runtime activity immediately before commit", asyn
   );
   assert.deepEqual(events, ["active", "set", "active", "delete"]);
 });
+
+test("filesystem RPC authorization fixes resource kind by operation without host I/O", () => {
+  const registrations = new Map();
+  const registry = {
+    use() {},
+    registerRequest(method, handler, options) { registrations.set(method, { handler, options }); },
+  };
+  const middlewareOwner = { createMiddleware: () => async (_context, next) => next() };
+  const filesystemCalls = [];
+  const filesystemBroker = {
+    validateRead: (params) => params,
+    validateWrite: (params) => params,
+    validatePath: (params) => params,
+    describeReadAuthorization(params, resourceKind) {
+      filesystemCalls.push([params.path, resourceKind]);
+      return { permission: "filesystem.read", resources: [params.path], resourceKinds: [resourceKind] };
+    },
+    describeWriteAuthorization(params) {
+      filesystemCalls.push([params.path, "exact"]);
+      return { permission: "filesystem.write", resources: [params.path], resourceKinds: ["exact"] };
+    },
+    readFile: async () => null,
+    stat: async () => null,
+    readDirectory: async () => null,
+    writeFile: async () => null,
+  };
+  const broker = new Proxy({}, { get: () => () => ({}) });
+  registerSecurePluginCapabilities(registry, {
+    quotaManager: middlewareOwner,
+    permissionEngine: middlewareOwner,
+    secretStore: {},
+    credentialBroker: broker,
+    networkBroker: broker,
+    filesystemBroker,
+    companionSupervisor: broker,
+    assertLeaseParams: (params) => params,
+  });
+
+  const target = "/canonical/target";
+  for (const method of ["filesystem.readFile", "filesystem.stat", "filesystem.readDirectory"]) {
+    registrations.get(method).options.authorization({ path: target });
+  }
+  registrations.get("filesystem.writeFile").options.authorization({
+    path: target,
+    data: "value",
+    overwrite: true,
+  });
+  assert.deepEqual(filesystemCalls, [
+    [target, "exact"],
+    [target, "exact"],
+    [target, "directory"],
+    [target, "exact"],
+  ]);
+});

--- a/electron/plugins/secureCapabilities.test.cjs
+++ b/electron/plugins/secureCapabilities.test.cjs
@@ -31,7 +31,7 @@ test("secret mutations recheck runtime activity immediately before commit", asyn
   const requests = createRegistrations({
     set(_pluginId, _key, _value) {
       events.push("set");
-      return { kind: "secret", id: "secret-reference-0000000000000000" };
+      return { kind: "secret", id: "secret-reference-0000000000000000", key: "api-key" };
     },
     delete() { events.push("delete"); },
     getReference() { return null; },

--- a/electron/plugins/secureCapabilities.test.cjs
+++ b/electron/plugins/secureCapabilities.test.cjs
@@ -112,3 +112,48 @@ test("filesystem RPC authorization fixes resource kind by operation without host
     [target, "exact"],
   ]);
 });
+
+test("companion start authorization receives host-owned runtime placement", () => {
+  const registrations = new Map();
+  const registry = {
+    use() {},
+    registerRequest(method, handler, options) { registrations.set(method, { handler, options }); },
+  };
+  const middlewareOwner = { createMiddleware: () => async (_context, next) => next() };
+  const broker = new Proxy({}, { get: () => () => ({}) });
+  let observedContext;
+  const companionSupervisor = {
+    validateStart: (params) => params,
+    describeStartAuthorization(params, context) {
+      observedContext = context;
+      return {
+        permission: "companion.execute",
+        resources: [params.companionId],
+      };
+    },
+    validateRequest: (params) => params,
+    validateStop: (params) => params,
+    describeHandleAuthorization: () => ({
+      permission: "companion.execute",
+      resources: ["com.example.secure.helper"],
+    }),
+    start: async () => null,
+    request: async () => null,
+    stop: async () => null,
+  };
+  registerSecurePluginCapabilities(registry, {
+    quotaManager: middlewareOwner,
+    permissionEngine: middlewareOwner,
+    secretStore: {},
+    credentialBroker: broker,
+    networkBroker: broker,
+    filesystemBroker: broker,
+    companionSupervisor,
+    assertLeaseParams: (params) => params,
+  });
+  const runtimeContext = { runtimeKind: "utility", runtimeId: "runtime-advanced" };
+  registrations.get("companion.start").options.authorization({
+    companionId: "com.example.secure.helper",
+  }, runtimeContext);
+  assert.equal(observedContext, runtimeContext);
+});

--- a/electron/plugins/secureCapabilities.test.cjs
+++ b/electron/plugins/secureCapabilities.test.cjs
@@ -1,0 +1,60 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { registerSecurePluginCapabilities } = require("./secureCapabilities.cjs");
+
+function createRegistrations(secretStore) {
+  const requests = new Map();
+  const registry = {
+    use() {},
+    registerRequest(method, handler) { requests.set(method, handler); },
+  };
+  const middlewareOwner = { createMiddleware: () => async (_context, next) => next() };
+  const broker = new Proxy({}, { get: () => () => ({}) });
+  registerSecurePluginCapabilities(registry, {
+    quotaManager: middlewareOwner,
+    permissionEngine: middlewareOwner,
+    secretStore,
+    credentialBroker: broker,
+    networkBroker: broker,
+    filesystemBroker: broker,
+    companionSupervisor: broker,
+    assertLeaseParams: (params) => params,
+  });
+  return requests;
+}
+
+test("secret mutations recheck runtime activity immediately before commit", async () => {
+  const events = [];
+  const requests = createRegistrations({
+    set(_pluginId, _key, _value) {
+      events.push("set");
+      return { kind: "secret", id: "secret-reference-0000000000000000" };
+    },
+    delete() { events.push("delete"); },
+    getReference() { return null; },
+  });
+  const activeContext = {
+    pluginId: "com.example.secure",
+    async assertActive() { events.push("active"); },
+  };
+  await requests.get("secrets.set")({ key: "api-key", value: "value" }, activeContext);
+  await requests.get("secrets.delete")({ key: "api-key" }, activeContext);
+  assert.deepEqual(events, ["active", "set", "active", "delete"]);
+
+  const stoppedContext = {
+    pluginId: "com.example.secure",
+    async assertActive() { throw new Error("runtime stopped"); },
+  };
+  await assert.rejects(
+    requests.get("secrets.set")({ key: "api-key", value: "value" }, stoppedContext),
+    /runtime stopped/,
+  );
+  await assert.rejects(
+    requests.get("secrets.delete")({ key: "api-key" }, stoppedContext),
+    /runtime stopped/,
+  );
+  assert.deepEqual(events, ["active", "set", "active", "delete"]);
+});

--- a/electron/plugins/utilityPluginRuntime.cjs
+++ b/electron/plugins/utilityPluginRuntime.cjs
@@ -202,6 +202,10 @@ class UtilityPluginRuntime {
     return this.router.streams.openOutgoing(streamId, windowBytes);
   }
 
+  getProcessId() {
+    return this.child?.pid ?? null;
+  }
+
   #beginTermination(error) {
     this.terminationError ??= error;
     const router = this.router;

--- a/electron/plugins/utilityPluginRuntime.cjs
+++ b/electron/plugins/utilityPluginRuntime.cjs
@@ -78,6 +78,7 @@ class UtilityPluginRuntime {
     this.onIncomingStream = options.onIncomingStream;
     this.onBeforeMessage = options.onBeforeMessage;
     this.onProgress = options.onProgress;
+    this.onProcessReady = options.onProcessReady ?? (() => {});
     this.logger = options.logger;
     this.onExit = options.onExit ?? (() => {});
     this.onProtocolError = options.onProtocolError ?? (() => {});
@@ -130,6 +131,7 @@ class UtilityPluginRuntime {
       allowLoadingUnsignedLibraries: false,
       disclaim: process.platform === "darwin",
     });
+    this.onProcessReady();
     this.exitPromise = new Promise((resolve) => { this.resolveExit = resolve; });
     this.child.on("error", (_type, location) => {
       this.#beginTermination(new Error(`Plugin utility fatal error at ${location}`));

--- a/electron/plugins/utilityPluginRuntime.test.cjs
+++ b/electron/plugins/utilityPluginRuntime.test.cjs
@@ -65,6 +65,7 @@ test("utility runtime launches without a shell using a minimal environment", asy
   }
   const child = new FakeChild();
   const onBeforeMessage = () => {};
+  let processReadyCalls = 0;
   const runtime = new UtilityPluginRuntime({
     utilityProcess: {
       fork(_bootstrap, _args, options) {
@@ -81,6 +82,7 @@ test("utility runtime launches without a shell using a minimal environment", asy
     moduleMappings: {},
     handlers: {},
     onBeforeMessage,
+    onProcessReady: () => { processReadyCalls += 1; },
     logger: { write() {} },
   });
   await runtime.start({
@@ -99,6 +101,7 @@ test("utility runtime launches without a shell using a minimal environment", asy
   assert.equal(Object.hasOwn(forkOptions, "shell"), false);
   assert.equal(Object.hasOwn(forkOptions.env, "NODE_OPTIONS"), false);
   assert.equal(Object.hasOwn(forkOptions.env, "HOME"), false);
+  assert.equal(processReadyCalls, 1);
 });
 
 test("utility runtime stop waits for the child exit before releasing the activation", async (context) => {

--- a/packages/plugin-cli/src/cli.test.ts
+++ b/packages/plugin-cli/src/cli.test.ts
@@ -217,6 +217,20 @@ test("manifest validation reports permission and contribution mistakes", () => {
   assert.match(result.errors.join("\n"), /undeclared command/);
 });
 
+test("Node utility entrypoints require the explicit advanced-runtime permission", () => {
+  const missing = validateManifestValue(manifest({
+    main: { node: "dist/index.js" },
+  }));
+  assert.equal(missing.valid, false);
+  assert.match(missing.errors.join("\n"), /requires declared permission: runtime\.advanced/);
+
+  const declared = validateManifestValue(manifest({
+    main: { node: "dist/index.js" },
+    permissions: { required: ["runtime.advanced"] },
+  }));
+  assert.equal(declared.valid, true, declared.errors.join("\n"));
+});
+
 test("manifest byte parsing rejects invalid UTF-8 before JSON validation", () => {
   const validContents = new TextEncoder().encode(JSON.stringify(manifest()));
   assert.equal(parseAndValidateManifestContents(validContents).id, "com.example.package-test");

--- a/packages/plugin-cli/src/cli.test.ts
+++ b/packages/plugin-cli/src/cli.test.ts
@@ -206,7 +206,10 @@ test("path validation rejects traversal, platform aliases, and duplicates", () =
 
 test("manifest validation reports permission and contribution mistakes", () => {
   const result = validateManifestValue(manifest({
-    permissions: { required: ["network"], optional: ["network"] },
+    permissions: {
+      required: [{ permission: "network", resources: ["https://example.com"] }],
+      optional: ["network"],
+    },
     contributes: {
       commands: [{ id: "com.example.package-test.run", title: "Run" }],
       menus: [{ command: "com.example.package-test.missing", location: "commandPalette" }],
@@ -215,6 +218,31 @@ test("manifest validation reports permission and contribution mistakes", () => {
   assert.equal(result.valid, false);
   assert.match(result.errors.join("\n"), /both required and optional/);
   assert.match(result.errors.join("\n"), /undeclared command/);
+});
+
+test("resource-scoped required permissions must declare activation-time bounds", () => {
+  for (const [permission, resource] of [
+    ["network", "https://example.com"],
+    ["filesystem.read", "/tmp/plugin-read"],
+    ["filesystem.write", "/tmp/plugin-write"],
+    ["companion.execute", "com.example.package-test.helper"],
+  ] as const) {
+    const unbounded = validateManifestValue(manifest({
+      permissions: { required: [permission] },
+    }));
+    assert.equal(unbounded.valid, false, permission);
+    assert.match(unbounded.errors.join("\n"), /must declare explicit resources/u);
+
+    const bounded = validateManifestValue(manifest({
+      permissions: { required: [{ permission, resources: [resource] }] },
+    }));
+    assert.equal(bounded.valid, true, bounded.errors.join("\n"));
+
+    const optional = validateManifestValue(manifest({
+      permissions: { optional: [permission] },
+    }));
+    assert.equal(optional.valid, true, optional.errors.join("\n"));
+  }
 });
 
 test("manifest validation applies the runtime resource limit for each permission", () => {
@@ -328,7 +356,16 @@ test("manifest validation rejects duplicate companion executable paths", () => {
 
 test("manifest validation supports platform-specific companion variants", () => {
   const result = validateManifestValue(manifest({
-    permissions: { required: ["companion.execute"] },
+    main: { browser: "dist/index.js", node: "dist/index.js" },
+    permissions: {
+      required: [
+        "runtime.advanced",
+        {
+          permission: "companion.execute",
+          resources: ["com.example.package-test.helper"],
+        },
+      ],
+    },
     companionExecutables: [{
       id: "com.example.package-test.helper",
       variants: [
@@ -348,7 +385,16 @@ test("manifest validation supports platform-specific companion variants", () => 
   assert.equal(result.valid, true, result.errors.join("\n"));
 
   const duplicatePlatform = validateManifestValue(manifest({
-    permissions: { required: ["companion.execute"] },
+    main: { browser: "dist/index.js", node: "dist/index.js" },
+    permissions: {
+      required: [
+        "runtime.advanced",
+        {
+          permission: "companion.execute",
+          resources: ["com.example.package-test.helper"],
+        },
+      ],
+    },
     companionExecutables: [{
       id: "com.example.package-test.helper",
       variants: [
@@ -367,6 +413,36 @@ test("manifest validation supports platform-specific companion variants", () => 
   }));
   assert.equal(duplicatePlatform.valid, false);
   assert.match(duplicatePlatform.errors.join("\n"), /Duplicate companion platform/);
+});
+
+test("companion executables require an advanced utility placement", () => {
+  const companionExecutables = [{
+    id: "com.example.package-test.helper",
+    variants: [{
+      path: "bin/helper",
+      platforms: ["linux-x64"],
+      sha256: "0".repeat(64),
+    }],
+  }];
+  const companionPermission = {
+    permission: "companion.execute" as const,
+    resources: ["com.example.package-test.helper"],
+  };
+
+  const browserOnly = validateManifestValue(manifest({
+    permissions: { required: [companionPermission] },
+    companionExecutables,
+  }));
+  assert.equal(browserOnly.valid, false);
+  assert.match(browserOnly.errors.join("\n"), /require a Node utility entrypoint/u);
+
+  const missingAdvanced = validateManifestValue(manifest({
+    main: { browser: "dist/index.js", node: "dist/index.js" },
+    permissions: { required: [companionPermission] },
+    companionExecutables,
+  }));
+  assert.equal(missingAdvanced.valid, false);
+  assert.match(missingAdvanced.errors.join("\n"), /requires declared permission: runtime\.advanced/u);
 });
 
 test("packaging treats contributed package icons as required safe files", async (context) => {
@@ -552,7 +628,16 @@ test("logical content identity follows companion declarations across ZIP mode en
   await writeFile(
     path.join(directory, "netcatty.plugin.json"),
     `${JSON.stringify(manifest({
-      permissions: { required: ["companion.execute"] },
+      main: { browser: "dist/index.js", node: "dist/index.js" },
+      permissions: {
+        required: [
+          "runtime.advanced",
+          {
+            permission: "companion.execute",
+            resources: ["com.example.package-test.helper"],
+          },
+        ],
+      },
       companionExecutables: [{
         id: "com.example.package-test.helper",
         variants: [{

--- a/packages/plugin-cli/src/cli.test.ts
+++ b/packages/plugin-cli/src/cli.test.ts
@@ -238,6 +238,12 @@ test("resource-scoped required permissions must declare activation-time bounds",
     }));
     assert.equal(bounded.valid, true, bounded.errors.join("\n"));
 
+    const wildcard = validateManifestValue(manifest({
+      permissions: { required: [{ permission, resources: ["*"] }] },
+    }));
+    assert.equal(wildcard.valid, false, permission);
+    assert.match(wildcard.errors.join("\n"), /must not use the wildcard resource/u);
+
     const optional = validateManifestValue(manifest({
       permissions: { optional: [permission] },
     }));
@@ -252,9 +258,9 @@ test("manifest validation applies the runtime resource limit for each permission
     ["companion.execute", 193, 192],
   ] as const) {
     const result = validateManifestValue(manifest({
-      permissions: {
-        required: [{ permission, resources: ["x".repeat(length)] }],
-      },
+      permissions: permission === "storage"
+        ? { optional: [{ permission, resources: ["x".repeat(length)] }] }
+        : { required: [{ permission, resources: ["x".repeat(length)] }] },
     }));
     assert.equal(result.valid, false);
     assert.match(

--- a/packages/plugin-cli/src/cli.test.ts
+++ b/packages/plugin-cli/src/cli.test.ts
@@ -217,6 +217,32 @@ test("manifest validation reports permission and contribution mistakes", () => {
   assert.match(result.errors.join("\n"), /undeclared command/);
 });
 
+test("manifest validation applies the runtime resource limit for each permission", () => {
+  for (const [permission, length, expectedLimit] of [
+    ["network", 2_049, 2_048],
+    ["storage", 2_049, 2_048],
+    ["companion.execute", 193, 192],
+  ] as const) {
+    const result = validateManifestValue(manifest({
+      permissions: {
+        required: [{ permission, resources: ["x".repeat(length)] }],
+      },
+    }));
+    assert.equal(result.valid, false);
+    assert.match(
+      result.errors.join("\n"),
+      new RegExp(`Permission resource for ${permission.replace(".", "\\.")} exceeds ${expectedLimit}`),
+    );
+  }
+
+  const filesystem = validateManifestValue(manifest({
+    permissions: {
+      required: [{ permission: "filesystem.read", resources: [`/${"x".repeat(4_096)}`] }],
+    },
+  }));
+  assert.equal(filesystem.valid, true, filesystem.errors.join("\n"));
+});
+
 test("Node utility entrypoints require the explicit advanced-runtime permission", () => {
   const missing = validateManifestValue(manifest({
     main: { node: "dist/index.js" },

--- a/packages/plugin-cli/src/manifest.ts
+++ b/packages/plugin-cli/src/manifest.ts
@@ -140,6 +140,26 @@ function permissionResourceLimit(permission: PluginPermission): number {
   return 2_048;
 }
 
+const resourceScopedPermissions = new Set<PluginPermission>([
+  "network",
+  "filesystem.read",
+  "filesystem.write",
+  "companion.execute",
+]);
+
+function validateRequiredPermissionBounds(value: unknown): string[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+  const permissions = (value as { permissions?: unknown }).permissions;
+  if (!permissions || typeof permissions !== "object" || Array.isArray(permissions)) return [];
+  const required = (permissions as { required?: unknown }).required;
+  if (!Array.isArray(required)) return [];
+  return required.flatMap((declaration) => (
+    typeof declaration === "string" && resourceScopedPermissions.has(declaration as PluginPermission)
+      ? [`Required permission ${declaration} must declare explicit resources`]
+      : []
+  ));
+}
+
 function validatePermissionResourceLimits(manifest: PluginManifest): string[] {
   const errors: string[] = [];
   for (const declaration of [
@@ -294,6 +314,14 @@ function validateSemantics(manifest: PluginManifest): string[] {
     "companion.execute",
     "Companion executables",
   );
+  requirePermission(
+    Boolean(manifest.companionExecutables?.length),
+    "runtime.advanced",
+    "Companion executables",
+  );
+  if (manifest.companionExecutables?.length && !manifest.main.node) {
+    errors.push("Companion executables require a Node utility entrypoint");
+  }
   const providerPermissions = new Map<string, readonly PluginPermission[]>([
     ["terminal.completion", ["provider.terminal", "terminal.complete"]],
     ["terminal.decoration", ["provider.terminal", "terminal.output", "terminal.decorate"]],
@@ -526,6 +554,10 @@ export function validateManifestValue(value: unknown): ManifestValidationResult 
       valid: false,
       errors: [error instanceof Error ? error.message : String(error)],
     };
+  }
+  const requiredPermissionErrors = validateRequiredPermissionBounds(value);
+  if (requiredPermissionErrors.length > 0) {
+    return { valid: false, errors: requiredPermissionErrors };
   }
   if (!validateSchema(value)) {
     return {

--- a/packages/plugin-cli/src/manifest.ts
+++ b/packages/plugin-cli/src/manifest.ts
@@ -32,6 +32,9 @@ interface PluginContractSchema extends Record<string, unknown> {
         readonly maxNodes: number;
       };
     };
+    readonly ResourceScopedPermission: {
+      readonly enum: readonly PluginPermission[];
+    };
   };
 }
 
@@ -140,12 +143,9 @@ function permissionResourceLimit(permission: PluginPermission): number {
   return 2_048;
 }
 
-const resourceScopedPermissions = new Set<PluginPermission>([
-  "network",
-  "filesystem.read",
-  "filesystem.write",
-  "companion.execute",
-]);
+const resourceScopedPermissions = new Set<PluginPermission>(
+  contractSchema.$defs.ResourceScopedPermission.enum,
+);
 
 function validateRequiredPermissionBounds(value: unknown): string[] {
   if (!value || typeof value !== "object" || Array.isArray(value)) return [];
@@ -153,11 +153,22 @@ function validateRequiredPermissionBounds(value: unknown): string[] {
   if (!permissions || typeof permissions !== "object" || Array.isArray(permissions)) return [];
   const required = (permissions as { required?: unknown }).required;
   if (!Array.isArray(required)) return [];
-  return required.flatMap((declaration) => (
-    typeof declaration === "string" && resourceScopedPermissions.has(declaration as PluginPermission)
-      ? [`Required permission ${declaration} must declare explicit resources`]
-      : []
-  ));
+  return required.flatMap((declaration) => {
+    if (typeof declaration === "string") {
+      return resourceScopedPermissions.has(declaration as PluginPermission)
+        ? [`Required permission ${declaration} must declare explicit resources`]
+        : [];
+    }
+    if (!declaration || typeof declaration !== "object" || Array.isArray(declaration)) return [];
+    const permission = (declaration as { permission?: unknown }).permission;
+    const resources = (declaration as { resources?: unknown }).resources;
+    return typeof permission === "string"
+      && resourceScopedPermissions.has(permission as PluginPermission)
+      && Array.isArray(resources)
+      && resources.includes("*")
+      ? [`Required permission ${permission} must not use the wildcard resource`]
+      : [];
+  });
 }
 
 function validatePermissionResourceLimits(manifest: PluginManifest): string[] {

--- a/packages/plugin-cli/src/manifest.ts
+++ b/packages/plugin-cli/src/manifest.ts
@@ -134,6 +134,31 @@ function permissionName(declaration: PermissionDeclaration): PluginPermission {
   return typeof declaration === "string" ? declaration : declaration.permission;
 }
 
+function permissionResourceLimit(permission: PluginPermission): number {
+  if (permission === "filesystem.read" || permission === "filesystem.write") return 8_192;
+  if (permission === "companion.execute") return 192;
+  return 2_048;
+}
+
+function validatePermissionResourceLimits(manifest: PluginManifest): string[] {
+  const errors: string[] = [];
+  for (const declaration of [
+    ...(manifest.permissions?.required ?? []),
+    ...(manifest.permissions?.optional ?? []),
+  ]) {
+    if (typeof declaration === "string") continue;
+    const maximum = permissionResourceLimit(declaration.permission);
+    for (const resource of declaration.resources) {
+      if (resource.length > maximum) {
+        errors.push(
+          `Permission resource for ${declaration.permission} exceeds ${maximum} characters`,
+        );
+      }
+    }
+  }
+  return errors;
+}
+
 function findDuplicateIds(manifest: PluginManifest): string[] {
   const errors: string[] = [];
   const groups = [
@@ -185,6 +210,7 @@ function validateSemantics(manifest: PluginManifest): string[] {
   const errors = [
     ...findDuplicateIds(manifest),
     ...validateOwnedContributionIds(manifest),
+    ...validatePermissionResourceLimits(manifest),
   ];
   for (const [engine, range] of Object.entries(manifest.engines)) {
     if (validRange(range) === null) {

--- a/packages/plugin-cli/src/manifest.ts
+++ b/packages/plugin-cli/src/manifest.ts
@@ -252,6 +252,11 @@ function validateSemantics(manifest: PluginManifest): string[] {
     "Setting contributions",
   );
   requirePermission(
+    Boolean(manifest.main.node),
+    "runtime.advanced",
+    "Node utility entrypoints",
+  );
+  requirePermission(
     Boolean(manifest.contributes?.commands?.length),
     "commands",
     "Command contributions",

--- a/packages/plugin-contract/schema/plugin-contract.schema.json
+++ b/packages/plugin-contract/schema/plugin-contract.schema.json
@@ -204,6 +204,39 @@
         "provider.importer"
       ]
     },
+    "NonResourceScopedPermission": {
+      "description": "A permission whose complete activation-time scope is represented by the permission name itself.",
+      "type": "string",
+      "enum": [
+        "storage",
+        "runtime.advanced",
+        "settings.read",
+        "settings.write",
+        "commands",
+        "menus",
+        "views",
+        "clipboard.read",
+        "clipboard.write",
+        "terminal.metadata",
+        "terminal.output",
+        "terminal.input",
+        "terminal.decorate",
+        "terminal.complete",
+        "terminal.intercept.input",
+        "terminal.intercept.output",
+        "vault.metadata",
+        "vault.write",
+        "vault.credentials",
+        "sftp.read",
+        "sftp.write",
+        "secrets",
+        "provider.terminal",
+        "provider.connection",
+        "provider.authentication",
+        "provider.sync",
+        "provider.importer"
+      ]
+    },
     "PermissionResource": {
       "description": "A host-canonicalized permission resource. Filesystem resources may be absolute platform paths; other permission kinds impose narrower runtime limits.",
       "type": "string",
@@ -215,25 +248,33 @@
       "type": "string",
       "enum": ["exact", "directory"]
     },
+    "PermissionResourceDeclaration": {
+      "type": "object",
+      "required": ["permission", "resources"],
+      "properties": {
+        "permission": { "$ref": "#/$defs/PluginPermission" },
+        "resources": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 128,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/PermissionResource" }
+        },
+        "reason": { "type": "string", "maxLength": 1024 }
+      },
+      "additionalProperties": false
+    },
     "PermissionDeclaration": {
       "oneOf": [
         { "$ref": "#/$defs/PluginPermission" },
-        {
-          "type": "object",
-          "required": ["permission", "resources"],
-          "properties": {
-            "permission": { "$ref": "#/$defs/PluginPermission" },
-            "resources": {
-              "type": "array",
-              "minItems": 1,
-              "maxItems": 128,
-              "uniqueItems": true,
-              "items": { "$ref": "#/$defs/PermissionResource" }
-            },
-            "reason": { "type": "string", "maxLength": 1024 }
-          },
-          "additionalProperties": false
-        }
+        { "$ref": "#/$defs/PermissionResourceDeclaration" }
+      ]
+    },
+    "RequiredPermissionDeclaration": {
+      "description": "Required resource-scoped permissions must name their complete activation-time approval bounds.",
+      "oneOf": [
+        { "$ref": "#/$defs/NonResourceScopedPermission" },
+        { "$ref": "#/$defs/PermissionResourceDeclaration" }
       ]
     },
     "PermissionSet": {
@@ -242,7 +283,7 @@
         "required": {
           "type": "array",
           "maxItems": 64,
-          "items": { "$ref": "#/$defs/PermissionDeclaration" }
+          "items": { "$ref": "#/$defs/RequiredPermissionDeclaration" }
         },
         "optional": {
           "type": "array",

--- a/packages/plugin-contract/schema/plugin-contract.schema.json
+++ b/packages/plugin-contract/schema/plugin-contract.schema.json
@@ -118,6 +118,28 @@
       },
       "additionalProperties": false
     },
+    "CredentialRef": {
+      "description": "An opaque host-issued reference to a Netcatty-owned credential. The host validates ownership and provider-operation scope before issuing a plaintext lease.",
+      "type": "object",
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": { "const": "credential" },
+        "id": { "type": "string", "minLength": 16, "maxLength": 256 }
+      },
+      "additionalProperties": false
+    },
+    "SecretLeaseRef": {
+      "description": "An opaque, operation-bound, single-consumption lease. Only a host capability broker can consume it after revalidating runtime identity and operation scope.",
+      "type": "object",
+      "required": ["kind", "id", "operationId", "expiresAt"],
+      "properties": {
+        "kind": { "const": "secret-lease" },
+        "id": { "type": "string", "minLength": 32, "maxLength": 256 },
+        "operationId": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "expiresAt": { "$ref": "#/$defs/SafePositiveInteger" }
+      },
+      "additionalProperties": false
+    },
     "SemanticVersion": {
       "type": "string",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-(?:0|[1-9]\\d*|\\d*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
@@ -144,6 +166,7 @@
       "type": "string",
       "enum": [
         "storage",
+        "runtime.advanced",
         "settings.read",
         "settings.write",
         "commands",
@@ -175,6 +198,12 @@
         "provider.importer"
       ]
     },
+    "PermissionResource": {
+      "description": "A host-canonicalized permission resource. Filesystem resources may be absolute platform paths; other permission kinds impose narrower runtime limits.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 8192
+    },
     "PermissionDeclaration": {
       "oneOf": [
         { "$ref": "#/$defs/PluginPermission" },
@@ -188,7 +217,7 @@
               "minItems": 1,
               "maxItems": 128,
               "uniqueItems": true,
-              "items": { "type": "string", "minLength": 1, "maxLength": 2048 }
+              "items": { "$ref": "#/$defs/PermissionResource" }
             },
             "reason": { "type": "string", "maxLength": 1024 }
           },
@@ -963,15 +992,21 @@
       "properties": {
         "requestId": { "type": "string", "minLength": 1, "maxLength": 128 },
         "pluginId": { "$ref": "#/$defs/PluginId" },
+        "pluginVersion": { "$ref": "#/$defs/SemanticVersion" },
+        "pluginName": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "publisher": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "runtimeId": { "type": ["string", "null"], "minLength": 1, "maxLength": 128 },
+        "runtimeKind": { "type": ["string", "null"], "enum": ["browser", "utility", null] },
         "permission": { "$ref": "#/$defs/PluginPermission" },
         "resources": {
           "type": "array",
           "maxItems": 128,
           "uniqueItems": true,
-          "items": { "type": "string", "minLength": 1, "maxLength": 2048 }
+          "items": { "$ref": "#/$defs/PermissionResource" }
         },
         "reason": { "type": "string", "minLength": 1, "maxLength": 1024 },
-        "operationId": { "type": "string", "minLength": 1, "maxLength": 128 }
+        "operationId": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "sessionId": { "type": "string", "minLength": 1, "maxLength": 128 }
       },
       "additionalProperties": false
     },
@@ -988,7 +1023,7 @@
               "type": "array",
               "maxItems": 128,
               "uniqueItems": true,
-              "items": { "type": "string", "minLength": 1, "maxLength": 2048 }
+              "items": { "$ref": "#/$defs/PermissionResource" }
             }
           },
           "additionalProperties": false

--- a/packages/plugin-contract/schema/plugin-contract.schema.json
+++ b/packages/plugin-contract/schema/plugin-contract.schema.json
@@ -109,12 +109,18 @@
       "pattern": "^[a-z][a-z0-9-]*(?:\\.[a-z0-9][a-z0-9_-]*)+$"
     },
     "SecretRef": {
-      "description": "An opaque host-issued reference to secret material. The identifier is never sufficient authority on its own; privileged consumers must revalidate plugin ownership and operation scope.",
+      "description": "A host-issued reference to secret material. The random identifier is opaque and never sufficient authority on its own. The non-secret key binds permission authorization to the packaged manifest resource; privileged consumers must revalidate identifier ownership, key binding, and operation scope.",
       "type": "object",
-      "required": ["kind", "id"],
+      "required": ["kind", "id", "key"],
       "properties": {
         "kind": { "const": "secret" },
-        "id": { "type": "string", "minLength": 16, "maxLength": 256 }
+        "id": { "type": "string", "minLength": 16, "maxLength": 256 },
+        "key": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "pattern": "^[^\\u0000]+$"
+        }
       },
       "additionalProperties": false
     },

--- a/packages/plugin-contract/schema/plugin-contract.schema.json
+++ b/packages/plugin-contract/schema/plugin-contract.schema.json
@@ -237,11 +237,28 @@
         "provider.importer"
       ]
     },
+    "ResourceScopedPermission": {
+      "description": "A permission whose approval must be constrained to explicit canonical resources.",
+      "type": "string",
+      "enum": [
+        "network",
+        "filesystem.read",
+        "filesystem.write",
+        "companion.execute"
+      ]
+    },
     "PermissionResource": {
       "description": "A host-canonicalized permission resource. Filesystem resources may be absolute platform paths; other permission kinds impose narrower runtime limits.",
       "type": "string",
       "minLength": 1,
       "maxLength": 8192
+    },
+    "BoundedPermissionResource": {
+      "description": "An explicit resource bound; the all-resources wildcard is not an activation-time bound.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 8192,
+      "not": { "const": "*" }
     },
     "PermissionResourceKind": {
       "description": "Whether a canonical resource grant covers only that resource or a filesystem directory subtree.",
@@ -270,11 +287,27 @@
         { "$ref": "#/$defs/PermissionResourceDeclaration" }
       ]
     },
+    "RequiredPermissionResourceDeclaration": {
+      "type": "object",
+      "required": ["permission", "resources"],
+      "properties": {
+        "permission": { "$ref": "#/$defs/ResourceScopedPermission" },
+        "resources": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 128,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/BoundedPermissionResource" }
+        },
+        "reason": { "type": "string", "maxLength": 1024 }
+      },
+      "additionalProperties": false
+    },
     "RequiredPermissionDeclaration": {
       "description": "Required resource-scoped permissions must name their complete activation-time approval bounds.",
       "oneOf": [
         { "$ref": "#/$defs/NonResourceScopedPermission" },
-        { "$ref": "#/$defs/PermissionResourceDeclaration" }
+        { "$ref": "#/$defs/RequiredPermissionResourceDeclaration" }
       ]
     },
     "PermissionSet": {

--- a/packages/plugin-contract/schema/plugin-contract.schema.json
+++ b/packages/plugin-contract/schema/plugin-contract.schema.json
@@ -204,6 +204,11 @@
       "minLength": 1,
       "maxLength": 8192
     },
+    "PermissionResourceKind": {
+      "description": "Whether a canonical resource grant covers only that resource or a filesystem directory subtree.",
+      "type": "string",
+      "enum": ["exact", "directory"]
+    },
     "PermissionDeclaration": {
       "oneOf": [
         { "$ref": "#/$defs/PluginPermission" },
@@ -1003,6 +1008,11 @@
           "maxItems": 128,
           "uniqueItems": true,
           "items": { "$ref": "#/$defs/PermissionResource" }
+        },
+        "resourceKinds": {
+          "type": "array",
+          "maxItems": 128,
+          "items": { "$ref": "#/$defs/PermissionResourceKind" }
         },
         "reason": { "type": "string", "minLength": 1, "maxLength": 1024 },
         "operationId": { "type": "string", "minLength": 1, "maxLength": 128 },

--- a/packages/plugin-contract/src/contract.test.ts
+++ b/packages/plugin-contract/src/contract.test.ts
@@ -59,6 +59,37 @@ test("plugin manifest schema accepts the internal contract", () => {
   assert.equal(validate({ ...validManifest, version: "1.0.0-01" }), false);
 });
 
+test("required resource-scoped permissions declare activation-time bounds", () => {
+  const validate = validator("PluginManifest");
+  const resourceScoped = [
+    ["network", "https://example.com"],
+    ["filesystem.read", "/tmp/plugin-read"],
+    ["filesystem.write", "/tmp/plugin-write"],
+    ["companion.execute", "com.example.contract-test.helper"],
+  ] as const;
+  assert.deepEqual(
+    schema.$defs.NonResourceScopedPermission.enum,
+    schema.$defs.PluginPermission.enum.filter(
+      (permission: string) => !resourceScoped.some(([scoped]) => scoped === permission),
+    ),
+    "the required-permission shorthand catalog must track every non-resource permission",
+  );
+  for (const [permission, resource] of resourceScoped) {
+    assert.equal(validate({
+      ...validManifest,
+      permissions: { required: [permission] },
+    }), false, `${permission} must not be an unbounded required declaration`);
+    assert.equal(validate({
+      ...validManifest,
+      permissions: { required: [{ permission, resources: [resource] }] },
+    }), true, JSON.stringify(validate.errors));
+    assert.equal(validate({
+      ...validManifest,
+      permissions: { optional: [permission] },
+    }), true, JSON.stringify(validate.errors));
+  }
+});
+
 test("manifest header remains forward-readable before version-specific validation", () => {
   const validateHeader = validator("PluginManifestHeader");
   assert.equal(validateHeader({
@@ -742,16 +773,21 @@ test("semantic namespacing covers every contribution registry and near-prefix co
   }];
   assert.equal(validateManifestValue({
     ...validManifest,
+    main: { ...validManifest.main, node: "dist/node.js" },
     contributes: contributions,
     permissions: {
       required: [
+        "runtime.advanced",
         "settings.read",
         "commands",
         "menus",
         "views",
         "provider.terminal",
         "terminal.complete",
-        "companion.execute",
+        {
+          permission: "companion.execute",
+          resources: ["com.example.contract-test.helper"],
+        },
       ],
       optional: [],
     },
@@ -877,8 +913,10 @@ test("planned phase consumers are representable without private application type
     },
     {
       ...validManifest,
+      main: { ...validManifest.main, node: "dist/node.js" },
       permissions: {
         required: [
+          "runtime.advanced",
           "provider.terminal",
           "terminal.complete",
           "terminal.output",
@@ -931,13 +969,18 @@ test("planned phase consumers are representable without private application type
     },
     {
       ...validManifest,
+      main: { ...validManifest.main, node: "dist/node.js" },
       permissions: {
         required: [
+          "runtime.advanced",
           "provider.connection",
           "provider.authentication",
           "provider.sync",
           "provider.importer",
-          "companion.execute",
+          {
+            permission: "companion.execute",
+            resources: ["com.example.contract-test.helper"],
+          },
         ],
       },
       contributes: {

--- a/packages/plugin-contract/src/contract.test.ts
+++ b/packages/plugin-contract/src/contract.test.ts
@@ -362,12 +362,18 @@ test("RPC, stream, permission, and provider schemas validate independently", () 
   assert.equal(permissionDecision({ requestId: "p1", decision: "allow", scope: "once" }), true);
   assert.equal(permissionDecision({ requestId: "p1", decision: "allow" }), false);
   assert.equal(permissionDecision({ requestId: "p1", decision: "deny", scope: "always" }), false);
-  assert.equal(secretRef({ kind: "secret", id: "secret-reference-1" }), true);
-  assert.equal(secretRef({ kind: "secret", id: "short" }), false);
-  assert.equal(secretRef({ kind: "secret", id: "secret-reference-1", value: "plaintext" }), false);
+  assert.equal(secretRef({ kind: "secret", id: "secret-reference-1", key: "api-key" }), true);
+  assert.equal(secretRef({ kind: "secret", id: "secret-reference-1" }), false);
+  assert.equal(secretRef({ kind: "secret", id: "short", key: "api-key" }), false);
+  assert.equal(secretRef({
+    kind: "secret",
+    id: "secret-reference-1",
+    key: "api-key",
+    value: "plaintext",
+  }), false);
   assert.equal(secretRef({ kind: "credential", id: "secret-reference-1" }), false);
   assert.equal(credentialRef({ kind: "credential", id: "credential-ref-1" }), true);
-  assert.equal(credentialRef({ kind: "secret", id: "credential-ref-1" }), false);
+  assert.equal(credentialRef({ kind: "secret", id: "credential-ref-1", key: "api-key" }), false);
   assert.equal(provider({
     providerId: "com.example.contract-test.completion",
     operation: "provideCompletions",

--- a/packages/plugin-contract/src/contract.test.ts
+++ b/packages/plugin-contract/src/contract.test.ts
@@ -130,6 +130,7 @@ test("RPC, stream, permission, and provider schemas validate independently", () 
   const permission = validator("PermissionRequest");
   const permissionDecision = validator("PermissionDecision");
   const secretRef = validator("SecretRef");
+  const credentialRef = validator("CredentialRef");
   const provider = validator("ProviderRequest");
   const providerResult = validator("ProviderResult");
 
@@ -323,10 +324,31 @@ test("RPC, stream, permission, and provider schemas validate independently", () 
   assert.equal(permission({
     requestId: "p1",
     pluginId: "com.example.contract-test",
+    pluginVersion: "1.2.3",
+    pluginName: "Contract test",
+    publisher: "example",
+    runtimeId: "runtime-1",
+    runtimeKind: "browser",
     permission: "network",
     reason: "Fetch completion metadata",
     resources: ["https://api.example.com"],
+    operationId: "network:https://api.example.com",
+    sessionId: "terminal-session-1",
   }), true);
+  assert.equal(permission({
+    requestId: "p2",
+    pluginId: "com.example.contract-test",
+    permission: "filesystem.read",
+    reason: "Read a long absolute path",
+    resources: [`/${"a".repeat(4_096)}`],
+  }), true, JSON.stringify(permission.errors));
+  assert.equal(permission({
+    requestId: "p3",
+    pluginId: "com.example.contract-test",
+    permission: "network",
+    reason: "Reject unknown runtime placement",
+    runtimeKind: "renderer",
+  }), false);
   assert.equal(permissionDecision({ requestId: "p1", decision: "allow", scope: "once" }), true);
   assert.equal(permissionDecision({ requestId: "p1", decision: "allow" }), false);
   assert.equal(permissionDecision({ requestId: "p1", decision: "deny", scope: "always" }), false);
@@ -334,6 +356,8 @@ test("RPC, stream, permission, and provider schemas validate independently", () 
   assert.equal(secretRef({ kind: "secret", id: "short" }), false);
   assert.equal(secretRef({ kind: "secret", id: "secret-reference-1", value: "plaintext" }), false);
   assert.equal(secretRef({ kind: "credential", id: "secret-reference-1" }), false);
+  assert.equal(credentialRef({ kind: "credential", id: "credential-ref-1" }), true);
+  assert.equal(credentialRef({ kind: "secret", id: "credential-ref-1" }), false);
   assert.equal(provider({
     providerId: "com.example.contract-test.completion",
     operation: "provideCompletions",
@@ -443,6 +467,7 @@ test("permission and setting-control catalogs cover planned public surfaces", ()
     "vault.credentials",
     "sftp.write",
     "filesystem.write",
+    "runtime.advanced",
     "provider.connection",
     "provider.sync",
   ]) {

--- a/packages/plugin-contract/src/contract.test.ts
+++ b/packages/plugin-contract/src/contract.test.ts
@@ -68,6 +68,11 @@ test("required resource-scoped permissions declare activation-time bounds", () =
     ["companion.execute", "com.example.contract-test.helper"],
   ] as const;
   assert.deepEqual(
+    schema.$defs.ResourceScopedPermission.enum,
+    resourceScoped.map(([permission]) => permission),
+    "the resource-scoped permission catalog must track every bounded permission",
+  );
+  assert.deepEqual(
     schema.$defs.NonResourceScopedPermission.enum,
     schema.$defs.PluginPermission.enum.filter(
       (permission: string) => !resourceScoped.some(([scoped]) => scoped === permission),
@@ -83,6 +88,10 @@ test("required resource-scoped permissions declare activation-time bounds", () =
       ...validManifest,
       permissions: { required: [{ permission, resources: [resource] }] },
     }), true, JSON.stringify(validate.errors));
+    assert.equal(validate({
+      ...validManifest,
+      permissions: { required: [{ permission, resources: ["*"] }] },
+    }), false, `${permission} must not accept a wildcard activation bound`);
     assert.equal(validate({
       ...validManifest,
       permissions: { optional: [permission] },

--- a/packages/plugin-contract/src/contract.test.ts
+++ b/packages/plugin-contract/src/contract.test.ts
@@ -332,6 +332,7 @@ test("RPC, stream, permission, and provider schemas validate independently", () 
     permission: "network",
     reason: "Fetch completion metadata",
     resources: ["https://api.example.com"],
+    resourceKinds: ["exact"],
     operationId: "network:https://api.example.com",
     sessionId: "terminal-session-1",
   }), true);
@@ -341,7 +342,16 @@ test("RPC, stream, permission, and provider schemas validate independently", () 
     permission: "filesystem.read",
     reason: "Read a long absolute path",
     resources: [`/${"a".repeat(4_096)}`],
+    resourceKinds: ["directory"],
   }), true, JSON.stringify(permission.errors));
+  assert.equal(permission({
+    requestId: "p2-invalid",
+    pluginId: "com.example.contract-test",
+    permission: "filesystem.read",
+    reason: "Reject an unknown resource kind",
+    resources: ["/tmp"],
+    resourceKinds: ["subtree"],
+  }), false);
   assert.equal(permission({
     requestId: "p3",
     pluginId: "com.example.contract-test",

--- a/packages/plugin-contract/src/generated/plugin-contract.ts
+++ b/packages/plugin-contract/src/generated/plugin-contract.ts
@@ -357,6 +357,7 @@ export type SecretLeaseRef = {
 export type SecretRef = {
   kind: "secret";
   id: string;
+  key: string;
 };
 
 export type SemanticVersion = string;

--- a/packages/plugin-contract/src/generated/plugin-contract.ts
+++ b/packages/plugin-contract/src/generated/plugin-contract.ts
@@ -4,6 +4,8 @@
 
 export type ActivationEvent = "onStartupFinished" | `onCommand:${ContributionId}` | `onView:${ContributionId}` | `onProvider:${ContributionId}`;
 
+export type BoundedPermissionResource = string;
+
 export type CommandContribution = {
   id: ContributionId;
   title: LocalizedText;
@@ -261,7 +263,15 @@ export type ProviderResult = ({
 
 export type RelativePackagePath = string;
 
-export type RequiredPermissionDeclaration = (NonResourceScopedPermission) | (PermissionResourceDeclaration);
+export type RequiredPermissionDeclaration = (NonResourceScopedPermission) | (RequiredPermissionResourceDeclaration);
+
+export type RequiredPermissionResourceDeclaration = {
+  permission: ResourceScopedPermission;
+  resources: Array<BoundedPermissionResource>;
+  reason?: string;
+};
+
+export type ResourceScopedPermission = "network" | "filesystem.read" | "filesystem.write" | "companion.execute";
 
 export type RpcCancel = {
   jsonrpc: "2.0";

--- a/packages/plugin-contract/src/generated/plugin-contract.ts
+++ b/packages/plugin-contract/src/generated/plugin-contract.ts
@@ -76,6 +76,8 @@ export type MenuContribution = {
 
 export type MenuLocation = "commandPalette" | "application" | "host/context" | "terminal/context" | "terminal/toolbar" | "statusBar";
 
+export type NonResourceScopedPermission = "storage" | "runtime.advanced" | "settings.read" | "settings.write" | "commands" | "menus" | "views" | "clipboard.read" | "clipboard.write" | "terminal.metadata" | "terminal.output" | "terminal.input" | "terminal.decorate" | "terminal.complete" | "terminal.intercept.input" | "terminal.intercept.output" | "vault.metadata" | "vault.write" | "vault.credentials" | "sftp.read" | "sftp.write" | "secrets" | "provider.terminal" | "provider.connection" | "provider.authentication" | "provider.sync" | "provider.importer";
+
 export type NullableRpcId = (RpcId) | (null);
 
 export type PackageIcon = {
@@ -94,11 +96,7 @@ export type PermissionDecision = ({
   decision: "deny" | "cancel";
 });
 
-export type PermissionDeclaration = (PluginPermission) | ({
-  permission: PluginPermission;
-  resources: Array<PermissionResource>;
-  reason?: string;
-});
+export type PermissionDeclaration = (PluginPermission) | (PermissionResourceDeclaration);
 
 export type PermissionGrantScope = "once" | "session" | "application" | "always";
 
@@ -120,10 +118,16 @@ export type PermissionRequest = {
 
 export type PermissionResource = string;
 
+export type PermissionResourceDeclaration = {
+  permission: PluginPermission;
+  resources: Array<PermissionResource>;
+  reason?: string;
+};
+
 export type PermissionResourceKind = "exact" | "directory";
 
 export type PermissionSet = {
-  required?: Array<PermissionDeclaration>;
+  required?: Array<RequiredPermissionDeclaration>;
   optional?: Array<PermissionDeclaration>;
 };
 
@@ -256,6 +260,8 @@ export type ProviderResult = ({
 });
 
 export type RelativePackagePath = string;
+
+export type RequiredPermissionDeclaration = (NonResourceScopedPermission) | (PermissionResourceDeclaration);
 
 export type RpcCancel = {
   jsonrpc: "2.0";

--- a/packages/plugin-contract/src/generated/plugin-contract.ts
+++ b/packages/plugin-contract/src/generated/plugin-contract.ts
@@ -31,6 +31,11 @@ export type ContextKeyExpression = string;
 
 export type ContributionId = string;
 
+export type CredentialRef = {
+  kind: "credential";
+  id: string;
+};
+
 export type FeatureId = string;
 
 export type IconReference = (ThemeIcon) | (PackageIcon);
@@ -83,7 +88,7 @@ export type PermissionDecision = ({
   requestId: string;
   decision: "allow";
   scope: PermissionGrantScope;
-  resources?: Array<string>;
+  resources?: Array<PermissionResource>;
 }) | ({
   requestId: string;
   decision: "deny" | "cancel";
@@ -91,7 +96,7 @@ export type PermissionDecision = ({
 
 export type PermissionDeclaration = (PluginPermission) | ({
   permission: PluginPermission;
-  resources: Array<string>;
+  resources: Array<PermissionResource>;
   reason?: string;
 });
 
@@ -100,11 +105,19 @@ export type PermissionGrantScope = "once" | "session" | "application" | "always"
 export type PermissionRequest = {
   requestId: string;
   pluginId: PluginId;
+  pluginVersion?: SemanticVersion;
+  pluginName?: string;
+  publisher?: string;
+  runtimeId?: string | null;
+  runtimeKind?: "browser" | "utility" | null;
   permission: PluginPermission;
-  resources?: Array<string>;
+  resources?: Array<PermissionResource>;
   reason: string;
   operationId?: string;
+  sessionId?: string;
 };
+
+export type PermissionResource = string;
 
 export type PermissionSet = {
   required?: Array<PermissionDeclaration>;
@@ -178,7 +191,7 @@ export type PluginManifestHeader = ({
   engines: PluginEngineHeader;
 } & Record<string, unknown>);
 
-export type PluginPermission = "storage" | "settings.read" | "settings.write" | "commands" | "menus" | "views" | "clipboard.read" | "clipboard.write" | "terminal.metadata" | "terminal.output" | "terminal.input" | "terminal.decorate" | "terminal.complete" | "terminal.intercept.input" | "terminal.intercept.output" | "vault.metadata" | "vault.write" | "vault.credentials" | "sftp.read" | "sftp.write" | "network" | "filesystem.read" | "filesystem.write" | "secrets" | "companion.execute" | "provider.terminal" | "provider.connection" | "provider.authentication" | "provider.sync" | "provider.importer";
+export type PluginPermission = "storage" | "runtime.advanced" | "settings.read" | "settings.write" | "commands" | "menus" | "views" | "clipboard.read" | "clipboard.write" | "terminal.metadata" | "terminal.output" | "terminal.input" | "terminal.decorate" | "terminal.complete" | "terminal.intercept.input" | "terminal.intercept.output" | "vault.metadata" | "vault.write" | "vault.credentials" | "sftp.read" | "sftp.write" | "network" | "filesystem.read" | "filesystem.write" | "secrets" | "companion.execute" | "provider.terminal" | "provider.connection" | "provider.authentication" | "provider.sync" | "provider.importer";
 
 export type PluginWireErrorCode = -32001 | -32002 | -32003 | -32004 | -32005 | -32006 | -32007 | -32008 | -32009 | -32010 | -32011 | -32012 | -32013 | -32014 | -32015 | -32016;
 
@@ -330,6 +343,13 @@ export type RuntimeInitializeSuccess = {
 export type SafePositiveInteger = number;
 
 export type SafeUnsignedInteger = number;
+
+export type SecretLeaseRef = {
+  kind: "secret-lease";
+  id: string;
+  operationId: string;
+  expiresAt: SafePositiveInteger;
+};
 
 export type SecretRef = {
   kind: "secret";

--- a/packages/plugin-contract/src/generated/plugin-contract.ts
+++ b/packages/plugin-contract/src/generated/plugin-contract.ts
@@ -112,12 +112,15 @@ export type PermissionRequest = {
   runtimeKind?: "browser" | "utility" | null;
   permission: PluginPermission;
   resources?: Array<PermissionResource>;
+  resourceKinds?: Array<PermissionResourceKind>;
   reason: string;
   operationId?: string;
   sessionId?: string;
 };
 
 export type PermissionResource = string;
+
+export type PermissionResourceKind = "exact" | "directory";
 
 export type PermissionSet = {
   required?: Array<PermissionDeclaration>;

--- a/packages/plugin-sdk/src/index.test.ts
+++ b/packages/plugin-sdk/src/index.test.ts
@@ -17,6 +17,7 @@ import type { PluginSecretStore, SecretRef } from "./index.ts";
 const testSecretRef: SecretRef = {
   kind: "secret",
   id: "secret-reference-1",
+  key: "token",
 };
 
 const testSecretStore: PluginSecretStore = {
@@ -76,6 +77,7 @@ test("PluginSecretStore exposes opaque references instead of plaintext reads", a
   assert.deepEqual(await testSecretStore.get("token"), testSecretRef);
   assert.deepEqual(await testSecretStore.set("token", "already-known-value"), testSecretRef);
   assert.equal("value" in testSecretRef, false);
+  assert.equal(testSecretRef.key, "token");
 });
 
 test("DisposableStore disposes every item once", () => {

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -87,7 +87,10 @@ export interface PluginFilesystemStat {
 
 export interface PluginFilesystemClient {
   readFile(path: string, options?: Readonly<{ encoding?: "utf8" | "base64"; maxBytes?: number }>): Promise<string>;
-  writeFile(path: string, data: string, options?: Readonly<{ encoding?: "utf8" | "base64"; overwrite?: boolean }>): Promise<void>;
+  writeFile(path: string, data: string, options: Readonly<{
+    encoding?: "utf8" | "base64";
+    overwrite: true;
+  }>): Promise<void>;
   stat(path: string): Promise<PluginFilesystemStat>;
   readDirectory(path: string): Promise<readonly PluginFilesystemEntry[]>;
 }

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -1,4 +1,5 @@
 import type {
+  CredentialRef,
   FeatureId,
   JsonValue,
   PluginErrorData,
@@ -6,6 +7,7 @@ import type {
   PluginId,
   PluginWireErrorCode,
   RpcErrorObject,
+  SecretLeaseRef,
   SecretRef,
   SemanticVersion,
 } from "@netcatty/plugin-contract";
@@ -43,6 +45,71 @@ export interface PluginSecretStore {
   delete(key: string): Promise<void>;
 }
 
+export interface PluginCredentialLeaseOptions {
+  readonly operationId: string;
+  readonly purpose: string;
+  readonly ttlMs?: number;
+}
+
+export interface PluginCredentialBroker {
+  createLease(credential: SecretRef | CredentialRef, options: PluginCredentialLeaseOptions): Promise<SecretLeaseRef>;
+}
+
+export interface PluginNetworkRequest {
+  readonly url: string;
+  readonly method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD";
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly body?: Readonly<{ encoding: "utf8" | "base64"; data: string }>;
+  readonly timeoutMs?: number;
+}
+
+export interface PluginNetworkResponse {
+  readonly url: string;
+  readonly status: number;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: Readonly<{ encoding: "base64"; data: string }>;
+}
+
+export interface PluginNetworkClient {
+  request(request: PluginNetworkRequest): Promise<PluginNetworkResponse>;
+}
+
+export interface PluginFilesystemEntry {
+  readonly name: string;
+  readonly kind: "file" | "directory" | "other";
+}
+
+export interface PluginFilesystemStat {
+  readonly kind: "file" | "directory" | "other";
+  readonly size: number;
+  readonly modifiedAt: number;
+}
+
+export interface PluginFilesystemClient {
+  readFile(path: string, options?: Readonly<{ encoding?: "utf8" | "base64"; maxBytes?: number }>): Promise<string>;
+  writeFile(path: string, data: string, options?: Readonly<{ encoding?: "utf8" | "base64"; overwrite?: boolean }>): Promise<void>;
+  stat(path: string): Promise<PluginFilesystemStat>;
+  readDirectory(path: string): Promise<readonly PluginFilesystemEntry[]>;
+}
+
+export interface PluginCompanionRequestOptions {
+  readonly timeoutMs?: number;
+}
+
+export interface PluginCompanionHandle extends Disposable {
+  readonly id: string;
+  request<T extends JsonValue = JsonValue>(
+    method: string,
+    params?: JsonValue,
+    options?: PluginCompanionRequestOptions,
+  ): Promise<T>;
+  stop(): Promise<void>;
+}
+
+export interface PluginCompanionService {
+  start(companionId: string): Promise<PluginCompanionHandle>;
+}
+
 export interface PluginContext {
   readonly pluginId: PluginId;
   readonly netcattyVersion: SemanticVersion;
@@ -51,6 +118,10 @@ export interface PluginContext {
   readonly subscriptions: DisposableStore;
   readonly storage: PluginKeyValueStore;
   readonly secrets: PluginSecretStore;
+  readonly credentials: PluginCredentialBroker;
+  readonly network: PluginNetworkClient;
+  readonly filesystem: PluginFilesystemClient;
+  readonly companions: PluginCompanionService;
   readonly logger: PluginLogger;
 }
 


### PR DESCRIPTION
## Summary

Phase 3 of the production plugin-platform delivery (`Related to #2269`).

- add a fail-closed `PluginPermissionEngine` with declared capabilities, resource-bound grants, `once` / `session` / `application` / `always` scopes, prompt coalescing, preflight checks, revocation, and security audit records
- add canonical network-origin, realpath-scoped filesystem, secret, credential, companion, runtime, and quota capability boundaries
- store plugin secrets through Electron `safeStorage`, expose one-use operation/runtime/plugin-bound `SecretLease` values, and keep Netcatty credentials behind late-bound `CredentialRef` resolution
- launch companion processes without a shell only after digest verification, with bounded JSON-RPC, resource quotas, cancellation, and cleanup
- extend the canonical contract, generated schema, SDK, runtime peer, host services, and documentation for downstream PRs 4-9
- keep the complete unreleased database shape at schema v1; this PR deliberately adds no migration chain

## Security and rollout

The platform remains behind the existing development gate and fails closed when no renderer permission prompt is available. Required resource-scoped permissions must declare explicit activation-time bounds and cannot use the all-resources wildcard, so an install or update cannot activate before those resources are approved. Native companions require an explicit Node utility placement and `runtime.advanced`; the first-party resolver selects utility placement for companion manifests, and browser runtimes are rejected before a companion grant can be persisted or a process can be created. The advanced utility runtime is an ambient-authority surface and remains ineligible for public enablement until phase 9 binds it to verified publisher identity.

User-owned permission, secret, and security-audit data is stored separately from package-version cascade storage. The new internal interfaces were audited against the planned UI, terminal/API, vault, agent, marketplace/signing, and compatibility phases so later PRs can consume stable authorization and credential seams without widening this boundary.

## Validation

- `npm run test:plugin-runtime`: 229 passed, 1 intentional Electron skip
- `npm run test:plugin-runtime:electron`: passed
- `npm run test:plugin-contract`: 70/70 passed
- focused permission, companion-placement, broker, manifest, runtime, lifecycle, and cancellation regressions: passed
- `npm run lint -- --quiet`: passed
- `npm run check:plugin-contract`: passed
- `npm run build`: passed
- `npm run pack:dir`: passed
- `git diff --check`: passed
- full `npm test`: 6,141 tests, 6,129 passed, 11 skipped, with one unchanged upstream SSH keyboard-interactive auth-retry failure; both `sshBridge.cjs` and its failing test are byte-identical to `upstream/main`
