### PR TITLE
fix(ci): allow automation to open draft PRs via TRIAGE token

### DIFF
--- a/.github/workflows/cursor-automation.yml
+++ b/.github/workflows/cursor-automation.yml
@@ -868,6 +868,10 @@ jobs:
           ISSUE_NUMBER: ${{ needs.implement.outputs.issue_number }}
           ISSUE_TITLE: ${{ needs.implement.outputs.issue_title }}
         with:
+          # GITHUB_TOKEN cannot create PRs unless the repo enables
+          # "Allow GitHub Actions to create and approve pull requests".
+          # Prefer TRIAGE_GITHUB_TOKEN (PAT) so implement can open draft PRs.
+          github-token: ${{ secrets.TRIAGE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const auto = require(`${process.env.RUNNER_TEMP}/cursor-automation.cjs`);
             const fs = require('node:fs');


### PR DESCRIPTION
## Summary
- Implement path pushed the branch for #2421 but failed to open the PR: `GitHub Actions is not permitted to create or approve pull requests`.
- Use `TRIAGE_GITHUB_TOKEN || GITHUB_TOKEN` for `pulls.create` (same as other write paths).

## Also
- Manually opened the stranded #2421 implement branch as a draft PR.
- Repo can alternatively enable Settings → Actions → General → **Allow GitHub Actions to create and approve pull requests**.