### PR TITLE
Improve keychain identity discoverability and layout

### DIFF
--- a/components/KeychainCardLayout.test.tsx
+++ b/components/KeychainCardLayout.test.tsx
@@ -10,6 +10,7 @@ import KeychainManager from "./KeychainManager.tsx";
 import { IdentityCard } from "./keychain/IdentityCard.tsx";
 import { KeyCard } from "./keychain/KeyCard.tsx";
 import {
+  resolvePreferredKeySection,
   shouldShowIdentitySection,
   shouldShowKeySection,
   shouldShowSearchNoResults,
@@ -266,6 +267,27 @@ test("keychain browsing keeps sections exclusive outside search", () => {
     filteredKeyCount: 1,
     search: "",
   }), true);
+});
+
+test("keychain browsing can switch back to the full key section", () => {
+  const state = {
+    activeFilter: "key" as const,
+    identityCount: 1,
+    filteredIdentityCount: 1,
+    filteredKeyCount: 1,
+    preferredSection: "key" as const,
+    search: "",
+  };
+
+  assert.equal(shouldShowIdentitySection(state), false);
+  assert.equal(shouldShowKeySection(state), true);
+});
+
+test("keychain default follows identities until the user chooses a section", () => {
+  assert.equal(resolvePreferredKeySection(null, 0), "key");
+  assert.equal(resolvePreferredKeySection(null, 1), "identity");
+  assert.equal(resolvePreferredKeySection("key", 1), "key");
+  assert.equal(resolvePreferredKeySection("identity", 0), "key");
 });
 
 test("keychain distinguishes search misses from an empty vault", () => {

--- a/components/KeychainCardLayout.test.tsx
+++ b/components/KeychainCardLayout.test.tsx
@@ -117,7 +117,7 @@ test("KeyCard list layout constrains long labels", () => {
   assert.match(markup, /block max-w-full truncate text-sm font-semibold/);
 });
 
-test("KeychainManager list layout constrains long key and identity rows", () => {
+test("KeychainManager shows identities without the keys section when identities exist", () => {
   installNavigatorStub();
   installStorageStub("list");
 
@@ -145,6 +145,65 @@ test("KeychainManager list layout constrains long key and identity rows", () => 
   assert.doesNotMatch(markup, /flex-1 min-w-0 w-full overflow-y-auto overflow-x-hidden/);
   assert.match(markup, /flex min-w-0 w-full max-w-full flex-col gap-0/);
   assert.match(markup, /block min-w-0 w-full max-w-full/);
-  assert.match(markup, /Keys/);
-  assert.match(markup, /Identities/);
+  assert.match(markup, /data-section="keychain-identities"/);
+  assert.doesNotMatch(markup, /data-section="keychain-keys"/);
+  assert.doesNotMatch(markup, /data-section="keychain-empty"/);
+});
+
+test("KeychainManager shows keys without the identities section when no identities exist", () => {
+  installNavigatorStub();
+  installStorageStub();
+
+  const markup = renderWithI18n(
+    React.createElement(KeychainManager, {
+      keys: [keyItem],
+      identities: [],
+      onSave: () => {},
+      onUpdate: () => {},
+      onDelete: () => {},
+      onSaveIdentity: () => {},
+    }),
+  );
+
+  assert.match(markup, /data-section="keychain-keys"/);
+  assert.doesNotMatch(markup, /data-section="keychain-identities"/);
+  assert.doesNotMatch(markup, /data-section="keychain-empty"/);
+});
+
+test("KeychainManager shows the empty prompt only when keys and identities are absent", () => {
+  installNavigatorStub();
+  installStorageStub();
+
+  const markup = renderWithI18n(
+    React.createElement(KeychainManager, {
+      keys: [],
+      identities: [],
+      onSave: () => {},
+      onUpdate: () => {},
+      onDelete: () => {},
+      onSaveIdentity: () => {},
+    }),
+  );
+
+  assert.match(markup, /data-section="keychain-keys"/);
+  assert.match(markup, /data-section="keychain-empty"/);
+  assert.doesNotMatch(markup, /data-section="keychain-identities"/);
+});
+
+test("KeychainManager exposes the new identity action in the header", () => {
+  installNavigatorStub();
+  installStorageStub();
+
+  const markup = renderWithI18n(
+    React.createElement(KeychainManager, {
+      keys: [],
+      identities: [],
+      onSave: () => {},
+      onUpdate: () => {},
+      onDelete: () => {},
+      onSaveIdentity: () => {},
+    }),
+  );
+
+  assert.match(markup, />New Identity<\/button>/);
 });

--- a/components/KeychainCardLayout.test.tsx
+++ b/components/KeychainCardLayout.test.tsx
@@ -11,6 +11,7 @@ import { IdentityCard } from "./keychain/IdentityCard.tsx";
 import { KeyCard } from "./keychain/KeyCard.tsx";
 import {
   shouldShowIdentitySection,
+  shouldShowKeySection,
   shouldShowSearchNoResults,
 } from "./keychain/utils.ts";
 
@@ -236,6 +237,34 @@ test("keychain search keeps identities for identity matches or no results", () =
     filteredIdentityCount: 0,
     filteredKeyCount: 0,
     search: "no-results",
+  }), true);
+});
+
+test("keychain search shows both sections when both kinds match", () => {
+  const state = {
+    activeFilter: "key" as const,
+    identityCount: 1,
+    filteredIdentityCount: 1,
+    filteredKeyCount: 1,
+    search: "shared-label",
+  };
+
+  assert.equal(shouldShowIdentitySection(state), true);
+  assert.equal(shouldShowKeySection(state), true);
+});
+
+test("keychain browsing keeps sections exclusive outside search", () => {
+  assert.equal(shouldShowKeySection({
+    activeFilter: "key",
+    identityCount: 1,
+    filteredKeyCount: 1,
+    search: "",
+  }), false);
+  assert.equal(shouldShowKeySection({
+    activeFilter: "key",
+    identityCount: 0,
+    filteredKeyCount: 1,
+    search: "",
   }), true);
 });
 

--- a/components/KeychainCardLayout.test.tsx
+++ b/components/KeychainCardLayout.test.tsx
@@ -9,6 +9,7 @@ import type { Identity, SSHKey } from "../types.ts";
 import KeychainManager from "./KeychainManager.tsx";
 import { IdentityCard } from "./keychain/IdentityCard.tsx";
 import { KeyCard } from "./keychain/KeyCard.tsx";
+import { shouldShowIdentitySection } from "./keychain/utils.ts";
 
 const longLabel =
   "sdakdjkasjakjskajskaijssdakdjkasjakjskajskaijssdakdjkasjakjskajskaijssdakdjkasjakjskajskaijs";
@@ -206,4 +207,31 @@ test("KeychainManager exposes the new identity action in the header", () => {
   );
 
   assert.match(markup, />New Identity<\/button>/);
+});
+
+test("keychain search reveals matching keys when identities do not match", () => {
+  assert.equal(shouldShowIdentitySection({
+    activeFilter: "key",
+    identityCount: 1,
+    filteredIdentityCount: 0,
+    filteredKeyCount: 1,
+    search: "matching-key",
+  }), false);
+});
+
+test("keychain search keeps identities for identity matches or no results", () => {
+  assert.equal(shouldShowIdentitySection({
+    activeFilter: "key",
+    identityCount: 1,
+    filteredIdentityCount: 1,
+    filteredKeyCount: 0,
+    search: "matching-identity",
+  }), true);
+  assert.equal(shouldShowIdentitySection({
+    activeFilter: "key",
+    identityCount: 1,
+    filteredIdentityCount: 0,
+    filteredKeyCount: 0,
+    search: "no-results",
+  }), true);
 });

