### PR TITLE
fix(port-forward): restore OTP authentication

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -245,6 +245,8 @@ function App({ settings }: { settings: SettingsState }) {
     updateGroupConfigs,
   } = useVaultState();
 
+  const hostsRef = useRef(hosts);
+  hostsRef.current = hosts;
   const keysRef = useRef(keys);
   keysRef.current = keys;
   const knownHostsRef = useRef(knownHosts);
@@ -689,10 +691,10 @@ function App({ settings }: { settings: SettingsState }) {
   }, [isVaultInitialized, pendingTrayPanelConnectHostIds]);
 
   // Handle keyboard-interactive submit
-  const handleKeyboardInteractiveSubmit = useCallback((requestId: string, responses: string[], savePassword?: string) => { return handleKeyboardInteractiveSubmitImpl(() => ({ hosts, keyboardInteractiveQueue, netcattyBridge, requestId, responses, savePassword, sessions, setKeyboardInteractiveQueue, updateHosts }), requestId, responses, savePassword); }, [keyboardInteractiveQueue, sessions, hosts, updateHosts]);
+  const handleKeyboardInteractiveSubmit = useCallback((requestId: string, responses: string[], savePassword?: string) => { return handleKeyboardInteractiveSubmitImpl(() => ({ hosts, hostsRef, keyboardInteractiveQueue, netcattyBridge, requestId, responses, savePassword, sessions, setKeyboardInteractiveQueue, t, toast, updateHosts }), requestId, responses, savePassword); }, [keyboardInteractiveQueue, sessions, hosts, t, updateHosts]);
 
   // Handle keyboard-interactive cancel
