### PR TITLE
fix(terminal): prevent Docker log color-query leakage

### DIFF
--- a/application/state/useTerminalBackend.ts
+++ b/application/state/useTerminalBackend.ts
@@ -374,6 +374,14 @@ export const useTerminalBackend = () => {
     return bridge.getSessionPwd(sessionId, options);
   }, []);
 
+  const getLocalSessionForeground = useCallback(async (sessionId: string) => {
+    const bridge = netcattyBridge.get();
+    if (!bridge?.getLocalSessionForeground) {
+      return { success: false, error: 'getLocalSessionForeground unavailable' };
+    }
+    return bridge.getLocalSessionForeground(sessionId);
+  }, []);
+
   const getSessionRemoteInfo = useCallback(async (sessionId: string) => {
     const bridge = netcattyBridge.get();
     if (!bridge?.getSessionRemoteInfo) {
@@ -437,6 +445,7 @@ export const useTerminalBackend = () => {
         execCommand,
         setupOsc7Tracking,
         getSessionPwd,
+        getLocalSessionForeground,
         getSessionRemoteInfo,
         getSessionDistroInfo,
         getServerStats,
@@ -514,6 +523,7 @@ export const useTerminalBackend = () => {
       execCommand,
       setupOsc7Tracking,
       getSessionPwd,
+      getLocalSessionForeground,
       getSessionRemoteInfo,
       getSessionDistroInfo,
       getServerStats,

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -360,7 +360,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   ), [sessionId]);
   const sensitivePromptOutputTailRef = useRef("");
   const trustedShellPromptReadyRef = useRef(false);
-  const hibernatedBroadcastInputRef = useRef({ promptReady: false, line: "", tracking: false });
+  const hibernatedBroadcastInputRef = useRef({ promptReady: false, line: "", tracking: false, edited: false });
   const [activeScriptRun, setActiveScriptRun] = useState<import('@/types/global/netcatty-bridge-script.d.ts').ScriptRun | undefined>(undefined);
   const dismissedScriptRunIdRef = useRef<string | null>(null);
 
@@ -1018,7 +1018,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       }
       if (data.includes("\r") || data.includes("\n") || data.includes("\x03")) {
         trustedShellPromptReadyRef.current = false;
-        hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false };
+        hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false, edited: false };
       }
     },
   ), [isNetworkDevice, sessionId]);
@@ -1408,6 +1408,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
           xtermRuntimeRef.current?.getKittyKeyboardProtocolEnabled()
             ?? kittyKeyboardProtocolEnabledForSession,
           passwordPromptActiveRef.current,
+          suppressOscColorQueriesForActiveCommandRef.current,
           knownCwdRef.current ?? null,
           terminalTitleRef.current ?? null,
         );
@@ -1431,6 +1432,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         }
         if (typeof payload.passwordPromptActive === "boolean") {
           passwordPromptActiveRef.current = payload.passwordPromptActive;
+        }
+        if (typeof payload.suppressOscColorQueries === "boolean") {
+          suppressOscColorQueriesForActiveCommandRef.current = payload.suppressOscColorQueries;
         }
         if (payload.cwd !== undefined) {
           const cwd = terminalCwdTracker.setRendererCwd(payload.cwd);
@@ -1572,6 +1576,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
             kittyKeyboardProtocolEnabled:
               xtermRuntimeRef.current?.getKittyKeyboardProtocolEnabled(),
             passwordPromptActive: passwordPromptActiveRef.current,
+            suppressOscColorQueries: suppressOscColorQueriesForActiveCommandRef.current,
             cwd: knownCwdRef.current ?? null,
             title: terminalTitleRef.current ?? null,
           },
@@ -1654,7 +1659,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const clearHibernateRuntimeState = useCallback(() => {
     hibernatedRef.current = false;
     trustedShellPromptReadyRef.current = false;
-    hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false };
+    hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false, edited: false };
     softHiddenRef.current = false;
     hibernateSnapshotRef.current = "";
     hibernateViewportSnapshotRef.current = "";
@@ -1729,12 +1734,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       passwordPromptActiveRef.current = meta.pluginPipelineSensitiveInput;
       trustedShellPromptReadyRef.current = false;
       if (meta.pluginPipelineSensitiveInput) {
-        hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false };
+        hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false, edited: false };
         autocompleteCloseRef.current?.();
       } else {
         sensitivePromptOutputTailRef.current = "";
         if (!hibernatedBroadcastInputRef.current.tracking) {
-          hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false };
+          hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false, edited: false };
         }
       }
       return;
@@ -1744,7 +1749,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     )) {
       passwordPromptActiveRef.current = true;
       trustedShellPromptReadyRef.current = false;
-      hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false };
+      hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false, edited: false };
       autocompleteCloseRef.current?.();
     } else if (isConfirmedTerminalShellPrompt(
       sensitivePromptOutputTailRef.current,
@@ -1752,11 +1757,11 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     )) {
       passwordPromptActiveRef.current = false;
       trustedShellPromptReadyRef.current = true;
-      hibernatedBroadcastInputRef.current = { promptReady: true, line: "", tracking: false };
+      hibernatedBroadcastInputRef.current = { promptReady: true, line: "", tracking: false, edited: false };
     } else {
       trustedShellPromptReadyRef.current = false;
       if (hibernatedRef.current && !hibernatedBroadcastInputRef.current.tracking) {
-        hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false };
+        hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false, edited: false };
       }
     }
   }, [isNetworkDevice]);
@@ -1919,6 +1924,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       promptReady: trustedShellPromptReadyRef.current,
       line: "",
       tracking: false,
+      edited: false,
     };
     isBootActiveRef.current = false;
     releaseTerminalFlowBeforeHibernate(terminalBackend, term, backendId);

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -152,6 +152,7 @@ import {
   type SudoPasswordAutofill,
 } from "./terminal/runtime/terminalSudoAutofill";
 import {
+  isTrustedTerminalShellSubmission,
   recordTerminalCommandExecution,
   shouldRecordShellHistory,
 } from "./terminal/runtime/terminalCommandExecution";
@@ -457,11 +458,14 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const suppressOscColorQueriesForActiveCommandRef = useRef(false);
   useEffect(() => registerOscColorQuerySuppressionArmer(
     sessionId,
-    (command) => beginOscColorQuerySuppressionForCommand(
-      suppressOscColorQueriesForActiveCommandRef,
-      command,
-    ),
-  ), [sessionId]);
+    (command) => {
+      if (!isTrustedTerminalShellSubmission(command, termRef.current, isNetworkDevice)) return;
+      beginOscColorQuerySuppressionForCommand(
+        suppressOscColorQueriesForActiveCommandRef,
+        command,
+      );
+    },
+  ), [isNetworkDevice, sessionId]);
   const promptLineBreakStateRef = useRef<PromptLineBreakState>(createPromptLineBreakState());
   const [hasMouseTracking, setHasMouseTracking] = useState(false);
   const mouseTrackingRef = useRef(false);
@@ -831,6 +835,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       const sensitive = passwordPromptActiveRef.current;
       let textToWrite = text;
       let handledSubmittedInput = false;
+      let trustedSubmittedCommand: string | undefined;
       if (
         host.protocol !== "serial" &&
         statusRef.current === "connected" &&
@@ -880,11 +885,6 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         terminalBackend.writeToSession(id, textToWrite, { sensitive });
       }
 
-      // Broadcast to other sessions if broadcast mode is enabled
-      if (!sensitive && isBroadcastEnabledRef.current && onBroadcastInputRef.current) {
-        onBroadcastInputRef.current(text, sessionId);
-      }
-
       // Update command buffer for onCommandExecuted tracking
       for (const ch of text) {
         if (handledSubmittedInput) {
@@ -904,7 +904,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
             sessionId,
             onCommandExecuted,
             onCommandSubmitted,
-            onTrustedCommandSubmitted: pluginAwareOnCommandSubmitted,
+            onTrustedCommandSubmitted: (command) => {
+              trustedSubmittedCommand = command;
+              pluginAwareOnCommandSubmitted(command);
+            },
             commandBufferRef,
             promptLineBreakStateRef,
           }, termRef.current, { sensitive, allowHostStyleGreaterThanPrompt: isNetworkDevice });
@@ -920,6 +923,18 @@ const TerminalComponent: React.FC<TerminalProps> = ({
           commandBufferRef.current += ch;
           recorderRef.current.recordInput(ch);
         }
+      }
+
+      // Broadcast only after semantic command tracking so trusted direct-send
+      // submissions can carry the same peer suppression transition as typing.
+      if (!sensitive && isBroadcastEnabledRef.current && onBroadcastInputRef.current) {
+        onBroadcastInputRef.current(
+          text,
+          sessionId,
+          trustedSubmittedCommand !== undefined
+            ? { oscColorQuerySuppressionCommand: trustedSubmittedCommand }
+            : undefined,
+        );
       }
     }
   };

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -135,6 +135,7 @@ import {
   beginOscColorQuerySuppression,
   beginOscColorQuerySuppressionForCommand,
   endOscColorQuerySuppressionForCommand,
+  registerOscColorQuerySuppressionArmer,
 } from "./terminal/runtime/oscColorQuerySuppression";
 import { clearKittyKeyboardBroadcastSession } from "./terminal/runtime/kittyKeyboardBroadcast";
 import { registerTerminalSensitiveInputReader } from "./terminal/runtime/terminalSensitiveInputRegistry";
@@ -454,6 +455,13 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const onSessionExitRef = useRef(onSessionExit);
   const commandBufferRef = useRef<string>("");
   const suppressOscColorQueriesForActiveCommandRef = useRef(false);
+  useEffect(() => registerOscColorQuerySuppressionArmer(
+    sessionId,
+    (command) => beginOscColorQuerySuppressionForCommand(
+      suppressOscColorQueriesForActiveCommandRef,
+      command,
+    ),
+  ), [sessionId]);
   const promptLineBreakStateRef = useRef<PromptLineBreakState>(createPromptLineBreakState());
   const [hasMouseTracking, setHasMouseTracking] = useState(false);
   const mouseTrackingRef = useRef(false);
@@ -2608,6 +2616,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       onBroadcastInputRef.current(data, sessionId, {
         noAutoRun,
         ...(lineDelayMs ? { lineDelayMs } : {}),
+        ...(!noAutoRun ? { oscColorQuerySuppressionCommand: command } : {}),
       });
     }
 

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -117,6 +117,7 @@ import { ZmodemProgressIndicator } from "./terminal/ZmodemProgressIndicator";
 import { createReplaySafeTerminalLogSanitizer } from "./terminal/replaySafeTerminalLog";
 import { createConnectionLogBuffer } from "./terminal/connectionLogBuffer";
 import { createProgrammaticCommandLogRewriter, type ProgrammaticCommandLogRewrite } from "./terminal/programmaticCommandLog";
+import { getAlignedPrompt } from "./terminal/autocomplete/promptDetector";
 import { getSessionLogInitialLine } from "./terminal/sessionLogInitialLine";
 import { getTerminalSelectionForClipboard } from "./terminal/normalizeTerminalSelection";
 import { useZmodemTransfer } from "./terminal/hooks/useZmodemTransfer";
@@ -130,6 +131,11 @@ import {
   resetKittyKeyboardModeStateForSession,
   type XTermRuntime,
 } from "./terminal/runtime/createXTermRuntime";
+import {
+  beginOscColorQuerySuppression,
+  beginOscColorQuerySuppressionForCommand,
+  endOscColorQuerySuppressionForCommand,
+} from "./terminal/runtime/oscColorQuerySuppression";
 import { clearKittyKeyboardBroadcastSession } from "./terminal/runtime/kittyKeyboardBroadcast";
 import { registerTerminalSensitiveInputReader } from "./terminal/runtime/terminalSensitiveInputRegistry";
 import { applyUserCursorPreference } from "./terminal/runtime/cursorPreference";
@@ -254,6 +260,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   lastCwd,
   restoreTerminalCwd = false,
   startupCommand,
+  startupCommandKind,
   noAutoRun,
   multiLineRunMode,
   pendingScriptId,
@@ -446,6 +453,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const onTerminalDataCaptureRef = useRef(onTerminalDataCapture);
   const onSessionExitRef = useRef(onSessionExit);
   const commandBufferRef = useRef<string>("");
+  const suppressOscColorQueriesForActiveCommandRef = useRef(false);
   const promptLineBreakStateRef = useRef<PromptLineBreakState>(createPromptLineBreakState());
   const [hasMouseTracking, setHasMouseTracking] = useState(false);
   const mouseTrackingRef = useRef(false);
@@ -1700,6 +1708,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
     disposeExitRef.current?.();
     disposeExitRef.current = terminalBackend.onSessionExit(backendId, (evt) => {
+      endOscColorQuerySuppressionForCommand(suppressOscColorQueriesForActiveCommandRef);
       disposeTelnetEchoModeRef.current?.();
       disposeTelnetEchoModeRef.current = null;
       telnetLocalEchoRef.current = false;
@@ -1958,6 +1967,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const pluginAwareOnCommandSubmitted = useCallback((
     command: string,
   ) => {
+    beginOscColorQuerySuppressionForCommand(
+      suppressOscColorQueriesForActiveCommandRef,
+      command,
+    );
     markTerminalCommandCompletionPending(promptLineBreakStateRef);
     pluginTerminalLifecycle.onCommandSubmitted();
     void xtermRuntimeRef.current?.pluginProviderHost?.commandSubmitted(command);
@@ -2078,6 +2091,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       knownCwdRef.current = cwd;
     },
     onSessionExit: (closedSessionId, evt) => {
+      endOscColorQuerySuppressionForCommand(suppressOscColorQueriesForActiveCommandRef);
       clearTerminalCwd();
       pluginTerminalLifecycle.onSessionExited(evt.exitCode);
       onSessionExitRef.current?.(closedSessionId, evt);
@@ -2094,6 +2108,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     onTerminalLogData: captureTerminalLogData,
     onProgrammaticCommandLogRewrite: queueProgrammaticCommandLogRewrite,
     onOsDetected,
+    onStartupCommandStarted: () => {
+      if (startupCommandKind !== 'dockerLogs') return;
+      beginOscColorQuerySuppression(suppressOscColorQueriesForActiveCommandRef);
+    },
     onCommandExecuted,
     onCommandSubmitted,
     onCommandCompleted: pluginAwareOnCommandCompleted,
@@ -2546,6 +2564,22 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     const id = sessionRef.current;
     if (!term || !id) return;
 
+    if (!noAutoRun) {
+      const prompt = getAlignedPrompt(term, '', false).prompt;
+      if (
+        prompt.isAtPrompt
+        && prompt.userInput.trim().length === 0
+        && isConfirmedTerminalShellPrompt(prompt.promptText, {
+          allowHostStyleGreaterThan: isNetworkDevice,
+        })
+      ) {
+        beginOscColorQuerySuppressionForCommand(
+          suppressOscColorQueriesForActiveCommandRef,
+          command,
+        );
+      }
+    }
+
     let data = normalizeLineEndings(command);
     const lineDelayMs = shouldDelayAutoRunSnippetInput(data, {
       noAutoRun,
@@ -2585,7 +2619,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     });
     scrollToBottomAfterProgrammaticInput(data);
     term.focus();
-  }, [prepareProgrammaticSudoInput, scrollToBottomAfterProgrammaticInput, terminalBackend, sessionId]);
+  }, [isNetworkDevice, prepareProgrammaticSudoInput, scrollToBottomAfterProgrammaticInput, terminalBackend, sessionId]);
 
   const executeSnippet = useCallback(async (snippet: Snippet) => {
     if (isScriptSnippet(snippet)) {
@@ -3204,6 +3238,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     resolvedFontFamily,
     fontSize: effectiveFontSize,
     terminalTheme: effectiveTheme,
+    suppressOscColorQueriesForActiveCommandRef,
     terminalSettingsRef,
     kittyKeyboardProtocolEnabled: kittyKeyboardProtocolEnabledForSession,
     terminalBackend,
@@ -3438,7 +3473,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     onWake: wakeFromHibernateRuntime,
   });
 
-  useTerminalEffects({ CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, chainHosts: resolvedChainHosts, chainProgress, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, finalizeTerminalLogData, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceCloseHibernatedSession, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, hasRuntimeRef, host, hotkeySchemeRef, hibernatedRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen: effectiveComposeBarOpen, isConnectionAwaitingUserInput, isConnectionPastTcpDial, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing: deferTerminalResize, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, kittyKeyboardProtocolEnabledForSession, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, needsHostKeyVerification, onBroadcastInputRef, onBroadcastInterruptPriorityChange, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onOutputTriggerUserInputRef: noteOutputTriggerUserInputRef, onPluginRuntimeCwdChange: pluginAwareOnRuntimeCwdChange, onSnippetShortkeyRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, passwordPromptActiveRef, pendingAuthRef, pendingOutputScrollRef, pluginDecorationRefreshRef, pluginDecorationRules, pluginDecorationRulesRef, pluginTerminalLifecycle, pluginTerminalProviderRevision, isPluginTerminalProviderAvailable, requestPluginTerminalProviders, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, scriptRecorderRef: recorderRef, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, requestSearchFocus, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shellType, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, attachExistingSession, attachAuthorization, attachHomeWebContentsIdRef, snippetsRef, splitResizeActive: isResizing, status, statusRef, sudoAutofillRef, t, teardown, telnetLocalEchoRef, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, terminalTitleRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, workspaceId, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState });
+  useTerminalEffects({ CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, chainHosts: resolvedChainHosts, chainProgress, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, finalizeTerminalLogData, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceCloseHibernatedSession, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, hasRuntimeRef, host, hotkeySchemeRef, hibernatedRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen: effectiveComposeBarOpen, isConnectionAwaitingUserInput, isConnectionPastTcpDial, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing: deferTerminalResize, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, kittyKeyboardProtocolEnabledForSession, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, needsHostKeyVerification, onBroadcastInputRef, onBroadcastInterruptPriorityChange, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onOutputTriggerUserInputRef: noteOutputTriggerUserInputRef, onPluginRuntimeCwdChange: pluginAwareOnRuntimeCwdChange, onSnippetShortkeyRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, passwordPromptActiveRef, pendingAuthRef, pendingOutputScrollRef, pluginDecorationRefreshRef, pluginDecorationRules, pluginDecorationRulesRef, pluginTerminalLifecycle, pluginTerminalProviderRevision, isPluginTerminalProviderAvailable, requestPluginTerminalProviders, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, scriptRecorderRef: recorderRef, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, requestSearchFocus, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shellType, suppressOscColorQueriesForActiveCommandRef, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, attachExistingSession, attachAuthorization, attachHomeWebContentsIdRef, snippetsRef, splitResizeActive: isResizing, status, statusRef, sudoAutofillRef, t, teardown, telnetLocalEchoRef, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, terminalTitleRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, workspaceId, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState });
 
   return (
     <>

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -987,22 +987,35 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     (data, command) => {
       const broadcastInput = hibernatedBroadcastInputRef.current;
       if (termRef.current && !broadcastInput.tracking) {
-        broadcastInput.promptReady = isTrustedTerminalShellSubmission(
-          "",
-          termRef.current,
-          isNetworkDevice,
+        const livePrompt = getAlignedPrompt(termRef.current, "", false).prompt;
+        broadcastInput.promptReady = Boolean(
+          livePrompt.isAtPrompt
+          && livePrompt.userInput.trim().length === 0
+          && isConfirmedTerminalShellPrompt(livePrompt.promptText, {
+            allowHostStyleGreaterThan: isNetworkDevice,
+          }),
         );
         broadcastInput.line = "";
       }
-      const trustedTarget = (termRef.current || hibernatedRef.current)
+      const trackedTarget = (termRef.current || hibernatedRef.current)
         ? consumeHibernatedBroadcastInput(broadcastInput, data, command)
         : false;
+      const liveTarget = termRef.current && command !== undefined
+        ? getAlignedPrompt(termRef.current, "", false).prompt
+        : null;
+      const trustedTarget = trackedTarget || Boolean(
+        liveTarget?.isAtPrompt
+        && liveTarget.userInput.trim() === command?.trim()
+        && isConfirmedTerminalShellPrompt(liveTarget.promptText, {
+          allowHostStyleGreaterThan: isNetworkDevice,
+        }),
+      );
       if (trustedTarget && command !== undefined) {
         beginOscColorQuerySuppressionForCommand(
           suppressOscColorQueriesForActiveCommandRef,
           command,
         );
-      } else if (data.includes("\r") || data.includes("\n") || data.includes("\x03")) {
+      } else if (data.includes("\r") || data.includes("\n")) {
         endOscColorQuerySuppressionForCommand(suppressOscColorQueriesForActiveCommandRef);
       }
       if (data.includes("\r") || data.includes("\n") || data.includes("\x03")) {
@@ -1717,11 +1730,14 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     if (typeof meta?.pluginPipelineSensitiveInput === "boolean") {
       passwordPromptActiveRef.current = meta.pluginPipelineSensitiveInput;
       trustedShellPromptReadyRef.current = false;
-      hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false };
       if (meta.pluginPipelineSensitiveInput) {
+        hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false };
         autocompleteCloseRef.current?.();
       } else {
         sensitivePromptOutputTailRef.current = "";
+        if (!hibernatedBroadcastInputRef.current.tracking) {
+          hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false };
+        }
       }
       return;
     } else if (isUntrustedTerminalInputPrompt(
@@ -1741,6 +1757,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       hibernatedBroadcastInputRef.current = { promptReady: true, line: "", tracking: false };
     } else {
       trustedShellPromptReadyRef.current = false;
+      if (hibernatedRef.current && !hibernatedBroadcastInputRef.current.tracking) {
+        hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false };
+      }
     }
   }, [isNetworkDevice]);
 
@@ -2623,12 +2642,15 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       && onBroadcastInputRef.current
     ) {
       const pastedCommand = getSinglePastedCommand(data)?.command;
-      const trustedCommand = pastedCommand && isTrustedTerminalShellSubmission(
-        pastedCommand,
+      const submittedCommand = pastedCommand
+        ? `${commandBufferRef.current}${pastedCommand}`
+        : undefined;
+      const trustedCommand = submittedCommand && isTrustedTerminalShellSubmission(
+        submittedCommand,
         termRef.current,
         isNetworkDevice,
       )
-        ? pastedCommand
+        ? submittedCommand
         : undefined;
       onBroadcastInputRef.current(
         data,

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -134,6 +134,7 @@ import {
 import {
   beginOscColorQuerySuppressionForCommand,
   beginOscColorQuerySuppressionForStartupCommand,
+  consumeHibernatedBroadcastInput,
   endOscColorQuerySuppressionForCommand,
   registerOscColorQuerySuppressionArmer,
 } from "./terminal/runtime/oscColorQuerySuppression";
@@ -359,6 +360,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   ), [sessionId]);
   const sensitivePromptOutputTailRef = useRef("");
   const trustedShellPromptReadyRef = useRef(false);
+  const hibernatedBroadcastInputRef = useRef({ promptReady: false, line: "" });
   const [activeScriptRun, setActiveScriptRun] = useState<import('@/types/global/netcatty-bridge-script.d.ts').ScriptRun | undefined>(undefined);
   const dismissedScriptRunIdRef = useRef<string | null>(null);
 
@@ -982,16 +984,28 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     host.deviceType === 'network' || detectedDeviceClass === 'network-device';
   useEffect(() => registerOscColorQuerySuppressionArmer(
     sessionId,
-    (command) => {
+    (data, command) => {
       const trustedTarget = termRef.current
-        ? isTrustedTerminalShellSubmission(command, termRef.current, isNetworkDevice)
-        : hibernatedRef.current && trustedShellPromptReadyRef.current;
-      if (!trustedTarget) return;
-      beginOscColorQuerySuppressionForCommand(
-        suppressOscColorQueriesForActiveCommandRef,
-        command,
-      );
-      trustedShellPromptReadyRef.current = false;
+        ? command !== undefined
+          && isTrustedTerminalShellSubmission(command, termRef.current, isNetworkDevice)
+        : hibernatedRef.current
+          && consumeHibernatedBroadcastInput(
+            hibernatedBroadcastInputRef.current,
+            data,
+            command,
+          );
+      if (trustedTarget) {
+        beginOscColorQuerySuppressionForCommand(
+          suppressOscColorQueriesForActiveCommandRef,
+          command,
+        );
+      } else if (data.includes("\r") || data.includes("\n") || data.includes("\x03")) {
+        endOscColorQuerySuppressionForCommand(suppressOscColorQueriesForActiveCommandRef);
+      }
+      if (data.includes("\r") || data.includes("\n") || data.includes("\x03")) {
+        trustedShellPromptReadyRef.current = false;
+        hibernatedBroadcastInputRef.current = { promptReady: false, line: "" };
+      }
     },
   ), [isNetworkDevice, sessionId]);
   const remoteDragDropUsesZmodem = supportsZmodemTerminalDragDrop(host, isNetworkDevice);
@@ -1626,6 +1640,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const clearHibernateRuntimeState = useCallback(() => {
     hibernatedRef.current = false;
     trustedShellPromptReadyRef.current = false;
+    hibernatedBroadcastInputRef.current = { promptReady: false, line: "" };
     softHiddenRef.current = false;
     hibernateSnapshotRef.current = "";
     hibernateViewportSnapshotRef.current = "";
@@ -1699,6 +1714,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     if (typeof meta?.pluginPipelineSensitiveInput === "boolean") {
       passwordPromptActiveRef.current = meta.pluginPipelineSensitiveInput;
       trustedShellPromptReadyRef.current = false;
+      hibernatedBroadcastInputRef.current = { promptReady: false, line: "" };
       if (meta.pluginPipelineSensitiveInput) {
         autocompleteCloseRef.current?.();
       } else {
@@ -1711,6 +1727,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     )) {
       passwordPromptActiveRef.current = true;
       trustedShellPromptReadyRef.current = false;
+      hibernatedBroadcastInputRef.current = { promptReady: false, line: "" };
       autocompleteCloseRef.current?.();
     } else if (isConfirmedTerminalShellPrompt(
       sensitivePromptOutputTailRef.current,
@@ -1718,6 +1735,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     )) {
       passwordPromptActiveRef.current = false;
       trustedShellPromptReadyRef.current = true;
+      if (hibernatedRef.current) {
+        hibernatedBroadcastInputRef.current = { promptReady: true, line: "" };
+      }
     } else {
       trustedShellPromptReadyRef.current = false;
     }
@@ -1877,6 +1897,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       term,
       isNetworkDevice,
     );
+    hibernatedBroadcastInputRef.current = {
+      promptReady: trustedShellPromptReadyRef.current,
+      line: "",
+    };
     isBootActiveRef.current = false;
     releaseTerminalFlowBeforeHibernate(terminalBackend, term, backendId);
     disposeDataRef.current?.();

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -2578,6 +2578,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     const id = sessionRef.current;
     if (!term || !id) return;
 
+    let trustedShellSubmission = false;
     if (!noAutoRun) {
       const prompt = getAlignedPrompt(term, '', false).prompt;
       if (
@@ -2587,6 +2588,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
           allowHostStyleGreaterThan: isNetworkDevice,
         })
       ) {
+        trustedShellSubmission = true;
         beginOscColorQuerySuppressionForCommand(
           suppressOscColorQueriesForActiveCommandRef,
           command,
@@ -2622,7 +2624,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       onBroadcastInputRef.current(data, sessionId, {
         noAutoRun,
         ...(lineDelayMs ? { lineDelayMs } : {}),
-        ...(!noAutoRun ? { oscColorQuerySuppressionCommand: command } : {}),
+        ...(trustedShellSubmission ? { oscColorQuerySuppressionCommand: command } : {}),
       });
     }
 

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -147,6 +147,7 @@ import {
   type PromptLineBreakState,
 } from "./terminal/runtime/promptLineBreak";
 import {
+  getSinglePastedCommand,
   prepareSudoAutofillInput,
   type PasswordPromptPickerState,
   type SudoPasswordAutofill,
@@ -2595,11 +2596,25 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       && isBroadcastEnabledRef.current
       && onBroadcastInputRef.current
     ) {
-      onBroadcastInputRef.current(data, sessionId);
+      const pastedCommand = getSinglePastedCommand(data)?.command;
+      const trustedCommand = pastedCommand && isTrustedTerminalShellSubmission(
+        pastedCommand,
+        termRef.current,
+        isNetworkDevice,
+      )
+        ? pastedCommand
+        : undefined;
+      onBroadcastInputRef.current(
+        data,
+        sessionId,
+        trustedCommand !== undefined
+          ? { oscColorQuerySuppressionCommand: trustedCommand }
+          : undefined,
+      );
       return true;
     }
     return false;
-  }, [sessionId]);
+  }, [isNetworkDevice, sessionId]);
 
   const executeSnippetCommand = useCallback((
     command: string,

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -2086,7 +2086,13 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     pluginTerminalLifecycle.onCommandSubmitted();
     void xtermRuntimeRef.current?.pluginProviderHost?.commandSubmitted(command);
   }, [pluginTerminalLifecycle]);
