### PR TITLE
Fix quick switcher selection and workspace creation UX

### DIFF
--- a/components/AddToWorkspaceDialog.keyboard.test.ts
+++ b/components/AddToWorkspaceDialog.keyboard.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  getWorkspaceTargetRowStateClass,
+  shouldToggleWorkspaceTarget,
+} from './workspace/AddToWorkspaceDialog';
+
+test('space toggles the current target when the search is empty', () => {
+  assert.equal(shouldToggleWorkspaceTarget(' ', '', false, false), true);
+});
+
+test('space remains available inside a non-empty search query', () => {
+  assert.equal(shouldToggleWorkspaceTarget(' ', 'database server', false, false), false);
+});
+
+test('plain Enter toggles while modified Enter remains the commit shortcut', () => {
+  assert.equal(shouldToggleWorkspaceTarget('Enter', '', false, false), true);
+  assert.equal(shouldToggleWorkspaceTarget('Enter', '', true, false), false);
+  assert.equal(shouldToggleWorkspaceTarget('Enter', '', false, true), false);
+});
+
+test('checked targets keep a visible background after the cursor moves away', () => {
+  assert.equal(getWorkspaceTargetRowStateClass(false, false), 'hover:bg-muted/50');
+  assert.equal(getWorkspaceTargetRowStateClass(true, false), 'bg-primary/15');
+  assert.equal(getWorkspaceTargetRowStateClass(false, true), 'bg-primary/10');
+  assert.equal(getWorkspaceTargetRowStateClass(true, true), 'bg-primary/20');
+});

