### PR TITLE
feat(snippets): open quick add/edit as a centered modal

### DIFF
--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -559,7 +559,7 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
         />
       </div>
 
-      {/* Global "quick add / edit snippet" dialog, triggered by the
+      {/* Global "quick add / edit snippet" modal, triggered by the
           netcatty:snippets:add and :edit window events (from ScriptsSidePanel
           "+" button and right-click menu). Delete is handled by a sibling
           useEffect above — it does not need a dialog. */}

--- a/components/QuickAddSnippetDialog.test.tsx
+++ b/components/QuickAddSnippetDialog.test.tsx
@@ -35,6 +35,11 @@ test("quick add snippet form binds shortkeys and uses a centered Dialog modal", 
   // Escape while recording a shortkey cancels capture instead of closing
   assert.match(source, /onEscapeKeyDown/);
   assert.match(source, /isRecordingShortkey/);
+  // Pointer dismissals must close even while recording (no stale-recording gate)
+  assert.doesNotMatch(
+    source,
+    /if\s*\(\s*isRecordingShortkey\s*\)\s*\{\s*setIsRecordingShortkey\(false\);\s*setShortkeyError\(null\);\s*return;/,
+  );
 });
 
 test("shared Dialog exposes data-dialog-close for Cmd+W / hasOpenAppDialog", () => {

--- a/components/QuickAddSnippetDialog.test.tsx
+++ b/components/QuickAddSnippetDialog.test.tsx
@@ -24,18 +24,20 @@ test("quick add snippet event defaults to an empty command", () => {
   );
 });
 
-test("quick add snippet form binds shortkeys and uses a side panel drawer", () => {
-  assert.match(source, /AsidePanel/);
+test("quick add snippet form binds shortkeys and uses a centered Dialog modal", () => {
+  assert.match(source, /DialogContent/);
+  assert.match(source, /from '\.\/ui\/dialog'/);
+  assert.doesNotMatch(source, /AsidePanel/);
   assert.match(source, /snippets\.field\.shortkey/);
   assert.match(source, /keyEventToString/);
   assert.match(source, /shortkey: shortkey \|\| undefined/);
   assert.match(source, /if \(e\.defaultPrevented\) return/);
-  // Modal contract for hasOpenAppDialog / Cmd+W interception
-  assert.match(source, /role="dialog"/);
-  assert.match(source, /data-state="open"/);
-  assert.match(source, /data-dialog-close="true"/);
-  // Focus trap + restore opener focus
-  assert.match(source, /previouslyFocusedRef/);
-  assert.match(source, /listFocusable/);
-  assert.match(source, /focusin/);
+  // Escape while recording a shortkey cancels capture instead of closing
+  assert.match(source, /onEscapeKeyDown/);
+  assert.match(source, /isRecordingShortkey/);
+});
+
+test("shared Dialog exposes data-dialog-close for Cmd+W / hasOpenAppDialog", () => {
+  const dialogSource = readFileSync(new URL("./ui/dialog.tsx", import.meta.url), "utf8");
+  assert.match(dialogSource, /data-dialog-close="true"/);
 });

--- a/components/QuickAddSnippetDialog.tsx
+++ b/components/QuickAddSnippetDialog.tsx
@@ -316,17 +316,12 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
 
   const handleOpenChange = useCallback((nextOpen: boolean) => {
     if (!nextOpen) {
-      // Keep the dialog open while capturing a shortkey (Escape cancels capture only).
-      if (isRecordingShortkey) {
-        setIsRecordingShortkey(false);
-        setShortkeyError(null);
-        return;
-      }
+      // Escape while recording is gated by onEscapeKeyDown; X/backdrop always close.
       handleClose();
       return;
     }
     setOpen(true);
-  }, [handleClose, isRecordingShortkey]);
+  }, [handleClose]);
 
   const handleSave = useCallback(() => {
     if (!canSave) return;

--- a/components/QuickAddSnippetDialog.tsx
+++ b/components/QuickAddSnippetDialog.tsx
@@ -1,9 +1,9 @@
 /**
- * QuickAddSnippetDialog — lightweight "new snippet" side panel mounted at the
- * App root and triggered by the `netcatty:snippets:add` window event.
+ * QuickAddSnippetDialog — lightweight "new / edit snippet" modal mounted at the
+ * App root and triggered by the `netcatty:snippets:add` / `:edit` window events.
  *
- * Opens as a right-side drawer (AsidePanel) so it matches the host-list
- * create/edit UX. Fields: label, command, package, shortkey, multi-line mode.
+ * Opens as a centered Dialog so it does not compete with the scripts side panel.
+ * Fields: label, command, package, shortkey, multi-line mode.
  * Advanced fields (target hosts, tags) can still be set later in the full
  * Snippets manager.
  */
@@ -21,9 +21,16 @@ import {
 } from '../domain/models';
 import { isScriptSnippet } from '../domain/snippetScript.ts';
 import { cn, isMacPlatform } from '../lib/utils';
-import { AsidePanel, AsidePanelContent, AsidePanelFooter } from './ui/aside-panel';
 import { Button } from './ui/button';
 import { Combobox } from './ui/combobox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog';
 import { Input } from './ui/input';
 import { Label } from './ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
@@ -67,8 +74,6 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
   const [shortkeyError, setShortkeyError] = useState<string | null>(null);
   const [editing, setEditing] = useState<Snippet | null>(null);
   const labelInputRef = useRef<HTMLInputElement>(null);
-  const dialogRootRef = useRef<HTMLDivElement>(null);
-  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
 
   // Listen for the global "add snippet" request dispatched by the
   // terminal-side ScriptsSidePanel + button. We reset form state on
@@ -112,85 +117,12 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
     return () => window.removeEventListener('netcatty:snippets:edit', handler);
   }, []);
 
-  // Capture opener focus on open; restore it when the drawer closes.
-  // Also trap Tab within the drawer so focus cannot fall into the covered terminal.
+  // Focus the label field when the modal opens.
   useEffect(() => {
     if (!open) return;
-    previouslyFocusedRef.current = document.activeElement instanceof HTMLElement
-      ? document.activeElement
-      : null;
-
-    const root = () => dialogRootRef.current;
-
-    const isInsideOpenOverlay = (node: Node | null): boolean => {
-      if (!(node instanceof Element)) return false;
-      // Portaled Select/Combobox content is still part of the modal interaction.
-      if (node.closest('[data-radix-popper-content-wrapper], [role="listbox"]')) return true;
-      return Boolean(root()?.contains(node));
-    };
-
-    const listFocusable = (): HTMLElement[] => {
-      const container = root();
-      if (!container) return [];
-      const nodes = container.querySelectorAll<HTMLElement>(
-        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      );
-      return Array.from(nodes).filter((el) => {
-        if (el.getAttribute('aria-hidden') === 'true') return false;
-        if (el.tabIndex < 0) return false;
-        // Skip the invisible full-screen backdrop and sr-only dialog-close control.
-        if (el.classList.contains('sr-only')) return false;
-        if (el.getAttribute('aria-label') === t('common.cancel') && el.classList.contains('absolute')) {
-          return false;
-        }
-        return el.offsetParent !== null || el === document.activeElement;
-      });
-    };
-
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab' || e.defaultPrevented) return;
-      const focusable = listFocusable();
-      if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      const active = document.activeElement as HTMLElement | null;
-      if (e.shiftKey) {
-        if (!active || active === first || !isInsideOpenOverlay(active)) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else if (!active || active === last || !isInsideOpenOverlay(active)) {
-        e.preventDefault();
-        first.focus();
-      }
-    };
-
-    const onFocusIn = (e: FocusEvent) => {
-      const target = e.target as Node | null;
-      if (isInsideOpenOverlay(target)) return;
-      // Keep focus inside the drawer when something outside tries to steal it.
-      const focusable = listFocusable();
-      (focusable[0] ?? labelInputRef.current)?.focus();
-    };
-
-    // Defer initial focus so AsidePanel / inputs mount first.
     const focusTimer = window.setTimeout(() => labelInputRef.current?.focus(), 50);
-    document.addEventListener('keydown', onKeyDown, true);
-    document.addEventListener('focusin', onFocusIn);
-
-    return () => {
-      window.clearTimeout(focusTimer);
-      document.removeEventListener('keydown', onKeyDown, true);
-      document.removeEventListener('focusin', onFocusIn);
-      const previous = previouslyFocusedRef.current;
-      previouslyFocusedRef.current = null;
-      window.setTimeout(() => {
-        if (previous && document.contains(previous)) {
-          previous.focus();
-        }
-      }, 0);
-    };
-  }, [open, t]);
+    return () => window.clearTimeout(focusTimer);
+  }, [open]);
 
   const isMac = useMemo(() => (
     hotkeyScheme === 'mac' || (hotkeyScheme === 'disabled' && isMacPlatform())
@@ -315,7 +247,7 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
     t,
   ]);
 
