### PR TITLE
feat(ai): 新增 MCP 会话静默运行开关

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -61,6 +61,7 @@ import { netcattyBridge } from './infrastructure/services/netcattyBridge';
 import { localStorageAdapter } from './infrastructure/persistence/localStorageAdapter';
 import {
   readExternalMcpFocusOnHostOpen,
+  readExternalMcpSilentSessions,
   syncExternalMcpStartupState,
 } from './application/state/useExternalMcpToggleState';
 import { useExternalMcpSessionSync } from './application/state/useExternalMcpSessionSync';
@@ -1102,7 +1103,7 @@ function App({ settings }: { settings: SettingsState }) {
   ), [createWorkspaceFromTargets, resolveEffectiveHost]);
 
   // Wrapper to connect to host with logging
-  const handleConnectToHost = useCallback((host: Host, alreadyEffective = false) => {
+  const handleConnectToHost = useCallback((host: Host, alreadyEffective = false, hidden = false) => {
     if (host.ephemeral) {
       setEphemeralHosts((previous) => {
         const existingIndex = previous.findIndex((candidate) => candidate.id === host.id);
@@ -1122,11 +1123,11 @@ function App({ settings }: { settings: SettingsState }) {
       resolveEffectiveHost: effectiveHostResolver,
       resolveHostAuth,
       systemInfoRef,
-    }), host);
+    }), host, hidden);
   }, [addConnectionLog, connectToHost, resolveEffectiveHost, identities, keys]);
 
   const openHostForVaultAgent = useCallback((host: Host) => {
-    const sessionId = handleConnectToHost(host, true);
+    const sessionId = handleConnectToHost(host, true, readExternalMcpSilentSessions());
     if (!sessionId) {
       return { ok: false as const, error: `Failed to open host "${host.id}".` };
     }

--- a/App.tsx
+++ b/App.tsx
@@ -1127,8 +1127,9 @@ function App({ settings }: { settings: SettingsState }) {
   }, [addConnectionLog, connectToHost, resolveEffectiveHost, identities, keys]);
 
   const openHostForVaultAgent = useCallback((host: Host, isExternalMcpCall: boolean) => {
-    // Silent sessions only apply to actual external MCP clients (no chatSessionId).
-    // The in-app Catty AI chat's host_open always opens a visible tab, as documented.
+    // Silent sessions only apply to actual external MCP clients (chatSessionId
+    // equals the reserved external-MCP scope). The in-app Catty AI chat's
+    // host_open always opens a visible tab, as documented.
     const hidden = isExternalMcpCall && readExternalMcpSilentSessions();
     const sessionId = handleConnectToHost(host, true, hidden);
     if (!sessionId) {

--- a/App.tsx
+++ b/App.tsx
@@ -1126,8 +1126,11 @@ function App({ settings }: { settings: SettingsState }) {
     }), host, hidden);
   }, [addConnectionLog, connectToHost, resolveEffectiveHost, identities, keys]);
 