--- a/components/AddToWorkspaceDialog.keyboard.test.ts
+++ b/components/AddToWorkspaceDialog.keyboard.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import {
@@ -25,4 +26,15 @@ test('checked targets keep a visible background after the cursor moves away', ()
   assert.equal(getWorkspaceTargetRowStateClass(true, false), 'bg-primary/15');
   assert.equal(getWorkspaceTargetRowStateClass(false, true), 'bg-primary/10');
   assert.equal(getWorkspaceTargetRowStateClass(true, true), 'bg-primary/20');
+});
+
+test('clicking a target aligns the keyboard cursor with that target', () => {
+  const source = readFileSync(
+    new URL('./workspace/AddToWorkspaceDialog.tsx', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(source, /onClick=\{\(\) => handleTargetClick\(idx, LOCAL_ITEM_ID\)\}/);
+  assert.match(source, /onClick=\{\(\) => handleTargetClick\(idx, host\.id\)\}/);
+  assert.match(source, /handleTargetClick[\s\S]*inputRef\.current\?\.focus\(\)/);
 });

--- a/components/QuickSwitcher.pluginContributions.test.tsx
+++ b/components/QuickSwitcher.pluginContributions.test.tsx
@@ -1,7 +1,44 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { buildPluginPaletteItems } from './QuickSwitcher';
+import {
+  buildPluginPaletteItems,
+  getQuickSwitcherRowStateClass,
+  shouldUseQuickSwitcherPointerNavigation,
+} from './QuickSwitcher';
+
+test('keeps the new workspace action outside the scrollable results', () => {
+  const source = readFileSync(new URL('./QuickSwitcher.tsx', import.meta.url), 'utf8');
+  const actionIndex = source.indexOf('{/* Jump To hint + New Workspace action */}');
+  const resultsScrollIndex = source.indexOf('<ScrollArea className="flex-1 h-full">');
+
+  assert.notEqual(actionIndex, -1);
+  assert.notEqual(resultsScrollIndex, -1);
+  assert.ok(actionIndex < resultsScrollIndex);
+});
+
+test('pointer hover never rewrites the keyboard selection', () => {
+  const quickSwitcherSource = readFileSync(new URL('./QuickSwitcher.tsx', import.meta.url), 'utf8');
+  const workspacePickerSource = readFileSync(new URL('./workspace/AddToWorkspaceDialog.tsx', import.meta.url), 'utf8');
+
+  assert.doesNotMatch(quickSwitcherSource, /onMouseEnter/);
+  assert.doesNotMatch(quickSwitcherSource, /selectWithPointer/);
+  assert.doesNotMatch(workspacePickerSource, /onMouseEnter/);
+  assert.doesNotMatch(workspacePickerSource, /onMouseMove/);
+});
+
+test('keyboard navigation shows only the current keyboard selection', () => {
+  assert.equal(getQuickSwitcherRowStateClass(true, true), 'bg-primary/15');
+  assert.equal(getQuickSwitcherRowStateClass(false, true), '');
+  assert.equal(getQuickSwitcherRowStateClass(false, false), 'hover:bg-muted/50');
+});
+
+test('layout movement under a stationary pointer cannot take over keyboard navigation', () => {
+  assert.equal(shouldUseQuickSwitcherPointerNavigation(0, 0), false);
+  assert.equal(shouldUseQuickSwitcherPointerNavigation(1, 0), true);
+  assert.equal(shouldUseQuickSwitcherPointerNavigation(0, -1), true);
+});
 
 function pluginSnapshot(menuEnabled: boolean): NetcattyPluginContributionSnapshot['plugins'] {
   return [{

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -35,6 +35,21 @@ type QuickSwitcherItem = QuickSwitcherItemBase & (
   | { type: "host" | "tab" | "workspace" | "action" | "shell" | "plugin-view"; commandId?: never }
 );
 
+export function getQuickSwitcherRowStateClass(
+  isSelected: boolean,
+  isKeyboardNavigating: boolean,
+): string {
+  if (isSelected) return "bg-primary/15";
+  return isKeyboardNavigating ? "" : "hover:bg-muted/50";
+}
+
+export function shouldUseQuickSwitcherPointerNavigation(
+  movementX: number,
+  movementY: number,
+): boolean {
+  return movementX !== 0 || movementY !== 0;
+}
+
 export function buildPluginPaletteItems(
   plugins: NetcattyPluginContributionSnapshot['plugins'],
   trimmedQuery: string,
@@ -97,22 +112,20 @@ const IS_MAC = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(naviga
 const HostItem = memo(({
   host,
   isSelected,
+  isKeyboardNavigating,
   selectedItemRef,
   onSelect,
-  onMouseEnter,
 }: {
   host: Host;
   isSelected: boolean;
+  isKeyboardNavigating: boolean;
   selectedItemRef?: React.RefCallback<HTMLDivElement>;
   onSelect: (host: Host) => void;
-  onMouseEnter: () => void;
 }) => (
   <div
     ref={selectedItemRef}
-    className={`flex items-center justify-between px-4 py-2.5 cursor-pointer transition-colors ${isSelected ? "bg-primary/15" : "hover:bg-muted/50"
-      }`}
+    className={`flex items-center justify-between px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`}
     onClick={() => onSelect(host)}
-    onMouseEnter={onMouseEnter}
   >
     <div className="flex items-center gap-3 min-w-0">
       <DistroAvatar
@@ -193,11 +206,19 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
   }, [keyBindings]);
   const quickSwitchKey = getHotkeyLabel('quick-switch');
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [isKeyboardNavigating, setIsKeyboardNavigating] = useState(true);
+  const isKeyboardNavigatingRef = useRef(true);
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const selectedItemRef = useRef<HTMLElement>(null);
   const setSelectedItemRef = useCallback((element: HTMLElement | null) => {
     selectedItemRef.current = element;
+  }, []);
+  const handlePointerHover = useCallback((movementX: number, movementY: number) => {
+    if (!shouldUseQuickSwitcherPointerNavigation(movementX, movementY)) return;
+    if (!isKeyboardNavigatingRef.current) return;
+    isKeyboardNavigatingRef.current = false;
+    setIsKeyboardNavigating(false);
   }, []);
 
   // Reset state when opening
@@ -209,6 +230,8 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
     }, 50);
 
     setSelectedIndex(0);
+    isKeyboardNavigatingRef.current = true;
+    setIsKeyboardNavigating(true);
 
     return () => {
       window.clearTimeout(focusTimer);
@@ -342,9 +365,13 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
+      isKeyboardNavigatingRef.current = true;
+      setIsKeyboardNavigating(true);
       setSelectedIndex((prev) => Math.min(prev + 1, flatItems.length - 1));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
+      isKeyboardNavigatingRef.current = true;
+      setIsKeyboardNavigating(true);
       setSelectedIndex((prev) => Math.max(prev - 1, 0));
     } else if (e.key === "Enter" && flatItems.length > 0) {
       e.preventDefault();
@@ -403,6 +430,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
         ref={containerRef}
         className="w-full max-w-2xl mx-4 bg-background border border-border rounded-xl shadow-2xl overflow-hidden max-h-[520px] flex flex-col"
         style={{ pointerEvents: "auto" }}
+        onMouseMove={(event) => handlePointerHover(event.movementX, event.movementY)}
       >
         {/* Search Header */}
         <div className="flex items-center gap-3 px-4 py-3 border-b border-border">
@@ -413,6 +441,8 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
             onChange={(e) => {
               onQueryChange(e.target.value);
               setSelectedIndex(0);
+              isKeyboardNavigatingRef.current = true;
+              setIsKeyboardNavigating(true);
             }}
             onKeyDown={handleKeyDown}
             placeholder={t("qs.search.placeholder")}
@@ -425,32 +455,32 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
           )}
         </div>
 
+        {/* Jump To hint + New Workspace action */}
+        <div className="flex shrink-0 items-center gap-2 border-b border-border/60 px-4 py-2">
+          <span className="text-xs text-muted-foreground">{t("qs.jumpTo")}</span>
+          {quickSwitchKey && (
+            <kbd className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded">
+              {quickSwitchKey.replace(/ \+ /g, '+')}
+            </kbd>
+          )}
+          {onCreateWorkspace && (
+            <button
+              type="button"
+              onClick={() => {
+                onCreateWorkspace();
+                onClose();
+              }}
+              className="ml-auto inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground border border-border rounded px-1.5 py-0.5 transition-colors hover:bg-muted/50"
+            >
+              <Plus size={11} />
+              <span>New Workspace</span>
+            </button>
+          )}
+        </div>
+
         <ScrollArea className="flex-1 h-full">
           {/* Categorized view: Hosts/Tabs/Quick connect */}
           <div>
-            {/* Jump To hint + New Workspace action */}
-            <div className="px-4 py-2 flex items-center gap-2">
-              <span className="text-xs text-muted-foreground">{t("qs.jumpTo")}</span>
-              {quickSwitchKey && (
-                <kbd className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded">
-                  {quickSwitchKey.replace(/ \+ /g, '+')}
-                </kbd>
-              )}
-              {onCreateWorkspace && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    onCreateWorkspace();
-                    onClose();
-                  }}
-                  className="ml-auto inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground border border-border rounded px-1.5 py-0.5 transition-colors hover:bg-muted/50"
-                >
-                  <Plus size={11} />
-                  <span>New Workspace</span>
-                </button>
-              )}
-            </div>
-
             {/* Hosts section */}
             {results.length > 0 && (
               <div>
@@ -464,9 +494,9 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                     key={host.id}
                     host={host}
                     isSelected={getItemIndex("host", host.id) === selectedIndex}
+                    isKeyboardNavigating={isKeyboardNavigating}
                     selectedItemRef={getItemIndex("host", host.id) === selectedIndex ? setSelectedItemRef : undefined}
                     onSelect={onSelect}
-                    onMouseEnter={() => setSelectedIndex(getItemIndex("host", host.id))}
                   />
                 ))}
               </div>
