### PR TITLE
fix(port-forwarding): restart auto-start rules after network recovery

### DIFF
--- a/application/state/usePortForwardingAutoStart.test.ts
+++ b/application/state/usePortForwardingAutoStart.test.ts
@@ -2,11 +2,21 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  runPortForwardingAutoStart,
+  subscribeToPortForwardingNetworkRecovery,
   getAutoStartRuleBlockReason,
   isAutoStartProxyReady,
   isPortForwardingAutoStartEnabled,
 } from "./usePortForwardingAutoStart.ts";
 import type { GroupConfig, Host, PortForwardingRule, ProxyProfile } from "../../domain/models.ts";
+import { STORAGE_KEY_PORT_FORWARDING } from "../../infrastructure/config/storageKeys.ts";
+import {
+  getActiveConnection,
+  setReconnectCallback,
+  startPortForward,
+  stopPortForward,
+  stopAndCleanupRuleAndWait,
+} from "../../infrastructure/services/portForwardingService.ts";
 
 const host = (overrides: Partial<Host> = {}): Host => ({
   id: "host-1",
@@ -38,6 +48,47 @@ const rule = (overrides: Partial<PortForwardingRule> = {}): PortForwardingRule =
   status: "inactive",
   createdAt: 1,
   ...overrides,
+});
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+
+const installStorage = () => {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  const backing = new Map<string, string>();
+  const storage: Storage = {
+    get length() { return backing.size; },
+    clear() { backing.clear(); },
+    getItem(key) { return backing.get(key) ?? null; },
+    key(index) { return Array.from(backing.keys())[index] ?? null; },
+    removeItem(key) { backing.delete(key); },
+    setItem(key, value) { backing.set(key, value); },
+  };
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
+  return {
+    storage,
+    restore() {
+      if (previous) Object.defineProperty(globalThis, "localStorage", previous);
+      else Reflect.deleteProperty(globalThis, "localStorage");
+    },
+  };
+};
+
+const autoStartOptions = (hosts: Host[]) => ({
+  hosts,
+  keys: [],
+  identities: [],
+  proxyProfiles: [],
+  groupConfigs: [],
+  knownHosts: [],
+  isHostAuthReady: () => true,
+  resolveEffectiveHost: (currentHost: Host) => currentHost,
+  updateStoredRuleStatus: () => undefined,
 });
 
 test("isAutoStartProxyReady waits when a host saved proxy is unresolved", () => {
@@ -124,4 +175,248 @@ test("reconnect eligibility follows the current auto-start setting", () => {
   assert.equal(isPortForwardingAutoStartEnabled([rule({ autoStart: true })], "rule-1"), true);
   assert.equal(isPortForwardingAutoStartEnabled([rule({ autoStart: false })], "rule-1"), false);
   assert.equal(isPortForwardingAutoStartEnabled([], "rule-1"), false);
+});
+
+test("network recovery starts an exhausted auto-start rule through the real service path", async (t) => {
+  const env = installStorage();
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  let onlineListener: (() => void) | undefined;
+  const startedRuleIds: string[] = [];
+  const exhaustedStartResult = deferred<{ success: boolean; error: string }>();
+  let preparingExhaustedRule = true;
+  const backendSnapshot = deferred<[]>();
+  let snapshotCalls = 0;
+  const target = {
+    addEventListener(type: string, listener: () => void) {
+      if (type === "online") onlineListener = listener;
+    },
+    removeEventListener(type: string, listener: () => void) {
+      if (type === "online" && onlineListener === listener) onlineListener = undefined;
+    },
+  };
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        listPortForwards: async () => {
+          snapshotCalls++;
+          return backendSnapshot.promise;
+        },
+        startPortForward: async ({ ruleId }: { ruleId: string }) => {
+          startedRuleIds.push(ruleId);
+          if (ruleId === "exhausted" && preparingExhaustedRule) {
+            return exhaustedStartResult.promise;
+          }
+          return { success: true };
+        },
+        onPortForwardStatus: () => () => undefined,
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+      },
+    },
+  });
+  t.after(async () => {
+    await Promise.all([
+      stopAndCleanupRuleAndWait("exhausted"),
+      stopAndCleanupRuleAndWait("already-active"),
+    ]);
+    setReconnectCallback(null);
+    env.restore();
+    if (previousWindow) Object.defineProperty(globalThis, "window", previousWindow);
+    else Reflect.deleteProperty(globalThis, "window");
+  });
+
+  const rules = [
+    rule({ id: "exhausted", autoStart: true }),
+    rule({ id: "already-active", autoStart: true }),
+    rule({ id: "manually-stopped", autoStart: true, status: "inactive" }),
+    rule({ id: "manual", autoStart: false }),
+  ];
+  env.storage.setItem(STORAGE_KEY_PORT_FORWARDING, JSON.stringify(rules));
+  setReconnectCallback(async () => ({ success: true }));
+  const exhaustedStart = startPortForward(
+    rules[0]!,
+    host(),
+    [host()],
+    [],
+    [],
+    () => undefined,
+    true,
+  );
+  const exhaustedConnection = getActiveConnection("exhausted");
+  assert.ok(exhaustedConnection);
+  exhaustedConnection.reconnectAttempts = 5;
+  exhaustedStartResult.resolve({ success: false, error: "offline socket" });
+  await exhaustedStart;
+  preparingExhaustedRule = false;
+
+  await startPortForward(
+    rules[1]!,
+    host(),
+    [host()],
+    [],
+    [],
+    () => undefined,
+    true,
+  );
+  startedRuleIds.length = 0;
+
+  const unsubscribe = subscribeToPortForwardingNetworkRecovery(target, (recoveryRuleIds) =>
+    runPortForwardingAutoStart({
+      ...autoStartOptions([host()]),
+      recoveryRuleIds,
+    }),
+  );
+
+  onlineListener?.();
+  onlineListener?.();
+  assert.equal(snapshotCalls, 1);
+  backendSnapshot.resolve([]);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.deepEqual(startedRuleIds, ["exhausted"]);
+
+  unsubscribe();
+  assert.equal(onlineListener, undefined);
+});
+
+test("network recovery refreshes retries for a connecting final attempt", async (t) => {
+  const env = installStorage();
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const startResult = deferred<{ success: boolean; error: string }>();
+  let onlineListener: (() => void) | undefined;
+  const target = {
+    addEventListener(type: string, listener: () => void) {
+      if (type === "online") onlineListener = listener;
+    },
+    removeEventListener(type: string, listener: () => void) {
+      if (type === "online" && onlineListener === listener) onlineListener = undefined;
+    },
+  };
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        listPortForwards: async () => [],
+        startPortForward: async () => startResult.promise,
+        onPortForwardStatus: () => () => undefined,
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+      },
+    },
+  });
+  const retryingRule = rule({ id: "recovering-final-attempt", autoStart: true });
+  env.storage.setItem(STORAGE_KEY_PORT_FORWARDING, JSON.stringify([retryingRule]));
+  setReconnectCallback(async () => ({ success: true }));
+  const unsubscribe = subscribeToPortForwardingNetworkRecovery(target, (recoveryRuleIds) =>
+    runPortForwardingAutoStart({
+      ...autoStartOptions([host()]),
+      recoveryRuleIds,
+    }),
+  );
+  t.after(async () => {
+    unsubscribe();
+    setReconnectCallback(null);
+    await stopAndCleanupRuleAndWait(retryingRule.id);
+    env.restore();
+    if (previousWindow) Object.defineProperty(globalThis, "window", previousWindow);
+    else Reflect.deleteProperty(globalThis, "window");
+  });
+
+  const pendingStart = startPortForward(
+    retryingRule,
+    host(),
+    [host()],
+    [],
+    [],
+    () => undefined,
+    true,
+  );
+  const connection = getActiveConnection(retryingRule.id);
+  assert.ok(connection);
+  connection.reconnectAttempts = 5;
+
+  onlineListener?.();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(connection.reconnectAttempts, 0);
+
+  startResult.resolve({ success: false, error: "offline socket" });
+  await pendingStart;
+  assert.equal(connection.reconnectAttempts, 1);
+  assert.ok(connection.reconnectTimerCallback);
+});
+
+test("manual stop cancels an exhausted recovery while backend sync is pending", async (t) => {
+  const env = installStorage();
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const exhaustedStartResult = deferred<{ success: boolean; error: string }>();
+  const backendSnapshot = deferred<[]>();
+  const stopResult = deferred<{ stopped: number; failed: number; errors: string[] }>();
+  const startedRuleIds: string[] = [];
+  let preparingExhaustedRule = true;
+  let onlineListener: (() => void) | undefined;
+  const target = {
+    addEventListener(type: string, listener: () => void) {
+      if (type === "online") onlineListener = listener;
+    },
+    removeEventListener(type: string, listener: () => void) {
+      if (type === "online" && onlineListener === listener) onlineListener = undefined;
+    },
+  };
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        listPortForwards: async () => backendSnapshot.promise,
+        startPortForward: async ({ ruleId }: { ruleId: string }) => {
+          startedRuleIds.push(ruleId);
+          if (preparingExhaustedRule) return exhaustedStartResult.promise;
+          return { success: true };
+        },
+        onPortForwardStatus: () => () => undefined,
+        stopPortForwardByRuleId: async () => stopResult.promise,
+      },
+    },
+  });
+  const exhaustedRule = rule({ id: "exhausted-then-stopped", autoStart: true });
+  env.storage.setItem(STORAGE_KEY_PORT_FORWARDING, JSON.stringify([exhaustedRule]));
+  setReconnectCallback(async () => ({ success: true }));
+  const unsubscribe = subscribeToPortForwardingNetworkRecovery(target, (recoveryRuleIds) =>
+    runPortForwardingAutoStart({
+      ...autoStartOptions([host()]),
+      recoveryRuleIds,
+    }),
+  );
+  t.after(async () => {
+    unsubscribe();
+    setReconnectCallback(null);
+    await stopAndCleanupRuleAndWait(exhaustedRule.id);
+    env.restore();
+    if (previousWindow) Object.defineProperty(globalThis, "window", previousWindow);
+    else Reflect.deleteProperty(globalThis, "window");
+  });
+
+  const exhaustedStart = startPortForward(
+    exhaustedRule,
+    host(),
+    [host()],
+    [],
+    [],
+    () => undefined,
+    true,
+  );
+  const connection = getActiveConnection(exhaustedRule.id);
+  assert.ok(connection);
+  connection.reconnectAttempts = 5;
+  exhaustedStartResult.resolve({ success: false, error: "offline socket" });
+  await exhaustedStart;
+  preparingExhaustedRule = false;
+  startedRuleIds.length = 0;
+
+  onlineListener?.();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const manualStop = stopPortForward(exhaustedRule.id, () => undefined);
+  backendSnapshot.resolve([]);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(startedRuleIds, []);
+  stopResult.resolve({ stopped: 1, failed: 0, errors: [] });
+  await manualStop;
 });

