### PR TITLE
fix(ci): use GITHUB_TOKEN for star history PRs

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -39,10 +39,12 @@ jobs:
             --output "$out_dir/star-history-dark.svg"
 
       # main is protected (require PR + enforce_admins), so direct pushes fail with GH006.
-      # Open/update a fixed-branch PR and merge it when the branch rules allow.
+      # Push the chart branch with RELEASE_TOKEN (checkout credentials), then open/merge
+      # the PR with GITHUB_TOKEN — RELEASE_TOKEN is not granted createPullRequest.
       - name: Commit via pull request
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          # Prefer GITHUB_TOKEN for PR API; fall back is not used for git push auth.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -60,6 +62,7 @@ jobs:
 
           git checkout -B "$branch"
           git commit -m "chore: update star history charts [skip ci]"
+          # Auth comes from actions/checkout (RELEASE_TOKEN), not GH_TOKEN above.
           git push -u origin "HEAD:${branch}" --force
 
           existing="$(

--- a/docs/assets/star-history/README.md
+++ b/docs/assets/star-history/README.md
@@ -30,9 +30,12 @@ Or trigger the **Star History** GitHub Actions workflow
 secret (same PAT already used for release publishing) so no new secret is
 needed. Because `main` requires pull requests (with admin enforcement), the
 workflow never pushes to the default branch directly: it force-updates
-`chore/star-history`, opens or reuses a PR, then squash-merges it. The token
-must be able to:
+`chore/star-history` with `RELEASE_TOKEN`, then opens/reuses and squash-merges
+a PR with the built-in `GITHUB_TOKEN` (PATs often lack `createPullRequest`).
+`RELEASE_TOKEN` must be able to:
 
 - read stargazers (repo admin/collaborator)
 - push the `chore/star-history` branch
-- open and merge pull requests into the default branch
+
+Also ensure the repo setting **Allow GitHub Actions to create and approve pull
+requests** is enabled so `GITHUB_TOKEN` can open the chart PR.


### PR DESCRIPTION
## Summary
- Previous fix still failed: `RELEASE_TOKEN` got `Resource not accessible by personal access token (createPullRequest)`.
- Push chart branch with checkout/`RELEASE_TOKEN`; create and merge PR with `GITHUB_TOKEN`.

## Test plan
- [ ] Merge this PR
- [ ] Run Star History workflow; confirm chart PR is created and merged