### PR TITLE
fix(sftp): resolve hook dependency warnings

### DIFF
--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -227,6 +227,8 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     warmTransferPoolForHost: sftp.warmTransferPoolForHost,
   });
 
+  const { getConnectionCacheKey, leftPane } = sftp;
+
   useEffect(() => {
     /** Per-task locks so resume-all can prepare multiple transfers sequentially. */
     const connectingTaskIds = new Set<string>();
@@ -718,13 +720,13 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     if (!pendingUpload || !activeHost) return;
     if (handledPendingUploadIdRef.current === pendingUpload.requestId) return;
 
-    const activePane = sftp.leftPane;
+    const activePane = leftPane;
     const connection = activePane.connection;
     // Prefer the live connection cache key (includes session overrides). Fall
     // back to the tab map only when the connect-time stamp is not yet readable.
     const paneConnectionKey = connection && !connection.isLocal
       ? (
-        sftp.getConnectionCacheKey?.(connection.id)
+        getConnectionCacheKey?.(connection.id)
         ?? tabConnectionKeyMapRef.current.get(activePane.id)
         ?? null
       )
@@ -767,10 +769,10 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     void runUpload();
   }, [
     activeHost,
+    getConnectionCacheKey,
+    leftPane,
     onPendingUploadHandled,
     pendingUpload,
-    sftp.getConnectionCacheKey,
-    sftp.leftPane,
     t,
   ]);
 

--- a/components/sftp/hooks/useSftpKeyboardShortcuts.ts
+++ b/components/sftp/hooks/useSftpKeyboardShortcuts.ts
@@ -533,6 +533,7 @@ export const useSftpKeyboardShortcuts = ({
       isActive,
       keyBindings,
       pasteInternalSftpClipboard,
+      sftpRef,
       triggerDropEntriesClipboardUpload,
       triggerPathBackedClipboardUpload,
     ],


### PR DESCRIPTION
## Summary

Resolve two React hook dependency warnings in the SFTP side panel while keeping the pending-upload effect scoped to the state it actually reads.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other

## Related Issue (optional)

N/A

## Changes Made

- Depend on the SFTP ref used by the clipboard paste callback.
- Destructure the left pane and connection-key helper so the pending-upload effect tracks only relevant SFTP state.
- Remove both `react-hooks/exhaustive-deps` warnings without broadening effect reruns to unrelated transfer state.

## Screenshots / Demo

No visual change.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Focused SFTP tests pass: 87/87. Production build passes. The full local suite was also run; four failures are in unrelated SSH/transfer bridge tests and do not touch this two-file renderer-only change.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation, or documentation is not needed
- [x] I have not introduced any breaking changes
