### PR TITLE
fix(ui): open AI silent sessions in an attach terminal popup

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -647,7 +647,18 @@ function App({ settings }: { settings: SettingsState }) {
 
   // Window controls - must be before update toast effect which uses openSettingsWindow
   const { openSettingsWindow } = useWindowControls();
-  const _handleTrayJumpToSession = useEffectEvent((sessionId: string) => { return handleTrayJumpToSessionImpl(() => ({ sessionId, sessions, setActiveTabId, setWorkspaceFocusedSession }), sessionId); });
+  const _handleTrayJumpToSession = useEffectEvent((sessionId: string) => {
+    return handleTrayJumpToSessionImpl(() => ({
+      sessionId,
+      sessions,
+      setActiveTabId,
+      setWorkspaceFocusedSession,
+      getActiveTabId: () => activeTabStore.getActiveTabId(),
+      netcattyBridge,
+      toast,
+      t,
+    }), sessionId);
+  });
   const _handleTrayTogglePortForward = useEffectEvent((ruleId: string, start: boolean) => { return handleTrayTogglePortForwardImpl(() => ({ hasRuntimeTunnel, hosts, identities, keys, knownHosts: effectiveKnownHosts, portForwardingRules, resolveEffectiveHost, ruleId, start, startTunnel, stopTunnel, t, terminalSettings, toast, undefined }), ruleId, start); });
   const _handleTrayPanelConnect = useEffectEvent((hostId: string) => { return handleTrayPanelConnectImpl(() => ({ addConnectionLog, connectToHost, hostId, hosts, identities, keys, resolveEffectiveHost, resolveHostAuth, systemInfoRef, t, toast }), hostId); });
   const _handleTrayPanelConnectRequest = useEffectEvent((hostId: string) => { return handleTrayPanelConnectRequestImpl(() => ({ connectNow: _handleTrayPanelConnect, hostId, isVaultInitialized, queueConnect: (queuedHostId: string) => setPendingTrayPanelConnectHostIds((prev) => [...prev, queuedHostId]) }), hostId); });

--- a/application/AppHandlers.trayJump.test.ts
+++ b/application/AppHandlers.trayJump.test.ts
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { TerminalSession } from "../domain/models";
+import {
+  buildAiSilentSessionPopupPayload,
+  handleTrayJumpToSessionImpl,
+} from "./app/AppHandlers";
+
+const session = (overrides: Partial<TerminalSession> = {}): TerminalSession => ({
+  id: "session-1",
+  hostId: "host-1",
+  hostLabel: "AI Box",
+  hostname: "10.0.0.1",
+  username: "root",
+  status: "connected",
+  protocol: "ssh",
+  port: 22,
+  ...overrides,
+});
+
+test("buildAiSilentSessionPopupPayload attaches the same live session PTY", () => {
+  const payload = buildAiSilentSessionPopupPayload(
+    session({ hiddenFromTabs: true }),
+  );
+
+  assert.equal(payload.parentSessionId, "session-1");
+  assert.equal(payload.attachSessionId, "session-1");
+  assert.equal(payload.title, "AI Box");
+  assert.equal(payload.startupCommand, "");
+  assert.equal(payload.sourceSession.hiddenFromTabs, undefined);
+  assert.equal(payload.sourceSession.reuseConnectionFromSessionId, undefined);
+});
+
+test("handleTrayJumpToSessionImpl opens a terminal popup for AI silent sessions", async () => {
+  const opened: unknown[] = [];
+  let activeTabId = "session-1";
+
+  await handleTrayJumpToSessionImpl(
+    () => ({
+      sessions: [session({ hiddenFromTabs: true })],
+      setActiveTabId: (id: string) => {
+        activeTabId = id;
+      },
+      getActiveTabId: () => activeTabId,
+      setWorkspaceFocusedSession: () => {
+        throw new Error("should not focus workspace for silent sessions");
+      },
+      netcattyBridge: {
+        get: () => ({
+          openTerminalPopup: async (payload: unknown) => {
+            opened.push(payload);
+            return { success: true, popupId: "popup-1" };
+          },
+        }),
+      },
+    }),
+    "session-1",
+  );
+
+  assert.equal(opened.length, 1);
+  assert.equal(activeTabId, "vault");
+  assert.deepEqual(opened[0], buildAiSilentSessionPopupPayload(session({ hiddenFromTabs: true })));
+});
+
+test("handleTrayJumpToSessionImpl still activates normal solo sessions in the main window", async () => {
+  let activeTabId = "vault";
+  let openedMain = 0;
+
+  await handleTrayJumpToSessionImpl(
+    () => ({
+      sessions: [session()],
+      setActiveTabId: (id: string) => {
+        activeTabId = id;
+      },
+      setWorkspaceFocusedSession: () => {
+        throw new Error("solo sessions should not use workspace focus");
+      },
+      netcattyBridge: {
+        get: () => ({
+          openMainWindow: async () => {
+            openedMain += 1;
+            return { success: true };
+          },
+          openTerminalPopup: async () => {
+            throw new Error("should not open popup for visible sessions");
+          },
+        }),
+      },
+    }),
+    "session-1",
+  );
+
+  assert.equal(activeTabId, "session-1");
+  assert.equal(openedMain, 1);
+});
+
+test("handleTrayJumpToSessionImpl focuses workspace sessions without opening a popup", async () => {
+  let activeTabId = "vault";
+  let focused: { workspaceId: string; sessionId: string } | null = null;
+  let openedMain = 0;
+
+  await handleTrayJumpToSessionImpl(
+    () => ({
+      sessions: [session({ workspaceId: "ws-1" })],
+      setActiveTabId: (id: string) => {
+        activeTabId = id;
+      },
+      setWorkspaceFocusedSession: (workspaceId: string, sessionId: string) => {
+        focused = { workspaceId, sessionId };
+      },
+      netcattyBridge: {
+        get: () => ({
+          openMainWindow: async () => {
+            openedMain += 1;
+            return { success: true };
+          },
+          openTerminalPopup: async () => {
+            throw new Error("should not open popup for workspace sessions");
+          },
+        }),
+      },
+    }),
+    "session-1",
+  );
+
+  assert.equal(activeTabId, "ws-1");
+  assert.equal(openedMain, 1);
+  assert.deepEqual(focused, { workspaceId: "ws-1", sessionId: "session-1" });
+});

--- a/application/app/AppHandlers.ts
+++ b/application/app/AppHandlers.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type React from 'react';
-import type { Host, HostProtocol } from '../../types';
+import type { Host, HostProtocol, TerminalSession } from '../../types';
 import type { PassphraseRequest } from '../../components/PassphraseModal';
+import type { TerminalPopupPayload } from '../../domain/systemManager/types';
 import { getEffectiveHostDistro } from '../../domain/host';
 import { sanitizeHostIconFields } from '../../domain/hostIcon';
 import { resolveEffectiveTerminalProtocol } from '../../domain/terminalProtocol';
@@ -49,17 +50,80 @@ export const getLogHostVisualSnapshot = (host: Host) => {
   };
 };
 
