### PR TITLE
fix(sftp): reuse authenticated SSH session for SFTP

### DIFF
--- a/application/state/sftp/useSftpConnections.test.ts
+++ b/application/state/sftp/useSftpConnections.test.ts
@@ -1,0 +1,77 @@
+// Created: 2026-07-21
+// Purpose: Verify SFTP prefers live terminal session reuse before fresh auth.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { openSftpWithSessionPreference } from "./useSftpConnections.ts";
+
+const openOptions = {
+  sessionId: "sftp-request-1",
+  hostname: "192.168.9.138",
+  username: "zhlrs",
+  port: 22,
+} as NetcattySSHOptions;
+
+test("openSftpWithSessionPreference opens session-backed SFTP before authing again", async () => {
+  const calls: string[] = [];
+  const sftpId = await openSftpWithSessionPreference({
+    bridge: {
+      openSftpForSession: async (sessionId: string) => {
+        calls.push(`openForSession:${sessionId}`);
+        return "session-backed-sftp";
+      },
+      openSftp: async () => {
+        calls.push("openSftp");
+        return "fresh-sftp";
+      },
+    },
+    sourceSessionId: "ssh-session-1",
+    openOptions,
+  });
+
+  assert.equal(sftpId, "session-backed-sftp");
+  assert.deepEqual(calls, ["openForSession:ssh-session-1"]);
+});
+
+test("openSftpWithSessionPreference falls back to normal SFTP when session reuse fails", async () => {
+  const calls: string[] = [];
+  const sftpId = await openSftpWithSessionPreference({
+    bridge: {
+      openSftpForSession: async (sessionId: string) => {
+        calls.push(`openForSession:${sessionId}`);
+        throw new Error("channel unavailable");
+      },
+      openSftp: async (options: NetcattySSHOptions) => {
+        calls.push(`openSftp:${options.sessionId}`);
+        return "fresh-sftp";
+      },
+    },
+    sourceSessionId: "ssh-session-1",
+    openOptions,
+  });
+
+  assert.equal(sftpId, "fresh-sftp");
+  assert.deepEqual(calls, ["openForSession:ssh-session-1", "openSftp:sftp-request-1"]);
+});
+
+test("openSftpWithSessionPreference opens normal SFTP without a source session", async () => {
+  const calls: string[] = [];
+  const sftpId = await openSftpWithSessionPreference({
+    bridge: {
+      openSftpForSession: async () => {
+        calls.push("openForSession");
+        return "session-backed-sftp";
+      },
+      openSftp: async (options: NetcattySSHOptions) => {
+        calls.push(`openSftp:${options.sessionId}`);
+        return "fresh-sftp";
+      },
+    },
+    sourceSessionId: undefined,
+    openOptions,
+  });
+
+  assert.equal(sftpId, "fresh-sftp");
+  assert.deepEqual(calls, ["openSftp:sftp-request-1"]);
+});

--- a/application/state/sftp/useSftpConnections.ts
+++ b/application/state/sftp/useSftpConnections.ts
@@ -45,6 +45,33 @@ export interface SftpConnectOptions {
   sourceSessionId?: string;
 }
 
