### PR TITLE
fix(terminal): preserve tabs after non-zero shell exits

### DIFF
--- a/application/state/resolveTerminalSessionExitIntent.test.ts
+++ b/application/state/resolveTerminalSessionExitIntent.test.ts
@@ -13,6 +13,20 @@ test("normal backend exited events close the session tab", () => {
   );
 });
 
+test("non-zero backend exits keep the tab and mark it disconnected", () => {
+  assert.deepEqual(
+    resolveTerminalSessionExitIntent({ reason: "exited", exitCode: 1 }),
+    { kind: "markDisconnected" },
+  );
+});
+
+test("backend exits without a confirmed clean exit code keep the tab", () => {
+  assert.deepEqual(
+    resolveTerminalSessionExitIntent({ reason: "exited" }),
+    { kind: "markDisconnected" },
+  );
+});
+
 test("backend timeout events keep the tab and mark it disconnected", () => {
   assert.deepEqual(
     resolveTerminalSessionExitIntent({ reason: "timeout", error: "idle timeout" }),

--- a/application/state/resolveTerminalSessionExitIntent.ts
+++ b/application/state/resolveTerminalSessionExitIntent.ts
@@ -9,18 +9,22 @@ export type TerminalSessionExitIntent =
   | { kind: "closeSession" }
   | { kind: "markDisconnected" };
 
+function isConfirmedCleanExit(evt: TerminalSessionExitEvent): boolean {
+  return evt.reason === "exited" && evt.exitCode === 0;
+}
+
 export function resolveTerminalSessionExitIntent(
   evt: TerminalSessionExitEvent,
 ): TerminalSessionExitIntent {
-  if (evt.reason === "exited") {
+  if (isConfirmedCleanExit(evt)) {
     return { kind: "closeSession" };
   }
 
-  // Timeouts, transport errors, and channel closes should keep the tab visible
-  // so the user can inspect output and reconnect.
+  // Non-zero or unknown exits, timeouts, transport errors, and channel closes
+  // should keep the tab visible so the user can inspect output and reconnect.
   return { kind: "markDisconnected" };
 }
 
 export function shouldCloseTerminalPopupOnExit(evt: TerminalSessionExitEvent): boolean {
-  return evt.reason === "exited" && evt.exitCode === 0;
+  return isConfirmedCleanExit(evt);
 }

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -538,8 +538,8 @@ function startLocalSession(event, payload) {
       sessions.delete(sessionId);
       const contents = electronModule.webContents.fromId(session.webContentsId);
       // Signal present = killed externally (show disconnected UI).
-      // No signal = process exited normally, even with non-zero code
-      // (e.g. user typed `exit` after a failed command), so auto-close.
+      // No signal = the process exited and the renderer decides whether to
+      // auto-close based on the reported exit code.
       const reason = evt.signal ? "error" : "exited";
       contents?.send("netcatty:exit", { sessionId, ...evt, reason });
     };


### PR DESCRIPTION
## Summary

Keep terminal tabs visible when a shell exits with a non-zero or unknown exit code so users can inspect the final output and reconnect or close the session themselves.

The backend already reports the real exit code, but the main terminal tab policy treated every `reason: "exited"` event as a clean exit. This made `exit 1`, `set -e` failures, and similar shell failures remove the tab immediately. Only a confirmed `exitCode: 0` now auto-closes the tab.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue

Closes #2381

## Changes Made

- Add a shared predicate for confirmed clean terminal exits.
- Preserve non-zero and unknown exits as disconnected sessions.
- Keep the existing auto-close behavior for confirmed zero exits.
- Add regression coverage for non-zero and missing exit codes.

## Screenshots / Demo

Not applicable. This changes terminal session exit behavior without changing the UI layout.

## Testing

- [x] Targeted exit-intent tests pass (7/7): `node --experimental-strip-types --test application/state/resolveTerminalSessionExitIntent.test.ts`
- [x] The modified state module passes a targeted TypeScript compile.
- [x] `git diff --check` passes.
- [ ] Full `npm test` / lint suite was not run because npm 10.9.7 repeatedly aborted dependency installation with its internal `Exit handler never called!` error.
- [ ] Generated capability tool specs are updated when applicable (not applicable to this change).

## Checklist

- [x] My code follows the existing project style.
- [x] I have added regression tests for the changed behavior.
- [x] I have not introduced any breaking changes.
