### PR TITLE
chore(nix): update release metadata for v1.1.70

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,14 +1,14 @@
 {
-  version = "1.1.68";
+  version = "1.1.70";
 
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-RpOzHwUfv/6KSqO7vCiUahW/n9V0IcnmBqbOvHkI40E=";
+      hash = "sha256-3nLVrKnY/u1iKo/4m9+Ji3oDH8CdNw+JtRvrR4s/O64=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-ZqPQGw6yDf6c4LUsnrFRQaRZdKp21++xdkdlaFvkBwg=";
+      hash = "sha256-pK0PUxQcCVU3OcDpAJBSkgGTY0Z57JPAHrEKUN3c91k=";
     };
   };
 }


### PR DESCRIPTION
## Summary
- update the Nix package version to v1.1.70
- refresh x86_64 and arm64 AppImage hashes from the published release assets

## Context
The v1.1.70 release and Homebrew update completed successfully. The release workflow could not push this generated metadata directly because the main branch requires changes through a pull request.

## Validation
- node --test scripts/update-nix-release.test.cjs
- git diff --check