### PR TITLE
fix(plugin): revoke session grants after worker exit

### DIFF
--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -982,6 +982,7 @@ function createTerminalWorkerManager(options = {}) {
       } catch {}
     }
     for (const [sessionId, webContentsId] of sessionWebContentsIds.entries()) {
+      notifySessionClosed(sessionId, "worker-exit");
       const targets = new Set();
       if (webContentsId != null) targets.add(webContentsId);
       const homeId = attachHomeWebContentsIds.get(sessionId);

--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -195,11 +195,19 @@ function createTerminalWorkerManager(options = {}) {
   const pendingOutput = new Map();
   const pendingOutputBytes = new Map();
   const closedSessions = new Set();
-  const outputPortPending = new Set();
+  const closedSessionSequences = new Map();
+  let sessionLifecycleSequence = 0;
+  const outputPortPending = new Map();
   const outputPortReady = new Set();
   const outputRoutePending = new Map();
+  const pendingSessionStartSequences = new Map();
+  const latestSessionStartSequences = new Map();
+  const suppressedPendingOutputSessions = new Set();
+  const workerSessionIds = new Set();
   const sessionWebContentsIds = new Map();
   const sessionGenerations = new Map();
+  const closedSessionGenerations = new Map();
+  const supersedingSessionGenerations = new Map();
   const urgentInputPorts = new Map();
   const outputTaps = new Set();
   const terminalInterceptorWarningListeners = new Set();
@@ -365,7 +373,7 @@ function createTerminalWorkerManager(options = {}) {
   function bufferOutput(sessionId, data, meta) {
     if (
       !sessionId
-      || closedSessions.has(sessionId)
+      || (closedSessions.has(sessionId) && !hasPendingSessionLifecycle(sessionId))
       || maxPendingOutputChunks === 0
       || maxPendingOutputBytes === 0
     ) {
@@ -435,7 +443,7 @@ function createTerminalWorkerManager(options = {}) {
     }
   }
 
-  async function openOutputSession(sessionId, webContentsId) {
+  async function openOutputSession(sessionId, webContentsId, isStillCurrent = null) {
     if (!sessionId || !webContentsId) return false;
     if (closedSessions.has(sessionId)) {
       clearBufferedOutput(sessionId);
@@ -462,6 +470,12 @@ function createTerminalWorkerManager(options = {}) {
       contents.removeListener?.("destroyed", onDestroyed);
     }
     if (closedSessions.has(sessionId)) return false;
+    if (isStillCurrent && !isStillCurrent()) {
+      if (outputRoutePending.get(sessionId) === openToken) {
+        outputRoutePending.delete(sessionId);
+      }
+      return false;
+    }
     if (outputRoutePending.get(sessionId) !== openToken) {
       return outputRoutePending.get(sessionId)?.webContentsId === webContentsId;
     }
@@ -475,6 +489,7 @@ function createTerminalWorkerManager(options = {}) {
     let openedUrgentInputPort = false;
     let replacedOutputChannel = false;
     let transferringBufferedOutput = [];
+    let workerIpcFailed = false;
     try {
       sessionWebContentsIds.set(sessionId, webContentsId);
       openedUrgentInputPort = openUrgentInputPort(webContentsId, contents);
@@ -483,13 +498,25 @@ function createTerminalWorkerManager(options = {}) {
       });
       replacedOutputChannel = Boolean(outputPort);
       if (outputPort && outputPort !== true && child?.postMessage) {
-        outputPortPending.add(sessionId);
+        const worker = child;
+        const outputPortRequestId = randomUUID();
+        const sessionGeneration = sessionGenerations.get(sessionId) ?? 0;
+        outputPortReady.delete(sessionId);
+        outputPortPending.set(sessionId, outputPortRequestId);
         transferringBufferedOutput = takeBufferedOutput(sessionId);
-        child.postMessage({
-          kind: "output-port",
-          sessionId,
-          bufferedOutput: transferringBufferedOutput,
-        }, [outputPort]);
+        try {
+          worker.postMessage({
+            kind: "output-port",
+            sessionId,
+            outputPortRequestId,
+            sessionGeneration,
+            bufferedOutput: transferringBufferedOutput,
+          }, [outputPort]);
+        } catch (error) {
+          workerIpcFailed = true;
+          retireWorkerAfterIpcFailure(worker, error);
+          throw error;
+        }
         transferringBufferedOutput = [];
         if (outputRoutePending.get(sessionId) === openToken) {
           outputRoutePending.delete(sessionId);
@@ -502,6 +529,7 @@ function createTerminalWorkerManager(options = {}) {
       flushBufferedOutput(sessionId);
       return true;
     } catch {
+      if (workerIpcFailed) return false;
       for (const chunk of transferringBufferedOutput) {
         bufferOutput(sessionId, chunk);
       }
@@ -655,20 +683,118 @@ function createTerminalWorkerManager(options = {}) {
     if (sessionId) attachHomeWebContentsIds.delete(sessionId);
   }
 
+  function markSessionClosed(sessionId) {
+    if (!sessionId || closedSessions.has(sessionId)) return;
+    closedSessions.add(sessionId);
+    closedSessionSequences.set(sessionId, ++sessionLifecycleSequence);
+  }
+
+  function cancelPendingSessionStart(sessionId) {
+    if (!pendingSessionStartSequences.delete(sessionId)) return;
+    if (closedSessions.has(sessionId)) {
+      closedSessionSequences.set(sessionId, ++sessionLifecycleSequence);
+    }
+  }
+
+  function finishPendingSessionStart(entry) {
+    if (entry?.requestedSessionId
+      && pendingSessionStartSequences.get(entry.requestedSessionId) === entry.requestSequence) {
+      pendingSessionStartSequences.delete(entry.requestedSessionId);
+    }
+  }
+
+  function hasPendingSessionLifecycle(sessionId) {
+    const pendingStartSequence = pendingSessionStartSequences.get(sessionId);
+    const closedSequence = closedSessionSequences.get(sessionId);
+    return pendingStartSequence != null
+      && (closedSequence == null || pendingStartSequence > closedSequence);
+  }
+
+  function recordClosedSessionGeneration(sessionId, generation) {
+    if (!sessionId || !Number.isSafeInteger(generation)) return;
+    const previous = closedSessionGenerations.get(sessionId);
+    if (previous == null || generation > previous) {
+      closedSessionGenerations.set(sessionId, generation);
+    }
+  }
+
+  function recordSupersedingSessionGeneration(message) {
+    if (!message?.sessionId
+      || !Number.isSafeInteger(message.sessionGeneration)
+      || !message.replacementRequestId) return;
+    const entry = pending.get(message.replacementRequestId);
+    if (!entry?.requestedSessionId || entry.requestedSessionId !== message.sessionId) return;
+    let generations = supersedingSessionGenerations.get(message.sessionId);
+    if (!generations) {
+      generations = new Map();
+      supersedingSessionGenerations.set(message.sessionId, generations);
+    }
+    generations.set(message.sessionGeneration, {
+      requestId: message.replacementRequestId,
+      requestSequence: entry.requestSequence,
+    });
+  }
+
+  function takeSupersedingSessionGeneration(sessionId, generation) {
+    if (!sessionId || !Number.isSafeInteger(generation)) return null;
+    const generations = supersedingSessionGenerations.get(sessionId);
+    const marker = generations?.get(generation) ?? null;
+    if (!marker) return null;
+    generations.delete(generation);
+    if (generations.size === 0) supersedingSessionGenerations.delete(sessionId);
+    return marker;
+  }
+
+  function clearOlderSupersedingSessionGenerations(sessionId, generation) {
+    if (!sessionId || !Number.isSafeInteger(generation)) return;
+    const generations = supersedingSessionGenerations.get(sessionId);
+    if (!generations) return;
+    for (const oldGeneration of generations.keys()) {
+      if (oldGeneration < generation) generations.delete(oldGeneration);
+    }
+    if (generations.size === 0) supersedingSessionGenerations.delete(sessionId);
+  }
+
+  function isOutputFromNewerGeneration(message) {
+    if (!Number.isSafeInteger(message?.sessionGeneration)) return false;
+    const closedGeneration = closedSessionGenerations.get(message.sessionId);
+    return message.sessionGeneration > (closedGeneration ?? 0);
+  }
+
+  function isOutputFromCurrentPendingStart(message) {
+    if (!Number.isSafeInteger(message?.sessionGeneration)) return false;
+    if (!message?.originRequestId) return isOutputFromNewerGeneration(message);
+    const entry = pending.get(message.originRequestId);
+    const latestStartSequence = latestSessionStartSequences.get(message.sessionId);
+    const isCurrentRequest = entry?.requestedSessionId === message.sessionId
+      && latestStartSequence != null
+      && entry.requestSequence === latestStartSequence;
+    if (!isCurrentRequest) return false;
+    const closedGeneration = closedSessionGenerations.get(message.sessionId);
+    return closedGeneration == null || message.sessionGeneration > closedGeneration;
+  }
+
   function closeOutputSession(sessionId) {
     if (!sessionId) return;
-    closedSessions.add(sessionId);
+    markSessionClosed(sessionId);
+    latestSessionStartSequences.delete(sessionId);
+    suppressedPendingOutputSessions.delete(sessionId);
+    workerSessionIds.delete(sessionId);
     clearBufferedOutput(sessionId);
     outputRoutePending.delete(sessionId);
     outputPortPending.delete(sessionId);
     outputPortReady.delete(sessionId);
     sessionWebContentsIds.delete(sessionId);
+    const activeGeneration = sessionGenerations.get(sessionId);
+    recordClosedSessionGeneration(sessionId, activeGeneration);
     sessionGenerations.delete(sessionId);
+    supersedingSessionGenerations.delete(sessionId);
     clearAttachHome(sessionId);
+    const worker = child;
     try {
-      child?.postMessage?.({ kind: "close-output-port", sessionId });
-    } catch {
-      // The worker may already be gone while closing a tab or quitting.
+      worker?.postMessage?.({ kind: "close-output-port", sessionId });
+    } catch (error) {
+      retireWorkerAfterIpcFailure(worker, error);
     }
     terminalOutputChannel?.closeSession?.(sessionId);
   }
@@ -702,10 +828,12 @@ function createTerminalWorkerManager(options = {}) {
 
   function drainOutputSession(sessionId, requestId) {
     if (!sessionId || !requestId || !outputPortReady.has(sessionId)) return false;
+    const worker = ensureStarted();
     try {
-      ensureStarted().postMessage({ kind: "output-drain", sessionId, requestId });
+      worker.postMessage({ kind: "output-drain", sessionId, requestId });
       return true;
-    } catch {
+    } catch (error) {
+      retireWorkerAfterIpcFailure(worker, error);
       return false;
     }
   }
@@ -753,10 +881,12 @@ function createTerminalWorkerManager(options = {}) {
   function flushOutputToWorker(sessionId) {
     const chunks = takeBufferedOutput(sessionId);
     if (!chunks.length || closedSessions.has(sessionId)) return;
+    const worker = child;
     try {
-      child?.postMessage?.({ kind: "output-flush", sessionId, chunks });
-    } catch {
+      worker?.postMessage?.({ kind: "output-flush", sessionId, chunks });
+    } catch (error) {
       for (const chunk of chunks) bufferOutput(sessionId, chunk);
+      retireWorkerAfterIpcFailure(worker, error);
     }
   }
 
@@ -783,32 +913,92 @@ function createTerminalWorkerManager(options = {}) {
   function handleMessage(eventOrMessage) {
     const message = unwrapMessageEvent(eventOrMessage);
     if (!message || typeof message !== "object") return;
+    if (message.kind === "session-superseding") {
+      recordSupersedingSessionGeneration(message);
+      return;
+    }
     if (message.kind === "response") {
       const entry = pending.get(message.requestId);
       if (!entry) return;
       if (message.error) {
+        if (entry.opensOutputSession && entry.requestedSessionId
+          && latestSessionStartSequences.get(entry.requestedSessionId) === entry.requestSequence) {
+          clearBufferedOutput(entry.requestedSessionId);
+          suppressedPendingOutputSessions.add(entry.requestedSessionId);
+          if (!sessionWebContentsIds.has(entry.requestedSessionId)
+            && !outputRoutePending.has(entry.requestedSessionId)) {
+            workerSessionIds.delete(entry.requestedSessionId);
+          }
+        }
+        finishPendingSessionStart(entry);
         pending.delete(message.requestId);
         entry.reject(new Error(message.error));
       } else {
         const sessionId = message.result?.sessionId;
         if (!entry.opensOutputSession || !sessionId) {
+          finishPendingSessionStart(entry);
           pending.delete(message.requestId);
           entry.resolve(message.result);
           return;
         }
+        const latestStartSequence = latestSessionStartSequences.get(sessionId);
+        if (latestStartSequence != null && entry.requestSequence < latestStartSequence) {
+          if (Number.isSafeInteger(message.sessionGeneration)) {
+            recordClosedSessionGeneration(sessionId, message.sessionGeneration);
+          }
+          finishPendingSessionStart(entry);
+          pending.delete(message.requestId);
+          entry.reject(new Error("Terminal session was superseded by a newer start request"));
+          return;
+        }
+        const closedSequence = closedSessionSequences.get(sessionId);
+        if (closedSequence != null && closedSequence >= entry.requestSequence) {
+          recordClosedSessionGeneration(sessionId, message.sessionGeneration);
+          finishPendingSessionStart(entry);
+          pending.delete(message.requestId);
+          entry.reject(new Error("Terminal session closed before its output route opened"));
+          return;
+        }
+        suppressedPendingOutputSessions.delete(sessionId);
+        closedSessionGenerations.delete(sessionId);
+        closedSessions.delete(sessionId);
+        closedSessionSequences.delete(sessionId);
+        workerSessionIds.add(sessionId);
         if (Number.isSafeInteger(message.sessionGeneration)) {
           sessionGenerations.set(sessionId, message.sessionGeneration);
+          clearOlderSupersedingSessionGenerations(sessionId, message.sessionGeneration);
         }
-        void openOutputSession(sessionId, entry.webContentsId).then((opened) => {
+        const isStillCurrent = () => {
+          if (!entry.requestedSessionId) return true;
+          const latestSequence = latestSessionStartSequences.get(sessionId);
+          const currentClosedSequence = closedSessionSequences.get(sessionId);
+          return latestSequence === entry.requestSequence
+            && !(currentClosedSequence != null && currentClosedSequence >= entry.requestSequence);
+        };
+        void openOutputSession(sessionId, entry.webContentsId, isStillCurrent).then((opened) => {
           if (pending.get(message.requestId) !== entry) return;
+          finishPendingSessionStart(entry);
           pending.delete(message.requestId);
           if (!opened) {
-            entry.reject(new Error("Terminal session closed before its output route opened"));
+            const currentClosedSequence = closedSessionSequences.get(sessionId);
+            if (currentClosedSequence != null && currentClosedSequence >= entry.requestSequence) {
+              entry.reject(new Error("Terminal session closed before its output route opened"));
+            } else if (entry.requestedSessionId
+              && latestSessionStartSequences.get(sessionId) !== entry.requestSequence) {
+              recordClosedSessionGeneration(sessionId, message.sessionGeneration);
+              if (sessionGenerations.get(sessionId) === message.sessionGeneration) {
+                sessionGenerations.delete(sessionId);
+              }
+              entry.reject(new Error("Terminal session was superseded by a newer start request"));
+            } else {
+              entry.reject(new Error("Terminal session closed before its output route opened"));
+            }
             return;
           }
           entry.resolve(message.result);
         }, (error) => {
           if (pending.get(message.requestId) !== entry) return;
+          finishPendingSessionStart(entry);
           pending.delete(message.requestId);
           entry.reject(error);
         });
@@ -816,7 +1006,15 @@ function createTerminalWorkerManager(options = {}) {
       return;
     }
     if (message.kind === "output") {
-      if (closedSessions.has(message.sessionId)) return;
+      if (suppressedPendingOutputSessions.has(message.sessionId)
+        && !isOutputFromCurrentPendingStart(message)) return;
+      if (closedSessions.has(message.sessionId)) {
+        if (!hasPendingSessionLifecycle(message.sessionId)
+          || !isOutputFromCurrentPendingStart(message)) return;
+        bufferOutput(message.sessionId, message.data, message.meta);
+        return;
+      }
+      if (message.sessionId) workerSessionIds.add(message.sessionId);
       // Chunks sent through the runtime sender's port fallback were already
       // announced via a dedicated output-tap message (message.tapped);
       // notifying taps again here would double-write session logs and
@@ -839,12 +1037,21 @@ function createTerminalWorkerManager(options = {}) {
       return;
     }
     if (message.kind === "output-tap") {
-      if (!closedSessions.has(message.sessionId)) {
+      if (suppressedPendingOutputSessions.has(message.sessionId)
+        && !isOutputFromCurrentPendingStart(message)) return;
+      if (!closedSessions.has(message.sessionId)
+        || (hasPendingSessionLifecycle(message.sessionId)
+          && isOutputFromCurrentPendingStart(message))) {
+        if (message.sessionId) workerSessionIds.add(message.sessionId);
         notifyOutputTaps(message.sessionId, message.data);
       }
       return;
     }
     if (message.kind === "output-port-ready") {
+      if (!message.outputPortRequestId
+        || outputPortPending.get(message.sessionId) !== message.outputPortRequestId
+        || !Number.isSafeInteger(message.sessionGeneration)
+        || (sessionGenerations.get(message.sessionId) ?? 0) !== message.sessionGeneration) return;
       outputPortPending.delete(message.sessionId);
       if (!closedSessions.has(message.sessionId)) {
         outputPortReady.add(message.sessionId);
@@ -862,9 +1069,75 @@ function createTerminalWorkerManager(options = {}) {
       // Prefer the currently rebound display target. Worker-captured
       // webContentsId is from session start and goes stale after attach/rebind.
       const sessionId = message.payload?.sessionId;
+      const originEntry = message.originRequestId
+        ? pending.get(message.originRequestId)
+        : null;
+      const latestStartSequence = latestSessionStartSequences.get(sessionId);
       if (message.channel === "netcatty:exit"
         && Number.isSafeInteger(message.sessionGeneration)
-        && sessionGenerations.get(sessionId) !== message.sessionGeneration) {
+      ) {
+        const closedGeneration = closedSessionGenerations.get(sessionId);
+        if (closedGeneration != null && message.sessionGeneration <= closedGeneration) return;
+        if (sessionGenerations.has(sessionId)
+          && sessionGenerations.get(sessionId) !== message.sessionGeneration) {
+          return;
+        }
+      }
+      const supersedingMarker = message.channel === "netcatty:exit"
+        ? takeSupersedingSessionGeneration(sessionId, message.sessionGeneration)
+        : null;
+      const isSupersededActiveExit = Boolean(
+        supersedingMarker
+        && latestStartSequence != null
+        && latestStartSequence >= supersedingMarker.requestSequence
+        && hasPendingSessionLifecycle(sessionId),
+      );
+      if (isSupersededActiveExit) {
+        const displayWebContentsId = sessionWebContentsIds.get(sessionId) ?? message.webContentsId;
+        const homeWebContentsId = attachHomeWebContentsIds.get(sessionId) ?? null;
+        recordClosedSessionGeneration(sessionId, message.sessionGeneration);
+        clearBufferedOutput(sessionId);
+        outputRoutePending.delete(sessionId);
+        outputPortPending.delete(sessionId);
+        outputPortReady.delete(sessionId);
+        workerSessionIds.delete(sessionId);
+        sessionWebContentsIds.delete(sessionId);
+        if (sessionGenerations.get(sessionId) === message.sessionGeneration) {
+          sessionGenerations.delete(sessionId);
+        }
+        clearAttachHome(sessionId);
+        terminalOutputChannel?.closeSession?.(sessionId);
+        suppressedPendingOutputSessions.add(sessionId);
+        notifySessionClosed(sessionId, message.payload?.reason || "superseded");
+        const targets = new Set([displayWebContentsId, homeWebContentsId]);
+        if (onRendererEvent) {
+          for (const webContentsId of targets) {
+            if (webContentsId == null) continue;
+            onRendererEvent({ ...message, webContentsId });
+          }
+        } else {
+          for (const webContentsId of targets) {
+            if (webContentsId == null) continue;
+            electronModule?.webContents?.fromId?.(webContentsId)?.send?.(
+              message.channel,
+              message.payload,
+            );
+          }
+        }
+        return;
+      }
+      const isSupersededStartExit = message.channel === "netcatty:exit"
+        && originEntry?.requestedSessionId === sessionId
+        && latestStartSequence != null
+        && originEntry.requestSequence < latestStartSequence;
+      if (isSupersededStartExit) {
+        recordClosedSessionGeneration(sessionId, message.sessionGeneration);
+        clearBufferedOutput(sessionId);
+        workerSessionIds.delete(sessionId);
+        finishPendingSessionStart(originEntry);
+        pending.delete(message.originRequestId);
+        originEntry.reject(new Error("Terminal session was superseded by a newer start request"));
+        notifySessionClosed(sessionId, message.payload?.reason);
         return;
       }
       const displayWebContentsId =
@@ -877,14 +1150,19 @@ function createTerminalWorkerManager(options = {}) {
       const wasExplicitlyClosed = Boolean(
         message.channel === "netcatty:exit"
         && sessionId
-        && closedSessions.has(sessionId),
+        && closedSessions.has(sessionId)
+        && !hasPendingSessionLifecycle(sessionId),
       );
       if (message.channel === "netcatty:exit" && sessionId) {
+        if (Number.isSafeInteger(message.sessionGeneration)) {
+          recordClosedSessionGeneration(sessionId, message.sessionGeneration);
+        }
+        cancelPendingSessionStart(sessionId);
+        closeOutputSession(sessionId);
+        clearAttachHome(sessionId);
         if (!wasExplicitlyClosed) {
           notifySessionClosed(sessionId, message.payload?.reason);
         }
-        closeOutputSession(sessionId);
-        clearAttachHome(sessionId);
       }
       // Explicit close already notified both display and home before removing
       // their routes. Ignore the worker's later transport-level exit event.
@@ -973,20 +1251,66 @@ function createTerminalWorkerManager(options = {}) {
     }
   }
 
-  function handleExit(code) {
-    const error = new Error(`Terminal worker exited${Number.isFinite(code) ? ` with code ${code}` : ""}`);
+  function retireWorkerAfterIpcFailure(worker, error) {
+    if (!worker || child !== worker) return;
+    handleExit(1, error);
+    try { worker.kill?.(); } catch {}
+  }
+
+  function handleExit(code, cause = null) {
+    const error = cause instanceof Error
+      ? cause
+      : new Error(`Terminal worker exited${Number.isFinite(code) ? ` with code ${code}` : ""}`);
     const exitCode = Number.isFinite(code) ? code : 1;
+    const affectedSessionIds = new Set([
+      ...sessionWebContentsIds.keys(),
+      ...outputRoutePending.keys(),
+      ...workerSessionIds,
+      ...pendingOutput.keys(),
+      ...pendingSessionStartSequences.keys(),
+    ]);
+    const sessionNotifications = [];
+    for (const sessionId of affectedSessionIds) {
+      const hasNewPendingLifecycle = hasPendingSessionLifecycle(sessionId);
+      if (closedSessions.has(sessionId) && !hasNewPendingLifecycle) continue;
+      if (closedSessions.has(sessionId)) {
+        closedSessionSequences.set(sessionId, ++sessionLifecycleSequence);
+      } else {
+        markSessionClosed(sessionId);
+      }
+      const targets = new Set();
+      const webContentsId = sessionWebContentsIds.get(sessionId);
+      if (webContentsId != null) targets.add(webContentsId);
+      const pendingWebContentsId = outputRoutePending.get(sessionId)?.webContentsId;
+      if (pendingWebContentsId != null) targets.add(pendingWebContentsId);
+      const homeId = attachHomeWebContentsIds.get(sessionId);
+      if (homeId != null) targets.add(homeId);
+      sessionNotifications.push({ sessionId, targets });
+    }
+    child = null;
+    pendingOutput.clear();
+    pendingOutputBytes.clear();
+    outputPortPending.clear();
+    outputPortReady.clear();
+    outputRoutePending.clear();
+    pendingSessionStartSequences.clear();
+    latestSessionStartSequences.clear();
+    suppressedPendingOutputSessions.clear();
+    workerSessionIds.clear();
+    sessionWebContentsIds.clear();
+    sessionGenerations.clear();
+    closedSessionGenerations.clear();
+    supersedingSessionGenerations.clear();
+    attachHomeWebContentsIds.clear();
+    closeAllUrgentInputPorts();
+    rejectAllPending(error);
+    terminalOutputChannel?.closeAll?.();
     for (const listener of [...terminalInterceptorWarningListeners]) {
       try {
         listener(Object.freeze({ code: "worker-exit", message: error.message }));
       } catch {}
     }
-    for (const [sessionId, webContentsId] of sessionWebContentsIds.entries()) {
-      notifySessionClosed(sessionId, "worker-exit");
-      const targets = new Set();
-      if (webContentsId != null) targets.add(webContentsId);
-      const homeId = attachHomeWebContentsIds.get(sessionId);
-      if (homeId != null) targets.add(homeId);
+    for (const { sessionId, targets } of sessionNotifications) {
       for (const targetId of targets) {
         try {
           const contents = electronModule?.webContents?.fromId?.(targetId);
@@ -1000,20 +1324,8 @@ function createTerminalWorkerManager(options = {}) {
           // Ignore renderer notification failures while unwinding a crashed worker.
         }
       }
+      notifySessionClosed(sessionId, "worker-exit");
     }
-    child = null;
-    pendingOutput.clear();
-    pendingOutputBytes.clear();
-    closedSessions.clear();
-    outputPortPending.clear();
-    outputPortReady.clear();
-    outputRoutePending.clear();
-    sessionWebContentsIds.clear();
-    sessionGenerations.clear();
-    attachHomeWebContentsIds.clear();
-    closeAllUrgentInputPorts();
-    terminalOutputChannel?.closeAll?.();
-    rejectAllPending(error);
   }
 
   function ensureStarted() {
@@ -1021,47 +1333,106 @@ function createTerminalWorkerManager(options = {}) {
     if (!utilityProcess?.fork) {
       throw new Error("Electron utilityProcess is unavailable");
     }
-    child = utilityProcess.fork(workerScriptPath);
-    child.on?.("message", handleMessage);
-    child.on?.("exit", handleExit);
-    return child;
+    const worker = utilityProcess.fork(workerScriptPath);
+    child = worker;
+    worker.on?.("message", (message) => {
+      if (child === worker) handleMessage(message);
+    });
+    worker.on?.("exit", (code) => {
+      if (child === worker) handleExit(code);
+    });
+    return worker;
   }
 
   function request(channel, payload, optionsForRequest = {}) {
+    if (channel === "netcatty:close:await"
+      && payload?.sessionId
+      && closedSessions.has(payload.sessionId)
+      && !pendingSessionStartSequences.has(payload.sessionId)) {
+      return Promise.resolve(undefined);
+    }
     const requestId = randomUUID();
     const worker = ensureStarted();
+    const requestSequence = ++sessionLifecycleSequence;
+    const requestedSessionId = payload?.sessionId && SESSION_START_CHANNELS.has(channel)
+      ? payload.sessionId
+      : null;
     const promise = new Promise((resolve, reject) => {
       pending.set(requestId, {
         resolve,
         reject,
+        requestSequence,
+        requestedSessionId,
         webContentsId: optionsForRequest.webContentsId,
         opensOutputSession: channel === "netcatty:start"
           || channel === "netcatty:local:reconnect"
           || /^(?:netcatty:)(?:local|telnet|mosh|et|serial):start$/u.test(channel),
       });
     });
+    let notifyClosedAfterPost = false;
     if (channel === "netcatty:close:await" && payload?.sessionId) {
+      const closesPendingLifecycle = hasPendingSessionLifecycle(payload.sessionId);
+      notifyClosedAfterPost = !closedSessions.has(payload.sessionId) || closesPendingLifecycle;
+      cancelPendingSessionStart(payload.sessionId);
       notifyExplicitSessionClose(payload.sessionId);
-      if (!closedSessions.has(payload.sessionId)) notifySessionClosed(payload.sessionId, "closed");
       closeOutputSession(payload.sessionId);
-    } else if (payload?.sessionId && SESSION_START_CHANNELS.has(channel)) {
-      closedSessions.delete(payload.sessionId);
+    } else if (requestedSessionId) {
+      if (pendingSessionStartSequences.has(requestedSessionId)) {
+        clearBufferedOutput(requestedSessionId);
+        suppressedPendingOutputSessions.add(requestedSessionId);
+      }
+      pendingSessionStartSequences.set(requestedSessionId, requestSequence);
+      latestSessionStartSequences.set(requestedSessionId, requestSequence);
     }
-    worker.postMessage({
-      kind: "request",
-      requestId,
-      channel,
-      payload,
-      webContentsId: optionsForRequest.webContentsId,
-    });
+    try {
+      worker.postMessage({
+        kind: "request",
+        requestId,
+        channel,
+        payload,
+        webContentsId: optionsForRequest.webContentsId,
+      });
+    } catch (error) {
+      retireWorkerAfterIpcFailure(worker, error);
+      const entry = pending.get(requestId);
+      pending.delete(requestId);
+      finishPendingSessionStart(entry);
+      entry?.reject(error);
+    }
+    if (notifyClosedAfterPost) notifySessionClosed(payload.sessionId, "closed");
     return promise;
   }
 
   function send(channel, payload, optionsForSend = {}) {
-    if (channel === "netcatty:close" && payload?.sessionId) {
-      notifyExplicitSessionClose(payload.sessionId);
-      if (!closedSessions.has(payload.sessionId)) notifySessionClosed(payload.sessionId, "closed");
+    if (channel === "netcatty:close"
+      && payload?.sessionId
+      && closedSessions.has(payload.sessionId)
+      && !pendingSessionStartSequences.has(payload.sessionId)) {
       closeOutputSession(payload.sessionId);
+      return;
+    }
+    if (channel === "netcatty:close" && payload?.sessionId) {
+      const closesPendingLifecycle = hasPendingSessionLifecycle(payload.sessionId);
+      const shouldNotifyClosed = !closedSessions.has(payload.sessionId) || closesPendingLifecycle;
+      cancelPendingSessionStart(payload.sessionId);
+      notifyExplicitSessionClose(payload.sessionId);
+      closeOutputSession(payload.sessionId);
+      let postError = null;
+      const worker = ensureStarted();
+      try {
+        worker.postMessage({
+          kind: "send",
+          channel,
+          payload,
+          webContentsId: optionsForSend.webContentsId,
+        });
+      } catch (error) {
+        retireWorkerAfterIpcFailure(worker, error);
+        postError = error;
+      }
+      if (shouldNotifyClosed) notifySessionClosed(payload.sessionId, "closed");
+      if (postError) throw postError;
+      return;
     }
     if (channel === "netcatty:interrupt") {
       const trace = normalizeTrace(payload);
@@ -1071,25 +1442,42 @@ function createTerminalWorkerManager(options = {}) {
         hasChild: Boolean(child),
       }, trace);
     }
-    ensureStarted().postMessage({
-      kind: "send",
-      channel,
-      payload,
-      webContentsId: optionsForSend.webContentsId,
-    });
+    const worker = ensureStarted();
+    try {
+      worker.postMessage({
+        kind: "send",
+        channel,
+        payload,
+        webContentsId: optionsForSend.webContentsId,
+      });
+    } catch (error) {
+      retireWorkerAfterIpcFailure(worker, error);
+      throw error;
+    }
   }
 
   function attachTerminalInterceptor(descriptor, port) {
     if (!port) throw new TypeError("Terminal interceptor port is required");
-    ensureStarted().postMessage({
-      kind: "terminal-interceptor-port",
-      ...descriptor,
-    }, [port]);
+    const worker = ensureStarted();
+    try {
+      worker.postMessage({
+        kind: "terminal-interceptor-port",
+        ...descriptor,
+      }, [port]);
+    } catch (error) {
+      retireWorkerAfterIpcFailure(worker, error);
+      throw error;
+    }
   }
 
   function detachTerminalInterceptor(sessionId, direction) {
     if (!child) return;
-    child.postMessage({ kind: "terminal-interceptor-detach", sessionId, direction });
+    const worker = child;
+    try {
+      worker.postMessage({ kind: "terminal-interceptor-detach", sessionId, direction });
+    } catch (error) {
+      retireWorkerAfterIpcFailure(worker, error);
+    }
   }
 
   function onTerminalInterceptorWarning(listener) {
@@ -1120,11 +1508,18 @@ function createTerminalWorkerManager(options = {}) {
       pendingOutput.clear();
       pendingOutputBytes.clear();
       closedSessions.clear();
+      closedSessionSequences.clear();
       outputPortPending.clear();
       outputPortReady.clear();
       outputRoutePending.clear();
+      pendingSessionStartSequences.clear();
+      latestSessionStartSequences.clear();
+      suppressedPendingOutputSessions.clear();
+      workerSessionIds.clear();
       sessionWebContentsIds.clear();
       sessionGenerations.clear();
+      closedSessionGenerations.clear();
+      supersedingSessionGenerations.clear();
       closeAllUrgentInputPorts();
       terminalInterceptorWarningListeners.clear();
       sessionOwnedListeners.clear();

--- a/electron/bridges/terminalWorkerManager.test.cjs
+++ b/electron/bridges/terminalWorkerManager.test.cjs
@@ -1957,3 +1957,47 @@ test("worker exit notifies renderers for active worker sessions", async () => {
     },
   ]);
 });
+
+test("worker exit notifies host lifecycle listeners for every active session", async () => {
+  const child = new FakeChild();
+  const closed = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: {
+      openSession() {},
+      closeAll() {},
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const first = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages[0].requestId,
+    result: { sessionId: "local-1" },
+  });
+  await first;
+
+  const second = manager.request("netcatty:local:start", {}, { webContentsId: 8 });
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages.at(-1).requestId,
+    result: { sessionId: "local-2" },
+  });
+  await second;
+
+  child.emit("exit", 1);
+
+  assert.deepEqual(closed, [
+    { sessionId: "local-1", reason: "worker-exit" },
+    { sessionId: "local-2", reason: "worker-exit" },
+  ]);
+});

--- a/electron/bridges/terminalWorkerManager.test.cjs
+++ b/electron/bridges/terminalWorkerManager.test.cjs
@@ -6,6 +6,7 @@ const {
   createTerminalWorkerManager,
   isTerminalWorkerEnabled,
 } = require("./terminalWorkerManager.cjs");
+const { createTerminalWorkerRuntime } = require("../terminalWorker/runtime.cjs");
 
 class FakeChild extends EventEmitter {
   constructor() {
@@ -23,6 +24,42 @@ class FakeChild extends EventEmitter {
   kill() {
     this.killed = true;
   }
+}
+
+class LinkedRuntimeChild extends FakeChild {
+  connectRuntime(registerBridges) {
+    let workerMessageListener = null;
+    const parentPort = {
+      on(event, listener) {
+        if (event === "message") workerMessageListener = listener;
+      },
+      postMessage: (message) => {
+        queueMicrotask(() => this.emit("message", message));
+      },
+    };
+    const runtime = createTerminalWorkerRuntime({ parentPort, registerBridges });
+    runtime.start();
+    this.workerMessageListener = (message) => workerMessageListener?.(message);
+    return runtime;
+  }
+
+  postMessage(message, transferList) {
+    super.postMessage(message, transferList);
+    queueMicrotask(() => this.workerMessageListener?.(message));
+  }
+}
+
+function emitOutputPortReady(child, sessionId) {
+  const openMessage = [...child.messages].reverse().find((message) => (
+    message.kind === "output-port" && message.sessionId === sessionId
+  ));
+  assert.ok(openMessage);
+  child.emit("message", {
+    kind: "output-port-ready",
+    sessionId,
+    sessionGeneration: openMessage.sessionGeneration,
+    outputPortRequestId: openMessage.outputPortRequestId,
+  });
 }
 
 class FakePort extends EventEmitter {
@@ -159,6 +196,43 @@ test("destroying a renderer immediately cancels its pending session ownership", 
   assert.equal(outputOpened, false);
 });
 
+test("worker exit after renderer loss still closes a session with pending ownership", async () => {
+  const child = new FakeChild();
+  const contents = new EventEmitter();
+  contents.id = 7;
+  contents.destroyed = false;
+  contents.isDestroyed = () => contents.destroyed;
+  const closed = [];
+  let releaseOwnership;
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: { openSession() {} },
+    electronModule: { webContents: { fromId: () => contents } },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionOwned(() => new Promise((resolve) => { releaseOwnership = resolve; }));
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const start = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages[0].requestId,
+    result: { sessionId: "local-1" },
+  });
+  while (!releaseOwnership) await new Promise((resolve) => setImmediate(resolve));
+
+  contents.destroyed = true;
+  contents.emit("destroyed");
+  releaseOwnership();
+  await assert.rejects(start, /output route opened/u);
+  assert.deepEqual(closed, []);
+
+  child.emit("exit", 1);
+  assert.deepEqual(closed, [{ sessionId: "local-1", reason: "worker-exit" }]);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(closed, [{ sessionId: "local-1", reason: "worker-exit" }]);
+});
+
 test("a start closed while ownership is pending rejects instead of creating a ghost session", async () => {
   const child = new FakeChild();
   let releaseOwnership;
@@ -193,6 +267,7 @@ test("a start closed while ownership is pending rejects instead of creating a gh
 
 test("a worker exit while ownership is pending rejects instead of creating a ghost session", async () => {
   const child = new FakeChild();
+  const closed = [];
   let releaseOwnership;
   let outputOpened = false;
   const manager = createTerminalWorkerManager({
@@ -206,6 +281,7 @@ test("a worker exit while ownership is pending rejects instead of creating a gho
     workerScriptPath: "/worker.cjs",
   });
   manager.onSessionOwned(() => new Promise((resolve) => { releaseOwnership = resolve; }));
+  manager.onSessionClosed((event) => closed.push(event));
 
   const start = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
   child.emit("message", {
@@ -217,6 +293,7 @@ test("a worker exit while ownership is pending rejects instead of creating a gho
 
   child.emit("exit", 1);
   await assert.rejects(start, /Terminal worker exited with code 1/u);
+  assert.deepEqual(closed, [{ sessionId: "local-1", reason: "worker-exit" }]);
   releaseOwnership();
   await new Promise((resolve) => setImmediate(resolve));
 
@@ -494,11 +571,11 @@ test("request transfers the output port to the worker when available", async () 
   });
   await promise;
 
-  assert.deepEqual(child.messages[1], {
-    kind: "output-port",
-    sessionId: "local-1",
-    bufferedOutput: ["early"],
-  });
+  assert.equal(child.messages[1].kind, "output-port");
+  assert.equal(child.messages[1].sessionId, "local-1");
+  assert.equal(child.messages[1].sessionGeneration, 0);
+  assert.equal(typeof child.messages[1].outputPortRequestId, "string");
+  assert.deepEqual(child.messages[1].bufferedOutput, ["early"]);
   assert.deepEqual(child.transferLists[1], [outputPort]);
 });
 
@@ -630,15 +707,113 @@ test("output-port-ready flushes output that arrived during port transfer", async
     sessionId: "local-1",
     data: "during-transfer",
   });
-  child.emit("message", {
-    kind: "output-port-ready",
-    sessionId: "local-1",
-  });
+  emitOutputPortReady(child, "local-1");
 
   assert.deepEqual(child.messages[2], {
     kind: "output-flush",
     sessionId: "local-1",
     chunks: ["during-transfer"],
+  });
+});
+
+test("a stale output-port-ready cannot release a reused session route", async () => {
+  const child = new FakeChild();
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    MessageChannelMain: FakeMessageChannelMain,
+    terminalOutputChannel: {
+      openSession() {
+        return new FakePort("worker-output");
+      },
+      closeSession() {},
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  const first = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  const firstRequest = child.messages.at(-1);
+  child.emit("message", {
+    kind: "response",
+    requestId: firstRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await first;
+  const oldOpen = child.messages.find((message) => message.kind === "output-port");
+
+  manager.send("netcatty:close", { sessionId: "session-1" }, { webContentsId: 7 });
+  const second = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 8 },
+  );
+  const secondRequest = child.messages.at(-1);
+  child.emit("message", {
+    kind: "response",
+    requestId: secondRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 1,
+  });
+  await second;
+  const newOpen = [...child.messages].reverse().find((message) => message.kind === "output-port");
+  child.emit("message", {
+    kind: "output",
+    sessionId: "session-1",
+    data: "NEW-PENDING",
+    sessionGeneration: 1,
+    originRequestId: secondRequest.requestId,
+  });
+
+  child.emit("message", {
+    kind: "output-port-ready",
+    sessionId: "session-1",
+    sessionGeneration: oldOpen.sessionGeneration,
+    outputPortRequestId: oldOpen.outputPortRequestId,
+  });
+  assert.equal(
+    child.messages.some((message) => message.kind === "output-flush"),
+    false,
+  );
+
+  child.emit("message", {
+    kind: "output-port-ready",
+    sessionId: "session-1",
+    sessionGeneration: newOpen.sessionGeneration,
+    outputPortRequestId: newOpen.outputPortRequestId,
+  });
+  assert.deepEqual(child.messages.at(-1), {
+    kind: "output-flush",
+    sessionId: "session-1",
+    chunks: ["NEW-PENDING"],
+  });
+
+  assert.equal((await manager.rebindOutputSession("session-1", 9)).success, true);
+  assert.equal(manager.drainOutputSession("session-1", "too-early"), false);
+  const reboundOpen = [...child.messages].reverse().find((message) => (
+    message.kind === "output-port"
+  ));
+  child.emit("message", {
+    kind: "output-port-ready",
+    sessionId: "session-1",
+    sessionGeneration: reboundOpen.sessionGeneration,
+    outputPortRequestId: reboundOpen.outputPortRequestId,
+  });
+  assert.equal(manager.drainOutputSession("session-1", "after-ready"), true);
+  assert.deepEqual(child.messages.at(-1), {
+    kind: "output-drain",
+    sessionId: "session-1",
+    requestId: "after-ready",
   });
 });
 
@@ -679,10 +854,7 @@ test("worker buffered output byte cap preserves split alternate-screen metadata"
     sessionId: "local-1",
     data: "\x1b[?1049hREADY",
   });
-  child.emit("message", {
-    kind: "output-port-ready",
-    sessionId: "local-1",
-  });
+  emitOutputPortReady(child, "local-1");
 
   assert.deepEqual(child.messages[2], {
     kind: "output-flush",
@@ -740,10 +912,7 @@ test("worker buffered output chunk cap carries dropped metadata to retained outp
     sessionId: "local-1",
     data: "READY",
   });
-  child.emit("message", {
-    kind: "output-port-ready",
-    sessionId: "local-1",
-  });
+  emitOutputPortReady(child, "local-1");
 
   assert.deepEqual(child.messages[2], {
     kind: "output-flush",
@@ -781,7 +950,7 @@ test("metadata-only interceptor output obeys the pending chunk cap", async () =>
       meta: { pluginPipelineIngressBytes: 1 },
     });
   }
-  child.emit("message", { kind: "output-port-ready", sessionId: "local-1" });
+  emitOutputPortReady(child, "local-1");
 
   assert.deepEqual(child.messages[2], {
     kind: "output-flush",
@@ -823,7 +992,7 @@ test("pending output merge keeps state and provenance from only the latest raw c
     sessionId: "local-1",
     data: "READY",
   });
-  child.emit("message", { kind: "output-port-ready", sessionId: "local-1" });
+  emitOutputPortReady(child, "local-1");
 
   assert.deepEqual(child.messages[2], {
     kind: "output-flush",
@@ -858,7 +1027,7 @@ test("partial trimming carries sliced raw ingress into inherited flow accounting
   });
   child.emit("message", { kind: "output", sessionId: "local-1", data: "abcde" });
   child.emit("message", { kind: "output", sessionId: "local-1", data: "Z" });
-  child.emit("message", { kind: "output-port-ready", sessionId: "local-1" });
+  emitOutputPortReady(child, "local-1");
 
   assert.deepEqual(child.messages[2], {
     kind: "output-flush",
@@ -914,10 +1083,7 @@ test("worker fallback output after a ready output port is delivered over legacy 
     result: { sessionId: "local-1" },
   });
   await promise;
-  child.emit("message", {
-    kind: "output-port-ready",
-    sessionId: "local-1",
-  });
+  emitOutputPortReady(child, "local-1");
 
   child.emit("message", {
     kind: "output",
@@ -1511,6 +1677,260 @@ test("a duplicate exit from an old session generation cannot close a reconnected
   assert.deepEqual(closed, [{ sessionId: "session-1", reason: "error" }]);
 });
 
+test("a duplicate old-generation exit cannot cancel a pending same-id reconnect", async () => {
+  const child = new FakeChild();
+  const closed = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: { openSession: () => true, closeSession() {} },
+    electronModule: { webContents: { fromId: (id) => ({ id, isDestroyed: () => false, send() {} }) } },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const first = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages[0].requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await first;
+  const oldExit = {
+    kind: "renderer-event",
+    webContentsId: 7,
+    channel: "netcatty:exit",
+    payload: { sessionId: "session-1", reason: "error" },
+    sessionGeneration: 0,
+  };
+  child.emit("message", oldExit);
+
+  const reconnect = manager.request("netcatty:local:reconnect", { sessionId: "session-1" }, {
+    webContentsId: 7,
+  });
+  child.emit("message", oldExit);
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages.at(-1).requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 1,
+  });
+
+  await reconnect;
+  assert.equal(manager.hasOpenSession("session-1"), true);
+  assert.deepEqual(closed, [{ sessionId: "session-1", reason: "error" }]);
+});
+
+test("an old-generation exit after explicit close cannot cancel a pending reconnect", async () => {
+  const child = new FakeChild();
+  const closed = [];
+  const routed = [];
+  let outputOpen = false;
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: {
+      openSession() {
+        outputOpen = true;
+        return true;
+      },
+      closeSession() {
+        outputOpen = false;
+      },
+      send(sessionId, data) {
+        if (!outputOpen) return false;
+        routed.push({ sessionId, data });
+        return true;
+      },
+    },
+    electronModule: { webContents: { fromId: (id) => ({ id, isDestroyed: () => false, send() {} }) } },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const first = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  const firstRequestId = child.messages[0].requestId;
+  child.emit("message", {
+    kind: "response",
+    requestId: firstRequestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await first;
+  const staleReplacement = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 8 },
+  );
+  const staleRequest = child.messages.at(-1);
+  const staleRejected = assert.rejects(staleReplacement, /close failed/u);
+  manager.send("netcatty:close", { sessionId: "session-1" }, { webContentsId: 7 });
+
+  const reconnect = manager.request("netcatty:local:reconnect", { sessionId: "session-1" }, {
+    webContentsId: 9,
+  });
+  const reconnectRequest = child.messages.at(-1);
+  child.emit("message", {
+    kind: "session-superseding",
+    sessionId: "session-1",
+    sessionGeneration: 0,
+    replacementRequestId: staleRequest.requestId,
+  });
+  child.emit("message", {
+    kind: "response",
+    requestId: staleRequest.requestId,
+    error: "close failed",
+  });
+  await staleRejected;
+  child.emit("message", {
+    kind: "output",
+    sessionId: "session-1",
+    data: "STALE-OLD",
+    sessionGeneration: 0,
+    originRequestId: firstRequestId,
+  });
+  child.emit("message", {
+    kind: "output",
+    sessionId: "session-1",
+    data: "NEW-EARLY",
+    sessionGeneration: 1,
+    originRequestId: reconnectRequest.requestId,
+  });
+  child.emit("message", {
+    kind: "renderer-event",
+    webContentsId: 7,
+    channel: "netcatty:exit",
+    payload: { sessionId: "session-1", reason: "closed" },
+    sessionGeneration: 0,
+  });
+  child.emit("message", {
+    kind: "response",
+    requestId: reconnectRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 1,
+  });
+
+  await reconnect;
+  assert.equal(manager.hasOpenSession("session-1"), true);
+  assert.deepEqual(closed, [{ sessionId: "session-1", reason: "closed" }]);
+  assert.deepEqual(routed, [{ sessionId: "session-1", data: "NEW-EARLY" }]);
+});
+
+test("a closed pending start response records its generation before a later reconnect", async () => {
+  const child = new FakeChild();
+  const closed = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: { openSession: () => true, closeSession() {} },
+    electronModule: { webContents: { fromId: (id) => ({ id, isDestroyed: () => false, send() {} }) } },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const first = manager.request("netcatty:local:reconnect", { sessionId: "session-1" }, {
+    webContentsId: 7,
+  });
+  const firstRequest = child.messages.at(-1);
+  manager.send("netcatty:close", { sessionId: "session-1" }, { webContentsId: 7 });
+  child.emit("message", {
+    kind: "response",
+    requestId: firstRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await assert.rejects(first, /closed before its output route opened/u);
+
+  const second = manager.request("netcatty:local:reconnect", { sessionId: "session-1" }, {
+    webContentsId: 7,
+  });
+  child.emit("message", {
+    kind: "renderer-event",
+    webContentsId: 7,
+    channel: "netcatty:exit",
+    payload: { sessionId: "session-1", reason: "closed" },
+    sessionGeneration: 0,
+  });
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages.at(-1).requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 1,
+  });
+
+  await second;
+  assert.equal(manager.hasOpenSession("session-1"), true);
+  assert.deepEqual(closed, [{ sessionId: "session-1", reason: "closed" }]);
+});
+
+test("a much older exit cannot cancel a reconnect after multiple generations", async () => {
+  const child = new FakeChild();
+  const closed = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: { openSession: () => true, closeSession() {} },
+    electronModule: { webContents: { fromId: (id) => ({ id, isDestroyed: () => false, send() {} }) } },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const start = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages[0].requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await start;
+  child.emit("message", {
+    kind: "renderer-event",
+    webContentsId: 7,
+    channel: "netcatty:exit",
+    payload: { sessionId: "session-1", reason: "gen-0" },
+    sessionGeneration: 0,
+  });
+
+  const second = manager.request("netcatty:local:reconnect", { sessionId: "session-1" }, {
+    webContentsId: 7,
+  });
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages.at(-1).requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 1,
+  });
+  await second;
+  child.emit("message", {
+    kind: "renderer-event",
+    webContentsId: 7,
+    channel: "netcatty:exit",
+    payload: { sessionId: "session-1", reason: "gen-1" },
+    sessionGeneration: 1,
+  });
+
+  const third = manager.request("netcatty:local:reconnect", { sessionId: "session-1" }, {
+    webContentsId: 7,
+  });
+  child.emit("message", {
+    kind: "renderer-event",
+    webContentsId: 7,
+    channel: "netcatty:exit",
+    payload: { sessionId: "session-1", reason: "late-gen-0" },
+    sessionGeneration: 0,
+  });
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages.at(-1).requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 2,
+  });
+
+  await third;
+  assert.equal(manager.hasOpenSession("session-1"), true);
+  assert.deepEqual(closed, [
+    { sessionId: "session-1", reason: "gen-0" },
+    { sessionId: "session-1", reason: "gen-1" },
+  ]);
+});
+
 test("rebound interactive events target only the popup while exit also reaches home", async () => {
   const child = new FakeChild();
   const forwarded = [];
@@ -1655,8 +2075,10 @@ test("rebind waits for ownership and routes interactive events to the pending re
   assert.equal(manager.getSessionOwnerWebContentsId("session-1"), 9);
 });
 
-test("failed output-port transfer clears pending state and restores the previous route", async () => {
+test("failed output-port transfer retires the dead worker before the next start", async () => {
+  const children = [];
   const child = new FakeChild();
+  children.push(child);
   const postMessage = child.postMessage.bind(child);
   child.postMessage = (message, transferList) => {
     if (message?.kind === "output-port") {
@@ -1664,10 +2086,15 @@ test("failed output-port transfer clears pending state and restores the previous
     }
     postMessage(message, transferList);
   };
-  const forwarded = [];
+  const closed = [];
   let openCount = 0;
   const manager = createTerminalWorkerManager({
-    utilityProcess: { fork() { return child; } },
+    utilityProcess: {
+      fork() {
+        if (children.length === 1) return child;
+        return children.at(-1);
+      },
+    },
     terminalOutputChannel: {
       openSession() {
         openCount += 1;
@@ -1675,6 +2102,7 @@ test("failed output-port transfer clears pending state and restores the previous
       },
       send() { return false; },
       closeSession() {},
+      closeAll() {},
     },
     electronModule: {
       webContents: {
@@ -1682,13 +2110,14 @@ test("failed output-port transfer clears pending state and restores the previous
           return {
             id,
             isDestroyed() { return false; },
-            send(channel, payload) { forwarded.push({ id, channel, payload }); },
+            send() {},
           };
         },
       },
     },
     workerScriptPath: "/worker.cjs",
   });
+  manager.onSessionClosed((event) => closed.push(event));
 
   const started = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
   child.emit("message", {
@@ -1704,24 +2133,26 @@ test("failed output-port transfer clears pending state and restores the previous
     success: false,
     error: "Failed to rebind session output",
   });
-  assert.equal(manager.getSessionWebContentsId("session-1"), 7);
+  assert.equal(manager.hasOpenSession("session-1"), false);
+  assert.equal(child.killed, true);
+  assert.equal(manager.getSessionWebContentsId("session-1"), null);
   assert.equal(manager.getAttachHomeWebContentsId("session-1"), null);
+  assert.deepEqual(closed, [{ sessionId: "session-1", reason: "worker-exit" }]);
 
-  child.emit("message", {
-    kind: "renderer-event",
-    webContentsId: 7,
-    channel: "netcatty:zmodem:overwrite-request",
-    payload: { sessionId: "session-1", requestId: "request-1" },
+  const replacement = new FakeChild();
+  children.push(replacement);
+  const restarted = manager.request("netcatty:local:reconnect", { sessionId: "session-1" }, {
+    webContentsId: 9,
   });
-  assert.deepEqual(forwarded, [{
-    id: 7,
-    channel: "netcatty:zmodem:overwrite-request",
-    payload: { sessionId: "session-1", requestId: "request-1" },
-  }]);
-  assert.equal(
-    child.messages.some((message) => message.kind === "output-flush" && message.sessionId === "session-1"),
-    true,
-  );
+  replacement.emit("message", {
+    kind: "response",
+    requestId: replacement.messages[0].requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await restarted;
+  child.emit("exit", 1);
+  assert.equal(manager.hasOpenSession("session-1"), true);
 });
 
 test("explicit close notifies both a rebound popup and its home renderer", async () => {
@@ -1845,6 +2276,42 @@ test("worker exit rejects pending requests and closes output routes", async () =
   assert.deepEqual(closed, ["all"]);
 });
 
+test("worker exit closes a session identified by output before its start response", async () => {
+  const child = new FakeChild();
+  const closed = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: { closeAll() {} },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const start = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  child.emit("message", { kind: "output", sessionId: "session-1", data: "banner" });
+  child.emit("exit", 1);
+
+  await assert.rejects(start, /Terminal worker exited/u);
+  assert.deepEqual(closed, [{ sessionId: "session-1", reason: "worker-exit" }]);
+});
+
+test("worker exit closes a session identified only by an output tap before its start response", async () => {
+  const child = new FakeChild();
+  const closed = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: { closeAll() {} },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const start = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  child.emit("message", { kind: "output-tap", sessionId: "session-1", data: "banner" });
+  child.emit("exit", 1);
+
+  await assert.rejects(start, /Terminal worker exited/u);
+  assert.deepEqual(closed, [{ sessionId: "session-1", reason: "worker-exit" }]);
+});
+
 test("worker stop clears buffered output byte accounting before session id reuse", async () => {
   const children = [];
   const routed = [];
@@ -1904,6 +2371,1643 @@ test("worker stop clears buffered output byte accounting before session id reuse
   await promise;
 
   assert.deepEqual(routed, [{ sessionId: "session-1", data: "READY" }]);
+});
+
+test("a replacement worker can deliver generation-zero early output after a crash", async () => {
+  const children = [];
+  const routed = [];
+  let opened = false;
+  const manager = createTerminalWorkerManager({
+    utilityProcess: {
+      fork() {
+        const child = new FakeChild();
+        children.push(child);
+        return child;
+      },
+    },
+    terminalOutputChannel: {
+      openSession() {
+        opened = true;
+      },
+      send(sessionId, data) {
+        if (!opened) return false;
+        routed.push({ sessionId, data });
+        return true;
+      },
+      closeAll() {
+        opened = false;
+      },
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  const first = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  const firstChild = children[0];
+  const firstRequest = firstChild.messages.at(-1);
+  firstChild.emit("message", {
+    kind: "response",
+    requestId: firstRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await first;
+  firstChild.emit("exit", 1);
+
+  const second = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 8 },
+  );
+  const secondChild = children[1];
+  const secondRequest = secondChild.messages.at(-1);
+  secondChild.emit("message", {
+    kind: "output",
+    sessionId: "session-1",
+    data: "NEW-WORKER-EARLY",
+    sessionGeneration: 0,
+    originRequestId: secondRequest.requestId,
+  });
+  secondChild.emit("message", {
+    kind: "response",
+    requestId: secondRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await second;
+
+  assert.deepEqual(routed, [{ sessionId: "session-1", data: "NEW-WORKER-EARLY" }]);
+});
+
+test("a stale worker exit cannot close sessions owned by its replacement", async () => {
+  const children = [];
+  const closed = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: {
+      fork() {
+        const child = new FakeChild();
+        children.push(child);
+        return child;
+      },
+    },
+    terminalOutputChannel: {
+      openSession() {},
+      closeAll() {},
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  const firstChild = manager.ensureStarted();
+  manager.stop();
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const start = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  const secondChild = children[1];
+  secondChild.emit("message", {
+    kind: "response",
+    requestId: secondChild.messages[0].requestId,
+    result: { sessionId: "session-2" },
+  });
+  await start;
+
+  firstChild.emit("exit", 1);
+  assert.deepEqual(closed, []);
+  assert.equal(manager.hasOpenSession("session-2"), true);
+
+  secondChild.emit("exit", 1);
+  assert.deepEqual(closed, [{ sessionId: "session-2", reason: "worker-exit" }]);
+  assert.equal(manager.hasOpenSession("session-2"), false);
+});
+
+test("closing a crashed session is idempotent until a new worker reuses its id", async () => {
+  const children = [];
+  const closed = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: {
+      fork() {
+        const child = new FakeChild();
+        children.push(child);
+        return child;
+      },
+    },
+    terminalOutputChannel: {
+      openSession() {},
+      closeAll() {},
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const firstStart = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  const firstChild = children[0];
+  firstChild.emit("message", {
+    kind: "response",
+    requestId: firstChild.messages[0].requestId,
+    result: { sessionId: "session-1" },
+  });
+  await firstStart;
+  firstChild.emit("exit", 1);
+  assert.deepEqual(closed, [{ sessionId: "session-1", reason: "worker-exit" }]);
+
+  const close = manager.request("netcatty:close:await", { sessionId: "session-1" }, {
+    webContentsId: 7,
+  });
+  if (children[1]) {
+    const closeRequest = children[1].messages.at(-1);
+    children[1].emit("message", {
+      kind: "response",
+      requestId: closeRequest.requestId,
+      result: { sessionId: "session-1" },
+    });
+  }
+  await close;
+  assert.equal(children.length, 1);
+  assert.deepEqual(closed, [{ sessionId: "session-1", reason: "worker-exit" }]);
+
+  const secondStart = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  const secondChild = children[1];
+  secondChild.emit("message", {
+    kind: "response",
+    requestId: secondChild.messages[0].requestId,
+    result: { sessionId: "session-1" },
+  });
+  await secondStart;
+  secondChild.emit("exit", 1);
+  assert.deepEqual(closed, [
+    { sessionId: "session-1", reason: "worker-exit" },
+    { sessionId: "session-1", reason: "worker-exit" },
+  ]);
+});
+
+test("an old start response cannot reopen a session claimed by a later same-id start", async () => {
+  const child = new FakeChild();
+  const routed = [];
+  let outputOpen = false;
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: {
+      openSession() { outputOpen = true; },
+      send(sessionId, data) {
+        if (!outputOpen) return false;
+        routed.push({ sessionId, data });
+        return true;
+      },
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  const first = manager.request("netcatty:local:reconnect", { sessionId: "session-1" }, {
+    webContentsId: 7,
+  });
+  const firstRequest = child.messages.at(-1);
+  manager.send("netcatty:close", { sessionId: "session-1" }, { webContentsId: 7 });
+  const second = manager.request("netcatty:local:reconnect", { sessionId: "session-1" }, {
+    webContentsId: 7,
+  });
+  const secondRequest = child.messages.at(-1);
+  child.emit("message", {
+    kind: "output",
+    sessionId: "session-1",
+    data: "new-banner",
+    sessionGeneration: 1,
+    originRequestId: secondRequest.requestId,
+  });
+
+  child.emit("message", {
+    kind: "response",
+    requestId: firstRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await assert.rejects(first, /superseded by a newer start request/u);
+  assert.equal(manager.hasOpenSession("session-1"), false);
+
+  child.emit("message", {
+    kind: "response",
+    requestId: secondRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 1,
+  });
+  await second;
+  assert.equal(manager.hasOpenSession("session-1"), true);
+  assert.deepEqual(routed, [{ sessionId: "session-1", data: "new-banner" }]);
+});
+
+test("a later same-id start response cannot be overwritten by an older response", async () => {
+  const child = new FakeChild();
+  const owners = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: { openSession() {} },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionOwned((event) => owners.push(event));
+
+  const first = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  const firstRequest = child.messages.at(-1);
+  const second = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 8 },
+  );
+  const secondRequest = child.messages.at(-1);
+
+  child.emit("message", {
+    kind: "response",
+    requestId: secondRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 2,
+  });
+  await second;
+  child.emit("message", {
+    kind: "response",
+    requestId: firstRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 1,
+  });
+
+  await assert.rejects(first, /superseded by a newer start request/u);
+  assert.deepEqual(owners, [{ sessionId: "session-1", webContentsId: 8 }]);
+});
+
+test("a later same-id start does not inherit ambiguous output from an older pending start", async () => {
+  const child = new FakeChild();
+  const routed = [];
+  let outputOpen = false;
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: {
+      openSession() { outputOpen = true; },
+      send(sessionId, data) {
+        if (!outputOpen) return false;
+        routed.push({ sessionId, data });
+        return true;
+      },
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  const first = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  void first.catch(() => {});
+  const firstRequest = child.messages.at(-1);
+  child.emit("message", { kind: "output", sessionId: "session-1", data: "OLD" });
+
+  const second = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 8 },
+  );
+  const secondRequest = child.messages.at(-1);
+  child.emit("message", { kind: "output", sessionId: "session-1", data: "AMBIGUOUS" });
+  child.emit("message", {
+    kind: "response",
+    requestId: secondRequest.requestId,
+    result: { sessionId: "session-1" },
+  });
+  await second;
+  child.emit("message", { kind: "output", sessionId: "session-1", data: "NEW" });
+
+  child.emit("message", {
+    kind: "response",
+    requestId: firstRequest.requestId,
+    result: { sessionId: "session-1" },
+  });
+  await assert.rejects(first, /superseded by a newer start request/u);
+  assert.deepEqual(routed, [{ sessionId: "session-1", data: "NEW" }]);
+});
+
+test("a serialized same-id restart keeps its generation-bound early output", async () => {
+  const child = new FakeChild();
+  const routed = [];
+  let outputOpen = false;
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: {
+      openSession() { outputOpen = true; },
+      send(sessionId, data) {
+        if (!outputOpen) return false;
+        routed.push({ sessionId, data });
+        return true;
+      },
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  const first = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  const firstRequest = child.messages.at(-1);
+  const second = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 8 },
+  );
+  const secondRequest = child.messages.at(-1);
+
+  child.emit("message", {
+    kind: "response",
+    requestId: firstRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await assert.rejects(first, /superseded by a newer start request/u);
+  child.emit("message", {
+    kind: "output",
+    sessionId: "session-1",
+    data: "NEW-EARLY",
+    sessionGeneration: 1,
+  });
+  child.emit("message", {
+    kind: "response",
+    requestId: secondRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 1,
+  });
+
+  await second;
+  assert.deepEqual(routed, [{ sessionId: "session-1", data: "NEW-EARLY" }]);
+});
+
+test("an internal same-id replacement exit retires only the old generation", async () => {
+  const child = new FakeChild();
+  const routed = [];
+  const closed = [];
+  let outputOpen = false;
+  let outputWebContentsId = null;
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: {
+      openSession(_sessionId, contents) {
+        outputOpen = true;
+        outputWebContentsId = contents.id;
+      },
+      closeSession() {
+        outputOpen = false;
+        outputWebContentsId = null;
+      },
+      send(sessionId, data) {
+        if (!outputOpen) return false;
+        routed.push({ sessionId, data, webContentsId: outputWebContentsId });
+        return true;
+      },
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const first = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  const firstRequest = child.messages.at(-1);
+  child.emit("message", {
+    kind: "response",
+    requestId: firstRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await first;
+
+  const second = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 8 },
+  );
+  const secondRequest = child.messages.at(-1);
+  child.emit("message", {
+    kind: "session-superseding",
+    sessionId: "session-1",
+    sessionGeneration: 0,
+    replacementRequestId: secondRequest.requestId,
+  });
+  child.emit("message", {
+    kind: "renderer-event",
+    webContentsId: 7,
+    channel: "netcatty:exit",
+    payload: { sessionId: "session-1", exitCode: 0, reason: "closed" },
+    sessionGeneration: 0,
+  });
+  child.emit("message", {
+    kind: "output",
+    sessionId: "session-1",
+    data: "NEW-EARLY",
+    sessionGeneration: 1,
+    originRequestId: secondRequest.requestId,
+  });
+  child.emit("message", {
+    kind: "response",
+    requestId: secondRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 1,
+  });
+
+  await second;
+  assert.deepEqual(routed, [{
+    sessionId: "session-1",
+    data: "NEW-EARLY",
+    webContentsId: 8,
+  }]);
+  assert.deepEqual(closed, [{ sessionId: "session-1", reason: "closed" }]);
+  assert.equal(outputOpen, true);
+  assert.equal(
+    child.messages.some((message) => (
+      message.kind === "close-output-port" && message.sessionId === "session-1"
+    )),
+    false,
+  );
+});
+
+test("a failed replacement is not reported closed again when the worker exits", async () => {
+  const child = new FakeChild();
+  const closed = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: { openSession() {}, closeSession() {} },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const first = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  const firstRequest = child.messages.at(-1);
+  child.emit("message", {
+    kind: "response",
+    requestId: firstRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await first;
+
+  const replacement = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 8 },
+  );
+  const replacementRequest = child.messages.at(-1);
+  child.emit("message", {
+    kind: "session-superseding",
+    sessionId: "session-1",
+    sessionGeneration: 0,
+    replacementRequestId: replacementRequest.requestId,
+  });
+  child.emit("message", {
+    kind: "renderer-event",
+    webContentsId: 7,
+    channel: "netcatty:exit",
+    payload: { sessionId: "session-1", reason: "closed" },
+    sessionGeneration: 0,
+  });
+  child.emit("message", {
+    kind: "output",
+    sessionId: "session-1",
+    data: "FAILED-EARLY",
+    sessionGeneration: 1,
+    originRequestId: replacementRequest.requestId,
+  });
+  child.emit("message", {
+    kind: "response",
+    requestId: replacementRequest.requestId,
+    error: "start failed",
+  });
+  await assert.rejects(replacement, /start failed/u);
+  child.emit("exit", 1);
+
+  assert.deepEqual(closed, [{ sessionId: "session-1", reason: "closed" }]);
+});
+
+test("manager and runtime preserve a completed same-id replacement end to end", async () => {
+  const child = new LinkedRuntimeChild();
+  const order = [];
+  const routed = [];
+  const closed = [];
+  let active = null;
+  let outputWebContentsId = null;
+  child.connectRuntime((ipcMain) => {
+    ipcMain.handle("netcatty:local:reconnect", (event, payload) => {
+      const generation = event.sender.claimSessionGeneration(payload.sessionId);
+      order.push(`start:${payload.attempt}:g${generation}`);
+      active = { attempt: payload.attempt, generation, sender: event.sender };
+      event.sender.send("netcatty:data", {
+        sessionId: payload.sessionId,
+        data: payload.attempt === "second" ? "NEW-EARLY" : "OLD",
+        _terminalSessionGeneration: generation,
+      });
+      return { sessionId: payload.sessionId };
+    });
+    ipcMain.handle("netcatty:close:await", (_event, payload) => {
+      order.push(`close:${active.attempt}:g${active.generation}`);
+      active.sender.send("netcatty:exit", {
+        sessionId: payload.sessionId,
+        exitCode: 0,
+        reason: "closed",
+        _terminalSessionGeneration: active.generation,
+      });
+      active = null;
+    });
+  });
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: {
+      openSession(_sessionId, contents) {
+        outputWebContentsId = contents.id;
+        return true;
+      },
+      closeSession() {
+        outputWebContentsId = null;
+      },
+      send(sessionId, data) {
+        if (outputWebContentsId == null) return false;
+        routed.push({ sessionId, data, webContentsId: outputWebContentsId });
+        return true;
+      },
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  await manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1", attempt: "first" },
+    { webContentsId: 7 },
+  );
+  await manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1", attempt: "second" },
+    { webContentsId: 8 },
+  );
+
+  assert.deepEqual(order, [
+    "start:first:g0",
+    "close:first:g0",
+    "start:second:g1",
+  ]);
+  assert.deepEqual(routed, [
+    { sessionId: "session-1", data: "OLD", webContentsId: 7 },
+    { sessionId: "session-1", data: "NEW-EARLY", webContentsId: 8 },
+  ]);
+  assert.deepEqual(closed, [{ sessionId: "session-1", reason: "closed" }]);
+  assert.equal(outputWebContentsId, 8);
+  assert.equal(
+    child.messages.some((message) => (
+      message.kind === "close-output-port" && message.sessionId === "session-1"
+    )),
+    false,
+  );
+});
+
+test("a failed replacement close cannot let the old exit cancel the next start", async () => {
+  const child = new LinkedRuntimeChild();
+  const order = [];
+  const routed = [];
+  let active = null;
+  let closeAttempts = 0;
+  let outputWebContentsId = null;
+  child.connectRuntime((ipcMain) => {
+    ipcMain.handle("netcatty:local:reconnect", (event, payload) => {
+      const generation = event.sender.claimSessionGeneration(payload.sessionId);
+      order.push(`start:${payload.attempt}:g${generation}`);
+      active = { attempt: payload.attempt, generation, sender: event.sender };
+      event.sender.send("netcatty:data", {
+        sessionId: payload.sessionId,
+        data: payload.attempt,
+        _terminalSessionGeneration: generation,
+      });
+      return { sessionId: payload.sessionId };
+    });
+    ipcMain.handle("netcatty:close:await", (_event, payload) => {
+      closeAttempts += 1;
+      order.push(`close:${active.attempt}:g${active.generation}`);
+      if (closeAttempts === 1) throw new Error("close failed");
+      active.sender.send("netcatty:exit", {
+        sessionId: payload.sessionId,
+        exitCode: 0,
+        reason: "closed",
+        _terminalSessionGeneration: active.generation,
+      });
+      active = null;
+    });
+  });
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: {
+      openSession(_sessionId, contents) {
+        outputWebContentsId = contents.id;
+        return true;
+      },
+      closeSession() {
+        outputWebContentsId = null;
+      },
+      send(sessionId, data) {
+        if (outputWebContentsId == null) return false;
+        routed.push({ sessionId, data, webContentsId: outputWebContentsId });
+        return true;
+      },
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  await manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1", attempt: "R1" },
+    { webContentsId: 7 },
+  );
+  await assert.rejects(
+    manager.request(
+      "netcatty:local:reconnect",
+      { sessionId: "session-1", attempt: "R2" },
+      { webContentsId: 8 },
+    ),
+    /close failed/u,
+  );
+  await manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1", attempt: "R3" },
+    { webContentsId: 9 },
+  );
+
+  assert.deepEqual(order, [
+    "start:R1:g0",
+    "close:R1:g0",
+    "close:R1:g0",
+    "start:R3:g2",
+  ]);
+  assert.deepEqual(routed, [
+    { sessionId: "session-1", data: "R1", webContentsId: 7 },
+    { sessionId: "session-1", data: "R3", webContentsId: 9 },
+  ]);
+  assert.equal(outputWebContentsId, 9);
+  assert.equal(
+    child.messages.some((message) => (
+      message.kind === "close-output-port" && message.sessionId === "session-1"
+    )),
+    false,
+  );
+});
+
+test("a failed replacement start cannot leak its early output into the next start", async () => {
+  const child = new LinkedRuntimeChild();
+  const routed = [];
+  let active = null;
+  let outputWebContentsId = null;
+  child.connectRuntime((ipcMain) => {
+    ipcMain.handle("netcatty:local:reconnect", (event, payload) => {
+      const generation = event.sender.claimSessionGeneration(payload.sessionId);
+      event.sender.send("netcatty:data", {
+        sessionId: payload.sessionId,
+        data: `${payload.attempt}-EARLY`,
+        _terminalSessionGeneration: generation,
+      });
+      if (payload.attempt === "R2") throw new Error("start failed");
+      active = { generation, sender: event.sender };
+      return { sessionId: payload.sessionId };
+    });
+    ipcMain.handle("netcatty:close:await", (_event, payload) => {
+      if (!active) return;
+      active.sender.send("netcatty:exit", {
+        sessionId: payload.sessionId,
+        exitCode: 0,
+        reason: "closed",
+        _terminalSessionGeneration: active.generation,
+      });
+      active = null;
+    });
+  });
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: {
+      openSession(_sessionId, contents) {
+        outputWebContentsId = contents.id;
+        return true;
+      },
+      closeSession() {
+        outputWebContentsId = null;
+      },
+      send(sessionId, data) {
+        if (outputWebContentsId == null) return false;
+        routed.push({ sessionId, data, webContentsId: outputWebContentsId });
+        return true;
+      },
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  await manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1", attempt: "R1" },
+    { webContentsId: 7 },
+  );
+  await assert.rejects(
+    manager.request(
+      "netcatty:local:reconnect",
+      { sessionId: "session-1", attempt: "R2" },
+      { webContentsId: 8 },
+    ),
+    /start failed/u,
+  );
+  await manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1", attempt: "R3" },
+    { webContentsId: 9 },
+  );
+
+  assert.deepEqual(routed, [
+    { sessionId: "session-1", data: "R1-EARLY", webContentsId: 7 },
+    { sessionId: "session-1", data: "R3-EARLY", webContentsId: 9 },
+  ]);
+  assert.equal(outputWebContentsId, 9);
+});
+
+test("overlapping same-id reconnects keep only the latest request's early output", async () => {
+  const child = new FakeChild();
+  const routed = [];
+  let outputOpen = false;
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: {
+      openSession() { outputOpen = true; },
+      closeSession() { outputOpen = false; },
+      send(sessionId, data) {
+        if (!outputOpen) return false;
+        routed.push({ sessionId, data });
+        return true;
+      },
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  const initial = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages[0].requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await initial;
+  manager.send("netcatty:close", { sessionId: "session-1" }, { webContentsId: 7 });
+
+  const first = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  const firstRequest = child.messages.at(-1);
+  const second = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 8 },
+  );
+  const secondRequest = child.messages.at(-1);
+
+  child.emit("message", {
+    kind: "output",
+    sessionId: "session-1",
+    data: "OLD-FIRST",
+    sessionGeneration: 1,
+    originRequestId: firstRequest.requestId,
+  });
+  child.emit("message", {
+    kind: "response",
+    requestId: firstRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 1,
+  });
+  await assert.rejects(first, /superseded by a newer start request/u);
+  child.emit("message", {
+    kind: "output",
+    sessionId: "session-1",
+    data: "NEW-SECOND",
+    sessionGeneration: 2,
+    originRequestId: secondRequest.requestId,
+  });
+  child.emit("message", {
+    kind: "response",
+    requestId: secondRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 2,
+  });
+
+  await second;
+  assert.deepEqual(routed, [{ sessionId: "session-1", data: "NEW-SECOND" }]);
+});
+
+test("a superseded ownership waiter cannot flush the latest reconnect output to its old renderer", async () => {
+  const child = new FakeChild();
+  const routed = [];
+  let currentOwner = null;
+  let releaseFirstOwnership;
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: {
+      openSession(_sessionId, contents) { currentOwner = contents.id; },
+      closeSession() { currentOwner = null; },
+      send(sessionId, data) {
+        if (currentOwner == null) return false;
+        routed.push({ sessionId, data, webContentsId: currentOwner });
+        return true;
+      },
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionOwned(({ webContentsId }) => {
+    if (webContentsId !== 7) return undefined;
+    return new Promise((resolve) => { releaseFirstOwnership = resolve; });
+  });
+
+  const initial = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 6 },
+  );
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages[0].requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await initial;
+  manager.send("netcatty:close", { sessionId: "session-1" }, { webContentsId: 6 });
+
+  const first = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  const firstRequest = child.messages.at(-1);
+  child.emit("message", {
+    kind: "response",
+    requestId: firstRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 1,
+  });
+  while (!releaseFirstOwnership) await new Promise((resolve) => setImmediate(resolve));
+
+  const second = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 8 },
+  );
+  const secondRequest = child.messages.at(-1);
+  child.emit("message", {
+    kind: "output",
+    sessionId: "session-1",
+    data: "LATEST-EARLY",
+    sessionGeneration: 2,
+    originRequestId: secondRequest.requestId,
+  });
+
+  releaseFirstOwnership();
+  await assert.rejects(first, /superseded by a newer start request/u);
+  assert.deepEqual(routed, []);
+
+  child.emit("message", {
+    kind: "response",
+    requestId: secondRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 2,
+  });
+  await second;
+  assert.deepEqual(routed, [{
+    sessionId: "session-1",
+    data: "LATEST-EARLY",
+    webContentsId: 8,
+  }]);
+});
+
+test("a superseded start failure cannot cancel the queued same-id restart", async () => {
+  const child = new FakeChild();
+  const closed = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: { openSession() {} },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const first = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  const firstRequest = child.messages.at(-1);
+  const second = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 8 },
+  );
+  const secondRequest = child.messages.at(-1);
+
+  child.emit("message", {
+    kind: "renderer-event",
+    originRequestId: firstRequest.requestId,
+    webContentsId: 7,
+    channel: "netcatty:exit",
+    payload: { sessionId: "session-1", reason: "failed" },
+    sessionGeneration: 0,
+  });
+  await assert.rejects(first, /superseded by a newer start request/u);
+  child.emit("message", {
+    kind: "response",
+    requestId: firstRequest.requestId,
+    error: "first failed",
+  });
+  child.emit("message", {
+    kind: "response",
+    requestId: secondRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 1,
+  });
+
+  await second;
+  assert.equal(manager.hasOpenSession("session-1"), true);
+  assert.deepEqual(closed, [{ sessionId: "session-1", reason: "failed" }]);
+});
+
+test("a failed reconnect after worker exit keeps later close cleanup idempotent", async () => {
+  const children = [];
+  const closed = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: {
+      fork() {
+        const child = new FakeChild();
+        children.push(child);
+        return child;
+      },
+    },
+    terminalOutputChannel: {
+      openSession() {},
+      closeAll() {},
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const start = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  const firstChild = children[0];
+  firstChild.emit("message", {
+    kind: "response",
+    requestId: firstChild.messages[0].requestId,
+    result: { sessionId: "session-1" },
+  });
+  await start;
+  firstChild.emit("exit", 1);
+
+  const reconnect = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  const secondChild = children[1];
+  secondChild.emit("message", {
+    kind: "response",
+    requestId: secondChild.messages[0].requestId,
+    error: "reconnect failed",
+  });
+  await assert.rejects(reconnect, /reconnect failed/u);
+
+  manager.send("netcatty:close", { sessionId: "session-1" }, { webContentsId: 7 });
+  assert.equal(children.length, 2);
+  assert.deepEqual(closed, [{ sessionId: "session-1", reason: "worker-exit" }]);
+});
+
+test("a same-id reconnect that outputs before another worker exit closes its new lifecycle", async () => {
+  const children = [];
+  const closed = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: {
+      fork() {
+        const child = new FakeChild();
+        children.push(child);
+        return child;
+      },
+    },
+    terminalOutputChannel: {
+      openSession() {},
+      closeAll() {},
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const start = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  const firstChild = children[0];
+  firstChild.emit("message", {
+    kind: "response",
+    requestId: firstChild.messages[0].requestId,
+    result: { sessionId: "session-1" },
+  });
+  await start;
+  firstChild.emit("exit", 1);
+
+  const reconnect = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  const secondChild = children[1];
+  secondChild.emit("message", {
+    kind: "output",
+    sessionId: "session-1",
+    data: "reconnected banner",
+  });
+  secondChild.emit("exit", 1);
+
+  await assert.rejects(reconnect, /Terminal worker exited/u);
+  assert.deepEqual(closed, [
+    { sessionId: "session-1", reason: "worker-exit" },
+    { sessionId: "session-1", reason: "worker-exit" },
+  ]);
+});
+
+test("closing a same-id reconnect before its response closes the new lifecycle once", async () => {
+  const children = [];
+  const closed = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: {
+      fork() {
+        const child = new FakeChild();
+        children.push(child);
+        return child;
+      },
+    },
+    terminalOutputChannel: {
+      openSession() {},
+      closeAll() {},
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const start = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  const firstChild = children[0];
+  firstChild.emit("message", {
+    kind: "response",
+    requestId: firstChild.messages[0].requestId,
+    result: { sessionId: "session-1" },
+  });
+  await start;
+  firstChild.emit("exit", 1);
+
+  const reconnect = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  void reconnect.catch(() => {});
+  const secondChild = children[1];
+  secondChild.emit("message", {
+    kind: "output",
+    sessionId: "session-1",
+    data: "reconnected banner",
+  });
+  manager.send("netcatty:close", { sessionId: "session-1" }, { webContentsId: 7 });
+
+  const closeMessage = secondChild.messages.at(-1);
+  assert.equal(closeMessage.channel, "netcatty:close");
+  assert.deepEqual(closed, [
+    { sessionId: "session-1", reason: "worker-exit" },
+    { sessionId: "session-1", reason: "closed" },
+  ]);
+
+  secondChild.emit("message", {
+    kind: "response",
+    requestId: secondChild.messages[0].requestId,
+    result: { sessionId: "session-1" },
+  });
+  await assert.rejects(reconnect, /closed before its output route opened/u);
+  secondChild.emit("message", { kind: "session-exit", sessionId: "session-1", exitCode: 0 });
+  assert.deepEqual(closed, [
+    { sessionId: "session-1", reason: "worker-exit" },
+    { sessionId: "session-1", reason: "closed" },
+  ]);
+});
+
+test("a pending reconnect exit drops late output before another same-id restart", async () => {
+  const children = [];
+  const closed = [];
+  const routed = [];
+  let outputOpen = false;
+  const manager = createTerminalWorkerManager({
+    utilityProcess: {
+      fork() {
+        const child = new FakeChild();
+        children.push(child);
+        return child;
+      },
+    },
+    terminalOutputChannel: {
+      openSession() { outputOpen = true; },
+      closeSession() { outputOpen = false; },
+      closeAll() { outputOpen = false; },
+      send(sessionId, data) {
+        if (!outputOpen) return false;
+        routed.push({ sessionId, data });
+        return true;
+      },
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const start = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  const firstChild = children[0];
+  firstChild.emit("message", {
+    kind: "response",
+    requestId: firstChild.messages[0].requestId,
+    result: { sessionId: "session-1" },
+  });
+  await start;
+  firstChild.emit("exit", 1);
+
+  const reconnect = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  const secondChild = children[1];
+  const reconnectRequest = secondChild.messages[0];
+  secondChild.emit("message", {
+    kind: "renderer-event",
+    webContentsId: 7,
+    channel: "netcatty:exit",
+    payload: { sessionId: "session-1", reason: "exited" },
+    sessionGeneration: 0,
+  });
+  secondChild.emit("message", {
+    kind: "output",
+    sessionId: "session-1",
+    data: "STALE",
+  });
+  secondChild.emit("message", {
+    kind: "response",
+    requestId: reconnectRequest.requestId,
+    error: "reconnect failed",
+  });
+  await assert.rejects(reconnect, /reconnect failed/u);
+
+  const restart = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  const restartRequest = secondChild.messages.at(-1);
+  secondChild.emit("message", {
+    kind: "response",
+    requestId: restartRequest.requestId,
+    result: { sessionId: "session-1" },
+  });
+  await restart;
+
+  assert.deepEqual(routed, []);
+  assert.deepEqual(closed, [
+    { sessionId: "session-1", reason: "worker-exit" },
+    { sessionId: "session-1", reason: "exited" },
+  ]);
+});
+
+test("a worker-exit close listener can start a replacement without later cleanup removing it", async () => {
+  const children = [];
+  let replacementStart;
+  const manager = createTerminalWorkerManager({
+    utilityProcess: {
+      fork() {
+        const child = new FakeChild();
+        children.push(child);
+        return child;
+      },
+    },
+    terminalOutputChannel: {
+      openSession() {},
+      closeAll() {},
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => {
+    if (event.reason !== "worker-exit") return;
+    replacementStart = manager.request("netcatty:local:start", {}, { webContentsId: 8 });
+    void replacementStart.catch(() => {});
+  });
+
+  const firstStart = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
+  const firstChild = children[0];
+  firstChild.emit("message", {
+    kind: "response",
+    requestId: firstChild.messages[0].requestId,
+    result: { sessionId: "session-1" },
+  });
+  await firstStart;
+
+  firstChild.emit("exit", 1);
+  assert.equal(children.length, 2);
+
+  const secondChild = children[1];
+  secondChild.emit("message", {
+    kind: "response",
+    requestId: secondChild.messages[0].requestId,
+    result: { sessionId: "session-2" },
+  });
+  await replacementStart;
+  assert.equal(manager.hasOpenSession("session-2"), true);
+});
+
+test("an explicit-close listener can restart the same id without later cleanup removing it", async () => {
+  const child = new FakeChild();
+  let replacementStart;
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: { openSession() {}, closeSession() {} },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => {
+    if (event.reason !== "closed") return;
+    replacementStart = manager.request(
+      "netcatty:local:reconnect",
+      { sessionId: event.sessionId },
+      { webContentsId: 8 },
+    );
+    void replacementStart.catch(() => {});
+  });
+
+  const firstStart = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages[0].requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await firstStart;
+
+  manager.send("netcatty:close", { sessionId: "session-1" }, { webContentsId: 7 });
+  const replacementRequest = child.messages.find((message) => (
+    message.kind === "request"
+    && message.channel === "netcatty:local:reconnect"
+    && message.requestId !== child.messages[0].requestId
+  ));
+  const workerCloseIndex = child.messages.findIndex((message) => (
+    message.kind === "send" && message.channel === "netcatty:close"
+  ));
+  const replacementIndex = child.messages.indexOf(replacementRequest);
+  assert.equal(workerCloseIndex < replacementIndex, true);
+  child.emit("message", {
+    kind: "response",
+    requestId: replacementRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 1,
+  });
+
+  await replacementStart;
+  assert.equal(manager.hasOpenSession("session-1"), true);
+});
+
+test("an awaited close reaches the worker before its listener can restart the same id", async () => {
+  const child = new FakeChild();
+  let replacementStart;
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: { openSession() {}, closeSession() {} },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => {
+    if (event.reason !== "closed") return;
+    replacementStart = manager.request(
+      "netcatty:local:reconnect",
+      { sessionId: event.sessionId },
+      { webContentsId: 8 },
+    );
+    void replacementStart.catch(() => {});
+  });
+
+  const firstStart = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages[0].requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await firstStart;
+
+  const close = manager.request(
+    "netcatty:close:await",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  const closeRequest = child.messages.find((message) => (
+    message.kind === "request" && message.channel === "netcatty:close:await"
+  ));
+  const replacementRequest = child.messages.find((message) => (
+    message.kind === "request"
+    && message.channel === "netcatty:local:reconnect"
+    && message.requestId !== child.messages[0].requestId
+  ));
+  assert.equal(child.messages.indexOf(closeRequest) < child.messages.indexOf(replacementRequest), true);
+
+  child.emit("message", {
+    kind: "response",
+    requestId: closeRequest.requestId,
+    result: undefined,
+  });
+  child.emit("message", {
+    kind: "response",
+    requestId: replacementRequest.requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 1,
+  });
+  await close;
+  await replacementStart;
+  assert.equal(manager.hasOpenSession("session-1"), true);
+});
+
+test("an awaited close still notifies lifecycle cleanup when worker IPC is already dead", async () => {
+  const child = new FakeChild();
+  const closed = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: { fork: () => child },
+    terminalOutputChannel: { openSession() {}, closeSession() {} },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => closed.push(event));
+
+  const start = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  child.emit("message", {
+    kind: "response",
+    requestId: child.messages[0].requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await start;
+
+  child.postMessage = () => { throw new Error("IPC closed"); };
+  const close = manager.request(
+    "netcatty:close:await",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+
+  await assert.rejects(close, /IPC closed/u);
+  assert.deepEqual(closed, [{ sessionId: "session-1", reason: "closed" }]);
+  assert.equal(manager.hasOpenSession("session-1"), false);
+});
+
+test("a dead worker is replaced when close cleanup immediately restarts the same id", async () => {
+  const children = [];
+  let replacementStart;
+  const manager = createTerminalWorkerManager({
+    utilityProcess: {
+      fork() {
+        const child = new FakeChild();
+        children.push(child);
+        return child;
+      },
+    },
+    terminalOutputChannel: { openSession() {}, closeSession() {}, closeAll() {} },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return { id, send() {} };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+  manager.onSessionClosed((event) => {
+    if (event.reason !== "closed") return;
+    replacementStart = manager.request(
+      "netcatty:local:reconnect",
+      { sessionId: event.sessionId },
+      { webContentsId: 8 },
+    );
+    void replacementStart.catch(() => {});
+  });
+
+  const start = manager.request(
+    "netcatty:local:reconnect",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  const firstChild = children[0];
+  firstChild.emit("message", {
+    kind: "response",
+    requestId: firstChild.messages[0].requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await start;
+
+  firstChild.postMessage = () => { throw new Error("IPC closed"); };
+  const close = manager.request(
+    "netcatty:close:await",
+    { sessionId: "session-1" },
+    { webContentsId: 7 },
+  );
+  await assert.rejects(close, /IPC closed/u);
+  assert.equal(firstChild.killed, true);
+  assert.equal(children.length, 2);
+
+  const secondChild = children[1];
+  secondChild.emit("message", {
+    kind: "response",
+    requestId: secondChild.messages[0].requestId,
+    result: { sessionId: "session-1" },
+    sessionGeneration: 0,
+  });
+  await replacementStart;
+  firstChild.emit("exit", 1);
+
+  assert.equal(manager.hasOpenSession("session-1"), true);
+  assert.equal(children.length, 2);
 });
 
 test("worker exit notifies renderers for active worker sessions", async () => {
@@ -1976,7 +4080,10 @@ test("worker exit notifies host lifecycle listeners for every active session", a
     },
     workerScriptPath: "/worker.cjs",
   });
-  manager.onSessionClosed((event) => closed.push(event));
+  manager.onSessionClosed((event) => {
+    manager.detachTerminalInterceptor(event.sessionId, "input");
+    closed.push(event);
+  });
 
   const first = manager.request("netcatty:local:start", {}, { webContentsId: 7 });
   child.emit("message", {
@@ -1994,6 +4101,9 @@ test("worker exit notifies host lifecycle listeners for every active session", a
   });
   await second;
 
+  child.postMessage = () => {
+    throw new Error("worker IPC channel is closed");
+  };
   child.emit("exit", 1);
 
   assert.deepEqual(closed, [

--- a/electron/terminalWorker/runtime.cjs
+++ b/electron/terminalWorker/runtime.cjs
@@ -5,6 +5,16 @@ const {
   normalizeTrace,
 } = require("../bridges/terminalInterruptDiagnostics.cjs");
 
+const SESSION_START_CHANNELS = new Set([
+  "netcatty:start",
+  "netcatty:local:start",
+  "netcatty:telnet:start",
+  "netcatty:mosh:start",
+  "netcatty:et:start",
+  "netcatty:serial:start",
+  "netcatty:local:reconnect",
+]);
+
 function createIpcMainHarness() {
   const handlers = new Map();
   const listeners = new Map();
@@ -149,6 +159,8 @@ function createSender(
   terminalDataPipeline,
   pendingOutputBySession = new Map(),
   sessionOutputGenerations = new Map(),
+  sessionRequestIds = new Map(),
+  fixedOriginRequestId = null,
 ) {
   const ownedSessionGenerations = new Map();
   const getOwnedSessionGeneration = (sessionId) => {
@@ -166,6 +178,9 @@ function createSender(
     };
     void pending.then(clearPending, clearPending);
   };
+  const getOriginRequestId = (sessionId) => (
+    fixedOriginRequestId || sessionRequestIds.get(sessionId) || null
+  );
   const postRendererEvent = (channel, payload) => {
     const explicitGeneration = payload?._terminalSessionGeneration;
     const sessionGeneration = Number.isSafeInteger(explicitGeneration)
@@ -178,6 +193,7 @@ function createSender(
       : Object.freeze(Object.fromEntries(
         Object.entries(payload).filter(([key]) => key !== "_terminalSessionGeneration"),
       ));
+    const originRequestId = getOriginRequestId(payload?.sessionId);
     if (channel === "netcatty:exit" && payload?.sessionId) {
       if ((sessionOutputGenerations.get(payload.sessionId) ?? 0) === sessionGeneration) {
         sessionOutputGenerations.set(payload.sessionId, sessionGeneration + 1);
@@ -192,6 +208,7 @@ function createSender(
       channel,
       payload: rendererPayload,
       ...(sessionGeneration === undefined ? {} : { sessionGeneration }),
+      ...(originRequestId ? { originRequestId } : {}),
     });
   };
   const deliverTerminalData = (payload) => {
@@ -200,11 +217,14 @@ function createSender(
     const outputGeneration = Number.isSafeInteger(explicitGeneration)
       ? explicitGeneration
       : getOwnedSessionGeneration(sessionId);
+    const originRequestId = getOriginRequestId(sessionId);
     if ((sessionOutputGenerations.get(sessionId) ?? 0) !== outputGeneration) return;
     const tapMessage = {
       kind: "output-tap",
       sessionId: payload?.sessionId,
       data: payload?.data,
+      sessionGeneration: outputGeneration,
+      ...(originRequestId ? { originRequestId } : {}),
     };
     if (payload?.meta) tapMessage.meta = payload.meta;
     if (payload?.tapped !== true) parentPort.postMessage(tapMessage);
@@ -249,6 +269,8 @@ function createSender(
         sessionId: payload?.sessionId,
         data,
         tapped: true,
+        sessionGeneration: outputGeneration,
+        ...(originRequestId ? { originRequestId } : {}),
       };
       if (meta) outputMessage.meta = meta;
       parentPort.postMessage(outputMessage);
@@ -323,6 +345,11 @@ function createTerminalWorkerRuntime(options = {}) {
   const outputPorts = createOutputPortRegistry();
   const pendingOutputBySession = new Map();
   const sessionOutputGenerations = new Map();
+  const sessionRequestIds = new Map();
+  const sessionOperationTails = new Map();
+  const sessionOperationKinds = new Map();
+  const sessionCloseEpochs = new Map();
+  const sessionStartMarkers = new Set();
   let urgentInputPorts = null;
 
   const createWorkerOutputSender = () => createSender(
@@ -332,6 +359,7 @@ function createTerminalWorkerRuntime(options = {}) {
     terminalDataPipeline,
     pendingOutputBySession,
     sessionOutputGenerations,
+    sessionRequestIds,
   );
 
   function replayWorkerOutput(sessionId, chunks) {
@@ -359,6 +387,7 @@ function createTerminalWorkerRuntime(options = {}) {
     pendingOutputBySession.delete(sessionId);
     outputPorts.closeSession(sessionId);
     terminalDataPipeline?.detach?.(sessionId, undefined, "session-closed");
+    sessionRequestIds.delete(sessionId);
   }
 
   async function handleRequest(message) {
@@ -372,6 +401,9 @@ function createTerminalWorkerRuntime(options = {}) {
       return;
     }
     try {
+      const isSessionStart = SESSION_START_CHANNELS.has(message.channel);
+      const requestedSessionId = isSessionStart ? message.payload?.sessionId : null;
+      if (requestedSessionId) sessionRequestIds.set(requestedSessionId, message.requestId);
       const result = await handler({
         sender: createSender(
           parentPort,
@@ -380,9 +412,15 @@ function createTerminalWorkerRuntime(options = {}) {
           terminalDataPipeline,
           pendingOutputBySession,
           sessionOutputGenerations,
+          sessionRequestIds,
+          isSessionStart ? message.requestId : null,
         ),
       }, message.payload);
       const sessionId = result?.sessionId;
+      if (isSessionStart && sessionId) {
+        sessionRequestIds.set(sessionId, message.requestId);
+        sessionStartMarkers.add(sessionId);
+      }
       parentPort.postMessage({
         kind: "response",
         requestId: message.requestId,
@@ -398,6 +436,112 @@ function createTerminalWorkerRuntime(options = {}) {
         error: err?.message || String(err),
       });
     }
+  }
+
+  async function closeSupersededSessionStart(message) {
+    const sessionId = message.payload?.sessionId;
+    if (!sessionId) return;
+    parentPort.postMessage({
+      kind: "session-superseding",
+      sessionId,
+      sessionGeneration: sessionOutputGenerations.get(sessionId) ?? 0,
+      replacementRequestId: message.requestId,
+    });
+    invalidateSessionOutput(sessionId);
+    const closeHandler = ipcMain.handlers.get("netcatty:close:await");
+    if (closeHandler) {
+      await closeHandler({
+        sender: createSender(
+          parentPort,
+          message.webContentsId,
+          outputPorts,
+          terminalDataPipeline,
+          pendingOutputBySession,
+          sessionOutputGenerations,
+          sessionRequestIds,
+        ),
+      }, { sessionId });
+    }
+  }
+
+  function postRequestError(message, error) {
+    parentPort.postMessage({
+      kind: "response",
+      requestId: message.requestId,
+      error: error?.message || String(error),
+    });
+  }
+
+  function trackSessionOperation(sessionId, operation, kind) {
+    sessionOperationTails.set(sessionId, operation);
+    sessionOperationKinds.set(sessionId, kind);
+    void operation.finally(() => {
+      if (sessionOperationTails.get(sessionId) === operation) {
+        sessionOperationTails.delete(sessionId);
+        sessionOperationKinds.delete(sessionId);
+      }
+    });
+  }
+
+  function dispatchRequest(message) {
+    const sessionId = SESSION_START_CHANNELS.has(message.channel)
+      ? message.payload?.sessionId
+      : null;
+    if (message.channel === "netcatty:close:await" && message.payload?.sessionId) {
+      dispatchSessionClose(message, true);
+      return;
+    }
+    if (!sessionId) {
+      void handleRequest(message);
+      return;
+    }
+    const closeEpoch = sessionCloseEpochs.get(sessionId) ?? 0;
+    const previous = sessionOperationTails.get(sessionId);
+    const previousKind = sessionOperationKinds.get(sessionId);
+    const shouldClosePreviousStart = previousKind === "start" || sessionStartMarkers.has(sessionId);
+    const current = (previous || Promise.resolve()).catch(() => {}).then(async () => {
+      if ((sessionCloseEpochs.get(sessionId) ?? 0) !== closeEpoch) {
+        postRequestError(message, new Error("Terminal session start was cancelled by close"));
+        return;
+      }
+      try {
+        if (shouldClosePreviousStart) await closeSupersededSessionStart(message);
+        if ((sessionCloseEpochs.get(sessionId) ?? 0) !== closeEpoch) {
+          postRequestError(message, new Error("Terminal session start was cancelled by close"));
+          return;
+        }
+        sessionStartMarkers.add(sessionId);
+        await handleRequest(message);
+      } catch (error) {
+        postRequestError(message, error);
+      }
+    });
+    trackSessionOperation(sessionId, current, "start");
+  }
+
+  function dispatchSessionClose(message, expectsResponse) {
+    const sessionId = message.payload?.sessionId;
+    if (!sessionId) {
+      if (expectsResponse) void handleRequest(message);
+      else handleSend(message);
+      return;
+    }
+    sessionCloseEpochs.set(sessionId, (sessionCloseEpochs.get(sessionId) ?? 0) + 1);
+    const previous = sessionOperationTails.get(sessionId);
+    const current = (previous || Promise.resolve()).catch(() => {}).then(async () => {
+      try {
+        if (expectsResponse) {
+          invalidateSessionOutput(sessionId);
+          await handleRequest(message);
+        } else {
+          handleSend(message);
+        }
+        sessionStartMarkers.delete(sessionId);
+      } catch (error) {
+        if (expectsResponse) postRequestError(message, error);
+      }
+    });
+    trackSessionOperation(sessionId, current, "close");
   }
 
   function handleSend(message) {
@@ -450,16 +594,30 @@ function createTerminalWorkerRuntime(options = {}) {
       return;
     }
     if (message?.kind === "output-port") {
+      const sessionGeneration = sessionOutputGenerations.get(message.sessionId) ?? 0;
+      if (Number.isSafeInteger(message.sessionGeneration)
+        && message.sessionGeneration !== sessionGeneration) {
+        try { ports?.[0]?.close?.(); } catch {}
+        return;
+      }
       outputPorts.open(message.sessionId, ports?.[0]);
       replayWorkerOutput(message.sessionId, message.bufferedOutput);
       const pending = pendingOutputBySession.get(message.sessionId);
+      const notifyReady = () => parentPort.postMessage({
+        kind: "output-port-ready",
+        sessionId: message.sessionId,
+        ...(Number.isSafeInteger(message.sessionGeneration) ? { sessionGeneration } : {}),
+        ...(message.outputPortRequestId
+          ? { outputPortRequestId: message.outputPortRequestId }
+          : {}),
+      });
       if (pending) {
         void pending.then(
-          () => parentPort.postMessage({ kind: "output-port-ready", sessionId: message.sessionId }),
-          () => parentPort.postMessage({ kind: "output-port-ready", sessionId: message.sessionId }),
+          notifyReady,
+          notifyReady,
         );
       } else {
-        parentPort.postMessage({ kind: "output-port-ready", sessionId: message.sessionId });
+        notifyReady();
       }
       return;
     }
@@ -487,10 +645,14 @@ function createTerminalWorkerRuntime(options = {}) {
       return;
     }
     if (message?.kind === "request") {
-      void handleRequest(message);
+      dispatchRequest(message);
       return;
     }
     if (message?.kind === "send") {
+      if (message.channel === "netcatty:close" && message.payload?.sessionId) {
+        dispatchSessionClose(message, false);
+        return;
+      }
       handleSend(message);
     }
   }
@@ -514,6 +676,7 @@ function createTerminalWorkerRuntime(options = {}) {
         terminalDataPipeline,
         pendingOutputBySession,
         sessionOutputGenerations,
+        sessionRequestIds,
       );
     },
     closeUrgentInputPortsForTest() {

--- a/electron/terminalWorker/runtime.test.cjs
+++ b/electron/terminalWorker/runtime.test.cjs
@@ -82,6 +82,319 @@ test("runtime invokes registered request handlers and posts responses", async ()
   ]);
 });
 
+test("runtime serializes overlapping same-id starts and closes the superseded session first", async () => {
+  const parentPort = createParentPort();
+  const order = [];
+  let active = null;
+  let releaseFirst;
+  const firstGate = new Promise((resolve) => { releaseFirst = resolve; });
+  const runtime = createTerminalWorkerRuntime({
+    parentPort,
+    registerBridges(ipcMain) {
+      ipcMain.handle("netcatty:local:reconnect", async (_event, payload) => {
+        order.push(`start:${payload.attempt}`);
+        if (payload.attempt === "first") await firstGate;
+        active = payload.attempt;
+        order.push(`publish:${payload.attempt}`);
+        return { sessionId: payload.sessionId };
+      });
+      ipcMain.handle("netcatty:close:await", (_event, payload) => {
+        order.push(`close:${active}:${payload.sessionId}`);
+        active = null;
+      });
+    },
+  });
+  runtime.start();
+
+  parentPort.emitMessage({
+    kind: "request",
+    requestId: "req-1",
+    channel: "netcatty:local:reconnect",
+    payload: { sessionId: "session-1", attempt: "first" },
+    webContentsId: 7,
+  });
+  parentPort.emitMessage({
+    kind: "request",
+    requestId: "req-2",
+    channel: "netcatty:local:reconnect",
+    payload: { sessionId: "session-1", attempt: "second" },
+    webContentsId: 8,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(order, ["start:first"]);
+
+  releaseFirst();
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(order, [
+    "start:first",
+    "publish:first",
+    "close:first:session-1",
+    "start:second",
+    "publish:second",
+  ]);
+  assert.equal(active, "second");
+  assert.deepEqual(
+    parentPort.messages.filter((message) => message.kind === "response").map((message) => message.requestId),
+    ["req-1", "req-2"],
+  );
+});
+
+test("runtime closes a completed same-id start before a later request begins", async () => {
+  const parentPort = createParentPort();
+  const order = [];
+  let active = null;
+  const runtime = createTerminalWorkerRuntime({
+    parentPort,
+    registerBridges(ipcMain) {
+      ipcMain.handle("netcatty:local:reconnect", async (_event, payload) => {
+        order.push(`start:${payload.attempt}`);
+        active = payload.attempt;
+        order.push(`publish:${payload.attempt}`);
+        return { sessionId: payload.sessionId };
+      });
+      ipcMain.handle("netcatty:close:await", (_event, payload) => {
+        order.push(`close:${active}:${payload.sessionId}`);
+        active = null;
+      });
+    },
+  });
+  runtime.start();
+
+  parentPort.emitMessage({
+    kind: "request",
+    requestId: "req-1",
+    channel: "netcatty:local:reconnect",
+    payload: { sessionId: "session-1", attempt: "first" },
+    webContentsId: 7,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  parentPort.emitMessage({
+    kind: "request",
+    requestId: "req-2",
+    channel: "netcatty:local:reconnect",
+    payload: { sessionId: "session-1", attempt: "second" },
+    webContentsId: 8,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(order, [
+    "start:first",
+    "publish:first",
+    "close:first:session-1",
+    "start:second",
+    "publish:second",
+  ]);
+  assert.equal(active, "second");
+  assert.deepEqual(
+    parentPort.messages.filter((message) => message.kind === "session-superseding"),
+    [{
+      kind: "session-superseding",
+      sessionId: "session-1",
+      sessionGeneration: 0,
+      replacementRequestId: "req-2",
+    }],
+  );
+});
+
+test("runtime records a generated session id so a later same-id start closes it first", async () => {
+  const parentPort = createParentPort();
+  const order = [];
+  let active = null;
+  const runtime = createTerminalWorkerRuntime({
+    parentPort,
+    registerBridges(ipcMain) {
+      ipcMain.handle("netcatty:local:start", async (_event, payload) => {
+        order.push(`start:${payload.attempt}`);
+        active = payload.attempt;
+        return { sessionId: "generated-1" };
+      });
+      ipcMain.handle("netcatty:close:await", (_event, payload) => {
+        order.push(`close:${active}:${payload.sessionId}`);
+        active = null;
+      });
+    },
+  });
+  runtime.start();
+
+  parentPort.emitMessage({
+    kind: "request",
+    requestId: "req-1",
+    channel: "netcatty:local:start",
+    payload: { attempt: "first" },
+    webContentsId: 7,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  parentPort.emitMessage({
+    kind: "request",
+    requestId: "req-2",
+    channel: "netcatty:local:start",
+    payload: { sessionId: "generated-1", attempt: "second" },
+    webContentsId: 8,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(order, [
+    "start:first",
+    "close:first:generated-1",
+    "start:second",
+  ]);
+  assert.equal(active, "second");
+  assert.deepEqual(
+    parentPort.messages
+      .filter((message) => message.kind === "response")
+      .map((message) => message.sessionGeneration),
+    [0, 1],
+  );
+});
+
+test("runtime close waits for a pending start and removes the session it publishes", async () => {
+  const parentPort = createParentPort();
+  const order = [];
+  let active = null;
+  let releaseStart;
+  const startGate = new Promise((resolve) => { releaseStart = resolve; });
+  const runtime = createTerminalWorkerRuntime({
+    parentPort,
+    registerBridges(ipcMain) {
+      ipcMain.handle("netcatty:local:reconnect", async (_event, payload) => {
+        order.push("start");
+        await startGate;
+        active = payload.sessionId;
+        order.push("publish");
+        return { sessionId: payload.sessionId };
+      });
+      ipcMain.on("netcatty:close", (_event, payload) => {
+        order.push(`close:${payload.sessionId}`);
+        active = null;
+      });
+    },
+  });
+  runtime.start();
+
+  parentPort.emitMessage({
+    kind: "request",
+    requestId: "req-1",
+    channel: "netcatty:local:reconnect",
+    payload: { sessionId: "session-1" },
+    webContentsId: 7,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(order, ["start"]);
+  parentPort.emitMessage({
+    kind: "send",
+    channel: "netcatty:close",
+    payload: { sessionId: "session-1" },
+    webContentsId: 7,
+  });
+
+  releaseStart();
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(order, ["start", "publish", "close:session-1"]);
+  assert.equal(active, null);
+});
+
+test("runtime close cancels every same-id start that was queued before it", async () => {
+  const parentPort = createParentPort();
+  const starts = [];
+  let active = null;
+  let releaseFirst;
+  const firstGate = new Promise((resolve) => { releaseFirst = resolve; });
+  const runtime = createTerminalWorkerRuntime({
+    parentPort,
+    registerBridges(ipcMain) {
+      ipcMain.handle("netcatty:local:reconnect", async (_event, payload) => {
+        starts.push(payload.attempt);
+        if (payload.attempt === "first") await firstGate;
+        active = payload.attempt;
+        return { sessionId: payload.sessionId };
+      });
+      ipcMain.on("netcatty:close", () => { active = null; });
+    },
+  });
+  runtime.start();
+
+  parentPort.emitMessage({
+    kind: "request",
+    requestId: "req-1",
+    channel: "netcatty:local:reconnect",
+    payload: { sessionId: "session-1", attempt: "first" },
+    webContentsId: 7,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  parentPort.emitMessage({
+    kind: "request",
+    requestId: "req-2",
+    channel: "netcatty:local:reconnect",
+    payload: { sessionId: "session-1", attempt: "second" },
+    webContentsId: 7,
+  });
+  parentPort.emitMessage({
+    kind: "send",
+    channel: "netcatty:close",
+    payload: { sessionId: "session-1" },
+    webContentsId: 7,
+  });
+  releaseFirst();
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(starts, ["first"]);
+  assert.equal(active, null);
+  assert.equal(parentPort.messages.some((message) => (
+    message.requestId === "req-2" && /cancelled by close/u.test(message.error)
+  )), true);
+});
+
+test("runtime tags a failing start exit so its queued replacement can distinguish it", async () => {
+  const parentPort = createParentPort();
+  const runtime = createTerminalWorkerRuntime({
+    parentPort,
+    registerBridges(ipcMain) {
+      ipcMain.handle("netcatty:local:reconnect", async (event, payload) => {
+        if (payload.attempt === "first") {
+          event.sender.send("netcatty:exit", {
+            sessionId: payload.sessionId,
+            reason: "failed",
+          });
+          throw new Error("first failed");
+        }
+        return { sessionId: payload.sessionId };
+      });
+      ipcMain.handle("netcatty:close:await", () => {});
+    },
+  });
+  runtime.start();
+
+  for (const [requestId, attempt] of [["req-1", "first"], ["req-2", "second"]]) {
+    parentPort.emitMessage({
+      kind: "request",
+      requestId,
+      channel: "netcatty:local:reconnect",
+      payload: { sessionId: "session-1", attempt },
+      webContentsId: 7,
+    });
+  }
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const exit = parentPort.messages.find((message) => message.kind === "renderer-event");
+  assert.equal(exit.originRequestId, "req-1");
+  assert.equal(parentPort.messages.some((message) => (
+    message.requestId === "req-2" && message.result?.sessionId === "session-1"
+  )), true);
+});
+
 test("runtime routes interceptor ports to the worker-owned data pipeline", () => {
   const parentPort = createParentPort();
   const attached = [];
@@ -343,12 +656,14 @@ test("runtime routes terminal data over output messages", async () => {
     kind: "output-tap",
     sessionId: "s1",
     data: "hello",
+    sessionGeneration: 0,
   });
   assert.deepEqual(parentPort.messages[1], {
     kind: "output",
     sessionId: "s1",
     data: "hello",
     tapped: true,
+    sessionGeneration: 0,
   });
 });
 
@@ -411,12 +726,14 @@ test("runtime sends transformed output to the renderer while host taps retain or
     kind: "output-tap",
     sessionId: "s1",
     data: "hello",
+    sessionGeneration: 0,
   });
   assert.deepEqual(parentPort.messages[1], {
     kind: "output",
     sessionId: "s1",
     data: "HELLO",
     tapped: true,
+    sessionGeneration: 0,
     meta: {
       pluginPipelineIngressBytes: 5,
       pluginPipelineProcessed: true,
@@ -449,6 +766,7 @@ test("runtime classifies original prompts when only an output interceptor is act
     sessionId: "s1",
     data: "masked> ",
     tapped: true,
+    sessionGeneration: 0,
     meta: {
       pluginPipelineIngressBytes: 10,
       pluginPipelineProcessed: true,
@@ -663,6 +981,7 @@ test("runtime routes terminal data over a transferred output port", async () => 
     kind: "output-tap",
     sessionId: "s1",
     data: "hello",
+    sessionGeneration: 0,
   });
   assert.equal(parentPort.messages.some((message) => message.kind === "output"), false);
 });
@@ -897,6 +1216,7 @@ test("runtime.createSender uses the transferred output port", () => {
     kind: "output-tap",
     sessionId: "s1",
     data: "hello",
+    sessionGeneration: 0,
   });
 });
 


### PR DESCRIPTION
## Summary

- Notify host session lifecycle listeners when the terminal worker process exits.
- Ensure session-scoped terminal interceptor grants, cached provider selections, and pending session work are disposed before the same session id can reconnect.
- Add a regression test covering multiple active sessions during a worker crash.

Follow-up to #2402 and addresses its post-merge Codex review comment.

## Root cause

The worker-crash path notified renderers and cleared terminal routing state, but did not publish the host-side session-close event used by the plugin data pipeline to revoke session-scoped state.

## Validation

- 84 focused terminal worker and interceptor pipeline tests passed.
- Plugin runtime suite: 357 passed, 1 intentional skip.
- `npm run lint -- --quiet`
- `npm run build`
- `git diff --check`
- Full suite: 6682 passed, 7 skipped; one unrelated SSH authentication retry test failed and reproduces in isolation on unchanged SSH code.
- Two independent local reviews: clean for repository standards and clean for the review requirement.
