### PR TITLE
fix(terminal): aggregate mounted disk summary

### DIFF
--- a/application/i18n/locales/en/terminal.ts
+++ b/application/i18n/locales/en/terminal.ts
@@ -89,7 +89,7 @@ export const enTerminalMessages: Messages = {
   'terminal.serverStats.swapFree': 'Swap Free',
   'terminal.serverStats.swapTotal': 'Total',
   'terminal.serverStats.topProcesses': 'Top Processes by Memory',
-  'terminal.serverStats.disk': 'Disk Usage (Root)',
+  'terminal.serverStats.disk': 'Disk Usage',
   'terminal.serverStats.diskDetails': 'Mounted Disks',
   'terminal.serverStats.network': 'Network Speed',
   'terminal.serverStats.latency': 'SSH network latency',

--- a/application/i18n/locales/ru/terminal.ts
+++ b/application/i18n/locales/ru/terminal.ts
@@ -110,7 +110,7 @@ export const ruTerminalMessages: Messages = {
   'terminal.serverStats.swapFree': 'Свободный swap',
   'terminal.serverStats.swapTotal': 'Всего',
   'terminal.serverStats.topProcesses': 'Топ процессов по памяти',
-  'terminal.serverStats.disk': 'Использование диска (корень)',
+  'terminal.serverStats.disk': 'Использование дисков',
   'terminal.serverStats.diskDetails': 'Смонтированные диски',
   'terminal.serverStats.network': 'Скорость сети',
   'terminal.serverStats.latency': 'Сетевая задержка SSH',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -419,7 +419,7 @@ export const zhCNVaultMessages: Messages = {
   'terminal.serverStats.swapFree': '空闲交换',
   'terminal.serverStats.swapTotal': '总计',
   'terminal.serverStats.topProcesses': '内存占用前十进程',
-  'terminal.serverStats.disk': '磁盘使用（根分区）',
+  'terminal.serverStats.disk': '磁盘使用',
   'terminal.serverStats.diskDetails': '已挂载磁盘',
   'terminal.serverStats.network': '网络速度',
   'terminal.serverStats.latency': 'SSH 网络延迟',

--- a/application/i18n/locales/zh-TW/vault.ts
+++ b/application/i18n/locales/zh-TW/vault.ts
@@ -419,7 +419,7 @@ export const zhTWVaultMessages: Messages = {
   'terminal.serverStats.swapFree': '空閒交換',
   'terminal.serverStats.swapTotal': '總計',
   'terminal.serverStats.topProcesses': '記憶體佔用前十程序',
-  'terminal.serverStats.disk': '磁碟使用（根分割槽）',
+  'terminal.serverStats.disk': '磁碟使用',
   'terminal.serverStats.diskDetails': '已掛載磁碟',
   'terminal.serverStats.network': '網路速度',
   'terminal.serverStats.latency': 'SSH 網路延遲',

--- a/components/terminal/TerminalServerStats.tsx
+++ b/components/terminal/TerminalServerStats.tsx
@@ -7,7 +7,7 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from '../ui/hover-card'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { formatNetSpeed } from './terminalHelpers';
 import { useServerStats } from './hooks/useServerStats';
-import { formatDiskCapacityGb } from './serverStatsFormat';
+import { formatDiskCapacityGb, resolveTerminalDiskSummary } from './serverStatsFormat';
 
 interface TerminalServerStatsProps {
   sessionId: string;
@@ -47,6 +47,7 @@ export const TerminalServerStats: React.FC<TerminalServerStatsProps> = ({
   });
   const hasNetworkDetails = serverStats.netInterfaces.length > 0;
   const hasLatency = serverStats.latencyMs !== null;
+  const diskSummary = resolveTerminalDiskSummary(serverStats);
 
   if (!enabled || !isConnected || !serverStats.lastUpdated) return null;
 
@@ -258,13 +259,13 @@ export const TerminalServerStats: React.FC<TerminalServerStatsProps> = ({
                       <HardDrive size={10} className="flex-shrink-0" />
                       <span className={cn(
                         "truncate",
-                        serverStats.diskPercent !== null && serverStats.diskPercent >= 90 && "text-red-400",
-                        serverStats.diskPercent !== null && serverStats.diskPercent >= 80 && serverStats.diskPercent < 90 && "text-amber-400"
+                        diskSummary.percent !== null && diskSummary.percent >= 90 && "text-red-400",
+                        diskSummary.percent !== null && diskSummary.percent >= 80 && diskSummary.percent < 90 && "text-amber-400"
                       )}>
-                        {serverStats.diskUsed !== null && serverStats.diskTotal !== null && serverStats.diskPercent !== null
-                          ? `${formatDiskCapacityGb(serverStats.diskUsed)}/${formatDiskCapacityGb(serverStats.diskTotal)}G (${serverStats.diskPercent}%)`
-                          : serverStats.diskPercent !== null
-                            ? `${serverStats.diskPercent}%`
+                        {diskSummary.used !== null && diskSummary.total !== null && diskSummary.percent !== null
+                          ? `${formatDiskCapacityGb(diskSummary.used)}/${formatDiskCapacityGb(diskSummary.total)}G (${diskSummary.percent}%)`
+                          : diskSummary.percent !== null
+                            ? `${diskSummary.percent}%`
                             : '--'}
                       </span>
                     </button>

--- a/components/terminal/serverStatsFormat.test.ts
+++ b/components/terminal/serverStatsFormat.test.ts
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { formatDiskCapacityGb } from "./serverStatsFormat.ts";
+import {
+  formatDiskCapacityGb,
+  resolveTerminalDiskSummary,
+} from "./serverStatsFormat.ts";
 
 test("disk capacity uses at most two decimal places", () => {
   assert.equal(formatDiskCapacityGb(5.964138), "5.96");
@@ -9,4 +12,34 @@ test("disk capacity uses at most two decimal places", () => {
   assert.equal(formatDiskCapacityGb(0.005907), "0.01");
   assert.equal(formatDiskCapacityGb(10), "10");
   assert.equal(formatDiskCapacityGb(10.5), "10.5");
+});
+
+test("terminal disk summary totals every mounted filesystem", () => {
+  const summary = resolveTerminalDiskSummary({
+    diskUsed: 9.285,
+    diskTotal: 899.763855,
+    diskPercent: 2,
+    disks: [
+      { capacityKey: "/dev/sdb4", mountPoint: "/", used: 9.285, total: 899.763855 },
+      { capacityKey: "/dev/sdb2", mountPoint: "/boot", used: 0.070892, total: 0.89909 },
+      { capacityKey: "/dev/sdb1", mountPoint: "/boot/efi", used: 0.008568, total: 0.474628 },
+      { capacityKey: "/dev/sda1", mountPoint: "/var", used: 215.84272, total: 1862.105923 },
+    ],
+  });
+
+  assert.equal(summary.used === null ? null : formatDiskCapacityGb(summary.used), "225.21");
+  assert.equal(summary.total === null ? null : formatDiskCapacityGb(summary.total), "2763.24");
+  assert.equal(summary.percent, 8);
+});
+
+test("terminal disk summary preserves legacy root-only stats as a fallback", () => {
+  assert.deepEqual(
+    resolveTerminalDiskSummary({
+      diskUsed: 12,
+      diskTotal: 100,
+      diskPercent: 12,
+      disks: [],
+    }),
+    { used: 12, total: 100, percent: 12 },
+  );
 });

--- a/components/terminal/serverStatsFormat.ts
+++ b/components/terminal/serverStatsFormat.ts
@@ -1,3 +1,40 @@
+import {
+  aggregateMountedDiskUsage,
+  type MountedDiskUsage,
+} from "../../domain/systemDiskUsage";
+
+interface TerminalDiskStats {
+  diskUsed: number | null;
+  diskTotal: number | null;
+  diskPercent: number | null;
+  disks: readonly MountedDiskUsage[];
+}
+
+export interface TerminalDiskSummary {
+  used: number | null;
+  total: number | null;
+  percent: number | null;
+}
+
 export function formatDiskCapacityGb(value: number): string {
   return Number(value.toFixed(2)).toString();
+}
+
+export function resolveTerminalDiskSummary(
+  stats: TerminalDiskStats,
+): TerminalDiskSummary {
+  const mountedUsage = aggregateMountedDiskUsage(stats.disks);
+  if (mountedUsage) {
+    return {
+      used: mountedUsage.used,
+      total: mountedUsage.total,
+      percent: Math.round(mountedUsage.percent),
+    };
+  }
+
+  return {
+    used: stats.diskUsed,
+    total: stats.diskTotal,
+    percent: stats.diskPercent,
+  };
 }


### PR DESCRIPTION
## Summary

- show the total usage and capacity of all mounted disks in the terminal header
- keep the existing per-mount hover details
- preserve the legacy root-disk fallback when mount details are unavailable
- rename the tooltip label so it no longer implies root-only usage

## Root cause

The earlier disk aggregation change only updated System Overview. The compact terminal header still read the root filesystem compatibility fields, so multi-disk hosts displayed the first/root disk instead of the aggregate.

## Validation

- connected through the supplied SOCKS5 proxy to the representative multi-disk host and verified the header shows `225.21/2763.24G (8%)`
- 21 focused disk and localization tests passed
- lint passed
- production build passed
- two independent review rounds found no issues
- full suite: 6111 passed, 7 skipped; one pre-existing SSH auth retry test still fails unchanged and is unrelated to this diff