### PR TITLE
docs: add privacy and code signing policies

### DIFF
--- a/.github/scripts/generate-release-note.js
+++ b/.github/scripts/generate-release-note.js
@@ -107,6 +107,14 @@ const content = `
 | **Windows** | ${badges.win.setup_x64} |
 | **macOS** | ${badges.mac.apple_silicon} ${badges.mac.intel} |
 | **Linux** | ${badges.linux.appimage_x64} ${badges.linux.deb_x64} ${badges.linux.rpm_x64} ${badges.linux.pacman_x64} <br> ${badges.linux.appimage_arm64} ${badges.linux.deb_arm64} ${badges.linux.rpm_arm64} ${badges.linux.pacman_arm64} |
+
+## Code signing policy
+
+Netcatty is applying to the SignPath Foundation open-source program. Once
+approved, covered Windows release artifacts will use **Free code signing provided by SignPath.io, certificate by SignPath Foundation**.
+See the
+[Code signing policy](https://github.com/${repo}/blob/${tag}/CODE_SIGNING_POLICY.md)
+and [Privacy policy](https://github.com/${repo}/blob/${tag}/PRIVACY.md).
 `;
 
 fs.writeFileSync('release_notes.md', content);

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -1,0 +1,55 @@
+# Netcatty Code Signing Policy
+
+## Status
+
+Netcatty is applying to the SignPath Foundation open-source program. Once the
+application and artifact scope are approved, covered Windows release artifacts
+will use **Free code signing provided by SignPath.io, certificate by SignPath Foundation**.
+Until that approval and integration are complete, Windows release artifacts may
+remain unsigned.
+
+SignPath eligibility and the permitted artifact scope are still subject to
+SignPath Foundation review, including review of separately licensed third-party
+components bundled with optional integrations. Netcatty will not represent an
+artifact as SignPath-signed until that review is complete.
+
+## Source and release provenance
+
+- Official source repository:
+  [binaricat/Netcatty](https://github.com/binaricat/Netcatty)
+- Official releases:
+  [GitHub Releases](https://github.com/binaricat/Netcatty/releases)
+- Release artifacts are built from the official repository with GitHub
+  Actions.
+- Signing requests must originate from the approved build workflow and source
+  revision.
+- A maintainer must approve every production signing request.
+- Third-party binaries are outside the Netcatty publisher-signing scope unless
+  SignPath Foundation explicitly approves them. They retain their upstream
+  signatures or remain unsigned.
+
+## Roles
+
+The project is currently maintained by an individual maintainer.
+
+- Committer and reviewer: [binaricat](https://github.com/binaricat)
+- Signing approver: [binaricat](https://github.com/binaricat)
+
+Changes from other contributors are accepted through pull requests and must be
+reviewed before merge. Changes to release workflows, signing policy, artifact
+configuration, or signing permissions require maintainer review.
+
+## Key protection and revocation
+
+Netcatty maintainers do not receive or store the SignPath Foundation private
+key. Signing is performed by SignPath.io under the approved project and
+artifact policies.
+
+If a signed artifact, release workflow, maintainer account, or signing request
+is suspected to be compromised, the project will stop signing and publishing,
+investigate the incident, notify SignPath Foundation, and request revocation
+when appropriate.
+
+## Privacy
+
+See the [Netcatty Privacy Policy](PRIVACY.md).

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,89 @@
+# Netcatty Privacy Policy
+
+Effective date: July 27, 2026
+
+This policy applies to the Netcatty desktop application distributed through
+the official Netcatty GitHub repository. It does not cover third-party
+websites, services, plugins, command-line agents, or servers that you choose to
+use with Netcatty.
+
+## Summary
+
+Netcatty does not operate a centralized user account, advertising, analytics,
+or crash-reporting service. The Netcatty maintainers do not automatically
+receive your saved hosts, credentials, terminal contents, files, chat history,
+or diagnostic logs.
+
+Netcatty stores application data on your device by default. It connects to
+external services only when required for a feature you use, including update
+checks, remote connections, cloud sync, AI providers, and user-installed or
+user-configured integrations.
+
+## Data stored on your device
+
+Depending on the features you use, Netcatty may store:
+
+- hosts, groups, usernames, notes, snippets, terminal settings, and workspace
+  state;
+- passwords, private keys, passphrases, access tokens, and provider
+  credentials;
+- terminal, file-transfer, editor, and AI conversation state;
+- preferences, update settings, permission decisions, and local diagnostic
+  information.
+
+Sensitive fields are protected using operating-system-backed storage where it
+is available in the packaged desktop application. You remain responsible for
+protecting your device, operating-system account, exported backups, and any
+unencrypted files that you create or export.
+
+You can remove local Netcatty data by deleting it in the application or by
+uninstalling Netcatty and removing its application-data directory. Data kept
+by a third-party service must be removed through that service.
+
+## Network connections and third parties
+
+Netcatty sends data directly to third parties in the following situations:
+
+- **Updates:** Netcatty may contact GitHub to check for and download official
+  releases. GitHub receives normal connection information such as your IP
+  address and request metadata.
+- **Remote access and file transfer:** When you connect through SSH, Telnet,
+  serial, Mosh, SFTP, SCP, port forwarding, or related tools, connection data,
+  terminal input and output, authentication data, and transferred files are
+  exchanged with the destination systems that you select. Private keys remain
+  on your device unless you explicitly transfer or export them.
+- **Cloud sync:** If you enable sync, Netcatty sends an encrypted vault to the
+  provider you choose: GitHub Gist, Google Drive, Microsoft OneDrive, WebDAV,
+  or an S3-compatible service. Encryption and decryption occur on your device.
+  Authentication and account metadata are exchanged with the selected
+  provider.
+- **AI and agent features:** If you configure or use an AI provider or coding
+  agent, prompts, conversation content, selected terminal or workspace
+  context, tool inputs and outputs, and related request metadata may be sent to
+  that provider. The exact data and retention rules are controlled by the
+  provider and your provider account or configuration.
+- **Plugins and custom endpoints:** User-installed plugins, custom AI
+  endpoints, proxy servers, WebDAV servers, S3-compatible services, and other
+  integrations may process data under their own policies.
+
+These services are not operated by the Netcatty maintainers. Review their
+privacy policies and terms before enabling the corresponding feature.
+
+## Diagnostics and support
+
+Netcatty does not automatically upload application logs or crash reports to
+the maintainers. If you attach logs, screenshots, configuration, or other
+diagnostic material to a GitHub issue, discussion, or support request, that
+information is shared by your choice and is governed by the service through
+which you submit it. Remove passwords, private keys, access tokens, host
+details, and other secrets before sharing diagnostic material.
+
+## Changes to this policy
+
+Material changes to this policy will be published in the Netcatty repository.
+The effective date at the top of this document identifies the current version.
+
+## Contact
+
+For privacy questions, open a GitHub discussion or contact
+`binaricat.io@gmail.com`.

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -206,6 +206,14 @@ Netcatty は接続したホストの OS を検出し、ホスト一覧でアイ�
 
 または [GitHub Releases](https://github.com/binaricat/Netcatty/releases) ですべてのリリースを参照してください。
 
+### コード署名とプライバシー
+
+Netcatty は SignPath Foundation のオープンソースプログラムに申請中です。
+承認後、対象となる Windows リリース成果物には **Free code signing provided by SignPath.io, certificate by SignPath Foundation** が使用されます。詳細は
+[コード署名ポリシー](CODE_SIGNING_POLICY.md)と
+[プライバシーポリシー](PRIVACY.md)をご覧ください。申請と導入が完了するまで、
+Windows リリースは未署名の場合があります。
+
 > **Windows のポータブルデータ：** Netcatty を終了し、`Netcatty.exe`（zip 版）またはポータブル版ランチャーと同じ場所に `data` フォルダーを作成してください。次回起動時から、Netcatty はデータをこのフォルダーに保存します。保存済みのパスワードと秘密鍵は、作成した Windows ユーザーによって引き続き保護されます。別のコンピューターまたは Windows ユーザーへ移動した場合は、これらの機密情報を再入力する必要があります。
 
 > **macOS ユーザーへ：** 現在のリリースはコード署名と notarization が行われている想定です。Gatekeeper の警告が出る場合は、GitHub Releases から最新版の公式ビルドを取得しているか確認してください。

--- a/README.md
+++ b/README.md
@@ -207,6 +207,14 @@ Download the latest release for your platform from [GitHub Releases](https://git
 
 Or browse all releases at [GitHub Releases](https://github.com/binaricat/Netcatty/releases).
 
+### Code signing and privacy
+
+Netcatty is applying to the SignPath Foundation open-source program. Once
+approved, covered Windows release artifacts will use **Free code signing provided by SignPath.io, certificate by SignPath Foundation**.
+See the [code signing policy](CODE_SIGNING_POLICY.md) and
+[privacy policy](PRIVACY.md). Windows releases may remain unsigned until the
+application and integration are complete.
+
 > **Windows portable data:** Exit Netcatty, then create a folder named `data` beside `Netcatty.exe` (zip build) or beside the portable launcher. Netcatty will store its profile there on the next launch. Saved passwords and private keys remain protected by the Windows user account that created them, so they must be re-entered after moving the folder to another computer or Windows account.
 
 > **macOS Users:** Current releases are expected to be code-signed and notarized. If Gatekeeper still warns, make sure you downloaded the latest official build from GitHub Releases.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -206,6 +206,13 @@ Netcatty 会自动识别并在主机列表中展示对应的系统图标：
 
 或在 [GitHub Releases](https://github.com/binaricat/Netcatty/releases) 浏览所有版本。
 
+### 代码签名与隐私
+
+Netcatty 正在申请 SignPath Foundation 开源项目计划。申请通过后，适用的
+Windows 发布文件将使用 **Free code signing provided by SignPath.io, certificate by SignPath Foundation**。
+详情见[代码签名政策](CODE_SIGNING_POLICY.md)和[隐私政策](PRIVACY.md)。申请和接入完成前，
+Windows 发布文件可能仍未签名。
+
 > **Windows 便携数据：** 退出 Netcatty，在 `Netcatty.exe`（zip 版）或便携版启动文件旁创建名为 `data` 的文件夹。下次启动后，Netcatty 会把数据保存在这里。已保存的密码和私钥仍受创建它们的 Windows 用户保护；将该文件夹移到其他电脑或 Windows 用户后，需要重新输入这些敏感信息。
 
 > **macOS 用户注意：** 当前发布版本应已完成代码签名和公证。如果 Gatekeeper 仍然提示风险，请确认您下载的是 GitHub Releases 中的最新官方构建。

--- a/scripts/generate-release-note.test.cjs
+++ b/scripts/generate-release-note.test.cjs
@@ -33,4 +33,13 @@ test("release notes include Arch pacman downloads for x64 and arm64", (t) => {
     notes,
     /https:\/\/github\.com\/binaricat\/Netcatty\/releases\/download\/v1\.2\.3\/Netcatty-1\.2\.3-linux-aarch64\.pacman/,
   );
+  assert.match(notes, /Code signing policy/);
+  assert.match(
+    notes,
+    /Free code signing provided by SignPath\.io, certificate by SignPath Foundation/,
+  );
+  assert.match(
+    notes,
+    /https:\/\/github\.com\/binaricat\/Netcatty\/blob\/v1\.2\.3\/CODE_SIGNING_POLICY\.md/,
+  );
 });


### PR DESCRIPTION
## Summary

Add the public privacy and code-signing policies required for the SignPath Foundation open-source application. The wording reflects the current application behavior and clearly states that SignPath approval is still pending.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [x] Documentation update
- [x] Build / CI change
- [ ] Other

## Related Issue (optional)

N/A

## Changes Made

- Add a privacy policy covering local storage, update checks, remote connections, encrypted cloud sync, AI providers, plugins, diagnostics, deletion, and contact details
- Add a code-signing policy with project roles, build provenance, approval, third-party component boundaries, and revocation handling
- Link both policies from the English, Chinese, and Japanese download sections
- Add the required SignPath attribution while keeping the pending and currently unsigned status explicit
- Include the policy links in every generated GitHub Release note
- Add a regression check for generated Release notes

## Screenshots / Demo

Documentation-only change; no UI changes.

## Testing

- [ ] I have tested these changes locally (npm run dev)
- [ ] Linting passes (npm run lint; isolated docs worktree has no dependencies installed)
- [ ] Tests pass (npm test; not run for this documentation-only change)
- [x] Focused Release-note test passes
- [x] All added relative Markdown links resolve
- [x] git diff --check passes
- [x] Independent standards and requirements reviews are clean
- [x] Generated capability tool specs are updated when applicable (not applicable)
- [x] No new console errors or warnings, if this affects app behavior (not applicable)

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes