### PR TITLE
fix(ci): restore Cursor issue automation

### DIFF
--- a/.github/workflows/cursor-automation.yml
+++ b/.github/workflows/cursor-automation.yml
@@ -18,6 +18,9 @@ on:
   # poll open automation PRs so the loop can observe and mark ready.
   schedule:
     - cron: '*/20 * * * *'
+    # Exercise the real Cursor sandbox/config path once per day so a provider
+    # behavior change cannot hide behind green Codex polling runs.
+    - cron: '17 3 * * *'
   workflow_dispatch:
     inputs:
       issue_number:
@@ -136,6 +139,9 @@ jobs:
             };
 
             if (event === 'schedule') {
+              if (context.payload.schedule === '17 3 * * *') {
+                return set('skip', { reason: 'scheduled Cursor sandbox smoke' });
+              }
               return set('codex_poll', {
                 reason: 'scheduled poll for reaction-only clean / expired requests',
               });
@@ -524,11 +530,10 @@ jobs:
           # Enable sandbox + block shell network only. Do NOT deny built-in
           # web tools yet — the isolated research pass must still call them.
           node -e '
-            const fs = require("node:fs");
-            const p = process.env.HOME + "/.cursor/cli-config.json";
-            const c = JSON.parse(fs.readFileSync(p, "utf8"));
-            c.sandbox = { ...(c.sandbox || {}), mode: "enabled", networkAccess: "user_config" };
-            fs.writeFileSync(p, JSON.stringify(c, null, 2) + "\n");
+            const auto = require(process.env.RUNNER_TEMP + "/cursor-automation.cjs");
+            auto.prepareCursorCliConfig({
+              configPath: process.env.HOME + "/.cursor/cli-config.json",
+            });
           '
           agent sandbox run --sandbox bash -c 'touch .cursor-runtime/sandbox-check'
           test -f .cursor-runtime/sandbox-check
@@ -626,18 +631,11 @@ jobs:
           # Research has finished. Block web tools for classify and later agents
           # that share this HOME / user-level cli-config.
           node -e '
-            const fs = require("node:fs");
-            const p = process.env.HOME + "/.cursor/cli-config.json";
-            const c = JSON.parse(fs.readFileSync(p, "utf8"));
-            c.permissions = {
-              ...(c.permissions || {}),
-              deny: [...new Set([
-                ...(c.permissions?.deny || []),
-                "WebSearch(*)",
-                "WebFetch(*)",
-              ])],
-            };
-            fs.writeFileSync(p, JSON.stringify(c, null, 2) + "\n");
+            const auto = require(process.env.RUNNER_TEMP + "/cursor-automation.cjs");
+            auto.prepareCursorCliConfig({
+              configPath: process.env.HOME + "/.cursor/cli-config.json",
+              denyWeb: true,
+            });
           '
 
       - name: Classify with Cursor CLI
@@ -821,11 +819,23 @@ jobs:
 
   sandbox_smoke:
     name: Cursor sandbox smoke
-    if: github.event_name == 'workflow_dispatch' && inputs.sandbox_smoke == true
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.sandbox_smoke == true) ||
+      (github.event_name == 'schedule' && github.event.schedule == '17 3 * * *')
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions: {}
+    permissions:
+      contents: read
     steps:
+      - name: Checkout trusted helper
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'schedule' && github.event.repository.default_branch || github.sha }}
+          persist-credentials: false
+
+      - name: Freeze trusted helper
+        run: cp scripts/cursor-automation.cjs "$RUNNER_TEMP/cursor-automation.cjs"
+
       - name: Install Cursor CLI
         run: |
           curl https://cursor.com/install -fsS | bash
@@ -872,10 +882,23 @@ jobs:
             sudo journalctl -k --no-pager -n 100 >&2 || true
             exit 1
           fi
+          node -e '
+            const auto = require(process.env.RUNNER_TEMP + "/cursor-automation.cjs");
+            auto.prepareCursorCliConfig({
+              configPath: process.env.HOME + "/.cursor/cli-config.json",
+              denyWeb: true,
+            });
+          '
+          agent sandbox run --sandbox bash -c 'touch .cursor-runtime/sandbox-smoke'
+          test -f .cursor-runtime/sandbox-smoke
+          if agent sandbox run --sandbox bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
+            echo "Cursor sandbox unexpectedly allowed network access." >&2
+            exit 1
+          fi
           write_sandbox_policy
           "$sandbox_helper" --policy "$sandbox_policy_file" -- \
