### PR TITLE
fix: use Plug icon for External MCP top-bar toggle

### DIFF
--- a/components/TopTabs.test.ts
+++ b/components/TopTabs.test.ts
@@ -124,6 +124,7 @@ test("top tabs expose the External MCP quick toggle", () => {
   assert.match(topTabsSource, /topTabs\.externalMcp\.(enable|disable)/);
   assert.match(topTabsSource, /aria-label=\{t\(externalMcpEnabled \? 'topTabs\.externalMcp\.disable' : 'topTabs\.externalMcp\.enable'\)\}/);
   assert.match(topTabsSource, /aria-pressed=\{externalMcpEnabled\}/);
+  assert.match(topTabsSource, /<Plug size=\{16\} \/>/);
 });
 
 test("External MCP top bar labels exist in Traditional Chinese", () => {

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -1,4 +1,4 @@
-import { Folder, FolderLock, Menu, Moon, MoreHorizontal, Plus, Radio, Settings, Sparkles, Sun } from 'lucide-react';
+import { Folder, FolderLock, Menu, Moon, MoreHorizontal, Plus, Plug, Settings, Sparkles, Sun } from 'lucide-react';
 import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { fromEditorTabId, isEditorTabId, useActiveTabId } from '../application/state/activeTabStore';
 import { isHostTreeWorkTabSurface } from '../application/app/workTabSurface';
@@ -1119,7 +1119,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
                   aria-pressed={externalMcpEnabled}
                   onClick={() => onToggleExternalMcp(!externalMcpEnabled)}
                 >
-                  <Radio size={16} />
+                  <Plug size={16} />
                 </Button>
               </TooltipTrigger>
               <TooltipContent>


### PR DESCRIPTION
## Summary
- Replace the External MCP top-bar `Radio` icon with `Plug`
- Keep the existing enable/disable tooltip and pressed-state behavior
- Update the source-level TopTabs coverage to lock the new glyph

## Why
`Radio` reads more like signal/broadcast, which is easy to confuse with other top-bar actions. This control is about exposing Netcatty as a local MCP bridge for external clients, so `Plug` is a clearer metaphor.

## Test plan
- [x] `node --test --import tsx components/TopTabs.test.ts`
- [ ] Open Netcatty, confirm the top-bar External MCP control uses the plug icon
- [ ] Toggle the control and confirm tooltip/pressed color still work