--- a/components/KeychainCardLayout.test.tsx
+++ b/components/KeychainCardLayout.test.tsx
@@ -9,7 +9,10 @@ import type { Identity, SSHKey } from "../types.ts";
 import KeychainManager from "./KeychainManager.tsx";
 import { IdentityCard } from "./keychain/IdentityCard.tsx";
 import { KeyCard } from "./keychain/KeyCard.tsx";
-import { shouldShowIdentitySection } from "./keychain/utils.ts";
+import {
+  shouldShowIdentitySection,
+  shouldShowSearchNoResults,
+} from "./keychain/utils.ts";
 
 const longLabel =
   "sdakdjkasjakjskajskaijssdakdjkasjakjskajskaijssdakdjkasjakjskajskaijssdakdjkasjakjskajskaijs";
@@ -234,4 +237,10 @@ test("keychain search keeps identities for identity matches or no results", () =
     filteredKeyCount: 0,
     search: "no-results",
   }), true);
+});
+
+test("keychain distinguishes search misses from an empty vault", () => {
+  assert.equal(shouldShowSearchNoResults("missing", 0, 1), true);
+  assert.equal(shouldShowSearchNoResults("", 0, 1), false);
+  assert.equal(shouldShowSearchNoResults("missing", 0, 0), false);
 });

