### PR TITLE
fix(ci): accept fenced Cursor research status

### DIFF
--- a/.github/workflows/cursor-automation.yml
+++ b/.github/workflows/cursor-automation.yml
@@ -673,7 +673,7 @@ jobs:
           prompt="$(cat "$RUNNER_TEMP/cursor-prompts/research.md")"
           sudo --preserve-env=HOME,RUNNER_TEMP,GITHUB_WORKSPACE \
             "$RUNNER_TEMP/cursor-agent-authenticated" \
-            -p --mode=ask --force --trust --sandbox enabled --model auto --output-format stream-json \
+            -p --mode=ask --force --trust --sandbox enabled --model auto --output-format stream-json --stream-partial-output \
             --workspace "$research_dir" "$prompt" \
             > .cursor-runtime/external-research-raw.txt
           cat .cursor-runtime/external-research-raw.txt
@@ -1410,7 +1410,7 @@ jobs:
           prompt="$(cat "$RUNNER_TEMP/research.md")"
           sudo --preserve-env=HOME,RUNNER_TEMP,GITHUB_WORKSPACE \
             "$RUNNER_TEMP/cursor-agent-authenticated" \
-            -p --mode=ask --force --trust --sandbox enabled --model auto --output-format stream-json \
+            -p --mode=ask --force --trust --sandbox enabled --model auto --output-format stream-json --stream-partial-output \
             --workspace "$research_dir" "$prompt" \
             > .cursor-runtime/followup-research-raw.txt
           cat .cursor-runtime/followup-research-raw.txt

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -305,23 +305,18 @@ function parseExternalResearchStream(value, input) {
   const finalAssistantText = assistantMessages.findLast(
     (message) => message.isFinalFlush,
   )?.text;
-  const fencedEnvelope = fencedAssistantSuffixes
-    .map((candidate) => parseExternalResearchEnvelope(candidate))
-    .find(Boolean);
-  const aggregateEnvelope = [finalAssistantText, terminalResult]
-    .filter(Boolean)
-    .map((candidate) => parseExternalResearchEnvelope(candidate))
-    .find(Boolean);
-  if (fencedEnvelope && aggregateEnvelope
-    && fencedEnvelope.match[1] !== aggregateEnvelope.match[1]) {
-    throw new Error('External research output contains conflicting research statuses.');
-  }
   const candidates = [
     ...fencedAssistantSuffixes,
     finalAssistantText,
     terminalResult,
     partialAssistantText || assistantText,
   ].filter(Boolean);
+  const candidateStatuses = new Set(candidates
+    .map((candidate) => parseExternalResearchEnvelope(candidate)?.match[1])
+    .filter(Boolean));
+  if (candidateStatuses.size > 1) {
+    throw new Error('External research output contains conflicting research statuses.');
+  }
   const selected = candidates.find((candidate) => parseExternalResearchEnvelope(candidate));
   const normalized = normalizeExternalResearchText(selected || candidates[0] || '', {
     input,

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -223,7 +223,9 @@ function extractHttpsUrls(value) {
 /** Parse Cursor stream-json and prove that completed research used a web tool. */
 function parseExternalResearchStream(value, input) {
   let assistantText = '';
+  let partialAssistantText = '';
   const assistantMessages = [];
+  const partialAssistantMessages = [];
   let terminalResult = '';
   let webToolUsed = false;
   const webEvidenceUrls = new Set();
@@ -269,25 +271,32 @@ function parseExternalResearchStream(value, input) {
       .map((block) => String(block.text))
       .join('');
     if (eventText) {
+      const hasModelCallId = event.model_call_id != null || event.modelCallId != null;
+      const isPartialDelta = event.timestamp_ms != null && !hasModelCallId;
       assistantMessages.push({
         text: eventText,
         isFinalFlush: event.timestamp_ms == null
-          && event.model_call_id == null
-          && event.modelCallId == null,
+          && !hasModelCallId,
       });
+      if (isPartialDelta) {
+        partialAssistantMessages.push(eventText);
+        partialAssistantText += eventText;
+      }
       assistantText += eventText;
     }
   }
 
-  // Cursor can split a fenced final envelope across assistant events. A valid
-  // terminal result remains authoritative; otherwise prefer the shortest
-  // complete fenced suffix, then an isolated final event, and retain the full
-  // stream only as the last delta fallback. Never search arbitrary prose for
-  // a status marker.
+  // Cursor can prepend earlier text to its terminal result or split a fenced
+  // final envelope across assistant events. Prefer the explicit final flush,
+  // then the shortest complete fenced suffix, before the aggregate terminal
+  // and full delta stream. Never search arbitrary prose for a status marker.
   const assistantSuffixes = [];
   let assistantSuffix = '';
-  for (let index = assistantMessages.length - 1; index >= 0; index -= 1) {
-    assistantSuffix = assistantMessages[index].text + assistantSuffix;
+  const suffixMessages = partialAssistantMessages.length
+    ? partialAssistantMessages
+    : assistantMessages.map((message) => message.text);
+  for (let index = suffixMessages.length - 1; index >= 0; index -= 1) {
+    assistantSuffix = suffixMessages[index] + assistantSuffix;
     assistantSuffixes.push(assistantSuffix);
   }
   const fencedAssistantSuffixes = assistantSuffixes.filter(
@@ -297,10 +306,10 @@ function parseExternalResearchStream(value, input) {
     (message) => message.isFinalFlush,
   )?.text;
   const candidates = [
-    terminalResult,
-    ...fencedAssistantSuffixes,
     finalAssistantText,
-    assistantText,
+    ...fencedAssistantSuffixes,
+    terminalResult,
+    partialAssistantText || assistantText,
   ].filter(Boolean);
   const selected = candidates.find((candidate) => parseExternalResearchEnvelope(candidate));
   const normalized = normalizeExternalResearchText(selected || candidates[0] || '', {

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -278,7 +278,7 @@ function parseExternalResearchStream(value, input) {
   const candidates = [
     terminalResult,
     assistantText,
-    ...assistantMessages.slice().reverse(),
+    assistantMessages[assistantMessages.length - 1],
   ].filter(Boolean);
   const selected = candidates.find((candidate) => parseExternalResearchEnvelope(candidate));
   const normalized = normalizeExternalResearchText(selected || candidates[0] || '', {

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -272,13 +272,13 @@ function parseExternalResearchStream(value, input) {
   }
 
   // Cursor's terminal result may prepend earlier conversational text to the
-  // final answer. Prefer it when it is already a valid envelope, otherwise
-  // accept the complete assistant stream or one isolated final message. Never
-  // search arbitrary prose for a status marker.
+  // final answer. Prefer an isolated final message, then a valid terminal
+  // result, and retain the complete stream only for statuses split across
+  // events. Never search arbitrary prose for a status marker.
   const candidates = [
+    assistantMessages[assistantMessages.length - 1],
     terminalResult,
     assistantText,
-    assistantMessages[assistantMessages.length - 1],
   ].filter(Boolean);
   const selected = candidates.find((candidate) => parseExternalResearchEnvelope(candidate));
   const normalized = normalizeExternalResearchText(selected || candidates[0] || '', {

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -151,6 +151,9 @@ function getUserAuthoredResearchText(input = {}) {
 function parseExternalResearchEnvelope(value) {
   const text = sanitizeUntrustedText(value, 16_000);
   const fenced = text.match(/^```(?:text)?[ \t]*\r?\n([\s\S]*?)\r?\n```[ \t]*$/i);
+  if (!fenced && ((text.match(/```/g) || []).length % 2) !== 0) {
+    return null;
+  }
   const normalized = fenced ? sanitizeUntrustedText(fenced[1], 16_000) : text;
   const firstLine = normalized.split('\n').find((line) => line.trim())?.trim() || '';
   const match = firstLine.match(

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -269,7 +269,12 @@ function parseExternalResearchStream(value, input) {
       .map((block) => String(block.text))
       .join('');
     if (eventText) {
-      assistantMessages.push(eventText);
+      assistantMessages.push({
+        text: eventText,
+        isFinalFlush: event.timestamp_ms == null
+          && event.model_call_id == null
+          && event.modelCallId == null,
+      });
       assistantText += eventText;
     }
   }
@@ -282,16 +287,19 @@ function parseExternalResearchStream(value, input) {
   const assistantSuffixes = [];
   let assistantSuffix = '';
   for (let index = assistantMessages.length - 1; index >= 0; index -= 1) {
-    assistantSuffix = assistantMessages[index] + assistantSuffix;
+    assistantSuffix = assistantMessages[index].text + assistantSuffix;
     assistantSuffixes.push(assistantSuffix);
   }
   const fencedAssistantSuffixes = assistantSuffixes.filter(
     (candidate) => parseExternalResearchEnvelope(candidate)?.fenced,
   );
+  const finalAssistantText = assistantMessages.findLast(
+    (message) => message.isFinalFlush,
+  )?.text;
   const candidates = [
     terminalResult,
     ...fencedAssistantSuffixes,
-    assistantMessages[assistantMessages.length - 1],
+    finalAssistantText,
     assistantText,
   ].filter(Boolean);
   const selected = candidates.find((candidate) => parseExternalResearchEnvelope(candidate));

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -306,8 +306,8 @@ function parseExternalResearchStream(value, input) {
     (message) => message.isFinalFlush,
   )?.text;
   const candidates = [
-    finalAssistantText,
     ...fencedAssistantSuffixes,
+    finalAssistantText,
     terminalResult,
     partialAssistantText || assistantText,
   ].filter(Boolean);

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -311,10 +311,10 @@ function parseExternalResearchStream(value, input) {
     terminalResult,
     partialAssistantText || assistantText,
   ].filter(Boolean);
-  const candidateStatuses = new Set(candidates
-    .map((candidate) => parseExternalResearchEnvelope(candidate)?.match[1])
+  const candidateTexts = new Set(candidates
+    .map((candidate) => parseExternalResearchEnvelope(candidate)?.text)
     .filter(Boolean));
-  if (candidateStatuses.size > 1) {
+  if (candidateTexts.size > 1) {
     throw new Error('External research output contains conflicting research statuses.');
   }
   const selected = candidates.find((candidate) => parseExternalResearchEnvelope(candidate));

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -274,12 +274,18 @@ function parseExternalResearchStream(value, input) {
     }
   }
 
-  // Cursor's terminal result may prepend earlier conversational text to the
-  // final answer. Prefer an isolated final message, then a valid terminal
-  // result, and retain the complete stream only for statuses split across
-  // events. Never search arbitrary prose for a status marker.
+  // Cursor can split the final envelope across assistant events. Try the
+  // shortest suffix ending at the final event first, so an earlier status can
+  // never override a later revision. Use the terminal/complete streams only
+  // as fallbacks. Never search arbitrary prose for a status marker.
+  const assistantSuffixes = [];
+  let assistantSuffix = '';
+  for (let index = assistantMessages.length - 1; index >= 0; index -= 1) {
+    assistantSuffix = assistantMessages[index] + assistantSuffix;
+    assistantSuffixes.push(assistantSuffix);
+  }
   const candidates = [
-    assistantMessages[assistantMessages.length - 1],
+    ...assistantSuffixes,
     terminalResult,
     assistantText,
   ].filter(Boolean);

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -148,12 +148,20 @@ function getUserAuthoredResearchText(input = {}) {
  * Validate the bounded handoff emitted by the isolated WebSearch pass.
  * Research output remains untrusted input for every later agent.
  */
-function normalizeExternalResearchText(value, { input, webToolUsed = false } = {}) {
+function parseExternalResearchEnvelope(value) {
   const text = sanitizeUntrustedText(value, 16_000);
-  const firstLine = text.split('\n').find((line) => line.trim())?.trim() || '';
+  const fenced = text.match(/^```(?:text)?[ \t]*\r?\n([\s\S]*?)\r?\n```[ \t]*$/i);
+  const normalized = fenced ? sanitizeUntrustedText(fenced[1], 16_000) : text;
+  const firstLine = normalized.split('\n').find((line) => line.trim())?.trim() || '';
   const match = firstLine.match(
     /^(RESEARCH_COMPLETE|RESEARCH_NOT_NEEDED|RESEARCH_BLOCKED):\s+(.+)$/,
   );
+  return match ? { text: normalized, match } : null;
+}
+
+function normalizeExternalResearchText(value, { input, webToolUsed = false } = {}) {
+  const envelope = parseExternalResearchEnvelope(value);
+  const match = envelope?.match;
   if (!match) {
     throw new Error('External research output is missing a valid research status.');
   }
@@ -168,14 +176,14 @@ function normalizeExternalResearchText(value, { input, webToolUsed = false } = {
     if (!webToolUsed) {
       throw new Error('Completed external research requires a recorded WebSearch/WebFetch tool call.');
     }
-    const sourceLines = text.match(
+    const sourceLines = envelope.text.match(
       /^-\s+https:\/\/[^\s<>()]+\s+(?:—|–|-)\s+\S.*$/gim,
     ) || [];
     if (!sourceLines.length) {
       throw new Error('Completed external research must include at least one structured HTTPS source URL.');
     }
   }
-  return text;
+  return envelope.text;
 }
 
 function normalizeResearchSourceUrl(value) {
@@ -212,6 +220,7 @@ function extractHttpsUrls(value) {
 /** Parse Cursor stream-json and prove that completed research used a web tool. */
 function parseExternalResearchStream(value, input) {
   let assistantText = '';
+  const assistantMessages = [];
   let terminalResult = '';
   let webToolUsed = false;
   const webEvidenceUrls = new Set();
@@ -256,10 +265,23 @@ function parseExternalResearchStream(value, input) {
       .filter((block) => block?.type === 'text' && block.text)
       .map((block) => String(block.text))
       .join('');
-    if (eventText) assistantText += eventText;
+    if (eventText) {
+      assistantMessages.push(eventText);
+      assistantText += eventText;
+    }
   }
 
-  const normalized = normalizeExternalResearchText(terminalResult || assistantText, {
+  // Cursor's terminal result may prepend earlier conversational text to the
+  // final answer. Prefer it when it is already a valid envelope, otherwise
+  // accept the complete assistant stream or one isolated final message. Never
+  // search arbitrary prose for a status marker.
+  const candidates = [
+    terminalResult,
+    assistantText,
+    ...assistantMessages.slice().reverse(),
+  ].filter(Boolean);
+  const selected = candidates.find((candidate) => parseExternalResearchEnvelope(candidate));
+  const normalized = normalizeExternalResearchText(selected || candidates[0] || '', {
     input,
     webToolUsed,
   });

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -159,7 +159,7 @@ function parseExternalResearchEnvelope(value) {
   const match = firstLine.match(
     /^(RESEARCH_COMPLETE|RESEARCH_NOT_NEEDED|RESEARCH_BLOCKED):\s+(.+)$/,
   );
-  return match ? { text: normalized, match } : null;
+  return match ? { text: normalized, match, fenced: Boolean(fenced) } : null;
 }
 
 function normalizeExternalResearchText(value, { input, webToolUsed = false } = {}) {
@@ -274,19 +274,24 @@ function parseExternalResearchStream(value, input) {
     }
   }
 
-  // Cursor can split the final envelope across assistant events. Try the
-  // shortest suffix ending at the final event first, so an earlier status can
-  // never override a later revision. Use the terminal/complete streams only
-  // as fallbacks. Never search arbitrary prose for a status marker.
+  // Cursor can split a fenced final envelope across assistant events. A valid
+  // terminal result remains authoritative; otherwise prefer the shortest
+  // complete fenced suffix, then an isolated final event, and retain the full
+  // stream only as the last delta fallback. Never search arbitrary prose for
+  // a status marker.
   const assistantSuffixes = [];
   let assistantSuffix = '';
   for (let index = assistantMessages.length - 1; index >= 0; index -= 1) {
     assistantSuffix = assistantMessages[index] + assistantSuffix;
     assistantSuffixes.push(assistantSuffix);
   }
+  const fencedAssistantSuffixes = assistantSuffixes.filter(
+    (candidate) => parseExternalResearchEnvelope(candidate)?.fenced,
+  );
   const candidates = [
-    ...assistantSuffixes,
     terminalResult,
+    ...fencedAssistantSuffixes,
+    assistantMessages[assistantMessages.length - 1],
     assistantText,
   ].filter(Boolean);
   const selected = candidates.find((candidate) => parseExternalResearchEnvelope(candidate));

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -305,6 +305,17 @@ function parseExternalResearchStream(value, input) {
   const finalAssistantText = assistantMessages.findLast(
     (message) => message.isFinalFlush,
   )?.text;
+  const fencedEnvelope = fencedAssistantSuffixes
+    .map((candidate) => parseExternalResearchEnvelope(candidate))
+    .find(Boolean);
+  const aggregateEnvelope = [finalAssistantText, terminalResult]
+    .filter(Boolean)
+    .map((candidate) => parseExternalResearchEnvelope(candidate))
+    .find(Boolean);
+  if (fencedEnvelope && aggregateEnvelope
+    && fencedEnvelope.match[1] !== aggregateEnvelope.match[1]) {
+    throw new Error('External research output contains conflicting research statuses.');
+  }
   const candidates = [
     ...fencedAssistantSuffixes,
     finalAssistantText,

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -2111,14 +2111,14 @@ test('parseExternalResearchStream prefers the final isolated status over stale e
       'RESEARCH_NOT_NEEDED: initially appeared local-only',
       'RESEARCH_BLOCKED: WebSearch became unavailable',
     ].join('\n')),
-    /External research blocked: WebSearch became unavailable/,
+    /conflicting research statuses/,
   );
   assert.throws(
     () => parse([
       'RESEARCH_NOT_NEEDED: initially appeared local-only',
       'RESEARCH_BLOCKED: WebSearch became unavailable',
     ].join('\n')),
-    /External research blocked: WebSearch became unavailable/,
+    /conflicting research statuses/,
   );
 });
 
@@ -2290,6 +2290,76 @@ test('parseExternalResearchStream rejects a fenced status example that conflicts
   );
 });
 
+test('parseExternalResearchStream rejects conflicts across every valid candidate', () => {
+  const noOp = 'RESEARCH_NOT_NEEDED: initially appeared local-only';
+  const blocked = 'RESEARCH_BLOCKED: WebSearch became unavailable';
+  const fencedNoOp = `\`\`\`text\n${noOp}\n\`\`\``;
+  const threeWayConflict = [
+    {
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: { content: [{ type: 'text', text: '```text\n' }] },
+    },
+    {
+      type: 'assistant',
+      timestamp_ms: 2,
+      message: { content: [{ type: 'text', text: `${noOp}\n\`\`\`` }] },
+    },
+    {
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: fencedNoOp }] },
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: blocked,
+    },
+  ].map(JSON.stringify).join('\n');
+
+  assert.throws(
+    () => auto.parseExternalResearchStream(threeWayConflict, {}),
+    /conflicting research statuses/,
+  );
+
+  const fencedExample = '```text\nRESEARCH_BLOCKED: example only\n```';
+  const partialAggregate = `${noOp}\n${fencedExample}`;
+  const prefixedAggregateConflict = [
+    {
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: { content: [{ type: 'text', text: `${noOp}\n` }] },
+    },
+    {
+      type: 'assistant',
+      timestamp_ms: 2,
+      message: { content: [{ type: 'text', text: '```text\n' }] },
+    },
+    {
+      type: 'assistant',
+      timestamp_ms: 3,
+      message: { content: [{ type: 'text', text: 'RESEARCH_BLOCKED: example only\n```' }] },
+    },
+    {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: `Conversation preamble\n${partialAggregate}` }],
+      },
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: `Conversation preamble\n${partialAggregate}`,
+    },
+  ].map(JSON.stringify).join('\n');
+
+  assert.throws(
+    () => auto.parseExternalResearchStream(prefixedAggregateConflict, {}),
+    /conflicting research statuses/,
+  );
+});
+
 test('parseExternalResearchStream keeps a valid terminal status over assistant fragments', () => {
   const terminalStatus = 'RESEARCH_BLOCKED: WebSearch became unavailable';
   const staleAssistantEvents = [
@@ -2315,7 +2385,7 @@ test('parseExternalResearchStream keeps a valid terminal status over assistant f
 
   assert.throws(
     () => auto.parseExternalResearchStream(staleAssistantEvents, {}),
-    /External research blocked: WebSearch became unavailable/,
+    /conflicting research statuses/,
   );
 
   const terminalNoOp = 'RESEARCH_NOT_NEEDED: only local Netcatty behavior is involved';

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -2113,13 +2113,6 @@ test('parseExternalResearchStream prefers the final isolated status over stale e
     ].join('\n')),
     /External research blocked: WebSearch became unavailable/,
   );
-  assert.throws(
-    () => parse([
-      'RESEARCH_NOT_NEEDED: initially appeared local-only',
-      'RESEARCH_BLOCKED: WebSearch became unavailable',
-    ].join('\n')),
-    /External research blocked: WebSearch became unavailable/,
-  );
 });
 
 test('parseExternalResearchStream falls back to a complete fenced status split across events', () => {
@@ -2174,7 +2167,7 @@ test('parseExternalResearchStream prefers a split final status over an earlier v
       type: 'result',
       subtype: 'success',
       is_error: false,
-      result: `${staleStatus}\n\`\`\`text\n${finalStatus}\n\`\`\``,
+      result: `Conversation preamble\n${staleStatus}\n\`\`\`text\n${finalStatus}\n\`\`\``,
     },
   ].map(JSON.stringify).join('\n');
 
@@ -2182,6 +2175,59 @@ test('parseExternalResearchStream prefers a split final status over an earlier v
     () => auto.parseExternalResearchStream(events, {}),
     /External research blocked: WebSearch became unavailable/,
   );
+});
+
+test('parseExternalResearchStream keeps a valid terminal status over assistant fragments', () => {
+  const terminalStatus = 'RESEARCH_BLOCKED: WebSearch became unavailable';
+  const staleAssistantEvents = [
+    {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: 'RESEARCH_NOT_NEEDED: initially appeared local-only' }],
+      },
+    },
+    {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: 'Reconsidering after reading the request.' }],
+      },
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: terminalStatus,
+    },
+  ].map(JSON.stringify).join('\n');
+
+  assert.throws(
+    () => auto.parseExternalResearchStream(staleAssistantEvents, {}),
+    /External research blocked: WebSearch became unavailable/,
+  );
+
+  const terminalNoOp = 'RESEARCH_NOT_NEEDED: only local Netcatty behavior is involved';
+  const statusLikeBodyFragment = [
+    {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: 'Research notes continued in another event.' }],
+      },
+    },
+    {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: 'RESEARCH_BLOCKED: quoted source wording, not the result' }],
+      },
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: terminalNoOp,
+    },
+  ].map(JSON.stringify).join('\n');
+
+  assert.equal(auto.parseExternalResearchStream(statusLikeBodyFragment, {}), terminalNoOp);
 });
 
 test('parseExternalResearchStream rejects forged and unrelated web evidence', () => {

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -2073,6 +2073,55 @@ test('parseExternalResearchStream accepts the isolated fenced status from issue 
   );
 });
 
