### PR TITLE
fix(ai): route auto-detected network devices to raw PTY exec (#2367)

### DIFF
--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -8,6 +8,9 @@ import { getTopTabInsertionTarget, isPointInsideRect, WORKSPACE_SESSION_DRAG_TYP
 import { useAIState } from '../../application/state/useAIState';
 import { useStoredBoolean } from '../../application/state/useStoredBoolean';
 import { isSavedVaultHost } from '../../domain/ephemeralHosts';
+import { buildAITerminalSessionInfo, type AITerminalSessionInfo } from './buildAITerminalSessionInfo';
+export { buildAITerminalSessionInfo };
+export type { AITerminalSessionInfo };
 import { collectSessionIds, SplitDirection } from '../../domain/workspace';
 import { resolveSessionTabTitle } from '../../domain/sessionTabTitle';
 import {
@@ -262,42 +265,6 @@ export const hasNotifiableTerminalOutput = (filter: ChunkedEscapeFilter, chunk: 
   return filter.feed(chunk).trim().length > 0;
 };
 
-export type AITerminalSessionInfo = {
-  sessionId: string;
-  hostId: string;
-  hostname: string;
-  label: string;
-  os?: string;
-  username?: string;
-  protocol?: string;
-  shellType?: string;
-  deviceType?: string;
-  connected: boolean;
-  hostChain?: Array<{ hostId: string; label?: string; hostname?: string }>;
-  activePortForwards?: Array<{
-    ruleId: string;
-    label?: string;
-    type?: string;
-    localPort?: number;
-    status?: string;
-  }>;
-};
-
-function summarizeHostChain(
-  host: Host | undefined,
-  allHosts: Host[],
-): AITerminalSessionInfo['hostChain'] | undefined {
-  if (!host?.hostChain?.hostIds?.length) return undefined;
-  return host.hostChain.hostIds.map((hostId) => {
-    const jumpHost = allHosts.find((entry) => entry.id === hostId);
-    return {
-      hostId,
-      label: jumpHost?.label,
-      hostname: jumpHost?.hostname,
-    };
-  });
-}
-
 export type AIPanelContext = {
   scopeType: 'terminal' | 'workspace';
   scopeTargetId?: string;
@@ -309,48 +276,6 @@ export type AIPanelContext = {
 type AIStateValue = ReturnType<typeof useAIState>;
 
 const AIStateContext = createContext<AIStateValue | null>(null);
-
-export const buildAITerminalSessionInfo = (
-  session: TerminalSession | undefined,
-  host: Host | undefined,
-  localOs: 'linux' | 'macos' | 'windows',
-  options?: {
-    allHosts?: Host[];
-    portForwardingRules?: import('../../domain/models').PortForwardingRule[];
-  },
-): AITerminalSessionInfo => {
-  const protocol = session?.protocol || host?.protocol;
-  const isLocalSession = protocol === 'local' || session?.hostId?.startsWith('local-');
-  const allHosts = options?.allHosts ?? (host ? [host] : []);
-  const hostChain = summarizeHostChain(host, allHosts);
-  const activePortForwards = host?.id && options?.portForwardingRules
-    ? options.portForwardingRules
-      .filter((rule) => rule.hostId === host.id && (rule.status === 'active' || rule.status === 'connecting'))
-      .map((rule) => ({
-        ruleId: rule.id,
-        label: rule.label,
-        type: rule.type,
-        localPort: rule.localPort,
-        status: rule.status,
-      }))
-    : undefined;
-  return {
-    sessionId: session?.id || '',
-    hostId: session?.hostId || '',
-    hostname: host?.hostname || session?.hostname || '',
-    label: host?.label || session?.hostLabel || '',
-    os: host?.os || (isLocalSession ? localOs : undefined),
-    username: host?.username || session?.username,
-    protocol,
-    shellType: session?.shellType && session.shellType !== 'unknown' ? session.shellType : undefined,
-    // Suppress deviceType for Mosh / ET sessions — both require a shell-backed
-    // PTY and cannot connect to vendor CLIs, so network device mode doesn't apply.
-    deviceType: (session?.moshEnabled || host?.moshEnabled || session?.etEnabled || host?.etEnabled) ? undefined : host?.deviceType,
-    connected: session?.status === 'connected',
-    ...(hostChain?.length ? { hostChain } : {}),
-    ...(activePortForwards?.length ? { activePortForwards } : {}),
-  };
-};
 
 interface AIChatPanelsHostProps {
   mountedTabIds: string[];

--- a/components/terminalLayer/buildAITerminalSessionInfo.test.ts
+++ b/components/terminalLayer/buildAITerminalSessionInfo.test.ts
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildAITerminalSessionInfo } from "./buildAITerminalSessionInfo";
+import type { Host, TerminalSession } from "../../types";
+
+const baseHost = (overrides: Partial<Host> = {}): Host =>
+  ({
+    id: "h1",
+    label: "sw1",
+    hostname: "10.0.0.1",
+    username: "admin",
+    protocol: "ssh",
+    ...overrides,
+  } as Host);
+
+const baseSession = (overrides: Partial<TerminalSession> = {}): TerminalSession =>
+  ({
+    id: "s1",
+    hostId: "h1",
+    protocol: "ssh",
+    status: "connected",
+    ...overrides,
+  } as TerminalSession);
+
+test("keeps explicit network deviceType", () => {
+  const info = buildAITerminalSessionInfo(
+    baseSession(),
+    baseHost({ deviceType: "network" }),
+    "linux",
+  );
+  assert.equal(info.deviceType, "network");
+});
+
+test("reports 'network' when the detected distro classifies as a network device (#2367)", () => {
+  // Huawei VRP is a known network-device vendor id; the user has NOT flipped
+  // Network Device Mode, so host.deviceType is unset.
+  const info = buildAITerminalSessionInfo(
+    baseSession(),
+    baseHost({ distro: "huawei" }),
+    "linux",
+  );
+  assert.equal(info.deviceType, "network");
+});
+
+test("does not force network for a normal linux distro", () => {
+  const info = buildAITerminalSessionInfo(
+    baseSession(),
+    baseHost({ distro: "ubuntu" }),
+    "linux",
+  );
+  assert.notEqual(info.deviceType, "network");
+});
+
+test("suppresses network deviceType for Mosh sessions", () => {
+  const info = buildAITerminalSessionInfo(
+    baseSession({ moshEnabled: true }),
+    baseHost({ distro: "huawei", deviceType: "network" }),
+    "linux",
+  );
+  assert.equal(info.deviceType, undefined);
+});
+
+test("suppresses network deviceType for ET sessions", () => {
+  const info = buildAITerminalSessionInfo(
+    baseSession({ etEnabled: true }),
+    baseHost({ deviceType: "network" }),
+    "linux",
+  );
+  assert.equal(info.deviceType, undefined);
+});

--- a/components/terminalLayer/buildAITerminalSessionInfo.test.ts
+++ b/components/terminalLayer/buildAITerminalSessionInfo.test.ts
@@ -52,6 +52,21 @@ test("does not force network for a normal linux distro", () => {
   assert.notEqual(info.deviceType, "network");
 });
 
+test("does not misclassify a distro that merely contains a vendor keyword as a substring", () => {
+  // Classification is exact-match against the vendor id list, not a substring
+  // scan: a custom distro string that merely embeds "cisco"/"huawei" must NOT
+  // be treated as a network device (guards against a false positive that would
+  // send raw, shell-unwrapped commands to a real POSIX host).
+  for (const distro of ["cisco-lab-server", "my-huawei-cloud", "cisco linux", "fortinet-vm"]) {
+    const info = buildAITerminalSessionInfo(
+      baseSession(),
+      baseHost({ distro }),
+      "linux",
+    );
+    assert.notEqual(info.deviceType, "network", `distro "${distro}" should not be network`);
+  }
+});
+
 test("suppresses network deviceType for Mosh sessions", () => {
   const info = buildAITerminalSessionInfo(
     baseSession({ moshEnabled: true }),

--- a/components/terminalLayer/buildAITerminalSessionInfo.ts
+++ b/components/terminalLayer/buildAITerminalSessionInfo.ts
@@ -1,0 +1,95 @@
+import { classifyDistroId } from '../../domain/host';
+import type { PortForwardingRule } from '../../domain/models';
+import type { Host, TerminalSession } from '../../types';
+
+export type AITerminalSessionInfo = {
+  sessionId: string;
+  hostId: string;
+  hostname: string;
+  label: string;
+  os?: string;
+  username?: string;
+  protocol?: string;
+  shellType?: string;
+  deviceType?: string;
+  connected: boolean;
+  hostChain?: Array<{ hostId: string; label?: string; hostname?: string }>;
+  activePortForwards?: Array<{
+    ruleId: string;
+    label?: string;
+    type?: string;
+    localPort?: number;
+    status?: string;
+  }>;
+};
+
+function summarizeHostChain(
+  host: Host | undefined,
+  allHosts: Host[],
+): AITerminalSessionInfo['hostChain'] | undefined {
+  if (!host?.hostChain?.hostIds?.length) return undefined;
+  return host.hostChain.hostIds.map((hostId) => {
+    const jumpHost = allHosts.find((entry) => entry.id === hostId);
+    return {
+      hostId,
+      label: jumpHost?.label,
+      hostname: jumpHost?.hostname,
+    };
+  });
+}
+
+export const buildAITerminalSessionInfo = (
+  session: TerminalSession | undefined,
+  host: Host | undefined,
+  localOs: 'linux' | 'macos' | 'windows',
+  options?: {
+    allHosts?: Host[];
+    portForwardingRules?: PortForwardingRule[];
+  },
+): AITerminalSessionInfo => {
+  const protocol = session?.protocol || host?.protocol;
+  const isLocalSession = protocol === 'local' || session?.hostId?.startsWith('local-');
+  const allHosts = options?.allHosts ?? (host ? [host] : []);
+  const hostChain = summarizeHostChain(host, allHosts);
+  const activePortForwards = host?.id && options?.portForwardingRules
+    ? options.portForwardingRules
+      .filter((rule) => rule.hostId === host.id && (rule.status === 'active' || rule.status === 'connecting'))
+      .map((rule) => ({
+        ruleId: rule.id,
+        label: rule.label,
+        type: rule.type,
+        localPort: rule.localPort,
+        status: rule.status,
+      }))
+    : undefined;
+  // Mosh / ET sessions always run over a shell-backed PTY and cannot reach a
+  // vendor CLI, so network device mode never applies to them.
+  const isMoshOrEt = Boolean(
+    session?.moshEnabled || host?.moshEnabled || session?.etEnabled || host?.etEnabled,
+  );
+  // Report 'network' when the host is explicitly a network device OR when the
+  // detected distro/vendor classifies as one (Huawei VRP, Cisco IOS, …). This
+  // mirrors the terminal's own gating (Terminal.tsx / systemTarget.ts) so AI
+  // exec skips shell wrapping (routing to the raw-PTY path) and the system
+  // prompt gets vendor-CLI guidance even before the user manually flips
+  // Network Device Mode (#2367).
+  const isNetworkDevice = host?.deviceType === 'network'
+    || classifyDistroId(host?.distro) === 'network-device';
+  const deviceType = isMoshOrEt
+    ? undefined
+    : (isNetworkDevice ? 'network' : host?.deviceType);
+  return {
+    sessionId: session?.id || '',
+    hostId: session?.hostId || '',
+    hostname: host?.hostname || session?.hostname || '',
+    label: host?.label || session?.hostLabel || '',
+    os: host?.os || (isLocalSession ? localOs : undefined),
+    username: host?.username || session?.username,
+    protocol,
+    shellType: session?.shellType && session.shellType !== 'unknown' ? session.shellType : undefined,
+    deviceType,
+    connected: session?.status === 'connected',
+    ...(hostChain?.length ? { hostChain } : {}),
+    ...(activePortForwards?.length ? { activePortForwards } : {}),
+  };
+};

--- a/components/terminalLayer/buildAITerminalSessionInfo.ts
+++ b/components/terminalLayer/buildAITerminalSessionInfo.ts
@@ -68,7 +68,7 @@ export const buildAITerminalSessionInfo = (
     session?.moshEnabled || host?.moshEnabled || session?.etEnabled || host?.etEnabled,
   );
   // Report 'network' when the host is explicitly a network device OR when the
-  // detected distro/vendor classifies as one (Huawei VRP, Cisco IOS, …). This
+  // detected distro/vendor classifies as one (Huawei VRP, Cisco IOS, ...). This
   // mirrors the terminal's own gating (Terminal.tsx / systemTarget.ts) so AI
   // exec skips shell wrapping (routing to the raw-PTY path) and the system
   // prompt gets vendor-CLI guidance even before the user manually flips


### PR DESCRIPTION
## Summary

AI command execution stalls (and effectively fails) on network switches when the device was auto-detected rather than manually flagged. The three AI exec paths (Catty `cattyExecHandlers`, worker `aiExec`, MCP `execHandlers`) all decide whether to send commands raw (no shell wrapping) based on `meta.deviceType === "network"`. That metadata only reflected the manual **Network Device Mode** toggle (`host.deviceType`), so auto-detected switches (Huawei VRP, Cisco IOS, …) still went through the POSIX shell wrapper. Vendor CLIs reject the wrapped command, the start marker never arrives, and the call stalls until the startup timeout.

This reports `deviceType: "network"` when the detected distro/vendor classifies as a network device too — mirroring the terminal's own gating (`Terminal.tsx` / `systemTarget.ts`). It also gives the AI system prompt vendor-CLI guidance before the user manually flips the toggle. Mosh/ET sessions stay suppressed since they require a shell-backed PTY.

## Type of Change

- [x] Bug fix
- [x] Refactor / code cleanup

## Related Issue

Closes #2367

## Changes Made

- `buildAITerminalSessionInfo` now derives `deviceType: "network"` from `host.deviceType === "network" || classifyDistroId(host.distro) === "network-device"`, fixing all three exec paths at the single metadata source.
- Extracted the pure `buildAITerminalSessionInfo` helper (plus `summarizeHostChain` and the `AITerminalSessionInfo` type) out of the heavy `TerminalLayerSupport.tsx` into `buildAITerminalSessionInfo.ts`, re-exported for existing importers.
- Added unit coverage for the deviceType derivation (explicit network, auto-detected vendor, normal linux, Mosh/ET suppression).

## Testing

- [x] Linting passes (`npx eslint` on changed files)
- [x] Tests pass (new `buildAITerminalSessionInfo.test.ts` + existing source-assertion suites)
- [x] No new console errors or warnings

Notes: no wall-clock timeout was added to the Catty shell path on purpose — both underlying executors already have hard bounds (raw PTY has an overall timeout + 512 KB cap; shell path has a startup timeout), and forcing a wall timeout would regress long-running streaming commands (`tail -f`, `top`).

## Checklist

- [x] My code follows the existing project style
- [x] I have not introduced any breaking changes

Made with [Cursor](https://cursor.com)