### PR TITLE
fix(lint): clear react-hooks and unused-import warnings

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1415,7 +1415,14 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     return () => {
       for (const unsub of unsubs) unsub();
     };
-  }, [attachExistingSession, kittyKeyboardProtocolEnabledForSession, sessionId]);
+  }, [
+    attachExistingSession,
+    kittyKeyboardProtocolEnabledForSession,
+    onTerminalCwdChange,
+    onTerminalTitleChange,
+    sessionId,
+    terminalCwdTracker,
+  ]);
 
   const cleanupSession = async () => {
     const closingSessionId = sessionRef.current;

--- a/components/settings/tabs/SettingsAITab.tsx
+++ b/components/settings/tabs/SettingsAITab.tsx
@@ -436,7 +436,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
         setResolving(false);
       }
     }
-  }, [applyResolvedAgentPath, cursorApiKeyEncrypted, cursorAuthMode]);
+  }, [applyResolvedAgentPath, cursorApiKeyEncrypted]);
 
   useEffect(() => {
     if (activeSubTab !== "agents") return;
@@ -731,7 +731,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
         codexPath: result?.path || undefined,
       });
     }
-  }, [cursorApiKeyEncrypted, cursorAuthMode, resolveAgentPath, refreshCodexIntegration]);
+  }, [cursorApiKeyEncrypted, resolveAgentPath, refreshCodexIntegration]);
 
   useEffect(() => {
     if (activeSubTab !== "agents") return;

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -1,7 +1,5 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createRequire } from "node:module";
-import type { Terminal as XTerm } from "@xterm/xterm";
 
 import {
   MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES,
@@ -31,8 +29,7 @@ const createFakeTerm = (options: {
   const disposedMarkerLines: number[] = [];
   const liveMarkers: Array<{ line: number; isDisposed: boolean; dispose: () => void }> = [];
   let cursorLine = 0;
-  let cursorColumn = 0;
-  const cols = options.cols ?? Number.POSITIVE_INFINITY;
+  const cols = options.cols ?? Number.POSITIVE_INFINITY
   let wraparoundMode = options.wraparoundMode ?? true;
   const scrollback = options.scrollback;
   const rows = options.rows ?? 24;
@@ -214,7 +211,6 @@ const createFakeTerm = (options: {
     },
     set cursorX(value: number) {
       currentState().column = Math.max(0, value);
-      cursorColumn = currentState().column;
     },
     get length() {
       return resolveLength(currentState());
@@ -239,14 +235,12 @@ const createFakeTerm = (options: {
     altState.lineText.clear();
     screen = "alternate";
     cursorLine = 0;
-    cursorColumn = 0;
   };
 
   const leaveAlternate = () => {
     if (screen !== "alternate") return;
     screen = "normal";
     cursorLine = normalState.absoluteCursorLine;
-    cursorColumn = normalState.column;
   };
 
   const term = {
@@ -299,19 +293,15 @@ const createFakeTerm = (options: {
           state.column = Number.isFinite(cols) && state.column >= cols
             ? cols - 1
             : 0;
-          cursorColumn = state.column;
           trimScrollbackIfNeeded(state);
         } else if (char === "\r") {
           state.column = 0;
-          cursorColumn = 0;
         } else if (char === "\b") {
           state.column = Math.max(0, state.column - 1);
-          cursorColumn = state.column;
         } else if (char === "\t") {
           if (state.column < cols) {
             const nextTabStop = state.column + (8 - (state.column % 8));
             state.column = Math.min(nextTabStop, cols - 1);
-            cursorColumn = state.column;
           }
         } else if (isCombiningMark(char)) {
           continue;
@@ -328,7 +318,6 @@ const createFakeTerm = (options: {
             state.absoluteCursorLine += 1;
             cursorLine = state.absoluteCursorLine;
             state.column = 0;
-            cursorColumn = 0;
             trimScrollbackIfNeeded(state);
           }
           const existing = state.lineText.get(state.absoluteCursorLine) ?? "";
@@ -339,11 +328,9 @@ const createFakeTerm = (options: {
           state.column = Number.isFinite(cols)
             ? Math.min(cols, state.column + width)
             : state.column + width;
-          cursorColumn = state.column;
         }
       }
       cursorLine = currentState().absoluteCursorLine;
-      cursorColumn = currentState().column;
       trimScrollbackIfNeeded(currentState());
       callback?.();
     },
@@ -392,7 +379,6 @@ const createFakeTerm = (options: {
       altState.absoluteCursorLine = 40;
       altState.column = 0;
       cursorLine = 40;
-      cursorColumn = 0;
     },
     getNormalAbsoluteLine: () => normalState.absoluteCursorLine,
   };


### PR DESCRIPTION
## Summary

Clear the 6 ESLint warnings that show up during `npm run dev` startup.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- `Terminal.tsx`: include missing `useEffect` deps (`onTerminalCwdChange`, `onTerminalTitleChange`, `terminalCwdTracker`) for the attach snapshot apply path
- `SettingsAITab.tsx`: remove unnecessary `cursorAuthMode` from two `useCallback` dependency arrays (bodies only use `cursorApiKeyEncrypted`)
- `terminalLineTimestamps.test.ts`: drop unused `createRequire` / `XTerm` imports and write-only `cursorColumn` fake-term state

## Screenshots / Demo

N/A — lint-only cleanup

## Testing

- [x] Linting passes (`npx eslint` on the three files)
- [x] Related tests pass (`terminalLineTimestamps.test.ts` — 32/32)
- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)