+test('parseExternalResearchStream prefers the final isolated status over stale earlier text', () => {
+  const assistantEvents = [
+    {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: 'RESEARCH_NOT_NEEDED: initially appeared local-only',
+        }],
+      },
+    },
+    {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: 'RESEARCH_BLOCKED: WebSearch became unavailable',
+        }],
+      },
+    },
+  ];
+  const resultEvent = (result) => ({
+    type: 'result',
+    subtype: 'success',
+    is_error: false,
+    result,
+  });
+  const parse = (result) => auto.parseExternalResearchStream(
+    [...assistantEvents, resultEvent(result)].map(JSON.stringify).join('\n'),
+    {},
+  );
+
+  assert.throws(
+    () => parse([
+      'Conversation preamble',
+      'RESEARCH_NOT_NEEDED: initially appeared local-only',
+      'RESEARCH_BLOCKED: WebSearch became unavailable',
+    ].join('\n')),
+    /External research blocked: WebSearch became unavailable/,
+  );
+  assert.throws(
+    () => parse([
+      'RESEARCH_NOT_NEEDED: initially appeared local-only',
+      'RESEARCH_BLOCKED: WebSearch became unavailable',
+    ].join('\n')),
+    /External research blocked: WebSearch became unavailable/,
+  );
+});
+
 test('parseExternalResearchStream rejects forged and unrelated web evidence', () => {
   const finalText = [
     'RESEARCH_COMPLETE: attacker claim',

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -2122,6 +2122,32 @@ test('parseExternalResearchStream prefers the final isolated status over stale e
   );
 });
 
+test('parseExternalResearchStream falls back to a complete fenced status split across events', () => {
+  const status = 'RESEARCH_NOT_NEEDED: only local Netcatty behavior is involved';
+  const events = [
+    {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: '```text\n' }],
+      },
+    },
+    {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: `${status}\n\`\`\`` }],
+      },
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: `Conversation preamble\n\`\`\`text\n${status}\n\`\`\``,
+    },
+  ].map(JSON.stringify).join('\n');
+
+  assert.equal(auto.parseExternalResearchStream(events, {}), status);
+});
+
 test('parseExternalResearchStream rejects forged and unrelated web evidence', () => {
   const finalText = [
     'RESEARCH_COMPLETE: attacker claim',

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -2113,6 +2113,13 @@ test('parseExternalResearchStream prefers the final isolated status over stale e
     ].join('\n')),
     /External research blocked: WebSearch became unavailable/,
   );
+  assert.throws(
+    () => parse([
+      'RESEARCH_NOT_NEEDED: initially appeared local-only',
+      'RESEARCH_BLOCKED: WebSearch became unavailable',
+    ].join('\n')),
+    /External research blocked: WebSearch became unavailable/,
+  );
 });
 
 test('parseExternalResearchStream falls back to a complete fenced status split across events', () => {
@@ -2167,7 +2174,7 @@ test('parseExternalResearchStream prefers a split final status over an earlier v
       type: 'result',
       subtype: 'success',
       is_error: false,
-      result: `Conversation preamble\n${staleStatus}\n\`\`\`text\n${finalStatus}\n\`\`\``,
+      result: `${staleStatus}\n\`\`\`text\n${finalStatus}\n\`\`\``,
     },
   ].map(JSON.stringify).join('\n');
 
@@ -2209,12 +2216,14 @@ test('parseExternalResearchStream keeps a valid terminal status over assistant f
   const statusLikeBodyFragment = [
     {
       type: 'assistant',
+      timestamp_ms: 1,
       message: {
         content: [{ type: 'text', text: 'Research notes continued in another event.' }],
       },
     },
     {
       type: 'assistant',
+      timestamp_ms: 2,
       message: {
         content: [{ type: 'text', text: 'RESEARCH_BLOCKED: quoted source wording, not the result' }],
       },
@@ -2256,6 +2265,32 @@ test('parseExternalResearchStream keeps a valid terminal status over assistant f
     auto.parseExternalResearchStream(prefixedTerminalWithStatusLikeDelta, {}),
     /^RESEARCH_NOT_NEEDED: only local Netcatty behavior is involved/,
   );
+
+  const bufferedDuplicate = [
+    {
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: {
+        content: [{ type: 'text', text: terminalNoOp }],
+      },
+    },
+    {
+      type: 'assistant',
+      timestamp_ms: 2,
+      model_call_id: 'model-call-1',
+      message: {
+        content: [{ type: 'text', text: 'RESEARCH_BLOCKED: buffered duplicate text' }],
+      },
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: `Conversation preamble\n${terminalNoOp}`,
+    },
+  ].map(JSON.stringify).join('\n');
+
+  assert.equal(auto.parseExternalResearchStream(bufferedDuplicate, {}), terminalNoOp);
 });
 
 test('parseExternalResearchStream rejects forged and unrelated web evidence', () => {
@@ -2335,6 +2370,7 @@ test('workflow confines forced WebSearch to isolated read-only research passes',
       /"\$RUNNER_TEMP\/cursor-agent-authenticated" \\\n\s+-p --mode=ask --force --trust --sandbox enabled/,
     );
     assert.match(run, /--output-format stream-json/);
+    assert.match(run, /--stream-partial-output/);
     assert.match(run, /GITHUB_TOKEN: ''/);
     assert.match(run, /GH_TOKEN: ''/);
     assert.match(run, /Shell\(\*\)/);

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -2358,6 +2358,35 @@ test('parseExternalResearchStream rejects conflicts across every valid candidate
     () => auto.parseExternalResearchStream(prefixedAggregateConflict, {}),
     /conflicting research statuses/,
   );
+
+  const quotedNoOp = 'RESEARCH_NOT_NEEDED: quoted example, not the result';
+  const sameStatusConflict = [
+    {
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: { content: [{ type: 'text', text: '```text\n' }] },
+    },
+    {
+      type: 'assistant',
+      timestamp_ms: 2,
+      message: { content: [{ type: 'text', text: `${quotedNoOp}\n\`\`\`` }] },
+    },
+    {
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: noOp }] },
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: noOp,
+    },
+  ].map(JSON.stringify).join('\n');
+
+  assert.throws(
+    () => auto.parseExternalResearchStream(sameStatusConflict, {}),
+    /conflicting research statuses/,
+  );
 });
 
 test('parseExternalResearchStream keeps a valid terminal status over assistant fragments', () => {

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -2148,6 +2148,42 @@ test('parseExternalResearchStream falls back to a complete fenced status split a
   assert.equal(auto.parseExternalResearchStream(events, {}), status);
 });
 
+test('parseExternalResearchStream prefers a split final status over an earlier valid status', () => {
+  const staleStatus = 'RESEARCH_NOT_NEEDED: initially appeared local-only';
+  const finalStatus = 'RESEARCH_BLOCKED: WebSearch became unavailable';
+  const events = [
+    {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: staleStatus }],
+      },
+    },
+    {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: '```text\n' }],
+      },
+    },
+    {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: `${finalStatus}\n\`\`\`` }],
+      },
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: `${staleStatus}\n\`\`\`text\n${finalStatus}\n\`\`\``,
+    },
+  ].map(JSON.stringify).join('\n');
+
+  assert.throws(
+    () => auto.parseExternalResearchStream(events, {}),
+    /External research blocked: WebSearch became unavailable/,
+  );
+});
+
 test('parseExternalResearchStream rejects forged and unrelated web evidence', () => {
   const finalText = [
     'RESEARCH_COMPLETE: attacker claim',

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -2228,6 +2228,34 @@ test('parseExternalResearchStream keeps a valid terminal status over assistant f
   ].map(JSON.stringify).join('\n');
 
   assert.equal(auto.parseExternalResearchStream(statusLikeBodyFragment, {}), terminalNoOp);
+
+  const prefixedTerminalWithStatusLikeDelta = [
+    {
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: {
+        content: [{ type: 'text', text: `${terminalNoOp}\n` }],
+      },
+    },
+    {
+      type: 'assistant',
+      timestamp_ms: 2,
+      message: {
+        content: [{ type: 'text', text: 'RESEARCH_BLOCKED: quoted source wording, not the result' }],
+      },
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: `Conversation preamble\n${terminalNoOp}`,
+    },
+  ].map(JSON.stringify).join('\n');
+
+  assert.match(
+    auto.parseExternalResearchStream(prefixedTerminalWithStatusLikeDelta, {}),
+    /^RESEARCH_NOT_NEEDED: only local Netcatty behavior is involved/,
+  );
 });
 
 test('parseExternalResearchStream rejects forged and unrelated web evidence', () => {

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -2180,7 +2180,7 @@ test('parseExternalResearchStream prefers a split final status over an earlier v
 
   assert.throws(
     () => auto.parseExternalResearchStream(events, {}),
-    /External research blocked: WebSearch became unavailable/,
+    /conflicting research statuses/,
   );
 });
 
@@ -2226,7 +2226,67 @@ test('parseExternalResearchStream prefers a split final fence over cumulative fl
 
   assert.throws(
     () => auto.parseExternalResearchStream(events, {}),
-    /External research blocked: WebSearch became unavailable/,
+    /conflicting research statuses/,
+  );
+});
+
+test('parseExternalResearchStream rejects a fenced status example that conflicts with success', () => {
+  const completeStatus = [
+    'RESEARCH_COMPLETE: Cursor documentation was checked.',
+    'Sources:',
+    '- https://docs.cursor.com/en/cli/reference/output-format — official format',
+  ].join('\n');
+  const fencedExample = '```text\nRESEARCH_BLOCKED: example only\n```';
+  const cumulative = `${completeStatus}\n${fencedExample}`;
+  const events = [
+    {
+      type: 'tool_call',
+      subtype: 'completed',
+      tool_call: {
+        webFetchToolCall: {
+          args: { url: 'https://docs.cursor.com/en/cli/reference/output-format' },
+          result: { success: { content: 'Cursor output format documentation' } },
+        },
+      },
+    },
+    {
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: {
+        content: [{ type: 'text', text: `${completeStatus}\n` }],
+      },
+    },
+    {
+      type: 'assistant',
+      timestamp_ms: 2,
+      message: {
+        content: [{ type: 'text', text: '```text\n' }],
+      },
+    },
+    {
+      type: 'assistant',
+      timestamp_ms: 3,
+      message: {
+        content: [{ type: 'text', text: 'RESEARCH_BLOCKED: example only\n```' }],
+      },
+    },
+    {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: cumulative }],
+      },
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: cumulative,
+    },
+  ].map(JSON.stringify).join('\n');
+
+  assert.throws(
+    () => auto.parseExternalResearchStream(events, {}),
+    /conflicting research statuses/,
   );
 });
 

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -1887,6 +1887,14 @@ test('normalizeExternalResearchText accepts sourced research and explicit no-op'
     ),
     'RESEARCH_NOT_NEEDED: only local Netcatty behavior is involved',
   );