-  const openHostForVaultAgent = useCallback((host: Host) => {
-    const sessionId = handleConnectToHost(host, true, readExternalMcpSilentSessions());
+  const openHostForVaultAgent = useCallback((host: Host, isExternalMcpCall: boolean) => {
+    // Silent sessions only apply to actual external MCP clients (no chatSessionId).
+    // The in-app Catty AI chat's host_open always opens a visible tab, as documented.
+    const hidden = isExternalMcpCall && readExternalMcpSilentSessions();
+    const sessionId = handleConnectToHost(host, true, hidden);
     if (!sessionId) {
       return { ok: false as const, error: `Failed to open host "${host.id}".` };
     }

--- a/application/app/AppHandlers.ts
+++ b/application/app/AppHandlers.ts
@@ -822,7 +822,7 @@ export function handleCreateLocalTerminalImpl(
   }
 }
 
-export function handleConnectToHostImpl(getCtx: AppContextGetter, host: Host) {
+export function handleConnectToHostImpl(getCtx: AppContextGetter, host: Host, hidden = false) {
   const { addConnectionLog, connectToHost, identities, keys, resolveEffectiveHost, resolveHostAuth, systemInfoRef } = getCtx();
 {
     const { username, hostname: localHost } = systemInfoRef.current;
@@ -832,7 +832,7 @@ export function handleConnectToHostImpl(getCtx: AppContextGetter, host: Host) {
     // Handle serial hosts separately
     if (effectiveHost.protocol === 'serial') {
       const portName = host.hostname.split('/').pop() || host.hostname;
-      const sessionId = connectToHost(effectiveHost);
+      const sessionId = connectToHost(effectiveHost, { hidden });
       addConnectionLog({
         sessionId,
         hostId: host.id,
@@ -851,7 +851,7 @@ export function handleConnectToHostImpl(getCtx: AppContextGetter, host: Host) {
 
     const protocol = effectiveHost.etEnabled ? 'et' : effectiveHost.moshEnabled ? 'mosh' : (effectiveHost.protocol || 'ssh');
     const resolvedAuth = resolveHostAuth({ host: effectiveHost, keys, identities });
-    const sessionId = connectToHost(effectiveHost);
+    const sessionId = connectToHost(effectiveHost, { hidden });
     addConnectionLog({
       sessionId,
       hostId: host.id,

--- a/application/app/AppMounts.test.ts
+++ b/application/app/AppMounts.test.ts
@@ -65,3 +65,12 @@ test('active tab chrome keeps removed theme side effects unmounted', () => {
   assert.equal(activeTabChromeSource.includes(removedThemeHook), false);
   assert.equal(activeTabChromeSource.includes(removedThemeStoreSetter), false);
 });
+
+test('terminal layer force-mounts immediately when a hidden MCP session exists', () => {
+  // A silent session never becomes activeTabId, so without this it would wait
+  // for the up-to-5s idle-callback fallback before TerminalPanesHost renders
+  // TerminalPane and starts the PTY — racing an immediate terminal_execute.
+  assert.match(appMountsSource, /hasHiddenSession = props\.sessions\.some\(\(session\) => session\.hiddenFromTabs\)/);
+  assert.match(appMountsSource, /useState\(isVisible \|\| hasHiddenSession\)/);
+  assert.match(appMountsSource, /if \(isVisible \|\| hasHiddenSession\) setShouldMount\(true\)/);
+});

--- a/application/app/AppMounts.tsx
+++ b/application/app/AppMounts.tsx
@@ -172,11 +172,16 @@ export const TerminalLayerMount: React.FC<TerminalLayerProps> = (props) => {
     sessionIds,
     workspaceIds,
   }) || !!props.draggingSessionId;
-  const [shouldMount, setShouldMount] = useState(isVisible);
+  // Silent MCP sessions never become the activeTabId, so `isVisible` alone
+  // would leave this whole layer (and its PTY-starting TerminalPane) unmounted
+  // for up to 5s (the idle-callback fallback below) after host_open returns —
+  // long enough for an immediate terminal_execute to race an unstarted session.
+  const hasHiddenSession = props.sessions.some((session) => session.hiddenFromTabs);
+  const [shouldMount, setShouldMount] = useState(isVisible || hasHiddenSession);
 
   useEffect(() => {
-    if (isVisible) setShouldMount(true);
-  }, [isVisible]);
+    if (isVisible || hasHiddenSession) setShouldMount(true);
+  }, [isVisible, hasHiddenSession]);
 
   useEffect(() => {
     if (shouldMount) return;

--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -285,7 +285,7 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
             shellHistory={shellHistory}
             connectionLogs={connectionLogs}
             managedSources={managedSources}
-            sessionCount={sessions.length}
+            sessionCount={sessions.filter((s) => !s.hiddenFromTabs).length}
             hotkeyScheme={hotkeyScheme}
             keyBindings={keyBindings}
             terminalThemeId={terminalThemeId}

--- a/application/app/useAppStartupEffects.ts
+++ b/application/app/useAppStartupEffects.ts
@@ -129,6 +129,7 @@ export function useAppStartupEffects(ctx: StartupEffectsContext) {
           status: s.status,
           workspaceId: s.workspaceId,
           workspaceTitle: ws?.title,
+          aiHidden: s.hiddenFromTabs === true,
         };
       });
 

--- a/application/i18n/locales/en/ai.ts
+++ b/application/i18n/locales/en/ai.ts
@@ -236,6 +236,8 @@ export const enAiMessages: Messages = {
   'ai.externalMcp.idleTimeout.minutes': 'min',
   'ai.externalMcp.focusOnHostOpen': 'Focus window on host_open',
   'ai.externalMcp.focusOnHostOpen.description': 'When an MCP client opens a host, bring the main window to the foreground. Turn off to keep working without interruption.',
+  'ai.externalMcp.silentSessions': 'Silent MCP sessions',
+  'ai.externalMcp.silentSessions.description': 'Sessions opened by AI stay out of your tab bar and are not restored after restart. View them anytime from the tray panel.',
   'ai.externalMcp.sessionIdleTimeout': 'Opened session idle timeout',
   'ai.externalMcp.sessionIdleTimeout.description': 'Automatically close sessions opened by an AI after this many minutes without terminal or file activity.',
   'ai.externalMcp.usage.title': 'How to use',

--- a/application/i18n/locales/ru/ai.ts
+++ b/application/i18n/locales/ru/ai.ts
@@ -204,6 +204,8 @@ export const ruAiMessages: Messages = {
   'ai.externalMcp.idleTimeout.minutes': 'мин',
   'ai.externalMcp.focusOnHostOpen': 'Активировать окно при host_open',
   'ai.externalMcp.focusOnHostOpen.description': 'Когда MCP-клиент открывает хост, выводить главное окно на передний план. Отключите, чтобы работать без прерываний.',
+  'ai.externalMcp.silentSessions': 'Бесшумные сеансы MCP',
+  'ai.externalMcp.silentSessions.description': 'Сеансы, открытые ИИ, не отображаются на панели вкладок и не восстанавливаются после перезапуска. Их можно посмотреть в любой момент через панель в трее.',
   'ai.externalMcp.sessionIdleTimeout': 'Тайм-аут открытого сеанса',
   'ai.externalMcp.sessionIdleTimeout.description': 'Автоматически закрывать сеансы, открытые ИИ, после указанного числа минут без операций терминала или файлов.',
   'ai.externalMcp.usage.title': 'Как пользоваться',

--- a/application/i18n/locales/zh-CN/ai.ts
+++ b/application/i18n/locales/zh-CN/ai.ts
@@ -236,6 +236,8 @@ export const zhCNAiMessages: Messages = {
   'ai.externalMcp.idleTimeout.minutes': '分钟',
   'ai.externalMcp.focusOnHostOpen': 'host_open 时激活窗口',
   'ai.externalMcp.focusOnHostOpen.description': '当 MCP 客户端打开主机连接时，将主窗口切换到前台。关闭后可不受打扰地继续当前工作。',
+  'ai.externalMcp.silentSessions': 'AI 会话静默运行',
+  'ai.externalMcp.silentSessions.description': 'AI 打开的会话不会出现在标签栏，重启后也不会恢复。可随时在托盘面板中查看。',
   'ai.externalMcp.sessionIdleTimeout': '已打开会话空闲超时',
   'ai.externalMcp.sessionIdleTimeout.description': 'AI 打开的会话若超过该分钟数没有终端或文件操作，将自动关闭。',
   'ai.externalMcp.usage.title': '使用说明',

--- a/application/i18n/locales/zh-TW/ai.ts
+++ b/application/i18n/locales/zh-TW/ai.ts
@@ -235,6 +235,8 @@ export const zhTWAiMessages: Messages = {
   'ai.externalMcp.idleTimeout.minutes': '分鐘',
   'ai.externalMcp.focusOnHostOpen': 'host_open 時啟用視窗',
   'ai.externalMcp.focusOnHostOpen.description': '當 MCP 用戶端開啟主機連線時，將主視窗切換到前景。關閉後可不受打擾地繼續目前工作。',
+  'ai.externalMcp.silentSessions': 'AI 工作階段靜默執行',
+  'ai.externalMcp.silentSessions.description': 'AI 開啟的工作階段不會出現在分頁列，重新啟動後也不會還原。可隨時在系統匣面板中查看。',
   'ai.externalMcp.sessionIdleTimeout': '已開啟工作階段閒置逾時',
   'ai.externalMcp.sessionIdleTimeout.description': 'AI 開啟的工作階段若超過該分鐘數沒有終端或檔案操作，將自動關閉。',
   'ai.externalMcp.usage.title': '使用說明',

--- a/application/state/sessionWorkspaceDetach.test.ts
+++ b/application/state/sessionWorkspaceDetach.test.ts
@@ -179,6 +179,24 @@ test("closing the last workspace session does not invent a surviving terminal", 
   );
 });
 
+test("closing the last visible solo tab does not fall back to a hidden MCP session", () => {
+  const visibleSession: TerminalSession = { ...session("s1", undefined) };
+  const hiddenSession: TerminalSession = { ...session("s2", undefined), hiddenFromTabs: true };
+  const layoutResult = closeSessionWorkspaceLayoutState([], undefined, "s1");
+  const remainingSessions = [hiddenSession];
+
+  assert.equal(
+    resolveActiveTabAfterCloseSession({
+      currentActiveTabId: visibleSession.id,
+      closedSessionId: "s1",
+      workspaceId: undefined,
+      layoutResult,
+      remainingSessions,
+    }),
+    "vault",
+  );
+});
+
 test("closing several standalone sessions removes the whole batch", () => {
   const standaloneSession = (id: string): TerminalSession => ({
     ...session(id),

--- a/application/state/sessionWorkspaceDetach.ts
+++ b/application/state/sessionWorkspaceDetach.ts
@@ -143,7 +143,7 @@ export function resolveActiveTabAfterCloseSession({
   remainingSessions: readonly TerminalSession[];
 }): string | null {
   const fallbackWorkspace = layoutResult.workspaces[layoutResult.workspaces.length - 1];
-  const fallbackSolo = remainingSessions.filter((session) => !session.workspaceId).slice(-1)[0];
+  const fallbackSolo = remainingSessions.filter((session) => !session.workspaceId && !session.hiddenFromTabs).slice(-1)[0];
   const fallback = layoutResult.lastRemainingSessionId
     ?? fallbackWorkspace?.id
     ?? fallbackSolo?.id

--- a/application/state/useExternalMcpToggleState.test.ts
+++ b/application/state/useExternalMcpToggleState.test.ts
@@ -6,8 +6,10 @@ import {
   normalizeExternalMcpMode,
   normalizeSessionIdleTimeoutMinutes,
   readExternalMcpFocusOnHostOpen,
+  readExternalMcpSilentSessions,
   shouldStartExternalMcpOnStartup,
   writeExternalMcpFocusOnHostOpen,
+  writeExternalMcpSilentSessions,
 } from './useExternalMcpToggleState.ts';
 
 function installMemoryLocalStorage() {
@@ -92,6 +94,19 @@ describe('useExternalMcpToggleState helpers', () => {
       assert.equal(readExternalMcpFocusOnHostOpen(), false);
       writeExternalMcpFocusOnHostOpen(true);
       assert.equal(readExternalMcpFocusOnHostOpen(), true);
+    } finally {
+      restore();
+    }
+  });
+
+  it('silent-sessions defaults to false and round-trips through storage', () => {
+    const restore = installMemoryLocalStorage();
+    try {
+      assert.equal(readExternalMcpSilentSessions(), false);
+      writeExternalMcpSilentSessions(true);
+      assert.equal(readExternalMcpSilentSessions(), true);
+      writeExternalMcpSilentSessions(false);
+      assert.equal(readExternalMcpSilentSessions(), false);
     } finally {
       restore();
     }

--- a/application/state/useExternalMcpToggleState.ts
+++ b/application/state/useExternalMcpToggleState.ts
@@ -4,6 +4,7 @@ import {
   STORAGE_KEY_AI_EXTERNAL_MCP_FOCUS_ON_HOST_OPEN,
   STORAGE_KEY_AI_EXTERNAL_MCP_IDLE_TIMEOUT_MINUTES,
   STORAGE_KEY_AI_EXTERNAL_MCP_MODE,
+  STORAGE_KEY_AI_EXTERNAL_MCP_SILENT_SESSIONS,
   STORAGE_KEY_AI_SESSION_IDLE_TIMEOUT_MINUTES,
 } from '../../infrastructure/config/storageKeys';
 import { localStorageAdapter } from '../../infrastructure/persistence/localStorageAdapter';
@@ -73,6 +74,16 @@ export function readExternalMcpFocusOnHostOpen(): boolean {
 export function writeExternalMcpFocusOnHostOpen(focusOnHostOpen: boolean): void {
   localStorageAdapter.writeBoolean(STORAGE_KEY_AI_EXTERNAL_MCP_FOCUS_ON_HOST_OPEN, focusOnHostOpen);
   emitAIStateChanged(STORAGE_KEY_AI_EXTERNAL_MCP_FOCUS_ON_HOST_OPEN);
+}
+
+/** Whether host_open sessions stay hidden from the tab bar. Defaults to false (existing behavior). */
+export function readExternalMcpSilentSessions(): boolean {
+  return localStorageAdapter.readBoolean(STORAGE_KEY_AI_EXTERNAL_MCP_SILENT_SESSIONS) ?? false;
+}
+
+export function writeExternalMcpSilentSessions(silentSessions: boolean): void {
+  localStorageAdapter.writeBoolean(STORAGE_KEY_AI_EXTERNAL_MCP_SILENT_SESSIONS, silentSessions);
+  emitAIStateChanged(STORAGE_KEY_AI_EXTERNAL_MCP_SILENT_SESSIONS);
 }
 
 export function normalizeSessionIdleTimeoutMinutes(value: number | null): number {

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -350,10 +350,12 @@ export const useSessionState = ({
     return sessionId;
   }, [setActiveTabId]);
 
-  const connectToHost = useCallback((host: Host) => {
+  const connectToHost = useCallback((host: Host, options?: { hidden?: boolean }) => {
+    const hidden = options?.hidden === true;
     const newSession = createHostTerminalSession(crypto.randomUUID(), host);
-    setSessions(prev => [...prev, newSession]);
-    setActiveTabId(newSession.id);
+    const sessionToAdd = hidden ? { ...newSession, hiddenFromTabs: true } : newSession;
+    setSessions(prev => [...prev, sessionToAdd]);
+    if (!hidden) setActiveTabId(newSession.id);
     return newSession.id;
   }, [setActiveTabId]);
 
@@ -943,7 +945,7 @@ export const useSessionState = ({
 	    setActiveTabId(workspace.id);
 	  }, [setActiveTabId]);
 
-  const orphanSessions = useMemo(() => sessions.filter(s => !s.workspaceId), [sessions]);
+  const orphanSessions = useMemo(() => sessions.filter(s => !s.workspaceId && !s.hiddenFromTabs), [sessions]);
 
   const openLogView = useCallback((log: ConnectionLog) => {
     const tabId = getLogViewTabId(log);

--- a/application/state/useVaultAgentBridge.ts
+++ b/application/state/useVaultAgentBridge.ts
@@ -177,7 +177,7 @@ export function useVaultAgentBridge(input: UseVaultAgentBridgeInput): void {
         stopTunnel: current.stopTunnel,
         stopRuleTunnels: current.stopRuleTunnels,
         openHost: current.openHost
-          ? (host) => current.openHost!(host)
+          ? (host, isExternalMcpCall) => current.openHost!(host, isExternalMcpCall)
           : undefined,
         closeSession: current.closeSession
           ? (sessionId) => current.closeSession!(sessionId)

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -234,7 +234,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
 
   // Memoize orphan sessions
   const orphanSessions = useMemo(
-    () => sessions.filter((s) => !s.workspaceId),
+    () => sessions.filter((s) => !s.workspaceId && !s.hiddenFromTabs),
     [sessions]
   );
   const trimmedQuery = query.trim();

--- a/components/TrayPanel.tsx
+++ b/components/TrayPanel.tsx
@@ -52,6 +52,8 @@ type TraySession = {
   status: "connecting" | "connected" | "disconnected";
   workspaceId?: string;
   workspaceTitle?: string;
+  /** Mirrors TerminalSession.hiddenFromTabs; marks AI-opened silent sessions. */
+  aiHidden?: boolean;
 };
 
 // Collapsible workspace group component
@@ -101,6 +103,11 @@ const WorkspaceGroup: React.FC<{
                       spinning={s.status === "connecting"}
                     />
                     <span className="truncate">{s.hostLabel || s.label}</span>
+                    {s.aiHidden && (
+                      <span className="shrink-0 rounded px-1 py-0.5 text-[10px] font-medium leading-none bg-muted text-muted-foreground">
+                        AI
+                      </span>
+                    )}
                   </span>
                   <span className="ml-2 text-xs text-muted-foreground">{t(`tray.status.${s.status}`)}</span>
                 </button>
@@ -325,6 +332,11 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
                             spinning={s.status === "connecting"}
                           />
                           <span className="truncate">{s.hostLabel || s.label}</span>
+                          {s.aiHidden && (
+                            <span className="shrink-0 rounded px-1 py-0.5 text-[10px] font-medium leading-none bg-muted text-muted-foreground">
+                              AI
+                            </span>
+                          )}
                         </span>
                         <span className="ml-2 text-xs text-muted-foreground">{t(`tray.status.${s.status}`)}</span>
                       </button>

--- a/components/settings/tabs/ai/ExternalMcpCard.tsx
+++ b/components/settings/tabs/ai/ExternalMcpCard.tsx
@@ -8,8 +8,10 @@ import {
   readExternalMcpFocusOnHostOpen,
   readExternalMcpIdleTimeoutMinutes,
   readExternalMcpMode,
+  readExternalMcpSilentSessions,
   readSessionIdleTimeoutMinutes,
   writeExternalMcpFocusOnHostOpen,
+  writeExternalMcpSilentSessions,
   type ExternalMcpMode,
   useExternalMcpToggleState,
 } from "../../../../application/state/useExternalMcpToggleState";
@@ -303,6 +305,7 @@ export const ExternalMcpCard: React.FC = () => {
   const [idleTimeoutMinutes, setIdleTimeoutRaw] = useState<number>(() => readExternalMcpIdleTimeoutMinutes());
   const [focusOnHostOpen, setFocusOnHostOpenRaw] = useState<boolean>(() => readExternalMcpFocusOnHostOpen());
   const [sessionIdleTimeoutMinutes, setSessionIdleTimeoutRaw] = useState<number>(() => readSessionIdleTimeoutMinutes());
+  const [silentSessions, setSilentSessionsRaw] = useState<boolean>(() => readExternalMcpSilentSessions());
   const [status, setStatus] = useState<ExternalMcpStatus | null>(null);
   const [selectedClient, setSelectedClient] = useState<ExternalMcpClient>("codex");
   const [codexStatus, setCodexStatus] = useState<ClientSetupStatus | null>(null);
@@ -351,6 +354,11 @@ export const ExternalMcpCard: React.FC = () => {
   const setFocusOnHostOpen = useCallback((nextFocusOnHostOpen: boolean) => {
     setFocusOnHostOpenRaw(nextFocusOnHostOpen);
     writeExternalMcpFocusOnHostOpen(nextFocusOnHostOpen);
+  }, []);
+
+  const setSilentSessions = useCallback((nextSilentSessions: boolean) => {
+    setSilentSessionsRaw(nextSilentSessions);
+    writeExternalMcpSilentSessions(nextSilentSessions);
   }, []);
 
   const refreshStatus = useCallback(async (options?: { quiet?: boolean; clients?: boolean }) => {
@@ -733,6 +741,13 @@ export const ExternalMcpCard: React.FC = () => {
             <div className="text-xs text-muted-foreground">{t("ai.externalMcp.focusOnHostOpen.description")}</div>
           </div>
           <Toggle checked={focusOnHostOpen} onChange={setFocusOnHostOpen} />
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <div className="text-sm font-medium">{t("ai.externalMcp.silentSessions")}</div>
+            <div className="text-xs text-muted-foreground">{t("ai.externalMcp.silentSessions.description")}</div>
+          </div>
+          <Toggle checked={silentSessions} onChange={setSilentSessions} />
         </div>
         <div className="flex items-center justify-between gap-4">
           <div className="min-w-0">

--- a/domain/models/terminal.ts
+++ b/domain/models/terminal.ts
@@ -510,6 +510,15 @@ export interface TerminalSession {
    * the one-time credentials cannot survive a relaunch.
    */
   ephemeralHost?: boolean;
+  /**
+   * Runtime marker for sessions opened via MCP host_open while "silent
+   * sessions" is enabled. Hidden from the main window's tab bar (TopTabs,
+   * QuickSwitcher, orphan tab ordering) and excluded from session-restore
+   * persistence, but remains a fully live session reachable by terminal
+   * exec/sftp/session-close tools, and still visible in TrayPanel and the
+   * external MCP session list.
+   */
+  hiddenFromTabs?: boolean;
   /** Runtime hint to auto-open a side panel once the session connects. */
   autoOpenSidePanel?: 'sftp';
   /** Latest known working directory captured from terminal cwd tracking. */

--- a/domain/sessionRestore.test.ts
+++ b/domain/sessionRestore.test.ts
@@ -56,6 +56,23 @@ test("buildSessionRestorePayload excludes ephemeral-host sessions and their tabs
   assert.notEqual(payload.activeTabId, "s2");
 });
 
+test("buildSessionRestorePayload excludes silent MCP sessions and their tabs", () => {
+  const payload = buildSessionRestorePayload({
+    sessions: [
+      session("s1"),
+      { ...session("s2"), hiddenFromTabs: true },
+    ],
+    workspaces: [],
+    tabOrder: ["s1", "s2"],
+    activeTabId: "s2",
+    now: 123,
+  });
+
+  assert.deepEqual(payload.sessions.map((entry) => entry.id), ["s1"]);
+  assert.deepEqual(payload.tabOrder, ["s1"]);
+  assert.notEqual(payload.activeTabId, "s2");
+});
+
 test("buildSessionRestorePayload only stores allowlisted session fields", () => {
   const payload = buildSessionRestorePayload({
     sessions: [{

--- a/domain/sessionRestore.ts
+++ b/domain/sessionRestore.ts
@@ -406,7 +406,9 @@ export function buildSessionRestorePayload(input: BuildSessionRestorePayloadInpu
     // Ephemeral-host sessions (password deep links) cannot be restored: their
     // in-memory credentials do not survive a relaunch, and persisting them
     // would leak the supposedly ephemeral host metadata into restore storage.
-    sessions: input.sessions.filter((session) => !session.ephemeralHost).map(restoreSession),
+    // Silent MCP sessions are likewise excluded — they exist for the duration
+    // of an AI task, not as a user-intended workspace to bring back on launch.
+    sessions: input.sessions.filter((session) => !session.ephemeralHost && !session.hiddenFromTabs).map(restoreSession),
     workspaces: input.workspaces,
   });
 }

--- a/infrastructure/ai/vaultAgentBridgeClient.test.ts
+++ b/infrastructure/ai/vaultAgentBridgeClient.test.ts
@@ -308,7 +308,11 @@ describe('handleVaultAgentOp vault hosts', () => {
     assert.equal(receivedIsExternalMcpCall, false);
   });
 
-  it('host.open marks calls without chatSessionId as an external MCP call', async () => {
+  it('host.open marks calls under the reserved external-MCP scope as an external MCP call', async () => {
+    // The TCP bridge forces every authenticated external-MCP socket's
+    // chatSessionId to '__external_mcp__' (electron/bridges/mcpServerBridge.cjs),
+    // so that reserved value — not a missing chatSessionId — is what identifies
+    // a real external MCP client.
     const host: Host = {
       id: 'host-open-3',
       label: 'edge',
@@ -325,9 +329,31 @@ describe('handleVaultAgentOp vault hosts', () => {
       },
     });
 
-    await handleVaultAgentOp('host.open', { hostId: 'host-open-3' }, deps);
+    await handleVaultAgentOp('host.open', { hostId: 'host-open-3', chatSessionId: '__external_mcp__' }, deps);
 
     assert.equal(receivedIsExternalMcpCall, true);
+  });
+
+  it('host.open does not treat a missing chatSessionId as an external MCP call', async () => {
+    const host: Host = {
+      id: 'host-open-4',
+      label: 'edge',
+      hostname: 'edge.example.com',
+      username: 'ops',
+      port: 22,
+    };
+    let receivedIsExternalMcpCall: boolean | undefined;
+    const deps = createDeps({
+      hosts: [host],
+      openHost: (hostToOpen, isExternalMcpCall) => {
+        receivedIsExternalMcpCall = isExternalMcpCall;
+        return { ok: true, sessionId: `session-${hostToOpen.id}`, host: hostToOpen };
+      },
+    });
+
+    await handleVaultAgentOp('host.open', { hostId: 'host-open-4' }, deps);
+
+    assert.equal(receivedIsExternalMcpCall, false);
   });
 
   it('session.close closes the matching terminal session', async () => {

--- a/infrastructure/ai/vaultAgentBridgeClient.test.ts
+++ b/infrastructure/ai/vaultAgentBridgeClient.test.ts
@@ -286,6 +286,50 @@ describe('handleVaultAgentOp vault hosts', () => {
     assert.equal((result as { host?: { hostname?: string } }).host?.hostname, 'edge.example.com');
   });
 
+  it('host.open marks in-app chat opens (with chatSessionId) as not an external MCP call', async () => {
+    const host: Host = {
+      id: 'host-open-2',
+      label: 'edge',
+      hostname: 'edge.example.com',
+      username: 'ops',
+      port: 22,
+    };
+    let receivedIsExternalMcpCall: boolean | undefined;
+    const deps = createDeps({
+      hosts: [host],
+      openHost: (hostToOpen, isExternalMcpCall) => {
+        receivedIsExternalMcpCall = isExternalMcpCall;
+        return { ok: true, sessionId: `session-${hostToOpen.id}`, host: hostToOpen };
+      },
+    });
+
+    await handleVaultAgentOp('host.open', { hostId: 'host-open-2', chatSessionId: 'chat-1' }, deps);
+
+    assert.equal(receivedIsExternalMcpCall, false);
+  });
+
+  it('host.open marks calls without chatSessionId as an external MCP call', async () => {
+    const host: Host = {
+      id: 'host-open-3',
+      label: 'edge',
+      hostname: 'edge.example.com',
+      username: 'ops',
+      port: 22,
+    };
+    let receivedIsExternalMcpCall: boolean | undefined;
+    const deps = createDeps({
+      hosts: [host],
+      openHost: (hostToOpen, isExternalMcpCall) => {
+        receivedIsExternalMcpCall = isExternalMcpCall;
+        return { ok: true, sessionId: `session-${hostToOpen.id}`, host: hostToOpen };
+      },
+    });
+
+    await handleVaultAgentOp('host.open', { hostId: 'host-open-3' }, deps);
+
+    assert.equal(receivedIsExternalMcpCall, true);
+  });
+
   it('session.close closes the matching terminal session', async () => {
     const closed: string[] = [];
     const result = await handleVaultAgentOp(

--- a/infrastructure/ai/vaultAgentBridgeClient.ts
+++ b/infrastructure/ai/vaultAgentBridgeClient.ts
@@ -62,6 +62,16 @@ const SENSITIVE_HOST_KEYS = new Set([
   'passphrase',
 ]);
 
+/**
+ * Reserved chatSessionId the TCP bridge forces onto every authenticated
+ * external-MCP socket (see electron/bridges/mcpServerBridge.cjs and
+ * electron/cli/externalMcpDiscoveryPath.cjs). A missing chatSessionId is NOT
+ * a reliable "external MCP" signal — the stdio server always sends one, and
+ * the bridge overwrites it with this value for external-token sockets — so
+ * callers must compare against this exact constant instead.
+ */
+const EXTERNAL_MCP_CHAT_SESSION_ID = '__external_mcp__';
+
 const VAULT_HOST_UPDATE_FIELDS = [
   'label',
   'name',
@@ -490,7 +500,7 @@ async function registerOpenedSessionInMcpScope(
   // Always merge into the reserved external MCP scope when that surface is
   // active; External MCP agents can then terminal_execute without waiting for
   // the next React session-sync tick.
-  scopes.add('__external_mcp__');
+  scopes.add(EXTERNAL_MCP_CHAT_SESSION_ID);
 
   await Promise.all(
     [...scopes].map(async (scopeId) => {
@@ -543,8 +553,12 @@ export async function handleVaultAgentOp(
       const chatSessionId = typeof params.chatSessionId === 'string'
         ? params.chatSessionId
         : undefined;
+      // The TCP bridge forces every authenticated external-MCP socket's
+      // chatSessionId to this reserved value, so a missing chatSessionId is
+      // not a reliable signal — compare against the constant instead.
+      const isExternalMcpCall = chatSessionId === EXTERNAL_MCP_CHAT_SESSION_ID;
       const effectiveHost = deps.resolveEffectiveHost(host);
-      const opened = deps.openHost(effectiveHost, !chatSessionId);
+      const opened = deps.openHost(effectiveHost, isExternalMcpCall);
       if (!opened.ok) {
         return { ok: false, error: opened.error };
       }

--- a/infrastructure/ai/vaultAgentBridgeClient.ts
+++ b/infrastructure/ai/vaultAgentBridgeClient.ts
@@ -419,9 +419,12 @@ export interface VaultAgentApiDeps {
   stopRuleTunnels: (ruleId: string) => Promise<{ success: boolean; error?: string }>;
   /**
    * Open a vault host as a terminal tab (same path as tray / host list click).
-   * Must return the new sessionId so MCP can target terminal tools.
+   * Must return the new sessionId so MCP can target terminal tools. `isExternalMcpCall`
+   * is true only when the request has no chatSessionId — i.e. it came from an actual
+   * external MCP client rather than the in-app Catty AI chat — and gates the "silent
+   * sessions" setting so the in-app chat's host_open still opens a visible tab.
    */
-  openHost?: (host: Host) => {
+  openHost?: (host: Host, isExternalMcpCall: boolean) => {
     ok: true;
     sessionId: string;
     host: Host;
@@ -537,15 +540,15 @@ export async function handleVaultAgentOp(
         return { ok: false, error: 'Host open is not available in this window.' };
       }
 
+      const chatSessionId = typeof params.chatSessionId === 'string'
+        ? params.chatSessionId
+        : undefined;
       const effectiveHost = deps.resolveEffectiveHost(host);
-      const opened = deps.openHost(effectiveHost);
+      const opened = deps.openHost(effectiveHost, !chatSessionId);
       if (!opened.ok) {
         return { ok: false, error: opened.error };
       }
 
-      const chatSessionId = typeof params.chatSessionId === 'string'
-        ? params.chatSessionId
-        : undefined;
       await registerOpenedSessionInMcpScope(opened.sessionId, effectiveHost, chatSessionId);
 
       const protocol = effectiveHost.etEnabled

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -191,6 +191,8 @@ export const STORAGE_KEY_AI_EXTERNAL_MCP_IDLE_TIMEOUT_MINUTES = 'netcatty_ai_ext
 export const STORAGE_KEY_AI_EXTERNAL_MCP_FOCUS_ON_HOST_OPEN = 'netcatty_ai_external_mcp_focus_on_host_open_v1';
 /** Idle timeout for terminal sessions opened by an AI through host_open. */
 export const STORAGE_KEY_AI_SESSION_IDLE_TIMEOUT_MINUTES = 'netcatty_ai_session_idle_timeout_minutes_v1';
+/** External MCP: whether host_open sessions stay hidden from the tab bar (default false). */
+export const STORAGE_KEY_AI_EXTERNAL_MCP_SILENT_SESSIONS = 'netcatty_ai_external_mcp_silent_sessions_v1';
 
 // SFTP Transfer Concurrency
 export const STORAGE_KEY_SFTP_TRANSFER_CONCURRENCY = 'netcatty_sftp_transfer_concurrency_v1';


### PR DESCRIPTION
## 背景

Closes #2340

AI 通过 MCP `host_open` 打开会话时，会在主窗口标签栏新建一个标签并将其设为当前激活标签，打断用户正在查看的其他标签。此前已有的 `focusOnHostOpen` 开关只解决了"是否把主窗口提到前台"，但新标签本身仍然会出现在标签栏并抢占 `activeTabId`。

## 改动内容

在 **Settings → AI → External MCP** 中新增 **"AI 会话静默运行"** 开关（默认关闭，保持现状行为）：

- 开启后，MCP `host_open` 打开的新会话完全不出现在主窗口标签栏（TopTabs / QuickSwitcher / Ctrl+Tab 与数字键切换 / 批量关闭标签等均不受影响，只是看不到、切不到这些会话）
- 这些"隐藏会话"仍然在后台真实运行（SSH 连接保持存活），AI 可以继续用 `terminal_execute` / `sftp_*` 等工具正常操作
- 关闭方式：AI 主动调用 `session_close`，或已有的 per-session 空闲超时机制自动清理
- 应用重启后，这些隐藏会话不会被当作普通标签恢复出来
- 用户可以通过 **托盘面板（TrayPanel）** 查看这些隐藏会话在做什么（带 "AI" 徽标），点击可跳转到主窗口并临时激活该标签
- 外部 MCP 客户端（`get_environment` 查询）仍能看到这些会话，不受影响（正交概念，保持现状）

## 实现要点

- `domain/models/terminal.ts`：`TerminalSession` 新增 `hiddenFromTabs?: boolean` 运行时标记字段
- `useSessionState.ts` 的 `orphanSessions` 过滤枢纽新增该条件，级联影响标签渲染、快捷键切换等消费点
- `QuickSwitcher.tsx` / `AppView.tsx` 独立遍历 `sessions` 的消费点单独处理
- `sessionRestore.ts` 的 `buildSessionRestorePayload` 排除隐藏会话，重启不恢复
- `TrayPanel.tsx` + `useAppStartupEffects.ts` 扩展数据流和 UI，作为人工查看入口

## 测试

- `npm run lint`：0 error（4 个既有 warning，与本次改动无关）
- `npx tsc --noEmit`：无新增类型错误（既有错误均已通过 `git stash` 对比确认为改动前既存）
- 相关单元测试全部通过（`useExternalMcpToggleState.test.ts` / `sessionRestore.test.ts`，共 37 条）
- 本地 `npm run dev` 实机验证：开关开启后 `host_open` 不新建标签、不打断当前焦点；`terminal_execute` 确认隐藏会话正常存活；托盘面板可见带 AI 徽标的隐藏会话并可跳转；`session_close` 清理正常；关闭开关后行为完全恢复如初

🤖 Generated with [Claude Code](https://claude.com/claude-code)