-  // Shortkey recording capture. Escape cancels recording only (does not close the panel).
+  // Shortkey recording capture. Escape cancels recording only (does not close the modal).
   useEffect(() => {
     if (!isRecordingShortkey) return;
 
@@ -382,24 +314,19 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
     setShortkeyError(null);
   }, []);
 
-  // Escape dismisses the drawer when not recording a shortkey (matches previous Dialog).
-  // Use bubble phase so nested Select/Combobox can consume Escape first.
-  useEffect(() => {
-    if (!open || isRecordingShortkey) return;
-    const onEscape = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape' || e.defaultPrevented) return;
-      // Nested popovers/listboxes that stay open should keep Escape.
-      if (document.querySelector(
-        '[role="listbox"][data-state="open"], [data-radix-popper-content-wrapper] [data-state="open"]',
-      )) {
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    if (!nextOpen) {
+      // Keep the dialog open while capturing a shortkey (Escape cancels capture only).
+      if (isRecordingShortkey) {
+        setIsRecordingShortkey(false);
+        setShortkeyError(null);
         return;
       }
-      e.preventDefault();
       handleClose();
-    };
-    window.addEventListener('keydown', onEscape);
-    return () => window.removeEventListener('keydown', onEscape);
-  }, [open, isRecordingShortkey, handleClose]);
+      return;
+    }
+    setOpen(true);
+  }, [handleClose, isRecordingShortkey]);
 
   const handleSave = useCallback(() => {
     if (!canSave) return;
@@ -453,7 +380,7 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.defaultPrevented) return;
-      // Cmd/Ctrl+Enter from anywhere in the panel saves the snippet.
+      // Cmd/Ctrl+Enter from anywhere in the modal saves the snippet.
       if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && canSave) {
         e.preventDefault();
         handleSave();
@@ -466,46 +393,29 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
     if (canSave) handleSave();
   }, [canSave, handleSave]);
 
