### PR TITLE
fix(sftp): restore cancel-by-task, clipboard confirm, and browse stay-alive

### DIFF
--- a/application/state/sftp/useSftpExternalOperations.ts
+++ b/application/state/sftp/useSftpExternalOperations.ts
@@ -72,8 +72,38 @@ export const useSftpExternalOperations = (
     return { sftpId, release: () => {} };
   }, [ensureRemoteSftpId, getActivePane, sftpSessionsRef]);
 
-  // Upload controller for cancellation support
-  const uploadControllerRef = useRef<UploadController | null>(null);
+  // Per-upload controllers so canceling upload A does not touch upload B.
+  const uploadControllersByTaskRef = useRef<Map<string, UploadController>>(new Map());
+
+  const registerUploadController = useCallback((taskId: string, controller: UploadController) => {
+    uploadControllersByTaskRef.current.set(taskId, controller);
+  }, []);
+
+  const unregisterUploadController = useCallback((controller: UploadController) => {
+    for (const [taskId, active] of [...uploadControllersByTaskRef.current]) {
+      if (active === controller) {
+        uploadControllersByTaskRef.current.delete(taskId);
+      }
+    }
+  }, []);
+
+  const bindUploadControllerCallbacks = useCallback((
+    controller: UploadController,
+    callbacks: UploadCallbacks,
+  ): UploadCallbacks => ({
+    ...callbacks,
+    onScanningStart: (taskId) => {
+      registerUploadController(taskId, controller);
+      callbacks.onScanningStart?.(taskId);
+    },
+    onTaskCreated: (task) => {
+      registerUploadController(task.id, controller);
+      if (task.parentTaskId) {
+        registerUploadController(task.parentTaskId, controller);
+      }
+      callbacks.onTaskCreated?.(task);
+    },
+  }), [registerUploadController]);
 
   // Track active file watches so the side panel can block host-switching.
   // Reset to 0 when the SFTP session disconnects (handled in SftpSidePanel).
@@ -84,6 +114,8 @@ export const useSftpExternalOperations = (
     setDefault: (action: FileConflictAction) => void;
   };
   const uploadConflictResolversRef = useRef<Map<string, UploadConflictResolver>>(new Map());
