### PR TITLE
fix(ci): correct Cursor sandbox command parsing

### DIFF
--- a/.github/workflows/cursor-automation.yml
+++ b/.github/workflows/cursor-automation.yml
@@ -535,9 +535,9 @@ jobs:
               configPath: process.env.HOME + "/.cursor/cli-config.json",
             });
           '
-          agent sandbox run -- bash -c 'touch .cursor-runtime/sandbox-check'
+          agent sandbox run -- touch .cursor-runtime/sandbox-check
           test -f .cursor-runtime/sandbox-check
-          if agent sandbox run -- bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
+          if agent sandbox run -- curl -fsS --max-time 3 -o /dev/null https://example.com; then
             echo "Cursor command sandbox unexpectedly allowed network access." >&2
             exit 1
           fi
@@ -889,9 +889,9 @@ jobs:
               denyWeb: true,
             });
           '
-          agent sandbox run -- bash -c 'touch .cursor-runtime/sandbox-smoke'
+          agent sandbox run -- touch .cursor-runtime/sandbox-smoke
           test -f .cursor-runtime/sandbox-smoke
-          if agent sandbox run -- bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
+          if agent sandbox run -- curl -fsS --max-time 3 -o /dev/null https://example.com; then
             echo "Cursor sandbox unexpectedly allowed network access." >&2
             exit 1
           fi
@@ -1132,9 +1132,9 @@ jobs:
               configPath: process.env.HOME + "/.cursor/cli-config.json",
             });
           '
-          agent sandbox run -- bash -c 'touch .cursor-runtime/followup-sandbox-check'
+          agent sandbox run -- touch .cursor-runtime/followup-sandbox-check
           test -f .cursor-runtime/followup-sandbox-check
-          if agent sandbox run -- bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
+          if agent sandbox run -- curl -fsS --max-time 3 -o /dev/null https://example.com; then
             echo "Cursor command sandbox unexpectedly allowed network access." >&2
             exit 1
           fi
@@ -2380,9 +2380,9 @@ jobs:
               denyWeb: true,
             });
           '
-          agent sandbox run -- bash -c 'touch .cursor-runtime/implement-sandbox-check'
+          agent sandbox run -- touch .cursor-runtime/implement-sandbox-check
           test -f .cursor-runtime/implement-sandbox-check
-          if agent sandbox run -- bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
+          if agent sandbox run -- curl -fsS --max-time 3 -o /dev/null https://example.com; then
             echo "Cursor command sandbox unexpectedly allowed network access." >&2
             exit 1
           fi
@@ -3656,9 +3656,9 @@ jobs:
               denyWeb: true,
             });
           '
-          agent sandbox run -- bash -c 'touch .cursor-runtime/fix-sandbox-check'
+          agent sandbox run -- touch .cursor-runtime/fix-sandbox-check
           test -f .cursor-runtime/fix-sandbox-check
-          if agent sandbox run -- bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
+          if agent sandbox run -- curl -fsS --max-time 3 -o /dev/null https://example.com; then
             echo "Cursor command sandbox unexpectedly allowed network access." >&2
             exit 1
           fi

--- a/.github/workflows/cursor-automation.yml
+++ b/.github/workflows/cursor-automation.yml
@@ -535,9 +535,9 @@ jobs:
               configPath: process.env.HOME + "/.cursor/cli-config.json",
             });
           '
-          agent sandbox run --sandbox bash -c 'touch .cursor-runtime/sandbox-check'
+          agent sandbox run -- bash -c 'touch .cursor-runtime/sandbox-check'
           test -f .cursor-runtime/sandbox-check
-          if agent sandbox run --sandbox bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
+          if agent sandbox run -- bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
             echo "Cursor command sandbox unexpectedly allowed network access." >&2
             exit 1
           fi
@@ -889,9 +889,9 @@ jobs:
               denyWeb: true,
             });
           '
-          agent sandbox run --sandbox bash -c 'touch .cursor-runtime/sandbox-smoke'
+          agent sandbox run -- bash -c 'touch .cursor-runtime/sandbox-smoke'
           test -f .cursor-runtime/sandbox-smoke