-  const pluginAwareOnCommandCompleted = useCallback(() => {
+  const pluginAwareOnCommandCompleted = useCallback((meta?: { source: 'osc133' | 'prompt' }) => {
+    // Prompt-shaped container output is not a trustworthy end boundary. Shell
+    // integration completion is the only in-band natural-completion signal;
+    // session exit covers the built-in Docker logs window.
+    if (meta?.source === 'osc133') {
+      endOscColorQuerySuppressionForCommand(suppressOscColorQueriesForActiveCommandRef);
+    }
     pluginTerminalLifecycle.onCommandCompleted();
     void xtermRuntimeRef.current?.pluginProviderHost?.commandCompleted();
   }, [pluginTerminalLifecycle]);

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1782,7 +1782,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         const suppressionVersion = getOscColorQuerySuppressionVersion(
           suppressOscColorQueriesForActiveCommandRef,
         );
-        void terminalBackend.getSessionPwd(activeSessionId, { allowHomeFallback: false })
+        const foregroundProbe = isLocalConnection
+          ? terminalBackend.getLocalSessionForeground(activeSessionId)
+          : terminalBackend.getSessionPwd(activeSessionId, { allowHomeFallback: false });
+        void foregroundProbe
           .then((result) => {
             if (
               result.success
@@ -1806,7 +1809,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false, edited: false };
       }
     }
-  }, [isNetworkDevice, terminalBackend]);
+  }, [isLocalConnection, isNetworkDevice, terminalBackend]);
 
   const beginHibernatedSessionListeners = useCallback((backendId: string) => {
     disposeDataRef.current?.();
@@ -1960,15 +1963,14 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     const hibernatePrompt = getAlignedPrompt(term, "", false).prompt;
     trustedShellPromptReadyRef.current = Boolean(
       hibernatePrompt.isAtPrompt
-      && hibernatePrompt.userInput.trim().length === 0
       && isConfirmedTerminalShellPrompt(hibernatePrompt.promptText, {
         allowHostStyleGreaterThan: isNetworkDevice,
       }),
     );
     hibernatedBroadcastInputRef.current = {
       promptReady: trustedShellPromptReadyRef.current,
-      line: "",
-      tracking: false,
+      line: hibernatePrompt.userInput,
+      tracking: hibernatePrompt.userInput.length > 0,
       edited: false,
     };
     isBootActiveRef.current = false;

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -136,6 +136,7 @@ import {
   beginOscColorQuerySuppressionForStartupCommand,
   consumeHibernatedBroadcastInput,
   endOscColorQuerySuppressionForCommand,
+  markOscColorQuerySuppressionEndBoundary,
   registerOscColorQuerySuppressionArmer,
 } from "./terminal/runtime/oscColorQuerySuppression";
 import { clearKittyKeyboardBroadcastSession } from "./terminal/runtime/kittyKeyboardBroadcast";
@@ -985,6 +986,11 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   useEffect(() => registerOscColorQuerySuppressionArmer(
     sessionId,
     (data, command) => {
+      if (data.includes("\x03")) {
+        markOscColorQuerySuppressionEndBoundary(
+          suppressOscColorQueriesForActiveCommandRef,
+        );
+      }
       const broadcastInput = hibernatedBroadcastInputRef.current;
       if (termRef.current && !broadcastInput.tracking) {
         const livePrompt = getAlignedPrompt(termRef.current, "", false).prompt;

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -357,6 +357,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     () => passwordPromptActiveRef.current,
   ), [sessionId]);
   const sensitivePromptOutputTailRef = useRef("");
+  const trustedShellPromptReadyRef = useRef(false);
   const [activeScriptRun, setActiveScriptRun] = useState<import('@/types/global/netcatty-bridge-script.d.ts').ScriptRun | undefined>(undefined);
   const dismissedScriptRunIdRef = useRef<string | null>(null);
 
@@ -459,11 +460,15 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   useEffect(() => registerOscColorQuerySuppressionArmer(
     sessionId,
     (command) => {
-      if (!isTrustedTerminalShellSubmission(command, termRef.current, isNetworkDevice)) return;
+      const trustedTarget = termRef.current
+        ? isTrustedTerminalShellSubmission(command, termRef.current, isNetworkDevice)
+        : hibernatedRef.current && trustedShellPromptReadyRef.current;
+      if (!trustedTarget) return;
       beginOscColorQuerySuppressionForCommand(
         suppressOscColorQueriesForActiveCommandRef,
         command,
       );
+      trustedShellPromptReadyRef.current = false;
     },
   ), [isNetworkDevice, sessionId]);
   const promptLineBreakStateRef = useRef<PromptLineBreakState>(createPromptLineBreakState());
@@ -1619,6 +1624,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const clearHibernateRuntimeState = useCallback(() => {
     hibernatedRef.current = false;
+    trustedShellPromptReadyRef.current = false;
     softHiddenRef.current = false;
     hibernateSnapshotRef.current = "";
     hibernateViewportSnapshotRef.current = "";
@@ -1691,6 +1697,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     const promptSecurityOptions = { allowHostStyleGreaterThan: isNetworkDevice };
     if (typeof meta?.pluginPipelineSensitiveInput === "boolean") {
       passwordPromptActiveRef.current = meta.pluginPipelineSensitiveInput;
+      trustedShellPromptReadyRef.current = false;
       if (meta.pluginPipelineSensitiveInput) {
         autocompleteCloseRef.current?.();
       } else {
@@ -1702,12 +1709,16 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       promptSecurityOptions,
     )) {
       passwordPromptActiveRef.current = true;
+      trustedShellPromptReadyRef.current = false;
       autocompleteCloseRef.current?.();
     } else if (isConfirmedTerminalShellPrompt(
       sensitivePromptOutputTailRef.current,
       promptSecurityOptions,
     )) {
       passwordPromptActiveRef.current = false;
+      trustedShellPromptReadyRef.current = true;
+    } else {
+      trustedShellPromptReadyRef.current = false;
     }
   }, [isNetworkDevice]);
 
@@ -1860,6 +1871,11 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }
 
     applyHibernateSnapshot(snapshot);
+    trustedShellPromptReadyRef.current = isTrustedTerminalShellSubmission(
+      "",
+      term,
+      isNetworkDevice,
+    );
     isBootActiveRef.current = false;
     releaseTerminalFlowBeforeHibernate(terminalBackend, term, backendId);
     disposeDataRef.current?.();
@@ -1885,6 +1901,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     beginHibernatedSessionListeners,
     clearHibernateRetry,
     scheduleHibernateRetry,
+    isNetworkDevice,
     sessionId,
     shouldSkipHibernateForActiveAlternateScreen,
     terminalBackend,
@@ -2688,6 +2705,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     normalizeTextOnCopyRef,
     isBroadcastEnabledRef,
     onBroadcastInputRef,
+    onPasteData: broadcastUserPasteData,
     passwordPromptActiveRef,
     isLocalConnection,
     supportsRemoteImagePaste,

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -136,8 +136,10 @@ import {
   beginOscColorQuerySuppressionForStartupCommand,
   consumeHibernatedBroadcastInput,
   endOscColorQuerySuppressionForCommand,
+  hasOscColorQuerySuppressionEndBoundary,
   markOscColorQuerySuppressionEndBoundary,
   registerOscColorQuerySuppressionArmer,
+  restoreOscColorQuerySuppressionEndBoundary,
 } from "./terminal/runtime/oscColorQuerySuppression";
 import { clearKittyKeyboardBroadcastSession } from "./terminal/runtime/kittyKeyboardBroadcast";
 import { registerTerminalSensitiveInputReader } from "./terminal/runtime/terminalSensitiveInputRegistry";
@@ -1415,6 +1417,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
             ?? kittyKeyboardProtocolEnabledForSession,
           passwordPromptActiveRef.current,
           suppressOscColorQueriesForActiveCommandRef.current,
+          hasOscColorQuerySuppressionEndBoundary(
+            suppressOscColorQueriesForActiveCommandRef,
+          ),
           knownCwdRef.current ?? null,
           terminalTitleRef.current ?? null,
         );
@@ -1441,6 +1446,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         }
         if (typeof payload.suppressOscColorQueries === "boolean") {
           suppressOscColorQueriesForActiveCommandRef.current = payload.suppressOscColorQueries;
+          restoreOscColorQuerySuppressionEndBoundary(
+            suppressOscColorQueriesForActiveCommandRef,
+            payload.suppressOscColorQueriesCanEnd === true,
+          );
         }
         if (payload.cwd !== undefined) {
           const cwd = terminalCwdTracker.setRendererCwd(payload.cwd);
@@ -1583,6 +1592,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
               xtermRuntimeRef.current?.getKittyKeyboardProtocolEnabled(),
             passwordPromptActive: passwordPromptActiveRef.current,
             suppressOscColorQueries: suppressOscColorQueriesForActiveCommandRef.current,
+            suppressOscColorQueriesCanEnd: hasOscColorQuerySuppressionEndBoundary(
+              suppressOscColorQueriesForActiveCommandRef,
+            ),
             cwd: knownCwdRef.current ?? null,
             title: terminalTitleRef.current ?? null,
           },

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -136,6 +136,7 @@ import {
   beginOscColorQuerySuppressionForStartupCommand,
   consumeHibernatedBroadcastInput,
   endOscColorQuerySuppressionForCommand,
+  getOscColorQuerySuppressionVersion,
   hasOscColorQuerySuppressionEndBoundary,
   markOscColorQuerySuppressionEndBoundary,
   registerOscColorQuerySuppressionArmer,
@@ -1776,13 +1777,36 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       passwordPromptActiveRef.current = false;
       trustedShellPromptReadyRef.current = true;
       hibernatedBroadcastInputRef.current = { promptReady: true, line: "", tracking: false, edited: false };
+      const activeSessionId = sessionRef.current;
+      if (suppressOscColorQueriesForActiveCommandRef.current && activeSessionId) {
+        const suppressionVersion = getOscColorQuerySuppressionVersion(
+          suppressOscColorQueriesForActiveCommandRef,
+        );
+        void terminalBackend.getSessionPwd(activeSessionId, { allowHomeFallback: false })
+          .then((result) => {
+            if (
+              result.success
+              && result.shellForeground === true
+              && sessionRef.current === activeSessionId
+              && suppressOscColorQueriesForActiveCommandRef.current
+              && getOscColorQuerySuppressionVersion(
+                suppressOscColorQueriesForActiveCommandRef,
+              ) === suppressionVersion
+            ) {
+              endOscColorQuerySuppressionForCommand(
+                suppressOscColorQueriesForActiveCommandRef,
+              );
+            }
+          })
+          .catch(() => {});
+      }
     } else {
       trustedShellPromptReadyRef.current = false;
       if (hibernatedRef.current && !hibernatedBroadcastInputRef.current.tracking) {
         hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false, edited: false };
       }
     }
