### PR TITLE
fix(sftp): prevent large folder upload renderer stalls

### DIFF
--- a/application/app/useAppStartupEffects.ts
+++ b/application/app/useAppStartupEffects.ts
@@ -418,8 +418,9 @@ export function useAppStartupEffects(ctx: StartupEffectsContext) {
       },
       retry: async (taskId) => { await restartBackgroundTransfer(taskId, true); },
       prioritize: async (taskId) => { await bridge?.prioritizeTransfer?.(taskId); },
-      dismiss: (taskId) => {
-        const task = sftpTransferCenterStore.getSnapshot().tasks.find((candidate) => candidate.id === taskId);
+      dismiss: (taskId, prunedTask) => {
+        const task = prunedTask
+          ?? sftpTransferCenterStore.getSnapshot().tasks.find((candidate) => candidate.id === taskId);
         if (!task) return;
         void bridge?.cleanupTransferArtifacts?.({
           transferId: task.id,

--- a/application/state/sftp/useSftpTransfers.ts
+++ b/application/state/sftp/useSftpTransfers.ts
@@ -1222,13 +1222,10 @@ export const useSftpTransfers = ({
     setTransfers((prev) => prev.filter((t) => t.id !== transferId && t.parentTaskId !== transferId));
   }, [cleanupTaskArtifacts, setTransfers]);
 
-  const dismissTransfers = useCallback((transferIds: readonly string[]) => {
-    if (transferIds.length === 0) return;
-    const removing = new Set(transferIds);
-    const artifactTasks = transfersRef.current.filter((task) => (
-      task.status !== "completed"
-      && (removing.has(task.id) || removing.has(task.parentTaskId ?? ""))
-    ));
+  const dismissTransfers = useCallback((prunedTasks: readonly TransferTask[]) => {
+    if (prunedTasks.length === 0) return;
+    const removing = new Set(prunedTasks.map((task) => task.id));
+    const artifactTasks = prunedTasks.filter((task) => task.status !== "completed");
     // This callback is used only for automatic history eviction. Completed
     // streams already cleaned their staging files; sending one cleanup IPC per
     // pruned child recreates a main-process event storm at folder completion.

--- a/application/state/sftp/useSftpTransfers.ts
+++ b/application/state/sftp/useSftpTransfers.ts
@@ -1222,6 +1222,34 @@ export const useSftpTransfers = ({
     setTransfers((prev) => prev.filter((t) => t.id !== transferId && t.parentTaskId !== transferId));
   }, [cleanupTaskArtifacts, setTransfers]);
 
+  const dismissTransfers = useCallback((transferIds: readonly string[]) => {
+    if (transferIds.length === 0) return;
+    const removing = new Set(transferIds);
+    const artifactTasks = transfersRef.current.filter((task) => (
+      task.status !== "completed"
+      && (removing.has(task.id) || removing.has(task.parentTaskId ?? ""))
+    ));
+    // This callback is used only for automatic history eviction. Completed
+    // streams already cleaned their staging files; sending one cleanup IPC per
+    // pruned child recreates a main-process event storm at folder completion.
+    setTransfers((prev) => prev.filter((task) => (
+      !removing.has(task.id) && !removing.has(task.parentTaskId ?? "")
+    )));
+    // Failed/cancelled transfers can retain resumable staging files. Clean them
+    // sequentially in the background so a large eviction never floods IPC.
+    if (artifactTasks.length > 0) {
+      void (async () => {
+        for (const task of artifactTasks) {
+          try {
+            await cleanupTaskArtifacts(task);
+          } catch {
+            // best-effort history cleanup
+          }
+        }
+      })();
+    }
+  }, [cleanupTaskArtifacts, setTransfers]);
+
   const isTransferCancelled = useCallback((transferId: string) => {
     return cancelledTasksRef.current.has(transferId) || isTransferCancelledFlag(transferId);
   }, []);
@@ -1834,6 +1862,7 @@ export const useSftpTransfers = ({
     retry: retryTransfer,
     prioritize: prioritizeTransfer,
     dismiss: dismissTransfer,
+    dismissMany: dismissTransfers,
     resolveConflict,
     // Origin/local listing only — soft pause/resume must not key on this.
     ownsTask: (taskId: string) => transfersRef.current.some(
@@ -1843,7 +1872,7 @@ export const useSftpTransfers = ({
     canAdopt: (task) => resolveAdoptionPanes(task) !== null,
     canPrepareAdoption,
     adopt: adoptInterruptedTransfer,
-  }), [adoptInterruptedTransfer, canPrepareAdoption, cancelTransfer, dismissTransfer, ownerId, prioritizeTransfer, resolveAdoptionPanes, resolveConflict, resumeTransfer, retryTransfer, syncOwnedTasksFromStore]);
+  }), [adoptInterruptedTransfer, canPrepareAdoption, cancelTransfer, dismissTransfer, dismissTransfers, ownerId, prioritizeTransfer, resolveAdoptionPanes, resolveConflict, resumeTransfer, retryTransfer, syncOwnedTasksFromStore]);
 
   return {
     transfers,

--- a/application/state/sftpTransferCenterStore.test.ts
+++ b/application/state/sftpTransferCenterStore.test.ts
@@ -176,6 +176,83 @@ test("paused source fingerprint patches are persisted for restart", () => {
   assert.equal(restored.getSnapshot().tasks[0]?.sourceFingerprint, "sha256:durable");
 });
 
+test("background source fingerprint progress is persisted immediately for restart", () => {
+  let persisted = "";
+  const first = createSftpTransferCenterStore({
+    read: () => null,
+    write: (value) => { persisted = value; },
+  });
+  first.publishOwner("panel-a", [makeTask("background-fingerprint", "paused")]);
+  first.ingestBackgroundEvent({
+    type: "progress",
+    transferId: "background-fingerprint",
+    transferred: 2,
+    totalBytes: 10,
+    speed: 0,
+    checkpointBytes: 2,
+    sourceFingerprint: "sha256:background-durable",
+    lifecycleState: "paused",
+  });
+
+  const restored = createSftpTransferCenterStore({
+    read: () => persisted,
+    write: () => {},
+  });
+  assert.equal(restored.getSnapshot().tasks[0]?.sourceFingerprint, "sha256:background-durable");
+});
+
+test("owner source fingerprint publish is persisted immediately for restart", () => {
+  let persisted = "";
+  const first = createSftpTransferCenterStore({
+    read: () => null,
+    write: (value) => { persisted = value; },
+  });
+  const paused = makeTask("owner-fingerprint", "paused");
+  first.publishOwner("panel-a", [paused]);
+  first.publishOwner("panel-a", [{
+    ...paused,
+    sourceFingerprint: "sha256:owner-durable",
+  }]);
+
+  const restored = createSftpTransferCenterStore({
+    read: () => persisted,
+    write: () => {},
+  });
+  assert.equal(restored.getSnapshot().tasks[0]?.sourceFingerprint, "sha256:owner-durable");
+});
+
+test("top-level completion is persisted immediately while child completions stay coalesced", () => {
+  let writes = 0;
+  let persisted = "";
+  const first = createSftpTransferCenterStore({
+    read: () => null,
+    write: (value) => {
+      writes += 1;
+      persisted = value;
+    },
+  });
+  const parent = {
+    ...makeTask("completed-parent"),
+    isDirectory: true,
+    progressMode: "files" as const,
+  };
+  const child = { ...makeTask("completed-child"), parentTaskId: parent.id };
+  first.publishOwner("panel-a", [parent, child]);
+  first.publishOwner("panel-a", [parent, { ...child, status: "completed", endTime: Date.now() }]);
+  assert.equal(writes, 1, "child completion should remain coalesced");
+  first.publishOwner("panel-a", [
+    { ...parent, status: "completed", endTime: Date.now() },
+    { ...child, status: "completed", endTime: Date.now() },
+  ]);
+  assert.equal(writes, 2, "parent completion should flush immediately");
+
+  const restored = createSftpTransferCenterStore({
+    read: () => persisted,
+    write: () => {},
+  });
+  assert.equal(restored.getSnapshot().tasks.find((task) => task.id === parent.id)?.status, "completed");
+});
+
 test("orphaned unfinished tasks stay controllable so dead rows can be cancelled", () => {
   const store = createSftpTransferCenterStore();
   store.publishOwner("gone-panel", [
@@ -381,6 +458,69 @@ test("main-process progress ingest keeps panel-owned transfers moving without Re
     endedAt: Date.now(),
   });
   assert.equal(store.getSnapshot().tasks.find((row) => row.id === "upload-1")?.status, "completed");
+});
+
+test("duplicate main-process progress does not notify or persist a second renderer update", async () => {
+  let writes = 0;
+  let notifications = 0;
+  const store = createSftpTransferCenterStore({
+    read: () => null,
+    write: () => { writes += 1; },
+  });
+  store.publishOwner("panel-a", [{
+    ...makeTask("duplicate-progress"),
+    transferredBytes: 5,
+    totalBytes: 10,
+    speed: 2,
+    lifecycleEpoch: 0,
+  }]);
+  store.subscribe(() => { notifications += 1; });
+
+  store.ingestBackgroundEvent({
+    type: "progress",
+    transferId: "duplicate-progress",
+    transferred: 5,
+    totalBytes: 10,
+    speed: 2,
+    lifecycleEpoch: 0,
+    lifecycleState: "transferring",
+  });
+  await new Promise((resolve) => setTimeout(resolve, 300));
+
+  assert.equal(notifications, 0);
+  assert.equal(writes, 1);
+});
+
+test("owner publish after global progress does not repeat the same renderer update", () => {
+  const store = createSftpTransferCenterStore();
+  store.publishOwner("panel-a", [{
+    ...makeTask("global-first"),
+    transferredBytes: 0,
+    totalBytes: 10,
+    speed: 0,
+    lifecycleEpoch: 0,
+  }]);
+  let notifications = 0;
+  store.subscribe(() => { notifications += 1; });
+
+  store.ingestBackgroundEvent({
+    type: "progress",
+    transferId: "global-first",
+    transferred: 5,
+    totalBytes: 10,
+    speed: 2,
+    lifecycleEpoch: 0,
+    lifecycleState: "transferring",
+  });
+  store.publishOwner("panel-a", [{
+    ...makeTask("global-first"),
+    transferredBytes: 5,
+    totalBytes: 10,
+    speed: 2,
+    lifecycleEpoch: 0,
+  }]);
+
+  assert.equal(notifications, 1);
 });
 
 test("newer backend lifecycle progress reopens a paused row", () => {
@@ -864,6 +1004,48 @@ test("pause after terminal close works without any React owner", async () => {
   assert.equal(isTransferPauseLatched("stale-dir"), true);
   assert.ok(pauseCalls.includes("stale-child"));
   cleanup();
+});
+
+test("soft pause checkpoint and source fingerprint persist before pause returns", async (t) => {
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  t.after(() => {
+    if (previousWindow) Object.defineProperty(globalThis, "window", previousWindow);
+    else Reflect.deleteProperty(globalThis, "window");
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        pauseTransfer: async () => ({
+          success: true,
+          checkpointBytes: 7,
+          sourceFingerprint: "sha256:pause-return",
+          lifecycleEpoch: 1,
+        }),
+      },
+    },
+  });
+  let persisted = "";
+  const store = createSftpTransferCenterStore({
+    read: () => null,
+    write: (value) => { persisted = value; },
+  });
+  store.publishOwner("closed-panel", [{
+    ...makeTask("pause-durable", "transferring"),
+    transferredBytes: 7,
+    totalBytes: 10,
+  }]);
+
+  await store.pause("pause-durable");
+
+  const restored = createSftpTransferCenterStore({
+    read: () => persisted,
+    write: () => {},
+  });
+  const restoredTask = restored.getSnapshot().tasks[0];
+  assert.equal(restoredTask?.status, "interrupted");
+  assert.equal(restoredTask?.checkpointBytes, 7);
+  assert.equal(restoredTask?.sourceFingerprint, "sha256:pause-return");
 });
 
 test("publishOwner still allows explicit restart that resets progress to zero", () => {
@@ -2464,4 +2646,122 @@ test("directory soft resume then new/queued child progress at bridge epoch 0 adv
   // Soft resume left queued status; progress with transferring lifecycle should open bar.
   const queued = store.getSnapshot().tasks.find((t) => t.id === "queued-child");
   assert.equal(queued?.transferredBytes, 25, "queued sibling progress at epoch 0 must not be stale-dropped");
+});
+
+test("large directory progress coalesces synchronous persistence work", async () => {
+  let writes = 0;
+  let writtenCharacters = 0;
+  const store = createSftpTransferCenterStore({
+    read: () => null,
+    write(value) {
+      writes += 1;
+      writtenCharacters += value.length;
+    },
+  });
+  const parent = {
+    ...makeTask("large-folder"),
+    isDirectory: true,
+    progressMode: "files" as const,
+    totalBytes: 2_000,
+    transferredBytes: 0,
+  };
+  let tasks: TransferTask[] = [
+    parent,
+    ...Array.from({ length: 2_000 }, (_, index) => ({
+      ...makeTask(`large-child-${index}`, index < 1_000 ? "completed" : "queued"),
+      parentTaskId: parent.id,
+      startTime: index + 2,
+    })),
+  ];
+
+  store.publishOwner("panel-a", tasks);
+  const oneSnapshotCharacters = writtenCharacters;
+  for (let tick = 1; tick <= 24; tick += 1) {
+    tasks = tasks.map((task) => task.id === parent.id
+      ? { ...task, transferredBytes: 1_000 + tick }
+      : task);
+    store.publishOwner("panel-a", tasks);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  assert.ok(writes <= 3, `expected at most 3 storage writes, got ${writes}`);
+  assert.ok(
+    writtenCharacters <= oneSnapshotCharacters * 3,
+    `expected bounded persistence volume, wrote ${writtenCharacters} characters for a ${oneSnapshotCharacters}-character snapshot`,
+  );
+});
+
+test("completed directory history is pruned with one owner update and no reentrant dismiss storm", () => {
+  const store = createSftpTransferCenterStore();
+  const now = Date.now();
+  const parent = {
+    ...makeTask("finished-folder"),
+    isDirectory: true,
+    progressMode: "files" as const,
+    totalBytes: 250,
+    transferredBytes: 250,
+  };
+  let ownerTasks: TransferTask[] = [
+    parent,
+    ...Array.from({ length: 250 }, (_, index) => ({
+      ...makeTask(`finished-child-${index}`, "completed"),
+      parentTaskId: parent.id,
+      startTime: index + 2,
+      endTime: now - index,
+    })),
+  ];
+  let individualDismisses = 0;
+  let batchDismisses = 0;
+  let publishDepth = 0;
+  let maxPublishDepth = 0;
+  const republish = () => {
+    publishDepth += 1;
+    maxPublishDepth = Math.max(maxPublishDepth, publishDepth);
+    store.publishOwner("panel-a", ownerTasks);
+    publishDepth -= 1;
+  };
+  const controls = {
+    pause: async () => {},
+    resume: async () => {},
+    cancel: async () => {},
+    retry: async () => {},
+    prioritize: async () => {},
+    dismiss(id: string) {
+      individualDismisses += 1;
+      ownerTasks = ownerTasks.filter((task) => task.id !== id && task.parentTaskId !== id);
+      republish();
+    },
+    dismissMany(ids: readonly string[]) {
+      batchDismisses += 1;
+      const removing = new Set(ids);
+      ownerTasks = ownerTasks.filter((task) => !removing.has(task.id) && !removing.has(task.parentTaskId ?? ""));
+      republish();
+    },
+  };
+  store.registerOwner("panel-a", controls);
+
+  republish();
+  ownerTasks = ownerTasks.map((task) => task.id === parent.id
+    ? { ...task, status: "completed", endTime: now }
+    : task);
+  republish();
+
+  assert.equal(individualDismisses, 0);
+  assert.equal(batchDismisses, 1);
+  assert.equal(maxPublishDepth, 2);
+  assert.ok(store.getSnapshot().tasks.length <= 200);
+});
+
+test("storage exhaustion cannot escape into the renderer update path", () => {
+  const store = createSftpTransferCenterStore({
+    read: () => null,
+    write() {
+      throw new DOMException("quota exceeded", "QuotaExceededError");
+    },
+  });
+
+  assert.doesNotThrow(() => {
+    store.publishOwner("panel-a", [makeTask("quota-safe")]);
+  });
+  assert.equal(store.getSnapshot().tasks[0]?.id, "quota-safe");
 });

--- a/application/state/sftpTransferCenterStore.test.ts
+++ b/application/state/sftpTransferCenterStore.test.ts
@@ -253,6 +253,49 @@ test("top-level completion is persisted immediately while child completions stay
   assert.equal(restored.getSnapshot().tasks.find((task) => task.id === parent.id)?.status, "completed");
 });
 
+test("explicit history deletions are persisted before returning", () => {
+  const cases = [
+    {
+      name: "dismiss",
+      task: makeTask("dismissed-history", "failed"),
+      remove: (store: ReturnType<typeof createSftpTransferCenterStore>) => store.dismiss("dismissed-history"),
+    },
+    {
+      name: "clear terminal",
+      task: makeTask("cleared-history", "completed"),
+      remove: (store: ReturnType<typeof createSftpTransferCenterStore>) => store.clearTerminal("completed"),
+    },
+    {
+      name: "owner publish",
+      task: makeTask("owner-removed-history", "failed"),
+      remove: (store: ReturnType<typeof createSftpTransferCenterStore>) => store.publishOwner("panel-a", []),
+    },
+  ];
+
+  for (const scenario of cases) {
+    let writes = 0;
+    let persisted = "";
+    const store = createSftpTransferCenterStore({
+      read: () => null,
+      write: (value) => {
+        writes += 1;
+        persisted = value;
+      },
+    });
+    store.publishOwner("panel-a", [scenario.task]);
+    assert.equal(writes, 1, `${scenario.name}: setup should write once`);
+
+    scenario.remove(store);
+
+    assert.equal(writes, 2, `${scenario.name}: deletion should flush immediately`);
+    const restored = createSftpTransferCenterStore({
+      read: () => persisted,
+      write: () => {},
+    });
+    assert.equal(restored.getSnapshot().tasks.length, 0, `${scenario.name}: deleted history must not return`);
+  }
+});
+
 test("orphaned unfinished tasks stay controllable so dead rows can be cancelled", () => {
   const store = createSftpTransferCenterStore();
   store.publishOwner("gone-panel", [

--- a/application/state/sftpTransferCenterStore.test.ts
+++ b/application/state/sftpTransferCenterStore.test.ts
@@ -1385,6 +1385,33 @@ test("clearing terminal history asks each owner to clean transfer artifacts", ()
   assert.deepEqual(store.getSnapshot().tasks.map((task) => task.id), ["failed"]);
 });
 
+test("history pruning passes removed task data to background cleanup after snapshot eviction", () => {
+  let removedTask: TransferTask | undefined;
+  const store = createSftpTransferCenterStore();
+  store.registerOwner("background-agent", {
+    pause: async () => {},
+    resume: async () => {},
+    cancel: async () => {},
+    retry: async () => {},
+    prioritize: async () => {},
+    dismiss: (_taskId: string, task?: TransferTask) => {
+      removedTask = task;
+    },
+  });
+  const now = Date.now();
+  store.publishOwner("background-agent", Array.from({ length: 201 }, (_, index) => ({
+    ...makeTask(`background-history-${index}`, "failed"),
+    startTime: now - index,
+    endTime: now - index,
+    stagedTargetPath: `/target/.background-history-${index}.part`,
+  })));
+
+  assert.equal(store.getSnapshot().tasks.length, 200);
+  assert.equal(removedTask?.id, "background-history-200");
+  assert.equal(removedTask?.stagedTargetPath, "/target/.background-history-200.part");
+  assert.equal(store.getSnapshot().tasks.some((task) => task.id === removedTask?.id), false);
+});
+
 test("failed reauthentication leaves a paused transfer requiring attention with the failure reason", async (t) => {
   const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
   t.after(() => {
@@ -2731,9 +2758,9 @@ test("completed directory history is pruned with one owner update and no reentra
       ownerTasks = ownerTasks.filter((task) => task.id !== id && task.parentTaskId !== id);
       republish();
     },
-    dismissMany(ids: readonly string[]) {
+    dismissMany(prunedTasks: readonly TransferTask[]) {
       batchDismisses += 1;
-      const removing = new Set(ids);
+      const removing = new Set(prunedTasks.map((task) => task.id));
       ownerTasks = ownerTasks.filter((task) => !removing.has(task.id) && !removing.has(task.parentTaskId ?? ""));
       republish();
     },

--- a/application/state/sftpTransferCenterStore.ts
+++ b/application/state/sftpTransferCenterStore.ts
@@ -44,9 +44,9 @@ export interface SftpTransferOwnerControls {
   cancel: (taskId: string) => void | Promise<void>;
   retry: (taskId: string) => void | Promise<void>;
   prioritize: (taskId: string) => void | Promise<void>;
-  dismiss: (taskId: string) => void;
+  dismiss: (taskId: string, task?: TransferTask) => void;
   /** Remove a pruned group in one owner update to avoid publish/dismiss feedback loops. */
-  dismissMany?: (taskIds: readonly string[]) => void;
+  dismissMany?: (tasks: readonly TransferTask[]) => void;
   /**
    * True when the panel still lists this task locally.
    * Used only for adopt/retry UX after hard reconnect — never for soft
@@ -407,20 +407,20 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
   };
   const notifyOwnersOfPrunedTasks = (removed: readonly TransferTask[]) => {
     if (removed.length === 0) return;
-    const byOwner = new Map<string, string[]>();
+    const byOwner = new Map<string, TransferTask[]>();
     for (const task of removed) {
       if (!task.ownerId) continue;
-      const ids = byOwner.get(task.ownerId) ?? [];
-      ids.push(task.id);
-      byOwner.set(task.ownerId, ids);
+      const ownerTasks = byOwner.get(task.ownerId) ?? [];
+      ownerTasks.push(task);
+      byOwner.set(task.ownerId, ownerTasks);
     }
-    for (const [ownerId, ids] of byOwner) {
+    for (const [ownerId, ownerTasks] of byOwner) {
       const controller = controllers.get(ownerId);
       if (!controller) continue;
       if (controller.dismissMany) {
-        controller.dismissMany(ids);
+        controller.dismissMany(ownerTasks);
       } else {
-        for (const id of ids) controller.dismiss(id);
+        for (const task of ownerTasks) controller.dismiss(task.id, task);
       }
     }
   };
@@ -1574,10 +1574,11 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
       await controller?.resolveConflict?.(taskId, action, applyToAll);
     },
     dismiss(taskId) {
-      const ownerId = findOwner(taskId);
+      const task = tasks.find((candidate) => candidate.id === taskId);
+      const ownerId = task?.ownerId;
       const controller = ownerId ? controllers.get(ownerId) : undefined;
       if (controller) {
-        controller.dismiss(taskId);
+        controller.dismiss(taskId, task);
       }
       tasks = tasks.filter((task) => task.id !== taskId && task.parentTaskId !== taskId);
       emit();

--- a/application/state/sftpTransferCenterStore.ts
+++ b/application/state/sftpTransferCenterStore.ts
@@ -11,6 +11,7 @@ import {
   pathConflictMessage,
 } from "../../domain/sftpTransferConflicts";
 import { STORAGE_KEY_SFTP_TRANSFER_CENTER } from "../../infrastructure/config/storageKeys";
+import { localStorageAdapter } from "../../infrastructure/persistence/localStorageAdapter";
 import { netcattyBridge } from "../../infrastructure/services/netcattyBridge";
 import { notify } from "../notification";
 import { globalSftpTransferScheduler } from "./sftp/globalTransferScheduler";
@@ -44,6 +45,8 @@ export interface SftpTransferOwnerControls {
   retry: (taskId: string) => void | Promise<void>;
   prioritize: (taskId: string) => void | Promise<void>;
   dismiss: (taskId: string) => void;
+  /** Remove a pruned group in one owner update to avoid publish/dismiss feedback loops. */
+  dismissMany?: (taskIds: readonly string[]) => void;
   /**
    * True when the panel still lists this task locally.
    * Used only for adopt/retry UX after hard reconnect — never for soft
@@ -305,12 +308,29 @@ export function mergeOwnerPublishedTask(
   return merged;
 }
 
+function areTransferTasksEquivalent(left: TransferTask, right: TransferTask): boolean {
+  const leftRecord = left as unknown as Record<string, unknown>;
+  const rightRecord = right as unknown as Record<string, unknown>;
+  const keys = new Set([...Object.keys(leftRecord), ...Object.keys(rightRecord)]);
+  for (const key of keys) {
+    // updatedAt is bookkeeping, not a visible or durable transfer change.
+    if (key === "updatedAt") continue;
+    if (!Object.is(leftRecord[key], rightRecord[key])) return false;
+  }
+  return true;
+}
+
 export function createSftpTransferCenterStore(persistence?: StorePersistence): SftpTransferCenterStore {
   const restored = deserializeSftpTransferCenter(persistence?.read() ?? null);
   let tasks = pruneSftpTransferHistory(restored.tasks);
   let snapshot = tasks.length > 0 ? buildSnapshot(tasks) : EMPTY_SNAPSHOT;
   const listeners = new Set<Listener>();
   const controllers = new Map<string, SftpTransferOwnerControls>();
+  const lastPublishedByOwner = new Map<string, ReadonlyMap<string, TransferTask>>();
+  const PERSIST_INTERVAL_MS = 250;
+  let lastPersistedAt = 0;
+  let persistenceDirty = false;
+  let persistenceTimer: ReturnType<typeof setTimeout> | null = null;
   const resumeInvocations = new Map<string, Promise<void>>();
   const resumePreparationFailures = new Map<string, string>();
   let dedicatedResumeHandler: DedicatedTransferResumeHandler | null = null;
@@ -352,21 +372,108 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
     dedicatedResumeWaiters.add(waiter);
   });
 
-  const persist = () => {
-    persistence?.write(serializeSftpTransferCenter(tasks));
+  const writePersistence = () => {
+    if (!persistence || !persistenceDirty) return;
+    persistenceDirty = false;
+    try {
+      persistence.write(serializeSftpTransferCenter(tasks));
+    } catch (error) {
+      // Transfer history is recoverability metadata. Storage exhaustion or a
+      // transient browser storage failure must never take down the renderer.
+      console.warn("[SFTP] Could not persist transfer history", error);
+    } finally {
+      // Measure the interval from completion, since stringify/setItem itself can
+      // be expensive for a large directory snapshot.
+      lastPersistedAt = Date.now();
+    }
   };
-  const emit = () => {
+  const persist = (immediate = false) => {
+    if (!persistence) return;
+    persistenceDirty = true;
+    const elapsed = Date.now() - lastPersistedAt;
+    if (immediate || lastPersistedAt === 0 || elapsed >= PERSIST_INTERVAL_MS) {
+      if (persistenceTimer) {
+        clearTimeout(persistenceTimer);
+        persistenceTimer = null;
+      }
+      writePersistence();
+      return;
+    }
+    if (persistenceTimer) return;
+    persistenceTimer = setTimeout(() => {
+      persistenceTimer = null;
+      writePersistence();
+    }, PERSIST_INTERVAL_MS - elapsed);
+  };
+  const notifyOwnersOfPrunedTasks = (removed: readonly TransferTask[]) => {
+    if (removed.length === 0) return;
+    const byOwner = new Map<string, string[]>();
+    for (const task of removed) {
+      if (!task.ownerId) continue;
+      const ids = byOwner.get(task.ownerId) ?? [];
+      ids.push(task.id);
+      byOwner.set(task.ownerId, ids);
+    }
+    for (const [ownerId, ids] of byOwner) {
+      const controller = controllers.get(ownerId);
+      if (!controller) continue;
+      if (controller.dismissMany) {
+        controller.dismissMany(ids);
+      } else {
+        for (const id of ids) controller.dismiss(id);
+      }
+    }
+  };
+  const hasCriticalPersistenceChange = (
+    previous: readonly TransferTask[],
+    next: readonly TransferTask[],
+  ) => {
+    const previousById = new Map(previous.map((task) => [task.id, task]));
+    for (const task of next) {
+      const before = previousById.get(task.id);
+      if (task.sourceFingerprint !== before?.sourceFingerprint) return true;
+      if (task.status === "paused" || task.status === "pausing") {
+        if (
+          task.status !== before?.status
+          || task.checkpointBytes !== before?.checkpointBytes
+          || task.resumeStage !== before?.resumeStage
+          || task.downloadCheckpointBytes !== before?.downloadCheckpointBytes
+          || task.uploadCheckpointBytes !== before?.uploadCheckpointBytes
+        ) return true;
+      }
+      if (
+        !task.parentTaskId
+        && task.status !== before?.status
+        && (task.status === "completed" || task.status === "failed" || task.status === "cancelled")
+      ) return true;
+    }
+    return false;
+  };
+  const emit = (persistImmediately = false) => {
+    const shouldPersistImmediately = persistImmediately
+      || hasCriticalPersistenceChange(snapshot.tasks, tasks);
     const beforePrune = tasks;
     tasks = pruneSftpTransferHistory(tasks);
     const retainedIds = new Set(tasks.map((task) => task.id));
-    for (const removed of beforePrune) {
-      if (retainedIds.has(removed.id)) continue;
-      controllers.get(removed.ownerId ?? "")?.dismiss(removed.id);
+    const removed = beforePrune.filter((task) => !retainedIds.has(task.id));
+    if (removed.length > 0) {
+      for (const [ownerId, published] of lastPublishedByOwner) {
+        if (published.size === 0) continue;
+        const retained = new Map(
+          [...published].filter(([taskId]) => retainedIds.has(taskId)),
+        );
+        if (retained.size === 0) lastPublishedByOwner.delete(ownerId);
+        else if (retained.size !== published.size) lastPublishedByOwner.set(ownerId, retained);
+      }
     }
     snapshot = buildSnapshot(tasks);
-    persist();
+    persist(shouldPersistImmediately);
     notifyDedicatedResumeWaiters();
     for (const listener of listeners) listener();
+    // Notify only after the store snapshot is final. Owners must remove the
+    // whole group atomically; per-row callbacks republish the remaining stale
+    // rows and recursively re-enter pruning for large completed directories.
+    notifyOwnersOfPrunedTasks(removed);
   };
   const findOwner = (taskId: string) => tasks.find((task) => task.id === taskId)?.ownerId;
   const findAdopter = (task: TransferTask) => [...controllers.entries()].find(([, controls]) => (
@@ -967,7 +1074,12 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
       return tasks.filter((task) => task.ownerId === ownerId).map((task) => ({ ...task }));
     },
     publishOwner(ownerId, ownerTasks) {
+      const previousTasks = tasks;
+      let changed = false;
+      let persistImmediately = false;
       const incoming = new Map(ownerTasks.map((task) => [task.id, task]));
+      const previousPublished = lastPublishedByOwner.get(ownerId);
+      lastPublishedByOwner.set(ownerId, incoming);
       const existingIds = new Set(tasks.map((task) => task.id));
       // Resolve parent status from the store first when runtime owns the walk
       // (panel is view-only for live lifecycle), else prefer the panel snapshot.
@@ -1006,8 +1118,14 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
           ) {
             return [task];
           }
+          changed = true;
           return [];
         }
+        // setTransfers keeps unchanged rows by reference. If this exact owner
+        // row was already published, the store may only be newer (for example
+        // from global progress), so leave it untouched without comparing every
+        // field of thousands of directory children.
+        if (previousPublished?.get(task.id) === replacement) return [task];
         let merged = mergeOwnerPublishedTask(
           task,
           replacement,
@@ -1037,6 +1155,22 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
             };
           }
         }
+        if (areTransferTasksEquivalent(task, merged)) return [task];
+        if (
+          merged.sourceFingerprint !== task.sourceFingerprint
+          || (
+            merged.status !== task.status
+            && (merged.status === "paused" || merged.status === "pausing")
+          )
+          || (
+            merged.status !== task.status
+            && !merged.parentTaskId
+            && (merged.status === "completed" || merged.status === "failed" || merged.status === "cancelled")
+          )
+        ) {
+          persistImmediately = true;
+        }
+        changed = true;
         return [merged];
       });
       for (const task of ownerTasks) {
@@ -1054,14 +1188,32 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
             seeded.speed = 0;
           }
           tasks.push(seeded);
+          if (
+            seeded.sourceFingerprint !== undefined
+            || seeded.status === "paused"
+            || seeded.status === "pausing"
+            || (!seeded.parentTaskId && (
+              seeded.status === "completed" || seeded.status === "failed" || seeded.status === "cancelled"
+            ))
+          ) {
+            persistImmediately = true;
+          }
+          changed = true;
         }
       }
-      emit();
+      if (!changed) {
+        tasks = previousTasks;
+        return;
+      }
+      emit(persistImmediately);
     },
     registerOwner(ownerId, controls) {
       controllers.set(ownerId, controls);
       return () => {
-        if (controllers.get(ownerId) === controls) controllers.delete(ownerId);
+        if (controllers.get(ownerId) === controls) {
+          controllers.delete(ownerId);
+          lastPublishedByOwner.delete(ownerId);
+        }
       };
     },
     setDedicatedResumeHandler(handler) {
@@ -1162,7 +1314,7 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
         }
         return merged;
       });
-      if (changed) emit();
+      if (changed) emit(updates.sourceFingerprint !== undefined);
     },
     upsertTasks(incoming) {
       if (incoming.length === 0) return;
@@ -1442,12 +1594,10 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
         && (status === undefined || task.status === status)
         && !(task.parentTaskId && unfinishedParents.has(task.parentTaskId)),
       );
-      for (const task of removing) {
-        controllers.get(task.ownerId ?? "")?.dismiss(task.id);
-      }
       const removingIds = new Set(removing.map((task) => task.id));
       tasks = tasks.filter((task) => !removingIds.has(task.id) && !removingIds.has(task.parentTaskId ?? ""));
       emit();
+      notifyOwnersOfPrunedTasks(removing);
     },
     markReconnectRequired(taskId, error) {
       tasks = tasks.map((task) => task.id === taskId ? {
@@ -1465,6 +1615,13 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
     },
     ingestBackgroundEvent(event) {
       const existing = tasks.find((task) => task.id === event.transferId);
+      const persistImmediately = event.type === "paused"
+        || event.type === "pausing"
+        || (
+          !existing?.parentTaskId
+          && (event.type === "completed" || event.type === "failed" || event.type === "cancelled")
+        )
+        || (event.sourceFingerprint !== undefined && event.sourceFingerprint !== existing?.sourceFingerprint);
       const terminal = existing
         && (existing.status === "cancelled" || existing.status === "completed" || existing.status === "failed");
       // Never resurrect a finished/cancelled agent row with late queued/progress.
@@ -1475,6 +1632,48 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
           return;
         }
         if (event.type === "queued" || event.type === "started" || event.type === "progress" || event.type === "pausing" || event.type === "resumed" || event.type === "paused") {
+          return;
+        }
+      }
+      if (existing && event.type === "progress") {
+        const parent = existing.parentTaskId
+          ? tasks.find((task) => task.id === existing.parentTaskId)
+          : undefined;
+        const pauseHeld = existing.status === "paused"
+          || existing.status === "pausing"
+          || parent?.status === "paused"
+          || parent?.status === "pausing"
+          || isTransferOrRootPauseLatched(existing.parentTaskId ?? existing.id, existing.id)
+          || isTransferPauseLatched(existing.id);
+        const lifecycleStatus = event.lifecycleState === "paused"
+          ? "paused"
+          : event.lifecycleState === "pausing"
+            ? "pausing"
+            : event.lifecycleState === "queued"
+              ? "queued"
+              : "transferring";
+        const sameLifecycle = event.lifecycleState === undefined
+          ? existing.status === "transferring"
+          : existing.status === lifecycleStatus;
+        const sameOptional = <T>(incoming: T | undefined, current: T | undefined) => (
+          incoming === undefined || incoming === current
+        );
+        if (
+          !pauseHeld
+          && sameLifecycle
+          && existing.error === undefined
+          && existing.endTime === undefined
+          && sameOptional(event.transferred, existing.transferredBytes)
+          && sameOptional(event.totalBytes, existing.totalBytes)
+          && sameOptional(event.speed, existing.speed)
+          && sameOptional(event.checkpointBytes, existing.checkpointBytes)
+          && sameOptional(event.resumeStage, existing.resumeStage)
+          && sameOptional(event.downloadCheckpointBytes, existing.downloadCheckpointBytes)
+          && sameOptional(event.uploadCheckpointBytes, existing.uploadCheckpointBytes)
+          && sameOptional(event.sourceFingerprint, existing.sourceFingerprint)
+          && sameOptional(event.phase, existing.phase)
+          && sameOptional(event.lifecycleEpoch, existing.lifecycleEpoch)
+        ) {
           return;
         }
       }
@@ -1667,7 +1866,7 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
           speed: 0,
         } : task);
       }
-      emit();
+      emit(persistImmediately);
     },
   };
 }
@@ -1676,7 +1875,7 @@ const browserPersistence: StorePersistence | undefined = typeof globalThis.local
   ? undefined
   : {
       read: () => globalThis.localStorage.getItem(STORAGE_KEY_SFTP_TRANSFER_CENTER),
-      write: (value) => globalThis.localStorage.setItem(STORAGE_KEY_SFTP_TRANSFER_CENTER, value),
+      write: (value) => { localStorageAdapter.writeString(STORAGE_KEY_SFTP_TRANSFER_CENTER, value); },
     };
 
 export const sftpTransferCenterStore = createSftpTransferCenterStore(browserPersistence);

--- a/application/state/sftpTransferCenterStore.ts
+++ b/application/state/sftpTransferCenterStore.ts
@@ -1119,6 +1119,7 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
             return [task];
           }
           changed = true;
+          persistImmediately = true;
           return [];
         }
         // setTransfers keeps unchanged rows by reference. If this exact owner
@@ -1581,7 +1582,7 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
         controller.dismiss(taskId, task);
       }
       tasks = tasks.filter((task) => task.id !== taskId && task.parentTaskId !== taskId);
-      emit();
+      emit(true);
     },
     clearTerminal(status) {
       const terminal = new Set<TransferTask["status"]>(["completed", "failed", "cancelled"]);
@@ -1597,7 +1598,7 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
       );
       const removingIds = new Set(removing.map((task) => task.id));
       tasks = tasks.filter((task) => !removingIds.has(task.id) && !removingIds.has(task.parentTaskId ?? ""));
-      emit();
+      emit(true);
       notifyOwnersOfPrunedTasks(removing);
     },
     markReconnectRequired(taskId, error) {


### PR DESCRIPTION
## Summary

Fix large SFTP folder uploads that drove renderer CPU high and could leave the main window blank when the parent task completed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2514

## Changes Made

- Batch completed child-history eviction so folder completion no longer creates a recursive dismiss/publish loop.
- Coalesce high-frequency transfer-history persistence and contain browser storage exhaustion.
- Ignore duplicate progress delivered through the owner and global event paths.
- Keep pause checkpoints, source fingerprints, and top-level terminal state durable immediately.
- Clean failed/cancelled transfer artifacts sequentially without flooding IPC.

## Screenshots / Demo

Behavior-only fix. A 2,391-file completion stress run now performs one batch cleanup, two storage writes, retains 200 history rows, and completes the final store transition in about 3 ms on the test machine.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Additional verification:
- SFTP-focused suite: 348/348 passed
- Transfer-center suite: 73/73 passed
- Production build passed (`npm run build`)
- Two independent final review passes: CLEAN

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)