### PR TITLE
fix(terminal): scroll to bottom on Ctrl+C with scroll-on-input

### DIFF
--- a/domain/terminalScroll.test.ts
+++ b/domain/terminalScroll.test.ts
@@ -4,92 +4,129 @@ import test from "node:test";
 import {
   scrollTerminalToBottomAfterInputIfEnabled,
   scrollTerminalToBottomIfNeeded,
+  shouldScrollOnTerminalInput,
 } from "./terminalScroll.ts";
 
-test("does not request another scroll when the terminal is already at the bottom", () => {
+const createScrollTarget = (viewportY: number, baseY = 10_000) => {
   let scrollCalls = 0;
-  const terminal = {
-    buffer: {
-      active: {
-        baseY: 10_000,
-        viewportY: 10_000,
+  return {
+    terminal: {
+      buffer: {
+        active: {
+          baseY,
+          viewportY,
+        },
+      },
+      scrollToBottom() {
+        scrollCalls += 1;
       },
     },
-    scrollToBottom() {
-      scrollCalls += 1;
+    get scrollCalls() {
+      return scrollCalls;
     },
   };
+};
 
-  const didScroll = scrollTerminalToBottomIfNeeded(terminal);
+test("does not request another scroll when the terminal is already at the bottom", () => {
+  const fixture = createScrollTarget(10_000);
+
+  const didScroll = scrollTerminalToBottomIfNeeded(fixture.terminal);
 
   assert.equal(didScroll, false);
-  assert.equal(scrollCalls, 0);
+  assert.equal(fixture.scrollCalls, 0);
 });
 
 test("scrolls to the bottom when the user is viewing earlier output", () => {
-  let scrollCalls = 0;
-  const terminal = {
-    buffer: {
-      active: {
-        baseY: 10_000,
-        viewportY: 9_900,
-      },
-    },
-    scrollToBottom() {
-      scrollCalls += 1;
-    },
-  };
+  const fixture = createScrollTarget(9_900);
 
-  const didScroll = scrollTerminalToBottomIfNeeded(terminal);
+  const didScroll = scrollTerminalToBottomIfNeeded(fixture.terminal);
 
   assert.equal(didScroll, true);
-  assert.equal(scrollCalls, 1);
+  assert.equal(fixture.scrollCalls, 1);
 });
 
 test("printable input does not request another scroll when already at the bottom", () => {
-  let scrollCalls = 0;
-  const terminal = {
-    buffer: {
-      active: {
-        baseY: 10_000,
-        viewportY: 10_000,
-      },
-    },
-    scrollToBottom() {
-      scrollCalls += 1;
-    },
-  };
+  const fixture = createScrollTarget(10_000);
 
   const didScroll = scrollTerminalToBottomAfterInputIfEnabled(
-    terminal,
+    fixture.terminal,
     { scrollOnInput: true },
     "f",
   );
 
   assert.equal(didScroll, false);
-  assert.equal(scrollCalls, 0);
+  assert.equal(fixture.scrollCalls, 0);
 });
 
 test("printable input still scrolls when the user is viewing earlier output", () => {
-  let scrollCalls = 0;
-  const terminal = {
-    buffer: {
-      active: {
-        baseY: 10_000,
-        viewportY: 9_900,
-      },
-    },
-    scrollToBottom() {
-      scrollCalls += 1;
-    },
-  };
+  const fixture = createScrollTarget(9_900);
 
   const didScroll = scrollTerminalToBottomAfterInputIfEnabled(
-    terminal,
+    fixture.terminal,
     { scrollOnInput: true },
     "f",
   );
 
   assert.equal(didScroll, true);
-  assert.equal(scrollCalls, 1);
+  assert.equal(fixture.scrollCalls, 1);
+});
+
+test("Ctrl+C scrolls under scrollOnInput when viewing earlier output (#2287)", () => {
+  const fixture = createScrollTarget(9_900);
+
+  assert.equal(
+    shouldScrollOnTerminalInput({ scrollOnInput: true, scrollOnKeyPress: false }, "\x03"),
+    true,
+  );
+
+  const didScroll = scrollTerminalToBottomAfterInputIfEnabled(
+    fixture.terminal,
+    { scrollOnInput: true, scrollOnKeyPress: false },
+    "\x03",
+  );
+
+  assert.equal(didScroll, true);
+  assert.equal(fixture.scrollCalls, 1);
+});
+
+test("Ctrl+C still scrolls when only scrollOnKeyPress is enabled", () => {
+  const fixture = createScrollTarget(9_900);
+
+  const didScroll = scrollTerminalToBottomAfterInputIfEnabled(
+    fixture.terminal,
+    { scrollOnInput: false, scrollOnKeyPress: true },
+    "\x03",
+  );
+
+  assert.equal(didScroll, true);
+  assert.equal(fixture.scrollCalls, 1);
+});
+
+test("Ctrl+C does not scroll when both input scroll settings are off", () => {
+  const fixture = createScrollTarget(9_900);
+
+  assert.equal(
+    shouldScrollOnTerminalInput({ scrollOnInput: false, scrollOnKeyPress: false }, "\x03"),
+    false,
+  );
+
+  const didScroll = scrollTerminalToBottomAfterInputIfEnabled(
+    fixture.terminal,
+    { scrollOnInput: false, scrollOnKeyPress: false },
+    "\x03",
+  );
+
+  assert.equal(didScroll, false);
+  assert.equal(fixture.scrollCalls, 0);
+});
+
+test("non-printable keys still require scrollOnKeyPress", () => {
+  assert.equal(
+    shouldScrollOnTerminalInput({ scrollOnInput: true, scrollOnKeyPress: false }, "\r"),
+    false,
+  );
+  assert.equal(
+    shouldScrollOnTerminalInput({ scrollOnInput: true, scrollOnKeyPress: true }, "\r"),
+    true,
+  );
 });

--- a/domain/terminalScroll.ts
+++ b/domain/terminalScroll.ts
@@ -42,6 +42,14 @@ export const shouldScrollOnTerminalInput = (
     return false;
   }
 
+  // Ctrl+C (SIGINT) is handled by our urgent-interrupt path, which bypasses
+  // xterm's native scrollOnUserInput. Map it to scroll-on-input so the default
+  // "Scroll on input" setting returns the viewport to the bottom after the user
+  // interrupts a scrolled-up stream (e.g. tail logs). #2287
+  if (data === "\x03") {
+    return scrollOnInput || scrollOnKeyPress;
+  }
+
   return hasPrintableTerminalInput(data) ? scrollOnInput : scrollOnKeyPress;
 };
 


### PR DESCRIPTION
## Summary

- Treat **Ctrl+C** (`\x03`) as scroll-on-input eligible so the default **Scroll on input** setting returns the viewport to the bottom after an urgent interrupt.
- Urgent interrupt already calls `scrollToBottomAfterInput("\x03")`, but non-printable keys previously required **Scroll on key press** (default off), so scrolled-up `tail` + Ctrl+C never jumped back.
- Leave other non-printable keys (e.g. Enter) on the existing `scrollOnKeyPress` path; both scroll settings off still disables interrupt auto-scroll.

Fixes #2287

## Test plan

- [x] `node --test --import tsx domain/terminalScroll.test.ts` (8/8)
- [ ] Manual: enable Scroll on input (default), run `tail -f` / large log, scroll up, press Ctrl+C → viewport returns to bottom
- [ ] Manual: disable both Scroll on input and Scroll on key press → Ctrl+C does not force scroll
- [ ] Manual: only Scroll on key press enabled → Ctrl+C still scrolls