-export function handleTrayJumpToSessionImpl(getCtx: AppContextGetter, sessionId: string) {
-  const { sessions, setActiveTabId, setWorkspaceFocusedSession } = getCtx();
-{
-    const session = sessions.find((item) => item.id === sessionId);
-    if (session?.workspaceId) {
-      setActiveTabId(session.workspaceId);
-      setWorkspaceFocusedSession(session.workspaceId, sessionId);
+/**
+ * AI silent sessions stay out of the tab bar. Opening them via tray should
+ * attach a terminal-popup window to the same live PTY (same sessionId) instead
+ * of activating them as a main-window tab (tab-less terminal surface) or
+ * spawning a new shell via connection reuse.
+ */
+export function buildAiSilentSessionPopupPayload(session: TerminalSession): TerminalPopupPayload {
+  const { hiddenFromTabs: _hiddenFromTabs, ...sourceSession } = session;
+  return {
+    title: session.hostLabel || 'Terminal',
+    parentSessionId: session.id,
+    startupCommand: '',
+    attachSessionId: session.id,
+    sourceSession: {
+      ...sourceSession,
+    },
+  };
+}
+
+export async function handleTrayJumpToSessionImpl(getCtx: AppContextGetter, sessionId: string) {
+  const {
+    sessions,
+    setActiveTabId,
+    setWorkspaceFocusedSession,
+    netcattyBridge,
+    toast,
+    t,
+  } = getCtx();
+  const session = sessions.find((item: TerminalSession) => item.id === sessionId);
+  if (!session) return;
+
+  if (session.hiddenFromTabs) {
+    // Leave the main surface if this silent session was already activated
+    // (legacy jump path left a terminal with no tab chrome).
+    const getActiveTabId = getCtx().getActiveTabId as (() => string) | undefined;
+    if (!getActiveTabId || getActiveTabId() === sessionId) {
+      setActiveTabId('vault');
+    }
+
+    const bridge = netcattyBridge?.get?.();
+    if (!bridge?.openTerminalPopup) {
+      toast?.error?.(t?.('tabs.copyTabToNewWindowFailed') ?? 'Failed to open tab in a new window');
       return;
     }
-    setActiveTabId(sessionId);
+    try {
+      const result = await bridge.openTerminalPopup(buildAiSilentSessionPopupPayload(session));
+      if (!result?.success) {
+        toast?.error?.(
+          result?.error
+            || t?.('tabs.copyTabToNewWindowFailed')
+            || 'Failed to open tab in a new window',
+        );
+      }
+    } catch (err) {
+      toast?.error?.(
+        err instanceof Error
+          ? err.message
+          : (t?.('tabs.copyTabToNewWindowFailed') ?? 'Failed to open tab in a new window'),
+      );
+    }
+    return;
   }
+
+  // Visible sessions still live in the main window; bring it forward now that
+  // the tray jump IPC no longer auto-focuses main (silent AI sessions open a
+  // popup instead and must not steal main-window focus).
+  void netcattyBridge?.get?.()?.openMainWindow?.();
+
+  if (session.workspaceId) {
+    setActiveTabId(session.workspaceId);
+    setWorkspaceFocusedSession(session.workspaceId, sessionId);
+    return;
+  }
+  setActiveTabId(sessionId);
 }
 
 export function handleTrayTogglePortForwardImpl(getCtx: AppContextGetter, ruleId: string, start: boolean) {

--- a/application/state/useTerminalBackend.ts
+++ b/application/state/useTerminalBackend.ts
@@ -159,12 +159,22 @@ export const useTerminalBackend = () => {
     return bridge.requestTerminalSessionSnapshot(sessionId, authorization);
   }, []);
 
-  const applySessionSnapshot = useCallback(async (sessionId: string, snapshot: string, authorization: string) => {
+  const applySessionSnapshot = useCallback(async (
+    sessionId: string,
+    snapshot: string,
+    context: {
+      contextSnapshot: string;
+      contextViewportSnapshot: string;
+      contextScrollbackSnapshot: string;
+      alternateScreen: boolean;
+    },
+    authorization: string,
+  ) => {
     const bridge = netcattyBridge.get();
     if (!bridge?.applyTerminalSessionSnapshot) {
       return { success: false as const, error: "applyTerminalSessionSnapshot unavailable" };
     }
-    return bridge.applyTerminalSessionSnapshot(sessionId, snapshot, authorization);
+    return bridge.applyTerminalSessionSnapshot(sessionId, snapshot, context, authorization);
   }, []);
 
   const setSessionEncoding = useCallback(async (sessionId: string, encoding: string) => {

--- a/application/state/useTerminalBackend.ts
+++ b/application/state/useTerminalBackend.ts
@@ -143,6 +143,14 @@ export const useTerminalBackend = () => {
     return bridge.requestTerminalSessionSnapshot(sessionId);
   }, []);
 
+  const applySessionSnapshot = useCallback(async (sessionId: string, snapshot: string) => {
+    const bridge = netcattyBridge.get();
+    if (!bridge?.applyTerminalSessionSnapshot) {
+      return { success: false as const, error: "applyTerminalSessionSnapshot unavailable" };
+    }
+    return bridge.applyTerminalSessionSnapshot(sessionId, snapshot);
+  }, []);
+
   const setSessionEncoding = useCallback(async (sessionId: string, encoding: string) => {
     const bridge = netcattyBridge.get();
     if (!bridge?.setSessionEncoding) return { ok: false, encoding };
@@ -402,6 +410,7 @@ export const useTerminalBackend = () => {
         rebindSessionOutput,
         restoreSessionOutput,
         requestSessionSnapshot,
+        applySessionSnapshot,
         setSessionEncoding,
         onSessionData,
         onSessionExit,
@@ -474,6 +483,7 @@ export const useTerminalBackend = () => {
       rebindSessionOutput,
       restoreSessionOutput,
       requestSessionSnapshot,
+      applySessionSnapshot,
       setSessionEncoding,
       onSessionData,
       onSessionExit,

--- a/application/state/useTerminalBackend.ts
+++ b/application/state/useTerminalBackend.ts
@@ -116,6 +116,25 @@ export const useTerminalBackend = () => {
     await bridge?.closeSession?.(sessionId);
   }, []);
 
+  const rebindSessionOutput = useCallback(async (sessionId: string) => {
+    const bridge = netcattyBridge.get();
+    if (!bridge?.rebindTerminalSessionOutput) {
+      return { success: false as const, error: "rebindTerminalSessionOutput unavailable" };
+    }
+    return bridge.rebindTerminalSessionOutput(sessionId);
+  }, []);
+
+  const restoreSessionOutput = useCallback(async (
+    sessionId: string,
+    webContentsId?: number | null,
+  ) => {
+    const bridge = netcattyBridge.get();
+    if (!bridge?.restoreTerminalSessionOutput) {
+      return { success: false as const, error: "restoreTerminalSessionOutput unavailable" };
+    }
+    return bridge.restoreTerminalSessionOutput(sessionId, webContentsId);
+  }, []);
+
   const setSessionEncoding = useCallback(async (sessionId: string, encoding: string) => {
     const bridge = netcattyBridge.get();
     if (!bridge?.setSessionEncoding) return { ok: false, encoding };
@@ -372,6 +391,8 @@ export const useTerminalBackend = () => {
         setSessionFlowPaused,
         ackSessionFlow,
         closeSession,
+        rebindSessionOutput,
+        restoreSessionOutput,
         setSessionEncoding,
         onSessionData,
         onSessionExit,
@@ -441,6 +462,8 @@ export const useTerminalBackend = () => {
       setSessionFlowPaused,
       ackSessionFlow,
       closeSession,
+      rebindSessionOutput,
+      restoreSessionOutput,
       setSessionEncoding,
       onSessionData,
       onSessionExit,

--- a/application/state/useTerminalBackend.ts
+++ b/application/state/useTerminalBackend.ts
@@ -106,9 +106,24 @@ export const useTerminalBackend = () => {
     bridge?.setSessionFlowPaused?.(sessionId, paused);
   }, []);
 
+  const setSessionFlowPausedAndWait = useCallback(async (sessionId: string, paused: boolean) => {
+    const bridge = netcattyBridge.get();
+    if (!bridge?.setSessionFlowPausedAndWait) {
+      bridge?.setSessionFlowPaused?.(sessionId, paused);
+      return paused
+        ? { success: false, error: "Output drain unavailable" }
+        : { success: true };
+    }
+    return bridge.setSessionFlowPausedAndWait(sessionId, paused);
+  }, []);
+
   const ackSessionFlow = useCallback((sessionId: string, bytes: number) => {
     const bridge = netcattyBridge.get();
     bridge?.ackSessionFlow?.(sessionId, bytes);
+  }, []);
+
+  const notifyTerminalSessionDisplayReady = useCallback((sessionId: string) => {
+    netcattyBridge.get()?.notifyTerminalSessionDisplayReady?.(sessionId);
   }, []);
 
   const closeSession = useCallback(async (sessionId: string) => {
@@ -116,39 +131,40 @@ export const useTerminalBackend = () => {
     await bridge?.closeSession?.(sessionId);
   }, []);
 
-  const rebindSessionOutput = useCallback(async (sessionId: string) => {
+  const rebindSessionOutput = useCallback(async (sessionId: string, authorization: string) => {
     const bridge = netcattyBridge.get();
     if (!bridge?.rebindTerminalSessionOutput) {
       return { success: false as const, error: "rebindTerminalSessionOutput unavailable" };
     }
-    return bridge.rebindTerminalSessionOutput(sessionId);
+    return bridge.rebindTerminalSessionOutput(sessionId, authorization);
   }, []);
 
   const restoreSessionOutput = useCallback(async (
     sessionId: string,
     webContentsId?: number | null,
+    authorization?: string,
   ) => {
     const bridge = netcattyBridge.get();
     if (!bridge?.restoreTerminalSessionOutput) {
       return { success: false as const, error: "restoreTerminalSessionOutput unavailable" };
     }
-    return bridge.restoreTerminalSessionOutput(sessionId, webContentsId);
+    return bridge.restoreTerminalSessionOutput(sessionId, webContentsId, authorization);
   }, []);
 
-  const requestSessionSnapshot = useCallback(async (sessionId: string) => {
+  const requestSessionSnapshot = useCallback(async (sessionId: string, authorization: string) => {
     const bridge = netcattyBridge.get();
     if (!bridge?.requestTerminalSessionSnapshot) {
       return { success: false as const, snapshot: "", error: "requestTerminalSessionSnapshot unavailable" };
     }
-    return bridge.requestTerminalSessionSnapshot(sessionId);
+    return bridge.requestTerminalSessionSnapshot(sessionId, authorization);
   }, []);
 
-  const applySessionSnapshot = useCallback(async (sessionId: string, snapshot: string) => {
+  const applySessionSnapshot = useCallback(async (sessionId: string, snapshot: string, authorization: string) => {
     const bridge = netcattyBridge.get();
     if (!bridge?.applyTerminalSessionSnapshot) {
       return { success: false as const, error: "applyTerminalSessionSnapshot unavailable" };
     }
-    return bridge.applyTerminalSessionSnapshot(sessionId, snapshot);
+    return bridge.applyTerminalSessionSnapshot(sessionId, snapshot, authorization);
   }, []);
 
   const setSessionEncoding = useCallback(async (sessionId: string, encoding: string) => {
@@ -191,6 +207,12 @@ export const useTerminalBackend = () => {
   const onTelnetEchoMode = useCallback((sessionId: string, cb: (evt: { sessionId: string; remoteEcho: boolean; localEcho: boolean }) => void) => {
     const bridge = netcattyBridge.get();
     return bridge?.onTelnetEchoMode?.(sessionId, cb);
+  }, []);
+
+  const getTelnetEchoMode = useCallback(async (sessionId: string) => {
+    const bridge = netcattyBridge.get();
+    if (!bridge?.getTelnetEchoMode) return { success: false as const, error: "getTelnetEchoMode unavailable" };
+    return bridge.getTelnetEchoMode(sessionId);
   }, []);
 
   const onChainProgress = useCallback((cb: (sessionId: string, hop: number, total: number, label: string, status: string, error?: string) => void) => {
@@ -405,7 +427,9 @@ export const useTerminalBackend = () => {
         interruptSession,
         resizeSession,
         setSessionFlowPaused,
+        setSessionFlowPausedAndWait,
         ackSessionFlow,
+        notifyTerminalSessionDisplayReady,
         closeSession,
         rebindSessionOutput,
         restoreSessionOutput,
@@ -417,6 +441,7 @@ export const useTerminalBackend = () => {
         onTelnetAutoLoginComplete,
         onTelnetAutoLoginCancelled,
         onTelnetEchoMode,
+        getTelnetEchoMode,
         onChainProgress,
         onConnectionReuseFallback,
         onWindowFullScreenChanged,
@@ -478,7 +503,9 @@ export const useTerminalBackend = () => {
       interruptSession,
       resizeSession,
       setSessionFlowPaused,
+      setSessionFlowPausedAndWait,
       ackSessionFlow,
+      notifyTerminalSessionDisplayReady,
       closeSession,
       rebindSessionOutput,
       restoreSessionOutput,
@@ -491,6 +518,7 @@ export const useTerminalBackend = () => {
       onTelnetAutoLoginCancelled,
       onMoshSessionReady,
       onTelnetEchoMode,
+      getTelnetEchoMode,
       onChainProgress,
       onConnectionReuseFallback,
       onWindowFullScreenChanged,

--- a/application/state/useTerminalBackend.ts
+++ b/application/state/useTerminalBackend.ts
@@ -135,6 +135,14 @@ export const useTerminalBackend = () => {
     return bridge.restoreTerminalSessionOutput(sessionId, webContentsId);
   }, []);
 
+  const requestSessionSnapshot = useCallback(async (sessionId: string) => {
+    const bridge = netcattyBridge.get();
+    if (!bridge?.requestTerminalSessionSnapshot) {
+      return { success: false as const, snapshot: "", error: "requestTerminalSessionSnapshot unavailable" };
+    }
+    return bridge.requestTerminalSessionSnapshot(sessionId);
+  }, []);
+
   const setSessionEncoding = useCallback(async (sessionId: string, encoding: string) => {
     const bridge = netcattyBridge.get();
     if (!bridge?.setSessionEncoding) return { ok: false, encoding };
@@ -393,6 +401,7 @@ export const useTerminalBackend = () => {
         closeSession,
         rebindSessionOutput,
         restoreSessionOutput,
+        requestSessionSnapshot,
         setSessionEncoding,
         onSessionData,
         onSessionExit,
@@ -464,6 +473,7 @@ export const useTerminalBackend = () => {
       closeSession,
       rebindSessionOutput,
       restoreSessionOutput,
+      requestSessionSnapshot,
       setSessionEncoding,
       onSessionData,
       onSessionExit,

--- a/application/state/useTerminalPopupWindow.ts
+++ b/application/state/useTerminalPopupWindow.ts
@@ -17,5 +17,13 @@ export function useTerminalPopupWindow() {
     return bridge.onTerminalPopupConfig(cb);
   }, []);
 
-  return { close, setWindowTitle, onPopupConfig };
+  const markAttachClosePrepared = useCallback(async (sessionId: string, authorization: string) => {
+    return netcattyBridge.get()?.markAttachPopupClosePrepared?.(sessionId, authorization);
+  }, []);
+
+  const onPrepareClose = useCallback((cb: (payload: { sessionId: string; authorization: string }) => void) => {
+    return netcattyBridge.get()?.onTerminalPopupPrepareClose?.(cb) ?? (() => {});
+  }, []);
+
+  return { close, setWindowTitle, onPopupConfig, markAttachClosePrepared, onPrepareClose };
 }

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1232,6 +1232,27 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const attachHomeWebContentsIdRef = useRef<number | null | undefined>(undefined);
 
+  // Home renderer for AI observe popups: serialize scrollback on demand.
+  useEffect(() => {
+    if (attachExistingSession) return undefined;
+    const bridge = netcattyBridge.get();
+    if (!bridge?.onTerminalSessionSnapshotRequest || !bridge?.respondTerminalSessionSnapshot) {
+      return undefined;
+    }
+    return bridge.onTerminalSessionSnapshotRequest((payload) => {
+      if (!payload || payload.sessionId !== sessionId) return;
+      let snapshot = "";
+      try {
+        if (sessionRef.current === sessionId && serializeAddonRef.current) {
+          snapshot = serializeAddonRef.current.serialize() || "";
+        }
+      } catch (err) {
+        logger.warn("Failed to serialize terminal snapshot for attach popup", err);
+      }
+      bridge.respondTerminalSessionSnapshot?.(payload.requestId, snapshot);
+    });
+  }, [attachExistingSession, sessionId]);
+
   const cleanupSession = async () => {
     const closingSessionId = sessionRef.current;
     sessionRef.current = null;
@@ -1256,6 +1277,18 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       const homeId = attachHomeWebContentsIdRef.current;
       attachHomeWebContentsIdRef.current = undefined;
       try {
+        // If the popup paused the backend under output pressure, resume it and
+        // drain local queues before handing the route back to home.
+        const activeTerm = termRef.current;
+        if (activeTerm) {
+          releaseTerminalFlowBeforeHibernate(terminalBackend, activeTerm, closingSessionId, {
+            resumeBackend: true,
+          });
+        } else {
+          flushTerminalSessionFlowAck(closingSessionId);
+          clearTerminalSessionFlowAck(closingSessionId);
+          terminalBackend.setSessionFlowPaused?.(closingSessionId, false);
+        }
         await terminalBackend.restoreSessionOutput?.(closingSessionId, homeId ?? null);
       } catch (err) {
         logger.warn("Failed to restore terminal output after attach popup close", err);
@@ -1335,6 +1368,20 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       if (attachExistingSession) {
         const homeId = attachHomeWebContentsIdRef.current;
         attachHomeWebContentsIdRef.current = undefined;
+        try {
+          const term = termRef.current;
+          if (term) {
+            releaseTerminalFlowBeforeHibernate(terminalBackend, term, closingSessionId, {
+              resumeBackend: true,
+            });
+          } else {
+            flushTerminalSessionFlowAck(closingSessionId);
+            clearTerminalSessionFlowAck(closingSessionId);
+            terminalBackend.setSessionFlowPaused?.(closingSessionId, false);
+          }
+        } catch (err) {
+          logger.warn("Failed to release attach popup flow state on hibernate close", err);
+        }
         void terminalBackend.restoreSessionOutput?.(closingSessionId, homeId ?? null).catch((err) => {
           logger.warn("Failed to restore terminal output after attach popup hibernate close", err);
         });

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1141,6 +1141,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   updateStatusRef.current = updateStatus;
 
   const scheduleAutoReconnect = useCallback((trigger?: { evt?: Parameters<typeof shouldAutoReconnectAfterExit>[0]["evt"] }) => {
+    // Observe popups display an existing backend; the hidden owner remains the
+    // sole authority for reconnecting or replacing that session.
+    if (attachExistingSession) return false;
     const shouldSchedule = trigger?.evt
       ? shouldAutoReconnectAfterExit({
         evt: trigger.evt,
@@ -1183,7 +1186,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }, TERMINAL_AUTO_RECONNECT_DELAY_MS);
 
     return true;
-  }, [host, t, terminalSettings, updateStatus]);
+  }, [attachExistingSession, host, t, terminalSettings, updateStatus]);
 
   const prepareRestoredReconnect = useCallback(() => {
     suppressHostStartupCommandRef.current = shouldSuppressHostStartupCommandOnReconnect(
@@ -2635,6 +2638,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   };
 
   const startReconnect = async (mode: "manual" | "auto" = "manual") => {
+    if (attachExistingSession) return;
     if (!termRef.current && hibernatedRef.current) {
       if (reconnectWakeInFlightRef.current) return;
       const wakeForReconnect = wakeHibernatedRuntimeForReconnectRef.current;
@@ -2768,10 +2772,13 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     startReconnect("manual");
   };
   manualReconnectRequestRef.current = handleRetry;
-  useEffect(() => terminalReconnectRegistry.register(
-    sessionId,
-    () => manualReconnectRequestRef.current(),
-  ), [sessionId]);
+  useEffect(() => {
+    if (attachExistingSession) return undefined;
+    return terminalReconnectRegistry.register(
+      sessionId,
+      () => manualReconnectRequestRef.current(),
+    );
+  }, [attachExistingSession, sessionId]);
 
   const shouldShowConnectionDialog = shouldShowTerminalConnectionDialog({
     status,

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1232,25 +1232,52 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const attachHomeWebContentsIdRef = useRef<number | null | undefined>(undefined);
 
-  // Home renderer for AI observe popups: serialize scrollback on demand.
+  // Home renderer for AI observe popups: serialize scrollback on demand, and
+  // accept reverse snapshots when the observe popup restores the route.
   useEffect(() => {
     if (attachExistingSession) return undefined;
     const bridge = netcattyBridge.get();
-    if (!bridge?.onTerminalSessionSnapshotRequest || !bridge?.respondTerminalSessionSnapshot) {
-      return undefined;
-    }
-    return bridge.onTerminalSessionSnapshotRequest((payload) => {
-      if (!payload || payload.sessionId !== sessionId) return;
-      let snapshot = "";
-      try {
-        if (sessionRef.current === sessionId && serializeAddonRef.current) {
-          snapshot = serializeAddonRef.current.serialize() || "";
+    const unsubs: Array<() => void> = [];
+    if (bridge?.onTerminalSessionSnapshotRequest && bridge?.respondTerminalSessionSnapshot) {
+      unsubs.push(bridge.onTerminalSessionSnapshotRequest((payload) => {
+        if (!payload || payload.sessionId !== sessionId) return;
+        let snapshot = "";
+        try {
+          if (serializeAddonRef.current) {
+            snapshot = serializeAddonRef.current.serialize() || "";
+          } else if (hibernatedRef.current || softHiddenRef.current) {
+            // Hibernate path: live xterm is torn down; use retained snapshot.
+            snapshot = [
+              hibernateSnapshotRef.current || "",
+              hibernatePendingBufferRef.current || "",
+            ].join("");
+          }
+        } catch (err) {
+          logger.warn("Failed to serialize terminal snapshot for attach popup", err);
         }
-      } catch (err) {
-        logger.warn("Failed to serialize terminal snapshot for attach popup", err);
-      }
-      bridge.respondTerminalSessionSnapshot?.(payload.requestId, snapshot);
-    });
+        bridge.respondTerminalSessionSnapshot?.(payload.requestId, snapshot);
+      }));
+    }
+    if (bridge?.onTerminalSessionApplySnapshot) {
+      unsubs.push(bridge.onTerminalSessionApplySnapshot((payload) => {
+        if (!payload || payload.sessionId !== sessionId || !payload.snapshot) return;
+        try {
+          if (termRef.current) {
+            termRef.current.reset();
+            termRef.current.write(payload.snapshot);
+            try { termRef.current.scrollToBottom?.(); } catch { /* ignore */ }
+          } else if (hibernatedRef.current || softHiddenRef.current) {
+            hibernateSnapshotRef.current = payload.snapshot;
+            hibernatePendingBufferRef.current = "";
+          }
+        } catch (err) {
+          logger.warn("Failed to apply observe-popup snapshot to home terminal", err);
+        }
+      }));
+    }
+    return () => {
+      for (const unsub of unsubs) unsub();
+    };
   }, [attachExistingSession, sessionId]);
 
   const cleanupSession = async () => {
@@ -1277,6 +1304,15 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       const homeId = attachHomeWebContentsIdRef.current;
       attachHomeWebContentsIdRef.current = undefined;
       try {
+        // Push popup display state home first so reopen is not stale.
+        try {
+          const snap = serializeAddonRef.current?.serialize?.() || "";
+          if (snap) {
+            await terminalBackend.applySessionSnapshot?.(closingSessionId, snap);
+          }
+        } catch (snapErr) {
+          logger.warn("Failed to push observe-popup snapshot home before restore", snapErr);
+        }
         // If the popup paused the backend under output pressure, resume it and
         // drain local queues before handing the route back to home.
         const activeTerm = termRef.current;

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -160,6 +160,7 @@ import { useTerminalEffects } from "./terminal/useTerminalEffects";
 import { useTerminalHibernateEffect } from "./terminal/useTerminalHibernateEffect";
 import { readActiveTerminalBufferTextRange } from "./terminal/terminalContextBuffer";
 import {
+  applyAuthoritativeHibernateSnapshot,
   appendHibernatePendingBuffer,
   isTerminalAlternateScreenActive,
   serializeTerminalForHibernate,
@@ -169,7 +170,10 @@ import {
   clearTerminalSessionFlowAck,
   flushTerminalSessionFlowAck,
 } from "./terminal/runtime/terminalFlowAckBuffer";
-import { releaseTerminalFlowBeforeHibernate } from "./terminal/runtime/terminalSessionAttachment";
+import {
+  releaseTerminalFlowBeforeHibernate,
+  resolveAttachSnapshot,
+} from "./terminal/runtime/terminalSessionAttachment";
 import { flushPendingTerminalWritesBeforeHibernate } from "./terminal/runtime/terminalUnfocusedRepaint";
 import {
   isTerminalFileTransferActive,
@@ -1277,16 +1281,26 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }
     if (bridge?.onTerminalSessionApplySnapshot) {
       unsubs.push(bridge.onTerminalSessionApplySnapshot(async (payload) => {
-        if (!payload || payload.sessionId !== sessionId || !payload.snapshot) return false;
+        if (!payload || payload.sessionId !== sessionId || typeof payload.snapshot !== "string") return false;
         if (termRef.current) {
           const term = termRef.current;
           await flushPendingTerminalWritesBeforeHibernate(term);
           term.reset();
-          await new Promise<void>((resolve) => term.write(payload.snapshot, resolve));
+          if (payload.snapshot) {
+            await new Promise<void>((resolve) => term.write(payload.snapshot, resolve));
+          }
           try { term.scrollToBottom?.(); } catch { /* ignore */ }
         } else if (hibernatedRef.current || softHiddenRef.current) {
-          hibernateSnapshotRef.current = payload.snapshot;
-          hibernatePendingBufferRef.current = "";
+          applyAuthoritativeHibernateSnapshot({
+            snapshot: hibernateSnapshotRef,
+            viewportSnapshot: hibernateViewportSnapshotRef,
+            scrollbackSnapshot: hibernateScrollbackSnapshotRef,
+            contextSnapshot: hibernateContextSnapshotRef,
+            contextViewportSnapshot: hibernateContextViewportSnapshotRef,
+            contextScrollbackSnapshot: hibernateContextScrollbackSnapshotRef,
+            pendingBuffer: hibernatePendingBufferRef,
+            alternateScreen: hibernateAlternateScreenRef,
+          }, payload.snapshot);
         }
         return true;
       }));
@@ -1352,15 +1366,19 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         const snapshotTerm = termRef.current;
         if (snapshotTerm) await flushPendingTerminalWritesBeforeHibernate(snapshotTerm);
         // Push popup display state home first so reopen is not stale.
-        const snap = serializeAddonRef.current?.serialize?.() || fallbackSnapshot;
-        if (snap) {
-          const applied = await terminalBackend.applySessionSnapshot?.(
-            closingSessionId,
-            snap,
-            attachAuthorization || "",
-          );
-          if (applied && !applied.success) throw new Error(applied.error || "Failed to apply terminal snapshot");
+        let finalSnapshot: unknown;
+        try {
+          finalSnapshot = serializeAddonRef.current?.serialize?.();
+        } catch {
+          finalSnapshot = undefined;
         }
+        const snap = resolveAttachSnapshot(finalSnapshot, fallbackSnapshot);
+        const applied = await terminalBackend.applySessionSnapshot?.(
+          closingSessionId,
+          snap,
+          attachAuthorization || "",
+        );
+        if (applied && !applied.success) throw new Error(applied.error || "Failed to apply terminal snapshot");
         // Hand the route home while output is still paused, then detach the
         // popup listener and resume so subsequent bytes land on the home route.
         const restored = await terminalBackend.restoreSessionOutput?.(

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -243,6 +243,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   pendingScript,
   reuseConnectionFromSessionId,
   attachExistingSession = false,
+  attachAuthorization,
+  onAttachClosePreparationChange,
   serialConfig,
   hotkeyScheme = "disabled",
   disableTerminalFontZoom = false,
@@ -1232,6 +1234,17 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const attachHomeWebContentsIdRef = useRef<number | null | undefined>(undefined);
 
+  useEffect(() => {
+    const bridge = netcattyBridge.get();
+    if (!bridge?.onTerminalOutputDrainRequest || !bridge?.respondTerminalOutputDrain) return undefined;
+    return bridge.onTerminalOutputDrainRequest(sessionId, async (payload) => {
+      const term = termRef.current;
+      if (term) await flushPendingTerminalWritesBeforeHibernate(term);
+      flushTerminalSessionFlowAck(sessionId);
+      bridge.respondTerminalOutputDrain?.(payload.requestId);
+    });
+  }, [sessionId]);
+
   // Home renderer for AI observe popups: serialize scrollback on demand, and
   // accept reverse snapshots when the observe popup restores the route.
   useEffect(() => {
@@ -1239,11 +1252,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     const bridge = netcattyBridge.get();
     const unsubs: Array<() => void> = [];
     if (bridge?.onTerminalSessionSnapshotRequest && bridge?.respondTerminalSessionSnapshot) {
-      unsubs.push(bridge.onTerminalSessionSnapshotRequest((payload) => {
+      unsubs.push(bridge.onTerminalSessionSnapshotRequest(async (payload) => {
         if (!payload || payload.sessionId !== sessionId) return;
         let snapshot = "";
         try {
           if (serializeAddonRef.current) {
+            if (termRef.current) await flushPendingTerminalWritesBeforeHibernate(termRef.current);
             snapshot = serializeAddonRef.current.serialize() || "";
           } else if (hibernatedRef.current || softHiddenRef.current) {
             // Hibernate path: live xterm is torn down; use retained snapshot.
@@ -1259,20 +1273,19 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       }));
     }
     if (bridge?.onTerminalSessionApplySnapshot) {
-      unsubs.push(bridge.onTerminalSessionApplySnapshot((payload) => {
-        if (!payload || payload.sessionId !== sessionId || !payload.snapshot) return;
-        try {
-          if (termRef.current) {
-            termRef.current.reset();
-            termRef.current.write(payload.snapshot);
-            try { termRef.current.scrollToBottom?.(); } catch { /* ignore */ }
-          } else if (hibernatedRef.current || softHiddenRef.current) {
-            hibernateSnapshotRef.current = payload.snapshot;
-            hibernatePendingBufferRef.current = "";
-          }
-        } catch (err) {
-          logger.warn("Failed to apply observe-popup snapshot to home terminal", err);
+      unsubs.push(bridge.onTerminalSessionApplySnapshot(async (payload) => {
+        if (!payload || payload.sessionId !== sessionId || !payload.snapshot) return false;
+        if (termRef.current) {
+          const term = termRef.current;
+          await flushPendingTerminalWritesBeforeHibernate(term);
+          term.reset();
+          await new Promise<void>((resolve) => term.write(payload.snapshot, resolve));
+          try { term.scrollToBottom?.(); } catch { /* ignore */ }
+        } else if (hibernatedRef.current || softHiddenRef.current) {
+          hibernateSnapshotRef.current = payload.snapshot;
+          hibernatePendingBufferRef.current = "";
         }
+        return true;
       }));
     }
     return () => {
@@ -1283,38 +1296,77 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const cleanupSession = async () => {
     const closingSessionId = sessionRef.current;
     sessionRef.current = null;
-    disposeDataRef.current?.();
-    disposeDataRef.current = null;
-    disposeExitRef.current?.();
-    disposeExitRef.current = null;
-    disposeTelnetEchoModeRef.current?.();
-    disposeTelnetEchoModeRef.current = null;
-    telnetLocalEchoRef.current = false;
+    const disposeSessionListeners = () => {
+      disposeDataRef.current?.();
+      disposeDataRef.current = null;
+      disposeExitRef.current?.();
+      disposeExitRef.current = null;
+      disposeTelnetEchoModeRef.current?.();
+      disposeTelnetEchoModeRef.current = null;
+      telnetLocalEchoRef.current = false;
+    };
+
+    if (!attachExistingSession) {
+      disposeSessionListeners();
+    }
 
     const pendingCleanup = sessionCleanupPromiseRef.current;
     if (pendingCleanup) {
       await pendingCleanup;
     }
 
-    if (!closingSessionId) return;
+    if (!closingSessionId) {
+      disposeSessionListeners();
+      return;
+    }
 
     // Observe/attach popups must not kill the backend session — only release
     // the display route back to the home renderer.
     if (attachExistingSession) {
       const homeId = attachHomeWebContentsIdRef.current;
       attachHomeWebContentsIdRef.current = undefined;
+      let fallbackSnapshot = "";
       try {
-        // Push popup display state home first so reopen is not stale.
-        try {
-          const snap = serializeAddonRef.current?.serialize?.() || "";
-          if (snap) {
-            await terminalBackend.applySessionSnapshot?.(closingSessionId, snap);
+        fallbackSnapshot = serializeAddonRef.current?.serialize?.() || "";
+      } catch {
+        // The post-pause snapshot below remains authoritative when available.
+      }
+      try {
+        // Stop the source before detaching the popup listener. This lets any
+        // already-delivered writes settle into xterm before its final snapshot.
+        if (terminalBackend.setSessionFlowPausedAndWait) {
+          const paused = await terminalBackend.setSessionFlowPausedAndWait(closingSessionId, true);
+          if (!paused?.success && paused?.error === "Output drain unavailable") {
+            terminalBackend.setSessionFlowPaused?.(closingSessionId, true);
+            await new Promise((resolve) => setTimeout(resolve, 40));
+          } else if (!paused?.success) {
+            throw new Error(paused?.error || "Failed to drain terminal output");
           }
-        } catch (snapErr) {
-          logger.warn("Failed to push observe-popup snapshot home before restore", snapErr);
+        } else {
+          terminalBackend.setSessionFlowPaused?.(closingSessionId, true);
+          await new Promise((resolve) => setTimeout(resolve, 40));
         }
-        // If the popup paused the backend under output pressure, resume it and
-        // drain local queues before handing the route back to home.
+        const snapshotTerm = termRef.current;
+        if (snapshotTerm) await flushPendingTerminalWritesBeforeHibernate(snapshotTerm);
+        // Push popup display state home first so reopen is not stale.
+        const snap = serializeAddonRef.current?.serialize?.() || fallbackSnapshot;
+        if (snap) {
+          const applied = await terminalBackend.applySessionSnapshot?.(
+            closingSessionId,
+            snap,
+            attachAuthorization || "",
+          );
+          if (applied && !applied.success) throw new Error(applied.error || "Failed to apply terminal snapshot");
+        }
+        // Hand the route home while output is still paused, then detach the
+        // popup listener and resume so subsequent bytes land on the home route.
+        const restored = await terminalBackend.restoreSessionOutput?.(
+          closingSessionId,
+          homeId ?? null,
+          attachAuthorization || "",
+        );
+        if (restored && !restored.success) throw new Error(restored.error || "Failed to restore terminal output");
+        disposeSessionListeners();
         const activeTerm = termRef.current;
         if (activeTerm) {
           releaseTerminalFlowBeforeHibernate(terminalBackend, activeTerm, closingSessionId, {
@@ -1325,9 +1377,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
           clearTerminalSessionFlowAck(closingSessionId);
           terminalBackend.setSessionFlowPaused?.(closingSessionId, false);
         }
-        await terminalBackend.restoreSessionOutput?.(closingSessionId, homeId ?? null);
       } catch (err) {
         logger.warn("Failed to restore terminal output after attach popup close", err);
+        disposeSessionListeners();
+        throw err;
       }
       return;
     }
@@ -1358,6 +1411,15 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       }
     }
   };
+
+  const cleanupSessionRef = useRef(cleanupSession);
+  cleanupSessionRef.current = cleanupSession;
+  useEffect(() => {
+    if (!attachExistingSession || !onAttachClosePreparationChange) return undefined;
+    const prepare = () => cleanupSessionRef.current();
+    onAttachClosePreparationChange(prepare);
+    return () => onAttachClosePreparationChange(null);
+  }, [attachExistingSession, onAttachClosePreparationChange]);
 
   const disposeRuntimeOnly = () => {
     xtermRuntimeRef.current?.dispose();
@@ -1404,21 +1466,17 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       if (attachExistingSession) {
         const homeId = attachHomeWebContentsIdRef.current;
         attachHomeWebContentsIdRef.current = undefined;
-        try {
-          const term = termRef.current;
-          if (term) {
-            releaseTerminalFlowBeforeHibernate(terminalBackend, term, closingSessionId, {
-              resumeBackend: true,
-            });
-          } else {
-            flushTerminalSessionFlowAck(closingSessionId);
-            clearTerminalSessionFlowAck(closingSessionId);
-            terminalBackend.setSessionFlowPaused?.(closingSessionId, false);
-          }
-        } catch (err) {
-          logger.warn("Failed to release attach popup flow state on hibernate close", err);
-        }
-        void terminalBackend.restoreSessionOutput?.(closingSessionId, homeId ?? null).catch((err) => {
+        terminalBackend.setSessionFlowPaused?.(closingSessionId, true);
+        void terminalBackend.restoreSessionOutput?.(
+          closingSessionId,
+          homeId ?? null,
+          attachAuthorization || "",
+        ).then((result) => {
+          if (!result?.success) throw new Error(result?.error || "Failed to restore terminal output");
+          flushTerminalSessionFlowAck(closingSessionId);
+          clearTerminalSessionFlowAck(closingSessionId);
+          terminalBackend.setSessionFlowPaused?.(closingSessionId, false);
+        }).catch((err) => {
           logger.warn("Failed to restore terminal output after attach popup hibernate close", err);
         });
       } else {
@@ -1434,7 +1492,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }
     sessionRef.current = null;
     clearHibernateRuntimeState();
-  }, [attachExistingSession, clearHibernateRuntimeState, handleTerminalDataCaptureOnce, sessionId, terminalBackend]);
+  }, [attachAuthorization, attachExistingSession, clearHibernateRuntimeState, handleTerminalDataCaptureOnce, sessionId, terminalBackend]);
 
   const beginHibernatedSessionListeners = useCallback((backendId: string) => {
     disposeDataRef.current?.();
@@ -3183,7 +3241,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     onWake: wakeFromHibernateRuntime,
   });
 
-  useTerminalEffects({ CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, chainHosts: resolvedChainHosts, chainProgress, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, finalizeTerminalLogData, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceCloseHibernatedSession, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, hasRuntimeRef, host, hotkeySchemeRef, hibernatedRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen: effectiveComposeBarOpen, isConnectionAwaitingUserInput, isConnectionPastTcpDial, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing: deferTerminalResize, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, needsHostKeyVerification, onBroadcastInputRef, onBroadcastInterruptPriorityChange, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onOutputTriggerUserInputRef: noteOutputTriggerUserInputRef, onPluginRuntimeCwdChange: pluginAwareOnRuntimeCwdChange, onSnippetShortkeyRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, passwordPromptActiveRef, pendingAuthRef, pendingOutputScrollRef, pluginDecorationRefreshRef, pluginDecorationRules, pluginDecorationRulesRef, pluginTerminalLifecycle, pluginTerminalProviderRevision, isPluginTerminalProviderAvailable, requestPluginTerminalProviders, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, scriptRecorderRef: recorderRef, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, requestSearchFocus, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shellType, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, attachExistingSession, attachHomeWebContentsIdRef, snippetsRef, splitResizeActive: isResizing, status, statusRef, sudoAutofillRef, t, teardown, telnetLocalEchoRef, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, workspaceId, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState });
+  useTerminalEffects({ CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, chainHosts: resolvedChainHosts, chainProgress, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, finalizeTerminalLogData, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceCloseHibernatedSession, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, hasRuntimeRef, host, hotkeySchemeRef, hibernatedRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen: effectiveComposeBarOpen, isConnectionAwaitingUserInput, isConnectionPastTcpDial, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing: deferTerminalResize, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, needsHostKeyVerification, onBroadcastInputRef, onBroadcastInterruptPriorityChange, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onOutputTriggerUserInputRef: noteOutputTriggerUserInputRef, onPluginRuntimeCwdChange: pluginAwareOnRuntimeCwdChange, onSnippetShortkeyRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, passwordPromptActiveRef, pendingAuthRef, pendingOutputScrollRef, pluginDecorationRefreshRef, pluginDecorationRules, pluginDecorationRulesRef, pluginTerminalLifecycle, pluginTerminalProviderRevision, isPluginTerminalProviderAvailable, requestPluginTerminalProviders, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, scriptRecorderRef: recorderRef, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, requestSearchFocus, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shellType, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, attachExistingSession, attachAuthorization, attachHomeWebContentsIdRef, snippetsRef, splitResizeActive: isResizing, status, statusRef, sudoAutofillRef, t, teardown, telnetLocalEchoRef, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, workspaceId, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState });
 
   return (
     <>

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -163,6 +163,8 @@ import {
   applyAuthoritativeHibernateSnapshot,
   appendHibernatePendingBuffer,
   isTerminalAlternateScreenActive,
+  readTerminalHibernateContext,
+  resolveTerminalSnapshotCapture,
   serializeTerminalForHibernate,
 } from "./terminal/terminalHibernateRuntime";
 import {
@@ -172,7 +174,6 @@ import {
 } from "./terminal/runtime/terminalFlowAckBuffer";
 import {
   releaseTerminalFlowBeforeHibernate,
-  resolveAttachSnapshot,
 } from "./terminal/runtime/terminalSessionAttachment";
 import { flushPendingTerminalWritesBeforeHibernate } from "./terminal/runtime/terminalUnfocusedRepaint";
 import {
@@ -541,7 +542,13 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       viewportText: hibernateContextViewportSnapshotRef.current,
       pendingText: hibernatePendingBufferRef.current,
     });
-    const fullText = snapshot.fullText || hibernateContextSnapshotRef.current;
+    const retainedText = hibernateContextSnapshotRef.current;
+    const fullText = retainedText
+      ? [retainedText, hibernatePendingBufferRef.current].filter(Boolean).join("\n")
+      : snapshot.fullText;
+    const viewportEndLine = hibernatePendingBufferRef.current && fullText
+      ? fullText.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n").length - 1
+      : snapshot.viewportEndLine;
 
     if (!fullText) {
       return { ok: false, error: `Terminal session "${sessionId}" has no readable terminal buffer yet.` };
@@ -557,7 +564,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       source: 'snapshot',
       alternateScreen: hibernateAlternateScreenRef.current,
       viewportStartLine: snapshot.viewportStartLine,
-      viewportEndLine: snapshot.viewportEndLine,
+      viewportEndLine,
     });
   }, [host.label, sessionDisplayName, sessionId]);
 
@@ -1281,7 +1288,15 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }
     if (bridge?.onTerminalSessionApplySnapshot) {
       unsubs.push(bridge.onTerminalSessionApplySnapshot(async (payload) => {
-        if (!payload || payload.sessionId !== sessionId || typeof payload.snapshot !== "string") return false;
+        if (
+          !payload
+          || payload.sessionId !== sessionId
+          || typeof payload.snapshot !== "string"
+          || typeof payload.contextSnapshot !== "string"
+          || typeof payload.contextViewportSnapshot !== "string"
+          || typeof payload.contextScrollbackSnapshot !== "string"
+          || typeof payload.alternateScreen !== "boolean"
+        ) return false;
         if (termRef.current) {
           const term = termRef.current;
           await flushPendingTerminalWritesBeforeHibernate(term);
@@ -1300,7 +1315,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
             contextScrollbackSnapshot: hibernateContextScrollbackSnapshotRef,
             pendingBuffer: hibernatePendingBufferRef,
             alternateScreen: hibernateAlternateScreenRef,
-          }, payload.snapshot);
+          }, payload.snapshot, {
+            contextSnapshot: payload.contextSnapshot,
+            contextViewportSnapshot: payload.contextViewportSnapshot,
+            contextScrollbackSnapshot: payload.contextScrollbackSnapshot,
+            alternateScreen: payload.alternateScreen,
+          });
         }
         return true;
       }));
@@ -1342,12 +1362,6 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     if (attachExistingSession) {
       const homeId = attachHomeWebContentsIdRef.current;
       attachHomeWebContentsIdRef.current = undefined;
-      let fallbackSnapshot = "";
-      try {
-        fallbackSnapshot = serializeAddonRef.current?.serialize?.() || "";
-      } catch {
-        // The post-pause snapshot below remains authoritative when available.
-      }
       try {
         // Stop the source before detaching the popup listener. This lets any
         // already-delivered writes settle into xterm before its final snapshot.
@@ -1366,16 +1380,30 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         const snapshotTerm = termRef.current;
         if (snapshotTerm) await flushPendingTerminalWritesBeforeHibernate(snapshotTerm);
         // Push popup display state home first so reopen is not stale.
-        let finalSnapshot: unknown;
+        let finalContext = {
+          contextSnapshot: "",
+          contextViewportSnapshot: "",
+          contextScrollbackSnapshot: "",
+          alternateScreen: snapshotTerm ? isTerminalAlternateScreenActive(snapshotTerm) : false,
+        };
         try {
-          finalSnapshot = serializeAddonRef.current?.serialize?.();
-        } catch {
-          finalSnapshot = undefined;
+          if (snapshotTerm) finalContext = readTerminalHibernateContext(snapshotTerm);
+        } catch (err) {
+          logger.warn("Failed to read terminal context for attach popup", err);
         }
-        const snap = resolveAttachSnapshot(finalSnapshot, fallbackSnapshot);
+        let serializedSnapshot: unknown;
+        try {
+          serializedSnapshot = serializeAddonRef.current?.serialize?.();
+        } catch (err) {
+          logger.warn("Failed to serialize terminal snapshot for attach popup", err);
+        }
+        const capture = resolveTerminalSnapshotCapture(serializedSnapshot, finalContext);
+        const snap = capture.snapshot;
+        finalContext = capture.context;
         const applied = await terminalBackend.applySessionSnapshot?.(
           closingSessionId,
           snap,
+          finalContext,
           attachAuthorization || "",
         );
         if (applied && !applied.success) throw new Error(applied.error || "Failed to apply terminal snapshot");

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -242,6 +242,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   pendingScriptId,
   pendingScript,
   reuseConnectionFromSessionId,
+  attachExistingSession = false,
   serialConfig,
   hotkeyScheme = "disabled",
   disableTerminalFontZoom = false,
@@ -1229,6 +1230,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     captureHandler(capturedSessionId, capturedData);
   }, [finalizeTerminalLogData]);
 
+  const attachHomeWebContentsIdRef = useRef<number | null | undefined>(undefined);
+
   const cleanupSession = async () => {
     const closingSessionId = sessionRef.current;
     sessionRef.current = null;
@@ -1246,6 +1249,19 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }
 
     if (!closingSessionId) return;
+
+    // Observe/attach popups must not kill the backend session — only release
+    // the display route back to the home renderer.
+    if (attachExistingSession) {
+      const homeId = attachHomeWebContentsIdRef.current;
+      attachHomeWebContentsIdRef.current = undefined;
+      try {
+        await terminalBackend.restoreSessionOutput?.(closingSessionId, homeId ?? null);
+      } catch (err) {
+        logger.warn("Failed to restore terminal output after attach popup close", err);
+      }
+      return;
+    }
 
     const cleanupPromise = (async () => {
       const activeTerm = termRef.current;
@@ -1316,18 +1332,26 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     if (closingSessionId) {
       flushTerminalSessionFlowAck(closingSessionId);
       clearTerminalSessionFlowAck(closingSessionId);
-      try {
-        const closeResult = terminalBackend.closeSession(closingSessionId);
-        void Promise.resolve(closeResult).catch((err) => {
-          logger.warn("Failed to close hibernated session", err);
+      if (attachExistingSession) {
+        const homeId = attachHomeWebContentsIdRef.current;
+        attachHomeWebContentsIdRef.current = undefined;
+        void terminalBackend.restoreSessionOutput?.(closingSessionId, homeId ?? null).catch((err) => {
+          logger.warn("Failed to restore terminal output after attach popup hibernate close", err);
         });
-      } catch (err) {
-        logger.warn("Failed to close hibernated session", err);
+      } else {
+        try {
+          const closeResult = terminalBackend.closeSession(closingSessionId);
+          void Promise.resolve(closeResult).catch((err) => {
+            logger.warn("Failed to close hibernated session", err);
+          });
+        } catch (err) {
+          logger.warn("Failed to close hibernated session", err);
+        }
       }
     }
     sessionRef.current = null;
     clearHibernateRuntimeState();
-  }, [clearHibernateRuntimeState, handleTerminalDataCaptureOnce, sessionId, terminalBackend]);
+  }, [attachExistingSession, clearHibernateRuntimeState, handleTerminalDataCaptureOnce, sessionId, terminalBackend]);
 
   const beginHibernatedSessionListeners = useCallback((backendId: string) => {
     disposeDataRef.current?.();
@@ -3076,7 +3100,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     onWake: wakeFromHibernateRuntime,
   });
 
-  useTerminalEffects({ CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, chainHosts: resolvedChainHosts, chainProgress, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, finalizeTerminalLogData, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceCloseHibernatedSession, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, hasRuntimeRef, host, hotkeySchemeRef, hibernatedRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen: effectiveComposeBarOpen, isConnectionAwaitingUserInput, isConnectionPastTcpDial, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing: deferTerminalResize, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, needsHostKeyVerification, onBroadcastInputRef, onBroadcastInterruptPriorityChange, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onOutputTriggerUserInputRef: noteOutputTriggerUserInputRef, onPluginRuntimeCwdChange: pluginAwareOnRuntimeCwdChange, onSnippetShortkeyRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, passwordPromptActiveRef, pendingAuthRef, pendingOutputScrollRef, pluginDecorationRefreshRef, pluginDecorationRules, pluginDecorationRulesRef, pluginTerminalLifecycle, pluginTerminalProviderRevision, isPluginTerminalProviderAvailable, requestPluginTerminalProviders, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, scriptRecorderRef: recorderRef, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, requestSearchFocus, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shellType, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, snippetsRef, splitResizeActive: isResizing, status, statusRef, sudoAutofillRef, t, teardown, telnetLocalEchoRef, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, workspaceId, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState });
+  useTerminalEffects({ CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, chainHosts: resolvedChainHosts, chainProgress, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, finalizeTerminalLogData, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceCloseHibernatedSession, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, hasRuntimeRef, host, hotkeySchemeRef, hibernatedRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen: effectiveComposeBarOpen, isConnectionAwaitingUserInput, isConnectionPastTcpDial, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing: deferTerminalResize, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, needsHostKeyVerification, onBroadcastInputRef, onBroadcastInterruptPriorityChange, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onOutputTriggerUserInputRef: noteOutputTriggerUserInputRef, onPluginRuntimeCwdChange: pluginAwareOnRuntimeCwdChange, onSnippetShortkeyRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, passwordPromptActiveRef, pendingAuthRef, pendingOutputScrollRef, pluginDecorationRefreshRef, pluginDecorationRules, pluginDecorationRulesRef, pluginTerminalLifecycle, pluginTerminalProviderRevision, isPluginTerminalProviderAvailable, requestPluginTerminalProviders, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, scriptRecorderRef: recorderRef, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, requestSearchFocus, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shellType, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, attachExistingSession, attachHomeWebContentsIdRef, snippetsRef, splitResizeActive: isResizing, status, statusRef, sudoAutofillRef, t, teardown, telnetLocalEchoRef, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, workspaceId, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState });
 
   return (
     <>

--- a/components/TerminalPopupPage.test.ts
+++ b/components/TerminalPopupPage.test.ts
@@ -70,6 +70,28 @@ test('resolveTerminalPopupHost does not turn command popups into serial sessions
   assert.equal(host.moshEnabled, false);
 });
 
+test('resolveTerminalPopupHost preserves serial settings when attaching a live session', () => {
+  const serialConfig = {
+    path: '/dev/ttyUSB0',
+    baudRate: 115200,
+    lineMode: true,
+    localEcho: true,
+  } as const;
+  const payload = popupPayload(sourceSession({
+    protocol: 'serial',
+    hostname: serialConfig.path,
+    port: serialConfig.baudRate,
+    serialConfig,
+  }));
+  payload.attachSessionId = payload.sourceSession.id;
+
+  const host = resolveTerminalPopupHost(payload, [vaultHost({ protocol: 'serial', serialConfig })]);
+
+  assert.equal(host.protocol, 'serial');
+  assert.deepEqual(host.serialConfig, serialConfig);
+  assert.match(source, /serialConfig=\{isAttachMode \? config\.sourceSession\.serialConfig : undefined\}/);
+});
+
 test('resolveTerminalPopupReuseId uses the explicit reuse id from the prepared source session', () => {
   assert.equal(
     resolveTerminalPopupReuseId(popupPayload(sourceSession({ reuseConnectionFromSessionId: 'session-1' }))),
@@ -87,4 +109,10 @@ test('popup terminals resolve complete host config and pass jump hosts into Term
   assert.match(source, /resolveTerminalPopupHost\(config,\s*hosts,\s*\{\s+groupConfigs,\s+proxyProfiles,/);
   assert.match(source, /resolveTerminalChainHosts\(\{\s+host,\s+hosts,\s+groupConfigs,\s+proxyProfiles,/);
   assert.match(source, /chainHosts=\{chainHosts\}/);
+});
+
+test('attach popup close preparation has a bounded timeout', () => {
+  assert.match(source, /Promise\.race\(\[/);
+  assert.match(source, /Attach close preparation timed out/);
+  assert.match(source, /1500/);
 });

--- a/components/TerminalPopupPage.test.ts
+++ b/components/TerminalPopupPage.test.ts
@@ -116,3 +116,8 @@ test('attach popup close preparation has a bounded timeout', () => {
   assert.match(source, /Attach close preparation timed out/);
   assert.match(source, /1500/);
 });
+
+test('an explicitly closed attached session closes its observe popup', () => {
+  assert.match(source, /isAttachMode && evt\.reason === 'closed'/);
+  assert.match(source, /void handleClose\(\)/);
+});

--- a/components/TerminalPopupPage.test.ts
+++ b/components/TerminalPopupPage.test.ts
@@ -7,6 +7,7 @@ import type { TerminalPopupPayload } from '../domain/systemManager/types';
 import { resolveTerminalPopupHost, resolveTerminalPopupReuseId } from './TerminalPopupPage';
 
 const source = readFileSync(new URL('./TerminalPopupPage.tsx', import.meta.url), 'utf8');
+const terminalSource = readFileSync(new URL('./Terminal.tsx', import.meta.url), 'utf8');
 
 const vaultHost = (overrides: Partial<Host> = {}): Host => ({
   id: 'host-1',
@@ -118,6 +119,19 @@ test('attach popup close preparation has a bounded timeout', () => {
 });
 
 test('an explicitly closed attached session closes its observe popup', () => {
-  assert.match(source, /isAttachMode && evt\.reason === 'closed'/);
+  assert.match(source, /onSessionExit=\{\(_closedSessionId, evt\) => \{\s+if \(isAttachMode\)/);
   assert.match(source, /void handleClose\(\)/);
+});
+
+test('an attached observe popup never owns automatic reconnect', () => {
+  const reconnectStart = terminalSource.indexOf('const scheduleAutoReconnect = useCallback');
+  const reconnectEnd = terminalSource.indexOf('const prepareRestoredReconnect', reconnectStart);
+  const reconnectSource = terminalSource.slice(reconnectStart, reconnectEnd);
+  assert.match(reconnectSource, /if \(attachExistingSession\) return false;/);
+  assert.match(reconnectSource, /\[attachExistingSession, host, t, terminalSettings, updateStatus\]/);
+  assert.match(terminalSource, /const startReconnect = async[\s\S]*?if \(attachExistingSession\) return;/);
+  assert.match(
+    terminalSource,
+    /useEffect\(\(\) => \{\s+if \(attachExistingSession\) return undefined;\s+return terminalReconnectRegistry\.register/,
+  );
 });

--- a/components/TerminalPopupPage.tsx
+++ b/components/TerminalPopupPage.tsx
@@ -465,6 +465,10 @@ function TerminalPopupPageInner() {
                 void handleClose();
               }}
               onSessionExit={(_closedSessionId, evt) => {
+                if (isAttachMode && evt.reason === 'closed') {
+                  void handleClose();
+                  return;
+                }
                 if (shouldCloseTerminalPopupOnExit(evt)) {
                   void handleClose();
                   return;

--- a/components/TerminalPopupPage.tsx
+++ b/components/TerminalPopupPage.tsx
@@ -249,7 +249,11 @@ function TerminalPopupPageInner() {
   const [config, setConfig] = useState<TerminalPopupPayload | null>(null);
   const [terminalReady, setTerminalReady] = useState(false);
   const [startupError, setStartupError] = useState<string | null>(null);
-  const sessionId = useMemo(() => crypto.randomUUID(), []);
+  const generatedSessionId = useMemo(() => crypto.randomUUID(), []);
+  const attachSessionId = config?.attachSessionId;
+  const isAttachMode = Boolean(attachSessionId);
+  // Attach mode must reuse the live backend session id so input/output hit the same PTY.
+  const sessionId = attachSessionId || generatedSessionId;
   const knownHostsRef = React.useRef(knownHosts);
   const effectiveKnownHosts = useMemo(
     () => getEffectiveKnownHosts(knownHosts) ?? [],
@@ -309,6 +313,8 @@ function TerminalPopupPageInner() {
 
   const ready = Boolean(config && host && vaultInitialized);
   const startupRevealDelayMs = useMemo(() => {
+    // Attach mode shows the live session immediately (no startup command).
+    if (isAttachMode) return 0;
     if (!config?.startupCommand) return 0;
     const configuredDelay = settings.terminalSettings?.startupCommandDelayMs;
     const startupDelay = typeof configuredDelay === 'number' && Number.isFinite(configuredDelay)
@@ -318,7 +324,7 @@ function TerminalPopupPageInner() {
       POPUP_STARTUP_REVEAL_MAX_DELAY_MS,
       Math.max(POPUP_STARTUP_REVEAL_MIN_DELAY_MS, startupDelay + POPUP_STARTUP_REVEAL_EXTRA_DELAY_MS),
     );
-  }, [config?.startupCommand, settings.terminalSettings?.startupCommandDelayMs]);
+  }, [config?.startupCommand, isAttachMode, settings.terminalSettings?.startupCommandDelayMs]);
   const revealTerminal = useCallback(() => {
     setTerminalReady(true);
   }, []);
@@ -330,9 +336,13 @@ function TerminalPopupPageInner() {
 
   useEffect(() => {
     if (!ready) return undefined;
+    if (isAttachMode) {
+      setTerminalReady(true);
+      return undefined;
+    }
     const timeout = window.setTimeout(() => setTerminalReady(true), startupRevealDelayMs);
     return () => window.clearTimeout(timeout);
-  }, [config?.popupId, ready, startupRevealDelayMs]);
+  }, [config?.popupId, isAttachMode, ready, startupRevealDelayMs]);
 
   return (
     <div
@@ -390,8 +400,9 @@ function TerminalPopupPageInner() {
               terminalSettings={settings.terminalSettings}
               disableTerminalFontZoom={settings.disableTerminalFontZoom}
               sessionId={sessionId}
-              startupCommand={config.startupCommand}
-              reuseConnectionFromSessionId={reuseId}
+              startupCommand={isAttachMode ? undefined : config.startupCommand}
+              reuseConnectionFromSessionId={isAttachMode ? undefined : reuseId}
+              attachExistingSession={isAttachMode}
               onCloseSession={() => {
                 void close();
               }}
@@ -400,11 +411,12 @@ function TerminalPopupPageInner() {
                   void close();
                   return;
                 }
-                if (!terminalReady && config.startupCommand) {
+                if (!terminalReady && config.startupCommand && !isAttachMode) {
                   setStartupError(t('systemManager.popup.startupFailed'));
                 }
               }}
               onStatusChange={(_changedSessionId, status) => {
+                if (isAttachMode && status === 'connected') revealTerminal();
                 if (!config.startupCommand && status === 'connected') revealTerminal();
               }}
               onTerminalDataCapture={revealTerminal}

--- a/components/TerminalPopupPage.tsx
+++ b/components/TerminalPopupPage.tsx
@@ -176,10 +176,14 @@ function TerminalPopupTitleIcon({ icon }: { icon: TerminalPopupPayload['icon'] }
   );
 }
 
-function resolveHostProtocolFromSourceSession(source: TerminalPopupPayload['sourceSession']): Host['protocol'] {
+function resolveHostProtocolFromSourceSession(
+  source: TerminalPopupPayload['sourceSession'],
+  attachExistingSession: boolean,
+): Host['protocol'] {
   if (
     source.protocol === 'local' ||
-    source.protocol === 'telnet'
+    source.protocol === 'telnet' ||
+    (attachExistingSession && source.protocol === 'serial')
   ) {
     return source.protocol;
   }
@@ -189,8 +193,9 @@ function resolveHostProtocolFromSourceSession(source: TerminalPopupPayload['sour
 function applySourceSessionConnectionOverrides(
   host: Host,
   source: TerminalPopupPayload['sourceSession'],
+  attachExistingSession: boolean,
 ): Host {
-  const protocol = resolveHostProtocolFromSourceSession(source);
+  const protocol = resolveHostProtocolFromSourceSession(source, attachExistingSession);
   return {
     ...host,
     hostname: source.hostname || host.hostname,
@@ -200,6 +205,9 @@ function applySourceSessionConnectionOverrides(
     moshEnabled: source.moshEnabled === true,
     etEnabled: source.etEnabled === true,
     charset: source.charset ?? host.charset,
+    ...(protocol === 'serial' && source.serialConfig
+      ? { serialConfig: source.serialConfig }
+      : {}),
   };
 }
 
@@ -222,6 +230,7 @@ export function resolveTerminalPopupHost(
   return applySourceSessionConnectionOverrides(
     resolvedHost,
     config.sourceSession,
+    Boolean(config.attachSessionId),
   );
 }
 
@@ -231,7 +240,13 @@ export function resolveTerminalPopupReuseId(config: TerminalPopupPayload): strin
 
 function TerminalPopupPageInner() {
   const { t } = useI18n();
-  const { close, setWindowTitle, onPopupConfig } = useTerminalPopupWindow();
+  const {
+    close,
+    markAttachClosePrepared,
+    onPopupConfig,
+    onPrepareClose,
+    setWindowTitle,
+  } = useTerminalPopupWindow();
   const { notifyRendererReady, onWindowCommandCloseRequested } = useWindowControls();
   const settings = useSettingsState();
   const {
@@ -251,10 +266,43 @@ function TerminalPopupPageInner() {
   const [startupError, setStartupError] = useState<string | null>(null);
   const generatedSessionId = useMemo(() => crypto.randomUUID(), []);
   const attachSessionId = config?.attachSessionId;
+  const attachAuthorization = config?.attachAuthorization;
   const isAttachMode = Boolean(attachSessionId);
   // Attach mode must reuse the live backend session id so input/output hit the same PTY.
   const sessionId = attachSessionId || generatedSessionId;
   const knownHostsRef = React.useRef(knownHosts);
+  const attachClosePreparationRef = React.useRef<(() => Promise<void>) | null>(null);
+  const closePromiseRef = React.useRef<Promise<void> | null>(null);
+  const handleAttachClosePreparationChange = useCallback((prepare: (() => Promise<void>) | null) => {
+    attachClosePreparationRef.current = prepare;
+  }, []);
+  const handleClose = useCallback(() => {
+    if (closePromiseRef.current) return closePromiseRef.current;
+    const closePromise = (async () => {
+      if (isAttachMode && attachSessionId && attachAuthorization) {
+        try {
+          const preparation = attachClosePreparationRef.current?.();
+          if (preparation) {
+            await Promise.race([
+              preparation,
+              new Promise<never>((_, reject) => setTimeout(
+                () => reject(new Error("Attach close preparation timed out")),
+                1500,
+              )),
+            ]);
+          }
+          await markAttachClosePrepared(attachSessionId, attachAuthorization);
+        } catch { /* The main-process close handshake owns the final fallback. */ }
+      }
+      await close();
+    })();
+    closePromiseRef.current = closePromise;
+    const clearClosePromise = () => {
+      if (closePromiseRef.current === closePromise) closePromiseRef.current = null;
+    };
+    void closePromise.then(clearClosePromise, clearClosePromise);
+    return closePromise;
+  }, [attachAuthorization, attachSessionId, close, isAttachMode, markAttachClosePrepared]);
   const effectiveKnownHosts = useMemo(
     () => getEffectiveKnownHosts(knownHosts) ?? [],
     [knownHosts],
@@ -286,9 +334,16 @@ function TerminalPopupPageInner() {
 
   useEffect(() => {
     return onWindowCommandCloseRequested(() => {
-      void close();
+      void handleClose();
     });
-  }, [close, onWindowCommandCloseRequested]);
+  }, [handleClose, onWindowCommandCloseRequested]);
+
+  useEffect(() => {
+    return onPrepareClose((payload) => {
+      if (payload.sessionId !== attachSessionId || payload.authorization !== attachAuthorization) return;
+      void handleClose();
+    });
+  }, [attachAuthorization, attachSessionId, handleClose, onPrepareClose]);
 
   const host = useMemo(() => {
     if (!config) return null;
@@ -365,7 +420,7 @@ function TerminalPopupPageInner() {
             {config?.title ?? ''}
           </div>
         </div>
-        {!isMac && <TerminalPopupWindowControls mac={false} onClose={() => void close()} />}
+        {!isMac && <TerminalPopupWindowControls mac={false} onClose={() => void handleClose()} />}
       </div>
       {!ready || !config || !host ? (
         <TerminalPopupSpinner />
@@ -373,7 +428,7 @@ function TerminalPopupPageInner() {
         <TerminalPopupStartupError
           message={startupError}
           closeLabel={t('common.close')}
-          onClose={() => void close()}
+          onClose={() => void handleClose()}
         />
       ) : (
         <div className="relative flex-1 min-h-0 flex flex-col bg-[color:var(--terminal-popup-bg)]">
@@ -403,12 +458,15 @@ function TerminalPopupPageInner() {
               startupCommand={isAttachMode ? undefined : config.startupCommand}
               reuseConnectionFromSessionId={isAttachMode ? undefined : reuseId}
               attachExistingSession={isAttachMode}
+              attachAuthorization={attachAuthorization}
+              onAttachClosePreparationChange={handleAttachClosePreparationChange}
+              serialConfig={isAttachMode ? config.sourceSession.serialConfig : undefined}
               onCloseSession={() => {
-                void close();
+                void handleClose();
               }}
               onSessionExit={(_closedSessionId, evt) => {
                 if (shouldCloseTerminalPopupOnExit(evt)) {
-                  void close();
+                  void handleClose();
                   return;
                 }
                 if (!terminalReady && config.startupCommand && !isAttachMode) {

--- a/components/TerminalPopupPage.tsx
+++ b/components/TerminalPopupPage.tsx
@@ -465,7 +465,7 @@ function TerminalPopupPageInner() {
                 void handleClose();
               }}
               onSessionExit={(_closedSessionId, evt) => {
-                if (isAttachMode && evt.reason === 'closed') {
+                if (isAttachMode) {
                   void handleClose();
                   return;
                 }

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -140,12 +140,19 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
     if (!ctx.telnetLocalEchoRef || !ctx.terminalBackend.onTelnetEchoMode) return;
     clearTelnetEchoMode({ resetLocalEcho });
     if (resetLocalEcho) ctx.telnetLocalEchoRef.current = false;
+    let receivedLiveUpdate = false;
     const dispose = ctx.terminalBackend.onTelnetEchoMode(
       backendSessionId,
       (evt) => {
+        receivedLiveUpdate = true;
         ctx.telnetLocalEchoRef!.current = Boolean(evt.localEcho);
       },
     ) ?? null;
+    void ctx.terminalBackend.getTelnetEchoMode?.(backendSessionId).then((mode) => {
+      if (!receivedLiveUpdate && mode?.success) {
+        ctx.telnetLocalEchoRef!.current = Boolean(mode.localEcho);
+      }
+    }).catch(() => {});
     if (ctx.disposeTelnetEchoModeRef) {
       ctx.disposeTelnetEchoModeRef.current = dispose;
     } else {

--- a/components/terminal/runtime/createTerminalSessionStarters.types.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.types.ts
@@ -74,6 +74,13 @@ export type TerminalBackendApi = {
     sessionId: string,
     cb: (evt: { sessionId: string; remoteEcho: boolean; localEcho: boolean }) => void,
   ) => (() => void) | undefined;
+  getTelnetEchoMode?: (sessionId: string) => Promise<{
+    success: boolean;
+    sessionId?: string;
+    remoteEcho?: boolean;
+    localEcho?: boolean;
+    error?: string;
+  }>;
   onChainProgress: (
     cb: (sessionId: string, hop: number, total: number, label: string, status: string, error?: string) => void,
   ) => (() => void) | undefined;
@@ -88,6 +95,7 @@ export type TerminalBackendApi = {
   setSessionFlowPaused?: (sessionId: string, paused: boolean) => void;
   /** Acknowledge rendered terminal output bytes for main-process IPC back-pressure. */
   ackSessionFlow?: (sessionId: string, bytes: number) => void;
+  notifyTerminalSessionDisplayReady?: (sessionId: string) => void;
 };
 
 export type PendingAuth = {

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -1070,6 +1070,44 @@ test("attachSessionToTerminal resets timestamp state for a reused terminal", () 
   assert.equal(writes[1], "fresh");
 });
 
+test("attachSessionToTerminal clears the backend id before reporting exit", () => {
+  const { term } = createFakeTerm();
+  let onExit: ((evt: { reason?: string }) => void) | null = null;
+  let sessionIdSeenByConsumer: string | null | undefined = "not-called";
+  const sessionRef = { current: null as string | null };
+  const ctx = {
+    ...createContext(false),
+    sessionId: "session-1",
+    sessionRef,
+    hasConnectedRef: { current: true },
+    hasRunStartupCommandRef: { current: false },
+    disposeDataRef: { current: null },
+    disposeExitRef: { current: null },
+    fitAddonRef: { current: null },
+    serializeAddonRef: { current: null },
+    pendingAuthRef: { current: null },
+    terminalBackend: {
+      onSessionData: () => () => {},
+      onSessionExit: (_id: string, callback: (evt: { reason?: string }) => void) => {
+        onExit = callback;
+        return () => {};
+      },
+    },
+    updateStatus: () => {},
+    setError: () => {},
+    onSessionExit: () => {
+      sessionIdSeenByConsumer = sessionRef.current;
+    },
+  };
+
+  attachSessionToTerminal(ctx as never, term, "session-1");
+  assert.equal(sessionRef.current, "session-1");
+  onExit?.({ reason: "closed" });
+
+  assert.equal(sessionRef.current, null);
+  assert.equal(sessionIdSeenByConsumer, null);
+});
+
 test("attachSessionToTerminal keeps interrupt-time output visible", () => {
   clearTerminalSessionFlowAck("session-1");
   const { term, writes } = createFakeTerm();

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -14,9 +14,11 @@ import {
   attachSessionToTerminal,
   getFlowController,
   notePendingOutputScrollIfEnabled,
+  resolveAttachSnapshot,
   tryAttachSessionToTerminal,
   writeSessionData,
 } from "./terminalSessionAttachment.ts";
+
 import {
   clearTerminalSessionFlowAck,
   flushTerminalSessionFlowAck,
@@ -38,6 +40,12 @@ import {
   createPromptLineBreakState,
   markTerminalCommandCompletionPending,
 } from "./promptLineBreak";
+
+test("resolveAttachSnapshot keeps an authoritative empty final snapshot", () => {
+  assert.equal(resolveAttachSnapshot("", "stale fallback"), "");
+  assert.equal(resolveAttachSnapshot("fresh", "stale fallback"), "fresh");
+  assert.equal(resolveAttachSnapshot(undefined, "fallback"), "fallback");
+});
 
 const createFakeTerm = (activeType = "normal") => {
   const writes: string[] = [];

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -791,6 +791,11 @@ export const attachSessionToTerminal = (
   ctx.terminalBackend.notifyTerminalSessionDisplayReady?.(id);
 
   ctx.disposeExitRef.current = ctx.terminalBackend.onSessionExit(id, (evt) => {
+    // The backend is already gone. In particular, an observe popup must not
+    // run its normal pause/snapshot/restore handoff while closing afterward.
+    if (ctx.sessionRef.current === id) {
+      ctx.sessionRef.current = null;
+    }
     ctx.updateStatus("disconnected");
     if (evt.error) {
       ctx.setError(evt.error);

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -680,6 +680,11 @@ export const releaseTerminalFlowBeforeHibernate = (
   terminalFlowControllers.delete(term);
 };
 
+export const resolveAttachSnapshot = (
+  finalSnapshot: unknown,
+  fallbackSnapshot: string,
+): string => (typeof finalSnapshot === "string" ? finalSnapshot : fallbackSnapshot);
+
 export const detachSessionDataListeners = (
   ctx: TerminalSessionStartersContext,
   term: XTerm,

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -788,6 +788,7 @@ export const attachSessionToTerminal = (
     },
     { replayBacklog: true },
   );
+  ctx.terminalBackend.notifyTerminalSessionDisplayReady?.(id);
 
   ctx.disposeExitRef.current = ctx.terminalBackend.onSessionExit(id, (evt) => {
     ctx.updateStatus("disconnected");

--- a/components/terminal/terminalHelpers.ts
+++ b/components/terminal/terminalHelpers.ts
@@ -144,6 +144,10 @@ export interface TerminalProps {
    * backend session on unmount.
    */
   attachExistingSession?: boolean;
+  /** Ephemeral grant required for attach-session IPC. */
+  attachAuthorization?: string;
+  /** Registers the async handoff that must finish before an attach popup closes. */
+  onAttachClosePreparationChange?: (prepare: (() => Promise<void>) | null) => void;
   serialConfig?: SerialConfig;
   hotkeyScheme?: "disabled" | "mac" | "pc";
   disableTerminalFontZoom?: boolean;

--- a/components/terminal/terminalHelpers.ts
+++ b/components/terminal/terminalHelpers.ts
@@ -138,6 +138,12 @@ export interface TerminalProps {
   // source session whose authenticated connection should be reused for a new
   // shell channel — skipping a second MFA prompt (issue #1204).
   reuseConnectionFromSessionId?: string;
+  /**
+   * Attach to an already-running backend session (same PTY) instead of starting
+   * a new one. Used by the AI silent-session observe popup. Must not close the
+   * backend session on unmount.
+   */
+  attachExistingSession?: boolean;
   serialConfig?: SerialConfig;
   hotkeyScheme?: "disabled" | "mac" | "pc";
   disableTerminalFontZoom?: boolean;

--- a/components/terminal/terminalHibernateRuntime.test.ts
+++ b/components/terminal/terminalHibernateRuntime.test.ts
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { buildTerminalContextSnapshotText } from "../../domain/terminalContextRead.ts";
 
 import {
   applyAuthoritativeHibernateSnapshot,
   isTerminalAlternateScreenActive,
+  readTerminalHibernateContext,
   refreshTerminalViewport,
   resolveHibernateSerializeOptions,
+  resolveTerminalSnapshotCapture,
   serializeTerminalForHibernate,
 } from "./terminalHibernateRuntime.ts";
 
@@ -22,7 +25,12 @@ test("authoritative empty snapshots clear every hibernated copy", () => {
     alternateScreen: ref(true),
   };
 
-  applyAuthoritativeHibernateSnapshot(refs, "");
+  applyAuthoritativeHibernateSnapshot(refs, "", {
+    contextSnapshot: "",
+    contextViewportSnapshot: "",
+    contextScrollbackSnapshot: "",
+    alternateScreen: false,
+  });
 
   assert.deepEqual(Object.fromEntries(
     Object.entries(refs).map(([key, value]) => [key, value.current]),
@@ -36,6 +44,38 @@ test("authoritative empty snapshots clear every hibernated copy", () => {
     pendingBuffer: "",
     alternateScreen: false,
   });
+});
+
+test("authoritative non-empty snapshots keep readable hibernated context", () => {
+  const ref = <T>(current: T) => ({ current });
+  const refs = {
+    snapshot: ref(""),
+    viewportSnapshot: ref(""),
+    scrollbackSnapshot: ref("old scrollback"),
+    contextSnapshot: ref("old context"),
+    contextViewportSnapshot: ref("old context viewport"),
+    contextScrollbackSnapshot: ref("old context scrollback"),
+    pendingBuffer: ref("old pending"),
+    alternateScreen: ref(true),
+  };
+  const serialized = "\x1b[31mleft\x1b[4Cright\x1b[0m";
+  const context = {
+    contextSnapshot: "history\nleft    right",
+    contextViewportSnapshot: "left    right",
+    contextScrollbackSnapshot: "history",
+    alternateScreen: true,
+  };
+
+  applyAuthoritativeHibernateSnapshot(refs, serialized, context);
+
+  assert.equal(refs.snapshot.current, serialized);
+  assert.equal(refs.viewportSnapshot.current, serialized);
+  assert.equal(refs.scrollbackSnapshot.current, "");
+  assert.equal(refs.contextSnapshot.current, context.contextSnapshot);
+  assert.equal(refs.contextViewportSnapshot.current, context.contextViewportSnapshot);
+  assert.equal(refs.contextScrollbackSnapshot.current, context.contextScrollbackSnapshot);
+  assert.equal(refs.pendingBuffer.current, "");
+  assert.equal(refs.alternateScreen.current, true);
 });
 
 const createFakeTerm = (bufferType: "normal" | "alternate", rows = 24, length = 30) => ({
@@ -72,6 +112,107 @@ test("resolveHibernateSerializeOptions excludes alt buffer on the normal screen"
     excludeModes: true,
     alternateScreen: false,
   });
+});
+
+test("readTerminalHibernateContext uses rendered buffer text instead of replay control sequences", () => {
+  const term = createFakeTerm("normal", 3, 5);
+  const context = readTerminalHibernateContext(term as never);
+  assert.equal(context.contextScrollbackSnapshot, "screen-0\nscreen-1");
+  assert.equal(context.contextViewportSnapshot, "screen-2\nscreen-3\nscreen-4");
+  assert.equal(context.contextSnapshot, "screen-0\nscreen-1\nscreen-2\nscreen-3\nscreen-4");
+});
+
+test("readTerminalHibernateContext preserves a scrolled viewport separately from full context", () => {
+  const term = createFakeTerm("normal", 3, 7);
+  Object.assign(term.buffer.active, { viewportY: 2 });
+  const context = readTerminalHibernateContext(term as never);
+  assert.equal(context.contextSnapshot, Array.from({ length: 7 }, (_, index) => `screen-${index}`).join("\n"));
+  assert.equal(context.contextScrollbackSnapshot, "screen-0\nscreen-1");
+  assert.equal(context.contextViewportSnapshot, "screen-2\nscreen-3\nscreen-4");
+  assert.equal(context.alternateScreen, false);
+});
+
+test("readTerminalHibernateContext marks alternate-screen viewport context", () => {
+  const term = createFakeTerm("alternate", 3, 3);
+  assert.deepEqual(readTerminalHibernateContext(term as never), {
+    contextSnapshot: "screen-0\nscreen-1\nscreen-2",
+    contextViewportSnapshot: "screen-0\nscreen-1\nscreen-2",
+    contextScrollbackSnapshot: "",
+    alternateScreen: true,
+  });
+});
+
+test("readTerminalHibernateContext treats an all-empty buffer as no readable context", () => {
+  const term = createFakeTerm("normal", 3, 3);
+  Object.assign(term.buffer.active, {
+    getLine() {
+      return { translateToString: () => "" };
+    },
+  });
+  assert.deepEqual(readTerminalHibernateContext(term as never), {
+    contextSnapshot: "",
+    contextViewportSnapshot: "",
+    contextScrollbackSnapshot: "",
+    alternateScreen: false,
+  });
+});
+
+test("readTerminalHibernateContext preserves blank scrollback line boundaries", () => {
+  const lines = ["", "", "v1", "v2", "v3"];
+  const term = createFakeTerm("normal", 3, lines.length);
+  Object.assign(term.buffer.active, {
+    viewportY: 2,
+    getLine(index: number) {
+      return { translateToString: () => lines[index] ?? "" };
+    },
+  });
+  const context = readTerminalHibernateContext(term as never);
+  assert.equal(context.contextSnapshot, "\n\nv1\nv2\nv3");
+  assert.equal(context.contextScrollbackSnapshot, "\n");
+  assert.equal(context.contextViewportSnapshot, "v1\nv2\nv3");
+  assert.deepEqual(buildTerminalContextSnapshotText({
+    scrollbackText: context.contextScrollbackSnapshot,
+    viewportText: context.contextViewportSnapshot,
+    pendingText: "",
+  }), {
+    fullText: "\n\nv1\nv2\nv3",
+    viewportStartLine: 2,
+    viewportEndLine: 4,
+  });
+});
+
+test("readTerminalHibernateContext preserves an empty viewport after readable history", () => {
+  const lines = ["history", "", "", ""];
+  const term = createFakeTerm("normal", 3, lines.length);
+  Object.assign(term.buffer.active, {
+    viewportY: 1,
+    getLine(index: number) {
+      return { translateToString: () => lines[index] ?? "" };
+    },
+  });
+  const context = readTerminalHibernateContext(term as never);
+  assert.equal(context.contextSnapshot, "history\n\n\n");
+  assert.equal(context.contextScrollbackSnapshot, "history");
+  assert.equal(context.contextViewportSnapshot, "\n\n");
+  assert.equal(buildTerminalContextSnapshotText({
+    scrollbackText: context.contextScrollbackSnapshot,
+    viewportText: context.contextViewportSnapshot,
+    pendingText: "",
+  }).viewportStartLine, 1);
+});
+
+test("resolveTerminalSnapshotCapture falls back for missing serializers and preserves alternate mode", () => {
+  const context = {
+    contextSnapshot: "old\nscreen",
+    contextViewportSnapshot: "screen",
+    contextScrollbackSnapshot: "old",
+    alternateScreen: true,
+  };
+  assert.deepEqual(resolveTerminalSnapshotCapture(undefined, context), {
+    snapshot: "\x1b[?1049h\x1b[Hscreen",
+    context,
+  });
+  assert.equal(resolveTerminalSnapshotCapture("", context).snapshot, "");
 });
 
 test("refreshTerminalViewport skips refresh when the terminal has no rows", () => {
@@ -124,6 +265,22 @@ test("serializeTerminalForHibernate requests viewport-only range on alternate sc
   assert.equal(result.snapshot, "alt-viewport");
   assert.equal(result.contextViewportSnapshot, Array.from({ length: 24 }, (_, index) => `screen-${index}`).join("\n"));
   assert.deepEqual(capturedOptions?.range, { start: 0, end: 23 });
+});
+
+test("serializeTerminalForHibernate keeps visual capture when context buffer reading fails", async () => {
+  const term = createFakeTerm("normal", 3, 3);
+  Object.assign(term.buffer.active, {
+    getLine() {
+      throw new Error("buffer unavailable");
+    },
+  });
+  const result = await serializeTerminalForHibernate(term as never, {
+    serialize: () => "serialized",
+  } as never);
+  assert.equal(result.snapshot, "serialized");
+  assert.equal(result.contextSnapshot, "");
+  assert.equal(result.contextViewportSnapshot, "");
+  assert.equal(result.contextScrollbackSnapshot, "");
 });
 
 test("serializeTerminalForHibernate preserves plain text context for normal screen", async () => {

--- a/components/terminal/terminalHibernateRuntime.test.ts
+++ b/components/terminal/terminalHibernateRuntime.test.ts
@@ -2,11 +2,41 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  applyAuthoritativeHibernateSnapshot,
   isTerminalAlternateScreenActive,
   refreshTerminalViewport,
   resolveHibernateSerializeOptions,
   serializeTerminalForHibernate,
 } from "./terminalHibernateRuntime.ts";
+
+test("authoritative empty snapshots clear every hibernated copy", () => {
+  const ref = <T>(current: T) => ({ current });
+  const refs = {
+    snapshot: ref("old snapshot"),
+    viewportSnapshot: ref("old viewport"),
+    scrollbackSnapshot: ref("old scrollback"),
+    contextSnapshot: ref("old context"),
+    contextViewportSnapshot: ref("old context viewport"),
+    contextScrollbackSnapshot: ref("old context scrollback"),
+    pendingBuffer: ref("old pending"),
+    alternateScreen: ref(true),
+  };
+
+  applyAuthoritativeHibernateSnapshot(refs, "");
+
+  assert.deepEqual(Object.fromEntries(
+    Object.entries(refs).map(([key, value]) => [key, value.current]),
+  ), {
+    snapshot: "",
+    viewportSnapshot: "",
+    scrollbackSnapshot: "",
+    contextSnapshot: "",
+    contextViewportSnapshot: "",
+    contextScrollbackSnapshot: "",
+    pendingBuffer: "",
+    alternateScreen: false,
+  });
+});
 
 const createFakeTerm = (bufferType: "normal" | "alternate", rows = 24, length = 30) => ({
   rows,

--- a/components/terminal/terminalHibernateRuntime.ts
+++ b/components/terminal/terminalHibernateRuntime.ts
@@ -57,15 +57,111 @@ export function applyAuthoritativeHibernateSnapshot(
     alternateScreen: MutableValue<boolean>;
   },
   snapshot: string,
+  context: TerminalHibernateContextSnapshot,
 ): void {
   refs.snapshot.current = snapshot;
   refs.viewportSnapshot.current = snapshot;
   refs.scrollbackSnapshot.current = "";
-  refs.contextSnapshot.current = "";
-  refs.contextViewportSnapshot.current = "";
-  refs.contextScrollbackSnapshot.current = "";
+  refs.contextSnapshot.current = context.contextSnapshot;
+  refs.contextViewportSnapshot.current = context.contextViewportSnapshot;
+  refs.contextScrollbackSnapshot.current = context.contextScrollbackSnapshot;
   refs.pendingBuffer.current = "";
-  refs.alternateScreen.current = false;
+  refs.alternateScreen.current = context.alternateScreen;
+}
+
+export type TerminalHibernateContextSnapshot = Required<Pick<
+  TerminalHibernateSnapshot,
+  "contextSnapshot" | "contextViewportSnapshot" | "contextScrollbackSnapshot" | "alternateScreen"
+>>;
+
+export function resolveTerminalSnapshotCapture(
+  serialized: unknown,
+  context: TerminalHibernateContextSnapshot,
+): { snapshot: string; context: TerminalHibernateContextSnapshot } {
+  if (typeof serialized === "string") return { snapshot: serialized, context };
+  const plainText = context.alternateScreen
+    ? context.contextViewportSnapshot
+    : context.contextSnapshot;
+  const replayText = plainText.replace(/\r?\n/g, "\r\n");
+  return {
+    snapshot: context.alternateScreen
+      ? `\x1b[?1049h\x1b[H${replayText}`
+      : replayText,
+    context,
+  };
+}
+
+function isEmptyTerminalContext(text: string): boolean {
+  return text.split("\n").every((line) => line.length === 0);
+}
+
+export function readTerminalHibernateContext(
+  term: XTerm,
+): TerminalHibernateContextSnapshot {
+  const rows = Math.max(1, term.rows);
+  const bufferLength = resolveActiveBufferLength(term);
+
+  if (isTerminalAlternateScreenActive(term)) {
+    const contextViewportSnapshot = readActiveTerminalBufferTextRange(term, {
+      startLine: 0,
+      endLine: Math.max(0, rows - 1),
+    });
+    const empty = isEmptyTerminalContext(contextViewportSnapshot);
+    return {
+      contextSnapshot: empty ? "" : contextViewportSnapshot,
+      contextViewportSnapshot: empty ? "" : contextViewportSnapshot,
+      contextScrollbackSnapshot: "",
+      alternateScreen: true,
+    };
+  }
+
+  const activeBuffer = term.buffer.active as typeof term.buffer.active & { viewportY?: number };
+  const bottomViewportStart = Math.max(0, bufferLength - rows);
+  const viewportStart = Math.min(
+    bottomViewportStart,
+    Math.max(0, activeBuffer.viewportY ?? bottomViewportStart),
+  );
+  const viewportEnd = bufferLength > 0
+    ? Math.min(bufferLength - 1, viewportStart + rows - 1)
+    : -1;
+  const contextViewportSnapshot = readActiveTerminalBufferTextRange(term, {
+    startLine: viewportStart,
+    endLine: viewportEnd,
+  });
+  const contextStart = Math.min(
+    viewportStart,
+    Math.max(0, bufferLength - TERMINAL_HIBERNATE_SNAPSHOT_MAX_LINES),
+  );
+  const contextEnd = bufferLength > 0
+    ? Math.min(
+      bufferLength - 1,
+      Math.max(viewportEnd, contextStart + TERMINAL_HIBERNATE_SNAPSHOT_MAX_LINES - 1),
+    )
+    : -1;
+  const contextScrollbackSnapshot = viewportStart > 0
+    ? readActiveTerminalBufferTextRange(term, {
+      startLine: contextStart,
+      endLine: viewportStart - 1,
+    })
+    : "";
+  const contextSnapshot = readActiveTerminalBufferTextRange(term, {
+    startLine: contextStart,
+    endLine: contextEnd,
+  });
+  if (isEmptyTerminalContext(contextSnapshot)) {
+    return {
+      contextSnapshot: "",
+      contextViewportSnapshot: "",
+      contextScrollbackSnapshot: "",
+      alternateScreen: false,
+    };
+  }
+  return {
+    contextSnapshot,
+    contextViewportSnapshot,
+    contextScrollbackSnapshot,
+    alternateScreen: false,
+  };
 }
 
 function resolveActiveBufferLength(term: XTerm): number {
@@ -99,6 +195,17 @@ export async function serializeTerminalForHibernate(
   const preferWasm = options.preferWasm === true;
   const rows = Math.max(1, term.rows);
   const bufferLength = resolveActiveBufferLength(term);
+  let context: TerminalHibernateContextSnapshot = {
+    contextSnapshot: "",
+    contextViewportSnapshot: "",
+    contextScrollbackSnapshot: "",
+    alternateScreen,
+  };
+  try {
+    context = readTerminalHibernateContext(term);
+  } catch {
+    // A transient buffer read failure must not prevent visual snapshot capture.
+  }
 
   try {
     if (alternateScreen) {
@@ -111,17 +218,11 @@ export async function serializeTerminalForHibernate(
         }, preferWasm),
         rows,
       );
-      const contextViewportSnapshot = readActiveTerminalBufferTextRange(term, {
-        startLine: 0,
-        endLine: endRow,
-      });
       return {
         snapshot: viewportSnapshot,
         viewportSnapshot,
         scrollbackSnapshot: "",
-        contextSnapshot: contextViewportSnapshot,
-        contextViewportSnapshot,
-        contextScrollbackSnapshot: "",
+        ...context,
         alternateScreen: true,
       };
     }
@@ -133,13 +234,7 @@ export async function serializeTerminalForHibernate(
       excludeModes,
       range: { start: viewportStart, end: viewportEnd },
     }, preferWasm);
-    const contextViewportSnapshot = readActiveTerminalBufferTextRange(term, {
-      startLine: viewportStart,
-      endLine: viewportEnd,
-    });
-
     let scrollbackSnapshot = "";
-    let contextScrollbackSnapshot = "";
     if (viewportStart > 0) {
       const scrollbackStart = Math.max(0, viewportStart - TERMINAL_HIBERNATE_SNAPSHOT_MAX_LINES);
       scrollbackSnapshot = capHibernateBufferByLines(
@@ -150,10 +245,6 @@ export async function serializeTerminalForHibernate(
         }, preferWasm),
         TERMINAL_HIBERNATE_SNAPSHOT_MAX_LINES,
       );
-      contextScrollbackSnapshot = readActiveTerminalBufferTextRange(term, {
-        startLine: scrollbackStart,
-        endLine: viewportStart - 1,
-      });
     }
 
     const snapshot = capHibernateBufferByLines(
@@ -168,9 +259,7 @@ export async function serializeTerminalForHibernate(
       snapshot,
       viewportSnapshot,
       scrollbackSnapshot,
-      contextSnapshot: [contextScrollbackSnapshot, contextViewportSnapshot].filter(Boolean).join("\n"),
-      contextViewportSnapshot,
-      contextScrollbackSnapshot,
+      ...context,
       alternateScreen: false,
     };
   } catch {

--- a/components/terminal/terminalHibernateRuntime.ts
+++ b/components/terminal/terminalHibernateRuntime.ts
@@ -43,6 +43,31 @@ export type TerminalHibernateSnapshot = {
   alternateScreen: boolean;
 };
 
+type MutableValue<T> = { current: T };
+
+export function applyAuthoritativeHibernateSnapshot(
+  refs: {
+    snapshot: MutableValue<string>;
+    viewportSnapshot: MutableValue<string>;
+    scrollbackSnapshot: MutableValue<string>;
+    contextSnapshot: MutableValue<string>;
+    contextViewportSnapshot: MutableValue<string>;
+    contextScrollbackSnapshot: MutableValue<string>;
+    pendingBuffer: MutableValue<string>;
+    alternateScreen: MutableValue<boolean>;
+  },
+  snapshot: string,
+): void {
+  refs.snapshot.current = snapshot;
+  refs.viewportSnapshot.current = snapshot;
+  refs.scrollbackSnapshot.current = "";
+  refs.contextSnapshot.current = "";
+  refs.contextViewportSnapshot.current = "";
+  refs.contextScrollbackSnapshot.current = "";
+  refs.pendingBuffer.current = "";
+  refs.alternateScreen.current = false;
+}
+
 function resolveActiveBufferLength(term: XTerm): number {
   return term.buffer.active.length;
 }

--- a/components/terminal/terminalMemo.ts
+++ b/components/terminal/terminalMemo.ts
@@ -44,6 +44,7 @@ export const terminalPropsAreEqual = (
   && prev.pendingScriptId === next.pendingScriptId
   && prev.pendingScript === next.pendingScript
   && prev.reuseConnectionFromSessionId === next.reuseConnectionFromSessionId
+  && prev.attachExistingSession === next.attachExistingSession
   && prev.serialConfig === next.serialConfig
   && prev.hotkeyScheme === next.hotkeyScheme
   && prev.disableTerminalFontZoom === next.disableTerminalFontZoom

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -169,7 +169,7 @@ export function resolveSelectionOverlayPosition(term: any, container: HTMLElemen
 }
 
 export function useTerminalEffects(ctx: TerminalEffectsContext) {
-  const { CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, chainHosts, chainProgress, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, finalizeTerminalLogData, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceCloseHibernatedSession, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, hasRuntimeRef, host, hotkeySchemeRef, hibernatedRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen, isConnectionAwaitingUserInput, isConnectionPastTcpDial, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, needsHostKeyVerification, onBroadcastInputRef, onBroadcastInterruptPriorityChange, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onOutputTriggerUserInputRef, onPluginRuntimeCwdChange, onSnippetExecutorChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, passwordPromptActiveRef, pendingAuthRef, pendingOutputScrollRef, pluginDecorationRules, pluginTerminalLifecycle, pluginTerminalProviderRevision, isPluginTerminalProviderAvailable, requestPluginTerminalProviders, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, scriptRecorderRef, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, requestSearchFocus, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, onSnippetShortkeyRef, snippetsRef, splitResizeActive, status, statusRef, sudoAutofillRef, t, teardown, telnetLocalEchoRef, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState } = ctx;
+  const { CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, chainHosts, chainProgress, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, finalizeTerminalLogData, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceCloseHibernatedSession, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, hasRuntimeRef, host, hotkeySchemeRef, hibernatedRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen, isConnectionAwaitingUserInput, isConnectionPastTcpDial, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, needsHostKeyVerification, onBroadcastInputRef, onBroadcastInterruptPriorityChange, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onOutputTriggerUserInputRef, onPluginRuntimeCwdChange, onSnippetExecutorChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, passwordPromptActiveRef, pendingAuthRef, pendingOutputScrollRef, pluginDecorationRules, pluginTerminalLifecycle, pluginTerminalProviderRevision, isPluginTerminalProviderAvailable, requestPluginTerminalProviders, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, scriptRecorderRef, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, requestSearchFocus, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, attachExistingSession, attachHomeWebContentsIdRef, onSnippetShortkeyRef, snippetsRef, splitResizeActive, status, statusRef, sudoAutofillRef, t, teardown, telnetLocalEchoRef, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState } = ctx;
   const effectiveTerminalProtocol = resolveEffectiveTerminalProtocol(host);
   const hibernateHiddenTabs = resolveTerminalHibernateEnabledForProtocol(
     terminalSettings,
@@ -515,6 +515,48 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
             setStatus("connecting");
           }
         };
+
+        if (attachExistingSession) {
+          // Observe popup: rebind the live PTY output here, do not start a new shell.
+          try {
+            const rebind = await terminalBackend.rebindSessionOutput?.(sessionId);
+            if (!rebind?.success) {
+              setError(rebind?.error || "Failed to attach to session");
+              updateStatus("disconnected");
+              isBootActiveRef.current = false;
+              return;
+            }
+            if (attachHomeWebContentsIdRef) {
+              attachHomeWebContentsIdRef.current = rebind.previousWebContentsId ?? null;
+            }
+            sessionRef.current = sessionId;
+            const attached = sessionStarters.reattachSession(term);
+            if (!attached) {
+              setError("Failed to attach display to session");
+              updateStatus("disconnected");
+              isBootActiveRef.current = false;
+              return;
+            }
+            hasConnectedRef.current = true;
+            updateStatus("connected");
+            setTimeout(() => {
+              if (disposed) return;
+              safeFit({ force: true, requireVisible: true });
+              try {
+                terminalBackend.resizeSession?.(sessionId, term.cols, term.rows);
+              } catch {
+                // ignore
+              }
+            }, 50);
+          } catch (attachErr) {
+            if (disposed) return;
+            logger.error("Failed to attach existing session", attachErr);
+            setError(attachErr instanceof Error ? attachErr.message : String(attachErr));
+            updateStatus("disconnected");
+          }
+          isBootActiveRef.current = false;
+          return;
+        }
 
         if (!shouldStartTerminalBackend()) {
           isBootActiveRef.current = false;

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -169,7 +169,7 @@ export function resolveSelectionOverlayPosition(term: any, container: HTMLElemen
 }
 
 export function useTerminalEffects(ctx: TerminalEffectsContext) {
-  const { CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, chainHosts, chainProgress, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, finalizeTerminalLogData, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceCloseHibernatedSession, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, hasRuntimeRef, host, hotkeySchemeRef, hibernatedRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen, isConnectionAwaitingUserInput, isConnectionPastTcpDial, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, needsHostKeyVerification, onBroadcastInputRef, onBroadcastInterruptPriorityChange, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onOutputTriggerUserInputRef, onPluginRuntimeCwdChange, onSnippetExecutorChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, passwordPromptActiveRef, pendingAuthRef, pendingOutputScrollRef, pluginDecorationRules, pluginTerminalLifecycle, pluginTerminalProviderRevision, isPluginTerminalProviderAvailable, requestPluginTerminalProviders, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, scriptRecorderRef, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, requestSearchFocus, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, attachExistingSession, attachHomeWebContentsIdRef, onSnippetShortkeyRef, snippetsRef, splitResizeActive, status, statusRef, sudoAutofillRef, t, teardown, telnetLocalEchoRef, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState } = ctx;
+  const { CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, chainHosts, chainProgress, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, finalizeTerminalLogData, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceCloseHibernatedSession, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, hasRuntimeRef, host, hotkeySchemeRef, hibernatedRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen, isConnectionAwaitingUserInput, isConnectionPastTcpDial, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, needsHostKeyVerification, onBroadcastInputRef, onBroadcastInterruptPriorityChange, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onOutputTriggerUserInputRef, onPluginRuntimeCwdChange, onSnippetExecutorChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, passwordPromptActiveRef, pendingAuthRef, pendingOutputScrollRef, pluginDecorationRules, pluginTerminalLifecycle, pluginTerminalProviderRevision, isPluginTerminalProviderAvailable, requestPluginTerminalProviders, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, scriptRecorderRef, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, requestSearchFocus, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, attachExistingSession, attachAuthorization, attachHomeWebContentsIdRef, onSnippetShortkeyRef, snippetsRef, splitResizeActive, status, statusRef, sudoAutofillRef, t, teardown, telnetLocalEchoRef, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState } = ctx;
   const effectiveTerminalProtocol = resolveEffectiveTerminalProtocol(host);
   const hibernateHiddenTabs = resolveTerminalHibernateEnabledForProtocol(
     terminalSettings,
@@ -519,35 +519,61 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         if (attachExistingSession) {
           // Observe popup: pause → snapshot → rebind → resume so no live bytes
           // fall into the gap between snapshot and route handoff.
+          let outputRebound = false;
+          let reboundHomeWebContentsId: number | null = null;
           try {
-            try {
+            if (terminalBackend.setSessionFlowPausedAndWait) {
+              const paused = await terminalBackend.setSessionFlowPausedAndWait(sessionId, true);
+              if (!paused?.success && paused?.error === "Output drain unavailable") {
+                terminalBackend.setSessionFlowPaused?.(sessionId, true);
+                await new Promise((resolve) => setTimeout(resolve, 40));
+              } else if (!paused?.success) {
+                throw new Error(paused?.error || "Failed to drain terminal output");
+              }
+            } else {
               terminalBackend.setSessionFlowPaused?.(sessionId, true);
-            } catch {
-              // ignore
+              await new Promise((resolve) => setTimeout(resolve, 40));
             }
-            // Worker-mode pause is async; brief settle so most in-flight chunks
-            // drain before we snapshot+rebind (best-effort, not a full ack).
-            await new Promise((resolve) => setTimeout(resolve, 40));
             if (disposed) {
               try { terminalBackend.setSessionFlowPaused?.(sessionId, false); } catch { /* ignore */ }
               return;
             }
             // Snapshot while home still owns the display route (and stream is paused).
-            const snap = await terminalBackend.requestSessionSnapshot?.(sessionId);
+            const snap = await terminalBackend.requestSessionSnapshot?.(
+              sessionId,
+              attachAuthorization || "",
+            );
             if (disposed) {
               try { terminalBackend.setSessionFlowPaused?.(sessionId, false); } catch { /* ignore */ }
               return;
             }
+            if (!snap?.success) {
+              throw new Error(snap?.error || "Failed to capture terminal snapshot");
+            }
             if (snap?.success && snap.snapshot) {
               try {
-                term.write(snap.snapshot);
+                await new Promise<void>((resolve) => term.write(snap.snapshot!, resolve));
               } catch (writeErr) {
                 logger.warn("Failed to write attach snapshot to popup terminal", writeErr);
               }
             }
 
-            const rebind = await terminalBackend.rebindSessionOutput?.(sessionId);
+            const rebind = await terminalBackend.rebindSessionOutput?.(
+              sessionId,
+              attachAuthorization || "",
+            );
             if (disposed) {
+              if (rebind?.success) {
+                try {
+                  await terminalBackend.restoreSessionOutput?.(
+                    sessionId,
+                    rebind.previousWebContentsId ?? null,
+                    attachAuthorization || "",
+                  );
+                } catch {
+                  // Main-process closed lifecycle remains the final fallback.
+                }
+              }
               try { terminalBackend.setSessionFlowPaused?.(sessionId, false); } catch { /* ignore */ }
               return;
             }
@@ -558,23 +584,18 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
               isBootActiveRef.current = false;
               return;
             }
+            outputRebound = true;
+            reboundHomeWebContentsId = rebind.previousWebContentsId ?? null;
             if (attachHomeWebContentsIdRef) {
               attachHomeWebContentsIdRef.current = rebind.previousWebContentsId ?? null;
             }
             sessionRef.current = sessionId;
-            // Resume after rebind so buffered output lands on the popup route.
-            try {
-              terminalBackend.setSessionFlowPaused?.(sessionId, false);
-            } catch {
-              // ignore
-            }
             const attached = sessionStarters.reattachSession(term);
             if (!attached) {
-              setError("Failed to attach display to session");
-              updateStatus("disconnected");
-              isBootActiveRef.current = false;
-              return;
+              throw new Error("Failed to attach display to session");
             }
+            // Resume only after the popup has subscribed to the live session.
+            terminalBackend.setSessionFlowPaused?.(sessionId, false);
             hasConnectedRef.current = true;
             updateStatus("connected");
             setTimeout(() => {
@@ -592,6 +613,20 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
               }
             }, 50);
           } catch (attachErr) {
+            if (outputRebound) {
+              try {
+                const restored = await terminalBackend.restoreSessionOutput?.(
+                  sessionId,
+                  reboundHomeWebContentsId,
+                  attachAuthorization || "",
+                );
+                if (restored?.success) terminalBackend.setSessionFlowPaused?.(sessionId, false);
+              } catch {
+                // Main-process close/recovery lifecycle remains the fallback.
+              }
+            } else {
+              try { terminalBackend.setSessionFlowPaused?.(sessionId, false); } catch { /* ignore */ }
+            }
             if (disposed) return;
             logger.error("Failed to attach existing session", attachErr);
             setError(attachErr instanceof Error ? attachErr.message : String(attachErr));

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -517,9 +517,22 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         };
 
         if (attachExistingSession) {
-          // Observe popup: rebind the live PTY output here, do not start a new shell.
+          // Observe popup: capture home scrollback, rebind the live PTY output,
+          // and attach without starting a new shell.
           try {
+            // Snapshot while home still owns the display route.
+            const snap = await terminalBackend.requestSessionSnapshot?.(sessionId);
+            if (disposed) return;
+            if (snap?.success && snap.snapshot) {
+              try {
+                term.write(snap.snapshot);
+              } catch (writeErr) {
+                logger.warn("Failed to write attach snapshot to popup terminal", writeErr);
+              }
+            }
+
             const rebind = await terminalBackend.rebindSessionOutput?.(sessionId);
+            if (disposed) return;
             if (!rebind?.success) {
               setError(rebind?.error || "Failed to attach to session");
               updateStatus("disconnected");
@@ -542,6 +555,11 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
             setTimeout(() => {
               if (disposed) return;
               safeFit({ force: true, requireVisible: true });
+              try {
+                term.scrollToBottom?.();
+              } catch {
+                // ignore
+              }
               try {
                 terminalBackend.resizeSession?.(sessionId, term.cols, term.rows);
               } catch {

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -543,6 +543,13 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
               attachHomeWebContentsIdRef.current = rebind.previousWebContentsId ?? null;
             }
             sessionRef.current = sessionId;
+            // Hidden home terminal may have paused the backend under pressure;
+            // resume so the popup's new flow controller can receive output.
+            try {
+              terminalBackend.setSessionFlowPaused?.(sessionId, false);
+            } catch {
+              // ignore
+            }
             const attached = sessionStarters.reattachSession(term);
             if (!attached) {
               setError("Failed to attach display to session");

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -525,6 +525,13 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
             } catch {
               // ignore
             }
+            // Worker-mode pause is async; brief settle so most in-flight chunks
+            // drain before we snapshot+rebind (best-effort, not a full ack).
+            await new Promise((resolve) => setTimeout(resolve, 40));
+            if (disposed) {
+              try { terminalBackend.setSessionFlowPaused?.(sessionId, false); } catch { /* ignore */ }
+              return;
+            }
             // Snapshot while home still owns the display route (and stream is paused).
             const snap = await terminalBackend.requestSessionSnapshot?.(sessionId);
             if (disposed) {

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -517,12 +517,20 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         };
 
         if (attachExistingSession) {
-          // Observe popup: capture home scrollback, rebind the live PTY output,
-          // and attach without starting a new shell.
+          // Observe popup: pause → snapshot → rebind → resume so no live bytes
+          // fall into the gap between snapshot and route handoff.
           try {
-            // Snapshot while home still owns the display route.
+            try {
+              terminalBackend.setSessionFlowPaused?.(sessionId, true);
+            } catch {
+              // ignore
+            }
+            // Snapshot while home still owns the display route (and stream is paused).
             const snap = await terminalBackend.requestSessionSnapshot?.(sessionId);
-            if (disposed) return;
+            if (disposed) {
+              try { terminalBackend.setSessionFlowPaused?.(sessionId, false); } catch { /* ignore */ }
+              return;
+            }
             if (snap?.success && snap.snapshot) {
               try {
                 term.write(snap.snapshot);
@@ -532,8 +540,12 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
             }
 
             const rebind = await terminalBackend.rebindSessionOutput?.(sessionId);
-            if (disposed) return;
+            if (disposed) {
+              try { terminalBackend.setSessionFlowPaused?.(sessionId, false); } catch { /* ignore */ }
+              return;
+            }
             if (!rebind?.success) {
+              try { terminalBackend.setSessionFlowPaused?.(sessionId, false); } catch { /* ignore */ }
               setError(rebind?.error || "Failed to attach to session");
               updateStatus("disconnected");
               isBootActiveRef.current = false;
@@ -543,8 +555,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
               attachHomeWebContentsIdRef.current = rebind.previousWebContentsId ?? null;
             }
             sessionRef.current = sessionId;
-            // Hidden home terminal may have paused the backend under pressure;
-            // resume so the popup's new flow controller can receive output.
+            // Resume after rebind so buffered output lands on the popup route.
             try {
               terminalBackend.setSessionFlowPaused?.(sessionId, false);
             } catch {

--- a/domain/systemManager/types.ts
+++ b/domain/systemManager/types.ts
@@ -141,4 +141,6 @@ export interface TerminalPopupPayload {
    * (same PTY) instead of starting a new shell. Used for AI silent sessions.
    */
   attachSessionId?: string;
+  /** Ephemeral main-process grant bound to the attach popup window. */
+  attachAuthorization?: string;
 }

--- a/domain/systemManager/types.ts
+++ b/domain/systemManager/types.ts
@@ -136,4 +136,9 @@ export interface TerminalPopupPayload {
   sourceSession: import('../../types').TerminalSession;
   startupCommand: string;
   localShellType?: import('../../types').TerminalSession['shellType'];
+  /**
+   * When set, the popup attaches to this already-running backend session
+   * (same PTY) instead of starting a new shell. Used for AI silent sessions.
+   */
+  attachSessionId?: string;
 }

--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -740,12 +740,11 @@ function buildTrayMenuTemplate() {
       menuTemplate.push({
         label: `  ${session.hostLabel || session.label}  (${statusText})`,
         click: () => {
-          // Focus window and switch to this session
-          const win = getMainWindow();
-          if (win && bringMainWindowToForeground(win)) {
-            // Notify renderer to focus this session
-            win.webContents?.send("netcatty:tray:focusSession", session.id);
-          }
+          // AI silent sessions open a terminal popup from the renderer and must
+          // not be force-focused into a tab-less main-window surface.
+          void sendToMainWindow("netcatty:tray:focusSession", session.id, {
+            focus: session.aiHidden !== true,
+          });
         },
       });
     }
@@ -1013,7 +1012,12 @@ function registerHandlers(ipcMain) {
   });
 
   ipcMain.handle("netcatty:trayPanel:jumpToSession", async (_event, sessionId) => {
-    await sendToMainWindow("netcatty:trayPanel:jumpToSession", sessionId);
+    // Do not force-focus the main window here. Visible sessions open/focus it
+    // from the renderer; AI silent sessions open a terminal popup instead and
+    // should not steal focus into a tab-less main-window surface.
+    await sendToMainWindow("netcatty:trayPanel:jumpToSession", sessionId, {
+      focus: false,
+    });
     return { success: true };
   });
 

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -523,7 +523,9 @@ printf '%s\n' '${scanCompleteMarker}'`;
             const contents = event.sender;
             const liveSession = sessions.get(sessionId);
             const transportError = liveSession?._transportError;
-            if (transportError) {
+            if (liveSession?.closed) {
+              // Explicit close already notified every attached renderer.
+            } else if (transportError) {
               safeSendSessionExit({ safeSend, electronModule, sessions }, contents, sessionId, { sessionId, exitCode: 1, error: transportError, reason: "error" });
             } else {
               // A shell TMOUT auto-logout is a clean exit (numeric code, no

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -14,10 +14,46 @@ const {
   logTerminalOutputDropSample,
 } = require("../terminalInterruptDiagnostics.cjs");
 const { runWhenProxyConnectionReady } = require("../proxyUtils.cjs");
+const { getAttachHomeWebContentsId } = require("../terminalAttachRestore.cjs");
 
 const SSH_TCP_CONNECT_TIMEOUT_MS = 20000;
 const SSH_AUTH_READY_TIMEOUT_MS = 120000;
 const MAX_SSH_CONNECTION_TIMEOUT_MS = 3600000;
+
+/**
+ * Fan out netcatty:exit to the primary contents plus any attach-home owner
+ * (AI observe popup rebind) so neither side is left stale.
+ */
+function safeSendSessionExit(ctx, primaryContents, sessionId, payload) {
+  const { safeSend, electronModule, sessions } = ctx;
+  const seen = new Set();
+  const sendTo = (contents) => {
+    if (!contents || typeof contents.id !== "number" || seen.has(contents.id)) return;
+    seen.add(contents.id);
+    try {
+      safeSend(contents, "netcatty:exit", payload);
+    } catch {
+      // ignore destroyed renderers
+    }
+  };
+  sendTo(primaryContents);
+  try {
+    const live = sessions?.get?.(sessionId);
+    if (typeof live?.webContentsId === "number") {
+      sendTo(electronModule?.webContents?.fromId?.(live.webContentsId));
+    }
+  } catch {
+    // ignore
+  }
+  try {
+    const homeId = getAttachHomeWebContentsId(sessionId);
+    if (typeof homeId === "number") {
+      sendTo(electronModule?.webContents?.fromId?.(homeId));
+    }
+  } catch {
+    // ignore
+  }
+}
 
 function normalizeSshConnectionTimeoutMs(value, fallback) {
   return Number.isFinite(value) && value >= 1000 && value <= MAX_SSH_CONNECTION_TIMEOUT_MS
@@ -488,7 +524,7 @@ printf '%s\n' '${scanCompleteMarker}'`;
             const liveSession = sessions.get(sessionId);
             const transportError = liveSession?._transportError;
             if (transportError) {
-              safeSend(contents, "netcatty:exit", { sessionId, exitCode: 1, error: transportError, reason: "error" });
+              safeSendSessionExit({ safeSend, electronModule, sessions }, contents, sessionId, { sessionId, exitCode: 1, error: transportError, reason: "error" });
             } else {
               // A shell TMOUT auto-logout is a clean exit (numeric code, no
               // signal) — identical to a user-typed `exit` by code/signal —
@@ -497,7 +533,7 @@ printf '%s\n' '${scanCompleteMarker}'`;
               // for reconnect instead of auto-closing it (#1062 / #977).
               const idleTimedOut = streamExited && looksLikeIdleAutoLogout(liveSession?._promptTrackTail);
               const reason = idleTimedOut ? "timeout" : (streamExited ? "exited" : "closed");
-              safeSend(contents, "netcatty:exit", { sessionId, exitCode: streamExitCode, reason });
+              safeSendSessionExit({ safeSend, electronModule, sessions }, contents, sessionId, { sessionId, exitCode: streamExitCode, reason });
             }
             liveSession?.zmodemSentry?.cancel();
             // Release this channel's hold on the shared connection. The transport
@@ -1765,7 +1801,7 @@ printf '%s\n' '${scanCompleteMarker}'`;
                 hostname: options.hostname,
               });
             } else {
-              safeSend(contents, "netcatty:exit", { sessionId, exitCode: 1, error: err.message, reason: "error" });
+              safeSendSessionExit({ safeSend, electronModule, sessions }, contents, sessionId, { sessionId, exitCode: 1, error: err.message, reason: "error" });
             }
             sessionLogStreamManager.stopStream(sessionId, ownerLogStreamToken);
             if (detachX11Forwarding) {
@@ -1800,7 +1836,7 @@ printf '%s\n' '${scanCompleteMarker}'`;
             });
             const contents = event.sender;
             sendProgress(totalHops, totalHops, options.hostname, 'error', err.message);
-            safeSend(contents, "netcatty:exit", { sessionId, exitCode: 1, error: err.message, reason: "timeout" });
+            safeSendSessionExit({ safeSend, electronModule, sessions }, contents, sessionId, { sessionId, exitCode: 1, error: err.message, reason: "timeout" });
             sessionLogStreamManager.stopStream(sessionId, ownerLogStreamToken);
             sessions.get(sessionId)?.zmodemSentry?.cancel();
             closeTerminalOutputSession?.(sessionId);
@@ -1839,9 +1875,9 @@ printf '%s\n' '${scanCompleteMarker}'`;
               const transportError = session?._transportError;
               if (transportError) {
                 // A transport error was recorded — report it as an error exit
-                safeSend(contents, "netcatty:exit", { sessionId, exitCode: 1, error: transportError, reason: "error" });
+                safeSendSessionExit({ safeSend, electronModule, sessions }, contents, sessionId, { sessionId, exitCode: 1, error: transportError, reason: "error" });
               } else {
-                safeSend(contents, "netcatty:exit", { sessionId, exitCode: 0, reason: "closed" });
+                safeSendSessionExit({ safeSend, electronModule, sessions }, contents, sessionId, { sessionId, exitCode: 0, reason: "closed" });
               }
               // Use this connection's captured token so a late close from an
               // old transport can't stop a newer same-sessionId stream (#916).
@@ -1953,7 +1989,7 @@ printf '%s\n' '${scanCompleteMarker}'`;
         const suppressPreShellAuthExit = Boolean(options._suppressPreShellAuthExit && isAuthError);
         if (!suppressPreShellAuthExit) {
           const contents = event.sender;
-          safeSend(contents, "netcatty:exit", { sessionId, exitCode: 1, error: err.message });
+          safeSendSessionExit({ safeSend, electronModule, sessions }, contents, sessionId, { sessionId, exitCode: 1, error: err.message });
         }
         throw err;
       }

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -354,6 +354,17 @@ printf '%s\n' '${scanCompleteMarker}'`;
       session.takePendingData = takePendingBuffer;
       session.discardPendingData = discardBuffer;
 
+      const getCurrentSessionWebContents = () => {
+        const currentId = sessions.get(sessionId)?.webContentsId;
+        if (typeof currentId === "number") {
+          const current = electronModule?.webContents?.fromId?.(currentId);
+          if (current) return current;
+        }
+        return event.sender;
+      };
+      const getCurrentSessionWebContentsId = () =>
+        getCurrentSessionWebContents()?.id ?? event.sender.id;
+
       const sshZmodemSentry = createZmodemSentry({
         sessionId,
         onData(buf) {
@@ -411,19 +422,19 @@ printf '%s\n' '${scanCompleteMarker}'`;
               clearTimeout(timer);
               resolve({ action: payload.action, applyToRest: !!payload.applyToRest });
             });
-            safeSend(event.sender, "netcatty:zmodem:overwrite-request", {
+            safeSend(getCurrentSessionWebContents(), "netcatty:zmodem:overwrite-request", {
               sessionId, requestId, filename,
             });
           });
         },
         getWebContents() {
-          return event.sender;
+          return getCurrentSessionWebContents();
         },
         selectUploadFiles: selectZmodemUploadFiles
-          ? () => selectZmodemUploadFiles(event.sender.id)
+          ? () => selectZmodemUploadFiles(getCurrentSessionWebContentsId())
           : undefined,
         selectDownloadDirectory: selectZmodemDownloadDirectory
-          ? () => selectZmodemDownloadDirectory(event.sender.id)
+          ? () => selectZmodemDownloadDirectory(getCurrentSessionWebContentsId())
           : undefined,
         label: "SSH",
       });

--- a/electron/bridges/terminalAttachRestore.cjs
+++ b/electron/bridges/terminalAttachRestore.cjs
@@ -8,6 +8,7 @@
 
 let restoreImpl = null;
 let attachHomeLookup = null;
+let fanoutExitImpl = null;
 
 function setRestoreAttachedSessionOutput(fn) {
   restoreImpl = typeof fn === "function" ? fn : null;
@@ -38,9 +39,28 @@ function getAttachHomeWebContentsId(sessionId) {
   }
 }
 
+function setFanoutSessionExit(fn) {
+  fanoutExitImpl = typeof fn === "function" ? fn : null;
+}
+
+function fanoutSessionExit(sessionId, primaryWebContentsId, payload) {
+  if (typeof fanoutExitImpl === "function") {
+    try {
+      fanoutExitImpl(sessionId, primaryWebContentsId, payload);
+      return;
+    } catch {
+      // fall through
+    }
+  }
+  // Best-effort: at least primary if fanout not wired yet.
+  // Callers that only have a contents object should keep using contents.send.
+}
+
 module.exports = {
   setRestoreAttachedSessionOutput,
   restoreAttachedSessionOutput,
   setAttachHomeLookup,
   getAttachHomeWebContentsId,
+  setFanoutSessionExit,
+  fanoutSessionExit,
 };

--- a/electron/bridges/terminalAttachRestore.cjs
+++ b/electron/bridges/terminalAttachRestore.cjs
@@ -9,20 +9,71 @@
 let restoreImpl = null;
 let attachHomeLookup = null;
 let fanoutExitImpl = null;
+const attachPopupAuthorizations = new Map();
+const pendingAttachRestores = new Set();
+
+function registerAttachPopupAuthorization(token, sessionId, webContentsId) {
+  if (!token || !sessionId || typeof webContentsId !== "number") return false;
+  attachPopupAuthorizations.set(token, {
+    sessionId,
+    webContentsId,
+    closePrepared: false,
+  });
+  return true;
+}
+
+function validateAttachPopupAuthorization(token, sessionId, webContentsId) {
+  if (!token || !sessionId || typeof webContentsId !== "number") return false;
+  const grant = attachPopupAuthorizations.get(token);
+  return Boolean(
+    grant
+    && grant.sessionId === sessionId
+    && grant.webContentsId === webContentsId,
+  );
+}
+
+function markAttachPopupClosePrepared(token, sessionId, webContentsId) {
+  if (!validateAttachPopupAuthorization(token, sessionId, webContentsId)) return false;
+  attachPopupAuthorizations.get(token).closePrepared = true;
+  return true;
+}
+
+function isAttachPopupClosePrepared(token) {
+  return attachPopupAuthorizations.get(token)?.closePrepared === true;
+}
+
+function releaseAttachPopupAuthorization(token) {
+  if (token) attachPopupAuthorizations.delete(token);
+}
 
 function setRestoreAttachedSessionOutput(fn) {
   restoreImpl = typeof fn === "function" ? fn : null;
 }
 
-function restoreAttachedSessionOutput(sessionId) {
+function restoreAttachedSessionOutput(sessionId, preferredHomeWebContentsId = null) {
   if (!sessionId || typeof restoreImpl !== "function") {
     return { success: false, restored: false };
   }
   try {
-    return restoreImpl(sessionId) || { success: true, restored: false };
+    const result = restoreImpl(sessionId, preferredHomeWebContentsId) || { success: true, restored: false };
+    if (result.success) pendingAttachRestores.delete(sessionId);
+    else pendingAttachRestores.add(sessionId);
+    return result;
   } catch (err) {
+    pendingAttachRestores.add(sessionId);
     return { success: false, restored: false, error: err?.message || String(err) };
   }
+}
+
+function retryPendingAttachedSessionOutputs() {
+  for (const sessionId of Array.from(pendingAttachRestores)) {
+    restoreAttachedSessionOutput(sessionId);
+  }
+}
+
+function retryPendingAttachedSessionOutput(sessionId, preferredHomeWebContentsId = null) {
+  if (!pendingAttachRestores.has(sessionId)) return { success: true, restored: false };
+  return restoreAttachedSessionOutput(sessionId, preferredHomeWebContentsId);
 }
 
 function setAttachHomeLookup(fn) {
@@ -43,22 +94,38 @@ function setFanoutSessionExit(fn) {
   fanoutExitImpl = typeof fn === "function" ? fn : null;
 }
 
-function fanoutSessionExit(sessionId, primaryWebContentsId, payload) {
+function fanoutSessionExit(sessionId, primaryContents, payload) {
+  const primaryWebContentsId = typeof primaryContents === "number"
+    ? primaryContents
+    : primaryContents?.id;
   if (typeof fanoutExitImpl === "function") {
     try {
       fanoutExitImpl(sessionId, primaryWebContentsId, payload);
-      return;
+      return true;
     } catch {
       // fall through
     }
   }
-  // Best-effort: at least primary if fanout not wired yet.
-  // Callers that only have a contents object should keep using contents.send.
+  // Session implementations can run before terminalBridge wires the shared
+  // registry. Preserve the original primary-renderer notification then.
+  try {
+    primaryContents?.send?.("netcatty:exit", payload);
+    return typeof primaryContents?.send === "function";
+  } catch {
+    return false;
+  }
 }
 
 module.exports = {
+  registerAttachPopupAuthorization,
+  validateAttachPopupAuthorization,
+  markAttachPopupClosePrepared,
+  isAttachPopupClosePrepared,
+  releaseAttachPopupAuthorization,
   setRestoreAttachedSessionOutput,
   restoreAttachedSessionOutput,
+  retryPendingAttachedSessionOutputs,
+  retryPendingAttachedSessionOutput,
   setAttachHomeLookup,
   getAttachHomeWebContentsId,
   setFanoutSessionExit,

--- a/electron/bridges/terminalAttachRestore.cjs
+++ b/electron/bridges/terminalAttachRestore.cjs
@@ -7,6 +7,7 @@
  */
 
 let restoreImpl = null;
+let attachHomeLookup = null;
 
 function setRestoreAttachedSessionOutput(fn) {
   restoreImpl = typeof fn === "function" ? fn : null;
@@ -23,7 +24,23 @@ function restoreAttachedSessionOutput(sessionId) {
   }
 }
 
+function setAttachHomeLookup(fn) {
+  attachHomeLookup = typeof fn === "function" ? fn : null;
+}
+
+function getAttachHomeWebContentsId(sessionId) {
+  if (!sessionId || typeof attachHomeLookup !== "function") return null;
+  try {
+    const id = attachHomeLookup(sessionId);
+    return typeof id === "number" ? id : null;
+  } catch {
+    return null;
+  }
+}
+
 module.exports = {
   setRestoreAttachedSessionOutput,
   restoreAttachedSessionOutput,
+  setAttachHomeLookup,
+  getAttachHomeWebContentsId,
 };

--- a/electron/bridges/terminalAttachRestore.cjs
+++ b/electron/bridges/terminalAttachRestore.cjs
@@ -1,0 +1,29 @@
+"use strict";
+
+/**
+ * Tiny registry so the terminal popup window can restore output routing after
+ * an AI observe/attach popup is closed or destroyed, without creating a
+ * windowManager <-> terminalBridge require cycle.
+ */
+
+let restoreImpl = null;
+
+function setRestoreAttachedSessionOutput(fn) {
+  restoreImpl = typeof fn === "function" ? fn : null;
+}
+
+function restoreAttachedSessionOutput(sessionId) {
+  if (!sessionId || typeof restoreImpl !== "function") {
+    return { success: false, restored: false };
+  }
+  try {
+    return restoreImpl(sessionId) || { success: true, restored: false };
+  } catch (err) {
+    return { success: false, restored: false, error: err?.message || String(err) };
+  }
+}
+
+module.exports = {
+  setRestoreAttachedSessionOutput,
+  restoreAttachedSessionOutput,
+};

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -264,7 +264,22 @@ function applyTerminalSessionSnapshot(event, payload, terminalWorkerManager = nu
   const sessionId = typeof payload?.sessionId === "string" ? payload.sessionId : "";
   const hasSnapshot = typeof payload?.snapshot === "string";
   const snapshot = hasSnapshot ? payload.snapshot : "";
-  if (!sessionId || !hasSnapshot) {
+  const hasContextSnapshot = typeof payload?.contextSnapshot === "string";
+  const contextSnapshot = hasContextSnapshot ? payload.contextSnapshot : "";
+  const hasContextViewportSnapshot = typeof payload?.contextViewportSnapshot === "string";
+  const contextViewportSnapshot = hasContextViewportSnapshot ? payload.contextViewportSnapshot : "";
+  const hasContextScrollbackSnapshot = typeof payload?.contextScrollbackSnapshot === "string";
+  const contextScrollbackSnapshot = hasContextScrollbackSnapshot ? payload.contextScrollbackSnapshot : "";
+  const hasAlternateScreen = typeof payload?.alternateScreen === "boolean";
+  const alternateScreen = payload?.alternateScreen === true;
+  if (
+    !sessionId
+    || !hasSnapshot
+    || !hasContextSnapshot
+    || !hasContextViewportSnapshot
+    || !hasContextScrollbackSnapshot
+    || !hasAlternateScreen
+  ) {
     return Promise.resolve({ success: false, error: "Missing sessionId or snapshot" });
   }
   if (!isAuthorizedAttachIpc(event, payload, sessionId)) {
@@ -293,7 +308,15 @@ function applyTerminalSessionSnapshot(event, payload, terminalWorkerManager = nu
       }, TERMINAL_SNAPSHOT_TIMEOUT_MS);
       pendingTerminalSnapshotApplies.set(requestId, { resolve, timeout, webContentsId: home.id });
       try {
-        home.send("netcatty:terminal:apply-snapshot", { sessionId, snapshot, requestId });
+        home.send("netcatty:terminal:apply-snapshot", {
+          sessionId,
+          snapshot,
+          contextSnapshot,
+          contextViewportSnapshot,
+          contextScrollbackSnapshot,
+          alternateScreen,
+          requestId,
+        });
       } catch (err) {
         clearTimeout(timeout);
         pendingTerminalSnapshotApplies.delete(requestId);

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -262,8 +262,9 @@ function handleTerminalOutputDrainResponse(event, payload) {
  */
 function applyTerminalSessionSnapshot(event, payload, terminalWorkerManager = null) {
   const sessionId = typeof payload?.sessionId === "string" ? payload.sessionId : "";
-  const snapshot = typeof payload?.snapshot === "string" ? payload.snapshot : "";
-  if (!sessionId || !snapshot) {
+  const hasSnapshot = typeof payload?.snapshot === "string";
+  const snapshot = hasSnapshot ? payload.snapshot : "";
+  if (!sessionId || !hasSnapshot) {
     return Promise.resolve({ success: false, error: "Missing sessionId or snapshot" });
   }
   if (!isAuthorizedAttachIpc(event, payload, sessionId)) {

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -135,14 +135,27 @@ function closeTerminalOutputSession(sessionId) {
 
 /** @type {Map<string, { resolve: (value: any) => void, timeout: NodeJS.Timeout }>} */
 const pendingTerminalSnapshots = new Map();
+const pendingTerminalSnapshotApplies = new Map();
+const pendingTerminalOutputDrains = new Map();
 const TERMINAL_SNAPSHOT_TIMEOUT_MS = 2000;
 /** In-process (non-worker) attach home mapping: sessionId -> webContentsId */
 const attachHomeWebContentsIds = new Map();
 const {
+  markAttachPopupClosePrepared,
+  retryPendingAttachedSessionOutput,
   setRestoreAttachedSessionOutput,
   setAttachHomeLookup,
   setFanoutSessionExit,
+  validateAttachPopupAuthorization,
 } = require("./terminalAttachRestore.cjs");
+
+function isAuthorizedAttachIpc(event, payload, sessionId) {
+  return validateAttachPopupAuthorization(
+    payload?.authorization,
+    sessionId,
+    event?.sender?.id,
+  );
+}
 
 function resolveSessionHomeWebContentsId(sessionId, terminalWorkerManager = null) {
   if (!sessionId) return null;
@@ -164,6 +177,9 @@ function requestTerminalSessionSnapshot(event, payload, terminalWorkerManager = 
   if (!sessionId) {
     return Promise.resolve({ success: false, snapshot: "", error: "Missing sessionId" });
   }
+  if (!isAuthorizedAttachIpc(event, payload, sessionId)) {
+    return Promise.resolve({ success: false, snapshot: "", error: "Unauthorized attach request" });
+  }
   const homeId = resolveSessionHomeWebContentsId(sessionId, terminalWorkerManager);
   if (typeof homeId !== "number" || !electronModule?.webContents?.fromId) {
     return Promise.resolve({ success: false, snapshot: "", error: "Home renderer not found" });
@@ -184,7 +200,7 @@ function requestTerminalSessionSnapshot(event, payload, terminalWorkerManager = 
       pendingTerminalSnapshots.delete(requestId);
       resolve({ success: false, snapshot: "", error: "timeout" });
     }, TERMINAL_SNAPSHOT_TIMEOUT_MS);
-    pendingTerminalSnapshots.set(requestId, { resolve, timeout });
+    pendingTerminalSnapshots.set(requestId, { resolve, timeout, webContentsId: home.id });
     try {
       home.send("netcatty:terminal:snapshot-request", { sessionId, requestId });
     } catch (err) {
@@ -195,17 +211,49 @@ function requestTerminalSessionSnapshot(event, payload, terminalWorkerManager = 
   });
 }
 
-function handleTerminalSessionSnapshotResponse(_event, payload) {
+function handleTerminalSessionSnapshotResponse(event, payload) {
   const requestId = typeof payload?.requestId === "string" ? payload.requestId : "";
   if (!requestId) return;
   const pending = pendingTerminalSnapshots.get(requestId);
   if (!pending) return;
+  if (pending.webContentsId !== event?.sender?.id) return;
   clearTimeout(pending.timeout);
   pendingTerminalSnapshots.delete(requestId);
   pending.resolve({
     success: true,
     snapshot: typeof payload?.snapshot === "string" ? payload.snapshot : "",
   });
+}
+
+function requestTerminalOutputDrain(sessionId, terminalWorkerManager = null) {
+  const targetId = resolveSessionHomeWebContentsId(sessionId, terminalWorkerManager);
+  if (typeof targetId !== "number") {
+    return Promise.resolve({ success: false, error: "Display renderer not found" });
+  }
+  const requestId = randomUUID();
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      pendingTerminalOutputDrains.delete(requestId);
+      resolve({ success: false, error: "timeout" });
+    }, TERMINAL_SNAPSHOT_TIMEOUT_MS);
+    pendingTerminalOutputDrains.set(requestId, { resolve, timeout, webContentsId: targetId });
+    const sent = terminalWorkerManager
+      ? terminalWorkerManager.drainOutputSession?.(sessionId, requestId)
+      : terminalOutputChannel?.drainSession?.(sessionId, requestId);
+    if (!sent) {
+      clearTimeout(timeout);
+      pendingTerminalOutputDrains.delete(requestId);
+      resolve({ success: false, error: "Output drain unavailable" });
+    }
+  });
+}
+
+function handleTerminalOutputDrainResponse(event, payload) {
+  const pending = pendingTerminalOutputDrains.get(payload?.requestId);
+  if (!pending || pending.webContentsId !== event?.sender?.id) return;
+  clearTimeout(pending.timeout);
+  pendingTerminalOutputDrains.delete(payload.requestId);
+  pending.resolve({ success: true });
 }
 
 /**
@@ -216,7 +264,10 @@ function applyTerminalSessionSnapshot(event, payload, terminalWorkerManager = nu
   const sessionId = typeof payload?.sessionId === "string" ? payload.sessionId : "";
   const snapshot = typeof payload?.snapshot === "string" ? payload.snapshot : "";
   if (!sessionId || !snapshot) {
-    return { success: false, error: "Missing sessionId or snapshot" };
+    return Promise.resolve({ success: false, error: "Missing sessionId or snapshot" });
+  }
+  if (!isAuthorizedAttachIpc(event, payload, sessionId)) {
+    return Promise.resolve({ success: false, error: "Unauthorized attach request" });
   }
   let homeId = null;
   if (terminalWorkerManager?.getAttachHomeWebContentsId) {
@@ -225,19 +276,42 @@ function applyTerminalSessionSnapshot(event, payload, terminalWorkerManager = nu
   if (homeId == null) {
     homeId = attachHomeWebContentsIds.get(sessionId) ?? null;
   }
-  if (typeof homeId !== "number" || !electronModule?.webContents?.fromId) {
-    return { success: false, error: "Home renderer not found" };
+  if (typeof homeId !== "number") {
+    return Promise.resolve({ success: false, error: "Home renderer not found" });
   }
   try {
-    const home = electronModule.webContents.fromId(homeId);
-    if (!home || home.isDestroyed?.()) {
-      return { success: false, error: "Home renderer destroyed" };
+    const home = findRegisteredMainWebContents(homeId);
+    if (!home) {
+      return Promise.resolve({ success: false, error: "Home renderer unavailable" });
     }
-    home.send("netcatty:terminal:apply-snapshot", { sessionId, snapshot });
-    return { success: true };
+    const requestId = randomUUID();
+    return new Promise((resolve) => {
+      const timeout = setTimeout(() => {
+        pendingTerminalSnapshotApplies.delete(requestId);
+        resolve({ success: false, error: "timeout" });
+      }, TERMINAL_SNAPSHOT_TIMEOUT_MS);
+      pendingTerminalSnapshotApplies.set(requestId, { resolve, timeout, webContentsId: home.id });
+      try {
+        home.send("netcatty:terminal:apply-snapshot", { sessionId, snapshot, requestId });
+      } catch (err) {
+        clearTimeout(timeout);
+        pendingTerminalSnapshotApplies.delete(requestId);
+        resolve({ success: false, error: err?.message || String(err) });
+      }
+    });
   } catch (err) {
-    return { success: false, error: err?.message || String(err) };
+    return Promise.resolve({ success: false, error: err?.message || String(err) });
   }
+}
+
+function handleTerminalSessionApplySnapshotResponse(event, payload) {
+  const pending = pendingTerminalSnapshotApplies.get(payload?.requestId);
+  if (!pending || pending.webContentsId !== event?.sender?.id) return;
+  clearTimeout(pending.timeout);
+  pendingTerminalSnapshotApplies.delete(payload.requestId);
+  pending.resolve(payload?.success === false
+    ? { success: false, error: payload?.error || "Snapshot apply failed" }
+    : { success: true });
 }
 
 /**
@@ -258,10 +332,18 @@ function rebindTerminalSessionOutput(event, payload, terminalWorkerManager = nul
   if (!sender || sender.isDestroyed?.()) {
     return { success: false, error: "Invalid sender" };
   }
+  if (!isAuthorizedAttachIpc(event, payload, sessionId)) {
+    return { success: false, error: "Unauthorized attach request" };
+  }
 
   if (terminalWorkerManager) {
     try {
-      return terminalWorkerManager.rebindOutputSession(sessionId, sender.id);
+      const result = terminalWorkerManager.rebindOutputSession(sessionId, sender.id);
+      if (result?.success && sender.isDestroyed?.()) {
+        restoreAttachedSessionOutput(sessionId, terminalWorkerManager);
+        return { success: false, error: "Attach window closed during rebind" };
+      }
+      return result;
     } catch (err) {
       return { success: false, error: err?.message || String(err) };
     }
@@ -283,6 +365,10 @@ function rebindTerminalSessionOutput(event, payload, terminalWorkerManager = nul
     }
     openTerminalOutputSession(sessionId, sender);
     session.webContentsId = sender.id;
+    if (sender.isDestroyed?.()) {
+      restoreAttachedSessionOutput(sessionId, terminalWorkerManager);
+      return { success: false, error: "Attach window closed during rebind" };
+    }
     return {
       success: true,
       previousWebContentsId,
@@ -313,6 +399,17 @@ function resumeSessionOutputFlow(sessionId, terminalWorkerManager = null) {
   }
 }
 
+function pauseSessionOutputFlow(sessionId, terminalWorkerManager = null) {
+  if (!sessionId) return;
+  if (terminalWorkerManager?.send) {
+    try { terminalWorkerManager.send("netcatty:flow", { sessionId, paused: true }, {}); } catch {}
+    return;
+  }
+  const session = sessions?.get?.(sessionId);
+  if (!session) return;
+  try { setRendererFlowPaused(session, true); } catch {}
+}
+
 function fanoutSessionLifecycleEvent(sessionId, primaryWebContentsId, channel, payload) {
   const targets = new Set();
   if (typeof primaryWebContentsId === "number") targets.add(primaryWebContentsId);
@@ -329,36 +426,72 @@ function fanoutSessionLifecycleEvent(sessionId, primaryWebContentsId, channel, p
   attachHomeWebContentsIds.delete(sessionId);
 }
 
-function restoreAttachedSessionOutput(sessionId, terminalWorkerManager = null) {
-  if (!sessionId) return { success: false, restored: false };
-  // Always unpause first: popup may have left the backend paused under pressure
-  // and React cleanup is not guaranteed when the window is force-closed.
-  resumeSessionOutputFlow(sessionId, terminalWorkerManager);
-  if (terminalWorkerManager?.restoreAttachHome) {
-    return terminalWorkerManager.restoreAttachHome(sessionId);
-  }
-  const homeId = attachHomeWebContentsIds.get(sessionId);
-  if (homeId == null) {
-    return { success: true, restored: false };
-  }
-  const session = sessions?.get?.(sessionId);
-  if (!session) {
-    attachHomeWebContentsIds.delete(sessionId);
-    return { success: true, restored: false };
-  }
+function findRegisteredMainWebContents(preferredId) {
   try {
-    const home = electronModule?.webContents?.fromId?.(homeId);
-    if (!home || home.isDestroyed?.()) {
-      attachHomeWebContentsIds.delete(sessionId);
-      return { success: false, restored: false, error: "Home renderer destroyed" };
+    const wm = require("./windowManager.cjs");
+    const mains = typeof wm.getMainWindows === "function"
+      ? wm.getMainWindows()
+      : (typeof wm.getMainWindow === "function" ? [wm.getMainWindow()].filter(Boolean) : []);
+    const liveContents = [];
+    for (const win of mains) {
+      const contents = win?.webContents;
+      if (contents && !contents.isDestroyed?.()) liveContents.push(contents);
     }
-    openTerminalOutputSession(sessionId, home);
-    session.webContentsId = homeId;
-    attachHomeWebContentsIds.delete(sessionId);
-    return { success: true, restored: true, webContentsId: homeId };
-  } catch (err) {
-    return { success: false, restored: false, error: err?.message || String(err) };
+    if (typeof preferredId === "number") {
+      const preferred = liveContents.find((contents) => contents.id === preferredId);
+      if (preferred) return preferred;
+    }
+    return liveContents[0] || null;
+  } catch {
+    // ignore unavailable window manager during isolated tests/startup
   }
+  return null;
+}
+
+function restoreAttachedSessionOutput(
+  sessionId,
+  terminalWorkerManager = null,
+  preferredHomeWebContentsId = null,
+) {
+  if (!sessionId) return { success: false, restored: false };
+  pauseSessionOutputFlow(sessionId, terminalWorkerManager);
+  let result;
+  if (terminalWorkerManager?.restoreAttachHome) {
+    result = terminalWorkerManager.restoreAttachHome(sessionId, preferredHomeWebContentsId);
+  } else {
+    const homeId = attachHomeWebContentsIds.get(sessionId);
+    if (homeId == null) {
+      result = { success: true, restored: false };
+    } else {
+      const session = sessions?.get?.(sessionId);
+      if (!session) {
+        attachHomeWebContentsIds.delete(sessionId);
+        result = { success: true, restored: false };
+      } else {
+        try {
+          const home = findRegisteredMainWebContents(preferredHomeWebContentsId ?? homeId);
+          if (!home) {
+            result = { success: false, restored: false, error: "Home renderer unavailable" };
+          } else {
+            openTerminalOutputSession(sessionId, home);
+            session.webContentsId = home.id;
+            attachHomeWebContentsIds.delete(sessionId);
+            result = { success: true, restored: true, webContentsId: home.id };
+          }
+        } catch (err) {
+          result = { success: false, restored: false, error: err?.message || String(err) };
+        }
+      }
+    }
+  }
+
+  // Resume only after output has a live destination. If no main renderer is
+  // currently available, keep the source paused and the home mapping intact so
+  // a later attach/recovery can safely reclaim the session.
+  if (result?.success) {
+    resumeSessionOutputFlow(sessionId, terminalWorkerManager);
+  }
+  return result;
 }
 
 /**
@@ -370,42 +503,12 @@ function restoreTerminalSessionOutput(event, payload, terminalWorkerManager = nu
   if (!sessionId) {
     return { success: false, error: "Missing sessionId" };
   }
+  if (!isAuthorizedAttachIpc(event, payload, sessionId)) {
+    return { success: false, error: "Unauthorized attach request" };
+  }
 
-  let target = null;
   const homeId = payload?.webContentsId;
-  if (typeof homeId === "number" && electronModule?.webContents?.fromId) {
-    try {
-      const home = electronModule.webContents.fromId(homeId);
-      if (home && !home.isDestroyed?.()) target = home;
-    } catch {
-      // fall through
-    }
-  }
-  if (!target && electronModule?.BrowserWindow?.getAllWindows) {
-    try {
-      const wins = electronModule.BrowserWindow.getAllWindows() || [];
-      for (const win of wins) {
-        const wc = win?.webContents;
-        if (!wc || wc.isDestroyed?.()) continue;
-        // Prefer a non-popup / non-tray renderer if we can tell; otherwise first live.
-        const url = typeof wc.getURL === "function" ? wc.getURL() : "";
-        if (url.includes("#/terminal-popup") || url.includes("#/tray")) continue;
-        target = wc;
-        break;
-      }
-      if (!target) {
-        for (const win of wins) {
-          const wc = win?.webContents;
-          if (wc && !wc.isDestroyed?.()) {
-            target = wc;
-            break;
-          }
-        }
-      }
-    } catch {
-      // ignore
-    }
-  }
+  const target = findRegisteredMainWebContents(homeId);
   if (!target) {
     return { success: false, error: "No live renderer to restore output to" };
   }
@@ -420,6 +523,7 @@ function restoreTerminalSessionOutput(event, payload, terminalWorkerManager = nu
       if (!result?.success) {
         return { success: false, error: result?.error || "Failed to restore session output" };
       }
+      terminalWorkerManager.clearAttachHome?.(sessionId);
       return { success: true, restored: true, webContentsId: target.id };
     } catch (err) {
       return { success: false, error: err?.message || String(err) };
@@ -434,6 +538,7 @@ function restoreTerminalSessionOutput(event, payload, terminalWorkerManager = nu
   try {
     openTerminalOutputSession(sessionId, target);
     session.webContentsId = target.id;
+    attachHomeWebContentsIds.delete(sessionId);
     return { success: true, restored: true, webContentsId: target.id };
   } catch (err) {
     return { success: false, error: err?.message || String(err) };
@@ -1690,6 +1795,13 @@ function setSessionEncoding(_event, { sessionId, encoding }) {
   return { ok: true, encoding: enc };
 }
 
+function getTelnetEchoMode(_event, { sessionId }) {
+  const mode = sessions?.get(sessionId)?.telnetEchoMode;
+  return mode
+    ? { success: true, ...mode }
+    : { success: false, error: "Telnet echo mode unavailable" };
+}
+
 /**
  * Register IPC handlers for terminal operations
  */
@@ -1721,9 +1833,39 @@ function registerHandlers(ipcMain, options = {}) {
     requestTerminalSessionSnapshot(event, payload, terminalWorkerManager));
   ipcMain.handle("netcatty:terminal:applySnapshot", (event, payload) =>
     applyTerminalSessionSnapshot(event, payload, terminalWorkerManager));
+  ipcMain.handle("netcatty:terminal:setFlowPausedAndWait", async (event, payload) => {
+    if (terminalWorkerManager) {
+      await terminalWorkerManager.request("netcatty:terminal:setFlowPausedAndWait", payload, {
+        webContentsId: event?.sender?.id,
+      });
+    } else {
+      setSessionFlowPaused(event, payload);
+    }
+    if (!payload?.paused) return { success: true };
+    return requestTerminalOutputDrain(payload?.sessionId, terminalWorkerManager);
+  });
+  ipcMain.handle("netcatty:terminal:markAttachClosePrepared", (event, payload) => {
+    const sessionId = typeof payload?.sessionId === "string" ? payload.sessionId : "";
+    const success = markAttachPopupClosePrepared(
+      payload?.authorization,
+      sessionId,
+      event?.sender?.id,
+    );
+    return success
+      ? { success: true }
+      : { success: false, error: "Unauthorized attach request" };
+  });
   ipcMain.on("netcatty:terminal:snapshot-response", handleTerminalSessionSnapshotResponse);
-  setRestoreAttachedSessionOutput((sessionId) =>
-    restoreAttachedSessionOutput(sessionId, terminalWorkerManager));
+  ipcMain.on("netcatty:terminal:output-drain-response", handleTerminalOutputDrainResponse);
+  ipcMain.on("netcatty:terminal:apply-snapshot-response", handleTerminalSessionApplySnapshotResponse);
+  ipcMain.on("netcatty:terminal:display-ready", (event, payload) => {
+    const sessionId = typeof payload?.sessionId === "string" ? payload.sessionId : "";
+    const readyMain = findRegisteredMainWebContents(event?.sender?.id);
+    if (!sessionId || readyMain?.id !== event?.sender?.id) return;
+    retryPendingAttachedSessionOutput(sessionId, event.sender.id);
+  });
+  setRestoreAttachedSessionOutput((sessionId, preferredHomeWebContentsId) =>
+    restoreAttachedSessionOutput(sessionId, terminalWorkerManager, preferredHomeWebContentsId));
   setAttachHomeLookup((sessionId) => {
     if (terminalWorkerManager?.getAttachHomeWebContentsId) {
       return terminalWorkerManager.getAttachHomeWebContentsId(sessionId);
@@ -1748,6 +1890,7 @@ function registerHandlers(ipcMain, options = {}) {
       "netcatty:local:validatePath",
       "netcatty:shells:discover",
       "netcatty:terminal:setEncoding",
+      "netcatty:telnet:getEchoMode",
       "netcatty:close:await",
     ].forEach((channel) => registerWorkerHandle(ipcMain, terminalWorkerManager, channel));
     ipcMain.on("netcatty:write", (event, payload) => {
@@ -1790,6 +1933,7 @@ function registerHandlers(ipcMain, options = {}) {
   ipcMain.handle("netcatty:local:validatePath", validatePath);
   ipcMain.handle("netcatty:shells:discover", () => discoverShells());
   ipcMain.handle("netcatty:terminal:setEncoding", setSessionEncoding);
+  ipcMain.handle("netcatty:telnet:getEchoMode", getTelnetEchoMode);
   ipcMain.on("netcatty:write", writeToSession);
   ipcMain.on("netcatty:interrupt", interruptSession);
   ipcMain.on("netcatty:resize", resizeSession);

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -259,8 +259,47 @@ function rebindTerminalSessionOutput(event, payload, terminalWorkerManager = nul
   }
 }
 
+function resumeSessionOutputFlow(sessionId, terminalWorkerManager = null) {
+  if (!sessionId) return;
+  if (terminalWorkerManager?.send) {
+    try {
+      terminalWorkerManager.send("netcatty:flow", { sessionId, paused: false }, {});
+    } catch {
+      // ignore
+    }
+    return;
+  }
+  const session = sessions?.get?.(sessionId);
+  if (!session) return;
+  try {
+    setRendererFlowPaused(session, false);
+    session.flushPendingData?.();
+  } catch {
+    // ignore
+  }
+}
+
+function fanoutSessionLifecycleEvent(sessionId, primaryWebContentsId, channel, payload) {
+  const targets = new Set();
+  if (typeof primaryWebContentsId === "number") targets.add(primaryWebContentsId);
+  const homeId = attachHomeWebContentsIds.get(sessionId);
+  if (typeof homeId === "number") targets.add(homeId);
+  for (const id of targets) {
+    try {
+      const contents = electronModule?.webContents?.fromId?.(id);
+      contents?.send?.(channel, payload);
+    } catch {
+      // ignore destroyed renderers
+    }
+  }
+  attachHomeWebContentsIds.delete(sessionId);
+}
+
 function restoreAttachedSessionOutput(sessionId, terminalWorkerManager = null) {
   if (!sessionId) return { success: false, restored: false };
+  // Always unpause first: popup may have left the backend paused under pressure
+  // and React cleanup is not guaranteed when the window is force-closed.
+  resumeSessionOutputFlow(sessionId, terminalWorkerManager);
   if (terminalWorkerManager?.restoreAttachHome) {
     return terminalWorkerManager.restoreAttachHome(sessionId);
   }
@@ -770,12 +809,16 @@ function startLocalSession(event, payload) {
       sessionLogStreamManager.stopStream(sessionId, logStreamToken);
       ptyProcessTree.unregisterPid(sessionId);
       sessions.delete(sessionId);
-      const contents = electronModule.webContents.fromId(session.webContentsId);
       // Signal present = killed externally (show disconnected UI).
       // No signal = process exited normally, even with non-zero code
       // (e.g. user typed `exit` after a failed command), so auto-close.
       const reason = evt.signal ? "error" : "exited";
-      contents?.send("netcatty:exit", { sessionId, ...evt, reason });
+      fanoutSessionLifecycleEvent(
+        sessionId,
+        session.webContentsId,
+        "netcatty:exit",
+        { sessionId, ...evt, reason },
+      );
     };
     flushLocalPaced(finalizeExit);
   });
@@ -998,10 +1041,15 @@ async function startSerialSession(event, options) {
           session.zmodemSentry?.cancel();
           session.ymodemAbortController?.abort();
           sessionLogStreamManager.stopStream(sessionId, logStreamToken);
-          const contents = electronModule.webContents.fromId(session.webContentsId);
-          contents?.send("netcatty:exit", { sessionId, exitCode: 1, error: err.message, reason: "error" });
+          const primaryId = session.webContentsId;
           ptyProcessTree.unregisterPid(sessionId);
           sessions.delete(sessionId);
+          fanoutSessionLifecycleEvent(
+            sessionId,
+            primaryId,
+            "netcatty:exit",
+            { sessionId, exitCode: 1, error: err.message, reason: "error" },
+          );
         });
 
         serialPort.on('close', () => {
@@ -1009,10 +1057,15 @@ async function startSerialSession(event, options) {
           session.zmodemSentry?.cancel();
           session.ymodemAbortController?.abort();
           sessionLogStreamManager.stopStream(sessionId, logStreamToken);
-          const contents = electronModule.webContents.fromId(session.webContentsId);
-          contents?.send("netcatty:exit", { sessionId, exitCode: 0, reason: "closed" });
+          const primaryId = session.webContentsId;
           ptyProcessTree.unregisterPid(sessionId);
           sessions.delete(sessionId);
+          fanoutSessionLifecycleEvent(
+            sessionId,
+            primaryId,
+            "netcatty:exit",
+            { sessionId, exitCode: 0, reason: "closed" },
+          );
         });
 
         resolve({ sessionId });

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -136,6 +136,11 @@ function closeTerminalOutputSession(sessionId) {
 /** @type {Map<string, { resolve: (value: any) => void, timeout: NodeJS.Timeout }>} */
 const pendingTerminalSnapshots = new Map();
 const TERMINAL_SNAPSHOT_TIMEOUT_MS = 2000;
+/** In-process (non-worker) attach home mapping: sessionId -> webContentsId */
+const attachHomeWebContentsIds = new Map();
+const {
+  setRestoreAttachedSessionOutput,
+} = require("./terminalAttachRestore.cjs");
 
 function resolveSessionHomeWebContentsId(sessionId, terminalWorkerManager = null) {
   if (!sessionId) return null;
@@ -235,6 +240,13 @@ function rebindTerminalSessionOutput(event, payload, terminalWorkerManager = nul
   const previousWebContentsId =
     typeof session.webContentsId === "number" ? session.webContentsId : null;
   try {
+    if (
+      previousWebContentsId != null
+      && previousWebContentsId !== sender.id
+      && !attachHomeWebContentsIds.has(sessionId)
+    ) {
+      attachHomeWebContentsIds.set(sessionId, previousWebContentsId);
+    }
     openTerminalOutputSession(sessionId, sender);
     session.webContentsId = sender.id;
     return {
@@ -244,6 +256,35 @@ function rebindTerminalSessionOutput(event, payload, terminalWorkerManager = nul
     };
   } catch (err) {
     return { success: false, error: err?.message || String(err) };
+  }
+}
+
+function restoreAttachedSessionOutput(sessionId, terminalWorkerManager = null) {
+  if (!sessionId) return { success: false, restored: false };
+  if (terminalWorkerManager?.restoreAttachHome) {
+    return terminalWorkerManager.restoreAttachHome(sessionId);
+  }
+  const homeId = attachHomeWebContentsIds.get(sessionId);
+  if (homeId == null) {
+    return { success: true, restored: false };
+  }
+  const session = sessions?.get?.(sessionId);
+  if (!session) {
+    attachHomeWebContentsIds.delete(sessionId);
+    return { success: true, restored: false };
+  }
+  try {
+    const home = electronModule?.webContents?.fromId?.(homeId);
+    if (!home || home.isDestroyed?.()) {
+      attachHomeWebContentsIds.delete(sessionId);
+      return { success: false, restored: false, error: "Home renderer destroyed" };
+    }
+    openTerminalOutputSession(sessionId, home);
+    session.webContentsId = homeId;
+    attachHomeWebContentsIds.delete(sessionId);
+    return { success: true, restored: true, webContentsId: homeId };
+  } catch (err) {
+    return { success: false, restored: false, error: err?.message || String(err) };
   }
 }
 
@@ -1592,6 +1633,8 @@ function registerHandlers(ipcMain, options = {}) {
   ipcMain.handle("netcatty:terminal:requestSnapshot", (event, payload) =>
     requestTerminalSessionSnapshot(event, payload, terminalWorkerManager));
   ipcMain.on("netcatty:terminal:snapshot-response", handleTerminalSessionSnapshotResponse);
+  setRestoreAttachedSessionOutput((sessionId) =>
+    restoreAttachedSessionOutput(sessionId, terminalWorkerManager));
 
   if (terminalWorkerManager) {
     [

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -134,6 +134,101 @@ function closeTerminalOutputSession(sessionId) {
 }
 
 /**
+ * Rebind a live session's output MessagePort to another renderer (e.g. AI
+ * silent-session observe popup). Keeps the same PTY/stream; only the display
+ * route moves. Returns the previous webContentsId so the caller can restore.
+ */
+function rebindTerminalSessionOutput(event, payload) {
+  const sessionId = typeof payload?.sessionId === "string" ? payload.sessionId : "";
+  if (!sessionId) {
+    return { success: false, error: "Missing sessionId" };
+  }
+  const session = sessions?.get?.(sessionId);
+  if (!session) {
+    return { success: false, error: "Session not found" };
+  }
+  const sender = event?.sender;
+  if (!sender || sender.isDestroyed?.()) {
+    return { success: false, error: "Invalid sender" };
+  }
+  const previousWebContentsId =
+    typeof session.webContentsId === "number" ? session.webContentsId : null;
+  try {
+    openTerminalOutputSession(sessionId, sender);
+    session.webContentsId = sender.id;
+    return {
+      success: true,
+      previousWebContentsId,
+      webContentsId: sender.id,
+    };
+  } catch (err) {
+    return { success: false, error: err?.message || String(err) };
+  }
+}
+
+/**
+ * Restore output to a previous renderer after an attach popup closes.
+ * Falls back to the first live main-ish window if the home webContents is gone.
+ */
+function restoreTerminalSessionOutput(event, payload) {
+  const sessionId = typeof payload?.sessionId === "string" ? payload.sessionId : "";
+  if (!sessionId) {
+    return { success: false, error: "Missing sessionId" };
+  }
+  const session = sessions?.get?.(sessionId);
+  if (!session) {
+    // Session already closed — nothing to restore.
+    return { success: true, restored: false };
+  }
+
+  let target = null;
+  const homeId = payload?.webContentsId;
+  if (typeof homeId === "number" && electronModule?.webContents?.fromId) {
+    try {
+      const home = electronModule.webContents.fromId(homeId);
+      if (home && !home.isDestroyed?.()) target = home;
+    } catch {
+      // fall through
+    }
+  }
+  if (!target && electronModule?.BrowserWindow?.getAllWindows) {
+    try {
+      const wins = electronModule.BrowserWindow.getAllWindows() || [];
+      for (const win of wins) {
+        const wc = win?.webContents;
+        if (!wc || wc.isDestroyed?.()) continue;
+        // Prefer a non-popup / non-tray renderer if we can tell; otherwise first live.
+        const url = typeof wc.getURL === "function" ? wc.getURL() : "";
+        if (url.includes("#/terminal-popup") || url.includes("#/tray")) continue;
+        target = wc;
+        break;
+      }
+      if (!target) {
+        for (const win of wins) {
+          const wc = win?.webContents;
+          if (wc && !wc.isDestroyed?.()) {
+            target = wc;
+            break;
+          }
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+  if (!target) {
+    return { success: false, error: "No live renderer to restore output to" };
+  }
+  try {
+    openTerminalOutputSession(sessionId, target);
+    session.webContentsId = target.id;
+    return { success: true, restored: true, webContentsId: target.id };
+  } catch (err) {
+    return { success: false, error: err?.message || String(err) };
+  }
+}
+
+/**
  * Locate an executable on POSIX systems by name.
  *
  * macOS GUI Electron apps inherit launchd's minimal PATH
@@ -1446,6 +1541,8 @@ function registerHandlers(ipcMain, options = {}) {
   ipcMain.handle("netcatty:local:validatePath", validatePath);
   ipcMain.handle("netcatty:shells:discover", () => discoverShells());
   ipcMain.handle("netcatty:terminal:setEncoding", setSessionEncoding);
+  ipcMain.handle("netcatty:terminal:rebindOutput", rebindTerminalSessionOutput);
+  ipcMain.handle("netcatty:terminal:restoreOutput", restoreTerminalSessionOutput);
   ipcMain.on("netcatty:write", writeToSession);
   ipcMain.on("netcatty:interrupt", interruptSession);
   ipcMain.on("netcatty:resize", resizeSession);

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -140,6 +140,7 @@ const TERMINAL_SNAPSHOT_TIMEOUT_MS = 2000;
 const attachHomeWebContentsIds = new Map();
 const {
   setRestoreAttachedSessionOutput,
+  setAttachHomeLookup,
 } = require("./terminalAttachRestore.cjs");
 
 function resolveSessionHomeWebContentsId(sessionId, terminalWorkerManager = null) {
@@ -204,6 +205,38 @@ function handleTerminalSessionSnapshotResponse(_event, payload) {
     success: true,
     snapshot: typeof payload?.snapshot === "string" ? payload.snapshot : "",
   });
+}
+
+/**
+ * Push the observe-popup terminal state back to the home renderer before
+ * restoring the display route, so reopen/attach doesn't show a stale view.
+ */
+function applyTerminalSessionSnapshot(event, payload, terminalWorkerManager = null) {
+  const sessionId = typeof payload?.sessionId === "string" ? payload.sessionId : "";
+  const snapshot = typeof payload?.snapshot === "string" ? payload.snapshot : "";
+  if (!sessionId || !snapshot) {
+    return { success: false, error: "Missing sessionId or snapshot" };
+  }
+  let homeId = null;
+  if (terminalWorkerManager?.getAttachHomeWebContentsId) {
+    homeId = terminalWorkerManager.getAttachHomeWebContentsId(sessionId);
+  }
+  if (homeId == null) {
+    homeId = attachHomeWebContentsIds.get(sessionId) ?? null;
+  }
+  if (typeof homeId !== "number" || !electronModule?.webContents?.fromId) {
+    return { success: false, error: "Home renderer not found" };
+  }
+  try {
+    const home = electronModule.webContents.fromId(homeId);
+    if (!home || home.isDestroyed?.()) {
+      return { success: false, error: "Home renderer destroyed" };
+    }
+    home.send("netcatty:terminal:apply-snapshot", { sessionId, snapshot });
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: err?.message || String(err) };
+  }
 }
 
 /**
@@ -1685,9 +1718,17 @@ function registerHandlers(ipcMain, options = {}) {
     restoreTerminalSessionOutput(event, payload, terminalWorkerManager));
   ipcMain.handle("netcatty:terminal:requestSnapshot", (event, payload) =>
     requestTerminalSessionSnapshot(event, payload, terminalWorkerManager));
+  ipcMain.handle("netcatty:terminal:applySnapshot", (event, payload) =>
+    applyTerminalSessionSnapshot(event, payload, terminalWorkerManager));
   ipcMain.on("netcatty:terminal:snapshot-response", handleTerminalSessionSnapshotResponse);
   setRestoreAttachedSessionOutput((sessionId) =>
     restoreAttachedSessionOutput(sessionId, terminalWorkerManager));
+  setAttachHomeLookup((sessionId) => {
+    if (terminalWorkerManager?.getAttachHomeWebContentsId) {
+      return terminalWorkerManager.getAttachHomeWebContentsId(sessionId);
+    }
+    return attachHomeWebContentsIds.get(sessionId) ?? null;
+  });
 
   if (terminalWorkerManager) {
     [

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -141,6 +141,7 @@ const attachHomeWebContentsIds = new Map();
 const {
   setRestoreAttachedSessionOutput,
   setAttachHomeLookup,
+  setFanoutSessionExit,
 } = require("./terminalAttachRestore.cjs");
 
 function resolveSessionHomeWebContentsId(sessionId, terminalWorkerManager = null) {
@@ -1728,6 +1729,9 @@ function registerHandlers(ipcMain, options = {}) {
       return terminalWorkerManager.getAttachHomeWebContentsId(sessionId);
     }
     return attachHomeWebContentsIds.get(sessionId) ?? null;
+  });
+  setFanoutSessionExit((sessionId, primaryWebContentsId, payload) => {
+    fanoutSessionLifecycleEvent(sessionId, primaryWebContentsId, "netcatty:exit", payload);
   });
 
   if (terminalWorkerManager) {

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -133,6 +133,74 @@ function closeTerminalOutputSession(sessionId) {
   terminalOutputChannel?.closeSession?.(sessionId);
 }
 
+/** @type {Map<string, { resolve: (value: any) => void, timeout: NodeJS.Timeout }>} */
+const pendingTerminalSnapshots = new Map();
+const TERMINAL_SNAPSHOT_TIMEOUT_MS = 2000;
+
+function resolveSessionHomeWebContentsId(sessionId, terminalWorkerManager = null) {
+  if (!sessionId) return null;
+  if (terminalWorkerManager?.getSessionWebContentsId) {
+    const id = terminalWorkerManager.getSessionWebContentsId(sessionId);
+    if (typeof id === "number") return id;
+  }
+  const session = sessions?.get?.(sessionId);
+  if (typeof session?.webContentsId === "number") return session.webContentsId;
+  return null;
+}
+
+/**
+ * Capture a serialize snapshot from the home renderer before rebinding output
+ * to an observe popup, so the popup is not an empty shell.
+ */
+function requestTerminalSessionSnapshot(event, payload, terminalWorkerManager = null) {
+  const sessionId = typeof payload?.sessionId === "string" ? payload.sessionId : "";
+  if (!sessionId) {
+    return Promise.resolve({ success: false, snapshot: "", error: "Missing sessionId" });
+  }
+  const homeId = resolveSessionHomeWebContentsId(sessionId, terminalWorkerManager);
+  if (typeof homeId !== "number" || !electronModule?.webContents?.fromId) {
+    return Promise.resolve({ success: false, snapshot: "", error: "Home renderer not found" });
+  }
+  let home;
+  try {
+    home = electronModule.webContents.fromId(homeId);
+  } catch {
+    home = null;
+  }
+  if (!home || home.isDestroyed?.()) {
+    return Promise.resolve({ success: false, snapshot: "", error: "Home renderer destroyed" });
+  }
+
+  const requestId = randomUUID();
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      pendingTerminalSnapshots.delete(requestId);
+      resolve({ success: false, snapshot: "", error: "timeout" });
+    }, TERMINAL_SNAPSHOT_TIMEOUT_MS);
+    pendingTerminalSnapshots.set(requestId, { resolve, timeout });
+    try {
+      home.send("netcatty:terminal:snapshot-request", { sessionId, requestId });
+    } catch (err) {
+      clearTimeout(timeout);
+      pendingTerminalSnapshots.delete(requestId);
+      resolve({ success: false, snapshot: "", error: err?.message || String(err) });
+    }
+  });
+}
+
+function handleTerminalSessionSnapshotResponse(_event, payload) {
+  const requestId = typeof payload?.requestId === "string" ? payload.requestId : "";
+  if (!requestId) return;
+  const pending = pendingTerminalSnapshots.get(requestId);
+  if (!pending) return;
+  clearTimeout(pending.timeout);
+  pendingTerminalSnapshots.delete(requestId);
+  pending.resolve({
+    success: true,
+    snapshot: typeof payload?.snapshot === "string" ? payload.snapshot : "",
+  });
+}
+
 /**
  * Rebind a live session's output MessagePort to another renderer (e.g. AI
  * silent-session observe popup). Keeps the same PTY/stream; only the display
@@ -1521,6 +1589,9 @@ function registerHandlers(ipcMain, options = {}) {
     rebindTerminalSessionOutput(event, payload, terminalWorkerManager));
   ipcMain.handle("netcatty:terminal:restoreOutput", (event, payload) =>
     restoreTerminalSessionOutput(event, payload, terminalWorkerManager));
+  ipcMain.handle("netcatty:terminal:requestSnapshot", (event, payload) =>
+    requestTerminalSessionSnapshot(event, payload, terminalWorkerManager));
+  ipcMain.on("netcatty:terminal:snapshot-response", handleTerminalSessionSnapshotResponse);
 
   if (terminalWorkerManager) {
     [

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -948,6 +948,7 @@ function startLocalSession(event, payload) {
       sessionLogStreamManager.stopStream(sessionId, logStreamToken);
       ptyProcessTree.unregisterPid(sessionId);
       sessions.delete(sessionId);
+      if (session.closed) return;
       // Signal present = killed externally (show disconnected UI).
       // No signal = process exited normally, even with non-zero code
       // (e.g. user typed `exit` after a failed command), so auto-close.
@@ -1183,6 +1184,7 @@ async function startSerialSession(event, options) {
           const primaryId = session.webContentsId;
           ptyProcessTree.unregisterPid(sessionId);
           sessions.delete(sessionId);
+          if (session.closed) return;
           fanoutSessionLifecycleEvent(
             sessionId,
             primaryId,
@@ -1199,6 +1201,7 @@ async function startSerialSession(event, options) {
           const primaryId = session.webContentsId;
           ptyProcessTree.unregisterPid(sessionId);
           sessions.delete(sessionId);
+          if (session.closed) return;
           fanoutSessionLifecycleEvent(
             sessionId,
             primaryId,
@@ -1706,6 +1709,12 @@ function closeSession(event, payload) {
   const session = sessions.get(payload.sessionId);
   if (!session) return;
   session.closed = true;
+  fanoutSessionLifecycleEvent(
+    payload.sessionId,
+    session.webContentsId,
+    "netcatty:exit",
+    { sessionId: payload.sessionId, exitCode: 0, reason: "closed" },
+  );
   closeTerminalOutputSession(payload.sessionId);
 
   try {

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -137,19 +137,32 @@ function closeTerminalOutputSession(sessionId) {
  * Rebind a live session's output MessagePort to another renderer (e.g. AI
  * silent-session observe popup). Keeps the same PTY/stream; only the display
  * route moves. Returns the previous webContentsId so the caller can restore.
+ *
+ * Worker mode: sessions live in the utilityProcess; display routing is owned
+ * by terminalWorkerManager (sessionWebContentsIds + output ports).
+ * In-process mode: sessions Map in this bridge owns webContentsId.
  */
-function rebindTerminalSessionOutput(event, payload) {
+function rebindTerminalSessionOutput(event, payload, terminalWorkerManager = null) {
   const sessionId = typeof payload?.sessionId === "string" ? payload.sessionId : "";
   if (!sessionId) {
     return { success: false, error: "Missing sessionId" };
   }
-  const session = sessions?.get?.(sessionId);
-  if (!session) {
-    return { success: false, error: "Session not found" };
-  }
   const sender = event?.sender;
   if (!sender || sender.isDestroyed?.()) {
     return { success: false, error: "Invalid sender" };
+  }
+
+  if (terminalWorkerManager) {
+    try {
+      return terminalWorkerManager.rebindOutputSession(sessionId, sender.id);
+    } catch (err) {
+      return { success: false, error: err?.message || String(err) };
+    }
+  }
+
+  const session = sessions?.get?.(sessionId);
+  if (!session) {
+    return { success: false, error: "Session not found" };
   }
   const previousWebContentsId =
     typeof session.webContentsId === "number" ? session.webContentsId : null;
@@ -170,15 +183,10 @@ function rebindTerminalSessionOutput(event, payload) {
  * Restore output to a previous renderer after an attach popup closes.
  * Falls back to the first live main-ish window if the home webContents is gone.
  */
-function restoreTerminalSessionOutput(event, payload) {
+function restoreTerminalSessionOutput(event, payload, terminalWorkerManager = null) {
   const sessionId = typeof payload?.sessionId === "string" ? payload.sessionId : "";
   if (!sessionId) {
     return { success: false, error: "Missing sessionId" };
-  }
-  const session = sessions?.get?.(sessionId);
-  if (!session) {
-    // Session already closed — nothing to restore.
-    return { success: true, restored: false };
   }
 
   let target = null;
@@ -218,6 +226,28 @@ function restoreTerminalSessionOutput(event, payload) {
   }
   if (!target) {
     return { success: false, error: "No live renderer to restore output to" };
+  }
+
+  if (terminalWorkerManager) {
+    if (!terminalWorkerManager.hasOpenSession?.(sessionId)) {
+      // Session already closed — nothing to restore.
+      return { success: true, restored: false };
+    }
+    try {
+      const result = terminalWorkerManager.rebindOutputSession(sessionId, target.id);
+      if (!result?.success) {
+        return { success: false, error: result?.error || "Failed to restore session output" };
+      }
+      return { success: true, restored: true, webContentsId: target.id };
+    } catch (err) {
+      return { success: false, error: err?.message || String(err) };
+    }
+  }
+
+  const session = sessions?.get?.(sessionId);
+  if (!session) {
+    // Session already closed — nothing to restore.
+    return { success: true, restored: false };
   }
   try {
     openTerminalOutputSession(sessionId, target);
@@ -1485,6 +1515,13 @@ function registerWorkerSend(ipcMain, terminalWorkerManager, channel) {
 
 function registerHandlers(ipcMain, options = {}) {
   const terminalWorkerManager = options.terminalWorkerManager || null;
+  // Attach/observe popups rebind display routing in the main process even when
+  // PTY I/O is owned by the terminal worker. Always register these handlers.
+  ipcMain.handle("netcatty:terminal:rebindOutput", (event, payload) =>
+    rebindTerminalSessionOutput(event, payload, terminalWorkerManager));
+  ipcMain.handle("netcatty:terminal:restoreOutput", (event, payload) =>
+    restoreTerminalSessionOutput(event, payload, terminalWorkerManager));
+
   if (terminalWorkerManager) {
     [
       "netcatty:local:start",
@@ -1541,8 +1578,6 @@ function registerHandlers(ipcMain, options = {}) {
   ipcMain.handle("netcatty:local:validatePath", validatePath);
   ipcMain.handle("netcatty:shells:discover", () => discoverShells());
   ipcMain.handle("netcatty:terminal:setEncoding", setSessionEncoding);
-  ipcMain.handle("netcatty:terminal:rebindOutput", rebindTerminalSessionOutput);
-  ipcMain.handle("netcatty:terminal:restoreOutput", restoreTerminalSessionOutput);
   ipcMain.on("netcatty:write", writeToSession);
   ipcMain.on("netcatty:interrupt", interruptSession);
   ipcMain.on("netcatty:resize", resizeSession);

--- a/electron/bridges/terminalBridge.outputFlood.test.cjs
+++ b/electron/bridges/terminalBridge.outputFlood.test.cjs
@@ -216,7 +216,10 @@ test("closing a local terminal discards buffered output instead of flushing it",
   spawns[0].emitData(Buffer.from("pending tail"));
   bridge.closeSession({ sender: {} }, { sessionId: "local-flood-close" });
 
-  assert.deepEqual(sent, []);
+  assert.deepEqual(sent, [{
+    channel: "netcatty:exit",
+    payload: { sessionId: "local-flood-close", exitCode: 0, reason: "closed" },
+  }]);
 });
 
 test("app cleanup discards buffered output instead of flushing it", () => {

--- a/electron/bridges/terminalBridge.rebindOutput.test.cjs
+++ b/electron/bridges/terminalBridge.rebindOutput.test.cjs
@@ -142,6 +142,70 @@ test("attach close restores the output route before resuming the backend", () =>
   assert.match(mainRestoreSource, /if \(result\?\.success\) \{\s*resumeSessionOutputFlow/);
 });
 
+test("in-process explicit close sends an exit event before dropping the output route", () => {
+  const source = require("node:fs").readFileSync(
+    path.join(__dirname, "terminalBridge.cjs"),
+    "utf8",
+  );
+  const start = source.indexOf("function closeSession(event, payload)");
+  const end = source.indexOf("function setSessionEncoding", start);
+  const closeSource = source.slice(start, end);
+  assert.ok(
+    closeSource.indexOf("fanoutSessionLifecycleEvent") < closeSource.indexOf("closeTerminalOutputSession"),
+    "notify attached renderers before removing their output route",
+  );
+  assert.match(source, /if \(session\.closed\) return;/, "transport callbacks suppress duplicate explicit-close exits");
+  const sshSource = require("node:fs").readFileSync(
+    path.join(__dirname, "sshBridge/startSession.cjs"),
+    "utf8",
+  );
+  assert.match(sshSource, /if \(liveSession\?\.closed\)/, "SSH close callback suppresses duplicate explicit-close exits");
+});
+
+test("in-process explicit close notifies a rebound popup and its home renderer", () => {
+  const { bridge, fakeChannel } = loadTerminalBridgeWithMocks();
+  const sent = [];
+  const contents = new Map([7, 9].map((id) => [id, {
+    id,
+    isDestroyed: () => false,
+    send: (channel, payload) => sent.push({ id, channel, payload }),
+  }]));
+  const sessions = new Map([[
+    "session-close",
+    { webContentsId: 7, proc: { kill() {} } },
+  ]]);
+  bridge.init({
+    sessions,
+    electronModule: { webContents: { fromId: (id) => contents.get(id) } },
+    terminalOutputChannel: fakeChannel,
+  });
+  const registry = require("./terminalAttachRestore.cjs");
+  registry.registerAttachPopupAuthorization("close-grant", "session-close", 9);
+  assert.equal(bridge.registerHandlers != null, true);
+  const ipcMain = {
+    handlers: new Map(),
+    listeners: new Map(),
+    handle(channel, handler) { this.handlers.set(channel, handler); },
+    on(channel, handler) { this.listeners.set(channel, handler); },
+  };
+  bridge.registerHandlers(ipcMain);
+  assert.equal(
+    ipcMain.handlers.get("netcatty:terminal:rebindOutput")(
+      { sender: contents.get(9) },
+      { sessionId: "session-close", authorization: "close-grant" },
+    ).success,
+    true,
+  );
+
+  bridge.closeSession({ sender: contents.get(7) }, { sessionId: "session-close" });
+
+  assert.deepEqual(sent, [
+    { id: 9, channel: "netcatty:exit", payload: { sessionId: "session-close", exitCode: 0, reason: "closed" } },
+    { id: 7, channel: "netcatty:exit", payload: { sessionId: "session-close", exitCode: 0, reason: "closed" } },
+  ]);
+  registry.releaseAttachPopupAuthorization("close-grant");
+});
+
 test("snapshot apply acknowledgements are emitted only by the matching terminal", () => {
   const preloadSource = require("node:fs").readFileSync(
     path.join(__dirname, "../preload/api.cjs"),

--- a/electron/bridges/terminalBridge.rebindOutput.test.cjs
+++ b/electron/bridges/terminalBridge.rebindOutput.test.cjs
@@ -1,0 +1,64 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const Module = require("node:module");
+
+function loadTerminalBridgeWithMocks() {
+  const bridgePath = require.resolve("./terminalBridge.cjs");
+  delete require.cache[bridgePath];
+
+  const opened = [];
+  const fakeChannel = {
+    openSession(sessionId, webContents) {
+      opened.push({ sessionId, webContentsId: webContents.id });
+      return true;
+    },
+    closeSession() {},
+  };
+
+  const originalRequire = Module.prototype.require;
+  Module.prototype.require = function patchedRequire(request) {
+    if (request === "./terminalOutputChannel.cjs" || request.endsWith("terminalOutputChannel.cjs")) {
+      return {
+        createTerminalOutputChannel: () => fakeChannel,
+        TERMINAL_OUTPUT_PORT_CHANNEL: "netcatty:terminal-output-port",
+      };
+    }
+    if (request === "./emitTerminalSessionData.cjs" || request.endsWith("emitTerminalSessionData.cjs")) {
+      return { configureTerminalSessionDataEmitter: () => {} };
+    }
+    return originalRequire.apply(this, arguments);
+  };
+
+  try {
+    const bridge = require("./terminalBridge.cjs");
+    return { bridge, opened, fakeChannel };
+  } finally {
+    Module.prototype.require = originalRequire;
+  }
+}
+
+test("rebindTerminalSessionOutput moves output and updates webContentsId", () => {
+  // Load bridge source helpers via init + direct IPC simulation is heavy;
+  // assert the implementation is registered and the openSession rebind contract
+  // used by the attach popup is present.
+  const source = require("node:fs").readFileSync(
+    path.join(__dirname, "terminalBridge.cjs"),
+    "utf8",
+  );
+  assert.match(source, /function rebindTerminalSessionOutput/);
+  assert.match(source, /function restoreTerminalSessionOutput/);
+  assert.match(source, /netcatty:terminal:rebindOutput/);
+  assert.match(source, /netcatty:terminal:restoreOutput/);
+  assert.match(source, /session\.webContentsId = sender\.id/);
+});
+
+test("attach popup payload field is consumed by terminal popup window", () => {
+  const source = require("node:fs").readFileSync(
+    path.join(__dirname, "windowManager/terminalPopupWindow.cjs"),
+    "utf8",
+  );
+  assert.match(source, /attachSessionId/);
+  assert.match(source, /attachSessionPopups/);
+  assert.match(source, /reused: true/);
+});

--- a/electron/bridges/terminalBridge.rebindOutput.test.cjs
+++ b/electron/bridges/terminalBridge.rebindOutput.test.cjs
@@ -95,6 +95,31 @@ test("worker renderer-event forwarding prefers rebound webContentsId", () => {
   );
 });
 
+test("in-process SSH and Telnet ZMODEM prompts follow the rebound display", () => {
+  const sshSource = require("node:fs").readFileSync(
+    path.join(__dirname, "sshBridge/startSession.cjs"),
+    "utf8",
+  );
+  const telnetSource = require("node:fs").readFileSync(
+    path.join(__dirname, "terminalBridge/telnetSession.cjs"),
+    "utf8",
+  );
+  const sshSentry = sshSource.slice(
+    sshSource.indexOf("const sshZmodemSentry"),
+    sshSource.indexOf("session.zmodemSentry = sshZmodemSentry"),
+  );
+  const telnetSentry = telnetSource.slice(
+    telnetSource.indexOf("const telnetZmodemSentry"),
+    telnetSource.indexOf("const attachTelnetSentry"),
+  );
+  assert.match(sshSentry, /getCurrentSessionWebContents/);
+  assert.match(sshSentry, /getCurrentSessionWebContentsId/);
+  assert.doesNotMatch(sshSentry, /event\.sender/);
+  assert.match(telnetSentry, /getCurrentTelnetWebContents/);
+  assert.match(telnetSentry, /getCurrentTelnetWebContentsId/);
+  assert.doesNotMatch(telnetSentry, /telnetWebContentsId/);
+});
+
 test("popup window closed lifecycle restores attach output", () => {
   const source = require("node:fs").readFileSync(
     path.join(__dirname, "windowManager/terminalPopupWindow.cjs"),

--- a/electron/bridges/terminalBridge.rebindOutput.test.cjs
+++ b/electron/bridges/terminalBridge.rebindOutput.test.cjs
@@ -245,10 +245,13 @@ test("snapshot apply acknowledgements are emitted only by the matching terminal"
     "utf8",
   );
   assert.match(preloadSource, /if \(handled !== true\) return/);
-  assert.match(terminalSource, /payload\.sessionId !== sessionId \|\| typeof payload\.snapshot !== "string"\) return false/);
+  assert.match(terminalSource, /typeof payload\.contextViewportSnapshot !== "string"/);
   assert.doesNotMatch(terminalSource, /if \(snap\) \{\s*const applied = await terminalBackend\.applySessionSnapshot/);
   assert.match(terminalSource, /const applied = await terminalBackend\.applySessionSnapshot/);
   assert.match(bridgeSource, /const hasSnapshot = typeof payload\?\.snapshot === "string"/);
+  assert.match(bridgeSource, /const hasContextSnapshot = typeof payload\?\.contextSnapshot === "string"/);
+  assert.match(preloadSource, /contextSnapshot: typeof context\?\.contextSnapshot === "string"/);
+  assert.match(terminalSource, /finalContext = readTerminalHibernateContext\(snapshotTerm\)/);
 });
 
 test("exit fanout preserves the original renderer before registry wiring", () => {

--- a/electron/bridges/terminalBridge.rebindOutput.test.cjs
+++ b/electron/bridges/terminalBridge.rebindOutput.test.cjs
@@ -53,6 +53,34 @@ test("rebindTerminalSessionOutput moves output and updates webContentsId", () =>
   assert.match(source, /session\.webContentsId = sender\.id/);
 });
 
+test("rebind and restore handlers register even when terminal worker is enabled", () => {
+  const source = require("node:fs").readFileSync(
+    path.join(__dirname, "terminalBridge.cjs"),
+    "utf8",
+  );
+  // Must be registered before the worker early-return, otherwise production
+  // (worker-on) hits "No handler registered for rebindOutput" on first attach.
+  const rebindIdx = source.indexOf('ipcMain.handle("netcatty:terminal:rebindOutput"');
+  const restoreIdx = source.indexOf('ipcMain.handle("netcatty:terminal:restoreOutput"');
+  const workerReturnIdx = source.indexOf("].forEach((channel) => registerWorkerSend");
+  assert.ok(rebindIdx > 0, "rebind handler present");
+  assert.ok(restoreIdx > 0, "restore handler present");
+  assert.ok(workerReturnIdx > 0, "worker send registration present");
+  assert.ok(rebindIdx < workerReturnIdx, "rebind registered before worker-only early return");
+  assert.ok(restoreIdx < workerReturnIdx, "restore registered before worker-only early return");
+  assert.match(source, /terminalWorkerManager\.rebindOutputSession/);
+});
+
+test("terminal worker manager exposes rebindOutputSession", () => {
+  const source = require("node:fs").readFileSync(
+    path.join(__dirname, "terminalWorkerManager.cjs"),
+    "utf8",
+  );
+  assert.match(source, /function rebindOutputSession/);
+  assert.match(source, /rebindOutputSession,/);
+  assert.match(source, /getSessionWebContentsId\(sessionId\)/);
+});
+
 test("attach popup payload field is consumed by terminal popup window", () => {
   const source = require("node:fs").readFileSync(
     path.join(__dirname, "windowManager/terminalPopupWindow.cjs"),

--- a/electron/bridges/terminalBridge.rebindOutput.test.cjs
+++ b/electron/bridges/terminalBridge.rebindOutput.test.cjs
@@ -215,8 +215,15 @@ test("snapshot apply acknowledgements are emitted only by the matching terminal"
     path.join(__dirname, "../../components/Terminal.tsx"),
     "utf8",
   );
+  const bridgeSource = require("node:fs").readFileSync(
+    path.join(__dirname, "terminalBridge.cjs"),
+    "utf8",
+  );
   assert.match(preloadSource, /if \(handled !== true\) return/);
-  assert.match(terminalSource, /payload\.sessionId !== sessionId \|\| !payload\.snapshot\) return false/);
+  assert.match(terminalSource, /payload\.sessionId !== sessionId \|\| typeof payload\.snapshot !== "string"\) return false/);
+  assert.doesNotMatch(terminalSource, /if \(snap\) \{\s*const applied = await terminalBackend\.applySessionSnapshot/);
+  assert.match(terminalSource, /const applied = await terminalBackend\.applySessionSnapshot/);
+  assert.match(bridgeSource, /const hasSnapshot = typeof payload\?\.snapshot === "string"/);
 });
 
 test("exit fanout preserves the original renderer before registry wiring", () => {

--- a/electron/bridges/terminalBridge.rebindOutput.test.cjs
+++ b/electron/bridges/terminalBridge.rebindOutput.test.cjs
@@ -62,13 +62,30 @@ test("rebind and restore handlers register even when terminal worker is enabled"
   // (worker-on) hits "No handler registered for rebindOutput" on first attach.
   const rebindIdx = source.indexOf('ipcMain.handle("netcatty:terminal:rebindOutput"');
   const restoreIdx = source.indexOf('ipcMain.handle("netcatty:terminal:restoreOutput"');
+  const snapshotIdx = source.indexOf('ipcMain.handle("netcatty:terminal:requestSnapshot"');
   const workerReturnIdx = source.indexOf("].forEach((channel) => registerWorkerSend");
   assert.ok(rebindIdx > 0, "rebind handler present");
   assert.ok(restoreIdx > 0, "restore handler present");
+  assert.ok(snapshotIdx > 0, "snapshot handler present");
   assert.ok(workerReturnIdx > 0, "worker send registration present");
   assert.ok(rebindIdx < workerReturnIdx, "rebind registered before worker-only early return");
   assert.ok(restoreIdx < workerReturnIdx, "restore registered before worker-only early return");
+  assert.ok(snapshotIdx < workerReturnIdx, "snapshot registered before worker-only early return");
   assert.match(source, /terminalWorkerManager\.rebindOutputSession/);
+  assert.match(source, /function requestTerminalSessionSnapshot/);
+});
+
+test("worker renderer-event forwarding prefers rebound webContentsId", () => {
+  const source = require("node:fs").readFileSync(
+    path.join(__dirname, "terminalWorkerManager.cjs"),
+    "utf8",
+  );
+  assert.match(source, /sessionWebContentsIds\.get\(sessionId\)/);
+  assert.match(source, /targetWebContentsId/);
+  // Exit cleanup must not run before we capture the rebound target.
+  const captureIdx = source.indexOf("const targetWebContentsId =");
+  const closeIdx = source.indexOf('if (message.channel === "netcatty:exit"');
+  assert.ok(captureIdx > 0 && closeIdx > captureIdx, "capture target before closeOutputSession on exit");
 });
 
 test("terminal worker manager exposes rebindOutputSession", () => {

--- a/electron/bridges/terminalBridge.rebindOutput.test.cjs
+++ b/electron/bridges/terminalBridge.rebindOutput.test.cjs
@@ -88,6 +88,11 @@ test("worker renderer-event forwarding prefers rebound webContentsId", () => {
   const captureIdx = source.indexOf("const displayWebContentsId =");
   const closeIdx = source.indexOf('if (message.channel === "netcatty:exit"');
   assert.ok(captureIdx > 0 && closeIdx > captureIdx, "capture targets before closeOutputSession on exit");
+  assert.match(
+    source,
+    /message\.channel === "netcatty:exit" && homeWebContentsId != null/,
+    "only exit events fan out to the attach home",
+  );
 });
 
 test("popup window closed lifecycle restores attach output", () => {
@@ -97,6 +102,139 @@ test("popup window closed lifecycle restores attach output", () => {
   );
   assert.match(source, /restoreAttachedSessionOutput\(attachSessionId\)/);
   assert.match(source, /terminalAttachRestore/);
+  const crashStart = source.indexOf('"render-process-gone"');
+  const crashEnd = source.indexOf('"console-message"', crashStart);
+  assert.match(source.slice(crashStart, crashEnd), /win\.destroy\(\)/);
+});
+
+test("attach close restores the output route before resuming the backend", () => {
+  const bridgeSource = require("node:fs").readFileSync(
+    path.join(__dirname, "terminalBridge.cjs"),
+    "utf8",
+  );
+  const restoreStart = bridgeSource.indexOf("function restoreAttachedSessionOutput");
+  const restoreEnd = bridgeSource.indexOf("function restoreTerminalSessionOutput", restoreStart);
+  const restoreSource = bridgeSource.slice(restoreStart, restoreEnd);
+  const routeIdx = restoreSource.indexOf("restoreAttachHome");
+  const resumeIdx = restoreSource.indexOf("resumeSessionOutputFlow");
+  assert.ok(routeIdx > 0 && resumeIdx > routeIdx, "restore route before resuming output");
+
+  const terminalSource = require("node:fs").readFileSync(
+    path.join(__dirname, "../../components/Terminal.tsx"),
+    "utf8",
+  );
+  const cleanupStart = terminalSource.indexOf("Observe/attach popups must not kill");
+  const cleanupEnd = terminalSource.indexOf("const cleanupPromise", cleanupStart);
+  const cleanupSource = terminalSource.slice(cleanupStart, cleanupEnd);
+  const pauseIdx = cleanupSource.indexOf("setSessionFlowPaused?.(closingSessionId, true)");
+  const snapshotIdx = cleanupSource.indexOf("applySessionSnapshot");
+  const rendererRestoreIdx = cleanupSource.indexOf("restoreSessionOutput");
+  const disposeIdx = cleanupSource.indexOf("disposeSessionListeners()");
+  const releaseIdx = cleanupSource.indexOf("releaseTerminalFlowBeforeHibernate");
+  assert.ok(pauseIdx > 0, "pause before final snapshot");
+  assert.ok(snapshotIdx > pauseIdx, "snapshot after pause");
+  assert.ok(rendererRestoreIdx > snapshotIdx, "restore route after snapshot");
+  assert.ok(disposeIdx > rendererRestoreIdx, "detach popup listener after route restore");
+  assert.ok(releaseIdx > disposeIdx, "resume only after popup listener detaches");
+  const mainRestoreStart = bridgeSource.indexOf("function restoreAttachedSessionOutput");
+  const mainRestoreEnd = bridgeSource.indexOf("function restoreTerminalSessionOutput", mainRestoreStart);
+  const mainRestoreSource = bridgeSource.slice(mainRestoreStart, mainRestoreEnd);
+  assert.match(mainRestoreSource, /if \(result\?\.success\) \{\s*resumeSessionOutputFlow/);
+});
+
+test("snapshot apply acknowledgements are emitted only by the matching terminal", () => {
+  const preloadSource = require("node:fs").readFileSync(
+    path.join(__dirname, "../preload/api.cjs"),
+    "utf8",
+  );
+  const terminalSource = require("node:fs").readFileSync(
+    path.join(__dirname, "../../components/Terminal.tsx"),
+    "utf8",
+  );
+  assert.match(preloadSource, /if \(handled !== true\) return/);
+  assert.match(terminalSource, /payload\.sessionId !== sessionId \|\| !payload\.snapshot\) return false/);
+});
+
+test("exit fanout preserves the original renderer before registry wiring", () => {
+  const attachRestore = require("./terminalAttachRestore.cjs");
+  attachRestore.setFanoutSessionExit(null);
+  const sent = [];
+  const contents = {
+    id: 42,
+    send(channel, payload) {
+      sent.push({ channel, payload });
+    },
+  };
+  const payload = { sessionId: "session-1", reason: "exited" };
+  assert.equal(attachRestore.fanoutSessionExit("session-1", contents, payload), true);
+  assert.deepEqual(sent, [{ channel: "netcatty:exit", payload }]);
+});
+
+test("attach authorization is bound to one session and renderer", () => {
+  const registry = require("./terminalAttachRestore.cjs");
+  registry.registerAttachPopupAuthorization("grant-1", "session-1", 42);
+  assert.equal(registry.validateAttachPopupAuthorization("grant-1", "session-1", 42), true);
+  assert.equal(registry.validateAttachPopupAuthorization("grant-1", "session-2", 42), false);
+  assert.equal(registry.validateAttachPopupAuthorization("grant-1", "session-1", 43), false);
+  assert.equal(registry.markAttachPopupClosePrepared("grant-1", "session-1", 42), true);
+  assert.equal(registry.isAttachPopupClosePrepared("grant-1"), true);
+  registry.releaseAttachPopupAuthorization("grant-1");
+  assert.equal(registry.validateAttachPopupAuthorization("grant-1", "session-1", 42), false);
+});
+
+test("failed attach restores retry when a main renderer becomes ready", () => {
+  const registry = require("./terminalAttachRestore.cjs");
+  let available = false;
+  let calls = 0;
+  registry.setRestoreAttachedSessionOutput(() => {
+    calls += 1;
+    return available
+      ? { success: true, restored: true }
+      : { success: false, restored: false, error: "Home renderer unavailable" };
+  });
+
+  assert.equal(registry.restoreAttachedSessionOutput("session-retry").success, false);
+  available = true;
+  registry.retryPendingAttachedSessionOutputs();
+  registry.retryPendingAttachedSessionOutputs();
+
+  assert.equal(calls, 2, "successful retry clears the pending restore");
+});
+
+test("a ready replacement main renderer becomes the explicit restore target", () => {
+  const registry = require("./terminalAttachRestore.cjs");
+  const targets = [];
+  registry.setRestoreAttachedSessionOutput((_sessionId, preferredHomeWebContentsId) => {
+    targets.push(preferredHomeWebContentsId);
+    return targets.length === 1
+      ? { success: false, restored: false }
+      : { success: true, restored: true };
+  });
+
+  registry.restoreAttachedSessionOutput("session-replacement");
+  registry.retryPendingAttachedSessionOutput("session-replacement", 99);
+
+  assert.deepEqual(targets, [null, 99]);
+});
+
+test("attach IPC handlers validate popup authorization and flow pause has an awaitable barrier", () => {
+  const source = require("node:fs").readFileSync(
+    path.join(__dirname, "terminalBridge.cjs"),
+    "utf8",
+  );
+  assert.match(source, /function isAuthorizedAttachIpc/);
+  for (const functionName of [
+    "requestTerminalSessionSnapshot",
+    "applyTerminalSessionSnapshot",
+    "rebindTerminalSessionOutput",
+    "restoreTerminalSessionOutput",
+  ]) {
+    const start = source.indexOf(`function ${functionName}`);
+    const end = source.indexOf("\nfunction ", start + 10);
+    assert.match(source.slice(start, end), /isAuthorizedAttachIpc/);
+  }
+  assert.match(source, /netcatty:terminal:setFlowPausedAndWait/);
+  assert.match(source, /terminalWorkerManager\.request\("netcatty:terminal:setFlowPausedAndWait"/);
 });
 
 test("terminal worker manager exposes rebindOutputSession", () => {

--- a/electron/bridges/terminalBridge.rebindOutput.test.cjs
+++ b/electron/bridges/terminalBridge.rebindOutput.test.cjs
@@ -81,11 +81,22 @@ test("worker renderer-event forwarding prefers rebound webContentsId", () => {
     "utf8",
   );
   assert.match(source, /sessionWebContentsIds\.get\(sessionId\)/);
-  assert.match(source, /targetWebContentsId/);
-  // Exit cleanup must not run before we capture the rebound target.
-  const captureIdx = source.indexOf("const targetWebContentsId =");
+  assert.match(source, /displayWebContentsId/);
+  assert.match(source, /attachHomeWebContentsIds/);
+  assert.match(source, /restoreAttachHome/);
+  // Exit cleanup must not run before we capture display/home targets.
+  const captureIdx = source.indexOf("const displayWebContentsId =");
   const closeIdx = source.indexOf('if (message.channel === "netcatty:exit"');
-  assert.ok(captureIdx > 0 && closeIdx > captureIdx, "capture target before closeOutputSession on exit");
+  assert.ok(captureIdx > 0 && closeIdx > captureIdx, "capture targets before closeOutputSession on exit");
+});
+
+test("popup window closed lifecycle restores attach output", () => {
+  const source = require("node:fs").readFileSync(
+    path.join(__dirname, "windowManager/terminalPopupWindow.cjs"),
+    "utf8",
+  );
+  assert.match(source, /restoreAttachedSessionOutput\(attachSessionId\)/);
+  assert.match(source, /terminalAttachRestore/);
 });
 
 test("terminal worker manager exposes rebindOutputSession", () => {

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -1113,6 +1113,7 @@ main();
             sessionLogStreamManager.stopStream(sessionId);
             closeTerminalOutputSession?.(sessionId);
             sessions.delete(sessionId);
+            if (session.closed) return;
             const contents = electronModule.webContents.fromId(session.webContentsId);
             fanoutSessionExit(sessionId, contents, { sessionId, ...evt, reason: evt.exitCode === 0 ? "exited" : "error" });
           });

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -27,6 +27,7 @@ function createEtSessionApi(ctx) {
     const ET_ASKPASS_SCRIPT = String.raw`#!/usr/bin/env node
 const fs = require("node:fs");
 const path = require("node:path");
+const { fanoutSessionExit } = require("../terminalAttachRestore.cjs");
 
 function normalizePrompt(prompt) {
   return String(prompt || "").toLowerCase();
@@ -1113,7 +1114,7 @@ main();
             closeTerminalOutputSession?.(sessionId);
             sessions.delete(sessionId);
             const contents = electronModule.webContents.fromId(session.webContentsId);
-            contents?.send("netcatty:exit", { sessionId, ...evt, reason: evt.exitCode === 0 ? "exited" : "error" });
+            fanoutSessionExit(sessionId, session?.webContentsId ?? contents?.id, { sessionId, ...evt, reason: evt.exitCode === 0 ? "exited" : "error" });
           });
         });
 

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -8,6 +8,7 @@ const {
   shouldProcessSessionOutput,
 } = require("../terminalFlowAck.cjs");
 const { orderSshIdentityNames, SSH_KEY_PATTERN } = require("../sshAuthHelper.cjs");
+const { fanoutSessionExit } = require("../terminalAttachRestore.cjs");
 
 //
 // EternalTerminal session backend, factored into the createXxxSessionApi
@@ -27,7 +28,6 @@ function createEtSessionApi(ctx) {
     const ET_ASKPASS_SCRIPT = String.raw`#!/usr/bin/env node
 const fs = require("node:fs");
 const path = require("node:path");
-const { fanoutSessionExit } = require("../terminalAttachRestore.cjs");
 
 function normalizePrompt(prompt) {
   return String(prompt || "").toLowerCase();
@@ -1114,7 +1114,7 @@ main();
             closeTerminalOutputSession?.(sessionId);
             sessions.delete(sessionId);
             const contents = electronModule.webContents.fromId(session.webContentsId);
-            fanoutSessionExit(sessionId, session?.webContentsId ?? contents?.id, { sessionId, ...evt, reason: evt.exitCode === 0 ? "exited" : "error" });
+            fanoutSessionExit(sessionId, contents, { sessionId, ...evt, reason: evt.exitCode === 0 ? "exited" : "error" });
           });
         });
 

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -43,11 +43,12 @@ function makeApi(t, overrides = {}) {
     StringDecoder: require("node:string_decoder").StringDecoder,
     randomUUID: require("node:crypto").randomUUID,
     pty,
-    sessionLogStreamManager: {},
+    sessionLogStreamManager: overrides.sessionLogStreamManager || {},
     tempDirBridge,
     createZmodemSentry: () => ({}),
     trackSessionIdlePrompt: () => {},
-    createPtyOutputBuffer: () => ({ bufferData() {}, flush() {}, flushPaced() {} }),
+    createPtyOutputBuffer: overrides.createPtyOutputBuffer
+      || (() => ({ bufferData() {}, flush() {}, flushPaced() {} })),
     findExecutable: () => "ssh",
     bundledEtClient,
   });
@@ -107,6 +108,46 @@ test("startEtSession preserves discovered automatic identities for host informat
     [keyPath],
   );
   assert.equal(sessions.get("sess-auto-stats").etStatsAuth.authMethod, "auto");
+});
+
+test("explicitly closed ET sessions do not emit a second exit event", async (t) => {
+  let onExit = null;
+  const sent = [];
+  const proc = {
+    onData() {},
+    onExit(callback) { onExit = callback; },
+    write() {},
+  };
+  const { api, sessions } = makeApi(t, {
+    bundledEtClient: () => "/fake/et",
+    pty: { spawn: () => proc },
+    electronModule: {
+      webContents: {
+        fromId: () => ({ id: 7, send: (channel, payload) => sent.push({ channel, payload }) }),
+      },
+    },
+    openTerminalOutputSession: () => {},
+    closeTerminalOutputSession: () => {},
+    sessionLogStreamManager: { stopStream() {} },
+    createPtyOutputBuffer: () => ({
+      bufferData() {},
+      flush() {},
+      flushPaced(callback) { callback(); },
+    }),
+    selectZmodemUploadFiles: null,
+    selectZmodemDownloadDirectory: null,
+  });
+
+  await api.startEtSession({ sender: { id: 7 } }, {
+    sessionId: "sess-explicit-close",
+    hostname: "host.example",
+    username: "alice",
+  });
+  sessions.get("sess-explicit-close").closed = true;
+  onExit({ exitCode: 0 });
+
+  assert.deepEqual(sent, []);
+  assert.equal(sessions.has("sess-explicit-close"), false);
 });
 
 test("prepareEtSshEnvironment passes a non-default port via --ssh-option", (t) => {

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -575,7 +575,7 @@ function createMoshSessionApi(ctx) {
             flushPaced(() => {
               sessionLogStreamManager.stopStream(sessionId, logStreamToken);
               const contents = electronModule.webContents.fromId(session.webContentsId);
-              fanoutSessionExit(sessionId, session?.webContentsId ?? contents?.id, {
+              fanoutSessionExit(sessionId, contents, {
                 sessionId,
                 reason: "error",
                 error: `Failed to spawn mosh-client: ${err.message}`,
@@ -606,7 +606,7 @@ function createMoshSessionApi(ctx) {
         flushPaced(() => {
           sessionLogStreamManager.stopStream(sessionId, logStreamToken);
           const contents = electronModule.webContents.fromId(session.webContentsId);
-          fanoutSessionExit(sessionId, session?.webContentsId ?? contents?.id, {
+          fanoutSessionExit(sessionId, contents, {
             sessionId,
             exitCode,
             signal,
@@ -788,7 +788,7 @@ function createMoshSessionApi(ctx) {
         flushPaced(() => {
           sessionLogStreamManager.stopStream(sessionId, session.logStreamToken);
           const contents = electronModule.webContents.fromId(session.webContentsId);
-          fanoutSessionExit(sessionId, session?.webContentsId ?? contents?.id, {
+          fanoutSessionExit(sessionId, contents, {
             sessionId,
             exitCode,
             signal,

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -9,6 +9,7 @@ const {
 } = require("../terminalFlowAck.cjs");
 const { createSshConnExecProbe } = require("../ai/sessionShellKind.cjs");
 const { orderSshIdentityNames, SSH_KEY_PATTERN } = require("../sshAuthHelper.cjs");
+const { fanoutSessionExit } = require("../terminalAttachRestore.cjs");
 
 const execFileAsync = promisify(execFile);
 
@@ -574,7 +575,7 @@ function createMoshSessionApi(ctx) {
             flushPaced(() => {
               sessionLogStreamManager.stopStream(sessionId, logStreamToken);
               const contents = electronModule.webContents.fromId(session.webContentsId);
-              contents?.send("netcatty:exit", {
+              fanoutSessionExit(sessionId, session?.webContentsId ?? contents?.id, {
                 sessionId,
                 reason: "error",
                 error: `Failed to spawn mosh-client: ${err.message}`,
@@ -605,7 +606,7 @@ function createMoshSessionApi(ctx) {
         flushPaced(() => {
           sessionLogStreamManager.stopStream(sessionId, logStreamToken);
           const contents = electronModule.webContents.fromId(session.webContentsId);
-          contents?.send("netcatty:exit", {
+          fanoutSessionExit(sessionId, session?.webContentsId ?? contents?.id, {
             sessionId,
             exitCode,
             signal,
@@ -787,7 +788,7 @@ function createMoshSessionApi(ctx) {
         flushPaced(() => {
           sessionLogStreamManager.stopStream(sessionId, session.logStreamToken);
           const contents = electronModule.webContents.fromId(session.webContentsId);
-          contents?.send("netcatty:exit", {
+          fanoutSessionExit(sessionId, session?.webContentsId ?? contents?.id, {
             sessionId,
             exitCode,
             signal,

--- a/electron/bridges/terminalBridge/telnetSession.cjs
+++ b/electron/bridges/terminalBridge/telnetSession.cjs
@@ -73,7 +73,7 @@ function createTelnetSessionApi(ctx) {
               localEcho: localEchoEnabled,
             };
           }
-          const contents = electronModule.webContents.fromId(event.sender.id);
+          const contents = electronModule.webContents.fromId(session?.webContentsId ?? event.sender.id);
           contents?.send("netcatty:telnet:echo-mode", {
             sessionId,
             remoteEcho: remoteEchoEnabled,
@@ -344,7 +344,7 @@ function createTelnetSessionApi(ctx) {
               if (session) {
                 session.zmodemSentry?.cancel();
                 const contents = electronModule.webContents.fromId(session.webContentsId);
-                fanoutSessionExit(sessionId, session?.webContentsId ?? contents?.id, { sessionId, exitCode: 1, error: err.message, reason: "error" });
+                fanoutSessionExit(sessionId, contents, { sessionId, exitCode: 1, error: err.message, reason: "error" });
               }
               ptyProcessTree.unregisterPid(sessionId);
               closeTerminalOutputSession?.(sessionId);
@@ -370,7 +370,7 @@ function createTelnetSessionApi(ctx) {
             if (session) {
               session.zmodemSentry?.cancel();
               const contents = electronModule.webContents.fromId(session.webContentsId);
-              fanoutSessionExit(sessionId, session?.webContentsId ?? contents?.id, { sessionId, exitCode: hadError ? 1 : 0, reason: hadError ? "error" : "closed" });
+              fanoutSessionExit(sessionId, contents, { sessionId, exitCode: hadError ? 1 : 0, reason: hadError ? "error" : "closed" });
             }
             ptyProcessTree.unregisterPid(sessionId);
             closeTerminalOutputSession?.(sessionId);

--- a/electron/bridges/terminalBridge/telnetSession.cjs
+++ b/electron/bridges/terminalBridge/telnetSession.cjs
@@ -242,13 +242,16 @@ function createTelnetSessionApi(ctx) {
           resolve({ sessionId });
         });
     
-        const telnetWebContentsId = event.sender.id;
+        const getCurrentTelnetWebContentsId = () =>
+          sessions.get(sessionId)?.webContentsId ?? event.sender.id;
+        const getCurrentTelnetWebContents = () =>
+          electronModule.webContents.fromId(getCurrentTelnetWebContentsId());
         const {
           bufferData: bufferTelnetData,
           flushPaced: flushTelnetPaced,
           discard: discardTelnet,
         } = createPtyOutputBuffer((data, meta) => {
-          const contents = electronModule.webContents.fromId(telnetWebContentsId);
+          const contents = getCurrentTelnetWebContents();
           emitTerminalSessionData(contents, sessionId, data, { cols, rows, meta });
         }, {
           onPendingBytesChange: (bytes) => {
@@ -290,13 +293,13 @@ function createTelnetSessionApi(ctx) {
             } catch { return true; }
           },
           getWebContents() {
-            return electronModule.webContents.fromId(telnetWebContentsId);
+            return getCurrentTelnetWebContents();
           },
           selectUploadFiles: selectZmodemUploadFiles
-            ? () => selectZmodemUploadFiles(telnetWebContentsId)
+            ? () => selectZmodemUploadFiles(getCurrentTelnetWebContentsId())
             : undefined,
           selectDownloadDirectory: selectZmodemDownloadDirectory
-            ? () => selectZmodemDownloadDirectory(telnetWebContentsId)
+            ? () => selectZmodemDownloadDirectory(getCurrentTelnetWebContentsId())
             : undefined,
           label: "Telnet",
         });

--- a/electron/bridges/terminalBridge/telnetSession.cjs
+++ b/electron/bridges/terminalBridge/telnetSession.cjs
@@ -5,6 +5,7 @@ const {
   shouldAcceptSessionOutput,
   shouldProcessSessionOutput,
 } = require("../terminalFlowAck.cjs");
+const { fanoutSessionExit } = require("../terminalAttachRestore.cjs");
 
 const TELNET_SESSION_REPLACED_ERROR = "Telnet session start was replaced";
 
@@ -343,7 +344,7 @@ function createTelnetSessionApi(ctx) {
               if (session) {
                 session.zmodemSentry?.cancel();
                 const contents = electronModule.webContents.fromId(session.webContentsId);
-                contents?.send("netcatty:exit", { sessionId, exitCode: 1, error: err.message, reason: "error" });
+                fanoutSessionExit(sessionId, session?.webContentsId ?? contents?.id, { sessionId, exitCode: 1, error: err.message, reason: "error" });
               }
               ptyProcessTree.unregisterPid(sessionId);
               closeTerminalOutputSession?.(sessionId);
@@ -369,7 +370,7 @@ function createTelnetSessionApi(ctx) {
             if (session) {
               session.zmodemSentry?.cancel();
               const contents = electronModule.webContents.fromId(session.webContentsId);
-              contents?.send("netcatty:exit", { sessionId, exitCode: hadError ? 1 : 0, reason: hadError ? "error" : "closed" });
+              fanoutSessionExit(sessionId, session?.webContentsId ?? contents?.id, { sessionId, exitCode: hadError ? 1 : 0, reason: hadError ? "error" : "closed" });
             }
             ptyProcessTree.unregisterPid(sessionId);
             closeTerminalOutputSession?.(sessionId);

--- a/electron/bridges/terminalOutputChannel.cjs
+++ b/electron/bridges/terminalOutputChannel.cjs
@@ -39,6 +39,17 @@ function createTerminalOutputChannel(options = {}) {
     return true;
   }
 
+  function drainSession(sessionId, requestId) {
+    const entry = sessions.get(sessionId);
+    if (!entry || entry.transferToWorker || !requestId) return false;
+    try {
+      entry.port.postMessage({ kind: "drain", sessionId, requestId });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   function closeSession(sessionId) {
     const entry = sessions.get(sessionId);
     if (!entry) return;
@@ -56,6 +67,7 @@ function createTerminalOutputChannel(options = {}) {
   return {
     openSession,
     send,
+    drainSession,
     closeSession,
     closeAll,
     getSessionForTest: (sessionId) => sessions.get(sessionId),

--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -372,17 +372,27 @@ function createTerminalWorkerManager(options = {}) {
     }
   }
 
+  function isLiveWebContentsId(webContentsId) {
+    if (typeof webContentsId !== "number") return false;
+    try {
+      const contents = electronModule?.webContents?.fromId?.(webContentsId);
+      return Boolean(contents && !contents.isDestroyed?.());
+    } catch {
+      return false;
+    }
+  }
+
   function openOutputSession(sessionId, webContentsId) {
     if (!sessionId || !webContentsId) return false;
     if (closedSessions.has(sessionId)) {
       clearBufferedOutput(sessionId);
       return false;
     }
-    sessionWebContentsIds.set(sessionId, webContentsId);
     const contents = electronModule?.webContents?.fromId?.(webContentsId);
     if (!contents || contents.isDestroyed?.()) {
       return false;
     }
+    sessionWebContentsIds.set(sessionId, webContentsId);
     openUrgentInputPort(webContentsId, contents);
     const outputPort = terminalOutputChannel?.openSession?.(sessionId, contents, {
       transferToWorker: true,
@@ -435,6 +445,23 @@ function createTerminalWorkerManager(options = {}) {
     };
   }
 
+  function findFallbackHomeWebContentsId(preferredId) {
+    if (isLiveWebContentsId(preferredId)) return preferredId;
+    try {
+      const wins = electronModule?.BrowserWindow?.getAllWindows?.() || [];
+      for (const win of wins) {
+        const wc = win?.webContents;
+        if (!wc || wc.isDestroyed?.()) continue;
+        const url = typeof wc.getURL === "function" ? wc.getURL() : "";
+        if (url.includes("#/terminal-popup") || url.includes("#/tray")) continue;
+        if (typeof wc.id === "number") return wc.id;
+      }
+    } catch {
+      // ignore
+    }
+    return null;
+  }
+
   function restoreAttachHome(sessionId) {
     if (!sessionId) return { success: false, restored: false };
     // Unpause backend if the observe popup left flow paused under pressure.
@@ -443,22 +470,45 @@ function createTerminalWorkerManager(options = {}) {
     } catch {
       // ignore
     }
-    const homeId = attachHomeWebContentsIds.get(sessionId);
-    if (homeId == null) {
+    const savedHomeId = attachHomeWebContentsIds.get(sessionId);
+    if (savedHomeId == null) {
       return { success: true, restored: false };
     }
     if (closedSessions.has(sessionId)) {
       attachHomeWebContentsIds.delete(sessionId);
       return { success: true, restored: false };
     }
+    const homeId = findFallbackHomeWebContentsId(savedHomeId);
+    if (homeId == null) {
+      // Keep the attach-home mapping so a later tray re-open can still recover.
+      return {
+        success: false,
+        restored: false,
+        error: "Home renderer unavailable",
+      };
+    }
     const ok = openOutputSession(sessionId, homeId);
-    attachHomeWebContentsIds.delete(sessionId);
+    if (ok) {
+      attachHomeWebContentsIds.delete(sessionId);
+    }
     return {
       success: ok,
       restored: ok,
       webContentsId: ok ? homeId : undefined,
       error: ok ? undefined : "Failed to restore attach home output",
     };
+  }
+
+  function resolveDialogWebContentsId(webContentsId) {
+    // Worker dialogs often still carry the original home id after rebind.
+    // Prefer the current display route when this id is a remembered attach home.
+    if (typeof webContentsId !== "number") return webContentsId;
+    for (const [sessionId, homeId] of attachHomeWebContentsIds.entries()) {
+      if (homeId !== webContentsId) continue;
+      const current = sessionWebContentsIds.get(sessionId);
+      if (isLiveWebContentsId(current)) return current;
+    }
+    return webContentsId;
   }
 
   function getAttachHomeWebContentsId(sessionId) {
@@ -636,7 +686,8 @@ function createTerminalWorkerManager(options = {}) {
 
   async function handleZmodemUploadDialogRequest(message) {
     try {
-      const contents = electronModule?.webContents?.fromId?.(message.webContentsId);
+      const webContentsId = resolveDialogWebContentsId(message.webContentsId);
+      const contents = electronModule?.webContents?.fromId?.(webContentsId);
       const win = contents && electronModule?.BrowserWindow?.fromWebContents
         ? electronModule.BrowserWindow.fromWebContents(contents)
         : null;
@@ -660,7 +711,8 @@ function createTerminalWorkerManager(options = {}) {
 
   async function handleZmodemDownloadDialogRequest(message) {
     try {
-      const contents = electronModule?.webContents?.fromId?.(message.webContentsId);
+      const webContentsId = resolveDialogWebContentsId(message.webContentsId);
+      const contents = electronModule?.webContents?.fromId?.(webContentsId);
       const win = contents && electronModule?.BrowserWindow?.fromWebContents
         ? electronModule.BrowserWindow.fromWebContents(contents)
         : null;
@@ -686,16 +738,22 @@ function createTerminalWorkerManager(options = {}) {
     const error = new Error(`Terminal worker exited${Number.isFinite(code) ? ` with code ${code}` : ""}`);
     const exitCode = Number.isFinite(code) ? code : 1;
     for (const [sessionId, webContentsId] of sessionWebContentsIds.entries()) {
-      try {
-        const contents = electronModule?.webContents?.fromId?.(webContentsId);
-        contents?.send?.("netcatty:exit", {
-          sessionId,
-          exitCode,
-          error: error.message,
-          reason: "error",
-        });
-      } catch {
-        // Ignore renderer notification failures while unwinding a crashed worker.
+      const targets = new Set();
+      if (webContentsId != null) targets.add(webContentsId);
+      const homeId = attachHomeWebContentsIds.get(sessionId);
+      if (homeId != null) targets.add(homeId);
+      for (const targetId of targets) {
+        try {
+          const contents = electronModule?.webContents?.fromId?.(targetId);
+          contents?.send?.("netcatty:exit", {
+            sessionId,
+            exitCode,
+            error: error.message,
+            reason: "error",
+          });
+        } catch {
+          // Ignore renderer notification failures while unwinding a crashed worker.
+        }
       }
     }
     child = null;
@@ -705,6 +763,7 @@ function createTerminalWorkerManager(options = {}) {
     outputPortPending.clear();
     outputPortReady.clear();
     sessionWebContentsIds.clear();
+    attachHomeWebContentsIds.clear();
     urgentInputWebContentsIds.clear();
     terminalOutputChannel?.closeAll?.();
     rejectAllPending(error);

--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -171,7 +171,7 @@ function createTerminalWorkerManager(options = {}) {
   const outputPortPending = new Set();
   const outputPortReady = new Set();
   const sessionWebContentsIds = new Map();
-  const urgentInputWebContentsIds = new Set();
+  const urgentInputPorts = new Map();
   const outputTaps = new Set();
   const maxPendingOutputChunks = Number.isFinite(options.maxPendingOutputChunks)
     ? Math.max(0, Math.trunc(options.maxPendingOutputChunks))
@@ -465,14 +465,8 @@ function createTerminalWorkerManager(options = {}) {
     return null;
   }
 
-  function restoreAttachHome(sessionId) {
+  function restoreAttachHome(sessionId, preferredHomeWebContentsId = null) {
     if (!sessionId) return { success: false, restored: false };
-    // Unpause backend if the observe popup left flow paused under pressure.
-    try {
-      send("netcatty:flow", { sessionId, paused: false }, {});
-    } catch {
-      // ignore
-    }
     const savedHomeId = attachHomeWebContentsIds.get(sessionId);
     if (savedHomeId == null) {
       return { success: true, restored: false };
@@ -481,7 +475,7 @@ function createTerminalWorkerManager(options = {}) {
       attachHomeWebContentsIds.delete(sessionId);
       return { success: true, restored: false };
     }
-    const homeId = findFallbackHomeWebContentsId(savedHomeId);
+    const homeId = findFallbackHomeWebContentsId(preferredHomeWebContentsId ?? savedHomeId);
     if (homeId == null) {
       // Keep the attach-home mapping so a later tray re-open can still recover.
       return {
@@ -538,8 +532,18 @@ function createTerminalWorkerManager(options = {}) {
     terminalOutputChannel?.closeSession?.(sessionId);
   }
 
+  function drainOutputSession(sessionId, requestId) {
+    if (!sessionId || !requestId || !outputPortReady.has(sessionId)) return false;
+    try {
+      ensureStarted().postMessage({ kind: "output-drain", sessionId, requestId });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   function openUrgentInputPort(webContentsId, contents) {
-    if (!webContentsId || urgentInputWebContentsIds.has(webContentsId)) return false;
+    if (!webContentsId || urgentInputPorts.has(webContentsId)) return false;
     if (typeof MessageChannelMain !== "function" || !contents?.postMessage || !child?.postMessage) {
       return false;
     }
@@ -550,12 +554,31 @@ function createTerminalWorkerManager(options = {}) {
         webContentsId,
       }, [port1]);
       contents.postMessage(TERMINAL_URGENT_INPUT_PORT_CHANNEL, {}, [port2]);
-      urgentInputWebContentsIds.add(webContentsId);
+      const onDestroyed = () => closeUrgentInputPort(webContentsId);
+      urgentInputPorts.set(webContentsId, { port1, port2, contents, onDestroyed });
+      contents.once?.("destroyed", onDestroyed);
       return true;
     } catch {
       try { port1?.close?.(); } catch {}
       try { port2?.close?.(); } catch {}
+      try { child?.postMessage?.({ kind: "close-urgent-input-port", webContentsId }); } catch {}
       return false;
+    }
+  }
+
+  function closeUrgentInputPort(webContentsId) {
+    const entry = urgentInputPorts.get(webContentsId);
+    if (!entry) return;
+    urgentInputPorts.delete(webContentsId);
+    entry.contents?.removeListener?.("destroyed", entry.onDestroyed);
+    try { entry.port1?.close?.(); } catch {}
+    try { entry.port2?.close?.(); } catch {}
+    try { child?.postMessage?.({ kind: "close-urgent-input-port", webContentsId }); } catch {}
+  }
+
+  function closeAllUrgentInputPorts() {
+    for (const webContentsId of Array.from(urgentInputPorts.keys())) {
+      closeUrgentInputPort(webContentsId);
     }
   }
 
@@ -658,8 +681,11 @@ function createTerminalWorkerManager(options = {}) {
       }
       const targets = new Set();
       if (displayWebContentsId != null) targets.add(displayWebContentsId);
-      // Keep the original owner in the loop for lifecycle (status/tray cleanup).
-      if (homeWebContentsId != null) targets.add(homeWebContentsId);
+      // Keep the original owner in the loop only for terminal lifecycle. Other
+      // renderer events may be interactive and must have a single responder.
+      if (message.channel === "netcatty:exit" && homeWebContentsId != null) {
+        targets.add(homeWebContentsId);
+      }
       if (targets.size === 0 && message.webContentsId != null) {
         targets.add(message.webContentsId);
       }
@@ -767,7 +793,7 @@ function createTerminalWorkerManager(options = {}) {
     outputPortReady.clear();
     sessionWebContentsIds.clear();
     attachHomeWebContentsIds.clear();
-    urgentInputWebContentsIds.clear();
+    closeAllUrgentInputPorts();
     terminalOutputChannel?.closeAll?.();
     rejectAllPending(error);
   }
@@ -837,7 +863,7 @@ function createTerminalWorkerManager(options = {}) {
       outputPortPending.clear();
       outputPortReady.clear();
       sessionWebContentsIds.clear();
-      urgentInputWebContentsIds.clear();
+      closeAllUrgentInputPorts();
       terminalOutputChannel?.closeAll?.();
       rejectAllPending(new Error("Terminal worker stopped"));
     }
@@ -849,6 +875,7 @@ function createTerminalWorkerManager(options = {}) {
     send,
     openOutputSession,
     rebindOutputSession,
+    drainOutputSession,
     restoreAttachHome,
     getAttachHomeWebContentsId,
     clearAttachHome,

--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -447,13 +447,16 @@ function createTerminalWorkerManager(options = {}) {
 
   function findFallbackHomeWebContentsId(preferredId) {
     if (isLiveWebContentsId(preferredId)) return preferredId;
+    // Only fall back to registered main app windows — never settings/prewarm/
+    // tray/popup renderers, which cannot host the hidden silent Terminal.
     try {
-      const wins = electronModule?.BrowserWindow?.getAllWindows?.() || [];
-      for (const win of wins) {
+      const wm = require("./windowManager.cjs");
+      const mains = typeof wm.getMainWindows === "function"
+        ? wm.getMainWindows()
+        : (typeof wm.getMainWindow === "function" ? [wm.getMainWindow()].filter(Boolean) : []);
+      for (const win of mains) {
         const wc = win?.webContents;
         if (!wc || wc.isDestroyed?.()) continue;
-        const url = typeof wc.getURL === "function" ? wc.getURL() : "";
-        if (url.includes("#/terminal-popup") || url.includes("#/tray")) continue;
         if (typeof wc.id === "number") return wc.id;
       }
     } catch {

--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -373,13 +373,16 @@ function createTerminalWorkerManager(options = {}) {
   }
 
   function openOutputSession(sessionId, webContentsId) {
-    if (!sessionId || !webContentsId) return;
+    if (!sessionId || !webContentsId) return false;
     if (closedSessions.has(sessionId)) {
       clearBufferedOutput(sessionId);
-      return;
+      return false;
     }
     sessionWebContentsIds.set(sessionId, webContentsId);
     const contents = electronModule?.webContents?.fromId?.(webContentsId);
+    if (!contents || contents.isDestroyed?.()) {
+      return false;
+    }
     openUrgentInputPort(webContentsId, contents);
     const outputPort = terminalOutputChannel?.openSession?.(sessionId, contents, {
       transferToWorker: true,
@@ -391,9 +394,33 @@ function createTerminalWorkerManager(options = {}) {
         sessionId,
         bufferedOutput: takeBufferedOutput(sessionId),
       }, [outputPort]);
-      return;
+      return true;
     }
     flushBufferedOutput(sessionId);
+    return true;
+  }
+
+  /**
+   * Move a live session's renderer output route to another webContents
+   * (AI silent-session observe popup). Same PTY; only the display target changes.
+   */
+  function rebindOutputSession(sessionId, webContentsId) {
+    if (!sessionId || !webContentsId) {
+      return { success: false, error: "Missing sessionId or webContentsId" };
+    }
+    if (closedSessions.has(sessionId) || !sessionWebContentsIds.has(sessionId)) {
+      return { success: false, error: "Session not found" };
+    }
+    const previousWebContentsId = sessionWebContentsIds.get(sessionId) ?? null;
+    const ok = openOutputSession(sessionId, webContentsId);
+    if (!ok) {
+      return { success: false, error: "Failed to rebind session output" };
+    }
+    return {
+      success: true,
+      previousWebContentsId,
+      webContentsId,
+    };
   }
 
   function closeOutputSession(sessionId) {
@@ -687,12 +714,18 @@ function createTerminalWorkerManager(options = {}) {
     ensureStarted,
     request,
     send,
+    openOutputSession,
+    rebindOutputSession,
     hasOpenSession(sessionId) {
       return Boolean(
         sessionId
         && sessionWebContentsIds.has(sessionId)
         && !closedSessions.has(sessionId),
       );
+    },
+    getSessionWebContentsId(sessionId) {
+      if (!sessionId) return null;
+      return sessionWebContentsIds.get(sessionId) ?? null;
     },
     addOutputTap(listener) {
       if (typeof listener !== "function") return () => {};

--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -543,14 +543,23 @@ function createTerminalWorkerManager(options = {}) {
       return;
     }
     if (message.kind === "renderer-event") {
-      if (message.channel === "netcatty:exit" && message.payload?.sessionId) {
-        closeOutputSession(message.payload.sessionId);
+      // Prefer the currently rebound display target. Worker-captured
+      // webContentsId is from session start and goes stale after attach/rebind.
+      const sessionId = message.payload?.sessionId;
+      const targetWebContentsId =
+        (typeof sessionId === "string" && sessionWebContentsIds.get(sessionId))
+        || message.webContentsId;
+      if (message.channel === "netcatty:exit" && sessionId) {
+        closeOutputSession(sessionId);
       }
       if (onRendererEvent) {
-        onRendererEvent(message);
+        onRendererEvent({
+          ...message,
+          webContentsId: targetWebContentsId,
+        });
         return;
       }
-      const contents = electronModule?.webContents?.fromId?.(message.webContentsId);
+      const contents = electronModule?.webContents?.fromId?.(targetWebContentsId);
       contents?.send?.(message.channel, message.payload);
       return;
     }

--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -437,6 +437,12 @@ function createTerminalWorkerManager(options = {}) {
 
   function restoreAttachHome(sessionId) {
     if (!sessionId) return { success: false, restored: false };
+    // Unpause backend if the observe popup left flow paused under pressure.
+    try {
+      send("netcatty:flow", { sessionId, paused: false }, {});
+    } catch {
+      // ignore
+    }
     const homeId = attachHomeWebContentsIds.get(sessionId);
     if (homeId == null) {
       return { success: true, restored: false };

--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -154,6 +154,15 @@ function mergeTerminalOutputMeta(previous, next) {
   return merged;
 }
 
+const SESSION_START_CHANNELS = new Set([
+  "netcatty:start",
+  "netcatty:local:start",
+  "netcatty:telnet:start",
+  "netcatty:mosh:start",
+  "netcatty:et:start",
+  "netcatty:serial:start",
+]);
+
 function createTerminalWorkerManager(options = {}) {
   const {
     utilityProcess,
@@ -524,12 +533,33 @@ function createTerminalWorkerManager(options = {}) {
     outputPortPending.delete(sessionId);
     outputPortReady.delete(sessionId);
     sessionWebContentsIds.delete(sessionId);
+    clearAttachHome(sessionId);
     try {
       child?.postMessage?.({ kind: "close-output-port", sessionId });
     } catch {
       // The worker may already be gone while closing a tab or quitting.
     }
     terminalOutputChannel?.closeSession?.(sessionId);
+  }
+
+  function notifyExplicitSessionClose(sessionId) {
+    if (!sessionId) return;
+    const targets = new Set([
+      sessionWebContentsIds.get(sessionId),
+      attachHomeWebContentsIds.get(sessionId),
+    ]);
+    for (const targetId of targets) {
+      if (typeof targetId !== "number") continue;
+      try {
+        electronModule?.webContents?.fromId?.(targetId)?.send?.("netcatty:exit", {
+          sessionId,
+          exitCode: 0,
+          reason: "closed",
+        });
+      } catch {
+        // A closing renderer may disappear between lookup and notification.
+      }
+    }
   }
 
   function drainOutputSession(sessionId, requestId) {
@@ -675,10 +705,18 @@ function createTerminalWorkerManager(options = {}) {
       const homeWebContentsId =
         (typeof sessionId === "string" && attachHomeWebContentsIds.get(sessionId))
         || null;
+      const wasExplicitlyClosed = Boolean(
+        message.channel === "netcatty:exit"
+        && sessionId
+        && closedSessions.has(sessionId),
+      );
       if (message.channel === "netcatty:exit" && sessionId) {
         closeOutputSession(sessionId);
         clearAttachHome(sessionId);
       }
+      // Explicit close already notified both display and home before removing
+      // their routes. Ignore the worker's later transport-level exit event.
+      if (wasExplicitlyClosed) return;
       const targets = new Set();
       if (displayWebContentsId != null) targets.add(displayWebContentsId);
       // Keep the original owner in the loop only for terminal lifecycle. Other
@@ -816,8 +854,9 @@ function createTerminalWorkerManager(options = {}) {
       pending.set(requestId, { resolve, reject, webContentsId: optionsForRequest.webContentsId });
     });
     if (channel === "netcatty:close:await" && payload?.sessionId) {
+      notifyExplicitSessionClose(payload.sessionId);
       closeOutputSession(payload.sessionId);
-    } else if (payload?.sessionId) {
+    } else if (payload?.sessionId && SESSION_START_CHANNELS.has(channel)) {
       closedSessions.delete(payload.sessionId);
     }
     worker.postMessage({
@@ -832,6 +871,7 @@ function createTerminalWorkerManager(options = {}) {
 
   function send(channel, payload, optionsForSend = {}) {
     if (channel === "netcatty:close" && payload?.sessionId) {
+      notifyExplicitSessionClose(payload.sessionId);
       closeOutputSession(payload.sessionId);
     }
     if (channel === "netcatty:interrupt") {

--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -404,6 +404,9 @@ function createTerminalWorkerManager(options = {}) {
    * Move a live session's renderer output route to another webContents
    * (AI silent-session observe popup). Same PTY; only the display target changes.
    */
+  /** sessionId -> home webContentsId while an attach/observe popup owns display */
+  const attachHomeWebContentsIds = new Map();
+
   function rebindOutputSession(sessionId, webContentsId) {
     if (!sessionId || !webContentsId) {
       return { success: false, error: "Missing sessionId or webContentsId" };
@@ -412,6 +415,15 @@ function createTerminalWorkerManager(options = {}) {
       return { success: false, error: "Session not found" };
     }
     const previousWebContentsId = sessionWebContentsIds.get(sessionId) ?? null;
+    // Remember the first home target so popup destruction / session exit can
+    // restore or dual-notify the original owner.
+    if (
+      previousWebContentsId != null
+      && previousWebContentsId !== webContentsId
+      && !attachHomeWebContentsIds.has(sessionId)
+    ) {
+      attachHomeWebContentsIds.set(sessionId, previousWebContentsId);
+    }
     const ok = openOutputSession(sessionId, webContentsId);
     if (!ok) {
       return { success: false, error: "Failed to rebind session output" };
@@ -421,6 +433,35 @@ function createTerminalWorkerManager(options = {}) {
       previousWebContentsId,
       webContentsId,
     };
+  }
+
+  function restoreAttachHome(sessionId) {
+    if (!sessionId) return { success: false, restored: false };
+    const homeId = attachHomeWebContentsIds.get(sessionId);
+    if (homeId == null) {
+      return { success: true, restored: false };
+    }
+    if (closedSessions.has(sessionId)) {
+      attachHomeWebContentsIds.delete(sessionId);
+      return { success: true, restored: false };
+    }
+    const ok = openOutputSession(sessionId, homeId);
+    attachHomeWebContentsIds.delete(sessionId);
+    return {
+      success: ok,
+      restored: ok,
+      webContentsId: ok ? homeId : undefined,
+      error: ok ? undefined : "Failed to restore attach home output",
+    };
+  }
+
+  function getAttachHomeWebContentsId(sessionId) {
+    if (!sessionId) return null;
+    return attachHomeWebContentsIds.get(sessionId) ?? null;
+  }
+
+  function clearAttachHome(sessionId) {
+    if (sessionId) attachHomeWebContentsIds.delete(sessionId);
   }
 
   function closeOutputSession(sessionId) {
@@ -546,21 +587,36 @@ function createTerminalWorkerManager(options = {}) {
       // Prefer the currently rebound display target. Worker-captured
       // webContentsId is from session start and goes stale after attach/rebind.
       const sessionId = message.payload?.sessionId;
-      const targetWebContentsId =
+      const displayWebContentsId =
         (typeof sessionId === "string" && sessionWebContentsIds.get(sessionId))
         || message.webContentsId;
+      const homeWebContentsId =
+        (typeof sessionId === "string" && attachHomeWebContentsIds.get(sessionId))
+        || null;
       if (message.channel === "netcatty:exit" && sessionId) {
         closeOutputSession(sessionId);
+        clearAttachHome(sessionId);
+      }
+      const targets = new Set();
+      if (displayWebContentsId != null) targets.add(displayWebContentsId);
+      // Keep the original owner in the loop for lifecycle (status/tray cleanup).
+      if (homeWebContentsId != null) targets.add(homeWebContentsId);
+      if (targets.size === 0 && message.webContentsId != null) {
+        targets.add(message.webContentsId);
       }
       if (onRendererEvent) {
-        onRendererEvent({
-          ...message,
-          webContentsId: targetWebContentsId,
-        });
+        for (const webContentsId of targets) {
+          onRendererEvent({
+            ...message,
+            webContentsId,
+          });
+        }
         return;
       }
-      const contents = electronModule?.webContents?.fromId?.(targetWebContentsId);
-      contents?.send?.(message.channel, message.payload);
+      for (const webContentsId of targets) {
+        const contents = electronModule?.webContents?.fromId?.(webContentsId);
+        contents?.send?.(message.channel, message.payload);
+      }
       return;
     }
     if (message.kind === "zmodem-upload-dialog") {
@@ -725,6 +781,9 @@ function createTerminalWorkerManager(options = {}) {
     send,
     openOutputSession,
     rebindOutputSession,
+    restoreAttachHome,
+    getAttachHomeWebContentsId,
+    clearAttachHome,
     hasOpenSession(sessionId) {
       return Boolean(
         sessionId

--- a/electron/bridges/terminalWorkerManager.test.cjs
+++ b/electron/bridges/terminalWorkerManager.test.cjs
@@ -1126,6 +1126,68 @@ test("rebound interactive events target only the popup while exit also reaches h
   ]);
 });
 
+test("explicit close notifies both a rebound popup and its home renderer", async () => {
+  const child = new FakeChild();
+  const forwarded = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: { openSession: () => true, closeSession() {} },
+    electronModule: {
+      webContents: {
+        fromId: (id) => ({
+          id,
+          isDestroyed: () => false,
+          send: (channel, payload) => forwarded.push({ id, channel, payload }),
+        }),
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  const started = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages[0].requestId,
+    result: { sessionId: "session-1" },
+  });
+  await started;
+  assert.equal(manager.rebindOutputSession("session-1", 9).success, true);
+
+  const closing = manager.request(
+    "netcatty:close:await",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  const closeRequest = child.messages.at(-1);
+  child.emit("message", { kind: "response", requestId: closeRequest.requestId, result: undefined });
+  await closing;
+
+  assert.deepEqual(forwarded, [
+    { id: 9, channel: "netcatty:exit", payload: { sessionId: "session-1", exitCode: 0, reason: "closed" } },
+    { id: 7, channel: "netcatty:exit", payload: { sessionId: "session-1", exitCode: 0, reason: "closed" } },
+  ]);
+  assert.equal(manager.getAttachHomeWebContentsId("session-1"), null);
+  assert.equal(manager.hasOpenSession("session-1"), false);
+
+  child.emit("message", {
+    kind: "renderer-event",
+    webContentsId: 7,
+    channel: "netcatty:exit",
+    payload: { sessionId: "session-1", reason: "closed" },
+  });
+  assert.equal(forwarded.length, 2, "worker transport close is not forwarded twice");
+
+  const lateFlow = manager.request(
+    "netcatty:terminal:setFlowPausedAndWait",
+    { sessionId: "session-1", paused: true },
+    { webContentsId: 9 },
+  );
+  const flowRequest = child.messages.at(-1);
+  child.emit("message", { kind: "response", requestId: flowRequest.requestId, result: { success: false } });
+  await lateFlow;
+  assert.equal(manager.hasOpenSession("session-1"), false, "late control requests cannot reopen a closed session");
+});
+
 test("worker exit events close the session output route", () => {
   const child = new FakeChild();
   const closed = [];

--- a/electron/bridges/terminalWorkerManager.test.cjs
+++ b/electron/bridges/terminalWorkerManager.test.cjs
@@ -323,6 +323,58 @@ test("request transfers a dedicated urgent input port to the worker and renderer
   assert.deepEqual(rendererMessages[0].transferList.map((port) => port.label), ["port2"]);
 });
 
+test("destroying a renderer closes its dedicated urgent input port", async () => {
+  const child = new FakeChild();
+  const contents = new EventEmitter();
+  contents.id = 7;
+  contents.postMessage = () => {};
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    MessageChannelMain: FakeMessageChannelMain,
+    electronModule: { webContents: { fromId: () => contents } },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  const promise = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages[0].requestId,
+    result: { sessionId: "local-1" },
+  });
+  await promise;
+  contents.emit("destroyed");
+
+  assert.ok(child.messages.some((message) => (
+    message.kind === "close-urgent-input-port" && message.webContentsId === 7
+  )));
+});
+
+test("failed renderer urgent-input transfer closes the worker port", async () => {
+  const child = new FakeChild();
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    MessageChannelMain: FakeMessageChannelMain,
+    electronModule: {
+      webContents: {
+        fromId: () => ({ id: 7, postMessage() { throw new Error("destroyed"); } }),
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  const promise = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages[0].requestId,
+    result: { sessionId: "local-1" },
+  });
+  await promise;
+
+  assert.ok(child.messages.some((message) => (
+    message.kind === "close-urgent-input-port" && message.webContentsId === 7
+  )));
+});
+
 test("output-port-ready flushes output that arrived during port transfer", async () => {
   const child = new FakeChild();
   const outputPort = { label: "worker-output-port" };
@@ -1014,6 +1066,63 @@ test("worker renderer events wrapped in MessageEvent data are forwarded", () => 
         transferType: "download",
       },
     },
+  ]);
+});
+
+test("rebound interactive events target only the popup while exit also reaches home", async () => {
+  const child = new FakeChild();
+  const forwarded = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork() { return child; } },
+    terminalOutputChannel: {
+      openSession() { return true; },
+      closeSession() {},
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return {
+            id,
+            isDestroyed() { return false; },
+            send(channel, payload) { forwarded.push({ id, channel, payload }); },
+          };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  const started = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages[0].requestId,
+    result: { sessionId: "session-1" },
+  });
+  await started;
+  assert.equal(manager.rebindOutputSession("session-1", 9).success, true);
+
+  child.emit("message", {
+    kind: "renderer-event",
+    webContentsId: 7,
+    channel: "netcatty:zmodem:overwrite-request",
+    payload: { sessionId: "session-1", requestId: "request-1" },
+  });
+  assert.deepEqual(forwarded, [{
+    id: 9,
+    channel: "netcatty:zmodem:overwrite-request",
+    payload: { sessionId: "session-1", requestId: "request-1" },
+  }]);
+
+  forwarded.length = 0;
+  child.emit("message", {
+    kind: "renderer-event",
+    webContentsId: 7,
+    channel: "netcatty:exit",
+    payload: { sessionId: "session-1", reason: "exited" },
+  });
+  assert.deepEqual(forwarded, [
+    { id: 9, channel: "netcatty:exit", payload: { sessionId: "session-1", reason: "exited" } },
+    { id: 7, channel: "netcatty:exit", payload: { sessionId: "session-1", reason: "exited" } },
   ]);
 });
 

--- a/electron/bridges/windowManager/terminalPopupWindow.cjs
+++ b/electron/bridges/windowManager/terminalPopupWindow.cjs
@@ -3,6 +3,7 @@
 const { randomUUID } = require("node:crypto");
 
 const crashLogBridge = require("../crashLogBridge.cjs");
+const { restoreAttachedSessionOutput } = require("../terminalAttachRestore.cjs");
 
 function createTerminalPopupWindowApi(ctx) {
   with (ctx) {
@@ -93,6 +94,17 @@ function createTerminalPopupWindowApi(ctx) {
         terminalPopupWindows.delete(popupId);
         if (attachSessionId && attachSessionPopups.get(attachSessionId) === popupId) {
           attachSessionPopups.delete(attachSessionId);
+          // Window may be destroyed before React cleanup runs; always restore
+          // the display route from the main-process lifecycle.
+          try {
+            restoreAttachedSessionOutput(attachSessionId);
+          } catch (err) {
+            crashLogBridge.captureError?.("terminal-popup", err, {
+              popupId,
+              attachSessionId,
+              step: "restore attach output on close",
+            });
+          }
         }
         unregisterAppContentWindow(win);
         notifyAppContentWindowClosed(win);

--- a/electron/bridges/windowManager/terminalPopupWindow.cjs
+++ b/electron/bridges/windowManager/terminalPopupWindow.cjs
@@ -3,7 +3,14 @@
 const { randomUUID } = require("node:crypto");
 
 const crashLogBridge = require("../crashLogBridge.cjs");
-const { restoreAttachedSessionOutput } = require("../terminalAttachRestore.cjs");
+const {
+  isAttachPopupClosePrepared,
+  registerAttachPopupAuthorization,
+  releaseAttachPopupAuthorization,
+  restoreAttachedSessionOutput,
+} = require("../terminalAttachRestore.cjs");
+
+const ATTACH_CLOSE_PREPARE_TIMEOUT_MS = 2000;
 
 function createTerminalPopupWindowApi(ctx) {
   with (ctx) {
@@ -22,6 +29,7 @@ function createTerminalPopupWindowApi(ctx) {
       const attachSessionId = typeof payload?.attachSessionId === "string" && payload.attachSessionId
         ? payload.attachSessionId
         : null;
+      const attachAuthorization = attachSessionId ? randomUUID() : null;
       if (attachSessionId) {
         const existingPopupId = attachSessionPopups.get(attachSessionId);
         const existing = existingPopupId ? terminalPopupWindows.get(existingPopupId) : null;
@@ -88,9 +96,12 @@ function createTerminalPopupWindowApi(ctx) {
       });
 
       let lifecycleReleased = false;
+      let closePreparationRequested = false;
+      let closePreparationTimer = null;
       const releaseLifecycle = () => {
         if (lifecycleReleased) return;
         lifecycleReleased = true;
+        if (closePreparationTimer) clearTimeout(closePreparationTimer);
         terminalPopupWindows.delete(popupId);
         if (attachSessionId && attachSessionPopups.get(attachSessionId) === popupId) {
           attachSessionPopups.delete(attachSessionId);
@@ -106,12 +117,18 @@ function createTerminalPopupWindowApi(ctx) {
             });
           }
         }
+        releaseAttachPopupAuthorization(attachAuthorization);
         unregisterAppContentWindow(win);
         notifyAppContentWindowClosed(win);
       };
       terminalPopupWindows.set(popupId, { releaseLifecycle, win });
       if (attachSessionId) {
         attachSessionPopups.set(attachSessionId, popupId);
+        registerAttachPopupAuthorization(
+          attachAuthorization,
+          attachSessionId,
+          win.webContents.id,
+        );
       }
       registerAppContentWindow(win);
       crashLogBridge.captureDiagnostic("terminal-popup", "popup BrowserWindow created", {
@@ -128,6 +145,28 @@ function createTerminalPopupWindowApi(ctx) {
         // ignore
       }
 
+      win.on("close", (event) => {
+        if (!attachSessionId || isAttachPopupClosePrepared(attachAuthorization)) return;
+        event?.preventDefault?.();
+        if (closePreparationRequested) return;
+        closePreparationRequested = true;
+        try {
+          win.webContents.send("netcatty:terminal-popup:prepare-close", {
+            sessionId: attachSessionId,
+            authorization: attachAuthorization,
+          });
+        } catch {
+          // Timeout below force-closes and restores the route.
+        }
+        closePreparationTimer = setTimeout(() => {
+          closePreparationTimer = null;
+          try {
+            if (isLiveWindow(win)) win.destroy();
+          } catch {
+            releaseLifecycle();
+          }
+        }, ATTACH_CLOSE_PREPARE_TIMEOUT_MS);
+      });
       win.on("closed", releaseLifecycle);
 
       try {
@@ -141,6 +180,14 @@ function createTerminalPopupWindowApi(ctx) {
         });
         win.webContents?.on?.("render-process-gone", (_event, details) => {
           console.warn("[TerminalPopup] Renderer process gone", { popupId, details });
+          if (attachSessionId) {
+            restoreAttachedSessionOutput(attachSessionId);
+          }
+          try {
+            if (isLiveWindow(win)) win.destroy();
+          } catch {
+            releaseLifecycle();
+          }
         });
         win.webContents?.on?.("console-message", (_event, level, message, line, sourceId) => {
           crashLogBridge.captureDiagnostic("terminal-popup-console", message, {
@@ -204,7 +251,11 @@ function createTerminalPopupWindowApi(ctx) {
           await win.loadURL(`app://netcatty/index.html${popupPath}`);
         }
 
-        win.webContents.send("netcatty:window:terminalPopupConfig", { ...payload, popupId });
+        win.webContents.send("netcatty:window:terminalPopupConfig", {
+          ...payload,
+          popupId,
+          ...(attachAuthorization ? { attachAuthorization } : {}),
+        });
         crashLogBridge.captureDiagnostic("terminal-popup", "popup config delivered", {
           popupId,
           title,

--- a/electron/bridges/windowManager/terminalPopupWindow.cjs
+++ b/electron/bridges/windowManager/terminalPopupWindow.cjs
@@ -7,6 +7,8 @@ const crashLogBridge = require("../crashLogBridge.cjs");
 function createTerminalPopupWindowApi(ctx) {
   with (ctx) {
     const terminalPopupWindows = new Map();
+    /** attachSessionId -> popupId for AI silent-session observe windows */
+    const attachSessionPopups = new Map();
 
     function isLiveWindow(win) {
       return Boolean(win && typeof win.isDestroyed === "function" && !win.isDestroyed());
@@ -15,6 +17,23 @@ function createTerminalPopupWindowApi(ctx) {
     async function openTerminalPopupWindow(electronModule, options, payload) {
       const { BrowserWindow, shell } = electronModule;
       const { preload, devServerUrl, isDev, appIcon, isMac, electronDir, sourceWindow } = options;
+
+      const attachSessionId = typeof payload?.attachSessionId === "string" && payload.attachSessionId
+        ? payload.attachSessionId
+        : null;
+      if (attachSessionId) {
+        const existingPopupId = attachSessionPopups.get(attachSessionId);
+        const existing = existingPopupId ? terminalPopupWindows.get(existingPopupId) : null;
+        if (existing && isLiveWindow(existing.win)) {
+          try {
+            showAndFocusWindow(existing.win);
+          } catch {
+            // ignore focus races
+          }
+          return { success: true, popupId: existingPopupId, reused: true };
+        }
+        if (existingPopupId) attachSessionPopups.delete(attachSessionId);
+      }
 
       const osTheme = electronModule?.nativeTheme?.shouldUseDarkColors ? "dark" : "light";
       const effectiveTheme = currentTheme === "dark" || currentTheme === "light" ? currentTheme : osTheme;
@@ -72,10 +91,16 @@ function createTerminalPopupWindowApi(ctx) {
         if (lifecycleReleased) return;
         lifecycleReleased = true;
         terminalPopupWindows.delete(popupId);
+        if (attachSessionId && attachSessionPopups.get(attachSessionId) === popupId) {
+          attachSessionPopups.delete(attachSessionId);
+        }
         unregisterAppContentWindow(win);
         notifyAppContentWindowClosed(win);
       };
       terminalPopupWindows.set(popupId, { releaseLifecycle, win });
+      if (attachSessionId) {
+        attachSessionPopups.set(attachSessionId, popupId);
+      }
       registerAppContentWindow(win);
       crashLogBridge.captureDiagnostic("terminal-popup", "popup BrowserWindow created", {
         popupId,

--- a/electron/bridges/windowManager/terminalPopupWindow.test.cjs
+++ b/electron/bridges/windowManager/terminalPopupWindow.test.cjs
@@ -5,6 +5,7 @@ const test = require("node:test");
 
 const { createAppContentWindowClosedHandler } = require("../../appWindowLifecycle.cjs");
 const { createTerminalPopupWindowApi } = require("./terminalPopupWindow.cjs");
+const { markAttachPopupClosePrepared } = require("../terminalAttachRestore.cjs");
 
 test("terminal popups participate in the last app-content-window lifecycle", async () => {
   const appContentWindows = new Set();
@@ -207,4 +208,77 @@ test("popup close failures cannot leave a ghost app-content window", async () =>
   assert.doesNotThrow(() => api.closeTerminalPopupWindow("close-failure"));
   assert.deepEqual([...appContentWindows], []);
   assert.equal(closeNotifications, 1);
+});
+
+test("attach popup waits for renderer handoff before closing", async () => {
+  const sent = [];
+  let popupWindow;
+  class AttachBrowserWindowStub {
+    constructor() {
+      popupWindow = this;
+      this.destroyed = false;
+      this.handlers = new Map();
+      this.webContents = {
+        id: 45,
+        on() {},
+        send(channel, payload) { sent.push({ channel, payload }); },
+        setWindowOpenHandler() {},
+      };
+    }
+    on(channel, handler) { this.handlers.set(channel, handler); }
+    isDestroyed() { return this.destroyed; }
+    isVisible() { return true; }
+    loadURL() { return Promise.resolve(); }
+    setBackgroundColor() {}
+    close() {
+      let prevented = false;
+      this.handlers.get("close")?.({ preventDefault() { prevented = true; } });
+      if (!prevented) {
+        this.destroyed = true;
+        this.handlers.get("closed")?.();
+      }
+    }
+    destroy() {
+      this.destroyed = true;
+      this.handlers.get("closed")?.();
+    }
+  }
+  const api = createTerminalPopupWindowApi({
+    mainWindow: null,
+    currentTheme: "light",
+    V8_CACHE_OPTIONS: "bypassHeatCheck",
+    resolveFrontendBackgroundColor() { return "#fff"; },
+    resolveSettingsWindowBounds() { return {}; },
+    createExternalOnlyWindowOpenHandler() { return {}; },
+    applyWindowOpacityToWindow() {},
+    getDevRendererBaseUrl(url) { return url; },
+    showAndFocusWindow() {},
+    registerAppContentWindow() {},
+    unregisterAppContentWindow() {},
+    notifyAppContentWindowClosed() {},
+  });
+
+  await api.openTerminalPopupWindow(
+    { BrowserWindow: AttachBrowserWindowStub, nativeTheme: {}, shell: {} },
+    { preload: "/tmp/preload.cjs", isDev: false, appIcon: null, isMac: false, electronDir: __dirname },
+    {
+      popupId: "attach-popup",
+      title: "Attach",
+      attachSessionId: "session-1",
+      sourceSession: { id: "session-1" },
+    },
+  );
+  const config = sent.find((entry) => entry.channel === "netcatty:window:terminalPopupConfig")?.payload;
+  assert.equal(typeof config.attachAuthorization, "string");
+
+  api.closeTerminalPopupWindow("attach-popup");
+  assert.equal(popupWindow.destroyed, false);
+  assert.deepEqual(sent.at(-1), {
+    channel: "netcatty:terminal-popup:prepare-close",
+    payload: { sessionId: "session-1", authorization: config.attachAuthorization },
+  });
+
+  assert.equal(markAttachPopupClosePrepared(config.attachAuthorization, "session-1", 45), true);
+  api.closeTerminalPopupWindow("attach-popup");
+  assert.equal(popupWindow.destroyed, true);
 });

--- a/electron/bridges/zmodemHelper.cjs
+++ b/electron/bridges/zmodemHelper.cjs
@@ -412,12 +412,11 @@ function createZmodemSentry(opts) {
           ? Buffer.from(zsession._last_ZRINIT.to_hex())
           : null;
 
-      const contents = getWebContents();
       const transferType = zsession.type === "send" ? "upload" : "download";
 
       console.log(`[ZMODEM][${label}] Detected ${transferType} for session ${sessionId}`);
 
-      safeSend(contents, "netcatty:zmodem:detect", {
+      safeSend(getWebContents(), "netcatty:zmodem:detect", {
         sessionId,
         transferType,
       });
@@ -451,13 +450,13 @@ function createZmodemSentry(opts) {
           // Only act if this is still the active session (not replaced by a new one)
           if (currentZSession !== zsession) return;
           console.log(`[ZMODEM][${label}] Transfer completed for session ${sessionId}`);
-          safeSend(contents, "netcatty:zmodem:complete", { sessionId });
+          safeSend(getWebContents(), "netcatty:zmodem:complete", { sessionId });
         })
         .catch((err) => {
           if (currentZSession !== zsession) return;
           console.error(`[ZMODEM][${label}] Transfer error:`, err.message || err);
           try { zsession.abort(); } catch { /* ignore */ }
-          safeSend(contents, "netcatty:zmodem:error", {
+          safeSend(getWebContents(), "netcatty:zmodem:error", {
             sessionId,
             error: String(err.message || err),
           });
@@ -809,7 +808,7 @@ async function handleUpload(zsession, opts) {
     const { filePath, stat, name } = offers[i];
     opts.resetUploadBackpressure?.();
 
-    safeSend(contents, "netcatty:zmodem:progress", {
+    safeSend(getWebContents(), "netcatty:zmodem:progress", {
       sessionId,
       filename: name,
       transferred: 0,
@@ -853,7 +852,7 @@ async function handleUpload(zsession, opts) {
         xfer.send(new Uint8Array(buf.buffer, buf.byteOffset, bytesRead));
         sent += bytesRead;
 
-        safeSend(contents, "netcatty:zmodem:progress", {
+        safeSend(getWebContents(), "netcatty:zmodem:progress", {
           sessionId,
           filename: name,
           transferred: sent,
@@ -871,7 +870,7 @@ async function handleUpload(zsession, opts) {
       // All data written to Node.js buffer — but TCP may still be
       // flushing to the remote.  Show "finalizing" state while we
       // wait for the remote to acknowledge.
-      safeSend(contents, "netcatty:zmodem:progress", {
+      safeSend(getWebContents(), "netcatty:zmodem:progress", {
         sessionId,
         filename: name,
         transferred: stat.size,
@@ -955,7 +954,7 @@ async function handleDownload(zsession, opts) {
     const savePath = path.join(downloadDir, name);
     const currentIndex = fileIndex++;
 
-    safeSend(contents, "netcatty:zmodem:progress", {
+    safeSend(getWebContents(), "netcatty:zmodem:progress", {
       sessionId,
       filename: name,
       transferred: 0,
@@ -1003,7 +1002,7 @@ async function handleDownload(zsession, opts) {
         const now = Date.now();
         if (now - lastProgressTime >= 100) {
           lastProgressTime = now;
-          safeSend(contents, "netcatty:zmodem:progress", {
+          safeSend(getWebContents(), "netcatty:zmodem:progress", {
             sessionId,
             filename: name,
             transferred: received,

--- a/electron/bridges/zmodemHelper.test.cjs
+++ b/electron/bridges/zmodemHelper.test.cjs
@@ -269,6 +269,49 @@ test("handleUpload completes when the remote confirms after progress reaches 100
   fs.rmSync(tempDir, { recursive: true, force: true });
 });
 
+test("handleUpload progress follows a display rebind during transfer", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-zmodem-rebind-"));
+  const filePath = path.join(tempDir, "upload.txt");
+  fs.writeFileSync(filePath, "payload");
+  const events = [];
+  const contents = {
+    home: {
+      isDestroyed: () => false,
+      send: (channel, data) => events.push({ target: "home", channel, data }),
+    },
+    popup: {
+      isDestroyed: () => false,
+      send: (channel, data) => events.push({ target: "popup", channel, data }),
+    },
+  };
+  let target = "home";
+  const zsession = {
+    async send_offer() {
+      return {
+        send() { target = "popup"; },
+        async end() {},
+      };
+    },
+    async close() {},
+  };
+
+  await handleUpload(zsession, {
+    sessionId: "session-1",
+    getWebContents: () => contents[target],
+    takeDragDropUpload: () => ({
+      filePaths: [filePath],
+      remoteNames: ["upload.txt"],
+    }),
+  });
+
+  const progressTargets = events
+    .filter((event) => event.channel === "netcatty:zmodem:progress")
+    .map((event) => event.target);
+  assert.equal(progressTargets[0], "home");
+  assert.deepEqual(progressTargets.slice(1), ["popup", "popup"]);
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
 test("handleUpload uses injected file picker when no drag-drop upload is queued", async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-zmodem-"));
   const filePath = path.join(tempDir, "picker-upload.txt");

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -162,9 +162,9 @@ const _deliverToListeners = createTerminalDataDispatcher({
   shouldDropSession: (sessionId) => closedTerminalDataSessions.has(sessionId),
 });
 
-function scheduleMcpBufferedFlush(sessionId) {
-  if (!_mcpLineBufs.has(sessionId)) return;
-  _mcpFlushTimers.set(sessionId, setTimeout(() => {
+function flushMcpBufferedOutput(sessionId) {
+    const timer = _mcpFlushTimers.get(sessionId);
+    if (timer) clearTimeout(timer);
     const held = _mcpLineBufs.get(sessionId);
     const heldMeta = _mcpLineMetas.get(sessionId);
     _mcpLineBufs.delete(sessionId);
@@ -181,7 +181,11 @@ function scheduleMcpBufferedFlush(sessionId) {
       }));
       _mcpPendingMetas.delete(sessionId);
     }
-  }, 80));
+}
+
+function scheduleMcpBufferedFlush(sessionId) {
+  if (!_mcpLineBufs.has(sessionId)) return;
+  _mcpFlushTimers.set(sessionId, setTimeout(() => flushMcpBufferedOutput(sessionId), 80));
 }
 
 function deliverTerminalData(sessionId, data, options = {}) {
@@ -203,6 +207,7 @@ function deliverTerminalData(sessionId, data, options = {}) {
   scheduleMcpBufferedFlush(sessionId);
 }
 
+const terminalOutputDrainListeners = new Map();
 const terminalOutputPorts = createTerminalOutputPortRegistry({
   ipcRenderer,
   deliverToListeners: _deliverToListeners,
@@ -216,6 +221,12 @@ const terminalOutputPorts = createTerminalOutputPortRegistry({
     return filtered;
   },
   closedTerminalDataSessions,
+  onDrain(sessionId, requestId) {
+    flushMcpBufferedOutput(sessionId);
+    for (const listener of terminalOutputDrainListeners.get(sessionId) || []) {
+      try { listener({ sessionId, requestId }); } catch (err) { console.error("Terminal drain callback failed", err); }
+    }
+  },
 });
 terminalOutputPorts.register();
 
@@ -817,6 +828,7 @@ const api = createPreloadApi({
   moshSessionReadyListeners,
   terminalDataBacklog,
   terminalOutputPorts,
+  terminalOutputDrainListeners,
   terminalUrgentInputPorts,
   languageChangeListeners,
   fullscreenChangeListeners,

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -325,6 +325,10 @@ function createPreloadApi(ctx) {
       ipcRenderer.send("netcatty:close", { sessionId });
     }
   },
+  rebindTerminalSessionOutput: (sessionId) =>
+    ipcRenderer.invoke("netcatty:terminal:rebindOutput", { sessionId }),
+  restoreTerminalSessionOutput: (sessionId, webContentsId) =>
+    ipcRenderer.invoke("netcatty:terminal:restoreOutput", { sessionId, webContentsId }),
   setSessionEncoding: async (sessionId, encoding) => {
     // Try the SSH handler first; it returns { ok: false } for non-SSH
     // sessions (no session.stream). Telnet and serial sessions fall

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -309,6 +309,27 @@ function createPreloadApi(ctx) {
   setSessionFlowPaused: (sessionId, paused) => {
     ipcRenderer.send("netcatty:flow", { sessionId, paused: Boolean(paused) });
   },
+  setSessionFlowPausedAndWait: (sessionId, paused) =>
+    ipcRenderer.invoke("netcatty:terminal:setFlowPausedAndWait", {
+      sessionId,
+      paused: Boolean(paused),
+    }),
+  onTerminalOutputDrainRequest: (sessionId, cb) => {
+    const listeners = ctx.terminalOutputDrainListeners;
+    if (!listeners.has(sessionId)) listeners.set(sessionId, new Set());
+    listeners.get(sessionId).add(cb);
+    return () => {
+      const set = listeners.get(sessionId);
+      set?.delete(cb);
+      if (set?.size === 0) listeners.delete(sessionId);
+    };
+  },
+  respondTerminalOutputDrain: (requestId) => {
+    ipcRenderer.send("netcatty:terminal:output-drain-response", { requestId });
+  },
+  notifyTerminalSessionDisplayReady: (sessionId) => {
+    ipcRenderer.send("netcatty:terminal:display-ready", { sessionId });
+  },
   ackSessionFlow: (sessionId, bytes) => {
     if (!sessionId || !Number.isFinite(bytes) || bytes <= 0) return;
     ipcRenderer.send("netcatty:flow:ack", { sessionId, bytes });
@@ -325,12 +346,12 @@ function createPreloadApi(ctx) {
       ipcRenderer.send("netcatty:close", { sessionId });
     }
   },
-  rebindTerminalSessionOutput: (sessionId) =>
-    ipcRenderer.invoke("netcatty:terminal:rebindOutput", { sessionId }),
-  restoreTerminalSessionOutput: (sessionId, webContentsId) =>
-    ipcRenderer.invoke("netcatty:terminal:restoreOutput", { sessionId, webContentsId }),
-  requestTerminalSessionSnapshot: (sessionId) =>
-    ipcRenderer.invoke("netcatty:terminal:requestSnapshot", { sessionId }),
+  rebindTerminalSessionOutput: (sessionId, authorization) =>
+    ipcRenderer.invoke("netcatty:terminal:rebindOutput", { sessionId, authorization }),
+  restoreTerminalSessionOutput: (sessionId, webContentsId, authorization) =>
+    ipcRenderer.invoke("netcatty:terminal:restoreOutput", { sessionId, webContentsId, authorization }),
+  requestTerminalSessionSnapshot: (sessionId, authorization) =>
+    ipcRenderer.invoke("netcatty:terminal:requestSnapshot", { sessionId, authorization }),
   onTerminalSessionSnapshotRequest: (cb) => {
     const handler = (_event, payload) => {
       try {
@@ -348,18 +369,35 @@ function createPreloadApi(ctx) {
       snapshot: typeof snapshot === "string" ? snapshot : "",
     });
   },
-  applyTerminalSessionSnapshot: (sessionId, snapshot) =>
+  applyTerminalSessionSnapshot: (sessionId, snapshot, authorization) =>
     ipcRenderer.invoke("netcatty:terminal:applySnapshot", {
       sessionId,
       snapshot: typeof snapshot === "string" ? snapshot : "",
+      authorization,
     }),
+  markAttachPopupClosePrepared: (sessionId, authorization) =>
+    ipcRenderer.invoke("netcatty:terminal:markAttachClosePrepared", { sessionId, authorization }),
+  onTerminalPopupPrepareClose: (cb) => {
+    const handler = (_event, payload) => cb?.(payload);
+    ipcRenderer.on("netcatty:terminal-popup:prepare-close", handler);
+    return () => ipcRenderer.removeListener("netcatty:terminal-popup:prepare-close", handler);
+  },
   onTerminalSessionApplySnapshot: (cb) => {
     const handler = (_event, payload) => {
-      try {
-        cb?.(payload);
-      } catch {
-        // ignore provider failures
-      }
+      Promise.resolve().then(() => cb?.(payload)).then(
+        (handled) => {
+          if (handled !== true) return;
+          ipcRenderer.send("netcatty:terminal:apply-snapshot-response", {
+            requestId: payload?.requestId,
+            success: true,
+          });
+        },
+        (err) => ipcRenderer.send("netcatty:terminal:apply-snapshot-response", {
+          requestId: payload?.requestId,
+          success: false,
+          error: err?.message || String(err),
+        }),
+      );
     };
     ipcRenderer.on("netcatty:terminal:apply-snapshot", handler);
     return () => ipcRenderer.removeListener("netcatty:terminal:apply-snapshot", handler);
@@ -470,6 +508,8 @@ function createPreloadApi(ctx) {
     telnetEchoModeListeners.get(sessionId).add(cb);
     return () => telnetEchoModeListeners.get(sessionId)?.delete(cb);
   },
+  getTelnetEchoMode: (sessionId) =>
+    ipcRenderer.invoke("netcatty:telnet:getEchoMode", { sessionId }),
   onAuthFailed: (sessionId, cb) => {
     if (!authFailedListeners.has(sessionId)) authFailedListeners.set(sessionId, new Set());
     authFailedListeners.get(sessionId).add(cb);

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -369,10 +369,18 @@ function createPreloadApi(ctx) {
       snapshot: typeof snapshot === "string" ? snapshot : "",
     });
   },
-  applyTerminalSessionSnapshot: (sessionId, snapshot, authorization) =>
+  applyTerminalSessionSnapshot: (sessionId, snapshot, context, authorization) =>
     ipcRenderer.invoke("netcatty:terminal:applySnapshot", {
       sessionId,
       snapshot: typeof snapshot === "string" ? snapshot : "",
+      contextSnapshot: typeof context?.contextSnapshot === "string" ? context.contextSnapshot : "",
+      contextViewportSnapshot: typeof context?.contextViewportSnapshot === "string"
+        ? context.contextViewportSnapshot
+        : "",
+      contextScrollbackSnapshot: typeof context?.contextScrollbackSnapshot === "string"
+        ? context.contextScrollbackSnapshot
+        : "",
+      alternateScreen: context?.alternateScreen === true,
       authorization,
     }),
   markAttachPopupClosePrepared: (sessionId, authorization) =>

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -329,6 +329,25 @@ function createPreloadApi(ctx) {
     ipcRenderer.invoke("netcatty:terminal:rebindOutput", { sessionId }),
   restoreTerminalSessionOutput: (sessionId, webContentsId) =>
     ipcRenderer.invoke("netcatty:terminal:restoreOutput", { sessionId, webContentsId }),
+  requestTerminalSessionSnapshot: (sessionId) =>
+    ipcRenderer.invoke("netcatty:terminal:requestSnapshot", { sessionId }),
+  onTerminalSessionSnapshotRequest: (cb) => {
+    const handler = (_event, payload) => {
+      try {
+        cb?.(payload);
+      } catch {
+        // Provider failures must not break the main process request.
+      }
+    };
+    ipcRenderer.on("netcatty:terminal:snapshot-request", handler);
+    return () => ipcRenderer.removeListener("netcatty:terminal:snapshot-request", handler);
+  },
+  respondTerminalSessionSnapshot: (requestId, snapshot) => {
+    ipcRenderer.send("netcatty:terminal:snapshot-response", {
+      requestId,
+      snapshot: typeof snapshot === "string" ? snapshot : "",
+    });
+  },
   setSessionEncoding: async (sessionId, encoding) => {
     // Try the SSH handler first; it returns { ok: false } for non-SSH
     // sessions (no session.stream). Telnet and serial sessions fall

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -348,6 +348,22 @@ function createPreloadApi(ctx) {
       snapshot: typeof snapshot === "string" ? snapshot : "",
     });
   },
+  applyTerminalSessionSnapshot: (sessionId, snapshot) =>
+    ipcRenderer.invoke("netcatty:terminal:applySnapshot", {
+      sessionId,
+      snapshot: typeof snapshot === "string" ? snapshot : "",
+    }),
+  onTerminalSessionApplySnapshot: (cb) => {
+    const handler = (_event, payload) => {
+      try {
+        cb?.(payload);
+      } catch {
+        // ignore provider failures
+      }
+    };
+    ipcRenderer.on("netcatty:terminal:apply-snapshot", handler);
+    return () => ipcRenderer.removeListener("netcatty:terminal:apply-snapshot", handler);
+  },
   setSessionEncoding: async (sessionId, encoding) => {
     // Try the SSH handler first; it returns { ok: false } for non-SSH
     // sessions (no session.stream). Telnet and serial sessions fall

--- a/electron/preload/terminalOutputPorts.cjs
+++ b/electron/preload/terminalOutputPorts.cjs
@@ -9,6 +9,7 @@ function createTerminalOutputPortRegistry(options = {}) {
     filterData = null,
     closedTerminalDataSessions = new Set(),
     onPortError = console.error,
+    onDrain = null,
   } = options;
   const ports = new Map();
 
@@ -30,6 +31,10 @@ function createTerminalOutputPortRegistry(options = {}) {
     port.onmessage = (event) => {
       const message = event?.data || {};
       const targetSessionId = message.sessionId || sessionId;
+      if (message.kind === "drain" && message.requestId) {
+        onDrain?.(targetSessionId, message.requestId);
+        return;
+      }
       if (closedTerminalDataSessions.has(targetSessionId)) return;
       if (!message.data) return;
       try {

--- a/electron/preloadTerminalOutputPorts.test.cjs
+++ b/electron/preloadTerminalOutputPorts.test.cjs
@@ -91,6 +91,28 @@ test("terminal output ports forward terminal output metadata", () => {
   ]);
 });
 
+test("terminal output drain marker follows earlier data on the same port", () => {
+  const events = [];
+  const ipcRenderer = createFakeIpcRenderer();
+  const registry = createTerminalOutputPortRegistry({
+    ipcRenderer,
+    deliverToListeners(_sessionId, data) {
+      events.push(`data:${data}`);
+    },
+    onDrain(_sessionId, requestId) {
+      events.push(`drain:${requestId}`);
+    },
+  });
+  const port = createFakePort();
+
+  registry.register();
+  ipcRenderer.emitPort("session-1", port);
+  port.emit({ sessionId: "session-1", data: "tail" });
+  port.emit({ kind: "drain", sessionId: "session-1", requestId: "drain-1" });
+
+  assert.deepEqual(events, ["data:tail", "drain:drain-1"]);
+});
+
 test("terminal output ports filter data before delivery", () => {
   const delivered = [];
   const ipcRenderer = createFakeIpcRenderer();

--- a/electron/terminalWorker/runtime.cjs
+++ b/electron/terminalWorker/runtime.cjs
@@ -59,6 +59,18 @@ function createOutputPortRegistry(parentPort) {
     }
   }
 
+  function postControl(sessionId, message) {
+    const port = outputPorts.get(sessionId);
+    if (!port) return false;
+    try {
+      port.postMessage({ ...message, sessionId });
+      return true;
+    } catch {
+      closeSession(sessionId);
+      return false;
+    }
+  }
+
   function open(sessionId, port, bufferedOutput = []) {
     if (!sessionId || !port) return;
     closeSession(sessionId);
@@ -89,6 +101,7 @@ function createOutputPortRegistry(parentPort) {
   return {
     open,
     post,
+    postControl,
     flush,
     closeSession,
   };
@@ -141,6 +154,7 @@ function createUrgentInputPortRegistry(dispatch) {
 
   return {
     open,
+    close,
     closeAll,
   };
 }
@@ -265,6 +279,10 @@ function createTerminalWorkerRuntime(options = {}) {
       urgentInputPorts?.open(message.webContentsId, ports?.[0]);
       return;
     }
+    if (message?.kind === "close-urgent-input-port") {
+      urgentInputPorts?.close(message.webContentsId);
+      return;
+    }
     if (message?.kind === "output-port") {
       outputPorts.open(message.sessionId, ports?.[0], message.bufferedOutput);
       return;
@@ -275,6 +293,13 @@ function createTerminalWorkerRuntime(options = {}) {
     }
     if (message?.kind === "close-output-port") {
       outputPorts.closeSession(message.sessionId);
+      return;
+    }
+    if (message?.kind === "output-drain") {
+      outputPorts.postControl(message.sessionId, {
+        kind: "drain",
+        requestId: message.requestId,
+      });
       return;
     }
     if (message?.kind === "request") {

--- a/electron/terminalWorker/runtime.test.cjs
+++ b/electron/terminalWorker/runtime.test.cjs
@@ -103,6 +103,38 @@ test("runtime invokes fire-and-forget listeners", () => {
   assert.deepEqual(calls, [{ sessionId: "s1", data: "x" }]);
 });
 
+test("runtime sends output drain markers through the session output port", () => {
+  const parentPort = createParentPort();
+  const outputPort = new FakePort();
+  const runtime = createTerminalWorkerRuntime({ parentPort, registerBridges() {} });
+  runtime.start();
+
+  parentPort.emitMessage({
+    data: { kind: "output-port", sessionId: "s1" },
+    ports: [outputPort],
+  });
+  parentPort.emitMessage({ kind: "output-drain", sessionId: "s1", requestId: "drain-1" });
+
+  assert.deepEqual(outputPort.messages, [
+    { kind: "drain", requestId: "drain-1", sessionId: "s1" },
+  ]);
+});
+
+test("runtime closes an urgent input port when its renderer is destroyed", () => {
+  const parentPort = createParentPort();
+  const urgentPort = new FakePort();
+  const runtime = createTerminalWorkerRuntime({ parentPort, registerBridges() {} });
+  runtime.start();
+  parentPort.emitMessage({
+    data: { kind: "urgent-input-port", webContentsId: 7 },
+    ports: [urgentPort],
+  });
+
+  parentPort.emitMessage({ kind: "close-urgent-input-port", webContentsId: 7 });
+
+  assert.equal(urgentPort.closed, true);
+});
+
 test("runtime routes urgent input port interrupts to the interrupt listener", () => {
   const parentPort = createParentPort();
   const urgentPort = new FakePort();

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -344,7 +344,17 @@ declare global {
     /** Home renderer: reply with serialized scrollback. */
     respondTerminalSessionSnapshot?(requestId: string, snapshot: string): void;
     /** Observe popup: push current state back to the home renderer before restore. */
-    applyTerminalSessionSnapshot?(sessionId: string, snapshot: string, authorization: string): Promise<{
+    applyTerminalSessionSnapshot?(
+      sessionId: string,
+      snapshot: string,
+      context: {
+        contextSnapshot: string;
+        contextViewportSnapshot: string;
+        contextScrollbackSnapshot: string;
+        alternateScreen: boolean;
+      },
+      authorization: string,
+    ): Promise<{
       success: boolean;
       error?: string;
     }>;
@@ -352,7 +362,15 @@ declare global {
     onTerminalPopupPrepareClose?(cb: (payload: { sessionId: string; authorization: string }) => void): () => void;
     /** Home renderer: apply a pushed snapshot from an observe popup. */
     onTerminalSessionApplySnapshot?(
-      cb: (payload: { sessionId: string; snapshot: string; requestId: string }) => boolean | Promise<boolean>,
+      cb: (payload: {
+        sessionId: string;
+        snapshot: string;
+        contextSnapshot: string;
+        contextViewportSnapshot: string;
+        contextScrollbackSnapshot: string;
+        alternateScreen: boolean;
+        requestId: string;
+      }) => boolean | Promise<boolean>,
     ): () => void;
     // ZMODEM file transfer
     onZmodemEvent?(

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -309,10 +309,17 @@ declare global {
     interruptSession?(sessionId: string, trace?: NetcattyTerminalInterruptTrace): void;
     resizeSession(sessionId: string, cols: number, rows: number): void;
     setSessionFlowPaused(sessionId: string, paused: boolean): void;
+    setSessionFlowPausedAndWait?(sessionId: string, paused: boolean): Promise<{ success: boolean; error?: string }>;
+    onTerminalOutputDrainRequest?(
+      sessionId: string,
+      cb: (payload: { sessionId: string; requestId: string }) => void | Promise<void>,
+    ): () => void;
+    respondTerminalOutputDrain?(requestId: string): void;
+    notifyTerminalSessionDisplayReady?(sessionId: string): void;
     ackSessionFlow(sessionId: string, bytes: number): void;
     closeSession(sessionId: string): void | Promise<void>;
     /** Move a live session's output port to this renderer (same PTY). */
-    rebindTerminalSessionOutput?(sessionId: string): Promise<{
+    rebindTerminalSessionOutput?(sessionId: string, authorization: string): Promise<{
       success: boolean;
       previousWebContentsId?: number | null;
       webContentsId?: number;
@@ -322,9 +329,10 @@ declare global {
     restoreTerminalSessionOutput?(
       sessionId: string,
       webContentsId?: number | null,
+      authorization?: string,
     ): Promise<{ success: boolean; restored?: boolean; webContentsId?: number; error?: string }>;
     /** Ask the home renderer to serialize current terminal scrollback. */
-    requestTerminalSessionSnapshot?(sessionId: string): Promise<{
+    requestTerminalSessionSnapshot?(sessionId: string, authorization: string): Promise<{
       success: boolean;
       snapshot?: string;
       error?: string;
@@ -336,13 +344,15 @@ declare global {
     /** Home renderer: reply with serialized scrollback. */
     respondTerminalSessionSnapshot?(requestId: string, snapshot: string): void;
     /** Observe popup: push current state back to the home renderer before restore. */
-    applyTerminalSessionSnapshot?(sessionId: string, snapshot: string): Promise<{
+    applyTerminalSessionSnapshot?(sessionId: string, snapshot: string, authorization: string): Promise<{
       success: boolean;
       error?: string;
     }>;
+    markAttachPopupClosePrepared?(sessionId: string, authorization: string): Promise<{ success: boolean; error?: string }>;
+    onTerminalPopupPrepareClose?(cb: (payload: { sessionId: string; authorization: string }) => void): () => void;
     /** Home renderer: apply a pushed snapshot from an observe popup. */
     onTerminalSessionApplySnapshot?(
-      cb: (payload: { sessionId: string; snapshot: string }) => void,
+      cb: (payload: { sessionId: string; snapshot: string; requestId: string }) => boolean | Promise<boolean>,
     ): () => void;
     // ZMODEM file transfer
     onZmodemEvent?(
@@ -415,6 +425,13 @@ declare global {
       sessionId: string,
       cb: (evt: { sessionId: string; remoteEcho: boolean; localEcho: boolean }) => void
     ): () => void;
+    getTelnetEchoMode?(sessionId: string): Promise<{
+      success: boolean;
+      sessionId?: string;
+      remoteEcho?: boolean;
+      localEcho?: boolean;
+      error?: string;
+    }>;
     onAuthFailed?(
       sessionId: string,
       cb: (evt: { sessionId: string; error: string; hostname: string }) => void

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -311,6 +311,18 @@ declare global {
     setSessionFlowPaused(sessionId: string, paused: boolean): void;
     ackSessionFlow(sessionId: string, bytes: number): void;
     closeSession(sessionId: string): void | Promise<void>;
+    /** Move a live session's output port to this renderer (same PTY). */
+    rebindTerminalSessionOutput?(sessionId: string): Promise<{
+      success: boolean;
+      previousWebContentsId?: number | null;
+      webContentsId?: number;
+      error?: string;
+    }>;
+    /** Restore output after an attach popup closes. */
+    restoreTerminalSessionOutput?(
+      sessionId: string,
+      webContentsId?: number | null,
+    ): Promise<{ success: boolean; restored?: boolean; webContentsId?: number; error?: string }>;
     // ZMODEM file transfer
     onZmodemEvent?(
       sessionId: string,

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -335,6 +335,15 @@ declare global {
     ): () => void;
     /** Home renderer: reply with serialized scrollback. */
     respondTerminalSessionSnapshot?(requestId: string, snapshot: string): void;
+    /** Observe popup: push current state back to the home renderer before restore. */
+    applyTerminalSessionSnapshot?(sessionId: string, snapshot: string): Promise<{
+      success: boolean;
+      error?: string;
+    }>;
+    /** Home renderer: apply a pushed snapshot from an observe popup. */
+    onTerminalSessionApplySnapshot?(
+      cb: (payload: { sessionId: string; snapshot: string }) => void,
+    ): () => void;
     // ZMODEM file transfer
     onZmodemEvent?(
       sessionId: string,

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -323,6 +323,18 @@ declare global {
       sessionId: string,
       webContentsId?: number | null,
     ): Promise<{ success: boolean; restored?: boolean; webContentsId?: number; error?: string }>;
+    /** Ask the home renderer to serialize current terminal scrollback. */
+    requestTerminalSessionSnapshot?(sessionId: string): Promise<{
+      success: boolean;
+      snapshot?: string;
+      error?: string;
+    }>;
+    /** Home renderer: listen for snapshot requests. */
+    onTerminalSessionSnapshotRequest?(
+      cb: (payload: { sessionId: string; requestId: string }) => void,
+    ): () => void;
+    /** Home renderer: reply with serialized scrollback. */
+    respondTerminalSessionSnapshot?(requestId: string, snapshot: string): void;
     // ZMODEM file transfer
     onZmodemEvent?(
       sessionId: string,


### PR DESCRIPTION
## Summary
- Silent AI/MCP sessions (`hiddenFromTabs`) no longer become the main-window active tab when opened from the tray (which left a terminal surface with no tab chrome).
- Tray jump for those sessions opens the existing terminal popup and **attaches to the same live session/PTY** (`attachSessionId`), not a new shell via connection reuse.
- Main process rebinds terminal output to the popup (`rebindOutput`) and restores it when the popup closes (`restoreOutput`) without killing the backend session.
- Re-opening the same silent session focuses the existing observe popup.
- Normal (non-silent) sessions still open/focus the main window and switch tabs.

## Test plan
- [ ] With **Silent MCP sessions** off: AI/host open still creates a normal main-window tab; tray jump focuses that tab
- [ ] With **Silent MCP sessions** on: AI session does not appear in the tab bar; tray shows AI badge
- [ ] Tray click on AI silent session: independent terminal popup opens; shows the live AI session output
- [ ] Typing in the popup affects the same remote shell the AI is using
- [ ] Closing the popup does not close the silent session; tray still lists it
- [ ] Tray click again reuses/focuses the same popup
- [ ] Tray close session still closes the silent session
- [ ] Normal sessions from tray still focus main window tabs