### PR TITLE
fix: forget remembered passphrase when deleting a key

### DIFF
--- a/application/defaultKeyPassphrases.ts
+++ b/application/defaultKeyPassphrases.ts
@@ -188,6 +188,29 @@ export async function removeDefaultKeyPassphraseAliases(keyPaths: string[]): Pro
   return aliases;
 }
 
+export async function deleteVaultKey(keys: SSHKey[], keyId: string): Promise<SSHKey[]> {
+  const key = keys.find((candidate) => candidate.id === keyId);
+  if (!key) return keys;
+
+  const remainingKeys = keys.filter((candidate) => candidate.id !== keyId);
+  if (key.source === "reference" && key.filePath) {
+    const deletedAliases = matchingPathKeys(
+      await resolveDefaultKeyPassphraseAliases(key.filePath),
+    );
+    const remainingReferencePaths = remainingKeys
+      .filter((candidate) => candidate.source === "reference" && candidate.filePath)
+      .map((candidate) => candidate.filePath!);
+    const remainingAliases = matchingPathKeys((await Promise.all(
+      remainingReferencePaths.map(resolveDefaultKeyPassphraseAliases),
+    )).flat());
+    const pathStillReferenced = [...deletedAliases].some((path) => remainingAliases.has(path));
+    if (!pathStillReferenced) {
+      await removeDefaultKeyPassphraseAliases([key.filePath]);
+    }
+  }
+  return remainingKeys;
+}
+
 export function clearReferenceKeyPassphrases(keys: SSHKey[], keyPaths: string[]): SSHKey[] {
   const pathKeys = matchingPathKeys(keyPaths);
   let changed = false;

--- a/application/defaultKeyPassphrases.ts
+++ b/application/defaultKeyPassphrases.ts
@@ -188,27 +188,31 @@ export async function removeDefaultKeyPassphraseAliases(keyPaths: string[]): Pro
   return aliases;
 }
 
