### PR TITLE
fix(sftp): keep copied tab cwd distinct

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1637,6 +1637,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     resolvedChainHosts,
     sessionId,
     reuseConnectionFromSessionId,
+    isNetworkDevice,
     startupCommand,
     noAutoRun,
     multiLineRunMode,

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -134,6 +134,32 @@ test("startSSH forwards imported system agent authentication settings", async ()
   );
 });
 
+test("startSSH tells the bridge to skip shell discovery for network devices", async () => {
+  let capturedOptions: Record<string, unknown> | null = null;
+  const terminalBackend = {
+    backendAvailable: () => true,
+    startSSHSession: async (options: Record<string, unknown>) => {
+      capturedOptions = options;
+      return "ssh-session";
+    },
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: noop,
+    resizeSession: noop,
+  };
+  const ctx = createStarterContext({
+    isNetworkDevice: true,
+    reuseConnectionFromSessionId: "source-session",
+    terminalBackend,
+  });
+
+  await createTerminalSessionStarters(ctx as never).startSSH(createTermStub() as never);
+
+  assert.equal(capturedOptions?.sourceSessionId, "source-session");
+  assert.equal(capturedOptions?.skipShellPidDiscovery, true);
+});
+
 test("startSSH uses the system agent when a synced vault key cannot be decrypted", async () => {
   let capturedOptions: Record<string, unknown> | null = null;
   const terminalBackend = {

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -564,6 +564,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
           // bridge silently falls back to a fresh connection if the source is
           // gone, so reconnect/retry after the source closed still works.
           sourceSessionId: ctx.reuseConnectionFromSessionId,
+          skipShellPidDiscovery: ctx.isNetworkDevice === true,
         });
       };
 

