### PR TITLE
fix(sftp): restore editor tab saves after maximize

### DIFF
--- a/application/state/editorSftpBridge.ts
+++ b/application/state/editorSftpBridge.ts
@@ -7,7 +7,8 @@ export interface EditorSftpWrite {
     filePath: string,
     content: string,
     filenameEncoding?: SftpFilenameEncoding,
-  ): Promise<void>;
+    sftpTabId?: string,
+  ): Promise<string>;
 }
 
 // `useSftpState` is instantiated in at least two places (the top-level SftpView
@@ -51,8 +52,7 @@ export const editorSftpWrite: EditorSftpWrite = async (...args) => {
   let lastNotMine: Error | null = null;
   for (const fn of writers) {
     try {
-      await fn(...args);
-      return;
+      return await fn(...args);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (NOT_MY_CONNECTION_RE.test(msg)) {

--- a/application/state/editorTabSave.test.ts
+++ b/application/state/editorTabSave.test.ts
@@ -111,10 +111,14 @@ test("promoted side-panel editor saves while hidden and releases its session aft
   });
   const browseSessions = new Map([["conn_1", "sftp_1"]]);
   const ownedSessionIds = new Set(["conn_1"]);
+  const ownedSftpTabIds = new Set(["pane_1"]);
   const applyHiddenLifecycle = () => {
     const interactive = isBrowseSessionInteractive({
       surfaceVisible: false,
-      hasOwnedEditorTab: store.hasTabForSessions(ownedSessionIds),
+      hasOwnedEditorTab: store.hasOwnedEditorForSftpOwner({
+        sessionIds: ownedSessionIds,
+        sftpTabIds: ownedSftpTabIds,
+      }),
     });
     if (shouldParkBrowseSessions({ interactive, browseParked: false })) {
       takeBrowseSessionsForClose(browseSessions);
@@ -139,6 +143,37 @@ test("promoted side-panel editor saves while hidden and releases its session aft
   store.close(tabId);
   applyHiddenLifecycle();
   assert.equal(browseSessions.size, 0);
+});
+
+test("hidden panel stays interactive while browse reconnects before session remap", () => {
+  const store = new EditorTabStore();
+  store.promoteFromModal({
+    sessionId: "conn_old",
+    sftpTabId: "pane_1",
+    hostId: "host_1",
+    remotePath: "/tmp/script.sh",
+    fileName: "script.sh",
+    languageId: "shell",
+    content: "echo changed",
+    baselineContent: "echo original",
+    wordWrap: false,
+    viewState: null,
+  });
+  const browseSessions = new Map([["conn_new", "sftp_1"]]);
+
+  const interactive = isBrowseSessionInteractive({
+    surfaceVisible: false,
+    hasOwnedEditorTab: store.hasOwnedEditorForSftpOwner({
+      sessionIds: new Set(["conn_new"]),
+      sftpTabIds: new Set(["pane_1"]),
+    }),
+  });
+  assert.equal(interactive, true);
+  assert.equal(
+    shouldParkBrowseSessions({ interactive, browseParked: false }),
+    false,
+  );
+  assert.equal(browseSessions.get("conn_new"), "sftp_1");
 });
 
 test("editor tab save remaps stale session ids returned by the SFTP writer", async () => {

--- a/application/state/editorTabSave.test.ts
+++ b/application/state/editorTabSave.test.ts
@@ -23,6 +23,7 @@ const makeTab = (overrides: Partial<EditorTab> = {}): EditorTab => ({
   id: "edt_1",
   kind: "editor",
   sessionId: "conn_1",
+  sftpTabId: "pane_1",
   hostId: "host_1",
   remotePath: "/tmp/file.txt",
   fileName: "file.txt",
@@ -46,6 +47,7 @@ test("editor tab save service joins duplicate saves for the same content", async
     write: async (_sessionId, _hostId, _remotePath, content) => {
       writes.push(content);
       await pending.promise;
+      return "conn_1";
     },
   });
 
@@ -73,6 +75,7 @@ test("editor tab save service queues newer tab content after an in-flight save",
     write: async (_sessionId, _hostId, _remotePath, content) => {
       writes.push(content);
       await (content === "v1" ? firstSave.promise : secondSave.promise);
+      return "conn_1";
     },
   });
 
@@ -96,6 +99,7 @@ test("promoted side-panel editor saves while hidden and releases its session aft
   const store = new EditorTabStore();
   const tabId = store.promoteFromModal({
     sessionId: "conn_1",
+    sftpTabId: "pane_1",
     hostId: "host_1",
     remotePath: "/tmp/script.sh",
     fileName: "script.sh",
@@ -126,6 +130,7 @@ test("promoted side-panel editor saves while hidden and releases its session aft
     write: async (connectionId, _hostId, _remotePath, content) => {
       assert.equal(browseSessions.has(connectionId), true);
       writes.push(content);
+      return connectionId;
     },
   });
   assert.equal(await service.saveTab(tabId), true);
@@ -134,4 +139,31 @@ test("promoted side-panel editor saves while hidden and releases its session aft
   store.close(tabId);
   applyHiddenLifecycle();
   assert.equal(browseSessions.size, 0);
+});
+
+test("editor tab save remaps stale session ids returned by the SFTP writer", async () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab({ sessionId: "conn_old", sftpTabId: "pane_1" }));
+  const seenConnectionIds: string[] = [];
+  const service = createEditorTabSaveService({
+    store,
+    write: async (connectionId, _hostId, _remotePath, content, _encoding, sftpTabId) => {
+      seenConnectionIds.push(connectionId);
+      assert.equal(sftpTabId, "pane_1");
+      if (content === "next") {
+        assert.equal(connectionId, "conn_old");
+        return "conn_new";
+      }
+      assert.equal(connectionId, "conn_new");
+      assert.equal(content, "next2");
+      return "conn_new";
+    },
+  });
+
+  assert.equal(await service.saveTab("edt_1", "next"), true);
+  assert.equal(store.getTab("edt_1")?.sessionId, "conn_new");
+
+  store.updateContent("edt_1", "next2", null);
+  assert.equal(await service.saveTab("edt_1"), true);
+  assert.deepEqual(seenConnectionIds, ["conn_old", "conn_new"]);
 });

--- a/application/state/editorTabSave.test.ts
+++ b/application/state/editorTabSave.test.ts
@@ -187,6 +187,7 @@ test("editor tab save remaps stale session ids returned by the SFTP writer", asy
       assert.equal(sftpTabId, "pane_1");
       if (content === "next") {
         assert.equal(connectionId, "conn_old");
+        store.remapSessionId("conn_old", "conn_new");
         return "conn_new";
       }
       assert.equal(connectionId, "conn_new");
@@ -201,4 +202,25 @@ test("editor tab save remaps stale session ids returned by the SFTP writer", asy
   store.updateContent("edt_1", "next2", null);
   assert.equal(await service.saveTab("edt_1"), true);
   assert.deepEqual(seenConnectionIds, ["conn_old", "conn_new"]);
+});
+
+test("closing an SFTP pane prompts for dirty editors after reconnect id churn", async () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab({
+    sessionId: "conn_old",
+    sftpTabId: "pane_1",
+    content: "dirty",
+    baselineContent: "clean",
+  }));
+  let prompted = false;
+  const ok = await store.confirmCloseByOwner(
+    { sessionId: "conn_new", sftpTabId: "pane_1" },
+    async () => {
+      prompted = true;
+      return "discard";
+    },
+  );
+  assert.equal(prompted, true);
+  assert.equal(ok, true);
+  assert.equal(store.getTabs().length, 0);
 });

--- a/application/state/editorTabSave.ts
+++ b/application/state/editorTabSave.ts
@@ -32,7 +32,17 @@ export const createEditorTabSaveService = ({
       onSave: async (content) => {
         const tab = store.getTab(id);
         if (!tab) throw new Error("Editor tab closed before save completed");
-        await write(tab.sessionId, tab.hostId, tab.remotePath, content);
+        const liveConnectionId = await write(
+          tab.sessionId,
+          tab.hostId,
+          tab.remotePath,
+          content,
+          undefined,
+          tab.sftpTabId,
+        );
+        if (liveConnectionId !== tab.sessionId) {
+          store.remapSessionId(tab.sessionId, liveConnectionId);
+        }
       },
       onSaveStart: () => {
         store.setSavingState(id, "saving");

--- a/application/state/editorTabStore.test.ts
+++ b/application/state/editorTabStore.test.ts
@@ -332,6 +332,35 @@ test("hasOwnedEditorForSftpOwner keeps ownership via pane tab id during reconnec
   );
 });
 
+test("confirmCloseByOwner matches editors by stable SFTP pane tab id", async () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab({
+    sessionId: "conn_old",
+    sftpTabId: "pane_1",
+    content: "dirty",
+    baselineContent: "clean",
+  }));
+  let prompted = false;
+  const ok = await store.confirmCloseByOwner(
+    { sessionId: "conn_new", sftpTabId: "pane_1" },
+    async () => {
+      prompted = true;
+      return "cancel";
+    },
+  );
+  assert.equal(prompted, true);
+  assert.equal(ok, false);
+  assert.equal(store.getTabs().length, 1);
+});
+
+test("forceCloseByOwners closes editors matched by SFTP pane tab id", () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab({ sessionId: "conn_old", sftpTabId: "pane_1" }));
+  const closed = store.forceCloseByOwners({ sftpTabIds: ["pane_1"] });
+  assert.deepEqual(closed, ["edt_1"]);
+  assert.equal(store.getTabs().length, 0);
+});
+
 test("updateContent does not bump editor presence revision", () => {
   const store = new EditorTabStore();
   store._debugInsert(makeTab());

--- a/application/state/editorTabStore.test.ts
+++ b/application/state/editorTabStore.test.ts
@@ -318,6 +318,20 @@ test("remapSessionId updates editor ownership after browse reconnect", () => {
   assert.equal(store.getPresenceRevision(), before + 1);
 });
 
+test("hasOwnedEditorForSftpOwner keeps ownership via pane tab id during reconnect gap", () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab({ sessionId: "conn_old", sftpTabId: "pane_1" }));
+
+  assert.equal(store.hasTabForSessions(new Set(["conn_new"])), false);
+  assert.equal(
+    store.hasOwnedEditorForSftpOwner({
+      sessionIds: new Set(["conn_new"]),
+      sftpTabIds: new Set(["pane_1"]),
+    }),
+    true,
+  );
+});
+
 test("updateContent does not bump editor presence revision", () => {
   const store = new EditorTabStore();
   store._debugInsert(makeTab());

--- a/application/state/editorTabStore.test.ts
+++ b/application/state/editorTabStore.test.ts
@@ -14,6 +14,7 @@ const makeTab = (overrides: Partial<EditorTab> = {}): EditorTab => ({
   id: "edt_1",
   kind: "editor",
   sessionId: "conn_1",
+  sftpTabId: "pane_1",
   hostId: "host_1",
   remotePath: "/etc/nginx/nginx.conf",
   fileName: "nginx.conf",
@@ -94,6 +95,7 @@ test("promoteFromModal creates a new tab and returns its id", () => {
   const store = new EditorTabStore();
   const id = store.promoteFromModal({
     sessionId: "conn_1",
+    sftpTabId: "pane_1",
     hostId: "host_1",
     remotePath: "/etc/nginx/nginx.conf",
     fileName: "nginx.conf",
@@ -113,6 +115,7 @@ test("hasTabForSessions identifies the SFTP owner of a promoted editor", () => {
   const store = new EditorTabStore();
   store.promoteFromModal({
     sessionId: "conn_owned",
+    sftpTabId: "pane_owned",
     hostId: "host_1",
     remotePath: "/tmp/script.sh",
     fileName: "script.sh",
@@ -153,6 +156,7 @@ test("useHasEditorTabForSessions updates when the owning editor opens and closes
     await act(async () => {
       tabId = editorTabStore.promoteFromModal({
         sessionId: "conn_hook_test",
+        sftpTabId: "pane_hook_test",
         hostId: "host_1",
         remotePath: "/tmp/hook-test.sh",
         fileName: "hook-test.sh",
@@ -184,6 +188,7 @@ test("promoteFromModal focuses existing tab for same sessionId+normalized path a
   const store = new EditorTabStore();
   const first = store.promoteFromModal({
     sessionId: "conn_1",
+    sftpTabId: "pane_1",
     hostId: "host_1",
     remotePath: "/etc/nginx/./nginx.conf",
     fileName: "nginx.conf",
@@ -195,6 +200,7 @@ test("promoteFromModal focuses existing tab for same sessionId+normalized path a
   });
   const second = store.promoteFromModal({
     sessionId: "conn_1",
+    sftpTabId: "pane_1",
     hostId: "host_1",
     remotePath: "/etc/nginx/nginx.conf",
     fileName: "nginx.conf",
@@ -213,6 +219,7 @@ test("dedup scope is per-sessionId — same path on different sessions are disti
   const store = new EditorTabStore();
   const a = store.promoteFromModal({
     sessionId: "conn_A",
+    sftpTabId: "pane_a",
     hostId: "host_1",
     remotePath: "/etc/hosts",
     fileName: "hosts",
@@ -221,6 +228,7 @@ test("dedup scope is per-sessionId — same path on different sessions are disti
   });
   const b = store.promoteFromModal({
     sessionId: "conn_B",
+    sftpTabId: "pane_b",
     hostId: "host_2",
     remotePath: "/etc/hosts",
     fileName: "hosts",
@@ -294,4 +302,26 @@ test("confirmCloseBySession reports every closed editor tab to cleanup callback"
   assert.equal(ok, true);
   assert.deepEqual(closed, ["edt_clean", "edt_dirty"]);
   assert.equal(store.getTabs().length, 0);
+});
+
+test("remapSessionId updates editor ownership after browse reconnect", () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab({ sessionId: "conn_old" }));
+  assert.equal(store.hasTabForSessions(new Set(["conn_old"])), true);
+  assert.equal(store.hasTabForSessions(new Set(["conn_new"])), false);
+
+  const before = store.getPresenceRevision();
+  store.remapSessionId("conn_old", "conn_new");
+
+  assert.equal(store.getTab("edt_1")?.sessionId, "conn_new");
+  assert.equal(store.hasTabForSessions(new Set(["conn_new"])), true);
+  assert.equal(store.getPresenceRevision(), before + 1);
+});
+
+test("updateContent does not bump editor presence revision", () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab());
+  const before = store.getPresenceRevision();
+  store.updateContent("edt_1", "changed", null);
+  assert.equal(store.getPresenceRevision(), before);
 });

--- a/application/state/editorTabStore.ts
+++ b/application/state/editorTabStore.ts
@@ -123,18 +123,32 @@ export class EditorTabStore {
    * entirely (e.g. the hosting terminal tab was closed) and there is no
    * realistic save channel anyway. Returns the closed tab ids.
    */
-  forceCloseBySessions = (sessionIds: readonly string[]): EditorTabId[] => {
-    if (sessionIds.length === 0) return [];
-    const idSet = new Set(sessionIds);
-    const removed = this.tabs.filter((t) => idSet.has(t.sessionId)).map((t) => t.id);
+  private tabMatchesOwner = (
+    tab: EditorTab,
+    owner: { sessionId?: string; sftpTabId?: string },
+  ): boolean =>
+    (owner.sessionId != null && tab.sessionId === owner.sessionId)
+    || (owner.sftpTabId != null && tab.sftpTabId === owner.sftpTabId);
+
+  /**
+   * Force-close every tab bound to any owner id, with no dirty prompt.
+   * Matches by live connection id and/or stable SFTP pane tab id.
+   */
+  forceCloseByOwners = (owners: {
+    sessionIds?: readonly string[];
+    sftpTabIds?: readonly string[];
+  }): EditorTabId[] => {
+    const sessionSet = new Set(owners.sessionIds ?? []);
+    const tabIdSet = new Set(owners.sftpTabIds ?? []);
+    if (sessionSet.size === 0 && tabIdSet.size === 0) return [];
+    const removed = this.tabs
+      .filter((t) => sessionSet.has(t.sessionId) || tabIdSet.has(t.sftpTabId))
+      .map((t) => t.id);
     if (removed.length === 0) return [];
-    this.tabs = this.tabs.filter((t) => !idSet.has(t.sessionId));
+    const removedSet = new Set(removed);
+    this.tabs = this.tabs.filter((t) => !removedSet.has(t.id));
     this.notifyStructural();
 
-    // If the current active tab was one of the editor tabs we just removed,
-    // fall back to 'vault' so the user doesn't end up on a stale id (empty
-    // chrome + no content). Any better neighbor choice would need the full
-    // orderedTabs list, which isn't available here; 'vault' is always valid.
     const activeId = activeTabStore.getActiveTabId();
     if (isEditorTabId(activeId)) {
       const activeEditorId = fromEditorTabId(activeId);
@@ -145,6 +159,9 @@ export class EditorTabStore {
 
     return removed;
   };
+
+  forceCloseBySessions = (sessionIds: readonly string[]): EditorTabId[] =>
+    this.forceCloseByOwners({ sessionIds });
 
   promoteFromModal = (snapshot: {
     sessionId: string;
@@ -194,17 +211,17 @@ export class EditorTabStore {
   };
 
   /**
-   * Walk all editor tabs bound to `sessionId`. Clean tabs close silently; dirty tabs
-   * prompt via `promptChoice`. 'save' invokes `saveTab` and closes only on its success.
-   * Any 'cancel' aborts the batch (subsequent dirty tabs are preserved) and returns false.
+   * Walk editor tabs owned by a connection id and/or SFTP pane tab id. Clean tabs
+   * close silently; dirty tabs prompt via `promptChoice`. 'save' invokes `saveTab`
+   * and closes only on its success. Any 'cancel' aborts the batch and returns false.
    */
-  confirmCloseBySession = async (
-    sessionId: string,
+  confirmCloseByOwner = async (
+    owner: { sessionId?: string; sftpTabId?: string },
     promptChoice: (tab: EditorTab) => Promise<"save" | "discard" | "cancel">,
     saveTab?: (tabId: EditorTabId) => Promise<void>,
     onCloseTab?: (tabId: EditorTabId) => void,
   ): Promise<boolean> => {
-    const matching = this.tabs.filter((t) => t.sessionId === sessionId);
+    const matching = this.tabs.filter((t) => this.tabMatchesOwner(t, owner));
     for (const tab of matching) {
       const dirty = tab.content !== tab.baselineContent;
       if (!dirty) {
@@ -233,6 +250,14 @@ export class EditorTabStore {
     }
     return true;
   };
+
+  confirmCloseBySession = async (
+    sessionId: string,
+    promptChoice: (tab: EditorTab) => Promise<"save" | "discard" | "cancel">,
+    saveTab?: (tabId: EditorTabId) => Promise<void>,
+    onCloseTab?: (tabId: EditorTabId) => void,
+  ): Promise<boolean> =>
+    this.confirmCloseByOwner({ sessionId }, promptChoice, saveTab, onCloseTab);
 
   subscribe = (listener: Listener): (() => void) => {
     this.listeners.add(listener);

--- a/application/state/editorTabStore.ts
+++ b/application/state/editorTabStore.ts
@@ -52,6 +52,18 @@ export class EditorTabStore {
   hasTabForSessions = (sessionIds: ReadonlySet<string>): boolean =>
     this.tabs.some((tab) => sessionIds.has(tab.sessionId));
 
+  hasTabForSftpTabIds = (sftpTabIds: ReadonlySet<string>): boolean =>
+    this.tabs.some((tab) => sftpTabIds.has(tab.sftpTabId));
+
+  /** Match promoted editors by stable pane tab id and/or live connection id. */
+  hasOwnedEditorForSftpOwner = (params: {
+    sessionIds: ReadonlySet<string>;
+    sftpTabIds: ReadonlySet<string>;
+  }): boolean =>
+    this.tabs.some((tab) =>
+      params.sftpTabIds.has(tab.sftpTabId) || params.sessionIds.has(tab.sessionId),
+    );
+
   getPresenceRevision = (): number => this.presenceRevision;
 
   /** Update editor tabs after browse reconnect replaces a connection id. */

--- a/application/state/editorTabStore.ts
+++ b/application/state/editorTabStore.ts
@@ -19,6 +19,8 @@ export interface EditorTab {
   kind: "editor";
   /** SFTP connection id (matches SftpConnection.id). Session lookup key. */
   sessionId: string;
+  /** Stable SFTP pane tab id — survives browse reconnects that regenerate connection ids. */
+  sftpTabId: string;
   /** Stable endpoint id; used to verify the session is still the one we opened against. */
   hostId: string;
   remotePath: string;
@@ -40,12 +42,29 @@ const genId = (): EditorTabId => `edt_${Date.now().toString(36)}_${(++idCounter)
 export class EditorTabStore {
   private tabs: EditorTab[] = [];
   private listeners = new Set<Listener>();
+  private presenceListeners = new Set<Listener>();
   private pendingNotify = false;
+  private pendingPresenceNotify = false;
+  private presenceRevision = 0;
 
   getTabs = (): readonly EditorTab[] => this.tabs;
   getTab = (id: EditorTabId): EditorTab | undefined => this.tabs.find((t) => t.id === id);
   hasTabForSessions = (sessionIds: ReadonlySet<string>): boolean =>
     this.tabs.some((tab) => sessionIds.has(tab.sessionId));
+
+  getPresenceRevision = (): number => this.presenceRevision;
+
+  /** Update editor tabs after browse reconnect replaces a connection id. */
+  remapSessionId = (fromSessionId: string, toSessionId: string): void => {
+    if (fromSessionId === toSessionId) return;
+    let changed = false;
+    this.tabs = this.tabs.map((tab) => {
+      if (tab.sessionId !== fromSessionId) return tab;
+      changed = true;
+      return { ...tab, sessionId: toSessionId };
+    });
+    if (changed) this.notifyStructural();
+  };
   isDirty = (id: EditorTabId): boolean => {
     const t = this.getTab(id);
     return !!t && t.content !== t.baselineContent;
@@ -82,7 +101,7 @@ export class EditorTabStore {
     const next = this.tabs.filter((t) => t.id !== id);
     if (next.length !== this.tabs.length) {
       this.tabs = next;
-      this.notify();
+      this.notifyStructural();
     }
   };
 
@@ -98,7 +117,7 @@ export class EditorTabStore {
     const removed = this.tabs.filter((t) => idSet.has(t.sessionId)).map((t) => t.id);
     if (removed.length === 0) return [];
     this.tabs = this.tabs.filter((t) => !idSet.has(t.sessionId));
-    this.notify();
+    this.notifyStructural();
 
     // If the current active tab was one of the editor tabs we just removed,
     // fall back to 'vault' so the user doesn't end up on a stale id (empty
@@ -117,6 +136,7 @@ export class EditorTabStore {
 
   promoteFromModal = (snapshot: {
     sessionId: string;
+    sftpTabId: string;
     hostId: string;
     remotePath: string;
     fileName: string;
@@ -144,6 +164,7 @@ export class EditorTabStore {
       id: this.makeId(),
       kind: "editor",
       sessionId: snapshot.sessionId,
+      sftpTabId: snapshot.sftpTabId,
       hostId: snapshot.hostId,
       remotePath: snapshot.remotePath,
       fileName: snapshot.fileName,
@@ -156,7 +177,7 @@ export class EditorTabStore {
       saveError: null,
     };
     this.tabs = [...this.tabs, tab];
-    this.notify();
+    this.notifyStructural();
     return tab.id;
   };
 
@@ -206,10 +227,16 @@ export class EditorTabStore {
     return () => { this.listeners.delete(listener); };
   };
 
+  /** Tab open/close/session remap only — not editor content or save-state churn. */
+  subscribePresence = (listener: Listener): (() => void) => {
+    this.presenceListeners.add(listener);
+    return () => { this.presenceListeners.delete(listener); };
+  };
+
   /** TEST-ONLY: seed a tab without going through promote/openOrFocus. */
   _debugInsert = (tab: EditorTab) => {
     this.tabs = [...this.tabs, tab];
-    this.notify();
+    this.notifyStructural();
   };
 
   protected makeId = genId;
@@ -221,15 +248,30 @@ export class EditorTabStore {
       changed = true;
       return { ...t, ...patch };
     });
-    if (changed) this.notify();
+    if (changed) this.notifyContent();
   };
 
-  protected notify = () => {
+  protected notifyContent = () => {
     if (this.pendingNotify) return;
     this.pendingNotify = true;
     Promise.resolve().then(() => {
       this.pendingNotify = false;
       this.listeners.forEach((l) => l());
+    });
+  };
+
+  protected notifyStructural = () => {
+    this.presenceRevision += 1;
+    this.notifyPresence();
+    this.notifyContent();
+  };
+
+  protected notifyPresence = () => {
+    if (this.pendingPresenceNotify) return;
+    this.pendingPresenceNotify = true;
+    Promise.resolve().then(() => {
+      this.pendingPresenceNotify = false;
+      this.presenceListeners.forEach((l) => l());
     });
   };
 }
@@ -251,6 +293,14 @@ export const useHasEditorTabForSessions = (
   );
   return useSyncExternalStore(editorTabStore.subscribe, getSnapshot, getSnapshot);
 };
+
+/** Re-render only when editor tabs open/close or their SFTP session binding changes. */
+export const useEditorTabPresenceRevision = (): number =>
+  useSyncExternalStore(
+    editorTabStore.subscribePresence,
+    () => editorTabStore.getPresenceRevision(),
+    () => editorTabStore.getPresenceRevision(),
+  );
 
 export const useEditorTab = (id: EditorTabId): EditorTab | undefined => {
   const getSnapshot = useCallback(() => editorTabStore.getTab(id), [id]);

--- a/application/state/sftp/browseSessionLifecycle.test.ts
+++ b/application/state/sftp/browseSessionLifecycle.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   listRemoteBrowseConnectionIds,
+  listRemoteBrowseSftpTabIds,
   isBrowseSessionInteractive,
   listRemoteConnectionIdsForRestore,
   shouldParkBrowseSessions,
@@ -17,6 +18,15 @@ test("editor retention tracks remote browse connections but excludes local panes
     { connection: null },
     { connection: { id: "remote-a", isLocal: false } },
   ]), ["remote-a"]);
+});
+
+test("editor ownership tracks stable remote pane tab ids", () => {
+  assert.deepEqual(listRemoteBrowseSftpTabIds([
+    { id: "pane-remote-a", connection: { id: "remote-a", isLocal: false } },
+    { id: "pane-local", connection: { id: "local-a", isLocal: true } },
+    { id: "pane-empty", connection: null },
+    { id: "pane-remote-b", connection: { id: "remote-b", isLocal: false } },
+  ]), ["pane-remote-a", "pane-remote-b"]);
 });
 
 test("keeps a hidden SFTP owner interactive while its promoted editor tab is open", () => {

--- a/application/state/sftp/browseSessionLifecycle.ts
+++ b/application/state/sftp/browseSessionLifecycle.ts
@@ -27,6 +27,22 @@ export function listRemoteBrowseConnectionIds(
   return [...ids];
 }
 
+/** Stable SFTP pane tab ids for editor ownership across browse reconnects. */
+export function listRemoteBrowseSftpTabIds(
+  tabs: ReadonlyArray<{
+    id: string;
+    connection: { id: string; isLocal: boolean } | null;
+  }>,
+): string[] {
+  const ids = new Set<string>();
+  for (const tab of tabs) {
+    const connection = tab.connection;
+    if (!connection || connection.isLocal) continue;
+    ids.add(tab.id);
+  }
+  return [...ids];
+}
+
 export function shouldParkBrowseSessions(params: {
   interactive: boolean;
   /** True after we already soft-closed browse while the owner stayed mounted. */

--- a/application/state/sftp/useSftpExternalOperations.ts
+++ b/application/state/sftp/useSftpExternalOperations.ts
@@ -25,6 +25,7 @@ import { getSftpTransferResourceKeys, globalSftpTransferScheduler } from "./glob
 import { localStorageAdapter } from "../../../infrastructure/persistence/localStorageAdapter";
 import { STORAGE_KEY_SFTP_TRANSFER_CONCURRENCY } from "../../../infrastructure/config/storageKeys";
 import { sftpTransferCenterStore } from "../sftpTransferCenterStore";
+import { editorTabStore } from "../editorTabStore";
 import {
   resolveUploadStreamTargetSftpId,
 } from "../../../domain/sftpDedicatedStreamPolicy";
@@ -347,6 +348,10 @@ export const useSftpExternalOperations = (
         sftpId = sftpSessionsRef.current.get(liveConnectionId);
       }
       if (!sftpId) throw new Error("SFTP session not found");
+
+      if (liveConnectionId !== connectionId) {
+        editorTabStore.remapSessionId(connectionId, liveConnectionId);
+      }
 
       const bridge = netcattyBridge.get();
       if (!bridge) throw new Error("Bridge not available");

--- a/application/state/sftp/useSftpExternalOperations.ts
+++ b/application/state/sftp/useSftpExternalOperations.ts
@@ -76,6 +76,8 @@ export const useSftpExternalOperations = (
     getActivePane,
     getPaneByConnectionId,
     getPaneByTabId,
+    getTabByConnectionId,
+    getTabByHostId,
     getSideByTabId,
     refresh,
     sftpSessionsRef,
@@ -284,7 +286,16 @@ export const useSftpExternalOperations = (
       content: string,
       filenameEncoding?: SftpFilenameEncoding,
     ): Promise<void> => {
-      const pane = getPaneByConnectionId(connectionId);
+      let tabRef = getTabByConnectionId?.(connectionId) ?? null;
+      let pane = tabRef?.pane ?? getPaneByConnectionId(connectionId);
+
+      // Promoted editors keep the connection id from promote time; browse
+      // restore/reconnect may regenerate it while the host stays the same.
+      if (!pane?.connection && getTabByHostId) {
+        tabRef = getTabByHostId(expectedHostId);
+        pane = tabRef?.pane ?? null;
+      }
+
       if (!pane?.connection) {
         throw new Error("SFTP connection is no longer available");
       }
@@ -300,7 +311,17 @@ export const useSftpExternalOperations = (
         return;
       }
 
-      const sftpId = sftpSessionsRef.current.get(pane.connection.id);
+      const liveConnectionId = pane.connection.id;
+      const tabId = tabRef?.tabId ?? pane.id;
+      const side = tabRef?.side ?? getSideByTabId?.(tabId) ?? null;
+
+      let sftpId = sftpSessionsRef.current.get(liveConnectionId);
+      if (!sftpId && ensureRemoteSftpId && side) {
+        sftpId = await ensureRemoteSftpId(side, {
+          connectionId: liveConnectionId,
+          tabId,
+        });
+      }
       if (!sftpId) throw new Error("SFTP session not found");
 
       const bridge = netcattyBridge.get();
@@ -308,7 +329,14 @@ export const useSftpExternalOperations = (
 
       await bridge.writeSftp(sftpId, filePath, content, filenameEncoding ?? pane.filenameEncoding);
     },
-    [getPaneByConnectionId, sftpSessionsRef],
+    [
+      ensureRemoteSftpId,
+      getPaneByConnectionId,
+      getSideByTabId,
+      getTabByConnectionId,
+      getTabByHostId,
+      sftpSessionsRef,
+    ],
   );
 
   const downloadToTemp = useCallback(

--- a/application/state/sftp/useSftpExternalOperations.ts
+++ b/application/state/sftp/useSftpExternalOperations.ts
@@ -313,23 +313,50 @@ export const useSftpExternalOperations = (
         return pane.connection.id;
       }
 
-      const liveConnectionId = pane.connection.id;
       const tabId = tabRef?.tabId ?? pane.id;
       const side = tabRef?.side ?? getSideByTabId?.(tabId) ?? null;
 
-      let sftpId = sftpSessionsRef.current.get(liveConnectionId);
+      let sftpId = sftpSessionsRef.current.get(pane.connection.id);
       if (!sftpId && ensureRemoteSftpId && side) {
         sftpId = await ensureRemoteSftpId(side, {
-          connectionId: liveConnectionId,
+          connectionId: pane.connection.id,
           tabId,
         });
+      }
+
+      // Reconnect replaces the pane's connection id — resolve again before write/return.
+      const refreshedPane = (() => {
+        if (sftpTabId) {
+          const pinned = getPaneByTabId(sftpTabId);
+          if (pinned?.connection) return pinned;
+        }
+        return getTabByConnectionId?.(connectionId)?.pane
+          ?? getPaneByConnectionId(connectionId)
+          ?? pane;
+      })();
+
+      if (!refreshedPane?.connection) {
+        throw new Error("SFTP connection is no longer available");
+      }
+      if (refreshedPane.connection.hostId !== expectedHostId) {
+        throw new Error("SFTP connection changed while editing — file not saved to prevent writing to wrong host");
+      }
+
+      const liveConnectionId = refreshedPane.connection.id;
+      if (!sftpId) {
+        sftpId = sftpSessionsRef.current.get(liveConnectionId);
       }
       if (!sftpId) throw new Error("SFTP session not found");
 
       const bridge = netcattyBridge.get();
       if (!bridge) throw new Error("Bridge not available");
 
-      await bridge.writeSftp(sftpId, filePath, content, filenameEncoding ?? pane.filenameEncoding);
+      await bridge.writeSftp(
+        sftpId,
+        filePath,
+        content,
+        filenameEncoding ?? refreshedPane.filenameEncoding,
+      );
       return liveConnectionId;
     },
     [

--- a/application/state/sftp/useSftpExternalOperations.ts
+++ b/application/state/sftp/useSftpExternalOperations.ts
@@ -77,7 +77,6 @@ export const useSftpExternalOperations = (
     getPaneByConnectionId,
     getPaneByTabId,
     getTabByConnectionId,
-    getTabByHostId,
     getSideByTabId,
     refresh,
     sftpSessionsRef,
@@ -286,15 +285,8 @@ export const useSftpExternalOperations = (
       content: string,
       filenameEncoding?: SftpFilenameEncoding,
     ): Promise<void> => {
-      let tabRef = getTabByConnectionId?.(connectionId) ?? null;
-      let pane = tabRef?.pane ?? getPaneByConnectionId(connectionId);
-
-      // Promoted editors keep the connection id from promote time; browse
-      // restore/reconnect may regenerate it while the host stays the same.
-      if (!pane?.connection && getTabByHostId) {
-        tabRef = getTabByHostId(expectedHostId);
-        pane = tabRef?.pane ?? null;
-      }
+      const tabRef = getTabByConnectionId?.(connectionId) ?? null;
+      const pane = tabRef?.pane ?? getPaneByConnectionId(connectionId);
 
       if (!pane?.connection) {
         throw new Error("SFTP connection is no longer available");
@@ -334,7 +326,6 @@ export const useSftpExternalOperations = (
       getPaneByConnectionId,
       getSideByTabId,
       getTabByConnectionId,
-      getTabByHostId,
       sftpSessionsRef,
     ],
   );

--- a/application/state/sftp/useSftpExternalOperations.ts
+++ b/application/state/sftp/useSftpExternalOperations.ts
@@ -284,9 +284,19 @@ export const useSftpExternalOperations = (
       filePath: string,
       content: string,
       filenameEncoding?: SftpFilenameEncoding,
-    ): Promise<void> => {
-      const tabRef = getTabByConnectionId?.(connectionId) ?? null;
-      const pane = tabRef?.pane ?? getPaneByConnectionId(connectionId);
+      sftpTabId?: string,
+    ): Promise<string> => {
+      let tabRef = getTabByConnectionId?.(connectionId) ?? null;
+      let pane = tabRef?.pane ?? getPaneByConnectionId(connectionId);
+
+      if (!pane?.connection && sftpTabId) {
+        const pinned = getPaneByTabId(sftpTabId);
+        if (pinned?.connection) {
+          pane = pinned;
+          const side = getSideByTabId?.(sftpTabId);
+          if (side) tabRef = { side, tabId: sftpTabId, pane: pinned };
+        }
+      }
 
       if (!pane?.connection) {
         throw new Error("SFTP connection is no longer available");
@@ -300,7 +310,7 @@ export const useSftpExternalOperations = (
         if (!bridge?.writeLocalFile) throw new Error("Local file writing not supported");
         const data = new TextEncoder().encode(content);
         await bridge.writeLocalFile(filePath, data.buffer);
-        return;
+        return pane.connection.id;
       }
 
       const liveConnectionId = pane.connection.id;
@@ -320,10 +330,12 @@ export const useSftpExternalOperations = (
       if (!bridge) throw new Error("Bridge not available");
 
       await bridge.writeSftp(sftpId, filePath, content, filenameEncoding ?? pane.filenameEncoding);
+      return liveConnectionId;
     },
     [
       ensureRemoteSftpId,
       getPaneByConnectionId,
+      getPaneByTabId,
       getSideByTabId,
       getTabByConnectionId,
       sftpSessionsRef,

--- a/application/state/sftp/useSftpExternalOperations.types.ts
+++ b/application/state/sftp/useSftpExternalOperations.types.ts
@@ -15,11 +15,6 @@ export interface UseSftpExternalOperationsParams {
     tabId: string;
     pane: SftpPane;
   } | null;
-  getTabByHostId?: (hostId: string) => {
-    side: "left" | "right";
-    tabId: string;
-    pane: SftpPane;
-  } | null;
   getSideByTabId?: (tabId: string) => "left" | "right" | null;
   refresh: (side: "left" | "right", options?: { tabId?: string }) => Promise<void>;
   sftpSessionsRef: React.MutableRefObject<Map<string, string>>;

--- a/application/state/sftp/useSftpExternalOperations.types.ts
+++ b/application/state/sftp/useSftpExternalOperations.types.ts
@@ -57,7 +57,8 @@ export interface SftpExternalOperationsResult {
     filePath: string,
     content: string,
     filenameEncoding?: SftpFilenameEncoding,
-  ) => Promise<void>;
+    sftpTabId?: string,
+  ) => Promise<string>;
   downloadToTempAndOpen: (
     side: "left" | "right",
     remotePath: string,

--- a/application/state/sftp/useSftpExternalOperations.types.ts
+++ b/application/state/sftp/useSftpExternalOperations.types.ts
@@ -10,6 +10,16 @@ export interface UseSftpExternalOperationsParams {
   getActivePane: (side: "left" | "right") => SftpPane | null;
   getPaneByConnectionId: (connectionId: string) => SftpPane | null;
   getPaneByTabId: (tabId: string) => SftpPane | null;
+  getTabByConnectionId?: (connectionId: string) => {
+    side: "left" | "right";
+    tabId: string;
+    pane: SftpPane;
+  } | null;
+  getTabByHostId?: (hostId: string) => {
+    side: "left" | "right";
+    tabId: string;
+    pane: SftpPane;
+  } | null;
   getSideByTabId?: (tabId: string) => "left" | "right" | null;
   refresh: (side: "left" | "right", options?: { tabId?: string }) => Promise<void>;
   sftpSessionsRef: React.MutableRefObject<Map<string, string>>;

--- a/application/state/useSftpState.ts
+++ b/application/state/useSftpState.ts
@@ -179,22 +179,6 @@ export const useSftpState = (
     return null;
   }, [leftTabsRef, rightTabsRef]);
 
-  const getTabByHostId = useCallback((hostId: string) => {
-    for (const tab of leftTabsRef.current.tabs) {
-      const connection = tab.connection;
-      if (connection && !connection.isLocal && connection.hostId === hostId) {
-        return { side: "left" as const, tabId: tab.id, pane: tab };
-      }
-    }
-    for (const tab of rightTabsRef.current.tabs) {
-      const connection = tab.connection;
-      if (connection && !connection.isLocal && connection.hostId === hostId) {
-        return { side: "right" as const, tabId: tab.id, pane: tab };
-      }
-    }
-    return null;
-  }, [leftTabsRef, rightTabsRef]);
-
   // Ref to track pending reconnections to avoid multiple reconnect attempts
   const reconnectingRef = useRef<{ left: boolean; right: boolean }>({
     left: false,
@@ -591,7 +575,6 @@ export const useSftpState = (
     getPaneByConnectionId,
     getPaneByTabId,
     getTabByConnectionId,
-    getTabByHostId,
     getSideByTabId,
     refresh,
     sftpSessionsRef,

--- a/application/state/useSftpState.ts
+++ b/application/state/useSftpState.ts
@@ -179,6 +179,22 @@ export const useSftpState = (
     return null;
   }, [leftTabsRef, rightTabsRef]);
 
+  const getTabByHostId = useCallback((hostId: string) => {
+    for (const tab of leftTabsRef.current.tabs) {
+      const connection = tab.connection;
+      if (connection && !connection.isLocal && connection.hostId === hostId) {
+        return { side: "left" as const, tabId: tab.id, pane: tab };
+      }
+    }
+    for (const tab of rightTabsRef.current.tabs) {
+      const connection = tab.connection;
+      if (connection && !connection.isLocal && connection.hostId === hostId) {
+        return { side: "right" as const, tabId: tab.id, pane: tab };
+      }
+    }
+    return null;
+  }, [leftTabsRef, rightTabsRef]);
+
   // Ref to track pending reconnections to avoid multiple reconnect attempts
   const reconnectingRef = useRef<{ left: boolean; right: boolean }>({
     left: false,
@@ -574,6 +590,8 @@ export const useSftpState = (
     getActivePane,
     getPaneByConnectionId,
     getPaneByTabId,
+    getTabByConnectionId,
+    getTabByHostId,
     getSideByTabId,
     refresh,
     sftpSessionsRef,

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -22,7 +22,7 @@ import {
 import { registerEditorSftpWriterScoped } from "../application/state/editorSftpBridge";
 import {
   editorTabStore,
-  useEditorTabs,
+  useEditorTabPresenceRevision,
 } from "../application/state/editorTabStore";
 import { releaseEditorTabSaveCoordinator } from "../application/state/editorTabSave";
 import { useSftpBackend } from "../application/state/useSftpBackend";
@@ -193,10 +193,8 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
   }), [t]);
 
   const ownedEditorSessionIdsRef = useRef<ReadonlySet<string>>(new Set());
-  // Subscribe for tab open/close, but read the store synchronously on each
-  // render. useSyncExternalStore defers promote notifications to a microtask,
-  // which can park browse sessions before hasOwnedEditorTab flips true.
-  useEditorTabs();
+  // Re-render on tab open/close/session remap only — not on every editor keystroke.
+  useEditorTabPresenceRevision();
   const hasOwnedEditorTab = editorTabStore.hasTabForSessions(
     ownedEditorSessionIdsRef.current,
   );
@@ -379,8 +377,8 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
   // tab switches, listings) doesn't make this unregister+reregister on every
   // re-render.
   useEffect(() => {
-    return registerEditorSftpWriterScoped((connectionId, expectedHostId, filePath, content, encoding) =>
-      sftpRef.current.writeTextFileByConnection(connectionId, expectedHostId, filePath, content, encoding),
+    return registerEditorSftpWriterScoped((connectionId, expectedHostId, filePath, content, encoding, sftpTabId) =>
+      sftpRef.current.writeTextFileByConnection(connectionId, expectedHostId, filePath, content, encoding, sftpTabId),
     );
   }, []);
 

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -22,7 +22,7 @@ import {
 import { registerEditorSftpWriterScoped } from "../application/state/editorSftpBridge";
 import {
   editorTabStore,
-  useHasEditorTabForSessions,
+  useEditorTabs,
 } from "../application/state/editorTabStore";
 import { releaseEditorTabSaveCoordinator } from "../application/state/editorTabSave";
 import { useSftpBackend } from "../application/state/useSftpBackend";
@@ -193,11 +193,13 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
   }), [t]);
 
   const ownedEditorSessionIdsRef = useRef<ReadonlySet<string>>(new Set());
-  const getOwnedEditorSessionIds = useCallback(
-    () => ownedEditorSessionIdsRef.current,
-    [],
+  // Subscribe for tab open/close, but read the store synchronously on each
+  // render. useSyncExternalStore defers promote notifications to a microtask,
+  // which can park browse sessions before hasOwnedEditorTab flips true.
+  useEditorTabs();
+  const hasOwnedEditorTab = editorTabStore.hasTabForSessions(
+    ownedEditorSessionIdsRef.current,
   );
-  const hasOwnedEditorTab = useHasEditorTabForSessions(getOwnedEditorSessionIds);
 
   const sftpOptions = useMemo(() => ({
     ...fileWatchHandlers,

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -33,6 +33,7 @@ import { resolveSftpAutoConnectPath } from "../application/state/sftp/sftpReopen
 import {
   isBrowseSessionInteractive,
   listRemoteBrowseConnectionIds,
+  listRemoteBrowseSftpTabIds,
 } from "../application/state/sftp/browseSessionLifecycle";
 import { logger } from "../lib/logger";
 import type { DropEntry } from "../lib/sftpFileUtils";
@@ -193,11 +194,13 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
   }), [t]);
 
   const ownedEditorSessionIdsRef = useRef<ReadonlySet<string>>(new Set());
+  const ownedEditorSftpTabIdsRef = useRef<ReadonlySet<string>>(new Set());
   // Re-render on tab open/close/session remap only — not on every editor keystroke.
   useEditorTabPresenceRevision();
-  const hasOwnedEditorTab = editorTabStore.hasTabForSessions(
-    ownedEditorSessionIdsRef.current,
-  );
+  const hasOwnedEditorTab = editorTabStore.hasOwnedEditorForSftpOwner({
+    sessionIds: ownedEditorSessionIdsRef.current,
+    sftpTabIds: ownedEditorSftpTabIdsRef.current,
+  });
 
   const sftpOptions = useMemo(() => ({
     ...fileWatchHandlers,
@@ -234,6 +237,12 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
   const sftp = useSftpState(hosts, keys, identities, sftpOptions);
   ownedEditorSessionIdsRef.current = new Set(
     listRemoteBrowseConnectionIds([
+      ...sftp.leftTabs.tabs,
+      ...sftp.rightTabs.tabs,
+    ]),
+  );
+  ownedEditorSftpTabIdsRef.current = new Set(
+    listRemoteBrowseSftpTabIds([
       ...sftp.leftTabs.tabs,
       ...sftp.rightTabs.tabs,
     ]),
@@ -611,7 +620,9 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
       : null;
     const hasEditorBoundToCurrentConnection = !!(
       currentConn
-      && editorTabStore.getTabs().some((tab) => tab.sessionId === currentConn.id)
+      && editorTabStore.getTabs().some((tab) =>
+        tab.sessionId === currentConn.id || tab.sftpTabId === s.leftPane.id,
+      )
     );
     const hasActiveTransferOnCurrentConnection = !!(
       currentConn

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -404,17 +404,18 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     return () => {
       const s = sftpRef.current;
       if (!s) return;
-      const owned = new Set<string>();
-      for (const tab of s.leftTabs?.tabs ?? []) {
+      const ownedSessionIds: string[] = [];
+      const ownedSftpTabIds: string[] = [];
+      for (const tab of [...(s.leftTabs?.tabs ?? []), ...(s.rightTabs?.tabs ?? [])]) {
+        ownedSftpTabIds.push(tab.id);
         const id = tab.connection?.id;
-        if (id) owned.add(id);
+        if (id) ownedSessionIds.push(id);
       }
-      for (const tab of s.rightTabs?.tabs ?? []) {
-        const id = tab.connection?.id;
-        if (id) owned.add(id);
-      }
-      if (owned.size === 0) return;
-      const closed = editorTabStore.forceCloseBySessions([...owned]);
+      if (ownedSessionIds.length === 0 && ownedSftpTabIds.length === 0) return;
+      const closed = editorTabStore.forceCloseByOwners({
+        sessionIds: ownedSessionIds,
+        sftpTabIds: ownedSftpTabIds,
+      });
       closed.forEach(releaseEditorTabSaveCoordinator);
     };
   }, []);

--- a/components/SftpView.tsx
+++ b/components/SftpView.tsx
@@ -203,8 +203,8 @@ const SftpViewInner: React.FC<SftpViewProps> = ({
   // always reads the latest writeTextFileByConnection; that method is stable
   // across sftp re-renders (it's a methodsRef-backed dispatcher).
   useEffect(() => {
-    return registerEditorSftpWriterScoped((connectionId, expectedHostId, filePath, content, encoding) =>
-      sftpRef.current.writeTextFileByConnection(connectionId, expectedHostId, filePath, content, encoding),
+    return registerEditorSftpWriterScoped((connectionId, expectedHostId, filePath, content, encoding, sftpTabId) =>
+      sftpRef.current.writeTextFileByConnection(connectionId, expectedHostId, filePath, content, encoding, sftpTabId),
     );
   }, []);
 

--- a/components/sftp/hooks/useSftpViewFileOps.ts
+++ b/components/sftp/hooks/useSftpViewFileOps.ts
@@ -217,6 +217,7 @@ export const useSftpViewFileOps = ({
 
     const editorId = editorTabStore.promoteFromModal({
       sessionId: connection.id,
+      sftpTabId: pane.id,
       hostId: target.hostId,
       remotePath: target.fullPath,
       fileName: target.file.name,

--- a/components/sftp/hooks/useSftpViewPaneActions.ts
+++ b/components/sftp/hooks/useSftpViewPaneActions.ts
@@ -162,50 +162,36 @@ export const useSftpViewPaneActions = ({
   // canceled the dirty-editor prompt. Callers that kick off a replacement
   // connect (e.g. the host picker) MUST gate their follow-up on this result
   // so a canceled prompt doesn't silently drop the user onto a new host.
+  const confirmCloseActivePaneEditors = useCallback(async (side: "left" | "right"): Promise<boolean> => {
+    const pane = sftpRef.current.getActivePane(side);
+    if (!pane?.connection?.id && !pane?.id) return true;
+    const choice = (tab: EditorTab) => promptUnsavedChanges(tab.fileName);
+    const saveTab = async (id: EditorTabId) => {
+      const ok = await saveEditorTab(id);
+      const tab = editorTabStore.getTab(id);
+      if (!ok || (tab && tab.content !== tab.baselineContent)) {
+        throw new Error(tab?.saveError ?? "Save failed");
+      }
+    };
+    return editorTabStore.confirmCloseByOwner(
+      { sessionId: pane.connection?.id, sftpTabId: pane.id },
+      choice,
+      saveTab,
+      releaseEditorTabSaveCoordinator,
+    );
+  }, [sftpRef]);
   const onDisconnectLeft = useCallback(async (): Promise<boolean> => {
-    const connectionId = sftpRef.current.getActivePane("left")?.connection?.id;
-    if (connectionId) {
-      const choice = (tab: EditorTab) => promptUnsavedChanges(tab.fileName);
-      const saveTab = async (id: EditorTabId) => {
-        const ok = await saveEditorTab(id);
-        const tab = editorTabStore.getTab(id);
-        if (!ok || (tab && tab.content !== tab.baselineContent)) {
-          throw new Error(tab?.saveError ?? "Save failed");
-        }
-      };
-      const ok = await editorTabStore.confirmCloseBySession(
-        connectionId,
-        choice,
-        saveTab,
-        releaseEditorTabSaveCoordinator,
-      );
-      if (!ok) return false;
-    }
+    const ok = await confirmCloseActivePaneEditors("left");
+    if (!ok) return false;
     sftpRef.current.disconnect("left");
     return true;
-  }, [sftpRef]);
+  }, [confirmCloseActivePaneEditors, sftpRef]);
   const onDisconnectRight = useCallback(async (): Promise<boolean> => {
-    const connectionId = sftpRef.current.getActivePane("right")?.connection?.id;
-    if (connectionId) {
-      const choice = (tab: EditorTab) => promptUnsavedChanges(tab.fileName);
-      const saveTab = async (id: EditorTabId) => {
-        const ok = await saveEditorTab(id);
-        const tab = editorTabStore.getTab(id);
-        if (!ok || (tab && tab.content !== tab.baselineContent)) {
-          throw new Error(tab?.saveError ?? "Save failed");
-        }
-      };
-      const ok = await editorTabStore.confirmCloseBySession(
-        connectionId,
-        choice,
-        saveTab,
-        releaseEditorTabSaveCoordinator,
-      );
-      if (!ok) return false;
-    }
+    const ok = await confirmCloseActivePaneEditors("right");
+    if (!ok) return false;
     sftpRef.current.disconnect("right");
     return true;
-  }, [sftpRef]);
+  }, [confirmCloseActivePaneEditors, sftpRef]);
   const onPrepareSelectionLeft = useCallback(() => {
     keepOnlyActivePaneSelections(sftpRef.current, "left");
   }, [sftpRef]);

--- a/components/sftp/hooks/useSftpViewTabs.ts
+++ b/components/sftp/hooks/useSftpViewTabs.ts
@@ -72,7 +72,10 @@ export const useSftpViewTabs = ({ sftp, sftpRef, hosts = [] }: UseSftpViewTabsPa
     return tabId;
   }, [sftpRef]);
 
-  const confirmCloseEditorTabsByConnection = useCallback(async (connectionId: string): Promise<boolean> => {
+  const confirmCloseEditorTabsByOwner = useCallback(async (owner: {
+    sessionId?: string;
+    sftpTabId?: string;
+  }): Promise<boolean> => {
     const choice = (tab: EditorTab) => promptUnsavedChanges(tab.fileName);
     const saveTab = async (id: EditorTabId) => {
       const ok = await saveEditorTab(id);
@@ -81,8 +84,8 @@ export const useSftpViewTabs = ({ sftp, sftpRef, hosts = [] }: UseSftpViewTabsPa
         throw new Error(tab?.saveError ?? "Save failed");
       }
     };
-    return editorTabStore.confirmCloseBySession(
-      connectionId,
+    return editorTabStore.confirmCloseByOwner(
+      owner,
       choice,
       saveTab,
       releaseEditorTabSaveCoordinator,
@@ -92,13 +95,15 @@ export const useSftpViewTabs = ({ sftp, sftpRef, hosts = [] }: UseSftpViewTabsPa
   const handleCloseSftpTab = useCallback(async (side: "left" | "right", tabId: string) => {
     const sideTabs = side === "left" ? sftpRef.current.leftTabs : sftpRef.current.rightTabs;
     const pane = sideTabs.tabs.find((tab) => tab.id === tabId);
-    const connectionId = pane?.connection?.id;
-    if (connectionId) {
-      const ok = await confirmCloseEditorTabsByConnection(connectionId);
+    if (pane?.connection?.id || pane) {
+      const ok = await confirmCloseEditorTabsByOwner({
+        sessionId: pane?.connection?.id,
+        sftpTabId: tabId,
+      });
       if (!ok) return;
     }
     await sftpRef.current.closeTab(side, tabId);
-  }, [confirmCloseEditorTabsByConnection, sftpRef]);
+  }, [confirmCloseEditorTabsByOwner, sftpRef]);
 
   const handleCloseTabLeft = useCallback((tabId: string) => (
     handleCloseSftpTab("left", tabId)

--- a/components/terminalLayer/sftpPanelLifecycle.test.ts
+++ b/components/terminalLayer/sftpPanelLifecycle.test.ts
@@ -154,6 +154,7 @@ test("terminal side panel reports transfer activity and uses store-backed retain
   assert.doesNotMatch(panelSource, /useEffect\(\(\) => \(\) => \{\s*onActiveTransfersChange\?\.\(0\);\s*\}, \[onActiveTransfersChange\]\)/);
   assert.match(panelSource, /interactive:\s*isBrowseSessionInteractive\(\{/);
   assert.match(panelSource, /surfaceVisible:\s*isVisible/);
+  assert.match(panelSource, /useEditorTabs\(\)/);
   assert.match(panelSource, /hasOwnedEditorTab/);
   assert.match(slotsSource, /onActiveTransfersChange=\{handleActiveTransfersChange\}/);
   assert.match(layerSource, /resolveTabActiveTransfersCount/);

--- a/components/terminalLayer/sftpPanelLifecycle.test.ts
+++ b/components/terminalLayer/sftpPanelLifecycle.test.ts
@@ -154,7 +154,7 @@ test("terminal side panel reports transfer activity and uses store-backed retain
   assert.doesNotMatch(panelSource, /useEffect\(\(\) => \(\) => \{\s*onActiveTransfersChange\?\.\(0\);\s*\}, \[onActiveTransfersChange\]\)/);
   assert.match(panelSource, /interactive:\s*isBrowseSessionInteractive\(\{/);
   assert.match(panelSource, /surfaceVisible:\s*isVisible/);
-  assert.match(panelSource, /useEditorTabs\(\)/);
+  assert.match(panelSource, /useEditorTabPresenceRevision\(\)/);
   assert.match(panelSource, /hasOwnedEditorTab/);
   assert.match(slotsSource, /onActiveTransfersChange=\{handleActiveTransfersChange\}/);
   assert.match(layerSource, /resolveTabActiveTransfersCount/);


### PR DESCRIPTION
## Summary
- Fix "SFTP session not found" when saving from a promoted (maximized) built-in SFTP editor tab
- Keep terminal side-panel browse sessions alive during promote by reading editor tab ownership synchronously
- Reconnect the browse SFTP session on editor-tab save when the session mapping is missing or the connection id changed

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2576

## Changes Made

- `SftpSidePanel`: subscribe with `useEditorTabs()` but compute `hasOwnedEditorTab` synchronously to avoid a promote/tab-switch race that parks browse sessions too early
- `writeTextFileByConnection`: fall back to host-based pane lookup and call `ensureRemoteSftpId` before writing
- `useSftpState`: add `getTabByHostId` helper for stale connection-id recovery

## Screenshots / Demo

N/A

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

Made with [Cursor](https://cursor.com)