### PR TITLE
fix(#2436): [Bug] 终端闪现-Terminal Flash / Screen Flicker

### DIFF
--- a/components/terminal/runtime/webglContextLossRecovery.test.ts
+++ b/components/terminal/runtime/webglContextLossRecovery.test.ts
@@ -111,6 +111,50 @@ test("burst losses trip a persistent breaker that ensure and suspend cannot rear
   assert.equal(harness.loadedStates.at(-1), false);
 });
 
+// Periodic GPU context loss (~every 15s on some Linux drivers) must still trip the
+// breaker. A short recovery window ages each prior loss out, so WebGL keeps
+// dispose→rebuild cycling and the terminal flashes forever (#2436).
+test("periodic losses spaced ~15s apart trip the breaker instead of flashing forever", () => {
+  const harness = createHarness();
+  harness.controller.ensure();
+
+  for (let loss = 0; loss < 3; loss += 1) {
+    harness.setTime(loss * 15_000);
+    harness.addons[loss].loseContext();
+    if (loss < 2) harness.runNextTimer();
+  }
+
+  assert.equal(harness.pendingTimers, 0);
+  assert.ok(harness.warnings.some((warning) => warning.includes("staying on DOM renderer")));
+  assert.equal(harness.loadCalls, 3);
+  assert.equal(harness.controller.getAddon(), null);
+  assert.equal(harness.loadedStates.at(-1), false);
+
+  harness.controller.ensure();
+  assert.equal(harness.loadCalls, 3);
+});
+
+test("a quiet gap longer than the recovery window allows a fresh recovery", () => {
+  const harness = createHarness();
+  harness.controller.ensure();
+
+  harness.setTime(0);
+  harness.addons[0].loseContext();
+  harness.runNextTimer();
+  harness.setTime(15_000);
+  harness.addons[1].loseContext();
+  harness.runNextTimer();
+
+  // After the recovery window elapses with no further losses, a later single
+  // loss should recover once rather than staying broken forever.
+  harness.setTime(15_000 + 60_001);
+  harness.addons[2].loseContext();
+  assert.equal(harness.pendingTimers, 1);
+  harness.runNextTimer();
+  assert.equal(harness.loadCalls, 4);
+  assert.equal(harness.loadedStates.at(-1), true);
+});
+
 test("suspend and dispose cancel pending recovery callbacks", () => {
   for (const action of ["suspend", "dispose"] as const) {
     const harness = createHarness();

--- a/components/terminal/runtime/webglContextLossRecovery.test.ts
+++ b/components/terminal/runtime/webglContextLossRecovery.test.ts
@@ -113,7 +113,7 @@ test("burst losses trip a persistent breaker that ensure and suspend cannot rear
 
 // Periodic GPU context loss (~every 15s on some Linux drivers) must still trip the
 // breaker. A short recovery window ages each prior loss out, so WebGL keeps
-// dispose→rebuild cycling and the terminal flashes forever (#2436).
+// dispose -> rebuild cycling and the terminal flashes forever (#2436).
 test("periodic losses spaced ~15s apart trip the breaker instead of flashing forever", () => {
   const harness = createHarness();
   harness.controller.ensure();

--- a/components/terminal/runtime/webglRendererController.ts
+++ b/components/terminal/runtime/webglRendererController.ts
@@ -35,7 +35,7 @@ export function createWebglRendererController<TAddon extends WebglRendererAddon>
   const recoveryDelayMs = options.recoveryDelayMs ?? 50;
   // Keep a wide enough window that periodic GPU context loss (commonly ~15s on
   // some Linux drivers/compositors) still accumulates and trips the breaker.
-  // A 10s window aged those losses out, so WebGL kept dispose→rebuild flashing.
+  // A 10s window aged those losses out, so WebGL kept dispose -> rebuild flashing.
   const recoveryWindowMs = options.recoveryWindowMs ?? 60_000;
   const maxRecoveriesPerWindow = options.maxRecoveriesPerWindow ?? 2;
   const contextLosses: number[] = [];

--- a/components/terminal/runtime/webglRendererController.ts
+++ b/components/terminal/runtime/webglRendererController.ts
@@ -33,7 +33,10 @@ export function createWebglRendererController<TAddon extends WebglRendererAddon>
   const setTimer = options.setTimer ?? setTimeout;
   const clearTimer = options.clearTimer ?? clearTimeout;
   const recoveryDelayMs = options.recoveryDelayMs ?? 50;
-  const recoveryWindowMs = options.recoveryWindowMs ?? 10_000;
+  // Keep a wide enough window that periodic GPU context loss (commonly ~15s on
+  // some Linux drivers/compositors) still accumulates and trips the breaker.
+  // A 10s window aged those losses out, so WebGL kept dispose→rebuild flashing.
+  const recoveryWindowMs = options.recoveryWindowMs ?? 60_000;
   const maxRecoveriesPerWindow = options.maxRecoveriesPerWindow ?? 2;
   const contextLosses: number[] = [];
   let addon: TAddon | null = null;


### PR DESCRIPTION
<!-- cursor-bot-pr -->
<!-- cursor-automation -->

## Summary
Automated Cursor implement for terminal WebGL flash (#2436).

Widens WebGL context-loss recovery so ~15s periodic GPU losses trip the DOM circuit breaker instead of flashing forever; adds regression tests.

Fixes #2436

## Automation
- Implemented by Cursor CLI on branch `cursor/issue-2436-30071061802`
- Opened manually because Actions GITHUB_TOKEN is still blocked from `pulls.create` (repo setting / TRIAGE PAT). Implement job classified + coded successfully.
- Review gate: `@codex review`