### PR TITLE
fix(terminal): complete Windows ConPTY clear handling

### DIFF
--- a/components/lazyLoadedSurfaces.test.ts
+++ b/components/lazyLoadedSurfaces.test.ts
@@ -37,7 +37,7 @@ test("Windows settings close uses a plain button without a primary tooltip", () 
   const source = readFileSync(new URL("./SettingsPage.tsx", import.meta.url), "utf8");
   const closeIndex = source.indexOf('aria-label={t("common.close")}');
   assert.notEqual(closeIndex, -1);
-  // The old Tooltip + TooltipContent("关闭") rendered as a stuck blue chip over the chrome.
+  // The old Tooltip + TooltipContent("Close") rendered as a stuck blue chip over the chrome.
   assert.doesNotMatch(
     source.slice(Math.max(0, closeIndex - 200), closeIndex + 400),
     /TooltipContent|TooltipTrigger/,

--- a/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
+++ b/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
@@ -138,21 +138,15 @@ test("startMoshSession handshake path returns the same shape as the legacy path"
 
 test("Mosh PTYs explicitly enable bundled ConPTY clear support only on Windows", async (t) => {
   const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
-  const originalSystemRoot = process.env.SystemRoot;
 
   const startAndSwap = async (platform) => {
     const h = makeHarness(t);
-    if (platform === "win32") {
-      const system32 = path.join(h.tmp, "System32");
-      const whereExe = path.join(system32, "where.exe");
-      fs.mkdirSync(system32, { recursive: true });
-      fs.writeFileSync(whereExe, `#!/bin/sh\nprintf '%s\\n' '${h.sshPath.replace(/'/g, "'\\''")}'\n`);
-      fs.chmodSync(whereExe, 0o755);
-      process.env.SystemRoot = h.tmp;
-    }
     Object.defineProperty(process, "platform", { ...platformDescriptor, value: platform });
 
-    await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });
+    await h.bridge.startMoshSession(h.event, h.options, {
+      moshClientLookup: h.lookupOpts,
+      findExecutable: () => h.sshPath,
+    });
     h.spawns[0].emitData(
       "MOSH IP 203.0.113.8\r\nMOSH CONNECT 60002 ABCDEFGHIJKLMNOPQRSTUV==\r\n",
     );
@@ -172,8 +166,6 @@ test("Mosh PTYs explicitly enable bundled ConPTY clear support only on Windows",
     assert.equal(linuxSpawns[1].opts.useConptyDll, false);
   } finally {
     Object.defineProperty(process, "platform", platformDescriptor);
-    if (originalSystemRoot === undefined) delete process.env.SystemRoot;
-    else process.env.SystemRoot = originalSystemRoot;
   }
 });
 

--- a/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
+++ b/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
@@ -108,6 +108,8 @@ function makeHarness(t) {
 
   return {
     bridge,
+    tmp,
+    sshPath,
     sessions,
     sent,
     spawns,
@@ -134,19 +136,45 @@ test("startMoshSession handshake path returns the same shape as the legacy path"
   assert.deepEqual(result, { sessionId: "mosh-test-session" });
 });
 
-test("Mosh PTYs enable bundled ConPTY clear support on Windows", async (t) => {
-  const h = makeHarness(t);
-  await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });
+test("Mosh PTYs explicitly enable bundled ConPTY clear support only on Windows", async (t) => {
+  const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalSystemRoot = process.env.SystemRoot;
 
-  assert.equal(h.spawns[0].opts.useConptyDll, process.platform === "win32");
+  const startAndSwap = async (platform) => {
+    const h = makeHarness(t);
+    if (platform === "win32") {
+      const system32 = path.join(h.tmp, "System32");
+      const whereExe = path.join(system32, "where.exe");
+      fs.mkdirSync(system32, { recursive: true });
+      fs.writeFileSync(whereExe, `#!/bin/sh\nprintf '%s\\n' '${h.sshPath.replace(/'/g, "'\\''")}'\n`);
+      fs.chmodSync(whereExe, 0o755);
+      process.env.SystemRoot = h.tmp;
+    }
+    Object.defineProperty(process, "platform", { ...platformDescriptor, value: platform });
 
-  h.spawns[0].emitData(
-    "MOSH IP 203.0.113.8\r\nMOSH CONNECT 60002 ABCDEFGHIJKLMNOPQRSTUV==\r\n",
-  );
-  h.spawns[0].emitExit({ exitCode: 0, signal: 0 });
+    await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });
+    h.spawns[0].emitData(
+      "MOSH IP 203.0.113.8\r\nMOSH CONNECT 60002 ABCDEFGHIJKLMNOPQRSTUV==\r\n",
+    );
+    h.spawns[0].emitExit({ exitCode: 0, signal: 0 });
+    return h.spawns;
+  };
 
-  assert.equal(h.spawns.length, 2);
-  assert.equal(h.spawns[1].opts.useConptyDll, process.platform === "win32");
+  try {
+    const windowsSpawns = await startAndSwap("win32");
+    assert.equal(windowsSpawns.length, 2);
+    assert.equal(windowsSpawns[0].opts.useConptyDll, true);
+    assert.equal(windowsSpawns[1].opts.useConptyDll, true);
+
+    const linuxSpawns = await startAndSwap("linux");
+    assert.equal(linuxSpawns.length, 2);
+    assert.equal(linuxSpawns[0].opts.useConptyDll, false);
+    assert.equal(linuxSpawns[1].opts.useConptyDll, false);
+  } finally {
+    Object.defineProperty(process, "platform", platformDescriptor);
+    if (originalSystemRoot === undefined) delete process.env.SystemRoot;
+    else process.env.SystemRoot = originalSystemRoot;
+  }
 });
 
 test("startMoshSession offers all locale settings to mosh-server without exporting them through SSH", async (t) => {

--- a/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
+++ b/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
@@ -134,6 +134,21 @@ test("startMoshSession handshake path returns the same shape as the legacy path"
   assert.deepEqual(result, { sessionId: "mosh-test-session" });
 });
 
+test("Mosh PTYs enable bundled ConPTY clear support on Windows", async (t) => {
+  const h = makeHarness(t);
+  await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });
+
+  assert.equal(h.spawns[0].opts.useConptyDll, process.platform === "win32");
+
+  h.spawns[0].emitData(
+    "MOSH IP 203.0.113.8\r\nMOSH CONNECT 60002 ABCDEFGHIJKLMNOPQRSTUV==\r\n",
+  );
+  h.spawns[0].emitExit({ exitCode: 0, signal: 0 });
+
+  assert.equal(h.spawns.length, 2);
+  assert.equal(h.spawns[1].opts.useConptyDll, process.platform === "win32");
+});
+
 test("startMoshSession offers all locale settings to mosh-server without exporting them through SSH", async (t) => {
   const h = makeHarness(t);
   h.options.env = {

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -963,6 +963,7 @@ main();
           env,
           cwd: os.homedir(),
           encoding: null, // Return Buffer for ZMODEM binary support
+          useConptyDll: process.platform === "win32",
         });
 
         const session = {

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -110,6 +110,36 @@ test("startEtSession preserves discovered automatic identities for host informat
   assert.equal(sessions.get("sess-auto-stats").etStatsAuth.authMethod, "auto");
 });
 
+test("ET PTY enables bundled ConPTY clear support on Windows", async (t) => {
+  let spawnOptions = null;
+  const proc = {
+    onData() {},
+    onExit() {},
+    write() {},
+  };
+  const { api } = makeApi(t, {
+    bundledEtClient: () => "/fake/et",
+    pty: {
+      spawn: (_command, _args, options) => {
+        spawnOptions = options;
+        return proc;
+      },
+    },
+    electronModule: { webContents: { fromId: () => null } },
+    openTerminalOutputSession: () => {},
+    selectZmodemUploadFiles: null,
+    selectZmodemDownloadDirectory: null,
+  });
+
+  await api.startEtSession({ sender: { id: 7 } }, {
+    sessionId: "sess-conpty-clear",
+    hostname: "host.example",
+    username: "alice",
+  });
+
+  assert.equal(spawnOptions.useConptyDll, process.platform === "win32");
+});
+
 test("explicitly closed ET sessions do not emit a second exit event", async (t) => {
   let onExit = null;
   const sent = [];

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -110,34 +110,41 @@ test("startEtSession preserves discovered automatic identities for host informat
   assert.equal(sessions.get("sess-auto-stats").etStatsAuth.authMethod, "auto");
 });
 
-test("ET PTY enables bundled ConPTY clear support on Windows", async (t) => {
-  let spawnOptions = null;
-  const proc = {
-    onData() {},
-    onExit() {},
-    write() {},
-  };
-  const { api } = makeApi(t, {
-    bundledEtClient: () => "/fake/et",
-    pty: {
-      spawn: (_command, _args, options) => {
-        spawnOptions = options;
-        return proc;
+test("ET PTY explicitly enables bundled ConPTY clear support only on Windows", async (t) => {
+  const spawnForPlatform = async (platform) => {
+    let spawnOptions = null;
+    const processMock = Object.create(process);
+    Object.defineProperty(processMock, "platform", { value: platform });
+    const proc = {
+      onData() {},
+      onExit() {},
+      write() {},
+    };
+    const { api } = makeApi(t, {
+      process: processMock,
+      bundledEtClient: () => "/fake/et",
+      pty: {
+        spawn: (_command, _args, options) => {
+          spawnOptions = options;
+          return proc;
+        },
       },
-    },
-    electronModule: { webContents: { fromId: () => null } },
-    openTerminalOutputSession: () => {},
-    selectZmodemUploadFiles: null,
-    selectZmodemDownloadDirectory: null,
-  });
+      electronModule: { webContents: { fromId: () => null } },
+      openTerminalOutputSession: () => {},
+      selectZmodemUploadFiles: null,
+      selectZmodemDownloadDirectory: null,
+    });
 
-  await api.startEtSession({ sender: { id: 7 } }, {
-    sessionId: "sess-conpty-clear",
-    hostname: "host.example",
-    username: "alice",
-  });
+    await api.startEtSession({ sender: { id: 7 } }, {
+      sessionId: `sess-conpty-clear-${platform}`,
+      hostname: "host.example",
+      username: "alice",
+    });
+    return spawnOptions;
+  };
 
-  assert.equal(spawnOptions.useConptyDll, process.platform === "win32");
+  assert.equal((await spawnForPlatform("win32")).useConptyDll, true);
+  assert.equal((await spawnForPlatform("linux")).useConptyDll, false);
 });
 
 test("explicitly closed ET sessions do not emit a second exit event", async (t) => {

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -427,6 +427,7 @@ function createMoshSessionApi(ctx) {
           env: sshEnv,
           cwd: os.homedir(),
           encoding: null,
+          useConptyDll: process.platform === "win32",
         });
       } catch (err) {
         cleanupMoshAuthTempFiles(moshAuth.tempFiles);
@@ -674,6 +675,7 @@ function createMoshSessionApi(ctx) {
         env,
         cwd: os.homedir(),
         encoding: null,
+        useConptyDll: process.platform === "win32",
       });
     
       // Atomic swap — writeToSession / resizeSession both read

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -845,7 +845,7 @@ function createMoshSessionApi(ctx) {
       const sshExe = moshHandshake.resolveSshExecutable({
         findExecutable: (name) => (
           process.platform === "win32"
-            ? findExecutable(name, { pathOverride: mergedPathForResolution })
+            ? (opts.findExecutable || findExecutable)(name, { pathOverride: mergedPathForResolution })
             : resolvePosixExecutable(name, { pathOverride: mergedPathForResolution })
         ),
         fileExists: (p) => isExecutableFile(p) || fs.existsSync(p),

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "pack:linux": "npm run build && cross-env NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --linux --publish=never",
     "pack:linux-x64": "npm run build && cross-env npm_config_arch=x64 NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --linux --x64 --publish=never",
     "pack:linux-arm64": "npm run build && cross-env npm_config_arch=arm64 NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --linux --arm64 --publish=never",
-    "postinstall": "electron-builder install-app-deps && patch-package && node scripts/patch-xterm-webgl-atlas.cjs",
+    "postinstall": "patch-package && electron-builder install-app-deps && node scripts/rebuildPatchedNodePty.cjs && node scripts/patch-xterm-webgl-atlas.cjs",
     "rebuild": "electron-builder install-app-deps",
     "tool:cli": "node electron/cli/netcatty-tool-cli.cjs",
     "generate:capability-tools": "node scripts/generate-capability-tools.cjs",

--- a/patches/node-pty+1.1.0.patch
+++ b/patches/node-pty+1.1.0.patch
@@ -1,26 +1,17 @@
 diff --git a/node_modules/node-pty/src/win/conpty.cc b/node_modules/node-pty/src/win/conpty.cc
-index 7b286d3..451dcce 100644
+index 7b286d3..5423c8e 100644
 --- a/node_modules/node-pty/src/win/conpty.cc
 +++ b/node_modules/node-pty/src/win/conpty.cc
-@@ -523,7 +523,7 @@ static Napi::Value PtyClear(const Napi::CallbackInfo& info) {
-       PFNCLEARPSEUDOCONSOLE const pfnClearPseudoConsole = (PFNCLEARPSEUDOCONSOLE)GetProcAddress((HMODULE)hLibrary, "ConptyClearPseudoConsole");
-       if (pfnClearPseudoConsole)
-       {
+@@ -35 +35 @@ typedef HRESULT (__stdcall *PFNRESIZEPSEUDOCONSOLE)(HPCON hpc, COORD newSize);
+-typedef HRESULT (__stdcall *PFNCLEARPSEUDOCONSOLE)(HPCON hpc);
++typedef HRESULT (__stdcall *PFNCLEARPSEUDOCONSOLE)(HPCON hpc, BOOL keepCursorRow);
+@@ -526 +526 @@ static Napi::Value PtyClear(const Napi::CallbackInfo& info) {
 -        pfnClearPseudoConsole(handle->hpc);
 +        pfnClearPseudoConsole(handle->hpc, TRUE);
-       }
-     }
-   }
 diff --git a/node_modules/node-pty/src/win/conpty.h b/node_modules/node-pty/src/win/conpty.h
 index 4cef31c..4f03a0c 100644
 --- a/node_modules/node-pty/src/win/conpty.h
 +++ b/node_modules/node-pty/src/win/conpty.h
-@@ -30,7 +30,7 @@ CONPTY_EXPORT HRESULT WINAPI ConptyCreatePseudoConsole(COORD size, HANDLE hInput
- CONPTY_EXPORT HRESULT WINAPI ConptyCreatePseudoConsoleAsUser(HANDLE hToken, COORD size, HANDLE hInput, HANDLE hOutput, DWORD dwFlags, HPCON* phPC);
- 
- CONPTY_EXPORT HRESULT WINAPI ConptyResizePseudoConsole(HPCON hPC, COORD size);
+@@ -33 +33 @@ CONPTY_EXPORT HRESULT WINAPI ConptyResizePseudoConsole(HPCON hPC, COORD size);
 -CONPTY_EXPORT HRESULT WINAPI ConptyClearPseudoConsole(HPCON hPC);
 +CONPTY_EXPORT HRESULT WINAPI ConptyClearPseudoConsole(HPCON hPC, BOOL keepCursorRow);
- CONPTY_EXPORT HRESULT WINAPI ConptyShowHidePseudoConsole(HPCON hPC, bool show);
- CONPTY_EXPORT HRESULT WINAPI ConptyReparentPseudoConsole(HPCON hPC, HWND newParent);
- CONPTY_EXPORT HRESULT WINAPI ConptyReleasePseudoConsole(HPCON hPC);

--- a/patches/node-pty+1.1.0.patch
+++ b/patches/node-pty+1.1.0.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/node-pty/src/win/conpty.cc b/node_modules/node-pty/src/win/conpty.cc
+index 7b286d3..451dcce 100644
+--- a/node_modules/node-pty/src/win/conpty.cc
++++ b/node_modules/node-pty/src/win/conpty.cc
+@@ -523,7 +523,7 @@ static Napi::Value PtyClear(const Napi::CallbackInfo& info) {
+       PFNCLEARPSEUDOCONSOLE const pfnClearPseudoConsole = (PFNCLEARPSEUDOCONSOLE)GetProcAddress((HMODULE)hLibrary, "ConptyClearPseudoConsole");
+       if (pfnClearPseudoConsole)
+       {
+-        pfnClearPseudoConsole(handle->hpc);
++        pfnClearPseudoConsole(handle->hpc, TRUE);
+       }
+     }
+   }
+diff --git a/node_modules/node-pty/src/win/conpty.h b/node_modules/node-pty/src/win/conpty.h
+index 4cef31c..4f03a0c 100644
+--- a/node_modules/node-pty/src/win/conpty.h
++++ b/node_modules/node-pty/src/win/conpty.h
+@@ -30,7 +30,7 @@ CONPTY_EXPORT HRESULT WINAPI ConptyCreatePseudoConsole(COORD size, HANDLE hInput
+ CONPTY_EXPORT HRESULT WINAPI ConptyCreatePseudoConsoleAsUser(HANDLE hToken, COORD size, HANDLE hInput, HANDLE hOutput, DWORD dwFlags, HPCON* phPC);
+ 
+ CONPTY_EXPORT HRESULT WINAPI ConptyResizePseudoConsole(HPCON hPC, COORD size);
+-CONPTY_EXPORT HRESULT WINAPI ConptyClearPseudoConsole(HPCON hPC);
++CONPTY_EXPORT HRESULT WINAPI ConptyClearPseudoConsole(HPCON hPC, BOOL keepCursorRow);
+ CONPTY_EXPORT HRESULT WINAPI ConptyShowHidePseudoConsole(HPCON hPC, bool show);
+ CONPTY_EXPORT HRESULT WINAPI ConptyReparentPseudoConsole(HPCON hPC, HWND newParent);
+ CONPTY_EXPORT HRESULT WINAPI ConptyReleasePseudoConsole(HPCON hPC);

--- a/scripts/afterPackMacUuid.cjs
+++ b/scripts/afterPackMacUuid.cjs
@@ -20,6 +20,10 @@ const fs = require("node:fs");
 const path = require("node:path");
 const crypto = require("node:crypto");
 const { execFileSync } = require("node:child_process");
+const {
+  copyPatchedNodePtyToPackagedApp,
+  rebuildPatchedNodePty,
+} = require("./nodePtyConptyPatch.cjs");
 
 const LC_UUID = 0x1b;
 const MH_MAGIC_64 = 0xfeedfacf; // thin 64-bit, little-endian on disk
@@ -297,6 +301,17 @@ async function afterPack(context) {
     console.log(
       `[afterPack] Removed unused Cursor SDK platform package(s): ${removedCursorPackages.join(", ")}`,
     );
+  }
+
+  if (context.electronPlatformName === "win32") {
+    const projectDir = context.packager.appDir || context.packager.projectDir;
+    rebuildPatchedNodePty({ projectDir, platform: "win32", arch: context.arch });
+    copyPatchedNodePtyToPackagedApp({
+      projectDir,
+      resourcesDir: appResourcesDir(context),
+    });
+    console.log("[afterPack] Installed patched node-pty ConPTY runtime into packaged app");
+    return;
   }
 
   if (context.electronPlatformName !== "darwin") return;

--- a/scripts/beforePackCursorSdk.cjs
+++ b/scripts/beforePackCursorSdk.cjs
@@ -34,67 +34,6 @@ function npmExecutable() {
   return process.platform === "win32" ? "npm.cmd" : "npm";
 }
 
-const ELECTRON_BUILDER_ARCH = {
-  0: "ia32",
-  1: "x64",
-  2: "armv7l",
-  3: "arm64",
-  4: "universal",
-};
-
-function rebuildPatchedNodePty({
-  projectDir,
-  platform,
-  arch,
-  run = execFileSync,
-  exists = fs.existsSync,
-  logger = console,
-}) {
-  if (platform !== "win32") return false;
-  const targetArch = typeof arch === "number" ? ELECTRON_BUILDER_ARCH[arch] : arch;
-  if (!targetArch || targetArch === "universal") {
-    throw new Error(`[beforePackCursorSdk] Unsupported Windows architecture: ${String(arch)}`);
-  }
-  const rebuildExecutable = path.join(
-    projectDir,
-    "node_modules",
-    ".bin",
-    process.platform === "win32" ? "electron-rebuild.cmd" : "electron-rebuild",
-  );
-  logger.log(`[beforePackCursorSdk] Rebuilding patched node-pty for Windows ${targetArch}`);
-  run(rebuildExecutable, [
-    "--force",
-    "--build-from-source",
-    "--which-module",
-    "node-pty",
-    "--arch",
-    targetArch,
-  ], {
-    cwd: projectDir,
-    stdio: "inherit",
-  });
-
-  const nodePtyDir = path.join(projectDir, "node_modules", "node-pty");
-  run(process.execPath, [path.join(nodePtyDir, "scripts", "post-install.js")], {
-    cwd: projectDir,
-    stdio: "inherit",
-    env: { ...process.env, npm_config_arch: targetArch },
-  });
-
-  const requiredArtifacts = [
-    path.join(nodePtyDir, "build", "Release", "conpty.node"),
-    path.join(nodePtyDir, "build", "Release", "conpty", "conpty.dll"),
-    path.join(nodePtyDir, "build", "Release", "conpty", "OpenConsole.exe"),
-  ];
-  const missingArtifacts = requiredArtifacts.filter((filePath) => !exists(filePath));
-  if (missingArtifacts.length > 0) {
-    throw new Error(
-      `[beforePackCursorSdk] Patched node-pty artifacts missing: ${missingArtifacts.join(", ")}`,
-    );
-  }
-  return true;
-}
-
 function ensureCursorSdkPlatformPackages({
   projectDir,
   platform,
@@ -129,11 +68,9 @@ function beforePackCursorSdk(context = {}) {
   const projectDir = context.appDir || process.cwd();
   const platform = context.electronPlatformName || process.platform;
   ensureCursorSdkPlatformPackages({ projectDir, platform });
-  rebuildPatchedNodePty({ projectDir, platform, arch: context.arch ?? process.arch });
 }
 
 module.exports = beforePackCursorSdk;
 module.exports.default = beforePackCursorSdk;
 module.exports.ensureCursorSdkPlatformPackages = ensureCursorSdkPlatformPackages;
-module.exports.rebuildPatchedNodePty = rebuildPatchedNodePty;
 module.exports.CURSOR_PLATFORM_PACKAGES = CURSOR_PLATFORM_PACKAGES;

--- a/scripts/beforePackCursorSdk.cjs
+++ b/scripts/beforePackCursorSdk.cjs
@@ -47,6 +47,7 @@ function rebuildPatchedNodePty({
   platform,
   arch,
   run = execFileSync,
+  exists = fs.existsSync,
   logger = console,
 }) {
   if (platform !== "win32") return false;
@@ -72,6 +73,25 @@ function rebuildPatchedNodePty({
     cwd: projectDir,
     stdio: "inherit",
   });
+
+  const nodePtyDir = path.join(projectDir, "node_modules", "node-pty");
+  run(process.execPath, [path.join(nodePtyDir, "scripts", "post-install.js")], {
+    cwd: projectDir,
+    stdio: "inherit",
+    env: { ...process.env, npm_config_arch: targetArch },
+  });
+
+  const requiredArtifacts = [
+    path.join(nodePtyDir, "build", "Release", "conpty.node"),
+    path.join(nodePtyDir, "build", "Release", "conpty", "conpty.dll"),
+    path.join(nodePtyDir, "build", "Release", "conpty", "OpenConsole.exe"),
+  ];
+  const missingArtifacts = requiredArtifacts.filter((filePath) => !exists(filePath));
+  if (missingArtifacts.length > 0) {
+    throw new Error(
+      `[beforePackCursorSdk] Patched node-pty artifacts missing: ${missingArtifacts.join(", ")}`,
+    );
+  }
   return true;
 }
 

--- a/scripts/beforePackCursorSdk.cjs
+++ b/scripts/beforePackCursorSdk.cjs
@@ -34,6 +34,47 @@ function npmExecutable() {
   return process.platform === "win32" ? "npm.cmd" : "npm";
 }
 
+const ELECTRON_BUILDER_ARCH = {
+  0: "ia32",
+  1: "x64",
+  2: "armv7l",
+  3: "arm64",
+  4: "universal",
+};
+
+function rebuildPatchedNodePty({
+  projectDir,
+  platform,
+  arch,
+  run = execFileSync,
+  logger = console,
+}) {
+  if (platform !== "win32") return false;
+  const targetArch = typeof arch === "number" ? ELECTRON_BUILDER_ARCH[arch] : arch;
+  if (!targetArch || targetArch === "universal") {
+    throw new Error(`[beforePackCursorSdk] Unsupported Windows architecture: ${String(arch)}`);
+  }
+  const rebuildExecutable = path.join(
+    projectDir,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "electron-rebuild.cmd" : "electron-rebuild",
+  );
+  logger.log(`[beforePackCursorSdk] Rebuilding patched node-pty for Windows ${targetArch}`);
+  run(rebuildExecutable, [
+    "--force",
+    "--build-from-source",
+    "--which-module",
+    "node-pty",
+    "--arch",
+    targetArch,
+  ], {
+    cwd: projectDir,
+    stdio: "inherit",
+  });
+  return true;
+}
+
 function ensureCursorSdkPlatformPackages({
   projectDir,
   platform,
@@ -68,9 +109,11 @@ function beforePackCursorSdk(context = {}) {
   const projectDir = context.appDir || process.cwd();
   const platform = context.electronPlatformName || process.platform;
   ensureCursorSdkPlatformPackages({ projectDir, platform });
+  rebuildPatchedNodePty({ projectDir, platform, arch: context.arch ?? process.arch });
 }
 
 module.exports = beforePackCursorSdk;
 module.exports.default = beforePackCursorSdk;
 module.exports.ensureCursorSdkPlatformPackages = ensureCursorSdkPlatformPackages;
+module.exports.rebuildPatchedNodePty = rebuildPatchedNodePty;
 module.exports.CURSOR_PLATFORM_PACKAGES = CURSOR_PLATFORM_PACKAGES;

--- a/scripts/beforePackCursorSdk.test.cjs
+++ b/scripts/beforePackCursorSdk.test.cjs
@@ -7,8 +7,11 @@ const path = require("node:path");
 const {
   CURSOR_PLATFORM_PACKAGES,
   ensureCursorSdkPlatformPackages,
-  rebuildPatchedNodePty,
 } = require("./beforePackCursorSdk.cjs");
+const {
+  copyPatchedNodePtyToPackagedApp,
+  rebuildPatchedNodePty,
+} = require("./nodePtyConptyPatch.cjs");
 
 function writeJson(filePath, value) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -75,8 +78,9 @@ test("Windows packaging rebuilds patched node-pty from source for the target arc
 
   assert.equal(rebuilt, true);
   assert.equal(calls.length, 2);
-  assert.match(calls[0][0], /node_modules[/\\]\.bin[/\\]electron-rebuild(?:\.cmd)?$/);
+  assert.equal(calls[0][0], process.execPath);
   assert.deepEqual(calls[0][1], [
+    path.join("/workspace/netcatty", "node_modules", "@electron", "rebuild", "lib", "cli.js"),
     "--force",
     "--build-from-source",
     "--which-module",
@@ -116,6 +120,27 @@ test("non-Windows packaging keeps the prebuilt node-pty path", () => {
 
   assert.equal(rebuilt, false);
   assert.deepEqual(calls, []);
+});
+
+test("Windows afterPack copies rebuilt ConPTY files over packaged prebuilds", () => {
+  const copied = [];
+  const made = [];
+  const destinations = copyPatchedNodePtyToPackagedApp({
+    projectDir: "/workspace/netcatty",
+    resourcesDir: "/workspace/release/resources",
+    copy: (...args) => copied.push(args),
+    mkdir: (...args) => made.push(args),
+  });
+
+  assert.equal(copied.length, 3);
+  assert.equal(made.length, 3);
+  assert.equal(copied[0][0], path.join(
+    "/workspace/netcatty", "node_modules", "node-pty", "build", "Release", "conpty.node",
+  ));
+  assert.equal(copied[0][1], path.join(
+    "/workspace/release/resources", "app.asar.unpacked", "node_modules", "node-pty", "build", "Release", "conpty.node",
+  ));
+  assert.deepEqual(destinations, copied.map(([, destination]) => destination));
 });
 
 test("node-pty patch matches bundled ConPTY clear ABI and preserves the cursor row", () => {

--- a/scripts/beforePackCursorSdk.test.cjs
+++ b/scripts/beforePackCursorSdk.test.cjs
@@ -69,11 +69,12 @@ test("Windows packaging rebuilds patched node-pty from source for the target arc
     platform: "win32",
     arch: 3,
     run: (...args) => calls.push(args),
+    exists: () => true,
     logger: { log() {} },
   });
 
   assert.equal(rebuilt, true);
-  assert.equal(calls.length, 1);
+  assert.equal(calls.length, 2);
   assert.match(calls[0][0], /node_modules[/\\]\.bin[/\\]electron-rebuild(?:\.cmd)?$/);
   assert.deepEqual(calls[0][1], [
     "--force",
@@ -84,6 +85,23 @@ test("Windows packaging rebuilds patched node-pty from source for the target arc
     "arm64",
   ]);
   assert.equal(calls[0][2].cwd, "/workspace/netcatty");
+  assert.equal(calls[1][0], process.execPath);
+  assert.equal(
+    calls[1][1][0],
+    path.join("/workspace/netcatty", "node_modules", "node-pty", "scripts", "post-install.js"),
+  );
+  assert.equal(calls[1][2].env.npm_config_arch, "arm64");
+});
+
+test("Windows packaging fails when rebuilt node-pty runtime files are incomplete", () => {
+  assert.throws(() => rebuildPatchedNodePty({
+    projectDir: "/workspace/netcatty",
+    platform: "win32",
+    arch: 1,
+    run() {},
+    exists: (filePath) => !filePath.endsWith("conpty.dll"),
+    logger: { log() {} },
+  }), /Patched node-pty artifacts missing: .*conpty\.dll/);
 });
 
 test("non-Windows packaging keeps the prebuilt node-pty path", () => {
@@ -107,6 +125,7 @@ test("node-pty patch matches bundled ConPTY clear ABI and preserves the cursor r
   );
 
   assert.match(patch, /ConptyClearPseudoConsole\(HPCON hPC, BOOL keepCursorRow\)/);
+  assert.match(patch, /PFNCLEARPSEUDOCONSOLE\)\(HPCON hpc, BOOL keepCursorRow\)/);
   assert.match(patch, /pfnClearPseudoConsole\(handle->hpc, TRUE\)/);
   assert.doesNotMatch(patch, /node_modules\/node-pty\/build\//);
 });

--- a/scripts/beforePackCursorSdk.test.cjs
+++ b/scripts/beforePackCursorSdk.test.cjs
@@ -83,7 +83,7 @@ test("Windows packaging rebuilds patched node-pty from source for the target arc
     path.join("/workspace/netcatty", "node_modules", "@electron", "rebuild", "lib", "cli.js"),
     "--force",
     "--build-from-source",
-    "--which-module",
+    "--only",
     "node-pty",
     "--arch",
     "arm64",

--- a/scripts/beforePackCursorSdk.test.cjs
+++ b/scripts/beforePackCursorSdk.test.cjs
@@ -7,6 +7,7 @@ const path = require("node:path");
 const {
   CURSOR_PLATFORM_PACKAGES,
   ensureCursorSdkPlatformPackages,
+  rebuildPatchedNodePty,
 } = require("./beforePackCursorSdk.cjs");
 
 function writeJson(filePath, value) {
@@ -59,4 +60,53 @@ test("ensureCursorSdkPlatformPackages is a no-op when target packages exist", (t
 
   assert.deepEqual(installed, []);
   assert.deepEqual(calls, []);
+});
+
+test("Windows packaging rebuilds patched node-pty from source for the target architecture", () => {
+  const calls = [];
+  const rebuilt = rebuildPatchedNodePty({
+    projectDir: "/workspace/netcatty",
+    platform: "win32",
+    arch: 3,
+    run: (...args) => calls.push(args),
+    logger: { log() {} },
+  });
+
+  assert.equal(rebuilt, true);
+  assert.equal(calls.length, 1);
+  assert.match(calls[0][0], /node_modules[/\\]\.bin[/\\]electron-rebuild(?:\.cmd)?$/);
+  assert.deepEqual(calls[0][1], [
+    "--force",
+    "--build-from-source",
+    "--which-module",
+    "node-pty",
+    "--arch",
+    "arm64",
+  ]);
+  assert.equal(calls[0][2].cwd, "/workspace/netcatty");
+});
+
+test("non-Windows packaging keeps the prebuilt node-pty path", () => {
+  const calls = [];
+  const rebuilt = rebuildPatchedNodePty({
+    projectDir: "/workspace/netcatty",
+    platform: "linux",
+    arch: 1,
+    run: (...args) => calls.push(args),
+    logger: { log() {} },
+  });
+
+  assert.equal(rebuilt, false);
+  assert.deepEqual(calls, []);
+});
+
+test("node-pty patch matches bundled ConPTY clear ABI and preserves the cursor row", () => {
+  const patch = fs.readFileSync(
+    path.join(__dirname, "..", "patches", "node-pty+1.1.0.patch"),
+    "utf8",
+  );
+
+  assert.match(patch, /ConptyClearPseudoConsole\(HPCON hPC, BOOL keepCursorRow\)/);
+  assert.match(patch, /pfnClearPseudoConsole\(handle->hpc, TRUE\)/);
+  assert.doesNotMatch(patch, /node_modules\/node-pty\/build\//);
 });

--- a/scripts/nodePtyConptyPatch.cjs
+++ b/scripts/nodePtyConptyPatch.cjs
@@ -39,7 +39,7 @@ function rebuildPatchedNodePty({
     rebuildCli,
     "--force",
     "--build-from-source",
-    "--which-module",
+    "--only",
     "node-pty",
     "--arch",
     targetArch,

--- a/scripts/nodePtyConptyPatch.cjs
+++ b/scripts/nodePtyConptyPatch.cjs
@@ -1,0 +1,92 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+
+const ELECTRON_BUILDER_ARCH = {
+  0: "ia32",
+  1: "x64",
+  2: "armv7l",
+  3: "arm64",
+  4: "universal",
+};
+
+function nodePtyArtifacts(projectDir) {
+  const releaseDir = path.join(projectDir, "node_modules", "node-pty", "build", "Release");
+  return [
+    { source: path.join(releaseDir, "conpty.node"), relative: "conpty.node" },
+    { source: path.join(releaseDir, "conpty", "conpty.dll"), relative: path.join("conpty", "conpty.dll") },
+    { source: path.join(releaseDir, "conpty", "OpenConsole.exe"), relative: path.join("conpty", "OpenConsole.exe") },
+  ];
+}
+
+function rebuildPatchedNodePty({
+  projectDir,
+  platform,
+  arch,
+  run = execFileSync,
+  exists = fs.existsSync,
+  logger = console,
+}) {
+  if (platform !== "win32") return false;
+  const targetArch = typeof arch === "number" ? ELECTRON_BUILDER_ARCH[arch] : arch;
+  if (!targetArch || targetArch === "universal") {
+    throw new Error(`[nodePtyConptyPatch] Unsupported Windows architecture: ${String(arch)}`);
+  }
+
+  const rebuildCli = path.join(projectDir, "node_modules", "@electron", "rebuild", "lib", "cli.js");
+  logger.log(`[nodePtyConptyPatch] Rebuilding patched node-pty for Windows ${targetArch}`);
+  run(process.execPath, [
+    rebuildCli,
+    "--force",
+    "--build-from-source",
+    "--which-module",
+    "node-pty",
+    "--arch",
+    targetArch,
+  ], {
+    cwd: projectDir,
+    stdio: "inherit",
+  });
+
+  const nodePtyDir = path.join(projectDir, "node_modules", "node-pty");
+  run(process.execPath, [path.join(nodePtyDir, "scripts", "post-install.js")], {
+    cwd: projectDir,
+    stdio: "inherit",
+    env: { ...process.env, npm_config_arch: targetArch },
+  });
+
+  const missingArtifacts = nodePtyArtifacts(projectDir)
+    .map(({ source }) => source)
+    .filter((filePath) => !exists(filePath));
+  if (missingArtifacts.length > 0) {
+    throw new Error(
+      `[nodePtyConptyPatch] Patched node-pty artifacts missing: ${missingArtifacts.join(", ")}`,
+    );
+  }
+  return true;
+}
+
+function copyPatchedNodePtyToPackagedApp({ projectDir, resourcesDir, copy = fs.copyFileSync, mkdir = fs.mkdirSync }) {
+  const packagedReleaseDir = path.join(
+    resourcesDir,
+    "app.asar.unpacked",
+    "node_modules",
+    "node-pty",
+    "build",
+    "Release",
+  );
+  const copied = [];
+  for (const artifact of nodePtyArtifacts(projectDir)) {
+    const destination = path.join(packagedReleaseDir, artifact.relative);
+    mkdir(path.dirname(destination), { recursive: true });
+    copy(artifact.source, destination);
+    copied.push(destination);
+  }
+  return copied;
+}
+
+module.exports = {
+  copyPatchedNodePtyToPackagedApp,
+  nodePtyArtifacts,
+  rebuildPatchedNodePty,
+};

--- a/scripts/rebuildPatchedNodePty.cjs
+++ b/scripts/rebuildPatchedNodePty.cjs
@@ -1,0 +1,7 @@
+const { rebuildPatchedNodePty } = require("./nodePtyConptyPatch.cjs");
+
+rebuildPatchedNodePty({
+  projectDir: process.cwd(),
+  platform: process.platform,
+  arch: process.env.npm_config_arch || process.arch,
+});


### PR DESCRIPTION
## 说明

#2454 在后续审查完成前已经合并。本 PR 补上合并后确认的 Windows 终端清屏修正：

- 让 Mosh 和 Eternal Terminal 与本地终端使用一致的 Windows 清屏能力
- 对齐当前 Windows 终端组件的接口，并保证安装、打包后的实际文件不会被后续步骤覆盖
- 只重新生成需要修正的组件，避免无关依赖拖慢或阻断 Windows 构建
- 增加真实 Windows 条件、Mosh 两阶段、ET、安装与打包路径的回归测试
- 处理 #2454 合并后留下的代码规范意见

## 影响

清空终端画面后，前台显示与 Windows 后台缓冲区会保持一致；备用屏幕没有实际清空时，不会误清后台内容。

## 验证

- 相关终端、Mosh、ET 和打包测试全部通过
- 完整构建通过
- 差异格式检查通过
- 三轮独立本地审查，最终一轮两名审查者均为 CLEAN

Follow-up to #2454.