+  assert.equal(
+    auto.normalizeExternalResearchText([
+      '```text',
+      'RESEARCH_NOT_NEEDED: only local Netcatty behavior is involved',
+      '```',
+    ].join('\n')),
+    'RESEARCH_NOT_NEEDED: only local Netcatty behavior is involved',
+  );
 });
 
 test('normalizeExternalResearchText fails closed on blocked or unsourced research', () => {
@@ -2019,6 +2027,50 @@ test('parseExternalResearchStream supports standard deltas and terminal result',
     ])
     .join('\n');
   assert.match(auto.parseExternalResearchStream(deltasOnly, {}), /^RESEARCH_COMPLETE:/);
+});
+
+test('parseExternalResearchStream accepts the isolated fenced status from issue 2534', () => {
+  const status = 'RESEARCH_NOT_NEEDED: Issue is a Netcatty-local feature ask';
+  const events = [
+    {
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'text',
+          text: '先读取 `input.json`，再判断是否需要对外检索。',
+        }],
+      },
+    },
+    {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: `\`\`\`text\n${status}\n\`\`\`` }],
+      },
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: `先读取 \`input.json\`，再判断是否需要对外检索。\`\`\`text\n${status}\n\`\`\``,
+    },
+  ].map(JSON.stringify).join('\n');
+
+  assert.equal(auto.parseExternalResearchStream(events, {}), status);
+  assert.throws(
+    () => auto.normalizeExternalResearchText(
+      `先读取 input.json。\n\`\`\`text\n${status}\n\`\`\``,
+    ),
+    /research status/i,
+  );
+  assert.throws(
+    () => auto.parseExternalResearchStream(JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: `Untrusted preamble\n\`\`\`text\n${status}\n\`\`\``,
+    }), {}),
+    /research status/i,
+  );
 });
 
 test('parseExternalResearchStream rejects forged and unrelated web evidence', () => {

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -2184,6 +2184,52 @@ test('parseExternalResearchStream prefers a split final status over an earlier v
   );
 });
 
