### PR TITLE
[codex] Persist terminal highlights across scrolling

### DIFF
--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -627,6 +627,44 @@ test("persistent highlight lookup follows uniform scrollback marker shifts", () 
   }
 });
 
+test("external marker reset invalidates persistent highlight coverage", () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const {
+      term,
+      handlers,
+      getActiveDecorationCount,
+      getTranslateCount,
+      markers,
+      resetTranslateCount,
+    } = createFakeTerminal("hello DEPLOY world", { lineCount: 9 });
+    term.rows = 3;
+    const highlighter = new KeywordHighlighter(term as never);
+    const rules: KeywordHighlightRule[] = [
+      {
+        id: "deploy",
+        label: "Deploy",
+        patterns: ["DEPLOY"],
+        color: "#F87171",
+        enabled: true,
+      },
+    ];
+
+    highlighter.setRules(rules, true);
+    raf.flush();
+    for (const marker of [...markers]) marker.dispose();
+    resetTranslateCount();
+
+    handlers.scroll?.();
+
+    assert.equal(getTranslateCount(), term.rows);
+    assert.equal(getActiveDecorationCount(), term.rows);
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
 test("in-place redraw removes a persistent highlight when text stops matching", async () => {
   const raf = installAnimationFrameQueue();
   try {

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -57,12 +57,20 @@ function createFakeLine(text: string, onTranslate?: () => void) {
 }
 
 let nextFakeMarkerId = 1;
+let fakeMarkerLineReadCount = 0;
 
 function createFakeMarker(line: number) {
   const listeners = new Set<() => void>();
+  let currentLine = line;
   return {
     id: nextFakeMarkerId++,
-    line,
+    get line() {
+      fakeMarkerLineReadCount += 1;
+      return currentLine;
+    },
+    set line(value: number) {
+      currentLine = value;
+    },
     isDisposed: false,
     onDispose(listener: () => void) {
       listeners.add(listener);
@@ -621,6 +629,43 @@ test("persistent highlight lookup follows uniform scrollback marker shifts", () 
 
     assert.equal(getTranslateCount(), term.rows);
     assert.equal(getActiveDecorationCount(), 8);
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("persistent marker index synchronization stays constant-time", () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, handlers } = createFakeTerminal("hello DEPLOY world", { lineCount: 400 });
+    term.rows = 30;
+    const highlighter = new KeywordHighlighter(term as never);
+    const rules: KeywordHighlightRule[] = [
+      {
+        id: "deploy",
+        label: "Deploy",
+        patterns: ["DEPLOY"],
+        color: "#F87171",
+        enabled: true,
+      },
+    ];
+
+    highlighter.setRules(rules, true);
+    raf.flush();
+    term.buffer.active.baseY = 370;
+    for (const viewportY of [120, 180, 240, 300]) {
+      term.buffer.active.viewportY = viewportY;
+      handlers.scroll?.();
+    }
+
+    fakeMarkerLineReadCount = 0;
+    handlers.scroll?.();
+
+    assert.ok(
+      fakeMarkerLineReadCount < 10,
+      `expected constant marker reads, got ${fakeMarkerLineReadCount}`,
+    );
     highlighter.dispose();
   } finally {
     raf.restore();

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -56,6 +56,28 @@ function createFakeLine(text: string, onTranslate?: () => void) {
   };
 }
 
+let nextFakeMarkerId = 1;
+
+function createFakeMarker(line: number) {
+  const listeners = new Set<() => void>();
+  return {
+    id: nextFakeMarkerId++,
+    line,
+    isDisposed: false,
+    onDispose(listener: () => void) {
+      listeners.add(listener);
+      return { dispose: () => listeners.delete(listener) };
+    },
+    dispose() {
+      if (this.isDisposed) return;
+      this.isDisposed = true;
+      this.line = -1;
+      for (const listener of listeners) listener();
+      listeners.clear();
+    },
+  };
+}
+
 function createFakeWrappedLine(text: string, isWrapped: boolean) {
   return {
     ...createFakeLine(text),
@@ -86,13 +108,7 @@ function createFakeTerminalFromLines(lines: Array<{ text: string; isWrapped: boo
     onResize: () => noopDisposable,
     onRender: () => noopDisposable,
     registerMarker(offset: number) {
-      return {
-        line: offset,
-        isDisposed: false,
-        dispose() {
-          this.isDisposed = true;
-        },
-      };
+      return createFakeMarker(offset);
     },
     registerDecoration(options: { x: number; width: number; foregroundColor: string }) {
       decorations.push(options);
@@ -167,13 +183,7 @@ function createFakeTerminalFromLargeWrappedBlock({
       return noopDisposable;
     },
     registerMarker(offset: number) {
-      return {
-        line: offset,
-        isDisposed: false,
-        dispose() {
-          this.isDisposed = true;
-        },
-      };
+      return createFakeMarker(offset);
     },
     registerDecoration(options: { x: number; width: number; foregroundColor: string }) {
       decorations.push(options);
@@ -252,13 +262,9 @@ function createFakeTerminal(lineText: string, options: { lineCount?: number } = 
       return noopDisposable;
     },
     registerMarker(offset: number) {
-      const marker = {
-        line: term.buffer.active.baseY + term.buffer.active.cursorY + offset,
-        isDisposed: false,
-        dispose() {
-          this.isDisposed = true;
-        },
-      };
+      const marker = createFakeMarker(
+        term.buffer.active.baseY + term.buffer.active.cursorY + offset,
+      );
       markers.push(marker);
       return marker;
     },
@@ -552,9 +558,52 @@ test("persistent highlights remain until xterm disposes their markers", () => {
     handlers.scroll?.();
     assert.equal(getActiveDecorationCount(), 12);
 
-    markers[0].isDisposed = true;
+    markers[0].dispose();
     handlers.scroll?.();
     assert.equal(getActiveDecorationCount(), 11);
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("persistent highlight lookup follows uniform scrollback marker shifts", () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const {
+      term,
+      handlers,
+      getActiveDecorationCount,
+      getTranslateCount,
+      markers,
+      resetTranslateCount,
+    } = createFakeTerminal("hello DEPLOY world", { lineCount: 30 });
+    term.rows = 3;
+    const highlighter = new KeywordHighlighter(term as never);
+    const rules: KeywordHighlightRule[] = [
+      {
+        id: "deploy",
+        label: "Deploy",
+        patterns: ["DEPLOY"],
+        color: "#F87171",
+        enabled: true,
+      },
+    ];
+
+    highlighter.setRules(rules, true);
+    raf.flush();
+    markers[0].dispose();
+    for (const marker of markers) {
+      if (!marker.isDisposed) marker.line -= 1;
+    }
+    resetTranslateCount();
+
+    term.buffer.active.baseY = 27;
+    term.buffer.active.viewportY = 0;
+    handlers.scroll?.();
+
+    assert.equal(getTranslateCount(), 0);
+    assert.equal(getActiveDecorationCount(), 8);
     highlighter.dispose();
   } finally {
     raf.restore();

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -627,7 +627,7 @@ test("persistent highlight lookup follows uniform scrollback marker shifts", () 
   }
 });
 
-test("in-place redraw removes a persistent highlight when text stops matching", () => {
+test("in-place redraw removes a persistent highlight when text stops matching", async () => {
   const raf = installAnimationFrameQueue();
   try {
     const {
@@ -654,6 +654,7 @@ test("in-place redraw removes a persistent highlight when text stops matching", 
 
     setLineText(1, "hello SAFE world 1");
     handlers.writeParsed?.();
+    await new Promise((resolve) => { setTimeout(resolve, 120); });
     raf.flush();
 
     assert.equal(getActiveDecorationCount(), 8);

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -211,12 +211,26 @@ function createFakeTerminal(lineText: string, options: { lineCount?: number } = 
   const lineCount = options.lineCount ?? 1;
   let translateCount = 0;
   const translatedLineIndexes: number[] = [];
-  const lines = Array.from({ length: lineCount }, (_, index) =>
-    createFakeLine(`${lineText} ${index}`, () => {
+  const lineTexts = Array.from({ length: lineCount }, (_, index) => `${lineText} ${index}`);
+  const lines = lineTexts.map((_, index) => ({
+    isWrapped: false,
+    get length() {
+      return lineTexts[index].length;
+    },
+    translateToString() {
       translateCount += 1;
       translatedLineIndexes.push(index);
-    })
-  );
+      return lineTexts[index];
+    },
+    getCell(cellIndex: number) {
+      const text = lineTexts[index];
+      if (cellIndex < 0 || cellIndex >= text.length) return undefined;
+      return {
+        getChars: () => text[cellIndex],
+        getWidth: () => 1,
+      };
+    },
+  }));
   const decorations: Array<{ x: number; width: number; foregroundColor: string }> = [];
   const decorationStates: Array<{ isDisposed: boolean; dispose: () => void }> = [];
   const markers: Array<{ line: number; isDisposed: boolean; dispose: () => void }> = [];
@@ -290,6 +304,9 @@ function createFakeTerminal(lineText: string, options: { lineCount?: number } = 
     getTranslatedLineIndexes: () => [...translatedLineIndexes],
     getActiveDecorationCount: () => decorationStates.filter((state) => !state.isDisposed).length,
     markers,
+    setLineText: (index: number, text: string) => {
+      lineTexts[index] = text;
+    },
     resetTranslateCount: () => {
       translateCount = 0;
       translatedLineIndexes.length = 0;
@@ -603,6 +620,42 @@ test("persistent highlight lookup follows uniform scrollback marker shifts", () 
     handlers.scroll?.();
 
     assert.equal(getTranslateCount(), 0);
+    assert.equal(getActiveDecorationCount(), 8);
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("in-place redraw removes a persistent highlight when text stops matching", () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const {
+      term,
+      handlers,
+      getActiveDecorationCount,
+      setLineText,
+    } = createFakeTerminal("hello DEPLOY world", { lineCount: 9 });
+    term.rows = 3;
+    const highlighter = new KeywordHighlighter(term as never);
+    const rules: KeywordHighlightRule[] = [
+      {
+        id: "deploy",
+        label: "Deploy",
+        patterns: ["DEPLOY"],
+        color: "#F87171",
+        enabled: true,
+      },
+    ];
+
+    highlighter.setRules(rules, true);
+    raf.flush();
+    assert.equal(getActiveDecorationCount(), 9);
+
+    setLineText(1, "hello SAFE world 1");
+    handlers.writeParsed?.();
+    raf.flush();
+
     assert.equal(getActiveDecorationCount(), 8);
     highlighter.dispose();
   } finally {

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -463,6 +463,7 @@ test("user scrollback browsing stays synchronous during a write burst", () => {
     for (let index = 0; index < 6; index += 1) {
       handlers.writeParsed?.();
     }
+    resetTranslateCount();
     term.buffer.active.baseY = 190;
     term.buffer.active.viewportY = 120;
     handlers.scroll?.();

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -208,6 +208,8 @@ function createFakeTerminal(lineText: string, options: { lineCount?: number } = 
     })
   );
   const decorations: Array<{ x: number; width: number; foregroundColor: string }> = [];
+  const decorationStates: Array<{ isDisposed: boolean; dispose: () => void }> = [];
+  const markers: Array<{ line: number; isDisposed: boolean; dispose: () => void }> = [];
   const noopDisposable = { dispose() {} };
   const handlers: {
     scroll?: () => void;
@@ -229,8 +231,8 @@ function createFakeTerminal(lineText: string, options: { lineCount?: number } = 
         getLine: (lineY: number) => lines[lineY],
       },
     },
-    onScroll: (handler: () => void) => {
-      handlers.scroll = handler;
+    onScroll: (handler: (viewportY: number) => void) => {
+      handlers.scroll = () => handler(term.buffer.active.viewportY);
       return noopDisposable;
     },
     onData: (handler: (data: string) => void) => {
@@ -250,22 +252,26 @@ function createFakeTerminal(lineText: string, options: { lineCount?: number } = 
       return noopDisposable;
     },
     registerMarker(offset: number) {
-      return {
-        line: offset,
+      const marker = {
+        line: term.buffer.active.baseY + term.buffer.active.cursorY + offset,
         isDisposed: false,
         dispose() {
           this.isDisposed = true;
         },
       };
+      markers.push(marker);
+      return marker;
     },
     registerDecoration(options: { x: number; width: number; foregroundColor: string }) {
       decorations.push(options);
-      return {
+      const decoration = {
         isDisposed: false,
         dispose() {
           this.isDisposed = true;
         },
       };
+      decorationStates.push(decoration);
+      return decoration;
     },
     refresh() {},
   };
@@ -276,6 +282,8 @@ function createFakeTerminal(lineText: string, options: { lineCount?: number } = 
     handlers,
     getTranslateCount: () => translateCount,
     getTranslatedLineIndexes: () => [...translatedLineIndexes],
+    getActiveDecorationCount: () => decorationStates.filter((state) => !state.isDisposed).length,
+    markers,
     resetTranslateCount: () => {
       translateCount = 0;
       translatedLineIndexes.length = 0;
@@ -348,7 +356,7 @@ test("output-driven viewport changes defer keyword highlight scans", async () =>
   }
 });
 
-test("user scroll defers keyword highlight scans and scans only visible rows", async () => {
+test("user scroll reuses persistent prehighlighted lines without delayed scans", async () => {
   const raf = installAnimationFrameQueue();
   try {
     const { term, handlers, getTranslateCount, resetTranslateCount } = createFakeTerminal("hello DEPLOY world", {
@@ -377,14 +385,14 @@ test("user scroll defers keyword highlight scans and scans only visible rows", a
     assert.equal(getTranslateCount(), 0);
 
     await new Promise((resolve) => { setTimeout(resolve, 130); });
-    assert.equal(getTranslateCount(), term.rows);
+    assert.equal(getTranslateCount(), 0);
     highlighter.dispose();
   } finally {
     raf.restore();
   }
 });
 
-test("continuous user scroll cancels stale keyword highlight continuation work", async () => {
+test("distant user scroll synchronously highlights only the target viewport", async () => {
   const raf = installAnimationFrameQueue();
   try {
     const {
@@ -392,7 +400,7 @@ test("continuous user scroll cancels stale keyword highlight continuation work",
       handlers,
       getTranslatedLineIndexes,
       resetTranslateCount,
-    } = createFakeTerminal("hello DEPLOY world", { lineCount: 120 });
+    } = createFakeTerminal("hello DEPLOY world", { lineCount: 220 });
     term.rows = 30;
     const highlighter = new KeywordHighlighter(term as never);
     const rules: KeywordHighlightRule[] = [
@@ -409,24 +417,101 @@ test("continuous user scroll cancels stale keyword highlight continuation work",
     raf.flush();
     resetTranslateCount();
 
-    term.buffer.active.viewportY = 10;
+    term.buffer.active.baseY = 190;
+    term.buffer.active.viewportY = 120;
     handlers.scroll?.();
-    await new Promise((resolve) => { setTimeout(resolve, 60); });
-
-    term.buffer.active.viewportY = 60;
-    handlers.scroll?.();
-    await new Promise((resolve) => { setTimeout(resolve, 130); });
-    raf.flush();
 
     assert.deepEqual(
-      getTranslatedLineIndexes().filter((lineY) => lineY > 17 && lineY < 60),
-      [],
-      "stale continuation from the first scroll should not keep scanning old viewport rows",
+      getTranslatedLineIndexes(),
+      Array.from({ length: term.rows }, (_, index) => 120 + index),
+      "the destination viewport should be indexed before the scroll event returns",
     );
-    assert.ok(
-      getTranslatedLineIndexes().some((lineY) => lineY >= 60 && lineY < 90),
-      "latest viewport should be highlighted after scroll settles",
+
+    await new Promise((resolve) => { setTimeout(resolve, 130); });
+    assert.equal(getTranslatedLineIndexes().length, term.rows);
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("continuous distant scrolls do not scan skipped viewport ranges", () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const {
+      term,
+      handlers,
+      getTranslatedLineIndexes,
+      resetTranslateCount,
+    } = createFakeTerminal("hello DEPLOY world", { lineCount: 260 });
+    term.rows = 30;
+    const highlighter = new KeywordHighlighter(term as never);
+    const rules: KeywordHighlightRule[] = [
+      {
+        id: "deploy",
+        label: "Deploy",
+        patterns: ["DEPLOY"],
+        color: "#F87171",
+        enabled: true,
+      },
+    ];
+
+    highlighter.setRules(rules, true);
+    raf.flush();
+    resetTranslateCount();
+
+    term.buffer.active.baseY = 230;
+    term.buffer.active.viewportY = 120;
+    handlers.scroll?.();
+    term.buffer.active.viewportY = 180;
+    handlers.scroll?.();
+
+    assert.deepEqual(
+      getTranslatedLineIndexes(),
+      [
+        ...Array.from({ length: term.rows }, (_, index) => 120 + index),
+        ...Array.from({ length: term.rows }, (_, index) => 180 + index),
+      ],
     );
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("persistent highlights remain until xterm disposes their markers", () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const {
+      term,
+      handlers,
+      getActiveDecorationCount,
+      markers,
+    } = createFakeTerminal("hello DEPLOY world", { lineCount: 200 });
+    term.rows = 3;
+    const highlighter = new KeywordHighlighter(term as never);
+    const rules: KeywordHighlightRule[] = [
+      {
+        id: "deploy",
+        label: "Deploy",
+        patterns: ["DEPLOY"],
+        color: "#F87171",
+        enabled: true,
+      },
+    ];
+
+    highlighter.setRules(rules, true);
+    raf.flush();
+    assert.equal(getActiveDecorationCount(), 9);
+
+    term.buffer.active.baseY = 170;
+    term.buffer.active.viewportY = 120;
+    handlers.scroll?.();
+    assert.equal(getActiveDecorationCount(), 12);
+
+    markers[0].isDisposed = true;
+    handlers.scroll?.();
+    assert.equal(getActiveDecorationCount(), 11);
     highlighter.dispose();
   } finally {
     raf.restore();
@@ -611,7 +696,7 @@ test("wrapped highlight scanning stops before walking an oversized soft-wrapped 
   }
 });
 
-test("scroll refresh reuses wrapped scan misses across visible rows", async () => {
+test("scroll refresh reuses wrapped scan misses across visible rows", () => {
   const raf = installAnimationFrameQueue();
   try {
     const lineText = "a".repeat(80);
@@ -643,7 +728,6 @@ test("scroll refresh reuses wrapped scan misses across visible rows", async () =
 
     term.buffer.active.viewportY = 29_500;
     handlers.scroll?.();
-    await new Promise((resolve) => { setTimeout(resolve, 130); });
 
     assert.ok(
       getLineCount() < 1_000,

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -11,6 +11,7 @@ import {
   TERMINAL_AUX_LONG_LINE_SCAN_LIMIT_CHARS,
   TERMINAL_LONG_LINE_PRESSURE_BYTES,
 } from "./runtime/terminalFlowConstants.ts";
+import { XTERM_PERFORMANCE_CONFIG } from "../../infrastructure/config/xtermPerformance.ts";
 
 type RafCallback = (time: number) => void;
 
@@ -666,6 +667,48 @@ test("persistent marker index synchronization stays constant-time", () => {
       fakeMarkerLineReadCount < 10,
       `expected constant marker reads, got ${fakeMarkerLineReadCount}`,
     );
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("persistent highlights stay bounded for broad matching rules", () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const {
+      term,
+      handlers,
+      getActiveDecorationCount,
+    } = createFakeTerminal("hello DEPLOY world", { lineCount: 2_000 });
+    term.rows = 30;
+    const highlighter = new KeywordHighlighter(term as never);
+    const rules: KeywordHighlightRule[] = [
+      {
+        id: "deploy",
+        label: "Deploy",
+        patterns: ["DEPLOY"],
+        color: "#F87171",
+        enabled: true,
+      },
+    ];
+
+    highlighter.setRules(rules, true);
+    raf.flush();
+    term.buffer.active.baseY = 1_970;
+    for (let viewportY = 120; viewportY <= 1_800; viewportY += term.rows) {
+      term.buffer.active.viewportY = viewportY;
+      handlers.scroll?.();
+    }
+
+    const expectedLimit = Math.min(
+      XTERM_PERFORMANCE_CONFIG.highlighting.maxPersistentDecorationLines,
+      Math.max(
+        XTERM_PERFORMANCE_CONFIG.highlighting.minPersistentDecorationLines,
+        term.rows * XTERM_PERFORMANCE_CONFIG.highlighting.persistentDecorationViewports,
+      ),
+    );
+    assert.equal(getActiveDecorationCount(), expectedLimit);
     highlighter.dispose();
   } finally {
     raf.restore();

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -619,7 +619,7 @@ test("persistent highlight lookup follows uniform scrollback marker shifts", () 
     term.buffer.active.viewportY = 0;
     handlers.scroll?.();
 
-    assert.equal(getTranslateCount(), 0);
+    assert.equal(getTranslateCount(), term.rows);
     assert.equal(getActiveDecorationCount(), 8);
     highlighter.dispose();
   } finally {

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -435,6 +435,48 @@ test("distant user scroll synchronously highlights only the target viewport", as
   }
 });
 
+test("user scrollback browsing stays synchronous during a write burst", () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const {
+      term,
+      handlers,
+      getTranslatedLineIndexes,
+      resetTranslateCount,
+    } = createFakeTerminal("hello DEPLOY world", { lineCount: 220 });
+    term.rows = 30;
+    const highlighter = new KeywordHighlighter(term as never);
+    const rules: KeywordHighlightRule[] = [
+      {
+        id: "deploy",
+        label: "Deploy",
+        patterns: ["DEPLOY"],
+        color: "#F87171",
+        enabled: true,
+      },
+    ];
+
+    highlighter.setRules(rules, true);
+    raf.flush();
+    resetTranslateCount();
+
+    for (let index = 0; index < 6; index += 1) {
+      handlers.writeParsed?.();
+    }
+    term.buffer.active.baseY = 190;
+    term.buffer.active.viewportY = 120;
+    handlers.scroll?.();
+
+    assert.deepEqual(
+      getTranslatedLineIndexes(),
+      Array.from({ length: term.rows }, (_, index) => 120 + index),
+    );
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
 test("continuous distant scrolls do not scan skipped viewport ranges", () => {
   const raf = installAnimationFrameQueue();
   try {

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -31,6 +31,7 @@ interface LineDecorationState {
   marker: IMarker;
   decorations: IDecoration[];
   signature: string;
+  indexedLine: number;
 }
 
 type RefreshReason = "scroll" | "write" | "full";
@@ -76,6 +77,7 @@ export class KeywordHighlighter implements IDisposable {
   private term: XTerm;
   private compiledRules: CompiledRule[] = [];
   private lineDecorations = new Map<number, LineDecorationState>();
+  private markerLineOffset = 0;
   private debounceTimer: NodeJS.Timeout | null = null;
   /** Single quiet-window catch-up after bulk dumps (no per-write schedule). */
   private bulkPressureCatchUpTimer: NodeJS.Timeout | null = null;
@@ -165,6 +167,7 @@ export class KeywordHighlighter implements IDisposable {
       }),
       // Also refresh on resize as viewport content changes
       this.term.onResize(() => {
+        this.syncLineDecorationIndex(true);
         this.lastRenderRange = null;
         this.triggerRefresh("debounced", "full");
       }),
@@ -290,6 +293,7 @@ export class KeywordHighlighter implements IDisposable {
       this.disposeLineDecorations(lineY, state);
     }
     this.lineDecorations.clear();
+    this.markerLineOffset = 0;
     this.lastViewportRange = null;
     this.lastRenderRange = null;
     this.clearDirtySegments();
@@ -300,7 +304,7 @@ export class KeywordHighlighter implements IDisposable {
   }
 
   private disposeLineDecorations(lineY: number, state?: LineDecorationState) {
-    const target = state ?? this.lineDecorations.get(lineY);
+    const target = state ?? this.getLineDecorationState(lineY);
     if (!target) return;
     const removedLineY = this.removeLineDecorationState(target, lineY);
     const markerLineBeforeDispose = target.marker.isDisposed ? -1 : target.marker.line;
@@ -311,17 +315,26 @@ export class KeywordHighlighter implements IDisposable {
   }
 
   private removeLineDecorationState(target: LineDecorationState, lineHint?: number): number | null {
+    const indexedState = this.lineDecorations.get(target.indexedLine);
+    if (indexedState === target) {
+      this.lineDecorations.delete(target.indexedLine);
+      return target.marker.isDisposed
+        ? (lineHint ?? null)
+        : target.marker.line;
+    }
     if (lineHint != null) {
-      const hinted = this.lineDecorations.get(lineHint);
+      const hinted = this.lineDecorations.get(this.toIndexedLine(lineHint));
       if (hinted === target) {
-        this.lineDecorations.delete(lineHint);
+        this.lineDecorations.delete(hinted.indexedLine);
         return lineHint;
       }
     }
     for (const [mappedLineY, mappedState] of this.lineDecorations) {
       if (mappedState === target) {
         this.lineDecorations.delete(mappedLineY);
-        return mappedLineY;
+        return target.marker.isDisposed
+          ? (lineHint ?? null)
+          : target.marker.line;
       }
     }
     return null;
@@ -345,7 +358,7 @@ export class KeywordHighlighter implements IDisposable {
     const offset = lineY - cursorAbsoluteY;
     const marker = this.term.registerMarker(offset);
     if (!marker) {
-      this.lineDecorations.delete(lineY);
+      this.lineDecorations.delete(this.toIndexedLine(lineY));
       return;
     }
 
@@ -364,15 +377,23 @@ export class KeywordHighlighter implements IDisposable {
 
     if (decorations.length === 0) {
       marker.dispose();
-      this.lineDecorations.delete(lineY);
+      this.lineDecorations.delete(this.toIndexedLine(lineY));
       return;
     }
 
-    this.lineDecorations.set(lineY, {
+    const state: LineDecorationState = {
       marker,
       decorations,
       signature,
+      indexedLine: this.toIndexedLine(lineY),
+    };
+    marker.onDispose(() => {
+      this.removeLineDecorationState(state, lineY);
+      for (const decoration of decorations) {
+        if (!decoration.isDisposed) decoration.dispose();
+      }
     });
+    this.lineDecorations.set(state.indexedLine, state);
     this.markTerminalRefreshNeeded(lineY);
   }
 
@@ -594,7 +615,7 @@ export class KeywordHighlighter implements IDisposable {
     const previousRange = this.lastRenderRange;
     this.beginTerminalRefreshTracking(viewportStart, viewportEnd);
     try {
-      this.reindexLineDecorationsFromMarkers();
+      this.syncLineDecorationIndex();
 
       if (reason === "write") {
         this.processDirtyLinesInRange(rangeStart, rangeEnd, cursorAbsoluteY, "write");
@@ -663,8 +684,34 @@ export class KeywordHighlighter implements IDisposable {
     }
   }
 
-  private reindexLineDecorationsFromMarkers() {
-    if (this.lineDecorations.size === 0) return;
+  private toIndexedLine(lineY: number): number {
+    return lineY - this.markerLineOffset;
+  }
+
+  private getLineDecorationState(lineY: number): LineDecorationState | undefined {
+    this.syncLineDecorationIndex();
+    let state = this.lineDecorations.get(this.toIndexedLine(lineY));
+    if (state && state.marker.line !== lineY) {
+      this.syncLineDecorationIndex(true);
+      state = this.lineDecorations.get(this.toIndexedLine(lineY));
+    }
+    return state;
+  }
+
+  private syncLineDecorationIndex(force = false) {
+    if (this.lineDecorations.size === 0) {
+      this.markerLineOffset = 0;
+      return;
+    }
+
+    if (!force) {
+      const anchor = this.lineDecorations.values().next().value as LineDecorationState | undefined;
+      if (anchor && !anchor.marker.isDisposed && anchor.marker.line >= 0) {
+        this.markerLineOffset += anchor.marker.line - (anchor.indexedLine + this.markerLineOffset);
+        return;
+      }
+    }
+
     const nextLineDecorations = new Map<number, LineDecorationState>();
     const staleStates = new Set<LineDecorationState>();
 
@@ -674,11 +721,12 @@ export class KeywordHighlighter implements IDisposable {
         continue;
       }
       const markerLine = state.marker.line;
-      const existing = nextLineDecorations.get(markerLine);
+      state.indexedLine = markerLine;
+      const existing = nextLineDecorations.get(state.indexedLine);
       if (existing && existing !== state) {
         staleStates.add(existing);
       }
-      nextLineDecorations.set(markerLine, state);
+      nextLineDecorations.set(state.indexedLine, state);
     }
 
     for (const state of nextLineDecorations.values()) {
@@ -686,6 +734,10 @@ export class KeywordHighlighter implements IDisposable {
     }
 
     this.lineDecorations = nextLineDecorations;
+    this.markerLineOffset = 0;
+    if (staleStates.size > 0) {
+      this.lastRenderRange = null;
+    }
 
     for (const state of staleStates) {
       const markerLineBeforeDispose = state.marker.isDisposed ? -1 : state.marker.line;
@@ -1158,7 +1210,7 @@ export class KeywordHighlighter implements IDisposable {
       }
 
       const signature = this.buildRangesSignature(cachedRanges);
-      const existing = this.lineDecorations.get(lineY);
+      const existing = this.getLineDecorationState(lineY);
       if (
         existing &&
         !existing.marker.isDisposed &&

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -69,8 +69,8 @@ const RE_ASCII_ONLY = /^[\x00-\x7f]*$/;
 
 /**
  * Manages terminal decorations for keyword highlighting.
- * Uses xterm.js Decoration API to overlay styles without modifying the data stream.
- * This ensures zero impact on scrolling performance ("lazy" highlighting).
+ * Uses persistent xterm.js markers so indexed lines keep their decorations for
+ * their full scrollback lifetime without modifying the terminal data stream.
  */
 export class KeywordHighlighter implements IDisposable {
   private term: XTerm;
@@ -567,7 +567,7 @@ export class KeywordHighlighter implements IDisposable {
       !isBrowsingScrollback &&
       this.lastWriteAt > 0 &&
       now - this.lastWriteAt <= KeywordHighlighter.WRITE_BURST_HIGHLIGHT_PAUSE_MS;
-    if (isOutputDrivenViewportChange || this.isWriteBurstActive(now)) {
+    if (isOutputDrivenViewportChange || (!isBrowsingScrollback && this.isWriteBurstActive(now))) {
       this.markVisibleRangeDirty();
       this.triggerRefresh("debounced", "write");
       return;

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -60,15 +60,6 @@ interface WrappedBlockScanCache {
   cappedMiss: DirtyLineSegment | null;
 }
 
-interface ScrollRefreshJob {
-  generation: number;
-  start: number;
-  end: number;
-  nextLine: number;
-  cursorAbsoluteY: number;
-  wrappedBlockCache: WrappedBlockScanCache;
-}
-
 /** Shared empty array for non-matching lines to avoid per-call allocations. */
 const EMPTY_RANGES: readonly CachedDecorationRange[] = Object.freeze([]);
 
@@ -107,10 +98,7 @@ export class KeywordHighlighter implements IDisposable {
   private lastWriteAt = 0;
   private lastBurstDecayAt = 0;
   private lastUserInputAt = 0;
-  private scrollRefreshJob: ScrollRefreshJob | null = null;
-  private scrollRefreshGeneration = 0;
   private static readonly DIRTY_SCAN_PADDING = XTERM_PERFORMANCE_CONFIG.highlighting.dirtyScanPadding;
-  private static readonly SCROLL_SETTLE_DEBOUNCE_MS = XTERM_PERFORMANCE_CONFIG.highlighting.scrollSettleDebounceMs;
   private static readonly INPUT_QUIET_MS = XTERM_PERFORMANCE_CONFIG.highlighting.inputQuietMs;
   private static readonly WRITE_BURST_INTERVAL_MS = 28;
   private static readonly WRITE_BURST_DECAY_MS = 80;
@@ -128,7 +116,8 @@ export class KeywordHighlighter implements IDisposable {
     // Hook into terminal events to trigger highlighting
     this.disposables.push(
       // When user scrolls, refresh visible area
-      this.term.onScroll(() => {
+      this.term.onScroll((viewportY) => {
+        this.lastViewportY = viewportY;
         this.triggerViewportChangeRefresh();
       }),
       // User input should keep terminal echo responsive; highlight can catch up
@@ -175,7 +164,10 @@ export class KeywordHighlighter implements IDisposable {
         );
       }),
       // Also refresh on resize as viewport content changes
-      this.term.onResize(() => this.triggerRefresh("debounced", "full")),
+      this.term.onResize(() => {
+        this.lastRenderRange = null;
+        this.triggerRefresh("debounced", "full");
+      }),
       // onRender fires after each render cycle - catch scrolls that onScroll might miss
       this.term.onRender(() => {
         // Only trigger refresh if viewport position changed
@@ -225,7 +217,6 @@ export class KeywordHighlighter implements IDisposable {
   }
 
   public dispose() {
-    this.cancelScrollRefresh();
     this.clearDecorations();
     this.disposables.forEach(d => d.dispose());
     this.disposables = [];
@@ -283,7 +274,6 @@ export class KeywordHighlighter implements IDisposable {
     // Re-check state: may have changed since the refresh was scheduled
     if (!this.enabled || this.compiledRules.length === 0) return;
     if (this.term.buffer.active.type === 'alternate') {
-      this.cancelScrollRefresh();
       if (this.lineDecorations.size > 0) this.clearDecorations();
       return;
     }
@@ -295,7 +285,6 @@ export class KeywordHighlighter implements IDisposable {
   }
 
   private clearDecorations() {
-    this.cancelScrollRefresh();
     const hadDecorations = this.lineDecorations.size > 0;
     for (const [lineY, state] of this.lineDecorations) {
       this.disposeLineDecorations(lineY, state);
@@ -432,9 +421,6 @@ export class KeywordHighlighter implements IDisposable {
 
   private triggerRefresh(mode: "immediate" | "debounced" | "continuation", reason: RefreshReason = "full") {
     if (!this.enabled || this.compiledRules.length === 0) return;
-    if (reason !== "scroll") {
-      this.cancelScrollRefresh();
-    }
     this.pendingRefreshReason = this.mergeRefreshReason(this.pendingRefreshReason, reason);
 
     // Optimization: Disable highlighting in Alternate Buffer (e.g. Vim, Htop)
@@ -463,6 +449,22 @@ export class KeywordHighlighter implements IDisposable {
         this.debounceTimer = null;
         this.executeRefresh();
       }, delay);
+      return;
+    }
+
+    // xterm emits onScroll synchronously before it queues the viewport refresh.
+    // Reconcile only the newly visible lines in that event so decorations are
+    // registered before the next frame, including for distant scrollbar jumps.
+    if (mode === "immediate" && reason === "scroll") {
+      if (this.animationFrameId !== null) {
+        cancelAnimationFrame(this.animationFrameId);
+        this.animationFrameId = null;
+      }
+      if (this.debounceTimer) {
+        clearTimeout(this.debounceTimer);
+        this.debounceTimer = null;
+      }
+      this.executeRefresh();
       return;
     }
 
@@ -550,9 +552,7 @@ export class KeywordHighlighter implements IDisposable {
     const inputQuietDelay = reason === "write"
       ? this.getInputProtectionRemainingMs(performance.now())
       : 0;
-    const delay = reason === "scroll"
-      ? KeywordHighlighter.SCROLL_SETTLE_DEBOUNCE_MS
-      : Math.max(this.getAdaptiveHighlightingProfile().debounceMs, inputQuietDelay);
+    const delay = Math.max(this.getAdaptiveHighlightingProfile().debounceMs, inputQuietDelay);
     this.debounceTimer = setTimeout(() => {
       this.debounceTimer = null;
       this.executeRefresh();
@@ -560,9 +560,11 @@ export class KeywordHighlighter implements IDisposable {
   }
 
   private triggerViewportChangeRefresh() {
-    this.cancelScrollRefresh();
     const now = performance.now();
+    const buffer = this.term.buffer.active;
+    const isBrowsingScrollback = buffer.viewportY < buffer.baseY;
     const isOutputDrivenViewportChange =
+      !isBrowsingScrollback &&
       this.lastWriteAt > 0 &&
       now - this.lastWriteAt <= KeywordHighlighter.WRITE_BURST_HIGHLIGHT_PAUSE_MS;
     if (isOutputDrivenViewportChange || this.isWriteBurstActive(now)) {
@@ -571,7 +573,7 @@ export class KeywordHighlighter implements IDisposable {
       return;
     }
 
-    this.triggerRefresh("debounced", "scroll");
+    this.triggerRefresh("immediate", "scroll");
   }
 
   private refreshViewport(reason: RefreshReason) {
@@ -597,8 +599,12 @@ export class KeywordHighlighter implements IDisposable {
       if (reason === "write") {
         this.processDirtyLinesInRange(rangeStart, rangeEnd, cursorAbsoluteY, "write");
       } else if (reason === "scroll") {
-        this.startScrollRefresh(viewportStart, viewportEnd, cursorAbsoluteY);
-        return;
+        this.processScrollViewport(
+          viewportStart,
+          viewportEnd,
+          cursorAbsoluteY,
+          previousRange,
+        );
       } else if (previousRange !== null && this.lineDecorations.size > 0) {
         if (rangeStart < previousRange.start) {
           this.processLineRange(rangeStart, Math.min(rangeEnd, previousRange.start - 1), cursorAbsoluteY);
@@ -610,18 +616,14 @@ export class KeywordHighlighter implements IDisposable {
         this.processLineRange(rangeStart, rangeEnd, cursorAbsoluteY);
       }
 
-      for (const [lineY, state] of this.lineDecorations) {
-        if (lineY < rangeStart || lineY > rangeEnd || state.marker.isDisposed) {
-          this.disposeLineDecorations(lineY, state);
-        }
-      }
-
       // `write` refresh only processes dirty lines and does NOT guarantee the whole
       // viewport/render range is covered. If we still persist these ranges, later
       // scroll refreshes may take an incremental path and incorrectly skip lines.
       if (reason === "write") {
         this.lastViewportRange = null;
         this.lastRenderRange = null;
+      } else if (reason === "scroll") {
+        // processScrollViewport records the contiguous range already indexed.
       } else {
         this.lastViewportRange = { start: viewportStart, end: viewportEnd };
         this.lastRenderRange = { start: rangeStart, end: rangeEnd };
@@ -1173,67 +1175,46 @@ export class KeywordHighlighter implements IDisposable {
     }
   }
 
-  private startScrollRefresh(start: number, end: number, cursorAbsoluteY: number) {
-    this.cancelScrollRefresh();
-    const generation = this.scrollRefreshGeneration;
-    this.scrollRefreshJob = {
-      generation,
-      start,
-      end,
-      nextLine: start,
-      cursorAbsoluteY,
-      wrappedBlockCache: this.createWrappedBlockScanCache(),
-    };
-    this.runScrollRefreshChunk(generation);
-  }
+  private processScrollViewport(
+    start: number,
+    end: number,
+    cursorAbsoluteY: number,
+    previousRange: DirtyLineSegment | null,
+  ) {
+    const wrappedBlockCache = this.createWrappedBlockScanCache();
+    const overlapsPreviousRange = previousRange !== null
+      && start <= previousRange.end + 1
+      && end + 1 >= previousRange.start;
 
-  private runScrollRefreshChunk(generation: number) {
-    const job = this.scrollRefreshJob;
-    if (!job || job.generation !== generation) return;
-    if (!this.enabled || this.compiledRules.length === 0 || this.term.buffer.active.type === "alternate") {
-      this.cancelScrollRefresh();
-      return;
+    if (!overlapsPreviousRange || previousRange === null) {
+      this.processLineRange(start, end, cursorAbsoluteY, wrappedBlockCache);
+      this.lastRenderRange = { start, end };
+    } else {
+      if (start < previousRange.start) {
+        this.processLineRange(
+          start,
+          Math.min(end, previousRange.start - 1),
+          cursorAbsoluteY,
+          wrappedBlockCache,
+        );
+      }
+      if (end > previousRange.end) {
+        this.processLineRange(
+          Math.max(start, previousRange.end + 1),
+          end,
+          cursorAbsoluteY,
+          wrappedBlockCache,
+        );
+      }
+      this.lastRenderRange = {
+        start: Math.min(start, previousRange.start),
+        end: Math.max(end, previousRange.end),
+      };
     }
 
-    this.beginTerminalRefreshTracking(job.start, job.end);
-    try {
-      this.reindexLineDecorationsFromMarkers();
-      this.processLineRange(
-        job.nextLine,
-        job.end,
-        job.cursorAbsoluteY,
-        job.wrappedBlockCache,
-      );
-      this.removeDirtyRange(job.nextLine, job.end);
-      job.nextLine = job.end + 1;
-    } finally {
-      this.flushTerminalRefresh();
-    }
-
-    this.finishScrollRefresh(job);
-  }
-
-  private finishScrollRefresh(job: ScrollRefreshJob) {
-    if (this.scrollRefreshJob !== job) return;
-    this.scrollRefreshJob = null;
+    this.removeDirtyRange(start, end);
     this.dirtyAllInRenderRange = false;
-    this.clearLineDecorationsOutsideRange(job.start, job.end);
-    this.lastViewportRange = { start: job.start, end: job.end };
-    this.lastRenderRange = { start: job.start, end: job.end };
-  }
-
-  private cancelScrollRefresh() {
-    this.scrollRefreshJob = null;
-    this.scrollRefreshGeneration += 1;
-  }
-
-  private clearLineDecorationsOutsideRange(start: number, end: number) {
-    if (this.lineDecorations.size === 0) return;
-    const entries = Array.from(this.lineDecorations.entries());
-    for (const [lineY, state] of entries) {
-      if (lineY >= start && lineY <= end) continue;
-      this.disposeLineDecorations(lineY, state);
-    }
+    this.lastViewportRange = { start, end };
   }
 
   private getCachedRanges(line: IBufferLine, lineText: string): CachedDecorationRange[] {

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -397,6 +397,7 @@ export class KeywordHighlighter implements IDisposable {
       }
     });
     this.lineDecorations.set(state.indexedLine, state);
+    this.prunePersistentDecorations();
     this.markTerminalRefreshNeeded(lineY);
   }
 
@@ -752,6 +753,23 @@ export class KeywordHighlighter implements IDisposable {
       if (markerLineBeforeDispose >= 0) {
         this.markTerminalRefreshNeeded(markerLineBeforeDispose);
       }
+    }
+  }
+
+  private prunePersistentDecorations() {
+    const config = XTERM_PERFORMANCE_CONFIG.highlighting;
+    const maxPersistentLines = Math.min(
+      config.maxPersistentDecorationLines,
+      Math.max(
+        config.minPersistentDecorationLines,
+        this.term.rows * config.persistentDecorationViewports,
+      ),
+    );
+
+    while (this.lineDecorations.size > maxPersistentLines) {
+      const oldest = this.lineDecorations.values().next().value as LineDecorationState | undefined;
+      if (!oldest) break;
+      this.disposeLineDecorations(oldest.marker.line, oldest);
     }
   }
 

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -78,6 +78,7 @@ export class KeywordHighlighter implements IDisposable {
   private compiledRules: CompiledRule[] = [];
   private lineDecorations = new Map<number, LineDecorationState>();
   private markerLineOffset = 0;
+  private lineDecorationIndexNeedsRebuild = false;
   private debounceTimer: NodeJS.Timeout | null = null;
   /** Single quiet-window catch-up after bulk dumps (no per-write schedule). */
   private bulkPressureCatchUpTimer: NodeJS.Timeout | null = null;
@@ -294,6 +295,7 @@ export class KeywordHighlighter implements IDisposable {
     }
     this.lineDecorations.clear();
     this.markerLineOffset = 0;
+    this.lineDecorationIndexNeedsRebuild = false;
     this.lastViewportRange = null;
     this.lastRenderRange = null;
     this.clearDirtySegments();
@@ -389,6 +391,7 @@ export class KeywordHighlighter implements IDisposable {
     };
     marker.onDispose(() => {
       this.removeLineDecorationState(state, lineY);
+      this.lastRenderRange = null;
       for (const decoration of decorations) {
         if (!decoration.isDisposed) decoration.dispose();
       }
@@ -612,10 +615,10 @@ export class KeywordHighlighter implements IDisposable {
     const rangeStart = Math.max(0, viewportY - overscan);
     const rangeEnd = viewportEnd + overscan;
 
-    const previousRange = this.lastRenderRange;
     this.beginTerminalRefreshTracking(viewportStart, viewportEnd);
     try {
       this.syncLineDecorationIndex();
+      const previousRange = this.lastRenderRange;
 
       if (reason === "write") {
         this.processDirtyLinesInRange(rangeStart, rangeEnd, cursorAbsoluteY, "write");
@@ -699,8 +702,10 @@ export class KeywordHighlighter implements IDisposable {
   }
 
   private syncLineDecorationIndex(force = false) {
+    force = force || this.lineDecorationIndexNeedsRebuild;
     if (this.lineDecorations.size === 0) {
       this.markerLineOffset = 0;
+      this.lineDecorationIndexNeedsRebuild = false;
       return;
     }
 
@@ -735,6 +740,7 @@ export class KeywordHighlighter implements IDisposable {
 
     this.lineDecorations = nextLineDecorations;
     this.markerLineOffset = 0;
+    this.lineDecorationIndexNeedsRebuild = false;
     if (staleStates.size > 0) {
       this.lastRenderRange = null;
     }
@@ -1012,6 +1018,7 @@ export class KeywordHighlighter implements IDisposable {
     // Detect in-place ANSI redraw chunks (cursor returns near original line while
     // multiple viewport regions are actually rewritten).
     if (sameWindow && cursorSpan <= Math.max(1, padding * 2) && probeDiffCount >= 2) {
+      this.lineDecorationIndexNeedsRebuild = true;
       this.markVisibleRangeDirty();
       return;
     }

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -70,8 +70,9 @@ const RE_ASCII_ONLY = /^[\x00-\x7f]*$/;
 
 /**
  * Manages terminal decorations for keyword highlighting.
- * Uses persistent xterm.js markers so indexed lines keep their decorations for
- * their full scrollback lifetime without modifying the terminal data stream.
+ * Uses persistent xterm.js markers so nearby indexed lines keep decorations
+ * across scrollback navigation without modifying the terminal data stream.
+ * Retention is bounded to protect xterm's marker listeners for broad rules.
  */
 export class KeywordHighlighter implements IDisposable {
   private term: XTerm;

--- a/infrastructure/config/xtermPerformance.ts
+++ b/infrastructure/config/xtermPerformance.ts
@@ -124,8 +124,6 @@ export const XTERM_PERFORMANCE_CONFIG = {
     writeRefreshBudgetMs: 4,
     // Process dirty contiguous lines in chunks so budget checks can preempt.
     dirtySegmentChunkSize: 48,
-    // User-scroll catch-up should be almost invisible to the renderer.
-    scrollSettleDebounceMs: 120,
     // Keep highlighting deprioritized briefly after a large output burst.
     // Longer quiet window lets xterm paint bulk dumps (cat/yes/tail) without
     // competing decoration scans every few hundred ms.

--- a/infrastructure/config/xtermPerformance.ts
+++ b/infrastructure/config/xtermPerformance.ts
@@ -110,6 +110,11 @@ export const XTERM_PERFORMANCE_CONFIG = {
     immediateMinIntervalMs: 16,
     // Number of unique line scan results to keep cached.
     cacheEntries: 1200,
+    // Retain matched-line markers across nearby scrollback without allowing a
+    // broad rule to register unbounded xterm trim listeners.
+    persistentDecorationViewports: 20,
+    minPersistentDecorationLines: 200,
+    maxPersistentDecorationLines: 1200,
     // Keep decorations for lines just outside the viewport so small scrolls
     // don't constantly dispose/recreate them. Scales with current terminal rows.
     overscanViewportRatio: 2.0,


### PR DESCRIPTION
## Summary
- render newly exposed keyword highlights synchronously before xterm paints a user scroll, including distant scrollbar jumps
- retain nearby matched-line decorations across scrollback navigation instead of deleting them at viewport boundaries
- keep persistent marker lookup constant-time across uniform scrollback trims and rebuild only for resize or structural redraws
- bound retained markers to 20 viewports and at most 1,200 matched lines so broad rules cannot create unbounded xterm trim listeners

## Root cause
The current user-scroll path intentionally waits 120 ms, scans only the settled viewport, and then deletes decorations outside that viewport. This makes unhighlighted text visible before the delayed decoration refresh. Restoring the old full-window synchronous rebuild would bring back scroll jank because it rescanned roughly five viewports on every scroll event.

## Behavior
User scrolling now reuses the contiguous indexed range and scans only newly exposed rows. A distant jump scans one viewport synchronously in xterm's `onScroll` callback, before xterm queues its own refresh. Output-driven scrolling, large-output quiet windows, recent-input protection, long-line safeguards, and alternate-buffer behavior remain unchanged.

## Validation
- `npm run lint` (0 errors; 4 pre-existing warnings outside this change)
- `node --test --import tsx components/terminal/keywordHighlight.test.ts components/terminal/keywordHighlightRegex.test.ts components/terminal/runtime/terminalOutputPressure.test.ts` (31 passed)
- `git diff upstream/main...HEAD --check`

Regression coverage includes preindexed scrolling, distant jumps, continuous jumps, scrolling during write bursts, marker disposal and reset, uniform scrollback shifts, constant-time marker lookup, bounded broad-rule retention, ANSI in-place redraws, large output, recent input, and oversized wrapped lines.