### PR TITLE
feat(terminal): add exit auto-close setting

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -526,6 +526,9 @@ Highlight the focused split pane:
     'Adjust colors to meet contrast requirements (1 = disabled, 21 = max)',
   'settings.terminal.behavior.rightClick': 'Right-click behavior',
   'settings.terminal.behavior.rightClick.desc': 'Action when right-clicking in terminal',
+  'settings.terminal.behavior.autoCloseOnExit': 'Auto-close terminal on exit',
+  'settings.terminal.behavior.autoCloseOnExit.desc':
+    'Allow terminal tabs and windows to close automatically after session exit. Turn this off to keep them open after every exit.',
   'settings.terminal.behavior.rightClick.menu': 'Show menu',
   'settings.terminal.behavior.rightClick.paste': 'Paste',
   'settings.terminal.behavior.rightClick.selectWord': 'Select word',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -502,6 +502,9 @@ export const ruCoreMessages: Messages = {
     'Подстраивать цвета под требования контрастности (1 = отключено, 21 = максимум)',
   'settings.terminal.behavior.rightClick': 'Поведение правой кнопки мыши',
   'settings.terminal.behavior.rightClick.desc': 'Действие при щелчке правой кнопкой в терминале',
+  'settings.terminal.behavior.autoCloseOnExit': 'Автоматически закрывать терминал при выходе',
+  'settings.terminal.behavior.autoCloseOnExit.desc':
+    'Разрешить автоматическое закрытие вкладок и окон терминала после завершения сеанса. Отключите, чтобы сохранять их после любого выхода.',
   'settings.terminal.behavior.rightClick.menu': 'Показать меню',
   'settings.terminal.behavior.rightClick.paste': 'Вставить',
   'settings.terminal.behavior.rightClick.selectWord': 'Выбрать слово',

--- a/application/i18n/locales/zh-CN/terminal.ts
+++ b/application/i18n/locales/zh-CN/terminal.ts
@@ -257,6 +257,8 @@ export const zhCNTerminalMessages: Messages = {
   'settings.terminal.accessibility.minimumContrastRatio.desc': '调整颜色以满足对比度要求 (1 = 禁用, 21 = 最大)',
   'settings.terminal.behavior.rightClick': '右键行为',
   'settings.terminal.behavior.rightClick.desc': '在终端中右键时执行的操作',
+  'settings.terminal.behavior.autoCloseOnExit': '退出后自动关闭终端',
+  'settings.terminal.behavior.autoCloseOnExit.desc': '允许终端标签页和窗口在会话退出后自动关闭。关闭此项后，无论退出结果如何都会保留。',
   'settings.terminal.behavior.rightClick.menu': '显示菜单',
   'settings.terminal.behavior.rightClick.paste': '粘贴',
   'settings.terminal.behavior.rightClick.selectWord': '选择单词',

--- a/application/i18n/locales/zh-TW/terminal.ts
+++ b/application/i18n/locales/zh-TW/terminal.ts
@@ -257,6 +257,8 @@ export const zhTWTerminalMessages: Messages = {
   'settings.terminal.accessibility.minimumContrastRatio.desc': '調整顏色以滿足對比度要求 (1 = 停用, 21 = 最大)',
   'settings.terminal.behavior.rightClick': '右鍵行為',
   'settings.terminal.behavior.rightClick.desc': '在終端中右鍵時執行的操作',
+  'settings.terminal.behavior.autoCloseOnExit': '結束後自動關閉終端',
+  'settings.terminal.behavior.autoCloseOnExit.desc': '允許終端標籤頁和視窗在工作階段結束後自動關閉。關閉此項後，無論結束結果如何都會保留。',
   'settings.terminal.behavior.rightClick.menu': '顯示選單',
   'settings.terminal.behavior.rightClick.paste': '貼上',
   'settings.terminal.behavior.rightClick.selectWord': '選擇單字',

--- a/application/state/resolveTerminalSessionExitIntent.test.ts
+++ b/application/state/resolveTerminalSessionExitIntent.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   resolveTerminalSessionExitIntent,
   shouldCloseTerminalPopupOnExit,
+  shouldRevealTerminalPopupOnExit,
 } from "./resolveTerminalSessionExitIntent.ts";
 
 test("normal backend exited events close the session tab", () => {
@@ -73,6 +74,30 @@ test("disabled auto-close keeps command and attached terminal popups open", () =
   assert.equal(
     shouldCloseTerminalPopupOnExit(
       { reason: "closed", exitCode: 0 },
+      { autoCloseOnExit: false, isAttachMode: true },
+    ),
+    false,
+  );
+});
+
+test("disabled auto-close reveals a clean command popup exit instead of reporting startup failure", () => {
+  assert.equal(
+    shouldRevealTerminalPopupOnExit(
+      { reason: "exited", exitCode: 0 },
+      { autoCloseOnExit: false },
+    ),
+    true,
+  );
+  assert.equal(
+    shouldRevealTerminalPopupOnExit(
+      { reason: "exited", exitCode: 1 },
+      { autoCloseOnExit: false },
+    ),
+    false,
+  );
+  assert.equal(
+    shouldRevealTerminalPopupOnExit(
+      { reason: "exited", exitCode: 0 },
       { autoCloseOnExit: false, isAttachMode: true },
     ),
     false,

--- a/application/state/resolveTerminalSessionExitIntent.test.ts
+++ b/application/state/resolveTerminalSessionExitIntent.test.ts
@@ -80,7 +80,7 @@ test("disabled auto-close keeps command and attached terminal popups open", () =
   );
 });
 
-test("disabled auto-close reveals a clean command popup exit instead of reporting startup failure", () => {
+test("disabled auto-close reveals every command popup exit instead of reporting startup failure", () => {
   assert.equal(
     shouldRevealTerminalPopupOnExit(
       { reason: "exited", exitCode: 0 },
@@ -93,7 +93,14 @@ test("disabled auto-close reveals a clean command popup exit instead of reportin
       { reason: "exited", exitCode: 1 },
       { autoCloseOnExit: false },
     ),
-    false,
+    true,
+  );
+  assert.equal(
+    shouldRevealTerminalPopupOnExit(
+      { reason: "exited" },
+      { autoCloseOnExit: false },
+    ),
+    true,
   );
   assert.equal(
     shouldRevealTerminalPopupOnExit(

--- a/application/state/resolveTerminalSessionExitIntent.test.ts
+++ b/application/state/resolveTerminalSessionExitIntent.test.ts
@@ -13,6 +13,13 @@ test("normal backend exited events close the session tab", () => {
   );
 });
 
+test("disabled auto-close keeps the session tab after a clean exit", () => {
+  assert.deepEqual(
+    resolveTerminalSessionExitIntent({ reason: "exited", exitCode: 0 }, false),
+    { kind: "markDisconnected" },
+  );
+});
+
 test("non-zero backend exits keep the tab and mark it disconnected", () => {
   assert.deepEqual(
     resolveTerminalSessionExitIntent({ reason: "exited", exitCode: 1 }),
@@ -53,4 +60,31 @@ test("terminal popup only auto-closes after clean command exit", () => {
   assert.equal(shouldCloseTerminalPopupOnExit({ reason: "exited", exitCode: 1 }), false);
   assert.equal(shouldCloseTerminalPopupOnExit({ reason: "error", error: "connection reset" }), false);
   assert.equal(shouldCloseTerminalPopupOnExit({ reason: "closed", exitCode: 0 }), false);
+});
+
+test("disabled auto-close keeps command and attached terminal popups open", () => {
+  assert.equal(
+    shouldCloseTerminalPopupOnExit(
+      { reason: "exited", exitCode: 0 },
+      { autoCloseOnExit: false },
+    ),
+    false,
+  );
+  assert.equal(
+    shouldCloseTerminalPopupOnExit(
+      { reason: "closed", exitCode: 0 },
+      { autoCloseOnExit: false, isAttachMode: true },
+    ),
+    false,
+  );
+});
+
+test("attached terminal popups keep their existing auto-close behavior by default", () => {
+  assert.equal(
+    shouldCloseTerminalPopupOnExit(
+      { reason: "closed", exitCode: 0 },
+      { isAttachMode: true },
+    ),
+    true,
+  );
 });

--- a/application/state/resolveTerminalSessionExitIntent.ts
+++ b/application/state/resolveTerminalSessionExitIntent.ts
@@ -9,14 +9,20 @@ export type TerminalSessionExitIntent =
   | { kind: "closeSession" }
   | { kind: "markDisconnected" };
 
+type TerminalPopupExitOptions = {
+  autoCloseOnExit?: boolean;
+  isAttachMode?: boolean;
+};
+
 function isConfirmedCleanExit(evt: TerminalSessionExitEvent): boolean {
   return evt.reason === "exited" && evt.exitCode === 0;
 }
 
 export function resolveTerminalSessionExitIntent(
   evt: TerminalSessionExitEvent,
+  autoCloseOnExit = true,
 ): TerminalSessionExitIntent {
-  if (isConfirmedCleanExit(evt)) {
+  if (autoCloseOnExit && isConfirmedCleanExit(evt)) {
     return { kind: "closeSession" };
   }
 
@@ -25,6 +31,10 @@ export function resolveTerminalSessionExitIntent(
   return { kind: "markDisconnected" };
 }
 
-export function shouldCloseTerminalPopupOnExit(evt: TerminalSessionExitEvent): boolean {
-  return isConfirmedCleanExit(evt);
+export function shouldCloseTerminalPopupOnExit(
+  evt: TerminalSessionExitEvent,
+  options: TerminalPopupExitOptions = {},
+): boolean {
+  if (options.autoCloseOnExit === false) return false;
+  return options.isAttachMode === true || isConfirmedCleanExit(evt);
 }

--- a/application/state/resolveTerminalSessionExitIntent.ts
+++ b/application/state/resolveTerminalSessionExitIntent.ts
@@ -38,3 +38,12 @@ export function shouldCloseTerminalPopupOnExit(
   if (options.autoCloseOnExit === false) return false;
   return options.isAttachMode === true || isConfirmedCleanExit(evt);
 }
+
+export function shouldRevealTerminalPopupOnExit(
+  evt: TerminalSessionExitEvent,
+  options: TerminalPopupExitOptions = {},
+): boolean {
+  return options.autoCloseOnExit === false &&
+    options.isAttachMode !== true &&
+    isConfirmedCleanExit(evt);
+}

--- a/application/state/resolveTerminalSessionExitIntent.ts
+++ b/application/state/resolveTerminalSessionExitIntent.ts
@@ -40,10 +40,9 @@ export function shouldCloseTerminalPopupOnExit(
 }
 
 export function shouldRevealTerminalPopupOnExit(
-  evt: TerminalSessionExitEvent,
+  _evt: TerminalSessionExitEvent,
   options: TerminalPopupExitOptions = {},
 ): boolean {
   return options.autoCloseOnExit === false &&
-    options.isAttachMode !== true &&
-    isConfirmedCleanExit(evt);
+    options.isAttachMode !== true;
 }

--- a/application/syncPayload.test.ts
+++ b/application/syncPayload.test.ts
@@ -969,6 +969,26 @@ test("buildSyncPayload includes the terminal host information bar preference", (
   assert.equal(termSettings.showHostInfoBar, false);
 });
 
+test("terminal auto-close preference survives sync round-trip", async () => {
+  localStorage.setItem(
+    storageKeys.STORAGE_KEY_TERM_SETTINGS,
+    JSON.stringify({ autoCloseOnExit: false }),
+  );
+
+  const payload = buildSyncPayload(vault());
+  const termSettings = (payload.settings?.terminalSettings ?? {}) as Record<string, unknown>;
+  assert.equal(termSettings.autoCloseOnExit, false);
+
+  localStorage.setItem(
+    storageKeys.STORAGE_KEY_TERM_SETTINGS,
+    JSON.stringify({ autoCloseOnExit: true }),
+  );
+  await applySyncPayload(payload, { importVaultData: () => {} });
+
+  const restored = JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_TERM_SETTINGS)!);
+  assert.equal(restored.autoCloseOnExit, false);
+});
+
 test("applySyncPayload restores the terminal host information bar preference", async () => {
   localStorage.setItem(
     storageKeys.STORAGE_KEY_TERM_SETTINGS,

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -210,6 +210,7 @@ const SYNCABLE_TERMINAL_KEYS = [
   'linkModifier', 'keywordHighlightEnabled', 'keywordHighlightRules',
   'keepaliveInterval', 'keepaliveCountMax', 'disableBracketedPaste', 'clearWipesScrollback',
   'preserveSelectionOnInput', 'forcePromptNewLine', 'osc52Clipboard', 'dynamicTabTitleMode',
+  'autoCloseOnExit',
   'showHostInfoBar', 'showServerStats',
   'serverStatsRefreshInterval',
   'systemManagerProcessRefreshInterval', 'systemManagerTmuxRefreshInterval',

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -431,6 +431,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const terminalLogSanitizerRef = useRef(createReplaySafeTerminalLogSanitizer());
   const commandLogRewriterRef = useRef(createProgrammaticCommandLogRewriter());
   const onTerminalDataCaptureRef = useRef(onTerminalDataCapture);
+  const onSessionExitRef = useRef(onSessionExit);
   const commandBufferRef = useRef<string>("");
   const promptLineBreakStateRef = useRef<PromptLineBreakState>(createPromptLineBreakState());
   const [hasMouseTracking, setHasMouseTracking] = useState(false);
@@ -438,6 +439,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const serialLineBufferRef = useRef<string>("");
   const telnetLocalEchoRef = useRef(false);
   const pluginTerminalSessionExitRef = useRef<(exitCode?: number) => void>(() => {});
+
+  useLayoutEffect(() => {
+    onSessionExitRef.current = onSessionExit;
+  }, [onSessionExit]);
 
   useEffect(() => () => {
     reconnectWakeTokenRef.current = null;
@@ -1614,10 +1619,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         hibernatePendingBufferRef.current,
         exitMessage,
       );
-      onSessionExit?.(sessionId, evt);
+      onSessionExitRef.current?.(sessionId, evt);
       scheduleAutoReconnect({ evt });
     });
-  }, [onSessionExit, scheduleAutoReconnect, sessionId, terminalBackend]);
+  }, [scheduleAutoReconnect, sessionId, terminalBackend]);
 
   const clearHibernateRetry = useCallback(() => {
     if (hibernateRetryTimerRef.current === null) return;
@@ -1976,7 +1981,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     onSessionExit: (closedSessionId, evt) => {
       clearTerminalCwd();
       pluginTerminalLifecycle.onSessionExited(evt.exitCode);
-      onSessionExit?.(closedSessionId, evt);
+      onSessionExitRef.current?.(closedSessionId, evt);
       scheduleAutoReconnect({ evt });
     },
     onTerminalDataCapture: handleTerminalDataCaptureOnce,

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -481,13 +481,16 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   }, [onUpdateSessionStatus]);
 
   const handleSessionExit = useCallback((sessionId: string, evt: TerminalSessionExitEvent) => {
-    const intent = resolveTerminalSessionExitIntent(evt);
+    const intent = resolveTerminalSessionExitIntent(
+      evt,
+      terminalSettings?.autoCloseOnExit ?? true,
+    );
     if (intent.kind === "closeSession") {
       onCloseSession(sessionId);
     } else {
       onUpdateSessionStatus(sessionId, 'disconnected');
     }
-  }, [onCloseSession, onUpdateSessionStatus]);
+  }, [onCloseSession, onUpdateSessionStatus, terminalSettings?.autoCloseOnExit]);
 
   const handleOsDetected = useCallback((hostId: string, distro: string) => {
     onUpdateHostDistro(hostId, distro);

--- a/components/TerminalPopupPage.test.ts
+++ b/components/TerminalPopupPage.test.ts
@@ -128,6 +128,10 @@ test('terminal exit auto-close setting reaches tabs, workspaces, and popups', ()
     source,
     /shouldCloseTerminalPopupOnExit\(evt, \{\s+autoCloseOnExit: settings\.terminalSettings\.autoCloseOnExit,\s+isAttachMode,\s+\}\)/,
   );
+  assert.match(
+    source,
+    /shouldRevealTerminalPopupOnExit\(evt, \{\s+autoCloseOnExit: settings\.terminalSettings\.autoCloseOnExit,\s+isAttachMode,\s+\}\)[\s\S]*?revealTerminal\(\);\s+return;[\s\S]*?setStartupError/,
+  );
 });
 
 test('an attached observe popup never owns automatic reconnect', () => {

--- a/components/TerminalPopupPage.test.ts
+++ b/components/TerminalPopupPage.test.ts
@@ -125,6 +125,14 @@ test('terminal exit auto-close setting reaches tabs, workspaces, and popups', ()
     /resolveTerminalSessionExitIntent\(\s+evt,\s+terminalSettings\?\.autoCloseOnExit \?\? true,\s+\)/,
   );
   assert.match(
+    terminalSource,
+    /const onSessionExitRef = useRef\(onSessionExit\);[\s\S]*?useLayoutEffect\(\(\) => \{\s+onSessionExitRef\.current = onSessionExit;\s+\}, \[onSessionExit\]\);/,
+  );
+  assert.match(
+    terminalSource,
+    /onSessionExitRef\.current\?\.\(closedSessionId, evt\)/,
+  );
+  assert.match(
     source,
     /shouldCloseTerminalPopupOnExit\(evt, \{\s+autoCloseOnExit: settings\.terminalSettings\.autoCloseOnExit,\s+isAttachMode,\s+\}\)/,
   );

--- a/components/TerminalPopupPage.test.ts
+++ b/components/TerminalPopupPage.test.ts
@@ -8,6 +8,7 @@ import { resolveTerminalPopupHost, resolveTerminalPopupReuseId } from './Termina
 
 const source = readFileSync(new URL('./TerminalPopupPage.tsx', import.meta.url), 'utf8');
 const terminalSource = readFileSync(new URL('./Terminal.tsx', import.meta.url), 'utf8');
+const terminalLayerSource = readFileSync(new URL('./TerminalLayer.tsx', import.meta.url), 'utf8');
 
 const vaultHost = (overrides: Partial<Host> = {}): Host => ({
   id: 'host-1',
@@ -118,9 +119,15 @@ test('attach popup close preparation has a bounded timeout', () => {
   assert.match(source, /1500/);
 });
 
-test('an explicitly closed attached session closes its observe popup', () => {
-  assert.match(source, /onSessionExit=\{\(_closedSessionId, evt\) => \{\s+if \(isAttachMode\)/);
-  assert.match(source, /void handleClose\(\)/);
+test('terminal exit auto-close setting reaches tabs, workspaces, and popups', () => {
+  assert.match(
+    terminalLayerSource,
+    /resolveTerminalSessionExitIntent\(\s+evt,\s+terminalSettings\?\.autoCloseOnExit \?\? true,\s+\)/,
+  );
+  assert.match(
+    source,
+    /shouldCloseTerminalPopupOnExit\(evt, \{\s+autoCloseOnExit: settings\.terminalSettings\.autoCloseOnExit,\s+isAttachMode,\s+\}\)/,
+  );
 });
 
 test('an attached observe popup never owns automatic reconnect', () => {

--- a/components/TerminalPopupPage.tsx
+++ b/components/TerminalPopupPage.tsx
@@ -465,11 +465,10 @@ function TerminalPopupPageInner() {
                 void handleClose();
               }}
               onSessionExit={(_closedSessionId, evt) => {
-                if (isAttachMode) {
-                  void handleClose();
-                  return;
-                }
-                if (shouldCloseTerminalPopupOnExit(evt)) {
+                if (shouldCloseTerminalPopupOnExit(evt, {
+                  autoCloseOnExit: settings.terminalSettings.autoCloseOnExit,
+                  isAttachMode,
+                })) {
                   void handleClose();
                   return;
                 }

--- a/components/TerminalPopupPage.tsx
+++ b/components/TerminalPopupPage.tsx
@@ -5,7 +5,10 @@ import { useSettingsState } from '../application/state/useSettingsState';
 import { useTerminalPopupWindow } from '../application/state/useTerminalPopupWindow';
 import { useVaultState } from '../application/state/useVaultState';
 import { useWindowControls } from '../application/state/useWindowControls';
-import { shouldCloseTerminalPopupOnExit } from '../application/state/resolveTerminalSessionExitIntent';
+import {
+  shouldCloseTerminalPopupOnExit,
+  shouldRevealTerminalPopupOnExit,
+} from '../application/state/resolveTerminalSessionExitIntent';
 import { upsertKnownHost } from '../domain/knownHosts';
 import { resolveTerminalChainHosts, resolveTerminalSessionHost } from '../domain/terminalHostResolution';
 import type { TerminalPopupPayload } from '../domain/systemManager/types';
@@ -470,6 +473,13 @@ function TerminalPopupPageInner() {
                   isAttachMode,
                 })) {
                   void handleClose();
+                  return;
+                }
+                if (shouldRevealTerminalPopupOnExit(evt, {
+                  autoCloseOnExit: settings.terminalSettings.autoCloseOnExit,
+                  isAttachMode,
+                })) {
+                  revealTerminal();
                   return;
                 }
                 if (!terminalReady && config.startupCommand && !isAttachMode) {

--- a/components/settings/tabs/TerminalBehaviorSettings.test.ts
+++ b/components/settings/tabs/TerminalBehaviorSettings.test.ts
@@ -23,7 +23,7 @@ test("terminal behavior settings expose enabled auto-close by default", () => {
   );
 });
 
-test("terminal behavior settings show disabled auto-close", () => {
+test("terminal behavior settings expose disabled auto-close", () => {
   const markup = renderSettings(false);
 
   assert.match(

--- a/components/settings/tabs/TerminalBehaviorSettings.test.tsx
+++ b/components/settings/tabs/TerminalBehaviorSettings.test.tsx
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { normalizeTerminalSettings } from "../../../domain/models/terminal.ts";
+import { TerminalBehaviorSettings } from "./TerminalBehaviorSettings.tsx";
+
+const renderSettings = (autoCloseOnExit: boolean) => renderToStaticMarkup(
+  React.createElement(TerminalBehaviorSettings, {
+    t: (key: string) => key,
+    terminalSettings: normalizeTerminalSettings({ autoCloseOnExit }),
+    updateTerminalSetting: () => {},
+  }),
+);
+
+test("terminal behavior settings expose enabled auto-close by default", () => {
+  const markup = renderSettings(true);
+
+  assert.match(
+    markup,
+    /settings\.terminal\.behavior\.autoCloseOnExit[\s\S]*?role="switch" aria-checked="true"/,
+  );
+});
+
+test("terminal behavior settings show disabled auto-close", () => {
+  const markup = renderSettings(false);
+
+  assert.match(
+    markup,
+    /settings\.terminal\.behavior\.autoCloseOnExit[\s\S]*?role="switch" aria-checked="false"/,
+  );
+});

--- a/components/settings/tabs/TerminalBehaviorSettings.tsx
+++ b/components/settings/tabs/TerminalBehaviorSettings.tsx
@@ -40,6 +40,16 @@ export const TerminalBehaviorSettings: React.FC<TerminalBehaviorSettingsProps> =
       <SectionHeader title={t("settings.terminal.section.behavior")} />
       <div className="space-y-0 divide-y divide-border rounded-lg border bg-card px-4">
         <SettingRow
+          label={t("settings.terminal.behavior.autoCloseOnExit")}
+          description={t("settings.terminal.behavior.autoCloseOnExit.desc")}
+        >
+          <Toggle
+            checked={terminalSettings.autoCloseOnExit}
+            onChange={(v) => updateTerminalSetting("autoCloseOnExit", v)}
+          />
+        </SettingRow>
+
+        <SettingRow
           label={t("settings.terminal.behavior.rightClick")}
           description={t("settings.terminal.behavior.rightClick.desc")}
         >

--- a/domain/models/terminal.ts
+++ b/domain/models/terminal.ts
@@ -86,6 +86,7 @@ export interface TerminalSettings {
   middleClickPaste: boolean; // Legacy mirror for older settings payloads
   wordSeparators: string; // Characters for word selection
   linkModifier: LinkModifier; // Modifier key to click links
+  autoCloseOnExit: boolean; // Automatically close terminal UI after eligible session exits
 
   // Keyword Highlighting
   keywordHighlightEnabled: boolean;
@@ -384,6 +385,7 @@ const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   middleClickPaste: true,
   wordSeparators: DEFAULT_TERMINAL_WORD_SEPARATORS,
   linkModifier: 'none',
+  autoCloseOnExit: true,
   keywordHighlightEnabled: true,
   keywordHighlightRules: DEFAULT_KEYWORD_HIGHLIGHT_RULES,
   localShell: '', // Empty = use system default

--- a/domain/terminalSettings.test.ts
+++ b/domain/terminalSettings.test.ts
@@ -80,6 +80,14 @@ test("normalizeTerminalSettings enables font smoothing by default", () => {
   assert.equal(normalizeTerminalSettings().fontSmoothing, true);
 });
 
+test("normalizeTerminalSettings enables terminal auto-close by default", () => {
+  assert.equal(normalizeTerminalSettings().autoCloseOnExit, true);
+});
+
+test("normalizeTerminalSettings preserves disabled terminal auto-close", () => {
+  assert.equal(normalizeTerminalSettings({ autoCloseOnExit: false }).autoCloseOnExit, false);
+});
+
 test("normalizeTerminalSettings disables SSH auto reconnect by default", () => {
   assert.equal(normalizeTerminalSettings().sshAutoReconnectEnabled, false);
 });


### PR DESCRIPTION
## Summary

- Add an enabled-by-default **Auto-close terminal on exit** toggle under Settings > Terminal > Behavior.
- When disabled, keep regular terminal tabs, workspace terminals, command popups, and attached terminal popups open after every session exit.
- Preserve the safe exit policy from #2390: non-zero and unknown exits stay open even when auto-close is enabled.
- Add English, Simplified Chinese, Traditional Chinese, and Russian labels and descriptions.

## Why

Terminal auto-close has valid but conflicting user preferences. Keeping the current behavior as the default avoids a surprise for existing users, while the new toggle lets users opt out completely without weakening failure-output preservation.

## Validation

- 53 focused exit-policy, settings-default, settings-UI, popup, and workspace-path tests passed.
- 6 localized-settings tests passed.
- `npm run lint`
- `npm run build`
- `git diff --check`
- Independent standards review: clean.
- Independent requirements review: clean.

Local `npm test` was attempted, but this worktree's Electron installation is incomplete (`node_modules/electron/path.txt` is missing), so Electron-dependent files could not start. The draft PR's GitHub Actions run is the authoritative full-suite check.

Follow-up to #2390.