-            bash -c 'touch .cursor-runtime/sandbox-smoke'
-          test -f .cursor-runtime/sandbox-smoke
+            bash -c 'touch .cursor-runtime/sandbox-helper-smoke'
+          test -f .cursor-runtime/sandbox-helper-smoke
           write_sandbox_policy
           if "$sandbox_helper" --policy "$sandbox_policy_file" -- \
             bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
@@ -1104,11 +1127,10 @@ jobs:
           # Enable sandbox + block shell network only. Do NOT deny built-in
           # web tools yet — the isolated research pass must still call them.
           node -e '
-            const fs = require("node:fs");
-            const p = process.env.HOME + "/.cursor/cli-config.json";
-            const c = JSON.parse(fs.readFileSync(p, "utf8"));
-            c.sandbox = { ...(c.sandbox || {}), mode: "enabled", networkAccess: "user_config" };
-            fs.writeFileSync(p, JSON.stringify(c, null, 2) + "\n");
+            const auto = require(process.env.RUNNER_TEMP + "/cursor-automation.cjs");
+            auto.prepareCursorCliConfig({
+              configPath: process.env.HOME + "/.cursor/cli-config.json",
+            });
           '
           agent sandbox run --sandbox bash -c 'touch .cursor-runtime/followup-sandbox-check'
           test -f .cursor-runtime/followup-sandbox-check
@@ -1195,18 +1217,11 @@ jobs:
           # Research has finished. Block web tools for the follow-up agent and
           # any later steps that share this HOME / user-level cli-config.
           node -e '
-            const fs = require("node:fs");
-            const p = process.env.HOME + "/.cursor/cli-config.json";
-            const c = JSON.parse(fs.readFileSync(p, "utf8"));
-            c.permissions = {
-              ...(c.permissions || {}),
-              deny: [...new Set([
-                ...(c.permissions?.deny || []),
-                "WebSearch(*)",
-                "WebFetch(*)",
-              ])],
-            };
-            fs.writeFileSync(p, JSON.stringify(c, null, 2) + "\n");
+            const auto = require(process.env.RUNNER_TEMP + "/cursor-automation.cjs");
+            auto.prepareCursorCliConfig({
+              configPath: process.env.HOME + "/.cursor/cli-config.json",
+              denyWeb: true,
+            });
           '
 
       - name: Review follow-up with Cursor CLI
@@ -2359,19 +2374,11 @@ jobs:
           agent sandbox reset
           agent sandbox enable
           node -e '
-            const fs = require("node:fs");
-            const p = process.env.HOME + "/.cursor/cli-config.json";
-            const c = JSON.parse(fs.readFileSync(p, "utf8"));
-            c.sandbox = { ...(c.sandbox || {}), mode: "enabled", networkAccess: "user_config" };
-            c.permissions = {
-              ...(c.permissions || {}),
-              deny: [...new Set([
-                ...(c.permissions?.deny || []),
-                "WebSearch(*)",
-                "WebFetch(*)",
-              ])],
-            };
-            fs.writeFileSync(p, JSON.stringify(c, null, 2) + "\n");
+            const auto = require(process.env.RUNNER_TEMP + "/cursor-automation.cjs");
+            auto.prepareCursorCliConfig({
+              configPath: process.env.HOME + "/.cursor/cli-config.json",
+              denyWeb: true,
+            });
           '
           agent sandbox run --sandbox bash -c 'touch .cursor-runtime/implement-sandbox-check'
           test -f .cursor-runtime/implement-sandbox-check
@@ -3643,19 +3650,11 @@ jobs:
           agent sandbox reset
           agent sandbox enable
           node -e '