-          if agent sandbox run --sandbox bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
+          if agent sandbox run -- bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
             echo "Cursor sandbox unexpectedly allowed network access." >&2
             exit 1
           fi
@@ -1132,9 +1132,9 @@ jobs:
               configPath: process.env.HOME + "/.cursor/cli-config.json",
             });
           '
-          agent sandbox run --sandbox bash -c 'touch .cursor-runtime/followup-sandbox-check'
+          agent sandbox run -- bash -c 'touch .cursor-runtime/followup-sandbox-check'
           test -f .cursor-runtime/followup-sandbox-check
-          if agent sandbox run --sandbox bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
+          if agent sandbox run -- bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
             echo "Cursor command sandbox unexpectedly allowed network access." >&2
             exit 1
           fi
@@ -2380,9 +2380,9 @@ jobs:
               denyWeb: true,
             });
           '
-          agent sandbox run --sandbox bash -c 'touch .cursor-runtime/implement-sandbox-check'
+          agent sandbox run -- bash -c 'touch .cursor-runtime/implement-sandbox-check'
           test -f .cursor-runtime/implement-sandbox-check
-          if agent sandbox run --sandbox bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
+          if agent sandbox run -- bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
             echo "Cursor command sandbox unexpectedly allowed network access." >&2
             exit 1
           fi
@@ -3656,9 +3656,9 @@ jobs:
               denyWeb: true,
             });
           '
-          agent sandbox run --sandbox bash -c 'touch .cursor-runtime/fix-sandbox-check'
+          agent sandbox run -- bash -c 'touch .cursor-runtime/fix-sandbox-check'
           test -f .cursor-runtime/fix-sandbox-check
