### PR TITLE
fix(known-hosts): filter out public service hosts from scan/import

### DIFF
--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -87,6 +87,7 @@ export const enVaultMessages: Messages = {
   'knownHosts.toast.scanImported': 'Imported {count} new hosts.',
   'knownHosts.toast.scanNoNew': 'No new hosts found.',
   'knownHosts.toast.scanFailed': 'Failed to scan system known_hosts.',
+  'knownHosts.toast.scanFiltered': 'Skipped {count} public service hosts.',
 
   // Port Forwarding
   'pf.empty.title': 'Set up port forwarding',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -123,6 +123,7 @@ export const ruVaultMessages: Messages = {
   'knownHosts.toast.scanImported': 'Импортировано новых хостов: {count}.',
   'knownHosts.toast.scanNoNew': 'Новых хостов не найдено.',
   'knownHosts.toast.scanFailed': 'Не удалось просканировать системный known_hosts.',
+  'knownHosts.toast.scanFiltered': 'Пропущено {count} публичных серверов.',
 
   // Port Forwarding
   'pf.empty.title': 'Настройте проброс портов',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -680,6 +680,7 @@ export const zhCNCoreMessages: Messages = {
   'knownHosts.toast.scanImported': '已导入 {count} 个新主机。',
   'knownHosts.toast.scanNoNew': '没有发现新的主机。',
   'knownHosts.toast.scanFailed': '扫描系统 known_hosts 失败。',
+  'knownHosts.toast.scanFiltered': '已跳过 {count} 个公共服务主机。',
 
   // Port Forwarding
   'pf.empty.title': '配置端口转发规则',

--- a/application/i18n/locales/zh-TW/core.ts
+++ b/application/i18n/locales/zh-TW/core.ts
@@ -680,6 +680,7 @@ export const zhTWCoreMessages: Messages = {
   'knownHosts.toast.scanImported': '已匯入 {count} 個新主機。',
   'knownHosts.toast.scanNoNew': '沒有發現新的主機。',
   'knownHosts.toast.scanFailed': '掃描系統 known_hosts 失敗。',
+  'knownHosts.toast.scanFiltered': '已跳過 {count} 個公共服務主機。',
 
   // Port Forwarding
   'pf.empty.title': '設定埠轉發規則',

--- a/components/KnownHostsManager.tsx
+++ b/components/KnownHostsManager.tsx
@@ -114,7 +114,20 @@ const parseKnownHostsFile = (content: string): KnownHost[] => {
   return parsed;
 };
 
+
+ // Well-known public service hostnames that should not be imported as managed hosts.
+ const PUBLIC_SERVICE_HOSTNAMES = new Set([
+   'github.com',
+   'gitlab.com',
+   'bitbucket.org',
+   'ssh.dev.azure.com',
+   'vs-ssh.visualstudio.com',
+ ]);
+
+ const isPublicServiceHost = (hostname: string): boolean =>
+   PUBLIC_SERVICE_HOSTNAMES.has(hostname);
 // Memoized Grid Item Component
+
 interface HostItemProps {
   knownHost: KnownHost;
   converted: boolean;
@@ -336,8 +349,9 @@ const KnownHostsManager: React.FC<KnownHostsManagerProps> = ({
         knownHosts.map((h) => `${h.hostname}:${h.port}`),
       );
       const newHosts = parsed.filter(
-        (h) => !existingHostnames.has(`${h.hostname}:${h.port}`),
+        (h) => !existingHostnames.has(`${h.hostname}:${h.port}`) && !isPublicServiceHost(h.hostname),
       );
+      const publicFiltered = parsed.filter((h) => isPublicServiceHost(h.hostname)).length;
 
       if (newHosts.length > 0) {
         onImportFromFile(newHosts);
@@ -347,6 +361,13 @@ const KnownHostsManager: React.FC<KnownHostsManagerProps> = ({
         );
       } else {
         if (!silent) toast.info(t("knownHosts.toast.scanNoNew"), t("vault.nav.knownHosts"));
+      }
+
+      if (!silent && publicFiltered > 0) {
+        toast.info(
+          t("knownHosts.toast.scanFiltered", { count: publicFiltered }),
+          t("vault.nav.knownHosts"),
+        );
       }
     } catch (err) {
       logger.error("Failed to scan system known_hosts:", err);
@@ -437,7 +458,7 @@ const KnownHostsManager: React.FC<KnownHostsManagerProps> = ({
           knownHosts.map((h) => `${h.hostname}:${h.port}`),
         );
         const newHosts = parsed.filter(
-          (h) => !existingHostnames.has(`${h.hostname}:${h.port}`),
+          (h) => !existingHostnames.has(`${h.hostname}:${h.port}`) && !isPublicServiceHost(h.hostname),
         );
 
         if (newHosts.length > 0) {


### PR DESCRIPTION
## Summary

When scanning the system known_hosts file or importing from a file, well-known public service hostnames (e.g. github.com, gitlab.com) are now excluded from being added to the Known Hosts vault.

### Changes

- Added PUBLIC_SERVICE_HOSTNAMES exclusion list (github.com, gitlab.com, bitbucket.org, Azure DevOps)
- Applied filter in both system scan and file import paths
- Added toast notification when entries are filtered out
- Added locale strings (en, zh-CN, zh-TW, ru)

### Before

Scanning system known_hosts would import github.com, gitlab.com, etc. into the vault.

### After

Public service hostnames are filtered out, and a toast shows how many were skipped.