### PR TITLE
fix(ui): unify HostDetails setting row heights

### DIFF
--- a/components/GroupSshSettingsSection.tsx
+++ b/components/GroupSshSettingsSection.tsx
@@ -415,7 +415,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
                   value === startupCommandRunModeFallback ? undefined : value,
                 )}
               >
-                <SelectTrigger className="h-9 w-[180px]">
+                <SelectTrigger className="h-8 w-[180px]">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/components/HostDetailsAdvancedSections.tsx
+++ b/components/HostDetailsAdvancedSections.tsx
@@ -227,7 +227,7 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
               <HostDetailsSettingRow label={t("hostDetails.et.port")} hint={t("hostDetails.et.port.desc")}>
                 <Input
                   type="number"
-                  className="w-28"
+                  className="h-8 w-28"
                   placeholder="2022"
                   value={form.etPort ?? ""}
                   onChange={(e) => {
@@ -271,7 +271,7 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
                 hint={t("hostDetails.systemSshAgent.socket.desc")}
               >
                 <Input
-                  className="w-44 font-mono text-xs"
+                  className="h-8 w-44 font-mono text-xs"
                   placeholder="$SSH_AUTH_SOCK"
                   value={form.identityAgent ?? ""}
                   onChange={(event) => setForm((previous: typeof form) => ({
@@ -463,7 +463,7 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
               value={form.backspaceBehavior ?? "default"}
               onValueChange={(v) => update("backspaceBehavior", v === "default" ? undefined : v)}
             >
-              <SelectTrigger className="h-10 w-36 text-xs">
+              <SelectTrigger className="h-8 w-36 text-xs">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -760,7 +760,7 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
                 value === inheritedStartupCommandRunMode ? undefined : value,
               )}
             >
-              <SelectTrigger className="h-9 w-[180px]">
+              <SelectTrigger className="h-8 w-[180px]">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/components/HostDetailsConnectionSections.tsx
+++ b/components/HostDetailsConnectionSections.tsx
@@ -745,7 +745,7 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
                 }
               }}
             >
-              <SelectTrigger className="h-10 w-32">
+              <SelectTrigger className="h-8 w-32">
                 <SelectValue placeholder={t("hostDetails.sftp.fileProtocol.auto")} />
               </SelectTrigger>
               <SelectContent>
@@ -778,7 +778,7 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
               value={form.sftpEncoding || "auto"}
               onValueChange={(val) => update("sftpEncoding", val as Host["sftpEncoding"])}
             >
-              <SelectTrigger className="h-10 w-32">
+              <SelectTrigger className="h-8 w-32">
                 <SelectValue placeholder={t("sftp.encoding.label")} />
               </SelectTrigger>
               <SelectContent>

--- a/components/host-details/HostDetailsSection.tsx
+++ b/components/host-details/HostDetailsSection.tsx
@@ -80,7 +80,8 @@ export function HostDetailsSettingRow({
   return (
     <div
       className={cn(
-        "flex min-h-12 items-center justify-between gap-3 rounded-lg border border-border/60 bg-secondary/40 px-3 py-2",
+        // Fixed height so switch / select / input rows stay aligned.
+        "flex h-12 items-center justify-between gap-3 rounded-lg border border-border/60 bg-secondary/40 px-3",
         className,
       )}
     >


### PR DESCRIPTION
## Summary
- Fix uneven heights among Host Details setting rows (SFTP, system SSH agent, etc.) where Switch rows were shorter than Select/Input rows.
- Give `HostDetailsSettingRow` a fixed `h-12` (replacing `min-h-12` + `py-2`) so all rows share the same height.
- Normalize in-row Select/Input controls to `h-8` for consistent control sizing across host and group detail panels.

## Test plan
- [x] Open Host Details → SFTP: file protocol, sudo toggle, and encoding rows are the same height
- [x] Open Host Details → System SSH Agent: enable toggle, socket input, and identities-only toggle rows match
- [x] Spot-check other Host Details setting rows (backspace, keepalive, startup command run mode, ET port)
- [x] Spot-check Group SSH settings startup command run mode row