### PR TITLE
fix(sftp): 避免 SSH 打开 SFTP 时重复二次认证

### DIFF
--- a/application/state/sftp/useSftpTransferLifecycle.test.ts
+++ b/application/state/sftp/useSftpTransferLifecycle.test.ts
@@ -1,5 +1,5 @@
-// 创建时间: 2026-07-27
-// 功能说明: 验证 SFTP 传输连接池预热策略，避免后台触发二次认证。
+// Created: 2026-07-27
+// Purpose: Verify SFTP transfer pool warmup policy avoids background MFA prompts.
 
 import assert from "node:assert/strict";
 import test from "node:test";

--- a/application/state/sftp/useSftpTransferLifecycle.test.ts
+++ b/application/state/sftp/useSftpTransferLifecycle.test.ts
@@ -1,0 +1,28 @@
+// 创建时间: 2026-07-27
+// 功能说明: 验证 SFTP 传输连接池预热策略，避免后台触发二次认证。
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getWarmSftpTransferPoolHostIds } from "./useSftpTransferLifecycle.ts";
+
+test("transfer pool warmup is disabled by default to avoid background MFA prompts", () => {
+  assert.deepEqual(
+    getWarmSftpTransferPoolHostIds({
+      hostIds: ["host-b", "host-a"],
+      activeHostId: "host-c",
+    }),
+    [],
+  );
+});
+
+test("transfer pool warmup deduplicates hosts when explicitly enabled", () => {
+  assert.deepEqual(
+    getWarmSftpTransferPoolHostIds({
+      hostIds: ["host-b", "host-a", "host-b"],
+      activeHostId: "host-a",
+      enabled: true,
+    }),
+    ["host-a", "host-b"],
+  );
+});

