### PR TITLE
perf(vault): virtualize host pickers for large inventories

### DIFF
--- a/components/CreateWorkspaceDialog.tsx
+++ b/components/CreateWorkspaceDialog.tsx
@@ -1,5 +1,5 @@
 import { Search } from 'lucide-react';
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect, useCallback } from 'react';
 import { useI18n } from '../application/i18n/I18nProvider';
 import { Host } from '../types';
 import { DistroAvatar } from './DistroAvatar';
@@ -7,7 +7,9 @@ import { Button } from './ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from './ui/dialog';
 import { Input } from './ui/input';
 import { Label } from './ui/label';
-import { ScrollArea } from './ui/scroll-area';
+import { FixedSizeVirtualList } from './ui/FixedSizeVirtualList';
+
+const CREATE_WS_HOST_ROW_HEIGHT = 52;
 
 interface CreateWorkspaceDialogProps {
   isOpen: boolean;
@@ -37,7 +39,7 @@ export const CreateWorkspaceDialog: React.FC<CreateWorkspaceDialogProps> = ({
     );
   }, [hosts, search]);
 
-  const toggleHost = (hostId: string) => {
+  const toggleHost = useCallback((hostId: string) => {
     setSelectedHostIds(prev => {
       const next = new Set(prev);
       if (next.has(hostId)) {
@@ -47,7 +49,7 @@ export const CreateWorkspaceDialog: React.FC<CreateWorkspaceDialogProps> = ({
       }
       return next;
     });
-  };
+  }, []);
 
   const handleCreate = () => {
     const selected = hosts.filter(h => selectedHostIds.has(h.id));
@@ -62,6 +64,26 @@ export const CreateWorkspaceDialog: React.FC<CreateWorkspaceDialogProps> = ({
         setSelectedHostIds(new Set());
     }
   }, [isOpen]);
+
+  const renderHostRow = useCallback((host: Host) => {
+    const isSelected = selectedHostIds.has(host.id);
+    return (
+      <div
+        data-host-id={host.id}
+        className={`flex h-full items-center gap-3 px-2 rounded-md cursor-pointer hover:bg-muted/50 ${isSelected ? 'bg-primary/10' : ''}`}
+        onClick={() => toggleHost(host.id)}
+      >
+        <div className={`h-4 w-4 border rounded flex items-center justify-center ${isSelected ? 'bg-primary border-primary' : 'border-muted-foreground'}`}>
+          {isSelected && <div className="h-2 w-2 bg-primary-foreground rounded-sm" />}
+        </div>
+        <DistroAvatar host={host} size="sm" fallback={host.label.slice(0, 2).toUpperCase()} />
+        <div className="flex-1 min-w-0">
+          <div className="font-medium truncate">{host.label}</div>
+          <div className="text-xs text-muted-foreground truncate">{host.hostname}</div>
+        </div>
+      </div>
+    );
+  }, [selectedHostIds, toggleHost]);
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -94,36 +116,21 @@ export const CreateWorkspaceDialog: React.FC<CreateWorkspaceDialogProps> = ({
                 />
             </div>
 
-            <div className="border rounded-md flex-1 min-h-[200px]">
-                <ScrollArea className="h-full max-h-[300px]">
-                    <div className="p-2 space-y-1">
-                        {filteredHosts.length === 0 ? (
-                            <div className="text-center py-4 text-sm text-muted-foreground">
-                                {t('common.noResults', { defaultValue: 'No hosts found' })}
-                            </div>
-                        ) : (
-                            filteredHosts.map(host => {
-                                const isSelected = selectedHostIds.has(host.id);
-                                return (
-                                    <div
-                                        key={host.id}
-                                        className={`flex items-center gap-3 p-2 rounded-md cursor-pointer hover:bg-muted/50 ${isSelected ? 'bg-primary/10' : ''}`}
-                                        onClick={() => toggleHost(host.id)}
-                                    >
-                                        <div className={`h-4 w-4 border rounded flex items-center justify-center ${isSelected ? 'bg-primary border-primary' : 'border-muted-foreground'}`}>
-                                            {isSelected && <div className="h-2 w-2 bg-primary-foreground rounded-sm" />}
-                                        </div>
-                                        <DistroAvatar host={host} size="sm" fallback={host.label.slice(0, 2).toUpperCase()} />
-                                        <div className="flex-1 min-w-0">
-                                            <div className="font-medium truncate">{host.label}</div>
-                                            <div className="text-xs text-muted-foreground truncate">{host.hostname}</div>
-                                        </div>
-                                    </div>
-                                );
-                            })
-                        )}
+            <div className="border rounded-md h-[300px] min-h-[200px]" data-host-picker-virtual="create-workspace">
+                {filteredHosts.length === 0 ? (
+                    <div className="text-center py-4 text-sm text-muted-foreground">
+                        {t('common.noResults', { defaultValue: 'No hosts found' })}
                     </div>
-                </ScrollArea>
+                ) : (
+                    <FixedSizeVirtualList
+                      items={filteredHosts}
+                      itemHeight={CREATE_WS_HOST_ROW_HEIGHT}
+                      className="h-full"
+                      overscan={8}
+                      getItemKey={(host) => host.id}
+                      renderItem={renderHostRow}
+                    />
+                )}
             </div>
             <div className="text-xs text-muted-foreground text-right">
                 {selectedHostIds.size} {t('common.selected', { defaultValue: 'selected' })}

--- a/components/QuickSwitcher.pluginContributions.test.tsx
+++ b/components/QuickSwitcher.pluginContributions.test.tsx
@@ -11,11 +11,12 @@ import {
 test('keeps the new workspace action outside the scrollable results', () => {
   const source = readFileSync(new URL('./QuickSwitcher.tsx', import.meta.url), 'utf8');
   const actionIndex = source.indexOf('{/* Jump To hint + New Workspace action */}');
-  const resultsScrollIndex = source.indexOf('<ScrollArea className="flex-1 h-full">');
+  const resultsScrollIndex = source.indexOf('data-host-picker-virtual="quick-switcher"');
 
   assert.notEqual(actionIndex, -1);
   assert.notEqual(resultsScrollIndex, -1);
   assert.ok(actionIndex < resultsScrollIndex);
+  assert.match(source, /VariableSizeVirtualList/);
 });
 
 test('pointer hover never rewrites the keyboard selection', () => {

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -102,44 +102,21 @@ export function buildPluginPaletteItems(
 }
 import { DistroAvatar } from "./DistroAvatar";
 import { Input } from "./ui/input";
-import { ScrollArea } from "./ui/scroll-area";
+import {
+  VariableSizeVirtualList,
+  type VariableSizeVirtualListHandle,
+} from "./ui/VariableSizeVirtualList";
+import { clampListIndex, stepListIndex } from "./ui/virtualListMath";
 
 // Compute once at module level
 const IS_MAC = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform);
 
-// Memoized host item component to prevent unnecessary re-renders
-const HostItem = memo(({
-  host,
-  isSelected,
-  isKeyboardNavigating,
-  selectedItemRef,
-  onSelect,
-}: {
-  host: Host;
-  isSelected: boolean;
-  isKeyboardNavigating: boolean;
-  selectedItemRef?: React.RefCallback<HTMLDivElement>;
-  onSelect: (host: Host) => void;
-}) => (
-  <div
-    ref={selectedItemRef}
-    className={`flex items-center justify-between px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`}
-    onClick={() => onSelect(host)}
-  >
-    <div className="flex items-center gap-3 min-w-0">
-      <DistroAvatar
-        host={host}
-        fallback={host.label.slice(0, 2).toUpperCase()}
-        size="sm"
-      />
-      <span className="text-sm font-medium truncate">{host.label}</span>
-    </div>
-    <div className="text-[11px] text-muted-foreground">
-      {host.group ? `Personal / ${host.group}` : "Personal"}
-    </div>
-  </div>
-));
-HostItem.displayName = "HostItem";
+const QS_ROW_HEIGHT = 44;
+const QS_HEADER_HEIGHT = 32;
+
+type QuickSwitcherVisualRow =
+  | { kind: "header"; key: string; label: string }
+  | { kind: "item"; key: string; item: QuickSwitcherItem; itemIndex: number };
 
 interface QuickSwitcherProps {
   isOpen: boolean;
@@ -209,10 +186,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
   const isKeyboardNavigatingRef = useRef(true);
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const selectedItemRef = useRef<HTMLElement>(null);
-  const setSelectedItemRef = useCallback((element: HTMLElement | null) => {
-    selectedItemRef.current = element;
-  }, []);
+  const listRef = useRef<VariableSizeVirtualListHandle>(null);
   const handlePointerHover = useCallback((movementX: number, movementY: number) => {
     if (!shouldUseQuickSwitcherPointerNavigation(movementX, movementY)) return;
     if (!isKeyboardNavigatingRef.current) return;
@@ -294,70 +268,103 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
     trimmedQuery,
   ), [pluginContributions.snapshot.plugins, trimmedQuery]);
 
-  // Always show categorized view (Hosts/Tabs/Quick connect)
-  const showCategorized = true;
-
-  // Memoize flat items list and index map
-  const { flatItems, itemIndexMap } = useMemo(() => {
+  // Memoize flat selectable items + visual rows (headers + items) for virtualization.
+  const { flatItems, visualRows, itemIndexToVisualIndex } = useMemo(() => {
     const items: QuickSwitcherItem[] = [];
+    const visual: QuickSwitcherVisualRow[] = [];
+    const itemToVisual = new Map<number, number>();
 
-    if (showCategorized) {
-      // Hosts
-      results.forEach((host) =>
-        items.push({ type: "host", id: host.id, data: host }),
-      );
-      // Tabs (built-in + sessions + workspaces)
-      builtInTabs.forEach((tabId) => {
-        items.push({ type: "tab", id: tabId });
+    const pushHeader = (key: string, label: string) => {
+      visual.push({ kind: "header", key, label });
+    };
+    const pushItem = (item: QuickSwitcherItem) => {
+      const itemIndex = items.length;
+      items.push(item);
+      itemToVisual.set(itemIndex, visual.length);
+      visual.push({
+        kind: "item",
+        key: `${item.type}:${item.id}`,
+        item,
+        itemIndex,
       });
-      filteredOrphanSessions.forEach((s) =>
-        items.push({ type: "tab", id: s.id, data: s }),
-      );
-      filteredWorkspaces.forEach((w) =>
-        items.push({ type: "workspace", id: w.id, data: w }),
-      );
-      // Local shells (or fallback action if discovery not ready)
-      if (filteredShells.length > 0) {
-        filteredShells.forEach((shell) =>
-          items.push({ type: "shell", id: shell.id }),
-        );
-      } else if (shouldShowLocalTerminalFallback) {
-        items.push({ type: "action", id: "local-terminal" });
-      }
-      items.push(...pluginPaletteItems);
-    } else {
-      // Recent connections only
+    };
+
+    if (results.length > 0) {
+      pushHeader("header:hosts", "Hosts");
       results.forEach((host) =>
-        items.push({ type: "host", id: host.id, data: host }),
+        pushItem({ type: "host", id: host.id, data: host }),
       );
-      // Also include matching shells in search results
-      filteredShells.forEach((shell) =>
-        items.push({ type: "shell", id: shell.id }),
-      );
-      items.push(...pluginPaletteItems);
     }
 
-    // Build index map for O(1) lookup
-    const indexMap = new Map<string, number>();
-    items.forEach((item, idx) => {
-      indexMap.set(`${item.type}:${item.id}`, idx);
-    });
+    const hasTabsSection =
+      builtInTabs.length > 0
+      || filteredOrphanSessions.length > 0
+      || filteredWorkspaces.length > 0;
+    if (hasTabsSection) {
+      pushHeader("header:tabs", "Tabs");
+      builtInTabs.forEach((tabId) => {
+        pushItem({ type: "tab", id: tabId });
+      });
+      filteredWorkspaces.forEach((w) =>
+        pushItem({ type: "workspace", id: w.id, data: w }),
+      );
+      filteredOrphanSessions.forEach((s) =>
+        pushItem({ type: "tab", id: s.id, data: s }),
+      );
+    }
 
-    return { flatItems: items, itemIndexMap: indexMap };
-  }, [showCategorized, results, builtInTabs, filteredOrphanSessions, filteredWorkspaces, filteredShells, shouldShowLocalTerminalFallback, pluginPaletteItems]);
+    if (filteredShells.length > 0) {
+      pushHeader("header:shells", t("qs.localShells"));
+      filteredShells.forEach((shell) =>
+        pushItem({ type: "shell", id: shell.id }),
+      );
+    } else if (shouldShowLocalTerminalFallback) {
+      pushHeader("header:shells", t("qs.localShells"));
+      pushItem({ type: "action", id: "local-terminal" });
+    }
 
-  // O(1) index lookup
-  const getItemIndex = useCallback((type: string, id: string) => {
-    return itemIndexMap.get(`${type}:${id}`) ?? -1;
-  }, [itemIndexMap]);
+    if (pluginPaletteItems.length > 0) {
+      pushHeader("header:plugins", t("settings.tab.plugins"));
+      pluginPaletteItems.forEach((item) => pushItem(item));
+    }
 
-  const selectedItem = flatItems[selectedIndex];
-  const selectedItemKey = selectedItem ? `${selectedItem.type}:${selectedItem.id}` : '';
+    return {
+      flatItems: items,
+      visualRows: visual,
+      itemIndexToVisualIndex: itemToVisual,
+    };
+  }, [
+    builtInTabs,
+    filteredOrphanSessions,
+    filteredShells,
+    filteredWorkspaces,
+    pluginPaletteItems,
+    results,
+    shouldShowLocalTerminalFallback,
+    t,
+  ]);
 
   useEffect(() => {
-    if (!isOpen || !selectedItemKey) return;
-    selectedItemRef.current?.scrollIntoView({ block: "nearest" });
-  }, [isOpen, selectedIndex, selectedItemKey]);
+    if (!isOpen) return;
+    setSelectedIndex((prev) => clampListIndex(prev, flatItems.length));
+  }, [flatItems.length, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const visualIndex = itemIndexToVisualIndex.get(selectedIndex);
+    if (visualIndex === undefined) return;
+    listRef.current?.scrollToIndex(visualIndex, "auto");
+  }, [isOpen, itemIndexToVisualIndex, selectedIndex]);
+
+  const shellById = useMemo(
+    () => new Map(quickSwitcherShells.map((shell) => [shell.id, shell])),
+    [quickSwitcherShells],
+  );
+
+  const getRowHeight = useCallback(
+    (row: QuickSwitcherVisualRow) => (row.kind === "header" ? QS_HEADER_HEIGHT : QS_ROW_HEIGHT),
+    [],
+  );
 
   if (!isOpen) return null;
 
@@ -366,15 +373,16 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
       e.preventDefault();
       isKeyboardNavigatingRef.current = true;
       setIsKeyboardNavigating(true);
-      setSelectedIndex((prev) => Math.min(prev + 1, flatItems.length - 1));
+      setSelectedIndex((prev) => stepListIndex(prev, flatItems.length, 1));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       isKeyboardNavigatingRef.current = true;
       setIsKeyboardNavigating(true);
-      setSelectedIndex((prev) => Math.max(prev - 1, 0));
+      setSelectedIndex((prev) => stepListIndex(prev, flatItems.length, -1));
     } else if (e.key === "Enter" && flatItems.length > 0) {
       e.preventDefault();
-      const item = flatItems[selectedIndex];
+      const item = flatItems[clampListIndex(selectedIndex, flatItems.length)];
+      if (!item) return;
       handleItemSelect(item, e.altKey);
     }
   };
@@ -477,105 +485,77 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
           )}
         </div>
 
-        <ScrollArea className="flex-1 h-full">
-          {/* Categorized view: Hosts/Tabs/Quick connect */}
-          <div>
-            {/* Hosts section */}
-            {results.length > 0 && (
-              <div>
-                <div className="px-4 py-1.5">
-                  <span className="text-xs font-medium text-muted-foreground">
-                    Hosts
-                  </span>
-                </div>
-                {results.map((host) => (
-                  <HostItem
-                    key={host.id}
-                    host={host}
-                    isSelected={getItemIndex("host", host.id) === selectedIndex}
-                    isKeyboardNavigating={isKeyboardNavigating}
-                    selectedItemRef={getItemIndex("host", host.id) === selectedIndex ? setSelectedItemRef : undefined}
-                    onSelect={onSelect}
-                  />
-                ))}
-              </div>
-            )}
-
-            {/* Tabs section */}
-            <div>
-              <div className="px-4 py-1.5">
-                <span className="text-xs font-medium text-muted-foreground">
-                  Tabs
-                </span>
-              </div>
-
-              {/* Built-in tabs */}
-              {builtInTabs.map((tabId) => {
-                const idx = getItemIndex("tab", tabId);
-                const isSelected = idx === selectedIndex;
-                const icon =
-                  tabId === "vault" ? (
-                    <FolderLock size={16} />
-                  ) : (
-                    <Folder size={16} />
-                  );
-                const label = tabId === "vault" ? "Vaults" : "SFTP";
-
+        <div className="min-h-0 flex-1" data-host-picker-virtual="quick-switcher">
+          <VariableSizeVirtualList<QuickSwitcherVisualRow>
+            ref={listRef}
+            items={visualRows}
+            getItemHeight={getRowHeight}
+            className="h-full"
+            overscan={8}
+            getItemKey={(row) => row.key}
+            renderItem={(row) => {
+              if (row.kind === "header") {
                 return (
-                  <div
-                    key={tabId}
-                    ref={isSelected ? setSelectedItemRef : undefined}
-                    className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`}
-                    onClick={() => {
-                      onSelectTab(tabId);
-                      onClose();
-                    }}
-                  >
-                    <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
-                      {icon}
-                    </div>
-                    <span className="text-sm font-medium">{label}</span>
-                  </div>
-                );
-              })}
-
-              {/* Workspaces */}
-              {filteredWorkspaces.map((workspace) => {
-                const idx = getItemIndex("workspace", workspace.id);
-                const isSelected = idx === selectedIndex;
-
-                return (
-                  <div
-                    key={workspace.id}
-                    ref={isSelected ? setSelectedItemRef : undefined}
-                    className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`}
-                    onClick={() => {
-                      onSelectTab(workspace.id);
-                      onClose();
-                    }}
-                  >
-                    <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
-                      <LayoutGrid size={16} />
-                    </div>
-                    <span className="text-sm font-medium">
-                      {workspace.title}
+                  <div className="flex h-full items-end px-4 pb-1.5">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      {row.label}
                     </span>
                   </div>
                 );
-              })}
+              }
 
-              {/* Orphan sessions */}
-              {filteredOrphanSessions.map((session) => {
-                const idx = getItemIndex("tab", session.id);
-                const isSelected = idx === selectedIndex;
+              const { item, itemIndex } = row;
+              const isSelected = itemIndex === selectedIndex;
+              const rowClass = `flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`;
 
+              if (item.type === "host") {
+                const host = item.data as Host;
                 return (
                   <div
-                    key={session.id}
-                    ref={isSelected ? setSelectedItemRef : undefined}
-                    className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`}
+                    className={`flex items-center justify-between px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`}
+                    onClick={() => onSelect(host)}
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <DistroAvatar
+                        host={host}
+                        fallback={host.label.slice(0, 2).toUpperCase()}
+                        size="sm"
+                      />
+                      <span className="text-sm font-medium truncate">{host.label}</span>
+                    </div>
+                    <div className="text-[11px] text-muted-foreground">
+                      {host.group ? `Personal / ${host.group}` : "Personal"}
+                    </div>
+                  </div>
+                );
+              }
+
+              if (item.type === "tab") {
+                const isBuiltIn = item.id === "vault" || item.id === "sftp";
+                if (isBuiltIn) {
+                  const icon = item.id === "vault" ? <FolderLock size={16} /> : <Folder size={16} />;
+                  const label = item.id === "vault" ? "Vaults" : "SFTP";
+                  return (
+                    <div
+                      className={rowClass}
+                      onClick={() => {
+                        onSelectTab(item.id);
+                        onClose();
+                      }}
+                    >
+                      <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
+                        {icon}
+                      </div>
+                      <span className="text-sm font-medium">{label}</span>
+                    </div>
+                  );
+                }
+                const session = item.data as TerminalSession | undefined;
+                return (
+                  <div
+                    className={rowClass}
                     onClick={() => {
-                      onSelectTab(session.id);
+                      onSelectTab(item.id);
                       onClose();
                     }}
                   >
@@ -583,110 +563,108 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                       <TerminalSquare size={16} />
                     </div>
                     <span className="text-sm font-medium">
-                      {session.hostLabel}
+                      {session?.hostLabel ?? item.id}
                     </span>
                   </div>
                 );
-              })}
-            </div>
+              }
 
-            {/* Local Shells section */}
-            {/* Local Shells or fallback Local Terminal */}
-            {filteredShells.length > 0 ? (
-              <div>
-                <div className="px-4 py-1.5">
-                  <span className="text-xs font-medium text-muted-foreground">
-                    {t("qs.localShells")}
-                  </span>
-                </div>
-                {filteredShells.map((shell) => {
-                  const idx = getItemIndex("shell", shell.id);
-                  const isSelected = idx === selectedIndex;
-                  return (
-                    <div
-                      key={shell.id}
-                      ref={isSelected ? setSelectedItemRef : undefined}
-                      className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`}
-                      onClick={() => {
-                        if (onCreateLocalTerminal) {
-                          onCreateLocalTerminal({ command: shell.command, args: shell.args, name: shell.name, icon: shell.icon });
-                          onClose();
-                        }
-                      }}
-                    >
-                      <img
-                        src={getShellIconPath(shell.icon)}
-                        alt={shell.name}
-                        className={`h-6 w-6 shrink-0${isMonochromeShellIcon(shell.icon) ? " dark:invert" : ""}`}
-                      />
-                      <span className="text-sm font-medium">{shell.name}</span>
-                      {shell.isDefault && (
-                        <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
-                          {t("qs.default")}
-                        </span>
-                      )}
+              if (item.type === "workspace") {
+                const workspace = item.data as Workspace | undefined;
+                return (
+                  <div
+                    className={rowClass}
+                    onClick={() => {
+                      onSelectTab(item.id);
+                      onClose();
+                    }}
+                  >
+                    <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
+                      <LayoutGrid size={16} />
                     </div>
-                  );
-                })}
-              </div>
-            ) : shouldShowLocalTerminalFallback && (
-              <div>
-                <div className="px-4 py-1.5">
-                  <span className="text-xs font-medium text-muted-foreground">
-                    {t("qs.localShells")}
-                  </span>
-                </div>
-                <div
-                  ref={getItemIndex("action", "local-terminal") === selectedIndex ? setSelectedItemRef : undefined}
-                  className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(
-                    getItemIndex("action", "local-terminal") === selectedIndex,
-                    isKeyboardNavigating,
-                  )}`}
-                  onClick={() => {
-                    onCreateLocalTerminal();
-                    onClose();
-                  }}
-                >
-                  <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
-                    <Terminal size={16} />
+                    <span className="text-sm font-medium">
+                      {workspace?.title ?? item.id}
+                    </span>
                   </div>
-                  <span className="text-sm font-medium">{t("qs.localTerminal")}</span>
-                </div>
-              </div>
-            )}
+                );
+              }
 
-            {pluginPaletteItems.length > 0 && (
-              <div>
-                <div className="px-4 py-1.5">
-                  <span className="text-xs font-medium text-muted-foreground">{t('settings.tab.plugins')}</span>
-                </div>
-                {pluginPaletteItems.map((item) => {
-                  const idx = getItemIndex(item.type, item.id);
-                  const isSelected = idx === selectedIndex;
-                  return (
-                    <button
-                      type="button"
-                      key={`${item.type}:${item.id}`}
-                      ref={isSelected ? setSelectedItemRef : undefined}
-                      disabled={item.enabled === false}
-                      className={`flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)} disabled:opacity-50`}
-                      onClick={(event) => handleItemSelect(item, event.altKey)}
-                    >
-                      <div className="flex h-6 w-6 items-center justify-center text-muted-foreground">
-                        <PluginContributionIcon pluginId={item.pluginId} icon={item.icon} size={16} />
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <div className="truncate text-sm font-medium">{item.title}</div>
-                        <div className="truncate text-[10px] text-muted-foreground">{item.pluginTitle}</div>
-                      </div>
-                      {item.shortcut && <kbd className="text-[10px] text-muted-foreground">{item.shortcut}</kbd>}
-                    </button>
-                  );
-                })}
-              </div>
-            )}
-          </div>
-        </ScrollArea>
+              if (item.type === "shell") {
+                const shell = shellById.get(item.id);
+                if (!shell) return null;
+                return (
+                  <div
+                    className={rowClass}
+                    onClick={() => {
+                      if (onCreateLocalTerminal) {
+                        onCreateLocalTerminal({
+                          command: shell.command,
+                          args: shell.args,
+                          name: shell.name,
+                          icon: shell.icon,
+                        });
+                        onClose();
+                      }
+                    }}
+                  >
+                    <img
+                      src={getShellIconPath(shell.icon)}
+                      alt={shell.name}
+                      className={`h-6 w-6 shrink-0${isMonochromeShellIcon(shell.icon) ? " dark:invert" : ""}`}
+                    />
+                    <span className="text-sm font-medium">{shell.name}</span>
+                    {shell.isDefault && (
+                      <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                        {t("qs.default")}
+                      </span>
+                    )}
+                  </div>
+                );
+              }
+
+              if (item.type === "action" && item.id === "local-terminal") {
+                return (
+                  <div
+                    className={rowClass}
+                    onClick={() => {
+                      onCreateLocalTerminal?.();
+                      onClose();
+                    }}
+                  >
+                    <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
+                      <Terminal size={16} />
+                    </div>
+                    <span className="text-sm font-medium">{t("qs.localTerminal")}</span>
+                  </div>
+                );
+              }
+
+              if (item.type === "plugin-command" || item.type === "plugin-view") {
+                return (
+                  <button
+                    type="button"
+                    disabled={item.enabled === false}
+                    className={`flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)} disabled:opacity-50`}
+                    onClick={(event) => handleItemSelect(item, event.altKey)}
+                  >
+                    <div className="flex h-6 w-6 items-center justify-center text-muted-foreground">
+                      <PluginContributionIcon pluginId={item.pluginId} icon={item.icon} size={16} />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium">{item.title}</div>
+                      <div className="truncate text-[10px] text-muted-foreground">{item.pluginTitle}</div>
+                    </div>
+                    {item.shortcut && (
+                      <kbd className="text-[10px] text-muted-foreground">{item.shortcut}</kbd>
+                    )}
+                  </button>
+                );
+              }
+
+              return null;
+            }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -112,6 +112,8 @@ import { clampListIndex, stepListIndex } from "./ui/virtualListMath";
 const IS_MAC = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform);
 
 const QS_ROW_HEIGHT = 44;
+/** Two-line plugin rows (title + plugin name) with py-2.5 exceed QS_ROW_HEIGHT. */
+const QS_PLUGIN_ROW_HEIGHT = 56;
 const QS_HEADER_HEIGHT = 32;
 
 type QuickSwitcherVisualRow =
@@ -361,10 +363,13 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
     [quickSwitcherShells],
   );
 
-  const getRowHeight = useCallback(
-    (row: QuickSwitcherVisualRow) => (row.kind === "header" ? QS_HEADER_HEIGHT : QS_ROW_HEIGHT),
-    [],
-  );
+  const getRowHeight = useCallback((row: QuickSwitcherVisualRow) => {
+    if (row.kind === "header") return QS_HEADER_HEIGHT;
+    if (row.item.type === "plugin-command" || row.item.type === "plugin-view") {
+      return QS_PLUGIN_ROW_HEIGHT;
+    }
+    return QS_ROW_HEIGHT;
+  }, []);
 
   if (!isOpen) return null;
 

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -496,12 +496,17 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
           )}
         </div>
 
-        <div className="min-h-0 flex-1" data-host-picker-virtual="quick-switcher">
+        {/*
+          max-h on the list is required: the popup only has max-h-[520px], so a bare
+          h-full child can expand with the virtual spacer and get clipped with no scroll.
+          Cap the scroller so large inventories remain reachable.
+        */}
+        <div className="min-h-0 flex-1 overflow-hidden" data-host-picker-virtual="quick-switcher">
           <VariableSizeVirtualList<QuickSwitcherVisualRow>
             ref={listRef}
             items={visualRows}
             getItemHeight={getRowHeight}
-            className="h-full"
+            className="h-full max-h-[min(360px,calc(100vh-14rem))]"
             overscan={8}
             getItemKey={(row) => row.key}
             renderItem={(row) => {

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -517,24 +517,25 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
 
               const { item, itemIndex } = row;
               const isSelected = itemIndex === selectedIndex;
-              const rowClass = `flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`;
+              // Fixed virtual slots: keep content single-line (or plugin two-line) and clip overflow.
+              const rowClass = `flex h-full min-h-0 items-center gap-3 overflow-hidden px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`;
 
               if (item.type === "host") {
                 const host = item.data as Host;
                 return (
                   <div
-                    className={`flex items-center justify-between px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`}
+                    className={`flex h-full min-h-0 items-center justify-between overflow-hidden px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`}
                     onClick={() => onSelect(host)}
                   >
-                    <div className="flex items-center gap-3 min-w-0">
+                    <div className="flex min-w-0 items-center gap-3">
                       <DistroAvatar
                         host={host}
                         fallback={host.label.slice(0, 2).toUpperCase()}
                         size="sm"
                       />
-                      <span className="text-sm font-medium truncate">{host.label}</span>
+                      <span className="truncate text-sm font-medium">{host.label}</span>
                     </div>
-                    <div className="text-[11px] text-muted-foreground">
+                    <div className="ml-3 max-w-[12rem] shrink-0 truncate text-[11px] text-muted-foreground">
                       {host.group ? `Personal / ${host.group}` : "Personal"}
                     </div>
                   </div>
@@ -554,10 +555,10 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                         onClose();
                       }}
                     >
-                      <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
+                      <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground">
                         {icon}
                       </div>
-                      <span className="text-sm font-medium">{label}</span>
+                      <span className="truncate text-sm font-medium">{label}</span>
                     </div>
                   );
                 }
@@ -570,10 +571,10 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                       onClose();
                     }}
                   >
-                    <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
+                    <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground">
                       <TerminalSquare size={16} />
                     </div>
-                    <span className="text-sm font-medium">
+                    <span className="min-w-0 truncate text-sm font-medium">
                       {session?.hostLabel ?? item.id}
                     </span>
                   </div>
@@ -590,10 +591,10 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                       onClose();
                     }}
                   >
-                    <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
+                    <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground">
                       <LayoutGrid size={16} />
                     </div>
-                    <span className="text-sm font-medium">
+                    <span className="min-w-0 truncate text-sm font-medium">
                       {workspace?.title ?? item.id}
                     </span>
                   </div>
@@ -623,9 +624,9 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                       alt={shell.name}
                       className={`h-6 w-6 shrink-0${isMonochromeShellIcon(shell.icon) ? " dark:invert" : ""}`}
                     />
-                    <span className="text-sm font-medium">{shell.name}</span>
+                    <span className="min-w-0 truncate text-sm font-medium">{shell.name}</span>
                     {shell.isDefault && (
-                      <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                      <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
                         {t("qs.default")}
                       </span>
                     )}
@@ -642,10 +643,10 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                       onClose();
                     }}
                   >
-                    <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
+                    <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground">
                       <Terminal size={16} />
                     </div>
-                    <span className="text-sm font-medium">{t("qs.localTerminal")}</span>
+                    <span className="truncate text-sm font-medium">{t("qs.localTerminal")}</span>
                   </div>
                 );
               }
@@ -655,10 +656,10 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                   <button
                     type="button"
                     disabled={item.enabled === false}
-                    className={`flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)} disabled:opacity-50`}
+                    className={`flex h-full min-h-0 w-full items-center gap-3 overflow-hidden px-4 py-2.5 text-left transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)} disabled:opacity-50`}
                     onClick={(event) => handleItemSelect(item, event.altKey)}
                   >
-                    <div className="flex h-6 w-6 items-center justify-center text-muted-foreground">
+                    <div className="flex h-6 w-6 shrink-0 items-center justify-center text-muted-foreground">
                       <PluginContributionIcon pluginId={item.pluginId} icon={item.icon} size={16} />
                     </div>
                     <div className="min-w-0 flex-1">
@@ -666,7 +667,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                       <div className="truncate text-[10px] text-muted-foreground">{item.pluginTitle}</div>
                     </div>
                     {item.shortcut && (
-                      <kbd className="text-[10px] text-muted-foreground">{item.shortcut}</kbd>
+                      <kbd className="shrink-0 text-[10px] text-muted-foreground">{item.shortcut}</kbd>
                     )}
                   </button>
                 );

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -112,13 +112,22 @@ import { clampListIndex, stepListIndex } from "./ui/virtualListMath";
 const IS_MAC = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform);
 
 const QS_ROW_HEIGHT = 44;
-/** Two-line plugin rows (title + plugin name) with py-2.5 exceed QS_ROW_HEIGHT. */
+/** Two-line plugin command/view rows (title + subtitle + py-2.5) need a taller slot. */
 const QS_PLUGIN_ROW_HEIGHT = 56;
 const QS_HEADER_HEIGHT = 32;
 
 type QuickSwitcherVisualRow =
   | { kind: "header"; key: string; label: string }
   | { kind: "item"; key: string; item: QuickSwitcherItem; itemIndex: number };
+
+/** Exported for tests — must match VariableSizeVirtualList absolute slot heights. */
+export function getQuickSwitcherVisualRowHeight(row: QuickSwitcherVisualRow): number {
+  if (row.kind === "header") return QS_HEADER_HEIGHT;
+  if (row.item.type === "plugin-command" || row.item.type === "plugin-view") {
+    return QS_PLUGIN_ROW_HEIGHT;
+  }
+  return QS_ROW_HEIGHT;
+}
 
 interface QuickSwitcherProps {
   isOpen: boolean;
@@ -363,13 +372,10 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
     [quickSwitcherShells],
   );
 
-  const getRowHeight = useCallback((row: QuickSwitcherVisualRow) => {
-    if (row.kind === "header") return QS_HEADER_HEIGHT;
-    if (row.item.type === "plugin-command" || row.item.type === "plugin-view") {
-      return QS_PLUGIN_ROW_HEIGHT;
-    }
-    return QS_ROW_HEIGHT;
-  }, []);
+  const getRowHeight = useCallback(
+    (row: QuickSwitcherVisualRow) => getQuickSwitcherVisualRowHeight(row),
+    [],
+  );
 
   if (!isOpen) return null;
 

--- a/components/SelectHostPanelContent.tsx
+++ b/components/SelectHostPanelContent.tsx
@@ -8,7 +8,7 @@ import {
   Search,
   Square,
 } from 'lucide-react';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '../lib/utils';
 import { matchesHostSearchQuery, matchesSearchQuery } from '../lib/searchMatcher';
 import { useI18n } from '../application/i18n/I18nProvider';
@@ -23,7 +23,6 @@ import { DistroAvatar } from './DistroAvatar';
 import HostDetailsPanel from './HostDetailsPanel';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
-import { ScrollArea } from './ui/scroll-area';
 import { SortDropdown, SortMode } from './ui/sort-dropdown';
 import { TagFilterDropdown } from './ui/tag-filter-dropdown';
 import {
@@ -32,6 +31,14 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from './ui/tooltip';
+import {
+  VariableSizeVirtualList,
+  type VariableSizeVirtualListHandle,
+} from './ui/VariableSizeVirtualList';
+import { clampListIndex, stepListIndex } from './ui/virtualListMath';
+
+const SELECT_HOST_SECTION_HEIGHT = 28;
+const SELECT_HOST_ROW_HEIGHT = 48;
 
 export interface SelectHostPanelContentProps {
   hosts: Host[];
@@ -52,6 +59,11 @@ export interface SelectHostPanelContentProps {
   onNewHostPanelOpenChange?: (open: boolean) => void;
   className?: string;
 }
+
+type SelectHostListRow =
+  | { kind: 'section'; key: string; title: string }
+  | { kind: 'group'; key: string; path: string; name: string; count: number }
+  | { kind: 'host'; key: string; host: Host };
 
 /** Shared host-picker body used by aside panel and dialog variants. */
 export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
@@ -78,6 +90,8 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
   const [sortMode, setSortMode] = useState<SortMode>('az');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [showNewHostPanel, setShowNewHostPanel] = useState(false);
+  const [activeNavIndex, setActiveNavIndex] = useState(0);
+  const listRef = useRef<VariableSizeVirtualListHandle>(null);
 
   useEffect(() => {
     onNewHostPanelOpenChange?.(showNewHostPanel);
@@ -212,7 +226,42 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
     return map;
   }, [multiSelect, groupsWithCounts, selectableHosts]);
 
-  const applySelectionChange = (nextSelectedHostIds: string[]) => {
+  const listRows = useMemo<SelectHostListRow[]>(() => {
+    const rows: SelectHostListRow[] = [];
+    if (groupsWithCounts.length > 0) {
+      rows.push({
+        kind: 'section',
+        key: 'section:groups',
+        title: t('vault.groups.title'),
+      });
+      for (const group of groupsWithCounts) {
+        rows.push({
+          kind: 'group',
+          key: `group:${group.path}`,
+          path: group.path,
+          name: group.name,
+          count: group.count,
+        });
+      }
+    }
+    if (filteredHosts.length > 0) {
+      rows.push({
+        kind: 'section',
+        key: 'section:hosts',
+        title: t('vault.nav.hosts'),
+      });
+      for (const host of filteredHosts) {
+        rows.push({
+          kind: 'host',
+          key: `host:${host.id}`,
+          host,
+        });
+      }
+    }
+    return rows;
+  }, [filteredHosts, groupsWithCounts, t]);
+
+  const applySelectionChange = useCallback((nextSelectedHostIds: string[]) => {
     if (onSelectionChange) {
       onSelectionChange(nextSelectedHostIds);
       return;
@@ -225,28 +274,228 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
       const isSelected = next.has(host.id);
       if (wasSelected !== isSelected) onSelect(host);
     }
-  };
+  }, [onSelect, onSelectionChange, selectableHosts, selectedHostIds]);
 
-  const handleHostClick = (host: Host) => {
+  const handleHostClick = useCallback((host: Host) => {
     if (multiSelect && onSelectionChange) {
       onSelectionChange(toggleIdsInSelection(selectedHostIds, [host.id]));
       return;
     }
     onSelect(host);
-  };
+  }, [multiSelect, onSelect, onSelectionChange, selectedHostIds]);
 
-  const handleGroupToggle = (groupPath: string) => {
+  const handleGroupToggle = useCallback((groupPath: string) => {
     const groupHostIds = groupHostIdsByPath.get(groupPath)
       ?? collectSelectableHostIdsInGroup(selectableHosts, groupPath);
     if (groupHostIds.length === 0) return;
     applySelectionChange(toggleIdsInSelection(selectedHostIds, groupHostIds));
-  };
+  }, [applySelectionChange, groupHostIdsByPath, selectableHosts, selectedHostIds]);
+
+  // Navigable rows (groups + hosts) for listbox keyboard model under virtualization.
+  const navigable = useMemo(() => {
+    const entries: { key: string; listIndex: number; row: SelectHostListRow }[] = [];
+    listRows.forEach((row, listIndex) => {
+      if (row.kind === 'group' || row.kind === 'host') {
+        entries.push({ key: row.key, listIndex, row });
+      }
+    });
+    return entries;
+  }, [listRows]);
+
+  const activeNavKey = navigable[clampListIndex(activeNavIndex, navigable.length)]?.key ?? null;
+
+  useEffect(() => {
+    setActiveNavIndex((prev) => clampListIndex(prev, navigable.length));
+  }, [navigable.length, currentPath, searchQuery, selectedTags, sortMode]);
+
+  useEffect(() => {
+    const entry = navigable[clampListIndex(activeNavIndex, navigable.length)];
+    if (!entry) return;
+    listRef.current?.scrollToIndex(entry.listIndex, 'auto');
+  }, [activeNavIndex, navigable]);
+
+  const handleListKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (navigable.length === 0) return;
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveNavIndex((prev) => stepListIndex(prev, navigable.length, 1));
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveNavIndex((prev) => stepListIndex(prev, navigable.length, -1));
+      return;
+    }
+    if (event.key === 'Home') {
+      event.preventDefault();
+      setActiveNavIndex(0);
+      return;
+    }
+    if (event.key === 'End') {
+      event.preventDefault();
+      setActiveNavIndex(Math.max(0, navigable.length - 1));
+      return;
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      const entry = navigable[clampListIndex(activeNavIndex, navigable.length)];
+      if (!entry) return;
+      if (entry.row.kind === 'group') {
+        if (multiSelect && event.key === ' ') {
+          handleGroupToggle(entry.row.path);
+          return;
+        }
+        setCurrentPath(entry.row.path);
+        return;
+      }
+      handleHostClick(entry.row.host);
+    }
+  }, [activeNavIndex, handleGroupToggle, handleHostClick, multiSelect, navigable]);
 
   const renderSelectionIcon = (state: 'none' | 'partial' | 'all') => {
     if (state === 'all') return <CheckSquare size={16} className="text-primary shrink-0" />;
     if (state === 'partial') return <MinusSquare size={16} className="text-primary shrink-0" />;
     return <Square size={16} className="text-muted-foreground shrink-0" />;
   };
+
+  const getRowHeight = useCallback((row: SelectHostListRow) => (
+    row.kind === 'section' ? SELECT_HOST_SECTION_HEIGHT : SELECT_HOST_ROW_HEIGHT
+  ), []);
+
+  const renderRow = useCallback((row: SelectHostListRow) => {
+    if (row.kind === 'section') {
+      return (
+        <div className="flex h-full items-end px-1 pb-1">
+          <h4 className="text-xs font-semibold text-muted-foreground">{row.title}</h4>
+        </div>
+      );
+    }
+
+    const isActive = activeNavKey === row.key;
+
+    if (row.kind === 'group') {
+      const groupHostIds = groupHostIdsByPath.get(row.path) ?? [];
+      const groupState = multiSelect
+        ? getGroupSelectionState(selectedHostIdSet, groupHostIds)
+        : 'none';
+      const canToggleGroup = multiSelect && groupHostIds.length > 0;
+
+      return (
+        <div
+          role="option"
+          aria-selected={isActive}
+          data-active={isActive ? 'true' : undefined}
+          className={cn(
+            'flex h-full items-center gap-2.5 px-2.5 rounded-lg transition-colors',
+            isActive ? 'bg-primary/10 ring-1 ring-primary/40' : 'hover:bg-muted/70',
+          )}
+          onClick={() => {
+            const navIndex = navigable.findIndex((entry) => entry.key === row.key);
+            if (navIndex >= 0) setActiveNavIndex(navIndex);
+            setCurrentPath(row.path);
+          }}
+        >
+          {multiSelect ? (
+            <button
+              type="button"
+              tabIndex={-1}
+              className={cn(
+                'shrink-0 rounded-sm p-0.5 -m-0.5',
+                canToggleGroup
+                  ? 'hover:bg-muted cursor-pointer'
+                  : 'opacity-40 cursor-not-allowed',
+              )}
+              disabled={!canToggleGroup}
+              aria-label={t('selectHost.toggleGroup', { name: row.name })}
+              aria-pressed={groupState === 'all'}
+              onClick={(event) => {
+                event.stopPropagation();
+                handleGroupToggle(row.path);
+              }}
+            >
+              {renderSelectionIcon(groupState)}
+            </button>
+          ) : null}
+          <div className="flex flex-1 min-w-0 items-center gap-2.5 text-left cursor-pointer">
+            <div className="h-8 w-8 rounded-lg bg-primary/15 text-primary flex items-center justify-center shrink-0">
+              <LayoutGrid size={15} />
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="text-[13px] font-medium truncate">{row.name}</div>
+              <div className="text-[11px] text-muted-foreground">
+                {t('vault.groups.hostsCount', { count: row.count })}
+              </div>
+            </div>
+            <ChevronRight size={14} className="text-muted-foreground shrink-0 opacity-60" />
+          </div>
+        </div>
+      );
+    }
+
+    const host = row.host;
+    const isSelected = selectedHostIdSet.has(host.id);
+    const connectionStr = `${host.username}@${host.hostname}:${host.port || 22}`;
+
+    return (
+      <div
+        role="option"
+        aria-selected={isSelected || isActive}
+        data-host-id={host.id}
+        data-active={isActive ? 'true' : undefined}
+        aria-label={t('selectHost.toggleHost', { name: host.label })}
+        className={cn(
+          'flex h-full items-center gap-2.5 px-2.5 rounded-lg cursor-pointer transition-colors',
+          isSelected ? 'bg-muted' : isActive ? 'bg-primary/10 ring-1 ring-primary/40' : 'hover:bg-muted/70',
+        )}
+        onClick={() => {
+          const navIndex = navigable.findIndex((entry) => entry.key === row.key);
+          if (navIndex >= 0) setActiveNavIndex(navIndex);
+          handleHostClick(host);
+        }}
+      >
+        {multiSelect ? (
+          <span className="shrink-0" aria-hidden>
+            {renderSelectionIcon(isSelected ? 'all' : 'none')}
+          </span>
+        ) : null}
+        <DistroAvatar
+          host={host}
+          fallback={(host.os || 'L')[0].toUpperCase()}
+          size="md"
+        />
+        <div className="flex-1 min-w-0">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="text-[13px] font-medium truncate">{host.label}</div>
+            </TooltipTrigger>
+            <TooltipContent side="top" align="start">
+              <p>{host.label}</p>
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="text-[11px] text-muted-foreground truncate">{connectionStr}</div>
+            </TooltipTrigger>
+            <TooltipContent side="top" align="start">
+              <p>{connectionStr}</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+        {!multiSelect && isSelected ? (
+          <Check size={14} className="text-primary shrink-0" />
+        ) : null}
+      </div>
+    );
+  }, [
+    activeNavKey,
+    groupHostIdsByPath,
+    handleGroupToggle,
+    handleHostClick,
+    multiSelect,
+    navigable,
+    selectedHostIdSet,
+    t,
+  ]);
 
   return (
     <TooltipProvider delayDuration={300}>
@@ -291,171 +540,61 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
           </div>
         </div>
 
-        <ScrollArea className="flex-1 min-h-0 min-w-0">
-          <div className="p-3 space-y-3">
-            {currentPath ? (
-              <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                <button
-                  type="button"
-                  onClick={() => setCurrentPath(null)}
-                  className="text-primary hover:underline"
-                >
-                  {t('vault.hosts.allHosts')}
-                </button>
-                {breadcrumbs.map((crumb, index) => (
-                  <React.Fragment key={crumb.path}>
-                    <ChevronRight size={12} className="shrink-0 opacity-50" />
-                    <button
-                      type="button"
-                      onClick={() => setCurrentPath(crumb.path)}
-                      className={cn(
-                        'hover:underline',
-                        index === breadcrumbs.length - 1
-                          ? 'text-foreground font-medium'
-                          : 'text-primary',
-                      )}
-                    >
-                      {crumb.name}
-                    </button>
-                  </React.Fragment>
-                ))}
-              </div>
-            ) : null}
+        <div className="flex-1 min-h-0 min-w-0 flex flex-col">
+          {currentPath ? (
+            <div className="flex shrink-0 items-center gap-1 px-3 pt-3 text-xs text-muted-foreground">
+              <button
+                type="button"
+                onClick={() => setCurrentPath(null)}
+                className="text-primary hover:underline"
+              >
+                {t('vault.hosts.allHosts')}
+              </button>
+              {breadcrumbs.map((crumb, index) => (
+                <React.Fragment key={crumb.path}>
+                  <ChevronRight size={12} className="shrink-0 opacity-50" />
+                  <button
+                    type="button"
+                    onClick={() => setCurrentPath(crumb.path)}
+                    className={cn(
+                      'hover:underline',
+                      index === breadcrumbs.length - 1
+                        ? 'text-foreground font-medium'
+                        : 'text-primary',
+                    )}
+                  >
+                    {crumb.name}
+                  </button>
+                </React.Fragment>
+              ))}
+            </div>
+          ) : null}
 
-            {groupsWithCounts.length > 0 ? (
-              <div>
-                <h4 className="text-xs font-semibold mb-2 text-muted-foreground">{t('vault.groups.title')}</h4>
-                <div className="space-y-1">
-                  {groupsWithCounts.map((group) => {
-                    const groupHostIds = groupHostIdsByPath.get(group.path) ?? [];
-                    const groupState = multiSelect
-                      ? getGroupSelectionState(selectedHostIdSet, groupHostIds)
-                      : 'none';
-                    const canToggleGroup = multiSelect && groupHostIds.length > 0;
-
-                    return (
-                      <div
-                        key={group.path}
-                        className="flex items-center gap-2.5 px-2.5 py-2 rounded-lg hover:bg-muted/70 transition-colors"
-                      >
-                        {multiSelect ? (
-                          <button
-                            type="button"
-                            className={cn(
-                              'shrink-0 rounded-sm p-0.5 -m-0.5',
-                              canToggleGroup
-                                ? 'hover:bg-muted cursor-pointer'
-                                : 'opacity-40 cursor-not-allowed',
-                            )}
-                            disabled={!canToggleGroup}
-                            aria-label={t('selectHost.toggleGroup', { name: group.name })}
-                            aria-pressed={groupState === 'all'}
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              handleGroupToggle(group.path);
-                            }}
-                          >
-                            {renderSelectionIcon(groupState)}
-                          </button>
-                        ) : null}
-                        <button
-                          type="button"
-                          className="flex flex-1 min-w-0 items-center gap-2.5 text-left cursor-pointer"
-                          onClick={() => setCurrentPath(group.path)}
-                        >
-                          <div className="h-8 w-8 rounded-lg bg-primary/15 text-primary flex items-center justify-center shrink-0">
-                            <LayoutGrid size={15} />
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <div className="text-[13px] font-medium truncate">{group.name}</div>
-                            <div className="text-[11px] text-muted-foreground">
-                              {t('vault.groups.hostsCount', { count: group.count })}
-                            </div>
-                          </div>
-                          <ChevronRight size={14} className="text-muted-foreground shrink-0 opacity-60" />
-                        </button>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            ) : null}
-
-            {filteredHosts.length > 0 ? (
-              <div>
-                <h4 className="text-xs font-semibold mb-2 text-muted-foreground">{t('vault.nav.hosts')}</h4>
-                <div className="space-y-1">
-                  {filteredHosts.map((host) => {
-                    const isSelected = selectedHostIdSet.has(host.id);
-                    const connectionStr = `${host.username}@${host.hostname}:${host.port || 22}`;
-
-                    return (
-                      <div
-                        key={host.id}
-                        role="button"
-                        tabIndex={0}
-                        aria-label={t('selectHost.toggleHost', { name: host.label })}
-                        aria-pressed={isSelected}
-                        className={cn(
-                          'flex items-center gap-2.5 px-2.5 py-2 rounded-lg cursor-pointer transition-colors',
-                          isSelected ? 'bg-muted' : 'hover:bg-muted/70',
-                        )}
-                        onClick={() => handleHostClick(host)}
-                        onKeyDown={(event) => {
-                          if (event.key === 'Enter' || event.key === ' ') {
-                            event.preventDefault();
-                            handleHostClick(host);
-                          }
-                        }}
-                      >
-                        {multiSelect ? (
-                          <span
-                            className="shrink-0"
-                            aria-hidden
-                          >
-                            {renderSelectionIcon(isSelected ? 'all' : 'none')}
-                          </span>
-                        ) : null}
-                        <DistroAvatar
-                          host={host}
-                          fallback={host.os[0].toUpperCase()}
-                          size="md"
-                        />
-                        <div className="flex-1 min-w-0">
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <div className="text-[13px] font-medium truncate">{host.label}</div>
-                            </TooltipTrigger>
-                            <TooltipContent side="top" align="start">
-                              <p>{host.label}</p>
-                            </TooltipContent>
-                          </Tooltip>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <div className="text-[11px] text-muted-foreground truncate">{connectionStr}</div>
-                            </TooltipTrigger>
-                            <TooltipContent side="top" align="start">
-                              <p>{connectionStr}</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </div>
-                        {!multiSelect && isSelected ? (
-                          <Check size={14} className="text-primary shrink-0" />
-                        ) : null}
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            ) : null}
-
-            {groupsWithCounts.length === 0 && filteredHosts.length === 0 ? (
-              <div className="text-center py-12 text-muted-foreground">
-                <p>{t('selectHost.noHostsFound')}</p>
-              </div>
-            ) : null}
-          </div>
-        </ScrollArea>
+          {listRows.length === 0 ? (
+            <div className="text-center py-12 text-muted-foreground">
+              <p>{t('selectHost.noHostsFound')}</p>
+            </div>
+          ) : (
+            <div
+              className="flex-1 min-h-0 px-3 py-2 outline-none"
+              data-host-picker-virtual="select-host"
+              role="listbox"
+              aria-label={t('selectHost.title')}
+              tabIndex={0}
+              onKeyDown={handleListKeyDown}
+            >
+              <VariableSizeVirtualList<SelectHostListRow>
+                ref={listRef}
+                items={listRows}
+                getItemHeight={getRowHeight}
+                className="h-full"
+                overscan={8}
+                getItemKey={(row) => row.key}
+                renderItem={renderRow}
+              />
+            </div>
+          )}
+        </div>
 
         <div className="px-4 py-3 border-t border-border/60 shrink-0">
           <Button

--- a/components/SelectHostPanelContent.tsx
+++ b/components/SelectHostPanelContent.tsx
@@ -310,6 +310,15 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
     return entries;
   }, [listRows]);
 
+  // O(1) key → nav index for virtual row renders (avoid findIndex per visible row).
+  const navigableIndexByKey = useMemo(() => {
+    const map = new Map<string, number>();
+    navigable.forEach((entry, index) => {
+      map.set(entry.key, index);
+    });
+    return map;
+  }, [navigable]);
+
   const clampedNavIndex = clampListIndex(activeNavIndex, navigable.length);
   const activeNavEntry = navigable[clampedNavIndex];
   const activeNavKey = activeNavEntry?.key ?? null;
@@ -391,7 +400,7 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
       );
     }
 
-    const navIndex = navigable.findIndex((entry) => entry.key === row.key);
+    const navIndex = navigableIndexByKey.get(row.key) ?? -1;
     const isActive = activeNavKey === row.key;
 
     if (row.kind === 'group') {
@@ -467,7 +476,9 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
         aria-label={t('selectHost.toggleHost', { name: host.label })}
         className={cn(
           'flex h-full min-h-0 cursor-pointer items-center gap-2.5 overflow-hidden rounded-lg px-2.5 transition-colors',
-          isSelected ? 'bg-muted' : isActive ? 'bg-primary/10 ring-1 ring-primary/40' : 'hover:bg-muted/70',
+          isSelected ? 'bg-muted' : isActive ? 'bg-primary/10' : 'hover:bg-muted/70',
+          // Keep keyboard cursor visible even when the host is already selected.
+          isActive && 'ring-1 ring-primary/40',
         )}
         onClick={() => {
           if (navIndex >= 0) setActiveNavIndex(navIndex);
@@ -513,7 +524,7 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
     handleGroupToggle,
     handleHostClick,
     multiSelect,
-    navigable,
+    navigableIndexByKey,
     optionDomId,
     selectedHostIdSet,
     t,

--- a/components/SelectHostPanelContent.tsx
+++ b/components/SelectHostPanelContent.tsx
@@ -65,6 +65,8 @@ type SelectHostListRow =
   | { kind: 'group'; key: string; path: string; name: string; count: number }
   | { kind: 'host'; key: string; host: Host };
 
+type SelectHostNavigableRow = Extract<SelectHostListRow, { kind: 'group' | 'host' }>;
+
 /** Shared host-picker body used by aside panel and dialog variants. */
 export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
   hosts,
@@ -293,7 +295,7 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
 
   // Navigable rows (groups + hosts) for listbox keyboard model under virtualization.
   const navigable = useMemo(() => {
-    const entries: { key: string; listIndex: number; row: SelectHostListRow }[] = [];
+    const entries: { key: string; listIndex: number; row: SelectHostNavigableRow }[] = [];
     listRows.forEach((row, listIndex) => {
       if (row.kind === 'group' || row.kind === 'host') {
         entries.push({ key: row.key, listIndex, row });
@@ -348,7 +350,9 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
         setCurrentPath(entry.row.path);
         return;
       }
-      handleHostClick(entry.row.host);
+      if (entry.row.kind === 'host') {
+        handleHostClick(entry.row.host);
+      }
     }
   }, [activeNavIndex, handleGroupToggle, handleHostClick, multiSelect, navigable]);
 

--- a/components/SelectHostPanelContent.tsx
+++ b/components/SelectHostPanelContent.tsx
@@ -394,7 +394,7 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
         <div
           id={optionDomId(row.key)}
           role="option"
-          aria-selected={isActive}
+          aria-selected={multiSelect ? groupState === 'all' : false}
           data-active={isActive ? 'true' : undefined}
           className={cn(
             'flex h-full min-h-0 items-center gap-2.5 overflow-hidden px-2.5 rounded-lg transition-colors',
@@ -451,7 +451,7 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
       <div
         id={optionDomId(row.key)}
         role="option"
-        aria-selected={isSelected || isActive}
+        aria-selected={isSelected}
         data-host-id={host.id}
         data-active={isActive ? 'true' : undefined}
         aria-label={t('selectHost.toggleHost', { name: host.label })}

--- a/components/SelectHostPanelContent.tsx
+++ b/components/SelectHostPanelContent.tsx
@@ -315,9 +315,16 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
   const activeNavKey = activeNavEntry?.key ?? null;
   const activeDescendantId = activeNavEntry ? optionDomId(clampedNavIndex) : undefined;
 
+  // Opening a group / changing filters must start at the first entry; otherwise a
+  // deep prior cursor scrolls the new list partway down and hides its top rows.
+  useEffect(() => {
+    setActiveNavIndex(0);
+  }, [currentPath, searchQuery, selectedTags, sortMode]);
+
+  // Inventory-only shrinkage keeps the prior cursor when still in range.
   useEffect(() => {
     setActiveNavIndex((prev) => clampListIndex(prev, navigable.length));
-  }, [navigable.length, currentPath, searchQuery, selectedTags, sortMode]);
+  }, [navigable.length]);
 
   useEffect(() => {
     const entry = navigable[clampListIndex(activeNavIndex, navigable.length)];

--- a/components/SelectHostPanelContent.tsx
+++ b/components/SelectHostPanelContent.tsx
@@ -95,8 +95,10 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
   const [activeNavIndex, setActiveNavIndex] = useState(0);
   const listRef = useRef<VariableSizeVirtualListHandle>(null);
   const listboxId = useId();
-  const optionDomId = useCallback((key: string) => (
-    `${listboxId}-opt-${key.replace(/[^a-zA-Z0-9_-]/g, '_')}`
+  // Index-based IDs stay unique even when group paths only differ by chars that
+  // would collide under a sanitize-to-_ mapping (e.g. "Prod East" vs "Prod_East").
+  const optionDomId = useCallback((navIndex: number) => (
+    `${listboxId}-opt-${navIndex}`
   ), [listboxId]);
 
   useEffect(() => {
@@ -308,9 +310,10 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
     return entries;
   }, [listRows]);
 
-  const activeNavEntry = navigable[clampListIndex(activeNavIndex, navigable.length)];
+  const clampedNavIndex = clampListIndex(activeNavIndex, navigable.length);
+  const activeNavEntry = navigable[clampedNavIndex];
   const activeNavKey = activeNavEntry?.key ?? null;
-  const activeDescendantId = activeNavKey ? optionDomId(activeNavKey) : undefined;
+  const activeDescendantId = activeNavEntry ? optionDomId(clampedNavIndex) : undefined;
 
   useEffect(() => {
     setActiveNavIndex((prev) => clampListIndex(prev, navigable.length));
@@ -381,6 +384,7 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
       );
     }
 
+    const navIndex = navigable.findIndex((entry) => entry.key === row.key);
     const isActive = activeNavKey === row.key;
 
     if (row.kind === 'group') {
@@ -392,7 +396,7 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
 
       return (
         <div
-          id={optionDomId(row.key)}
+          id={navIndex >= 0 ? optionDomId(navIndex) : undefined}
           role="option"
           aria-selected={multiSelect ? groupState === 'all' : false}
           data-active={isActive ? 'true' : undefined}
@@ -401,7 +405,6 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
             isActive ? 'bg-primary/10 ring-1 ring-primary/40' : 'hover:bg-muted/70',
           )}
           onClick={() => {
-            const navIndex = navigable.findIndex((entry) => entry.key === row.key);
             if (navIndex >= 0) setActiveNavIndex(navIndex);
             setCurrentPath(row.path);
           }}
@@ -449,7 +452,7 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
 
     return (
       <div
-        id={optionDomId(row.key)}
+        id={navIndex >= 0 ? optionDomId(navIndex) : undefined}
         role="option"
         aria-selected={isSelected}
         data-host-id={host.id}
@@ -460,7 +463,6 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
           isSelected ? 'bg-muted' : isActive ? 'bg-primary/10 ring-1 ring-primary/40' : 'hover:bg-muted/70',
         )}
         onClick={() => {
-          const navIndex = navigable.findIndex((entry) => entry.key === row.key);
           if (navIndex >= 0) setActiveNavIndex(navIndex);
           handleHostClick(host);
         }}

--- a/components/SelectHostPanelContent.tsx
+++ b/components/SelectHostPanelContent.tsx
@@ -613,6 +613,7 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
               data-host-picker-virtual="select-host"
               role="listbox"
               aria-label={t('selectHost.title')}
+              aria-multiselectable={multiSelect || undefined}
               aria-activedescendant={activeDescendantId}
               tabIndex={0}
               onKeyDown={handleListKeyDown}

--- a/components/SelectHostPanelContent.tsx
+++ b/components/SelectHostPanelContent.tsx
@@ -8,7 +8,7 @@ import {
   Search,
   Square,
 } from 'lucide-react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { cn } from '../lib/utils';
 import { matchesHostSearchQuery, matchesSearchQuery } from '../lib/searchMatcher';
 import { useI18n } from '../application/i18n/I18nProvider';
@@ -94,6 +94,10 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
   const [showNewHostPanel, setShowNewHostPanel] = useState(false);
   const [activeNavIndex, setActiveNavIndex] = useState(0);
   const listRef = useRef<VariableSizeVirtualListHandle>(null);
+  const listboxId = useId();
+  const optionDomId = useCallback((key: string) => (
+    `${listboxId}-opt-${key.replace(/[^a-zA-Z0-9_-]/g, '_')}`
+  ), [listboxId]);
 
   useEffect(() => {
     onNewHostPanelOpenChange?.(showNewHostPanel);
@@ -304,7 +308,9 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
     return entries;
   }, [listRows]);
 
-  const activeNavKey = navigable[clampListIndex(activeNavIndex, navigable.length)]?.key ?? null;
+  const activeNavEntry = navigable[clampListIndex(activeNavIndex, navigable.length)];
+  const activeNavKey = activeNavEntry?.key ?? null;
+  const activeDescendantId = activeNavKey ? optionDomId(activeNavKey) : undefined;
 
   useEffect(() => {
     setActiveNavIndex((prev) => clampListIndex(prev, navigable.length));
@@ -386,11 +392,12 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
 
       return (
         <div
+          id={optionDomId(row.key)}
           role="option"
           aria-selected={isActive}
           data-active={isActive ? 'true' : undefined}
           className={cn(
-            'flex h-full items-center gap-2.5 px-2.5 rounded-lg transition-colors',
+            'flex h-full min-h-0 items-center gap-2.5 overflow-hidden px-2.5 rounded-lg transition-colors',
             isActive ? 'bg-primary/10 ring-1 ring-primary/40' : 'hover:bg-muted/70',
           )}
           onClick={() => {
@@ -442,13 +449,14 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
 
     return (
       <div
+        id={optionDomId(row.key)}
         role="option"
         aria-selected={isSelected || isActive}
         data-host-id={host.id}
         data-active={isActive ? 'true' : undefined}
         aria-label={t('selectHost.toggleHost', { name: host.label })}
         className={cn(
-          'flex h-full items-center gap-2.5 px-2.5 rounded-lg cursor-pointer transition-colors',
+          'flex h-full min-h-0 cursor-pointer items-center gap-2.5 overflow-hidden rounded-lg px-2.5 transition-colors',
           isSelected ? 'bg-muted' : isActive ? 'bg-primary/10 ring-1 ring-primary/40' : 'hover:bg-muted/70',
         )}
         onClick={() => {
@@ -497,6 +505,7 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
     handleHostClick,
     multiSelect,
     navigable,
+    optionDomId,
     selectedHostIdSet,
     t,
   ]);
@@ -584,6 +593,7 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
               data-host-picker-virtual="select-host"
               role="listbox"
               aria-label={t('selectHost.title')}
+              aria-activedescendant={activeDescendantId}
               tabIndex={0}
               onKeyDown={handleListKeyDown}
             >

--- a/components/hostPickerVirtualization.test.ts
+++ b/components/hostPickerVirtualization.test.ts
@@ -24,6 +24,10 @@ test('SelectHostPanelContent virtualizes with listbox keyboard model', () => {
   assert.match(source, /role="listbox"/);
   assert.match(source, /handleListKeyDown/);
   assert.match(source, /stepListIndex/);
+  // Screen readers need active option linkage while focus stays on the listbox.
+  assert.match(source, /aria-activedescendant=\{activeDescendantId\}/);
+  assert.match(source, /optionDomId/);
+  assert.match(source, /id=\{optionDomId\(row\.key\)\}/);
   assert.doesNotMatch(source, /filteredHosts\.map\(\(host\) =>/);
   // One listbox tab stop — not per-host tabIndex under virtualization.
   assert.match(source, /role="listbox"[\s\S]*tabIndex=\{0\}/);
@@ -38,6 +42,9 @@ test('QuickSwitcher virtualizes categorized rows and clamps empty-list keyboard'
   assert.match(source, /clampListIndex/);
   // Two-line plugin rows need a taller virtual slot than QS_ROW_HEIGHT.
   assert.match(source, /QS_PLUGIN_ROW_HEIGHT/);
+  // Fixed-height slots must clip/truncate so long titles never overlap the next row.
+  assert.match(source, /overflow-hidden/);
+  assert.match(source, /max-w-\[12rem\] shrink-0 truncate/);
   assert.doesNotMatch(source, /results\.map\(\(host\) =>/);
   // Must not use bare length-1 which yields -1 on empty lists.
   assert.doesNotMatch(
@@ -53,6 +60,8 @@ test('AddToWorkspaceDialog virtualizes and clamps selection on shrink', () => {
   assert.match(source, /clampListIndex\(prev, items\.length\)/);
   assert.match(source, /onClick=\{\(\) => handleTargetClick\(idx, LOCAL_ITEM_ID\)\}/);
   assert.match(source, /onClick=\{\(\) => handleTargetClick\(idx, host\.id\)\}/);
+  // Long group paths must not wrap out of the fixed virtual row.
+  assert.match(source, /max-w-\[12rem\] truncate text-\[11px\] text-muted-foreground/);
   assert.doesNotMatch(source, /filteredHosts\.map\(\(host, i\) =>/);
 });
 

--- a/components/hostPickerVirtualization.test.ts
+++ b/components/hostPickerVirtualization.test.ts
@@ -27,7 +27,9 @@ test('SelectHostPanelContent virtualizes with listbox keyboard model', () => {
   // Screen readers need active option linkage while focus stays on the listbox.
   assert.match(source, /aria-activedescendant=\{activeDescendantId\}/);
   assert.match(source, /optionDomId/);
-  assert.match(source, /id=\{optionDomId\(row\.key\)\}/);
+  // Navigable-index IDs avoid collisions when group paths sanitize identically.
+  assert.match(source, /id=\{navIndex >= 0 \? optionDomId\(navIndex\) : undefined\}/);
+  assert.match(source, /\$\{listboxId\}-opt-\$\{navIndex\}/);
   assert.doesNotMatch(source, /filteredHosts\.map\(\(host\) =>/);
   // One listbox tab stop — not per-host tabIndex under virtualization.
   assert.match(source, /role="listbox"[\s\S]*tabIndex=\{0\}/);

--- a/components/hostPickerVirtualization.test.ts
+++ b/components/hostPickerVirtualization.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import {
+  buildItemIndexToVisualIndexMap,
+  clampListIndex,
+  getFixedSizeVirtualWindow,
+  stepListIndex,
+} from './ui/virtualListMath.ts';
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+
+const read = (relativePath: string) =>
+  readFileSync(path.join(root, relativePath), 'utf8');
+
+test('SelectHostPanelContent virtualizes with listbox keyboard model', () => {
+  const source = read('SelectHostPanelContent.tsx');
+  assert.match(source, /VariableSizeVirtualList/);
+  assert.match(source, /data-host-picker-virtual="select-host"/);
+  assert.match(source, /role="listbox"/);
+  assert.match(source, /handleListKeyDown/);
+  assert.match(source, /stepListIndex/);
+  assert.doesNotMatch(source, /filteredHosts\.map\(\(host\) =>/);
+  // One listbox tab stop — not per-host tabIndex under virtualization.
+  assert.match(source, /role="listbox"[\s\S]*tabIndex=\{0\}/);
+  assert.doesNotMatch(source, /data-host-id=\{host\.id\}[\s\S]{0,120}tabIndex=\{0\}/);
+});
+
+test('QuickSwitcher virtualizes categorized rows and clamps empty-list keyboard', () => {
+  const source = read('QuickSwitcher.tsx');
+  assert.match(source, /VariableSizeVirtualList/);
+  assert.match(source, /data-host-picker-virtual="quick-switcher"/);
+  assert.match(source, /stepListIndex/);
+  assert.match(source, /clampListIndex/);
+  assert.doesNotMatch(source, /results\.map\(\(host\) =>/);
+  // Must not use bare length-1 which yields -1 on empty lists.
+  assert.doesNotMatch(
+    source,
+    /setSelectedIndex\(\(prev\) => Math\.min\(prev \+ 1, flatItems\.length - 1\)\)/,
+  );
+});
+
+test('AddToWorkspaceDialog virtualizes and clamps selection on shrink', () => {
+  const source = read('workspace/AddToWorkspaceDialog.tsx');
+  assert.match(source, /VariableSizeVirtualList/);
+  assert.match(source, /data-host-picker-virtual="add-workspace"/);
+  assert.match(source, /clampListIndex\(prev, items\.length\)/);
+  assert.match(source, /onClick=\{\(\) => handleTargetClick\(idx, LOCAL_ITEM_ID\)\}/);
+  assert.match(source, /onClick=\{\(\) => handleTargetClick\(idx, host\.id\)\}/);
+  assert.doesNotMatch(source, /filteredHosts\.map\(\(host, i\) =>/);
+});
+
+test('CreateWorkspaceDialog virtualizes selectable hosts', () => {
+  const source = read('CreateWorkspaceDialog.tsx');
+  assert.match(source, /FixedSizeVirtualList/);
+  assert.match(source, /data-host-picker-virtual="create-workspace"/);
+  assert.doesNotMatch(source, /filteredHosts\.map\(host =>/);
+});
+
+test('FixedSizeVirtualList uses shared window math (render path clamp)', () => {
+  const source = read('ui/FixedSizeVirtualList.tsx');
+  assert.match(source, /getFixedSizeVirtualWindow/);
+  assert.match(source, /effectiveScrollTop/);
+});
+
+test('shipped virtual window math proves large lists only render a viewport slice', () => {
+  const window = getFixedSizeVirtualWindow({
+    itemCount: 8_000,
+    itemHeight: 52,
+    scrollTop: 12_000,
+    viewportHeight: 300,
+    overscan: 8,
+  });
+  const rendered = window.endIndex - window.startIndex;
+  assert.ok(rendered > 0);
+  assert.ok(rendered < 80);
+  assert.ok(window.startIndex > 0);
+  assert.ok(window.endIndex < 8_000);
+});
+
+test('shipped keyboard helpers block empty-list ArrowDown crash path', () => {
+  // Reproduce the review finding: empty list + ArrowDown must not yield -1.
+  let index = 0;
+  index = stepListIndex(index, 0, 1);
+  assert.equal(index, 0);
+  index = clampListIndex(index, 0);
+  assert.equal(index, 0);
+  // List repopulates with 5 items — index stays valid for Enter.
+  index = clampListIndex(index, 5);
+  assert.equal(index, 0);
+});
+
+test('shipped visual index map matches picker header/item interleaving', () => {
+  // Mirrors QuickSwitcher / SFTP / AddToWorkspace visual row shape.
+  const visual = [
+    { kind: 'header' },
+    { kind: 'item' },
+    { kind: 'item' },
+    { kind: 'header' },
+    { kind: 'item' },
+  ];
+  const map = buildItemIndexToVisualIndexMap(visual);
+  assert.deepEqual([...map.entries()], [[0, 1], [1, 2], [2, 4]]);
+});

--- a/components/hostPickerVirtualization.test.ts
+++ b/components/hostPickerVirtualization.test.ts
@@ -35,6 +35,8 @@ test('QuickSwitcher virtualizes categorized rows and clamps empty-list keyboard'
   assert.match(source, /data-host-picker-virtual="quick-switcher"/);
   assert.match(source, /stepListIndex/);
   assert.match(source, /clampListIndex/);
+  // Two-line plugin rows need a taller virtual slot than QS_ROW_HEIGHT.
+  assert.match(source, /QS_PLUGIN_ROW_HEIGHT/);
   assert.doesNotMatch(source, /results\.map\(\(host\) =>/);
   // Must not use bare length-1 which yields -1 on empty lists.
   assert.doesNotMatch(

--- a/components/hostPickerVirtualization.test.ts
+++ b/components/hostPickerVirtualization.test.ts
@@ -30,6 +30,17 @@ test('SelectHostPanelContent virtualizes with listbox keyboard model', () => {
   // Navigable-index IDs avoid collisions when group paths sanitize identically.
   assert.match(source, /id=\{navIndex >= 0 \? optionDomId\(navIndex\) : undefined\}/);
   assert.match(source, /\$\{listboxId\}-opt-\$\{navIndex\}/);
+  // Virtual rows must O(1)-lookup nav indices, not findIndex the full navigable list.
+  assert.match(source, /navigableIndexByKey/);
+  assert.match(source, /navigableIndexByKey\.get\(row\.key\)/);
+  assert.doesNotMatch(source, /navigable\.findIndex/);
+  // Selected hosts must still show the keyboard active ring.
+  assert.match(source, /isSelected \? 'bg-muted' : isActive \? 'bg-primary\/10' : 'hover:bg-muted\/70'/);
+  assert.match(source, /isActive && 'ring-1 ring-primary\/40'/);
+  assert.doesNotMatch(
+    source,
+    /isSelected \? 'bg-muted' : isActive \? 'bg-primary\/10 ring-1 ring-primary\/40'/,
+  );
   assert.doesNotMatch(source, /filteredHosts\.map\(\(host\) =>/);
   // One listbox tab stop — not per-host tabIndex under virtualization.
   assert.match(source, /role="listbox"[\s\S]*tabIndex=\{0\}/);

--- a/components/hostPickerVirtualization.test.ts
+++ b/components/hostPickerVirtualization.test.ts
@@ -10,6 +10,7 @@ import {
   getFixedSizeVirtualWindow,
   stepListIndex,
 } from './ui/virtualListMath.ts';
+import { getQuickSwitcherVisualRowHeight } from './QuickSwitcher.tsx';
 
 const root = path.dirname(fileURLToPath(import.meta.url));
 
@@ -106,4 +107,64 @@ test('shipped visual index map matches picker header/item interleaving', () => {
   ];
   const map = buildItemIndexToVisualIndexMap(visual);
   assert.deepEqual([...map.entries()], [[0, 1], [1, 2], [2, 4]]);
+});
+
+test('QuickSwitcher plugin rows use a taller virtual slot than single-line hosts', () => {
+  assert.equal(
+    getQuickSwitcherVisualRowHeight({ kind: 'header', key: 'h', label: 'Hosts' }),
+    32,
+  );
+  assert.equal(
+    getQuickSwitcherVisualRowHeight({
+      kind: 'item',
+      key: 'host:1',
+      itemIndex: 0,
+      item: { type: 'host', id: '1' },
+    }),
+    44,
+  );
+  // Two-line plugin chrome must not share the 44px host slot (overflow/overlap).
+  assert.equal(
+    getQuickSwitcherVisualRowHeight({
+      kind: 'item',
+      key: 'plugin:1',
+      itemIndex: 1,
+      item: {
+        type: 'plugin-command',
+        id: 'p1',
+        commandId: 'cmd',
+        title: 'Run',
+        pluginTitle: 'Plugin',
+      },
+    }),
+    56,
+  );
+  assert.equal(
+    getQuickSwitcherVisualRowHeight({
+      kind: 'item',
+      key: 'view:1',
+      itemIndex: 2,
+      item: { type: 'plugin-view', id: 'v1', title: 'View', pluginTitle: 'Plugin' },
+    }),
+    56,
+  );
+  assert.ok(
+    getQuickSwitcherVisualRowHeight({
+      kind: 'item',
+      key: 'plugin:1',
+      itemIndex: 1,
+      item: {
+        type: 'plugin-command',
+        id: 'p1',
+        commandId: 'cmd',
+        title: 'Run',
+        pluginTitle: 'Plugin',
+      },
+    }) > getQuickSwitcherVisualRowHeight({
+      kind: 'item',
+      key: 'host:1',
+      itemIndex: 0,
+      item: { type: 'host', id: '1' },
+    }),
+  );
 });

--- a/components/hostPickerVirtualization.test.ts
+++ b/components/hostPickerVirtualization.test.ts
@@ -34,6 +34,15 @@ test('SelectHostPanelContent virtualizes with listbox keyboard model', () => {
   // One listbox tab stop — not per-host tabIndex under virtualization.
   assert.match(source, /role="listbox"[\s\S]*tabIndex=\{0\}/);
   assert.doesNotMatch(source, /data-host-id=\{host\.id\}[\s\S]{0,120}tabIndex=\{0\}/);
+  // Path/filter changes must reset the cursor; length-only shrinks still clamp.
+  assert.match(
+    source,
+    /setActiveNavIndex\(0\);\s*\}, \[currentPath, searchQuery, selectedTags, sortMode\]/,
+  );
+  assert.match(
+    source,
+    /setActiveNavIndex\(\(prev\) => clampListIndex\(prev, navigable\.length\)\);\s*\}, \[navigable\.length\]/,
+  );
 });
 
 test('QuickSwitcher virtualizes categorized rows and clamps empty-list keyboard', () => {

--- a/components/hostPickerVirtualization.test.ts
+++ b/components/hostPickerVirtualization.test.ts
@@ -54,6 +54,8 @@ test('SelectHostPanelContent virtualizes with listbox keyboard model', () => {
     source,
     /setActiveNavIndex\(\(prev\) => clampListIndex\(prev, navigable\.length\)\);\s*\}, \[navigable\.length\]/,
   );
+  // Multi-select listbox must advertise multi-selection to AT.
+  assert.match(source, /aria-multiselectable=\{multiSelect \|\| undefined\}/);
 });
 
 test('QuickSwitcher virtualizes categorized rows and clamps empty-list keyboard', () => {
@@ -67,6 +69,8 @@ test('QuickSwitcher virtualizes categorized rows and clamps empty-list keyboard'
   // Fixed-height slots must clip/truncate so long titles never overlap the next row.
   assert.match(source, /overflow-hidden/);
   assert.match(source, /max-w-\[12rem\] shrink-0 truncate/);
+  // List scroller needs a definite max height under max-h-only popup chrome.
+  assert.match(source, /max-h-\[min\(360px,calc\(100vh-14rem\)\)\]/);
   assert.doesNotMatch(source, /results\.map\(\(host\) =>/);
   // Must not use bare length-1 which yields -1 on empty lists.
   assert.doesNotMatch(
@@ -84,6 +88,7 @@ test('AddToWorkspaceDialog virtualizes and clamps selection on shrink', () => {
   assert.match(source, /onClick=\{\(\) => handleTargetClick\(idx, host\.id\)\}/);
   // Long group paths must not wrap out of the fixed virtual row.
   assert.match(source, /max-w-\[12rem\] truncate text-\[11px\] text-muted-foreground/);
+  assert.match(source, /max-h-\[min\(360px,calc\(100vh-14rem\)\)\]/);
   assert.doesNotMatch(source, /filteredHosts\.map\(\(host, i\) =>/);
 });
 

--- a/components/sftp/SftpHostPicker.test.ts
+++ b/components/sftp/SftpHostPicker.test.ts
@@ -49,3 +49,10 @@ test("sftp host picker uses single-line quick switcher row layout", () => {
   assert.doesNotMatch(source, /bg-primary\/10 border border-primary\/30/);
   assert.doesNotMatch(source, /text-xs text-muted-foreground truncate/);
 });
+
+test("sftp host picker virtualizes the host list", () => {
+  assert.match(source, /VariableSizeVirtualList/);
+  assert.match(source, /data-host-picker-virtual="sftp"/);
+  assert.match(source, /itemIndexToVisualIndex/);
+  assert.doesNotMatch(source, /filteredHosts\.map\(\(host\) =>/);
+});

--- a/components/sftp/SftpHostPicker.test.ts
+++ b/components/sftp/SftpHostPicker.test.ts
@@ -55,4 +55,14 @@ test("sftp host picker virtualizes the host list", () => {
   assert.match(source, /data-host-picker-virtual="sftp"/);
   assert.match(source, /itemIndexToVisualIndex/);
   assert.doesNotMatch(source, /filteredHosts\.map\(\(host\) =>/);
+  // Connected-only results must not leave a dangling empty Hosts header.
+  assert.match(source, /if \(filteredHosts\.length > 0\) \{\s*pushHeader\('header:hosts'/);
+  assert.match(
+    source,
+    /else if \(filteredConnectedHosts\.length === 0\) \{\s*pushHeader\('header:hosts'/,
+  );
+  // Short lists shrink; long lists cap at 360px (not a forced blank 360px dialog).
+  assert.match(source, /Math\.min\(360, Math\.max\(total, 1\)\)/);
+  assert.match(source, /listViewportHeight/);
+  assert.doesNotMatch(source, /className="h-\[360px\]"/);
 });

--- a/components/sftp/SftpHostPicker.tsx
+++ b/components/sftp/SftpHostPicker.tsx
@@ -15,7 +15,15 @@ import { DistroAvatar } from '../DistroAvatar';
 import { getQuickSwitcherRowStateClass, shouldUseQuickSwitcherPointerNavigation } from '../QuickSwitcher';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../ui/dialog';
 import { Input } from '../ui/input';
-import { ScrollArea } from '../ui/scroll-area';
+import {
+    VariableSizeVirtualList,
+    type VariableSizeVirtualListHandle,
+} from '../ui/VariableSizeVirtualList';
+import { clampListIndex, stepListIndex } from '../ui/virtualListMath';
+
+const SFTP_PICKER_ROW_HEIGHT = 44;
+const SFTP_PICKER_HEADER_HEIGHT = 32;
+const SFTP_PICKER_EMPTY_HEIGHT = 56;
 
 interface SftpHostPickerProps {
     open: boolean;
@@ -38,6 +46,16 @@ function formatHostMeta(host: Host): string {
     return host.group ? `${endpoint} · ${host.group}` : endpoint;
 }
 
+type PickerItem =
+    | { type: 'local'; id: string }
+    | { type: 'connected'; id: string; entry: SftpConnectedHostEntry }
+    | { type: 'host'; id: string; host: Host };
+
+type VisualRow =
+    | { kind: 'header'; key: string; label: string }
+    | { kind: 'item'; key: string; item: PickerItem; itemIndex: number }
+    | { kind: 'empty'; key: string; message: string };
+
 const SftpHostPickerInner: React.FC<SftpHostPickerProps> = ({
     open,
     onOpenChange,
@@ -51,6 +69,7 @@ const SftpHostPickerInner: React.FC<SftpHostPickerProps> = ({
 }) => {
     const { t } = useI18n();
     const inputRef = useRef<HTMLInputElement>(null);
+    const listRef = useRef<VariableSizeVirtualListHandle>(null);
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [isKeyboardNavigating, setIsKeyboardNavigating] = useState(true);
     const isKeyboardNavigatingRef = useRef(true);
@@ -89,21 +108,54 @@ const SftpHostPickerInner: React.FC<SftpHostPickerProps> = ({
     }, [hosts, term, connectedByHostId]);
     const sideLabel = side === 'left' ? t('common.left') : t('common.right');
 
-    type PickerItem =
-        | { type: 'local'; id: string }
-        | { type: 'connected'; id: string; entry: SftpConnectedHostEntry }
-        | { type: 'host'; id: string; host: Host };
+    const { items, visualRows, itemIndexToVisualIndex } = useMemo(() => {
+        const nextItems: PickerItem[] = [];
+        const nextVisual: VisualRow[] = [];
+        const nextMap = new Map<number, number>();
 
-    const items = useMemo<PickerItem[]>(() => {
-        const localItem: PickerItem = { type: 'local', id: 'local' };
-        const connectedItems: PickerItem[] = filteredConnectedHosts.map((entry) => ({
-            type: 'connected',
-            id: `connected:${entry.sessionId}`,
-            entry,
-        }));
-        const hostItems: PickerItem[] = filteredHosts.map((host) => ({ type: 'host', id: host.id, host }));
-        return [localItem, ...connectedItems, ...hostItems];
-    }, [filteredConnectedHosts, filteredHosts]);
+        const pushHeader = (key: string, label: string) => {
+            nextVisual.push({ kind: 'header', key, label });
+        };
+        const pushItem = (item: PickerItem) => {
+            const itemIndex = nextItems.length;
+            nextItems.push(item);
+            nextMap.set(itemIndex, nextVisual.length);
+            nextVisual.push({ kind: 'item', key: item.id, item, itemIndex });
+        };
+
+        pushHeader('header:local', t('sftp.picker.local.badge'));
+        pushItem({ type: 'local', id: 'local' });
+
+        if (filteredConnectedHosts.length > 0) {
+            pushHeader('header:connected', t('sftp.picker.connected.section'));
+            for (const entry of filteredConnectedHosts) {
+                pushItem({
+                    type: 'connected',
+                    id: `connected:${entry.sessionId}`,
+                    entry,
+                });
+            }
+        }
+
+        pushHeader('header:hosts', t('vault.nav.hosts'));
+        if (filteredHosts.length > 0) {
+            for (const host of filteredHosts) {
+                pushItem({ type: 'host', id: host.id, host });
+            }
+        } else if (filteredConnectedHosts.length === 0) {
+            nextVisual.push({
+                kind: 'empty',
+                key: 'empty:hosts',
+                message: t('sftp.picker.noMatch'),
+            });
+        }
+
+        return {
+            items: nextItems,
+            visualRows: nextVisual,
+            itemIndexToVisualIndex: nextMap,
+        };
+    }, [filteredConnectedHosts, filteredHosts, t]);
 
     useEffect(() => {
         if (!open) return;
@@ -123,10 +175,17 @@ const SftpHostPickerInner: React.FC<SftpHostPickerProps> = ({
 
     useEffect(() => {
         if (!open) return;
-        setSelectedIndex((prev) => Math.min(prev, Math.max(items.length - 1, 0)));
+        setSelectedIndex((prev) => clampListIndex(prev, items.length));
     }, [items.length, open]);
 
-    const handleSelect = (item: PickerItem) => {
+    useEffect(() => {
+        if (!open) return;
+        const visualIndex = itemIndexToVisualIndex.get(selectedIndex);
+        if (visualIndex === undefined) return;
+        listRef.current?.scrollToIndex(visualIndex, 'auto');
+    }, [itemIndexToVisualIndex, open, selectedIndex]);
+
+    const handleSelect = useCallback((item: PickerItem) => {
         if (item.type === 'local') {
             onSelectLocal();
         } else if (item.type === 'connected') {
@@ -135,7 +194,7 @@ const SftpHostPickerInner: React.FC<SftpHostPickerProps> = ({
             onSelectHost(item.host);
         }
         onOpenChange(false);
-    };
+    }, [onOpenChange, onSelectHost, onSelectLocal]);
 
     // Match Quick Switcher: pointer movement only leaves keyboard-nav mode.
     // It must not rewrite the keyboard-selected index until the user clicks.
@@ -151,42 +210,77 @@ const SftpHostPickerInner: React.FC<SftpHostPickerProps> = ({
             e.preventDefault();
             isKeyboardNavigatingRef.current = true;
             setIsKeyboardNavigating(true);
-            setSelectedIndex((prev) => Math.min(prev + 1, items.length - 1));
+            setSelectedIndex((prev) => stepListIndex(prev, items.length, 1));
         } else if (e.key === 'ArrowUp') {
             e.preventDefault();
             isKeyboardNavigatingRef.current = true;
             setIsKeyboardNavigating(true);
-            setSelectedIndex((prev) => Math.max(prev - 1, 0));
+            setSelectedIndex((prev) => stepListIndex(prev, items.length, -1));
         } else if (e.key === 'Enter' && items.length > 0) {
             e.preventDefault();
-            handleSelect(items[selectedIndex]);
+            const item = items[clampListIndex(selectedIndex, items.length)];
+            if (!item) return;
+            handleSelect(item);
         }
     };
 
-    const itemIndexById = useMemo(() => {
-        const map = new Map<string, number>();
-        items.forEach((item, index) => map.set(item.id, index));
-        return map;
-    }, [items]);
+    const getRowHeight = useCallback((row: VisualRow) => {
+        if (row.kind === 'header') return SFTP_PICKER_HEADER_HEIGHT;
+        if (row.kind === 'empty') return SFTP_PICKER_EMPTY_HEIGHT;
+        return SFTP_PICKER_ROW_HEIGHT;
+    }, []);
 
-    const renderHostRow = (
-        itemId: string,
-        host: Host,
-        meta: { showStatus?: boolean } = {},
-    ) => {
-        const itemIndex = itemIndexById.get(itemId) ?? 0;
+    const renderRow = useCallback((row: VisualRow) => {
+        if (row.kind === 'header') {
+            return (
+                <div className="flex h-full items-end px-4 pb-1.5">
+                    <span className="text-xs font-medium text-muted-foreground">{row.label}</span>
+                </div>
+            );
+        }
+        if (row.kind === 'empty') {
+            return (
+                <div className="px-4 py-6 text-xs text-muted-foreground text-center">
+                    {row.message}
+                </div>
+            );
+        }
+
+        const { item, itemIndex } = row;
         const isSelected = selectedIndex === itemIndex;
+
+        if (item.type === 'local') {
+            return (
+                <div
+                    className={`flex items-center justify-between px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`}
+                    onClick={() => handleSelect(item)}
+                    onMouseMove={(event) => handlePointerHover(event.movementX, event.movementY)}
+                >
+                    <div className="flex items-center gap-3 min-w-0">
+                        <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
+                            <Monitor size={16} />
+                        </div>
+                        <span className="text-sm font-medium truncate">{t('sftp.picker.local.title')}</span>
+                    </div>
+                    <div className="ml-3 shrink-0 text-[11px] text-muted-foreground truncate max-w-[12rem]">
+                        {t('sftp.picker.local.desc')}
+                    </div>
+                </div>
+            );
+        }
+
+        const host = item.type === 'connected' ? item.entry.host : item.host;
+        const showStatus = item.type === 'connected';
         return (
             <div
-                key={itemId}
                 className={`flex items-center justify-between px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(isSelected, isKeyboardNavigating)}`}
-                onClick={() => handleSelect(items[itemIndex])}
+                onClick={() => handleSelect(item)}
                 onMouseMove={(event) => handlePointerHover(event.movementX, event.movementY)}
             >
                 <div className="flex items-center gap-3 min-w-0">
                     <DistroAvatar host={host} fallback={host.label.slice(0, 2).toUpperCase()} size="sm" />
                     <div className="flex min-w-0 items-center gap-1.5">
-                        {meta.showStatus ? <StatusDot /> : null}
+                        {showStatus ? <StatusDot /> : null}
                         <span className="text-sm font-medium truncate">{host.label}</span>
                     </div>
                 </div>
@@ -195,10 +289,7 @@ const SftpHostPickerInner: React.FC<SftpHostPickerProps> = ({
                 </div>
             </div>
         );
-    };
-
-    const showHostsEmpty = filteredHosts.length === 0 && filteredConnectedHosts.length === 0;
-    const localSelected = selectedIndex === 0;
+    }, [handlePointerHover, handleSelect, isKeyboardNavigating, selectedIndex, t]);
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
@@ -224,64 +315,17 @@ const SftpHostPickerInner: React.FC<SftpHostPickerProps> = ({
                     </span>
                 </div>
 
-                <ScrollArea className="max-h-[360px]">
-                    <div className="py-2">
-                        <div className="px-4 py-1.5">
-                            <span className="text-xs font-medium text-muted-foreground">
-                                {t('sftp.picker.local.badge')}
-                            </span>
-                        </div>
-                        <div
-                            className={`flex items-center justify-between px-4 py-2.5 cursor-pointer transition-colors ${getQuickSwitcherRowStateClass(localSelected, isKeyboardNavigating)}`}
-                            onClick={() => handleSelect(items[0])}
-                            onMouseMove={(event) => handlePointerHover(event.movementX, event.movementY)}
-                        >
-                            <div className="flex items-center gap-3 min-w-0">
-                                <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
-                                    <Monitor size={16} />
-                                </div>
-                                <span className="text-sm font-medium truncate">{t('sftp.picker.local.title')}</span>
-                            </div>
-                            <div className="ml-3 shrink-0 text-[11px] text-muted-foreground truncate max-w-[12rem]">
-                                {t('sftp.picker.local.desc')}
-                            </div>
-                        </div>
-
-                        {filteredConnectedHosts.length > 0 && (
-                            <>
-                                <div className="px-4 pt-3 pb-1.5">
-                                    <span className="text-xs font-medium text-muted-foreground">
-                                        {t('sftp.picker.connected.section')}
-                                    </span>
-                                </div>
-                                {filteredConnectedHosts.map((entry) =>
-                                    renderHostRow(
-                                        `connected:${entry.sessionId}`,
-                                        entry.host,
-                                        { showStatus: true },
-                                    ),
-                                )}
-                            </>
-                        )}
-
-                        {(filteredHosts.length > 0 || showHostsEmpty) && (
-                          <>
-                            <div className="px-4 pt-3 pb-1.5">
-                                <span className="text-xs font-medium text-muted-foreground">
-                                    {t('vault.nav.hosts')}
-                                </span>
-                            </div>
-                            {filteredHosts.length > 0 ? (
-                                filteredHosts.map((host) => renderHostRow(host.id, host))
-                            ) : (
-                                <div className="px-4 py-6 text-xs text-muted-foreground text-center">
-                                    {t('sftp.picker.noMatch')}
-                                </div>
-                            )}
-                          </>
-                        )}
-                    </div>
-                </ScrollArea>
+                <div className="h-[360px]" data-host-picker-virtual="sftp">
+                    <VariableSizeVirtualList<VisualRow>
+                        ref={listRef}
+                        items={visualRows}
+                        getItemHeight={getRowHeight}
+                        className="h-full"
+                        overscan={8}
+                        getItemKey={(row) => row.key}
+                        renderItem={renderRow}
+                    />
+                </div>
             </DialogContent>
         </Dialog>
     );

--- a/components/sftp/SftpHostPicker.tsx
+++ b/components/sftp/SftpHostPicker.tsx
@@ -137,12 +137,16 @@ const SftpHostPickerInner: React.FC<SftpHostPickerProps> = ({
             }
         }
 
-        pushHeader('header:hosts', t('vault.nav.hosts'));
+        // Only show the Hosts section when there are saved hosts to list, or when
+        // nothing matched at all (no connected + no saved). Avoid a dangling
+        // "Hosts" header after connected-only results hide the saved inventory.
         if (filteredHosts.length > 0) {
+            pushHeader('header:hosts', t('vault.nav.hosts'));
             for (const host of filteredHosts) {
                 pushItem({ type: 'host', id: host.id, host });
             }
         } else if (filteredConnectedHosts.length === 0) {
+            pushHeader('header:hosts', t('vault.nav.hosts'));
             nextVisual.push({
                 kind: 'empty',
                 key: 'empty:hosts',
@@ -230,6 +234,14 @@ const SftpHostPickerInner: React.FC<SftpHostPickerProps> = ({
         return SFTP_PICKER_ROW_HEIGHT;
     }, []);
 
+    // Cap at 360px for large inventories, but shrink to content for short lists
+    // (Local-only / few hosts) so the dialog does not leave a large blank region.
+    const listViewportHeight = useMemo(() => {
+        let total = 0;
+        for (const row of visualRows) total += getRowHeight(row);
+        return Math.min(360, Math.max(total, 1));
+    }, [getRowHeight, visualRows]);
+
     const renderRow = useCallback((row: VisualRow) => {
         if (row.kind === 'header') {
             return (
@@ -315,7 +327,11 @@ const SftpHostPickerInner: React.FC<SftpHostPickerProps> = ({
                     </span>
                 </div>
 
-                <div className="h-[360px]" data-host-picker-virtual="sftp">
+                <div
+                    className="max-h-[360px]"
+                    style={{ height: listViewportHeight }}
+                    data-host-picker-virtual="sftp"
+                >
                     <VariableSizeVirtualList<VisualRow>
                         ref={listRef}
                         items={visualRows}

--- a/components/ui/FixedSizeVirtualList.tsx
+++ b/components/ui/FixedSizeVirtualList.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 
 import { cn } from '../../lib/utils';
+import { getFixedSizeVirtualWindow } from './virtualListMath';
 
 const DEFAULT_OVERSCAN = 6;
 
@@ -55,6 +56,32 @@ function FixedSizeVirtualListInner<T>(
     return () => observer.disconnect();
   }, []);
 
+  const {
+    startIndex,
+    endIndex,
+    effectiveScrollTop,
+    totalHeight,
+  } = getFixedSizeVirtualWindow({
+    itemCount: items.length,
+    itemHeight,
+    scrollTop,
+    viewportHeight,
+    overscan,
+  });
+
+  // Sync the DOM scroll position when content shrinks (filter / data change).
+  // Layout already uses effectiveScrollTop so the list never blanks for a frame.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    if (container.scrollTop !== effectiveScrollTop) {
+      container.scrollTop = effectiveScrollTop;
+    }
+    if (scrollTop !== effectiveScrollTop) {
+      setScrollTop(effectiveScrollTop);
+    }
+  }, [effectiveScrollTop, scrollTop]);
+
   useImperativeHandle(ref, () => ({
     scrollToIndex: (index: number, align = 'auto') => {
       const container = containerRef.current;
@@ -82,11 +109,6 @@ function FixedSizeVirtualListInner<T>(
   const handleScroll = useCallback((event: React.UIEvent<HTMLDivElement>) => {
     setScrollTop(event.currentTarget.scrollTop);
   }, []);
-
-  const totalHeight = items.length * itemHeight;
-  const startIndex = Math.max(0, Math.floor(scrollTop / itemHeight) - overscan);
-  const visibleCount = Math.ceil(viewportHeight / itemHeight) + overscan * 2;
-  const endIndex = Math.min(items.length, startIndex + visibleCount);
 
   return (
     <div

--- a/components/ui/VariableSizeVirtualList.tsx
+++ b/components/ui/VariableSizeVirtualList.tsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 
 import { cn } from '../../lib/utils';
+import { clampScrollTop } from './virtualListMath';
 
 const DEFAULT_OVERSCAN = 6;
 
@@ -52,18 +53,23 @@ function VariableSizeVirtualListInner<T>(
     return { offsets, totalHeight: total };
   }, [getItemHeight, items]);
 
+  const effectiveScrollTop = clampScrollTop(
+    scrollTop,
+    layout.totalHeight,
+    viewportHeight,
+  );
+
+  // Sync DOM when content shrinks; render path already uses effectiveScrollTop.
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
-
-    const maxScroll = Math.max(0, layout.totalHeight - container.clientHeight);
-    if (container.scrollTop > maxScroll) {
-      container.scrollTop = maxScroll;
-      setScrollTop(maxScroll);
-    } else {
-      setScrollTop(container.scrollTop);
+    if (container.scrollTop !== effectiveScrollTop) {
+      container.scrollTop = effectiveScrollTop;
     }
-  }, [layout.totalHeight, items.length]);
+    if (scrollTop !== effectiveScrollTop) {
+      setScrollTop(effectiveScrollTop);
+    }
+  }, [effectiveScrollTop, scrollTop]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -113,29 +119,27 @@ function VariableSizeVirtualListInner<T>(
       return { startIndex: 0, endIndex: 0 };
     }
 
-    let start = 0;
-    let end = items.length;
     const { offsets } = layout;
 
-    // First visible row: largest index whose top <= scrollTop.
+    // First visible row: largest index whose top <= effectiveScrollTop.
     let lo = 0;
     let hi = items.length - 1;
     while (lo < hi) {
       const mid = Math.floor((lo + hi + 1) / 2);
-      if ((offsets[mid] ?? 0) <= scrollTop) lo = mid;
+      if ((offsets[mid] ?? 0) <= effectiveScrollTop) lo = mid;
       else hi = mid - 1;
     }
-    start = Math.max(0, lo - overscan);
+    const start = Math.max(0, lo - overscan);
 
-    const viewBottom = scrollTop + viewportHeight;
+    const viewBottom = effectiveScrollTop + viewportHeight;
     let scan = start;
     while (scan < items.length && (offsets[scan] ?? 0) < viewBottom + overscan * 40) {
       scan += 1;
     }
-    end = Math.min(items.length, scan + overscan);
+    const end = Math.min(items.length, scan + overscan);
 
     return { startIndex: start, endIndex: end };
-  }, [items.length, layout, overscan, scrollTop, viewportHeight]);
+  }, [effectiveScrollTop, items.length, layout, overscan, viewportHeight]);
 
   return (
     <div

--- a/components/ui/virtualListMath.test.ts
+++ b/components/ui/virtualListMath.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildItemIndexToVisualIndexMap,
+  clampListIndex,
+  clampScrollTop,
+  getFixedSizeVirtualWindow,
+  stepListIndex,
+} from './virtualListMath.ts';
+
+test('clampScrollTop keeps the window on-content after a deep scroll + filter shrink', () => {
+  // User was deep in a long list (scrollTop large), then filter leaves few rows.
+  assert.equal(clampScrollTop(50_000, 10 * 44, 360), Math.max(0, 10 * 44 - 360));
+  assert.equal(clampScrollTop(-10, 1000, 200), 0);
+  assert.equal(clampScrollTop(100, 1000, 200), 100);
+  assert.equal(clampScrollTop(0, 0, 200), 0);
+});
+
+test('getFixedSizeVirtualWindow never starts past the last item after shrink', () => {
+  const deep = getFixedSizeVirtualWindow({
+    itemCount: 10_000,
+    itemHeight: 44,
+    scrollTop: 40_000,
+    viewportHeight: 300,
+    overscan: 6,
+  });
+  assert.ok(deep.startIndex < 10_000);
+  assert.ok(deep.endIndex - deep.startIndex < 100);
+  assert.ok(deep.endIndex <= 10_000);
+
+  const shrunk = getFixedSizeVirtualWindow({
+    itemCount: 8,
+    itemHeight: 44,
+    scrollTop: 40_000,
+    viewportHeight: 300,
+    overscan: 6,
+  });
+  assert.equal(shrunk.effectiveScrollTop, Math.max(0, 8 * 44 - 300));
+  assert.ok(shrunk.startIndex >= 0);
+  assert.ok(shrunk.startIndex < 8);
+  assert.equal(shrunk.endIndex, 8);
+  // Window must include at least one real item so the list never blanks.
+  assert.ok(shrunk.endIndex > shrunk.startIndex);
+});
+
+test('getFixedSizeVirtualWindow only materializes a viewport-sized slice for large lists', () => {
+  const window = getFixedSizeVirtualWindow({
+    itemCount: 8_000,
+    itemHeight: 44,
+    scrollTop: 0,
+    viewportHeight: 360,
+    overscan: 8,
+  });
+  const rendered = window.endIndex - window.startIndex;
+  assert.ok(rendered > 0);
+  assert.ok(rendered < 100, `expected viewport window, got ${rendered}`);
+  assert.equal(window.startIndex, 0);
+});
+
+test('clampListIndex and stepListIndex never produce -1 on empty or non-empty lists', () => {
+  assert.equal(clampListIndex(-1, 0), 0);
+  assert.equal(clampListIndex(5, 0), 0);
+  assert.equal(clampListIndex(-1, 5), 0);
+  assert.equal(clampListIndex(99, 5), 4);
+  assert.equal(clampListIndex(2, 5), 2);
+
+  assert.equal(stepListIndex(0, 0, 1), 0);
+  assert.equal(stepListIndex(0, 0, -1), 0);
+  // Empty list + ArrowDown must not go to -1 (QuickSwitcher regression).
+  assert.equal(stepListIndex(0, 0, 1), 0);
+  assert.equal(stepListIndex(0, 3, 1), 1);
+  assert.equal(stepListIndex(2, 3, 1), 2);
+  assert.equal(stepListIndex(0, 3, -1), 0);
+});
+
+test('buildItemIndexToVisualIndexMap skips headers for keyboard scroll targets', () => {
+  const visual = [
+    { kind: 'header' },
+    { kind: 'item' },
+    { kind: 'item' },
+    { kind: 'header' },
+    { kind: 'item' },
+  ];
+  const map = buildItemIndexToVisualIndexMap(visual);
+  assert.equal(map.get(0), 1);
+  assert.equal(map.get(1), 2);
+  assert.equal(map.get(2), 4);
+  assert.equal(map.size, 3);
+  // Keyboard index 1 scrolls to visual row 2 (second host, after first header).
+  assert.notEqual(map.get(1), 1);
+});

--- a/components/ui/virtualListMath.ts
+++ b/components/ui/virtualListMath.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure math for virtual lists and keyboard cursors.
+ * Kept free of React so tests drive the same functions the pickers use.
+ */
+
+export function clampScrollTop(
+  scrollTop: number,
+  totalHeight: number,
+  viewportHeight: number,
+): number {
+  const maxScroll = Math.max(0, totalHeight - Math.max(viewportHeight, 0));
+  return Math.min(Math.max(0, scrollTop), maxScroll);
+}
+
+export function getFixedSizeVirtualWindow({
+  itemCount,
+  itemHeight,
+  scrollTop,
+  viewportHeight,
+  overscan,
+}: {
+  itemCount: number;
+  itemHeight: number;
+  scrollTop: number;
+  viewportHeight: number;
+  overscan: number;
+}): { startIndex: number; endIndex: number; effectiveScrollTop: number; totalHeight: number } {
+  const totalHeight = Math.max(0, itemCount * itemHeight);
+  const effectiveScrollTop = clampScrollTop(scrollTop, totalHeight, viewportHeight);
+  if (itemCount <= 0 || itemHeight <= 0) {
+    return { startIndex: 0, endIndex: 0, effectiveScrollTop, totalHeight };
+  }
+  const startIndex = Math.max(0, Math.floor(effectiveScrollTop / itemHeight) - overscan);
+  const visibleCount = Math.ceil(Math.max(viewportHeight, 1) / itemHeight) + overscan * 2;
+  const endIndex = Math.min(itemCount, startIndex + visibleCount);
+  return { startIndex, endIndex, effectiveScrollTop, totalHeight };
+}
+
+/** Clamp a keyboard cursor into [0, length-1], or 0 when the list is empty. */
+export function clampListIndex(index: number, length: number): number {
+  if (length <= 0) return 0;
+  if (!Number.isFinite(index)) return 0;
+  return Math.max(0, Math.min(Math.trunc(index), length - 1));
+}
+
+/** Move a keyboard cursor by delta without ever landing on -1. */
+export function stepListIndex(index: number, length: number, delta: number): number {
+  if (length <= 0) return 0;
+  return clampListIndex(index + delta, length);
+}
+
+/**
+ * Map selectable item indices to visual row indices for lists that interleave
+ * non-selectable chrome (headers, hints, empty rows).
+ */
+export function buildItemIndexToVisualIndexMap(
+  visualRows: ReadonlyArray<{ kind: string }>,
+  itemKind = 'item',
+): Map<number, number> {
+  const map = new Map<number, number>();
+  let itemIndex = 0;
+  visualRows.forEach((row, visualIndex) => {
+    if (row.kind !== itemKind) return;
+    map.set(itemIndex, visualIndex);
+    itemIndex += 1;
+  });
+  return map;
+}

--- a/components/workspace/AddToWorkspaceDialog.tsx
+++ b/components/workspace/AddToWorkspaceDialog.tsx
@@ -5,12 +5,16 @@
  * the right and a thin footer to commit the selection.
  */
 import { Check, Search, Terminal } from 'lucide-react';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Host } from '../../types';
 import { DistroAvatar } from '../DistroAvatar';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
-import { ScrollArea } from '../ui/scroll-area';
+import {
+  VariableSizeVirtualList,
+  type VariableSizeVirtualListHandle,
+} from '../ui/VariableSizeVirtualList';
+import { clampListIndex, stepListIndex } from '../ui/virtualListMath';
 
 export type AddTarget =
   | { kind: 'local' }
@@ -25,10 +29,18 @@ interface AddToWorkspaceDialogProps {
 }
 
 const LOCAL_ITEM_ID = '__local-terminal__';
+const ADD_WS_ROW_HEIGHT = 44;
+const ADD_WS_HEADER_HEIGHT = 32;
+const ADD_WS_HINT_HEIGHT = 36;
 
 type Item =
   | { type: 'local'; id: typeof LOCAL_ITEM_ID }
   | { type: 'host'; id: string; host: Host };
+
+type VisualRow =
+  | { kind: 'hint'; key: string }
+  | { kind: 'header'; key: string; label: string }
+  | { kind: 'item'; key: string; item: Item; itemIndex: number };
 
 export function shouldToggleWorkspaceTarget(
   key: string,
@@ -62,6 +74,7 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<VariableSizeVirtualListHandle>(null);
 
   // Reset on open + auto-focus the search input.
   useEffect(() => {
@@ -109,26 +122,60 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
     );
   }, [selectableHosts, query]);
 
-  const items = useMemo<Item[]>(() => {
+  const { items, visualRows, itemIndexToVisualIndex } = useMemo(() => {
     const list: Item[] = [];
-    if (localMatches) list.push({ type: 'local', id: LOCAL_ITEM_ID });
-    for (const h of filteredHosts) list.push({ type: 'host', id: h.id, host: h });
-    return list;
-  }, [localMatches, filteredHosts]);
+    const visual: VisualRow[] = [{ kind: 'hint', key: 'hint' }];
+    const itemToVisual = new Map<number, number>();
 
-  const toggle = (id: string) => {
+    const pushHeader = (key: string, label: string) => {
+      visual.push({ kind: 'header', key, label });
+    };
+    const pushItem = (item: Item) => {
+      const itemIndex = list.length;
+      list.push(item);
+      itemToVisual.set(itemIndex, visual.length);
+      visual.push({ kind: 'item', key: item.id, item, itemIndex });
+    };
+
+    if (localMatches) {
+      pushHeader('header:local', 'Local Shells');
+      pushItem({ type: 'local', id: LOCAL_ITEM_ID });
+    }
+    if (filteredHosts.length > 0) {
+      pushHeader('header:hosts', 'Hosts');
+      for (const host of filteredHosts) {
+        pushItem({ type: 'host', id: host.id, host });
+      }
+    }
+
+    return { items: list, visualRows: visual, itemIndexToVisualIndex: itemToVisual };
+  }, [filteredHosts, localMatches]);
+
+  useEffect(() => {
+    if (!open) return;
+    setSelectedIndex((prev) => clampListIndex(prev, items.length));
+  }, [items.length, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const visualIndex = itemIndexToVisualIndex.get(selectedIndex);
+    if (visualIndex === undefined) return;
+    listRef.current?.scrollToIndex(visualIndex, 'auto');
+  }, [itemIndexToVisualIndex, open, selectedIndex]);
+
+  const toggle = useCallback((id: string) => {
     setSelected((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id); else next.add(id);
       return next;
     });
-  };
+  }, []);
 
-  const handleTargetClick = (index: number, id: string) => {
+  const handleTargetClick = useCallback((index: number, id: string) => {
     setSelectedIndex(index);
     toggle(id);
     inputRef.current?.focus();
-  };
+  }, [toggle]);
 
   const handleCommit = () => {
     if (selected.size === 0) return;
@@ -150,25 +197,92 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
     }
     if (e.key === 'ArrowDown') {
       e.preventDefault();
-      setSelectedIndex((i) => Math.min(i + 1, Math.max(items.length - 1, 0)));
+      setSelectedIndex((i) => stepListIndex(i, items.length, 1));
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
-      setSelectedIndex((i) => Math.max(i - 1, 0));
+      setSelectedIndex((i) => stepListIndex(i, items.length, -1));
     } else if (shouldToggleWorkspaceTarget(e.key, query, e.metaKey, e.ctrlKey)) {
       if (items.length === 0) return;
       e.preventDefault();
-      toggle(items[selectedIndex].id);
+      const item = items[clampListIndex(selectedIndex, items.length)];
+      if (!item) return;
+      toggle(item.id);
     } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
       handleCommit();
     }
   };
 
+  const getRowHeight = useCallback((row: VisualRow) => {
+    if (row.kind === 'hint') return ADD_WS_HINT_HEIGHT;
+    if (row.kind === 'header') return ADD_WS_HEADER_HEIGHT;
+    return ADD_WS_ROW_HEIGHT;
+  }, []);
+
+  const renderRow = useCallback((row: VisualRow) => {
+    if (row.kind === 'hint') {
+      return (
+        <div className="px-4 py-2 flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">Pick one or more</span>
+          <kbd className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded">Space / Enter</kbd>
+          <span className="text-[10px] text-muted-foreground">toggle</span>
+          <kbd className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded">
+            {typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform) ? '⌘' : 'Ctrl'}+Enter
+          </kbd>
+          <span className="text-[10px] text-muted-foreground">add</span>
+        </div>
+      );
+    }
+    if (row.kind === 'header') {
+      return (
+        <div className="flex h-full items-end px-4 pb-1.5">
+          <span className="text-xs font-medium text-muted-foreground">{row.label}</span>
+        </div>
+      );
+    }
+
+    const { item, itemIndex: idx } = row;
+    const isCursor = idx === selectedIndex;
+    const isChecked = selected.has(item.id);
+
+    if (item.type === 'local') {
+      return (
+        <div
+          className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getWorkspaceTargetRowStateClass(isCursor, isChecked)}`}
+          onClick={() => handleTargetClick(idx, LOCAL_ITEM_ID)}
+        >
+          <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
+            <Terminal size={16} />
+          </div>
+          <span className="text-sm font-medium flex-1 truncate">Local Terminal</span>
+          {isChecked && <Check size={14} className="text-primary flex-shrink-0" />}
+        </div>
+      );
+    }
+
+    const host = item.host;
+    return (
+      <div
+        className={`flex items-center justify-between px-4 py-2.5 cursor-pointer transition-colors ${getWorkspaceTargetRowStateClass(isCursor, isChecked)}`}
+        onClick={() => handleTargetClick(idx, host.id)}
+      >
+        <div className="flex items-center gap-3 min-w-0">
+          <DistroAvatar host={host} fallback={(host.label || host.hostname).slice(0, 2).toUpperCase()} size="sm" />
+          <span className="text-sm font-medium truncate">{host.label || host.hostname}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="text-[11px] text-muted-foreground">
+            {host.group ? `Personal / ${host.group}` : 'Personal'}
+          </div>
+          {isChecked && <Check size={14} className="text-primary flex-shrink-0" />}
+        </div>
+      </div>
+    );
+  }, [handleTargetClick, selected, selectedIndex]);
+
   if (!open) return null;
 
   const count = selected.size;