@@ -496,13 +526,11 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                   <div
                     key={tabId}
                     ref={isSelected ? setSelectedItemRef : undefined}
-                    className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${isSelected ? "bg-primary/15" : "hover:bg-muted/50"
-                      }`}
+                    className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`}
                     onClick={() => {
                       onSelectTab(tabId);
                       onClose();
                     }}
-                    onMouseEnter={() => setSelectedIndex(idx)}
                   >
                     <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
                       {icon}
@@ -521,13 +549,11 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                   <div
                     key={workspace.id}
                     ref={isSelected ? setSelectedItemRef : undefined}
-                    className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${isSelected ? "bg-primary/15" : "hover:bg-muted/50"
-                      }`}
+                    className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`}
                     onClick={() => {
                       onSelectTab(workspace.id);
                       onClose();
                     }}
-                    onMouseEnter={() => setSelectedIndex(idx)}
                   >
                     <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
                       <LayoutGrid size={16} />
@@ -548,13 +574,11 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                   <div
                     key={session.id}
                     ref={isSelected ? setSelectedItemRef : undefined}
-                    className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${isSelected ? "bg-primary/15" : "hover:bg-muted/50"
-                      }`}
+                    className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`}
                     onClick={() => {
                       onSelectTab(session.id);
                       onClose();
                     }}