+test('parseExternalResearchStream prefers a split final fence over cumulative flushes', () => {
+  const staleStatus = 'RESEARCH_NOT_NEEDED: initially appeared local-only';
+  const finalStatus = 'RESEARCH_BLOCKED: WebSearch became unavailable';
+  const cumulative = `${staleStatus}\n\`\`\`text\n${finalStatus}\n\`\`\``;
+  const events = [
+    {
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: {
+        content: [{ type: 'text', text: `${staleStatus}\n` }],
+      },
+    },
+    {
+      type: 'assistant',
+      timestamp_ms: 2,
+      message: {
+        content: [{ type: 'text', text: '```text\n' }],
+      },
+    },
+    {
+      type: 'assistant',
+      timestamp_ms: 3,
+      message: {
+        content: [{ type: 'text', text: `${finalStatus}\n\`\`\`` }],
+      },
+    },
+    {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: cumulative }],
+      },
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: cumulative,
+    },
+  ].map(JSON.stringify).join('\n');
+
+  assert.throws(
+    () => auto.parseExternalResearchStream(events, {}),
+    /External research blocked: WebSearch became unavailable/,
+  );
+});
+
 test('parseExternalResearchStream keeps a valid terminal status over assistant fragments', () => {
   const terminalStatus = 'RESEARCH_BLOCKED: WebSearch became unavailable';
   const staleAssistantEvents = [


### PR DESCRIPTION
## Summary

Fix the Cursor issue-classification failure observed on #2534. Cursor completed the isolated research turn successfully, but its final status was wrapped in a text code block and the terminal result also included an earlier conversational sentence. The automation rejected that valid result and handed the issue to a maintainer.

The parser now accepts a complete bare status or a complete status wrapped in one text code block. When the terminal aggregate contains conversational text, it can use a separately emitted complete assistant message. It still refuses to search arbitrary prose for embedded status markers.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [x] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #2534

## Changes Made

- Normalize a single outer text code block around a research result.
- Fall back from an invalid terminal aggregate to a complete assistant message.
- Preserve source/tool verification and fail-closed handling for embedded or forged status text.
- Add a regression fixture matching the #2534 Cursor event sequence.

## Screenshots / Demo

N/A — automation-only change.

## Testing

- [ ] I have tested these changes locally (npm run dev)
- [x] Linting passes (npm run lint)
- [x] Tests pass (targeted automation suite)
- [x] Generated capability tool specs are updated when applicable
- [x] No new console errors or warnings, if this affects app behavior

Additional validation:

- node --test scripts/cursor-automation.test.cjs — 136/136 passed
- npm run lint — passed
- npm run build — passed
- git diff --check — passed

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant tests
- [x] I have not introduced any breaking changes