-            const fs = require("node:fs");
-            const p = process.env.HOME + "/.cursor/cli-config.json";
-            const c = JSON.parse(fs.readFileSync(p, "utf8"));
-            c.sandbox = { ...(c.sandbox || {}), mode: "enabled", networkAccess: "user_config" };
-            c.permissions = {
-              ...(c.permissions || {}),
-              deny: [...new Set([
-                ...(c.permissions?.deny || []),
-                "WebSearch(*)",
-                "WebFetch(*)",
-              ])],
-            };
-            fs.writeFileSync(p, JSON.stringify(c, null, 2) + "\n");
+            const auto = require(process.env.RUNNER_TEMP + "/cursor-automation.cjs");
+            auto.prepareCursorCliConfig({
+              configPath: process.env.HOME + "/.cursor/cli-config.json",
+              denyWeb: true,
+            });
           '
           agent sandbox run --sandbox bash -c 'touch .cursor-runtime/fix-sandbox-check'
           test -f .cursor-runtime/fix-sandbox-check

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -2162,6 +2162,57 @@ function writeText(filePath, value) {
 }
 
 /**
+ * Cursor may persist authentication without creating its documented CLI config.
+ * Prepare the file deterministically so sandbox and permission policy setup does
+ * not depend on an earlier Cursor command having written unrelated preferences.
+ */
+function prepareCursorCliConfig({ configPath, denyWeb = false }) {
+  const target = String(configPath || '').trim();
+  if (!target) throw new Error('Cursor CLI config path is required.');
+
+  let existing = {};
+  try {
+    existing = JSON.parse(fs.readFileSync(target, 'utf8'));
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  if (!existing || typeof existing !== 'object' || Array.isArray(existing)) {
+    throw new Error('Cursor CLI config must contain a JSON object.');
+  }
+
+  const config = {
+    ...existing,
+    version: existing.version ?? 1,
+    sandbox: {
+      ...(existing.sandbox || {}),
+      mode: 'enabled',
+      networkAccess: 'user_config',
+    },
+  };
+  if (denyWeb) {
+    config.permissions = {
+      ...(existing.permissions || {}),
+      deny: [...new Set([
+        ...(existing.permissions?.deny || []),
+        'WebSearch(*)',
+        'WebFetch(*)',
+      ])],
+    };
+  }
+
+  fs.mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
+  const temporary = `${target}.${process.pid}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(config, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
+  fs.chmodSync(temporary, 0o600);
+  fs.renameSync(temporary, target);
+  fs.chmodSync(target, 0o600);
+  return config;
+}
+
+/**
  * Octokit's paginate plugin normalizes Search API responses so that
  * `response.data` is already the items array (with total_count attached).
  * Older code expected `response.data.items`. Accept both shapes, and never
@@ -3083,6 +3134,7 @@ module.exports = {
   ensurePullRequestReady,
   restoreCleanPullRequestAfterNoChange,
   prepareIssueFollowupContext,
+  prepareCursorCliConfig,
   writeJson,
   writeText,
 };

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -8,6 +8,53 @@ const os = require('node:os');
 
 const auto = require('./cursor-automation.cjs');
 
+test('prepareCursorCliConfig creates a secure config when Cursor leaves it absent', (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-cli-config-'));
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+  const configPath = path.join(tempDir, '.cursor', 'cli-config.json');
+
+  const config = auto.prepareCursorCliConfig({ configPath });
+
+  assert.deepEqual(config.sandbox, {
+    mode: 'enabled',
+    networkAccess: 'user_config',
+  });
+  assert.equal(config.version, 1);
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(configPath, 'utf8')),
+    config,
+  );
+  assert.equal(fs.statSync(configPath).mode & 0o777, 0o600);
+});
+
+test('prepareCursorCliConfig preserves preferences and adds web denials once', (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-cli-config-'));
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+  const configPath = path.join(tempDir, 'cli-config.json');
+  fs.writeFileSync(configPath, JSON.stringify({
+    version: 7,
+    editor: { vimMode: true },
+    permissions: {
+      allow: ['Read(**)'],
+      deny: ['WebSearch(*)'],
+    },
+    sandbox: { mode: 'disabled', networkAccess: 'enabled', git: true },
+  }));
+
+  auto.prepareCursorCliConfig({ configPath, denyWeb: true });
+  const config = auto.prepareCursorCliConfig({ configPath, denyWeb: true });
+
+  assert.equal(config.version, 7);
+  assert.deepEqual(config.editor, { vimMode: true });
+  assert.deepEqual(config.permissions.allow, ['Read(**)']);
+  assert.deepEqual(config.permissions.deny, ['WebSearch(*)', 'WebFetch(*)']);
+  assert.deepEqual(config.sandbox, {
+    mode: 'enabled',
+    networkAccess: 'user_config',
+    git: true,
+  });
+});
+
 test('isValidIssueFormat accepts modern bug template', () => {
   assert.equal(
     auto.isValidIssueFormat({
@@ -1690,7 +1737,7 @@ test('every Cursor job prepares and verifies the Linux sandbox host', () => {
   }
 });
 
-test('workflow exposes a credential-free Cursor sandbox smoke check', () => {
+test('workflow exposes a write-credential-free Cursor sandbox smoke check', () => {
   const workflow = fs.readFileSync(
     path.join(__dirname, '..', '.github', 'workflows', 'cursor-automation.yml'),
     'utf8',
@@ -1702,17 +1749,56 @@ test('workflow exposes a credential-free Cursor sandbox smoke check', () => {
   const smokeJob = workflow.match(
     /\n  sandbox_smoke:\n[\s\S]*?(?=\n  [a-zA-Z0-9_]+:\n)/,
   )?.[0] || '';
-  assert.match(smokeJob, /permissions: \{\}/);
+  assert.match(smokeJob, /permissions:\n\s+contents: read/);
+  assert.match(
+    smokeJob,
+    /Checkout trusted helper[\s\S]*?persist-credentials: false/,
+  );
+  assert.match(
+    smokeJob,
+    /ref: \$\{\{ github\.event_name == 'schedule' && github\.event\.repository\.default_branch \|\| github\.sha \}\}/,
+  );
   assert.match(smokeJob, /run: \*prepare_cursor_sandbox_host/);
   assert.match(smokeJob, /agent sandbox enable/);
+  assert.match(
+    smokeJob,
+    /prepareCursorCliConfig[\s\S]*?agent sandbox run --sandbox bash -c 'touch \.cursor-runtime\/sandbox-smoke'/,
+  );
+  assert.match(
+    smokeJob,
+    /agent sandbox run --sandbox bash -c 'curl -fsS --max-time 3 https:\/\/example\.com >\/dev\/null'/,
+  );
   assert.match(smokeJob, /--policy "\$sandbox_policy_file"/);
   assert.match(smokeJob, /sandbox: \{/);
   assert.match(smokeJob, /networkAccess: false/);
   assert.match(smokeJob, /touch \.cursor-runtime\/sandbox-smoke/);
   assert.match(smokeJob, /Cursor sandbox unexpectedly allowed network access/);
-  assert.doesNotMatch(smokeJob, /agent sandbox run/);
   assert.doesNotMatch(smokeJob, /--sandbox-policy/);
   assert.doesNotMatch(smokeJob, /CURSOR_API_KEY|GITHUB_TOKEN|GH_TOKEN/);
+});
+
+test('workflow prepares missing Cursor config on every agent path and checks it daily', () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, '..', '.github', 'workflows', 'cursor-automation.yml'),
+    'utf8',
+  );
+  const prepareCalls = workflow.match(/prepareCursorCliConfig/g) || [];
+
+  assert.equal(prepareCalls.length, 7);
+  assert.doesNotMatch(
+    workflow,
+    /JSON\.parse\(fs\.readFileSync\(p, "utf8"\)\)/,
+  );
+  assert.match(workflow, /- cron: '17 3 \* \* \*'/);
+  assert.match(
+    workflow,
+    /context\.payload\.schedule === '17 3 \* \* \*'[\s\S]*?return set\('skip'/,
+  );
+  const smokeJob = workflow.match(
+    /\n  sandbox_smoke:\n[\s\S]*?(?=\n  [a-zA-Z0-9_]+:\n)/,
+  )?.[0] || '';
+  assert.match(smokeJob, /github\.event\.schedule == '17 3 \* \* \*'/);
+  assert.match(smokeJob, /prepareCursorCliConfig/);
 });
 
 test('normalizeExternalResearchText accepts sourced research and explicit no-op', () => {
@@ -1966,8 +2052,7 @@ test('workflow confines forced WebSearch to isolated read-only research passes',
     assert.match(run, /process\.env\.HOME/);
     assert.match(run, /process\.env\.GITHUB_WORKSPACE/);
     // Research itself must not write the non-research web-tool denylist.
-    assert.doesNotMatch(run, /"WebSearch\(\*\)"/);
-    assert.doesNotMatch(run, /"WebFetch\(\*\)"/);
+    assert.doesNotMatch(run, /denyWeb: true/);
   }
 
   const nonResearchAgentLines = workflow
@@ -1978,8 +2063,7 @@ test('workflow confines forced WebSearch to isolated read-only research passes',
     workflow.split('\n').filter((line) => line.includes('agent -p') && line.includes('--force')).length,
     2,
   );
-  assert.equal((workflow.match(/"WebSearch\(\*\)"/g) || []).length, 4);
-  assert.equal((workflow.match(/"WebFetch\(\*\)"/g) || []).length, 4);
+  assert.equal((workflow.match(/denyWeb: true/g) || []).length, 5);
   assert.doesNotMatch(workflow, /issue-research-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/);
   assert.match(workflow, /name: issue-research-\$\{\{ github\.run_id \}\}[\s\S]*?overwrite: true/);
 });
@@ -2008,21 +2092,15 @@ test('workflow denies WebSearch only after isolated research, not before it', ()
     const preResearch = job.slice(0, researchIdx);
     assert.doesNotMatch(
       preResearch,
-      /"WebSearch\(\*\)"/,
+      /denyWeb: true/,
       `${label} must not deny WebSearch before research`,
-    );
-    assert.doesNotMatch(
-      preResearch,
-      /"WebFetch\(\*\)"/,
-      `${label} must not deny WebFetch before research`,
     );
 
     const postResearch = job.slice(researchIdx);
     const denyStep = postResearch.match(
       /- name: Deny WebSearch and WebFetch after[\s\S]*?(?=\n\s{6}- name:)/,
     )?.[0] || '';
-    assert.match(denyStep, /"WebSearch\(\*\)"/, `${label} post-research deny missing WebSearch`);
-    assert.match(denyStep, /"WebFetch\(\*\)"/, `${label} post-research deny missing WebFetch`);
+    assert.match(denyStep, /denyWeb: true/, `${label} post-research deny missing web block`);
 
     const denyIdx = postResearch.indexOf('- name: Deny WebSearch and WebFetch after');
     const agentIdx = postResearch.search(
@@ -2035,7 +2113,7 @@ test('workflow denies WebSearch only after isolated research, not before it', ()
   const implementJob = workflow.match(
     /\n  implement:\n[\s\S]*?(?=\n  [a-zA-Z0-9_]+:\n)/,
   )?.[0] || '';
-  assert.match(implementJob, /Require the Cursor command sandbox for implementation[\s\S]*?"WebSearch\(\*\)"/);
+  assert.match(implementJob, /Require the Cursor command sandbox for implementation[\s\S]*?denyWeb: true/);
   assert.doesNotMatch(implementJob, /Research external context/);
 });
 


### PR DESCRIPTION
## Summary

Restore Cursor issue automation after the CLI stopped creating `~/.cursor/cli-config.json` during authentication or sandbox setup. The workflow now creates or updates that documented config safely before every Cursor agent path and runs a daily credential-free smoke check through the real Cursor sandbox command.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [x] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #2512, #2513, and #2514

## Changes Made

- Create the Cursor CLI config when it is absent while preserving existing preferences and enforcing the sandbox/web-tool policy.
- Use the same tested helper in classification, follow-up, implementation, and Codex-fix paths.
- Add a daily smoke run that exercises the real Cursor sandbox path without passing repository or Cursor credentials to the executed shell.
- Keep the smoke-only schedule from starting an extra Codex polling cycle, and make manual smoke runs test the selected workflow revision.

## Screenshots / Demo

N/A — workflow-only change.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Additional validation:

- `node --test scripts/cursor-automation.test.cjs` — 133/133 passed
- Workflow YAML parse and whitespace validation passed
- `npm run build` passed
- The full suite reached three existing SFTP transfer-test failures on unchanged code; no Cursor automation test failed.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