-                    onMouseEnter={() => setSelectedIndex(idx)}
                   >
                     <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
                       <TerminalSquare size={16} />
@@ -583,16 +607,13 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                     <div
                       key={shell.id}
                       ref={isSelected ? setSelectedItemRef : undefined}
-                      className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${
-                        isSelected ? "bg-primary/15" : "hover:bg-muted/50"
-                      }`}
+                      className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`}
                       onClick={() => {
                         if (onCreateLocalTerminal) {
                           onCreateLocalTerminal({ command: shell.command, args: shell.args, name: shell.name, icon: shell.icon });
                           onClose();
                         }
                       }}
-                      onMouseEnter={() => setSelectedIndex(idx)}
                     >
                       <img
                         src={getShellIconPath(shell.icon)}
@@ -618,18 +639,14 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                 </div>
                 <div
                   ref={getItemIndex("action", "local-terminal") === selectedIndex ? setSelectedItemRef : undefined}
-                  className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${
-                    getItemIndex("action", "local-terminal") === selectedIndex
-                      ? "bg-primary/15"
-                      : "hover:bg-muted/50"
-                  }`}
+                  className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(
+                    getItemIndex("action", "local-terminal") === selectedIndex,
+                    isKeyboardNavigating,
+                  )}`}
                   onClick={() => {
                     onCreateLocalTerminal();
                     onClose();
                   }}
-                  onMouseEnter={() =>
-                    setSelectedIndex(getItemIndex("action", "local-terminal"))
-                  }
                 >
                   <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
                     <Terminal size={16} />
@@ -653,9 +670,8 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                       key={`${item.type}:${item.id}`}
                       ref={isSelected ? setSelectedItemRef : undefined}
                       disabled={item.enabled === false}
-                      className={`flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors ${isSelected ? 'bg-primary/15' : 'hover:bg-muted/50'} disabled:opacity-50`}
+                      className={`flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)} disabled:opacity-50`}
                       onClick={(event) => handleItemSelect(item, event.altKey)}
-                      onMouseEnter={() => setSelectedIndex(idx)}
                     >
                       <div className="flex h-6 w-6 items-center justify-center text-muted-foreground">
                         <PluginContributionIcon pluginId={item.pluginId} icon={item.icon} size={16} />

--- a/components/workspace/AddToWorkspaceDialog.tsx
+++ b/components/workspace/AddToWorkspaceDialog.tsx
@@ -124,6 +124,12 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
     });
   };
 
