### PR TITLE
Clarify pending CRDT replica setup

### DIFF
--- a/application/i18n/locales/cloudSyncConvergentLocales.test.ts
+++ b/application/i18n/locales/cloudSyncConvergentLocales.test.ts
@@ -12,6 +12,7 @@ const keys = [
   'cloudSync.convergent.desc',
   'cloudSync.convergent.active',
   'cloudSync.convergent.paused',
+  'cloudSync.convergent.setupRequired',
   'cloudSync.convergent.enabled',
   'cloudSync.convergent.preview.title',
   'cloudSync.convergent.preview.entities',

--- a/application/i18n/locales/en/terminal.ts
+++ b/application/i18n/locales/en/terminal.ts
@@ -347,6 +347,7 @@ export const enTerminalMessages: Messages = {
   'cloudSync.convergent.desc': 'Uses an encrypted CRDT replica to preserve offline edits, concurrent deletions, and changes from every connected provider.',
   'cloudSync.convergent.active': 'CRDT v2 is active. Provider writes are verified after upload.',
   'cloudSync.convergent.paused': 'CRDT v2 is paused on this device; cloud metadata is retained.',
+  'cloudSync.convergent.setupRequired': 'Create the CRDT replica below to finish enabling this feature.',
   'cloudSync.convergent.enabled': 'Convergent sync enabled',
   'cloudSync.convergent.preview.title': 'Migration preview',
   'cloudSync.convergent.preview.entities': 'Entities',

--- a/application/i18n/locales/ru/terminal.ts
+++ b/application/i18n/locales/ru/terminal.ts
@@ -363,6 +363,7 @@ export const ruTerminalMessages: Messages = {
   'cloudSync.convergent.desc': 'Зашифрованная CRDT-реплика сохраняет офлайн-правки, параллельные удаления и изменения всех подключённых провайдеров.',
   'cloudSync.convergent.active': 'CRDT v2 активна. Каждая загрузка проверяется чтением из облака.',
   'cloudSync.convergent.paused': 'CRDT v2 приостановлена на этом устройстве; облачные метаданные сохранены.',
+  'cloudSync.convergent.setupRequired': 'Создайте CRDT-реплику ниже, чтобы завершить включение этой функции.',
   'cloudSync.convergent.enabled': 'Сходящаяся синхронизация включена',
   'cloudSync.convergent.preview.title': 'Предпросмотр миграции',
   'cloudSync.convergent.preview.entities': 'Объекты',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -659,6 +659,7 @@ export const zhCNVaultMessages: Messages = {
   'cloudSync.convergent.desc': '使用加密 CRDT 副本保留离线编辑、并发删除，以及所有已连接云服务中的变化。',
   'cloudSync.convergent.active': 'CRDT v2 已启用；每次上传后都会验证云端写入。',
   'cloudSync.convergent.paused': '此设备已暂停 CRDT v2；云端元数据仍会保留。',
+  'cloudSync.convergent.setupRequired': '请先创建 CRDT 副本，完成后此功能才会正式启用。',
   'cloudSync.convergent.enabled': '已启用可收敛同步',
   'cloudSync.convergent.preview.title': '迁移预览',
   'cloudSync.convergent.preview.entities': '实体',

--- a/application/i18n/locales/zh-TW/vault.ts
+++ b/application/i18n/locales/zh-TW/vault.ts
@@ -659,6 +659,7 @@ export const zhTWVaultMessages: Messages = {
   'cloudSync.convergent.desc': '使用加密 CRDT 副本保留離線編輯、並行刪除，以及所有已連線雲端服務中的變化。',
   'cloudSync.convergent.active': 'CRDT v2 已啟用；每次上傳後都會驗證雲端寫入。',
   'cloudSync.convergent.paused': '此裝置已暫停 CRDT v2；雲端中繼資料仍會保留。',
+  'cloudSync.convergent.setupRequired': '請先建立 CRDT 副本，完成後此功能才會正式啟用。',
   'cloudSync.convergent.enabled': '已啟用可收斂同步',
   'cloudSync.convergent.preview.title': '遷移預覽',
   'cloudSync.convergent.preview.entities': '實體',

--- a/components/cloud-sync/ConvergentSyncPanel.test.tsx
+++ b/components/cloud-sync/ConvergentSyncPanel.test.tsx
@@ -79,3 +79,55 @@ test('secret fields nested inside array candidates never reach rendered markup',
   assert.equal(markup.includes('NESTED-API-KEY-MUST-NOT-RENDER'), false);
   assert.equal(markup.includes('SECRET_SET'), true);
 });
+
+test('pending setup keeps the switch on and disabled until the replica is created', () => {
+  const migrationPreview = {
+    schemaVersion: 2 as const,
+    canInitialize: true,
+    entityCounts: {},
+    settingsLeafCount: 0,
+    conflictCount: 0,
+    conflicts: [],
+    shrinkFindings: [],
+    providers: [],
+    oldClientCompatibility: 'materialized-v1-snapshot' as const,
+    blockedReasons: [],
+  };
+  const renderPanel = (
+    preview: typeof migrationPreview | null,
+    busy = false,
+  ) => renderToStaticMarkup(
+    <ConvergentSyncPanel
+      t={t}
+      resolvedLocale="en"
+      config={{ enabled: false, initialized: false }}
+      preview={preview}
+      busy={busy}
+      error={null}
+      conflicts={[]}
+      onToggle={() => {}}
+      onConfirmMigration={() => {}}
+      onCancelMigration={() => {}}
+      onResolveConflict={() => {}}
+      onDowngrade={() => {}}
+    />,
+  );
+
+  assert.equal(
+    renderPanel(migrationPreview).includes('cloudSync.convergent.setupRequired'),
+    true,
+  );
+  assert.match(
+    renderPanel(migrationPreview),
+    /role="switch"[^>]*aria-checked="true"[^>]*disabled=""/,
+  );
+  assert.equal(
+    renderPanel(null).includes('cloudSync.convergent.setupRequired'),
+    false,
+  );
+  assert.match(renderPanel(null), /role="switch"[^>]*aria-checked="false"/);
+  assert.match(
+    renderPanel(null, true),
+    /role="switch"[^>]*aria-checked="true"[^>]*disabled=""/,
+  );
+});

--- a/components/cloud-sync/ConvergentSyncPanel.test.tsx
+++ b/components/cloud-sync/ConvergentSyncPanel.test.tsx
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
+import type { ConvergentMigrationPreview } from '../../domain/sync';
 import { ConvergentSyncPanel } from './ConvergentSyncPanel.tsx';
 
 const t = (key: string, values?: Record<string, string | number>) =>
@@ -81,8 +82,8 @@ test('secret fields nested inside array candidates never reach rendered markup',
 });
 
 test('pending setup keeps the switch on and disabled until the replica is created', () => {
-  const migrationPreview = {
-    schemaVersion: 2 as const,
+  const migrationPreview: ConvergentMigrationPreview = {
+    schemaVersion: 2,
     canInitialize: true,
     entityCounts: {},
     settingsLeafCount: 0,
@@ -129,5 +130,19 @@ test('pending setup keeps the switch on and disabled until the replica is create
   assert.match(
     renderPanel(null, true),
     /role="switch"[^>]*aria-checked="true"[^>]*disabled=""/,
+  );
+
+  const blockedMarkup = renderPanel({
+    ...migrationPreview,
+    canInitialize: false,
+    blockedReasons: ['Provider unavailable'],
+  });
+  const blockedSwitch = blockedMarkup.match(/<button[^>]*role="switch"[^>]*>/)?.[0];
+  assert.ok(blockedSwitch);
+  assert.match(blockedSwitch, /aria-checked="false"/);
+  assert.doesNotMatch(blockedSwitch, /\sdisabled(?:=""|(?=\s|>))/);
+  assert.equal(
+    blockedMarkup.includes('cloudSync.convergent.setupRequired'),
+    false,
   );
 });

--- a/components/cloud-sync/ConvergentSyncPanel.tsx
+++ b/components/cloud-sync/ConvergentSyncPanel.tsx
@@ -103,8 +103,11 @@ export const ConvergentSyncPanel: React.FC<ConvergentSyncPanelProps> = ({
   onCancelMigration,
   onResolveConflict,
   onDowngrade,
-}) => (
-  <div className="space-y-4 overflow-hidden rounded-xl border border-amber-500/25 bg-gradient-to-br from-amber-500/[0.07] via-card to-card p-4 shadow-sm">
+}) => {
+  const setupPending = !config.initialized && preview?.canInitialize === true;
+
+  return (
+    <div className="space-y-4 overflow-hidden rounded-xl border border-amber-500/25 bg-gradient-to-br from-amber-500/[0.07] via-card to-card p-4 shadow-sm">
     <div className="flex items-start justify-between gap-3">
       <div className="flex min-w-0 items-start gap-3">
         <div
@@ -126,9 +129,9 @@ export const ConvergentSyncPanel: React.FC<ConvergentSyncPanelProps> = ({
         </div>
       </div>
       <ConvergentToggle
-        checked={config.enabled || (!config.initialized && (busy || preview !== null))}
+        checked={config.enabled || (!config.initialized && busy) || setupPending}
         onChange={onToggle}
-        disabled={busy || (!config.initialized && preview !== null)}
+        disabled={busy || setupPending}
         label={t('cloudSync.convergent.title')}
       />
     </div>
@@ -142,7 +145,7 @@ export const ConvergentSyncPanel: React.FC<ConvergentSyncPanelProps> = ({
       </div>
     )}
 
-    {!config.initialized && preview !== null && (
+    {setupPending && (
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         <Info size={14} className="shrink-0 text-amber-600 dark:text-amber-400" />
         <span>{t('cloudSync.convergent.setupRequired')}</span>
@@ -260,5 +263,6 @@ export const ConvergentSyncPanel: React.FC<ConvergentSyncPanelProps> = ({
         </Button>
       </div>
     )}
-  </div>
-);
+    </div>
+  );
+};

--- a/components/cloud-sync/ConvergentSyncPanel.tsx
+++ b/components/cloud-sync/ConvergentSyncPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AlertTriangle, FlaskConical, RotateCcw, ShieldCheck } from 'lucide-react';
+import { AlertTriangle, FlaskConical, Info, RotateCcw, ShieldCheck } from 'lucide-react';
 
 import type {
   ConvergentFieldConflict,
@@ -126,9 +126,9 @@ export const ConvergentSyncPanel: React.FC<ConvergentSyncPanelProps> = ({
         </div>
       </div>
       <ConvergentToggle
-        checked={config.enabled}
+        checked={config.enabled || (!config.initialized && (busy || preview !== null))}
         onChange={onToggle}
-        disabled={busy}
+        disabled={busy || (!config.initialized && preview !== null)}
         label={t('cloudSync.convergent.title')}
       />
     </div>
@@ -139,6 +139,13 @@ export const ConvergentSyncPanel: React.FC<ConvergentSyncPanelProps> = ({
         {config.enabled
           ? t('cloudSync.convergent.active')
           : t('cloudSync.convergent.paused')}
+      </div>
+    )}
+
+    {!config.initialized && preview !== null && (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Info size={14} className="shrink-0 text-amber-600 dark:text-amber-400" />
+        <span>{t('cloudSync.convergent.setupRequired')}</span>
       </div>
     )}
 


### PR DESCRIPTION
## Summary

- show the convergent sync switch as enabled and locked while the initial CRDT replica is pending
- add concise setup guidance below the switch without changing the existing default color treatment
- cover the pending, idle, and busy switch states with focused tests

## Root cause

The setup preview kept the switch visually disabled even though enabling convergent sync had already started the initial replica workflow. This made the UI state look inconsistent and did not explain that sync becomes available only after the CRDT replica is created.

## User impact

Users now see an enabled-but-locked switch during initial setup, together with a short explanation of the required CRDT replica step. Once setup completes, the switch becomes interactive as expected.

## Validation

- focused Vitest coverage for the convergent sync panel and locale completeness
- ESLint on all changed files
- production build (`npm run build`)

## Screenshot

<img width="736" height="390" alt="Convergent sync setup guidance" src="https://github.com/user-attachments/assets/312f314a-1f17-4265-8149-3a56ff7fac3b" />

Closes #2317
