### PR TITLE
fix(terminal): batch hidden log output

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1911,6 +1911,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     terminalBackend,
     serialConfig,
     telnetLocalEchoRef,
+    isPaneVisibleRef: isVisibleRef,
     isVisibleRef: isRendererActiveRef,
     isBootActiveRef,
     pendingOutputScrollRef,

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -510,7 +510,22 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }
 
     const range = normalizeTerminalContextRange(request.range);
-    const term = termRef.current;
+    let term = termRef.current;
+    let liveContextReady = !term;
+    for (let attempt = 0; term && attempt < 2; attempt += 1) {
+      const targetTerm = term;
+      const flushed = await flushPendingTerminalWritesBeforeHibernate(targetTerm);
+      term = termRef.current;
+      if (term !== targetTerm) continue;
+      if (!flushed) {
+        return { ok: false, error: "Terminal output is still draining; retry the context read." };
+      }
+      liveContextReady = true;
+      break;
+    }
+    if (term && !liveContextReady) {
+      return { ok: false, error: "Terminal changed while reading its context; retry the request." };
+    }
     if (term) {
       const alternateScreen = isTerminalAlternateScreenActive(term);
       const activeBuffer = term.buffer.active as typeof term.buffer.active & {

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -180,7 +180,10 @@ import {
 import {
   releaseTerminalFlowBeforeHibernate,
 } from "./terminal/runtime/terminalSessionAttachment";
-import { flushPendingTerminalWritesBeforeHibernate } from "./terminal/runtime/terminalUnfocusedRepaint";
+import {
+  flushPendingTerminalWritesBeforeHibernate,
+  writeLocalTerminalDataInOrder,
+} from "./terminal/runtime/terminalUnfocusedRepaint";
 import {
   isTerminalFileTransferActive,
   resolveHibernateKeepRendererCount,
@@ -605,9 +608,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   }, [onProgrammaticCommandLogRewriteChange, queueProgrammaticCommandLogRewrite, sessionId]);
 
   const writeLocalTerminalData = useCallback((data: string) => {
-    if (!data) return;
-    captureTerminalLogData(data);
-    termRef.current?.write(data);
+    const term = termRef.current;
+    if (!term) return;
+    writeLocalTerminalDataInOrder(term, data, captureTerminalLogData);
   }, [captureTerminalLogData]);
 
   const hotkeySchemeRef = useRef(hotkeyScheme);

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -453,6 +453,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const terminalSettingsRef = useRef(terminalSettings);
   terminalSettingsRef.current = terminalSettings;
+  const hostRef = useRef(host);
+  hostRef.current = host;
   // The protocol capability is connection-scoped. A settings change applies
   // to newly mounted terminals so an already-negotiated remote never sees the
   // parser and encoder disagree or disappear during hibernation/reconnect.
@@ -1912,6 +1914,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const sessionStarters = createTerminalSessionStarters({
     host,
+    hostRef,
     keys,
     identities,
     knownHosts,

--- a/components/terminal/runtime/createTerminalSessionStarters.types.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.types.ts
@@ -123,6 +123,12 @@ export type SessionLogConfig = {
 
 export type TerminalSessionStartersContext = {
   host: Host & Pick<Partial<TerminalSession>, "localStartDir">;
+  /**
+   * Live host snapshot updated every render. Session data handlers close over
+   * boot-time ctx, so mid-session host toggles (e.g. line timestamps) must be
+   * read from this ref rather than the frozen `host` field.
+   */
+  hostRef?: RefObject<Host & Pick<Partial<TerminalSession>, "localStartDir">>;
   keys: SSHKey[];
   identities?: Identity[];
   knownHosts?: KnownHost[];

--- a/components/terminal/runtime/createTerminalSessionStarters.types.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.types.ts
@@ -153,6 +153,8 @@ export type TerminalSessionStartersContext = {
     active: boolean,
     state: PasswordPromptPickerState | null,
   ) => boolean;
+  /** Actual tab/pane visibility; the renderer may remain active while hidden. */
+  isPaneVisibleRef?: RefObject<boolean>;
   isVisibleRef?: RefObject<boolean>;
   /** False after unmount/teardown so in-flight session starts skip attach. */
   isBootActiveRef?: RefObject<boolean>;

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -116,6 +116,7 @@ import {
 import { clearTerminalInputStateForInterrupt } from "./terminalInterruptInputState";
 import { getFlowControllerForTerm } from "./terminalSessionAttachment";
 import { createTerminalResizeScheduler } from "./terminalResizeScheduler";
+import { writeLocalTerminalDataInOrder } from "./terminalUnfocusedRepaint";
 import {
   prioritizeTerminalInput,
   shouldArmTerminalInterruptDisplayGateForProtocol,
@@ -904,8 +905,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   });
 
   const writeLocalTerminalData = (nextData: string) => {
-    ctx.onTerminalLogData?.(nextData);
-    term.write(nextData);
+    writeLocalTerminalDataInOrder(term, nextData, ctx.onTerminalLogData);
   };
 
   const handleTerminalInputData = (

--- a/components/terminal/runtime/promptLineBreak.test.ts
+++ b/components/terminal/runtime/promptLineBreak.test.ts
@@ -5,12 +5,48 @@ import {
   consumeOsc133CommandCompletion,
   createPromptLineBreakState,
   detectTerminalCommandCompletions,
+  doesTerminalPromptStartAtSourceChunk,
   insertPromptLineBreakBeforePrompt,
   markPromptLineBreakCommandPending,
   markTerminalCommandCompletionPending,
   prepareTerminalDataForPromptLineBreak,
   syncPromptLineBreakState,
 } from "./promptLineBreak";
+
+test("detects prompt chunks across trailing and leading ANSI sequences", () => {
+  const trailingAnsiData = "file tail\x1b[0m$ ";
+  assert.equal(
+    doesTerminalPromptStartAtSourceChunk(trailingAnsiData, "$ ", ["file tail\x1b[0m".length]),
+    true,
+  );
+
+  const leadingAnsiData = "file tail\x1b[32m$ ";
+  assert.equal(
+    doesTerminalPromptStartAtSourceChunk(leadingAnsiData, "$ ", ["file tail".length]),
+    true,
+  );
+  assert.equal(doesTerminalPromptStartAtSourceChunk("file tail$ ", "$ ", []), false);
+
+  const clearData = "file tail\x1b[2J$ ";
+  const promptStartsAtSourceChunk = doesTerminalPromptStartAtSourceChunk(
+    clearData,
+    "$ ",
+    ["file tail\x1b[2J".length],
+  );
+  const state = createPromptLineBreakState();
+  state.lastPromptText = "$ ";
+  state.pendingCommand = true;
+  assert.equal(
+    prepareTerminalDataForPromptLineBreak(
+      createFakeTerm("", 0) as never,
+      "file tail\x1b[2J\x1b[3J$ ",
+      state,
+      true,
+      promptStartsAtSourceChunk,
+    ),
+    "file tail\r\n\x1b[2J\x1b[3J$ ",
+  );
+});
 
 function createFakeTerm(lineText = "", cursorX = lineText.length) {
   return {
@@ -217,7 +253,7 @@ test("uses a preserved PTY chunk boundary to separate a short prompt", () => {
       "file tail$ ",
       state,
       true,
-      ["file tail".length],
+      true,
     ),
     "file tail\r\n$ ",
   );

--- a/components/terminal/runtime/promptLineBreak.test.ts
+++ b/components/terminal/runtime/promptLineBreak.test.ts
@@ -5,7 +5,7 @@ import {
   consumeOsc133CommandCompletion,
   createPromptLineBreakState,
   detectTerminalCommandCompletions,
-  doesTerminalPromptStartAtSourceChunk,
+  findTerminalPromptSourceChunkVisibleStarts,
   insertPromptLineBreakBeforePrompt,
   markPromptLineBreakCommandPending,
   markTerminalCommandCompletionPending,
@@ -13,22 +13,26 @@ import {
   syncPromptLineBreakState,
 } from "./promptLineBreak";
 
-test("detects prompt chunks across trailing and leading ANSI sequences", () => {
+test("finds prompt chunks across trailing and leading ANSI sequences", () => {
   const trailingAnsiData = "file tail\x1b[0m$ ";
-  assert.equal(
-    doesTerminalPromptStartAtSourceChunk(trailingAnsiData, "$ ", ["file tail\x1b[0m".length]),
-    true,
+  assert.deepEqual(
+    findTerminalPromptSourceChunkVisibleStarts(
+      trailingAnsiData,
+      "$ ",
+      ["file tail\x1b[0m".length],
+    ),
+    ["file tail".length],
   );
 
   const leadingAnsiData = "file tail\x1b[32m$ ";
-  assert.equal(
-    doesTerminalPromptStartAtSourceChunk(leadingAnsiData, "$ ", ["file tail".length]),
-    true,
+  assert.deepEqual(
+    findTerminalPromptSourceChunkVisibleStarts(leadingAnsiData, "$ ", ["file tail".length]),
+    ["file tail".length],
   );
-  assert.equal(doesTerminalPromptStartAtSourceChunk("file tail$ ", "$ ", []), false);
+  assert.deepEqual(findTerminalPromptSourceChunkVisibleStarts("file tail$ ", "$ ", []), []);
 
   const clearData = "file tail\x1b[2J$ ";
-  const promptStartsAtSourceChunk = doesTerminalPromptStartAtSourceChunk(
+  const promptVisibleStarts = findTerminalPromptSourceChunkVisibleStarts(
     clearData,
     "$ ",
     ["file tail\x1b[2J".length],
@@ -42,7 +46,7 @@ test("detects prompt chunks across trailing and leading ANSI sequences", () => {
       "file tail\x1b[2J\x1b[3J$ ",
       state,
       true,
-      promptStartsAtSourceChunk,
+      promptVisibleStarts,
     ),
     "file tail\r\n\x1b[2J\x1b[3J$ ",
   );
@@ -253,7 +257,7 @@ test("uses a preserved PTY chunk boundary to separate a short prompt", () => {
       "file tail$ ",
       state,
       true,
-      true,
+      ["file tail".length],
     ),
     "file tail\r\n$ ",
   );

--- a/components/terminal/runtime/promptLineBreak.test.ts
+++ b/components/terminal/runtime/promptLineBreak.test.ts
@@ -52,6 +52,54 @@ test("finds prompt chunks across trailing and leading ANSI sequences", () => {
   );
 });
 
+test("keeps cursor movement before a prompt-side line break", () => {
+  const state = createPromptLineBreakState();
+  state.lastPromptText = "$ ";
+  state.pendingCommand = true;
+  const output = "foo\x1b[E";
+  const data = `${output}$ `;
+  const promptStarts = findTerminalPromptSourceChunkVisibleStarts(
+    data,
+    state.lastPromptText,
+    [output.length],
+  );
+
+  assert.equal(
+    prepareTerminalDataForPromptLineBreak(
+      createFakeTerm("", 0) as never,
+      data,
+      state,
+      true,
+      promptStarts,
+    ),
+    data,
+  );
+});
+
+test("inserts a prompt line break after leaving the alternate screen", () => {
+  const state = createPromptLineBreakState();
+  state.lastPromptText = "$ ";
+  state.pendingCommand = true;
+  const leaveAlternateScreen = "\x1b[?1049l";
+  const data = `${leaveAlternateScreen}$ `;
+  const promptStarts = findTerminalPromptSourceChunkVisibleStarts(
+    data,
+    state.lastPromptText,
+    [leaveAlternateScreen.length],
+  );
+
+  assert.equal(
+    prepareTerminalDataForPromptLineBreak(
+      createFakeTerm("", 5) as never,
+      data,
+      state,
+      true,
+      promptStarts,
+    ),
+    `${leaveAlternateScreen}\r\n$ `,
+  );
+});
+
 function createFakeTerm(lineText = "", cursorX = lineText.length) {
   return {
     buffer: {

--- a/components/terminal/runtime/promptLineBreak.test.ts
+++ b/components/terminal/runtime/promptLineBreak.test.ts
@@ -76,6 +76,62 @@ test("keeps cursor movement before a prompt-side line break", () => {
   );
 });
 
+test("measures cursor-only prompt prefixes before deciding on a line break", () => {
+  const state = createPromptLineBreakState();
+  state.lastPromptText = "$ ";
+  state.pendingCommand = true;
+  const cursorForward = "\x1b[10C";
+  const data = `${cursorForward}$ `;
+
+  assert.equal(
+    prepareTerminalDataForPromptLineBreak(
+      createFakeTerm("", 0) as never,
+      data,
+      state,
+      true,
+      findTerminalPromptSourceChunkVisibleStarts(data, "$ ", [cursorForward.length]),
+    ),
+    `${cursorForward}\r\n$ `,
+  );
+});
+
+test("does not move a clear-screen prompt away from cursor home", () => {
+  const state = createPromptLineBreakState();
+  state.lastPromptText = "$ ";
+  state.pendingCommand = true;
+  const data = "\x1b[H\x1b[2J$ ";
+
+  assert.equal(
+    prepareTerminalDataForPromptLineBreak(
+      createFakeTerm("", 5) as never,
+      data,
+      state,
+      true,
+      findTerminalPromptSourceChunkVisibleStarts(data, "$ "),
+    ),
+    data,
+  );
+});
+
+test("does not add a second break after carriage return", () => {
+  const state = createPromptLineBreakState();
+  state.lastPromptText = "$ ";
+  state.pendingCommand = true;
+  const output = "foo\r";
+  const data = `${output}$ `;
+
+  assert.equal(
+    prepareTerminalDataForPromptLineBreak(
+      createFakeTerm("", 5) as never,
+      data,
+      state,
+      true,
+      findTerminalPromptSourceChunkVisibleStarts(data, "$ ", [output.length]),
+    ),
+    data,
+  );
+});
+
 test("inserts a prompt line break after leaving the alternate screen", () => {
   const state = createPromptLineBreakState();
   state.lastPromptText = "$ ";

--- a/components/terminal/runtime/promptLineBreak.test.ts
+++ b/components/terminal/runtime/promptLineBreak.test.ts
@@ -1201,3 +1201,34 @@ test("does not refresh cached prompt from an unchanged mid-line write without a 
   assert.equal(state.pendingCommand, true);
   assert.equal(state.suppressNextPromptCache, false);
 });
+
+test("does not insert a blank line after a full-width prefix that already wrapped", () => {
+  const state = createPromptLineBreakState();
+  state.lastPromptText = "$ ";
+  state.pendingCommand = true;
+  const cols = 10;
+  const fullWidth = "x".repeat(cols);
+  const term = createWrappedFakeTerm([fullWidth], 0, 0, cols);
+
+  assert.equal(
+    prepareTerminalDataForPromptLineBreak(
+      term as never,
+      `${fullWidth}$ `,
+      state,
+      true,
+      [fullWidth.length],
+    ),
+    `${fullWidth}$ `,
+  );
+});
+
+test("finds prompt starts on the display string after identity transforms", () => {
+  const prompt = "$ ";
+  const data = `file tail${prompt}`;
+  const starts = findTerminalPromptSourceChunkVisibleStarts(
+    data,
+    prompt,
+    ["file tail".length],
+  );
+  assert.deepEqual(starts, ["file tail".length]);
+});

--- a/components/terminal/runtime/promptLineBreak.test.ts
+++ b/components/terminal/runtime/promptLineBreak.test.ts
@@ -206,6 +206,24 @@ test("does not refresh cached prompt from output that only ends with the prompt 
   assert.equal(state.suppressNextPromptCache, false);
 });
 
+test("uses a preserved PTY chunk boundary to separate a short prompt", () => {
+  const state = createPromptLineBreakState();
+  state.lastPromptText = "$ ";
+  state.pendingCommand = true;
+
+  assert.equal(
+    prepareTerminalDataForPromptLineBreak(
+      createFakeTerm("", 0) as never,
+      "file tail$ ",
+      state,
+      true,
+      ["file tail".length],
+    ),
+    "file tail\r\n$ ",
+  );
+  assert.equal(state.suppressNextPromptCache, false);
+});
+
 test("keeps waiting for the real prompt after an output suffix matches the prompt text", () => {
   const state = createPromptLineBreakState();
   state.lastPromptText = "$ ";

--- a/components/terminal/runtime/promptLineBreak.test.ts
+++ b/components/terminal/runtime/promptLineBreak.test.ts
@@ -153,6 +153,47 @@ test("does not move prompts after row-positioning controls", () => {
   }
 });
 
+test("keeps non-moving mode toggles on the prompt side of an inserted break", () => {
+  for (const control of ["\x1b[?2004h", "\x1b[?25h", "\x1b[?25l"]) {
+    const stateAtLineStart = createPromptLineBreakState();
+    stateAtLineStart.lastPromptText = "$ ";
+    stateAtLineStart.pendingCommand = true;
+    const data = `${control}$ `;
+    const promptStarts = findTerminalPromptSourceChunkVisibleStarts(
+      data,
+      stateAtLineStart.lastPromptText,
+      [control.length],
+    );
+
+    assert.equal(
+      prepareTerminalDataForPromptLineBreak(
+        createFakeTerm("", 0) as never,
+        data,
+        stateAtLineStart,
+        true,
+        promptStarts,
+      ),
+      data,
+      JSON.stringify(control),
+    );
+
+    const stateMidLine = createPromptLineBreakState();
+    stateMidLine.lastPromptText = "$ ";
+    stateMidLine.pendingCommand = true;
+    assert.equal(
+      prepareTerminalDataForPromptLineBreak(
+        createFakeTerm("output", 6) as never,
+        data,
+        stateMidLine,
+        true,
+        promptStarts,
+      ),
+      `\r\n${data}`,
+      JSON.stringify(control),
+    );
+  }
+});
+
 test("inserts a prompt line break after leaving the alternate screen", () => {
   const state = createPromptLineBreakState();
   state.lastPromptText = "$ ";

--- a/components/terminal/runtime/promptLineBreak.test.ts
+++ b/components/terminal/runtime/promptLineBreak.test.ts
@@ -132,6 +132,27 @@ test("does not add a second break after carriage return", () => {
   );
 });
 
+test("does not move prompts after row-positioning controls", () => {
+  for (const control of ["\x1b[r", "\x1b[A", "\x1b[B", "\x1b[d", "\x1b[e"]) {
+    const state = createPromptLineBreakState();
+    state.lastPromptText = "$ ";
+    state.pendingCommand = true;
+    const data = `${control}$ `;
+
+    assert.equal(
+      prepareTerminalDataForPromptLineBreak(
+        createFakeTerm("", 0) as never,
+        data,
+        state,
+        true,
+        findTerminalPromptSourceChunkVisibleStarts(data, "$ ", [control.length]),
+      ),
+      data,
+      JSON.stringify(control),
+    );
+  }
+});
+
 test("inserts a prompt line break after leaving the alternate screen", () => {
   const state = createPromptLineBreakState();
   state.lastPromptText = "$ ";

--- a/components/terminal/runtime/promptLineBreak.ts
+++ b/components/terminal/runtime/promptLineBreak.ts
@@ -223,6 +223,7 @@ export function insertPromptLineBreakBeforePrompt(
   data: string,
   promptText: string,
   cursorXBeforeWrite: number,
+  sourceChunkBoundaries: readonly number[] = [],
 ): string {
   if (!data || !promptText) return data;
 
@@ -231,13 +232,14 @@ export function insertPromptLineBreakBeforePrompt(
 
   const promptTextStart = mapped.text.length - promptText.length;
   const prefixText = mapped.text.slice(0, promptTextStart);
+  const promptRawStart = mapped.rawStartByTextIndex[promptTextStart] ?? 0;
+  const promptStartsAtSourceChunk = sourceChunkBoundaries.includes(promptRawStart);
   if (prefixText.length === 0 && cursorXBeforeWrite <= 0) return data;
   if (prefixText.length > 0) {
     if (endsWithLineBreak(prefixText)) return data;
-    if (!isDistinctPromptText(promptText)) return data;
+    if (!isDistinctPromptText(promptText) && !promptStartsAtSourceChunk) return data;
   }
 
-  const promptRawStart = mapped.rawStartByTextIndex[promptTextStart] ?? 0;
   return `${data.slice(0, promptRawStart)}\r\n${data.slice(promptRawStart)}`;
 }
 
@@ -246,6 +248,7 @@ export function prepareTerminalDataForPromptLineBreak(
   data: string,
   state: PromptLineBreakState | undefined,
   enabled: boolean,
+  sourceChunkBoundaries: readonly number[] = [],
 ): string {
   if (!enabled || !state?.pendingCommand || !state.lastPromptText) return data;
 
@@ -254,6 +257,7 @@ export function prepareTerminalDataForPromptLineBreak(
     data,
     state.lastPromptText,
     cursorXBeforeWrite,
+    sourceChunkBoundaries,
   );
   const visibleText = mapVisibleText(data).text;
   const ambiguousPromptSuffix = hasAmbiguousPromptSuffix(data, state.lastPromptText);

--- a/components/terminal/runtime/promptLineBreak.ts
+++ b/components/terminal/runtime/promptLineBreak.ts
@@ -219,6 +219,7 @@ const measurePromptPrefixColumn = (
             if (privateOrIntermediate) return null;
             column = clampColumn(parameterCount(params, 1) - 1);
             columnKnown = true;
+            separated = true;
             break;
           case "E":
           case "F":
@@ -312,7 +313,7 @@ const measurePromptPrefixColumn = (
       if (next === "E" || next === "c") {
         column = 0;
         columnKnown = true;
-        if (next === "E") separated = true;
+        separated = true;
         index += 1;
         continue;
       }
@@ -370,11 +371,12 @@ const measurePromptPrefixColumn = (
 const endsAtKnownColumnZero = (
   term: XTerm,
   rawText: string,
+  visibleText: string,
   cursorXBeforeWrite: number,
   convertEol: boolean,
 ): boolean => {
   const measured = measurePromptPrefixColumn(term, rawText, cursorXBeforeWrite, convertEol);
-  return measured?.column === 0 && measured.separated;
+  return measured?.column === 0 && (measured.separated || endsWithLineBreak(visibleText));
 };
 
 const containsLineReset = (text: string): boolean =>
@@ -628,7 +630,6 @@ const insertPromptLineBreaksAtVisibleStarts = (
         firstVisibleRawIndex,
       );
       const prefixText = mapped.text.slice(0, visibleStart);
-      if (prefixText.length === 0 && cursorXBeforeWrite <= 0) return [];
       const lastColumnResetVisibleIndex = prefixText.lastIndexOf("\r");
       const lastColumnResetRawIndex = lastColumnResetVisibleIndex >= 0
         ? mapped.rawIndexByTextIndex[lastColumnResetVisibleIndex]
@@ -636,14 +637,18 @@ const insertPromptLineBreaksAtVisibleStarts = (
       const measuredRawStart = lastColumnResetRawIndex === undefined
         ? 0
         : lastColumnResetRawIndex + 1;
+      const measuredRawText = data.slice(measuredRawStart, rawStart);
+      if (endsAtKnownColumnZero(
+        term,
+        measuredRawText,
+        prefixText,
+        lastColumnResetRawIndex === undefined ? cursorXBeforeWrite : 0,
+        convertEol,
+      )) return [];
       if (
-        prefixText.length > 0
-        && endsAtKnownColumnZero(
-          term,
-          data.slice(measuredRawStart, rawStart),
-          lastColumnResetRawIndex === undefined ? cursorXBeforeWrite : 0,
-          convertEol,
-        )
+        prefixText.length === 0
+        && measuredRawText.length === 0
+        && cursorXBeforeWrite <= 0
       ) return [];
       return [rawStart];
     });

--- a/components/terminal/runtime/promptLineBreak.ts
+++ b/components/terminal/runtime/promptLineBreak.ts
@@ -120,12 +120,59 @@ const parseCsiParams = (body: string): number[] => {
   });
 };
 
+const CURSOR_PREFIX_CSI_FINALS = new Set([
+  "@", "A", "B", "C", "D", "E", "F", "G", "H", "I", "L", "M",
+  "P", "S", "T", "X", "Z", "`", "a", "d", "e", "f", "h", "l", "r",
+  "s", "u",
+]);
+
+const advancePromptBreakPastLeadingCursorControls = (
+  data: string,
+  rawStart: number,
+  firstVisibleRawIndex: number,
+): number => {
+  let breakIndex = rawStart;
+  for (let index = rawStart; index < firstVisibleRawIndex; index += 1) {
+    const char = data[index];
+    if (char === ESC || char === "\x9b") {
+      const isCsi = char === "\x9b" || data[index + 1] === "[";
+      if (isCsi) {
+        const sequence = readCsiSequence(data, index);
+        if (!sequence || sequence.end >= firstVisibleRawIndex) break;
+        if (CURSOR_PREFIX_CSI_FINALS.has(sequence.final)) {
+          breakIndex = sequence.end + 1;
+        }
+        index = sequence.end;
+        continue;
+      }
+
+      const next = data[index + 1];
+      if (next === "]" || next === "P" || next === "X" || next === "^" || next === "_") {
+        const end = readControlStringEnd(data, index + 2);
+        if (end === null || end >= firstVisibleRawIndex) break;
+        index = end;
+        continue;
+      }
+      if (["7", "8", "D", "E", "H", "M", "c"].includes(next)) {
+        breakIndex = index + 2;
+      }
+      if (next) index += 1;
+    }
+  }
+  return breakIndex;
+};
+
+type PromptPrefixMeasurement = {
+  column: number;
+  separated: boolean;
+};
+
 const measurePromptPrefixColumn = (
   term: XTerm,
   data: string,
   startColumn: number,
   convertEol: boolean,
-): number | null => {
+): PromptPrefixMeasurement | null => {
   const maxColumn = Number.isFinite(term.cols) && term.cols > 0
     ? term.cols - 1
     : Number.MAX_SAFE_INTEGER;
@@ -137,6 +184,7 @@ const measurePromptPrefixColumn = (
   let hasSavedColumn = false;
   let savedColumn: number | null = null;
   let lastPrintableWidth: number | null = null;
+  let separated = false;
 
   for (let index = 0; index < data.length; index += 1) {
     const char = data[index];
@@ -177,6 +225,7 @@ const measurePromptPrefixColumn = (
             if (privateOrIntermediate) return null;
             column = 0;
             columnKnown = true;
+            separated = true;
             break;
           case "I":
           case "Z":
@@ -208,8 +257,6 @@ const measurePromptPrefixColumn = (
           case "B":
           case "J":
           case "K":
-          case "L":
-          case "M":
           case "P":
           case "S":
           case "T":
@@ -221,6 +268,12 @@ const measurePromptPrefixColumn = (
           case "m":
           case "n":
           case "q":
+            break;
+          case "L":
+          case "M":
+            if (privateOrIntermediate) return null;
+            column = 0;
+            columnKnown = true;
             break;
           case "h":
           case "l":
@@ -259,6 +312,7 @@ const measurePromptPrefixColumn = (
       if (next === "E" || next === "c") {
         column = 0;
         columnKnown = true;
+        if (next === "E") separated = true;
         index += 1;
         continue;
       }
@@ -274,6 +328,7 @@ const measurePromptPrefixColumn = (
     }
 
     if (char === "\n" || char === "\v" || char === "\f") {
+      separated = true;
       if (newlineMode) {
         column = 0;
         columnKnown = true;
@@ -283,6 +338,7 @@ const measurePromptPrefixColumn = (
     if (char === "\r") {
       column = 0;
       columnKnown = true;
+      separated = true;
       continue;
     }
     if (char === "\b") {
@@ -308,19 +364,18 @@ const measurePromptPrefixColumn = (
     if (columnKnown) column = clampColumn(column + 1);
   }
 
-  return columnKnown ? column : null;
+  return columnKnown ? { column, separated } : null;
 };
 
 const endsAtKnownColumnZero = (
   term: XTerm,
   rawText: string,
-  visibleText: string,
   cursorXBeforeWrite: number,
   convertEol: boolean,
-): boolean => (
-  endsWithLineBreak(visibleText)
-  && measurePromptPrefixColumn(term, rawText, cursorXBeforeWrite, convertEol) === 0
-);
+): boolean => {
+  const measured = measurePromptPrefixColumn(term, rawText, cursorXBeforeWrite, convertEol);
+  return measured?.column === 0 && measured.separated;
+};
 
 const containsLineReset = (text: string): boolean =>
   text.includes("\n") || text.includes("\r");
@@ -564,8 +619,14 @@ const insertPromptLineBreaksAtVisibleStarts = (
       if (mapped.text.slice(visibleStart, visibleStart + promptText.length) !== promptText) {
         return [];
       }
-      const rawStart = mapped.rawStartByTextIndex[visibleStart];
-      if (rawStart === undefined) return [];
+      const leadingControlsRawStart = mapped.rawStartByTextIndex[visibleStart];
+      const firstVisibleRawIndex = mapped.rawIndexByTextIndex[visibleStart];
+      if (leadingControlsRawStart === undefined || firstVisibleRawIndex === undefined) return [];
+      const rawStart = advancePromptBreakPastLeadingCursorControls(
+        data,
+        leadingControlsRawStart,
+        firstVisibleRawIndex,
+      );
       const prefixText = mapped.text.slice(0, visibleStart);
       if (prefixText.length === 0 && cursorXBeforeWrite <= 0) return [];
       const lastColumnResetVisibleIndex = prefixText.lastIndexOf("\r");
@@ -580,7 +641,6 @@ const insertPromptLineBreaksAtVisibleStarts = (
         && endsAtKnownColumnZero(
           term,
           data.slice(measuredRawStart, rawStart),
-          prefixText,
           lastColumnResetRawIndex === undefined ? cursorXBeforeWrite : 0,
           convertEol,
         )

--- a/components/terminal/runtime/promptLineBreak.ts
+++ b/components/terminal/runtime/promptLineBreak.ts
@@ -132,6 +132,9 @@ const measurePromptPrefixColumn = (
   const clampColumn = (value: number) => Math.max(0, Math.min(maxColumn, value));
   const parameterCount = (params: readonly number[], index = 0) => Math.max(1, params[index] || 1);
   let column = clampColumn(startColumn);
+  let columnKnown = true;
+  let newlineMode = convertEol;
+  let hasSavedColumn = false;
   let savedColumn: number | null = null;
   let lastPrintableWidth: number | null = null;
 
@@ -151,54 +154,55 @@ const measurePromptPrefixColumn = (
           case "C":
           case "a":
             if (privateOrIntermediate) return null;
-            column = clampColumn(column + count);
+            if (columnKnown) column = clampColumn(column + count);
             break;
           case "D":
             if (privateOrIntermediate) return null;
-            column = clampColumn(column - count);
+            if (columnKnown) column = clampColumn(column - count);
             break;
           case "G":
           case "`":
             if (privateOrIntermediate) return null;
             column = clampColumn(count - 1);
+            columnKnown = true;
             break;
           case "H":
           case "f":
             if (privateOrIntermediate) return null;
             column = clampColumn(parameterCount(params, 1) - 1);
+            columnKnown = true;
             break;
           case "E":
           case "F":
             if (privateOrIntermediate) return null;
             column = 0;
+            columnKnown = true;
             break;
           case "I":
-            if (privateOrIntermediate) return null;
-            for (let tab = 0; tab < count; tab += 1) {
-              column = clampColumn(column + (8 - (column % 8)));
-            }
-            break;
           case "Z":
             if (privateOrIntermediate) return null;
-            for (let tab = 0; tab < count; tab += 1) {
-              column = Math.max(0, column - (column % 8 || 8));
-            }
+            // HTS/TBC can replace the default 8-column stops. Without reading
+            // xterm's private tab map, the resulting column is unknown.
+            columnKnown = false;
             break;
           case "s":
             if (privateOrIntermediate || params.length > 0) return null;
-            savedColumn = column;
+            hasSavedColumn = true;
+            savedColumn = columnKnown ? column : null;
             break;
           case "u":
-            if (privateOrIntermediate || params.length > 0 || savedColumn === null) return null;
-            column = savedColumn;
+            if (privateOrIntermediate || params.length > 0 || !hasSavedColumn) return null;
+            columnKnown = savedColumn !== null;
+            if (savedColumn !== null) column = savedColumn;
             break;
           case "b":
             if (privateOrIntermediate || lastPrintableWidth === null) return null;
-            column = clampColumn(column + (lastPrintableWidth * count));
+            if (columnKnown) column = clampColumn(column + (lastPrintableWidth * count));
             break;
           case "r":
             if (privateOrIntermediate) return null;
             column = 0;
+            columnKnown = true;
             break;
           case "A":
           case "B":
@@ -214,14 +218,19 @@ const measurePromptPrefixColumn = (
           case "c":
           case "d":
           case "e":
-          case "h":
-          case "l":
           case "m":
           case "n":
           case "q":
             break;
+          case "h":
+          case "l":
+            if (!privateOrIntermediate && params.includes(20)) {
+              newlineMode = sequence.final === "h";
+            }
+            break;
           default:
-            return null;
+            columnKnown = false;
+            break;
         }
         index = sequence.end;
         continue;
@@ -235,18 +244,21 @@ const measurePromptPrefixColumn = (
         continue;
       }
       if (next === "7") {
-        savedColumn = column;
+        hasSavedColumn = true;
+        savedColumn = columnKnown ? column : null;
         index += 1;
         continue;
       }
       if (next === "8") {
-        if (savedColumn === null) return null;
-        column = savedColumn;
+        if (!hasSavedColumn) return null;
+        columnKnown = savedColumn !== null;
+        if (savedColumn !== null) column = savedColumn;
         index += 1;
         continue;
       }
       if (next === "E" || next === "c") {
         column = 0;
+        columnKnown = true;
         index += 1;
         continue;
       }
@@ -262,32 +274,41 @@ const measurePromptPrefixColumn = (
     }
 
     if (char === "\n" || char === "\v" || char === "\f") {
-      if (convertEol) column = 0;
+      if (newlineMode) {
+        column = 0;
+        columnKnown = true;
+      }
       continue;
     }
     if (char === "\r") {
       column = 0;
+      columnKnown = true;
       continue;
     }
     if (char === "\b") {
-      column = Math.max(0, column - 1);
+      if (columnKnown) column = Math.max(0, column - 1);
       continue;
     }
     if (char === "\t") {
-      column = clampColumn(column + (8 - (column % 8)));
+      columnKnown = false;
       continue;
     }
     const code = char.charCodeAt(0);
     if (code < 0x20 || code === 0x7f) {
       if (code === 0 || code === 7 || code === 14 || code === 15) continue;
-      return null;
+      columnKnown = false;
+      continue;
     }
-    if (code > 0x7e) return null;
+    if (code > 0x7e) {
+      columnKnown = false;
+      lastPrintableWidth = null;
+      continue;
+    }
     lastPrintableWidth = 1;
-    column = clampColumn(column + 1);
+    if (columnKnown) column = clampColumn(column + 1);
   }
 
-  return column;
+  return columnKnown ? column : null;
 };
 
 const endsAtKnownColumnZero = (
@@ -547,10 +568,7 @@ const insertPromptLineBreaksAtVisibleStarts = (
       if (rawStart === undefined) return [];
       const prefixText = mapped.text.slice(0, visibleStart);
       if (prefixText.length === 0 && cursorXBeforeWrite <= 0) return [];
-      const lastColumnResetVisibleIndex = Math.max(
-        prefixText.lastIndexOf("\r"),
-        convertEol ? prefixText.lastIndexOf("\n") : -1,
-      );
+      const lastColumnResetVisibleIndex = prefixText.lastIndexOf("\r");
       const lastColumnResetRawIndex = lastColumnResetVisibleIndex >= 0
         ? mapped.rawIndexByTextIndex[lastColumnResetVisibleIndex]
         : undefined;

--- a/components/terminal/runtime/promptLineBreak.ts
+++ b/components/terminal/runtime/promptLineBreak.ts
@@ -253,9 +253,13 @@ const measurePromptPrefixColumn = (
             if (privateOrIntermediate) return null;
             column = 0;
             columnKnown = true;
+            separated = true;
             break;
           case "A":
           case "B":
+            if (privateOrIntermediate) return null;
+            separated = true;
+            break;
           case "J":
           case "K":
           case "P":
@@ -264,11 +268,14 @@ const measurePromptPrefixColumn = (
           case "X":
           case "@":
           case "c":
-          case "d":
-          case "e":
           case "m":
           case "n":
           case "q":
+            break;
+          case "d":
+          case "e":
+            if (privateOrIntermediate) return null;
+            separated = true;
             break;
           case "L":
           case "M":

--- a/components/terminal/runtime/promptLineBreak.ts
+++ b/components/terminal/runtime/promptLineBreak.ts
@@ -17,6 +17,7 @@ export type PromptLineBreakState = {
 type VisibleTextMap = {
   text: string;
   rawStartByTextIndex: number[];
+  rawIndexByTextIndex: number[];
 };
 
 const ESC = "\x1b";
@@ -30,10 +31,12 @@ const isCsiFinalByte = (char: string): boolean => {
 const mapVisibleText = (data: string): VisibleTextMap => {
   let text = "";
   const rawStartByTextIndex: number[] = [];
+  const rawIndexByTextIndex: number[] = [];
   let nextVisibleSegmentStart = 0;
 
   const appendVisible = (index: number, char: string) => {
     rawStartByTextIndex.push(nextVisibleSegmentStart);
+    rawIndexByTextIndex.push(index);
     text += char;
     nextVisibleSegmentStart = index + char.length;
   };
@@ -72,7 +75,7 @@ const mapVisibleText = (data: string): VisibleTextMap => {
     }
   }
 
-  return { text, rawStartByTextIndex };
+  return { text, rawStartByTextIndex, rawIndexByTextIndex };
 };
 
 const endsWithLineBreak = (text: string): boolean => {
@@ -223,7 +226,7 @@ export function insertPromptLineBreakBeforePrompt(
   data: string,
   promptText: string,
   cursorXBeforeWrite: number,
-  sourceChunkBoundaries: readonly number[] = [],
+  promptStartsAtSourceChunk = false,
 ): string {
   if (!data || !promptText) return data;
 
@@ -233,7 +236,6 @@ export function insertPromptLineBreakBeforePrompt(
   const promptTextStart = mapped.text.length - promptText.length;
   const prefixText = mapped.text.slice(0, promptTextStart);
   const promptRawStart = mapped.rawStartByTextIndex[promptTextStart] ?? 0;
-  const promptStartsAtSourceChunk = sourceChunkBoundaries.includes(promptRawStart);
   if (prefixText.length === 0 && cursorXBeforeWrite <= 0) return data;
   if (prefixText.length > 0) {
     if (endsWithLineBreak(prefixText)) return data;
@@ -243,12 +245,33 @@ export function insertPromptLineBreakBeforePrompt(
   return `${data.slice(0, promptRawStart)}\r\n${data.slice(promptRawStart)}`;
 }
 
+export function doesTerminalPromptStartAtSourceChunk(
+  data: string,
+  promptText: string,
+  sourceChunkBoundaries: readonly number[],
+): boolean {
+  if (!data || !promptText || sourceChunkBoundaries.length === 0) return false;
+
+  const mapped = mapVisibleText(data);
+  if (!mapped.text.endsWith(promptText)) return false;
+
+  const promptTextStart = mapped.text.length - promptText.length;
+  const promptRawIndex = mapped.rawIndexByTextIndex[promptTextStart];
+  if (promptRawIndex === undefined) return false;
+
+  const previousVisibleRawIndex =
+    promptTextStart > 0 ? mapped.rawIndexByTextIndex[promptTextStart - 1] : -1;
+  return sourceChunkBoundaries.some(
+    (boundary) => boundary > previousVisibleRawIndex && boundary <= promptRawIndex,
+  );
+}
+
 export function prepareTerminalDataForPromptLineBreak(
   term: XTerm,
   data: string,
   state: PromptLineBreakState | undefined,
   enabled: boolean,
-  sourceChunkBoundaries: readonly number[] = [],
+  promptStartsAtSourceChunk = false,
 ): string {
   if (!enabled || !state?.pendingCommand || !state.lastPromptText) return data;
 
@@ -257,7 +280,7 @@ export function prepareTerminalDataForPromptLineBreak(
     data,
     state.lastPromptText,
     cursorXBeforeWrite,
-    sourceChunkBoundaries,
+    promptStartsAtSourceChunk,
   );
   const visibleText = mapVisibleText(data).text;
   const ambiguousPromptSuffix = hasAmbiguousPromptSuffix(data, state.lastPromptText);

--- a/components/terminal/runtime/promptLineBreak.ts
+++ b/components/terminal/runtime/promptLineBreak.ts
@@ -547,13 +547,23 @@ const insertPromptLineBreaksAtVisibleStarts = (
       if (rawStart === undefined) return [];
       const prefixText = mapped.text.slice(0, visibleStart);
       if (prefixText.length === 0 && cursorXBeforeWrite <= 0) return [];
+      const lastColumnResetVisibleIndex = Math.max(
+        prefixText.lastIndexOf("\r"),
+        convertEol ? prefixText.lastIndexOf("\n") : -1,
+      );
+      const lastColumnResetRawIndex = lastColumnResetVisibleIndex >= 0
+        ? mapped.rawIndexByTextIndex[lastColumnResetVisibleIndex]
+        : undefined;
+      const measuredRawStart = lastColumnResetRawIndex === undefined
+        ? 0
+        : lastColumnResetRawIndex + 1;
       if (
         prefixText.length > 0
         && endsAtKnownColumnZero(
           term,
-          data.slice(0, rawStart),
+          data.slice(measuredRawStart, rawStart),
           prefixText,
-          cursorXBeforeWrite,
+          lastColumnResetRawIndex === undefined ? cursorXBeforeWrite : 0,
           convertEol,
         )
       ) return [];

--- a/components/terminal/runtime/promptLineBreak.ts
+++ b/components/terminal/runtime/promptLineBreak.ts
@@ -83,21 +83,223 @@ const endsWithLineBreak = (text: string): boolean => {
   return last === "\n" || last === "\r";
 };
 
+type CsiSequence = {
+  body: string;
+  end: number;
+  final: string;
+};
+
+const readCsiSequence = (data: string, index: number): CsiSequence | null => {
+  const parameterStart = data[index] === ESC ? index + 2 : index + 1;
+  if (data[index] === ESC && data[index + 1] !== "[") return null;
+  for (let end = parameterStart; end < data.length; end += 1) {
+    if (!isCsiFinalByte(data[end])) continue;
+    return {
+      body: data.slice(parameterStart, end),
+      end,
+      final: data[end],
+    };
+  }
+  return null;
+};
+
+const readControlStringEnd = (data: string, start: number): number | null => {
+  for (let index = start; index < data.length; index += 1) {
+    if (data[index] === BEL) return index;
+    if (data[index] === ESC && data[index + 1] === "\\") return index + 1;
+  }
+  return null;
+};
+
+const parseCsiParams = (body: string): number[] => {
+  const parameterText = body.match(/^[0-9;:]*/)?.[0] ?? "";
+  if (!parameterText) return [];
+  return parameterText.split(";").map((part) => {
+    const value = Number.parseInt(part.split(":", 1)[0] ?? "", 10);
+    return Number.isFinite(value) ? value : 0;
+  });
+};
+
+const measurePromptPrefixColumn = (
+  term: XTerm,
+  data: string,
+  startColumn: number,
+  convertEol: boolean,
+): number | null => {
+  const maxColumn = Number.isFinite(term.cols) && term.cols > 0
+    ? term.cols - 1
+    : Number.MAX_SAFE_INTEGER;
+  const clampColumn = (value: number) => Math.max(0, Math.min(maxColumn, value));
+  const parameterCount = (params: readonly number[], index = 0) => Math.max(1, params[index] || 1);
+  let column = clampColumn(startColumn);
+  let savedColumn: number | null = null;
+  let lastPrintableWidth: number | null = null;
+
+  for (let index = 0; index < data.length; index += 1) {
+    const char = data[index];
+    if (char === ESC || char === "\x9b") {
+      const isCsi = char === "\x9b" || data[index + 1] === "[";
+      if (isCsi) {
+        const sequence = readCsiSequence(data, index);
+        if (!sequence) return null;
+        const params = parseCsiParams(sequence.body);
+        const privateOrIntermediate = sequence.body.slice(
+          sequence.body.match(/^[0-9;:]*/)?.[0].length ?? 0,
+        );
+        const count = parameterCount(params);
+        switch (sequence.final) {
+          case "C":
+          case "a":
+            if (privateOrIntermediate) return null;
+            column = clampColumn(column + count);
+            break;
+          case "D":
+            if (privateOrIntermediate) return null;
+            column = clampColumn(column - count);
+            break;
+          case "G":
+          case "`":
+            if (privateOrIntermediate) return null;
+            column = clampColumn(count - 1);
+            break;
+          case "H":
+          case "f":
+            if (privateOrIntermediate) return null;
+            column = clampColumn(parameterCount(params, 1) - 1);
+            break;
+          case "E":
+          case "F":
+            if (privateOrIntermediate) return null;
+            column = 0;
+            break;
+          case "I":
+            if (privateOrIntermediate) return null;
+            for (let tab = 0; tab < count; tab += 1) {
+              column = clampColumn(column + (8 - (column % 8)));
+            }
+            break;
+          case "Z":
+            if (privateOrIntermediate) return null;
+            for (let tab = 0; tab < count; tab += 1) {
+              column = Math.max(0, column - (column % 8 || 8));
+            }
+            break;
+          case "s":
+            if (privateOrIntermediate || params.length > 0) return null;
+            savedColumn = column;
+            break;
+          case "u":
+            if (privateOrIntermediate || params.length > 0 || savedColumn === null) return null;
+            column = savedColumn;
+            break;
+          case "b":
+            if (privateOrIntermediate || lastPrintableWidth === null) return null;
+            column = clampColumn(column + (lastPrintableWidth * count));
+            break;
+          case "r":
+            if (privateOrIntermediate) return null;
+            column = 0;
+            break;
+          case "A":
+          case "B":
+          case "J":
+          case "K":
+          case "L":
+          case "M":
+          case "P":
+          case "S":
+          case "T":
+          case "X":
+          case "@":
+          case "c":
+          case "d":
+          case "e":
+          case "h":
+          case "l":
+          case "m":
+          case "n":
+          case "q":
+            break;
+          default:
+            return null;
+        }
+        index = sequence.end;
+        continue;
+      }
+
+      const next = data[index + 1];
+      if (next === "]" || next === "P" || next === "X" || next === "^" || next === "_") {
+        const end = readControlStringEnd(data, index + 2);
+        if (end === null) return null;
+        index = end;
+        continue;
+      }
+      if (next === "7") {
+        savedColumn = column;
+        index += 1;
+        continue;
+      }
+      if (next === "8") {
+        if (savedColumn === null) return null;
+        column = savedColumn;
+        index += 1;
+        continue;
+      }
+      if (next === "E" || next === "c") {
+        column = 0;
+        index += 1;
+        continue;
+      }
+      if (next === "D" || next === "M" || next === "=" || next === ">" || next === "H") {
+        index += 1;
+        continue;
+      }
+      if (["(", ")", "*", "+", "-", ".", "/"].includes(next) && data[index + 2]) {
+        index += 2;
+        continue;
+      }
+      return null;
+    }
+
+    if (char === "\n" || char === "\v" || char === "\f") {
+      if (convertEol) column = 0;
+      continue;
+    }
+    if (char === "\r") {
+      column = 0;
+      continue;
+    }
+    if (char === "\b") {
+      column = Math.max(0, column - 1);
+      continue;
+    }
+    if (char === "\t") {
+      column = clampColumn(column + (8 - (column % 8)));
+      continue;
+    }
+    const code = char.charCodeAt(0);
+    if (code < 0x20 || code === 0x7f) {
+      if (code === 0 || code === 7 || code === 14 || code === 15) continue;
+      return null;
+    }
+    if (code > 0x7e) return null;
+    lastPrintableWidth = 1;
+    column = clampColumn(column + 1);
+  }
+
+  return column;
+};
+
 const endsAtKnownColumnZero = (
-  text: string,
+  term: XTerm,
+  rawText: string,
+  visibleText: string,
   cursorXBeforeWrite: number,
   convertEol: boolean,
-): boolean => {
-  if (text.endsWith("\r")) return true;
-  if (!text.endsWith("\n")) return false;
-  if (convertEol) return true;
-
-  const beforeFinalLineFeed = text.slice(0, -1);
-  const lastCarriageReturn = beforeFinalLineFeed.lastIndexOf("\r");
-  const sinceColumnReset = beforeFinalLineFeed.slice(lastCarriageReturn + 1);
-  if (sinceColumnReset.replaceAll("\n", "").length > 0) return false;
-  return lastCarriageReturn >= 0 || cursorXBeforeWrite <= 0;
-};
+): boolean => (
+  endsWithLineBreak(visibleText)
+  && measurePromptPrefixColumn(term, rawText, cursorXBeforeWrite, convertEol) === 0
+);
 
 const containsLineReset = (text: string): boolean =>
   text.includes("\n") || text.includes("\r");
@@ -327,6 +529,7 @@ export function findTerminalPromptSourceChunkVisibleStarts(
 }
 
 const insertPromptLineBreaksAtVisibleStarts = (
+  term: XTerm,
   data: string,
   promptText: string,
   cursorXBeforeWrite: number,
@@ -340,14 +543,21 @@ const insertPromptLineBreaksAtVisibleStarts = (
       if (mapped.text.slice(visibleStart, visibleStart + promptText.length) !== promptText) {
         return [];
       }
+      const rawStart = mapped.rawStartByTextIndex[visibleStart];
+      if (rawStart === undefined) return [];
       const prefixText = mapped.text.slice(0, visibleStart);
       if (prefixText.length === 0 && cursorXBeforeWrite <= 0) return [];
       if (
         prefixText.length > 0
-        && endsAtKnownColumnZero(prefixText, cursorXBeforeWrite, convertEol)
+        && endsAtKnownColumnZero(
+          term,
+          data.slice(0, rawStart),
+          prefixText,
+          cursorXBeforeWrite,
+          convertEol,
+        )
       ) return [];
-      const rawStart = mapped.rawStartByTextIndex[visibleStart];
-      return rawStart === undefined ? [] : [rawStart];
+      return [rawStart];
     });
   if (rawStarts.length === 0) return data;
 
@@ -372,6 +582,7 @@ export function prepareTerminalDataForPromptLineBreak(
   const cursorXBeforeWrite = getCursorX(term);
   const nextData = promptVisibleStarts.length > 0
     ? insertPromptLineBreaksAtVisibleStarts(
+      term,
       data,
       state.lastPromptText,
       cursorXBeforeWrite,

--- a/components/terminal/runtime/promptLineBreak.ts
+++ b/components/terminal/runtime/promptLineBreak.ts
@@ -245,43 +245,115 @@ export function insertPromptLineBreakBeforePrompt(
   return `${data.slice(0, promptRawStart)}\r\n${data.slice(promptRawStart)}`;
 }
 
-export function doesTerminalPromptStartAtSourceChunk(
+const lowerBoundRawIndex = (rawIndexes: readonly number[], target: number): number => {
+  let low = 0;
+  let high = rawIndexes.length;
+  while (low < high) {
+    const middle = low + Math.floor((high - low) / 2);
+    if (rawIndexes[middle] < target) {
+      low = middle + 1;
+    } else {
+      high = middle;
+    }
+  }
+  return low;
+};
+
+export function findTerminalPromptSourceChunkVisibleStarts(
   data: string,
   promptText: string,
   sourceChunkBoundaries: readonly number[] = [],
-): boolean {
-  if (!data || !promptText || sourceChunkBoundaries.length === 0) return false;
+): number[] {
+  if (!data || !promptText) return [];
 
   const mapped = mapVisibleText(data);
-  if (!mapped.text.endsWith(promptText)) return false;
+  const boundaries = [
+    0,
+    ...sourceChunkBoundaries.filter(
+      (boundary, index) => (
+        boundary > 0
+        && boundary < data.length
+        && (index === 0 || boundary > sourceChunkBoundaries[index - 1])
+      ),
+    ),
+    data.length,
+  ];
+  const promptVisibleStarts: number[] = [];
 
-  const promptTextStart = mapped.text.length - promptText.length;
-  const promptRawIndex = mapped.rawIndexByTextIndex[promptTextStart];
-  if (promptRawIndex === undefined) return false;
+  for (let index = 0; index < boundaries.length - 1; index += 1) {
+    const chunkVisibleStart = lowerBoundRawIndex(
+      mapped.rawIndexByTextIndex,
+      boundaries[index],
+    );
+    const chunkVisibleEnd = lowerBoundRawIndex(
+      mapped.rawIndexByTextIndex,
+      boundaries[index + 1],
+    );
+    if (chunkVisibleEnd <= chunkVisibleStart) continue;
 
-  const previousVisibleRawIndex =
-    promptTextStart > 0 ? mapped.rawIndexByTextIndex[promptTextStart - 1] : -1;
-  return sourceChunkBoundaries.some(
-    (boundary) => boundary > previousVisibleRawIndex && boundary <= promptRawIndex,
-  );
+    const chunkText = mapped.text.slice(chunkVisibleStart, chunkVisibleEnd);
+    if (!chunkText.endsWith(promptText)) continue;
+    const promptVisibleStart = chunkVisibleEnd - promptText.length;
+    const chunkPrefix = mapped.text.slice(chunkVisibleStart, promptVisibleStart);
+    if (chunkPrefix.length > 0 && !isDistinctPromptText(promptText)) continue;
+    promptVisibleStarts.push(promptVisibleStart);
+  }
+
+  return promptVisibleStarts;
 }
+
+const insertPromptLineBreaksAtVisibleStarts = (
+  data: string,
+  promptText: string,
+  cursorXBeforeWrite: number,
+  promptVisibleStarts: readonly number[],
+): string => {
+  const mapped = mapVisibleText(data);
+  const rawStarts = [...new Set(promptVisibleStarts)]
+    .sort((left, right) => left - right)
+    .flatMap((visibleStart) => {
+      if (mapped.text.slice(visibleStart, visibleStart + promptText.length) !== promptText) {
+        return [];
+      }
+      const prefixText = mapped.text.slice(0, visibleStart);
+      if (prefixText.length === 0 && cursorXBeforeWrite <= 0) return [];
+      if (prefixText.length > 0 && endsWithLineBreak(prefixText)) return [];
+      const rawStart = mapped.rawStartByTextIndex[visibleStart];
+      return rawStart === undefined ? [] : [rawStart];
+    });
+  if (rawStarts.length === 0) return data;
+
+  let result = "";
+  let lastRawIndex = 0;
+  for (const rawStart of rawStarts) {
+    result += `${data.slice(lastRawIndex, rawStart)}\r\n`;
+    lastRawIndex = rawStart;
+  }
+  return `${result}${data.slice(lastRawIndex)}`;
+};
 
 export function prepareTerminalDataForPromptLineBreak(
   term: XTerm,
   data: string,
   state: PromptLineBreakState | undefined,
   enabled: boolean,
-  promptStartsAtSourceChunk = false,
+  promptVisibleStarts: readonly number[] = [],
 ): string {
   if (!enabled || !state?.pendingCommand || !state.lastPromptText) return data;
 
   const cursorXBeforeWrite = getCursorX(term);
-  const nextData = insertPromptLineBreakBeforePrompt(
-    data,
-    state.lastPromptText,
-    cursorXBeforeWrite,
-    promptStartsAtSourceChunk,
-  );
+  const nextData = promptVisibleStarts.length > 0
+    ? insertPromptLineBreaksAtVisibleStarts(
+      data,
+      state.lastPromptText,
+      cursorXBeforeWrite,
+      promptVisibleStarts,
+    )
+    : insertPromptLineBreakBeforePrompt(
+      data,
+      state.lastPromptText,
+      cursorXBeforeWrite,
+    );
   const visibleText = mapVisibleText(data).text;
   const ambiguousPromptSuffix = hasAmbiguousPromptSuffix(data, state.lastPromptText);
   state.suppressNextPromptCache =

--- a/components/terminal/runtime/promptLineBreak.ts
+++ b/components/terminal/runtime/promptLineBreak.ts
@@ -83,6 +83,20 @@ const endsWithLineBreak = (text: string): boolean => {
   return last === "\n" || last === "\r";
 };
 
+const endsAtKnownColumnZero = (
+  text: string,
+  cursorXBeforeWrite: number,
+): boolean => {
+  if (text.endsWith("\r")) return true;
+  if (!text.endsWith("\n")) return false;
+
+  const beforeFinalLineFeed = text.slice(0, -1);
+  const lastCarriageReturn = beforeFinalLineFeed.lastIndexOf("\r");
+  const sinceColumnReset = beforeFinalLineFeed.slice(lastCarriageReturn + 1);
+  if (sinceColumnReset.replaceAll("\n", "").length > 0) return false;
+  return lastCarriageReturn >= 0 || cursorXBeforeWrite <= 0;
+};
+
 const containsLineReset = (text: string): boolean =>
   text.includes("\n") || text.includes("\r");
 
@@ -317,7 +331,10 @@ const insertPromptLineBreaksAtVisibleStarts = (
       }
       const prefixText = mapped.text.slice(0, visibleStart);
       if (prefixText.length === 0 && cursorXBeforeWrite <= 0) return [];
-      if (prefixText.length > 0 && endsWithLineBreak(prefixText)) return [];
+      if (
+        prefixText.length > 0
+        && endsAtKnownColumnZero(prefixText, cursorXBeforeWrite)
+      ) return [];
       const rawStart = mapped.rawStartByTextIndex[visibleStart];
       return rawStart === undefined ? [] : [rawStart];
     });

--- a/components/terminal/runtime/promptLineBreak.ts
+++ b/components/terminal/runtime/promptLineBreak.ts
@@ -122,9 +122,22 @@ const parseCsiParams = (body: string): number[] => {
 
 const CURSOR_PREFIX_CSI_FINALS = new Set([
   "@", "A", "B", "C", "D", "E", "F", "G", "H", "I", "L", "M",
-  "P", "S", "T", "X", "Z", "`", "a", "d", "e", "f", "h", "l", "r",
+  "P", "S", "T", "X", "Z", "`", "a", "d", "e", "f", "r",
   "s", "u",
 ]);
+
+const CURSOR_AFFECTING_PRIVATE_MODES = new Set([3, 6, 47, 1047, 1048, 1049]);
+
+const isCursorAffectingCsiSequence = (sequence: CsiSequence): boolean => {
+  if (CURSOR_PREFIX_CSI_FINALS.has(sequence.final)) return true;
+  if ((sequence.final !== "h" && sequence.final !== "l") || !sequence.body.startsWith("?")) {
+    return false;
+  }
+  return sequence.body.slice(1).split(";").some((part) => {
+    const mode = Number.parseInt(part.split(":", 1)[0] ?? "", 10);
+    return CURSOR_AFFECTING_PRIVATE_MODES.has(mode);
+  });
+};
 
 const advancePromptBreakPastLeadingCursorControls = (
   data: string,
@@ -139,7 +152,7 @@ const advancePromptBreakPastLeadingCursorControls = (
       if (isCsi) {
         const sequence = readCsiSequence(data, index);
         if (!sequence || sequence.end >= firstVisibleRawIndex) break;
-        if (CURSOR_PREFIX_CSI_FINALS.has(sequence.final)) {
+        if (isCursorAffectingCsiSequence(sequence)) {
           breakIndex = sequence.end + 1;
         }
         index = sequence.end;

--- a/components/terminal/runtime/promptLineBreak.ts
+++ b/components/terminal/runtime/promptLineBreak.ts
@@ -248,7 +248,7 @@ export function insertPromptLineBreakBeforePrompt(
 export function doesTerminalPromptStartAtSourceChunk(
   data: string,
   promptText: string,
-  sourceChunkBoundaries: readonly number[],
+  sourceChunkBoundaries: readonly number[] = [],
 ): boolean {
   if (!data || !promptText || sourceChunkBoundaries.length === 0) return false;
 

--- a/components/terminal/runtime/promptLineBreak.ts
+++ b/components/terminal/runtime/promptLineBreak.ts
@@ -215,6 +215,7 @@ const measurePromptPrefixColumn = (
           case "C":
           case "a":
             if (privateOrIntermediate) return null;
+            // CUF clamps at the margin in xterm; it does not wrap.
             if (columnKnown) column = clampColumn(column + count);
             break;
           case "D":
@@ -260,7 +261,19 @@ const measurePromptPrefixColumn = (
             break;
           case "b":
             if (privateOrIntermediate || lastPrintableWidth === null) return null;
-            if (columnKnown) column = clampColumn(column + (lastPrintableWidth * count));
+            if (columnKnown) {
+              // REP repeats a printable; model simple line wrap like printables.
+              for (let rep = 0; rep < count; rep += 1) {
+                for (let width = 0; width < lastPrintableWidth; width += 1) {
+                  if (column >= maxColumn) {
+                    column = 0;
+                    separated = true;
+                  } else {
+                    column += 1;
+                  }
+                }
+              }
+            }
             break;
           case "r":
             if (privateOrIntermediate) return null;
@@ -382,7 +395,17 @@ const measurePromptPrefixColumn = (
       continue;
     }
     lastPrintableWidth = 1;
-    if (columnKnown) column = clampColumn(column + 1);
+    if (columnKnown) {
+      if (column >= maxColumn) {
+        // Simple wrap: a full-width line leaves the cursor at column 0 of the
+        // next row. Clamping at cols-1 falsely looked mid-line and inserted an
+        // extra blank before the following prompt.
+        column = 0;
+        separated = true;
+      } else {
+        column = column + 1;
+      }
+    }
   }
 
   return columnKnown ? { column, separated } : null;

--- a/components/terminal/runtime/promptLineBreak.ts
+++ b/components/terminal/runtime/promptLineBreak.ts
@@ -86,9 +86,11 @@ const endsWithLineBreak = (text: string): boolean => {
 const endsAtKnownColumnZero = (
   text: string,
   cursorXBeforeWrite: number,
+  convertEol: boolean,
 ): boolean => {
   if (text.endsWith("\r")) return true;
   if (!text.endsWith("\n")) return false;
+  if (convertEol) return true;
 
   const beforeFinalLineFeed = text.slice(0, -1);
   const lastCarriageReturn = beforeFinalLineFeed.lastIndexOf("\r");
@@ -120,6 +122,14 @@ const getCursorX = (term: XTerm): number => {
     return term.buffer.active.cursorX;
   } catch {
     return 0;
+  }
+};
+
+const getConvertEol = (term: XTerm): boolean => {
+  try {
+    return term.options.convertEol === true;
+  } catch {
+    return false;
   }
 };
 
@@ -321,6 +331,7 @@ const insertPromptLineBreaksAtVisibleStarts = (
   promptText: string,
   cursorXBeforeWrite: number,
   promptVisibleStarts: readonly number[],
+  convertEol: boolean,
 ): string => {
   const mapped = mapVisibleText(data);
   const rawStarts = [...new Set(promptVisibleStarts)]
@@ -333,7 +344,7 @@ const insertPromptLineBreaksAtVisibleStarts = (
       if (prefixText.length === 0 && cursorXBeforeWrite <= 0) return [];
       if (
         prefixText.length > 0
-        && endsAtKnownColumnZero(prefixText, cursorXBeforeWrite)
+        && endsAtKnownColumnZero(prefixText, cursorXBeforeWrite, convertEol)
       ) return [];
       const rawStart = mapped.rawStartByTextIndex[visibleStart];
       return rawStart === undefined ? [] : [rawStart];
@@ -365,6 +376,7 @@ export function prepareTerminalDataForPromptLineBreak(
       state.lastPromptText,
       cursorXBeforeWrite,
       promptVisibleStarts,
+      getConvertEol(term),
     )
     : insertPromptLineBreakBeforePrompt(
       data,

--- a/components/terminal/runtime/terminalCloseCapture.test.ts
+++ b/components/terminal/runtime/terminalCloseCapture.test.ts
@@ -62,16 +62,18 @@ test("isTerminalCloseGenerationCurrent rejects stale close generations", () => {
   assert.equal(isTerminalCloseGenerationCurrent(1, 2), false);
 });
 
-test("terminal close drains pending output before finalizing capture", () => {
+test("terminal close fully drains pending output before finalizing capture", () => {
   const source = readFileSync(
     new URL("../useTerminalEffects.ts", import.meta.url),
     "utf8",
   );
   const cleanupStart = source.indexOf("return () => {", source.indexOf("boot();"));
-  const flushIndex = source.indexOf("flushPendingTerminalWritesOnResume(term)", cleanupStart);
+  const flushIndex = source.indexOf("await flushPendingTerminalWritesBeforeHibernate(term)", cleanupStart);
+  const incompleteIndex = source.indexOf("if (!flushed)", flushIndex);
   const finalizeIndex = source.indexOf("resolveConnectionLogCapturePayload(finalizeTerminalLogData)", cleanupStart);
 
   assert.ok(cleanupStart >= 0);
   assert.ok(flushIndex > cleanupStart);
+  assert.ok(incompleteIndex > flushIndex);
   assert.ok(finalizeIndex > flushIndex);
 });

--- a/components/terminal/runtime/terminalCloseCapture.test.ts
+++ b/components/terminal/runtime/terminalCloseCapture.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { readFileSync } from "node:fs";
 
 import {
   isTerminalCloseGenerationCurrent,
@@ -59,4 +60,18 @@ test("scheduleTerminalCloseTeardown runs teardown asynchronously", async () => {
 test("isTerminalCloseGenerationCurrent rejects stale close generations", () => {
   assert.equal(isTerminalCloseGenerationCurrent(1, 1), true);
   assert.equal(isTerminalCloseGenerationCurrent(1, 2), false);
+});
+
+test("terminal close drains pending output before finalizing capture", () => {
+  const source = readFileSync(
+    new URL("../useTerminalEffects.ts", import.meta.url),
+    "utf8",
+  );
+  const cleanupStart = source.indexOf("return () => {", source.indexOf("boot();"));
+  const flushIndex = source.indexOf("flushPendingTerminalWritesOnResume(term)", cleanupStart);
+  const finalizeIndex = source.indexOf("resolveConnectionLogCapturePayload(finalizeTerminalLogData)", cleanupStart);
+
+  assert.ok(cleanupStart >= 0);
+  assert.ok(flushIndex > cleanupStart);
+  assert.ok(finalizeIndex > flushIndex);
 });

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -17,6 +17,10 @@ import {
   tryMeasureVisualRows,
   getVisualRowMeasureCountForTests,
   resetVisualRowMeasureCountForTests,
+  getTerminalLineTimestampLedgerCount,
+  getTerminalLineTimestampEntryCount,
+  materializeTimestampLedgerToMarkers,
+  getVisibleTerminalLineTimestampRows,
   type TerminalLineTimestampPerfStep,
   writeTerminalDataWithLineTimestamps,
 } from "./terminalLineTimestamps.ts";
@@ -106,12 +110,29 @@ const createFakeTerm = (options: {
     }
   };
 
+  const activeBuffer = {
+    type: "normal" as string,
+    viewportY: 0,
+    get baseY() {
+      return 0;
+    },
+    get cursorY() {
+      return cursorLine;
+    },
+    get cursorX() {
+      return cursorColumn;
+    },
+    get length() {
+      return cursorLine + 1;
+    },
+    getLine: () => ({ isWrapped: false }),
+  };
   const term = {
     _core: {
       unicodeService,
     },
     buffer: {
-      active: { type: "normal", viewportY: 0 },
+      active: activeBuffer,
     },
     cols,
     options: Number.isFinite(scrollback) ? { scrollback } : {},
@@ -281,14 +302,55 @@ test("formats timestamp labels without terminal escape codes", () => {
   assert.equal(formatTerminalLineTimestamp(new Date(2026, 5, 6, 1, 2, 3)), "01:02:03");
 });
 
-test("skips segmenter and markers when timestamps are disabled", () => {
+test("gutter off records a per-second ledger without markers", () => {
   const { term, writes, markerLines } = createFakeTerm();
-  writeTerminalDataWithLineTimestamps(term as never, "before\r\nnext", () => {}, {
+  const t0 = new Date(2026, 5, 6, 12, 0, 0);
+  writeTerminalDataWithLineTimestamps(term as never, "before\r\nnext\r\nthird", () => {}, {
     enabled: false,
+    timestampDate: t0,
   });
 
-  assert.equal(writes.join(""), "before\r\nnext");
+  assert.equal(writes.join(""), "before\r\nnext\r\nthird");
   assert.deepEqual(markerLines, []);
+  // Same second → one ledger stamp for three lines.
+  assert.equal(getTerminalLineTimestampLedgerCount(term as never), 1);
+});
+
+test("gutter off keeps one ledger stamp per wall-clock second", () => {
+  const { term, markerLines } = createFakeTerm();
+  writeTerminalDataWithLineTimestamps(term as never, "a\r\nb\r\n", () => {}, {
+    enabled: false,
+    timestampDate: new Date(2026, 5, 6, 12, 0, 0),
+  });
+  writeTerminalDataWithLineTimestamps(term as never, "c\r\nd\r\n", () => {}, {
+    enabled: false,
+    timestampDate: new Date(2026, 5, 6, 12, 0, 1),
+  });
+
+  assert.deepEqual(markerLines, []);
+  assert.equal(getTerminalLineTimestampLedgerCount(term as never), 2);
+});
+
+test("opening gutter materializes ledger stamps into markers", () => {
+  const { term, markerLines } = createFakeTerm();
+  writeTerminalDataWithLineTimestamps(term as never, "a\r\nb\r\n", () => {}, {
+    enabled: false,
+    timestampDate: new Date(2026, 5, 6, 12, 0, 0),
+  });
+  writeTerminalDataWithLineTimestamps(term as never, "c\r\n", () => {}, {
+    enabled: false,
+    timestampDate: new Date(2026, 5, 6, 12, 0, 1),
+  });
+  assert.deepEqual(markerLines, []);
+
+  const created = materializeTimestampLedgerToMarkers(term as never);
+  assert.equal(created, 2);
+  assert.equal(getTerminalLineTimestampEntryCount(term as never, { prune: false }), 2);
+  assert.ok(markerLines.length >= 1);
+
+  // Paint path also materializes (idempotent).
+  const rows = getVisibleTerminalLineTimestampRows(term as never);
+  assert.ok(rows.length >= 1);
 });
 
 test("records line timestamps when enabled (default for direct callers)", () => {

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -11,6 +11,7 @@ import {
   getVisibleTerminalLineTimestampRows,
   isSimpleAsciiControlText,
   onTerminalLineTimestampsChange,
+  resetTerminalLineTimestamps,
   resolveTerminalLineTimestampCapacity,
   resolveTerminalTimestampGutterRows,
   tryMeasureVisualRows,
@@ -889,6 +890,8 @@ test("large slow batches keep live xterm markers near the retained capacity", as
       });
     }
 
+    await new Promise((resolve) => { setTimeout(resolve, 100); });
+
     assert.ok(term.markers.length <= MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES + 512);
     assert.equal(
       getTerminalLineTimestampEntryCount(term),
@@ -897,6 +900,28 @@ test("large slow batches keep live xterm markers near the retained capacity", as
   } finally {
     term.dispose();
   }
+});
+
+test("large timestamp prunes defer orphan disposal across later tasks", async () => {
+  const { term, disposedMarkerLines } = createFakeTerm({
+    scrollback: 100000,
+    rows: 24,
+  });
+  const lines = Array.from(
+    { length: MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES },
+    (_, index) => `line-${index}`,
+  ).join("\r\n");
+
+  writeTerminalDataWithLineTimestamps(term as never, lines, () => {});
+  writeTerminalDataWithLineTimestamps(term as never, lines, () => {});
+
+  const disposedImmediately = disposedMarkerLines.length;
+  assert.equal(disposedImmediately, 64);
+
+  await new Promise((resolve) => { setTimeout(resolve, 10); });
+  assert.ok(disposedMarkerLines.length > disposedImmediately);
+
+  resetTerminalLineTimestamps(term as never);
 });
 
 test("small batched writes amortize full timestamp-store pruning", () => {

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -8,6 +8,7 @@ import {
   createTerminalLineTimestampSegmenter,
   formatTerminalLineTimestamp,
   getTerminalLineTimestampEntryCount,
+  getVisibleTerminalLineTimestampRows,
   isSimpleAsciiControlText,
   onTerminalLineTimestampsChange,
   resolveTerminalLineTimestampCapacity,
@@ -413,14 +414,47 @@ test("accounts for backspace cursor movement when batching timestamp markers", (
   assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
 });
 
-test("accounts for tab stops without soft wrapping timestamp markers", () => {
+test("keeps tabbed writes on the segmented path so xterm owns tab stops", () => {
   const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
+  const steps: string[] = [];
   const lines = Array.from({ length: 80 }, () => "\t").join("\r\n");
 
-  writeTerminalDataWithLineTimestamps(term as never, lines, () => {});
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    lines,
+    () => {},
+    { onStep: (step) => steps.push(step.kind) },
+  );
 
-  assert.deepEqual(writes, [lines]);
+  assert.equal(writes.join(""), lines);
+  assert.equal(steps.includes("batched-write"), false);
+  assert.equal(steps.includes("segmented-write"), true);
   assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
+});
+
+test("uses changed xterm tab stops when placing timestamps", async () => {
+  const require = createRequire(import.meta.url);
+  const { Terminal } = require("@xterm/xterm") as {
+    Terminal: new (options: Record<string, unknown>) => XTerm;
+  };
+  const term = new Terminal({ cols: 10, rows: 5, scrollback: 20, allowProposedApi: true });
+  const rawWrite = (data: string) => new Promise<void>((resolve) => term.write(data, resolve));
+  const timestampedWrite = (data: string) => new Promise<void>((resolve) => {
+    writeTerminalDataWithLineTimestamps(term, data, resolve);
+  });
+
+  try {
+    // Clear all tab stops. xterm then treats TAB differently from the default
+    // eight-column model used by the fast-path estimator.
+    await rawWrite("\x1b[3g");
+    await timestampedWrite("aa\tXY\r\nb");
+
+    const rows = getVisibleTerminalLineTimestampRows(term);
+    assert.deepEqual(rows.map(({ row }) => row), [0, 1, 2]);
+    assert.ok(rows.every(({ label }) => /^\d{2}:\d{2}:\d{2}$/.test(label)));
+  } finally {
+    term.dispose();
+  }
 });
 
 test("falls back from batched timestamp markers for combining characters", () => {

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -92,33 +92,80 @@ const createFakeTerm = (options: {
       return cellWidth(String.fromCodePoint(codePoint));
     },
   };
-  const trimMarkersToScrollback = () => {
-    if (!Number.isFinite(scrollback) || scrollback === undefined || scrollback < 0) return;
-    // Approximate xterm: keep the newest (scrollback + rows) buffer lines.
-    const keepFromLine = Math.max(0, cursorLine - (scrollback + rows) + 1);
+  // Approximate xterm: buffer always has at least `rows` lines; once full
+  // (scrollback + rows), further growth raises baseY and trims the top.
+  const maxBufferLines = Number.isFinite(scrollback) && scrollback !== undefined && scrollback >= 0
+    ? scrollback + rows
+    : Number.POSITIVE_INFINITY;
+  let absoluteCursorLine = 0;
+  let baseY = 0;
+  /** When null, viewport follows bottom (baseY). Tests may pin a scroll-up offset. */
+  let viewportYOverride: number | null = null;
+  const lineText = new Map<number, string>();
+
+  // When not yet full, length grows with content but never below viewport.
+  // When full, length stays at maxBufferLines and baseY tracks the trim offset.
+  const resolveLength = (): number => {
+    if (!Number.isFinite(maxBufferLines)) {
+      return Math.max(rows, absoluteCursorLine + 1);
+    }
+    // absolute lines still in buffer: [baseY, baseY + length)
+    return Math.min(maxBufferLines, Math.max(rows, absoluteCursorLine - baseY + 1));
+  };
+
+  const trimScrollbackIfNeeded = () => {
+    if (!Number.isFinite(maxBufferLines)) return;
+    // Cursor absolute line past the last retained slot → drop from top.
+    while (absoluteCursorLine - baseY + 1 > maxBufferLines) {
+      baseY += 1;
+    }
+    const keepFromAbsolute = baseY;
     for (const marker of liveMarkers) {
-      if (!marker.isDisposed && marker.line < keepFromLine) {
+      if (!marker.isDisposed && marker.line < keepFromAbsolute) {
         marker.dispose();
       }
+    }
+    for (const key of [...lineText.keys()]) {
+      if (key < keepFromAbsolute) lineText.delete(key);
     }
   };
 
   const activeBuffer = {
     type: "normal" as string,
-    viewportY: 0,
+    get viewportY() {
+      return viewportYOverride ?? baseY;
+    },
+    set viewportY(value: number) {
+      viewportYOverride = Math.max(0, value);
+    },
     get baseY() {
-      return 0;
+      return baseY;
+    },
+    set baseY(value: number) {
+      baseY = Math.max(0, value);
     },
     get cursorY() {
-      return cursorLine;
+      // Relative to bottom page (baseY).
+      return Math.max(0, absoluteCursorLine - baseY);
+    },
+    set cursorY(value: number) {
+      absoluteCursorLine = baseY + Math.max(0, value);
+      cursorLine = absoluteCursorLine;
     },
     get cursorX() {
       return cursorColumn;
     },
     get length() {
-      return cursorLine + 1;
+      return resolveLength();
     },
-    getLine: () => ({ isWrapped: false }),
+    getLine: (line?: number) => {
+      const absolute = typeof line === "number" ? line : absoluteCursorLine;
+      const text = lineText.get(absolute) ?? "";
+      return {
+        isWrapped: false,
+        translateToString: (_trimRight?: boolean) => text,
+      };
+    },
   };
   const term = {
     _core: {
@@ -139,15 +186,18 @@ const createFakeTerm = (options: {
         const sequence = readCsiSequence(data, index);
         if (sequence) {
           applyCsiSequence(sequence.sequence);
+          absoluteCursorLine = cursorLine;
           index = sequence.endIndex;
           continue;
         }
         const char = data[index];
         if (char === "\n") {
-          cursorLine += 1;
-          if (Number.isFinite(cols) && cursorColumn >= cols) {
-            cursorColumn = cols - 1;
-          }
+          absoluteCursorLine += 1;
+          cursorLine = absoluteCursorLine;
+          cursorColumn = Number.isFinite(cols) && cursorColumn >= cols
+            ? cols - 1
+            : 0;
+          trimScrollbackIfNeeded();
         } else if (char === "\r") {
           cursorColumn = 0;
         } else if (char === "\b") {
@@ -169,19 +219,24 @@ const createFakeTerm = (options: {
             index += 1;
           }
           if (wraparoundMode && cursorColumn + width > cols) {
-            cursorLine += 1;
+            absoluteCursorLine += 1;
+            cursorLine = absoluteCursorLine;
             cursorColumn = 0;
+            trimScrollbackIfNeeded();
           }
+          const existing = lineText.get(absoluteCursorLine) ?? "";
+          lineText.set(absoluteCursorLine, existing + (isEmojiVariationSequence ? "❤️" : char));
           cursorColumn = Number.isFinite(cols)
             ? Math.min(cols, cursorColumn + width)
             : cursorColumn + width;
         }
       }
-      trimMarkersToScrollback();
+      cursorLine = absoluteCursorLine;
+      trimScrollbackIfNeeded();
       callback?.();
     },
     registerMarker(offset: number) {
-      const line = cursorLine + offset;
+      const line = absoluteCursorLine + offset;
       markerLines.push(line);
       const marker = {
         line,
@@ -197,7 +252,22 @@ const createFakeTerm = (options: {
     },
   };
 
-  return { term, writes, markerLines, disposedMarkerLines, liveMarkers };
+  return {
+    term,
+    writes,
+    markerLines,
+    disposedMarkerLines,
+    liveMarkers,
+    /** Test helper: inspect / force xterm-like baseY growth. */
+    getBaseY: () => baseY,
+    setBaseY: (value: number) => {
+      baseY = Math.max(0, value);
+    },
+    setViewportY: (value: number) => {
+      viewportYOverride = Math.max(0, value);
+    },
+    getAbsoluteCursorLine: () => absoluteCursorLine,
+  };
 };
 
 test("segments terminal output into raw bytes plus timestamp markers", () => {
@@ -436,6 +506,97 @@ test("resolveTerminalTimestampGutterRowsFromLedger fills gaps with previous time
     { row: 3, label: "12:00:01" },
     { row: 4, label: "12:00:01" },
   ]);
+});
+
+test("resolveTerminalTimestampGutterRowsFromLedger does not paint past lastPaintLine", () => {
+  // Viewport is 10 rows but content only reaches line 2 — empty rows stay blank.
+  const rows = resolveTerminalTimestampGutterRowsFromLedger({
+    viewportY: 0,
+    rows: 10,
+    lastPaintLine: 2,
+    ledger: [
+      { label: "12:00:00", secondKey: 1, line: 0 },
+    ],
+  });
+  assert.deepEqual(rows, [
+    { row: 0, label: "12:00:00" },
+    { row: 1, label: "12:00:00" },
+    { row: 2, label: "12:00:00" },
+  ]);
+});
+
+test("gutter paint does not fill empty viewport rows past real content", () => {
+  // Fake buffer length is always >= rows (like xterm), even with few content lines.
+  const { term } = createFakeTerm({ rows: 24 });
+  writeTerminalDataWithLineTimestamps(term as never, "motd\r\nlogin\r\n", () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 0),
+  });
+
+  const painted = getVisibleTerminalLineTimestampRows(term as never);
+  // "motd\nlogin\n" → content on lines 0-1; cursor sits empty on line 2.
+  assert.ok(painted.length > 0);
+  assert.ok(
+    painted.every((row) => row.row <= 1),
+    `expected paint only on content rows, got rows: ${painted.map((r) => r.row).join(",")}`,
+  );
+  assert.equal(painted.at(-1)?.row, 1);
+});
+
+test("baseY growth while buffer is still growing does not drop early ledger stamps", () => {
+  // Large scrollback so a short session is not yet "full"; baseY may still rise
+  // as the viewport follows the cursor. Old logic rebased on every baseY delta
+  // and wiped MOTD stamps even though nothing was trimmed.
+  const fake = createFakeTerm({ rows: 10, scrollback: 1000 });
+  const { term } = fake;
+
+  writeTerminalDataWithLineTimestamps(term as never, "banner-line\r\n", () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 0),
+  });
+  writeTerminalDataWithLineTimestamps(term as never, "later-line\r\n", () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 5),
+  });
+
+  assert.equal(getTerminalLineTimestampLedgerCount(term as never), 2);
+
+  // Simulate mistaken "baseY follows cursor" growth while buffer not full.
+  fake.setBaseY(2);
+  // Scroll back to the top so paint includes the original banner line.
+  fake.setViewportY(0);
+
+  const painted = getVisibleTerminalLineTimestampRows(term as never);
+  // Early stamp must still fill-forward (not discarded by rebase).
+  assert.ok(
+    painted.some((row) => row.label === "12:00:00"),
+    `expected early stamp still visible, got ${JSON.stringify(painted)}`,
+  );
+  assert.equal(getTerminalLineTimestampLedgerCount(term as never), 2);
+});
+
+test("full-buffer scrollback trim rebases ledger and drops lines past the top", () => {
+  const fake = createFakeTerm({ rows: 4, scrollback: 4 });
+  const { term } = fake;
+  // maxLines = 4 + 4 = 8. Write enough distinct seconds to stamp many lines,
+  // then overflow so baseY grows while buffer is full.
+
+  for (let second = 0; second < 12; second += 1) {
+    writeTerminalDataWithLineTimestamps(
+      term as never,
+      `line-${second}\r\n`,
+      () => {},
+      { timestampDate: new Date(2026, 5, 6, 12, 0, second) },
+    );
+  }
+
+  assert.ok(fake.getBaseY() > 0, "expected scrollback trim to raise baseY");
+  const ledgerCount = getTerminalLineTimestampLedgerCount(term as never);
+  assert.ok(ledgerCount > 0);
+  // Stamps for lines that scrolled off the top must be gone after rebase+filter.
+  const painted = getVisibleTerminalLineTimestampRows(term as never);
+  assert.ok(painted.length > 0);
+  // Every painted label should still be a valid HH:MM:SS from our window.
+  for (const row of painted) {
+    assert.match(row.label, /^12:00:\d{2}$/);
+  }
 });
 
 

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -5,6 +5,7 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 
 import {
   MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES,
+  applyAltScreenAction,
   createTerminalLineTimestampSegmenter,
   formatTerminalLineTimestamp,
   getTerminalLineTimestampLedgerCount,
@@ -16,6 +17,7 @@ import {
   resolveTerminalTimestampGutterRowsFromLedger,
   tryMeasureVisualRows,
   writeTerminalDataWithLineTimestamps,
+  type StampCursorEstimate,
 } from "./terminalLineTimestamps.ts";
 
 const createFakeTerm = (options: {
@@ -665,6 +667,61 @@ test("records a ledger stamp after leaving alternate screen", () => {
   assert.ok(getTerminalLineTimestampLedgerCount(term as never) >= 1);
 });
 
+test("applyAltScreenAction never rewinds normal-buffer line or column", () => {
+  // Pure truth table: enter/leave × altActive; line/col immutable.
+  const base: StampCursorEstimate = {
+    absoluteLine: 7,
+    column: 3,
+    wraparoundMode: true,
+    altActive: false,
+  };
+  const cases: Array<{
+    name: string;
+    start: StampCursorEstimate;
+    action: "enter" | "leave";
+    expectAlt: boolean;
+  }> = [
+    {
+      name: "enter while normal",
+      start: { ...base, altActive: false },
+      action: "enter",
+      expectAlt: true,
+    },
+    {
+      name: "enter while already alt",
+      start: { ...base, altActive: true },
+      action: "enter",
+      expectAlt: true,
+    },
+    {
+      name: "leave while alt",
+      start: { ...base, altActive: true },
+      action: "leave",
+      expectAlt: false,
+    },
+    {
+      name: "spurious leave while already normal",
+      start: { ...base, altActive: false, absoluteLine: 7, column: 3 },
+      action: "leave",
+      expectAlt: false,
+    },
+  ];
+  for (const row of cases) {
+    const next = applyAltScreenAction(row.start, row.action);
+    assert.equal(next.absoluteLine, row.start.absoluteLine, row.name);
+    assert.equal(next.column, row.start.column, row.name);
+    assert.equal(next.wraparoundMode, row.start.wraparoundMode, row.name);
+    assert.equal(next.altActive, row.expectAlt, row.name);
+  }
+  // enter then leave preserves line/col from mid-walk freeze point.
+  const afterEnter = applyAltScreenAction({ ...base, absoluteLine: 1 }, "enter");
+  const afterLeave = applyAltScreenAction(afterEnter, "leave");
+  assert.equal(afterLeave.absoluteLine, 1);
+  assert.equal(afterLeave.altActive, false);
+});
+
+// --- Three write-path integrations for alt/seed/leave (shipped entry) ---
+
 test("alt-screen newlines do not inflate post-exit stamp anchor lines", () => {
   const { term, liveMarkers } = createFakeTerm({ rows: 24, scrollback: 1000 });
   // Many hard newlines inside the alt screen must not push the restored
@@ -685,8 +742,7 @@ test("alt-screen newlines do not inflate post-exit stamp anchor lines", () => {
 
 test("same-chunk normal advance before enter is kept after leave for post-TUI stamp", () => {
   // Leading hard newline advances the normal estimate to line 1 with no stamp
-  // yet; enter freezes that estimate; leave must NOT re-read pre-write
-  // buffer.normal (line 0) or the post-TUI prompt stamp pins to the wrong row.
+  // yet; enter freezes that estimate; leave must not rewind to line 0.
   const { term, liveMarkers } = createFakeTerm({ rows: 24, scrollback: 1000, cols: 80 });
   const payload = `\r\n\x1b[?1049h${"frame\n".repeat(20)}\x1b[?1049lprompt\r\n`;
   writeTerminalDataWithLineTimestamps(term as never, payload, () => {}, {
@@ -699,6 +755,24 @@ test("same-chunk normal advance before enter is kept after leave for post-TUI st
     liveMarkers[0]?.line,
     1,
     `expected prompt stamp on advanced normal line 1, got ${liveMarkers[0]?.line}`,
+  );
+});
+
+test("spurious leave without enter keeps same-chunk normal advance for prompt stamp", () => {
+  // Skeptic: '\r\n\x1b[?1049lprompt\r\n' must stamp line 1, not rewind to 0.
+  const { term, liveMarkers } = createFakeTerm({ rows: 24, scrollback: 1000, cols: 80 });
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    "\r\n\x1b[?1049lprompt\r\n",
+    () => {},
+    { timestampDate: new Date(2026, 5, 6, 12, 0, 0) },
+  );
+  assert.equal(getTerminalLineTimestampLedgerCount(term as never), 1);
+  assert.equal(liveMarkers.length, 1);
+  assert.equal(
+    liveMarkers[0]?.line,
+    1,
+    `expected stamp on line 1 after leading \\n + spurious leave, got ${liveMarkers[0]?.line}`,
   );
 });
 

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -539,6 +539,24 @@ test("records a ledger stamp after leaving alternate screen", () => {
   assert.ok(getTerminalLineTimestampLedgerCount(term as never) >= 1);
 });
 
+test("alt-screen newlines do not inflate post-exit stamp anchor lines", () => {
+  const { term, liveMarkers } = createFakeTerm({ rows: 24, scrollback: 1000 });
+  // Many hard newlines inside the alt screen must not push the restored
+  // normal-buffer stamp down (would mis-pin sparse reflow anchors).
+  const payload = `\x1b[?1049h${"frame\n".repeat(30)}\x1b[?1049lprompt\r\n`;
+  writeTerminalDataWithLineTimestamps(term as never, payload, () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 0),
+  });
+
+  assert.equal(getTerminalLineTimestampLedgerCount(term as never), 1);
+  assert.equal(liveMarkers.length, 1);
+  assert.equal(
+    liveMarkers[0]?.line,
+    0,
+    `expected stamp on restored normal buffer line 0, got ${liveMarkers[0]?.line}`,
+  );
+});
+
 test("resolveTerminalTimestampGutterRowsFromLedger fills gaps with previous time", () => {
   const rows = resolveTerminalTimestampGutterRowsFromLedger({
     viewportY: 0,

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -737,6 +737,23 @@ test("large multi-chunk flood stays within capacity across writes", () => {
   assert.ok(live <= capacity, `expected <= ${capacity} live entries, got ${live}`);
 });
 
+test("small batched writes amortize full timestamp-store pruning", () => {
+  const { term } = createFakeTerm({ scrollback: 1000, rows: 24 });
+  (term as unknown as { registerMarker: (offset: number) => unknown }).registerMarker = () => ({
+    line: 0,
+    isDisposed: false,
+    dispose() {
+      this.isDisposed = true;
+    },
+  });
+
+  writeTerminalDataWithLineTimestamps(term as never, "seed\r\n", () => {});
+  writeTerminalDataWithLineTimestamps(term as never, "a\r\nb", () => {});
+
+  assert.equal(getTerminalLineTimestampEntryCount(term as never, { prune: false }), 3);
+  assert.equal(getTerminalLineTimestampEntryCount(term as never), 1);
+});
+
 test("simple ASCII control text gate matches seq-style floods", () => {
   assert.equal(isSimpleAsciiControlText("1\n2\n3\n"), true);
   assert.equal(isSimpleAsciiControlText("line-0\r\nline-1\r\n"), true);

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -866,6 +866,39 @@ test("large multi-chunk flood stays within capacity across writes", () => {
   assert.ok(live <= capacity, `expected <= ${capacity} live entries, got ${live}`);
 });
 
+test("large slow batches keep live xterm markers near the retained capacity", async () => {
+  const require = createRequire(import.meta.url);
+  const { Terminal } = require("@xterm/xterm") as {
+    Terminal: new (options: Record<string, unknown>) => XTerm;
+  };
+  const term = new Terminal({
+    cols: 80,
+    rows: 24,
+    scrollback: 100000,
+    allowProposedApi: true,
+  });
+
+  try {
+    for (let batch = 0; batch < 14; batch += 1) {
+      const data = Array.from(
+        { length: 500 },
+        (_, index) => `batch-${batch}-${index}`,
+      ).join("\r\n") + "\r\n";
+      await new Promise<void>((resolve) => {
+        writeTerminalDataWithLineTimestamps(term, data, resolve);
+      });
+    }
+
+    assert.ok(term.markers.length <= MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES + 512);
+    assert.equal(
+      getTerminalLineTimestampEntryCount(term),
+      MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES,
+    );
+  } finally {
+    term.dispose();
+  }
+});
+
 test("small batched writes amortize full timestamp-store pruning", () => {
   const { term } = createFakeTerm({ scrollback: 1000, rows: 24 });
   (term as unknown as { registerMarker: (offset: number) => unknown }).registerMarker = () => ({

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -325,7 +325,7 @@ test("ledger keeps one stamp per wall-clock second whether gutter is on or off",
   assert.equal(getTerminalLineTimestampLedgerCount(term as never), 2);
 });
 
-test("gutter paint shows ledger labels on stamp lines only", () => {
+test("gutter paint fills blank rows with the previous stamp time", () => {
   const { term } = createFakeTerm();
   writeTerminalDataWithLineTimestamps(term as never, "a\r\nb\r\n", () => {}, {
     timestampDate: new Date(2026, 5, 6, 12, 0, 0),
@@ -335,9 +335,14 @@ test("gutter paint shows ledger labels on stamp lines only", () => {
   });
 
   const rows = getVisibleTerminalLineTimestampRows(term as never);
+  // line0 stamp 12:00:00 fills line1; line2 stamp 12:00:01.
   assert.deepEqual(
-    rows.map((row) => row.label),
-    ["12:00:00", "12:00:01"],
+    rows.filter((row) => row.row <= 2).map((row) => ({ row: row.row, label: row.label })),
+    [
+      { row: 0, label: "12:00:00" },
+      { row: 1, label: "12:00:00" },
+      { row: 2, label: "12:00:01" },
+    ],
   );
 });
 
@@ -415,7 +420,7 @@ test("records a ledger stamp after leaving alternate screen", () => {
   assert.ok(getTerminalLineTimestampLedgerCount(term as never) >= 1);
 });
 
-test("resolveTerminalTimestampGutterRowsFromLedger paints only stamp lines", () => {
+test("resolveTerminalTimestampGutterRowsFromLedger fills gaps with previous time", () => {
   const rows = resolveTerminalTimestampGutterRowsFromLedger({
     viewportY: 0,
     rows: 5,
@@ -426,7 +431,10 @@ test("resolveTerminalTimestampGutterRowsFromLedger paints only stamp lines", () 
   });
   assert.deepEqual(rows, [
     { row: 0, label: "12:00:00" },
+    { row: 1, label: "12:00:00" },
+    { row: 2, label: "12:00:00" },
     { row: 3, label: "12:00:01" },
+    { row: 4, label: "12:00:01" },
   ]);
 });
 

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import type { Terminal as XTerm } from "@xterm/xterm";
 
 import {
+  MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES,
   createTerminalLineTimestampSegmenter,
   formatTerminalLineTimestamp,
   getTerminalLineTimestampEntryCount,
@@ -651,7 +654,7 @@ test("timestamps a prompt after split alternate-screen enter and leave in one ch
   assert.deepEqual(markerLines, [0]);
 });
 
-test("capacity follows terminal scrollback so flood output cannot retain unbounded markers", () => {
+test("capacity follows small scrollback and caps large histories", () => {
   assert.equal(
     resolveTerminalLineTimestampCapacity({
       rows: 24,
@@ -659,28 +662,53 @@ test("capacity follows terminal scrollback so flood output cannot retain unbound
     } as never),
     1000 + 24 + 64,
   );
-  // Settings UI allows up to 100000 scrollback rows.
+  // Large scrollback values must not create a live xterm marker per retained row.
   assert.equal(
     resolveTerminalLineTimestampCapacity({
       rows: 24,
       options: { scrollback: 200000 },
     } as never),
-    100000 + 2048,
+    MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES,
   );
   assert.equal(
     resolveTerminalLineTimestampCapacity({
       rows: 24,
       options: { scrollback: 80000 },
     } as never),
-    80000 + 24 + 64,
+    MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES,
   );
   assert.equal(
     resolveTerminalLineTimestampCapacity({
       rows: 400,
       options: { scrollback: 100000 },
     } as never),
-    100000 + 400 + 64,
+    MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES,
   );
+});
+
+test("real xterm keeps live timestamp markers bounded while scrollback trims", async () => {
+  const require = createRequire(import.meta.url);
+  const { Terminal } = require("@xterm/xterm") as {
+    Terminal: new (options: Record<string, unknown>) => XTerm;
+  };
+  const term = new Terminal({ cols: 80, rows: 24, scrollback: 5000, allowProposedApi: true });
+  const write = (data: string) => new Promise<void>((resolve) => {
+    writeTerminalDataWithLineTimestamps(term, data, resolve);
+  });
+
+  try {
+    await write(Array.from({ length: 6000 }, (_, index) => `seed-${index}`).join("\r\n"));
+    for (let batch = 0; batch < 300; batch += 1) {
+      await write(`a-${batch}\r\nb-${batch}\r\n`);
+    }
+
+    const capacity = resolveTerminalLineTimestampCapacity(term);
+    const liveMarkers = (term as XTerm & { markers: readonly unknown[] }).markers.length;
+    assert.ok(liveMarkers <= capacity + 512, `expected bounded markers, got ${liveMarkers}`);
+    assert.ok(getTerminalLineTimestampEntryCount(term) <= capacity);
+  } finally {
+    term.dispose();
+  }
 });
 
 test("always records timestamps without a gutter listener so expanding later still has history", () => {

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -404,13 +404,21 @@ test("falls back from batched timestamp markers for combined alternate-screen se
   assert.deepEqual(markerLines, [0, 2]);
 });
 
-test("accounts for backspace cursor movement when batching timestamp markers", () => {
+test("keeps backspace writes on the segmented timestamp path", () => {
   const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
+  const steps: string[] = [];
   const lines = Array.from({ length: 80 }, () => "abc\b\b\bdef").join("\r\n");
 
-  writeTerminalDataWithLineTimestamps(term as never, lines, () => {});
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    lines,
+    () => {},
+    { onStep: (step) => steps.push(step.kind) },
+  );
 
-  assert.deepEqual(writes, [lines]);
+  assert.equal(writes.join(""), lines);
+  assert.equal(steps.includes("batched-write"), false);
+  assert.equal(steps.includes("segmented-write"), true);
   assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
 });
 
@@ -452,6 +460,65 @@ test("uses changed xterm tab stops when placing timestamps", async () => {
     const rows = getVisibleTerminalLineTimestampRows(term);
     assert.deepEqual(rows.map(({ row }) => row), [0, 1, 2]);
     assert.ok(rows.every(({ label }) => /^\d{2}:\d{2}:\d{2}$/.test(label)));
+  } finally {
+    term.dispose();
+  }
+});
+
+test("uses xterm delayed-wrap state when backspaces follow a full row", async () => {
+  const require = createRequire(import.meta.url);
+  const { Terminal } = require("@xterm/xterm") as {
+    Terminal: new (options: Record<string, unknown>) => XTerm;
+  };
+  const term = new Terminal({ cols: 5, rows: 8, scrollback: 20, allowProposedApi: true });
+  const steps: string[] = [];
+
+  try {
+    await new Promise<void>((resolve) => {
+      writeTerminalDataWithLineTimestamps(
+        term,
+        "bc\r\n\b\b12345\bbc",
+        resolve,
+        { onStep: (step) => steps.push(step.kind) },
+      );
+    });
+
+    assert.equal(steps.includes("batched-write"), false);
+    assert.equal(steps.includes("segmented-write"), true);
+    assert.deepEqual(
+      getVisibleTerminalLineTimestampRows(term).map(({ row }) => row),
+      [0, 1],
+    );
+  } finally {
+    term.dispose();
+  }
+});
+
+test("uses xterm newline mode when placing timestamps", async () => {
+  const require = createRequire(import.meta.url);
+  const { Terminal } = require("@xterm/xterm") as {
+    Terminal: new (options: Record<string, unknown>) => XTerm;
+  };
+  const term = new Terminal({ cols: 10, rows: 8, scrollback: 20, allowProposedApi: true });
+  const steps: string[] = [];
+
+  try {
+    await new Promise<void>((resolve) => term.write("\x1b[20h", resolve));
+    await new Promise<void>((resolve) => {
+      writeTerminalDataWithLineTimestamps(
+        term,
+        "aa\n123456789\r\nb",
+        resolve,
+        { onStep: (step) => steps.push(step.kind) },
+      );
+    });
+
+    assert.equal(steps.includes("batched-write"), false);
+    assert.equal(steps.includes("segmented-write"), true);
+    assert.deepEqual(
+      getVisibleTerminalLineTimestampRows(term).map(({ row }) => row),
+      [0, 1, 2],
+    );
   } finally {
     term.dispose();
   }

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -15,6 +15,8 @@ import {
   resolveTerminalLineTimestampCapacity,
   resolveTerminalTimestampGutterRows,
   tryMeasureVisualRows,
+  getVisualRowMeasureCountForTests,
+  resetVisualRowMeasureCountForTests,
   type TerminalLineTimestampPerfStep,
   writeTerminalDataWithLineTimestamps,
 } from "./terminalLineTimestamps.ts";
@@ -279,7 +281,17 @@ test("formats timestamp labels without terminal escape codes", () => {
   assert.equal(formatTerminalLineTimestamp(new Date(2026, 5, 6, 1, 2, 3)), "01:02:03");
 });
 
-test("records line timestamps even while the gutter is hidden", () => {
+test("skips segmenter and markers when timestamps are disabled", () => {
+  const { term, writes, markerLines } = createFakeTerm();
+  writeTerminalDataWithLineTimestamps(term as never, "before\r\nnext", () => {}, {
+    enabled: false,
+  });
+
+  assert.equal(writes.join(""), "before\r\nnext");
+  assert.deepEqual(markerLines, []);
+});
+
+test("records line timestamps when enabled (default for direct callers)", () => {
   const { term, writes, markerLines } = createFakeTerm();
   writeTerminalDataWithLineTimestamps(term as never, "before\r\nnext", () => {});
 
@@ -1054,4 +1066,34 @@ test("capacity prune dedupes rewritten lines so unique history is not dropped", 
   // Unique-line history should still fit under capacity; rewrite noise must not
   // push older unique lines out purely by duplicate count.
   assert.ok(live >= Math.min(capacity, 20), `expected meaningful unique history, got ${live}`);
+});
+
+
+test("batched simple multi-line path measures each data segment once", () => {
+  const { term, writes, markerLines } = createFakeTerm({ cols: 40 });
+  const payload = Array.from({ length: 20 }, (_, i) => `row-${i}`).join("\r\n");
+  resetVisualRowMeasureCountForTests();
+  const steps: TerminalLineTimestampPerfStep[] = [];
+  writeTerminalDataWithLineTimestamps(term as never, payload, () => {}, {
+    onStep: (step) => steps.push(step),
+  });
+  assert.equal(writes.join(""), payload);
+  assert.equal(steps.filter((step) => step.kind === "batched-write").length, 1);
+  // Simple ASCII: no full-batch validation walk; one tryMeasure per data segment only.
+  const measureCount = getVisualRowMeasureCountForTests();
+  assert.equal(measureCount, 20, `expected 20 segment measures, got ${measureCount}`);
+  assert.ok(markerLines.length >= 2);
+});
+
+test("batched single data segment reuses one full-batch measure", () => {
+  const { term, writes } = createFakeTerm({ cols: 40 });
+  const payload = "x".repeat(5000);
+  resetVisualRowMeasureCountForTests();
+  const steps: TerminalLineTimestampPerfStep[] = [];
+  writeTerminalDataWithLineTimestamps(term as never, payload, () => {}, {
+    onStep: (step) => steps.push(step),
+  });
+  assert.equal(writes.join(""), payload);
+  assert.equal(steps.filter((step) => step.kind === "batched-write").length, 1);
+  assert.equal(getVisualRowMeasureCountForTests(), 1);
 });

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -366,7 +366,7 @@ test("formats timestamp labels without terminal escape codes", () => {
 });
 
 
-test("gutter off records a per-second ledger without markers", () => {
+test("gutter off records a per-second ledger with a sparse reflow anchor", () => {
   const { term, writes, markerLines } = createFakeTerm();
   const t0 = new Date(2026, 5, 6, 12, 0, 0);
   writeTerminalDataWithLineTimestamps(term as never, "before\r\nnext\r\nthird", () => {}, {
@@ -375,7 +375,8 @@ test("gutter off records a per-second ledger without markers", () => {
   });
 
   assert.equal(writes.join(""), "before\r\nnext\r\nthird");
-  assert.deepEqual(markerLines, []);
+  // One wall-clock second → one sparse anchor (not per-line markers).
+  assert.equal(markerLines.length, 1);
   assert.equal(getTerminalLineTimestampLedgerCount(term as never), 1);
 });
 
@@ -390,8 +391,8 @@ test("ledger keeps one stamp per wall-clock second whether gutter is on or off",
     timestampDate: new Date(2026, 5, 6, 12, 0, 1),
   });
 
-  // Record path never registerMarkers.
-  assert.deepEqual(markerLines, []);
+  // Sparse anchors only: one registerMarker per stamped second.
+  assert.equal(markerLines.length, 2);
   assert.equal(getTerminalLineTimestampLedgerCount(term as never), 2);
 });
 
@@ -447,8 +448,56 @@ test("large multi-line dump in one second still uses a single ledger stamp", () 
   });
 
   assert.deepEqual(writes, [lines]);
-  assert.deepEqual(markerLines, []);
+  assert.equal(markerLines.length, 1);
   assert.equal(getTerminalLineTimestampLedgerCount(term as never), 1);
+});
+
+test("soft-wrapped long line places the next-second stamp after visual rows", () => {
+  // cols=10: "abcdefghij" is one full row; "klmnopqrst" wraps to a second row, then \n.
+  const { term, liveMarkers } = createFakeTerm({ cols: 10, rows: 24 });
+  writeTerminalDataWithLineTimestamps(term as never, `${"x".repeat(25)}\r\n`, () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 0),
+  });
+  writeTerminalDataWithLineTimestamps(term as never, "next\r\n", () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 1),
+  });
+
+  assert.equal(getTerminalLineTimestampLedgerCount(term as never), 2);
+  // 25 chars @ width 10 → rows 0,1,2 for first logical line; "next" on line 3.
+  // Second stamp must not share line 0 with the first (hard-\n-only bug).
+  const lines = liveMarkers.map((marker) => marker.line).sort((a, b) => a - b);
+  assert.equal(lines[0], 0);
+  assert.ok(
+    lines[1]! >= 3,
+    `expected second stamp at or after line 3 after soft-wrap, got ${JSON.stringify(lines)}`,
+  );
+
+  const painted = getVisibleTerminalLineTimestampRows(term as never);
+  assert.ok(painted.some((row) => row.label === "12:00:00"));
+  assert.ok(painted.some((row) => row.label === "12:00:01"));
+});
+
+test("reflow updates painted rows from sparse anchor marker.line", () => {
+  const { term, liveMarkers } = createFakeTerm({ cols: 80, rows: 24, scrollback: 1000 });
+  writeTerminalDataWithLineTimestamps(term as never, "early\r\n", () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 0),
+  });
+  writeTerminalDataWithLineTimestamps(term as never, "late\r\n", () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 1),
+  });
+  assert.equal(liveMarkers.length, 2);
+
+  // Simulate xterm reflow: markers move to new absolute lines.
+  liveMarkers[0]!.line = 5;
+  liveMarkers[1]!.line = 12;
+
+  const painted = getVisibleTerminalLineTimestampRows(term as never);
+  const byRow = new Map(painted.map((row) => [row.row, row.label]));
+  // viewportY=0 → buffer line === row for these anchors.
+  assert.equal(byRow.get(5), "12:00:00");
+  assert.equal(byRow.get(12), "12:00:01");
+  // Fill-forward between anchors.
+  assert.equal(byRow.get(8), "12:00:00");
 });
 
 test("does not withhold output when an OSC sequence is split across chunks", () => {

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -683,6 +683,25 @@ test("alt-screen newlines do not inflate post-exit stamp anchor lines", () => {
   );
 });
 
+test("same-chunk normal advance before enter is kept after leave for post-TUI stamp", () => {
+  // Leading hard newline advances the normal estimate to line 1 with no stamp
+  // yet; enter freezes that estimate; leave must NOT re-read pre-write
+  // buffer.normal (line 0) or the post-TUI prompt stamp pins to the wrong row.
+  const { term, liveMarkers } = createFakeTerm({ rows: 24, scrollback: 1000, cols: 80 });
+  const payload = `\r\n\x1b[?1049h${"frame\n".repeat(20)}\x1b[?1049lprompt\r\n`;
+  writeTerminalDataWithLineTimestamps(term as never, payload, () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 0),
+  });
+
+  assert.equal(getTerminalLineTimestampLedgerCount(term as never), 1);
+  assert.equal(liveMarkers.length, 1);
+  assert.equal(
+    liveMarkers[0]?.line,
+    1,
+    `expected prompt stamp on advanced normal line 1, got ${liveMarkers[0]?.line}`,
+  );
+});
+
 test("already-on-alt leave stamps on saved normal line not deep alt cursor", () => {
   const fake = createFakeTerm({ rows: 24, scrollback: 1000 });
   const { term, liveMarkers, disposedMarkerLines } = fake;

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -7,21 +7,14 @@ import {
   MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES,
   createTerminalLineTimestampSegmenter,
   formatTerminalLineTimestamp,
-  getTerminalLineTimestampEntryCount,
+  getTerminalLineTimestampLedgerCount,
   getVisibleTerminalLineTimestampRows,
   isSimpleAsciiControlText,
   onTerminalLineTimestampsChange,
-  resetTerminalLineTimestamps,
   resolveTerminalLineTimestampCapacity,
   resolveTerminalTimestampGutterRows,
+  resolveTerminalTimestampGutterRowsFromLedger,
   tryMeasureVisualRows,
-  getVisualRowMeasureCountForTests,
-  resetVisualRowMeasureCountForTests,
-  getTerminalLineTimestampLedgerCount,
-  getTerminalLineTimestampEntryCount,
-  materializeTimestampLedgerToMarkers,
-  getVisibleTerminalLineTimestampRows,
-  type TerminalLineTimestampPerfStep,
   writeTerminalDataWithLineTimestamps,
 } from "./terminalLineTimestamps.ts";
 
@@ -302,6 +295,7 @@ test("formats timestamp labels without terminal escape codes", () => {
   assert.equal(formatTerminalLineTimestamp(new Date(2026, 5, 6, 1, 2, 3)), "01:02:03");
 });
 
+
 test("gutter off records a per-second ledger without markers", () => {
   const { term, writes, markerLines } = createFakeTerm();
   const t0 = new Date(2026, 5, 6, 12, 0, 0);
@@ -312,14 +306,13 @@ test("gutter off records a per-second ledger without markers", () => {
 
   assert.equal(writes.join(""), "before\r\nnext\r\nthird");
   assert.deepEqual(markerLines, []);
-  // Same second → one ledger stamp for three lines.
   assert.equal(getTerminalLineTimestampLedgerCount(term as never), 1);
 });
 
-test("gutter off keeps one ledger stamp per wall-clock second", () => {
+test("ledger keeps one stamp per wall-clock second whether gutter is on or off", () => {
   const { term, markerLines } = createFakeTerm();
   writeTerminalDataWithLineTimestamps(term as never, "a\r\nb\r\n", () => {}, {
-    enabled: false,
+    enabled: true,
     timestampDate: new Date(2026, 5, 6, 12, 0, 0),
   });
   writeTerminalDataWithLineTimestamps(term as never, "c\r\nd\r\n", () => {}, {
@@ -327,408 +320,64 @@ test("gutter off keeps one ledger stamp per wall-clock second", () => {
     timestampDate: new Date(2026, 5, 6, 12, 0, 1),
   });
 
+  // Record path never registerMarkers.
   assert.deepEqual(markerLines, []);
   assert.equal(getTerminalLineTimestampLedgerCount(term as never), 2);
 });
 
-test("opening gutter materializes ledger stamps into markers", () => {
-  const { term, markerLines } = createFakeTerm();
+test("gutter paint shows ledger labels on stamp lines only", () => {
+  const { term } = createFakeTerm();
   writeTerminalDataWithLineTimestamps(term as never, "a\r\nb\r\n", () => {}, {
-    enabled: false,
     timestampDate: new Date(2026, 5, 6, 12, 0, 0),
   });
   writeTerminalDataWithLineTimestamps(term as never, "c\r\n", () => {}, {
-    enabled: false,
     timestampDate: new Date(2026, 5, 6, 12, 0, 1),
   });
-  assert.deepEqual(markerLines, []);
 
-  const created = materializeTimestampLedgerToMarkers(term as never);
-  assert.equal(created, 2);
-  assert.equal(getTerminalLineTimestampEntryCount(term as never, { prune: false }), 2);
-  assert.ok(markerLines.length >= 1);
-
-  // Paint path also materializes (idempotent).
   const rows = getVisibleTerminalLineTimestampRows(term as never);
-  assert.ok(rows.length >= 1);
+  assert.deepEqual(
+    rows.map((row) => row.label),
+    ["12:00:00", "12:00:01"],
+  );
 });
 
-test("records line timestamps when enabled (default for direct callers)", () => {
-  const { term, writes, markerLines } = createFakeTerm();
-  writeTerminalDataWithLineTimestamps(term as never, "before\r\nnext", () => {});
-
-  assert.equal(writes.join(""), "before\r\nnext");
-  assert.deepEqual(markerLines, [0, 1]);
-});
-
-test("coalesces timestamp change notifications per write", () => {
-  const { term, markerLines } = createFakeTerm();
+test("ledger notifies listeners once when a new second is stamped", () => {
+  const { term } = createFakeTerm();
   let notifications = 0;
   const unsubscribe = onTerminalLineTimestampsChange(term as never, () => {
     notifications += 1;
   });
 
-  writeTerminalDataWithLineTimestamps(term as never, "one\r\ntwo\r\nthree", () => {});
-  writeTerminalDataWithLineTimestamps(term as never, " continued", () => {});
+  writeTerminalDataWithLineTimestamps(term as never, "one\r\ntwo\r\nthree", () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 0),
+  });
+  writeTerminalDataWithLineTimestamps(term as never, " continued", () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 0),
+  });
+  writeTerminalDataWithLineTimestamps(term as never, "\r\nnext-second\r\n", () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 1),
+  });
   unsubscribe();
 
-  assert.deepEqual(markerLines, [0, 1, 2]);
-  assert.equal(notifications, 1);
+  assert.equal(getTerminalLineTimestampLedgerCount(term as never), 2);
+  assert.equal(notifications, 2);
 });
 
-test("writes large timestamped output in one batch while preserving marker lines", () => {
+test("large multi-line dump in one second still uses a single ledger stamp", () => {
   const { term, writes, markerLines } = createFakeTerm();
   const lines = Array.from({ length: 80 }, (_, index) => `line-${index}`).join("\r\n");
 
-  writeTerminalDataWithLineTimestamps(term as never, lines, () => {});
-
-  assert.deepEqual(writes, [lines]);
-  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
-});
-
-test("accounts for soft-wrapped rows when batching timestamp markers", () => {
-  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
-  const lines = Array.from({ length: 80 }, (_, index) => `line-${index}`).join("\r\n");
-
-  writeTerminalDataWithLineTimestamps(term as never, lines, () => {});
-
-  assert.deepEqual(writes, [lines]);
-  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index * 2));
-});
-
-test("does not soft-wrap exact-width rows when batching timestamp markers", () => {
-  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
-  const lines = Array.from({ length: 80 }, () => "abcde").join("\r\n");
-
-  writeTerminalDataWithLineTimestamps(term as never, lines, () => {});
-
-  assert.deepEqual(writes, [lines]);
-  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
-});
-
-test("preserves bare line feed cursor columns when batching timestamp markers", () => {
-  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
-  const lines = Array.from({ length: 80 }, () => "abcde").join("\n");
-
-  writeTerminalDataWithLineTimestamps(term as never, lines, () => {});
-
-  assert.deepEqual(writes, [lines]);
-  assert.deepEqual(markerLines, [
-    0,
-    ...Array.from({ length: 79 }, (_, index) => (index * 2) + 1),
-  ]);
-});
-
-test("respects disabled autowrap when batching timestamp markers", () => {
-  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
-  const lines = `\x1b[?7l${Array.from({ length: 80 }, () => "abcdef").join("\r\n")}`;
-
-  writeTerminalDataWithLineTimestamps(term as never, lines, () => {});
-
-  assert.deepEqual(writes, [lines]);
-  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
-});
-
-test("falls back from batched timestamp markers for cursor-moving escape sequences", () => {
-  const { term, writes, markerLines } = createFakeTerm();
-  const steps: string[] = [];
-  const lines = [
-    "line-0",
-    "line-1",
-    "\x1b[Aline-1-again",
-    ...Array.from({ length: 77 }, (_, index) => `line-${index + 3}`),
-  ].join("\r\n");
-
-  writeTerminalDataWithLineTimestamps(
-    term as never,
-    lines,
-    () => {},
-    { onStep: (step) => steps.push(step.kind) },
-  );
-
-  assert.notDeepEqual(writes, [lines]);
-  assert.equal(steps.includes("batched-write"), false);
-  assert.equal(steps.includes("segmented-write"), true);
-  assert.deepEqual(markerLines, [
-    0,
-    1,
-    1,
-    ...Array.from({ length: 77 }, (_, index) => index + 2),
-  ]);
-});
-
-test("falls back from batched timestamp markers for combined alternate-screen sequences", () => {
-  const { term, writes, markerLines } = createFakeTerm();
-  const steps: string[] = [];
-  const lines = [
-    "line-0",
-    `\x1b[?7;1049h${"vim".repeat(1400)}`,
-    "\x1b[?1049lline-1",
-  ].join("\r\n");
-
-  writeTerminalDataWithLineTimestamps(
-    term as never,
-    lines,
-    () => {},
-    { onStep: (step) => steps.push(step.kind) },
-  );
-
-  assert.notDeepEqual(writes, [lines]);
-  assert.equal(steps.includes("batched-write"), false);
-  assert.equal(steps.includes("segmented-write"), true);
-  assert.deepEqual(markerLines, [0, 2]);
-});
-
-test("keeps backspace writes on the segmented timestamp path", () => {
-  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
-  const steps: string[] = [];
-  const lines = Array.from({ length: 80 }, () => "abc\b\b\bdef").join("\r\n");
-
-  writeTerminalDataWithLineTimestamps(
-    term as never,
-    lines,
-    () => {},
-    { onStep: (step) => steps.push(step.kind) },
-  );
-
-  assert.equal(writes.join(""), lines);
-  assert.equal(steps.includes("batched-write"), false);
-  assert.equal(steps.includes("segmented-write"), true);
-  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
-});
-
-test("keeps tabbed writes on the segmented path so xterm owns tab stops", () => {
-  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
-  const steps: string[] = [];
-  const lines = Array.from({ length: 80 }, () => "\t").join("\r\n");
-
-  writeTerminalDataWithLineTimestamps(
-    term as never,
-    lines,
-    () => {},
-    { onStep: (step) => steps.push(step.kind) },
-  );
-
-  assert.equal(writes.join(""), lines);
-  assert.equal(steps.includes("batched-write"), false);
-  assert.equal(steps.includes("segmented-write"), true);
-  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
-});
-
-test("uses changed xterm tab stops when placing timestamps", async () => {
-  const require = createRequire(import.meta.url);
-  const { Terminal } = require("@xterm/xterm") as {
-    Terminal: new (options: Record<string, unknown>) => XTerm;
-  };
-  const term = new Terminal({ cols: 10, rows: 5, scrollback: 20, allowProposedApi: true });
-  const rawWrite = (data: string) => new Promise<void>((resolve) => term.write(data, resolve));
-  const timestampedWrite = (data: string) => new Promise<void>((resolve) => {
-    writeTerminalDataWithLineTimestamps(term, data, resolve);
+  writeTerminalDataWithLineTimestamps(term as never, lines, () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 0),
   });
 
-  try {
-    // Clear all tab stops. xterm then treats TAB differently from the default
-    // eight-column model used by the fast-path estimator.
-    await rawWrite("\x1b[3g");
-    await timestampedWrite("aa\tXY\r\nb");
-
-    const rows = getVisibleTerminalLineTimestampRows(term);
-    assert.deepEqual(rows.map(({ row }) => row), [0, 1, 2]);
-    assert.ok(rows.every(({ label }) => /^\d{2}:\d{2}:\d{2}$/.test(label)));
-  } finally {
-    term.dispose();
-  }
-});
-
-test("uses xterm delayed-wrap state when backspaces follow a full row", async () => {
-  const require = createRequire(import.meta.url);
-  const { Terminal } = require("@xterm/xterm") as {
-    Terminal: new (options: Record<string, unknown>) => XTerm;
-  };
-  const term = new Terminal({ cols: 5, rows: 8, scrollback: 20, allowProposedApi: true });
-  const steps: string[] = [];
-
-  try {
-    await new Promise<void>((resolve) => {
-      writeTerminalDataWithLineTimestamps(
-        term,
-        "bc\r\n\b\b12345\bbc",
-        resolve,
-        { onStep: (step) => steps.push(step.kind) },
-      );
-    });
-
-    assert.equal(steps.includes("batched-write"), false);
-    assert.equal(steps.includes("segmented-write"), true);
-    assert.deepEqual(
-      getVisibleTerminalLineTimestampRows(term).map(({ row }) => row),
-      [0, 1],
-    );
-  } finally {
-    term.dispose();
-  }
-});
-
-test("uses xterm newline mode when placing timestamps", async () => {
-  const require = createRequire(import.meta.url);
-  const { Terminal } = require("@xterm/xterm") as {
-    Terminal: new (options: Record<string, unknown>) => XTerm;
-  };
-  const term = new Terminal({ cols: 10, rows: 8, scrollback: 20, allowProposedApi: true });
-  const steps: string[] = [];
-
-  try {
-    await new Promise<void>((resolve) => term.write("\x1b[20h", resolve));
-    await new Promise<void>((resolve) => {
-      writeTerminalDataWithLineTimestamps(
-        term,
-        "aa\n123456789\r\nb",
-        resolve,
-        { onStep: (step) => steps.push(step.kind) },
-      );
-    });
-
-    assert.equal(steps.includes("batched-write"), false);
-    assert.equal(steps.includes("segmented-write"), true);
-    assert.deepEqual(
-      getVisibleTerminalLineTimestampRows(term).map(({ row }) => row),
-      [0, 1, 2],
-    );
-  } finally {
-    term.dispose();
-  }
-});
-
-test("falls back from batched timestamp markers for combining characters", () => {
-  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
-  const steps: string[] = [];
-  const lines = Array.from({ length: 80 }, () => "e\u0301e\u0301e\u0301").join("\r\n");
-
-  writeTerminalDataWithLineTimestamps(
-    term as never,
-    lines,
-    () => {},
-    { onStep: (step) => steps.push(step.kind) },
-  );
-
-  assert.equal(writes.join(""), lines);
-  assert.equal(steps.includes("batched-write"), false);
-  assert.equal(steps.includes("segmented-write"), true);
-  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
-});
-
-test("accounts for wide character soft wraps when batching timestamp markers", () => {
-  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
-  const lines = Array.from({ length: 80 }, () => "界界界").join("\r\n");
-
-  writeTerminalDataWithLineTimestamps(term as never, lines, () => {});
-
   assert.deepEqual(writes, [lines]);
-  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index * 2));
-});
-
-test("uses xterm unicode widths for less common wide characters", () => {
-  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
-  const steps: string[] = [];
-  const lines = Array.from({ length: 80 }, () => "🀄〈🀄").join("\r\n");
-
-  writeTerminalDataWithLineTimestamps(
-    term as never,
-    lines,
-    () => {},
-    { onStep: (step) => steps.push(step.kind) },
-  );
-
-  assert.deepEqual(writes, [lines]);
-  assert.equal(steps.includes("batched-write"), true);
-  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index * 2));
-});
-
-test("falls back from batched timestamp markers for non-Latin combining marks", () => {
-  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
-  const steps: string[] = [];
-  const lines = Array.from({ length: 80 }, () => "س\u0651س\u0651س\u0651").join("\r\n");
-
-  writeTerminalDataWithLineTimestamps(
-    term as never,
-    lines,
-    () => {},
-    { onStep: (step) => steps.push(step.kind) },
-  );
-
-  assert.equal(writes.join(""), lines);
-  assert.equal(steps.includes("batched-write"), false);
-  assert.equal(steps.includes("segmented-write"), true);
-  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
-});
-
-test("falls back from batched timestamp markers for Hangul jamo joins", () => {
-  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
-  const steps: string[] = [];
-  const lines = Array.from({ length: 80 }, () => "\u1100\u1161\u1100\u1161").join("\r\n");
-
-  writeTerminalDataWithLineTimestamps(
-    term as never,
-    lines,
-    () => {},
-    { onStep: (step) => steps.push(step.kind) },
-  );
-
-  assert.equal(writes.join(""), lines);
-  assert.equal(steps.includes("batched-write"), false);
-  assert.equal(steps.includes("segmented-write"), true);
-  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index * 2));
-});
-
-test("falls back from batched timestamp markers for zero-width format characters", () => {
-  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
-  const steps: string[] = [];
-  const lines = Array.from({ length: 80 }, () => "xx\u200bxx").join("\r\n");
-
-  writeTerminalDataWithLineTimestamps(
-    term as never,
-    lines,
-    () => {},
-    { onStep: (step) => steps.push(step.kind) },
-  );
-
-  assert.equal(writes.join(""), lines);
-  assert.equal(steps.includes("batched-write"), false);
-  assert.equal(steps.includes("segmented-write"), true);
-  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
-});
-
-test("falls back from batched timestamp markers for emoji variation sequences", () => {
-  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
-  const steps: string[] = [];
-  const lines = Array.from({ length: 80 }, () => "❤️❤️❤️").join("\r\n");
-
-  writeTerminalDataWithLineTimestamps(
-    term as never,
-    lines,
-    () => {},
-    { onStep: (step) => steps.push(step.kind) },
-  );
-
-  assert.equal(writes.join(""), lines);
-  assert.equal(steps.includes("batched-write"), false);
-  assert.equal(steps.includes("segmented-write"), true);
-  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index * 2));
-});
-
-test("keeps recording and preserves existing timestamps when the gutter is hidden", () => {
-  const { term, markerLines, disposedMarkerLines } = createFakeTerm();
-
-  writeTerminalDataWithLineTimestamps(term as never, "shown\r\n", () => {});
-  writeTerminalDataWithLineTimestamps(term as never, "hidden\r\n", () => {});
-  writeTerminalDataWithLineTimestamps(term as never, "shown again", () => {});
-
-  assert.deepEqual(markerLines, [0, 1, 2]);
-  assert.deepEqual(disposedMarkerLines, []);
+  assert.deepEqual(markerLines, []);
+  assert.equal(getTerminalLineTimestampLedgerCount(term as never), 1);
 });
 
 test("does not withhold output when an OSC sequence is split across chunks", () => {
-  const { term, writes, markerLines } = createFakeTerm();
+  const { term, writes } = createFakeTerm();
   const callbacks: string[] = [];
 
   writeTerminalDataWithLineTimestamps(
@@ -742,94 +391,75 @@ test("does not withhold output when an OSC sequence is split across chunks", () 
     () => callbacks.push("second"),
   );
 
-  assert.equal(writes.join(""), "\x1b]7;file://server/home/alice\u009calice@server:~$ ");
   assert.deepEqual(callbacks, ["first", "second"]);
-  assert.deepEqual(markerLines, [0]);
+  assert.ok(writes.join("").includes("alice@server:~$ "));
 });
 
-test("keeps timestamps for visible text before a split OSC sequence", () => {
-  const { term, writes, markerLines } = createFakeTerm();
-  const steps: TerminalLineTimestampPerfStep[] = [];
-  const tail = "\x1b]7;file://server/home/alice";
+test("does not timestamp output suspended on the alternate screen", () => {
+  const { term } = createFakeTerm();
+  writeTerminalDataWithLineTimestamps(term as never, "\x1b[?1049hvim screen", () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 0),
+  });
+  assert.equal(getTerminalLineTimestampLedgerCount(term as never), 0);
+});
 
+test("records a ledger stamp after leaving alternate screen", () => {
+  const { term } = createFakeTerm();
+  // Start as if already on alt screen via segmenter enter then leave in data
   writeTerminalDataWithLineTimestamps(
     term as never,
-    `hello ${tail}`,
+    "\x1b[?1049hframe\x1b[?1049lprompt line\r\n",
     () => {},
-    { onStep: (step) => steps.push(step) },
+    { timestampDate: new Date(2026, 5, 6, 12, 0, 0) },
   );
+  assert.ok(getTerminalLineTimestampLedgerCount(term as never) >= 1);
+});
 
-  assert.equal(writes.join(""), `hello ${tail}`);
-  assert.deepEqual(markerLines, [0]);
+test("resolveTerminalTimestampGutterRowsFromLedger paints only stamp lines", () => {
+  const rows = resolveTerminalTimestampGutterRowsFromLedger({
+    viewportY: 0,
+    rows: 5,
+    ledger: [
+      { label: "12:00:00", secondKey: 1, line: 0 },
+      { label: "12:00:01", secondKey: 2, line: 3 },
+    ],
+  });
+  assert.deepEqual(rows, [
+    { row: 0, label: "12:00:00" },
+    { row: 3, label: "12:00:01" },
+  ]);
+});
+
+
+test("simple ASCII control text gate matches seq-style floods", () => {
+  assert.equal(isSimpleAsciiControlText("1\n2\n3\n"), true);
+  assert.equal(isSimpleAsciiControlText("line-0\r\nline-1\r\n"), true);
+  assert.equal(isSimpleAsciiControlText("a\tb\b c"), true);
+  assert.equal(isSimpleAsciiControlText("hello\x1b[0m"), false);
+  assert.equal(isSimpleAsciiControlText("界"), false);
+});
+test("tryMeasureVisualRows matches hard-newline accounting for short ASCII lines", () => {
+  const { term } = createFakeTerm({ cols: 80 });
+  const data = Array.from({ length: 100 }, (_, index) => `line-${index}`).join("\r\n");
+  const measured = tryMeasureVisualRows(term as never, data, 0, 80, true);
+  assert.ok(measured);
+  assert.equal(measured?.rowOffset, 99);
+  assert.equal(measured?.column, "line-99".length);
+});
+test("tryMeasureVisualRows accounts for soft wraps on long ASCII lines", () => {
+  const { term } = createFakeTerm({ cols: 5 });
+  const measured = tryMeasureVisualRows(term as never, "abcdefghij", 0, 5, true);
+  assert.ok(measured);
+  assert.equal(measured?.rowOffset, 1);
+  assert.equal(measured?.column, 5);
+});
+test("tryMeasureVisualRows rejects unmeasurable escape sequences", () => {
+  const { term } = createFakeTerm({ cols: 80 });
   assert.equal(
-    steps.some((step) => (
-      step.kind === "segmented-write"
-      && step.writeCalls === 1
-      && step.writeChars === "hello ".length
-    )),
-    true,
-  );
-  assert.equal(
-    steps.some((step) => step.kind === "fallback-write" && step.dataChars === tail.length),
-    true,
+    tryMeasureVisualRows(term as never, "\x1b[Aup", 0, 80, true),
+    null,
   );
 });
-
-test("keeps fallback timestamps on the matching multiline rows", () => {
-  const { term, writes, markerLines } = createFakeTerm();
-
-  writeTerminalDataWithLineTimestamps(
-    term as never,
-    "one\r\ntwo \x1b]7;file://server/home/alice",
-    () => {},
-  );
-
-  assert.equal(writes.join(""), "one\r\ntwo \x1b]7;file://server/home/alice");
-  assert.deepEqual(markerLines, [0, 1]);
-});
-
-test("does not duplicate a line timestamp after a split OSC fallback", () => {
-  const { term, writes, markerLines } = createFakeTerm();
-
-  writeTerminalDataWithLineTimestamps(
-    term as never,
-    "hello \x1b]7;file://server/home/alice",
-    () => {},
-  );
-  writeTerminalDataWithLineTimestamps(
-    term as never,
-    "\u009cworld",
-    () => {},
-  );
-
-  assert.equal(writes.join(""), "hello \x1b]7;file://server/home/alice\u009cworld");
-  assert.deepEqual(markerLines, [0]);
-});
-
-test("does not timestamp the next chunk after a split alternate-screen sequence", () => {
-  const { term, writes, markerLines } = createFakeTerm();
-
-  writeTerminalDataWithLineTimestamps(term as never, "\x1b[?1049", () => {});
-  writeTerminalDataWithLineTimestamps(term as never, "hvim screen", () => {});
-
-  assert.equal(writes.join(""), "\x1b[?1049hvim screen");
-  assert.deepEqual(markerLines, []);
-});
-
-test("timestamps a prompt after split alternate-screen enter and leave in one chunk", () => {
-  const { term, writes, markerLines } = createFakeTerm();
-
-  writeTerminalDataWithLineTimestamps(term as never, "\x1b[?1049", () => {});
-  writeTerminalDataWithLineTimestamps(
-    term as never,
-    "hvim screen\x1b[?1049lprompt",
-    () => {},
-  );
-
-  assert.equal(writes.join(""), "\x1b[?1049hvim screen\x1b[?1049lprompt");
-  assert.deepEqual(markerLines, [0]);
-});
-
 test("capacity follows small scrollback and caps large histories", () => {
   assert.equal(
     resolveTerminalLineTimestampCapacity({
@@ -860,302 +490,4 @@ test("capacity follows small scrollback and caps large histories", () => {
     } as never),
     MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES,
   );
-});
-
-test("real xterm keeps live timestamp markers bounded while scrollback trims", async () => {
-  const require = createRequire(import.meta.url);
-  const { Terminal } = require("@xterm/xterm") as {
-    Terminal: new (options: Record<string, unknown>) => XTerm;
-  };
-  const term = new Terminal({ cols: 80, rows: 24, scrollback: 5000, allowProposedApi: true });
-  const write = (data: string) => new Promise<void>((resolve) => {
-    writeTerminalDataWithLineTimestamps(term, data, resolve);
-  });
-
-  try {
-    await write(Array.from({ length: 6000 }, (_, index) => `seed-${index}`).join("\r\n"));
-    for (let batch = 0; batch < 300; batch += 1) {
-      await write(`a-${batch}\r\nb-${batch}\r\n`);
-    }
-
-    const capacity = resolveTerminalLineTimestampCapacity(term);
-    const liveMarkers = (term as XTerm & { markers: readonly unknown[] }).markers.length;
-    assert.ok(liveMarkers <= capacity + 512, `expected bounded markers, got ${liveMarkers}`);
-    assert.ok(getTerminalLineTimestampEntryCount(term) <= capacity);
-  } finally {
-    term.dispose();
-  }
-});
-
-test("always records timestamps without a gutter listener so expanding later still has history", () => {
-  const { term, markerLines } = createFakeTerm();
-
-  // No onTerminalLineTimestampsChange subscription — gutter is hidden.
-  writeTerminalDataWithLineTimestamps(term as never, "a\r\nb\r\nc", () => {});
-
-  assert.deepEqual(markerLines, [0, 1, 2]);
-  assert.equal(getTerminalLineTimestampEntryCount(term as never), 3);
-
-  let notifications = 0;
-  const unsubscribe = onTerminalLineTimestampsChange(term as never, () => {
-    notifications += 1;
-  });
-  // Late subscriber must still see the already-recorded markers.
-  assert.equal(getTerminalLineTimestampEntryCount(term as never), 3);
-  writeTerminalDataWithLineTimestamps(term as never, "\r\nd", () => {});
-  unsubscribe();
-  assert.equal(notifications, 1);
-  assert.equal(getTerminalLineTimestampEntryCount(term as never), 4);
-});
-
-test("prunes disposed markers in bulk under scrollback pressure without retaining all flood lines", () => {
-  const scrollback = 200;
-  const rows = 24;
-  const { term } = createFakeTerm({ scrollback, rows });
-  const lineCount = 5000;
-  const lines = Array.from({ length: lineCount }, (_, index) => `line-${index}`).join("\r\n");
-
-  writeTerminalDataWithLineTimestamps(term as never, lines, () => {});
-
-  const live = getTerminalLineTimestampEntryCount(term as never);
-  const capacity = resolveTerminalLineTimestampCapacity(term as never);
-  assert.ok(live <= capacity, `expected <= ${capacity} live entries, got ${live}`);
-  // Must not retain near the full flood (old O(n) store grew with every line).
-  assert.ok(live < lineCount / 2, `expected aggressive prune, got ${live} of ${lineCount}`);
-});
-
-test("large multi-chunk flood stays within capacity across writes", () => {
-  const scrollback = 500;
-  const { term } = createFakeTerm({ scrollback, rows: 24 });
-
-  for (let chunk = 0; chunk < 40; chunk += 1) {
-    const lines = Array.from(
-      { length: 200 },
-      (_, index) => `c${chunk}-l${index}`,
-    ).join("\r\n");
-    writeTerminalDataWithLineTimestamps(term as never, `${lines}\r\n`, () => {});
-  }
-
-  const live = getTerminalLineTimestampEntryCount(term as never);
-  const capacity = resolveTerminalLineTimestampCapacity(term as never);
-  assert.ok(live <= capacity, `expected <= ${capacity} live entries, got ${live}`);
-});
-
-test("large slow batches keep live xterm markers near the retained capacity", async () => {
-  const require = createRequire(import.meta.url);
-  const { Terminal } = require("@xterm/xterm") as {
-    Terminal: new (options: Record<string, unknown>) => XTerm;
-  };
-  const term = new Terminal({
-    cols: 80,
-    rows: 24,
-    scrollback: 100000,
-    allowProposedApi: true,
-  });
-
-  try {
-    for (let batch = 0; batch < 14; batch += 1) {
-      const data = Array.from(
-        { length: 500 },
-        (_, index) => `batch-${batch}-${index}`,
-      ).join("\r\n") + "\r\n";
-      await new Promise<void>((resolve) => {
-        writeTerminalDataWithLineTimestamps(term, data, resolve);
-      });
-    }
-
-    await new Promise((resolve) => { setTimeout(resolve, 100); });
-
-    assert.ok(term.markers.length <= MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES + 512);
-    assert.equal(
-      getTerminalLineTimestampEntryCount(term),
-      MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES,
-    );
-  } finally {
-    term.dispose();
-  }
-});
-
-test("large timestamp prunes defer orphan disposal across later tasks", async () => {
-  const { term, disposedMarkerLines } = createFakeTerm({
-    scrollback: 100000,
-    rows: 24,
-  });
-  const lines = Array.from(
-    { length: MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES },
-    (_, index) => `line-${index}`,
-  ).join("\r\n");
-
-  writeTerminalDataWithLineTimestamps(term as never, lines, () => {});
-  writeTerminalDataWithLineTimestamps(term as never, lines, () => {});
-
-  const disposedImmediately = disposedMarkerLines.length;
-  assert.equal(disposedImmediately, 64);
-
-  await new Promise((resolve) => { setTimeout(resolve, 10); });
-  assert.ok(disposedMarkerLines.length > disposedImmediately);
-
-  resetTerminalLineTimestamps(term as never);
-});
-
-test("small batched writes amortize full timestamp-store pruning", () => {
-  const { term } = createFakeTerm({ scrollback: 1000, rows: 24 });
-  (term as unknown as { registerMarker: (offset: number) => unknown }).registerMarker = () => ({
-    line: 0,
-    isDisposed: false,
-    dispose() {
-      this.isDisposed = true;
-    },
-  });
-
-  writeTerminalDataWithLineTimestamps(term as never, "seed\r\n", () => {});
-  writeTerminalDataWithLineTimestamps(term as never, "a\r\nb", () => {});
-
-  assert.equal(getTerminalLineTimestampEntryCount(term as never, { prune: false }), 3);
-  assert.equal(getTerminalLineTimestampEntryCount(term as never), 1);
-});
-
-test("simple ASCII control text gate matches seq-style floods", () => {
-  assert.equal(isSimpleAsciiControlText("1\n2\n3\n"), true);
-  assert.equal(isSimpleAsciiControlText("line-0\r\nline-1\r\n"), true);
-  assert.equal(isSimpleAsciiControlText("a\tb\b c"), true);
-  assert.equal(isSimpleAsciiControlText("hello\x1b[0m"), false);
-  assert.equal(isSimpleAsciiControlText("界"), false);
-});
-
-test("tryMeasureVisualRows matches hard-newline accounting for short ASCII lines", () => {
-  const { term } = createFakeTerm({ cols: 80 });
-  const data = Array.from({ length: 100 }, (_, index) => `line-${index}`).join("\r\n");
-  const measured = tryMeasureVisualRows(term as never, data, 0, 80, true);
-  assert.ok(measured);
-  assert.equal(measured?.rowOffset, 99);
-  assert.equal(measured?.column, "line-99".length);
-});
-
-test("tryMeasureVisualRows accounts for soft wraps on long ASCII lines", () => {
-  const { term } = createFakeTerm({ cols: 5 });
-  const measured = tryMeasureVisualRows(term as never, "abcdefghij", 0, 5, true);
-  assert.ok(measured);
-  assert.equal(measured?.rowOffset, 1);
-  assert.equal(measured?.column, 5);
-});
-
-test("tryMeasureVisualRows rejects unmeasurable escape sequences", () => {
-  const { term } = createFakeTerm({ cols: 80 });
-  assert.equal(
-    tryMeasureVisualRows(term as never, "\x1b[Aup", 0, 80, true),
-    null,
-  );
-});
-
-test("gutter row resolution finds viewport labels across a large entry list", () => {
-  const entries = Array.from({ length: 1000 }, (_, index) => ({
-    marker: { line: index },
-    label: `t-${index}`,
-  }));
-  assert.deepEqual(
-    resolveTerminalTimestampGutterRows({
-      viewportY: 500,
-      rows: 4,
-      entries,
-    }),
-    [
-      { row: 0, label: "t-500" },
-      { row: 1, label: "t-501" },
-      { row: 2, label: "t-502" },
-      { row: 3, label: "t-503" },
-    ],
-  );
-});
-
-test("gutter prefers the latest label when a later marker rewrites an earlier line", () => {
-  // Cursor-up / reposition can append a newer marker on a lower line index.
-  assert.deepEqual(
-    resolveTerminalTimestampGutterRows({
-      viewportY: 0,
-      rows: 2,
-      entries: [
-        { marker: { line: 0 }, label: "10:00:00" },
-        { marker: { line: 1 }, label: "10:00:01" },
-        { marker: { line: 0 }, label: "10:00:02" },
-      ],
-    }),
-    [
-      { row: 0, label: "10:00:02" },
-      { row: 1, label: "10:00:01" },
-    ],
-  );
-});
-
-test("bulk timestamp batching is disabled inside a partial scrolling region", () => {
-  const { term, writes } = createFakeTerm({ cols: 80, rows: 24 });
-  (term as { _core?: { buffer?: { scrollTop: number; scrollBottom: number } } })._core = {
-    buffer: { scrollTop: 1, scrollBottom: 10 },
-  };
-  const steps: string[] = [];
-  const lines = Array.from({ length: 80 }, (_, index) => `line-${index}`).join("\r\n");
-
-  writeTerminalDataWithLineTimestamps(
-    term as never,
-    lines,
-    () => {},
-    { onStep: (step) => steps.push(step.kind) },
-  );
-
-  assert.equal(steps.includes("batched-write"), false);
-  assert.equal(steps.includes("segmented-write"), true);
-  // Segmented path still emits the original bytes.
-  assert.equal(writes.join(""), lines);
-});
-
-test("capacity prune dedupes rewritten lines so unique history is not dropped", () => {
-  const scrollback = 100;
-  const rows = 1;
-  const { term } = createFakeTerm({ scrollback, rows, cols: 80 });
-
-  // Fill unique lines up to roughly the capacity window.
-  const seed = Array.from({ length: scrollback + rows }, (_, index) => `line-${index}`).join("\r\n");
-  writeTerminalDataWithLineTimestamps(term as never, seed, () => {});
-
-  // Rewrite the same line many times via cursor-up (segmented path).
-  for (let index = 0; index < 200; index += 1) {
-    writeTerminalDataWithLineTimestamps(term as never, "\x1b[Ax\r\n", () => {});
-  }
-
-  const live = getTerminalLineTimestampEntryCount(term as never);
-  const capacity = resolveTerminalLineTimestampCapacity(term as never);
-  assert.ok(live <= capacity, `expected <= ${capacity} live entries, got ${live}`);
-  // Unique-line history should still fit under capacity; rewrite noise must not
-  // push older unique lines out purely by duplicate count.
-  assert.ok(live >= Math.min(capacity, 20), `expected meaningful unique history, got ${live}`);
-});
-
-
-test("batched simple multi-line path measures each data segment once", () => {
-  const { term, writes, markerLines } = createFakeTerm({ cols: 40 });
-  const payload = Array.from({ length: 20 }, (_, i) => `row-${i}`).join("\r\n");
-  resetVisualRowMeasureCountForTests();
-  const steps: TerminalLineTimestampPerfStep[] = [];
-  writeTerminalDataWithLineTimestamps(term as never, payload, () => {}, {
-    onStep: (step) => steps.push(step),
-  });
-  assert.equal(writes.join(""), payload);
-  assert.equal(steps.filter((step) => step.kind === "batched-write").length, 1);
-  // Simple ASCII: no full-batch validation walk; one tryMeasure per data segment only.
-  const measureCount = getVisualRowMeasureCountForTests();
-  assert.equal(measureCount, 20, `expected 20 segment measures, got ${measureCount}`);
-  assert.ok(markerLines.length >= 2);
-});
-
-test("batched single data segment reuses one full-batch measure", () => {
-  const { term, writes } = createFakeTerm({ cols: 40 });
-  const payload = "x".repeat(5000);
-  resetVisualRowMeasureCountForTests();
-  const steps: TerminalLineTimestampPerfStep[] = [];
-  writeTerminalDataWithLineTimestamps(term as never, payload, () => {}, {
-    onStep: (step) => steps.push(step),
-  });
-  assert.equal(writes.join(""), payload);
-  assert.equal(steps.filter((step) => step.kind === "batched-write").length, 1);
-  assert.equal(getVisualRowMeasureCountForTests(), 1);
 });

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -92,87 +92,168 @@ const createFakeTerm = (options: {
       return cellWidth(String.fromCodePoint(codePoint));
     },
   };
-  // Approximate xterm: buffer always has at least `rows` lines; once full
-  // (scrollback + rows), further growth raises baseY and trims the top.
+  // Approximate xterm: dual buffers (normal + alternate). Active switches on
+  // 1049h/l; buffer.normal always exposes the saved normal-buffer cursor so
+  // stamp placement can restore correctly when a write starts already on alt.
   const maxBufferLines = Number.isFinite(scrollback) && scrollback !== undefined && scrollback >= 0
     ? scrollback + rows
     : Number.POSITIVE_INFINITY;
-  let absoluteCursorLine = 0;
-  let baseY = 0;
+  type BufferState = {
+    absoluteCursorLine: number;
+    baseY: number;
+    column: number;
+    lineText: Map<number, string>;
+  };
+  const normalState: BufferState = {
+    absoluteCursorLine: 0,
+    baseY: 0,
+    column: 0,
+    lineText: new Map(),
+  };
+  const altState: BufferState = {
+    absoluteCursorLine: 0,
+    baseY: 0,
+    column: 0,
+    lineText: new Map(),
+  };
+  let screen: "normal" | "alternate" = "normal";
+  const currentState = (): BufferState => (screen === "alternate" ? altState : normalState);
   /** When null, viewport follows bottom (baseY). Tests may pin a scroll-up offset. */
   let viewportYOverride: number | null = null;
-  const lineText = new Map<number, string>();
 
   // When not yet full, length grows with content but never below viewport.
   // When full, length stays at maxBufferLines and baseY tracks the trim offset.
-  const resolveLength = (): number => {
+  const resolveLength = (state: BufferState): number => {
     if (!Number.isFinite(maxBufferLines)) {
-      return Math.max(rows, absoluteCursorLine + 1);
+      return Math.max(rows, state.absoluteCursorLine + 1);
     }
-    // absolute lines still in buffer: [baseY, baseY + length)
-    return Math.min(maxBufferLines, Math.max(rows, absoluteCursorLine - baseY + 1));
+    return Math.min(
+      maxBufferLines,
+      Math.max(rows, state.absoluteCursorLine - state.baseY + 1),
+    );
   };
 
-  const trimScrollbackIfNeeded = () => {
+  const trimScrollbackIfNeeded = (state: BufferState) => {
     if (!Number.isFinite(maxBufferLines)) return;
-    // Cursor absolute line past the last retained slot → drop from top.
-    while (absoluteCursorLine - baseY + 1 > maxBufferLines) {
-      baseY += 1;
+    while (state.absoluteCursorLine - state.baseY + 1 > maxBufferLines) {
+      state.baseY += 1;
     }
-    const keepFromAbsolute = baseY;
+    if (screen !== "normal") return;
+    const keepFromAbsolute = state.baseY;
     for (const marker of liveMarkers) {
       if (!marker.isDisposed && marker.line < keepFromAbsolute) {
         marker.dispose();
       }
     }
-    for (const key of [...lineText.keys()]) {
-      if (key < keepFromAbsolute) lineText.delete(key);
+    for (const key of [...state.lineText.keys()]) {
+      if (key < keepFromAbsolute) state.lineText.delete(key);
     }
   };
 
-  const activeBuffer = {
-    type: "normal" as string,
+  // buffer.normal: always the primary buffer (xterm keeps this while alt is active).
+  const normalBuffer = {
+    type: "normal" as const,
     get viewportY() {
-      return viewportYOverride ?? baseY;
-    },
-    set viewportY(value: number) {
-      viewportYOverride = Math.max(0, value);
+      return viewportYOverride ?? normalState.baseY;
     },
     get baseY() {
-      return baseY;
-    },
-    set baseY(value: number) {
-      baseY = Math.max(0, value);
+      return normalState.baseY;
     },
     get cursorY() {
-      // Relative to bottom page (baseY).
-      return Math.max(0, absoluteCursorLine - baseY);
-    },
-    set cursorY(value: number) {
-      absoluteCursorLine = baseY + Math.max(0, value);
-      cursorLine = absoluteCursorLine;
+      return Math.max(0, normalState.absoluteCursorLine - normalState.baseY);
     },
     get cursorX() {
-      return cursorColumn;
+      return normalState.column;
     },
     get length() {
-      return resolveLength();
+      return resolveLength(normalState);
     },
     getLine: (line?: number) => {
-      const absolute = typeof line === "number" ? line : absoluteCursorLine;
-      const text = lineText.get(absolute) ?? "";
+      const absolute = typeof line === "number" ? line : normalState.absoluteCursorLine;
+      const text = normalState.lineText.get(absolute) ?? "";
       return {
         isWrapped: false,
         translateToString: (_trimRight?: boolean) => text,
       };
     },
   };
+
+  // active.type must reflect the current screen for alt-screen gates.
+  const activeBuffer = {
+    get type() {
+      return screen;
+    },
+    set type(value: string) {
+      screen = value === "alternate" ? "alternate" : "normal";
+    },
+    get viewportY() {
+      return viewportYOverride ?? currentState().baseY;
+    },
+    set viewportY(value: number) {
+      viewportYOverride = Math.max(0, value);
+    },
+    get baseY() {
+      return currentState().baseY;
+    },
+    set baseY(value: number) {
+      currentState().baseY = Math.max(0, value);
+    },
+    get cursorY() {
+      const state = currentState();
+      return Math.max(0, state.absoluteCursorLine - state.baseY);
+    },
+    set cursorY(value: number) {
+      const state = currentState();
+      state.absoluteCursorLine = state.baseY + Math.max(0, value);
+      cursorLine = state.absoluteCursorLine;
+    },
+    get cursorX() {
+      return currentState().column;
+    },
+    set cursorX(value: number) {
+      currentState().column = Math.max(0, value);
+      cursorColumn = currentState().column;
+    },
+    get length() {
+      return resolveLength(currentState());
+    },
+    getLine: (line?: number) => {
+      const state = currentState();
+      const absolute = typeof line === "number" ? line : state.absoluteCursorLine;
+      const text = state.lineText.get(absolute) ?? "";
+      return {
+        isWrapped: false,
+        translateToString: (_trimRight?: boolean) => text,
+      };
+    },
+  };
+
+  const enterAlternate = () => {
+    if (screen === "alternate") return;
+    // Save normal cursor (already in normalState); reset alt surface.
+    altState.absoluteCursorLine = 0;
+    altState.baseY = 0;
+    altState.column = 0;
+    altState.lineText.clear();
+    screen = "alternate";
+    cursorLine = 0;
+    cursorColumn = 0;
+  };
+
+  const leaveAlternate = () => {
+    if (screen !== "alternate") return;
+    screen = "normal";
+    cursorLine = normalState.absoluteCursorLine;
+    cursorColumn = normalState.column;
+  };
+
   const term = {
     _core: {
       unicodeService,
     },
     buffer: {
       active: activeBuffer,
+      normal: normalBuffer,
     },
     cols,
     options: Number.isFinite(scrollback) ? { scrollback } : {},
@@ -185,27 +266,50 @@ const createFakeTerm = (options: {
       for (let index = 0; index < data.length; index += 1) {
         const sequence = readCsiSequence(data, index);
         if (sequence) {
+          if (
+            sequence.sequence === "\x1b[?1049h"
+            || sequence.sequence === "\x1b[?47h"
+            || sequence.sequence === "\x1b[?1047h"
+          ) {
+            enterAlternate();
+            index = sequence.endIndex;
+            continue;
+          }
+          if (
+            sequence.sequence === "\x1b[?1049l"
+            || sequence.sequence === "\x1b[?47l"
+            || sequence.sequence === "\x1b[?1047l"
+          ) {
+            leaveAlternate();
+            index = sequence.endIndex;
+            continue;
+          }
           applyCsiSequence(sequence.sequence);
-          absoluteCursorLine = cursorLine;
+          currentState().absoluteCursorLine = cursorLine;
           index = sequence.endIndex;
           continue;
         }
+        const state = currentState();
         const char = data[index];
         if (char === "\n") {
-          absoluteCursorLine += 1;
-          cursorLine = absoluteCursorLine;
-          cursorColumn = Number.isFinite(cols) && cursorColumn >= cols
+          state.absoluteCursorLine += 1;
+          cursorLine = state.absoluteCursorLine;
+          state.column = Number.isFinite(cols) && state.column >= cols
             ? cols - 1
             : 0;
-          trimScrollbackIfNeeded();
+          cursorColumn = state.column;
+          trimScrollbackIfNeeded(state);
         } else if (char === "\r") {
+          state.column = 0;
           cursorColumn = 0;
         } else if (char === "\b") {
-          cursorColumn = Math.max(0, cursorColumn - 1);
+          state.column = Math.max(0, state.column - 1);
+          cursorColumn = state.column;
         } else if (char === "\t") {
-          if (cursorColumn < cols) {
-            const nextTabStop = cursorColumn + (8 - (cursorColumn % 8));
-            cursorColumn = Math.min(nextTabStop, cols - 1);
+          if (state.column < cols) {
+            const nextTabStop = state.column + (8 - (state.column % 8));
+            state.column = Math.min(nextTabStop, cols - 1);
+            cursorColumn = state.column;
           }
         } else if (isCombiningMark(char)) {
           continue;
@@ -218,25 +322,34 @@ const createFakeTerm = (options: {
           if (isEmojiVariationSequence) {
             index += 1;
           }
-          if (wraparoundMode && cursorColumn + width > cols) {
-            absoluteCursorLine += 1;
-            cursorLine = absoluteCursorLine;
+          if (wraparoundMode && state.column + width > cols) {
+            state.absoluteCursorLine += 1;
+            cursorLine = state.absoluteCursorLine;
+            state.column = 0;
             cursorColumn = 0;
-            trimScrollbackIfNeeded();
+            trimScrollbackIfNeeded(state);
           }
-          const existing = lineText.get(absoluteCursorLine) ?? "";
-          lineText.set(absoluteCursorLine, existing + (isEmojiVariationSequence ? "❤️" : char));
-          cursorColumn = Number.isFinite(cols)
-            ? Math.min(cols, cursorColumn + width)
-            : cursorColumn + width;
+          const existing = state.lineText.get(state.absoluteCursorLine) ?? "";
+          state.lineText.set(
+            state.absoluteCursorLine,
+            existing + (isEmojiVariationSequence ? "❤️" : char),
+          );
+          state.column = Number.isFinite(cols)
+            ? Math.min(cols, state.column + width)
+            : state.column + width;
+          cursorColumn = state.column;
         }
       }
-      cursorLine = absoluteCursorLine;
-      trimScrollbackIfNeeded();
+      cursorLine = currentState().absoluteCursorLine;
+      cursorColumn = currentState().column;
+      trimScrollbackIfNeeded(currentState());
       callback?.();
     },
     registerMarker(offset: number) {
-      const line = absoluteCursorLine + offset;
+      // Markers attach to the normal buffer in production for our ledger path
+      // after leave; while on alt, offset is still relative to active cursor.
+      const state = currentState();
+      const line = state.absoluteCursorLine + offset;
       markerLines.push(line);
       const marker = {
         line,
@@ -258,15 +371,28 @@ const createFakeTerm = (options: {
     markerLines,
     disposedMarkerLines,
     liveMarkers,
-    /** Test helper: inspect / force xterm-like baseY growth. */
-    getBaseY: () => baseY,
+    /** Test helper: inspect / force xterm-like baseY growth on the normal buffer. */
+    getBaseY: () => normalState.baseY,
     setBaseY: (value: number) => {
-      baseY = Math.max(0, value);
+      normalState.baseY = Math.max(0, value);
     },
     setViewportY: (value: number) => {
       viewportYOverride = Math.max(0, value);
     },
-    getAbsoluteCursorLine: () => absoluteCursorLine,
+    getAbsoluteCursorLine: () => currentState().absoluteCursorLine,
+    /** Force already-on-alt with a saved normal cursor (skeptic multi-write path). */
+    enterAlternateWithSavedNormal: (savedNormalLine: number, savedNormalColumn = 0) => {
+      normalState.absoluteCursorLine = Math.max(0, savedNormalLine);
+      normalState.column = Math.max(0, savedNormalColumn);
+      normalState.lineText.set(normalState.absoluteCursorLine, "shell-prompt");
+      enterAlternate();
+      // Simulate a tall TUI: alt cursor deep in the alternate buffer.
+      altState.absoluteCursorLine = 40;
+      altState.column = 0;
+      cursorLine = 40;
+      cursorColumn = 0;
+    },
+    getNormalAbsoluteLine: () => normalState.absoluteCursorLine,
   };
 };
 
@@ -555,6 +681,55 @@ test("alt-screen newlines do not inflate post-exit stamp anchor lines", () => {
     0,
     `expected stamp on restored normal buffer line 0, got ${liveMarkers[0]?.line}`,
   );
+});
+
+test("already-on-alt leave stamps on saved normal line not deep alt cursor", () => {
+  const fake = createFakeTerm({ rows: 24, scrollback: 1000 });
+  const { term, liveMarkers, disposedMarkerLines } = fake;
+
+  // Normal-buffer banner first (saves a real primary-buffer line).
+  writeTerminalDataWithLineTimestamps(term as never, "banner\r\n", () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 0),
+  });
+  const savedNormalLine = fake.getNormalAbsoluteLine();
+  assert.ok(savedNormalLine >= 1);
+
+  // Simulate a multi-write TUI session: already on alt with a deep alt cursor
+  // while buffer.normal still holds the shell line.
+  fake.enterAlternateWithSavedNormal(savedNormalLine, 0);
+  assert.equal((term.buffer.active as { type: string }).type, "alternate");
+  assert.equal(fake.getAbsoluteCursorLine(), 40);
+
+  // Alt-only output must not add stamps (segmenter suspended).
+  writeTerminalDataWithLineTimestamps(term as never, `${"frame\n".repeat(15)}`, () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 1),
+  });
+  assert.equal(getTerminalLineTimestampLedgerCount(term as never), 1);
+
+  // Leave alt + shell prompt — stamp must pin to saved normal line, not alt 40+.
+  writeTerminalDataWithLineTimestamps(term as never, "\x1b[?1049lprompt\r\n", () => {}, {
+    timestampDate: new Date(2026, 5, 6, 12, 0, 2),
+  });
+
+  assert.equal(
+    getTerminalLineTimestampLedgerCount(term as never),
+    2,
+    "post-TUI stamp must remain in the ledger (not dropped as past bufferLength)",
+  );
+  const live = liveMarkers.filter((marker) => !marker.isDisposed);
+  assert.ok(live.length >= 2);
+  const promptAnchor = live[live.length - 1]!;
+  assert.ok(
+    promptAnchor.line < 20,
+    `expected normal-buffer stamp, got alt-depth line ${promptAnchor.line}`,
+  );
+  assert.ok(
+    promptAnchor.line >= savedNormalLine - 1 && promptAnchor.line <= savedNormalLine + 2,
+    `expected stamp near saved normal line ${savedNormalLine}, got ${promptAnchor.line}`,
+  );
+  // The deep-alt mis-pin (line ~40) must not be the surviving prompt anchor.
+  assert.equal(disposedMarkerLines.includes(40), false);
+  assert.notEqual(promptAnchor.line, 40);
 });
 
 test("resolveTerminalTimestampGutterRowsFromLedger fills gaps with previous time", () => {

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -517,17 +517,56 @@ const getTimestampStore = (term: XTerm): TimestampStore => {
 
 const secondKeyFromDate = (date: Date): number => Math.floor(date.getTime() / 1000);
 
+type BufferCursorState = {
+  absoluteLine: number;
+  column: number;
+};
+
+const readBufferCursorState = (
+  buffer: { baseY?: number; cursorY?: number; cursorX?: number } | null | undefined,
+): BufferCursorState => {
+  const baseY = typeof buffer?.baseY === "number" ? buffer.baseY : 0;
+  const cursorY = typeof buffer?.cursorY === "number" ? buffer.cursorY : 0;
+  const cursorX = typeof buffer?.cursorX === "number" ? buffer.cursorX : 0;
+  return {
+    absoluteLine: Math.max(0, baseY + cursorY),
+    column: Math.max(0, cursorX),
+  };
+};
+
 const getAbsoluteCursorLine = (term: XTerm): number => {
   try {
-    const active = term.buffer?.active as
-      | { baseY?: number; cursorY?: number }
-      | undefined;
-    const baseY = typeof active?.baseY === "number" ? active.baseY : 0;
-    const cursorY = typeof active?.cursorY === "number" ? active.cursorY : 0;
-    return Math.max(0, baseY + cursorY);
+    return readBufferCursorState(
+      term.buffer?.active as { baseY?: number; cursorY?: number; cursorX?: number } | undefined,
+    ).absoluteLine;
   } catch {
     return 0;
   }
+};
+
+/**
+ * Cursor on the normal (primary) buffer — used for stamp placement when the
+ * active buffer is the alternate screen. xterm keeps the pre-alt position on
+ * `buffer.normal` while `active` is alternate; reading active alone pins stamps
+ * to alt rows and drops them after leave.
+ */
+const getNormalBufferCursorState = (term: XTerm): BufferCursorState => {
+  try {
+    const buffers = term.buffer as {
+      normal?: { baseY?: number; cursorY?: number; cursorX?: number };
+      active?: { type?: string; baseY?: number; cursorY?: number; cursorX?: number };
+    } | undefined;
+    if (buffers?.normal) {
+      return readBufferCursorState(buffers.normal);
+    }
+    const active = buffers?.active;
+    if (active && active.type !== "alternate") {
+      return readBufferCursorState(active);
+    }
+  } catch {
+    // fall through
+  }
+  return { absoluteLine: 0, column: 0 };
 };
 
 /** Advance absolute line by hard newlines in a data span (fallback estimate). */
@@ -603,11 +642,15 @@ const advanceStampCursorThroughData = (
       }
       const altAction = getAlternateScreenAction(sequence.sequence);
       if (altAction === "enter") {
+        // Freeze the current normal-buffer estimate; alt rows must not advance it.
         altActive = true;
       } else if (altAction === "leave") {
         altActive = false;
-        // 1049 restore: normal buffer cursor is back where it was; keep the
-        // frozen absoluteLine/column from before enter (do not carry alt rows).
+        // Restore from buffer.normal (works when the write *started* on alt too —
+        // freezing active's alt cursor would mis-pin or drop post-TUI stamps).
+        const restored = getNormalBufferCursorState(term);
+        absoluteLine = restored.absoluteLine;
+        column = restored.column;
       }
       const wrapAction = getWraparoundAction(sequence.sequence);
       if (wrapAction !== null && !altActive) {
@@ -1604,11 +1647,21 @@ const writeTerminalDataWithSecondLedger = (
     store.timestampOnlyPrefix = pendingEscapeSequence;
   }
 
+  const startedOnAlt = (
+    (term.buffer?.active as { type?: string } | undefined)?.type
+  ) === "alternate";
+  // If already on alt, seed from the saved normal buffer — not active (alt) cursor.
+  const seedCursor = startedOnAlt
+    ? getNormalBufferCursorState(term)
+    : {
+      absoluteLine: getAbsoluteCursorLine(term),
+      column: _getTerminalCursorColumn(term),
+    };
   let stampCursor: StampCursorEstimate = {
-    absoluteLine: getAbsoluteCursorLine(term),
-    column: _getTerminalCursorColumn(term),
+    absoluteLine: seedCursor.absoluteLine,
+    column: seedCursor.column,
     wraparoundMode: _getTerminalWraparoundMode(term),
-    altActive: ((term.buffer?.active as { type?: string } | undefined)?.type) === "alternate",
+    altActive: startedOnAlt,
   };
   const columns = _getTerminalColumnCount(term);
   const capacity = resolveTerminalLineTimestampCapacity(term);

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -615,6 +615,13 @@ type StampCursorEstimate = {
   wraparoundMode: boolean;
   /** True while DEC alt-screen is active — do not advance normal-buffer lines. */
   altActive: boolean;
+  /**
+   * True after an enter CSI in this walk. Leave then keeps the frozen
+   * in-walk estimate (includes same-chunk normal advances before enter).
+   * When false and we leave, the write started on alt — restore from
+   * buffer.normal (pre-write active cursor is the TUI row).
+   */
+  enteredAltInWalk: boolean;
 };
 
 /**
@@ -628,7 +635,13 @@ const advanceStampCursorThroughData = (
   data: string,
   columns: number,
 ): StampCursorEstimate => {
-  let { absoluteLine, column, wraparoundMode, altActive } = cursor;
+  let {
+    absoluteLine,
+    column,
+    wraparoundMode,
+    altActive,
+    enteredAltInWalk,
+  } = cursor;
   for (let index = 0; index < data.length;) {
     if (data[index] === "\x1b") {
       const sequence = readEscapeSequence(data, index);
@@ -644,13 +657,20 @@ const advanceStampCursorThroughData = (
       if (altAction === "enter") {
         // Freeze the current normal-buffer estimate; alt rows must not advance it.
         altActive = true;
+        enteredAltInWalk = true;
       } else if (altAction === "leave") {
         altActive = false;
-        // Restore from buffer.normal (works when the write *started* on alt too —
-        // freezing active's alt cursor would mis-pin or drop post-TUI stamps).
-        const restored = getNormalBufferCursorState(term);
-        absoluteLine = restored.absoluteLine;
-        column = restored.column;
+        if (enteredAltInWalk) {
+          // Same-chunk enter: keep frozen line/col (do NOT re-read pre-write
+          // buffer.normal — that would wipe normal advances before enter).
+          enteredAltInWalk = false;
+        } else {
+          // Write started already on alt: active cursor is the TUI row; restore
+          // the saved primary-buffer position xterm keeps on buffer.normal.
+          const restored = getNormalBufferCursorState(term);
+          absoluteLine = restored.absoluteLine;
+          column = restored.column;
+        }
       }
       const wrapAction = getWraparoundAction(sequence.sequence);
       if (wrapAction !== null && !altActive) {
@@ -680,7 +700,13 @@ const advanceStampCursorThroughData = (
     }
     index = end;
   }
-  return { absoluteLine, column, wraparoundMode, altActive };
+  return {
+    absoluteLine,
+    column,
+    wraparoundMode,
+    altActive,
+    enteredAltInWalk,
+  };
 };
 
 const disposeLedgerMarker = (entry: TimestampLedgerEntry): void => {
@@ -1662,6 +1688,8 @@ const writeTerminalDataWithSecondLedger = (
     column: seedCursor.column,
     wraparoundMode: _getTerminalWraparoundMode(term),
     altActive: startedOnAlt,
+    // Leave only re-reads buffer.normal when we never saw enter in this walk.
+    enteredAltInWalk: false,
   };
   const columns = _getTerminalColumnCount(term);
   const capacity = resolveTerminalLineTimestampCapacity(term);

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -124,10 +124,10 @@ const stores = new WeakMap<XTerm, TimestampStore>();
 const MIN_BATCHED_TIMESTAMP_DATA_SEGMENTS = 2;
 const BULK_TIMESTAMP_BATCH_MIN_BYTES = 4096;
 /**
- * Hard ceiling for live xterm markers. xterm updates every marker whenever a
- * scrollback row is trimmed, so matching a 100k-row scrollback makes steady
- * output progressively more expensive. Keep enough recent timestamp history
- * for normal navigation while bounding that per-line trim work.
+ * Target ceiling for retained timestamp entries. xterm updates every marker
+ * whenever a scrollback row is trimmed, so matching a 100k-row scrollback makes
+ * steady output progressively more expensive. Keep enough recent timestamp
+ * history for normal navigation while bounding that per-line trim work.
  */
 export const MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES = 4096;
 /** Compact disposed holes at least this often during flood writes. */
@@ -147,7 +147,8 @@ export const formatTerminalLineTimestamp = (date: Date): string => (
 /**
  * Resolve how many line timestamps to retain for a terminal.
  * Prefer the live scrollback option so a smaller history trims timestamps too.
- * Capacity is scrollback + viewport (+slack), matching xterm's retained lines.
+ * Capacity follows scrollback + viewport (+slack), bounded by the live-marker
+ * target so very large histories do not make every trim progressively slower.
  */
 export const resolveTerminalLineTimestampCapacity = (
   term: XTerm,
@@ -1225,6 +1226,10 @@ export const writeTerminalDataWithLineTimestamps = (
       dataSegmentCount >= MIN_BATCHED_TIMESTAMP_DATA_SEGMENTS
       || data.length >= BULK_TIMESTAMP_BATCH_MIN_BYTES
     )
+    // Tab stops are mutable terminal state. The row estimator intentionally
+    // avoids xterm internals, so keep tabbed writes on the ordered segmented
+    // path where marker positions come from xterm after each write.
+    && !data.includes("\t")
     // Cheap ASCII gate first (seq / log floods); otherwise one validate+measure probe.
     && (
       isSimpleAsciiControlText(data)

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -508,7 +508,14 @@ const drainOrphanedMarkers = (
 ): void => {
   let remaining = budget;
   if (store.orphanedMarkers.length >= TIMESTAMP_ORPHAN_CATCHUP_THRESHOLD) {
-    remaining = Math.max(remaining, TIMESTAMP_ORPHAN_CATCHUP_BUDGET);
+    // Keep the deferred-disposal tail bounded even when one PTY batch adds
+    // more markers than the fixed catch-up budget. Otherwise 500-line chunks
+    // can add 244 live xterm markers per pass forever.
+    remaining = Math.max(
+      remaining,
+      TIMESTAMP_ORPHAN_CATCHUP_BUDGET,
+      store.orphanedMarkers.length - TIMESTAMP_ORPHAN_CATCHUP_THRESHOLD + 1,
+    );
   }
   while (remaining > 0 && store.orphanedMarkers.length > 0) {
     const marker = store.orphanedMarkers.pop();

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -116,7 +116,7 @@ export type TerminalLineTimestampDiagnostics = {
 };
 
 const stores = new WeakMap<XTerm, TimestampStore>();
-const MAX_SEGMENTED_TIMESTAMP_WRITES = 64;
+const MIN_BATCHED_TIMESTAMP_DATA_SEGMENTS = 2;
 const BULK_TIMESTAMP_BATCH_MIN_BYTES = 4096;
 /**
  * Hard ceiling for retained timestamps. Matches Settings UI max scrollback
@@ -1208,7 +1208,7 @@ export const writeTerminalDataWithLineTimestamps = (
     && parsedData === dataForTimestamps
     && !hasPartialScrollingRegion(term)
     && (
-      dataSegmentCount > MAX_SEGMENTED_TIMESTAMP_WRITES
+      dataSegmentCount >= MIN_BATCHED_TIMESTAMP_DATA_SEGMENTS
       || data.length >= BULK_TIMESTAMP_BATCH_MIN_BYTES
     )
     // Cheap ASCII gate first (seq / log floods); otherwise one validate+measure probe.

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -124,10 +124,12 @@ const stores = new WeakMap<XTerm, TimestampStore>();
 const MIN_BATCHED_TIMESTAMP_DATA_SEGMENTS = 2;
 const BULK_TIMESTAMP_BATCH_MIN_BYTES = 4096;
 /**
- * Hard ceiling for retained timestamps. Matches Settings UI max scrollback
- * (100000) plus generous viewport headroom for very tall terminals.
+ * Hard ceiling for live xterm markers. xterm updates every marker whenever a
+ * scrollback row is trimmed, so matching a 100k-row scrollback makes steady
+ * output progressively more expensive. Keep enough recent timestamp history
+ * for normal navigation while bounding that per-line trim work.
  */
-export const MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES = 100000 + 2048;
+export const MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES = 4096;
 /** Compact disposed holes at least this often during flood writes. */
 const TIMESTAMP_PRUNE_EVERY_RECORDS = 256;
 /** Max xterm marker.dispose() calls per prune/write pass (amortize O(n) splices). */

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -33,8 +33,11 @@ type TimestampEntry = {
 };
 
 /**
- * Record/render separation: write path only appends ledger stamps (one per
- * second). Gutter paint maps ledger → visible rows without registerMarker.
+ * Record/render separation: write path appends at most one ledger stamp per
+ * second. Gutter paint maps ledger → visible rows (fill-forward).
+ *
+ * Each stamp may hold a sparse xterm marker so reflow/scrollback trim keep
+ * `line` honest without per-row markers on every output line.
  */
 type TimestampLedgerEntry = {
   label: string;
@@ -42,6 +45,11 @@ type TimestampLedgerEntry = {
   secondKey: number;
   /** Absolute buffer line (baseY + cursorY style) at stamp time. */
   line: number;
+  /**
+   * Sparse reflow/scrollback anchor. xterm updates `marker.line` on reflow;
+   * disposed when the line is trimmed from scrollback. Prefer when live.
+   */
+  marker?: TimestampMarker;
 };
 
 type TimestampStore = {
@@ -64,6 +72,8 @@ type TimestampStore = {
    */
   lastSeenBaseY: number | null;
   lastSeenBufferLength: number | null;
+  /** Last seen cols; when cols change, reflow may have shifted bare line numbers. */
+  lastSeenCols: number | null;
   /** @deprecated materialize path removed; always false. */
   ledgerMaterialized: boolean;
   /**
@@ -486,6 +496,7 @@ const getTimestampStore = (term: XTerm): TimestampStore => {
       lastStampSecondKey: null,
       lastSeenBaseY: null,
       lastSeenBufferLength: null,
+      lastSeenCols: null,
       ledgerMaterialized: false,
       orphanedMarkers: [],
       listeners: new Set(),
@@ -519,7 +530,7 @@ const getAbsoluteCursorLine = (term: XTerm): number => {
   }
 };
 
-/** Advance absolute line by hard newlines in a data span (pre-write estimate). */
+/** Advance absolute line by hard newlines in a data span (fallback estimate). */
 const advanceAbsoluteLineByData = (line: number, data: string): number => {
   let next = line;
   for (let index = 0; index < data.length; index += 1) {
@@ -528,12 +539,52 @@ const advanceAbsoluteLineByData = (line: number, data: string): number => {
   return next;
 };
 
+/**
+ * Soft-wrap–aware pre-write line advance for stamp placement.
+ * Uses the same bulk measurer as the (legacy) batched marker path so narrow
+ * terminals still land stamps on the correct buffer row when measurable.
+ */
+const advanceStampCursorByData = (
+  term: XTerm,
+  absoluteLine: number,
+  column: number,
+  data: string,
+  columns: number,
+  wraparoundMode: boolean,
+): { absoluteLine: number; column: number; wraparoundMode: boolean } => {
+  const measured = tryMeasureVisualRows(term, data, column, columns, wraparoundMode);
+  if (measured) {
+    return {
+      absoluteLine: absoluteLine + measured.rowOffset,
+      column: measured.column,
+      wraparoundMode: measured.wraparoundMode,
+    };
+  }
+  // Unmeasurable (cursor motion / partial CSI): hard newlines only.
+  return {
+    absoluteLine: advanceAbsoluteLineByData(absoluteLine, data),
+    column: 0,
+    wraparoundMode,
+  };
+};
+
+const disposeLedgerMarker = (entry: TimestampLedgerEntry): void => {
+  const marker = entry.marker;
+  entry.marker = undefined;
+  if (!marker || marker.isDisposed) return;
+  marker.dispose?.();
+};
+
 const trimLedgerToCapacity = (
   store: TimestampStore,
   capacity: number,
 ): void => {
   if (capacity > 0 && store.ledger.length > capacity) {
-    store.ledger.splice(0, store.ledger.length - capacity);
+    const drop = store.ledger.length - capacity;
+    for (let index = 0; index < drop; index += 1) {
+      disposeLedgerMarker(store.ledger[index]!);
+    }
+    store.ledger.splice(0, drop);
   }
 };
 
@@ -556,9 +607,75 @@ const pushLedgerStamp = (
   secondKey: number,
   line: number,
   capacity: number,
-): void => {
-  store.ledger.push({ label, secondKey, line: Math.max(0, line) });
+): TimestampLedgerEntry => {
+  const entry: TimestampLedgerEntry = {
+    label,
+    secondKey,
+    line: Math.max(0, line),
+  };
+  store.ledger.push(entry);
   trimLedgerToCapacity(store, capacity);
+  return entry;
+};
+
+/**
+ * After term.write, pin new stamps to sparse xterm markers so reflow and
+ * scrollback trim keep line anchors accurate (still ≤1 marker/second).
+ */
+const attachLedgerAnchors = (
+  term: XTerm,
+  pending: readonly TimestampLedgerEntry[],
+): void => {
+  if (pending.length === 0) return;
+  const registerMarker = (
+    term as XTerm & { registerMarker?: (offset: number) => TimestampMarker | undefined }
+  ).registerMarker;
+  if (typeof registerMarker !== "function") return;
+
+  const cursorLine = getAbsoluteCursorLine(term);
+  for (const entry of pending) {
+    if (entry.marker && !entry.marker.isDisposed) continue;
+    const offset = entry.line - cursorLine;
+    let marker: TimestampMarker | undefined;
+    try {
+      marker = registerMarker.call(term, offset);
+    } catch {
+      marker = undefined;
+    }
+    if (!marker || marker.isDisposed) continue;
+    entry.marker = marker;
+    if (typeof marker.line === "number" && Number.isFinite(marker.line)) {
+      entry.line = Math.max(0, marker.line);
+    }
+  }
+};
+
+/**
+ * Refresh ledger.line from live sparse anchors. Drops entries whose markers
+ * were disposed by scrollback trim. Bare (unanchored) lines keep their values
+ * unless a full-buffer baseY rebase applied earlier in the same pass.
+ */
+const syncLedgerFromAnchors = (store: TimestampStore): void => {
+  if (store.ledger.length === 0) return;
+  let write = 0;
+  for (let read = 0; read < store.ledger.length; read += 1) {
+    const entry = store.ledger[read]!;
+    const marker = entry.marker;
+    if (marker) {
+      if (marker.isDisposed) {
+        entry.marker = undefined;
+        // Trimmed away with its scrollback row — drop the stamp.
+        continue;
+      }
+      if (typeof marker.line === "number" && Number.isFinite(marker.line)) {
+        entry.line = Math.max(0, marker.line);
+      }
+    }
+    if (entry.line < 0) continue;
+    store.ledger[write] = entry;
+    write += 1;
+  }
+  store.ledger.length = write;
 };
 
 const resolveBufferMaxLines = (term: XTerm): number => {
@@ -572,12 +689,15 @@ const resolveBufferMaxLines = (term: XTerm): number => {
 };
 
 /**
- * Rebase ledger only when scrollback actually trims old lines from the top.
+ * Rebase / refresh ledger anchors after write, paint, or resize.
  *
- * Important: while the buffer is still growing, baseY also increases as the
- * viewport follows the cursor — absolute line indices of older content do NOT
- * shift. Subtracting every baseY delta incorrectly deletes early stamps
- * (MOTD / login banner vanishing on scroll).
+ * - Sparse markers: xterm already moved them for scrollback trim + reflow;
+ *   syncLedgerFromAnchors copies marker.line and drops disposed stamps.
+ * - Bare line numbers (marker attach failed): only subtract baseY when the
+ *   buffer is actually full and trimming — never while still growing (MOTD
+ *   vanishing on scroll).
+ * - Cols change: reflow invalidates bare numbers; drop unanchored stamps so we
+ *   never paint wrong times on reshuffled history (anchored stamps survive).
  */
 const rebaseLedgerForScrollback = (term: XTerm, store: TimestampStore): void => {
   let baseY = 0;
@@ -592,13 +712,18 @@ const rebaseLedgerForScrollback = (term: XTerm, store: TimestampStore): void => 
     return;
   }
 
+  const cols = _getTerminalColumnCount(term);
+  const colsChanged = store.lastSeenCols !== null
+    && Number.isFinite(cols)
+    && cols !== store.lastSeenCols;
+
   const maxLines = resolveBufferMaxLines(term);
   const bufferWasFull = store.lastSeenBufferLength !== null
     && store.lastSeenBufferLength >= maxLines;
   const bufferIsFull = bufferLength >= maxLines;
 
   // Only while full (or staying full) does baseY growth mean "N lines dropped
-  // from the top" and absolute indices of survivors decrease by N.
+  // from the top" for entries that still use bare line numbers.
   if (
     bufferWasFull
     && bufferIsFull
@@ -607,19 +732,40 @@ const rebaseLedgerForScrollback = (term: XTerm, store: TimestampStore): void => 
   ) {
     const delta = baseY - store.lastSeenBaseY;
     for (const entry of store.ledger) {
+      if (entry.marker && !entry.marker.isDisposed) continue;
       entry.line -= delta;
+    }
+  }
+
+  if (colsChanged) {
+    // Reflow: keep only stamps still pinned by a live marker.
+    for (const entry of store.ledger) {
+      if (entry.marker && !entry.marker.isDisposed) continue;
+      // Unanchored after reflow — line no longer trustworthy.
+      entry.line = -1;
     }
   }
 
   store.lastSeenBaseY = baseY;
   store.lastSeenBufferLength = bufferLength;
+  if (Number.isFinite(cols)) {
+    store.lastSeenCols = cols;
+  }
+
+  syncLedgerFromAnchors(store);
 
   if (store.ledger.length === 0) return;
   let write = 0;
   for (let read = 0; read < store.ledger.length; read += 1) {
     const entry = store.ledger[read]!;
-    if (entry.line < 0) continue;
-    if (bufferLength > 0 && entry.line >= bufferLength) continue;
+    if (entry.line < 0) {
+      disposeLedgerMarker(entry);
+      continue;
+    }
+    if (bufferLength > 0 && entry.line >= bufferLength) {
+      disposeLedgerMarker(entry);
+      continue;
+    }
     store.ledger[write] = entry;
     write += 1;
   }
@@ -637,7 +783,10 @@ const resolveLastPaintBufferLine = (
 ): number => {
   let lastLedgerLine = -1;
   for (const entry of store.ledger) {
-    if (entry.line > lastLedgerLine) lastLedgerLine = entry.line;
+    const line = entry.marker && !entry.marker.isDisposed && typeof entry.marker.line === "number"
+      ? entry.marker.line
+      : entry.line;
+    if (line > lastLedgerLine) lastLedgerLine = line;
   }
 
   let cursorAbs = 0;
@@ -822,11 +971,15 @@ const resetTimestampStore = (store: TimestampStore) => {
   for (const marker of store.orphanedMarkers) {
     if (!marker.isDisposed) marker.dispose?.();
   }
+  for (const entry of store.ledger) {
+    disposeLedgerMarker(entry);
+  }
   store.entries = [];
   store.ledger = [];
   store.lastStampSecondKey = null;
   store.lastSeenBaseY = null;
   store.lastSeenBufferLength = null;
+  store.lastSeenCols = null;
   store.ledgerMaterialized = false;
   store.orphanedMarkers = [];
   store.segmenter.reset();
@@ -1245,10 +1398,23 @@ export const resolveTerminalTimestampGutterRows = ({
   return visible;
 };
 
+const effectiveLedgerLine = (entry: TimestampLedgerEntry): number => {
+  if (
+    entry.marker
+    && !entry.marker.isDisposed
+    && typeof entry.marker.line === "number"
+    && Number.isFinite(entry.marker.line)
+  ) {
+    return Math.max(0, entry.marker.line);
+  }
+  return entry.line;
+};
+
 /**
- * Render gutter rows from the per-second ledger (no xterm markers).
+ * Render gutter rows from the per-second ledger.
  * Each visible line uses the latest stamp with stamp.line <= line so blank
  * gaps between stamps (and soft-wrap continuations) fill with the previous time.
+ * Prefer live sparse marker lines when present (reflow-safe).
  */
 export const resolveTerminalTimestampGutterRowsFromLedger = ({
   viewportY,
@@ -1270,8 +1436,8 @@ export const resolveTerminalTimestampGutterRowsFromLedger = ({
   if (ledger.length === 0 || rows <= 0) return [];
 
   const stamps = ledger
+    .map((entry) => ({ label: entry.label, secondKey: entry.secondKey, line: effectiveLedgerLine(entry) }))
     .filter((entry) => entry.line >= 0)
-    .slice()
     .sort((left, right) => left.line - right.line || left.secondKey - right.secondKey);
 
   const labelAtOrBefore = (line: number): string | undefined => {
@@ -1335,7 +1501,9 @@ export const getVisibleTerminalLineTimestampRows = (
 };
 
 /**
- * Record path: one term.write + per-second ledger updates (no registerMarker).
+ * Record path: one term.write + per-second ledger updates.
+ * Soft-wrap–aware pre-write line estimates; sparse markers after write for
+ * reflow/scrollback (still ≤1 marker per wall-clock second).
  */
 const writeTerminalDataWithSecondLedger = (
   term: XTerm,
@@ -1362,22 +1530,41 @@ const writeTerminalDataWithSecondLedger = (
   }
 
   let absoluteLine = getAbsoluteCursorLine(term);
+  let column = _getTerminalCursorColumn(term);
+  const columns = _getTerminalColumnCount(term);
+  let wraparoundMode = _getTerminalWraparoundMode(term);
   const capacity = resolveTerminalLineTimestampCapacity(term);
   let ledgerChanged = false;
+  const pendingAnchors: TimestampLedgerEntry[] = [];
   for (const segment of segments) {
     if (segment.kind === "timestamp") {
       const secondKey = store.labelCacheKey ?? secondKeyFromDate(stampDate);
       if (tryBeginSecondStamp(store, secondKey)) {
-        pushLedgerStamp(store, segment.label, secondKey, absoluteLine, capacity);
+        const entry = pushLedgerStamp(
+          store,
+          segment.label,
+          secondKey,
+          absoluteLine,
+          capacity,
+        );
+        pendingAnchors.push(entry);
         ledgerChanged = true;
       }
       continue;
     }
-    absoluteLine = advanceAbsoluteLineByData(absoluteLine, segment.data);
+    ({ absoluteLine, column, wraparoundMode } = advanceStampCursorByData(
+      term,
+      absoluteLine,
+      column,
+      segment.data,
+      columns,
+      wraparoundMode,
+    ));
   }
 
   const writeStartedAt = shouldMeasureDiagnostics ? performance.now() : 0;
   term.write(data, () => {
+    attachLedgerAnchors(term, pendingAnchors);
     rebaseLedgerForScrollback(term, store);
     if (ledgerChanged) {
       notifyTimestampStore(store);
@@ -1428,8 +1615,7 @@ export const writeTerminalDataWithLineTimestamps = (
     return;
   }
 
-  // Record/render separation: always maintain the per-second ledger; gutter
-  // paint reads ledger only (no xterm markers on the write path).
+  // Record/render separation: per-second ledger + sparse reflow anchors.
   writeTerminalDataWithSecondLedger(
     term,
     data,

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -56,6 +56,8 @@ type TimestampStore = {
   /** Intern HH:MM:SS for the current wall-clock second. */
   labelCacheKey: number | null;
   labelCacheValue: string;
+  /** Deferred fixed-size marker cleanup, one task at a time. */
+  orphanDrainTimer?: ReturnType<typeof setTimeout>;
 };
 
 type XTermWithUnicodeService = XTerm & {
@@ -134,9 +136,6 @@ export const MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES = 4096;
 const TIMESTAMP_PRUNE_EVERY_RECORDS = 256;
 /** Max xterm marker.dispose() calls per prune/write pass (amortize O(n) splices). */
 const TIMESTAMP_ORPHAN_DISPOSE_BUDGET = 64;
-/** When orphan backlog grows large, spend a bigger budget to catch up. */
-const TIMESTAMP_ORPHAN_CATCHUP_THRESHOLD = 512;
-const TIMESTAMP_ORPHAN_CATCHUP_BUDGET = 256;
 
 const pad2 = (value: number): string => value.toString().padStart(2, "0");
 
@@ -502,28 +501,32 @@ const enqueueOrphanedMarker = (
  * keeps rewrite/flood sessions responsive while still retiring superseded
  * markers that scrollback will never trim (e.g. DECSTBM row rewrites).
  */
-const drainOrphanedMarkers = (
+function scheduleOrphanMarkerDrain(store: TimestampStore): void {
+  if (store.orphanDrainTimer !== undefined || store.orphanedMarkers.length === 0) return;
+  const timer = setTimeout(() => {
+    if (store.orphanDrainTimer !== timer) return;
+    store.orphanDrainTimer = undefined;
+    drainOrphanedMarkers(store);
+  }, 0);
+  if (typeof timer === "object" && "unref" in timer && typeof timer.unref === "function") {
+    timer.unref();
+  }
+  store.orphanDrainTimer = timer;
+}
+
+function drainOrphanedMarkers(
   store: TimestampStore,
   budget = TIMESTAMP_ORPHAN_DISPOSE_BUDGET,
-): void => {
-  let remaining = budget;
-  if (store.orphanedMarkers.length >= TIMESTAMP_ORPHAN_CATCHUP_THRESHOLD) {
-    // Keep the deferred-disposal tail bounded even when one PTY batch adds
-    // more markers than the fixed catch-up budget. Otherwise 500-line chunks
-    // can add 244 live xterm markers per pass forever.
-    remaining = Math.max(
-      remaining,
-      TIMESTAMP_ORPHAN_CATCHUP_BUDGET,
-      store.orphanedMarkers.length - TIMESTAMP_ORPHAN_CATCHUP_THRESHOLD + 1,
-    );
-  }
+): void {
+  let remaining = Math.max(0, budget);
   while (remaining > 0 && store.orphanedMarkers.length > 0) {
     const marker = store.orphanedMarkers.pop();
     remaining -= 1;
     if (!marker || marker.isDisposed) continue;
     marker.dispose?.();
   }
-};
+  scheduleOrphanMarkerDrain(store);
+}
 
 /** Cheap pass for paint/write paths: drop disposed holes only (no dedupe / capacity). */
 const compactDisposedMarkersOnly = (store: TimestampStore): void => {
@@ -617,6 +620,10 @@ const maybePruneTimestampEntries = (
 };
 
 const resetTimestampStore = (store: TimestampStore) => {
+  if (store.orphanDrainTimer !== undefined) {
+    clearTimeout(store.orphanDrainTimer);
+    store.orphanDrainTimer = undefined;
+  }
   for (const entry of store.entries) {
     entry.disposeListener?.dispose();
     entry.marker.dispose?.();

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -1226,10 +1226,12 @@ export const writeTerminalDataWithLineTimestamps = (
       dataSegmentCount >= MIN_BATCHED_TIMESTAMP_DATA_SEGMENTS
       || data.length >= BULK_TIMESTAMP_BATCH_MIN_BYTES
     )
-    // Tab stops are mutable terminal state. The row estimator intentionally
-    // avoids xterm internals, so keep tabbed writes on the ordered segmented
+    // Tab stops, delayed wrap around backspaces, and ANSI newline mode depend
+    // on live xterm parser state. Keep those writes on the ordered segmented
     // path where marker positions come from xterm after each write.
     && !data.includes("\t")
+    && !data.includes("\b")
+    && (term as XTerm & { options?: { convertEol?: boolean } }).options?.convertEol !== true
     // Cheap ASCII gate first (seq / log floods); otherwise one validate+measure probe.
     && (
       isSimpleAsciiControlText(data)

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -33,12 +33,12 @@ type TimestampEntry = {
 };
 
 /**
- * Lightweight per-second history kept without xterm markers while the gutter
- * is off. On enable, entries materialize into markers for rendering.
+ * Record/render separation: write path only appends ledger stamps (one per
+ * second). Gutter paint maps ledger → visible rows without registerMarker.
  */
 type TimestampLedgerEntry = {
   label: string;
-  /** Floor(unixMs/1000); at most one ledger/marker stamp per second. */
+  /** Floor(unixMs/1000); at most one ledger stamp per second. */
   secondKey: number;
   /** Absolute buffer line (baseY + cursorY style) at stamp time. */
   line: number;
@@ -47,18 +47,19 @@ type TimestampLedgerEntry = {
 type TimestampStore = {
   segmenter: TerminalLineTimestampSegmenter;
   /**
-   * Live xterm markers while the gutter is on (also one-per-second).
-   * Capacity is capped so flood output cannot grow unboundedly.
+   * Legacy marker list (unused on the hot path). Kept so old helpers/tests that
+   * still touch markers do not crash; production paint reads `ledger` only.
    */
   entries: TimestampEntry[];
   /**
-   * Per-second stamps without markers. Written while gutter is off; used to
-   * rebuild markers when the user turns timestamps on.
+   * Source of truth: per-second stamps with buffer line anchors.
    */
   ledger: TimestampLedgerEntry[];
-  /** Last secondKey accepted for ledger or markers (shared throttle). */
+  /** Last secondKey accepted (one stamp per second). */
   lastStampSecondKey: number | null;
-  /** Whether markers currently reflect the ledger (avoid re-materialize storms). */
+  /** Last observed buffer.baseY for scrollback trim rebasing. */
+  lastSeenBaseY: number | null;
+  /** @deprecated materialize path removed; always false. */
   ledgerMaterialized: boolean;
   /**
    * Markers dropped from `entries` but not yet disposed. Drained with a per-pass
@@ -139,16 +140,13 @@ export type TerminalLineTimestampWriteOptions = TerminalLineTimestampDiagnostics
   /** Wall-clock arrival time for this batch, preserved across delayed writes. */
   timestampDate?: Date;
   /**
-   * Gutter visible: materialize markers (one per second) for paint.
-   * Gutter hidden: keep a lightweight per-second ledger only (no registerMarker).
-   * Defaults to true for direct unit-test callers; production passes host flag.
+   * Deprecated for recording: write path always maintains the per-second ledger
+   * (record/render separation). Kept for call-site compatibility; ignored.
    */
   enabled?: boolean;
 };
 
 const stores = new WeakMap<XTerm, TimestampStore>();
-const MIN_BATCHED_TIMESTAMP_DATA_SEGMENTS = 2;
-const BULK_TIMESTAMP_BATCH_MIN_BYTES = 4096;
 /**
  * Target ceiling for retained timestamp entries. xterm updates every marker
  * whenever a scrollback row is trimmed, so matching a 100k-row scrollback makes
@@ -481,6 +479,7 @@ const getTimestampStore = (term: XTerm): TimestampStore => {
       entries: [],
       ledger: [],
       lastStampSecondKey: null,
+      lastSeenBaseY: null,
       ledgerMaterialized: false,
       orphanedMarkers: [],
       listeners: new Set(),
@@ -551,85 +550,54 @@ const pushLedgerStamp = (
   secondKey: number,
   line: number,
   capacity: number,
-  options: { /** When true, markers already track this stamp (gutter on). */ keepMaterialized?: boolean } = {},
 ): void => {
   store.ledger.push({ label, secondKey, line: Math.max(0, line) });
   trimLedgerToCapacity(store, capacity);
-  // Gutter-off ledger writes need a later materialize pass when opened.
-  if (!options.keepMaterialized) {
-    store.ledgerMaterialized = false;
-  }
-};
-
-const clearLiveMarkers = (store: TimestampStore): void => {
-  for (const entry of store.entries) {
-    entry.disposeListener?.dispose();
-    entry.marker.dispose?.();
-  }
-  store.entries = [];
-  store.orphanedMarkers = [];
-  store.disposedPendingCompact = 0;
-  store.recordsSincePrune = 0;
-  store.ledgerMaterialized = false;
 };
 
 /**
- * Turn lightweight ledger stamps into xterm markers for gutter paint.
- * Safe to call from paint/write; no-ops when already materialized or empty.
+ * When scrollback trims, xterm shifts absolute line indices down as baseY grows.
+ * Rebase ledger anchors the same way markers would have been updated.
  */
-export const materializeTimestampLedgerToMarkers = (term: XTerm): number => {
-  const store = getTimestampStore(term);
-  if (store.ledgerMaterialized || store.ledger.length === 0) {
-    return 0;
-  }
-  const registerMarker = (
-    term as XTerm & { registerMarker?: (offset: number) => TimestampMarker | undefined }
-  ).registerMarker;
-  if (typeof registerMarker !== "function") {
-    store.ledgerMaterialized = true;
-    return 0;
-  }
-
-  // Drop stale markers first so we rebuild from the ledger only.
-  clearLiveMarkers(store);
-
-  const cursorLine = getAbsoluteCursorLine(term);
+const rebaseLedgerForScrollback = (term: XTerm, store: TimestampStore): void => {
+  let baseY = 0;
   let bufferLength = 0;
   try {
-    const active = term.buffer?.active as { length?: number } | undefined;
+    const active = term.buffer?.active as
+      | { baseY?: number; length?: number }
+      | undefined;
+    baseY = typeof active?.baseY === "number" ? active.baseY : 0;
     bufferLength = typeof active?.length === "number" ? active.length : 0;
   } catch {
-    bufferLength = 0;
+    return;
   }
 
-  let created = 0;
-  for (const entry of store.ledger) {
-    if (bufferLength > 0 && (entry.line < 0 || entry.line >= bufferLength)) {
-      continue;
+  if (store.lastSeenBaseY !== null && baseY > store.lastSeenBaseY) {
+    const delta = baseY - store.lastSeenBaseY;
+    for (const entry of store.ledger) {
+      entry.line -= delta;
     }
-    const offset = entry.line - cursorLine;
-    const marker = registerMarker.call(term, offset);
-    if (!marker) continue;
-    const markerEntry: TimestampEntry = { marker, label: entry.label };
-    markerEntry.disposeListener = marker.onDispose?.(() => {
-      store.disposedPendingCompact += 1;
-      markerEntry.disposeListener?.dispose();
-      markerEntry.disposeListener = undefined;
-    });
-    store.entries.push(markerEntry);
-    created += 1;
   }
-  store.ledgerMaterialized = true;
-  if (created > 0) {
-    maybePruneTimestampEntries(term, store, true, created);
-    notifyTimestampStore(store);
+  store.lastSeenBaseY = baseY;
+
+  if (store.ledger.length === 0) return;
+  let write = 0;
+  for (let read = 0; read < store.ledger.length; read += 1) {
+    const entry = store.ledger[read]!;
+    if (entry.line < 0) continue;
+    if (bufferLength > 0 && entry.line >= bufferLength) continue;
+    store.ledger[write] = entry;
+    write += 1;
   }
-  return created;
+  store.ledger.length = write;
 };
 
-/** Test helper: per-second ledger depth (no markers). */
+/** Test helper: per-second ledger depth. */
 export const getTerminalLineTimestampLedgerCount = (term: XTerm): number =>
   getTimestampStore(term).ledger.length;
+
+/** @deprecated No-op; paint reads the ledger directly. */
+export const materializeTimestampLedgerToMarkers = (_term: XTerm): number => 0;
 
 const internTerminalLineTimestampLabel = (
   store: TimestampStore,
@@ -688,26 +656,6 @@ function drainOrphanedMarkers(
 }
 
 /** Cheap pass for paint/write paths: drop disposed holes only (no dedupe / capacity). */
-const compactDisposedMarkersOnly = (store: TimestampStore): void => {
-  if (store.disposedPendingCompact <= 0) {
-    // Still drop any disposed holes we notice, but skip the scan when we have
-    // no dispose signals and the list is empty.
-    if (store.entries.length === 0) return;
-  }
-  const entries = store.entries;
-  let write = 0;
-  for (let read = 0; read < entries.length; read += 1) {
-    const entry = entries[read];
-    if (entry.marker.isDisposed) {
-      entry.disposeListener?.dispose();
-      continue;
-    }
-    entries[write] = entry;
-    write += 1;
-  }
-  entries.length = write;
-  store.disposedPendingCompact = 0;
-};
 
 /**
  * Compact disposed markers, collapse rewritten lines to their latest label,
@@ -793,6 +741,7 @@ const resetTimestampStore = (store: TimestampStore) => {
   store.entries = [];
   store.ledger = [];
   store.lastStampSecondKey = null;
+  store.lastSeenBaseY = null;
   store.ledgerMaterialized = false;
   store.orphanedMarkers = [];
   store.segmenter.reset();
@@ -804,7 +753,7 @@ const resetTimestampStore = (store: TimestampStore) => {
   notifyTimestampStore(store);
 };
 
-const recordTerminalLineTimestamp = (
+const _recordTerminalLineTimestamp = (
   term: XTerm,
   store: TimestampStore,
   label: string,
@@ -849,7 +798,7 @@ export const getTerminalLineTimestampEntryCount = (
   return store.entries.length;
 };
 
-const countLineFeeds = (data: string): number => {
+const _countLineFeeds = (data: string): number => {
   let count = 0;
   for (const char of data) {
     if (char === "\n") count += 1;
@@ -857,21 +806,21 @@ const countLineFeeds = (data: string): number => {
   return count;
 };
 
-const getTerminalColumnCount = (term: XTerm): number => {
+const _getTerminalColumnCount = (term: XTerm): number => {
   const columns = (term as XTerm & { cols?: number }).cols;
   return Number.isFinite(columns) && Number(columns) > 0
     ? Math.floor(Number(columns))
     : Number.POSITIVE_INFINITY;
 };
 
-const getTerminalCursorColumn = (term: XTerm): number => {
+const _getTerminalCursorColumn = (term: XTerm): number => {
   const cursorX = ((term.buffer?.active as { cursorX?: number } | undefined)?.cursorX);
   return Number.isFinite(cursorX) && Number(cursorX) >= 0
     ? Math.floor(Number(cursorX))
     : 0;
 };
 
-const getTerminalWraparoundMode = (term: XTerm): boolean => (
+const _getTerminalWraparoundMode = (term: XTerm): boolean => (
   ((term as XTerm & { modes?: { wraparoundMode?: boolean } }).modes?.wraparoundMode) !== false
 );
 
@@ -1136,132 +1085,6 @@ export const tryMeasureVisualRows = (
   return { rowOffset, column, wraparoundMode };
 };
 
-/**
- * True when `data` can be bulk-measured without a full width walk.
- * Avoids calling tryMeasureVisualRows at the batch gate (that used to double
- * measure: once with fake geometry at the gate, again per segment for offsets).
- */
-export const canBulkMeasureTerminalData = (term: XTerm, data: string): boolean => {
-  if (isSimpleAsciiControlText(data)) return true;
-  // Real geometry validity check only when non-ASCII/CSI is present — still a
-  // single measure later in writeBatchedTimestampSegments for marker offsets.
-  return tryMeasureVisualRows(
-    term,
-    data,
-    0,
-    Number.POSITIVE_INFINITY,
-    true,
-  ) !== null;
-};
-
-const writeBatchedTimestampSegments = (
-  term: XTerm,
-  store: TimestampStore,
-  data: string,
-  segments: TerminalLineTimestampSegment[],
-  done: () => void,
-  diagnostics?: TerminalLineTimestampDiagnostics,
-  /**
-   * Optional pre-measured full-batch geometry when the batch is a single data
-   * segment equal to `data` (reuses the gate measure; no second walk).
-   */
-  premeasuredFullBatch?: MeasuredTerminalRows | null,
-): void => {
-  const timestamps: Array<{ label: string; rowOffset: number }> = [];
-  const columns = getTerminalColumnCount(term);
-  let column = getTerminalCursorColumn(term);
-  let wraparoundMode = getTerminalWraparoundMode(term);
-  let rowOffset = 0;
-  const shouldMeasureDiagnostics = Boolean(diagnostics);
-  const measureStartedAt = shouldMeasureDiagnostics ? performance.now() : 0;
-
-  const dataSegments = segments.filter(
-    (segment): segment is { kind: "data"; data: string } => segment.kind === "data",
-  );
-  const canReuseFullBatchMeasure = Boolean(
-    premeasuredFullBatch
-    && dataSegments.length === 1
-    && dataSegments[0]!.data === data
-  );
-
-  for (const segment of segments) {
-    if (segment.kind === "timestamp") {
-      timestamps.push({ label: segment.label, rowOffset });
-      continue;
-    }
-    const measured = (
-      canReuseFullBatchMeasure && segment.data === data
-        ? premeasuredFullBatch!
-        : tryMeasureVisualRows(
-          term,
-          segment.data,
-          column,
-          columns,
-          wraparoundMode,
-        )
-    ) ?? {
-      // Unmeasurable chunk: preserve prior column/wrap state and count hard newlines only.
-      rowOffset: countLineFeeds(segment.data),
-      column,
-      wraparoundMode,
-    };
-    rowOffset += measured.rowOffset;
-    column = measured.column;
-    wraparoundMode = measured.wraparoundMode;
-  }
-  const measureMs = shouldMeasureDiagnostics ? performance.now() - measureStartedAt : 0;
-
-  const writeStartedAt = shouldMeasureDiagnostics ? performance.now() : 0;
-  term.write(data, () => {
-    const writeCallbackMs = shouldMeasureDiagnostics ? performance.now() - writeStartedAt : 0;
-    const markerStartedAt = shouldMeasureDiagnostics ? performance.now() : 0;
-    const capacity = resolveTerminalLineTimestampCapacity(term);
-    // Only register markers that land in the retained visual-row window.
-    // Slice by timestamp count is wrong for soft-wrapped floods (many stamps
-    // can map outside the buffer while fewer visual rows remain). Prefer the
-    // last `capacity` visual rows by measured rowOffset.
-    const minRowOffset = Math.max(0, rowOffset - capacity + 1);
-    let timestampsToRecord = timestamps.filter(
-      (timestamp) => timestamp.rowOffset >= minRowOffset,
-    );
-    if (timestampsToRecord.length > capacity) {
-      timestampsToRecord = timestampsToRecord.slice(
-        timestampsToRecord.length - capacity,
-      );
-    }
-    let timestampRecorded = false;
-    for (const timestamp of timestampsToRecord) {
-      timestampRecorded = recordTerminalLineTimestamp(
-        term,
-        store,
-        timestamp.label,
-        false,
-        timestamp.rowOffset - rowOffset,
-        { skipPrune: true },
-      ) || timestampRecorded;
-    }
-    // Amortize small batches. A forced full-store scan on every 2–8 line
-    // hidden drain grows with retained history and recreates the CPU climb this
-    // path is meant to avoid. Large batches still cross the record threshold.
-    maybePruneTimestampEntries(term, store, false, timestampsToRecord.length);
-    if (timestampRecorded) {
-      notifyTimestampStore(store);
-    }
-    if (diagnostics) {
-      diagnostics.onStep?.({
-        kind: "batched-write",
-        dataChars: data.length,
-        timestamps: timestamps.length,
-        measureMs,
-        writeCallbackMs,
-        markerMs: performance.now() - markerStartedAt,
-        rowOffset,
-        columns,
-      });
-    }
-    done();
-  });
-};
 
 export const resetTerminalLineTimestamps = (term: XTerm) => {
   resetTimestampStore(getTimestampStore(term));
@@ -1278,6 +1101,9 @@ export const onTerminalLineTimestampsChange = (
   };
 };
 
+/**
+ * Paint helper from marker entries (legacy). Prefer ledger-based paint.
+ */
 export const resolveTerminalTimestampGutterRows = ({
   viewportY,
   rows,
@@ -1306,9 +1132,6 @@ export const resolveTerminalTimestampGutterRows = ({
     }
   }
 
-  // Full scan (not binary search): cursor-up / reposition writes can append a
-  // newer marker on an earlier buffer line, so entries are not always sorted by
-  // marker.line. Later entries win for the same line.
   const labelByLine = new Map<number, string>();
   for (const entry of entries) {
     if (entry.marker.isDisposed) continue;
@@ -1337,6 +1160,51 @@ export const resolveTerminalTimestampGutterRows = ({
   return visible;
 };
 
+/**
+ * Render gutter rows from the per-second ledger (no xterm markers).
+ * Show a label only on the stamp line (and soft-wrap continuations of it),
+ * matching classic marker gutters — not every empty row below.
+ */
+export const resolveTerminalTimestampGutterRowsFromLedger = ({
+  viewportY,
+  rows,
+  ledger,
+  isWrappedLine,
+}: {
+  viewportY: number;
+  rows: number;
+  ledger: readonly TimestampLedgerEntry[];
+  isWrappedLine?: (line: number) => boolean;
+}): TerminalTimestampGutterRow[] => {
+  if (ledger.length === 0 || rows <= 0) return [];
+
+  const labelByLine = new Map<number, string>();
+  for (const entry of ledger) {
+    if (entry.line < 0) continue;
+    labelByLine.set(entry.line, entry.label);
+  }
+
+  const resolveSourceLine = (line: number): number => {
+    if (!isWrappedLine?.(line)) return line;
+    let sourceLine = line;
+    while (sourceLine > 0 && isWrappedLine(sourceLine)) {
+      sourceLine -= 1;
+    }
+    return sourceLine;
+  };
+
+  const visible: TerminalTimestampGutterRow[] = [];
+  for (let row = 0; row < rows; row += 1) {
+    const line = viewportY + row;
+    const sourceLine = resolveSourceLine(line);
+    const label = labelByLine.get(sourceLine);
+    if (label) {
+      visible.push({ row, label });
+    }
+  }
+  return visible;
+};
+
 export const getVisibleTerminalLineTimestampRows = (
   term: XTerm,
 ): TerminalTimestampGutterRow[] => {
@@ -1344,23 +1212,19 @@ export const getVisibleTerminalLineTimestampRows = (
     return [];
   }
   const store = getTimestampStore(term);
-  // Gutter just opened: promote per-second ledger into markers for paint.
-  materializeTimestampLedgerToMarkers(term);
-  // Paint path: only drop disposed holes. Full dedupe/capacity runs on write.
-  compactDisposedMarkersOnly(store);
-  return resolveTerminalTimestampGutterRows({
+  rebaseLedgerForScrollback(term, store);
+  return resolveTerminalTimestampGutterRowsFromLedger({
     viewportY: term.buffer.active.viewportY,
     rows: term.rows,
-    entries: store.entries,
+    ledger: store.ledger,
     isWrappedLine: (line) => term.buffer.active.getLine(line)?.isWrapped === true,
   });
 };
 
 /**
- * Gutter off: one term.write, maintain per-second ledger only (no markers).
- * Keeps segmenter state so enable can continue cleanly.
+ * Record path: one term.write + per-second ledger updates (no registerMarker).
  */
-const writeTerminalDataWithSecondLedgerOnly = (
+const writeTerminalDataWithSecondLedger = (
   term: XTerm,
   data: string,
   done: () => void,
@@ -1369,14 +1233,6 @@ const writeTerminalDataWithSecondLedgerOnly = (
   shouldMeasureDiagnostics = false,
 ): void => {
   const store = getTimestampStore(term);
-  // Free xterm marker cost while the gutter is hidden.
-  if (store.entries.length > 0 || store.orphanedMarkers.length > 0) {
-    clearLiveMarkers(store);
-    for (const marker of store.orphanedMarkers) {
-      if (!marker.isDisposed) marker.dispose?.();
-    }
-    store.orphanedMarkers = [];
-  }
 
   store.segmenter.setAlternateScreenActive(
     ((term.buffer?.active as { type?: string } | undefined)?.type) === "alternate",
@@ -1394,11 +1250,13 @@ const writeTerminalDataWithSecondLedgerOnly = (
 
   let absoluteLine = getAbsoluteCursorLine(term);
   const capacity = resolveTerminalLineTimestampCapacity(term);
+  let ledgerChanged = false;
   for (const segment of segments) {
     if (segment.kind === "timestamp") {
       const secondKey = store.labelCacheKey ?? secondKeyFromDate(stampDate);
       if (tryBeginSecondStamp(store, secondKey)) {
         pushLedgerStamp(store, segment.label, secondKey, absoluteLine, capacity);
+        ledgerChanged = true;
       }
       continue;
     }
@@ -1407,6 +1265,10 @@ const writeTerminalDataWithSecondLedgerOnly = (
 
   const writeStartedAt = shouldMeasureDiagnostics ? performance.now() : 0;
   term.write(data, () => {
+    rebaseLedgerForScrollback(term, store);
+    if (ledgerChanged) {
+      notifyTimestampStore(store);
+    }
     if (diagnostics) {
       diagnostics.onStep?.({
         kind: "fallback-write",
@@ -1440,28 +1302,7 @@ export const writeTerminalDataWithLineTimestamps = (
     });
   };
 
-  // Host gutter off: per-second ledger only (no registerMarker).
-  if (options?.enabled === false) {
-    writeTerminalDataWithSecondLedgerOnly(
-      term,
-      data,
-      done,
-      options,
-      diagnostics,
-      shouldMeasureDiagnostics,
-    );
-    return;
-  }
-
-  const registerMarker = (term as XTerm & { registerMarker?: unknown }).registerMarker;
-  if (typeof registerMarker !== "function") {
-    writeFallbackOnly(data, done);
-    return;
-  }
-
-  // Only skip markers under true flood / long-line pressure — not merely
-  // "scrollback full + multi-line" (that would drop timestamps for docker ps
-  // after a prior seq). Product semantics: each line can show a gutter stamp.
+  // True flood: skip ledger work entirely (same product rule as before).
   if (shouldSkipTerminalLineTimestamps(term)) {
     const store = getTimestampStore(term);
     store.segmenter.setAlternateScreenActive(
@@ -1474,186 +1315,14 @@ export const writeTerminalDataWithLineTimestamps = (
     return;
   }
 
-  const store = getTimestampStore(term);
-  // Gutter on: promote any ledger built while hidden into markers once.
-  materializeTimestampLedgerToMarkers(term);
-  // Clears / scrollback wipes dispose markers without new stamps. Compact only
-  // when dispose signals arrived — not on every tiny write against a full store.
-  if (store.disposedPendingCompact > 0) {
-    compactDisposedMarkersOnly(store);
-  }
-  store.segmenter.setAlternateScreenActive(
-    ((term.buffer?.active as { type?: string } | undefined)?.type) === "alternate",
+  // Record/render separation: always maintain the per-second ledger; gutter
+  // paint reads ledger only (no xterm markers on the write path).
+  writeTerminalDataWithSecondLedger(
+    term,
+    data,
+    done,
+    options,
+    diagnostics,
+    shouldMeasureDiagnostics,
   );
-  const timestampOnlyPrefix = store.timestampOnlyPrefix;
-  store.timestampOnlyPrefix = "";
-  const dataForTimestamps = `${timestampOnlyPrefix}${data}`;
-  const segmentStartedAt = shouldMeasureDiagnostics ? performance.now() : 0;
-  const segments = store.segmenter.append(dataForTimestamps, options?.timestampDate);
-  const parsedData = segments
-    .filter((segment): segment is { kind: "data"; data: string } => segment.kind === "data")
-    .map((segment) => segment.data)
-    .join("");
-  const dataSegmentCount = segments.reduce((count, segment) => (
-    segment.kind === "data" && segment.data ? count + 1 : count
-  ), 0);
-  if (diagnostics) {
-    diagnostics.onStep?.({
-      kind: "segment",
-      durationMs: performance.now() - segmentStartedAt,
-      dataChars: data.length,
-      segmentCount: segments.length,
-      dataSegmentCount,
-      timestampSegmentCount: segments.length - dataSegmentCount,
-      parsedChars: parsedData.length,
-    });
-  }
-  const writeFallbackData = writeFallbackOnly;
-  if (
-    timestampOnlyPrefix.length === 0
-    && parsedData === dataForTimestamps
-    && !hasPartialScrollingRegion(term)
-    && (
-      dataSegmentCount >= MIN_BATCHED_TIMESTAMP_DATA_SEGMENTS
-      || data.length >= BULK_TIMESTAMP_BATCH_MIN_BYTES
-    )
-    // Tab stops, delayed wrap around backspaces, and ANSI newline mode depend
-    // on live xterm parser state. Keep those writes on the ordered segmented
-    // path where marker positions come from xterm after each write.
-    && !data.includes("\t")
-    && !data.includes("\b")
-    && (term as XTerm & { options?: { convertEol?: boolean } }).options?.convertEol !== true
-  ) {
-    // Prefer a single geometry walk per bytes measured:
-    // - one data segment: measure with real cursor/cols once, reuse in writeBatched
-    // - multi-segment / simple ASCII: validate (if needed) then measure each
-    //   segment once inside writeBatched (no second full-batch measure for reuse)
-    const isSimpleAscii = isSimpleAsciiControlText(data);
-    if (!isSimpleAscii && dataSegmentCount === 1) {
-      const premeasuredFullBatch = tryMeasureVisualRows(
-        term,
-        data,
-        getTerminalCursorColumn(term),
-        getTerminalColumnCount(term),
-        getTerminalWraparoundMode(term),
-      );
-      if (premeasuredFullBatch !== null) {
-        writeBatchedTimestampSegments(
-          term,
-          store,
-          data,
-          segments,
-          done,
-          diagnostics,
-          premeasuredFullBatch,
-        );
-        return;
-      }
-      // Unmeasurable single segment → segmented writes below.
-    } else if (isSimpleAscii || canBulkMeasureTerminalData(term, data)) {
-      writeBatchedTimestampSegments(
-        term,
-        store,
-        data,
-        segments,
-        done,
-        diagnostics,
-        null,
-      );
-      return;
-    }
-  }
-  const writeSegments = (
-    onComplete: () => void,
-    skipLeadingDataLength = 0,
-  ) => {
-    let index = 0;
-    let remainingSkipLength = skipLeadingDataLength;
-    let timestampRecorded = false;
-    let timestampCount = 0;
-    let writeCalls = 0;
-    let writeChars = 0;
-    let writeCallbackMs = 0;
-    const startedAt = shouldMeasureDiagnostics ? performance.now() : 0;
-
-    const complete = () => {
-      if (timestampRecorded) {
-        notifyTimestampStore(store);
-      }
-      if (diagnostics) {
-        diagnostics.onStep?.({
-          kind: "segmented-write",
-          dataChars: data.length,
-          timestamps: timestampCount,
-          writeCalls,
-          writeChars,
-          writeCallbackMs,
-          totalMs: performance.now() - startedAt,
-        });
-      }
-      onComplete();
-    };
-
-    const writeNext = () => {
-      const segment = segments[index];
-      index += 1;
-
-      if (!segment) {
-        complete();
-        return;
-      }
-
-      if (segment.kind === "timestamp") {
-        timestampCount += 1;
-        timestampRecorded = recordTerminalLineTimestamp(term, store, segment.label, false)
-          || timestampRecorded;
-        writeNext();
-        return;
-      }
-
-      let segmentData = segment.data;
-      if (remainingSkipLength > 0) {
-        const skippedLength = Math.min(remainingSkipLength, segmentData.length);
-        segmentData = segmentData.slice(skippedLength);
-        remainingSkipLength -= skippedLength;
-      }
-
-      if (!segmentData) {
-        writeNext();
-        return;
-      }
-
-      const writeStartedAt = shouldMeasureDiagnostics ? performance.now() : 0;
-      term.write(segmentData, () => {
-        writeCalls += 1;
-        writeChars += segmentData.length;
-        if (shouldMeasureDiagnostics) {
-          writeCallbackMs += performance.now() - writeStartedAt;
-        }
-        writeNext();
-      });
-    };
-
-    writeNext();
-  };
-
-  if (parsedData !== dataForTimestamps) {
-    const pendingEscapeSequence = store.segmenter.flushPendingEscapeSequence();
-    if (isPotentialAlternateScreenSequence(pendingEscapeSequence)) {
-      store.timestampOnlyPrefix = pendingEscapeSequence;
-    }
-    if (!parsedData || !dataForTimestamps.startsWith(parsedData)) {
-      writeFallbackData(data, done);
-      return;
-    }
-
-    const parsedCurrentDataLength = Math.max(0, parsedData.length - timestampOnlyPrefix.length);
-    const trailingData = data.slice(parsedCurrentDataLength);
-    writeSegments(
-      () => writeFallbackData(trailingData, done),
-      timestampOnlyPrefix.length,
-    );
-    return;
-  }
-  writeSegments(done, timestampOnlyPrefix.length);
 };

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -1162,27 +1162,38 @@ export const resolveTerminalTimestampGutterRows = ({
 
 /**
  * Render gutter rows from the per-second ledger (no xterm markers).
- * Show a label only on the stamp line (and soft-wrap continuations of it),
- * matching classic marker gutters — not every empty row below.
+ * Each visible line uses the latest stamp with stamp.line <= line so blank
+ * gaps between stamps (and soft-wrap continuations) fill with the previous time.
  */
 export const resolveTerminalTimestampGutterRowsFromLedger = ({
   viewportY,
   rows,
   ledger,
   isWrappedLine,
+  /** When set, do not paint past the last buffer line (avoids filling empty viewport). */
+  bufferLength,
 }: {
   viewportY: number;
   rows: number;
   ledger: readonly TimestampLedgerEntry[];
   isWrappedLine?: (line: number) => boolean;
+  bufferLength?: number;
 }): TerminalTimestampGutterRow[] => {
   if (ledger.length === 0 || rows <= 0) return [];
 
-  const labelByLine = new Map<number, string>();
-  for (const entry of ledger) {
-    if (entry.line < 0) continue;
-    labelByLine.set(entry.line, entry.label);
-  }
+  const stamps = ledger
+    .filter((entry) => entry.line >= 0)
+    .slice()
+    .sort((left, right) => left.line - right.line || left.secondKey - right.secondKey);
+
+  const labelAtOrBefore = (line: number): string | undefined => {
+    let label: string | undefined;
+    for (const stamp of stamps) {
+      if (stamp.line > line) break;
+      label = stamp.label;
+    }
+    return label;
+  };
 
   const resolveSourceLine = (line: number): number => {
     if (!isWrappedLine?.(line)) return line;
@@ -1193,11 +1204,16 @@ export const resolveTerminalTimestampGutterRowsFromLedger = ({
     return sourceLine;
   };
 
+  const lastBufferLine = typeof bufferLength === "number" && bufferLength > 0
+    ? bufferLength - 1
+    : Number.POSITIVE_INFINITY;
+
   const visible: TerminalTimestampGutterRow[] = [];
   for (let row = 0; row < rows; row += 1) {
     const line = viewportY + row;
+    if (line > lastBufferLine) break;
     const sourceLine = resolveSourceLine(line);
-    const label = labelByLine.get(sourceLine);
+    const label = labelAtOrBefore(sourceLine);
     if (label) {
       visible.push({ row, label });
     }
@@ -1213,11 +1229,19 @@ export const getVisibleTerminalLineTimestampRows = (
   }
   const store = getTimestampStore(term);
   rebaseLedgerForScrollback(term, store);
+  let bufferLength = 0;
+  try {
+    const active = term.buffer?.active as { length?: number } | undefined;
+    bufferLength = typeof active?.length === "number" ? active.length : 0;
+  } catch {
+    bufferLength = 0;
+  }
   return resolveTerminalTimestampGutterRowsFromLedger({
     viewportY: term.buffer.active.viewportY,
     rows: term.rows,
     ledger: store.ledger,
     isWrappedLine: (line) => term.buffer.active.getLine(line)?.isWrapped === true,
+    bufferLength,
   });
 };
 

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -540,9 +540,8 @@ const advanceAbsoluteLineByData = (line: number, data: string): number => {
 };
 
 /**
- * Soft-wrap–aware pre-write line advance for stamp placement.
- * Uses the same bulk measurer as the (legacy) batched marker path so narrow
- * terminals still land stamps on the correct buffer row when measurable.
+ * Soft-wrap–aware pre-write line advance for a span that is known to be on the
+ * normal buffer (not alternate screen).
  */
 const advanceStampCursorByData = (
   term: XTerm,
@@ -552,6 +551,9 @@ const advanceStampCursorByData = (
   columns: number,
   wraparoundMode: boolean,
 ): { absoluteLine: number; column: number; wraparoundMode: boolean } => {
+  if (!data) {
+    return { absoluteLine, column, wraparoundMode };
+  }
   const measured = tryMeasureVisualRows(term, data, column, columns, wraparoundMode);
   if (measured) {
     return {
@@ -566,6 +568,76 @@ const advanceStampCursorByData = (
     column: 0,
     wraparoundMode,
   };
+};
+
+type StampCursorEstimate = {
+  absoluteLine: number;
+  column: number;
+  wraparoundMode: boolean;
+  /** True while DEC alt-screen is active — do not advance normal-buffer lines. */
+  altActive: boolean;
+};
+
+/**
+ * Walk a data segment for stamp line estimates: honor soft-wrap on the normal
+ * buffer, ignore visual rows while the alternate screen is active (vim/less),
+ * and toggle alt on enter/leave CSI so post-TUI stamps are not inflated.
+ */
+const advanceStampCursorThroughData = (
+  term: XTerm,
+  cursor: StampCursorEstimate,
+  data: string,
+  columns: number,
+): StampCursorEstimate => {
+  let { absoluteLine, column, wraparoundMode, altActive } = cursor;
+  for (let index = 0; index < data.length;) {
+    if (data[index] === "\x1b") {
+      const sequence = readEscapeSequence(data, index);
+      if (!sequence) {
+        index += 1;
+        continue;
+      }
+      if (!sequence.complete) {
+        // Incomplete ESC at chunk end — segmenter holds it; do not invent rows.
+        break;
+      }
+      const altAction = getAlternateScreenAction(sequence.sequence);
+      if (altAction === "enter") {
+        altActive = true;
+      } else if (altAction === "leave") {
+        altActive = false;
+        // 1049 restore: normal buffer cursor is back where it was; keep the
+        // frozen absoluteLine/column from before enter (do not carry alt rows).
+      }
+      const wrapAction = getWraparoundAction(sequence.sequence);
+      if (wrapAction !== null && !altActive) {
+        wraparoundMode = wrapAction;
+      }
+      index = sequence.endIndex + 1;
+      continue;
+    }
+
+    if (altActive) {
+      const nextEsc = data.indexOf("\x1b", index + 1);
+      index = nextEsc === -1 ? data.length : nextEsc;
+      continue;
+    }
+
+    const nextEsc = data.indexOf("\x1b", index);
+    const end = nextEsc === -1 ? data.length : nextEsc;
+    if (end > index) {
+      ({ absoluteLine, column, wraparoundMode } = advanceStampCursorByData(
+        term,
+        absoluteLine,
+        column,
+        data.slice(index, end),
+        columns,
+        wraparoundMode,
+      ));
+    }
+    index = end;
+  }
+  return { absoluteLine, column, wraparoundMode, altActive };
 };
 
 const disposeLedgerMarker = (entry: TimestampLedgerEntry): void => {
@@ -624,6 +696,7 @@ const pushLedgerStamp = (
  */
 const attachLedgerAnchors = (
   term: XTerm,
+  store: TimestampStore,
   pending: readonly TimestampLedgerEntry[],
 ): void => {
   if (pending.length === 0) return;
@@ -632,8 +705,10 @@ const attachLedgerAnchors = (
   ).registerMarker;
   if (typeof registerMarker !== "function") return;
 
+  const stillInLedger = new Set(store.ledger);
   const cursorLine = getAbsoluteCursorLine(term);
   for (const entry of pending) {
+    if (!stillInLedger.has(entry)) continue;
     if (entry.marker && !entry.marker.isDisposed) continue;
     const offset = entry.line - cursorLine;
     let marker: TimestampMarker | undefined;
@@ -1529,22 +1604,27 @@ const writeTerminalDataWithSecondLedger = (
     store.timestampOnlyPrefix = pendingEscapeSequence;
   }
 
-  let absoluteLine = getAbsoluteCursorLine(term);
-  let column = _getTerminalCursorColumn(term);
+  let stampCursor: StampCursorEstimate = {
+    absoluteLine: getAbsoluteCursorLine(term),
+    column: _getTerminalCursorColumn(term),
+    wraparoundMode: _getTerminalWraparoundMode(term),
+    altActive: ((term.buffer?.active as { type?: string } | undefined)?.type) === "alternate",
+  };
   const columns = _getTerminalColumnCount(term);
-  let wraparoundMode = _getTerminalWraparoundMode(term);
   const capacity = resolveTerminalLineTimestampCapacity(term);
   let ledgerChanged = false;
   const pendingAnchors: TimestampLedgerEntry[] = [];
   for (const segment of segments) {
     if (segment.kind === "timestamp") {
-      const secondKey = store.labelCacheKey ?? secondKeyFromDate(stampDate);
+      // Segmenter only emits timestamps off the alt screen; still guard line.
+      if (stampCursor.altActive) continue;
+      const secondKey = secondKeyFromDate(stampDate);
       if (tryBeginSecondStamp(store, secondKey)) {
         const entry = pushLedgerStamp(
           store,
           segment.label,
           secondKey,
-          absoluteLine,
+          stampCursor.absoluteLine,
           capacity,
         );
         pendingAnchors.push(entry);
@@ -1552,19 +1632,17 @@ const writeTerminalDataWithSecondLedger = (
       }
       continue;
     }
-    ({ absoluteLine, column, wraparoundMode } = advanceStampCursorByData(
+    stampCursor = advanceStampCursorThroughData(
       term,
-      absoluteLine,
-      column,
+      stampCursor,
       segment.data,
       columns,
-      wraparoundMode,
-    ));
+    );
   }
 
   const writeStartedAt = shouldMeasureDiagnostics ? performance.now() : 0;
   term.write(data, () => {
-    attachLedgerAnchors(term, pendingAnchors);
+    attachLedgerAnchors(term, store, pendingAnchors);
     rebaseLedgerForScrollback(term, store);
     if (ledgerChanged) {
       notifyTimestampStore(store);

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -32,15 +32,34 @@ type TimestampEntry = {
   disposeListener?: { dispose: () => void };
 };
 
+/**
+ * Lightweight per-second history kept without xterm markers while the gutter
+ * is off. On enable, entries materialize into markers for rendering.
+ */
+type TimestampLedgerEntry = {
+  label: string;
+  /** Floor(unixMs/1000); at most one ledger/marker stamp per second. */
+  secondKey: number;
+  /** Absolute buffer line (baseY + cursorY style) at stamp time. */
+  line: number;
+};
+
 type TimestampStore = {
   segmenter: TerminalLineTimestampSegmenter;
   /**
-   * Dense ring of live markers for hosts with line timestamps enabled.
-   * Capacity is capped to scrollback so flood output cannot grow unboundedly.
-   * When the host gutter is off we skip this store on the write path; recording
-   * starts when the user turns timestamps on.
+   * Live xterm markers while the gutter is on (also one-per-second).
+   * Capacity is capped so flood output cannot grow unboundedly.
    */
   entries: TimestampEntry[];
+  /**
+   * Per-second stamps without markers. Written while gutter is off; used to
+   * rebuild markers when the user turns timestamps on.
+   */
+  ledger: TimestampLedgerEntry[];
+  /** Last secondKey accepted for ledger or markers (shared throttle). */
+  lastStampSecondKey: number | null;
+  /** Whether markers currently reflect the ledger (avoid re-materialize storms). */
+  ledgerMaterialized: boolean;
   /**
    * Markers dropped from `entries` but not yet disposed. Drained with a per-pass
    * budget so rewrite storms do not O(n²)-freeze on xterm marker list splices.
@@ -120,9 +139,9 @@ export type TerminalLineTimestampWriteOptions = TerminalLineTimestampDiagnostics
   /** Wall-clock arrival time for this batch, preserved across delayed writes. */
   timestampDate?: Date;
   /**
-   * When false, skip segmenter/marker work and write bytes only.
-   * Defaults to true for direct unit-test callers; production passes the host
-   * `showLineTimestamps` flag so disabled gutters stay off the hot path.
+   * Gutter visible: materialize markers (one per second) for paint.
+   * Gutter hidden: keep a lightweight per-second ledger only (no registerMarker).
+   * Defaults to true for direct unit-test callers; production passes host flag.
    */
   enabled?: boolean;
 };
@@ -460,6 +479,9 @@ const getTimestampStore = (term: XTerm): TimestampStore => {
       // Placeholder; replaced immediately with an interning segmenter below.
       segmenter: createTerminalLineTimestampSegmenter(),
       entries: [],
+      ledger: [],
+      lastStampSecondKey: null,
+      ledgerMaterialized: false,
       orphanedMarkers: [],
       listeners: new Set(),
       timestampOnlyPrefix: "",
@@ -476,6 +498,138 @@ const getTimestampStore = (term: XTerm): TimestampStore => {
   }
   return store;
 };
+
+const secondKeyFromDate = (date: Date): number => Math.floor(date.getTime() / 1000);
+
+const getAbsoluteCursorLine = (term: XTerm): number => {
+  try {
+    const active = term.buffer?.active as
+      | { baseY?: number; cursorY?: number }
+      | undefined;
+    const baseY = typeof active?.baseY === "number" ? active.baseY : 0;
+    const cursorY = typeof active?.cursorY === "number" ? active.cursorY : 0;
+    return Math.max(0, baseY + cursorY);
+  } catch {
+    return 0;
+  }
+};
+
+/** Advance absolute line by hard newlines in a data span (pre-write estimate). */
+const advanceAbsoluteLineByData = (line: number, data: string): number => {
+  let next = line;
+  for (let index = 0; index < data.length; index += 1) {
+    if (data[index] === "\n") next += 1;
+  }
+  return next;
+};
+
+const trimLedgerToCapacity = (
+  store: TimestampStore,
+  capacity: number,
+): void => {
+  if (capacity > 0 && store.ledger.length > capacity) {
+    store.ledger.splice(0, store.ledger.length - capacity);
+  }
+};
+
+/**
+ * Accept at most one stamp per wall-clock second across ledger + markers.
+ * Returns false when this second was already stamped.
+ */
+const tryBeginSecondStamp = (
+  store: TimestampStore,
+  secondKey: number,
+): boolean => {
+  if (store.lastStampSecondKey === secondKey) return false;
+  store.lastStampSecondKey = secondKey;
+  return true;
+};
+
+const pushLedgerStamp = (
+  store: TimestampStore,
+  label: string,
+  secondKey: number,
+  line: number,
+  capacity: number,
+  options: { /** When true, markers already track this stamp (gutter on). */ keepMaterialized?: boolean } = {},
+): void => {
+  store.ledger.push({ label, secondKey, line: Math.max(0, line) });
+  trimLedgerToCapacity(store, capacity);
+  // Gutter-off ledger writes need a later materialize pass when opened.
+  if (!options.keepMaterialized) {
+    store.ledgerMaterialized = false;
+  }
+};
+
+const clearLiveMarkers = (store: TimestampStore): void => {
+  for (const entry of store.entries) {
+    entry.disposeListener?.dispose();
+    entry.marker.dispose?.();
+  }
+  store.entries = [];
+  store.orphanedMarkers = [];
+  store.disposedPendingCompact = 0;
+  store.recordsSincePrune = 0;
+  store.ledgerMaterialized = false;
+};
+
+/**
+ * Turn lightweight ledger stamps into xterm markers for gutter paint.
+ * Safe to call from paint/write; no-ops when already materialized or empty.
+ */
+export const materializeTimestampLedgerToMarkers = (term: XTerm): number => {
+  const store = getTimestampStore(term);
+  if (store.ledgerMaterialized || store.ledger.length === 0) {
+    return 0;
+  }
+  const registerMarker = (
+    term as XTerm & { registerMarker?: (offset: number) => TimestampMarker | undefined }
+  ).registerMarker;
+  if (typeof registerMarker !== "function") {
+    store.ledgerMaterialized = true;
+    return 0;
+  }
+
+  // Drop stale markers first so we rebuild from the ledger only.
+  clearLiveMarkers(store);
+
+  const cursorLine = getAbsoluteCursorLine(term);
+  let bufferLength = 0;
+  try {
+    const active = term.buffer?.active as { length?: number } | undefined;
+    bufferLength = typeof active?.length === "number" ? active.length : 0;
+  } catch {
+    bufferLength = 0;
+  }
+
+  let created = 0;
+  for (const entry of store.ledger) {
+    if (bufferLength > 0 && (entry.line < 0 || entry.line >= bufferLength)) {
+      continue;
+    }
+    const offset = entry.line - cursorLine;
+    const marker = registerMarker.call(term, offset);
+    if (!marker) continue;
+    const markerEntry: TimestampEntry = { marker, label: entry.label };
+    markerEntry.disposeListener = marker.onDispose?.(() => {
+      store.disposedPendingCompact += 1;
+      markerEntry.disposeListener?.dispose();
+      markerEntry.disposeListener = undefined;
+    });
+    store.entries.push(markerEntry);
+    created += 1;
+  }
+  store.ledgerMaterialized = true;
+  if (created > 0) {
+    maybePruneTimestampEntries(term, store, true, created);
+    notifyTimestampStore(store);
+  }
+  return created;
+};
+
+/** Test helper: per-second ledger depth (no markers). */
+export const getTerminalLineTimestampLedgerCount = (term: XTerm): number =>
+  getTimestampStore(term).ledger.length;
 
 const internTerminalLineTimestampLabel = (
   store: TimestampStore,
@@ -637,6 +791,9 @@ const resetTimestampStore = (store: TimestampStore) => {
     if (!marker.isDisposed) marker.dispose?.();
   }
   store.entries = [];
+  store.ledger = [];
+  store.lastStampSecondKey = null;
+  store.ledgerMaterialized = false;
   store.orphanedMarkers = [];
   store.segmenter.reset();
   store.timestampOnlyPrefix = "";
@@ -655,6 +812,8 @@ const recordTerminalLineTimestamp = (
   cursorYOffset = 0,
   options: { skipPrune?: boolean } = {},
 ): boolean => {
+  // Gutter-on path: per-line markers for accurate paint. The gutter-off path
+  // uses a per-second ledger instead (see writeTerminalDataWithSecondLedgerOnly).
   const registerMarker = (term as XTerm & { registerMarker?: (offset: number) => TimestampMarker | undefined }).registerMarker;
   const marker = registerMarker?.call(term, cursorYOffset);
   if (!marker) return false;
@@ -668,6 +827,7 @@ const recordTerminalLineTimestamp = (
     entry.disposeListener = undefined;
   });
   store.entries.push(entry);
+  store.ledgerMaterialized = true;
   if (!options.skipPrune) {
     maybePruneTimestampEntries(term, store);
   }
@@ -1184,6 +1344,8 @@ export const getVisibleTerminalLineTimestampRows = (
     return [];
   }
   const store = getTimestampStore(term);
+  // Gutter just opened: promote per-second ledger into markers for paint.
+  materializeTimestampLedgerToMarkers(term);
   // Paint path: only drop disposed holes. Full dedupe/capacity runs on write.
   compactDisposedMarkersOnly(store);
   return resolveTerminalTimestampGutterRows({
@@ -1191,6 +1353,68 @@ export const getVisibleTerminalLineTimestampRows = (
     rows: term.rows,
     entries: store.entries,
     isWrappedLine: (line) => term.buffer.active.getLine(line)?.isWrapped === true,
+  });
+};
+
+/**
+ * Gutter off: one term.write, maintain per-second ledger only (no markers).
+ * Keeps segmenter state so enable can continue cleanly.
+ */
+const writeTerminalDataWithSecondLedgerOnly = (
+  term: XTerm,
+  data: string,
+  done: () => void,
+  options?: TerminalLineTimestampWriteOptions,
+  diagnostics?: TerminalLineTimestampDiagnostics,
+  shouldMeasureDiagnostics = false,
+): void => {
+  const store = getTimestampStore(term);
+  // Free xterm marker cost while the gutter is hidden.
+  if (store.entries.length > 0 || store.orphanedMarkers.length > 0) {
+    clearLiveMarkers(store);
+    for (const marker of store.orphanedMarkers) {
+      if (!marker.isDisposed) marker.dispose?.();
+    }
+    store.orphanedMarkers = [];
+  }
+
+  store.segmenter.setAlternateScreenActive(
+    ((term.buffer?.active as { type?: string } | undefined)?.type) === "alternate",
+  );
+  const timestampOnlyPrefix = store.timestampOnlyPrefix;
+  store.timestampOnlyPrefix = "";
+  const dataForTimestamps = `${timestampOnlyPrefix}${data}`;
+  const stampDate = options?.timestampDate ?? new Date();
+  const segments = store.segmenter.append(dataForTimestamps, stampDate);
+
+  const pendingEscapeSequence = store.segmenter.flushPendingEscapeSequence();
+  if (isPotentialAlternateScreenSequence(pendingEscapeSequence)) {
+    store.timestampOnlyPrefix = pendingEscapeSequence;
+  }
+
+  let absoluteLine = getAbsoluteCursorLine(term);
+  const capacity = resolveTerminalLineTimestampCapacity(term);
+  for (const segment of segments) {
+    if (segment.kind === "timestamp") {
+      const secondKey = store.labelCacheKey ?? secondKeyFromDate(stampDate);
+      if (tryBeginSecondStamp(store, secondKey)) {
+        pushLedgerStamp(store, segment.label, secondKey, absoluteLine, capacity);
+      }
+      continue;
+    }
+    absoluteLine = advanceAbsoluteLineByData(absoluteLine, segment.data);
+  }
+
+  const writeStartedAt = shouldMeasureDiagnostics ? performance.now() : 0;
+  term.write(data, () => {
+    if (diagnostics) {
+      diagnostics.onStep?.({
+        kind: "fallback-write",
+        dataChars: data.length,
+        writeCallbackMs: performance.now() - writeStartedAt,
+      });
+    }
+    done();
   });
 };
 
@@ -1216,9 +1440,16 @@ export const writeTerminalDataWithLineTimestamps = (
     });
   };
 
-  // Host gutter off: skip segmenter/store/markers entirely (plain write).
+  // Host gutter off: per-second ledger only (no registerMarker).
   if (options?.enabled === false) {
-    writeFallbackOnly(data, done);
+    writeTerminalDataWithSecondLedgerOnly(
+      term,
+      data,
+      done,
+      options,
+      diagnostics,
+      shouldMeasureDiagnostics,
+    );
     return;
   }
 
@@ -1238,11 +1469,14 @@ export const writeTerminalDataWithLineTimestamps = (
     );
     store.segmenter.reset();
     store.timestampOnlyPrefix = "";
+    store.lastStampSecondKey = null;
     writeFallbackOnly(data, done);
     return;
   }
 
   const store = getTimestampStore(term);
+  // Gutter on: promote any ledger built while hidden into markers once.
+  materializeTimestampLedgerToMarkers(term);
   // Clears / scrollback wipes dispose markers without new stamps. Compact only
   // when dispose signals arrived — not on every tiny write against a full store.
   if (store.disposedPendingCompact > 0) {

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -609,19 +609,33 @@ const advanceStampCursorByData = (
   };
 };
 
-type StampCursorEstimate = {
+/**
+ * Stamp line estimate in **normal-buffer** coordinates only.
+ * Seeded once per write (active cursor, or buffer.normal when already on alt).
+ * Enter freezes advancement; leave never rewinds line/col from the live term.
+ */
+export type StampCursorEstimate = {
   absoluteLine: number;
   column: number;
   wraparoundMode: boolean;
   /** True while DEC alt-screen is active — do not advance normal-buffer lines. */
   altActive: boolean;
-  /**
-   * True after an enter CSI in this walk. Leave then keeps the frozen
-   * in-walk estimate (includes same-chunk normal advances before enter).
-   * When false and we leave, the write started on alt — restore from
-   * buffer.normal (pre-write active cursor is the TUI row).
-   */
-  enteredAltInWalk: boolean;
+};
+
+/**
+ * Pure alt-screen enter/leave for stamp estimates.
+ * Invariant: absoluteLine/column always mean normal-buffer coords and never
+ * change here — leave must not re-read term.buffer (spurious 1049l, same-chunk
+ * pre-enter advances, already-on-alt seed are all handled by seed + freeze).
+ */
+export const applyAltScreenAction = (
+  cursor: StampCursorEstimate,
+  action: "enter" | "leave",
+): StampCursorEstimate => {
+  if (action === "enter") {
+    return { ...cursor, altActive: true };
+  }
+  return { ...cursor, altActive: false };
 };
 
 /**
@@ -635,13 +649,7 @@ const advanceStampCursorThroughData = (
   data: string,
   columns: number,
 ): StampCursorEstimate => {
-  let {
-    absoluteLine,
-    column,
-    wraparoundMode,
-    altActive,
-    enteredAltInWalk,
-  } = cursor;
+  let { absoluteLine, column, wraparoundMode, altActive } = cursor;
   for (let index = 0; index < data.length;) {
     if (data[index] === "\x1b") {
       const sequence = readEscapeSequence(data, index);
@@ -654,23 +662,11 @@ const advanceStampCursorThroughData = (
         break;
       }
       const altAction = getAlternateScreenAction(sequence.sequence);
-      if (altAction === "enter") {
-        // Freeze the current normal-buffer estimate; alt rows must not advance it.
-        altActive = true;
-        enteredAltInWalk = true;
-      } else if (altAction === "leave") {
-        altActive = false;
-        if (enteredAltInWalk) {
-          // Same-chunk enter: keep frozen line/col (do NOT re-read pre-write
-          // buffer.normal — that would wipe normal advances before enter).
-          enteredAltInWalk = false;
-        } else {
-          // Write started already on alt: active cursor is the TUI row; restore
-          // the saved primary-buffer position xterm keeps on buffer.normal.
-          const restored = getNormalBufferCursorState(term);
-          absoluteLine = restored.absoluteLine;
-          column = restored.column;
-        }
+      if (altAction) {
+        ({ absoluteLine, column, wraparoundMode, altActive } = applyAltScreenAction(
+          { absoluteLine, column, wraparoundMode, altActive },
+          altAction,
+        ));
       }
       const wrapAction = getWraparoundAction(sequence.sequence);
       if (wrapAction !== null && !altActive) {
@@ -700,13 +696,7 @@ const advanceStampCursorThroughData = (
     }
     index = end;
   }
-  return {
-    absoluteLine,
-    column,
-    wraparoundMode,
-    altActive,
-    enteredAltInWalk,
-  };
+  return { absoluteLine, column, wraparoundMode, altActive };
 };
 
 const disposeLedgerMarker = (entry: TimestampLedgerEntry): void => {
@@ -1688,8 +1678,6 @@ const writeTerminalDataWithSecondLedger = (
     column: seedCursor.column,
     wraparoundMode: _getTerminalWraparoundMode(term),
     altActive: startedOnAlt,
-    // Leave only re-reads buffer.normal when we never saw enter in this walk.
-    enteredAltInWalk: false,
   };
   const columns = _getTerminalColumnCount(term);
   const capacity = resolveTerminalLineTimestampCapacity(term);

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -7,7 +7,7 @@ export type TerminalLineTimestampSegment =
   | { kind: "timestamp"; label: string };
 
 export type TerminalLineTimestampSegmenter = {
-  append: (data: string) => TerminalLineTimestampSegment[];
+  append: (data: string, timestampDate?: Date) => TerminalLineTimestampSegment[];
   reset: () => void;
   flushPendingEscapeSequence: () => string;
   setAlternateScreenActive: (active: boolean) => void;
@@ -113,6 +113,11 @@ export type TerminalLineTimestampPerfStep =
 
 export type TerminalLineTimestampDiagnostics = {
   onStep?: (step: TerminalLineTimestampPerfStep) => void;
+};
+
+export type TerminalLineTimestampWriteOptions = TerminalLineTimestampDiagnostics & {
+  /** Wall-clock arrival time for this batch, preserved across delayed writes. */
+  timestampDate?: Date;
 };
 
 const stores = new WeakMap<XTerm, TimestampStore>();
@@ -337,18 +342,21 @@ export const createTerminalLineTimestampSegmenter = (
     currentLineStamped = false;
   };
 
-  const pushTimestampIfNeeded = (segments: TerminalLineTimestampSegment[]) => {
+  const pushTimestampIfNeeded = (
+    segments: TerminalLineTimestampSegment[],
+    timestampDate?: Date,
+  ) => {
     if (!atLineStart || currentLineStamped) return;
     currentLineStamped = true;
     atLineStart = false;
     segments.push({
       kind: "timestamp",
-      label: formatLabel(now()),
+      label: formatLabel(timestampDate ?? now()),
     });
   };
 
   return {
-    append(data: string) {
+    append(data: string, timestampDate?: Date) {
       const input = pendingEscapeSequence ? `${pendingEscapeSequence}${data}` : data;
       pendingEscapeSequence = "";
       const segments: TerminalLineTimestampSegment[] = [];
@@ -403,7 +411,7 @@ export const createTerminalLineTimestampSegmenter = (
         // state-changing character (ESC/LF/CR) and append the span in one
         // slice. Control chars inside the span (BEL, backspace, DEL, C1)
         // never change segmenter state, matching the per-char loop.
-        pushTimestampIfNeeded(segments);
+        pushTimestampIfNeeded(segments, timestampDate);
         atLineStart = false;
         const end = nextSegmenterBoundary(input, index + 1);
         pushDataSegment(segments, input.slice(index, end));
@@ -585,9 +593,10 @@ const maybePruneTimestampEntries = (
   term: XTerm,
   store: TimestampStore,
   force = false,
+  recordsAdded = 1,
 ): void => {
   const capacity = resolveTerminalLineTimestampCapacity(term);
-  store.recordsSincePrune += 1;
+  store.recordsSincePrune += Math.max(0, recordsAdded);
   if (
     force
     || store.recordsSincePrune >= TIMESTAMP_PRUNE_EVERY_RECORDS
@@ -1017,8 +1026,10 @@ const writeBatchedTimestampSegments = (
         { skipPrune: true },
       ) || timestampRecorded;
     }
-    // Single prune after bulk registration (intermediate prunes dominate large floods).
-    maybePruneTimestampEntries(term, store, true);
+    // Amortize small batches. A forced full-store scan on every 2–8 line
+    // hidden drain grows with retained history and recreates the CPU climb this
+    // path is meant to avoid. Large batches still cross the record threshold.
+    maybePruneTimestampEntries(term, store, false, timestampsToRecord.length);
     if (timestampRecorded) {
       notifyTimestampStore(store);
     }
@@ -1133,8 +1144,9 @@ export const writeTerminalDataWithLineTimestamps = (
   term: XTerm,
   data: string,
   done: () => void,
-  diagnostics?: TerminalLineTimestampDiagnostics,
+  options?: TerminalLineTimestampWriteOptions,
 ) => {
+  const diagnostics = options?.onStep ? options : undefined;
   const shouldMeasureDiagnostics = Boolean(diagnostics);
   const writeFallbackOnly = (fallbackData: string, onComplete: () => void): void => {
     const writeStartedAt = shouldMeasureDiagnostics ? performance.now() : 0;
@@ -1183,7 +1195,7 @@ export const writeTerminalDataWithLineTimestamps = (
   store.timestampOnlyPrefix = "";
   const dataForTimestamps = `${timestampOnlyPrefix}${data}`;
   const segmentStartedAt = shouldMeasureDiagnostics ? performance.now() : 0;
-  const segments = store.segmenter.append(dataForTimestamps);
+  const segments = store.segmenter.append(dataForTimestamps, options?.timestampDate);
   const parsedData = segments
     .filter((segment): segment is { kind: "data"; data: string } => segment.kind === "data")
     .map((segment) => segment.data)

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -35,11 +35,10 @@ type TimestampEntry = {
 type TimestampStore = {
   segmenter: TerminalLineTimestampSegmenter;
   /**
-   * Dense ring of live markers. Always records (even when the gutter is off)
-   * so expanding timestamps later still shows history — same product model as
-   * iTerm2, where per-line time lives in buffer metadata and display is a
-   * view toggle. Capacity is capped to scrollback so flood output cannot grow
-   * unboundedly.
+   * Dense ring of live markers for hosts with line timestamps enabled.
+   * Capacity is capped to scrollback so flood output cannot grow unboundedly.
+   * When the host gutter is off we skip this store on the write path; recording
+   * starts when the user turns timestamps on.
    */
   entries: TimestampEntry[];
   /**
@@ -120,6 +119,12 @@ export type TerminalLineTimestampDiagnostics = {
 export type TerminalLineTimestampWriteOptions = TerminalLineTimestampDiagnostics & {
   /** Wall-clock arrival time for this batch, preserved across delayed writes. */
   timestampDate?: Date;
+  /**
+   * When false, skip segmenter/marker work and write bytes only.
+   * Defaults to true for direct unit-test callers; production passes the host
+   * `showLineTimestamps` flag so disabled gutters stay off the hot path.
+   */
+  enabled?: boolean;
 };
 
 const stores = new WeakMap<XTerm, TimestampStore>();
@@ -887,6 +892,13 @@ const measureSimpleAsciiRows = (
  * Returns null when the chunk contains sequences we cannot bulk-measure safely
  * (caller falls back to line-feed counting / segmented writes).
  */
+/** Test-only: counts tryMeasureVisualRows invocations on the shipped path. */
+let visualRowMeasureCountForTests = 0;
+export const getVisualRowMeasureCountForTests = (): number => visualRowMeasureCountForTests;
+export const resetVisualRowMeasureCountForTests = (): void => {
+  visualRowMeasureCountForTests = 0;
+};
+
 export const tryMeasureVisualRows = (
   term: XTerm,
   data: string,
@@ -894,6 +906,7 @@ export const tryMeasureVisualRows = (
   columns: number,
   startWraparoundMode: boolean,
 ): MeasuredTerminalRows | null => {
+  visualRowMeasureCountForTests += 1;
   if (isSimpleAsciiControlText(data)) {
     return measureSimpleAsciiRows(data, startColumn, columns, startWraparoundMode);
   }
@@ -963,17 +976,23 @@ export const tryMeasureVisualRows = (
   return { rowOffset, column, wraparoundMode };
 };
 
-/** @deprecated Prefer tryMeasureVisualRows — kept for call-site clarity in gates. */
-const canMeasureVisualRows = (term: XTerm, data: string): boolean => (
-  isSimpleAsciiControlText(data)
-  || tryMeasureVisualRows(
+/**
+ * True when `data` can be bulk-measured without a full width walk.
+ * Avoids calling tryMeasureVisualRows at the batch gate (that used to double
+ * measure: once with fake geometry at the gate, again per segment for offsets).
+ */
+export const canBulkMeasureTerminalData = (term: XTerm, data: string): boolean => {
+  if (isSimpleAsciiControlText(data)) return true;
+  // Real geometry validity check only when non-ASCII/CSI is present — still a
+  // single measure later in writeBatchedTimestampSegments for marker offsets.
+  return tryMeasureVisualRows(
     term,
     data,
     0,
     Number.POSITIVE_INFINITY,
     true,
-  ) !== null
-);
+  ) !== null;
+};
 
 const writeBatchedTimestampSegments = (
   term: XTerm,
@@ -982,6 +1001,11 @@ const writeBatchedTimestampSegments = (
   segments: TerminalLineTimestampSegment[],
   done: () => void,
   diagnostics?: TerminalLineTimestampDiagnostics,
+  /**
+   * Optional pre-measured full-batch geometry when the batch is a single data
+   * segment equal to `data` (reuses the gate measure; no second walk).
+   */
+  premeasuredFullBatch?: MeasuredTerminalRows | null,
 ): void => {
   const timestamps: Array<{ label: string; rowOffset: number }> = [];
   const columns = getTerminalColumnCount(term);
@@ -991,17 +1015,30 @@ const writeBatchedTimestampSegments = (
   const shouldMeasureDiagnostics = Boolean(diagnostics);
   const measureStartedAt = shouldMeasureDiagnostics ? performance.now() : 0;
 
+  const dataSegments = segments.filter(
+    (segment): segment is { kind: "data"; data: string } => segment.kind === "data",
+  );
+  const canReuseFullBatchMeasure = Boolean(
+    premeasuredFullBatch
+    && dataSegments.length === 1
+    && dataSegments[0]!.data === data
+  );
+
   for (const segment of segments) {
     if (segment.kind === "timestamp") {
       timestamps.push({ label: segment.label, rowOffset });
       continue;
     }
-    const measured = tryMeasureVisualRows(
-      term,
-      segment.data,
-      column,
-      columns,
-      wraparoundMode,
+    const measured = (
+      canReuseFullBatchMeasure && segment.data === data
+        ? premeasuredFullBatch!
+        : tryMeasureVisualRows(
+          term,
+          segment.data,
+          column,
+          columns,
+          wraparoundMode,
+        )
     ) ?? {
       // Unmeasurable chunk: preserve prior column/wrap state and count hard newlines only.
       rowOffset: countLineFeeds(segment.data),
@@ -1179,6 +1216,12 @@ export const writeTerminalDataWithLineTimestamps = (
     });
   };
 
+  // Host gutter off: skip segmenter/store/markers entirely (plain write).
+  if (options?.enabled === false) {
+    writeFallbackOnly(data, done);
+    return;
+  }
+
   const registerMarker = (term as XTerm & { registerMarker?: unknown }).registerMarker;
   if (typeof registerMarker !== "function") {
     writeFallbackOnly(data, done);
@@ -1246,14 +1289,45 @@ export const writeTerminalDataWithLineTimestamps = (
     && !data.includes("\t")
     && !data.includes("\b")
     && (term as XTerm & { options?: { convertEol?: boolean } }).options?.convertEol !== true
-    // Cheap ASCII gate first (seq / log floods); otherwise one validate+measure probe.
-    && (
-      isSimpleAsciiControlText(data)
-      || canMeasureVisualRows(term, data)
-    )
   ) {
-    writeBatchedTimestampSegments(term, store, data, segments, done, diagnostics);
-    return;
+    // Prefer a single geometry walk per bytes measured:
+    // - one data segment: measure with real cursor/cols once, reuse in writeBatched
+    // - multi-segment / simple ASCII: validate (if needed) then measure each
+    //   segment once inside writeBatched (no second full-batch measure for reuse)
+    const isSimpleAscii = isSimpleAsciiControlText(data);
+    if (!isSimpleAscii && dataSegmentCount === 1) {
+      const premeasuredFullBatch = tryMeasureVisualRows(
+        term,
+        data,
+        getTerminalCursorColumn(term),
+        getTerminalColumnCount(term),
+        getTerminalWraparoundMode(term),
+      );
+      if (premeasuredFullBatch !== null) {
+        writeBatchedTimestampSegments(
+          term,
+          store,
+          data,
+          segments,
+          done,
+          diagnostics,
+          premeasuredFullBatch,
+        );
+        return;
+      }
+      // Unmeasurable single segment → segmented writes below.
+    } else if (isSimpleAscii || canBulkMeasureTerminalData(term, data)) {
+      writeBatchedTimestampSegments(
+        term,
+        store,
+        data,
+        segments,
+        done,
+        diagnostics,
+        null,
+      );
+      return;
+    }
   }
   const writeSegments = (
     onComplete: () => void,

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -57,8 +57,13 @@ type TimestampStore = {
   ledger: TimestampLedgerEntry[];
   /** Last secondKey accepted (one stamp per second). */
   lastStampSecondKey: number | null;
-  /** Last observed buffer.baseY for scrollback trim rebasing. */
+  /**
+   * Last observed buffer.baseY / length. Used only to detect scrollback *trim*
+   * (circular drop from the top while buffer is full) — not ordinary baseY
+   * growth while the buffer is still growing.
+   */
   lastSeenBaseY: number | null;
+  lastSeenBufferLength: number | null;
   /** @deprecated materialize path removed; always false. */
   ledgerMaterialized: boolean;
   /**
@@ -480,6 +485,7 @@ const getTimestampStore = (term: XTerm): TimestampStore => {
       ledger: [],
       lastStampSecondKey: null,
       lastSeenBaseY: null,
+      lastSeenBufferLength: null,
       ledgerMaterialized: false,
       orphanedMarkers: [],
       listeners: new Set(),
@@ -555,9 +561,23 @@ const pushLedgerStamp = (
   trimLedgerToCapacity(store, capacity);
 };
 
+const resolveBufferMaxLines = (term: XTerm): number => {
+  const options = (term as XTerm & { options?: { scrollback?: number } }).options;
+  const scrollback = typeof options?.scrollback === "number" && options.scrollback > 0
+    ? Math.floor(options.scrollback)
+    : 0;
+  const rows = Number.isFinite(term.rows) && term.rows > 0 ? term.rows : 24;
+  // xterm keeps scrollback + viewport rows in the active buffer.
+  return scrollback + rows;
+};
+
 /**
- * When scrollback trims, xterm shifts absolute line indices down as baseY grows.
- * Rebase ledger anchors the same way markers would have been updated.
+ * Rebase ledger only when scrollback actually trims old lines from the top.
+ *
+ * Important: while the buffer is still growing, baseY also increases as the
+ * viewport follows the cursor — absolute line indices of older content do NOT
+ * shift. Subtracting every baseY delta incorrectly deletes early stamps
+ * (MOTD / login banner vanishing on scroll).
  */
 const rebaseLedgerForScrollback = (term: XTerm, store: TimestampStore): void => {
   let baseY = 0;
@@ -572,13 +592,27 @@ const rebaseLedgerForScrollback = (term: XTerm, store: TimestampStore): void => 
     return;
   }
 
-  if (store.lastSeenBaseY !== null && baseY > store.lastSeenBaseY) {
+  const maxLines = resolveBufferMaxLines(term);
+  const bufferWasFull = store.lastSeenBufferLength !== null
+    && store.lastSeenBufferLength >= maxLines;
+  const bufferIsFull = bufferLength >= maxLines;
+
+  // Only while full (or staying full) does baseY growth mean "N lines dropped
+  // from the top" and absolute indices of survivors decrease by N.
+  if (
+    bufferWasFull
+    && bufferIsFull
+    && store.lastSeenBaseY !== null
+    && baseY > store.lastSeenBaseY
+  ) {
     const delta = baseY - store.lastSeenBaseY;
     for (const entry of store.ledger) {
       entry.line -= delta;
     }
   }
+
   store.lastSeenBaseY = baseY;
+  store.lastSeenBufferLength = bufferLength;
 
   if (store.ledger.length === 0) return;
   let write = 0;
@@ -590,6 +624,56 @@ const rebaseLedgerForScrollback = (term: XTerm, store: TimestampStore): void => 
     write += 1;
   }
   store.ledger.length = write;
+};
+
+/**
+ * Last buffer line that should show a gutter label: never past real content.
+ * Avoids painting empty viewport rows after the final content line.
+ */
+const resolveLastPaintBufferLine = (
+  term: XTerm,
+  store: TimestampStore,
+  bufferLength: number,
+): number => {
+  let lastLedgerLine = -1;
+  for (const entry of store.ledger) {
+    if (entry.line > lastLedgerLine) lastLedgerLine = entry.line;
+  }
+
+  let cursorAbs = 0;
+  let cursorX = 0;
+  try {
+    const active = term.buffer?.active as
+      | { baseY?: number; cursorY?: number; cursorX?: number }
+      | undefined;
+    const baseY = typeof active?.baseY === "number" ? active.baseY : 0;
+    const cursorY = typeof active?.cursorY === "number" ? active.cursorY : 0;
+    cursorX = typeof active?.cursorX === "number" ? active.cursorX : 0;
+    cursorAbs = Math.max(0, baseY + cursorY);
+  } catch {
+    cursorAbs = 0;
+  }
+
+  // After a trailing "\n", the cursor sits on an empty next line — that row
+  // should not force an extra painted gutter cell past content.
+  let contentEnd = cursorAbs;
+  try {
+    const line = term.buffer?.active?.getLine?.(cursorAbs) as
+      | { translateToString?: (trimRight?: boolean) => string }
+      | undefined;
+    const text = line?.translateToString?.(true) ?? "";
+    if (cursorX === 0 && text.length === 0 && cursorAbs > 0) {
+      contentEnd = cursorAbs - 1;
+    }
+  } catch {
+    // keep contentEnd
+  }
+
+  let lastPaint = Math.max(lastLedgerLine, contentEnd);
+  if (bufferLength > 0) {
+    lastPaint = Math.min(lastPaint, bufferLength - 1);
+  }
+  return Math.max(0, lastPaint);
 };
 
 /** Test helper: per-second ledger depth. */
@@ -742,6 +826,7 @@ const resetTimestampStore = (store: TimestampStore) => {
   store.ledger = [];
   store.lastStampSecondKey = null;
   store.lastSeenBaseY = null;
+  store.lastSeenBufferLength = null;
   store.ledgerMaterialized = false;
   store.orphanedMarkers = [];
   store.segmenter.reset();
@@ -1170,14 +1255,17 @@ export const resolveTerminalTimestampGutterRowsFromLedger = ({
   rows,
   ledger,
   isWrappedLine,
-  /** When set, do not paint past the last buffer line (avoids filling empty viewport). */
-  bufferLength,
+  /**
+   * Inclusive last buffer line that may receive a label. Caps paint at real
+   * content (not empty viewport rows past the last line).
+   */
+  lastPaintLine,
 }: {
   viewportY: number;
   rows: number;
   ledger: readonly TimestampLedgerEntry[];
   isWrappedLine?: (line: number) => boolean;
-  bufferLength?: number;
+  lastPaintLine?: number;
 }): TerminalTimestampGutterRow[] => {
   if (ledger.length === 0 || rows <= 0) return [];
 
@@ -1204,14 +1292,14 @@ export const resolveTerminalTimestampGutterRowsFromLedger = ({
     return sourceLine;
   };
 
-  const lastBufferLine = typeof bufferLength === "number" && bufferLength > 0
-    ? bufferLength - 1
+  const maxLine = typeof lastPaintLine === "number" && Number.isFinite(lastPaintLine)
+    ? lastPaintLine
     : Number.POSITIVE_INFINITY;
 
   const visible: TerminalTimestampGutterRow[] = [];
   for (let row = 0; row < rows; row += 1) {
     const line = viewportY + row;
-    if (line > lastBufferLine) break;
+    if (line > maxLine) break;
     const sourceLine = resolveSourceLine(line);
     const label = labelAtOrBefore(sourceLine);
     if (label) {
@@ -1236,12 +1324,13 @@ export const getVisibleTerminalLineTimestampRows = (
   } catch {
     bufferLength = 0;
   }
+  const lastPaintLine = resolveLastPaintBufferLine(term, store, bufferLength);
   return resolveTerminalTimestampGutterRowsFromLedger({
     viewportY: term.buffer.active.viewportY,
     rows: term.rows,
     ledger: store.ledger,
     isWrappedLine: (line) => term.buffer.active.getLine(line)?.isWrapped === true,
-    bufferLength,
+    lastPaintLine,
   });
 };
 

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -644,6 +644,43 @@ test("normal output before an alternate-screen frame keeps its earlier timestamp
   }
 });
 
+test("normal output after an alternate-screen frame keeps its earlier timestamp", () => {
+  const { term, writes } = createFakeTerm("alternate");
+  const activeBuffer = term.buffer.active as { type: string };
+  const originalWrite = term.write.bind(term);
+  term.write = (data: string | Uint8Array, callback?: () => void) => {
+    const text = typeof data === "string" ? data : new TextDecoder().decode(data);
+    if (text.includes("\x1b[?1049l")) {
+      activeBuffer.type = "normal";
+    }
+    originalWrite(data, callback);
+  };
+  const ctx = {
+    ...createContext(true),
+    isVisibleRef: { current: true },
+    isPaneVisibleRef: { current: false },
+  };
+  const originalDateNow = Date.now;
+  let fakeNow = new Date(2026, 0, 1, 12, 0, 59, 800).getTime();
+  Date.now = () => fakeNow;
+
+  try {
+    writeSessionData(ctx as never, term, "\x1b[?1049lafter\r\n");
+    fakeNow = new Date(2026, 0, 1, 12, 1, 0, 20).getTime();
+    writeSessionData(ctx as never, term, "next\r\n");
+    flushPendingTerminalWritesOnResume(term);
+
+    assert.equal(writes.join(""), "\x1b[?1049lafter\r\nnext\r\n");
+    assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
+      { row: 0, label: "12:00:59" },
+      { row: 1, label: "12:01:00" },
+    ]);
+  } finally {
+    Date.now = originalDateNow;
+    resetTerminalWriteCoalescer(term);
+  }
+});
+
 test("hiding a pane preserves the arrival second of already queued output", () => {
   const { term, writes } = createFakeTerm();
   const ctx = {

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -556,8 +556,9 @@ test("frequent hidden log lines are drained in one complete terminal write", asy
   await new Promise((resolve) => { setTimeout(resolve, 190); });
 
   assert.deepEqual(writes, [chunks.join("")]);
-  // Host timestamps off: drain still completes without marker work.
-  assert.equal(markerLines.length, 0);
+  // Host timestamps off still records the per-second ledger; sparse anchors
+  // only (≤1/sec), never per-line markers for 8 short lines.
+  assert.ok(markerLines.length <= 1);
   assert.equal(getFlowController(ctx as never, term).pendingBytes(), 0);
   resetTerminalWriteCoalescer(term);
 });
@@ -1502,17 +1503,19 @@ test("writeSessionData records terminal output timestamps without changing outpu
 
   assert.equal(writes.join(""), "hello\r\nnext");
   assert.equal((writes.join("").match(/\[\d{2}:\d{2}:\d{2}\]/g) ?? []).length, 0);
-  // Record/render separation: ledger only, never xterm markers on write.
-  assert.deepEqual(markerLines, []);
+  // Per-second sparse reflow anchor (not per output line).
+  assert.equal(markerLines.length, 1);
 });
 
-test("writeSessionData never registers xterm markers for timestamps", () => {
+test("writeSessionData uses sparse reflow anchors not per-line markers", () => {
   const { term, writes, markerLines } = createFakeTerm();
   writeSessionData(createContext(true, { showLineTimestamps: false }) as never, term, "hello\r\nnext");
   writeSessionData(createContext(false, { showLineTimestamps: true }) as never, term, "more\r\n");
 
   assert.ok(writes.join("").includes("hello"));
-  assert.deepEqual(markerLines, []);
+  // At most one anchor per stamped wall-clock second across both writes.
+  assert.ok(markerLines.length <= 2);
+  assert.ok(markerLines.length >= 1);
 });
 
 test("writeSessionData records timestamps for hosts with timestamps enabled", () => {
@@ -1520,7 +1523,7 @@ test("writeSessionData records timestamps for hosts with timestamps enabled", ()
   writeSessionData(createContext(false, { showLineTimestamps: true }) as never, term, "hello");
 
   assert.equal(writes.join(""), "hello");
-  assert.deepEqual(markerLines, []);
+  assert.equal(markerLines.length, 1);
   assert.ok(getVisibleTerminalLineTimestampRows(term).length >= 1);
 });
 
@@ -1545,7 +1548,7 @@ test("writeSessionData resumes timestamps after leaving alternate screen in the 
   writeSessionData(createContext(false, { showLineTimestamps: true }) as never, term, "\x1b[?1049lprompt");
 
   assert.equal(writes.join(""), "\x1b[?1049lprompt");
-  assert.deepEqual(markerLines, []);
+  assert.equal(markerLines.length, 1);
   assert.ok(getVisibleTerminalLineTimestampRows(term).length >= 1);
 });
 
@@ -1586,19 +1589,21 @@ test("writeSessionData always uses ledger recording regardless of gutter toggle"
   const ctx = createContext(false, { showLineTimestamps: false });
 
   writeSessionData(ctx as never, term, "before\r\n");
-  assert.deepEqual(markerLines, []);
+  // Per-second sparse reflow anchors (not per-line markers).
+  assert.equal(markerLines.length, 1);
 
   ctx.host = { showLineTimestamps: true };
   ctx.hostRef.current = ctx.host;
   writeSessionData(ctx as never, term, "enabled\r\n");
-  assert.deepEqual(markerLines, [], "write path never registerMarkers");
+  // Same wall-clock second in real runs may still be one stamp; here two writes
+  // share one second unless Date.now advances — allow ≤2 sparse anchors total.
+  assert.ok(markerLines.length <= 2, `expected sparse anchors, got ${markerLines.length}`);
 
   ctx.host = { showLineTimestamps: false };
   ctx.hostRef.current = ctx.host;
   writeSessionData(ctx as never, term, "disabled");
 
   assert.equal(writes.join(""), "before\r\nenabled\r\ndisabled");
-  assert.deepEqual(markerLines, []);
   // Ledger still has stamps for paint when gutter is shown.
   assert.ok(getVisibleTerminalLineTimestampRows(term).length >= 1);
 });
@@ -1614,7 +1619,7 @@ test("writeSessionData follows live hostRef toggles without replacing boot host 
   };
 
   writeSessionData(ctx as never, term, "boot-off\r\n");
-  assert.deepEqual(markerLines, []);
+  assert.ok(markerLines.length <= 1);
 
   hostRef.current = { showLineTimestamps: true };
   assert.equal(bootHost.showLineTimestamps, false);
@@ -1622,13 +1627,13 @@ test("writeSessionData follows live hostRef toggles without replacing boot host 
 
   writeSessionData(ctx as never, term, "live-on\r\n");
   assert.equal(writes.join(""), "boot-off\r\nlive-on\r\n");
-  assert.deepEqual(markerLines, []);
+  // Sparse anchors only (≤1 per stamped second).
+  assert.ok(markerLines.length <= 2);
   assert.ok(getVisibleTerminalLineTimestampRows(term).length >= 1);
 
   hostRef.current = { showLineTimestamps: false };
   writeSessionData(ctx as never, term, "live-off");
   assert.equal(writes.join(""), "boot-off\r\nlive-on\r\nlive-off");
-  assert.deepEqual(markerLines, []);
 });
 
 test("writeSessionData batches timestamp bookkeeping for bulk line output", () => {
@@ -1642,8 +1647,8 @@ test("writeSessionData batches timestamp bookkeeping for bulk line output", () =
   }
 
   assert.equal(writes.join(""), payload);
-  // One wall-clock second → one ledger stamp; paint fills every viewport row.
-  assert.deepEqual(markerLines, []);
+  // One wall-clock second → one ledger stamp + one sparse reflow anchor.
+  assert.equal(markerLines.length, 1);
   const painted = getVisibleTerminalLineTimestampRows(term);
   assert.ok(painted.length >= 1);
   assert.ok(painted.every((row) => row.label.length > 0));

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -921,13 +921,26 @@ test("hidden prompt formatting respects cursor movement before a bare line feed"
   const { Terminal } = require("@xterm/xterm") as {
     Terminal: new (options: Record<string, unknown>) => XTerm;
   };
-  const scenarios = [
+  const scenarios: Array<{
+    convertEol: boolean;
+    output: string;
+    promptRow: number;
+    setup?: string;
+  }> = [
     { convertEol: false, output: "foo\n", promptRow: 2 },
     { convertEol: true, output: "foo\n", promptRow: 1 },
     { convertEol: false, output: "\x1b[10C\n", promptRow: 2 },
     { convertEol: false, output: "foo\x1b[1G\n", promptRow: 1 },
     { convertEol: false, output: "你好\r\n", promptRow: 1 },
     { convertEol: false, output: "你好\n", promptRow: 2 },
+    { convertEol: false, output: "foo\x1b[20h\n", promptRow: 1 },
+    { convertEol: true, output: "foo\x1b[20l\n", promptRow: 2 },
+    {
+      convertEol: false,
+      setup: "\x1b[3g\x1b[6G\x1bH\x1b[1G",
+      output: "\x1b[I\n",
+      promptRow: 2,
+    },
   ];
   for (const scenario of scenarios) {
     const term = new Terminal({
@@ -955,6 +968,10 @@ test("hidden prompt formatting respects cursor movement before a bare line feed"
     };
 
     try {
+      if (scenario.setup) {
+        term.write(scenario.setup);
+        flushPendingTerminalWritesOnResume(term);
+      }
       withAnimationFrameQueue(() => {
         writeSessionData(ctx as never, term, scenario.output);
         writeSessionData(ctx as never, term, "$ ");

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -613,6 +613,12 @@ test("hidden prompt formatting preserves PTY chunk boundaries", () => {
     Terminal: new (options: Record<string, unknown>) => XTerm;
   };
   const term = new Terminal({ cols: 80, rows: 5, scrollback: 20, allowProposedApi: true });
+  const originalWrite = term.write.bind(term);
+  let writeCalls = 0;
+  term.write = ((data: string | Uint8Array, callback?: () => void) => {
+    writeCalls += 1;
+    return originalWrite(data, callback);
+  }) as XTerm["write"];
   const promptState = createPromptLineBreakState();
   promptState.lastPromptText = "$ ";
   promptState.pendingCommand = true;
@@ -640,6 +646,7 @@ test("hidden prompt formatting preserves PTY chunk boundaries", () => {
     assert.equal(term.buffer.active.getLine(0)?.translateToString(true), "foo");
     assert.equal(term.buffer.active.getLine(1)?.translateToString(true), "$");
     assert.equal(term.buffer.active.cursorX, 2);
+    assert.equal(writeCalls, 1);
   } finally {
     resetTerminalWriteCoalescer(term);
     term.dispose();

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -926,6 +926,8 @@ test("hidden prompt formatting respects cursor movement before a bare line feed"
     { convertEol: true, output: "foo\n", promptRow: 1 },
     { convertEol: false, output: "\x1b[10C\n", promptRow: 2 },
     { convertEol: false, output: "foo\x1b[1G\n", promptRow: 1 },
+    { convertEol: false, output: "你好\r\n", promptRow: 1 },
+    { convertEol: false, output: "你好\n", promptRow: 2 },
   ];
   for (const scenario of scenarios) {
     const term = new Terminal({

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -607,6 +607,42 @@ test("hiding a pane preserves the arrival second of already queued output", () =
   }
 });
 
+test("hiding the page preserves the arrival second of already queued output", () => {
+  const { term, writes } = createFakeTerm();
+  const ctx = {
+    ...createContext(true),
+    isVisibleRef: { current: true },
+    isPaneVisibleRef: { current: true },
+  };
+  const originalDateNow = Date.now;
+  let fakeNow = new Date(2026, 0, 1, 12, 0, 59, 800).getTime();
+  Date.now = () => fakeNow;
+
+  try {
+    withAnimationFrameQueue(() => {
+      withDocumentVisibility("visible", () => {
+        writeSessionData(ctx as never, term, "first\r\n");
+      });
+      assert.deepEqual(writes, []);
+
+      fakeNow = new Date(2026, 0, 1, 12, 1, 0, 20).getTime();
+      withDocumentVisibility("hidden", () => {
+        writeSessionData(ctx as never, term, "second\r\n");
+      });
+      flushPendingTerminalWritesOnResume(term);
+
+      assert.deepEqual(writes, ["first\r\n", "second\r\n"]);
+      assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
+        { row: 0, label: "12:00:59" },
+        { row: 1, label: "12:01:00" },
+      ]);
+    });
+  } finally {
+    Date.now = originalDateNow;
+    resetTerminalWriteCoalescer(term);
+  }
+});
+
 test("hidden prompt formatting preserves PTY chunk boundaries", () => {
   const require = createRequire(import.meta.url);
   const { Terminal } = require("@xterm/xterm") as {
@@ -640,11 +676,16 @@ test("hidden prompt formatting preserves PTY chunk boundaries", () => {
     withAnimationFrameQueue(() => {
       writeSessionData(ctx as never, term, "foo");
       writeSessionData(ctx as never, term, "$ ");
+      writeSessionData(ctx as never, term, "notice\r\n");
+      writeSessionData(ctx as never, term, "bar");
+      writeSessionData(ctx as never, term, "$ ");
       flushPendingTerminalWritesOnResume(term);
     });
 
     assert.equal(term.buffer.active.getLine(0)?.translateToString(true), "foo");
-    assert.equal(term.buffer.active.getLine(1)?.translateToString(true), "$");
+    assert.equal(term.buffer.active.getLine(1)?.translateToString(true), "$ notice");
+    assert.equal(term.buffer.active.getLine(2)?.translateToString(true), "bar");
+    assert.equal(term.buffer.active.getLine(3)?.translateToString(true), "$");
     assert.equal(term.buffer.active.cursorX, 2);
     assert.equal(writeCalls, 1);
   } finally {

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -90,6 +90,12 @@ const createFakeTerm = (activeType = "normal") => {
     },
     write(data: string, callback?: () => void) {
       writes.push(data);
+      if (data.includes("\x1b[?1049h") || data.includes("\x1b[?47h") || data.includes("\x1b[?1047h")) {
+        active.type = "alternate";
+      }
+      if (data.includes("\x1b[?1049l") || data.includes("\x1b[?47l") || data.includes("\x1b[?1047l")) {
+        active.type = "normal";
+      }
       for (const char of data) {
         if (char === "\n") {
           cursorLine += 1;
@@ -892,9 +898,9 @@ test("showing a pane preserves the background arrival second still queued with v
         "hidden\r\nvisible-same-second\r\n",
         "visible-next-second\r\n",
       ]);
+      // Per-second ledger: same-second lines share one stamp on the first line.
       assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
         { row: 0, label: "12:00:59" },
-        { row: 1, label: "12:00:59" },
         { row: 2, label: "12:01:00" },
       ]);
     });
@@ -1493,15 +1499,16 @@ test("writeSessionData records terminal output timestamps without changing outpu
 
   assert.equal(writes.join(""), "hello\r\nnext");
   assert.equal((writes.join("").match(/\[\d{2}:\d{2}:\d{2}\]/g) ?? []).length, 0);
-  assert.deepEqual(markerLines, [0, 1]);
+  // Record/render separation: ledger only, never xterm markers on write.
+  assert.deepEqual(markerLines, []);
 });
 
-test("writeSessionData skips timestamp markers when the host gutter is disabled", () => {
+test("writeSessionData never registers xterm markers for timestamps", () => {
   const { term, writes, markerLines } = createFakeTerm();
   writeSessionData(createContext(true, { showLineTimestamps: false }) as never, term, "hello\r\nnext");
+  writeSessionData(createContext(false, { showLineTimestamps: true }) as never, term, "more\r\n");
 
-  assert.equal(writes.join(""), "hello\r\nnext");
-  // Gutter off: per-second ledger only — no xterm markers.
+  assert.ok(writes.join("").includes("hello"));
   assert.deepEqual(markerLines, []);
 });
 
@@ -1510,7 +1517,8 @@ test("writeSessionData records timestamps for hosts with timestamps enabled", ()
   writeSessionData(createContext(false, { showLineTimestamps: true }) as never, term, "hello");
 
   assert.equal(writes.join(""), "hello");
-  assert.deepEqual(markerLines, [0]);
+  assert.deepEqual(markerLines, []);
+  assert.ok(getVisibleTerminalLineTimestampRows(term).length >= 1);
 });
 
 test("writeSessionData skips timestamps on the alternate screen", () => {
@@ -1534,7 +1542,8 @@ test("writeSessionData resumes timestamps after leaving alternate screen in the 
   writeSessionData(createContext(false, { showLineTimestamps: true }) as never, term, "\x1b[?1049lprompt");
 
   assert.equal(writes.join(""), "\x1b[?1049lprompt");
-  assert.deepEqual(markerLines, [0]);
+  assert.deepEqual(markerLines, []);
+  assert.ok(getVisibleTerminalLineTimestampRows(term).length >= 1);
 });
 
 test("writeSessionData inserts erase-scrollback immediately after normal full clear", () => {
@@ -1569,32 +1578,30 @@ test("writeSessionData does not add erase-scrollback inside synchronized output"
   assert.equal(writes.join(""), "\x1b[?2026h\x1b[H\x1b[2Jframe\x1b[?2026l");
 });
 
-test("writeSessionData uses markers only while the host gutter is enabled", () => {
+test("writeSessionData always uses ledger recording regardless of gutter toggle", () => {
   const { term, writes, markerLines } = createFakeTerm();
   const ctx = createContext(false, { showLineTimestamps: false });
 
   writeSessionData(ctx as never, term, "before\r\n");
-  assert.deepEqual(markerLines, [], "gutter off keeps a ledger without markers");
+  assert.deepEqual(markerLines, []);
 
   ctx.host = { showLineTimestamps: true };
   ctx.hostRef.current = ctx.host;
   writeSessionData(ctx as never, term, "enabled\r\n");
-  // Enable materializes ledger + records the new line.
-  assert.ok(markerLines.length >= 1, "gutter on creates markers");
+  assert.deepEqual(markerLines, [], "write path never registerMarkers");
 
-  const markersWhileOn = markerLines.length;
   ctx.host = { showLineTimestamps: false };
   ctx.hostRef.current = ctx.host;
   writeSessionData(ctx as never, term, "disabled");
 
   assert.equal(writes.join(""), "before\r\nenabled\r\ndisabled");
-  // Turning off clears live markers (dispose) and does not register new ones.
-  assert.equal(markerLines.length, markersWhileOn);
+  assert.deepEqual(markerLines, []);
+  // Ledger still has stamps for paint when gutter is shown.
+  assert.ok(getVisibleTerminalLineTimestampRows(term).length >= 1);
 });
 
 test("writeSessionData follows live hostRef toggles without replacing boot host snapshot", () => {
   const { term, writes, markerLines } = createFakeTerm();
-  // Frozen boot-time host object (what attachSessionToTerminal closes over).
   const bootHost = { showLineTimestamps: false as boolean };
   const hostRef = { current: bootHost };
   const ctx = {
@@ -1606,26 +1613,23 @@ test("writeSessionData follows live hostRef toggles without replacing boot host 
   writeSessionData(ctx as never, term, "boot-off\r\n");
   assert.deepEqual(markerLines, []);
 
-  // Toolbar toggle: live host updates via hostRef; boot snapshot stays false.
   hostRef.current = { showLineTimestamps: true };
   assert.equal(bootHost.showLineTimestamps, false);
   assert.equal(ctx.host.showLineTimestamps, false);
 
   writeSessionData(ctx as never, term, "live-on\r\n");
   assert.equal(writes.join(""), "boot-off\r\nlive-on\r\n");
-  assert.ok(markerLines.length >= 1, "live enable materializes/records markers");
+  assert.deepEqual(markerLines, []);
+  assert.ok(getVisibleTerminalLineTimestampRows(term).length >= 1);
 
-  const markersWhileOn = markerLines.length;
   hostRef.current = { showLineTimestamps: false };
   writeSessionData(ctx as never, term, "live-off");
   assert.equal(writes.join(""), "boot-off\r\nlive-on\r\nlive-off");
-  assert.equal(markerLines.length, markersWhileOn, "live disable does not register new markers");
+  assert.deepEqual(markerLines, []);
 });
 
 test("writeSessionData batches timestamp bookkeeping for bulk line output", () => {
   const { term, writes, markerLines } = createFakeTerm();
-  // Stay under large-output pressure so timestamp markers still record; bulk
-  // batching of markers is covered without degrading the flood fast-path.
   const payload = `${Array.from({ length: 40 }, () => "x".repeat(80)).join("\n")}\n`;
 
   writeSessionData(createContext(false, { showLineTimestamps: true }) as never, term, payload, payload.length);
@@ -1635,7 +1639,9 @@ test("writeSessionData batches timestamp bookkeeping for bulk line output", () =
   }
 
   assert.equal(writes.join(""), payload);
-  assert.equal(markerLines.length, 40);
+  // One wall-clock second → one ledger stamp, zero markers.
+  assert.deepEqual(markerLines, []);
+  assert.equal(getVisibleTerminalLineTimestampRows(term).length, 1);
   assert.ok(writes.length >= 1);
 });
 

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -18,6 +18,7 @@ import {
   tryAttachSessionToTerminal,
   writeSessionData,
 } from "./terminalSessionAttachment.ts";
+import { getVisibleTerminalLineTimestampRows } from "./terminalLineTimestamps.ts";
 
 import {
   clearTerminalSessionFlowAck,
@@ -53,8 +54,16 @@ const createFakeTerm = (activeType = "normal") => {
   const disposedMarkerLines: number[] = [];
   let cursorLine = 0;
   const term = {
+    rows: 24,
+    cols: 80,
+    options: { scrollback: 1000 },
     buffer: {
-      active: { type: activeType },
+      active: {
+        type: activeType,
+        viewportY: 0,
+        cursorX: 0,
+        getLine: () => ({ isWrapped: false }),
+      },
     },
     write(data: string, callback?: () => void) {
       writes.push(data);
@@ -504,6 +513,34 @@ test("frequent hidden log lines are drained in one complete terminal write", asy
   assert.equal(markerLines.length, chunks.length);
   assert.equal(getFlowController(ctx as never, term).pendingBytes(), 0);
   resetTerminalWriteCoalescer(term);
+});
+
+test("hidden output keeps its arrival second when a batch crosses a clock boundary", () => {
+  const { term, writes } = createFakeTerm();
+  const ctx = {
+    ...createContext(true),
+    isVisibleRef: { current: true },
+    isPaneVisibleRef: { current: false },
+  };
+  const originalDateNow = Date.now;
+  let fakeNow = new Date(2026, 0, 1, 12, 0, 59, 800).getTime();
+  Date.now = () => fakeNow;
+
+  try {
+    writeSessionData(ctx as never, term, "first\r\n");
+    fakeNow = new Date(2026, 0, 1, 12, 1, 0, 20).getTime();
+    writeSessionData(ctx as never, term, "second\r\n");
+    flushPendingTerminalWritesOnResume(term);
+
+    assert.deepEqual(writes, ["first\r\n", "second\r\n"]);
+    assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
+      { row: 0, label: "12:00:59" },
+      { row: 1, label: "12:01:00" },
+    ]);
+  } finally {
+    Date.now = originalDateNow;
+    resetTerminalWriteCoalescer(term);
+  }
 });
 
 test("writeSessionData keeps the current perf trace when hidden output is flushed", () => {
@@ -1152,6 +1189,54 @@ test("attachSessionToTerminal clears the backend id before reporting exit", () =
 
   assert.equal(sessionRef.current, null);
   assert.equal(sessionIdSeenByConsumer, null);
+});
+
+test("attachSessionToTerminal drains hidden final output before exit capture", () => {
+  const { term, writes } = createFakeTerm();
+  let onData: ((data: string) => void) | null = null;
+  let onExit: ((evt: { reason?: string }) => void) | null = null;
+  let captured = "";
+  const ctx = {
+    ...createContext(false),
+    sessionId: "session-1",
+    sessionRef: { current: null as string | null },
+    isVisibleRef: { current: true },
+    isPaneVisibleRef: { current: false },
+    hasConnectedRef: { current: true },
+    hasRunStartupCommandRef: { current: false },
+    disposeDataRef: { current: null },
+    disposeExitRef: { current: null },
+    fitAddonRef: { current: null },
+    serializeAddonRef: { current: { serialize: () => writes.join("") } },
+    pendingAuthRef: { current: null },
+    terminalBackend: {
+      onSessionData: (_id: string, callback: (data: string) => void) => {
+        onData = callback;
+        return () => {};
+      },
+      onSessionExit: (_id: string, callback: (evt: { reason?: string }) => void) => {
+        onExit = callback;
+        return () => {};
+      },
+    },
+    updateStatus: () => {},
+    setError: () => {},
+    onTerminalDataCapture: (_sessionId: string, data: string) => {
+      captured = data;
+    },
+    onSessionExit: () => {},
+  };
+
+  attachSessionToTerminal(ctx as never, term, "session-1");
+  onData?.("final output\r\n");
+  assert.deepEqual(writes, []);
+
+  onExit?.({ reason: "closed" });
+
+  const expected = "final output\r\n\r\n[session closed]\r\n";
+  assert.equal(writes.join(""), expected);
+  assert.equal(captured, expected);
+  resetTerminalWriteCoalescer(term);
 });
 
 test("attachSessionToTerminal keeps interrupt-time output visible", () => {

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -517,6 +517,77 @@ test("frequent hidden log lines are drained in one complete terminal write", asy
   resetTerminalWriteCoalescer(term);
 });
 
+test("large hidden bursts yield between terminal write slices", () => {
+  type FakeTimer = {
+    active: boolean;
+    callback: () => void;
+    delay: number;
+    unref: () => void;
+  };
+
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const timers: FakeTimer[] = [];
+  globalThis.setTimeout = ((callback: (...args: unknown[]) => void, delay = 0, ...args: unknown[]) => {
+    const timer: FakeTimer = {
+      active: true,
+      callback: () => callback(...args),
+      delay: Number(delay),
+      unref() {},
+    };
+    timers.push(timer);
+    return timer as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+  globalThis.clearTimeout = ((timer: FakeTimer | undefined) => {
+    if (timer) timer.active = false;
+  }) as unknown as typeof clearTimeout;
+
+  const { term, writes } = createFakeTerm();
+  const ctx = {
+    ...createContext(false),
+    isVisibleRef: { current: true },
+    isPaneVisibleRef: { current: false },
+  };
+  const chunks = Array.from({ length: 96 }, () => "x".repeat(4096));
+  const payload = chunks.join("");
+
+  try {
+    for (const chunk of chunks) {
+      writeSessionData(ctx as never, term, chunk);
+    }
+    assert.deepEqual(writes, []);
+
+    const hiddenDrain = timers.find((timer) => timer.active && timer.delay === 160);
+    assert.ok(hiddenDrain);
+    hiddenDrain.active = false;
+    hiddenDrain.callback();
+
+    assert.deepEqual(writes, []);
+    const firstQueueDrain = timers.find((timer) => timer.active && timer.delay === 0);
+    assert.ok(firstQueueDrain);
+    firstQueueDrain.active = false;
+    firstQueueDrain.callback();
+
+    assert.equal(writes.length, 1);
+    assert.ok(writes[0]!.length <= MAX_TERMINAL_PLAIN_WRITE_CHUNK_BYTES);
+    assert.ok(writes.join("").length < payload.length);
+    assert.ok(timers.some((timer) => timer.active && timer.delay === 0));
+
+    flushPendingTerminalWritesOnResume(term);
+    assert.equal(writes.join(""), payload);
+
+    const followupDrain = timers.find((timer) => timer.active && timer.delay === 160);
+    if (followupDrain) {
+      followupDrain.active = false;
+      followupDrain.callback();
+    }
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+    resetTerminalWriteCoalescer(term);
+  }
+});
+
 test("hidden output keeps its arrival second when a batch crosses a clock boundary", () => {
   const { term, writes } = createFakeTerm();
   const ctx = {
@@ -838,43 +909,54 @@ test("hidden prompt formatting preserves PTY chunk boundaries", () => {
   }
 });
 
-test("hidden prompt formatting resets the column after a bare line feed", () => {
+test("hidden prompt formatting respects xterm newline mode after a bare line feed", () => {
   const require = createRequire(import.meta.url);
   const { Terminal } = require("@xterm/xterm") as {
     Terminal: new (options: Record<string, unknown>) => XTerm;
   };
-  const term = new Terminal({ cols: 80, rows: 5, scrollback: 20, allowProposedApi: true });
-  const promptState = createPromptLineBreakState();
-  promptState.lastPromptText = "$ ";
-  promptState.pendingCommand = true;
-  const settings = {
-    showLineTimestamps: false,
-    scrollOnOutput: false,
-    forcePromptNewLine: true,
-  };
-  const ctx = {
-    ...createContext(false),
-    terminalSettingsRef: { current: settings },
-    terminalSettings: settings,
-    promptLineBreakStateRef: { current: promptState },
-    isVisibleRef: { current: true },
-    isPaneVisibleRef: { current: false },
-  };
-
-  try {
-    withAnimationFrameQueue(() => {
-      writeSessionData(ctx as never, term, "foo\n");
-      writeSessionData(ctx as never, term, "$ ");
-      flushPendingTerminalWritesOnResume(term);
+  for (const convertEol of [false, true]) {
+    const term = new Terminal({
+      cols: 80,
+      rows: 5,
+      scrollback: 20,
+      allowProposedApi: true,
+      convertEol,
     });
+    const promptState = createPromptLineBreakState();
+    promptState.lastPromptText = "$ ";
+    promptState.pendingCommand = true;
+    const settings = {
+      showLineTimestamps: false,
+      scrollOnOutput: false,
+      forcePromptNewLine: true,
+    };
+    const ctx = {
+      ...createContext(false),
+      terminalSettingsRef: { current: settings },
+      terminalSettings: settings,
+      promptLineBreakStateRef: { current: promptState },
+      isVisibleRef: { current: true },
+      isPaneVisibleRef: { current: false },
+    };
 
-    assert.equal(term.buffer.active.getLine(0)?.translateToString(true), "foo");
-    assert.equal(term.buffer.active.getLine(1)?.translateToString(true), "");
-    assert.equal(term.buffer.active.getLine(2)?.translateToString(true), "$");
-    assert.equal(term.buffer.active.cursorX, 2);
-  } finally {
-    resetTerminalWriteCoalescer(term);
-    term.dispose();
+    try {
+      withAnimationFrameQueue(() => {
+        writeSessionData(ctx as never, term, "foo\n");
+        writeSessionData(ctx as never, term, "$ ");
+        flushPendingTerminalWritesOnResume(term);
+      });
+
+      const promptRow = convertEol ? 1 : 2;
+      assert.equal(term.buffer.active.getLine(0)?.translateToString(true), "foo");
+      if (!convertEol) {
+        assert.equal(term.buffer.active.getLine(1)?.translateToString(true), "");
+      }
+      assert.equal(term.buffer.active.getLine(promptRow)?.translateToString(true), "$");
+      assert.equal(term.buffer.active.cursorX, 2);
+    } finally {
+      resetTerminalWriteCoalescer(term);
+      term.dispose();
+    }
   }
 });
 

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -609,6 +609,41 @@ test("visible alternate-screen output stays frame-batched across a clock boundar
   }
 });
 
+test("normal output before an alternate-screen frame keeps its earlier timestamp", () => {
+  const { term, writes } = createFakeTerm();
+  const ctx = {
+    ...createContext(true),
+    isVisibleRef: { current: true },
+    isPaneVisibleRef: { current: true },
+  };
+  const originalDateNow = Date.now;
+  let fakeNow = new Date(2026, 0, 1, 12, 0, 59, 800).getTime();
+  Date.now = () => fakeNow;
+
+  try {
+    withAnimationFrameQueue((schedule) => {
+      writeSessionData(ctx as never, term, "before\r\n\x1b[?1049hframe-a");
+      assert.deepEqual(writes, ["before\r\n"]);
+
+      fakeNow = new Date(2026, 0, 1, 12, 1, 0, 20).getTime();
+      writeSessionData(ctx as never, term, "frame-b\x1b[?1049lafter");
+      schedule.flushScheduled();
+
+      assert.equal(
+        writes.join(""),
+        "before\r\n\x1b[?1049hframe-aframe-b\x1b[?1049lafter",
+      );
+      assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
+        { row: 0, label: "12:00:59" },
+        { row: 1, label: "12:01:00" },
+      ]);
+    });
+  } finally {
+    Date.now = originalDateNow;
+    resetTerminalWriteCoalescer(term);
+  }
+});
+
 test("hiding a pane preserves the arrival second of already queued output", () => {
   const { term, writes } = createFakeTerm();
   const ctx = {

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -97,26 +97,31 @@ const createFakeTerm = (activeType = "normal") => {
   return { term, writes, markerLines, disposedMarkerLines };
 };
 
-const createContext = (showLineTimestamps: boolean, host: Record<string, unknown> = {}) => ({
+const createContext = (showLineTimestamps: boolean, host: Record<string, unknown> = {}) => {
   // Production gates markers on host.showLineTimestamps; keep the first arg as
   // the host default unless the test overrides host explicitly.
-  host: { showLineTimestamps, ...host },
-  terminalSettingsRef: {
-    current: {
+  const liveHost = { showLineTimestamps, ...host };
+  return {
+    host: liveHost,
+    // Mirror Terminal.tsx: write path reads hostRef.current for live toggles.
+    hostRef: { current: liveHost },
+    terminalSettingsRef: {
+      current: {
+        showLineTimestamps,
+        scrollOnOutput: false,
+        forcePromptNewLine: false,
+      },
+    },
+    terminalSettings: {
       showLineTimestamps,
       scrollOnOutput: false,
       forcePromptNewLine: false,
     },
-  },
-  terminalSettings: {
-    showLineTimestamps,
-    scrollOnOutput: false,
-    forcePromptNewLine: false,
-  },
-  terminalBackend: {},
-  sessionRef: { current: "session-1" },
-  promptLineBreakStateRef: { current: undefined },
-});
+    terminalBackend: {},
+    sessionRef: { current: "session-1" },
+    promptLineBreakStateRef: { current: undefined },
+  };
+};
 
 test("terminal output publishes one completion for each pending command at the next prompt", () => {
   const { term } = createFakeTerm();
@@ -1551,14 +1556,46 @@ test("writeSessionData only records timestamps while the host gutter is enabled"
 
   writeSessionData(ctx as never, term, "before\r\n");
   ctx.host = { showLineTimestamps: true };
+  ctx.hostRef.current = ctx.host;
   writeSessionData(ctx as never, term, "enabled\r\n");
   ctx.host = { showLineTimestamps: false };
+  ctx.hostRef.current = ctx.host;
   writeSessionData(ctx as never, term, "disabled");
 
   assert.equal(writes.join(""), "before\r\nenabled\r\ndisabled");
   // Only the enabled window records markers; earlier/later disabled writes do not.
   assert.deepEqual(markerLines, [1]);
   assert.deepEqual(disposedMarkerLines, []);
+});
+
+test("writeSessionData follows live hostRef toggles without replacing boot host snapshot", () => {
+  const { term, writes, markerLines } = createFakeTerm();
+  // Frozen boot-time host object (what attachSessionToTerminal closes over).
+  const bootHost = { showLineTimestamps: false as boolean };
+  const hostRef = { current: bootHost };
+  const ctx = {
+    ...createContext(false),
+    host: bootHost,
+    hostRef,
+  };
+
+  writeSessionData(ctx as never, term, "boot-off\r\n");
+  assert.deepEqual(markerLines, []);
+
+  // Toolbar toggle: live host updates via hostRef; boot snapshot stays false.
+  hostRef.current = { showLineTimestamps: true };
+  assert.equal(bootHost.showLineTimestamps, false);
+  assert.equal(ctx.host.showLineTimestamps, false);
+
+  writeSessionData(ctx as never, term, "live-on\r\n");
+  assert.equal(writes.join(""), "boot-off\r\nlive-on\r\n");
+  assert.deepEqual(markerLines, [1]);
+
+  hostRef.current = { showLineTimestamps: false };
+  writeSessionData(ctx as never, term, "live-off");
+  assert.equal(writes.join(""), "boot-off\r\nlive-on\r\nlive-off");
+  // No new markers while live-disabled.
+  assert.deepEqual(markerLines, [1]);
 });
 
 test("writeSessionData batches timestamp bookkeeping for bulk line output", () => {

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -57,17 +57,36 @@ const createFakeTerm = (activeType = "normal") => {
   const markerLines: number[] = [];
   const disposedMarkerLines: number[] = [];
   let cursorLine = 0;
+  const active: {
+    type: string;
+    viewportY: number;
+    cursorX: number;
+    baseY: number;
+    cursorY: number;
+    length: number;
+    getLine: () => { isWrapped: boolean };
+  } = {
+    type: activeType,
+    viewportY: 0,
+    cursorX: 0,
+    baseY: 0,
+    get cursorY() {
+      return cursorLine;
+    },
+    set cursorY(value: number) {
+      cursorLine = Math.max(0, value);
+    },
+    get length() {
+      return cursorLine + 1;
+    },
+    getLine: () => ({ isWrapped: false }),
+  };
   const term = {
     rows: 24,
     cols: 80,
     options: { scrollback: 1000 },
     buffer: {
-      active: {
-        type: activeType,
-        viewportY: 0,
-        cursorX: 0,
-        getLine: () => ({ isWrapped: false }),
-      },
+      active,
     },
     write(data: string, callback?: () => void) {
       writes.push(data);
@@ -1482,7 +1501,7 @@ test("writeSessionData skips timestamp markers when the host gutter is disabled"
   writeSessionData(createContext(true, { showLineTimestamps: false }) as never, term, "hello\r\nnext");
 
   assert.equal(writes.join(""), "hello\r\nnext");
-  // Disabled gutters no longer pay segmenter/marker cost on the hot path.
+  // Gutter off: per-second ledger only — no xterm markers.
   assert.deepEqual(markerLines, []);
 });
 
@@ -1550,22 +1569,27 @@ test("writeSessionData does not add erase-scrollback inside synchronized output"
   assert.equal(writes.join(""), "\x1b[?2026h\x1b[H\x1b[2Jframe\x1b[?2026l");
 });
 
-test("writeSessionData only records timestamps while the host gutter is enabled", () => {
-  const { term, writes, markerLines, disposedMarkerLines } = createFakeTerm();
+test("writeSessionData uses markers only while the host gutter is enabled", () => {
+  const { term, writes, markerLines } = createFakeTerm();
   const ctx = createContext(false, { showLineTimestamps: false });
 
   writeSessionData(ctx as never, term, "before\r\n");
+  assert.deepEqual(markerLines, [], "gutter off keeps a ledger without markers");
+
   ctx.host = { showLineTimestamps: true };
   ctx.hostRef.current = ctx.host;
   writeSessionData(ctx as never, term, "enabled\r\n");
+  // Enable materializes ledger + records the new line.
+  assert.ok(markerLines.length >= 1, "gutter on creates markers");
+
+  const markersWhileOn = markerLines.length;
   ctx.host = { showLineTimestamps: false };
   ctx.hostRef.current = ctx.host;
   writeSessionData(ctx as never, term, "disabled");
 
   assert.equal(writes.join(""), "before\r\nenabled\r\ndisabled");
-  // Only the enabled window records markers; earlier/later disabled writes do not.
-  assert.deepEqual(markerLines, [1]);
-  assert.deepEqual(disposedMarkerLines, []);
+  // Turning off clears live markers (dispose) and does not register new ones.
+  assert.equal(markerLines.length, markersWhileOn);
 });
 
 test("writeSessionData follows live hostRef toggles without replacing boot host snapshot", () => {
@@ -1589,13 +1613,13 @@ test("writeSessionData follows live hostRef toggles without replacing boot host 
 
   writeSessionData(ctx as never, term, "live-on\r\n");
   assert.equal(writes.join(""), "boot-off\r\nlive-on\r\n");
-  assert.deepEqual(markerLines, [1]);
+  assert.ok(markerLines.length >= 1, "live enable materializes/records markers");
 
+  const markersWhileOn = markerLines.length;
   hostRef.current = { showLineTimestamps: false };
   writeSessionData(ctx as never, term, "live-off");
   assert.equal(writes.join(""), "boot-off\r\nlive-on\r\nlive-off");
-  // No new markers while live-disabled.
-  assert.deepEqual(markerLines, [1]);
+  assert.equal(markerLines.length, markersWhileOn, "live disable does not register new markers");
 });
 
 test("writeSessionData batches timestamp bookkeeping for bulk line output", () => {

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -527,6 +527,7 @@ test("large hidden bursts yield between terminal write slices", () => {
 
   const originalSetTimeout = globalThis.setTimeout;
   const originalClearTimeout = globalThis.clearTimeout;
+  const originalDateNow = Date.now;
   const timers: FakeTimer[] = [];
   globalThis.setTimeout = ((callback: (...args: unknown[]) => void, delay = 0, ...args: unknown[]) => {
     const timer: FakeTimer = {
@@ -549,12 +550,17 @@ test("large hidden bursts yield between terminal write slices", () => {
     isPaneVisibleRef: { current: false },
   };
   const chunks = Array.from({ length: 96 }, () => "x".repeat(4096));
-  const payload = chunks.join("");
+  const nextSecondChunk = "y";
+  const payload = `${chunks.join("")}${nextSecondChunk}`;
+  let fakeNow = new Date(2026, 0, 1, 12, 0, 59, 800).getTime();
+  Date.now = () => fakeNow;
 
   try {
     for (const chunk of chunks) {
       writeSessionData(ctx as never, term, chunk);
     }
+    fakeNow += 1_000;
+    writeSessionData(ctx as never, term, nextSecondChunk);
     assert.deepEqual(writes, []);
 
     const hiddenDrain = timers.find((timer) => timer.active && timer.delay === 160);
@@ -582,6 +588,7 @@ test("large hidden bursts yield between terminal write slices", () => {
       followupDrain.callback();
     }
   } finally {
+    Date.now = originalDateNow;
     globalThis.setTimeout = originalSetTimeout;
     globalThis.clearTimeout = originalClearTimeout;
     resetTerminalWriteCoalescer(term);

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -430,7 +430,7 @@ test("writeSessionData flushes pending coalesced output with the background fast
   clearTerminalSessionFlowAck("session-1");
 });
 
-test("hidden tab output is written completely while the tab remains hidden", () => {
+test("hidden tab output is written completely while the tab remains hidden", async () => {
   clearTerminalSessionFlowAck("session-1");
   const lines: string[] = [];
   let payloadLength = 0;
@@ -467,12 +467,43 @@ test("hidden tab output is written completely while the tab remains hidden", () 
   withAnimationFrameQueue(() => {
     writeSessionData(ctx as never, term, payload);
   });
+  assert.deepEqual(writes, []);
+
+  await new Promise((resolve) => { setTimeout(resolve, 190); });
   flushTerminalSessionFlowAck("session-1");
 
   assert.equal(writes.join(""), payload);
   assert.equal(getFlowController(ctx as never, term).pendingBytes(), 0);
   assert.equal(acked.reduce((total, bytes) => total + bytes, 0), payload.length);
   clearTerminalSessionFlowAck("session-1");
+});
+
+test("frequent hidden log lines are drained in one complete terminal write", async () => {
+  const { term, writes, markerLines } = createFakeTerm();
+  const ctx = {
+    ...createContext(false),
+    // The renderer stays active when hidden-tab hibernation is disabled, but
+    // the pane itself is not visible. This is the normal multi-tab runtime.
+    isVisibleRef: { current: true },
+    isPaneVisibleRef: { current: false },
+  };
+  const chunks = Array.from(
+    { length: 8 },
+    (_, index) => `line-${String(index + 1).padStart(2, "0")}\r\n`,
+  );
+
+  for (const chunk of chunks) {
+    writeSessionData(ctx as never, term, chunk);
+  }
+
+  assert.deepEqual(writes, []);
+
+  await new Promise((resolve) => { setTimeout(resolve, 190); });
+
+  assert.deepEqual(writes, [chunks.join("")]);
+  assert.equal(markerLines.length, chunks.length);
+  assert.equal(getFlowController(ctx as never, term).pendingBytes(), 0);
+  resetTerminalWriteCoalescer(term);
 });
 
 test("writeSessionData keeps the current perf trace when hidden output is flushed", () => {
@@ -562,7 +593,7 @@ test("writeSessionData drains output after the pane hides before the scheduled f
   clearTerminalSessionFlowAck("session-1");
 });
 
-test("writeSessionData drains hidden pane output without waiting for reveal", () => {
+test("writeSessionData drains hidden pane output without waiting for reveal", async () => {
   clearTerminalSessionFlowAck("session-1");
   const payload = "x".repeat(XTERM_WRITE_CALLBACK_FAST_PATH_MAX_BYTES + 1);
   const writes: string[] = [];
@@ -587,6 +618,9 @@ test("writeSessionData drains hidden pane output without waiting for reveal", ()
   };
 
   writeSessionData(ctx as never, term, payload);
+  assert.deepEqual(writes, []);
+
+  await new Promise((resolve) => { setTimeout(resolve, 190); });
   flushTerminalSessionFlowAck("session-1");
 
   assert.equal(writes.join(""), payload);
@@ -645,7 +679,7 @@ test("writeSessionData keeps the hidden flush gate after coalescer reset and flu
   clearTerminalSessionFlowAck("session-1");
 });
 
-test("hidden tab output marks pending scroll without scrolling immediately", () => {
+test("hidden tab output marks pending scroll without scrolling immediately", async () => {
   const writes: string[] = [];
   let scrollCalls = 0;
   const term = {
@@ -678,6 +712,10 @@ test("hidden tab output marks pending scroll without scrolling immediately", () 
   };
 
   writeSessionData(ctx as never, term, "fresh output");
+
+  assert.equal(writes.join(""), "");
+  assert.equal(ctx.pendingOutputScrollRef.current, false);
+  await new Promise((resolve) => { setTimeout(resolve, 190); });
 
   assert.equal(writes.join(""), "fresh output");
   assert.equal(ctx.pendingOutputScrollRef.current, true);

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -98,7 +98,9 @@ const createFakeTerm = (activeType = "normal") => {
 };
 
 const createContext = (showLineTimestamps: boolean, host: Record<string, unknown> = {}) => ({
-  host,
+  // Production gates markers on host.showLineTimestamps; keep the first arg as
+  // the host default unless the test overrides host explicitly.
+  host: { showLineTimestamps, ...host },
   terminalSettingsRef: {
     current: {
       showLineTimestamps,
@@ -524,7 +526,8 @@ test("frequent hidden log lines are drained in one complete terminal write", asy
   await new Promise((resolve) => { setTimeout(resolve, 190); });
 
   assert.deepEqual(writes, [chunks.join("")]);
-  assert.equal(markerLines.length, chunks.length);
+  // Host timestamps off: drain still completes without marker work.
+  assert.equal(markerLines.length, 0);
   assert.equal(getFlowController(ctx as never, term).pendingBytes(), 0);
   resetTerminalWriteCoalescer(term);
 });
@@ -1469,12 +1472,13 @@ test("writeSessionData records terminal output timestamps without changing outpu
   assert.deepEqual(markerLines, [0, 1]);
 });
 
-test("writeSessionData keeps timestamp metadata when the host gutter is disabled", () => {
+test("writeSessionData skips timestamp markers when the host gutter is disabled", () => {
   const { term, writes, markerLines } = createFakeTerm();
-  writeSessionData(createContext(true, { showLineTimestamps: false }) as never, term, "hello");
+  writeSessionData(createContext(true, { showLineTimestamps: false }) as never, term, "hello\r\nnext");
 
-  assert.deepEqual(writes, ["hello"]);
-  assert.deepEqual(markerLines, [0]);
+  assert.equal(writes.join(""), "hello\r\nnext");
+  // Disabled gutters no longer pay segmenter/marker cost on the hot path.
+  assert.deepEqual(markerLines, []);
 });
 
 test("writeSessionData records timestamps for hosts with timestamps enabled", () => {
@@ -1541,7 +1545,7 @@ test("writeSessionData does not add erase-scrollback inside synchronized output"
   assert.equal(writes.join(""), "\x1b[?2026h\x1b[H\x1b[2Jframe\x1b[?2026l");
 });
 
-test("writeSessionData preserves timestamps across host gutter visibility changes", () => {
+test("writeSessionData only records timestamps while the host gutter is enabled", () => {
   const { term, writes, markerLines, disposedMarkerLines } = createFakeTerm();
   const ctx = createContext(false, { showLineTimestamps: false });
 
@@ -1552,7 +1556,8 @@ test("writeSessionData preserves timestamps across host gutter visibility change
   writeSessionData(ctx as never, term, "disabled");
 
   assert.equal(writes.join(""), "before\r\nenabled\r\ndisabled");
-  assert.deepEqual(markerLines, [0, 1, 2]);
+  // Only the enabled window records markers; earlier/later disabled writes do not.
+  assert.deepEqual(markerLines, [1]);
   assert.deepEqual(disposedMarkerLines, []);
 });
 
@@ -1562,7 +1567,7 @@ test("writeSessionData batches timestamp bookkeeping for bulk line output", () =
   // batching of markers is covered without degrading the flood fast-path.
   const payload = `${Array.from({ length: 40 }, () => "x".repeat(80)).join("\n")}\n`;
 
-  writeSessionData(createContext(false, { showLineTimestamps: false }) as never, term, payload, payload.length);
+  writeSessionData(createContext(false, { showLineTimestamps: true }) as never, term, payload, payload.length);
   flushTerminalWriteCoalescer(term);
   for (let guard = 0; guard < 1000 && flushTerminalWriteQueueBypassingTimers(term); guard += 1) {
     // Drain cooperative bulk-output timers so the assertion observes the full write plan.

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -661,6 +661,7 @@ test("hidden output keeps its arrival second when a batch crosses a clock bounda
     assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
       { row: 0, label: "12:00:59" },
       { row: 1, label: "12:01:00" },
+      { row: 2, label: "12:01:00" },
     ]);
   } finally {
     Date.now = originalDateNow;
@@ -694,6 +695,7 @@ test("visible pressure-batched output keeps its arrival second across a clock bo
       assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
         { row: 0, label: "12:00:59" },
         { row: 1, label: "12:01:00" },
+        { row: 2, label: "12:01:00" },
       ]);
     });
   } finally {
@@ -756,6 +758,7 @@ test("normal output before an alternate-screen frame keeps its earlier timestamp
         writes.join(""),
         "before\r\n\x1b[?1049hframe-aframe-b\x1b[?1049lafter",
       );
+      // before @ :59; after leave alt "after" @ :00 (same buffer line count).
       assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
         { row: 0, label: "12:00:59" },
         { row: 1, label: "12:01:00" },
@@ -797,6 +800,7 @@ test("normal output after an alternate-screen frame keeps its earlier timestamp"
     assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
       { row: 0, label: "12:00:59" },
       { row: 1, label: "12:01:00" },
+      { row: 2, label: "12:01:00" },
     ]);
   } finally {
     Date.now = originalDateNow;
@@ -829,6 +833,7 @@ test("hiding a pane preserves the arrival second of already queued output", () =
       assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
         { row: 0, label: "12:00:59" },
         { row: 1, label: "12:01:00" },
+        { row: 2, label: "12:01:00" },
       ]);
     });
   } finally {
@@ -865,6 +870,7 @@ test("hiding the page preserves the arrival second of already queued output", ()
       assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
         { row: 0, label: "12:00:59" },
         { row: 1, label: "12:01:00" },
+        { row: 2, label: "12:01:00" },
       ]);
     });
   } finally {
@@ -898,10 +904,12 @@ test("showing a pane preserves the background arrival second still queued with v
         "hidden\r\nvisible-same-second\r\n",
         "visible-next-second\r\n",
       ]);
-      // Per-second ledger: same-second lines share one stamp on the first line.
+      // Per-second ledger + fill-forward paint (incl. trailing empty cursor line).
       assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
         { row: 0, label: "12:00:59" },
+        { row: 1, label: "12:00:59" },
         { row: 2, label: "12:01:00" },
+        { row: 3, label: "12:01:00" },
       ]);
     });
   } finally {
@@ -1639,9 +1647,11 @@ test("writeSessionData batches timestamp bookkeeping for bulk line output", () =
   }
 
   assert.equal(writes.join(""), payload);
-  // One wall-clock second → one ledger stamp, zero markers.
+  // One wall-clock second → one ledger stamp; paint fills every viewport row.
   assert.deepEqual(markerLines, []);
-  assert.equal(getVisibleTerminalLineTimestampRows(term).length, 1);
+  const painted = getVisibleTerminalLineTimestampRows(term);
+  assert.ok(painted.length >= 1);
+  assert.ok(painted.every((row) => row.label.length > 0));
   assert.ok(writes.length >= 1);
 });
 

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -658,10 +658,10 @@ test("hidden output keeps its arrival second when a batch crosses a clock bounda
     flushPendingTerminalWritesOnResume(term);
 
     assert.deepEqual(writes, ["first\r\n", "second\r\n"]);
+    // Paint only through real content lines (not the empty cursor row after \n).
     assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
       { row: 0, label: "12:00:59" },
       { row: 1, label: "12:01:00" },
-      { row: 2, label: "12:01:00" },
     ]);
   } finally {
     Date.now = originalDateNow;
@@ -695,7 +695,6 @@ test("visible pressure-batched output keeps its arrival second across a clock bo
       assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
         { row: 0, label: "12:00:59" },
         { row: 1, label: "12:01:00" },
-        { row: 2, label: "12:01:00" },
       ]);
     });
   } finally {
@@ -800,7 +799,6 @@ test("normal output after an alternate-screen frame keeps its earlier timestamp"
     assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
       { row: 0, label: "12:00:59" },
       { row: 1, label: "12:01:00" },
-      { row: 2, label: "12:01:00" },
     ]);
   } finally {
     Date.now = originalDateNow;
@@ -833,7 +831,6 @@ test("hiding a pane preserves the arrival second of already queued output", () =
       assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
         { row: 0, label: "12:00:59" },
         { row: 1, label: "12:01:00" },
-        { row: 2, label: "12:01:00" },
       ]);
     });
   } finally {
@@ -870,7 +867,6 @@ test("hiding the page preserves the arrival second of already queued output", ()
       assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
         { row: 0, label: "12:00:59" },
         { row: 1, label: "12:01:00" },
-        { row: 2, label: "12:01:00" },
       ]);
     });
   } finally {
@@ -904,12 +900,11 @@ test("showing a pane preserves the background arrival second still queued with v
         "hidden\r\nvisible-same-second\r\n",
         "visible-next-second\r\n",
       ]);
-      // Per-second ledger + fill-forward paint (incl. trailing empty cursor line).
+      // Per-second ledger + fill-forward through content only (no empty cursor row).
       assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
         { row: 0, label: "12:00:59" },
         { row: 1, label: "12:00:59" },
         { row: 2, label: "12:01:00" },
-        { row: 3, label: "12:01:00" },
       ]);
     });
   } finally {

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -916,18 +916,24 @@ test("hidden prompt formatting preserves PTY chunk boundaries", () => {
   }
 });
 
-test("hidden prompt formatting respects xterm newline mode after a bare line feed", () => {
+test("hidden prompt formatting respects cursor movement before a bare line feed", () => {
   const require = createRequire(import.meta.url);
   const { Terminal } = require("@xterm/xterm") as {
     Terminal: new (options: Record<string, unknown>) => XTerm;
   };
-  for (const convertEol of [false, true]) {
+  const scenarios = [
+    { convertEol: false, output: "foo\n", promptRow: 2 },
+    { convertEol: true, output: "foo\n", promptRow: 1 },
+    { convertEol: false, output: "\x1b[10C\n", promptRow: 2 },
+    { convertEol: false, output: "foo\x1b[1G\n", promptRow: 1 },
+  ];
+  for (const scenario of scenarios) {
     const term = new Terminal({
       cols: 80,
       rows: 5,
       scrollback: 20,
       allowProposedApi: true,
-      convertEol,
+      convertEol: scenario.convertEol,
     });
     const promptState = createPromptLineBreakState();
     promptState.lastPromptText = "$ ";
@@ -948,17 +954,12 @@ test("hidden prompt formatting respects xterm newline mode after a bare line fee
 
     try {
       withAnimationFrameQueue(() => {
-        writeSessionData(ctx as never, term, "foo\n");
+        writeSessionData(ctx as never, term, scenario.output);
         writeSessionData(ctx as never, term, "$ ");
         flushPendingTerminalWritesOnResume(term);
       });
 
-      const promptRow = convertEol ? 1 : 2;
-      assert.equal(term.buffer.active.getLine(0)?.translateToString(true), "foo");
-      if (!convertEol) {
-        assert.equal(term.buffer.active.getLine(1)?.translateToString(true), "");
-      }
-      assert.equal(term.buffer.active.getLine(promptRow)?.translateToString(true), "$");
+      assert.equal(term.buffer.active.getLine(scenario.promptRow)?.translateToString(true), "$");
       assert.equal(term.buffer.active.cursorX, 2);
     } finally {
       resetTerminalWriteCoalescer(term);

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 import type { Terminal as XTerm } from "@xterm/xterm";
 
 import {
@@ -570,6 +571,78 @@ test("visible alternate-screen output stays frame-batched across a clock boundar
   } finally {
     Date.now = originalDateNow;
     resetTerminalWriteCoalescer(term);
+  }
+});
+
+test("hiding a pane preserves the arrival second of already queued output", () => {
+  const { term, writes } = createFakeTerm();
+  const ctx = {
+    ...createContext(true),
+    isVisibleRef: { current: true },
+    isPaneVisibleRef: { current: true },
+  };
+  const originalDateNow = Date.now;
+  let fakeNow = new Date(2026, 0, 1, 12, 0, 59, 800).getTime();
+  Date.now = () => fakeNow;
+
+  try {
+    withAnimationFrameQueue(() => {
+      writeSessionData(ctx as never, term, "first\r\n");
+      assert.deepEqual(writes, []);
+
+      ctx.isPaneVisibleRef.current = false;
+      fakeNow = new Date(2026, 0, 1, 12, 1, 0, 20).getTime();
+      writeSessionData(ctx as never, term, "second\r\n");
+      flushPendingTerminalWritesOnResume(term);
+
+      assert.deepEqual(writes, ["first\r\n", "second\r\n"]);
+      assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
+        { row: 0, label: "12:00:59" },
+        { row: 1, label: "12:01:00" },
+      ]);
+    });
+  } finally {
+    Date.now = originalDateNow;
+    resetTerminalWriteCoalescer(term);
+  }
+});
+
+test("hidden prompt formatting preserves PTY chunk boundaries", () => {
+  const require = createRequire(import.meta.url);
+  const { Terminal } = require("@xterm/xterm") as {
+    Terminal: new (options: Record<string, unknown>) => XTerm;
+  };
+  const term = new Terminal({ cols: 80, rows: 5, scrollback: 20, allowProposedApi: true });
+  const promptState = createPromptLineBreakState();
+  promptState.lastPromptText = "$ ";
+  promptState.pendingCommand = true;
+  const settings = {
+    showLineTimestamps: false,
+    scrollOnOutput: false,
+    forcePromptNewLine: true,
+  };
+  const ctx = {
+    ...createContext(false),
+    terminalSettingsRef: { current: settings },
+    terminalSettings: settings,
+    promptLineBreakStateRef: { current: promptState },
+    isVisibleRef: { current: true },
+    isPaneVisibleRef: { current: false },
+  };
+
+  try {
+    withAnimationFrameQueue(() => {
+      writeSessionData(ctx as never, term, "foo");
+      writeSessionData(ctx as never, term, "$ ");
+      flushPendingTerminalWritesOnResume(term);
+    });
+
+    assert.equal(term.buffer.active.getLine(0)?.translateToString(true), "foo");
+    assert.equal(term.buffer.active.getLine(1)?.translateToString(true), "$");
+    assert.equal(term.buffer.active.cursorX, 2);
+  } finally {
+    resetTerminalWriteCoalescer(term);
+    term.dispose();
   }
 });
 

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -20,6 +20,7 @@ import {
   writeSessionData,
 } from "./terminalSessionAttachment.ts";
 import { getVisibleTerminalLineTimestampRows } from "./terminalLineTimestamps.ts";
+import { noteTerminalOutputPressureData } from "./terminalOutputPressure.ts";
 
 import {
   clearTerminalSessionFlowAck,
@@ -538,6 +539,40 @@ test("hidden output keeps its arrival second when a batch crosses a clock bounda
       { row: 0, label: "12:00:59" },
       { row: 1, label: "12:01:00" },
     ]);
+  } finally {
+    Date.now = originalDateNow;
+    resetTerminalWriteCoalescer(term);
+  }
+});
+
+test("visible pressure-batched output keeps its arrival second across a clock boundary", () => {
+  const { term, writes } = createFakeTerm();
+  const ctx = {
+    ...createContext(true),
+    isVisibleRef: { current: true },
+    isPaneVisibleRef: { current: true },
+  };
+  const originalDateNow = Date.now;
+  let fakeNow = new Date(2026, 0, 1, 12, 0, 59, 800).getTime();
+  Date.now = () => fakeNow;
+
+  try {
+    withAnimationFrameQueue((schedule) => {
+      noteTerminalOutputPressureData(term, "x".repeat(20_000));
+      writeSessionData(ctx as never, term, "first\r\n");
+      assert.ok(schedule.scheduledCount() >= 1);
+      assert.deepEqual(writes, []);
+
+      fakeNow = new Date(2026, 0, 1, 12, 1, 0, 20).getTime();
+      writeSessionData(ctx as never, term, "second\r\n");
+      schedule.flushScheduled();
+
+      assert.deepEqual(writes, ["first\r\n", "second\r\n"]);
+      assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
+        { row: 0, label: "12:00:59" },
+        { row: 1, label: "12:01:00" },
+      ]);
+    });
   } finally {
     Date.now = originalDateNow;
     resetTerminalWriteCoalescer(term);

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -31,7 +31,9 @@ import {
   resetTerminalWriteCoalescer,
 } from "./terminalWriteCoalescer.ts";
 import {
+  cancelScheduledUnfocusedRepaint,
   flushPendingTerminalWritesOnResume,
+  flushTerminalWriteBufferBypassingTimers,
 } from "./terminalUnfocusedRepaint.ts";
 import {
   clearDeferredTerminalWriteAck,
@@ -330,7 +332,7 @@ test("writeSessionData flushes xterm writes while the page is hidden", () => {
   clearTerminalSessionFlowAck("session-1");
 });
 
-test("writeSessionData flushes xterm writes while the window is unfocused but visible", () => {
+test("writeSessionData batches while unfocused-but-visible then drains on idle flush", async () => {
   clearTerminalSessionFlowAck("session-1");
   const payload = "x".repeat(FLOW_CHAR_COUNT_ACK_SIZE + 1);
   const writes: string[] = [];
@@ -366,6 +368,14 @@ test("writeSessionData flushes xterm writes while the window is unfocused but vi
   withDocumentVisibility("visible", () => {
     writeSessionData(ctx as never, term, payload);
   }, { hasFocus: false });
+
+  // Unfocused-but-visible no longer force-flushes every chunk (preserves
+  // batching / alt-screen frames). Microtask/idle/unfocused timers drain it.
+  await new Promise((resolve) => { setTimeout(resolve, 90); });
+  flushTerminalWriteCoalescer(term);
+  flushTerminalWriteBufferBypassingTimers(term);
+  flushTerminalWriteQueueBypassingTimers(term);
+  flushTerminalWriteBufferBypassingTimers(term);
   flushTerminalSessionFlowAck("session-1");
 
   assert.equal(writes.join(""), payload);
@@ -373,6 +383,8 @@ test("writeSessionData flushes xterm writes while the window is unfocused but vi
   assert.equal(getFlowController(ctx as never, term).pendingBytes(), 0);
   assert.equal(getDeferredTerminalWriteAckBytes(term), 0);
   assert.equal(acked.reduce((total, bytes) => total + bytes, 0), payload.length);
+  cancelScheduledUnfocusedRepaint(term);
+  resetTerminalWriteCoalescer(term);
   clearTerminalSessionFlowAck("session-1");
 });
 

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -643,6 +643,43 @@ test("hiding the page preserves the arrival second of already queued output", ()
   }
 });
 
+test("showing a pane preserves the background arrival second still queued with visible output", () => {
+  const { term, writes } = createFakeTerm();
+  const ctx = {
+    ...createContext(true),
+    isVisibleRef: { current: true },
+    isPaneVisibleRef: { current: false },
+  };
+  const originalDateNow = Date.now;
+  let fakeNow = new Date(2026, 0, 1, 12, 0, 59, 800).getTime();
+  Date.now = () => fakeNow;
+
+  try {
+    withAnimationFrameQueue(() => {
+      writeSessionData(ctx as never, term, "hidden\r\n");
+      ctx.isPaneVisibleRef.current = true;
+      writeSessionData(ctx as never, term, "visible-same-second\r\n");
+
+      fakeNow = new Date(2026, 0, 1, 12, 1, 0, 20).getTime();
+      writeSessionData(ctx as never, term, "visible-next-second\r\n");
+      flushPendingTerminalWritesOnResume(term);
+
+      assert.deepEqual(writes, [
+        "hidden\r\nvisible-same-second\r\n",
+        "visible-next-second\r\n",
+      ]);
+      assert.deepEqual(getVisibleTerminalLineTimestampRows(term), [
+        { row: 0, label: "12:00:59" },
+        { row: 1, label: "12:00:59" },
+        { row: 2, label: "12:01:00" },
+      ]);
+    });
+  } finally {
+    Date.now = originalDateNow;
+    resetTerminalWriteCoalescer(term);
+  }
+});
+
 test("hidden prompt formatting preserves PTY chunk boundaries", () => {
   const require = createRequire(import.meta.url);
   const { Terminal } = require("@xterm/xterm") as {

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -925,6 +925,7 @@ test("hidden prompt formatting respects cursor movement before a bare line feed"
     convertEol: boolean;
     output: string;
     promptRow: number;
+    promptLine?: string;
     setup?: string;
   }> = [
     { convertEol: false, output: "foo\n", promptRow: 2 },
@@ -935,6 +936,9 @@ test("hidden prompt formatting respects cursor movement before a bare line feed"
     { convertEol: false, output: "你好\n", promptRow: 2 },
     { convertEol: false, output: "foo\x1b[20h\n", promptRow: 1 },
     { convertEol: true, output: "foo\x1b[20l\n", promptRow: 2 },
+    { convertEol: false, output: "foo\x1b[E", promptRow: 1 },
+    { convertEol: false, output: "foo\x1b[L\n", promptRow: 1, promptLine: "$ o" },
+    { convertEol: false, output: "foo\x1b[M\n", promptRow: 1 },
     {
       convertEol: false,
       setup: "\x1b[3g\x1b[6G\x1bH\x1b[1G",
@@ -978,7 +982,11 @@ test("hidden prompt formatting respects cursor movement before a bare line feed"
         flushPendingTerminalWritesOnResume(term);
       });
 
-      assert.equal(term.buffer.active.getLine(scenario.promptRow)?.translateToString(true), "$");
+      assert.equal(
+        term.buffer.active.getLine(scenario.promptRow)?.translateToString(true),
+        scenario.promptLine ?? "$",
+        JSON.stringify(scenario),
+      );
       assert.equal(term.buffer.active.cursorX, 2);
     } finally {
       resetTerminalWriteCoalescer(term);

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -543,6 +543,36 @@ test("hidden output keeps its arrival second when a batch crosses a clock bounda
   }
 });
 
+test("visible alternate-screen output stays frame-batched across a clock boundary", () => {
+  const { term, writes } = createFakeTerm("alternate");
+  const ctx = {
+    ...createContext(false),
+    isVisibleRef: { current: true },
+    isPaneVisibleRef: { current: true },
+  };
+  const originalDateNow = Date.now;
+  let fakeNow = new Date(2026, 0, 1, 12, 0, 59, 800).getTime();
+  Date.now = () => fakeNow;
+
+  try {
+    withAnimationFrameQueue((schedule) => {
+      writeSessionData(ctx as never, term, "frame-a");
+      assert.ok(schedule.scheduledCount() >= 1);
+      assert.deepEqual(writes, []);
+
+      fakeNow = new Date(2026, 0, 1, 12, 1, 0, 20).getTime();
+      writeSessionData(ctx as never, term, "frame-b");
+      assert.deepEqual(writes, []);
+
+      schedule.flushScheduled();
+      assert.equal(writes.join(""), "frame-aframe-b");
+    });
+  } finally {
+    Date.now = originalDateNow;
+    resetTerminalWriteCoalescer(term);
+  }
+});
+
 test("writeSessionData keeps the current perf trace when hidden output is flushed", () => {
   const payload = "hidden current output\n";
   const writes: string[] = [];

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -838,6 +838,46 @@ test("hidden prompt formatting preserves PTY chunk boundaries", () => {
   }
 });
 
+test("hidden prompt formatting resets the column after a bare line feed", () => {
+  const require = createRequire(import.meta.url);
+  const { Terminal } = require("@xterm/xterm") as {
+    Terminal: new (options: Record<string, unknown>) => XTerm;
+  };
+  const term = new Terminal({ cols: 80, rows: 5, scrollback: 20, allowProposedApi: true });
+  const promptState = createPromptLineBreakState();
+  promptState.lastPromptText = "$ ";
+  promptState.pendingCommand = true;
+  const settings = {
+    showLineTimestamps: false,
+    scrollOnOutput: false,
+    forcePromptNewLine: true,
+  };
+  const ctx = {
+    ...createContext(false),
+    terminalSettingsRef: { current: settings },
+    terminalSettings: settings,
+    promptLineBreakStateRef: { current: promptState },
+    isVisibleRef: { current: true },
+    isPaneVisibleRef: { current: false },
+  };
+
+  try {
+    withAnimationFrameQueue(() => {
+      writeSessionData(ctx as never, term, "foo\n");
+      writeSessionData(ctx as never, term, "$ ");
+      flushPendingTerminalWritesOnResume(term);
+    });
+
+    assert.equal(term.buffer.active.getLine(0)?.translateToString(true), "foo");
+    assert.equal(term.buffer.active.getLine(1)?.translateToString(true), "");
+    assert.equal(term.buffer.active.getLine(2)?.translateToString(true), "$");
+    assert.equal(term.buffer.active.cursorX, 2);
+  } finally {
+    resetTerminalWriteCoalescer(term);
+    term.dispose();
+  }
+});
+
 test("writeSessionData keeps the current perf trace when hidden output is flushed", () => {
   const payload = "hidden current output\n";
   const writes: string[] = [];

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -54,6 +54,7 @@ import {
   resolveFloodCoalescerByteCap,
   setTerminalWriteCoalescerByteCapResolver,
   setTerminalWriteCoalescerFlushGate,
+  shouldPreserveTerminalWriteFrameBatch,
 } from "./terminalWriteCoalescer";
 import {
   accumulateDeferredTerminalWriteAck,
@@ -157,7 +158,6 @@ const HIDDEN_PANE_DRAIN_MS = 160;
 const visibleWriteIdleFlushTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
 const hiddenPaneDrainTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
 const pendingTimestampSecondByTerm = new WeakMap<XTerm, number>();
-const pendingTimestampBackgroundByTerm = new WeakMap<XTerm, boolean>();
 
 type LineTimestampPerfTotals = {
   segmentCalls: number;
@@ -272,27 +272,19 @@ const flushPendingTerminalOutputNow = (term: XTerm): void => {
 const flushBeforeTimestampBoundary = (
   term: XTerm,
   timestampDate: Date,
-  usesBackgroundWritePath: boolean,
 ): void => {
   const timestampSecond = Math.floor(timestampDate.getTime() / 1000);
   const pendingTimestampSecond = pendingTimestampSecondByTerm.get(term);
-  const pendingUsedBackgroundPath = pendingTimestampBackgroundByTerm.get(term);
   const hadPendingOutput = getTerminalWriteCoalescerPendingBytes(term) > 0;
   if (
     hadPendingOutput
     && pendingTimestampSecond !== undefined
     && pendingTimestampSecond !== timestampSecond
-    && (usesBackgroundWritePath || pendingUsedBackgroundPath === true)
+    && !shouldPreserveTerminalWriteFrameBatch(term)
   ) {
     flushPendingTerminalOutputNow(term);
   }
   pendingTimestampSecondByTerm.set(term, timestampSecond);
-  pendingTimestampBackgroundByTerm.set(
-    term,
-    hadPendingOutput && getTerminalWriteCoalescerPendingBytes(term) > 0
-      ? pendingUsedBackgroundPath === true || usesBackgroundWritePath
-      : usesBackgroundWritePath,
-  );
 };
 
 function flushHiddenPaneWritesNow(term: XTerm, isPaneVisible: () => boolean): void {
@@ -428,10 +420,9 @@ export const writeSessionData = (
   const isPaneVisible = isPaneCurrentlyVisible();
   const timestampDate = new Date(Date.now());
   const usesBackgroundWritePath = shouldFlushTerminalWritesForBackgroundOutput(isPaneVisible);
-  // Hidden panes may wait before coalesced output is drained. Flush a batch
-  // across an arrival-second boundary whenever either side is hidden, while
-  // leaving visible full-screen repaints frame-batched.
-  flushBeforeTimestampBoundary(term, timestampDate, usesBackgroundWritePath);
+  // Flush normal-screen output across an arrival-second boundary so every
+  // line keeps its real timestamp. Alternate-screen repaints stay atomic.
+  flushBeforeTimestampBoundary(term, timestampDate);
   const perfTrace = createTerminalOutputPerfTrace({
     sessionId: ctx.sessionRef.current ?? ctx.sessionId,
     data,
@@ -750,7 +741,6 @@ export const releaseTerminalFlowBeforeHibernate = (
   setTerminalWriteCoalescerByteCapResolver(term);
   setTerminalWriteCoalescerFlushGate(term);
   pendingTimestampSecondByTerm.delete(term);
-  pendingTimestampBackgroundByTerm.delete(term);
   resetDeferredTerminalWriteAck(term);
   terminalFlowControllers.delete(term);
 };
@@ -795,7 +785,6 @@ export const attachSessionToTerminal = (
 
   flushPendingTerminalOutputNow(term);
   pendingTimestampSecondByTerm.delete(term);
-  pendingTimestampBackgroundByTerm.delete(term);
   ctx.sessionRef.current = id;
   const flow = getFlowController(ctx, term);
   teardownTerminalOutputPipeline(ctx, term, id, flow);

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -290,7 +290,10 @@ const flushBeforeTimestampBoundary = (
 function flushHiddenPaneWritesNow(term: XTerm, isPaneVisible: () => boolean): void {
   if (isPaneVisible()) return;
   flushTerminalWriteCoalescer(term);
-  flushTerminalWritesForBackgroundOutput(term);
+  // Each background queue item flushes xterm's parser buffer itself. Leave the
+  // queue's zero-delay yield timers intact so a large hidden burst cannot turn
+  // the whole backlog into one long renderer task.
+  flushTerminalWriteBufferBypassingTimers(term);
   if (!isPaneVisible() && hasPendingTerminalWrites(term)) {
     scheduleHiddenPaneDrain(term, isPaneVisible);
   }
@@ -449,11 +452,16 @@ export const writeSessionData = (
     ): void => {
       writeSessionDataImmediate(ctx, term, batch, batchIngress, {
         ...writeOptions,
+        deferStart: writeOptions?.deferStart ?? !isPaneCurrentlyVisible(),
         flushXtermWriteBuffer: true,
         perfTrace: writeOptions?.preservePerfTrace === false ? null : perfTrace,
         timestampDate,
       });
-      flushTerminalWritesForBackgroundOutput(term);
+      if (isPaneCurrentlyVisible()) {
+        flushTerminalWritesForBackgroundOutput(term);
+      } else {
+        flushTerminalWriteBufferBypassingTimers(term);
+      }
     };
     if (isPaneVisible) {
       flushTerminalWriteCoalescer(term, writeBackgroundOutputData);

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -424,17 +424,6 @@ export const writeSessionData = (
   // across an arrival-second boundary whenever either side is hidden, while
   // leaving visible full-screen repaints frame-batched.
   flushBeforeTimestampBoundary(term, timestampDate, isPaneVisible);
-  const settings = ctx.terminalSettingsRef?.current ?? ctx.terminalSettings;
-  if (
-    !isPaneVisible
-    && settings?.forcePromptNewLine === true
-    && ctx.promptLineBreakStateRef?.current?.pendingCommand === true
-    && getTerminalWriteCoalescerPendingBytes(term) > 0
-  ) {
-    // Prompt formatting needs the cursor state after each PTY chunk. Preserve
-    // that boundary only while the feature is actively waiting for a prompt.
-    flushPendingTerminalOutputNow(term);
-  }
   const perfTrace = createTerminalOutputPerfTrace({
     sessionId: ctx.sessionRef.current ?? ctx.sessionId,
     data,
@@ -539,6 +528,7 @@ const writeSessionDataImmediate = (
         pasteDisplayData,
         ctx.promptLineBreakStateRef?.current,
         forcePromptNewLine,
+        writeOptions.sourceChunkBoundaries,
       );
       prepareMs = shouldMeasurePerf ? performance.now() - prepareStartedAt : 0;
     }

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -435,6 +435,12 @@ export const writeSessionData = (
   flow.received(ingressBytes);
   setTerminalOutputPressureVisibility(term, isPaneVisible);
   noteTerminalOutputPressureData(term, data);
+  const settings = ctx.terminalSettingsRef?.current ?? ctx.terminalSettings;
+  const preservePromptSourceChunks = Boolean(
+    settings?.forcePromptNewLine
+    && ctx.promptLineBreakStateRef?.current?.pendingCommand
+    && ctx.promptLineBreakStateRef.current.lastPromptText,
+  );
   if (usesBackgroundWritePath) {
     const writeBackgroundOutputData = (
       batch: string,
@@ -453,7 +459,13 @@ export const writeSessionData = (
       flushTerminalWriteCoalescer(term, writeBackgroundOutputData);
       flushTerminalWritesForBackgroundOutput(term);
     }
-    enqueueCoalescedTerminalWrite(term, data, writeBackgroundOutputData, ingressBytes);
+    enqueueCoalescedTerminalWrite(
+      term,
+      data,
+      writeBackgroundOutputData,
+      ingressBytes,
+      { preserveSourceChunkBoundaries: preservePromptSourceChunks },
+    );
     if (isPaneVisible) {
       flushTerminalWriteCoalescer(term, writeBackgroundOutputData);
       flushTerminalWritesForBackgroundOutput(term);
@@ -468,7 +480,7 @@ export const writeSessionData = (
       perfTrace: writeOptions?.preservePerfTrace === false ? null : perfTrace,
       timestampDate,
     });
-  }, ingressBytes);
+  }, ingressBytes, { preserveSourceChunkBoundaries: preservePromptSourceChunks });
   scheduleVisibleTerminalWriteIdleFlush(term, isPaneCurrentlyVisible);
   scheduleHiddenPaneDrain(term, isPaneCurrentlyVisible);
   maybeFlushTerminalWriteCoalescerWhenUnfocused(

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -662,8 +662,8 @@ const writeSessionDataImmediate = (
         }
         callback();
       };
-      // writeTerminalDataWithLineTimestamps skips markers only under true flood
-      // (not saturated multi-line), preserving per-line gutter timestamps.
+      // Per-second ledger always records (record/render split); true flood still
+      // skips via shouldSkipTerminalLineTimestamps. Sparse reflow anchors ≤1/s.
       writeTerminalDataWithLineTimestamps(
         term,
         preparedDisplayData,
@@ -673,9 +673,8 @@ const writeSessionDataImmediate = (
             ? { onStep: (step: TerminalLineTimestampPerfStep) => recordLineTimestampPerfStep(lineTimestampPerf, step) }
             : {}),
           timestampDate: writeOptions.timestampDate,
-          // Only host-enabled gutters pay segmenter/marker cost on the hot path.
-          // Read through hostRef so toolbar/vault toggles apply without reattach
-          // (attach handlers close over boot-time ctx.host).
+          // hostRef: live gutter toggle for call-site compatibility (recording
+          // itself is always on; paint is gated by gutter UI).
           enabled: resolveLiveHostShowLineTimestamps(ctx),
         },
       );

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -11,6 +11,7 @@ import {
 } from "./terminalUserPaste";
 import {
   detectTerminalCommandCompletions,
+  doesTerminalPromptStartAtSourceChunk,
   prepareTerminalDataForPromptLineBreak,
   syncPromptLineBreakState,
 } from "./promptLineBreak";
@@ -501,6 +502,16 @@ const writeSessionDataImmediate = (
     const prepareStartedAt = shouldMeasurePerf ? performance.now() : 0;
     const settings = ctx.terminalSettingsRef?.current ?? ctx.terminalSettings;
     const forcePromptNewLine = settings?.forcePromptNewLine ?? false;
+    const promptLineBreakState = ctx.promptLineBreakStateRef?.current;
+    const promptStartsAtSourceChunk = Boolean(
+      forcePromptNewLine
+      && promptLineBreakState?.pendingCommand
+      && doesTerminalPromptStartAtSourceChunk(
+        data,
+        promptLineBreakState.lastPromptText,
+        writeOptions.sourceChunkBoundaries,
+      ),
+    );
     // Always run filter + paste bookkeeping (stateful). Bulk-plain only skips
     // erase-scrollback / prompt cosmetics when the *post-paste* stream is still
     // plain and forcePromptNewLine is off (Codex: long paste cleanup must run).
@@ -526,9 +537,9 @@ const writeSessionDataImmediate = (
       preparedDisplayData = prepareTerminalDataForPromptLineBreak(
         term,
         pasteDisplayData,
-        ctx.promptLineBreakStateRef?.current,
+        promptLineBreakState,
         forcePromptNewLine,
-        writeOptions.sourceChunkBoundaries,
+        promptStartsAtSourceChunk,
       );
       prepareMs = shouldMeasurePerf ? performance.now() - prepareStartedAt : 0;
     }

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -282,7 +282,9 @@ const flushBeforeTimestampBoundary = (
     && pendingTimestampSecond !== timestampSecond
     && !shouldPreserveTerminalWriteFrameBatch(term)
   ) {
-    flushPendingTerminalOutputNow(term);
+    // Split arrival-time batches at the second boundary, but keep any queued
+    // bulk slices on their cooperative yield schedule.
+    flushTerminalWriteCoalescer(term);
   }
   pendingTimestampSecondByTerm.set(term, timestampSecond);
 };

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -277,8 +277,9 @@ const flushBeforeTimestampBoundary = (
   const timestampSecond = Math.floor(timestampDate.getTime() / 1000);
   const pendingTimestampSecond = pendingTimestampSecondByTerm.get(term);
   const pendingUsedBackgroundPath = pendingTimestampBackgroundByTerm.get(term);
+  const hadPendingOutput = getTerminalWriteCoalescerPendingBytes(term) > 0;
   if (
-    getTerminalWriteCoalescerPendingBytes(term) > 0
+    hadPendingOutput
     && pendingTimestampSecond !== undefined
     && pendingTimestampSecond !== timestampSecond
     && (usesBackgroundWritePath || pendingUsedBackgroundPath === true)
@@ -286,7 +287,12 @@ const flushBeforeTimestampBoundary = (
     flushPendingTerminalOutputNow(term);
   }
   pendingTimestampSecondByTerm.set(term, timestampSecond);
-  pendingTimestampBackgroundByTerm.set(term, usesBackgroundWritePath);
+  pendingTimestampBackgroundByTerm.set(
+    term,
+    hadPendingOutput && getTerminalWriteCoalescerPendingBytes(term) > 0
+      ? pendingUsedBackgroundPath === true || usesBackgroundWritePath
+      : usesBackgroundWritePath,
+  );
 };
 
 function flushHiddenPaneWritesNow(term: XTerm, isPaneVisible: () => boolean): void {

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -156,6 +156,7 @@ const HIDDEN_PANE_DRAIN_MS = 160;
 const visibleWriteIdleFlushTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
 const hiddenPaneDrainTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
 const pendingTimestampSecondByTerm = new WeakMap<XTerm, number>();
+const pendingTimestampPaneVisibleByTerm = new WeakMap<XTerm, boolean>();
 
 type LineTimestampPerfTotals = {
   segmentCalls: number;
@@ -270,17 +271,21 @@ const flushPendingTerminalOutputNow = (term: XTerm): void => {
 const flushBeforeTimestampBoundary = (
   term: XTerm,
   timestampDate: Date,
+  isPaneVisible: boolean,
 ): void => {
   const timestampSecond = Math.floor(timestampDate.getTime() / 1000);
   const pendingTimestampSecond = pendingTimestampSecondByTerm.get(term);
+  const pendingPaneWasVisible = pendingTimestampPaneVisibleByTerm.get(term);
   if (
     getTerminalWriteCoalescerPendingBytes(term) > 0
     && pendingTimestampSecond !== undefined
     && pendingTimestampSecond !== timestampSecond
+    && (!isPaneVisible || pendingPaneWasVisible === false)
   ) {
     flushPendingTerminalOutputNow(term);
   }
   pendingTimestampSecondByTerm.set(term, timestampSecond);
+  pendingTimestampPaneVisibleByTerm.set(term, isPaneVisible);
 };
 
 function flushHiddenPaneWritesNow(term: XTerm, isPaneVisible: () => boolean): void {
@@ -415,11 +420,20 @@ export const writeSessionData = (
   const isPaneCurrentlyVisible = () => isTerminalPaneVisible(ctx);
   const isPaneVisible = isPaneCurrentlyVisible();
   const timestampDate = new Date(Date.now());
-  // Hidden panes may wait before their coalesced output is drained, so keep
-  // their timestamp batches inside the arrival second. Visible panes must stay
-  // frame-batched, especially while full-screen terminal apps repaint.
-  if (!isPaneVisible) {
-    flushBeforeTimestampBoundary(term, timestampDate);
+  // Hidden panes may wait before coalesced output is drained. Flush a batch
+  // across an arrival-second boundary whenever either side is hidden, while
+  // leaving visible full-screen repaints frame-batched.
+  flushBeforeTimestampBoundary(term, timestampDate, isPaneVisible);
+  const settings = ctx.terminalSettingsRef?.current ?? ctx.terminalSettings;
+  if (
+    !isPaneVisible
+    && settings?.forcePromptNewLine === true
+    && ctx.promptLineBreakStateRef?.current?.pendingCommand === true
+    && getTerminalWriteCoalescerPendingBytes(term) > 0
+  ) {
+    // Prompt formatting needs the cursor state after each PTY chunk. Preserve
+    // that boundary only while the feature is actively waiting for a prompt.
+    flushPendingTerminalOutputNow(term);
   }
   const perfTrace = createTerminalOutputPerfTrace({
     sessionId: ctx.sessionRef.current ?? ctx.sessionId,
@@ -727,6 +741,7 @@ export const releaseTerminalFlowBeforeHibernate = (
   setTerminalWriteCoalescerByteCapResolver(term);
   setTerminalWriteCoalescerFlushGate(term);
   pendingTimestampSecondByTerm.delete(term);
+  pendingTimestampPaneVisibleByTerm.delete(term);
   resetDeferredTerminalWriteAck(term);
   terminalFlowControllers.delete(term);
 };
@@ -771,6 +786,7 @@ export const attachSessionToTerminal = (
 
   flushPendingTerminalOutputNow(term);
   pendingTimestampSecondByTerm.delete(term);
+  pendingTimestampPaneVisibleByTerm.delete(term);
   ctx.sessionRef.current = id;
   const flow = getFlowController(ctx, term);
   teardownTerminalOutputPipeline(ctx, term, id, flow);

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -415,7 +415,12 @@ export const writeSessionData = (
   const isPaneCurrentlyVisible = () => isTerminalPaneVisible(ctx);
   const isPaneVisible = isPaneCurrentlyVisible();
   const timestampDate = new Date(Date.now());
-  flushBeforeTimestampBoundary(term, timestampDate);
+  // Hidden panes may wait before their coalesced output is drained, so keep
+  // their timestamp batches inside the arrival second. Visible panes must stay
+  // frame-batched, especially while full-screen terminal apps repaint.
+  if (!isPaneVisible) {
+    flushBeforeTimestampBoundary(term, timestampDate);
+  }
   const perfTrace = createTerminalOutputPerfTrace({
     sessionId: ctx.sessionRef.current ?? ctx.sessionId,
     data,

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -398,6 +398,13 @@ const acknowledgeDroppedTerminalDisplayBytes = (
   }
 };
 
+/** Live host fields for write-path feature gates (prefer hostRef over frozen host). */
+export const resolveLiveHostShowLineTimestamps = (
+  ctx: Pick<TerminalSessionStartersContext, "host" | "hostRef">,
+): boolean => (
+  (ctx.hostRef?.current ?? ctx.host)?.showLineTimestamps === true
+);
+
 export const writeTerminalLine = (
   ctx: TerminalSessionStartersContext,
   term: XTerm,
@@ -667,7 +674,9 @@ const writeSessionDataImmediate = (
             : {}),
           timestampDate: writeOptions.timestampDate,
           // Only host-enabled gutters pay segmenter/marker cost on the hot path.
-          enabled: ctx.host?.showLineTimestamps === true,
+          // Read through hostRef so toolbar/vault toggles apply without reattach
+          // (attach handlers close over boot-time ctx.host).
+          enabled: resolveLiveHostShowLineTimestamps(ctx),
         },
       );
       if (

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -106,6 +106,10 @@ export const buildTermEnv = (host: Host, terminalSettings?: TerminalSettings) =>
   return env;
 };
 
+const isTerminalPaneVisible = (ctx: TerminalSessionStartersContext): boolean => (
+  (ctx.isPaneVisibleRef?.current ?? ctx.isVisibleRef?.current) !== false
+);
+
 const handleTerminalOutputAutoScroll = (
   ctx: TerminalSessionStartersContext,
   term: XTerm,
@@ -115,7 +119,7 @@ const handleTerminalOutputAutoScroll = (
     return;
   }
 
-  if (ctx.isVisibleRef?.current === false) {
+  if (!isTerminalPaneVisible(ctx)) {
     notePendingOutputScrollIfEnabled(ctx);
     return;
   }
@@ -341,7 +345,7 @@ export const getFlowController = (
       isTerminalWriteQueueInFloodMode(term) || shouldDegradeTerminalSideWork(term),
     )
   ));
-  setTerminalWriteCoalescerFlushGate(term, () => ctx.isVisibleRef?.current !== false);
+  setTerminalWriteCoalescerFlushGate(term, () => isTerminalPaneVisible(ctx));
   return controller;
 };
 
@@ -380,7 +384,7 @@ export const writeSessionData = (
   meta?: TerminalSessionDataMeta,
 ) => {
   const flow = getFlowController(ctx, term);
-  const isPaneCurrentlyVisible = () => ctx.isVisibleRef?.current !== false;
+  const isPaneCurrentlyVisible = () => isTerminalPaneVisible(ctx);
   const isPaneVisible = isPaneCurrentlyVisible();
   const perfTrace = createTerminalOutputPerfTrace({
     sessionId: ctx.sessionRef.current ?? ctx.sessionId,
@@ -407,11 +411,17 @@ export const writeSessionData = (
       });
       flushTerminalWritesForBackgroundOutput(term);
     };
-    flushTerminalWriteCoalescer(term, writeBackgroundOutputData);
-    flushTerminalWritesForBackgroundOutput(term);
+    if (isPaneVisible) {
+      flushTerminalWriteCoalescer(term, writeBackgroundOutputData);
+      flushTerminalWritesForBackgroundOutput(term);
+    }
     enqueueCoalescedTerminalWrite(term, data, writeBackgroundOutputData, ingressBytes);
-    flushTerminalWriteCoalescer(term, writeBackgroundOutputData);
-    flushTerminalWritesForBackgroundOutput(term);
+    if (isPaneVisible) {
+      flushTerminalWriteCoalescer(term, writeBackgroundOutputData);
+      flushTerminalWritesForBackgroundOutput(term);
+    } else {
+      scheduleHiddenPaneDrain(term, isPaneCurrentlyVisible);
+    }
     return;
   }
   enqueueCoalescedTerminalWrite(term, data, (batch, batchIngress, writeOptions) => {
@@ -510,7 +520,7 @@ const writeSessionDataImmediate = (
       if (shouldScrollOnTerminalOutput(settings)) {
         handleTerminalOutputAutoScroll(ctx, term);
       }
-      if (ctx.isVisibleRef?.current !== false) {
+      if (isTerminalPaneVisible(ctx)) {
         // Unfocused-but-visible windows have no rAF-driven render; this
         // debounced sync repaint is the only path that updates pixels (#1761).
         scheduleTerminalRepaintWhenUnfocused(term);

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -11,7 +11,7 @@ import {
 } from "./terminalUserPaste";
 import {
   detectTerminalCommandCompletions,
-  doesTerminalPromptStartAtSourceChunk,
+  findTerminalPromptSourceChunkVisibleStarts,
   prepareTerminalDataForPromptLineBreak,
   syncPromptLineBreakState,
 } from "./promptLineBreak";
@@ -157,7 +157,7 @@ const HIDDEN_PANE_DRAIN_MS = 160;
 const visibleWriteIdleFlushTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
 const hiddenPaneDrainTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
 const pendingTimestampSecondByTerm = new WeakMap<XTerm, number>();
-const pendingTimestampPaneVisibleByTerm = new WeakMap<XTerm, boolean>();
+const pendingTimestampBackgroundByTerm = new WeakMap<XTerm, boolean>();
 
 type LineTimestampPerfTotals = {
   segmentCalls: number;
@@ -272,21 +272,21 @@ const flushPendingTerminalOutputNow = (term: XTerm): void => {
 const flushBeforeTimestampBoundary = (
   term: XTerm,
   timestampDate: Date,
-  isPaneVisible: boolean,
+  usesBackgroundWritePath: boolean,
 ): void => {
   const timestampSecond = Math.floor(timestampDate.getTime() / 1000);
   const pendingTimestampSecond = pendingTimestampSecondByTerm.get(term);
-  const pendingPaneWasVisible = pendingTimestampPaneVisibleByTerm.get(term);
+  const pendingUsedBackgroundPath = pendingTimestampBackgroundByTerm.get(term);
   if (
     getTerminalWriteCoalescerPendingBytes(term) > 0
     && pendingTimestampSecond !== undefined
     && pendingTimestampSecond !== timestampSecond
-    && (!isPaneVisible || pendingPaneWasVisible === false)
+    && (usesBackgroundWritePath || pendingUsedBackgroundPath === true)
   ) {
     flushPendingTerminalOutputNow(term);
   }
   pendingTimestampSecondByTerm.set(term, timestampSecond);
-  pendingTimestampPaneVisibleByTerm.set(term, isPaneVisible);
+  pendingTimestampBackgroundByTerm.set(term, usesBackgroundWritePath);
 };
 
 function flushHiddenPaneWritesNow(term: XTerm, isPaneVisible: () => boolean): void {
@@ -421,10 +421,11 @@ export const writeSessionData = (
   const isPaneCurrentlyVisible = () => isTerminalPaneVisible(ctx);
   const isPaneVisible = isPaneCurrentlyVisible();
   const timestampDate = new Date(Date.now());
+  const usesBackgroundWritePath = shouldFlushTerminalWritesForBackgroundOutput(isPaneVisible);
   // Hidden panes may wait before coalesced output is drained. Flush a batch
   // across an arrival-second boundary whenever either side is hidden, while
   // leaving visible full-screen repaints frame-batched.
-  flushBeforeTimestampBoundary(term, timestampDate, isPaneVisible);
+  flushBeforeTimestampBoundary(term, timestampDate, usesBackgroundWritePath);
   const perfTrace = createTerminalOutputPerfTrace({
     sessionId: ctx.sessionRef.current ?? ctx.sessionId,
     data,
@@ -437,7 +438,7 @@ export const writeSessionData = (
   flow.received(ingressBytes);
   setTerminalOutputPressureVisibility(term, isPaneVisible);
   noteTerminalOutputPressureData(term, data);
-  if (shouldFlushTerminalWritesForBackgroundOutput(isPaneVisible)) {
+  if (usesBackgroundWritePath) {
     const writeBackgroundOutputData = (
       batch: string,
       batchIngress: number,
@@ -503,14 +504,15 @@ const writeSessionDataImmediate = (
     const settings = ctx.terminalSettingsRef?.current ?? ctx.terminalSettings;
     const forcePromptNewLine = settings?.forcePromptNewLine ?? false;
     const promptLineBreakState = ctx.promptLineBreakStateRef?.current;
-    const promptStartsAtSourceChunk = Boolean(
+    const promptVisibleStarts = (
       forcePromptNewLine
       && promptLineBreakState?.pendingCommand
-      && doesTerminalPromptStartAtSourceChunk(
+      ? findTerminalPromptSourceChunkVisibleStarts(
         data,
         promptLineBreakState.lastPromptText,
         writeOptions.sourceChunkBoundaries,
-      ),
+      )
+      : []
     );
     // Always run filter + paste bookkeeping (stateful). Bulk-plain only skips
     // erase-scrollback / prompt cosmetics when the *post-paste* stream is still
@@ -539,7 +541,7 @@ const writeSessionDataImmediate = (
         pasteDisplayData,
         promptLineBreakState,
         forcePromptNewLine,
-        promptStartsAtSourceChunk,
+        promptVisibleStarts,
       );
       prepareMs = shouldMeasurePerf ? performance.now() - prepareStartedAt : 0;
     }
@@ -742,7 +744,7 @@ export const releaseTerminalFlowBeforeHibernate = (
   setTerminalWriteCoalescerByteCapResolver(term);
   setTerminalWriteCoalescerFlushGate(term);
   pendingTimestampSecondByTerm.delete(term);
-  pendingTimestampPaneVisibleByTerm.delete(term);
+  pendingTimestampBackgroundByTerm.delete(term);
   resetDeferredTerminalWriteAck(term);
   terminalFlowControllers.delete(term);
 };
@@ -787,7 +789,7 @@ export const attachSessionToTerminal = (
 
   flushPendingTerminalOutputNow(term);
   pendingTimestampSecondByTerm.delete(term);
-  pendingTimestampPaneVisibleByTerm.delete(term);
+  pendingTimestampBackgroundByTerm.delete(term);
   ctx.sessionRef.current = id;
   const flow = getFlowController(ctx, term);
   teardownTerminalOutputPipeline(ctx, term, id, flow);

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -523,16 +523,6 @@ const writeSessionDataImmediate = (
     const settings = ctx.terminalSettingsRef?.current ?? ctx.terminalSettings;
     const forcePromptNewLine = settings?.forcePromptNewLine ?? false;
     const promptLineBreakState = ctx.promptLineBreakStateRef?.current;
-    const promptVisibleStarts = (
-      forcePromptNewLine
-      && promptLineBreakState?.pendingCommand
-      ? findTerminalPromptSourceChunkVisibleStarts(
-        data,
-        promptLineBreakState.lastPromptText,
-        writeOptions.sourceChunkBoundaries,
-      )
-      : []
-    );
     // Always run filter + paste bookkeeping (stateful). Bulk-plain only skips
     // erase-scrollback / prompt cosmetics when the *post-paste* stream is still
     // plain and forcePromptNewLine is off (Codex: long paste cleanup must run).
@@ -542,6 +532,21 @@ const writeSessionDataImmediate = (
       normalScreen: term.buffer?.active?.type !== "alternate",
     });
     const pasteDisplayData = prepareTerminalDataForUserPasteDisplay(term, afterErase);
+    // Prompt indices must match the string passed to prepare… — source-chunk
+    // boundaries are only valid when display transforms are identity.
+    const promptSourceBoundaries = pasteDisplayData === data
+      ? writeOptions.sourceChunkBoundaries
+      : undefined;
+    const promptVisibleStarts = (
+      forcePromptNewLine
+      && promptLineBreakState?.pendingCommand
+      ? findTerminalPromptSourceChunkVisibleStarts(
+        pasteDisplayData,
+        promptLineBreakState.lastPromptText,
+        promptSourceBoundaries,
+      )
+      : []
+    );
     const bulkPlainPath = shouldDegradeTerminalSideWork(term)
       && isPlainTerminalDisplayData(pasteDisplayData)
       && !forcePromptNewLine;

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -666,6 +666,8 @@ const writeSessionDataImmediate = (
             ? { onStep: (step: TerminalLineTimestampPerfStep) => recordLineTimestampPerfStep(lineTimestampPerf, step) }
             : {}),
           timestampDate: writeOptions.timestampDate,
+          // Only host-enabled gutters pay segmenter/marker cost on the hot path.
+          enabled: ctx.host?.showLineTimestamps === true,
         },
       );
       if (

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -49,6 +49,7 @@ import {
   type CoalescedTerminalWriteOptions,
   enqueueCoalescedTerminalWrite,
   flushTerminalWriteCoalescer,
+  getTerminalWriteCoalescerPendingBytes,
   resolveFloodCoalescerByteCap,
   setTerminalWriteCoalescerByteCapResolver,
   setTerminalWriteCoalescerFlushGate,
@@ -142,6 +143,7 @@ const terminalFlowControllers = new WeakMap<XTerm, OutputFlowController>();
 type TerminalSessionWriteOptions = CoalescedTerminalWriteOptions & {
   flushXtermWriteBuffer?: boolean;
   perfTrace?: TerminalOutputPerfTrace | null;
+  timestampDate?: Date;
 };
 
 const BACKGROUND_OUTPUT_FLUSH_MAX_PASSES = 64;
@@ -153,6 +155,7 @@ const VISIBLE_WRITE_IDLE_FLUSH_MS = 24;
 const HIDDEN_PANE_DRAIN_MS = 160;
 const visibleWriteIdleFlushTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
 const hiddenPaneDrainTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
+const pendingTimestampSecondByTerm = new WeakMap<XTerm, number>();
 
 type LineTimestampPerfTotals = {
   segmentCalls: number;
@@ -256,6 +259,28 @@ const cancelHiddenPaneDrain = (term: XTerm): void => {
   if (timer === undefined) return;
   clearTimeout(timer);
   hiddenPaneDrainTimers.delete(term);
+};
+
+const flushPendingTerminalOutputNow = (term: XTerm): void => {
+  cancelHiddenPaneDrain(term);
+  flushTerminalWriteCoalescer(term);
+  flushTerminalWritesForBackgroundOutput(term);
+};
+
+const flushBeforeTimestampBoundary = (
+  term: XTerm,
+  timestampDate: Date,
+): void => {
+  const timestampSecond = Math.floor(timestampDate.getTime() / 1000);
+  const pendingTimestampSecond = pendingTimestampSecondByTerm.get(term);
+  if (
+    getTerminalWriteCoalescerPendingBytes(term) > 0
+    && pendingTimestampSecond !== undefined
+    && pendingTimestampSecond !== timestampSecond
+  ) {
+    flushPendingTerminalOutputNow(term);
+  }
+  pendingTimestampSecondByTerm.set(term, timestampSecond);
 };
 
 function flushHiddenPaneWritesNow(term: XTerm, isPaneVisible: () => boolean): void {
@@ -369,11 +394,14 @@ export const writeTerminalLine = (
   term: XTerm,
   data: string,
 ) => {
+  // Keep lifecycle/control lines ordered after all preceding PTY output.
+  flushPendingTerminalOutputNow(term);
   const lineData = `${data}\r\n`;
   enqueueTerminalWrite(term, lineData.length, (done) => {
     ctx.onTerminalLogData?.(lineData);
     term.write(lineData, done);
   });
+  flushTerminalWritesForBackgroundOutput(term);
 };
 
 export const writeSessionData = (
@@ -386,6 +414,8 @@ export const writeSessionData = (
   const flow = getFlowController(ctx, term);
   const isPaneCurrentlyVisible = () => isTerminalPaneVisible(ctx);
   const isPaneVisible = isPaneCurrentlyVisible();
+  const timestampDate = new Date(Date.now());
+  flushBeforeTimestampBoundary(term, timestampDate);
   const perfTrace = createTerminalOutputPerfTrace({
     sessionId: ctx.sessionRef.current ?? ctx.sessionId,
     data,
@@ -408,6 +438,7 @@ export const writeSessionData = (
         ...writeOptions,
         flushXtermWriteBuffer: true,
         perfTrace: writeOptions?.preservePerfTrace === false ? null : perfTrace,
+        timestampDate,
       });
       flushTerminalWritesForBackgroundOutput(term);
     };
@@ -428,6 +459,7 @@ export const writeSessionData = (
     writeSessionDataImmediate(ctx, term, batch, batchIngress, {
       ...writeOptions,
       perfTrace: writeOptions?.preservePerfTrace === false ? null : perfTrace,
+      timestampDate,
     });
   }, ingressBytes);
   scheduleVisibleTerminalWriteIdleFlush(term, isPaneCurrentlyVisible);
@@ -583,9 +615,12 @@ const writeSessionDataImmediate = (
         term,
         preparedDisplayData,
         finishWrite,
-        shouldMeasurePerf && lineTimestampPerf
-          ? { onStep: (step) => recordLineTimestampPerfStep(lineTimestampPerf, step) }
-          : undefined,
+        {
+          ...(shouldMeasurePerf && lineTimestampPerf
+            ? { onStep: (step: TerminalLineTimestampPerfStep) => recordLineTimestampPerfStep(lineTimestampPerf, step) }
+            : {}),
+          timestampDate: writeOptions.timestampDate,
+        },
       );
       if (
         !writeOptions.flushXtermWriteBuffer
@@ -682,10 +717,11 @@ export const releaseTerminalFlowBeforeHibernate = (
   options?: { resumeBackend?: boolean },
 ): void => {
   const flow = terminalFlowControllers.get(term);
-  cancelHiddenPaneDrain(term);
+  flushPendingTerminalOutputNow(term);
   releaseTerminalFlowOutputForTerm(term, backend, sessionId, flow, options);
   setTerminalWriteCoalescerByteCapResolver(term);
   setTerminalWriteCoalescerFlushGate(term);
+  pendingTimestampSecondByTerm.delete(term);
   resetDeferredTerminalWriteAck(term);
   terminalFlowControllers.delete(term);
 };
@@ -728,6 +764,8 @@ export const attachSessionToTerminal = (
     return;
   }
 
+  flushPendingTerminalOutputNow(term);
+  pendingTimestampSecondByTerm.delete(term);
   ctx.sessionRef.current = id;
   const flow = getFlowController(ctx, term);
   teardownTerminalOutputPipeline(ctx, term, id, flow);

--- a/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
@@ -343,7 +343,10 @@ test("writeSessionData bypasses animation-frame coalescing for background output
   );
   assert.match(source, /shouldFlushTerminalWritesForBackgroundOutput\(isPaneVisible\)/);
   assert.match(source, /flushTerminalWriteCoalescer\(term, writeBackgroundOutputData\)/);
-  assert.match(source, /enqueueCoalescedTerminalWrite\(term, data, writeBackgroundOutputData, ingressBytes\)/);
+  assert.match(
+    source,
+    /enqueueCoalescedTerminalWrite\(\s*term,\s*data,\s*writeBackgroundOutputData,\s*ingressBytes,/,
+  );
   assert.match(source, /flushTerminalWriteQueueBypassingTimers\(term\)/);
   assert.match(source, /const deferFlowAck = !writeOptions\.flushXtermWriteBuffer/);
 });

--- a/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
@@ -336,10 +336,9 @@ test("writeSessionDataImmediate schedules unfocused repaint for visible panes on
     new URL("./terminalSessionAttachment.ts", import.meta.url),
     "utf8",
   );
-  // The background fast path must NOT skip this: unfocused-but-visible windows
-  // have no rAF render loop, so the debounced sync repaint is the only way
-  // pixels update (#1761 regression guard).
-  assert.match(source, /if \(ctx\.isVisibleRef\?\.current !== false\) \{[^}]*scheduleTerminalRepaintWhenUnfocused\(term\)/);
+  // Unfocused-but-visible windows have no rAF render loop, so the debounced
+  // sync repaint remains required. Hidden tabs use the batched drain instead.
+  assert.match(source, /if \(isTerminalPaneVisible\(ctx\)\) \{[^}]*scheduleTerminalRepaintWhenUnfocused\(term\)/);
 });
 
 test("app resume recovery flushes pending writes before WebGL recovery", () => {

--- a/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
@@ -12,7 +12,9 @@ import {
   repaintTerminalAfterReveal,
   scheduleTerminalRepaintWhenUnfocused,
   shouldFlushTerminalWritesForBackgroundOutput,
+  writeLocalTerminalDataInOrder,
 } from "./terminalUnfocusedRepaint.ts";
+import { enqueueCoalescedTerminalWrite } from "./terminalWriteCoalescer.ts";
 
 const withDocumentVisibility = (
   visibilityState: "visible" | "hidden",
@@ -244,6 +246,21 @@ test("flushPendingTerminalWritesOnResume drains coalescer, queue, and xterm writ
   assert.match(source, /flushTerminalWriteCoalescer\(term\)/);
   assert.match(source, /flushTerminalWriteQueueBypassingTimers\(term\)/);
   assert.match(source, /flushTerminalWriteBufferBypassingTimers\(term\)/);
+});
+
+test("direct local writes stay ordered after pending hidden output", () => {
+  const { term, writes } = createBufferedFakeTerm();
+  const captured: string[] = [];
+
+  enqueueCoalescedTerminalWrite(term, "remote-before", (data) => {
+    captured.push(data);
+    term.write(data);
+  });
+  writeLocalTerminalDataInOrder(term, "local-after", (data) => captured.push(data));
+  flushTerminalWriteBufferBypassingTimers(term);
+
+  assert.deepEqual(writes, ["remote-before", "local-after"]);
+  assert.deepEqual(captured, ["remote-before", "local-after"]);
 });
 
 test("flushPendingTerminalWritesBeforeHibernate drains pending xterm output completely", async () => {

--- a/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
@@ -15,6 +15,7 @@ import {
   writeLocalTerminalDataInOrder,
 } from "./terminalUnfocusedRepaint.ts";
 import { enqueueCoalescedTerminalWrite } from "./terminalWriteCoalescer.ts";
+import { enqueueTerminalWrite } from "./terminalWriteQueue.ts";
 
 const withDocumentVisibility = (
   visibilityState: "visible" | "hidden",
@@ -280,6 +281,23 @@ test("repeated local writes stay queued without forcing parser flushes", async (
   assert.equal(flushed, true);
   assert.equal(writes.join(""), localWrites.join(""));
   assert.deepEqual(captured, localWrites);
+});
+
+test("full close-style flush drains more than the synchronous resume pass limit", async () => {
+  const { term, writes } = createBufferedFakeTerm();
+  const chunks = Array.from({ length: 80 }, (_, index) => String(index % 10));
+
+  for (const chunk of chunks) {
+    enqueueTerminalWrite(term, chunk.length, (done) => {
+      term.write(chunk, done);
+    }, { deferStart: true, yieldAfter: true });
+  }
+
+  const flushed = await flushPendingTerminalWritesBeforeHibernate(term);
+
+  assert.equal(flushed, true);
+  assert.equal(hasPendingTerminalWrites(term), false);
+  assert.equal(writes.join(""), chunks.join(""));
 });
 
 test("flushPendingTerminalWritesBeforeHibernate drains pending xterm output completely", async () => {

--- a/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
@@ -169,7 +169,7 @@ test("repaintTerminalAfterReveal repaints again after the reveal reaches a brows
   assert.equal(visibleTail, "__END_1000__");
 });
 
-test("shouldFlushTerminalWritesForBackgroundOutput flushes hidden panes and unfocused pages", () => {
+test("shouldFlushTerminalWritesForBackgroundOutput flushes hidden panes and page-hidden docs", () => {
   withDocumentVisibility("visible", () => {
     assert.equal(shouldFlushTerminalWritesForBackgroundOutput(false), true);
   }, { hasFocus: true });
@@ -177,8 +177,9 @@ test("shouldFlushTerminalWritesForBackgroundOutput flushes hidden panes and unfo
     assert.equal(shouldFlushTerminalWritesForBackgroundOutput(true), true);
     assert.equal(shouldFlushTerminalWritesForBackgroundOutput(false), true);
   });
+  // Unfocused-but-visible keeps normal batching; maybeFlush throttles instead.
   withDocumentVisibility("visible", () => {
-    assert.equal(shouldFlushTerminalWritesForBackgroundOutput(true), true);
+    assert.equal(shouldFlushTerminalWritesForBackgroundOutput(true), false);
     assert.equal(shouldFlushTerminalWritesForBackgroundOutput(false), true);
   }, { hasFocus: false });
   withDocumentVisibility("visible", () => {

--- a/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
@@ -263,6 +263,25 @@ test("direct local writes stay ordered after pending hidden output", () => {
   assert.deepEqual(captured, ["remote-before", "local-after"]);
 });
 
+test("repeated local writes stay queued without forcing parser flushes", async () => {
+  const { term, writes } = createBufferedFakeTerm();
+  const captured: string[] = [];
+  const localWrites = Array.from({ length: 100 }, (_, index) => String(index % 10));
+
+  for (const data of localWrites) {
+    writeLocalTerminalDataInOrder(term, data, (capturedData) => captured.push(capturedData));
+  }
+
+  assert.deepEqual(writes, []);
+  assert.equal(hasPendingTerminalWrites(term), true);
+
+  const flushed = await flushPendingTerminalWritesBeforeHibernate(term);
+
+  assert.equal(flushed, true);
+  assert.equal(writes.join(""), localWrites.join(""));
+  assert.deepEqual(captured, localWrites);
+});
+
 test("flushPendingTerminalWritesBeforeHibernate drains pending xterm output completely", async () => {
   const { term, writes } = createBufferedFakeTerm();
   const payload = "x".repeat(300000);

--- a/components/terminal/runtime/terminalUnfocusedRepaint.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.ts
@@ -10,6 +10,7 @@ import {
   getTerminalWriteCoalescerPendingBytes,
 } from "./terminalWriteCoalescer";
 import {
+  enqueueTerminalWrite,
   flushTerminalWriteQueueBypassingTimers,
   hasPendingTerminalWriteQueueWork,
 } from "./terminalWriteQueue";
@@ -202,10 +203,13 @@ export function writeLocalTerminalDataInOrder(
 ): void {
   if (!data) return;
   // Hidden-pane PTY output may still be waiting in the coalescer. Drain it
-  // before a direct local write so prompts/control sequences cannot overtake it.
-  flushPendingTerminalWritesOnResume(term);
-  capture?.(data);
-  term.write(data);
+  // into the ordered queue before appending local echo. Do not bypass queue
+  // yields for every echoed character during a large output burst.
+  flushTerminalWriteCoalescer(term);
+  enqueueTerminalWrite(term, 0, (done) => {
+    capture?.(data);
+    term.write(data, done);
+  });
 }
 
 const waitForTerminalWriteCallbacks = (): Promise<void> =>

--- a/components/terminal/runtime/terminalUnfocusedRepaint.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.ts
@@ -195,6 +195,19 @@ export function flushPendingTerminalWritesOnResume(term: XTerm): void {
   }
 }
 
+export function writeLocalTerminalDataInOrder(
+  term: XTerm,
+  data: string,
+  capture?: (data: string) => void,
+): void {
+  if (!data) return;
+  // Hidden-pane PTY output may still be waiting in the coalescer. Drain it
+  // before a direct local write so prompts/control sequences cannot overtake it.
+  flushPendingTerminalWritesOnResume(term);
+  capture?.(data);
+  term.write(data);
+}
+
 const waitForTerminalWriteCallbacks = (): Promise<void> =>
   new Promise((resolve) => {
     setTimeout(resolve, 0);

--- a/components/terminal/runtime/terminalUnfocusedRepaint.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.ts
@@ -53,10 +53,12 @@ export function shouldFlushTerminalWritesForBackgroundOutput(isPaneVisible: bool
   // Hidden panes should keep their xterm buffer current so tab switches do not
   // reveal a delayed replay of long-running output (#1985).
   if (!isPaneVisible) return true;
-  // Minimized/hidden pages and occluded-but-visible windows (common on Windows
-  // when Alt+Tabbing away) both throttle requestAnimationFrame, which lets the
-  // write coalescer backlog grow and replay slowly on foreground return (#1880).
-  return isTerminalPageHidden() || isTerminalWindowUnfocusedButVisible();
+  // Fully page-hidden documents throttle rAF hard; force the background drain
+  // path so backlog does not sit until the tab is shown again (#1880).
+  // Unfocused-but-still-visible windows (Alt+Tab, second monitor) keep normal
+  // coalescing + maybeFlush… throttling so alt-screen frames and log batching
+  // are not destroyed by a per-chunk force flush.
+  return isTerminalPageHidden();
 }
 
 function normalizeXtermWriteBufferOffset(writeBuffer: XTermPrivateWriteBuffer): void {
@@ -242,8 +244,8 @@ export function maybeFlushTerminalWriteCoalescerWhenUnfocused(
   term: XTerm,
   isPaneVisible: boolean,
 ): void {
-  // Background fast path already drains coalescer/queue synchronously.
-  if (!isPaneVisible || shouldFlushTerminalWritesForBackgroundOutput(isPaneVisible)) return;
+  // Hidden pane / page-hidden use the background drain path in writeSessionData.
+  if (!isPaneVisible || isTerminalPageHidden()) return;
   if (!isTerminalWindowUnfocusedButVisible()) return;
   if (unfocusedFlushTimers.has(term)) return;
 

--- a/components/terminal/runtime/terminalWriteCoalescer.test.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.test.ts
@@ -11,6 +11,7 @@ import {
   resolveFloodCoalescerByteCap,
   setTerminalWriteCoalescerByteCapResolver,
   setTerminalWriteCoalescerFlushGate,
+  shouldPreserveTerminalWriteFrameBatch,
   type CoalescedTerminalWriteOptions,
 } from "./terminalWriteCoalescer.ts";
 import {
@@ -700,11 +701,13 @@ test("upgrades to rAF when alternate-screen CSI is split across PTY chunks", () 
     });
     assert.equal(frames.length, 1);
     assert.equal(microtasks.length, 0);
+    assert.equal(shouldPreserveTerminalWriteFrameBatch(term), true);
 
     enqueueCoalescedTerminalWrite(term, "9hframe", (data) => {
       writes.push(data);
     });
     assert.equal(frames.length, 1);
+    assert.equal(shouldPreserveTerminalWriteFrameBatch(term), true);
     frames[0]!(0);
     assert.deepEqual(writes, ["\x1b[?1049hframe"]);
   } finally {

--- a/components/terminal/runtime/terminalWriteCoalescer.test.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.test.ts
@@ -20,6 +20,11 @@ import {
   MAX_TERMINAL_PLAIN_WRITE_CHUNK_BYTES,
   MAX_TERMINAL_UNBROKEN_WRITE_CHUNK_BYTES,
 } from "./terminalFlowConstants.ts";
+import {
+  createPromptLineBreakState,
+  findTerminalPromptSourceChunkVisibleStarts,
+  prepareTerminalDataForPromptLineBreak,
+} from "./promptLineBreak.ts";
 
 const createFakeTerm = () => ({}) as XTerm;
 const withAnimationFrameQueue = (run: () => void) => {
@@ -133,6 +138,53 @@ test("marks merged coalesced output as not preserving single-chunk perf metadata
     data: "firstsecond",
     options: { preservePerfTrace: false, sourceChunkBoundaries: [5] },
   }]);
+
+  resetTerminalWriteCoalescer(term);
+});
+
+test("keeps a prompt source chunk intact when slicing merged output", () => {
+  const term = {
+    buffer: { active: { type: "normal", cursorX: 1 } },
+  } as unknown as XTerm;
+  const writes: Array<{ data: string; options?: CoalescedTerminalWriteOptions }> = [];
+  const promptState = createPromptLineBreakState();
+  promptState.lastPromptText = "$ ";
+  promptState.pendingCommand = true;
+
+  setTerminalWriteCoalescerByteCapResolver(term, () => 4);
+  setTerminalWriteCoalescerFlushGate(term, () => false);
+  withAnimationFrameQueue(() => {
+    enqueueCoalescedTerminalWrite(
+      term,
+      "abc",
+      () => {},
+      "abc".length,
+      { preserveSourceChunkBoundaries: true },
+    );
+    enqueueCoalescedTerminalWrite(term, "$ ", (data, _ingressBytes, options) => {
+      const promptStarts = findTerminalPromptSourceChunkVisibleStarts(
+        data,
+        promptState.lastPromptText,
+        options?.sourceChunkBoundaries,
+      );
+      writes.push({
+        data: prepareTerminalDataForPromptLineBreak(
+          term,
+          data,
+          promptState,
+          true,
+          promptStarts,
+        ),
+        options,
+      });
+    }, "$ ".length, { preserveSourceChunkBoundaries: true });
+    flushTerminalWriteCoalescer(term);
+  });
+
+  assert.deepEqual(
+    writes.map((write) => write.data),
+    ["abc", "\r\n$ "],
+  );
 
   resetTerminalWriteCoalescer(term);
 });

--- a/components/terminal/runtime/terminalWriteCoalescer.test.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.test.ts
@@ -7,6 +7,8 @@ import {
   abortTerminalWriteCoalescer,
   enqueueCoalescedTerminalWrite,
   flushTerminalWriteCoalescer,
+  getAltScreenProbeScanCountForTests,
+  resetAltScreenProbeScanCountForTests,
   resetTerminalWriteCoalescer,
   resolveFloodCoalescerByteCap,
   setTerminalWriteCoalescerByteCapResolver,
@@ -1161,4 +1163,27 @@ test("resolveFloodCoalescerByteCap keeps bulk batches while flow is paused (#196
   );
   assert.ok(MAX_PENDING_WRITE_COALESCE_BYTES_FLOOD >= 64 * 1024);
   assert.ok(MAX_PENDING_WRITE_COALESCE_BYTES_FLOOD < MAX_PENDING_WRITE_COALESCE_BYTES);
+});
+
+test("enqueue performs one alt-screen CSI scan per chunk", () => {
+  const term = createFakeTerm();
+  resetAltScreenProbeScanCountForTests();
+  setTerminalWriteCoalescerByteCapResolver(term, () => 64 * 1024);
+  withAnimationFrameQueue(() => {
+    enqueueCoalescedTerminalWrite(
+      term,
+      "\x1b[?1049hframe",
+      () => {},
+      "\x1b[?1049hframe".length,
+    );
+    flushTerminalWriteCoalescer(term);
+  });
+
+  assert.equal(
+    getAltScreenProbeScanCountForTests(),
+    1,
+    "frame split + schedule latch must share one probe pass",
+  );
+  resetTerminalWriteCoalescer(term);
+  resetAltScreenProbeScanCountForTests();
 });

--- a/components/terminal/runtime/terminalWriteCoalescer.test.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.test.ts
@@ -189,6 +189,43 @@ test("keeps a prompt source chunk intact when slicing merged output", () => {
   resetTerminalWriteCoalescer(term);
 });
 
+test("extends a real-sized slice to preserve a nearby prompt boundary", () => {
+  const term = {
+    buffer: { active: { type: "normal", cursorX: 1 } },
+  } as unknown as XTerm;
+  const prompt = "(base) user@host:~$ ";
+  const firstChunk = `${"a".repeat((128 * 1024) - prompt.length + 1)}${prompt}`;
+  const writes: Array<{ data: string; promptStarts: number[] }> = [];
+
+  setTerminalWriteCoalescerByteCapResolver(term, () => 1024 * 1024);
+  setTerminalWriteCoalescerFlushGate(term, () => false);
+  withAnimationFrameQueue(() => {
+    enqueueCoalescedTerminalWrite(
+      term,
+      firstChunk,
+      () => {},
+      firstChunk.length,
+      { preserveSourceChunkBoundaries: true },
+    );
+    enqueueCoalescedTerminalWrite(term, "later output", (data, _ingressBytes, options) => {
+      writes.push({
+        data,
+        promptStarts: findTerminalPromptSourceChunkVisibleStarts(
+          data,
+          prompt,
+          options?.sourceChunkBoundaries,
+        ),
+      });
+    }, "later output".length, { preserveSourceChunkBoundaries: true });
+    flushTerminalWriteCoalescer(term);
+  });
+
+  assert.equal(writes[0]?.data, firstChunk);
+  assert.deepEqual(writes[0]?.promptStarts, [firstChunk.length - prompt.length]);
+
+  resetTerminalWriteCoalescer(term);
+});
+
 test("preserves prompt line breaks after a coalesced bare line feed", () => {
   const term = {
     buffer: { active: { type: "normal", cursorX: 0 } },

--- a/components/terminal/runtime/terminalWriteCoalescer.test.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.test.ts
@@ -130,7 +130,7 @@ test("marks merged coalesced output as not preserving single-chunk perf metadata
 
   assert.deepEqual(writes, [{
     data: "firstsecond",
-    options: { preservePerfTrace: false },
+    options: { preservePerfTrace: false, sourceChunkBoundaries: [5] },
   }]);
 
   resetTerminalWriteCoalescer(term);

--- a/components/terminal/runtime/terminalWriteCoalescer.test.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.test.ts
@@ -136,7 +136,7 @@ test("marks merged coalesced output as not preserving single-chunk perf metadata
 
   assert.deepEqual(writes, [{
     data: "firstsecond",
-    options: { preservePerfTrace: false, sourceChunkBoundaries: [5] },
+    options: { preservePerfTrace: false },
   }]);
 
   resetTerminalWriteCoalescer(term);

--- a/components/terminal/runtime/terminalWriteCoalescer.test.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.test.ts
@@ -154,14 +154,7 @@ test("keeps a prompt source chunk intact when slicing merged output", () => {
   setTerminalWriteCoalescerByteCapResolver(term, () => 4);
   setTerminalWriteCoalescerFlushGate(term, () => false);
   withAnimationFrameQueue(() => {
-    enqueueCoalescedTerminalWrite(
-      term,
-      "abc",
-      () => {},
-      "abc".length,
-      { preserveSourceChunkBoundaries: true },
-    );
-    enqueueCoalescedTerminalWrite(term, "$ ", (data, _ingressBytes, options) => {
+    const captureWrite = (data: string, _ingressBytes?: number, options?: CoalescedTerminalWriteOptions) => {
       const promptStarts = findTerminalPromptSourceChunkVisibleStarts(
         data,
         promptState.lastPromptText,
@@ -177,7 +170,21 @@ test("keeps a prompt source chunk intact when slicing merged output", () => {
         ),
         options,
       });
-    }, "$ ".length, { preserveSourceChunkBoundaries: true });
+    };
+    enqueueCoalescedTerminalWrite(
+      term,
+      "abc",
+      captureWrite,
+      "abc".length,
+      { preserveSourceChunkBoundaries: true },
+    );
+    enqueueCoalescedTerminalWrite(
+      term,
+      "$ ",
+      captureWrite,
+      "$ ".length,
+      { preserveSourceChunkBoundaries: true },
+    );
     flushTerminalWriteCoalescer(term);
   });
 
@@ -354,10 +361,10 @@ test("pending output skipped while hidden can be flushed after the pane is shown
   resetTerminalWriteCoalescer(term);
 });
 
-test("cap-triggered coalescer flushes wait until a hidden pane is visible", () => {
+test("cap-triggered coalescer flushes while a pane is still hidden", () => {
   const term = createFakeTerm();
   const writes: string[] = [];
-  let isPaneVisible = false;
+  const isPaneVisible = false;
 
   setTerminalWriteCoalescerByteCapResolver(term, () => 10);
   setTerminalWriteCoalescerFlushGate(term, () => isPaneVisible);
@@ -365,7 +372,9 @@ test("cap-triggered coalescer flushes wait until a hidden pane is visible", () =
     enqueueCoalescedTerminalWrite(
       term,
       "123456",
-      () => {},
+      (data) => {
+        writes.push(data);
+      },
       "123456".length,
     );
     enqueueCoalescedTerminalWrite(
@@ -377,23 +386,21 @@ test("cap-triggered coalescer flushes wait until a hidden pane is visible", () =
       "abcdef".length,
     );
     frames.splice(0).forEach((frame) => frame(0));
-
-    assert.deepEqual(writes, []);
-
-    isPaneVisible = true;
+    // First chunk flushed on cap pressure while still hidden; second may wait
+    // under the gate if it alone is within the cap.
+    assert.equal(writes.join(""), "123456");
     flushTerminalWriteCoalescer(term);
   });
 
   assert.equal(writes.join(""), "123456abcdef");
-  assert.deepEqual(writes.map((write) => write.length), [10, 2]);
 
   resetTerminalWriteCoalescer(term);
 });
 
-test("oversized coalesced output waits while hidden instead of writing directly", () => {
+test("oversized coalesced output drains while hidden instead of unbounded hold", () => {
   const term = createFakeTerm();
   const writes: string[] = [];
-  let isPaneVisible = false;
+  const isPaneVisible = false;
 
   setTerminalWriteCoalescerByteCapResolver(term, () => 4);
   setTerminalWriteCoalescerFlushGate(term, () => isPaneVisible);
@@ -407,14 +414,10 @@ test("oversized coalesced output waits while hidden instead of writing directly"
       "oversized".length,
     );
     frames.splice(0).forEach((frame) => frame(0));
-
-    assert.deepEqual(writes, []);
-
-    isPaneVisible = true;
-    flushTerminalWriteCoalescer(term);
   });
 
-  assert.deepEqual(writes.join(""), "oversized");
+  assert.equal(writes.join(""), "oversized");
+  assert.ok(writes.length >= 1);
 
   resetTerminalWriteCoalescer(term);
 });
@@ -510,7 +513,8 @@ test("hidden oversized enter-alt still latches rAF for follow-up after reveal", 
   };
 
   try {
-    // Cap below enter-alt payload so the gated oversize path is taken while hidden.
+    // Cap below enter-alt payload: size cap drains while hidden, but enter-alt
+    // probing must still latch rAF for later under-cap repaints.
     setTerminalWriteCoalescerByteCapResolver(term, () => 4);
     setTerminalWriteCoalescerFlushGate(term, () => isPaneVisible);
 
@@ -519,16 +523,12 @@ test("hidden oversized enter-alt still latches rAF for follow-up after reveal", 
     });
     frames.splice(0).forEach((frame) => frame(0));
     microtasks.splice(0).forEach((task) => task());
-    assert.deepEqual(writes, []);
-
-    isPaneVisible = true;
-    flushTerminalWriteCoalescer(term);
-    // Cap is 4, so the flush may shard the batch; content must still be intact.
     assert.equal(writes.join(""), "\x1b[?1049hframe");
     writes.length = 0;
     frames.length = 0;
     microtasks.length = 0;
 
+    isPaneVisible = true;
     // Buffer still reports normal until xterm parses; latch must force rAF.
     // Raise the cap so the follow-up uses normal scheduling (not cap flush).
     setTerminalWriteCoalescerByteCapResolver(term, () => 64 * 1024);

--- a/components/terminal/runtime/terminalWriteCoalescer.test.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.test.ts
@@ -189,6 +189,47 @@ test("keeps a prompt source chunk intact when slicing merged output", () => {
   resetTerminalWriteCoalescer(term);
 });
 
+test("preserves prompt line breaks after a coalesced bare line feed", () => {
+  const term = {
+    buffer: { active: { type: "normal", cursorX: 0 } },
+  } as unknown as XTerm;
+  const writes: string[] = [];
+  const promptState = createPromptLineBreakState();
+  promptState.lastPromptText = "$ ";
+  promptState.pendingCommand = true;
+
+  setTerminalWriteCoalescerByteCapResolver(term, () => 64 * 1024);
+  setTerminalWriteCoalescerFlushGate(term, () => false);
+  withAnimationFrameQueue(() => {
+    enqueueCoalescedTerminalWrite(
+      term,
+      "foo\n",
+      () => {},
+      "foo\n".length,
+      { preserveSourceChunkBoundaries: true },
+    );
+    enqueueCoalescedTerminalWrite(term, "$ ", (data, _ingressBytes, options) => {
+      const promptStarts = findTerminalPromptSourceChunkVisibleStarts(
+        data,
+        promptState.lastPromptText,
+        options?.sourceChunkBoundaries,
+      );
+      writes.push(prepareTerminalDataForPromptLineBreak(
+        term,
+        data,
+        promptState,
+        true,
+        promptStarts,
+      ));
+    }, "$ ".length, { preserveSourceChunkBoundaries: true });
+    flushTerminalWriteCoalescer(term);
+  });
+
+  assert.deepEqual(writes, ["foo\n\r\n$ "]);
+
+  resetTerminalWriteCoalescer(term);
+});
+
 test("uses the pending writer when a new chunk forces an old single chunk flush", () => {
   const term = createFakeTerm();
   const firstWriter: string[] = [];

--- a/components/terminal/runtime/terminalWriteCoalescer.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.ts
@@ -303,9 +303,6 @@ const resolveCoalescerByteCap = (term: XTerm): number => {
   return resolver?.() ?? defaultCoalescerByteCap();
 };
 
-const shouldAutoFlushCoalescer = (term: XTerm): boolean =>
-  terminalWriteCoalescerFlushGates.get(term)?.() ?? true;
-
 const getPendingCoalescedBytes = (term: XTerm): number =>
   terminalWriteCoalescers.get(term)?.pendingBytes() ?? 0;
 
@@ -581,12 +578,16 @@ export const enqueueCoalescedTerminalWrite = (
   }
 
   const maxPendingBytes = resolveCoalescerByteCap(term);
-  const canAutoFlush = shouldAutoFlushCoalescer(term);
-  if (canAutoFlush && getPendingCoalescedBytes(term) + data.length > maxPendingBytes) {
+  // Size caps always drain, even when the frame gate holds scheduled flushes
+  // (hidden panes). Otherwise continuous logs pile multi-MB joins for the
+  // timed drain window and defeat the original batching bound.
+  // Flush *previous* pending with its existing writer before installing this
+  // call's writeNow — preserves per-chunk writer identity under cap pressure.
+  if (getPendingCoalescedBytes(term) + data.length > maxPendingBytes) {
     flushTerminalWriteCoalescer(term);
   }
   terminalWriteCoalescerWriters.set(term, writeNow);
-  if (canAutoFlush && data.length > maxPendingBytes) {
+  if (data.length > maxPendingBytes) {
     // Oversized batches skip the coalescer frame arm, but still must latch
     // enter-alt-screen so follow-up repaint chunks use rAF.
     noteAltScreenScheduleProbe(term, data);

--- a/components/terminal/runtime/terminalWriteCoalescer.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.ts
@@ -363,6 +363,7 @@ const isPlainTerminalOutput = (data: string): boolean =>
   !data.includes("\x1b") && !data.includes("\x9b");
 
 const LINE_BREAK_SCAN = /[\n\r]/g;
+const SOURCE_BOUNDARY_SLICE_SLACK_BYTES = 1024;
 
 const hasLongUnbrokenRun = (data: string, maxRunBytes: number): boolean => {
   if (data.length <= maxRunBytes) {
@@ -463,6 +464,20 @@ const writeLargeTerminalBatch = (
       }
       if (boundaryEndIndex > sourceBoundaryIndex) {
         end = sourceChunkBoundaries[boundaryEndIndex - 1];
+      }
+      if (end === idealEnd) {
+        const nextBoundary = sourceChunkBoundaries[boundaryEndIndex];
+        const boundarySlack = Math.min(batchSize, SOURCE_BOUNDARY_SLICE_SLACK_BYTES);
+        if (
+          nextBoundary !== undefined
+          && nextBoundary > idealEnd
+          && nextBoundary - idealEnd <= boundarySlack
+        ) {
+          // A prompt can end just after the nominal slice boundary. Extending
+          // by a small bounded amount keeps that PTY chunk intact without
+          // giving up cooperative bulk-write limits.
+          end = nextBoundary;
+        }
       }
       // A prompt may share its PTY chunk with preceding output. If no source
       // boundary helped, leave enough tail for the final prompt to stay whole.

--- a/components/terminal/runtime/terminalWriteCoalescer.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.ts
@@ -266,6 +266,10 @@ export type CoalescedTerminalWriteOptions = {
   /** Raw offsets where later PTY chunks begin inside this coalesced batch. */
   sourceChunkBoundaries?: readonly number[];
 };
+export type EnqueueCoalescedTerminalWriteOptions = {
+  /** Keep original PTY chunks intact when prompt formatting depends on them. */
+  preserveSourceChunkBoundaries?: boolean;
+};
 type CoalescedTerminalWriteNow = (
   data: string,
   ingressBytes: number,
@@ -276,6 +280,7 @@ const terminalWriteCoalescers = new WeakMap<XTerm, WriteCoalescer>();
 const terminalWriteCoalescerIngress = new WeakMap<XTerm, number>();
 const terminalWriteCoalescerChunkCounts = new WeakMap<XTerm, number>();
 const terminalWriteCoalescerChunkBoundaries = new WeakMap<XTerm, number[]>();
+const terminalWriteCoalescerPreserveSourceChunks = new WeakSet<XTerm>();
 const terminalWriteCoalescerByteCapResolvers = new WeakMap<XTerm, CoalescerByteCapResolver>();
 const terminalWriteCoalescerFlushGates = new WeakMap<XTerm, CoalescerFlushGate>();
 const terminalWriteCoalescerWriters = new WeakMap<XTerm, CoalescedTerminalWriteNow>();
@@ -320,6 +325,12 @@ const takePendingChunkBoundaries = (term: XTerm): number[] => {
   const boundaries = terminalWriteCoalescerChunkBoundaries.get(term) ?? [];
   terminalWriteCoalescerChunkBoundaries.delete(term);
   return boundaries;
+};
+
+const takePendingPreserveSourceChunks = (term: XTerm): boolean => {
+  const preserve = terminalWriteCoalescerPreserveSourceChunks.has(term);
+  terminalWriteCoalescerPreserveSourceChunks.delete(term);
+  return preserve;
 };
 
 export const setTerminalWriteCoalescerFlushGate = (
@@ -420,6 +431,7 @@ const writeLargeTerminalBatch = (
     options?: CoalescedTerminalWriteOptions,
   ) => void,
   options: CoalescedTerminalWriteOptions = {},
+  preserveSourceChunkBoundaries = false,
 ): void => {
   const batchSize = Math.max(1, maxBatchBytes);
   const isSliced = data.length > batchSize;
@@ -430,7 +442,29 @@ const writeLargeTerminalBatch = (
   let bytesSinceYield = 0;
 
   while (offset < data.length) {
-    const end = Math.min(data.length, offset + batchSize);
+    const idealEnd = Math.min(data.length, offset + batchSize);
+    let end = idealEnd;
+    if (preserveSourceChunkBoundaries && idealEnd < data.length) {
+      // Prompt formatting treats each original PTY chunk as a semantic unit.
+      // Keep one intact when it crosses an otherwise arbitrary bulk slice.
+      for (let index = sourceChunkBoundaries.length - 1; index >= 0; index -= 1) {
+        const boundary = sourceChunkBoundaries[index];
+        if (boundary > idealEnd) continue;
+        if (boundary > offset) {
+          end = boundary;
+        }
+        break;
+      }
+      // A prompt may share its PTY chunk with preceding output. If no source
+      // boundary helped, leave enough tail for the final prompt to stay whole.
+      if (end === idealEnd) {
+        const minimumFinalSliceBytes = Math.min(batchSize, 1024);
+        const finalSliceStart = data.length - minimumFinalSliceBytes;
+        if (finalSliceStart > offset && idealEnd > finalSliceStart) {
+          end = finalSliceStart;
+        }
+      }
+    }
     const slice = data.slice(offset, end);
     const sliceIngress = end >= data.length
       ? remainingIngressBytes
@@ -471,6 +505,7 @@ export const enqueueCoalescedTerminalWrite = (
   data: string,
   writeNow: CoalescedTerminalWriteNow,
   ingressBytes: number = data.length,
+  enqueueOptions: EnqueueCoalescedTerminalWriteOptions = {},
 ): void => {
   const resumedAltScreenCsi = incompleteAltScreenCsiByTerm.has(term);
   const frameProbe = probeAltScreenScheduling(
@@ -502,12 +537,15 @@ export const enqueueCoalescedTerminalWrite = (
         prefixIngress,
         resolveTerminalWriteBatchBytes(prefix, resolveCoalescerByteCap(term)),
         writeNow,
+        {},
+        enqueueOptions.preserveSourceChunkBoundaries === true,
       );
       enqueueCoalescedTerminalWrite(
         term,
         data.slice(frameStart),
         writeNow,
         Math.max(0, ingressBytes - prefixIngress),
+        enqueueOptions,
       );
       return;
     }
@@ -528,6 +566,8 @@ export const enqueueCoalescedTerminalWrite = (
       ingressBytes,
       resolveTerminalWriteBatchBytes(data, maxPendingBytes),
       writeNow,
+      {},
+      enqueueOptions.preserveSourceChunkBoundaries === true,
     );
     return;
   }
@@ -540,6 +580,9 @@ export const enqueueCoalescedTerminalWrite = (
     term,
     (terminalWriteCoalescerChunkCounts.get(term) ?? 0) + 1,
   );
+  if (enqueueOptions.preserveSourceChunkBoundaries) {
+    terminalWriteCoalescerPreserveSourceChunks.add(term);
+  }
   const pendingBytesBeforePush = getPendingCoalescedBytes(term);
   if (pendingBytesBeforePush > 0) {
     const boundaries = terminalWriteCoalescerChunkBoundaries.get(term) ?? [];
@@ -553,6 +596,7 @@ export const enqueueCoalescedTerminalWrite = (
       const batchIngress = takePendingIngressBytes(term, batch.length);
       const chunkCount = takePendingChunkCount(term);
       const sourceChunkBoundaries = takePendingChunkBoundaries(term);
+      const preserveSourceChunkBoundaries = takePendingPreserveSourceChunks(term);
       const activeWriteNow = terminalWriteCoalescerWriters.get(term) ?? writeNow;
       writeLargeTerminalBatch(
         batch,
@@ -562,6 +606,7 @@ export const enqueueCoalescedTerminalWrite = (
         chunkCount === 1
           ? {}
           : { preservePerfTrace: false, sourceChunkBoundaries },
+        preserveSourceChunkBoundaries,
       );
     }, {
       getMaxPendingBytes: () => resolveCoalescerByteCap(term),
@@ -616,6 +661,7 @@ export const flushTerminalWriteCoalescer = (
     const batchIngress = takePendingIngressBytes(term, batch.length);
     const chunkCount = takePendingChunkCount(term);
     const sourceChunkBoundaries = takePendingChunkBoundaries(term);
+    const preserveSourceChunkBoundaries = takePendingPreserveSourceChunks(term);
     writeLargeTerminalBatch(
       batch,
       batchIngress,
@@ -624,6 +670,7 @@ export const flushTerminalWriteCoalescer = (
       chunkCount === 1
         ? {}
         : { preservePerfTrace: false, sourceChunkBoundaries },
+      preserveSourceChunkBoundaries,
     );
   });
 };
@@ -634,6 +681,7 @@ export const resetTerminalWriteCoalescer = (term: XTerm): void => {
   terminalWriteCoalescerIngress.delete(term);
   terminalWriteCoalescerChunkCounts.delete(term);
   terminalWriteCoalescerChunkBoundaries.delete(term);
+  terminalWriteCoalescerPreserveSourceChunks.delete(term);
   terminalWriteCoalescerByteCapResolvers.delete(term);
   terminalWriteCoalescerFlushGates.delete(term);
   terminalWriteCoalescerWriters.delete(term);
@@ -670,6 +718,7 @@ export const abortTerminalWriteCoalescer = (
   );
   takePendingChunkCount(term);
   takePendingChunkBoundaries(term);
+  takePendingPreserveSourceChunks(term);
   coalescer.abort();
   if (ingressDropped > 0) {
     onDropped?.(ingressDropped);

--- a/components/terminal/runtime/terminalWriteCoalescer.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.ts
@@ -45,6 +45,8 @@ type AltScreenProbeResult = {
   needsRaf: boolean;
   incomplete: IncompletePrivateCsi | null;
   lastTransition: "enter" | "leave" | null;
+  /** Raw offset where a new alternate-screen frame (or possible split entry) starts. */
+  frameStart: number | null;
 };
 
 /**
@@ -60,14 +62,20 @@ const probeAltScreenScheduling = (
   let params = resume?.params ?? "";
   let lastTransition: "enter" | "leave" | null = null;
   let incomplete: IncompletePrivateCsi | null = null;
+  let sequenceStart = resume ? 0 : -1;
+  let frameStart: number | null = null;
 
   const finishPrivate = (final: string): void => {
     const parts = params.split(";").filter(Boolean);
     if (parts.some((param) => ALT_SCREEN_DECSET.has(param))) {
       lastTransition = final === "h" ? "enter" : "leave";
+      if (final === "h" && frameStart === null) {
+        frameStart = Math.max(0, sequenceStart);
+      }
     }
     phase = null;
     params = "";
+    sequenceStart = -1;
   };
 
   for (let i = 0; i < data.length; i += 1) {
@@ -78,11 +86,13 @@ const probeAltScreenScheduling = (
       if (ch === ESC) {
         phase = 0;
         params = "";
+        sequenceStart = i;
         continue;
       }
       if (ch === C1_CSI) {
         phase = 3;
         params = "";
+        sequenceStart = i;
         continue;
       }
       continue;
@@ -99,10 +109,12 @@ const probeAltScreenScheduling = (
         lastTransition = "leave";
         phase = null;
         params = "";
+        sequenceStart = -1;
         continue;
       }
       phase = null;
       params = "";
+      sequenceStart = -1;
       i -= 1; // reprocess this char as potential start
       continue;
     }
@@ -116,6 +128,7 @@ const probeAltScreenScheduling = (
       }
       phase = null;
       params = "";
+      sequenceStart = -1;
       i -= 1;
       continue;
     }
@@ -129,6 +142,7 @@ const probeAltScreenScheduling = (
       }
       phase = null;
       params = "";
+      sequenceStart = -1;
       i -= 1;
       continue;
     }
@@ -148,6 +162,7 @@ const probeAltScreenScheduling = (
     // the same) — reprocess this byte as a fresh introducer.
     phase = null;
     params = "";
+    sequenceStart = -1;
     if (ch === ESC || ch === C1_CSI) {
       i -= 1;
     }
@@ -155,12 +170,16 @@ const probeAltScreenScheduling = (
 
   if (phase !== null) {
     incomplete = { phase, params };
+    if (frameStart === null) {
+      frameStart = Math.max(0, sequenceStart);
+    }
   }
 
   return {
     needsRaf: lastTransition === "enter" || incomplete !== null,
     incomplete,
     lastTransition,
+    frameStart,
   };
 };
 
@@ -437,6 +456,46 @@ export const enqueueCoalescedTerminalWrite = (
   writeNow: CoalescedTerminalWriteNow,
   ingressBytes: number = data.length,
 ): void => {
+  const resumedAltScreenCsi = incompleteAltScreenCsiByTerm.has(term);
+  const frameProbe = probeAltScreenScheduling(
+    data,
+    incompleteAltScreenCsiByTerm.get(term) ?? null,
+  );
+  const startsNewFrame = frameProbe.frameStart !== null
+    && !(resumedAltScreenCsi && frameProbe.frameStart === 0);
+  if (startsNewFrame) {
+    // Keep ordinary shell output out of an alternate-screen frame. Otherwise a
+    // frame held across a clock boundary makes the preceding shell line inherit
+    // the later timestamp when the batch finally drains.
+    flushTerminalWriteCoalescer(term);
+    const frameStart = frameProbe.frameStart!;
+    if (frameStart > 0) {
+      const prefix = data.slice(0, frameStart);
+      const prefixIngress = splitIngressBytes(
+        data.length,
+        ingressBytes,
+        prefix.length,
+        ingressBytes,
+      );
+      // Advance split CSI state for a resumed sequence that turned out not to
+      // be an alternate-screen entry before the new frame begins.
+      noteAltScreenScheduleProbe(term, prefix);
+      writeLargeTerminalBatch(
+        prefix,
+        prefixIngress,
+        resolveTerminalWriteBatchBytes(prefix, resolveCoalescerByteCap(term)),
+        writeNow,
+      );
+      enqueueCoalescedTerminalWrite(
+        term,
+        data.slice(frameStart),
+        writeNow,
+        Math.max(0, ingressBytes - prefixIngress),
+      );
+      return;
+    }
+  }
+
   const maxPendingBytes = resolveCoalescerByteCap(term);
   const canAutoFlush = shouldAutoFlushCoalescer(term);
   if (canAutoFlush && getPendingCoalescedBytes(term) + data.length > maxPendingBytes) {

--- a/components/terminal/runtime/terminalWriteCoalescer.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.ts
@@ -440,20 +440,29 @@ const writeLargeTerminalBatch = (
   let offset = 0;
   let remainingIngressBytes = Math.max(0, ingressBytes);
   let bytesSinceYield = 0;
+  let sourceBoundaryIndex = 0;
 
   while (offset < data.length) {
+    while (
+      sourceBoundaryIndex < sourceChunkBoundaries.length
+      && sourceChunkBoundaries[sourceBoundaryIndex] <= offset
+    ) {
+      sourceBoundaryIndex += 1;
+    }
     const idealEnd = Math.min(data.length, offset + batchSize);
     let end = idealEnd;
     if (preserveSourceChunkBoundaries && idealEnd < data.length) {
       // Prompt formatting treats each original PTY chunk as a semantic unit.
       // Keep one intact when it crosses an otherwise arbitrary bulk slice.
-      for (let index = sourceChunkBoundaries.length - 1; index >= 0; index -= 1) {
-        const boundary = sourceChunkBoundaries[index];
-        if (boundary > idealEnd) continue;
-        if (boundary > offset) {
-          end = boundary;
-        }
-        break;
+      let boundaryEndIndex = sourceBoundaryIndex;
+      while (
+        boundaryEndIndex < sourceChunkBoundaries.length
+        && sourceChunkBoundaries[boundaryEndIndex] <= idealEnd
+      ) {
+        boundaryEndIndex += 1;
+      }
+      if (boundaryEndIndex > sourceBoundaryIndex) {
+        end = sourceChunkBoundaries[boundaryEndIndex - 1];
       }
       // A prompt may share its PTY chunk with preceding output. If no source
       // boundary helped, leave enough tail for the final prompt to stay whole.
@@ -481,9 +490,14 @@ const writeLargeTerminalBatch = (
     if (shouldYield) {
       bytesSinceYield = 0;
     }
-    const sliceChunkBoundaries = sourceChunkBoundaries
-      .filter((boundary) => boundary > offset && boundary < end)
-      .map((boundary) => boundary - offset);
+    const sliceChunkBoundaries: number[] = [];
+    while (
+      sourceBoundaryIndex < sourceChunkBoundaries.length
+      && sourceChunkBoundaries[sourceBoundaryIndex] < end
+    ) {
+      sliceChunkBoundaries.push(sourceChunkBoundaries[sourceBoundaryIndex] - offset);
+      sourceBoundaryIndex += 1;
+    }
     const nextOptions = {
       ...baseOptions,
       ...(shouldYield ? { yieldAfter: true } : {}),
@@ -584,7 +598,10 @@ export const enqueueCoalescedTerminalWrite = (
     terminalWriteCoalescerPreserveSourceChunks.add(term);
   }
   const pendingBytesBeforePush = getPendingCoalescedBytes(term);
-  if (pendingBytesBeforePush > 0) {
+  if (
+    terminalWriteCoalescerPreserveSourceChunks.has(term)
+    && pendingBytesBeforePush > 0
+  ) {
     const boundaries = terminalWriteCoalescerChunkBoundaries.get(term) ?? [];
     boundaries.push(pendingBytesBeforePush);
     terminalWriteCoalescerChunkBoundaries.set(term, boundaries);

--- a/components/terminal/runtime/terminalWriteCoalescer.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.ts
@@ -172,6 +172,18 @@ const isTerminalAlternateScreenActive = (term: XTerm): boolean => {
   }
 };
 
+/**
+ * Keep a pending write atomic when it is part of an alternate-screen frame.
+ * This includes enter sequences that xterm has not parsed yet, including a
+ * private CSI split across PTY chunks.
+ */
+export const shouldPreserveTerminalWriteFrameBatch = (term: XTerm): boolean => (
+  isTerminalAlternateScreenActive(term)
+  || observedAltScreenByTerm.has(term)
+  || pendingAltScreenEntryByTerm.has(term)
+  || incompleteAltScreenCsiByTerm.has(term)
+);
+
 const noteAltScreenScheduleProbe = (term: XTerm, chunk: string): boolean => {
   // Always scan the chunk first so leave-alt CSI is observed even while
   // buffer.active still reports "alternate" (parser lags our write schedule).

--- a/components/terminal/runtime/terminalWriteCoalescer.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.ts
@@ -37,6 +37,8 @@ const incompleteAltScreenCsiByTerm = new WeakMap<XTerm, IncompletePrivateCsi>();
 const pendingAltScreenEntryByTerm = new WeakMap<XTerm, true>();
 /** True once we have observed the alternate buffer live on this term. */
 const observedAltScreenByTerm = new WeakMap<XTerm, true>();
+/** Leave CSI was queued while xterm still reported the alternate buffer. */
+const pendingAltScreenLeaveByTerm = new WeakMap<XTerm, true>();
 
 const isPrivateParamCharCode = (code: number): boolean =>
   (code >= 0x30 && code <= 0x39) || code === 0x3b;
@@ -47,6 +49,8 @@ type AltScreenProbeResult = {
   lastTransition: "enter" | "leave" | null;
   /** Raw offset where a new alternate-screen frame (or possible split entry) starts. */
   frameStart: number | null;
+  /** Raw offset immediately after the final transition back to normal screen. */
+  normalScreenStart: number | null;
 };
 
 /**
@@ -64,14 +68,16 @@ const probeAltScreenScheduling = (
   let incomplete: IncompletePrivateCsi | null = null;
   let sequenceStart = resume ? 0 : -1;
   let frameStart: number | null = null;
+  let normalScreenStart: number | null = null;
 
-  const finishPrivate = (final: string): void => {
+  const finishPrivate = (final: string, endOffset: number): void => {
     const parts = params.split(";").filter(Boolean);
     if (parts.some((param) => ALT_SCREEN_DECSET.has(param))) {
       lastTransition = final === "h" ? "enter" : "leave";
       if (final === "h" && frameStart === null) {
         frameStart = Math.max(0, sequenceStart);
       }
+      normalScreenStart = final === "l" ? endOffset : null;
     }
     phase = null;
     params = "";
@@ -107,6 +113,7 @@ const probeAltScreenScheduling = (
       if (ch === "c") {
         // RIS returns the terminal to the normal screen without DECSET leave.
         lastTransition = "leave";
+        normalScreenStart = i + 1;
         phase = null;
         params = "";
         sequenceStart = -1;
@@ -155,7 +162,7 @@ const probeAltScreenScheduling = (
       continue;
     }
     if (ch === "h" || ch === "l") {
-      finishPrivate(ch);
+      finishPrivate(ch, i + 1);
       continue;
     }
     // Abort incomplete private mode. ESC / C1 start a new sequence (xterm does
@@ -180,6 +187,7 @@ const probeAltScreenScheduling = (
     incomplete,
     lastTransition,
     frameStart,
+    normalScreenStart,
   };
 };
 
@@ -197,7 +205,7 @@ const isTerminalAlternateScreenActive = (term: XTerm): boolean => {
  * private CSI split across PTY chunks.
  */
 export const shouldPreserveTerminalWriteFrameBatch = (term: XTerm): boolean => (
-  isTerminalAlternateScreenActive(term)
+  (!pendingAltScreenLeaveByTerm.has(term) && isTerminalAlternateScreenActive(term))
   || observedAltScreenByTerm.has(term)
   || pendingAltScreenEntryByTerm.has(term)
   || incompleteAltScreenCsiByTerm.has(term)
@@ -217,12 +225,19 @@ const noteAltScreenScheduleProbe = (term: XTerm, chunk: string): boolean => {
   if (probe.lastTransition === "leave") {
     pendingAltScreenEntryByTerm.delete(term);
     observedAltScreenByTerm.delete(term);
+    pendingAltScreenLeaveByTerm.set(term, true);
   } else if (probe.lastTransition === "enter") {
     // Complete enter CSI observed; xterm may still report normal until parse.
     pendingAltScreenEntryByTerm.set(term, true);
+    pendingAltScreenLeaveByTerm.delete(term);
   }
 
   if (isTerminalAlternateScreenActive(term)) {
+    if (pendingAltScreenLeaveByTerm.has(term)) {
+      // Schedule the leave with the current TUI frame, but do not re-latch the
+      // old alternate state while xterm is still parsing the queued leave.
+      return true;
+    }
     // Buffer realized alternate — drop enter-pending (no longer needed).
     observedAltScreenByTerm.set(term, true);
     pendingAltScreenEntryByTerm.delete(term);
@@ -234,6 +249,7 @@ const noteAltScreenScheduleProbe = (term: XTerm, chunk: string): boolean => {
     observedAltScreenByTerm.delete(term);
     pendingAltScreenEntryByTerm.delete(term);
   }
+  pendingAltScreenLeaveByTerm.delete(term);
 
   return (
     probe.needsRaf
@@ -463,6 +479,7 @@ export const enqueueCoalescedTerminalWrite = (
   );
   const startsNewFrame = frameProbe.frameStart !== null
     && !(resumedAltScreenCsi && frameProbe.frameStart === 0);
+  const flushAfterAltScreenLeave = frameProbe.normalScreenStart !== null;
   if (startsNewFrame) {
     // Keep ordinary shell output out of an alternate-screen frame. Otherwise a
     // frame held across a clock boundary makes the preceding shell line inherit
@@ -577,6 +594,12 @@ export const enqueueCoalescedTerminalWrite = (
     terminalWriteCoalescers.set(term, coalescer);
   }
   coalescer.push(data);
+  if (flushAfterAltScreenLeave) {
+    // Do not let shell output after a TUI exit inherit a later batch timestamp.
+    // Keeping the leave and its same-chunk suffix together also lets the
+    // timestamp parser observe the transition before stamping that suffix.
+    flushTerminalWriteCoalescer(term);
+  }
 };
 
 export const flushTerminalWriteCoalescer = (
@@ -617,6 +640,7 @@ export const resetTerminalWriteCoalescer = (term: XTerm): void => {
   incompleteAltScreenCsiByTerm.delete(term);
   pendingAltScreenEntryByTerm.delete(term);
   observedAltScreenByTerm.delete(term);
+  pendingAltScreenLeaveByTerm.delete(term);
 };
 
 export const getTerminalWriteCoalescerPendingBytes = (term: XTerm): number =>
@@ -636,6 +660,7 @@ export const abortTerminalWriteCoalescer = (
   incompleteAltScreenCsiByTerm.delete(term);
   pendingAltScreenEntryByTerm.delete(term);
   observedAltScreenByTerm.delete(term);
+  pendingAltScreenLeaveByTerm.delete(term);
 
   const coalescer = terminalWriteCoalescers.get(term);
   if (!coalescer) return;

--- a/components/terminal/runtime/terminalWriteCoalescer.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.ts
@@ -216,6 +216,8 @@ export type CoalescedTerminalWriteOptions = {
   deferStart?: boolean;
   yieldAfter?: boolean;
   preservePerfTrace?: boolean;
+  /** Raw offsets where later PTY chunks begin inside this coalesced batch. */
+  sourceChunkBoundaries?: readonly number[];
 };
 type CoalescedTerminalWriteNow = (
   data: string,
@@ -226,6 +228,7 @@ type CoalescedTerminalWriteNow = (
 const terminalWriteCoalescers = new WeakMap<XTerm, WriteCoalescer>();
 const terminalWriteCoalescerIngress = new WeakMap<XTerm, number>();
 const terminalWriteCoalescerChunkCounts = new WeakMap<XTerm, number>();
+const terminalWriteCoalescerChunkBoundaries = new WeakMap<XTerm, number[]>();
 const terminalWriteCoalescerByteCapResolvers = new WeakMap<XTerm, CoalescerByteCapResolver>();
 const terminalWriteCoalescerFlushGates = new WeakMap<XTerm, CoalescerFlushGate>();
 const terminalWriteCoalescerWriters = new WeakMap<XTerm, CoalescedTerminalWriteNow>();
@@ -264,6 +267,12 @@ const takePendingChunkCount = (term: XTerm): number => {
   const count = terminalWriteCoalescerChunkCounts.get(term) ?? 1;
   terminalWriteCoalescerChunkCounts.delete(term);
   return count;
+};
+
+const takePendingChunkBoundaries = (term: XTerm): number[] => {
+  const boundaries = terminalWriteCoalescerChunkBoundaries.get(term) ?? [];
+  terminalWriteCoalescerChunkBoundaries.delete(term);
+  return boundaries;
 };
 
 export const setTerminalWriteCoalescerFlushGate = (
@@ -368,6 +377,7 @@ const writeLargeTerminalBatch = (
   const batchSize = Math.max(1, maxBatchBytes);
   const isSliced = data.length > batchSize;
   const yieldBudget = resolveSliceYieldBudgetBytes(data, batchSize);
+  const { sourceChunkBoundaries = [], ...baseOptions } = options;
   let offset = 0;
   let remainingIngressBytes = Math.max(0, ingressBytes);
   let bytesSinceYield = 0;
@@ -390,9 +400,15 @@ const writeLargeTerminalBatch = (
     if (shouldYield) {
       bytesSinceYield = 0;
     }
+    const sliceChunkBoundaries = sourceChunkBoundaries
+      .filter((boundary) => boundary > offset && boundary < end)
+      .map((boundary) => boundary - offset);
     const nextOptions = {
-      ...options,
+      ...baseOptions,
       ...(shouldYield ? { yieldAfter: true } : {}),
+      ...(sliceChunkBoundaries.length > 0
+        ? { sourceChunkBoundaries: sliceChunkBoundaries }
+        : {}),
     };
     writeNow(
       slice,
@@ -436,19 +452,28 @@ export const enqueueCoalescedTerminalWrite = (
     term,
     (terminalWriteCoalescerChunkCounts.get(term) ?? 0) + 1,
   );
+  const pendingBytesBeforePush = getPendingCoalescedBytes(term);
+  if (pendingBytesBeforePush > 0) {
+    const boundaries = terminalWriteCoalescerChunkBoundaries.get(term) ?? [];
+    boundaries.push(pendingBytesBeforePush);
+    terminalWriteCoalescerChunkBoundaries.set(term, boundaries);
+  }
 
   let coalescer = terminalWriteCoalescers.get(term);
   if (!coalescer) {
     coalescer = createWriteCoalescer((batch) => {
       const batchIngress = takePendingIngressBytes(term, batch.length);
       const chunkCount = takePendingChunkCount(term);
+      const sourceChunkBoundaries = takePendingChunkBoundaries(term);
       const activeWriteNow = terminalWriteCoalescerWriters.get(term) ?? writeNow;
       writeLargeTerminalBatch(
         batch,
         batchIngress,
         resolveTerminalWriteBatchBytes(batch, resolveCoalescerByteCap(term)),
         activeWriteNow,
-        chunkCount === 1 ? {} : { preservePerfTrace: false },
+        chunkCount === 1
+          ? {}
+          : { preservePerfTrace: false, sourceChunkBoundaries },
       );
     }, {
       getMaxPendingBytes: () => resolveCoalescerByteCap(term),
@@ -496,12 +521,15 @@ export const flushTerminalWriteCoalescer = (
   coalescer.flushSync((batch) => {
     const batchIngress = takePendingIngressBytes(term, batch.length);
     const chunkCount = takePendingChunkCount(term);
+    const sourceChunkBoundaries = takePendingChunkBoundaries(term);
     writeLargeTerminalBatch(
       batch,
       batchIngress,
       resolveTerminalWriteBatchBytes(batch, resolveCoalescerByteCap(term)),
       writeNow,
-      chunkCount === 1 ? {} : { preservePerfTrace: false },
+      chunkCount === 1
+        ? {}
+        : { preservePerfTrace: false, sourceChunkBoundaries },
     );
   });
 };
@@ -511,6 +539,7 @@ export const resetTerminalWriteCoalescer = (term: XTerm): void => {
   terminalWriteCoalescers.delete(term);
   terminalWriteCoalescerIngress.delete(term);
   terminalWriteCoalescerChunkCounts.delete(term);
+  terminalWriteCoalescerChunkBoundaries.delete(term);
   terminalWriteCoalescerByteCapResolvers.delete(term);
   terminalWriteCoalescerFlushGates.delete(term);
   terminalWriteCoalescerWriters.delete(term);
@@ -544,6 +573,7 @@ export const abortTerminalWriteCoalescer = (
     coalescer.pendingBytes(),
   );
   takePendingChunkCount(term);
+  takePendingChunkBoundaries(term);
   coalescer.abort();
   if (ingressDropped > 0) {
     onDropped?.(ingressDropped);

--- a/components/terminal/runtime/terminalWriteCoalescer.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.ts
@@ -39,6 +39,15 @@ const pendingAltScreenEntryByTerm = new WeakMap<XTerm, true>();
 const observedAltScreenByTerm = new WeakMap<XTerm, true>();
 /** Leave CSI was queued while xterm still reported the alternate buffer. */
 const pendingAltScreenLeaveByTerm = new WeakMap<XTerm, true>();
+/** One-shot: schedule mode consumes a probe already applied for this push. */
+const preappliedAltScreenNeedsRafByTerm = new WeakMap<XTerm, boolean>();
+
+/** Test-only: counts full CSI scans in probeAltScreenScheduling. */
+let altScreenProbeScanCountForTests = 0;
+export const getAltScreenProbeScanCountForTests = (): number => altScreenProbeScanCountForTests;
+export const resetAltScreenProbeScanCountForTests = (): void => {
+  altScreenProbeScanCountForTests = 0;
+};
 
 const isPrivateParamCharCode = (code: number): boolean =>
   (code >= 0x30 && code <= 0x39) || code === 0x3b;
@@ -62,6 +71,7 @@ const probeAltScreenScheduling = (
   data: string,
   resume: IncompletePrivateCsi | null,
 ): AltScreenProbeResult => {
+  altScreenProbeScanCountForTests += 1;
   let phase: IncompletePrivateCsi["phase"] | null = resume?.phase ?? null;
   let params = resume?.params ?? "";
   let lastTransition: "enter" | "leave" | null = null;
@@ -211,11 +221,14 @@ export const shouldPreserveTerminalWriteFrameBatch = (term: XTerm): boolean => (
   || incompleteAltScreenCsiByTerm.has(term)
 );
 
-const noteAltScreenScheduleProbe = (term: XTerm, chunk: string): boolean => {
-  // Always scan the chunk first so leave-alt CSI is observed even while
-  // buffer.active still reports "alternate" (parser lags our write schedule).
-  const resume = incompleteAltScreenCsiByTerm.get(term) ?? null;
-  const probe = probeAltScreenScheduling(chunk, resume);
+/**
+ * Apply a completed alt-screen probe to per-term latches.
+ * Returns whether the next write schedule should use rAF.
+ */
+const applyAltScreenScheduleProbeResult = (
+  term: XTerm,
+  probe: AltScreenProbeResult,
+): boolean => {
   if (probe.incomplete) {
     incompleteAltScreenCsiByTerm.set(term, probe.incomplete);
   } else {
@@ -255,6 +268,14 @@ const noteAltScreenScheduleProbe = (term: XTerm, chunk: string): boolean => {
     probe.needsRaf
     || pendingAltScreenEntryByTerm.has(term)
   );
+};
+
+const noteAltScreenScheduleProbe = (term: XTerm, chunk: string): boolean => {
+  // Always scan the chunk first so leave-alt CSI is observed even while
+  // buffer.active still reports "alternate" (parser lags our write schedule).
+  const resume = incompleteAltScreenCsiByTerm.get(term) ?? null;
+  const probe = probeAltScreenScheduling(chunk, resume);
+  return applyAltScreenScheduleProbeResult(term, probe);
 };
 
 type CoalescerByteCapResolver = () => number;
@@ -534,6 +555,7 @@ export const enqueueCoalescedTerminalWrite = (
   enqueueOptions: EnqueueCoalescedTerminalWriteOptions = {},
 ): void => {
   const resumedAltScreenCsi = incompleteAltScreenCsiByTerm.has(term);
+  // Single CSI scan for frame split + schedule latch (not a second full pass).
   const frameProbe = probeAltScreenScheduling(
     data,
     incompleteAltScreenCsiByTerm.get(term) ?? null,
@@ -555,8 +577,7 @@ export const enqueueCoalescedTerminalWrite = (
         prefix.length,
         ingressBytes,
       );
-      // Advance split CSI state for a resumed sequence that turned out not to
-      // be an alternate-screen entry before the new frame begins.
+      // Prefix may not be the enter CSI; re-probe only those bytes.
       noteAltScreenScheduleProbe(term, prefix);
       writeLargeTerminalBatch(
         prefix,
@@ -577,6 +598,9 @@ export const enqueueCoalescedTerminalWrite = (
     }
   }
 
+  // Apply the single full-chunk probe once before schedule/push or oversized write.
+  const needsRafFromProbe = applyAltScreenScheduleProbeResult(term, frameProbe);
+
   const maxPendingBytes = resolveCoalescerByteCap(term);
   // Size caps always drain, even when the frame gate holds scheduled flushes
   // (hidden panes). Otherwise continuous logs pile multi-MB joins for the
@@ -588,9 +612,7 @@ export const enqueueCoalescedTerminalWrite = (
   }
   terminalWriteCoalescerWriters.set(term, writeNow);
   if (data.length > maxPendingBytes) {
-    // Oversized batches skip the coalescer frame arm, but still must latch
-    // enter-alt-screen so follow-up repaint chunks use rAF.
-    noteAltScreenScheduleProbe(term, data);
+    // Oversized batches skip the coalescer frame arm; probe already latched above.
     writeLargeTerminalBatch(
       data,
       ingressBytes,
@@ -623,6 +645,10 @@ export const enqueueCoalescedTerminalWrite = (
     terminalWriteCoalescerChunkBoundaries.set(term, boundaries);
   }
 
+  // Hand the already-applied probe result to schedule mode so push() does not
+  // re-scan these bytes.
+  preappliedAltScreenNeedsRafByTerm.set(term, needsRafFromProbe);
+
   let coalescer = terminalWriteCoalescers.get(term);
   if (!coalescer) {
     coalescer = createWriteCoalescer((batch) => {
@@ -650,9 +676,12 @@ export const enqueueCoalescedTerminalWrite = (
       // When rAF is unavailable (Node unit tests), prefer the "raf" mode so the
       // coalescer falls back to an immediate flush (legacy test contract).
       resolveScheduleMode: ({ nextChunk }): WriteCoalesceScheduleMode => {
-        // Probe always runs (handles leave while buffer is still alternate).
-        // O(chunk) parser state — no quadratic pending joins.
-        if (noteAltScreenScheduleProbe(term, nextChunk)) {
+        const preapplied = preappliedAltScreenNeedsRafByTerm.get(term);
+        if (preapplied !== undefined) {
+          preappliedAltScreenNeedsRafByTerm.delete(term);
+          if (preapplied) return "raf";
+        } else if (noteAltScreenScheduleProbe(term, nextChunk)) {
+          // Later pushes (or paths without a preapplied probe) still scan once.
           return "raf";
         }
         // Bulk pressure: prefer rAF so the browser can paint between flushes.
@@ -672,6 +701,8 @@ export const enqueueCoalescedTerminalWrite = (
     terminalWriteCoalescers.set(term, coalescer);
   }
   coalescer.push(data);
+  // If push did not consume the preapplied flag (e.g. empty/disposed), drop it.
+  preappliedAltScreenNeedsRafByTerm.delete(term);
   if (flushAfterAltScreenLeave) {
     // Do not let shell output after a TUI exit inherit a later batch timestamp.
     // Keeping the leave and its same-chunk suffix together also lets the
@@ -722,6 +753,7 @@ export const resetTerminalWriteCoalescer = (term: XTerm): void => {
   pendingAltScreenEntryByTerm.delete(term);
   observedAltScreenByTerm.delete(term);
   pendingAltScreenLeaveByTerm.delete(term);
+  preappliedAltScreenNeedsRafByTerm.delete(term);
 };
 
 export const getTerminalWriteCoalescerPendingBytes = (term: XTerm): number =>
@@ -742,6 +774,7 @@ export const abortTerminalWriteCoalescer = (
   pendingAltScreenEntryByTerm.delete(term);
   observedAltScreenByTerm.delete(term);
   pendingAltScreenLeaveByTerm.delete(term);
+  preappliedAltScreenNeedsRafByTerm.delete(term);
 
   const coalescer = terminalWriteCoalescers.get(term);
   if (!coalescer) return;

--- a/components/terminal/runtime/writeCoalescer.test.ts
+++ b/components/terminal/runtime/writeCoalescer.test.ts
@@ -192,7 +192,7 @@ test("uses a tighter pending-byte cap when getMaxPendingBytes is set", () => {
   assert.equal(writes[0]?.length, cap + 1);
 });
 
-test("does not flush cap-sized pending bytes while automatic flushing is gated", () => {
+test("byte-cap flushes even while scheduled frames are gated", () => {
   const writes: string[] = [];
   let canFlush = false;
   const cap = 8;
@@ -201,19 +201,17 @@ test("does not flush cap-sized pending bytes while automatic flushing is gated",
     shouldFlushScheduledFrame: () => canFlush,
   });
 
+  // Under the cap: gated frame holds.
   coalescer.push("x".repeat(cap));
-  coalescer.push("y");
   fireFrame();
-
   assert.deepEqual(writes, []);
 
-  canFlush = true;
-  coalescer.flushSync();
-
+  // Past the cap: drain immediately so hidden log floods stay bounded.
+  coalescer.push("y");
   assert.deepEqual(writes, ["x".repeat(cap) + "y"]);
 });
 
-test("still resolves schedule mode for gated oversize pushes (alt-screen probe)", () => {
+test("still resolves schedule mode before gated under-cap frames and cap drains", () => {
   const writes: string[] = [];
   let canFlush = false;
   const probed: string[] = [];
@@ -227,18 +225,14 @@ test("still resolves schedule mode for gated oversize pushes (alt-screen probe)"
     },
   });
 
-  // First chunk arms microtask schedule under the cap; second exceeds cap while
-  // gated — resolveScheduleMode must still run so enter-alt latches fire.
+  // First chunk arms a gated under-cap frame; second exceeds cap and drains.
+  // resolveScheduleMode must still run so enter-alt latches fire.
   coalescer.push("shell");
   coalescer.push(`\x1b[?1049h${"x".repeat(cap)}`);
-  fireFrame();
 
-  assert.deepEqual(writes, []);
   assert.deepEqual(probed, ["shell", `\x1b[?1049h${"x".repeat(cap)}`]);
-
-  canFlush = true;
-  coalescer.flushSync();
   assert.equal(writes.join("").includes("\x1b[?1049h"), true);
+  assert.equal(writes.join("").startsWith("shell"), true);
 });
 
 test("dispose flushes remaining bytes and stops accepting new chunks", () => {

--- a/components/terminal/runtime/writeCoalescer.ts
+++ b/components/terminal/runtime/writeCoalescer.ts
@@ -182,24 +182,16 @@ export const createWriteCoalescer = (
     const pendingBytesBefore = pendingBytes;
     pending.push(chunk);
     pendingBytes += chunk.length;
-    // Always resolve schedule mode before gated-cap returns so callers can
-    // probe enter-alt CSI (side-effect latch) even when hidden oversized
-    // pending cannot auto-flush yet. Skipping this left follow-up repaints on
-    // microtask after reveal (Codex CLI review).
+    // Always resolve schedule mode before cap drain so callers can probe
+    // enter-alt CSI (side-effect latch) even when this push immediately flushes.
     const mode = resolveScheduleMode({
       nextChunk: chunk,
       pendingBytesBefore,
     });
     if (pendingBytes > getMaxPendingBytes()) {
-      if (!shouldFlushScheduledFrame()) {
-        // Hold the batch, but keep schedule mode upgrades for any already-armed
-        // frame so a later reveal flush is not the only path that sees rAF.
-        if (cancelPendingFrame !== null && scheduledMode === "microtask" && mode === "raf") {
-          cancelScheduledFrame();
-          armSchedule("raf");
-        }
-        return;
-      }
+      // Byte-cap always drains. The frame gate only suppresses idle/rAF flushes
+      // (hidden panes); unbounded hold past the cap freezes multi-terminal log
+      // floods with multi-MB joins until a timed drain (issue #2397).
       flushSync();
       return;
     }

--- a/components/terminal/terminalContinuousRendering.test.ts
+++ b/components/terminal/terminalContinuousRendering.test.ts
@@ -15,6 +15,7 @@ test("renderer activity follows the hibernate setting instead of active-tab visi
     terminalSource,
     /const isRendererActive = isVisible \|\| !hibernateEnabled/,
   );
+  assert.match(terminalSource, /isPaneVisibleRef: isVisibleRef/);
   assert.match(terminalSource, /isVisibleRef: isRendererActiveRef/);
   assert.match(terminalSource, /if \(!isRendererActiveRef\.current && !options\?\.allowHidden\)/);
   assert.match(

--- a/components/terminal/terminalHibernateFlush.test.ts
+++ b/components/terminal/terminalHibernateFlush.test.ts
@@ -54,6 +54,24 @@ test("full hibernate flushes pending hidden output before taking the snapshot", 
   assert.ok(snapshotIndex < releaseIndex, "release flow only after snapshot");
 });
 
+test("live context reads flush pending hidden output before reading the buffer", () => {
+  const source = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
+  const body = readFunctionBody(
+    source,
+    "const readTerminalContext = useCallback<TerminalContextReader>(async (request) =>",
+  );
+
+  const flushIndex = body.indexOf("await flushPendingTerminalWritesBeforeHibernate(targetTerm)");
+  const drainGuardIndex = body.indexOf("if (!flushed)");
+  const bufferReadIndex = body.indexOf("term.buffer.active");
+
+  assert.notEqual(flushIndex, -1, "context reads must flush pending terminal writes");
+  assert.notEqual(drainGuardIndex, -1, "context reads must reject an incomplete drain");
+  assert.notEqual(bufferReadIndex, -1, "context reads must inspect the live terminal buffer");
+  assert.ok(flushIndex < drainGuardIndex, "check the drain result after flushing");
+  assert.ok(flushIndex < bufferReadIndex, "flush pending writes before reading the live buffer");
+});
+
 test("hibernate retry preserves normal hibernate blockers", () => {
   const source = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
   const body = readFunctionBody(source, "const scheduleHibernateRetry = useCallback(() =>");

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -714,6 +714,13 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         return;
       }
 
+      const term = termRef.current;
+      if (term) {
+        // Hidden output can still be inside the delayed coalescer. Capture only
+        // after it has reached both the log buffer and xterm.
+        flushPendingTerminalWritesOnResume(term);
+      }
+
       const persistCloseCapture = (data: string, source: string, dataLength: number) => {
         logger.info("[Terminal] Capturing data on unmount", {
           sessionId,
@@ -736,7 +743,6 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         return;
       }
 
-      const term = termRef.current;
       const serializeAddon = serializeAddonRef.current;
       if (!terminalDataCapturedRef.current && term && serializeAddon) {
         const preferWasm = resolveHibernatePreferWasmSerialize(terminalSettingsRef.current);

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -36,6 +36,7 @@ import {
 } from './terminalHibernateRuntime';
 import {
   cancelScheduledUnfocusedRepaint,
+  flushPendingTerminalWritesBeforeHibernate,
   flushPendingTerminalWritesOnResume,
   forceTerminalRepaintBypassingAnimationFrame,
   repaintTerminalAfterReveal,
@@ -714,13 +715,6 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         return;
       }
 
-      const term = termRef.current;
-      if (term) {
-        // Hidden output can still be inside the delayed coalescer. Capture only
-        // after it has reached both the log buffer and xterm.
-        flushPendingTerminalWritesOnResume(term);
-      }
-
       const persistCloseCapture = (data: string, source: string, dataLength: number) => {
         logger.info("[Terminal] Capturing data on unmount", {
           sessionId,
@@ -730,24 +724,44 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         handleTerminalDataCaptureOnce(sessionId, data, { finalized: true });
       };
 
-      const connectionLogPayload = !terminalDataCapturedRef.current
-        ? resolveConnectionLogCapturePayload(finalizeTerminalLogData)
-        : null;
-      if (connectionLogPayload) {
-        persistCloseCapture(
-          connectionLogPayload.data,
-          connectionLogPayload.source,
-          connectionLogPayload.data.length,
-        );
-        scheduleTerminalCloseTeardown(teardown);
-        return;
-      }
+      const term = termRef.current;
+      const completeClose = async () => {
+        if (term) {
+          // A hidden terminal can have more output queued than the synchronous
+          // resume helper intentionally drains. Wait for the complete ordered
+          // backlog before finalizing the saved capture.
+          const flushed = await flushPendingTerminalWritesBeforeHibernate(term);
+          if (!isTerminalCloseGenerationCurrent(
+            closeGeneration,
+            terminalBootCloseGenerationRef.current,
+          )) {
+            return;
+          }
+          if (!flushed) {
+            logger.warn("Terminal output did not drain before close capture; skipping stale capture");
+            teardown();
+            return;
+          }
+        }
 
-      const serializeAddon = serializeAddonRef.current;
-      if (!terminalDataCapturedRef.current && term && serializeAddon) {
-        const preferWasm = resolveHibernatePreferWasmSerialize(terminalSettingsRef.current);
-        void serializeTerminalCloseFallback(term, serializeAddon, { preferWasm })
-          .then((payload) => {
+        const connectionLogPayload = !terminalDataCapturedRef.current
+          ? resolveConnectionLogCapturePayload(finalizeTerminalLogData)
+          : null;
+        if (connectionLogPayload) {
+          persistCloseCapture(
+            connectionLogPayload.data,
+            connectionLogPayload.source,
+            connectionLogPayload.data.length,
+          );
+          scheduleTerminalCloseTeardown(teardown);
+          return;
+        }
+
+        const serializeAddon = serializeAddonRef.current;
+        if (!terminalDataCapturedRef.current && term && serializeAddon) {
+          const preferWasm = resolveHibernatePreferWasmSerialize(terminalSettingsRef.current);
+          try {
+            const payload = await serializeTerminalCloseFallback(term, serializeAddon, { preferWasm });
             if (!isTerminalCloseGenerationCurrent(
               closeGeneration,
               terminalBootCloseGenerationRef.current,
@@ -758,8 +772,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
               persistCloseCapture(payload.data, payload.source, payload.data.length);
             }
             scheduleTerminalCloseTeardown(teardown);
-          })
-          .catch((err) => {
+          } catch (err) {
             if (!isTerminalCloseGenerationCurrent(
               closeGeneration,
               terminalBootCloseGenerationRef.current,
@@ -768,11 +781,14 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
             }
             logger.warn("Failed to serialize terminal data on unmount:", err);
             scheduleTerminalCloseTeardown(teardown);
-          });
-        return;
-      }
+          }
+          return;
+        }
 
-      teardown();
+        teardown();
+      };
+
+      void completeClose();
     };
      
   }, [forceCloseHibernatedSession, handleTerminalDataCaptureOnce, host.id, sessionId]);


### PR DESCRIPTION
## Summary

- distinguish actual pane visibility from a hidden renderer that remains active
- batch continuous hidden-tab output on the existing background drain
- preserve output order and line times when hidden batches are drained
- amortize timestamp-history cleanup so short batches stay cheap over long sessions

## Confirmed contributing path

When hidden-tab hibernation is disabled, inactive terminals keep their renderers active. The output pipeline treated that renderer state as actual pane visibility, so every small PTY chunk from hidden `tail -f`-style sessions was flushed and timestamped synchronously. This is a confirmed high-CPU path in the reported scenario, but the original long-running issue was not reproduced end to end locally.

## Validation

- live test with two hidden SSH terminals at about 50 lines/s each: renderer CPU dropped from about 77–85% to about 10–12%; switching tabs showed current, continuous output
- focused terminal output suite: 108/108 passed after review fixes
- 100k-line timestamp history plus 100 short batches: about 858 ms before the review fix, about 0.84 ms after
- `npm run lint`
- `npm run build`
- local `npm test`: 6590 passed, 7 skipped, 1 unrelated SSH auth-retry test failed; it also fails when run alone, and this PR does not change that code or test

Related to #2397
