### PR TITLE
docs: document issue/PR format gate in agent guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,16 @@ smoke coverage. Packaged-resource changes must also pass `npm run pack:dir`.
 - Avoid direct network/fetch in components; add a service/adaptor first.
 - Maintain ASCII-only unless required by existing file content.
 
+## Reporting Issues & PRs
+
+Issues opened without the required format are **auto-closed** by the issue-format bot. Agents that file issues via `gh` or the API must still follow these rules:
+
+- **Title:** start with `[Bug]`, `[Feature]`, or `[Other]`, then a short summary (≥ 4 characters after the prefix). Example: `[Bug] SFTP upload fails on Windows`.
+- **Body:** use the templates under [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/) (Bug Report or Feature Request) and fill every required field. Blank issues are disabled.
+- **PRs:** follow [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
+
+Full contributor guidance (setup, commits, PR process): [CONTRIBUTING.md](./CONTRIBUTING.md).
+
 ## Review Boundaries
 - Treat `electron/cli/*`, `netcatty-tool-cli`, the CLI discovery file, and the local TCP bridge as internal Netcatty integration surfaces unless a task explicitly says otherwise.
 - Do not review those surfaces as public APIs by default, and do not assume they must support third-party callers, manual launches, or non-Netcatty agents.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,3 +60,13 @@ UI calls `window.electron.*` (preload API) → IPC → bridge handler in main pr
 - Aside panels (VaultView subpages) use the shared design system in `components/ui/aside-panel.tsx` — see `AGENTS.md` for usage patterns.
 - Renderer code is TypeScript/ESM; Electron main/bridges are CommonJS (`.cjs`).
 - Path alias `@/` resolves to the repo root (configured in `vite.config.ts` and `tsconfig.json`).
+
+## Reporting Issues & PRs
+
+Issues that skip the format gate are auto-closed. When opening issues (including via `gh` / API):
+
+- Title must start with `[Bug]`, `[Feature]`, or `[Other]` plus a short summary.
+- Body must use `.github/ISSUE_TEMPLATE/` (Bug Report or Feature Request) and fill required fields.
+- PRs should follow `.github/PULL_REQUEST_TEMPLATE.md`.
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) and the "Reporting Issues & PRs" section in [AGENTS.md](./AGENTS.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,28 @@ This project follows the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUC
 - Fix bugs or implement features listed in Issues
 - Improve documentation
 
+## Reporting Issues
+
+Issues that do not follow the required format are closed automatically by the
+issue-format bot.
+
+- **Title prefix (required):** start with `[Bug]`, `[Feature]`, or `[Other]`,
+  then a short summary of at least 4 characters.
+  Example: `[Bug] SFTP upload fails on Windows`
+- **Template (required):** open from
+  [New Issue](https://github.com/binaricat/Netcatty/issues/new/choose) and pick
+  **Bug Report** or **Feature Request**. Fill every required field. Blank
+  issues are disabled (`blank_issues_enabled: false`).
+- **Templates live in**
+  [`.github/ISSUE_TEMPLATE/`](https://github.com/binaricat/Netcatty/tree/main/.github/ISSUE_TEMPLATE).
+- Questions and open-ended discussion belong in
+  [GitHub Discussions](https://github.com/binaricat/Netcatty/discussions), not Issues.
+
+If you open an issue via the API or `gh`, you must still use a valid title
+prefix and a body that matches the Bug Report or Feature Request template
+structure (required headings such as "Steps to reproduce" or
+"Problem / pain point").
+
 ## Development Setup
 
 **Prerequisites:** Node.js 22+ and npm.
@@ -60,7 +82,8 @@ npm test               # Run the test suite
    ```bash
    git commit -m 'feat: add amazing feature'
    ```
-5. Push the branch and open a Pull Request against `main`.
+5. Push the branch and open a Pull Request against `main`. Use the checklist in
+   [`.github/PULL_REQUEST_TEMPLATE.md`](https://github.com/binaricat/Netcatty/blob/main/.github/PULL_REQUEST_TEMPLATE.md).
 6. Run `npm run lint` and `npm test` before requesting review.
 7. If you changed the capability catalog, run `npm run generate:capability-tools`
    and commit any generated updates.


### PR DESCRIPTION
## Summary

- Document the issue-format gate (`[Bug]` / `[Feature]` / `[Other]` titles, required templates) in `AGENTS.md` and `CLAUDE.md` so AI agents and API/`gh` openers see the rules before filing.
- Add a full **Reporting Issues** section to `CONTRIBUTING.md` and point the PR process at `.github/PULL_REQUEST_TEMPLATE.md`.

## Type of Change

- [x] Documentation update

## Related Issue (optional)

Closes #2492

## Changes Made

- `CONTRIBUTING.md`: new Reporting Issues section + PR template link
- `AGENTS.md`: short "Reporting Issues & PRs" section for agents
- `CLAUDE.md`: short pointer to the same rules

## Screenshots / Demo

N/A (docs only)

## Testing

- [x] N/A for app runtime (`npm run dev` not required)
- [x] Linting not applicable (markdown only)
- [x] Locally verified issue #2492 body/title now pass `getIssueFormatErrors` (format bot reopened the issue)

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes