### PR TITLE
fix(ui): match global transfer toggle to top-tab muted icons

### DIFF
--- a/components/GlobalSftpTransferCenter.tsx
+++ b/components/GlobalSftpTransferCenter.tsx
@@ -597,6 +597,7 @@ export function GlobalSftpTransferCenter() {
               variant="ghost"
               size="icon"
               className="relative h-7 w-7 shrink-0 app-no-drag top-tab-utility-btn"
+              style={{ color: "var(--top-tabs-muted, hsl(var(--muted-foreground)))" }}
               aria-label={t("sftp.transferCenter.title")}
               data-section="global-sftp-transfer-toggle"
             >


### PR DESCRIPTION
## Summary

Top-right global SFTP transfer toggle used default button foreground (reads as hard white) instead of the same muted color as AI / sync / controls icons next to it.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Set `style={{ color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}` on the `GlobalSftpTransferCenter` popover trigger, matching `TopTabs` utility buttons (`Sparkles`, `SyncStatusButton`, `TopTabsQuickControls`, settings).

## Screenshots / Demo

Before: transfer icon brighter/white vs neighbors  
After: same muted icon color as the rest of the top-right utility row

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)