### PR TITLE
fix(ssh): enforce vault host keys for Mosh and ET

### DIFF
--- a/electron/bridges/externalSshHostKeyPolicy.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.cjs
@@ -316,6 +316,56 @@ const expandKnownHostsPath = (rawPath, { homedir = os.homedir(), pathModule = pa
 };
 
 /**
+ * Split an ssh -G known_hosts path list. OpenSSH emits unquoted paths, so a
+ * single path containing spaces looks like multiple tokens. Prefer the full
+ * remainder when it exists on disk, otherwise greedily reassemble tokens into
+ * existing paths before falling back to whitespace splits.
+ */
+const splitKnownHostsPathList = (rest, {
+  fs: fsApi = null,
+  homedir = os.homedir(),
+  pathModule = path,
+} = {}) => {
+  const raw = String(rest || "").trim();
+  if (!raw) return [];
+  const expand = (value) => expandKnownHostsPath(value, { homedir, pathModule });
+  const exists = (value) => {
+    if (!value) return false;
+    try {
+      return typeof fsApi?.existsSync === "function" ? fsApi.existsSync(value) : false;
+    } catch {
+      return false;
+    }
+  };
+
+  const expandedAll = expand(raw);
+  if (exists(expandedAll)) return [expandedAll];
+
+  const tokens = raw.split(/\s+/).filter(Boolean);
+  if (tokens.length <= 1) return tokens.map(expand).filter(Boolean);
+
+  const paths = [];
+  let index = 0;
+  while (index < tokens.length) {
+    let end = index;
+    let candidate = expand(tokens[index]);
+    // Grow the token span while the candidate path does not exist.
+    while (end + 1 < tokens.length && !exists(candidate)) {
+      end += 1;
+      candidate = expand(tokens.slice(index, end + 1).join(" "));
+    }
+    if (!exists(candidate)) {
+      // Nothing exists for this span; keep the single token and continue.
+      candidate = expand(tokens[index]);
+      end = index;
+    }
+    if (candidate) paths.push(candidate);
+    index = end + 1;
+  }
+  return paths;
+};
+
+/**
  * Parse `ssh -G` output for a multi-path known_hosts directive
  * (`globalknownhostsfile` / `userknownhostsfile`).
  */
@@ -331,13 +381,26 @@ const parseSshGKnownHostsPaths = (sshGOutput, directive, opts = {}) => {
     if (key !== want) continue;
     const rest = line.slice(space).trim();
     if (!rest) return [];
-    // ssh -G prints unquoted space-separated paths.
-    return rest
-      .split(/\s+/)
-      .map((entry) => expandKnownHostsPath(entry, opts))
-      .filter(Boolean);
+    return splitKnownHostsPathList(rest, opts);
   }
   return null;
+};
+
+const runSshG = ({
+  hostname,
+  platform = process.platform,
+  execFileSyncFn = execFileSync,
+  sshCommand,
+} = {}) => {
+  const target = String(hostname || "").trim() || "localhost";
+  if (typeof execFileSyncFn !== "function") return "";
+  const cmd = sshCommand || "ssh";
+  return execFileSyncFn(cmd, ["-G", target], {
+    encoding: "utf8",
+    timeout: 4000,
+    windowsHide: true,
+    env: process.env,
+  });
 };
 
 /**
@@ -353,27 +416,55 @@ const resolveEffectiveGlobalKnownHostsPaths = ({
   programData = process.env.ProgramData,
   homedir = os.homedir(),
   pathModule = path,
+  fs: fsApi = null,
   execFileSyncFn = execFileSync,
   sshCommand,
+  sshGOutput,
 } = {}) => {
   const defaults = getDefaultGlobalKnownHostsPaths({ platform, programData, pathModule });
-  const target = String(hostname || "").trim() || "localhost";
   try {
-    if (typeof execFileSyncFn !== "function") return defaults;
-    const cmd = sshCommand || (platform === "win32" ? "ssh" : "ssh");
-    const output = execFileSyncFn(cmd, ["-G", target], {
-      encoding: "utf8",
-      timeout: 4000,
-      windowsHide: true,
-      env: process.env,
-    });
+    const output = sshGOutput != null
+      ? sshGOutput
+      : runSshG({ hostname, platform, execFileSyncFn, sshCommand });
     const parsed = parseSshGKnownHostsPaths(output, "globalknownhostsfile", {
+      fs: fsApi,
       homedir,
       pathModule,
     });
     if (Array.isArray(parsed) && parsed.length > 0) return parsed;
   } catch {
     // Discovery is best-effort; fall back to compiled-in defaults.
+  }
+  return defaults;
+};
+
+/**
+ * Resolve the effective UserKnownHostsFile list for a target host via
+ * `ssh -G`, falling back to the default ~/.ssh/known_hosts{,2} paths.
+ */
+const resolveEffectiveUserKnownHostsPaths = ({
+  hostname,
+  platform = process.platform,
+  homedir = os.homedir(),
+  pathModule = path,
+  fs: fsApi = null,
+  execFileSyncFn = execFileSync,
+  sshCommand,
+  sshGOutput,
+} = {}) => {
+  const defaults = getDefaultUserKnownHostsPaths({ homedir, pathModule });
+  try {
+    const output = sshGOutput != null
+      ? sshGOutput
+      : runSshG({ hostname, platform, execFileSyncFn, sshCommand });
+    const parsed = parseSshGKnownHostsPaths(output, "userknownhostsfile", {
+      fs: fsApi,
+      homedir,
+      pathModule,
+    });
+    if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+  } catch {
+    // Best-effort.
   }
   return defaults;
 };
