### PR TITLE
fix(sftp): raise upload WRITE fanout for higher throughput

### DIFF
--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -1065,9 +1065,25 @@ async function uploadLocalToSftp(_event, payload) {
   const encodedStagedPath = encodePath(stagedRemotePath, encoding);
   const encodedBackupPath = encodePath(backupRemotePath, encoding);
   throwIfAborted(payload.abortSignal);
-  const content = fs.createReadStream(payload.localPath);
+  const {
+    TRANSFER_CHUNK_SIZE,
+    UPLOAD_TRANSFER_CONCURRENCY,
+  } = require("./transferLimits.cjs");
   try {
-    await client.put(content, encodedStagedPath, { signal: payload.abortSignal });
+    // Prefer pipelined WRITEs (ssh2 fastPut). createReadStream→put is serial and
+    // RTT-bound (~1×32KB in flight) — the usual cause of sub-MB/s uploads (#2449).
+    if (typeof client.fastPut === "function") {
+      await client.fastPut(payload.localPath, encodedStagedPath, {
+        chunkSize: TRANSFER_CHUNK_SIZE,
+        concurrency: UPLOAD_TRANSFER_CONCURRENCY,
+        signal: payload.abortSignal,
+      });
+    } else {
+      const content = fs.createReadStream(payload.localPath, {
+        highWaterMark: TRANSFER_CHUNK_SIZE,
+      });
+      await client.put(content, encodedStagedPath, { signal: payload.abortSignal });
+    }
     throwIfAborted(payload.abortSignal);
     await renameRemotePath(client, encodedStagedPath, encodedPath, encodedBackupPath);
   } catch (err) {

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -1100,7 +1100,9 @@ function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelC
         scheduleForceFinish(createAbortError(signal, "Upload cancelled"));
         return;
       }
-      // Shared channel: wait for fastPut callback only.
+      // Shared browse/sudo channel: do not sftp.end() (would kill the session).
+      // Still bound cancellation so a stalled fastPut cannot hang forever.
+      scheduleForceFinish(createAbortError(signal, "Upload cancelled"));
     };
     try { sftp.on?.("error", onChannelError); } catch { /* ignore */ }
     if (typeof onChannel === "function") {

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -684,14 +684,6 @@ async function planRemoteUploadReplace(client, encodedPath) {
   return { writeInPlace: false, existingMode: null };
 }
 
-function isNetcattyStagedRemotePath(remotePath) {
-  const asString = Buffer.isBuffer(remotePath)
-    ? remotePath.toString("utf8")
-    : String(remotePath || "");
-  // Only our randomized stage names — never the caller's final destination.
-  return /(^|\/|\\)\.netcatty-upload-[^/\\]+\.part$/.test(asString);
-}
-
 async function restoreRemoteMode(client, encodedPath, mode) {
   if (mode == null || !Number.isFinite(mode)) return;
   try {
@@ -760,7 +752,10 @@ async function pipelinedUploadWithOptionalStaging(client, localPath, remotePath,
   const encodedStagedPath = encodePath(stagedLogical, encoding);
   const encodedBackupPath = encodePath(backupLogical, encoding);
   try {
-    await pipelinedUploadLocalFile(client, localPath, encodedStagedPath, fastPutOptions);
+    await pipelinedUploadLocalFile(client, localPath, encodedStagedPath, {
+      ...fastPutOptions,
+      generatedStagePath: true,
+    });
     throwIfAborted(signal);
     if (Number.isFinite(expectedSize) && expectedSize >= 0 && typeof client.stat === "function") {
       const stagedStat = await client.stat(encodedStagedPath);
@@ -1271,7 +1266,7 @@ async function acquireUploadSftpChannel(client, options = {}) {
  * Disposable channels are ended on abort; shared channels only mark cancelled.
  */
 function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelControl = {}) {
-  const { dispose = false, signal = null } = channelControl;
+  const { dispose = false, signal = null, generatedStagePath = false } = channelControl;
   throwIfAborted(signal);
   if (typeof sftp?.fastPut !== "function") {
     throw new Error(
@@ -1293,13 +1288,12 @@ function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelC
     const scheduleForceFinish = (err) => {
       clearForceFinish();
       forceFinishTimer = setTimeout(() => {
-        // Shared channel: best-effort unlink only Netcatty staged .part paths so a
-        // late fastPut cannot keep growing a temp after cancel reports.
-        // Never unlink the caller's final destination (in-place / symlink writes).
+        // Shared channel: best-effort unlink only paths explicitly created by
+        // our staging planner. A caller's final name may resemble a stage path.
         if (
           !dispose
           && (abortRequested || signal?.aborted || pendingError)
-          && isNetcattyStagedRemotePath(remotePath)
+          && generatedStagePath
         ) {
           try { sftp.unlink?.(remotePath, () => {}); } catch { /* ignore */ }
         }
@@ -1373,9 +1367,16 @@ function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelC
 
 async function runAbortableFastPut(client, localPath, remotePath, options = {}) {
   const signal = options?.signal || null;
+  const generatedStagePath = options?.generatedStagePath === true;
+  const fastPutOptions = { ...options };
+  delete fastPutOptions.generatedStagePath;
   throwIfAborted(signal);
   const { sftp, dispose } = await acquireUploadSftpChannel(client, { signal });
-  return runFastPutOnChannel(sftp, localPath, remotePath, options, { dispose, signal });
+  return runFastPutOnChannel(sftp, localPath, remotePath, fastPutOptions, {
+    dispose,
+    signal,
+    generatedStagePath,
+  });
 }
 
 /**
@@ -1392,7 +1393,9 @@ async function pipelinedUploadLocalFile(client, localPath, remotePath, options =
     return runAbortableFastPut(client, localPath, remotePath, options);
   }
   // ssh2-sftp-client without abort: native fastPut on the shared connection.
-  return client.fastPut(localPath, remotePath, options);
+  const fastPutOptions = { ...options };
+  delete fastPutOptions.generatedStagePath;
+  return client.fastPut(localPath, remotePath, fastPutOptions);
 }
 
 async function uploadLocalToSftp(_event, payload) {

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -1070,20 +1070,18 @@ async function uploadLocalToSftp(_event, payload) {
     UPLOAD_TRANSFER_CONCURRENCY,
   } = require("./transferLimits.cjs");
   try {
-    // Prefer pipelined WRITEs (ssh2 fastPut). createReadStream→put is serial and
-    // RTT-bound (~1×32KB in flight) — the usual cause of sub-MB/s uploads (#2449).
-    if (typeof client.fastPut === "function") {
-      await client.fastPut(payload.localPath, encodedStagedPath, {
-        chunkSize: TRANSFER_CHUNK_SIZE,
-        concurrency: UPLOAD_TRANSFER_CONCURRENCY,
-        signal: payload.abortSignal,
-      });
-    } else {
-      const content = fs.createReadStream(payload.localPath, {
-        highWaterMark: TRANSFER_CHUNK_SIZE,
-      });
-      await client.put(content, encodedStagedPath, { signal: payload.abortSignal });
+    // Pipelined WRITEs only (ssh2 fastPut). Serial createReadStream→put is
+    // RTT-bound and is never used as a silent fallback (#2449 / industry practice).
+    if (typeof client.fastPut !== "function") {
+      throw new Error(
+        "SFTP pipelined upload (fastPut) is not available on this session",
+      );
     }
+    await client.fastPut(payload.localPath, encodedStagedPath, {
+      chunkSize: TRANSFER_CHUNK_SIZE,
+      concurrency: UPLOAD_TRANSFER_CONCURRENCY,
+      signal: payload.abortSignal,
+    });
     throwIfAborted(payload.abortSignal);
     await renameRemotePath(client, encodedStagedPath, encodedPath, encodedBackupPath);
   } catch (err) {

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -1044,6 +1044,7 @@ function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelC
   return new Promise((resolve, reject) => {
     let settled = false;
     let abortRequested = false;
+    let pendingError = null;
     let forceFinishTimer = null;
     const clearForceFinish = () => {
       if (forceFinishTimer) {
@@ -1051,8 +1052,11 @@ function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelC
         forceFinishTimer = null;
       }
     };
-    const onChannelError = (err) => {
-      finish(err || new Error("SFTP channel error"));
+    const scheduleForceFinish = (err) => {
+      clearForceFinish();
+      forceFinishTimer = setTimeout(() => {
+        finish(err || new Error("SFTP channel closed"));
+      }, 2000);
     };
     const finish = (err) => {
       if (settled) return;
@@ -1068,20 +1072,23 @@ function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelC
       if (err) reject(err);
       else resolve();
     };
+    // Channel errors must not finish immediately: wait for fastPut callback (or
+    // force timeout) so local temp files are not unlinked while still open.
+    const onChannelError = (err) => {
+      pendingError = err || new Error("SFTP channel error");
+      if (dispose) {
+        try { sftp.end?.(); } catch { /* ignore */ }
+        scheduleForceFinish(pendingError);
+      }
+    };
     const onAbort = () => {
       abortRequested = true;
       if (dispose) {
-        // Tear down disposable channel; wait for fastPut cb to release local fd.
         try { sftp.end?.(); } catch { /* ignore */ }
-        // If the callback never fires, force-finish so callers are not stuck.
-        clearForceFinish();
-        forceFinishTimer = setTimeout(() => {
-          finish(createAbortError(signal, "Upload cancelled"));
-        }, 2000);
+        scheduleForceFinish(createAbortError(signal, "Upload cancelled"));
         return;
       }
-      // Shared channel: cannot end without killing browse/sudo SFTP. Wait for
-      // fastPut's callback so temp-file cleanup does not race in-flight WRITEs.
+      // Shared channel: wait for fastPut callback only.
     };
     try { sftp.on?.("error", onChannelError); } catch { /* ignore */ }
     if (typeof onChannel === "function") {
@@ -1089,7 +1096,6 @@ function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelC
     }
     if (signal) {
       if (signal.aborted) {
-        // Do not start the transfer when already aborted.
         finish(createAbortError(signal, "Upload cancelled"));
         return;
       }
@@ -1099,6 +1105,10 @@ function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelC
       sftp.fastPut(localPath, remotePath, fastPutOptions, (err) => {
         if (abortRequested || signal?.aborted) {
           finish(createAbortError(signal, "Upload cancelled"));
+          return;
+        }
+        if (pendingError) {
+          finish(pendingError);
           return;
         }
         finish(err || null);

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -602,7 +602,8 @@ function isRemoteMissingError(err) {
   return code === 2
     || code === "ENOENT"
     || code === "NO_SUCH_FILE"
-    || code === "SSH_FX_NO_SUCH_FILE";
+    || code === "SSH_FX_NO_SUCH_FILE"
+    || String(err?.message || "").trim() === "ENOENT";
 }
 
 function attrsIndicateSymlink(attrs) {
@@ -679,13 +680,15 @@ async function planRemoteUploadReplace(client, encodedPath) {
       // Confirmed missing destination — stage a new file.
     }
   } catch {
-    // Channel probe failure — default to staging for cancel-safe new uploads.
+    // Unknown target state: preserve a possible symlink instead of replacing it.
+    return { writeInPlace: true, existingMode: null };
   }
   return { writeInPlace: false, existingMode: null };
 }
 
-async function restoreRemoteMode(client, encodedPath, mode) {
+async function restoreRemoteMode(client, encodedPath, mode, options = {}) {
   if (mode == null || !Number.isFinite(mode)) return;
+  const bestEffort = options?.bestEffort !== false;
   try {
     if (typeof client.chmod === "function") {
       await client.chmod(encodedPath, mode);
@@ -701,11 +704,27 @@ async function restoreRemoteMode(client, encodedPath, mode) {
         sftp.setstat(encodedPath, { mode }, (err) => (err ? reject(err) : resolve()));
         return;
       }
-      resolve();
+      reject(new Error("Remote server does not support restoring file mode"));
     });
-  } catch {
-    // Best-effort only — do not fail a successful upload over metadata restore.
+  } catch (err) {
+    if (!bestEffort) throw err;
   }
+}
+
+function createRemoteRecoveryError(promotionError, restoreError, paths = {}) {
+  const recoveryLocations = [
+    paths.backupPath ? `backup=${String(paths.backupPath)}` : null,
+    paths.stagePath ? `staged=${String(paths.stagePath)}` : null,
+  ].filter(Boolean).join(", ");
+  const error = new Error(
+    `Remote upload promotion failed and the original destination could not be restored (${recoveryLocations}): ${restoreError?.message || String(restoreError)}`,
+    { cause: promotionError },
+  );
+  error.preserveStagedUpload = true;
+  error.remoteStagePath = paths.stagePath || null;
+  error.remoteBackupPath = paths.backupPath || null;
+  error.remoteFinalPath = paths.finalPath || null;
+  return error;
 }
 
 /**
@@ -768,16 +787,22 @@ async function pipelinedUploadWithOptionalStaging(client, localPath, remotePath,
     }
     // Cancel may arrive during the awaited size verify; recheck before promote.
     throwIfAborted(signal);
+    // Apply the old mode to the stage before promotion. A failed chmod must not
+    // replace an executable final with a non-executable file and report success.
+    await restoreRemoteMode(client, encodedStagedPath, plan.existingMode, {
+      bestEffort: false,
+    });
     await renameRemotePath(client, encodedStagedPath, encodedPath, encodedBackupPath);
-    await restoreRemoteMode(client, encodedPath, plan.existingMode);
     return { staged: true };
   } catch (err) {
-    try {
-      if (typeof client.delete === "function") {
-        await client.delete(encodedStagedPath);
+    if (!err?.preserveStagedUpload) {
+      try {
+        if (typeof client.delete === "function") {
+          await client.delete(encodedStagedPath);
+        }
+      } catch {
+        // Best-effort cleanup of a partial stage.
       }
-    } catch {
-      // Best-effort cleanup of a partial stage.
     }
     // Parent dir not writable but existing file may still be: fall back to in-place.
     if (isRemotePermissionError(err)) {
@@ -832,8 +857,12 @@ async function renameRemotePath(client, fromPath, toPath, backupPath = null) {
       if (movedExistingTarget) {
         try {
           await client.rename(backupPath, toPath);
-        } catch {
-          // Ignore restore failures and surface the original fallback error.
+        } catch (restoreErr) {
+          throw createRemoteRecoveryError(fallbackErr, restoreErr, {
+            stagePath: fromPath,
+            backupPath,
+            finalPath: toPath,
+          });
         }
       }
       throw fallbackErr;
@@ -1416,21 +1445,20 @@ async function uploadLocalToSftp(_event, payload) {
 
     // Symlinks must be written in-place so scp follows the link target. Staging
     // + rename would replace the link node itself (Codex PR review).
-    let existingIsSymlink = false;
+    let existing = null;
     try {
-      const existing = await backend.stat(payload.remotePath, { encoding });
-      if (existing?.isDirectory) {
-        throw new Error(`Remote path is a directory: ${payload.remotePath}`);
-      }
-      existingIsSymlink = !!(
-        existing?.isSymbolicLink
-        || existing?.isSymlink
-        || existing?.type === "symlink"
-      );
+      existing = await backend.stat(payload.remotePath, { encoding });
     } catch (statErr) {
-      if (/directory/i.test(statErr?.message || "")) throw statErr;
-      // ENOENT / missing is fine — fall through to staged create.
+      if (!isRemoteMissingError(statErr)) throw statErr;
     }
+    if (existing?.isDirectory) {
+      throw new Error(`Remote path is a directory: ${payload.remotePath}`);
+    }
+    const existingIsSymlink = !!(
+      existing?.isSymbolicLink
+      || existing?.isSymlink
+      || existing?.type === "symlink"
+    );
 
     if (existingIsSymlink) {
       try {
@@ -1468,21 +1496,42 @@ async function uploadLocalToSftp(_event, payload) {
       // otherwise end up recursively deleting the whole tree via backup cleanup.
       let movedExisting = false;
       try {
-        const existing = await backend.stat(payload.remotePath, { encoding });
-        if (existing?.isDirectory) {
+        let latestExisting = null;
+        try {
+          latestExisting = await backend.stat(payload.remotePath, { encoding });
+        } catch (statErr) {
+          if (!isRemoteMissingError(statErr)) throw statErr;
+        }
+        if (latestExisting?.isDirectory) {
           throw new Error(`Remote path is a directory: ${payload.remotePath}`);
         }
-        await backend.rename(payload.remotePath, backupRemotePath, { encoding });
-        movedExisting = true;
+        if (
+          latestExisting?.isSymbolicLink
+          || latestExisting?.isSymlink
+          || latestExisting?.type === "symlink"
+        ) {
+          throw new Error(`Remote destination changed to a symlink during upload: ${payload.remotePath}`);
+        }
+        if (latestExisting) {
+          await backend.rename(payload.remotePath, backupRemotePath, { encoding });
+          movedExisting = true;
+        }
       } catch (statOrRenameErr) {
-        if (/directory/i.test(statOrRenameErr?.message || "")) throw statOrRenameErr;
-        // Destination may not exist yet (ENOENT) — continue with staged promote.
+        throw statOrRenameErr;
       }
       try {
         await backend.rename(stagedRemotePath, payload.remotePath, { encoding });
       } catch (renameErr) {
         if (movedExisting) {
-          try { await backend.rename(backupRemotePath, payload.remotePath, { encoding }); } catch { /* ignore */ }
+          try {
+            await backend.rename(backupRemotePath, payload.remotePath, { encoding });
+          } catch (restoreErr) {
+            throw createRemoteRecoveryError(renameErr, restoreErr, {
+              stagePath: stagedRemotePath,
+              backupPath: backupRemotePath,
+              finalPath: payload.remotePath,
+            });
+          }
         }
         throw renameErr;
       }
@@ -1491,7 +1540,9 @@ async function uploadLocalToSftp(_event, payload) {
       }
       return { success: true, remotePath: payload.remotePath };
     } catch (err) {
-      try { await backend.remove(stagedRemotePath, { recursive: false, encoding }); } catch { /* ignore */ }
+      if (!err?.preserveStagedUpload) {
+        try { await backend.remove(stagedRemotePath, { recursive: false, encoding }); } catch { /* ignore */ }
+      }
       throw err;
     } finally {
       try { transfer?.detachAbortSignal?.(); } catch { /* ignore */ }
@@ -1719,6 +1770,7 @@ module.exports = {
   downloadSftpToLocal,
   uploadLocalToSftp,
   pipelinedUploadLocalFile,
+  _renameRemotePathForTests: renameRemotePath,
   closeSftp,
   mkdirSftp,
   deleteSftp,

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -570,6 +570,144 @@ function buildBackupRemotePath(remotePath) {
   return dir ? `${dir}${backupName}` : backupName;
 }
 
+function isRemotePermissionError(err) {
+  const code = err?.code;
+  if (code === 3 || code === "EACCES" || code === "EPERM" || code === "ERR_PERMISSION") {
+    return true;
+  }
+  return /permission|denied|access/i.test(String(err?.message || ""));
+}
+
+function attrsIndicateSymlink(attrs) {
+  if (!attrs) return false;
+  if (typeof attrs.isSymbolicLink === "function") return !!attrs.isSymbolicLink();
+  if (typeof attrs.isSymbolicLink === "boolean") return attrs.isSymbolicLink;
+  const mode = Number(attrs.mode);
+  return Number.isFinite(mode) && (mode & 0o170000) === 0o120000;
+}
+
+/**
+ * Plan overwrite strategy for a remote upload target.
+ * - Symlinks: write in-place so the server follows the link (rename would replace the link node).
+ * - Regular files: stage + rename, and capture mode bits to restore after the new inode lands.
+ */
+async function planRemoteUploadReplace(client, encodedPath) {
+  let existingMode = null;
+  let writeInPlace = false;
+  try {
+    const sftp = await requireSftpChannel(client);
+    let attrs = null;
+    try {
+      attrs = await lstatAsync(sftp, encodedPath);
+    } catch {
+      attrs = null;
+    }
+    if (!attrs) return { writeInPlace: false, existingMode: null };
+    if (attrsIndicateSymlink(attrs)) {
+      return { writeInPlace: true, existingMode: null };
+    }
+    const mode = Number(attrs.mode);
+    if (Number.isFinite(mode) && mode > 0) {
+      existingMode = mode & 0o7777;
+    }
+  } catch {
+    // Missing destination / unsupported lstat is fine — default to staging.
+  }
+  return { writeInPlace, existingMode };
+}
+
+async function restoreRemoteMode(client, encodedPath, mode) {
+  if (mode == null || !Number.isFinite(mode)) return;
+  try {
+    if (typeof client.chmod === "function") {
+      await client.chmod(encodedPath, mode);
+      return;
+    }
+    const sftp = await requireSftpChannel(client);
+    await new Promise((resolve, reject) => {
+      if (typeof sftp.chmod === "function") {
+        sftp.chmod(encodedPath, mode, (err) => (err ? reject(err) : resolve()));
+        return;
+      }
+      if (typeof sftp.setstat === "function") {
+        sftp.setstat(encodedPath, { mode }, (err) => (err ? reject(err) : resolve()));
+        return;
+      }
+      resolve();
+    });
+  } catch {
+    // Best-effort only — do not fail a successful upload over metadata restore.
+  }
+}
+
+/**
+ * Pipelined upload with stage+rename by default (cancel-safe final dest).
+ * Writes in-place for symlink destinations; falls back to in-place when staging
+ * fails due to parent-directory permission (file itself still writable).
+ */
+async function pipelinedUploadWithOptionalStaging(client, localPath, remotePath, options = {}) {
+  const signal = options?.signal || null;
+  const expectedSize = options?.expectedSize;
+  const plan = await planRemoteUploadReplace(client, remotePath);
+  const fastPutOptions = { ...options };
+  delete fastPutOptions.expectedSize;
+
+  const uploadDirect = async () => {
+    await pipelinedUploadLocalFile(client, localPath, remotePath, fastPutOptions);
+    throwIfAborted(signal);
+    if (Number.isFinite(expectedSize) && expectedSize >= 0 && typeof client.stat === "function") {
+      const st = await client.stat(remotePath);
+      const size = Number(st?.size);
+      if (Number.isFinite(size) && size !== expectedSize) {
+        throw new Error(
+          `Upload size mismatch for ${remotePath}: expected ${expectedSize} bytes, got ${size}`,
+        );
+      }
+    }
+    return { staged: false };
+  };
+
+  if (plan.writeInPlace) {
+    return uploadDirect();
+  }
+
+  const stagedRemotePath = buildStagedRemotePath(remotePath);
+  const backupRemotePath = buildBackupRemotePath(remotePath);
+  try {
+    await pipelinedUploadLocalFile(client, localPath, stagedRemotePath, fastPutOptions);
+    throwIfAborted(signal);
+    if (Number.isFinite(expectedSize) && expectedSize >= 0 && typeof client.stat === "function") {
+      const stagedStat = await client.stat(stagedRemotePath);
+      const stagedSize = Number(stagedStat?.size);
+      if (Number.isFinite(stagedSize) && stagedSize !== expectedSize) {
+        throw new Error(
+          `Upload size mismatch for ${remotePath}: expected ${expectedSize} bytes, got ${stagedSize}`,
+        );
+      }
+    }
+    await renameRemotePath(client, stagedRemotePath, remotePath, backupRemotePath);
+    await restoreRemoteMode(client, remotePath, plan.existingMode);
+    return { staged: true };
+  } catch (err) {
+    try {
+      if (typeof client.delete === "function") {
+        await client.delete(stagedRemotePath);
+      }
+    } catch {
+      // Best-effort cleanup of a partial stage.
+    }
+    // Parent dir not writable but existing file may still be: fall back to in-place.
+    if (isRemotePermissionError(err)) {
+      console.warn(
+        "[SFTP] Staged upload unavailable (permission); falling back to in-place overwrite:",
+        err?.message || String(err),
+      );
+      return uploadDirect();
+    }
+    throw err;
+  }
+}
+
 const posixRenameAsync = (sftp, fromPath, toPath) =>
   new Promise((resolve, reject) => {
     if (typeof sftp?.ext_openssh_rename !== "function") {
@@ -1231,50 +1369,24 @@ async function uploadLocalToSftp(_event, payload) {
 
   await requireSftpChannel(client);
   const encoding = resolveEncodingForRequest(payload.sftpId, payload.encoding);
-  const stagedRemotePath = buildStagedRemotePath(payload.remotePath);
-  const backupRemotePath = buildBackupRemotePath(payload.remotePath);
   const encodedPath = encodePath(payload.remotePath, encoding);
-  const encodedStagedPath = encodePath(stagedRemotePath, encoding);
-  const encodedBackupPath = encodePath(backupRemotePath, encoding);
   throwIfAborted(payload.abortSignal);
   const {
     TRANSFER_CHUNK_SIZE,
     UPLOAD_TRANSFER_CONCURRENCY,
   } = require("./transferLimits.cjs");
+  let expectedSize = null;
   try {
-    // Pipelined WRITEs only. Supports ssh2-sftp-client (client.fastPut) and
-    // session-backed clients (client.fastPut → raw sftp.fastPut). Serial put is
-    // never used as a silent fallback (#2449 / industry practice).
-    await pipelinedUploadLocalFile(client, payload.localPath, encodedStagedPath, {
-      chunkSize: TRANSFER_CHUNK_SIZE,
-      concurrency: UPLOAD_TRANSFER_CONCURRENCY,
-      signal: payload.abortSignal,
-    });
-    throwIfAborted(payload.abortSignal);
-    // Verify staged size before promoting over the destination (#2022 / silent
-    // truncation on servers that mishandle non-default WRITE sizes).
-    let expectedSize = null;
-    try {
-      expectedSize = Number((await fs.promises.stat(payload.localPath))?.size);
-    } catch { /* ignore — fall through without size check if local vanished */ }
-    if (Number.isFinite(expectedSize) && expectedSize >= 0) {
-      const stagedStat = await client.stat(encodedStagedPath);
-      const stagedSize = Number(stagedStat?.size);
-      if (Number.isFinite(stagedSize) && stagedSize !== expectedSize) {
-        throw new Error(
-          `Upload size mismatch for ${payload.remotePath}: expected ${expectedSize} bytes, got ${stagedSize}`,
-        );
-      }
-    }
-    await renameRemotePath(client, encodedStagedPath, encodedPath, encodedBackupPath);
-  } catch (err) {
-    try {
-      await client.delete(encodedStagedPath);
-    } catch {
-      // Ignore best-effort cleanup failures for partially uploaded temp files.
-    }
-    throw err;
-  }
+    expectedSize = Number((await fs.promises.stat(payload.localPath))?.size);
+  } catch { /* ignore — fall through without size check if local vanished */ }
+  // Pipelined WRITEs with stage+rename by default (cancel-safe). Symlink and
+  // parent-dir permission edge cases fall back to in-place overwrite.
+  await pipelinedUploadWithOptionalStaging(client, payload.localPath, encodedPath, {
+    chunkSize: TRANSFER_CHUNK_SIZE,
+    concurrency: UPLOAD_TRANSFER_CONCURRENCY,
+    signal: payload.abortSignal,
+    expectedSize: Number.isFinite(expectedSize) ? expectedSize : undefined,
+  });
   return { success: true, remotePath: payload.remotePath };
 }
 
@@ -1330,6 +1442,7 @@ const fileOpsApi = createFileOpsApi({
   writeFileChunkAsync, closeFileAsync, createAbortError, copySftpEncodingState, clearSftpEncodingState,
   safeSend, tempDirBridge, randomUUID,
   pipelinedUploadLocalFile,
+  pipelinedUploadWithOptionalStaging,
 });
 const {
   listSftp,

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -1067,6 +1067,12 @@ function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelC
     const scheduleForceFinish = (err) => {
       clearForceFinish();
       forceFinishTimer = setTimeout(() => {
+        // Shared channel: best-effort unlink the in-progress remote target so a
+        // late fastPut cannot keep growing a staged .part after cancel reports.
+        // Disposable channels are already ended; unlink is optional there.
+        if (!dispose && (abortRequested || signal?.aborted || pendingError)) {
+          try { sftp.unlink?.(remotePath, () => {}); } catch { /* ignore */ }
+        }
         finish(err || new Error("SFTP channel closed"));
       }, 2000);
     };
@@ -1319,6 +1325,7 @@ const fileOpsApi = createFileOpsApi({
   requireSftpChannel, resolveEncodingForRequest, updateResolvedEncoding, encodePath, decodeName,
   detectEncodingFromList, statResultFromAttrs, normalizeRemotePathString, collectReadable, writeToWritable,
   throwIfAborted, pipeStreams, ensureRemoteDirForSession, removeRemotePathInternal, renameRemotePath,
+  buildStagedRemotePath, buildBackupRemotePath,
   realpathAsync, statAsync, lstatAsync, readdirAsync, mkdirAsync, rmdirAsync, unlinkAsync, openFileAsync,
   writeFileChunkAsync, closeFileAsync, createAbortError, copySftpEncodingState, clearSftpEncodingState,
   safeSend, tempDirBridge, randomUUID,

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -743,23 +743,12 @@ function createSessionBackedSftpClient(sessionId, sshClient, options = {}) {
      * Session-backed clients are not ssh2-sftp-client instances and do not
      * inherit client.fastPut — expose the channel method so uploadLocal /
      * writeSftpBinaryWithProgress keep the high-throughput path (#2449).
+     *
+     * When `options.signal` is provided, open a disposable SFTP channel so
+     * abort can end the transfer without killing the browse session.
      */
     async fastPut(localPath, remotePath, options = {}) {
-      const sftp = await requireSftpChannel(client);
-      if (typeof sftp.fastPut !== "function") {
-        throw new Error(
-          "SFTP pipelined upload (fastPut) is not available on this session",
-        );
-      }
-      const signal = options?.signal || null;
-      throwIfAborted(signal);
-      const { signal: _ignoredSignal, ...fastPutOptions } = options || {};
-      return new Promise((resolve, reject) => {
-        sftp.fastPut(localPath, remotePath, fastPutOptions, (err) => {
-          if (err) reject(err);
-          else resolve();
-        });
-      });
+      return runAbortableFastPut(client, localPath, remotePath, options);
     },
     async stat(remotePath) {
       const sftp = await requireSftpChannel(client);
@@ -1017,29 +1006,103 @@ async function downloadSftpToLocal(_event, payload) {
 }
 
 /**
- * Pipelined local→remote upload.
- * - ssh2-sftp-client: client.fastPut
- * - session-backed (openForSession/reuse): client.fastPut wraps sftp.fastPut
- * - last resort: raw channel after requireSftpChannel
- * Never falls back to serial createWriteStream/put (#2449).
+ * Open a disposable SFTP channel for cancelable pipelined uploads when possible.
+ * Falls back to the shared browse channel (not disposable) for sudo / missing SSH client.
  */
-async function pipelinedUploadLocalFile(client, localPath, remotePath, options = {}) {
-  if (typeof client?.fastPut === "function") {
-    return client.fastPut(localPath, remotePath, options);
+async function acquireUploadSftpChannel(client, options = {}) {
+  if (client?.__netcattySudoMode) {
+    const sftp = await requireSftpChannel(client, options);
+    return { sftp, dispose: false };
   }
-  const sftp = await requireSftpChannel(client);
-  if (typeof sftp.fastPut !== "function") {
+  const sshClient = client?.client;
+  if (sshClient && typeof sshClient.sftp === "function") {
+    const sftp = await tryOpenSftpChannel(client, options);
+    if (sftp && typeof sftp.fastPut === "function") {
+      return { sftp, dispose: true };
+    }
+    try { sftp?.end?.(); } catch { /* ignore */ }
+  }
+  const shared = await requireSftpChannel(client, options);
+  return { sftp: shared, dispose: false };
+}
+
+/**
+ * Run ssh2 SFTP fastPut with optional AbortSignal.
+ * When dispose is true, abort/end closes only this channel.
+ */
+function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelControl = {}) {
+  const { dispose = false, signal = null } = channelControl;
+  throwIfAborted(signal);
+  if (typeof sftp?.fastPut !== "function") {
     throw new Error(
       "SFTP pipelined upload (fastPut) is not available on this session",
     );
   }
-  const { signal: _ignoredSignal, ...fastPutOptions } = options || {};
+  const { signal: _ignoredSignal, onChannel, ...fastPutOptions } = options || {};
   return new Promise((resolve, reject) => {
-    sftp.fastPut(localPath, remotePath, fastPutOptions, (err) => {
+    let settled = false;
+    const finish = (err) => {
+      if (settled) return;
+      settled = true;
+      if (signal && onAbort) {
+        try { signal.removeEventListener("abort", onAbort); } catch { /* ignore */ }
+      }
+      if (dispose) {
+        try { sftp.end?.(); } catch { /* ignore */ }
+      }
       if (err) reject(err);
       else resolve();
-    });
+    };
+    const onAbort = () => {
+      try { if (dispose) sftp.end?.(); } catch { /* ignore */ }
+      finish(createAbortError(signal, "Upload cancelled"));
+    };
+    if (typeof onChannel === "function") {
+      try { onChannel(sftp, { dispose, abort: onAbort }); } catch { /* ignore */ }
+    }
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+    try {
+      sftp.fastPut(localPath, remotePath, fastPutOptions, (err) => {
+        if (signal?.aborted) {
+          finish(createAbortError(signal, "Upload cancelled"));
+          return;
+        }
+        finish(err || null);
+      });
+    } catch (err) {
+      finish(err);
+    }
   });
+}
+
+async function runAbortableFastPut(client, localPath, remotePath, options = {}) {
+  const signal = options?.signal || null;
+  throwIfAborted(signal);
+  const { sftp, dispose } = await acquireUploadSftpChannel(client, { signal });
+  return runFastPutOnChannel(sftp, localPath, remotePath, options, { dispose, signal });
+}
+
+/**
+ * Pipelined local→remote upload.
+ * - Prefer disposable-channel fastPut when abortable / session-backed
+ * - ssh2-sftp-client.fastPut when no signal and method exists
+ * Never falls back to serial createWriteStream/put (#2449).
+ */
+async function pipelinedUploadLocalFile(client, localPath, remotePath, options = {}) {
+  const signal = options?.signal || null;
+  // Always use abortable channel path when a signal is present, or when the
+  // client is session-backed (wrapper fastPut → disposable channel).
+  if (signal || client?.__netcattySessionBacked || typeof client?.fastPut !== "function") {
+    return runAbortableFastPut(client, localPath, remotePath, options);
+  }
+  // ssh2-sftp-client without abort: native fastPut on the shared connection.
+  return client.fastPut(localPath, remotePath, options);
 }
 
 async function uploadLocalToSftp(_event, payload) {
@@ -1190,6 +1253,7 @@ const fileOpsApi = createFileOpsApi({
   realpathAsync, statAsync, lstatAsync, readdirAsync, mkdirAsync, rmdirAsync, unlinkAsync, openFileAsync,
   writeFileChunkAsync, closeFileAsync, createAbortError, copySftpEncodingState, clearSftpEncodingState,
   safeSend, tempDirBridge, randomUUID,
+  pipelinedUploadLocalFile,
 });
 const {
   listSftp,

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -1383,6 +1383,42 @@ async function uploadLocalToSftp(_event, payload) {
     const backend = getScpBackendForClient(client);
     const encodingRaw = resolveEncodingForRequest(payload.sftpId, payload.encoding);
     const encoding = encodingRaw === "auto" ? "utf-8" : encodingRaw;
+
+    // Symlinks must be written in-place so scp follows the link target. Staging
+    // + rename would replace the link node itself (Codex PR review).
+    let existingIsSymlink = false;
+    try {
+      const existing = await backend.stat(payload.remotePath, { encoding });
+      if (existing?.isDirectory) {
+        throw new Error(`Remote path is a directory: ${payload.remotePath}`);
+      }
+      existingIsSymlink = !!(
+        existing?.isSymbolicLink
+        || existing?.isSymlink
+        || existing?.type === "symlink"
+      );
+    } catch (statErr) {
+      if (/directory/i.test(statErr?.message || "")) throw statErr;
+      // ENOENT / missing is fine — fall through to staged create.
+    }
+
+    if (existingIsSymlink) {
+      try {
+        await backend.uploadFile(payload.localPath, payload.remotePath, {
+          transfer,
+          encoding,
+          signal: payload.abortSignal || null,
+        });
+        throwIfAborted(payload.abortSignal);
+        if (transfer?.cancelled) {
+          throw createAbortError(payload.abortSignal, "Transfer cancelled");
+        }
+        return { success: true, remotePath: payload.remotePath };
+      } finally {
+        try { transfer?.detachAbortSignal?.(); } catch { /* ignore */ }
+      }
+    }
+
     // Upload to a staged remote name, then rename into place so a cancelled or
     // failed transfer cannot leave a truncated original (matches SFTP path).
     const stagedRemotePath = buildStagedRemotePath(payload.remotePath);

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -597,6 +597,14 @@ function isRemotePermissionError(err) {
     || code === "SSH_FX_PERMISSION_DENIED";
 }
 
+function isRemoteMissingError(err) {
+  const code = err?.code;
+  return code === 2
+    || code === "ENOENT"
+    || code === "NO_SUCH_FILE"
+    || code === "SSH_FX_NO_SUCH_FILE";
+}
+
 function attrsIndicateSymlink(attrs) {
   if (!attrs) return false;
   if (typeof attrs.isSymbolicLink === "function") return !!attrs.isSymbolicLink();
@@ -623,8 +631,23 @@ async function planRemoteUploadReplace(client, encodedPath) {
       let attrs = null;
       try {
         attrs = await lstatAsync(sftp, encodedPath);
-      } catch {
-        attrs = null;
+      } catch (lstatError) {
+        if (isRemoteMissingError(lstatError)) {
+          return { writeInPlace: false, existingMode: null };
+        }
+        // Some SFTP servers expose lstat client-side but reject it at runtime.
+        // A successful stat proves the destination exists, but cannot tell us
+        // whether it is a symlink, so preserve it with an in-place write.
+        try {
+          attrs = await statAsync(sftp, encodedPath);
+          if (attrs) return { writeInPlace: true, existingMode: null };
+        } catch (statError) {
+          if (isRemoteMissingError(statError)) {
+            return { writeInPlace: false, existingMode: null };
+          }
+          // Unknown inspection failure: do not risk rename-replacing a link.
+          return { writeInPlace: true, existingMode: null };
+        }
       }
       if (!attrs) return { writeInPlace: false, existingMode: null };
       if (attrsIndicateSymlink(attrs)) {
@@ -648,8 +671,12 @@ async function planRemoteUploadReplace(client, encodedPath) {
           : null;
         return { writeInPlace: true, existingMode };
       }
-    } catch {
-      // Missing destination — stage a new file.
+    } catch (statError) {
+      if (!isRemoteMissingError(statError)) {
+        // Unknown existing-path state: preserve a possible symlink.
+        return { writeInPlace: true, existingMode: null };
+      }
+      // Confirmed missing destination — stage a new file.
     }
   } catch {
     // Channel probe failure — default to staging for cancel-safe new uploads.

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -587,11 +587,14 @@ function buildBackupRemotePath(remotePath) {
 }
 
 function isRemotePermissionError(err) {
+  // Codes only — do not match message substrings (filenames may contain
+  // "permission"/"access"/"denied" and must not trigger in-place fallback).
   const code = err?.code;
-  if (code === 3 || code === "EACCES" || code === "EPERM" || code === "ERR_PERMISSION") {
-    return true;
-  }
-  return /permission|denied|access/i.test(String(err?.message || ""));
+  return code === 3
+    || code === "EACCES"
+    || code === "EPERM"
+    || code === "ERR_PERMISSION"
+    || code === "SSH_FX_PERMISSION_DENIED";
 }
 
 function attrsIndicateSymlink(attrs) {
@@ -604,33 +607,52 @@ function attrsIndicateSymlink(attrs) {
 
 /**
  * Plan overwrite strategy for a remote upload target.
- * - Symlinks: write in-place so the server follows the link (rename would
- *   replace the link node). Shared-channel cancel cannot hard-stop fastPut;
- *   symlink overwrite is rare and accepted as best-effort.
- * - Regular files (new or existing): stage + rename so cancel cannot keep
- *   mutating the final destination after the UI reports cancellation. Capture
- *   mode bits to restore after the new inode lands.
+ * - Confirmed symlinks: write in-place so the server follows the link.
+ * - When lstat is unavailable but the path exists: write in-place so we never
+ *   replace an unknown link node via stage+rename.
+ * - Confirmed regular files (new or existing): stage + rename so cancel cannot
+ *   keep mutating the final destination. Restore mode bits after promotion
+ *   (SFTP v3 cannot portably preserve owner/ACL/xattr/hard-links).
  */
 async function planRemoteUploadReplace(client, encodedPath) {
   try {
     const sftp = await requireSftpChannel(client);
-    let attrs = null;
+    const hasNativeLstat = typeof sftp?.lstat === "function";
+
+    if (hasNativeLstat) {
+      let attrs = null;
+      try {
+        attrs = await lstatAsync(sftp, encodedPath);
+      } catch {
+        attrs = null;
+      }
+      if (!attrs) return { writeInPlace: false, existingMode: null };
+      if (attrsIndicateSymlink(attrs)) {
+        return { writeInPlace: true, existingMode: null };
+      }
+      const mode = Number(attrs.mode);
+      const existingMode = Number.isFinite(mode) && mode > 0
+        ? (mode & 0o7777)
+        : null;
+      return { writeInPlace: false, existingMode };
+    }
+
+    // No lstat: if the path exists via stat, write in-place so a symlink is not
+    // replaced by rename when we cannot inspect the link node.
     try {
-      attrs = await lstatAsync(sftp, encodedPath);
+      const attrs = await statAsync(sftp, encodedPath);
+      if (attrs) {
+        const mode = Number(attrs.mode);
+        const existingMode = Number.isFinite(mode) && mode > 0
+          ? (mode & 0o7777)
+          : null;
+        return { writeInPlace: true, existingMode };
+      }
     } catch {
-      attrs = null;
+      // Missing destination — stage a new file.
     }
-    if (!attrs) return { writeInPlace: false, existingMode: null };
-    if (attrsIndicateSymlink(attrs)) {
-      return { writeInPlace: true, existingMode: null };
-    }
-    const mode = Number(attrs.mode);
-    const existingMode = Number.isFinite(mode) && mode > 0
-      ? (mode & 0o7777)
-      : null;
-    return { writeInPlace: false, existingMode };
   } catch {
-    // Missing destination / unsupported lstat is fine — default to staging.
+    // Channel probe failure — default to staging for cancel-safe new uploads.
   }
   return { writeInPlace: false, existingMode: null };
 }
@@ -669,9 +691,9 @@ async function restoreRemoteMode(client, encodedPath, mode) {
 
 /**
  * Pipelined upload with optional stage+rename.
- * - New files: stage then rename (cancel-safe promotion).
- * - Existing files/symlinks: write in-place (preserve inode / link / metadata).
- * - Parent-dir permission on stage: fall back to in-place.
+ * - Confirmed regular files: stage then rename (cancel-safe finals) + mode restore.
+ * - Symlinks / unknown-existing (no lstat): write in-place.
+ * - Parent-dir permission on stage: fall back to in-place (code-based only).
  *
  * `remotePath` must be the logical (pre-encode) path string. Encoding is applied
  * here so staged/backup names are not built from Buffer path bytes.

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -1016,11 +1016,23 @@ async function acquireUploadSftpChannel(client, options = {}) {
   }
   const sshClient = client?.client;
   if (sshClient && typeof sshClient.sftp === "function") {
-    const sftp = await tryOpenSftpChannel(client, options);
-    if (sftp && typeof sftp.fastPut === "function") {
-      return { sftp, dispose: true };
+    // Prefer a disposable channel for cancel, but never fail the whole upload
+    // when MaxSessions / server policy refuses another subsystem — fall back to
+    // the existing browse channel (Codex PR review).
+    try {
+      throwIfAborted(options?.signal);
+      const sftp = await tryOpenSftpChannel(client, options);
+      if (sftp && typeof sftp.fastPut === "function") {
+        return { sftp, dispose: true };
+      }
+      try { sftp?.end?.(); } catch { /* ignore */ }
+    } catch (err) {
+      if (options?.signal?.aborted) throw err;
+      console.warn(
+        "[SFTP] Disposable upload channel unavailable, using shared SFTP channel:",
+        err?.message || String(err),
+      );
     }
-    try { sftp?.end?.(); } catch { /* ignore */ }
   }
   const shared = await requireSftpChannel(client, options);
   return { sftp: shared, dispose: false };

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -588,12 +588,11 @@ function attrsIndicateSymlink(attrs) {
 
 /**
  * Plan overwrite strategy for a remote upload target.
- * - Symlinks: write in-place so the server follows the link (rename would replace the link node).
- * - Regular files: stage + rename, and capture mode bits to restore after the new inode lands.
+ * - Existing files / symlinks: write in-place so the inode, mode, ACL, and link
+ *   node are preserved (stage+rename would replace the inode).
+ * - Missing targets: stage + rename for cancel-safe promotion of new files.
  */
 async function planRemoteUploadReplace(client, encodedPath) {
-  let existingMode = null;
-  let writeInPlace = false;
   try {
     const sftp = await requireSftpChannel(client);
     let attrs = null;
@@ -603,17 +602,24 @@ async function planRemoteUploadReplace(client, encodedPath) {
       attrs = null;
     }
     if (!attrs) return { writeInPlace: false, existingMode: null };
-    if (attrsIndicateSymlink(attrs)) {
-      return { writeInPlace: true, existingMode: null };
-    }
+    // Existing node (file or symlink): prefer in-place overwrite.
     const mode = Number(attrs.mode);
-    if (Number.isFinite(mode) && mode > 0) {
-      existingMode = mode & 0o7777;
-    }
+    const existingMode = Number.isFinite(mode) && mode > 0 && !attrsIndicateSymlink(attrs)
+      ? (mode & 0o7777)
+      : null;
+    return { writeInPlace: true, existingMode };
   } catch {
     // Missing destination / unsupported lstat is fine — default to staging.
   }
-  return { writeInPlace, existingMode };
+  return { writeInPlace: false, existingMode: null };
+}
+
+function isNetcattyStagedRemotePath(remotePath) {
+  const asString = Buffer.isBuffer(remotePath)
+    ? remotePath.toString("utf8")
+    : String(remotePath || "");
+  // Only our randomized stage names — never the caller's final destination.
+  return /(^|\/|\\)\.netcatty-upload-[^/\\]+\.part$/.test(asString);
 }
 
 async function restoreRemoteMode(client, encodedPath, mode) {
@@ -641,22 +647,29 @@ async function restoreRemoteMode(client, encodedPath, mode) {
 }
 
 /**
- * Pipelined upload with stage+rename by default (cancel-safe final dest).
- * Writes in-place for symlink destinations; falls back to in-place when staging
- * fails due to parent-directory permission (file itself still writable).
+ * Pipelined upload with optional stage+rename.
+ * - New files: stage then rename (cancel-safe promotion).
+ * - Existing files/symlinks: write in-place (preserve inode / link / metadata).
+ * - Parent-dir permission on stage: fall back to in-place.
+ *
+ * `remotePath` must be the logical (pre-encode) path string. Encoding is applied
+ * here so staged/backup names are not built from Buffer path bytes.
  */
 async function pipelinedUploadWithOptionalStaging(client, localPath, remotePath, options = {}) {
   const signal = options?.signal || null;
   const expectedSize = options?.expectedSize;
-  const plan = await planRemoteUploadReplace(client, remotePath);
+  const encoding = options?.encoding || "utf-8";
+  const encodedPath = encodePath(remotePath, encoding);
+  const plan = await planRemoteUploadReplace(client, encodedPath);
   const fastPutOptions = { ...options };
   delete fastPutOptions.expectedSize;
+  delete fastPutOptions.encoding;
 
   const uploadDirect = async () => {
-    await pipelinedUploadLocalFile(client, localPath, remotePath, fastPutOptions);
+    await pipelinedUploadLocalFile(client, localPath, encodedPath, fastPutOptions);
     throwIfAborted(signal);
     if (Number.isFinite(expectedSize) && expectedSize >= 0 && typeof client.stat === "function") {
-      const st = await client.stat(remotePath);
+      const st = await client.stat(encodedPath);
       const size = Number(st?.size);
       if (Number.isFinite(size) && size !== expectedSize) {
         throw new Error(
@@ -671,13 +684,16 @@ async function pipelinedUploadWithOptionalStaging(client, localPath, remotePath,
     return uploadDirect();
   }
 
-  const stagedRemotePath = buildStagedRemotePath(remotePath);
-  const backupRemotePath = buildBackupRemotePath(remotePath);
+  // Build stage/backup names from the logical string, then encode each path.
+  const stagedLogical = buildStagedRemotePath(remotePath);
+  const backupLogical = buildBackupRemotePath(remotePath);
+  const encodedStagedPath = encodePath(stagedLogical, encoding);
+  const encodedBackupPath = encodePath(backupLogical, encoding);
   try {
-    await pipelinedUploadLocalFile(client, localPath, stagedRemotePath, fastPutOptions);
+    await pipelinedUploadLocalFile(client, localPath, encodedStagedPath, fastPutOptions);
     throwIfAborted(signal);
     if (Number.isFinite(expectedSize) && expectedSize >= 0 && typeof client.stat === "function") {
-      const stagedStat = await client.stat(stagedRemotePath);
+      const stagedStat = await client.stat(encodedStagedPath);
       const stagedSize = Number(stagedStat?.size);
       if (Number.isFinite(stagedSize) && stagedSize !== expectedSize) {
         throw new Error(
@@ -685,13 +701,13 @@ async function pipelinedUploadWithOptionalStaging(client, localPath, remotePath,
         );
       }
     }
-    await renameRemotePath(client, stagedRemotePath, remotePath, backupRemotePath);
-    await restoreRemoteMode(client, remotePath, plan.existingMode);
+    await renameRemotePath(client, encodedStagedPath, encodedPath, encodedBackupPath);
+    await restoreRemoteMode(client, encodedPath, plan.existingMode);
     return { staged: true };
   } catch (err) {
     try {
       if (typeof client.delete === "function") {
-        await client.delete(stagedRemotePath);
+        await client.delete(encodedStagedPath);
       }
     } catch {
       // Best-effort cleanup of a partial stage.
@@ -1205,10 +1221,14 @@ function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelC
     const scheduleForceFinish = (err) => {
       clearForceFinish();
       forceFinishTimer = setTimeout(() => {
-        // Shared channel: best-effort unlink the in-progress remote target so a
-        // late fastPut cannot keep growing a staged .part after cancel reports.
-        // Disposable channels are already ended; unlink is optional there.
-        if (!dispose && (abortRequested || signal?.aborted || pendingError)) {
+        // Shared channel: best-effort unlink only Netcatty staged .part paths so a
+        // late fastPut cannot keep growing a temp after cancel reports.
+        // Never unlink the caller's final destination (in-place / symlink writes).
+        if (
+          !dispose
+          && (abortRequested || signal?.aborted || pendingError)
+          && isNetcattyStagedRemotePath(remotePath)
+        ) {
           try { sftp.unlink?.(remotePath, () => {}); } catch { /* ignore */ }
         }
         finish(err || new Error("SFTP channel closed"));
@@ -1369,7 +1389,6 @@ async function uploadLocalToSftp(_event, payload) {
 
   await requireSftpChannel(client);
   const encoding = resolveEncodingForRequest(payload.sftpId, payload.encoding);
-  const encodedPath = encodePath(payload.remotePath, encoding);
   throwIfAborted(payload.abortSignal);
   const {
     TRANSFER_CHUNK_SIZE,
@@ -1379,12 +1398,12 @@ async function uploadLocalToSftp(_event, payload) {
   try {
     expectedSize = Number((await fs.promises.stat(payload.localPath))?.size);
   } catch { /* ignore — fall through without size check if local vanished */ }
-  // Pipelined WRITEs with stage+rename by default (cancel-safe). Symlink and
-  // parent-dir permission edge cases fall back to in-place overwrite.
-  await pipelinedUploadWithOptionalStaging(client, payload.localPath, encodedPath, {
+  // Logical path in; helper encodes stage/final so non-UTF-8 dirs stay intact.
+  await pipelinedUploadWithOptionalStaging(client, payload.localPath, payload.remotePath, {
     chunkSize: TRANSFER_CHUNK_SIZE,
     concurrency: UPLOAD_TRANSFER_CONCURRENCY,
     signal: payload.abortSignal,
+    encoding,
     expectedSize: Number.isFinite(expectedSize) ? expectedSize : undefined,
   });
   return { success: true, remotePath: payload.remotePath };

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -744,6 +744,8 @@ async function pipelinedUploadWithOptionalStaging(client, localPath, remotePath,
         );
       }
     }
+    // Cancel may arrive during the awaited size verify; recheck before promote.
+    throwIfAborted(signal);
     await renameRemotePath(client, encodedStagedPath, encodedPath, encodedBackupPath);
     await restoreRemoteMode(client, encodedPath, plan.existingMode);
     return { staged: true };

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -1086,12 +1086,14 @@ function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelC
     };
     // Channel errors must not finish immediately: wait for fastPut callback (or
     // force timeout) so local temp files are not unlinked while still open.
+    // Shared channels also get force-settle (without sftp.end) so a stalled
+    // callback after error cannot hang the upload forever.
     const onChannelError = (err) => {
       pendingError = err || new Error("SFTP channel error");
       if (dispose) {
         try { sftp.end?.(); } catch { /* ignore */ }
-        scheduleForceFinish(pendingError);
       }
+      scheduleForceFinish(pendingError);
     };
     const onAbort = () => {
       abortRequested = true;

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -738,6 +738,29 @@ function createSessionBackedSftpClient(sessionId, sshClient, options = {}) {
       }
       return true;
     },
+    /**
+     * Pipelined local→remote upload via the raw ssh2 SFTP channel.
+     * Session-backed clients are not ssh2-sftp-client instances and do not
+     * inherit client.fastPut — expose the channel method so uploadLocal /
+     * writeSftpBinaryWithProgress keep the high-throughput path (#2449).
+     */
+    async fastPut(localPath, remotePath, options = {}) {
+      const sftp = await requireSftpChannel(client);
+      if (typeof sftp.fastPut !== "function") {
+        throw new Error(
+          "SFTP pipelined upload (fastPut) is not available on this session",
+        );
+      }
+      const signal = options?.signal || null;
+      throwIfAborted(signal);
+      const { signal: _ignoredSignal, ...fastPutOptions } = options || {};
+      return new Promise((resolve, reject) => {
+        sftp.fastPut(localPath, remotePath, fastPutOptions, (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+    },
     async stat(remotePath) {
       const sftp = await requireSftpChannel(client);
       const attrs = await statAsync(sftp, remotePath);
@@ -993,6 +1016,32 @@ async function downloadSftpToLocal(_event, payload) {
   return { success: true, localPath: payload.localPath };
 }
 
+/**
+ * Pipelined local→remote upload.
+ * - ssh2-sftp-client: client.fastPut
+ * - session-backed (openForSession/reuse): client.fastPut wraps sftp.fastPut
+ * - last resort: raw channel after requireSftpChannel
+ * Never falls back to serial createWriteStream/put (#2449).
+ */
+async function pipelinedUploadLocalFile(client, localPath, remotePath, options = {}) {
+  if (typeof client?.fastPut === "function") {
+    return client.fastPut(localPath, remotePath, options);
+  }
+  const sftp = await requireSftpChannel(client);
+  if (typeof sftp.fastPut !== "function") {
+    throw new Error(
+      "SFTP pipelined upload (fastPut) is not available on this session",
+    );
+  }
+  const { signal: _ignoredSignal, ...fastPutOptions } = options || {};
+  return new Promise((resolve, reject) => {
+    sftp.fastPut(localPath, remotePath, fastPutOptions, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
 async function uploadLocalToSftp(_event, payload) {
   const client = sftpClients.get(payload.sftpId);
   if (!client) throw new Error("SFTP session not found");
@@ -1070,14 +1119,10 @@ async function uploadLocalToSftp(_event, payload) {
     UPLOAD_TRANSFER_CONCURRENCY,
   } = require("./transferLimits.cjs");
   try {
-    // Pipelined WRITEs only (ssh2 fastPut). Serial createReadStream→put is
-    // RTT-bound and is never used as a silent fallback (#2449 / industry practice).
-    if (typeof client.fastPut !== "function") {
-      throw new Error(
-        "SFTP pipelined upload (fastPut) is not available on this session",
-      );
-    }
-    await client.fastPut(payload.localPath, encodedStagedPath, {
+    // Pipelined WRITEs only. Supports ssh2-sftp-client (client.fastPut) and
+    // session-backed clients (client.fastPut → raw sftp.fastPut). Serial put is
+    // never used as a silent fallback (#2449 / industry practice).
+    await pipelinedUploadLocalFile(client, payload.localPath, encodedStagedPath, {
       chunkSize: TRANSFER_CHUNK_SIZE,
       concurrency: UPLOAD_TRANSFER_CONCURRENCY,
       signal: payload.abortSignal,
@@ -1290,6 +1335,7 @@ module.exports = {
   cancelSftpUpload,
   downloadSftpToLocal,
   uploadLocalToSftp,
+  pipelinedUploadLocalFile,
   closeSftp,
   mkdirSftp,
   deleteSftp,

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -1229,6 +1229,21 @@ async function uploadLocalToSftp(_event, payload) {
       signal: payload.abortSignal,
     });
     throwIfAborted(payload.abortSignal);
+    // Verify staged size before promoting over the destination (#2022 / silent
+    // truncation on servers that mishandle non-default WRITE sizes).
+    let expectedSize = null;
+    try {
+      expectedSize = Number((await fs.promises.stat(payload.localPath))?.size);
+    } catch { /* ignore — fall through without size check if local vanished */ }
+    if (Number.isFinite(expectedSize) && expectedSize >= 0) {
+      const stagedStat = await client.stat(encodedStagedPath);
+      const stagedSize = Number(stagedStat?.size);
+      if (Number.isFinite(stagedSize) && stagedSize !== expectedSize) {
+        throw new Error(
+          `Upload size mismatch for ${payload.remotePath}: expected ${expectedSize} bytes, got ${stagedSize}`,
+        );
+      }
+    }
     await renameRemotePath(client, encodedStagedPath, encodedPath, encodedBackupPath);
   } catch (err) {
     try {

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -1028,10 +1028,9 @@ async function acquireUploadSftpChannel(client, options = {}) {
 
 /**
  * Run ssh2 SFTP fastPut with optional AbortSignal.
- * When dispose is true, abort ends only this channel and rejects immediately.
- * When dispose is false (shared browse channel), abort marks cancelled but waits
- * for the fastPut callback before rejecting so callers do not delete temp/staged
- * files while writes are still in flight.
+ * Always waits for the fastPut callback (or a short dispose grace period) before
+ * settling so local temp files are not unlinked while ssh2 still holds them.
+ * Disposable channels are ended on abort; shared channels only mark cancelled.
  */
 function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelControl = {}) {
   const { dispose = false, signal = null } = channelControl;
@@ -1045,12 +1044,24 @@ function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelC
   return new Promise((resolve, reject) => {
     let settled = false;
     let abortRequested = false;
+    let forceFinishTimer = null;
+    const clearForceFinish = () => {
+      if (forceFinishTimer) {
+        clearTimeout(forceFinishTimer);
+        forceFinishTimer = null;
+      }
+    };
+    const onChannelError = (err) => {
+      finish(err || new Error("SFTP channel error"));
+    };
     const finish = (err) => {
       if (settled) return;
       settled = true;
+      clearForceFinish();
       if (signal && onAbort) {
         try { signal.removeEventListener("abort", onAbort); } catch { /* ignore */ }
       }
+      try { sftp.removeListener?.("error", onChannelError); } catch { /* ignore */ }
       if (dispose) {
         try { sftp.end?.(); } catch { /* ignore */ }
       }
@@ -1060,22 +1071,25 @@ function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelC
     const onAbort = () => {
       abortRequested = true;
       if (dispose) {
-        // Disposable channel: tearing it down stops fastPut and unblocks callers.
+        // Tear down disposable channel; wait for fastPut cb to release local fd.
         try { sftp.end?.(); } catch { /* ignore */ }
-        finish(createAbortError(signal, "Upload cancelled"));
+        // If the callback never fires, force-finish so callers are not stuck.
+        clearForceFinish();
+        forceFinishTimer = setTimeout(() => {
+          finish(createAbortError(signal, "Upload cancelled"));
+        }, 2000);
         return;
       }
       // Shared channel: cannot end without killing browse/sudo SFTP. Wait for
       // fastPut's callback so temp-file cleanup does not race in-flight WRITEs.
     };
+    try { sftp.on?.("error", onChannelError); } catch { /* ignore */ }
     if (typeof onChannel === "function") {
       try { onChannel(sftp, { dispose, abort: onAbort }); } catch { /* ignore */ }
     }
     if (signal) {
       if (signal.aborted) {
-        onAbort();
-        if (dispose || settled) return;
-        // Shared + already aborted before start: do not begin the transfer.
+        // Do not start the transfer when already aborted.
         finish(createAbortError(signal, "Upload cancelled"));
         return;
       }

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -551,12 +551,27 @@ function ensureRemoteSftpSupport(sessionId) {
   return { session, sshClient };
 }
 
+// Common remote NAME_MAX; keep stage/backup basenames within this budget.
+const REMOTE_BASENAME_MAX = 255;
+
+function clipRemoteBaseName(baseName, overhead) {
+  const raw = baseName || "upload";
+  const maxBase = Math.max(8, REMOTE_BASENAME_MAX - overhead);
+  if (Buffer.byteLength(raw, "utf8") <= maxBase) return raw;
+  // Prefer character-safe clip: shrink until utf8 bytes fit.
+  let clipped = raw;
+  while (clipped.length > 1 && Buffer.byteLength(clipped, "utf8") > maxBase) {
+    clipped = clipped.slice(0, -1);
+  }
+  return clipped || "upload";
+}
+
 function buildStagedRemotePath(remotePath) {
-  const isWindowsPath = isWindowsRemotePath(remotePath);
   const lastSeparatorIndex = Math.max(remotePath.lastIndexOf("/"), remotePath.lastIndexOf("\\"));
   const dir = lastSeparatorIndex >= 0 ? remotePath.slice(0, lastSeparatorIndex + 1) : "";
   const baseName = lastSeparatorIndex >= 0 ? remotePath.slice(lastSeparatorIndex + 1) : remotePath;
-  const safeBaseName = baseName || "upload";
+  // ".netcatty-upload-" (17) + 8 hex + "-" (1) + ".part" (5) = 31
+  const safeBaseName = clipRemoteBaseName(baseName, 31);
   const stagedName = `.netcatty-upload-${randomUUID().slice(0, 8)}-${safeBaseName}.part`;
   return dir ? `${dir}${stagedName}` : stagedName;
 }
@@ -565,7 +580,8 @@ function buildBackupRemotePath(remotePath) {
   const lastSeparatorIndex = Math.max(remotePath.lastIndexOf("/"), remotePath.lastIndexOf("\\"));
   const dir = lastSeparatorIndex >= 0 ? remotePath.slice(0, lastSeparatorIndex + 1) : "";
   const baseName = lastSeparatorIndex >= 0 ? remotePath.slice(lastSeparatorIndex + 1) : remotePath;
-  const safeBaseName = baseName || "upload";
+  // ".netcatty-backup-" (17) + 8 hex + "-" (1) + ".bak" (4) = 30
+  const safeBaseName = clipRemoteBaseName(baseName, 30);
   const backupName = `.netcatty-backup-${randomUUID().slice(0, 8)}-${safeBaseName}.bak`;
   return dir ? `${dir}${backupName}` : backupName;
 }
@@ -588,9 +604,12 @@ function attrsIndicateSymlink(attrs) {
 
 /**
  * Plan overwrite strategy for a remote upload target.
- * - Existing files / symlinks: write in-place so the inode, mode, ACL, and link
- *   node are preserved (stage+rename would replace the inode).
- * - Missing targets: stage + rename for cancel-safe promotion of new files.
+ * - Symlinks: write in-place so the server follows the link (rename would
+ *   replace the link node). Shared-channel cancel cannot hard-stop fastPut;
+ *   symlink overwrite is rare and accepted as best-effort.
+ * - Regular files (new or existing): stage + rename so cancel cannot keep
+ *   mutating the final destination after the UI reports cancellation. Capture
+ *   mode bits to restore after the new inode lands.
  */
 async function planRemoteUploadReplace(client, encodedPath) {
   try {
@@ -602,12 +621,14 @@ async function planRemoteUploadReplace(client, encodedPath) {
       attrs = null;
     }
     if (!attrs) return { writeInPlace: false, existingMode: null };
-    // Existing node (file or symlink): prefer in-place overwrite.
+    if (attrsIndicateSymlink(attrs)) {
+      return { writeInPlace: true, existingMode: null };
+    }
     const mode = Number(attrs.mode);
-    const existingMode = Number.isFinite(mode) && mode > 0 && !attrsIndicateSymlink(attrs)
+    const existingMode = Number.isFinite(mode) && mode > 0
       ? (mode & 0o7777)
       : null;
-    return { writeInPlace: true, existingMode };
+    return { writeInPlace: false, existingMode };
   } catch {
     // Missing destination / unsupported lstat is fine — default to staging.
   }

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -1028,7 +1028,10 @@ async function acquireUploadSftpChannel(client, options = {}) {
 
 /**
  * Run ssh2 SFTP fastPut with optional AbortSignal.
- * When dispose is true, abort/end closes only this channel.
+ * When dispose is true, abort ends only this channel and rejects immediately.
+ * When dispose is false (shared browse channel), abort marks cancelled but waits
+ * for the fastPut callback before rejecting so callers do not delete temp/staged
+ * files while writes are still in flight.
  */
 function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelControl = {}) {
   const { dispose = false, signal = null } = channelControl;
@@ -1041,6 +1044,7 @@ function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelC
   const { signal: _ignoredSignal, onChannel, ...fastPutOptions } = options || {};
   return new Promise((resolve, reject) => {
     let settled = false;
+    let abortRequested = false;
     const finish = (err) => {
       if (settled) return;
       settled = true;
@@ -1054,8 +1058,15 @@ function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelC
       else resolve();
     };
     const onAbort = () => {
-      try { if (dispose) sftp.end?.(); } catch { /* ignore */ }
-      finish(createAbortError(signal, "Upload cancelled"));
+      abortRequested = true;
+      if (dispose) {
+        // Disposable channel: tearing it down stops fastPut and unblocks callers.
+        try { sftp.end?.(); } catch { /* ignore */ }
+        finish(createAbortError(signal, "Upload cancelled"));
+        return;
+      }
+      // Shared channel: cannot end without killing browse/sudo SFTP. Wait for
+      // fastPut's callback so temp-file cleanup does not race in-flight WRITEs.
     };
     if (typeof onChannel === "function") {
       try { onChannel(sftp, { dispose, abort: onAbort }); } catch { /* ignore */ }
@@ -1063,13 +1074,16 @@ function runFastPutOnChannel(sftp, localPath, remotePath, options = {}, channelC
     if (signal) {
       if (signal.aborted) {
         onAbort();
+        if (dispose || settled) return;
+        // Shared + already aborted before start: do not begin the transfer.
+        finish(createAbortError(signal, "Upload cancelled"));
         return;
       }
       signal.addEventListener("abort", onAbort, { once: true });
     }
     try {
       sftp.fastPut(localPath, remotePath, fastPutOptions, (err) => {
-        if (signal?.aborted) {
+        if (abortRequested || signal?.aborted) {
           finish(createAbortError(signal, "Upload cancelled"));
           return;
         }

--- a/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
+++ b/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
@@ -245,8 +245,8 @@ test("session-backed writeSftpBinaryWithProgress uses pipelined fastPut", async 
   assert.deepEqual(remoteFiles.get("/home/alice/mem.bin"), payload);
 });
 
-test("existing destinations overwrite in-place to preserve metadata", async (t) => {
-  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-inplace-meta-"));
+test("existing destinations stage then restore mode after rename", async (t) => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-stage-meta-"));
   t.after(async () => {
     await fs.promises.rm(tempRoot, { recursive: true, force: true });
   });
@@ -282,12 +282,53 @@ test("existing destinations overwrite in-place to preserve metadata", async (t) 
   });
 
   assert.equal(fastPutCalls.length, 1);
-  assert.equal(fastPutCalls[0].remotePath, "/usr/local/bin/tool");
+  assert.match(fastPutCalls[0].remotePath, /\.netcatty-upload-.*\.part$/);
   assert.ok(remoteFiles.has("/usr/local/bin/tool"));
   assert.deepEqual(remoteFiles.get("/usr/local/bin/tool"), payload);
-  // In-place overwrite should not need a post-rename chmod restore.
-  assert.equal(chmodCalls.length, 0);
-  assert.equal(remoteMeta.get("/usr/local/bin/tool")?.mode, 0o100755);
+  // Stage+rename replaces the inode; restore prior mode bits afterwards.
+  assert.ok(
+    chmodCalls.some((c) => c.targetPath === "/usr/local/bin/tool" && (c.mode & 0o777) === 0o755),
+    `expected mode restore via chmod, got ${JSON.stringify(chmodCalls)}`,
+  );
+});
+
+test("staged basenames stay within the remote NAME_MAX budget", async (t) => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-long-name-"));
+  t.after(async () => {
+    await fs.promises.rm(tempRoot, { recursive: true, force: true });
+  });
+  tempDirBridge.init?.({ getPath: () => tempRoot });
+
+  const longBase = `${"a".repeat(240)}.bin`;
+  const localPath = path.join(tempRoot, "payload.bin");
+  await fs.promises.writeFile(localPath, Buffer.from("x"));
+
+  const { channel, fastPutCalls, remoteFiles } = createSessionChannel();
+  const connection = {
+    sftp(callback) { callback(null, channel); },
+  };
+  const sftpClients = new Map();
+  sftpBridge.init({
+    electronModule: { webContents: { fromId: () => null } },
+    sessions: new Map([["session-long", { conn: connection }]]),
+    sftpClients,
+  });
+  const opened = await sftpBridge.openSftpForSession(null, {
+    sessionId: "session-long",
+    fileProtocol: "sftp",
+  });
+
+  await sftpBridge.uploadLocalToSftp(null, {
+    sftpId: opened.sftpId,
+    localPath,
+    remotePath: `/tmp/${longBase}`,
+    encoding: "utf-8",
+  });
+
+  assert.equal(fastPutCalls.length, 1);
+  const stagedBase = path.posix.basename(fastPutCalls[0].remotePath);
+  assert.ok(Buffer.byteLength(stagedBase, "utf8") <= 255, stagedBase);
+  assert.ok(remoteFiles.has(`/tmp/${longBase}`));
 });
 
 test("symlink destinations are written in-place (not replaced by rename)", async (t) => {

--- a/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
+++ b/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
@@ -1,0 +1,242 @@
+"use strict";
+
+/**
+ * Session-backed SFTP clients (openForSession / terminal reuse) are not
+ * ssh2-sftp-client instances. They must still expose pipelined fastPut so
+ * uploadLocal / writeSftpBinaryWithProgress do not throw after serial put
+ * was removed (#2449 fail-closed alignment).
+ */
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const sftpBridge = require("./sftpBridge.cjs");
+const tempDirBridge = require("./tempDirBridge.cjs");
+const {
+  TRANSFER_CHUNK_SIZE,
+  UPLOAD_TRANSFER_CONCURRENCY,
+} = require("./transferLimits.cjs");
+
+function createSessionChannel() {
+  const fastPutCalls = [];
+  const remoteFiles = new Map();
+  const channel = {
+    // hasSftpChannelApi requires these four methods.
+    readdir(_targetPath, callback) {
+      callback(null, []);
+    },
+    mkdir(_targetPath, callback) {
+      callback(null);
+    },
+    unlink(targetPath, callback) {
+      remoteFiles.delete(targetPath);
+      callback(null);
+    },
+    stat(targetPath, callback) {
+      const data = remoteFiles.get(targetPath);
+      if (!data) {
+        const err = new Error(`ENOENT ${targetPath}`);
+        err.code = 2;
+        callback(err);
+        return;
+      }
+      callback(null, {
+        size: data.length,
+        isDirectory: () => false,
+        isFile: () => true,
+      });
+    },
+    fastPut(localPath, remotePath, options, callback) {
+      fastPutCalls.push({
+        localPath,
+        remotePath,
+        concurrency: options?.concurrency,
+        chunkSize: options?.chunkSize,
+      });
+      try {
+        const data = fs.readFileSync(localPath);
+        remoteFiles.set(remotePath, data);
+        if (typeof options?.step === "function") {
+          options.step(data.length, data.length, data.length);
+        }
+        queueMicrotask(() => callback(null));
+      } catch (err) {
+        queueMicrotask(() => callback(err));
+      }
+    },
+    rename(from, to, callback) {
+      if (!remoteFiles.has(from)) {
+        const err = new Error(`ENOENT ${from}`);
+        err.code = 2;
+        callback(err);
+        return;
+      }
+      remoteFiles.set(to, remoteFiles.get(from));
+      remoteFiles.delete(from);
+      callback(null);
+    },
+    end() {},
+  };
+  return { channel, fastPutCalls, remoteFiles };
+}
+
+test("session-backed uploadLocalToSftp uses pipelined fastPut on the raw SFTP channel", async (t) => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-session-upload-"));
+  t.after(async () => {
+    await fs.promises.rm(tempRoot, { recursive: true, force: true });
+  });
+  tempDirBridge.init?.({ getPath: () => tempRoot });
+
+  const localPath = path.join(tempRoot, "payload.bin");
+  const payload = Buffer.alloc(48 * 1024, 17);
+  await fs.promises.writeFile(localPath, payload);
+
+  const { channel, fastPutCalls, remoteFiles } = createSessionChannel();
+  const connection = {
+    sftp(callback) {
+      callback(null, channel);
+    },
+  };
+  const sftpClients = new Map();
+  sftpBridge.init({
+    electronModule: { webContents: { fromId: () => null } },
+    sessions: new Map([["session-upload", { conn: connection }]]),
+    sftpClients,
+  });
+
+  const opened = await sftpBridge.openSftpForSession(null, {
+    sessionId: "session-upload",
+    fileProtocol: "sftp",
+  });
+  assert.equal(opened.ok, true);
+  assert.equal(opened.fileProtocol, "sftp");
+
+  // Session-backed wrapper must expose fastPut (not only raw channel).
+  const client = sftpClients.get(opened.sftpId);
+  assert.equal(typeof client.fastPut, "function");
+  assert.equal(client.__netcattySessionBacked, true);
+
+  const result = await sftpBridge.uploadLocalToSftp(null, {
+    sftpId: opened.sftpId,
+    localPath,
+    remotePath: "/home/alice/payload.bin",
+    encoding: "utf-8",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(fastPutCalls.length, 1);
+  assert.equal(fastPutCalls[0].concurrency, UPLOAD_TRANSFER_CONCURRENCY);
+  assert.equal(fastPutCalls[0].chunkSize, TRANSFER_CHUNK_SIZE);
+  assert.equal(fastPutCalls[0].localPath, localPath);
+  // Final path after staged rename
+  assert.ok(remoteFiles.has("/home/alice/payload.bin"));
+  assert.equal(remoteFiles.get("/home/alice/payload.bin").length, payload.length);
+});
+
+test("session-backed writeSftpBinaryWithProgress uses pipelined fastPut", async (t) => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-session-write-progress-"));
+  t.after(async () => {
+    await fs.promises.rm(tempRoot, { recursive: true, force: true });
+  });
+  tempDirBridge.init?.({ getPath: () => tempRoot });
+  // ensureTempDir may be required by getTempFilePath
+  if (typeof tempDirBridge.ensureTempDir === "function") {
+    tempDirBridge.ensureTempDir();
+  }
+
+  const payload = Buffer.alloc(40 * 1024, 29);
+  const { channel, fastPutCalls, remoteFiles } = createSessionChannel();
+  const connection = {
+    sftp(callback) {
+      callback(null, channel);
+    },
+  };
+  const sftpClients = new Map();
+  sftpBridge.init({
+    electronModule: {
+      webContents: {
+        fromId: () => ({ send() {} }),
+      },
+    },
+    sessions: new Map([["session-write", { conn: connection }]]),
+    sftpClients,
+  });
+
+  const opened = await sftpBridge.openSftpForSession(null, {
+    sessionId: "session-write",
+    fileProtocol: "sftp",
+  });
+
+  let progressError = null;
+  const result = await sftpBridge.writeSftpBinaryWithProgress(
+    { sender: { id: 1 } },
+    {
+      sftpId: opened.sftpId,
+      path: "/home/alice/mem.bin",
+      content: payload,
+      transferId: "mem-upload-1",
+      encoding: "utf-8",
+      onProgress() {},
+      onComplete() {},
+      onError(message) {
+        progressError = message;
+      },
+    },
+  );
+
+  assert.equal(progressError, null, progressError);
+  assert.equal(result.success, true, result.error || progressError || "upload failed");
+  assert.equal(fastPutCalls.length, 1);
+  assert.equal(fastPutCalls[0].concurrency, UPLOAD_TRANSFER_CONCURRENCY);
+  assert.equal(fastPutCalls[0].chunkSize, TRANSFER_CHUNK_SIZE);
+  assert.ok(remoteFiles.has("/home/alice/mem.bin"));
+  assert.deepEqual(remoteFiles.get("/home/alice/mem.bin"), payload);
+});
+
+test("pipelinedUploadLocalFile falls back to raw sftp.fastPut when client.fastPut is missing", async () => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-raw-fastput-"));
+  const localPath = path.join(tempRoot, "raw.bin");
+  await fs.promises.writeFile(localPath, Buffer.from("hello-raw"));
+
+  let sawRawFastPut = false;
+  const channel = {
+    readdir(_p, cb) { cb(null, []); },
+    mkdir(_p, cb) { cb(null); },
+    unlink(_p, cb) { cb(null); },
+    stat(_p, cb) {
+      const err = new Error("ENOENT");
+      err.code = 2;
+      cb(err);
+    },
+    fastPut(local, remote, _opts, callback) {
+      sawRawFastPut = local === localPath && remote === "/tmp/out.bin";
+      queueMicrotask(() => callback(null));
+    },
+  };
+  // Bare client with only raw channel.fastPut (no high-level client.fastPut).
+  const bareClient = {
+    sftp: channel,
+    client: {
+      sftp(cb) {
+        cb(null, channel);
+      },
+    },
+  };
+
+  sftpBridge.init({
+    electronModule: {},
+    sessions: new Map(),
+    sftpClients: new Map(),
+  });
+
+  await sftpBridge.pipelinedUploadLocalFile(bareClient, localPath, "/tmp/out.bin", {
+    concurrency: UPLOAD_TRANSFER_CONCURRENCY,
+    chunkSize: TRANSFER_CHUNK_SIZE,
+  });
+  assert.equal(sawRawFastPut, true);
+
+  await fs.promises.rm(tempRoot, { recursive: true, force: true });
+});

--- a/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
+++ b/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
@@ -21,9 +21,11 @@ const {
   UPLOAD_TRANSFER_CONCURRENCY,
 } = require("./transferLimits.cjs");
 
-function createSessionChannel() {
+function createSessionChannel(options = {}) {
   const fastPutCalls = [];
   const remoteFiles = new Map();
+  const remoteMeta = new Map(); // path -> { mode, isSymlink }
+  const chmodCalls = [];
   const channel = {
     // hasSftpChannelApi requires these four methods.
     readdir(_targetPath, callback) {
@@ -34,6 +36,7 @@ function createSessionChannel() {
     },
     unlink(targetPath, callback) {
       remoteFiles.delete(targetPath);
+      remoteMeta.delete(targetPath);
       callback(null);
     },
     stat(targetPath, callback) {
@@ -44,24 +47,54 @@ function createSessionChannel() {
         callback(err);
         return;
       }
+      const meta = remoteMeta.get(targetPath) || {};
       callback(null, {
         size: data.length,
+        mode: meta.mode ?? 0o100644,
         isDirectory: () => false,
         isFile: () => true,
+        isSymbolicLink: () => !!meta.isSymlink,
       });
     },
-    fastPut(localPath, remotePath, options, callback) {
+    lstat(targetPath, callback) {
+      const meta = remoteMeta.get(targetPath);
+      const data = remoteFiles.get(targetPath);
+      if (!data && !meta) {
+        const err = new Error(`ENOENT ${targetPath}`);
+        err.code = 2;
+        callback(err);
+        return;
+      }
+      callback(null, {
+        size: data ? data.length : 0,
+        mode: meta?.isSymlink ? 0o120777 : (meta?.mode ?? 0o100644),
+        isDirectory: () => false,
+        isFile: () => !meta?.isSymlink,
+        isSymbolicLink: () => !!meta?.isSymlink,
+      });
+    },
+    fastPut(localPath, remotePath, opts, callback) {
       fastPutCalls.push({
         localPath,
         remotePath,
-        concurrency: options?.concurrency,
-        chunkSize: options?.chunkSize,
+        concurrency: opts?.concurrency,
+        chunkSize: opts?.chunkSize,
       });
+      if (typeof options.onFastPut === "function") {
+        const intercept = options.onFastPut(localPath, remotePath);
+        if (intercept?.error) {
+          queueMicrotask(() => callback(intercept.error));
+          return;
+        }
+      }
       try {
         const data = fs.readFileSync(localPath);
         remoteFiles.set(remotePath, data);
-        if (typeof options?.step === "function") {
-          options.step(data.length, data.length, data.length);
+        if (!remoteMeta.has(remotePath)) {
+          remoteMeta.set(remotePath, { mode: 0o100644 });
+        }
+        if (typeof opts?.step === "function") {
+          opts.step(data.length, data.length, data.length);
         }
         queueMicrotask(() => callback(null));
       } catch (err) {
@@ -77,11 +110,23 @@ function createSessionChannel() {
       }
       remoteFiles.set(to, remoteFiles.get(from));
       remoteFiles.delete(from);
+      // Rename creates a new name; do not inherit destination mode automatically
+      // so restoreRemoteMode can re-apply the captured bits.
+      if (!remoteMeta.has(to)) {
+        remoteMeta.set(to, { mode: 0o100644 });
+      }
+      remoteMeta.delete(from);
+      callback(null);
+    },
+    chmod(targetPath, mode, callback) {
+      chmodCalls.push({ targetPath, mode });
+      const prev = remoteMeta.get(targetPath) || {};
+      remoteMeta.set(targetPath, { ...prev, mode });
       callback(null);
     },
     end() {},
   };
-  return { channel, fastPutCalls, remoteFiles };
+  return { channel, fastPutCalls, remoteFiles, remoteMeta, chmodCalls };
 }
 
 test("session-backed uploadLocalToSftp uses pipelined fastPut on the raw SFTP channel", async (t) => {
@@ -198,6 +243,142 @@ test("session-backed writeSftpBinaryWithProgress uses pipelined fastPut", async 
   assert.notEqual(fastPutCalls[0].remotePath, "/home/alice/mem.bin");
   assert.ok(remoteFiles.has("/home/alice/mem.bin"));
   assert.deepEqual(remoteFiles.get("/home/alice/mem.bin"), payload);
+});
+
+test("staged overwrite restores previous remote mode bits", async (t) => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-mode-restore-"));
+  t.after(async () => {
+    await fs.promises.rm(tempRoot, { recursive: true, force: true });
+  });
+  tempDirBridge.init?.({ getPath: () => tempRoot });
+
+  const localPath = path.join(tempRoot, "exec.bin");
+  const payload = Buffer.from("#!/bin/sh\necho hi\n");
+  await fs.promises.writeFile(localPath, payload);
+
+  const { channel, remoteFiles, remoteMeta, chmodCalls } = createSessionChannel();
+  remoteFiles.set("/usr/local/bin/tool", Buffer.from("old"));
+  remoteMeta.set("/usr/local/bin/tool", { mode: 0o100755 });
+
+  const connection = {
+    sftp(callback) { callback(null, channel); },
+  };
+  const sftpClients = new Map();
+  sftpBridge.init({
+    electronModule: { webContents: { fromId: () => null } },
+    sessions: new Map([["session-mode", { conn: connection }]]),
+    sftpClients,
+  });
+  const opened = await sftpBridge.openSftpForSession(null, {
+    sessionId: "session-mode",
+    fileProtocol: "sftp",
+  });
+
+  await sftpBridge.uploadLocalToSftp(null, {
+    sftpId: opened.sftpId,
+    localPath,
+    remotePath: "/usr/local/bin/tool",
+    encoding: "utf-8",
+  });
+
+  assert.ok(remoteFiles.has("/usr/local/bin/tool"));
+  assert.deepEqual(remoteFiles.get("/usr/local/bin/tool"), payload);
+  assert.ok(
+    chmodCalls.some((c) => c.targetPath === "/usr/local/bin/tool" && (c.mode & 0o777) === 0o755),
+    `expected mode restore via chmod, got ${JSON.stringify(chmodCalls)}`,
+  );
+});
+
+test("symlink destinations are written in-place (not replaced by rename)", async (t) => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-symlink-upload-"));
+  t.after(async () => {
+    await fs.promises.rm(tempRoot, { recursive: true, force: true });
+  });
+  tempDirBridge.init?.({ getPath: () => tempRoot });
+
+  const localPath = path.join(tempRoot, "cfg.json");
+  const payload = Buffer.from('{"ok":true}');
+  await fs.promises.writeFile(localPath, payload);
+
+  const { channel, fastPutCalls, remoteFiles, remoteMeta } = createSessionChannel();
+  // Symlink at the destination path; real content elsewhere.
+  remoteMeta.set("/etc/app/config.json", { isSymlink: true, mode: 0o120777 });
+  remoteFiles.set("/etc/app/config.json", Buffer.from("link-placeholder"));
+
+  const connection = {
+    sftp(callback) { callback(null, channel); },
+  };
+  const sftpClients = new Map();
+  sftpBridge.init({
+    electronModule: { webContents: { fromId: () => null } },
+    sessions: new Map([["session-link", { conn: connection }]]),
+    sftpClients,
+  });
+  const opened = await sftpBridge.openSftpForSession(null, {
+    sessionId: "session-link",
+    fileProtocol: "sftp",
+  });
+
+  await sftpBridge.uploadLocalToSftp(null, {
+    sftpId: opened.sftpId,
+    localPath,
+    remotePath: "/etc/app/config.json",
+    encoding: "utf-8",
+  });
+
+  assert.equal(fastPutCalls.length, 1);
+  assert.equal(fastPutCalls[0].remotePath, "/etc/app/config.json");
+  assert.deepEqual(remoteFiles.get("/etc/app/config.json"), payload);
+});
+
+test("parent-dir permission on staged path falls back to in-place overwrite", async (t) => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-stage-perm-"));
+  t.after(async () => {
+    await fs.promises.rm(tempRoot, { recursive: true, force: true });
+  });
+  tempDirBridge.init?.({ getPath: () => tempRoot });
+
+  const localPath = path.join(tempRoot, "data.bin");
+  const payload = Buffer.from("new-content");
+  await fs.promises.writeFile(localPath, payload);
+
+  const { channel, fastPutCalls, remoteFiles, remoteMeta } = createSessionChannel({
+    onFastPut(_local, remotePath) {
+      if (String(remotePath).includes(".part") || String(remotePath).includes(".netcatty-upload-")) {
+        const err = new Error("Permission denied");
+        err.code = 3;
+        return { error: err };
+      }
+      return null;
+    },
+  });
+  remoteFiles.set("/ro-dir/file.bin", Buffer.from("old"));
+  remoteMeta.set("/ro-dir/file.bin", { mode: 0o100644 });
+
+  const connection = {
+    sftp(callback) { callback(null, channel); },
+  };
+  const sftpClients = new Map();
+  sftpBridge.init({
+    electronModule: { webContents: { fromId: () => null } },
+    sessions: new Map([["session-perm", { conn: connection }]]),
+    sftpClients,
+  });
+  const opened = await sftpBridge.openSftpForSession(null, {
+    sessionId: "session-perm",
+    fileProtocol: "sftp",
+  });
+
+  await sftpBridge.uploadLocalToSftp(null, {
+    sftpId: opened.sftpId,
+    localPath,
+    remotePath: "/ro-dir/file.bin",
+    encoding: "utf-8",
+  });
+
+  assert.ok(fastPutCalls.length >= 2, "expected staged attempt then in-place");
+  assert.equal(fastPutCalls[fastPutCalls.length - 1].remotePath, "/ro-dir/file.bin");
+  assert.deepEqual(remoteFiles.get("/ro-dir/file.bin"), payload);
 });
 
 test("pipelinedUploadLocalFile aborts in-flight fastPut when AbortSignal fires", async () => {

--- a/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
+++ b/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
@@ -193,6 +193,9 @@ test("session-backed writeSftpBinaryWithProgress uses pipelined fastPut", async 
   assert.equal(fastPutCalls.length, 1);
   assert.equal(fastPutCalls[0].concurrency, UPLOAD_TRANSFER_CONCURRENCY);
   assert.equal(fastPutCalls[0].chunkSize, TRANSFER_CHUNK_SIZE);
+  // Upload must stage to a remote .part path, not write the final path directly.
+  assert.match(fastPutCalls[0].remotePath, /\.part$/);
+  assert.notEqual(fastPutCalls[0].remotePath, "/home/alice/mem.bin");
   assert.ok(remoteFiles.has("/home/alice/mem.bin"));
   assert.deepEqual(remoteFiles.get("/home/alice/mem.bin"), payload);
 });
@@ -274,10 +277,14 @@ test("shared-channel fastPut cancel force-settles when callback stalls", async (
   await fs.promises.writeFile(localPath, Buffer.alloc(8 * 1024, 5));
 
   let ended = false;
+  let unlinkedPath = null;
   const channel = {
     readdir(_p, cb) { cb(null, []); },
     mkdir(_p, cb) { cb(null); },
-    unlink(_p, cb) { cb(null); },
+    unlink(targetPath, cb) {
+      unlinkedPath = targetPath;
+      cb(null);
+    },
     stat(_p, cb) {
       const err = new Error("ENOENT");
       err.code = 2;
@@ -324,6 +331,8 @@ test("shared-channel fastPut cancel force-settles when callback stalls", async (
   assert.ok(elapsed < 5000, `cancel took too long: ${elapsed}ms`);
   // Shared channel must not be ended (would kill browse/sudo session).
   assert.equal(ended, false);
+  // Force-settle best-effort unlinks the in-progress remote target.
+  assert.equal(unlinkedPath, "/tmp/stall-out.bin");
 
   await fs.promises.rm(tempRoot, { recursive: true, force: true });
 });

--- a/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
+++ b/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
@@ -267,6 +267,66 @@ test("pipelinedUploadLocalFile aborts in-flight fastPut when AbortSignal fires",
   await fs.promises.rm(tempRoot, { recursive: true, force: true });
 });
 
+test("shared-channel fastPut cancel force-settles when callback stalls", async () => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-shared-abort-bound-"));
+  const localPath = path.join(tempRoot, "stall.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(8 * 1024, 5));
+
+  let ended = false;
+  const channel = {
+    readdir(_p, cb) { cb(null, []); },
+    mkdir(_p, cb) { cb(null); },
+    unlink(_p, cb) { cb(null); },
+    stat(_p, cb) {
+      const err = new Error("ENOENT");
+      err.code = 2;
+      cb(err);
+    },
+    // Never invoke the callback — simulates a stalled shared-channel fastPut.
+    fastPut() {},
+    end() {
+      ended = true;
+    },
+  };
+  // No client.sftp() for a second channel → acquireUpload uses shared channel.
+  const sharedOnlyClient = {
+    __netcattySudoMode: true,
+    sftp: channel,
+    client: null,
+  };
+
+  sftpBridge.init({
+    electronModule: {},
+    sessions: new Map(),
+    sftpClients: new Map(),
+  });
+
+  const controller = new AbortController();
+  const uploadPromise = sftpBridge.pipelinedUploadLocalFile(
+    sharedOnlyClient,
+    localPath,
+    "/tmp/stall-out.bin",
+    {
+      concurrency: UPLOAD_TRANSFER_CONCURRENCY,
+      chunkSize: TRANSFER_CHUNK_SIZE,
+      signal: controller.signal,
+    },
+  );
+
+  await new Promise((r) => setImmediate(r));
+  controller.abort();
+
+  const started = Date.now();
+  await assert.rejects(uploadPromise, /abort|cancel/i);
+  const elapsed = Date.now() - started;
+  // Must settle via the 2s force-finish path, not hang forever.
+  assert.ok(elapsed < 5000, `cancel took too long: ${elapsed}ms`);
+  // Shared channel must not be ended (would kill browse/sudo session).
+  assert.equal(ended, false);
+
+  await fs.promises.rm(tempRoot, { recursive: true, force: true });
+});
+
 test("pipelinedUploadLocalFile falls back to raw sftp.fastPut when client.fastPut is missing", async () => {
   const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-raw-fastput-"));
   const localPath = path.join(tempRoot, "raw.bin");

--- a/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
+++ b/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
@@ -108,13 +108,10 @@ function createSessionChannel(options = {}) {
         callback(err);
         return;
       }
+      const sourceMeta = remoteMeta.get(from);
       remoteFiles.set(to, remoteFiles.get(from));
       remoteFiles.delete(from);
-      // Rename creates a new name; do not inherit destination mode automatically
-      // so restoreRemoteMode can re-apply the captured bits.
-      if (!remoteMeta.has(to)) {
-        remoteMeta.set(to, { mode: 0o100644 });
-      }
+      remoteMeta.set(to, sourceMeta || { mode: 0o100644 });
       remoteMeta.delete(from);
       callback(null);
     },
@@ -287,9 +284,259 @@ test("existing destinations stage then restore mode after rename", async (t) => 
   assert.deepEqual(remoteFiles.get("/usr/local/bin/tool"), payload);
   // Stage+rename replaces the inode; restore prior mode bits afterwards.
   assert.ok(
-    chmodCalls.some((c) => c.targetPath === "/usr/local/bin/tool" && (c.mode & 0o777) === 0o755),
+    chmodCalls.some((c) => String(c.targetPath).includes(".netcatty-upload-") && (c.mode & 0o777) === 0o755),
     `expected mode restore via chmod, got ${JSON.stringify(chmodCalls)}`,
   );
+  assert.equal(remoteMeta.get("/usr/local/bin/tool")?.mode & 0o777, 0o755);
+});
+
+test("mode restore failure leaves the existing destination untouched", async (t) => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-stage-mode-fail-"));
+  t.after(async () => {
+    await fs.promises.rm(tempRoot, { recursive: true, force: true });
+  });
+  tempDirBridge.init?.({ getPath: () => tempRoot });
+
+  const localPath = path.join(tempRoot, "tool");
+  await fs.promises.writeFile(localPath, Buffer.from("new-tool"));
+  const { channel, remoteFiles, remoteMeta } = createSessionChannel();
+  remoteFiles.set("/usr/local/bin/tool", Buffer.from("old-tool"));
+  remoteMeta.set("/usr/local/bin/tool", { mode: 0o100755 });
+  channel.chmod = (_targetPath, _mode, callback) => {
+    const err = new Error("chmod failed");
+    err.code = "EIO";
+    callback(err);
+  };
+
+  const sftpClients = new Map();
+  sftpBridge.init({
+    electronModule: { webContents: { fromId: () => null } },
+    sessions: new Map([["session-mode-fail", { conn: { sftp: (cb) => cb(null, channel) } }]]),
+    sftpClients,
+  });
+  const opened = await sftpBridge.openSftpForSession(null, {
+    sessionId: "session-mode-fail",
+    fileProtocol: "sftp",
+  });
+
+  await assert.rejects(
+    () => sftpBridge.uploadLocalToSftp(null, {
+      sftpId: opened.sftpId,
+      localPath,
+      remotePath: "/usr/local/bin/tool",
+      encoding: "utf-8",
+    }),
+    /chmod failed/,
+  );
+  assert.deepEqual(remoteFiles.get("/usr/local/bin/tool"), Buffer.from("old-tool"));
+  assert.equal(
+    [...remoteFiles.keys()].some((key) => String(key).includes(".netcatty-upload-")),
+    false,
+  );
+});
+
+test("failed promotion and failed restore preserve both recovery files", async (t) => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-stage-restore-fail-"));
+  t.after(async () => {
+    await fs.promises.rm(tempRoot, { recursive: true, force: true });
+  });
+  tempDirBridge.init?.({ getPath: () => tempRoot });
+
+  const localPath = path.join(tempRoot, "data.bin");
+  await fs.promises.writeFile(localPath, Buffer.from("new-data"));
+  const { channel, remoteFiles, remoteMeta } = createSessionChannel();
+  const finalPath = "/tmp/data.bin";
+  remoteFiles.set(finalPath, Buffer.from("old-data"));
+  remoteMeta.set(finalPath, { mode: 0o100644 });
+  const originalRename = channel.rename.bind(channel);
+  let stagePromoteAttempts = 0;
+  channel.rename = (from, to, callback) => {
+    const fromString = String(from);
+    const toString = String(to);
+    if (fromString.includes(".netcatty-upload-") && toString === finalPath) {
+      stagePromoteAttempts += 1;
+      callback(new Error("stage promote failed"));
+      return;
+    }
+    if (fromString.includes(".netcatty-backup-") && toString === finalPath) {
+      callback(new Error("backup restore failed"));
+      return;
+    }
+    originalRename(from, to, callback);
+  };
+
+  const sftpClients = new Map();
+  sftpBridge.init({
+    electronModule: { webContents: { fromId: () => null } },
+    sessions: new Map([["session-restore-fail", { conn: { sftp: (cb) => cb(null, channel) } }]]),
+    sftpClients,
+  });
+  const opened = await sftpBridge.openSftpForSession(null, {
+    sessionId: "session-restore-fail",
+    fileProtocol: "sftp",
+  });
+
+  await assert.rejects(
+    () => sftpBridge.uploadLocalToSftp(null, {
+      sftpId: opened.sftpId,
+      localPath,
+      remotePath: finalPath,
+      encoding: "utf-8",
+    }),
+    /could not be restored/,
+  );
+  assert.ok(stagePromoteAttempts >= 2);
+  assert.equal(remoteFiles.has(finalPath), false);
+  assert.ok(
+    [...remoteFiles.entries()].some(([key, value]) => String(key).includes(".netcatty-upload-") && value.equals(Buffer.from("new-data"))),
+  );
+  assert.ok(
+    [...remoteFiles.entries()].some(([key, value]) => String(key).includes(".netcatty-backup-") && value.equals(Buffer.from("old-data"))),
+  );
+});
+
+test("rename fallback replaces safely and restores the old target on promotion failure", async () => {
+  const makeClient = ({ failEveryStagePromotion = false } = {}) => {
+    const files = new Map([
+      ["/tmp/stage", Buffer.from("new")],
+      ["/tmp/final", Buffer.from("old")],
+    ]);
+    let stagePromotionAttempts = 0;
+    const channel = {
+      readdir(_path, cb) { cb(null, []); },
+      mkdir(_path, cb) { cb(null); },
+      unlink(targetPath, cb) { files.delete(targetPath); cb(null); },
+      stat(targetPath, cb) {
+        if (!files.has(targetPath)) {
+          const err = new Error("ENOENT");
+          err.code = 2;
+          cb(err);
+          return;
+        }
+        cb(null, { size: files.get(targetPath).length, isDirectory: false });
+      },
+    };
+    return {
+      files,
+      client: {
+        sftp: channel,
+        async stat(targetPath) {
+          return { size: files.get(targetPath)?.length || 0, isDirectory: false };
+        },
+        async rename(from, to) {
+          if (from === "/tmp/stage" && to === "/tmp/final") {
+            stagePromotionAttempts += 1;
+            if (stagePromotionAttempts === 1 || failEveryStagePromotion) {
+              throw new Error("overwrite unsupported");
+            }
+          }
+          if (!files.has(from)) throw new Error("ENOENT");
+          files.set(to, files.get(from));
+          files.delete(from);
+        },
+        async delete(targetPath) {
+          files.delete(targetPath);
+        },
+      },
+    };
+  };
+
+  const successful = makeClient();
+  await sftpBridge._renameRemotePathForTests(
+    successful.client,
+    "/tmp/stage",
+    "/tmp/final",
+    "/tmp/backup",
+  );
+  assert.deepEqual(successful.files.get("/tmp/final"), Buffer.from("new"));
+  assert.equal(successful.files.has("/tmp/backup"), false);
+
+  const restored = makeClient({ failEveryStagePromotion: true });
+  await assert.rejects(
+    () => sftpBridge._renameRemotePathForTests(
+      restored.client,
+      "/tmp/stage",
+      "/tmp/final",
+      "/tmp/backup",
+    ),
+    /overwrite unsupported/,
+  );
+  assert.deepEqual(restored.files.get("/tmp/final"), Buffer.from("old"));
+  assert.deepEqual(restored.files.get("/tmp/stage"), Buffer.from("new"));
+  assert.equal(restored.files.has("/tmp/backup"), false);
+});
+
+test("SCP upload stops when the destination type cannot be inspected", async () => {
+  let uploadCalls = 0;
+  const backend = {
+    async stat() {
+      throw new Error("temporary stat failure");
+    },
+    async uploadFile() {
+      uploadCalls += 1;
+    },
+  };
+  const client = {
+    __netcattyFileProtocol: "scp",
+    __netcattyScpBackend: backend,
+  };
+  sftpBridge.init({
+    electronModule: {},
+    sessions: new Map(),
+    sftpClients: new Map([["scp-stat-fail", client]]),
+  });
+
+  await assert.rejects(
+    () => sftpBridge.uploadLocalToSftp(null, {
+      sftpId: "scp-stat-fail",
+      localPath: "/tmp/local.bin",
+      remotePath: "/tmp/remote.bin",
+      encoding: "utf-8",
+    }),
+    /temporary stat failure/,
+  );
+  assert.equal(uploadCalls, 0);
+});
+
+test("SCP upload does not replace a symlink that appears before promotion", async () => {
+  let statCalls = 0;
+  let renameCalls = 0;
+  let removedStage = false;
+  const backend = {
+    async stat() {
+      statCalls += 1;
+      if (statCalls === 1) return { type: "file", isDirectory: false };
+      return { type: "symlink", isDirectory: false, isSymbolicLink: true };
+    },
+    async uploadFile() {},
+    async rename() {
+      renameCalls += 1;
+    },
+    async remove(remotePath) {
+      if (String(remotePath).includes(".netcatty-upload-")) removedStage = true;
+    },
+  };
+  const client = {
+    __netcattyFileProtocol: "scp",
+    __netcattyScpBackend: backend,
+  };
+  sftpBridge.init({
+    electronModule: {},
+    sessions: new Map(),
+    sftpClients: new Map([["scp-symlink-race", client]]),
+  });
+
+  await assert.rejects(
+    () => sftpBridge.uploadLocalToSftp(null, {
+      sftpId: "scp-symlink-race",
+      localPath: "/tmp/local.bin",
+      remotePath: "/tmp/remote.bin",
+      encoding: "utf-8",
+    }),
+    /changed to a symlink/,
+  );
+  assert.equal(renameCalls, 0);
+  assert.equal(removedStage, true);
 });
 
 test("staged basenames stay within the remote NAME_MAX budget", async (t) => {

--- a/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
+++ b/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
@@ -423,6 +423,68 @@ test("parent-dir permission on staged path falls back to in-place for new files"
   assert.deepEqual(remoteFiles.get("/ro-dir/file.bin"), payload);
 });
 
+test("late abort during staged size verify does not promote .part", async (t) => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-late-abort-promote-"));
+  t.after(async () => {
+    await fs.promises.rm(tempRoot, { recursive: true, force: true });
+  });
+  tempDirBridge.init?.({ getPath: () => tempRoot });
+
+  const localPath = path.join(tempRoot, "payload.bin");
+  const payload = Buffer.from("late-abort-payload");
+  await fs.promises.writeFile(localPath, payload);
+
+  const { channel, fastPutCalls, remoteFiles } = createSessionChannel();
+  const controller = new AbortController();
+  let renameCalled = false;
+  const origStat = channel.stat.bind(channel);
+  const origRename = channel.rename.bind(channel);
+  channel.stat = (targetPath, callback) => {
+    if (String(targetPath).includes(".netcatty-upload-")) {
+      // Abort while size verification is in flight so the post-stat check must
+      // block promotion (throwIfAborted after await client.stat).
+      controller.abort();
+      queueMicrotask(() => origStat(targetPath, callback));
+      return;
+    }
+    return origStat(targetPath, callback);
+  };
+  channel.rename = (from, to, callback) => {
+    renameCalled = true;
+    return origRename(from, to, callback);
+  };
+
+  const connection = {
+    sftp(callback) { callback(null, channel); },
+  };
+  const sftpClients = new Map();
+  sftpBridge.init({
+    electronModule: { webContents: { fromId: () => null } },
+    sessions: new Map([["session-late-abort", { conn: connection }]]),
+    sftpClients,
+  });
+  const opened = await sftpBridge.openSftpForSession(null, {
+    sessionId: "session-late-abort",
+    fileProtocol: "sftp",
+  });
+
+  await assert.rejects(
+    () => sftpBridge.uploadLocalToSftp(null, {
+      sftpId: opened.sftpId,
+      localPath,
+      remotePath: "/tmp/late-abort.bin",
+      encoding: "utf-8",
+      abortSignal: controller.signal,
+    }),
+    /abort|cancel/i,
+  );
+
+  assert.equal(fastPutCalls.length, 1);
+  assert.match(fastPutCalls[0].remotePath, /\.netcatty-upload-.*\.part$/);
+  assert.equal(renameCalled, false);
+  assert.equal(remoteFiles.has("/tmp/late-abort.bin"), false);
+});
+
 test("size-mismatch on path containing 'access' does not fall back to in-place", async (t) => {
   const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-access-name-"));
   t.after(async () => {

--- a/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
+++ b/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
@@ -238,15 +238,15 @@ test("session-backed writeSftpBinaryWithProgress uses pipelined fastPut", async 
   assert.equal(fastPutCalls.length, 1);
   assert.equal(fastPutCalls[0].concurrency, UPLOAD_TRANSFER_CONCURRENCY);
   assert.equal(fastPutCalls[0].chunkSize, TRANSFER_CHUNK_SIZE);
-  // Upload must stage to a remote .part path, not write the final path directly.
-  assert.match(fastPutCalls[0].remotePath, /\.part$/);
+  // New destinations stage to a remote .part path, then rename into place.
+  assert.match(fastPutCalls[0].remotePath, /\.netcatty-upload-.*\.part$/);
   assert.notEqual(fastPutCalls[0].remotePath, "/home/alice/mem.bin");
   assert.ok(remoteFiles.has("/home/alice/mem.bin"));
   assert.deepEqual(remoteFiles.get("/home/alice/mem.bin"), payload);
 });
 
-test("staged overwrite restores previous remote mode bits", async (t) => {
-  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-mode-restore-"));
+test("existing destinations overwrite in-place to preserve metadata", async (t) => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-inplace-meta-"));
   t.after(async () => {
     await fs.promises.rm(tempRoot, { recursive: true, force: true });
   });
@@ -256,7 +256,7 @@ test("staged overwrite restores previous remote mode bits", async (t) => {
   const payload = Buffer.from("#!/bin/sh\necho hi\n");
   await fs.promises.writeFile(localPath, payload);
 
-  const { channel, remoteFiles, remoteMeta, chmodCalls } = createSessionChannel();
+  const { channel, fastPutCalls, remoteFiles, remoteMeta, chmodCalls } = createSessionChannel();
   remoteFiles.set("/usr/local/bin/tool", Buffer.from("old"));
   remoteMeta.set("/usr/local/bin/tool", { mode: 0o100755 });
 
@@ -281,12 +281,13 @@ test("staged overwrite restores previous remote mode bits", async (t) => {
     encoding: "utf-8",
   });
 
+  assert.equal(fastPutCalls.length, 1);
+  assert.equal(fastPutCalls[0].remotePath, "/usr/local/bin/tool");
   assert.ok(remoteFiles.has("/usr/local/bin/tool"));
   assert.deepEqual(remoteFiles.get("/usr/local/bin/tool"), payload);
-  assert.ok(
-    chmodCalls.some((c) => c.targetPath === "/usr/local/bin/tool" && (c.mode & 0o777) === 0o755),
-    `expected mode restore via chmod, got ${JSON.stringify(chmodCalls)}`,
-  );
+  // In-place overwrite should not need a post-rename chmod restore.
+  assert.equal(chmodCalls.length, 0);
+  assert.equal(remoteMeta.get("/usr/local/bin/tool")?.mode, 0o100755);
 });
 
 test("symlink destinations are written in-place (not replaced by rename)", async (t) => {
@@ -331,7 +332,7 @@ test("symlink destinations are written in-place (not replaced by rename)", async
   assert.deepEqual(remoteFiles.get("/etc/app/config.json"), payload);
 });
 
-test("parent-dir permission on staged path falls back to in-place overwrite", async (t) => {
+test("parent-dir permission on staged path falls back to in-place for new files", async (t) => {
   const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-stage-perm-"));
   t.after(async () => {
     await fs.promises.rm(tempRoot, { recursive: true, force: true });
@@ -342,9 +343,9 @@ test("parent-dir permission on staged path falls back to in-place overwrite", as
   const payload = Buffer.from("new-content");
   await fs.promises.writeFile(localPath, payload);
 
-  const { channel, fastPutCalls, remoteFiles, remoteMeta } = createSessionChannel({
+  const { channel, fastPutCalls, remoteFiles } = createSessionChannel({
     onFastPut(_local, remotePath) {
-      if (String(remotePath).includes(".part") || String(remotePath).includes(".netcatty-upload-")) {
+      if (String(remotePath).includes(".netcatty-upload-")) {
         const err = new Error("Permission denied");
         err.code = 3;
         return { error: err };
@@ -352,8 +353,7 @@ test("parent-dir permission on staged path falls back to in-place overwrite", as
       return null;
     },
   });
-  remoteFiles.set("/ro-dir/file.bin", Buffer.from("old"));
-  remoteMeta.set("/ro-dir/file.bin", { mode: 0o100644 });
+  // Destination does not exist → staging is attempted first.
 
   const connection = {
     sftp(callback) { callback(null, channel); },
@@ -377,6 +377,7 @@ test("parent-dir permission on staged path falls back to in-place overwrite", as
   });
 
   assert.ok(fastPutCalls.length >= 2, "expected staged attempt then in-place");
+  assert.match(fastPutCalls[0].remotePath, /\.netcatty-upload-.*\.part$/);
   assert.equal(fastPutCalls[fastPutCalls.length - 1].remotePath, "/ro-dir/file.bin");
   assert.deepEqual(remoteFiles.get("/ro-dir/file.bin"), payload);
 });
@@ -512,8 +513,62 @@ test("shared-channel fastPut cancel force-settles when callback stalls", async (
   assert.ok(elapsed < 5000, `cancel took too long: ${elapsed}ms`);
   // Shared channel must not be ended (would kill browse/sudo session).
   assert.equal(ended, false);
-  // Force-settle best-effort unlinks the in-progress remote target.
-  assert.equal(unlinkedPath, "/tmp/stall-out.bin");
+  // Final destinations must not be unlinked on shared-channel force-settle.
+  assert.equal(unlinkedPath, null);
+
+  await fs.promises.rm(tempRoot, { recursive: true, force: true });
+});
+
+test("shared-channel force-settle unlinks only Netcatty staged .part paths", async () => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-shared-stage-unlink-"));
+  const localPath = path.join(tempRoot, "stall.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(4 * 1024, 9));
+
+  let unlinkedPath = null;
+  const channel = {
+    readdir(_p, cb) { cb(null, []); },
+    mkdir(_p, cb) { cb(null); },
+    unlink(targetPath, cb) {
+      unlinkedPath = targetPath;
+      cb(null);
+    },
+    stat(_p, cb) {
+      const err = new Error("ENOENT");
+      err.code = 2;
+      cb(err);
+    },
+    fastPut() {},
+    end() {},
+  };
+  const sharedOnlyClient = {
+    __netcattySudoMode: true,
+    sftp: channel,
+    client: null,
+  };
+
+  sftpBridge.init({
+    electronModule: {},
+    sessions: new Map(),
+    sftpClients: new Map(),
+  });
+
+  const controller = new AbortController();
+  const stagedPath = "/tmp/.netcatty-upload-deadbeef-stall.bin.part";
+  const uploadPromise = sftpBridge.pipelinedUploadLocalFile(
+    sharedOnlyClient,
+    localPath,
+    stagedPath,
+    {
+      concurrency: UPLOAD_TRANSFER_CONCURRENCY,
+      chunkSize: TRANSFER_CHUNK_SIZE,
+      signal: controller.signal,
+    },
+  );
+
+  await new Promise((r) => setImmediate(r));
+  controller.abort();
+  await assert.rejects(uploadPromise, /abort|cancel/i);
+  assert.equal(unlinkedPath, stagedPath);
 
   await fs.promises.rm(tempRoot, { recursive: true, force: true });
 });

--- a/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
+++ b/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
@@ -373,6 +373,52 @@ test("symlink destinations are written in-place (not replaced by rename)", async
   assert.deepEqual(remoteFiles.get("/etc/app/config.json"), payload);
 });
 
+test("lstat unsupported falls back to stat and preserves an existing destination", async (t) => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-lstat-fallback-"));
+  t.after(async () => {
+    await fs.promises.rm(tempRoot, { recursive: true, force: true });
+  });
+  tempDirBridge.init?.({ getPath: () => tempRoot });
+
+  const localPath = path.join(tempRoot, "cfg.json");
+  const payload = Buffer.from('{"fallback":true}');
+  await fs.promises.writeFile(localPath, payload);
+
+  const { channel, fastPutCalls, remoteFiles, remoteMeta } = createSessionChannel();
+  remoteFiles.set("/etc/app/config.json", Buffer.from("old-target-content"));
+  remoteMeta.set("/etc/app/config.json", { isSymlink: true, mode: 0o120777 });
+  channel.lstat = (_targetPath, callback) => {
+    const err = new Error("SSH_FX_OP_UNSUPPORTED");
+    err.code = 8;
+    callback(err);
+  };
+
+  const connection = {
+    sftp(callback) { callback(null, channel); },
+  };
+  const sftpClients = new Map();
+  sftpBridge.init({
+    electronModule: { webContents: { fromId: () => null } },
+    sessions: new Map([["session-lstat-fallback", { conn: connection }]]),
+    sftpClients,
+  });
+  const opened = await sftpBridge.openSftpForSession(null, {
+    sessionId: "session-lstat-fallback",
+    fileProtocol: "sftp",
+  });
+
+  await sftpBridge.uploadLocalToSftp(null, {
+    sftpId: opened.sftpId,
+    localPath,
+    remotePath: "/etc/app/config.json",
+    encoding: "utf-8",
+  });
+
+  assert.equal(fastPutCalls.length, 1);
+  assert.equal(fastPutCalls[0].remotePath, "/etc/app/config.json");
+  assert.deepEqual(remoteFiles.get("/etc/app/config.json"), payload);
+});
+
 test("parent-dir permission on staged path falls back to in-place for new files", async (t) => {
   const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-stage-perm-"));
   t.after(async () => {

--- a/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
+++ b/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
@@ -196,6 +196,77 @@ test("session-backed writeSftpBinaryWithProgress uses pipelined fastPut", async 
   assert.deepEqual(remoteFiles.get("/home/alice/mem.bin"), payload);
 });
 
+test("pipelinedUploadLocalFile aborts in-flight fastPut when AbortSignal fires", async () => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-abort-fastput-"));
+  const localPath = path.join(tempRoot, "abort.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(64 * 1024, 3));
+
+  let ended = false;
+  let fastPutStarted = false;
+  const channel = {
+    readdir(_p, cb) { cb(null, []); },
+    mkdir(_p, cb) { cb(null); },
+    unlink(_p, cb) { cb(null); },
+    stat(_p, cb) {
+      const err = new Error("ENOENT");
+      err.code = 2;
+      cb(err);
+    },
+    fastPut(_local, _remote, _opts, callback) {
+      fastPutStarted = true;
+      // Stay pending until end() cancels the transfer.
+      this._pendingCallback = callback;
+    },
+    end() {
+      ended = true;
+      const cb = this._pendingCallback;
+      this._pendingCallback = null;
+      if (typeof cb === "function") {
+        const err = new Error("SFTP channel closed");
+        queueMicrotask(() => cb(err));
+      }
+    },
+  };
+  const bareClient = {
+    __netcattySessionBacked: true,
+    sftp: null,
+    client: {
+      sftp(cb) {
+        cb(null, channel);
+      },
+    },
+  };
+
+  sftpBridge.init({
+    electronModule: {},
+    sessions: new Map(),
+    sftpClients: new Map(),
+  });
+
+  const controller = new AbortController();
+  const uploadPromise = sftpBridge.pipelinedUploadLocalFile(
+    bareClient,
+    localPath,
+    "/tmp/abort-out.bin",
+    {
+      concurrency: UPLOAD_TRANSFER_CONCURRENCY,
+      chunkSize: TRANSFER_CHUNK_SIZE,
+      signal: controller.signal,
+    },
+  );
+
+  // Allow fastPut to start, then abort.
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setTimeout(r, 20));
+  assert.equal(fastPutStarted, true);
+  controller.abort();
+
+  await assert.rejects(uploadPromise, /abort|cancel/i);
+  assert.equal(ended, true);
+
+  await fs.promises.rm(tempRoot, { recursive: true, force: true });
+});
+
 test("pipelinedUploadLocalFile falls back to raw sftp.fastPut when client.fastPut is missing", async () => {
   const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-raw-fastput-"));
   const localPath = path.join(tempRoot, "raw.bin");

--- a/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
+++ b/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
@@ -9,6 +9,7 @@
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -322,6 +323,61 @@ test("shared-channel fastPut cancel force-settles when callback stalls", async (
   // Must settle via the 2s force-finish path, not hang forever.
   assert.ok(elapsed < 5000, `cancel took too long: ${elapsed}ms`);
   // Shared channel must not be ended (would kill browse/sudo session).
+  assert.equal(ended, false);
+
+  await fs.promises.rm(tempRoot, { recursive: true, force: true });
+});
+
+test("shared-channel fastPut error force-settles when callback stalls", async () => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-shared-error-bound-"));
+  const localPath = path.join(tempRoot, "err.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(4 * 1024, 7));
+
+  let ended = false;
+  const channel = new EventEmitter();
+  Object.assign(channel, {
+    readdir(_p, cb) { cb(null, []); },
+    mkdir(_p, cb) { cb(null); },
+    unlink(_p, cb) { cb(null); },
+    stat(_p, cb) {
+      const err = new Error("ENOENT");
+      err.code = 2;
+      cb(err);
+    },
+    // Emit channel error and never invoke the fastPut callback.
+    fastPut() {
+      queueMicrotask(() => channel.emit("error", new Error("channel failed")));
+    },
+    end() {
+      ended = true;
+    },
+  });
+  const sharedOnlyClient = {
+    __netcattySudoMode: true,
+    sftp: channel,
+    client: null,
+  };
+
+  sftpBridge.init({
+    electronModule: {},
+    sessions: new Map(),
+    sftpClients: new Map(),
+  });
+
+  const uploadPromise = sftpBridge.pipelinedUploadLocalFile(
+    sharedOnlyClient,
+    localPath,
+    "/tmp/err-out.bin",
+    {
+      concurrency: UPLOAD_TRANSFER_CONCURRENCY,
+      chunkSize: TRANSFER_CHUNK_SIZE,
+    },
+  );
+
+  const started = Date.now();
+  await assert.rejects(uploadPromise, /channel failed|SFTP channel/i);
+  const elapsed = Date.now() - started;
+  assert.ok(elapsed < 5000, `error settle took too long: ${elapsed}ms`);
   assert.equal(ended, false);
 
   await fs.promises.rm(tempRoot, { recursive: true, force: true });

--- a/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
+++ b/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
@@ -725,7 +725,7 @@ test("shared-channel fastPut cancel force-settles when callback stalls", async (
   await fs.promises.rm(tempRoot, { recursive: true, force: true });
 });
 
-test("shared-channel force-settle unlinks only Netcatty staged .part paths", async () => {
+test("shared-channel force-settle unlinks explicitly generated stage paths", async () => {
   const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-shared-stage-unlink-"));
   const localPath = path.join(tempRoot, "stall.bin");
   await fs.promises.writeFile(localPath, Buffer.alloc(4 * 1024, 9));
@@ -768,6 +768,7 @@ test("shared-channel force-settle unlinks only Netcatty staged .part paths", asy
       concurrency: UPLOAD_TRANSFER_CONCURRENCY,
       chunkSize: TRANSFER_CHUNK_SIZE,
       signal: controller.signal,
+      generatedStagePath: true,
     },
   );
 
@@ -775,6 +776,60 @@ test("shared-channel force-settle unlinks only Netcatty staged .part paths", asy
   controller.abort();
   await assert.rejects(uploadPromise, /abort|cancel/i);
   assert.equal(unlinkedPath, stagedPath);
+
+  await fs.promises.rm(tempRoot, { recursive: true, force: true });
+});
+
+test("shared-channel cancel never unlinks a caller path that resembles a stage", async () => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-shared-stage-lookalike-"));
+  const localPath = path.join(tempRoot, "stall.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(4 * 1024, 11));
+
+  let unlinkedPath = null;
+  const channel = {
+    readdir(_p, cb) { cb(null, []); },
+    mkdir(_p, cb) { cb(null); },
+    unlink(targetPath, cb) {
+      unlinkedPath = targetPath;
+      cb(null);
+    },
+    stat(_p, cb) {
+      const err = new Error("ENOENT");
+      err.code = 2;
+      cb(err);
+    },
+    fastPut() {},
+    end() {},
+  };
+  const sharedOnlyClient = {
+    __netcattySudoMode: true,
+    sftp: channel,
+    client: null,
+  };
+
+  sftpBridge.init({
+    electronModule: {},
+    sessions: new Map(),
+    sftpClients: new Map(),
+  });
+
+  const controller = new AbortController();
+  const callerPath = "/tmp/.netcatty-upload-deadbeef-user-file.part";
+  const uploadPromise = sftpBridge.pipelinedUploadLocalFile(
+    sharedOnlyClient,
+    localPath,
+    callerPath,
+    {
+      concurrency: UPLOAD_TRANSFER_CONCURRENCY,
+      chunkSize: TRANSFER_CHUNK_SIZE,
+      signal: controller.signal,
+    },
+  );
+
+  await new Promise((r) => setImmediate(r));
+  controller.abort();
+  await assert.rejects(uploadPromise, /abort|cancel/i);
+  assert.equal(unlinkedPath, null);
 
   await fs.promises.rm(tempRoot, { recursive: true, force: true });
 });

--- a/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
+++ b/electron/bridges/sftpBridge.sessionBackedUpload.test.cjs
@@ -423,6 +423,63 @@ test("parent-dir permission on staged path falls back to in-place for new files"
   assert.deepEqual(remoteFiles.get("/ro-dir/file.bin"), payload);
 });
 
+test("size-mismatch on path containing 'access' does not fall back to in-place", async (t) => {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-access-name-"));
+  t.after(async () => {
+    await fs.promises.rm(tempRoot, { recursive: true, force: true });
+  });
+  tempDirBridge.init?.({ getPath: () => tempRoot });
+
+  const localPath = path.join(tempRoot, "payload.bin");
+  const payload = Buffer.from("twelve-bytes"); // 12 bytes
+  await fs.promises.writeFile(localPath, payload);
+
+  const { channel, fastPutCalls } = createSessionChannel();
+  // Make staged-path stat report a wrong size so size-verify throws a message
+  // containing the path word "access" — must NOT be treated as permission.
+  const origStat = channel.stat.bind(channel);
+  channel.stat = (targetPath, callback) => {
+    if (String(targetPath).includes(".netcatty-upload-")) {
+      callback(null, {
+        size: 1,
+        mode: 0o100644,
+        isDirectory: () => false,
+        isFile: () => true,
+        isSymbolicLink: () => false,
+      });
+      return;
+    }
+    return origStat(targetPath, callback);
+  };
+
+  const connection = {
+    sftp(callback) { callback(null, channel); },
+  };
+  const sftpClients = new Map();
+  sftpBridge.init({
+    electronModule: { webContents: { fromId: () => null } },
+    sessions: new Map([["session-access", { conn: connection }]]),
+    sftpClients,
+  });
+  const opened = await sftpBridge.openSftpForSession(null, {
+    sessionId: "session-access",
+    fileProtocol: "sftp",
+  });
+
+  await assert.rejects(
+    () => sftpBridge.uploadLocalToSftp(null, {
+      sftpId: opened.sftpId,
+      localPath,
+      remotePath: "/tmp/access-denied-name.bin",
+      encoding: "utf-8",
+    }),
+    /size mismatch/i,
+  );
+  // Only the staged attempt — no in-place fallback write to the final path.
+  assert.equal(fastPutCalls.length, 1);
+  assert.match(fastPutCalls[0].remotePath, /\.netcatty-upload-.*\.part$/);
+});
+
 test("pipelinedUploadLocalFile aborts in-flight fastPut when AbortSignal fires", async () => {
   const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-abort-fastput-"));
   const localPath = path.join(tempRoot, "abort.bin");

--- a/electron/bridges/sftpBridge/fileOps.cjs
+++ b/electron/bridges/sftpBridge/fileOps.cjs
@@ -440,7 +440,18 @@ function createFileOpsApi(ctx) {
 
       await requireSftpChannel(client);
       const encoding = resolveEncodingForRequest(payload.sftpId, payload.encoding);
+      // Stage to a remote .part path, then rename into place. Shared-channel
+      // cancel cannot stop ssh2 fastPut without ending the session; staging
+      // keeps late WRITEs off the final destination after cancel reports.
+      const stagedRemotePath = typeof buildStagedRemotePath === "function"
+        ? buildStagedRemotePath(remotePath)
+        : `${remotePath}.part`;
+      const backupRemotePath = typeof buildBackupRemotePath === "function"
+        ? buildBackupRemotePath(remotePath)
+        : `${remotePath}.bak`;
       const encodedPath = encodePath(remotePath, encoding);
+      const encodedStagedPath = encodePath(stagedRemotePath, encoding);
+      const encodedBackupPath = encodePath(backupRemotePath, encoding);
     
       // Extract callback functions from payload
       const onProgress = payload.onProgress;
@@ -500,17 +511,17 @@ function createFileOpsApi(ctx) {
         }
       };
 
-      const assertRemoteSize = async () => {
+      const assertStagedRemoteSize = async () => {
         if (typeof client.stat !== "function") return;
-        const attrs = await client.stat(encodedPath);
+        const attrs = await client.stat(encodedStagedPath);
         const remoteSize = Number(attrs?.size);
         if (Number.isFinite(remoteSize) && remoteSize !== totalBytes) {
           try {
             if (typeof client.delete === "function") {
-              await client.delete(encodedPath);
+              await client.delete(encodedStagedPath);
             }
           } catch {
-            // Best-effort cleanup of the corrupt remote file.
+            // Best-effort cleanup of the corrupt staged remote file.
           }
           throw new Error(
             `Upload size mismatch for ${remotePath}: expected ${totalBytes} bytes, got ${remoteSize}`,
@@ -518,8 +529,8 @@ function createFileOpsApi(ctx) {
         }
       };
 
-      // Pipelined fastPut via temp file only. Serial put()/WriteStream is not
-      // used as a silent fallback (#2449; align Electerm/OpenSSH/WinSCP).
+      // Pipelined fastPut via local temp + remote .part only. Serial put()/WriteStream
+      // is not used as a silent fallback (#2449; align Electerm/OpenSSH/WinSCP).
       // Prefer a disposable SFTP channel so cancelSftpUpload can abort mid-transfer.
       let tempPath = null;
       let lastProgressTime = Date.now();
@@ -590,7 +601,7 @@ function createFileOpsApi(ctx) {
           throw new Error("SFTP pipelined upload helper is not available");
         }
 
-        await pipelinedUploadLocalFile(client, tempPath, encodedPath, {
+        await pipelinedUploadLocalFile(client, tempPath, encodedStagedPath, {
           chunkSize: TRANSFER_CHUNK_SIZE,
           concurrency: UPLOAD_TRANSFER_CONCURRENCY,
           step,
@@ -610,10 +621,24 @@ function createFileOpsApi(ctx) {
           throw new Error("Upload cancelled");
         }
 
-        await assertRemoteSize();
+        await assertStagedRemoteSize();
+        if (typeof renameRemotePath === "function") {
+          await renameRemotePath(client, encodedStagedPath, encodedPath, encodedBackupPath);
+        } else if (typeof client.rename === "function") {
+          await client.rename(encodedStagedPath, encodedPath);
+        } else {
+          throw new Error("SFTP rename is not available to promote staged upload");
+        }
         emitComplete();
         return { success: true, transferId };
       } catch (err) {
+        try {
+          if (typeof client.delete === "function") {
+            await client.delete(encodedStagedPath);
+          }
+        } catch {
+          // Best-effort cleanup of partial remote stage after cancel/error.
+        }
         const uploadState = activeSftpUploads.get(transferId);
         if (
           uploadState?.cancelled

--- a/electron/bridges/sftpBridge/fileOps.cjs
+++ b/electron/bridges/sftpBridge/fileOps.cjs
@@ -518,11 +518,8 @@ function createFileOpsApi(ctx) {
         }
       };
 
-      // Prefer pipelined fastPut via a temp file. Streaming put() uses ssh2's
-      // serial WriteStream (1 WRITE in flight) and collapses to RTT-bound KB/s
-      // on multi-ms paths (#2449). Spill even modest buffers — the alternative
-      // is always the slow path when the UI only has ArrayBuffer content.
-      const useFastPut = typeof client.fastPut === "function" && totalBytes > 0;
+      // Pipelined fastPut via temp file only. Serial put()/WriteStream is not
+      // used as a silent fallback (#2449; align Electerm/OpenSSH/WinSCP).
       let tempPath = null;
       let lastProgressTime = Date.now();
       let lastTransferredBytes = 0;
@@ -530,80 +527,36 @@ function createFileOpsApi(ctx) {
       activeSftpUploads.set(transferId, { cancelled: false, stream: null });
 
       try {
-        if (useFastPut) {
-          tempPath = await tempDirBridge.getTempFilePath(
-            `sftp-upload-${transferId || Date.now()}.bin`,
+        if (typeof client.fastPut !== "function") {
+          throw new Error(
+            "SFTP pipelined upload (fastPut) is not available on this session",
           );
-          await fs.promises.writeFile(tempPath, buffer);
-          if (activeSftpUploads.get(transferId)?.cancelled) {
-            throw new Error("Upload cancelled");
-          }
-          await client.fastPut(tempPath, encodedPath, {
-            chunkSize: TRANSFER_CHUNK_SIZE,
-            concurrency: UPLOAD_TRANSFER_CONCURRENCY,
-            step: (transferred, _chunk, total) => {
-              if (activeSftpUploads.get(transferId)?.cancelled) return;
-              const now = Date.now();
-              const elapsed = (now - lastProgressTime) / 1000;
-              let speed = 0;
-              if (elapsed >= 0.1) {
-                speed = (transferred - lastTransferredBytes) / elapsed;
-                lastProgressTime = now;
-                lastTransferredBytes = transferred;
-              }
-              emitProgress(transferred, speed);
-            },
-          });
-          if (activeSftpUploads.get(transferId)?.cancelled) {
-            throw new Error("Upload cancelled");
-          }
-        } else {
-          let transferredBytes = 0;
-          let lastProgressSentTime = 0;
-          let lastProgressSentBytes = 0;
-          const PROGRESS_THROTTLE_MS = 100;
-          const PROGRESS_THROTTLE_BYTES = 1024 * 1024;
-          const { Readable } = require("stream");
-          const readableStream = new Readable({
-            read() {
-              const uploadState = activeSftpUploads.get(transferId);
-              if (uploadState?.cancelled) {
-                this.destroy(new Error("Upload cancelled"));
-                return;
-              }
-              const chunkSize = TRANSFER_CHUNK_SIZE;
-              if (transferredBytes < totalBytes) {
-                const end = Math.min(transferredBytes + chunkSize, totalBytes);
-                const chunk = buffer.subarray(transferredBytes, end);
-                transferredBytes = end;
-                const now = Date.now();
-                const elapsed = (now - lastProgressTime) / 1000;
-                let speed = 0;
-                if (elapsed >= 0.1) {
-                  speed = (transferredBytes - lastTransferredBytes) / elapsed;
-                  lastProgressTime = now;
-                  lastTransferredBytes = transferredBytes;
-                }
-                const timeSinceLastProgress = now - lastProgressSentTime;
-                const bytesSinceLastProgress = transferredBytes - lastProgressSentBytes;
-                const isComplete = transferredBytes >= totalBytes;
-                if (
-                  isComplete
-                  || timeSinceLastProgress >= PROGRESS_THROTTLE_MS
-                  || bytesSinceLastProgress >= PROGRESS_THROTTLE_BYTES
-                ) {
-                  emitProgress(transferredBytes, speed);
-                  lastProgressSentTime = now;
-                  lastProgressSentBytes = transferredBytes;
-                }
-                this.push(chunk);
-              } else {
-                this.push(null);
-              }
-            },
-          });
-          activeSftpUploads.set(transferId, { cancelled: false, stream: readableStream });
-          await client.put(readableStream, encodedPath);
+        }
+        tempPath = await tempDirBridge.getTempFilePath(
+          `sftp-upload-${transferId || Date.now()}.bin`,
+        );
+        await fs.promises.writeFile(tempPath, buffer);
+        if (activeSftpUploads.get(transferId)?.cancelled) {
+          throw new Error("Upload cancelled");
+        }
+        await client.fastPut(tempPath, encodedPath, {
+          chunkSize: TRANSFER_CHUNK_SIZE,
+          concurrency: UPLOAD_TRANSFER_CONCURRENCY,
+          step: (transferred, _chunk, total) => {
+            if (activeSftpUploads.get(transferId)?.cancelled) return;
+            const now = Date.now();
+            const elapsed = (now - lastProgressTime) / 1000;
+            let speed = 0;
+            if (elapsed >= 0.1) {
+              speed = (transferred - lastTransferredBytes) / elapsed;
+              lastProgressTime = now;
+              lastTransferredBytes = transferred;
+            }
+            emitProgress(transferred, speed);
+          },
+        });
+        if (activeSftpUploads.get(transferId)?.cancelled) {
+          throw new Error("Upload cancelled");
         }
 
         await assertRemoteSize();

--- a/electron/bridges/sftpBridge/fileOps.cjs
+++ b/electron/bridges/sftpBridge/fileOps.cjs
@@ -520,25 +520,36 @@ function createFileOpsApi(ctx) {
 
       // Pipelined fastPut via temp file only. Serial put()/WriteStream is not
       // used as a silent fallback (#2449; align Electerm/OpenSSH/WinSCP).
-      // Session-backed clients expose fastPut on the wrapper (→ sftp.fastPut);
-      // also accept raw sftp.fastPut when the high-level method is missing.
+      // Prefer a disposable SFTP channel so cancelSftpUpload can abort mid-transfer.
       let tempPath = null;
       let lastProgressTime = Date.now();
       let lastTransferredBytes = 0;
+      let lastProgressSentTime = 0;
+      let lastProgressSentBytes = 0;
+      const PROGRESS_THROTTLE_MS = 100;
+      const PROGRESS_THROTTLE_BYTES = 1024 * 1024;
 
-      activeSftpUploads.set(transferId, { cancelled: false, stream: null });
+      const transferControl = {
+        cancelled: false,
+        abort: null,
+      };
+      activeSftpUploads.set(transferId, {
+        cancelled: false,
+        stream: null,
+        transfer: transferControl,
+      });
 
       try {
         tempPath = await tempDirBridge.getTempFilePath(
           `sftp-upload-${transferId || Date.now()}.bin`,
         );
         await fs.promises.writeFile(tempPath, buffer);
-        if (activeSftpUploads.get(transferId)?.cancelled) {
+        if (activeSftpUploads.get(transferId)?.cancelled || transferControl.cancelled) {
           throw new Error("Upload cancelled");
         }
 
-        const step = (transferred) => {
-          if (activeSftpUploads.get(transferId)?.cancelled) return;
+        const step = (transferred, _chunk, total) => {
+          if (activeSftpUploads.get(transferId)?.cancelled || transferControl.cancelled) return;
           const now = Date.now();
           const elapsed = (now - lastProgressTime) / 1000;
           let speed = 0;
@@ -547,31 +558,51 @@ function createFileOpsApi(ctx) {
             lastProgressTime = now;
             lastTransferredBytes = transferred;
           }
-          emitProgress(transferred, speed);
+          const totalSize = Number(total) > 0 ? Number(total) : totalBytes;
+          const isComplete = transferred >= totalSize;
+          const timeSinceLast = now - lastProgressSentTime;
+          const bytesSinceLast = transferred - lastProgressSentBytes;
+          if (
+            isComplete
+            || timeSinceLast >= PROGRESS_THROTTLE_MS
+            || bytesSinceLast >= PROGRESS_THROTTLE_BYTES
+          ) {
+            emitProgress(transferred, speed);
+            lastProgressSentTime = now;
+            lastProgressSentBytes = transferred;
+          }
         };
-        const putOptions = {
+
+        // Open a disposable channel when possible so cancel can end it.
+        // pipelinedUploadLocalFile is injected from sftpBridge (ctx).
+        if (typeof pipelinedUploadLocalFile !== "function") {
+          throw new Error("SFTP pipelined upload helper is not available");
+        }
+        const abortController = typeof AbortController === "function"
+          ? new AbortController()
+          : null;
+        transferControl.abort = () => {
+          transferControl.cancelled = true;
+          try { abortController?.abort(); } catch { /* ignore */ }
+        };
+
+        await pipelinedUploadLocalFile(client, tempPath, encodedPath, {
           chunkSize: TRANSFER_CHUNK_SIZE,
           concurrency: UPLOAD_TRANSFER_CONCURRENCY,
           step,
-        };
-
-        if (typeof client.fastPut === "function") {
-          await client.fastPut(tempPath, encodedPath, putOptions);
-        } else {
-          const sftp = await requireSftpChannel(client);
-          if (typeof sftp.fastPut !== "function") {
-            throw new Error(
-              "SFTP pipelined upload (fastPut) is not available on this session",
-            );
-          }
-          await new Promise((resolve, reject) => {
-            sftp.fastPut(tempPath, encodedPath, putOptions, (err) => {
-              if (err) reject(err);
-              else resolve();
-            });
-          });
-        }
-        if (activeSftpUploads.get(transferId)?.cancelled) {
+          signal: abortController?.signal || null,
+          onChannel(sftp, control) {
+            // Prefer channel end for cancel when the channel is disposable.
+            if (control?.dispose) {
+              transferControl.abort = () => {
+                transferControl.cancelled = true;
+                try { control.abort?.(); } catch { /* ignore */ }
+                try { sftp.end?.(); } catch { /* ignore */ }
+              };
+            }
+          },
+        });
+        if (activeSftpUploads.get(transferId)?.cancelled || transferControl.cancelled) {
           throw new Error("Upload cancelled");
         }
 
@@ -580,9 +611,16 @@ function createFileOpsApi(ctx) {
         return { success: true, transferId };
       } catch (err) {
         const uploadState = activeSftpUploads.get(transferId);
-        if (uploadState?.cancelled || err.message === "Upload cancelled") {
-          const contents = electronModule.webContents.fromId(event.sender.id);
-          contents?.send("netcatty:upload:cancelled", { transferId });
+        if (
+          uploadState?.cancelled
+          || transferControl.cancelled
+          || err.message === "Upload cancelled"
+          || /abort/i.test(err.message || "")
+        ) {
+          try {
+            const contents = electronModule.webContents.fromId(event?.sender?.id);
+            contents?.send("netcatty:upload:cancelled", { transferId });
+          } catch { /* ignore */ }
           return { success: false, transferId, cancelled: true };
         }
         emitError(err.message);

--- a/electron/bridges/sftpBridge/fileOps.cjs
+++ b/electron/bridges/sftpBridge/fileOps.cjs
@@ -533,6 +533,13 @@ function createFileOpsApi(ctx) {
         cancelled: false,
         abort: null,
       };
+      const abortController = typeof AbortController === "function"
+        ? new AbortController()
+        : null;
+      transferControl.abort = () => {
+        transferControl.cancelled = true;
+        try { abortController?.abort(); } catch { /* ignore */ }
+      };
       activeSftpUploads.set(transferId, {
         cancelled: false,
         stream: null,
@@ -543,7 +550,11 @@ function createFileOpsApi(ctx) {
         tempPath = await tempDirBridge.getTempFilePath(
           `sftp-upload-${transferId || Date.now()}.bin`,
         );
-        await fs.promises.writeFile(tempPath, buffer);
+        // Stage to disk with abort support (Node writeFile accepts signal).
+        const writeOpts = abortController?.signal
+          ? { signal: abortController.signal }
+          : undefined;
+        await fs.promises.writeFile(tempPath, buffer, writeOpts);
         if (activeSftpUploads.get(transferId)?.cancelled || transferControl.cancelled) {
           throw new Error("Upload cancelled");
         }
@@ -578,13 +589,6 @@ function createFileOpsApi(ctx) {
         if (typeof pipelinedUploadLocalFile !== "function") {
           throw new Error("SFTP pipelined upload helper is not available");
         }
-        const abortController = typeof AbortController === "function"
-          ? new AbortController()
-          : null;
-        transferControl.abort = () => {
-          transferControl.cancelled = true;
-          try { abortController?.abort(); } catch { /* ignore */ }
-        };
 
         await pipelinedUploadLocalFile(client, tempPath, encodedPath, {
           chunkSize: TRANSFER_CHUNK_SIZE,

--- a/electron/bridges/sftpBridge/fileOps.cjs
+++ b/electron/bridges/sftpBridge/fileOps.cjs
@@ -578,6 +578,9 @@ function createFileOpsApi(ctx) {
               if (control?.dispose) {
                 transferControl.abort = () => {
                   transferControl.cancelled = true;
+                  // Keep AbortSignal aborted so post-upload throwIfAborted
+                  // blocks staged rename/promotion after a late cancel.
+                  try { abortController?.abort(); } catch { /* ignore */ }
                   try { control.abort?.(); } catch { /* ignore */ }
                   try { sftp.end?.(); } catch { /* ignore */ }
                 };
@@ -596,6 +599,7 @@ function createFileOpsApi(ctx) {
               if (control?.dispose) {
                 transferControl.abort = () => {
                   transferControl.cancelled = true;
+                  try { abortController?.abort(); } catch { /* ignore */ }
                   try { control.abort?.(); } catch { /* ignore */ }
                   try { sftp.end?.(); } catch { /* ignore */ }
                 };

--- a/electron/bridges/sftpBridge/fileOps.cjs
+++ b/electron/bridges/sftpBridge/fileOps.cjs
@@ -520,6 +520,8 @@ function createFileOpsApi(ctx) {
 
       // Pipelined fastPut via temp file only. Serial put()/WriteStream is not
       // used as a silent fallback (#2449; align Electerm/OpenSSH/WinSCP).
+      // Session-backed clients expose fastPut on the wrapper (→ sftp.fastPut);
+      // also accept raw sftp.fastPut when the high-level method is missing.
       let tempPath = null;
       let lastProgressTime = Date.now();
       let lastTransferredBytes = 0;
@@ -527,11 +529,6 @@ function createFileOpsApi(ctx) {
       activeSftpUploads.set(transferId, { cancelled: false, stream: null });
 
       try {
-        if (typeof client.fastPut !== "function") {
-          throw new Error(
-            "SFTP pipelined upload (fastPut) is not available on this session",
-          );
-        }
         tempPath = await tempDirBridge.getTempFilePath(
           `sftp-upload-${transferId || Date.now()}.bin`,
         );
@@ -539,22 +536,41 @@ function createFileOpsApi(ctx) {
         if (activeSftpUploads.get(transferId)?.cancelled) {
           throw new Error("Upload cancelled");
         }
-        await client.fastPut(tempPath, encodedPath, {
+
+        const step = (transferred) => {
+          if (activeSftpUploads.get(transferId)?.cancelled) return;
+          const now = Date.now();
+          const elapsed = (now - lastProgressTime) / 1000;
+          let speed = 0;
+          if (elapsed >= 0.1) {
+            speed = (transferred - lastTransferredBytes) / elapsed;
+            lastProgressTime = now;
+            lastTransferredBytes = transferred;
+          }
+          emitProgress(transferred, speed);
+        };
+        const putOptions = {
           chunkSize: TRANSFER_CHUNK_SIZE,
           concurrency: UPLOAD_TRANSFER_CONCURRENCY,
-          step: (transferred, _chunk, total) => {
-            if (activeSftpUploads.get(transferId)?.cancelled) return;
-            const now = Date.now();
-            const elapsed = (now - lastProgressTime) / 1000;
-            let speed = 0;
-            if (elapsed >= 0.1) {
-              speed = (transferred - lastTransferredBytes) / elapsed;
-              lastProgressTime = now;
-              lastTransferredBytes = transferred;
-            }
-            emitProgress(transferred, speed);
-          },
-        });
+          step,
+        };
+
+        if (typeof client.fastPut === "function") {
+          await client.fastPut(tempPath, encodedPath, putOptions);
+        } else {
+          const sftp = await requireSftpChannel(client);
+          if (typeof sftp.fastPut !== "function") {
+            throw new Error(
+              "SFTP pipelined upload (fastPut) is not available on this session",
+            );
+          }
+          await new Promise((resolve, reject) => {
+            sftp.fastPut(tempPath, encodedPath, putOptions, (err) => {
+              if (err) reject(err);
+              else resolve();
+            });
+          });
+        }
         if (activeSftpUploads.get(transferId)?.cancelled) {
           throw new Error("Upload cancelled");
         }

--- a/electron/bridges/sftpBridge/fileOps.cjs
+++ b/electron/bridges/sftpBridge/fileOps.cjs
@@ -451,138 +451,178 @@ function createFileOpsApi(ctx) {
       // For ArrayBuffer from renderer, we still need to convert but use a more efficient method
       const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content);
       const totalBytes = buffer.length;
-      let transferredBytes = 0;
-      let lastProgressTime = Date.now();
-      let lastTransferredBytes = 0;
-      let lastProgressSentTime = 0;
-    
-      // Throttle settings: send progress at most every 100ms or every 1MB
-      const PROGRESS_THROTTLE_MS = 100;
-      const PROGRESS_THROTTLE_BYTES = 1024 * 1024; // 1MB
-      let lastProgressSentBytes = 0;
-    
-      const { Readable } = require("stream");
-      const readableStream = new Readable({
-        read() {
-          // Check for cancellation
-          const uploadState = activeSftpUploads.get(transferId);
-          if (uploadState?.cancelled) {
-            this.destroy(new Error("Upload cancelled"));
-            return;
-          }
-    
-          // Use larger chunk size for better performance (256KB instead of 64KB)
-          const chunkSize = 262144;
-          if (transferredBytes < totalBytes) {
-            const end = Math.min(transferredBytes + chunkSize, totalBytes);
-            // Use subarray instead of slice to avoid copying
-            const chunk = buffer.subarray(transferredBytes, end);
-            transferredBytes = end;
-    
-            const now = Date.now();
-            const elapsed = (now - lastProgressTime) / 1000;
-            let speed = 0;
-            if (elapsed >= 0.1) {
-              speed = (transferredBytes - lastTransferredBytes) / elapsed;
-              lastProgressTime = now;
-              lastTransferredBytes = transferredBytes;
-            }
-    
-            // Throttle IPC progress events: only send if enough time or bytes have passed
-            const timeSinceLastProgress = now - lastProgressSentTime;
-            const bytesSinceLastProgress = transferredBytes - lastProgressSentBytes;
-            const isComplete = transferredBytes >= totalBytes;
-    
-            if (isComplete || timeSinceLastProgress >= PROGRESS_THROTTLE_MS || bytesSinceLastProgress >= PROGRESS_THROTTLE_BYTES) {
-              // Call the progress callback if provided, otherwise send IPC event
-              if (typeof onProgress === 'function') {
-                try {
-                  onProgress(transferredBytes, totalBytes, speed);
-                } catch (err) {
-                  console.warn('[SFTP] Progress callback error:', err);
-                }
-              } else {
-                const contents = electronModule.webContents.fromId(event.sender.id);
-                contents?.send("netcatty:upload:progress", {
-                  transferId,
-                  transferred: transferredBytes,
-                  totalBytes,
-                  speed,
-                });
-              }
-              lastProgressSentTime = now;
-              lastProgressSentBytes = transferredBytes;
-            }
-    
-            this.push(chunk);
-          } else {
-            this.push(null);
-          }
-        }
-      });
-    
-      // Register this upload for potential cancellation
-      activeSftpUploads.set(transferId, { cancelled: false, stream: readableStream });
-    
-      try {
-        await client.put(readableStream, encodedPath);
+      const {
+        TRANSFER_CHUNK_SIZE,
+        UPLOAD_TRANSFER_CONCURRENCY,
+      } = require("../transferLimits.cjs");
 
-        // Guard against silent truncation on servers that mishandle large writes (#2022).
-        if (typeof client.stat === "function") {
-          const attrs = await client.stat(encodedPath);
-          const remoteSize = Number(attrs?.size);
-          if (Number.isFinite(remoteSize) && remoteSize !== totalBytes) {
-            try {
-              if (typeof client.delete === "function") {
-                await client.delete(encodedPath);
-              }
-            } catch {
-              // Best-effort cleanup of the corrupt remote file.
-            }
-            throw new Error(
-              `Upload size mismatch for ${remotePath}: expected ${totalBytes} bytes, got ${remoteSize}`,
-            );
+      const emitProgress = (transferred, speed = 0) => {
+        if (typeof onProgress === "function") {
+          try {
+            onProgress(transferred, totalBytes, speed);
+          } catch (err) {
+            console.warn("[SFTP] Progress callback error:", err);
           }
+        } else {
+          const contents = electronModule.webContents.fromId(event.sender.id);
+          contents?.send("netcatty:upload:progress", {
+            transferId,
+            transferred,
+            totalBytes,
+            speed,
+          });
         }
-    
-        // Call the complete callback if provided, otherwise send IPC event
-        if (typeof onComplete === 'function') {
+      };
+
+      const emitComplete = () => {
+        if (typeof onComplete === "function") {
           try {
             onComplete();
           } catch (err) {
-            console.warn('[SFTP] Complete callback error:', err);
+            console.warn("[SFTP] Complete callback error:", err);
           }
         } else {
           const contents = electronModule.webContents.fromId(event.sender.id);
           contents?.send("netcatty:upload:complete", { transferId });
         }
-    
+      };
+
+      const emitError = (message) => {
+        if (typeof onError === "function") {
+          try {
+            onError(message);
+          } catch (callbackErr) {
+            console.warn("[SFTP] Error callback error:", callbackErr);
+          }
+        } else {
+          const contents = electronModule.webContents.fromId(event.sender.id);
+          contents?.send("netcatty:upload:error", { transferId, error: message });
+        }
+      };
+
+      const assertRemoteSize = async () => {
+        if (typeof client.stat !== "function") return;
+        const attrs = await client.stat(encodedPath);
+        const remoteSize = Number(attrs?.size);
+        if (Number.isFinite(remoteSize) && remoteSize !== totalBytes) {
+          try {
+            if (typeof client.delete === "function") {
+              await client.delete(encodedPath);
+            }
+          } catch {
+            // Best-effort cleanup of the corrupt remote file.
+          }
+          throw new Error(
+            `Upload size mismatch for ${remotePath}: expected ${totalBytes} bytes, got ${remoteSize}`,
+          );
+        }
+      };
+
+      // Prefer pipelined fastPut via a temp file. Streaming put() uses ssh2's
+      // serial WriteStream (1 WRITE in flight) and collapses to RTT-bound KB/s
+      // on multi-ms paths (#2449). Spill even modest buffers — the alternative
+      // is always the slow path when the UI only has ArrayBuffer content.
+      const useFastPut = typeof client.fastPut === "function" && totalBytes > 0;
+      let tempPath = null;
+      let lastProgressTime = Date.now();
+      let lastTransferredBytes = 0;
+
+      activeSftpUploads.set(transferId, { cancelled: false, stream: null });
+
+      try {
+        if (useFastPut) {
+          tempPath = await tempDirBridge.getTempFilePath(
+            `sftp-upload-${transferId || Date.now()}.bin`,
+          );
+          await fs.promises.writeFile(tempPath, buffer);
+          if (activeSftpUploads.get(transferId)?.cancelled) {
+            throw new Error("Upload cancelled");
+          }
+          await client.fastPut(tempPath, encodedPath, {
+            chunkSize: TRANSFER_CHUNK_SIZE,
+            concurrency: UPLOAD_TRANSFER_CONCURRENCY,
+            step: (transferred, _chunk, total) => {
+              if (activeSftpUploads.get(transferId)?.cancelled) return;
+              const now = Date.now();
+              const elapsed = (now - lastProgressTime) / 1000;
+              let speed = 0;
+              if (elapsed >= 0.1) {
+                speed = (transferred - lastTransferredBytes) / elapsed;
+                lastProgressTime = now;
+                lastTransferredBytes = transferred;
+              }
+              emitProgress(transferred, speed);
+            },
+          });
+          if (activeSftpUploads.get(transferId)?.cancelled) {
+            throw new Error("Upload cancelled");
+          }
+        } else {
+          let transferredBytes = 0;
+          let lastProgressSentTime = 0;
+          let lastProgressSentBytes = 0;
+          const PROGRESS_THROTTLE_MS = 100;
+          const PROGRESS_THROTTLE_BYTES = 1024 * 1024;
+          const { Readable } = require("stream");
+          const readableStream = new Readable({
+            read() {
+              const uploadState = activeSftpUploads.get(transferId);
+              if (uploadState?.cancelled) {
+                this.destroy(new Error("Upload cancelled"));
+                return;
+              }
+              const chunkSize = TRANSFER_CHUNK_SIZE;
+              if (transferredBytes < totalBytes) {
+                const end = Math.min(transferredBytes + chunkSize, totalBytes);
+                const chunk = buffer.subarray(transferredBytes, end);
+                transferredBytes = end;
+                const now = Date.now();
+                const elapsed = (now - lastProgressTime) / 1000;
+                let speed = 0;
+                if (elapsed >= 0.1) {
+                  speed = (transferredBytes - lastTransferredBytes) / elapsed;
+                  lastProgressTime = now;
+                  lastTransferredBytes = transferredBytes;
+                }
+                const timeSinceLastProgress = now - lastProgressSentTime;
+                const bytesSinceLastProgress = transferredBytes - lastProgressSentBytes;
+                const isComplete = transferredBytes >= totalBytes;
+                if (
+                  isComplete
+                  || timeSinceLastProgress >= PROGRESS_THROTTLE_MS
+                  || bytesSinceLastProgress >= PROGRESS_THROTTLE_BYTES
+                ) {
+                  emitProgress(transferredBytes, speed);
+                  lastProgressSentTime = now;
+                  lastProgressSentBytes = transferredBytes;
+                }
+                this.push(chunk);
+              } else {
+                this.push(null);
+              }
+            },
+          });
+          activeSftpUploads.set(transferId, { cancelled: false, stream: readableStream });
+          await client.put(readableStream, encodedPath);
+        }
+
+        await assertRemoteSize();
+        emitComplete();
         return { success: true, transferId };
       } catch (err) {
-        // Check if this upload was cancelled - the error might not be exactly "Upload cancelled"
-        // when stream is destroyed, SFTP server may return different errors like "Write stream error"
         const uploadState = activeSftpUploads.get(transferId);
         if (uploadState?.cancelled || err.message === "Upload cancelled") {
           const contents = electronModule.webContents.fromId(event.sender.id);
           contents?.send("netcatty:upload:cancelled", { transferId });
           return { success: false, transferId, cancelled: true };
         }
-    
-        // Call the error callback if provided, otherwise send IPC event
-        if (typeof onError === 'function') {
-          try {
-            onError(err.message);
-          } catch (callbackErr) {
-            console.warn('[SFTP] Error callback error:', callbackErr);
-          }
-        } else {
-          const contents = electronModule.webContents.fromId(event.sender.id);
-          contents?.send("netcatty:upload:error", { transferId, error: err.message });
-        }
+        emitError(err.message);
         throw err;
       } finally {
-        // Cleanup
         activeSftpUploads.delete(transferId);
+        if (tempPath) {
+          try { await fs.promises.unlink(tempPath); } catch { /* ignore */ }
+        }
       }
     }
     

--- a/electron/bridges/sftpBridge/fileOps.cjs
+++ b/electron/bridges/sftpBridge/fileOps.cjs
@@ -440,18 +440,7 @@ function createFileOpsApi(ctx) {
 
       await requireSftpChannel(client);
       const encoding = resolveEncodingForRequest(payload.sftpId, payload.encoding);
-      // Stage to a remote .part path, then rename into place. Shared-channel
-      // cancel cannot stop ssh2 fastPut without ending the session; staging
-      // keeps late WRITEs off the final destination after cancel reports.
-      const stagedRemotePath = typeof buildStagedRemotePath === "function"
-        ? buildStagedRemotePath(remotePath)
-        : `${remotePath}.part`;
-      const backupRemotePath = typeof buildBackupRemotePath === "function"
-        ? buildBackupRemotePath(remotePath)
-        : `${remotePath}.bak`;
       const encodedPath = encodePath(remotePath, encoding);
-      const encodedStagedPath = encodePath(stagedRemotePath, encoding);
-      const encodedBackupPath = encodePath(backupRemotePath, encoding);
     
       // Extract callback functions from payload
       const onProgress = payload.onProgress;
@@ -511,27 +500,9 @@ function createFileOpsApi(ctx) {
         }
       };
 
-      const assertStagedRemoteSize = async () => {
-        if (typeof client.stat !== "function") return;
-        const attrs = await client.stat(encodedStagedPath);
-        const remoteSize = Number(attrs?.size);
-        if (Number.isFinite(remoteSize) && remoteSize !== totalBytes) {
-          try {
-            if (typeof client.delete === "function") {
-              await client.delete(encodedStagedPath);
-            }
-          } catch {
-            // Best-effort cleanup of the corrupt staged remote file.
-          }
-          throw new Error(
-            `Upload size mismatch for ${remotePath}: expected ${totalBytes} bytes, got ${remoteSize}`,
-          );
-        }
-      };
-
-      // Pipelined fastPut via local temp + remote .part only. Serial put()/WriteStream
-      // is not used as a silent fallback (#2449; align Electerm/OpenSSH/WinSCP).
-      // Prefer a disposable SFTP channel so cancelSftpUpload can abort mid-transfer.
+      // Pipelined fastPut via local temp + optional remote .part. Serial put()/WriteStream
+      // is not used as a silent fallback (#2449). Prefer disposable channel for cancel.
+      // Stage+rename by default so shared-channel cancel cannot keep writing the final path.
       let tempPath = null;
       let lastProgressTime = Date.now();
       let lastTransferredBytes = 0;
@@ -595,50 +566,50 @@ function createFileOpsApi(ctx) {
           }
         };
 
-        // Open a disposable channel when possible so cancel can end it.
-        // pipelinedUploadLocalFile is injected from sftpBridge (ctx).
-        if (typeof pipelinedUploadLocalFile !== "function") {
+        if (typeof pipelinedUploadWithOptionalStaging === "function") {
+          await pipelinedUploadWithOptionalStaging(client, tempPath, encodedPath, {
+            chunkSize: TRANSFER_CHUNK_SIZE,
+            concurrency: UPLOAD_TRANSFER_CONCURRENCY,
+            step,
+            signal: abortController?.signal || null,
+            expectedSize: totalBytes,
+            onChannel(sftp, control) {
+              if (control?.dispose) {
+                transferControl.abort = () => {
+                  transferControl.cancelled = true;
+                  try { control.abort?.(); } catch { /* ignore */ }
+                  try { sftp.end?.(); } catch { /* ignore */ }
+                };
+              }
+            },
+          });
+        } else if (typeof pipelinedUploadLocalFile === "function") {
+          // Fallback if staging helper is unavailable (older injection).
+          await pipelinedUploadLocalFile(client, tempPath, encodedPath, {
+            chunkSize: TRANSFER_CHUNK_SIZE,
+            concurrency: UPLOAD_TRANSFER_CONCURRENCY,
+            step,
+            signal: abortController?.signal || null,
+            onChannel(sftp, control) {
+              if (control?.dispose) {
+                transferControl.abort = () => {
+                  transferControl.cancelled = true;
+                  try { control.abort?.(); } catch { /* ignore */ }
+                  try { sftp.end?.(); } catch { /* ignore */ }
+                };
+              }
+            },
+          });
+        } else {
           throw new Error("SFTP pipelined upload helper is not available");
         }
-
-        await pipelinedUploadLocalFile(client, tempPath, encodedStagedPath, {
-          chunkSize: TRANSFER_CHUNK_SIZE,
-          concurrency: UPLOAD_TRANSFER_CONCURRENCY,
-          step,
-          signal: abortController?.signal || null,
-          onChannel(sftp, control) {
-            // Prefer channel end for cancel when the channel is disposable.
-            if (control?.dispose) {
-              transferControl.abort = () => {
-                transferControl.cancelled = true;
-                try { control.abort?.(); } catch { /* ignore */ }
-                try { sftp.end?.(); } catch { /* ignore */ }
-              };
-            }
-          },
-        });
         if (activeSftpUploads.get(transferId)?.cancelled || transferControl.cancelled) {
           throw new Error("Upload cancelled");
         }
 
-        await assertStagedRemoteSize();
-        if (typeof renameRemotePath === "function") {
-          await renameRemotePath(client, encodedStagedPath, encodedPath, encodedBackupPath);
-        } else if (typeof client.rename === "function") {
-          await client.rename(encodedStagedPath, encodedPath);
-        } else {
-          throw new Error("SFTP rename is not available to promote staged upload");
-        }
         emitComplete();
         return { success: true, transferId };
       } catch (err) {
-        try {
-          if (typeof client.delete === "function") {
-            await client.delete(encodedStagedPath);
-          }
-        } catch {
-          // Best-effort cleanup of partial remote stage after cancel/error.
-        }
         const uploadState = activeSftpUploads.get(transferId);
         if (
           uploadState?.cancelled

--- a/electron/bridges/sftpBridge/fileOps.cjs
+++ b/electron/bridges/sftpBridge/fileOps.cjs
@@ -440,7 +440,6 @@ function createFileOpsApi(ctx) {
 
       await requireSftpChannel(client);
       const encoding = resolveEncodingForRequest(payload.sftpId, payload.encoding);
-      const encodedPath = encodePath(remotePath, encoding);
     
       // Extract callback functions from payload
       const onProgress = payload.onProgress;
@@ -567,11 +566,13 @@ function createFileOpsApi(ctx) {
         };
 
         if (typeof pipelinedUploadWithOptionalStaging === "function") {
-          await pipelinedUploadWithOptionalStaging(client, tempPath, encodedPath, {
+          // Pass the logical remote path; helper encodes stage/final paths.
+          await pipelinedUploadWithOptionalStaging(client, tempPath, remotePath, {
             chunkSize: TRANSFER_CHUNK_SIZE,
             concurrency: UPLOAD_TRANSFER_CONCURRENCY,
             step,
             signal: abortController?.signal || null,
+            encoding,
             expectedSize: totalBytes,
             onChannel(sftp, control) {
               if (control?.dispose) {
@@ -585,6 +586,7 @@ function createFileOpsApi(ctx) {
           });
         } else if (typeof pipelinedUploadLocalFile === "function") {
           // Fallback if staging helper is unavailable (older injection).
+          const encodedPath = encodePath(remotePath, encoding);
           await pipelinedUploadLocalFile(client, tempPath, encodedPath, {
             chunkSize: TRANSFER_CHUNK_SIZE,
             concurrency: UPLOAD_TRANSFER_CONCURRENCY,

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -1213,6 +1213,7 @@ async function runPausableConcurrentRanges({
   sendProgress,
   abortChannel,
   sftp = null,
+  forceSettleOnError = false,
 }) {
   let nextOffset = checkpoint;
   // Progress may complete out of order, but the resume checkpoint must never
@@ -1264,10 +1265,10 @@ async function runPausableConcurrentRanges({
         if (settled) return;
         if (error) terminalError = terminalError || error;
         if (active > 0) {
-          // On cancel/error with in-flight WRITEs (especially shared-channel
-          // where abort cannot end the SFTP subsystem), force-settle so Cancel
-          // cannot hang forever waiting for stalled remote callbacks.
-          if (terminalError || transfer.cancelled) {
+          // Cancel must remain bounded even on a shared channel. Ordinary
+          // shared-channel errors, however, must drain their in-flight WRITEs
+          // before the caller can clean up or retry the same remote path.
+          if (transfer.cancelled || (terminalError && forceSettleOnError)) {
             clearForceFinish();
             forceFinishTimer = setTimeout(() => {
               if (settled) return;
@@ -1452,6 +1453,7 @@ async function uploadFileConcurrent(
         sendProgress,
         abortChannel,
         sftp,
+        forceSettleOnError: disposeChannel,
       });
       if (channelError) throw channelError;
       await assertLocalContentFingerprintUnchangedFromHandle(

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -828,11 +828,17 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
 
     // fastPut always truncates and rewrites from offset 0 — skip when we
     // already have a durable resume checkpoint from a prior concurrent attempt.
+    // fastPut is not pause-aware; do not advertise pause while it runs.
     const hasResumeCheckpoint = Math.max(0, Number(transfer.checkpointBytes) || 0) > 0;
     if (isolated && typeof isolated.fastPut === "function" && !hasResumeCheckpoint) {
       let fastPutOk = false;
       try {
         transfer.uploadStrategy = "fastPut-isolated";
+        transfer.pauseSupported = false;
+        transfer.pauseUnavailableReason = "Pause is unavailable during fastPut upload";
+        sendProgress(Math.max(0, Number(transfer.checkpointBytes) || 0), fileSize, {
+          force: true,
+        });
         await uploadViaFastPut(
           localPath,
           remotePath,
@@ -845,6 +851,11 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
         fastPutOk = true;
       } catch (err) {
         isolated = null;
+        // Restore pause capability for subsequent pause-aware strategies.
+        transfer.pauseSupported = Boolean(transfer.resumable);
+        transfer.pauseUnavailableReason = transfer.resumable
+          ? undefined
+          : transfer.pauseUnavailableReason;
         if (transfer.cancelled) throw err;
         rememberPipelineError(err);
         console.warn(
@@ -867,6 +878,8 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
     let sharedOk = false;
     try {
       transfer.uploadStrategy = "concurrent-shared";
+      transfer.pauseSupported = Boolean(transfer.resumable);
+      if (transfer.resumable) transfer.pauseUnavailableReason = undefined;
       await uploadFileConcurrent(
         localPath,
         remotePath,

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -900,7 +900,13 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
           ? undefined
           : transfer.pauseUnavailableReason;
         if (transfer.cancelled) throw err;
+        // Source-change / hard safety errors must not be retried on another path.
+        if (err?.noTransferFallback || err?.sourceChanged) throw err;
         rememberPipelineError(err);
+        // fastPut progress is not a durable contiguous checkpoint — reset so
+        // concurrent-shared does not resume past holes left by the failed put.
+        transfer.checkpointBytes = 0;
+        sendProgress(0, fileSize, { force: true, checkpointBytes: 0 });
         console.warn(
           "[transferBridge] isolated fastPut failed, trying next pipelined strategy:",
           err?.message || String(err),

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -669,10 +669,19 @@ async function prepareUploadFallbackCheckpoint(transfer, client, fileSize, sendP
 async function uploadViaFastPut(localPath, remotePath, sftp, fileSize, transfer, sendProgress, { disposeChannel }) {
   await new Promise((resolve, reject) => {
     let settled = false;
+    let pendingError = null;
+    let forceFinishTimer = null;
     let onFastSftpError = null;
+    const clearForceFinish = () => {
+      if (forceFinishTimer) {
+        clearTimeout(forceFinishTimer);
+        forceFinishTimer = null;
+      }
+    };
     const finish = (err) => {
       if (settled) return;
       settled = true;
+      clearForceFinish();
       if (transfer.abort === abortFastTransfer) {
         transfer.abort = null;
       }
@@ -688,17 +697,30 @@ async function uploadViaFastPut(localPath, remotePath, sftp, fileSize, transfer,
       else if (err) reject(err);
       else resolve();
     };
+    const scheduleForceFinish = (err) => {
+      clearForceFinish();
+      forceFinishTimer = setTimeout(() => finish(err), 2000);
+    };
     const abortFastTransfer = () => {
       if (settled) return;
       transfer.cancelled = true;
       if (disposeChannel) {
         try { sftp.end(); } catch { /* ignore */ }
+        // Wait for fastPut callback when possible; force after grace period.
+        scheduleForceFinish(new Error("Transfer cancelled"));
+        return;
       }
-      finish(new Error("Transfer cancelled"));
+      // Shared channel: wait for callback.
     };
     transfer.abort = abortFastTransfer;
-    onFastSftpError = (err) => finish(err);
-    sftp.once?.("error", onFastSftpError);
+    onFastSftpError = (err) => {
+      pendingError = err || new Error("SFTP channel error");
+      if (disposeChannel) {
+        try { sftp.end(); } catch { /* ignore */ }
+        scheduleForceFinish(pendingError);
+      }
+    };
+    sftp.on?.("error", onFastSftpError);
 
     if (transfer.cancelled) {
       finish(new Error("Transfer cancelled"));
@@ -712,7 +734,17 @@ async function uploadViaFastPut(localPath, remotePath, sftp, fileSize, transfer,
         if (transfer.cancelled) return;
         sendProgress(transferred, total || fileSize);
       },
-    }, finish);
+    }, (err) => {
+      if (transfer.cancelled) {
+        finish(new Error("Transfer cancelled"));
+        return;
+      }
+      if (pendingError) {
+        finish(pendingError);
+        return;
+      }
+      finish(err || null);
+    });
   });
 }
 
@@ -832,6 +864,7 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
     const hasResumeCheckpoint = Math.max(0, Number(transfer.checkpointBytes) || 0) > 0;
     if (isolated && typeof isolated.fastPut === "function" && !hasResumeCheckpoint) {
       let fastPutOk = false;
+      let fastPutFingerprint = null;
       try {
         transfer.uploadStrategy = "fastPut-isolated";
         transfer.pauseSupported = false;
@@ -839,6 +872,9 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
         sendProgress(Math.max(0, Number(transfer.checkpointBytes) || 0), fileSize, {
           force: true,
         });
+        if (transfer.resumable) {
+          fastPutFingerprint = await captureLocalContentFingerprint(localPath, fileSize);
+        }
         await uploadViaFastPut(
           localPath,
           remotePath,
@@ -848,6 +884,13 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
           sendProgress,
           { disposeChannel: true },
         );
+        if (fastPutFingerprint) {
+          await assertLocalContentFingerprintUnchanged(
+            localPath,
+            fastPutFingerprint,
+            fileSize,
+          );
+        }
         fastPutOk = true;
       } catch (err) {
         isolated = null;

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -735,8 +735,8 @@ async function uploadViaFastPut(localPath, remotePath, sftp, fileSize, transfer,
         // UI progress only. fastPut byte totals are not a durable contiguous
         // resume offset — keep checkpoint at 0 so a crash mid-fastPut cannot
         // resume past sparse holes on the next run.
+        // Do not force every chunk: ssh2 steps per 32KB and would flood IPC.
         sendProgress(transferred, total || fileSize, {
-          force: true,
           checkpointBytes: 0,
         });
       },

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -1253,10 +1253,33 @@ async function runPausableConcurrentRanges({
 
   try {
     await new Promise((resolve, reject) => {
+      let forceFinishTimer = null;
+      const clearForceFinish = () => {
+        if (forceFinishTimer) {
+          clearTimeout(forceFinishTimer);
+          forceFinishTimer = null;
+        }
+      };
       const finish = (error) => {
         if (settled) return;
         if (error) terminalError = terminalError || error;
-        if (active > 0) return;
+        if (active > 0) {
+          // On cancel/error with in-flight WRITEs (especially shared-channel
+          // where abort cannot end the SFTP subsystem), force-settle so Cancel
+          // cannot hang forever waiting for stalled remote callbacks.
+          if (terminalError || transfer.cancelled) {
+            clearForceFinish();
+            forceFinishTimer = setTimeout(() => {
+              if (settled) return;
+              active = 0;
+              settled = true;
+              reject(terminalError || new Error("Transfer cancelled"));
+            }, 2000);
+            forceFinishTimer.unref?.();
+          }
+          return;
+        }
+        clearForceFinish();
         settled = true;
         if (terminalError) reject(terminalError);
         else resolve();
@@ -1264,7 +1287,7 @@ async function runPausableConcurrentRanges({
 
       const abort = (error = new Error("Transfer cancelled")) => {
         terminalError = terminalError || error;
-        try { abortChannel?.(); } catch { }
+        try { abortChannel?.(); } catch { /* ignore */ }
         finish(terminalError);
       };
 

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -732,7 +732,13 @@ async function uploadViaFastPut(localPath, remotePath, sftp, fileSize, transfer,
       concurrency: UPLOAD_TRANSFER_CONCURRENCY,
       step: (transferred, _chunk, total) => {
         if (transfer.cancelled) return;
-        sendProgress(transferred, total || fileSize);
+        // UI progress only. fastPut byte totals are not a durable contiguous
+        // resume offset — keep checkpoint at 0 so a crash mid-fastPut cannot
+        // resume past sparse holes on the next run.
+        sendProgress(transferred, total || fileSize, {
+          force: true,
+          checkpointBytes: 0,
+        });
       },
     }, (err) => {
       if (transfer.cancelled) {
@@ -1448,13 +1454,24 @@ async function uploadFileConcurrent(
       await localHandle.close().catch(() => {});
     }
     let remoteCloseError = null;
-    // Always close the remote handle — required on shared browse channels so a
-    // failed/cancelled transfer does not leak OPEN handles into the session.
+    // Close remote handles while the channel is still live. On disposeChannel
+    // cancel/failure the channel is about to be ended (or already dead); a
+    // CLOSE request would hang forever with no callback from ssh2.
     if (remoteHandle) {
-      try {
-        await closeSftpHandle(sftp, remoteHandle);
-      } catch (error) {
-        if (!failed && !transfer.cancelled) remoteCloseError = error;
+      const skipClose = disposeChannel && (failed || transfer.cancelled);
+      if (!skipClose) {
+        try {
+          await Promise.race([
+            closeSftpHandle(sftp, remoteHandle),
+            new Promise((_, reject) => {
+              setTimeout(() => reject(new Error("SFTP close timed out")), 2000);
+            }),
+          ]);
+        } catch (error) {
+          if (!failed && !transfer.cancelled && !/timed out/i.test(error?.message || "")) {
+            remoteCloseError = error;
+          }
+        }
       }
     }
     if (!failed && !transfer.cancelled && !remoteCloseError && channelError) {

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -1091,37 +1091,22 @@ function createSourceContentChangedError() {
   return error;
 }
 
-function sampleOffsetsForFingerprint(fileSize) {
-  if (fileSize <= 0) return [];
-  const sampleSize = Math.min(TRANSFER_CHUNK_SIZE, fileSize);
-  return [...new Set([
-    0,
-    Math.max(0, Math.floor((fileSize - sampleSize) / 2)),
-    Math.max(0, fileSize - sampleSize),
-  ])].map((position) => ({
-    position,
-    length: Math.min(sampleSize, fileSize - position),
-  }));
-}
-
 /**
- * Content fingerprint for same-size rewrite detection. Metadata (mtime/ctime)
- * alone is not enough: some filesystems keep the same timestamp within a tick.
+ * Full content fingerprint for same-size rewrite detection. Uploads can read
+ * ranges out of order, so metadata or sparse sampling cannot prove that a
+ * large source stayed unchanged throughout the transfer.
  */
 async function captureLocalContentFingerprintFromHandle(fileHandle, fileSize) {
-  const samples = sampleOffsetsForFingerprint(fileSize);
-  if (samples.length === 0) return { size: fileSize, digests: [] };
-  const digests = [];
-  for (const { position, length } of samples) {
-    const buffer = Buffer.allocUnsafe(length);
+  const hash = crypto.createHash("sha256");
+  const buffer = Buffer.allocUnsafe(Math.min(1024 * 1024, Math.max(1, fileSize)));
+  let position = 0;
+  while (position < fileSize) {
+    const length = Math.min(buffer.length, fileSize - position);
     await readLocalRange(fileHandle, buffer, position, length);
-    digests.push({
-      position,
-      length,
-      digest: crypto.createHash("sha256").update(buffer).digest("hex"),
-    });
+    hash.update(buffer.subarray(0, length));
+    position += length;
   }
-  return { size: fileSize, digests };
+  return { size: fileSize, digest: hash.digest("hex") };
 }
 
 async function captureLocalContentFingerprint(filePath, fileSize) {
@@ -1151,38 +1136,16 @@ async function assertLocalContentFingerprintUnchanged(filePath, fingerprint, exp
     throw createSourceSizeChangedError(expectedSize, latestSize);
   }
   const latest = await captureLocalContentFingerprint(filePath, expectedSize);
-  if (latest.digests.length !== fingerprint.digests.length) {
+  if (latest.digest !== fingerprint.digest) {
     throw createSourceContentChangedError();
-  }
-  for (let i = 0; i < fingerprint.digests.length; i += 1) {
-    const before = fingerprint.digests[i];
-    const after = latest.digests[i];
-    if (
-      before.position !== after.position
-      || before.length !== after.length
-      || before.digest !== after.digest
-    ) {
-      throw createSourceContentChangedError();
-    }
   }
 }
 
 async function assertLocalContentFingerprintUnchangedFromHandle(fileHandle, fingerprint, expectedSize) {
   if (!fingerprint) return;
   const latest = await captureLocalContentFingerprintFromHandle(fileHandle, expectedSize);
-  if (latest.size !== expectedSize || latest.digests.length !== fingerprint.digests.length) {
+  if (latest.size !== expectedSize || latest.digest !== fingerprint.digest) {
     throw createSourceContentChangedError();
-  }
-  for (let i = 0; i < fingerprint.digests.length; i += 1) {
-    const before = fingerprint.digests[i];
-    const after = latest.digests[i];
-    if (
-      before.position !== after.position
-      || before.length !== after.length
-      || before.digest !== after.digest
-    ) {
-      throw createSourceContentChangedError();
-    }
   }
 }
 
@@ -2420,7 +2383,7 @@ async function startTransferNow(event, payload, onProgress) {
         transfer.stagedRemote = null;
       }
     }
-    if (err.message === 'Transfer cancelled') {
+    if (transfer.cancelled || err.message === 'Transfer cancelled') {
       if (transfer.stagedLocalPath) {
         try { await fs.promises.unlink(transfer.stagedLocalPath); } catch { }
       }

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -645,13 +645,92 @@ async function acquireIsolatedDownloadChannel(client, transfer) {
 }
 
 /**
- * Upload a local file to SFTP using ssh2's fastPut (parallel SFTP requests).
- * Falls back to sequential stream piping if fastPut is unavailable.
+ * After a concurrent-range attempt fails, staged remote bytes may extend past
+ * the contiguous checkpoint. Truncate / reset so the next strategy resumes
+ * safely instead of leaving sparse tails.
+ */
+async function prepareUploadFallbackCheckpoint(transfer, client, fileSize, sendProgress) {
+  await prepareStreamFallbackAfterRangeFailure(transfer, client);
+  const fallbackCheckpoint = Math.max(0, Number(transfer.checkpointBytes) || 0);
+  if (fallbackCheckpoint > 0 && transfer.stagedRemote) {
+    let stagedSize = Number.POSITIVE_INFINITY;
+    try {
+      const staged = transfer.stagedRemote;
+      const encoded = encodePathForSession(staged.sftpId, staged.path, staged.encoding);
+      stagedSize = Number((await (staged.client || client).stat(encoded))?.size);
+    } catch { /* missing staged file — restart */ }
+    if (!Number.isFinite(stagedSize) || stagedSize !== fallbackCheckpoint) {
+      transfer.checkpointBytes = 0;
+      sendProgress(0, fileSize, { force: true, checkpointBytes: 0 });
+    }
+  }
+}
+
+async function uploadViaFastPut(localPath, remotePath, sftp, fileSize, transfer, sendProgress, { disposeChannel }) {
+  await new Promise((resolve, reject) => {
+    let settled = false;
+    let onFastSftpError = null;
+    const finish = (err) => {
+      if (settled) return;
+      settled = true;
+      if (transfer.abort === abortFastTransfer) {
+        transfer.abort = null;
+      }
+      if (onFastSftpError) {
+        try { sftp.removeListener("error", onFastSftpError); } catch { /* ignore */ }
+        onFastSftpError = null;
+      }
+      if (disposeChannel) {
+        try { sftp.end(); } catch { /* ignore */ }
+      }
+
+      if (transfer.cancelled) reject(new Error("Transfer cancelled"));
+      else if (err) reject(err);
+      else resolve();
+    };
+    const abortFastTransfer = () => {
+      if (settled) return;
+      transfer.cancelled = true;
+      if (disposeChannel) {
+        try { sftp.end(); } catch { /* ignore */ }
+      }
+      finish(new Error("Transfer cancelled"));
+    };
+    transfer.abort = abortFastTransfer;
+    onFastSftpError = (err) => finish(err);
+    sftp.once?.("error", onFastSftpError);
+
+    if (transfer.cancelled) {
+      finish(new Error("Transfer cancelled"));
+      return;
+    }
+
+    sftp.fastPut(localPath, remotePath, {
+      chunkSize: TRANSFER_CHUNK_SIZE,
+      concurrency: UPLOAD_TRANSFER_CONCURRENCY,
+      step: (transferred, _chunk, total) => {
+        if (transfer.cancelled) return;
+        sendProgress(transferred, total || fileSize);
+      },
+    }, finish);
+  });
+}
+
+/**
+ * Upload a local file with pipelined SFTP WRITEs.
+ *
+ * Strategy order (never jump straight to serial WriteStream — that path is
+ * ~RTT-bound at ~1 WRITE × 32KB and is the usual cause of sub-MB/s speeds):
+ *   1. concurrent ranges on an isolated channel (resumable + cancel-safe)
+ *   2. ssh2 fastPut on an isolated channel
+ *   3. concurrent ranges on the shared browse channel
+ *   4. serial createWriteStream (last resort for servers that reject fanout)
  */
 async function uploadFile(localPath, remotePath, client, fileSize, transfer, sendProgress, encoding = "utf-8") {
   if (isScpModeClient(client)) {
     transfer.pauseSupported = false;
     transfer.pauseUnavailableReason = "Pause is unavailable for SCP transfers";
+    transfer.uploadStrategy = "scp";
     const backend = getScpBackendForClient(client);
     await backend.uploadFile(localPath, remotePath, {
       fileSize,
@@ -670,116 +749,142 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
     ? await fs.promises.stat(localPath)
     : null;
 
+  const finishSuccessfulUpload = async () => {
+    if (initialSource) {
+      const latestSource = await fs.promises.stat(localPath);
+      assertSourceMetadataUnchanged(initialSource, latestSource, fileSize);
+    }
+    await assertRemoteUploadSize(client, remotePath, fileSize);
+  };
+
   // Prefer an isolated SFTP channel so cancellation cannot kill the browse session.
   if (!client.__netcattySudoMode) {
-    let fastSftp = null;
+    let isolated = null;
     try {
-      fastSftp = await openIsolatedSftpChannel(client);
+      isolated = await openIsolatedSftpChannel(client);
     } catch (err) {
-      console.warn("[transferBridge] Failed to open isolated SFTP channel for fastPut, falling back to streams:", err.message || String(err));
+      console.warn(
+        "[transferBridge] Failed to open isolated SFTP channel for upload:",
+        err.message || String(err),
+      );
     }
 
-    if (fastSftp && transfer.resumable) {
+    if (isolated && transfer.resumable) {
+      let concurrentIsolatedOk = false;
       try {
-        await uploadFileResumableFast(
+        transfer.uploadStrategy = "concurrent-isolated";
+        await uploadFileConcurrent(
           localPath,
           remotePath,
-          fastSftp,
+          isolated,
           fileSize,
           transfer,
           sendProgress,
+          { disposeChannel: true },
         );
-        const latestSource = await fs.promises.stat(localPath);
-        assertSourceMetadataUnchanged(initialSource, latestSource, fileSize);
-        // Content samples already verified inside uploadFileResumableFast.
-        await assertRemoteUploadSize(client, remotePath, fileSize);
-        return;
+        concurrentIsolatedOk = true;
       } catch (err) {
-        // uploadFileResumableFast ends the isolated channel itself. Clear the
-        // handle so we do not reuse a closed channel for fastPut below.
-        fastSftp = null;
+        // uploadFileConcurrent ends the isolated channel itself.
+        isolated = null;
         if (transfer.cancelled) throw err;
         if (err?.noTransferFallback) throw err;
-        // Ranges may have written past the contiguous checkpoint; truncate
-        // the staged remote .part before sequential stream resume.
-        await prepareStreamFallbackAfterRangeFailure(transfer, client);
-        const fallbackCheckpoint = Math.max(0, Number(transfer.checkpointBytes) || 0);
-        if (fallbackCheckpoint > 0 && transfer.stagedRemote) {
-          let stagedSize = Number.POSITIVE_INFINITY;
-          try {
-            const staged = transfer.stagedRemote;
-            const encoded = encodePathForSession(staged.sftpId, staged.path, staged.encoding);
-            stagedSize = Number((await (staged.client || client).stat(encoded))?.size);
-          } catch { }
-          if (!Number.isFinite(stagedSize) || stagedSize !== fallbackCheckpoint) {
-            transfer.checkpointBytes = 0;
-            sendProgress(0, fileSize, { force: true, checkpointBytes: 0 });
-          }
-        }
+        await prepareUploadFallbackCheckpoint(transfer, client, fileSize, sendProgress);
         console.warn(
-          "[transferBridge] resumable fast upload failed, falling back to a compatible stream:",
+          "[transferBridge] concurrent isolated upload failed, trying next strategy:",
           err?.message || String(err),
+        );
+      }
+      // Verification errors must not fall through into slower strategies.
+      if (concurrentIsolatedOk) {
+        await finishSuccessfulUpload();
+        return;
+      }
+    }
+
+    if (!isolated) {
+      try {
+        isolated = await openIsolatedSftpChannel(client);
+      } catch (err) {
+        console.warn(
+          "[transferBridge] Failed to reopen isolated SFTP channel for fastPut:",
+          err.message || String(err),
         );
       }
     }
 
-    if (fastSftp && typeof fastSftp.fastPut === "function") {
-      await new Promise((resolve, reject) => {
-        let settled = false;
-        let onFastSftpError = null;
-        const finish = (err) => {
-          if (settled) return;
-          settled = true;
-          if (transfer.abort === abortFastTransfer) {
-            transfer.abort = null;
-          }
-          if (onFastSftpError) {
-            try { fastSftp.removeListener("error", onFastSftpError); } catch { }
-            onFastSftpError = null;
-          }
-          try { fastSftp.end(); } catch { }
-
-          if (transfer.cancelled) reject(new Error("Transfer cancelled"));
-          else if (err) reject(err);
-          else resolve();
-        };
-        const abortFastTransfer = () => {
-          if (settled) return;
-          transfer.cancelled = true;
-          try { fastSftp.end(); } catch { }
-          finish(new Error("Transfer cancelled"));
-        };
-        transfer.abort = abortFastTransfer;
-        onFastSftpError = (err) => finish(err);
-        fastSftp.once("error", onFastSftpError);
-
-        if (transfer.cancelled) {
-          finish(new Error("Transfer cancelled"));
-          return;
-        }
-
-        fastSftp.fastPut(localPath, remotePath, {
-          chunkSize: TRANSFER_CHUNK_SIZE,
-          concurrency: UPLOAD_TRANSFER_CONCURRENCY,
-          step: (transferred, _chunk, total) => {
-            if (transfer.cancelled) return;
-            sendProgress(transferred, total || fileSize);
-          },
-        }, finish);
-      });
-      await assertRemoteUploadSize(client, remotePath, fileSize);
-      return;
-    }
-
-    if (fastSftp && typeof fastSftp.end === "function") {
-      try { fastSftp.end(); } catch { }
+    // fastPut always truncates and rewrites from offset 0 — skip when we
+    // already have a durable resume checkpoint from a prior concurrent attempt.
+    const hasResumeCheckpoint = Math.max(0, Number(transfer.checkpointBytes) || 0) > 0;
+    if (isolated && typeof isolated.fastPut === "function" && !hasResumeCheckpoint) {
+      let fastPutOk = false;
+      try {
+        transfer.uploadStrategy = "fastPut-isolated";
+        await uploadViaFastPut(
+          localPath,
+          remotePath,
+          isolated,
+          fileSize,
+          transfer,
+          sendProgress,
+          { disposeChannel: true },
+        );
+        fastPutOk = true;
+      } catch (err) {
+        isolated = null;
+        if (transfer.cancelled) throw err;
+        console.warn(
+          "[transferBridge] isolated fastPut failed, trying next strategy:",
+          err?.message || String(err),
+        );
+      }
+      if (fastPutOk) {
+        await finishSuccessfulUpload();
+        return;
+      }
+    } else if (isolated && typeof isolated.end === "function") {
+      try { isolated.end(); } catch { /* ignore */ }
     }
   }
 
-  // Fallback: sequential stream piping.
+  // Concurrent WRITEs on the shared browse channel — still pipelined, does not
+  // end the session on cancel/dispose (sudo mode and isolated-open failures).
+  if (typeof sftp.open === "function" && typeof sftp.write === "function") {
+    let sharedOk = false;
+    try {
+      transfer.uploadStrategy = "concurrent-shared";
+      await uploadFileConcurrent(
+        localPath,
+        remotePath,
+        sftp,
+        fileSize,
+        transfer,
+        sendProgress,
+        { disposeChannel: false },
+      );
+      sharedOk = true;
+    } catch (err) {
+      if (transfer.cancelled) throw err;
+      if (err?.noTransferFallback) throw err;
+      await prepareUploadFallbackCheckpoint(transfer, client, fileSize, sendProgress);
+      console.warn(
+        "[transferBridge] concurrent shared upload failed, falling back to serial stream:",
+        err?.message || String(err),
+      );
+    }
+    if (sharedOk) {
+      await finishSuccessfulUpload();
+      return;
+    }
+  }
+
+  // Last resort: sequential stream piping (ssh2 WriteStream is 1-in-flight).
   // ssh2 closes the remote handle from _final and may suppress Node's normal
   // 'finish' event. Treat a successful close after the complete local read as
   // completion, then verify the persisted remote size below.
+  transfer.uploadStrategy = "stream-serial";
+  console.warn(
+    "[transferBridge] using serial SFTP WriteStream (slow path); expect RTT-bound throughput",
+  );
   const streamContentFingerprint = transfer.resumable
     ? await captureLocalContentFingerprint(localPath, fileSize)
     : null;
@@ -798,7 +903,7 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
     transfer.writeStream = writeStream;
     // Honor a pause that raced stream open (fingerprint / dir ensure window).
     if (transfer.paused) {
-      try { readStream.pause(); } catch { }
+      try { readStream.pause(); } catch { /* ignore */ }
     }
 
     const cleanup = (err) => {
@@ -807,28 +912,28 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
       readStream.removeAllListeners();
       writeStream.removeAllListeners();
       if (err) {
-        try { readStream.destroy(); } catch { }
-        try { writeStream.destroy(); } catch { }
+        try { readStream.destroy(); } catch { /* ignore */ }
+        try { writeStream.destroy(); } catch { /* ignore */ }
         reject(err);
       } else {
         resolve();
       }
     };
 
-    readStream.on('data', (chunk) => {
-      if (transfer.cancelled) { cleanup(new Error('Transfer cancelled')); return; }
+    readStream.on("data", (chunk) => {
+      if (transfer.cancelled) { cleanup(new Error("Transfer cancelled")); return; }
       transferred += chunk.length;
       sendProgress(transferred, fileSize);
     });
-    readStream.on('error', cleanup);
-    writeStream.on('error', cleanup);
-    writeStream.on('close', () => {
+    readStream.on("error", cleanup);
+    writeStream.on("error", cleanup);
+    writeStream.on("close", () => {
       if (transfer.cancelled) {
-        cleanup(new Error('Transfer cancelled'));
+        cleanup(new Error("Transfer cancelled"));
         return;
       }
       if (!readStream.readableEnded || transferred !== fileSize) {
-        cleanup(new Error('Upload stream closed before finish'));
+        cleanup(new Error("Upload stream closed before finish"));
         return;
       }
       cleanup(null);
@@ -1223,25 +1328,39 @@ async function runPausableConcurrentRanges({
   }
 }
 
-async function uploadFileResumableFast(
+/**
+ * Pipelined SFTP WRITE upload (same fanout as ssh2 fastPut).
+ *
+ * @param {{ disposeChannel?: boolean }} [options]
+ *   disposeChannel — when true (isolated channel), end the SFTP subsystem on
+ *   cancel/finish. When false (shared browse session), never call sftp.end().
+ */
+async function uploadFileConcurrent(
   localPath,
   remotePath,
   sftp,
   fileSize,
   transfer,
   sendProgress,
+  options = {},
 ) {
+  const disposeChannel = options.disposeChannel !== false;
   const checkpoint = Math.max(0, Math.min(transfer.checkpointBytes || 0, fileSize));
   let channelError = null;
   const onChannelError = (error) => {
     channelError = channelError || error;
   };
   sftp.on?.("error", onChannelError);
-  // Install cancel before OPEN so a stalled remote open can still end the
+  // Install cancel before OPEN so a stalled remote open can still end an
   // isolated channel (runPausableConcurrentRanges would install this later).
+  const abortChannel = () => {
+    if (disposeChannel) {
+      try { sftp.end?.(); } catch { /* ignore */ }
+    }
+  };
   const abortEarly = () => {
     transfer.cancelled = true;
-    try { sftp.end?.(); } catch { }
+    abortChannel();
   };
   transfer.abort = abortEarly;
 
@@ -1283,7 +1402,7 @@ async function uploadFileResumableFast(
           await writeSftpRange(sftp, remoteHandle, buffer, position, length);
         },
         sendProgress,
-        abortChannel: () => sftp.end?.(),
+        abortChannel,
         sftp,
       });
       if (channelError) throw channelError;
@@ -1311,22 +1430,28 @@ async function uploadFileResumableFast(
       await localHandle.close().catch(() => {});
     }
     let remoteCloseError = null;
-    if (remoteHandle && !failed && !transfer.cancelled) {
+    // Always close the remote handle — required on shared browse channels so a
+    // failed/cancelled transfer does not leak OPEN handles into the session.
+    if (remoteHandle) {
       try {
         await closeSftpHandle(sftp, remoteHandle);
       } catch (error) {
-        remoteCloseError = error;
+        if (!failed && !transfer.cancelled) remoteCloseError = error;
       }
     }
     if (!failed && !transfer.cancelled && !remoteCloseError && channelError) {
       remoteCloseError = channelError;
     }
-    // Single dispose path for the isolated channel.
-    try { sftp.end?.(); } catch { }
-    try { sftp.removeListener?.("error", onChannelError); } catch { }
+    if (disposeChannel) {
+      try { sftp.end?.(); } catch { /* ignore */ }
+    }
+    try { sftp.removeListener?.("error", onChannelError); } catch { /* ignore */ }
     if (remoteCloseError) throw remoteCloseError;
   }
 }
+
+// Back-compat alias for older call sites / tests that still name the isolated path.
+const uploadFileResumableFast = uploadFileConcurrent;
 
 /**
  * Preserve fastGet's high-latency request window without giving up a safe

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -717,14 +717,18 @@ async function uploadViaFastPut(localPath, remotePath, sftp, fileSize, transfer,
 }
 
 /**
- * Upload a local file with pipelined SFTP WRITEs.
+ * Upload a local file with pipelined SFTP WRITEs only.
  *
- * Strategy order (never jump straight to serial WriteStream — that path is
- * ~RTT-bound at ~1 WRITE × 32KB and is the usual cause of sub-MB/s speeds):
+ * Aligns with OpenSSH sftp / Electerm / WinSCP: default is outstanding-request
+ * fanout, not serial WriteStream. Strategy order:
  *   1. concurrent ranges on an isolated channel (resumable + cancel-safe)
  *   2. ssh2 fastPut on an isolated channel
  *   3. concurrent ranges on the shared browse channel
- *   4. serial createWriteStream (last resort for servers that reject fanout)
+ *
+ * There is no silent serial createWriteStream/put fallback — that path is
+ * RTT-bound (~1 WRITE × 32KB) and was the usual cause of sub-MB/s uploads
+ * (#2449). When every pipelined strategy fails, the transfer fails with the
+ * last underlying error (Electerm-style: fail closed, do not crawl).
  */
 async function uploadFile(localPath, remotePath, client, fileSize, transfer, sendProgress, encoding = "utf-8") {
   if (isScpModeClient(client)) {
@@ -757,12 +761,20 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
     await assertRemoteUploadSize(client, remotePath, fileSize);
   };
 
+  /** @type {Error | null} */
+  let lastPipelineError = null;
+  const rememberPipelineError = (err) => {
+    if (err && typeof err === "object") lastPipelineError = err;
+    else lastPipelineError = new Error(String(err || "SFTP upload failed"));
+  };
+
   // Prefer an isolated SFTP channel so cancellation cannot kill the browse session.
   if (!client.__netcattySudoMode) {
     let isolated = null;
     try {
       isolated = await openIsolatedSftpChannel(client);
     } catch (err) {
+      rememberPipelineError(err);
       console.warn(
         "[transferBridge] Failed to open isolated SFTP channel for upload:",
         err.message || String(err),
@@ -788,13 +800,14 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
         isolated = null;
         if (transfer.cancelled) throw err;
         if (err?.noTransferFallback) throw err;
+        rememberPipelineError(err);
         await prepareUploadFallbackCheckpoint(transfer, client, fileSize, sendProgress);
         console.warn(
-          "[transferBridge] concurrent isolated upload failed, trying next strategy:",
+          "[transferBridge] concurrent isolated upload failed, trying next pipelined strategy:",
           err?.message || String(err),
         );
       }
-      // Verification errors must not fall through into slower strategies.
+      // Verification errors must not fall through into other strategies.
       if (concurrentIsolatedOk) {
         await finishSuccessfulUpload();
         return;
@@ -805,6 +818,7 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
       try {
         isolated = await openIsolatedSftpChannel(client);
       } catch (err) {
+        rememberPipelineError(err);
         console.warn(
           "[transferBridge] Failed to reopen isolated SFTP channel for fastPut:",
           err.message || String(err),
@@ -832,8 +846,9 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
       } catch (err) {
         isolated = null;
         if (transfer.cancelled) throw err;
+        rememberPipelineError(err);
         console.warn(
-          "[transferBridge] isolated fastPut failed, trying next strategy:",
+          "[transferBridge] isolated fastPut failed, trying next pipelined strategy:",
           err?.message || String(err),
         );
       }
@@ -865,9 +880,10 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
     } catch (err) {
       if (transfer.cancelled) throw err;
       if (err?.noTransferFallback) throw err;
+      rememberPipelineError(err);
       await prepareUploadFallbackCheckpoint(transfer, client, fileSize, sendProgress);
       console.warn(
-        "[transferBridge] concurrent shared upload failed, falling back to serial stream:",
+        "[transferBridge] concurrent shared upload failed (no serial stream fallback):",
         err?.message || String(err),
       );
     }
@@ -875,83 +891,23 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
       await finishSuccessfulUpload();
       return;
     }
-  }
-
-  // Last resort: sequential stream piping (ssh2 WriteStream is 1-in-flight).
-  // ssh2 closes the remote handle from _final and may suppress Node's normal
-  // 'finish' event. Treat a successful close after the complete local read as
-  // completion, then verify the persisted remote size below.
-  transfer.uploadStrategy = "stream-serial";
-  console.warn(
-    "[transferBridge] using serial SFTP WriteStream (slow path); expect RTT-bound throughput",
-  );
-  const streamContentFingerprint = transfer.resumable
-    ? await captureLocalContentFingerprint(localPath, fileSize)
-    : null;
-  await new Promise((resolve, reject) => {
-    const checkpoint = Math.max(0, Math.min(transfer.checkpointBytes || 0, fileSize));
-    const readStream = fs.createReadStream(localPath, { highWaterMark: TRANSFER_CHUNK_SIZE, start: checkpoint });
-    const writeStream = sftp.createWriteStream(remotePath, {
-      highWaterMark: TRANSFER_CHUNK_SIZE,
-      flags: checkpoint > 0 ? "r+" : "w",
-      start: checkpoint,
-    });
-    let transferred = checkpoint;
-    let settled = false;
-
-    transfer.readStream = readStream;
-    transfer.writeStream = writeStream;
-    // Honor a pause that raced stream open (fingerprint / dir ensure window).
-    if (transfer.paused) {
-      try { readStream.pause(); } catch { /* ignore */ }
-    }
-
-    const cleanup = (err) => {
-      if (settled) return;
-      settled = true;
-      readStream.removeAllListeners();
-      writeStream.removeAllListeners();
-      if (err) {
-        try { readStream.destroy(); } catch { /* ignore */ }
-        try { writeStream.destroy(); } catch { /* ignore */ }
-        reject(err);
-      } else {
-        resolve();
-      }
-    };
-
-    readStream.on("data", (chunk) => {
-      if (transfer.cancelled) { cleanup(new Error("Transfer cancelled")); return; }
-      transferred += chunk.length;
-      sendProgress(transferred, fileSize);
-    });
-    readStream.on("error", cleanup);
-    writeStream.on("error", cleanup);
-    writeStream.on("close", () => {
-      if (transfer.cancelled) {
-        cleanup(new Error("Transfer cancelled"));
-        return;
-      }
-      if (!readStream.readableEnded || transferred !== fileSize) {
-        cleanup(new Error("Upload stream closed before finish"));
-        return;
-      }
-      cleanup(null);
-    });
-    readStream.pipe(writeStream);
-  });
-  await assertRemoteUploadSize(client, remotePath, fileSize);
-  if (initialSource) {
-    const latestSource = await fs.promises.stat(localPath);
-    assertSourceMetadataUnchanged(initialSource, latestSource, fileSize);
-  }
-  if (streamContentFingerprint) {
-    await assertLocalContentFingerprintUnchanged(
-      localPath,
-      streamContentFingerprint,
-      fileSize,
+  } else if (!lastPipelineError) {
+    lastPipelineError = new Error(
+      "SFTP session does not support pipelined WRITE (open/write missing)",
     );
   }
+
+  // Fail closed — do not crawl via serial WriteStream (industry practice:
+  // OpenSSH/Electerm/WinSCP keep outstanding-request fanout; they do not
+  // silently degrade to 1-in-flight put on failure).
+  transfer.uploadStrategy = "failed";
+  const cause = lastPipelineError;
+  const message = cause?.message
+    ? `SFTP pipelined upload failed: ${cause.message}`
+    : "SFTP pipelined upload failed (no serial stream fallback)";
+  const error = new Error(message, cause ? { cause } : undefined);
+  if (cause?.noTransferFallback) error.noTransferFallback = true;
+  throw error;
 }
 
 function openSftpHandle(sftp, filePath, flags) {

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -430,7 +430,8 @@ test("failed resumable upload opens close their isolated channel", async (t) => 
 
   assert.match(result.error || "", /permission denied/);
   assert.equal(hadOpenErrorListener, true);
-  assert.equal(endedChannels, 1);
+  // concurrent-isolated + fastPut-isolated each open/end their own channel.
+  assert.ok(endedChannels >= 1, `expected isolated channels to end, got ${endedChannels}`);
 });
 
 test("failed local upload opens close their isolated channel", async (t) => {
@@ -687,7 +688,9 @@ test("resumable SFTP uploads fall back to a compatible stream after fast path fa
   );
 
   assert.equal(result.error, undefined);
-  assert.equal(endedChannels, 1);
+  // concurrent-isolated fails open; fastPut-isolated reopens and ends its channel.
+  // Serial stream uses the shared browse sftp and does not call end on isolated mocks.
+  assert.ok(endedChannels >= 1, `expected isolated channels to end, got ${endedChannels}`);
   assert.equal(remoteBytes, payload.length);
 });
 
@@ -1183,6 +1186,76 @@ test("SFTP uploads fail when remote size does not match local size", async (t) =
   assert.match(result.error || "", /Upload size mismatch/);
   assert.equal(deletedRemotePath, "/tmp/archive.zip");
   assert.ok(sender.sent.some((entry) => entry.channel === "netcatty:transfer:error"));
+});
+
+test("uploads prefer concurrent shared channel over serial WriteStream", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-shared-concurrent-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(UPLOAD_TRANSFER_CONCURRENCY * TRANSFER_CHUNK_SIZE, 91);
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, payload);
+
+  let maxInFlight = 0;
+  let activeWrites = 0;
+  let createWriteStreamCalls = 0;
+  const sharedSftp = createFastSftp({
+    open(_remotePath, flags, callback) {
+      assert.equal(flags, "w");
+      callback(null, Buffer.from("shared-handle"));
+    },
+    write(_handle, _buffer, _offset, length, _position, callback) {
+      activeWrites += 1;
+      maxInFlight = Math.max(maxInFlight, activeWrites);
+      setImmediate(() => {
+        activeWrites -= 1;
+        callback(null);
+      });
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+    createWriteStream() {
+      createWriteStreamCalls += 1;
+      throw new Error("serial WriteStream must not be used when concurrent works");
+    },
+  });
+
+  const client = {
+    // Force the isolated-channel path to be unavailable (sudo / no secondary channel).
+    __netcattySudoMode: true,
+    sftp: sharedSftp,
+    stat() {
+      return Promise.resolve({ size: payload.length });
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    delete() {
+      return Promise.resolve();
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-shared-concurrent",
+      sourcePath: localPath,
+      targetPath: "/tmp/upload.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+
+  assert.equal(result.error, undefined);
+  assert.equal(createWriteStreamCalls, 0);
+  assert.equal(maxInFlight, UPLOAD_TRANSFER_CONCURRENCY);
 });
 
 test("SFTP stream-fallback uploads wait for close after finish", async (t) => {

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -1235,6 +1235,82 @@ test("uploads prefer concurrent shared channel over serial WriteStream", async (
   );
 });
 
+test("shared upload errors wait for all in-flight WRITEs before returning", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-shared-error-drain-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const fileSize = 4 * TRANSFER_CHUNK_SIZE;
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(fileSize, 13));
+
+  const pendingWriteCallbacks = [];
+  let triggerFirstError;
+  const firstErrorTriggered = new Promise((resolve) => {
+    triggerFirstError = resolve;
+  });
+  let firstErrorScheduled = false;
+  const sharedSftp = createFastSftp({
+    open(_remotePath, flags, callback) {
+      assert.equal(flags, "w");
+      callback(null, Buffer.from("shared-handle"));
+    },
+    write(_handle, _buffer, _offset, _length, _position, callback) {
+      pendingWriteCallbacks.push(callback);
+      if (!firstErrorScheduled && pendingWriteCallbacks.length === 4) {
+        firstErrorScheduled = true;
+        setImmediate(() => {
+          const fail = pendingWriteCallbacks.shift();
+          fail(new Error("shared WRITE failed"));
+          triggerFirstError();
+        });
+      }
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+  });
+
+  const client = {
+    __netcattySudoMode: true,
+    sftp: sharedSftp,
+    stat() {
+      return Promise.resolve({ size: 0 });
+    },
+    delete() {
+      return Promise.resolve();
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  let transferSettled = false;
+  const running = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-shared-error-drain",
+      sourcePath: localPath,
+      targetPath: "/tmp/upload.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: fileSize,
+      resumable: true,
+    },
+  ).finally(() => {
+    transferSettled = true;
+  });
+
+  await firstErrorTriggered;
+  await new Promise((resolve) => setTimeout(resolve, 2100));
+  const settledBeforeRemainingWrites = transferSettled;
+  for (const callback of pendingWriteCallbacks.splice(0)) callback(null);
+
+  const result = await running;
+  assert.equal(settledBeforeRemainingWrites, false);
+  assert.match(result.error || "", /shared WRITE failed|pipelined upload failed/i);
+});
+
 test("sudo SFTP sessions without open/write fail closed (no serial WriteStream)", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-sudo-fail-closed-"));
   t.after(async () => {

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -9,6 +9,10 @@ const { PassThrough, Readable, Writable } = require("node:stream");
 
 const transferBridge = require("./transferBridge.cjs");
 const tempDirBridge = require("./tempDirBridge.cjs");
+const {
+  TRANSFER_CHUNK_SIZE,
+  UPLOAD_TRANSFER_CONCURRENCY,
+} = require("./transferLimits.cjs");
 
 function createSender() {
   return {
@@ -30,14 +34,16 @@ function createFastSftp(overrides) {
   return sftp;
 }
 
-test("resumable SFTP uploads use conservative per-file request concurrency", async (t) => {
+test("resumable SFTP uploads use the configured per-file request concurrency", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-test-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   });
 
+  // Need more than one fanout wave so the concurrency cap is observable.
+  const fileSize = UPLOAD_TRANSFER_CONCURRENCY * TRANSFER_CHUNK_SIZE * 2;
   const localPath = path.join(tempDir, "large.bin");
-  await fs.promises.writeFile(localPath, Buffer.alloc(1024 * 1024));
+  await fs.promises.writeFile(localPath, Buffer.alloc(fileSize));
 
   let activeWrites = 0;
   let observedConcurrency = 0;
@@ -72,7 +78,7 @@ test("resumable SFTP uploads use conservative per-file request concurrency", asy
   const client = {
     sftp: createFastSftp({}),
     stat() {
-      return Promise.resolve({ size: 1024 * 1024 });
+      return Promise.resolve({ size: fileSize });
     },
     rename() {
       return Promise.resolve();
@@ -103,12 +109,12 @@ test("resumable SFTP uploads use conservative per-file request concurrency", asy
   );
 
   const readyDeadline = Date.now() + 1000;
-  while (pendingWrites.length < 8 && Date.now() < readyDeadline) {
+  while (pendingWrites.length < UPLOAD_TRANSFER_CONCURRENCY && Date.now() < readyDeadline) {
     await new Promise((resolve) => setImmediate(resolve));
   }
-  assert.equal(pendingWrites.length, 8);
-  assert.equal(observedConcurrency, 8);
-  assert.equal(observedChunkSize, 32 * 1024);
+  assert.equal(pendingWrites.length, UPLOAD_TRANSFER_CONCURRENCY);
+  assert.equal(observedConcurrency, UPLOAD_TRANSFER_CONCURRENCY);
+  assert.equal(observedChunkSize, TRANSFER_CHUNK_SIZE);
   holdWrites = false;
   for (const complete of pendingWrites.splice(0)) complete();
   const result = await running;
@@ -121,7 +127,8 @@ test("fast resumable uploads pause only after in-flight ranges are durable", asy
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   });
 
-  const payload = Buffer.alloc(1024 * 1024, 13);
+  // First in-flight wave must be smaller than the file so pause can land mid-transfer.
+  const payload = Buffer.alloc(UPLOAD_TRANSFER_CONCURRENCY * TRANSFER_CHUNK_SIZE * 2, 13);
   const localPath = path.join(tempDir, "upload.bin");
   await fs.promises.writeFile(localPath, payload);
   const pendingWrites = [];
@@ -177,17 +184,17 @@ test("fast resumable uploads pause only after in-flight ranges are durable", asy
   );
 
   const readyDeadline = Date.now() + 1000;
-  while (pendingWrites.length < 8 && Date.now() < readyDeadline) {
+  while (pendingWrites.length < UPLOAD_TRANSFER_CONCURRENCY && Date.now() < readyDeadline) {
     await new Promise((resolve) => setImmediate(resolve));
   }
-  assert.equal(pendingWrites.length, 8);
+  assert.equal(pendingWrites.length, UPLOAD_TRANSFER_CONCURRENCY);
 
   const pausing = transferBridge.pauseTransfer(null, { transferId: "upload-fast-paused" });
   holdWrites = false;
   for (const complete of pendingWrites.splice(0)) complete();
   const paused = await pausing;
   assert.equal(paused.success, true);
-  assert.equal(paused.checkpointBytes, 256 * 1024);
+  assert.equal(paused.checkpointBytes, UPLOAD_TRANSFER_CONCURRENCY * TRANSFER_CHUNK_SIZE);
 
   assert.deepEqual(
     await transferBridge.resumeTransfer(null, { transferId: "upload-fast-paused" }),
@@ -276,7 +283,7 @@ test("resuming during pause fingerprinting prevents a stale pause success", asyn
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   });
 
-  const payload = Buffer.alloc(512 * 1024, 71);
+  const payload = Buffer.alloc(UPLOAD_TRANSFER_CONCURRENCY * TRANSFER_CHUNK_SIZE * 2, 71);
   const localPath = path.join(tempDir, "upload.bin");
   await fs.promises.writeFile(localPath, payload);
   const pendingWrites = [];
@@ -336,10 +343,10 @@ test("resuming during pause fingerprinting prevents a stale pause success", asyn
       },
     );
     const writeDeadline = Date.now() + 1000;
-    while (pendingWrites.length < 8 && Date.now() < writeDeadline) {
+    while (pendingWrites.length < UPLOAD_TRANSFER_CONCURRENCY && Date.now() < writeDeadline) {
       await new Promise((resolve) => setImmediate(resolve));
     }
-    assert.equal(pendingWrites.length, 8);
+    assert.equal(pendingWrites.length, UPLOAD_TRANSFER_CONCURRENCY);
 
     const pausing = transferBridge.pauseTransfer(null, { transferId: "late-pause-race" });
     holdWrites = false;

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -620,8 +620,8 @@ test("cancel during stalled resumable upload OPEN ends the isolated channel", as
   assert.ok(endedChannels >= 1, `expected isolated channel end on cancel, got ${endedChannels}`);
 });
 
-test("resumable SFTP uploads fall back to a compatible stream after fast path fails", async (t) => {
-  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-fallback-"));
+test("resumable SFTP uploads fail closed when pipelined strategies fail (no serial stream)", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-fail-closed-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   });
@@ -630,7 +630,7 @@ test("resumable SFTP uploads fall back to a compatible stream after fast path fa
   const localPath = path.join(tempDir, "upload.bin");
   await fs.promises.writeFile(localPath, payload);
   let endedChannels = 0;
-  let remoteBytes = 0;
+  let createWriteStreamCalls = 0;
   const fastSftp = createFastSftp({
     open(_remotePath, _flags, callback) {
       callback(new Error("server rejected random-access writes"));
@@ -641,23 +641,16 @@ test("resumable SFTP uploads fall back to a compatible stream after fast path fa
   });
   const client = {
     sftp: createFastSftp({
+      open(_remotePath, _flags, callback) {
+        callback(new Error("server rejected random-access writes"));
+      },
       createWriteStream() {
-        return new Writable({
-          write(chunk, _encoding, callback) {
-            remoteBytes += chunk.length;
-            callback();
-          },
-          final(callback) {
-            queueMicrotask(() => {
-              this.emit("close");
-              callback();
-            });
-          },
-        });
+        createWriteStreamCalls += 1;
+        throw new Error("serial WriteStream must not run");
       },
     }),
     stat() {
-      return Promise.resolve({ size: remoteBytes });
+      return Promise.resolve({ size: 0 });
     },
     rename() {
       return Promise.resolve();
@@ -676,7 +669,7 @@ test("resumable SFTP uploads fall back to a compatible stream after fast path fa
   const result = await transferBridge.startTransfer(
     { sender: createSender() },
     {
-      transferId: "upload-fallback",
+      transferId: "upload-fail-closed",
       sourcePath: localPath,
       targetPath: "/tmp/upload.bin",
       sourceType: "local",
@@ -687,51 +680,42 @@ test("resumable SFTP uploads fall back to a compatible stream after fast path fa
     },
   );
 
-  assert.equal(result.error, undefined);
-  // concurrent-isolated fails open; fastPut-isolated reopens and ends its channel.
-  // Serial stream uses the shared browse sftp and does not call end on isolated mocks.
+  assert.match(result.error || "", /pipelined upload failed|rejected random-access/i);
+  assert.equal(createWriteStreamCalls, 0);
   assert.ok(endedChannels >= 1, `expected isolated channels to end, got ${endedChannels}`);
-  assert.equal(remoteBytes, payload.length);
 });
 
-test("resumable upload fallback rejects a source changed during streaming", async (t) => {
-  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-fallback-change-"));
+test("resumable concurrent uploads reject a source rewritten mid-transfer", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-source-change-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   });
 
-  const payload = Buffer.alloc(32 * 1024, 41);
+  const payload = Buffer.alloc(64 * 1024, 41);
   const localPath = path.join(tempDir, "upload.bin");
   await fs.promises.writeFile(localPath, payload);
-  let changed = false;
+  let rewritten = false;
   let promoted = false;
   let stagedDeleted = false;
   let remoteBytes = 0;
   const fastSftp = createFastSftp({
     open(_remotePath, _flags, callback) {
-      callback(new Error("range upload unavailable"));
+      callback(null, Buffer.from("remote-handle"));
+    },
+    write(_handle, _buffer, _offset, length, position, callback) {
+      remoteBytes = Math.max(remoteBytes, position + length);
+      if (!rewritten && position === 0) {
+        rewritten = true;
+        fs.writeFileSync(localPath, Buffer.alloc(payload.length, 42));
+      }
+      callback(null);
+    },
+    close(_handle, callback) {
+      callback(null);
     },
   });
   const client = {
-    sftp: createFastSftp({
-      createWriteStream() {
-        return new Writable({
-          write(chunk, _encoding, callback) {
-            remoteBytes += chunk.length;
-            fs.promises.writeFile(localPath, Buffer.alloc(payload.length, 42)).then(() => {
-              changed = true;
-              callback();
-            }, callback);
-          },
-          final(callback) {
-            queueMicrotask(() => {
-              this.emit("close");
-              callback();
-            });
-          },
-        });
-      },
-    }),
+    sftp: createFastSftp({}),
     stat() {
       return Promise.resolve({ size: remoteBytes });
     },
@@ -754,7 +738,7 @@ test("resumable upload fallback rejects a source changed during streaming", asyn
   const result = await transferBridge.startTransfer(
     { sender: createSender() },
     {
-      transferId: "upload-fallback-change",
+      transferId: "upload-source-change",
       sourcePath: localPath,
       targetPath: "/tmp/upload.bin",
       sourceType: "local",
@@ -765,13 +749,13 @@ test("resumable upload fallback rejects a source changed during streaming", asyn
     },
   );
 
-  assert.equal(changed, true);
-  assert.match(result.error || "", /source.*changed/i);
+  assert.equal(rewritten, true);
+  assert.match(result.error || "", /source|content|changed|fingerprint|mismatch/i);
   assert.equal(promoted, false);
   assert.equal(stagedDeleted, true);
 });
 
-test("resumable fast uploads handle isolated channel errors before falling back", async (t) => {
+test("resumable fast uploads fail closed when isolated channel errors (no serial stream)", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-channel-error-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
@@ -781,7 +765,7 @@ test("resumable fast uploads handle isolated channel errors before falling back"
   const localPath = path.join(tempDir, "upload.bin");
   await fs.promises.writeFile(localPath, payload);
   let hadErrorListener = false;
-  let remoteBytes = 0;
+  let createWriteStreamCalls = 0;
   const fastSftp = createFastSftp({
     open(_remotePath, _flags, callback) {
       callback(null, Buffer.from("remote-handle"));
@@ -794,26 +778,23 @@ test("resumable fast uploads handle isolated channel errors before falling back"
         callback(error);
       });
     },
+    close(_handle, callback) {
+      callback(null);
+    },
+    end() {},
   });
   const client = {
     sftp: createFastSftp({
+      open(_remotePath, _flags, callback) {
+        callback(new Error("shared open also fails"));
+      },
       createWriteStream() {
-        return new Writable({
-          write(chunk, _encoding, callback) {
-            remoteBytes += chunk.length;
-            callback();
-          },
-          final(callback) {
-            queueMicrotask(() => {
-              this.emit("close");
-              callback();
-            });
-          },
-        });
+        createWriteStreamCalls += 1;
+        throw new Error("serial WriteStream must not run");
       },
     }),
     stat() {
-      return Promise.resolve({ size: remoteBytes });
+      return Promise.resolve({ size: 0 });
     },
     rename() {
       return Promise.resolve();
@@ -843,13 +824,13 @@ test("resumable fast uploads handle isolated channel errors before falling back"
     },
   );
 
-  assert.equal(result.error, undefined);
+  assert.match(result.error || "", /pipelined upload failed|isolated channel failed/i);
   assert.equal(hadErrorListener, true);
-  assert.equal(remoteBytes, payload.length);
+  assert.equal(createWriteStreamCalls, 0);
 });
 
-test("resumable fast upload fallback discards sparse remote tails", async (t) => {
-  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-sparse-tail-"));
+test("resumable concurrent range failure does not complete via serial stream", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-sparse-fail-closed-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   });
@@ -858,9 +839,8 @@ test("resumable fast upload fallback discards sparse remote tails", async (t) =>
   const localPath = path.join(tempDir, "upload.bin");
   await fs.promises.writeFile(localPath, payload);
   let secondWriteCallback = null;
-  let fallbackOptions = null;
+  let createWriteStreamCalls = 0;
   let remoteBytes = 0;
-  const progress = [];
   const fastSftp = createFastSftp({
     open(_remotePath, _flags, callback) {
       callback(null, Buffer.from("remote-handle"));
@@ -876,24 +856,19 @@ test("resumable fast upload fallback discards sparse remote tails", async (t) =>
         queueMicrotask(() => secondWriteCallback(new Error("second range failed")));
       }
     },
+    close(_handle, callback) {
+      callback(null);
+    },
+    end() {},
   });
   const client = {
     sftp: createFastSftp({
-      createWriteStream(_remotePath, options) {
-        fallbackOptions = options;
-        if (options.flags === "w") remoteBytes = 0;
-        return new Writable({
-          write(chunk, _encoding, callback) {
-            remoteBytes += chunk.length;
-            callback();
-          },
-          final(callback) {
-            queueMicrotask(() => {
-              this.emit("close");
-              callback();
-            });
-          },
-        });
+      open(_remotePath, _flags, callback) {
+        callback(new Error("shared open also fails"));
+      },
+      createWriteStream() {
+        createWriteStreamCalls += 1;
+        throw new Error("serial WriteStream must not run");
       },
     }),
     stat() {
@@ -916,7 +891,7 @@ test("resumable fast upload fallback discards sparse remote tails", async (t) =>
   const result = await transferBridge.startTransfer(
     { sender: createSender() },
     {
-      transferId: "upload-sparse-tail",
+      transferId: "upload-sparse-fail-closed",
       sourcePath: localPath,
       targetPath: "/tmp/upload.bin",
       sourceType: "local",
@@ -925,16 +900,10 @@ test("resumable fast upload fallback discards sparse remote tails", async (t) =>
       totalBytes: payload.length,
       resumable: true,
     },
-    (transferred) => progress.push(transferred),
   );
 
-  assert.equal(result.error, undefined);
-  assert.equal(fallbackOptions.flags, "w");
-  assert.equal(fallbackOptions.start, 0);
-  assert.equal(remoteBytes, payload.length);
-  const firstAdvanced = progress.findIndex((transferred) => transferred > 0);
-  assert.ok(firstAdvanced >= 0);
-  assert.ok(progress.slice(firstAdvanced + 1).includes(0));
+  assert.match(result.error || "", /pipelined upload failed|second range failed/i);
+  assert.equal(createWriteStreamCalls, 0);
 });
 
 test("resumable fast uploads reject a source that grows during transfer", async (t) => {
@@ -1255,11 +1224,19 @@ test("uploads prefer concurrent shared channel over serial WriteStream", async (
 
   assert.equal(result.error, undefined);
   assert.equal(createWriteStreamCalls, 0);
-  assert.equal(maxInFlight, UPLOAD_TRANSFER_CONCURRENCY);
+  // Pipelined fanout must be multi-WRITE (not serial 1-in-flight).
+  assert.ok(
+    maxInFlight >= 2,
+    `expected pipelined concurrency >= 2, got ${maxInFlight}`,
+  );
+  assert.ok(
+    maxInFlight <= UPLOAD_TRANSFER_CONCURRENCY,
+    `expected concurrency <= ${UPLOAD_TRANSFER_CONCURRENCY}, got ${maxInFlight}`,
+  );
 });
 
-test("SFTP stream-fallback uploads wait for close after finish", async (t) => {
-  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-stream-test-"));
+test("sudo SFTP sessions without open/write fail closed (no serial WriteStream)", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-sudo-fail-closed-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   });
@@ -1268,186 +1245,27 @@ test("SFTP stream-fallback uploads wait for close after finish", async (t) => {
   const payload = Buffer.alloc(64 * 1024, 7);
   await fs.promises.writeFile(localPath, payload);
 
-  let resolveClose;
-  const closeGate = new Promise((resolve) => {
-    resolveClose = resolve;
-  });
-  let sawFinishBeforeClose = false;
-  let remoteBytes = 0;
-
-  const streamSftp = createFastSftp({
+  let createWriteStreamCalls = 0;
+  const streamOnlySftp = createFastSftp({
     createWriteStream() {
-      const { Writable } = require("node:stream");
-      const writeStream = new Writable({
-        autoDestroy: false,
-        emitClose: false,
-        write(chunk, _encoding, callback) {
-          remoteBytes += chunk.length;
-          callback();
-        },
-      });
-      // Match ssh2 WriteStream: finish does not imply the remote handle is closed yet.
-      writeStream.on("finish", () => {
-        sawFinishBeforeClose = true;
-        setTimeout(() => {
-          writeStream.emit("close");
-          resolveClose();
-        }, 25);
-      });
-      return writeStream;
+      createWriteStreamCalls += 1;
+      throw new Error("serial WriteStream must not run");
     },
   });
 
   const client = {
-    // Force the sequential stream fallback (no isolated fastPut channel).
+    // Isolated channel skipped; shared sftp has only createWriteStream.
     __netcattySudoMode: true,
-    sftp: streamSftp,
-    stat() {
-      return Promise.resolve({ size: remoteBytes });
-    },
-  };
-  transferBridge.init({ sftpClients: new Map([["target", client]]) });
-
-  const sender = createSender();
-  let transferSettled = false;
-  const transferPromise = transferBridge.startTransfer(
-    { sender },
-    {
-      transferId: "upload-stream-fallback",
-      sourcePath: localPath,
-      targetPath: "/tmp/payload.bin",
-      sourceType: "local",
-      targetType: "sftp",
-      targetSftpId: "target",
-      totalBytes: payload.length,
-    },
-  ).finally(() => {
-    transferSettled = true;
-  });
-
-  // Wait until finish has been observed, then confirm we have not completed yet.
-  const finishDeadline = Date.now() + 1000;
-  while (!sawFinishBeforeClose && Date.now() < finishDeadline) {
-    await new Promise((resolve) => setTimeout(resolve, 5));
-  }
-  assert.equal(sawFinishBeforeClose, true);
-  assert.equal(transferSettled, false);
-
-  await closeGate;
-  // Give the close handler a turn to settle the transfer.
-  const result = await transferPromise;
-  assert.equal(result.error, undefined);
-  assert.equal(remoteBytes, payload.length);
-  assert.ok(sender.sent.some((entry) => entry.channel === "netcatty:transfer:complete"));
-});
-
-test("SFTP stream-fallback uploads accept ssh2 close without finish", async (t) => {
-  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-ssh2-close-"));
-  t.after(async () => {
-    await fs.promises.rm(tempDir, { recursive: true, force: true });
-  });
-
-  const localPath = path.join(tempDir, "payload.bin");
-  const payload = Buffer.alloc(64 * 1024, 9);
-  await fs.promises.writeFile(localPath, payload);
-
-  let remoteBytes = 0;
-  let sawFinish = false;
-  const streamSftp = createFastSftp({
-    createWriteStream() {
-      const { Writable } = require("node:stream");
-      const writeStream = new Writable({
-        autoDestroy: false,
-        emitClose: false,
-        write(chunk, _encoding, callback) {
-          remoteBytes += chunk.length;
-          callback();
-        },
-        final(callback) {
-          // ssh2 closes the remote handle from _final. On current Node versions,
-          // destroying here suppresses the normal Writable "finish" event.
-          this.destroy();
-          callback();
-        },
-        destroy(error, callback) {
-          queueMicrotask(() => {
-            callback(error);
-            if (!error) this.emit("close");
-          });
-        },
-      });
-      writeStream.on("finish", () => {
-        sawFinish = true;
-      });
-      return writeStream;
-    },
-  });
-
-  const client = {
-    __netcattySudoMode: true,
-    sftp: streamSftp,
-    stat() {
-      return Promise.resolve({ size: remoteBytes });
-    },
-  };
-  transferBridge.init({ sftpClients: new Map([["target", client]]) });
-
-  const sender = createSender();
-  const result = await transferBridge.startTransfer(
-    { sender },
-    {
-      transferId: "upload-stream-close-only",
-      sourcePath: localPath,
-      targetPath: "/tmp/payload.bin",
-      sourceType: "local",
-      targetType: "sftp",
-      targetSftpId: "target",
-      totalBytes: payload.length,
-    },
-  );
-
-  assert.equal(sawFinish, false);
-  assert.equal(remoteBytes, payload.length);
-  assert.equal(result.error, undefined);
-  assert.ok(sender.sent.some((entry) => entry.channel === "netcatty:transfer:complete"));
-});
-
-test("SFTP stream-fallback uploads fail on premature close", async (t) => {
-  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-premature-close-"));
-  t.after(async () => {
-    await fs.promises.rm(tempDir, { recursive: true, force: true });
-  });
-
-  const localPath = path.join(tempDir, "payload.bin");
-  await fs.promises.writeFile(localPath, Buffer.alloc(8 * 1024, 3));
-
-  const streamSftp = createFastSftp({
-    createWriteStream() {
-      const { Writable } = require("node:stream");
-      const writeStream = new Writable({
-        autoDestroy: false,
-        emitClose: false,
-        write(_chunk, _encoding, callback) {
-          callback();
-        },
-      });
-      writeStream.on("finish", () => {
-        // Intentionally skip finish-before-close ordering by closing without finish first
-        // is covered by destroying before end; here emit close without marking finish path
-        // via an early close from the producer side.
-      });
-      // Close before any finish event.
-      queueMicrotask(() => writeStream.emit("close"));
-      return writeStream;
-    },
-  });
-
-  const client = {
-    __netcattySudoMode: true,
-    sftp: streamSftp,
+    sftp: streamOnlySftp,
     stat() {
       return Promise.resolve({ size: 0 });
     },
+    rename() {
+      return Promise.resolve();
+    },
+    delete() {
+      return Promise.resolve();
+    },
   };
   transferBridge.init({ sftpClients: new Map([["target", client]]) });
 
@@ -1455,16 +1273,19 @@ test("SFTP stream-fallback uploads fail on premature close", async (t) => {
   const result = await transferBridge.startTransfer(
     { sender },
     {
-      transferId: "upload-premature-close",
+      transferId: "upload-sudo-fail-closed",
       sourcePath: localPath,
       targetPath: "/tmp/payload.bin",
       sourceType: "local",
       targetType: "sftp",
       targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: true,
     },
   );
 
-  assert.match(result.error || "", /closed before finish/);
+  assert.match(result.error || "", /pipelined upload failed|open\/write missing/i);
+  assert.equal(createWriteStreamCalls, 0);
   assert.ok(sender.sent.some((entry) => entry.channel === "netcatty:transfer:error"));
 });
 
@@ -1849,7 +1670,7 @@ test("range-failure fallback truncates sparse local tail before streaming", asyn
   assert.deepEqual(await fs.promises.readFile(targetPath), payload);
 });
 
-test("S2S upload-phase fallback does not truncate the complete local temp source", async (t) => {
+test("S2S upload-phase concurrent failure does not truncate the complete local temp source", async (t) => {
   const transferId = `s2s-no-truncate-${crypto.randomUUID()}`;
   const payload = Buffer.alloc(64 * 1024, 23);
   const localStage = tempDirBridge.getTransferTempFilePath(transferId, "payload.bin");
@@ -1858,9 +1679,7 @@ test("S2S upload-phase fallback does not truncate the complete local temp source
     await fs.promises.unlink(localStage).catch(() => {});
   });
 
-  let sizeAtFallback = null;
-  let fallbackStart = null;
-  let remote = Buffer.alloc(0);
+  let sizeAfterFail = null;
   const fastSftp = createFastSftp({
     open(_remotePath, _flags, callback) {
       callback(null, Buffer.from("remote-handle"));
@@ -1875,6 +1694,7 @@ test("S2S upload-phase fallback does not truncate the complete local temp source
     close(_handle, callback) {
       callback(null);
     },
+    end() {},
   });
   const sourceClient = {
     sftp: createFastSftp({}),
@@ -1882,31 +1702,14 @@ test("S2S upload-phase fallback does not truncate the complete local temp source
   };
   const targetClient = {
     sftp: createFastSftp({
-      createWriteStream(_path, options = {}) {
-        fallbackStart = options.start || 0;
-        try {
-          sizeAtFallback = fs.statSync(localStage).size;
-        } catch {
-          sizeAtFallback = -1;
-        }
-        let offset = options.start || 0;
-        return new Writable({
-          write(chunk, _encoding, callback) {
-            if (remote.length < offset) {
-              remote = Buffer.concat([remote, Buffer.alloc(offset - remote.length)]);
-            }
-            remote = Buffer.concat([
-              remote.subarray(0, offset),
-              Buffer.from(chunk),
-              remote.subarray(offset + chunk.length),
-            ]);
-            offset += chunk.length;
-            callback();
-          },
-        });
+      open(_remotePath, _flags, callback) {
+        callback(new Error("shared open also fails"));
+      },
+      createWriteStream() {
+        throw new Error("serial WriteStream must not run");
       },
     }),
-    stat: async () => ({ size: remote.length }),
+    stat: async () => ({ size: 0 }),
     rename: async () => {},
     delete: async () => {},
     client: {
@@ -1941,10 +1744,14 @@ test("S2S upload-phase fallback does not truncate the complete local temp source
     },
   );
 
-  // Capture happens when stream fallback opens — local temp must still be full.
-  assert.equal(sizeAtFallback, payload.length);
-  assert.equal(fallbackStart, 0);
-  assert.equal(result.error, undefined, result.error);
+  try {
+    sizeAfterFail = fs.statSync(localStage).size;
+  } catch {
+    sizeAfterFail = -1;
+  }
+  // Fail closed — local S2S temp is the fully-downloaded source, never truncated.
+  assert.match(result.error || "", /pipelined upload failed|first upload range failed/i);
+  assert.equal(sizeAfterFail, payload.length);
 });
 
 test("cancelled fast resumable downloads release their isolated channel", async (t) => {
@@ -2434,19 +2241,28 @@ test("server-to-server upload resume uses its own checkpoint instead of overall 
   let remote = Buffer.alloc(0);
   let promoted = false;
   const targetSftp = createFastSftp({
-    createWriteStream(_path, options = {}) {
-      const start = options.start || 0;
-      return new Writable({
-        write(chunk, _encoding, callback) {
-          if (remote.length < start) remote = Buffer.concat([remote, Buffer.alloc(start - remote.length)]);
-          remote = Buffer.concat([remote.subarray(0, start), Buffer.from(chunk)]);
-          callback();
-        },
-      });
+    open(_path, flags, callback) {
+      callback(null, Buffer.from("target-handle"));
+    },
+    write(_handle, buffer, offset, length, position, callback) {
+      const chunk = buffer.subarray(offset, offset + length);
+      if (remote.length < position) {
+        remote = Buffer.concat([remote, Buffer.alloc(position - remote.length)]);
+      }
+      remote = Buffer.concat([
+        remote.subarray(0, position),
+        chunk,
+        remote.subarray(position + chunk.length),
+      ]);
+      callback(null);
+    },
+    close(_handle, callback) {
+      callback(null);
     },
   });
   const sourceClient = { sftp: createFastSftp({}), stat: async () => ({ size: payload.length }) };
   const targetClient = {
+    __netcattySudoMode: true,
     sftp: targetSftp,
     stat: async () => ({ size: remote.length }),
     rename: async () => { promoted = true; },
@@ -2470,13 +2286,13 @@ test("server-to-server upload resume uses its own checkpoint instead of overall 
     uploadCheckpointBytes: 0,
   });
 
-  assert.equal(result.error, undefined);
+  assert.equal(result.error, undefined, result.error);
   assert.deepEqual(remote, payload);
   assert.equal(promoted, true);
 });
 
-test("server-to-server fallback resets mapped progress to its durable checkpoint", async (t) => {
-  const transferId = `server-copy-fallback-${crypto.randomUUID()}`;
+test("server-to-server concurrent failure does not complete via serial stream", async (t) => {
+  const transferId = `server-copy-fail-closed-${crypto.randomUUID()}`;
   const sourcePath = "/source/payload.bin";
   const targetPath = "/target/payload.bin";
   const payload = Buffer.alloc(3 * 32 * 1024, 53);
@@ -2486,6 +2302,7 @@ test("server-to-server fallback resets mapped progress to its durable checkpoint
 
   let secondWriteCallback = null;
   let remoteBytes = 0;
+  let createWriteStreamCalls = 0;
   const fastSftp = createFastSftp({
     open(_remotePath, _flags, callback) {
       callback(null, Buffer.from("remote-handle"));
@@ -2501,22 +2318,18 @@ test("server-to-server fallback resets mapped progress to its durable checkpoint
         queueMicrotask(() => secondWriteCallback(new Error("second range failed")));
       }
     },
+    close(_handle, callback) {
+      callback(null);
+    },
+    end() {},
   });
   const targetSftp = createFastSftp({
-    createWriteStream(_remotePath, options) {
-      if (options.flags === "w") remoteBytes = 0;
-      return new Writable({
-        write(chunk, _encoding, callback) {
-          remoteBytes += chunk.length;
-          callback();
-        },
-        final(callback) {
-          queueMicrotask(() => {
-            this.emit("close");
-            callback();
-          });
-        },
-      });
+    open(_remotePath, _flags, callback) {
+      callback(new Error("shared open also fails"));
+    },
+    createWriteStream() {
+      createWriteStreamCalls += 1;
+      throw new Error("serial WriteStream must not run");
     },
   });
   const sourceClient = {
@@ -2536,7 +2349,6 @@ test("server-to-server fallback resets mapped progress to its durable checkpoint
   };
   transferBridge.init({ sftpClients: new Map([["source", sourceClient], ["target", targetClient]]) });
 
-  const progress = [];
   const result = await transferBridge.startTransfer(
     { sender: createSender() },
     {
@@ -2553,15 +2365,12 @@ test("server-to-server fallback resets mapped progress to its durable checkpoint
       downloadCheckpointBytes: payload.length,
       uploadCheckpointBytes: 0,
     },
-    (transferred) => progress.push(transferred),
   );
 
-  assert.equal(result.error, undefined);
-  const uploadStageStart = payload.length / 2;
-  const firstAdvanced = progress.findIndex((transferred) => transferred > uploadStageStart);
-  assert.ok(firstAdvanced >= 0);
-  assert.ok(progress.slice(firstAdvanced + 1).includes(uploadStageStart));
-  assert.equal(remoteBytes, payload.length);
+  assert.match(result.error || "", /pipelined upload failed|second range failed/i);
+  assert.equal(createWriteStreamCalls, 0);
+  // Local S2S temp (full download) must survive failed upload attempts.
+  assert.equal(fs.statSync(localStage).size, payload.length);
 });
 
 test("upload resume after hard quit clamps checkpoint to durable remote .part size", async (t) => {
@@ -2580,39 +2389,42 @@ test("upload resume after hard quit clamps checkpoint to durable remote .part si
   // Durable remote has first 4 bytes; claimed checkpoint is 8 (progress ahead).
   let remote = Buffer.from("abcd");
   let promoted = false;
-  const streamSftp = createFastSftp({
+  let minWritePosition = Infinity;
+  const concurrentSftp = createFastSftp({
+    open(_path, flags, callback) {
+      callback(null, Buffer.from("resume-handle"));
+    },
+    write(_handle, buffer, offset, length, position, callback) {
+      minWritePosition = Math.min(minWritePosition, position);
+      const chunk = buffer.subarray(offset, offset + length);
+      if (remote.length < position) {
+        remote = Buffer.concat([remote, Buffer.alloc(position - remote.length)]);
+      }
+      remote = Buffer.concat([
+        remote.subarray(0, position),
+        chunk,
+        remote.subarray(position + chunk.length),
+      ]);
+      callback(null);
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+    // Resume safety samples the durable remote prefix via createReadStream.
     createReadStream(_path, options = {}) {
       const start = options.start || 0;
       const end = options.end;
       const slice = end === undefined ? remote.subarray(start) : remote.subarray(start, end + 1);
       return Readable.from([slice]);
     },
-    createWriteStream(_path, options = {}) {
-      let offset = options.start || 0;
-      return new Writable({
-        write(chunk, _encoding, callback) {
-          const buf = Buffer.from(chunk);
-          if (remote.length < offset) {
-            remote = Buffer.concat([remote, Buffer.alloc(offset - remote.length)]);
-          }
-          remote = Buffer.concat([
-            remote.subarray(0, offset),
-            buf,
-            remote.subarray(offset + buf.length),
-          ]);
-          offset += buf.length;
-          callback();
-        },
-        final(callback) {
-          callback();
-          queueMicrotask(() => this.emit("close"));
-        },
-      });
+    createWriteStream() {
+      throw new Error("serial WriteStream must not run");
     },
   });
   const client = {
-    __netcattySudoMode: true, // force sequential stream path (not fastPut)
-    sftp: streamSftp,
+    __netcattySudoMode: true, // shared concurrent path only
+    sftp: concurrentSftp,
+    // First stats clamp checkpoint from claimed 8 down to durable remote size 4.
     stat: async () => ({ size: remote.length }),
     rename: async () => { promoted = true; },
     delete: async () => {},
@@ -2634,6 +2446,8 @@ test("upload resume after hard quit clamps checkpoint to durable remote .part si
   assert.equal(result.error, undefined, result.error);
   assert.deepEqual(remote, payload);
   assert.equal(promoted, true);
+  // Resume must not rewrite the durable prefix from offset 0.
+  assert.ok(minWritePosition >= 4, `expected resume from >=4, got ${minWritePosition}`);
 });
 
 test("local resume after hard quit clamps checkpoint to durable staged file size", async (t) => {

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -94,9 +94,8 @@ test("resumable SFTP uploads use the configured per-file request concurrency", a
   };
   transferBridge.init({ sftpClients: new Map([["target", client]]) });
 
-  const sender = createSender();
   const running = transferBridge.startTransfer(
-    { sender },
+    { sender: createSender() },
     {
       transferId: "upload-large",
       sourcePath: localPath,
@@ -244,8 +243,9 @@ test("resuming while a fast pause is pending settles the pause request", async (
   };
   transferBridge.init({ sftpClients: new Map([["target", client]]) });
 
+  const sender = createSender();
   const running = transferBridge.startTransfer(
-    { sender: createSender() },
+    { sender },
     {
       transferId: "pause-resume-race",
       sourcePath: localPath,
@@ -593,8 +593,9 @@ test("cancel during stalled resumable upload OPEN ends the isolated channel", as
   };
   transferBridge.init({ sftpClients: new Map([["target", client]]) });
 
+  const sender = createSender();
   const running = transferBridge.startTransfer(
-    { sender: createSender() },
+    { sender },
     {
       transferId: "upload-open-stall-cancel",
       sourcePath: localPath,
@@ -618,6 +619,8 @@ test("cancel during stalled resumable upload OPEN ends the isolated channel", as
   const result = await running;
   assert.match(result.error || "", /cancel|closed/i);
   assert.ok(endedChannels >= 1, `expected isolated channel end on cancel, got ${endedChannels}`);
+  assert.ok(sender.sent.some((entry) => entry.channel === "netcatty:transfer:cancelled"));
+  assert.equal(sender.sent.some((entry) => entry.channel === "netcatty:transfer:error"), false);
 });
 
 test("resumable SFTP uploads fail closed when pipelined strategies fail (no serial stream)", async (t) => {
@@ -970,16 +973,17 @@ test("resumable fast uploads reject a source that grows during transfer", async 
   assert.equal(promoted, false);
 });
 
-test("resumable fast uploads reject same-size source changes", async (t) => {
+test("resumable fast uploads reject same-size changes outside old sample regions", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-metadata-change-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   });
 
-  const payload = Buffer.alloc(32 * 1024, 73);
+  const payload = Buffer.alloc(8 * TRANSFER_CHUNK_SIZE, 73);
   const localPath = path.join(tempDir, "upload.bin");
   await fs.promises.writeFile(localPath, payload);
   const frozenStat = await fs.promises.stat(localPath);
+  let changeStarted = false;
   let changed = false;
   let promoted = false;
   let stagedDeleted = false;
@@ -988,14 +992,27 @@ test("resumable fast uploads reject same-size source changes", async (t) => {
       callback(null, Buffer.from("remote-handle"));
     },
     write(_handle, _buffer, _offset, _length, _position, callback) {
-      // Same-size rewrite + restore original mtime/ctime so metadata-only
-      // checks cannot detect the change (Codex regression on coarse FS clocks).
-      fs.promises.writeFile(localPath, Buffer.alloc(payload.length, 74))
-        .then(() => fs.promises.utimes(
-          localPath,
-          frozenStat.atime,
-          frozenStat.mtime,
-        ))
+      if (changeStarted) {
+        callback(null);
+        return;
+      }
+      changeStarted = true;
+      // Rewrite only the second chunk. The old start/middle/end sampling did
+      // not cover this range, and restoring mtime models a coarse filesystem.
+      fs.promises.open(localPath, "r+")
+        .then(async (handle) => {
+          try {
+            await handle.write(
+              Buffer.alloc(TRANSFER_CHUNK_SIZE, 74),
+              0,
+              TRANSFER_CHUNK_SIZE,
+              TRANSFER_CHUNK_SIZE,
+            );
+          } finally {
+            await handle.close();
+          }
+        })
+        .then(() => fs.promises.utimes(localPath, frozenStat.atime, frozenStat.mtime))
         .then(() => {
           changed = true;
           callback(null);

--- a/electron/bridges/transferLimits.cjs
+++ b/electron/bridges/transferLimits.cjs
@@ -4,10 +4,13 @@
 // requests and can silently produce truncated/corrupt files (GitHub #2022).
 const TRANSFER_CHUNK_SIZE = 32 * 1024;
 
-// Upload fanout: 8 parallel 32KB requests (~256KB in flight). Higher than the
-// previous 4 to help high-latency paths, still far below download fanout so
-// interactive terminal traffic is not starved (GitHub #1507).
-const UPLOAD_TRANSFER_CONCURRENCY = 8;
+// Upload fanout: 32 parallel 32KB WRITE requests (~1MB in flight). Measured
+// against real hosts (public ~38ms RTT and LAN ~13ms RTT): concurrency 8 left
+// multi-MB/s on the table; 32 matched Electerm/ssh2-class throughput without
+// the occasional stalls seen at a full 64 on higher-latency paths. Uploads still
+// use an isolated SFTP channel / dedicated transfer session so interactive
+// terminal traffic is not starved (GitHub #1507, #2449).
+const UPLOAD_TRANSFER_CONCURRENCY = 32;
 
 // Downloads need a larger request window on high-latency proxy paths. 64 is
 // ssh2's fastGet default and, with the safe 32KB request size, restores the 2MB

--- a/electron/bridges/transferLimits.test.cjs
+++ b/electron/bridges/transferLimits.test.cjs
@@ -9,12 +9,15 @@ const {
 } = require("./transferLimits.cjs");
 
 test("SFTP transfer limits preserve upload safety and the pre-regression download window", () => {
-  assert.equal(UPLOAD_TRANSFER_CONCURRENCY, 8);
+  assert.equal(UPLOAD_TRANSFER_CONCURRENCY, 32);
   assert.equal(DOWNLOAD_TRANSFER_CONCURRENCY, 64);
   assert.equal(FAST_DOWNLOAD_CHANNELS_PER_SESSION, 1);
   // Keep ssh2's default chunk size — larger packets can corrupt uploads on
   // servers that do not honour non-default WRITE sizes (#2022).
   assert.equal(TRANSFER_CHUNK_SIZE, 32 * 1024);
+  // #2449: upload window is 1MB (32 × 32KB). Raising only concurrency keeps
+  // the safe packet size while matching measured throughput on ~10–40ms paths.
+  assert.equal(UPLOAD_TRANSFER_CONCURRENCY * TRANSFER_CHUNK_SIZE, 1 * 1024 * 1024);
   // #2030 reduced the shared chunk size from 512KB to 32KB. Downloads need
   // enough parallel reads to preserve the 2MB in-flight window that existed
   // after #1533, otherwise high-latency proxy paths collapse to KB/s speeds.


### PR DESCRIPTION
## Summary

- Raise `UPLOAD_TRANSFER_CONCURRENCY` from **8 → 32** so SFTP uploads keep ~**1MB** in flight (`32 × 32KB`), matching measured sweet-spot on real hosts and closing most of the gap with Electerm/ssh2 defaults (`64 × 32KB`).
- Keep `TRANSFER_CHUNK_SIZE` at ssh2’s safe **32KB** default (still required after #2022 / #2030 — larger WRITE packets can corrupt files on some servers).
- Update transfer-bridge tests to assert the configured fanout instead of a hardcoded `8`.

Fixes #2449 (slow SFTP upload vs WindTerm).

## Why

SFTP WRITE throughput is roughly `in_flight / RTT`. With only 8 parallel 32KB requests (256KB window), multi-ms paths leave a lot of bandwidth unused. Stream/`put` fallback is even worse (strictly serial ACKs).

Benchmarks on two test hosts (64MB random payload, `ssh2.fastPut`, same cipher path Netcatty uses):

| Host | RTT | concurrency 8 | concurrency 32 | stream serial |
|------|-----|---------------|----------------|---------------|
| Public `101` | ~38ms | **5.4 MB/s** | **12.4 MB/s** | 0.86 MB/s |
| LAN `10.0.60.25` | ~13ms | **11.0 MB/s** | **19.6 MB/s** | 2.1 MB/s |

Concurrency **64** matched 32 on the LAN when the path was free, but was less consistent on the higher-latency host, so **32** is the default sweet spot (1MB window; downloads remain at 64 / 2MB).

Isolated SFTP channels / dedicated transfer sessions already keep bulk transfer off the interactive terminal path (#1507), so this fanout increase should not reintroduce UI freezes from shared-session pressure.

## Test plan

- [x] `node --test electron/bridges/transferLimits.test.cjs electron/bridges/transferBridge.test.cjs` (46 pass)
- [x] Live `ssh2.fastPut` A/B on public + LAN hosts (see table)
- [ ] Manual: upload a large file in the SFTP panel and confirm speed is no longer stuck near KB/s on multi-ms RTT links
- [ ] Manual: confirm remote size / integrity (zip/tar) still OK after upload
- [ ] Manual: pause/resume still works mid-upload