--- a/components/KeychainManager.tsx
+++ b/components/KeychainManager.tsx
@@ -49,6 +49,7 @@ import {
   VaultHeaderSearch,
   VaultPageHeader,
   vaultHeaderIconButtonClass,
+  vaultHeaderSecondaryButtonClass,
   vaultSectionTitleClass,
 } from "./vault/VaultPageHeader";
 import { VaultDeleteConfirmDialog } from "./vault/VaultDeleteConfirmDialog";
@@ -209,11 +210,10 @@ echo $3 >> "$FILE"`);
     toast.error(message, title);
   }, [t]);
 
-  // Filter keys based on active tab and search
-  const filteredKeys = useMemo(() => {
+  // Filter keys based on active tab
+  const keysForActiveFilter = useMemo(() => {
     let result = keys;
 
-    // Filter by tab
     switch (activeFilter) {
       case "key":
         result = result.filter(
@@ -227,7 +227,13 @@ echo $3 >> "$FILE"`);
         break;
     }
 
-    // Filter by search
+    return sortByVaultOrder(result);
+  }, [keys, activeFilter]);
+
+  // Filter the active key collection by search
+  const filteredKeys = useMemo(() => {
+    let result = keysForActiveFilter;
+
     if (search.trim()) {
       const s = search.toLowerCase();
       result = result.filter(
@@ -238,8 +244,8 @@ echo $3 >> "$FILE"`);
       );
     }
 
-    return sortByVaultOrder(result);
-  }, [keys, activeFilter, search]);
+    return result;
+  }, [keysForActiveFilter, search]);
 
   // Filter identities based on search
   const filteredIdentities = useMemo(() => {
@@ -251,6 +257,9 @@ echo $3 >> "$FILE"`);
         i.username.toLowerCase().includes(s),
     ));
   }, [identities, search]);
