### PR TITLE
polish host auth method UI and clear lint warnings

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -316,7 +316,6 @@ function App({ settings }: { settings: SettingsState }) {
     moveFocusInWorkspace,
     runSnippet,
     orphanSessions,
-    orderedTabs,
     getOrderedWorkTabs,
     reorderTabs,
     toggleBroadcast,

--- a/application/state/usePluginContributions.ts
+++ b/application/state/usePluginContributions.ts
@@ -138,10 +138,11 @@ export function usePluginContributions(
   }, [bridge, queryKey]);
 
   useEffect(() => {
+    const guard = refreshGuard.current;
     void refresh();
     const unsubscribe = bridge?.onPluginContributionsChanged?.(() => { void refresh(); });
     return () => {
-      refreshGuard.current.invalidate();
+      guard.invalidate();
       unsubscribe?.();
     };
   }, [bridge, refresh]);

--- a/application/state/usePluginViewLifecycle.ts
+++ b/application/state/usePluginViewLifecycle.ts
@@ -248,7 +248,7 @@ export function usePluginViewLifecycle({
           await setViewBounds(opened.id, nextBounds);
           await setViewVisibility(opened.id, true);
         } catch {
-          try { await closeView(opened.id); } catch {}
+          try { await closeView(opened.id); } catch { /* best-effort cleanup after restore failure */ }
           opened = null;
         }
       }

--- a/components/HostDetailsConnectionSections.test.tsx
+++ b/components/HostDetailsConnectionSections.test.tsx
@@ -10,6 +10,7 @@ import {
   HOST_AUTH_METHOD_CHOICES,
   HostDetailsConnectionSections,
   removeSelectedHostCredential,
+  shouldForceAuthMethodReselect,
 } from "./HostDetailsConnectionSections.tsx";
 import { TooltipProvider } from "./ui/tooltip.tsx";
 