-export async function deleteVaultKey(keys: SSHKey[], keyId: string): Promise<SSHKey[]> {
-  const key = keys.find((candidate) => candidate.id === keyId);
-  if (!key) return keys;
+export async function deleteVaultKey(args: {
+  keyId: string;
+  getKeys: () => SSHKey[];
+  updateKeys: (keys: SSHKey[]) => void;
+}): Promise<void> {
+  const keys = args.getKeys();
+  const key = keys.find((candidate) => candidate.id === args.keyId);
+  if (!key) return;
 
-  const remainingKeys = keys.filter((candidate) => candidate.id !== keyId);
-  if (key.source === "reference" && key.filePath) {
-    const deletedAliases = matchingPathKeys(
-      await resolveDefaultKeyPassphraseAliases(key.filePath),
-    );
-    const remainingReferencePaths = remainingKeys
-      .filter((candidate) => candidate.source === "reference" && candidate.filePath)
-      .map((candidate) => candidate.filePath!);
-    const remainingAliases = matchingPathKeys((await Promise.all(
-      remainingReferencePaths.map(resolveDefaultKeyPassphraseAliases),
-    )).flat());
-    const pathStillReferenced = [...deletedAliases].some((path) => remainingAliases.has(path));
-    if (!pathStillReferenced) {
-      await removeDefaultKeyPassphraseAliases([key.filePath]);
-    }
+  args.updateKeys(keys.filter((candidate) => candidate.id !== args.keyId));
+  if (key.source !== "reference" || !key.filePath) return;
+
+  const deletedAliases = matchingPathKeys(
+    await resolveDefaultKeyPassphraseAliases(key.filePath),
+  );
+  const currentReferencePaths = args.getKeys()
+    .filter((candidate) => candidate.source === "reference" && candidate.filePath)
+    .map((candidate) => candidate.filePath!);
+  const currentAliases = matchingPathKeys((await Promise.all(
+    currentReferencePaths.map(resolveDefaultKeyPassphraseAliases),
+  )).flat());
+  const pathStillReferenced = [...deletedAliases].some((path) => currentAliases.has(path));
+  if (!pathStillReferenced) {
+    await removeDefaultKeyPassphraseAliases([key.filePath]);
   }
-  return remainingKeys;
 }
 
 export function clearReferenceKeyPassphrases(keys: SSHKey[], keyPaths: string[]): SSHKey[] {

--- a/application/defaultKeyPassphrases.ts
+++ b/application/defaultKeyPassphrases.ts
@@ -200,18 +200,15 @@ export async function deleteVaultKey(args: {
   args.updateKeys(keys.filter((candidate) => candidate.id !== args.keyId));
   if (key.source !== "reference" || !key.filePath) return;
 
-  const deletedAliases = matchingPathKeys(
-    await resolveDefaultKeyPassphraseAliases(key.filePath),
-  );
-  const currentReferencePaths = args.getKeys()
+  const deletedAliases = await resolveDefaultKeyPassphraseAliases(key.filePath);
+  const deletedAliasKeys = matchingPathKeys(deletedAliases);
+  const currentReferencePathKeys = matchingPathKeys(args.getKeys()
     .filter((candidate) => candidate.source === "reference" && candidate.filePath)
-    .map((candidate) => candidate.filePath!);
-  const currentAliases = matchingPathKeys((await Promise.all(
-    currentReferencePaths.map(resolveDefaultKeyPassphraseAliases),
-  )).flat());
-  const pathStillReferenced = [...deletedAliases].some((path) => currentAliases.has(path));
+    .map((candidate) => candidate.filePath!));
+  const pathStillReferenced = [...currentReferencePathKeys]
+    .some((path) => deletedAliasKeys.has(path));
   if (!pathStillReferenced) {
-    await removeDefaultKeyPassphraseAliases([key.filePath]);
+    removeDefaultKeyPassphrases(deletedAliases);
   }
 }
 

--- a/application/state/defaultKeyPassphrases.test.ts
+++ b/application/state/defaultKeyPassphrases.test.ts
@@ -65,11 +65,18 @@ const referenceKey = (): SSHKey => ({
 test("deleting a reference key also forgets its remembered passphrase", async (t) => {
   installLocalStorage(t);
   const key = referenceKey();
+  let keys = [key];
   await saveDefaultKeyPassphrase(key.filePath!, "remembered-passphrase");
 
-  const remainingKeys = await deleteVaultKey([key], key.id);
+  await deleteVaultKey({
+    keyId: key.id,
+    getKeys: () => keys,
+    updateKeys: (updated) => {
+      keys = updated;
+    },
+  });
 
-  assert.deepEqual(remainingKeys, []);
+  assert.deepEqual(keys, []);
   assert.equal(await loadDefaultKeyPassphrase(key.filePath!), null);
 });
 
@@ -77,14 +84,94 @@ test("deleting one reference keeps the passphrase while another key uses the sam
   installLocalStorage(t);
   const key = referenceKey();
   const duplicate = { ...key, id: "duplicate-reference" };
+  let keys = [key, duplicate];
   await saveDefaultKeyPassphrase(key.filePath!, "remembered-passphrase");
 
-  const remainingKeys = await deleteVaultKey([key, duplicate], key.id);
+  await deleteVaultKey({
+    keyId: key.id,
+    getKeys: () => keys,
+    updateKeys: (updated) => {
+      keys = updated;
+    },
+  });
 
-  assert.deepEqual(remainingKeys, [duplicate]);
+  assert.deepEqual(keys, [duplicate]);
   assert.equal(
     await loadDefaultKeyPassphrase(key.filePath!),
     "remembered-passphrase",
+  );
+});
+
+test("deleting a key cannot overwrite a concurrent key-list update", async (t) => {
+  installLocalStorage(t);
+  const key = referenceKey();
+  const concurrentReference = { ...key, id: "concurrent-reference" };
+  let keys = [key];
+  await saveDefaultKeyPassphrase(key.filePath!, "remembered-passphrase");
+  let releaseHomeLookup: (() => void) | undefined;
+  const homeLookup = new Promise<void>((resolve) => {
+    releaseHomeLookup = resolve;
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { netcatty: { getHomeDir: async () => {
+      await homeLookup;
+      return "/Users/alice";
+    } } },
+  });
+
+  const deletion = deleteVaultKey({
+    keyId: key.id,
+    getKeys: () => keys,
+    updateKeys: (updated) => {
+      keys = updated;
+    },
+  });
+  assert.deepEqual(keys, []);
+  keys = [concurrentReference];
+  releaseHomeLookup?.();
+  await deletion;
+
+  assert.deepEqual(keys, [concurrentReference]);
+  assert.equal(
+    await loadDefaultKeyPassphrase(key.filePath!),
+    "remembered-passphrase",
+  );
+});
+
+test("deleting a Windows reference clears remembered path aliases", async (t) => {
+  installLocalStorage(t);
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { netcatty: { getHomeDir: async () => "C:\\Users\\Alice" } },
+  });
+  const key = {
+    ...referenceKey(),
+    filePath: "~/.ssh/id_ed25519",
+  };
+  let keys = [key];
+  globalThis.localStorage.setItem(
+    STORAGE_KEY_DEFAULT_KEY_PASSPHRASES,
+    JSON.stringify({
+      "~/.ssh/id_ed25519": "old-relative",
+      "C:\\Users\\Alice\\.ssh\\id_ed25519": "old-native",
+      "C:/Users/Alice/.ssh/id_ed25519": "old-normalized",
+      "C:/Users/Alice/.ssh/other": "keep",
+    }),
+  );
+
+  await deleteVaultKey({
+    keyId: key.id,
+    getKeys: () => keys,
+    updateKeys: (updated) => {
+      keys = updated;
+    },
+  });
+
+  assert.deepEqual(keys, []);
+  assert.deepEqual(
+    JSON.parse(globalThis.localStorage.getItem(STORAGE_KEY_DEFAULT_KEY_PASSPHRASES) ?? "{}"),
+    { "C:/Users/Alice/.ssh/other": "keep" },
   );
 });
 

--- a/application/state/defaultKeyPassphrases.test.ts
+++ b/application/state/defaultKeyPassphrases.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   clearKeyPassphrasesByIds,
   clearReferenceKeyPassphrases,
+  deleteVaultKey,
   loadDefaultKeyPassphrase,
   rememberKeyPassphrase,
   removeDefaultKeyPassphraseAliases,
@@ -59,6 +60,32 @@ const referenceKey = (): SSHKey => ({
   filePath: "/Users/alice/.ssh/id_ed25519",
   privateKey: "",
   created: 1,
+});
+
+test("deleting a reference key also forgets its remembered passphrase", async (t) => {
+  installLocalStorage(t);
+  const key = referenceKey();
+  await saveDefaultKeyPassphrase(key.filePath!, "remembered-passphrase");
+
+  const remainingKeys = await deleteVaultKey([key], key.id);
+
+  assert.deepEqual(remainingKeys, []);
+  assert.equal(await loadDefaultKeyPassphrase(key.filePath!), null);
+});
+
+test("deleting one reference keeps the passphrase while another key uses the same file", async (t) => {
+  installLocalStorage(t);
+  const key = referenceKey();
+  const duplicate = { ...key, id: "duplicate-reference" };
+  await saveDefaultKeyPassphrase(key.filePath!, "remembered-passphrase");
+
+  const remainingKeys = await deleteVaultKey([key, duplicate], key.id);
+
+  assert.deepEqual(remainingKeys, [duplicate]);
+  assert.equal(
+    await loadDefaultKeyPassphrase(key.filePath!),
+    "remembered-passphrase",
+  );
 });
 
 test("loadDefaultKeyPassphrase removes undecryptable credential placeholders", async (t) => {

--- a/application/state/defaultKeyPassphrases.test.ts
+++ b/application/state/defaultKeyPassphrases.test.ts
@@ -112,9 +112,11 @@ test("deleting a key cannot overwrite a concurrent key-list update", async (t) =
   const homeLookup = new Promise<void>((resolve) => {
     releaseHomeLookup = resolve;
   });
+  let homeLookupCount = 0;
   Object.defineProperty(globalThis, "window", {
     configurable: true,
     value: { netcatty: { getHomeDir: async () => {
+      homeLookupCount += 1;
       await homeLookup;
       return "/Users/alice";
     } } },
@@ -133,6 +135,7 @@ test("deleting a key cannot overwrite a concurrent key-list update", async (t) =
   await deletion;
 
   assert.deepEqual(keys, [concurrentReference]);
+  assert.equal(homeLookupCount, 1);
   assert.equal(
     await loadDefaultKeyPassphrase(key.filePath!),
     "remembered-passphrase",

--- a/components/VaultViewLayout.test.ts
+++ b/components/VaultViewLayout.test.ts
@@ -29,3 +29,9 @@ test("vault sidebar toggle keeps an accessible action label", () => {
     /aria-label=\{sidebarCollapsed \? t\("vault\.sidebar\.expand"\) : t\("vault\.sidebar\.collapse"\)\}/,
   );
 });
+
+test("keychain deletion clears the remembered passphrase through the vault handler", () => {
+  assert.match(vaultViewLayoutSource, /const handleDeleteVaultKey = React\.useCallback/);
+  assert.match(vaultViewLayoutSource, /void deleteVaultKey\(\{/);
+  assert.match(vaultViewLayoutSource, /onDelete=\{handleDeleteVaultKey\}/);
+});

--- a/components/vault/VaultViewLayout.tsx
+++ b/components/vault/VaultViewLayout.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from "react";
+import { deleteVaultKey } from "../../application/defaultKeyPassphrases";
 import { preserveConcurrentHostLineTimestampUpdate } from "../../domain/host";
 import { STORAGE_KEY_VAULT_HOST_PANEL_WIDTH } from "@/infrastructure/config/storageKeys.ts";
 import { VaultHostListSection } from "./VaultHostListSection";
@@ -663,7 +664,9 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
                 )
               }
               onReorderKeys={onUpdateKeys}
-              onDelete={(id) => onUpdateKeys(keys.filter((k) => k.id !== id))}
+              onDelete={(id) => {
+                void deleteVaultKey(keys, id).then(onUpdateKeys);
+              }}
               onSaveIdentity={(identity) =>
                 onUpdateIdentities(
                   identities.find((ex) => ex.id === identity.id)

--- a/components/vault/VaultViewLayout.tsx
+++ b/components/vault/VaultViewLayout.tsx
@@ -28,6 +28,8 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
     resizeAriaLabel: t("vault.panel.resizeWidth"),
   };
   const [isSidebarResizing, setIsSidebarResizing] = React.useState(false);
+  const keyListRef = React.useRef(keys);
+  keyListRef.current = keys;
   const newHostActionsRef = React.useRef<HTMLDivElement>(null);
   const sessionActionsRef = React.useRef<HTMLDivElement>(null);
   const sidebarMinWidth = 56;
@@ -36,6 +38,18 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
     sidebarMinWidth,
     Math.min(sidebarMaxWidth, Number(sidebarWidth) || 208),
   );
+  const handleDeleteVaultKey = React.useCallback((keyId: string) => {
+    void deleteVaultKey({
+      keyId,
+      getKeys: () => keyListRef.current,
+      updateKeys: (updatedKeys) => {
+        keyListRef.current = updatedKeys;
+        void onUpdateKeys(updatedKeys);
+      },
+    }).catch((error) => {
+      console.error("[Vault] Failed to clear a deleted key's remembered passphrase.", error);
+    });
+  }, [onUpdateKeys]);
   const handleSidebarResizeStart = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     event.preventDefault();
     event.stopPropagation();
@@ -664,9 +678,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
                 )
               }
               onReorderKeys={onUpdateKeys}
-              onDelete={(id) => {
-                void deleteVaultKey(keys, id).then(onUpdateKeys);
-              }}
+              onDelete={handleDeleteVaultKey}
               onSaveIdentity={(identity) =>
                 onUpdateIdentities(
                   identities.find((ex) => ex.id === identity.id)


### PR DESCRIPTION
## What changed

- clear Netcatty's remembered passphrase when the last Keychain reference to a local key file is deleted
- preserve the passphrase when another Keychain entry still references the same file
- route Keychain deletion through the cleanup path

## Why

Deleting a reference key removed the Keychain entry but left the separately persisted passphrase behind. Automatic authentication could later rediscover the local key file and silently reuse that passphrase, including after deleting the host or restarting Netcatty.

Fixes #2321.

## Validation

- added a regression test that failed before the fix
- 96 focused SSH/key deletion tests pass
- full `npm test` passes
- `npm run build` passes
- affected-file ESLint and `git diff --check` pass