### PR TITLE
fix(ai): handle terminal output without trailing newline

### DIFF
--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -24,6 +24,13 @@ const {
   stripAnsi,
 } = require("./ptyExecHelpers.cjs");
 
+function stripJobMarkerLines(text, marker) {
+  return text.replace(
+    new RegExp(`^([^\r\n]*?)${marker}[^\r\n]*[\r\n]*`, "gm"),
+    "$1",
+  );
+}
+
 function startPtyJob(ptyStream, command, options) {
   const {
     stripMarkers = false,
@@ -217,7 +224,7 @@ function startPtyJob(ptyStream, command, options) {
   }
 
   function checkEnd() {
-    const found = findEndMarker(output, marker);
+    const found = findEndMarker(output, marker, { allowInline: true });
     if (!found) return;
     const stdout = output.slice(0, found.endIdx);
     finish(stdout, found.exitCode);
@@ -268,7 +275,7 @@ function startPtyJob(ptyStream, command, options) {
       // Strip only this job's specific marker lines so user output that
       // happens to contain "__NCMCP_" (e.g. printf '__NCMCP_demo\n') is
       // preserved.
-      cleanVisible = cleanVisible.replace(new RegExp(`^[^\r\n]*${marker}[^\r\n]*[\r\n]*`, "gm"), "");
+      cleanVisible = stripJobMarkerLines(cleanVisible, marker);
       if (!cleanVisible) return;
     }
     visibleHighWatermark += cleanVisible.length;
@@ -311,7 +318,7 @@ function startPtyJob(ptyStream, command, options) {
 
     // Flush any incomplete marker carry — if it wasn't this job's marker, append it.
     if (visibleMarkerCarry) {
-      const leftover = visibleMarkerCarry.replace(new RegExp(`^[^\r\n]*${marker}[^\r\n]*[\r\n]*`, "gm"), "");
+      const leftover = stripJobMarkerLines(visibleMarkerCarry, marker);
       visibleMarkerCarry = "";
       if (leftover) {
         const next = appendBoundedOutput(visibleOutput, leftover, maxBufferedChars);

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -1,17 +1,54 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { spawnSync } = require("node:child_process");
+const { EventEmitter } = require("node:events");
 const { mkdtempSync, rmSync, realpathSync } = require("node:fs");
 const { tmpdir } = require("node:os");
 const { join } = require("node:path");
 
 const {
+  execViaPty,
+  startPtyJob,
   resolveEffectiveShellKind,
   execViaChannel,
 } = require("./ptyExec.cjs");
 const {
   buildWrappedCommand,
 } = require("./ptyExecHelpers.cjs");
+
+class ShellBackedPty extends EventEmitter {
+  write(data) {
+    if (data === "\x03") return;
+    const result = spawnSync("sh", ["-c", String(data)], { encoding: "utf8" });
+    queueMicrotask(() => {
+      this.emit("data", Buffer.from(result.stdout));
+    });
+  }
+}
+
+test("execViaPty completes when command output has no trailing newline", async () => {
+  const result = await execViaPty(new ShellBackedPty(), "printf 'abc'", {
+    shellKind: "posix",
+    timeoutMs: 1000,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.stdout, "abc");
+  assert.equal(result.exitCode, 0);
+});
+
+test("background PTY jobs preserve output that has no trailing newline", async () => {
+  const job = startPtyJob(new ShellBackedPty(), "printf 'abc'", {
+    shellKind: "posix",
+    timeoutMs: 1000,
+    maxBufferedChars: 1024,
+  });
+  const result = await job.resultPromise;
+
+  assert.equal(result.ok, true);
+  assert.equal(result.stdout, "abc");
+  assert.equal(result.exitCode, 0);
+});
 
 test("uses PowerShell wrapping when a session with no confirmed shell sees a PowerShell prompt", () => {
   // SSH sessions don't set shellKind (sshBridge never assigns one), which

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -230,15 +230,18 @@ function buildWrappedCommand(command, shellKind, marker) {
   }
 }
 
-function findEndMarker(outputText, marker) {
+function findEndMarker(outputText, marker, { allowInline = false } = {}) {
   const endPattern = marker + "_E:";
   let searchFrom = 0;
   while (searchFrom < outputText.length) {
     const endIdx = outputText.indexOf(endPattern, searchFrom);
     if (endIdx === -1) return null;
 
-    // Accept if at start of output, or preceded by \n or \r (line boundary)
-    if (endIdx === 0 || outputText[endIdx - 1] === "\n" || outputText[endIdx - 1] === "\r") {
+    // Before the start marker is confirmed, require a line boundary so the
+    // echoed wrapper command cannot be mistaken for real completion. Once the
+    // command has started, the random marker can safely follow output that did
+    // not end with a newline.
+    if (allowInline || endIdx === 0 || outputText[endIdx - 1] === "\n" || outputText[endIdx - 1] === "\r") {
       const afterEnd = outputText.slice(endIdx + endPattern.length);
       const codeMatch = afterEnd.match(/^(\d+)/);
       const exitCode = codeMatch ? parseInt(codeMatch[1], 10) : null;


### PR DESCRIPTION
## Summary

- recognize command completion when terminal output does not end with a newline
- preserve the final output bytes for both foreground execution and background jobs
- add regression coverage using a real POSIX shell wrapper

## Root cause

The completion marker could immediately follow the command's last output byte. Marker detection required a line boundary, so commands such as `curl ... | head -c 200` completed in the terminal but the tool kept waiting until timeout.

## Validation

- `node --test electron/bridges/ai/ptyExec.test.cjs`
- related terminal execution tests: 62 passed
- exact issue command returned 200 characters with exit code 0 in under one second
- `npm run lint -- --no-cache`
- `npm run build`
- full `npm test`: 7000 passed, 7 skipped, 1 unrelated SSH authentication retry test failed and reproduced in isolation outside the changed path

Fixes #2431