-  const localIndex = items.findIndex((it) => it.type === 'local');
-  const firstHostIndex = items.findIndex((it) => it.type === 'host');
 
   return (
     <div
@@ -201,86 +315,23 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
           )}
         </div>
 
-        <ScrollArea className="flex-1 h-full">
-          <div>
-            {/* Jump-to hint */}
-            <div className="px-4 py-2 flex items-center gap-2">
-              <span className="text-xs text-muted-foreground">Pick one or more</span>
-              <kbd className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded">Space / Enter</kbd>
-              <span className="text-[10px] text-muted-foreground">toggle</span>
-              <kbd className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded">
-                {typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform) ? '⌘' : 'Ctrl'}+Enter
-              </kbd>
-              <span className="text-[10px] text-muted-foreground">add</span>
+        <div className="min-h-0 flex-1" data-host-picker-virtual="add-workspace">
+          {items.length === 0 ? (
+            <div className="px-4 py-8 text-center text-xs text-muted-foreground">
+              No matches
             </div>
-
-            {/* Local Shells section */}
-            {localIndex !== -1 && (
-              <div>
-                <div className="px-4 py-1.5">
-                  <span className="text-xs font-medium text-muted-foreground">
-                    Local Shells
-                  </span>
-                </div>
-                {(() => {
-                  const idx = localIndex;
-                  const isCursor = idx === selectedIndex;
-                  const isChecked = selected.has(LOCAL_ITEM_ID);
-                  return (
-                    <div
-                      className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getWorkspaceTargetRowStateClass(isCursor, isChecked)}`}
-                      onClick={() => handleTargetClick(idx, LOCAL_ITEM_ID)}
-                    >
-                      <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
-                        <Terminal size={16} />
-                      </div>
-                      <span className="text-sm font-medium flex-1 truncate">Local Terminal</span>
-                      {isChecked && <Check size={14} className="text-primary flex-shrink-0" />}
-                    </div>
-                  );
-                })()}
-              </div>
-            )}
-
-            {/* Hosts section */}
-            {filteredHosts.length > 0 && (
-              <div>
-                <div className="px-4 py-1.5">
-                  <span className="text-xs font-medium text-muted-foreground">Hosts</span>
-                </div>
-                {filteredHosts.map((host, i) => {
-                  const idx = firstHostIndex + i;
-                  const isCursor = idx === selectedIndex;
-                  const isChecked = selected.has(host.id);
-                  return (
-                    <div
-                      key={host.id}
-                      className={`flex items-center justify-between px-4 py-2.5 cursor-pointer transition-colors ${getWorkspaceTargetRowStateClass(isCursor, isChecked)}`}
-                      onClick={() => handleTargetClick(idx, host.id)}
-                    >
-                      <div className="flex items-center gap-3 min-w-0">
-                        <DistroAvatar host={host} fallback={(host.label || host.hostname).slice(0, 2).toUpperCase()} size="sm" />
-                        <span className="text-sm font-medium truncate">{host.label || host.hostname}</span>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <div className="text-[11px] text-muted-foreground">
-                          {host.group ? `Personal / ${host.group}` : 'Personal'}
-                        </div>
-                        {isChecked && <Check size={14} className="text-primary flex-shrink-0" />}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-
-            {items.length === 0 && (
-              <div className="px-4 py-8 text-center text-xs text-muted-foreground">
-                No matches
-              </div>
-            )}
-          </div>
-        </ScrollArea>
+          ) : (
+            <VariableSizeVirtualList<VisualRow>
+              ref={listRef}
+              items={visualRows}
+              getItemHeight={getRowHeight}
+              className="h-full"
+              overscan={8}
+              getItemKey={(row) => row.key}
+              renderItem={renderRow}
+            />
+          )}
+        </div>
 
         {/* Slim footer to commit. Kept minimal so the layout feels like
             QuickSwitcher's chrome with a single action strip tacked on. */}

--- a/components/workspace/AddToWorkspaceDialog.tsx
+++ b/components/workspace/AddToWorkspaceDialog.tsx
@@ -248,14 +248,14 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
     if (item.type === 'local') {
       return (
         <div
-          className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getWorkspaceTargetRowStateClass(isCursor, isChecked)}`}
+          className={`flex h-full min-h-0 items-center gap-3 overflow-hidden px-4 py-2.5 cursor-pointer transition-colors ${getWorkspaceTargetRowStateClass(isCursor, isChecked)}`}
           onClick={() => handleTargetClick(idx, LOCAL_ITEM_ID)}
         >
-          <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
+          <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground">
             <Terminal size={16} />
           </div>
-          <span className="text-sm font-medium flex-1 truncate">Local Terminal</span>
-          {isChecked && <Check size={14} className="text-primary flex-shrink-0" />}
+          <span className="min-w-0 flex-1 truncate text-sm font-medium">Local Terminal</span>
+          {isChecked && <Check size={14} className="text-primary shrink-0" />}
         </div>
       );
     }
@@ -263,18 +263,18 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
     const host = item.host;
     return (
       <div
-        className={`flex items-center justify-between px-4 py-2.5 cursor-pointer transition-colors ${getWorkspaceTargetRowStateClass(isCursor, isChecked)}`}
+        className={`flex h-full min-h-0 items-center justify-between overflow-hidden px-4 py-2.5 cursor-pointer transition-colors ${getWorkspaceTargetRowStateClass(isCursor, isChecked)}`}
         onClick={() => handleTargetClick(idx, host.id)}
       >
-        <div className="flex items-center gap-3 min-w-0">
+        <div className="flex min-w-0 items-center gap-3">
           <DistroAvatar host={host} fallback={(host.label || host.hostname).slice(0, 2).toUpperCase()} size="sm" />
-          <span className="text-sm font-medium truncate">{host.label || host.hostname}</span>
+          <span className="truncate text-sm font-medium">{host.label || host.hostname}</span>
         </div>
-        <div className="flex items-center gap-2">
-          <div className="text-[11px] text-muted-foreground">
+        <div className="ml-2 flex min-w-0 shrink-0 items-center gap-2">
+          <div className="max-w-[12rem] truncate text-[11px] text-muted-foreground">
             {host.group ? `Personal / ${host.group}` : 'Personal'}
           </div>
-          {isChecked && <Check size={14} className="text-primary flex-shrink-0" />}
+          {isChecked && <Check size={14} className="text-primary shrink-0" />}
         </div>
       </div>
     );

--- a/components/workspace/AddToWorkspaceDialog.tsx
+++ b/components/workspace/AddToWorkspaceDialog.tsx
@@ -315,7 +315,11 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
           )}
         </div>
 
-        <div className="min-h-0 flex-1" data-host-picker-virtual="add-workspace">
+        {/*
+          Same max-h flex trap as Quick Switcher: list must not grow with the virtual
+          spacer or hosts below the first screen become unreachable.
+        */}
+        <div className="min-h-0 flex-1 overflow-hidden" data-host-picker-virtual="add-workspace">
           {items.length === 0 ? (
             <div className="px-4 py-8 text-center text-xs text-muted-foreground">
               No matches
@@ -325,7 +329,7 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
               ref={listRef}
               items={visualRows}
               getItemHeight={getRowHeight}
-              className="h-full"
+              className="h-full max-h-[min(360px,calc(100vh-14rem))]"
               overscan={8}
               getItemKey={(row) => row.key}
               renderItem={renderRow}


### PR DESCRIPTION
## Summary

Virtualizes every remaining large host-picker surface so extreme inventories (thousands–tens of thousands of hosts) stay responsive. Select Host panel/dialog, Quick Switcher, SFTP host picker, Add to Workspace, and Create Workspace now render only the visible window instead of mapping every host into the DOM.

Also hardens virtual-list scroll clamping and keyboard cursors so empty search, filter-while-scrolled, and list shrink cannot blank the list or drive `selectedIndex` to `-1`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [x] Other (please describe): Performance improvement

## Related Issue (optional)

N/A

## Changes Made

- Virtualize `SelectHostPanelContent` with flattened group/host rows + listbox keyboard model
- Virtualize `QuickSwitcher` categorized host/tab/shell/plugin rows
- Virtualize `SftpHostPicker` (local / connected / hosts)
- Virtualize `AddToWorkspaceDialog` and `CreateWorkspaceDialog` host lists
- Extract shared `virtualListMath` (scroll clamp, fixed window, keyboard index step)
- Apply render-path `effectiveScrollTop` clamp in Fixed/Variable virtual lists
- Add unit tests that drive shipped math (viewport slice, empty ArrowDown, visual index map)

## Screenshots / Demo

No visual redesign; same row chrome with virtualized scrolling under large host sets.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Focused tests (28/28 pass):

```
node --test --import tsx \
  components/ui/virtualListMath.test.ts \
  components/hostPickerVirtualization.test.ts \
  components/sftp/SftpHostPicker.test.ts \
  components/AddToWorkspaceDialog.keyboard.test.ts \
  components/QuickSwitcher.pluginContributions.test.tsx
```

ESLint on all changed TS/TSX files: clean (0 errors).

Two independent code reviews after fixes: CLEAN (no remaining blocking findings).

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)