### PR TITLE
fix(ci): bump star-history workflow to actions/checkout@v7

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Same PAT used for releases — needs stargazers read (admin/collaborator)
           # plus contents write to push SVG updates.


### PR DESCRIPTION
## Summary
- Update `.github/workflows/star-history.yml` from `actions/checkout@v4` to `@v7`

## Why
CI failed on #2490 because `scripts/github-workflow-ci.test.cjs` requires GitHub-owned actions to use current Node 24 majors (`actions/checkout@v7`).

## Test plan
- [x] `node --test scripts/github-workflow-ci.test.cjs` (pass)
- [ ] CI `lint-and-test` green on this PR