### PR TITLE
fix(terminal): suppress autocomplete on alternate screen (#2530)

### DIFF
--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -726,6 +726,14 @@ export function useTerminalAutocomplete(
 
     if (disposedRef.current || version !== fetchVersionRef.current) return;
 
+    // Recheck after the async lookup: the terminal may have entered the alternate
+    // screen while completions were pending (e.g. launching codex/vim). Drop any
+    // result that would paint popup/ghost over a TUI. Same unconditional policy. #2530
+    if (isTerminalAlternateScreenActive(term)) {
+      clearState();
+      return;
+    }
+
     // Discard stale results: if the user kept typing while getCompletions was running,
     // the current prompt input will have changed. Re-detect and compare.
     const { prompt: currentPrompt } = getAlignedPrompt(term, typedInputBufferRef.current, typedBufferReliableRef.current);

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -644,13 +644,14 @@ export function useTerminalAutocomplete(
       return;
     }
 
-    // Suppress autocomplete while a full-screen TUI owns the alternate screen
-    // buffer (codex CLI, vim, htop, less, …). These apps render their own input
-    // UI on the alternate buffer; Netcatty's popup/ghost text would clash with
-    // it — e.g. codex's "/" slash-command menu gets covered by our path/command
-    // popup because codex's composer line also matches the shell-prompt
-    // heuristic. Bail before prompt detection so neither popup nor ghost text
-    // is produced. #2530
+    // Suppress autocomplete for the entire alternate screen buffer (codex CLI,
+    // vim, htop, less, …). Full-screen apps own their own input UI there;
+    // Netcatty's popup/ghost text would clash — e.g. codex's "/" slash-command
+    // menu gets covered because the composer line also matches the shell-prompt
+    // heuristic. This is intentionally unconditional: multiplexers (tmux/screen)
+    // also keep the outer xterm on the alternate buffer for the whole session,
+    // so Netcatty autocomplete is off while attached — same simple tradeoff as
+    // other terminal hosts, rather than chasing TUI-vs-shell heuristics. #2530
     if (isTerminalAlternateScreenActive(term)) {
       clearState();
       return;

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -37,6 +37,7 @@ import {
 } from "./terminalAutocompleteLayout";
 import { handleTerminalAutocompleteInput } from "./terminalAutocompleteInput";
 import { handleTerminalAutocompleteKeyEvent } from "./terminalAutocompleteKeyEvent";
+import { isTerminalAlternateScreenActive } from "../terminalHibernateRuntime";
 
 export interface AutocompleteSettings {
   enabled: boolean;
@@ -640,6 +641,18 @@ export function useTerminalAutocomplete(
   const fetchSuggestions = useCallback(async () => {
     const term = termRef.current;
     if (!term || disposedRef.current || !settingsRef.current.enabled) {
+      return;
+    }
+
+    // Suppress autocomplete while a full-screen TUI owns the alternate screen
+    // buffer (codex CLI, vim, htop, less, …). These apps render their own input
+    // UI on the alternate buffer; Netcatty's popup/ghost text would clash with
+    // it — e.g. codex's "/" slash-command menu gets covered by our path/command
+    // popup because codex's composer line also matches the shell-prompt
+    // heuristic. Bail before prompt detection so neither popup nor ghost text
+    // is produced. #2530
+    if (isTerminalAlternateScreenActive(term)) {
+      clearState();
       return;
     }
 


### PR DESCRIPTION
## Summary

When typing `/` inside codex CLI, Netcatty's autocomplete popup covers codex's slash-command menu. Fix: **unconditionally disable** Netcatty autocomplete (popup + ghost text) while the terminal is on the alternate screen buffer.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #2530

## Changes Made

- Gate `fetchSuggestions` on `isTerminalAlternateScreenActive(term)` before prompt detection / completion work.
- Re-check the same condition after async completion lookup so results cannot paint over a TUI that entered alt-screen mid-flight.
- Reuses existing `isTerminalAlternateScreenActive` from hibernate runtime.

## Policy (intentional)

- **Alternate screen → no Netcatty autocomplete. Period.**
- Multiplexers (tmux/screen) keep the outer xterm on the alternate buffer for the whole session → Netcatty autocomplete is off while attached. Accepted tradeoff; do **not** add TUI-vs-shell heuristics.
- Same simple approach other terminal hosts use for full-screen apps.

## Out of scope

- `codex --no-alt-screen` / inline mode without alt screen
- Re-enabling completions inside tmux panes
- Multiplexer chrome heuristics from the aborted auto-fix loop

## Testing

- [x] Diff limited to `useTerminalAutocomplete.ts`
- [ ] Manual: open codex, type `/` — Netcatty popup must not cover codex menu

## Checklist

- [x] Simple unconditional policy only
- [x] No bloated alt-screen gate module