### PR TITLE
[codex] Fix keyboard navigation in host pickers

### DIFF
--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -103,7 +103,7 @@ const HostItem = memo(({
 }: {
   host: Host;
   isSelected: boolean;
-  selectedItemRef?: React.Ref<HTMLDivElement>;
+  selectedItemRef?: React.RefCallback<HTMLDivElement>;
   onSelect: (host: Host) => void;
   onMouseEnter: () => void;
 }) => (
@@ -195,7 +195,10 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const selectedItemRef = useRef<HTMLDivElement>(null);
+  const selectedItemRef = useRef<HTMLElement>(null);
+  const setSelectedItemRef = useCallback((element: HTMLElement | null) => {
+    selectedItemRef.current = element;
+  }, []);
 
   // Reset state when opening
   useEffect(() => {
@@ -461,7 +464,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                     key={host.id}
                     host={host}
                     isSelected={getItemIndex("host", host.id) === selectedIndex}
-                    selectedItemRef={getItemIndex("host", host.id) === selectedIndex ? selectedItemRef : undefined}
+                    selectedItemRef={getItemIndex("host", host.id) === selectedIndex ? setSelectedItemRef : undefined}
                     onSelect={onSelect}
                     onMouseEnter={() => setSelectedIndex(getItemIndex("host", host.id))}
                   />
@@ -492,7 +495,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                 return (
                   <div
                     key={tabId}
-                    ref={isSelected ? selectedItemRef : undefined}
+                    ref={isSelected ? setSelectedItemRef : undefined}
                     className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${isSelected ? "bg-primary/15" : "hover:bg-muted/50"
                       }`}
                     onClick={() => {
@@ -517,7 +520,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                 return (
                   <div
                     key={workspace.id}
-                    ref={isSelected ? selectedItemRef : undefined}
+                    ref={isSelected ? setSelectedItemRef : undefined}
                     className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${isSelected ? "bg-primary/15" : "hover:bg-muted/50"
                       }`}
                     onClick={() => {
@@ -544,7 +547,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                 return (
                   <div
                     key={session.id}
-                    ref={isSelected ? selectedItemRef : undefined}
+                    ref={isSelected ? setSelectedItemRef : undefined}
                     className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${isSelected ? "bg-primary/15" : "hover:bg-muted/50"
                       }`}
                     onClick={() => {
@@ -579,7 +582,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                   return (
                     <div
                       key={shell.id}
-                      ref={isSelected ? selectedItemRef : undefined}
+                      ref={isSelected ? setSelectedItemRef : undefined}
                       className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${
                         isSelected ? "bg-primary/15" : "hover:bg-muted/50"
                       }`}
@@ -614,7 +617,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                   </span>
                 </div>
                 <div
-                  ref={getItemIndex("action", "local-terminal") === selectedIndex ? selectedItemRef : undefined}
+                  ref={getItemIndex("action", "local-terminal") === selectedIndex ? setSelectedItemRef : undefined}
                   className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${
                     getItemIndex("action", "local-terminal") === selectedIndex
                       ? "bg-primary/15"
@@ -648,6 +651,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                     <button
                       type="button"
                       key={`${item.type}:${item.id}`}
+                      ref={isSelected ? setSelectedItemRef : undefined}
                       disabled={item.enabled === false}
                       className={`flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors ${isSelected ? 'bg-primary/15' : 'hover:bg-muted/50'} disabled:opacity-50`}
                       onClick={(event) => handleItemSelect(item, event.altKey)}

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -97,15 +97,18 @@ const IS_MAC = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(naviga
 const HostItem = memo(({
   host,
   isSelected,
+  selectedItemRef,
   onSelect,
   onMouseEnter,
 }: {
   host: Host;
   isSelected: boolean;
+  selectedItemRef?: React.Ref<HTMLDivElement>;
   onSelect: (host: Host) => void;
   onMouseEnter: () => void;
 }) => (
   <div
+    ref={selectedItemRef}
     className={`flex items-center justify-between px-4 py-2.5 cursor-pointer transition-colors ${isSelected ? "bg-primary/15" : "hover:bg-muted/50"
       }`}
     onClick={() => onSelect(host)}
@@ -192,6 +195,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const selectedItemRef = useRef<HTMLDivElement>(null);
 
   // Reset state when opening
   useEffect(() => {
@@ -322,6 +326,14 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
     return itemIndexMap.get(`${type}:${id}`) ?? -1;
   }, [itemIndexMap]);
 
+  const selectedItem = flatItems[selectedIndex];
+  const selectedItemKey = selectedItem ? `${selectedItem.type}:${selectedItem.id}` : '';
+
+  useEffect(() => {
+    if (!isOpen || !selectedItemKey) return;
+    selectedItemRef.current?.scrollIntoView({ block: "nearest" });
+  }, [isOpen, selectedIndex, selectedItemKey]);
+
   if (!isOpen) return null;
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -449,6 +461,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                     key={host.id}
                     host={host}
                     isSelected={getItemIndex("host", host.id) === selectedIndex}
+                    selectedItemRef={getItemIndex("host", host.id) === selectedIndex ? selectedItemRef : undefined}
                     onSelect={onSelect}
                     onMouseEnter={() => setSelectedIndex(getItemIndex("host", host.id))}
                   />
@@ -479,6 +492,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                 return (
                   <div
                     key={tabId}
+                    ref={isSelected ? selectedItemRef : undefined}
                     className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${isSelected ? "bg-primary/15" : "hover:bg-muted/50"
                       }`}
                     onClick={() => {
@@ -503,6 +517,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                 return (
                   <div
                     key={workspace.id}
+                    ref={isSelected ? selectedItemRef : undefined}
                     className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${isSelected ? "bg-primary/15" : "hover:bg-muted/50"
                       }`}
                     onClick={() => {
@@ -529,6 +544,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                 return (
                   <div
                     key={session.id}
+                    ref={isSelected ? selectedItemRef : undefined}
                     className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${isSelected ? "bg-primary/15" : "hover:bg-muted/50"
                       }`}
                     onClick={() => {
@@ -563,6 +579,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                   return (
                     <div
                       key={shell.id}
+                      ref={isSelected ? selectedItemRef : undefined}
                       className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${
                         isSelected ? "bg-primary/15" : "hover:bg-muted/50"
                       }`}
@@ -597,6 +614,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                   </span>
                 </div>
                 <div
+                  ref={getItemIndex("action", "local-terminal") === selectedIndex ? selectedItemRef : undefined}
                   className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${
                     getItemIndex("action", "local-terminal") === selectedIndex
                       ? "bg-primary/15"

--- a/components/workspace/AddToWorkspaceDialog.tsx
+++ b/components/workspace/AddToWorkspaceDialog.tsx
@@ -128,7 +128,7 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       setSelectedIndex((i) => Math.max(i - 1, 0));
-    } else if (e.key === ' ' || (e.key === 'Enter' && !(e.metaKey || e.ctrlKey))) {
+    } else if (e.key === 'Enter' && !(e.metaKey || e.ctrlKey)) {
       if (items.length === 0) return;
       e.preventDefault();
       toggle(items[selectedIndex].id);
@@ -180,7 +180,7 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
             {/* Jump-to hint */}
             <div className="px-4 py-2 flex items-center gap-2">
               <span className="text-xs text-muted-foreground">Pick one or more</span>
-              <kbd className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded">Space</kbd>
+              <kbd className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded">Enter</kbd>
               <span className="text-[10px] text-muted-foreground">toggle</span>
               <kbd className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded">
                 {typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform) ? '⌘' : 'Ctrl'}+Enter


### PR DESCRIPTION
## Summary
- keep the Ctrl+K keyboard selection inside the visible QuickSwitcher viewport
- let spaces remain searchable text in the New Workspace picker
- use Enter to toggle a workspace target while preserving Ctrl/Cmd+Enter to add

## Root cause
QuickSwitcher updated its selected index without scrolling the selected row into view. The workspace picker also handled Space on its focused search input as a selection command, preventing multi-word searches.

## Validation
- `npx eslint components/QuickSwitcher.tsx components/workspace/AddToWorkspaceDialog.tsx` (no errors; one pre-existing unused `Puzzle` import warning)
- `node --test --import tsx components/QuickSwitcher.pluginContributions.test.tsx` (3 passed)
- `git diff upstream/main...HEAD --check`

Full build is currently blocked before this UI code is compiled: the plugin workspace cannot resolve `@netcatty/plugin-contract`, and direct Vite build cannot resolve the installed `@fontsource/mona-sans/400.css` dependency.