-  const handleKeyboardInteractiveCancel = useCallback((requestId: string) => { return handleKeyboardInteractiveCancelImpl(() => ({ netcattyBridge, requestId, setKeyboardInteractiveQueue }), requestId); }, []);
+  const handleKeyboardInteractiveCancel = useCallback((requestId: string) => { return handleKeyboardInteractiveCancelImpl(() => ({ netcattyBridge, requestId, setKeyboardInteractiveQueue, t, toast }), requestId); }, [t]);
 
   // Passphrase request event listener for encrypted SSH keys
   useEffect(() => {
@@ -1037,9 +1039,6 @@ function App({ settings }: { settings: SettingsState }) {
   }, [updateKnownHosts]);
 
   // System info for connection logs
-  const hostsRef = useRef(hosts);
-  hostsRef.current = hosts;
-
   const systemInfoRef = useRef<{ username: string; hostname: string }>({
     username: 'user',
     hostname: 'localhost',

--- a/application/AppHandlers.connect.test.ts
+++ b/application/AppHandlers.connect.test.ts
@@ -136,7 +136,7 @@ test('queued tray panel connects flush in order', () => {
   assert.deepEqual(pendingHostIds, []);
 });
 
-test('keyboard-interactive submit can save login password for the session host', () => {
+test('keyboard-interactive submit can save login password for the session host', async () => {
   let hosts: Host[] = [{
     ...baseHost,
     password: 'old-password',
@@ -151,7 +151,7 @@ test('keyboard-interactive submit can save login password for the session host',
   const bridgeResponses: unknown[] = [];
   const hostUpdates: Host[][] = [];
 
-  handleKeyboardInteractiveSubmitImpl(
+  await handleKeyboardInteractiveSubmitImpl(
     () => ({
       hosts,
       keyboardInteractiveQueue: queue,
@@ -159,6 +159,7 @@ test('keyboard-interactive submit can save login password for the session host',
         get: () => ({
           respondKeyboardInteractive: (...args: unknown[]) => {
             bridgeResponses.push(args);
+            return { success: true };
           },
         }),
       },
@@ -170,6 +171,8 @@ test('keyboard-interactive submit can save login password for the session host',
       setKeyboardInteractiveQueue: (updater: (items: typeof queue) => typeof queue) => {
         queue = updater(queue);
       },
+      t: (key: string) => key,
+      toast: { error: () => {} },
       updateHosts: (nextHosts: Host[]) => {
         hostUpdates.push(nextHosts);
         hosts = nextHosts;
@@ -190,7 +193,7 @@ test('keyboard-interactive submit can save login password for the session host',
   assert.equal(bridgeResponses.length, 1);
 });
 
-test('keyboard-interactive submit does not save secondary password when allowSavePassword is false', () => {
+test('keyboard-interactive submit does not save secondary password when allowSavePassword is false', async () => {
   let hosts: Host[] = [{
     ...baseHost,
     password: 'login-password',
@@ -205,19 +208,21 @@ test('keyboard-interactive submit does not save secondary password when allowSav
   }];
   let hostUpdates = 0;
 
-  handleKeyboardInteractiveSubmitImpl(
+  await handleKeyboardInteractiveSubmitImpl(
     () => ({
       hosts,
       keyboardInteractiveQueue: queue,
       netcattyBridge: {
         get: () => ({
-          respondKeyboardInteractive: () => {},
+          respondKeyboardInteractive: () => ({ success: true }),
         }),
       },
       sessions: [],
       setKeyboardInteractiveQueue: (updater: (items: typeof queue) => typeof queue) => {
         queue = updater(queue);
       },
+      t: (key: string) => key,
+      toast: { error: () => {} },
       updateHosts: (nextHosts: Host[]) => {
         hostUpdates += 1;
         hosts = nextHosts;
@@ -233,7 +238,7 @@ test('keyboard-interactive submit does not save secondary password when allowSav
   assert.deepEqual(queue, []);
 });
 
-test('keyboard-interactive submit uses explicit hostId when saving password', () => {
+test('keyboard-interactive submit uses explicit hostId when saving password', async () => {
   const jumpHost: Host = {
     ...baseHost,
     id: 'jump-1',
@@ -254,13 +259,13 @@ test('keyboard-interactive submit uses explicit hostId when saving password', ()
     allowSavePassword: true,
   }];
 
-  handleKeyboardInteractiveSubmitImpl(
+  await handleKeyboardInteractiveSubmitImpl(
     () => ({
       hosts,
       keyboardInteractiveQueue: queue,
       netcattyBridge: {
         get: () => ({
-          respondKeyboardInteractive: () => {},
+          respondKeyboardInteractive: () => ({ success: true }),
         }),
       },
       sessions: [{
@@ -271,6 +276,8 @@ test('keyboard-interactive submit uses explicit hostId when saving password', ()
       setKeyboardInteractiveQueue: (updater: (items: typeof queue) => typeof queue) => {
         queue = updater(queue);
       },
+      t: (key: string) => key,
+      toast: { error: () => {} },
       updateHosts: (nextHosts: Host[]) => {
         hosts = nextHosts;
       },
@@ -282,4 +289,112 @@ test('keyboard-interactive submit uses explicit hostId when saving password', ()
 
   assert.equal(hosts.find((host) => host.id === baseHost.id)?.password, 'target-password');
   assert.equal(hosts.find((host) => host.id === jumpHost.id)?.password, 'new-jump-password');
+});
+
+test('keyboard-interactive submit preserves host changes made while delivery is pending', async () => {
+  let hosts: Host[] = [{
+    ...baseHost,
+    label: 'Original label',
+    password: 'old-password',
+  }];
+  const hostsRef = { current: hosts };
+  let queue = [{
+    requestId: 'ki-delayed',
+    sessionId: 'session-delayed',
+    hostname: baseHost.hostname,
+    allowSavePassword: true,
+  }];
+  let resolveDelivery: (result: { success: boolean }) => void = () => {};
+  const delivery = new Promise<{ success: boolean }>((resolve) => {
+    resolveDelivery = resolve;
+  });
+
+  const submitPromise = handleKeyboardInteractiveSubmitImpl(
+    () => ({
+      hosts,
+      hostsRef,
+      keyboardInteractiveQueue: queue,
+      netcattyBridge: {
+        get: () => ({ respondKeyboardInteractive: () => delivery }),
+      },
+      sessions: [{
+        id: 'session-delayed',
+        hostId: baseHost.id,
+        hostname: baseHost.hostname,
+      }],
+      setKeyboardInteractiveQueue: (updater: (items: typeof queue) => typeof queue) => {
+        queue = updater(queue);
+      },
+      t: (key: string) => key,
+      toast: { error: () => {} },
+      updateHosts: (nextHosts: Host[]) => {
+        hosts = nextHosts;
+        hostsRef.current = nextHosts;
+      },
+    }),
+    'ki-delayed',
+    ['new-password'],
+    'new-password',
+  );
+
+  hosts = [{ ...hosts[0], label: 'Synced label', tags: ['synced'] }];
+  hostsRef.current = hosts;
+  resolveDelivery({ success: true });
+  await submitPromise;
+
+  assert.deepEqual(hosts[0], {
+    ...baseHost,
+    label: 'Synced label',
+    tags: ['synced'],
+    password: 'new-password',
+    savePassword: true,
+  });
+  assert.deepEqual(queue, []);
+});
+
+test('keyboard-interactive submit keeps the prompt and password unchanged when delivery fails', async () => {
+  let hosts: Host[] = [{
+    ...baseHost,
+    password: 'old-password',
+  }];
+  let queue = [{
+    requestId: 'ki-failed',
+    sessionId: 'session-1',
+    hostname: baseHost.hostname,
+    allowSavePassword: true,
+  }];
+  const errors: string[] = [];
+
+  const submitted = await handleKeyboardInteractiveSubmitImpl(
+    () => ({
+      hosts,
+      keyboardInteractiveQueue: queue,
+      netcattyBridge: {
+        get: () => ({
+          respondKeyboardInteractive: () => ({ success: false, error: 'Request not found' }),
+        }),
+      },
+      sessions: [{
+        id: 'session-1',
+        hostId: baseHost.id,
+        hostname: baseHost.hostname,
+      }],
+      setKeyboardInteractiveQueue: (updater: (items: typeof queue) => typeof queue) => {
+        queue = updater(queue);
+      },
+      t: (key: string) => key,
+      toast: { error: (message: string) => errors.push(message) },
+      updateHosts: (nextHosts: Host[]) => {
+        hosts = nextHosts;
+      },
+    }),
+    'ki-failed',
+    ['new-password'],
+    'new-password',
+  );
+
+  assert.equal(submitted, false);
+  assert.deepEqual(queue.map((request) => request.requestId), ['ki-failed']);
+  assert.equal(hosts[0].password, 'old-password');
+  assert.deepEqual(errors, ['Request not found']);
 });

--- a/application/app/AppHandlers.ts
+++ b/application/app/AppHandlers.ts
@@ -11,6 +11,31 @@ import { buildNumberShortcutTabTargets } from './tabShortcutTargets';
 type AppContextGetter = () => Record<string, any>;
 const TERMINAL_PASSTHROUGH_ACTIONS = getTerminalPassthroughActions();
 
+async function deliverKeyboardInteractiveResponse(
+  ctx: Record<string, any>,
+  requestId: string,
+  responses: string[],
+  cancelled: boolean,
+) {
+  const { netcattyBridge, t, toast } = ctx;
+  const bridge = netcattyBridge.get();
+  if (!bridge?.respondKeyboardInteractive) {
+    toast.error(t('common.unknownError'), t('common.error'));
+    return false;
+  }
+  try {
+    const result = await bridge.respondKeyboardInteractive(requestId, responses, cancelled);
+    if (!result?.success) {
+      toast.error(result?.error || t('common.unknownError'), t('common.error'));
+      return false;
+    }
+    return true;
+  } catch (err) {
+    toast.error(err instanceof Error ? err.message : t('common.unknownError'), t('common.error'));
+    return false;
+  }
+}
+
 export const getLogHostVisualSnapshot = (host: Host) => {
   const icon = sanitizeHostIconFields(host);
   return {
@@ -232,25 +257,23 @@ export function handleEscapeKeyDownImpl(getCtx: AppContextGetter, e: KeyboardEve
   }
 }
 
-export function handleKeyboardInteractiveSubmitImpl(
+export async function handleKeyboardInteractiveSubmitImpl(
   getCtx: AppContextGetter,
   requestId: string,
   responses: string[],
   savePassword?: string,
 ) {
+  const ctx = getCtx();
   const {
     hosts,
+    hostsRef,
     keyboardInteractiveQueue,
-    netcattyBridge,
     sessions,
     setKeyboardInteractiveQueue,
     updateHosts,
-  } = getCtx();
+  } = ctx;
 {
-    const bridge = netcattyBridge.get();
-    if (bridge?.respondKeyboardInteractive) {
-      void bridge.respondKeyboardInteractive(requestId, responses, false);
-    }
+    if (!await deliverKeyboardInteractiveResponse(ctx, requestId, responses, false)) return false;
     const request = keyboardInteractiveQueue.find(r => r.requestId === requestId);
     const session = request?.sessionId
       ? sessions.find(s => s.id === request.sessionId)
@@ -268,14 +291,15 @@ export function handleKeyboardInteractiveSubmitImpl(
       : canUpdateDestinationHost
         ? session.hostId
         : undefined;
+    const latestHosts = hostsRef?.current ?? hosts;
     const host = hostIdToUpdate
-      ? hosts.find(h => h.id === hostIdToUpdate)
+      ? latestHosts.find((h: Host) => h.id === hostIdToUpdate)
       : undefined;
     // Save password to host if requested - never for second-factor / EDR prompts
     // (allowSavePassword === false) so a secondary secret cannot overwrite the
     // host login password (#2150 / Codex review on #2151).
     if (savePassword && host && request?.allowSavePassword !== false) {
-      updateHosts(hosts.map(h => h.id === host.id ? {
+      updateHosts(latestHosts.map((h: Host) => h.id === host.id ? {
         ...h,
         password: savePassword,
         savePassword: true,
@@ -283,18 +307,18 @@ export function handleKeyboardInteractiveSubmitImpl(
     }
     // Remove from queue by requestId
     setKeyboardInteractiveQueue(prev => prev.filter(r => r.requestId !== requestId));
+    return true;
   }
 }
 
-export function handleKeyboardInteractiveCancelImpl(getCtx: AppContextGetter, requestId: string) {
-  const { netcattyBridge, setKeyboardInteractiveQueue } = getCtx();
+export async function handleKeyboardInteractiveCancelImpl(getCtx: AppContextGetter, requestId: string) {
+  const ctx = getCtx();
+  const { setKeyboardInteractiveQueue } = ctx;
 {
-    const bridge = netcattyBridge.get();
-    if (bridge?.respondKeyboardInteractive) {
-      void bridge.respondKeyboardInteractive(requestId, [], true);
-    }
+    if (!await deliverKeyboardInteractiveResponse(ctx, requestId, [], true)) return false;
     // Remove from queue by requestId
     setKeyboardInteractiveQueue(prev => prev.filter(r => r.requestId !== requestId));
+    return true;
   }
 }
 

--- a/application/app/keyboardInteractiveScope.test.ts
+++ b/application/app/keyboardInteractiveScope.test.ts
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { shouldQueueKeyboardInteractiveRequest } from "./useAppStartupEffects.ts";
+import {
+  removeKeyboardInteractiveRequest,
+  shouldQueueKeyboardInteractiveRequest,
+} from "./useAppStartupEffects.ts";
 
 const sessions = [{ id: "terminal-1" }, { id: "terminal-2" }];
 
@@ -46,4 +49,9 @@ test("legacy unscoped keyboard-interactive requests remain visible", () => {
     shouldQueueKeyboardInteractiveRequest({ sessionId: "legacy-conn" }, sessions),
     true,
   );
+});
+
+test("cancelled keyboard-interactive requests are removed from the renderer queue", () => {
+  const queue = [{ requestId: "keep" }, { requestId: "cancel" }];
+  assert.deepEqual(removeKeyboardInteractiveRequest(queue, "cancel"), [{ requestId: "keep" }]);
 });

--- a/application/app/useAppStartupEffects.ts
+++ b/application/app/useAppStartupEffects.ts
@@ -15,6 +15,7 @@ type KeyboardInteractiveRequestLike = {
   hostId?: string;
 };
 type SessionIdLike = { id: string; hostId?: string; hostname?: string };
+type KeyboardInteractiveQueueItem = { requestId: string };
 
 export function shouldQueueKeyboardInteractiveRequest(
   request: KeyboardInteractiveRequestLike,
@@ -23,6 +24,13 @@ export function shouldQueueKeyboardInteractiveRequest(
   if (request.scope !== "terminal") return true;
   if (!request.sessionId) return false;
   return sessions.some((session) => session.id === request.sessionId);
+}
+
+export function removeKeyboardInteractiveRequest<T extends KeyboardInteractiveQueueItem>(
+  queue: T[],
+  requestId: string,
+): T[] {
+  return queue.filter(request => request.requestId !== requestId);
 }
 
 export function useAppStartupEffects(ctx: StartupEffectsContext) {
@@ -212,9 +220,13 @@ export function useAppStartupEffects(ctx: StartupEffectsContext) {
         allowSavePassword: request.allowSavePassword !== false,
       }]);
     });
+    const unsubscribeCancelled = bridge.onKeyboardInteractiveCancelled?.((event) => {
+      setKeyboardInteractiveQueue(prev => removeKeyboardInteractiveRequest(prev, event.requestId));
+    });
 
     return () => {
       unsubscribe?.();
+      unsubscribeCancelled?.();
     };
   }, [enabled, setKeyboardInteractiveQueue]);
 

--- a/components/KeyboardInteractiveModal.tsx
+++ b/components/KeyboardInteractiveModal.tsx
@@ -105,8 +105,8 @@ const isAPasswordPrompt = (prompt: KeyboardInteractivePrompt) => {
 
 interface KeyboardInteractiveModalProps {
   request: KeyboardInteractiveRequest | null;
-  onSubmit: (requestId: string, responses: string[], savePassword?: string) => void;
-  onCancel: (requestId: string) => void;
+  onSubmit: (requestId: string, responses: string[], savePassword?: string) => boolean | Promise<boolean>;
+  onCancel: (requestId: string) => boolean | Promise<boolean>;
 }
 
 export const KeyboardInteractiveModal: React.FC<KeyboardInteractiveModalProps> = ({
@@ -159,26 +159,37 @@ export const KeyboardInteractiveModal: React.FC<KeyboardInteractiveModalProps> =
 
   const canSavePassword = request?.allowSavePassword !== false;
 
-  const handleSubmit = useCallback(() => {
+  const handleSubmit = useCallback(async () => {
     if (!request || isSubmitting) return;
     setIsSubmitting(true);
     const passwordToSave =
       canSavePassword && savePassword && passwordPromptIndex >= 0
         ? responses[passwordPromptIndex]
         : undefined;
-    onSubmit(request.requestId, responses, passwordToSave);
+    try {
+      const submitted = await onSubmit(request.requestId, responses, passwordToSave);
+      if (!submitted) setIsSubmitting(false);
+    } catch {
+      setIsSubmitting(false);
+    }
   }, [request, responses, onSubmit, isSubmitting, savePassword, passwordPromptIndex, canSavePassword]);
 
-  const handleCancel = useCallback(() => {
-    if (!request) return;
-    onCancel(request.requestId);
-  }, [request, onCancel]);
+  const handleCancel = useCallback(async () => {
+    if (!request || isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      const cancelled = await onCancel(request.requestId);
+      if (!cancelled) setIsSubmitting(false);
+    } catch {
+      setIsSubmitting(false);
+    }
+  }, [request, onCancel, isSubmitting]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === "Enter" && !isSubmitting) {
         e.preventDefault();
-        handleSubmit();
+        void handleSubmit();
       }
     },
     [handleSubmit, isSubmitting]

--- a/electron/bridges/hostKeyVerifier.cjs
+++ b/electron/bridges/hostKeyVerifier.cjs
@@ -247,6 +247,11 @@ const createHostVerifier = ({
 
 const handleResponse = (_event, payload) => {
   const { requestId, accept, addToKnownHosts } = payload || {};
+  const pending = hostKeyRequests.get(requestId);
+  if (!pending) return { success: false, error: "Request not found" };
+  if (_event?.sender?.id !== pending.webContentsId) {
+    return { success: false, error: "Wrong sender" };
+  }
   return settleRequest(requestId, {
     accept: Boolean(accept),
     addToKnownHosts: Boolean(addToKnownHosts),

--- a/electron/bridges/hostKeyVerifier.test.cjs
+++ b/electron/bridges/hostKeyVerifier.test.cjs
@@ -347,7 +347,7 @@ test("createHostVerifier prompts for unknown host keys and waits for user respon
   assert.equal(sent[0].payload.hostname, "switch.local");
   assert.equal(sent[0].payload.status, "unknown");
 
-  handleResponse(null, {
+  handleResponse({ sender: { id: sender.id } }, {
     requestId: sent[0].payload.requestId,
     accept: true,
     addToKnownHosts: true,
@@ -391,7 +391,7 @@ test("createHostVerifier includes existing known host details when a key changes
   assert.equal(sent[0].payload.knownHostId, "kh-1");
   assert.equal(sent[0].payload.knownFingerprint, "old-key");
 
-  handleResponse(null, {
+  handleResponse({ sender: { id: sender.id } }, {
     requestId: sent[0].payload.requestId,
     accept: true,
     addToKnownHosts: true,

--- a/electron/bridges/keyboardInteractiveHandler.cjs
+++ b/electron/bridges/keyboardInteractiveHandler.cjs
@@ -23,7 +23,7 @@ function generateRequestId(prefix = 'ki') {
 /**
  * Store a keyboard-interactive request with TTL cleanup
  */
-function storeRequest(requestId, finishCallback, webContentsId, sessionId) {
+function storeRequest(requestId, finishCallback, webContentsId, sessionId, sender) {
   // Set up TTL timeout to clean up abandoned requests
   const timeoutId = setTimeout(() => {
     const pending = keyboardInteractiveRequests.get(requestId);
@@ -36,6 +36,7 @@ function storeRequest(requestId, finishCallback, webContentsId, sessionId) {
       } catch (err) {
         console.warn(`[KeyboardInteractive] Failed to call finishCallback for timed out request:`, err.message);
       }
+      notifyCancellation(pending, requestId, "timeout");
     }
   }, REQUEST_TTL_MS);
 
@@ -43,6 +44,7 @@ function storeRequest(requestId, finishCallback, webContentsId, sessionId) {
     finishCallback,
     webContentsId,
     sessionId,
+    sender,
     createdAt: Date.now(),
     timeoutId,
   });
@@ -74,22 +76,60 @@ function handleResponse(_event, payload) {
     return { success: false, error: 'Wrong sender' };
   }
 
-  // Clear the TTL timeout since we received a response
-  if (pending.timeoutId) {
-    clearTimeout(pending.timeoutId);
-  }
-
+  if (pending.timeoutId) clearTimeout(pending.timeoutId);
   keyboardInteractiveRequests.delete(requestId);
 
-  if (cancelled) {
-    console.log(`[KeyboardInteractive] Auth cancelled for ${requestId}`);
-    pending.finishCallback([]); // Empty responses to cancel
-  } else {
-    console.log(`[KeyboardInteractive] Auth response received for ${requestId}, responses count:`, responses?.length);
-    pending.finishCallback(responses);
+  try {
+    if (cancelled) {
+      console.log(`[KeyboardInteractive] Auth cancelled for ${requestId}`);
+      pending.finishCallback([]); // Empty responses to cancel
+    } else {
+      console.log(`[KeyboardInteractive] Auth response received for ${requestId}, responses count:`, responses?.length);
+      pending.finishCallback(responses);
+    }
+  } catch (err) {
+    console.warn(`[KeyboardInteractive] Failed to deliver response for ${requestId}:`, err?.message);
+    notifyCancellation(pending, requestId, "delivery-failed");
+    return { success: false, error: "Failed to deliver response" };
   }
 
   return { success: true };
+}
+
+/**
+ * Cancel every pending request owned by a session or external operation.
+ */
+function notifyCancellation(pending, requestId, reason) {
+  try {
+    if (!pending.sender?.isDestroyed?.()) {
+      pending.sender?.send?.("netcatty:keyboard-interactive-cancelled", {
+        requestId,
+        sessionId: pending.sessionId,
+        reason,
+      });
+    }
+  } catch (err) {
+    console.warn(`[KeyboardInteractive] Failed to notify cancellation for ${requestId}:`, err.message);
+  }
+}
+
+function cancelRequestsForSession(sessionId, reason = "cancelled") {
+  let cancelled = 0;
+  for (const [requestId, pending] of keyboardInteractiveRequests) {
+    if (pending.sessionId !== sessionId) continue;
+    if (pending.timeoutId) {
+      clearTimeout(pending.timeoutId);
+    }
+    keyboardInteractiveRequests.delete(requestId);
+    try {
+      pending.finishCallback([]);
+    } catch (err) {
+      console.warn(`[KeyboardInteractive] Failed to cancel request ${requestId}:`, err.message);
+    }
+    notifyCancellation(pending, requestId, reason);
+    cancelled += 1;
+  }
+  return cancelled;
 }
 
 /**
@@ -110,6 +150,7 @@ module.exports = {
   generateRequestId,
   storeRequest,
   handleResponse,
+  cancelRequestsForSession,
   getRequests,
   registerHandler,
 };

--- a/electron/bridges/keyboardInteractiveHandler.test.cjs
+++ b/electron/bridges/keyboardInteractiveHandler.test.cjs
@@ -54,3 +54,100 @@ test("keyboard-interactive responses never write password or OTP contents to log
     true,
   );
 });
+
+test("keyboard-interactive delivery failures close the renderer prompt", (t) => {
+  t.mock.method(console, "warn", () => {});
+  const notifications = [];
+  const requestId = keyboardInteractiveHandler.generateRequestId("delivery-failure");
+  keyboardInteractiveHandler.storeRequest(
+    requestId,
+    () => {
+      throw new Error("connection closed");
+    },
+    404,
+    "session-delivery-failure",
+    {
+      isDestroyed: () => false,
+      send: (channel, payload) => notifications.push({ channel, payload }),
+    },
+  );
+
+  const result = keyboardInteractiveHandler.handleResponse(
+    { sender: { id: 404 } },
+    { requestId, responses: ["123456"], cancelled: false },
+  );
+
+  assert.deepEqual(result, { success: false, error: "Failed to deliver response" });
+  assert.equal(keyboardInteractiveHandler.getRequests().has(requestId), false);
+  assert.deepEqual(notifications, [{
+    channel: "netcatty:keyboard-interactive-cancelled",
+    payload: {
+      requestId,
+      sessionId: "session-delivery-failure",
+      reason: "delivery-failed",
+    },
+  }]);
+});
+
+test("keyboard-interactive responses settle once when delivery closes the session", () => {
+  const finishCalls = [];
+  const requestId = keyboardInteractiveHandler.generateRequestId("reentrant-close");
+  keyboardInteractiveHandler.storeRequest(
+    requestId,
+    (responses) => {
+      finishCalls.push(responses);
+      keyboardInteractiveHandler.cancelRequestsForSession("session-reentrant-close");
+    },
+    505,
+    "session-reentrant-close",
+  );
+
+  const result = keyboardInteractiveHandler.handleResponse(
+    { sender: { id: 505 } },
+    { requestId, responses: ["123456"], cancelled: false },
+  );
+
+  assert.deepEqual(result, { success: true });
+  assert.deepEqual(finishCalls, [["123456"]]);
+  assert.equal(keyboardInteractiveHandler.getRequests().has(requestId), false);
+});
+
+test("keyboard-interactive requests can be cancelled by owning session", () => {
+  const finishCalls = [];
+  const notifications = [];
+  const matchingRequestId = keyboardInteractiveHandler.generateRequestId("matching");
+  const otherRequestId = keyboardInteractiveHandler.generateRequestId("other");
+  keyboardInteractiveHandler.storeRequest(
+    matchingRequestId,
+    (responses) => finishCalls.push({ requestId: matchingRequestId, responses }),
+    101,
+    "tunnel-1",
+    {
+      isDestroyed: () => false,
+      send: (channel, payload) => notifications.push({ channel, payload }),
+    },
+  );
+  keyboardInteractiveHandler.storeRequest(
+    otherRequestId,
+    (responses) => finishCalls.push({ requestId: otherRequestId, responses }),
+    101,
+    "tunnel-2",
+  );
+
+  const cancelled = keyboardInteractiveHandler.cancelRequestsForSession("tunnel-1", "tunnel-stopped");
+
+  assert.equal(cancelled, 1);
+  assert.deepEqual(finishCalls, [{ requestId: matchingRequestId, responses: [] }]);
+  assert.deepEqual(notifications, [{
+    channel: "netcatty:keyboard-interactive-cancelled",
+    payload: {
+      requestId: matchingRequestId,
+      sessionId: "tunnel-1",
+      reason: "tunnel-stopped",
+    },
+  }]);
+  assert.equal(keyboardInteractiveHandler.getRequests().has(matchingRequestId), false);
+  assert.equal(keyboardInteractiveHandler.getRequests().has(otherRequestId), true);
+
+  keyboardInteractiveHandler.cancelRequestsForSession("tunnel-2");
+});

--- a/electron/bridges/passphraseHandler.cjs
+++ b/electron/bridges/passphraseHandler.cjs
@@ -149,6 +149,11 @@ function handleResponse(_event, payload) {
     console.warn(`[Passphrase] No pending request for ${requestId}`);
     return { success: false, error: 'Request not found' };
   }
+
+  if (_event?.sender?.id !== pending.webContentsId) {
+    console.warn(`[Passphrase] Wrong sender for request ${requestId}`);
+    return { success: false, error: 'Wrong sender' };
+  }
   
   if (cancelled) {
     // User clicked Cancel - stop the entire passphrase flow

--- a/electron/bridges/portForwardingBridge.cancel.test.cjs
+++ b/electron/bridges/portForwardingBridge.cancel.test.cjs
@@ -6,6 +6,7 @@ const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 
 const passphraseHandler = require("./passphraseHandler.cjs");
+const keyboardInteractiveHandler = require("./keyboardInteractiveHandler.cjs");
 const {
   startPortForward,
   stopPortForward,
@@ -116,6 +117,23 @@ test("failed active tunnel cleanup publishes an error instead of a false inactiv
   assert.equal(shouldFinalizeTunnelClose(tunnel), false);
   assert.equal(tunnel.status, "error");
   assert.deepEqual(statuses, [{ status: "error", error: "server: server close failed" }]);
+});
+
+test("cancelling a tunnel clears its pending keyboard-interactive request", () => {
+  const tunnelId = "pf-keyboard-interactive-cancel";
+  const requestId = keyboardInteractiveHandler.generateRequestId("port-forward");
+  const finishCalls = [];
+  keyboardInteractiveHandler.storeRequest(
+    requestId,
+    (responses) => finishCalls.push(responses),
+    1,
+    tunnelId,
+  );
+
+  cancelTunnel(tunnelId, {}, () => {});
+
+  assert.deepEqual(finishCalls, [[]]);
+  assert.equal(keyboardInteractiveHandler.getRequests().has(requestId), false);
 });
 
 test("port forwarding can be stopped while waiting for a key passphrase", async (t) => {

--- a/electron/bridges/portForwardingBridge.cjs
+++ b/electron/bridges/portForwardingBridge.cjs
@@ -78,6 +78,7 @@ function cancelTunnel(tunnelId, tunnel, sendStatus, { deleteEntry = false } = {}
   };
   tunnel.cancelled = true;
   tunnel.cleanupInProgress = true;
+  keyboardInteractiveHandler.cancelRequestsForSession(tunnelId, "tunnel-stopped");
   if (tunnel.server) {
     if (cleanup('server', () => tunnel.server.close())) tunnel.server = null;
   }
@@ -464,6 +465,7 @@ async function startPortForward(event, payload) {
       try { connectionSocket.end?.(); } catch { /* ignore */ }
       try { connectionSocket.destroy?.(); } catch { /* ignore */ }
     }
+    keyboardInteractiveHandler.cancelRequestsForSession(tunnelId, "connection-ended");
     portForwardingTunnels.delete(tunnelId);
     sendStatus('error', err?.message || String(err));
     throw err;
@@ -716,6 +718,7 @@ async function startPortForward(event, payload) {
 
     conn.once('close', () => {
       clearAuthReadyTimer();
+      keyboardInteractiveHandler.cancelRequestsForSession(tunnelId, "connection-ended");
       console.log(`[PortForward] SSH connection closed for tunnel ${tunnelId}`);
       const tunnel = portForwardingTunnels.get(tunnelId) || tunnelState;
       // Capture the cancelled flag BEFORE cleanup deletes the entry.

--- a/electron/bridges/portForwardingBridge.jumpScope.test.cjs
+++ b/electron/bridges/portForwardingBridge.jumpScope.test.cjs
@@ -6,16 +6,17 @@ const { EventEmitter } = require("node:events");
 const { readFileSync } = require("node:fs");
 const { Duplex } = require("node:stream");
 const Module = require("node:module");
+const keyboardInteractiveHandler = require("./keyboardInteractiveHandler.cjs");
 
-function createSender() {
+function createSender(onSend = () => {}) {
   return {
     id: 1,
     isDestroyed: () => false,
-    send() {},
+    send: onSend,
   };
 }
 
-function loadBridgeWithMocks(t, { systemAgent = false } = {}) {
+function loadBridgeWithMocks(t, { systemAgent = false, chainError = null } = {}) {
   const originalLoad = Module._load;
   let capturedChainOptions = null;
   let capturedConnectOptions = null;
@@ -67,8 +68,19 @@ function loadBridgeWithMocks(t, { systemAgent = false } = {}) {
     if (request === "./sshBridge.cjs") {
       return {
         buildAlgorithms: () => ({}),
-        connectThroughChain: async (_event, options) => {
+        connectThroughChain: async (_event, options, _jumpHosts, _hostname, _port, sessionId) => {
           capturedChainOptions = options;
+          if (chainError) {
+            const requestId = keyboardInteractiveHandler.generateRequestId("jump-host");
+            keyboardInteractiveHandler.storeRequest(
+              requestId,
+              () => {},
+              _event.sender.id,
+              sessionId,
+              _event.sender,
+            );
+            throw chainError;
+          }
           return {
             socket: new Duplex({
               read() {},
@@ -178,6 +190,40 @@ test("port forwarding forwards target hostId to keyboard-interactive prompts", (
   assert.match(
     source,
     /conn\.on\("keyboard-interactive", createKeyboardInteractiveHandler\(\{\s*sender,\s*sessionId: tunnelId,\s*hostId,/,
+  );
+});
+
+test("jump-host startup failures clear pending keyboard-interactive prompts", async (t) => {
+  const sent = [];
+  const { bridge } = loadBridgeWithMocks(t, { chainError: new Error("jump auth timeout") });
+  const event = { sender: createSender((channel, payload) => sent.push({ channel, payload })) };
+
+  await assert.rejects(
+    bridge.startPortForward(event, {
+      tunnelId: "pf-jump-failure",
+      type: "local",
+      localPort: 0,
+      bindAddress: "127.0.0.1",
+      remoteHost: "127.0.0.1",
+      remotePort: 3306,
+      hostname: "db.internal",
+      username: "dbuser",
+      jumpHosts: [{ hostname: "jump.internal", username: "jumpuser" }],
+    }),
+    /jump auth timeout/,
+  );
+
+  assert.equal(
+    Array.from(keyboardInteractiveHandler.getRequests().values())
+      .some((request) => request.sessionId === "pf-jump-failure"),
+    false,
+  );
+  assert.equal(
+    sent.some(({ channel, payload }) =>
+      channel === "netcatty:keyboard-interactive-cancelled" &&
+      payload.sessionId === "pf-jump-failure" &&
+      payload.reason === "connection-ended"),
+    true,
   );
 });
 

--- a/electron/bridges/sftpBridge.hostKeyVerification.test.cjs
+++ b/electron/bridges/sftpBridge.hostKeyVerification.test.cjs
@@ -180,7 +180,7 @@ function makeSender({ rejectHostKeyPrompts = false } = {}) {
       if (rejectHostKeyPrompts && channel === "netcatty:host-key:verify") {
         const { handleResponse } = require("./hostKeyVerifier.cjs");
         queueMicrotask(() => {
-          handleResponse(null, {
+          handleResponse({ sender: { id: this.id } }, {
             requestId: payload.requestId,
             accept: false,
           });

--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -1793,7 +1793,7 @@ function createKeyboardInteractiveHandler(options) {
       console.log(`${logPrefix} Received user responses, finishing keyboard-interactive`);
       try { onUserResponded?.(); } catch (err) { console.warn(`${logPrefix} onUserResponded callback threw`, err); }
       finish(userResponses);
-    }, sender.id, sessionId);
+    }, sender.id, sessionId, sender);
 
     const promptsData = prompts.map((p) => ({
       prompt: p.prompt,

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -1341,6 +1341,17 @@ function registerWorkerHandle(ipcMain, terminalWorkerManager, channel) {
   });
 }
 
+function registerOwnedAuthResponseHandler(ipcMain, terminalWorkerManager, channel, mainProcessHandler) {
+  ipcMain.handle(channel, (event, payload) => {
+    if (mainProcessHandler.getRequests().has(payload?.requestId)) {
+      return mainProcessHandler.handleResponse(event, payload);
+    }
+    return terminalWorkerManager.request(channel, payload, {
+      webContentsId: event?.sender?.id,
+    });
+  });
+}
+
 function registerHandlers(ipcMain, options = {}) {
   const terminalWorkerManager = options.terminalWorkerManager || null;
   if (terminalWorkerManager) {
@@ -1354,10 +1365,25 @@ function registerHandlers(ipcMain, options = {}) {
       "netcatty:ssh:listdir",
       "netcatty:ssh:stats",
       "netcatty:ssh:setEncoding",
-      "netcatty:keyboard-interactive:respond",
-      "netcatty:passphrase:respond",
-      "netcatty:host-key:respond",
     ].forEach((channel) => registerWorkerHandle(ipcMain, terminalWorkerManager, channel));
+    registerOwnedAuthResponseHandler(
+      ipcMain,
+      terminalWorkerManager,
+      "netcatty:keyboard-interactive:respond",
+      keyboardInteractiveHandler,
+    );
+    registerOwnedAuthResponseHandler(
+      ipcMain,
+      terminalWorkerManager,
+      "netcatty:passphrase:respond",
+      passphraseHandler,
+    );
+    registerOwnedAuthResponseHandler(
+      ipcMain,
+      terminalWorkerManager,
+      "netcatty:host-key:respond",
+      hostKeyVerifier,
+    );
     ipcMain.on("netcatty:zmodem:overwrite-response", (event, payload) => {
       terminalWorkerManager.send("netcatty:zmodem:overwrite-response", payload, {
         webContentsId: event?.sender?.id,

--- a/electron/bridges/sshBridge.hostKeyChain.test.cjs
+++ b/electron/bridges/sshBridge.hostKeyChain.test.cjs
@@ -121,7 +121,7 @@ function makeSender({ rejectHostKeyPrompts = false } = {}) {
       if (rejectHostKeyPrompts && channel === "netcatty:host-key:verify") {
         const { handleResponse } = require("./hostKeyVerifier.cjs");
         queueMicrotask(() => {
-          handleResponse(null, {
+          handleResponse({ sender: { id: this.id } }, {
             requestId: payload.requestId,
             accept: false,
           });

--- a/electron/bridges/terminalWorkerProxyRegistration.test.cjs
+++ b/electron/bridges/terminalWorkerProxyRegistration.test.cjs
@@ -3,6 +3,9 @@ const test = require("node:test");
 
 const terminalBridge = require("./terminalBridge.cjs");
 const sshBridge = require("./sshBridge.cjs");
+const keyboardInteractiveHandler = require("./keyboardInteractiveHandler.cjs");
+const passphraseHandler = require("./passphraseHandler.cjs");
+const hostKeyVerifier = require("./hostKeyVerifier.cjs");
 const sftpBridge = require("./sftpBridge.cjs");
 const transferBridge = require("./transferBridge.cjs");
 const compressUploadBridge = require("./compressUploadBridge.cjs");
@@ -127,6 +130,139 @@ test("terminal worker mode proxies SSH session and remote helper requests", asyn
       "netcatty:ssh:listdir",
       "netcatty:ssh:stats",
       "netcatty:ssh:setEncoding",
+    ],
+  );
+});
+
+test("terminal worker mode keeps main-process keyboard-interactive responses in the main process", async () => {
+  const ipcMain = createFakeIpcMain();
+  const terminalWorkerManager = createFakeWorkerManager();
+  const requestId = keyboardInteractiveHandler.generateRequestId("port-forward");
+  let receivedResponses = null;
+
+  keyboardInteractiveHandler.storeRequest(
+    requestId,
+    (responses) => {
+      receivedResponses = responses;
+    },
+    fakeEvent.sender.id,
+    "tunnel-1",
+  );
+  sshBridge.registerHandlers(ipcMain, { terminalWorkerManager });
+
+  const result = await ipcMain.handlers.get("netcatty:keyboard-interactive:respond")(
+    fakeEvent,
+    { requestId, responses: ["123456"], cancelled: false },
+  );
+
+  const remainedPending = keyboardInteractiveHandler.getRequests().has(requestId);
+  if (remainedPending) {
+    keyboardInteractiveHandler.handleResponse(fakeEvent, {
+      requestId,
+      responses: [],
+      cancelled: true,
+    });
+  }
+
+  assert.deepEqual(result, { success: true });
+  assert.deepEqual(receivedResponses, ["123456"]);
+  assert.equal(remainedPending, false);
+  assert.equal(terminalWorkerManager.requests.length, 0);
+});
+
+test("terminal worker mode keeps main-process passphrase responses in the main process", async () => {
+  const ipcMain = createFakeIpcMain();
+  const terminalWorkerManager = createFakeWorkerManager();
+  const sent = [];
+  const sender = {
+    id: fakeEvent.sender.id,
+    isDestroyed: () => false,
+    send: (channel, payload) => sent.push({ channel, payload }),
+  };
+  const responsePromise = passphraseHandler.requestPassphrase(
+    sender,
+    "/tmp/test-key",
+    "test-key",
+    "example.com",
+    false,
+  );
+  const requestId = sent[0].payload.requestId;
+  sshBridge.registerHandlers(ipcMain, { terminalWorkerManager });
+
+  const wrongResult = await ipcMain.handlers.get("netcatty:passphrase:respond")(
+    { sender: { id: fakeEvent.sender.id + 1 } },
+    { requestId, passphrase: "stolen", cancelled: false },
+  );
+  assert.deepEqual(wrongResult, { success: false, error: "Wrong sender" });
+  assert.equal(passphraseHandler.getRequests().has(requestId), true);
+
+  const result = await ipcMain.handlers.get("netcatty:passphrase:respond")(
+    fakeEvent,
+    { requestId, passphrase: "secret", cancelled: false },
+  );
+
+  assert.deepEqual(result, { success: true });
+  assert.deepEqual(await responsePromise, { passphrase: "secret" });
+  assert.equal(passphraseHandler.getRequests().has(requestId), false);
+  assert.equal(terminalWorkerManager.requests.length, 0);
+});
+
+test("terminal worker mode keeps main-process host-key responses in the main process", async () => {
+  const ipcMain = createFakeIpcMain();
+  const terminalWorkerManager = createFakeWorkerManager();
+  const sent = [];
+  const sender = {
+    id: fakeEvent.sender.id,
+    isDestroyed: () => false,
+    send: (channel, payload) => sent.push({ channel, payload }),
+  };
+  const responsePromise = hostKeyVerifier.requestHostKeyVerification(sender, {
+    sessionId: "tunnel-1",
+    hostname: "example.com",
+    port: 22,
+    status: "unknown",
+  });
+  const requestId = sent[0].payload.requestId;
+  sshBridge.registerHandlers(ipcMain, { terminalWorkerManager });
+
+  const wrongResult = await ipcMain.handlers.get("netcatty:host-key:respond")(
+    { sender: { id: fakeEvent.sender.id + 1 } },
+    { requestId, accept: true, addToKnownHosts: false },
+  );
+  assert.deepEqual(wrongResult, { success: false, error: "Wrong sender" });
+  assert.equal(hostKeyVerifier.getRequests().has(requestId), true);
+
+  const result = await ipcMain.handlers.get("netcatty:host-key:respond")(
+    fakeEvent,
+    { requestId, accept: true, addToKnownHosts: false },
+  );
+
+  assert.deepEqual(result, { success: true });
+  assert.deepEqual(await responsePromise, { accept: true, addToKnownHosts: false });
+  assert.equal(hostKeyVerifier.getRequests().has(requestId), false);
+  assert.equal(terminalWorkerManager.requests.length, 0);
+});
+
+test("terminal worker mode forwards worker-owned authentication responses", async () => {
+  const ipcMain = createFakeIpcMain();
+  const terminalWorkerManager = createFakeWorkerManager();
+  sshBridge.registerHandlers(ipcMain, { terminalWorkerManager });
+
+  for (const channel of [
+    "netcatty:keyboard-interactive:respond",
+    "netcatty:passphrase:respond",
+    "netcatty:host-key:respond",
+  ]) {
+    const result = await ipcMain.handlers.get(channel)(fakeEvent, { requestId: `worker-${channel}` });
+    assert.deepEqual(result, { ok: true, channel });
+  }
+
+  assert.deepEqual(
+    terminalWorkerManager.requests.map((entry) => entry.channel),
+    [
+      "netcatty:keyboard-interactive:respond",
+      "netcatty:passphrase:respond",
+      "netcatty:host-key:respond",
     ],
   );
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -43,6 +43,7 @@ const windowShownListeners = new Set();
 const windowFocusRequestedListeners = new Set();
 const windowWillHideListeners = new Set();
 const keyboardInteractiveListeners = new Set();
+const keyboardInteractiveCancelledListeners = new Set();
 const hostKeyVerificationListeners = new Set();
 const passphraseListeners = new Set();
 const passphraseTimeoutListeners = new Set();
@@ -473,6 +474,16 @@ ipcRenderer.on("netcatty:keyboard-interactive", (_event, payload) => {
   });
 });
 
+ipcRenderer.on("netcatty:keyboard-interactive-cancelled", (_event, payload) => {
+  keyboardInteractiveCancelledListeners.forEach((cb) => {
+    try {
+      cb(payload);
+    } catch (err) {
+      console.error("Keyboard-interactive cancellation callback failed", err);
+    }
+  });
+});
+
 ipcRenderer.on("netcatty:host-key:verify", (_event, payload) => {
   hostKeyVerificationListeners.forEach((cb) => {
     try {
@@ -813,6 +824,7 @@ const api = createPreloadApi({
   windowFocusRequestedListeners,
   windowWillHideListeners,
   keyboardInteractiveListeners,
+  keyboardInteractiveCancelledListeners,
   hostKeyVerificationListeners,
   passphraseListeners,
   passphraseTimeoutListeners,

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -441,6 +441,10 @@ function createPreloadApi(ctx) {
     keyboardInteractiveListeners.add(cb);
     return () => keyboardInteractiveListeners.delete(cb);
   },
+  onKeyboardInteractiveCancelled: (cb) => {
+    keyboardInteractiveCancelledListeners.add(cb);
+    return () => keyboardInteractiveCancelledListeners.delete(cb);
+  },
   respondKeyboardInteractive: async (requestId, responses, cancelled = false) => {
     return ipcRenderer.invoke("netcatty:keyboard-interactive:respond", {
       requestId,

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -403,6 +403,13 @@ declare global {
         scope?: "terminal" | "external";
       }) => void
     ): () => void;
+    onKeyboardInteractiveCancelled?(
+      cb: (event: {
+        requestId: string;
+        sessionId?: string;
+        reason?: string;
+      }) => void
+    ): () => void;
     respondKeyboardInteractive?(
       requestId: string,
       responses: string[],


### PR DESCRIPTION
## What changed
- Route authentication responses to the process that owns each pending request.
- Keep the authentication prompt open and show an error when a response cannot be delivered.
- Clear pending OTP requests and their prompts when a port-forwarding connection stops or times out.
- Reject passphrase and host-key responses from the wrong window.
- Preserve concurrent host edits while saving a password after authentication.

## Why
Port forwarding still runs in the main process, while terminal sessions moved to the terminal worker. Authentication responses were always sent to the worker, so port-forward OTP requests never received the submitted code and eventually timed out.

## Validation
- 139 focused authentication, port-forwarding, SSH, and current-main integration tests pass.
- Production build passes on the exact remote head.
- ESLint reports no new errors.
- Full local suite: 6,321 passed, 7 skipped, and 1 known baseline failure reproduced without this change.
- `git diff --check` passes.

Closes #2346
