### PR TITLE
fix(ui): enable host details panel resize from host tree

### DIFF
--- a/application/app/AppHostEditorLayer.test.ts
+++ b/application/app/AppHostEditorLayer.test.ts
@@ -75,6 +75,15 @@ test('editor overlay leaves the work surface interactive outside the panel', () 
   assert.equal((source.match(/layout="overlay"/g) ?? []).length, 2);
 });
 
+test('editor host panels share vault resize width persistence', () => {
+  const source = readFileSync(new URL('./AppHostEditorLayer.tsx', import.meta.url), 'utf8');
+
+  assert.match(source, /STORAGE_KEY_VAULT_HOST_PANEL_WIDTH/);
+  assert.match(source, /resizable:\s*true/);
+  assert.match(source, /\{\.\.\.hostPanelResizeProps\}/);
+  assert.equal((source.match(/\{\.\.\.hostPanelResizeProps\}/g) ?? []).length, 2);
+});
+
 test('editor stays mounted while another app surface is active', () => {
   assert.deepEqual(getAppHostEditorLayerStyle(false), {
     display: 'none',

--- a/application/app/AppHostEditorLayer.tsx
+++ b/application/app/AppHostEditorLayer.tsx
@@ -1,10 +1,12 @@
 import React, { useMemo, useState } from 'react';
 
 import type { WorkSurfaceHostEditorTarget } from '../state/useWorkSurfaceHostEditor';
+import { useI18n } from '../i18n/I18nProvider';
 import HostDetailsPanel from '../../components/HostDetailsPanel';
 import SerialHostDetailsPanel from '../../components/SerialHostDetailsPanel';
 import { PortalContainerProvider } from '../../components/ui/portal-container';
 import { resolveGroupDefaults } from '../../domain/groupConfig';
+import { STORAGE_KEY_VAULT_HOST_PANEL_WIDTH } from '@/infrastructure/config/storageKeys';
 import type {
   GroupConfig,
   Host,
@@ -100,6 +102,7 @@ export const AppHostEditorLayer: React.FC<AppHostEditorLayerProps> = ({
   onImportOrReuseKey,
   onUpdateSnippets,
 }) => {
+  const { t } = useI18n();
   const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(null);
   const groups = useMemo(
     () => collectWorkSurfaceHostGroups(hosts, customGroups, groupConfigs),
@@ -113,6 +116,12 @@ export const AppHostEditorLayer: React.FC<AppHostEditorLayerProps> = ({
     () => (groupPath ? resolveGroupDefaults(groupPath, groupConfigs) : undefined),
     [groupConfigs, groupPath],
   );
+  // Share width persistence with Vault host details so both entry points feel consistent.
+  const hostPanelResizeProps = {
+    resizable: true as const,
+    persistWidthStorageKey: STORAGE_KEY_VAULT_HOST_PANEL_WIDTH,
+    resizeAriaLabel: t('vault.panel.resizeWidth'),
+  };
 
   if (!target || !editorKey) return null;
 
@@ -135,6 +144,7 @@ export const AppHostEditorLayer: React.FC<AppHostEditorLayerProps> = ({
             onCancel={onCancel}
             layout="overlay"
             className="pointer-events-auto"
+            {...hostPanelResizeProps}
           />
         ) : (
           <HostDetailsPanel
@@ -160,6 +170,7 @@ export const AppHostEditorLayer: React.FC<AppHostEditorLayerProps> = ({
             onCreateGroup={onCreateGroup}
             layout="overlay"
             className="pointer-events-auto"
+            {...hostPanelResizeProps}
           />
         )}
       </PortalContainerProvider>

--- a/components/ui/aside-panel.tsx
+++ b/components/ui/aside-panel.tsx
@@ -353,27 +353,29 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
     dataSection,
 }) => {
     const fallbackWidthPx = parseInlineWidthPx(width);
-    const [inlineWidthPx, setInlineWidthPx] = useState(() =>
+    const [panelWidthPx, setPanelWidthPx] = useState(() =>
         resizable ? readPersistedAsideWidth(persistWidthStorageKey, fallbackWidthPx) : fallbackWidthPx,
     );
     const [isResizing, setIsResizing] = useState(false);
-    const effectiveInlineWidthPx = resizable ? inlineWidthPx : fallbackWidthPx;
+    const effectivePanelWidthPx = resizable ? panelWidthPx : fallbackWidthPx;
+    // Resizable panels always use pixel width so overlay and inline share the same drag path.
+    const usesPixelWidth = resizable || layout === 'inline';
 
-    const inlineStyle = layout === 'inline'
+    const panelStyle = usesPixelWidth
         ? ({
-            width: `${effectiveInlineWidthPx}px`,
-            ['--aside-inline-width' as string]: `${effectiveInlineWidthPx}px`,
+            width: `${effectivePanelWidthPx}px`,
+            ['--aside-inline-width' as string]: `${effectivePanelWidthPx}px`,
         } as React.CSSProperties)
         : undefined;
 
     const handleResizeStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-        if (!resizable || layout !== 'inline') return;
+        if (!resizable) return;
 
         event.preventDefault();
         event.stopPropagation();
 
         const startX = event.clientX;
-        const startWidth = inlineWidthPx;
+        const startWidth = panelWidthPx;
         const previousCursor = document.body.style.cursor;
         const previousUserSelect = document.body.style.userSelect;
 
@@ -382,11 +384,11 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
         document.body.style.userSelect = 'none';
 
         const handlePointerMove = (moveEvent: PointerEvent) => {
-            setInlineWidthPx(clampAsideInlineWidth(startWidth + startX - moveEvent.clientX));
+            setPanelWidthPx(clampAsideInlineWidth(startWidth + startX - moveEvent.clientX));
         };
         const handlePointerUp = (upEvent: PointerEvent) => {
             const nextWidth = clampAsideInlineWidth(startWidth + startX - upEvent.clientX);
-            setInlineWidthPx(nextWidth);
+            setPanelWidthPx(nextWidth);
             if (persistWidthStorageKey) {
                 localStorageAdapter.writeNumber(persistWidthStorageKey, nextWidth);
             }
@@ -401,7 +403,7 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
         window.addEventListener('pointermove', handlePointerMove);
         window.addEventListener('pointerup', handlePointerUp);
         window.addEventListener('pointercancel', handlePointerUp);
-    }, [inlineWidthPx, layout, persistWidthStorageKey, resizable]);
+    }, [panelWidthPx, persistWidthStorageKey, resizable]);
 
     if (!open) return null;
 
@@ -410,13 +412,13 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
             layout === 'inline'
                 ? "relative split-panel-enter shrink-0 h-full min-h-0 max-w-full border-l border-border/60 bg-background flex flex-col app-no-drag overflow-hidden shadow-[-16px_0_32px_hsl(var(--foreground)/0.08)]"
                 : "absolute right-0 top-0 bottom-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag overflow-hidden",
-            layout === 'overlay' && width,
-            isResizing && layout === 'inline' && 'transition-none',
+            layout === 'overlay' && !usesPixelWidth && width,
+            isResizing && 'transition-none',
             className
         )}
-        style={inlineStyle}
+        style={panelStyle}
         data-section={dataSection}>
-            {resizable && layout === 'inline' ? (
+            {resizable ? (
                 <div
                     role="separator"
                     aria-orientation="vertical"


### PR DESCRIPTION
## Summary
- Host details opened from the sidebar host tree used `layout="overlay"` without resize props, so it could not be dragged wider/narrower unlike Vault.
- Extend `AsidePanel` so resize works for both `inline` and `overlay` layouts.
- Wire `AppHostEditorLayer` (standard + serial) to `resizable` with shared `STORAGE_KEY_VAULT_HOST_PANEL_WIDTH`.

## Test plan
- [ ] From host tree sidebar: edit a host → drag left edge of the panel; width changes and persists after reopen
- [ ] From Vault hosts: edit a host → resize still works; width is shared with sidebar editor
- [ ] Serial host edit from host tree also resizes
- [ ] Outside the overlay panel remains clickable (pointer-events behavior unchanged)