@@ -136,6 +137,14 @@ test("host credentials expose automatic and password-only choices", () => {
     markup,
     /role="combobox"[\s\S]*?<span class="min-w-0 flex-1 truncate text-left">hostDetails\.auth\.auto<\/span>/,
   );
+});
+
+test("reselecting the current key or certificate method still forces the chooser path", () => {
+  assert.equal(shouldForceAuthMethodReselect("key", "key"), true);
+  assert.equal(shouldForceAuthMethodReselect("certificate", "certificate"), true);
+  assert.equal(shouldForceAuthMethodReselect("password", "password"), false);
+  assert.equal(shouldForceAuthMethodReselect("auto", "auto"), false);
+  assert.equal(shouldForceAuthMethodReselect("key", "password"), false);
 });
 
 test("ET hosts do not offer the unsupported interactive-auth preference", () => {

--- a/components/HostDetailsConnectionSections.test.tsx
+++ b/components/HostDetailsConnectionSections.test.tsx
@@ -1,4 +1,7 @@
 import test from "node:test";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import assert from "node:assert/strict";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -140,8 +143,8 @@ test("host credentials expose automatic and password-only choices", () => {
 });
 
 test("wires same-value key/certificate reselect through pointer and keyboard handlers", () => {
-  const source = require("node:fs").readFileSync(
-    new URL("./HostDetailsConnectionSections.tsx", import.meta.url),
+  const source = fs.readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "HostDetailsConnectionSections.tsx"),
     "utf8",
   );
   assert.match(source, /onPointerUp=\{\(\) => \{[\s\S]*shouldForceAuthMethodReselect/);

--- a/components/HostDetailsConnectionSections.test.tsx
+++ b/components/HostDetailsConnectionSections.test.tsx
@@ -113,11 +113,20 @@ test("host credentials expose automatic and password-only choices", () => {
   });
 
   assert.match(markup, /hostDetails\.auth\.method/);
+  assert.match(markup, /role="combobox"/);
+  assert.match(markup, /aria-label="hostDetails\.auth\.auto\.desc"/);
   assert.match(markup, /hostDetails\.auth\.auto/);
-  assert.match(markup, /hostDetails\.auth\.passwordOnly/);
-  assert.match(markup, /hostDetails\.auth\.key/);
-  assert.match(markup, /hostDetails\.auth\.certificate/);
   assert.match(markup, /hostDetails\.auth\.mfaFirst/);
+  // Login method uses the same option-style setting row as other host form controls.
+  assert.match(
+    markup,
+    /hostDetails\.auth\.method[\s\S]*?role="combobox"[\s\S]*?hostDetails\.auth\.auto[\s\S]*?<\/div>\s*<div class="flex min-h-12 items-center justify-between gap-3 rounded-lg border border-border\/60 bg-secondary\/40 px-3 py-2">[\s\S]*hostDetails\.auth\.mfaFirst/,
+  );
+  assert.match(markup, /class="[^"]*h-8 w-\[7\.5rem\][^"]*"/);
+  assert.match(
+    markup,
+    /role="combobox"[\s\S]*?<span class="min-w-0 flex-1 truncate text-left">hostDetails\.auth\.auto<\/span>/,
+  );
 });
 
 test("ET hosts do not offer the unsupported interactive-auth preference", () => {
@@ -141,7 +150,13 @@ test("host authentication choices remain visible for a selected identity", () =>
     authMethod: "password",
   });
 
-  assert.match(markup, /hostDetails\.auth\.passwordOnly/);
+  assert.match(markup, /hostDetails\.auth\.method/);
+  assert.match(markup, /role="combobox"/);
+  assert.match(markup, /aria-label="hostDetails\.auth\.password\.desc"/);
+  assert.match(
+    markup,
+    /role="combobox"[\s\S]*?<span class="min-w-0 flex-1 truncate text-left">hostDetails\.auth\.passwordOnly<\/span>/,
+  );
 });
 
 test("host authentication choices show the inherited effective method", () => {
@@ -151,7 +166,13 @@ test("host authentication choices show the inherited effective method", () => {
     effectiveAuthMethod: "password",
   });
 
-  assert.match(markup, /<button[^>]*aria-pressed="true"[^>]*>hostDetails\.auth\.passwordOnly<\/button>/);
+  assert.match(markup, /hostDetails\.auth\.method/);
+  assert.match(markup, /role="combobox"/);
+  assert.match(markup, /aria-label="hostDetails\.auth\.password\.desc"/);
+  assert.match(
+    markup,
+    /role="combobox"[\s\S]*?<span class="min-w-0 flex-1 truncate text-left">hostDetails\.auth\.passwordOnly<\/span>/,
+  );
 });
 
 test("reselecting an inherited authentication method preserves group credentials", () => {

--- a/components/HostDetailsConnectionSections.test.tsx
+++ b/components/HostDetailsConnectionSections.test.tsx
@@ -7,6 +7,7 @@ import type { Host, SSHKey } from "../types.ts";
 import {
   applyEffectiveHostAuthMethodSelection,
   detachEffectiveHostIdentity,
+  HOST_AUTH_METHOD_CHOICES,
   HostDetailsConnectionSections,
   removeSelectedHostCredential,
 } from "./HostDetailsConnectionSections.tsx";
@@ -112,9 +113,17 @@ test("host credentials expose automatic and password-only choices", () => {
     identityFileId: undefined,
   });
 
+  assert.deepEqual(
+    HOST_AUTH_METHOD_CHOICES.map(([value, labelKey]) => [value, labelKey]),
+    [
+      ["auto", "hostDetails.auth.auto"],
+      ["password", "hostDetails.auth.passwordOnly"],
+      ["key", "hostDetails.auth.key"],
+      ["certificate", "hostDetails.auth.certificate"],
+    ],
+  );
   assert.match(markup, /hostDetails\.auth\.method/);
-  assert.match(markup, /role="combobox"/);
-  assert.match(markup, /aria-label="hostDetails\.auth\.auto\.desc"/);
+  assert.match(markup, /role="combobox"[^>]*aria-label="hostDetails\.auth\.method"/);
   assert.match(markup, /hostDetails\.auth\.auto/);
   assert.match(markup, /hostDetails\.auth\.mfaFirst/);
   // Login method uses the same option-style setting row as other host form controls.
@@ -122,7 +131,7 @@ test("host credentials expose automatic and password-only choices", () => {
     markup,
     /hostDetails\.auth\.method[\s\S]*?role="combobox"[\s\S]*?hostDetails\.auth\.auto[\s\S]*?<\/div>\s*<div class="flex min-h-12 items-center justify-between gap-3 rounded-lg border border-border\/60 bg-secondary\/40 px-3 py-2">[\s\S]*hostDetails\.auth\.mfaFirst/,
   );
-  assert.match(markup, /class="[^"]*h-8 w-\[7\.5rem\][^"]*"/);
+  assert.match(markup, /class="[^"]*h-10 w-32[^"]*"/);
   assert.match(
     markup,
     /role="combobox"[\s\S]*?<span class="min-w-0 flex-1 truncate text-left">hostDetails\.auth\.auto<\/span>/,
@@ -151,8 +160,7 @@ test("host authentication choices remain visible for a selected identity", () =>
   });
 
   assert.match(markup, /hostDetails\.auth\.method/);
-  assert.match(markup, /role="combobox"/);
-  assert.match(markup, /aria-label="hostDetails\.auth\.password\.desc"/);
+  assert.match(markup, /role="combobox"[^>]*aria-label="hostDetails\.auth\.method"/);
   assert.match(
     markup,
     /role="combobox"[\s\S]*?<span class="min-w-0 flex-1 truncate text-left">hostDetails\.auth\.passwordOnly<\/span>/,
@@ -167,8 +175,7 @@ test("host authentication choices show the inherited effective method", () => {
   });
 
   assert.match(markup, /hostDetails\.auth\.method/);
-  assert.match(markup, /role="combobox"/);
-  assert.match(markup, /aria-label="hostDetails\.auth\.password\.desc"/);
+  assert.match(markup, /role="combobox"[^>]*aria-label="hostDetails\.auth\.method"/);
   assert.match(
     markup,
     /role="combobox"[\s\S]*?<span class="min-w-0 flex-1 truncate text-left">hostDetails\.auth\.passwordOnly<\/span>/,

--- a/components/HostDetailsConnectionSections.test.tsx
+++ b/components/HostDetailsConnectionSections.test.tsx
@@ -139,6 +139,16 @@ test("host credentials expose automatic and password-only choices", () => {
   );
 });
 
+test("wires same-value key/certificate reselect through pointer and keyboard handlers", () => {
+  const source = require("node:fs").readFileSync(
+    new URL("./HostDetailsConnectionSections.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(source, /onPointerUp=\{\(\) => \{[\s\S]*shouldForceAuthMethodReselect/);
+  assert.match(source, /onKeyDown=\{\(event\) => \{[\s\S]*shouldForceAuthMethodReselect/);
+  assert.doesNotMatch(source, /onSelect=\{\(\) => \{[\s\S]*shouldForceAuthMethodReselect/);
+});
+
 test("reselecting the current key or certificate method still forces the chooser path", () => {
   assert.equal(shouldForceAuthMethodReselect("key", "key"), true);
   assert.equal(shouldForceAuthMethodReselect("certificate", "certificate"), true);

--- a/components/HostDetailsConnectionSections.test.tsx
+++ b/components/HostDetailsConnectionSections.test.tsx
@@ -135,7 +135,7 @@ test("host credentials expose automatic and password-only choices", () => {
     markup,
     /hostDetails\.auth\.method[\s\S]*?role="combobox"[\s\S]*?hostDetails\.auth\.auto[\s\S]*?<\/div>\s*<div class="flex min-h-12 items-center justify-between gap-3 rounded-lg border border-border\/60 bg-secondary\/40 px-3 py-2">[\s\S]*hostDetails\.auth\.mfaFirst/,
   );
-  assert.match(markup, /class="[^"]*h-10 w-32[^"]*"/);
+  assert.match(markup, /class="[^"]*h-8 w-32[^"]*"/);
   assert.match(
     markup,
     /role="combobox"[\s\S]*?<span class="min-w-0 flex-1 truncate text-left">hostDetails\.auth\.auto<\/span>/,

--- a/components/HostDetailsConnectionSections.tsx
+++ b/components/HostDetailsConnectionSections.tsx
@@ -16,6 +16,13 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type HostDetailsConnectionSectionsProps = Record<string, any>;
 
+export const HOST_AUTH_METHOD_CHOICES = [
+  ["auto", "hostDetails.auth.auto"],
+  ["password", "hostDetails.auth.passwordOnly"],
+  ["key", "hostDetails.auth.key"],
+  ["certificate", "hostDetails.auth.certificate"],
+] as const;
+
 export const applyEffectiveHostAuthMethodSelection = (
   host: Host,
   authMethod: "auto" | "password" | "key" | "certificate",
@@ -99,17 +106,11 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
     setCredentialPopoverOpen(false);
   };
 
-  const authChoices = [
-    ["auto", "hostDetails.auth.auto"],
-    ["password", "hostDetails.auth.passwordOnly"],
-    ["key", "hostDetails.auth.key"],
-    ["certificate", "hostDetails.auth.certificate"],
-  ] as const;
-  const resolvedAuthMethod = authChoices.some(([value]) => value === effectiveAuthMethod)
+  const resolvedAuthMethod = HOST_AUTH_METHOD_CHOICES.some(([value]) => value === effectiveAuthMethod)
     ? effectiveAuthMethod
     : "auto";
   const selectedAuthMethodLabel = t(
-    authChoices.find(([value]) => value === resolvedAuthMethod)?.[1] ?? "hostDetails.auth.auto",
+    HOST_AUTH_METHOD_CHOICES.find(([value]) => value === resolvedAuthMethod)?.[1] ?? "hostDetails.auth.auto",
   );
   const effectiveEtEnabled = form.etEnabled ?? groupDefaults?.etEnabled;
   const effectiveProtocol = form.protocol ?? groupDefaults?.protocol;
@@ -160,8 +161,8 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
                 onValueChange={(val) => selectAuthMethod(val as "auto" | "password" | "key" | "certificate")}
               >
                 <SelectTrigger
-                  className="h-8 w-[7.5rem] gap-2"
-                  aria-label={selectedAuthMethodLabel}
+                  className="h-10 w-32 gap-2"
+                  aria-label={t("hostDetails.auth.method")}
                 >
                   {/*
                     Radix Select only mirrors the selected item text after the
@@ -173,7 +174,7 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
                   </span>
                 </SelectTrigger>
                 <SelectContent>
-                  {authChoices.map(([value, labelKey]) => (
+                  {HOST_AUTH_METHOD_CHOICES.map(([value, labelKey]) => (
                     <SelectItem key={value} value={value} textValue={t(labelKey)}>
                       {t(labelKey)}
                     </SelectItem>

--- a/components/HostDetailsConnectionSections.tsx
+++ b/components/HostDetailsConnectionSections.tsx
@@ -105,6 +105,12 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
     ["key", "hostDetails.auth.key"],
     ["certificate", "hostDetails.auth.certificate"],
   ] as const;
+  const resolvedAuthMethod = authChoices.some(([value]) => value === effectiveAuthMethod)
+    ? effectiveAuthMethod
+    : "auto";
+  const selectedAuthMethodLabel = t(
+    authChoices.find(([value]) => value === resolvedAuthMethod)?.[1] ?? "hostDetails.auth.auto",
+  );
   const effectiveEtEnabled = form.etEnabled ?? groupDefaults?.etEnabled;
   const effectiveProtocol = form.protocol ?? groupDefaults?.protocol;
 
@@ -145,49 +151,47 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
             </div>
           </div>
           <div className="grid gap-2">
-            <div className="space-y-2 rounded-md border border-border/60 bg-secondary/30 p-2.5">
-                <div>
-                  <div className="text-xs font-medium text-foreground">
-                    {t("hostDetails.auth.method")}
-                  </div>
-                  <div className="text-[11px] text-muted-foreground">
-                    {t(`hostDetails.auth.${effectiveAuthMethod}.desc`)}
-                  </div>
-                </div>
-                <div className="grid grid-cols-2 gap-1.5">
+            <HostDetailsSettingRow
+              label={t("hostDetails.auth.method")}
+              hint={t(`hostDetails.auth.${resolvedAuthMethod}.desc`)}
+            >
+              <Select
+                value={resolvedAuthMethod}
+                onValueChange={(val) => selectAuthMethod(val as "auto" | "password" | "key" | "certificate")}
+              >
+                <SelectTrigger
+                  className="h-8 w-[7.5rem] gap-2"
+                  aria-label={selectedAuthMethodLabel}
+                >
+                  {/*
+                    Radix Select only mirrors the selected item text after the
+                    closed control is measured. Render the current label directly
+                    so the default value is never blank on first paint.
+                  */}
+                  <span className="min-w-0 flex-1 truncate text-left">
+                    {selectedAuthMethodLabel}
+                  </span>
+                </SelectTrigger>
+                <SelectContent>
                   {authChoices.map(([value, labelKey]) => (
-                    <button
-                      key={value}
-                      type="button"
-                      aria-pressed={effectiveAuthMethod === value}
-                      onClick={() => selectAuthMethod(value)}
-                      className={`h-8 rounded-md border px-2 text-xs font-medium transition-colors ${
-                        effectiveAuthMethod === value
-                          ? "border-primary/60 bg-primary/10 text-primary"
-                          : "border-border/60 bg-background text-muted-foreground hover:text-foreground"
-                      }`}
-                    >
+                    <SelectItem key={value} value={value} textValue={t(labelKey)}>
                       {t(labelKey)}
-                    </button>
+                    </SelectItem>
                   ))}
-                </div>
-                {!effectiveEtEnabled && effectiveProtocol !== "et" && (
-                  <div className="mt-2 flex items-center justify-between gap-3 rounded-md border border-border/60 bg-background px-2.5 py-2">
-                    <div className="min-w-0">
-                      <div className="text-xs font-medium text-foreground">
-                        {t("hostDetails.auth.mfaFirst")}
-                      </div>
-                      <div className="text-[11px] text-muted-foreground">
-                        {t("hostDetails.auth.mfaFirst.desc")}
-                      </div>
-                    </div>
-                    <Switch
-                      checked={!!form.requiresMfa}
-                      onCheckedChange={(val) => update("requiresMfa" as keyof Host, val)}
-                    />
-                  </div>
-                )}
-            </div>
+                </SelectContent>
+              </Select>
+            </HostDetailsSettingRow>
+            {!effectiveEtEnabled && effectiveProtocol !== "et" && (
+              <HostDetailsSettingRow
+                label={t("hostDetails.auth.mfaFirst")}
+                hint={t("hostDetails.auth.mfaFirst.desc")}
+              >
+                <Switch
+                  checked={!!form.requiresMfa}
+                  onCheckedChange={(val) => update("requiresMfa" as keyof Host, val)}
+                />
+              </HostDetailsSettingRow>
+            )}
             {selectedIdentity ? (
               <div className="flex items-center gap-2 h-10 px-3 rounded-md border border-border/70 bg-secondary/60">
                 <User size={16} className="text-muted-foreground" />

--- a/components/HostDetailsConnectionSections.tsx
+++ b/components/HostDetailsConnectionSections.tsx
@@ -23,6 +23,19 @@ export const HOST_AUTH_METHOD_CHOICES = [
   ["certificate", "hostDetails.auth.certificate"],
 ] as const;
 
+export function shouldForceAuthMethodReselect(
+  nextMethod: "auto" | "password" | "key" | "certificate",
+  currentMethod: "auto" | "password" | "key" | "certificate",
+): boolean {
+  // Radix Select skips onValueChange when the value is unchanged. Key/certificate
+  // still need that path so re-opening the chooser keeps working.
+  return (
+    nextMethod === currentMethod
+    && (nextMethod === "key" || nextMethod === "certificate")
+  );
+}
+
+
 export const applyEffectiveHostAuthMethodSelection = (
   host: Host,
   authMethod: "auto" | "password" | "key" | "certificate",
@@ -175,7 +188,16 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
                 </SelectTrigger>
                 <SelectContent>
                   {HOST_AUTH_METHOD_CHOICES.map(([value, labelKey]) => (
-                    <SelectItem key={value} value={value} textValue={t(labelKey)}>
+                    <SelectItem
+                      key={value}
+                      value={value}
+                      textValue={t(labelKey)}
+                      onSelect={() => {
+                        if (shouldForceAuthMethodReselect(value, resolvedAuthMethod)) {
+                          selectAuthMethod(value);
+                        }
+                      }}
+                    >
                       {t(labelKey)}
                     </SelectItem>
                   ))}

--- a/components/HostDetailsConnectionSections.tsx
+++ b/components/HostDetailsConnectionSections.tsx
@@ -192,8 +192,18 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
                       key={value}
                       value={value}
                       textValue={t(labelKey)}
-                      onSelect={() => {
+                      onPointerUp={() => {
+                        // Radix skips consumer onValueChange for an unchanged value.
+                        // Key/certificate still need the same-item path to reopen the chooser.
                         if (shouldForceAuthMethodReselect(value, resolvedAuthMethod)) {
+                          selectAuthMethod(value);
+                        }
+                      }}
+                      onKeyDown={(event) => {
+                        if (
+                          (event.key === "Enter" || event.key === " ")
+                          && shouldForceAuthMethodReselect(value, resolvedAuthMethod)
+                        ) {
                           selectAuthMethod(value);
                         }
                       }}

--- a/components/HostDetailsConnectionSections.tsx
+++ b/components/HostDetailsConnectionSections.tsx
@@ -174,7 +174,7 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
                 onValueChange={(val) => selectAuthMethod(val as "auto" | "password" | "key" | "certificate")}
               >
                 <SelectTrigger
-                  className="h-10 w-32 gap-2"
+                  className="h-8 w-32 gap-2"
                   aria-label={t("hostDetails.auth.method")}
                 >
                   {/*

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -6,7 +6,6 @@ import {
   Search,
   Terminal,
   TerminalSquare,
-  Puzzle,
 } from "lucide-react";
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useI18n } from "../application/i18n/I18nProvider";


### PR DESCRIPTION
## Summary
- Move “prefer interactive auth” out of the nested login-method card into a normal host setting row.
- Replace the login-method button grid with a compact select control that always shows the current choice.
- Clean a few existing lint warnings in nearby app/plugin code.

## Why
The host credentials form looked denser and less consistent than the surrounding host settings. Nesting the interactive-auth switch inside the method chooser made the section hard to scan, and the four-button method picker didn’t match the rest of the form controls. The select also needed an always-visible selected label so the default method never looked blank.

## Validation
- `node --test --import tsx components/HostDetailsConnectionSections.test.tsx`
- `npx eslint App.tsx application/state/usePluginContributions.ts application/state/usePluginViewLifecycle.ts components/QuickSwitcher.tsx components/HostDetailsConnectionSections.tsx components/HostDetailsConnectionSections.test.tsx`