--- a/components/terminal/runtime/createTerminalSessionStarters.types.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.types.ts
@@ -123,6 +123,7 @@ export type TerminalSessionStartersContext = {
   // Source session id to reuse an authenticated SSH connection from when this
   // terminal was created from an existing SSH session.
   reuseConnectionFromSessionId?: string;
+  isNetworkDevice?: boolean;
   startupCommand?: string;
   noAutoRun?: boolean;
   multiLineRunMode?: TerminalSession["multiLineRunMode"];

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -939,6 +939,7 @@ const startSessionApi = createStartSessionApi({
   get sessions() { return sessions; },
   get electronModule() { return electronModule; },
   SSHClient, sshUtils, NetcattyAgent, keyboardInteractiveHandler, passphraseHandler, hostKeyVerifier,
+  quoteShellArg,
   fs, path, os, net, crypto, Buffer, process, console, setTimeout, clearTimeout,
   createProxySocket, attachX11Forwarding, createPtyOutputBuffer, sessionLogStreamManager,
   trackSessionIdlePrompt, looksLikeIdleAutoLogout, createZmodemSentry, enableSshNoDelay, enableTcpNoDelay,

--- a/electron/bridges/sshBridge.connectionReuse.test.cjs
+++ b/electron/bridges/sshBridge.connectionReuse.test.cjs
@@ -316,6 +316,33 @@ test("concurrent Copy Tab requests serialize shell discovery per connection", as
   assert.equal(sessions.get("copy-2").shellPid, "333");
 });
 
+test("concurrent copies keep distinct shell IDs when the source closes immediately", async (t) => {
+  const { bridge } = loadBridgeWithMockedSsh2(t);
+  const terminalBridge = require("./terminalBridge.cjs");
+  const sessions = new Map();
+  const sourceConn = makePidTrackingReusableConn();
+  sessions.set("source", makeSourceSession(sourceConn, { hostname: "10.0.0.1", username: "alice" }));
+
+  terminalBridge.init({ sessions, electronModule: {} });
+  const start = registerStartHandler(bridge, sessions);
+  const copies = Promise.all([
+    start(
+      { sender: makeSender() },
+      { sessionId: "copy-1", hostname: "10.0.0.1", username: "alice", sourceSessionId: "source" },
+    ),
+    start(
+      { sender: makeSender() },
+      { sessionId: "copy-2", hostname: "10.0.0.1", username: "alice", sourceSessionId: "source" },
+    ),
+  ]);
+
+  terminalBridge.closeSession({ sender: {} }, { sessionId: "source" });
+  await copies;
+
+  assert.equal(sessions.get("copy-1").shellPid, "222");
+  assert.equal(sessions.get("copy-2").shellPid, "333");
+});
+
 test("Copy Tab preserves the server locale unless the host explicitly overrides it", async (t) => {
   const { bridge } = loadBridgeWithMockedSsh2(t);
   const sessions = new Map();

--- a/electron/bridges/sshBridge.connectionReuse.test.cjs
+++ b/electron/bridges/sshBridge.connectionReuse.test.cjs
@@ -144,7 +144,10 @@ function makeFailedDiscoveryCommandConn() {
     const stream = new EventEmitter();
     stream.stderr = new EventEmitter();
     stream.close = () => {};
-    setImmediate(() => stream.emit("close", 127));
+    setImmediate(() => {
+      stream.emit("data", Buffer.from("111\n"));
+      stream.emit("close", 127);
+    });
     callback(null, stream);
   };
   return conn;
@@ -308,6 +311,7 @@ test("Copy Tab does not retry when remote shell discovery is unavailable", async
   );
 
   assert.equal(sourceConn.discoveryExecCalls, 1);
+  assert.equal(sessions.get("source").shellPid, undefined);
   assert.equal(sessions.get("copy").shellPid, undefined);
 });
 

--- a/electron/bridges/sshBridge.connectionReuse.test.cjs
+++ b/electron/bridges/sshBridge.connectionReuse.test.cjs
@@ -272,6 +272,31 @@ test("Copy Tab records a distinct remote shell for each shared terminal", async 
   assert.equal(sessions.get("copy").shellPid, "222");
 });
 
+test("Copy Tab skips POSIX shell discovery for network devices", async (t) => {
+  const { bridge } = loadBridgeWithMockedSsh2(t);
+  const sessions = new Map();
+  const sourceConn = makeReusableConn();
+  let execCalls = 0;
+  sourceConn.exec = () => { execCalls += 1; };
+  sessions.set("source", makeSourceSession(sourceConn, { hostname: "10.0.0.1", username: "alice" }));
+
+  const start = registerStartHandler(bridge, sessions);
+  await start(
+    { sender: makeSender() },
+    {
+      sessionId: "copy",
+      hostname: "10.0.0.1",
+      username: "alice",
+      sourceSessionId: "source",
+      skipShellPidDiscovery: true,
+    },
+  );
+
+  assert.equal(execCalls, 0);
+  assert.equal(sourceConn.openedShells.length, 1);
+  assert.ok(sessions.get("copy"));
+});
+
 test("Copy Tab waits briefly when the new remote shell is not visible immediately", async (t) => {
   const { bridge } = loadBridgeWithMockedSsh2(t);
   const sessions = new Map();

--- a/electron/bridges/sshBridge.connectionReuse.test.cjs
+++ b/electron/bridges/sshBridge.connectionReuse.test.cjs
@@ -324,7 +324,7 @@ test("concurrent copies keep distinct shell IDs when the source closes immediate
   const { bridge } = loadBridgeWithMockedSsh2(t);
   const terminalBridge = require("./terminalBridge.cjs");
   const sessions = new Map();
-  const sourceConn = makePidTrackingReusableConn();
+  const sourceConn = makePidTrackingReusableConn({ delayFirstNewPid: true });
   const source = makeSourceSession(sourceConn, { hostname: "10.0.0.1", username: "alice" });
   source.shellPid = "111";
   const closeSourceStream = source.stream.close;

--- a/electron/bridges/sshBridge.connectionReuse.test.cjs
+++ b/electron/bridges/sshBridge.connectionReuse.test.cjs
@@ -94,15 +94,25 @@ function makeReusableConn() {
   return conn;
 }
 
-function makePidTrackingReusableConn() {
+function makePidTrackingReusableConn({ delayFirstNewPid = false } = {}) {
   const conn = makeReusableConn();
   conn.shellPidSnapshots = [];
+  let delayed = false;
   conn.exec = (_command, callback) => {
     const stream = new EventEmitter();
     stream.stderr = new EventEmitter();
     stream.close = () => {};
-    const pids = conn.openedShells.length === 0 ? "111\n" : "111\n222\n";
-    conn.shellPidSnapshots.push(pids.trim().split("\n"));
+    let visibleShellCount = conn.openedShells.length + 1;
+    if (delayFirstNewPid && conn.openedShells.length > 0 && !delayed) {
+      delayed = true;
+      visibleShellCount -= 1;
+    }
+    const snapshot = Array.from(
+      { length: visibleShellCount },
+      (_value, index) => String((index + 1) * 111),
+    );
+    const pids = `${snapshot.join("\n")}\n`;
+    conn.shellPidSnapshots.push(snapshot);
     setImmediate(() => {
       stream.emit("data", Buffer.from(pids));
       stream.emit("close", 0);
@@ -229,6 +239,50 @@ test("Copy Tab records a distinct remote shell for each shared terminal", async 
   assert.deepEqual(sourceConn.shellPidSnapshots, [["111"], ["111", "222"]]);
   assert.equal(source.shellPid, "111");
   assert.equal(sessions.get("copy").shellPid, "222");
+});
+
+test("Copy Tab waits briefly when the new remote shell is not visible immediately", async (t) => {
+  const { bridge } = loadBridgeWithMockedSsh2(t);
+  const sessions = new Map();
+  const sourceConn = makePidTrackingReusableConn({ delayFirstNewPid: true });
+  sessions.set("source", makeSourceSession(sourceConn, { hostname: "10.0.0.1", username: "alice" }));
+
+  const start = registerStartHandler(bridge, sessions);
+  await start(
+    { sender: makeSender() },
+    {
+      sessionId: "copy",
+      hostname: "10.0.0.1",
+      username: "alice",
+      sourceSessionId: "source",
+    },
+  );
+
+  assert.deepEqual(sourceConn.shellPidSnapshots, [["111"], ["111"], ["111", "222"]]);
+  assert.equal(sessions.get("copy").shellPid, "222");
+});
+
+test("concurrent Copy Tab requests serialize shell discovery per connection", async (t) => {
+  const { bridge } = loadBridgeWithMockedSsh2(t);
+  const sessions = new Map();
+  const sourceConn = makePidTrackingReusableConn();
+  sessions.set("source", makeSourceSession(sourceConn, { hostname: "10.0.0.1", username: "alice" }));
+
+  const start = registerStartHandler(bridge, sessions);
+  await Promise.all([
+    start(
+      { sender: makeSender() },
+      { sessionId: "copy-1", hostname: "10.0.0.1", username: "alice", sourceSessionId: "source" },
+    ),
+    start(
+      { sender: makeSender() },
+      { sessionId: "copy-2", hostname: "10.0.0.1", username: "alice", sourceSessionId: "source" },
+    ),
+  ]);
+
+  assert.equal(sessions.get("source").shellPid, "111");
+  assert.equal(sessions.get("copy-1").shellPid, "222");
+  assert.equal(sessions.get("copy-2").shellPid, "333");
 });
 
 test("Copy Tab preserves the server locale unless the host explicitly overrides it", async (t) => {

--- a/electron/bridges/sshBridge.connectionReuse.test.cjs
+++ b/electron/bridges/sshBridge.connectionReuse.test.cjs
@@ -115,7 +115,7 @@ function makePidTrackingReusableConn({ delayFirstNewPid = false } = {}) {
         (_value, index) => String((index + 2) * 111),
       ),
     ];
-    const pids = `${snapshot.join("\n")}\n`;
+    const pids = `${snapshot.join("\n")}\n__NETCATTY_SHELL_SCAN_COMPLETE__\n`;
     conn.shellPidSnapshots.push(snapshot);
     setImmediate(() => {
       stream.emit("data", Buffer.from(pids));
@@ -132,6 +132,20 @@ function makeUnavailableDiscoveryConn() {
   conn.exec = (_command, callback) => {
     conn.discoveryExecCalls += 1;
     callback(new Error("exec channels disabled"));
+  };
+  return conn;
+}
+
+function makeFailedDiscoveryCommandConn() {
+  const conn = makeReusableConn();
+  conn.discoveryExecCalls = 0;
+  conn.exec = (_command, callback) => {
+    conn.discoveryExecCalls += 1;
+    const stream = new EventEmitter();
+    stream.stderr = new EventEmitter();
+    stream.close = () => {};
+    setImmediate(() => stream.emit("close", 127));
+    callback(null, stream);
   };
   return conn;
 }
@@ -280,6 +294,27 @@ test("Copy Tab does not retry when remote shell discovery is unavailable", async
   const { bridge } = loadBridgeWithMockedSsh2(t);
   const sessions = new Map();
   const sourceConn = makeUnavailableDiscoveryConn();
+  sessions.set("source", makeSourceSession(sourceConn, { hostname: "10.0.0.1", username: "alice" }));
+
+  const start = registerStartHandler(bridge, sessions);
+  await start(
+    { sender: makeSender() },
+    {
+      sessionId: "copy",
+      hostname: "10.0.0.1",
+      username: "alice",
+      sourceSessionId: "source",
+    },
+  );
+
+  assert.equal(sourceConn.discoveryExecCalls, 1);
+  assert.equal(sessions.get("copy").shellPid, undefined);
+});
+
+test("Copy Tab does not retry when the remote discovery command fails", async (t) => {
+  const { bridge } = loadBridgeWithMockedSsh2(t);
+  const sessions = new Map();
+  const sourceConn = makeFailedDiscoveryCommandConn();
   sessions.set("source", makeSourceSession(sourceConn, { hostname: "10.0.0.1", username: "alice" }));
 
   const start = registerStartHandler(bridge, sessions);

--- a/electron/bridges/sshBridge.connectionReuse.test.cjs
+++ b/electron/bridges/sshBridge.connectionReuse.test.cjs
@@ -94,6 +94,24 @@ function makeReusableConn() {
   return conn;
 }
 
+function makePidTrackingReusableConn() {
+  const conn = makeReusableConn();
+  conn.shellPidSnapshots = [];
+  conn.exec = (_command, callback) => {
+    const stream = new EventEmitter();
+    stream.stderr = new EventEmitter();
+    stream.close = () => {};
+    const pids = conn.openedShells.length === 0 ? "111\n" : "111\n222\n";
+    conn.shellPidSnapshots.push(pids.trim().split("\n"));
+    setImmediate(() => {
+      stream.emit("data", Buffer.from(pids));
+      stream.emit("close", 0);
+    });
+    callback(null, stream);
+  };
+  return conn;
+}
+
 // A reusable connection whose shell callback is held until released, so a test
 // can simulate the source tab closing while conn.shell() is still pending.
 function makeDeferredShellConn() {
@@ -188,6 +206,29 @@ test("Copy Tab reuses the source connection instead of dialing fresh", async (t)
   const progress = sender.sent.filter((m) => m.channel === "netcatty:chain:progress");
   assert.ok(progress.some((m) => m.payload.status === "connected"));
   assert.equal(getConnectionReuseFallbackEvents(sender).length, 0, "successful reuse should not emit fallback");
+});
+
+test("Copy Tab records a distinct remote shell for each shared terminal", async (t) => {
+  const { bridge } = loadBridgeWithMockedSsh2(t);
+  const sessions = new Map();
+  const sourceConn = makePidTrackingReusableConn();
+  const source = makeSourceSession(sourceConn, { hostname: "10.0.0.1", username: "alice" });
+  sessions.set("source", source);
+
+  const start = registerStartHandler(bridge, sessions);
+  await start(
+    { sender: makeSender() },
+    {
+      sessionId: "copy",
+      hostname: "10.0.0.1",
+      username: "alice",
+      sourceSessionId: "source",
+    },
+  );
+
+  assert.deepEqual(sourceConn.shellPidSnapshots, [["111"], ["111", "222"]]);
+  assert.equal(source.shellPid, "111");
+  assert.equal(sessions.get("copy").shellPid, "222");
 });
 
 test("Copy Tab preserves the server locale unless the host explicitly overrides it", async (t) => {

--- a/electron/bridges/sshBridge.connectionReuse.test.cjs
+++ b/electron/bridges/sshBridge.connectionReuse.test.cjs
@@ -122,6 +122,16 @@ function makePidTrackingReusableConn({ delayFirstNewPid = false } = {}) {
   return conn;
 }
 
+function makeUnavailableDiscoveryConn() {
+  const conn = makeReusableConn();
+  conn.discoveryExecCalls = 0;
+  conn.exec = (_command, callback) => {
+    conn.discoveryExecCalls += 1;
+    callback(new Error("exec channels disabled"));
+  };
+  return conn;
+}
+
 // A reusable connection whose shell callback is held until released, so a test
 // can simulate the source tab closing while conn.shell() is still pending.
 function makeDeferredShellConn() {
@@ -260,6 +270,27 @@ test("Copy Tab waits briefly when the new remote shell is not visible immediatel
 
   assert.deepEqual(sourceConn.shellPidSnapshots, [["111"], ["111"], ["111", "222"]]);
   assert.equal(sessions.get("copy").shellPid, "222");
+});
+
+test("Copy Tab does not retry when remote shell discovery is unavailable", async (t) => {
+  const { bridge } = loadBridgeWithMockedSsh2(t);
+  const sessions = new Map();
+  const sourceConn = makeUnavailableDiscoveryConn();
+  sessions.set("source", makeSourceSession(sourceConn, { hostname: "10.0.0.1", username: "alice" }));
+
+  const start = registerStartHandler(bridge, sessions);
+  await start(
+    { sender: makeSender() },
+    {
+      sessionId: "copy",
+      hostname: "10.0.0.1",
+      username: "alice",
+      sourceSessionId: "source",
+    },
+  );
+
+  assert.equal(sourceConn.discoveryExecCalls, 1);
+  assert.equal(sessions.get("copy").shellPid, undefined);
 });
 
 test("concurrent Copy Tab requests serialize shell discovery per connection", async (t) => {

--- a/electron/bridges/sshBridge.connectionReuse.test.cjs
+++ b/electron/bridges/sshBridge.connectionReuse.test.cjs
@@ -97,20 +97,24 @@ function makeReusableConn() {
 function makePidTrackingReusableConn({ delayFirstNewPid = false } = {}) {
   const conn = makeReusableConn();
   conn.shellPidSnapshots = [];
+  conn.sourceShellVisible = true;
   let delayed = false;
   conn.exec = (_command, callback) => {
     const stream = new EventEmitter();
     stream.stderr = new EventEmitter();
     stream.close = () => {};
-    let visibleShellCount = conn.openedShells.length + 1;
+    let visibleShellCount = conn.openedShells.length;
     if (delayFirstNewPid && conn.openedShells.length > 0 && !delayed) {
       delayed = true;
       visibleShellCount -= 1;
     }
-    const snapshot = Array.from(
-      { length: visibleShellCount },
-      (_value, index) => String((index + 1) * 111),
-    );
+    const snapshot = [
+      ...(conn.sourceShellVisible ? ["111"] : []),
+      ...Array.from(
+        { length: visibleShellCount },
+        (_value, index) => String((index + 2) * 111),
+      ),
+    ];
     const pids = `${snapshot.join("\n")}\n`;
     conn.shellPidSnapshots.push(snapshot);
     setImmediate(() => {
@@ -321,7 +325,14 @@ test("concurrent copies keep distinct shell IDs when the source closes immediate
   const terminalBridge = require("./terminalBridge.cjs");
   const sessions = new Map();
   const sourceConn = makePidTrackingReusableConn();
-  sessions.set("source", makeSourceSession(sourceConn, { hostname: "10.0.0.1", username: "alice" }));
+  const source = makeSourceSession(sourceConn, { hostname: "10.0.0.1", username: "alice" });
+  source.shellPid = "111";
+  const closeSourceStream = source.stream.close;
+  source.stream.close = () => {
+    sourceConn.sourceShellVisible = false;
+    closeSourceStream();
+  };
+  sessions.set("source", source);
 
   terminalBridge.init({ sessions, electronModule: {} });
   const start = registerStartHandler(bridge, sessions);

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -234,6 +234,16 @@ function createSessionOpsApi(ctx) {
       if (!session || !session.conn) {
         return { success: false, error: 'Session not found or not connected' };
       }
+
+      const targetLoginPid = /^\d+$/.test(String(session.shellPid || ''))
+        ? String(session.shellPid)
+        : '';
+      if ((session.connRef?.count || 1) > 1 && !targetLoginPid) {
+        return {
+          success: false,
+          error: 'Current directory is ambiguous across shared terminal channels',
+        };
+      }
     
       // Completely silent: uses a separate exec channel, nothing is printed
       // in the interactive terminal. The exec channel and the interactive
@@ -257,6 +267,7 @@ function createSessionOpsApi(ctx) {
         // so sh keeps the same PID and $PPID = sshd. Starting another shell
         // without exec would make $PPID point at the intermediate shell instead.
         const posixScript = `SELF=$$
+    TARGET_LOGIN=${targetLoginPid}
     ALLOW_FALLBACK=${allowHomeFallback ? "1" : "0"}
     # Find the user's interactive shell on this SSH connection.
     # Prefer the one attached to a controlling tty (the user's shell): probe exec
@@ -338,8 +349,10 @@ function createSessionOpsApi(ctx) {
         }
       '
     }
-    login=$(find_login_shell "$PPID")
+    login="$TARGET_LOGIN"
+    [ -n "$login" ] || login=$(find_login_shell "$PPID")
     if [ -n "$login" ]; then
+      printf 'NETCATTY_LOGIN_PID=%s\\n' "$login" >&2
       pid=$(find_active_shell "$login")
       [ -n "$pid" ] || pid="$login"
       cwd=$(readlink /proc/$pid/cwd 2>/dev/null)
@@ -387,6 +400,10 @@ function createSessionOpsApi(ctx) {
           stream.on('close', (code) => {
             clearTimeout(timer);
             const path = out.trim();
+            const loginPidMatch = errOut.match(/(?:^|\n)NETCATTY_LOGIN_PID=(\d+)(?:\n|$)/);
+            if (loginPidMatch) {
+              session.shellPid = loginPidMatch[1];
+            }
             log('[getSessionPwd]', { stdout: path, stderr: errOut.trim(), exitCode: code });
             if (path && path.startsWith('/')) {
               resolve({ success: true, cwd: path });

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -238,7 +238,12 @@ function createSessionOpsApi(ctx) {
       const targetLoginPid = /^\d+$/.test(String(session.shellPid || ''))
         ? String(session.shellPid)
         : '';
-      if ((session.connRef?.count || 1) > 1 && !targetLoginPid) {
+      const sharedTerminalCount = session.connRef
+        ? [...sessions.values()].filter(
+          (candidate) => candidate?.connRef === session.connRef && candidate?.stream,
+        ).length
+        : 1;
+      if (sharedTerminalCount > 1 && !targetLoginPid) {
         return {
           success: false,
           error: 'Current directory is ambiguous across shared terminal channels',

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -285,7 +285,7 @@ function createSessionOpsApi(ctx) {
     # entirely (#1123).
     find_login_shell() {
       _shell=$(ps -e -o pid=,ppid=,tty=,comm= 2>/dev/null | awk -v pp="$1" -v self="$SELF" '
-        $1 != self && $2 == pp && $4 ~ /^-?(ba|z|fi|k|da|a)?sh$/ {
+        $1 != self && $2 == pp && $4 ~ /^-?(ba|z|fi|k|da|a|c|tc)?sh$/ {
           if ($3 != "?") { print $1; found=1; exit }
           if (any == "") any=$1
         }
@@ -312,7 +312,7 @@ function createSessionOpsApi(ctx) {
         [ "$_conn2" = "$_conn" ] || continue
         _comm=$(cat "$_d/comm" 2>/dev/null)
         case "$_comm" in
-          sh|bash|zsh|fish|ksh|dash|ash) ;;
+          sh|bash|zsh|fish|ksh|dash|ash|csh|tcsh) ;;
           *) continue ;;
         esac
         _tty=$(ps -p "$_pid" -o tty= 2>/dev/null | tr -d '[:space:]')
@@ -334,7 +334,7 @@ function createSessionOpsApi(ctx) {
     find_active_shell() {
       ps -e -o pid=,ppid=,stat=,comm= 2>/dev/null | awk -v start="$1" '
         { pp[$1]=$2; st[$1]=$3; cm[$1]=$4; ord[NR]=$1 }
-        function isshell(c) { return c ~ /^-?(ba|z|fi|k|da|a)?sh$/ }
+        function isshell(c) { return c ~ /^-?(ba|z|fi|k|da|a|c|tc)?sh$/ }
         function depth(p,   d) { d=0; while (p != "" && d < 64) { if (p == start) return d; p=pp[p]; d++ } return -1 }
         END {
           best=-1; bp="";

--- a/electron/bridges/sshBridge/sessionOps.cwd.test.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cwd.test.cjs
@@ -20,9 +20,9 @@ function makePwdStream(cwd, loginPid) {
   return stream;
 }
 
-function makeApi(session) {
+function makeApi(session, siblingSessions = []) {
   return createSessionOpsApi({
-    sessions: new Map([["session-1", session]]),
+    sessions: new Map([["session-1", session], ...siblingSessions]),
     setTimeout,
     clearTimeout,
     quoteShellArg,
@@ -32,12 +32,14 @@ function makeApi(session) {
 
 test("shared terminal cwd probe refuses to guess without a shell pid", async () => {
   let execCalls = 0;
+  const connRef = { count: 2 };
   const api = makeApi({
-    connRef: { count: 2 },
+    connRef,
+    stream: {},
     conn: {
       exec() { execCalls += 1; },
     },
-  });
+  }, [["session-2", { connRef, stream: {} }]]);
 
   const result = await api.getSessionPwd(null, { sessionId: "session-1" });
 
@@ -51,6 +53,7 @@ test("shared terminal cwd probe targets the shell pid assigned to that tab", asy
   const session = {
     shellPid: "4242",
     connRef: { count: 2 },
+    stream: {},
     conn: {
       exec(nextCommand, callback) {
         command = nextCommand;
@@ -70,6 +73,7 @@ test("shared terminal cwd probe targets the shell pid assigned to that tab", asy
 test("an unshared terminal remembers the shell pid discovered by its cwd probe", async () => {
   const session = {
     connRef: { count: 1 },
+    stream: {},
     conn: {
       exec(_command, callback) {
         callback(null, makePwdStream("/home/alice/project", "3131"));
@@ -82,4 +86,22 @@ test("an unshared terminal remembers the shell pid discovered by its cwd probe",
 
   assert.deepEqual(result, { success: true, cwd: "/home/alice/project" });
   assert.equal(session.shellPid, "3131");
+});
+
+test("an SFTP reference does not make one terminal cwd ambiguous", async () => {
+  const session = {
+    connRef: { count: 2 },
+    stream: {},
+    conn: {
+      exec(_command, callback) {
+        callback(null, makePwdStream("/home/alice/project", "5151"));
+      },
+    },
+  };
+  const api = makeApi(session);
+
+  const result = await api.getSessionPwd(null, { sessionId: "session-1" });
+
+  assert.deepEqual(result, { success: true, cwd: "/home/alice/project" });
+  assert.equal(session.shellPid, "5151");
 });

--- a/electron/bridges/sshBridge/sessionOps.cwd.test.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cwd.test.cjs
@@ -1,0 +1,85 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+
+const { createSessionOpsApi } = require("./sessionOps.cjs");
+
+function quoteShellArg(value) {
+  return "'" + String(value).replace(/'/g, "'\\''") + "'";
+}
+
+function makePwdStream(cwd, loginPid) {
+  const stream = new EventEmitter();
+  stream.stderr = new EventEmitter();
+  stream.close = () => {};
+  setImmediate(() => {
+    stream.emit("data", Buffer.from(`${cwd}\n`));
+    stream.stderr.emit("data", Buffer.from(`NETCATTY_LOGIN_PID=${loginPid}\n`));
+    stream.emit("close", 0);
+  });
+  return stream;
+}
+
+function makeApi(session) {
+  return createSessionOpsApi({
+    sessions: new Map([["session-1", session]]),
+    setTimeout,
+    clearTimeout,
+    quoteShellArg,
+    log: () => {},
+  });
+}
+
+test("shared terminal cwd probe refuses to guess without a shell pid", async () => {
+  let execCalls = 0;
+  const api = makeApi({
+    connRef: { count: 2 },
+    conn: {
+      exec() { execCalls += 1; },
+    },
+  });
+
+  const result = await api.getSessionPwd(null, { sessionId: "session-1" });
+
+  assert.equal(result.success, false);
+  assert.match(result.error, /ambiguous/);
+  assert.equal(execCalls, 0);
+});
+
+test("shared terminal cwd probe targets the shell pid assigned to that tab", async () => {
+  let command = "";
+  const session = {
+    shellPid: "4242",
+    connRef: { count: 2 },
+    conn: {
+      exec(nextCommand, callback) {
+        command = nextCommand;
+        callback(null, makePwdStream("/srv/copied-tab", "4242"));
+      },
+    },
+  };
+  const api = makeApi(session);
+
+  const result = await api.getSessionPwd(null, { sessionId: "session-1" });
+
+  assert.deepEqual(result, { success: true, cwd: "/srv/copied-tab" });
+  assert.match(command, /TARGET_LOGIN=4242/);
+  assert.equal(session.shellPid, "4242");
+});
+
+test("an unshared terminal remembers the shell pid discovered by its cwd probe", async () => {
+  const session = {
+    connRef: { count: 1 },
+    conn: {
+      exec(_command, callback) {
+        callback(null, makePwdStream("/home/alice/project", "3131"));
+      },
+    },
+  };
+  const api = makeApi(session);
+
+  const result = await api.getSessionPwd(null, { sessionId: "session-1" });
+
+  assert.deepEqual(result, { success: true, cwd: "/home/alice/project" });
+  assert.equal(session.shellPid, "3131");
+});

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -165,9 +165,10 @@ printf '%s\n' '${scanCompleteMarker}'`;
               const effectiveExitStatus = typeof code === "number" ? code : exitStatus;
               const lines = stdout.split(/\r?\n/);
               const completed = lines.includes(scanCompleteMarker);
+              const available = completed && (effectiveExitStatus === null || effectiveExitStatus === 0);
               settle({
-                available: completed && (effectiveExitStatus === null || effectiveExitStatus === 0),
-                pids: lines.filter((value) => /^\d+$/.test(value)),
+                available,
+                pids: available ? lines.filter((value) => /^\d+$/.test(value)) : [],
               });
             });
           });

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -99,6 +99,69 @@ function shouldPromoteCachedAuthMethod(authMethod, cachedMethod) {
 
 function createStartSessionApi(ctx) {
   with (ctx) {
+    const listInteractiveShellPids = (conn) => {
+      if (!conn || typeof conn.exec !== "function") return Promise.resolve([]);
+
+      const script = `SELF=$$
+{
+  ps -e -o pid=,ppid=,tty=,comm= 2>/dev/null | awk -v pp="$PPID" -v self="$SELF" '
+    $1 != self && $2 == pp && $3 != "?" && $4 ~ /^-?(ba|z|fi|k|da|a)?sh$/ { print $1 }
+  '
+  if [ -r /proc/$SELF/environ ]; then
+    conn=$(tr '\\0' '\\n' < /proc/$SELF/environ 2>/dev/null | sed -n 's/^SSH_CONNECTION=//p' | head -n1)
+    if [ -n "$conn" ]; then
+      for d in /proc/[0-9]*; do
+        pid=$(basename "$d")
+        [ "$pid" = "$SELF" ] && continue
+        [ -r "$d/environ" ] || continue
+        conn2=$(tr '\\0' '\\n' < "$d/environ" 2>/dev/null | sed -n 's/^SSH_CONNECTION=//p' | head -n1)
+        [ "$conn2" = "$conn" ] || continue
+        comm=$(cat "$d/comm" 2>/dev/null)
+        case "$comm" in sh|bash|zsh|fish|ksh|dash|ash) ;; *) continue ;; esac
+        ppid=$(awk '{ print $4 }' "$d/stat" 2>/dev/null)
+        pcomm=$(cat "/proc/$ppid/comm" 2>/dev/null)
+        case "$pcomm" in sshd|dropbear|dropbearmulti) ;; *) continue ;; esac
+        tty=$(ps -p "$pid" -o tty= 2>/dev/null | tr -d '[:space:]')
+        [ -n "$tty" ] && [ "$tty" != "?" ] && printf '%s\\n' "$pid"
+      done
+    fi
+  fi
+} | awk '/^[0-9]+$/ && !seen[$1]++ { print $1 }'`;
+
+      return new Promise((resolve) => {
+        let settled = false;
+        let activeStream = null;
+        const settle = (pids) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          resolve(pids);
+        };
+        const timer = setTimeout(() => {
+          try { activeStream?.close?.(); } catch { /* ignore */ }
+          settle([]);
+        }, 1500);
+
+        try {
+          conn.exec(`exec sh -c ${quoteShellArg(script)}`, (err, stream) => {
+            if (err || !stream) {
+              settle([]);
+              return;
+            }
+            activeStream = stream;
+            let stdout = "";
+            stream.on("data", (chunk) => { stdout += chunk.toString(); });
+            stream.stderr?.on("data", () => {});
+            stream.on("close", () => {
+              settle(stdout.split(/\r?\n/).filter((value) => /^\d+$/.test(value)));
+            });
+          });
+        } catch {
+          settle([]);
+        }
+      });
+    };
+
     /**
      * Wire up a freshly-opened shell channel (PTY stream) for a session:
      * output buffering, ZMODEM handling, encoding, exit/close reporting and
@@ -457,11 +520,41 @@ function createStartSessionApi(ctx) {
      * Resolves with `{ sessionId }` on success. Throws on failure so the caller
      * can fall back to a normal fresh connection.
      */
-    function reuseShellSession(event, options, sourceSession, sessionId, log) {
+    async function reuseShellSession(event, options, sourceSession, sessionId, log) {
       const cols = options.cols || 80;
       const rows = options.rows || 24;
       const sender = event.sender;
       const conn = sourceSession.conn;
+      // Pin before the discovery probe as well as before conn.shell(): the
+      // source tab can close while either async operation is in flight.
+      const connRef = sourceSession.connRef;
+      const refHolder = {};
+      acquireConnectionRef(refHolder, connRef);
+      let discoveryConnectionError = null;
+      const onDiscoveryConnectionError = (err) => {
+        discoveryConnectionError = err;
+      };
+      conn.once("error", onDiscoveryConnectionError);
+      const shellPidsBeforeOpen = await listInteractiveShellPids(conn);
+      conn.removeListener("error", onDiscoveryConnectionError);
+      if (discoveryConnectionError) {
+        releaseConnectionRef(refHolder);
+        throw discoveryConnectionError;
+      }
+      if (!sourceSession.shellPid) {
+        const assignedPids = new Set(
+          [...sessions.values()]
+            .filter((candidate) => candidate?.connRef === sourceSession.connRef && candidate.shellPid)
+            .map((candidate) => String(candidate.shellPid)),
+        );
+        const unclaimedPids = shellPidsBeforeOpen.filter((pid) => !assignedPids.has(pid));
+        const unassignedSessions = [...sessions.values()].filter(
+          (candidate) => candidate?.connRef === sourceSession.connRef && !candidate.shellPid,
+        );
+        if (unclaimedPids.length === 1 && unassignedSessions.length === 1) {
+          unassignedSessions[0].shellPid = unclaimedPids[0];
+        }
+      }
 
       log("reusing existing connection for new shell channel", {
         sessionId,
@@ -493,10 +586,6 @@ function createStartSessionApi(ctx) {
       // object as the ref holder, then hand the ref over to the real session
       // once the channel opens. On any failure we release this hold so the count
       // is restored.
-      const connRef = sourceSession.connRef;
-      const refHolder = {};
-      acquireConnectionRef(refHolder, connRef);
-
       return new Promise((resolve, reject) => {
         let settled = false;
 
@@ -560,9 +649,16 @@ function createStartSessionApi(ctx) {
                 chainConnections: [],
                 isReused: true,
               });
-
-              settled = true;
-              resolve({ sessionId });
+              void listInteractiveShellPids(conn).then((shellPidsAfterOpen) => {
+                const previousPids = new Set(shellPidsBeforeOpen);
+                const newPids = shellPidsAfterOpen.filter((pid) => !previousPids.has(pid));
+                const copiedSession = sessions.get(sessionId);
+                if (copiedSession && newPids.length === 1) {
+                  copiedSession.shellPid = newPids[0];
+                }
+                settled = true;
+                resolve({ sessionId });
+              });
             }
           );
         } catch (syncErr) {

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -100,7 +100,9 @@ function shouldPromoteCachedAuthMethod(authMethod, cachedMethod) {
 function createStartSessionApi(ctx) {
   with (ctx) {
     const listInteractiveShellPids = (conn) => {
-      if (!conn || typeof conn.exec !== "function") return Promise.resolve([]);
+      if (!conn || typeof conn.exec !== "function") {
+        return Promise.resolve({ available: false, pids: [] });
+      }
 
       const script = `SELF=$$
 {
@@ -131,21 +133,21 @@ function createStartSessionApi(ctx) {
       return new Promise((resolve) => {
         let settled = false;
         let activeStream = null;
-        const settle = (pids) => {
+        const settle = (result) => {
           if (settled) return;
           settled = true;
           clearTimeout(timer);
-          resolve(pids);
+          resolve(result);
         };
         const timer = setTimeout(() => {
           try { activeStream?.close?.(); } catch { /* ignore */ }
-          settle([]);
+          settle({ available: false, pids: [] });
         }, 1500);
 
         try {
           conn.exec(`exec sh -c ${quoteShellArg(script)}`, (err, stream) => {
             if (err || !stream) {
-              settle([]);
+              settle({ available: false, pids: [] });
               return;
             }
             activeStream = stream;
@@ -153,11 +155,14 @@ function createStartSessionApi(ctx) {
             stream.on("data", (chunk) => { stdout += chunk.toString(); });
             stream.stderr?.on("data", () => {});
             stream.on("close", () => {
-              settle(stdout.split(/\r?\n/).filter((value) => /^\d+$/.test(value)));
+              settle({
+                available: true,
+                pids: stdout.split(/\r?\n/).filter((value) => /^\d+$/.test(value)),
+              });
             });
           });
         } catch {
-          settle([]);
+          settle({ available: false, pids: [] });
         }
       });
     };
@@ -165,8 +170,9 @@ function createStartSessionApi(ctx) {
     const waitForNewInteractiveShellPid = async (conn, previousPids) => {
       const previous = new Set(previousPids);
       for (let attempt = 0; attempt < 5; attempt += 1) {
-        const currentPids = await listInteractiveShellPids(conn);
-        const newPids = currentPids.filter((pid) => !previous.has(pid));
+        const discovery = await listInteractiveShellPids(conn);
+        if (!discovery.available) return null;
+        const newPids = discovery.pids.filter((pid) => !previous.has(pid));
         if (newPids.length === 1) return newPids[0];
         if (newPids.length > 1) return null;
         if (attempt < 4) {
@@ -552,7 +558,8 @@ function createStartSessionApi(ctx) {
         discoveryConnectionError = err;
       };
       conn.once("error", onDiscoveryConnectionError);
-      const shellPidsBeforeOpen = await listInteractiveShellPids(conn);
+      const shellDiscoveryBeforeOpen = await listInteractiveShellPids(conn);
+      const shellPidsBeforeOpen = shellDiscoveryBeforeOpen.pids;
       conn.removeListener("error", onDiscoveryConnectionError);
       if (discoveryConnectionError) {
         releaseConnectionRef(refHolder);
@@ -664,7 +671,7 @@ function createStartSessionApi(ctx) {
                 chainConnections: [],
                 isReused: true,
               });
-              const newShellPidPromise = shellPidsBeforeOpen.length > 0
+              const newShellPidPromise = shellDiscoveryBeforeOpen.available
                 ? waitForNewInteractiveShellPid(conn, shellPidsBeforeOpen)
                 : Promise.resolve(null);
               void newShellPidPromise.then((newShellPid) => {

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -568,10 +568,13 @@ printf '%s\n' '${scanCompleteMarker}'`;
       const onDiscoveryConnectionError = (err) => {
         discoveryConnectionError = err;
       };
-      conn.once("error", onDiscoveryConnectionError);
-      const shellDiscoveryBeforeOpen = await listInteractiveShellPids(conn);
+      let shellDiscoveryBeforeOpen = { available: false, pids: [] };
+      if (!options.skipShellPidDiscovery) {
+        conn.once("error", onDiscoveryConnectionError);
+        shellDiscoveryBeforeOpen = await listInteractiveShellPids(conn);
+        conn.removeListener("error", onDiscoveryConnectionError);
+      }
       const shellPidsBeforeOpen = shellDiscoveryBeforeOpen.pids;
-      conn.removeListener("error", onDiscoveryConnectionError);
       if (discoveryConnectionError) {
         releaseConnectionRef(refHolder);
         throw discoveryConnectionError;

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -551,19 +551,9 @@ function createStartSessionApi(ctx) {
       const onDiscoveryConnectionError = (err) => {
         discoveryConnectionError = err;
       };
-      const sharedSessions = [...sessions.values()].filter(
-        (candidate) => candidate?.connRef === sourceSession.connRef,
-      );
-      const allSharedShellPidsKnown = sharedSessions.length > 0
-        && sharedSessions.every((candidate) => /^\d+$/.test(String(candidate.shellPid || "")));
-      let shellPidsBeforeOpen;
-      if (allSharedShellPidsKnown) {
-        shellPidsBeforeOpen = sharedSessions.map((candidate) => String(candidate.shellPid));
-      } else {
-        conn.once("error", onDiscoveryConnectionError);
-        shellPidsBeforeOpen = await listInteractiveShellPids(conn);
-        conn.removeListener("error", onDiscoveryConnectionError);
-      }
+      conn.once("error", onDiscoveryConnectionError);
+      const shellPidsBeforeOpen = await listInteractiveShellPids(conn);
+      conn.removeListener("error", onDiscoveryConnectionError);
       if (discoveryConnectionError) {
         releaseConnectionRef(refHolder);
         throw discoveryConnectionError;
@@ -571,12 +561,12 @@ function createStartSessionApi(ctx) {
       if (!sourceSession.shellPid) {
         const assignedPids = new Set(
           [...sessions.values()]
-            .filter((candidate) => candidate?.connRef === sourceSession.connRef && candidate.shellPid)
+            .filter((candidate) => candidate?.connRef === connRef && candidate.shellPid)
             .map((candidate) => String(candidate.shellPid)),
         );
         const unclaimedPids = shellPidsBeforeOpen.filter((pid) => !assignedPids.has(pid));
         const unassignedSessions = [...sessions.values()].filter(
-          (candidate) => candidate?.connRef === sourceSession.connRef && !candidate.shellPid,
+          (candidate) => candidate?.connRef === connRef && !candidate.shellPid,
         );
         if (unclaimedPids.length === 1 && unassignedSessions.length === 1) {
           unassignedSessions[0].shellPid = unclaimedPids[0];

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -558,19 +558,17 @@ function createStartSessionApi(ctx) {
         releaseConnectionRef(refHolder);
         throw discoveryConnectionError;
       }
-      if (!sourceSession.shellPid) {
-        const assignedPids = new Set(
-          [...sessions.values()]
-            .filter((candidate) => candidate?.connRef === connRef && candidate.shellPid)
-            .map((candidate) => String(candidate.shellPid)),
-        );
-        const unclaimedPids = shellPidsBeforeOpen.filter((pid) => !assignedPids.has(pid));
-        const unassignedSessions = [...sessions.values()].filter(
-          (candidate) => candidate?.connRef === connRef && !candidate.shellPid,
-        );
-        if (unclaimedPids.length === 1 && unassignedSessions.length === 1) {
-          unassignedSessions[0].shellPid = unclaimedPids[0];
-        }
+      const assignedPids = new Set(
+        [...sessions.values()]
+          .filter((candidate) => candidate?.connRef === connRef && candidate.shellPid)
+          .map((candidate) => String(candidate.shellPid)),
+      );
+      const unclaimedPids = shellPidsBeforeOpen.filter((pid) => !assignedPids.has(pid));
+      const unassignedSessions = [...sessions.values()].filter(
+        (candidate) => candidate?.connRef === connRef && !candidate.shellPid,
+      );
+      if (unclaimedPids.length === 1 && unassignedSessions.length === 1) {
+        unassignedSessions[0].shellPid = unclaimedPids[0];
       }
 
       log("reusing existing connection for new shell channel", {

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -551,9 +551,19 @@ function createStartSessionApi(ctx) {
       const onDiscoveryConnectionError = (err) => {
         discoveryConnectionError = err;
       };
-      conn.once("error", onDiscoveryConnectionError);
-      const shellPidsBeforeOpen = await listInteractiveShellPids(conn);
-      conn.removeListener("error", onDiscoveryConnectionError);
+      const sharedSessions = [...sessions.values()].filter(
+        (candidate) => candidate?.connRef === sourceSession.connRef,
+      );
+      const allSharedShellPidsKnown = sharedSessions.length > 0
+        && sharedSessions.every((candidate) => /^\d+$/.test(String(candidate.shellPid || "")));
+      let shellPidsBeforeOpen;
+      if (allSharedShellPidsKnown) {
+        shellPidsBeforeOpen = sharedSessions.map((candidate) => String(candidate.shellPid));
+      } else {
+        conn.once("error", onDiscoveryConnectionError);
+        shellPidsBeforeOpen = await listInteractiveShellPids(conn);
+        conn.removeListener("error", onDiscoveryConnectionError);
+      }
       if (discoveryConnectionError) {
         releaseConnectionRef(refHolder);
         throw discoveryConnectionError;
@@ -666,7 +676,10 @@ function createStartSessionApi(ctx) {
                 chainConnections: [],
                 isReused: true,
               });
-              void waitForNewInteractiveShellPid(conn, shellPidsBeforeOpen).then((newShellPid) => {
+              const newShellPidPromise = shellPidsBeforeOpen.length > 0
+                ? waitForNewInteractiveShellPid(conn, shellPidsBeforeOpen)
+                : Promise.resolve(null);
+              void newShellPidPromise.then((newShellPid) => {
                 const copiedSession = sessions.get(sessionId);
                 if (copiedSession && newShellPid) {
                   copiedSession.shellPid = newShellPid;

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -105,7 +105,7 @@ function createStartSessionApi(ctx) {
       const script = `SELF=$$
 {
   ps -e -o pid=,ppid=,tty=,comm= 2>/dev/null | awk -v pp="$PPID" -v self="$SELF" '
-    $1 != self && $2 == pp && $3 != "?" && $4 ~ /^-?(ba|z|fi|k|da|a)?sh$/ { print $1 }
+    $1 != self && $2 == pp && $3 != "?" && $4 ~ /^-?(ba|z|fi|k|da|a|c|tc)?sh$/ { print $1 }
   '
   if [ -r /proc/$SELF/environ ]; then
     conn=$(tr '\\0' '\\n' < /proc/$SELF/environ 2>/dev/null | sed -n 's/^SSH_CONNECTION=//p' | head -n1)
@@ -117,7 +117,7 @@ function createStartSessionApi(ctx) {
         conn2=$(tr '\\0' '\\n' < "$d/environ" 2>/dev/null | sed -n 's/^SSH_CONNECTION=//p' | head -n1)
         [ "$conn2" = "$conn" ] || continue
         comm=$(cat "$d/comm" 2>/dev/null)
-        case "$comm" in sh|bash|zsh|fish|ksh|dash|ash) ;; *) continue ;; esac
+        case "$comm" in sh|bash|zsh|fish|ksh|dash|ash|csh|tcsh) ;; *) continue ;; esac
         ppid=$(awk '{ print $4 }' "$d/stat" 2>/dev/null)
         pcomm=$(cat "/proc/$ppid/comm" 2>/dev/null)
         case "$pcomm" in sshd|dropbear|dropbearmulti) ;; *) continue ;; esac
@@ -160,6 +160,20 @@ function createStartSessionApi(ctx) {
           settle([]);
         }
       });
+    };
+
+    const waitForNewInteractiveShellPid = async (conn, previousPids) => {
+      const previous = new Set(previousPids);
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        const currentPids = await listInteractiveShellPids(conn);
+        const newPids = currentPids.filter((pid) => !previous.has(pid));
+        if (newPids.length === 1) return newPids[0];
+        if (newPids.length > 1) return null;
+        if (attempt < 4) {
+          await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+        }
+      }
+      return null;
     };
 
     /**
@@ -520,16 +534,19 @@ function createStartSessionApi(ctx) {
      * Resolves with `{ sessionId }` on success. Throws on failure so the caller
      * can fall back to a normal fresh connection.
      */
-    async function reuseShellSession(event, options, sourceSession, sessionId, log) {
+    async function openReusedShellSerialized(
+      event,
+      options,
+      sourceSession,
+      sessionId,
+      log,
+      connRef,
+      refHolder,
+    ) {
       const cols = options.cols || 80;
       const rows = options.rows || 24;
       const sender = event.sender;
       const conn = sourceSession.conn;
-      // Pin before the discovery probe as well as before conn.shell(): the
-      // source tab can close while either async operation is in flight.
-      const connRef = sourceSession.connRef;
-      const refHolder = {};
-      acquireConnectionRef(refHolder, connRef);
       let discoveryConnectionError = null;
       const onDiscoveryConnectionError = (err) => {
         discoveryConnectionError = err;
@@ -649,12 +666,10 @@ function createStartSessionApi(ctx) {
                 chainConnections: [],
                 isReused: true,
               });
-              void listInteractiveShellPids(conn).then((shellPidsAfterOpen) => {
-                const previousPids = new Set(shellPidsBeforeOpen);
-                const newPids = shellPidsAfterOpen.filter((pid) => !previousPids.has(pid));
+              void waitForNewInteractiveShellPid(conn, shellPidsBeforeOpen).then((newShellPid) => {
                 const copiedSession = sessions.get(sessionId);
-                if (copiedSession && newPids.length === 1) {
-                  copiedSession.shellPid = newPids[0];
+                if (copiedSession && newShellPid) {
+                  copiedSession.shellPid = newShellPid;
                 }
                 settled = true;
                 resolve({ sessionId });
@@ -669,6 +684,35 @@ function createStartSessionApi(ctx) {
           conn.removeListener("error", onConnError);
           log("reused shell threw synchronously", { sessionId, hostname: options.hostname, error: syncErr?.message });
           failReuse(syncErr);
+        }
+      });
+    }
+
+    function reuseShellSession(event, options, sourceSession, sessionId, log) {
+      const connRef = sourceSession.connRef;
+      const refHolder = {};
+      // Pin while queued as well as while opening: the source tab may close
+      // before this copy reaches the front of the per-connection queue.
+      acquireConnectionRef(refHolder, connRef);
+
+      const previous = connRef.shellOpenQueue || Promise.resolve();
+      const operation = previous
+        .catch(() => {})
+        .then(() => openReusedShellSerialized(
+          event,
+          options,
+          sourceSession,
+          sessionId,
+          log,
+          connRef,
+          refHolder,
+        ));
+      const tail = operation.then(() => undefined, () => undefined);
+      connRef.shellOpenQueue = tail;
+
+      return operation.finally(() => {
+        if (connRef.shellOpenQueue === tail) {
+          delete connRef.shellOpenQueue;
         }
       });
     }

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -104,9 +104,11 @@ function createStartSessionApi(ctx) {
         return Promise.resolve({ available: false, pids: [] });
       }
 
+      const scanCompleteMarker = "__NETCATTY_SHELL_SCAN_COMPLETE__";
       const script = `SELF=$$
+ps_output=$(ps -e -o pid=,ppid=,tty=,comm= 2>/dev/null) || exit 69
 {
-  ps -e -o pid=,ppid=,tty=,comm= 2>/dev/null | awk -v pp="$PPID" -v self="$SELF" '
+  printf '%s\n' "$ps_output" | awk -v pp="$PPID" -v self="$SELF" '
     $1 != self && $2 == pp && $3 != "?" && $4 ~ /^-?(ba|z|fi|k|da|a|c|tc)?sh$/ { print $1 }
   '
   if [ -r /proc/$SELF/environ ]; then
@@ -128,7 +130,8 @@ function createStartSessionApi(ctx) {
       done
     fi
   fi
-} | awk '/^[0-9]+$/ && !seen[$1]++ { print $1 }'`;
+} | awk '/^[0-9]+$/ && !seen[$1]++ { print $1 }'
+printf '%s\n' '${scanCompleteMarker}'`;
 
       return new Promise((resolve) => {
         let settled = false;
@@ -152,12 +155,19 @@ function createStartSessionApi(ctx) {
             }
             activeStream = stream;
             let stdout = "";
+            let exitStatus = null;
             stream.on("data", (chunk) => { stdout += chunk.toString(); });
             stream.stderr?.on("data", () => {});
-            stream.on("close", () => {
+            stream.on("exit", (code) => {
+              if (typeof code === "number") exitStatus = code;
+            });
+            stream.on("close", (code) => {
+              const effectiveExitStatus = typeof code === "number" ? code : exitStatus;
+              const lines = stdout.split(/\r?\n/);
+              const completed = lines.includes(scanCompleteMarker);
               settle({
-                available: true,
-                pids: stdout.split(/\r?\n/).filter((value) => /^\d+$/.test(value)),
+                available: completed && (effectiveExitStatus === null || effectiveExitStatus === 0),
+                pids: lines.filter((value) => /^\d+$/.test(value)),
               });
             });
           });

--- a/global.d.ts
+++ b/global.d.ts
@@ -163,6 +163,8 @@ declare global {
     // The bridge falls back to a fresh connection if the source is gone, unless
     // reuseOnly is also set.
     sourceSessionId?: string;
+    // Skip POSIX process discovery when copying a network-device session.
+    skipShellPidDiscovery?: boolean;
     // When true with sourceSessionId: (1) fail instead of falling back to a
     // fresh SSH dial, and (2) skip renderer endpoint matching so a Connected
     // picker probe can reuse the named live session even if session.username


### PR DESCRIPTION
## Summary

- record the remote shell belonging to each terminal when a tab reuses an existing SSH connection
- resolve SFTP terminal-directory requests against that tab's shell instead of another shell on the shared connection
- reject ambiguous directory probes when a safe tab-to-shell mapping is unavailable

## Root cause

Copied tabs open separate shell channels on one authenticated SSH connection. The directory probe searched that shared connection and selected the first interactive shell it found, so both tabs could report the same path even after changing to different directories.

## User impact

After copying a terminal tab, each tab's SFTP panel now follows and locates its own terminal directory while retaining connection reuse and avoiding another MFA prompt.

## Validation

- `node --test electron/bridges/sshBridge/sessionOps.cwd.test.cjs electron/bridges/sshBridge.connectionReuse.test.cjs electron/bridges/sshConnectionPool.test.cjs`
- `npm run lint` (passes with 4 existing warnings outside this change)
- `npm run build`
- `git diff --check`

Fixes #2322