+
+  const showIdentitySection = activeFilter === "key" && identities.length > 0;
+  const showKeySection = !showIdentitySection;
 
   // Push a new panel onto the stack
   const pushPanel = useCallback((newPanel: PanelMode) => {
@@ -635,15 +644,6 @@ echo $3 >> "$FILE"`);
                 >
                   <Upload size={14} /> {t("keychain.action.importKey")}
                 </Button>
-                {onSaveIdentity && (
-                  <Button
-                    variant="ghost"
-                    className="w-full justify-start gap-2"
-                    onClick={openNewIdentity}
-                  >
-                    <UserPlus size={14} /> {t("keychain.action.newIdentity")}
-                  </Button>
-                )}
               </DropdownContent>
             </Dropdown>
 
@@ -686,6 +686,18 @@ echo $3 >> "$FILE"`);
                 </Button>
               </DropdownContent>
             </Dropdown>
+
+            {onSaveIdentity && (
+              <Button
+                size="sm"
+                variant="secondary"
+                className={cn(vaultHeaderSecondaryButtonClass, "shrink-0")}
+                onClick={openNewIdentity}
+              >
+                <UserPlus size={14} />
+                {t("keychain.action.newIdentity")}
+              </Button>
+            )}
           </div>
 
           {/* Search and View Mode - hide search when panel is open */}
@@ -755,132 +767,143 @@ echo $3 >> "$FILE"`);
           }}
         >
           {/* Keys Section */}
-          <div className="min-w-0 w-full space-y-3 p-3">
-            <div className="flex items-center justify-between">
-              <h2 className={vaultSectionTitleClass}>
-                {t("keychain.section.keys")}
-              </h2>
-              <span className="text-xs text-muted-foreground">
-                {t("keychain.count.items", { count: filteredKeys.length })}
-              </span>
-            </div>
-
-          {filteredKeys.length === 0 ? (
-            <div className="flex flex-col items-center justify-center h-64 text-muted-foreground">
-              <div className="h-16 w-16 rounded-2xl bg-secondary/80 flex items-center justify-center mb-4">
-                <Shield size={32} className="opacity-60" />
+          {showKeySection && (
+            <div
+              className="min-w-0 w-full space-y-3 p-3"
+              data-section="keychain-keys"
+            >
+              <div className="flex items-center justify-between">
+                <h2 className={vaultSectionTitleClass}>
+                  {t("keychain.section.keys")}
+                </h2>
+                <span className="text-xs text-muted-foreground">
+                  {t("keychain.count.items", { count: filteredKeys.length })}
+                </span>
               </div>
-              <h3 className="text-lg font-semibold text-foreground mb-2">
-                {t("keychain.empty.title")}
-              </h3>
-              <p className="text-sm text-center max-w-sm mb-4">
-                {t("keychain.empty.desc")}
-              </p>
-              {(activeFilter === "key" || activeFilter === "certificate") && (
-                <div className="flex gap-2">
-                  <Button variant="secondary" onClick={openImport}>
-                    <Upload size={14} className="mr-2" />
-                    {t("common.import")}
-                  </Button>
-                  <Button onClick={openGenerate}>
-                    <Plus size={14} className="mr-2" />
-                    {t("common.generate")}
-                  </Button>
+
+              {keysForActiveFilter.length === 0 ? (
+                <div
+                  className="flex flex-col items-center justify-center h-64 text-muted-foreground"
+                  data-section="keychain-empty"
+                >
+                  <div className="h-16 w-16 rounded-2xl bg-secondary/80 flex items-center justify-center mb-4">
+                    <Shield size={32} className="opacity-60" />
+                  </div>
+                  <h3 className="text-lg font-semibold text-foreground mb-2">
+                    {t("keychain.empty.title")}
+                  </h3>
+                  <p className="text-sm text-center max-w-sm mb-4">
+                    {t("keychain.empty.desc")}
+                  </p>
+                  {(activeFilter === "key" || activeFilter === "certificate") && (
+                    <div className="flex gap-2">
+                      <Button variant="secondary" onClick={openImport}>
+                        <Upload size={14} className="mr-2" />
+                        {t("common.import")}
+                      </Button>
+                      <Button onClick={openGenerate}>
+                        <Plus size={14} className="mr-2" />
+                        {t("common.generate")}
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div
+                  className={
+                    viewMode === "grid"
+                      ? "grid min-w-0 w-full max-w-full gap-3 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+                      : "flex min-w-0 w-full max-w-full flex-col gap-0"
+                  }
+                >
+                  {filteredKeys.map((key) => (
+                    <KeyCard
+                      key={key.id}
+                      keyItem={key}
+                      viewMode={viewMode}
+                      isSelected={
+                        (panel.type === "view" && panel.key.id === key.id) ||
+                        (panel.type === "export" && panel.key.id === key.id)
+                      }
+                      isMac={isMacOS()}
+                      reorderProps={keyReorder.getItemReorderProps(key.id, `key:${key.id}`)}
+                      onClick={() => openKeyView(key)}
+                      onEdit={() => openKeyEdit(key)}
+                      onExport={() => openKeyExport(key)}
+                      onCopyPublicKey={() => copyPublicKey(key)}
+                      onDelete={() => handleDelete(key.id)}
+                    />
+                  ))}
                 </div>
               )}
             </div>
-          ) : (
+          )}
+
+          {/* Identities Section */}
+          {showIdentitySection && (
             <div
-              className={
-                viewMode === "grid"
-                  ? "grid min-w-0 w-full max-w-full gap-3 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
-                  : "flex min-w-0 w-full max-w-full flex-col gap-0"
-              }
+              className="min-w-0 w-full space-y-3 p-3"
+              data-section="keychain-identities"
             >
-              {filteredKeys.map((key) => (
-                <KeyCard
-                  key={key.id}
-                  keyItem={key}
-                  viewMode={viewMode}
-                  isSelected={
-                    (panel.type === "view" && panel.key.id === key.id) ||
-                    (panel.type === "export" && panel.key.id === key.id)
-                  }
-                  isMac={isMacOS()}
-                  reorderProps={keyReorder.getItemReorderProps(key.id, `key:${key.id}`)}
-                  onClick={() => openKeyView(key)}
-                  onEdit={() => openKeyEdit(key)}
-                  onExport={() => openKeyExport(key)}
-                  onCopyPublicKey={() => copyPublicKey(key)}
-                  onDelete={() => handleDelete(key.id)}
-                />
-              ))}
+              <div className="flex items-center justify-between">
+                <h2 className={vaultSectionTitleClass}>
+                  {t("keychain.section.identities")}
+                </h2>
+                <span className="text-xs text-muted-foreground">
+                  {t("keychain.count.items", { count: filteredIdentities.length })}
+                </span>
+              </div>
+              <div
+                className={
+                  viewMode === "grid"
+                    ? "grid min-w-0 w-full max-w-full gap-3 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+                    : "flex min-w-0 w-full max-w-full flex-col gap-0"
+                }
+              >
+                {filteredIdentities.map((identity) => (
+                  <ContextMenu key={identity.id}>
+                    <ContextMenuTrigger className="block min-w-0 w-full max-w-full">
+                      <IdentityCard
+                        identity={identity}
+                        viewMode={viewMode}
+                        isSelected={
+                          panel.type === "identity" &&
+                          panel.identity?.id === identity.id
+                        }
+                        reorderProps={identityReorder.getItemReorderProps(identity.id, `identity:${identity.id}`)}
+                        onClick={() => {
+                          setPanelStack([{ type: "identity", identity }]);
+                          setDraftIdentity({ ...identity });
+                        }}
+                      />
+                    </ContextMenuTrigger>
+                    <ContextMenuContent>
+                      <ContextMenuItem
+                        onClick={() => {
+                          setPanelStack([{ type: "identity", identity }]);
+                          setDraftIdentity({ ...identity });
+                        }}
+                      >
+                        <Edit2 className="mr-2 h-4 w-4" /> {t("action.edit")}
+                      </ContextMenuItem>
+                      {onDeleteIdentity && (
+                        <>
+                          <ContextMenuSeparator />
+                          <ContextMenuItem
+                            className="text-destructive"
+                            onClick={() => _handleDeleteIdentity(identity.id)}
+                          >
+                            <Trash2 className="mr-2 h-4 w-4" />{" "}
+                            {t("action.delete")}
+                          </ContextMenuItem>
+                        </>
+                      )}
+                    </ContextMenuContent>
+                  </ContextMenu>
+                ))}
+              </div>
             </div>
           )}
-        </div>
-
-        {/* Identities Section */}
-        {activeFilter === "key" && filteredIdentities.length > 0 && (
-          <div className="min-w-0 w-full space-y-3 px-3 pb-3">
-            <div className="flex items-center justify-between">
-              <h2 className={vaultSectionTitleClass}>
-                {t("keychain.section.identities")}
-              </h2>
-              <span className="text-xs text-muted-foreground">
-                {t("keychain.count.items", { count: filteredIdentities.length })}
-              </span>
-            </div>
-            <div
-              className={
-                viewMode === "grid"
-                  ? "grid min-w-0 w-full max-w-full gap-3 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
-                  : "flex min-w-0 w-full max-w-full flex-col gap-0"
-              }
-            >
-              {filteredIdentities.map((identity) => (
-                <ContextMenu key={identity.id}>
-                  <ContextMenuTrigger className="block min-w-0 w-full max-w-full">
-                    <IdentityCard
-                      identity={identity}
-                      viewMode={viewMode}
-                      isSelected={
-                        panel.type === "identity" &&
-                        panel.identity?.id === identity.id
-                      }
-                      reorderProps={identityReorder.getItemReorderProps(identity.id, `identity:${identity.id}`)}
-                      onClick={() => {
-                        setPanelStack([{ type: "identity", identity }]);
-                        setDraftIdentity({ ...identity });
-                      }}
-                    />
-                  </ContextMenuTrigger>
-                  <ContextMenuContent>
-                    <ContextMenuItem
-                      onClick={() => {
-                        setPanelStack([{ type: "identity", identity }]);
-                        setDraftIdentity({ ...identity });
-                      }}
-                    >
-                      <Edit2 className="mr-2 h-4 w-4" /> {t("action.edit")}
-                    </ContextMenuItem>
-                    {onDeleteIdentity && (
-                      <>
-                        <ContextMenuSeparator />
-                        <ContextMenuItem
-                          className="text-destructive"
-                          onClick={() => _handleDeleteIdentity(identity.id)}
-                        >
-                          <Trash2 className="mr-2 h-4 w-4" />{" "}
-                          {t("action.delete")}
-                        </ContextMenuItem>
-                      </>
-                    )}
-                  </ContextMenuContent>
-                </ContextMenu>
-              ))}
-            </div>
-          </div>
-        )}
         </div>
       </div>
 

--- a/components/KeychainManager.tsx
+++ b/components/KeychainManager.tsx
@@ -66,6 +66,7 @@ import {
   KeyCard,
   type PanelMode,
   shouldShowIdentitySection,
+  shouldShowKeySection,
   shouldShowSearchNoResults,
   ViewKeyPanel,
 } from "./keychain";
@@ -267,7 +268,12 @@ echo $3 >> "$FILE"`);
     filteredKeyCount: filteredKeys.length,
     search,
   });
