### PR TITLE
fix(ui): keep quick controls trigger color static

### DIFF
--- a/components/TopTabsQuickControls.tsx
+++ b/components/TopTabsQuickControls.tsx
@@ -50,10 +50,6 @@ export const TopTabsQuickControls: React.FC<TopTabsQuickControlsProps> = ({
   const isPresetActive = (value: number) => Math.round(value * 100) === opacityPercent;
   const isDark = theme === 'dark';
   const externalMcpLabelId = React.useId();
-  const triggerActive = (
-    (showExternalMcpToggle && externalMcpEnabled)
-    || opacityPercent < 100
-  );
 
   return (
     <Popover
@@ -72,9 +68,7 @@ export const TopTabsQuickControls: React.FC<TopTabsQuickControlsProps> = ({
               className={cn('h-7 w-7 shrink-0 app-no-drag top-tab-utility-btn', className)}
               style={{
                 ...style,
-                color: triggerActive
-                  ? 'hsl(var(--primary))'
-                  : (style?.color ?? 'var(--top-tabs-muted, hsl(var(--muted-foreground)))'),
+                color: style?.color ?? 'var(--top-tabs-muted, hsl(var(--muted-foreground)))',
               }}
               aria-label={t('topTabs.controlPanel')}
               data-section="top-tabs-quick-controls"


### PR DESCRIPTION
## Summary

- Remove state-based highlight on the top-bar quick controls trigger button
- External MCP on/off and window opacity no longer change the icon color
- Trigger always uses the default muted top-tabs color

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- In `TopTabsQuickControls.tsx`, drop `triggerActive` logic that tinted the button primary when External MCP was enabled or opacity was below 100%
- Always render the trigger with the default muted color

## Screenshots / Demo

Quick controls icon stays muted regardless of External MCP toggle or opacity preset.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)