--- a/application/state/usePortForwardingAutoStart.ts
+++ b/application/state/usePortForwardingAutoStart.ts
@@ -11,6 +11,8 @@ import { STORAGE_KEY_PORT_FORWARDING } from "../../infrastructure/config/storage
 import { localStorageAdapter } from "../../infrastructure/persistence/localStorageAdapter";
 import {
   getActiveConnection,
+  isReconnectRecoveryEligible,
+  resetReconnectAttempts,
   setReconnectCallback,
   startPortForward,
   syncWithBackend,
@@ -99,6 +101,140 @@ export const isPortForwardingAutoStartEnabled = (
   rules: PortForwardingRule[],
   ruleId: string,
 ): boolean => rules.some((rule) => rule.id === ruleId && rule.autoStart === true);
+
+export const shouldStartPortForwardingAutoStartRule = (
+  rule: PortForwardingRule,
+  connection?: { status: PortForwardingRule["status"] },
+): boolean => rule.autoStart === true && (
+  !connection || connection.status === "inactive" || connection.status === "error"
+);
+
+export const recoverPortForwardingAutoStartAfterNetworkRestore = async (
+  restartAutoStartRules: (recoverableRuleIds: ReadonlySet<string>) => Promise<void>,
+): Promise<void> => {
+  const rules = localStorageAdapter.read<PortForwardingRule[]>(
+    STORAGE_KEY_PORT_FORWARDING,
+  ) ?? [];
+  const recoverableRuleIds = new Set<string>();
+  for (const rule of rules) {
+    if (rule.autoStart && resetReconnectAttempts(rule.id)) {
+      recoverableRuleIds.add(rule.id);
+    }
+  }
+  if (recoverableRuleIds.size > 0) {
+    await restartAutoStartRules(recoverableRuleIds);
+  }
+};
+
+interface PortForwardingNetworkRecoveryTarget {
+  addEventListener: (type: "online", listener: EventListener) => void;
+  removeEventListener: (type: "online", listener: EventListener) => void;
+}
+
+export const subscribeToPortForwardingNetworkRecovery = (
+  target: PortForwardingNetworkRecoveryTarget,
+  restartAutoStartRules: (recoverableRuleIds: ReadonlySet<string>) => Promise<void>,
+): (() => void) => {
+  let restartInFlight: Promise<void> | undefined;
+  const handleOnline: EventListener = () => {
+    if (restartInFlight) return;
+    restartInFlight = recoverPortForwardingAutoStartAfterNetworkRestore(restartAutoStartRules)
+      .catch((error: unknown) => {
+        logger.warn("[PortForwardingAutoStart] Network recovery restart failed:", error);
+      })
+      .finally(() => {
+        restartInFlight = undefined;
+      });
+  };
+
+  target.addEventListener("online", handleOnline);
+  return () => target.removeEventListener("online", handleOnline);
+};
+
+interface RunPortForwardingAutoStartOptions {
+  hosts: Host[];
+  keys: SSHKey[];
+  identities: Identity[];
+  proxyProfiles: ProxyProfile[];
+  groupConfigs: GroupConfig[];
+  knownHosts: KnownHost[];
+  terminalSettings?: { keepaliveInterval: number; keepaliveCountMax: number };
+  isHostAuthReady: (host: Host) => boolean;
+  resolveEffectiveHost: (host: Host) => Host;
+  updateStoredRuleStatus: (
+    ruleId: string,
+    status: PortForwardingRule["status"],
+    error?: string,
+  ) => void;
+  recoveryRuleIds?: ReadonlySet<string>;
+}
+
+export const runPortForwardingAutoStart = async ({
+  hosts,
+  keys,
+  identities,
+  proxyProfiles,
+  groupConfigs,
+  knownHosts,
+  terminalSettings,
+  isHostAuthReady,
+  resolveEffectiveHost,
+  updateStoredRuleStatus,
+  recoveryRuleIds,
+}: RunPortForwardingAutoStartOptions): Promise<void> => {
+  await syncWithBackend({
+    shouldReconnect: (ruleId) => isPortForwardingAutoStartEnabled(
+      localStorageAdapter.read<PortForwardingRule[]>(STORAGE_KEY_PORT_FORWARDING) ?? [],
+      ruleId,
+    ),
+    onStatusChange: (ruleId, status, error) => {
+      updateStoredRuleStatus(ruleId, status, error);
+    },
+  });
+
+  const rules = localStorageAdapter.read<PortForwardingRule[]>(
+    STORAGE_KEY_PORT_FORWARDING,
+  ) ?? [];
+  const autoStartRules = rules.filter((rule) =>
+    (!recoveryRuleIds || recoveryRuleIds.has(rule.id)) &&
+    (!recoveryRuleIds || isReconnectRecoveryEligible(rule.id)) &&
+    shouldStartPortForwardingAutoStartRule(rule, getActiveConnection(rule.id)),
+  );
+
+  if (autoStartRules.length === 0) return;
+  logger.info(`[PortForwardingAutoStart] Starting ${autoStartRules.length} auto-start rules`);
+  const effectiveHosts = hosts.map((host) => resolveEffectiveHost(host));
+
+  for (const rule of autoStartRules) {
+    const rawHost = hosts.find((host) => host.id === rule.hostId);
+    const blockReason = getAutoStartRuleBlockReason(
+      rule,
+      hosts,
+      proxyProfiles,
+      groupConfigs,
+      isHostAuthReady,
+    );
+    if (blockReason) {
+      updateStoredRuleStatus(rule.id, "error", blockReason);
+      continue;
+    }
+
+    if (!rawHost) continue;
+    void startPortForward(
+      rule,
+      resolveEffectiveHost(rawHost),
+      effectiveHosts,
+      keys,
+      identities,
+      (status, error) => {
+        updateStoredRuleStatus(rule.id, status, error);
+      },
+      true,
+      terminalSettings,
+      knownHosts,
+    );
+  }
+};
 
 /**
  * Auto-starts port forwarding rules that have autoStart enabled.
@@ -266,6 +402,20 @@ export const usePortForwardingAutoStart = ({
     };
   }, [enabled, isHostAuthReady, resolveEffectiveHost, resolveEffectiveHosts]);
 
+  const runAutoStart = useCallback((recoveryRuleIds?: ReadonlySet<string>) => runPortForwardingAutoStart({
+    hosts: hostsRef.current,
+    keys: keysRef.current,
+    identities: identitiesRef.current,
+    proxyProfiles: proxyProfilesRef.current,
+    groupConfigs: groupConfigsRef.current,
+    knownHosts: knownHostsRef.current,
+    terminalSettings: terminalSettingsRef.current,
+    isHostAuthReady: (host) => isHostAuthReady(host),
+    resolveEffectiveHost,
+    updateStoredRuleStatus,
+    recoveryRuleIds,
+  }), [isHostAuthReady, resolveEffectiveHost, updateStoredRuleStatus]);
+
   // Auto-start rules on app launch
   useEffect(() => {
     if (!enabled) return;
@@ -276,86 +426,18 @@ export const usePortForwardingAutoStart = ({
     // (React StrictMode or dependency changes could cause re-runs)
     autoStartExecutedRef.current = true;
 
-    const runAutoStart = async () => {
-      // First sync with backend to get any active tunnels and subscribe this
-      // renderer to their later disconnect/error events.
-      await syncWithBackend({
-        shouldReconnect: (ruleId) => isPortForwardingAutoStartEnabled(
-          localStorageAdapter.read<PortForwardingRule[]>(STORAGE_KEY_PORT_FORWARDING) ?? [],
-          ruleId,
-        ),
-        onStatusChange: (ruleId, status, error) => {
-          updateStoredRuleStatus(ruleId, status, error);
-        },
-      });
-
-      // Re-read after the async sync so another window's delete or auto-start
-      // change cannot launch a stale rule.
-      const rules = localStorageAdapter.read<PortForwardingRule[]>(
-        STORAGE_KEY_PORT_FORWARDING,
-      ) ?? [];
-
-      // Only start rules that are not already active
-      const autoStartRules = rules.filter((r) => {
-        if (!r.autoStart) return false;
-        // Check if there's an active connection for this rule
-        const conn = getActiveConnection(r.id);
-        // Only start if not already connecting or active
-        return !conn || conn.status === 'inactive' || conn.status === 'error';
-      });
-
-      if (autoStartRules.length === 0) return;
-      logger.info(`[PortForwardingAutoStart] Starting ${autoStartRules.length} auto-start rules`);
-
-      // Start each auto-start rule
-      for (const rule of autoStartRules) {
-        const rawHost = hosts.find((h) => h.id === rule.hostId);
-        const blockReason = getAutoStartRuleBlockReason(
-          rule,
-          hosts,
-          proxyProfiles,
-          groupConfigs,
-          (host) => isHostAuthReady(host),
-        );
-        if (blockReason) {
-          updateStoredRuleStatus(rule.id, "error", blockReason);
-          continue;
-        }
-
-        if (!rawHost) continue;
-        const host = resolveEffectiveHost(rawHost);
-        void startPortForward(
-          rule,
-          host,
-          resolveEffectiveHosts(hosts),
-          keys,
-          identities,
-          (status, error) => {
-            updateStoredRuleStatus(rule.id, status, error);
-          },
-          true, // Enable reconnect for auto-start rules
-          // Read via ref so adjusting global keepalive after launch doesn't
-          // re-trigger the auto-start effect (its dep array is intentionally
-          // stable to fire once on vault init).
-          terminalSettingsRef.current,
-          knownHostsRef.current,
-        );
-      }
-    };
-
     void runAutoStart();
   }, [
-    groupConfigs,
     enabled,
-    hosts,
-    identities,
-    isHostAuthReady,
     isVaultInitialized,
-    keys,
-    knownHosts,
-    proxyProfiles,
-    resolveEffectiveHost,
-    resolveEffectiveHosts,
-    updateStoredRuleStatus,
+    runAutoStart,
   ]);
+
+  // A local outage can consume all bounded SSH retries. Only an explicit
+  // network recovery event starts a fresh retry cycle, so an unreachable
+  // server still stops retrying after the existing limit.
+  useEffect(() => {
+    if (!enabled || !isVaultInitialized || typeof window === "undefined") return;
+    return subscribeToPortForwardingNetworkRecovery(window, runAutoStart);
+  }, [enabled, isVaultInitialized, runAutoStart]);
 };

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -53,6 +53,10 @@ export interface PortForwardingConnection {
 
 // Map to track active connections
 const activeConnections = new Map<string, PortForwardingConnection>();
+// Rules are added only when their bounded automatic reconnect cycle is
+// exhausted. This distinguishes a local-outage failure from a tunnel that the
+// user intentionally stopped while leaving auto-start enabled for next launch.
+const exhaustedReconnectRules = new Set<string>();
 const rulesPendingCleanup = new Set<string>();
 const manualStopsInProgress = new Set<string>();
 const ruleCleanupPromises = new Map<string, Promise<{ success: boolean; error?: string }>>();
@@ -93,6 +97,24 @@ export const clearReconnectTimer = (ruleId: string): void => {
     conn.reconnectDueAt = undefined;
     conn.reconnectTimerCallback = undefined;
   }
+};
+
+/**
+ * Give a failed/retrying auto-start rule a fresh bounded retry cycle after
+ * local network recovery. Returns false for inactive rules that were stopped
+ * manually and therefore must stay stopped until the next app launch.
+ */
+export const resetReconnectAttempts = (ruleId: string): boolean => {
+  const connection = activeConnections.get(ruleId);
+  const shouldRecover = exhaustedReconnectRules.has(ruleId) ||
+    (connection?.reconnectAttempts ?? 0) > 0;
+  if (connection) connection.reconnectAttempts = 0;
+  return shouldRecover;
+};
+
+/** Re-check recovery eligibility after asynchronous backend reconciliation. */
+export const isReconnectRecoveryEligible = (ruleId: string): boolean => {
+  return exhaustedReconnectRules.has(ruleId);
 };
 
 interface PausedReconnectTimer {
@@ -150,6 +172,7 @@ export const initReconnectCancelListener = (): (() => void) => {
   const handler = (e: StorageEvent) => {
     if (e.key !== STORAGE_KEY_PF_RECONNECT_CANCEL || !e.newValue) return;
     const ruleId = e.newValue;
+    exhaustedReconnectRules.delete(ruleId);
     clearReconnectTimer(ruleId);
 
     const conn = activeConnections.get(ruleId);
@@ -204,6 +227,7 @@ const scheduleReconnectIfNeeded = (
     logger.info(`[PortForwardingService] Scheduling reconnect ${attempts}/${MAX_RECONNECT_ATTEMPTS}`);
 
     currentConn.reconnectAttempts = attempts;
+    exhaustedReconnectRules.delete(ruleId);
     const runReconnect = () => {
       if (currentConn.reconnectTimerCallback !== runReconnect) return;
       currentConn.reconnectTimeoutId = undefined;
@@ -226,6 +250,7 @@ const scheduleReconnectIfNeeded = (
   }
 
   logger.warn(`[PortForwardingService] Max reconnect attempts (${MAX_RECONNECT_ATTEMPTS}) reached for rule ${ruleId}`);
+  exhaustedReconnectRules.add(ruleId);
   // Reset reconnect attempts
   if (currentConn) {
     currentConn.reconnectAttempts = 0;
@@ -250,6 +275,7 @@ export const getActiveRuleIds = (): string[] => {
 };
 
 const finishRuleCleanup = (ruleId: string): void => {
+  exhaustedReconnectRules.delete(ruleId);
   rulesPendingCleanup.delete(ruleId);
   deferredReconnects.delete(ruleId);
   clearReconnectTimer(ruleId);
@@ -1028,6 +1054,7 @@ export const startPortForward = async (
     if (conn) {
       conn.reconnectAttempts = 0;
     }
+    exhaustedReconnectRules.delete(rule.id);
     
     return { success: true };
     
@@ -1055,6 +1082,10 @@ export const stopPortForward = async (
 ): Promise<{ success: boolean; error?: string }> => {
   const bridge = netcattyBridge.get();
   const conn = activeConnections.get(ruleId);
+
+  // User intent takes effect immediately. Do not let an already queued network
+  // recovery restart this rule while the backend stop request is still pending.
+  exhaustedReconnectRules.delete(ruleId);
   
   // Clear any pending reconnect timer
   clearReconnectTimer(ruleId);


### PR DESCRIPTION
## Summary

- restart eligible auto-start port forwarding rules when the local network comes back online
- give in-progress auto-start reconnects a fresh bounded retry cycle on network recovery
- keep the existing bounded retry limit for server-side outages
- keep manually stopped tunnels stopped, including when stop and recovery overlap
- avoid duplicate starts when a tunnel is already active or reconnecting
- cover the real backend sync and tunnel start path, duplicate online events, final-attempt recovery, and manual-stop races

## Root cause

Auto-start tunnels retry a failed connection up to five times. If the local network stays offline longer than that retry window, the renderer removes the exhausted connection state. Nothing listened for the later network recovery event, so the rule remained stopped until the user started it manually or restarted Netcatty.

There was also a recovery race when the network came back during the final in-progress attempt. The rule looked busy during the recovery check, but could fail immediately afterward with no retry budget left. Network recovery now refreshes that bounded retry cycle before checking which rules need a new start.

Recovery is limited to rules whose automatic retry cycle was exhausted. A user-initiated stop cancels recovery eligibility immediately, so an overlapping backend sync cannot restart the tunnel.

## Validation

- `node --test --import tsx application/state/usePortForwardingAutoStart.test.ts infrastructure/services/portForwardingService.test.ts` (55 passed)
- `npm run build`
- `npm run lint` (0 errors; 4 pre-existing warnings in untouched files)
- `git diff --check`
- repeated local multi-agent review rounds after each fix; all three reviewers returned `CLEAN` on the final revision

Fixes #2359
