### PR TITLE
fix(sftp): restore high-latency download throughput

### DIFF
--- a/electron/bridges/registerBridgesTransferLimits.test.cjs
+++ b/electron/bridges/registerBridgesTransferLimits.test.cjs
@@ -8,8 +8,8 @@ const EventEmitter = require("node:events");
 const { createBridgeRegistrar } = require("../main/registerBridges.cjs");
 const sftpBridge = require("./sftpBridge.cjs");
 const {
+  DOWNLOAD_TRANSFER_CONCURRENCY,
   TRANSFER_CHUNK_SIZE,
-  TRANSFER_CONCURRENCY,
 } = require("./transferLimits.cjs");
 
 function createNoopBridge() {
@@ -156,7 +156,7 @@ test("downloadToTemp applies shared SFTP transfer limits to direct fastGet downl
   assert.equal(localPath, path.join(tempDir, "report.bin"));
   assert.deepEqual(observed.options, {
     chunkSize: TRANSFER_CHUNK_SIZE,
-    concurrency: TRANSFER_CONCURRENCY,
+    concurrency: DOWNLOAD_TRANSFER_CONCURRENCY,
   });
 });
 

--- a/electron/bridges/registerBridgesTransferLimits.test.cjs
+++ b/electron/bridges/registerBridgesTransferLimits.test.cjs
@@ -7,10 +7,6 @@ const EventEmitter = require("node:events");
 
 const { createBridgeRegistrar } = require("../main/registerBridges.cjs");
 const sftpBridge = require("./sftpBridge.cjs");