+  /** Maps conflict id → owning UploadController so cancel A never stops B's prompts. */
+  const uploadConflictOwnersRef = useRef<Map<string, UploadController>>(new Map());
 
   const readTextFile = useCallback(
     async (side: "left" | "right", filePath: string): Promise<string> => {
@@ -511,23 +543,30 @@ export const useSftpExternalOperations = (
     const resolver = uploadConflictResolversRef.current.get(conflictId);
     if (!resolver) return;
     uploadConflictResolversRef.current.delete(conflictId);
+    uploadConflictOwnersRef.current.delete(conflictId);
     if (conflict && applyToAll) {
       resolver.setDefault(action);
     }
     resolver.resolve(action);
   }, [uploadConflicts]);
 
-  const cancelPendingUploadConflicts = useCallback(() => {
+  const cancelPendingUploadConflicts = useCallback((controller?: UploadController) => {
     if (uploadConflictResolversRef.current.size === 0) return;
-    const resolvers = [...uploadConflictResolversRef.current.values()];
-    uploadConflictResolversRef.current.clear();
-    setUploadConflicts([]);
-    for (const resolver of resolvers) {
+    const canceledIds: string[] = [];
+    for (const [conflictId, resolver] of [...uploadConflictResolversRef.current]) {
+      const owner = uploadConflictOwnersRef.current.get(conflictId);
+      // Scoped cancel: only stop prompts owned by this controller.
+      if (controller && owner !== controller) continue;
+      canceledIds.push(conflictId);
+      uploadConflictResolversRef.current.delete(conflictId);
+      uploadConflictOwnersRef.current.delete(conflictId);
       resolver.resolve("stop");
     }
+    if (canceledIds.length === 0) return;
+    setUploadConflicts((prev) => prev.filter((item) => !canceledIds.includes(item.transferId)));
   }, []);
 
-  const createUploadConflictResolver = useCallback(() => {
+  const createUploadConflictResolver = useCallback((controller: UploadController) => {
     const conflictDefaults = new Map<string, FileConflictAction>();
 
     return async (conflict: {
@@ -562,6 +601,7 @@ export const useSftpExternalOperations = (
 
       setUploadConflicts((prev) => [...prev, fileConflict]);
       return new Promise<FileConflictAction>((resolve) => {
+        uploadConflictOwnersRef.current.set(conflictId, controller);
         uploadConflictResolversRef.current.set(conflictId, {
           resolve,
           setDefault: (action) => {
@@ -738,13 +778,15 @@ export const useSftpExternalOperations = (
         const uploadPaneId = livePane.id;
         const uploadTargetPath = targetPath || livePane.connection.currentPath;
         const controller = new UploadController();
-        uploadControllerRef.current = controller;
-        const callbacks = createUploadCallbacks(
-          livePane.connection.id,
-          uploadTargetPath,
-          livePane.connection.isLocal ? undefined : livePane.connection.hostId,
-          livePane.connection.isLocal ? undefined : connectionCacheKeyMapRef.current.get(livePane.connection.id),
-          livePane.connection.isLocal ? undefined : livePane.connection.hostLabel,
+        const callbacks = bindUploadControllerCallbacks(
+          controller,
+          createUploadCallbacks(
+            livePane.connection.id,
+            uploadTargetPath,
+            livePane.connection.isLocal ? undefined : livePane.connection.hostId,
+            livePane.connection.isLocal ? undefined : connectionCacheKeyMapRef.current.get(livePane.connection.id),
+            livePane.connection.isLocal ? undefined : livePane.connection.hostLabel,
+          ),
         );
 
         try {
@@ -771,7 +813,7 @@ export const useSftpExternalOperations = (
                 joinPath,
                 callbacks,
                 useCompressedUpload,
-                resolveConflict: createUploadConflictResolver(),
+                resolveConflict: createUploadConflictResolver(controller),
               },
               controller,
             ),
@@ -786,10 +828,7 @@ export const useSftpExternalOperations = (
           return results;
         } finally {
           release();
-          // Don't clear a newer concurrent upload's controller.
-          if (uploadControllerRef.current === controller) {
-            uploadControllerRef.current = null;
-          }
+          unregisterUploadController(controller);
         }
       };
 
@@ -810,6 +849,8 @@ export const useSftpExternalOperations = (
       connectionCacheKeyMapRef,
       createUploadBridge,
       createUploadCallbacks,
+      bindUploadControllerCallbacks,
+      unregisterUploadController,
       createUploadConflictResolver,
       ensureRemoteSftpId,
       getActivePane,
@@ -839,14 +880,16 @@ export const useSftpExternalOperations = (
         const uploadPaneId = livePane.id;
         const uploadTargetPath = targetPath || livePane.connection.currentPath;
         const controller = new UploadController();
-        uploadControllerRef.current = controller;
 
-        const callbacks = createUploadCallbacks(
-          livePane.connection.id,
-          uploadTargetPath,
-          livePane.connection.isLocal ? undefined : livePane.connection.hostId,
-          livePane.connection.isLocal ? undefined : connectionCacheKeyMapRef.current.get(livePane.connection.id),
-          livePane.connection.isLocal ? undefined : livePane.connection.hostLabel,
+        const callbacks = bindUploadControllerCallbacks(
+          controller,
+          createUploadCallbacks(
+            livePane.connection.id,
+            uploadTargetPath,
+            livePane.connection.isLocal ? undefined : livePane.connection.hostId,
+            livePane.connection.isLocal ? undefined : connectionCacheKeyMapRef.current.get(livePane.connection.id),
+            livePane.connection.isLocal ? undefined : livePane.connection.hostLabel,
+          ),
         );
 
         try {
@@ -874,7 +917,7 @@ export const useSftpExternalOperations = (
                 joinPath,
                 callbacks,
                 useCompressedUpload,
-                resolveConflict: createUploadConflictResolver(),
+                resolveConflict: createUploadConflictResolver(controller),
               },
               controller,
             ),
@@ -889,9 +932,7 @@ export const useSftpExternalOperations = (
           return results;
         } finally {
           release();
-          if (uploadControllerRef.current === controller) {
-            uploadControllerRef.current = null;
-          }
+          unregisterUploadController(controller);
         }
       };
 
@@ -912,6 +953,8 @@ export const useSftpExternalOperations = (
       connectionCacheKeyMapRef,
       createUploadBridge,
       createUploadCallbacks,
+      bindUploadControllerCallbacks,
+      unregisterUploadController,
       createUploadConflictResolver,
       ensureRemoteSftpId,
       getActivePane,
@@ -941,14 +984,16 @@ export const useSftpExternalOperations = (
         const uploadPaneId = livePane.id;
         const uploadTargetPath = targetPath || livePane.connection.currentPath;
         const controller = new UploadController();
-        uploadControllerRef.current = controller;
 
-        const callbacks = createUploadCallbacks(
-          livePane.connection.id,
-          uploadTargetPath,
-          livePane.connection.isLocal ? undefined : livePane.connection.hostId,
-          livePane.connection.isLocal ? undefined : connectionCacheKeyMapRef.current.get(livePane.connection.id),
-          livePane.connection.isLocal ? undefined : livePane.connection.hostLabel,
+        const callbacks = bindUploadControllerCallbacks(
+          controller,
+          createUploadCallbacks(
+            livePane.connection.id,
+            uploadTargetPath,
+            livePane.connection.isLocal ? undefined : livePane.connection.hostId,
+            livePane.connection.isLocal ? undefined : connectionCacheKeyMapRef.current.get(livePane.connection.id),
+            livePane.connection.isLocal ? undefined : livePane.connection.hostLabel,
+          ),
         );
 
         const scanningTask = startUploadScanningTask(callbacks);
@@ -1012,7 +1057,7 @@ export const useSftpExternalOperations = (
                 joinPath,
                 callbacks,
                 useCompressedUpload,
-                resolveConflict: createUploadConflictResolver(),
+                resolveConflict: createUploadConflictResolver(controller),
               },
               controller,
             ),
@@ -1036,9 +1081,7 @@ export const useSftpExternalOperations = (
           throw error;
         } finally {
           release();
-          if (uploadControllerRef.current === controller) {
-            uploadControllerRef.current = null;
-          }
+          unregisterUploadController(controller);
         }
       };
 
@@ -1059,6 +1102,8 @@ export const useSftpExternalOperations = (
       connectionCacheKeyMapRef,
       createUploadBridge,
       createUploadCallbacks,
+      bindUploadControllerCallbacks,
+      unregisterUploadController,
       createUploadConflictResolver,
       ensureRemoteSftpId,
       getActivePane,
@@ -1087,15 +1132,17 @@ export const useSftpExternalOperations = (
         // upload, even if focus switches during the transfer.
         const uploadPaneId = livePane.id;
         const controller = new UploadController();
-        uploadControllerRef.current = controller;
         const uploadTargetPath = options?.targetPath || livePane.connection.currentPath;
 
-        const callbacks = createUploadCallbacks(
-          livePane.connection.id,
-          uploadTargetPath,
-          livePane.connection.isLocal ? undefined : livePane.connection.hostId,
-          livePane.connection.isLocal ? undefined : connectionCacheKeyMapRef.current.get(livePane.connection.id),
-          livePane.connection.isLocal ? undefined : livePane.connection.hostLabel,
+        const callbacks = bindUploadControllerCallbacks(
+          controller,
+          createUploadCallbacks(
+            livePane.connection.id,
+            uploadTargetPath,
+            livePane.connection.isLocal ? undefined : livePane.connection.hostId,
+            livePane.connection.isLocal ? undefined : connectionCacheKeyMapRef.current.get(livePane.connection.id),
+            livePane.connection.isLocal ? undefined : livePane.connection.hostLabel,
+          ),
         );
         const directUploadBridge: UploadBridge = {
           ...createUploadBridge,
@@ -1125,7 +1172,7 @@ export const useSftpExternalOperations = (
                 joinPath,
                 callbacks,
                 useCompressedUpload,
-                resolveConflict: createUploadConflictResolver(),
+                resolveConflict: createUploadConflictResolver(controller),
               },
               controller,
             ),
@@ -1144,9 +1191,7 @@ export const useSftpExternalOperations = (
           return results;
         } finally {
           release();
-          if (uploadControllerRef.current === controller) {
-            uploadControllerRef.current = null;
-          }
+          unregisterUploadController(controller);
         }
       };
 
@@ -1167,6 +1212,8 @@ export const useSftpExternalOperations = (
       connectionCacheKeyMapRef,
       createUploadBridge,
       createUploadCallbacks,
+      bindUploadControllerCallbacks,
+      unregisterUploadController,
       createUploadConflictResolver,
       ensureRemoteSftpId,
       getActivePane,
@@ -1176,14 +1223,23 @@ export const useSftpExternalOperations = (
     ],
   );
 
-  const cancelExternalUpload = useCallback(async () => {
-    const controller = uploadControllerRef.current;
+  const cancelExternalUpload = useCallback(async (taskId?: string) => {
     let cancelPromise: Promise<void> | undefined;
-    if (controller) {
-      logger.info("[SFTP] Cancelling external upload");
-      cancelPromise = controller.cancel();
+    if (taskId) {
+      const controller = uploadControllersByTaskRef.current.get(taskId);
+      if (controller) {
+        logger.info("[SFTP] Cancelling external upload", { taskId });
+        cancelPendingUploadConflicts(controller);
+        cancelPromise = controller.cancel();
+      }
+    } else {
+      const controllers = [...new Set(uploadControllersByTaskRef.current.values())];
+      if (controllers.length > 0) {
+        logger.info("[SFTP] Cancelling all external uploads", { count: controllers.length });
+        cancelPromise = Promise.all(controllers.map((controller) => controller.cancel())).then(() => undefined);
+      }
+      cancelPendingUploadConflicts();
     }
-    cancelPendingUploadConflicts();
     await cancelPromise;
   }, [cancelPendingUploadConflicts]);
 

--- a/application/state/sftp/useSftpExternalOperations.types.ts
+++ b/application/state/sftp/useSftpExternalOperations.types.ts
@@ -73,7 +73,7 @@ export interface SftpExternalOperationsResult {
     entries: DropEntry[],
     options?: { targetPath?: string }
   ) => Promise<UploadResult[]>;
-  cancelExternalUpload: () => Promise<void>;
+  cancelExternalUpload: (taskId?: string) => Promise<void>;
   selectApplication: () => Promise<{ path: string; name: string } | null>;
   uploadConflicts: FileConflict[];
   resolveUploadConflict: (conflictId: string, action: FileConflictAction, applyToAll?: boolean) => void;

--- a/application/state/useSftpState.ts
+++ b/application/state/useSftpState.ts
@@ -815,7 +815,7 @@ export const useSftpState = (
       methodsRef.current.uploadExternalFolderPath(...args),
     uploadExternalEntries: (...args: Parameters<typeof uploadExternalEntries>) =>
       methodsRef.current.uploadExternalEntries(...args),
-    cancelExternalUpload: () => methodsRef.current.cancelExternalUpload(),
+    cancelExternalUpload: (taskId?: string) => methodsRef.current.cancelExternalUpload(taskId),
     selectApplication: () => methodsRef.current.selectApplication(),
     startTransfer: (...args: Parameters<typeof startTransfer>) => methodsRef.current.startTransfer(...args),
     downloadToLocal: (...args: Parameters<typeof downloadToLocal>) => methodsRef.current.downloadToLocal(...args),

--- a/components/SftpTransferItem.test.tsx
+++ b/components/SftpTransferItem.test.tsx
@@ -102,10 +102,11 @@ test("renders pausing state feedback instead of a dead pause button", () => {
     resumable: true,
   });
 
-  assert.match(markup, /aria-label="Finishing the current step: archive\.tar\.gz"/);
+  // Soft-drain is short; status copy is "Pausing" (not "finishing current step").
+  assert.match(markup, /aria-label="Pausing: archive\.tar\.gz"/);
   assert.match(markup, /aria-busy="true"/);
   assert.doesNotMatch(markup, /aria-label="Pause: archive\.tar\.gz"/);
-  assert.match(markup, /Finishing the current step/);
+  assert.match(markup, />Pausing</);
 });
 
 test("surfaces pause unavailable reason on a transferring row", () => {

--- a/components/SftpView.tsx
+++ b/components/SftpView.tsx
@@ -130,9 +130,11 @@ const SftpViewInner: React.FC<SftpViewProps> = ({
   const sftpOptions = useMemo(() => ({
     ...fileWatchHandlers,
     transferOwnerId: "main-sftp-view",
-    // Leaving the main SFTP page parks browse channels; transfers continue
-    // on dedicated pool sessions (and any leased browse sockets).
-    interactive: isActive,
+    // Main SFTP page stays interactive while mounted so top-tab switches
+    // (e.g. Terminal ↔ SFTP) must not soft-close every tab's session;
+    // the terminal side panel still parks when its panel is hidden.
+    // Bulk transfers use dedicated pool sessions regardless.
+    interactive: true,
     useCompressedUpload: sftpUseCompressedUpload,
     defaultShowHiddenFiles: sftpShowHiddenFiles,
     terminalSettings,
@@ -142,7 +144,6 @@ const SftpViewInner: React.FC<SftpViewProps> = ({
     transferPoolIdleTtlMs: sftpTransferPoolIdleTtlMs,
   }), [
     fileWatchHandlers,
-    isActive,
     sftpUseCompressedUpload,
     sftpShowHiddenFiles,
     terminalSettings,

--- a/components/sftp/SftpClipboardUploadDialog.tsx
+++ b/components/sftp/SftpClipboardUploadDialog.tsx
@@ -1,5 +1,4 @@
-import React, { useState } from "react";
-import { Loader2 } from "lucide-react";
+import React, { useRef } from "react";
 import { Button } from "../ui/button";
 import {
   Dialog,
@@ -10,7 +9,11 @@ import {
   DialogTitle,
 } from "../ui/dialog";
 import type { SftpClipboardUploadRequest } from "./clipboardUpload";
-import { sftpClipboardUploadStore } from "./clipboardUpload";
+import {
+  confirmSftpClipboardUpload,
+  shouldStartClipboardUploadConfirm,
+  sftpClipboardUploadStore,
+} from "./clipboardUpload";
 
 interface SftpClipboardUploadDialogProps {
   request: SftpClipboardUploadRequest | null;
@@ -18,31 +21,44 @@ interface SftpClipboardUploadDialogProps {
   onUploaded?: (targetPath: string) => void;
 }
 
+/**
+ * Confirmation dialog for OS-clipboard / path-backed paste uploads.
+ *
+ * Important: clear the store request *before* awaiting the transfer so the
+ * modal overlay does not block the app for the entire upload (issue #2478).
+ * Progress and cancellation live in the transfer queue after handoff.
+ */
 export const SftpClipboardUploadDialog: React.FC<SftpClipboardUploadDialogProps> = ({
   request,
   currentPath,
   onUploaded,
 }) => {
-  const [uploading, setUploading] = useState(false);
+  // Double-click guard is scoped to the request identity so a later paste can
+  // confirm while an earlier background transfer is still running.
+  const confirmStartedForRef = useRef<SftpClipboardUploadRequest | null>(null);
   const open = !!request;
   const fileCount = request?.files.length ?? 0;
   const previewFiles = request?.files.slice(0, 5) ?? [];
   const remainingCount = Math.max(0, fileCount - previewFiles.length);
 
   const handleClose = (nextOpen: boolean) => {
-    if (nextOpen || uploading) return;
+    if (nextOpen) return;
     sftpClipboardUploadStore.clear(request);
   };
 
   const handleConfirm = async () => {
-    if (!request) return;
-    setUploading(true);
+    if (!request || !shouldStartClipboardUploadConfirm(request, confirmStartedForRef.current)) {
+      return;
+    }
+    const confirmedRequest = request;
+    confirmStartedForRef.current = confirmedRequest;
     try {
-      await request.onConfirm();
-      onUploaded?.(request.targetPath);
-      sftpClipboardUploadStore.clear(request);
-    } finally {
-      setUploading(false);
+      // Close immediately so side-panel / standalone SFTP stay interactive while
+      // the existing background transfer path runs.
+      await confirmSftpClipboardUpload({ request: confirmedRequest, onUploaded });
+    } catch {
+      // Transfer handlers toast failures; keep this path free of unhandled
+      // rejections after the dialog has already closed.
     }
   };
 
@@ -80,12 +96,10 @@ export const SftpClipboardUploadDialog: React.FC<SftpClipboardUploadDialogProps>
           <Button
             variant="outline"
             onClick={() => sftpClipboardUploadStore.clear(request)}
-            disabled={uploading}
           >
             Cancel
           </Button>
-          <Button onClick={handleConfirm} disabled={uploading || !request}>
-            {uploading && <Loader2 size={14} className="mr-2 animate-spin" />}
+          <Button onClick={handleConfirm} disabled={!request}>
             Upload
           </Button>
         </DialogFooter>

--- a/components/sftp/SftpTransferQueue.tsx
+++ b/components/sftp/SftpTransferQueue.tsx
@@ -427,7 +427,7 @@ export const SftpTransferQueue: React.FC<SftpTransferQueueProps> = ({
                 onToggleChildren={() => toggleExpanded(task.id)}
                 onCancel={() => {
                   if (task.sourceConnectionId === "external") {
-                    sftp.cancelExternalUpload();
+                    void sftp.cancelExternalUpload(task.id);
                   }
                   void sftpTransferCenterStore.cancel(task.id);
                 }}

--- a/components/sftp/clipboardUpload.ts
+++ b/components/sftp/clipboardUpload.ts
@@ -138,3 +138,27 @@ export const sftpClipboardUploadStore = {
     return () => clipboardUploadListeners.delete(listener);
   },
 };
+
+/**
+ * Hand off a confirmed clipboard upload without holding the modal open.
+ * Clears the active request first, then runs the transfer (issue #2478).
+ */
+export async function confirmSftpClipboardUpload(params: {
+  request: SftpClipboardUploadRequest;
+  clear?: (request: SftpClipboardUploadRequest) => void;
+  onUploaded?: (targetPath: string) => void;
+}): Promise<void> {
+  const { request, onUploaded } = params;
+  const clear = params.clear ?? sftpClipboardUploadStore.clear;
+  clear(request);
+  await request.onConfirm();
+  onUploaded?.(request.targetPath);
+}
+
+/** True when Upload should start for this request (blocks same-request double-click only). */
+export function shouldStartClipboardUploadConfirm(
+  request: SftpClipboardUploadRequest | null | undefined,
+  alreadyStartedFor: SftpClipboardUploadRequest | null | undefined,
+): boolean {
+  return !!request && alreadyStartedFor !== request;
+}

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -41,9 +41,15 @@ const RESUME_RANGE_SETTLE_MS = 1500;
  */
 function broadcastGlobalTransferEvent(payload) {
   if (!payload || !payload.transferId) return;
+  // Bare Node unit tests must never require("electron"): that package's entry
+  // downloads the binary when dist/ is missing, hanging transferBridge tests
+  // for tens of seconds per progress/pause event. process.versions.electron is
+  // only set inside a real Electron main/renderer process.
+  if (typeof process.versions?.electron !== "string") return;
   try {
-    // Lazy require so unit tests without full electron still load this module.
     const electron = require("electron");
+    // Outside Electron, require("electron") is a path string — not the API.
+    if (!electron || typeof electron !== "object") return;
     const BrowserWindow = electron.BrowserWindow;
     if (!BrowserWindow?.getAllWindows) return;
     for (const win of BrowserWindow.getAllWindows()) {
@@ -57,7 +63,7 @@ function broadcastGlobalTransferEvent(payload) {
       }
     }
   } catch {
-    // electron unavailable (unit tests)
+    // electron unavailable
   }
 }
 

--- a/electron/bridges/transferBridge.globalFanout.test.cjs
+++ b/electron/bridges/transferBridge.globalFanout.test.cjs
@@ -6,11 +6,36 @@ const Module = require("node:module");
 const path = require("node:path");
 
 /**
+ * broadcastGlobalTransferEvent only loads electron when process.versions.electron
+ * is set (avoids install.js downloads in bare Node unit tests).
+ */
+function withElectronVersionStub() {
+  const previous = process.versions.electron;
+  Object.defineProperty(process.versions, "electron", {
+    configurable: true,
+    enumerable: true,
+    value: previous || "test",
+  });
+  return () => {
+    if (previous === undefined) {
+      delete process.versions.electron;
+    } else {
+      Object.defineProperty(process.versions, "electron", {
+        configurable: true,
+        enumerable: true,
+        value: previous,
+      });
+    }
+  };
+}
+
+/**
  * Drive the shipped broadcastGlobalTransferEvent entry point with a stubbed
  * electron BrowserWindow — proves fan-out does not require a panel sender.
  */
 test("broadcastGlobalTransferEvent fans progress to all live BrowserWindows", () => {
   const sent = [];
+  const restoreElectronVersion = withElectronVersionStub();
   const originalLoad = Module._load;
   Module._load = function load(request, parent, isMain) {
     if (request === "electron") {
@@ -61,6 +86,7 @@ test("broadcastGlobalTransferEvent fans progress to all live BrowserWindows", ()
     assert.equal(sent[0].payload.transferred, 50);
   } finally {
     Module._load = originalLoad;
+    restoreElectronVersion();
     try {
       delete require.cache[require.resolve(path.join(__dirname, "transferBridge.cjs"))];
     } catch { /* ignore */ }
@@ -75,6 +101,7 @@ test("broadcastGlobalTransferEvent no-ops without transferId", () => {
 
 test("worker-backed pause and resume fan authoritative lifecycle to every window", async () => {
   const sent = [];
+  const restoreElectronVersion = withElectronVersionStub();
   const originalLoad = Module._load;
   Module._load = function load(request, parent, isMain) {
     if (request === "electron") {
@@ -150,6 +177,7 @@ test("worker-backed pause and resume fan authoritative lifecycle to every window
     ]);
   } finally {
     Module._load = originalLoad;
+    restoreElectronVersion();
     delete require.cache[require.resolve(bridgePath)];
   }
 });

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -1222,7 +1222,7 @@ test("pause soft-drains concurrent ranges but resume waits before truncating", a
   const paused = await transferBridge.pauseTransfer(null, { transferId: "upload-soft-pause" });
   const elapsed = Date.now() - started;
   assert.equal(paused.success, true);
-  // Soft drain is ~300ms; allow headroom without waiting multi-second full drain.
+  // Soft drain is PAUSE_RANGE_DRAIN_MS (~50ms); allow headroom without full drain.
   assert.ok(elapsed < 1500, `soft pause took too long: ${elapsed}ms`);
 
   const outOfOrderWrite = pendingWrites.pop();
@@ -4373,6 +4373,14 @@ test("resumable stream transfers pause without losing their checkpoint and conti
 
   const lifecycleEvents = [];
   const originalLoad = Module._load;
+  // broadcastGlobalTransferEvent only loads electron when process.versions.electron
+  // is set (avoids install.js downloads in bare Node unit tests).
+  const previousElectronVersion = process.versions.electron;
+  Object.defineProperty(process.versions, "electron", {
+    configurable: true,
+    enumerable: true,
+    value: previousElectronVersion || "test",
+  });
   Module._load = function load(request, parent, isMain) {
     if (request === "electron") {
       return {
@@ -4391,7 +4399,18 @@ test("resumable stream transfers pause without losing their checkpoint and conti
     }
     return originalLoad(request, parent, isMain);
   };
-  t.after(() => { Module._load = originalLoad; });
+  t.after(() => {
+    Module._load = originalLoad;
+    if (previousElectronVersion === undefined) {
+      delete process.versions.electron;
+    } else {
+      Object.defineProperty(process.versions, "electron", {
+        configurable: true,
+        enumerable: true,
+        value: previousElectronVersion,
+      });
+    }
+  });
 
   const sender = createSender();
   const running = transferBridge.startTransfer(


### PR DESCRIPTION
## Summary
- Restore per-task external upload cancel (`uploadControllersByTaskRef` + `cancelExternalUpload(taskId?)`) regressed by #2509 (#2495).
- Restore clipboard upload confirm close-before-await (#2478 / #2493).
- Keep main SFTP browse sessions interactive across top-tab switches (`interactive: true`, #2498).
- Keep Pausing status copy (no longer "Finishing the current step"); gate `broadcastGlobalTransferEvent` so bare Node unit tests do not download Electron; fix globalFanout tests to stub `process.versions.electron`.

## Context
#2509 unified transfer control under process-level TransferRuntime and fixed soft-drain pause/resume tests, but accidentally rolled back concurrent external-upload cancel isolation, clipboard dialog handoff, and main-view browse stay-alive. This PR restores those product fixes without reverting TransferRuntime.

## Test plan
- [x] `application/state/sftp/externalUploadCancel.test.ts`
- [x] `components/SftpClipboardUpload.test.ts`
- [x] `components/SftpTransferItem.test.tsx` (pausing copy)
- [x] `components/SftpView.memo.test.tsx` (interactive: true)
- [x] orphan directory pause latch + soft-drain pause/resume
- [x] `electron/bridges/transferBridge.globalFanout.test.cjs`
- [x] eslint on touched paths