### PR TITLE
Fix SFTP transfer throughput regression

### DIFF
--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -528,6 +528,7 @@ function getIsolatedDownloadChannelPool(client) {
     pool = {
       idle: [],
       idleTimers: new Map(),
+      idleErrorHandlers: new Map(),
       busy: new Set(),
       opening: 0,
       maxChannels: FAST_DOWNLOAD_CHANNELS_PER_SESSION,
@@ -552,6 +553,13 @@ function clearIdleIsolatedDownloadTimer(pool, sftp) {
   }
 }
 
+function clearIdleIsolatedDownloadErrorHandler(pool, sftp) {
+  const handler = pool.idleErrorHandlers.get(sftp);
+  if (!handler) return;
+  try { sftp?.removeListener?.("error", handler); } catch { }
+  pool.idleErrorHandlers.delete(sftp);
+}
+
 function scheduleIdleIsolatedDownloadChannel(client, sftp) {
   const pool = isolatedDownloadChannelPools.get(client);
   if (!pool) return;
@@ -559,10 +567,20 @@ function scheduleIdleIsolatedDownloadChannel(client, sftp) {
   clearIdleIsolatedDownloadTimer(pool, sftp);
   const timer = setTimeout(() => {
     clearIdleIsolatedDownloadTimer(pool, sftp);
+    clearIdleIsolatedDownloadErrorHandler(pool, sftp);
     removeIdleIsolatedDownloadChannel(pool, sftp);
     try { sftp?.end?.(); } catch { }
   }, ISOLATED_DOWNLOAD_IDLE_TTL_MS);
   pool.idleTimers.set(sftp, timer);
+
+  const onIdleError = () => {
+    clearIdleIsolatedDownloadTimer(pool, sftp);
+    clearIdleIsolatedDownloadErrorHandler(pool, sftp);
+    removeIdleIsolatedDownloadChannel(pool, sftp);
+    try { sftp?.end?.(); } catch { }
+  };
+  pool.idleErrorHandlers.set(sftp, onIdleError);
+  sftp?.once?.("error", onIdleError);
 }
 
 function releaseIsolatedDownloadChannel(client, sftp, options = {}) {
@@ -577,6 +595,7 @@ function releaseIsolatedDownloadChannel(client, sftp, options = {}) {
 
   pool.busy.delete(sftp);
   clearIdleIsolatedDownloadTimer(pool, sftp);
+  clearIdleIsolatedDownloadErrorHandler(pool, sftp);
 
   if (dispose) {
     try { sftp?.end?.(); } catch { }
@@ -594,6 +613,7 @@ async function acquireIsolatedDownloadChannel(client, transfer) {
   const cached = pool.idle.pop();
   if (cached) {
     clearIdleIsolatedDownloadTimer(pool, cached);
+    clearIdleIsolatedDownloadErrorHandler(pool, cached);
     pool.busy.add(cached);
     return cached;
   }
@@ -646,6 +666,9 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
   const sftp = client.sftp;
   if (!sftp) throw new Error("SFTP client not ready");
   transfer.pauseSupported = Boolean(transfer.resumable);
+  const initialSource = transfer.resumable
+    ? await fs.promises.stat(localPath)
+    : null;
 
   // Prefer an isolated SFTP channel so cancellation cannot kill the browse session.
   if (!client.__netcattySudoMode) {
@@ -666,6 +689,8 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
           transfer,
           sendProgress,
         );
+        const latestSource = await fs.promises.stat(localPath);
+        assertSourceMetadataUnchanged(initialSource, latestSource, fileSize);
         await assertRemoteUploadSize(client, remotePath, fileSize);
         return;
       } catch (err) {
@@ -673,9 +698,23 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
         // handle so we do not reuse a closed channel for fastPut below.
         fastSftp = null;
         if (transfer.cancelled) throw err;
+        if (err?.noTransferFallback) throw err;
         // Ranges may have written past the contiguous checkpoint; truncate
         // the staged remote .part before sequential stream resume.
         await prepareStreamFallbackAfterRangeFailure(transfer, client);
+        const fallbackCheckpoint = Math.max(0, Number(transfer.checkpointBytes) || 0);
+        if (fallbackCheckpoint > 0 && transfer.stagedRemote) {
+          let stagedSize = Number.POSITIVE_INFINITY;
+          try {
+            const staged = transfer.stagedRemote;
+            const encoded = encodePathForSession(staged.sftpId, staged.path, staged.encoding);
+            stagedSize = Number((await (staged.client || client).stat(encoded))?.size);
+          } catch { }
+          if (!Number.isFinite(stagedSize) || stagedSize !== fallbackCheckpoint) {
+            transfer.checkpointBytes = 0;
+            sendProgress(0, fileSize, { force: true, checkpointBytes: 0 });
+          }
+        }
         console.warn(
           "[transferBridge] resumable fast upload failed, falling back to a compatible stream:",
           err?.message || String(err),
@@ -793,6 +832,10 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
     readStream.pipe(writeStream);
   });
   await assertRemoteUploadSize(client, remotePath, fileSize);
+  if (initialSource) {
+    const latestSource = await fs.promises.stat(localPath);
+    assertSourceMetadataUnchanged(initialSource, latestSource, fileSize);
+  }
 }
 
 function openSftpHandle(sftp, filePath, flags) {
@@ -867,6 +910,58 @@ function writeSftpRange(sftp, handle, buffer, position, length) {
   });
 }
 
+async function verifyFastDownloadSamples(sftp, remoteHandle, localHandle, fileSize, transfer) {
+  if (fileSize <= 0) return;
+  const sampleSize = Math.min(TRANSFER_CHUNK_SIZE, fileSize);
+  const offsets = [...new Set([
+    0,
+    Math.max(0, Math.floor((fileSize - sampleSize) / 2)),
+    Math.max(0, fileSize - sampleSize),
+  ])];
+  for (const position of offsets) {
+    if (transfer.cancelled) throw new Error("Transfer cancelled");
+    const length = Math.min(sampleSize, fileSize - position);
+    const remoteBuffer = Buffer.allocUnsafe(length);
+    const localBuffer = Buffer.allocUnsafe(length);
+    await readSftpRange(sftp, remoteHandle, remoteBuffer, position, length);
+    await readLocalRange(localHandle, localBuffer, position, length);
+    if (!remoteBuffer.equals(localBuffer)) {
+      const error = new Error("Transfer source content changed during transfer");
+      error.noTransferFallback = true;
+      error.sourceChanged = true;
+      throw error;
+    }
+  }
+}
+
+function createSourceSizeChangedError(expectedSize, actualSize) {
+  const error = new Error(
+    `Transfer source size changed during transfer: expected ${expectedSize}, got ${actualSize}`,
+  );
+  error.noTransferFallback = true;
+  error.sourceChanged = true;
+  return error;
+}
+
+function assertSourceMetadataUnchanged(initialSource, latestSource, expectedSize) {
+  const latestSize = Number(latestSource?.size);
+  if (latestSize !== expectedSize) {
+    throw createSourceSizeChangedError(expectedSize, latestSize);
+  }
+  const versionFields = ["mtimeMs", "ctimeMs", "mtime", "ctime", "ino"];
+  const changed = versionFields.some((field) => {
+    const before = Number(initialSource?.[field]);
+    const after = Number(latestSource?.[field]);
+    return Number.isFinite(before) && Number.isFinite(after) && before !== after;
+  });
+  if (changed) {
+    const error = new Error("Transfer source changed during transfer");
+    error.noTransferFallback = true;
+    error.sourceChanged = true;
+    throw error;
+  }
+}
+
 async function runPausableConcurrentRanges({
   transfer,
   fileSize,
@@ -887,6 +982,12 @@ async function runPausableConcurrentRanges({
   let settled = false;
   let terminalError = null;
   let pauseResolvers = [];
+
+  const cancelPauseWait = () => {
+    const resolvers = pauseResolvers;
+    pauseResolvers = [];
+    for (const resolve of resolvers) resolve();
+  };
 
   const publishContiguousCheckpoint = (force = false) => {
     if (transfer.cancelled) return;
@@ -999,6 +1100,7 @@ async function runPausableConcurrentRanges({
         }
         return new Promise((resolvePause) => pauseResolvers.push(resolvePause));
       };
+      transfer.cancelPauseWait = cancelPauseWait;
       transfer.abort = abort;
       pump();
     });
@@ -1018,20 +1120,34 @@ async function uploadFileResumableFast(
   sendProgress,
 ) {
   const checkpoint = Math.max(0, Math.min(transfer.checkpointBytes || 0, fileSize));
-  let localHandle = null;
-  let remoteHandle = null;
-  let failed = false;
-  // Always end the isolated channel — callers clear fastSftp after any throw
-  // and assume this helper already disposed it.
+  let channelError = null;
+  const onChannelError = (error) => {
+    channelError = channelError || error;
+  };
+  sftp.on?.("error", onChannelError);
+  let localHandle;
   try {
-    try {
-      localHandle = await fs.promises.open(localPath, "r");
-      remoteHandle = await openSftpHandle(sftp, remotePath, checkpoint > 0 ? "r+" : "w");
-    } catch (error) {
-      failed = true;
-      throw error;
-    }
+    localHandle = await fs.promises.open(localPath, "r");
+  } catch (error) {
+    try { sftp.end?.(); } catch { }
+    try { sftp.removeListener?.("error", onChannelError); } catch { }
+    const localOpenError = new Error(error?.message || String(error), { cause: error });
+    localOpenError.noTransferFallback = true;
+    throw localOpenError;
+  }
+  let remoteHandle;
+  let failed = false;
+  try {
+    remoteHandle = await openSftpHandle(sftp, remotePath, checkpoint > 0 ? "r+" : "w");
+    if (channelError) throw channelError;
+  } catch (error) {
+    await localHandle.close().catch(() => {});
+    try { sftp.end?.(); } catch { }
+    try { sftp.removeListener?.("error", onChannelError); } catch { }
+    throw error;
+  }
 
+  try {
     try {
       await runPausableConcurrentRanges({
         transfer,
@@ -1047,6 +1163,7 @@ async function uploadFileResumableFast(
         abortChannel: () => sftp.end?.(),
         sftp,
       });
+      if (channelError) throw channelError;
     } catch (error) {
       failed = true;
       throw error;
@@ -1054,14 +1171,23 @@ async function uploadFileResumableFast(
   } finally {
     transfer.readStream = null;
     transfer.waitForPause = null;
+    transfer.cancelPauseWait = null;
     transfer.abort = null;
-    if (localHandle) {
-      await localHandle.close().catch(() => {});
+    await localHandle.close().catch(() => {});
+    let remoteCloseError = null;
+    if (!failed && !transfer.cancelled) {
+      try {
+        await closeSftpHandle(sftp, remoteHandle);
+      } catch (error) {
+        remoteCloseError = error;
+      }
     }
-    if (remoteHandle && !failed && !transfer.cancelled) {
-      await closeSftpHandle(sftp, remoteHandle).catch(() => {});
+    if (!failed && !transfer.cancelled && !remoteCloseError && channelError) {
+      remoteCloseError = channelError;
     }
     try { sftp.end?.(); } catch { }
+    try { sftp.removeListener?.("error", onChannelError); } catch { }
+    if (remoteCloseError) throw remoteCloseError;
   }
 }
 
@@ -1081,13 +1207,26 @@ async function downloadFileResumableFast(
   sendProgress,
 ) {
   const checkpoint = Math.max(0, Math.min(transfer.checkpointBytes || 0, fileSize));
-  const remoteHandle = await openSftpHandle(sftp, remotePath, "r");
+  let channelError = null;
+  const onChannelError = (error) => {
+    channelError = channelError || error;
+  };
+  sftp.on?.("error", onChannelError);
+  let remoteHandle;
+  try {
+    remoteHandle = await openSftpHandle(sftp, remotePath, "r");
+    if (channelError) throw channelError;
+  } catch (error) {
+    try { sftp.removeListener?.("error", onChannelError); } catch { }
+    throw error;
+  }
   let localHandle;
   let failed = false;
   try {
-    localHandle = await fs.promises.open(localPath, checkpoint > 0 ? "r+" : "w");
+    localHandle = await fs.promises.open(localPath, checkpoint > 0 ? "r+" : "w+");
   } catch (error) {
     await closeSftpHandle(sftp, remoteHandle).catch(() => {});
+    try { sftp.removeListener?.("error", onChannelError); } catch { }
     throw error;
   }
 
@@ -1107,6 +1246,8 @@ async function downloadFileResumableFast(
         abortChannel: () => sftp.end?.(),
         sftp,
       });
+      if (channelError) throw channelError;
+      await verifyFastDownloadSamples(sftp, remoteHandle, localHandle, fileSize, transfer);
     } catch (error) {
       failed = true;
       throw error;
@@ -1114,10 +1255,35 @@ async function downloadFileResumableFast(
   } finally {
     transfer.readStream = null;
     transfer.waitForPause = null;
+    transfer.cancelPauseWait = null;
     transfer.abort = null;
-    await localHandle.close().catch(() => {});
+    let localCloseError = null;
+    try {
+      await localHandle.close();
+    } catch (error) {
+      localCloseError = error;
+    }
+    let remoteCloseError = null;
     if (!failed && !transfer.cancelled) {
-      await closeSftpHandle(sftp, remoteHandle).catch(() => {});
+      try {
+        await closeSftpHandle(sftp, remoteHandle);
+      } catch (error) {
+        remoteCloseError = error;
+      }
+    }
+    if (!failed && !transfer.cancelled && !remoteCloseError && channelError) {
+      remoteCloseError = channelError;
+    }
+    try { sftp.removeListener?.("error", onChannelError); } catch { }
+    if (!failed && !transfer.cancelled && localCloseError) {
+      const error = new Error("Could not safely close the downloaded file", { cause: localCloseError });
+      error.noTransferFallback = true;
+      throw error;
+    }
+    if (!failed && !transfer.cancelled && remoteCloseError) {
+      const error = new Error("The isolated SFTP channel failed while closing", { cause: remoteCloseError });
+      error.completedWithUnhealthyChannel = true;
+      throw error;
     }
   }
 }
@@ -1144,6 +1310,9 @@ async function downloadFile(remotePath, localPath, client, fileSize, transfer, s
   const sftp = client.sftp;
   if (!sftp) throw new Error("SFTP client not ready");
   transfer.pauseSupported = Boolean(transfer.resumable);
+  const initialSource = transfer.resumable
+    ? await client.stat(remotePath)
+    : null;
 
   // Prefer an isolated SFTP channel so cancellation cannot kill the browse session.
   if (!client.__netcattySudoMode) {
@@ -1166,6 +1335,8 @@ async function downloadFile(remotePath, localPath, client, fileSize, transfer, s
             transfer,
             sendProgress,
           );
+          const latestSource = await client.stat(remotePath);
+          assertSourceMetadataUnchanged(initialSource, latestSource, fileSize);
           releaseIsolatedDownloadChannel(client, fastSftp);
           return;
         }
@@ -1219,9 +1390,23 @@ async function downloadFile(remotePath, localPath, client, fileSize, transfer, s
         // in pool.busy and the per-session fast-download budget is exhausted.
         releaseIsolatedDownloadChannel(client, fastSftp, { dispose: true });
         if (transfer.cancelled) throw err;
+        if (err?.noTransferFallback) throw err;
+        if (err?.completedWithUnhealthyChannel) {
+          const latestSource = await client.stat(remotePath);
+          assertSourceMetadataUnchanged(initialSource, latestSource, fileSize);
+          return;
+        }
         // Concurrent ranges may leave sparse tails past the contiguous
-        // checkpoint; truncate before sequential stream resume.
-        await prepareStreamFallbackAfterRangeFailure(transfer, client);
+        // checkpoint; truncate the actual local target before stream resume.
+        const checkpoint = Math.max(0, Math.min(transfer.checkpointBytes || 0, fileSize));
+        try {
+          await fs.promises.truncate(localPath, checkpoint);
+        } catch (truncateError) {
+          if (!(checkpoint === 0 && truncateError?.code === "ENOENT")) {
+            throw truncateError;
+          }
+        }
+        sendProgress(checkpoint, fileSize, { force: true, checkpointBytes: checkpoint });
         console.warn(
           "[transferBridge] fastGet failed, falling back to a compatible stream:",
           err?.message || String(err),
@@ -1234,7 +1419,7 @@ async function downloadFile(remotePath, localPath, client, fileSize, transfer, s
   }
 
   // Fallback: sequential stream piping
-  return new Promise((resolve, reject) => {
+  await new Promise((resolve, reject) => {
     const checkpoint = Math.max(0, Math.min(transfer.checkpointBytes || 0, fileSize));
     const readStream = sftp.createReadStream(remotePath, { highWaterMark: TRANSFER_CHUNK_SIZE, start: checkpoint });
     const writeStream = fs.createWriteStream(localPath, {
@@ -1286,6 +1471,10 @@ async function downloadFile(remotePath, localPath, client, fileSize, transfer, s
     });
     readStream.pipe(writeStream);
   });
+  if (initialSource) {
+    const latestSource = await client.stat(remotePath);
+    assertSourceMetadataUnchanged(initialSource, latestSource, fileSize);
+  }
 }
 
 /**
@@ -1784,6 +1973,7 @@ async function startTransferNow(event, payload, onProgress) {
             transfer.downloadCheckpointBytes = durableCheckpoint;
             sendProgress(Math.floor(transferred / 2), fileSize, {
               checkpointBytes: durableCheckpoint,
+              force: options.force === true,
             });
             transfer.checkpointBytes = durableCheckpoint;
           };
@@ -1846,6 +2036,7 @@ async function startTransferNow(event, payload, onProgress) {
           transfer.uploadCheckpointBytes = durableCheckpoint;
           sendProgress(Math.floor(fileSize / 2) + Math.floor(transferred / 2), fileSize, {
             checkpointBytes: durableCheckpoint,
+            force: options.force === true,
           });
           transfer.checkpointBytes = durableCheckpoint;
         };
@@ -1876,6 +2067,26 @@ async function startTransferNow(event, payload, onProgress) {
 
     return { transferId, totalBytes: fileSize };
   } catch (err) {
+    if (err?.sourceChanged) {
+      if (transfer.stagedLocalPath) {
+        try { await fs.promises.rm(transfer.stagedLocalPath, { force: true }); } catch { }
+        transfer.stagedLocalPath = null;
+      }
+      if (transfer.stagedRemote) {
+        const staged = transfer.stagedRemote;
+        try {
+          if (isScpModeClient(staged.client)) {
+            await getScpBackendForClient(staged.client).remove(staged.path, {
+              recursive: false,
+              encoding: staged.encoding,
+            });
+          } else {
+            await staged.client.delete(encodePathForSession(staged.sftpId, staged.path, staged.encoding));
+          }
+        } catch { }
+        transfer.stagedRemote = null;
+      }
+    }
     if (err.message === 'Transfer cancelled') {
       if (transfer.stagedLocalPath) {
         try { await fs.promises.unlink(transfer.stagedLocalPath); } catch { }
@@ -2084,11 +2295,17 @@ async function pauseTransfer(_event, payload) {
   ) {
     return { success: false, reason: "This transfer cannot be paused yet" };
   }
+  if (transfer.pauseOperation) return transfer.pauseOperation;
+  transfer.pauseSuperseded = false;
+  const pauseOperation = (async () => {
   transfer.paused = true;
   try { transfer.readStream?.pause?.(); } catch { }
   const usesContiguousRangeCheckpoint = typeof transfer.waitForPause === "function";
   if (usesContiguousRangeCheckpoint) {
     await transfer.waitForPause();
+    if (!transfer.paused || transfer.pauseSuperseded) {
+      return { success: false, reason: "Pause was superseded by resume" };
+    }
   }
   if (transfer.writeStream?.pending) {
     await new Promise((resolve) => {
@@ -2158,6 +2375,12 @@ async function pauseTransfer(_event, payload) {
       return { success: false, reason: "Could not verify that the source is safe to resume" };
     }
   }
+  if (transfer.cancelled || activeTransfers.get(payload?.transferId) !== transfer) {
+    return { success: false, reason: "Transfer is no longer active" };
+  }
+  if (!transfer.paused || transfer.pauseSuperseded) {
+    return { success: false, reason: "Pause was superseded by resume" };
+  }
   return {
     success: true,
     checkpointBytes: transfer.checkpointBytes || 0,
@@ -2166,6 +2389,13 @@ async function pauseTransfer(_event, payload) {
     uploadCheckpointBytes: transfer.uploadCheckpointBytes || 0,
     ...(transfer.sourceFingerprint ? { sourceFingerprint: transfer.sourceFingerprint } : {}),
   };
+  })();
+  transfer.pauseOperation = pauseOperation;
+  try {
+    return await pauseOperation;
+  } finally {
+    if (transfer.pauseOperation === pauseOperation) transfer.pauseOperation = null;
+  }
 }
 
 async function resumeTransfer(_event, payload) {
@@ -2180,7 +2410,17 @@ async function resumeTransfer(_event, payload) {
       reason: transfer.pauseUnavailableReason || "This transfer cannot be resumed safely",
     };
   }
+  if (transfer.pauseOperation) {
+    transfer.pauseSuperseded = true;
+    try { transfer.cancelPauseWait?.(); } catch { }
+    await transfer.pauseOperation.catch(() => {});
+  }
+  const currentTransfer = activeTransfers.get(payload?.transferId);
+  if (currentTransfer !== transfer || transfer.cancelled) {
+    return { success: false, reason: "Transfer is no longer active" };
+  }
   transfer.paused = false;
+  transfer.pauseSuperseded = false;
   try { transfer.readStream?.resume?.(); } catch { }
   return { success: true };
 }

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -898,6 +898,7 @@ async function uploadFileResumableFast(
     remoteHandle = await openSftpHandle(sftp, remotePath, checkpoint > 0 ? "r+" : "w");
   } catch (error) {
     await localHandle.close().catch(() => {});
+    try { sftp.end?.(); } catch { }
     throw error;
   }
 
@@ -1939,7 +1940,8 @@ async function pauseTransfer(_event, payload) {
   }
   transfer.paused = true;
   try { transfer.readStream?.pause?.(); } catch { }
-  if (typeof transfer.waitForPause === "function") {
+  const usesContiguousRangeCheckpoint = typeof transfer.waitForPause === "function";
+  if (usesContiguousRangeCheckpoint) {
     await transfer.waitForPause();
   }
   if (transfer.writeStream?.pending) {
@@ -1973,7 +1975,11 @@ async function pauseTransfer(_event, payload) {
     }
   }
   try {
-    if (transfer.stagedLocalPath) {
+    // Concurrent range transfers already track the highest contiguous durable
+    // byte. File size may extend past a hole when ranges finish out of order.
+    if (usesContiguousRangeCheckpoint) {
+      // Keep the checkpoint supplied by runPausableConcurrentRanges.
+    } else if (transfer.stagedLocalPath) {
       const stat = await fs.promises.stat(transfer.stagedLocalPath);
       transfer.checkpointBytes = stat.size;
     } else if (transfer.stagedRemote) {

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -438,6 +438,79 @@ async function openIsolatedSftpChannel(client) {
   });
 }
 
+/**
+ * After concurrent ranges fail, staged files may extend past the contiguous
+ * checkpoint (sparse tail). Truncate to the durable offset before stream
+ * fallback or pause-stat, so resume never skips holes.
+ */
+async function truncateStagedPathToCheckpoint(filePath, checkpointBytes) {
+  const checkpoint = Math.max(0, Number(checkpointBytes) || 0);
+  if (!filePath) return;
+  try {
+    const stat = await fs.promises.stat(filePath);
+    if (!stat.isFile()) return;
+    if (stat.size > checkpoint) {
+      await fs.promises.truncate(filePath, checkpoint);
+    }
+  } catch (error) {
+    if (error?.code === "ENOENT") return;
+    // Best-effort: stream fallback can still proceed from checkpoint.
+    console.warn(
+      "[transferBridge] failed to truncate staged local file before fallback:",
+      error?.message || String(error),
+    );
+  }
+}
+
+async function truncateRemoteStagedToCheckpoint(client, stagedRemote, checkpointBytes) {
+  const checkpoint = Math.max(0, Number(checkpointBytes) || 0);
+  if (!client || !stagedRemote?.path) return;
+  if (isScpModeClient(client)) return;
+  try {
+    const encoded = encodePathForSession(
+      stagedRemote.sftpId,
+      stagedRemote.path,
+      stagedRemote.encoding,
+    );
+    const stat = await client.stat(encoded);
+    const size = Math.max(0, Number(stat?.size) || 0);
+    if (size <= checkpoint) return;
+    // Prefer native truncate when available (ssh2-sftp-client).
+    if (typeof client.truncate === "function") {
+      await client.truncate(encoded, checkpoint);
+      return;
+    }
+    if (typeof client.sftp?.ftruncate === "function" && typeof client.sftp?.open === "function") {
+      await new Promise((resolve, reject) => {
+        client.sftp.open(encoded, "r+", (openErr, handle) => {
+          if (openErr) return reject(openErr);
+          client.sftp.ftruncate(handle, checkpoint, (truncErr) => {
+            client.sftp.close(handle, () => {
+              if (truncErr) reject(truncErr);
+              else resolve();
+            });
+          });
+        });
+      });
+    }
+  } catch (error) {
+    console.warn(
+      "[transferBridge] failed to truncate staged remote file before fallback:",
+      error?.message || String(error),
+    );
+  }
+}
+
+async function prepareStreamFallbackAfterRangeFailure(transfer, client) {
+  const checkpoint = Math.max(0, Number(transfer?.checkpointBytes) || 0);
+  if (transfer?.stagedLocalPath) {
+    await truncateStagedPathToCheckpoint(transfer.stagedLocalPath, checkpoint);
+  }
+  if (transfer?.stagedRemote) {
+    await truncateRemoteStagedToCheckpoint(client, transfer.stagedRemote, checkpoint);
+  }
+}
+
 function getIsolatedDownloadChannelPool(client) {
   let pool = isolatedDownloadChannelPools.get(client);
   if (!pool) {
@@ -589,6 +662,9 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
         // handle so we do not reuse a closed channel for fastPut below.
         fastSftp = null;
         if (transfer.cancelled) throw err;
+        // Ranges may have written past the contiguous checkpoint; truncate
+        // the staged remote .part before sequential stream resume.
+        await prepareStreamFallbackAfterRangeFailure(transfer, client);
         console.warn(
           "[transferBridge] resumable fast upload failed, falling back to a compatible stream:",
           err?.message || String(err),
@@ -1026,7 +1102,12 @@ async function downloadFile(remotePath, localPath, client, fileSize, transfer, s
   // Prefer an isolated SFTP channel so cancellation cannot kill the browse session.
   if (!client.__netcattySudoMode) {
     const fastSftp = await acquireIsolatedDownloadChannel(client, transfer);
-    if (transfer.cancelled) throw new Error("Transfer cancelled");
+    if (transfer.cancelled) {
+      if (fastSftp) {
+        releaseIsolatedDownloadChannel(client, fastSftp, { dispose: true });
+      }
+      throw new Error("Transfer cancelled");
+    }
 
     if (fastSftp && (transfer.resumable || typeof fastSftp.fastGet === "function")) {
       try {
@@ -1090,15 +1171,19 @@ async function downloadFile(remotePath, localPath, client, fileSize, transfer, s
       } catch (err) {
         // Always release before rethrowing cancel — otherwise the channel stays
         // in pool.busy and the per-session fast-download budget is exhausted.
-        if (transfer.resumable) {
-          releaseIsolatedDownloadChannel(client, fastSftp, { dispose: true });
-        }
+        releaseIsolatedDownloadChannel(client, fastSftp, { dispose: true });
         if (transfer.cancelled) throw err;
+        // Concurrent ranges may leave sparse tails past the contiguous
+        // checkpoint; truncate before sequential stream resume.
+        await prepareStreamFallbackAfterRangeFailure(transfer, client);
         console.warn(
           "[transferBridge] fastGet failed, falling back to a compatible stream:",
           err?.message || String(err),
         );
       }
+    } else if (fastSftp) {
+      // Acquired a channel but cannot use fast path — return it to the pool.
+      releaseIsolatedDownloadChannel(client, fastSftp);
     }
   }
 
@@ -1989,7 +2074,19 @@ async function pauseTransfer(_event, payload) {
     // Concurrent range transfers already track the highest contiguous durable
     // byte. File size may extend past a hole when ranges finish out of order.
     if (usesContiguousRangeCheckpoint) {
-      // Keep the checkpoint supplied by runPausableConcurrentRanges.
+      // Keep the checkpoint supplied by runPausableConcurrentRanges, and
+      // shrink any sparse tail so a later pause/stat cannot overshoot.
+      const checkpoint = Math.max(0, Number(transfer.checkpointBytes) || 0);
+      if (transfer.stagedLocalPath) {
+        await truncateStagedPathToCheckpoint(transfer.stagedLocalPath, checkpoint);
+      }
+      if (transfer.stagedRemote) {
+        await truncateRemoteStagedToCheckpoint(
+          transfer.stagedRemote.client,
+          transfer.stagedRemote,
+          checkpoint,
+        );
+      }
     } else if (transfer.stagedLocalPath) {
       const stat = await fs.promises.stat(transfer.stagedLocalPath);
       transfer.checkpointBytes = stat.size;

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -503,16 +503,13 @@ async function truncateRemoteStagedToCheckpoint(client, stagedRemote, checkpoint
 
 async function prepareStreamFallbackAfterRangeFailure(transfer, client) {
   const checkpoint = Math.max(0, Number(transfer?.checkpointBytes) || 0);
-  // Only truncate partial *target* staging. In SFTP→SFTP copies, stagedLocalPath
+  // Truncate partial *target* staging only. In SFTP→SFTP copies, stagedLocalPath
   // is the fully-downloaded temp *source* during the upload phase — never shrink it.
+  // Direct transfers keep resumeStage "direct"; S2S download uses "download".
+  // Anything other than "upload" with a staged local path is a partial target.
   const localIsPartialTarget =
-    transfer?.stagedLocalPath
-    && transfer.resumeStage !== "upload"
-    && (
-      transfer.resumeStage === "download"
-      || transfer.sourceType === "sftp" && transfer.targetType === "local"
-      || transfer.sourceType === "local" && transfer.targetType === "local"
-    );
+    Boolean(transfer?.stagedLocalPath)
+    && transfer.resumeStage !== "upload";
   if (localIsPartialTarget) {
     await truncateStagedPathToCheckpoint(transfer.stagedLocalPath, checkpoint);
   }
@@ -1327,9 +1324,13 @@ async function startTransferNow(event, payload, onProgress) {
     uploadCheckpointBytes: Math.max(0, Number(payload.uploadCheckpointBytes) || 0),
     sourceFingerprint: payload.sourceFingerprint,
     sourceType,
+    targetType,
     sourcePath,
+    targetPath,
     sourceSftpId,
+    targetSftpId,
     sourceEncoding,
+    targetEncoding,
     readStream: null,
     writeStream: null,
     abort: null,

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -691,6 +691,7 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
         );
         const latestSource = await fs.promises.stat(localPath);
         assertSourceMetadataUnchanged(initialSource, latestSource, fileSize);
+        // Content samples already verified inside uploadFileResumableFast.
         await assertRemoteUploadSize(client, remotePath, fileSize);
         return;
       } catch (err) {
@@ -779,6 +780,9 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
   // ssh2 closes the remote handle from _final and may suppress Node's normal
   // 'finish' event. Treat a successful close after the complete local read as
   // completion, then verify the persisted remote size below.
+  const streamContentFingerprint = transfer.resumable
+    ? await captureLocalContentFingerprint(localPath, fileSize)
+    : null;
   await new Promise((resolve, reject) => {
     const checkpoint = Math.max(0, Math.min(transfer.checkpointBytes || 0, fileSize));
     const readStream = fs.createReadStream(localPath, { highWaterMark: TRANSFER_CHUNK_SIZE, start: checkpoint });
@@ -835,6 +839,13 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
   if (initialSource) {
     const latestSource = await fs.promises.stat(localPath);
     assertSourceMetadataUnchanged(initialSource, latestSource, fileSize);
+  }
+  if (streamContentFingerprint) {
+    await assertLocalContentFingerprintUnchanged(
+      localPath,
+      streamContentFingerprint,
+      fileSize,
+    );
   }
 }
 
@@ -943,11 +954,115 @@ function createSourceSizeChangedError(expectedSize, actualSize) {
   return error;
 }
 
+function createSourceContentChangedError() {
+  const error = new Error("Transfer source content changed during transfer");
+  error.noTransferFallback = true;
+  error.sourceChanged = true;
+  return error;
+}
+
+function sampleOffsetsForFingerprint(fileSize) {
+  if (fileSize <= 0) return [];
+  const sampleSize = Math.min(TRANSFER_CHUNK_SIZE, fileSize);
+  return [...new Set([
+    0,
+    Math.max(0, Math.floor((fileSize - sampleSize) / 2)),
+    Math.max(0, fileSize - sampleSize),
+  ])].map((position) => ({
+    position,
+    length: Math.min(sampleSize, fileSize - position),
+  }));
+}
+
+/**
+ * Content fingerprint for same-size rewrite detection. Metadata (mtime/ctime)
+ * alone is not enough: some filesystems keep the same timestamp within a tick.
+ */
+async function captureLocalContentFingerprintFromHandle(fileHandle, fileSize) {
+  const samples = sampleOffsetsForFingerprint(fileSize);
+  if (samples.length === 0) return { size: fileSize, digests: [] };
+  const digests = [];
+  for (const { position, length } of samples) {
+    const buffer = Buffer.allocUnsafe(length);
+    await readLocalRange(fileHandle, buffer, position, length);
+    digests.push({
+      position,
+      length,
+      digest: crypto.createHash("sha256").update(buffer).digest("hex"),
+    });
+  }
+  return { size: fileSize, digests };
+}
+
+async function captureLocalContentFingerprint(filePath, fileSize) {
+  const handle = await fs.promises.open(filePath, "r");
+  try {
+    return await captureLocalContentFingerprintFromHandle(handle, fileSize);
+  } finally {
+    await handle.close().catch(() => {});
+  }
+}
+
+async function assertLocalContentFingerprintUnchanged(filePath, fingerprint, expectedSize) {
+  if (!fingerprint) return;
+  let latestStat;
+  try {
+    latestStat = await fs.promises.stat(filePath);
+  } catch (error) {
+    const err = new Error(
+      `Transfer source disappeared during transfer: ${error?.message || String(error)}`,
+    );
+    err.noTransferFallback = true;
+    err.sourceChanged = true;
+    throw err;
+  }
+  const latestSize = Number(latestStat?.size);
+  if (latestSize !== expectedSize) {
+    throw createSourceSizeChangedError(expectedSize, latestSize);
+  }
+  const latest = await captureLocalContentFingerprint(filePath, expectedSize);
+  if (latest.digests.length !== fingerprint.digests.length) {
+    throw createSourceContentChangedError();
+  }
+  for (let i = 0; i < fingerprint.digests.length; i += 1) {
+    const before = fingerprint.digests[i];
+    const after = latest.digests[i];
+    if (
+      before.position !== after.position
+      || before.length !== after.length
+      || before.digest !== after.digest
+    ) {
+      throw createSourceContentChangedError();
+    }
+  }
+}
+
+async function assertLocalContentFingerprintUnchangedFromHandle(fileHandle, fingerprint, expectedSize) {
+  if (!fingerprint) return;
+  const latest = await captureLocalContentFingerprintFromHandle(fileHandle, expectedSize);
+  if (latest.size !== expectedSize || latest.digests.length !== fingerprint.digests.length) {
+    throw createSourceContentChangedError();
+  }
+  for (let i = 0; i < fingerprint.digests.length; i += 1) {
+    const before = fingerprint.digests[i];
+    const after = latest.digests[i];
+    if (
+      before.position !== after.position
+      || before.length !== after.length
+      || before.digest !== after.digest
+    ) {
+      throw createSourceContentChangedError();
+    }
+  }
+}
+
 function assertSourceMetadataUnchanged(initialSource, latestSource, expectedSize) {
   const latestSize = Number(latestSource?.size);
   if (latestSize !== expectedSize) {
     throw createSourceSizeChangedError(expectedSize, latestSize);
   }
+  // Soft signal only — content fingerprint is the durable check for same-size
+  // rewrites. Keep metadata as a cheap early reject when timestamps move.
   const versionFields = ["mtimeMs", "ctimeMs", "mtime", "ctime", "ino"];
   const changed = versionFields.some((field) => {
     const before = Number(initialSource?.[field]);
@@ -955,10 +1070,7 @@ function assertSourceMetadataUnchanged(initialSource, latestSource, expectedSize
     return Number.isFinite(before) && Number.isFinite(after) && before !== after;
   });
   if (changed) {
-    const error = new Error("Transfer source changed during transfer");
-    error.noTransferFallback = true;
-    error.sourceChanged = true;
-    throw error;
+    throw createSourceContentChangedError();
   }
 }
 
@@ -1149,6 +1261,12 @@ async function uploadFileResumableFast(
       throw localOpenError;
     }
     if (transfer.cancelled) throw new Error("Transfer cancelled");
+    // Sample content after local OPEN so same-size rewrites are caught even when
+    // mtime/ctime stay put. Uses the open handle (channel already acquired).
+    const contentFingerprint = await captureLocalContentFingerprintFromHandle(
+      localHandle,
+      fileSize,
+    );
     remoteHandle = await openSftpHandle(sftp, remotePath, checkpoint > 0 ? "r+" : "w");
     if (channelError) throw channelError;
     if (transfer.cancelled) throw new Error("Transfer cancelled");
@@ -1169,6 +1287,11 @@ async function uploadFileResumableFast(
         sftp,
       });
       if (channelError) throw channelError;
+      await assertLocalContentFingerprintUnchangedFromHandle(
+        localHandle,
+        contentFingerprint,
+        fileSize,
+      );
     } catch (error) {
       failed = true;
       throw error;

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -864,6 +864,7 @@ async function runPausableConcurrentRanges({
   copyRange,
   sendProgress,
   abortChannel,
+  sftp = null,
 }) {
   let nextOffset = checkpoint;
   // Progress may complete out of order, but the resume checkpoint must never
@@ -876,97 +877,125 @@ async function runPausableConcurrentRanges({
   let terminalError = null;
   let pauseResolvers = [];
 
+  const publishContiguousCheckpoint = (force = false) => {
+    if (transfer.cancelled) return;
+    sendProgress(transferred, fileSize, {
+      checkpointBytes: contiguousCheckpoint,
+      ...(force ? { force: true } : {}),
+    });
+  };
+
   const settlePauseWaiters = () => {
     if (!transfer.paused || active !== 0 || pauseResolvers.length === 0) return;
+    // Flush the contiguous offset before resolving pause so pauseTransfer
+    // never has to re-stat a sparse staged file.
+    publishContiguousCheckpoint(true);
     const resolvers = pauseResolvers;
     pauseResolvers = [];
     for (const resolve of resolvers) resolve();
   };
 
-  await new Promise((resolve, reject) => {
-    const finish = (error) => {
-      if (settled) return;
-      if (error) terminalError = terminalError || error;
-      if (active > 0) return;
-      settled = true;
-      if (terminalError) reject(terminalError);
-      else resolve();
-    };
+  let onSftpError = null;
 
-    const abort = (error = new Error("Transfer cancelled")) => {
-      terminalError = terminalError || error;
-      try { abortChannel?.(); } catch { }
-      finish(terminalError);
-    };
+  try {
+    await new Promise((resolve, reject) => {
+      const finish = (error) => {
+        if (settled) return;
+        if (error) terminalError = terminalError || error;
+        if (active > 0) return;
+        settled = true;
+        if (terminalError) reject(terminalError);
+        else resolve();
+      };
 
-    const pump = () => {
-      if (settled) return;
-      if (terminalError || transfer.cancelled) {
-        finish(terminalError || new Error("Transfer cancelled"));
-        return;
-      }
-      if (transfer.paused) {
-        settlePauseWaiters();
-        return;
-      }
+      const abort = (error = new Error("Transfer cancelled")) => {
+        terminalError = terminalError || error;
+        try { abortChannel?.(); } catch { }
+        finish(terminalError);
+      };
 
-      while (
-        active < concurrency
-        && nextOffset < fileSize
-        && !transfer.paused
-        && !transfer.cancelled
-      ) {
-        const position = nextOffset;
-        const length = Math.min(TRANSFER_CHUNK_SIZE, fileSize - position);
-        nextOffset += length;
-        active += 1;
-
-        void copyRange(position, length)
-          .then(() => {
-            transferred += length;
-            completedRanges.set(position, position + length);
-            while (completedRanges.has(contiguousCheckpoint)) {
-              const nextCheckpoint = completedRanges.get(contiguousCheckpoint);
-              completedRanges.delete(contiguousCheckpoint);
-              contiguousCheckpoint = nextCheckpoint;
-            }
-            if (!transfer.cancelled) {
-              sendProgress(transferred, fileSize, { checkpointBytes: contiguousCheckpoint });
-            }
-          })
-          .catch((error) => abort(error))
-          .finally(() => {
-            active -= 1;
-            settlePauseWaiters();
-            if (terminalError || transfer.cancelled) {
-              finish(terminalError || new Error("Transfer cancelled"));
-            } else if (contiguousCheckpoint === fileSize) finish();
-            else pump();
-          });
+      // Channel-level errors must not become unhandled EventEmitter crashes.
+      if (sftp && typeof sftp.on === "function") {
+        onSftpError = (error) => {
+          abort(error || new Error("Isolated SFTP channel error"));
+        };
+        sftp.on("error", onSftpError);
       }
 
-      if (fileSize === checkpoint && active === 0) finish();
-    };
+      const pump = () => {
+        if (settled) return;
+        if (terminalError || transfer.cancelled) {
+          finish(terminalError || new Error("Transfer cancelled"));
+          return;
+        }
+        if (transfer.paused) {
+          settlePauseWaiters();
+          return;
+        }
 
-    transfer.readStream = {
-      pause() {
-        transfer.paused = true;
-      },
-      resume() {
-        transfer.paused = false;
-        pump();
-      },
-      destroy() {
-        abort();
-      },
-    };
-    transfer.waitForPause = () => {
-      if (active === 0) return Promise.resolve();
-      return new Promise((resolvePause) => pauseResolvers.push(resolvePause));
-    };
-    transfer.abort = abort;
-    pump();
-  });
+        while (
+          active < concurrency
+          && nextOffset < fileSize
+          && !transfer.paused
+          && !transfer.cancelled
+        ) {
+          const position = nextOffset;
+          const length = Math.min(TRANSFER_CHUNK_SIZE, fileSize - position);
+          nextOffset += length;
+          active += 1;
+
+          void copyRange(position, length)
+            .then(() => {
+              transferred += length;
+              completedRanges.set(position, position + length);
+              while (completedRanges.has(contiguousCheckpoint)) {
+                const nextCheckpoint = completedRanges.get(contiguousCheckpoint);
+                completedRanges.delete(contiguousCheckpoint);
+                contiguousCheckpoint = nextCheckpoint;
+              }
+              publishContiguousCheckpoint(false);
+            })
+            .catch((error) => abort(error))
+            .finally(() => {
+              active -= 1;
+              settlePauseWaiters();
+              if (terminalError || transfer.cancelled) {
+                finish(terminalError || new Error("Transfer cancelled"));
+              } else if (contiguousCheckpoint === fileSize) finish();
+              else pump();
+            });
+        }
+
+        if (fileSize === checkpoint && active === 0) finish();
+      };
+
+      transfer.readStream = {
+        pause() {
+          transfer.paused = true;
+        },
+        resume() {
+          transfer.paused = false;
+          pump();
+        },
+        destroy() {
+          abort();
+        },
+      };
+      transfer.waitForPause = () => {
+        if (active === 0) {
+          publishContiguousCheckpoint(true);
+          return Promise.resolve();
+        }
+        return new Promise((resolvePause) => pauseResolvers.push(resolvePause));
+      };
+      transfer.abort = abort;
+      pump();
+    });
+  } finally {
+    if (sftp && onSftpError && typeof sftp.removeListener === "function") {
+      try { sftp.removeListener("error", onSftpError); } catch { }
+    }
+  }
 }
 
 async function uploadFileResumableFast(
@@ -1003,6 +1032,7 @@ async function uploadFileResumableFast(
         },
         sendProgress,
         abortChannel: () => sftp.end?.(),
+        sftp,
       });
     } catch (error) {
       failed = true;
@@ -1060,6 +1090,7 @@ async function downloadFileResumableFast(
         },
         sendProgress,
         abortChannel: () => sftp.end?.(),
+        sftp,
       });
     } catch (error) {
       failed = true;

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -779,7 +779,10 @@ async function runPausableConcurrentRanges({
   abortChannel,
 }) {
   let nextOffset = checkpoint;
-  let transferred = checkpoint;
+  // Only the highest contiguous durable offset is safe to resume from.
+  // Out-of-order range completion must not advance the checkpoint past a hole.
+  let contiguousEnd = checkpoint;
+  const completedRanges = new Map();
   let active = 0;
   let settled = false;
   let terminalError = null;
@@ -790,6 +793,16 @@ async function runPausableConcurrentRanges({
     const resolvers = pauseResolvers;
     pauseResolvers = [];
     for (const resolve of resolvers) resolve();
+  };
+
+  const advanceContiguousEnd = (position, length) => {
+    completedRanges.set(position, length);
+    while (completedRanges.has(contiguousEnd)) {
+      const rangeLength = completedRanges.get(contiguousEnd);
+      completedRanges.delete(contiguousEnd);
+      contiguousEnd += rangeLength;
+    }
+    if (!transfer.cancelled) sendProgress(contiguousEnd, fileSize);
   };
 
   await new Promise((resolve, reject) => {
@@ -832,8 +845,7 @@ async function runPausableConcurrentRanges({
 
         void copyRange(position, length)
           .then(() => {
-            transferred += length;
-            if (!transfer.cancelled) sendProgress(transferred, fileSize);
+            advanceContiguousEnd(position, length);
           })
           .catch((error) => abort(error))
           .finally(() => {
@@ -841,7 +853,7 @@ async function runPausableConcurrentRanges({
             settlePauseWaiters();
             if (terminalError || transfer.cancelled) {
               finish(terminalError || new Error("Transfer cancelled"));
-            } else if (transferred === fileSize) finish();
+            } else if (contiguousEnd === fileSize) finish();
             else pump();
           });
       }
@@ -922,9 +934,10 @@ async function uploadFileResumableFast(
 
 /**
  * Preserve fastGet's high-latency request window without giving up a safe
- * pause checkpoint. Once pause is requested, no new ranges are scheduled and
- * we wait for every in-flight range before acknowledging it. The staged file
- * is therefore complete through its reported size and can resume from there.
+ * pause checkpoint. Progress and resume offsets track the highest contiguous
+ * durable byte; out-of-order range completion cannot advance past a hole.
+ * Once pause is requested, no new ranges are scheduled and we wait for every
+ * in-flight range before acknowledging it.
  */
 async function downloadFileResumableFast(
   remotePath,
@@ -1063,10 +1076,12 @@ async function downloadFile(remotePath, localPath, client, fileSize, transfer, s
         });
         return;
       } catch (err) {
-        if (transfer.cancelled) throw err;
+        // Always release before rethrowing cancel — otherwise the channel stays
+        // in pool.busy and the per-session fast-download budget is exhausted.
         if (transfer.resumable) {
           releaseIsolatedDownloadChannel(client, fastSftp, { dispose: true });
         }
+        if (transfer.cancelled) throw err;
         console.warn(
           "[transferBridge] fastGet failed, falling back to a compatible stream:",
           err?.message || String(err),

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -1018,18 +1018,20 @@ async function uploadFileResumableFast(
   sendProgress,
 ) {
   const checkpoint = Math.max(0, Math.min(transfer.checkpointBytes || 0, fileSize));
-  const localHandle = await fs.promises.open(localPath, "r");
-  let remoteHandle;
+  let localHandle = null;
+  let remoteHandle = null;
   let failed = false;
+  // Always end the isolated channel — callers clear fastSftp after any throw
+  // and assume this helper already disposed it.
   try {
-    remoteHandle = await openSftpHandle(sftp, remotePath, checkpoint > 0 ? "r+" : "w");
-  } catch (error) {
-    await localHandle.close().catch(() => {});
-    try { sftp.end?.(); } catch { }
-    throw error;
-  }
+    try {
+      localHandle = await fs.promises.open(localPath, "r");
+      remoteHandle = await openSftpHandle(sftp, remotePath, checkpoint > 0 ? "r+" : "w");
+    } catch (error) {
+      failed = true;
+      throw error;
+    }
 
-  try {
     try {
       await runPausableConcurrentRanges({
         transfer,
@@ -1053,8 +1055,10 @@ async function uploadFileResumableFast(
     transfer.readStream = null;
     transfer.waitForPause = null;
     transfer.abort = null;
-    await localHandle.close().catch(() => {});
-    if (!failed && !transfer.cancelled) {
+    if (localHandle) {
+      await localHandle.close().catch(() => {});
+    }
+    if (remoteHandle && !failed && !transfer.cancelled) {
       await closeSftpHandle(sftp, remoteHandle).catch(() => {});
     }
     try { sftp.end?.(); } catch { }

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -573,16 +573,27 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
     }
 
     if (fastSftp && transfer.resumable) {
-      await uploadFileResumableFast(
-        localPath,
-        remotePath,
-        fastSftp,
-        fileSize,
-        transfer,
-        sendProgress,
-      );
-      await assertRemoteUploadSize(client, remotePath, fileSize);
-      return;
+      try {
+        await uploadFileResumableFast(
+          localPath,
+          remotePath,
+          fastSftp,
+          fileSize,
+          transfer,
+          sendProgress,
+        );
+        await assertRemoteUploadSize(client, remotePath, fileSize);
+        return;
+      } catch (err) {
+        // uploadFileResumableFast ends the isolated channel itself. Clear the
+        // handle so we do not reuse a closed channel for fastPut below.
+        fastSftp = null;
+        if (transfer.cancelled) throw err;
+        console.warn(
+          "[transferBridge] resumable fast upload failed, falling back to a compatible stream:",
+          err?.message || String(err),
+        );
+      }
     }
 
     if (fastSftp && typeof fastSftp.fastPut === "function") {

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -780,6 +780,8 @@ async function runPausableConcurrentRanges({
 }) {
   let nextOffset = checkpoint;
   let transferred = checkpoint;
+  let contiguousCheckpoint = checkpoint;
+  const completedRanges = new Map();
   let active = 0;
   let settled = false;
   let terminalError = null;
@@ -833,7 +835,15 @@ async function runPausableConcurrentRanges({
         void copyRange(position, length)
           .then(() => {
             transferred += length;
-            if (!transfer.cancelled) sendProgress(transferred, fileSize);
+            completedRanges.set(position, position + length);
+            while (completedRanges.has(contiguousCheckpoint)) {
+              const nextCheckpoint = completedRanges.get(contiguousCheckpoint);
+              completedRanges.delete(contiguousCheckpoint);
+              contiguousCheckpoint = nextCheckpoint;
+            }
+            if (!transfer.cancelled) {
+              sendProgress(transferred, fileSize, { checkpointBytes: contiguousCheckpoint });
+            }
           })
           .catch((error) => abort(error))
           .finally(() => {
@@ -1063,10 +1073,10 @@ async function downloadFile(remotePath, localPath, client, fileSize, transfer, s
         });
         return;
       } catch (err) {
-        if (transfer.cancelled) throw err;
         if (transfer.resumable) {
           releaseIsolatedDownloadChannel(client, fastSftp, { dispose: true });
         }
+        if (transfer.cancelled) throw err;
         console.warn(
           "[transferBridge] fastGet failed, falling back to a compatible stream:",
           err?.message || String(err),
@@ -1295,7 +1305,10 @@ async function startTransferNow(event, payload, onProgress) {
 
     lastObservedTransferred = normalizedTransferred;
     lastObservedTotal = normalizedTotal;
-    transfer.checkpointBytes = normalizedTransferred;
+    const requestedCheckpoint = Number(options.checkpointBytes);
+    transfer.checkpointBytes = Number.isFinite(requestedCheckpoint) && requestedCheckpoint >= 0
+      ? Math.min(requestedCheckpoint, normalizedTotal || requestedCheckpoint)
+      : normalizedTransferred;
 
     const lastSample = speedSamples[speedSamples.length - 1];
     if (!lastSample || lastSample.bytes !== normalizedTransferred || now - lastSample.time >= PROGRESS_THROTTLE_MS) {
@@ -1612,10 +1625,15 @@ async function startTransferNow(event, payload, onProgress) {
               hashLocalPrefix(tempPath, verifyBytes),
             );
           }
-          const downloadProgress = (transferred) => {
-            transfer.downloadCheckpointBytes = transferred;
-            sendProgress(Math.floor(transferred / 2), fileSize);
-            transfer.checkpointBytes = transferred;
+          const downloadProgress = (transferred, _total, options = {}) => {
+            const durableCheckpoint = Number.isFinite(options.checkpointBytes)
+              ? options.checkpointBytes
+              : transferred;
+            transfer.downloadCheckpointBytes = durableCheckpoint;
+            sendProgress(Math.floor(transferred / 2), fileSize, {
+              checkpointBytes: durableCheckpoint,
+            });
+            transfer.checkpointBytes = durableCheckpoint;
           };
           await downloadFile(
             encodedSourcePath,
@@ -1669,10 +1687,15 @@ async function startTransferNow(event, payload, onProgress) {
         const encodedTargetPath = isScpModeClient(targetClient)
           ? uploadTargetPath
           : encodePathForSession(targetSftpId, uploadTargetPath, targetEncoding);
-        const uploadProgress = (transferred) => {
-          transfer.uploadCheckpointBytes = transferred;
-          sendProgress(Math.floor(fileSize / 2) + Math.floor(transferred / 2), fileSize);
-          transfer.checkpointBytes = transferred;
+        const uploadProgress = (transferred, _total, options = {}) => {
+          const durableCheckpoint = Number.isFinite(options.checkpointBytes)
+            ? options.checkpointBytes
+            : transferred;
+          transfer.uploadCheckpointBytes = durableCheckpoint;
+          sendProgress(Math.floor(fileSize / 2) + Math.floor(transferred / 2), fileSize, {
+            checkpointBytes: durableCheckpoint,
+          });
+          transfer.checkpointBytes = durableCheckpoint;
         };
         await uploadFile(
           tempPath,

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -563,13 +563,26 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
   if (!sftp) throw new Error("SFTP client not ready");
   transfer.pauseSupported = Boolean(transfer.resumable);
 
-  // Prefer fastPut on an isolated SFTP channel so cancellation can abort just this transfer.
-  if (!transfer.resumable && !client.__netcattySudoMode) {
+  // Prefer an isolated SFTP channel so cancellation cannot kill the browse session.
+  if (!client.__netcattySudoMode) {
     let fastSftp = null;
     try {
       fastSftp = await openIsolatedSftpChannel(client);
     } catch (err) {
       console.warn("[transferBridge] Failed to open isolated SFTP channel for fastPut, falling back to streams:", err.message || String(err));
+    }
+
+    if (fastSftp && transfer.resumable) {
+      await uploadFileResumableFast(
+        localPath,
+        remotePath,
+        fastSftp,
+        fileSize,
+        transfer,
+        sendProgress,
+      );
+      await assertRemoteUploadSize(client, remotePath, fileSize);
+      return;
     }
 
     if (fastSftp && typeof fastSftp.fastPut === "function") {
@@ -684,6 +697,284 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
   await assertRemoteUploadSize(client, remotePath, fileSize);
 }
 
+function openSftpHandle(sftp, filePath, flags) {
+  return new Promise((resolve, reject) => {
+    sftp.open(filePath, flags, (error, handle) => {
+      if (error) reject(error);
+      else resolve(handle);
+    });
+  });
+}
+
+function closeSftpHandle(sftp, handle) {
+  return new Promise((resolve, reject) => {
+    sftp.close(handle, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function readSftpRange(sftp, handle, buffer, position, length) {
+  let received = 0;
+  while (received < length) {
+    const bytesRead = await new Promise((resolve, reject) => {
+      sftp.read(
+        handle,
+        buffer,
+        received,
+        length - received,
+        position + received,
+        (error, count) => {
+          if (error) reject(error);
+          else resolve(Number(count) || 0);
+        },
+      );
+    });
+    if (bytesRead <= 0) {
+      throw new Error("Download stream finished before the full source was received");
+    }
+    received += bytesRead;
+  }
+}
+
+async function writeLocalRange(fileHandle, buffer, position, length) {
+  let written = 0;
+  while (written < length) {
+    const result = await fileHandle.write(buffer, written, length - written, position + written);
+    if (!result || result.bytesWritten <= 0) {
+      throw new Error("Local download file stopped accepting data");
+    }
+    written += result.bytesWritten;
+  }
+}
+
+async function readLocalRange(fileHandle, buffer, position, length) {
+  let received = 0;
+  while (received < length) {
+    const result = await fileHandle.read(buffer, received, length - received, position + received);
+    if (!result || result.bytesRead <= 0) {
+      throw new Error("Upload source ended before the expected file size");
+    }
+    received += result.bytesRead;
+  }
+}
+
+function writeSftpRange(sftp, handle, buffer, position, length) {
+  return new Promise((resolve, reject) => {
+    sftp.write(handle, buffer, 0, length, position, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function runPausableConcurrentRanges({
+  transfer,
+  fileSize,
+  checkpoint,
+  concurrency,
+  copyRange,
+  sendProgress,
+  abortChannel,
+}) {
+  let nextOffset = checkpoint;
+  let transferred = checkpoint;
+  let active = 0;
+  let settled = false;
+  let terminalError = null;
+  let pauseResolvers = [];
+
+  const settlePauseWaiters = () => {
+    if (!transfer.paused || active !== 0 || pauseResolvers.length === 0) return;
+    const resolvers = pauseResolvers;
+    pauseResolvers = [];
+    for (const resolve of resolvers) resolve();
+  };
+
+  await new Promise((resolve, reject) => {
+    const finish = (error) => {
+      if (settled) return;
+      if (error) terminalError = terminalError || error;
+      if (active > 0) return;
+      settled = true;
+      if (terminalError) reject(terminalError);
+      else resolve();
+    };
+
+    const abort = (error = new Error("Transfer cancelled")) => {
+      terminalError = terminalError || error;
+      try { abortChannel?.(); } catch { }
+      finish(terminalError);
+    };
+
+    const pump = () => {
+      if (settled) return;
+      if (terminalError || transfer.cancelled) {
+        finish(terminalError || new Error("Transfer cancelled"));
+        return;
+      }
+      if (transfer.paused) {
+        settlePauseWaiters();
+        return;
+      }
+
+      while (
+        active < concurrency
+        && nextOffset < fileSize
+        && !transfer.paused
+        && !transfer.cancelled
+      ) {
+        const position = nextOffset;
+        const length = Math.min(TRANSFER_CHUNK_SIZE, fileSize - position);
+        nextOffset += length;
+        active += 1;
+
+        void copyRange(position, length)
+          .then(() => {
+            transferred += length;
+            if (!transfer.cancelled) sendProgress(transferred, fileSize);
+          })
+          .catch((error) => abort(error))
+          .finally(() => {
+            active -= 1;
+            settlePauseWaiters();
+            if (terminalError || transfer.cancelled) {
+              finish(terminalError || new Error("Transfer cancelled"));
+            } else if (transferred === fileSize) finish();
+            else pump();
+          });
+      }
+
+      if (fileSize === checkpoint && active === 0) finish();
+    };
+
+    transfer.readStream = {
+      pause() {
+        transfer.paused = true;
+      },
+      resume() {
+        transfer.paused = false;
+        pump();
+      },
+      destroy() {
+        abort();
+      },
+    };
+    transfer.waitForPause = () => {
+      if (active === 0) return Promise.resolve();
+      return new Promise((resolvePause) => pauseResolvers.push(resolvePause));
+    };
+    transfer.abort = abort;
+    pump();
+  });
+}
+
+async function uploadFileResumableFast(
+  localPath,
+  remotePath,
+  sftp,
+  fileSize,
+  transfer,
+  sendProgress,
+) {
+  const checkpoint = Math.max(0, Math.min(transfer.checkpointBytes || 0, fileSize));
+  const localHandle = await fs.promises.open(localPath, "r");
+  let remoteHandle;
+  let failed = false;
+  try {
+    remoteHandle = await openSftpHandle(sftp, remotePath, checkpoint > 0 ? "r+" : "w");
+  } catch (error) {
+    await localHandle.close().catch(() => {});
+    throw error;
+  }
+
+  try {
+    try {
+      await runPausableConcurrentRanges({
+        transfer,
+        fileSize,
+        checkpoint,
+        concurrency: UPLOAD_TRANSFER_CONCURRENCY,
+        copyRange: async (position, length) => {
+          const buffer = Buffer.allocUnsafe(length);
+          await readLocalRange(localHandle, buffer, position, length);
+          await writeSftpRange(sftp, remoteHandle, buffer, position, length);
+        },
+        sendProgress,
+        abortChannel: () => sftp.end?.(),
+      });
+    } catch (error) {
+      failed = true;
+      throw error;
+    }
+  } finally {
+    transfer.readStream = null;
+    transfer.waitForPause = null;
+    transfer.abort = null;
+    await localHandle.close().catch(() => {});
+    if (!failed && !transfer.cancelled) {
+      await closeSftpHandle(sftp, remoteHandle).catch(() => {});
+    }
+    try { sftp.end?.(); } catch { }
+  }
+}
+
+/**
+ * Preserve fastGet's high-latency request window without giving up a safe
+ * pause checkpoint. Once pause is requested, no new ranges are scheduled and
+ * we wait for every in-flight range before acknowledging it. The staged file
+ * is therefore complete through its reported size and can resume from there.
+ */
+async function downloadFileResumableFast(
+  remotePath,
+  localPath,
+  sftp,
+  fileSize,
+  transfer,
+  sendProgress,
+) {
+  const checkpoint = Math.max(0, Math.min(transfer.checkpointBytes || 0, fileSize));
+  const remoteHandle = await openSftpHandle(sftp, remotePath, "r");
+  let localHandle;
+  let failed = false;
+  try {
+    localHandle = await fs.promises.open(localPath, checkpoint > 0 ? "r+" : "w");
+  } catch (error) {
+    await closeSftpHandle(sftp, remoteHandle).catch(() => {});
+    throw error;
+  }
+
+  try {
+    try {
+      await runPausableConcurrentRanges({
+        transfer,
+        fileSize,
+        checkpoint,
+        concurrency: DOWNLOAD_TRANSFER_CONCURRENCY,
+        copyRange: async (position, length) => {
+          const buffer = Buffer.allocUnsafe(length);
+          await readSftpRange(sftp, remoteHandle, buffer, position, length);
+          await writeLocalRange(localHandle, buffer, position, length);
+        },
+        sendProgress,
+        abortChannel: () => sftp.end?.(),
+      });
+    } catch (error) {
+      failed = true;
+      throw error;
+    }
+  } finally {
+    transfer.readStream = null;
+    transfer.waitForPause = null;
+    transfer.abort = null;
+    await localHandle.close().catch(() => {});
+    if (!failed && !transfer.cancelled) {
+      await closeSftpHandle(sftp, remoteHandle).catch(() => {});
+    }
+  }
+}
+
 /**
  * Download from SFTP to local file using ssh2's fastGet (parallel SFTP requests).
  * Falls back to sequential stream piping if fastGet is unavailable.
@@ -707,13 +998,25 @@ async function downloadFile(remotePath, localPath, client, fileSize, transfer, s
   if (!sftp) throw new Error("SFTP client not ready");
   transfer.pauseSupported = Boolean(transfer.resumable);
 
-  // Prefer fastGet on an isolated SFTP channel so cancellation can abort just this transfer.
-  if (!transfer.resumable && !client.__netcattySudoMode) {
+  // Prefer an isolated SFTP channel so cancellation cannot kill the browse session.
+  if (!client.__netcattySudoMode) {
     const fastSftp = await acquireIsolatedDownloadChannel(client, transfer);
     if (transfer.cancelled) throw new Error("Transfer cancelled");
 
-    if (fastSftp && typeof fastSftp.fastGet === "function") {
+    if (fastSftp && (transfer.resumable || typeof fastSftp.fastGet === "function")) {
       try {
+        if (transfer.resumable) {
+          await downloadFileResumableFast(
+            remotePath,
+            localPath,
+            fastSftp,
+            fileSize,
+            transfer,
+            sendProgress,
+          );
+          releaseIsolatedDownloadChannel(client, fastSftp);
+          return;
+        }
         await new Promise((resolve, reject) => {
           let settled = false;
           let onFastSftpError = null;
@@ -761,6 +1064,9 @@ async function downloadFile(remotePath, localPath, client, fileSize, transfer, s
         return;
       } catch (err) {
         if (transfer.cancelled) throw err;
+        if (transfer.resumable) {
+          releaseIsolatedDownloadChannel(client, fastSftp, { dispose: true });
+        }
         console.warn(
           "[transferBridge] fastGet failed, falling back to a compatible stream:",
           err?.message || String(err),
@@ -1605,6 +1911,9 @@ async function pauseTransfer(_event, payload) {
   }
   transfer.paused = true;
   try { transfer.readStream?.pause?.(); } catch { }
+  if (typeof transfer.waitForPause === "function") {
+    await transfer.waitForPause();
+  }
   if (transfer.writeStream?.pending) {
     await new Promise((resolve) => {
       const timer = setTimeout(resolve, 2000);

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -503,11 +503,25 @@ async function truncateRemoteStagedToCheckpoint(client, stagedRemote, checkpoint
 
 async function prepareStreamFallbackAfterRangeFailure(transfer, client) {
   const checkpoint = Math.max(0, Number(transfer?.checkpointBytes) || 0);
-  if (transfer?.stagedLocalPath) {
+  // Only truncate partial *target* staging. In SFTP→SFTP copies, stagedLocalPath
+  // is the fully-downloaded temp *source* during the upload phase — never shrink it.
+  const localIsPartialTarget =
+    transfer?.stagedLocalPath
+    && transfer.resumeStage !== "upload"
+    && (
+      transfer.resumeStage === "download"
+      || transfer.sourceType === "sftp" && transfer.targetType === "local"
+      || transfer.sourceType === "local" && transfer.targetType === "local"
+    );
+  if (localIsPartialTarget) {
     await truncateStagedPathToCheckpoint(transfer.stagedLocalPath, checkpoint);
   }
   if (transfer?.stagedRemote) {
-    await truncateRemoteStagedToCheckpoint(client, transfer.stagedRemote, checkpoint);
+    await truncateRemoteStagedToCheckpoint(
+      transfer.stagedRemote.client || client,
+      transfer.stagedRemote,
+      checkpoint,
+    );
   }
 }
 
@@ -2106,18 +2120,8 @@ async function pauseTransfer(_event, payload) {
     // byte. File size may extend past a hole when ranges finish out of order.
     if (usesContiguousRangeCheckpoint) {
       // Keep the checkpoint supplied by runPausableConcurrentRanges, and
-      // shrink any sparse tail so a later pause/stat cannot overshoot.
-      const checkpoint = Math.max(0, Number(transfer.checkpointBytes) || 0);
-      if (transfer.stagedLocalPath) {
-        await truncateStagedPathToCheckpoint(transfer.stagedLocalPath, checkpoint);
-      }
-      if (transfer.stagedRemote) {
-        await truncateRemoteStagedToCheckpoint(
-          transfer.stagedRemote.client,
-          transfer.stagedRemote,
-          checkpoint,
-        );
-      }
+      // shrink any sparse *target* tail so a later pause/stat cannot overshoot.
+      await prepareStreamFallbackAfterRangeFailure(transfer, transfer.stagedRemote?.client);
     } else if (transfer.stagedLocalPath) {
       const stat = await fs.promises.stat(transfer.stagedLocalPath);
       transfer.checkpointBytes = stat.size;

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -1125,29 +1125,34 @@ async function uploadFileResumableFast(
     channelError = channelError || error;
   };
   sftp.on?.("error", onChannelError);
-  let localHandle;
-  try {
-    localHandle = await fs.promises.open(localPath, "r");
-  } catch (error) {
+  // Install cancel before OPEN so a stalled remote open can still end the
+  // isolated channel (runPausableConcurrentRanges would install this later).
+  const abortEarly = () => {
+    transfer.cancelled = true;
     try { sftp.end?.(); } catch { }
-    try { sftp.removeListener?.("error", onChannelError); } catch { }
-    const localOpenError = new Error(error?.message || String(error), { cause: error });
-    localOpenError.noTransferFallback = true;
-    throw localOpenError;
-  }
-  let remoteHandle;
+  };
+  transfer.abort = abortEarly;
+
+  let localHandle = null;
+  let remoteHandle = null;
   let failed = false;
+  let noTransferFallback = false;
   try {
+    if (transfer.cancelled) throw new Error("Transfer cancelled");
+    try {
+      localHandle = await fs.promises.open(localPath, "r");
+    } catch (error) {
+      failed = true;
+      noTransferFallback = true;
+      const localOpenError = new Error(error?.message || String(error), { cause: error });
+      localOpenError.noTransferFallback = true;
+      throw localOpenError;
+    }
+    if (transfer.cancelled) throw new Error("Transfer cancelled");
     remoteHandle = await openSftpHandle(sftp, remotePath, checkpoint > 0 ? "r+" : "w");
     if (channelError) throw channelError;
-  } catch (error) {
-    await localHandle.close().catch(() => {});
-    try { sftp.end?.(); } catch { }
-    try { sftp.removeListener?.("error", onChannelError); } catch { }
-    throw error;
-  }
+    if (transfer.cancelled) throw new Error("Transfer cancelled");
 
-  try {
     try {
       await runPausableConcurrentRanges({
         transfer,
@@ -1168,14 +1173,22 @@ async function uploadFileResumableFast(
       failed = true;
       throw error;
     }
+  } catch (error) {
+    failed = true;
+    if (noTransferFallback && error && typeof error === "object") {
+      error.noTransferFallback = true;
+    }
+    throw error;
   } finally {
     transfer.readStream = null;
     transfer.waitForPause = null;
     transfer.cancelPauseWait = null;
     transfer.abort = null;
-    await localHandle.close().catch(() => {});
+    if (localHandle) {
+      await localHandle.close().catch(() => {});
+    }
     let remoteCloseError = null;
-    if (!failed && !transfer.cancelled) {
+    if (remoteHandle && !failed && !transfer.cancelled) {
       try {
         await closeSftpHandle(sftp, remoteHandle);
       } catch (error) {
@@ -1185,6 +1198,7 @@ async function uploadFileResumableFast(
     if (!failed && !transfer.cancelled && !remoteCloseError && channelError) {
       remoteCloseError = channelError;
     }
+    // Single dispose path for the isolated channel.
     try { sftp.end?.(); } catch { }
     try { sftp.removeListener?.("error", onChannelError); } catch { }
     if (remoteCloseError) throw remoteCloseError;
@@ -1212,25 +1226,25 @@ async function downloadFileResumableFast(
     channelError = channelError || error;
   };
   sftp.on?.("error", onChannelError);
-  let remoteHandle;
-  try {
-    remoteHandle = await openSftpHandle(sftp, remotePath, "r");
-    if (channelError) throw channelError;
-  } catch (error) {
-    try { sftp.removeListener?.("error", onChannelError); } catch { }
-    throw error;
-  }
-  let localHandle;
+  // Install cancel before OPEN so a stalled remote open can still end the
+  // isolated channel (runPausableConcurrentRanges would install this later).
+  const abortEarly = () => {
+    transfer.cancelled = true;
+    try { sftp.end?.(); } catch { }
+  };
+  transfer.abort = abortEarly;
+
+  let remoteHandle = null;
+  let localHandle = null;
   let failed = false;
   try {
+    if (transfer.cancelled) throw new Error("Transfer cancelled");
+    remoteHandle = await openSftpHandle(sftp, remotePath, "r");
+    if (channelError) throw channelError;
+    if (transfer.cancelled) throw new Error("Transfer cancelled");
     localHandle = await fs.promises.open(localPath, checkpoint > 0 ? "r+" : "w+");
-  } catch (error) {
-    await closeSftpHandle(sftp, remoteHandle).catch(() => {});
-    try { sftp.removeListener?.("error", onChannelError); } catch { }
-    throw error;
-  }
+    if (transfer.cancelled) throw new Error("Transfer cancelled");
 
-  try {
     try {
       await runPausableConcurrentRanges({
         transfer,
@@ -1252,19 +1266,24 @@ async function downloadFileResumableFast(
       failed = true;
       throw error;
     }
+  } catch (error) {
+    failed = true;
+    throw error;
   } finally {
     transfer.readStream = null;
     transfer.waitForPause = null;
     transfer.cancelPauseWait = null;
     transfer.abort = null;
     let localCloseError = null;
-    try {
-      await localHandle.close();
-    } catch (error) {
-      localCloseError = error;
+    if (localHandle) {
+      try {
+        await localHandle.close();
+      } catch (error) {
+        localCloseError = error;
+      }
     }
     let remoteCloseError = null;
-    if (!failed && !transfer.cancelled) {
+    if (remoteHandle && !failed && !transfer.cancelled) {
       try {
         await closeSftpHandle(sftp, remoteHandle);
       } catch (error) {
@@ -1288,10 +1307,6 @@ async function downloadFileResumableFast(
   }
 }
 
-/**
- * Download from SFTP to local file using ssh2's fastGet (parallel SFTP requests).
- * Falls back to sequential stream piping if fastGet is unavailable.
- */
 async function downloadFile(remotePath, localPath, client, fileSize, transfer, sendProgress, encoding = "utf-8") {
   if (isScpModeClient(client)) {
     transfer.pauseSupported = false;

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -582,6 +582,184 @@ test("fast resumable downloads pause only at a complete checkpoint", async (t) =
   assert.deepEqual(await fs.promises.readFile(targetPath), payload);
 });
 
+test("fast resumable downloads only checkpoint contiguous durable bytes", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-contiguous-ckpt-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(256 * 1024, 17);
+  const pendingReads = [];
+  let holdReads = true;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    read(_handle, buffer, offset, length, position, callback) {
+      const complete = () => {
+        payload.copy(buffer, offset, position, position + length);
+        callback(null, length, buffer, position);
+      };
+      if (holdReads) pendingReads.push({ position, complete });
+      else setImmediate(complete);
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+  });
+  const client = {
+    sftp: createFastSftp({
+      createReadStream() {
+        return Readable.from(payload);
+      },
+    }),
+    stat() {
+      return Promise.resolve({ size: payload.length });
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["source", client]]) });
+
+  const sender = createSender();
+  const targetPath = path.join(tempDir, "contiguous.bin");
+  const running = transferBridge.startTransfer(
+    { sender },
+    {
+      transferId: "download-contiguous-ckpt",
+      sourcePath: "/tmp/contiguous.bin",
+      targetPath,
+      sourceType: "sftp",
+      targetType: "local",
+      sourceSftpId: "source",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+
+  const readyDeadline = Date.now() + 1000;
+  while (pendingReads.length < 8 && Date.now() < readyDeadline) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(pendingReads.length, 8);
+
+  const maxProgress = () => sender.sent
+    .filter((entry) => entry.channel === "netcatty:transfer:progress")
+    .reduce((max, entry) => Math.max(max, Number(entry.payload?.transferred) || 0), 0);
+
+  // Complete a later range first — must not advance the resume checkpoint past a hole.
+  const later = pendingReads.find((entry) => entry.position === 7 * 32 * 1024);
+  assert.ok(later);
+  later.complete();
+  await new Promise((resolve) => setTimeout(resolve, 150));
+  assert.equal(maxProgress(), 0);
+
+  // Completing the leading range advances only through contiguous durable bytes.
+  const first = pendingReads.find((entry) => entry.position === 0);
+  assert.ok(first);
+  first.complete();
+  await new Promise((resolve) => setTimeout(resolve, 150));
+  assert.equal(maxProgress(), 32 * 1024);
+
+  holdReads = false;
+  for (const entry of pendingReads) {
+    if (entry !== later && entry !== first) entry.complete();
+  }
+  assert.equal((await running).error, undefined);
+  assert.deepEqual(await fs.promises.readFile(targetPath), payload);
+});
+
+test("cancelled resumable fast downloads release the isolated channel", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-cancel-release-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(256 * 1024, 19);
+  const pendingReads = [];
+  let holdReads = true;
+  let openedChannels = 0;
+  let fallbackReads = 0;
+  let endedChannels = 0;
+  const makeFastSftp = () => createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    read(_handle, buffer, offset, length, position, callback) {
+      const complete = () => {
+        payload.copy(buffer, offset, position, position + length);
+        callback(null, length, buffer, position);
+      };
+      if (holdReads) pendingReads.push(complete);
+      else setImmediate(complete);
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+    end() {
+      endedChannels += 1;
+    },
+  });
+  const client = {
+    sftp: createFastSftp({
+      createReadStream() {
+        fallbackReads += 1;
+        return Readable.from(payload);
+      },
+    }),
+    stat() {
+      return Promise.resolve({ size: payload.length });
+    },
+    client: {
+      sftp(callback) {
+        openedChannels += 1;
+        callback(null, makeFastSftp());
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["source", client]]) });
+
+  const start = (id) => transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: id,
+      sourcePath: `/tmp/${id}.bin`,
+      targetPath: path.join(tempDir, `${id}.bin`),
+      sourceType: "sftp",
+      targetType: "local",
+      sourceSftpId: "source",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+
+  const cancelledPromise = start("download-cancel-release");
+  const readyDeadline = Date.now() + 1000;
+  while (pendingReads.length < 8 && Date.now() < readyDeadline) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(pendingReads.length, 8);
+  assert.equal(openedChannels, 1);
+
+  await transferBridge.cancelTransfer(null, { transferId: "download-cancel-release" });
+  holdReads = false;
+  for (const complete of pendingReads.splice(0)) complete();
+  const cancelled = await cancelledPromise;
+  assert.equal(cancelled.error, "Transfer cancelled");
+  assert.ok(endedChannels >= 1);
+
+  const next = await Promise.race([
+    start("download-after-cancel-release"),
+    new Promise((_, reject) => setTimeout(() => reject(new Error("next download remained blocked")), 1000)),
+  ]);
+  assert.equal(next.error, undefined);
+  assert.equal(openedChannels, 2);
+  assert.equal(fallbackReads, 0);
+});
+
 test("SFTP downloads fall back to a compatible stream after fastGet fails", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-fallback-test-"));
   t.after(async () => {

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -30,7 +30,7 @@ function createFastSftp(overrides) {
   return sftp;
 }
 
-test("SFTP uploads use conservative per-file request concurrency", async (t) => {
+test("resumable SFTP uploads use conservative per-file request concurrency", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-test-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
@@ -39,20 +39,37 @@ test("SFTP uploads use conservative per-file request concurrency", async (t) => 
   const localPath = path.join(tempDir, "large.bin");
   await fs.promises.writeFile(localPath, Buffer.alloc(1024 * 1024));
 
+  let activeWrites = 0;
   let observedConcurrency = 0;
   let observedChunkSize = 0;
   const fastSftp = createFastSftp({
-    fastPut(_localPath, _remotePath, options, done) {
-      observedConcurrency = options.concurrency;
-      observedChunkSize = options.chunkSize;
-      options.step?.(1024 * 1024, 1024 * 1024, 1024 * 1024);
-      queueMicrotask(() => done());
+    open(_remotePath, flags, callback) {
+      assert.equal(flags, "w");
+      callback(null, Buffer.from("remote-handle"));
+    },
+    write(_handle, _buffer, _offset, length, _position, callback) {
+      activeWrites += 1;
+      observedConcurrency = Math.max(observedConcurrency, activeWrites);
+      observedChunkSize = Math.max(observedChunkSize, length);
+      setImmediate(() => {
+        activeWrites -= 1;
+        callback(null);
+      });
+    },
+    close(_handle, callback) {
+      callback(null);
     },
   });
   const client = {
     sftp: createFastSftp({}),
     stat() {
       return Promise.resolve({ size: 1024 * 1024 });
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    delete() {
+      return Promise.resolve();
     },
     client: {
       sftp(callback) {
@@ -72,12 +89,95 @@ test("SFTP uploads use conservative per-file request concurrency", async (t) => 
       sourceType: "local",
       targetType: "sftp",
       targetSftpId: "target",
+      resumable: true,
     },
   );
 
   assert.equal(result.error, undefined);
   assert.equal(observedConcurrency, 8);
   assert.equal(observedChunkSize, 32 * 1024);
+});
+
+test("fast resumable uploads pause only after in-flight ranges are durable", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-fast-upload-pause-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(1024 * 1024, 13);
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, payload);
+  const pendingWrites = [];
+  let holdWrites = true;
+  let durableBytes = 0;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    write(_handle, _buffer, _offset, length, position, callback) {
+      const complete = () => {
+        durableBytes = Math.max(durableBytes, position + length);
+        callback(null);
+      };
+      if (holdWrites) pendingWrites.push(complete);
+      else setImmediate(complete);
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+  });
+  const client = {
+    sftp: createFastSftp({}),
+    stat() {
+      return Promise.resolve({ size: durableBytes });
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    delete() {
+      return Promise.resolve();
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const running = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-fast-paused",
+      sourcePath: localPath,
+      targetPath: "/tmp/upload.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+
+  const readyDeadline = Date.now() + 1000;
+  while (pendingWrites.length < 8 && Date.now() < readyDeadline) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(pendingWrites.length, 8);
+
+  const pausing = transferBridge.pauseTransfer(null, { transferId: "upload-fast-paused" });
+  holdWrites = false;
+  for (const complete of pendingWrites.splice(0)) complete();
+  const paused = await pausing;
+  assert.equal(paused.success, true);
+  assert.equal(paused.checkpointBytes, 256 * 1024);
+
+  assert.deepEqual(
+    await transferBridge.resumeTransfer(null, { transferId: "upload-fast-paused" }),
+    { success: true },
+  );
+  assert.equal((await running).error, undefined);
+  assert.equal(durableBytes, payload.length);
 });
 
 test("SFTP uploads fail when remote size does not match local size", async (t) => {
@@ -342,29 +442,39 @@ test("SFTP stream-fallback uploads fail on premature close", async (t) => {
   assert.ok(sender.sent.some((entry) => entry.channel === "netcatty:transfer:error"));
 });
 
-test("SFTP downloads preserve a 2MB request window on high-latency paths", async (t) => {
+test("resumable SFTP downloads preserve a 2MB request window on high-latency paths", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-test-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   });
 
+  const payload = Buffer.alloc(4 * 1024 * 1024, 7);
+  let activeReads = 0;
   let observedConcurrency = 0;
   let observedChunkSize = 0;
   const fastSftp = createFastSftp({
-    fastGet(_remotePath, localPath, options, done) {
-      observedConcurrency = options.concurrency;
-      observedChunkSize = options.chunkSize;
-      options.step?.(1024 * 1024, 1024 * 1024, 1024 * 1024);
-      fs.promises.writeFile(localPath, Buffer.alloc(1024 * 1024)).then(
-        () => done(),
-        (err) => done(err),
-      );
+    open(_remotePath, flags, callback) {
+      assert.equal(flags, "r");
+      callback(null, Buffer.from("remote-handle"));
+    },
+    read(_handle, buffer, offset, length, position, callback) {
+      activeReads += 1;
+      observedConcurrency = Math.max(observedConcurrency, activeReads);
+      observedChunkSize = Math.max(observedChunkSize, length);
+      payload.copy(buffer, offset, position, position + length);
+      setImmediate(() => {
+        activeReads -= 1;
+        callback(null, length, buffer, position);
+      });
+    },
+    close(_handle, callback) {
+      callback(null);
     },
   });
   const client = {
     sftp: createFastSftp({}),
     stat(_path) {
-      return Promise.resolve({ size: 1024 * 1024 });
+      return Promise.resolve({ size: payload.length });
     },
     client: {
       sftp(callback) {
@@ -384,12 +494,92 @@ test("SFTP downloads preserve a 2MB request window on high-latency paths", async
       sourceType: "sftp",
       targetType: "local",
       sourceSftpId: "source",
+      resumable: true,
     },
   );
 
   assert.equal(result.error, undefined);
   assert.equal(observedChunkSize, 32 * 1024);
   assert.equal(observedConcurrency * observedChunkSize, 2 * 1024 * 1024);
+  assert.deepEqual(await fs.promises.readFile(path.join(tempDir, "large.bin")), payload);
+});
+
+test("fast resumable downloads pause only at a complete checkpoint", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-fast-pause-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(4 * 1024 * 1024, 11);
+  const pendingReads = [];
+  let holdReads = true;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    read(_handle, buffer, offset, length, position, callback) {
+      const complete = () => {
+        payload.copy(buffer, offset, position, position + length);
+        callback(null, length, buffer, position);
+      };
+      if (holdReads) pendingReads.push(complete);
+      else setImmediate(complete);
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+  });
+  const client = {
+    sftp: createFastSftp({
+      createReadStream() {
+        return Readable.from(payload);
+      },
+    }),
+    stat() {
+      return Promise.resolve({ size: payload.length });
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["source", client]]) });
+
+  const targetPath = path.join(tempDir, "large.bin");
+  const running = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "download-fast-paused",
+      sourcePath: "/tmp/large.bin",
+      targetPath,
+      sourceType: "sftp",
+      targetType: "local",
+      sourceSftpId: "source",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+
+  const readyDeadline = Date.now() + 1000;
+  while (pendingReads.length < 64 && Date.now() < readyDeadline) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(pendingReads.length, 64);
+
+  const pausing = transferBridge.pauseTransfer(null, { transferId: "download-fast-paused" });
+  holdReads = false;
+  for (const complete of pendingReads.splice(0)) complete();
+  const paused = await pausing;
+  assert.equal(paused.success, true);
+  assert.equal(paused.checkpointBytes, 2 * 1024 * 1024);
+
+  assert.deepEqual(
+    await transferBridge.resumeTransfer(null, { transferId: "download-fast-paused" }),
+    { success: true },
+  );
+  assert.equal((await running).error, undefined);
+  assert.deepEqual(await fs.promises.readFile(targetPath), payload);
 });
 
 test("SFTP downloads fall back to a compatible stream after fastGet fails", async (t) => {

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -198,7 +198,18 @@ test("failed resumable upload opens close their isolated channel", async (t) => 
     },
   });
   const client = {
-    sftp: createFastSftp({}),
+    // Stream fallback also rejects so the transfer still fails after cleanup.
+    sftp: createFastSftp({
+      createWriteStream() {
+        const writeStream = new Writable({
+          write(_chunk, _encoding, callback) {
+            callback(new Error("permission denied"));
+          },
+        });
+        queueMicrotask(() => writeStream.destroy(new Error("permission denied")));
+        return writeStream;
+      },
+    }),
     client: {
       sftp(callback) {
         callback(null, fastSftp);
@@ -223,6 +234,78 @@ test("failed resumable upload opens close their isolated channel", async (t) => 
 
   assert.match(result.error || "", /permission denied/);
   assert.equal(endedChannels, 1);
+});
+
+test("resumable SFTP uploads fall back to a compatible stream after fast path fails", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-fallback-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.from("complete fallback upload");
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, payload);
+  let endedChannels = 0;
+  let remoteBytes = 0;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(new Error("server rejected random-access writes"));
+    },
+    end() {
+      endedChannels += 1;
+    },
+  });
+  const client = {
+    sftp: createFastSftp({
+      createWriteStream() {
+        return new Writable({
+          write(chunk, _encoding, callback) {
+            remoteBytes += chunk.length;
+            callback();
+          },
+          final(callback) {
+            queueMicrotask(() => {
+              this.emit("close");
+              callback();
+            });
+          },
+        });
+      },
+    }),
+    stat() {
+      return Promise.resolve({ size: remoteBytes });
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    delete() {
+      return Promise.resolve();
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-fallback",
+      sourcePath: localPath,
+      targetPath: "/tmp/upload.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+
+  assert.equal(result.error, undefined);
+  assert.equal(endedChannels, 1);
+  assert.equal(remoteBytes, payload.length);
 });
 
 test("SFTP uploads fail when remote size does not match local size", async (t) => {

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -582,6 +582,162 @@ test("fast resumable downloads pause only at a complete checkpoint", async (t) =
   assert.deepEqual(await fs.promises.readFile(targetPath), payload);
 });
 
+test("fast resumable downloads fall back from the highest contiguous checkpoint", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-contiguous-fallback-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(2 * 32 * 1024, 17);
+  let fallbackStart = null;
+  let firstReadCallback = null;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    read(_handle, buffer, offset, length, position, callback) {
+      if (position === 0) {
+        firstReadCallback = callback;
+        return;
+      }
+      payload.copy(buffer, offset, position, position + length);
+      callback(null, length, buffer, position);
+      queueMicrotask(() => firstReadCallback(new Error("first range failed")));
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+  });
+  const client = {
+    sftp: createFastSftp({
+      createReadStream(_remotePath, options) {
+        fallbackStart = options.start;
+        return Readable.from(payload.subarray(options.start));
+      },
+    }),
+    stat() {
+      return Promise.resolve({ size: payload.length });
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["source", client]]) });
+
+  const targetPath = path.join(tempDir, "fallback.bin");
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "download-contiguous-fallback",
+      sourcePath: "/tmp/source.bin",
+      targetPath,
+      sourceType: "sftp",
+      targetType: "local",
+      sourceSftpId: "source",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+
+  assert.equal(result.error, undefined);
+  assert.equal(fallbackStart, 0);
+  assert.deepEqual(await fs.promises.readFile(targetPath), payload);
+});
+
+test("cancelled fast resumable downloads release their isolated channel", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-cancel-release-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(32 * 1024, 19);
+  let openedChannels = 0;
+  let fallbackReads = 0;
+  let cancelRead = null;
+  const firstChannel = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("first-handle"));
+    },
+    read(_handle, _buffer, _offset, _length, _position, callback) {
+      cancelRead = () => callback(new Error("channel cancelled"));
+    },
+    end() {
+      cancelRead?.();
+    },
+  });
+  const secondChannel = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("second-handle"));
+    },
+    read(_handle, buffer, offset, length, position, callback) {
+      payload.copy(buffer, offset, position, position + length);
+      callback(null, length, buffer, position);
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+  });
+  const client = {
+    sftp: createFastSftp({
+      createReadStream() {
+        fallbackReads += 1;
+        return Readable.from(payload);
+      },
+    }),
+    stat() {
+      return Promise.resolve({ size: payload.length });
+    },
+    client: {
+      sftp(callback) {
+        openedChannels += 1;
+        callback(null, openedChannels === 1 ? firstChannel : secondChannel);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["source", client]]) });
+
+  const first = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "download-cancel-release-first",
+      sourcePath: "/tmp/source.bin",
+      targetPath: path.join(tempDir, "first.bin"),
+      sourceType: "sftp",
+      targetType: "local",
+      sourceSftpId: "source",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+  const readyDeadline = Date.now() + 1000;
+  while (!cancelRead && Date.now() < readyDeadline) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(typeof cancelRead, "function");
+  await transferBridge.cancelTransfer(null, { transferId: "download-cancel-release-first" });
+  assert.equal((await first).error, "Transfer cancelled");
+
+  const second = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "download-cancel-release-second",
+      sourcePath: "/tmp/source.bin",
+      targetPath: path.join(tempDir, "second.bin"),
+      sourceType: "sftp",
+      targetType: "local",
+      sourceSftpId: "source",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+
+  assert.equal(second.error, undefined);
+  assert.equal(openedChannels, 2);
+  assert.equal(fallbackReads, 0);
+});
+
 test("SFTP downloads fall back to a compatible stream after fastGet fails", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-fallback-test-"));
   t.after(async () => {

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -180,6 +180,51 @@ test("fast resumable uploads pause only after in-flight ranges are durable", asy
   assert.equal(durableBytes, payload.length);
 });
 
+test("failed resumable upload opens close their isolated channel", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-open-fail-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(32 * 1024, 23));
+  let endedChannels = 0;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(new Error("permission denied"));
+    },
+    end() {
+      endedChannels += 1;
+    },
+  });
+  const client = {
+    sftp: createFastSftp({}),
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-open-fail",
+      sourcePath: localPath,
+      targetPath: "/tmp/upload.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: 32 * 1024,
+      resumable: true,
+    },
+  );
+
+  assert.match(result.error || "", /permission denied/);
+  assert.equal(endedChannels, 1);
+});
+
 test("SFTP uploads fail when remote size does not match local size", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-size-test-"));
   t.after(async () => {
@@ -567,10 +612,22 @@ test("fast resumable downloads pause only at a complete checkpoint", async (t) =
   }
   assert.equal(pendingReads.length, 64);
 
+  const originalStat = fs.promises.stat;
+  fs.promises.stat = async (filePath) => {
+    if (String(filePath).includes("download-fast-paused")) {
+      throw new Error("fast range checkpoints must not be inferred from file size");
+    }
+    return originalStat(filePath);
+  };
   const pausing = transferBridge.pauseTransfer(null, { transferId: "download-fast-paused" });
   holdReads = false;
   for (const complete of pendingReads.splice(0)) complete();
-  const paused = await pausing;
+  let paused;
+  try {
+    paused = await pausing;
+  } finally {
+    fs.promises.stat = originalStat;
+  }
   assert.equal(paused.success, true);
   assert.equal(paused.checkpointBytes, 2 * 1024 * 1024);
 

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -1000,6 +1000,7 @@ test("resumable fast uploads reject same-size source changes", async (t) => {
   const payload = Buffer.alloc(32 * 1024, 73);
   const localPath = path.join(tempDir, "upload.bin");
   await fs.promises.writeFile(localPath, payload);
+  const frozenStat = await fs.promises.stat(localPath);
   let changed = false;
   let promoted = false;
   let stagedDeleted = false;
@@ -1008,10 +1009,18 @@ test("resumable fast uploads reject same-size source changes", async (t) => {
       callback(null, Buffer.from("remote-handle"));
     },
     write(_handle, _buffer, _offset, _length, _position, callback) {
-      fs.promises.writeFile(localPath, Buffer.alloc(payload.length, 74)).then(() => {
-        changed = true;
-        callback(null);
-      }, callback);
+      // Same-size rewrite + restore original mtime/ctime so metadata-only
+      // checks cannot detect the change (Codex regression on coarse FS clocks).
+      fs.promises.writeFile(localPath, Buffer.alloc(payload.length, 74))
+        .then(() => fs.promises.utimes(
+          localPath,
+          frozenStat.atime,
+          frozenStat.mtime,
+        ))
+        .then(() => {
+          changed = true;
+          callback(null);
+        }, callback);
     },
     close(_handle, callback) {
       callback(null);
@@ -1053,7 +1062,7 @@ test("resumable fast uploads reject same-size source changes", async (t) => {
   );
 
   assert.equal(changed, true);
-  assert.match(result.error || "", /source.*changed/);
+  assert.match(result.error || "", /source.*changed/i);
   assert.equal(promoted, false);
   assert.equal(stagedDeleted, true);
 });

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -545,6 +545,73 @@ test("failed local open for resumable upload still ends the isolated channel", a
   assert.equal(remoteOpenAttempts, 0);
 });
 
+test("cancel during stalled resumable upload OPEN ends the isolated channel", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-open-stall-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(32 * 1024, 29));
+  let endedChannels = 0;
+  let releaseOpen = null;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      releaseOpen = () => callback(new Error("channel closed during open"));
+    },
+    end() {
+      endedChannels += 1;
+      // Simulate ssh2 failing the pending OPEN when the channel ends.
+      releaseOpen?.();
+      releaseOpen = null;
+    },
+  });
+  const client = {
+    sftp: createFastSftp({
+      createWriteStream() {
+        const writeStream = new Writable({
+          write(_chunk, _encoding, callback) {
+            callback(new Error("should not stream-fallback after cancel"));
+          },
+        });
+        return writeStream;
+      },
+    }),
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const running = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-open-stall-cancel",
+      sourcePath: localPath,
+      targetPath: "/tmp/upload.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: 32 * 1024,
+      resumable: true,
+      skipAdmission: true,
+    },
+  );
+
+  const readyDeadline = Date.now() + 1000;
+  while (!releaseOpen && Date.now() < readyDeadline) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.ok(releaseOpen, "expected remote OPEN to stall");
+
+  await transferBridge.cancelTransfer(null, { transferId: "upload-open-stall-cancel" });
+  const result = await running;
+  assert.match(result.error || "", /cancel|closed/i);
+  assert.ok(endedChannels >= 1, `expected isolated channel end on cancel, got ${endedChannels}`);
+});
+
 test("resumable SFTP uploads fall back to a compatible stream after fast path fails", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-fallback-"));
   t.after(async () => {

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -197,6 +197,174 @@ test("fast resumable uploads pause only after in-flight ranges are durable", asy
   assert.equal(durableBytes, payload.length);
 });
 
+test("resuming while a fast pause is pending settles the pause request", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-pause-resume-race-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(32 * 1024, 67);
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, payload);
+  let finishWrite = null;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    write(_handle, _buffer, _offset, _length, _position, callback) {
+      finishWrite = () => callback(null);
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+  });
+  const client = {
+    sftp: createFastSftp({}),
+    stat() {
+      return Promise.resolve({ size: payload.length });
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    delete() {
+      return Promise.resolve();
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const running = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "pause-resume-race",
+      sourcePath: localPath,
+      targetPath: "/tmp/upload.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+  const deadline = Date.now() + 1000;
+  while (!finishWrite && Date.now() < deadline) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(typeof finishWrite, "function");
+
+  const pausing = transferBridge.pauseTransfer(null, { transferId: "pause-resume-race" });
+  assert.deepEqual(
+    await transferBridge.resumeTransfer(null, { transferId: "pause-resume-race" }),
+    { success: true },
+  );
+  assert.deepEqual(await pausing, {
+    success: false,
+    reason: "Pause was superseded by resume",
+  });
+
+  finishWrite();
+  assert.equal((await running).error, undefined);
+});
+
+test("resuming during pause fingerprinting prevents a stale pause success", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-late-pause-race-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(512 * 1024, 71);
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, payload);
+  const pendingWrites = [];
+  let holdWrites = true;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    write(_handle, _buffer, _offset, _length, _position, callback) {
+      if (holdWrites) pendingWrites.push(callback);
+      else setImmediate(() => callback(null));
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+  });
+  const client = {
+    sftp: createFastSftp({}),
+    stat() {
+      return Promise.resolve({ size: payload.length });
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    delete() {
+      return Promise.resolve();
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const originalCreateReadStream = fs.createReadStream;
+  let fingerprintStream = null;
+  fs.createReadStream = (filePath, options) => {
+    if (filePath !== localPath || options) return originalCreateReadStream(filePath, options);
+    fingerprintStream = new Readable({ read() {} });
+    return fingerprintStream;
+  };
+
+  let running;
+  try {
+    running = transferBridge.startTransfer(
+      { sender: createSender() },
+      {
+        transferId: "late-pause-race",
+        sourcePath: localPath,
+        targetPath: "/tmp/upload.bin",
+        sourceType: "local",
+        targetType: "sftp",
+        targetSftpId: "target",
+        totalBytes: payload.length,
+        resumable: true,
+      },
+    );
+    const writeDeadline = Date.now() + 1000;
+    while (pendingWrites.length < 8 && Date.now() < writeDeadline) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    assert.equal(pendingWrites.length, 8);
+
+    const pausing = transferBridge.pauseTransfer(null, { transferId: "late-pause-race" });
+    holdWrites = false;
+    for (const callback of pendingWrites.splice(0)) callback(null);
+    const fingerprintDeadline = Date.now() + 1000;
+    while (!fingerprintStream && Date.now() < fingerprintDeadline) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    assert.ok(fingerprintStream);
+
+    const resuming = transferBridge.resumeTransfer(null, { transferId: "late-pause-race" });
+    fingerprintStream.push(payload);
+    fingerprintStream.push(null);
+    assert.deepEqual(await resuming, { success: true });
+    assert.deepEqual(await pausing, {
+      success: false,
+      reason: "Pause was superseded by resume",
+    });
+  } finally {
+    fs.createReadStream = originalCreateReadStream;
+  }
+
+  assert.equal((await running).error, undefined);
+});
+
 test("failed resumable upload opens close their isolated channel", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-open-fail-"));
   t.after(async () => {
@@ -206,9 +374,13 @@ test("failed resumable upload opens close their isolated channel", async (t) => 
   const localPath = path.join(tempDir, "upload.bin");
   await fs.promises.writeFile(localPath, Buffer.alloc(32 * 1024, 23));
   let endedChannels = 0;
+  let hadOpenErrorListener = false;
   const fastSftp = createFastSftp({
     open(_remotePath, _flags, callback) {
-      callback(new Error("permission denied"));
+      hadOpenErrorListener = fastSftp.listenerCount("error") > 0;
+      const error = new Error("permission denied");
+      if (hadOpenErrorListener) fastSftp.emit("error", error);
+      callback(error);
     },
     end() {
       endedChannels += 1;
@@ -250,6 +422,62 @@ test("failed resumable upload opens close their isolated channel", async (t) => 
   );
 
   assert.match(result.error || "", /permission denied/);
+  assert.equal(hadOpenErrorListener, true);
+  assert.equal(endedChannels, 1);
+});
+
+test("failed local upload opens close their isolated channel", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-local-open-fail-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(32 * 1024, 71));
+  let endedChannels = 0;
+  const fastSftp = createFastSftp({
+    end() {
+      endedChannels += 1;
+    },
+  });
+  const client = {
+    sftp: createFastSftp({}),
+    delete() {
+      return Promise.resolve();
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const originalOpen = fs.promises.open;
+  fs.promises.open = async (filePath, ...args) => {
+    if (filePath === localPath) throw new Error("local source unavailable");
+    return originalOpen(filePath, ...args);
+  };
+  let result;
+  try {
+    result = await transferBridge.startTransfer(
+      { sender: createSender() },
+      {
+        transferId: "upload-local-open-fail",
+        sourcePath: localPath,
+        targetPath: "/tmp/upload.bin",
+        sourceType: "local",
+        targetType: "sftp",
+        targetSftpId: "target",
+        totalBytes: 32 * 1024,
+        resumable: true,
+      },
+    );
+  } finally {
+    fs.promises.open = originalOpen;
+  }
+
+  assert.match(result.error || "", /local source unavailable/);
   assert.equal(endedChannels, 1);
 });
 
@@ -387,6 +615,439 @@ test("resumable SFTP uploads fall back to a compatible stream after fast path fa
   assert.equal(result.error, undefined);
   assert.equal(endedChannels, 1);
   assert.equal(remoteBytes, payload.length);
+});
+
+test("resumable upload fallback rejects a source changed during streaming", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-fallback-change-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(32 * 1024, 41);
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, payload);
+  let changed = false;
+  let promoted = false;
+  let stagedDeleted = false;
+  let remoteBytes = 0;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(new Error("range upload unavailable"));
+    },
+  });
+  const client = {
+    sftp: createFastSftp({
+      createWriteStream() {
+        return new Writable({
+          write(chunk, _encoding, callback) {
+            remoteBytes += chunk.length;
+            fs.promises.writeFile(localPath, Buffer.alloc(payload.length, 42)).then(() => {
+              changed = true;
+              callback();
+            }, callback);
+          },
+          final(callback) {
+            queueMicrotask(() => {
+              this.emit("close");
+              callback();
+            });
+          },
+        });
+      },
+    }),
+    stat() {
+      return Promise.resolve({ size: remoteBytes });
+    },
+    rename() {
+      promoted = true;
+      return Promise.resolve();
+    },
+    delete() {
+      stagedDeleted = true;
+      return Promise.resolve();
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-fallback-change",
+      sourcePath: localPath,
+      targetPath: "/tmp/upload.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+
+  assert.equal(changed, true);
+  assert.match(result.error || "", /source.*changed/i);
+  assert.equal(promoted, false);
+  assert.equal(stagedDeleted, true);
+});
+
+test("resumable fast uploads handle isolated channel errors before falling back", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-channel-error-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(32 * 1024, 31);
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, payload);
+  let hadErrorListener = false;
+  let remoteBytes = 0;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    write(_handle, _buffer, _offset, _length, _position, callback) {
+      hadErrorListener = fastSftp.listenerCount("error") > 0;
+      const error = new Error("isolated channel failed");
+      queueMicrotask(() => {
+        if (hadErrorListener) fastSftp.emit("error", error);
+        callback(error);
+      });
+    },
+  });
+  const client = {
+    sftp: createFastSftp({
+      createWriteStream() {
+        return new Writable({
+          write(chunk, _encoding, callback) {
+            remoteBytes += chunk.length;
+            callback();
+          },
+          final(callback) {
+            queueMicrotask(() => {
+              this.emit("close");
+              callback();
+            });
+          },
+        });
+      },
+    }),
+    stat() {
+      return Promise.resolve({ size: remoteBytes });
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    delete() {
+      return Promise.resolve();
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-channel-error",
+      sourcePath: localPath,
+      targetPath: "/tmp/upload.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+
+  assert.equal(result.error, undefined);
+  assert.equal(hadErrorListener, true);
+  assert.equal(remoteBytes, payload.length);
+});
+
+test("resumable fast upload fallback discards sparse remote tails", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-sparse-tail-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(3 * 32 * 1024, 41);
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, payload);
+  let secondWriteCallback = null;
+  let fallbackOptions = null;
+  let remoteBytes = 0;
+  const progress = [];
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    write(_handle, _buffer, _offset, length, position, callback) {
+      if (position === 32 * 1024) {
+        secondWriteCallback = callback;
+        return;
+      }
+      remoteBytes = Math.max(remoteBytes, position + length);
+      callback(null);
+      if (position === 2 * 32 * 1024) {
+        queueMicrotask(() => secondWriteCallback(new Error("second range failed")));
+      }
+    },
+  });
+  const client = {
+    sftp: createFastSftp({
+      createWriteStream(_remotePath, options) {
+        fallbackOptions = options;
+        if (options.flags === "w") remoteBytes = 0;
+        return new Writable({
+          write(chunk, _encoding, callback) {
+            remoteBytes += chunk.length;
+            callback();
+          },
+          final(callback) {
+            queueMicrotask(() => {
+              this.emit("close");
+              callback();
+            });
+          },
+        });
+      },
+    }),
+    stat() {
+      return Promise.resolve({ size: remoteBytes });
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    delete() {
+      return Promise.resolve();
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-sparse-tail",
+      sourcePath: localPath,
+      targetPath: "/tmp/upload.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+    (transferred) => progress.push(transferred),
+  );
+
+  assert.equal(result.error, undefined);
+  assert.equal(fallbackOptions.flags, "w");
+  assert.equal(fallbackOptions.start, 0);
+  assert.equal(remoteBytes, payload.length);
+  const firstAdvanced = progress.findIndex((transferred) => transferred > 0);
+  assert.ok(firstAdvanced >= 0);
+  assert.ok(progress.slice(firstAdvanced + 1).includes(0));
+});
+
+test("resumable fast uploads reject a source that grows during transfer", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-source-growth-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(32 * 1024, 59);
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, payload);
+  let sourceGrew = false;
+  let promoted = false;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    write(_handle, _buffer, _offset, _length, _position, callback) {
+      if (!sourceGrew) {
+        sourceGrew = true;
+        fs.appendFileSync(localPath, Buffer.from([1]));
+      }
+      callback(null);
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+  });
+  const client = {
+    sftp: createFastSftp({}),
+    stat() {
+      return Promise.resolve({ size: payload.length });
+    },
+    rename() {
+      promoted = true;
+      return Promise.resolve();
+    },
+    delete() {
+      return Promise.resolve();
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-source-growth",
+      sourcePath: localPath,
+      targetPath: "/tmp/upload.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+
+  assert.match(result.error || "", /source size changed/);
+  assert.equal(promoted, false);
+});
+
+test("resumable fast uploads reject same-size source changes", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-metadata-change-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(32 * 1024, 73);
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, payload);
+  let changed = false;
+  let promoted = false;
+  let stagedDeleted = false;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    write(_handle, _buffer, _offset, _length, _position, callback) {
+      fs.promises.writeFile(localPath, Buffer.alloc(payload.length, 74)).then(() => {
+        changed = true;
+        callback(null);
+      }, callback);
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+  });
+  const client = {
+    sftp: createFastSftp({}),
+    stat() {
+      return Promise.resolve({ size: payload.length });
+    },
+    rename() {
+      promoted = true;
+      return Promise.resolve();
+    },
+    delete() {
+      stagedDeleted = true;
+      return Promise.resolve();
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-metadata-change",
+      sourcePath: localPath,
+      targetPath: "/tmp/upload.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+
+  assert.equal(changed, true);
+  assert.match(result.error || "", /source.*changed/);
+  assert.equal(promoted, false);
+  assert.equal(stagedDeleted, true);
+});
+
+test("resumable fast downloads clear staged data after a same-second source change", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-download-source-change-"));
+  const transferId = "download-source-change";
+  const targetPath = path.join(tempDir, "download.bin");
+  const stagedPath = tempDirBridge.getTransferTempFilePath(transferId, path.basename(targetPath));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+    await fs.promises.rm(stagedPath, { force: true });
+  });
+  await fs.promises.writeFile(targetPath, "original");
+
+  const payload = Buffer.alloc(32 * 1024, 61);
+  const latestPayload = Buffer.alloc(payload.length, 62);
+  let reads = 0;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    read(_handle, buffer, offset, length, position, callback) {
+      const currentPayload = reads++ === 0 ? payload : latestPayload;
+      currentPayload.copy(buffer, offset, position, position + length);
+      callback(null, length, buffer, position);
+    },
+    close(_handle, callback) {
+      callback(new Error("remote close failed"));
+    },
+  });
+  const client = {
+    sftp: createFastSftp({}),
+    stat() {
+      return Promise.resolve({ size: payload.length, mtime: 1 });
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["source", client]]) });
+
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId,
+      sourcePath: "/tmp/source.bin",
+      targetPath,
+      sourceType: "sftp",
+      targetType: "local",
+      sourceSftpId: "source",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+
+  assert.match(result.error || "", /source.*changed/);
+  assert.equal(await fs.promises.readFile(targetPath, "utf8"), "original");
+  await assert.rejects(fs.promises.stat(stagedPath), { code: "ENOENT" });
 });
 
 test("SFTP uploads fail when remote size does not match local size", async (t) => {
@@ -681,7 +1342,11 @@ test("resumable SFTP downloads preserve a 2MB request window on high-latency pat
     },
   });
   const client = {
-    sftp: createFastSftp({}),
+    sftp: createFastSftp({
+      createReadStream() {
+        return Readable.from(payload);
+      },
+    }),
     stat(_path) {
       return Promise.resolve({ size: payload.length });
     },
@@ -809,21 +1474,26 @@ test("fast resumable downloads fall back from the highest contiguous checkpoint"
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   });
 
-  const payload = Buffer.alloc(2 * 32 * 1024, 17);
+  const payload = Buffer.alloc(3 * 32 * 1024, 17);
   let fallbackStart = null;
-  let firstReadCallback = null;
+  let secondReadCallback = null;
+  let targetPath = null;
+  let stagedPath = null;
+  const progress = [];
   const fastSftp = createFastSftp({
     open(_remotePath, _flags, callback) {
       callback(null, Buffer.from("remote-handle"));
     },
     read(_handle, buffer, offset, length, position, callback) {
-      if (position === 0) {
-        firstReadCallback = callback;
+      if (position === 32 * 1024) {
+        secondReadCallback = callback;
         return;
       }
       payload.copy(buffer, offset, position, position + length);
       callback(null, length, buffer, position);
-      queueMicrotask(() => firstReadCallback(new Error("first range failed")));
+      if (position === 2 * 32 * 1024) {
+        queueMicrotask(() => secondReadCallback(new Error("second range failed")));
+      }
     },
     close(_handle, callback) {
       callback(null);
@@ -833,6 +1503,7 @@ test("fast resumable downloads fall back from the highest contiguous checkpoint"
     sftp: createFastSftp({
       createReadStream(_remotePath, options) {
         fallbackStart = options.start;
+        assert.equal(fs.statSync(stagedPath).size, options.start);
         return Readable.from(payload.subarray(options.start));
       },
     }),
@@ -847,7 +1518,11 @@ test("fast resumable downloads fall back from the highest contiguous checkpoint"
   };
   transferBridge.init({ sftpClients: new Map([["source", client]]) });
 
-  const targetPath = path.join(tempDir, "fallback.bin");
+  targetPath = path.join(tempDir, "fallback.bin");
+  stagedPath = tempDirBridge.getTransferTempFilePath(
+    "download-contiguous-fallback",
+    path.basename(targetPath),
+  );
   const result = await transferBridge.startTransfer(
     { sender: createSender() },
     {
@@ -860,11 +1535,78 @@ test("fast resumable downloads fall back from the highest contiguous checkpoint"
       totalBytes: payload.length,
       resumable: true,
     },
+    (transferred) => progress.push(transferred),
   );
 
   assert.equal(result.error, undefined);
-  assert.equal(fallbackStart, 0);
+  assert.equal(fallbackStart, 32 * 1024);
+  const firstPastCheckpoint = progress.findIndex((transferred) => transferred > fallbackStart);
+  assert.ok(firstPastCheckpoint >= 0);
+  assert.ok(progress.slice(firstPastCheckpoint + 1).includes(fallbackStart));
   assert.deepEqual(await fs.promises.readFile(targetPath), payload);
+});
+
+test("resumable download fallback rejects a remote source changed during streaming", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-download-fallback-change-"));
+  const transferId = "download-fallback-change";
+  const targetPath = path.join(tempDir, "download.bin");
+  const stagedPath = tempDirBridge.getTransferTempFilePath(transferId, path.basename(targetPath));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+    await fs.promises.rm(stagedPath, { force: true });
+  });
+  await fs.promises.writeFile(targetPath, "original");
+
+  const payload = Buffer.alloc(32 * 1024, 51);
+  let sourceChanged = false;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    read(_handle, _buffer, _offset, _length, _position, callback) {
+      callback(new Error("range download unavailable"));
+    },
+  });
+  const client = {
+    sftp: createFastSftp({
+      createReadStream() {
+        sourceChanged = true;
+        return Readable.from(payload);
+      },
+    }),
+    stat() {
+      return Promise.resolve({
+        size: payload.length,
+        mtimeMs: sourceChanged ? 2 : 1,
+        ctimeMs: sourceChanged ? 2 : 1,
+      });
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["source", client]]) });
+
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId,
+      sourcePath: "/tmp/source.bin",
+      targetPath,
+      sourceType: "sftp",
+      targetType: "local",
+      sourceSftpId: "source",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+
+  assert.equal(sourceChanged, true);
+  assert.match(result.error || "", /source.*changed/i);
+  assert.equal(await fs.promises.readFile(targetPath, "utf8"), "original");
+  assert.equal(fs.existsSync(stagedPath), false);
 });
 
 test("range-failure fallback truncates sparse local tail before streaming", async (t) => {
@@ -1084,8 +1826,8 @@ test("cancelled fast resumable downloads release their isolated channel", async 
   });
   const client = {
     sftp: createFastSftp({
-      createReadStream() {
-        fallbackReads += 1;
+      createReadStream(_remotePath, options) {
+        if (options?.start !== undefined) fallbackReads += 1;
         return Readable.from(payload);
       },
     }),
@@ -1268,6 +2010,61 @@ test("SFTP downloads keep concurrent files moving within the fast-channel budget
   assert.equal((await first).error, undefined);
   assert.equal(maxActiveFastGets, 1);
   assert.equal(openedChannels, 1);
+});
+
+test("idle fast-download channels are discarded when a delayed error arrives", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-idle-error-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.from("downloaded");
+  const channels = [];
+  let endedChannels = 0;
+  const client = {
+    sftp: createFastSftp({}),
+    stat() {
+      return Promise.resolve({ size: payload.length });
+    },
+    client: {
+      sftp(callback) {
+        const channel = createFastSftp({
+          fastGet(_remotePath, localPath, _options, done) {
+            fs.promises.writeFile(localPath, payload).then(() => done(), done);
+          },
+          end() {
+            endedChannels += 1;
+          },
+        });
+        channels.push(channel);
+        callback(null, channel);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["source", client]]) });
+
+  const start = (id) => transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: id,
+      sourcePath: `/tmp/${id}.bin`,
+      targetPath: path.join(tempDir, `${id}.bin`),
+      sourceType: "sftp",
+      targetType: "local",
+      sourceSftpId: "source",
+      totalBytes: payload.length,
+    },
+  );
+
+  assert.equal((await start("idle-error-first")).error, undefined);
+  assert.equal(channels.length, 1);
+  assert.ok(channels[0].listenerCount("error") > 0);
+  channels[0].emit("error", new Error("delayed idle failure"));
+  assert.equal(endedChannels, 1);
+
+  assert.equal((await start("idle-error-second")).error, undefined);
+  assert.equal(channels.length, 2);
+  channels[1].emit("error", new Error("test cleanup"));
 });
 
 test("SFTP downloads cancelled while opening do not block the session", async (t) => {
@@ -1520,6 +2317,95 @@ test("server-to-server upload resume uses its own checkpoint instead of overall 
   assert.equal(result.error, undefined);
   assert.deepEqual(remote, payload);
   assert.equal(promoted, true);
+});
+
+test("server-to-server fallback resets mapped progress to its durable checkpoint", async (t) => {
+  const transferId = `server-copy-fallback-${crypto.randomUUID()}`;
+  const sourcePath = "/source/payload.bin";
+  const targetPath = "/target/payload.bin";
+  const payload = Buffer.alloc(3 * 32 * 1024, 53);
+  const localStage = tempDirBridge.getTransferTempFilePath(transferId, path.basename(sourcePath));
+  await fs.promises.writeFile(localStage, payload);
+  t.after(async () => { await fs.promises.unlink(localStage).catch(() => {}); });
+
+  let secondWriteCallback = null;
+  let remoteBytes = 0;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    write(_handle, _buffer, _offset, length, position, callback) {
+      if (position === 32 * 1024) {
+        secondWriteCallback = callback;
+        return;
+      }
+      remoteBytes = Math.max(remoteBytes, position + length);
+      callback(null);
+      if (position === 2 * 32 * 1024) {
+        queueMicrotask(() => secondWriteCallback(new Error("second range failed")));
+      }
+    },
+  });
+  const targetSftp = createFastSftp({
+    createWriteStream(_remotePath, options) {
+      if (options.flags === "w") remoteBytes = 0;
+      return new Writable({
+        write(chunk, _encoding, callback) {
+          remoteBytes += chunk.length;
+          callback();
+        },
+        final(callback) {
+          queueMicrotask(() => {
+            this.emit("close");
+            callback();
+          });
+        },
+      });
+    },
+  });
+  const sourceClient = {
+    sftp: createFastSftp({}),
+    stat: async () => ({ size: payload.length }),
+  };
+  const targetClient = {
+    sftp: targetSftp,
+    stat: async () => ({ size: remoteBytes }),
+    rename: async () => {},
+    delete: async () => {},
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["source", sourceClient], ["target", targetClient]]) });
+
+  const progress = [];
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId,
+      sourcePath,
+      targetPath,
+      sourceType: "sftp",
+      targetType: "sftp",
+      sourceSftpId: "source",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: true,
+      resumeStage: "upload",
+      downloadCheckpointBytes: payload.length,
+      uploadCheckpointBytes: 0,
+    },
+    (transferred) => progress.push(transferred),
+  );
+
+  assert.equal(result.error, undefined);
+  const uploadStageStart = payload.length / 2;
+  const firstAdvanced = progress.findIndex((transferred) => transferred > uploadStageStart);
+  assert.ok(firstAdvanced >= 0);
+  assert.ok(progress.slice(firstAdvanced + 1).includes(uploadStageStart));
+  assert.equal(remoteBytes, payload.length);
 });
 
 test("upload resume after hard quit clamps checkpoint to durable remote .part size", async (t) => {

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -42,6 +42,8 @@ test("resumable SFTP uploads use conservative per-file request concurrency", asy
   let activeWrites = 0;
   let observedConcurrency = 0;
   let observedChunkSize = 0;
+  const pendingWrites = [];
+  let holdWrites = true;
   const fastSftp = createFastSftp({
     open(_remotePath, flags, callback) {
       assert.equal(flags, "w");
@@ -51,6 +53,13 @@ test("resumable SFTP uploads use conservative per-file request concurrency", asy
       activeWrites += 1;
       observedConcurrency = Math.max(observedConcurrency, activeWrites);
       observedChunkSize = Math.max(observedChunkSize, length);
+      if (holdWrites) {
+        pendingWrites.push(() => {
+          activeWrites -= 1;
+          callback(null);
+        });
+        return;
+      }
       setImmediate(() => {
         activeWrites -= 1;
         callback(null);
@@ -80,7 +89,7 @@ test("resumable SFTP uploads use conservative per-file request concurrency", asy
   transferBridge.init({ sftpClients: new Map([["target", client]]) });
 
   const sender = createSender();
-  const result = await transferBridge.startTransfer(
+  const running = transferBridge.startTransfer(
     { sender },
     {
       transferId: "upload-large",
@@ -93,9 +102,17 @@ test("resumable SFTP uploads use conservative per-file request concurrency", asy
     },
   );
 
-  assert.equal(result.error, undefined);
+  const readyDeadline = Date.now() + 1000;
+  while (pendingWrites.length < 8 && Date.now() < readyDeadline) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(pendingWrites.length, 8);
   assert.equal(observedConcurrency, 8);
   assert.equal(observedChunkSize, 32 * 1024);
+  holdWrites = false;
+  for (const complete of pendingWrites.splice(0)) complete();
+  const result = await running;
+  assert.equal(result.error, undefined);
 });
 
 test("fast resumable uploads pause only after in-flight ranges are durable", async (t) => {
@@ -783,6 +800,86 @@ test("fast resumable downloads fall back from the highest contiguous checkpoint"
 
   assert.equal(result.error, undefined);
   assert.equal(fallbackStart, 0);
+  assert.deepEqual(await fs.promises.readFile(targetPath), payload);
+});
+
+test("range-failure fallback truncates sparse local tail before streaming", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-sparse-tail-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  // Two chunks: finish the second first, then fail the first so contiguous stays 0
+  // while the local file already has a sparse tail past the durable checkpoint.
+  const chunk = 32 * 1024;
+  const payload = Buffer.alloc(2 * chunk, 17);
+  let firstReadCallback = null;
+  let fallbackStart = null;
+  let sizeAtFallback = null;
+  const targetPath = path.join(tempDir, "sparse.bin");
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    read(_handle, buffer, offset, length, position, callback) {
+      if (position === 0) {
+        firstReadCallback = () => callback(new Error("first range failed"));
+        // Complete the later range first, then fail the first.
+        queueMicrotask(() => {
+          // second range is already in flight separately
+        });
+        return;
+      }
+      payload.copy(buffer, offset, position, position + length);
+      callback(null, length, buffer, position);
+      queueMicrotask(() => firstReadCallback?.());
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+  });
+  const client = {
+    sftp: createFastSftp({
+      createReadStream(_remotePath, options) {
+        fallbackStart = options.start;
+        // Capture staged size when stream fallback opens (post-truncate).
+        try {
+          sizeAtFallback = fs.statSync(targetPath).size;
+        } catch {
+          sizeAtFallback = 0;
+        }
+        return Readable.from(payload.subarray(options.start || 0));
+      },
+    }),
+    stat() {
+      return Promise.resolve({ size: payload.length });
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["source", client]]) });
+
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "download-sparse-tail",
+      sourcePath: "/tmp/source.bin",
+      targetPath,
+      sourceType: "sftp",
+      targetType: "local",
+      sourceSftpId: "source",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+
+  assert.equal(result.error, undefined, result.error);
+  assert.equal(fallbackStart, 0);
+  // Contiguous checkpoint never advanced past 0; sparse tail must be truncated.
+  assert.equal(sizeAtFallback, 0);
   assert.deepEqual(await fs.promises.readFile(targetPath), payload);
 });
 

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -259,10 +259,10 @@ test("failed local open for resumable upload still ends the isolated channel", a
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   });
 
-  // A directory path makes fs.promises.open(..., "r") reject after the isolated
-  // channel is already open (totalBytes skips the preflight file stat).
-  const localPath = path.join(tempDir, "not-a-file");
-  await fs.promises.mkdir(localPath);
+  // Create the source so preflight can proceed, then delete it as soon as the
+  // isolated channel opens so uploadFileResumableFast fails on local open.
+  const localPath = path.join(tempDir, "source.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(32 * 1024, 7));
   let endedChannels = 0;
   let remoteOpenAttempts = 0;
   const fastSftp = createFastSftp({
@@ -275,11 +275,22 @@ test("failed local open for resumable upload still ends the isolated channel", a
     },
   });
   const client = {
-    // No stream fallback path needed: assert cleanup before rethrow is enough.
-    sftp: createFastSftp({}),
+    sftp: createFastSftp({
+      createWriteStream() {
+        // Stream fallback after range-path failure — keep it error-safe.
+        const writeStream = new Writable({
+          write(_chunk, _encoding, callback) {
+            callback(new Error("stream fallback after missing local open"));
+          },
+        });
+        return writeStream;
+      },
+    }),
     client: {
       sftp(callback) {
-        callback(null, fastSftp);
+        fs.promises.unlink(localPath).finally(() => {
+          callback(null, fastSftp);
+        });
       },
     },
   };
@@ -300,9 +311,9 @@ test("failed local open for resumable upload still ends the isolated channel", a
     },
   );
 
-  // Range path fails on local open; stream fallback may surface a different error.
-  assert.ok(result.error, "expected transfer to fail when local source cannot be opened");
-  assert.equal(endedChannels, 1);
+  assert.ok(result.error, "expected transfer to fail when local source disappears");
+  // Critical: isolated channel must not leak when local open fails first.
+  assert.ok(endedChannels >= 1, `expected isolated channel end, got ${endedChannels}`);
   assert.equal(remoteOpenAttempts, 0);
 });
 

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -816,7 +816,10 @@ test("range-failure fallback truncates sparse local tail before streaming", asyn
   let firstReadCallback = null;
   let fallbackStart = null;
   let sizeAtFallback = null;
+  const transferId = "download-sparse-tail";
   const targetPath = path.join(tempDir, "sparse.bin");
+  // Resumable downloads stage under the transfer temp path, not the final target.
+  const stagedPath = tempDirBridge.getTransferTempFilePath(transferId, path.basename(targetPath));
   const fastSftp = createFastSftp({
     open(_remotePath, _flags, callback) {
       callback(null, Buffer.from("remote-handle"));
@@ -842,11 +845,11 @@ test("range-failure fallback truncates sparse local tail before streaming", asyn
     sftp: createFastSftp({
       createReadStream(_remotePath, options) {
         fallbackStart = options.start;
-        // Capture staged size when stream fallback opens (post-truncate).
+        // Capture *staged* size when stream fallback opens (post-truncate).
         try {
-          sizeAtFallback = fs.statSync(targetPath).size;
+          sizeAtFallback = fs.statSync(stagedPath).size;
         } catch {
-          sizeAtFallback = 0;
+          sizeAtFallback = -1;
         }
         return Readable.from(payload.subarray(options.start || 0));
       },
@@ -865,7 +868,7 @@ test("range-failure fallback truncates sparse local tail before streaming", asyn
   const result = await transferBridge.startTransfer(
     { sender: createSender() },
     {
-      transferId: "download-sparse-tail",
+      transferId,
       sourcePath: "/tmp/source.bin",
       targetPath,
       sourceType: "sftp",
@@ -878,9 +881,108 @@ test("range-failure fallback truncates sparse local tail before streaming", asyn
 
   assert.equal(result.error, undefined, result.error);
   assert.equal(fallbackStart, 0);
-  // Contiguous checkpoint never advanced past 0; sparse tail must be truncated.
+  // Contiguous checkpoint never advanced past 0; sparse tail must be truncated
+  // on the staged .part (final target is only written at promote time).
   assert.equal(sizeAtFallback, 0);
   assert.deepEqual(await fs.promises.readFile(targetPath), payload);
+});
+
+test("S2S upload-phase fallback does not truncate the complete local temp source", async (t) => {
+  const transferId = `s2s-no-truncate-${crypto.randomUUID()}`;
+  const payload = Buffer.alloc(64 * 1024, 23);
+  const localStage = tempDirBridge.getTransferTempFilePath(transferId, "payload.bin");
+  await fs.promises.writeFile(localStage, payload);
+  t.after(async () => {
+    await fs.promises.unlink(localStage).catch(() => {});
+  });
+
+  let sizeAtFallback = null;
+  let fallbackStart = null;
+  let remote = Buffer.alloc(0);
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    write(_handle, _buffer, _offset, _length, position, callback) {
+      if (position === 0) {
+        callback(new Error("first upload range failed"));
+        return;
+      }
+      callback(null);
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+  });
+  const sourceClient = {
+    sftp: createFastSftp({}),
+    stat: async () => ({ size: payload.length }),
+  };
+  const targetClient = {
+    sftp: createFastSftp({
+      createWriteStream(_path, options = {}) {
+        fallbackStart = options.start || 0;
+        try {
+          sizeAtFallback = fs.statSync(localStage).size;
+        } catch {
+          sizeAtFallback = -1;
+        }
+        let offset = options.start || 0;
+        return new Writable({
+          write(chunk, _encoding, callback) {
+            if (remote.length < offset) {
+              remote = Buffer.concat([remote, Buffer.alloc(offset - remote.length)]);
+            }
+            remote = Buffer.concat([
+              remote.subarray(0, offset),
+              Buffer.from(chunk),
+              remote.subarray(offset + chunk.length),
+            ]);
+            offset += chunk.length;
+            callback();
+          },
+        });
+      },
+    }),
+    stat: async () => ({ size: remote.length }),
+    rename: async () => {},
+    delete: async () => {},
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({
+    sftpClients: new Map([
+      ["source", sourceClient],
+      ["target", targetClient],
+    ]),
+  });
+
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId,
+      sourcePath: "/source/payload.bin",
+      targetPath: "/target/payload.bin",
+      sourceType: "sftp",
+      targetType: "sftp",
+      sourceSftpId: "source",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: true,
+      resumeStage: "upload",
+      downloadCheckpointBytes: payload.length,
+      uploadCheckpointBytes: 0,
+      checkpointBytes: 0,
+    },
+  );
+
+  // Capture happens when stream fallback opens — local temp must still be full.
+  assert.equal(sizeAtFallback, payload.length);
+  assert.equal(fallbackStart, 0);
+  assert.equal(result.error, undefined, result.error);
 });
 
 test("cancelled fast resumable downloads release their isolated channel", async (t) => {

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -253,6 +253,59 @@ test("failed resumable upload opens close their isolated channel", async (t) => 
   assert.equal(endedChannels, 1);
 });
 
+test("failed local open for resumable upload still ends the isolated channel", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-local-open-fail-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  // A directory path makes fs.promises.open(..., "r") reject after the isolated
+  // channel is already open (totalBytes skips the preflight file stat).
+  const localPath = path.join(tempDir, "not-a-file");
+  await fs.promises.mkdir(localPath);
+  let endedChannels = 0;
+  let remoteOpenAttempts = 0;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      remoteOpenAttempts += 1;
+      callback(null, Buffer.from("remote-handle"));
+    },
+    end() {
+      endedChannels += 1;
+    },
+  });
+  const client = {
+    // No stream fallback path needed: assert cleanup before rethrow is enough.
+    sftp: createFastSftp({}),
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-local-open-fail",
+      sourcePath: localPath,
+      targetPath: "/tmp/upload.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: 32 * 1024,
+      resumable: true,
+      skipAdmission: true,
+    },
+  );
+
+  // Range path fails on local open; stream fallback may surface a different error.
+  assert.ok(result.error, "expected transfer to fail when local source cannot be opened");
+  assert.equal(endedChannels, 1);
+  assert.equal(remoteOpenAttempts, 0);
+});
+
 test("resumable SFTP uploads fall back to a compatible stream after fast path fails", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-fallback-"));
   t.after(async () => {


### PR DESCRIPTION
## What changed

- restore parallel SFTP reads and writes for the default resumable transfer path
- keep pause checkpoints safe by waiting for all in-flight ranges before reporting a pause
- add regression coverage for upload/download concurrency and pause/resume integrity

## Why

Netcatty 1.1.71 made normal SFTP transfers resumable by default, but the resumable path bypassed the parallel transfer implementation. On high-latency connections this reduced a single file transfer to sequential 32 KB requests, matching the throughput regression reported in #2424.

## Impact

Default SFTP uploads and downloads regain their previous request window while retaining pause and resume support. Compatibility stream fallbacks remain available when a dedicated SFTP channel cannot be opened.

## Validation

- `node --test electron/bridges/transferBridge.test.cjs electron/bridges/transferLimits.test.cjs`
- `node --test --import tsx application/state/sftp/downloadTransferTask.test.ts application/state/sftp/dedicatedTransferResume.test.ts`
- `npm run lint -- --no-cache`
- `npm run build`
- full `npm test`: 6996 passed, 7 skipped, 1 unrelated existing SSH auth retry failure

Fixes #2424
