### PR TITLE
fix(tray): 托盘面板会话条目新增关闭按钮

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1151,6 +1151,15 @@ function App({ settings }: { settings: SettingsState }) {
     return { ok: true as const };
   }, [closeSession, sessions]);
 
+  useEffect(() => {
+    if (isPeerSessionWindow) return;
+    const bridge = netcattyBridge.get();
+    const unsubscribe = bridge?.onTrayPanelCloseSession?.((sessionId) => {
+      closeSessionForVaultAgent(sessionId);
+    });
+    return () => unsubscribe?.();
+  }, [isPeerSessionWindow, closeSessionForVaultAgent]);
+
   useVaultAgentBridge({
     hosts,
     snippets,

--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -235,6 +235,7 @@ export const enCoreMessages: Messages = {
   'tray.empty.title': 'Nothing here yet',
   'tray.empty.subtitle': 'Go connect to a server, they miss you 🚀',
   'tray.quit': 'Quit Netcatty',
+  'tray.closeSession': 'Close session',
 
   // Vault Sidebar
   'vault.sidebar.collapse': 'Collapse sidebar',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -223,6 +223,7 @@ export const ruCoreMessages: Messages = {
   'tray.empty.title': 'Пока здесь ничего нет',
   'tray.empty.subtitle': 'Подключитесь к серверу, они по вам скучают 🚀',
   'tray.quit': 'Выйти из Netcatty',
+  'tray.closeSession': 'Закрыть сессию',
 
   // Vault Sidebar
   'vault.sidebar.collapse': 'Свернуть боковую панель',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -232,6 +232,7 @@ export const zhCNCoreMessages: Messages = {
   'tray.empty.title': '一切都很安静',
   'tray.empty.subtitle': '去连接个服务器吧，它们想念你了 🚀',
   'tray.quit': '退出 Netcatty',
+  'tray.closeSession': '关闭会话',
 
   // Vault Sidebar
   'vault.sidebar.collapse': '收起侧边栏',

--- a/application/i18n/locales/zh-TW/core.ts
+++ b/application/i18n/locales/zh-TW/core.ts
@@ -232,6 +232,7 @@ export const zhTWCoreMessages: Messages = {
   'tray.empty.title': '一切都很安靜',
   'tray.empty.subtitle': '去連線個伺服器吧，它們想念你了 🚀',
   'tray.quit': '結束 Netcatty',
+  'tray.closeSession': '關閉工作階段',
 
   // Vault Sidebar
   'vault.sidebar.collapse': '收起側邊欄',

--- a/application/state/useTrayPanelBackend.ts
+++ b/application/state/useTrayPanelBackend.ts
@@ -22,6 +22,11 @@ export const useTrayPanelBackend = () => {
     await bridge?.jumpToSessionFromTrayPanel?.(sessionId);
   }, []);
 
+  const closeSessionFromTrayPanel = useCallback((sessionId: string) => {
+    const bridge = netcattyBridge.get();
+    bridge?.closeSession?.(sessionId);
+  }, []);
+
   const connectToHostFromTrayPanel = useCallback(async (hostId: string) => {
     const bridge = netcattyBridge.get();
     await bridge?.connectToHostFromTrayPanel?.(hostId);
@@ -65,6 +70,7 @@ export const useTrayPanelBackend = () => {
     openMainWindow,
     quitApp,
     jumpToSession,
+    closeSessionFromTrayPanel,
     connectToHostFromTrayPanel,
     onTrayPanelCloseRequest,
     onTrayPanelRefresh,

--- a/application/state/useTrayPanelBackend.ts
+++ b/application/state/useTrayPanelBackend.ts
@@ -22,9 +22,9 @@ export const useTrayPanelBackend = () => {
     await bridge?.jumpToSessionFromTrayPanel?.(sessionId);
   }, []);
 
-  const closeSessionFromTrayPanel = useCallback((sessionId: string) => {
+  const closeSessionFromTrayPanel = useCallback(async (sessionId: string) => {
     const bridge = netcattyBridge.get();
-    bridge?.closeSession?.(sessionId);
+    await bridge?.closeSessionFromTrayPanel?.(sessionId);
   }, []);
 
   const connectToHostFromTrayPanel = useCallback(async (hostId: string) => {

--- a/components/TrayPanel.closeSession.test.ts
+++ b/components/TrayPanel.closeSession.test.ts
@@ -7,9 +7,11 @@ const source = readFileSync(new URL("./TrayPanel.tsx", import.meta.url), "utf8")
 test("tray session close actions are discoverable without mouse hover", () => {
   const keyboardVisible = source.match(/focus-visible:opacity-100/g) ?? [];
   const touchVisible = source.match(/\[@media\(hover:none\)\]:opacity-100/g) ?? [];
+  const centeredActions = source.match(/inline-flex items-center justify-center opacity-0/g) ?? [];
   const labelledActions = source.match(/aria-label=\{t\("tray\.closeSession"\)\}/g) ?? [];
 
   assert.equal(keyboardVisible.length, 2);
   assert.equal(touchVisible.length, 2);
+  assert.equal(centeredActions.length, 2);
   assert.equal(labelledActions.length, 2);
 });

--- a/components/TrayPanel.closeSession.test.ts
+++ b/components/TrayPanel.closeSession.test.ts
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./TrayPanel.tsx", import.meta.url), "utf8");
+
+test("tray session close actions are discoverable without mouse hover", () => {
+  const keyboardVisible = source.match(/focus-visible:opacity-100/g) ?? [];
+  const touchVisible = source.match(/\[@media\(hover:none\)\]:opacity-100/g) ?? [];
+  const labelledActions = source.match(/aria-label=\{t\("tray\.closeSession"\)\}/g) ?? [];
+
+  assert.equal(keyboardVisible.length, 2);
+  assert.equal(touchVisible.length, 2);
+  assert.equal(labelledActions.length, 2);
+});

--- a/components/TrayPanel.tsx
+++ b/components/TrayPanel.tsx
@@ -120,7 +120,7 @@ const WorkspaceGroup: React.FC<{
                       e.stopPropagation();
                       onCloseSession(s.id);
                     }}
-                    className="shrink-0 mr-1 h-6 w-6 rounded opacity-0 group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100 hover:bg-destructive/10 hover:text-destructive text-muted-foreground transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    className="shrink-0 mr-1 h-6 w-6 rounded inline-flex items-center justify-center opacity-0 group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100 hover:bg-destructive/10 hover:text-destructive text-muted-foreground transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                     aria-label={t("tray.closeSession")}
                   >
                     <X size={12} />
@@ -374,7 +374,7 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
                             e.stopPropagation();
                             handleCloseSession(s.id);
                           }}
-                          className="shrink-0 mr-1.5 h-6 w-6 rounded opacity-0 group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100 hover:bg-destructive/10 hover:text-destructive text-muted-foreground transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                          className="shrink-0 mr-1.5 h-6 w-6 rounded inline-flex items-center justify-center opacity-0 group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100 hover:bg-destructive/10 hover:text-destructive text-muted-foreground transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                           aria-label={t("tray.closeSession")}
                         >
                           <X size={12} />

--- a/components/TrayPanel.tsx
+++ b/components/TrayPanel.tsx
@@ -154,7 +154,10 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
   } = useTrayPanelBackend();
 
   const { hosts, keys, identities, proxyProfiles, groupConfigs, knownHosts, updateKnownHosts } = useVaultState();
-  const { closeSession } = useSessionState({ persistSessionRestore: false });
+  // TrayPanel runs in its own BrowserWindow, so this hook's session state is
+  // independent from (and typically empty compared to) the main App's — it's
+  // used here only for its storage-sync side effects, never for closeSession.
+  useSessionState({ persistSessionRestore: false });
   const {
     rules: portForwardingRules,
     startTunnel,
@@ -175,9 +178,10 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
   }, [effectiveKnownHosts, updateKnownHosts]);
 
   const handleCloseSession = useCallback((sessionId: string) => {
-    closeSessionFromTrayPanel(sessionId);
-    closeSession(sessionId);
-  }, [closeSession, closeSessionFromTrayPanel]);
+    // Forwarded to the main window's App-owned closeSession, which is the
+    // instance that actually owns `sessions` and republishes tray menu data.
+    void closeSessionFromTrayPanel(sessionId);
+  }, [closeSessionFromTrayPanel]);
 
   const [traySessions, setTraySessions] = useState<TraySession[]>([]);
 

--- a/components/TrayPanel.tsx
+++ b/components/TrayPanel.tsx
@@ -63,8 +63,9 @@ const WorkspaceGroup: React.FC<{
   sessions: TraySession[];
   activeTabId: string | null;
   jumpToSession: (sessionId: string) => Promise<void>;
+  onCloseSession: (sessionId: string) => void;
   t: (key: string) => string;
-}> = ({ workspaceId, title, sessions, activeTabId, jumpToSession, t }) => {
+}> = ({ workspaceId, title, sessions, activeTabId, jumpToSession, onCloseSession, t }) => {
   const [expanded, setExpanded] = useState(true);
   const isAnyActive = sessions.some((s) => s.id === activeTabId) || activeTabId === workspaceId;
 
@@ -86,31 +87,45 @@ const WorkspaceGroup: React.FC<{
           {sessions.map((s) => (
             <Tooltip key={s.id}>
               <TooltipTrigger asChild>
-                <button
-                  onClick={() => {
-                    // Jump to session (using session id)
-                    void jumpToSession(s.id);
-                  }}
+                <div
                   className={cn(
-                    "w-full text-left px-2 py-1 rounded hover:bg-muted flex items-center justify-between text-sm",
+                    "group w-full rounded hover:bg-muted flex items-center justify-between text-sm",
                     s.status === "connected" ? "" : "text-muted-foreground",
                     activeTabId === s.id ? "bg-muted/60" : "",
                   )}
                 >
-                  <span className="flex items-center gap-2 min-w-0">
-                    <StatusDot
-                      status={s.status === "connected" ? "success" : s.status === "connecting" ? "warning" : "error"}
-                      spinning={s.status === "connecting"}
-                    />
-                    <span className="truncate">{s.hostLabel || s.label}</span>
-                    {s.aiHidden && (
-                      <span className="shrink-0 rounded px-1 py-0.5 text-[10px] font-medium leading-none bg-muted text-muted-foreground">
-                        AI
-                      </span>
-                    )}
-                  </span>
-                  <span className="ml-2 text-xs text-muted-foreground">{t(`tray.status.${s.status}`)}</span>
-                </button>
+                  <button
+                    onClick={() => {
+                      // Jump to session (using session id)
+                      void jumpToSession(s.id);
+                    }}
+                    className="flex-1 min-w-0 text-left px-2 py-1 flex items-center justify-between gap-1"
+                  >
+                    <span className="flex items-center gap-2 min-w-0">
+                      <StatusDot
+                        status={s.status === "connected" ? "success" : s.status === "connecting" ? "warning" : "error"}
+                        spinning={s.status === "connecting"}
+                      />
+                      <span className="truncate">{s.hostLabel || s.label}</span>
+                      {s.aiHidden && (
+                        <span className="shrink-0 rounded px-1 py-0.5 text-[10px] font-medium leading-none bg-muted text-muted-foreground">
+                          AI
+                        </span>
+                      )}
+                    </span>
+                    <span className="ml-2 text-xs text-muted-foreground">{t(`tray.status.${s.status}`)}</span>
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onCloseSession(s.id);
+                    }}
+                    className="shrink-0 mr-1 p-0.5 rounded opacity-0 group-hover:opacity-100 hover:bg-destructive/10 hover:text-destructive text-muted-foreground transition-opacity"
+                    aria-label={t("tray.closeSession")}
+                  >
+                    <X size={12} />
+                  </button>
+                </div>
               </TooltipTrigger>
               <TooltipContent>{s.hostLabel || s.label}</TooltipContent>
             </Tooltip>
@@ -132,13 +147,14 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
     openMainWindow,
     quitApp,
     jumpToSession,
+    closeSessionFromTrayPanel,
     onTrayPanelCloseRequest,
     onTrayPanelRefresh,
     onTrayPanelMenuData,
   } = useTrayPanelBackend();
 
   const { hosts, keys, identities, proxyProfiles, groupConfigs, knownHosts, updateKnownHosts } = useVaultState();
-  useSessionState({ persistSessionRestore: false });
+  const { closeSession } = useSessionState({ persistSessionRestore: false });
   const {
     rules: portForwardingRules,
     startTunnel,
@@ -157,6 +173,11 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
   const handleAddKnownHost = useCallback((knownHost: KnownHost) => {
     updateKnownHosts(upsertKnownHost(effectiveKnownHosts, knownHost));
   }, [effectiveKnownHosts, updateKnownHosts]);
+
+  const handleCloseSession = useCallback((sessionId: string) => {
+    closeSessionFromTrayPanel(sessionId);
+    closeSession(sessionId);
+  }, [closeSession, closeSessionFromTrayPanel]);
 
   const [traySessions, setTraySessions] = useState<TraySession[]>([]);
 
@@ -309,6 +330,7 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
                     sessions={group.sessions}
                     activeTabId={activeTabId}
                     jumpToSession={jumpToSession}
+                    onCloseSession={handleCloseSession}
                     t={t}
                   />
                 ))}
@@ -316,30 +338,44 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
                 {soloSessions.map((s) => (
                   <Tooltip key={s.id}>
                     <TooltipTrigger asChild>
-                      <button
-                        onClick={() => {
-                          void jumpToSession(s.id);
-                        }}
+                      <div
                         className={cn(
-                          "w-full text-left px-2 py-1.5 rounded hover:bg-muted flex items-center justify-between",
+                          "group w-full rounded hover:bg-muted flex items-center justify-between",
                           s.status === "connected" ? "" : "text-muted-foreground",
                           activeTabId === s.id ? "bg-muted" : "",
                         )}
                       >
-                        <span className="flex items-center gap-2 min-w-0">
-                          <StatusDot
-                            status={s.status === "connected" ? "success" : s.status === "connecting" ? "warning" : "error"}
-                            spinning={s.status === "connecting"}
-                          />
-                          <span className="truncate">{s.hostLabel || s.label}</span>
-                          {s.aiHidden && (
-                            <span className="shrink-0 rounded px-1 py-0.5 text-[10px] font-medium leading-none bg-muted text-muted-foreground">
-                              AI
-                            </span>
-                          )}
-                        </span>
-                        <span className="ml-2 text-xs text-muted-foreground">{t(`tray.status.${s.status}`)}</span>
-                      </button>
+                        <button
+                          onClick={() => {
+                            void jumpToSession(s.id);
+                          }}
+                          className="flex-1 min-w-0 text-left px-2 py-1.5 flex items-center justify-between gap-1"
+                        >
+                          <span className="flex items-center gap-2 min-w-0">
+                            <StatusDot
+                              status={s.status === "connected" ? "success" : s.status === "connecting" ? "warning" : "error"}
+                              spinning={s.status === "connecting"}
+                            />
+                            <span className="truncate">{s.hostLabel || s.label}</span>
+                            {s.aiHidden && (
+                              <span className="shrink-0 rounded px-1 py-0.5 text-[10px] font-medium leading-none bg-muted text-muted-foreground">
+                                AI
+                              </span>
+                            )}
+                          </span>
+                          <span className="ml-2 text-xs text-muted-foreground">{t(`tray.status.${s.status}`)}</span>
+                        </button>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleCloseSession(s.id);
+                          }}
+                          className="shrink-0 mr-1.5 p-0.5 rounded opacity-0 group-hover:opacity-100 hover:bg-destructive/10 hover:text-destructive text-muted-foreground transition-opacity"
+                          aria-label={t("tray.closeSession")}
+                        >
+                          <X size={12} />
+                        </button>
+                      </div>
                     </TooltipTrigger>
                     <TooltipContent>{s.hostLabel || s.label}</TooltipContent>
                   </Tooltip>

--- a/components/TrayPanel.tsx
+++ b/components/TrayPanel.tsx
@@ -120,7 +120,7 @@ const WorkspaceGroup: React.FC<{
                       e.stopPropagation();
                       onCloseSession(s.id);
                     }}
-                    className="shrink-0 mr-1 p-0.5 rounded opacity-0 group-hover:opacity-100 hover:bg-destructive/10 hover:text-destructive text-muted-foreground transition-opacity"
+                    className="shrink-0 mr-1 h-6 w-6 rounded opacity-0 group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100 hover:bg-destructive/10 hover:text-destructive text-muted-foreground transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                     aria-label={t("tray.closeSession")}
                   >
                     <X size={12} />
@@ -374,7 +374,7 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
                             e.stopPropagation();
                             handleCloseSession(s.id);
                           }}
-                          className="shrink-0 mr-1.5 p-0.5 rounded opacity-0 group-hover:opacity-100 hover:bg-destructive/10 hover:text-destructive text-muted-foreground transition-opacity"
+                          className="shrink-0 mr-1.5 h-6 w-6 rounded opacity-0 group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100 hover:bg-destructive/10 hover:text-destructive text-muted-foreground transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                           aria-label={t("tray.closeSession")}
                         >
                           <X size={12} />

--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -1014,6 +1014,11 @@ function registerHandlers(ipcMain) {
     return { success: true };
   });
 
+  ipcMain.handle("netcatty:trayPanel:closeSession", async (_event, sessionId) => {
+    await sendToMainWindow("netcatty:trayPanel:closeSession", sessionId);
+    return { success: true };
+  });
+
   ipcMain.handle("netcatty:trayPanel:quitApp", async () => {
     const { app } = electronModule;
     closeToTray = false;

--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -217,12 +217,14 @@ async function openMainWindowReady() {
   return win;
 }
 
-async function sendToMainWindow(channel, ...args) {
+async function sendToMainWindow(channel, payload, { focus = true } = {}) {
   const { win } = await getOrCreateMainWindow();
-  bringMainWindowToForeground(win);
+  if (focus) {
+    bringMainWindowToForeground(win);
+  }
   try {
     if (typeof sendWhenRendererReady === "function") {
-      const result = await sendWhenRendererReady(win, channel, args[0], { timeoutMs: 8000 });
+      const result = await sendWhenRendererReady(win, channel, payload, { timeoutMs: 8000 });
       if (!result?.success) {
         console.warn(
           `[GlobalShortcut] Failed to deliver ${channel} to main window:`,
@@ -231,7 +233,7 @@ async function sendToMainWindow(channel, ...args) {
       }
       return;
     }
-    win?.webContents?.send(channel, ...args);
+    win?.webContents?.send(channel, payload);
   } catch {
     // ignore
   }
@@ -248,6 +250,15 @@ function getTrayPanelUrl() {
     return `${devServerUrl.replace(/\/$/, "")}/#/tray`;
   }
   return "app://netcatty/index.html#/tray";
+}
+
+function pushTrayMenuDataToPanel() {
+  if (!trayPanelWindow || trayPanelWindow.isDestroyed()) return;
+  try {
+    trayPanelWindow.webContents?.send("netcatty:trayPanel:setMenuData", trayMenuData);
+  } catch {
+    // ignore
+  }
 }
 
 function ensureTrayPanelWindow() {
@@ -294,11 +305,7 @@ function ensureTrayPanelWindow() {
   void trayPanelWindow.loadURL(url);
 
   trayPanelWindow.webContents.on("did-finish-load", () => {
-    try {
-      trayPanelWindow?.webContents?.send("netcatty:trayPanel:setMenuData", trayMenuData);
-    } catch {
-      // ignore
-    }
+    pushTrayMenuDataToPanel();
   });
 
   return trayPanelWindow;
@@ -324,11 +331,7 @@ function showTrayPanel() {
   win.show();
   win.focus();
 
-  try {
-    win.webContents?.send("netcatty:trayPanel:setMenuData", trayMenuData);
-  } catch {
-    // ignore
-  }
+  pushTrayMenuDataToPanel();
 
   if (trayPanelRefreshTimer) clearInterval(trayPanelRefreshTimer);
   trayPanelRefreshTimer = setInterval(() => {
@@ -892,6 +895,7 @@ function setTrayMenuData(data) {
   // Rebuild menu with new data
   updateTrayMenu();
   updateDockMenu();
+  pushTrayMenuDataToPanel();
 }
 
 /**
@@ -1015,7 +1019,7 @@ function registerHandlers(ipcMain) {
   });
 
   ipcMain.handle("netcatty:trayPanel:closeSession", async (_event, sessionId) => {
-    await sendToMainWindow("netcatty:trayPanel:closeSession", sessionId);
+    await sendToMainWindow("netcatty:trayPanel:closeSession", sessionId, { focus: false });
     return { success: true };
   });
 

--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -217,8 +217,11 @@ async function openMainWindowReady() {
   return win;
 }
 
-async function sendToMainWindow(channel, payload, { focus = true } = {}) {
-  const { win } = await getOrCreateMainWindow();
+async function sendToMainWindow(channel, payload, { focus = true, createIfMissing = true } = {}) {
+  const { win } = createIfMissing
+    ? await getOrCreateMainWindow()
+    : { win: getTrackedMainWindow() };
+  if (!win) return false;
   if (focus) {
     bringMainWindowToForeground(win);
   }
@@ -231,11 +234,12 @@ async function sendToMainWindow(channel, payload, { focus = true } = {}) {
           result?.error || result?.reason || "unknown",
         );
       }
-      return;
+      return result?.success === true;
     }
-    win?.webContents?.send(channel, payload);
+    win.webContents?.send(channel, payload);
+    return true;
   } catch {
-    // ignore
+    return false;
   }
 }
 
@@ -1019,8 +1023,13 @@ function registerHandlers(ipcMain) {
   });
 
   ipcMain.handle("netcatty:trayPanel:closeSession", async (_event, sessionId) => {
-    await sendToMainWindow("netcatty:trayPanel:closeSession", sessionId, { focus: false });
-    return { success: true };
+    const delivered = await sendToMainWindow("netcatty:trayPanel:closeSession", sessionId, {
+      focus: false,
+      createIfMissing: false,
+    });
+    return delivered
+      ? { success: true }
+      : { success: false, error: "Main window is not available" };
   });
 
   ipcMain.handle("netcatty:trayPanel:quitApp", async () => {

--- a/electron/bridges/globalShortcutBridge.test.cjs
+++ b/electron/bridges/globalShortcutBridge.test.cjs
@@ -936,6 +936,31 @@ test("tray panel session close forwards without focusing the main window", async
   });
 });
 
+test("tray panel session close does not create a missing main window", async () => {
+  await withPlatform("darwin", async () => {
+    const bridge = loadBridge();
+    const electronModule = createElectronStub();
+    electronModule.BrowserWindow.getAllWindows = () => [];
+    let createCalls = 0;
+
+    bridge.init({
+      electronModule,
+      getMainWindow: () => null,
+      ensureMainWindow: async () => {
+        createCalls += 1;
+        return new FakeWindow();
+      },
+    });
+    const ipcMain = createIpcMainStub();
+    bridge.registerHandlers(ipcMain);
+
+    const result = await ipcMain.handlers.get("netcatty:trayPanel:closeSession")(null, "stale-session");
+
+    assert.deepEqual(result, { success: false, error: "Main window is not available" });
+    assert.equal(createCalls, 0);
+  });
+});
+
 test("tray menu updates refresh an already open tray panel", async () => {
   await withPlatform("darwin", async () => {
     const bridge = loadBridge();

--- a/electron/bridges/globalShortcutBridge.test.cjs
+++ b/electron/bridges/globalShortcutBridge.test.cjs
@@ -893,23 +893,31 @@ test("tray panel session jump waits for a newly created main window to be ready"
   });
 });
 
-test("tray panel session close forwards to the main window", async () => {
+test("tray panel session close forwards without focusing the main window", async () => {
   await withPlatform("darwin", async () => {
     const bridge = loadBridge();
     const electronModule = createElectronStub();
     const sentMessages = [];
-    const createdWin = new FakeWindow();
-    createdWin.webContents = {
+    const mainWin = new FakeWindow();
+    mainWin.visible = false;
+    mainWin.focused = false;
+    mainWin.webContents = {
       send(channel, ...args) {
         sentMessages.push([channel, ...args]);
       },
     };
-    electronModule.BrowserWindow.getAllWindows = () => [];
+    electronModule.BrowserWindow.getAllWindows = () => [mainWin];
+    let createCalls = 0;
 
     bridge.init({
       electronModule,
-      ensureMainWindow: async () => createdWin,
+      getMainWindow: () => mainWin,
+      ensureMainWindow: async () => {
+        createCalls += 1;
+        return mainWin;
+      },
       sendWhenRendererReady: async (win, channel, payload) => {
+        assert.equal(win, mainWin);
         win.webContents.send(channel, payload);
         return { success: true };
       },
@@ -921,6 +929,56 @@ test("tray panel session close forwards to the main window", async () => {
 
     assert.deepEqual(result, { success: true });
     assert.deepEqual(sentMessages, [["netcatty:trayPanel:closeSession", "session-1"]]);
+    assert.equal(createCalls, 0);
+    assert.equal(mainWin.showCalls, 0);
+    assert.equal(mainWin.focusCalls, 0);
+    assert.equal(mainWin.isVisible(), false);
+  });
+});
+
+test("tray menu updates refresh an already open tray panel", async () => {
+  await withPlatform("darwin", async () => {
+    const bridge = loadBridge();
+    const electronModule = createElectronStub();
+    const sentMessages = [];
+
+    class FakePanelWindow extends FakeWindow {
+      constructor() {
+        super();
+        const webContents = new EventEmitter();
+        webContents.send = (channel, ...args) => {
+          sentMessages.push([channel, ...args]);
+        };
+        this.webContents = webContents;
+      }
+
+      async loadURL() {}
+      getBounds() { return { width: 360, height: 520 }; }
+      setBounds() {}
+      destroy() { this.destroyed = true; }
+    }
+
+    FakePanelWindow.getAllWindows = () => [];
+    electronModule.BrowserWindow = FakePanelWindow;
+    electronModule.screen = {
+      getDisplayNearestPoint: () => ({ workArea: { x: 0, y: 0, width: 1440, height: 900 } }),
+    };
+
+    const { ipcMain } = await enableCloseToTray(bridge, electronModule);
+    const trayInstance = bridge.getTray();
+    trayInstance.getBounds = () => ({ x: 100, y: 0, width: 24, height: 24 });
+    trayInstance.handlers.get("click")();
+
+    sentMessages.length = 0;
+    const sessions = [{ id: "remaining", label: "Remaining", status: "connected" }];
+    await ipcMain.handlers.get("netcatty:tray:updateMenuData")(null, { sessions });
+
+    assert.deepEqual(sentMessages, [["netcatty:trayPanel:setMenuData", {
+      sessions,
+      portForwardRules: [],
+      hosts: [],
+    }]]);
+    bridge.cleanup();
   });
 });
 

--- a/electron/bridges/globalShortcutBridge.test.cjs
+++ b/electron/bridges/globalShortcutBridge.test.cjs
@@ -893,6 +893,37 @@ test("tray panel session jump waits for a newly created main window to be ready"
   });
 });
 
+test("tray panel session close forwards to the main window", async () => {
+  await withPlatform("darwin", async () => {
+    const bridge = loadBridge();
+    const electronModule = createElectronStub();
+    const sentMessages = [];
+    const createdWin = new FakeWindow();
+    createdWin.webContents = {
+      send(channel, ...args) {
+        sentMessages.push([channel, ...args]);
+      },
+    };
+    electronModule.BrowserWindow.getAllWindows = () => [];
+
+    bridge.init({
+      electronModule,
+      ensureMainWindow: async () => createdWin,
+      sendWhenRendererReady: async (win, channel, payload) => {
+        win.webContents.send(channel, payload);
+        return { success: true };
+      },
+    });
+    const ipcMain = createIpcMainStub();
+    bridge.registerHandlers(ipcMain);
+
+    const result = await ipcMain.handlers.get("netcatty:trayPanel:closeSession")(null, "session-1");
+
+    assert.deepEqual(result, { success: true });
+    assert.deepEqual(sentMessages, [["netcatty:trayPanel:closeSession", "session-1"]]);
+  });
+});
+
 test("toggleWindowVisibility show path delegates to showAndFocusMainWindow on win32", async () => {
   await withPlatform("win32", async () => {
     const windowManagerPath = require.resolve("./windowManager.cjs");

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -1071,6 +1071,11 @@ function createPreloadApi(ctx) {
     ipcRenderer.on("netcatty:trayPanel:connectToHost", handler);
     return () => ipcRenderer.removeListener("netcatty:trayPanel:connectToHost", handler);
   },
+  onTrayPanelCloseSession: (callback) => {
+    const handler = (_event, sessionId) => callback(sessionId);
+    ipcRenderer.on("netcatty:trayPanel:closeSession", handler);
+    return () => ipcRenderer.removeListener("netcatty:trayPanel:closeSession", handler);
+  },
 
   // Tray panel window
   hideTrayPanel: () => ipcRenderer.invoke("netcatty:trayPanel:hide"),
@@ -1080,6 +1085,8 @@ function createPreloadApi(ctx) {
     ipcRenderer.invoke("netcatty:trayPanel:jumpToSession", sessionId),
   connectToHostFromTrayPanel: (hostId) =>
     ipcRenderer.invoke("netcatty:trayPanel:connectToHost", hostId),
+  closeSessionFromTrayPanel: (sessionId) =>
+    ipcRenderer.invoke("netcatty:trayPanel:closeSession", sessionId),
   onTrayPanelCloseRequest: (callback) => {
     const handler = () => callback();
     ipcRenderer.on("netcatty:trayPanel:closeRequest", handler);

--- a/types/global/netcatty-bridge-app.d.ts
+++ b/types/global/netcatty-bridge-app.d.ts
@@ -93,12 +93,14 @@ declare global {
 
     onTrayPanelJumpToSession?(callback: (sessionId: string) => void): () => void;
     onTrayPanelConnectToHost?(callback: (hostId: string) => void): () => void;
+    onTrayPanelCloseSession?(callback: (sessionId: string) => void): () => void;
 
     hideTrayPanel?(): Promise<{ success: boolean }>;
     openMainWindow?(): Promise<{ success: boolean }>;
     quitApp?(): Promise<{ success: boolean }>;
     jumpToSessionFromTrayPanel?(sessionId: string): Promise<{ success: boolean }>;
     connectToHostFromTrayPanel?(hostId: string): Promise<{ success: boolean }>;
+    closeSessionFromTrayPanel?(sessionId: string): Promise<{ success: boolean }>;
     onTrayPanelCloseRequest?(callback: () => void): () => void;
     onTrayPanelRefresh?(callback: () => void): () => void;
     onTrayPanelMenuData?(callback: (data: {


### PR DESCRIPTION
## 背景

在实机验证 [PR #2345](https://github.com/binaricat/Netcatty/pull/2345)（AI 会话静默运行）时发现的可用性缺口：托盘面板（TrayPanel）里的每个会话条目此前只支持点击跳转到主窗口，没有直接关闭会话的入口。

对于 AI 静默会话（隐藏在标签栏之外）尤其不便：用户在托盘"偷看一眼"某个会话在做什么后，如果想关闭它，只能先点击跳转、把它变成可见标签，再去主窗口找关闭按钮——这个额外步骤跟静默会话"不打扰用户、在后台安静运行"的设计初衷相悖。

## 改动内容

给 TrayPanel 里 workspace 分组内的会话条目和独立（solo）会话条目，均新增一个悬停时出现的关闭按钮：

- 复用主窗口 / MCP `session_close` 同款的两段式关闭流程：先通过 `netcattyBridge` 通知主进程真正断开 PTY 连接，再从 React 状态里移除该会话
- 点击关闭按钮时阻止事件冒泡，避免同时触发"跳转到该会话"的点击行为
- 新增 `useTrayPanelBackend` 的 `closeSessionFromTrayPanel` 方法（遵循项目既有的"组件不直接 import infrastructure/services，走 application/state hooks"约束）
- 补充英/简中/繁中/俄四语言的 `tray.closeSession` 文案

## 测试

- `npx eslint`：0 error/warning
- `npx tsc --noEmit`：无新增类型错误
- 相关测试全部通过（`sessionRestoreSettings.test.ts` 里对 `TrayPanel.tsx` 源码的文本断言、`AppHandlers.connect.test.ts`、`PortForwardHostKeyDialog.test.ts`，共 25 条）

🤖 Generated with [Claude Code](https://claude.com/claude-code)