-  if (!open) return null;
-
   return (
-    <div
-      ref={dialogRootRef}
-      className="fixed inset-0 z-50"
-      onKeyDown={handleKeyDown}
-      role="dialog"
-      aria-modal="true"
-      data-state="open"
-      aria-label={t(editing ? 'snippets.panel.editTitle' : 'snippets.panel.newTitle')}
-    >
-      <button
-        type="button"
-        className="absolute inset-0 bg-black/40 cursor-default"
-        aria-label={t('common.cancel')}
-        tabIndex={-1}
-        onClick={handleClose}
-      />
-      {/* Hidden control so Cmd/Ctrl+W / hasOpenAppDialog() treat this drawer as an open dialog. */}
-      <button
-        type="button"
-        data-dialog-close="true"
-        tabIndex={-1}
-        aria-hidden="true"
-        className="sr-only"
-        onClick={handleClose}
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="max-w-2xl w-[min(42rem,calc(100vw-2rem))] max-h-[min(90vh,720px)] flex flex-col gap-0 p-0 overflow-hidden"
+        onKeyDown={handleKeyDown}
+        onEscapeKeyDown={(e) => {
+          if (isRecordingShortkey) {
+            e.preventDefault();
+            setIsRecordingShortkey(false);
+            setShortkeyError(null);
+          }
+        }}
       >
-        {t('common.close')}
-      </button>
-      <AsidePanel
-        open={open}
-        onClose={handleClose}
-        title={t(editing ? 'snippets.panel.editTitle' : 'snippets.panel.newTitle')}
-        subtitle={t('snippets.empty.desc')}
-        layout="overlay"
-        width="w-[400px]"
-        className="shadow-[-16px_0_32px_hsl(var(--foreground)/0.12)]"
-      >
-        <AsidePanelContent>
+        <DialogHeader className="px-6 pt-6 pb-3 shrink-0">
+          <DialogTitle>
+            {t(editing ? 'snippets.panel.editTitle' : 'snippets.panel.newTitle')}
+          </DialogTitle>
+          <DialogDescription>
+            {t('snippets.empty.desc')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex-1 min-h-0 overflow-y-auto px-6 py-2 space-y-4">
           <div className="space-y-1.5">
             <Label htmlFor="quick-add-snippet-label" className="text-xs">
               {t('snippets.field.description')}
@@ -619,19 +529,18 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
             ) : null}
             <p className="text-[11px] text-muted-foreground">{t('snippets.shortkey.hint')}</p>
           </div>
-        </AsidePanelContent>
-        <AsidePanelFooter>
-          <div className="flex gap-2">
-            <Button variant="outline" className="flex-1" onClick={handleClose}>
-              {t('common.cancel')}
-            </Button>
-            <Button className="flex-1" onClick={handleSave} disabled={!canSave}>
-              {t('common.save')}
-            </Button>
-          </div>
-        </AsidePanelFooter>
-      </AsidePanel>
-    </div>
+        </div>
+
+        <DialogFooter className="px-6 py-4 border-t border-border/60 shrink-0 sm:justify-end">
+          <Button variant="outline" onClick={handleClose}>
+            {t('common.cancel')}
+          </Button>
+          <Button onClick={handleSave} disabled={!canSave}>
+            {t('common.save')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 };
 


### PR DESCRIPTION
## Summary

- Convert the scripts side-panel quick add/edit snippet UI from a right-side `AsidePanel` drawer to a centered `Dialog` modal.
- Keep the same form fields (label, command, package, multi-line mode, shortkey) and behavior, including Escape canceling shortkey capture without closing the dialog.
- Widen the modal to `max-w-2xl` so long commands are easier to edit.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- `QuickAddSnippetDialog` now uses shared `Dialog` / `DialogContent` instead of overlay `AsidePanel`.
- Rely on Radix Dialog focus trap / Cmd+W close contract (`data-dialog-close` on shared dialog).
- Update source assertions in `QuickAddSnippetDialog.test.tsx`.
- Comment tweak in `AppView.tsx`.

## Screenshots / Demo

Scripts side panel → right-click snippet → Edit opens a centered modal (not a right drawer).

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)