### PR TITLE
fix(terminal): suppress autocomplete popup on alternate screen (#2530)

### DIFF
--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -644,13 +644,14 @@ export function useTerminalAutocomplete(
       return;
     }
 
-    // Suppress autocomplete while a full-screen TUI owns the alternate screen
-    // buffer (codex CLI, vim, htop, less, …). These apps render their own input
-    // UI on the alternate buffer; Netcatty's popup/ghost text would clash with
-    // it — e.g. codex's "/" slash-command menu gets covered by our path/command
-    // popup because codex's composer line also matches the shell-prompt
-    // heuristic. Bail before prompt detection so neither popup nor ghost text
-    // is produced. #2530
+    // Suppress autocomplete for the entire alternate screen buffer (codex CLI,
+    // vim, htop, less, …). Full-screen apps own their own input UI there;
+    // Netcatty's popup/ghost text would clash — e.g. codex's "/" slash-command
+    // menu gets covered because the composer line also matches the shell-prompt
+    // heuristic. This is intentionally unconditional: multiplexers (tmux/screen)
+    // also keep the outer xterm on the alternate buffer for the whole session,
+    // so Netcatty autocomplete is off while attached — same simple tradeoff as
+    // other terminal hosts, rather than chasing TUI-vs-shell heuristics. #2530
     if (isTerminalAlternateScreenActive(term)) {
       clearState();
       return;

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -726,6 +726,15 @@ export function useTerminalAutocomplete(
 
     if (disposedRef.current || version !== fetchVersionRef.current) return;
 
+    // Recheck after the async lookup: the terminal may have entered the
+    // alternate screen while provideCompletions was pending (e.g. launching
+    // codex/vim). Without this, ghost/popup from a normal-buffer query can
+    // paint over the TUI. #2530
+    if (isTerminalAlternateScreenActive(term)) {
+      clearState();
+      return;
+    }
+
     // Discard stale results: if the user kept typing while getCompletions was running,
     // the current prompt input will have changed. Re-detect and compare.
     const { prompt: currentPrompt } = getAlignedPrompt(term, typedInputBufferRef.current, typedBufferReliableRef.current);

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -37,6 +37,7 @@ import {
 } from "./terminalAutocompleteLayout";
 import { handleTerminalAutocompleteInput } from "./terminalAutocompleteInput";
 import { handleTerminalAutocompleteKeyEvent } from "./terminalAutocompleteKeyEvent";
+import { isTerminalAlternateScreenActive } from "../terminalHibernateRuntime";
 
 export interface AutocompleteSettings {
   enabled: boolean;
@@ -640,6 +641,18 @@ export function useTerminalAutocomplete(
   const fetchSuggestions = useCallback(async () => {
     const term = termRef.current;
     if (!term || disposedRef.current || !settingsRef.current.enabled) {
+      return;
+    }
+
+    // Suppress autocomplete while a full-screen TUI owns the alternate screen
+    // buffer (codex CLI, vim, htop, less, …). These apps render their own input
+    // UI on the alternate buffer; Netcatty's popup/ghost text would clash with
+    // it — e.g. codex's "/" slash-command menu gets covered by our path/command
+    // popup because codex's composer line also matches the shell-prompt
+    // heuristic. Bail before prompt detection so neither popup nor ghost text
+    // is produced. #2530
+    if (isTerminalAlternateScreenActive(term)) {
+      clearState();
       return;
     }
 


### PR DESCRIPTION
## Summary

When typing `/` inside codex CLI to bring up its slash-command menu, Netcatty's own command/path autocomplete popup is rendered on top of it. Root cause: Netcatty's autocomplete only gates on its shell-prompt heuristic, and codex's TUI composer line happens to match that heuristic — so `/` triggers Netcatty's completion query and popup.

## Type of Change

- [x] Bug fix

## Related Issue (optional)

Closes #2530

## Changes Made

- Added an **unconditional** alternate-screen guard at the top of `fetchSuggestions` in `useTerminalAutocomplete.ts`: when `term.buffer.active` is the alternate buffer, bail out via `clearState()` and produce no completions (popup or ghost text).
- Reuses the existing `isTerminalAlternateScreenActive` helper (`terminalHibernateRuntime.ts`), already used by the hibernate path.

### Why this works (and stays simple)

codex CLI's TUI enters the alternate screen by default, so `buffer.active.type === "alternate"` is true for the entire TUI lifetime. Guarding the single query entry point suppresses both popup and ghost text. Tab / arrow keys only act when `popupVisible` is already true, so they cannot bypass the gate.

This matches how other terminal hosts treat full-screen apps (vim / htop / less / TUIs).

### Intentional tradeoff

Multiplexers (tmux / screen) also keep the outer xterm on the alternate buffer for the whole attach session. **Netcatty autocomplete is intentionally off while attached to a multiplexer.** We tried narrower TUI-vs-shell heuristics via the Codex auto-fix loop; the complexity was not worth the edge-case surface. Accept the simple ban.

### Out of scope

- `codex --no-alt-screen` / `tui.alternate_screen = "never"` (inline mode without alt screen)
- Re-enabling autocomplete inside tmux panes with ordinary shell prompts

## Testing

- [x] Linting passes
- [x] Existing hibernate / autocomplete tests still apply
- [ ] Local manual: open codex, type `/` — Netcatty popup must not cover codex menu

## Checklist

- [x] My code follows the existing project style
- [x] I have not introduced any breaking changes