### PR TITLE
feat(settings): add searchable font pickers

### DIFF
--- a/components/GroupDetailsPanel.tsx
+++ b/components/GroupDetailsPanel.tsx
@@ -958,6 +958,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
                 }));
               }}
               className="min-w-0 flex-1"
+              ariaLabel={t("vault.groups.details.fontFamily")}
             />
             {form.fontFamilyOverride && (
               <HostDetailsOverrideReset

--- a/components/combobox.test.ts
+++ b/components/combobox.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import {
   applyComboboxWheelScroll,
   comboboxWheelDeltaToPixels,
+  filterComboboxOptions,
   getNextComboboxActiveIndex,
   type ComboboxScrollableTarget,
 } from "./ui/combobox.tsx";
@@ -37,6 +38,20 @@ test("combobox wheel input is ignored when the option list does not overflow", (
 
   assert.equal(applyComboboxWheelScroll(target, 5, 1), false);
   assert.equal(target.scrollTop, 20);
+});
+
+test("combobox search filters font-like options by name and value without case sensitivity", () => {
+  const options = [
+    { value: "jetbrains-mono", label: "JetBrains Mono" },
+    { value: "local-maple-mono", label: "Maple Mono NF", sublabel: "Installed font" },
+    { value: "system-ui", label: "System Default" },
+  ];
+
+  assert.deepEqual(filterComboboxOptions(options, "JETBRAINS", true), [options[0]]);
+  assert.deepEqual(filterComboboxOptions(options, "local-maple", true), [options[1]]);
+  assert.deepEqual(filterComboboxOptions(options, "installed", true), [options[1]]);
+  assert.deepEqual(filterComboboxOptions(options, "missing", true), []);
+  assert.equal(filterComboboxOptions(options, "JetBrains Mono", false), options);
 });
 
 test("combobox option popovers capture wheel events inside the popup list", () => {

--- a/components/combobox.test.ts
+++ b/components/combobox.test.ts
@@ -7,6 +7,7 @@ import {
   comboboxWheelDeltaToPixels,
   filterComboboxOptions,
   focusComboboxInput,
+  selectComboboxInputIfFocused,
   canComboboxOpen,
   getNextComboboxActiveIndex,
   type ComboboxScrollableTarget,
@@ -118,6 +119,23 @@ test("combobox focus helper selects only when the caller opts in", () => {
   focusComboboxInput(input, true);
   assert.equal(focusCount, 2);
   assert.equal(selectCount, 1);
+});
+
+test("combobox reselects a restored value only while its input remains focused", () => {
+  let selectCount = 0;
+  const input = {
+    focus: () => {},
+    select: () => { selectCount += 1; },
+  };
+
+  selectComboboxInputIfFocused(input, null);
+  assert.equal(selectCount, 0);
+
+  selectComboboxInputIfFocused(input, input as unknown as Element);
+  assert.equal(selectCount, 1);
+
+  assert.match(source, /const wasOpen = wasOpenRef\.current[\s\S]*wasOpenRef\.current = open/);
+  assert.match(source, /if \(wasOpen && selectValueOnFocus\) \{[\s\S]*requestAnimationFrame/);
 });
 
 test("disabled comboboxes cannot open or commit a selection", () => {

--- a/components/combobox.test.ts
+++ b/components/combobox.test.ts
@@ -85,3 +85,7 @@ test("combobox exposes active-option semantics for keyboard navigation", () => {
   assert.match(source, /<ComboboxOptionsList>\s*\{/);
   assert.match(source, /role="option"/);
 });
+
+test("combobox trigger shows a focus-within ring for keyboard users", () => {
+  assert.match(source, /focus-within:outline-none focus-within:ring-1 focus-within:ring-ring/);
+});

--- a/components/combobox.test.ts
+++ b/components/combobox.test.ts
@@ -98,3 +98,10 @@ test("combobox selects the current label on focus so typing replaces instead of 
     /if \(nextOpen\) \{\s*\/\/ Focus \+ select so opening via the chevron still replaces on first keystroke\.\s*focusAndSelectInput\(\)/,
   );
 });
+
+test("disabled comboboxes cannot open or commit a selection", () => {
+  assert.match(source, /if \(disabled && nextOpen\) return/);
+  assert.match(source, /<Popover open=\{open && !disabled\}/);
+  assert.match(source, /const handleSelect = \(optValue: string\) => \{\s*if \(disabled\) return/);
+  assert.match(source, /const handleCreate = \(\) => \{\s*if \(disabled\) return/);
+});

--- a/components/combobox.test.ts
+++ b/components/combobox.test.ts
@@ -6,6 +6,8 @@ import {
   applyComboboxWheelScroll,
   comboboxWheelDeltaToPixels,
   filterComboboxOptions,
+  focusComboboxInput,
+  canComboboxOpen,
   getNextComboboxActiveIndex,
   type ComboboxScrollableTarget,
 } from "./ui/combobox.tsx";
@@ -48,6 +50,7 @@ test("combobox search filters font-like options by name and value without case s
   ];
 
   assert.deepEqual(filterComboboxOptions(options, "JETBRAINS", true), [options[0]]);
+  assert.deepEqual(filterComboboxOptions(options, "  JETBRAINS  ", true), [options[0]]);
   assert.deepEqual(filterComboboxOptions(options, "local-maple", true), [options[1]]);
   assert.deepEqual(filterComboboxOptions(options, "installed", true), [options[1]]);
   assert.deepEqual(filterComboboxOptions(options, "missing", true), []);
@@ -84,24 +87,48 @@ test("combobox exposes active-option semantics for keyboard navigation", () => {
   assert.match(source, /<ComboboxOptionsList id=\{listboxId\} listbox>/);
   assert.match(source, /<ComboboxOptionsList>\s*\{/);
   assert.match(source, /role="option"/);
+  assert.match(source, /open && !disabled && hasActiveOption/);
+  assert.match(source, /const handleSelect = \(optValue: string\) => \{[\s\S]*?setOpen\(false\)\s*setActiveIndex\(-1\)/);
+  assert.match(source, /const handleCreate = \(\) => \{[\s\S]*?setOpen\(false\)\s*setActiveIndex\(-1\)/);
 });
 
 test("combobox trigger shows a focus-within ring for keyboard users", () => {
   assert.match(source, /focus-within:outline-none focus-within:ring-1 focus-within:ring-ring/);
 });
 
-test("combobox selects the current label on focus so typing replaces instead of appending", () => {
+test("combobox makes select-on-focus opt-in so editable controls keep normal caret behavior", () => {
+  assert.match(source, /selectValueOnFocus\?: boolean/);
+  assert.match(source, /selectValueOnFocus = false/);
   assert.match(source, /onFocus=\{handleInputFocus\}/);
-  assert.match(source, /inputRef\.current\?\.select\(\)/);
-  assert.match(
-    source,
-    /if \(nextOpen\) \{\s*\/\/ Focus \+ select so opening via the chevron still replaces on first keystroke\.\s*focusAndSelectInput\(\)/,
-  );
+  assert.match(source, /if \(selectValueOnFocus\) focusAndSelectInput\(\)/);
+});
+
+test("combobox focus helper selects only when the caller opts in", () => {
+  let focusCount = 0;
+  let selectCount = 0;
+  const input = {
+    focus: () => { focusCount += 1; },
+    select: () => { selectCount += 1; },
+  };
+
+  focusComboboxInput(input, false);
+  assert.equal(focusCount, 1);
+  assert.equal(selectCount, 0);
+
+  focusComboboxInput(input, true);
+  assert.equal(focusCount, 2);
+  assert.equal(selectCount, 1);
 });
 
 test("disabled comboboxes cannot open or commit a selection", () => {
-  assert.match(source, /if \(disabled && nextOpen\) return/);
+  assert.equal(canComboboxOpen(false, true), true);
+  assert.equal(canComboboxOpen(true, true), false);
+  assert.equal(canComboboxOpen(true, false), true);
   assert.match(source, /<Popover open=\{open && !disabled\}/);
   assert.match(source, /const handleSelect = \(optValue: string\) => \{\s*if \(disabled\) return/);
   assert.match(source, /const handleCreate = \(\) => \{\s*if \(disabled\) return/);
+  assert.match(source, /const handleClear = \(e: React\.MouseEvent\) => \{\s*if \(disabled\) return/);
+  assert.match(source, /clearable && !disabled && inputValue/);
+  assert.match(source, /aria-expanded=\{open && !disabled\}/);
+  assert.match(source, /disabled && "cursor-not-allowed opacity-50 hover:bg-background"/);
 });

--- a/components/combobox.test.ts
+++ b/components/combobox.test.ts
@@ -89,3 +89,12 @@ test("combobox exposes active-option semantics for keyboard navigation", () => {
 test("combobox trigger shows a focus-within ring for keyboard users", () => {
   assert.match(source, /focus-within:outline-none focus-within:ring-1 focus-within:ring-ring/);
 });
+
+test("combobox selects the current label on focus so typing replaces instead of appending", () => {
+  assert.match(source, /onFocus=\{handleInputFocus\}/);
+  assert.match(source, /inputRef\.current\?\.select\(\)/);
+  assert.match(
+    source,
+    /if \(nextOpen\) \{\s*\/\/ Focus \+ select so opening via the chevron still replaces on first keystroke\.\s*focusAndSelectInput\(\)/,
+  );
+});

--- a/components/settings/FontSelect.test.tsx
+++ b/components/settings/FontSelect.test.tsx
@@ -11,6 +11,8 @@ test('font picker uses the searchable combobox and preserves font previews', () 
   assert.match(source, /labelStyle: \{ fontFamily: font\.family \}/);
   assert.match(source, /inputStyle=\{\{ fontFamily: selectedFont\?\.family \}\}/);
   assert.match(source, /clearable=\{false\}/);
+  assert.match(source, /selectValueOnFocus/);
+  assert.match(source, /ariaLabel=\{ariaLabel\}/);
 });
 
 test('terminal font picker reuses the shared searchable font picker', () => {

--- a/components/settings/FontSelect.test.tsx
+++ b/components/settings/FontSelect.test.tsx
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+test('font picker uses the searchable combobox and preserves font previews', () => {
+  const source = readFileSync(new URL('./FontSelect.tsx', import.meta.url), 'utf8');
+
+  assert.match(source, /<Combobox/);
+  assert.match(source, /placeholder=\{t\('common\.searchPlaceholder'\)\}/);
+  assert.match(source, /emptyText=\{t\('common\.noResultsFound'\)\}/);
+  assert.match(source, /labelStyle: \{ fontFamily: font\.family \}/);
+  assert.match(source, /inputStyle=\{\{ fontFamily: selectedFont\?\.family \}\}/);
+  assert.match(source, /clearable=\{false\}/);
+});
+
+test('terminal font picker reuses the shared searchable font picker', () => {
+  const source = readFileSync(new URL('./TerminalFontSelect.tsx', import.meta.url), 'utf8');
+
+  assert.match(source, /<FontSelect/);
+  assert.match(source, /fonts=\{visibleFonts\}/);
+  assert.doesNotMatch(source, /<Combobox/);
+});

--- a/components/settings/FontSelect.tsx
+++ b/components/settings/FontSelect.tsx
@@ -14,6 +14,7 @@ interface FontSelectProps {
   onChange: (value: string) => void;
   className?: string;
   disabled?: boolean;
+  ariaLabel: string;
 }
 
 export const FontSelect: React.FC<FontSelectProps> = ({
@@ -22,6 +23,7 @@ export const FontSelect: React.FC<FontSelectProps> = ({
   onChange,
   className,
   disabled,
+  ariaLabel,
 }) => {
   const { t } = useI18n();
   const selectedFont = fonts.find((font) => font.id === value);
@@ -42,6 +44,8 @@ export const FontSelect: React.FC<FontSelectProps> = ({
       inputStyle={{ fontFamily: selectedFont?.family }}
       disabled={disabled}
       clearable={false}
+      selectValueOnFocus
+      ariaLabel={ariaLabel}
     />
   );
 };

--- a/components/settings/FontSelect.tsx
+++ b/components/settings/FontSelect.tsx
@@ -1,12 +1,16 @@
-import React from 'react';
-import * as SelectPrimitive from '@radix-ui/react-select';
-import { Check, ChevronDown, ChevronUp } from 'lucide-react';
-import { cn } from '../../lib/utils';
-import type { UIFont } from '../../infrastructure/config/uiFonts';
+import React, { useMemo } from 'react';
+import { useI18n } from '../../application/i18n/I18nProvider';
+import { Combobox, type ComboboxOption } from '../ui/combobox';
+
+interface SelectableFont {
+  id: string;
+  name: string;
+  family: string;
+}
 
 interface FontSelectProps {
   value: string;
-  fonts: UIFont[];
+  fonts: SelectableFont[];
   onChange: (value: string) => void;
   className?: string;
   disabled?: boolean;
@@ -19,60 +23,26 @@ export const FontSelect: React.FC<FontSelectProps> = ({
   className,
   disabled,
 }) => {
-  const selectedFont = fonts.find(f => f.id === value);
-  const fitSelectedText = typeof className !== 'string' || !className.includes('w-full');
+  const { t } = useI18n();
+  const selectedFont = fonts.find((font) => font.id === value);
+  const options = useMemo<ComboboxOption[]>(() => fonts.map((font) => ({
+    value: font.id,
+    label: font.name,
+    labelStyle: { fontFamily: font.family },
+  })), [fonts]);
 
   return (
-    <SelectPrimitive.Root value={value} onValueChange={onChange} disabled={disabled}>
-      <SelectPrimitive.Trigger
-        className={cn(
-          'flex h-9 max-w-full items-center justify-between rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:min-w-0 [&>span]:truncate [&>span]:whitespace-nowrap',
-          fitSelectedText && 'min-w-max',
-          className
-        )}
-      >
-        <SelectPrimitive.Value>
-          <span className="block truncate whitespace-nowrap" style={{ fontFamily: selectedFont?.family }}>
-            {selectedFont?.name || value}
-          </span>
-        </SelectPrimitive.Value>
-        <SelectPrimitive.Icon asChild>
-          <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </SelectPrimitive.Icon>
-      </SelectPrimitive.Trigger>
-      <SelectPrimitive.Portal>
-        <SelectPrimitive.Content
-          className="z-[200000] max-h-80 min-w-[12rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1"
-          position="popper"
-          sideOffset={4}
-        >
-          <SelectPrimitive.ScrollUpButton className="flex cursor-default items-center justify-center py-1">
-            <ChevronUp className="h-4 w-4" />
-          </SelectPrimitive.ScrollUpButton>
-          <SelectPrimitive.Viewport className="p-1 h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]">
-            {fonts.map((font) => (
-              <SelectPrimitive.Item
-                key={font.id}
-                value={font.id}
-                className="relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
-              >
-                <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-                  <SelectPrimitive.ItemIndicator>
-                    <Check className="h-4 w-4" />
-                  </SelectPrimitive.ItemIndicator>
-                </span>
-                <SelectPrimitive.ItemText>
-                  <span style={{ fontFamily: font.family }}>{font.name}</span>
-                </SelectPrimitive.ItemText>
-              </SelectPrimitive.Item>
-            ))}
-          </SelectPrimitive.Viewport>
-          <SelectPrimitive.ScrollDownButton className="flex cursor-default items-center justify-center py-1">
-            <ChevronDown className="h-4 w-4" />
-          </SelectPrimitive.ScrollDownButton>
-        </SelectPrimitive.Content>
-      </SelectPrimitive.Portal>
-    </SelectPrimitive.Root>
+    <Combobox
+      options={options}
+      value={value}
+      onValueChange={onChange}
+      placeholder={t('common.searchPlaceholder')}
+      emptyText={t('common.noResultsFound')}
+      triggerClassName={className}
+      inputStyle={{ fontFamily: selectedFont?.family }}
+      disabled={disabled}
+      clearable={false}
+    />
   );
 };
 

--- a/components/settings/TerminalFontSelect.tsx
+++ b/components/settings/TerminalFontSelect.tsx
@@ -1,7 +1,4 @@
 import React, { useMemo, useSyncExternalStore } from 'react';
-import * as SelectPrimitive from '@radix-ui/react-select';
-import { Check, ChevronDown, ChevronUp } from 'lucide-react';
-import { cn } from '../../lib/utils';
 import {
   extractPrimaryFamily,
   getFontAvailabilityVersion,
@@ -10,6 +7,7 @@ import {
   subscribeFontAvailability,
 } from '../../lib/fontAvailability';
 import type { TerminalFont } from '../../infrastructure/config/fonts';
+import { FontSelect } from './FontSelect';
 
 interface TerminalFontSelectProps {
   value: string;
@@ -26,8 +24,6 @@ export const TerminalFontSelect: React.FC<TerminalFontSelectProps> = ({
   className,
   disabled,
 }) => {
-  const selectedFont = fonts.find(f => f.id === value);
-
   // Subscribe to font availability so the filter re-evaluates after the
   // Local Font Access API populates the authoritative install set
   // asynchronously, even if the `fonts` prop ref hasn't changed.
@@ -53,64 +49,20 @@ export const TerminalFontSelect: React.FC<TerminalFontSelectProps> = ({
     // the version (isFontInstalled reads module state).
     void availabilityVersion;
     const filtered = fonts.filter(
-      (f) => f.id === value || isFontInstalled(extractPrimaryFamily(f.family)),
+      (font) => font.id === value || isFontInstalled(extractPrimaryFamily(font.family)),
     );
     if (hasAuthoritativeData()) return filtered;
     return filtered.length >= 1 ? filtered : fonts;
   }, [fonts, value, availabilityVersion]);
-  const fitSelectedText = typeof className !== 'string' || !className.includes('w-full');
 
   return (
-    <SelectPrimitive.Root value={value} onValueChange={onChange} disabled={disabled}>
-      <SelectPrimitive.Trigger
-        className={cn(
-          'flex h-9 max-w-full items-center justify-between rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:min-w-0 [&>span]:truncate [&>span]:whitespace-nowrap',
-          fitSelectedText && 'min-w-max',
-          className
-        )}
-      >
-        <SelectPrimitive.Value>
-          <span className="block truncate whitespace-nowrap" style={{ fontFamily: selectedFont?.family }}>
-            {selectedFont?.name || value}
-          </span>
-        </SelectPrimitive.Value>
-        <SelectPrimitive.Icon asChild>
-          <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </SelectPrimitive.Icon>
-      </SelectPrimitive.Trigger>
-      <SelectPrimitive.Portal>
-        <SelectPrimitive.Content
-          className="z-[200000] max-h-80 min-w-[14rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1"
-          position="popper"
-          sideOffset={4}
-        >
-          <SelectPrimitive.ScrollUpButton className="flex cursor-default items-center justify-center py-1">
-            <ChevronUp className="h-4 w-4" />
-          </SelectPrimitive.ScrollUpButton>
-          <SelectPrimitive.Viewport className="p-1 h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]">
-            {visibleFonts.map((font) => (
-              <SelectPrimitive.Item
-                key={font.id}
-                value={font.id}
-                className="relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
-              >
-                <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-                  <SelectPrimitive.ItemIndicator>
-                    <Check className="h-4 w-4" />
-                  </SelectPrimitive.ItemIndicator>
-                </span>
-                <SelectPrimitive.ItemText>
-                  <span style={{ fontFamily: font.family }}>{font.name}</span>
-                </SelectPrimitive.ItemText>
-              </SelectPrimitive.Item>
-            ))}
-          </SelectPrimitive.Viewport>
-          <SelectPrimitive.ScrollDownButton className="flex cursor-default items-center justify-center py-1">
-            <ChevronDown className="h-4 w-4" />
-          </SelectPrimitive.ScrollDownButton>
-        </SelectPrimitive.Content>
-      </SelectPrimitive.Portal>
-    </SelectPrimitive.Root>
+    <FontSelect
+      fonts={visibleFonts}
+      value={value}
+      onChange={onChange}
+      className={className}
+      disabled={disabled}
+    />
   );
 };
 

--- a/components/settings/TerminalFontSelect.tsx
+++ b/components/settings/TerminalFontSelect.tsx
@@ -15,6 +15,7 @@ interface TerminalFontSelectProps {
   onChange: (value: string) => void;
   className?: string;
   disabled?: boolean;
+  ariaLabel: string;
 }
 
 export const TerminalFontSelect: React.FC<TerminalFontSelectProps> = ({
@@ -23,6 +24,7 @@ export const TerminalFontSelect: React.FC<TerminalFontSelectProps> = ({
   onChange,
   className,
   disabled,
+  ariaLabel,
 }) => {
   // Subscribe to font availability so the filter re-evaluates after the
   // Local Font Access API populates the authoritative install set
@@ -62,6 +64,7 @@ export const TerminalFontSelect: React.FC<TerminalFontSelectProps> = ({
       onChange={onChange}
       className={className}
       disabled={disabled}
+      ariaLabel={ariaLabel}
     />
   );
 };

--- a/components/settings/tabs/SettingsAppearanceTab.tsx
+++ b/components/settings/tabs/SettingsAppearanceTab.tsx
@@ -212,6 +212,7 @@ function SettingsAppearanceTab(props: {
             fonts={availableUIFonts}
             onChange={(v) => setUiFontFamilyId(v)}
             className="w-48"
+            ariaLabel={t("settings.appearance.uiFont")}
           />
         </SettingRow>
       </div>

--- a/components/settings/tabs/SettingsPluginsTab.tsx
+++ b/components/settings/tabs/SettingsPluginsTab.tsx
@@ -180,6 +180,7 @@ export function PluginSettingField({
           disabled={saving}
           onChange={(next) => { setValue(next); void save(next); }}
           className="w-full max-w-xl"
+          ariaLabel={setting.label}
         />
       );
     }

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -514,6 +514,7 @@ function SettingsTerminalTab(props: {
             fonts={availableFonts}
             onChange={(id) => setTerminalFontFamilyId(id)}
             className="w-48"
+            ariaLabel={t("settings.terminal.font.family")}
           />
         </SettingRow>
 

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -27,6 +27,8 @@ interface ComboboxProps {
     onInputValueChange?: (value: string) => void;
     disabled?: boolean;
     clearable?: boolean;
+    selectValueOnFocus?: boolean;
+    ariaLabel?: string;
 }
 
 export const comboboxWheelDeltaToPixels = (deltaY: number, deltaMode: number): number => {
@@ -47,7 +49,7 @@ export const filterComboboxOptions = (
     isSearching: boolean,
 ): ComboboxOption[] => {
     if (!isSearching || !inputValue.trim()) return options
-    const lower = inputValue.toLowerCase()
+    const lower = inputValue.trim().toLowerCase()
     return options.filter(
         (option) =>
             option.label.toLowerCase().includes(lower) ||
@@ -78,6 +80,19 @@ export const getNextComboboxActiveIndex = (
     }
     return (currentIndex + direction + optionCount) % optionCount
 }
+
+export type ComboboxFocusableInput = Pick<HTMLInputElement, "focus" | "select">;
+
+export const focusComboboxInput = (
+    input: ComboboxFocusableInput | null,
+    selectValue: boolean,
+): void => {
+    input?.focus()
+    if (selectValue) input?.select()
+}
+
+export const canComboboxOpen = (disabled: boolean, nextOpen: boolean): boolean =>
+    !disabled || !nextOpen
 
 function ComboboxOptionsList({
     children,
@@ -125,6 +140,8 @@ export function Combobox({
     onInputValueChange,
     disabled = false,
     clearable = true,
+    selectValueOnFocus = false,
+    ariaLabel,
 }: ComboboxProps) {
     const [open, setOpen] = React.useState(false)
     const [inputValue, setInputValue] = React.useState("")
@@ -162,11 +179,20 @@ export function Combobox({
         activeOptionRef.current?.scrollIntoView({ block: 'nearest' })
     }, [activeIndex])
 
+    React.useEffect(() => {
+        if (!disabled || !open) return
+        setOpen(false)
+        setActiveIndex(-1)
+        setIsSearching(false)
+        onInputValueChange?.(value ?? "")
+    }, [disabled, open, onInputValueChange, value])
+
     const handleSelect = (optValue: string) => {
         if (disabled) return
         onValueChange?.(optValue)
         onInputValueChange?.(optValue)
         setOpen(false)
+        setActiveIndex(-1)
         const selected = options.find((opt) => opt.value === optValue)
         setInputValue(selected?.label || optValue)
     }
@@ -179,14 +205,14 @@ export function Combobox({
             onValueChange?.(newValue)
             onInputValueChange?.(newValue)
             setOpen(false)
+            setActiveIndex(-1)
         }
     }
 
     const focusAndSelectInput = () => {
         // Defer so selection wins over click-to-place-caret on focus.
         requestAnimationFrame(() => {
-            inputRef.current?.focus()
-            inputRef.current?.select()
+            focusComboboxInput(inputRef.current, true)
         })
     }
 
@@ -199,16 +225,18 @@ export function Combobox({
     }
 
     const handleInputFocus = () => {
-        focusAndSelectInput()
+        if (selectValueOnFocus) focusAndSelectInput()
     }
 
     const handleOpenChange = (nextOpen: boolean) => {
-        if (disabled && nextOpen) return
+        if (!canComboboxOpen(disabled, nextOpen)) return
         setOpen(nextOpen)
         setActiveIndex(-1)
         if (nextOpen) {
-            // Focus + select so opening via the chevron still replaces on first keystroke.
-            focusAndSelectInput()
+            if (selectValueOnFocus) {
+                // Opening a closed picker from its chevron should also replace on first keystroke.
+                focusAndSelectInput()
+            }
         } else {
             onInputValueChange?.(value ?? "")
         }
@@ -243,6 +271,7 @@ export function Combobox({
     }
 
     const handleClear = (e: React.MouseEvent) => {
+        if (disabled) return
         e.stopPropagation()
         setInputValue("")
         onInputValueChange?.("")
@@ -259,7 +288,7 @@ export function Combobox({
                         "flex h-10 w-full items-center rounded-md border border-input bg-background text-sm min-w-0 overflow-hidden",
                         "hover:bg-secondary/50 transition-colors",
                         "focus-within:outline-none focus-within:ring-1 focus-within:ring-ring",
-                        "disabled:cursor-not-allowed disabled:opacity-50",
+                        disabled && "cursor-not-allowed opacity-50 hover:bg-background",
                         triggerClassName
                     )}
                 >
@@ -272,18 +301,21 @@ export function Combobox({
                         onFocus={handleInputFocus}
                         onKeyDown={handleInputKeyDown}
                         role="combobox"
+                        aria-label={ariaLabel}
                         aria-autocomplete="list"
-                        aria-expanded={open}
+                        aria-expanded={open && !disabled}
                         aria-controls={listboxId}
                         aria-activedescendant={
-                            hasActiveOption ? `${listboxId}-option-${activeIndex}` : undefined
+                            open && !disabled && hasActiveOption
+                                ? `${listboxId}-option-${activeIndex}`
+                                : undefined
                         }
                         placeholder={placeholder}
                         style={inputStyle}
                         className="flex-1 min-w-0 h-full px-3 bg-transparent outline-none placeholder:text-muted-foreground"
                         disabled={disabled}
                     />
-                    {clearable && inputValue && (
+                    {clearable && !disabled && inputValue && (
                         <button
                             type="button"
                             onClick={handleClear}

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -237,6 +237,7 @@ export function Combobox({
                     className={cn(
                         "flex h-10 w-full items-center rounded-md border border-input bg-background text-sm min-w-0 overflow-hidden",
                         "hover:bg-secondary/50 transition-colors",
+                        "focus-within:outline-none focus-within:ring-1 focus-within:ring-ring",
                         "disabled:cursor-not-allowed disabled:opacity-50",
                         triggerClassName
                     )}

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -163,6 +163,7 @@ export function Combobox({
     }, [activeIndex])
 
     const handleSelect = (optValue: string) => {
+        if (disabled) return
         onValueChange?.(optValue)
         onInputValueChange?.(optValue)
         setOpen(false)
@@ -171,6 +172,7 @@ export function Combobox({
     }
 
     const handleCreate = () => {
+        if (disabled) return
         const newValue = inputValue.trim()
         if (newValue) {
             onCreateNew?.(newValue)
@@ -201,6 +203,7 @@ export function Combobox({
     }
 
     const handleOpenChange = (nextOpen: boolean) => {
+        if (disabled && nextOpen) return
         setOpen(nextOpen)
         setActiveIndex(-1)
         if (nextOpen) {
@@ -248,9 +251,10 @@ export function Combobox({
     }
 
     return (
-        <Popover open={open} onOpenChange={handleOpenChange}>
+        <Popover open={open && !disabled} onOpenChange={handleOpenChange}>
             <PopoverTrigger asChild disabled={disabled}>
                 <div
+                    aria-disabled={disabled}
                     className={cn(
                         "flex h-10 w-full items-center rounded-md border border-input bg-background text-sm min-w-0 overflow-hidden",
                         "hover:bg-secondary/50 transition-colors",

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -91,6 +91,13 @@ export const focusComboboxInput = (
     if (selectValue) input?.select()
 }
 
+export const selectComboboxInputIfFocused = (
+    input: ComboboxFocusableInput | null,
+    activeElement: Element | null,
+): void => {
+    if (input && input === activeElement) input.select()
+}
+
 export const canComboboxOpen = (disabled: boolean, nextOpen: boolean): boolean =>
     !disabled || !nextOpen
 
@@ -149,17 +156,32 @@ export function Combobox({
     // Track if user is actively searching (typed something after opening)
     const [isSearching, setIsSearching] = React.useState(false)
     const inputRef = React.useRef<HTMLInputElement>(null)
+    const wasOpenRef = React.useRef(false)
     const activeOptionRef = React.useRef<HTMLButtonElement>(null)
     const listboxId = React.useId()
 
     // Sync input value with external value when not focused
     React.useEffect(() => {
+        const wasOpen = wasOpenRef.current
+        wasOpenRef.current = open
+
         if (!open) {
             const selected = options.find((opt) => opt.value === value)
             setInputValue(selected?.label || value || "")
             setIsSearching(false)
+
+            if (wasOpen && selectValueOnFocus) {
+                // The restored label lands after the close event. Reselect it on the next
+                // frame so the next keystroke replaces it instead of appending to it.
+                requestAnimationFrame(() => {
+                    selectComboboxInputIfFocused(
+                        inputRef.current,
+                        typeof document === "undefined" ? null : document.activeElement,
+                    )
+                })
+            }
         }
-    }, [value, options, open])
+    }, [value, options, open, selectValueOnFocus])
 
     // Show all options when dropdown is open but user hasn't started searching
     const filteredOptions = React.useMemo(() => {

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -180,6 +180,14 @@ export function Combobox({
         }
     }
 
+    const focusAndSelectInput = () => {
+        // Defer so selection wins over click-to-place-caret on focus.
+        requestAnimationFrame(() => {
+            inputRef.current?.focus()
+            inputRef.current?.select()
+        })
+    }
+
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setInputValue(e.target.value)
         onInputValueChange?.(e.target.value)
@@ -188,10 +196,19 @@ export function Combobox({
         if (!open) setOpen(true)
     }
 
+    const handleInputFocus = () => {
+        focusAndSelectInput()
+    }
+
     const handleOpenChange = (nextOpen: boolean) => {
         setOpen(nextOpen)
         setActiveIndex(-1)
-        if (!nextOpen) onInputValueChange?.(value ?? "")
+        if (nextOpen) {
+            // Focus + select so opening via the chevron still replaces on first keystroke.
+            focusAndSelectInput()
+        } else {
+            onInputValueChange?.(value ?? "")
+        }
     }
 
     const handleInputKeyDown = (e: React.KeyboardEvent) => {
@@ -248,6 +265,7 @@ export function Combobox({
                         type="text"
                         value={inputValue}
                         onChange={handleInputChange}
+                        onFocus={handleInputFocus}
                         onKeyDown={handleInputKeyDown}
                         role="combobox"
                         aria-autocomplete="list"

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -26,6 +26,7 @@ interface ComboboxProps {
     inputStyle?: React.CSSProperties;
     onInputValueChange?: (value: string) => void;
     disabled?: boolean;
+    clearable?: boolean;
 }
 
 export const comboboxWheelDeltaToPixels = (deltaY: number, deltaMode: number): number => {
@@ -38,6 +39,21 @@ export type ComboboxScrollableTarget = {
     clientHeight: number;
     scrollHeight: number;
     scrollTop: number;
+}
+
+export const filterComboboxOptions = (
+    options: ComboboxOption[],
+    inputValue: string,
+    isSearching: boolean,
+): ComboboxOption[] => {
+    if (!isSearching || !inputValue.trim()) return options
+    const lower = inputValue.toLowerCase()
+    return options.filter(
+        (option) =>
+            option.label.toLowerCase().includes(lower) ||
+            option.value.toLowerCase().includes(lower) ||
+            option.sublabel?.toLowerCase().includes(lower)
+    )
 }
 
 export const applyComboboxWheelScroll = (
@@ -108,6 +124,7 @@ export function Combobox({
     inputStyle,
     onInputValueChange,
     disabled = false,
+    clearable = true,
 }: ComboboxProps) {
     const [open, setOpen] = React.useState(false)
     const [inputValue, setInputValue] = React.useState("")
@@ -129,14 +146,7 @@ export function Combobox({
 
     // Show all options when dropdown is open but user hasn't started searching
     const filteredOptions = React.useMemo(() => {
-        if (!isSearching || !inputValue.trim()) return options
-        const lower = inputValue.toLowerCase()
-        return options.filter(
-            (opt) =>
-                opt.label.toLowerCase().includes(lower) ||
-                opt.value.toLowerCase().includes(lower) ||
-                opt.sublabel?.toLowerCase().includes(lower)
-        )
+        return filterComboboxOptions(options, inputValue, isSearching)
     }, [options, inputValue, isSearching])
 
     const showCreateOption = React.useMemo(() => {
@@ -250,7 +260,7 @@ export function Combobox({
                         className="flex-1 min-w-0 h-full px-3 bg-transparent outline-none placeholder:text-muted-foreground"
                         disabled={disabled}
                     />
-                    {inputValue && (
+                    {clearable && inputValue && (
                         <button
                             type="button"
                             onClick={handleClear}

--- a/docs/research/issue-2506-font-picker-comparison.md
+++ b/docs/research/issue-2506-font-picker-comparison.md
@@ -1,0 +1,66 @@
+# Issue #2506: Tabby / Electerm 字体选择对照
+
+研究日期：2026-07-27
+
+源码版本：
+
+- Tabby：[`14e2d60b9b6dee84a53c37f05eefeb803787de04`](https://github.com/Eugeny/tabby/commit/14e2d60b9b6dee84a53c37f05eefeb803787de04)
+- Electerm：[`7dfb33ed19352430f0303ca14e379d9b2387f390`](https://github.com/electerm/electerm/commit/7dfb33ed19352430f0303ca14e379d9b2387f390)
+
+## 结论
+
+[Issue #2506](https://github.com/binaricat/Netcatty/issues/2506) 提议的字体搜索是成熟且范围可控的改进。Tabby 和 Electerm 的共同做法不是继续扩充一份内置字体清单，而是：读取本机字体、支持按名称搜索，同时保留手动输入，避免系统字体读取失败或漏报时把用户卡死。
+
+两者在备用字体上的取舍不同：Tabby 是“主字体 + 一个备用字体”，含义清楚，最接近 Netcatty 现有模型；Electerm 允许用户排列任意长度的字体链，更灵活，但也更容易出现顺序配置问题。对 #2506，建议沿用 Netcatty 的主字体 / 中文字体分工，把界面字体和终端主字体改成可搜索选择即可，不必引入任意字体链。
+
+## 对照
+
+| 问题 | Tabby | Electerm |
+|---|---|---|
+| 支持搜索 | 是。字体框是带自动补全的文本框；输入后等待 200 ms，按名称大小写不敏感地包含匹配并去重（[界面](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-terminal/src/components/appearanceSettingsTab.component.pug#L6-L12)，[过滤逻辑](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-terminal/src/components/appearanceSettingsTab.component.ts#L22-L32)）。 | 是。字体选择器明确开启搜索，按名称大小写不敏感地包含匹配（[源码](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/common/font-select.jsx#L32-L43)）。 |
+| 枚举系统字体 | 是。Windows / macOS 读取所有可用字体族；Linux 用 `fc-list :spacing=mono` 只列等宽字体（[源码](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-electron/src/services/platform.service.ts#L209-L224)）。Web 版无法枚举时返回空列表（[源码](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-web/src/platform.ts#L66-L68)）。 | 是。主进程通过 `font-list` 读取字体族，去掉名称中的引号；失败时返回空列表，不阻塞启动（[源码](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/app/lib/font-list.js#L7-L16)）。 |
+| 允许手动输入 | 是。控件本身就是文本输入框，建议列表不是封闭选项。 | 是。选择器使用标签模式，既能选本机字体，也能输入新字体（[源码](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/common/font-select.jsx#L32-L43)）。 |
+| 备用 / 中文字体 | 有独立的备用字体输入框，说明文字明确表示它用于主字体缺失的字符；同样支持系统字体自动补全（[源码](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-terminal/src/components/appearanceSettingsTab.component.pug#L151-L160)）。最终顺序是主字体、用户备用字体、内置后备、系统等宽字体（[源码](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-core/src/utils.ts#L20-L28)）。它不单独命名为“中文字体”，但可以把中文字体填在这里。 | 没有独立的中文 / 备用字体字段。用户添加多个字体标签，保存时按顺序拼成一个字体链（[保存逻辑](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/setting-panel/setting-terminal.jsx#L89-L94)，[界面](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/setting-panel/setting-terminal.jsx#L432-L439)），再直接交给终端渲染（[源码](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/terminal/terminal.jsx#L1288-L1293)）。中文字体可以放在后续标签里。 |
+| 预览与局部覆盖 | 没有在候选行逐项预览；主字体和备用字体共用同一个简单自动补全模型。 | 每个候选名称用该字体自身显示，能提供轻量预览（[源码](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/common/font-select.jsx#L14-L25)）。但单个连接的字体覆盖仍是普通文本框，并未复用全局搜索器（[源码](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/bookmark-form/config/common-fields.js#L170-L175)）。 |
+
+## 对 Netcatty 的建议
+
+1. 界面字体和终端主字体使用同一种可搜索选择体验，按名称包含匹配；候选项用自身字体显示名称。
+2. 继续读取本机字体，不要靠不断扩充内置清单来解决“字体少”。终端主字体仍优先展示等宽字体，避免比例字体破坏列对齐。
+3. 保留手动输入。字体读取可能被拒绝、失败或漏报；跨设备同步过来的字体也可能只在另一台机器安装。
+4. 保持现有“主字体 + 中文字体”模型。它比 Electerm 的任意字体链更容易理解，也和 Tabby 的做法一致。
+5. 系统字体读取失败时，仍显示当前值和安全的内置选项；不要让设置页变成空列表。
+
+## 本地验收字体包（macOS）
+
+以下 8 个字体用于验收 #2506，不是对 X 热度的量化排名。选择标准是：开发者社交圈常见、开源、官方项目仍可访问，并且截至 2026-07-27 均能从 Homebrew 官方字体仓库安装。它们刻意覆盖了连字、窄字面、Nerd Font 图标、简体中文、手写风格中文，以及同一安装包内多个相近字体名等情况。
+
+### 编程字体
+
+| 字体 | Homebrew cask | 等宽 / CJK | Nerd Font | 验收价值 |
+|---|---|---|---|---|
+| [JetBrains Mono](https://www.jetbrains.com/lp/mono/) | [`font-jetbrains-mono`](https://formulae.brew.sh/cask/font-jetbrains-mono) | 等宽；不含 CJK 汉字 | 否；基础字体带少量 Powerline 符号 | 常见基准字体，名称搜索和连字预览都容易辨认。 |
+| [Fira Code](https://github.com/tonsky/FiraCode) | [`font-fira-code`](https://formulae.brew.sh/cask/font-fira-code) | 等宽；不含 CJK 汉字 | 否；基础字体支持 Powerline | 连字丰富，适合检查候选项用自身字体展示时是否清晰。 |
+| [Cascadia Code](https://github.com/microsoft/cascadia-code) | [`font-cascadia-code`](https://formulae.brew.sh/cask/font-cascadia-code) | 等宽；不含 CJK 汉字 | 此 cask 否；官方另有 NF 变体 | 官方明确区分 Code、Mono、Powerline、Nerd Font，适合检查相似名称搜索。 |
+| [Iosevka](https://github.com/be5invis/Iosevka) | [`font-iosevka`](https://formulae.brew.sh/cask/font-iosevka) | 等宽家族；不含 CJK 汉字 | 此 cask 否；Homebrew 另有 Nerd Font 变体 | 字面较窄且家族变体多，适合检查长列表、相似名称和终端列宽。 |
+
+### CJK / 中文等宽字体
+
+| 字体 | Homebrew cask | 等宽 / CJK | Nerd Font | 验收价值 |
+|---|---|---|---|---|
+| [Maple Mono NF CN](https://font.subf.dev/en/) | [`font-maple-mono-nf-cn`](https://formulae.brew.sh/cask/font-maple-mono-nf-cn) | 中英文 2:1 等宽；含简体中文 | 是 | 一套字体同时覆盖代码、中文和图标，是最完整的终端实测样本。 |
+| [Sarasa Gothic / 更纱黑体](https://github.com/be5invis/Sarasa-Gothic) | [`font-sarasa-gothic`](https://formulae.brew.sh/cask/font-sarasa-gothic) | 安装包含 `Sarasa Mono SC`、`Term SC`、`Fixed SC` 等 CJK 等宽变体，也含非等宽变体 | 否 | 同一安装包会出现大量相近家族名，最适合压力测试搜索和过滤。 |
+| [LXGW WenKai GB / 霞鹜文楷 GB](https://github.com/lxgw/LxgwWenkaiGB) | [`font-lxgw-wenkai-gb`](https://formulae.brew.sh/cask/font-lxgw-wenkai-gb) | 安装包同时含 `LXGW WenKai Mono GB` 和非等宽版本；含简体中文 | 否 | 能验证搜索是否准确区分 Mono 与普通版本，也能观察中文风格差异。 |
+| [Noto Sans Mono CJK SC](https://github.com/notofonts/noto-cjk/tree/main/Sans) | [`font-noto-sans-mono-cjk-sc`](https://formulae.brew.sh/cask/font-noto-sans-mono-cjk-sc) | 半角 ASCII + 全角简体中文，适合终端 2:1 排版 | 否 | 中性基准字体，适合判断中文列宽和回退是否正确。 |
+
+建议一次安装这 8 个 cask，重启 Netcatty 后测试搜索、键盘选择、主字体与中文字体组合，以及 `A中B文 0O1lI -> !=` 和 Powerline / Nerd Font 图标的显示：
+
+```sh
+brew install --cask font-jetbrains-mono font-fira-code font-cascadia-code font-iosevka font-maple-mono-nf-cn font-sarasa-gothic font-lxgw-wenkai-gb font-noto-sans-mono-cjk-sc
+```
+
+基础版 JetBrains Mono 和 Fira Code 虽带少量 Powerline 符号，但不等同于完整 Nerd Font；本组只让 Maple Mono NF CN 承担完整图标字体测试，避免安装重复变体后让字体列表变得难以辨认。
+
+## 范围说明
+
+Tabby 与 Electerm 上述官方设置均针对终端字体。没有在所查官方设置源码中找到与 Netcatty“界面字体”完全对应的独立选择器；因此它们能直接证明的是搜索、系统字体枚举、手动输入和备用链的通用做法，而不是界面字体必须采用某个特定模型。

--- a/docs/research/issue-2506-font-picker-comparison.md
+++ b/docs/research/issue-2506-font-picker-comparison.md
@@ -1,66 +1,66 @@
-# Issue #2506: Tabby / Electerm 字体选择对照
+# Issue #2506: Tabby / Electerm font picker comparison
 
-研究日期：2026-07-27
+Research date: 2026-07-27
 
-源码版本：
+Source revisions:
 
-- Tabby：[`14e2d60b9b6dee84a53c37f05eefeb803787de04`](https://github.com/Eugeny/tabby/commit/14e2d60b9b6dee84a53c37f05eefeb803787de04)
-- Electerm：[`7dfb33ed19352430f0303ca14e379d9b2387f390`](https://github.com/electerm/electerm/commit/7dfb33ed19352430f0303ca14e379d9b2387f390)
+- Tabby: [`14e2d60b9b6dee84a53c37f05eefeb803787de04`](https://github.com/Eugeny/tabby/commit/14e2d60b9b6dee84a53c37f05eefeb803787de04)
+- Electerm: [`7dfb33ed19352430f0303ca14e379d9b2387f390`](https://github.com/electerm/electerm/commit/7dfb33ed19352430f0303ca14e379d9b2387f390)
 
-## 结论
+## Conclusion
 
-[Issue #2506](https://github.com/binaricat/Netcatty/issues/2506) 提议的字体搜索是成熟且范围可控的改进。Tabby 和 Electerm 的共同做法不是继续扩充一份内置字体清单，而是：读取本机字体、支持按名称搜索，同时保留手动输入，避免系统字体读取失败或漏报时把用户卡死。
+[Issue #2506](https://github.com/binaricat/Netcatty/issues/2506) proposes a mature, scoped improvement: searchable font pickers. Tabby and Electerm both avoid growing a hard-coded built-in font catalog. Their shared pattern is: enumerate local fonts, support name search, and keep free-text entry so a failed or incomplete system font scan does not lock the user out.
 
-两者在备用字体上的取舍不同：Tabby 是“主字体 + 一个备用字体”，含义清楚，最接近 Netcatty 现有模型；Electerm 允许用户排列任意长度的字体链，更灵活，但也更容易出现顺序配置问题。对 #2506，建议沿用 Netcatty 的主字体 / 中文字体分工，把界面字体和终端主字体改成可搜索选择即可，不必引入任意字体链。
+They differ on fallback fonts. Tabby uses a clear "main font + one fallback font" model, which is closest to Netcatty's existing shape. Electerm lets users order an arbitrary font chain, which is more flexible but easier to misconfigure. For #2506, keep Netcatty's main-font / CJK-font split, make the UI font and terminal main-font pickers searchable, and do not introduce an arbitrary font-chain editor.
 
-## 对照
+## Comparison
 
-| 问题 | Tabby | Electerm |
+| Question | Tabby | Electerm |
 |---|---|---|
-| 支持搜索 | 是。字体框是带自动补全的文本框；输入后等待 200 ms，按名称大小写不敏感地包含匹配并去重（[界面](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-terminal/src/components/appearanceSettingsTab.component.pug#L6-L12)，[过滤逻辑](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-terminal/src/components/appearanceSettingsTab.component.ts#L22-L32)）。 | 是。字体选择器明确开启搜索，按名称大小写不敏感地包含匹配（[源码](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/common/font-select.jsx#L32-L43)）。 |
-| 枚举系统字体 | 是。Windows / macOS 读取所有可用字体族；Linux 用 `fc-list :spacing=mono` 只列等宽字体（[源码](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-electron/src/services/platform.service.ts#L209-L224)）。Web 版无法枚举时返回空列表（[源码](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-web/src/platform.ts#L66-L68)）。 | 是。主进程通过 `font-list` 读取字体族，去掉名称中的引号；失败时返回空列表，不阻塞启动（[源码](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/app/lib/font-list.js#L7-L16)）。 |
-| 允许手动输入 | 是。控件本身就是文本输入框，建议列表不是封闭选项。 | 是。选择器使用标签模式，既能选本机字体，也能输入新字体（[源码](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/common/font-select.jsx#L32-L43)）。 |
-| 备用 / 中文字体 | 有独立的备用字体输入框，说明文字明确表示它用于主字体缺失的字符；同样支持系统字体自动补全（[源码](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-terminal/src/components/appearanceSettingsTab.component.pug#L151-L160)）。最终顺序是主字体、用户备用字体、内置后备、系统等宽字体（[源码](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-core/src/utils.ts#L20-L28)）。它不单独命名为“中文字体”，但可以把中文字体填在这里。 | 没有独立的中文 / 备用字体字段。用户添加多个字体标签，保存时按顺序拼成一个字体链（[保存逻辑](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/setting-panel/setting-terminal.jsx#L89-L94)，[界面](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/setting-panel/setting-terminal.jsx#L432-L439)），再直接交给终端渲染（[源码](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/terminal/terminal.jsx#L1288-L1293)）。中文字体可以放在后续标签里。 |
-| 预览与局部覆盖 | 没有在候选行逐项预览；主字体和备用字体共用同一个简单自动补全模型。 | 每个候选名称用该字体自身显示，能提供轻量预览（[源码](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/common/font-select.jsx#L14-L25)）。但单个连接的字体覆盖仍是普通文本框，并未复用全局搜索器（[源码](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/bookmark-form/config/common-fields.js#L170-L175)）。 |
+| Search support | Yes. The font field is a text box with autocomplete; after a 200 ms debounce it filters by case-insensitive name substring and dedupes ([UI](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-terminal/src/components/appearanceSettingsTab.component.pug#L6-L12), [filter logic](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-terminal/src/components/appearanceSettingsTab.component.ts#L22-L32)). | Yes. The font selector enables search and filters by case-insensitive name substring ([source](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/common/font-select.jsx#L32-L43)). |
+| Enumerate system fonts | Yes. Windows / macOS list all available families; Linux uses `fc-list :spacing=mono` for monospace only ([source](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-electron/src/services/platform.service.ts#L209-L224)). The web build returns an empty list when enumeration is unavailable ([source](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-web/src/platform.ts#L66-L68)). | Yes. The main process reads families via `font-list`, strips quotes from names, and returns an empty list on failure without blocking startup ([source](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/app/lib/font-list.js#L7-L16)). |
+| Allow manual entry | Yes. The control is a free-text input; suggestions are not a closed set. | Yes. The selector uses tag mode so users can pick local fonts or type a new family ([source](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/common/font-select.jsx#L32-L43)). |
+| Fallback / CJK font | Has a dedicated fallback font field whose copy says it covers glyphs missing from the main font; it also has local-font autocomplete ([source](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-terminal/src/components/appearanceSettingsTab.component.pug#L151-L160)). Final order is main font, user fallback, built-in fallbacks, then system monospace fonts ([source](https://github.com/Eugeny/tabby/blob/14e2d60b9b6dee84a53c37f05eefeb803787de04/tabby-core/src/utils.ts#L20-L28)). It is not labeled "CJK font", but a Chinese font can be entered there. | No separate CJK / fallback field. Users add multiple font tags; save concatenates them into one font stack ([save logic](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/setting-panel/setting-terminal.jsx#L89-L94), [UI](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/setting-panel/setting-terminal.jsx#L432-L439)) and hands that stack to the terminal ([source](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/terminal/terminal.jsx#L1288-L1293)). A Chinese font can be placed in a later tag. |
+| Preview and per-connection override | No per-row candidate preview; main and fallback share the same simple autocomplete model. | Each candidate name is rendered in its own family for a light preview ([source](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/common/font-select.jsx#L14-L25)). Per-connection font overrides remain plain text fields and do not reuse the global searchable picker ([source](https://github.com/electerm/electerm/blob/7dfb33ed19352430f0303ca14e379d9b2387f390/src/client/components/bookmark-form/config/common-fields.js#L170-L175)). |
 
-## 对 Netcatty 的建议
+## Recommendations for Netcatty
 
-1. 界面字体和终端主字体使用同一种可搜索选择体验，按名称包含匹配；候选项用自身字体显示名称。
-2. 继续读取本机字体，不要靠不断扩充内置清单来解决“字体少”。终端主字体仍优先展示等宽字体，避免比例字体破坏列对齐。
-3. 保留手动输入。字体读取可能被拒绝、失败或漏报；跨设备同步过来的字体也可能只在另一台机器安装。
-4. 保持现有“主字体 + 中文字体”模型。它比 Electerm 的任意字体链更容易理解，也和 Tabby 的做法一致。
-5. 系统字体读取失败时，仍显示当前值和安全的内置选项；不要让设置页变成空列表。
+1. Give UI font and terminal main font the same searchable picker UX: case-insensitive name substring match, with each candidate rendered in its own family.
+2. Keep reading local fonts instead of expanding a built-in catalog. Prefer monospace families for the terminal main font so proportional fonts do not break column alignment.
+3. Keep free-text entry. Font enumeration can be denied, fail, or miss families; synced fonts may also exist only on another machine.
+4. Keep the existing "main font + CJK font" model. It is easier to explain than Electerm's arbitrary chain and matches Tabby's approach.
+5. If system font enumeration fails, still show the current value and safe built-in options; do not leave the settings page with an empty list.
 
-## 本地验收字体包（macOS）
+## Local acceptance font pack (macOS)
 
-以下 8 个字体用于验收 #2506，不是对 X 热度的量化排名。选择标准是：开发者社交圈常见、开源、官方项目仍可访问，并且截至 2026-07-27 均能从 Homebrew 官方字体仓库安装。它们刻意覆盖了连字、窄字面、Nerd Font 图标、简体中文、手写风格中文，以及同一安装包内多个相近字体名等情况。
+These 8 fonts are for accepting #2506; they are not a quantified popularity ranking. Selection criteria: common in developer circles, open source, official projects still reachable, and installable from Homebrew's official font casks as of 2026-07-27. They deliberately cover ligatures, narrow metrics, Nerd Font icons, Simplified Chinese, handwritten-style Chinese, and multiple similar family names from one install.
 
-### 编程字体
+### Programming fonts
 
-| 字体 | Homebrew cask | 等宽 / CJK | Nerd Font | 验收价值 |
+| Font | Homebrew cask | Mono / CJK | Nerd Font | Acceptance value |
 |---|---|---|---|---|
-| [JetBrains Mono](https://www.jetbrains.com/lp/mono/) | [`font-jetbrains-mono`](https://formulae.brew.sh/cask/font-jetbrains-mono) | 等宽；不含 CJK 汉字 | 否；基础字体带少量 Powerline 符号 | 常见基准字体，名称搜索和连字预览都容易辨认。 |
-| [Fira Code](https://github.com/tonsky/FiraCode) | [`font-fira-code`](https://formulae.brew.sh/cask/font-fira-code) | 等宽；不含 CJK 汉字 | 否；基础字体支持 Powerline | 连字丰富，适合检查候选项用自身字体展示时是否清晰。 |
-| [Cascadia Code](https://github.com/microsoft/cascadia-code) | [`font-cascadia-code`](https://formulae.brew.sh/cask/font-cascadia-code) | 等宽；不含 CJK 汉字 | 此 cask 否；官方另有 NF 变体 | 官方明确区分 Code、Mono、Powerline、Nerd Font，适合检查相似名称搜索。 |
-| [Iosevka](https://github.com/be5invis/Iosevka) | [`font-iosevka`](https://formulae.brew.sh/cask/font-iosevka) | 等宽家族；不含 CJK 汉字 | 此 cask 否；Homebrew 另有 Nerd Font 变体 | 字面较窄且家族变体多，适合检查长列表、相似名称和终端列宽。 |
+| [JetBrains Mono](https://www.jetbrains.com/lp/mono/) | [`font-jetbrains-mono`](https://formulae.brew.sh/cask/font-jetbrains-mono) | Monospace; no CJK han | No; base font includes a few Powerline symbols | Common baseline; easy to recognize in name search and ligature preview. |
+| [Fira Code](https://github.com/tonsky/FiraCode) | [`font-fira-code`](https://formulae.brew.sh/cask/font-fira-code) | Monospace; no CJK han | No; base font supports Powerline | Rich ligatures; good check that candidates remain readable when rendered in their own family. |
+| [Cascadia Code](https://github.com/microsoft/cascadia-code) | [`font-cascadia-code`](https://formulae.brew.sh/cask/font-cascadia-code) | Monospace; no CJK han | Not this cask; official NF variants exist separately | Officially distinguishes Code, Mono, Powerline, and Nerd Font; good similar-name search check. |
+| [Iosevka](https://github.com/be5invis/Iosevka) | [`font-iosevka`](https://formulae.brew.sh/cask/font-iosevka) | Monospace family; no CJK han | Not this cask; Homebrew has separate NF variants | Narrow metrics and many family variants; good for long lists, similar names, and terminal column width. |
 
-### CJK / 中文等宽字体
+### CJK / Chinese monospace fonts
 
-| 字体 | Homebrew cask | 等宽 / CJK | Nerd Font | 验收价值 |
+| Font | Homebrew cask | Mono / CJK | Nerd Font | Acceptance value |
 |---|---|---|---|---|
-| [Maple Mono NF CN](https://font.subf.dev/en/) | [`font-maple-mono-nf-cn`](https://formulae.brew.sh/cask/font-maple-mono-nf-cn) | 中英文 2:1 等宽；含简体中文 | 是 | 一套字体同时覆盖代码、中文和图标，是最完整的终端实测样本。 |
-| [Sarasa Gothic / 更纱黑体](https://github.com/be5invis/Sarasa-Gothic) | [`font-sarasa-gothic`](https://formulae.brew.sh/cask/font-sarasa-gothic) | 安装包含 `Sarasa Mono SC`、`Term SC`、`Fixed SC` 等 CJK 等宽变体，也含非等宽变体 | 否 | 同一安装包会出现大量相近家族名，最适合压力测试搜索和过滤。 |
-| [LXGW WenKai GB / 霞鹜文楷 GB](https://github.com/lxgw/LxgwWenkaiGB) | [`font-lxgw-wenkai-gb`](https://formulae.brew.sh/cask/font-lxgw-wenkai-gb) | 安装包同时含 `LXGW WenKai Mono GB` 和非等宽版本；含简体中文 | 否 | 能验证搜索是否准确区分 Mono 与普通版本，也能观察中文风格差异。 |
-| [Noto Sans Mono CJK SC](https://github.com/notofonts/noto-cjk/tree/main/Sans) | [`font-noto-sans-mono-cjk-sc`](https://formulae.brew.sh/cask/font-noto-sans-mono-cjk-sc) | 半角 ASCII + 全角简体中文，适合终端 2:1 排版 | 否 | 中性基准字体，适合判断中文列宽和回退是否正确。 |
+| [Maple Mono NF CN](https://font.subf.dev/en/) | [`font-maple-mono-nf-cn`](https://formulae.brew.sh/cask/font-maple-mono-nf-cn) | Latin/CJK 2:1 monospace; includes Simplified Chinese | Yes | One family covering code, Chinese, and icons; the most complete terminal sample. |
+| [Sarasa Gothic](https://github.com/be5invis/Sarasa-Gothic) | [`font-sarasa-gothic`](https://formulae.brew.sh/cask/font-sarasa-gothic) | Install includes `Sarasa Mono SC`, `Term SC`, `Fixed SC`, and other CJK mono variants, plus proportional variants | No | One install yields many near-duplicate family names; best stress test for search and filtering. |
+| [LXGW WenKai GB](https://github.com/lxgw/LxgwWenkaiGB) | [`font-lxgw-wenkai-gb`](https://formulae.brew.sh/cask/font-lxgw-wenkai-gb) | Install includes both `LXGW WenKai Mono GB` and proportional versions; Simplified Chinese | No | Checks that search distinguishes Mono vs regular, and that Chinese style differences remain visible. |
+| [Noto Sans Mono CJK SC](https://github.com/notofonts/noto-cjk/tree/main/Sans) | [`font-noto-sans-mono-cjk-sc`](https://formulae.brew.sh/cask/font-noto-sans-mono-cjk-sc) | Half-width ASCII + full-width Simplified Chinese; suited to terminal 2:1 layout | No | Neutral baseline for Chinese column width and fallback behavior. |
 
-建议一次安装这 8 个 cask，重启 Netcatty 后测试搜索、键盘选择、主字体与中文字体组合，以及 `A中B文 0O1lI -> !=` 和 Powerline / Nerd Font 图标的显示：
+Install all 8 casks once, restart Netcatty, then test search, keyboard selection, main + CJK combinations, and rendering of `A中B文 0O1lI -> !=` plus Powerline / Nerd Font icons:
 
 ```sh
 brew install --cask font-jetbrains-mono font-fira-code font-cascadia-code font-iosevka font-maple-mono-nf-cn font-sarasa-gothic font-lxgw-wenkai-gb font-noto-sans-mono-cjk-sc
 ```
 
-基础版 JetBrains Mono 和 Fira Code 虽带少量 Powerline 符号，但不等同于完整 Nerd Font；本组只让 Maple Mono NF CN 承担完整图标字体测试，避免安装重复变体后让字体列表变得难以辨认。
+Base JetBrains Mono and Fira Code include a few Powerline symbols but are not full Nerd Fonts; this set relies on Maple Mono NF CN alone for complete icon-font coverage, avoiding duplicate variants that make the font list hard to scan.
 
-## 范围说明
+## Scope note
 
-Tabby 与 Electerm 上述官方设置均针对终端字体。没有在所查官方设置源码中找到与 Netcatty“界面字体”完全对应的独立选择器；因此它们能直接证明的是搜索、系统字体枚举、手动输入和备用链的通用做法，而不是界面字体必须采用某个特定模型。
+The Tabby and Electerm settings reviewed above target terminal fonts. The checked official settings sources do not expose a separate picker that fully matches Netcatty's "UI font" control. They therefore evidence shared patterns for search, system font enumeration, free-text entry, and fallback chains, not a required product model for UI fonts.


### PR DESCRIPTION
## Summary

- Add searchable pickers for the interface font and primary terminal font.
- Keep the existing installed-font filtering and previews while improving keyboard navigation.
- Document how Tabby and Electerm handle font selection, plus a practical macOS validation font pack.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor / maintenance

## Related Issue

Closes #2506

## Changes Made

- Replace the closed font dropdowns with a shared searchable picker.
- Match font names case-insensitively and select the current label on focus so typing starts a fresh search.
- Preserve font previews, visible keyboard focus, and disabled-state protection.
- Add focused tests for filtering, empty results, keyboard navigation, selection, focus, and disabled behavior.
- Compare the current approach with Tabby and Electerm and record recommended local test fonts.

## Screenshots / Demo

Tested in the running macOS app: clicking the selected `Cascadia Code` value and typing `Iosevka` replaces the existing label, shows the installed font immediately, and displays a visible focus ring. Closing the search restores the saved value. Refreshing local CJK fonts also finds the newly installed `Sarasa Mono SC` entry.

## Testing

- [x] Tested locally in dev environment
- [x] Lint passes (`npm run lint`)
- [x] Focused tests pass (13 tests)
- [x] Production build passes (`npm run build`)
- [x] GitHub full test and build workflow passes

## Checklist

- [x] Code follows the existing project style
- [x] Documentation updated where needed
- [x] No breaking changes introduced
- [x] Full test suite passes

## Additional Notes

The primary terminal picker searches Netcatty's supported font presets. The CJK picker continues to discover locally installed fonts and can be refreshed from the settings page.
