### PR TITLE
fix(terminal): run host startup command after restore

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -189,6 +189,7 @@ import type { CreateXTermRuntimeContext } from "./terminal/runtime/createXTermRu
 import { TerminalView } from "./terminal/TerminalView";
 import {
   getInitialTerminalStatus,
+  shouldSuppressHostStartupCommandOnReconnect,
   shouldStartTerminalBackend,
 } from "./terminal/restoredSessionGate";
 import {
@@ -1183,7 +1184,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   }, [host, t, terminalSettings, updateStatus]);
 
   const prepareRestoredReconnect = useCallback(() => {
-    suppressHostStartupCommandRef.current = false;
+    suppressHostStartupCommandRef.current = shouldSuppressHostStartupCommandOnReconnect(
+      restoreState === "restored-disconnected" ? "restored" : "manual",
+    );
     if (restoreState !== "restored-disconnected") {
       restoreCwdIntentRef.current = null;
       return;
@@ -2507,7 +2510,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       prepareRestoredReconnect();
     } else {
       restoreCwdIntentRef.current = null;
-      suppressHostStartupCommandRef.current = true;
+      suppressHostStartupCommandRef.current = shouldSuppressHostStartupCommandOnReconnect("automatic");
     }
     // Claim the retry before awaiting close. A close/cancel/unmount during the
     // awaited backend cleanup invalidates this token and stops the continuation.

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1183,13 +1183,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   }, [host, t, terminalSettings, updateStatus]);
 
   const prepareRestoredReconnect = useCallback(() => {
+    suppressHostStartupCommandRef.current = false;
     if (restoreState !== "restored-disconnected") {
-      suppressHostStartupCommandRef.current = false;
       restoreCwdIntentRef.current = null;
       return;
     }
 
-    suppressHostStartupCommandRef.current = true;
     restoreCwdIntentRef.current = resolveRestoreCwdIntent({
       enabled: restoreTerminalCwd,
       session: {

--- a/components/terminal/restoredSessionGate.test.ts
+++ b/components/terminal/restoredSessionGate.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 
 import {
   getInitialTerminalStatus,
+  shouldSuppressHostStartupCommandOnReconnect,
   shouldStartTerminalBackend,
 } from "./restoredSessionGate.ts";
 
@@ -20,6 +21,12 @@ test("normal sessions initialize as connecting", () => {
 
 test("restored disconnected sessions start terminal backend", () => {
   assert.equal(shouldStartTerminalBackend(), true);
+});
+
+test("host startup command policy distinguishes restored and automatic reconnects", () => {
+  assert.equal(shouldSuppressHostStartupCommandOnReconnect("restored"), false);
+  assert.equal(shouldSuppressHostStartupCommandOnReconnect("manual"), false);
+  assert.equal(shouldSuppressHostStartupCommandOnReconnect("automatic"), true);
 });
 
 test("restored disconnected sessions still create a terminal runtime before backend startup", () => {

--- a/components/terminal/restoredSessionGate.ts
+++ b/components/terminal/restoredSessionGate.ts
@@ -1,7 +1,13 @@
 import type { TerminalSession } from "../../domain/models";
 
+export type TerminalReconnectMode = "restored" | "manual" | "automatic";
+
 export const getInitialTerminalStatus = (): TerminalSession["status"] => (
   "connecting"
 );
 
 export const shouldStartTerminalBackend = (): boolean => true;
+
+export const shouldSuppressHostStartupCommandOnReconnect = (
+  mode: TerminalReconnectMode,
+): boolean => mode === "automatic";

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -8,6 +8,7 @@ import {
 import { createPromptLineBreakState } from "./promptLineBreak";
 import { resolveStartupCommand } from "./terminalStartupCommands";
 import { pasteTextIntoTerminal } from "./terminalUserPaste";
+import { shouldSuppressHostStartupCommandOnReconnect } from "../restoredSessionGate";
 
 const noop = () => undefined;
 const ENCRYPTED_CREDENTIAL_PLACEHOLDER = "enc:v1:djEwAAAA";
@@ -2258,7 +2259,7 @@ test("startup command suppression is consumed only when scheduling", () => {
   assert.equal(resolveStartupCommand(ctx as never), "echo host-startup");
 });
 
-test("restored local reconnect runs the current host startup command", async () => {
+test("restored local reconnect runs the host startup command while automatic retry suppresses it", async () => {
   const sessionWrites: Array<{ id: string; data: string; automated?: boolean }> = [];
 
   const terminalBackend = {
@@ -2295,7 +2296,9 @@ test("restored local reconnect runs the current host startup command", async () 
     terminalSettings: { startupCommandDelayMs: 0 },
     terminalBackend,
     startupCommand: undefined,
-    suppressHostStartupCommandRef: { current: false },
+    suppressHostStartupCommandRef: {
+      current: shouldSuppressHostStartupCommandOnReconnect("restored"),
+    },
     promptLineBreakStateRef: undefined,
   });
 
@@ -2305,6 +2308,21 @@ test("restored local reconnect runs the current host startup command", async () 
   assert.deepEqual(sessionWrites, [
     { id: "local-session", data: "echo host-startup\r", automated: true },
   ]);
+
+  sessionWrites.length = 0;
+  const automaticReconnectCtx = createStarterContext({
+    ...ctx,
+    sessionRef: { current: null },
+    hasRunStartupCommandRef: { current: false },
+    suppressHostStartupCommandRef: {
+      current: shouldSuppressHostStartupCommandOnReconnect("automatic"),
+    },
+  });
+
+  await createTerminalSessionStarters(automaticReconnectCtx as never).startLocal(createTermStub() as never);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(sessionWrites, []);
 });
 
 test("local session start uses per-session directory before global default", async () => {

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -2258,7 +2258,7 @@ test("startup command suppression is consumed only when scheduling", () => {
   assert.equal(resolveStartupCommand(ctx as never), "echo host-startup");
 });
 
-test("restored local reconnect does not fall back to host startup command", async () => {
+test("restored local reconnect runs the current host startup command", async () => {
   const sessionWrites: Array<{ id: string; data: string; automated?: boolean }> = [];
 
   const terminalBackend = {
@@ -2295,14 +2295,16 @@ test("restored local reconnect does not fall back to host startup command", asyn
     terminalSettings: { startupCommandDelayMs: 0 },
     terminalBackend,
     startupCommand: undefined,
-    suppressHostStartupCommandRef: { current: true },
+    suppressHostStartupCommandRef: { current: false },
     promptLineBreakStateRef: undefined,
   });
 
   await createTerminalSessionStarters(ctx as never).startLocal(createTermStub() as never);
   await new Promise((resolve) => setTimeout(resolve, 0));
 
-  assert.deepEqual(sessionWrites, []);
+  assert.deepEqual(sessionWrites, [
+    { id: "local-session", data: "echo host-startup\r", automated: true },
+  ]);
 });
 
 test("local session start uses per-session directory before global default", async () => {

--- a/docs/session-restore.md
+++ b/docs/session-restore.md
@@ -40,7 +40,7 @@ If the directory is missing, inaccessible, or rejected by the shell, the connect
 | Setting | Default | Effect |
 | --- | --- | --- |
 | Restore previous terminal tabs and workspace layout | On | Enables startup restore for tabs, workspaces, layout, and lightweight session metadata. |
-| Restore terminal working directory on reconnect | Off | Attempts a one-shot cwd restore after manually reconnecting an eligible restored terminal. |
+| Restore terminal working directory on reconnect | Off | Attempts a one-shot cwd restore when an eligible restored terminal reconnects. |
 
 The cwd setting is intentionally separate because it sends a command after reconnect. Keeping it off by default avoids surprising remote-side behavior.
 
@@ -71,9 +71,9 @@ Domain helpers do not read or write storage and do not start terminal runtime wo
 
 ### UI And Runtime Glue
 
-UI components display restored placeholders and reconnect actions. Terminal runtime helpers gate backend startup so restored placeholders remain disconnected until manual reconnect.
+UI components display reconnect progress and manual reconnect actions after failures. Terminal runtime helpers start restored sessions through the normal connection flow.
 
-Runtime code may consume a one-shot cwd restore intent after backend attach. It must not infer startup restore as permission to connect or run commands.
+Runtime code may consume a one-shot cwd restore intent after backend attach. A restored connection may run the startup command currently configured on its host, but it must never replay a per-session startup command from persisted restore data.
 
 ## Restore Payload Allowlist
 

--- a/docs/session-restore.md
+++ b/docs/session-restore.md
@@ -7,14 +7,13 @@ Session restore brings Netcatty back to the user's previous workspace shape on s
 Implemented behavior:
 
 - Restores terminal tabs, tab order, active tab, workspace split layout, and pane focus metadata.
-- Restores terminal sessions as disconnected placeholders.
-- Allows the user to manually reconnect a restored placeholder.
-- Optionally restores the last known working directory after a manual reconnect.
+- Restores terminal sessions and reconnects them automatically.
+- Allows the user to manually reconnect if the automatic reconnect fails.
+- Optionally restores the last known working directory when a restored terminal reconnects.
 - Flushes the lightweight restore payload on page hide / unload using the same sanitizer as normal persistence.
 
 Out of scope:
 
-- Automatic reconnect on startup.
 - Restoring terminal output, scrollback, command history, logs, snapshots, or process state.
 - Persisting passwords, passphrases, private keys, or other secret material.
 - Restoring mosh / ET / telnet / serial / network-device working directories.
@@ -24,13 +23,13 @@ Out of scope:
 
 ### Startup Restore
 
-When "Restore previous terminal tabs and workspace layout" is enabled, Netcatty restores the prior terminal workspace on launch. Restored terminals are marked with `restoreState: "restored-disconnected"` and stay disconnected until the user explicitly reconnects them.
+When "Restore previous terminal tabs and workspace layout" is enabled, Netcatty restores the prior terminal workspace on launch. Restored terminals are marked with `restoreState: "restored-disconnected"` while they reconnect.
 
-Startup restore must not start terminal backends, SSH connections, local shells, SFTP sessions, mosh, ET, telnet, serial sessions, cwd probes, or startup commands.
+After a restored terminal reconnects, it runs the startup command currently configured on its host. Per-session startup commands are not persisted or replayed by session restore.
 
 ### Manual Reconnect
 
-When the user reconnects a restored placeholder, the normal connection flow starts. The reconnect action is the boundary where side effects are allowed.
+If an automatic reconnect fails, the user can reconnect the restored terminal manually through the normal connection flow.
 
 If "Restore terminal working directory on reconnect" is enabled and the restored session has an eligible `lastCwd`, Netcatty sends an automated `cd -- ...` after backend attach. The command is shell-quoted, is not added to application command history, and is attempted at most once for that reconnect.
 


### PR DESCRIPTION
## Summary

- Run the current host startup command after a restored terminal reconnects.
- Keep per-session startup commands out of persisted restore data.
- Update the session restore documentation to match the current automatic reconnect behavior.

## Root cause

The restored-session path reused the startup-command suppression intended for later automatic reconnect retries. That also suppressed the startup command currently configured on the host.

## User impact

Hosts restored after an app restart now initialize the same way as newly opened hosts, so aliases and other startup setup are available immediately.

Closes #2342

## Validation

- `node --test --import tsx components/terminal/runtime/createTerminalSessionStarters.test.ts components/terminal/restoredSessionGate.test.ts domain/sessionRestore.test.ts` (103 passed)
- `npm run lint -- --quiet`
- `npm run build`
- `git diff --check`
- Final local review round: three independent reviewers returned `CLEAN`.
- Full `npm test`: 6335 passed, 7 skipped, 1 unrelated existing SSH authentication test failed (`failed keyboard-interactive retry still offers encrypted default key fallback`); the unchanged test also failed when rerun by itself.