-          if agent sandbox run --sandbox bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
+          if agent sandbox run -- bash -c 'curl -fsS --max-time 3 https://example.com >/dev/null'; then
             echo "Cursor command sandbox unexpectedly allowed network access." >&2
             exit 1
           fi

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -1762,11 +1762,11 @@ test('workflow exposes a write-credential-free Cursor sandbox smoke check', () =
   assert.match(smokeJob, /agent sandbox enable/);
   assert.match(
     smokeJob,
-    /prepareCursorCliConfig[\s\S]*?agent sandbox run --sandbox bash -c 'touch \.cursor-runtime\/sandbox-smoke'/,
+    /prepareCursorCliConfig[\s\S]*?agent sandbox run -- bash -c 'touch \.cursor-runtime\/sandbox-smoke'/,
   );
   assert.match(
     smokeJob,
-    /agent sandbox run --sandbox bash -c 'curl -fsS --max-time 3 https:\/\/example\.com >\/dev\/null'/,
+    /agent sandbox run -- bash -c 'curl -fsS --max-time 3 https:\/\/example\.com >\/dev\/null'/,
   );
   assert.match(smokeJob, /--policy "\$sandbox_policy_file"/);
   assert.match(smokeJob, /sandbox: \{/);
@@ -1799,6 +1799,21 @@ test('workflow prepares missing Cursor config on every agent path and checks it 
   )?.[0] || '';
   assert.match(smokeJob, /github\.event\.schedule == '17 3 \* \* \*'/);
   assert.match(smokeJob, /prepareCursorCliConfig/);
+});
+
+test('workflow passes sandbox commands after the Cursor option boundary', () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, '..', '.github', 'workflows', 'cursor-automation.yml'),
+    'utf8',
+  );
+  const sandboxRunLines = workflow
+    .split('\n')
+    .filter((line) => line.includes('agent sandbox run'));
+
+  assert.equal(sandboxRunLines.length, 10);
+  for (const line of sandboxRunLines) {
+    assert.match(line, /agent sandbox run -- bash -c/);
+  }
 });
 
 test('normalizeExternalResearchText accepts sourced research and explicit no-op', () => {

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -1762,11 +1762,11 @@ test('workflow exposes a write-credential-free Cursor sandbox smoke check', () =
   assert.match(smokeJob, /agent sandbox enable/);
   assert.match(
     smokeJob,
-    /prepareCursorCliConfig[\s\S]*?agent sandbox run -- bash -c 'touch \.cursor-runtime\/sandbox-smoke'/,
+    /prepareCursorCliConfig[\s\S]*?agent sandbox run -- touch \.cursor-runtime\/sandbox-smoke/,
   );
   assert.match(
     smokeJob,
-    /agent sandbox run -- bash -c 'curl -fsS --max-time 3 https:\/\/example\.com >\/dev\/null'/,
+    /agent sandbox run -- curl -fsS --max-time 3 -o \/dev\/null https:\/\/example\.com/,
   );
   assert.match(smokeJob, /--policy "\$sandbox_policy_file"/);
   assert.match(smokeJob, /sandbox: \{/);
@@ -1801,19 +1801,34 @@ test('workflow prepares missing Cursor config on every agent path and checks it 
   assert.match(smokeJob, /prepareCursorCliConfig/);
 });
 
-test('workflow passes sandbox commands after the Cursor option boundary', () => {
+test('workflow passes direct commands after the Cursor option boundary', () => {
   const workflow = fs.readFileSync(
     path.join(__dirname, '..', '.github', 'workflows', 'cursor-automation.yml'),
     'utf8',
   );
   const sandboxRunLines = workflow
     .split('\n')
-    .filter((line) => line.includes('agent sandbox run'));
+    .filter((line) => line.includes('agent sandbox run'))
+    .map((line) => line.trim());
+  const expectedTouchCommands = [
+    'agent sandbox run -- touch .cursor-runtime/sandbox-check',
+    'agent sandbox run -- touch .cursor-runtime/sandbox-smoke',
+    'agent sandbox run -- touch .cursor-runtime/followup-sandbox-check',
+    'agent sandbox run -- touch .cursor-runtime/implement-sandbox-check',
+    'agent sandbox run -- touch .cursor-runtime/fix-sandbox-check',
+  ];
+  const expectedCurlCommand =
+    'if agent sandbox run -- curl -fsS --max-time 3 -o /dev/null https://example.com; then';
 
   assert.equal(sandboxRunLines.length, 10);
-  for (const line of sandboxRunLines) {
-    assert.match(line, /agent sandbox run -- bash -c/);
-  }
+  assert.deepEqual(
+    sandboxRunLines.filter((line) => line.includes(' -- touch ')).sort(),
+    expectedTouchCommands.sort(),
+  );
+  assert.equal(
+    sandboxRunLines.filter((line) => line === expectedCurlCommand).length,
+    5,
+  );
 });
 
 test('normalizeExternalResearchText accepts sourced research and explicit no-op', () => {


### PR DESCRIPTION
## Summary

Fix the remaining Cursor automation failures after #2515. Cursor's root `--sandbox` option treated `bash` as an invalid mode, and its sandbox runner split the later `bash -c` script before execution. The probes now invoke their executables directly.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [x] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Follow-up to #2515. Observed in the post-merge runs for #2518 and #2517.

## Changes Made

- Invoke `touch` and `curl` directly after the command boundary in all five Cursor automation paths: classification, daily smoke, issue follow-up, implementation, and Codex fix.
- Keep the existing sandbox filesystem and network probes unchanged.
- Add a regression test that locks every sandbox probe to its complete expected command and arguments.

## Screenshots / Demo

N/A — workflow-only change.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Additional validation:

- `node --test scripts/cursor-automation.test.cjs` — 134/134 passed
- Workflow YAML parse and whitespace validation passed
- `npm run build` passed
- [Credential-free Cursor sandbox smoke run](https://github.com/binaricat/Netcatty/actions/runs/30236421174) passed on GitHub's Linux runner, including workspace write and denied-network probes.
- The full suite still reaches four unrelated failures on unchanged SSH/SFTP code and then hangs; the focused automation suite remains green.
- Two independent local review rounds completed; the final round was clean.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
