### PR TITLE
polish quick connect protocol picker presentation

### DIFF
--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -500,6 +500,7 @@ export const enVaultMessages: Messages = {
   'quickConnect.identity.unavailable': 'This identity is missing usable credentials on this device.',
   'quickConnect.identity.useCustom': 'Use custom credentials',
   'quickConnect.identity.connect': 'Connect with preset',
+  'quickConnect.connectTitle': 'Connect to {host}',
 
   // Terminal
   'terminal.connectionErrorTitle': 'Connection Error',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -536,6 +536,7 @@ export const ruVaultMessages: Messages = {
   'quickConnect.identity.unavailable': 'Для этого профиля нет доступных учётных данных на устройстве.',
   'quickConnect.identity.useCustom': 'Использовать другие данные',
   'quickConnect.identity.connect': 'Подключиться с профилем',
+  'quickConnect.connectTitle': 'Подключение к {host}',
 
   // Terminal
   'terminal.connectionErrorTitle': 'Ошибка подключения',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -61,6 +61,7 @@ export const zhCNVaultMessages: Messages = {
   'quickConnect.identity.unavailable': '此身份在当前设备上缺少可用凭据。',
   'quickConnect.identity.useCustom': '改用自定义凭据',
   'quickConnect.identity.connect': '使用预设连接',
+  'quickConnect.connectTitle': '连接到 {host}',
 
   // Protocol select dialog
   'protocolSelect.chooseProtocol': '选择协议',

--- a/application/i18n/locales/zh-TW/vault.ts
+++ b/application/i18n/locales/zh-TW/vault.ts
@@ -61,6 +61,7 @@ export const zhTWVaultMessages: Messages = {
   'quickConnect.identity.unavailable': '此身分在目前裝置上缺少可用憑據。',
   'quickConnect.identity.useCustom': '改用自訂憑據',
   'quickConnect.identity.connect': '使用預設連線',
+  'quickConnect.connectTitle': '連接到 {host}',
 
   // Protocol select dialog
   'protocolSelect.chooseProtocol': '選擇協定',

--- a/components/ProtocolSelectDialog.test.tsx
+++ b/components/ProtocolSelectDialog.test.tsx
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const source = fs.readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), "ProtocolSelectDialog.tsx"),
+  "utf8",
+);
+
+test("protocol select dialog uses plug header and semantic protocol icons", () => {
+  assert.match(source, /quickConnect\.connectTitle/);
+  assert.match(source, /<Plug size=\{18\} \/>/);
+  assert.doesNotMatch(source, /Progress indicator/);
+  assert.doesNotMatch(source, /DistroAvatar/);
+  assert.match(source, /bg-sky-500\/10 text-sky-500/);
+  assert.match(source, /bg-violet-500\/10 text-violet-500/);
+  assert.match(source, /bg-emerald-500\/10 text-emerald-500/);
+  assert.match(source, /bg-amber-500\/10 text-amber-500/);
+  assert.match(source, /<Shield size=\{18\} \/>/);
+  assert.match(source, /<Radio size=\{18\} \/>/);
+  assert.match(source, /<Link2 size=\{18\} \/>/);
+});

--- a/components/ProtocolSelectDialog.test.tsx
+++ b/components/ProtocolSelectDialog.test.tsx
@@ -22,4 +22,6 @@ test("protocol select dialog uses plug header and semantic protocol icons", () =
   assert.match(source, /<Shield size=\{18\} \/>/);
   assert.match(source, /<Radio size=\{18\} \/>/);
   assert.match(source, /<Link2 size=\{18\} \/>/);
+  assert.match(source, /text-sm font-medium leading-none/);
+  assert.doesNotMatch(source, /text-base font-semibold\}\{t\("protocolSelect\.chooseProtocol"\)\}/);
 });