@@ -415,6 +506,16 @@ const buildAuthoritativeKnownHostsContent = ({
   const vaultSelectors = extractVaultHostSelectors(knownHosts);
   const chunks = [vaultContent];
 
+  // One ssh -G probe for both global and user path discovery.
+  let sshGOutput;
+  if (!Array.isArray(globalPaths) || !Array.isArray(userPaths)) {
+    try {
+      sshGOutput = runSshG({ hostname, platform, execFileSyncFn, sshCommand });
+    } catch {
+      sshGOutput = "";
+    }
+  }
+
   const globals = Array.isArray(globalPaths)
     ? globalPaths
     : resolveEffectiveGlobalKnownHostsPaths({
@@ -423,8 +524,10 @@ const buildAuthoritativeKnownHostsContent = ({
       programData,
       homedir,
       pathModule,
+      fs: fsApi,
       execFileSyncFn,
       sshCommand,
+      sshGOutput,
     });
   for (const filePath of globals) {
     const filtered = filterKnownHostsContentExcludingVaultHosts(
@@ -434,9 +537,18 @@ const buildAuthoritativeKnownHostsContent = ({
     if (filtered) chunks.push(filtered);
   }
 
-  const users = Array.isArray(userPaths) && userPaths.length > 0
+  const users = Array.isArray(userPaths)
     ? userPaths
-    : getDefaultUserKnownHostsPaths({ homedir, pathModule });
+    : resolveEffectiveUserKnownHostsPaths({
+      hostname,
+      platform,
+      homedir,
+      pathModule,
+      fs: fsApi,
+      execFileSyncFn,
+      sshCommand,
+      sshGOutput,
+    });
   for (const filePath of users) {
     const filtered = filterKnownHostsContentExcludingVaultHosts(
       readKnownHostsFileContent(fsApi, filePath),
@@ -618,6 +730,8 @@ module.exports = {
   parseSshGKnownHostsPaths,
   quoteOpenSshOptionValue,
   resolveEffectiveGlobalKnownHostsPaths,
+  resolveEffectiveUserKnownHostsPaths,
   resolveExternalStrictHostKeyChecking,
+  splitKnownHostsPathList,
   vaultPinsConnectionHosts,
 };

--- a/electron/bridges/externalSshHostKeyPolicy.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.cjs
@@ -680,21 +680,31 @@ const buildAuthoritativeKnownHostsContent = ({
   }).trimEnd();
   if (!vaultContent) return "";
 
-  // Filter system pins for the connection alias, resolved HostName, and
-  // HostKeyAlias so none of those names can override the vault pin.
+  // Filter system pins for vault-covered hosts. Only when the vault pins THIS
+  // hop do we also strip system entries under HostName / HostKeyAlias aliases
+  // for the hop — otherwise an unrelated vault pin would wipe a trusted
+  // system entry for the current target and break strict stats probes.
   const vaultSelectors = extractVaultHostSelectors(knownHosts);
-  const extraLookupNames = new Set([
-    normalizeHostname(hostname),
-    normalizeHostname(resolvedHostName),
-    normalizeHostname(hostKeyAlias),
-    normalizeHostname(lookupHostName),
-  ]);
-  for (const name of extraLookupNames) {
-    if (!name) continue;
-    // HostKeyAlias / resolved names are stored as bare host tokens.
-    vaultSelectors.push({ hostname: name, port: 22 });
-    if (connectionPort !== 22) {
-      vaultSelectors.push({ hostname: name, port: connectionPort });
+  const vaultPinsThisHop = vaultSelectors.some(
+    (selector) => (
+      selector.hostname === normalizeHostname(hostname)
+      && selector.port === connectionPort
+    ),
+  );
+  if (vaultPinsThisHop) {
+    const extraLookupNames = new Set([
+      normalizeHostname(hostname),
+      normalizeHostname(resolvedHostName),
+      normalizeHostname(hostKeyAlias),
+      normalizeHostname(lookupHostName),
+    ]);
+    for (const name of extraLookupNames) {
+      if (!name) continue;
+      // HostKeyAlias / resolved names are stored as bare host tokens.
+      vaultSelectors.push({ hostname: name, port: 22 });
+      if (connectionPort !== 22) {
+        vaultSelectors.push({ hostname: name, port: connectionPort });
+      }
     }
   }
   const chunks = [vaultContent];

--- a/electron/bridges/externalSshHostKeyPolicy.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.cjs
@@ -9,24 +9,30 @@
  * different key of the same type.
  *
  * Strategy (aligned with issue #2501 user priority — key-change intercept):
- *   - When verifyHostKeys is enabled (default) and the vault has usable
- *     public-key blobs, write a single GlobalKnownHostsFile that merges
- *     OpenSSH's default global files (/etc/ssh/ssh_known_hosts{,2} or the
- *     Windows ProgramData equivalents) with the vault. Replacing
- *     GlobalKnownHostsFile without merging would drop admin-pinned hosts.
- *   - ET keeps StrictHostKeyChecking=accept-new (cannot answer interactive
- *     yes/no via SSH_ASKPASS; accept-new still rejects changed keys).
- *   - Mosh runs OpenSSH in an interactive PTY, so it leaves the default
- *     ask/accept policy alone and only adds the merged trust source unless
- *     verification is disabled.
+ *   - When verifyHostKeys is enabled and the vault has usable public-key
+ *     blobs, build one authoritative known_hosts file that contains:
+ *       1. vault pins (sole source of truth for those hosts), and
+ *       2. OpenSSH default global + user known_hosts lines for hosts that
+ *          are NOT vault-pinned.
+ *     Setting GlobalKnownHostsFile=/vault-only would drop admin pins; unioning
+ *     vault with the full system files would let a system K2 override vault K1
+ *     because OpenSSH accepts an exact match from ANY trust source.
+ *   - Point both UserKnownHostsFile and GlobalKnownHostsFile at that
+ *     authoritative snapshot (or empty Global) so no unfiltered system file
+ *     remains in the search path.
+ *   - ET uses StrictHostKeyChecking=accept-new (SSH_ASKPASS cannot answer
+ *     interactive yes/no). Mosh uses explicit StrictHostKeyChecking=ask so a
+ *     permissive user ssh_config cannot disable verification.
  *   - When verifyHostKeys is false, force StrictHostKeyChecking=no and point
- *     both UserKnownHostsFile and GlobalKnownHostsFile at an empty file.
- *     OpenSSH still consults known_hosts under `no` for password-auth MITM
- *     protection, so an outdated vault/system pin would otherwise still
- *     reject password / keyboard-interactive auth.
+ *     both trust files at an empty snapshot (OpenSSH still consults
+ *     known_hosts under `no` for password-auth MITM protection).
+ *   - Path-valued option values are quoted when they contain whitespace so
+ *     OpenSSH does not split them into multiple filenames.
  */
 
+const crypto = require("node:crypto");
 const path = require("node:path");
+const os = require("node:os");
 
 const formatVaultKnownHostLine = (knownHost) => {
   if (!knownHost?.hostname) return null;
@@ -60,6 +66,139 @@ const buildVaultKnownHostsContent = (knownHosts) => {
 };
 
 /**
+ * Host/port pairs that vault entries pin. Used to filter system known_hosts
+ * so vault remains authoritative for those hosts.
+ */
+const extractVaultHostSelectors = (knownHosts) => {
+  const selectors = [];
+  if (!Array.isArray(knownHosts)) return selectors;
+  for (const knownHost of knownHosts) {
+    if (!formatVaultKnownHostLine(knownHost)) continue;
+    const hostname = String(knownHost.hostname || "").trim().toLowerCase();
+    if (!hostname) continue;
+    const port = Number.isFinite(knownHost.port) ? Number(knownHost.port) : 22;
+    selectors.push({ hostname, port });
+  }
+  return selectors;
+};
+
+const normalizeHostname = (value) => String(value || "").trim().toLowerCase();
+
+const buildHashLookupTokens = (hostname, port) => {
+  const raw = String(hostname || "").trim();
+  if (!raw) return [];
+  const variants = new Set([raw, raw.toLowerCase()]);
+  const tokens = new Set();
+  const usePort = Number.isFinite(port) && Number(port) !== 22;
+  for (const variant of variants) {
+    tokens.add(usePort ? `[${variant}]:${Number(port)}` : variant);
+  }
+  return [...tokens];
+};
+
+const plainHostPatternMatchesSelector = (token, selector) => {
+  if (!token || token.startsWith("!") || token.includes("*") || token.includes("?")) {
+    return false;
+  }
+  const bracket = token.match(/^\[([^\]]+)\]:(\d+)$/);
+  if (bracket) {
+    return (
+      normalizeHostname(bracket[1]) === selector.hostname
+      && Number.parseInt(bracket[2], 10) === selector.port
+    );
+  }
+  return normalizeHostname(token) === selector.hostname && selector.port === 22;
+};
+
+const hashedHostFieldMatchesSelector = (hostField, selector) => {
+  const field = String(hostField || "");
+  if (!field.startsWith("|1|")) return false;
+  const rest = field.slice(3);
+  const sep = rest.indexOf("|");
+  if (sep <= 0) return false;
+  let salt;
+  let expectedBuf;
+  try {
+    salt = Buffer.from(rest.slice(0, sep), "base64");
+    expectedBuf = Buffer.from(rest.slice(sep + 1), "base64");
+  } catch {
+    return false;
+  }
+  if (!salt.length || !expectedBuf.length) return false;
+  for (const token of buildHashLookupTokens(selector.hostname, selector.port)) {
+    let computed;
+    try {
+      computed = crypto.createHmac("sha1", salt).update(token).digest();
+    } catch {
+      continue;
+    }
+    if (
+      computed.length === expectedBuf.length
+      && crypto.timingSafeEqual(computed, expectedBuf)
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const hostFieldMatchesAnyVaultSelector = (hostField, selectors) => {
+  if (!selectors.length) return false;
+  const field = String(hostField || "").trim();
+  if (!field) return false;
+  if (field.startsWith("|1|")) {
+    return selectors.some((selector) => hashedHostFieldMatchesSelector(field, selector));
+  }
+  const patterns = field.split(",");
+  for (const pattern of patterns) {
+    const token = pattern.trim();
+    if (!token) continue;
+    if (selectors.some((selector) => plainHostPatternMatchesSelector(token, selector))) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * Drop known_hosts lines that pin any vault-covered host so vault keys are
+ * the only trust source for those hosts. OpenSSH accepts a match from ANY
+ * configured file; leaving a system K2 next to vault K1 would let K2 win.
+ */
+const filterKnownHostsContentExcludingVaultHosts = (content, vaultSelectors) => {
+  if (!content || !vaultSelectors?.length) {
+    return typeof content === "string" && content.trim() ? content.trimEnd() : "";
+  }
+  const kept = [];
+  for (const rawLine of String(content).split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      if (line.startsWith("#")) kept.push(rawLine.trimEnd());
+      continue;
+    }
+    let rest = line;
+    while (rest.startsWith("@")) {
+      const spaceIdx = rest.search(/\s/);
+      if (spaceIdx < 0) {
+        rest = "";
+        break;
+      }
+      rest = rest.slice(spaceIdx).trim();
+    }
+    if (!rest) {
+      kept.push(rawLine.trimEnd());
+      continue;
+    }
+    const hostField = rest.split(/\s+/)[0];
+    if (hostFieldMatchesAnyVaultSelector(hostField, vaultSelectors)) {
+      continue;
+    }
+    kept.push(rawLine.trimEnd());
+  }
+  return kept.filter(Boolean).join("\n");
+};
+
+/**
  * OpenSSH default GlobalKnownHostsFile locations.
  * Matches `ssh -G -F /dev/null` on OpenSSH 9.x (Unix) and Windows OpenSSH.
  */
@@ -81,6 +220,14 @@ const getDefaultGlobalKnownHostsPaths = ({
   ];
 };
 
+const getDefaultUserKnownHostsPaths = ({
+  homedir = os.homedir(),
+  pathModule = path,
+} = {}) => ([
+  pathModule.join(homedir, ".ssh", "known_hosts"),
+  pathModule.join(homedir, ".ssh", "known_hosts2"),
+]);
+
 const readKnownHostsFileContent = (fsApi, filePath) => {
   if (!fsApi || !filePath) return "";
   try {
@@ -95,39 +242,60 @@ const readKnownHostsFileContent = (fsApi, filePath) => {
 };
 
 /**
- * Merge OpenSSH default global known_hosts files with Netcatty vault entries.
- * Returns "" when there is nothing usable to inject (caller should leave
- * GlobalKnownHostsFile unset so OpenSSH keeps its built-in defaults).
+ * Build the authoritative known_hosts content used when vault pins exist.
+ * Returns "" when the vault has no usable pins (caller should leave OpenSSH
+ * defaults alone).
  */
-const buildMergedGlobalKnownHostsContent = ({
+const buildAuthoritativeKnownHostsContent = ({
   knownHosts,
   fs: fsApi,
   platform = process.platform,
   programData = process.env.ProgramData,
+  homedir = os.homedir(),
   pathModule = path,
   globalPaths,
+  userPaths,
 } = {}) => {
-  const chunks = [];
-  const defaults = Array.isArray(globalPaths) && globalPaths.length > 0
+  const vaultContent = buildVaultKnownHostsContent(knownHosts).trimEnd();
+  if (!vaultContent) return "";
+
+  const vaultSelectors = extractVaultHostSelectors(knownHosts);
+  const chunks = [vaultContent];
+
+  const globals = Array.isArray(globalPaths) && globalPaths.length > 0
     ? globalPaths
     : getDefaultGlobalKnownHostsPaths({ platform, programData, pathModule });
-  for (const filePath of defaults) {
-    const content = readKnownHostsFileContent(fsApi, filePath);
-    if (content) chunks.push(content);
+  for (const filePath of globals) {
+    const filtered = filterKnownHostsContentExcludingVaultHosts(
+      readKnownHostsFileContent(fsApi, filePath),
+      vaultSelectors,
+    );
+    if (filtered) chunks.push(filtered);
   }
-  const vaultContent = buildVaultKnownHostsContent(knownHosts).trimEnd();
-  // Only emit a custom GlobalKnownHostsFile when the vault contributes pins.
-  // If the vault is empty, leave OpenSSH's built-in global defaults alone.
-  if (!vaultContent) return "";
-  chunks.push(vaultContent);
+
+  const users = Array.isArray(userPaths) && userPaths.length > 0
+    ? userPaths
+    : getDefaultUserKnownHostsPaths({ homedir, pathModule });
+  for (const filePath of users) {
+    const filtered = filterKnownHostsContentExcludingVaultHosts(
+      readKnownHostsFileContent(fsApi, filePath),
+      vaultSelectors,
+    );
+    if (filtered) chunks.push(filtered);
+  }
+
   return `${chunks.join("\n")}\n`;
 };
+
+// Back-compat name used by earlier call sites / tests.
+const buildMergedGlobalKnownHostsContent = (opts = {}) =>
+  buildAuthoritativeKnownHostsContent(opts);
 
 /**
  * @param {object} opts
  * @param {boolean} [opts.verifyHostKeys=true]
  * @param {"et"|"mosh"} [opts.protocol="et"]
- * @returns {"accept-new"|"no"|null} null means "do not override OpenSSH default"
+ * @returns {"accept-new"|"ask"|"no"}
  */
 const resolveExternalStrictHostKeyChecking = ({
   verifyHostKeys = true,
@@ -137,21 +305,35 @@ const resolveExternalStrictHostKeyChecking = ({
   // ET cannot answer OpenSSH's interactive host-key prompt (SSH_ASKPASS only
   // covers passwords/passphrases). accept-new still rejects a changed key.
   if (protocol === "et") return "accept-new";
-  // Mosh's handshake PTY can show OpenSSH's ask prompt for first-seen hosts.
-  return null;
+  // Force ask for Mosh so a user ssh_config StrictHostKeyChecking=no/off
+  // cannot disable Netcatty's verification setting.
+  return "ask";
+};
+
+/**
+ * Quote an OpenSSH option value when it contains whitespace or quotes so
+ * path-valued options are not split into multiple filenames.
+ */
+const quoteOpenSshOptionValue = (value) => {
+  const text = String(value ?? "");
+  if (!text) return text;
+  if (!/[\s"]/.test(text)) return text;
+  return `"${text.replace(/(["\\])/g, "\\$1")}"`;
 };
 
 /**
  * Build OpenSSH -o style option strings (or bare KEY=VALUE for ET --ssh-option).
  *
  * @param {object} opts
+ * @param {string|null|undefined} opts.authoritativeKnownHostsPath
+ *   Path to the vault-authoritative known_hosts snapshot (vault pins +
+ *   filtered system entries). When set under verifyHostKeys=true, both
+ *   UserKnownHostsFile and GlobalKnownHostsFile point here so no unfiltered
+ *   system file remains.
  * @param {string|null|undefined} opts.mergedGlobalKnownHostsPath
- *   Path to a file that already merges default global known_hosts + vault.
- *   Only used when verification is enabled. Omit / null when the vault is
- *   empty so OpenSSH keeps its built-in GlobalKnownHostsFile defaults.
+ *   Alias for authoritativeKnownHostsPath (back-compat).
  * @param {string|null|undefined} opts.emptyKnownHostsPath
- *   Empty trust file used when verification is disabled so OpenSSH cannot
- *   still block password auth against a stale vault/system pin.
+ *   Empty trust file used when verification is disabled.
  * @param {boolean} [opts.verifyHostKeys=true]
  * @param {"et"|"mosh"} [opts.protocol="et"]
  * @param {"args"|"values"} [opts.style="values"]
@@ -159,6 +341,7 @@ const resolveExternalStrictHostKeyChecking = ({
  * @returns {string[]}
  */
 const buildExternalHostKeySshOptions = ({
+  authoritativeKnownHostsPath,
   mergedGlobalKnownHostsPath,
   emptyKnownHostsPath,
   // Back-compat alias used by earlier call sites / tests.
@@ -177,19 +360,26 @@ const buildExternalHostKeySshOptions = ({
   if (verifyHostKeys === false) {
     const emptyPath = normalize(emptyKnownHostsPath);
     if (emptyPath) {
+      const quoted = quoteOpenSshOptionValue(emptyPath);
       // Neutralize every trust source. StrictHostKeyChecking=no alone is not
       // enough: OpenSSH still refuses password auth when a known_hosts pin
       // mismatches the live key.
-      values.push(`UserKnownHostsFile=${emptyPath}`);
-      values.push(`GlobalKnownHostsFile=${emptyPath}`);
+      values.push(`UserKnownHostsFile=${quoted}`);
+      values.push(`GlobalKnownHostsFile=${quoted}`);
     }
     values.push("StrictHostKeyChecking=no");
   } else {
-    const trustPath = normalize(mergedGlobalKnownHostsPath || vaultKnownHostsPath);
+    const trustPath = normalize(
+      authoritativeKnownHostsPath
+      || mergedGlobalKnownHostsPath
+      || vaultKnownHostsPath,
+    );
     if (trustPath) {
-      // Read-only trust input. New keys still land in the caller's
-      // UserKnownHostsFile (system ~/.ssh/known_hosts for ET / default Mosh).
-      values.push(`GlobalKnownHostsFile=${trustPath}`);
+      const quoted = quoteOpenSshOptionValue(trustPath);
+      // Vault-authoritative snapshot for both slots so OpenSSH cannot fall
+      // back to an unfiltered system known_hosts that still pins a rotated key.
+      values.push(`UserKnownHostsFile=${quoted}`);
+      values.push(`GlobalKnownHostsFile=${quoted}`);
     }
     const strict = resolveExternalStrictHostKeyChecking({ verifyHostKeys, protocol });
     if (strict) {
@@ -216,6 +406,7 @@ const buildExternalHostKeySshOptions = ({
  * would resolve "accept-new" into a filesystem path.
  */
 const buildExternalHostKeyConfigLines = ({
+  authoritativeKnownHostsPath,
   mergedGlobalKnownHostsPath,
   emptyKnownHostsPath,
   vaultKnownHostsPath,
@@ -223,9 +414,10 @@ const buildExternalHostKeyConfigLines = ({
   protocol = "et",
   indent = "  ",
   normalizePath = (p) => p,
-  quotePath = (v) => v,
+  quotePath = (v) => quoteOpenSshOptionValue(v),
 } = {}) => {
   const values = buildExternalHostKeySshOptions({
+    authoritativeKnownHostsPath,
     mergedGlobalKnownHostsPath,
     emptyKnownHostsPath,
     vaultKnownHostsPath,
@@ -238,20 +430,29 @@ const buildExternalHostKeyConfigLines = ({
     const eq = value.indexOf("=");
     if (eq <= 0) return `${indent}${value}`;
     const key = value.slice(0, eq);
-    const raw = value.slice(eq + 1);
-    if (key === "GlobalKnownHostsFile" || key === "UserKnownHostsFile") {
-      return `${indent}${key} ${quotePath(raw)}`;
+    let raw = value.slice(eq + 1);
+    // Values may already be quoted by buildExternalHostKeySshOptions.
+    if (
+      (key === "GlobalKnownHostsFile" || key === "UserKnownHostsFile")
+      && !(raw.startsWith('"') && raw.endsWith('"'))
+    ) {
+      raw = quotePath(raw);
     }
     return `${indent}${key} ${raw}`;
   });
 };
 
 module.exports = {
+  buildAuthoritativeKnownHostsContent,
   buildExternalHostKeyConfigLines,
   buildExternalHostKeySshOptions,
   buildMergedGlobalKnownHostsContent,
   buildVaultKnownHostsContent,
+  extractVaultHostSelectors,
+  filterKnownHostsContentExcludingVaultHosts,
   formatVaultKnownHostLine,
   getDefaultGlobalKnownHostsPaths,
+  getDefaultUserKnownHostsPaths,
+  quoteOpenSshOptionValue,
   resolveExternalStrictHostKeyChecking,
 };

--- a/electron/bridges/externalSshHostKeyPolicy.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.cjs
@@ -35,12 +35,15 @@ const path = require("node:path");
 const os = require("node:os");
 const { execFileSync } = require("node:child_process");
 
-const formatVaultKnownHostLine = (knownHost, { hostnameOverride } = {}) => {
+const formatVaultKnownHostLine = (knownHost, { hostnameOverride, portOverride, bareHostField = false } = {}) => {
   const hostname = String(hostnameOverride || knownHost?.hostname || "").trim();
   if (!hostname) return null;
-  const port = Number.isFinite(knownHost.port) ? Number(knownHost.port) : 22;
+  const port = Number.isFinite(portOverride)
+    ? Number(portOverride)
+    : (Number.isFinite(knownHost.port) ? Number(knownHost.port) : 22);
   // HostKeyAlias pins are looked up by alias name only (default port form).
-  const hostField = hostnameOverride
+  // Resolved HostName pins keep the connection port encoding.
+  const hostField = bareHostField
     ? hostname
     : (port !== 22 ? `[${hostname}]:${port}` : hostname);
   const pubKey = String(knownHost.publicKey || "").trim();
@@ -80,12 +83,14 @@ const formatVaultKnownHostLine = (knownHost, { hostnameOverride } = {}) => {
  * @param {string} [opts.connectionHostname] Netcatty connection hostname
  * @param {number} [opts.connectionPort]
  * @param {string} [opts.hostKeyAlias] Effective OpenSSH HostKeyAlias for the hop
+ * @param {string} [opts.resolvedHostName] Effective OpenSSH HostName for the hop
  */
 const buildVaultKnownHostsContent = (knownHosts, opts = {}) => {
   if (!Array.isArray(knownHosts) || knownHosts.length === 0) return "";
   const connectionHostname = normalizeHostname(opts.connectionHostname);
   const connectionPort = Number.isFinite(opts.connectionPort) ? Number(opts.connectionPort) : 22;
   const hostKeyAlias = String(opts.hostKeyAlias || "").trim();
+  const resolvedHostName = String(opts.resolvedHostName || "").trim();
   const lines = [];
   for (const knownHost of knownHosts) {
     const host = normalizeHostname(knownHost?.hostname);
@@ -93,11 +98,23 @@ const buildVaultKnownHostsContent = (knownHosts, opts = {}) => {
     const isConnectionHost = connectionHostname
       && host === connectionHostname
       && port === connectionPort;
-    // When OpenSSH uses HostKeyAlias, vault pins for this hop must be written
-    // under the alias name so lookup succeeds.
-    const line = formatVaultKnownHostLine(knownHost, {
-      hostnameOverride: isConnectionHost && hostKeyAlias ? hostKeyAlias : undefined,
-    });
+    let lineOpts;
+    if (isConnectionHost && hostKeyAlias) {
+      // HostKeyAlias pins are bare names (default-port form).
+      lineOpts = { hostnameOverride: hostKeyAlias, bareHostField: true };
+    } else if (
+      isConnectionHost
+      && resolvedHostName
+      && normalizeHostname(resolvedHostName) !== connectionHostname
+    ) {
+      // Resolved HostName keeps the connection port encoding.
+      lineOpts = {
+        hostnameOverride: resolvedHostName,
+        portOverride: connectionPort,
+        bareHostField: false,
+      };
+    }
+    const line = formatVaultKnownHostLine(knownHost, lineOpts);
     if (line) lines.push(line);
   }
   if (lines.length === 0) return "";
@@ -657,11 +674,9 @@ const buildAuthoritativeKnownHostsContent = ({
   const vaultContent = buildVaultKnownHostsContent(knownHosts, {
     connectionHostname: hostname,
     connectionPort,
-    // Prefer HostKeyAlias; else rewrite the connection pin under the resolved
-    // HostName so OpenSSH's lookup finds it.
-    hostKeyAlias: lookupHostName && normalizeHostname(lookupHostName) !== normalizeHostname(hostname)
-      ? lookupHostName
-      : hostKeyAlias,
+    // Prefer HostKeyAlias; else rewrite under the resolved HostName (with port).
+    hostKeyAlias,
+    resolvedHostName,
   }).trimEnd();
   if (!vaultContent) return "";
 

--- a/electron/bridges/externalSshHostKeyPolicy.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.cjs
@@ -171,6 +171,30 @@ const hashedHostFieldMatchesSelector = (hostField, selector) => {
   return false;
 };
 
+/**
+ * OpenSSH known_hosts host-field matching: a host matches when it matches any
+ * positive pattern and does not match any negated (`!`) pattern. Patterns are
+ * comma-separated in the host field (see known_hosts(5)).
+ */
+const plainHostFieldMatchesSelector = (hostField, selector) => {
+  const patterns = String(hostField || "").split(",");
+  let matchedPositive = false;
+  for (const pattern of patterns) {
+    const token = pattern.trim();
+    if (!token) continue;
+    if (token.startsWith("!")) {
+      if (plainHostPatternMatchesSelector(token.slice(1), selector)) {
+        return false;
+      }
+      continue;
+    }
+    if (plainHostPatternMatchesSelector(token, selector)) {
+      matchedPositive = true;
+    }
+  }
+  return matchedPositive;
+};
+
 const hostFieldMatchesAnyVaultSelector = (hostField, selectors) => {
   if (!selectors.length) return false;
   const field = String(hostField || "").trim();
@@ -178,15 +202,7 @@ const hostFieldMatchesAnyVaultSelector = (hostField, selectors) => {
   if (field.startsWith("|1|")) {
     return selectors.some((selector) => hashedHostFieldMatchesSelector(field, selector));
   }
-  const patterns = field.split(",");
-  for (const pattern of patterns) {
-    const token = pattern.trim();
-    if (!token) continue;
-    if (selectors.some((selector) => plainHostPatternMatchesSelector(token, selector))) {
-      return true;
-    }
-  }
-  return false;
+  return selectors.some((selector) => plainHostFieldMatchesSelector(field, selector));
 };
 
 /**

--- a/electron/bridges/externalSshHostKeyPolicy.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.cjs
@@ -500,12 +500,6 @@ const parseSshGKnownHostsPaths = (sshGOutput, directive, opts = {}) => {
   return null;
 };
 
-// Cache ssh -G output per hop identity so vault-pinned target+jump connections
-// do not pay for discovery twice, and so reconnects do not re-block the main
-// process on the same probe.
-const sshGCache = new Map();
-const SSH_G_CACHE_LIMIT = 64;
-
 const runSshG = ({
   hostname,
   port,
@@ -513,6 +507,10 @@ const runSshG = ({
   platform = process.platform,
   execFileSyncFn = execFileSync,
   sshCommand,
+  // Optional per-connection memo (Map). Used so target+jump discovery in one
+  // prepareEtSshEnvironment call can share probes without a process-lifetime
+  // cache that would serve stale HostName/HostKeyAlias after ssh_config edits.
+  memo = null,
 } = {}) => {
   const target = String(hostname || "").trim() || "localhost";
   if (typeof execFileSyncFn !== "function") return "";
@@ -525,11 +523,10 @@ const runSshG = ({
   }
   if (username) args.push("-l", String(username));
   args.push(target);
-  // Only cache real OpenSSH probes. Injected test doubles must not share the
-  // production cache (and vice versa).
-  const useCache = execFileSyncFn === execFileSync;
   const cacheKey = `${cmd}\0${args.join("\0")}`;
-  if (useCache && sshGCache.has(cacheKey)) return sshGCache.get(cacheKey);
+  if (memo && typeof memo.get === "function" && memo.has(cacheKey)) {
+    return memo.get(cacheKey);
+  }
   const output = execFileSyncFn(cmd, args, {
     encoding: "utf8",
     // Keep the timeout short so a hung Match exec cannot freeze the app long.
@@ -537,12 +534,8 @@ const runSshG = ({
     windowsHide: true,
     env: process.env,
   });
-  if (useCache) {
-    if (sshGCache.size >= SSH_G_CACHE_LIMIT) {
-      const oldest = sshGCache.keys().next().value;
-      sshGCache.delete(oldest);
-    }
-    sshGCache.set(cacheKey, output);
+  if (memo && typeof memo.set === "function") {
+    memo.set(cacheKey, output);
   }
   return output;
 };
@@ -566,12 +559,13 @@ const resolveEffectiveGlobalKnownHostsPaths = ({
   execFileSyncFn = execFileSync,
   sshCommand,
   sshGOutput,
+  memo = null,
 } = {}) => {
   const defaults = getDefaultGlobalKnownHostsPaths({ platform, programData, pathModule });
   try {
     const output = sshGOutput != null
       ? sshGOutput
-      : runSshG({ hostname, port, username, platform, execFileSyncFn, sshCommand });
+      : runSshG({ hostname, port, username, platform, execFileSyncFn, sshCommand, memo });
     const parsed = parseSshGKnownHostsPaths(output, "globalknownhostsfile", {
       fs: fsApi,
       homedir,
@@ -599,12 +593,13 @@ const resolveEffectiveUserKnownHostsPaths = ({
   execFileSyncFn = execFileSync,
   sshCommand,
   sshGOutput,
+  memo = null,
 } = {}) => {
   const defaults = getDefaultUserKnownHostsPaths({ homedir, pathModule });
   try {
     const output = sshGOutput != null
       ? sshGOutput
-      : runSshG({ hostname, port, username, platform, execFileSyncFn, sshCommand });
+      : runSshG({ hostname, port, username, platform, execFileSyncFn, sshCommand, memo });
     const parsed = parseSshGKnownHostsPaths(output, "userknownhostsfile", {
       fs: fsApi,
       homedir,
@@ -649,6 +644,7 @@ const buildAuthoritativeKnownHostsContent = ({
   userPaths,
   execFileSyncFn = execFileSync,
   sshCommand,
+  memo = null,
 } = {}) => {
   // One ssh -G probe for path discovery and HostKeyAlias resolution.
   let sshGOutput = "";
@@ -660,6 +656,7 @@ const buildAuthoritativeKnownHostsContent = ({
       platform,
       execFileSyncFn,
       sshCommand,
+      memo,
     });
   } catch {
     sshGOutput = "";
@@ -723,6 +720,7 @@ const buildAuthoritativeKnownHostsContent = ({
       execFileSyncFn,
       sshCommand,
       sshGOutput,
+      memo,
     });
   for (const filePath of globals) {
     const filtered = filterKnownHostsContentExcludingVaultHosts(
@@ -745,6 +743,7 @@ const buildAuthoritativeKnownHostsContent = ({
       execFileSyncFn,
       sshCommand,
       sshGOutput,
+      memo,
     });
   for (const filePath of users) {
     const filtered = filterKnownHostsContentExcludingVaultHosts(

--- a/electron/bridges/externalSshHostKeyPolicy.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.cjs
@@ -51,7 +51,22 @@ const formatVaultKnownHostLine = (knownHost, { hostnameOverride } = {}) => {
     keyType = parts[0];
     keyBlob = parts[1];
   } else if (parts.length === 1 && parts[0].length > 0 && !/^SHA256:/i.test(parts[0])) {
-    keyBlob = parts[0];
+    // One-token publicKey may be a bare base64 key blob — or a legacy
+    // fingerprint. Only accept values that decode as a real OpenSSH wire
+    // public key; fingerprint-only tokens must not become "vault pins".
+    try {
+      const blob = Buffer.from(parts[0], "base64");
+      if (blob.length < 8) return null;
+      const typeLen = blob.readUInt32BE(0);
+      if (typeLen <= 0 || typeLen > 128 || 4 + typeLen > blob.length) return null;
+      const decodedType = blob.subarray(4, 4 + typeLen).toString("ascii");
+      if (!/^[A-Za-z0-9@._+-]+$/.test(decodedType)) return null;
+      if (!/^ssh-|^ecdsa-|^sk-/.test(decodedType)) return null;
+      keyType = decodedType;
+      keyBlob = parts[0];
+    } catch {
+      return null;
+    }
   } else {
     return null;
   }

--- a/electron/bridges/externalSshHostKeyPolicy.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.cjs
@@ -1,0 +1,158 @@
+/**
+ * Host-key policy helpers for external OpenSSH-driven protocols (Mosh, ET).
+ *
+ * Netcatty's in-app SSH path uses ssh2 + hostKeyVerifier with a renderer
+ * confirmation dialog. Mosh and Eternal Terminal bootstrap via system
+ * OpenSSH instead, so they cannot share that dialog path. They still need
+ * the vault known_hosts snapshot for MITM protection: keys the user already
+ * trusted through Netcatty SSH must reject when the live server presents a
+ * different key of the same type.
+ *
+ * Strategy (aligned with issue #2501 user priority — key-change intercept):
+ *   - When verifyHostKeys is enabled (default), inject vault entries that
+ *     carry a full public-key blob as GlobalKnownHostsFile so OpenSSH checks
+ *     them alongside the user's ~/.ssh/known_hosts.
+ *   - ET keeps StrictHostKeyChecking=accept-new (cannot answer interactive
+ *     yes/no via SSH_ASKPASS; accept-new still rejects changed keys).
+ *   - Mosh runs OpenSSH in an interactive PTY, so it leaves the default
+ *     ask/accept policy alone and only adds the vault trust source unless
+ *     verification is disabled.
+ *   - When verifyHostKeys is false, force StrictHostKeyChecking=no to match
+ *     the in-app SSH setting.
+ */
+
+const formatVaultKnownHostLine = (knownHost) => {
+  if (!knownHost?.hostname) return null;
+  const port = Number.isFinite(knownHost.port) ? Number(knownHost.port) : 22;
+  const hostField = port !== 22 ? `[${knownHost.hostname}]:${port}` : knownHost.hostname;
+  const pubKey = String(knownHost.publicKey || "").trim();
+  const parts = pubKey.split(/\s+/);
+  let keyType = typeof knownHost.keyType === "string" ? knownHost.keyType.trim() : "";
+  let keyBlob = "";
+  if (parts.length >= 2 && /^ssh-|^ecdsa-|^sk-/.test(parts[0])) {
+    keyType = parts[0];
+    keyBlob = parts[1];
+  } else if (parts.length === 1 && parts[0].length > 0 && !/^SHA256:/i.test(parts[0])) {
+    keyBlob = parts[0];
+  } else {
+    return null;
+  }
+  if (!keyType || !keyBlob) return null;
+  return `${hostField} ${keyType} ${keyBlob}`;
+};
+
+const buildVaultKnownHostsContent = (knownHosts) => {
+  if (!Array.isArray(knownHosts) || knownHosts.length === 0) return "";
+  const lines = [];
+  for (const knownHost of knownHosts) {
+    const line = formatVaultKnownHostLine(knownHost);
+    if (line) lines.push(line);
+  }
+  if (lines.length === 0) return "";
+  return `${lines.join("\n")}\n`;
+};
+
+/**
+ * @param {object} opts
+ * @param {boolean} [opts.verifyHostKeys=true]
+ * @param {"et"|"mosh"} [opts.protocol="et"]
+ * @returns {"accept-new"|"no"|null} null means "do not override OpenSSH default"
+ */
+const resolveExternalStrictHostKeyChecking = ({
+  verifyHostKeys = true,
+  protocol = "et",
+} = {}) => {
+  if (verifyHostKeys === false) return "no";
+  // ET cannot answer OpenSSH's interactive host-key prompt (SSH_ASKPASS only
+  // covers passwords/passphrases). accept-new still rejects a changed key.
+  if (protocol === "et") return "accept-new";
+  // Mosh's handshake PTY can show OpenSSH's ask prompt for first-seen hosts.
+  return null;
+};
+
+/**
+ * Build OpenSSH -o style option strings (or bare KEY=VALUE for ET --ssh-option).
+ *
+ * @param {object} opts
+ * @param {string|null|undefined} opts.vaultKnownHostsPath
+ * @param {boolean} [opts.verifyHostKeys=true]
+ * @param {"et"|"mosh"} [opts.protocol="et"]
+ * @param {"args"|"values"} [opts.style="values"]
+ *   - values: ["StrictHostKeyChecking=accept-new", ...] (ET --ssh-option)
+ *   - args: ["-o", "StrictHostKeyChecking=accept-new", ...] (Mosh ssh argv)
+ * @param {(p: string) => string} [opts.normalizePath]
+ * @returns {string[]}
+ */
+const buildExternalHostKeySshOptions = ({
+  vaultKnownHostsPath,
+  verifyHostKeys = true,
+  protocol = "et",
+  style = "values",
+  normalizePath = (p) => p,
+} = {}) => {
+  const values = [];
+  const vaultPath = typeof vaultKnownHostsPath === "string" && vaultKnownHostsPath.trim()
+    ? normalizePath(vaultKnownHostsPath.trim())
+    : "";
+  if (vaultPath) {
+    // GlobalKnownHostsFile is read-only trust input; new keys still land in
+    // UserKnownHostsFile (system ~/.ssh/known_hosts for ET / default for Mosh).
+    values.push(`GlobalKnownHostsFile=${vaultPath}`);
+  }
+  const strict = resolveExternalStrictHostKeyChecking({ verifyHostKeys, protocol });
+  if (strict) {
+    values.push(`StrictHostKeyChecking=${strict}`);
+  }
+
+  if (style === "args") {
+    const args = [];
+    for (const value of values) {
+      args.push("-o", value);
+    }
+    return args;
+  }
+  return values;
+};
+
+/**
+ * SSH config Host-block lines (indented) for jump-host stanzas.
+ *
+ * Path-valued options (GlobalKnownHostsFile / UserKnownHostsFile) may need
+ * quoting and path normalization. Enum-valued options such as
+ * StrictHostKeyChecking=accept-new must stay literal — path-quoting helpers
+ * would resolve "accept-new" into a filesystem path.
+ */
+const buildExternalHostKeyConfigLines = ({
+  vaultKnownHostsPath,
+  verifyHostKeys = true,
+  protocol = "et",
+  indent = "  ",
+  normalizePath = (p) => p,
+  quotePath = (v) => v,
+} = {}) => {
+  const values = buildExternalHostKeySshOptions({
+    vaultKnownHostsPath,
+    verifyHostKeys,
+    protocol,
+    style: "values",
+    normalizePath,
+  });
+  return values.map((value) => {
+    const eq = value.indexOf("=");
+    if (eq <= 0) return `${indent}${value}`;
+    const key = value.slice(0, eq);
+    const raw = value.slice(eq + 1);
+    if (key === "GlobalKnownHostsFile" || key === "UserKnownHostsFile") {
+      return `${indent}${key} ${quotePath(raw)}`;
+    }
+    return `${indent}${key} ${raw}`;
+  });
+};
+
+module.exports = {
+  buildExternalHostKeyConfigLines,
+  buildExternalHostKeySshOptions,
+  buildVaultKnownHostsContent,
+  formatVaultKnownHostLine,
+  resolveExternalStrictHostKeyChecking,
+};

--- a/electron/bridges/externalSshHostKeyPolicy.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.cjs
@@ -96,16 +96,45 @@ const buildHashLookupTokens = (hostname, port) => {
   return [...tokens];
 };
 
-const plainHostPatternMatchesSelector = (token, selector) => {
-  if (!token || token.startsWith("!") || token.includes("*") || token.includes("?")) {
+/**
+ * OpenSSH host-pattern matching for `*` / `?` (case-insensitive hostnames).
+ * Used when filtering system known_hosts so a wildcard pin cannot override a
+ * vault pin for a matching host.
+ */
+const openSshHostGlobMatches = (pattern, hostname) => {
+  const rawPattern = String(pattern || "");
+  const host = normalizeHostname(hostname);
+  if (!rawPattern || !host) return false;
+  // Escape regex metacharacters except the OpenSSH wildcards we translate.
+  let regexSource = "";
+  for (const ch of rawPattern.toLowerCase()) {
+    if (ch === "*") regexSource += ".*";
+    else if (ch === "?") regexSource += ".";
+    else if (/[.+^${}()|[\]\\]/.test(ch)) regexSource += `\\${ch}`;
+    else regexSource += ch;
+  }
+  try {
+    return new RegExp(`^${regexSource}$`).test(host);
+  } catch {
     return false;
   }
+};
+
+const plainHostPatternMatchesSelector = (token, selector) => {
+  if (!token || token.startsWith("!")) return false;
   const bracket = token.match(/^\[([^\]]+)\]:(\d+)$/);
   if (bracket) {
-    return (
-      normalizeHostname(bracket[1]) === selector.hostname
-      && Number.parseInt(bracket[2], 10) === selector.port
-    );
+    const patternHost = bracket[1];
+    const patternPort = Number.parseInt(bracket[2], 10);
+    if (patternPort !== selector.port) return false;
+    if (patternHost.includes("*") || patternHost.includes("?")) {
+      return openSshHostGlobMatches(patternHost, selector.hostname);
+    }
+    return normalizeHostname(patternHost) === selector.hostname;
+  }
+  if (token.includes("*") || token.includes("?")) {
+    // Bare wildcard patterns imply the default SSH port.
+    return selector.port === 22 && openSshHostGlobMatches(token, selector.hostname);
   }
   return normalizeHostname(token) === selector.hostname && selector.port === 22;
 };
@@ -164,6 +193,9 @@ const hostFieldMatchesAnyVaultSelector = (hostField, selectors) => {
  * Drop known_hosts lines that pin any vault-covered host so vault keys are
  * the only trust source for those hosts. OpenSSH accepts a match from ANY
  * configured file; leaving a system K2 next to vault K1 would let K2 win.
+ *
+ * `@revoked` lines for vault-covered hosts are KEPT — admin revocations must
+ * remain authoritative and cannot be replaced by a vault pin alone.
  */
 const filterKnownHostsContentExcludingVaultHosts = (content, vaultSelectors) => {
   if (!content || !vaultSelectors?.length) {
@@ -177,12 +209,15 @@ const filterKnownHostsContentExcludingVaultHosts = (content, vaultSelectors) => 
       continue;
     }
     let rest = line;
+    let revoked = false;
     while (rest.startsWith("@")) {
       const spaceIdx = rest.search(/\s/);
       if (spaceIdx < 0) {
         rest = "";
         break;
       }
+      const marker = rest.slice(0, spaceIdx);
+      if (marker === "@revoked") revoked = true;
       rest = rest.slice(spaceIdx).trim();
     }
     if (!rest) {
@@ -191,11 +226,36 @@ const filterKnownHostsContentExcludingVaultHosts = (content, vaultSelectors) => 
     }
     const hostField = rest.split(/\s+/)[0];
     if (hostFieldMatchesAnyVaultSelector(hostField, vaultSelectors)) {
+      // Keep revocations; drop alternate trust pins for vault-covered hosts.
+      if (revoked) kept.push(rawLine.trimEnd());
       continue;
     }
     kept.push(rawLine.trimEnd());
   }
   return kept.filter(Boolean).join("\n");
+};
+
+/**
+ * True when the vault contains a usable pin for at least one of the hosts
+ * involved in this connection (target and jump hosts). Used so ET only
+ * switches UserKnownHostsFile to a session snapshot when vault authority is
+ * actually needed — otherwise accept-new keeps writing to the persistent
+ * ~/.ssh/known_hosts.
+ */
+const vaultPinsConnectionHosts = (knownHosts, connectionHosts = []) => {
+  const vaultSelectors = extractVaultHostSelectors(knownHosts);
+  if (!vaultSelectors.length || !Array.isArray(connectionHosts) || connectionHosts.length === 0) {
+    return false;
+  }
+  for (const host of connectionHosts) {
+    const hostname = normalizeHostname(host?.hostname);
+    if (!hostname) continue;
+    const port = Number.isFinite(host?.port) ? Number(host.port) : 22;
+    if (vaultSelectors.some((selector) => selector.hostname === hostname && selector.port === port)) {
+      return true;
+    }
+  }
+  return false;
 };
 
 /**
@@ -453,6 +513,8 @@ module.exports = {
   formatVaultKnownHostLine,
   getDefaultGlobalKnownHostsPaths,
   getDefaultUserKnownHostsPaths,
+  openSshHostGlobMatches,
   quoteOpenSshOptionValue,
   resolveExternalStrictHostKeyChecking,
+  vaultPinsConnectionHosts,
 };

--- a/electron/bridges/externalSshHostKeyPolicy.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.cjs
@@ -33,6 +33,7 @@
 const crypto = require("node:crypto");
 const path = require("node:path");
 const os = require("node:os");
+const { execFileSync } = require("node:child_process");
 
 const formatVaultKnownHostLine = (knownHost) => {
   if (!knownHost?.hostname) return null;
@@ -304,6 +305,79 @@ const getDefaultUserKnownHostsPaths = ({
   pathModule.join(homedir, ".ssh", "known_hosts2"),
 ]);
 
+const expandKnownHostsPath = (rawPath, { homedir = os.homedir(), pathModule = path } = {}) => {
+  const text = String(rawPath || "").trim();
+  if (!text) return "";
+  if (text === "~") return homedir;
+  if (text.startsWith("~/") || text.startsWith("~\\")) {
+    return pathModule.join(homedir, text.slice(2));
+  }
+  return text;
+};
+
+/**
+ * Parse `ssh -G` output for a multi-path known_hosts directive
+ * (`globalknownhostsfile` / `userknownhostsfile`).
+ */
+const parseSshGKnownHostsPaths = (sshGOutput, directive, opts = {}) => {
+  const want = String(directive || "").toLowerCase();
+  if (!want) return null;
+  for (const rawLine of String(sshGOutput || "").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const space = line.search(/\s/);
+    if (space <= 0) continue;
+    const key = line.slice(0, space).toLowerCase();
+    if (key !== want) continue;
+    const rest = line.slice(space).trim();
+    if (!rest) return [];
+    // ssh -G prints unquoted space-separated paths.
+    return rest
+      .split(/\s+/)
+      .map((entry) => expandKnownHostsPath(entry, opts))
+      .filter(Boolean);
+  }
+  return null;
+};
+
+/**
+ * Resolve the effective GlobalKnownHostsFile list for a target host via
+ * `ssh -G`, falling back to OpenSSH's built-in defaults when discovery fails.
+ * Required because administrators may set non-default GlobalKnownHostsFile
+ * paths in ssh_config; replacing GlobalKnownHostsFile with a vault snapshot
+ * without merging those paths would drop admin pins / @revoked entries.
+ */
+const resolveEffectiveGlobalKnownHostsPaths = ({
+  hostname,
+  platform = process.platform,
+  programData = process.env.ProgramData,
+  homedir = os.homedir(),
+  pathModule = path,
+  execFileSyncFn = execFileSync,
+  sshCommand,
+} = {}) => {
+  const defaults = getDefaultGlobalKnownHostsPaths({ platform, programData, pathModule });
+  const target = String(hostname || "").trim() || "localhost";
+  try {
+    if (typeof execFileSyncFn !== "function") return defaults;
+    const cmd = sshCommand || (platform === "win32" ? "ssh" : "ssh");
+    const output = execFileSyncFn(cmd, ["-G", target], {
+      encoding: "utf8",
+      timeout: 4000,
+      windowsHide: true,
+      env: process.env,
+    });
+    const parsed = parseSshGKnownHostsPaths(output, "globalknownhostsfile", {
+      homedir,
+      pathModule,
+    });
+    if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+  } catch {
+    // Discovery is best-effort; fall back to compiled-in defaults.
+  }
+  return defaults;
+};
+
 const readKnownHostsFileContent = (fsApi, filePath) => {
   if (!fsApi || !filePath) return "";
   try {
@@ -325,12 +399,15 @@ const readKnownHostsFileContent = (fsApi, filePath) => {
 const buildAuthoritativeKnownHostsContent = ({
   knownHosts,
   fs: fsApi,
+  hostname,
   platform = process.platform,
   programData = process.env.ProgramData,
   homedir = os.homedir(),
   pathModule = path,
   globalPaths,
   userPaths,
+  execFileSyncFn = execFileSync,
+  sshCommand,
 } = {}) => {
   const vaultContent = buildVaultKnownHostsContent(knownHosts).trimEnd();
   if (!vaultContent) return "";
@@ -338,9 +415,17 @@ const buildAuthoritativeKnownHostsContent = ({
   const vaultSelectors = extractVaultHostSelectors(knownHosts);
   const chunks = [vaultContent];
 
-  const globals = Array.isArray(globalPaths) && globalPaths.length > 0
+  const globals = Array.isArray(globalPaths)
     ? globalPaths
-    : getDefaultGlobalKnownHostsPaths({ platform, programData, pathModule });
+    : resolveEffectiveGlobalKnownHostsPaths({
+      hostname,
+      platform,
+      programData,
+      homedir,
+      pathModule,
+      execFileSyncFn,
+      sshCommand,
+    });
   for (const filePath of globals) {
     const filtered = filterKnownHostsContentExcludingVaultHosts(
       readKnownHostsFileContent(fsApi, filePath),
@@ -530,7 +615,9 @@ module.exports = {
   getDefaultGlobalKnownHostsPaths,
   getDefaultUserKnownHostsPaths,
   openSshHostGlobMatches,
+  parseSshGKnownHostsPaths,
   quoteOpenSshOptionValue,
+  resolveEffectiveGlobalKnownHostsPaths,
   resolveExternalStrictHostKeyChecking,
   vaultPinsConnectionHosts,
 };

--- a/electron/bridges/externalSshHostKeyPolicy.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.cjs
@@ -9,17 +9,24 @@
  * different key of the same type.
  *
  * Strategy (aligned with issue #2501 user priority — key-change intercept):
- *   - When verifyHostKeys is enabled (default), inject vault entries that
- *     carry a full public-key blob as GlobalKnownHostsFile so OpenSSH checks
- *     them alongside the user's ~/.ssh/known_hosts.
+ *   - When verifyHostKeys is enabled (default) and the vault has usable
+ *     public-key blobs, write a single GlobalKnownHostsFile that merges
+ *     OpenSSH's default global files (/etc/ssh/ssh_known_hosts{,2} or the
+ *     Windows ProgramData equivalents) with the vault. Replacing
+ *     GlobalKnownHostsFile without merging would drop admin-pinned hosts.
  *   - ET keeps StrictHostKeyChecking=accept-new (cannot answer interactive
  *     yes/no via SSH_ASKPASS; accept-new still rejects changed keys).
  *   - Mosh runs OpenSSH in an interactive PTY, so it leaves the default
- *     ask/accept policy alone and only adds the vault trust source unless
+ *     ask/accept policy alone and only adds the merged trust source unless
  *     verification is disabled.
- *   - When verifyHostKeys is false, force StrictHostKeyChecking=no to match
- *     the in-app SSH setting.
+ *   - When verifyHostKeys is false, force StrictHostKeyChecking=no and point
+ *     both UserKnownHostsFile and GlobalKnownHostsFile at an empty file.
+ *     OpenSSH still consults known_hosts under `no` for password-auth MITM
+ *     protection, so an outdated vault/system pin would otherwise still
+ *     reject password / keyboard-interactive auth.
  */
+
+const path = require("node:path");
 
 const formatVaultKnownHostLine = (knownHost) => {
   if (!knownHost?.hostname) return null;
@@ -53,6 +60,70 @@ const buildVaultKnownHostsContent = (knownHosts) => {
 };
 
 /**
+ * OpenSSH default GlobalKnownHostsFile locations.
+ * Matches `ssh -G -F /dev/null` on OpenSSH 9.x (Unix) and Windows OpenSSH.
+ */
+const getDefaultGlobalKnownHostsPaths = ({
+  platform = process.platform,
+  programData = process.env.ProgramData,
+  pathModule = path,
+} = {}) => {
+  if (platform === "win32") {
+    const base = programData || "C:\\ProgramData";
+    return [
+      pathModule.join(base, "ssh", "ssh_known_hosts"),
+      pathModule.join(base, "ssh", "ssh_known_hosts2"),
+    ];
+  }
+  return [
+    "/etc/ssh/ssh_known_hosts",
+    "/etc/ssh/ssh_known_hosts2",
+  ];
+};
+
+const readKnownHostsFileContent = (fsApi, filePath) => {
+  if (!fsApi || !filePath) return "";
+  try {
+    if (typeof fsApi.existsSync === "function" && !fsApi.existsSync(filePath)) {
+      return "";
+    }
+    const content = fsApi.readFileSync(filePath, "utf8");
+    return typeof content === "string" && content.trim() ? content.trimEnd() : "";
+  } catch {
+    return "";
+  }
+};
+
+/**
+ * Merge OpenSSH default global known_hosts files with Netcatty vault entries.
+ * Returns "" when there is nothing usable to inject (caller should leave
+ * GlobalKnownHostsFile unset so OpenSSH keeps its built-in defaults).
+ */
+const buildMergedGlobalKnownHostsContent = ({
+  knownHosts,
+  fs: fsApi,
+  platform = process.platform,
+  programData = process.env.ProgramData,
+  pathModule = path,
+  globalPaths,
+} = {}) => {
+  const chunks = [];
+  const defaults = Array.isArray(globalPaths) && globalPaths.length > 0
+    ? globalPaths
+    : getDefaultGlobalKnownHostsPaths({ platform, programData, pathModule });
+  for (const filePath of defaults) {
+    const content = readKnownHostsFileContent(fsApi, filePath);
+    if (content) chunks.push(content);
+  }
+  const vaultContent = buildVaultKnownHostsContent(knownHosts).trimEnd();
+  // Only emit a custom GlobalKnownHostsFile when the vault contributes pins.
+  // If the vault is empty, leave OpenSSH's built-in global defaults alone.
+  if (!vaultContent) return "";
+  chunks.push(vaultContent);
+  return `${chunks.join("\n")}\n`;
+};
+
+/**
  * @param {object} opts
  * @param {boolean} [opts.verifyHostKeys=true]
  * @param {"et"|"mosh"} [opts.protocol="et"]
@@ -74,16 +145,23 @@ const resolveExternalStrictHostKeyChecking = ({
  * Build OpenSSH -o style option strings (or bare KEY=VALUE for ET --ssh-option).
  *
  * @param {object} opts
- * @param {string|null|undefined} opts.vaultKnownHostsPath
+ * @param {string|null|undefined} opts.mergedGlobalKnownHostsPath
+ *   Path to a file that already merges default global known_hosts + vault.
+ *   Only used when verification is enabled. Omit / null when the vault is
+ *   empty so OpenSSH keeps its built-in GlobalKnownHostsFile defaults.
+ * @param {string|null|undefined} opts.emptyKnownHostsPath
+ *   Empty trust file used when verification is disabled so OpenSSH cannot
+ *   still block password auth against a stale vault/system pin.
  * @param {boolean} [opts.verifyHostKeys=true]
  * @param {"et"|"mosh"} [opts.protocol="et"]
  * @param {"args"|"values"} [opts.style="values"]
- *   - values: ["StrictHostKeyChecking=accept-new", ...] (ET --ssh-option)
- *   - args: ["-o", "StrictHostKeyChecking=accept-new", ...] (Mosh ssh argv)
  * @param {(p: string) => string} [opts.normalizePath]
  * @returns {string[]}
  */
 const buildExternalHostKeySshOptions = ({
+  mergedGlobalKnownHostsPath,
+  emptyKnownHostsPath,
+  // Back-compat alias used by earlier call sites / tests.
   vaultKnownHostsPath,
   verifyHostKeys = true,
   protocol = "et",
@@ -91,17 +169,32 @@ const buildExternalHostKeySshOptions = ({
   normalizePath = (p) => p,
 } = {}) => {
   const values = [];
-  const vaultPath = typeof vaultKnownHostsPath === "string" && vaultKnownHostsPath.trim()
-    ? normalizePath(vaultKnownHostsPath.trim())
-    : "";
-  if (vaultPath) {
-    // GlobalKnownHostsFile is read-only trust input; new keys still land in
-    // UserKnownHostsFile (system ~/.ssh/known_hosts for ET / default for Mosh).
-    values.push(`GlobalKnownHostsFile=${vaultPath}`);
-  }
-  const strict = resolveExternalStrictHostKeyChecking({ verifyHostKeys, protocol });
-  if (strict) {
-    values.push(`StrictHostKeyChecking=${strict}`);
+  const normalize = (p) => {
+    if (typeof p !== "string" || !p.trim()) return "";
+    return normalizePath(p.trim());
+  };
+
+  if (verifyHostKeys === false) {
+    const emptyPath = normalize(emptyKnownHostsPath);
+    if (emptyPath) {
+      // Neutralize every trust source. StrictHostKeyChecking=no alone is not
+      // enough: OpenSSH still refuses password auth when a known_hosts pin
+      // mismatches the live key.
+      values.push(`UserKnownHostsFile=${emptyPath}`);
+      values.push(`GlobalKnownHostsFile=${emptyPath}`);
+    }
+    values.push("StrictHostKeyChecking=no");
+  } else {
+    const trustPath = normalize(mergedGlobalKnownHostsPath || vaultKnownHostsPath);
+    if (trustPath) {
+      // Read-only trust input. New keys still land in the caller's
+      // UserKnownHostsFile (system ~/.ssh/known_hosts for ET / default Mosh).
+      values.push(`GlobalKnownHostsFile=${trustPath}`);
+    }
+    const strict = resolveExternalStrictHostKeyChecking({ verifyHostKeys, protocol });
+    if (strict) {
+      values.push(`StrictHostKeyChecking=${strict}`);
+    }
   }
 
   if (style === "args") {
@@ -123,6 +216,8 @@ const buildExternalHostKeySshOptions = ({
  * would resolve "accept-new" into a filesystem path.
  */
 const buildExternalHostKeyConfigLines = ({
+  mergedGlobalKnownHostsPath,
+  emptyKnownHostsPath,
   vaultKnownHostsPath,
   verifyHostKeys = true,
   protocol = "et",
@@ -131,6 +226,8 @@ const buildExternalHostKeyConfigLines = ({
   quotePath = (v) => v,
 } = {}) => {
   const values = buildExternalHostKeySshOptions({
+    mergedGlobalKnownHostsPath,
+    emptyKnownHostsPath,
     vaultKnownHostsPath,
     verifyHostKeys,
     protocol,
@@ -152,7 +249,9 @@ const buildExternalHostKeyConfigLines = ({
 module.exports = {
   buildExternalHostKeyConfigLines,
   buildExternalHostKeySshOptions,
+  buildMergedGlobalKnownHostsContent,
   buildVaultKnownHostsContent,
   formatVaultKnownHostLine,
+  getDefaultGlobalKnownHostsPaths,
   resolveExternalStrictHostKeyChecking,
 };

--- a/electron/bridges/externalSshHostKeyPolicy.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.cjs
@@ -483,6 +483,12 @@ const parseSshGKnownHostsPaths = (sshGOutput, directive, opts = {}) => {
   return null;
 };
 
+// Cache ssh -G output per hop identity so vault-pinned target+jump connections
+// do not pay for discovery twice, and so reconnects do not re-block the main
+// process on the same probe.
+const sshGCache = new Map();
+const SSH_G_CACHE_LIMIT = 64;
+
 const runSshG = ({
   hostname,
   port,
@@ -502,12 +508,26 @@ const runSshG = ({
   }
   if (username) args.push("-l", String(username));
   args.push(target);
-  return execFileSyncFn(cmd, args, {
+  // Only cache real OpenSSH probes. Injected test doubles must not share the
+  // production cache (and vice versa).
+  const useCache = execFileSyncFn === execFileSync;
+  const cacheKey = `${cmd}\0${args.join("\0")}`;
+  if (useCache && sshGCache.has(cacheKey)) return sshGCache.get(cacheKey);
+  const output = execFileSyncFn(cmd, args, {
     encoding: "utf8",
-    timeout: 4000,
+    // Keep the timeout short so a hung Match exec cannot freeze the app long.
+    timeout: 1500,
     windowsHide: true,
     env: process.env,
   });
+  if (useCache) {
+    if (sshGCache.size >= SSH_G_CACHE_LIMIT) {
+      const oldest = sshGCache.keys().next().value;
+      sshGCache.delete(oldest);
+    }
+    sshGCache.set(cacheKey, output);
+  }
+  return output;
 };
 
 /**

--- a/electron/bridges/externalSshHostKeyPolicy.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.cjs
@@ -35,10 +35,14 @@ const path = require("node:path");
 const os = require("node:os");
 const { execFileSync } = require("node:child_process");
 
-const formatVaultKnownHostLine = (knownHost) => {
-  if (!knownHost?.hostname) return null;
+const formatVaultKnownHostLine = (knownHost, { hostnameOverride } = {}) => {
+  const hostname = String(hostnameOverride || knownHost?.hostname || "").trim();
+  if (!hostname) return null;
   const port = Number.isFinite(knownHost.port) ? Number(knownHost.port) : 22;
-  const hostField = port !== 22 ? `[${knownHost.hostname}]:${port}` : knownHost.hostname;
+  // HostKeyAlias pins are looked up by alias name only (default port form).
+  const hostField = hostnameOverride
+    ? hostname
+    : (port !== 22 ? `[${hostname}]:${port}` : hostname);
   const pubKey = String(knownHost.publicKey || "").trim();
   const parts = pubKey.split(/\s+/);
   let keyType = typeof knownHost.keyType === "string" ? knownHost.keyType.trim() : "";
@@ -55,11 +59,30 @@ const formatVaultKnownHostLine = (knownHost) => {
   return `${hostField} ${keyType} ${keyBlob}`;
 };
 
-const buildVaultKnownHostsContent = (knownHosts) => {
+/**
+ * @param {object[]} knownHosts
+ * @param {object} [opts]
+ * @param {string} [opts.connectionHostname] Netcatty connection hostname
+ * @param {number} [opts.connectionPort]
+ * @param {string} [opts.hostKeyAlias] Effective OpenSSH HostKeyAlias for the hop
+ */
+const buildVaultKnownHostsContent = (knownHosts, opts = {}) => {
   if (!Array.isArray(knownHosts) || knownHosts.length === 0) return "";
+  const connectionHostname = normalizeHostname(opts.connectionHostname);
+  const connectionPort = Number.isFinite(opts.connectionPort) ? Number(opts.connectionPort) : 22;
+  const hostKeyAlias = String(opts.hostKeyAlias || "").trim();
   const lines = [];
   for (const knownHost of knownHosts) {
-    const line = formatVaultKnownHostLine(knownHost);
+    const host = normalizeHostname(knownHost?.hostname);
+    const port = Number.isFinite(knownHost?.port) ? Number(knownHost.port) : 22;
+    const isConnectionHost = connectionHostname
+      && host === connectionHostname
+      && port === connectionPort;
+    // When OpenSSH uses HostKeyAlias, vault pins for this hop must be written
+    // under the alias name so lookup succeeds.
+    const line = formatVaultKnownHostLine(knownHost, {
+      hostnameOverride: isConnectionHost && hostKeyAlias ? hostKeyAlias : undefined,
+    });
     if (line) lines.push(line);
   }
   if (lines.length === 0) return "";
@@ -84,6 +107,20 @@ const extractVaultHostSelectors = (knownHosts) => {
 };
 
 const normalizeHostname = (value) => String(value || "").trim().toLowerCase();
+
+const parseSshGScalar = (sshGOutput, directive) => {
+  const want = String(directive || "").toLowerCase();
+  if (!want) return "";
+  for (const rawLine of String(sshGOutput || "").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const space = line.search(/\s/);
+    if (space <= 0) continue;
+    if (line.slice(0, space).toLowerCase() !== want) continue;
+    return line.slice(space).trim();
+  }
+  return "";
+};
 
 const buildHashLookupTokens = (hostname, port) => {
   const raw = String(hostname || "").trim();
@@ -388,6 +425,8 @@ const parseSshGKnownHostsPaths = (sshGOutput, directive, opts = {}) => {
 
 const runSshG = ({
   hostname,
+  port,
+  username,
   platform = process.platform,
   execFileSyncFn = execFileSync,
   sshCommand,
@@ -395,7 +434,15 @@ const runSshG = ({
   const target = String(hostname || "").trim() || "localhost";
   if (typeof execFileSyncFn !== "function") return "";
   const cmd = sshCommand || "ssh";
-  return execFileSyncFn(cmd, ["-G", target], {
+  const args = ["-G"];
+  // Pass port/user so %p / %r tokens in configured known_hosts paths expand
+  // the same way the real connection will.
+  if (Number.isFinite(port) && Number(port) > 0 && Number(port) !== 22) {
+    args.push("-p", String(Number(port)));
+  }
+  if (username) args.push("-l", String(username));
+  args.push(target);
+  return execFileSyncFn(cmd, args, {
     encoding: "utf8",
     timeout: 4000,
     windowsHide: true,
@@ -412,6 +459,8 @@ const runSshG = ({
  */
 const resolveEffectiveGlobalKnownHostsPaths = ({
   hostname,
+  port,
+  username,
   platform = process.platform,
   programData = process.env.ProgramData,
   homedir = os.homedir(),
@@ -425,7 +474,7 @@ const resolveEffectiveGlobalKnownHostsPaths = ({
   try {
     const output = sshGOutput != null
       ? sshGOutput
-      : runSshG({ hostname, platform, execFileSyncFn, sshCommand });
+      : runSshG({ hostname, port, username, platform, execFileSyncFn, sshCommand });
     const parsed = parseSshGKnownHostsPaths(output, "globalknownhostsfile", {
       fs: fsApi,
       homedir,
@@ -444,6 +493,8 @@ const resolveEffectiveGlobalKnownHostsPaths = ({
  */
 const resolveEffectiveUserKnownHostsPaths = ({
   hostname,
+  port,
+  username,
   platform = process.platform,
   homedir = os.homedir(),
   pathModule = path,
@@ -456,7 +507,7 @@ const resolveEffectiveUserKnownHostsPaths = ({
   try {
     const output = sshGOutput != null
       ? sshGOutput
-      : runSshG({ hostname, platform, execFileSyncFn, sshCommand });
+      : runSshG({ hostname, port, username, platform, execFileSyncFn, sshCommand });
     const parsed = parseSshGKnownHostsPaths(output, "userknownhostsfile", {
       fs: fsApi,
       homedir,
@@ -491,6 +542,8 @@ const buildAuthoritativeKnownHostsContent = ({
   knownHosts,
   fs: fsApi,
   hostname,
+  port,
+  username,
   platform = process.platform,
   programData = process.env.ProgramData,
   homedir = os.homedir(),
@@ -500,26 +553,47 @@ const buildAuthoritativeKnownHostsContent = ({
   execFileSyncFn = execFileSync,
   sshCommand,
 } = {}) => {
-  const vaultContent = buildVaultKnownHostsContent(knownHosts).trimEnd();
+  // One ssh -G probe for path discovery and HostKeyAlias resolution.
+  let sshGOutput = "";
+  try {
+    sshGOutput = runSshG({
+      hostname,
+      port,
+      username,
+      platform,
+      execFileSyncFn,
+      sshCommand,
+    });
+  } catch {
+    sshGOutput = "";
+  }
+  const hostKeyAlias = parseSshGScalar(sshGOutput, "hostkeyalias");
+  const connectionPort = Number.isFinite(port) ? Number(port) : 22;
+
+  const vaultContent = buildVaultKnownHostsContent(knownHosts, {
+    connectionHostname: hostname,
+    connectionPort,
+    hostKeyAlias,
+  }).trimEnd();
   if (!vaultContent) return "";
 
+  // Filter system pins for both the real hostname and HostKeyAlias so neither
+  // trust name can override the vault pin.
   const vaultSelectors = extractVaultHostSelectors(knownHosts);
-  const chunks = [vaultContent];
-
-  // One ssh -G probe for both global and user path discovery.
-  let sshGOutput;
-  if (!Array.isArray(globalPaths) || !Array.isArray(userPaths)) {
-    try {
-      sshGOutput = runSshG({ hostname, platform, execFileSyncFn, sshCommand });
-    } catch {
-      sshGOutput = "";
-    }
+  if (hostKeyAlias) {
+    vaultSelectors.push({
+      hostname: normalizeHostname(hostKeyAlias),
+      port: 22,
+    });
   }
+  const chunks = [vaultContent];
 
   const globals = Array.isArray(globalPaths)
     ? globalPaths
     : resolveEffectiveGlobalKnownHostsPaths({
       hostname,
+      port,
+      username,
       platform,
       programData,
       homedir,
@@ -541,6 +615,8 @@ const buildAuthoritativeKnownHostsContent = ({
     ? userPaths
     : resolveEffectiveUserKnownHostsPaths({
       hostname,
+      port,
+      username,
       platform,
       homedir,
       pathModule,
@@ -728,6 +804,7 @@ module.exports = {
   getDefaultUserKnownHostsPaths,
   openSshHostGlobMatches,
   parseSshGKnownHostsPaths,
+  parseSshGScalar,
   quoteOpenSshOptionValue,
   resolveEffectiveGlobalKnownHostsPaths,
   resolveEffectiveUserKnownHostsPaths,

--- a/electron/bridges/externalSshHostKeyPolicy.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.cjs
@@ -647,24 +647,40 @@ const buildAuthoritativeKnownHostsContent = ({
   } catch {
     sshGOutput = "";
   }
+  // OpenSSH known_hosts lookup uses HostKeyAlias when set, otherwise the
+  // resolved HostName (which may differ from the connection alias).
   const hostKeyAlias = parseSshGScalar(sshGOutput, "hostkeyalias");
+  const resolvedHostName = parseSshGScalar(sshGOutput, "hostname") || hostname;
+  const lookupHostName = hostKeyAlias || resolvedHostName;
   const connectionPort = Number.isFinite(port) ? Number(port) : 22;
 
   const vaultContent = buildVaultKnownHostsContent(knownHosts, {
     connectionHostname: hostname,
     connectionPort,
-    hostKeyAlias,
+    // Prefer HostKeyAlias; else rewrite the connection pin under the resolved
+    // HostName so OpenSSH's lookup finds it.
+    hostKeyAlias: lookupHostName && normalizeHostname(lookupHostName) !== normalizeHostname(hostname)
+      ? lookupHostName
+      : hostKeyAlias,
   }).trimEnd();
   if (!vaultContent) return "";
 
-  // Filter system pins for both the real hostname and HostKeyAlias so neither
-  // trust name can override the vault pin.
+  // Filter system pins for the connection alias, resolved HostName, and
+  // HostKeyAlias so none of those names can override the vault pin.
   const vaultSelectors = extractVaultHostSelectors(knownHosts);
-  if (hostKeyAlias) {
-    vaultSelectors.push({
-      hostname: normalizeHostname(hostKeyAlias),
-      port: 22,
-    });
+  const extraLookupNames = new Set([
+    normalizeHostname(hostname),
+    normalizeHostname(resolvedHostName),
+    normalizeHostname(hostKeyAlias),
+    normalizeHostname(lookupHostName),
+  ]);
+  for (const name of extraLookupNames) {
+    if (!name) continue;
+    // HostKeyAlias / resolved names are stored as bare host tokens.
+    vaultSelectors.push({ hostname: name, port: 22 });
+    if (connectionPort !== 22) {
+      vaultSelectors.push({ hostname: name, port: connectionPort });
+    }
   }
   const chunks = [vaultContent];
 

--- a/electron/bridges/externalSshHostKeyPolicy.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.cjs
@@ -259,9 +259,45 @@ const hostFieldMatchesAnyVaultSelector = (hostField, selectors) => {
 };
 
 /**
- * Drop known_hosts lines that pin any vault-covered host so vault keys are
- * the only trust source for those hosts. OpenSSH accepts a match from ANY
+ * Rewrite a plain (non-hashed) host field by removing patterns that match
+ * vault-covered hosts, while keeping patterns that only cover other hosts.
+ * Returns null when nothing remains (caller should drop the line).
+ */
+const rewriteHostFieldExcludingVaultHosts = (hostField, vaultSelectors) => {
+  const field = String(hostField || "").trim();
+  if (!field || field.startsWith("|1|")) {
+    // Hashed fields are all-or-nothing: drop if they match any vault host.
+    if (field.startsWith("|1|") && hostFieldMatchesAnyVaultSelector(field, vaultSelectors)) {
+      return null;
+    }
+    return field || null;
+  }
+  const keptPatterns = [];
+  for (const pattern of field.split(",")) {
+    const token = pattern.trim();
+    if (!token) continue;
+    const positive = token.startsWith("!") ? token.slice(1) : token;
+    // Drop a pattern when its positive form matches a vault-covered host.
+    // Keep negation patterns only when their positive form is also kept.
+    const matchesVault = vaultSelectors.some((selector) =>
+      plainHostPatternMatchesSelector(positive, selector),
+    );
+    if (matchesVault) continue;
+    keptPatterns.push(token);
+  }
+  // A host field with only negations left is not a useful trust pin.
+  if (!keptPatterns.some((pattern) => !pattern.startsWith("!"))) return null;
+  return keptPatterns.join(",");
+};
+
+/**
+ * Drop or rewrite known_hosts lines that pin vault-covered hosts so vault keys
+ * are the only trust source for those hosts. OpenSSH accepts a match from ANY
  * configured file; leaving a system K2 next to vault K1 would let K2 win.
+ *
+ * Multi-host lines such as `jump.example,target.example` keep the patterns
+ * that do not match vault hosts, so an unpinned hop is not accidentally
+ * converted to first-use trust.
  *
  * `@revoked` lines for vault-covered hosts are KEPT — admin revocations must
  * remain authoritative and cannot be replaced by a vault pin alone.
@@ -278,6 +314,7 @@ const filterKnownHostsContentExcludingVaultHosts = (content, vaultSelectors) => 
       continue;
     }
     let rest = line;
+    let markerPrefix = "";
     let revoked = false;
     while (rest.startsWith("@")) {
       const spaceIdx = rest.search(/\s/);
@@ -286,6 +323,7 @@ const filterKnownHostsContentExcludingVaultHosts = (content, vaultSelectors) => 
         break;
       }
       const marker = rest.slice(0, spaceIdx);
+      markerPrefix += `${marker} `;
       if (marker === "@revoked") revoked = true;
       rest = rest.slice(spaceIdx).trim();
     }
@@ -293,10 +331,17 @@ const filterKnownHostsContentExcludingVaultHosts = (content, vaultSelectors) => 
       kept.push(rawLine.trimEnd());
       continue;
     }
-    const hostField = rest.split(/\s+/)[0];
+    const parts = rest.split(/\s+/);
+    const hostField = parts[0];
+    const tail = parts.slice(1).join(" ");
     if (hostFieldMatchesAnyVaultSelector(hostField, vaultSelectors)) {
-      // Keep revocations; drop alternate trust pins for vault-covered hosts.
-      if (revoked) kept.push(rawLine.trimEnd());
+      if (revoked) {
+        kept.push(rawLine.trimEnd());
+        continue;
+      }
+      const rewrittenHost = rewriteHostFieldExcludingVaultHosts(hostField, vaultSelectors);
+      if (!rewrittenHost || !tail) continue;
+      kept.push(`${markerPrefix}${rewrittenHost} ${tail}`.trim());
       continue;
     }
     kept.push(rawLine.trimEnd());
@@ -731,6 +776,8 @@ const buildExternalHostKeySshOptions = ({
       values.push(`UserKnownHostsFile=${quoted}`);
       values.push(`GlobalKnownHostsFile=${quoted}`);
     }
+    // Disable KnownHostsCommand so dynamic trust cannot reintroduce pins.
+    values.push("KnownHostsCommand=none");
     values.push("StrictHostKeyChecking=no");
   } else {
     const trustPath = normalize(
@@ -744,6 +791,10 @@ const buildExternalHostKeySshOptions = ({
       // back to an unfiltered system known_hosts that still pins a rotated key.
       values.push(`UserKnownHostsFile=${quoted}`);
       values.push(`GlobalKnownHostsFile=${quoted}`);
+      // KnownHostsCommand runs in addition to known_hosts files; disable it
+      // when enforcing vault authority so a dynamic command cannot return a
+      // rotated live key that bypasses the vault pin.
+      values.push("KnownHostsCommand=none");
     }
     const strict = resolveExternalStrictHostKeyChecking({ verifyHostKeys, protocol });
     if (strict) {

--- a/electron/bridges/externalSshHostKeyPolicy.test.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.test.cjs
@@ -116,6 +116,20 @@ test("filterKnownHostsContentExcludingVaultHosts drops wildcards covering vault 
   assert.match(filtered, /AAAOK/);
 });
 
+test("filterKnownHostsContentExcludingVaultHosts respects negated patterns", () => {
+  const {
+    filterKnownHostsContentExcludingVaultHosts: filter,
+  } = require("./externalSshHostKeyPolicy.cjs");
+  // OpenSSH: target.example.com is excluded by !target; jump still matches.
+  const content = "*.example.com,!target.example.com ssh-ed25519 AAAJUMP\n";
+  const filteredForTarget = filter(content, [{ hostname: "target.example.com", port: 22 }]);
+  // Negation means this line does not pin target → keep it for the jump host.
+  assert.match(filteredForTarget, /AAAJUMP/);
+  const filteredForJump = filter(content, [{ hostname: "jump.example.com", port: 22 }]);
+  // Jump matches the positive wildcard → drop so vault remains authoritative.
+  assert.doesNotMatch(filteredForJump, /AAAJUMP/);
+});
+
 test("filterKnownHostsContentExcludingVaultHosts keeps @revoked for vault hosts", () => {
   const {
     filterKnownHostsContentExcludingVaultHosts: filter,

--- a/electron/bridges/externalSshHostKeyPolicy.test.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.test.cjs
@@ -18,23 +18,24 @@ const {
 } = require("./externalSshHostKeyPolicy.cjs");
 
 test("formatVaultKnownHostLine builds OpenSSH known_hosts lines", () => {
+  const validBlob = "AAAAC3NzaC1lZDI1NTE5AAAAIAcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcH";
   assert.equal(
     formatVaultKnownHostLine({
       hostname: "host.example",
       port: 22,
       keyType: "ssh-ed25519",
-      publicKey: "ssh-ed25519 AAAABASE64",
+      publicKey: `ssh-ed25519 ${validBlob}`,
     }),
-    "host.example ssh-ed25519 AAAABASE64",
+    `host.example ssh-ed25519 ${validBlob}`,
   );
   assert.equal(
     formatVaultKnownHostLine({
       hostname: "host.example",
       port: 2222,
       keyType: "ssh-ed25519",
-      publicKey: "AAAABASE64",
+      publicKey: validBlob,
     }),
-    "[host.example]:2222 ssh-ed25519 AAAABASE64",
+    `[host.example]:2222 ssh-ed25519 ${validBlob}`,
   );
 });
 
@@ -45,6 +46,15 @@ test("formatVaultKnownHostLine skips fingerprint-only vault entries", () => {
       keyType: "ssh-ed25519",
       publicKey: "SHA256:abcdef",
       fingerprint: "abcdef",
+    }),
+    null,
+  );
+  // Unprefixed fingerprint-like token must not be treated as a key blob.
+  assert.equal(
+    formatVaultKnownHostLine({
+      hostname: "host.example",
+      keyType: "ssh-ed25519",
+      publicKey: "not-a-real-key-blob",
     }),
     null,
   );

--- a/electron/bridges/externalSshHostKeyPolicy.test.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.test.cjs
@@ -1,11 +1,16 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
 
 const {
   buildExternalHostKeyConfigLines,
   buildExternalHostKeySshOptions,
+  buildMergedGlobalKnownHostsContent,
   buildVaultKnownHostsContent,
   formatVaultKnownHostLine,
+  getDefaultGlobalKnownHostsPaths,
   resolveExternalStrictHostKeyChecking,
 } = require("./externalSshHostKeyPolicy.cjs");
 
@@ -72,6 +77,76 @@ test("buildVaultKnownHostsContent joins usable vault entries", () => {
   assert.equal(buildVaultKnownHostsContent(undefined), "");
 });
 
+test("getDefaultGlobalKnownHostsPaths covers Unix and Windows defaults", () => {
+  assert.deepEqual(getDefaultGlobalKnownHostsPaths({ platform: "darwin" }), [
+    "/etc/ssh/ssh_known_hosts",
+    "/etc/ssh/ssh_known_hosts2",
+  ]);
+  assert.deepEqual(getDefaultGlobalKnownHostsPaths({ platform: "linux" }), [
+    "/etc/ssh/ssh_known_hosts",
+    "/etc/ssh/ssh_known_hosts2",
+  ]);
+  assert.deepEqual(
+    getDefaultGlobalKnownHostsPaths({ platform: "win32", programData: "C:\\ProgramData" }),
+    [
+      path.join("C:\\ProgramData", "ssh", "ssh_known_hosts"),
+      path.join("C:\\ProgramData", "ssh", "ssh_known_hosts2"),
+    ],
+  );
+});
+
+test("buildMergedGlobalKnownHostsContent merges system globals with vault", () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-kh-merge-"));
+  try {
+    const global1 = path.join(base, "ssh_known_hosts");
+    const global2 = path.join(base, "ssh_known_hosts2");
+    fs.writeFileSync(global1, "admin.example ssh-ed25519 AAAADMIN\n");
+    fs.writeFileSync(global2, "admin2.example ssh-rsa AAAADMIN2\n");
+
+    const content = buildMergedGlobalKnownHostsContent({
+      knownHosts: [{
+        hostname: "vault.example",
+        keyType: "ssh-ed25519",
+        publicKey: "ssh-ed25519 AAAVAULT",
+      }],
+      fs,
+      globalPaths: [global1, global2, path.join(base, "missing")],
+    });
+
+    assert.match(content, /admin\.example ssh-ed25519 AAAADMIN/);
+    assert.match(content, /admin2\.example ssh-rsa AAAADMIN2/);
+    assert.match(content, /vault\.example ssh-ed25519 AAAVAULT/);
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("buildMergedGlobalKnownHostsContent is empty when vault has no usable pins", () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-kh-empty-"));
+  try {
+    const global1 = path.join(base, "ssh_known_hosts");
+    fs.writeFileSync(global1, "admin.example ssh-ed25519 AAAADMIN\n");
+    assert.equal(
+      buildMergedGlobalKnownHostsContent({
+        knownHosts: [{ hostname: "x", fingerprint: "only" }],
+        fs,
+        globalPaths: [global1],
+      }),
+      "",
+    );
+    assert.equal(
+      buildMergedGlobalKnownHostsContent({
+        knownHosts: [],
+        fs,
+        globalPaths: [global1],
+      }),
+      "",
+    );
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("resolveExternalStrictHostKeyChecking matches protocol constraints", () => {
   assert.equal(resolveExternalStrictHostKeyChecking({ protocol: "et" }), "accept-new");
   assert.equal(resolveExternalStrictHostKeyChecking({ protocol: "mosh" }), null);
@@ -85,46 +160,64 @@ test("resolveExternalStrictHostKeyChecking matches protocol constraints", () => 
   );
 });
 
-test("buildExternalHostKeySshOptions injects vault GlobalKnownHostsFile", () => {
+test("buildExternalHostKeySshOptions injects merged GlobalKnownHostsFile when verifying", () => {
   const values = buildExternalHostKeySshOptions({
-    vaultKnownHostsPath: "/tmp/vault-kh",
+    mergedGlobalKnownHostsPath: "/tmp/merged-kh",
     protocol: "et",
     style: "values",
   });
   assert.deepEqual(values, [
-    "GlobalKnownHostsFile=/tmp/vault-kh",
+    "GlobalKnownHostsFile=/tmp/merged-kh",
     "StrictHostKeyChecking=accept-new",
   ]);
 
   const moshArgs = buildExternalHostKeySshOptions({
-    vaultKnownHostsPath: "/tmp/vault-kh",
+    mergedGlobalKnownHostsPath: "/tmp/merged-kh",
     protocol: "mosh",
     style: "args",
   });
   assert.deepEqual(moshArgs, [
-    "-o", "GlobalKnownHostsFile=/tmp/vault-kh",
+    "-o", "GlobalKnownHostsFile=/tmp/merged-kh",
   ]);
+});
 
+test("buildExternalHostKeySshOptions omits trust file when verification is disabled", () => {
   const disabled = buildExternalHostKeySshOptions({
-    vaultKnownHostsPath: "/tmp/vault-kh",
+    mergedGlobalKnownHostsPath: "/tmp/merged-kh",
+    emptyKnownHostsPath: "/tmp/empty-kh",
     verifyHostKeys: false,
     protocol: "mosh",
     style: "args",
   });
   assert.deepEqual(disabled, [
-    "-o", "GlobalKnownHostsFile=/tmp/vault-kh",
+    "-o", "UserKnownHostsFile=/tmp/empty-kh",
+    "-o", "GlobalKnownHostsFile=/tmp/empty-kh",
     "-o", "StrictHostKeyChecking=no",
   ]);
+  // Must not keep pointing at the vault/merged trust file.
+  assert.equal(disabled.some((part) => String(part).includes("/tmp/merged-kh")), false);
 });
 
 test("buildExternalHostKeyConfigLines formats indented jump-host stanzas", () => {
   const lines = buildExternalHostKeyConfigLines({
-    vaultKnownHostsPath: "/tmp/vault-kh",
+    mergedGlobalKnownHostsPath: "/tmp/merged-kh",
     protocol: "et",
     quotePath: (v) => `"${v}"`,
   });
   assert.deepEqual(lines, [
-    '  GlobalKnownHostsFile "/tmp/vault-kh"',
+    '  GlobalKnownHostsFile "/tmp/merged-kh"',
     "  StrictHostKeyChecking accept-new",
+  ]);
+
+  const disabled = buildExternalHostKeyConfigLines({
+    emptyKnownHostsPath: "/tmp/empty-kh",
+    verifyHostKeys: false,
+    protocol: "et",
+    quotePath: (v) => `"${v}"`,
+  });
+  assert.deepEqual(disabled, [
+    '  UserKnownHostsFile "/tmp/empty-kh"',
+    '  GlobalKnownHostsFile "/tmp/empty-kh"',
+    "  StrictHostKeyChecking no",
   ]);
 });

--- a/electron/bridges/externalSshHostKeyPolicy.test.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.test.cjs
@@ -267,10 +267,31 @@ test("buildAuthoritativeKnownHostsContent honors HostKeyAlias for vault pins", (
     port: 22,
     globalPaths: [],
     userPaths: [],
-    execFileSyncFn: () => "hostkeyalias shared-key\n",
+    execFileSyncFn: () => "hostkeyalias shared-key\nhostname host.example\n",
   });
   assert.match(content, /^shared-key ssh-ed25519 AAAVAULT$/m);
   assert.doesNotMatch(content, /^host\.example ssh-ed25519 AAAVAULT$/m);
+});
+
+test("buildAuthoritativeKnownHostsContent rewrites pins under resolved HostName", () => {
+  const {
+    buildAuthoritativeKnownHostsContent: build,
+  } = require("./externalSshHostKeyPolicy.cjs");
+  const content = build({
+    knownHosts: [{
+      hostname: "prod",
+      keyType: "ssh-ed25519",
+      publicKey: "ssh-ed25519 AAAVAULT",
+    }],
+    fs,
+    hostname: "prod",
+    port: 22,
+    globalPaths: [],
+    userPaths: [],
+    execFileSyncFn: () => "hostname 10.0.0.5\n",
+  });
+  assert.match(content, /^10\.0\.0\.5 ssh-ed25519 AAAVAULT$/m);
+  assert.doesNotMatch(content, /^prod ssh-ed25519 AAAVAULT$/m);
 });
 
 test("runSshG discovery receives port and username", () => {

--- a/electron/bridges/externalSshHostKeyPolicy.test.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.test.cjs
@@ -1,0 +1,130 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  buildExternalHostKeyConfigLines,
+  buildExternalHostKeySshOptions,
+  buildVaultKnownHostsContent,
+  formatVaultKnownHostLine,
+  resolveExternalStrictHostKeyChecking,
+} = require("./externalSshHostKeyPolicy.cjs");
+
+test("formatVaultKnownHostLine builds OpenSSH known_hosts lines", () => {
+  assert.equal(
+    formatVaultKnownHostLine({
+      hostname: "host.example",
+      port: 22,
+      keyType: "ssh-ed25519",
+      publicKey: "ssh-ed25519 AAAABASE64",
+    }),
+    "host.example ssh-ed25519 AAAABASE64",
+  );
+  assert.equal(
+    formatVaultKnownHostLine({
+      hostname: "host.example",
+      port: 2222,
+      keyType: "ssh-ed25519",
+      publicKey: "AAAABASE64",
+    }),
+    "[host.example]:2222 ssh-ed25519 AAAABASE64",
+  );
+});
+
+test("formatVaultKnownHostLine skips fingerprint-only vault entries", () => {
+  assert.equal(
+    formatVaultKnownHostLine({
+      hostname: "host.example",
+      keyType: "ssh-ed25519",
+      publicKey: "SHA256:abcdef",
+      fingerprint: "abcdef",
+    }),
+    null,
+  );
+  assert.equal(
+    formatVaultKnownHostLine({
+      hostname: "host.example",
+      fingerprint: "abcdef",
+    }),
+    null,
+  );
+});
+
+test("buildVaultKnownHostsContent joins usable vault entries", () => {
+  const content = buildVaultKnownHostsContent([
+    {
+      hostname: "a.example",
+      keyType: "ssh-ed25519",
+      publicKey: "ssh-ed25519 AAAAa",
+    },
+    { hostname: "skip.example", fingerprint: "only" },
+    {
+      hostname: "b.example",
+      port: 2200,
+      keyType: "ssh-rsa",
+      publicKey: "ssh-rsa AAAAb",
+    },
+  ]);
+  assert.equal(
+    content,
+    "a.example ssh-ed25519 AAAAa\n[b.example]:2200 ssh-rsa AAAAb\n",
+  );
+  assert.equal(buildVaultKnownHostsContent([]), "");
+  assert.equal(buildVaultKnownHostsContent(undefined), "");
+});
+
+test("resolveExternalStrictHostKeyChecking matches protocol constraints", () => {
+  assert.equal(resolveExternalStrictHostKeyChecking({ protocol: "et" }), "accept-new");
+  assert.equal(resolveExternalStrictHostKeyChecking({ protocol: "mosh" }), null);
+  assert.equal(
+    resolveExternalStrictHostKeyChecking({ protocol: "et", verifyHostKeys: false }),
+    "no",
+  );
+  assert.equal(
+    resolveExternalStrictHostKeyChecking({ protocol: "mosh", verifyHostKeys: false }),
+    "no",
+  );
+});
+
+test("buildExternalHostKeySshOptions injects vault GlobalKnownHostsFile", () => {
+  const values = buildExternalHostKeySshOptions({
+    vaultKnownHostsPath: "/tmp/vault-kh",
+    protocol: "et",
+    style: "values",
+  });
+  assert.deepEqual(values, [
+    "GlobalKnownHostsFile=/tmp/vault-kh",
+    "StrictHostKeyChecking=accept-new",
+  ]);
+
+  const moshArgs = buildExternalHostKeySshOptions({
+    vaultKnownHostsPath: "/tmp/vault-kh",
+    protocol: "mosh",
+    style: "args",
+  });
+  assert.deepEqual(moshArgs, [
+    "-o", "GlobalKnownHostsFile=/tmp/vault-kh",
+  ]);
+
+  const disabled = buildExternalHostKeySshOptions({
+    vaultKnownHostsPath: "/tmp/vault-kh",
+    verifyHostKeys: false,
+    protocol: "mosh",
+    style: "args",
+  });
+  assert.deepEqual(disabled, [
+    "-o", "GlobalKnownHostsFile=/tmp/vault-kh",
+    "-o", "StrictHostKeyChecking=no",
+  ]);
+});
+
+test("buildExternalHostKeyConfigLines formats indented jump-host stanzas", () => {
+  const lines = buildExternalHostKeyConfigLines({
+    vaultKnownHostsPath: "/tmp/vault-kh",
+    protocol: "et",
+    quotePath: (v) => `"${v}"`,
+  });
+  assert.deepEqual(lines, [
+    '  GlobalKnownHostsFile "/tmp/vault-kh"',
+    "  StrictHostKeyChecking accept-new",
+  ]);
+});

--- a/electron/bridges/externalSshHostKeyPolicy.test.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.test.cjs
@@ -294,6 +294,28 @@ test("buildAuthoritativeKnownHostsContent rewrites pins under resolved HostName"
   assert.doesNotMatch(content, /^prod ssh-ed25519 AAAVAULT$/m);
 });
 
+test("buildAuthoritativeKnownHostsContent keeps port form for resolved HostName", () => {
+  const {
+    buildAuthoritativeKnownHostsContent: build,
+  } = require("./externalSshHostKeyPolicy.cjs");
+  const content = build({
+    knownHosts: [{
+      hostname: "prod",
+      port: 2222,
+      keyType: "ssh-ed25519",
+      publicKey: "ssh-ed25519 AAAVAULT",
+    }],
+    fs,
+    hostname: "prod",
+    port: 2222,
+    globalPaths: [],
+    userPaths: [],
+    execFileSyncFn: () => "hostname 10.0.0.5\n",
+  });
+  assert.match(content, /^\[10\.0\.0\.5\]:2222 ssh-ed25519 AAAVAULT$/m);
+  assert.doesNotMatch(content, /^10\.0\.0\.5 ssh-ed25519 AAAVAULT$/m);
+});
+
 test("runSshG discovery receives port and username", () => {
   const { buildAuthoritativeKnownHostsContent: build } = require("./externalSshHostKeyPolicy.cjs");
   let capturedArgs = null;

--- a/electron/bridges/externalSshHostKeyPolicy.test.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.test.cjs
@@ -111,6 +111,16 @@ test("filterKnownHostsContentExcludingVaultHosts drops conflicting system pins",
   assert.match(filtered, /# comment kept/);
 });
 
+test("filterKnownHostsContentExcludingVaultHosts rewrites multi-host lines", () => {
+  const content = "jump.example,target.example ssh-ed25519 AAASHARED\n";
+  const filtered = filterKnownHostsContentExcludingVaultHosts(content, [
+    { hostname: "jump.example", port: 22 },
+  ]);
+  // Jump pattern removed; target pattern kept so unpinned target stays trusted.
+  assert.match(filtered, /^target\.example ssh-ed25519 AAASHARED$/m);
+  assert.doesNotMatch(filtered, /jump\.example/);
+});
+
 test("filterKnownHostsContentExcludingVaultHosts drops wildcards covering vault hosts", () => {
   const {
     filterKnownHostsContentExcludingVaultHosts: filter,
@@ -399,6 +409,7 @@ test("buildExternalHostKeySshOptions uses authoritative trust for both slots", (
   assert.deepEqual(values, [
     "UserKnownHostsFile=/tmp/auth-kh",
     "GlobalKnownHostsFile=/tmp/auth-kh",
+    "KnownHostsCommand=none",
     "StrictHostKeyChecking=accept-new",
   ]);
 
@@ -410,6 +421,7 @@ test("buildExternalHostKeySshOptions uses authoritative trust for both slots", (
   assert.deepEqual(moshArgs, [
     "-o", "UserKnownHostsFile=/tmp/auth-kh",
     "-o", "GlobalKnownHostsFile=/tmp/auth-kh",
+    "-o", "KnownHostsCommand=none",
     "-o", "StrictHostKeyChecking=ask",
   ]);
 });
@@ -423,6 +435,7 @@ test("buildExternalHostKeySshOptions quotes whitespace paths", () => {
   assert.deepEqual(values, [
     'UserKnownHostsFile="/tmp/user name/auth-kh"',
     'GlobalKnownHostsFile="/tmp/user name/auth-kh"',
+    "KnownHostsCommand=none",
     "StrictHostKeyChecking=accept-new",
   ]);
 });
@@ -438,6 +451,7 @@ test("buildExternalHostKeySshOptions neutralizes trust when verification is disa
   assert.deepEqual(disabled, [
     "-o", "UserKnownHostsFile=/tmp/empty-kh",
     "-o", "GlobalKnownHostsFile=/tmp/empty-kh",
+    "-o", "KnownHostsCommand=none",
     "-o", "StrictHostKeyChecking=no",
   ]);
   assert.equal(disabled.some((part) => String(part).includes("/tmp/auth-kh")), false);
@@ -451,6 +465,7 @@ test("buildExternalHostKeyConfigLines formats indented jump-host stanzas", () =>
   assert.deepEqual(lines, [
     "  UserKnownHostsFile /tmp/auth-kh",
     "  GlobalKnownHostsFile /tmp/auth-kh",
+    "  KnownHostsCommand none",
     "  StrictHostKeyChecking accept-new",
   ]);
 });

--- a/electron/bridges/externalSshHostKeyPolicy.test.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.test.cjs
@@ -255,6 +255,53 @@ test("parseSshGKnownHostsPaths reads multi-path directives", () => {
   );
 });
 
+test("parseSshGKnownHostsPaths preserves paths that contain spaces", () => {
+  const { parseSshGKnownHostsPaths } = require("./externalSshHostKeyPolicy.cjs");
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-kh-space-"));
+  try {
+    const spaced = path.join(base, "dir with space", "global kh");
+    fs.mkdirSync(path.dirname(spaced), { recursive: true });
+    fs.writeFileSync(spaced, "ok\n");
+    assert.deepEqual(
+      parseSshGKnownHostsPaths(
+        `globalknownhostsfile ${spaced}\n`,
+        "globalknownhostsfile",
+        { fs, pathModule: path },
+      ),
+      [spaced],
+    );
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("buildAuthoritativeKnownHostsContent merges effective user known_hosts paths", () => {
+  const {
+    buildAuthoritativeKnownHostsContent: build,
+  } = require("./externalSshHostKeyPolicy.cjs");
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-kh-user-"));
+  try {
+    const customUser = path.join(base, "custom_user_known_hosts");
+    fs.writeFileSync(customUser, "admin.user ssh-ed25519 AAAUSERCUSTOM\n");
+    const content = build({
+      knownHosts: [{
+        hostname: "host.example",
+        keyType: "ssh-ed25519",
+        publicKey: "ssh-ed25519 AAAVAULT",
+      }],
+      fs,
+      hostname: "host.example",
+      globalPaths: [],
+      userPaths: undefined,
+      execFileSyncFn: () => `userknownhostsfile ${customUser}\n`,
+    });
+    assert.match(content, /host\.example ssh-ed25519 AAAVAULT/);
+    assert.match(content, /admin\.user ssh-ed25519 AAAUSERCUSTOM/);
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("buildAuthoritativeKnownHostsContent is empty when vault has no usable pins", () => {
   assert.equal(
     buildAuthoritativeKnownHostsContent({

--- a/electron/bridges/externalSshHostKeyPolicy.test.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.test.cjs
@@ -101,6 +101,53 @@ test("filterKnownHostsContentExcludingVaultHosts drops conflicting system pins",
   assert.match(filtered, /# comment kept/);
 });
 
+test("filterKnownHostsContentExcludingVaultHosts drops wildcards covering vault hosts", () => {
+  const {
+    filterKnownHostsContentExcludingVaultHosts: filter,
+  } = require("./externalSshHostKeyPolicy.cjs");
+  const content = [
+    "*.example.com ssh-ed25519 AAAWILD",
+    "db.example.com ssh-rsa AAADB",
+    "unrelated.example.org ssh-ed25519 AAAOK",
+  ].join("\n");
+  const filtered = filter(content, [{ hostname: "host.example.com", port: 22 }]);
+  assert.doesNotMatch(filtered, /AAAWILD/);
+  assert.match(filtered, /db\.example\.com/);
+  assert.match(filtered, /AAAOK/);
+});
+
+test("filterKnownHostsContentExcludingVaultHosts keeps @revoked for vault hosts", () => {
+  const {
+    filterKnownHostsContentExcludingVaultHosts: filter,
+  } = require("./externalSshHostKeyPolicy.cjs");
+  const content = [
+    "@revoked host.example ssh-ed25519 AAAREVOKED",
+    "host.example ssh-ed25519 AAASYSTEM",
+    "other.example ssh-rsa AAAOTHER",
+  ].join("\n");
+  const filtered = filter(content, [{ hostname: "host.example", port: 22 }]);
+  assert.match(filtered, /@revoked host\.example ssh-ed25519 AAAREVOKED/);
+  assert.doesNotMatch(filtered, /AAASYSTEM/);
+  assert.match(filtered, /other\.example/);
+});
+
+test("vaultPinsConnectionHosts only matches the active connection", () => {
+  const { vaultPinsConnectionHosts } = require("./externalSshHostKeyPolicy.cjs");
+  const knownHosts = [{
+    hostname: "other.example",
+    keyType: "ssh-ed25519",
+    publicKey: "ssh-ed25519 AAAA",
+  }];
+  assert.equal(
+    vaultPinsConnectionHosts(knownHosts, [{ hostname: "target.example", port: 22 }]),
+    false,
+  );
+  assert.equal(
+    vaultPinsConnectionHosts(knownHosts, [{ hostname: "other.example", port: 22 }]),
+    true,
+  );
+});
+
 test("filterKnownHostsContentExcludingVaultHosts matches hashed host entries", () => {
   const hostname = "hashed.example";
   const salt = crypto.randomBytes(20);

--- a/electron/bridges/externalSshHostKeyPolicy.test.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.test.cjs
@@ -204,6 +204,57 @@ test("buildAuthoritativeKnownHostsContent makes vault authoritative over system 
   }
 });
 
+test("buildAuthoritativeKnownHostsContent merges ssh -G global known_hosts paths", () => {
+  const {
+    buildAuthoritativeKnownHostsContent: build,
+  } = require("./externalSshHostKeyPolicy.cjs");
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-kh-sshg-"));
+  try {
+    const customGlobal = path.join(base, "custom_global_known_hosts");
+    fs.writeFileSync(customGlobal, "admin.custom ssh-ed25519 AAAADMINCUSTOM\n");
+    const content = build({
+      knownHosts: [{
+        hostname: "host.example",
+        keyType: "ssh-ed25519",
+        publicKey: "ssh-ed25519 AAAVAULT",
+      }],
+      fs,
+      hostname: "host.example",
+      // Force discovery path (no explicit globalPaths).
+      globalPaths: undefined,
+      userPaths: [],
+      execFileSyncFn: () => `globalknownhostsfile ${customGlobal}\n`,
+    });
+    assert.match(content, /host\.example ssh-ed25519 AAAVAULT/);
+    assert.match(content, /admin\.custom ssh-ed25519 AAAADMINCUSTOM/);
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("parseSshGKnownHostsPaths reads multi-path directives", () => {
+  const { parseSshGKnownHostsPaths } = require("./externalSshHostKeyPolicy.cjs");
+  assert.deepEqual(
+    parseSshGKnownHostsPaths(
+      "globalknownhostsfile /etc/ssh/ssh_known_hosts /etc/custom/known_hosts\nuserknownhostsfile ~/.ssh/known_hosts\n",
+      "globalknownhostsfile",
+      { homedir: "/home/me", pathModule: path },
+    ),
+    ["/etc/ssh/ssh_known_hosts", "/etc/custom/known_hosts"],
+  );
+  assert.deepEqual(
+    parseSshGKnownHostsPaths(
+      "userknownhostsfile ~/.ssh/known_hosts ~/.ssh/known_hosts2\n",
+      "userknownhostsfile",
+      { homedir: "/home/me", pathModule: path },
+    ),
+    [
+      path.join("/home/me", ".ssh", "known_hosts"),
+      path.join("/home/me", ".ssh", "known_hosts2"),
+    ],
+  );
+});
+
 test("buildAuthoritativeKnownHostsContent is empty when vault has no usable pins", () => {
   assert.equal(
     buildAuthoritativeKnownHostsContent({

--- a/electron/bridges/externalSshHostKeyPolicy.test.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.test.cjs
@@ -232,6 +232,51 @@ test("buildAuthoritativeKnownHostsContent merges ssh -G global known_hosts paths
   }
 });
 
+test("buildAuthoritativeKnownHostsContent honors HostKeyAlias for vault pins", () => {
+  const {
+    buildAuthoritativeKnownHostsContent: build,
+  } = require("./externalSshHostKeyPolicy.cjs");
+  const content = build({
+    knownHosts: [{
+      hostname: "host.example",
+      keyType: "ssh-ed25519",
+      publicKey: "ssh-ed25519 AAAVAULT",
+    }],
+    fs,
+    hostname: "host.example",
+    port: 22,
+    globalPaths: [],
+    userPaths: [],
+    execFileSyncFn: () => "hostkeyalias shared-key\n",
+  });
+  assert.match(content, /^shared-key ssh-ed25519 AAAVAULT$/m);
+  assert.doesNotMatch(content, /^host\.example ssh-ed25519 AAAVAULT$/m);
+});
+
+test("runSshG discovery receives port and username", () => {
+  const { buildAuthoritativeKnownHostsContent: build } = require("./externalSshHostKeyPolicy.cjs");
+  let capturedArgs = null;
+  build({
+    knownHosts: [{
+      hostname: "host.example",
+      port: 2222,
+      keyType: "ssh-ed25519",
+      publicKey: "ssh-ed25519 AAAVAULT",
+    }],
+    fs,
+    hostname: "host.example",
+    port: 2222,
+    username: "bob",
+    globalPaths: [],
+    userPaths: [],
+    execFileSyncFn: (_cmd, args) => {
+      capturedArgs = args;
+      return "hostkeyalias none\n";
+    },
+  });
+  assert.deepEqual(capturedArgs, ["-G", "-p", "2222", "-l", "bob", "host.example"]);
+});
+
 test("parseSshGKnownHostsPaths reads multi-path directives", () => {
   const { parseSshGKnownHostsPaths } = require("./externalSshHostKeyPolicy.cjs");
   assert.deepEqual(

--- a/electron/bridges/externalSshHostKeyPolicy.test.cjs
+++ b/electron/bridges/externalSshHostKeyPolicy.test.cjs
@@ -3,14 +3,17 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const crypto = require("node:crypto");
 
 const {
+  buildAuthoritativeKnownHostsContent,
   buildExternalHostKeyConfigLines,
   buildExternalHostKeySshOptions,
-  buildMergedGlobalKnownHostsContent,
   buildVaultKnownHostsContent,
+  filterKnownHostsContentExcludingVaultHosts,
   formatVaultKnownHostLine,
   getDefaultGlobalKnownHostsPaths,
+  quoteOpenSshOptionValue,
   resolveExternalStrictHostKeyChecking,
 } = require("./externalSshHostKeyPolicy.cjs");
 
@@ -45,13 +48,6 @@ test("formatVaultKnownHostLine skips fingerprint-only vault entries", () => {
     }),
     null,
   );
-  assert.equal(
-    formatVaultKnownHostLine({
-      hostname: "host.example",
-      fingerprint: "abcdef",
-    }),
-    null,
-  );
 });
 
 test("buildVaultKnownHostsContent joins usable vault entries", () => {
@@ -73,15 +69,9 @@ test("buildVaultKnownHostsContent joins usable vault entries", () => {
     content,
     "a.example ssh-ed25519 AAAAa\n[b.example]:2200 ssh-rsa AAAAb\n",
   );
-  assert.equal(buildVaultKnownHostsContent([]), "");
-  assert.equal(buildVaultKnownHostsContent(undefined), "");
 });
 
 test("getDefaultGlobalKnownHostsPaths covers Unix and Windows defaults", () => {
-  assert.deepEqual(getDefaultGlobalKnownHostsPaths({ platform: "darwin" }), [
-    "/etc/ssh/ssh_known_hosts",
-    "/etc/ssh/ssh_known_hosts2",
-  ]);
   assert.deepEqual(getDefaultGlobalKnownHostsPaths({ platform: "linux" }), [
     "/etc/ssh/ssh_known_hosts",
     "/etc/ssh/ssh_known_hosts2",
@@ -95,61 +85,79 @@ test("getDefaultGlobalKnownHostsPaths covers Unix and Windows defaults", () => {
   );
 });
 
-test("buildMergedGlobalKnownHostsContent merges system globals with vault", () => {
-  const base = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-kh-merge-"));
+test("filterKnownHostsContentExcludingVaultHosts drops conflicting system pins", () => {
+  const content = [
+    "host.example ssh-ed25519 AAASYSTEM",
+    "other.example ssh-rsa AAAOTHER",
+    "[host.example]:2222 ssh-ed25519 AAAPORT",
+    "# comment kept",
+  ].join("\n");
+  const filtered = filterKnownHostsContentExcludingVaultHosts(content, [
+    { hostname: "host.example", port: 22 },
+  ]);
+  assert.doesNotMatch(filtered, /AAASYSTEM/);
+  assert.match(filtered, /other\.example ssh-rsa AAAOTHER/);
+  assert.match(filtered, /\[host\.example\]:2222/);
+  assert.match(filtered, /# comment kept/);
+});
+
+test("filterKnownHostsContentExcludingVaultHosts matches hashed host entries", () => {
+  const hostname = "hashed.example";
+  const salt = crypto.randomBytes(20);
+  const digest = crypto.createHmac("sha1", salt).update(hostname).digest("base64");
+  const hostField = `|1|${salt.toString("base64")}|${digest}`;
+  const content = `${hostField} ssh-ed25519 AAAHASHED\nother.example ssh-rsa AAAOTHER\n`;
+  const filtered = filterKnownHostsContentExcludingVaultHosts(content, [
+    { hostname, port: 22 },
+  ]);
+  assert.doesNotMatch(filtered, /AAAHASHED/);
+  assert.match(filtered, /other\.example/);
+});
+
+test("buildAuthoritativeKnownHostsContent makes vault authoritative over system pins", () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-kh-auth-"));
   try {
     const global1 = path.join(base, "ssh_known_hosts");
-    const global2 = path.join(base, "ssh_known_hosts2");
-    fs.writeFileSync(global1, "admin.example ssh-ed25519 AAAADMIN\n");
-    fs.writeFileSync(global2, "admin2.example ssh-rsa AAAADMIN2\n");
+    const user1 = path.join(base, "user_known_hosts");
+    fs.writeFileSync(global1, "host.example ssh-ed25519 AAAGLOBAL\nadmin.example ssh-rsa AAAADMIN\n");
+    fs.writeFileSync(user1, "host.example ssh-ed25519 AAAUSER\nother.example ssh-ed25519 AAAOTHER\n");
 
-    const content = buildMergedGlobalKnownHostsContent({
+    const content = buildAuthoritativeKnownHostsContent({
       knownHosts: [{
-        hostname: "vault.example",
+        hostname: "host.example",
         keyType: "ssh-ed25519",
         publicKey: "ssh-ed25519 AAAVAULT",
       }],
       fs,
-      globalPaths: [global1, global2, path.join(base, "missing")],
+      globalPaths: [global1],
+      userPaths: [user1],
     });
 
-    assert.match(content, /admin\.example ssh-ed25519 AAAADMIN/);
-    assert.match(content, /admin2\.example ssh-rsa AAAADMIN2/);
-    assert.match(content, /vault\.example ssh-ed25519 AAAVAULT/);
+    assert.match(content, /host\.example ssh-ed25519 AAAVAULT/);
+    assert.doesNotMatch(content, /AAAGLOBAL/);
+    assert.doesNotMatch(content, /AAAUSER/);
+    assert.match(content, /admin\.example ssh-rsa AAAADMIN/);
+    assert.match(content, /other\.example ssh-ed25519 AAAOTHER/);
   } finally {
     fs.rmSync(base, { recursive: true, force: true });
   }
 });
 
-test("buildMergedGlobalKnownHostsContent is empty when vault has no usable pins", () => {
-  const base = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-kh-empty-"));
-  try {
-    const global1 = path.join(base, "ssh_known_hosts");
-    fs.writeFileSync(global1, "admin.example ssh-ed25519 AAAADMIN\n");
-    assert.equal(
-      buildMergedGlobalKnownHostsContent({
-        knownHosts: [{ hostname: "x", fingerprint: "only" }],
-        fs,
-        globalPaths: [global1],
-      }),
-      "",
-    );
-    assert.equal(
-      buildMergedGlobalKnownHostsContent({
-        knownHosts: [],
-        fs,
-        globalPaths: [global1],
-      }),
-      "",
-    );
-  } finally {
-    fs.rmSync(base, { recursive: true, force: true });
-  }
+test("buildAuthoritativeKnownHostsContent is empty when vault has no usable pins", () => {
+  assert.equal(
+    buildAuthoritativeKnownHostsContent({
+      knownHosts: [{ hostname: "x", fingerprint: "only" }],
+      fs,
+      globalPaths: [],
+      userPaths: [],
+    }),
+    "",
+  );
 });
 
 test("resolveExternalStrictHostKeyChecking matches protocol constraints", () => {
   assert.equal(resolveExternalStrictHostKeyChecking({ protocol: "et" }), "accept-new");
-  assert.equal(resolveExternalStrictHostKeyChecking({ protocol: "mosh" }), null);
+  assert.equal(resolveExternalStrictHostKeyChecking({ protocol: "mosh" }), "ask");
   assert.equal(
     resolveExternalStrictHostKeyChecking({ protocol: "et", verifyHostKeys: false }),
     "no",
@@ -160,30 +168,54 @@ test("resolveExternalStrictHostKeyChecking matches protocol constraints", () => 
   );
 });
 
-test("buildExternalHostKeySshOptions injects merged GlobalKnownHostsFile when verifying", () => {
+test("quoteOpenSshOptionValue quotes paths with whitespace", () => {
+  assert.equal(quoteOpenSshOptionValue("/tmp/plain"), "/tmp/plain");
+  assert.equal(
+    quoteOpenSshOptionValue("/Users/Foo Bar/known_hosts"),
+    '"/Users/Foo Bar/known_hosts"',
+  );
+});
+
+test("buildExternalHostKeySshOptions uses authoritative trust for both slots", () => {
   const values = buildExternalHostKeySshOptions({
-    mergedGlobalKnownHostsPath: "/tmp/merged-kh",
+    authoritativeKnownHostsPath: "/tmp/auth-kh",
     protocol: "et",
     style: "values",
   });
   assert.deepEqual(values, [
-    "GlobalKnownHostsFile=/tmp/merged-kh",
+    "UserKnownHostsFile=/tmp/auth-kh",
+    "GlobalKnownHostsFile=/tmp/auth-kh",
     "StrictHostKeyChecking=accept-new",
   ]);
 
   const moshArgs = buildExternalHostKeySshOptions({
-    mergedGlobalKnownHostsPath: "/tmp/merged-kh",
+    authoritativeKnownHostsPath: "/tmp/auth-kh",
     protocol: "mosh",
     style: "args",
   });
   assert.deepEqual(moshArgs, [
-    "-o", "GlobalKnownHostsFile=/tmp/merged-kh",
+    "-o", "UserKnownHostsFile=/tmp/auth-kh",
+    "-o", "GlobalKnownHostsFile=/tmp/auth-kh",
+    "-o", "StrictHostKeyChecking=ask",
   ]);
 });
 
-test("buildExternalHostKeySshOptions omits trust file when verification is disabled", () => {
+test("buildExternalHostKeySshOptions quotes whitespace paths", () => {
+  const values = buildExternalHostKeySshOptions({
+    authoritativeKnownHostsPath: "/tmp/user name/auth-kh",
+    protocol: "et",
+    style: "values",
+  });
+  assert.deepEqual(values, [
+    'UserKnownHostsFile="/tmp/user name/auth-kh"',
+    'GlobalKnownHostsFile="/tmp/user name/auth-kh"',
+    "StrictHostKeyChecking=accept-new",
+  ]);
+});
+
+test("buildExternalHostKeySshOptions neutralizes trust when verification is disabled", () => {
   const disabled = buildExternalHostKeySshOptions({
-    mergedGlobalKnownHostsPath: "/tmp/merged-kh",
+    authoritativeKnownHostsPath: "/tmp/auth-kh",
     emptyKnownHostsPath: "/tmp/empty-kh",
     verifyHostKeys: false,
     protocol: "mosh",
@@ -194,30 +226,17 @@ test("buildExternalHostKeySshOptions omits trust file when verification is disab
     "-o", "GlobalKnownHostsFile=/tmp/empty-kh",
     "-o", "StrictHostKeyChecking=no",
   ]);
-  // Must not keep pointing at the vault/merged trust file.
-  assert.equal(disabled.some((part) => String(part).includes("/tmp/merged-kh")), false);
+  assert.equal(disabled.some((part) => String(part).includes("/tmp/auth-kh")), false);
 });
 
 test("buildExternalHostKeyConfigLines formats indented jump-host stanzas", () => {
   const lines = buildExternalHostKeyConfigLines({
-    mergedGlobalKnownHostsPath: "/tmp/merged-kh",
+    authoritativeKnownHostsPath: "/tmp/auth-kh",
     protocol: "et",
-    quotePath: (v) => `"${v}"`,
   });
   assert.deepEqual(lines, [
-    '  GlobalKnownHostsFile "/tmp/merged-kh"',
+    "  UserKnownHostsFile /tmp/auth-kh",
+    "  GlobalKnownHostsFile /tmp/auth-kh",
     "  StrictHostKeyChecking accept-new",
-  ]);
-
-  const disabled = buildExternalHostKeyConfigLines({
-    emptyKnownHostsPath: "/tmp/empty-kh",
-    verifyHostKeys: false,
-    protocol: "et",
-    quotePath: (v) => `"${v}"`,
-  });
-  assert.deepEqual(disabled, [
-    '  UserKnownHostsFile "/tmp/empty-kh"',
-    '  GlobalKnownHostsFile "/tmp/empty-kh"',
-    "  StrictHostKeyChecking no",
   ]);
 });

--- a/electron/bridges/terminalBridge.bareMoshClient.test.cjs
+++ b/electron/bridges/terminalBridge.bareMoshClient.test.cjs
@@ -204,16 +204,16 @@ test("Mosh injects vault known_hosts into the SSH bootstrap for key-change check
     }],
   }, "session-vault-kh");
 
-  let vaultPath = null;
+  let trustPath = null;
   for (let i = 0; i < auth.sshArgs.length - 1; i += 1) {
     if (auth.sshArgs[i] === "-o" && String(auth.sshArgs[i + 1]).startsWith("GlobalKnownHostsFile=")) {
-      vaultPath = auth.sshArgs[i + 1].slice("GlobalKnownHostsFile=".length);
+      trustPath = auth.sshArgs[i + 1].slice("GlobalKnownHostsFile=".length);
       break;
     }
   }
-  assert.ok(vaultPath, "expected GlobalKnownHostsFile ssh option");
-  assert.ok(fs.existsSync(vaultPath));
-  assert.match(fs.readFileSync(vaultPath, "utf8"), /host\.example ssh-ed25519 AAAAMOSHVAULT/);
+  assert.ok(trustPath, "expected GlobalKnownHostsFile ssh option");
+  assert.ok(fs.existsSync(trustPath));
+  assert.match(fs.readFileSync(trustPath, "utf8"), /host\.example ssh-ed25519 AAAAMOSHVAULT/);
   // Interactive Mosh leaves StrictHostKeyChecking alone so OpenSSH can ask
   // for first-seen hosts in the PTY while still rejecting vault mismatches.
   assert.equal(
@@ -238,12 +238,28 @@ test("Mosh disables host-key checks when verifyHostKeys is false", async (t) => 
   const auth = await api.buildMoshSshAuthArgs({
     useSshAgent: false,
     verifyHostKeys: false,
+    knownHosts: [{
+      hostname: "host.example",
+      keyType: "ssh-ed25519",
+      publicKey: "ssh-ed25519 AAASTALE",
+    }],
   }, "session-no-verify");
 
-  assert.deepEqual(auth.sshArgs, [
-    "-o", "IdentityAgent=none",
-    "-o", "StrictHostKeyChecking=no",
-  ]);
+  assert.equal(auth.sshArgs[0], "-o");
+  assert.equal(auth.sshArgs[1], "IdentityAgent=none");
+  let emptyPath = null;
+  for (let i = 0; i < auth.sshArgs.length - 1; i += 1) {
+    if (auth.sshArgs[i] === "-o" && String(auth.sshArgs[i + 1]).startsWith("UserKnownHostsFile=")) {
+      emptyPath = auth.sshArgs[i + 1].slice("UserKnownHostsFile=".length);
+      break;
+    }
+  }
+  assert.ok(emptyPath);
+  assert.ok(auth.sshArgs.includes(`GlobalKnownHostsFile=${emptyPath}`));
+  assert.ok(auth.sshArgs.includes("StrictHostKeyChecking=no"));
+  assert.equal(fs.readFileSync(emptyPath, "utf8").trim(), "");
+  assert.equal(auth.sshArgs.some((arg) => String(arg).includes("AAASTALE")), false);
+  api.cleanupMoshAuthTempFiles(auth.tempFiles);
 });
 
 test("Mosh explicitly disables native agent login after an opt-out", async () => {

--- a/electron/bridges/terminalBridge.bareMoshClient.test.cjs
+++ b/electron/bridges/terminalBridge.bareMoshClient.test.cjs
@@ -197,6 +197,8 @@ test("Mosh injects vault known_hosts into the SSH bootstrap for key-change check
 
   const auth = await api.buildMoshSshAuthArgs({
     useSshAgent: false,
+    hostname: "host.example",
+    port: 22,
     knownHosts: [{
       hostname: "host.example",
       port: 22,

--- a/electron/bridges/terminalBridge.bareMoshClient.test.cjs
+++ b/electron/bridges/terminalBridge.bareMoshClient.test.cjs
@@ -182,6 +182,70 @@ test("Mosh prepares the configured system agent before building native ssh optio
   api.cleanupMoshAuthTempFiles(selected.tempFiles);
 });
 
+test("Mosh injects vault known_hosts into the SSH bootstrap for key-change checks", async (t) => {
+  const tempBase = makeTmp();
+  t.after(() => fs.rmSync(tempBase, { recursive: true, force: true }));
+  const api = createMoshSessionApi({
+    os,
+    path,
+    fs,
+    process,
+    randomUUID: () => "fixed",
+    tempDirBridge: { getTempFilePath: (fileName) => path.join(tempBase, fileName) },
+  });
+
+  const auth = await api.buildMoshSshAuthArgs({
+    useSshAgent: false,
+    knownHosts: [{
+      hostname: "host.example",
+      port: 22,
+      keyType: "ssh-ed25519",
+      publicKey: "ssh-ed25519 AAAAMOSHVAULT",
+    }],
+  }, "session-vault-kh");
+
+  let vaultPath = null;
+  for (let i = 0; i < auth.sshArgs.length - 1; i += 1) {
+    if (auth.sshArgs[i] === "-o" && String(auth.sshArgs[i + 1]).startsWith("GlobalKnownHostsFile=")) {
+      vaultPath = auth.sshArgs[i + 1].slice("GlobalKnownHostsFile=".length);
+      break;
+    }
+  }
+  assert.ok(vaultPath, "expected GlobalKnownHostsFile ssh option");
+  assert.ok(fs.existsSync(vaultPath));
+  assert.match(fs.readFileSync(vaultPath, "utf8"), /host\.example ssh-ed25519 AAAAMOSHVAULT/);
+  // Interactive Mosh leaves StrictHostKeyChecking alone so OpenSSH can ask
+  // for first-seen hosts in the PTY while still rejecting vault mismatches.
+  assert.equal(
+    auth.sshArgs.some((arg) => String(arg).startsWith("StrictHostKeyChecking=")),
+    false,
+  );
+  api.cleanupMoshAuthTempFiles(auth.tempFiles);
+});
+
+test("Mosh disables host-key checks when verifyHostKeys is false", async (t) => {
+  const tempBase = makeTmp();
+  t.after(() => fs.rmSync(tempBase, { recursive: true, force: true }));
+  const api = createMoshSessionApi({
+    os,
+    path,
+    fs,
+    process,
+    randomUUID: () => "fixed",
+    tempDirBridge: { getTempFilePath: (fileName) => path.join(tempBase, fileName) },
+  });
+
+  const auth = await api.buildMoshSshAuthArgs({
+    useSshAgent: false,
+    verifyHostKeys: false,
+  }, "session-no-verify");
+
+  assert.deepEqual(auth.sshArgs, [
+    "-o", "IdentityAgent=none",
+    "-o", "StrictHostKeyChecking=no",
+  ]);
+});
+
 test("Mosh explicitly disables native agent login after an opt-out", async () => {
   const api = createMoshSessionApi({
     os,

--- a/electron/bridges/terminalBridge.bareMoshClient.test.cjs
+++ b/electron/bridges/terminalBridge.bareMoshClient.test.cjs
@@ -166,6 +166,7 @@ test("Mosh prepares the configured system agent before building native ssh optio
     "-i", path.join(os.homedir(), ".ssh", "id_work.pub"),
     "-o", "IdentitiesOnly=yes",
     "-o", "IdentityAgent=/tmp/custom-agent.sock",
+    "-o", "StrictHostKeyChecking=ask",
   ]);
   assert.equal(env.SSH_AUTH_SOCK, "/tmp/custom-agent.sock");
 
@@ -206,20 +207,17 @@ test("Mosh injects vault known_hosts into the SSH bootstrap for key-change check
 
   let trustPath = null;
   for (let i = 0; i < auth.sshArgs.length - 1; i += 1) {
-    if (auth.sshArgs[i] === "-o" && String(auth.sshArgs[i + 1]).startsWith("GlobalKnownHostsFile=")) {
-      trustPath = auth.sshArgs[i + 1].slice("GlobalKnownHostsFile=".length);
+    if (auth.sshArgs[i] === "-o" && String(auth.sshArgs[i + 1]).startsWith("UserKnownHostsFile=")) {
+      trustPath = auth.sshArgs[i + 1].slice("UserKnownHostsFile=".length);
       break;
     }
   }
-  assert.ok(trustPath, "expected GlobalKnownHostsFile ssh option");
+  assert.ok(trustPath, "expected UserKnownHostsFile ssh option");
+  assert.ok(auth.sshArgs.includes(`GlobalKnownHostsFile=${trustPath}`));
   assert.ok(fs.existsSync(trustPath));
   assert.match(fs.readFileSync(trustPath, "utf8"), /host\.example ssh-ed25519 AAAAMOSHVAULT/);
-  // Interactive Mosh leaves StrictHostKeyChecking alone so OpenSSH can ask
-  // for first-seen hosts in the PTY while still rejecting vault mismatches.
-  assert.equal(
-    auth.sshArgs.some((arg) => String(arg).startsWith("StrictHostKeyChecking=")),
-    false,
-  );
+  // Force ask so a permissive user ssh_config cannot disable verification.
+  assert.ok(auth.sshArgs.includes("StrictHostKeyChecking=ask"));
   api.cleanupMoshAuthTempFiles(auth.tempFiles);
 });
 
@@ -276,7 +274,10 @@ test("Mosh explicitly disables native agent login after an opt-out", async () =>
     { useSshAgent: false },
   );
 
-  assert.deepEqual(auth.sshArgs, ["-o", "IdentityAgent=none"]);
+  assert.deepEqual(auth.sshArgs, [
+    "-o", "IdentityAgent=none",
+    "-o", "StrictHostKeyChecking=ask",
+  ]);
   assert.equal(env.SSH_AUTH_SOCK, undefined);
 
   const forwardingAuth = await api.buildMoshSshAuthArgs({
@@ -290,6 +291,7 @@ test("Mosh explicitly disables native agent login after an opt-out", async () =>
   assert.deepEqual(forwardingAuth.sshArgs, [
     "-o", "IdentityAgent=none",
     "-o", "ForwardAgent=${SSH_AUTH_SOCK}",
+    "-o", "StrictHostKeyChecking=ask",
   ]);
   assert.equal(forwardingEnv.SSH_AUTH_SOCK, "/tmp/forwarded-agent.sock");
 });
@@ -316,6 +318,7 @@ test("Mosh automatic mode discovers custom local keys in preferred order", async
   assert.deepEqual(auth.sshArgs, [
     "-i", path.join(sshDir, "id_ed25519"),
     "-i", path.join(sshDir, "id_work"),
+    "-o", "StrictHostKeyChecking=ask",
   ]);
   assert.deepEqual(auth.identityFilePaths, [
     path.join(sshDir, "id_ed25519"),
@@ -330,6 +333,7 @@ test("Mosh automatic mode discovers custom local keys in preferred order", async
   assert.deepEqual(agentFallback.sshArgs, [
     "-i", path.join(sshDir, "id_ed25519"),
     "-i", path.join(sshDir, "id_work"),
+    "-o", "StrictHostKeyChecking=ask",
   ]);
   assert.deepEqual(agentFallback.identityFilePaths, [
     path.join(sshDir, "id_ed25519"),

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -379,7 +379,8 @@ main();
       // sessions. With a jump host, host-key options are applied per-hop via
       // Host blocks (not global --ssh-option) so one hop's snapshot cannot
       // force the other hop off the persistent trust file.
-      let authoritativeKnownHostsPath = null;
+      let targetAuthoritativeKnownHostsPath = null;
+      let jumpAuthoritativeKnownHostsPath = null;
       let emptyKnownHostsPath = null;
       const targetConnectionHost = {
         hostname: options.hostname,
@@ -392,17 +393,39 @@ main();
       const vaultPinsTarget = vaultPinsConnectionHosts(options.knownHosts, [targetConnectionHost]);
       const vaultPinsJump = vaultPinsConnectionHosts(options.knownHosts, jumpConnectionHosts);
       if (verifyHostKeys) {
-        if (vaultPinsTarget || vaultPinsJump) {
-          const authoritativeContent = buildAuthoritativeKnownHostsContent({
+        // Build per-hop snapshots with ssh -G discovery for THAT hop's
+        // hostname so Host-scoped GlobalKnownHostsFile / UserKnownHostsFile
+        // (and @revoked entries there) are not lost.
+        if (vaultPinsTarget) {
+          const targetContent = buildAuthoritativeKnownHostsContent({
             knownHosts: options.knownHosts,
             fs,
             hostname: options.hostname,
             pathModule: path,
             homedir: os.homedir(),
           });
-          if (authoritativeContent) {
-            authoritativeKnownHostsPath = path.join(sshDir, `${safeId}-authoritative-known_hosts`);
-            writeSecureFile(authoritativeKnownHostsPath, authoritativeContent, 0o600);
+          if (targetContent) {
+            targetAuthoritativeKnownHostsPath = path.join(
+              sshDir,
+              `${safeId}-authoritative-target-known_hosts`,
+            );
+            writeSecureFile(targetAuthoritativeKnownHostsPath, targetContent, 0o600);
+          }
+        }
+        if (vaultPinsJump && jumpHosts[0]) {
+          const jumpContent = buildAuthoritativeKnownHostsContent({
+            knownHosts: options.knownHosts,
+            fs,
+            hostname: jumpHosts[0].hostname,
+            pathModule: path,
+            homedir: os.homedir(),
+          });
+          if (jumpContent) {
+            jumpAuthoritativeKnownHostsPath = path.join(
+              sshDir,
+              `${safeId}-authoritative-jump-known_hosts`,
+            );
+            writeSecureFile(jumpAuthoritativeKnownHostsPath, jumpContent, 0o600);
           }
         }
       } else {
@@ -414,10 +437,10 @@ main();
       }
 
       const targetUsesAuthoritative = Boolean(
-        verifyHostKeys && vaultPinsTarget && authoritativeKnownHostsPath,
+        verifyHostKeys && vaultPinsTarget && targetAuthoritativeKnownHostsPath,
       );
       const jumpUsesAuthoritative = Boolean(
-        verifyHostKeys && vaultPinsJump && authoritativeKnownHostsPath,
+        verifyHostKeys && vaultPinsJump && jumpAuthoritativeKnownHostsPath,
       );
       const hasJumpHost = jumpHosts.length > 0;
 
@@ -429,7 +452,9 @@ main();
           sshOptions.push(`UserKnownHostsFile=${normalizeSshConfigPath(knownHostsPath)}`);
         }
         sshOptions.push(...buildExternalHostKeySshOptions({
-          authoritativeKnownHostsPath: targetUsesAuthoritative ? authoritativeKnownHostsPath : null,
+          authoritativeKnownHostsPath: targetUsesAuthoritative
+            ? targetAuthoritativeKnownHostsPath
+            : null,
           emptyKnownHostsPath,
           verifyHostKeys,
           protocol: "et",
@@ -439,12 +464,6 @@ main();
         if (!sshOptions.some((opt) => opt.startsWith("StrictHostKeyChecking="))) {
           sshOptions.push("StrictHostKeyChecking=accept-new");
         }
-      } else if (targetUsesAuthoritative) {
-        // Single-hop-style target policy is deferred into the Host <dest>
-        // block so it does not override the jump hop via --ssh-option.
-      } else {
-        // Target not vault-pinned: still need accept-new default for the
-        // destination hop; applied in the Host <dest> block below.
       }
       sshOptions.push("LogLevel=ERROR");
 
@@ -701,7 +720,7 @@ main();
         if (verifyHostKeys) {
           if (jumpUsesAuthoritative) {
             jumpConfigLines.push(...buildExternalHostKeyConfigLines({
-              authoritativeKnownHostsPath,
+              authoritativeKnownHostsPath: jumpAuthoritativeKnownHostsPath,
               verifyHostKeys: true,
               protocol: "et",
               normalizePath: normalizeSshConfigPath,
@@ -750,7 +769,7 @@ main();
         if (verifyHostKeys) {
           if (targetUsesAuthoritative) {
             for (const line of buildExternalHostKeyConfigLines({
-              authoritativeKnownHostsPath,
+              authoritativeKnownHostsPath: targetAuthoritativeKnownHostsPath,
               verifyHostKeys: true,
               protocol: "et",
               normalizePath: normalizeSshConfigPath,
@@ -862,43 +881,55 @@ main();
 
     /**
      * Build a known_hosts file for background ET exec (stats / distro probes).
-     * Merges the user's system known_hosts with any Netcatty-vault entries that
-     * carry a full public key blob, then pins StrictHostKeyChecking=yes on exec
-     * so accept-new cannot auto-trust a host in a non-interactive flow.
+     * Reuses the vault-authoritative snapshot builder so system pins for
+     * vault-covered hosts cannot override the vault key (same policy as the
+     * interactive ET bootstrap). Falls back to system+vault merge without
+     * filtering when the vault has no usable pins.
      */
     function ensureStrictExecKnownHostsFile(session, knownHosts) {
       if (session.etStrictExecKnownHostsPath) {
         return session.etStrictExecKnownHostsPath;
       }
 
-      const { readSystemKnownHostsContent } = createSystemKnownHostsApi({
-        fs, path, os, crypto, log: console,
+      const hostname = session.etStatsAuth?.hostname
+        || session.sshUserHost?.split("@").pop()
+        || "localhost";
+      let content = buildAuthoritativeKnownHostsContent({
+        knownHosts,
+        fs,
+        hostname,
+        pathModule: path,
+        homedir: os.homedir(),
       });
-      const chunks = [];
 
-      try {
-        const systemContent = readSystemKnownHostsContent();
-        if (systemContent) chunks.push(systemContent);
-      } catch {
-        // ignore read failures — strict checking fails closed below
-      }
-
-      const configuredKnownHosts = (session.sshOptions || []).find(
-        (opt) => opt.startsWith("UserKnownHostsFile="),
-      );
-      if (configuredKnownHosts) {
-        const configuredPath = configuredKnownHosts.slice("UserKnownHostsFile=".length);
+      // No vault pins: keep the previous fail-closed merge of system + any
+      // configured user known_hosts so probes still have a trust source.
+      if (!content) {
+        const { readSystemKnownHostsContent } = createSystemKnownHostsApi({
+          fs, path, os, crypto, log: console,
+        });
+        const chunks = [];
         try {
-          const configuredContent = fs.readFileSync(configuredPath, "utf8");
-          if (configuredContent) chunks.push(configuredContent);
+          const systemContent = readSystemKnownHostsContent();
+          if (systemContent) chunks.push(systemContent);
         } catch {
-          // ignore missing configured file
+          // ignore read failures — strict checking fails closed below
         }
-      }
-
-      const vaultContent = buildVaultKnownHostsContent(knownHosts);
-      if (vaultContent) {
-        chunks.push(vaultContent.trimEnd());
+        const configuredKnownHosts = (session.sshOptions || []).find(
+          (opt) => opt.startsWith("UserKnownHostsFile="),
+        );
+        if (configuredKnownHosts) {
+          const configuredPath = configuredKnownHosts.slice("UserKnownHostsFile=".length)
+            .replace(/^"|"$/g, "");
+          try {
+            const configuredContent = fs.readFileSync(configuredPath, "utf8");
+            if (configuredContent) chunks.push(configuredContent);
+          } catch {
+            // ignore missing configured file
+          }
+        }
+        content = chunks.filter(Boolean).join("\n");
+        if (content && !content.endsWith("\n")) content += "\n";
       }
 
       const artifact = Array.isArray(session.externalAuthArtifacts)
@@ -906,7 +937,7 @@ main();
         : null;
       const sshDir = artifact ? path.dirname(artifact) : tempDirBridge.getTempDir();
       const strictKhPath = path.join(sshDir, "netcatty-et-strict-known_hosts");
-      writeSecureFile(strictKhPath, chunks.filter(Boolean).join("\n") + (chunks.length ? "\n" : ""), 0o600);
+      writeSecureFile(strictKhPath, content || "", 0o600);
       session.etStrictExecKnownHostsPath = strictKhPath;
       if (Array.isArray(session.externalAuthArtifacts)) {
         session.externalAuthArtifacts.push(strictKhPath);

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -761,6 +761,38 @@ main();
       const writesConfigFile = configFileLines.length > 0;
       let configPath = null;
       if (writesConfigFile) {
+        // -F replaces the per-user config and also skips the system-wide
+        // config. Append Include directives AFTER our Host blocks so:
+        //   1) first-obtained-value keeps session overrides (ProxyJump,
+        //      vault known_hosts, IdentityFile, …) for matched hosts, and
+        //   2) HostName aliases / ProxyCommand / algorithms from the user's
+        //      normal ~/.ssh/config still apply (Codex P1 on PR #2529).
+        const includeLines = [];
+        try {
+          const realUserConfig = path.join(os.homedir(), ".ssh", "config");
+          if (fs.existsSync(realUserConfig)) {
+            includeLines.push(`Include ${quoteSshConfigValue(realUserConfig)}`);
+          }
+        } catch {
+          // ignore
+        }
+        try {
+          const systemConfigs = process.platform === "win32"
+            ? [path.join(process.env.ProgramData || "C:\\ProgramData", "ssh", "ssh_config")]
+            : ["/etc/ssh/ssh_config"];
+          for (const systemConfig of systemConfigs) {
+            if (fs.existsSync(systemConfig)) {
+              includeLines.push(`Include ${quoteSshConfigValue(systemConfig)}`);
+            }
+          }
+        } catch {
+          // ignore
+        }
+        if (includeLines.length > 0) {
+          configFileLines.push("");
+          configFileLines.push("# Preserve normal OpenSSH user/system configuration under -F.");
+          configFileLines.push(...includeLines);
+        }
         configPath = path.join(sshDir, "config");
         writeSecureFile(configPath, configFileLines.join("\n") + "\n", 0o600);
       }

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -1,6 +1,11 @@
 /* eslint-disable no-undef */
 const crypto = require("node:crypto");
 const { createSystemKnownHostsApi } = require("../sshBridge/systemKnownHosts.cjs");
+const {
+  buildExternalHostKeyConfigLines,
+  buildExternalHostKeySshOptions,
+  buildVaultKnownHostsContent,
+} = require("../externalSshHostKeyPolicy.cjs");
 const { emitTerminalSessionData } = require("../emitTerminalSessionData.cjs");
 const {
   setBufferedOutputBytes,
@@ -365,7 +370,30 @@ main();
       // LogLevel=ERROR silences the "Permanently added..." notice and other
       // ssh banners so the first real PTY bytes are the remote shell. Mirrors
       // the options already used by execOnEtSession.
-      sshOptions.push("StrictHostKeyChecking=accept-new");
+      //
+      // Vault known_hosts (issue #2501): keys the user already trusted via
+      // Netcatty SSH live in the in-app vault, not necessarily in
+      // ~/.ssh/known_hosts. Inject them as GlobalKnownHostsFile so a rotated
+      // server key is rejected the same way OpenSSH rejects system mismatches.
+      let vaultKnownHostsPath = null;
+      const vaultContent = buildVaultKnownHostsContent(options.knownHosts);
+      if (vaultContent) {
+        vaultKnownHostsPath = path.join(sshDir, `${safeId}-vault-known_hosts`);
+        writeSecureFile(vaultKnownHostsPath, vaultContent, 0o600);
+      }
+      sshOptions.push(...buildExternalHostKeySshOptions({
+        vaultKnownHostsPath,
+        verifyHostKeys: options.verifyHostKeys,
+        protocol: "et",
+        style: "values",
+        normalizePath: normalizeSshConfigPath,
+      }));
+      // When verification is on, buildExternalHostKeySshOptions already emits
+      // StrictHostKeyChecking=accept-new; when off it emits =no. Avoid a
+      // duplicate default so verifyHostKeys=false can disable checks.
+      if (!sshOptions.some((opt) => opt.startsWith("StrictHostKeyChecking="))) {
+        sshOptions.push("StrictHostKeyChecking=accept-new");
+      }
       sshOptions.push("LogLevel=ERROR");
 
       // Port
@@ -618,8 +646,20 @@ main();
         // Share known_hosts with the jump connection and apply the same
         // non-interactive host-key handling as the target hop — the jump's
         // ssh is just as unable to answer a yes/no prompt via SSH_ASKPASS.
+        // Vault keys (issue #2501) must also protect the jump hop.
         jumpConfigLines.push(`  UserKnownHostsFile ${quoteSshConfigValue(knownHostsPath)}`);
-        jumpConfigLines.push("  StrictHostKeyChecking accept-new");
+        const jumpHostKeyLines = buildExternalHostKeyConfigLines({
+          vaultKnownHostsPath,
+          verifyHostKeys: options.verifyHostKeys,
+          protocol: "et",
+          normalizePath: normalizeSshConfigPath,
+          quotePath: quoteSshConfigValue,
+        });
+        if (jumpHostKeyLines.length > 0) {
+          jumpConfigLines.push(...jumpHostKeyLines);
+        } else {
+          jumpConfigLines.push("  StrictHostKeyChecking accept-new");
+        }
         jumpConfigLines.push("  LogLevel ERROR");
         jumpConfigLines.push("  KbdInteractiveAuthentication yes");
         jumpConfigLines.push("  NumberOfPasswordPrompts 1");
@@ -733,26 +773,6 @@ main();
       return env;
     }
 
-    function formatVaultKnownHostLine(knownHost) {
-      if (!knownHost?.hostname || !knownHost?.keyType) return null;
-      const port = Number.isFinite(knownHost.port) ? Number(knownHost.port) : 22;
-      const hostField = port !== 22 ? `[${knownHost.hostname}]:${port}` : knownHost.hostname;
-      const pubKey = String(knownHost.publicKey || "").trim();
-      const parts = pubKey.split(/\s+/);
-      let keyType = knownHost.keyType;
-      let keyBlob = "";
-      if (parts.length >= 2 && /^ssh-|^ecdsa-|^sk-/.test(parts[0])) {
-        keyType = parts[0];
-        keyBlob = parts[1];
-      } else if (parts.length === 1 && parts[0].length > 0 && !/^SHA256:/i.test(parts[0])) {
-        keyBlob = parts[0];
-      } else {
-        return null;
-      }
-      if (!keyBlob) return null;
-      return `${hostField} ${keyType} ${keyBlob}`;
-    }
-
     /**
      * Build a known_hosts file for background ET exec (stats / distro probes).
      * Merges the user's system known_hosts with any Netcatty-vault entries that
@@ -789,15 +809,9 @@ main();
         }
       }
 
-      const vaultLines = [];
-      if (Array.isArray(knownHosts)) {
-        for (const knownHost of knownHosts) {
-          const line = formatVaultKnownHostLine(knownHost);
-          if (line) vaultLines.push(line);
-        }
-      }
-      if (vaultLines.length > 0) {
-        chunks.push(vaultLines.join("\n"));
+      const vaultContent = buildVaultKnownHostsContent(knownHosts);
+      if (vaultContent) {
+        chunks.push(vaultContent.trimEnd());
       }
 
       const artifact = Array.isArray(session.externalAuthArtifacts)

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -372,13 +372,15 @@ main();
       // ssh banners so the first real PTY bytes are the remote shell. Mirrors
       // the options already used by execOnEtSession.
       //
-      // Vault known_hosts (issue #2501): when the vault pins the target and/or
-      // jump hop, build authoritative session snapshot(s) and apply them via
-      // --ssh-option. ET only passes --ssh-option to OpenSSH reliably; Host
-      // blocks under a temp HOME are not always read on POSIX (OpenSSH uses
-      // the account home for config resolution), so command-line policy is
-      // the enforceable path.
-      let authoritativeKnownHostsPath = null;
+      // Vault known_hosts (issue #2501):
+      //  - Destination hop: enforced via --ssh-option (ET applies these only
+      //    to the final target; temp-HOME Host blocks are unreliable on POSIX).
+      //  - Jump hop: enforced via Host <jump> config block (ProxyJump child
+      //    process does not inherit --ssh-option).
+      // Build per-hop snapshots so shared multi-host system lines are filtered
+      // only for the hop that is vault-pinned.
+      let targetAuthoritativeKnownHostsPath = null;
+      let jumpAuthoritativeKnownHostsPath = null;
       let emptyKnownHostsPath = null;
       const targetConnectionHost = {
         hostname: options.hostname,
@@ -391,7 +393,6 @@ main();
       const vaultPinsTarget = vaultPinsConnectionHosts(options.knownHosts, [targetConnectionHost]);
       const vaultPinsJump = vaultPinsConnectionHosts(options.knownHosts, jumpConnectionHosts);
       if (verifyHostKeys) {
-        const contentChunks = [];
         if (vaultPinsTarget) {
           const targetContent = buildAuthoritativeKnownHostsContent({
             knownHosts: options.knownHosts,
@@ -402,7 +403,13 @@ main();
             pathModule: path,
             homedir: os.homedir(),
           });
-          if (targetContent) contentChunks.push(targetContent.trimEnd());
+          if (targetContent) {
+            targetAuthoritativeKnownHostsPath = path.join(
+              sshDir,
+              `${safeId}-authoritative-target-known_hosts`,
+            );
+            writeSecureFile(targetAuthoritativeKnownHostsPath, targetContent, 0o600);
+          }
         }
         if (vaultPinsJump && jumpHosts[0]) {
           const jumpContent = buildAuthoritativeKnownHostsContent({
@@ -414,24 +421,13 @@ main();
             pathModule: path,
             homedir: os.homedir(),
           });
-          if (jumpContent) contentChunks.push(jumpContent.trimEnd());
-        }
-        if (contentChunks.length > 0) {
-          // De-dupe lines across hop snapshots while preserving order.
-          const seen = new Set();
-          const merged = [];
-          for (const chunk of contentChunks) {
-            for (const line of chunk.split("\n")) {
-              if (!line || seen.has(line)) continue;
-              seen.add(line);
-              merged.push(line);
-            }
+          if (jumpContent) {
+            jumpAuthoritativeKnownHostsPath = path.join(
+              sshDir,
+              `${safeId}-authoritative-jump-known_hosts`,
+            );
+            writeSecureFile(jumpAuthoritativeKnownHostsPath, jumpContent, 0o600);
           }
-          authoritativeKnownHostsPath = path.join(
-            sshDir,
-            `${safeId}-authoritative-known_hosts`,
-          );
-          writeSecureFile(authoritativeKnownHostsPath, `${merged.join("\n")}\n`, 0o600);
         }
       } else {
         // StrictHostKeyChecking=no still consults known_hosts for password-auth
@@ -441,12 +437,12 @@ main();
         writeSecureFile(emptyKnownHostsPath, "", 0o600);
       }
 
-      // Always apply host-key policy through --ssh-option (see comment above).
-      if (verifyHostKeys && !authoritativeKnownHostsPath) {
+      // Destination hop host-key policy via --ssh-option.
+      if (verifyHostKeys && !targetAuthoritativeKnownHostsPath) {
         sshOptions.push(`UserKnownHostsFile=${normalizeSshConfigPath(knownHostsPath)}`);
       }
       sshOptions.push(...buildExternalHostKeySshOptions({
-        authoritativeKnownHostsPath,
+        authoritativeKnownHostsPath: targetAuthoritativeKnownHostsPath,
         emptyKnownHostsPath,
         verifyHostKeys,
         protocol: "et",
@@ -710,9 +706,9 @@ main();
         // ProxyJump starts a separate OpenSSH process that reads the jump
         // stanza (see comment near etJumpArgs).
         if (verifyHostKeys) {
-          if (authoritativeKnownHostsPath && vaultPinsJump) {
+          if (jumpAuthoritativeKnownHostsPath) {
             jumpConfigLines.push(...buildExternalHostKeyConfigLines({
-              authoritativeKnownHostsPath,
+              authoritativeKnownHostsPath: jumpAuthoritativeKnownHostsPath,
               verifyHostKeys: true,
               protocol: "et",
               normalizePath: normalizeSshConfigPath,

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -393,6 +393,9 @@ main();
       const vaultPinsTarget = vaultPinsConnectionHosts(options.knownHosts, [targetConnectionHost]);
       const vaultPinsJump = vaultPinsConnectionHosts(options.knownHosts, jumpConnectionHosts);
       if (verifyHostKeys) {
+        // Per-connection memo only — never process-lifetime, so ssh_config
+        // edits are observed on the next connect (Codex P1).
+        const sshGMemo = new Map();
         if (vaultPinsTarget) {
           const targetContent = buildAuthoritativeKnownHostsContent({
             knownHosts: options.knownHosts,
@@ -402,6 +405,7 @@ main();
             username: options.username,
             pathModule: path,
             homedir: os.homedir(),
+            memo: sshGMemo,
           });
           if (targetContent) {
             targetAuthoritativeKnownHostsPath = path.join(
@@ -420,6 +424,7 @@ main();
             username: jumpHosts[0].username,
             pathModule: path,
             homedir: os.homedir(),
+            memo: sshGMemo,
           });
           if (jumpContent) {
             jumpAuthoritativeKnownHostsPath = path.join(

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -3,6 +3,7 @@ const crypto = require("node:crypto");
 const { createSystemKnownHostsApi } = require("../sshBridge/systemKnownHosts.cjs");
 const {
   buildAuthoritativeKnownHostsContent,
+  buildExternalHostKeyConfigLines,
   buildExternalHostKeySshOptions,
   vaultPinsConnectionHosts,
 } = require("../externalSshHostKeyPolicy.cjs");
@@ -704,9 +705,32 @@ main();
           }), jumpPwPath);
         }
 
-        // Jump host identity/auth options only. Host-key policy is applied via
-        // --ssh-option (command line) so it is enforceable on POSIX where a
-        // temp-HOME config Host block may not be consulted by OpenSSH.
+        // Jump-host host-key policy must live in this Host block: ET's
+        // --ssh-option values apply only to the final destination hop, while
+        // ProxyJump starts a separate OpenSSH process that reads the jump
+        // stanza (see comment near etJumpArgs).
+        if (verifyHostKeys) {
+          if (authoritativeKnownHostsPath && vaultPinsJump) {
+            jumpConfigLines.push(...buildExternalHostKeyConfigLines({
+              authoritativeKnownHostsPath,
+              verifyHostKeys: true,
+              protocol: "et",
+              normalizePath: normalizeSshConfigPath,
+              quotePath: quoteSshConfigValue,
+            }));
+          } else {
+            jumpConfigLines.push(`  UserKnownHostsFile ${quoteSshConfigValue(knownHostsPath)}`);
+            jumpConfigLines.push("  StrictHostKeyChecking accept-new");
+          }
+        } else if (emptyKnownHostsPath) {
+          jumpConfigLines.push(...buildExternalHostKeyConfigLines({
+            emptyKnownHostsPath,
+            verifyHostKeys: false,
+            protocol: "et",
+            normalizePath: normalizeSshConfigPath,
+            quotePath: quoteSshConfigValue,
+          }));
+        }
         jumpConfigLines.push("  LogLevel ERROR");
         jumpConfigLines.push("  KbdInteractiveAuthentication yes");
         jumpConfigLines.push("  NumberOfPasswordPrompts 1");

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -789,7 +789,11 @@ main();
           // ignore
         }
         if (includeLines.length > 0) {
+          // Reset Host/Match context first. Without this, Includes after a
+          // `Host <jump>` stanza stay conditional on the jump host and are
+          // skipped for the destination (Codex P1).
           configFileLines.push("");
+          configFileLines.push("Match all");
           configFileLines.push("# Preserve normal OpenSSH user/system configuration under -F.");
           configFileLines.push(...includeLines);
         }
@@ -861,8 +865,19 @@ main();
               0o700,
             );
           }
-          const pathKey = Object.keys(process.env).find((k) => k.toLowerCase() === "path") || "PATH";
-          const currentPath = process.env[pathKey] || "";
+          // Prepend the wrapper to the effective session PATH (options.env),
+          // not bare process.env — host/session PATH may carry ProxyCommand
+          // helpers that must remain visible (Codex P2).
+          const sessionEnv = options.env && typeof options.env === "object" ? options.env : {};
+          const pathKey = Object.keys(sessionEnv).find((k) => k.toLowerCase() === "path")
+            || Object.keys(process.env).find((k) => k.toLowerCase() === "path")
+            || "PATH";
+          const currentPath = sessionEnv[pathKey]
+            || sessionEnv.PATH
+            || sessionEnv.Path
+            || process.env[pathKey]
+            || process.env.PATH
+            || "";
           pathEnv[pathKey] = currentPath ? `${wrapperDir}${path.delimiter}${currentPath}` : wrapperDir;
         } catch {
           // Wrapper is best-effort; destination --ssh-option still applies.

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -394,6 +394,7 @@ main();
           const authoritativeContent = buildAuthoritativeKnownHostsContent({
             knownHosts: options.knownHosts,
             fs,
+            hostname: options.hostname,
             pathModule: path,
             homedir: os.homedir(),
           });

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -610,8 +610,14 @@ main();
 
         // Per-hop jump settings live in a `Host <jumpHost>` block so they apply
         // to the ProxyJump connection only (not the destination).
+        // Do NOT set HostName to the alias token here: OpenSSH keeps the first
+        // obtained value, so a redundant `HostName bastion` would freeze the
+        // literal name and prevent the later Include of ~/.ssh/config from
+        // supplying the real HostName (e.g. 10.0.0.5). That would also diverge
+        // from the vault snapshot built via `ssh -G` against the real config.
+        // Omitting HostName lets Include resolve aliases; plain hostnames still
+        // default HostName to the Host token (Codex P1 on PR #2529).
         jumpConfigLines.push(`Host ${jumpHost}`);
-        jumpConfigLines.push(`  HostName ${jumpHost}`);
         jumpConfigLines.push(`  User ${jumpUser}`);
         jumpConfigLines.push(`  Port ${jumpPort}`);
 

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -776,9 +776,40 @@ main();
       const pathEnv = {};
       if (configPath) {
         try {
-          const realSsh = process.platform === "win32"
-            ? (findExecutable("ssh") || "ssh")
-            : "ssh";
+          // Resolve the real OpenSSH binary to an absolute path BEFORE we
+          // prepend the wrapper directory to PATH. Embedding a bare `ssh`
+          // name would recurse into the wrapper forever.
+          let realSsh = process.platform === "win32"
+            ? (findExecutable("ssh") || "")
+            : "";
+          if (!realSsh || !path.isAbsolute(realSsh)) {
+            try {
+              const resolved = execFileSync(
+                process.platform === "win32" ? "where" : "sh",
+                process.platform === "win32" ? ["ssh"] : ["-c", "command -v ssh"],
+                {
+                  encoding: "utf8",
+                  timeout: 2000,
+                  windowsHide: true,
+                  env: process.env,
+                },
+              ).trim().split(/\r?\n/)[0];
+              if (resolved) realSsh = resolved;
+            } catch {
+              // Fall through to common absolute locations.
+            }
+          }
+          if (!realSsh || !path.isAbsolute(String(realSsh))) {
+            const candidates = process.platform === "win32"
+              ? []
+              : ["/usr/bin/ssh", "/bin/ssh", "/usr/local/bin/ssh"];
+            realSsh = candidates.find((candidate) => {
+              try { return fs.existsSync(candidate); } catch { return false; }
+            }) || realSsh || "ssh";
+          }
+          if (!path.isAbsolute(String(realSsh))) {
+            throw new Error("unable to resolve absolute OpenSSH path for wrapper");
+          }
           const wrapperDir = path.join(sshDir, "bin");
           fs.mkdirSync(wrapperDir, { recursive: true });
           if (process.platform === "win32") {

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -2,9 +2,9 @@
 const crypto = require("node:crypto");
 const { createSystemKnownHostsApi } = require("../sshBridge/systemKnownHosts.cjs");
 const {
+  buildAuthoritativeKnownHostsContent,
   buildExternalHostKeyConfigLines,
   buildExternalHostKeySshOptions,
-  buildMergedGlobalKnownHostsContent,
   buildVaultKnownHostsContent,
 } = require("../externalSshHostKeyPolicy.cjs");
 const { emitTerminalSessionData } = require("../emitTerminalSessionData.cjs");
@@ -372,23 +372,27 @@ main();
       // ssh banners so the first real PTY bytes are the remote shell. Mirrors
       // the options already used by execOnEtSession.
       //
-      // Vault known_hosts (issue #2501): keys the user already trusted via
-      // Netcatty SSH live in the in-app vault, not necessarily in
-      // ~/.ssh/known_hosts. Merge vault pins with OpenSSH's default global
-      // known_hosts files into one GlobalKnownHostsFile so admin-pinned
-      // hosts in /etc/ssh/ssh_known_hosts are preserved (Codex review).
-      let mergedGlobalKnownHostsPath = null;
+      // Vault known_hosts (issue #2501): when the vault pins a host, build an
+      // authoritative known_hosts snapshot (vault pins + system entries for
+      // non-vault hosts) and point BOTH User/Global known_hosts at it. OpenSSH
+      // accepts a match from any trust source, so a rotated system K2 next to
+      // vault K1 would otherwise win.
+      let authoritativeKnownHostsPath = null;
       let emptyKnownHostsPath = null;
       if (verifyHostKeys) {
-        sshOptions.push(`UserKnownHostsFile=${normalizeSshConfigPath(knownHostsPath)}`);
-        const mergedContent = buildMergedGlobalKnownHostsContent({
+        const authoritativeContent = buildAuthoritativeKnownHostsContent({
           knownHosts: options.knownHosts,
           fs,
           pathModule: path,
+          homedir: os.homedir(),
         });
-        if (mergedContent) {
-          mergedGlobalKnownHostsPath = path.join(sshDir, `${safeId}-global-known_hosts`);
-          writeSecureFile(mergedGlobalKnownHostsPath, mergedContent, 0o600);
+        if (authoritativeContent) {
+          authoritativeKnownHostsPath = path.join(sshDir, `${safeId}-authoritative-known_hosts`);
+          writeSecureFile(authoritativeKnownHostsPath, authoritativeContent, 0o600);
+        } else {
+          // No vault pins: keep the persistent user known_hosts so accept-new
+          // records first-seen keys for later mismatch detection.
+          sshOptions.push(`UserKnownHostsFile=${normalizeSshConfigPath(knownHostsPath)}`);
         }
       } else {
         // StrictHostKeyChecking=no still consults known_hosts for password-auth
@@ -398,7 +402,7 @@ main();
         writeSecureFile(emptyKnownHostsPath, "", 0o600);
       }
       sshOptions.push(...buildExternalHostKeySshOptions({
-        mergedGlobalKnownHostsPath,
+        authoritativeKnownHostsPath,
         emptyKnownHostsPath,
         verifyHostKeys,
         protocol: "et",
@@ -664,11 +668,11 @@ main();
         // non-interactive host-key handling as the target hop — the jump's
         // ssh is just as unable to answer a yes/no prompt via SSH_ASKPASS.
         // Vault keys (issue #2501) must also protect the jump hop.
-        if (verifyHostKeys) {
+        if (verifyHostKeys && !authoritativeKnownHostsPath) {
           jumpConfigLines.push(`  UserKnownHostsFile ${quoteSshConfigValue(knownHostsPath)}`);
         }
         const jumpHostKeyLines = buildExternalHostKeyConfigLines({
-          mergedGlobalKnownHostsPath,
+          authoritativeKnownHostsPath,
           emptyKnownHostsPath,
           verifyHostKeys,
           protocol: "et",
@@ -676,12 +680,7 @@ main();
           quotePath: quoteSshConfigValue,
         });
         if (jumpHostKeyLines.length > 0) {
-          jumpHostKeyLines.forEach((line) => {
-            // Avoid duplicating UserKnownHostsFile when verification is on
-            // (already set above to the persistent system file).
-            if (verifyHostKeys && line.includes("UserKnownHostsFile ")) return;
-            jumpConfigLines.push(line);
-          });
+          jumpConfigLines.push(...jumpHostKeyLines);
         } else if (verifyHostKeys) {
           jumpConfigLines.push("  StrictHostKeyChecking accept-new");
         }

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -930,6 +930,20 @@ main();
 
       const sshCmd = process.platform === "win32" ? findExecutable("ssh") : "ssh";
       const args = ["-o", "BatchMode=no"];
+      // OpenSSH resolves the user config from the account home directory, not
+      // $HOME. Force the session-generated config (ProxyJump + jump Host-key
+      // policy) with -F so the ProxyJump child actually sees it.
+      const sessionHome = session.sshEnv?.HOME || session.sshEnv?.USERPROFILE;
+      if (sessionHome) {
+        const sessionConfigPath = path.join(sessionHome, ".ssh", "config");
+        try {
+          if (fs.existsSync(sessionConfigPath)) {
+            args.push("-F", sessionConfigPath);
+          }
+        } catch {
+          // Best-effort; fall through without -F.
+        }
+      }
       // OpenSSH keeps the first StrictHostKeyChecking value it sees. Only inject
       // accept-new when the session did not already supply a policy (e.g.
       // verifyHostKeys=false → StrictHostKeyChecking=no on the interactive ET

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -6,6 +6,7 @@ const {
   buildExternalHostKeyConfigLines,
   buildExternalHostKeySshOptions,
   buildVaultKnownHostsContent,
+  vaultPinsConnectionHosts,
 } = require("../externalSshHostKeyPolicy.cjs");
 const { emitTerminalSessionData } = require("../emitTerminalSessionData.cjs");
 const {
@@ -372,26 +373,39 @@ main();
       // ssh banners so the first real PTY bytes are the remote shell. Mirrors
       // the options already used by execOnEtSession.
       //
-      // Vault known_hosts (issue #2501): when the vault pins a host, build an
-      // authoritative known_hosts snapshot (vault pins + system entries for
-      // non-vault hosts) and point BOTH User/Global known_hosts at it. OpenSSH
-      // accepts a match from any trust source, so a rotated system K2 next to
-      // vault K1 would otherwise win.
+      // Vault known_hosts (issue #2501): only when the vault pins the target
+      // (or a jump host) do we switch to an authoritative session snapshot.
+      // OpenSSH accepts a match from any trust source, so a rotated system K2
+      // next to vault K1 would otherwise win. When the vault does not pin this
+      // connection, keep the persistent ~/.ssh/known_hosts so accept-new still
+      // records first-seen keys across sessions.
       let authoritativeKnownHostsPath = null;
       let emptyKnownHostsPath = null;
+      const connectionHosts = [
+        { hostname: options.hostname, port: options.port || 22 },
+        ...jumpHosts.map((jump) => ({
+          hostname: jump.hostname,
+          port: jump.port || 22,
+        })),
+      ];
+      const vaultCoversConnection = vaultPinsConnectionHosts(options.knownHosts, connectionHosts);
       if (verifyHostKeys) {
-        const authoritativeContent = buildAuthoritativeKnownHostsContent({
-          knownHosts: options.knownHosts,
-          fs,
-          pathModule: path,
-          homedir: os.homedir(),
-        });
-        if (authoritativeContent) {
-          authoritativeKnownHostsPath = path.join(sshDir, `${safeId}-authoritative-known_hosts`);
-          writeSecureFile(authoritativeKnownHostsPath, authoritativeContent, 0o600);
-        } else {
-          // No vault pins: keep the persistent user known_hosts so accept-new
-          // records first-seen keys for later mismatch detection.
+        if (vaultCoversConnection) {
+          const authoritativeContent = buildAuthoritativeKnownHostsContent({
+            knownHosts: options.knownHosts,
+            fs,
+            pathModule: path,
+            homedir: os.homedir(),
+          });
+          if (authoritativeContent) {
+            authoritativeKnownHostsPath = path.join(sshDir, `${safeId}-authoritative-known_hosts`);
+            writeSecureFile(authoritativeKnownHostsPath, authoritativeContent, 0o600);
+          }
+        }
+        if (!authoritativeKnownHostsPath) {
+          // No vault pin for this connection: keep the persistent user
+          // known_hosts so accept-new records first-seen keys for later
+          // mismatch detection.
           sshOptions.push(`UserKnownHostsFile=${normalizeSshConfigPath(knownHostsPath)}`);
         }
       } else {

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -5,7 +5,6 @@ const {
   buildAuthoritativeKnownHostsContent,
   buildExternalHostKeyConfigLines,
   buildExternalHostKeySshOptions,
-  buildVaultKnownHostsContent,
   vaultPinsConnectionHosts,
 } = require("../externalSshHostKeyPolicy.cjs");
 const { emitTerminalSessionData } = require("../emitTerminalSessionData.cjs");

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -373,24 +373,26 @@ main();
       // ssh banners so the first real PTY bytes are the remote shell. Mirrors
       // the options already used by execOnEtSession.
       //
-      // Vault known_hosts (issue #2501): only when the vault pins the target
-      // (or a jump host) do we switch to an authoritative session snapshot.
-      // OpenSSH accepts a match from any trust source, so a rotated system K2
-      // next to vault K1 would otherwise win. When the vault does not pin this
-      // connection, keep the persistent ~/.ssh/known_hosts so accept-new still
-      // records first-seen keys across sessions.
+      // Vault known_hosts (issue #2501): only hops the vault actually pins use
+      // an authoritative session snapshot. Unpinned hops keep the persistent
+      // ~/.ssh/known_hosts so accept-new still records first-seen keys across
+      // sessions. With a jump host, host-key options are applied per-hop via
+      // Host blocks (not global --ssh-option) so one hop's snapshot cannot
+      // force the other hop off the persistent trust file.
       let authoritativeKnownHostsPath = null;
       let emptyKnownHostsPath = null;
-      const connectionHosts = [
-        { hostname: options.hostname, port: options.port || 22 },
-        ...jumpHosts.map((jump) => ({
-          hostname: jump.hostname,
-          port: jump.port || 22,
-        })),
-      ];
-      const vaultCoversConnection = vaultPinsConnectionHosts(options.knownHosts, connectionHosts);
+      const targetConnectionHost = {
+        hostname: options.hostname,
+        port: options.port || 22,
+      };
+      const jumpConnectionHosts = jumpHosts.map((jump) => ({
+        hostname: jump.hostname,
+        port: jump.port || 22,
+      }));
+      const vaultPinsTarget = vaultPinsConnectionHosts(options.knownHosts, [targetConnectionHost]);
+      const vaultPinsJump = vaultPinsConnectionHosts(options.knownHosts, jumpConnectionHosts);
       if (verifyHostKeys) {
-        if (vaultCoversConnection) {
+        if (vaultPinsTarget || vaultPinsJump) {
           const authoritativeContent = buildAuthoritativeKnownHostsContent({
             knownHosts: options.knownHosts,
             fs,
@@ -403,12 +405,6 @@ main();
             writeSecureFile(authoritativeKnownHostsPath, authoritativeContent, 0o600);
           }
         }
-        if (!authoritativeKnownHostsPath) {
-          // No vault pin for this connection: keep the persistent user
-          // known_hosts so accept-new records first-seen keys for later
-          // mismatch detection.
-          sshOptions.push(`UserKnownHostsFile=${normalizeSshConfigPath(knownHostsPath)}`);
-        }
       } else {
         // StrictHostKeyChecking=no still consults known_hosts for password-auth
         // MITM protection. Point both trust files at an empty snapshot so
@@ -416,19 +412,39 @@ main();
         emptyKnownHostsPath = path.join(sshDir, `${safeId}-empty-known_hosts`);
         writeSecureFile(emptyKnownHostsPath, "", 0o600);
       }
-      sshOptions.push(...buildExternalHostKeySshOptions({
-        authoritativeKnownHostsPath,
-        emptyKnownHostsPath,
-        verifyHostKeys,
-        protocol: "et",
-        style: "values",
-        normalizePath: normalizeSshConfigPath,
-      }));
-      // When verification is on, buildExternalHostKeySshOptions already emits
-      // StrictHostKeyChecking=accept-new; when off it emits =no. Avoid a
-      // duplicate default so verifyHostKeys=false can disable checks.
-      if (!sshOptions.some((opt) => opt.startsWith("StrictHostKeyChecking="))) {
-        sshOptions.push("StrictHostKeyChecking=accept-new");
+
+      const targetUsesAuthoritative = Boolean(
+        verifyHostKeys && vaultPinsTarget && authoritativeKnownHostsPath,
+      );
+      const jumpUsesAuthoritative = Boolean(
+        verifyHostKeys && vaultPinsJump && authoritativeKnownHostsPath,
+      );
+      const hasJumpHost = jumpHosts.length > 0;
+
+      // Global --ssh-option host-key policy is only safe when there is no jump
+      // host (single hop). With a jump host, put per-hop policy in Host blocks
+      // below so unpinned hops keep persistent UserKnownHostsFile.
+      if (!hasJumpHost || !verifyHostKeys) {
+        if (verifyHostKeys && !targetUsesAuthoritative) {
+          sshOptions.push(`UserKnownHostsFile=${normalizeSshConfigPath(knownHostsPath)}`);
+        }
+        sshOptions.push(...buildExternalHostKeySshOptions({
+          authoritativeKnownHostsPath: targetUsesAuthoritative ? authoritativeKnownHostsPath : null,
+          emptyKnownHostsPath,
+          verifyHostKeys,
+          protocol: "et",
+          style: "values",
+          normalizePath: normalizeSshConfigPath,
+        }));
+        if (!sshOptions.some((opt) => opt.startsWith("StrictHostKeyChecking="))) {
+          sshOptions.push("StrictHostKeyChecking=accept-new");
+        }
+      } else if (targetUsesAuthoritative) {
+        // Single-hop-style target policy is deferred into the Host <dest>
+        // block so it does not override the jump hop via --ssh-option.
+      } else {
+        // Target not vault-pinned: still need accept-new default for the
+        // destination hop; applied in the Host <dest> block below.
       }
       sshOptions.push("LogLevel=ERROR");
 
@@ -679,25 +695,30 @@ main();
           }), jumpPwPath);
         }
 
-        // Share known_hosts with the jump connection and apply the same
-        // non-interactive host-key handling as the target hop — the jump's
-        // ssh is just as unable to answer a yes/no prompt via SSH_ASKPASS.
-        // Vault keys (issue #2501) must also protect the jump hop.
-        if (verifyHostKeys && !authoritativeKnownHostsPath) {
-          jumpConfigLines.push(`  UserKnownHostsFile ${quoteSshConfigValue(knownHostsPath)}`);
-        }
-        const jumpHostKeyLines = buildExternalHostKeyConfigLines({
-          authoritativeKnownHostsPath,
-          emptyKnownHostsPath,
-          verifyHostKeys,
-          protocol: "et",
-          normalizePath: normalizeSshConfigPath,
-          quotePath: quoteSshConfigValue,
-        });
-        if (jumpHostKeyLines.length > 0) {
-          jumpConfigLines.push(...jumpHostKeyLines);
-        } else if (verifyHostKeys) {
-          jumpConfigLines.push("  StrictHostKeyChecking accept-new");
+        // Per-hop host-key policy for the jump. Vault-pinned jumps use the
+        // authoritative snapshot; unpinned jumps keep the persistent user
+        // known_hosts so accept-new records first-seen jump keys.
+        if (verifyHostKeys) {
+          if (jumpUsesAuthoritative) {
+            jumpConfigLines.push(...buildExternalHostKeyConfigLines({
+              authoritativeKnownHostsPath,
+              verifyHostKeys: true,
+              protocol: "et",
+              normalizePath: normalizeSshConfigPath,
+              quotePath: quoteSshConfigValue,
+            }));
+          } else {
+            jumpConfigLines.push(`  UserKnownHostsFile ${quoteSshConfigValue(knownHostsPath)}`);
+            jumpConfigLines.push("  StrictHostKeyChecking accept-new");
+          }
+        } else if (emptyKnownHostsPath) {
+          jumpConfigLines.push(...buildExternalHostKeyConfigLines({
+            emptyKnownHostsPath,
+            verifyHostKeys: false,
+            protocol: "et",
+            normalizePath: normalizeSshConfigPath,
+            quotePath: quoteSshConfigValue,
+          }));
         }
         jumpConfigLines.push("  LogLevel ERROR");
         jumpConfigLines.push("  KbdInteractiveAuthentication yes");
@@ -724,6 +745,33 @@ main();
         configFileLines.push(`  ProxyJump ${jump.hostname}`);
         for (const line of configLines) {
           configFileLines.push(`  ${line}`);
+        }
+        // Per-hop host-key policy for the destination target.
+        if (verifyHostKeys) {
+          if (targetUsesAuthoritative) {
+            for (const line of buildExternalHostKeyConfigLines({
+              authoritativeKnownHostsPath,
+              verifyHostKeys: true,
+              protocol: "et",
+              normalizePath: normalizeSshConfigPath,
+              quotePath: quoteSshConfigValue,
+            })) {
+              configFileLines.push(line);
+            }
+          } else {
+            configFileLines.push(`  UserKnownHostsFile ${quoteSshConfigValue(knownHostsPath)}`);
+            configFileLines.push("  StrictHostKeyChecking accept-new");
+          }
+        } else if (emptyKnownHostsPath) {
+          for (const line of buildExternalHostKeyConfigLines({
+            emptyKnownHostsPath,
+            verifyHostKeys: false,
+            protocol: "et",
+            normalizePath: normalizeSshConfigPath,
+            quotePath: quoteSshConfigValue,
+          })) {
+            configFileLines.push(line);
+          }
         }
         configFileLines.push(...jumpConfigLines);
       } else {

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -4,6 +4,7 @@ const { createSystemKnownHostsApi } = require("../sshBridge/systemKnownHosts.cjs
 const {
   buildExternalHostKeyConfigLines,
   buildExternalHostKeySshOptions,
+  buildMergedGlobalKnownHostsContent,
   buildVaultKnownHostsContent,
 } = require("../externalSshHostKeyPolicy.cjs");
 const { emitTerminalSessionData } = require("../emitTerminalSessionData.cjs");
@@ -357,7 +358,7 @@ main();
         // sessions must still work when ~/.ssh cannot be read.
       }
       const knownHostsPath = path.join(realSshDir, "known_hosts");
-      sshOptions.push(`UserKnownHostsFile=${normalizeSshConfigPath(knownHostsPath)}`);
+      const verifyHostKeys = options.verifyHostKeys !== false;
 
       // et drives ssh itself and feeds credentials through SSH_ASKPASS, which
       // only answers password/passphrase prompts — never the interactive
@@ -373,17 +374,33 @@ main();
       //
       // Vault known_hosts (issue #2501): keys the user already trusted via
       // Netcatty SSH live in the in-app vault, not necessarily in
-      // ~/.ssh/known_hosts. Inject them as GlobalKnownHostsFile so a rotated
-      // server key is rejected the same way OpenSSH rejects system mismatches.
-      let vaultKnownHostsPath = null;
-      const vaultContent = buildVaultKnownHostsContent(options.knownHosts);
-      if (vaultContent) {
-        vaultKnownHostsPath = path.join(sshDir, `${safeId}-vault-known_hosts`);
-        writeSecureFile(vaultKnownHostsPath, vaultContent, 0o600);
+      // ~/.ssh/known_hosts. Merge vault pins with OpenSSH's default global
+      // known_hosts files into one GlobalKnownHostsFile so admin-pinned
+      // hosts in /etc/ssh/ssh_known_hosts are preserved (Codex review).
+      let mergedGlobalKnownHostsPath = null;
+      let emptyKnownHostsPath = null;
+      if (verifyHostKeys) {
+        sshOptions.push(`UserKnownHostsFile=${normalizeSshConfigPath(knownHostsPath)}`);
+        const mergedContent = buildMergedGlobalKnownHostsContent({
+          knownHosts: options.knownHosts,
+          fs,
+          pathModule: path,
+        });
+        if (mergedContent) {
+          mergedGlobalKnownHostsPath = path.join(sshDir, `${safeId}-global-known_hosts`);
+          writeSecureFile(mergedGlobalKnownHostsPath, mergedContent, 0o600);
+        }
+      } else {
+        // StrictHostKeyChecking=no still consults known_hosts for password-auth
+        // MITM protection. Point both trust files at an empty snapshot so
+        // verifyHostKeys=false truly bypasses stale vault/system pins.
+        emptyKnownHostsPath = path.join(sshDir, `${safeId}-empty-known_hosts`);
+        writeSecureFile(emptyKnownHostsPath, "", 0o600);
       }
       sshOptions.push(...buildExternalHostKeySshOptions({
-        vaultKnownHostsPath,
-        verifyHostKeys: options.verifyHostKeys,
+        mergedGlobalKnownHostsPath,
+        emptyKnownHostsPath,
+        verifyHostKeys,
         protocol: "et",
         style: "values",
         normalizePath: normalizeSshConfigPath,
@@ -647,17 +664,25 @@ main();
         // non-interactive host-key handling as the target hop — the jump's
         // ssh is just as unable to answer a yes/no prompt via SSH_ASKPASS.
         // Vault keys (issue #2501) must also protect the jump hop.
-        jumpConfigLines.push(`  UserKnownHostsFile ${quoteSshConfigValue(knownHostsPath)}`);
+        if (verifyHostKeys) {
+          jumpConfigLines.push(`  UserKnownHostsFile ${quoteSshConfigValue(knownHostsPath)}`);
+        }
         const jumpHostKeyLines = buildExternalHostKeyConfigLines({
-          vaultKnownHostsPath,
-          verifyHostKeys: options.verifyHostKeys,
+          mergedGlobalKnownHostsPath,
+          emptyKnownHostsPath,
+          verifyHostKeys,
           protocol: "et",
           normalizePath: normalizeSshConfigPath,
           quotePath: quoteSshConfigValue,
         });
         if (jumpHostKeyLines.length > 0) {
-          jumpConfigLines.push(...jumpHostKeyLines);
-        } else {
+          jumpHostKeyLines.forEach((line) => {
+            // Avoid duplicating UserKnownHostsFile when verification is on
+            // (already set above to the persistent system file).
+            if (verifyHostKeys && line.includes("UserKnownHostsFile ")) return;
+            jumpConfigLines.push(line);
+          });
+        } else if (verifyHostKeys) {
           jumpConfigLines.push("  StrictHostKeyChecking accept-new");
         }
         jumpConfigLines.push("  LogLevel ERROR");

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -400,6 +400,8 @@ main();
             knownHosts: options.knownHosts,
             fs,
             hostname: options.hostname,
+            port: options.port || 22,
+            username: options.username,
             pathModule: path,
             homedir: os.homedir(),
           });
@@ -416,6 +418,8 @@ main();
             knownHosts: options.knownHosts,
             fs,
             hostname: jumpHosts[0].hostname,
+            port: jumpHosts[0].port || 22,
+            username: jumpHosts[0].username,
             pathModule: path,
             homedir: os.homedir(),
           });
@@ -897,6 +901,8 @@ main();
         knownHosts,
         fs,
         hostname,
+        port: session.etStatsAuth?.port || 22,
+        username: session.etStatsAuth?.username,
         pathModule: path,
         homedir: os.homedir(),
       });

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -3,7 +3,6 @@ const crypto = require("node:crypto");
 const { createSystemKnownHostsApi } = require("../sshBridge/systemKnownHosts.cjs");
 const {
   buildAuthoritativeKnownHostsContent,
-  buildExternalHostKeyConfigLines,
   buildExternalHostKeySshOptions,
   vaultPinsConnectionHosts,
 } = require("../externalSshHostKeyPolicy.cjs");
@@ -372,14 +371,13 @@ main();
       // ssh banners so the first real PTY bytes are the remote shell. Mirrors
       // the options already used by execOnEtSession.
       //
-      // Vault known_hosts (issue #2501): only hops the vault actually pins use
-      // an authoritative session snapshot. Unpinned hops keep the persistent
-      // ~/.ssh/known_hosts so accept-new still records first-seen keys across
-      // sessions. With a jump host, host-key options are applied per-hop via
-      // Host blocks (not global --ssh-option) so one hop's snapshot cannot
-      // force the other hop off the persistent trust file.
-      let targetAuthoritativeKnownHostsPath = null;
-      let jumpAuthoritativeKnownHostsPath = null;
+      // Vault known_hosts (issue #2501): when the vault pins the target and/or
+      // jump hop, build authoritative session snapshot(s) and apply them via
+      // --ssh-option. ET only passes --ssh-option to OpenSSH reliably; Host
+      // blocks under a temp HOME are not always read on POSIX (OpenSSH uses
+      // the account home for config resolution), so command-line policy is
+      // the enforceable path.
+      let authoritativeKnownHostsPath = null;
       let emptyKnownHostsPath = null;
       const targetConnectionHost = {
         hostname: options.hostname,
@@ -392,9 +390,7 @@ main();
       const vaultPinsTarget = vaultPinsConnectionHosts(options.knownHosts, [targetConnectionHost]);
       const vaultPinsJump = vaultPinsConnectionHosts(options.knownHosts, jumpConnectionHosts);
       if (verifyHostKeys) {
-        // Build per-hop snapshots with ssh -G discovery for THAT hop's
-        // hostname so Host-scoped GlobalKnownHostsFile / UserKnownHostsFile
-        // (and @revoked entries there) are not lost.
+        const contentChunks = [];
         if (vaultPinsTarget) {
           const targetContent = buildAuthoritativeKnownHostsContent({
             knownHosts: options.knownHosts,
@@ -405,13 +401,7 @@ main();
             pathModule: path,
             homedir: os.homedir(),
           });
-          if (targetContent) {
-            targetAuthoritativeKnownHostsPath = path.join(
-              sshDir,
-              `${safeId}-authoritative-target-known_hosts`,
-            );
-            writeSecureFile(targetAuthoritativeKnownHostsPath, targetContent, 0o600);
-          }
+          if (targetContent) contentChunks.push(targetContent.trimEnd());
         }
         if (vaultPinsJump && jumpHosts[0]) {
           const jumpContent = buildAuthoritativeKnownHostsContent({
@@ -423,13 +413,24 @@ main();
             pathModule: path,
             homedir: os.homedir(),
           });
-          if (jumpContent) {
-            jumpAuthoritativeKnownHostsPath = path.join(
-              sshDir,
-              `${safeId}-authoritative-jump-known_hosts`,
-            );
-            writeSecureFile(jumpAuthoritativeKnownHostsPath, jumpContent, 0o600);
+          if (jumpContent) contentChunks.push(jumpContent.trimEnd());
+        }
+        if (contentChunks.length > 0) {
+          // De-dupe lines across hop snapshots while preserving order.
+          const seen = new Set();
+          const merged = [];
+          for (const chunk of contentChunks) {
+            for (const line of chunk.split("\n")) {
+              if (!line || seen.has(line)) continue;
+              seen.add(line);
+              merged.push(line);
+            }
           }
+          authoritativeKnownHostsPath = path.join(
+            sshDir,
+            `${safeId}-authoritative-known_hosts`,
+          );
+          writeSecureFile(authoritativeKnownHostsPath, `${merged.join("\n")}\n`, 0o600);
         }
       } else {
         // StrictHostKeyChecking=no still consults known_hosts for password-auth
@@ -439,34 +440,20 @@ main();
         writeSecureFile(emptyKnownHostsPath, "", 0o600);
       }
 
-      const targetUsesAuthoritative = Boolean(
-        verifyHostKeys && vaultPinsTarget && targetAuthoritativeKnownHostsPath,
-      );
-      const jumpUsesAuthoritative = Boolean(
-        verifyHostKeys && vaultPinsJump && jumpAuthoritativeKnownHostsPath,
-      );
-      const hasJumpHost = jumpHosts.length > 0;
-
-      // Global --ssh-option host-key policy is only safe when there is no jump
-      // host (single hop). With a jump host, put per-hop policy in Host blocks
-      // below so unpinned hops keep persistent UserKnownHostsFile.
-      if (!hasJumpHost || !verifyHostKeys) {
-        if (verifyHostKeys && !targetUsesAuthoritative) {
-          sshOptions.push(`UserKnownHostsFile=${normalizeSshConfigPath(knownHostsPath)}`);
-        }
-        sshOptions.push(...buildExternalHostKeySshOptions({
-          authoritativeKnownHostsPath: targetUsesAuthoritative
-            ? targetAuthoritativeKnownHostsPath
-            : null,
-          emptyKnownHostsPath,
-          verifyHostKeys,
-          protocol: "et",
-          style: "values",
-          normalizePath: normalizeSshConfigPath,
-        }));
-        if (!sshOptions.some((opt) => opt.startsWith("StrictHostKeyChecking="))) {
-          sshOptions.push("StrictHostKeyChecking=accept-new");
-        }
+      // Always apply host-key policy through --ssh-option (see comment above).
+      if (verifyHostKeys && !authoritativeKnownHostsPath) {
+        sshOptions.push(`UserKnownHostsFile=${normalizeSshConfigPath(knownHostsPath)}`);
+      }
+      sshOptions.push(...buildExternalHostKeySshOptions({
+        authoritativeKnownHostsPath,
+        emptyKnownHostsPath,
+        verifyHostKeys,
+        protocol: "et",
+        style: "values",
+        normalizePath: normalizeSshConfigPath,
+      }));
+      if (!sshOptions.some((opt) => opt.startsWith("StrictHostKeyChecking="))) {
+        sshOptions.push("StrictHostKeyChecking=accept-new");
       }
       sshOptions.push("LogLevel=ERROR");
 
@@ -717,31 +704,9 @@ main();
           }), jumpPwPath);
         }
 
-        // Per-hop host-key policy for the jump. Vault-pinned jumps use the
-        // authoritative snapshot; unpinned jumps keep the persistent user
-        // known_hosts so accept-new records first-seen jump keys.
-        if (verifyHostKeys) {
-          if (jumpUsesAuthoritative) {
-            jumpConfigLines.push(...buildExternalHostKeyConfigLines({
-              authoritativeKnownHostsPath: jumpAuthoritativeKnownHostsPath,
-              verifyHostKeys: true,
-              protocol: "et",
-              normalizePath: normalizeSshConfigPath,
-              quotePath: quoteSshConfigValue,
-            }));
-          } else {
-            jumpConfigLines.push(`  UserKnownHostsFile ${quoteSshConfigValue(knownHostsPath)}`);
-            jumpConfigLines.push("  StrictHostKeyChecking accept-new");
-          }
-        } else if (emptyKnownHostsPath) {
-          jumpConfigLines.push(...buildExternalHostKeyConfigLines({
-            emptyKnownHostsPath,
-            verifyHostKeys: false,
-            protocol: "et",
-            normalizePath: normalizeSshConfigPath,
-            quotePath: quoteSshConfigValue,
-          }));
-        }
+        // Jump host identity/auth options only. Host-key policy is applied via
+        // --ssh-option (command line) so it is enforceable on POSIX where a
+        // temp-HOME config Host block may not be consulted by OpenSSH.
         jumpConfigLines.push("  LogLevel ERROR");
         jumpConfigLines.push("  KbdInteractiveAuthentication yes");
         jumpConfigLines.push("  NumberOfPasswordPrompts 1");
@@ -767,33 +732,6 @@ main();
         configFileLines.push(`  ProxyJump ${jump.hostname}`);
         for (const line of configLines) {
           configFileLines.push(`  ${line}`);
-        }
-        // Per-hop host-key policy for the destination target.
-        if (verifyHostKeys) {
-          if (targetUsesAuthoritative) {
-            for (const line of buildExternalHostKeyConfigLines({
-              authoritativeKnownHostsPath: targetAuthoritativeKnownHostsPath,
-              verifyHostKeys: true,
-              protocol: "et",
-              normalizePath: normalizeSshConfigPath,
-              quotePath: quoteSshConfigValue,
-            })) {
-              configFileLines.push(line);
-            }
-          } else {
-            configFileLines.push(`  UserKnownHostsFile ${quoteSshConfigValue(knownHostsPath)}`);
-            configFileLines.push("  StrictHostKeyChecking accept-new");
-          }
-        } else if (emptyKnownHostsPath) {
-          for (const line of buildExternalHostKeyConfigLines({
-            emptyKnownHostsPath,
-            verifyHostKeys: false,
-            protocol: "et",
-            normalizePath: normalizeSshConfigPath,
-            quotePath: quoteSshConfigValue,
-          })) {
-            configFileLines.push(line);
-          }
         }
         configFileLines.push(...jumpConfigLines);
       } else {

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -887,7 +887,15 @@ main();
 
       const sshCmd = process.platform === "win32" ? findExecutable("ssh") : "ssh";
       const args = ["-o", "BatchMode=no"];
-      if (!requireTrustedHost) {
+      // OpenSSH keeps the first StrictHostKeyChecking value it sees. Only inject
+      // accept-new when the session did not already supply a policy (e.g.
+      // verifyHostKeys=false → StrictHostKeyChecking=no on the interactive ET
+      // bootstrap). Prepending accept-new would otherwise win over the session
+      // setting and re-enable mismatch rejection on follow-up ssh execs.
+      const sessionHasStrictHostKeyChecking = (session.sshOptions || []).some(
+        (opt) => typeof opt === "string" && opt.startsWith("StrictHostKeyChecking="),
+      );
+      if (!requireTrustedHost && !sessionHasStrictHostKeyChecking) {
         args.push("-o", "StrictHostKeyChecking=accept-new");
       }
       for (const opt of session.sshOptions) {

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -759,13 +759,52 @@ main();
       }
 
       const writesConfigFile = configFileLines.length > 0;
+      let configPath = null;
       if (writesConfigFile) {
-        const configPath = path.join(sshDir, "config");
+        configPath = path.join(sshDir, "config");
         writeSecureFile(configPath, configFileLines.join("\n") + "\n", 0o600);
       }
 
       // Create askpass artifacts
       const askpass = createEtAskpassArtifacts(sshDir, askpassEntries);
+
+      // OpenSSH resolves the user config from the account home directory, not
+      // $HOME. When we generate a private config (ProxyJump + jump host-key
+      // policy), inject a PATH-fronted `ssh` wrapper that always passes
+      // `-F <session-config>` so both interactive ET (ssh -J) and follow-up
+      // execOnEtSession honor the generated Host stanzas.
+      const pathEnv = {};
+      if (configPath) {
+        try {
+          const realSsh = process.platform === "win32"
+            ? (findExecutable("ssh") || "ssh")
+            : "ssh";
+          const wrapperDir = path.join(sshDir, "bin");
+          fs.mkdirSync(wrapperDir, { recursive: true });
+          if (process.platform === "win32") {
+            const wrapperPath = path.join(wrapperDir, "ssh.cmd");
+            writeSecureFile(
+              wrapperPath,
+              `@echo off\r\n"${String(realSsh).replace(/"/g, '""')}" -F "${configPath.replace(/"/g, '""')}" %*\r\n`,
+              0o700,
+            );
+          } else {
+            const wrapperPath = path.join(wrapperDir, "ssh");
+            const quotedSsh = `'${String(realSsh).replace(/'/g, `'\\''`)}'`;
+            const quotedConfig = `'${String(configPath).replace(/'/g, `'\\''`)}'`;
+            writeSecureFile(
+              wrapperPath,
+              `#!/bin/sh\nexec ${quotedSsh} -F ${quotedConfig} "$@"\n`,
+              0o700,
+            );
+          }
+          const pathKey = Object.keys(process.env).find((k) => k.toLowerCase() === "path") || "PATH";
+          const currentPath = process.env[pathKey] || "";
+          pathEnv[pathKey] = currentPath ? `${wrapperDir}${path.delimiter}${currentPath}` : wrapperDir;
+        } catch {
+          // Wrapper is best-effort; destination --ssh-option still applies.
+        }
+      }
 
       const userHost = `${options.username || os.userInfo().username}@${options.hostname}`;
 
@@ -775,8 +814,10 @@ main();
         identityFilePaths: identityPaths,
         etJumpArgs,
         env: {
-          // Set HOME/USERPROFILE so ssh finds .ssh/config for comma-containing options
+          // Set HOME/USERPROFILE so helpers that honor $HOME still find the
+          // session config; the PATH wrapper above is the enforceable path.
           ...(writesConfigFile ? { HOME: tempDir, USERPROFILE: tempDir } : {}),
+          ...pathEnv,
           ...askpass.env,
         },
         artifacts: [tempDir, ...askpass.artifacts],

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -1120,6 +1120,11 @@ test("prepareEtSshEnvironment injects a PATH ssh wrapper that forces -F", (t) =>
   const wrapperBody = fs.readFileSync(wrapperPath, "utf8");
   assert.match(wrapperBody, /-F/);
   assert.match(wrapperBody, /\.ssh[\\/]config/);
+  // Must invoke an absolute OpenSSH binary, not a bare `ssh` that would
+  // recurse into this wrapper via PATH.
+  if (process.platform !== "win32") {
+    assert.match(wrapperBody, /exec '\/[^']+\/ssh'/);
+  }
 });
 
 test("execOnEtSession requireTrustedHost uses strict host-key checking", async (t) => {

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -980,10 +980,8 @@ test("prepareEtSshEnvironment applies vault host-key policy via ssh-option for j
     }],
   });
 
-  // Host-key policy must ride --ssh-option so OpenSSH on POSIX enforces it
-  // even when a temp-HOME Host config block is not consulted.
+  // Destination hop: --ssh-option (ET applies these only to the final target).
   assert.ok(env.sshOptions.some((option) => option.startsWith("GlobalKnownHostsFile=")));
-  assert.ok(env.sshOptions.some((option) => option.startsWith("UserKnownHostsFile=")));
   assert.ok(env.sshOptions.includes("StrictHostKeyChecking=accept-new"));
   const trustPath = env.sshOptions
     .find((option) => option.startsWith("UserKnownHostsFile="))
@@ -992,6 +990,11 @@ test("prepareEtSshEnvironment applies vault host-key policy via ssh-option for j
     fs.readFileSync(trustPath, "utf8"),
     new RegExp(`jump\\.example ssh-ed25519 ${VALID_ED25519_BLOB}`),
   );
+  // Jump hop: Host block (ProxyJump child process does not inherit --ssh-option).
+  const config = fs.readFileSync(path.join(env.env.HOME, ".ssh", "config"), "utf8");
+  const jumpBlock = config.slice(config.indexOf("Host jump.example"));
+  assert.match(jumpBlock, /UserKnownHostsFile /);
+  assert.match(jumpBlock, /StrictHostKeyChecking /);
 });
 
 test("prepareEtSshEnvironment merges vault pins for target hop with jump present", (t) => {

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -1098,6 +1098,30 @@ test("execOnEtSession forces the session-generated SSH config with -F", async (t
   assert.match(capturedArgs[fIdx + 1], /[\\/]\.ssh[\\/]config$/);
 });
 
+test("prepareEtSshEnvironment injects a PATH ssh wrapper that forces -F", (t) => {
+  const { api } = makeApi(t);
+  const env = api.prepareEtSshEnvironment("sess1", {
+    hostname: "target.example",
+    username: "alice",
+    jumpHosts: [{
+      hostname: "jump.example",
+      username: "ops",
+      authMethod: "password",
+      password: "secret",
+    }],
+  });
+
+  const pathKey = Object.keys(env.env).find((k) => k.toLowerCase() === "path");
+  assert.ok(pathKey, "expected PATH override for ssh wrapper");
+  const wrapperDir = env.env[pathKey].split(path.delimiter)[0];
+  const wrapperName = process.platform === "win32" ? "ssh.cmd" : "ssh";
+  const wrapperPath = path.join(wrapperDir, wrapperName);
+  assert.ok(fs.existsSync(wrapperPath), "expected ssh wrapper on PATH");
+  const wrapperBody = fs.readFileSync(wrapperPath, "utf8");
+  assert.match(wrapperBody, /-F/);
+  assert.match(wrapperBody, /\.ssh[\\/]config/);
+});
+
 test("execOnEtSession requireTrustedHost uses strict host-key checking", async (t) => {
   let capturedArgs = null;
   const { api } = makeApi(t, {

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -983,6 +983,40 @@ test("prepareEtSshEnvironment applies vault host-key policy to jump hosts", (t) 
   assert.match(config, /accept-new/);
 });
 
+test("execOnEtSession honors session StrictHostKeyChecking=no over accept-new default", async (t) => {
+  let capturedArgs = null;
+  const { api } = makeApi(t, {
+    execFile: (_cmd, args, _opts, cb) => {
+      capturedArgs = args;
+      process.nextTick(() => cb(null, "", ""));
+    },
+  });
+  const env = api.prepareEtSshEnvironment("sess1", {
+    hostname: "host.example",
+    username: "alice",
+    verifyHostKeys: false,
+  });
+  const session = {
+    sshUserHost: env.userHost,
+    sshOptions: env.sshOptions,
+    sshEnv: env.env,
+    externalAuthArtifacts: env.artifacts,
+    externalAuthArtifactsCleaned: false,
+  };
+
+  await api.execOnEtSession(session, "echo ok", 1000);
+
+  const joined = capturedArgs.join(" ");
+  assert.match(joined, /StrictHostKeyChecking=no/);
+  // OpenSSH keeps the first value; accept-new must not precede =no.
+  const firstStrict = capturedArgs.findIndex(
+    (arg, index) => arg === "-o" && String(capturedArgs[index + 1] || "").startsWith("StrictHostKeyChecking="),
+  );
+  assert.ok(firstStrict >= 0);
+  assert.equal(capturedArgs[firstStrict + 1], "StrictHostKeyChecking=no");
+  assert.doesNotMatch(joined, /StrictHostKeyChecking=accept-new/);
+});
+
 test("execOnEtSession requireTrustedHost uses strict host-key checking", async (t) => {
   let capturedArgs = null;
   const { api } = makeApi(t, {

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -980,21 +980,27 @@ test("prepareEtSshEnvironment applies vault host-key policy via ssh-option for j
     }],
   });
 
-  // Destination hop: --ssh-option (ET applies these only to the final target).
-  assert.ok(env.sshOptions.some((option) => option.startsWith("GlobalKnownHostsFile=")));
+  // Destination is not vault-pinned: keep persistent known_hosts via --ssh-option.
   assert.ok(env.sshOptions.includes("StrictHostKeyChecking=accept-new"));
-  const trustPath = env.sshOptions
-    .find((option) => option.startsWith("UserKnownHostsFile="))
-    .slice("UserKnownHostsFile=".length);
-  assert.match(
-    fs.readFileSync(trustPath, "utf8"),
-    new RegExp(`jump\\.example ssh-ed25519 ${VALID_ED25519_BLOB}`),
+  assert.ok(env.sshOptions.some((option) => option.startsWith("UserKnownHostsFile=")));
+  assert.equal(
+    env.sshOptions.some((option) => option.startsWith("GlobalKnownHostsFile=")),
+    false,
   );
-  // Jump hop: Host block (ProxyJump child process does not inherit --ssh-option).
+  // Jump hop: Host block carries the vault-authoritative snapshot.
   const config = fs.readFileSync(path.join(env.env.HOME, ".ssh", "config"), "utf8");
   const jumpBlock = config.slice(config.indexOf("Host jump.example"));
   assert.match(jumpBlock, /UserKnownHostsFile /);
+  assert.match(jumpBlock, /GlobalKnownHostsFile /);
   assert.match(jumpBlock, /StrictHostKeyChecking /);
+  assert.match(jumpBlock, /KnownHostsCommand /);
+  const jumpTrustMatch = jumpBlock.match(/UserKnownHostsFile "?([^"\n]+)"?/);
+  assert.ok(jumpTrustMatch);
+  const jumpTrustPath = jumpTrustMatch[1].trim();
+  assert.match(
+    fs.readFileSync(jumpTrustPath, "utf8"),
+    new RegExp(`jump\\.example ssh-ed25519 ${VALID_ED25519_BLOB}`),
+  );
 });
 
 test("prepareEtSshEnvironment merges vault pins for target hop with jump present", (t) => {

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -7,6 +7,10 @@ const { execFileSync } = require("node:child_process");
 
 const { createEtSessionApi } = require("./etSession.cjs");
 
+// Valid OpenSSH wire-format ssh-ed25519 public key blob (base64) for vault tests.
+const VALID_ED25519_BLOB = "AAAAC3NzaC1lZDI1NTE5AAAAIAcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcH";
+const VALID_ED25519_PUB = `ssh-ed25519 ${VALID_ED25519_BLOB}`;
+
 // Build an et session API wired to a hermetic temp HOME so prepareEtSshEnvironment
 // is deterministic regardless of the developer's real ~/.ssh contents.
 function makeApi(t, overrides = {}) {
@@ -678,7 +682,8 @@ test("prepareEtSshEnvironment routes a single jump host through ET --jumphost/--
   assert.match(config, /\n {2}User ops/);
   assert.match(config, /\n {2}Port 2200/);
   assert.match(config, /Host h\n {2}ProxyJump jump\.example/);
-  assert.match(config, /StrictHostKeyChecking accept-new/);
+  // Host-key policy is enforced via --ssh-option (not Host config blocks).
+  assert.ok(env.sshOptions.includes("StrictHostKeyChecking=accept-new"));
   // No ProxyCommand anymore — ET owns the jump routing.
   assert.doesNotMatch(config, /ProxyCommand/);
 });
@@ -802,7 +807,8 @@ test("prepareEtSshEnvironment quotes ssh config paths that contain spaces", (t) 
   const config = fs.readFileSync(path.join(env.env.HOME, ".ssh", "config"), "utf8");
   const configKeyPath = keyPath.replace(/\\/g, "/");
   assert.match(config, new RegExp(`IdentityFile "${configKeyPath.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")}"`));
-  assert.match(config, /UserKnownHostsFile ".*known_hosts"/);
+  // Host-key paths ride --ssh-option; IdentityFile with spaces is still quoted in config.
+  assert.ok(env.sshOptions.some((option) => option.startsWith("UserKnownHostsFile=")));
 });
 
 test("prepareEtSshEnvironment scopes destination config under Host <dest> when a jump host is present", (t) => {
@@ -880,7 +886,7 @@ test("prepareEtSshEnvironment injects vault known_hosts for key-change checks", 
       hostname: "host.example",
       port: 22,
       keyType: "ssh-ed25519",
-      publicKey: "ssh-ed25519 AAAAVAULTBLOB",
+      publicKey: VALID_ED25519_PUB,
     }],
   });
 
@@ -892,7 +898,7 @@ test("prepareEtSshEnvironment injects vault known_hosts for key-change checks", 
   assert.equal(trustPath, globalOption.slice("GlobalKnownHostsFile=".length));
   assert.ok(fs.existsSync(trustPath));
   const trustContent = fs.readFileSync(trustPath, "utf8");
-  assert.match(trustContent, /host\.example ssh-ed25519 AAAAVAULTBLOB/);
+  assert.match(trustContent, new RegExp(`host\\.example ssh-ed25519 ${VALID_ED25519_BLOB}`));
   // System pin for the same host must not remain (would override vault).
   assert.doesNotMatch(trustContent, /AAASYSTEM/);
   assert.ok(env.sshOptions.includes("StrictHostKeyChecking=accept-new"));
@@ -907,7 +913,7 @@ test("prepareEtSshEnvironment keeps persistent known_hosts when vault does not p
     knownHosts: [{
       hostname: "unrelated.example",
       keyType: "ssh-ed25519",
-      publicKey: "ssh-ed25519 AAAOTHER",
+      publicKey: VALID_ED25519_PUB,
     }],
   });
 
@@ -933,7 +939,7 @@ test("prepareEtSshEnvironment disables host-key checks when verifyHostKeys is fa
     knownHosts: [{
       hostname: "host.example",
       keyType: "ssh-ed25519",
-      publicKey: "ssh-ed25519 AAASTALE",
+      publicKey: VALID_ED25519_PUB,
     }],
   });
 
@@ -953,18 +959,18 @@ test("prepareEtSshEnvironment disables host-key checks when verifyHostKeys is fa
   assert.ok(fs.existsSync(emptyPath));
   assert.equal(fs.readFileSync(emptyPath, "utf8").trim(), "");
   // Must not keep loading the stale vault pin when verification is off.
-  assert.doesNotMatch(fs.readFileSync(emptyPath, "utf8"), /AAASTALE/);
+  assert.equal(fs.readFileSync(emptyPath, "utf8").trim(), "");
 });
 
-test("prepareEtSshEnvironment applies vault host-key policy to jump hosts", (t) => {
-  const { api, base } = makeApi(t);
+test("prepareEtSshEnvironment applies vault host-key policy via ssh-option for jump hosts", (t) => {
+  const { api } = makeApi(t);
   const env = api.prepareEtSshEnvironment("sess1", {
     hostname: "target.example",
     username: "alice",
     knownHosts: [{
       hostname: "jump.example",
       keyType: "ssh-ed25519",
-      publicKey: "ssh-ed25519 AAAJUMP",
+      publicKey: VALID_ED25519_PUB,
     }],
     jumpHosts: [{
       hostname: "jump.example",
@@ -974,32 +980,29 @@ test("prepareEtSshEnvironment applies vault host-key policy to jump hosts", (t) 
     }],
   });
 
-  const configPath = path.join(base, "et-ssh-home-sess1", ".ssh", "config");
-  assert.ok(fs.existsSync(configPath));
-  const config = fs.readFileSync(configPath, "utf8");
-  assert.match(config, /Host jump\.example/);
-  // Jump is vault-pinned → authoritative snapshot.
-  assert.match(config, /Host jump\.example[\s\S]*GlobalKnownHostsFile /);
-  assert.match(config, /Host jump\.example[\s\S]*StrictHostKeyChecking /);
-  // Target is not vault-pinned → persistent user known_hosts.
-  assert.match(config, /Host target\.example[\s\S]*UserKnownHostsFile /);
-  assert.match(config, /Host target\.example[\s\S]*StrictHostKeyChecking accept-new/);
-  // Host-key policy must not be forced globally via --ssh-option (would override hop).
-  assert.equal(
-    env.sshOptions.some((option) => option.startsWith("GlobalKnownHostsFile=")),
-    false,
+  // Host-key policy must ride --ssh-option so OpenSSH on POSIX enforces it
+  // even when a temp-HOME Host config block is not consulted.
+  assert.ok(env.sshOptions.some((option) => option.startsWith("GlobalKnownHostsFile=")));
+  assert.ok(env.sshOptions.some((option) => option.startsWith("UserKnownHostsFile=")));
+  assert.ok(env.sshOptions.includes("StrictHostKeyChecking=accept-new"));
+  const trustPath = env.sshOptions
+    .find((option) => option.startsWith("UserKnownHostsFile="))
+    .slice("UserKnownHostsFile=".length);
+  assert.match(
+    fs.readFileSync(trustPath, "utf8"),
+    new RegExp(`jump\\.example ssh-ed25519 ${VALID_ED25519_BLOB}`),
   );
 });
 
-test("prepareEtSshEnvironment keeps unpinned jump on persistent known_hosts", (t) => {
-  const { api, base } = makeApi(t);
-  api.prepareEtSshEnvironment("sess1", {
+test("prepareEtSshEnvironment merges vault pins for target hop with jump present", (t) => {
+  const { api } = makeApi(t);
+  const env = api.prepareEtSshEnvironment("sess1", {
     hostname: "target.example",
     username: "alice",
     knownHosts: [{
       hostname: "target.example",
       keyType: "ssh-ed25519",
-      publicKey: "ssh-ed25519 AAATARGET",
+      publicKey: VALID_ED25519_PUB,
     }],
     jumpHosts: [{
       hostname: "jump.example",
@@ -1009,15 +1012,14 @@ test("prepareEtSshEnvironment keeps unpinned jump on persistent known_hosts", (t
     }],
   });
 
-  const configPath = path.join(base, "et-ssh-home-sess1", ".ssh", "config");
-  const config = fs.readFileSync(configPath, "utf8");
-  // Target vault-pinned → authoritative snapshot in Host target block.
-  assert.match(config, /Host target\.example[\s\S]*GlobalKnownHostsFile /);
-  // Jump unpinned → persistent user known_hosts, not the session snapshot.
-  const jumpBlock = config.slice(config.indexOf("Host jump.example"));
-  assert.match(jumpBlock, /UserKnownHostsFile /);
-  assert.match(jumpBlock, /StrictHostKeyChecking accept-new/);
-  assert.doesNotMatch(jumpBlock, /GlobalKnownHostsFile /);
+  assert.ok(env.sshOptions.some((option) => option.startsWith("GlobalKnownHostsFile=")));
+  const trustPath = env.sshOptions
+    .find((option) => option.startsWith("UserKnownHostsFile="))
+    .slice("UserKnownHostsFile=".length);
+  assert.match(
+    fs.readFileSync(trustPath, "utf8"),
+    new RegExp(`target\\.example ssh-ed25519 ${VALID_ED25519_BLOB}`),
+  );
 });
 
 test("execOnEtSession honors session StrictHostKeyChecking=no over accept-new default", async (t) => {
@@ -1070,11 +1072,14 @@ test("execOnEtSession requireTrustedHost uses strict host-key checking", async (
     externalAuthArtifacts: env.artifacts,
     externalAuthArtifactsCleaned: false,
     etStatsAuth: {
+      hostname: "host.example",
+      port: 22,
+      username: "alice",
       knownHosts: [{
         hostname: "host.example",
         port: 22,
         keyType: "ssh-ed25519",
-        publicKey: "vaultblob",
+        publicKey: VALID_ED25519_PUB,
       }],
     },
   };
@@ -1086,7 +1091,7 @@ test("execOnEtSession requireTrustedHost uses strict host-key checking", async (
   assert.doesNotMatch(joined, /StrictHostKeyChecking=accept-new/);
   assert.ok(session.etStrictExecKnownHostsPath);
   const strictContent = fs.readFileSync(session.etStrictExecKnownHostsPath, "utf8");
-  assert.match(strictContent, /host\.example ssh-ed25519 vaultblob/);
+  assert.match(strictContent, new RegExp(`host\\.example ssh-ed25519 ${VALID_ED25519_BLOB}`));
 });
 
 test("execOnEtSession forwards maxBuffer to the ssh execFile call", async (t) => {

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -899,6 +899,31 @@ test("prepareEtSshEnvironment injects vault known_hosts for key-change checks", 
   assert.ok(trustPath.startsWith(path.join(base, "et-ssh-home-sess1")));
 });
 
+test("prepareEtSshEnvironment keeps persistent known_hosts when vault does not pin target", (t) => {
+  const { api, base } = makeApi(t);
+  const env = api.prepareEtSshEnvironment("sess1", {
+    hostname: "target.example",
+    username: "alice",
+    knownHosts: [{
+      hostname: "unrelated.example",
+      keyType: "ssh-ed25519",
+      publicKey: "ssh-ed25519 AAAOTHER",
+    }],
+  });
+
+  const userOption = env.sshOptions.find((option) => option.startsWith("UserKnownHostsFile="));
+  assert.ok(userOption);
+  assert.equal(
+    userOption,
+    `UserKnownHostsFile=${path.join(base, "home", ".ssh", "known_hosts").replace(/\\/g, "/")}`,
+  );
+  // Must not force a session-local UserKnownHostsFile for unrelated vault pins.
+  assert.equal(
+    env.sshOptions.some((option) => option.startsWith("GlobalKnownHostsFile=")),
+    false,
+  );
+});
+
 test("prepareEtSshEnvironment disables host-key checks when verifyHostKeys is false", (t) => {
   const { api } = makeApi(t);
   const env = api.prepareEtSshEnvironment("sess1", {

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -868,6 +868,11 @@ test("prepareEtSshEnvironment uses a persistent user known_hosts file", (t) => {
 
 test("prepareEtSshEnvironment injects vault known_hosts for key-change checks", (t) => {
   const { api, base } = makeApi(t);
+  // Seed a conflicting system pin so we can assert vault wins.
+  const systemKh = path.join(base, "home", ".ssh", "known_hosts");
+  fs.mkdirSync(path.dirname(systemKh), { recursive: true });
+  fs.writeFileSync(systemKh, "host.example ssh-ed25519 AAASYSTEM\n");
+
   const env = api.prepareEtSshEnvironment("sess1", {
     hostname: "host.example",
     username: "alice",
@@ -879,14 +884,18 @@ test("prepareEtSshEnvironment injects vault known_hosts for key-change checks", 
     }],
   });
 
+  const userOption = env.sshOptions.find((option) => option.startsWith("UserKnownHostsFile="));
   const globalOption = env.sshOptions.find((option) => option.startsWith("GlobalKnownHostsFile="));
+  assert.ok(userOption, "expected UserKnownHostsFile for vault keys");
   assert.ok(globalOption, "expected GlobalKnownHostsFile for vault keys");
-  const trustPath = globalOption.slice("GlobalKnownHostsFile=".length);
+  const trustPath = userOption.slice("UserKnownHostsFile=".length);
+  assert.equal(trustPath, globalOption.slice("GlobalKnownHostsFile=".length));
   assert.ok(fs.existsSync(trustPath));
-  assert.match(fs.readFileSync(trustPath, "utf8"), /host\.example ssh-ed25519 AAAAVAULTBLOB/);
+  const trustContent = fs.readFileSync(trustPath, "utf8");
+  assert.match(trustContent, /host\.example ssh-ed25519 AAAAVAULTBLOB/);
+  // System pin for the same host must not remain (would override vault).
+  assert.doesNotMatch(trustContent, /AAASYSTEM/);
   assert.ok(env.sshOptions.includes("StrictHostKeyChecking=accept-new"));
-  // Still pin the persistent user known_hosts for first-seen accept-new writes.
-  assert.ok(env.sshOptions.some((option) => option.startsWith("UserKnownHostsFile=")));
   assert.ok(trustPath.startsWith(path.join(base, "et-ssh-home-sess1")));
 });
 

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -978,9 +978,46 @@ test("prepareEtSshEnvironment applies vault host-key policy to jump hosts", (t) 
   assert.ok(fs.existsSync(configPath));
   const config = fs.readFileSync(configPath, "utf8");
   assert.match(config, /Host jump\.example/);
-  assert.match(config, /GlobalKnownHostsFile /);
-  assert.match(config, /StrictHostKeyChecking /);
-  assert.match(config, /accept-new/);
+  // Jump is vault-pinned → authoritative snapshot.
+  assert.match(config, /Host jump\.example[\s\S]*GlobalKnownHostsFile /);
+  assert.match(config, /Host jump\.example[\s\S]*StrictHostKeyChecking /);
+  // Target is not vault-pinned → persistent user known_hosts.
+  assert.match(config, /Host target\.example[\s\S]*UserKnownHostsFile /);
+  assert.match(config, /Host target\.example[\s\S]*StrictHostKeyChecking accept-new/);
+  // Host-key policy must not be forced globally via --ssh-option (would override hop).
+  assert.equal(
+    env.sshOptions.some((option) => option.startsWith("GlobalKnownHostsFile=")),
+    false,
+  );
+});
+
+test("prepareEtSshEnvironment keeps unpinned jump on persistent known_hosts", (t) => {
+  const { api, base } = makeApi(t);
+  api.prepareEtSshEnvironment("sess1", {
+    hostname: "target.example",
+    username: "alice",
+    knownHosts: [{
+      hostname: "target.example",
+      keyType: "ssh-ed25519",
+      publicKey: "ssh-ed25519 AAATARGET",
+    }],
+    jumpHosts: [{
+      hostname: "jump.example",
+      username: "jumpuser",
+      authMethod: "password",
+      password: "secret",
+    }],
+  });
+
+  const configPath = path.join(base, "et-ssh-home-sess1", ".ssh", "config");
+  const config = fs.readFileSync(configPath, "utf8");
+  // Target vault-pinned → authoritative snapshot in Host target block.
+  assert.match(config, /Host target\.example[\s\S]*GlobalKnownHostsFile /);
+  // Jump unpinned → persistent user known_hosts, not the session snapshot.
+  const jumpBlock = config.slice(config.indexOf("Host jump.example"));
+  assert.match(jumpBlock, /UserKnownHostsFile /);
+  assert.match(jumpBlock, /StrictHostKeyChecking accept-new/);
+  assert.doesNotMatch(jumpBlock, /GlobalKnownHostsFile /);
 });
 
 test("execOnEtSession honors session StrictHostKeyChecking=no over accept-new default", async (t) => {

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -866,6 +866,73 @@ test("prepareEtSshEnvironment uses a persistent user known_hosts file", (t) => {
   assert.equal(fs.existsSync(path.join(base, "et-ssh-home-sess1", ".ssh", "known_hosts")), false);
 });
 
+test("prepareEtSshEnvironment injects vault known_hosts for key-change checks", (t) => {
+  const { api, base } = makeApi(t);
+  const env = api.prepareEtSshEnvironment("sess1", {
+    hostname: "host.example",
+    username: "alice",
+    knownHosts: [{
+      hostname: "host.example",
+      port: 22,
+      keyType: "ssh-ed25519",
+      publicKey: "ssh-ed25519 AAAAVAULTBLOB",
+    }],
+  });
+
+  const globalOption = env.sshOptions.find((option) => option.startsWith("GlobalKnownHostsFile="));
+  assert.ok(globalOption, "expected GlobalKnownHostsFile for vault keys");
+  const vaultPath = globalOption.slice("GlobalKnownHostsFile=".length);
+  assert.ok(fs.existsSync(vaultPath));
+  assert.match(fs.readFileSync(vaultPath, "utf8"), /host\.example ssh-ed25519 AAAAVAULTBLOB/);
+  assert.ok(env.sshOptions.includes("StrictHostKeyChecking=accept-new"));
+  // Still pin the persistent user known_hosts for first-seen accept-new writes.
+  assert.ok(env.sshOptions.some((option) => option.startsWith("UserKnownHostsFile=")));
+  assert.ok(vaultPath.startsWith(path.join(base, "et-ssh-home-sess1")));
+});
+
+test("prepareEtSshEnvironment disables host-key checks when verifyHostKeys is false", (t) => {
+  const { api } = makeApi(t);
+  const env = api.prepareEtSshEnvironment("sess1", {
+    hostname: "host.example",
+    username: "alice",
+    verifyHostKeys: false,
+  });
+
+  assert.ok(env.sshOptions.includes("StrictHostKeyChecking=no"));
+  assert.equal(
+    env.sshOptions.filter((option) => option.startsWith("StrictHostKeyChecking=")).length,
+    1,
+  );
+  assert.doesNotMatch(env.sshOptions.join("\n"), /StrictHostKeyChecking=accept-new/);
+});
+
+test("prepareEtSshEnvironment applies vault host-key policy to jump hosts", (t) => {
+  const { api, base } = makeApi(t);
+  const env = api.prepareEtSshEnvironment("sess1", {
+    hostname: "target.example",
+    username: "alice",
+    knownHosts: [{
+      hostname: "jump.example",
+      keyType: "ssh-ed25519",
+      publicKey: "ssh-ed25519 AAAJUMP",
+    }],
+    jumpHosts: [{
+      hostname: "jump.example",
+      username: "jumpuser",
+      authMethod: "password",
+      password: "secret",
+    }],
+  });
+
+  const configPath = path.join(base, "et-ssh-home-sess1", ".ssh", "config");
+  assert.ok(fs.existsSync(configPath));
+  const config = fs.readFileSync(configPath, "utf8");
+  assert.match(config, /Host jump\.example/);
+  assert.match(config, /GlobalKnownHostsFile /);
+  assert.match(config, /StrictHostKeyChecking /);
+  assert.match(config, /accept-new/);
+});
+
 test("execOnEtSession requireTrustedHost uses strict host-key checking", async (t) => {
   let capturedArgs = null;
   const { api } = makeApi(t, {

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -1166,6 +1166,40 @@ test("prepareEtSshEnvironment includes the real user SSH config under -F", (t) =
   );
 });
 
+test("prepareEtSshEnvironment does not freeze jump HostName to the alias token", (t) => {
+  const { api, base } = makeApi(t);
+  const realUserConfig = path.join(base, "home", ".ssh", "config");
+  fs.mkdirSync(path.dirname(realUserConfig), { recursive: true });
+  fs.writeFileSync(
+    realUserConfig,
+    "Host bastion\n  HostName 10.0.0.5\n  User jumpuser\n",
+  );
+
+  const env = api.prepareEtSshEnvironment("sess1", {
+    hostname: "target.example",
+    username: "alice",
+    jumpHosts: [{
+      hostname: "bastion",
+      username: "ops",
+      authMethod: "password",
+      password: "secret",
+    }],
+  });
+
+  const sessionConfig = fs.readFileSync(path.join(env.env.HOME, ".ssh", "config"), "utf8");
+  const jumpBlockStart = sessionConfig.indexOf("Host bastion");
+  assert.ok(jumpBlockStart >= 0, "expected Host bastion block");
+  const afterJump = sessionConfig.slice(jumpBlockStart);
+  const nextSection = afterJump.search(/\n(?:Host |Match )/);
+  const jumpBlock = nextSection >= 0 ? afterJump.slice(0, nextSection) : afterJump;
+
+  // Freezing HostName bastion would win over Include's HostName 10.0.0.5.
+  assert.doesNotMatch(jumpBlock, /^\s*HostName\s+/m);
+  assert.match(jumpBlock, /^\s*User ops\s*$/m);
+  assert.match(sessionConfig, /Include /);
+  assert.match(sessionConfig, /Match all/);
+});
+
 test("prepareEtSshEnvironment prepends ssh wrapper onto session PATH", (t) => {
   const { api } = makeApi(t);
   const env = api.prepareEtSshEnvironment("sess1", {

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -881,13 +881,13 @@ test("prepareEtSshEnvironment injects vault known_hosts for key-change checks", 
 
   const globalOption = env.sshOptions.find((option) => option.startsWith("GlobalKnownHostsFile="));
   assert.ok(globalOption, "expected GlobalKnownHostsFile for vault keys");
-  const vaultPath = globalOption.slice("GlobalKnownHostsFile=".length);
-  assert.ok(fs.existsSync(vaultPath));
-  assert.match(fs.readFileSync(vaultPath, "utf8"), /host\.example ssh-ed25519 AAAAVAULTBLOB/);
+  const trustPath = globalOption.slice("GlobalKnownHostsFile=".length);
+  assert.ok(fs.existsSync(trustPath));
+  assert.match(fs.readFileSync(trustPath, "utf8"), /host\.example ssh-ed25519 AAAAVAULTBLOB/);
   assert.ok(env.sshOptions.includes("StrictHostKeyChecking=accept-new"));
   // Still pin the persistent user known_hosts for first-seen accept-new writes.
   assert.ok(env.sshOptions.some((option) => option.startsWith("UserKnownHostsFile=")));
-  assert.ok(vaultPath.startsWith(path.join(base, "et-ssh-home-sess1")));
+  assert.ok(trustPath.startsWith(path.join(base, "et-ssh-home-sess1")));
 });
 
 test("prepareEtSshEnvironment disables host-key checks when verifyHostKeys is false", (t) => {
@@ -896,6 +896,11 @@ test("prepareEtSshEnvironment disables host-key checks when verifyHostKeys is fa
     hostname: "host.example",
     username: "alice",
     verifyHostKeys: false,
+    knownHosts: [{
+      hostname: "host.example",
+      keyType: "ssh-ed25519",
+      publicKey: "ssh-ed25519 AAASTALE",
+    }],
   });
 
   assert.ok(env.sshOptions.includes("StrictHostKeyChecking=no"));
@@ -904,6 +909,17 @@ test("prepareEtSshEnvironment disables host-key checks when verifyHostKeys is fa
     1,
   );
   assert.doesNotMatch(env.sshOptions.join("\n"), /StrictHostKeyChecking=accept-new/);
+
+  const userKh = env.sshOptions.find((option) => option.startsWith("UserKnownHostsFile="));
+  const globalKh = env.sshOptions.find((option) => option.startsWith("GlobalKnownHostsFile="));
+  assert.ok(userKh, "expected neutralized UserKnownHostsFile");
+  assert.ok(globalKh, "expected neutralized GlobalKnownHostsFile");
+  assert.equal(userKh.slice("UserKnownHostsFile=".length), globalKh.slice("GlobalKnownHostsFile=".length));
+  const emptyPath = userKh.slice("UserKnownHostsFile=".length);
+  assert.ok(fs.existsSync(emptyPath));
+  assert.equal(fs.readFileSync(emptyPath, "utf8").trim(), "");
+  // Must not keep loading the stale vault pin when verification is off.
+  assert.doesNotMatch(fs.readFileSync(emptyPath, "utf8"), /AAASTALE/);
 });
 
 test("prepareEtSshEnvironment applies vault host-key policy to jump hosts", (t) => {

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -1127,6 +1127,43 @@ test("prepareEtSshEnvironment injects a PATH ssh wrapper that forces -F", (t) =>
   }
 });
 
+test("prepareEtSshEnvironment includes the real user SSH config under -F", (t) => {
+  const { api, base } = makeApi(t);
+  const realUserConfig = path.join(base, "home", ".ssh", "config");
+  fs.mkdirSync(path.dirname(realUserConfig), { recursive: true });
+  fs.writeFileSync(
+    realUserConfig,
+    "Host work\n  HostName server.example\n  User deploy\n",
+  );
+
+  const env = api.prepareEtSshEnvironment("sess1", {
+    hostname: "target.example",
+    username: "alice",
+    // Force a generated session config (jump host writes Host blocks).
+    jumpHosts: [{
+      hostname: "jump.example",
+      username: "ops",
+      authMethod: "password",
+      password: "secret",
+    }],
+  });
+
+  const sessionConfigPath = path.join(env.env.HOME, ".ssh", "config");
+  assert.ok(fs.existsSync(sessionConfigPath));
+  const sessionConfig = fs.readFileSync(sessionConfigPath, "utf8");
+  // Session Host blocks come first (first-obtained-value keeps overrides).
+  const hostIdx = sessionConfig.indexOf("Host target.example");
+  const includeIdx = sessionConfig.indexOf("Include ");
+  assert.ok(hostIdx >= 0, "expected session Host block");
+  assert.ok(includeIdx > hostIdx, "Include must follow session Host blocks");
+  // Real user config is preserved so HostName aliases still resolve.
+  const normalizedUserConfig = realUserConfig.replace(/\\/g, "/");
+  assert.match(
+    sessionConfig,
+    new RegExp(`Include ["']?${normalizedUserConfig.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`),
+  );
+});
+
 test("execOnEtSession requireTrustedHost uses strict host-key checking", async (t) => {
   let capturedArgs = null;
   const { api } = makeApi(t, {

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -1065,6 +1065,39 @@ test("execOnEtSession honors session StrictHostKeyChecking=no over accept-new de
   assert.doesNotMatch(joined, /StrictHostKeyChecking=accept-new/);
 });
 
+test("execOnEtSession forces the session-generated SSH config with -F", async (t) => {
+  let capturedArgs = null;
+  const { api } = makeApi(t, {
+    execFile: (_cmd, args, _opts, cb) => {
+      capturedArgs = args;
+      process.nextTick(() => cb(null, "", ""));
+    },
+  });
+  const env = api.prepareEtSshEnvironment("sess1", {
+    hostname: "target.example",
+    username: "alice",
+    jumpHosts: [{
+      hostname: "jump.example",
+      username: "ops",
+      authMethod: "password",
+      password: "secret",
+    }],
+  });
+  const session = {
+    sshUserHost: env.userHost,
+    sshOptions: env.sshOptions,
+    sshEnv: env.env,
+    externalAuthArtifacts: env.artifacts,
+    externalAuthArtifactsCleaned: false,
+  };
+
+  await api.execOnEtSession(session, "echo ok", 1000);
+
+  const fIdx = capturedArgs.indexOf("-F");
+  assert.ok(fIdx >= 0, "expected -F session config");
+  assert.match(capturedArgs[fIdx + 1], /[\\/]\.ssh[\\/]config$/);
+});
+
 test("execOnEtSession requireTrustedHost uses strict host-key checking", async (t) => {
   let capturedArgs = null;
   const { api } = makeApi(t, {

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -1153,15 +1153,35 @@ test("prepareEtSshEnvironment includes the real user SSH config under -F", (t) =
   const sessionConfig = fs.readFileSync(sessionConfigPath, "utf8");
   // Session Host blocks come first (first-obtained-value keeps overrides).
   const hostIdx = sessionConfig.indexOf("Host target.example");
+  const matchAllIdx = sessionConfig.indexOf("Match all");
   const includeIdx = sessionConfig.indexOf("Include ");
   assert.ok(hostIdx >= 0, "expected session Host block");
-  assert.ok(includeIdx > hostIdx, "Include must follow session Host blocks");
+  assert.ok(matchAllIdx > hostIdx, "Match all must reset Host context after session blocks");
+  assert.ok(includeIdx > matchAllIdx, "Include must follow Match all");
   // Real user config is preserved so HostName aliases still resolve.
   const normalizedUserConfig = realUserConfig.replace(/\\/g, "/");
   assert.match(
     sessionConfig,
     new RegExp(`Include ["']?${normalizedUserConfig.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`),
   );
+});
+
+test("prepareEtSshEnvironment prepends ssh wrapper onto session PATH", (t) => {
+  const { api } = makeApi(t);
+  const env = api.prepareEtSshEnvironment("sess1", {
+    hostname: "target.example",
+    username: "alice",
+    env: { PATH: "/custom/bin:/usr/bin" },
+    jumpHosts: [{
+      hostname: "jump.example",
+      username: "ops",
+      authMethod: "password",
+      password: "secret",
+    }],
+  });
+  const pathKey = Object.keys(env.env).find((k) => k.toLowerCase() === "path");
+  assert.ok(pathKey);
+  assert.match(env.env[pathKey], /^[^:]+\/bin:\/custom\/bin:\/usr\/bin$/);
 });
 
 test("execOnEtSession requireTrustedHost uses strict host-key checking", async (t) => {

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -12,7 +12,7 @@ const { orderSshIdentityNames, SSH_KEY_PATTERN } = require("../sshAuthHelper.cjs
 const { fanoutSessionExit } = require("../terminalAttachRestore.cjs");
 const {
   buildExternalHostKeySshOptions,
-  buildVaultKnownHostsContent,
+  buildMergedGlobalKnownHostsContent,
 } = require("../externalSshHostKeyPolicy.cjs");
 
 const execFileAsync = promisify(execFile);
@@ -363,22 +363,38 @@ function createMoshSessionApi(ctx) {
 
         // Vault known_hosts (issue #2501): Mosh bootstraps via system OpenSSH,
         // which only sees ~/.ssh/known_hosts by default. Keys the user already
-        // trusted through Netcatty SSH live in the in-app vault — inject them
-        // as GlobalKnownHostsFile so a changed host key is rejected. The
-        // handshake runs in an interactive PTY, so first-seen hosts keep
+        // trusted through Netcatty SSH live in the in-app vault — merge them
+        // with OpenSSH default global known_hosts into one GlobalKnownHostsFile
+        // so a changed host key is rejected without dropping admin pins.
+        // The handshake runs in an interactive PTY, so first-seen hosts keep
         // OpenSSH's default ask prompt unless verification is disabled.
-        const vaultContent = buildVaultKnownHostsContent(options.knownHosts);
-        let vaultKnownHostsPath = null;
-        if (vaultContent) {
-          vaultKnownHostsPath = await writeMoshAuthTempFile(
-            safeMoshAuthFileName(sessionId, "vault-known-hosts", ".txt"),
-            vaultContent,
+        const verifyHostKeys = options.verifyHostKeys !== false;
+        let mergedGlobalKnownHostsPath = null;
+        let emptyKnownHostsPath = null;
+        if (verifyHostKeys) {
+          const mergedContent = buildMergedGlobalKnownHostsContent({
+            knownHosts: options.knownHosts,
+            fs,
+            pathModule: path,
+          });
+          if (mergedContent) {
+            mergedGlobalKnownHostsPath = await writeMoshAuthTempFile(
+              safeMoshAuthFileName(sessionId, "global-known-hosts", ".txt"),
+              mergedContent,
+            );
+            tempFiles.push(mergedGlobalKnownHostsPath);
+          }
+        } else {
+          emptyKnownHostsPath = await writeMoshAuthTempFile(
+            safeMoshAuthFileName(sessionId, "empty-known-hosts", ".txt"),
+            "",
           );
-          tempFiles.push(vaultKnownHostsPath);
+          tempFiles.push(emptyKnownHostsPath);
         }
         sshArgs.push(...buildExternalHostKeySshOptions({
-          vaultKnownHostsPath,
-          verifyHostKeys: options.verifyHostKeys,
+          mergedGlobalKnownHostsPath,
+          emptyKnownHostsPath,
+          verifyHostKeys,
           protocol: "mosh",
           style: "args",
         }));

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -393,6 +393,7 @@ function createMoshSessionApi(ctx) {
               username: options.username,
               pathModule: path,
               homedir: os.homedir(),
+              memo: new Map(),
             });
             if (authoritativeContent) {
               authoritativeKnownHostsPath = await writeMoshAuthTempFile(

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -13,6 +13,7 @@ const { fanoutSessionExit } = require("../terminalAttachRestore.cjs");
 const {
   buildAuthoritativeKnownHostsContent,
   buildExternalHostKeySshOptions,
+  vaultPinsConnectionHosts,
 } = require("../externalSshHostKeyPolicy.cjs");
 
 const execFileAsync = promisify(execFile);
@@ -371,18 +372,32 @@ function createMoshSessionApi(ctx) {
         let authoritativeKnownHostsPath = null;
         let emptyKnownHostsPath = null;
         if (verifyHostKeys) {
-          const authoritativeContent = buildAuthoritativeKnownHostsContent({
-            knownHosts: options.knownHosts,
-            fs,
-            pathModule: path,
-            homedir: os.homedir(),
-          });
-          if (authoritativeContent) {
-            authoritativeKnownHostsPath = await writeMoshAuthTempFile(
-              safeMoshAuthFileName(sessionId, "authoritative-known-hosts", ".txt"),
-              authoritativeContent,
-            );
-            tempFiles.push(authoritativeKnownHostsPath);
+          // Only override system known_hosts when the vault pins this target
+          // (or a jump host). Unrelated vault entries must not force a temp
+          // UserKnownHostsFile for every Mosh session.
+          const connectionHosts = [
+            { hostname: options.hostname, port: options.port || 22 },
+            ...(Array.isArray(options.jumpHosts)
+              ? options.jumpHosts.map((jump) => ({
+                hostname: jump.hostname,
+                port: jump.port || 22,
+              }))
+              : []),
+          ];
+          if (vaultPinsConnectionHosts(options.knownHosts, connectionHosts)) {
+            const authoritativeContent = buildAuthoritativeKnownHostsContent({
+              knownHosts: options.knownHosts,
+              fs,
+              pathModule: path,
+              homedir: os.homedir(),
+            });
+            if (authoritativeContent) {
+              authoritativeKnownHostsPath = await writeMoshAuthTempFile(
+                safeMoshAuthFileName(sessionId, "authoritative-known-hosts", ".txt"),
+                authoritativeContent,
+              );
+              tempFiles.push(authoritativeKnownHostsPath);
+            }
           }
         } else {
           emptyKnownHostsPath = await writeMoshAuthTempFile(

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -388,6 +388,7 @@ function createMoshSessionApi(ctx) {
             const authoritativeContent = buildAuthoritativeKnownHostsContent({
               knownHosts: options.knownHosts,
               fs,
+              hostname: options.hostname,
               pathModule: path,
               homedir: os.homedir(),
             });

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -11,8 +11,8 @@ const { createSshConnExecProbe } = require("../ai/sessionShellKind.cjs");
 const { orderSshIdentityNames, SSH_KEY_PATTERN } = require("../sshAuthHelper.cjs");
 const { fanoutSessionExit } = require("../terminalAttachRestore.cjs");
 const {
+  buildAuthoritativeKnownHostsContent,
   buildExternalHostKeySshOptions,
-  buildMergedGlobalKnownHostsContent,
 } = require("../externalSshHostKeyPolicy.cjs");
 
 const execFileAsync = promisify(execFile);
@@ -361,28 +361,28 @@ function createMoshSessionApi(ctx) {
           sshArgs.push("-o", `PreferredAuthentications=${preferredAuthentications}`);
         }
 
-        // Vault known_hosts (issue #2501): Mosh bootstraps via system OpenSSH,
-        // which only sees ~/.ssh/known_hosts by default. Keys the user already
-        // trusted through Netcatty SSH live in the in-app vault — merge them
-        // with OpenSSH default global known_hosts into one GlobalKnownHostsFile
-        // so a changed host key is rejected without dropping admin pins.
-        // The handshake runs in an interactive PTY, so first-seen hosts keep
-        // OpenSSH's default ask prompt unless verification is disabled.
+        // Vault known_hosts (issue #2501): Mosh bootstraps via system OpenSSH.
+        // When the vault pins hosts, write an authoritative known_hosts
+        // snapshot (vault pins + filtered system entries) and force
+        // StrictHostKeyChecking=ask so a permissive user ssh_config cannot
+        // disable verification. Vault hosts exclude conflicting system pins
+        // so a rotated system key cannot override the vault.
         const verifyHostKeys = options.verifyHostKeys !== false;
-        let mergedGlobalKnownHostsPath = null;
+        let authoritativeKnownHostsPath = null;
         let emptyKnownHostsPath = null;
         if (verifyHostKeys) {
-          const mergedContent = buildMergedGlobalKnownHostsContent({
+          const authoritativeContent = buildAuthoritativeKnownHostsContent({
             knownHosts: options.knownHosts,
             fs,
             pathModule: path,
+            homedir: os.homedir(),
           });
-          if (mergedContent) {
-            mergedGlobalKnownHostsPath = await writeMoshAuthTempFile(
-              safeMoshAuthFileName(sessionId, "global-known-hosts", ".txt"),
-              mergedContent,
+          if (authoritativeContent) {
+            authoritativeKnownHostsPath = await writeMoshAuthTempFile(
+              safeMoshAuthFileName(sessionId, "authoritative-known-hosts", ".txt"),
+              authoritativeContent,
             );
-            tempFiles.push(mergedGlobalKnownHostsPath);
+            tempFiles.push(authoritativeKnownHostsPath);
           }
         } else {
           emptyKnownHostsPath = await writeMoshAuthTempFile(
@@ -392,7 +392,7 @@ function createMoshSessionApi(ctx) {
           tempFiles.push(emptyKnownHostsPath);
         }
         sshArgs.push(...buildExternalHostKeySshOptions({
-          mergedGlobalKnownHostsPath,
+          authoritativeKnownHostsPath,
           emptyKnownHostsPath,
           verifyHostKeys,
           protocol: "mosh",

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -10,6 +10,10 @@ const {
 const { createSshConnExecProbe } = require("../ai/sessionShellKind.cjs");
 const { orderSshIdentityNames, SSH_KEY_PATTERN } = require("../sshAuthHelper.cjs");
 const { fanoutSessionExit } = require("../terminalAttachRestore.cjs");
+const {
+  buildExternalHostKeySshOptions,
+  buildVaultKnownHostsContent,
+} = require("../externalSshHostKeyPolicy.cjs");
 
 const execFileAsync = promisify(execFile);
 
@@ -356,6 +360,28 @@ function createMoshSessionApi(ctx) {
         if (preferredAuthentications) {
           sshArgs.push("-o", `PreferredAuthentications=${preferredAuthentications}`);
         }
+
+        // Vault known_hosts (issue #2501): Mosh bootstraps via system OpenSSH,
+        // which only sees ~/.ssh/known_hosts by default. Keys the user already
+        // trusted through Netcatty SSH live in the in-app vault — inject them
+        // as GlobalKnownHostsFile so a changed host key is rejected. The
+        // handshake runs in an interactive PTY, so first-seen hosts keep
+        // OpenSSH's default ask prompt unless verification is disabled.
+        const vaultContent = buildVaultKnownHostsContent(options.knownHosts);
+        let vaultKnownHostsPath = null;
+        if (vaultContent) {
+          vaultKnownHostsPath = await writeMoshAuthTempFile(
+            safeMoshAuthFileName(sessionId, "vault-known-hosts", ".txt"),
+            vaultContent,
+          );
+          tempFiles.push(vaultKnownHostsPath);
+        }
+        sshArgs.push(...buildExternalHostKeySshOptions({
+          vaultKnownHostsPath,
+          verifyHostKeys: options.verifyHostKeys,
+          protocol: "mosh",
+          style: "args",
+        }));
       } catch (err) {
         cleanupMoshAuthTempFiles(tempFiles);
         throw err;

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -389,6 +389,8 @@ function createMoshSessionApi(ctx) {
               knownHosts: options.knownHosts,
               fs,
               hostname: options.hostname,
+              port: options.port || 22,
+              username: options.username,
               pathModule: path,
               homedir: os.homedir(),
             });


### PR DESCRIPTION
## Summary
- Mosh / Eternal Terminal bootstrap via system OpenSSH and previously ignored Netcatty vault `known_hosts`, so a host key trusted through in-app SSH was not checked on later Mosh/ET connects.
- Inject vault entries that carry a full public-key blob as `GlobalKnownHostsFile` for both protocols, reusing shared OpenSSH policy helpers.
- Honor `verifyHostKeys=false` with `StrictHostKeyChecking=no`. ET keeps `accept-new` for first-seen hosts (SSH_ASKPASS cannot answer yes/no); Mosh keeps the interactive OpenSSH ask path for first-seen hosts.
- Addresses #2501 with the reporter’s priority: **reject on key change** (MITM), reusing existing vault known_hosts + OpenSSH trust rather than a new confirmation UI.

## Test plan
- [x] `node --test electron/bridges/externalSshHostKeyPolicy.test.cjs electron/bridges/terminalBridge/etSession.test.cjs electron/bridges/terminalBridge.bareMoshClient.test.cjs`
- [ ] Connect Mosh/ET to a host already trusted in Netcatty Known Hosts (with public key blob) → should connect
- [ ] Rotate/replace the server host key while vault still has the old key → Mosh/ET connection should fail with OpenSSH host-key mismatch
- [ ] Toggle Settings → Verify SSH host keys off → Mosh/ET should connect without host-key checks
- [ ] First-time ET host (not in vault/system known_hosts) → still connects (`accept-new`); first-time Mosh host → OpenSSH ask prompt in PTY

Closes #2501