+type SftpOpenBridge = Pick<NetcattyBridge, "openSftp"> &
+  Partial<Pick<NetcattyBridge, "openSftpForSession">>;
+
+interface OpenSftpWithSessionPreferenceParams {
+  bridge: SftpOpenBridge | null | undefined;
+  sourceSessionId?: string;
+  openOptions: NetcattySSHOptions;
+}
+
+/** Open SFTP through an already-authenticated terminal session before retrying normal auth. */
+export async function openSftpWithSessionPreference({
+  bridge,
+  sourceSessionId,
+  openOptions,
+}: OpenSftpWithSessionPreferenceParams): Promise<string> {
+  if (!bridge?.openSftp) throw new Error("SFTP bridge unavailable");
+  if (sourceSessionId && bridge.openSftpForSession) {
+    try {
+      return await bridge.openSftpForSession(sourceSessionId);
+    } catch {
+      // Fall through to the existing SFTP open path so users still get a usable
+      // file browser when the live SSH transport cannot provide an SFTP channel.
+    }
+  }
+  return bridge.openSftp(openOptions);
+}
+
 interface UseSftpConnectionsResult {
   connect: (side: "left" | "right", host: Host | "local", options?: SftpConnectOptions) => Promise<void>;
   disconnect: (side: "left" | "right") => Promise<void>;
@@ -481,9 +508,13 @@ export const useSftpConnections = ({
           if (options?.sourceSessionId && !host.sftpSudo) {
             const reuseCredentials = buildSftpReuseCredentials(host, options.sourceSessionId);
             try {
-              sftpId = await openSftp({
-                sessionId: sftpSessionId,
-                ...reuseCredentials,
+              sftpId = await openSftpWithSessionPreference({
+                bridge,
+                sourceSessionId: options.sourceSessionId,
+                openOptions: {
+                  sessionId: sftpSessionId,
+                  ...reuseCredentials,
+                },
               });
               credentials = reuseCredentials;
             } catch {

--- a/components/KeyboardInteractiveModal.test.ts
+++ b/components/KeyboardInteractiveModal.test.ts
@@ -3,8 +3,11 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import { formatKeyboardInteractiveServerPrompt } from "./KeyboardInteractiveModal.tsx";
+
+const modalSource = readFileSync(new URL("./KeyboardInteractiveModal.tsx", import.meta.url), "utf8");
 
 test("formatKeyboardInteractiveServerPrompt preserves server instructions and prompt labels", () => {
   const text = formatKeyboardInteractiveServerPrompt({
@@ -43,4 +46,10 @@ test("formatKeyboardInteractiveServerPrompt omits hostname-only fallback prompts
   });
 
   assert.equal(text, "");
+});
+
+test("keyboard-interactive modal cannot be dismissed by outside click or Escape", () => {
+  assert.match(modalSource, /onOpenChange=\{\(\) => \{\/\* intentionally non-dismissable \*\/\}\}/);
+  assert.match(modalSource, /onInteractOutside=\{\(e\) => e\.preventDefault\(\)\}/);
+  assert.match(modalSource, /onEscapeKeyDown=\{\(e\) => e\.preventDefault\(\)\}/);
 });

--- a/components/KeyboardInteractiveModal.tsx
+++ b/components/KeyboardInteractiveModal.tsx
@@ -194,8 +194,13 @@ export const KeyboardInteractiveModal: React.FC<KeyboardInteractiveModalProps> =
       : t("keyboard.interactive.desc");
 
   return (
-    <Dialog open={!!request} onOpenChange={(open) => !open && handleCancel()}>
-      <DialogContent className="sm:max-w-[425px]" hideCloseButton>
+    <Dialog open={!!request} onOpenChange={() => {/* intentionally non-dismissable */}}>
+      <DialogContent
+        className="sm:max-w-[425px]"
+        hideCloseButton
+        onInteractOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <div className="flex items-center gap-3 mb-2">
             <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center">


### PR DESCRIPTION
## 背景

前序 PR #2289 已合并，但合并时没有包含后续真实环境测试发现的两个问题：

- SSH 已完成 EDR 二次认证后，自动打开 SFTP 仍可能再次要求二次密码。
- 二次认证弹窗不是严格模态，点击旁边或按 Escape 会关闭，容易误取消认证流程。

本 PR 是 #2289 的后续修正，继续关联 #2150。

## 修改

- 自动打开 SFTP 时优先复用当前已认证的 SSH session 打开 SFTP channel，避免重复 MFA。
- 如果复用当前 SSH session 失败，则静默回退到原有新建 SFTP 连接流程，保证功能仍可用。
- 将 keyboard-interactive 二次认证弹窗改为不可通过外部点击或 Escape 关闭，只能显式取消或提交。
- 补充 SFTP session 复用与弹窗不可误关闭的回归测试。

## 验证

- `node --test --import tsx application/state/sftp/useSftpConnections.test.ts application/state/sftp/useSftpHostCredentials.test.ts components/KeyboardInteractiveModal.test.ts components/sftp/sftpSidePanelAutoConnect.test.ts`
- `node --test electron/bridges/sftpBridge.cleanup.test.cjs electron/bridges/sftpBridge.reuseOnly.test.cjs electron/bridges/sftpBridge.authRetry.test.cjs`
- `npx eslint application/state/sftp/useSftpConnections.ts application/state/sftp/useSftpConnections.test.ts components/KeyboardInteractiveModal.tsx components/KeyboardInteractiveModal.test.ts --quiet`
- `git diff --check origin/main..HEAD`
- 真实环境测试：用户确认 SSH 自动打开 SFTP 不再重复弹二次认证，弹窗行为正常。