--- a/components/ProtocolSelectDialog.test.tsx
+++ b/components/ProtocolSelectDialog.test.tsx
@@ -11,7 +11,8 @@ const source = fs.readFileSync(
 
 test("protocol select dialog uses plug header and semantic protocol icons", () => {
   assert.match(source, /quickConnect\.connectTitle/);
-  assert.match(source, /<Plug size=\{18\} \/>/);
+  assert.match(source, /<Plug size=\{18\} className="shrink-0 text-foreground" \/>/);
+  assert.doesNotMatch(source, /h-9 w-9 rounded-lg bg-primary\/15/);
   assert.doesNotMatch(source, /Progress indicator/);
   assert.doesNotMatch(source, /DistroAvatar/);
   assert.match(source, /bg-sky-500\/10 text-sky-500/);

--- a/components/ProtocolSelectDialog.test.tsx
+++ b/components/ProtocolSelectDialog.test.tsx
@@ -1,27 +1,45 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { I18nProvider } from "../application/i18n/I18nProvider";
+import type { Host } from "../types";
+import ProtocolSelectDialog from "./ProtocolSelectDialog";
+import { PROTOCOL_VISUAL_STYLES } from "./protocolVisuals";
 
-const source = fs.readFileSync(
-  path.join(path.dirname(fileURLToPath(import.meta.url)), "ProtocolSelectDialog.tsx"),
-  "utf8",
-);
+const host = (overrides: Partial<Host> = {}): Host => ({
+  id: "host-1",
+  label: "prod-db",
+  hostname: "10.2.0.31",
+  port: 22,
+  username: "root",
+  protocol: "ssh",
+  moshEnabled: true,
+  etEnabled: true,
+  telnetEnabled: true,
+  ...overrides,
+});
 
-test("protocol select dialog uses plug header and semantic protocol icons", () => {
-  assert.match(source, /quickConnect\.connectTitle/);
-  assert.match(source, /<Plug size=\{18\} className="shrink-0 text-foreground" \/>/);
-  assert.doesNotMatch(source, /h-9 w-9 rounded-lg bg-primary\/15/);
-  assert.doesNotMatch(source, /Progress indicator/);
-  assert.doesNotMatch(source, /DistroAvatar/);
-  assert.match(source, /bg-sky-500\/10 text-sky-500/);
-  assert.match(source, /bg-violet-500\/10 text-violet-500/);
-  assert.match(source, /bg-emerald-500\/10 text-emerald-500/);
-  assert.match(source, /bg-amber-500\/10 text-amber-500/);
-  assert.match(source, /<Shield size=\{18\} \/>/);
-  assert.match(source, /<Radio size=\{18\} \/>/);
-  assert.match(source, /<Link2 size=\{18\} \/>/);
-  assert.match(source, /text-sm font-medium/);
-  assert.doesNotMatch(source, /text-base font-semibold\}\{t\("protocolSelect\.chooseProtocol"\)\}/);
+test("protocol select dialog restores host label and shared protocol visuals", () => {
+  const markup = renderToStaticMarkup(
+    <I18nProvider locale="en">
+      <ProtocolSelectDialog
+        host={host()}
+        onSelect={() => undefined}
+        onCancel={() => undefined}
+      />
+    </I18nProvider>,
+  );
+
+  assert.match(markup, /Connect to prod-db/);
+  assert.match(markup, /10\.2\.0\.31:22/);
+  assert.match(markup, /lucide-plug/);
+  assert.match(markup, new RegExp(PROTOCOL_VISUAL_STYLES.ssh.selected.replace("/", "\\/")));
+  assert.match(markup, new RegExp(PROTOCOL_VISUAL_STYLES.mosh.idle.replace("/", "\\/")));
+  assert.match(markup, new RegExp(PROTOCOL_VISUAL_STYLES.et.idle.replace("/", "\\/")));
+  assert.match(markup, new RegExp(PROTOCOL_VISUAL_STYLES.telnet.idle.replace("/", "\\/")));
+  assert.match(markup, /lucide-shield/);
+  assert.match(markup, /lucide-radio/);
+  assert.match(markup, /lucide-link-2/);
+  assert.match(markup, /lucide-terminal/);
 });

--- a/components/ProtocolSelectDialog.test.tsx
+++ b/components/ProtocolSelectDialog.test.tsx
@@ -22,6 +22,6 @@ test("protocol select dialog uses plug header and semantic protocol icons", () =
   assert.match(source, /<Shield size=\{18\} \/>/);
   assert.match(source, /<Radio size=\{18\} \/>/);
   assert.match(source, /<Link2 size=\{18\} \/>/);
-  assert.match(source, /text-sm font-medium leading-none/);
+  assert.match(source, /text-sm font-medium/);
   assert.doesNotMatch(source, /text-base font-semibold\}\{t\("protocolSelect\.chooseProtocol"\)\}/);
 });

--- a/components/ProtocolSelectDialog.tsx
+++ b/components/ProtocolSelectDialog.tsx
@@ -151,7 +151,7 @@ const ProtocolSelectDialog: React.FC<ProtocolSelectDialogProps> = ({
 
                 {/* Protocol selection */}
                 <div className="px-6 py-4">
-                    <div className="space-y-2">
+                    <div className="space-y-3">
                     <h3 className="text-sm font-medium leading-none">{t("protocolSelect.chooseProtocol")}</h3>
                     <div className="space-y-3">
                         {protocolOptions.map((option) => (

--- a/components/ProtocolSelectDialog.tsx
+++ b/components/ProtocolSelectDialog.tsx
@@ -150,8 +150,9 @@ const ProtocolSelectDialog: React.FC<ProtocolSelectDialogProps> = ({
                 </div>
 
                 {/* Protocol selection */}
-                <div className="px-6 py-4 space-y-4">
-                    <h3 className="text-base font-semibold">{t("protocolSelect.chooseProtocol")}</h3>
+                <div className="px-6 py-4">
+                    <div className="space-y-2">
+                    <h3 className="text-sm font-medium leading-none">{t("protocolSelect.chooseProtocol")}</h3>
                     <div className="space-y-3">
                         {protocolOptions.map((option) => (
                             <button
@@ -197,6 +198,7 @@ const ProtocolSelectDialog: React.FC<ProtocolSelectDialogProps> = ({
                                 </div>
                             </button>
                         ))}
+                    </div>
                     </div>
                 </div>
 

--- a/components/ProtocolSelectDialog.tsx
+++ b/components/ProtocolSelectDialog.tsx
@@ -1,219 +1,207 @@
-import {
-Link2,
-Plug,
-Radio,
-Shield,
-Terminal as TerminalIcon,
-} from 'lucide-react';
-import React,{ useMemo,useState } from 'react';
-import { useI18n } from '../application/i18n/I18nProvider';
-import { formatHostPort } from '../domain/host';
-import { cn } from '../lib/utils';
-import { Host,HostProtocol } from '../types';
-import { Button } from './ui/button';
-import { Input } from './ui/input';
+import { Plug } from "lucide-react";
+import React, { useMemo, useState } from "react";
+import { useI18n } from "../application/i18n/I18nProvider";
+import { formatHostPort } from "../domain/host";
+import { cn } from "../lib/utils";
+import { Host, HostProtocol } from "../types";
+import { getProtocolVisualStyle, type ProtocolVisualKey } from "./protocolVisuals";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
 
 interface ProtocolOption {
-    protocol: HostProtocol;
-    port: number;
-    label: string;
-    icon: React.ReactNode;
-    description: string;
-    enabled: boolean;
-    iconIdleClass: string;
-    iconSelectedClass: string;
+  protocol: ProtocolVisualKey;
+  port: number;
+  label: string;
+  description: string;
+  enabled: boolean;
 }
 
 interface ProtocolSelectDialogProps {
-    host: Host;
-    onSelect: (protocol: HostProtocol, port: number) => void;
-    onCancel: () => void;
+  host: Host;
+  onSelect: (protocol: HostProtocol, port: number) => void;
+  onCancel: () => void;
 }
 
 const ProtocolSelectDialog: React.FC<ProtocolSelectDialogProps> = ({
-    host,
-    onSelect,
-    onCancel,
+  host,
+  onSelect,
+  onCancel,
 }) => {
-    const { t } = useI18n();
-    // Build protocol options from host configuration
-    const protocolOptions = useMemo<ProtocolOption[]>(() => {
-        const options: ProtocolOption[] = [];
+  const { t } = useI18n();
 
-        // SSH (always available if not explicitly disabled)
-        const sshEnabled = host.protocol === 'ssh' || !host.protocol || host.protocols?.some(p => p.protocol === 'ssh' && p.enabled);
-        if (sshEnabled !== false) {
-            const sshConfig = host.protocols?.find(p => p.protocol === 'ssh');
-            options.push({
-                protocol: 'ssh',
-                port: sshConfig?.port || host.port || 22,
-                label: 'SSH',
-                icon: <Shield size={18} />,
-                description: `ssh ${host.hostname}`,
-                enabled: true,
-                iconIdleClass: 'bg-sky-500/10 text-sky-500',
-                iconSelectedClass: 'bg-sky-500/20 text-sky-500',
-            });
-        }
+  const protocolOptions = useMemo<ProtocolOption[]>(() => {
+    const options: ProtocolOption[] = [];
 
-        // Mosh (if enabled)
-        if (host.moshEnabled || host.protocols?.some(p => p.protocol === 'mosh' && p.enabled)) {
-            const moshConfig = host.protocols?.find(p => p.protocol === 'mosh');
-            options.push({
-                protocol: 'mosh',
-                port: moshConfig?.port || host.port || 22,
-                label: 'Mosh',
-                icon: <Radio size={18} />,
-                description: `mosh ${host.hostname}`,
-                enabled: true,
-                iconIdleClass: 'bg-violet-500/10 text-violet-500',
-                iconSelectedClass: 'bg-violet-500/20 text-violet-500',
-            });
-        }
+    const sshEnabled =
+      host.protocol === "ssh" ||
+      !host.protocol ||
+      host.protocols?.some((p) => p.protocol === "ssh" && p.enabled);
+    if (sshEnabled !== false) {
+      const sshConfig = host.protocols?.find((p) => p.protocol === "ssh");
+      options.push({
+        protocol: "ssh",
+        port: sshConfig?.port || host.port || 22,
+        label: "SSH",
+        description: `ssh ${host.hostname}`,
+        enabled: true,
+      });
+    }
 
-        // EternalTerminal (if enabled)
-        if (host.etEnabled || host.protocols?.some(p => p.protocol === 'et' && p.enabled)) {
-            options.push({
-                protocol: 'et',
-                port: host.port || 22,
-                label: 'EternalTerminal',
-                icon: <Link2 size={18} />,
-                description: `et ${host.hostname}`,
-                enabled: true,
-                iconIdleClass: 'bg-emerald-500/10 text-emerald-500',
-                iconSelectedClass: 'bg-emerald-500/20 text-emerald-500',
-            });
-        }
+    if (host.moshEnabled || host.protocols?.some((p) => p.protocol === "mosh" && p.enabled)) {
+      const moshConfig = host.protocols?.find((p) => p.protocol === "mosh");
+      options.push({
+        protocol: "mosh",
+        port: moshConfig?.port || host.port || 22,
+        label: "Mosh",
+        description: `mosh ${host.hostname}`,
+        enabled: true,
+      });
+    }
 
-        // Telnet (if enabled)
-        if (host.telnetEnabled || host.protocol === 'telnet' || host.protocols?.some(p => p.protocol === 'telnet' && p.enabled)) {
-            const telnetConfig = host.protocols?.find(p => p.protocol === 'telnet');
-            options.push({
-                protocol: 'telnet',
-                port: telnetConfig?.port || host.telnetPort || 23,
-                label: 'Telnet',
-                icon: <TerminalIcon size={18} />,
-                description: `telnet ${host.hostname}`,
-                enabled: true,
-                iconIdleClass: 'bg-amber-500/10 text-amber-500',
-                iconSelectedClass: 'bg-amber-500/20 text-amber-500',
-            });
-        }
+    if (host.etEnabled || host.protocols?.some((p) => p.protocol === "et" && p.enabled)) {
+      options.push({
+        protocol: "et",
+        port: host.port || 22,
+        label: "EternalTerminal",
+        description: `et ${host.hostname}`,
+        enabled: true,
+      });
+    }
 
-        return options;
-    }, [host]);
+    if (
+      host.telnetEnabled ||
+      host.protocol === "telnet" ||
+      host.protocols?.some((p) => p.protocol === "telnet" && p.enabled)
+    ) {
+      const telnetConfig = host.protocols?.find((p) => p.protocol === "telnet");
+      options.push({
+        protocol: "telnet",
+        port: telnetConfig?.port || host.telnetPort || 23,
+        label: "Telnet",
+        description: `telnet ${host.hostname}`,
+        enabled: true,
+      });
+    }
 
-    // State for custom ports (allow editing inline)
-    const [ports, setPorts] = useState<Record<HostProtocol, number>>(() => {
-        const initial: Record<string, number> = {};
-        protocolOptions.forEach(opt => {
-            initial[opt.protocol] = opt.port;
-        });
-        return initial as Record<HostProtocol, number>;
+    return options;
+  }, [host]);
+
+  const [ports, setPorts] = useState<Record<HostProtocol, number>>(() => {
+    const initial: Record<string, number> = {};
+    protocolOptions.forEach((opt) => {
+      initial[opt.protocol] = opt.port;
     });
+    return initial as Record<HostProtocol, number>;
+  });
 
-    const [selectedProtocol, setSelectedProtocol] = useState<HostProtocol>(
-        protocolOptions[0]?.protocol || 'ssh'
-    );
+  const [selectedProtocol, setSelectedProtocol] = useState<HostProtocol>(
+    protocolOptions[0]?.protocol || "ssh",
+  );
 
-    const handlePortChange = (protocol: HostProtocol, value: string) => {
-        const port = parseInt(value, 10);
-        if (!isNaN(port) && port > 0 && port <= 65535) {
-            setPorts(prev => ({ ...prev, [protocol]: port }));
-        }
-    };
+  const handlePortChange = (protocol: HostProtocol, value: string) => {
+    const port = parseInt(value, 10);
+    if (!isNaN(port) && port > 0 && port <= 65535) {
+      setPorts((prev) => ({ ...prev, [protocol]: port }));
+    }
+  };
 
-    const handleContinue = () => {
-        onSelect(selectedProtocol, ports[selectedProtocol] || 22);
-    };
+  const handleContinue = () => {
+    onSelect(selectedProtocol, ports[selectedProtocol] || 22);
+  };
 
-    // If only one protocol, auto-select and proceed
-    React.useEffect(() => {
-        if (protocolOptions.length === 1) {
-            // Don't auto-proceed, let user confirm
-        }
-    }, [protocolOptions]);
+  const hostEndpoint = formatHostPort(
+    host.hostname,
+    ports[selectedProtocol] || host.port || 22,
+  );
 
-    return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={onCancel}>
-            <div className="w-[560px] max-w-[90vw] bg-background border border-border rounded-2xl animate-in fade-in-0 zoom-in-95 duration-200" style={{ boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25), 0 12px 24px -8px rgba(0, 0, 0, 0.15)' }} onClick={(e) => e.stopPropagation()}>
-                {/* Header */}
-                <div className="px-6 py-4 border-b border-border/50">
-                    <div className="flex items-center gap-2 min-w-0">
-                        <Plug size={18} className="shrink-0 text-foreground" />
-                        <h2 className="text-base font-semibold truncate">
-                            {t("quickConnect.connectTitle", {
-                                host: formatHostPort(host.hostname, ports[selectedProtocol] || host.port || 22),
-                            })}
-                        </h2>
-                    </div>
-                </div>
-
-                {/* Protocol selection */}
-                <div className="px-6 py-4">
-                    <div className="space-y-4">
-                    <h3 className="text-sm font-medium">{t("protocolSelect.chooseProtocol")}</h3>
-                    <div className="space-y-3">
-                        {protocolOptions.map((option) => (
-                            <button
-                                key={option.protocol}
-                                className={cn(
-                                    "w-full flex items-center justify-between px-4 py-3 rounded-xl border-2 transition-all text-left",
-                                    selectedProtocol === option.protocol
-                                        ? "border-primary bg-primary/5"
-                                        : "border-border/60 hover:border-border hover:bg-secondary/50"
-                                )}
-                                onClick={() => setSelectedProtocol(option.protocol)}
-                            >
-                                <div className="flex items-center gap-3">
-                                    <div className={cn(
-                                        "h-10 w-10 rounded-lg flex items-center justify-center",
-                                        selectedProtocol === option.protocol
-                                            ? option.iconSelectedClass
-                                            : option.iconIdleClass
-                                    )}>
-                                        {option.icon}
-                                    </div>
-                                    <div>
-                                        <div className="font-medium">{option.label}</div>
-                                        <div className="text-xs text-muted-foreground font-mono">
-                                            {option.description}
-                                        </div>
-                                    </div>
-                                </div>
-                                <div className="flex items-center gap-2">
-                                    <span className="text-xs text-muted-foreground">{t("protocolSelect.port")}</span>
-                                    <Input
-                                        type="number"
-                                        value={ports[option.protocol] || option.port}
-                                        onChange={(e) => handlePortChange(option.protocol, e.target.value)}
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            setSelectedProtocol(option.protocol);
-                                        }}
-                                        className="w-16 h-7 text-xs text-center"
-                                        min={1}
-                                        max={65535}
-                                    />
-                                </div>
-                            </button>
-                        ))}
-                    </div>
-                    </div>
-                </div>
-
-                {/* Footer */}
-                <div className="px-6 py-4 border-t border-border/50 flex items-center justify-between">
-                    <Button variant="secondary" onClick={onCancel}>
-                        {t("common.close")}
-                    </Button>
-                    <Button onClick={handleContinue}>
-                        {t("common.continue")}
-                    </Button>
-                </div>
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={onCancel}>
+      <div
+        className="w-[560px] max-w-[90vw] bg-background border border-border rounded-2xl animate-in fade-in-0 zoom-in-95 duration-200"
+        style={{
+          boxShadow:
+            "0 25px 50px -12px rgba(0, 0, 0, 0.25), 0 12px 24px -8px rgba(0, 0, 0, 0.15)",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-6 py-4 border-b border-border/50">
+          <div className="flex items-center gap-2 min-w-0">
+            <Plug size={18} className="shrink-0 text-foreground" />
+            <div className="min-w-0">
+              <h2 className="text-base font-semibold truncate">
+                {t("quickConnect.connectTitle", {
+                  host: host.label?.trim() || host.hostname,
+                })}
+              </h2>
+              <p className="text-xs text-muted-foreground font-mono truncate">{hostEndpoint}</p>
             </div>
+          </div>
         </div>
-    );
+
+        <div className="px-6 py-4">
+          <div className="space-y-4">
+            <h3 className="text-sm font-medium">{t("protocolSelect.chooseProtocol")}</h3>
+            <div className="space-y-3">
+              {protocolOptions.map((option) => {
+                const visual = getProtocolVisualStyle(option.protocol);
+                return (
+                  <button
+                    key={option.protocol}
+                    className={cn(
+                      "w-full flex items-center justify-between px-4 py-3 rounded-xl border-2 transition-all text-left",
+                      selectedProtocol === option.protocol
+                        ? "border-primary bg-primary/5"
+                        : "border-border/60 hover:border-border hover:bg-secondary/50",
+                    )}
+                    onClick={() => setSelectedProtocol(option.protocol)}
+                  >
+                    <div className="flex items-center gap-3">
+                      <div
+                        className={cn(
+                          "h-10 w-10 rounded-lg flex items-center justify-center",
+                          selectedProtocol === option.protocol ? visual.selected : visual.idle,
+                        )}
+                      >
+                        {visual.icon}
+                      </div>
+                      <div>
+                        <div className="font-medium">{option.label}</div>
+                        <div className="text-xs text-muted-foreground font-mono">
+                          {option.description}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs text-muted-foreground">{t("protocolSelect.port")}</span>
+                      <Input
+                        type="number"
+                        value={ports[option.protocol] || option.port}
+                        onChange={(e) => handlePortChange(option.protocol, e.target.value)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedProtocol(option.protocol);
+                        }}
+                        className="w-16 h-7 text-xs text-center"
+                        min={1}
+                        max={65535}
+                      />
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        <div className="px-6 py-4 border-t border-border/50 flex items-center justify-between">
+          <Button variant="secondary" onClick={onCancel}>
+            {t("common.close")}
+          </Button>
+          <Button onClick={handleContinue}>{t("common.continue")}</Button>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default ProtocolSelectDialog;

--- a/components/ProtocolSelectDialog.tsx
+++ b/components/ProtocolSelectDialog.tsx
@@ -151,8 +151,8 @@ const ProtocolSelectDialog: React.FC<ProtocolSelectDialogProps> = ({
 
                 {/* Protocol selection */}
                 <div className="px-6 py-4">
-                    <div className="space-y-3">
-                    <h3 className="text-sm font-medium leading-none">{t("protocolSelect.chooseProtocol")}</h3>
+                    <div className="space-y-4">
+                    <h3 className="text-sm font-medium">{t("protocolSelect.chooseProtocol")}</h3>
                     <div className="space-y-3">
                         {protocolOptions.map((option) => (
                             <button

--- a/components/ProtocolSelectDialog.tsx
+++ b/components/ProtocolSelectDialog.tsx
@@ -1,13 +1,15 @@
 import {
-Globe,
+Link2,
+Plug,
+Radio,
+Shield,
 Terminal as TerminalIcon,
-Wifi
 } from 'lucide-react';
 import React,{ useMemo,useState } from 'react';
 import { useI18n } from '../application/i18n/I18nProvider';
+import { formatHostPort } from '../domain/host';
 import { cn } from '../lib/utils';
 import { Host,HostProtocol } from '../types';
-import { DistroAvatar } from './DistroAvatar';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
 
@@ -18,6 +20,8 @@ interface ProtocolOption {
     icon: React.ReactNode;
     description: string;
     enabled: boolean;
+    iconIdleClass: string;
+    iconSelectedClass: string;
 }
 
 interface ProtocolSelectDialogProps {
@@ -44,9 +48,11 @@ const ProtocolSelectDialog: React.FC<ProtocolSelectDialogProps> = ({
                 protocol: 'ssh',
                 port: sshConfig?.port || host.port || 22,
                 label: 'SSH',
-                icon: <TerminalIcon size={18} />,
+                icon: <Shield size={18} />,
                 description: `ssh ${host.hostname}`,
                 enabled: true,
+                iconIdleClass: 'bg-sky-500/10 text-sky-500',
+                iconSelectedClass: 'bg-sky-500/20 text-sky-500',
             });
         }
 
@@ -57,9 +63,11 @@ const ProtocolSelectDialog: React.FC<ProtocolSelectDialogProps> = ({
                 protocol: 'mosh',
                 port: moshConfig?.port || host.port || 22,
                 label: 'Mosh',
-                icon: <Wifi size={18} />,
+                icon: <Radio size={18} />,
                 description: `mosh ${host.hostname}`,
                 enabled: true,
+                iconIdleClass: 'bg-violet-500/10 text-violet-500',
+                iconSelectedClass: 'bg-violet-500/20 text-violet-500',
             });
         }
 
@@ -69,9 +77,11 @@ const ProtocolSelectDialog: React.FC<ProtocolSelectDialogProps> = ({
                 protocol: 'et',
                 port: host.port || 22,
                 label: 'EternalTerminal',
-                icon: <Wifi size={18} />,
+                icon: <Link2 size={18} />,
                 description: `et ${host.hostname}`,
                 enabled: true,
+                iconIdleClass: 'bg-emerald-500/10 text-emerald-500',
+                iconSelectedClass: 'bg-emerald-500/20 text-emerald-500',
             });
         }
 
@@ -82,9 +92,11 @@ const ProtocolSelectDialog: React.FC<ProtocolSelectDialogProps> = ({
                 protocol: 'telnet',
                 port: telnetConfig?.port || host.telnetPort || 23,
                 label: 'Telnet',
-                icon: <Globe size={18} />,
+                icon: <TerminalIcon size={18} />,
                 description: `telnet ${host.hostname}`,
                 enabled: true,
+                iconIdleClass: 'bg-amber-500/10 text-amber-500',
+                iconSelectedClass: 'bg-amber-500/20 text-amber-500',
             });
         }
 
@@ -126,32 +138,16 @@ const ProtocolSelectDialog: React.FC<ProtocolSelectDialogProps> = ({
         <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={onCancel}>
             <div className="w-[560px] max-w-[90vw] bg-background border border-border rounded-2xl animate-in fade-in-0 zoom-in-95 duration-200" style={{ boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25), 0 12px 24px -8px rgba(0, 0, 0, 0.15)' }} onClick={(e) => e.stopPropagation()}>
                 {/* Header */}
-                <div className="px-6 py-5 border-b border-border/50">
-                    <div className="flex items-center gap-3">
-                        <DistroAvatar
-                            host={host}
-                            fallback={host.label.slice(0, 2).toUpperCase()}
-                            className="h-12 w-12"
-                        />
-                        <div>
-                            <h2 className="text-base font-semibold">{host.label}</h2>
-                            <p className="text-xs text-muted-foreground font-mono">
-                                {host.hostname}
-                            </p>
+                <div className="px-6 py-4 border-b border-border/50">
+                    <div className="flex items-center gap-3 min-w-0">
+                        <div className="h-9 w-9 rounded-lg bg-primary/15 text-primary flex items-center justify-center shrink-0">
+                            <Plug size={18} />
                         </div>
-                    </div>
-                </div>
-
-                {/* Progress indicator */}
-                <div className="px-6 py-4">
-                    <div className="flex items-center gap-3">
-                        <div className="h-8 w-8 rounded-full bg-primary/20 text-primary flex items-center justify-center">
-                            <TerminalIcon size={14} />
-                        </div>
-                        <div className="flex-1 h-0.5 bg-muted" />
-                        <div className="h-8 w-8 rounded-full bg-muted text-muted-foreground flex items-center justify-center text-xs font-mono">
-                            {'>_'}
-                        </div>
+                        <h2 className="text-base font-semibold truncate">
+                            {t("quickConnect.connectTitle", {
+                                host: formatHostPort(host.hostname, ports[selectedProtocol] || host.port || 22),
+                            })}
+                        </h2>
                     </div>
                 </div>
 
@@ -174,8 +170,8 @@ const ProtocolSelectDialog: React.FC<ProtocolSelectDialogProps> = ({
                                     <div className={cn(
                                         "h-10 w-10 rounded-lg flex items-center justify-center",
                                         selectedProtocol === option.protocol
-                                            ? "bg-primary/20 text-primary"
-                                            : "bg-muted text-muted-foreground"
+                                            ? option.iconSelectedClass
+                                            : option.iconIdleClass
                                     )}>
                                         {option.icon}
                                     </div>

--- a/components/ProtocolSelectDialog.tsx
+++ b/components/ProtocolSelectDialog.tsx
@@ -139,10 +139,8 @@ const ProtocolSelectDialog: React.FC<ProtocolSelectDialogProps> = ({
             <div className="w-[560px] max-w-[90vw] bg-background border border-border rounded-2xl animate-in fade-in-0 zoom-in-95 duration-200" style={{ boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25), 0 12px 24px -8px rgba(0, 0, 0, 0.15)' }} onClick={(e) => e.stopPropagation()}>
                 {/* Header */}
                 <div className="px-6 py-4 border-b border-border/50">
-                    <div className="flex items-center gap-3 min-w-0">
-                        <div className="h-9 w-9 rounded-lg bg-primary/15 text-primary flex items-center justify-center shrink-0">
-                            <Plug size={18} />
-                        </div>
+                    <div className="flex items-center gap-2 min-w-0">
+                        <Plug size={18} className="shrink-0 text-foreground" />
                         <h2 className="text-base font-semibold truncate">
                             {t("quickConnect.connectTitle", {
                                 host: formatHostPort(host.hostname, ports[selectedProtocol] || host.port || 22),

--- a/components/QuickConnectWizard.test.tsx
+++ b/components/QuickConnectWizard.test.tsx
@@ -74,5 +74,31 @@ test("quick connect protocol step uses simplified connect header and protocol ic
   assert.match(markup, /lucide-radio/);
   assert.match(markup, /lucide-link-2/);
   assert.match(markup, /lucide-terminal/);
+  assert.match(markup, /text-sm font-medium leading-none[^>]*>Choose protocol</);
+});
+
+test("quick connect credential section title matches protocol section title style", () => {
+  const markup = renderToStaticMarkup(
+    <I18nProvider locale="en">
+      <QuickConnectWizard
+        open
+        target={{ hostname: "10.2.0.31" }}
+        keys={[]}
+        identities={[{
+          id: "identity-root",
+          label: "Root devices",
+          username: "root",
+          authMethod: "password",
+          password: "secret",
+          created: 1,
+        }]}
+        onConnect={() => undefined}
+        onClose={() => undefined}
+      />
+    </I18nProvider>,
+  );
+
+  assert.match(markup, /text-sm font-medium leading-none[^>]*>Choose protocol</);
+  assert.match(markup, /text-sm font-medium leading-none[^>]*>Credential preset</);
 });
 

--- a/components/QuickConnectWizard.test.tsx
+++ b/components/QuickConnectWizard.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { I18nProvider } from "../application/i18n/I18nProvider";
 import QuickConnectWizard from "./QuickConnectWizard";
+import { PROTOCOL_VISUAL_STYLES } from "./protocolVisuals";
 
 test("QuickConnectWizard offers ET without obsolete Mosh path or log controls", () => {
   const markup = renderToStaticMarkup(
@@ -66,10 +67,10 @@ test("quick connect protocol step uses simplified connect header and protocol ic
   assert.match(markup, /Connect to 10\.2\.0\.31:22/);
   assert.match(markup, /lucide-plug/);
   assert.doesNotMatch(markup, />_</);
-  assert.match(markup, /bg-sky-500\/20 text-sky-500/);
-  assert.match(markup, /bg-violet-500\/10 text-violet-500/);
-  assert.match(markup, /bg-emerald-500\/10 text-emerald-500/);
-  assert.match(markup, /bg-amber-500\/10 text-amber-500/);
+  assert.match(markup, new RegExp(PROTOCOL_VISUAL_STYLES.ssh.selected.replace("/", "\\/")));
+  assert.match(markup, new RegExp(PROTOCOL_VISUAL_STYLES.mosh.idle.replace("/", "\\/")));
+  assert.match(markup, new RegExp(PROTOCOL_VISUAL_STYLES.et.idle.replace("/", "\\/")));
+  assert.match(markup, new RegExp(PROTOCOL_VISUAL_STYLES.telnet.idle.replace("/", "\\/")));
   assert.match(markup, /lucide-shield/);
   assert.match(markup, /lucide-radio/);
   assert.match(markup, /lucide-link-2/);

--- a/components/QuickConnectWizard.test.tsx
+++ b/components/QuickConnectWizard.test.tsx
@@ -74,7 +74,7 @@ test("quick connect protocol step uses simplified connect header and protocol ic
   assert.match(markup, /lucide-radio/);
   assert.match(markup, /lucide-link-2/);
   assert.match(markup, /lucide-terminal/);
-  assert.match(markup, /text-sm font-medium leading-none[^>]*>Choose protocol</);
+  assert.match(markup, /text-sm font-medium[^>]*>Choose protocol</);
 });
 
 test("quick connect credential section title matches protocol section title style", () => {
@@ -98,7 +98,7 @@ test("quick connect credential section title matches protocol section title styl
     </I18nProvider>,
   );
 
-  assert.match(markup, /text-sm font-medium leading-none[^>]*>Choose protocol</);
-  assert.match(markup, /text-sm font-medium leading-none[^>]*>Credential preset</);
+  assert.match(markup, /text-sm font-medium[^>]*>Choose protocol</);
+  assert.match(markup, /text-sm font-medium[^>]*>Credential preset</);
 });
 

--- a/components/QuickConnectWizard.test.tsx
+++ b/components/QuickConnectWizard.test.tsx
@@ -48,3 +48,31 @@ test("quick connect shows saved identities as credential presets", () => {
   assert.match(markup, /Credential preset/);
   assert.match(markup, /Choose a saved identity/);
 });
+
+test("quick connect protocol step uses simplified connect header and protocol icons", () => {
+  const markup = renderToStaticMarkup(
+    <I18nProvider locale="en">
+      <QuickConnectWizard
+        open
+        target={{ hostname: "10.2.0.31" }}
+        keys={[]}
+        identities={[]}
+        onConnect={() => undefined}
+        onClose={() => undefined}
+      />
+    </I18nProvider>,
+  );
+
+  assert.match(markup, /Connect to 10\.2\.0\.31:22/);
+  assert.match(markup, /lucide-plug/);
+  assert.doesNotMatch(markup, />_</);
+  assert.match(markup, /bg-sky-500\/20 text-sky-500/);
+  assert.match(markup, /bg-violet-500\/10 text-violet-500/);
+  assert.match(markup, /bg-emerald-500\/10 text-emerald-500/);
+  assert.match(markup, /bg-amber-500\/10 text-amber-500/);
+  assert.match(markup, /lucide-shield/);
+  assert.match(markup, /lucide-radio/);
+  assert.match(markup, /lucide-link-2/);
+  assert.match(markup, /lucide-terminal/);
+});
+

--- a/components/QuickConnectWizard.tsx
+++ b/components/QuickConnectWizard.tsx
@@ -287,7 +287,7 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
   // Render protocol selection step
   const renderProtocolStep = () => (
     <div className="space-y-5">
-      <div className="space-y-2">
+      <div className="space-y-3">
       <h3 className="text-sm font-medium leading-none">{t("protocolSelect.chooseProtocol")}</h3>
       <div className="space-y-3">
         {/* SSH */}
@@ -461,7 +461,7 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
       </div>
 
       {protocol !== "telnet" && identities.length > 0 && (
-        <div className="space-y-2">
+        <div className="space-y-3">
           <Label className="text-sm font-medium leading-none">{t("quickConnect.identity.label")}</Label>
           <Combobox
             options={identityOptions}

--- a/components/QuickConnectWizard.tsx
+++ b/components/QuickConnectWizard.tsx
@@ -4,13 +4,9 @@ import {
   Eye,
   EyeOff,
   Key,
-  Link2,
   Lock,
   Plug,
   Plus,
-  Radio,
-  Shield,
-  Terminal as TerminalIcon,
   User,
 } from "lucide-react";
 import React, { useMemo, useState } from "react";
@@ -32,34 +28,9 @@ import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Dropdown, DropdownContent, DropdownTrigger } from "./ui/dropdown";
 import { ScrollArea } from "./ui/scroll-area";
+import { PROTOCOL_VISUAL_STYLES } from "./protocolVisuals";
 
 
-const PROTOCOL_ICON_STYLES: Record<QuickConnectProtocol, {
-  icon: React.ReactNode;
-  idle: string;
-  selected: string;
-}> = {
-  ssh: {
-    icon: <Shield size={18} />,
-    idle: "bg-sky-500/10 text-sky-500",
-    selected: "bg-sky-500/20 text-sky-500",
-  },
-  mosh: {
-    icon: <Radio size={18} />,
-    idle: "bg-violet-500/10 text-violet-500",
-    selected: "bg-violet-500/20 text-violet-500",
-  },
-  et: {
-    icon: <Link2 size={18} />,
-    idle: "bg-emerald-500/10 text-emerald-500",
-    selected: "bg-emerald-500/20 text-emerald-500",
-  },
-  telnet: {
-    icon: <TerminalIcon size={18} />,
-    idle: "bg-amber-500/10 text-amber-500",
-    selected: "bg-amber-500/20 text-amber-500",
-  },
-};
 
 // Wizard steps
 type WizardStep = "protocol" | "username" | "knownhost" | "auth";
@@ -305,11 +276,11 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
               className={cn(
                 "h-10 w-10 rounded-lg flex items-center justify-center",
                 protocol === "ssh"
-                  ? PROTOCOL_ICON_STYLES.ssh.selected
-                  : PROTOCOL_ICON_STYLES.ssh.idle,
+                  ? PROTOCOL_VISUAL_STYLES.ssh.selected
+                  : PROTOCOL_VISUAL_STYLES.ssh.idle,
               )}
             >
-              {PROTOCOL_ICON_STYLES.ssh.icon}
+              {PROTOCOL_VISUAL_STYLES.ssh.icon}
             </div>
             <div>
               <div className="font-medium">SSH</div>
@@ -347,11 +318,11 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
               className={cn(
                 "h-10 w-10 rounded-lg flex items-center justify-center",
                 protocol === "mosh"
-                  ? PROTOCOL_ICON_STYLES.mosh.selected
-                  : PROTOCOL_ICON_STYLES.mosh.idle,
+                  ? PROTOCOL_VISUAL_STYLES.mosh.selected
+                  : PROTOCOL_VISUAL_STYLES.mosh.idle,
               )}
             >
-              {PROTOCOL_ICON_STYLES.mosh.icon}
+              {PROTOCOL_VISUAL_STYLES.mosh.icon}
             </div>
             <div>
               <div className="font-medium">Mosh</div>
@@ -389,11 +360,11 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
               className={cn(
                 "h-10 w-10 rounded-lg flex items-center justify-center",
                 protocol === "et"
-                  ? PROTOCOL_ICON_STYLES.et.selected
-                  : PROTOCOL_ICON_STYLES.et.idle,
+                  ? PROTOCOL_VISUAL_STYLES.et.selected
+                  : PROTOCOL_VISUAL_STYLES.et.idle,
               )}
             >
-              {PROTOCOL_ICON_STYLES.et.icon}
+              {PROTOCOL_VISUAL_STYLES.et.icon}
             </div>
             <div>
               <div className="font-medium">Eternal Terminal</div>
@@ -431,11 +402,11 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
               className={cn(
                 "h-10 w-10 rounded-lg flex items-center justify-center",
                 protocol === "telnet"
-                  ? PROTOCOL_ICON_STYLES.telnet.selected
-                  : PROTOCOL_ICON_STYLES.telnet.idle,
+                  ? PROTOCOL_VISUAL_STYLES.telnet.selected
+                  : PROTOCOL_VISUAL_STYLES.telnet.idle,
               )}
             >
-              {PROTOCOL_ICON_STYLES.telnet.icon}
+              {PROTOCOL_VISUAL_STYLES.telnet.icon}
             </div>
             <div>
               <div className="font-medium">Telnet</div>
@@ -687,9 +658,17 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
     </div>
   );
 
-  const connectTitle = t("quickConnect.connectTitle", {
-    host: formatHostPort(target.hostname, port || getQuickConnectDefaultPort(protocol)),
-  });
+  const hostEndpoint = formatHostPort(target.hostname, port || getQuickConnectDefaultPort(protocol));
+  const connectTitle = t("quickConnect.connectTitle", { host: hostEndpoint });
+  const protocolLabel = protocol === "et" ? "ET" : protocol.toUpperCase();
+  const effectiveUsername = username || target.username || "";
+  const connectSubtitle = step === "protocol"
+    ? null
+    : (
+      effectiveUsername
+        ? `${protocolLabel} ${effectiveUsername}@${hostEndpoint}`
+        : `${protocolLabel} ${hostEndpoint}`
+    );
 
   return (
     <div
@@ -708,7 +687,12 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
         <div className="px-6 py-4 border-b border-border/50">
           <div className="flex items-center gap-2 min-w-0">
             <Plug size={18} className="shrink-0 text-foreground" />
-            <h2 className="text-base font-semibold truncate">{connectTitle}</h2>
+            <div className="min-w-0">
+              <h2 className="text-base font-semibold truncate">{connectTitle}</h2>
+              {connectSubtitle ? (
+                <p className="text-xs text-muted-foreground font-mono truncate">{connectSubtitle}</p>
+              ) : null}
+            </div>
           </div>
         </div>
 

--- a/components/QuickConnectWizard.tsx
+++ b/components/QuickConnectWizard.tsx
@@ -286,9 +286,9 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
 
   // Render protocol selection step
   const renderProtocolStep = () => (
-    <div className="space-y-5">
-      <div className="space-y-3">
-      <h3 className="text-sm font-medium leading-none">{t("protocolSelect.chooseProtocol")}</h3>
+    <div className="space-y-6">
+      <div className="space-y-4">
+      <h3 className="text-sm font-medium">{t("protocolSelect.chooseProtocol")}</h3>
       <div className="space-y-3">
         {/* SSH */}
         <button
@@ -461,16 +461,18 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
       </div>
 
       {protocol !== "telnet" && identities.length > 0 && (
-        <div className="space-y-3">
-          <Label className="text-sm font-medium leading-none">{t("quickConnect.identity.label")}</Label>
-          <Combobox
-            options={identityOptions}
-            value={selectedIdentityId || undefined}
-            onValueChange={handleIdentitySelect}
-            placeholder={t("quickConnect.identity.placeholder")}
-            emptyText={t("quickConnect.identity.empty")}
-            icon={<User size={14} />}
-          />
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-3">
+            <Label className="text-sm font-medium">{t("quickConnect.identity.label")}</Label>
+            <Combobox
+              options={identityOptions}
+              value={selectedIdentityId || undefined}
+              onValueChange={handleIdentitySelect}
+              placeholder={t("quickConnect.identity.placeholder")}
+              emptyText={t("quickConnect.identity.empty")}
+              icon={<User size={14} />}
+            />
+          </div>
           <p className="text-xs text-muted-foreground">
             {selectedIdentity
               ? t("quickConnect.identity.selectedHint", { username: selectedIdentity.username })

--- a/components/QuickConnectWizard.tsx
+++ b/components/QuickConnectWizard.tsx
@@ -3,10 +3,13 @@ import {
   ChevronDown,
   Eye,
   EyeOff,
-  Globe,
   Key,
+  Link2,
   Lock,
+  Plug,
   Plus,
+  Radio,
+  Shield,
   Terminal as TerminalIcon,
   User,
 } from "lucide-react";
@@ -29,6 +32,34 @@ import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Dropdown, DropdownContent, DropdownTrigger } from "./ui/dropdown";
 import { ScrollArea } from "./ui/scroll-area";
+
+
+const PROTOCOL_ICON_STYLES: Record<QuickConnectProtocol, {
+  icon: React.ReactNode;
+  idle: string;
+  selected: string;
+}> = {
+  ssh: {
+    icon: <Shield size={18} />,
+    idle: "bg-sky-500/10 text-sky-500",
+    selected: "bg-sky-500/20 text-sky-500",
+  },
+  mosh: {
+    icon: <Radio size={18} />,
+    idle: "bg-violet-500/10 text-violet-500",
+    selected: "bg-violet-500/20 text-violet-500",
+  },
+  et: {
+    icon: <Link2 size={18} />,
+    idle: "bg-emerald-500/10 text-emerald-500",
+    selected: "bg-emerald-500/20 text-emerald-500",
+  },
+  telnet: {
+    icon: <TerminalIcon size={18} />,
+    idle: "bg-amber-500/10 text-amber-500",
+    selected: "bg-amber-500/20 text-amber-500",
+  },
+};
 
 // Wizard steps
 type WizardStep = "protocol" | "username" | "knownhost" | "auth";
@@ -273,11 +304,11 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
               className={cn(
                 "h-10 w-10 rounded-lg flex items-center justify-center",
                 protocol === "ssh"
-                  ? "bg-primary/20 text-primary"
-                  : "bg-muted text-muted-foreground",
+                  ? PROTOCOL_ICON_STYLES.ssh.selected
+                  : PROTOCOL_ICON_STYLES.ssh.idle,
               )}
             >
-              <TerminalIcon size={18} />
+              {PROTOCOL_ICON_STYLES.ssh.icon}
             </div>
             <div>
               <div className="font-medium">SSH</div>
@@ -315,11 +346,11 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
               className={cn(
                 "h-10 w-10 rounded-lg flex items-center justify-center",
                 protocol === "mosh"
-                  ? "bg-primary/20 text-primary"
-                  : "bg-muted text-muted-foreground",
+                  ? PROTOCOL_ICON_STYLES.mosh.selected
+                  : PROTOCOL_ICON_STYLES.mosh.idle,
               )}
             >
-              <Globe size={18} />
+              {PROTOCOL_ICON_STYLES.mosh.icon}
             </div>
             <div>
               <div className="font-medium">Mosh</div>
@@ -357,11 +388,11 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
               className={cn(
                 "h-10 w-10 rounded-lg flex items-center justify-center",
                 protocol === "et"
-                  ? "bg-primary/20 text-primary"
-                  : "bg-muted text-muted-foreground",
+                  ? PROTOCOL_ICON_STYLES.et.selected
+                  : PROTOCOL_ICON_STYLES.et.idle,
               )}
             >
-              <Globe size={18} />
+              {PROTOCOL_ICON_STYLES.et.icon}
             </div>
             <div>
               <div className="font-medium">Eternal Terminal</div>
@@ -399,11 +430,11 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
               className={cn(
                 "h-10 w-10 rounded-lg flex items-center justify-center",
                 protocol === "telnet"
-                  ? "bg-primary/20 text-primary"
-                  : "bg-muted text-muted-foreground",
+                  ? PROTOCOL_ICON_STYLES.telnet.selected
+                  : PROTOCOL_ICON_STYLES.telnet.idle,
               )}
             >
-              <TerminalIcon size={18} />
+              {PROTOCOL_ICON_STYLES.telnet.icon}
             </div>
             <div>
               <div className="font-medium">Telnet</div>
@@ -652,87 +683,9 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
     </div>
   );
 
-  // Get step title
-  const getStepTitle = () => {
-    switch (step) {
-      case "protocol":
-        return target.hostname;
-      case "username":
-        return target.hostname;
-      case "knownhost":
-        return target.hostname;
-      case "auth":
-        return target.hostname;
-    }
-  };
-
-  // Get step subtitle
-  const getStepSubtitle = () => {
-    const effectiveUsername = username || target.username || "";
-    switch (step) {
-      case "protocol":
-        return target.hostname;
-      case "username":
-        return `${protocol.toUpperCase()} ${formatHostPort(target.hostname, port)}`;
-      case "knownhost":
-        return `${protocol.toUpperCase()} ${effectiveUsername}@${formatHostPort(target.hostname, port)}`;
-      case "auth":
-        return `${protocol.toUpperCase()} ${formatHostPort(target.hostname, port)}`;
-    }
-  };
-
-  // Render progress indicator
-  const renderProgressIndicator = () => {
-    const steps: WizardStep[] = target.username
-      ? ["protocol", "auth"]
-      : ["protocol", "username", "auth"];
-    const currentIndex = steps.indexOf(step);
-
-    return (
-      <div className="flex items-center gap-3 py-3">
-        <div
-          className={cn(
-            "h-8 w-8 rounded-full flex items-center justify-center flex-shrink-0",
-            currentIndex >= 0
-              ? "bg-primary/20 text-primary"
-              : "bg-muted text-muted-foreground",
-          )}
-        >
-          <TerminalIcon size={14} />
-        </div>
-        <div className="flex-1 h-0.5 bg-muted" />
-        {!target.username && (
-          <>
-            <div
-              className={cn(
-                "h-8 w-8 rounded-full flex items-center justify-center flex-shrink-0",
-                currentIndex >= 1
-                  ? "bg-primary/20 text-primary"
-                  : "bg-muted text-muted-foreground",
-              )}
-            >
-              <User size={14} />
-            </div>
-            <div className="flex-1 h-0.5 bg-muted" />
-          </>
-        )}
-        <div
-          className={cn(
-            "h-8 w-8 rounded-full flex items-center justify-center flex-shrink-0",
-            step === "auth"
-              ? "bg-primary/20 text-primary"
-              : "bg-muted text-muted-foreground",
-          )}
-        >
-          {authMethod === "password" ? <Lock size={14} /> : <Key size={14} />}
-        </div>
-        <div className="flex-1 h-0.5 bg-muted" />
-        <div className="h-8 w-8 rounded-full bg-muted text-muted-foreground flex items-center justify-center text-xs font-mono">
-          {">_"}
-        </div>
-      </div>
-    );
-  };
+  const connectTitle = t("quickConnect.connectTitle", {
+    host: formatHostPort(target.hostname, port || getQuickConnectDefaultPort(protocol)),
+  });
 
   return (
     <div
@@ -748,24 +701,15 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="px-6 py-5 border-b border-border/50">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="h-12 w-12 rounded-xl bg-primary/15 text-primary flex items-center justify-center">
-                <TerminalIcon size={22} />
-              </div>
-              <div>
-                <h2 className="text-base font-semibold">{getStepTitle()}</h2>
-                <p className="text-xs text-muted-foreground font-mono">
-                  {getStepSubtitle()}
-                </p>
-              </div>
+        <div className="px-6 py-4 border-b border-border/50">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="h-9 w-9 rounded-lg bg-primary/15 text-primary flex items-center justify-center shrink-0">
+              <Plug size={18} />
             </div>
+            <h2 className="text-base font-semibold truncate">{connectTitle}</h2>
           </div>
         </div>
 
-        {/* Progress indicator */}
-        <div className="px-6">{renderProgressIndicator()}</div>
 
         {warnings && warnings.length > 0 && (
           <div className="px-6 pb-2">

--- a/components/QuickConnectWizard.tsx
+++ b/components/QuickConnectWizard.tsx
@@ -286,8 +286,9 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
 
   // Render protocol selection step
   const renderProtocolStep = () => (
-    <div className="space-y-4">
-      <h3 className="text-base font-semibold">{t("protocolSelect.chooseProtocol")}</h3>
+    <div className="space-y-5">
+      <div className="space-y-2">
+      <h3 className="text-sm font-medium leading-none">{t("protocolSelect.chooseProtocol")}</h3>
       <div className="space-y-3">
         {/* SSH */}
         <button
@@ -457,10 +458,11 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
           </div>
         </button>
       </div>
+      </div>
 
       {protocol !== "telnet" && identities.length > 0 && (
-        <div className="space-y-2 pt-1">
-          <Label>{t("quickConnect.identity.label")}</Label>
+        <div className="space-y-2">
+          <Label className="text-sm font-medium leading-none">{t("quickConnect.identity.label")}</Label>
           <Combobox
             options={identityOptions}
             value={selectedIdentityId || undefined}

--- a/components/QuickConnectWizard.tsx
+++ b/components/QuickConnectWizard.tsx
@@ -702,10 +702,8 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
       >
         {/* Header */}
         <div className="px-6 py-4 border-b border-border/50">
-          <div className="flex items-center gap-3 min-w-0">
-            <div className="h-9 w-9 rounded-lg bg-primary/15 text-primary flex items-center justify-center shrink-0">
-              <Plug size={18} />
-            </div>
+          <div className="flex items-center gap-2 min-w-0">
+            <Plug size={18} className="shrink-0 text-foreground" />
             <h2 className="text-base font-semibold truncate">{connectTitle}</h2>
           </div>
         </div>

--- a/components/protocolVisuals.tsx
+++ b/components/protocolVisuals.tsx
@@ -1,0 +1,43 @@
+import {
+  Link2,
+  Radio,
+  Shield,
+  Terminal as TerminalIcon,
+} from "lucide-react";
+import React from "react";
+import type { HostProtocol } from "../types";
+
+export type ProtocolVisualKey = Extract<HostProtocol, "ssh" | "mosh" | "et" | "telnet">;
+
+export interface ProtocolVisualStyle {
+  icon: React.ReactNode;
+  idle: string;
+  selected: string;
+}
+
+export const PROTOCOL_VISUAL_STYLES: Record<ProtocolVisualKey, ProtocolVisualStyle> = {
+  ssh: {
+    icon: <Shield size={18} />,
+    idle: "bg-sky-500/10 text-sky-500",
+    selected: "bg-sky-500/20 text-sky-500",
+  },
+  mosh: {
+    icon: <Radio size={18} />,
+    idle: "bg-violet-500/10 text-violet-500",
+    selected: "bg-violet-500/20 text-violet-500",
+  },
+  et: {
+    icon: <Link2 size={18} />,
+    idle: "bg-emerald-500/10 text-emerald-500",
+    selected: "bg-emerald-500/20 text-emerald-500",
+  },
+  telnet: {
+    icon: <TerminalIcon size={18} />,
+    idle: "bg-amber-500/10 text-amber-500",
+    selected: "bg-amber-500/20 text-amber-500",
+  },
+};
+
+export function getProtocolVisualStyle(protocol: ProtocolVisualKey): ProtocolVisualStyle {
+  return PROTOCOL_VISUAL_STYLES[protocol];
+}


### PR DESCRIPTION
## Summary
- Simplify the quick-connect header to a single plug icon and “Connect to …” title.
- Remove the redundant step progress indicator from the protocol selection screen.
- Give SSH / Mosh / Eternal Terminal / Telnet distinct Lucide icons and colors.
- Apply the same header and protocol-icon treatment to the host protocol select dialog.

## Why
The protocol picker looked denser and less intentional than the rest of the connect flow: the header repeated the host twice, the step dots added little, and protocol icons were too similar.

## Validation
- `node --test --import tsx components/QuickConnectWizard.test.tsx components/ProtocolSelectDialog.test.tsx`
- `npx eslint components/QuickConnectWizard.tsx components/ProtocolSelectDialog.tsx components/QuickConnectWizard.test.tsx components/ProtocolSelectDialog.test.tsx`