### PR TITLE
fix(sftp): close clipboard upload dialog before transfer

### DIFF
--- a/components/SftpClipboardUpload.test.ts
+++ b/components/SftpClipboardUpload.test.ts
@@ -9,6 +9,7 @@ import {
   isSftpNativeClipboardPasteEnabled,
   resolveSftpClipboardUploadTarget,
   shouldLetNativePasteEventHandleSftpPaste,
+  shouldStartClipboardUploadConfirm,
   type ClipboardLocalFile,
   type SftpClipboardUploadRequest,
 } from "./sftp/clipboardUpload.ts";
@@ -194,6 +195,29 @@ test("clipboard upload confirmation skips onUploaded when transfer fails", async
 
   // Dialog is still cleared so the UI is not stuck; refresh callback is skipped.
   assert.deepEqual(events, ["clear", "upload-start"]);
+});
+
+test("clipboard upload confirm guard is per request, not a global lock", () => {
+  const first: SftpClipboardUploadRequest = {
+    scopeId: "pane-1",
+    side: "left",
+    targetPath: "/a",
+    files: [{ path: "/tmp/a.txt", name: "a.txt", isDirectory: false, size: 1 }],
+    onConfirm: async () => {},
+  };
+  const second: SftpClipboardUploadRequest = {
+    scopeId: "pane-1",
+    side: "left",
+    targetPath: "/b",
+    files: [{ path: "/tmp/b.txt", name: "b.txt", isDirectory: false, size: 1 }],
+    onConfirm: async () => {},
+  };
+
+  assert.equal(shouldStartClipboardUploadConfirm(first, null), true);
+  assert.equal(shouldStartClipboardUploadConfirm(first, first), false);
+  // A later paste while the first transfer is still running must remain confirmable.
+  assert.equal(shouldStartClipboardUploadConfirm(second, first), true);
+  assert.equal(shouldStartClipboardUploadConfirm(null, first), false);
 });
 
 test("native clipboard paste follows SFTP paste shortcut availability", () => {

--- a/components/SftpClipboardUpload.test.ts
+++ b/components/SftpClipboardUpload.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  confirmSftpClipboardUpload,
   createDropEntriesFromClipboardFiles,
   getSftpClipboardSystemTextPaths,
   getSupportedClipboardUploadFiles,
@@ -9,6 +10,7 @@ import {
   resolveSftpClipboardUploadTarget,
   shouldLetNativePasteEventHandleSftpPaste,
   type ClipboardLocalFile,
+  type SftpClipboardUploadRequest,
 } from "./sftp/clipboardUpload.ts";
 import type { SftpFileEntry } from "../types";
 
@@ -124,6 +126,74 @@ test("SFTP paste keydown lets the native paste event handle OS clipboard files",
   assert.equal(shouldLetNativePasteEventHandleSftpPaste("sftpPaste", "Cmd + Shift + V"), false);
   assert.equal(shouldLetNativePasteEventHandleSftpPaste("sftpPaste", "F9"), false);
   assert.equal(shouldLetNativePasteEventHandleSftpPaste("sftpCopy", "Ctrl + V"), false);
+});
+
+test("clipboard upload confirmation clears the dialog before awaiting transfer", async () => {
+  const events: string[] = [];
+  let resolveUpload: (() => void) | undefined;
+  const uploadDone = new Promise<void>((resolve) => {
+    resolveUpload = resolve;
+  });
+
+  const request: SftpClipboardUploadRequest = {
+    scopeId: "pane-1",
+    side: "left",
+    targetPath: "/remote/inbox",
+    files: [{ path: "/tmp/a.txt", name: "a.txt", isDirectory: false, size: 1 }],
+    onConfirm: async () => {
+      events.push("upload-start");
+      await uploadDone;
+      events.push("upload-end");
+    },
+  };
+
+  const confirmPromise = confirmSftpClipboardUpload({
+    request,
+    clear: () => {
+      events.push("clear");
+    },
+    onUploaded: (targetPath) => {
+      events.push(`uploaded:${targetPath}`);
+    },
+  });
+
+  // Dialog must already be cleared while the transfer is still in flight.
+  // async function runs to its first await before returning the promise.
+  assert.deepEqual(events, ["clear", "upload-start"]);
+
+  resolveUpload?.();
+  await confirmPromise;
+  assert.deepEqual(events, ["clear", "upload-start", "upload-end", "uploaded:/remote/inbox"]);
+});
+
+test("clipboard upload confirmation skips onUploaded when transfer fails", async () => {
+  const events: string[] = [];
+  const request: SftpClipboardUploadRequest = {
+    scopeId: "pane-1",
+    side: "left",
+    targetPath: "/remote/inbox",
+    files: [{ path: "/tmp/a.txt", name: "a.txt", isDirectory: false, size: 1 }],
+    onConfirm: async () => {
+      events.push("upload-start");
+      throw new Error("boom");
+    },
+  };
+
+  await assert.rejects(
+    () => confirmSftpClipboardUpload({
+      request,
+      clear: () => {
+        events.push("clear");
+      },
+      onUploaded: () => {
+        events.push("uploaded");
+      },
+    }),
+    /boom/,
+  );
+
+  // Dialog is still cleared so the UI is not stuck; refresh callback is skipped.
+  assert.deepEqual(events, ["clear", "upload-start"]);
 });
 
 test("native clipboard paste follows SFTP paste shortcut availability", () => {

--- a/components/sftp/SftpClipboardUploadDialog.tsx
+++ b/components/sftp/SftpClipboardUploadDialog.tsx
@@ -9,7 +9,11 @@ import {
   DialogTitle,
 } from "../ui/dialog";
 import type { SftpClipboardUploadRequest } from "./clipboardUpload";
-import { confirmSftpClipboardUpload, sftpClipboardUploadStore } from "./clipboardUpload";
+import {
+  confirmSftpClipboardUpload,
+  shouldStartClipboardUploadConfirm,
+  sftpClipboardUploadStore,
+} from "./clipboardUpload";
 
 interface SftpClipboardUploadDialogProps {
   request: SftpClipboardUploadRequest | null;
@@ -29,8 +33,9 @@ export const SftpClipboardUploadDialog: React.FC<SftpClipboardUploadDialogProps>
   currentPath,
   onUploaded,
 }) => {
-  // Guard double-clicks before React re-renders with a cleared request.
-  const confirmStartedRef = useRef(false);
+  // Double-click guard is scoped to the request identity so a later paste can
+  // confirm while an earlier background transfer is still running.
+  const confirmStartedForRef = useRef<SftpClipboardUploadRequest | null>(null);
   const open = !!request;
   const fileCount = request?.files.length ?? 0;
   const previewFiles = request?.files.slice(0, 5) ?? [];
@@ -42,17 +47,18 @@ export const SftpClipboardUploadDialog: React.FC<SftpClipboardUploadDialogProps>
   };
 
   const handleConfirm = async () => {
-    if (!request || confirmStartedRef.current) return;
-    confirmStartedRef.current = true;
+    if (!request || !shouldStartClipboardUploadConfirm(request, confirmStartedForRef.current)) {
+      return;
+    }
+    const confirmedRequest = request;
+    confirmStartedForRef.current = confirmedRequest;
     try {
       // Close immediately so side-panel / standalone SFTP stay interactive while
       // the existing background transfer path runs.
-      await confirmSftpClipboardUpload({ request, onUploaded });
+      await confirmSftpClipboardUpload({ request: confirmedRequest, onUploaded });
     } catch {
       // Transfer handlers toast failures; keep this path free of unhandled
       // rejections after the dialog has already closed.
-    } finally {
-      confirmStartedRef.current = false;
     }
   };
 

--- a/components/sftp/SftpClipboardUploadDialog.tsx
+++ b/components/sftp/SftpClipboardUploadDialog.tsx
@@ -1,5 +1,4 @@
-import React, { useState } from "react";
-import { Loader2 } from "lucide-react";
+import React, { useRef } from "react";
 import { Button } from "../ui/button";
 import {
   Dialog,
@@ -10,7 +9,7 @@ import {
   DialogTitle,
 } from "../ui/dialog";
 import type { SftpClipboardUploadRequest } from "./clipboardUpload";
-import { sftpClipboardUploadStore } from "./clipboardUpload";
+import { confirmSftpClipboardUpload, sftpClipboardUploadStore } from "./clipboardUpload";
 
 interface SftpClipboardUploadDialogProps {
   request: SftpClipboardUploadRequest | null;
@@ -18,31 +17,42 @@ interface SftpClipboardUploadDialogProps {
   onUploaded?: (targetPath: string) => void;
 }
 
+/**
+ * Confirmation dialog for OS-clipboard / path-backed paste uploads.
+ *
+ * Important: clear the store request *before* awaiting the transfer so the
+ * modal overlay does not block the app for the entire upload (issue #2478).
+ * Progress and cancellation live in the transfer queue after handoff.
+ */
 export const SftpClipboardUploadDialog: React.FC<SftpClipboardUploadDialogProps> = ({
   request,
   currentPath,
   onUploaded,
 }) => {
-  const [uploading, setUploading] = useState(false);
+  // Guard double-clicks before React re-renders with a cleared request.
+  const confirmStartedRef = useRef(false);
   const open = !!request;
   const fileCount = request?.files.length ?? 0;
   const previewFiles = request?.files.slice(0, 5) ?? [];
   const remainingCount = Math.max(0, fileCount - previewFiles.length);
 
   const handleClose = (nextOpen: boolean) => {
-    if (nextOpen || uploading) return;
+    if (nextOpen) return;
     sftpClipboardUploadStore.clear(request);
   };
 
   const handleConfirm = async () => {
-    if (!request) return;
-    setUploading(true);
+    if (!request || confirmStartedRef.current) return;
+    confirmStartedRef.current = true;
     try {
-      await request.onConfirm();
-      onUploaded?.(request.targetPath);
-      sftpClipboardUploadStore.clear(request);
+      // Close immediately so side-panel / standalone SFTP stay interactive while
+      // the existing background transfer path runs.
+      await confirmSftpClipboardUpload({ request, onUploaded });
+    } catch {
+      // Transfer handlers toast failures; keep this path free of unhandled
+      // rejections after the dialog has already closed.
     } finally {
-      setUploading(false);
+      confirmStartedRef.current = false;
     }
   };
 
@@ -80,12 +90,10 @@ export const SftpClipboardUploadDialog: React.FC<SftpClipboardUploadDialogProps>
           <Button
             variant="outline"
             onClick={() => sftpClipboardUploadStore.clear(request)}
-            disabled={uploading}
           >
             Cancel
           </Button>
-          <Button onClick={handleConfirm} disabled={uploading || !request}>
-            {uploading && <Loader2 size={14} className="mr-2 animate-spin" />}
+          <Button onClick={handleConfirm} disabled={!request}>
             Upload
           </Button>
         </DialogFooter>

--- a/components/sftp/clipboardUpload.ts
+++ b/components/sftp/clipboardUpload.ts
@@ -138,3 +138,19 @@ export const sftpClipboardUploadStore = {
     return () => clipboardUploadListeners.delete(listener);
   },
 };
+
+/**
+ * Hand off a confirmed clipboard upload without holding the modal open.
+ * Clears the active request first, then runs the transfer (issue #2478).
+ */
+export async function confirmSftpClipboardUpload(params: {
+  request: SftpClipboardUploadRequest;
+  clear?: (request: SftpClipboardUploadRequest) => void;
+  onUploaded?: (targetPath: string) => void;
+}): Promise<void> {
+  const { request, onUploaded } = params;
+  const clear = params.clear ?? sftpClipboardUploadStore.clear;
+  clear(request);
+  await request.onConfirm();
+  onUploaded?.(request.targetPath);
+}

--- a/components/sftp/clipboardUpload.ts
+++ b/components/sftp/clipboardUpload.ts
@@ -154,3 +154,11 @@ export async function confirmSftpClipboardUpload(params: {
   await request.onConfirm();
   onUploaded?.(request.targetPath);
 }
+
+/** True when Upload should start for this request (blocks same-request double-click only). */
+export function shouldStartClipboardUploadConfirm(
+  request: SftpClipboardUploadRequest | null | undefined,
+  alreadyStartedFor: SftpClipboardUploadRequest | null | undefined,
+): boolean {
+  return !!request && alreadyStartedFor !== request;
+}


### PR DESCRIPTION
## Summary

- Close the SFTP clipboard upload confirmation immediately when the user clicks Upload.
- Let the existing background transfer path continue without a modal overlay blocking the app.
- Keep post-upload refresh via `onUploaded` after a successful transfer.
- Extract `confirmSftpClipboardUpload` and add regression tests for close-before-await ordering.

## Why

Fixes #2478: after confirming a clipboard paste upload, the dialog stayed open until the full transfer finished, freezing both side-panel and standalone SFTP.

This replaces closed PR #2479, which ballooned into pin/reconnect work and introduced regressions. This PR is intentionally minimal: dialog handoff only.

## Test plan

- [x] `node --test --import tsx components/SftpClipboardUpload.test.ts`
- [x] `npx eslint components/sftp/SftpClipboardUploadDialog.tsx components/sftp/clipboardUpload.ts components/SftpClipboardUpload.test.ts`
- [ ] Manual: paste local files into SFTP → Upload → dialog closes immediately, transfer queue runs, UI remains interactive