### PR TITLE
fix(ci): prevent lint-and-test hangs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
   test:
     name: lint-and-test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/application/state/sftp/transferDirectoryOps.ts
+++ b/application/state/sftp/transferDirectoryOps.ts
@@ -385,6 +385,7 @@ export function useSftpDirectoryTransferOps({
               total: number,
               speed: number,
               checkpoint?: {
+                phase?: TransferTask["phase"];
                 resumeStage?: TransferTask["resumeStage"];
                 checkpointBytes?: number;
                 downloadCheckpointBytes?: number;
@@ -461,6 +462,7 @@ export function useSftpDirectoryTransferOps({
                     downloadCheckpointBytes: checkpoint?.downloadCheckpointBytes ?? t.downloadCheckpointBytes,
                     uploadCheckpointBytes: checkpoint?.uploadCheckpointBytes ?? t.uploadCheckpointBytes,
                     sourceFingerprint: checkpoint?.sourceFingerprint ?? t.sourceFingerprint,
+                    phase: checkpoint?.phase ?? t.phase,
                     // Keep pause affordance while paused even if a progress event
                     // briefly reports pauseSupported=false mid soft-drain.
                     resumable: pauseRequested ? true : (checkpoint?.resumable ?? t.resumable),

--- a/application/state/sftp/uploadTaskCallbacks.ts
+++ b/application/state/sftp/uploadTaskCallbacks.ts
@@ -93,6 +93,7 @@ export const createUploadTaskCallbacks = ({
       // Soft-drain high-water transferred must not become the resume offset.
       checkpointBytes: durableCheckpoint,
       speed: progress.speed,
+      phase: progress.phase,
       resumable: progress.resumable,
       pauseUnavailableReason: progress.pauseUnavailableReason,
       // Durable pause identity may arrive on a forced progress event while

--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -30,6 +30,7 @@ function mapWorkerTransferChannelToGlobalEvent(channel, payload) {
       transferred: payload.transferred,
       totalBytes: payload.totalBytes,
       speed: payload.speed,
+      phase: payload.phase,
       checkpointBytes: payload.checkpointBytes,
       resumeStage: payload.resumeStage,
       downloadCheckpointBytes: payload.downloadCheckpointBytes,

--- a/electron/bridges/terminalWorkerManager.transferFanout.test.cjs
+++ b/electron/bridges/terminalWorkerManager.transferFanout.test.cjs
@@ -14,6 +14,7 @@ test("mapWorkerTransferChannelToGlobalEvent maps progress for store ingest", () 
     transferred: 42,
     totalBytes: 100,
     speed: 7,
+    phase: "verifying",
     checkpointBytes: 40,
     lifecycleEpoch: 2,
     lifecycleState: "transferring",
@@ -23,6 +24,7 @@ test("mapWorkerTransferChannelToGlobalEvent maps progress for store ingest", () 
   assert.equal(event.transferred, 42);
   assert.equal(event.totalBytes, 100);
   assert.equal(event.checkpointBytes, 40);
+  assert.equal(event.phase, "verifying");
   assert.equal(event.lifecycleEpoch, 2);
   assert.equal(event.lifecycleState, "transferring");
 });

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -169,52 +169,56 @@ async function resolveRemoteResumeCheckpoint(client, sftpId, filePath, encoding,
   }
 }
 
-async function hashReadable(readable, signal = null) {
-  if (signal?.aborted) {
-    try { readable.destroy?.(); } catch { /* ignore */ }
-    throw new Error("Transfer cancelled");
-  }
-  const hash = crypto.createHash("sha256");
-  const onAbort = () => {
-    try { readable.destroy?.(new Error("Transfer cancelled")); } catch { /* ignore */ }
+async function hashReadable(readable, options = {}) {
+  const { signal, onProgress } = options;
+  const cancellationError = () => {
+    const error = new Error("Transfer cancelled");
+    error.code = "ABORT_ERR";
+    return error;
   };
-  if (signal) {
-    signal.addEventListener("abort", onAbort, { once: true });
+  const abortReadable = () => {
+    try { readable.destroy?.(); } catch { /* ignore */ }
+  };
+  if (signal?.aborted) {
+    abortReadable();
+    throw cancellationError();
   }
+  signal?.addEventListener?.("abort", abortReadable, { once: true });
+  const hash = crypto.createHash("sha256");
+  let bytesRead = 0;
   try {
     for await (const chunk of readable) {
-      if (signal?.aborted) throw new Error("Transfer cancelled");
+      if (signal?.aborted) throw cancellationError();
       hash.update(chunk);
+      bytesRead += chunk.length;
+      onProgress?.(bytesRead);
     }
-    if (signal?.aborted) throw new Error("Transfer cancelled");
+    if (signal?.aborted) throw cancellationError();
     return hash.digest("hex");
+  } catch (error) {
+    if (signal?.aborted) throw cancellationError();
+    throw error;
   } finally {
-    if (signal) {
-      try { signal.removeEventListener("abort", onAbort); } catch { /* ignore */ }
-    }
+    signal?.removeEventListener?.("abort", abortReadable);
   }
 }
 
-function hashLocalRange(filePath, start, endExclusive, signal = null) {
-  const length = Math.max(0, (Number(endExclusive) || 0) - (Number(start) || 0));
-  if (!length) return Promise.resolve(null);
-  return hashReadable(
-    fs.createReadStream(filePath, {
-      start: Math.max(0, Number(start) || 0),
-      end: Math.max(0, Number(endExclusive) || 0) - 1,
-    }),
-    signal,
-  );
+function hashLocalPrefix(filePath, bytes, options) {
+  if (!bytes) return Promise.resolve(null);
+  return hashReadable(fs.createReadStream(filePath, { start: 0, end: bytes - 1 }), options);
 }
 
-function hashLocalFile(filePath, signal = null) {
-  return hashReadable(fs.createReadStream(filePath), signal);
+function hashLocalFile(filePath, options = {}) {
+  return hashReadable(fs.createReadStream(filePath), options);
 }
 
-async function hashRemoteFile(client, sftpId, filePath, encoding) {
+async function hashRemoteFile(client, sftpId, filePath, encoding, options = {}) {
   if (isScpModeClient(client)) return null;
   const sshClient = client?.client;
-  if (sshClient && typeof sshClient.exec === "function") {
+  // The server-side helper has no portable byte progress and its command stream
+  // is not consistently abortable across SSH backends. Visible/cancellable
+  // verification therefore uses the SFTP stream path below.
+  if (!options.signal && !options.onProgress && sshClient && typeof sshClient.exec === "function") {
     const escapedPath = String(filePath).replace(/'/g, "'\\''");
     const digest = await new Promise((resolve, reject) => {
       sshClient.exec(`sha256sum -- '${escapedPath}'`, (error, stream) => {
@@ -232,197 +236,59 @@ async function hashRemoteFile(client, sftpId, filePath, encoding) {
     }).catch(() => null);
     if (digest) return digest;
   }
-  if (!client.sftp) await requireSftpChannel(client);
+  if (!client.sftp) await requireSftpChannel(client, { signal: options.signal });
   if (typeof client.sftp?.createReadStream !== "function") {
     throw new Error("Remote SHA-256 verification is unavailable");
   }
-  return hashReadable(client.sftp.createReadStream(encodePathForSession(sftpId, filePath, encoding)));
+  return hashReadable(
+    client.sftp.createReadStream(encodePathForSession(sftpId, filePath, encoding)),
+    options,
+  );
 }
 
-async function computeSourceFingerprint({ sourceType, sourcePath, sourceSftpId, sourceEncoding }) {
-  if (sourceType === "local") return `sha256:${await hashLocalFile(sourcePath)}`;
+async function computeSourceFingerprint(
+  { sourceType, sourcePath, sourceSftpId, sourceEncoding },
+  options = {},
+) {
+  if (sourceType === "local") return `sha256:${await hashLocalFile(sourcePath, options)}`;
   const client = sftpClients.get(sourceSftpId);
   if (!client) throw new Error("Source SFTP session not found");
-  const digest = await hashRemoteFile(client, sourceSftpId, sourcePath, sourceEncoding);
+  const digest = await hashRemoteFile(client, sourceSftpId, sourcePath, sourceEncoding, options);
   return digest ? `sha256:${digest}` : null;
 }
 
-/**
- * Fast pause/resume identity: size + mtime + head/mid/tail content samples.
- * Full-file SHA-256 is too slow for the pause critical path and must not run
- * as a post-pause background network read (would keep remote I/O after the UI
- * shows paused). Size+mtime alone is unsafe for restart resumes — SFTP mtimes
- * are often whole seconds, so same-size rewrites can keep the meta stamp and
- * corrupt a checkpointed resume past the 256 KiB staged-content sample.
- */
-const IDENTITY_SAMPLE_BYTES = TRANSFER_CHUNK_SIZE;
-
-function sampleOffsetsForIdentity(fileSize) {
-  if (fileSize <= 0) return [];
-  const sampleSize = Math.min(IDENTITY_SAMPLE_BYTES, fileSize);
-  return [...new Set([
-    0,
-    Math.max(0, Math.floor((fileSize - sampleSize) / 2)),
-    Math.max(0, fileSize - sampleSize),
-  ])].map((position) => ({
-    position,
-    length: Math.min(sampleSize, fileSize - position),
-  }));
-}
-
-async function hashLocalIdentitySamples(filePath, fileSize) {
-  const samples = sampleOffsetsForIdentity(fileSize);
-  if (samples.length === 0) return null;
-  const hash = crypto.createHash("sha256");
-  const handle = await fs.promises.open(filePath, "r");
-  try {
-    for (const { position, length } of samples) {
-      const buffer = Buffer.allocUnsafe(length);
-      const { bytesRead } = await handle.read(buffer, 0, length, position);
-      if (bytesRead !== length) {
-        throw new Error("Could not sample source content for resume identity");
-      }
-      hash.update(buffer);
-      hash.update(`@${position}:${length};`);
-    }
-  } finally {
-    await handle.close().catch(() => {});
-  }
-  return hash.digest("hex");
-}
-
-async function hashRemoteIdentitySamples(client, sftpId, filePath, encoding, fileSize) {
-  if (isScpModeClient(client)) return null;
-  const samples = sampleOffsetsForIdentity(fileSize);
-  if (samples.length === 0) return null;
-  await requireSftpChannel(client);
-  const encodedPath = encodePathForSession(sftpId, filePath, encoding);
-  if (typeof client.sftp?.createReadStream !== "function") return null;
-  const hash = crypto.createHash("sha256");
-  for (const { position, length } of samples) {
-    const digest = await hashReadable(
-      client.sftp.createReadStream(encodedPath, {
-        start: position,
-        end: position + length - 1,
-      }),
-    );
-    hash.update(digest);
-    hash.update(`@${position}:${length};`);
-  }
-  return hash.digest("hex");
-}
-
-async function computeSourceIdentityLite({ sourceType, sourcePath, sourceSftpId, sourceEncoding }) {
-  if (sourceType === "local") {
-    const st = await fs.promises.stat(sourcePath);
-    const mtime = Number.isFinite(st.mtimeMs) ? Math.trunc(st.mtimeMs) : 0;
-    const sample = await hashLocalIdentitySamples(sourcePath, st.size);
-    return sample ? `meta:${st.size}:${mtime}:${sample}` : `meta:${st.size}:${mtime}`;
-  }
-  const client = sftpClients.get(sourceSftpId);
-  if (!client) throw new Error("Source SFTP session not found");
-  const attrs = isScpModeClient(client)
-    ? await getScpBackendForClient(client).stat(sourcePath, { encoding: sourceEncoding })
-    : await client.stat(encodePathForSession(sourceSftpId, sourcePath, sourceEncoding));
-  const size = Math.max(0, Number(attrs?.size) || 0);
-  // ssh2-sftp-client / SCP backends expose modifyTime (ms). Raw ssh2 attrs use
-  // mtime in whole seconds (or mtimeMs). Prefer modifyTime first or remote
-  // identity collapses to meta:size:0 and same-size rewrites false-pass.
-  const mtimeRaw = attrs?.modifyTime ?? attrs?.mtimeMs ?? attrs?.mtime;
-  // modifyTime is already ms; raw mtime is often seconds.
-  const mtime = Number.isFinite(Number(mtimeRaw))
-    ? Math.trunc(Number(mtimeRaw) > 1e12 ? Number(mtimeRaw) : Number(mtimeRaw) * 1000)
-    : 0;
-  const sample = await hashRemoteIdentitySamples(client, sourceSftpId, sourcePath, sourceEncoding, size);
-  return sample ? `meta:${size}:${mtime}:${sample}` : `meta:${size}:${mtime}`;
-}
-
-async function computeMatchingSourceFingerprint(storedFingerprint, params) {
-  if (typeof storedFingerprint === "string" && storedFingerprint.startsWith("meta:")) {
-    return computeSourceIdentityLite(params);
-  }
-  return computeSourceFingerprint(params);
-}
-
-/**
- * meta: fingerprints gained an optional content-sample suffix. Legacy
- * meta:size:mtime values still match when size+mtime agree; bounded checkpoint
- * content verify (see resumeContentVerifyRanges) covers same-size rewrites.
- */
 function sourceFingerprintsMatch(storedFingerprint, currentFingerprint) {
-  if (!storedFingerprint || !currentFingerprint) return false;
-  if (storedFingerprint === currentFingerprint) return true;
-  if (
-    typeof storedFingerprint !== "string"
-    || typeof currentFingerprint !== "string"
-    || !storedFingerprint.startsWith("meta:")
-    || !currentFingerprint.startsWith("meta:")
-  ) {
-    return false;
-  }
-  const storedParts = storedFingerprint.split(":");
-  const currentParts = currentFingerprint.split(":");
-  if (storedParts.length === 3 && currentParts.length >= 3) {
-    return storedParts[1] === currentParts[1] && storedParts[2] === currentParts[2];
-  }
-  return false;
+  return Boolean(storedFingerprint && currentFingerprint && storedFingerprint === currentFingerprint);
 }
 
-async function hashRemoteRange(client, sftpId, filePath, encoding, start, endExclusive, signal = null) {
-  const length = Math.max(0, (Number(endExclusive) || 0) - (Number(start) || 0));
-  if (!length) return null;
+async function hashRemotePrefix(client, sftpId, filePath, encoding, bytes, options) {
+  if (!bytes) return null;
   if (isScpModeClient(client)) return null;
-  await requireSftpChannel(client);
+  await requireSftpChannel(client, { signal: options?.signal });
   const encodedPath = encodePathForSession(sftpId, filePath, encoding);
   return hashReadable(
-    client.sftp.createReadStream(encodedPath, {
-      start: Math.max(0, Number(start) || 0),
-      end: Math.max(0, Number(endExclusive) || 0) - 1,
-    }),
-    signal,
+    client.sftp.createReadStream(encodedPath, { start: 0, end: bytes - 1 }),
+    options,
   );
 }
 
 /**
- * Cap content re-hash on resume. Full-prefix hashing of multi-GB .part files
- * over SFTP can take longer than the remaining transfer and freezes the UI at
- * "transferring" with no byte movement; cancel must also destroy the hash stream.
- *
- * Strong (sha256:) fingerprints only need a leading window. meta: identities
- * are size+mtime(+sparse samples), so also hash a trailing window of the
- * checkpoint to catch same-size rewrites past the leading 256 KiB without
- * re-reading the entire saved prefix.
+ * The full SHA-256 source identity proves the source version at capture time.
+ * The complete saved prefix must still match because pause acknowledgement can
+ * precede that capture; a source rewrite in that window must never mix old
+ * staged bytes with a newly fingerprinted suffix.
  */
-const RESUME_CONTENT_VERIFY_MAX_BYTES = 256 * 1024;
-
-function resumeContentVerifyRanges(checkpoint, fingerprint) {
+function resumeContentVerifyBytes(checkpoint, fingerprint) {
   const claimed = Math.max(0, Number(checkpoint) || 0);
-  if (!claimed) return [];
-  const window = RESUME_CONTENT_VERIFY_MAX_BYTES;
-  const leadingEnd = Math.min(claimed, window);
-  if (!(typeof fingerprint === "string" && fingerprint.startsWith("meta:")) || claimed <= window) {
-    return [{ start: 0, end: leadingEnd }];
-  }
-  const trailingStart = Math.max(0, claimed - window);
-  if (trailingStart <= leadingEnd) {
-    // Checkpoint fits in at most two overlapping windows — one contiguous hash.
-    return [{ start: 0, end: claimed }];
-  }
-  return [
-    { start: 0, end: leadingEnd },
-    { start: trailingStart, end: claimed },
-  ];
+  if (!claimed) return 0;
+  void fingerprint;
+  return claimed;
 }
 
-async function assertMatchingResumeRanges(ranges, hashSourceRange, hashStagedRange) {
-  for (const range of ranges) {
-    const [sourceHash, stagedHash] = await Promise.all([
-      hashSourceRange(range.start, range.end),
-      hashStagedRange(range.start, range.end),
-    ]);
-    if (sourceHash && stagedHash && sourceHash !== stagedHash) {
-      throw new Error("Resume safety check failed: saved content does not match the source");
-    }
+async function assertMatchingResumeContent(sourceHashPromise, stagedHashPromise) {
+  const [sourceHash, stagedHash] = await Promise.all([sourceHashPromise, stagedHashPromise]);
+  if (sourceHash && stagedHash && sourceHash !== stagedHash) {
+    throw new Error("Resume safety check failed: saved content does not match the source");
   }
 }
 
@@ -2084,7 +1950,6 @@ async function runPausableConcurrentRanges({
                 settled = true;
                 reject(terminalError || new Error("Transfer cancelled"));
               }, 2000);
-              forceFinishTimer.unref?.();
             }
           }
           return;
@@ -2195,7 +2060,6 @@ async function runPausableConcurrentRanges({
             publishContiguousCheckpoint(true);
             resolvePause();
           }, PAUSE_RANGE_DRAIN_MS);
-          entry.timer.unref?.();
           pauseResolvers.push(entry);
         });
       };
@@ -2364,17 +2228,20 @@ async function uploadFileConcurrent(
     if (remoteHandle) {
       const skipClose = disposeChannel && (failed || transfer.cancelled);
       if (!skipClose) {
+        let closeTimeout = null;
         try {
           await Promise.race([
             closeSftpHandle(sftp, remoteHandle),
             new Promise((_, reject) => {
-              setTimeout(() => reject(new Error("SFTP close timed out")), 2000);
+              closeTimeout = setTimeout(() => reject(new Error("SFTP close timed out")), 2000);
             }),
           ]);
         } catch (error) {
           if (!failed && !transfer.cancelled && !/timed out/i.test(error?.message || "")) {
             remoteCloseError = error;
           }
+        } finally {
+          if (closeTimeout) clearTimeout(closeTimeout);
         }
       }
     }
@@ -2723,6 +2590,7 @@ async function startTransferNow(event, payload, onProgress) {
     paused: false,
     lifecycleEpoch: Math.max(0, Number(payload.lifecycleEpoch) || 0),
     lifecycleState: "transferring",
+    phase: "transferring",
     pauseSupported: false,
     pauseUnavailableReason: "This transfer cannot be paused safely",
     resumable: payload.resumable === true,
@@ -2731,6 +2599,7 @@ async function startTransferNow(event, payload, onProgress) {
     downloadCheckpointBytes: Math.max(0, Number(payload.downloadCheckpointBytes) || 0),
     uploadCheckpointBytes: Math.max(0, Number(payload.uploadCheckpointBytes) || 0),
     sourceFingerprint: payload.sourceFingerprint,
+    sourceFingerprintPromise: null,
     sourceType,
     targetType,
     sourcePath,
@@ -2846,6 +2715,7 @@ async function startTransferNow(event, payload, onProgress) {
         sourceFingerprint: transfer.sourceFingerprint,
         lifecycleEpoch: transfer.lifecycleEpoch,
         lifecycleState: transfer.lifecycleState,
+        phase: transfer.phase,
         resumable: transfer.resumable && transfer.pauseSupported,
         // Only surface a reason when pause is actually unavailable; never keep
         // the startup default once pauseSupported is true.
@@ -2868,6 +2738,7 @@ async function startTransferNow(event, payload, onProgress) {
         sourceFingerprint: transfer.sourceFingerprint,
         lifecycleEpoch: transfer.lifecycleEpoch,
         lifecycleState: transfer.lifecycleState,
+        phase: transfer.phase,
         sourceHostId: transfer.sourceHostId || payload?.sourceHostId,
         targetHostId: transfer.targetHostId || payload?.targetHostId,
       });
@@ -2933,6 +2804,143 @@ async function startTransferNow(event, payload, onProgress) {
     lastObservedTotal,
     { force: true, checkpointBytes: transfer.checkpointBytes },
   );
+
+  const computeVisibleSourceFingerprint = async () => {
+    const previousPhase = transfer.phase;
+    const startedAt = Date.now();
+    let lastReportedAt = startedAt;
+    let lastReportedBytes = 0;
+    transfer.phase = "verifying";
+    transfer.publishCurrentProgress?.();
+    try {
+      return await runTransferAbortableOperation(transfer, (signal) => computeSourceFingerprint(
+        {
+          sourceType,
+          sourcePath,
+          sourceSftpId,
+          sourceEncoding,
+        },
+        {
+          signal,
+          onProgress(bytes) {
+            const now = Date.now();
+            const elapsed = now - lastReportedAt;
+            const delta = bytes - lastReportedBytes;
+            if (elapsed < PROGRESS_THROTTLE_MS && delta < PROGRESS_THROTTLE_BYTES) return;
+            const speed = elapsed > 0 && delta > 0 ? Math.round((delta * 1000) / elapsed) : 0;
+            lastReportedAt = now;
+            lastReportedBytes = bytes;
+            emitProgress(now, lastObservedTransferred, lastObservedTotal, speed, true);
+            onProgress?.(lastObservedTransferred, lastObservedTotal, speed);
+          },
+        },
+      ));
+    } finally {
+      transfer.phase = previousPhase || "transferring";
+      if (!transfer.cancelled && !transfer.signal?.aborted) transfer.publishCurrentProgress?.();
+    }
+  };
+
+  transfer.verifySourceFingerprint = async (storedFingerprint) => {
+    const currentFingerprint = await computeVisibleSourceFingerprint();
+    if (!sourceFingerprintsMatch(storedFingerprint, currentFingerprint)) {
+      throw new Error("Resume safety check failed: the source file has changed");
+    }
+  };
+
+  transfer.captureSourceFingerprint = () => {
+    if (transfer.sourceFingerprint) return Promise.resolve(transfer.sourceFingerprint);
+    if (transfer.sourceFingerprintPromise) return transfer.sourceFingerprintPromise;
+    const captureId = transferId;
+    const fingerprintPromise = computeVisibleSourceFingerprint().then((fingerprint) => {
+      const live = activeTransfers.get(captureId);
+      if (!fingerprint || !live || live !== transfer || live.cancelled) return fingerprint;
+      live.sourceFingerprint = fingerprint;
+      try { live.publishCurrentProgress?.(); } catch { /* best-effort */ }
+      if (live.paused) {
+        broadcastGlobalTransferEvent({
+          type: "paused",
+          transferId: captureId,
+          checkpointBytes: live.checkpointBytes || 0,
+          resumeStage: live.resumeStage,
+          downloadCheckpointBytes: live.downloadCheckpointBytes || 0,
+          uploadCheckpointBytes: live.uploadCheckpointBytes || 0,
+          sourceFingerprint: fingerprint,
+          lifecycleEpoch: live.lifecycleEpoch,
+          lifecycleState: "paused",
+        });
+      }
+      return fingerprint;
+    });
+    const trackedPromise = fingerprintPromise.catch((error) => {
+      if (transfer.sourceFingerprintPromise === trackedPromise) {
+        transfer.sourceFingerprintPromise = null;
+      }
+      throw error;
+    });
+    transfer.sourceFingerprintPromise = trackedPromise;
+    return transfer.sourceFingerprintPromise;
+  };
+
+  const verifyResumeContent = async (bytes, createSourceHash, createStagedHash) => {
+    if (!bytes) return;
+    const previousPhase = transfer.phase;
+    const verificationStartedAt = Date.now();
+    let sourceBytes = 0;
+    let stagedBytes = 0;
+    let lastReportedAt = verificationStartedAt;
+    let lastReportedBytes = 0;
+
+    const publishVerificationProgress = (force = false) => {
+      if (transfer.cancelled || transfer.signal?.aborted) return;
+      const now = Date.now();
+      const verifiedBytes = sourceBytes + stagedBytes;
+      const elapsedSinceReport = now - lastReportedAt;
+      const bytesSinceReport = verifiedBytes - lastReportedBytes;
+      if (
+        !force
+        && elapsedSinceReport < PROGRESS_THROTTLE_MS
+        && bytesSinceReport < PROGRESS_THROTTLE_BYTES
+      ) {
+        return;
+      }
+      const speed = elapsedSinceReport > 0 && bytesSinceReport > 0
+        ? Math.round((bytesSinceReport * 1000) / elapsedSinceReport)
+        : 0;
+      lastReportedAt = now;
+      lastReportedBytes = verifiedBytes;
+      emitProgress(now, lastObservedTransferred, lastObservedTotal, speed, true);
+      onProgress?.(lastObservedTransferred, lastObservedTotal, speed);
+    };
+
+    transfer.phase = "verifying";
+    publishVerificationProgress(true);
+    try {
+      await runTransferAbortableOperation(transfer, (signal) => assertMatchingResumeContent(
+        createSourceHash({
+          signal,
+          onProgress(value) {
+            sourceBytes = value;
+            publishVerificationProgress();
+          },
+        }),
+        createStagedHash({
+          signal,
+          onProgress(value) {
+            stagedBytes = value;
+            publishVerificationProgress();
+          },
+        }),
+      ));
+      publishVerificationProgress(true);
+    } finally {
+      transfer.phase = previousPhase || "transferring";
+      if (!transfer.cancelled && !transfer.signal?.aborted) {
+        emitProgress(Date.now(), lastObservedTransferred, lastObservedTotal, 0, true);
+        onProgress?.(lastObservedTransferred, lastObservedTotal, 0);
+      }
+    }
+  };
 
   const sendComplete = () => {
     sender.send("netcatty:transfer:complete", { transferId });
@@ -3000,23 +3008,28 @@ async function startTransferNow(event, payload, onProgress) {
       }
     }
 
+    const hasSavedCheckpoint = transfer.checkpointBytes > 0
+      || transfer.downloadCheckpointBytes > 0
+      || transfer.uploadCheckpointBytes > 0;
+    if (
+      transfer.resumable
+      && hasSavedCheckpoint
+      && (
+        !transfer.sourceFingerprint
+        || String(transfer.sourceFingerprint).startsWith("meta:")
+      )
+    ) {
+      // Older builds persisted only size/mtime/sparse samples. They cannot prove
+      // that the untransferred suffix still belongs to the same source. Restart
+      // safely from zero; new pauses persist a full SHA-256 identity.
+      transfer.checkpointBytes = 0;
+      transfer.downloadCheckpointBytes = 0;
+      transfer.uploadCheckpointBytes = 0;
+      transfer.sourceFingerprint = undefined;
+    }
+
     if (transfer.resumable && transfer.sourceFingerprint) {
-      const currentSourceFingerprint = await runCancelablePreflight(() => computeMatchingSourceFingerprint(
-        transfer.sourceFingerprint,
-        {
-          sourceType,
-          sourcePath,
-          sourceSftpId,
-          sourceEncoding,
-        },
-      ));
-      if (
-        transfer.sourceFingerprint
-        && currentSourceFingerprint
-        && !sourceFingerprintsMatch(transfer.sourceFingerprint, currentSourceFingerprint)
-      ) {
-        throw new Error("Resume safety check failed: the source file has changed");
-      }
+      await transfer.verifySourceFingerprint(transfer.sourceFingerprint);
     }
 
     sendProgress(transfer.checkpointBytes, fileSize, { force: true });
@@ -3070,22 +3083,22 @@ async function startTransferNow(event, payload, onProgress) {
             : 0;
           sendProgress(transfer.checkpointBytes, fileSize, { force: true });
           if (usesStage && transfer.checkpointBytes > 0) {
-            await runCancelablePreflight(() => assertMatchingResumeRanges(
-              resumeContentVerifyRanges(
-                transfer.checkpointBytes,
-                transfer.sourceFingerprint,
-              ),
-              (start, end) => hashLocalRange(sourcePath, start, end, transfer.signal),
-              (start, end) => hashRemoteRange(
+            const verifyBytes = resumeContentVerifyBytes(
+              transfer.checkpointBytes,
+              transfer.sourceFingerprint,
+            );
+            await verifyResumeContent(
+              verifyBytes,
+              (options) => hashLocalPrefix(sourcePath, verifyBytes, options),
+              (options) => hashRemotePrefix(
                 client,
                 targetSftpId,
                 uploadTargetPath,
                 targetEncoding,
-                start,
-                end,
-                transfer.signal,
+                verifyBytes,
+                options,
               ),
-            ));
+            );
           }
           await uploadFile(
             sourcePath,
@@ -3122,24 +3135,24 @@ async function startTransferNow(event, payload, onProgress) {
         downloadTargetPath, transfer.checkpointBytes,
       );
       sendProgress(transfer.checkpointBytes, fileSize, { force: true });
-      await runCancelablePreflight(async () => {
-        await assertMatchingResumeRanges(
-          resumeContentVerifyRanges(
-            transfer.checkpointBytes,
-            transfer.sourceFingerprint,
-          ),
-          (start, end) => hashRemoteRange(
+      {
+        const verifyBytes = resumeContentVerifyBytes(
+          transfer.checkpointBytes,
+          transfer.sourceFingerprint,
+        );
+        await verifyResumeContent(
+          verifyBytes,
+          (options) => hashRemotePrefix(
             client,
             sourceSftpId,
             sourcePath,
             sourceEncoding,
-            start,
-            end,
-            transfer.signal,
+            verifyBytes,
+            options,
           ),
-          (start, end) => hashLocalRange(downloadTargetPath, start, end, transfer.signal),
+          (options) => hashLocalPrefix(downloadTargetPath, verifyBytes, options),
         );
-      });
+      }
       const downloadResult = await downloadFile(
         encodedSourcePath,
         downloadTargetPath,
@@ -3213,11 +3226,14 @@ async function startTransferNow(event, payload, onProgress) {
       );
       transfer.checkpointBytes = checkpoint;
       sendProgress(checkpoint, fileSize, { force: true });
-      await assertMatchingResumeRanges(
-        resumeContentVerifyRanges(checkpoint, transfer.sourceFingerprint),
-        (start, end) => hashLocalRange(sourcePath, start, end, transfer.signal),
-        (start, end) => hashLocalRange(localTargetPath, start, end, transfer.signal),
-      );
+      {
+        const verifyBytes = resumeContentVerifyBytes(checkpoint, transfer.sourceFingerprint);
+        await verifyResumeContent(
+          verifyBytes,
+          (options) => hashLocalPrefix(sourcePath, verifyBytes, options),
+          (options) => hashLocalPrefix(localTargetPath, verifyBytes, options),
+        );
+      }
 
       await new Promise((resolve, reject) => {
         transfer.pauseSupported = Boolean(transfer.resumable);
@@ -3357,24 +3373,24 @@ async function startTransferNow(event, payload, onProgress) {
           const encodedSourcePath = isScpModeClient(sourceClient)
             ? sourcePath
             : encodePathForSession(sourceSftpId, sourcePath, sourceEncoding);
-          await runCancelablePreflight(async () => {
-            await assertMatchingResumeRanges(
-              resumeContentVerifyRanges(
-                transfer.downloadCheckpointBytes,
-                transfer.sourceFingerprint,
-              ),
-              (start, end) => hashRemoteRange(
+          {
+            const verifyBytes = resumeContentVerifyBytes(
+              transfer.downloadCheckpointBytes,
+              transfer.sourceFingerprint,
+            );
+            await verifyResumeContent(
+              verifyBytes,
+              (options) => hashRemotePrefix(
                 sourceClient,
                 sourceSftpId,
                 sourcePath,
                 sourceEncoding,
-                start,
-                end,
-                transfer.signal,
+                verifyBytes,
+                options,
               ),
-              (start, end) => hashLocalRange(tempPath, start, end, transfer.signal),
+              (options) => hashLocalPrefix(tempPath, verifyBytes, options),
             );
-          });
+          }
           const downloadProgress = (transferred, reportedTotal, options = {}) => {
             if (
               isScpModeClient(sourceClient)
@@ -3494,22 +3510,22 @@ async function startTransferNow(event, payload, onProgress) {
             sendProgress(lastObservedTransferred, fileSize, { force: true });
             transfer.checkpointBytes = transfer.uploadCheckpointBytes;
             if (usesStage && transfer.uploadCheckpointBytes > 0) {
-              await runCancelablePreflight(() => assertMatchingResumeRanges(
-                resumeContentVerifyRanges(
-                  transfer.uploadCheckpointBytes,
-                  transfer.sourceFingerprint,
-                ),
-                (start, end) => hashLocalRange(tempPath, start, end, transfer.signal),
-                (start, end) => hashRemoteRange(
+              const verifyBytes = resumeContentVerifyBytes(
+                transfer.uploadCheckpointBytes,
+                transfer.sourceFingerprint,
+              );
+              await verifyResumeContent(
+                verifyBytes,
+                (options) => hashLocalPrefix(tempPath, verifyBytes, options),
+                (options) => hashRemotePrefix(
                   targetClient,
                   targetSftpId,
                   uploadTargetPath,
                   targetEncoding,
-                  start,
-                  end,
-                  transfer.signal,
+                  verifyBytes,
+                  options,
                 ),
-              ));
+              );
             }
             await uploadFile(
               tempPath,
@@ -3872,7 +3888,6 @@ async function pauseTransfer(_event, payload) {
     if (transfer.writeStream?.pending) {
       await new Promise((resolve) => {
         const timer = setTimeout(resolve, PAUSE_STREAM_DRAIN_MS);
-        timer.unref?.();
         transfer.writeStream.once?.('open', () => {
           clearTimeout(timer);
           resolve();
@@ -3882,7 +3897,6 @@ async function pauseTransfer(_event, payload) {
     if (transfer.writeStream?.writableNeedDrain) {
       await new Promise((resolve) => {
         const timer = setTimeout(resolve, PAUSE_STREAM_DRAIN_MS);
-        timer.unref?.();
         transfer.writeStream.once?.('drain', () => {
           clearTimeout(timer);
           resolve();
@@ -4002,29 +4016,7 @@ async function pauseTransfer(_event, payload) {
     lifecycleState: transfer.lifecycleState,
   });
   if (transfer.resumable && !transfer.sourceFingerprint) {
-    const captureId = payload.transferId;
-    void computeSourceIdentityLite({
-      sourceType: transfer.sourceType,
-      sourcePath: transfer.sourcePath,
-      sourceSftpId: transfer.sourceSftpId,
-      sourceEncoding: transfer.sourceEncoding,
-    }).then((fingerprint) => {
-      const live = activeTransfers.get(captureId);
-      if (!live || live !== transfer || !live.paused || live.cancelled) return;
-      live.sourceFingerprint = fingerprint;
-      try { live.publishCurrentProgress?.(); } catch { /* best-effort */ }
-      broadcastGlobalTransferEvent({
-        type: "paused",
-        transferId: captureId,
-        checkpointBytes: live.checkpointBytes || 0,
-        resumeStage: live.resumeStage,
-        downloadCheckpointBytes: live.downloadCheckpointBytes || 0,
-        uploadCheckpointBytes: live.uploadCheckpointBytes || 0,
-        sourceFingerprint: fingerprint,
-        lifecycleEpoch: live.lifecycleEpoch,
-        lifecycleState: "paused",
-      });
-    }).catch(() => {
+    void transfer.captureSourceFingerprint?.().catch(() => {
       // Resume can recompute identity if pause-time fingerprint is missing.
     });
   }
@@ -4068,6 +4060,25 @@ async function resumeTransfer(_event, payload) {
       lifecycleEpoch: transfer.lifecycleEpoch,
     });
     return { success: true };
+  }
+  if (transfer.resumable) {
+    try {
+      if (!transfer.sourceFingerprint) {
+        await transfer.captureSourceFingerprint?.();
+      }
+      if (!transfer.sourceFingerprint) {
+        return { success: false, reason: "Could not verify the source file for resume" };
+      }
+      await transfer.verifySourceFingerprint?.(transfer.sourceFingerprint);
+    } catch (error) {
+      if (transfer.cancelled || activeTransfers.get(payload?.transferId) !== transfer) {
+        return { success: false, reason: "Transfer is no longer active" };
+      }
+      return {
+        success: false,
+        reason: error?.message || "Could not verify the source file for resume",
+      };
+    }
   }
   // Soft-drained concurrent pause may leave a sparse tail past the contiguous
   // checkpoint. Stay paused until leftover ranges settle, then truncate before
@@ -4413,5 +4424,4 @@ module.exports = {
   listTransferSftpIds,
   _promoteLocalTransferForTests: promoteLocalTransfer,
   _stableLocalFileIdentityForTests: stableLocalFileIdentity,
-  _resumeContentVerifyRangesForTests: resumeContentVerifyRanges,
 };

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -363,12 +363,9 @@ const RESUME_CONTENT_VERIFY_MAX_BYTES = 256 * 1024;
 function resumeContentVerifyBytes(checkpoint, fingerprint) {
   const claimed = Math.max(0, Number(checkpoint) || 0);
   if (!claimed) return 0;
-  // Always cap the leading-window hash. Hashing the full multi-MB checkpoint
-  // over SFTP after force-quit continue freezes the transfer-center bar at the
-  // resume offset (status "transferring", 0 B/s) for a long time with no
-  // progress events. meta: fingerprints already encode size/mtime/samples;
-  // a 256 KiB window is enough to catch mixed-stage corruption without stalling.
-  void fingerprint;
+  if (typeof fingerprint === "string" && fingerprint.startsWith("meta:")) {
+    return claimed;
+  }
   return Math.min(claimed, RESUME_CONTENT_VERIFY_MAX_BYTES);
 }
 

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -169,19 +169,46 @@ async function resolveRemoteResumeCheckpoint(client, sftpId, filePath, encoding,
   }
 }
 
-async function hashReadable(readable) {
+async function hashReadable(readable, signal = null) {
+  if (signal?.aborted) {
+    try { readable.destroy?.(); } catch { /* ignore */ }
+    throw new Error("Transfer cancelled");
+  }
   const hash = crypto.createHash("sha256");
-  for await (const chunk of readable) hash.update(chunk);
-  return hash.digest("hex");
+  const onAbort = () => {
+    try { readable.destroy?.(new Error("Transfer cancelled")); } catch { /* ignore */ }
+  };
+  if (signal) {
+    signal.addEventListener("abort", onAbort, { once: true });
+  }
+  try {
+    for await (const chunk of readable) {
+      if (signal?.aborted) throw new Error("Transfer cancelled");
+      hash.update(chunk);
+    }
+    if (signal?.aborted) throw new Error("Transfer cancelled");
+    return hash.digest("hex");
+  } finally {
+    if (signal) {
+      try { signal.removeEventListener("abort", onAbort); } catch { /* ignore */ }
+    }
+  }
 }
 
-function hashLocalPrefix(filePath, bytes) {
-  if (!bytes) return Promise.resolve(null);
-  return hashReadable(fs.createReadStream(filePath, { start: 0, end: bytes - 1 }));
+function hashLocalRange(filePath, start, endExclusive, signal = null) {
+  const length = Math.max(0, (Number(endExclusive) || 0) - (Number(start) || 0));
+  if (!length) return Promise.resolve(null);
+  return hashReadable(
+    fs.createReadStream(filePath, {
+      start: Math.max(0, Number(start) || 0),
+      end: Math.max(0, Number(endExclusive) || 0) - 1,
+    }),
+    signal,
+  );
 }
 
-function hashLocalFile(filePath) {
-  return hashReadable(fs.createReadStream(filePath));
+function hashLocalFile(filePath, signal = null) {
+  return hashReadable(fs.createReadStream(filePath), signal);
 }
 
 async function hashRemoteFile(client, sftpId, filePath, encoding) {
@@ -319,8 +346,8 @@ async function computeMatchingSourceFingerprint(storedFingerprint, params) {
 
 /**
  * meta: fingerprints gained an optional content-sample suffix. Legacy
- * meta:size:mtime values still match when size+mtime agree; full checkpoint
- * content verify (see resumeContentVerifyBytes) covers same-size rewrites.
+ * meta:size:mtime values still match when size+mtime agree; bounded checkpoint
+ * content verify (see resumeContentVerifyRanges) covers same-size rewrites.
  */
 function sourceFingerprintsMatch(storedFingerprint, currentFingerprint) {
   if (!storedFingerprint || !currentFingerprint) return false;
@@ -341,38 +368,61 @@ function sourceFingerprintsMatch(storedFingerprint, currentFingerprint) {
   return false;
 }
 
-async function hashRemotePrefix(client, sftpId, filePath, encoding, bytes) {
-  if (!bytes) return null;
+async function hashRemoteRange(client, sftpId, filePath, encoding, start, endExclusive, signal = null) {
+  const length = Math.max(0, (Number(endExclusive) || 0) - (Number(start) || 0));
+  if (!length) return null;
   if (isScpModeClient(client)) return null;
   await requireSftpChannel(client);
   const encodedPath = encodePathForSession(sftpId, filePath, encoding);
-  return hashReadable(client.sftp.createReadStream(encodedPath, { start: 0, end: bytes - 1 }));
+  return hashReadable(
+    client.sftp.createReadStream(encodedPath, {
+      start: Math.max(0, Number(start) || 0),
+      end: Math.max(0, Number(endExclusive) || 0) - 1,
+    }),
+    signal,
+  );
 }
 
 /**
- * Cap content re-hash on resume for strong (sha256:) fingerprints. Full-prefix
- * hashing of multi-MB .part files over SFTP can take longer than the remaining
- * transfer and freezes the UI at "transferring" with no byte movement.
+ * Cap content re-hash on resume. Full-prefix hashing of multi-GB .part files
+ * over SFTP can take longer than the remaining transfer and freezes the UI at
+ * "transferring" with no byte movement; cancel must also destroy the hash stream.
  *
- * meta: identities are only size+mtime(+samples). Same-size rewrites past the
- * sample points / 256 KiB leading window still need a full checkpoint compare
- * before appending, or the staged file mixes two source versions.
+ * Strong (sha256:) fingerprints only need a leading window. meta: identities
+ * are size+mtime(+sparse samples), so also hash a trailing window of the
+ * checkpoint to catch same-size rewrites past the leading 256 KiB without
+ * re-reading the entire saved prefix.
  */
 const RESUME_CONTENT_VERIFY_MAX_BYTES = 256 * 1024;
 
-function resumeContentVerifyBytes(checkpoint, fingerprint) {
+function resumeContentVerifyRanges(checkpoint, fingerprint) {
   const claimed = Math.max(0, Number(checkpoint) || 0);
-  if (!claimed) return 0;
-  if (typeof fingerprint === "string" && fingerprint.startsWith("meta:")) {
-    return claimed;
+  if (!claimed) return [];
+  const window = RESUME_CONTENT_VERIFY_MAX_BYTES;
+  const leadingEnd = Math.min(claimed, window);
+  if (!(typeof fingerprint === "string" && fingerprint.startsWith("meta:")) || claimed <= window) {
+    return [{ start: 0, end: leadingEnd }];
   }
-  return Math.min(claimed, RESUME_CONTENT_VERIFY_MAX_BYTES);
+  const trailingStart = Math.max(0, claimed - window);
+  if (trailingStart <= leadingEnd) {
+    // Checkpoint fits in at most two overlapping windows — one contiguous hash.
+    return [{ start: 0, end: claimed }];
+  }
+  return [
+    { start: 0, end: leadingEnd },
+    { start: trailingStart, end: claimed },
+  ];
 }
 
-async function assertMatchingResumeContent(sourceHashPromise, stagedHashPromise) {
-  const [sourceHash, stagedHash] = await Promise.all([sourceHashPromise, stagedHashPromise]);
-  if (sourceHash && stagedHash && sourceHash !== stagedHash) {
-    throw new Error("Resume safety check failed: saved content does not match the source");
+async function assertMatchingResumeRanges(ranges, hashSourceRange, hashStagedRange) {
+  for (const range of ranges) {
+    const [sourceHash, stagedHash] = await Promise.all([
+      hashSourceRange(range.start, range.end),
+      hashStagedRange(range.start, range.end),
+    ]);
+    if (sourceHash && stagedHash && sourceHash !== stagedHash) {
+      throw new Error("Resume safety check failed: saved content does not match the source");
+    }
   }
 }
 
@@ -3020,14 +3070,22 @@ async function startTransferNow(event, payload, onProgress) {
             : 0;
           sendProgress(transfer.checkpointBytes, fileSize, { force: true });
           if (usesStage && transfer.checkpointBytes > 0) {
-            const verifyBytes = resumeContentVerifyBytes(
-              transfer.checkpointBytes,
-              transfer.sourceFingerprint,
-            );
-            await runCancelablePreflight(() => assertMatchingResumeContent(
-                hashLocalPrefix(sourcePath, verifyBytes),
-                hashRemotePrefix(client, targetSftpId, uploadTargetPath, targetEncoding, verifyBytes),
-              ));
+            await runCancelablePreflight(() => assertMatchingResumeRanges(
+              resumeContentVerifyRanges(
+                transfer.checkpointBytes,
+                transfer.sourceFingerprint,
+              ),
+              (start, end) => hashLocalRange(sourcePath, start, end, transfer.signal),
+              (start, end) => hashRemoteRange(
+                client,
+                targetSftpId,
+                uploadTargetPath,
+                targetEncoding,
+                start,
+                end,
+                transfer.signal,
+              ),
+            ));
           }
           await uploadFile(
             sourcePath,
@@ -3065,13 +3123,21 @@ async function startTransferNow(event, payload, onProgress) {
       );
       sendProgress(transfer.checkpointBytes, fileSize, { force: true });
       await runCancelablePreflight(async () => {
-        const verifyBytes = resumeContentVerifyBytes(
-          transfer.checkpointBytes,
-          transfer.sourceFingerprint,
-        );
-        await assertMatchingResumeContent(
-          hashRemotePrefix(client, sourceSftpId, sourcePath, sourceEncoding, verifyBytes),
-          hashLocalPrefix(downloadTargetPath, verifyBytes),
+        await assertMatchingResumeRanges(
+          resumeContentVerifyRanges(
+            transfer.checkpointBytes,
+            transfer.sourceFingerprint,
+          ),
+          (start, end) => hashRemoteRange(
+            client,
+            sourceSftpId,
+            sourcePath,
+            sourceEncoding,
+            start,
+            end,
+            transfer.signal,
+          ),
+          (start, end) => hashLocalRange(downloadTargetPath, start, end, transfer.signal),
         );
       });
       const downloadResult = await downloadFile(
@@ -3147,13 +3213,11 @@ async function startTransferNow(event, payload, onProgress) {
       );
       transfer.checkpointBytes = checkpoint;
       sendProgress(checkpoint, fileSize, { force: true });
-      {
-        const verifyBytes = resumeContentVerifyBytes(checkpoint, transfer.sourceFingerprint);
-        await assertMatchingResumeContent(
-          hashLocalPrefix(sourcePath, verifyBytes),
-          hashLocalPrefix(localTargetPath, verifyBytes),
-        );
-      }
+      await assertMatchingResumeRanges(
+        resumeContentVerifyRanges(checkpoint, transfer.sourceFingerprint),
+        (start, end) => hashLocalRange(sourcePath, start, end, transfer.signal),
+        (start, end) => hashLocalRange(localTargetPath, start, end, transfer.signal),
+      );
 
       await new Promise((resolve, reject) => {
         transfer.pauseSupported = Boolean(transfer.resumable);
@@ -3294,13 +3358,21 @@ async function startTransferNow(event, payload, onProgress) {
             ? sourcePath
             : encodePathForSession(sourceSftpId, sourcePath, sourceEncoding);
           await runCancelablePreflight(async () => {
-            const verifyBytes = resumeContentVerifyBytes(
-              transfer.downloadCheckpointBytes,
-              transfer.sourceFingerprint,
-            );
-            await assertMatchingResumeContent(
-              hashRemotePrefix(sourceClient, sourceSftpId, sourcePath, sourceEncoding, verifyBytes),
-              hashLocalPrefix(tempPath, verifyBytes),
+            await assertMatchingResumeRanges(
+              resumeContentVerifyRanges(
+                transfer.downloadCheckpointBytes,
+                transfer.sourceFingerprint,
+              ),
+              (start, end) => hashRemoteRange(
+                sourceClient,
+                sourceSftpId,
+                sourcePath,
+                sourceEncoding,
+                start,
+                end,
+                transfer.signal,
+              ),
+              (start, end) => hashLocalRange(tempPath, start, end, transfer.signal),
             );
           });
           const downloadProgress = (transferred, reportedTotal, options = {}) => {
@@ -3422,20 +3494,22 @@ async function startTransferNow(event, payload, onProgress) {
             sendProgress(lastObservedTransferred, fileSize, { force: true });
             transfer.checkpointBytes = transfer.uploadCheckpointBytes;
             if (usesStage && transfer.uploadCheckpointBytes > 0) {
-              const verifyBytes = resumeContentVerifyBytes(
-                transfer.uploadCheckpointBytes,
-                transfer.sourceFingerprint,
-              );
-              await runCancelablePreflight(() => assertMatchingResumeContent(
-                  hashLocalPrefix(tempPath, verifyBytes),
-                  hashRemotePrefix(
-                    targetClient,
-                    targetSftpId,
-                    uploadTargetPath,
-                    targetEncoding,
-                    verifyBytes,
-                  ),
-                ));
+              await runCancelablePreflight(() => assertMatchingResumeRanges(
+                resumeContentVerifyRanges(
+                  transfer.uploadCheckpointBytes,
+                  transfer.sourceFingerprint,
+                ),
+                (start, end) => hashLocalRange(tempPath, start, end, transfer.signal),
+                (start, end) => hashRemoteRange(
+                  targetClient,
+                  targetSftpId,
+                  uploadTargetPath,
+                  targetEncoding,
+                  start,
+                  end,
+                  transfer.signal,
+                ),
+              ));
             }
             await uploadFile(
               tempPath,
@@ -4339,4 +4413,5 @@ module.exports = {
   listTransferSftpIds,
   _promoteLocalTransferForTests: promoteLocalTransfer,
   _stableLocalFileIdentityForTests: stableLocalFileIdentity,
+  _resumeContentVerifyRangesForTests: resumeContentVerifyRanges,
 };

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -1633,10 +1633,32 @@ test("remote pause identity reads modifyTime from session-backed stat", async (t
   assert.match(restarted.error || "", /source file has changed/i);
 });
 
+test("meta resume content verify stays bounded for large checkpoints", () => {
+  const ranges = transferBridge._resumeContentVerifyRangesForTests(
+    8 * 1024 * 1024 * 1024,
+    "meta:8589934592:1700000000000:deadbeef",
+  );
+  assert.deepEqual(ranges, [
+    { start: 0, end: 256 * 1024 },
+    { start: 8 * 1024 * 1024 * 1024 - 256 * 1024, end: 8 * 1024 * 1024 * 1024 },
+  ]);
+  const verifiedBytes = ranges.reduce((sum, range) => sum + (range.end - range.start), 0);
+  assert.equal(verifiedBytes, 512 * 1024);
+  assert.deepEqual(
+    transferBridge._resumeContentVerifyRangesForTests(400 * 1024, "meta:524288:1"),
+    [{ start: 0, end: 400 * 1024 }],
+  );
+  assert.deepEqual(
+    transferBridge._resumeContentVerifyRangesForTests(400 * 1024, "sha256:abc"),
+    [{ start: 0, end: 256 * 1024 }],
+  );
+});
+
 test("meta resume rejects same-size rewrite past the 256 KiB content window", async (t) => {
-  // Codex P1: size+mtime alone (and a 256 KiB leading content window) miss a
-  // same-size rewrite between identity sample points. meta: resumes must hash
-  // the full checkpoint against the staged .part before appending.
+  // Codex P1: size+mtime alone (and a leading 256 KiB window) miss a same-size
+  // rewrite between identity sample points. meta: resumes also hash a trailing
+  // checkpoint window (bounded; overlapping windows merge) so rewrites near the
+  // saved prefix tip are caught without re-reading multi-GB checkpoints.
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-meta-rewrite-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
@@ -1673,7 +1695,7 @@ test("meta resume rejects same-size rewrite past the 256 KiB content window", as
   transferBridge.init({ sftpClients: new Map([["source", client]]) });
 
   // Legacy meta:size:mtime (no samples) still passes the identity gate when
-  // size+mtime agree; the full-checkpoint content compare must catch the gap.
+  // size+mtime agree; the trailing checkpoint window must catch the gap.
   const result = await transferBridge.startTransfer(
     { sender: createSender() },
     {

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -933,7 +933,7 @@ test("shared SFTP channel reopen preserves the requested timeout", async () => {
   assert.equal(client._reopeningPromise, null);
 });
 
-test("server-to-server resume cancellation settles while source prefix verification is stalled", async (t) => {
+test("server-to-server resume cancellation settles while source identity verification is stalled", async (t) => {
   const transferId = `server-prefix-cancel-${crypto.randomUUID()}`;
   const sourcePath = "/source/payload.bin";
   const tempPath = tempDirBridge.getTransferTempFilePath(transferId, path.basename(sourcePath));
@@ -968,6 +968,7 @@ test("server-to-server resume cancellation settles while source prefix verificat
     resumeStage: "download",
     checkpointBytes: 4,
     downloadCheckpointBytes: 4,
+    sourceFingerprint: `sha256:${"0".repeat(64)}`,
   });
 
   await prefixStarted;
@@ -1424,10 +1425,10 @@ test("resuming while a fast pause is pending settles the pause request", async (
   assert.equal((await running).error, undefined);
 });
 
-test("pause stores a lightweight source identity without full-file hashing", async (t) => {
-  // Pause must not await full-file SHA-256 (or start a post-pause background
-  // full read). A size+mtime+sample meta fingerprint is durable for resume and
-  // cheap (head/mid/tail reads only).
+test("pause acknowledges quickly then publishes a full source identity", async (t) => {
+  // Pause acknowledgement must not wait for full-file SHA-256. The background
+  // identity is nevertheless a complete digest so a later resume cannot mix
+  // bytes from different source versions.
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-late-pause-race-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
@@ -1469,19 +1470,8 @@ test("pause stores a lightweight source identity without full-file hashing", asy
   };
   transferBridge.init({ sftpClients: new Map([["target", client]]) });
 
-  const originalCreateReadStream = fs.createReadStream;
-  let fullHashStreamOpened = false;
-  fs.createReadStream = (filePath, options) => {
-    // Full-file fingerprint uses createReadStream(path) with no options.
-    if (filePath === localPath && !options) {
-      fullHashStreamOpened = true;
-      return new Readable({ read() {} });
-    }
-    return originalCreateReadStream(filePath, options);
-  };
-
   let running;
-  try {
+  {
     const sender = createSender();
     running = transferBridge.startTransfer(
       { sender },
@@ -1515,33 +1505,30 @@ test("pause stores a lightweight source identity without full-file hashing", asy
     const pauseElapsed = Date.now() - pauseStarted;
     assert.equal(paused.success, true);
     assert.ok(pauseElapsed < 1500, `pause blocked too long: ${pauseElapsed}ms`);
-    assert.equal(fullHashStreamOpened, false, "pause must not open a full-file hash stream");
     const fingerprintPublished = await waitUntil(() => sender.sent.some((entry) => (
       entry.channel === "netcatty:transfer:progress"
-      && /^meta:\d+:\d+:[a-f0-9]{64}$/.test(entry.payload.sourceFingerprint || "")
+      && /^sha256:[a-f0-9]{64}$/.test(entry.payload.sourceFingerprint || "")
     )));
-    assert.equal(fingerprintPublished, true, "pause identity must be published after pause acknowledgement");
+    assert.equal(fingerprintPublished, true, "full pause identity must be published after pause acknowledgement");
     const fingerprintEntry = sender.sent.findLast((entry) => (
         entry.channel === "netcatty:transfer:progress"
-        && /^meta:\d+:\d+:[a-f0-9]{64}$/.test(entry.payload.sourceFingerprint || "")
+        && /^sha256:[a-f0-9]{64}$/.test(entry.payload.sourceFingerprint || "")
     ));
-    assert.match(fingerprintEntry?.payload.sourceFingerprint || "", /^meta:\d+:\d+:[a-f0-9]{64}$/);
+    assert.equal(
+      fingerprintEntry?.payload.sourceFingerprint,
+      `sha256:${crypto.createHash("sha256").update(payload).digest("hex")}`,
+    );
 
     assert.deepEqual(
       await transferBridge.resumeTransfer(null, { transferId: "late-pause-race" }),
       { success: true },
     );
-  } finally {
-    fs.createReadStream = originalCreateReadStream;
   }
 
   assert.equal((await running).error, undefined);
 });
 
-test("remote pause identity reads modifyTime from session-backed stat", async (t) => {
-  // Session-backed client.stat() returns modifyTime (ms), not mtime/mtimeMs.
-  // Ignoring it collapses every remote identity to meta:<size>:0 and lets a
-  // same-size rewrite with an unchanged 256 KiB prefix resume unsafely.
+test("remote pause identity rejects a same-size source rewrite", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-modifytime-id-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
@@ -1549,18 +1536,18 @@ test("remote pause identity reads modifyTime from session-backed stat", async (t
 
   const payload = Buffer.from("abcdef");
   const modifyTimeMs = 1_700_000_000_000;
-  let currentModifyTime = modifyTimeMs;
+  let currentPayload = payload;
   const source = new PassThrough();
   let readStreamCalls = 0;
   const client = {
     sftp: createFastSftp({
       createReadStream() {
         readStreamCalls += 1;
-        return readStreamCalls === 1 ? source : Readable.from(payload);
+        return readStreamCalls === 1 ? source : Readable.from(currentPayload);
       },
     }),
     stat() {
-      return Promise.resolve({ size: payload.length, modifyTime: currentModifyTime });
+      return Promise.resolve({ size: currentPayload.length, modifyTime: modifyTimeMs });
     },
     client: { sftp(callback) { callback(new Error("isolated channel unavailable")); } },
   };
@@ -1598,23 +1585,24 @@ test("remote pause identity reads modifyTime from session-backed stat", async (t
 
   const paused = await transferBridge.pauseTransfer(null, { transferId: "download-modifytime-id" });
   assert.equal(paused.success, true);
-  const expectedFingerprint = new RegExp(`^meta:${payload.length}:${modifyTimeMs}:[a-f0-9]{64}$`);
+  const expectedFingerprint = `sha256:${crypto.createHash("sha256").update(payload).digest("hex")}`;
   const fingerprintPublished = await waitUntil(() => sender.sent.some((entry) => (
     entry.channel === "netcatty:transfer:progress"
-    && expectedFingerprint.test(entry.payload.sourceFingerprint || "")
+    && entry.payload.sourceFingerprint === expectedFingerprint
   )));
   assert.equal(fingerprintPublished, true, "remote pause identity must be published after pause acknowledgement");
   const fingerprintEntry = sender.sent.findLast((entry) => (
     entry.channel === "netcatty:transfer:progress"
-    && expectedFingerprint.test(entry.payload.sourceFingerprint || "")
+    && entry.payload.sourceFingerprint === expectedFingerprint
   ));
   const sourceFingerprint = fingerprintEntry?.payload.sourceFingerprint;
-  assert.match(sourceFingerprint || "", expectedFingerprint);
+  assert.equal(sourceFingerprint, expectedFingerprint);
 
   await transferBridge.cancelTransfer(null, { transferId: "download-modifytime-id" });
   assert.match((await running).error || "", /cancel/i);
 
-  currentModifyTime = modifyTimeMs + 1000;
+  currentPayload = Buffer.from(payload);
+  currentPayload[4] = 90;
   const restarted = await transferBridge.startTransfer(
     { sender: createSender() },
     {
@@ -1633,32 +1621,7 @@ test("remote pause identity reads modifyTime from session-backed stat", async (t
   assert.match(restarted.error || "", /source file has changed/i);
 });
 
-test("meta resume content verify stays bounded for large checkpoints", () => {
-  const ranges = transferBridge._resumeContentVerifyRangesForTests(
-    8 * 1024 * 1024 * 1024,
-    "meta:8589934592:1700000000000:deadbeef",
-  );
-  assert.deepEqual(ranges, [
-    { start: 0, end: 256 * 1024 },
-    { start: 8 * 1024 * 1024 * 1024 - 256 * 1024, end: 8 * 1024 * 1024 * 1024 },
-  ]);
-  const verifiedBytes = ranges.reduce((sum, range) => sum + (range.end - range.start), 0);
-  assert.equal(verifiedBytes, 512 * 1024);
-  assert.deepEqual(
-    transferBridge._resumeContentVerifyRangesForTests(400 * 1024, "meta:524288:1"),
-    [{ start: 0, end: 400 * 1024 }],
-  );
-  assert.deepEqual(
-    transferBridge._resumeContentVerifyRangesForTests(400 * 1024, "sha256:abc"),
-    [{ start: 0, end: 256 * 1024 }],
-  );
-});
-
-test("meta resume rejects same-size rewrite past the 256 KiB content window", async (t) => {
-  // Codex P1: size+mtime alone (and a leading 256 KiB window) miss a same-size
-  // rewrite between identity sample points. meta: resumes also hash a trailing
-  // checkpoint window (bounded; overlapping windows merge) so rewrites near the
-  // saved prefix tip are caught without re-reading multi-GB checkpoints.
+test("legacy sampled identity restarts safely instead of resuming mixed content", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-meta-rewrite-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
@@ -1694,8 +1657,6 @@ test("meta resume rejects same-size rewrite past the 256 KiB content window", as
   };
   transferBridge.init({ sftpClients: new Map([["source", client]]) });
 
-  // Legacy meta:size:mtime (no samples) still passes the identity gate when
-  // size+mtime agree; the trailing checkpoint window must catch the gap.
   const result = await transferBridge.startTransfer(
     { sender: createSender() },
     {
@@ -1711,7 +1672,227 @@ test("meta resume rejects same-size rewrite past the 256 KiB content window", as
       sourceFingerprint: `meta:${fileSize}:${modifyTimeMs}`,
     },
   );
-  assert.match(result.error || "", /content does not match|Resume safety/i);
+  assert.equal(result.error, undefined);
+  assert.deepEqual(await fs.promises.readFile(targetPath), rewritten);
+});
+
+test("resume rejects a rewrite beyond the first 256 KiB of the saved prefix", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-full-prefix-"));
+  t.after(async () => { await fs.promises.rm(tempDir, { recursive: true, force: true }); });
+  const transferId = `full-prefix-${crypto.randomUUID()}`;
+  const sourcePath = path.join(tempDir, "source.bin");
+  const targetPath = path.join(tempDir, "target.bin");
+  const stagedPath = tempDirBridge.getTransferTempFilePath(transferId, "target.bin");
+  const fileSize = 768 * 1024;
+  const checkpoint = 400 * 1024;
+  const original = Buffer.alloc(fileSize, 17);
+  const current = Buffer.from(original);
+  current.fill(99, 300 * 1024, 332 * 1024);
+  await fs.promises.writeFile(sourcePath, current);
+  await fs.promises.writeFile(stagedPath, original.subarray(0, checkpoint));
+  t.after(async () => { await fs.promises.unlink(stagedPath).catch(() => {}); });
+
+  transferBridge.init({ sftpClients: new Map() });
+  const result = await transferBridge.startTransfer({ sender: createSender() }, {
+    transferId,
+    sourcePath,
+    targetPath,
+    sourceType: "local",
+    targetType: "local",
+    totalBytes: fileSize,
+    resumable: true,
+    checkpointBytes: checkpoint,
+    sourceFingerprint: `sha256:${crypto.createHash("sha256").update(current).digest("hex")}`,
+  });
+
+  assert.match(result.error || "", /saved content does not match/i);
+  assert.equal(fs.existsSync(targetPath), false);
+});
+
+test("local resume verification reports progress and destroys both readers on cancellation", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-verify-cancel-"));
+  t.after(async () => { await fs.promises.rm(tempDir, { recursive: true, force: true }); });
+  const transferId = `verify-cancel-${crypto.randomUUID()}`;
+  const sourcePath = path.join(tempDir, "source.bin");
+  const targetPath = path.join(tempDir, "target.bin");
+  const stagedPath = tempDirBridge.getTransferTempFilePath(transferId, "target.bin");
+  const checkpoint = 512 * 1024;
+  const verifyBytes = checkpoint;
+  const payload = Buffer.alloc(checkpoint + 1, 31);
+  await fs.promises.writeFile(sourcePath, payload);
+  await fs.promises.writeFile(stagedPath, payload.subarray(0, checkpoint));
+  t.after(async () => { await fs.promises.unlink(stagedPath).catch(() => {}); });
+
+  const sourceFingerprint = `sha256:${crypto.createHash("sha256").update(payload).digest("hex")}`;
+  const originalCreateReadStream = fs.createReadStream;
+  const verificationStreams = [];
+  fs.createReadStream = (filePath, options = {}) => {
+    if (
+      (filePath === sourcePath || filePath === stagedPath)
+      && options.start === 0
+      && options.end === verifyBytes - 1
+    ) {
+      const stream = new PassThrough();
+      verificationStreams.push(stream);
+      return stream;
+    }
+    return originalCreateReadStream(filePath, options);
+  };
+  t.after(() => { fs.createReadStream = originalCreateReadStream; });
+
+  transferBridge.init({ sftpClients: new Map() });
+  const sender = createSender();
+  const running = transferBridge.startTransfer({ sender }, {
+    transferId,
+    sourcePath,
+    targetPath,
+    sourceType: "local",
+    targetType: "local",
+    totalBytes: payload.length,
+    resumable: true,
+    checkpointBytes: checkpoint,
+    sourceFingerprint,
+  });
+  t.after(async () => {
+    await transferBridge.cancelTransfer(null, { transferId });
+    await running.catch(() => {});
+    transferBridge.clearPendingCancel(transferId);
+  });
+
+  assert.equal(await waitUntil(() => verificationStreams.length === 2), true);
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  for (const stream of verificationStreams) stream.write(Buffer.alloc(256 * 1024, 31));
+  assert.equal(await waitUntil(() => sender.sent.some((entry) => (
+    entry.channel === "netcatty:transfer:progress"
+    && entry.payload.phase === "verifying"
+    && entry.payload.speed > 0
+  ))), true, "resume verification progress must be visible");
+  const verifyingEvent = sender.sent.findLast((entry) => entry.payload?.phase === "verifying");
+  assert.equal(verifyingEvent?.payload.transferred, checkpoint);
+  assert.equal(verifyingEvent?.payload.checkpointBytes, checkpoint);
+
+  await transferBridge.cancelTransfer(null, { transferId });
+  const result = await running;
+  assert.match(result.error || "", /cancel/i);
+  assert.equal(verificationStreams.every((stream) => stream.destroyed), true);
+});
+
+test("remote resume verification destroys the SFTP reader on cancellation", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-remote-verify-cancel-"));
+  t.after(async () => { await fs.promises.rm(tempDir, { recursive: true, force: true }); });
+  const transferId = `remote-verify-cancel-${crypto.randomUUID()}`;
+  const targetPath = path.join(tempDir, "target.bin");
+  const stagedPath = tempDirBridge.getTransferTempFilePath(transferId, "target.bin");
+  const checkpoint = 512 * 1024;
+  const verifyBytes = checkpoint;
+  const payload = Buffer.alloc(checkpoint + 1, 47);
+  await fs.promises.writeFile(stagedPath, payload.subarray(0, checkpoint));
+  t.after(async () => { await fs.promises.unlink(stagedPath).catch(() => {}); });
+
+  const sourceFingerprint = `sha256:${crypto.createHash("sha256").update(payload).digest("hex")}`;
+  let verificationStream;
+  const sftp = createFastSftp({
+    createReadStream(_remotePath, options = {}) {
+      const start = Number(options.start) || 0;
+      const end = Number.isFinite(options.end) ? options.end : payload.length - 1;
+      if (start === 0 && end === verifyBytes - 1) {
+        verificationStream = new PassThrough();
+        return verificationStream;
+      }
+      return Readable.from(payload.subarray(start, end + 1));
+    },
+  });
+  const client = {
+    sftp,
+    stat: async () => ({ size: payload.length }),
+  };
+  transferBridge.init({ sftpClients: new Map([["source", client]]) });
+
+  const sender = createSender();
+  const running = transferBridge.startTransfer({ sender }, {
+    transferId,
+    sourcePath: "/tmp/source.bin",
+    targetPath,
+    sourceType: "sftp",
+    targetType: "local",
+    sourceSftpId: "source",
+    totalBytes: payload.length,
+    resumable: true,
+    checkpointBytes: checkpoint,
+    sourceFingerprint,
+  });
+  t.after(async () => {
+    await transferBridge.cancelTransfer(null, { transferId });
+    await running.catch(() => {});
+    transferBridge.clearPendingCancel(transferId);
+  });
+
+  assert.equal(await waitUntil(() => verificationStream !== undefined), true);
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  verificationStream.write(Buffer.alloc(256 * 1024, 47));
+  assert.equal(await waitUntil(() => sender.sent.some((entry) => (
+    entry.channel === "netcatty:transfer:progress"
+    && entry.payload.phase === "verifying"
+    && entry.payload.speed > 0
+  ))), true);
+  await transferBridge.cancelTransfer(null, { transferId });
+  const result = await running;
+  assert.match(result.error || "", /cancel/i);
+  assert.equal(verificationStream.destroyed, true);
+});
+
+test("remote resume verification cancellation does not wait for SFTP channel reopen", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-remote-verify-reopen-"));
+  t.after(async () => { await fs.promises.rm(tempDir, { recursive: true, force: true }); });
+  const transferId = `remote-verify-reopen-${crypto.randomUUID()}`;
+  const targetPath = path.join(tempDir, "target.bin");
+  const stagedPath = tempDirBridge.getTransferTempFilePath(transferId, "target.bin");
+  const checkpoint = 64 * 1024;
+  const totalBytes = checkpoint + 1;
+  await fs.promises.writeFile(stagedPath, Buffer.alloc(checkpoint, 19));
+  t.after(async () => { await fs.promises.unlink(stagedPath).catch(() => {}); });
+
+  let reopenStarted = false;
+  let finishReopen;
+  const client = {
+    sftp: null,
+    stat: async () => ({ size: totalBytes }),
+    client: {
+      sftp(callback) {
+        reopenStarted = true;
+        finishReopen = () => callback(null, createFastSftp({}));
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["source", client]]) });
+
+  const running = transferBridge.startTransfer({ sender: createSender() }, {
+    transferId,
+    sourcePath: "/tmp/source.bin",
+    targetPath,
+    sourceType: "sftp",
+    targetType: "local",
+    sourceSftpId: "source",
+    totalBytes,
+    resumable: true,
+    checkpointBytes: checkpoint,
+    sourceFingerprint: `sha256:${"0".repeat(64)}`,
+  });
+  t.after(async () => {
+    await transferBridge.cancelTransfer(null, { transferId });
+    await running.catch(() => {});
+    transferBridge.clearPendingCancel(transferId);
+  });
+
+  assert.equal(await waitUntil(() => reopenStarted), true);
+  await transferBridge.cancelTransfer(null, { transferId });
+  const result = await Promise.race([
+    running,
+    new Promise((_, reject) => setTimeout(() => reject(new Error("cancel timed out")), 250)),
+  ]);
+  assert.match(result.error || "", /cancel/i);
+  finishReopen?.();
+  assert.equal(await waitUntil(() => client._reopeningPromise === null), true);
 });
 
 test("failed resumable upload opens close their isolated channel", async (t) => {
@@ -5101,7 +5282,7 @@ test("server-to-server concurrent failure does not complete via serial stream", 
   assert.equal(fs.statSync(localStage).size, payload.length);
 });
 
-test("upload resume after hard quit clamps checkpoint to durable remote .part size", async (t) => {
+test("upload recovery without a full source identity restarts from zero", async (t) => {
   // Simulates force-quit mid-upload: UI progress saved a high checkpoint, but
   // only a shorter prefix made it into the remote staged .part file.
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-crash-resume-"));
@@ -5176,8 +5357,9 @@ test("upload resume after hard quit clamps checkpoint to durable remote .part si
   assert.equal(result.error, undefined, result.error);
   assert.deepEqual(remote, payload);
   assert.equal(promoted, true);
-  // Resume must not rewrite the durable prefix from offset 0.
-  assert.ok(minWritePosition >= 4, `expected resume from >=4, got ${minWritePosition}`);
+  // A checkpoint without a full source digest cannot prove the source suffix
+  // stayed unchanged across the crash, so the safe recovery is a full restart.
+  assert.equal(minWritePosition, 0);
 });
 
 test("local resume after hard quit clamps checkpoint to durable staged file size", async (t) => {
@@ -5229,6 +5411,7 @@ test("resume rejects a same-size temporary prefix that does not match the source
     totalBytes: 6,
     resumable: true,
     checkpointBytes: 3,
+    sourceFingerprint: `sha256:${crypto.createHash("sha256").update("abcdef").digest("hex")}`,
   });
 
   assert.match(result.error || "", /saved content does not match/i);

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -25,6 +25,14 @@ function createSender() {
   };
 }
 
+async function waitUntil(predicate, timeoutMs = 1000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate() && Date.now() < deadline) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  return predicate();
+}
+
 function createFastSftp(overrides) {
   const sftp = new EventEmitter();
   sftp.readdir = (_path, callback) => callback(null, []);
@@ -1488,6 +1496,11 @@ test("pause stores a lightweight source identity without full-file hashing", asy
         resumable: true,
       },
     );
+    t.after(async () => {
+      await transferBridge.cancelTransfer(null, { transferId: "late-pause-race" });
+      await running?.catch(() => {});
+      transferBridge.clearPendingCancel("late-pause-race");
+    });
     const writeDeadline = Date.now() + 1000;
     while (pendingWrites.length < UPLOAD_TRANSFER_CONCURRENCY && Date.now() < writeDeadline) {
       await new Promise((resolve) => setImmediate(resolve));
@@ -1503,14 +1516,16 @@ test("pause stores a lightweight source identity without full-file hashing", asy
     assert.equal(paused.success, true);
     assert.ok(pauseElapsed < 1500, `pause blocked too long: ${pauseElapsed}ms`);
     assert.equal(fullHashStreamOpened, false, "pause must not open a full-file hash stream");
-    assert.match(paused.sourceFingerprint || "", /^meta:\d+:\d+:[a-f0-9]{64}$/);
-    assert.ok(
-      sender.sent.some((entry) => (
+    const fingerprintPublished = await waitUntil(() => sender.sent.some((entry) => (
+      entry.channel === "netcatty:transfer:progress"
+      && /^meta:\d+:\d+:[a-f0-9]{64}$/.test(entry.payload.sourceFingerprint || "")
+    )));
+    assert.equal(fingerprintPublished, true, "pause identity must be published after pause acknowledgement");
+    const fingerprintEntry = sender.sent.findLast((entry) => (
         entry.channel === "netcatty:transfer:progress"
-        && entry.payload.sourceFingerprint === paused.sourceFingerprint
-      )),
-      "pause identity must be published for transfer-center persistence",
-    );
+        && /^meta:\d+:\d+:[a-f0-9]{64}$/.test(entry.payload.sourceFingerprint || "")
+    ));
+    assert.match(fingerprintEntry?.payload.sourceFingerprint || "", /^meta:\d+:\d+:[a-f0-9]{64}$/);
 
     assert.deepEqual(
       await transferBridge.resumeTransfer(null, { transferId: "late-pause-race" }),
@@ -1566,6 +1581,12 @@ test("remote pause identity reads modifyTime from session-backed stat", async (t
       resumable: true,
     },
   );
+  t.after(async () => {
+    source.destroy();
+    await transferBridge.cancelTransfer(null, { transferId: "download-modifytime-id" });
+    await running.catch(() => {});
+    transferBridge.clearPendingCancel("download-modifytime-id");
+  });
 
   const readyDeadline = Date.now() + 1000;
   while (source.listenerCount("data") === 0 && Date.now() < readyDeadline) {
@@ -1577,7 +1598,18 @@ test("remote pause identity reads modifyTime from session-backed stat", async (t
 
   const paused = await transferBridge.pauseTransfer(null, { transferId: "download-modifytime-id" });
   assert.equal(paused.success, true);
-  assert.match(paused.sourceFingerprint || "", new RegExp(`^meta:${payload.length}:${modifyTimeMs}:[a-f0-9]{64}$`));
+  const expectedFingerprint = new RegExp(`^meta:${payload.length}:${modifyTimeMs}:[a-f0-9]{64}$`);
+  const fingerprintPublished = await waitUntil(() => sender.sent.some((entry) => (
+    entry.channel === "netcatty:transfer:progress"
+    && expectedFingerprint.test(entry.payload.sourceFingerprint || "")
+  )));
+  assert.equal(fingerprintPublished, true, "remote pause identity must be published after pause acknowledgement");
+  const fingerprintEntry = sender.sent.findLast((entry) => (
+    entry.channel === "netcatty:transfer:progress"
+    && expectedFingerprint.test(entry.payload.sourceFingerprint || "")
+  ));
+  const sourceFingerprint = fingerprintEntry?.payload.sourceFingerprint;
+  assert.match(sourceFingerprint || "", expectedFingerprint);
 
   await transferBridge.cancelTransfer(null, { transferId: "download-modifytime-id" });
   assert.match((await running).error || "", /cancel/i);
@@ -1595,7 +1627,7 @@ test("remote pause identity reads modifyTime from session-backed stat", async (t
       totalBytes: payload.length,
       resumable: true,
       checkpointBytes: 3,
-      sourceFingerprint: paused.sourceFingerprint,
+      sourceFingerprint,
     },
   );
   assert.match(restarted.error || "", /source file has changed/i);
@@ -5206,13 +5238,21 @@ test("bridge admission applies one global concurrency limit across callers", asy
     globalConcurrency: 1,
   });
   const first = start("admission-first", "/first");
-  while (firstSource.listenerCount("data") === 0) await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(
+    await waitUntil(() => firstSource.listenerCount("data") > 0),
+    true,
+    "first admitted transfer did not start",
+  );
   const second = start("admission-second", "/second");
   await new Promise((resolve) => setImmediate(resolve));
   assert.equal(secondSource.listenerCount("data"), 0);
   firstSource.end(Buffer.from("a"));
   assert.equal((await first).error, undefined);
-  while (secondSource.listenerCount("data") === 0) await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(
+    await waitUntil(() => secondSource.listenerCount("data") > 0),
+    true,
+    "second admitted transfer did not start after the first completed",
+  );
   secondSource.end(Buffer.from("b"));
   assert.equal((await second).error, undefined);
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -675,6 +675,7 @@ ipcRenderer.on("netcatty:transfer:progress", (_event, payload) => {
   if (cb) {
     try {
       cb(payload.transferred, payload.totalBytes, payload.speed, {
+        phase: payload.phase,
         resumeStage: payload.resumeStage,
         checkpointBytes: payload.checkpointBytes,
         downloadCheckpointBytes: payload.downloadCheckpointBytes,

--- a/electron/preloadDataBacklog.test.cjs
+++ b/electron/preloadDataBacklog.test.cjs
@@ -95,6 +95,34 @@ function loadPreloadWithFakeElectron() {
   };
 }
 
+test("stream transfer progress preserves the verification phase", async (t) => {
+  const preload = loadPreloadWithFakeElectron();
+  t.after(preload.cleanup);
+  let observedCapability;
+
+  await preload.api.startStreamTransfer(
+    {
+      transferId: "verify-phase",
+      sourcePath: "/source.bin",
+      targetPath: "/target.bin",
+      sourceType: "local",
+      targetType: "local",
+    },
+    (_transferred, _total, _speed, capability) => {
+      observedCapability = capability;
+    },
+  );
+  preload.handlers.get("netcatty:transfer:progress")?.({}, {
+    transferId: "verify-phase",
+    transferred: 10,
+    totalBytes: 20,
+    speed: 5,
+    phase: "verifying",
+  });
+
+  assert.equal(observedCapability?.phase, "verifying");
+});
+
 test("stores early terminal data until the listener is registered", () => {
   const backlog = createTerminalDataBacklog();
 

--- a/lib/uploadService.ts
+++ b/lib/uploadService.ts
@@ -652,6 +652,7 @@ async function uploadEntries(
         transferred: number;
         total: number;
         speed: number;
+        phase?: UploadProgress['phase'];
         checkpointBytes?: number;
         sourceFingerprint?: string;
         resumable?: boolean;
@@ -660,6 +661,7 @@ async function uploadEntries(
       let rafScheduled = false;
 
       return (transferred: number, total: number, speed: number, capability?: {
+        phase?: UploadProgress['phase'];
         checkpointBytes?: number;
         sourceFingerprint?: string;
         resumable?: boolean;
@@ -681,6 +683,7 @@ async function uploadEntries(
                 transferred: update.transferred,
                 total: update.total,
                 speed: update.speed,
+                phase: update.phase,
                 percent: update.total > 0 ? (update.transferred / update.total) * 100 : 0,
                 // Forward contiguous offset + fingerprint for soft-drain pause safety.
                 checkpointBytes: update.checkpointBytes,

--- a/lib/uploadService.types.ts
+++ b/lib/uploadService.types.ts
@@ -4,6 +4,7 @@ export interface UploadProgress {
   speed: number;
   /** Percentage (0-100) */
   percent: number;
+  phase?: import('../domain/models/sftp').TransferPhase;
   /** Contiguous durable offset from the transfer bridge (may lag transferred). */
   checkpointBytes?: number;
   sourceFingerprint?: string;
@@ -92,6 +93,7 @@ export interface UploadBridge {
       totalBytes?: number;
     },
     onProgress?: (transferred: number, total: number, speed: number, capability?: {
+      phase?: import('../domain/models/sftp').TransferPhase;
       resumable?: boolean;
       pauseUnavailableReason?: string;
     }) => void,

--- a/scripts/github-workflow-ci.test.cjs
+++ b/scripts/github-workflow-ci.test.cjs
@@ -72,6 +72,7 @@ const triggersPackageValidation = (filePath) => {
 test("PR validation runs once per commit and includes a production build", () => {
   assert.match(testWorkflow, /push:\s*\n\s*branches:\s*\n\s*- main/);
   assert.doesNotMatch(testWorkflow, /branches:\s*\n\s*- "\*\*"/);
+  assert.match(testWorkflow, /name: lint-and-test\s*\n\s*runs-on: ubuntu-latest\s*\n\s*timeout-minutes: 20/);
   assert.match(testWorkflow, /- name: Build\s*\n\s*run: npm run build/);
   assert.doesNotMatch(testWorkflow, /\n  mosh-windows-conpty:/);
 });

--- a/types/global/netcatty-bridge-sftp.d.ts
+++ b/types/global/netcatty-bridge-sftp.d.ts
@@ -97,6 +97,7 @@ declare global {
         skipAdmission?: boolean;
       },
       onProgress?: (transferred: number, total: number, speed: number, checkpoint?: {
+        phase?: import('../../domain/models/sftp').TransferPhase;
         resumeStage?: 'direct' | 'download' | 'upload';
         checkpointBytes?: number;
         downloadCheckpointBytes?: number;


### PR DESCRIPTION
## Summary

Stop the shared `lint-and-test` workflow from hanging indefinitely after SFTP pause/resume assertions fail. The change restores resume-content safety, updates pause tests for asynchronous fingerprint persistence, guarantees cleanup after failed assertions, and caps the job at 20 minutes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [x] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- verify the full saved prefix when resuming from metadata-only source identity
- wait for the asynchronously published pause fingerprint in bridge tests
- clean up paused transfers even when an assertion fails
- replace unbounded admission waits with bounded failures
- stop the CI job after 20 minutes instead of allowing multi-hour hangs

## Screenshots / Demo

Not applicable; no UI changes.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Focused Node 22 validation: 102/102 passed.
Transfer bridge file: 83/83 passed and terminated normally.
Production build passed.
The full local suite terminated normally with 7,449 passed, 9 skipped, and one unrelated existing SSH authentication test failure (`failed keyboard-interactive retry still offers encrypted default key fallback`).

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