--- a/application/state/sftp/useSftpTransferLifecycle.ts
+++ b/application/state/sftp/useSftpTransferLifecycle.ts
@@ -5,20 +5,37 @@ import { sftpTransferCenterStore } from "../sftpTransferCenterStore";
 export function useWarmSftpTransferPool(params: {
   hostIds: readonly string[];
   activeHostId?: string;
+  enabled?: boolean;
   warmTransferPoolForHost?: (hostId: string) => void | Promise<void>;
 }) {
   const warmRef = useRef(params.warmTransferPoolForHost);
   warmRef.current = params.warmTransferPoolForHost;
-  const hostIdsKey = [...new Set([
-    ...params.hostIds,
-    ...(params.activeHostId ? [params.activeHostId] : []),
-  ])].sort().join("\u0000");
+  const hostIdsKey = getWarmSftpTransferPoolHostIds(params).join("\u0000");
 
   useEffect(() => {
     for (const hostId of hostIdsKey.split("\u0000").filter(Boolean)) {
       void warmRef.current?.(hostId);
     }
   }, [hostIdsKey]);
+}
+
+/**
+ * Resolve the hosts that may be pre-warmed for transfer-pool usage.
+ *
+ * The default is intentionally off: opening a terminal SFTP browser should not
+ * start a background SSH/SFTP authentication flow, because MFA-backed hosts can
+ * show an unexpected secondary-password prompt before any transfer begins.
+ */
+export function getWarmSftpTransferPoolHostIds(params: {
+  hostIds: readonly string[];
+  activeHostId?: string;
+  enabled?: boolean;
+}): string[] {
+  if (!params.enabled) return [];
+  return [...new Set([
+    ...params.hostIds,
+    ...(params.activeHostId ? [params.activeHostId] : []),
+  ])].sort();
 }
 
 export function useReportSftpTransferOwnerActivity(params: {

--- a/application/state/terminalConnectionReuse.test.ts
+++ b/application/state/terminalConnectionReuse.test.ts
@@ -35,7 +35,42 @@ test("non-SSH or unavailable sessions do not reuse a connection", () => {
   assert.equal(canReuseTerminalConnection(session({ etEnabled: true })), false);
 });
 
-test("SFTP source session survives the connected-status render race", () => {
+test("SFTP reuse prefers the focused session over a remembered source", () => {
+  const rememberedSession = session({ id: "remembered-session" });
+  const focusedSession = session({ id: "focused-session" });
+  const sourceSessionId = resolveReusableTerminalSessionIdForSftp({
+    activeSessionId: focusedSession.id,
+    preferredSourceSessionId: rememberedSession.id,
+    sftpActiveHost: {
+      hostname: focusedSession.hostname,
+      port: focusedSession.port,
+      username: focusedSession.username,
+    },
+    sessions: [rememberedSession, focusedSession],
+    sessionHostsMap: new Map([
+      [
+        rememberedSession.id,
+        {
+          hostname: rememberedSession.hostname,
+          port: rememberedSession.port,
+          username: rememberedSession.username,
+        },
+      ],
+      [
+        focusedSession.id,
+        {
+          hostname: focusedSession.hostname,
+          port: focusedSession.port,
+          username: focusedSession.username,
+        },
+      ],
+    ]),
+  });
+
+  assert.equal(sourceSessionId, focusedSession.id);
+});
+
+test("SFTP reuse rejects a preferred session that is still connecting", () => {
   const pendingRenderSession = session({ status: "connecting" });
   const sourceSessionId = resolveReusableTerminalSessionIdForSftp({
     activeSessionId: pendingRenderSession.id,
@@ -58,7 +93,7 @@ test("SFTP source session survives the connected-status render race", () => {
     ]),
   });
 
-  assert.equal(sourceSessionId, pendingRenderSession.id);
+  assert.equal(sourceSessionId, null);
 });
 
 test("split session clones reuse only connected SSH sources", () => {

--- a/application/state/terminalConnectionReuse.test.ts
+++ b/application/state/terminalConnectionReuse.test.ts
@@ -6,6 +6,7 @@ import {
   canReuseTerminalConnection,
   createCopiedTerminalSessionClone,
   createSplitTerminalSessionClone,
+  resolveReusableTerminalSessionIdForSftp,
 } from "./terminalConnectionReuse";
 
 const session = (overrides: Partial<TerminalSession> = {}): TerminalSession => ({
@@ -32,6 +33,32 @@ test("non-SSH or unavailable sessions do not reuse a connection", () => {
   assert.equal(canReuseTerminalConnection(session({ protocol: "telnet" })), false);
   assert.equal(canReuseTerminalConnection(session({ moshEnabled: true })), false);
   assert.equal(canReuseTerminalConnection(session({ etEnabled: true })), false);
+});
+
+test("SFTP source session survives the connected-status render race", () => {
+  const pendingRenderSession = session({ status: "connecting" });
+  const sourceSessionId = resolveReusableTerminalSessionIdForSftp({
+    activeSessionId: pendingRenderSession.id,
+    preferredSourceSessionId: pendingRenderSession.id,
+    sftpActiveHost: {
+      hostname: pendingRenderSession.hostname,
+      port: pendingRenderSession.port,
+      username: pendingRenderSession.username,
+    },
+    sessions: [pendingRenderSession],
+    sessionHostsMap: new Map([
+      [
+        pendingRenderSession.id,
+        {
+          hostname: pendingRenderSession.hostname,
+          port: pendingRenderSession.port,
+          username: pendingRenderSession.username,
+        },
+      ],
+    ]),
+  });
+
+  assert.equal(sourceSessionId, pendingRenderSession.id);
 });
 
 test("split session clones reuse only connected SSH sources", () => {

--- a/application/state/terminalConnectionReuse.ts
+++ b/application/state/terminalConnectionReuse.ts
@@ -1,4 +1,14 @@
-import type { TerminalSession } from "../../domain/models";
+import type { Host, TerminalSession } from "../../domain/models";
+
+type SftpReuseEndpoint = Pick<Host, "hostname" | "port" | "username">;
+
+type ResolveReusableTerminalSessionIdForSftpOptions = {
+  activeSessionId?: string | null;
+  preferredSourceSessionId?: string | null;
+  sftpActiveHost: SftpReuseEndpoint | null;
+  sessions: TerminalSession[];
+  sessionHostsMap: Map<string, SftpReuseEndpoint>;
+};
 
 export function canReuseTerminalConnection(session: TerminalSession): boolean {
   return (
@@ -7,6 +17,62 @@ export function canReuseTerminalConnection(session: TerminalSession): boolean {
     !session.etEnabled &&
     session.status === "connected"
   );
+}
+
+// Matches the SSH endpoint identity used by SFTP reuse without requiring host ids
+// to match; session-time overrides can point at the same live SSH connection.
+function sameSftpReuseEndpoint(a: SftpReuseEndpoint, b: SftpReuseEndpoint): boolean {
+  return a.hostname === b.hostname
+    && (a.port || 22) === (b.port || 22)
+    && (a.username || "root") === (b.username || "root");
+}
+
+// Allows the connected-status event to beat React session-state propagation while
+// still rejecting protocols that the backend cannot share with SFTP.
+function canReusePendingTerminalConnection(session: TerminalSession): boolean {
+  return (
+    (session.protocol === "ssh" || session.protocol === undefined) &&
+    !session.moshEnabled &&
+    !session.etEnabled &&
+    session.status === "connecting"
+  );
+}
+
+// Resolves the terminal session SFTP should try to reuse, preferring the session
+// that opened the panel so automatic SFTP opens do not lose MFA state on render races.
+export function resolveReusableTerminalSessionIdForSftp({
+  activeSessionId,
+  preferredSourceSessionId,
+  sftpActiveHost,
+  sessions,
+  sessionHostsMap,
+}: ResolveReusableTerminalSessionIdForSftpOptions): string | null {
+  if (!sftpActiveHost) return null;
+
+  const candidateIds = Array.from(new Set([
+    preferredSourceSessionId ?? null,
+    activeSessionId ?? null,
+  ].filter((id): id is string => !!id)));
+
+  for (const candidateId of candidateIds) {
+    const session = sessions.find((candidate) => candidate.id === candidateId);
+    if (!session) continue;
+    const isPreferredSource = candidateId === preferredSourceSessionId;
+    if (
+      !canReuseTerminalConnection(session)
+      && !(isPreferredSource && canReusePendingTerminalConnection(session))
+    ) {
+      continue;
+    }
+    const sessionEndpoint = sessionHostsMap.get(session.id) ?? {
+      hostname: session.hostname,
+      port: session.port,
+      username: session.username,
+    };
+    if (sameSftpReuseEndpoint(sessionEndpoint, sftpActiveHost)) return session.id;
+  }
+
+  return null;
 }
 
 type CloneSessionOptions = {

--- a/application/state/terminalConnectionReuse.ts
+++ b/application/state/terminalConnectionReuse.ts
@@ -27,19 +27,9 @@ function sameSftpReuseEndpoint(a: SftpReuseEndpoint, b: SftpReuseEndpoint): bool
     && (a.username || "root") === (b.username || "root");
 }
 
-// Allows the connected-status event to beat React session-state propagation while
-// still rejecting protocols that the backend cannot share with SFTP.
-function canReusePendingTerminalConnection(session: TerminalSession): boolean {
-  return (
-    (session.protocol === "ssh" || session.protocol === undefined) &&
-    !session.moshEnabled &&
-    !session.etEnabled &&
-    session.status === "connecting"
-  );
-}
-
-// Resolves the terminal session SFTP should try to reuse, preferring the session
-// that opened the panel so automatic SFTP opens do not lose MFA state on render races.
+// Resolves the terminal session SFTP should try to reuse. The focused session
+// wins once React has published it; remembered sources only cover the first
+// render before the live side-panel snapshot catches up.
 export function resolveReusableTerminalSessionIdForSftp({
   activeSessionId,
   preferredSourceSessionId,
@@ -50,20 +40,14 @@ export function resolveReusableTerminalSessionIdForSftp({
   if (!sftpActiveHost) return null;
 
   const candidateIds = Array.from(new Set([
-    preferredSourceSessionId ?? null,
     activeSessionId ?? null,
+    preferredSourceSessionId ?? null,
   ].filter((id): id is string => !!id)));
 
   for (const candidateId of candidateIds) {
     const session = sessions.find((candidate) => candidate.id === candidateId);
     if (!session) continue;
-    const isPreferredSource = candidateId === preferredSourceSessionId;
-    if (
-      !canReuseTerminalConnection(session)
-      && !(isPreferredSource && canReusePendingTerminalConnection(session))
-    ) {
-      continue;
-    }
+    if (!canReuseTerminalConnection(session)) continue;
     const sessionEndpoint = sessionHostsMap.get(session.id) ?? {
       hostname: session.hostname,
       port: session.port,

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -466,6 +466,11 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
         next.set(tabId, hostWithOverrides);
         return next;
       });
+      setSftpSourceSessionIdForTab(prev => {
+        const next = new Map(prev);
+        next.set(tabId, sessionId);
+        return next;
+      });
     } else if (targetPanel === 'ai') {
       setAiMountedTabIds((prev) => addMountedSidePanelTabId(prev, tabId));
     } else if (targetPanel === 'scripts') {
@@ -605,6 +610,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const [sftpPendingUploadsForTab, setSftpPendingUploadsForTab] = useState<
     Map<string, PendingSftpUpload>
   >(new Map());
+  const [sftpSourceSessionIdForTab, setSftpSourceSessionIdForTab] = useState<Map<string, string>>(new Map());
   const [pendingTerminalSelectionForAI, setPendingTerminalSelectionForAI] =
     useState<PendingTerminalSelectionForAI | null>(null);
   const [notesOpenNoteByTab, setNotesOpenNoteByTab] = useState<Map<string, { noteId: string; requestId: number }>>(new Map());
@@ -661,6 +667,12 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       return next;
     });
     setSftpInitialLocationForTab(prev => {
+      if (!prev.has(tabId)) return prev;
+      const next = new Map(prev);
+      next.delete(tabId);
+      return next;
+    });
+    setSftpSourceSessionIdForTab(prev => {
       if (!prev.has(tabId)) return prev;
       const next = new Map(prev);
       next.delete(tabId);
@@ -794,6 +806,18 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
         next.delete(tabId);
       } else {
         next.set(tabId, host);
+      }
+      return next;
+    });
+
+    setSftpSourceSessionIdForTab(prev => {
+      const next = new Map(prev);
+      if (isClosing && !keepSftpMounted) {
+        next.delete(tabId);
+      } else if (sourceSessionId) {
+        next.set(tabId, sourceSessionId);
+      } else {
+        next.delete(tabId);
       }
       return next;
     });
@@ -1310,6 +1334,15 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
         const next = new Map(prev);
         if (effectiveInitialPath) {
           next.set(tabId, { hostId: host.id, path: effectiveInitialPath });
+        } else {
+          next.delete(tabId);
+        }
+        return next;
+      });
+      setSftpSourceSessionIdForTab(prev => {
+        const next = new Map(prev);
+        if (sourceSessionId) {
+          next.set(tabId, sourceSessionId);
         } else {
           next.delete(tabId);
         }
@@ -1954,6 +1987,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     sftpHostForTab,
     sftpInitialLocationForTab,
     sftpPendingUploadsForTab,
+    sftpSourceSessionIdForTab,
     sftpShowHiddenFiles,
     SftpSidePanel,
     sftpUseCompressedUpload,

--- a/components/terminalLayer/TerminalLayerSidePanelSection.test.ts
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.test.ts
@@ -110,6 +110,14 @@ test('system monitoring only pauses for hidden remote tabs when hibernation is e
   assert.match(source, /isVisible=\{keepSystemWorkActive\}/);
 });
 
+test('SFTP side panel uses remembered source session before live state catches up', () => {
+  const source = readFileSync(new URL('./terminalLayerSidePanelSlots.tsx', import.meta.url), 'utf8');
+
+  assert.match(source, /const rememberedSourceSessionId = sftpSourceSessionIdForTab\.get\(tabId\) \?\? null/);
+  assert.match(source, /const panelActiveSessionId = isVisible\s*\?\s*\(live\.activeTerminalSessionIdForSftp \?\? rememberedSourceSessionId\)\s*:\s*null/);
+  assert.match(source, /activeSessionId=\{panelActiveSessionId\}/);
+});
+
 test('side panel tab bar and borders use inline resolved terminal theme colors', () => {
   const sectionSource = readFileSync(new URL('./TerminalLayerSidePanelSection.tsx', import.meta.url), 'utf8');
 

--- a/components/terminalLayer/TerminalLayerSidePanelSection.test.ts
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.test.ts
@@ -114,7 +114,9 @@ test('SFTP side panel uses remembered source session before live state catches u
   const source = readFileSync(new URL('./terminalLayerSidePanelSlots.tsx', import.meta.url), 'utf8');
 
   assert.match(source, /const rememberedSourceSessionId = sftpSourceSessionIdForTab\.get\(tabId\) \?\? null/);
-  assert.match(source, /const panelActiveSessionId = isVisible\s*\?\s*\(live\.activeTerminalSessionIdForSftp \?\? rememberedSourceSessionId\)\s*:\s*null/);
+  assert.match(source, /const shouldUseRememberedSourceSession = isVisible[\s\S]*!live\.focusedSessionId[\s\S]*!live\.activeTerminalSessionIdForSftp/);
+  assert.match(source, /const shouldDeferForPendingFocusedSession = isVisible[\s\S]*focusedSftpSession\?\.status === 'connecting'/);
+  assert.match(source, /live\.activeTerminalSessionIdForSftp \?\? \(shouldUseRememberedSourceSession \? rememberedSourceSessionId : null\)/);
   assert.match(source, /activeSessionId=\{panelActiveSessionId\}/);
 });
 

--- a/components/terminalLayer/TerminalLayerTabBridge.test.ts
+++ b/components/terminalLayer/TerminalLayerTabBridge.test.ts
@@ -32,7 +32,7 @@ test('terminal layer bridge passes vault open callbacks into the side panel cont
   assert.match(source, /onOpenVaultSectionFromChat: s\.onOpenVaultSectionFromChat/);
 });
 
-test('terminal layer bridge prefers the remembered SFTP source session', () => {
+test('terminal layer bridge passes the remembered SFTP source session', () => {
   assert.match(source, /const sftpSourceSessionIdForTab = s\.sftpSourceSessionIdForTab/);
   assert.match(source, /preferredSourceSessionId: activeTabId \? sftpSourceSessionIdForTab\.get\(activeTabId\) \?\? null : null/);
 });

--- a/components/terminalLayer/TerminalLayerTabBridge.test.ts
+++ b/components/terminalLayer/TerminalLayerTabBridge.test.ts
@@ -32,6 +32,11 @@ test('terminal layer bridge passes vault open callbacks into the side panel cont
   assert.match(source, /onOpenVaultSectionFromChat: s\.onOpenVaultSectionFromChat/);
 });
 
+test('terminal layer bridge prefers the remembered SFTP source session', () => {
+  assert.match(source, /const sftpSourceSessionIdForTab = s\.sftpSourceSessionIdForTab/);
+  assert.match(source, /preferredSourceSessionId: activeTabId \? sftpSourceSessionIdForTab\.get\(activeTabId\) \?\? null : null/);
+});
+
 test('terminal layer bridge updates side panel live state after render', () => {
   assert.match(source, /const sidePanelLiveSnapshot = useMemo<SidePanelLiveSnapshot>/);
   assert.match(

--- a/components/terminalLayer/TerminalLayerTabBridge.tsx
+++ b/components/terminalLayer/TerminalLayerTabBridge.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 
 import { useActiveTabId } from '../../application/state/activeTabStore';
 import { sessionCapabilitiesStore } from '../../application/state/sessionCapabilitiesStore';
 import { useSystemManagerBackend } from '../../application/state/useSystemManagerBackend';
-import { canReuseTerminalConnection } from '../../application/state/terminalConnectionReuse';
+import { resolveReusableTerminalSessionIdForSftp } from '../../application/state/terminalConnectionReuse';
 import { resolveSystemSidebarSession } from '../../domain/systemManager/resolveSystemSession';
 import type { TerminalContextReader } from '../../domain/terminalContextRead';
 import { useSystemCapabilitiesWarmup } from '../systemManager/hooks/useSystemManager';
@@ -35,6 +35,7 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
   const sessions = s.sessions as TerminalSession[];
   const sessionHostsMap = s.sessionHostsMap as Map<string, Host>;
   const sftpHostForTab = s.sftpHostForTab as Map<string, Host>;
+  const sftpSourceSessionIdForTab = s.sftpSourceSessionIdForTab as Map<string, string>;
   const sidePanelOpenTabs = s.sidePanelOpenTabs as Map<string, SidePanelTab>;
   const showHostTreeSidebar = s.showHostTreeSidebar as boolean | undefined;
 
@@ -127,18 +128,14 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
 
   const activeTerminalSessionIdForSftp = useMemo((): string | null => {
     if (!isSftpOpenForCurrentTab || !sftpActiveHost) return null;
-    const sessionId = activeWorkspace ? focusedSessionId : activeSession?.id;
-    if (!sessionId) return null;
-    const session = sessions.find((candidate) => candidate.id === sessionId);
-    if (!session || !canReuseTerminalConnection(session)) return null;
-    const sessionHost = sessionHostsMap.get(session.id);
-    if (!sessionHost) return null;
-    const sameEndpoint =
-      sessionHost.hostname === sftpActiveHost.hostname
-      && (sessionHost.port || 22) === (sftpActiveHost.port || 22)
-      && (sessionHost.username || 'root') === (sftpActiveHost.username || 'root');
-    return sameEndpoint ? session.id : null;
-  }, [activeSession?.id, activeWorkspace, focusedSessionId, isSftpOpenForCurrentTab, sessions, sessionHostsMap, sftpActiveHost]);
+    return resolveReusableTerminalSessionIdForSftp({
+      activeSessionId: activeWorkspace ? focusedSessionId : activeSession?.id,
+      preferredSourceSessionId: activeTabId ? sftpSourceSessionIdForTab.get(activeTabId) ?? null : null,
+      sftpActiveHost,
+      sessions,
+      sessionHostsMap,
+    });
+  }, [activeSession?.id, activeTabId, activeWorkspace, focusedSessionId, isSftpOpenForCurrentTab, sessions, sessionHostsMap, sftpActiveHost, sftpSourceSessionIdForTab]);
 
   const linkedTerminalSessionIdForSftp = useMemo((): string | null => {
     if (!isSftpOpenForCurrentTab) return null;
@@ -561,6 +558,7 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     sftpFollowTerminalCwd: s.sftpFollowTerminalCwd,
     sftpInitialLocationForTab: s.sftpInitialLocationForTab,
     sftpPendingUploadsForTab: s.sftpPendingUploadsForTab,
+    sftpSourceSessionIdForTab,
     sftpShowHiddenFiles: s.sftpShowHiddenFiles,
     SftpSidePanel: s.SftpSidePanel,
     sftpUseCompressedUpload: s.sftpUseCompressedUpload,
@@ -635,6 +633,7 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     s.terminalSettings,
     showHostTreeSidebar,
     sftpActiveHost,
+    sftpSourceSessionIdForTab,
     s.sftpFollowTerminalCwd,
     themeState,
     workspaceById,

--- a/components/terminalLayer/terminalLayerSidePanelSlots.tsx
+++ b/components/terminalLayer/terminalLayerSidePanelSlots.tsx
@@ -61,6 +61,7 @@ function SidePanelSftpSlotInner({
     handleAddKnownHost,
     sftpDefaultViewMode,
     sftpHostForTab,
+    sftpSourceSessionIdForTab,
     sftpInitialLocationForTab,
     sftpPendingUploadsForTab,
     handleSftpInitialLocationApplied,
@@ -86,6 +87,10 @@ function SidePanelSftpSlotInner({
   const panelActiveHost = isVisible
     ? (live.sftpActiveHost ?? storedSftpHost)
     : storedSftpHost;
+  const rememberedSourceSessionId = sftpSourceSessionIdForTab.get(tabId) ?? null;
+  const panelActiveSessionId = isVisible
+    ? (live.activeTerminalSessionIdForSftp ?? rememberedSourceSessionId)
+    : null;
 
   const handleFollowTerminalCwdChange = useCallback((enabled: boolean, visibleHost?: Host | null) => {
     const isActive = activeTabStore.getActiveTabId() === tabId;
@@ -129,13 +134,13 @@ function SidePanelSftpSlotInner({
       handleSftpCurrentPathChange(
         getSftpCurrentPathMemoryKey({
           tabId,
-          activeTerminalSessionIdForSftp: live.activeTerminalSessionIdForSftp,
+          activeTerminalSessionIdForSftp: panelActiveSessionId,
           focusedSessionId: live.focusedSessionId,
         }),
         location,
       );
     },
-    [handleSftpCurrentPathChange, live.activeTerminalSessionIdForSftp, live.focusedSessionId, tabId],
+    [handleSftpCurrentPathChange, live.focusedSessionId, panelActiveSessionId, tabId],
   );
 
   const handleActiveTransfersChange = useCallback(
@@ -159,7 +164,7 @@ function SidePanelSftpSlotInner({
         onAddKnownHost={handleAddKnownHost}
         sftpDefaultViewMode={sftpDefaultViewMode}
         activeHost={panelActiveHost}
-        activeSessionId={isVisible ? live.activeTerminalSessionIdForSftp : null}
+        activeSessionId={panelActiveSessionId}
         initialLocation={isVisible ? (sftpInitialLocationForTab.get(tabId) ?? null) : null}
         onInitialLocationApplied={handleInitialLocationApplied}
         onCurrentPathChange={handleCurrentPathChange}

--- a/components/terminalLayer/terminalLayerSidePanelSlots.tsx
+++ b/components/terminalLayer/terminalLayerSidePanelSlots.tsx
@@ -84,12 +84,23 @@ function SidePanelSftpSlotInner({
   } = ctx;
 
   const storedSftpHost = sftpHostForTab.get(tabId) ?? null;
-  const panelActiveHost = isVisible
-    ? (live.sftpActiveHost ?? storedSftpHost)
-    : storedSftpHost;
   const rememberedSourceSessionId = sftpSourceSessionIdForTab.get(tabId) ?? null;
+  const focusedSftpSession = rememberedSourceSessionId && live.focusedSessionId
+    ? (sessions as TerminalSession[]).find((session) => session.id === live.focusedSessionId) ?? null
+    : null;
+  const shouldDeferForPendingFocusedSession = isVisible
+    && !!rememberedSourceSessionId
+    && !live.activeTerminalSessionIdForSftp
+    && focusedSftpSession?.status === 'connecting';
+  const shouldUseRememberedSourceSession = isVisible
+    && !!rememberedSourceSessionId
+    && !live.focusedSessionId
+    && !live.activeTerminalSessionIdForSftp;
+  const panelActiveHost = isVisible
+    ? (shouldDeferForPendingFocusedSession ? null : (live.sftpActiveHost ?? storedSftpHost))
+    : storedSftpHost;
   const panelActiveSessionId = isVisible
-    ? (live.activeTerminalSessionIdForSftp ?? rememberedSourceSessionId)
+    ? (live.activeTerminalSessionIdForSftp ?? (shouldUseRememberedSourceSession ? rememberedSourceSessionId : null))
     : null;
 
   const handleFollowTerminalCwdChange = useCallback((enabled: boolean, visibleHost?: Host | null) => {

--- a/components/terminalLayer/terminalLayerViewMemo.test.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.test.ts
@@ -237,6 +237,25 @@ test("terminal layer side panel stable ctx re-renders when session transport fla
   );
 });
 
+test("terminal layer side panel stable ctx re-renders when remembered SFTP source changes", () => {
+  const baseCtx = {
+    mountedSftpTabIds: ["workspace-1"],
+    sidePanelOpenTabs: new Map([["workspace-1", "sftp"]]),
+    sftpSourceSessionIdForTab: new Map([["workspace-1", "session-1"]]),
+  };
+
+  assert.equal(
+    terminalLayerSidePanelStableCtxEqual(
+      baseCtx,
+      {
+        ...baseCtx,
+        sftpSourceSessionIdForTab: new Map([["workspace-1", "session-2"]]),
+      },
+    ),
+    false,
+  );
+});
+
 test("terminal layer side panel re-renders when linked terminal cwd changes", () => {
   const baseCtx = {
     mountedSftpTabIds: ["workspace-1"],

--- a/components/terminalLayer/terminalLayerViewMemo.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.ts
@@ -228,6 +228,7 @@ const SIDE_PANEL_STABLE_CTX_KEYS = [
   'sftpDefaultViewMode',
   'sftpInitialLocationForTab',
   'sftpPendingUploadsForTab',
+  'sftpSourceSessionIdForTab',
   'handleSftpCurrentPathChange',
   'sftpDoubleClickBehavior',
   'sftpAutoSync',


### PR DESCRIPTION
## 背景

用户在 1.1.73 中仍能复现：SSH 已经完成 EDR/MFA 二次认证后，打开或自动打开 SFTP 仍会额外弹出二次认证。

排查后确认，浏览侧栏本身已经走 `openSftpForSession` 复用当前 SSH session；额外弹窗来自 SFTP transfer pool 的后台预热，它会在打开 SFTP 浏览器时提前建立 dedicated SFTP 连接，从而绕过当前 SSH session 并重新触发认证。

## 修改

- 记录终端侧栏 SFTP 的来源 SSH session，并在 live state 尚未刷新时优先使用 remembered source session，避免自动打开竞态丢失复用来源。
- 默认关闭 SFTP transfer pool 预热，避免仅浏览 SFTP 时后台新建 dedicated SSH/SFTP 连接触发 MFA；真正上传/下载时仍按需建立 dedicated 连接，保证功能可用。
- 增加回归测试覆盖 session 记忆、侧栏 stable ctx、transfer pool warmup 默认关闭等场景。

## 验证

- `node --test --import tsx application/state/sftp/useSftpTransferLifecycle.test.ts application/state/sftp/openTransferSftpSession.dedicated.test.ts application/state/sftp/useSftpConnections.test.ts application/state/terminalConnectionReuse.test.ts components/sftp/sftpSidePanelAutoConnect.test.ts components/terminalLayer/TerminalLayerTabBridge.test.ts components/terminalLayer/TerminalLayerSidePanelSection.test.ts components/terminalLayer/terminalLayerViewMemo.test.ts`：62 pass
- `npx eslint application/state/sftp/useSftpTransferLifecycle.ts application/state/sftp/useSftpTransferLifecycle.test.ts application/state/terminalConnectionReuse.ts application/state/terminalConnectionReuse.test.ts components/TerminalLayer.tsx components/terminalLayer/TerminalLayerTabBridge.tsx components/terminalLayer/TerminalLayerTabBridge.test.ts components/terminalLayer/terminalLayerSidePanelSlots.tsx components/terminalLayer/TerminalLayerSidePanelSection.test.ts components/terminalLayer/terminalLayerViewMemo.ts components/terminalLayer/terminalLayerViewMemo.test.ts --quiet`
- `git diff --check`
- 本地真实环境复测：用户确认 SSH 打开 SFTP 不再重复弹二次认证。

关联：#2150