+  const handleTargetClick = (index: number, id: string) => {
+    setSelectedIndex(index);
+    toggle(id);
+    inputRef.current?.focus();
+  };
+
   const handleCommit = () => {
     if (selected.size === 0) return;
     const targets: AddTarget[] = [];
@@ -223,7 +229,7 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
                   return (
                     <div
                       className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getWorkspaceTargetRowStateClass(isCursor, isChecked)}`}
-                      onClick={() => toggle(LOCAL_ITEM_ID)}
+                      onClick={() => handleTargetClick(idx, LOCAL_ITEM_ID)}
                     >
                       <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
                         <Terminal size={16} />
@@ -250,7 +256,7 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
                     <div
                       key={host.id}
                       className={`flex items-center justify-between px-4 py-2.5 cursor-pointer transition-colors ${getWorkspaceTargetRowStateClass(isCursor, isChecked)}`}
-                      onClick={() => toggle(host.id)}
+                      onClick={() => handleTargetClick(idx, host.id)}
                     >
                       <div className="flex items-center gap-3 min-w-0">
                         <DistroAvatar host={host} fallback={(host.label || host.hostname).slice(0, 2).toUpperCase()} size="sm" />

--- a/components/workspace/AddToWorkspaceDialog.tsx
+++ b/components/workspace/AddToWorkspaceDialog.tsx
@@ -30,6 +30,26 @@ type Item =
   | { type: 'local'; id: typeof LOCAL_ITEM_ID }
   | { type: 'host'; id: string; host: Host };
 
+export function shouldToggleWorkspaceTarget(
+  key: string,
+  query: string,
+  metaKey: boolean,
+  ctrlKey: boolean,
+): boolean {
+  if (metaKey || ctrlKey) return false;
+  return key === 'Enter' || (key === ' ' && query.length === 0);
+}
+
+export function getWorkspaceTargetRowStateClass(
+  isCursor: boolean,
+  isChecked: boolean,
+): string {
+  if (isCursor && isChecked) return 'bg-primary/20';
+  if (isCursor) return 'bg-primary/15';
+  if (isChecked) return 'bg-primary/10';
+  return 'hover:bg-muted/50';
+}
+
 export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
   open,
   onOpenChange,
@@ -128,7 +148,7 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       setSelectedIndex((i) => Math.max(i - 1, 0));
-    } else if (e.key === 'Enter' && !(e.metaKey || e.ctrlKey)) {
+    } else if (shouldToggleWorkspaceTarget(e.key, query, e.metaKey, e.ctrlKey)) {
       if (items.length === 0) return;
       e.preventDefault();
       toggle(items[selectedIndex].id);
@@ -180,7 +200,7 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
             {/* Jump-to hint */}
             <div className="px-4 py-2 flex items-center gap-2">
               <span className="text-xs text-muted-foreground">Pick one or more</span>
-              <kbd className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded">Enter</kbd>
+              <kbd className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded">Space / Enter</kbd>
               <span className="text-[10px] text-muted-foreground">toggle</span>
               <kbd className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded">
                 {typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform) ? '⌘' : 'Ctrl'}+Enter
@@ -202,9 +222,8 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
                   const isChecked = selected.has(LOCAL_ITEM_ID);
                   return (
                     <div
-                      className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${isCursor ? 'bg-primary/15' : 'hover:bg-muted/50'}`}
+                      className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getWorkspaceTargetRowStateClass(isCursor, isChecked)}`}
                       onClick={() => toggle(LOCAL_ITEM_ID)}
-                      onMouseEnter={() => setSelectedIndex(idx)}
                     >
                       <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
                         <Terminal size={16} />
@@ -230,9 +249,8 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
                   return (
                     <div
                       key={host.id}
-                      className={`flex items-center justify-between px-4 py-2.5 cursor-pointer transition-colors ${isCursor ? 'bg-primary/15' : 'hover:bg-muted/50'}`}
+                      className={`flex items-center justify-between px-4 py-2.5 cursor-pointer transition-colors ${getWorkspaceTargetRowStateClass(isCursor, isChecked)}`}
                       onClick={() => toggle(host.id)}
-                      onMouseEnter={() => setSelectedIndex(idx)}
                     >
                       <div className="flex items-center gap-3 min-w-0">
                         <DistroAvatar host={host} fallback={(host.label || host.hostname).slice(0, 2).toUpperCase()} size="sm" />


### PR DESCRIPTION
## What changed

- Keep the New Workspace action visible while quick-switcher results scroll.
- Restore Space as the empty-search toggle in the workspace picker while preserving spaces inside search queries.
- Give checked workspace targets a persistent background state.
- Separate keyboard selection from pointer hover so scrolling beneath a stationary pointer cannot move or freeze the keyboard selection.
- Avoid per-row state updates during pointer movement to keep mouse interaction smooth.

## Why

The quick switcher used row hover events to update the keyboard selection. When keyboard navigation scrolled the list, rows moving beneath a stationary pointer could take over the selection. The same interaction also caused frequent state updates during normal mouse movement.

## Validation

- 11 focused interaction tests pass.
- Relevant lint has no errors (one pre-existing unused icon warning remains in QuickSwitcher).
- Full production build passes.
- Verified in the running app that ArrowDown moves from CI-Build-02 to the next host without jumping or freezing.