-  const showKeySection = !showIdentitySection;
+  const showKeySection = shouldShowKeySection({
+    activeFilter,
+    identityCount: identities.length,
+    filteredKeyCount: filteredKeys.length,
+    search,
+  });
 
   // Push a new panel onto the stack
   const pushPanel = useCallback((newPanel: PanelMode) => {

--- a/components/KeychainManager.tsx
+++ b/components/KeychainManager.tsx
@@ -11,6 +11,7 @@ import {
   Shield,
   Trash2,
   Upload,
+  User,
   UserPlus,
 } from "lucide-react";
 import React, { useCallback, useMemo, useRef, useState } from "react";
@@ -65,6 +66,7 @@ import {
   isMacOS,
   KeyCard,
   type PanelMode,
+  resolvePreferredKeySection,
   shouldShowIdentitySection,
   shouldShowKeySection,
   shouldShowSearchNoResults,
@@ -119,6 +121,11 @@ const KeychainManager: React.FC<KeychainManagerProps> = ({
   const { t } = useI18n();
   const { generateKeyPair, execCommand } = useKeychainBackend();
   const [activeFilter, setActiveFilter] = useState<FilterTab>("key");
+  const [preferredKeySection, setPreferredKeySection] = useState<"key" | "identity" | null>(null);
+  const effectiveKeySection = resolvePreferredKeySection(
+    preferredKeySection,
+    identities.length,
+  );
   const [search, setSearch] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<{
     type: "key" | "identity";
@@ -266,14 +273,23 @@ echo $3 >> "$FILE"`);
     identityCount: identities.length,
     filteredIdentityCount: filteredIdentities.length,
     filteredKeyCount: filteredKeys.length,
+    preferredSection: preferredKeySection,
     search,
   });
   const showKeySection = shouldShowKeySection({
     activeFilter,
     identityCount: identities.length,
     filteredKeyCount: filteredKeys.length,
+    preferredSection: preferredKeySection,
     search,
   });
+  const hasSearch = Boolean(search.trim());
+  const keyButtonActive = activeFilter === "key" && (
+    hasSearch ? showKeySection : effectiveKeySection === "key"
+  );
+  const identityButtonActive = activeFilter === "key" && (
+    hasSearch ? showIdentitySection : effectiveKeySection === "identity"
+  );
 
   // Push a new panel onto the stack
   const pushPanel = useCallback((newPanel: PanelMode) => {
@@ -343,6 +359,8 @@ echo $3 >> "$FILE"`);
 
   // Open panel for new identity
   const openNewIdentity = useCallback(() => {
+    setActiveFilter("key");
+    setPreferredKeySection("identity");
     setPanelStack([{ type: "identity" }]);
     setDraftIdentity({
       id: "",
@@ -619,7 +637,7 @@ echo $3 >> "$FILE"`);
               <div
                 className={cn(
                   "flex items-center rounded-md transition-colors",
-                  activeFilter === "key"
+                  keyButtonActive
                     ? "bg-foreground/10 text-foreground hover:bg-foreground/15"
                     : "bg-foreground/5 text-foreground hover:bg-foreground/10",
                 )}
@@ -628,7 +646,11 @@ echo $3 >> "$FILE"`);
                   size="sm"
                   variant="ghost"
                   className="h-10 px-3 gap-2 rounded-r-none hover:bg-transparent text-inherit"
-                  onClick={() => setActiveFilter("key")}
+                  onClick={() => {
+                    setActiveFilter("key");
+                    setPreferredKeySection("key");
+                    setSearch("");
+                  }}
                 >
                   <Key size={14} />
                   {t("keychain.filter.key")}
@@ -700,6 +722,27 @@ echo $3 >> "$FILE"`);
                 </Button>
               </DropdownContent>
             </Dropdown>
+
+            {identities.length > 0 && (
+              <Button
+                size="sm"
+                variant="ghost"
+                className={cn(
+                  "h-10 px-3 gap-2 shrink-0",
+                  identityButtonActive
+                    ? "bg-foreground/10 text-foreground hover:bg-foreground/15"
+                    : "bg-foreground/5 text-foreground hover:bg-foreground/10",
+                )}
+                onClick={() => {
+                  setActiveFilter("key");
+                  setPreferredKeySection("identity");
+                  setSearch("");
+                }}
+              >
+                <User size={14} />
+                {t("keychain.section.identities")}
+              </Button>
+            )}
 
             {onSaveIdentity && (
               <Button

--- a/components/KeychainManager.tsx
+++ b/components/KeychainManager.tsx
@@ -66,6 +66,7 @@ import {
   KeyCard,
   type PanelMode,
   shouldShowIdentitySection,
+  shouldShowSearchNoResults,
   ViewKeyPanel,
 } from "./keychain";
 
@@ -815,6 +816,17 @@ echo $3 >> "$FILE"`);
                     </div>
                   )}
                 </div>
+              ) : shouldShowSearchNoResults(
+                search,
+                filteredKeys.length,
+                keysForActiveFilter.length,
+              ) ? (
+                <div
+                  className="flex h-40 items-center justify-center text-sm text-muted-foreground"
+                  data-section="keychain-no-results"
+                >
+                  {t("common.noResultsFound")}
+                </div>
               ) : (
                 <div
                   className={
@@ -860,14 +872,26 @@ echo $3 >> "$FILE"`);
                   {t("keychain.count.items", { count: filteredIdentities.length })}
                 </span>
               </div>
-              <div
-                className={
-                  viewMode === "grid"
-                    ? "grid min-w-0 w-full max-w-full gap-3 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
-                    : "flex min-w-0 w-full max-w-full flex-col gap-0"
-                }
-              >
-                {filteredIdentities.map((identity) => (
+              {shouldShowSearchNoResults(
+                search,
+                filteredIdentities.length,
+                identities.length,
+              ) ? (
+                <div
+                  className="flex h-40 items-center justify-center text-sm text-muted-foreground"
+                  data-section="keychain-no-results"
+                >
+                  {t("common.noResultsFound")}
+                </div>
+              ) : (
+                <div
+                  className={
+                    viewMode === "grid"
+                      ? "grid min-w-0 w-full max-w-full gap-3 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+                      : "flex min-w-0 w-full max-w-full flex-col gap-0"
+                  }
+                >
+                  {filteredIdentities.map((identity) => (
                   <ContextMenu key={identity.id}>
                     <ContextMenuTrigger className="block min-w-0 w-full max-w-full">
                       <IdentityCard
@@ -907,8 +931,9 @@ echo $3 >> "$FILE"`);
                       )}
                     </ContextMenuContent>
                   </ContextMenu>
-                ))}
-              </div>
+                  ))}
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/components/KeychainManager.tsx
+++ b/components/KeychainManager.tsx
@@ -65,6 +65,7 @@ import {
   isMacOS,
   KeyCard,
   type PanelMode,
+  shouldShowIdentitySection,
   ViewKeyPanel,
 } from "./keychain";
 
