### PR TITLE
fix(sftp): keep active transfers accessible after closing the panel

### DIFF
--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -10,7 +10,7 @@
  * Used in TerminalLayer to provide SFTP alongside terminal sessions.
  */
 
-import React, { memo, useCallback, useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
+import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
 import { SftpSidePanelDeferredMount } from "./SftpSidePanelDeferredMount";
 import { formatHostPort } from "../domain/host";
 import { useI18n } from "../application/i18n/I18nProvider";
@@ -75,6 +75,7 @@ interface SftpSidePanelProps {
   initialLocation?: { hostId: string; path: string } | null;
   onInitialLocationApplied?: (location: { hostId: string; path: string }) => void;
   onCurrentPathChange?: (location: { hostId: string; connectionKey: string; path: string }) => void;
+  onActiveTransfersChange?: (count: number) => void;
   showWorkspaceHostHeader?: boolean;
   isVisible?: boolean;
   renderOverlays?: boolean;
@@ -117,6 +118,7 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
   initialLocation,
   onInitialLocationApplied,
   onCurrentPathChange,
+  onActiveTransfersChange,
   showWorkspaceHostHeader = false,
   isVisible = true,
   renderOverlays = true,
@@ -183,6 +185,14 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
 
   const sftpRef = useRef(sftp);
   sftpRef.current = sftp;
+
+  useLayoutEffect(() => {
+    onActiveTransfersChange?.(sftp.activeTransfersCount);
+  }, [onActiveTransfersChange, sftp.activeTransfersCount]);
+
+  useEffect(() => () => {
+    onActiveTransfersChange?.(0);
+  }, [onActiveTransfersChange]);
 
   // Register this instance's writeTextFileByConnection with the editor bridge
   // so editor tabs promoted from SFTP files opened in a terminal side panel
@@ -1368,6 +1378,7 @@ const sidePanelAreEqual = (prev: SftpSidePanelProps, next: SftpSidePanelProps): 
   prev.onSftpFollowTerminalCwdChange === next.onSftpFollowTerminalCwdChange &&
   prev.onRequestTerminalFocus === next.onRequestTerminalFocus &&
   prev.onCurrentPathChange === next.onCurrentPathChange &&
+  prev.onActiveTransfersChange === next.onActiveTransfersChange &&
   prev.initialLocation?.hostId === next.initialLocation?.hostId &&
   prev.initialLocation?.path === next.initialLocation?.path &&
   // Only the keepalive fields of terminalSettings affect SFTP connection

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -79,8 +79,10 @@ import { resolveAiSidePanelToggleIntent } from '../application/state/resolveAiSi
 import { terminalLayerAreEqual } from './terminalLayerMemo';
 import { TerminalLayerTabBridge } from './terminalLayer/TerminalLayerTabBridge';
 import {
+  SFTP_TRANSFER_HISTORY_RETENTION_MS,
   shouldClearSftpPanelAfterTransferChange,
   shouldKeepSftpMountedAfterClose,
+  shouldScheduleSftpRetainedPanelCleanup,
 } from './terminalLayer/sftpPanelLifecycle';
 import { resolveAiNoteArtifactPanelIntent } from './terminalLayer/aiNoteArtifactPanelIntent';
 import {
@@ -601,6 +603,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   sftpHostForTabRef.current = sftpHostForTab;
   const sftpActiveTransfersByTabRef = useRef<Map<string, number>>(new Map());
   const sftpRetainedAfterCloseTabIdsRef = useRef<Set<string>>(new Set());
+  const sftpRetainedCleanupTimersRef = useRef<Map<string, number>>(new Map());
   const sftpLastPathForSourceRef = useRef<Map<string, SftpRememberedLocation>>(new Map());
 
   const resolveSftpOpenTarget = useCallback((params: {
@@ -626,6 +629,11 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   }, []);
 
   const clearSftpPanelState = useCallback((tabId: string) => {
+    const cleanupTimer = sftpRetainedCleanupTimersRef.current.get(tabId);
+    if (cleanupTimer !== undefined) {
+      window.clearTimeout(cleanupTimer);
+      sftpRetainedCleanupTimersRef.current.delete(tabId);
+    }
     sftpActiveTransfersByTabRef.current.delete(tabId);
     sftpRetainedAfterCloseTabIdsRef.current.delete(tabId);
     setSftpHostForTab(prev => {
@@ -651,16 +659,40 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const handleSftpActiveTransfersChange = useCallback((tabId: string, count: number) => {
     const activeTransfersCount = Math.max(0, count);
     if (activeTransfersCount > 0) {
+      const cleanupTimer = sftpRetainedCleanupTimersRef.current.get(tabId);
+      if (cleanupTimer !== undefined) {
+        window.clearTimeout(cleanupTimer);
+        sftpRetainedCleanupTimersRef.current.delete(tabId);
+      }
       sftpActiveTransfersByTabRef.current.set(tabId, activeTransfersCount);
       return;
     }
     sftpActiveTransfersByTabRef.current.delete(tabId);
-    if (shouldClearSftpPanelAfterTransferChange({
+    const lifecycle = {
       activeTransfersCount,
       panelOpen: sidePanelOpenTabsRef.current.has(tabId),
       retainedAfterClose: sftpRetainedAfterCloseTabIdsRef.current.has(tabId),
-    })) {
+    };
+    if (shouldClearSftpPanelAfterTransferChange(lifecycle)) {
       clearSftpPanelState(tabId);
+      return;
+    }
+    if (
+      shouldScheduleSftpRetainedPanelCleanup(lifecycle)
+      && !sftpRetainedCleanupTimersRef.current.has(tabId)
+    ) {
+      const cleanupTimer = window.setTimeout(() => {
+        sftpRetainedCleanupTimersRef.current.delete(tabId);
+        const currentCount = sftpActiveTransfersByTabRef.current.get(tabId) ?? 0;
+        if (
+          currentCount <= 0
+          && !sidePanelOpenTabsRef.current.has(tabId)
+          && sftpRetainedAfterCloseTabIdsRef.current.has(tabId)
+        ) {
+          clearSftpPanelState(tabId);
+        }
+      }, SFTP_TRANSFER_HISTORY_RETENTION_MS);
+      sftpRetainedCleanupTimersRef.current.set(tabId, cleanupTimer);
     }
   }, [clearSftpPanelState]);
 
@@ -705,6 +737,11 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     if (keepSftpMounted) {
       sftpRetainedAfterCloseTabIdsRef.current.add(tabId);
     } else if (!isClosing) {
+      const cleanupTimer = sftpRetainedCleanupTimersRef.current.get(tabId);
+      if (cleanupTimer !== undefined) {
+        window.clearTimeout(cleanupTimer);
+        sftpRetainedCleanupTimersRef.current.delete(tabId);
+      }
       sftpRetainedAfterCloseTabIdsRef.current.delete(tabId);
     }
 
@@ -1006,10 +1043,22 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     }
     for (const tabId of sftpRetainedAfterCloseTabIdsRef.current) {
       if (!validAIScopeTargetIds.has(tabId)) {
+        const cleanupTimer = sftpRetainedCleanupTimersRef.current.get(tabId);
+        if (cleanupTimer !== undefined) {
+          window.clearTimeout(cleanupTimer);
+          sftpRetainedCleanupTimersRef.current.delete(tabId);
+        }
         sftpRetainedAfterCloseTabIdsRef.current.delete(tabId);
       }
     }
   }, [validAIScopeTargetIds]);
+
+  useEffect(() => () => {
+    for (const cleanupTimer of sftpRetainedCleanupTimersRef.current.values()) {
+      window.clearTimeout(cleanupTimer);
+    }
+    sftpRetainedCleanupTimersRef.current.clear();
+  }, []);
 
   const validSessionActivityIds = useMemo(() => {
     return getValidSessionActivityIds(sessions);
@@ -1161,6 +1210,11 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     if (currentPanel === tab) return;
 
     if (tab === 'sftp') {
+      const cleanupTimer = sftpRetainedCleanupTimersRef.current.get(tabId);
+      if (cleanupTimer !== undefined) {
+        window.clearTimeout(cleanupTimer);
+        sftpRetainedCleanupTimersRef.current.delete(tabId);
+      }
       sftpRetainedAfterCloseTabIdsRef.current.delete(tabId);
     }
 

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -78,7 +78,10 @@ import { resolveSidePanelToggleIntent } from '../application/state/resolveSidePa
 import { resolveAiSidePanelToggleIntent } from '../application/state/resolveAiSidePanelToggleIntent';
 import { terminalLayerAreEqual } from './terminalLayerMemo';
 import { TerminalLayerTabBridge } from './terminalLayer/TerminalLayerTabBridge';
-import { shouldKeepSftpMountedAfterClose } from './terminalLayer/sftpPanelLifecycle';
+import {
+  shouldClearSftpPanelAfterTransferChange,
+  shouldKeepSftpMountedAfterClose,
+} from './terminalLayer/sftpPanelLifecycle';
 import { resolveAiNoteArtifactPanelIntent } from './terminalLayer/aiNoteArtifactPanelIntent';
 import {
   canUseDirectSessionWriteFallback,
@@ -597,6 +600,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const sftpHostForTabRef = useRef(sftpHostForTab);
   sftpHostForTabRef.current = sftpHostForTab;
   const sftpActiveTransfersByTabRef = useRef<Map<string, number>>(new Map());
+  const sftpRetainedAfterCloseTabIdsRef = useRef<Set<string>>(new Set());
   const sftpLastPathForSourceRef = useRef<Map<string, SftpRememberedLocation>>(new Map());
 
   const resolveSftpOpenTarget = useCallback((params: {
@@ -622,6 +626,8 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   }, []);
 
   const clearSftpPanelState = useCallback((tabId: string) => {
+    sftpActiveTransfersByTabRef.current.delete(tabId);
+    sftpRetainedAfterCloseTabIdsRef.current.delete(tabId);
     setSftpHostForTab(prev => {
       if (!prev.has(tabId)) return prev;
       const next = new Map(prev);
@@ -649,7 +655,11 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       return;
     }
     sftpActiveTransfersByTabRef.current.delete(tabId);
-    if (!sidePanelOpenTabsRef.current.has(tabId)) {
+    if (shouldClearSftpPanelAfterTransferChange({
+      activeTransfersCount,
+      panelOpen: sidePanelOpenTabsRef.current.has(tabId),
+      retainedAfterClose: sftpRetainedAfterCloseTabIdsRef.current.has(tabId),
+    })) {
       clearSftpPanelState(tabId);
     }
   }, [clearSftpPanelState]);
@@ -692,6 +702,11 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     const activeTransfersCount = sftpActiveTransfersByTabRef.current.get(tabId) ?? 0;
     const keepSftpMounted = isClosing
       && shouldKeepSftpMountedAfterClose(activeTransfersCount);
+    if (keepSftpMounted) {
+      sftpRetainedAfterCloseTabIdsRef.current.add(tabId);
+    } else if (!isClosing) {
+      sftpRetainedAfterCloseTabIdsRef.current.delete(tabId);
+    }
 
     setSidePanelOpenTabs(prev => {
       const next = new Map(prev);
@@ -983,6 +998,19 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     return ids;
   }, [sessions, workspaces]);
 
+  useEffect(() => {
+    for (const tabId of sftpActiveTransfersByTabRef.current.keys()) {
+      if (!validAIScopeTargetIds.has(tabId)) {
+        sftpActiveTransfersByTabRef.current.delete(tabId);
+      }
+    }
+    for (const tabId of sftpRetainedAfterCloseTabIdsRef.current) {
+      if (!validAIScopeTargetIds.has(tabId)) {
+        sftpRetainedAfterCloseTabIdsRef.current.delete(tabId);
+      }
+    }
+  }, [validAIScopeTargetIds]);
+
   const validSessionActivityIds = useMemo(() => {
     return getValidSessionActivityIds(sessions);
   }, [sessions]);
@@ -1086,7 +1114,9 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       return next;
     });
     const activeTransfersCount = sftpActiveTransfersByTabRef.current.get(activeTabId) ?? 0;
-    if (!shouldKeepSftpMountedAfterClose(activeTransfersCount)) {
+    if (shouldKeepSftpMountedAfterClose(activeTransfersCount)) {
+      sftpRetainedAfterCloseTabIdsRef.current.add(activeTabId);
+    } else {
       clearSftpPanelState(activeTabId);
     }
     setAiMountedTabIds((prev) => removeMountedSidePanelTabId(prev, activeTabId));
@@ -1130,6 +1160,10 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     // If already on this tab, do nothing — user must click X to close
     if (currentPanel === tab) return;
 
+    if (tab === 'sftp') {
+      sftpRetainedAfterCloseTabIdsRef.current.delete(tabId);
+    }
+
     // If switching to SFTP and no host is stored yet, resolve it
     if (tab === 'sftp' && !sftpHostForTabRef.current.has(tabId)) {
       const host = resolveSftpHostForTab(tabId);
@@ -1156,9 +1190,9 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       });
     }
 
-    // Note: When switching away from SFTP, we keep the SFTP host state
-    // so the SftpSidePanel stays mounted (hidden) and preserves connections.
-    // SFTP state is only cleaned up when the panel is fully closed.
+    // Keep the hidden SFTP panel mounted while switching sub-panels. A panel
+    // closed during a transfer is also retained until the user reopens it and
+    // explicitly closes the now-idle panel, preserving the completed history.
 
     markSidePanelSubTabOpened(tabId, tab);
     startTransition(() => {

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -604,6 +604,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   sftpHostForTabRef.current = sftpHostForTab;
   const sftpActiveTransfersByTabRef = useRef<Map<string, number>>(new Map());
   const sftpRetainedAfterCloseTabIdsRef = useRef<Set<string>>(new Set());
+  const sftpOpeningTabIdsRef = useRef<Set<string>>(new Set());
   const sftpRetainedCleanupTimersRef = useRef<Map<string, number>>(new Map());
   const sftpLastPathForSourceRef = useRef<Map<string, SftpRememberedLocation>>(new Map());
 
@@ -637,6 +638,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     }
     sftpActiveTransfersByTabRef.current.delete(tabId);
     sftpRetainedAfterCloseTabIdsRef.current.delete(tabId);
+    sftpOpeningTabIdsRef.current.delete(tabId);
     setSftpHostForTab(prev => {
       if (!prev.has(tabId)) return prev;
       const next = new Map(prev);
@@ -671,7 +673,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     sftpActiveTransfersByTabRef.current.delete(tabId);
     const lifecycle = {
       activeTransfersCount,
-      panelOpen: sidePanelOpenTabsRef.current.has(tabId),
+      panelOpen: sidePanelOpenTabsRef.current.has(tabId) || sftpOpeningTabIdsRef.current.has(tabId),
       retainedAfterClose: sftpRetainedAfterCloseTabIdsRef.current.has(tabId),
     };
     if (shouldClearSftpPanelAfterTransferChange(lifecycle)) {
@@ -691,6 +693,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
         if (
           currentCount <= 0
           && !sidePanelOpenTabsRef.current.has(tabId)
+          && !sftpOpeningTabIdsRef.current.has(tabId)
           && sftpRetainedAfterCloseTabIdsRef.current.has(tabId)
         ) {
           clearSftpPanelState(tabId);
@@ -738,9 +741,13 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     const activeTransfersCount = sftpActiveTransfersByTabRef.current.get(tabId) ?? 0;
     const keepSftpMounted = isClosing
       && shouldKeepSftpMountedAfterClose(activeTransfersCount);
+    if (isClosing) {
+      sftpOpeningTabIdsRef.current.delete(tabId);
+    }
     if (keepSftpMounted) {
       sftpRetainedAfterCloseTabIdsRef.current.add(tabId);
     } else if (!isClosing) {
+      sftpOpeningTabIdsRef.current.add(tabId);
       const cleanupTimer = sftpRetainedCleanupTimersRef.current.get(tabId);
       if (cleanupTimer !== undefined) {
         window.clearTimeout(cleanupTimer);
@@ -1044,6 +1051,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       mountedTabIds: sftpHostForTab.keys(),
       activeTransferTabIds: sftpActiveTransfersByTabRef.current.keys(),
       retainedTabIds: sftpRetainedAfterCloseTabIdsRef.current,
+      openingTabIds: sftpOpeningTabIdsRef.current,
       cleanupTimerTabIds: sftpRetainedCleanupTimersRef.current.keys(),
       validTabIds: validAIScopeTargetIds,
     });
@@ -1051,6 +1059,14 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       clearSftpPanelState(tabId);
     }
   }, [clearSftpPanelState, sftpHostForTab, validAIScopeTargetIds]);
+
+  useEffect(() => {
+    for (const tabId of sftpOpeningTabIdsRef.current) {
+      if (sidePanelOpenTabs.get(tabId) === 'sftp') {
+        sftpOpeningTabIdsRef.current.delete(tabId);
+      }
+    }
+  }, [sidePanelOpenTabs]);
 
   useEffect(() => () => {
     for (const cleanupTimer of sftpRetainedCleanupTimersRef.current.values()) {
@@ -1161,6 +1177,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       next.delete(activeTabId);
       return next;
     });
+    sftpOpeningTabIdsRef.current.delete(activeTabId);
     const activeTransfersCount = sftpActiveTransfersByTabRef.current.get(activeTabId) ?? 0;
     if (shouldKeepSftpMountedAfterClose(activeTransfersCount)) {
       sftpRetainedAfterCloseTabIdsRef.current.add(activeTabId);
@@ -1209,6 +1226,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     if (currentPanel === tab) return;
 
     if (tab === 'sftp') {
+      sftpOpeningTabIdsRef.current.add(tabId);
       const cleanupTimer = sftpRetainedCleanupTimersRef.current.get(tabId);
       if (cleanupTimer !== undefined) {
         window.clearTimeout(cleanupTimer);

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -78,6 +78,7 @@ import { resolveSidePanelToggleIntent } from '../application/state/resolveSidePa
 import { resolveAiSidePanelToggleIntent } from '../application/state/resolveAiSidePanelToggleIntent';
 import { terminalLayerAreEqual } from './terminalLayerMemo';
 import { TerminalLayerTabBridge } from './terminalLayer/TerminalLayerTabBridge';
+import { shouldKeepSftpMountedAfterClose } from './terminalLayer/sftpPanelLifecycle';
 import { resolveAiNoteArtifactPanelIntent } from './terminalLayer/aiNoteArtifactPanelIntent';
 import {
   canUseDirectSessionWriteFallback,
@@ -595,6 +596,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const notesOpenRequestIdRef = useRef(0);
   const sftpHostForTabRef = useRef(sftpHostForTab);
   sftpHostForTabRef.current = sftpHostForTab;
+  const sftpActiveTransfersByTabRef = useRef<Map<string, number>>(new Map());
   const sftpLastPathForSourceRef = useRef<Map<string, SftpRememberedLocation>>(new Map());
 
   const resolveSftpOpenTarget = useCallback((params: {
@@ -618,6 +620,39 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
 
     return { connectionKey, effectiveInitialPath };
   }, []);
+
+  const clearSftpPanelState = useCallback((tabId: string) => {
+    setSftpHostForTab(prev => {
+      if (!prev.has(tabId)) return prev;
+      const next = new Map(prev);
+      next.delete(tabId);
+      return next;
+    });
+    setSftpPendingUploadsForTab(prev => {
+      if (!prev.has(tabId)) return prev;
+      const next = new Map(prev);
+      next.delete(tabId);
+      return next;
+    });
+    setSftpInitialLocationForTab(prev => {
+      if (!prev.has(tabId)) return prev;
+      const next = new Map(prev);
+      next.delete(tabId);
+      return next;
+    });
+  }, []);
+
+  const handleSftpActiveTransfersChange = useCallback((tabId: string, count: number) => {
+    const activeTransfersCount = Math.max(0, count);
+    if (activeTransfersCount > 0) {
+      sftpActiveTransfersByTabRef.current.set(tabId, activeTransfersCount);
+      return;
+    }
+    sftpActiveTransfersByTabRef.current.delete(tabId);
+    if (!sidePanelOpenTabsRef.current.has(tabId)) {
+      clearSftpPanelState(tabId);
+    }
+  }, [clearSftpPanelState]);
 
   const handleToggleWorkspaceComposeBar = useCallback(() => {
     setIsComposeBarOpen(prev => !prev);
@@ -654,6 +689,9 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       && (currentHost.sftpFileProtocol || "auto") === (host.sftpFileProtocol || "auto");
 
     const isClosing = !shouldKeepOpen && isOpen && isSameEndpoint;
+    const activeTransfersCount = sftpActiveTransfersByTabRef.current.get(tabId) ?? 0;
+    const keepSftpMounted = isClosing
+      && shouldKeepSftpMountedAfterClose(activeTransfersCount);
 
     setSidePanelOpenTabs(prev => {
       const next = new Map(prev);
@@ -669,7 +707,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     // Removing on close unmounts the panel so SFTP sessions are cleaned up.
     setSftpHostForTab(prev => {
       const next = new Map(prev);
-      if (isClosing) {
+      if (isClosing && !keepSftpMounted) {
         next.delete(tabId);
       } else {
         next.set(tabId, host);
@@ -1047,23 +1085,10 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       next.delete(activeTabId);
       return next;
     });
-    // Always clean up SFTP state (it may be mounted in the background
-    // while scripts/theme tab was active)
-    setSftpHostForTab(prev => {
-      const next = new Map(prev);
-      next.delete(activeTabId);
-      return next;
-    });
-    setSftpPendingUploadsForTab(prev => {
-      const next = new Map(prev);
-      next.delete(activeTabId);
-      return next;
-    });
-    setSftpInitialLocationForTab(prev => {
-      const next = new Map(prev);
-      next.delete(activeTabId);
-      return next;
-    });
+    const activeTransfersCount = sftpActiveTransfersByTabRef.current.get(activeTabId) ?? 0;
+    if (!shouldKeepSftpMountedAfterClose(activeTransfersCount)) {
+      clearSftpPanelState(activeTabId);
+    }
     setAiMountedTabIds((prev) => removeMountedSidePanelTabId(prev, activeTabId));
     setScriptsMountedTabIds((prev) => removeMountedSidePanelTabId(prev, activeTabId));
     setThemeMountedTabIds((prev) => removeMountedSidePanelTabId(prev, activeTabId));
@@ -1076,7 +1101,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     });
     notesReturnTabRef.current.delete(activeTabId);
     refocusTerminalSession(sessionIdToRefocus);
-  }, [getActiveTerminalSessionId, refocusTerminalSession, syncWorkspaceFocusIfNeeded]);
+  }, [clearSftpPanelState, getActiveTerminalSessionId, refocusTerminalSession, syncWorkspaceFocusIfNeeded]);
 
   // Resolve the SFTP host for a tab: a previously-stored host, otherwise the
   // host of the workspace's focused session or the active session. null = none.
@@ -1635,6 +1660,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     handlePendingUploadHandled,
     handleSessionExit,
     handleSftpCurrentPathChange,
+    handleSftpActiveTransfersChange,
     handleSftpInitialLocationApplied,
     persistSidePanelWidth,
     handleSnippetClickForFocusedSession,

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -80,6 +80,7 @@ import { terminalLayerAreEqual } from './terminalLayerMemo';
 import { TerminalLayerTabBridge } from './terminalLayer/TerminalLayerTabBridge';
 import {
   SFTP_TRANSFER_HISTORY_RETENTION_MS,
+  listInvalidSftpPanelTabIds,
   shouldClearSftpPanelAfterTransferChange,
   shouldKeepSftpMountedAfterClose,
   shouldScheduleSftpRetainedPanelCleanup,
@@ -678,7 +679,10 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       return;
     }
     if (
-      shouldScheduleSftpRetainedPanelCleanup(lifecycle)
+      shouldScheduleSftpRetainedPanelCleanup({
+        activeTransfersCount: lifecycle.activeTransfersCount,
+        retainedAfterClose: lifecycle.retainedAfterClose,
+      })
       && !sftpRetainedCleanupTimersRef.current.has(tabId)
     ) {
       const cleanupTimer = window.setTimeout(() => {
@@ -1036,22 +1040,17 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   }, [sessions, workspaces]);
 
   useEffect(() => {
-    for (const tabId of sftpActiveTransfersByTabRef.current.keys()) {
-      if (!validAIScopeTargetIds.has(tabId)) {
-        sftpActiveTransfersByTabRef.current.delete(tabId);
-      }
+    const invalidTabIds = listInvalidSftpPanelTabIds({
+      mountedTabIds: sftpHostForTab.keys(),
+      activeTransferTabIds: sftpActiveTransfersByTabRef.current.keys(),
+      retainedTabIds: sftpRetainedAfterCloseTabIdsRef.current,
+      cleanupTimerTabIds: sftpRetainedCleanupTimersRef.current.keys(),
+      validTabIds: validAIScopeTargetIds,
+    });
+    for (const tabId of invalidTabIds) {
+      clearSftpPanelState(tabId);
     }
-    for (const tabId of sftpRetainedAfterCloseTabIdsRef.current) {
-      if (!validAIScopeTargetIds.has(tabId)) {
-        const cleanupTimer = sftpRetainedCleanupTimersRef.current.get(tabId);
-        if (cleanupTimer !== undefined) {
-          window.clearTimeout(cleanupTimer);
-          sftpRetainedCleanupTimersRef.current.delete(tabId);
-        }
-        sftpRetainedAfterCloseTabIdsRef.current.delete(tabId);
-      }
-    }
-  }, [validAIScopeTargetIds]);
+  }, [clearSftpPanelState, sftpHostForTab, validAIScopeTargetIds]);
 
   useEffect(() => () => {
     for (const cleanupTimer of sftpRetainedCleanupTimersRef.current.values()) {

--- a/components/terminalLayer/TerminalLayerTabBridge.tsx
+++ b/components/terminalLayer/TerminalLayerTabBridge.tsx
@@ -447,6 +447,7 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     handlePendingUploadHandled: s.handlePendingUploadHandled,
     handleSessionExit: s.handleSessionExit,
     handleSftpCurrentPathChange: s.handleSftpCurrentPathChange,
+    handleSftpActiveTransfersChange: s.handleSftpActiveTransfersChange,
     handleSftpInitialLocationApplied: s.handleSftpInitialLocationApplied,
     persistSidePanelWidth: s.persistSidePanelWidth,
     setSidePanelWidth: s.setSidePanelWidth,

--- a/components/terminalLayer/sftpPanelLifecycle.test.ts
+++ b/components/terminalLayer/sftpPanelLifecycle.test.ts
@@ -3,8 +3,10 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
+  SFTP_TRANSFER_HISTORY_RETENTION_MS,
   shouldClearSftpPanelAfterTransferChange,
   shouldKeepSftpMountedAfterClose,
+  shouldScheduleSftpRetainedPanelCleanup,
 } from "./sftpPanelLifecycle.ts";
 
 test("closing the panel keeps SFTP mounted while a transfer is active", () => {
@@ -22,6 +24,12 @@ test("a transfer retained by close keeps its history after completion", () => {
     panelOpen: false,
     retainedAfterClose: true,
   }), false);
+  assert.equal(shouldScheduleSftpRetainedPanelCleanup({
+    activeTransfersCount: 0,
+    panelOpen: false,
+    retainedAfterClose: true,
+  }), true);
+  assert.ok(SFTP_TRANSFER_HISTORY_RETENTION_MS > 0);
 });
 
 test("an unretained hidden idle panel can be released", () => {
@@ -41,4 +49,5 @@ test("terminal side panel reports transfer activity and uses it during close", (
   assert.match(slotsSource, /onActiveTransfersChange=\{handleActiveTransfersChange\}/);
   assert.match(layerSource, /shouldKeepSftpMountedAfterClose\(activeTransfersCount\)/);
   assert.match(layerSource, /sftpRetainedAfterCloseTabIdsRef/);
+  assert.match(layerSource, /sftpRetainedCleanupTimersRef/);
 });

--- a/components/terminalLayer/sftpPanelLifecycle.test.ts
+++ b/components/terminalLayer/sftpPanelLifecycle.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 
 import {
   SFTP_TRANSFER_HISTORY_RETENTION_MS,
+  listInvalidSftpPanelTabIds,
   shouldClearSftpPanelAfterTransferChange,
   shouldKeepSftpMountedAfterClose,
   shouldScheduleSftpRetainedPanelCleanup,
@@ -26,10 +27,26 @@ test("a transfer retained by close keeps its history after completion", () => {
   }), false);
   assert.equal(shouldScheduleSftpRetainedPanelCleanup({
     activeTransfersCount: 0,
-    panelOpen: false,
     retainedAfterClose: true,
   }), true);
   assert.ok(SFTP_TRANSFER_HISTORY_RETENTION_MS > 0);
+});
+
+test("retained cleanup is scheduled even if close state has not committed yet", () => {
+  assert.equal(shouldScheduleSftpRetainedPanelCleanup({
+    activeTransfersCount: 0,
+    retainedAfterClose: true,
+  }), true);
+});
+
+test("closing a terminal tab finds every retained SFTP resource for cleanup", () => {
+  assert.deepEqual(listInvalidSftpPanelTabIds({
+    mountedTabIds: ["closed-tab", "open-tab"],
+    activeTransferTabIds: [],
+    retainedTabIds: ["closed-tab"],
+    cleanupTimerTabIds: ["closed-tab"],
+    validTabIds: new Set(["open-tab"]),
+  }), ["closed-tab"]);
 });
 
 test("an unretained hidden idle panel can be released", () => {

--- a/components/terminalLayer/sftpPanelLifecycle.test.ts
+++ b/components/terminalLayer/sftpPanelLifecycle.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { shouldKeepSftpMountedAfterClose } from "./sftpPanelLifecycle.ts";
+
+test("closing the panel keeps SFTP mounted while a transfer is active", () => {
+  assert.equal(shouldKeepSftpMountedAfterClose(1), true);
+  assert.equal(shouldKeepSftpMountedAfterClose(3), true);
+});
+
+test("closing an idle panel still releases its SFTP state", () => {
+  assert.equal(shouldKeepSftpMountedAfterClose(0), false);
+});
+
+test("terminal side panel reports transfer activity and uses it during close", () => {
+  const layerSource = readFileSync(new URL("../TerminalLayer.tsx", import.meta.url), "utf8");
+  const panelSource = readFileSync(new URL("../SftpSidePanel.tsx", import.meta.url), "utf8");
+  const slotsSource = readFileSync(new URL("./terminalLayerSidePanelSlots.tsx", import.meta.url), "utf8");
+
+  assert.match(panelSource, /onActiveTransfersChange\?\.\(sftp\.activeTransfersCount\)/);
+  assert.match(slotsSource, /onActiveTransfersChange=\{handleActiveTransfersChange\}/);
+  assert.match(layerSource, /shouldKeepSftpMountedAfterClose\(activeTransfersCount\)/);
+});

--- a/components/terminalLayer/sftpPanelLifecycle.test.ts
+++ b/components/terminalLayer/sftpPanelLifecycle.test.ts
@@ -44,9 +44,18 @@ test("closing a terminal tab finds every retained SFTP resource for cleanup", ()
     mountedTabIds: ["closed-tab", "open-tab"],
     activeTransferTabIds: [],
     retainedTabIds: ["closed-tab"],
+    openingTabIds: [],
     cleanupTimerTabIds: ["closed-tab"],
     validTabIds: new Set(["open-tab"]),
   }), ["closed-tab"]);
+});
+
+test("a reopening panel is not cleared before its open state commits", () => {
+  assert.equal(shouldClearSftpPanelAfterTransferChange({
+    activeTransfersCount: 0,
+    panelOpen: true,
+    retainedAfterClose: false,
+  }), false);
 });
 
 test("an unretained hidden idle panel can be released", () => {

--- a/components/terminalLayer/sftpPanelLifecycle.test.ts
+++ b/components/terminalLayer/sftpPanelLifecycle.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
-import { shouldKeepSftpMountedAfterClose } from "./sftpPanelLifecycle.ts";
+import {
+  shouldClearSftpPanelAfterTransferChange,
+  shouldKeepSftpMountedAfterClose,
+} from "./sftpPanelLifecycle.ts";
 
 test("closing the panel keeps SFTP mounted while a transfer is active", () => {
   assert.equal(shouldKeepSftpMountedAfterClose(1), true);
@@ -13,6 +16,22 @@ test("closing an idle panel still releases its SFTP state", () => {
   assert.equal(shouldKeepSftpMountedAfterClose(0), false);
 });
 
+test("a transfer retained by close keeps its history after completion", () => {
+  assert.equal(shouldClearSftpPanelAfterTransferChange({
+    activeTransfersCount: 0,
+    panelOpen: false,
+    retainedAfterClose: true,
+  }), false);
+});
+
+test("an unretained hidden idle panel can be released", () => {
+  assert.equal(shouldClearSftpPanelAfterTransferChange({
+    activeTransfersCount: 0,
+    panelOpen: false,
+    retainedAfterClose: false,
+  }), true);
+});
+
 test("terminal side panel reports transfer activity and uses it during close", () => {
   const layerSource = readFileSync(new URL("../TerminalLayer.tsx", import.meta.url), "utf8");
   const panelSource = readFileSync(new URL("../SftpSidePanel.tsx", import.meta.url), "utf8");
@@ -21,4 +40,5 @@ test("terminal side panel reports transfer activity and uses it during close", (
   assert.match(panelSource, /onActiveTransfersChange\?\.\(sftp\.activeTransfersCount\)/);
   assert.match(slotsSource, /onActiveTransfersChange=\{handleActiveTransfersChange\}/);
   assert.match(layerSource, /shouldKeepSftpMountedAfterClose\(activeTransfersCount\)/);
+  assert.match(layerSource, /sftpRetainedAfterCloseTabIdsRef/);
 });

--- a/components/terminalLayer/sftpPanelLifecycle.ts
+++ b/components/terminalLayer/sftpPanelLifecycle.ts
@@ -1,0 +1,3 @@
+export function shouldKeepSftpMountedAfterClose(activeTransfersCount: number): boolean {
+  return activeTransfersCount > 0;
+}

--- a/components/terminalLayer/sftpPanelLifecycle.ts
+++ b/components/terminalLayer/sftpPanelLifecycle.ts
@@ -1,3 +1,13 @@
 export function shouldKeepSftpMountedAfterClose(activeTransfersCount: number): boolean {
   return activeTransfersCount > 0;
 }
+
+export function shouldClearSftpPanelAfterTransferChange(params: {
+  activeTransfersCount: number;
+  panelOpen: boolean;
+  retainedAfterClose: boolean;
+}): boolean {
+  return params.activeTransfersCount <= 0
+    && !params.panelOpen
+    && !params.retainedAfterClose;
+}

--- a/components/terminalLayer/sftpPanelLifecycle.ts
+++ b/components/terminalLayer/sftpPanelLifecycle.ts
@@ -1,3 +1,5 @@
+export const SFTP_TRANSFER_HISTORY_RETENTION_MS = 10 * 60 * 1000;
+
 export function shouldKeepSftpMountedAfterClose(activeTransfersCount: number): boolean {
   return activeTransfersCount > 0;
 }
@@ -10,4 +12,14 @@ export function shouldClearSftpPanelAfterTransferChange(params: {
   return params.activeTransfersCount <= 0
     && !params.panelOpen
     && !params.retainedAfterClose;
+}
+
+export function shouldScheduleSftpRetainedPanelCleanup(params: {
+  activeTransfersCount: number;
+  panelOpen: boolean;
+  retainedAfterClose: boolean;
+}): boolean {
+  return params.activeTransfersCount <= 0
+    && !params.panelOpen
+    && params.retainedAfterClose;
 }

--- a/components/terminalLayer/sftpPanelLifecycle.ts
+++ b/components/terminalLayer/sftpPanelLifecycle.ts
@@ -16,10 +16,24 @@ export function shouldClearSftpPanelAfterTransferChange(params: {
 
 export function shouldScheduleSftpRetainedPanelCleanup(params: {
   activeTransfersCount: number;
-  panelOpen: boolean;
   retainedAfterClose: boolean;
 }): boolean {
   return params.activeTransfersCount <= 0
-    && !params.panelOpen
     && params.retainedAfterClose;
+}
+
+export function listInvalidSftpPanelTabIds(params: {
+  mountedTabIds: Iterable<string>;
+  activeTransferTabIds: Iterable<string>;
+  retainedTabIds: Iterable<string>;
+  cleanupTimerTabIds: Iterable<string>;
+  validTabIds: ReadonlySet<string>;
+}): string[] {
+  const trackedTabIds = new Set([
+    ...params.mountedTabIds,
+    ...params.activeTransferTabIds,
+    ...params.retainedTabIds,
+    ...params.cleanupTimerTabIds,
+  ]);
+  return [...trackedTabIds].filter((tabId) => !params.validTabIds.has(tabId));
 }

--- a/components/terminalLayer/sftpPanelLifecycle.ts
+++ b/components/terminalLayer/sftpPanelLifecycle.ts
@@ -26,6 +26,7 @@ export function listInvalidSftpPanelTabIds(params: {
   mountedTabIds: Iterable<string>;
   activeTransferTabIds: Iterable<string>;
   retainedTabIds: Iterable<string>;
+  openingTabIds: Iterable<string>;
   cleanupTimerTabIds: Iterable<string>;
   validTabIds: ReadonlySet<string>;
 }): string[] {
@@ -33,6 +34,7 @@ export function listInvalidSftpPanelTabIds(params: {
     ...params.mountedTabIds,
     ...params.activeTransferTabIds,
     ...params.retainedTabIds,
+    ...params.openingTabIds,
     ...params.cleanupTimerTabIds,
   ]);
   return [...trackedTabIds].filter((tabId) => !params.validTabIds.has(tabId));

--- a/components/terminalLayer/terminalLayerSidePanelSlots.tsx
+++ b/components/terminalLayer/terminalLayerSidePanelSlots.tsx
@@ -65,6 +65,7 @@ function SidePanelSftpSlotInner({
     sftpPendingUploadsForTab,
     handleSftpInitialLocationApplied,
     handleSftpCurrentPathChange,
+    handleSftpActiveTransfersChange,
     handlePendingUploadHandled,
     sftpDoubleClickBehavior,
     sftpAutoSync,
@@ -137,6 +138,13 @@ function SidePanelSftpSlotInner({
     [handleSftpCurrentPathChange, live.activeTerminalSessionIdForSftp, live.focusedSessionId, tabId],
   );
 
+  const handleActiveTransfersChange = useCallback(
+    (count: number) => {
+      handleSftpActiveTransfersChange(tabId, count);
+    },
+    [handleSftpActiveTransfersChange, tabId],
+  );
+
   return (
     <div className={sidePanelHiddenPanelClassName(!isVisible)}>
       <SftpSidePanel
@@ -154,6 +162,7 @@ function SidePanelSftpSlotInner({
         initialLocation={isVisible ? (sftpInitialLocationForTab.get(tabId) ?? null) : null}
         onInitialLocationApplied={handleInitialLocationApplied}
         onCurrentPathChange={handleCurrentPathChange}
+        onActiveTransfersChange={handleActiveTransfersChange}
         showWorkspaceHostHeader={isVisible && !!live.activeWorkspace}
         isVisible={isVisible}
         renderOverlays={isVisible}


### PR DESCRIPTION
## Summary

- keep the per-terminal SFTP panel mounted while file transfers are still active
- restore the same transfer queue when the user reopens SFTP
- release the hidden SFTP state automatically after the final active transfer finishes
- preserve the existing immediate cleanup behavior when the panel is idle

## Root cause

Closing the terminal side panel always removed the state that owned the transfer queue. The backend transfer continued, but reopening SFTP created a fresh state instance with no way to display the in-flight task.

Closes #2341

## Validation

- `node --test --import tsx components/terminalLayer/*.test.ts` (93 passed)
- focused ESLint on all changed files
- `npm run build`
- `git diff --check`