-  }, [isNetworkDevice]);
+  }, [isNetworkDevice, terminalBackend]);
 
   const beginHibernatedSessionListeners = useCallback((backendId: string) => {
     disposeDataRef.current?.();
@@ -1933,10 +1957,13 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }
 
     applyHibernateSnapshot(snapshot);
-    trustedShellPromptReadyRef.current = isTrustedTerminalShellSubmission(
-      "",
-      term,
-      isNetworkDevice,
+    const hibernatePrompt = getAlignedPrompt(term, "", false).prompt;
+    trustedShellPromptReadyRef.current = Boolean(
+      hibernatePrompt.isAtPrompt
+      && hibernatePrompt.userInput.trim().length === 0
+      && isConfirmedTerminalShellPrompt(hibernatePrompt.promptText, {
+        allowHostStyleGreaterThan: isNetworkDevice,
+      }),
     );
     hibernatedBroadcastInputRef.current = {
       promptReady: trustedShellPromptReadyRef.current,
@@ -2086,13 +2113,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     pluginTerminalLifecycle.onCommandSubmitted();
     void xtermRuntimeRef.current?.pluginProviderHost?.commandSubmitted(command);
   }, [pluginTerminalLifecycle]);
-  const pluginAwareOnCommandCompleted = useCallback((meta?: { source: 'osc133' | 'prompt' }) => {
-    // Prompt-shaped container output is not a trustworthy end boundary. Shell
-    // integration completion is the only in-band natural-completion signal;
-    // session exit covers the built-in Docker logs window.
-    if (meta?.source === 'osc133') {
-      endOscColorQuerySuppressionForCommand(suppressOscColorQueriesForActiveCommandRef);
-    }
+  const pluginAwareOnCommandCompleted = useCallback(() => {
     pluginTerminalLifecycle.onCommandCompleted();
     void xtermRuntimeRef.current?.pluginProviderHost?.commandCompleted();
   }, [pluginTerminalLifecycle]);

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -132,8 +132,8 @@ import {
   type XTermRuntime,
 } from "./terminal/runtime/createXTermRuntime";
 import {
-  beginOscColorQuerySuppression,
   beginOscColorQuerySuppressionForCommand,
+  beginOscColorQuerySuppressionForStartupCommand,
   endOscColorQuerySuppressionForCommand,
   registerOscColorQuerySuppressionArmer,
 } from "./terminal/runtime/oscColorQuerySuppression";
@@ -2119,9 +2119,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     onTerminalLogData: captureTerminalLogData,
     onProgrammaticCommandLogRewrite: queueProgrammaticCommandLogRewrite,
     onOsDetected,
-    onStartupCommandStarted: () => {
-      if (startupCommandKind !== 'dockerLogs') return;
-      beginOscColorQuerySuppression(suppressOscColorQueriesForActiveCommandRef);
+    onStartupCommandStarted: (command) => {
+      beginOscColorQuerySuppressionForStartupCommand(
+        suppressOscColorQueriesForActiveCommandRef,
+        command,
+        startupCommandKind,
+      );
     },
     onCommandExecuted,
     onCommandSubmitted,

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1015,8 +1015,6 @@ const TerminalComponent: React.FC<TerminalProps> = ({
           suppressOscColorQueriesForActiveCommandRef,
           command,
         );
-      } else if (data.includes("\r") || data.includes("\n")) {
-        endOscColorQuerySuppressionForCommand(suppressOscColorQueriesForActiveCommandRef);
       }
       if (data.includes("\r") || data.includes("\n") || data.includes("\x03")) {
         trustedShellPromptReadyRef.current = false;

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -360,7 +360,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   ), [sessionId]);
   const sensitivePromptOutputTailRef = useRef("");
   const trustedShellPromptReadyRef = useRef(false);
-  const hibernatedBroadcastInputRef = useRef({ promptReady: false, line: "" });
+  const hibernatedBroadcastInputRef = useRef({ promptReady: false, line: "", tracking: false });
   const [activeScriptRun, setActiveScriptRun] = useState<import('@/types/global/netcatty-bridge-script.d.ts').ScriptRun | undefined>(undefined);
   const dismissedScriptRunIdRef = useRef<string | null>(null);
 
@@ -985,16 +985,19 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   useEffect(() => registerOscColorQuerySuppressionArmer(
     sessionId,
     (data, command) => {
-      const trustedTarget = termRef.current
-        ? command !== undefined
-          && isTrustedTerminalShellSubmission(command, termRef.current, isNetworkDevice)
-        : hibernatedRef.current
-          && consumeHibernatedBroadcastInput(
-            hibernatedBroadcastInputRef.current,
-            data,
-            command,
-          );
-      if (trustedTarget) {
+      const broadcastInput = hibernatedBroadcastInputRef.current;
+      if (termRef.current && !broadcastInput.tracking) {
+        broadcastInput.promptReady = isTrustedTerminalShellSubmission(
+          "",
+          termRef.current,
+          isNetworkDevice,
+        );
+        broadcastInput.line = "";
+      }
+      const trustedTarget = (termRef.current || hibernatedRef.current)
+        ? consumeHibernatedBroadcastInput(broadcastInput, data, command)
+        : false;
+      if (trustedTarget && command !== undefined) {
         beginOscColorQuerySuppressionForCommand(
           suppressOscColorQueriesForActiveCommandRef,
           command,
@@ -1004,7 +1007,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       }
       if (data.includes("\r") || data.includes("\n") || data.includes("\x03")) {
         trustedShellPromptReadyRef.current = false;
-        hibernatedBroadcastInputRef.current = { promptReady: false, line: "" };
+        hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false };
       }
     },
   ), [isNetworkDevice, sessionId]);
@@ -1640,7 +1643,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const clearHibernateRuntimeState = useCallback(() => {
     hibernatedRef.current = false;
     trustedShellPromptReadyRef.current = false;
-    hibernatedBroadcastInputRef.current = { promptReady: false, line: "" };
+    hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false };
     softHiddenRef.current = false;
     hibernateSnapshotRef.current = "";
     hibernateViewportSnapshotRef.current = "";
@@ -1714,7 +1717,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     if (typeof meta?.pluginPipelineSensitiveInput === "boolean") {
       passwordPromptActiveRef.current = meta.pluginPipelineSensitiveInput;
       trustedShellPromptReadyRef.current = false;
-      hibernatedBroadcastInputRef.current = { promptReady: false, line: "" };
+      hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false };
       if (meta.pluginPipelineSensitiveInput) {
         autocompleteCloseRef.current?.();
       } else {
@@ -1727,7 +1730,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     )) {
       passwordPromptActiveRef.current = true;
       trustedShellPromptReadyRef.current = false;
-      hibernatedBroadcastInputRef.current = { promptReady: false, line: "" };
+      hibernatedBroadcastInputRef.current = { promptReady: false, line: "", tracking: false };
       autocompleteCloseRef.current?.();
     } else if (isConfirmedTerminalShellPrompt(
       sensitivePromptOutputTailRef.current,
@@ -1735,9 +1738,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     )) {
       passwordPromptActiveRef.current = false;
       trustedShellPromptReadyRef.current = true;
-      if (hibernatedRef.current) {
-        hibernatedBroadcastInputRef.current = { promptReady: true, line: "" };
-      }
+      hibernatedBroadcastInputRef.current = { promptReady: true, line: "", tracking: false };
     } else {
       trustedShellPromptReadyRef.current = false;
     }
@@ -1900,6 +1901,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     hibernatedBroadcastInputRef.current = {
       promptReady: trustedShellPromptReadyRef.current,
       line: "",
+      tracking: false,
     };
     isBootActiveRef.current = false;
     releaseTerminalFlowBeforeHibernate(terminalBackend, term, backendId);

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1455,6 +1455,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     };
 
     if (!attachExistingSession) {
+      // Reconnect/teardown dispose the exit listener before closeSession, so the
+      // exit callback never clears Docker-log OSC suppression — reset here too.
+      endOscColorQuerySuppressionForCommand(suppressOscColorQueriesForActiveCommandRef);
       disposeSessionListeners();
     }
 

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -458,20 +458,6 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const onSessionExitRef = useRef(onSessionExit);
   const commandBufferRef = useRef<string>("");
   const suppressOscColorQueriesForActiveCommandRef = useRef(false);
-  useEffect(() => registerOscColorQuerySuppressionArmer(
-    sessionId,
-    (command) => {
-      const trustedTarget = termRef.current
-        ? isTrustedTerminalShellSubmission(command, termRef.current, isNetworkDevice)
-        : hibernatedRef.current && trustedShellPromptReadyRef.current;
-      if (!trustedTarget) return;
-      beginOscColorQuerySuppressionForCommand(
-        suppressOscColorQueriesForActiveCommandRef,
-        command,
-      );
-      trustedShellPromptReadyRef.current = false;
-    },
-  ), [isNetworkDevice, sessionId]);
   const promptLineBreakStateRef = useRef<PromptLineBreakState>(createPromptLineBreakState());
   const [hasMouseTracking, setHasMouseTracking] = useState(false);
   const mouseTrackingRef = useRef(false);
@@ -994,6 +980,20 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const detectedDeviceClass = classifyDistroId(host.distro);
   const isNetworkDevice =
     host.deviceType === 'network' || detectedDeviceClass === 'network-device';
+  useEffect(() => registerOscColorQuerySuppressionArmer(
+    sessionId,
+    (command) => {
+      const trustedTarget = termRef.current
+        ? isTrustedTerminalShellSubmission(command, termRef.current, isNetworkDevice)
+        : hibernatedRef.current && trustedShellPromptReadyRef.current;
+      if (!trustedTarget) return;
+      beginOscColorQuerySuppressionForCommand(
+        suppressOscColorQueriesForActiveCommandRef,
+        command,
+      );
+      trustedShellPromptReadyRef.current = false;
+    },
+  ), [isNetworkDevice, sessionId]);
   const remoteDragDropUsesZmodem = supportsZmodemTerminalDragDrop(host, isNetworkDevice);
 
   // Check if this is a local or serial connection (doesn't need connection dialog during connecting)

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -987,12 +987,16 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
 
     // Broadcast peers receive submitted bytes via writeToSession and never run
     // the source command-submission path, so Docker-log OSC suppression must be
-    // armed here when broadcast mode is on for the workspace.
+    // armed here when broadcast mode is on for the workspace. Mirror the same
+    // delivery filters as handleBroadcastInput so peers that never receive the
+    // command (sensitive input / non-writable) are not left suppressing OSC.
     const sourceSession = sessionsRef.current.find((candidate) => candidate.id === sessionId);
     const broadcastWorkspaceId = sourceSession?.workspaceId;
     if (broadcastWorkspaceId && isBroadcastEnabled?.(broadcastWorkspaceId)) {
       for (const peer of sessionsRef.current) {
         if (peer.workspaceId !== broadcastWorkspaceId || peer.id === sessionId) continue;
+        if (!canUseDirectSessionWriteFallback(peer)) continue;
+        if (isTerminalSensitiveInputActive(peer.id)) continue;
         armOscColorQuerySuppressionForSession(peer.id, command);
       }
     }

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -965,6 +965,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
 
       const lineDelayMs = options?.lineDelayMs;
       if (data === "\x03" && terminalBackend.interruptSession) {
+        handleOscColorQueryBroadcastInputForSession(session.id, data);
         broadcastInterruptPrioritizersRef.current.get(session.id)?.();
         terminalBackend.interruptSession(session.id);
         continue;

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -40,6 +40,7 @@ import { applySessionFontSizeToHost } from '../domain/terminalAppearance';
 import { resolveHostAutofillPassword } from '../domain/sshAuth';
 import { listPasswordPromptFillCandidates } from '../domain/passwordPromptAssist';
 import { isTerminalSensitiveInputActive } from './terminal/runtime/terminalSensitiveInputRegistry';
+import { armOscColorQuerySuppressionForSession } from './terminal/runtime/oscColorQuerySuppression';
 import {
   resolveEffectiveTerminalHost,
   resolveTerminalChainHosts,
@@ -965,6 +966,12 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
         continue;
       }
       if (isTerminalSensitiveInputActive(session.id)) continue;
+      if (options?.oscColorQuerySuppressionCommand !== undefined) {
+        armOscColorQuerySuppressionForSession(
+          session.id,
+          options.oscColorQuerySuppressionCommand,
+        );
+      }
       terminalBackend.writeToSession(session.id, data, {
         automated: true,
         sensitive: false,
@@ -978,8 +985,20 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const handleCommandSubmitted = useCallback((command: string, _hostId: string, _hostLabel: string, sessionId: string) => {
     applySessionCodingCliProviderFromCommand(sessionId, command);
 
+    // Broadcast peers receive submitted bytes via writeToSession and never run
+    // the source command-submission path, so Docker-log OSC suppression must be
+    // armed here when broadcast mode is on for the workspace.
+    const sourceSession = sessionsRef.current.find((candidate) => candidate.id === sessionId);
+    const broadcastWorkspaceId = sourceSession?.workspaceId;
+    if (broadcastWorkspaceId && isBroadcastEnabled?.(broadcastWorkspaceId)) {
+      for (const peer of sessionsRef.current) {
+        if (peer.workspaceId !== broadcastWorkspaceId || peer.id === sessionId) continue;
+        armOscColorQuerySuppressionForSession(peer.id, command);
+      }
+    }
+
     const tabId = activeTabIdRef.current;
-    const session = sessionsRef.current.find((candidate) => candidate.id === sessionId);
+    const session = sourceSession;
     if (!session || !canReuseTerminalConnection(session)) return;
     const sessionHost = sessionHostsMapRef.current.get(sessionId);
     const visibleSftpHost = tabId && sidePanelOpenTabsRef.current.get(tabId) === 'sftp'
@@ -1022,7 +1041,13 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       },
     });
     cwdProbeCancelersRef.current.set(sessionId, cancelProbe);
-  }, [applySessionCodingCliProviderFromCommand, handleTerminalCwdChange, restoreTerminalCwd, terminalBackend]);
+  }, [
+    applySessionCodingCliProviderFromCommand,
+    handleTerminalCwdChange,
+    isBroadcastEnabled,
+    restoreTerminalCwd,
+    terminalBackend,
+  ]);
 
   const handleCommandExecuted = useCallback((command: string, hostId: string, hostLabel: string, sessionId: string) => {
     onCommandExecuted?.(command, hostId, hostLabel, sessionId);

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -984,22 +984,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
 
   const handleCommandSubmitted = useCallback((command: string, _hostId: string, _hostLabel: string, sessionId: string) => {
     applySessionCodingCliProviderFromCommand(sessionId, command);
-
-    // Broadcast peers receive submitted bytes via writeToSession and never run
-    // the source command-submission path, so Docker-log OSC suppression must be
-    // armed here when broadcast mode is on for the workspace. Mirror the same
-    // delivery filters as handleBroadcastInput so peers that never receive the
-    // command (sensitive input / non-writable) are not left suppressing OSC.
     const sourceSession = sessionsRef.current.find((candidate) => candidate.id === sessionId);
-    const broadcastWorkspaceId = sourceSession?.workspaceId;
-    if (broadcastWorkspaceId && isBroadcastEnabled?.(broadcastWorkspaceId)) {
-      for (const peer of sessionsRef.current) {
-        if (peer.workspaceId !== broadcastWorkspaceId || peer.id === sessionId) continue;
-        if (!canUseDirectSessionWriteFallback(peer)) continue;
-        if (isTerminalSensitiveInputActive(peer.id)) continue;
-        armOscColorQuerySuppressionForSession(peer.id, command);
-      }
-    }
 
     const tabId = activeTabIdRef.current;
     const session = sourceSession;
@@ -1048,7 +1033,6 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   }, [
     applySessionCodingCliProviderFromCommand,
     handleTerminalCwdChange,
-    isBroadcastEnabled,
     restoreTerminalCwd,
     terminalBackend,
   ]);

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -40,7 +40,7 @@ import { applySessionFontSizeToHost } from '../domain/terminalAppearance';
 import { resolveHostAutofillPassword } from '../domain/sshAuth';
 import { listPasswordPromptFillCandidates } from '../domain/passwordPromptAssist';
 import { isTerminalSensitiveInputActive } from './terminal/runtime/terminalSensitiveInputRegistry';
-import { armOscColorQuerySuppressionForSession } from './terminal/runtime/oscColorQuerySuppression';
+import { handleOscColorQueryBroadcastInputForSession } from './terminal/runtime/oscColorQuerySuppression';
 import {
   resolveEffectiveTerminalHost,
   resolveTerminalChainHosts,
@@ -966,12 +966,11 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
         continue;
       }
       if (isTerminalSensitiveInputActive(session.id)) continue;
-      if (options?.oscColorQuerySuppressionCommand !== undefined) {
-        armOscColorQuerySuppressionForSession(
-          session.id,
-          options.oscColorQuerySuppressionCommand,
-        );
-      }
+      handleOscColorQueryBroadcastInputForSession(
+        session.id,
+        data,
+        options?.oscColorQuerySuppressionCommand,
+      );
       terminalBackend.writeToSession(session.id, data, {
         automated: true,
         sensitive: false,

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -950,9 +950,13 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       if (!canUseDirectSessionWriteFallback(session)) continue;
 
       if (options?.kittyKeyboardInput) {
-        dispatchKittyKeyboardBroadcastInput(session.id, options.kittyKeyboardInput, {
+        const kittyKeyboardInput = options.kittyKeyboardInput;
+        dispatchKittyKeyboardBroadcastInput(session.id, kittyKeyboardInput, {
           beforeUrgentInterrupt: () => {
             broadcastInterruptPrioritizersRef.current.get(session.id)?.();
+          },
+          onResolvedInput: (resolvedData, command) => {
+            handleOscColorQueryBroadcastInputForSession(session.id, resolvedData, command);
           },
         });
         deliveredSessionIds.push(session.id);

--- a/components/TerminalPopupPage.tsx
+++ b/components/TerminalPopupPage.tsx
@@ -459,6 +459,7 @@ function TerminalPopupPageInner() {
               disableTerminalFontZoom={settings.disableTerminalFontZoom}
               sessionId={sessionId}
               startupCommand={isAttachMode ? undefined : config.startupCommand}
+              startupCommandKind={isAttachMode ? undefined : config.startupCommandKind}
               reuseConnectionFromSessionId={isAttachMode ? undefined : reuseId}
               attachExistingSession={isAttachMode}
               attachAuthorization={attachAuthorization}

--- a/components/systemManager/DockerContainersPanel.tsx
+++ b/components/systemManager/DockerContainersPanel.tsx
@@ -388,7 +388,10 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
       parentSession,
       `logs: ${container.name || id}`,
       buildDockerLogsCommand(id),
-      { icon: await buildContainerPopupIcon(container.image) },
+      {
+        icon: await buildContainerPopupIcon(container.image),
+        startupCommandKind: 'dockerLogs',
+      },
     );
     if (!result.success) {
       await writeSystemManagerDiagnostic('docker open logs failed', {

--- a/components/systemManager/openInteractiveTerminal.test.ts
+++ b/components/systemManager/openInteractiveTerminal.test.ts
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 import type { TerminalSession } from '../../types';
 import { openInteractiveTerminal } from './openInteractiveTerminal';
@@ -92,4 +93,39 @@ test('openInteractiveTerminal keeps SSH connection reuse for ordinary connected 
   assert.equal(payload.sourceSession.moshEnabled, false);
   assert.equal(payload.sourceSession.protocol, 'ssh');
   assert.equal(payload.sourceSession.reuseConnectionFromSessionId, 'session-1');
+});
+
+test('openInteractiveTerminal marks a Docker logs startup command without exposing a setting', async () => {
+  const payloads: unknown[] = [];
+  const backend = {
+    openTerminalPopup: async (payload: unknown) => {
+      payloads.push(payload);
+      return { success: true };
+    },
+  };
+
+  await openInteractiveTerminal(
+    backend as never,
+    parentSession(),
+    'logs: api',
+    'generated docker logs launcher',
+    { startupCommandKind: 'dockerLogs' },
+  );
+
+  assert.equal(
+    (payloads[0] as { startupCommandKind?: string }).startupCommandKind,
+    'dockerLogs',
+  );
+});
+
+test('only the built-in Docker logs action carries the Docker logs command kind', () => {
+  const source = readFileSync(
+    new URL('./DockerContainersPanel.tsx', import.meta.url),
+    'utf8',
+  );
+  const shellBlock = source.slice(source.indexOf('const openShell'), source.indexOf('const openLogs'));
+  const logsBlock = source.slice(source.indexOf('const openLogs'), source.indexOf('const restart'));
+
+  assert.doesNotMatch(shellBlock, /startupCommandKind/);
+  assert.match(logsBlock, /startupCommandKind:\s*'dockerLogs'/);
 });

--- a/components/systemManager/openInteractiveTerminal.ts
+++ b/components/systemManager/openInteractiveTerminal.ts
@@ -49,7 +49,7 @@ export async function openInteractiveTerminal(
   parentSession: TerminalSession,
   title: string,
   startupCommand: string,
-  options?: { icon?: TerminalPopupIcon },
+  options?: { icon?: TerminalPopupIcon; startupCommandKind?: 'dockerLogs' },
 ): Promise<{ success: boolean; error?: string }> {
   const canReuseConnection = canReuseTerminalConnection(parentSession);
   const popupTitle = buildPopupTitle(parentSession, title);
@@ -67,6 +67,7 @@ export async function openInteractiveTerminal(
     icon: options?.icon,
     parentSessionId: parentSession.id,
     startupCommand,
+    ...(options?.startupCommandKind ? { startupCommandKind: options.startupCommandKind } : {}),
     sourceSession: buildCommandPopupSourceSession(parentSession, startupCommand, canReuseConnection),
   });
   await writeSystemManagerDiagnostic('openInteractiveTerminal result', {

--- a/components/terminal/hooks/useTerminalContextActions.ts
+++ b/components/terminal/hooks/useTerminalContextActions.ts
@@ -50,6 +50,7 @@ export const useTerminalContextActions = ({
   scrollOnPasteRef,
   isBroadcastEnabledRef,
   onBroadcastInputRef,
+  onPasteData,
   passwordPromptActiveRef,
   isLocalConnection,
   supportsRemoteImagePaste,
@@ -67,6 +68,7 @@ export const useTerminalContextActions = ({
   scrollOnPasteRef?: RefObject<boolean>;
   isBroadcastEnabledRef?: RefObject<boolean | undefined>;
   onBroadcastInputRef?: RefObject<((data: string, sourceSessionId: string) => void) | undefined>;
+  onPasteData?: (data: string) => boolean | void;
   passwordPromptActiveRef?: RefObject<boolean | undefined>;
   isLocalConnection: boolean;
   supportsRemoteImagePaste: boolean;
@@ -82,6 +84,7 @@ export const useTerminalContextActions = ({
   onClipboardImageUploadResult?: (result: RemoteClipboardImageUploadResult) => void;
 }) => {
   const broadcastUserPasteData = useCallback((data: string) => {
+    if (onPasteData) return onPasteData(data);
     return broadcastTerminalPasteData(data, {
       sourceSessionId,
       sessionRef,
@@ -89,7 +92,7 @@ export const useTerminalContextActions = ({
       onBroadcastInputRef,
       passwordPromptActiveRef,
     });
-  }, [isBroadcastEnabledRef, onBroadcastInputRef, passwordPromptActiveRef, sessionRef, sourceSessionId]);
+  }, [isBroadcastEnabledRef, onBroadcastInputRef, onPasteData, passwordPromptActiveRef, sessionRef, sourceSessionId]);
 
   const onCopy = useCallback(() => {
     const term = termRef.current;

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -6,6 +6,10 @@ import {
   getMissingChainHostIds,
 } from "./createTerminalSessionStarters";
 import { createPromptLineBreakState } from "./promptLineBreak";
+import {
+  beginOscColorQuerySuppression,
+  endOscColorQuerySuppressionForCommand,
+} from "./oscColorQuerySuppression";
 import { resolveStartupCommand } from "./terminalStartupCommands";
 import { pasteTextIntoTerminal } from "./terminalUserPaste";
 import { shouldSuppressHostStartupCommandOnReconnect } from "../restoredSessionGate";
@@ -2013,6 +2017,8 @@ test("local session acknowledges metadata-only plugin output immediately", async
 test("local session runs startup command after attaching", async () => {
   const sessionWrites: Array<{ id: string; data: string; automated?: boolean }> = [];
   const attached: string[] = [];
+  const started: string[] = [];
+  const colorQuerySuppression = { current: false };
 
   const terminalBackend = {
     backendAvailable: () => true,
@@ -2049,12 +2055,20 @@ test("local session runs startup command after attaching", async () => {
     startupCommand: "docker logs -f --tail 200 abc123",
     promptLineBreakStateRef: undefined,
     onSessionAttached: (id: string) => attached.push(id),
+    onStartupCommandStarted: (command: string) => {
+      started.push(command);
+      beginOscColorQuerySuppression(colorQuerySuppression);
+    },
   });
 
   await createTerminalSessionStarters(ctx as never).startLocal(createTermStub() as never);
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   assert.deepEqual(attached, ["local-session"]);
+  assert.deepEqual(started, ["docker logs -f --tail 200 abc123"]);
+  assert.equal(colorQuerySuppression.current, true);
+  endOscColorQuerySuppressionForCommand(colorQuerySuppression);
+  assert.equal(colorQuerySuppression.current, false);
   assert.deepEqual(sessionWrites, [{
     id: "local-session",
     data: "docker logs -f --tail 200 abc123\r",

--- a/components/terminal/runtime/createTerminalSessionStarters.types.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.types.ts
@@ -200,6 +200,7 @@ export type TerminalSessionStartersContext = {
   onProgrammaticCommandLogRewrite?: (rewrite: ProgrammaticCommandLogRewrite) => void;
   onTerminalOutput?: (chunk: string, meta?: TerminalSessionDataMeta) => void;
   onOsDetected?: (hostId: string, distro: string) => void;
+  onStartupCommandStarted?: (command: string) => void;
   onCommandExecuted?: (
     command: string,
     hostId: string,

--- a/components/terminal/runtime/createTerminalSessionStarters.types.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.types.ts
@@ -213,7 +213,7 @@ export type TerminalSessionStartersContext = {
     hostLabel: string,
     sessionId: string,
   ) => void;
-  onCommandCompleted?: () => void;
+  onCommandCompleted?: (meta?: { source: "osc133" | "prompt" }) => void;
 };
 
 export type TerminalSessionDataMeta = {

--- a/components/terminal/runtime/createTerminalSessionStarters.types.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.types.ts
@@ -213,7 +213,7 @@ export type TerminalSessionStartersContext = {
     hostLabel: string,
     sessionId: string,
   ) => void;
-  onCommandCompleted?: (meta?: { source: "osc133" | "prompt" }) => void;
+  onCommandCompleted?: () => void;
 };
 
 export type TerminalSessionDataMeta = {

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -63,6 +63,9 @@ import {
 } from "./kittyKeyboardProtocol";
 import { installKittyKeyboardProtocolHandlersIfEnabled } from "./kittyKeyboardRuntime";
 import {
+  installOscColorQuerySuppression,
+} from "./oscColorQuerySuppression";
+import {
   clearKittyKeyboardBroadcastPairingState,
   createKittyKeyboardBroadcastForwarder,
   createKittyKeyboardBroadcastHandler,
@@ -225,6 +228,7 @@ export type CreateXTermRuntimeContext = {
   resolvedFontFamily: string;
   fontSize: number;
   terminalTheme: TerminalTheme;
+  suppressOscColorQueriesForActiveCommandRef?: RefObject<boolean>;
   terminalSettingsRef: RefObject<TerminalSettings | undefined>;
   kittyKeyboardProtocolEnabled?: boolean;
   kittyKeyboardModeState?: KittyKeyboardModeState;
@@ -1865,6 +1869,11 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     return true; // Indicate we handled the sequence
   });
 
+  const oscColorQuerySuppressionDisposable = installOscColorQuerySuppression(
+    term.parser,
+    () => ctx.suppressOscColorQueriesForActiveCommandRef?.current === true,
+  );
+
   const osc133Disposable = term.parser.registerOscHandler(133, (data) => {
     if (consumeOsc133CommandCompletion(data, ctx.promptLineBreakStateRef?.current)) {
       ctx.onCommandCompleted?.();
@@ -2042,6 +2051,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       textarea?.removeEventListener("blur", clearKittyTransientInputState);
       clearKittyTransientInputState();
       osc7Disposable.dispose();
+      oscColorQuerySuppressionDisposable?.dispose();
       osc133Disposable.dispose();
       osc52Disposable.dispose();
       titleChangeDisposable.dispose();

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -283,7 +283,7 @@ export type CreateXTermRuntimeContext = {
     hostLabel: string,
     sessionId: string,
   ) => void;
-  onCommandCompleted?: (meta?: { source: "osc133" | "prompt" }) => void;
+  onCommandCompleted?: () => void;
   requestPluginTerminalProviders?: RequestPluginTerminalProviders;
   pluginProviderVisible?: boolean;
   isPluginTerminalProviderAvailable?: (kind: NetcattyTerminalProviderKind) => boolean;
@@ -1971,7 +1971,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
 
   const osc133Disposable = term.parser.registerOscHandler(133, (data) => {
     if (consumeOsc133CommandCompletion(data, ctx.promptLineBreakStateRef?.current)) {
-      ctx.onCommandCompleted?.({ source: "osc133" });
+      ctx.onCommandCompleted?.();
     }
     return true;
   });

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -63,7 +63,7 @@ import {
 } from "./kittyKeyboardProtocol";
 import { installKittyKeyboardProtocolHandlersIfEnabled } from "./kittyKeyboardRuntime";
 import {
-  installOscColorQuerySuppression,
+  stripOscColorQueryResponses,
 } from "./oscColorQuerySuppression";
 import {
   clearKittyKeyboardBroadcastPairingState,
@@ -1708,7 +1708,12 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   ctx.container.addEventListener("input", markKittyTextInput, true);
   textarea?.addEventListener("blur", clearKittyTransientInputState);
 
-  term.onData((data) => {
+  term.onData((rawData) => {
+    const data = stripOscColorQueryResponses(
+      rawData,
+      ctx.suppressOscColorQueriesForActiveCommandRef?.current === true,
+    );
+    if (!data) return;
     if (kittyCompositionPending && !data.startsWith("\u001b")) {
       kittyCompositionPending = false;
       if (kittyCompositionClearTimer !== undefined) {
@@ -1868,12 +1873,6 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     }
     return true; // Indicate we handled the sequence
   });
-
-  const oscColorQuerySuppressionDisposable = installOscColorQuerySuppression(
-    term.parser,
-    () => ctx.suppressOscColorQueriesForActiveCommandRef?.current === true,
-    (sequence) => term.write(sequence),
-  );
 
   const osc133Disposable = term.parser.registerOscHandler(133, (data) => {
     if (consumeOsc133CommandCompletion(data, ctx.promptLineBreakStateRef?.current)) {
@@ -2052,7 +2051,6 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       textarea?.removeEventListener("blur", clearKittyTransientInputState);
       clearKittyTransientInputState();
       osc7Disposable.dispose();
-      oscColorQuerySuppressionDisposable?.dispose();
       osc133Disposable.dispose();
       osc52Disposable.dispose();
       titleChangeDisposable.dispose();

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -134,7 +134,10 @@ import {
   consumeOsc133CommandCompletion,
   type PromptLineBreakState,
 } from "./promptLineBreak";
-import { recordTerminalCommandExecution } from "./terminalCommandExecution";
+import {
+  isTrustedTerminalShellSubmission,
+  recordTerminalCommandExecution,
+} from "./terminalCommandExecution";
 import {
   getSingleBracketedPasteLine,
   getSinglePastedCommand,
@@ -789,7 +792,21 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       && ctx.isBroadcastEnabledRef.current
       && ctx.onBroadcastInputRef.current
     ) {
-      ctx.onBroadcastInputRef.current(data, ctx.sessionId);
+      const pastedCommand = getSinglePastedCommand(data)?.command;
+      const trustedCommand = pastedCommand && isTrustedTerminalShellSubmission(
+        pastedCommand,
+        term,
+        ctx.allowHostStyleGreaterThanPrompt,
+      )
+        ? pastedCommand
+        : undefined;
+      ctx.onBroadcastInputRef.current(
+        data,
+        ctx.sessionId,
+        trustedCommand !== undefined
+          ? { oscColorQuerySuppressionCommand: trustedCommand }
+          : undefined,
+      );
       return true;
     }
     return false;

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -64,6 +64,7 @@ import {
 } from "./kittyKeyboardProtocol";
 import { installKittyKeyboardProtocolHandlersIfEnabled } from "./kittyKeyboardRuntime";
 import {
+  markOscColorQuerySuppressionEndBoundary,
   stripOscColorQueryResponses,
 } from "./oscColorQuerySuppression";
 import {
@@ -1405,6 +1406,11 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         });
         if (ctx.passwordPromptActiveRef) {
           ctx.passwordPromptActiveRef.current = false;
+        }
+        if (ctx.suppressOscColorQueriesForActiveCommandRef) {
+          markOscColorQuerySuppressionEndBoundary(
+            ctx.suppressOscColorQueriesForActiveCommandRef,
+          );
         }
         if (ctx.terminalBackend.interruptSession) {
           ctx.terminalBackend.interruptSession(id, interruptTrace);

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -139,6 +139,8 @@ import {
   recordTerminalCommandExecution,
   resolveSubmittedShellCommand,
 } from "./terminalCommandExecution";
+import { getAlignedPrompt } from "../autocomplete/promptDetector";
+import { isConfirmedTerminalShellPrompt } from "../../../domain/terminalPromptSecurity";
 import {
   getSingleBracketedPasteLine,
   getSinglePastedCommand,
@@ -794,12 +796,15 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       && ctx.onBroadcastInputRef.current
     ) {
       const pastedCommand = getSinglePastedCommand(data)?.command;
-      const trustedCommand = pastedCommand && isTrustedTerminalShellSubmission(
-        pastedCommand,
+      const submittedCommand = pastedCommand
+        ? `${ctx.commandBufferRef.current}${pastedCommand}`
+        : undefined;
+      const trustedCommand = submittedCommand && isTrustedTerminalShellSubmission(
+        submittedCommand,
         term,
         ctx.allowHostStyleGreaterThanPrompt,
       )
-        ? pastedCommand
+        ? submittedCommand
         : undefined;
       ctx.onBroadcastInputRef.current(
         data,
@@ -1160,6 +1165,30 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     isSensitiveInput: () => ctx.passwordPromptActiveRef?.current === true,
     getDispatcher: () => ctx.onBroadcastInputRef.current,
   });
+  const resolveTrustedKeyboardBroadcastCommand = (): string | undefined => {
+    const livePrompt = getAlignedPrompt(term, "", false).prompt;
+    if (
+      livePrompt.isAtPrompt
+      && livePrompt.userInput.trim().length > 0
+      && isConfirmedTerminalShellPrompt(livePrompt.promptText, {
+        allowHostStyleGreaterThan: ctx.allowHostStyleGreaterThanPrompt,
+      })
+    ) {
+      return livePrompt.userInput.trim();
+    }
+    const command = resolveSubmittedShellCommand(
+      ctx.commandBufferRef.current,
+      term,
+      ctx.promptLineBreakStateRef?.current?.lastPromptText,
+    );
+    return command && isTrustedTerminalShellSubmission(
+      ctx.commandBufferRef.current,
+      term,
+      ctx.allowHostStyleGreaterThanPrompt,
+    )
+      ? command
+      : undefined;
+  };
 
   term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
     // Preserve mouse selection across keystrokes when enabled. xterm.js
@@ -1556,6 +1585,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         urgentInterrupt: shouldUseUrgentTerminalInterrupt(e, {
           hasSelection: term.hasSelection(),
         }),
+        ...(kittyEvent.type !== "keyup" && kittyEvent.key === "Enter"
+          ? { oscColorQuerySuppressionCommand: resolveTrustedKeyboardBroadcastCommand() }
+          : {}),
       });
       if (forwarded) {
         upsertKittyKeyboardForwardedPress(
@@ -1624,20 +1656,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         event: normalizedKittyEvent,
         fallbackToLegacy: true,
         ...(normalizedKittyEvent.type !== "keyup" && normalizedKittyEvent.key === "Enter"
-          ? (() => {
-              const command = resolveSubmittedShellCommand(
-                ctx.commandBufferRef.current,
-                term,
-                ctx.promptLineBreakStateRef?.current?.lastPromptText,
-              );
-              return command && isTrustedTerminalShellSubmission(
-                ctx.commandBufferRef.current,
-                term,
-                ctx.allowHostStyleGreaterThanPrompt,
-              )
-                ? { oscColorQuerySuppressionCommand: command }
-                : {};
-            })()
+          ? { oscColorQuerySuppressionCommand: resolveTrustedKeyboardBroadcastCommand() }
           : {}),
       });
       if (forwarded) {

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -1577,6 +1577,14 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       e.preventDefault();
       e.stopPropagation();
       const kittyEvent = toKittyKeyboardEvent(e);
+      const urgentInterrupt = shouldUseUrgentTerminalInterrupt(e, {
+        hasSelection: term.hasSelection(),
+      });
+      if (urgentInterrupt && ctx.suppressOscColorQueriesForActiveCommandRef) {
+        markOscColorQuerySuppressionEndBoundary(
+          ctx.suppressOscColorQueriesForActiveCommandRef,
+        );
+      }
       upsertKittyKeyboardForwardedPress(
         kittyForwardedKeys,
         kittyKeyIdentity(e),
@@ -1588,9 +1596,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         kind: "key",
         event: kittyEvent,
         fallbackToLegacy: true,
-        urgentInterrupt: shouldUseUrgentTerminalInterrupt(e, {
-          hasSelection: term.hasSelection(),
-        }),
+        urgentInterrupt,
         ...(kittyEvent.type !== "keyup" && kittyEvent.key === "Enter"
           ? { oscColorQuerySuppressionCommand: resolveTrustedKeyboardBroadcastCommand() }
           : {}),

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -1844,10 +1844,10 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   });
   registerKittyKeyboardBroadcastHandler(
     ctx.sessionId,
-    (input) => {
+    (input, dispatchOptions) => {
       handlingKittyBroadcast = true;
       try {
-        handleKittyKeyboardBroadcast(input);
+        handleKittyKeyboardBroadcast(input, dispatchOptions);
       } finally {
         handlingKittyBroadcast = false;
       }

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -283,7 +283,7 @@ export type CreateXTermRuntimeContext = {
     hostLabel: string,
     sessionId: string,
   ) => void;
-  onCommandCompleted?: () => void;
+  onCommandCompleted?: (meta?: { source: "osc133" | "prompt" }) => void;
   requestPluginTerminalProviders?: RequestPluginTerminalProviders;
   pluginProviderVisible?: boolean;
   isPluginTerminalProviderAvailable?: (kind: NetcattyTerminalProviderKind) => boolean;
@@ -1591,14 +1591,25 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         kittyEvent,
         [],
       );
+      const trustedKittyCommand = kittyEvent.type !== "keyup" && kittyEvent.key === "Enter"
+        ? resolveTrustedKeyboardBroadcastCommand()
+        : undefined;
+      if (trustedKittyCommand) {
+        ctx.onTrustedCommandSubmitted?.(
+          trustedKittyCommand,
+          ctx.host.id,
+          ctx.host.label,
+          ctx.sessionId,
+        );
+      }
       handleTerminalInputData(kittySequenceForKeyDown, { source: "kitty" });
       const forwarded = broadcastKittyInput({
         kind: "key",
         event: kittyEvent,
         fallbackToLegacy: true,
         urgentInterrupt,
-        ...(kittyEvent.type !== "keyup" && kittyEvent.key === "Enter"
-          ? { oscColorQuerySuppressionCommand: resolveTrustedKeyboardBroadcastCommand() }
+        ...(trustedKittyCommand !== undefined
+          ? { oscColorQuerySuppressionCommand: trustedKittyCommand }
           : {}),
       });
       if (forwarded) {
@@ -1960,7 +1971,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
 
   const osc133Disposable = term.parser.registerOscHandler(133, (data) => {
     if (consumeOsc133CommandCompletion(data, ctx.promptLineBreakStateRef?.current)) {
-      ctx.onCommandCompleted?.();
+      ctx.onCommandCompleted?.({ source: "osc133" });
     }
     return true;
   });

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -6,6 +6,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal as XTerm } from "@xterm/xterm";
 import type { RefObject } from "react";
+import type { TerminalBroadcastInputOptions } from "../terminalHelpers";
 import {
   checkAppShortcut,
   getAppLevelActions,
@@ -72,7 +73,6 @@ import {
   flushKittyKeyboardBroadcastReleases,
   registerKittyKeyboardBroadcastHandler,
   upsertKittyKeyboardForwardedPress,
-  type KittyKeyboardBroadcastInput,
   type KittyKeyboardForwardedPress,
 } from "./kittyKeyboardBroadcast";
 import { installUserCursorPreferenceGuard } from "./cursorPreference";
@@ -248,7 +248,7 @@ export type CreateXTermRuntimeContext = {
     ((
       data: string,
       sourceSessionId: string,
-      options?: { kittyKeyboardInput?: KittyKeyboardBroadcastInput },
+      options?: TerminalBroadcastInputOptions,
     ) => void) | undefined
   >;
 
@@ -931,6 +931,19 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     const dataToWrite = data;
     const sensitive = ctx.passwordPromptActiveRef?.current === true;
     let handledSubmittedInput = false;
+    let trustedSubmittedCommand: string | undefined;
+    const commandExecutionContext = {
+      ...ctx,
+      onTrustedCommandSubmitted: (
+        command: string,
+        hostId: string,
+        hostLabel: string,
+        sessionId: string,
+      ) => {
+        trustedSubmittedCommand = command;
+        ctx.onTrustedCommandSubmitted?.(command, hostId, hostLabel, sessionId);
+      },
+    };
     const submittedInput: { text: string; lineEnding: "\r\n" | "\r" | "\n" } | null =
       inputSource === "shift-enter"
         ? getShiftEnterSubmittedInput(data)
@@ -962,7 +975,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       if (ctx.passwordPromptActiveRef) ctx.passwordPromptActiveRef.current = false;
       const recordedCommand = recordTerminalCommandExecution(
         ctx.commandBufferRef.current,
-        ctx,
+        commandExecutionContext,
         term,
         { sensitive, allowHostStyleGreaterThanPrompt: ctx.allowHostStyleGreaterThanPrompt },
       );
@@ -984,7 +997,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         if (ctx.passwordPromptActiveRef) ctx.passwordPromptActiveRef.current = false;
         const recordedCommand = recordTerminalCommandExecution(
           `${ctx.commandBufferRef.current}${pastedCommand.command}`,
-          ctx,
+          commandExecutionContext,
           term,
           { sensitive, allowHostStyleGreaterThanPrompt: ctx.allowHostStyleGreaterThanPrompt },
         );
@@ -1044,7 +1057,13 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       // Use remapped data so broadcast peers also receive the correct byte
       const broadcastData = mapTerminalBackspaceInput(dataToWrite, ctx.host.backspaceBehavior);
       if (willBroadcastInput) {
-        onBroadcastInput?.(broadcastData, ctx.sessionId);
+        onBroadcastInput?.(
+          broadcastData,
+          ctx.sessionId,
+          trustedSubmittedCommand !== undefined
+            ? { oscColorQuerySuppressionCommand: trustedSubmittedCommand }
+            : undefined,
+        );
       }
 
       if (!shouldSuppressTerminalInputScrollForUserPaste(term, data)) {

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -1872,6 +1872,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   const oscColorQuerySuppressionDisposable = installOscColorQuerySuppression(
     term.parser,
     () => ctx.suppressOscColorQueriesForActiveCommandRef?.current === true,
+    (sequence) => term.write(sequence),
   );
 
   const osc133Disposable = term.parser.registerOscHandler(133, (data) => {

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -137,6 +137,7 @@ import {
 import {
   isTrustedTerminalShellSubmission,
   recordTerminalCommandExecution,
+  resolveSubmittedShellCommand,
 } from "./terminalCommandExecution";
 import {
   getSingleBracketedPasteLine,
@@ -1622,6 +1623,22 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         kind: "key",
         event: normalizedKittyEvent,
         fallbackToLegacy: true,
+        ...(normalizedKittyEvent.type !== "keyup" && normalizedKittyEvent.key === "Enter"
+          ? (() => {
+              const command = resolveSubmittedShellCommand(
+                ctx.commandBufferRef.current,
+                term,
+                ctx.promptLineBreakStateRef?.current?.lastPromptText,
+              );
+              return command && isTrustedTerminalShellSubmission(
+                ctx.commandBufferRef.current,
+                term,
+                ctx.allowHostStyleGreaterThanPrompt,
+              )
+                ? { oscColorQuerySuppressionCommand: command }
+                : {};
+            })()
+          : {}),
       });
       if (forwarded) {
         upsertKittyKeyboardForwardedPress(

--- a/components/terminal/runtime/kittyKeyboardBroadcast.test.ts
+++ b/components/terminal/runtime/kittyKeyboardBroadcast.test.ts
@@ -690,6 +690,41 @@ test("keyup clears target pairing even when its flags do not encode releases", (
   }), null);
 });
 
+test("resolved keyboard input carries trusted command metadata to broadcast targets", () => {
+  const tracked: Array<{ data: string; command?: string }> = [];
+  const writes: string[] = [];
+  const handler = createKittyKeyboardBroadcastHandler({
+    resolveOptions: () => ({
+      kittyProtocolEnabled: false,
+      kittyMode: createKittyKeyboardModeState(),
+      applicationCursorMode: false,
+      encodedKeys: new Set<string>(),
+    }),
+    getSessionId: () => "target",
+    isConnected: () => true,
+    isRuntimeDisposed: () => false,
+    writeDisposed: () => undefined,
+    writeActive: (data) => writes.push(data),
+  });
+  const onResolvedInput = (data: string, command?: string) => tracked.push({ data, command });
+  handler({
+    kind: "key",
+    fallbackToLegacy: true,
+    event: { type: "keydown", key: "d", code: "KeyD" },
+  }, { onResolvedInput });
+  handler({
+    kind: "key",
+    fallbackToLegacy: true,
+    event: { type: "keydown", key: "Enter", code: "Enter" },
+    oscColorQuerySuppressionCommand: "docker logs api",
+  }, { onResolvedInput });
+  assert.deepEqual(tracked, [
+    { data: "d", command: undefined },
+    { data: "\r", command: "docker logs api" },
+  ]);
+  assert.deepEqual(writes, ["d", "\r"]);
+});
+
 test("queued inputs survive a temporarily absent hibernated target handler", () => {
   const received: KittyKeyboardBroadcastInput[] = [];
   const input: KittyKeyboardBroadcastInput = {

--- a/components/terminal/runtime/kittyKeyboardBroadcast.ts
+++ b/components/terminal/runtime/kittyKeyboardBroadcast.ts
@@ -13,12 +13,14 @@ export type KittyKeyboardBroadcastInput =
       event: KittyKeyboardEvent;
       fallbackToLegacy?: boolean;
       urgentInterrupt?: boolean;
+      oscColorQuerySuppressionCommand?: string;
     }
   | { kind: "legacy"; data: string; keyIdentity: string; urgentInterrupt?: boolean }
   | { kind: "text"; text: string };
 
 type KittyKeyboardBroadcastDispatchOptions = {
   beforeUrgentInterrupt?: () => void;
+  onResolvedInput?: (data: string, command?: string) => void;
 };
 
 type KittyKeyboardBroadcastHandler = (
@@ -271,8 +273,22 @@ export const createKittyKeyboardBroadcastHandler = (options: {
   if (!sessionId || !options.isConnected()) return;
   const isPairedRelease = input.kind === "key" && input.event.type === "keyup";
   if (!isPairedRelease && options.isSensitiveInput?.() === true) return;
-  const resolved = resolveKittyKeyboardBroadcastInput(input, options.resolveOptions());
+  const resolvedOptions = options.resolveOptions();
+  const resolved = resolveKittyKeyboardBroadcastInput(input, resolvedOptions);
   if (!resolved) return;
+  const trackingData = input.kind === "text"
+    ? input.text
+    : input.kind === "legacy"
+      ? input.data
+      : input.event.type === "keyup"
+        ? ""
+        : encodeLegacyKeyboardEvent(input.event, resolvedOptions.applicationCursorMode) ?? "";
+  if (trackingData) {
+    dispatchOptions?.onResolvedInput?.(
+      trackingData,
+      input.kind === "key" ? input.oscColorQuerySuppressionCommand : undefined,
+    );
+  }
   if (resolved.urgentInterrupt && options.interruptSession) {
     dispatchOptions?.beforeUrgentInterrupt?.();
     options.interruptSession(sessionId);

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -56,9 +56,12 @@ test('ordinary terminals do not install color-query suppression', () => {
 
 test('docker logs detection covers direct and privileged commands without matching other docker commands', () => {
   assert.equal(isDockerLogsCommand('docker logs -f api'), true);
+  assert.equal(isDockerLogsCommand('docker container logs -f api'), true);
   assert.equal(isDockerLogsCommand('sudo -n docker logs --tail 200 api'), true);
+  assert.equal(isDockerLogsCommand('sudo docker --host tcp://1.2.3.4:2375 container logs api'), true);
   assert.equal(isDockerLogsCommand('/usr/bin/docker --context prod logs api'), true);
   assert.equal(isDockerLogsCommand('docker exec api sh'), false);
+  assert.equal(isDockerLogsCommand('docker container exec api sh'), false);
   assert.equal(isDockerLogsCommand('echo docker logs api'), false);
   assert.equal(isDockerLogsCommand('docker logs api; vim'), false);
   assert.equal(isDockerLogsCommand('docker logs api && vim'), false);

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -7,9 +7,11 @@ import {
   beginOscColorQuerySuppressionForStartupCommand,
   consumeHibernatedBroadcastInput,
   endOscColorQuerySuppressionForCommand,
+  hasOscColorQuerySuppressionEndBoundary,
   isDockerLogsCommand,
   markOscColorQuerySuppressionEndBoundary,
   registerOscColorQuerySuppressionArmer,
+  restoreOscColorQuerySuppressionEndBoundary,
   stripOscColorQueryResponses,
 } from './oscColorQuerySuppression.ts';
 
@@ -73,6 +75,25 @@ test('a non-log command restores ordinary color queries only after a user interr
   assert.equal(state.current, false);
   endOscColorQuerySuppressionForCommand(state);
   assert.equal(state.current, false);
+});
+
+test('the interrupt boundary survives a terminal-view handoff', () => {
+  const source = { current: false };
+  beginOscColorQuerySuppressionForCommand(source, 'docker logs -f api');
+  markOscColorQuerySuppressionEndBoundary(source);
+
+  const target = { current: source.current };
+  restoreOscColorQuerySuppressionEndBoundary(
+    target,
+    hasOscColorQuerySuppressionEndBoundary(source),
+  );
+  beginOscColorQuerySuppressionForCommand(target, 'vim');
+  assert.equal(target.current, false);
+
+  const activeLogsTarget = { current: true };
+  restoreOscColorQuerySuppressionEndBoundary(activeLogsTarget, false);
+  beginOscColorQuerySuppressionForCommand(activeLogsTarget, 'vim');
+  assert.equal(activeLogsTarget.current, true);
 });
 
 test('startup commands recognize saved Docker logs commands and built-in launchers', () => {

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   armOscColorQuerySuppressionForSession,
   beginOscColorQuerySuppressionForCommand,
+  beginOscColorQuerySuppressionForStartupCommand,
   endOscColorQuerySuppressionForCommand,
   installOscColorQuerySuppression,
   isDockerLogsCommand,
@@ -91,6 +92,23 @@ test('the next trusted non-log command restores ordinary color queries', () => {
   assert.equal(state.current, false);
   endOscColorQuerySuppressionForCommand(state);
   assert.equal(state.current, false);
+});
+
+test('startup commands recognize saved Docker logs commands and built-in launchers', () => {
+  const state = { current: false };
+
+  beginOscColorQuerySuppressionForStartupCommand(state, 'docker logs -f api');
+  assert.equal(state.current, true);
+
+  beginOscColorQuerySuppressionForStartupCommand(state, 'vim');
+  assert.equal(state.current, false);
+
+  beginOscColorQuerySuppressionForStartupCommand(
+    state,
+    'generated shell wrapper',
+    'dockerLogs',
+  );
+  assert.equal(state.current, true);
 });
 
 test('broadcast peer sessions can be armed through the suppression registry', () => {

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -8,6 +8,7 @@ import {
   consumeHibernatedBroadcastInput,
   endOscColorQuerySuppressionForCommand,
   isDockerLogsCommand,
+  markOscColorQuerySuppressionEndBoundary,
   registerOscColorQuerySuppressionArmer,
   stripOscColorQueryResponses,
 } from './oscColorQuerySuppression.ts';
@@ -62,8 +63,12 @@ test('docker logs stays protected through prompt-like output and interrupt resid
   assert.equal(state.current, true);
 });
 
-test('the next trusted non-log command restores ordinary color queries', () => {
+test('a non-log command restores ordinary color queries only after a user interrupt boundary', () => {
   const state = { current: true };
+  beginOscColorQuerySuppressionForCommand(state, 'vim');
+  assert.equal(state.current, true);
+  markOscColorQuerySuppressionEndBoundary(state);
+  assert.equal(state.current, true);
   beginOscColorQuerySuppressionForCommand(state, 'vim');
   assert.equal(state.current, false);
   endOscColorQuerySuppressionForCommand(state);
@@ -92,6 +97,13 @@ test('startup commands recognize saved Docker logs commands and built-in launche
     state,
     'docker logs api && echo done',
   );
+  assert.equal(state.current, true);
+
+  endOscColorQuerySuppressionForCommand(state);
+  beginOscColorQuerySuppressionForStartupCommand(
+    state,
+    'docker logs api && echo done',
+  );
   assert.equal(state.current, false);
 
   beginOscColorQuerySuppressionForStartupCommand(state, 'vim');
@@ -110,13 +122,15 @@ test('broadcast peer sessions can be armed through the suppression registry', ()
   const popupState = { current: false };
   const unregisterPeer = registerOscColorQuerySuppressionArmer(
     'peer-session',
-    (_data, command) => {
+    (data, command) => {
+      if (data.includes('\x03')) markOscColorQuerySuppressionEndBoundary(peerState);
       if (command !== undefined) beginOscColorQuerySuppressionForCommand(peerState, command);
     },
   );
   const unregisterPopup = registerOscColorQuerySuppressionArmer(
     'peer-session',
-    (_data, command) => {
+    (data, command) => {
+      if (data.includes('\x03')) markOscColorQuerySuppressionEndBoundary(popupState);
       if (command !== undefined) beginOscColorQuerySuppressionForCommand(popupState, command);
     },
   );
@@ -125,6 +139,7 @@ test('broadcast peer sessions can be armed through the suppression registry', ()
   assert.equal(peerState.current, true);
   assert.equal(popupState.current, true);
 
+  handleOscColorQueryBroadcastInputForSession('peer-session', '\x03');
   handleOscColorQueryBroadcastInputForSession('peer-session', '\r', 'vim');
   assert.equal(peerState.current, false);
   assert.equal(popupState.current, false);

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -70,6 +70,24 @@ test('startup commands recognize saved Docker logs commands and built-in launche
   beginOscColorQuerySuppressionForStartupCommand(state, 'docker logs -f api');
   assert.equal(state.current, true);
 
+  beginOscColorQuerySuppressionForStartupCommand(
+    state,
+    'cd /srv\ndocker logs -f api',
+  );
+  assert.equal(state.current, true);
+
+  beginOscColorQuerySuppressionForStartupCommand(
+    state,
+    'cd "/srv/a && b" && docker logs -f api',
+  );
+  assert.equal(state.current, true);
+
+  beginOscColorQuerySuppressionForStartupCommand(
+    state,
+    'docker logs api && echo done',
+  );
+  assert.equal(state.current, false);
+
   beginOscColorQuerySuppressionForStartupCommand(state, 'vim');
   assert.equal(state.current, false);
 

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  beginOscColorQuerySuppressionForCommand,
+  endOscColorQuerySuppressionForCommand,
+  installOscColorQuerySuppression,
+  isDockerLogsCommand,
+} from './oscColorQuerySuppression.ts';
+
+type OscHandler = (data: string) => boolean | Promise<boolean>;
+
+const createParser = () => {
+  const handlers = new Map<number, OscHandler>();
+  const disposed = new Set<number>();
+  return {
+    parser: {
+      registerOscHandler(identifier: number, handler: OscHandler) {
+        handlers.set(identifier, handler);
+        return { dispose: () => disposed.add(identifier) };
+      },
+    },
+    handlers,
+    disposed,
+  };
+};
+
+test('Docker log color-query suppression consumes queries but preserves color settings', async () => {
+  const { parser, handlers, disposed } = createParser();
+  const disposable = installOscColorQuerySuppression(parser, true);
+
+  assert.deepEqual([...handlers.keys()], [10, 11, 12]);
+  for (const identifier of [10, 11, 12]) {
+    const handler = handlers.get(identifier);
+    assert.ok(handler);
+    assert.equal(await handler('?'), true);
+    assert.equal(await handler(' ? '), true);
+    assert.equal(await handler('rgb:11/22/33'), false);
+    assert.equal(await handler('#123456'), false);
+  }
+
+  disposable?.dispose();
+  assert.deepEqual([...disposed], [10, 11, 12]);
+});
+
+test('ordinary terminals do not install color-query suppression', () => {
+  const { parser, handlers } = createParser();
+
+  const disposable = installOscColorQuerySuppression(parser, false);
+
+  assert.equal(disposable, undefined);
+  assert.equal(handlers.size, 0);
+});
+
+test('docker logs detection covers direct and privileged commands without matching other docker commands', () => {
+  assert.equal(isDockerLogsCommand('docker logs -f api'), true);
+  assert.equal(isDockerLogsCommand('sudo -n docker logs --tail 200 api'), true);
+  assert.equal(isDockerLogsCommand('/usr/bin/docker --context prod logs api'), true);
+  assert.equal(isDockerLogsCommand('docker exec api sh'), false);
+  assert.equal(isDockerLogsCommand('echo docker logs api'), false);
+  assert.equal(isDockerLogsCommand('docker logs api; vim'), false);
+  assert.equal(isDockerLogsCommand('docker logs api && vim'), false);
+  assert.equal(isDockerLogsCommand('docker logs api | less'), false);
+});
+
+test('docker logs stays protected through prompt-like output and interrupt residue', async () => {
+  const { parser, handlers } = createParser();
+  const state = { current: false };
+  installOscColorQuerySuppression(parser, () => state.current);
+
+  const handler = handlers.get(11);
+  assert.ok(handler);
+  assert.equal(await handler('?'), false);
+  beginOscColorQuerySuppressionForCommand(state, 'docker logs -f api');
+  assert.equal(await handler('?'), true);
+  assert.equal(await handler('rgb:11/22/33'), false);
+  // Neither prompt-shaped log lines nor Ctrl+C are safe boundaries: output
+  // already in flight can still contain color queries after the interrupt.
+  assert.equal(await handler('?'), true);
+  assert.equal(state.current, true);
+});
+
+test('the next trusted non-log command restores ordinary color queries', () => {
+  const state = { current: true };
+  beginOscColorQuerySuppressionForCommand(state, 'vim');
+  assert.equal(state.current, false);
+  endOscColorQuerySuppressionForCommand(state);
+  assert.equal(state.current, false);
+});

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -186,3 +186,20 @@ test('broadcast input accepts trusted multi-line and cursor-edited submissions',
   consumeHibernatedBroadcastInput(untrusted, 'docker logs');
   assert.equal(consumeHibernatedBroadcastInput(untrusted, '\r', 'docker logs'), false);
 });
+
+test('broadcast history navigation cannot borrow the source command identity', () => {
+  const history = { promptReady: true, line: '', tracking: false };
+  consumeHibernatedBroadcastInput(history, 'vim');
+  consumeHibernatedBroadcastInput(history, '\x1b[A');
+  assert.equal(
+    consumeHibernatedBroadcastInput(history, '\r', 'docker logs -f api'),
+    false,
+  );
+
+  const reverseSearch = { promptReady: true, line: '', tracking: false };
+  consumeHibernatedBroadcastInput(reverseSearch, '\x12docker');
+  assert.equal(
+    consumeHibernatedBroadcastInput(reverseSearch, '\r', 'docker logs -f api'),
+    false,
+  );
+});

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -34,6 +34,10 @@ test('docker logs detection covers direct and privileged commands without matchi
   assert.equal(isDockerLogsCommand('docker logs -f api'), true);
   assert.equal(isDockerLogsCommand('docker container logs -f api'), true);
   assert.equal(isDockerLogsCommand('sudo -n docker logs --tail 200 api'), true);
+  assert.equal(isDockerLogsCommand('sudo --user root docker logs -f api'), true);
+  assert.equal(isDockerLogsCommand('doas -u root docker logs -f api'), true);
+  assert.equal(isDockerLogsCommand('env DOCKER_HOST=unix:///run/docker.sock docker logs -f api'), true);
+  assert.equal(isDockerLogsCommand('env -u DOCKER_CONTEXT docker logs api'), true);
   assert.equal(isDockerLogsCommand('sudo docker --host tcp://1.2.3.4:2375 container logs api'), true);
   assert.equal(isDockerLogsCommand('/usr/bin/docker --context prod logs api'), true);
   assert.equal(isDockerLogsCommand('docker exec api sh'), false);
@@ -51,6 +55,12 @@ test('docker logs detection covers direct and privileged commands without matchi
   assert.equal(isDockerLogsCommand('docker logs -f api &&'), false);
   assert.equal(isDockerLogsCommand('vim && docker logs -f api'), false);
   assert.equal(isDockerLogsCommand('command cd /srv && docker logs -f api'), true);
+  assert.equal(isDockerLogsCommand('command -p docker logs -f api'), true);
+  assert.equal(isDockerLogsCommand('command -v docker logs'), false);
+  assert.equal(isDockerLogsCommand('command -V docker logs'), false);
+  assert.equal(isDockerLogsCommand('docker --help logs'), false);
+  assert.equal(isDockerLogsCommand('docker --version logs'), false);
+  assert.equal(isDockerLogsCommand('sudo --help docker logs api'), false);
 });
 
 test('docker logs stays protected through prompt-like output and interrupt residue', () => {

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -42,6 +42,10 @@ test('docker logs detection covers direct and privileged commands without matchi
   assert.equal(isDockerLogsCommand('docker logs api 2>&1'), true);
   assert.equal(isDockerLogsCommand('docker logs api > logs.txt'), true);
   assert.equal(isDockerLogsCommand('docker logs api &'), false);
+  assert.equal(isDockerLogsCommand('cd /srv && docker logs -f api'), true);
+  assert.equal(isDockerLogsCommand('cd /srv\ndocker container logs api'), true);
+  assert.equal(isDockerLogsCommand('docker logs -f api;\n'), true);
+  assert.equal(isDockerLogsCommand('docker logs -f api &&'), false);
 });
 
 test('docker logs stays protected through prompt-like output and interrupt residue', () => {
@@ -137,7 +141,7 @@ test('broadcast peer sessions can be armed through the suppression registry', ()
 });
 
 test('hibernated broadcast input stays trusted across typed echoes until submission', () => {
-  const state = { promptReady: true, line: '' };
+  const state = { promptReady: true, line: '', tracking: false };
   for (const char of 'docker logs -f api') {
     assert.equal(consumeHibernatedBroadcastInput(state, char), false);
   }
@@ -146,11 +150,11 @@ test('hibernated broadcast input stays trusted across typed echoes until submiss
     consumeHibernatedBroadcastInput(state, '\r', 'docker logs -f api'),
     true,
   );
-  assert.deepEqual(state, { promptReady: false, line: '' });
+  assert.deepEqual(state, { promptReady: false, line: '', tracking: false });
 });
 
 test('hibernated broadcast input rejects mismatched and interrupted submissions', () => {
-  const state = { promptReady: true, line: '' };
+  const state = { promptReady: true, line: '', tracking: false };
   consumeHibernatedBroadcastInput(state, 'docker ps');
   assert.equal(consumeHibernatedBroadcastInput(state, '\r', 'docker logs -f api'), false);
 

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -2,10 +2,12 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  armOscColorQuerySuppressionForSession,
   beginOscColorQuerySuppressionForCommand,
   endOscColorQuerySuppressionForCommand,
   installOscColorQuerySuppression,
   isDockerLogsCommand,
+  registerOscColorQuerySuppressionArmer,
 } from './oscColorQuerySuppression.ts';
 
 type OscHandler = (data: string) => boolean | Promise<boolean>;
@@ -86,4 +88,22 @@ test('the next trusted non-log command restores ordinary color queries', () => {
   assert.equal(state.current, false);
   endOscColorQuerySuppressionForCommand(state);
   assert.equal(state.current, false);
+});
+
+test('broadcast peer sessions can be armed through the suppression registry', () => {
+  const peerState = { current: false };
+  const unregister = registerOscColorQuerySuppressionArmer(
+    'peer-session',
+    (command) => beginOscColorQuerySuppressionForCommand(peerState, command),
+  );
+
+  armOscColorQuerySuppressionForSession('peer-session', 'docker logs -f api');
+  assert.equal(peerState.current, true);
+
+  armOscColorQuerySuppressionForSession('peer-session', 'vim');
+  assert.equal(peerState.current, false);
+
+  unregister();
+  armOscColorQuerySuppressionForSession('peer-session', 'docker logs -f api');
+  assert.equal(peerState.current, false);
 });

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -82,6 +82,7 @@ test('docker logs detection covers direct and privileged commands without matchi
   assert.equal(isDockerLogsCommand("sudo sh -c 'docker logs -f api'"), true);
   assert.equal(isDockerLogsCommand("sh -c 'docker logs api'"), true);
   assert.equal(isDockerLogsCommand("sh -c 'vim && docker logs -f api'"), false);
+  assert.equal(isDockerLogsCommand("sh -c 'cd /srv && docker logs -f api'"), true);
   assert.equal(isDockerLogsCommand("bash -n -c 'docker logs -f api'"), false);
   assert.equal(isDockerLogsCommand("bash --noexec -c 'docker logs -f api'"), false);
   assert.equal(isDockerLogsCommand('docker logs --help -f api'), false);
@@ -112,12 +113,16 @@ test('a non-log command restores ordinary color queries only after a user interr
   assert.equal(state.current, false);
 });
 
-test('bounded Docker logs commands do not enable follow-mode suppression', () => {
+test('bounded Docker logs commands suppress replies until the next trusted command', () => {
   const state = { current: false };
   beginOscColorQuerySuppressionForCommand(state, 'docker logs --tail 200 api');
+  assert.equal(state.current, true);
+  beginOscColorQuerySuppressionForCommand(state, 'vim');
   assert.equal(state.current, false);
 
   beginOscColorQuerySuppressionForCommand(state, 'docker logs --follow=false api');
+  assert.equal(state.current, true);
+  beginOscColorQuerySuppressionForCommand(state, 'vim');
   assert.equal(state.current, false);
 });
 
@@ -135,10 +140,12 @@ test('Docker follow boolean and combined shorthand forms select the right lifecy
     ['docker logs -tf=false api', false],
     ['docker logs -ft=false api', true],
   ];
-  for (const [command, expected] of cases) {
+  for (const [command, expectedSticky] of cases) {
     const state = { current: false };
     beginOscColorQuerySuppressionForCommand(state, command);
-    assert.equal(state.current, expected, command);
+    assert.equal(state.current, true, command);
+    beginOscColorQuerySuppressionForCommand(state, 'vim');
+    assert.equal(state.current, expectedSticky, command);
   }
 });
 

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -97,6 +97,11 @@ test('a bounded Docker logs command restores on the next trusted command', () =>
   assert.equal(state.current, true);
   beginOscColorQuerySuppressionForCommand(state, 'vim');
   assert.equal(state.current, false);
+
+  beginOscColorQuerySuppressionForCommand(state, 'docker logs --follow=false api');
+  assert.equal(state.current, true);
+  beginOscColorQuerySuppressionForCommand(state, 'vim');
+  assert.equal(state.current, false);
 });
 
 test('the interrupt boundary survives a terminal-view handoff', () => {

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -2,9 +2,10 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
-  armOscColorQuerySuppressionForSession,
+  handleOscColorQueryBroadcastInputForSession,
   beginOscColorQuerySuppressionForCommand,
   beginOscColorQuerySuppressionForStartupCommand,
+  consumeHibernatedBroadcastInput,
   endOscColorQuerySuppressionForCommand,
   isDockerLogsCommand,
   registerOscColorQuerySuppressionArmer,
@@ -85,30 +86,61 @@ test('broadcast peer sessions can be armed through the suppression registry', ()
   const popupState = { current: false };
   const unregisterPeer = registerOscColorQuerySuppressionArmer(
     'peer-session',
-    (command) => beginOscColorQuerySuppressionForCommand(peerState, command),
+    (_data, command) => {
+      if (command !== undefined) beginOscColorQuerySuppressionForCommand(peerState, command);
+    },
   );
   const unregisterPopup = registerOscColorQuerySuppressionArmer(
     'peer-session',
-    (command) => beginOscColorQuerySuppressionForCommand(popupState, command),
+    (_data, command) => {
+      if (command !== undefined) beginOscColorQuerySuppressionForCommand(popupState, command);
+    },
   );
 
-  armOscColorQuerySuppressionForSession('peer-session', 'docker logs -f api');
+  handleOscColorQueryBroadcastInputForSession('peer-session', '\r', 'docker logs -f api');
   assert.equal(peerState.current, true);
   assert.equal(popupState.current, true);
 
-  armOscColorQuerySuppressionForSession('peer-session', 'vim');
+  handleOscColorQueryBroadcastInputForSession('peer-session', '\r', 'vim');
   assert.equal(peerState.current, false);
   assert.equal(popupState.current, false);
 
   unregisterPopup();
   peerState.current = false;
   popupState.current = false;
-  armOscColorQuerySuppressionForSession('peer-session', 'docker logs -f api');
+  handleOscColorQueryBroadcastInputForSession('peer-session', '\r', 'docker logs -f api');
   assert.equal(peerState.current, true);
   assert.equal(popupState.current, false);
 
   unregisterPeer();
   peerState.current = false;
-  armOscColorQuerySuppressionForSession('peer-session', 'docker logs -f api');
+  handleOscColorQueryBroadcastInputForSession('peer-session', '\r', 'docker logs -f api');
   assert.equal(peerState.current, false);
+});
+
+test('hibernated broadcast input stays trusted across typed echoes until submission', () => {
+  const state = { promptReady: true, line: '' };
+  for (const char of 'docker logs -f api') {
+    assert.equal(consumeHibernatedBroadcastInput(state, char), false);
+  }
+  assert.equal(state.promptReady, true);
+  assert.equal(
+    consumeHibernatedBroadcastInput(state, '\r', 'docker logs -f api'),
+    true,
+  );
+  assert.deepEqual(state, { promptReady: false, line: '' });
+});
+
+test('hibernated broadcast input rejects mismatched and interrupted submissions', () => {
+  const state = { promptReady: true, line: '' };
+  consumeHibernatedBroadcastInput(state, 'docker ps');
+  assert.equal(consumeHibernatedBroadcastInput(state, '\r', 'docker logs -f api'), false);
+
+  state.promptReady = true;
+  consumeHibernatedBroadcastInput(state, 'old\x15docker logs -f api');
+  assert.equal(consumeHibernatedBroadcastInput(state, '\r', 'docker logs -f api'), true);
+
+  state.promptReady = true;
+  consumeHibernatedBroadcastInput(state, 'docker logs -f api\x03');
+  assert.equal(consumeHibernatedBroadcastInput(state, '\r', 'docker logs -f api'), false);
 });

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -152,7 +152,7 @@ test('hibernated broadcast input stays trusted across typed echoes until submiss
     consumeHibernatedBroadcastInput(state, '\r', 'docker logs -f api'),
     true,
   );
-  assert.deepEqual(state, { promptReady: false, line: '', tracking: false });
+  assert.deepEqual(state, { promptReady: false, line: '', tracking: false, edited: false });
 });
 
 test('hibernated broadcast input rejects mismatched and interrupted submissions', () => {
@@ -167,4 +167,22 @@ test('hibernated broadcast input rejects mismatched and interrupted submissions'
   state.promptReady = true;
   consumeHibernatedBroadcastInput(state, 'docker logs -f api\x03');
   assert.equal(consumeHibernatedBroadcastInput(state, '\r', 'docker logs -f api'), false);
+});
+
+test('broadcast input accepts trusted multi-line and cursor-edited submissions', () => {
+  const multiline = { promptReady: true, line: '', tracking: false };
+  assert.equal(consumeHibernatedBroadcastInput(
+    multiline,
+    'cd /srv\ndocker logs -f api\r',
+    'cd /srv\ndocker logs -f api',
+  ), true);
+
+  const edited = { promptReady: true, line: '', tracking: false };
+  consumeHibernatedBroadcastInput(edited, 'docker logx');
+  consumeHibernatedBroadcastInput(edited, '\x1b[D\x7fs');
+  assert.equal(consumeHibernatedBroadcastInput(edited, '\r', 'docker logs'), true);
+
+  const untrusted = { promptReady: false, line: '', tracking: false };
+  consumeHibernatedBroadcastInput(untrusted, 'docker logs');
+  assert.equal(consumeHibernatedBroadcastInput(untrusted, '\r', 'docker logs'), false);
 });

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -46,6 +46,8 @@ test('docker logs detection covers direct and privileged commands without matchi
   assert.equal(isDockerLogsCommand('cd /srv\ndocker container logs api'), true);
   assert.equal(isDockerLogsCommand('docker logs -f api;\n'), true);
   assert.equal(isDockerLogsCommand('docker logs -f api &&'), false);
+  assert.equal(isDockerLogsCommand('vim && docker logs -f api'), false);
+  assert.equal(isDockerLogsCommand('command cd /srv && docker logs -f api'), true);
 });
 
 test('docker logs stays protected through prompt-like output and interrupt residue', () => {

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -38,6 +38,9 @@ test('docker logs detection covers direct and privileged commands without matchi
   assert.equal(isDockerLogsCommand('doas -u root docker logs -f api'), true);
   assert.equal(isDockerLogsCommand('env DOCKER_HOST=unix:///run/docker.sock docker logs -f api'), true);
   assert.equal(isDockerLogsCommand('env -u DOCKER_CONTEXT docker logs api'), true);
+  assert.equal(isDockerLogsCommand('env -C /tmp docker logs -f api'), true);
+  assert.equal(isDockerLogsCommand('env --chdir /tmp docker logs -f api'), true);
+  assert.equal(isDockerLogsCommand('sudo -T 30 docker logs -f api'), true);
   assert.equal(isDockerLogsCommand('sudo docker --host tcp://1.2.3.4:2375 container logs api'), true);
   assert.equal(isDockerLogsCommand('/usr/bin/docker --context prod logs api'), true);
   assert.equal(isDockerLogsCommand('docker exec api sh'), false);
@@ -76,7 +79,8 @@ test('docker logs stays protected through prompt-like output and interrupt resid
 });
 
 test('a non-log command restores ordinary color queries only after a user interrupt boundary', () => {
-  const state = { current: true };
+  const state = { current: false };
+  beginOscColorQuerySuppressionForCommand(state, 'docker logs -f api');
   beginOscColorQuerySuppressionForCommand(state, 'vim');
   assert.equal(state.current, true);
   markOscColorQuerySuppressionEndBoundary(state);
@@ -84,6 +88,14 @@ test('a non-log command restores ordinary color queries only after a user interr
   beginOscColorQuerySuppressionForCommand(state, 'vim');
   assert.equal(state.current, false);
   endOscColorQuerySuppressionForCommand(state);
+  assert.equal(state.current, false);
+});
+
+test('a bounded Docker logs command restores on the next trusted command', () => {
+  const state = { current: false };
+  beginOscColorQuerySuppressionForCommand(state, 'docker logs --tail 200 api');
+  assert.equal(state.current, true);
+  beginOscColorQuerySuppressionForCommand(state, 'vim');
   assert.equal(state.current, false);
 });
 

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -64,10 +64,23 @@ test('docker logs detection covers direct and privileged commands without matchi
   assert.equal(isDockerLogsCommand('docker --help logs'), false);
   assert.equal(isDockerLogsCommand('docker --version logs'), false);
   assert.equal(isDockerLogsCommand('sudo --help docker logs api'), false);
+  assert.equal(isDockerLogsCommand('sudo -l docker logs -f api'), false);
+  assert.equal(isDockerLogsCommand('sudo --list docker logs -f api'), false);
+  assert.equal(isDockerLogsCommand('sudo -v docker logs -f api'), false);
+  assert.equal(isDockerLogsCommand('sudo --validate docker logs -f api'), false);
+  assert.equal(isDockerLogsCommand('sudo -K docker logs -f api'), false);
+  assert.equal(isDockerLogsCommand('doas -L docker logs -f api'), false);
   assert.equal(isDockerLogsCommand('doas -C /etc/doas.conf docker logs -f api'), false);
+  assert.equal(isDockerLogsCommand('docker --help=true logs -f api'), false);
+  assert.equal(isDockerLogsCommand('docker --version=true logs -f api'), false);
   assert.equal(isDockerLogsCommand('env LABEL="two words" docker logs -f api'), true);
   assert.equal(isDockerLogsCommand('env LABEL="a|b" docker logs -f api'), true);
   assert.equal(isDockerLogsCommand('sudo -p "Password for %u: " docker logs -f api'), true);
+  assert.equal(isDockerLogsCommand("sh -c 'docker logs -f api'"), true);
+  assert.equal(isDockerLogsCommand("bash -lc 'exec docker logs --follow=true api'"), true);
+  assert.equal(isDockerLogsCommand("sudo sh -c 'docker logs -f api'"), true);
+  assert.equal(isDockerLogsCommand("sh -c 'docker logs api'"), true);
+  assert.equal(isDockerLogsCommand("sh -c 'vim && docker logs -f api'"), false);
 });
 
 test('docker logs stays protected through prompt-like output and interrupt residue', () => {

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -64,6 +64,10 @@ test('docker logs detection covers direct and privileged commands without matchi
   assert.equal(isDockerLogsCommand('docker --help logs'), false);
   assert.equal(isDockerLogsCommand('docker --version logs'), false);
   assert.equal(isDockerLogsCommand('sudo --help docker logs api'), false);
+  assert.equal(isDockerLogsCommand('doas -C /etc/doas.conf docker logs -f api'), false);
+  assert.equal(isDockerLogsCommand('env LABEL="two words" docker logs -f api'), true);
+  assert.equal(isDockerLogsCommand('env LABEL="a|b" docker logs -f api'), true);
+  assert.equal(isDockerLogsCommand('sudo -p "Password for %u: " docker logs -f api'), true);
 });
 
 test('docker logs stays protected through prompt-like output and interrupt residue', () => {
@@ -91,17 +95,34 @@ test('a non-log command restores ordinary color queries only after a user interr
   assert.equal(state.current, false);
 });
 
-test('a bounded Docker logs command restores on the next trusted command', () => {
+test('bounded Docker logs commands do not enable follow-mode suppression', () => {
   const state = { current: false };
   beginOscColorQuerySuppressionForCommand(state, 'docker logs --tail 200 api');
-  assert.equal(state.current, true);
-  beginOscColorQuerySuppressionForCommand(state, 'vim');
   assert.equal(state.current, false);
 
   beginOscColorQuerySuppressionForCommand(state, 'docker logs --follow=false api');
-  assert.equal(state.current, true);
-  beginOscColorQuerySuppressionForCommand(state, 'vim');
   assert.equal(state.current, false);
+});
+
+test('Docker follow boolean and combined shorthand forms select the right lifecycle', () => {
+  const cases: Array<[string, boolean]> = [
+    ['docker logs --follow api', true],
+    ['docker logs --follow=1 api', true],
+    ['docker logs --follow=TRUE api', true],
+    ['docker logs --follow=0 api', false],
+    ['docker logs --follow=FALSE api', false],
+    ['docker logs -f=true api', true],
+    ['docker logs -f=1 api', true],
+    ['docker logs -f=false api', false],
+    ['docker logs -f=0 api', false],
+    ['docker logs -tf=false api', false],
+    ['docker logs -ft=false api', true],
+  ];
+  for (const [command, expected] of cases) {
+    const state = { current: false };
+    beginOscColorQuerySuppressionForCommand(state, command);
+    assert.equal(state.current, expected, command);
+  }
 });
 
 test('the interrupt boundary survives a terminal-view handoff', () => {

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -82,18 +82,32 @@ test('startup commands recognize saved Docker logs commands and built-in launche
 
 test('broadcast peer sessions can be armed through the suppression registry', () => {
   const peerState = { current: false };
-  const unregister = registerOscColorQuerySuppressionArmer(
+  const popupState = { current: false };
+  const unregisterPeer = registerOscColorQuerySuppressionArmer(
     'peer-session',
     (command) => beginOscColorQuerySuppressionForCommand(peerState, command),
+  );
+  const unregisterPopup = registerOscColorQuerySuppressionArmer(
+    'peer-session',
+    (command) => beginOscColorQuerySuppressionForCommand(popupState, command),
   );
 
   armOscColorQuerySuppressionForSession('peer-session', 'docker logs -f api');
   assert.equal(peerState.current, true);
+  assert.equal(popupState.current, true);
 
   armOscColorQuerySuppressionForSession('peer-session', 'vim');
   assert.equal(peerState.current, true);
+  assert.equal(popupState.current, true);
 
-  unregister();
+  unregisterPopup();
+  peerState.current = false;
+  popupState.current = false;
+  armOscColorQuerySuppressionForSession('peer-session', 'docker logs -f api');
+  assert.equal(peerState.current, true);
+  assert.equal(popupState.current, false);
+
+  unregisterPeer();
   peerState.current = false;
   armOscColorQuerySuppressionForSession('peer-session', 'docker logs -f api');
   assert.equal(peerState.current, false);

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -69,6 +69,7 @@ test('docker logs detection covers direct and privileged commands without matchi
   assert.equal(isDockerLogsCommand('sudo -v docker logs -f api'), false);
   assert.equal(isDockerLogsCommand('sudo --validate docker logs -f api'), false);
   assert.equal(isDockerLogsCommand('sudo -K docker logs -f api'), false);
+  assert.equal(isDockerLogsCommand('sudo -D /tmp docker logs -f api'), true);
   assert.equal(isDockerLogsCommand('doas -L docker logs -f api'), false);
   assert.equal(isDockerLogsCommand('doas -C /etc/doas.conf docker logs -f api'), false);
   assert.equal(isDockerLogsCommand('docker --help=true logs -f api'), false);
@@ -81,6 +82,9 @@ test('docker logs detection covers direct and privileged commands without matchi
   assert.equal(isDockerLogsCommand("sudo sh -c 'docker logs -f api'"), true);
   assert.equal(isDockerLogsCommand("sh -c 'docker logs api'"), true);
   assert.equal(isDockerLogsCommand("sh -c 'vim && docker logs -f api'"), false);
+  assert.equal(isDockerLogsCommand("bash -n -c 'docker logs -f api'"), false);
+  assert.equal(isDockerLogsCommand("bash --noexec -c 'docker logs -f api'"), false);
+  assert.equal(isDockerLogsCommand('docker logs --help -f api'), false);
 });
 
 test('docker logs stays protected through prompt-like output and interrupt residue', () => {

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -30,7 +30,10 @@ const createParser = () => {
 
 test('Docker log color-query suppression consumes queries but preserves color settings', async () => {
   const { parser, handlers, disposed } = createParser();
-  const disposable = installOscColorQuerySuppression(parser, true);
+  const forwarded: string[] = [];
+  const disposable = installOscColorQuerySuppression(parser, true, (sequence) => {
+    forwarded.push(sequence);
+  });
 
   assert.deepEqual([...handlers.keys()], [4, 10, 11, 12]);
   const indexedColorHandler = handlers.get(4);
@@ -39,6 +42,8 @@ test('Docker log color-query suppression consumes queries but preserves color se
   assert.equal(await indexedColorHandler('0;?;15;?'), true);
   assert.equal(await indexedColorHandler('0;rgb:11/22/33'), false);
   assert.equal(await indexedColorHandler('0;#123456;15;#abcdef'), false);
+  assert.equal(await indexedColorHandler('0;#123456;15;?'), true);
+  assert.deepEqual(forwarded.splice(0), ['\x1b]4;0;#123456\x1b\\']);
   for (const identifier of [10, 11, 12]) {
     const handler = handlers.get(identifier);
     assert.ok(handler);
@@ -49,6 +54,12 @@ test('Docker log color-query suppression consumes queries but preserves color se
     assert.equal(await handler('rgb:11/22/33;#123456'), false);
     assert.equal(await handler('#123456'), false);
   }
+  const foregroundHandler = handlers.get(10);
+  assert.ok(foregroundHandler);
+  assert.equal(await foregroundHandler('#123456;?'), true);
+  assert.deepEqual(forwarded.splice(0), ['\x1b]10;#123456\x1b\\']);
+  assert.equal(await foregroundHandler('?;#abcdef'), true);
+  assert.deepEqual(forwarded.splice(0), ['\x1b]11;#abcdef\x1b\\']);
 
   disposable?.dispose();
   assert.deepEqual([...disposed], [4, 10, 11, 12]);
@@ -57,7 +68,7 @@ test('Docker log color-query suppression consumes queries but preserves color se
 test('ordinary terminals do not install color-query suppression', () => {
   const { parser, handlers } = createParser();
 
-  const disposable = installOscColorQuerySuppression(parser, false);
+  const disposable = installOscColorQuerySuppression(parser, false, () => {});
 
   assert.equal(disposable, undefined);
   assert.equal(handlers.size, 0);
@@ -75,12 +86,15 @@ test('docker logs detection covers direct and privileged commands without matchi
   assert.equal(isDockerLogsCommand('docker logs api; vim'), false);
   assert.equal(isDockerLogsCommand('docker logs api && vim'), false);
   assert.equal(isDockerLogsCommand('docker logs api | less'), false);
+  assert.equal(isDockerLogsCommand('docker logs api 2>&1'), true);
+  assert.equal(isDockerLogsCommand('docker logs api > logs.txt'), true);
+  assert.equal(isDockerLogsCommand('docker logs api &'), false);
 });
 
 test('docker logs stays protected through prompt-like output and interrupt residue', async () => {
   const { parser, handlers } = createParser();
   const state = { current: false };
-  installOscColorQuerySuppression(parser, () => state.current);
+  installOscColorQuerySuppression(parser, () => state.current, () => {});
 
   const handler = handlers.get(11);
   assert.ok(handler);

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -97,8 +97,8 @@ test('broadcast peer sessions can be armed through the suppression registry', ()
   assert.equal(popupState.current, true);
 
   armOscColorQuerySuppressionForSession('peer-session', 'vim');
-  assert.equal(peerState.current, true);
-  assert.equal(popupState.current, true);
+  assert.equal(peerState.current, false);
+  assert.equal(popupState.current, false);
 
   unregisterPopup();
   peerState.current = false;

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -6,72 +6,24 @@ import {
   beginOscColorQuerySuppressionForCommand,
   beginOscColorQuerySuppressionForStartupCommand,
   endOscColorQuerySuppressionForCommand,
-  installOscColorQuerySuppression,
   isDockerLogsCommand,
   registerOscColorQuerySuppressionArmer,
+  stripOscColorQueryResponses,
 } from './oscColorQuerySuppression.ts';
 
-type OscHandler = (data: string) => boolean | Promise<boolean>;
+test('Docker log color-query suppression removes only xterm color replies', () => {
+  const foregroundReply = '\x1b]10;rgb:1111/2222/3333\x1b\\';
+  const indexedReply = '\x1b]4;15;rgb:aaaa/bbbb/cccc\x1b\\';
+  const ordinaryInput = 'echo ok\r';
 
-const createParser = () => {
-  const handlers = new Map<number, OscHandler>();
-  const disposed = new Set<number>();
-  return {
-    parser: {
-      registerOscHandler(identifier: number, handler: OscHandler) {
-        handlers.set(identifier, handler);
-        return { dispose: () => disposed.add(identifier) };
-      },
-    },
-    handlers,
-    disposed,
-  };
-};
-
-test('Docker log color-query suppression consumes queries but preserves color settings', async () => {
-  const { parser, handlers, disposed } = createParser();
-  const forwarded: string[] = [];
-  const disposable = installOscColorQuerySuppression(parser, true, (sequence) => {
-    forwarded.push(sequence);
-  });
-
-  assert.deepEqual([...handlers.keys()], [4, 10, 11, 12]);
-  const indexedColorHandler = handlers.get(4);
-  assert.ok(indexedColorHandler);
-  assert.equal(await indexedColorHandler('0;?'), true);
-  assert.equal(await indexedColorHandler('0;?;15;?'), true);
-  assert.equal(await indexedColorHandler('0;rgb:11/22/33'), false);
-  assert.equal(await indexedColorHandler('0;#123456;15;#abcdef'), false);
-  assert.equal(await indexedColorHandler('0;#123456;15;?'), true);
-  assert.deepEqual(forwarded.splice(0), ['\x1b]4;0;#123456\x1b\\']);
-  for (const identifier of [10, 11, 12]) {
-    const handler = handlers.get(identifier);
-    assert.ok(handler);
-    assert.equal(await handler('?'), true);
-    assert.equal(await handler(' ? '), true);
-    assert.equal(await handler('?;?'), true);
-    assert.equal(await handler('rgb:11/22/33'), false);
-    assert.equal(await handler('rgb:11/22/33;#123456'), false);
-    assert.equal(await handler('#123456'), false);
-  }
-  const foregroundHandler = handlers.get(10);
-  assert.ok(foregroundHandler);
-  assert.equal(await foregroundHandler('#123456;?'), true);
-  assert.deepEqual(forwarded.splice(0), ['\x1b]10;#123456\x1b\\']);
-  assert.equal(await foregroundHandler('?;#abcdef'), true);
-  assert.deepEqual(forwarded.splice(0), ['\x1b]11;#abcdef\x1b\\']);
-
-  disposable?.dispose();
-  assert.deepEqual([...disposed], [4, 10, 11, 12]);
-});
-
-test('ordinary terminals do not install color-query suppression', () => {
-  const { parser, handlers } = createParser();
-
-  const disposable = installOscColorQuerySuppression(parser, false, () => {});
-
-  assert.equal(disposable, undefined);
-  assert.equal(handlers.size, 0);
+  assert.equal(stripOscColorQueryResponses(foregroundReply, true), '');
+  assert.equal(stripOscColorQueryResponses(indexedReply, true), '');
+  assert.equal(
+    stripOscColorQueryResponses(`${ordinaryInput}${foregroundReply}${indexedReply}`, true),
+    ordinaryInput,
+  );
+  assert.equal(stripOscColorQueryResponses(foregroundReply, false), foregroundReply);
+  assert.equal(stripOscColorQueryResponses('\x1b]10;#123456\x1b\\', true), '\x1b]10;#123456\x1b\\');
 });
 
 test('docker logs detection covers direct and privileged commands without matching other docker commands', () => {
@@ -91,20 +43,15 @@ test('docker logs detection covers direct and privileged commands without matchi
   assert.equal(isDockerLogsCommand('docker logs api &'), false);
 });
 
-test('docker logs stays protected through prompt-like output and interrupt residue', async () => {
-  const { parser, handlers } = createParser();
+test('docker logs stays protected through prompt-like output and interrupt residue', () => {
   const state = { current: false };
-  installOscColorQuerySuppression(parser, () => state.current, () => {});
-
-  const handler = handlers.get(11);
-  assert.ok(handler);
-  assert.equal(await handler('?'), false);
+  const reply = '\x1b]11;rgb:1111/2222/3333\x1b\\';
+  assert.equal(stripOscColorQueryResponses(reply, state.current), reply);
   beginOscColorQuerySuppressionForCommand(state, 'docker logs -f api');
-  assert.equal(await handler('?'), true);
-  assert.equal(await handler('rgb:11/22/33'), false);
+  assert.equal(stripOscColorQueryResponses(reply, state.current), '');
   // Neither prompt-shaped log lines nor Ctrl+C are safe boundaries: output
   // already in flight can still contain color queries after the interrupt.
-  assert.equal(await handler('?'), true);
+  assert.equal(stripOscColorQueryResponses(reply, state.current), '');
   assert.equal(state.current, true);
 });
 
@@ -144,9 +91,10 @@ test('broadcast peer sessions can be armed through the suppression registry', ()
   assert.equal(peerState.current, true);
 
   armOscColorQuerySuppressionForSession('peer-session', 'vim');
-  assert.equal(peerState.current, false);
+  assert.equal(peerState.current, true);
 
   unregister();
+  peerState.current = false;
   armOscColorQuerySuppressionForSession('peer-session', 'docker logs -f api');
   assert.equal(peerState.current, false);
 });

--- a/components/terminal/runtime/oscColorQuerySuppression.test.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.test.ts
@@ -32,18 +32,26 @@ test('Docker log color-query suppression consumes queries but preserves color se
   const { parser, handlers, disposed } = createParser();
   const disposable = installOscColorQuerySuppression(parser, true);
 
-  assert.deepEqual([...handlers.keys()], [10, 11, 12]);
+  assert.deepEqual([...handlers.keys()], [4, 10, 11, 12]);
+  const indexedColorHandler = handlers.get(4);
+  assert.ok(indexedColorHandler);
+  assert.equal(await indexedColorHandler('0;?'), true);
+  assert.equal(await indexedColorHandler('0;?;15;?'), true);
+  assert.equal(await indexedColorHandler('0;rgb:11/22/33'), false);
+  assert.equal(await indexedColorHandler('0;#123456;15;#abcdef'), false);
   for (const identifier of [10, 11, 12]) {
     const handler = handlers.get(identifier);
     assert.ok(handler);
     assert.equal(await handler('?'), true);
     assert.equal(await handler(' ? '), true);
+    assert.equal(await handler('?;?'), true);
     assert.equal(await handler('rgb:11/22/33'), false);
+    assert.equal(await handler('rgb:11/22/33;#123456'), false);
     assert.equal(await handler('#123456'), false);
   }
 
   disposable?.dispose();
-  assert.deepEqual([...disposed], [10, 11, 12]);
+  assert.deepEqual([...disposed], [4, 10, 11, 12]);
 });
 
 test('ordinary terminals do not install color-query suppression', () => {

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -143,12 +143,21 @@ const classifyStandaloneDockerLogsCommand = (command: string): DockerLogsCommand
   // `docker logs` is an alias of `docker container logs`.
   if (tokens[index] === 'container') index += 1;
   if (tokens[index] !== 'logs') return null;
-  return {
-    follow: tokens.slice(index + 1).some((token) => (
+  let follow = false;
+  for (const token of tokens.slice(index + 1)) {
+    if (token === '--follow=false' || token === '-f=false') {
+      follow = false;
+    } else if (
       token === '--follow'
-      || token.startsWith('--follow=')
-      || /^-[^-]*f/u.test(token)
-    )),
+      || token === '--follow=true'
+      || token === '-f'
+      || /^-[^-][^=]*f/u.test(token)
+    ) {
+      follow = true;
+    }
+  }
+  return {
+    follow,
   };
 };
 

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -11,8 +11,17 @@ const DOCKER_GLOBAL_OPTIONS_WITH_VALUE = new Set([
 
 const commandBasename = (token: string): string => token.split('/').pop() ?? token;
 
+const hasShellCommandSeparator = (command: string): boolean => {
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index];
+    if (char === ';' || char === '|' || char === '\r' || char === '\n') return true;
+    if (char === '&' && command[index - 1] !== '>' && command[index + 1] !== '>') return true;
+  }
+  return false;
+};
+
 export function isDockerLogsCommand(command: string): boolean {
-  if (/[;&|\r\n]/.test(command)) return false;
+  if (hasShellCommandSeparator(command)) return false;
   const tokens = command.trim().split(/\s+/).filter(Boolean);
   let index = 0;
 
@@ -104,23 +113,51 @@ export function armOscColorQuerySuppressionForSession(
 export function installOscColorQuerySuppression(
   parser: Pick<IParser, 'registerOscHandler'>,
   enabled: boolean | (() => boolean),
+  forwardColorSetting: (sequence: string) => void,
 ): IDisposable | undefined {
   if (!enabled) return undefined;
 
   const shouldSuppress = typeof enabled === 'function' ? enabled : () => true;
 
-  const containsColorQuery = (identifier: number, data: string): boolean => {
+  const suppressQueriesAndForwardSettings = (identifier: number, data: string): boolean => {
     const fields = data.split(';').map((field) => field.trim());
     if (identifier === 4) {
-      return fields.some((field, index) => index % 2 === 1 && field === '?');
+      let hasQuery = false;
+      const settings: string[] = [];
+      for (let index = 0; index + 1 < fields.length; index += 2) {
+        if (fields[index + 1] === '?') {
+          hasQuery = true;
+        } else {
+          settings.push(fields[index], fields[index + 1]);
+        }
+      }
+      if (!hasQuery) return false;
+      if (settings.length > 0) {
+        forwardColorSetting(`\x1b]4;${settings.join(';')}\x1b\\`);
+      }
+      return true;
     }
-    return fields.some((field) => field === '?');
+
+    let hasQuery = false;
+    const supportedFieldCount = 13 - identifier;
+    for (let index = 0; index < Math.min(fields.length, supportedFieldCount); index += 1) {
+      if (fields[index] === '?') {
+        hasQuery = true;
+      }
+    }
+    if (!hasQuery) return false;
+    for (let index = 0; index < Math.min(fields.length, supportedFieldCount); index += 1) {
+      if (fields[index] !== '?') {
+        forwardColorSetting(`\x1b]${identifier + index};${fields[index]}\x1b\\`);
+      }
+    }
+    return true;
   };
 
   const disposables = OSC_COLOR_QUERY_IDENTIFIERS.map((identifier) => (
     parser.registerOscHandler(
       identifier,
-      (data) => shouldSuppress() && containsColorQuery(identifier, data),
+      (data) => shouldSuppress() && suppressQueriesAndForwardSettings(identifier, data),
     )
   ));
 

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -14,9 +14,9 @@ const DOCKER_GLOBAL_OPTIONS_WITH_VALUE = new Set([
 
 const commandBasename = (token: string): string => token.split('/').pop() ?? token;
 
-const getLastForegroundCommandSegment = (command: string): string => {
+const getForegroundCommandSegments = (command: string): string[] => {
+  const segments: string[] = [];
   let segmentStart = 0;
-  let lastCompletedSegment = '';
   let trailingSeparator: 'soft' | 'and' | null = null;
   let quote: "'" | '"' | null = null;
   let escaped = false;
@@ -40,21 +40,26 @@ const getLastForegroundCommandSegment = (command: string): string => {
     }
     if (char === ';' || char === '\r' || char === '\n') {
       const segment = command.slice(segmentStart, index).trim();
-      if (segment) lastCompletedSegment = segment;
+      if (segment) segments.push(segment);
       segmentStart = index + 1;
       trailingSeparator = 'soft';
     } else if (char === '&' && command[index + 1] === '&') {
       const segment = command.slice(segmentStart, index).trim();
-      if (segment) lastCompletedSegment = segment;
+      if (segment) segments.push(segment);
       segmentStart = index + 2;
       trailingSeparator = 'and';
       index += 1;
     }
   }
   const finalSegment = command.slice(segmentStart).trim();
-  if (finalSegment) return finalSegment;
-  return trailingSeparator === 'soft' ? lastCompletedSegment : '';
+  if (finalSegment) segments.push(finalSegment);
+  if (!finalSegment && trailingSeparator === 'and') return [];
+  return segments;
 };
+
+const isSafeDockerLogsSetupCommand = (command: string): boolean => (
+  /^(?:builtin\s+|command\s+)?cd(?:\s|$)/u.test(command.trim())
+);
 
 const hasShellCommandSeparator = (command: string): boolean => {
   for (let index = 0; index < command.length; index += 1) {
@@ -106,7 +111,11 @@ const isStandaloneDockerLogsCommand = (command: string): boolean => {
 };
 
 export function isDockerLogsCommand(command: string): boolean {
-  return isStandaloneDockerLogsCommand(getLastForegroundCommandSegment(command));
+  const segments = getForegroundCommandSegments(command);
+  const dockerSegment = segments.at(-1);
+  return dockerSegment !== undefined
+    && segments.slice(0, -1).every(isSafeDockerLogsSetupCommand)
+    && isStandaloneDockerLogsCommand(dockerSegment);
 }
 
 export function beginOscColorQuerySuppressionForCommand(

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -89,16 +89,20 @@ export function endOscColorQuerySuppressionForCommand(state: { current: boolean 
   state.current = false;
 }
 
-const oscColorQuerySuppressionArmers = new Map<string, (command: string) => void>();
+const oscColorQuerySuppressionArmers = new Map<string, Set<(command: string) => void>>();
 
 /** Register a session's OSC color-query suppression armer for broadcast peers. */
 export function registerOscColorQuerySuppressionArmer(
   sessionId: string,
   armer: (command: string) => void,
 ): () => void {
-  oscColorQuerySuppressionArmers.set(sessionId, armer);
+  const armers = oscColorQuerySuppressionArmers.get(sessionId) ?? new Set();
+  armers.add(armer);
+  oscColorQuerySuppressionArmers.set(sessionId, armers);
   return () => {
-    if (oscColorQuerySuppressionArmers.get(sessionId) === armer) {
+    const currentArmers = oscColorQuerySuppressionArmers.get(sessionId);
+    currentArmers?.delete(armer);
+    if (currentArmers?.size === 0) {
       oscColorQuerySuppressionArmers.delete(sessionId);
     }
   };
@@ -110,7 +114,9 @@ export function armOscColorQuerySuppressionForSession(
   command: string,
 ): void {
   if (!isDockerLogsCommand(command)) return;
-  oscColorQuerySuppressionArmers.get(sessionId)?.(command);
+  for (const armer of oscColorQuerySuppressionArmers.get(sessionId) ?? []) {
+    armer(command);
+  }
 }
 
 export function stripOscColorQueryResponses(data: string, enabled: boolean): string {

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -151,6 +151,18 @@ export function markOscColorQuerySuppressionEndBoundary(state: { current: boolea
   if (state.current) suppressionEndBoundaries.add(state);
 }
 
+export function hasOscColorQuerySuppressionEndBoundary(state: { current: boolean }): boolean {
+  return state.current && suppressionEndBoundaries.has(state);
+}
+
+export function restoreOscColorQuerySuppressionEndBoundary(
+  state: { current: boolean },
+  enabled: boolean,
+): void {
+  suppressionEndBoundaries.delete(state);
+  if (state.current && enabled) suppressionEndBoundaries.add(state);
+}
+
 export function beginOscColorQuerySuppressionForStartupCommand(
   state: { current: boolean },
   command: string,

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -46,6 +46,8 @@ export function isDockerLogsCommand(command: string): boolean {
     index += 1;
     if (!option.includes('=') && DOCKER_GLOBAL_OPTIONS_WITH_VALUE.has(option)) index += 1;
   }
+  // `docker logs` is an alias of `docker container logs`.
+  if (tokens[index] === 'container') index += 1;
   return tokens[index] === 'logs';
 }
 

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -15,6 +15,11 @@ const DOCKER_GLOBAL_OPTIONS_WITH_VALUE = new Set([
   '-c', '-H', '-l',
 ]);
 const DOCKER_NON_EXECUTING_OPTIONS = new Set(['--help', '--version', '-v']);
+const SUDO_NON_EXECUTING_OPTIONS = new Set([
+  '--help', '--list', '--remove-timestamp', '--validate', '--version',
+  '-K', '-V', '-l', '-v',
+]);
+const DOAS_NON_EXECUTING_OPTIONS = new Set(['-C', '-L']);
 const SUDO_OPTIONS_WITH_VALUE = new Set([
   '--chdir', '--close-from', '--command-timeout', '--group', '--host', '--other-user', '--prompt', '--role',
   '--type', '--user', '-C', '-g', '-h', '-p', '-R', '-r', '-T', '-t', '-u',
@@ -137,7 +142,10 @@ const parseDockerBoolean = (value: string): boolean | null => {
 
 type DockerLogsCommand = { follow: boolean };
 
-const classifyStandaloneDockerLogsCommand = (command: string): DockerLogsCommand | null => {
+const classifyStandaloneDockerLogsCommand = (
+  command: string,
+  shellDepth = 0,
+): DockerLogsCommand | null => {
   if (hasShellCommandSeparator(command)) return null;
   const tokens = tokenizeShellWords(command);
   let index = 0;
@@ -167,8 +175,13 @@ const classifyStandaloneDockerLogsCommand = (command: string): DockerLogsCommand
       const optionsWithValue = wrapper === 'sudo' ? SUDO_OPTIONS_WITH_VALUE : DOAS_OPTIONS_WITH_VALUE;
       while ((tokens[index] ?? '').startsWith('-')) {
         const option = tokens[index];
-        if (['--help', '--version', '-V'].includes(option)) return null;
-        if (wrapper === 'doas' && (option === '-C' || option.startsWith('-C='))) return null;
+        if (
+          wrapper === 'sudo'
+            ? SUDO_NON_EXECUTING_OPTIONS.has(option)
+              || /^-[^-]*[lVvK][^-]*$/u.test(option)
+            : DOAS_NON_EXECUTING_OPTIONS.has(option)
+              || option.startsWith('-C=')
+        ) return null;
         index += 1;
         if (!option.includes('=') && optionsWithValue.has(option)) index += 1;
       }
@@ -188,11 +201,32 @@ const classifyStandaloneDockerLogsCommand = (command: string): DockerLogsCommand
     break;
   }
 
+  const shell = commandBasename(tokens[index] ?? '');
+  if (shellDepth < 2 && ['bash', 'dash', 'ksh', 'sh', 'zsh'].includes(shell)) {
+    index += 1;
+    let commandString: string | undefined;
+    while (index < tokens.length && (tokens[index] ?? '').startsWith('-')) {
+      const option = tokens[index];
+      index += 1;
+      if (option === '--') continue;
+      if (option === '-c' || /^-[^-]*c[^-]*$/u.test(option)) {
+        commandString = tokens[index];
+        break;
+      }
+    }
+    return commandString === undefined
+      ? null
+      : classifyStandaloneDockerLogsCommand(commandString, shellDepth + 1);
+  }
+
   if (commandBasename(tokens[index] ?? '') !== 'docker') return null;
   index += 1;
   while ((tokens[index] ?? '').startsWith('-')) {
     const option = tokens[index];
-    if (DOCKER_NON_EXECUTING_OPTIONS.has(option)) return null;
+    if (
+      DOCKER_NON_EXECUTING_OPTIONS.has(option)
+      || /^(?:--help|--version|-v)=/u.test(option)
+    ) return null;
     index += 1;
     if (!option.includes('=') && DOCKER_GLOBAL_OPTIONS_WITH_VALUE.has(option)) index += 1;
   }

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -3,6 +3,7 @@ const OSC_COLOR_RESPONSE_PATTERN = new RegExp(
   `${ESC}\\](?:4;\\d{1,3}|1[0-2]);rgb:[0-9a-f]+\\/[0-9a-f]+\\/[0-9a-f]+${ESC}\\\\`,
   'giu',
 );
+const BRACKETED_PASTE_MARKER_PATTERN = new RegExp(`${ESC}\\[(?:200|201)~`, 'gu');
 
 const PRIVILEGE_WRAPPERS = new Set(['sudo', 'doas']);
 const SIMPLE_WRAPPERS = new Set(['command', 'builtin', 'exec']);
@@ -89,12 +90,48 @@ export function endOscColorQuerySuppressionForCommand(state: { current: boolean 
   state.current = false;
 }
 
-const oscColorQuerySuppressionArmers = new Map<string, Set<(command: string) => void>>();
+export type HibernatedBroadcastInputState = {
+  promptReady: boolean;
+  line: string;
+};
+
+/** Track the input line while xterm is absent and verify the submitted command. */
+export function consumeHibernatedBroadcastInput(
+  state: HibernatedBroadcastInputState,
+  data: string,
+  command?: string,
+): boolean {
+  const input = data.replace(BRACKETED_PASTE_MARKER_PATTERN, '');
+  let trustedSubmission = false;
+  for (const char of input) {
+    if (char === '\x03') {
+      state.promptReady = false;
+      state.line = '';
+    } else if (char === '\x15') {
+      state.line = '';
+    } else if (char === '\b' || char === '\x7f') {
+      state.line = state.line.slice(0, -1);
+    } else if (char === '\r' || char === '\n') {
+      trustedSubmission ||= state.promptReady
+        && command !== undefined
+        && state.line.trim() === command.trim();
+      state.promptReady = false;
+      state.line = '';
+    } else if (char.charCodeAt(0) >= 32) {
+      state.line += char;
+    }
+  }
+  return trustedSubmission;
+}
+
+type OscColorQueryBroadcastInputHandler = (data: string, command?: string) => void;
+
+const oscColorQuerySuppressionArmers = new Map<string, Set<OscColorQueryBroadcastInputHandler>>();
 
 /** Register a session's OSC color-query suppression armer for broadcast peers. */
 export function registerOscColorQuerySuppressionArmer(
   sessionId: string,
-  armer: (command: string) => void,
+  armer: OscColorQueryBroadcastInputHandler,
 ): () => void {
   const armers = oscColorQuerySuppressionArmers.get(sessionId) ?? new Set();
   armers.add(armer);
@@ -108,13 +145,14 @@ export function registerOscColorQuerySuppressionArmer(
   };
 }
 
-/** Transition OSC suppression on a broadcast target for its next trusted command. */
-export function armOscColorQuerySuppressionForSession(
+/** Track broadcast input and transition suppression on the target's trusted submission. */
+export function handleOscColorQueryBroadcastInputForSession(
   sessionId: string,
-  command: string,
+  data: string,
+  command?: string,
 ): void {
   for (const armer of oscColorQuerySuppressionArmers.get(sessionId) ?? []) {
-    armer(command);
+    armer(data, command);
   }
 }
 

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -9,6 +9,15 @@ const TRUSTED_CURSOR_EDIT_SEQUENCE_PATTERN = new RegExp(
   'gu',
 );
 const suppressionEndBoundaries = new WeakSet<object>();
+const suppressionVersions = new WeakMap<object, number>();
+
+const advanceSuppressionVersion = (state: object): void => {
+  suppressionVersions.set(state, (suppressionVersions.get(state) ?? 0) + 1);
+};
+
+export function getOscColorQuerySuppressionVersion(state: object): number {
+  return suppressionVersions.get(state) ?? 0;
+}
 
 const DOCKER_GLOBAL_OPTIONS_WITH_VALUE = new Set([
   '--config', '--context', '--host', '--log-level', '--tlscacert', '--tlscert', '--tlskey',
@@ -22,7 +31,7 @@ const SUDO_NON_EXECUTING_OPTIONS = new Set([
 const DOAS_NON_EXECUTING_OPTIONS = new Set(['-C', '-L']);
 const SUDO_OPTIONS_WITH_VALUE = new Set([
   '--chdir', '--close-from', '--command-timeout', '--group', '--host', '--other-user', '--prompt', '--role',
-  '--type', '--user', '-C', '-g', '-h', '-p', '-R', '-r', '-T', '-t', '-u',
+  '--type', '--user', '-C', '-D', '-g', '-h', '-p', '-R', '-r', '-T', '-t', '-u',
 ]);
 const DOAS_OPTIONS_WITH_VALUE = new Set(['-a', '-C', '-u']);
 const ENV_OPTIONS_WITH_VALUE = new Set(['--chdir', '--unset', '-C', '-u']);
@@ -208,6 +217,10 @@ const classifyStandaloneDockerLogsCommand = (
     while (index < tokens.length && (tokens[index] ?? '').startsWith('-')) {
       const option = tokens[index];
       index += 1;
+      if (
+        ['--help', '--noexec', '--version', '-n'].includes(option)
+        || /^-[^-]*n[^-]*$/u.test(option)
+      ) return null;
       if (option === '--') continue;
       if (option === '-c' || /^-[^-]*c[^-]*$/u.test(option)) {
         commandString = tokens[index];
@@ -235,6 +248,7 @@ const classifyStandaloneDockerLogsCommand = (
   if (tokens[index] !== 'logs') return null;
   let follow = false;
   for (const token of tokens.slice(index + 1)) {
+    if (token === '--help' || token.startsWith('--help=')) return null;
     if (token === '--follow' || token === '-f') {
       follow = true;
       continue;
@@ -277,6 +291,7 @@ export function beginOscColorQuerySuppressionForCommand(
   state: { current: boolean },
   command: string,
 ): void {
+  advanceSuppressionVersion(state);
   const dockerLogs = classifyDockerLogsCommand(command);
   if (dockerLogs?.follow) {
     state.current = true;
@@ -293,6 +308,7 @@ export function beginOscColorQuerySuppressionForCommand(
 }
 
 export function beginOscColorQuerySuppression(state: { current: boolean }): void {
+  advanceSuppressionVersion(state);
   state.current = true;
   suppressionEndBoundaries.delete(state);
 }
@@ -310,6 +326,7 @@ export function restoreOscColorQuerySuppressionEndBoundary(
   state: { current: boolean },
   enabled: boolean,
 ): void {
+  advanceSuppressionVersion(state);
   suppressionEndBoundaries.delete(state);
   if (state.current && enabled) suppressionEndBoundaries.add(state);
 }
@@ -327,6 +344,7 @@ export function beginOscColorQuerySuppressionForStartupCommand(
 }
 
 export function endOscColorQuerySuppressionForCommand(state: { current: boolean }): void {
+  advanceSuppressionVersion(state);
   state.current = false;
   suppressionEndBoundaries.delete(state);
 }

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -72,19 +72,74 @@ const isSafeDockerLogsSetupCommand = (command: string): boolean => (
 );
 
 const hasShellCommandSeparator = (command: string): boolean => {
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
   for (let index = 0; index < command.length; index += 1) {
     const char = command[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
     if (char === ';' || char === '|' || char === '\r' || char === '\n') return true;
     if (char === '&' && command[index - 1] !== '>' && command[index + 1] !== '>') return true;
   }
   return false;
 };
 
+const tokenizeShellWords = (command: string): string[] => {
+  const tokens: string[] = [];
+  let token = '';
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  const push = () => {
+    if (token) tokens.push(token);
+    token = '';
+  };
+  for (const char of command) {
+    if (escaped) {
+      token += char;
+      escaped = false;
+    } else if (char === '\\' && quote !== "'") {
+      escaped = true;
+    } else if (quote) {
+      if (char === quote) quote = null;
+      else token += char;
+    } else if (char === "'" || char === '"') {
+      quote = char;
+    } else if (/\s/u.test(char)) {
+      push();
+    } else {
+      token += char;
+    }
+  }
+  if (quote || escaped) return [];
+  push();
+  return tokens;
+};
+
+const parseDockerBoolean = (value: string): boolean | null => {
+  if (/^(?:1|t|true)$/iu.test(value)) return true;
+  if (/^(?:0|f|false)$/iu.test(value)) return false;
+  return null;
+};
+
 type DockerLogsCommand = { follow: boolean };
 
 const classifyStandaloneDockerLogsCommand = (command: string): DockerLogsCommand | null => {
   if (hasShellCommandSeparator(command)) return null;
-  const tokens = command.trim().split(/\s+/).filter(Boolean);
+  const tokens = tokenizeShellWords(command);
   let index = 0;
 
   while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[index] ?? '')) index += 1;
@@ -113,6 +168,7 @@ const classifyStandaloneDockerLogsCommand = (command: string): DockerLogsCommand
       while ((tokens[index] ?? '').startsWith('-')) {
         const option = tokens[index];
         if (['--help', '--version', '-V'].includes(option)) return null;
+        if (wrapper === 'doas' && (option === '-C' || option.startsWith('-C='))) return null;
         index += 1;
         if (!option.includes('=') && optionsWithValue.has(option)) index += 1;
       }
@@ -145,15 +201,23 @@ const classifyStandaloneDockerLogsCommand = (command: string): DockerLogsCommand
   if (tokens[index] !== 'logs') return null;
   let follow = false;
   for (const token of tokens.slice(index + 1)) {
-    if (token === '--follow=false' || token === '-f=false') {
-      follow = false;
-    } else if (
-      token === '--follow'
-      || token === '--follow=true'
-      || token === '-f'
-      || /^-[^-][^=]*f/u.test(token)
-    ) {
+    if (token === '--follow' || token === '-f') {
       follow = true;
+      continue;
+    }
+    const longValue = /^--follow=(.+)$/iu.exec(token);
+    if (longValue) {
+      follow = parseDockerBoolean(longValue[1]) ?? false;
+      continue;
+    }
+    const shortCluster = /^-([^-][^=]*)(?:=(.+))?$/u.exec(token);
+    if (shortCluster) {
+      const followIndex = shortCluster[1].indexOf('f');
+      if (followIndex >= 0) {
+        follow = followIndex === shortCluster[1].length - 1 && shortCluster[2] !== undefined
+          ? parseDockerBoolean(shortCluster[2]) ?? false
+          : true;
+      }
     }
   }
   return {
@@ -180,12 +244,9 @@ export function beginOscColorQuerySuppressionForCommand(
   command: string,
 ): void {
   const dockerLogs = classifyDockerLogsCommand(command);
-  if (dockerLogs) {
+  if (dockerLogs?.follow) {
     state.current = true;
-    // Follow mode needs a user-originated interrupt before a prompt can be
-    // trusted. A bounded logs command may restore on its next trusted command.
-    if (dockerLogs.follow) suppressionEndBoundaries.delete(state);
-    else suppressionEndBoundaries.add(state);
+    suppressionEndBoundaries.delete(state);
     return;
   }
   // A prompt-shaped line can be emitted by the container itself. Keep the

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -14,6 +14,38 @@ const DOCKER_GLOBAL_OPTIONS_WITH_VALUE = new Set([
 
 const commandBasename = (token: string): string => token.split('/').pop() ?? token;
 
+const getLastStartupCommandSegment = (command: string): string => {
+  let segmentStart = 0;
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === ';' || char === '\r' || char === '\n') {
+      segmentStart = index + 1;
+    } else if (char === '&' && command[index + 1] === '&') {
+      segmentStart = index + 2;
+      index += 1;
+    }
+  }
+  return command.slice(segmentStart).trim();
+};
+
 const hasShellCommandSeparator = (command: string): boolean => {
   for (let index = 0; index < command.length; index += 1) {
     const char = command[index];
@@ -83,7 +115,7 @@ export function beginOscColorQuerySuppressionForStartupCommand(
     beginOscColorQuerySuppression(state);
     return;
   }
-  beginOscColorQuerySuppressionForCommand(state, command);
+  beginOscColorQuerySuppressionForCommand(state, getLastStartupCommandSegment(command));
 }
 
 export function endOscColorQuerySuppressionForCommand(state: { current: boolean }): void {

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -8,6 +8,7 @@ const TRUSTED_CURSOR_EDIT_SEQUENCE_PATTERN = new RegExp(
   `${ESC}(?:\\[[0-9;]*[CDFH]|O[HF])`,
   'gu',
 );
+const suppressionEndBoundaries = new WeakSet<object>();
 
 const PRIVILEGE_WRAPPERS = new Set(['sudo', 'doas']);
 const SIMPLE_WRAPPERS = new Set(['command', 'builtin', 'exec']);
@@ -126,11 +127,28 @@ export function beginOscColorQuerySuppressionForCommand(
   state: { current: boolean },
   command: string,
 ): void {
-  state.current = isDockerLogsCommand(command);
+  if (isDockerLogsCommand(command)) {
+    state.current = true;
+    suppressionEndBoundaries.delete(state);
+    return;
+  }
+  // A prompt-shaped line can be emitted by the container itself. Keep the
+  // active guard sticky until a local interrupt establishes a boundary that
+  // cannot have originated in Docker output.
+  if (!state.current || suppressionEndBoundaries.has(state)) {
+    state.current = false;
+    suppressionEndBoundaries.delete(state);
+  }
 }
 
 export function beginOscColorQuerySuppression(state: { current: boolean }): void {
   state.current = true;
+  suppressionEndBoundaries.delete(state);
+}
+
+/** Record a user-originated interrupt without exposing trailing output yet. */
+export function markOscColorQuerySuppressionEndBoundary(state: { current: boolean }): void {
+  if (state.current) suppressionEndBoundaries.add(state);
 }
 
 export function beginOscColorQuerySuppressionForStartupCommand(
@@ -147,6 +165,7 @@ export function beginOscColorQuerySuppressionForStartupCommand(
 
 export function endOscColorQuerySuppressionForCommand(state: { current: boolean }): void {
   state.current = false;
+  suppressionEndBoundaries.delete(state);
 }
 
 export type HibernatedBroadcastInputState = {

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -4,6 +4,10 @@ const OSC_COLOR_RESPONSE_PATTERN = new RegExp(
   'giu',
 );
 const BRACKETED_PASTE_MARKER_PATTERN = new RegExp(`${ESC}\\[(?:200|201)~`, 'gu');
+const TRUSTED_CURSOR_EDIT_SEQUENCE_PATTERN = new RegExp(
+  `${ESC}(?:\\[[0-9;]*[CDFH]|O[HF])`,
+  'gu',
+);
 
 const PRIVILEGE_WRAPPERS = new Set(['sudo', 'doas']);
 const SIMPLE_WRAPPERS = new Set(['command', 'builtin', 'exec']);
@@ -150,6 +154,7 @@ export type HibernatedBroadcastInputState = {
   line: string;
   tracking: boolean;
   edited?: boolean;
+  unverifiableEdit?: boolean;
 };
 
 /** Track the input line while xterm is absent and verify the submitted command. */
@@ -172,9 +177,22 @@ export function consumeHibernatedBroadcastInput(
     state.line = '';
     state.tracking = false;
     state.edited = false;
+    delete state.unverifiableEdit;
     return true;
   }
   const wasTracking = state.tracking;
+  const untrackedControls = input.replace(TRUSTED_CURSOR_EDIT_SEQUENCE_PATTERN, '');
+  if (Array.from(untrackedControls).some((char) => {
+    const code = char.charCodeAt(0);
+    return code < 32
+      && char !== '\r'
+      && char !== '\n'
+      && char !== '\x03'
+      && char !== '\x15'
+      && char !== '\b';
+  })) {
+    state.unverifiableEdit = true;
+  }
   if (input.includes(ESC)) state.edited = true;
   if (input) state.tracking = true;
   let trustedSubmission = false;
@@ -184,6 +202,7 @@ export function consumeHibernatedBroadcastInput(
       state.line = '';
       state.tracking = false;
       state.edited = false;
+      delete state.unverifiableEdit;
     } else if (char === '\x15') {
       state.line = '';
     } else if (char === '\b' || char === '\x7f') {
@@ -191,11 +210,15 @@ export function consumeHibernatedBroadcastInput(
     } else if (char === '\r' || char === '\n') {
       trustedSubmission ||= state.promptReady
         && command !== undefined
-        && (state.line.trim() === command.trim() || (wasTracking && state.edited === true));
+        && (
+          state.line.trim() === command.trim()
+          || (wasTracking && state.edited === true && state.unverifiableEdit !== true)
+        );
       state.promptReady = false;
       state.line = '';
       state.tracking = false;
       state.edited = false;
+      delete state.unverifiableEdit;
     } else if (char.charCodeAt(0) >= 32) {
       state.line += char;
     } else {

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -151,6 +151,16 @@ const parseDockerBoolean = (value: string): boolean | null => {
 
 type DockerLogsCommand = { follow: boolean };
 
+function classifyDockerLogsCommand(command: string, shellDepth = 0): DockerLogsCommand | null {
+  const segments = getForegroundCommandSegments(command);
+  const dockerSegment = segments.at(-1);
+  if (
+    dockerSegment === undefined
+    || !segments.slice(0, -1).every(isSafeDockerLogsSetupCommand)
+  ) return null;
+  return classifyStandaloneDockerLogsCommand(dockerSegment, shellDepth);
+}
+
 const classifyStandaloneDockerLogsCommand = (
   command: string,
   shellDepth = 0,
@@ -229,7 +239,7 @@ const classifyStandaloneDockerLogsCommand = (
     }
     return commandString === undefined
       ? null
-      : classifyStandaloneDockerLogsCommand(commandString, shellDepth + 1);
+      : classifyDockerLogsCommand(commandString, shellDepth + 1);
   }
 
   if (commandBasename(tokens[index] ?? '') !== 'docker') return null;
@@ -273,16 +283,6 @@ const classifyStandaloneDockerLogsCommand = (
   };
 };
 
-const classifyDockerLogsCommand = (command: string): DockerLogsCommand | null => {
-  const segments = getForegroundCommandSegments(command);
-  const dockerSegment = segments.at(-1);
-  if (
-    dockerSegment === undefined
-    || !segments.slice(0, -1).every(isSafeDockerLogsSetupCommand)
-  ) return null;
-  return classifyStandaloneDockerLogsCommand(dockerSegment);
-};
-
 export function isDockerLogsCommand(command: string): boolean {
   return classifyDockerLogsCommand(command) !== null;
 }
@@ -293,9 +293,10 @@ export function beginOscColorQuerySuppressionForCommand(
 ): void {
   advanceSuppressionVersion(state);
   const dockerLogs = classifyDockerLogsCommand(command);
-  if (dockerLogs?.follow) {
+  if (dockerLogs) {
     state.current = true;
-    suppressionEndBoundaries.delete(state);
+    if (dockerLogs.follow) suppressionEndBoundaries.delete(state);
+    else suppressionEndBoundaries.add(state);
     return;
   }
   // A prompt-shaped line can be emitted by the container itself. Keep the

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -149,6 +149,7 @@ export type HibernatedBroadcastInputState = {
   promptReady: boolean;
   line: string;
   tracking: boolean;
+  edited?: boolean;
 };
 
 /** Track the input line while xterm is absent and verify the submitted command. */
@@ -158,6 +159,23 @@ export function consumeHibernatedBroadcastInput(
   command?: string,
 ): boolean {
   const input = data.replace(BRACKETED_PASTE_MARKER_PATTERN, '');
+  const submittedInput = `${state.line}${input}`
+    .replace(/\r\n?/gu, '\n')
+    .replace(/[\r\n]+$/gu, '');
+  const normalizedCommand = command?.replace(/\r\n?/gu, '\n').trim();
+  if (
+    state.promptReady
+    && normalizedCommand !== undefined
+    && submittedInput.trim() === normalizedCommand
+  ) {
+    state.promptReady = false;
+    state.line = '';
+    state.tracking = false;
+    state.edited = false;
+    return true;
+  }
+  const wasTracking = state.tracking;
+  if (input.includes(ESC)) state.edited = true;
   if (input) state.tracking = true;
   let trustedSubmission = false;
   for (const char of input) {
@@ -165,6 +183,7 @@ export function consumeHibernatedBroadcastInput(
       state.promptReady = false;
       state.line = '';
       state.tracking = false;
+      state.edited = false;
     } else if (char === '\x15') {
       state.line = '';
     } else if (char === '\b' || char === '\x7f') {
@@ -172,12 +191,15 @@ export function consumeHibernatedBroadcastInput(
     } else if (char === '\r' || char === '\n') {
       trustedSubmission ||= state.promptReady
         && command !== undefined
-        && state.line.trim() === command.trim();
+        && (state.line.trim() === command.trim() || (wasTracking && state.edited === true));
       state.promptReady = false;
       state.line = '';
       state.tracking = false;
+      state.edited = false;
     } else if (char.charCodeAt(0) >= 32) {
       state.line += char;
+    } else {
+      state.edited = true;
     }
   }
   return trustedSubmission;

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -108,12 +108,11 @@ export function registerOscColorQuerySuppressionArmer(
   };
 }
 
-/** Arm Docker-log OSC suppression on a broadcast target without clearing target-owned state. */
+/** Transition OSC suppression on a broadcast target for its next trusted command. */
 export function armOscColorQuerySuppressionForSession(
   sessionId: string,
   command: string,
 ): void {
-  if (!isDockerLogsCommand(command)) return;
   for (const armer of oscColorQuerySuppressionArmers.get(sessionId) ?? []) {
     armer(command);
   }

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -64,6 +64,29 @@ export function endOscColorQuerySuppressionForCommand(state: { current: boolean 
   state.current = false;
 }
 
+const oscColorQuerySuppressionArmers = new Map<string, (command: string) => void>();
+
+/** Register a session's OSC color-query suppression armer for broadcast peers. */
+export function registerOscColorQuerySuppressionArmer(
+  sessionId: string,
+  armer: (command: string) => void,
+): () => void {
+  oscColorQuerySuppressionArmers.set(sessionId, armer);
+  return () => {
+    if (oscColorQuerySuppressionArmers.get(sessionId) === armer) {
+      oscColorQuerySuppressionArmers.delete(sessionId);
+    }
+  };
+}
+
+/** Arm (or clear) Docker-log OSC suppression on a broadcast target session. */
+export function armOscColorQuerySuppressionForSession(
+  sessionId: string,
+  command: string,
+): void {
+  oscColorQuerySuppressionArmers.get(sessionId)?.(command);
+}
+
 export function installOscColorQuerySuppression(
   parser: Pick<IParser, 'registerOscHandler'>,
   enabled: boolean | (() => boolean),

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -1,6 +1,8 @@
-import type { IDisposable, IParser } from '@xterm/xterm';
-
-const OSC_COLOR_QUERY_IDENTIFIERS = [4, 10, 11, 12] as const;
+const ESC = String.fromCharCode(0x1b);
+const OSC_COLOR_RESPONSE_PATTERN = new RegExp(
+  `${ESC}\\](?:4;\\d{1,3}|1[0-2]);rgb:[0-9a-f]+\\/[0-9a-f]+\\/[0-9a-f]+${ESC}\\\\`,
+  'giu',
+);
 
 const PRIVILEGE_WRAPPERS = new Set(['sudo', 'doas']);
 const SIMPLE_WRAPPERS = new Set(['command', 'builtin', 'exec']);
@@ -102,68 +104,15 @@ export function registerOscColorQuerySuppressionArmer(
   };
 }
 
-/** Arm (or clear) Docker-log OSC suppression on a broadcast target session. */
+/** Arm Docker-log OSC suppression on a broadcast target without clearing target-owned state. */
 export function armOscColorQuerySuppressionForSession(
   sessionId: string,
   command: string,
 ): void {
+  if (!isDockerLogsCommand(command)) return;
   oscColorQuerySuppressionArmers.get(sessionId)?.(command);
 }
 
-export function installOscColorQuerySuppression(
-  parser: Pick<IParser, 'registerOscHandler'>,
-  enabled: boolean | (() => boolean),
-  forwardColorSetting: (sequence: string) => void,
-): IDisposable | undefined {
-  if (!enabled) return undefined;
-
-  const shouldSuppress = typeof enabled === 'function' ? enabled : () => true;
-
-  const suppressQueriesAndForwardSettings = (identifier: number, data: string): boolean => {
-    const fields = data.split(';').map((field) => field.trim());
-    if (identifier === 4) {
-      let hasQuery = false;
-      const settings: string[] = [];
-      for (let index = 0; index + 1 < fields.length; index += 2) {
-        if (fields[index + 1] === '?') {
-          hasQuery = true;
-        } else {
-          settings.push(fields[index], fields[index + 1]);
-        }
-      }
-      if (!hasQuery) return false;
-      if (settings.length > 0) {
-        forwardColorSetting(`\x1b]4;${settings.join(';')}\x1b\\`);
-      }
-      return true;
-    }
-
-    let hasQuery = false;
-    const supportedFieldCount = 13 - identifier;
-    for (let index = 0; index < Math.min(fields.length, supportedFieldCount); index += 1) {
-      if (fields[index] === '?') {
-        hasQuery = true;
-      }
-    }
-    if (!hasQuery) return false;
-    for (let index = 0; index < Math.min(fields.length, supportedFieldCount); index += 1) {
-      if (fields[index] !== '?') {
-        forwardColorSetting(`\x1b]${identifier + index};${fields[index]}\x1b\\`);
-      }
-    }
-    return true;
-  };
-
-  const disposables = OSC_COLOR_QUERY_IDENTIFIERS.map((identifier) => (
-    parser.registerOscHandler(
-      identifier,
-      (data) => shouldSuppress() && suppressQueriesAndForwardSettings(identifier, data),
-    )
-  ));
-
-  return {
-    dispose: () => {
-      for (const disposable of disposables) disposable.dispose();
-    },
-  };
+export function stripOscColorQueryResponses(data: string, enabled: boolean): string {
+  return enabled ? data.replace(OSC_COLOR_RESPONSE_PATTERN, '') : data;
 }

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -1,6 +1,6 @@
 import type { IDisposable, IParser } from '@xterm/xterm';
 
-const OSC_COLOR_QUERY_IDENTIFIERS = [10, 11, 12] as const;
+const OSC_COLOR_QUERY_IDENTIFIERS = [4, 10, 11, 12] as const;
 
 const PRIVILEGE_WRAPPERS = new Set(['sudo', 'doas']);
 const SIMPLE_WRAPPERS = new Set(['command', 'builtin', 'exec']);
@@ -109,8 +109,19 @@ export function installOscColorQuerySuppression(
 
   const shouldSuppress = typeof enabled === 'function' ? enabled : () => true;
 
+  const containsColorQuery = (identifier: number, data: string): boolean => {
+    const fields = data.split(';').map((field) => field.trim());
+    if (identifier === 4) {
+      return fields.some((field, index) => index % 2 === 1 && field === '?');
+    }
+    return fields.some((field) => field === '?');
+  };
+
   const disposables = OSC_COLOR_QUERY_IDENTIFIERS.map((identifier) => (
-    parser.registerOscHandler(identifier, (data) => shouldSuppress() && data.trim() === '?')
+    parser.registerOscHandler(
+      identifier,
+      (data) => shouldSuppress() && containsColorQuery(identifier, data),
+    )
   ));
 
   return {

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -62,6 +62,18 @@ export function beginOscColorQuerySuppression(state: { current: boolean }): void
   state.current = true;
 }
 
+export function beginOscColorQuerySuppressionForStartupCommand(
+  state: { current: boolean },
+  command: string,
+  commandKind?: 'dockerLogs',
+): void {
+  if (commandKind === 'dockerLogs') {
+    beginOscColorQuerySuppression(state);
+    return;
+  }
+  beginOscColorQuerySuppressionForCommand(state, command);
+}
+
 export function endOscColorQuerySuppressionForCommand(state: { current: boolean }): void {
   state.current = false;
 }

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -1,0 +1,84 @@
+import type { IDisposable, IParser } from '@xterm/xterm';
+
+const OSC_COLOR_QUERY_IDENTIFIERS = [10, 11, 12] as const;
+
+const PRIVILEGE_WRAPPERS = new Set(['sudo', 'doas']);
+const SIMPLE_WRAPPERS = new Set(['command', 'builtin', 'exec']);
+const DOCKER_GLOBAL_OPTIONS_WITH_VALUE = new Set([
+  '--config', '--context', '--host', '--log-level', '--tlscacert', '--tlscert', '--tlskey',
+  '-c', '-H', '-l',
+]);
+
+const commandBasename = (token: string): string => token.split('/').pop() ?? token;
+
+export function isDockerLogsCommand(command: string): boolean {
+  if (/[;&|\r\n]/.test(command)) return false;
+  const tokens = command.trim().split(/\s+/).filter(Boolean);
+  let index = 0;
+
+  while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[index] ?? '')) index += 1;
+
+  while (index < tokens.length) {
+    const wrapper = commandBasename(tokens[index]);
+    if (SIMPLE_WRAPPERS.has(wrapper)) {
+      index += 1;
+      while ((tokens[index] ?? '').startsWith('-')) index += 1;
+      continue;
+    }
+    if (PRIVILEGE_WRAPPERS.has(wrapper)) {
+      index += 1;
+      while ((tokens[index] ?? '').startsWith('-')) {
+        const option = tokens[index];
+        index += 1;
+        if (!option.includes('=') && ['-C', '-g', '-h', '-p', '-R', '-r', '-t', '-u'].includes(option)) {
+          index += 1;
+        }
+      }
+      continue;
+    }
+    break;
+  }
+
+  if (commandBasename(tokens[index] ?? '') !== 'docker') return false;
+  index += 1;
+  while ((tokens[index] ?? '').startsWith('-')) {
+    const option = tokens[index];
+    index += 1;
+    if (!option.includes('=') && DOCKER_GLOBAL_OPTIONS_WITH_VALUE.has(option)) index += 1;
+  }
+  return tokens[index] === 'logs';
+}
+
+export function beginOscColorQuerySuppressionForCommand(
+  state: { current: boolean },
+  command: string,
+): void {
+  state.current = isDockerLogsCommand(command);
+}
+
+export function beginOscColorQuerySuppression(state: { current: boolean }): void {
+  state.current = true;
+}
+
+export function endOscColorQuerySuppressionForCommand(state: { current: boolean }): void {
+  state.current = false;
+}
+
+export function installOscColorQuerySuppression(
+  parser: Pick<IParser, 'registerOscHandler'>,
+  enabled: boolean | (() => boolean),
+): IDisposable | undefined {
+  if (!enabled) return undefined;
+
+  const shouldSuppress = typeof enabled === 'function' ? enabled : () => true;
+
+  const disposables = OSC_COLOR_QUERY_IDENTIFIERS.map((identifier) => (
+    parser.registerOscHandler(identifier, (data) => shouldSuppress() && data.trim() === '?')
+  ));
+
+  return {
+    dispose: () => {
+      for (const disposable of disposables) disposable.dispose();
+    },
+  };
+}

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -14,8 +14,10 @@ const DOCKER_GLOBAL_OPTIONS_WITH_VALUE = new Set([
 
 const commandBasename = (token: string): string => token.split('/').pop() ?? token;
 
-const getLastStartupCommandSegment = (command: string): string => {
+const getLastForegroundCommandSegment = (command: string): string => {
   let segmentStart = 0;
+  let lastCompletedSegment = '';
+  let trailingSeparator: 'soft' | 'and' | null = null;
   let quote: "'" | '"' | null = null;
   let escaped = false;
   for (let index = 0; index < command.length; index += 1) {
@@ -37,13 +39,21 @@ const getLastStartupCommandSegment = (command: string): string => {
       continue;
     }
     if (char === ';' || char === '\r' || char === '\n') {
+      const segment = command.slice(segmentStart, index).trim();
+      if (segment) lastCompletedSegment = segment;
       segmentStart = index + 1;
+      trailingSeparator = 'soft';
     } else if (char === '&' && command[index + 1] === '&') {
+      const segment = command.slice(segmentStart, index).trim();
+      if (segment) lastCompletedSegment = segment;
       segmentStart = index + 2;
+      trailingSeparator = 'and';
       index += 1;
     }
   }
-  return command.slice(segmentStart).trim();
+  const finalSegment = command.slice(segmentStart).trim();
+  if (finalSegment) return finalSegment;
+  return trailingSeparator === 'soft' ? lastCompletedSegment : '';
 };
 
 const hasShellCommandSeparator = (command: string): boolean => {
@@ -55,7 +65,7 @@ const hasShellCommandSeparator = (command: string): boolean => {
   return false;
 };
 
-export function isDockerLogsCommand(command: string): boolean {
+const isStandaloneDockerLogsCommand = (command: string): boolean => {
   if (hasShellCommandSeparator(command)) return false;
   const tokens = command.trim().split(/\s+/).filter(Boolean);
   let index = 0;
@@ -93,6 +103,10 @@ export function isDockerLogsCommand(command: string): boolean {
   // `docker logs` is an alias of `docker container logs`.
   if (tokens[index] === 'container') index += 1;
   return tokens[index] === 'logs';
+};
+
+export function isDockerLogsCommand(command: string): boolean {
+  return isStandaloneDockerLogsCommand(getLastForegroundCommandSegment(command));
 }
 
 export function beginOscColorQuerySuppressionForCommand(
@@ -115,7 +129,7 @@ export function beginOscColorQuerySuppressionForStartupCommand(
     beginOscColorQuerySuppression(state);
     return;
   }
-  beginOscColorQuerySuppressionForCommand(state, getLastStartupCommandSegment(command));
+  beginOscColorQuerySuppressionForCommand(state, command);
 }
 
 export function endOscColorQuerySuppressionForCommand(state: { current: boolean }): void {
@@ -125,6 +139,7 @@ export function endOscColorQuerySuppressionForCommand(state: { current: boolean 
 export type HibernatedBroadcastInputState = {
   promptReady: boolean;
   line: string;
+  tracking: boolean;
 };
 
 /** Track the input line while xterm is absent and verify the submitted command. */
@@ -134,11 +149,13 @@ export function consumeHibernatedBroadcastInput(
   command?: string,
 ): boolean {
   const input = data.replace(BRACKETED_PASTE_MARKER_PATTERN, '');
+  if (input) state.tracking = true;
   let trustedSubmission = false;
   for (const char of input) {
     if (char === '\x03') {
       state.promptReady = false;
       state.line = '';
+      state.tracking = false;
     } else if (char === '\x15') {
       state.line = '';
     } else if (char === '\b' || char === '\x7f') {
@@ -149,6 +166,7 @@ export function consumeHibernatedBroadcastInput(
         && state.line.trim() === command.trim();
       state.promptReady = false;
       state.line = '';
+      state.tracking = false;
     } else if (char.charCodeAt(0) >= 32) {
       state.line += char;
     }

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -10,12 +10,17 @@ const TRUSTED_CURSOR_EDIT_SEQUENCE_PATTERN = new RegExp(
 );
 const suppressionEndBoundaries = new WeakSet<object>();
 
-const PRIVILEGE_WRAPPERS = new Set(['sudo', 'doas']);
-const SIMPLE_WRAPPERS = new Set(['command', 'builtin', 'exec']);
 const DOCKER_GLOBAL_OPTIONS_WITH_VALUE = new Set([
   '--config', '--context', '--host', '--log-level', '--tlscacert', '--tlscert', '--tlskey',
   '-c', '-H', '-l',
 ]);
+const DOCKER_NON_EXECUTING_OPTIONS = new Set(['--help', '--version', '-v']);
+const SUDO_OPTIONS_WITH_VALUE = new Set([
+  '--chdir', '--close-from', '--group', '--host', '--other-user', '--prompt', '--role', '--type', '--user',
+  '-C', '-g', '-h', '-p', '-R', '-r', '-t', '-u',
+]);
+const DOAS_OPTIONS_WITH_VALUE = new Set(['-a', '-C', '-u']);
+const ENV_OPTIONS_WITH_VALUE = new Set(['--unset', '-u']);
 
 const commandBasename = (token: string): string => token.split('/').pop() ?? token;
 
@@ -84,20 +89,42 @@ const isStandaloneDockerLogsCommand = (command: string): boolean => {
 
   while (index < tokens.length) {
     const wrapper = commandBasename(tokens[index]);
-    if (SIMPLE_WRAPPERS.has(wrapper)) {
+    if (wrapper === 'command') {
       index += 1;
-      while ((tokens[index] ?? '').startsWith('-')) index += 1;
+      while (tokens[index] === '-p' || tokens[index] === '--') index += 1;
+      if ((tokens[index] ?? '').startsWith('-')) return false;
       continue;
     }
-    if (PRIVILEGE_WRAPPERS.has(wrapper)) {
+    if (wrapper === 'exec') {
       index += 1;
       while ((tokens[index] ?? '').startsWith('-')) {
         const option = tokens[index];
+        if (!['--', '-a', '-c', '-l'].includes(option)) return false;
         index += 1;
-        if (!option.includes('=') && ['-C', '-g', '-h', '-p', '-R', '-r', '-t', '-u'].includes(option)) {
-          index += 1;
-        }
+        if (option === '-a') index += 1;
       }
+      continue;
+    }
+    if (wrapper === 'sudo' || wrapper === 'doas') {
+      index += 1;
+      const optionsWithValue = wrapper === 'sudo' ? SUDO_OPTIONS_WITH_VALUE : DOAS_OPTIONS_WITH_VALUE;
+      while ((tokens[index] ?? '').startsWith('-')) {
+        const option = tokens[index];
+        if (['--help', '--version', '-V'].includes(option)) return false;
+        index += 1;
+        if (!option.includes('=') && optionsWithValue.has(option)) index += 1;
+      }
+      continue;
+    }
+    if (wrapper === 'env') {
+      index += 1;
+      while ((tokens[index] ?? '').startsWith('-')) {
+        const option = tokens[index];
+        if (['--help', '--version'].includes(option)) return false;
+        index += 1;
+        if (!option.includes('=') && ENV_OPTIONS_WITH_VALUE.has(option)) index += 1;
+      }
+      while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[index] ?? '')) index += 1;
       continue;
     }
     break;
@@ -107,6 +134,7 @@ const isStandaloneDockerLogsCommand = (command: string): boolean => {
   index += 1;
   while ((tokens[index] ?? '').startsWith('-')) {
     const option = tokens[index];
+    if (DOCKER_NON_EXECUTING_OPTIONS.has(option)) return false;
     index += 1;
     if (!option.includes('=') && DOCKER_GLOBAL_OPTIONS_WITH_VALUE.has(option)) index += 1;
   }

--- a/components/terminal/runtime/oscColorQuerySuppression.ts
+++ b/components/terminal/runtime/oscColorQuerySuppression.ts
@@ -16,11 +16,11 @@ const DOCKER_GLOBAL_OPTIONS_WITH_VALUE = new Set([
 ]);
 const DOCKER_NON_EXECUTING_OPTIONS = new Set(['--help', '--version', '-v']);
 const SUDO_OPTIONS_WITH_VALUE = new Set([
-  '--chdir', '--close-from', '--group', '--host', '--other-user', '--prompt', '--role', '--type', '--user',
-  '-C', '-g', '-h', '-p', '-R', '-r', '-t', '-u',
+  '--chdir', '--close-from', '--command-timeout', '--group', '--host', '--other-user', '--prompt', '--role',
+  '--type', '--user', '-C', '-g', '-h', '-p', '-R', '-r', '-T', '-t', '-u',
 ]);
 const DOAS_OPTIONS_WITH_VALUE = new Set(['-a', '-C', '-u']);
-const ENV_OPTIONS_WITH_VALUE = new Set(['--unset', '-u']);
+const ENV_OPTIONS_WITH_VALUE = new Set(['--chdir', '--unset', '-C', '-u']);
 
 const commandBasename = (token: string): string => token.split('/').pop() ?? token;
 
@@ -80,8 +80,10 @@ const hasShellCommandSeparator = (command: string): boolean => {
   return false;
 };
 
-const isStandaloneDockerLogsCommand = (command: string): boolean => {
-  if (hasShellCommandSeparator(command)) return false;
+type DockerLogsCommand = { follow: boolean };
+
+const classifyStandaloneDockerLogsCommand = (command: string): DockerLogsCommand | null => {
+  if (hasShellCommandSeparator(command)) return null;
   const tokens = command.trim().split(/\s+/).filter(Boolean);
   let index = 0;
 
@@ -92,14 +94,14 @@ const isStandaloneDockerLogsCommand = (command: string): boolean => {
     if (wrapper === 'command') {
       index += 1;
       while (tokens[index] === '-p' || tokens[index] === '--') index += 1;
-      if ((tokens[index] ?? '').startsWith('-')) return false;
+      if ((tokens[index] ?? '').startsWith('-')) return null;
       continue;
     }
     if (wrapper === 'exec') {
       index += 1;
       while ((tokens[index] ?? '').startsWith('-')) {
         const option = tokens[index];
-        if (!['--', '-a', '-c', '-l'].includes(option)) return false;
+        if (!['--', '-a', '-c', '-l'].includes(option)) return null;
         index += 1;
         if (option === '-a') index += 1;
       }
@@ -110,7 +112,7 @@ const isStandaloneDockerLogsCommand = (command: string): boolean => {
       const optionsWithValue = wrapper === 'sudo' ? SUDO_OPTIONS_WITH_VALUE : DOAS_OPTIONS_WITH_VALUE;
       while ((tokens[index] ?? '').startsWith('-')) {
         const option = tokens[index];
-        if (['--help', '--version', '-V'].includes(option)) return false;
+        if (['--help', '--version', '-V'].includes(option)) return null;
         index += 1;
         if (!option.includes('=') && optionsWithValue.has(option)) index += 1;
       }
@@ -120,7 +122,7 @@ const isStandaloneDockerLogsCommand = (command: string): boolean => {
       index += 1;
       while ((tokens[index] ?? '').startsWith('-')) {
         const option = tokens[index];
-        if (['--help', '--version'].includes(option)) return false;
+        if (['--help', '--version'].includes(option)) return null;
         index += 1;
         if (!option.includes('=') && ENV_OPTIONS_WITH_VALUE.has(option)) index += 1;
       }
@@ -130,34 +132,51 @@ const isStandaloneDockerLogsCommand = (command: string): boolean => {
     break;
   }
 
-  if (commandBasename(tokens[index] ?? '') !== 'docker') return false;
+  if (commandBasename(tokens[index] ?? '') !== 'docker') return null;
   index += 1;
   while ((tokens[index] ?? '').startsWith('-')) {
     const option = tokens[index];
-    if (DOCKER_NON_EXECUTING_OPTIONS.has(option)) return false;
+    if (DOCKER_NON_EXECUTING_OPTIONS.has(option)) return null;
     index += 1;
     if (!option.includes('=') && DOCKER_GLOBAL_OPTIONS_WITH_VALUE.has(option)) index += 1;
   }
   // `docker logs` is an alias of `docker container logs`.
   if (tokens[index] === 'container') index += 1;
-  return tokens[index] === 'logs';
+  if (tokens[index] !== 'logs') return null;
+  return {
+    follow: tokens.slice(index + 1).some((token) => (
+      token === '--follow'
+      || token.startsWith('--follow=')
+      || /^-[^-]*f/u.test(token)
+    )),
+  };
+};
+
+const classifyDockerLogsCommand = (command: string): DockerLogsCommand | null => {
+  const segments = getForegroundCommandSegments(command);
+  const dockerSegment = segments.at(-1);
+  if (
+    dockerSegment === undefined
+    || !segments.slice(0, -1).every(isSafeDockerLogsSetupCommand)
+  ) return null;
+  return classifyStandaloneDockerLogsCommand(dockerSegment);
 };
 
 export function isDockerLogsCommand(command: string): boolean {
-  const segments = getForegroundCommandSegments(command);
-  const dockerSegment = segments.at(-1);
-  return dockerSegment !== undefined
-    && segments.slice(0, -1).every(isSafeDockerLogsSetupCommand)
-    && isStandaloneDockerLogsCommand(dockerSegment);
+  return classifyDockerLogsCommand(command) !== null;
 }
 
 export function beginOscColorQuerySuppressionForCommand(
   state: { current: boolean },
   command: string,
 ): void {
-  if (isDockerLogsCommand(command)) {
+  const dockerLogs = classifyDockerLogsCommand(command);
+  if (dockerLogs) {
     state.current = true;
-    suppressionEndBoundaries.delete(state);
+    // Follow mode needs a user-originated interrupt before a prompt can be
+    // trusted. A bounded logs command may restore on its next trusted command.
+    if (dockerLogs.follow) suppressionEndBoundaries.delete(state);
+    else suppressionEndBoundaries.add(state);
     return;
   }
   // A prompt-shaped line can be emitted by the container itself. Keep the

--- a/components/terminal/runtime/shiftEnterText.test.ts
+++ b/components/terminal/runtime/shiftEnterText.test.ts
@@ -105,7 +105,7 @@ test("runtime routes Shift+Enter text through the shared input handler", () => {
   );
   assert.match(
     source,
-    /term\.onData\(\(data\) => \{[\s\S]*handleTerminalInputData\(data\);\s+\}\);/,
+    /term\.onData\(\(rawData\) => \{\s+const data = stripOscColorQueryResponses\([\s\S]*handleTerminalInputData\(data\);\s+\}\);/,
   );
   assert.match(
     source,

--- a/components/terminal/runtime/terminalCommandExecution.ts
+++ b/components/terminal/runtime/terminalCommandExecution.ts
@@ -666,12 +666,10 @@ export const recordTerminalCommandExecution = (
   if (cmd) {
     ctx.onCommandSubmitted?.(cmd, ctx.host.id, ctx.host.label, ctx.sessionId);
   }
-  const alignedPrompt = term ? getAlignedPrompt(term, command, true).prompt : null;
-  const trustedPrompt = Boolean(
-    term && alignedPrompt?.isAtPrompt
-    && isConfirmedTerminalShellPrompt(alignedPrompt.promptText, {
-      allowHostStyleGreaterThan: options?.allowHostStyleGreaterThanPrompt,
-    }),
+  const trustedPrompt = isTrustedTerminalShellSubmission(
+    command,
+    term,
+    options?.allowHostStyleGreaterThanPrompt,
   );
   if (cmd && shouldRecordShellHistory(cmd, term)) {
     if (trustedPrompt) {
@@ -685,4 +683,19 @@ export const recordTerminalCommandExecution = (
   ctx.commandBufferRef.current = "";
   markPromptLineBreakCommandPending(ctx.promptLineBreakStateRef, term, cmd || command);
   return null;
+};
+
+export const isTrustedTerminalShellSubmission = (
+  command: string,
+  term?: XTerm | null,
+  allowHostStyleGreaterThanPrompt?: boolean,
+): boolean => {
+  if (!term) return false;
+  const alignedPrompt = getAlignedPrompt(term, command, true).prompt;
+  return Boolean(
+    alignedPrompt.isAtPrompt
+    && isConfirmedTerminalShellPrompt(alignedPrompt.promptText, {
+      allowHostStyleGreaterThan: allowHostStyleGreaterThanPrompt,
+    }),
+  );
 };

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -164,6 +164,18 @@ test("broadcast targets and direct-send paths require their own trusted shell bo
     terminalSource,
     /autocompleteAcceptTextRef\.current[\s\S]*?let trustedSubmittedCommand[\s\S]*?trustedSubmittedCommand = command[\s\S]*?oscColorQuerySuppressionCommand: trustedSubmittedCommand/u,
   );
+  assert.match(
+    terminalSource,
+    /useTerminalContextActions\(\{[\s\S]*?onPasteData: broadcastUserPasteData/u,
+  );
+  assert.match(
+    terminalSource,
+    /trustedShellPromptReadyRef\.current = isTrustedTerminalShellSubmission[\s\S]*?disposeRuntimeOnly\(\)[\s\S]*?hibernatedRef\.current = true/u,
+  );
+  assert.match(
+    terminalSource,
+    /termRef\.current[\s\S]*?hibernatedRef\.current[\s\S]*?trustedShellPromptReadyRef\.current[\s\S]*?beginOscColorQuerySuppressionForCommand/u,
+  );
 });
 
 test("reconnect cleanup clears Docker-log OSC color-query suppression before disposing exit listeners", () => {

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -135,7 +135,7 @@ test("ordinary broadcast skips targets that are waiting for sensitive input", ()
 test("broadcast Docker-log submissions arm OSC color-query suppression on peers", () => {
   assert.match(
     terminalLayerSource,
-    /isBroadcastEnabled\?\.\(broadcastWorkspaceId\)[\s\S]*?armOscColorQuerySuppressionForSession\(peer\.id, command\)/u,
+    /isBroadcastEnabled\?\.\(broadcastWorkspaceId\)[\s\S]*?if \(!canUseDirectSessionWriteFallback\(peer\)\) continue;[\s\S]*?if \(isTerminalSensitiveInputActive\(peer\.id\)\) continue;[\s\S]*?armOscColorQuerySuppressionForSession\(peer\.id, command\)/u,
   );
   assert.match(
     terminalLayerSource,

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -131,3 +131,22 @@ test("ordinary broadcast skips targets that are waiting for sensitive input", ()
     /if \(isTerminalSensitiveInputActive\(session\.id\)\) continue;[\s\S]*?writeToSession\(session\.id, data/u,
   );
 });
+
+test("broadcast Docker-log submissions arm OSC color-query suppression on peers", () => {
+  assert.match(
+    terminalLayerSource,
+    /isBroadcastEnabled\?\.\(broadcastWorkspaceId\)[\s\S]*?armOscColorQuerySuppressionForSession\(peer\.id, command\)/u,
+  );
+  assert.match(
+    terminalLayerSource,
+    /oscColorQuerySuppressionCommand !== undefined[\s\S]*?armOscColorQuerySuppressionForSession\(\s*session\.id,\s*options\.oscColorQuerySuppressionCommand/u,
+  );
+  assert.match(
+    terminalSource,
+    /registerOscColorQuerySuppressionArmer\(\s*sessionId,\s*\(command\) => beginOscColorQuerySuppressionForCommand\(\s*suppressOscColorQueriesForActiveCommandRef,\s*command/u,
+  );
+  assert.match(
+    terminalSource,
+    /oscColorQuerySuppressionCommand: command/u,
+  );
+});

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -132,11 +132,7 @@ test("ordinary broadcast skips targets that are waiting for sensitive input", ()
   );
 });
 
-test("broadcast Docker-log submissions arm OSC color-query suppression on peers", () => {
-  assert.match(
-    terminalLayerSource,
-    /isBroadcastEnabled\?\.\(broadcastWorkspaceId\)[\s\S]*?if \(!canUseDirectSessionWriteFallback\(peer\)\) continue;[\s\S]*?if \(isTerminalSensitiveInputActive\(peer\.id\)\) continue;[\s\S]*?armOscColorQuerySuppressionForSession\(peer\.id, command\)/u,
-  );
+test("only trusted broadcast commands transition OSC color-query suppression on peers", () => {
   assert.match(
     terminalLayerSource,
     /oscColorQuerySuppressionCommand !== undefined[\s\S]*?armOscColorQuerySuppressionForSession\(\s*session\.id,\s*options\.oscColorQuerySuppressionCommand/u,
@@ -146,8 +142,16 @@ test("broadcast Docker-log submissions arm OSC color-query suppression on peers"
     /registerOscColorQuerySuppressionArmer\(\s*sessionId,\s*\(command\) => beginOscColorQuerySuppressionForCommand\(\s*suppressOscColorQueriesForActiveCommandRef,\s*command/u,
   );
   assert.match(
+    runtimeSource,
+    /onTrustedCommandSubmitted:[\s\S]*?trustedSubmittedCommand = command[\s\S]*?oscColorQuerySuppressionCommand: trustedSubmittedCommand/u,
+  );
+  assert.match(
     terminalSource,
-    /oscColorQuerySuppressionCommand: command/u,
+    /let trustedShellSubmission = false[\s\S]*?trustedShellSubmission = true[\s\S]*?trustedShellSubmission[\s\S]*?oscColorQuerySuppressionCommand: command/u,
+  );
+  assert.doesNotMatch(
+    terminalLayerSource,
+    /handleCommandSubmitted[\s\S]*?armOscColorQuerySuppressionForSession\(peer\.id, command\)/u,
   );
 });
 

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -166,6 +166,10 @@ test("only trusted broadcast commands transition OSC color-query suppression on 
     /if \(kittySequenceForKeyDown\)[\s\S]*?urgentInterrupt[\s\S]*?markOscColorQuerySuppressionEndBoundary/u,
   );
   assert.match(
+    runtimeSource,
+    /const trustedKittyCommand[\s\S]*?ctx\.onTrustedCommandSubmitted\?\.[\s\S]*?oscColorQuerySuppressionCommand: trustedKittyCommand/u,
+  );
+  assert.match(
     terminalSource,
     /let trustedShellSubmission = false[\s\S]*?trustedShellSubmission = true[\s\S]*?trustedShellSubmission[\s\S]*?oscColorQuerySuppressionCommand: command/u,
   );
@@ -230,5 +234,24 @@ test("reconnect cleanup clears Docker-log OSC color-query suppression before dis
   assert.match(
     terminalSource,
     /if \(!attachExistingSession\) \{[\s\S]*?endOscColorQuerySuppressionForCommand\(suppressOscColorQueriesForActiveCommandRef\);[\s\S]*?disposeSessionListeners\(\);/u,
+  );
+});
+
+test("only explicit shell integration completion ends Docker-log color-query suppression", () => {
+  assert.match(
+    runtimeSource,
+    /consumeOsc133CommandCompletion[\s\S]*?onCommandCompleted\?\.\(\{ source: "osc133" \}\)/u,
+  );
+  assert.match(
+    attachmentSource,
+    /onCommandCompleted\?\.\(\{ source: "prompt" \}\)/u,
+  );
+  assert.match(
+    terminalSource,
+    /meta\?\.source === 'osc133'[\s\S]*?endOscColorQuerySuppressionForCommand/u,
+  );
+  assert.doesNotMatch(
+    terminalSource,
+    /meta\?\.source === 'prompt'[\s\S]*?endOscColorQuerySuppressionForCommand/u,
   );
 });

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -209,6 +209,10 @@ test("broadcast targets and direct-send paths require their own trusted shell bo
     /termRef\.current[\s\S]*?hibernatedRef\.current[\s\S]*?consumeHibernatedBroadcastInput[\s\S]*?beginOscColorQuerySuppressionForCommand/u,
   );
   assert.match(
+    terminalLayerSource,
+    /if \(data === "\\x03" && terminalBackend\.interruptSession\) \{\s*handleOscColorQueryBroadcastInputForSession\(session\.id, data\);[\s\S]*?terminalBackend\.interruptSession/u,
+  );
+  assert.match(
     terminalSource,
     /hibernatedBroadcastInputRef\.current = \{\s*promptReady: trustedShellPromptReadyRef\.current,\s*line: "",\s*tracking: false,\s*edited: false,\s*\}/u,
   );

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -150,3 +150,10 @@ test("broadcast Docker-log submissions arm OSC color-query suppression on peers"
     /oscColorQuerySuppressionCommand: command/u,
   );
 });
+
+test("reconnect cleanup clears Docker-log OSC color-query suppression before disposing exit listeners", () => {
+  assert.match(
+    terminalSource,
+    /if \(!attachExistingSession\) \{[\s\S]*?endOscColorQuerySuppressionForCommand\(suppressOscColorQueriesForActiveCommandRef\);[\s\S]*?disposeSessionListeners\(\);/u,
+  );
+});

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -138,10 +138,6 @@ test("only trusted broadcast commands transition OSC color-query suppression on 
     /oscColorQuerySuppressionCommand !== undefined[\s\S]*?armOscColorQuerySuppressionForSession\(\s*session\.id,\s*options\.oscColorQuerySuppressionCommand/u,
   );
   assert.match(
-    terminalSource,
-    /registerOscColorQuerySuppressionArmer\(\s*sessionId,\s*\(command\) => beginOscColorQuerySuppressionForCommand\(\s*suppressOscColorQueriesForActiveCommandRef,\s*command/u,
-  );
-  assert.match(
     runtimeSource,
     /onTrustedCommandSubmitted:[\s\S]*?trustedSubmittedCommand = command[\s\S]*?oscColorQuerySuppressionCommand: trustedSubmittedCommand/u,
   );
@@ -152,6 +148,21 @@ test("only trusted broadcast commands transition OSC color-query suppression on 
   assert.doesNotMatch(
     terminalLayerSource,
     /handleCommandSubmitted[\s\S]*?armOscColorQuerySuppressionForSession\(peer\.id, command\)/u,
+  );
+});
+
+test("broadcast targets and direct-send paths require their own trusted shell boundary", () => {
+  assert.match(
+    terminalSource,
+    /registerOscColorQuerySuppressionArmer\([\s\S]*?isTrustedTerminalShellSubmission\([\s\S]*?beginOscColorQuerySuppressionForCommand/u,
+  );
+  assert.match(
+    runtimeSource,
+    /broadcastUserPasteData[\s\S]*?getSinglePastedCommand\(data\)[\s\S]*?isTrustedTerminalShellSubmission[\s\S]*?oscColorQuerySuppressionCommand/u,
+  );
+  assert.match(
+    terminalSource,
+    /autocompleteAcceptTextRef\.current[\s\S]*?let trustedSubmittedCommand[\s\S]*?trustedSubmittedCommand = command[\s\S]*?oscColorQuerySuppressionCommand: trustedSubmittedCommand/u,
   );
 });
 

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -151,7 +151,7 @@ test("only trusted broadcast commands transition OSC color-query suppression on 
   );
   assert.doesNotMatch(
     terminalSource,
-    /else if \(data\.includes\("\\r"\) \|\| data\.includes\("\\n"\) \|\| data\.includes\("\\x03"\)\)[\s\S]*?endOscColorQuerySuppressionForCommand/u,
+    /trustedTarget[\s\S]{0,500}else if \(data\.includes\("\\r"\)[\s\S]*?endOscColorQuerySuppressionForCommand/u,
   );
   assert.match(
     runtimeSource,

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -206,7 +206,7 @@ test("broadcast targets and direct-send paths require their own trusted shell bo
   );
   assert.match(
     terminalSource,
-    /hibernatedBroadcastInputRef\.current = \{\s*promptReady: trustedShellPromptReadyRef\.current,\s*line: "",\s*tracking: false,\s*\}/u,
+    /hibernatedBroadcastInputRef\.current = \{\s*promptReady: trustedShellPromptReadyRef\.current,\s*line: "",\s*tracking: false,\s*edited: false,\s*\}/u,
   );
   assert.match(
     terminalSource,

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -170,6 +170,10 @@ test("broadcast targets and direct-send paths require their own trusted shell bo
   );
   assert.match(
     terminalSource,
+    /const broadcastUserPasteData[\s\S]*?getSinglePastedCommand\(data\)[\s\S]*?isTrustedTerminalShellSubmission[\s\S]*?oscColorQuerySuppressionCommand/u,
+  );
+  assert.match(
+    terminalSource,
     /trustedShellPromptReadyRef\.current = isTrustedTerminalShellSubmission[\s\S]*?disposeRuntimeOnly\(\)[\s\S]*?hibernatedRef\.current = true/u,
   );
   assert.match(

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -182,7 +182,7 @@ test("broadcast targets and direct-send paths require their own trusted shell bo
   );
   assert.match(
     terminalSource,
-    /hibernatedBroadcastInputRef\.current = \{\s*promptReady: trustedShellPromptReadyRef\.current,\s*line: "",\s*\}/u,
+    /hibernatedBroadcastInputRef\.current = \{\s*promptReady: trustedShellPromptReadyRef\.current,\s*line: "",\s*tracking: false,\s*\}/u,
   );
 });
 

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -138,6 +138,14 @@ test("only trusted broadcast commands transition OSC color-query suppression on 
     /handleOscColorQueryBroadcastInputForSession\(\s*session\.id,\s*data,\s*options\?\.oscColorQuerySuppressionCommand/u,
   );
   assert.match(
+    terminalLayerSource,
+    /kittyKeyboardInput[\s\S]*?onResolvedInput:[\s\S]*?handleOscColorQueryBroadcastInputForSession\(session\.id, resolvedData, command\)[\s\S]*?continue/u,
+  );
+  assert.match(
+    runtimeSource,
+    /resolveSubmittedShellCommand\([\s\S]*?oscColorQuerySuppressionCommand: command[\s\S]*?broadcastKittyInput/u,
+  );
+  assert.match(
     runtimeSource,
     /onTrustedCommandSubmitted:[\s\S]*?trustedSubmittedCommand = command[\s\S]*?oscColorQuerySuppressionCommand: trustedSubmittedCommand/u,
   );

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -162,6 +162,10 @@ test("only trusted broadcast commands transition OSC color-query suppression on 
     /onTrustedCommandSubmitted:[\s\S]*?trustedSubmittedCommand = command[\s\S]*?oscColorQuerySuppressionCommand: trustedSubmittedCommand/u,
   );
   assert.match(
+    runtimeSource,
+    /if \(kittySequenceForKeyDown\)[\s\S]*?urgentInterrupt[\s\S]*?markOscColorQuerySuppressionEndBoundary/u,
+  );
+  assert.match(
     terminalSource,
     /let trustedShellSubmission = false[\s\S]*?trustedShellSubmission = true[\s\S]*?trustedShellSubmission[\s\S]*?oscColorQuerySuppressionCommand: command/u,
   );

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -135,7 +135,7 @@ test("ordinary broadcast skips targets that are waiting for sensitive input", ()
 test("only trusted broadcast commands transition OSC color-query suppression on peers", () => {
   assert.match(
     terminalLayerSource,
-    /oscColorQuerySuppressionCommand !== undefined[\s\S]*?armOscColorQuerySuppressionForSession\(\s*session\.id,\s*options\.oscColorQuerySuppressionCommand/u,
+    /handleOscColorQueryBroadcastInputForSession\(\s*session\.id,\s*data,\s*options\?\.oscColorQuerySuppressionCommand/u,
   );
   assert.match(
     runtimeSource,
@@ -178,7 +178,11 @@ test("broadcast targets and direct-send paths require their own trusted shell bo
   );
   assert.match(
     terminalSource,
-    /termRef\.current[\s\S]*?hibernatedRef\.current[\s\S]*?trustedShellPromptReadyRef\.current[\s\S]*?beginOscColorQuerySuppressionForCommand/u,
+    /termRef\.current[\s\S]*?hibernatedRef\.current[\s\S]*?consumeHibernatedBroadcastInput[\s\S]*?beginOscColorQuerySuppressionForCommand/u,
+  );
+  assert.match(
+    terminalSource,
+    /hibernatedBroadcastInputRef\.current = \{\s*promptReady: trustedShellPromptReadyRef\.current,\s*line: "",\s*\}/u,
   );
 });
 

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -211,7 +211,7 @@ test("broadcast targets and direct-send paths require their own trusted shell bo
   );
   assert.match(
     terminalSource,
-    /const hibernatePrompt = getAlignedPrompt[\s\S]*?hibernatePrompt\.userInput\.trim\(\)\.length === 0[\s\S]*?disposeRuntimeOnly\(\)[\s\S]*?hibernatedRef\.current = true/u,
+    /const hibernatePrompt = getAlignedPrompt[\s\S]*?line: hibernatePrompt\.userInput[\s\S]*?tracking: hibernatePrompt\.userInput\.length > 0[\s\S]*?disposeRuntimeOnly\(\)[\s\S]*?hibernatedRef\.current = true/u,
   );
   assert.match(
     terminalSource,
@@ -220,10 +220,6 @@ test("broadcast targets and direct-send paths require their own trusted shell bo
   assert.match(
     terminalLayerSource,
     /if \(data === "\\x03" && terminalBackend\.interruptSession\) \{\s*handleOscColorQueryBroadcastInputForSession\(session\.id, data\);[\s\S]*?terminalBackend\.interruptSession/u,
-  );
-  assert.match(
-    terminalSource,
-    /hibernatedBroadcastInputRef\.current = \{\s*promptReady: trustedShellPromptReadyRef\.current,\s*line: "",\s*tracking: false,\s*edited: false,\s*\}/u,
   );
   assert.match(
     terminalSource,
@@ -241,7 +237,7 @@ test("reconnect cleanup clears Docker-log OSC color-query suppression before dis
 test("natural completion requires an out-of-band foreground-shell check", () => {
   assert.match(
     terminalSource,
-    /isConfirmedTerminalShellPrompt[\s\S]*?getOscColorQuerySuppressionVersion[\s\S]*?getSessionPwd\(activeSessionId, \{ allowHomeFallback: false \}\)[\s\S]*?result\.shellForeground === true[\s\S]*?endOscColorQuerySuppressionForCommand/u,
+    /isConfirmedTerminalShellPrompt[\s\S]*?getOscColorQuerySuppressionVersion[\s\S]*?getLocalSessionForeground\(activeSessionId\)[\s\S]*?getSessionPwd\(activeSessionId, \{ allowHomeFallback: false \}\)[\s\S]*?result\.shellForeground === true[\s\S]*?endOscColorQuerySuppressionForCommand/u,
   );
   assert.doesNotMatch(
     runtimeSource,
@@ -249,6 +245,6 @@ test("natural completion requires an out-of-band foreground-shell check", () => 
   );
   assert.match(
     effectsSource,
-    /snap\.suppressOscColorQueries[\s\S]*?getSessionPwd\(sessionId, \{ allowHomeFallback: false \}\)[\s\S]*?result\.shellForeground === true[\s\S]*?endOscColorQuerySuppressionForCommand/u,
+    /snap\.suppressOscColorQueries[\s\S]*?getLocalSessionForeground\(sessionId\)[\s\S]*?getSessionPwd\(sessionId, \{ allowHomeFallback: false \}\)[\s\S]*?result\.shellForeground === true[\s\S]*?endOscColorQuerySuppressionForCommand/u,
   );
 });

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -146,6 +146,10 @@ test("only trusted broadcast commands transition OSC color-query suppression on 
     /resolveTrustedKeyboardBroadcastCommand[\s\S]*?resolveSubmittedShellCommand\([\s\S]*?oscColorQuerySuppressionCommand: resolveTrustedKeyboardBroadcastCommand\(\)/u,
   );
   assert.match(
+    runtimeSource,
+    /\(input, dispatchOptions\) => \{[\s\S]*?handleKittyKeyboardBroadcast\(input, dispatchOptions\)/u,
+  );
+  assert.match(
     terminalSource,
     /getAlignedPrompt\(termRef\.current, "", false\)[\s\S]*?livePrompt\.userInput\.trim\(\)\.length === 0/u,
   );

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -143,7 +143,15 @@ test("only trusted broadcast commands transition OSC color-query suppression on 
   );
   assert.match(
     runtimeSource,
-    /resolveSubmittedShellCommand\([\s\S]*?oscColorQuerySuppressionCommand: command[\s\S]*?broadcastKittyInput/u,
+    /resolveTrustedKeyboardBroadcastCommand[\s\S]*?resolveSubmittedShellCommand\([\s\S]*?oscColorQuerySuppressionCommand: resolveTrustedKeyboardBroadcastCommand\(\)/u,
+  );
+  assert.match(
+    terminalSource,
+    /getAlignedPrompt\(termRef\.current, "", false\)[\s\S]*?livePrompt\.userInput\.trim\(\)\.length === 0/u,
+  );
+  assert.doesNotMatch(
+    terminalSource,
+    /else if \(data\.includes\("\\r"\) \|\| data\.includes\("\\n"\) \|\| data\.includes\("\\x03"\)\)[\s\S]*?endOscColorQuerySuppressionForCommand/u,
   );
   assert.match(
     runtimeSource,
@@ -182,6 +190,14 @@ test("broadcast targets and direct-send paths require their own trusted shell bo
   );
   assert.match(
     terminalSource,
+    /submittedCommand = pastedCommand[\s\S]*?commandBufferRef\.current[\s\S]*?trustedCommand = submittedCommand/u,
+  );
+  assert.match(
+    runtimeSource,
+    /submittedCommand = pastedCommand[\s\S]*?ctx\.commandBufferRef\.current[\s\S]*?trustedCommand = submittedCommand/u,
+  );
+  assert.match(
+    terminalSource,
     /trustedShellPromptReadyRef\.current = isTrustedTerminalShellSubmission[\s\S]*?disposeRuntimeOnly\(\)[\s\S]*?hibernatedRef\.current = true/u,
   );
   assert.match(
@@ -191,6 +207,10 @@ test("broadcast targets and direct-send paths require their own trusted shell bo
   assert.match(
     terminalSource,
     /hibernatedBroadcastInputRef\.current = \{\s*promptReady: trustedShellPromptReadyRef\.current,\s*line: "",\s*tracking: false,\s*\}/u,
+  );
+  assert.match(
+    terminalSource,
+    /else \{\s*trustedShellPromptReadyRef\.current = false;[\s\S]*?hibernatedRef\.current && !hibernatedBroadcastInputRef\.current\.tracking[\s\S]*?promptReady: false/u,
   );
 });
 

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -6,6 +6,7 @@ const runtimeSource = readFileSync(new URL("./createXTermRuntime.ts", import.met
 const attachmentSource = readFileSync(new URL("./terminalSessionAttachment.ts", import.meta.url), "utf8");
 const terminalSource = readFileSync(new URL("../../Terminal.tsx", import.meta.url), "utf8");
 const terminalLayerSource = readFileSync(new URL("../../TerminalLayer.tsx", import.meta.url), "utf8");
+const effectsSource = readFileSync(new URL("../useTerminalEffects.ts", import.meta.url), "utf8");
 const preloadSource = readFileSync(
   new URL("../../../electron/preload/api.cjs", import.meta.url),
   "utf8",
@@ -210,7 +211,7 @@ test("broadcast targets and direct-send paths require their own trusted shell bo
   );
   assert.match(
     terminalSource,
-    /trustedShellPromptReadyRef\.current = isTrustedTerminalShellSubmission[\s\S]*?disposeRuntimeOnly\(\)[\s\S]*?hibernatedRef\.current = true/u,
+    /const hibernatePrompt = getAlignedPrompt[\s\S]*?hibernatePrompt\.userInput\.trim\(\)\.length === 0[\s\S]*?disposeRuntimeOnly\(\)[\s\S]*?hibernatedRef\.current = true/u,
   );
   assert.match(
     terminalSource,
@@ -237,21 +238,17 @@ test("reconnect cleanup clears Docker-log OSC color-query suppression before dis
   );
 });
 
-test("only explicit shell integration completion ends Docker-log color-query suppression", () => {
-  assert.match(
-    runtimeSource,
-    /consumeOsc133CommandCompletion[\s\S]*?onCommandCompleted\?\.\(\{ source: "osc133" \}\)/u,
-  );
-  assert.match(
-    attachmentSource,
-    /onCommandCompleted\?\.\(\{ source: "prompt" \}\)/u,
-  );
+test("natural completion requires an out-of-band foreground-shell check", () => {
   assert.match(
     terminalSource,
-    /meta\?\.source === 'osc133'[\s\S]*?endOscColorQuerySuppressionForCommand/u,
+    /isConfirmedTerminalShellPrompt[\s\S]*?getOscColorQuerySuppressionVersion[\s\S]*?getSessionPwd\(activeSessionId, \{ allowHomeFallback: false \}\)[\s\S]*?result\.shellForeground === true[\s\S]*?endOscColorQuerySuppressionForCommand/u,
   );
   assert.doesNotMatch(
-    terminalSource,
-    /meta\?\.source === 'prompt'[\s\S]*?endOscColorQuerySuppressionForCommand/u,
+    runtimeSource,
+    /consumeOsc133CommandCompletion[\s\S]{0,300}endOscColorQuerySuppressionForCommand/u,
+  );
+  assert.match(
+    effectsSource,
+    /snap\.suppressOscColorQueries[\s\S]*?getSessionPwd\(sessionId, \{ allowHomeFallback: false \}\)[\s\S]*?result\.shellForeground === true[\s\S]*?endOscColorQuerySuppressionForCommand/u,
   );
 });

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -602,7 +602,7 @@ const writeSessionDataImmediate = (
         ctx.promptLineBreakStateRef?.current,
       );
       for (let index = 0; index < completed; index += 1) {
-        ctx.onCommandCompleted?.({ source: "prompt" });
+        ctx.onCommandCompleted?.();
       }
     };
     const finishQueueItem = () => {

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -602,7 +602,7 @@ const writeSessionDataImmediate = (
         ctx.promptLineBreakStateRef?.current,
       );
       for (let index = 0; index < completed; index += 1) {
-        ctx.onCommandCompleted?.();
+        ctx.onCommandCompleted?.({ source: "prompt" });
       }
     };
     const finishQueueItem = () => {

--- a/components/terminal/runtime/terminalStartupCommands.ts
+++ b/components/terminal/runtime/terminalStartupCommands.ts
@@ -98,6 +98,7 @@ export const scheduleStartupCommand = (
         onSettled?.();
         return;
       }
+      ctx.onStartupCommandStarted?.(commandToRun);
       ctx.terminalBackend.writeToSession(
         ctx.sessionRef.current,
         buildStartupPasteInput(term, commandToRun),
@@ -125,6 +126,7 @@ export const scheduleStartupCommand = (
       return;
     }
     const line = lines[index];
+    ctx.onStartupCommandStarted?.(line);
     ctx.terminalBackend.writeToSession(ctx.sessionRef.current, `${line}\r`, { automated: true });
     markPromptLineBreakCommandPending(ctx.promptLineBreakStateRef, term, line);
     ctx.onCommandExecuted?.(line, ctx.host.id, ctx.host.label, ctx.sessionId);

--- a/components/terminal/terminalHelpers.ts
+++ b/components/terminal/terminalHelpers.ts
@@ -133,6 +133,7 @@ export interface TerminalProps {
   lastCwd?: string;
   restoreTerminalCwd?: boolean;
   startupCommand?: string;
+  startupCommandKind?: 'dockerLogs';
   noAutoRun?: boolean;
   multiLineRunMode?: Snippet["multiLineRunMode"];
   pendingScriptId?: string;

--- a/components/terminal/terminalHelpers.ts
+++ b/components/terminal/terminalHelpers.ts
@@ -27,6 +27,8 @@ export const AUTO_RUN_SNIPPET_LINE_DELAY_MS = 250;
 export interface TerminalBroadcastInputOptions {
   noAutoRun?: boolean;
   lineDelayMs?: number;
+  /** When set, arm Docker-log OSC color-query suppression on each broadcast peer. */
+  oscColorQuerySuppressionCommand?: string;
   kittyKeyboardInput?: KittyKeyboardBroadcastInput;
   kittyKeyboardTargetSessionIds?: string[];
 }

--- a/components/terminal/terminalMemo.test.ts
+++ b/components/terminal/terminalMemo.test.ts
@@ -40,6 +40,13 @@ test("terminal memo refreshes when restored local shell type changes", () => {
   );
 });
 
+test("terminal memo refreshes when the startup command kind changes", () => {
+  assert.equal(
+    terminalPropsAreEqual(baseProps, { ...baseProps, startupCommandKind: 'dockerLogs' }),
+    false,
+  );
+});
+
 test("terminal memo refreshes when terminal context reader callback changes", () => {
   assert.equal(
     terminalPropsAreEqual(baseProps, {

--- a/components/terminal/terminalMemo.ts
+++ b/components/terminal/terminalMemo.ts
@@ -40,6 +40,7 @@ export const terminalPropsAreEqual = (
   && prev.restoreTerminalCwd === next.restoreTerminalCwd
   && prev.sessionDisplayName === next.sessionDisplayName
   && prev.startupCommand === next.startupCommand
+  && prev.startupCommandKind === next.startupCommandKind
   && prev.noAutoRun === next.noAutoRun
   && prev.pendingScriptId === next.pendingScriptId
   && prev.pendingScript === next.pendingScript

--- a/components/terminal/terminalRuntimeMount.test.ts
+++ b/components/terminal/terminalRuntimeMount.test.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert/strict';
-import { createRequire } from 'node:module';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
@@ -10,50 +9,6 @@ const terminalSource = readFileSync(new URL('../Terminal.tsx', import.meta.url),
 const terminalViewSource = readFileSync(new URL('./TerminalView.tsx', import.meta.url), 'utf8');
 const xtermRuntimeSource = readFileSync(new URL('./runtime/createXTermRuntime.ts', import.meta.url), 'utf8');
 const providerHookSource = readFileSync(new URL('../../application/state/usePluginTerminalProviders.ts', import.meta.url), 'utf8');
-
-test('OSC 10-12 color handling remains owned by xterm', async () => {
-  assert.doesNotMatch(
-    xtermRuntimeSource,
-    /registerOscHandler\((?:10|11|12),/,
-    'runtime hooks must not swallow xterm color updates or queries',
-  );
-
-  const require = createRequire(import.meta.url);
-  const { Terminal } = require('@xterm/xterm') as {
-    Terminal: new (options: Record<string, unknown>) => {
-      _core: {
-        _inputHandler: {
-          onColor(listener: (event: Array<{ type: number; index: number }>) => void): { dispose(): void };
-        };
-      };
-      write(data: string, callback: () => void): void;
-      dispose(): void;
-    };
-  };
-  const term = new Terminal({ cols: 20, rows: 2, allowProposedApi: true });
-  const colorEvents: Array<Array<{ type: number; index: number }>> = [];
-  const disposable = term._core._inputHandler.onColor((event) => colorEvents.push(event));
-
-  try {
-    await new Promise<void>((resolve) => {
-      term.write(
-        '\x1b]10;rgb:11/22/33\x07\x1b]11;?\x07\x1b]12;rgb:44/55/66\x07',
-        resolve,
-      );
-    });
-    assert.deepEqual(
-      colorEvents.map(([event]) => ({ type: event.type, index: event.index })),
-      [
-        { type: 1, index: 256 },
-        { type: 0, index: 257 },
-        { type: 1, index: 258 },
-      ],
-    );
-  } finally {
-    disposable.dispose();
-    term.dispose();
-  }
-});
 
 test('hibernate runtime keyword setup restores plugin decoration rules', () => {
   let applied: { rules: unknown[]; enabled: boolean } | undefined;

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -60,6 +60,7 @@ import { resolveHostSshConnectionTimeouts } from '../../domain/sshConnectionTime
 import { resolveEffectiveTerminalProtocol } from '../../domain/terminalProtocol';
 import {
   beginOscColorQuerySuppressionForCommand,
+  restoreOscColorQuerySuppressionEndBoundary,
 } from './runtime/oscColorQuerySuppression';
 
 type TerminalEffectsContext = Record<string, any>;
@@ -569,6 +570,10 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
             }
             if (typeof snap.suppressOscColorQueries === "boolean") {
               ctx.suppressOscColorQueriesForActiveCommandRef.current = snap.suppressOscColorQueries;
+              restoreOscColorQuerySuppressionEndBoundary(
+                ctx.suppressOscColorQueriesForActiveCommandRef,
+                snap.suppressOscColorQueriesCanEnd === true,
+              );
             }
             if (snap.cwd !== undefined) {
               const cwd = terminalCwdTracker.setRendererCwd(snap.cwd);

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -580,7 +580,10 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
                 const suppressionVersion = getOscColorQuerySuppressionVersion(
                   ctx.suppressOscColorQueriesForActiveCommandRef,
                 );
-                void terminalBackend.getSessionPwd(sessionId, { allowHomeFallback: false })
+                const foregroundProbe = isLocalConnection
+                  ? terminalBackend.getLocalSessionForeground(sessionId)
+                  : terminalBackend.getSessionPwd(sessionId, { allowHomeFallback: false });
+                void foregroundProbe
                   .then((result: { success: boolean; shellForeground?: boolean }) => {
                     if (
                       !disposed

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -60,6 +60,7 @@ import { resolveHostSshConnectionTimeouts } from '../../domain/sshConnectionTime
 import { resolveEffectiveTerminalProtocol } from '../../domain/terminalProtocol';
 import {
   beginOscColorQuerySuppressionForCommand,
+  endOscColorQuerySuppressionForCommand,
   restoreOscColorQuerySuppressionEndBoundary,
 } from './runtime/oscColorQuerySuppression';
 
@@ -190,7 +191,10 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
     publishPluginTerminalRuntimeLifecycleEvent(pluginTerminalLifecycle, 'commandSubmitted');
     void xtermRuntimeRef.current?.pluginProviderHost?.commandSubmitted(args[0]);
   };
-  const pluginAwareOnCommandCompleted = () => {
+  const pluginAwareOnCommandCompleted = (meta?: { source: 'osc133' | 'prompt' }) => {
+    if (meta?.source === 'osc133') {
+      endOscColorQuerySuppressionForCommand(ctx.suppressOscColorQueriesForActiveCommandRef);
+    }
     publishPluginTerminalRuntimeLifecycleEvent(pluginTerminalLifecycle, 'commandCompleted');
     void xtermRuntimeRef.current?.pluginProviderHost?.commandCompleted();
   };

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -58,6 +58,9 @@ import {
 } from './connectionTimeouts';
 import { resolveHostSshConnectionTimeouts } from '../../domain/sshConnectionTimeouts';
 import { resolveEffectiveTerminalProtocol } from '../../domain/terminalProtocol';
+import {
+  beginOscColorQuerySuppressionForCommand,
+} from './runtime/oscColorQuerySuppression';
 
 type TerminalEffectsContext = Record<string, any>;
 
@@ -178,6 +181,10 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
   ) && !kittyKeyboardProtocolEnabledForSession;
   ctx.pluginDecorationRulesRef.current = pluginDecorationRules;
   const pluginAwareOnCommandSubmitted = (...args: Parameters<NonNullable<typeof onCommandSubmitted>>) => {
+    beginOscColorQuerySuppressionForCommand(
+      ctx.suppressOscColorQueriesForActiveCommandRef,
+      args[0],
+    );
     markTerminalCommandCompletionPending(promptLineBreakStateRef);
     publishPluginTerminalRuntimeLifecycleEvent(pluginTerminalLifecycle, 'commandSubmitted');
     void xtermRuntimeRef.current?.pluginProviderHost?.commandSubmitted(args[0]);
@@ -400,6 +407,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
           resolvedFontFamily,
           fontSize,
           terminalTheme: effectiveTheme,
+          suppressOscColorQueriesForActiveCommandRef: ctx.suppressOscColorQueriesForActiveCommandRef,
           terminalSettingsRef,
           kittyKeyboardProtocolEnabled: kittyKeyboardProtocolEnabledForSession,
           terminalBackend,

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -61,6 +61,7 @@ import { resolveEffectiveTerminalProtocol } from '../../domain/terminalProtocol'
 import {
   beginOscColorQuerySuppressionForCommand,
   endOscColorQuerySuppressionForCommand,
+  getOscColorQuerySuppressionVersion,
   restoreOscColorQuerySuppressionEndBoundary,
 } from './runtime/oscColorQuerySuppression';
 
@@ -191,10 +192,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
     publishPluginTerminalRuntimeLifecycleEvent(pluginTerminalLifecycle, 'commandSubmitted');
     void xtermRuntimeRef.current?.pluginProviderHost?.commandSubmitted(args[0]);
   };
-  const pluginAwareOnCommandCompleted = (meta?: { source: 'osc133' | 'prompt' }) => {
-    if (meta?.source === 'osc133') {
-      endOscColorQuerySuppressionForCommand(ctx.suppressOscColorQueriesForActiveCommandRef);
-    }
+  const pluginAwareOnCommandCompleted = () => {
     publishPluginTerminalRuntimeLifecycleEvent(pluginTerminalLifecycle, 'commandCompleted');
     void xtermRuntimeRef.current?.pluginProviderHost?.commandCompleted();
   };
@@ -578,6 +576,29 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
                 ctx.suppressOscColorQueriesForActiveCommandRef,
                 snap.suppressOscColorQueriesCanEnd === true,
               );
+              if (snap.suppressOscColorQueries) {
+                const suppressionVersion = getOscColorQuerySuppressionVersion(
+                  ctx.suppressOscColorQueriesForActiveCommandRef,
+                );
+                void terminalBackend.getSessionPwd(sessionId, { allowHomeFallback: false })
+                  .then((result: { success: boolean; shellForeground?: boolean }) => {
+                    if (
+                      !disposed
+                      && result.success
+                      && result.shellForeground === true
+                      && sessionRef.current === sessionId
+                      && ctx.suppressOscColorQueriesForActiveCommandRef.current
+                      && getOscColorQuerySuppressionVersion(
+                        ctx.suppressOscColorQueriesForActiveCommandRef,
+                      ) === suppressionVersion
+                    ) {
+                      endOscColorQuerySuppressionForCommand(
+                        ctx.suppressOscColorQueriesForActiveCommandRef,
+                      );
+                    }
+                  })
+                  .catch(() => {});
+              }
             }
             if (snap.cwd !== undefined) {
               const cwd = terminalCwdTracker.setRendererCwd(snap.cwd);

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -567,6 +567,9 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
             if (typeof snap.passwordPromptActive === "boolean") {
               passwordPromptActiveRef.current = snap.passwordPromptActive;
             }
+            if (typeof snap.suppressOscColorQueries === "boolean") {
+              ctx.suppressOscColorQueriesForActiveCommandRef.current = snap.suppressOscColorQueries;
+            }
             if (snap.cwd !== undefined) {
               const cwd = terminalCwdTracker.setRendererCwd(snap.cwd);
               knownCwdRef.current = cwd;

--- a/domain/systemManager/types.ts
+++ b/domain/systemManager/types.ts
@@ -135,6 +135,7 @@ export interface TerminalPopupPayload {
   parentSessionId: string;
   sourceSession: import('../../types').TerminalSession;
   startupCommand: string;
+  startupCommandKind?: 'dockerLogs';
   localShellType?: import('../../types').TerminalSession['shellType'];
   /**
    * When set, the popup attaches to this already-running backend session

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -416,6 +416,26 @@ function createSessionOpsApi(ctx) {
         }
       '
     }
+    # A visible prompt is trustworthy only when a foreground shell exists and
+    # no non-shell process in its subtree still owns the foreground group.
+    # This also covers shells with job control disabled, where the waiting shell
+    # and its foreground child share one process group and both carry "+".
+    is_shell_ready() {
+      ps -e -o pid=,ppid=,stat=,comm= 2>/dev/null | awk -v start="$1" '
+        { pp[$1]=$2; st[$1]=$3; cm[$1]=$4; ord[NR]=$1 }
+        function isshell(c) { sub(/^.*\//, "", c); sub(/^-/, "", c); return c ~ /^(ba|z|fi|k|da|a|c|tc)?sh$/ }
+        function descendant(p,   d) { d=0; while (p != "" && d < 64) { if (p == start) return 1; p=pp[p]; d++ } return 0 }
+        END {
+          shell_fg=0; busy=0;
+          for (i=1; i<=NR; i++) {
+            p=ord[i];
+            if (!descendant(p) || index(st[p], "+") == 0) continue;
+            if (isshell(cm[p])) shell_fg=1; else busy=1;
+          }
+          exit !(shell_fg && !busy)
+        }
+      '
+    }
     # Read a process's cwd. Linux exposes it via /proc; systems without a
     # readable /proc fall back to lsof so the SFTP follow-terminal probe also
     # works on macOS and on BSD hosts that provide lsof (#2335). Both paths
@@ -436,10 +456,11 @@ function createSessionOpsApi(ctx) {
       printf 'NETCATTY_LOGIN_PID=%s\\n' "$login" >&2
       pid=$(find_active_shell "$login")
       [ -n "$pid" ] || pid="$login"
-      case "$(ps -p "$pid" -o stat= 2>/dev/null)" in
-        *+*) printf 'NETCATTY_SHELL_FOREGROUND=1\\n' >&2 ;;
-        *) printf 'NETCATTY_SHELL_FOREGROUND=0\\n' >&2 ;;
-      esac
+      if is_shell_ready "$login"; then
+        printf 'NETCATTY_SHELL_FOREGROUND=1\\n' >&2
+      else
+        printf 'NETCATTY_SHELL_FOREGROUND=0\\n' >&2
+      fi
       cwd=$(read_shell_cwd "$pid")
       # The active shell's cwd is only readable for same-uid processes (ptrace
       # perms on /proc, lsof permissions on macOS/BSD), so this unprivileged

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -436,6 +436,10 @@ function createSessionOpsApi(ctx) {
       printf 'NETCATTY_LOGIN_PID=%s\\n' "$login" >&2
       pid=$(find_active_shell "$login")
       [ -n "$pid" ] || pid="$login"
+      case "$(ps -p "$pid" -o stat= 2>/dev/null)" in
+        *+*) printf 'NETCATTY_SHELL_FOREGROUND=1\\n' >&2 ;;
+        *) printf 'NETCATTY_SHELL_FOREGROUND=0\\n' >&2 ;;
+      esac
       cwd=$(read_shell_cwd "$pid")
       # The active shell's cwd is only readable for same-uid processes (ptrace
       # perms on /proc, lsof permissions on macOS/BSD), so this unprivileged
@@ -492,12 +496,21 @@ function createSessionOpsApi(ctx) {
                 ? decodeLsofFileName(rawPath.slice(lsofPrefix.length))
                 : rawPath;
               const loginPidMatch = errOut.match(/(?:^|\n)NETCATTY_LOGIN_PID=(\d+)(?:\n|$)/);
+              const shellForegroundMatch = errOut.match(
+                /(?:^|\n)NETCATTY_SHELL_FOREGROUND=([01])(?:\n|$)/,
+              );
               if (loginPidMatch) {
                 session.shellPid = loginPidMatch[1];
               }
               log('[getSessionPwd]', { stdout: rawPath, stderr: errOut.trim(), exitCode: code });
               if (path && path.startsWith('/')) {
-                settle({ success: true, cwd: path });
+                settle({
+                  success: true,
+                  cwd: path,
+                  ...(shellForegroundMatch
+                    ? { shellForeground: shellForegroundMatch[1] === '1' }
+                    : {}),
+                });
               } else {
                 settle({ success: false, error: 'Could not determine cwd' });
               }

--- a/electron/bridges/sshBridge/sessionOps.cwd.test.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cwd.test.cjs
@@ -8,13 +8,15 @@ function quoteShellArg(value) {
   return "'" + String(value).replace(/'/g, "'\\''") + "'";
 }
 
-function makePwdStream(cwd, loginPid) {
+function makePwdStream(cwd, loginPid, shellForeground) {
   const stream = new EventEmitter();
   stream.stderr = new EventEmitter();
   stream.close = () => {};
   setImmediate(() => {
     stream.emit("data", Buffer.from(`${cwd}\n`));
-    stream.stderr.emit("data", Buffer.from(`NETCATTY_LOGIN_PID=${loginPid}\n`));
+    stream.stderr.emit("data", Buffer.from(
+      `NETCATTY_LOGIN_PID=${loginPid}\n${shellForeground === undefined ? "" : `NETCATTY_SHELL_FOREGROUND=${shellForeground ? 1 : 0}\n`}`,
+    ));
     stream.emit("close", 0);
   });
   return stream;
@@ -71,6 +73,25 @@ test("shared terminal cwd probe targets the shell pid assigned to that tab", asy
   assert.ok(command.includes("$3 !~ /^\\?+$/"));
   assert.match(command, /LC_ALL=C lsof/);
   assert.equal(session.shellPid, "4242");
+});
+
+test("session cwd probe reports whether the interactive shell owns the foreground", async () => {
+  const session = {
+    shellPid: "4242",
+    connRef: { count: 1 },
+    stream: {},
+    conn: {
+      exec(_command, callback) {
+        callback(null, makePwdStream("/srv/app", "4242", true));
+      },
+    },
+  };
+  const api = makeApi(session);
+
+  assert.deepEqual(
+    await api.getSessionPwd(null, { sessionId: "session-1" }),
+    { success: true, cwd: "/srv/app", shellForeground: true },
+  );
 });
 
 test("lsof cwd output decodes UTF-8 bytes and escaped control characters", () => {

--- a/electron/bridges/sshBridge/sessionOps.cwd.test.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cwd.test.cjs
@@ -72,6 +72,8 @@ test("shared terminal cwd probe targets the shell pid assigned to that tab", asy
   assert.ok(command.includes("sub(/^.*\\//"));
   assert.ok(command.includes("$3 !~ /^\\?+$/"));
   assert.match(command, /LC_ALL=C lsof/);
+  assert.match(command, /is_shell_ready/);
+  assert.match(command, /shell_fg && !busy/);
   assert.equal(session.shellPid, "4242");
 });
 

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -12,6 +12,7 @@ const path = require("node:path");
 const { promisify } = require("node:util");
 const { StringDecoder } = require("node:string_decoder");
 const { ensureNodePtySpawnHelperExecutable } = require("./nodePtySpawnHelperPermissions.cjs");
+const { isLocalShellForegroundFromPs } = require("./terminalLocalForeground.cjs");
 
 ensureNodePtySpawnHelperExecutable();
 
@@ -1065,6 +1066,30 @@ function startLocalSession(event, payload) {
   return { sessionId };
 }
 
+async function getLocalSessionForeground(_event, payload) {
+  const session = sessions.get(payload?.sessionId);
+  const shellPid = Number(session?.proc?.pid);
+  if (session?.type !== "local" || !Number.isSafeInteger(shellPid) || shellPid < 1) {
+    return { success: false, error: "Local session not found" };
+  }
+  if (process.platform === "win32") {
+    const children = await ptyProcessTree.getChildProcesses(payload.sessionId);
+    return { success: true, shellForeground: children.length === 0 };
+  }
+  return new Promise((resolve) => {
+    execFile("ps", ["-A", "-o", "pid=,ppid=,stat=,comm="], (error, stdout) => {
+      if (error || typeof stdout !== "string") {
+        resolve({ success: false, error: error?.message || "Unable to inspect local shell" });
+        return;
+      }
+      resolve({
+        success: true,
+        shellForeground: isLocalShellForegroundFromPs(stdout, shellPid),
+      });
+    });
+  });
+}
+
 /**
  * Start a Telnet session using native Node.js net module
  */
@@ -2041,6 +2066,7 @@ function registerHandlers(ipcMain, options = {}) {
       "netcatty:serial:ymodem-receive",
       "netcatty:local:defaultShell",
       "netcatty:local:validatePath",
+      "netcatty:local:foreground",
       "netcatty:shells:discover",
       "netcatty:terminal:setEncoding",
       "netcatty:telnet:getEchoMode",
@@ -2085,6 +2111,7 @@ function registerHandlers(ipcMain, options = {}) {
   ipcMain.handle("netcatty:serial:ymodem-receive", receiveSerialYmodem);
   ipcMain.handle("netcatty:local:defaultShell", getDefaultShell);
   ipcMain.handle("netcatty:local:validatePath", validatePath);
+  ipcMain.handle("netcatty:local:foreground", getLocalSessionForeground);
   ipcMain.handle("netcatty:shells:discover", () => discoverShells());
   ipcMain.handle("netcatty:terminal:setEncoding", setSessionEncoding);
   ipcMain.handle("netcatty:telnet:getEchoMode", getTelnetEchoMode);
@@ -2248,6 +2275,7 @@ module.exports = {
   registerHandlers,
   findExecutable,
   startLocalSession,
+  getLocalSessionForeground,
   startTelnetSession,
   startMoshSession,
   bundledMoshClient,

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -252,6 +252,9 @@ function handleTerminalSessionSnapshotResponse(event, payload) {
     passwordPromptActive: typeof payload?.passwordPromptActive === "boolean"
       ? payload.passwordPromptActive
       : undefined,
+    suppressOscColorQueries: typeof payload?.suppressOscColorQueries === "boolean"
+      ? payload.suppressOscColorQueries
+      : undefined,
     cwd: payload?.cwd === null ? null : typeof payload?.cwd === "string" ? payload.cwd : undefined,
     title: payload?.title === null ? null : typeof payload?.title === "string" ? payload.title : undefined,
   });
@@ -311,6 +314,9 @@ function applyTerminalSessionSnapshot(event, payload, terminalWorkerManager = nu
   const passwordPromptActive = typeof payload?.passwordPromptActive === "boolean"
     ? payload.passwordPromptActive
     : undefined;
+  const suppressOscColorQueries = typeof payload?.suppressOscColorQueries === "boolean"
+    ? payload.suppressOscColorQueries
+    : undefined;
   const cwd = payload?.cwd === null ? null : typeof payload?.cwd === "string" ? payload.cwd : undefined;
   const title = payload?.title === null ? null : typeof payload?.title === "string" ? payload.title : undefined;
   if (
@@ -359,6 +365,7 @@ function applyTerminalSessionSnapshot(event, payload, terminalWorkerManager = nu
           kittyKeyboardModeState,
           kittyKeyboardProtocolEnabled,
           passwordPromptActive,
+          suppressOscColorQueries,
           cwd,
           title,
           requestId,

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -255,6 +255,9 @@ function handleTerminalSessionSnapshotResponse(event, payload) {
     suppressOscColorQueries: typeof payload?.suppressOscColorQueries === "boolean"
       ? payload.suppressOscColorQueries
       : undefined,
+    suppressOscColorQueriesCanEnd: typeof payload?.suppressOscColorQueriesCanEnd === "boolean"
+      ? payload.suppressOscColorQueriesCanEnd
+      : undefined,
     cwd: payload?.cwd === null ? null : typeof payload?.cwd === "string" ? payload.cwd : undefined,
     title: payload?.title === null ? null : typeof payload?.title === "string" ? payload.title : undefined,
   });
@@ -317,6 +320,9 @@ function applyTerminalSessionSnapshot(event, payload, terminalWorkerManager = nu
   const suppressOscColorQueries = typeof payload?.suppressOscColorQueries === "boolean"
     ? payload.suppressOscColorQueries
     : undefined;
+  const suppressOscColorQueriesCanEnd = typeof payload?.suppressOscColorQueriesCanEnd === "boolean"
+    ? payload.suppressOscColorQueriesCanEnd
+    : undefined;
   const cwd = payload?.cwd === null ? null : typeof payload?.cwd === "string" ? payload.cwd : undefined;
   const title = payload?.title === null ? null : typeof payload?.title === "string" ? payload.title : undefined;
   if (
@@ -366,6 +372,7 @@ function applyTerminalSessionSnapshot(event, payload, terminalWorkerManager = nu
           kittyKeyboardProtocolEnabled,
           passwordPromptActive,
           suppressOscColorQueries,
+          suppressOscColorQueriesCanEnd,
           cwd,
           title,
           requestId,

--- a/electron/bridges/terminalBridge.localForeground.test.cjs
+++ b/electron/bridges/terminalBridge.localForeground.test.cjs
@@ -1,0 +1,23 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { isLocalShellForegroundFromPs } = require("./terminalLocalForeground.cjs");
+
+test("local shell foreground detection rejects active jobs even without job control", () => {
+  assert.equal(isLocalShellForegroundFromPs([
+    "100 1 Ss+ zsh",
+    "101 100 S+ docker",
+  ].join("\n"), 100), false);
+  assert.equal(isLocalShellForegroundFromPs([
+    "100 1 Ss zsh",
+    "101 100 S+ docker",
+  ].join("\n"), 100), false);
+});
+
+test("local shell foreground detection accepts idle and nested interactive shells", () => {
+  assert.equal(isLocalShellForegroundFromPs("100 1 Ss+ zsh\n", 100), true);
+  assert.equal(isLocalShellForegroundFromPs([
+    "100 1 Ss zsh",
+    "101 100 S+ bash",
+  ].join("\n"), 100), true);
+});

--- a/electron/bridges/terminalBridge.rebindOutput.test.cjs
+++ b/electron/bridges/terminalBridge.rebindOutput.test.cjs
@@ -307,6 +307,13 @@ test("snapshot apply acknowledgements are emitted only by the matching terminal"
   assert.match(preloadSource, /typeof passwordPromptActive === "boolean"/u);
   assert.match(bridgeSource, /passwordPromptActive: typeof payload\?\.passwordPromptActive/u);
   assert.match(effectsSource, /passwordPromptActiveRef\.current = snap\.passwordPromptActive/u);
+  assert.match(terminalSource, /suppressOscColorQueries: suppressOscColorQueriesForActiveCommandRef\.current/u);
+  assert.match(preloadSource, /typeof suppressOscColorQueries === "boolean"/u);
+  assert.match(bridgeSource, /suppressOscColorQueries: typeof payload\?\.suppressOscColorQueries/u);
+  assert.match(
+    effectsSource,
+    /suppressOscColorQueriesForActiveCommandRef\.current = snap\.suppressOscColorQueries/u,
+  );
 });
 
 test("exit fanout preserves the original renderer before registry wiring", () => {

--- a/electron/bridges/terminalBridge.rebindOutput.test.cjs
+++ b/electron/bridges/terminalBridge.rebindOutput.test.cjs
@@ -308,12 +308,16 @@ test("snapshot apply acknowledgements are emitted only by the matching terminal"
   assert.match(bridgeSource, /passwordPromptActive: typeof payload\?\.passwordPromptActive/u);
   assert.match(effectsSource, /passwordPromptActiveRef\.current = snap\.passwordPromptActive/u);
   assert.match(terminalSource, /suppressOscColorQueries: suppressOscColorQueriesForActiveCommandRef\.current/u);
+  assert.match(terminalSource, /suppressOscColorQueriesCanEnd: hasOscColorQuerySuppressionEndBoundary/u);
   assert.match(preloadSource, /typeof suppressOscColorQueries === "boolean"/u);
+  assert.match(preloadSource, /typeof suppressOscColorQueriesCanEnd === "boolean"/u);
   assert.match(bridgeSource, /suppressOscColorQueries: typeof payload\?\.suppressOscColorQueries/u);
+  assert.match(bridgeSource, /suppressOscColorQueriesCanEnd: typeof payload\?\.suppressOscColorQueriesCanEnd/u);
   assert.match(
     effectsSource,
     /suppressOscColorQueriesForActiveCommandRef\.current = snap\.suppressOscColorQueries/u,
   );
+  assert.match(terminalSource, /restoreOscColorQuerySuppressionEndBoundary/u);
 });
 
 test("exit fanout preserves the original renderer before registry wiring", () => {

--- a/electron/bridges/terminalLocalForeground.cjs
+++ b/electron/bridges/terminalLocalForeground.cjs
@@ -1,0 +1,32 @@
+const path = require("node:path");
+
+function isLocalShellForegroundFromPs(stdout, shellPid) {
+  const processes = new Map();
+  for (const line of String(stdout || "").split("\n")) {
+    const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/);
+    if (!match) continue;
+    processes.set(Number(match[1]), {
+      ppid: Number(match[2]),
+      stat: match[3],
+      command: path.basename(match[4]).replace(/^-/, ""),
+    });
+  }
+  const isDescendant = (pid) => {
+    for (let depth = 0; pid && depth < 64; depth += 1) {
+      if (pid === shellPid) return true;
+      pid = processes.get(pid)?.ppid;
+    }
+    return false;
+  };
+  const isShell = (command) => /^(?:ba|z|fi|k|da|a|c|tc)?sh$/u.test(command);
+  let foregroundShell = false;
+  let foregroundJob = false;
+  for (const [pid, processInfo] of processes) {
+    if (!isDescendant(pid) || !processInfo.stat.includes("+")) continue;
+    if (isShell(processInfo.command)) foregroundShell = true;
+    else foregroundJob = true;
+  }
+  return foregroundShell && !foregroundJob;
+}
+
+module.exports = { isLocalShellForegroundFromPs };

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -389,6 +389,7 @@ function createPreloadApi(ctx) {
     kittyKeyboardProtocolEnabled,
     passwordPromptActive,
     suppressOscColorQueries,
+    suppressOscColorQueriesCanEnd,
     cwd,
     title,
   ) => {
@@ -404,6 +405,9 @@ function createPreloadApi(ctx) {
         : undefined,
       suppressOscColorQueries: typeof suppressOscColorQueries === "boolean"
         ? suppressOscColorQueries
+        : undefined,
+      suppressOscColorQueriesCanEnd: typeof suppressOscColorQueriesCanEnd === "boolean"
+        ? suppressOscColorQueriesCanEnd
         : undefined,
       cwd: cwd === null ? null : typeof cwd === "string" ? cwd : undefined,
       title: title === null ? null : typeof title === "string" ? title : undefined,
@@ -430,6 +434,9 @@ function createPreloadApi(ctx) {
         : undefined,
       suppressOscColorQueries: typeof context?.suppressOscColorQueries === "boolean"
         ? context.suppressOscColorQueries
+        : undefined,
+      suppressOscColorQueriesCanEnd: typeof context?.suppressOscColorQueriesCanEnd === "boolean"
+        ? context.suppressOscColorQueriesCanEnd
         : undefined,
       cwd: context?.cwd === null ? null : typeof context?.cwd === "string" ? context.cwd : undefined,
       title: context?.title === null ? null : typeof context?.title === "string" ? context.title : undefined,

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -388,6 +388,7 @@ function createPreloadApi(ctx) {
     kittyKeyboardModeState,
     kittyKeyboardProtocolEnabled,
     passwordPromptActive,
+    suppressOscColorQueries,
     cwd,
     title,
   ) => {
@@ -400,6 +401,9 @@ function createPreloadApi(ctx) {
         : undefined,
       passwordPromptActive: typeof passwordPromptActive === "boolean"
         ? passwordPromptActive
+        : undefined,
+      suppressOscColorQueries: typeof suppressOscColorQueries === "boolean"
+        ? suppressOscColorQueries
         : undefined,
       cwd: cwd === null ? null : typeof cwd === "string" ? cwd : undefined,
       title: title === null ? null : typeof title === "string" ? title : undefined,
@@ -423,6 +427,9 @@ function createPreloadApi(ctx) {
         : undefined,
       passwordPromptActive: typeof context?.passwordPromptActive === "boolean"
         ? context.passwordPromptActive
+        : undefined,
+      suppressOscColorQueries: typeof context?.suppressOscColorQueries === "boolean"
+        ? context.suppressOscColorQueries
         : undefined,
       cwd: context?.cwd === null ? null : typeof context?.cwd === "string" ? context.cwd : undefined,
       title: context?.title === null ? null : typeof context?.title === "string" ? context.title : undefined,

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -225,6 +225,9 @@ function createPreloadApi(ctx) {
       allowHomeFallback: options?.allowHomeFallback,
     });
   },
+  getLocalSessionForeground: async (sessionId) => {
+    return ipcRenderer.invoke("netcatty:local:foreground", { sessionId });
+  },
   getSessionRemoteInfo: async (sessionId) => {
     return ipcRenderer.invoke("netcatty:ssh:remoteInfo", { sessionId });
   },

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -353,6 +353,7 @@ declare global {
       kittyKeyboardModeState?: NetcattyKittyKeyboardModeState;
       kittyKeyboardProtocolEnabled?: boolean;
       passwordPromptActive?: boolean;
+      suppressOscColorQueries?: boolean;
       cwd?: string | null;
       title?: string | null;
       error?: string;
@@ -368,6 +369,7 @@ declare global {
       kittyKeyboardModeState?: NetcattyKittyKeyboardModeState,
       kittyKeyboardProtocolEnabled?: boolean,
       passwordPromptActive?: boolean,
+      suppressOscColorQueries?: boolean,
       cwd?: string | null,
       title?: string | null,
     ): void;
@@ -383,6 +385,7 @@ declare global {
         kittyKeyboardModeState?: NetcattyKittyKeyboardModeState;
         kittyKeyboardProtocolEnabled?: boolean;
         passwordPromptActive?: boolean;
+        suppressOscColorQueries?: boolean;
         cwd?: string | null;
         title?: string | null;
       },
@@ -405,6 +408,7 @@ declare global {
         kittyKeyboardModeState?: NetcattyKittyKeyboardModeState;
         kittyKeyboardProtocolEnabled?: boolean;
         passwordPromptActive?: boolean;
+        suppressOscColorQueries?: boolean;
         cwd?: string | null;
         title?: string | null;
         requestId: string;

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -354,6 +354,7 @@ declare global {
       kittyKeyboardProtocolEnabled?: boolean;
       passwordPromptActive?: boolean;
       suppressOscColorQueries?: boolean;
+      suppressOscColorQueriesCanEnd?: boolean;
       cwd?: string | null;
       title?: string | null;
       error?: string;
@@ -370,6 +371,7 @@ declare global {
       kittyKeyboardProtocolEnabled?: boolean,
       passwordPromptActive?: boolean,
       suppressOscColorQueries?: boolean,
+      suppressOscColorQueriesCanEnd?: boolean,
       cwd?: string | null,
       title?: string | null,
     ): void;
@@ -386,6 +388,7 @@ declare global {
         kittyKeyboardProtocolEnabled?: boolean;
         passwordPromptActive?: boolean;
         suppressOscColorQueries?: boolean;
+        suppressOscColorQueriesCanEnd?: boolean;
         cwd?: string | null;
         title?: string | null;
       },
@@ -409,6 +412,7 @@ declare global {
         kittyKeyboardProtocolEnabled?: boolean;
         passwordPromptActive?: boolean;
         suppressOscColorQueries?: boolean;
+        suppressOscColorQueriesCanEnd?: boolean;
         cwd?: string | null;
         title?: string | null;
         requestId: string;

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -219,7 +219,7 @@ declare global {
     getSessionPwd?(
       sessionId: string,
       options?: { allowHomeFallback?: boolean },
-    ): Promise<{ success: boolean; cwd?: string; error?: string }>;
+    ): Promise<{ success: boolean; cwd?: string; shellForeground?: boolean; error?: string }>;
     /**
      * Get metadata about an already-connected SSH session — currently the
      * SSH server identification string (the `software` part of the

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -220,6 +220,9 @@ declare global {
       sessionId: string,
       options?: { allowHomeFallback?: boolean },
     ): Promise<{ success: boolean; cwd?: string; shellForeground?: boolean; error?: string }>;
+    getLocalSessionForeground?(
+      sessionId: string,
+    ): Promise<{ success: boolean; shellForeground?: boolean; error?: string }>;
     /**
      * Get metadata about an already-connected SSH session — currently the
      * SSH server identification string (the `software` part of the


### PR DESCRIPTION
## Summary

- automatically contain OSC 10/11/12 color queries while Docker logs are active
- cover both the built-in Docker Logs action and manually entered `docker logs` commands
- preserve xterm color updates and ordinary color queries outside that command
- keep protection across log-like prompts, hibernation, and in-flight output, then restore it at a trusted next-command or session boundary
- replace the private xterm-internals regression test from #2460 with public parser and lifecycle coverage

No new user-facing setting is added.

Follow-up to #2460. Addresses #2262.

## Validation

- 89 focused terminal and startup-command tests
- `npm run lint`
- `npm run build`
- two independent local review tracks, final round CLEAN