@@ -258,7 +259,13 @@ echo $3 >> "$FILE"`);
     ));
   }, [identities, search]);
 
-  const showIdentitySection = activeFilter === "key" && identities.length > 0;
+  const showIdentitySection = shouldShowIdentitySection({
+    activeFilter,
+    identityCount: identities.length,
+    filteredIdentityCount: filteredIdentities.length,
+    filteredKeyCount: filteredKeys.length,
+    search,
+  });
   const showKeySection = !showIdentitySection;
 
   // Push a new panel onto the stack

--- a/components/keychain/index.ts
+++ b/components/keychain/index.ts
@@ -6,7 +6,7 @@
 
 // Utilities and types
 export {
-isMacOS,type FilterTab,type PanelMode
+isMacOS,shouldShowIdentitySection,type FilterTab,type PanelMode
 } from './utils';
 
 // Card components

--- a/components/keychain/index.ts
+++ b/components/keychain/index.ts
@@ -6,7 +6,7 @@
 
 // Utilities and types
 export {
-isMacOS,shouldShowIdentitySection,shouldShowKeySection,shouldShowSearchNoResults,type FilterTab,type PanelMode
+isMacOS,resolvePreferredKeySection,shouldShowIdentitySection,shouldShowKeySection,shouldShowSearchNoResults,type FilterTab,type PanelMode
 } from './utils';
 
 // Card components

--- a/components/keychain/index.ts
+++ b/components/keychain/index.ts
@@ -6,7 +6,7 @@
 
 // Utilities and types
 export {
-isMacOS,shouldShowIdentitySection,shouldShowSearchNoResults,type FilterTab,type PanelMode
+isMacOS,shouldShowIdentitySection,shouldShowKeySection,shouldShowSearchNoResults,type FilterTab,type PanelMode
 } from './utils';
 
 // Card components

--- a/components/keychain/index.ts
+++ b/components/keychain/index.ts
@@ -6,7 +6,7 @@
 
 // Utilities and types
 export {
-isMacOS,shouldShowIdentitySection,type FilterTab,type PanelMode
+isMacOS,shouldShowIdentitySection,shouldShowSearchNoResults,type FilterTab,type PanelMode
 } from './utils';
 
 // Card components

--- a/components/keychain/utils.ts
+++ b/components/keychain/utils.ts
@@ -72,18 +72,27 @@ interface IdentitySectionVisibilityOptions {
     identityCount: number;
     filteredIdentityCount: number;
     filteredKeyCount: number;
+    preferredSection?: 'key' | 'identity' | null;
     search: string;
 }
+
+export const resolvePreferredKeySection = (
+    preferredSection: 'key' | 'identity' | null,
+    identityCount: number,
+): 'key' | 'identity' => identityCount === 0
+    ? 'key'
+    : (preferredSection ?? 'identity');
 
 export const shouldShowIdentitySection = ({
     activeFilter,
     identityCount,
     filteredIdentityCount,
     filteredKeyCount,
+    preferredSection = null,
     search,
 }: IdentitySectionVisibilityOptions): boolean => {
     if (activeFilter !== 'key' || identityCount === 0) return false;
-    if (!search.trim()) return true;
+    if (!search.trim()) return resolvePreferredKeySection(preferredSection, identityCount) === 'identity';
 
     return filteredIdentityCount > 0 || filteredKeyCount === 0;
 };
@@ -92,13 +101,14 @@ export const shouldShowKeySection = ({
     activeFilter,
     identityCount,
     filteredKeyCount,
+    preferredSection = null,
     search,
 }: Pick<
     IdentitySectionVisibilityOptions,
-    'activeFilter' | 'identityCount' | 'filteredKeyCount' | 'search'
+    'activeFilter' | 'identityCount' | 'filteredKeyCount' | 'preferredSection' | 'search'
 >): boolean => {
     if (activeFilter !== 'key' || identityCount === 0) return true;
-    if (!search.trim()) return false;
+    if (!search.trim()) return resolvePreferredKeySection(preferredSection, identityCount) === 'key';
 
     return filteredKeyCount > 0;
 };

--- a/components/keychain/utils.ts
+++ b/components/keychain/utils.ts
@@ -87,3 +87,9 @@ export const shouldShowIdentitySection = ({
 
     return filteredIdentityCount > 0 || filteredKeyCount === 0;
 };
+
+export const shouldShowSearchNoResults = (
+    search: string,
+    filteredItemCount: number,
+    totalItemCount: number,
+): boolean => Boolean(search.trim()) && totalItemCount > 0 && filteredItemCount === 0;

--- a/components/keychain/utils.ts
+++ b/components/keychain/utils.ts
@@ -66,3 +66,24 @@ export type PanelMode =
 
 // Filter tab types
 export type FilterTab = 'key' | 'certificate';
+
+interface IdentitySectionVisibilityOptions {
+    activeFilter: FilterTab;
+    identityCount: number;
+    filteredIdentityCount: number;
+    filteredKeyCount: number;
+    search: string;
+}
+
+export const shouldShowIdentitySection = ({
+    activeFilter,
+    identityCount,
+    filteredIdentityCount,
+    filteredKeyCount,
+    search,
+}: IdentitySectionVisibilityOptions): boolean => {
+    if (activeFilter !== 'key' || identityCount === 0) return false;
+    if (!search.trim()) return true;
+
+    return filteredIdentityCount > 0 || filteredKeyCount === 0;
+};

--- a/components/keychain/utils.ts
+++ b/components/keychain/utils.ts
@@ -88,6 +88,21 @@ export const shouldShowIdentitySection = ({
     return filteredIdentityCount > 0 || filteredKeyCount === 0;
 };
 
+export const shouldShowKeySection = ({
+    activeFilter,
+    identityCount,
+    filteredKeyCount,
+    search,
+}: Pick<
+    IdentitySectionVisibilityOptions,
+    'activeFilter' | 'identityCount' | 'filteredKeyCount' | 'search'
+>): boolean => {
+    if (activeFilter !== 'key' || identityCount === 0) return true;
+    if (!search.trim()) return false;
+
+    return filteredKeyCount > 0;
+};
+
 export const shouldShowSearchNoResults = (
     search: string,
     filteredItemCount: number,


### PR DESCRIPTION
## What changed

- Move **New Identity** out of the key dropdown and into the visible keychain header.
- Show identities as the only content section when identities exist.
- Show the key section when there are no identities.
- Show the setup prompt only when both keys and identities are absent.
- Add coverage for each display state and the visible identity action.

## Why

The identity action was difficult to discover, and an empty key section could appear above existing identities. This makes the available content and next action immediately clear.

## Validation

- `node --test --import tsx components/KeychainCardLayout.test.tsx`
- `npx eslint components/KeychainManager.tsx components/KeychainCardLayout.test.tsx`
- `npm run build`
- Manual verification of the empty state, visible identity action, identity form, and identity-only layout