-const {
-  DOWNLOAD_TRANSFER_CONCURRENCY,
-  TRANSFER_CHUNK_SIZE,
-} = require("./transferLimits.cjs");
 
 function createNoopBridge() {
   return {
@@ -113,7 +109,7 @@ function createBridgeRegistrarForTest({
   });
 }
 
-test("downloadToTemp applies shared SFTP transfer limits to direct fastGet downloads", async (t) => {
+test("downloadToTemp routes direct downloads through the shared transfer bridge", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-download-temp-test-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
@@ -121,21 +117,19 @@ test("downloadToTemp applies shared SFTP transfer limits to direct fastGet downl
 
   const ipcMain = createIpcMainStub();
   const observed = {};
-  const sftpClients = new Map([
-    [
-      "sftp-1",
-      {
-        fastGet(_remotePath, localPath, options) {
-          observed.options = options;
-          return fs.promises.writeFile(localPath, "downloaded");
-        },
-      },
-    ],
-  ]);
+  const transferBridge = {
+    ...createNoopBridge(),
+    async startTransfer(event, payload) {
+      observed.event = event;
+      observed.payload = payload;
+      await fs.promises.writeFile(payload.targetPath, "downloaded");
+      return {};
+    },
+  };
   const registerBridges = createBridgeRegistrarForTest({
     ipcMain,
     tempDir,
-    sftpClients,
+    transferBridge,
   });
 
   registerBridges({});
@@ -154,13 +148,21 @@ test("downloadToTemp applies shared SFTP transfer limits to direct fastGet downl
   );
 
   assert.equal(localPath, path.join(tempDir, "report.bin"));
-  assert.deepEqual(observed.options, {
-    chunkSize: TRANSFER_CHUNK_SIZE,
-    concurrency: DOWNLOAD_TRANSFER_CONCURRENCY,
+  assert.equal(observed.event.sender.id, 1);
+  assert.equal(typeof observed.payload.transferId, "string");
+  const { transferId: _transferId, ...payload } = observed.payload;
+  assert.deepEqual(payload, {
+    sourcePath: "/remote/report.bin",
+    targetPath: path.join(tempDir, "report.bin"),
+    sourceType: "sftp",
+    targetType: "local",
+    sourceSftpId: "sftp-1",
+    sourceEncoding: "utf-8",
+    totalBytes: 0,
   });
 });
 
-test("downloadToTemp proxies to the terminal worker in worker mode", async (t) => {
+test("downloadToTemp proxies shared transfer work to the terminal worker", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-download-worker-test-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
@@ -194,13 +196,18 @@ test("downloadToTemp proxies to the terminal worker in worker mode", async (t) =
   );
   await new Promise((resolve) => setImmediate(resolve));
 
-  assert.equal(child.messages[0].channel, "netcatty:sftp:downloadToLocal");
+  assert.equal(child.messages[0].channel, "netcatty:transfer:start");
   assert.equal(child.messages[0].webContentsId, 12);
-  assert.deepEqual(child.messages[0].payload, {
-    sftpId: "worker-sftp-1",
-    remotePath: "/remote/report.bin",
-    localPath: path.join(tempDir, "report.bin"),
-    encoding: "utf-8",
+  assert.equal(typeof child.messages[0].payload.transferId, "string");
+  const { transferId: _transferId, ...workerPayload } = child.messages[0].payload;
+  assert.deepEqual(workerPayload, {
+    sourcePath: "/remote/report.bin",
+    targetPath: path.join(tempDir, "report.bin"),
+    sourceType: "sftp",
+    targetType: "local",
+    sourceSftpId: "worker-sftp-1",
+    sourceEncoding: "utf-8",
+    totalBytes: 0,
   });
   child.emit("message", {
     kind: "response",

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -8,7 +8,11 @@ const path = require("node:path");
 const os = require("node:os");
 const { encodePathForSession, ensureRemoteDirForSession, requireSftpChannel, resolveEncodingForRequest } = require("./sftpBridge.cjs");
 const { isScpModeClient, getScpBackendForClient } = require("./sftpBridge/scpBackend.cjs");
-const { TRANSFER_CHUNK_SIZE, TRANSFER_CONCURRENCY } = require("./transferLimits.cjs");
+const {
+  DOWNLOAD_TRANSFER_CONCURRENCY,
+  TRANSFER_CHUNK_SIZE,
+  UPLOAD_TRANSFER_CONCURRENCY,
+} = require("./transferLimits.cjs");
 
 /**
  * Verify a completed remote upload matches the expected byte count.
@@ -389,7 +393,7 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
 
         fastSftp.fastPut(localPath, remotePath, {
           chunkSize: TRANSFER_CHUNK_SIZE,
-          concurrency: TRANSFER_CONCURRENCY,
+          concurrency: UPLOAD_TRANSFER_CONCURRENCY,
           step: (transferred, _chunk, total) => {
             if (transfer.cancelled) return;
             sendProgress(transferred, total || fileSize);
@@ -517,7 +521,7 @@ async function downloadFile(remotePath, localPath, client, fileSize, transfer, s
 
         fastSftp.fastGet(remotePath, localPath, {
           chunkSize: TRANSFER_CHUNK_SIZE,
-          concurrency: TRANSFER_CONCURRENCY,
+          concurrency: DOWNLOAD_TRANSFER_CONCURRENCY,
           step: (transferred, _chunk, total) => {
             if (transfer.cancelled) return;
             sendProgress(transferred, total || fileSize);

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -10,6 +10,7 @@ const { encodePathForSession, ensureRemoteDirForSession, requireSftpChannel, res
 const { isScpModeClient, getScpBackendForClient } = require("./sftpBridge/scpBackend.cjs");
 const {
   DOWNLOAD_TRANSFER_CONCURRENCY,
+  FAST_DOWNLOAD_CHANNELS_PER_SESSION,
   TRANSFER_CHUNK_SIZE,
   UPLOAD_TRANSFER_CONCURRENCY,
 } = require("./transferLimits.cjs");
@@ -157,7 +158,7 @@ function getIsolatedDownloadChannelPool(client) {
       busy: new Set(),
       waiters: [],
       opening: 0,
-      maxChannels: null,
+      maxChannels: FAST_DOWNLOAD_CHANNELS_PER_SESSION,
       warnedCapacity: false,
     };
     isolatedDownloadChannelPools.set(client, pool);
@@ -481,53 +482,63 @@ async function downloadFile(remotePath, localPath, client, fileSize, transfer, s
 
   // Prefer fastGet on an isolated SFTP channel so cancellation can abort just this transfer.
   if (!client.__netcattySudoMode) {
-      const fastSftp = await acquireIsolatedDownloadChannel(client, transfer);
+    const fastSftp = await acquireIsolatedDownloadChannel(client, transfer);
+    if (transfer.cancelled) throw new Error("Transfer cancelled");
 
     if (fastSftp && typeof fastSftp.fastGet === "function") {
-      return new Promise((resolve, reject) => {
-        let settled = false;
-        let onFastSftpError = null;
-        const finish = (err) => {
-          if (settled) return;
-          settled = true;
-          if (transfer.abort === abortFastTransfer) {
-            transfer.abort = null;
+      try {
+        await new Promise((resolve, reject) => {
+          let settled = false;
+          let onFastSftpError = null;
+          const finish = (err) => {
+            if (settled) return;
+            settled = true;
+            if (transfer.abort === abortFastTransfer) {
+              transfer.abort = null;
+            }
+            if (onFastSftpError) {
+              try { fastSftp.removeListener("error", onFastSftpError); } catch { }
+              onFastSftpError = null;
+            }
+            releaseIsolatedDownloadChannel(client, fastSftp, {
+              dispose: !!err || transfer.cancelled,
+            });
+
+            if (transfer.cancelled) reject(new Error("Transfer cancelled"));
+            else if (err) reject(err);
+            else resolve();
+          };
+          const abortFastTransfer = () => {
+            if (settled) return;
+            transfer.cancelled = true;
+            finish(new Error("Transfer cancelled"));
+          };
+          transfer.abort = abortFastTransfer;
+          onFastSftpError = (err) => finish(err);
+          fastSftp.once("error", onFastSftpError);
+
+          if (transfer.cancelled) {
+            finish(new Error("Transfer cancelled"));
+            return;
           }
-          if (onFastSftpError) {
-            try { fastSftp.removeListener("error", onFastSftpError); } catch { }
-            onFastSftpError = null;
-          }
-          releaseIsolatedDownloadChannel(client, fastSftp, {
-            dispose: !!err || transfer.cancelled,
-          });
 
-          if (transfer.cancelled) reject(new Error("Transfer cancelled"));
-          else if (err) reject(err);
-          else resolve();
-        };
-        const abortFastTransfer = () => {
-          if (settled) return;
-          transfer.cancelled = true;
-          finish(new Error("Transfer cancelled"));
-        };
-        transfer.abort = abortFastTransfer;
-        onFastSftpError = (err) => finish(err);
-        fastSftp.once("error", onFastSftpError);
-
-        if (transfer.cancelled) {
-          finish(new Error("Transfer cancelled"));
-          return;
-        }
-
-        fastSftp.fastGet(remotePath, localPath, {
-          chunkSize: TRANSFER_CHUNK_SIZE,
-          concurrency: DOWNLOAD_TRANSFER_CONCURRENCY,
-          step: (transferred, _chunk, total) => {
-            if (transfer.cancelled) return;
-            sendProgress(transferred, total || fileSize);
-          },
-        }, finish);
-      });
+          fastSftp.fastGet(remotePath, localPath, {
+            chunkSize: TRANSFER_CHUNK_SIZE,
+            concurrency: DOWNLOAD_TRANSFER_CONCURRENCY,
+            step: (transferred, _chunk, total) => {
+              if (transfer.cancelled) return;
+              sendProgress(transferred, total || fileSize);
+            },
+          }, finish);
+        });
+        return;
+      } catch (err) {
+        if (transfer.cancelled) throw err;
+        console.warn(
+          "[transferBridge] fastGet failed, falling back to a compatible stream:",
+          err?.message || String(err),
+        );
+      }
     }
   }
 

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -156,49 +156,12 @@ function getIsolatedDownloadChannelPool(client) {
       idle: [],
       idleTimers: new Map(),
       busy: new Set(),
-      waiters: [],
       opening: 0,
       maxChannels: FAST_DOWNLOAD_CHANNELS_PER_SESSION,
-      warnedCapacity: false,
     };
     isolatedDownloadChannelPools.set(client, pool);
   }
   return pool;
-}
-
-function isIsolatedChannelOpenFailure(err) {
-  const message = err?.message || String(err || "");
-  return (
-    message.includes("Channel open failure") ||
-    message.includes("open failed")
-  );
-}
-
-function waitForIsolatedDownloadChannel(pool, transfer) {
-  return new Promise((resolve) => {
-    let settled = false;
-    const waiter = () => {
-      if (settled) return;
-      settled = true;
-      const index = pool.waiters.indexOf(waiter);
-      if (index !== -1) {
-        pool.waiters.splice(index, 1);
-      }
-      if (transfer?.wakeWaiter === waiter) {
-        transfer.wakeWaiter = null;
-      }
-      resolve();
-    };
-    if (transfer) {
-      transfer.wakeWaiter = waiter;
-    }
-    pool.waiters.push(waiter);
-  });
-}
-
-function notifyIsolatedDownloadWaiter(pool) {
-  const waiter = pool.waiters.shift();
-  if (waiter) waiter();
 }
 
 function removeIdleIsolatedDownloadChannel(pool, sftp) {
@@ -244,87 +207,47 @@ function releaseIsolatedDownloadChannel(client, sftp, options = {}) {
 
   if (dispose) {
     try { sftp?.end?.(); } catch { }
-    notifyIsolatedDownloadWaiter(pool);
     return;
   }
 
   pool.idle.push(sftp);
   scheduleIdleIsolatedDownloadChannel(client, sftp);
-  notifyIsolatedDownloadWaiter(pool);
 }
 
 async function acquireIsolatedDownloadChannel(client, transfer) {
   const pool = getIsolatedDownloadChannelPool(client);
+  if (transfer?.cancelled) return null;
 
-  while (true) {
-    if (transfer?.cancelled) return null;
+  const cached = pool.idle.pop();
+  if (cached) {
+    clearIdleIsolatedDownloadTimer(pool, cached);
+    pool.busy.add(cached);
+    return cached;
+  }
 
-    const cached = pool.idle.pop();
-    if (cached) {
-      clearIdleIsolatedDownloadTimer(pool, cached);
-      pool.busy.add(cached);
-      return cached;
-    }
+  const currentChannelCount = pool.idle.length + pool.busy.size + pool.opening;
+  if (currentChannelCount >= pool.maxChannels) {
+    return null;
+  }
 
-    const knownCapacity = pool.maxChannels;
-    const currentChannelCount = pool.idle.length + pool.busy.size + pool.opening;
-    if (knownCapacity !== null && currentChannelCount >= knownCapacity) {
-      if (pool.opening > 0) {
-        await waitForIsolatedDownloadChannel(pool, transfer);
-        if (transfer?.cancelled) return null;
-        continue;
-      }
-      if (pool.busy.size === 0) {
-        return null;
-      }
-      await waitForIsolatedDownloadChannel(pool, transfer);
-      if (transfer?.cancelled) return null;
-      continue;
-    }
-
-    pool.opening += 1;
-    try {
-      const opened = await openIsolatedSftpChannel(client);
-      pool.opening -= 1;
-      notifyIsolatedDownloadWaiter(pool);
-      if (!opened) return null;
-      pool.busy.add(opened);
-      const knownCapacity = pool.idle.length + pool.busy.size;
-      if (pool.maxChannels !== null) {
-        pool.maxChannels = Math.max(pool.maxChannels, knownCapacity);
-      }
-      return opened;
-    } catch (err) {
-      pool.opening -= 1;
-      notifyIsolatedDownloadWaiter(pool);
-      if (isIsolatedChannelOpenFailure(err)) {
-        if (pool.opening > 0) {
-          await waitForIsolatedDownloadChannel(pool, transfer);
-          if (transfer?.cancelled) return null;
-          continue;
-        }
-        const detectedCapacity = pool.idle.length + pool.busy.size;
-        pool.maxChannels = detectedCapacity;
-        if (!pool.warnedCapacity) {
-          pool.warnedCapacity = true;
-          console.warn(
-            `[transferBridge] Isolated fastGet channel capacity reached; reusing up to ${detectedCapacity} extra channel(s) for this SFTP session.`,
-          );
-        }
-        if (detectedCapacity > 0) {
-          await waitForIsolatedDownloadChannel(pool, transfer);
-          if (transfer?.cancelled) return null;
-          continue;
-        }
-        return null;
-      }
-
-      console.warn(
-        "[transferBridge] Failed to open isolated SFTP channel for fastGet, falling back to streams:",
-        err.message || String(err),
-      );
+  pool.opening += 1;
+  try {
+    const opened = await openIsolatedSftpChannel(client);
+    pool.opening -= 1;
+    if (!opened) return null;
+    if (transfer?.cancelled) {
+      try { opened.end?.(); } catch { }
       return null;
     }
+    pool.busy.add(opened);
+    return opened;
+  } catch (err) {
+    pool.opening -= 1;
+    console.warn(
+      "[transferBridge] Failed to open isolated SFTP channel for fastGet, falling back to streams:",
+      err.message || String(err),
+    );
+    return null;
   }
 }
 
@@ -603,7 +526,7 @@ async function startTransfer(event, payload, onProgress) {
   } = payload;
   const sender = event.sender;
 
-  const transfer = { cancelled: false, readStream: null, writeStream: null, abort: null, wakeWaiter: null };
+  const transfer = { cancelled: false, readStream: null, writeStream: null, abort: null };
   activeTransfers.set(transferId, transfer);
   const transferCreatedAt = Date.now();
 
@@ -941,10 +864,6 @@ async function cancelTransfer(event, payload) {
   const transfer = activeTransfers.get(transferId);
   if (transfer) {
     transfer.cancelled = true;
-    if (typeof transfer.wakeWaiter === "function") {
-      try { transfer.wakeWaiter(); } catch { }
-    }
-
     if (typeof transfer.abort === "function") {
       try { transfer.abort(); } catch { }
     }

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -388,3 +388,196 @@ test("SFTP downloads preserve a 2MB request window on high-latency paths", async
   assert.equal(observedChunkSize, 32 * 1024);
   assert.equal(observedConcurrency * observedChunkSize, 2 * 1024 * 1024);
 });
+
+test("SFTP downloads fall back to a compatible stream after fastGet fails", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-fallback-test-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const expected = Buffer.from("complete fallback download");
+  let fastGetAttempts = 0;
+  const fastSftp = createFastSftp({
+    fastGet(_remotePath, localPath, _options, done) {
+      fastGetAttempts += 1;
+      fs.promises.writeFile(localPath, "partial").then(
+        () => done(new Error("server rejected concurrent reads")),
+        done,
+      );
+    },
+  });
+  const client = {
+    sftp: createFastSftp({
+      createReadStream() {
+        const { Readable } = require("node:stream");
+        return Readable.from(expected);
+      },
+    }),
+    stat() {
+      return Promise.resolve({ size: expected.length });
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["source", client]]) });
+
+  const targetPath = path.join(tempDir, "fallback.bin");
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "download-fallback",
+      sourcePath: "/tmp/fallback.bin",
+      targetPath,
+      sourceType: "sftp",
+      targetType: "local",
+      sourceSftpId: "source",
+      totalBytes: expected.length,
+    },
+  );
+
+  assert.equal(result.error, undefined);
+  assert.equal(fastGetAttempts, 1);
+  assert.deepEqual(await fs.promises.readFile(targetPath), expected);
+});
+
+test("SFTP downloads cap fastGet to one channel per session", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-budget-test-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const completions = [];
+  let activeFastGets = 0;
+  let maxActiveFastGets = 0;
+  let openedChannels = 0;
+  const fastSftp = createFastSftp({
+    fastGet(_remotePath, localPath, _options, done) {
+      activeFastGets += 1;
+      maxActiveFastGets = Math.max(maxActiveFastGets, activeFastGets);
+      completions.push(async () => {
+        await fs.promises.writeFile(localPath, "downloaded");
+        activeFastGets -= 1;
+        done();
+      });
+    },
+  });
+  const client = {
+    sftp: createFastSftp({}),
+    stat() {
+      return Promise.resolve({ size: 10 });
+    },
+    client: {
+      sftp(callback) {
+        openedChannels += 1;
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["source", client]]) });
+
+  const start = (id) => transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: id,
+      sourcePath: `/tmp/${id}.bin`,
+      targetPath: path.join(tempDir, `${id}.bin`),
+      sourceType: "sftp",
+      targetType: "local",
+      sourceSftpId: "source",
+      totalBytes: 10,
+    },
+  );
+
+  const first = start("download-one");
+  const second = start("download-two");
+  const firstDeadline = Date.now() + 1000;
+  while (completions.length < 1 && Date.now() < firstDeadline) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(completions.length, 1);
+  assert.equal(openedChannels, 1);
+
+  await completions[0]();
+  const secondDeadline = Date.now() + 1000;
+  while (completions.length < 2 && Date.now() < secondDeadline) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(completions.length, 2);
+  await completions[1]();
+
+  const results = await Promise.all([first, second]);
+  assert.equal(results.some((result) => result.error), false);
+  assert.equal(maxActiveFastGets, 1);
+  assert.equal(openedChannels, 1);
+});
+
+test("SFTP downloads cancelled while waiting do not start a fallback transfer", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-wait-cancel-test-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  let finishFirst;
+  let fastGetCalls = 0;
+  let fallbackReads = 0;
+  const fastSftp = createFastSftp({
+    fastGet(_remotePath, localPath, _options, done) {
+      fastGetCalls += 1;
+      finishFirst = async () => {
+        await fs.promises.writeFile(localPath, "downloaded");
+        done();
+      };
+    },
+  });
+  const client = {
+    sftp: createFastSftp({
+      createReadStream() {
+        fallbackReads += 1;
+        const { Readable } = require("node:stream");
+        return Readable.from("fallback");
+      },
+    }),
+    stat() {
+      return Promise.resolve({ size: 10 });
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["source", client]]) });
+
+  const start = (id) => transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: id,
+      sourcePath: `/tmp/${id}.bin`,
+      targetPath: path.join(tempDir, `${id}.bin`),
+      sourceType: "sftp",
+      targetType: "local",
+      sourceSftpId: "source",
+      totalBytes: 10,
+    },
+  );
+
+  const first = start("download-blocker");
+  const second = start("download-waiting");
+  const deadline = Date.now() + 1000;
+  while (!finishFirst && Date.now() < deadline) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(typeof finishFirst, "function");
+
+  await transferBridge.cancelTransfer(null, { transferId: "download-waiting" });
+  const cancelled = await second;
+  assert.equal(cancelled.error, "Transfer cancelled");
+  assert.equal(fastGetCalls, 1);
+  assert.equal(fallbackReads, 0);
+
+  await finishFirst();
+  assert.equal((await first).error, undefined);
+});

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -339,16 +339,18 @@ test("SFTP stream-fallback uploads fail on premature close", async (t) => {
   assert.ok(sender.sent.some((entry) => entry.channel === "netcatty:transfer:error"));
 });
 
-test("SFTP downloads use conservative per-file request concurrency", async (t) => {
+test("SFTP downloads preserve a 2MB request window on high-latency paths", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-test-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   });
 
   let observedConcurrency = 0;
+  let observedChunkSize = 0;
   const fastSftp = createFastSftp({
     fastGet(_remotePath, localPath, options, done) {
       observedConcurrency = options.concurrency;
+      observedChunkSize = options.chunkSize;
       options.step?.(1024 * 1024, 1024 * 1024, 1024 * 1024);
       fs.promises.writeFile(localPath, Buffer.alloc(1024 * 1024)).then(
         () => done(),
@@ -383,5 +385,6 @@ test("SFTP downloads use conservative per-file request concurrency", async (t) =
   );
 
   assert.equal(result.error, undefined);
-  assert.equal(observedConcurrency, 4);
+  assert.equal(observedChunkSize, 32 * 1024);
+  assert.equal(observedConcurrency * observedChunkSize, 2 * 1024 * 1024);
 });

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -443,7 +443,7 @@ test("SFTP downloads fall back to a compatible stream after fastGet fails", asyn
   assert.deepEqual(await fs.promises.readFile(targetPath), expected);
 });
 
-test("SFTP downloads cap fastGet to one channel per session", async (t) => {
+test("SFTP downloads keep concurrent files moving within the fast-channel budget", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-budget-test-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
@@ -453,6 +453,7 @@ test("SFTP downloads cap fastGet to one channel per session", async (t) => {
   let activeFastGets = 0;
   let maxActiveFastGets = 0;
   let openedChannels = 0;
+  let fallbackReads = 0;
   const fastSftp = createFastSftp({
     fastGet(_remotePath, localPath, _options, done) {
       activeFastGets += 1;
@@ -465,7 +466,13 @@ test("SFTP downloads cap fastGet to one channel per session", async (t) => {
     },
   });
   const client = {
-    sftp: createFastSftp({}),
+    sftp: createFastSftp({
+      createReadStream() {
+        fallbackReads += 1;
+        const { Readable } = require("node:stream");
+        return Readable.from("downloaded");
+      },
+    }),
     stat() {
       return Promise.resolve({ size: 10 });
     },
@@ -492,60 +499,58 @@ test("SFTP downloads cap fastGet to one channel per session", async (t) => {
   );
 
   const first = start("download-one");
-  const second = start("download-two");
   const firstDeadline = Date.now() + 1000;
   while (completions.length < 1 && Date.now() < firstDeadline) {
     await new Promise((resolve) => setImmediate(resolve));
   }
   assert.equal(completions.length, 1);
   assert.equal(openedChannels, 1);
+  const second = start("download-two");
+  const secondResult = await second;
+  assert.equal(secondResult.error, undefined);
+  assert.equal(fallbackReads, 1);
 
   await completions[0]();
-  const secondDeadline = Date.now() + 1000;
-  while (completions.length < 2 && Date.now() < secondDeadline) {
-    await new Promise((resolve) => setImmediate(resolve));
-  }
-  assert.equal(completions.length, 2);
-  await completions[1]();
-
-  const results = await Promise.all([first, second]);
-  assert.equal(results.some((result) => result.error), false);
+  assert.equal((await first).error, undefined);
   assert.equal(maxActiveFastGets, 1);
   assert.equal(openedChannels, 1);
 });
 
-test("SFTP downloads cancelled while waiting do not start a fallback transfer", async (t) => {
-  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-wait-cancel-test-"));
+test("SFTP downloads cancelled while opening do not block the session", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-open-cancel-test-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   });
 
-  let finishFirst;
-  let fastGetCalls = 0;
-  let fallbackReads = 0;
-  const fastSftp = createFastSftp({
+  let delayedOpen = null;
+  let abandonedChannelClosed = false;
+  let openCalls = 0;
+  const abandonedSftp = createFastSftp({
+    end() {
+      abandonedChannelClosed = true;
+    },
+  });
+  const workingSftp = createFastSftp({
     fastGet(_remotePath, localPath, _options, done) {
-      fastGetCalls += 1;
-      finishFirst = async () => {
-        await fs.promises.writeFile(localPath, "downloaded");
-        done();
-      };
+      fs.promises.writeFile(localPath, "downloaded").then(
+        () => done(),
+        done,
+      );
     },
   });
   const client = {
-    sftp: createFastSftp({
-      createReadStream() {
-        fallbackReads += 1;
-        const { Readable } = require("node:stream");
-        return Readable.from("fallback");
-      },
-    }),
+    sftp: createFastSftp({}),
     stat() {
       return Promise.resolve({ size: 10 });
     },
     client: {
       sftp(callback) {
-        callback(null, fastSftp);
+        openCalls += 1;
+        if (openCalls === 1) {
+          delayedOpen = callback;
+        } else {
+          callback(null, workingSftp);
+        }
       },
     },
   };
@@ -564,20 +569,23 @@ test("SFTP downloads cancelled while waiting do not start a fallback transfer", 
     },
   );
 
-  const first = start("download-blocker");
-  const second = start("download-waiting");
+  const cancelledPromise = start("download-opening");
   const deadline = Date.now() + 1000;
-  while (!finishFirst && Date.now() < deadline) {
+  while (!delayedOpen && Date.now() < deadline) {
     await new Promise((resolve) => setImmediate(resolve));
   }
-  assert.equal(typeof finishFirst, "function");
+  assert.equal(typeof delayedOpen, "function");
+  await transferBridge.cancelTransfer(null, { transferId: "download-opening" });
+  delayedOpen(null, abandonedSftp);
 
-  await transferBridge.cancelTransfer(null, { transferId: "download-waiting" });
-  const cancelled = await second;
+  const cancelled = await cancelledPromise;
   assert.equal(cancelled.error, "Transfer cancelled");
-  assert.equal(fastGetCalls, 1);
-  assert.equal(fallbackReads, 0);
+  assert.equal(abandonedChannelClosed, true);
 
-  await finishFirst();
-  assert.equal((await first).error, undefined);
+  const next = await Promise.race([
+    start("download-after-cancel"),
+    new Promise((_, reject) => setTimeout(() => reject(new Error("next download remained blocked")), 1000)),
+  ]);
+  assert.equal(next.error, undefined);
+  assert.equal(openCalls, 2);
 });

--- a/electron/bridges/transferLimits.cjs
+++ b/electron/bridges/transferLimits.cjs
@@ -12,9 +12,11 @@ const UPLOAD_TRANSFER_CONCURRENCY = 4;
 // ssh2's fastGet default and, with the safe 32KB request size, restores the 2MB
 // in-flight window Netcatty used before the shared chunk-size fix in #2030.
 const DOWNLOAD_TRANSFER_CONCURRENCY = 64;
+const FAST_DOWNLOAD_CHANNELS_PER_SESSION = 1;
 
 module.exports = {
   DOWNLOAD_TRANSFER_CONCURRENCY,
+  FAST_DOWNLOAD_CHANNELS_PER_SESSION,
   TRANSFER_CHUNK_SIZE,
   UPLOAD_TRANSFER_CONCURRENCY,
 };

--- a/electron/bridges/transferLimits.cjs
+++ b/electron/bridges/transferLimits.cjs
@@ -1,16 +1,20 @@
 "use strict";
 
-// ssh2's fastPut/fastGet send multiple SFTP read/write requests in parallel.
-// Keep defaults conservative so one file transfer does not monopolize a shared
-// SSH/SFTP path used by interactive terminals.
-//
-// chunkSize must stay at ssh2's default (32KB). Larger values (e.g. 512KB) can
-// exceed what some SFTP servers accept and silently produce truncated/corrupt
-// remote files — see GitHub #2022 and ssh2-sftp-client's fastPut warnings.
+// Keep ssh2's default 32KB request size. Some SFTP servers mishandle larger
+// requests and can silently produce truncated/corrupt files (GitHub #2022).
 const TRANSFER_CHUNK_SIZE = 32 * 1024;
-const TRANSFER_CONCURRENCY = 4;
+
+// Upload fanout stays conservative so transfers do not monopolize the shared
+// SSH/network path used by interactive terminals (GitHub #1507).
+const UPLOAD_TRANSFER_CONCURRENCY = 4;
+
+// Downloads need a larger request window on high-latency proxy paths. 64 is
+// ssh2's fastGet default and, with the safe 32KB request size, restores the 2MB
+// in-flight window Netcatty used before the shared chunk-size fix in #2030.
+const DOWNLOAD_TRANSFER_CONCURRENCY = 64;
 
 module.exports = {
+  DOWNLOAD_TRANSFER_CONCURRENCY,
   TRANSFER_CHUNK_SIZE,
-  TRANSFER_CONCURRENCY,
+  UPLOAD_TRANSFER_CONCURRENCY,
 };

--- a/electron/bridges/transferLimits.cjs
+++ b/electron/bridges/transferLimits.cjs
@@ -12,6 +12,9 @@ const UPLOAD_TRANSFER_CONCURRENCY = 4;
 // ssh2's fastGet default and, with the safe 32KB request size, restores the 2MB
 // in-flight window Netcatty used before the shared chunk-size fix in #2030.
 const DOWNLOAD_TRANSFER_CONCURRENCY = 64;
+// Only one file per SFTP session gets the 64-request fast path. Concurrent
+// files keep moving through the compatible stream path instead of multiplying
+// fastGet pressure or overriding the user's file-transfer concurrency.
 const FAST_DOWNLOAD_CHANNELS_PER_SESSION = 1;
 
 module.exports = {

--- a/electron/bridges/transferLimits.test.cjs
+++ b/electron/bridges/transferLimits.test.cjs
@@ -2,13 +2,19 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
-  TRANSFER_CONCURRENCY,
+  DOWNLOAD_TRANSFER_CONCURRENCY,
+  UPLOAD_TRANSFER_CONCURRENCY,
   TRANSFER_CHUNK_SIZE,
 } = require("./transferLimits.cjs");
 
-test("SFTP transfer limits keep default per-file request fanout conservative", () => {
-  assert.equal(TRANSFER_CONCURRENCY, 4);
+test("SFTP transfer limits preserve upload safety and the pre-regression download window", () => {
+  assert.equal(UPLOAD_TRANSFER_CONCURRENCY, 4);
+  assert.equal(DOWNLOAD_TRANSFER_CONCURRENCY, 64);
   // Keep ssh2's default chunk size — larger packets can corrupt uploads on
   // servers that do not honour non-default WRITE sizes (#2022).
   assert.equal(TRANSFER_CHUNK_SIZE, 32 * 1024);
+  // #2030 reduced the shared chunk size from 512KB to 32KB. Downloads need
+  // enough parallel reads to preserve the 2MB in-flight window that existed
+  // after #1533, otherwise high-latency proxy paths collapse to KB/s speeds.
+  assert.equal(DOWNLOAD_TRANSFER_CONCURRENCY * TRANSFER_CHUNK_SIZE, 2 * 1024 * 1024);
 });

--- a/electron/bridges/transferLimits.test.cjs
+++ b/electron/bridges/transferLimits.test.cjs
@@ -2,6 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
+  FAST_DOWNLOAD_CHANNELS_PER_SESSION,
   DOWNLOAD_TRANSFER_CONCURRENCY,
   UPLOAD_TRANSFER_CONCURRENCY,
   TRANSFER_CHUNK_SIZE,
@@ -10,6 +11,7 @@ const {
 test("SFTP transfer limits preserve upload safety and the pre-regression download window", () => {
   assert.equal(UPLOAD_TRANSFER_CONCURRENCY, 4);
   assert.equal(DOWNLOAD_TRANSFER_CONCURRENCY, 64);
+  assert.equal(FAST_DOWNLOAD_CHANNELS_PER_SESSION, 1);
   // Keep ssh2's default chunk size — larger packets can corrupt uploads on
   // servers that do not honour non-default WRITE sizes (#2022).
   assert.equal(TRANSFER_CHUNK_SIZE, 32 * 1024);

--- a/electron/main/registerBridges.cjs
+++ b/electron/main/registerBridges.cjs
@@ -3,7 +3,10 @@
 let bridgesRegistered = false;
 let cloudSyncSessionPassword = null;
 const { readClipboardFiles, readClipboardImage } = require("../bridges/clipboardFiles.cjs");
-const { TRANSFER_CHUNK_SIZE, TRANSFER_CONCURRENCY } = require("../bridges/transferLimits.cjs");
+const {
+  DOWNLOAD_TRANSFER_CONCURRENCY,
+  TRANSFER_CHUNK_SIZE,
+} = require("../bridges/transferLimits.cjs");
 
 const excludedFigSpecPrefixes = ["aws", "gcloud", "az"];
 
@@ -1003,7 +1006,7 @@ function createBridgeRegistrar(context) {
         : remotePath;
       await sftpClient.fastGet(encodedPath, localPath, {
         chunkSize: TRANSFER_CHUNK_SIZE,
-        concurrency: TRANSFER_CONCURRENCY,
+        concurrency: DOWNLOAD_TRANSFER_CONCURRENCY,
       });
       console.log(`[Main]   File downloaded successfully`);
       return localPath;

--- a/electron/main/registerBridges.cjs
+++ b/electron/main/registerBridges.cjs
@@ -2,11 +2,8 @@
 
 let bridgesRegistered = false;
 let cloudSyncSessionPassword = null;
+const { randomUUID } = require("node:crypto");
 const { readClipboardFiles, readClipboardImage } = require("../bridges/clipboardFiles.cjs");
-const {
-  DOWNLOAD_TRANSFER_CONCURRENCY,
-  TRANSFER_CHUNK_SIZE,
-} = require("../bridges/transferLimits.cjs");
 
 const excludedFigSpecPrefixes = ["aws", "gcloud", "az"];
 
@@ -955,61 +952,35 @@ function createBridgeRegistrar(context) {
       console.log(`[Main]   Remote path: ${remotePath}`);
       console.log(`[Main]   File name: ${fileName}`);
       
-      const client = require("../bridges/sftpBridge.cjs");
       // Use tempDirBridge for dedicated Netcatty temp directory
       const localPath = await getTempDirBridge().getTempFilePath(fileName);
       
       console.log(`[Main]   Local temp path: ${localPath}`);
 
-      if (terminalWorkerManager) {
-        try {
-          const result = await terminalWorkerManager.request("netcatty:sftp:downloadToLocal", {
-            sftpId,
-            remotePath,
-            localPath,
-            encoding,
-          }, {
-            webContentsId: event?.sender?.id,
-          });
-          if (result?.error) throw new Error(result.error);
-          console.log(`[Main]   File downloaded successfully via terminal worker`);
-          return localPath;
-        } catch (err) {
-          try { await fs.promises.rm(localPath, { force: true }); } catch { /* ignore */ }
-          throw err;
-        }
-      }
-      
-      // Get the sftp client and download file
-      const sftpClients = client.getSftpClients ? client.getSftpClients() : null;
-      if (!sftpClients) {
-        console.log(`[Main]   Using fallback readSftp method`);
-        // Fallback: use readSftp and write to temp file
-        const content = await client.readSftp(null, { sftpId, path: remotePath, encoding });
-        if (typeof content === "string") {
-          await fs.promises.writeFile(localPath, content, "utf-8");
-        } else {
-          await fs.promises.writeFile(localPath, content);
-        }
-        console.log(`[Main]   File downloaded successfully (fallback)`);
+      const payload = {
+        transferId: `download-temp-${randomUUID()}`,
+        sourcePath: remotePath,
+        targetPath: localPath,
+        sourceType: "sftp",
+        targetType: "local",
+        sourceSftpId: sftpId,
+        sourceEncoding: encoding,
+        totalBytes: 0,
+      };
+
+      try {
+        const result = terminalWorkerManager
+          ? await terminalWorkerManager.request("netcatty:transfer:start", payload, {
+              webContentsId: event?.sender?.id,
+            })
+          : await transferBridge.startTransfer(event, payload);
+        if (result?.error) throw new Error(result.error);
+        console.log(`[Main]   File downloaded successfully`);
         return localPath;
+      } catch (err) {
+        try { await fs.promises.rm(localPath, { force: true }); } catch { /* ignore */ }
+        throw err;
       }
-      
-      const sftpClient = sftpClients.get(sftpId);
-      if (!sftpClient) {
-        console.error(`[Main]   SFTP session not found: ${sftpId}`);
-        throw new Error("SFTP session not found");
-      }
-      
-      const encodedPath = client.encodePathForSession
-        ? client.encodePathForSession(sftpId, remotePath, encoding)
-        : remotePath;
-      await sftpClient.fastGet(encodedPath, localPath, {
-        chunkSize: TRANSFER_CHUNK_SIZE,
-        concurrency: DOWNLOAD_TRANSFER_CONCURRENCY,
-      });
-      console.log(`[Main]   File downloaded successfully`);
-      return localPath;
     });
   
     // Download SFTP file to temp with progress reporting via transfer events.


### PR DESCRIPTION
## Summary

- Restore the 2 MB in-flight read window for SFTP downloads on high-latency proxy paths.
- Keep uploads at the existing conservative concurrency and 32 KB request size.
- Route side-panel, editor, and temporary downloads through the same transfer path.
- Limit each SFTP session to one high-pressure fast download while concurrent files keep moving through the compatible path.

Fixes #2349.

## Root cause

#2030 correctly reduced the shared SFTP request size from 512 KB to 32 KB to prevent corrupt uploads on servers that mishandle oversized writes. Because upload and download shared the same concurrency, that change also reduced the download read window from 2 MB to 128 KB. On a distant server reached through a proxy, the much smaller window makes throughput proportional to round-trip latency and can reduce downloads to KB/s.

This keeps the safe 32 KB request size and restores the previous 2 MB download window using ssh2's default 64 parallel reads. Uploads remain at 4 parallel writes, preserving the responsiveness mitigation from #1507 and the corruption fix from #2022. Only one file per SFTP session uses the high-pressure fast path; concurrent files continue through the compatible stream path, so folder downloads preserve the configured file concurrency without multiplying fast-path request pressure. Servers that reject the fast path automatically retry with the compatible stream path.

Directory listing still uses the configured proxy; its latency is a single request/response and is separate from the download throughput regression shown in the issue screenshots.

## Validation

- `node --test electron/bridges/transferLimits.test.cjs electron/bridges/transferBridge.test.cjs electron/bridges/registerBridgesTransferLimits.test.cjs` (13 tests)
- `node --test electron/bridges/transfer*.test.cjs electron/bridges/registerBridgesTransferLimits.test.cjs`
- `npm run lint` (0 errors; 4 pre-existing warnings in unrelated files)
- `npm run build`
- `git diff --check`
