### PR TITLE
fix(terminal): speed up dense keyword highlighting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install shell test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y fish
+          sudo apt-get install -y fish xvfb
 
       - name: Install deps
         run: npm ci
@@ -49,6 +49,9 @@ jobs:
 
       - name: Test
         run: npm test
+
+      - name: Test terminal decoration performance
+        run: xvfb-run -a npm run test:xterm-decoration-performance
 
       - name: Build
         run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,7 @@
         "cross-env": "^10.1.0",
         "electron": "^42.3.3",
         "electron-builder": "^26.15.2",
+        "esbuild": "0.27.2",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-unused-imports": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "@xterm/addon-unicode-graphemes": "0.5.0-beta.220",
         "@xterm/addon-web-links": "0.13.0-beta.220",
         "@xterm/addon-webgl": "0.20.0-beta.219",
-        "@xterm/xterm": "6.1.0-beta.220",
+        "@xterm/xterm": "6.1.0-beta.221",
         "ai": "^7.0.2",
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
@@ -8684,9 +8684,9 @@
       }
     },
     "node_modules/@xterm/xterm": {
-      "version": "6.1.0-beta.220",
-      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.1.0-beta.220.tgz",
-      "integrity": "sha512-rwEKE75wfwfNWeGnjl0iQRA1W50HigKoGcGMeF3o5CqDSdI9IjmwzpV9xHXqLH6CYj6s9N1g6bbKFVDou9dJ/A==",
+      "version": "6.1.0-beta.221",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.1.0-beta.221.tgz",
+      "integrity": "sha512-6vSQlHFCOfJxqR2fuVPug99movBua84dwILplD8c4fLBioaxc4rXQQJn91zK3BBPAWhRP4brE/G1ASYogb6AcQ==",
       "license": "MIT",
       "workspaces": [
         "addons/*"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "bench:sync-crdt": "tsx scripts/bench-sync-crdt.ts",
     "test:ssh-mfa-models": "node --test electron/bridges/sshMfaModels.live.test.cjs",
     "test:ssh-mfa-models:live": "SSH_MFA_LIVE=1 node --test electron/bridges/sshMfaModels.live.test.cjs",
-    "test:xterm-webgl-overflow": "electron scripts/xterm-webgl-atlas-overflow.live.test.cjs"
+    "test:xterm-webgl-overflow": "electron scripts/xterm-webgl-atlas-overflow.live.test.cjs",
+    "test:xterm-decoration-performance": "electron scripts/xterm-decoration-performance.live.test.cjs"
   },
   "dependencies": {
     "@eslint-community/regexpp": "4.12.2",
@@ -105,7 +106,7 @@
     "@xterm/addon-unicode-graphemes": "0.5.0-beta.220",
     "@xterm/addon-web-links": "0.13.0-beta.220",
     "@xterm/addon-webgl": "0.20.0-beta.219",
-    "@xterm/xterm": "6.1.0-beta.220",
+    "@xterm/xterm": "6.1.0-beta.221",
     "ai": "^7.0.2",
     "clsx": "2.1.1",
     "electron-updater": "^6.8.3",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "cross-env": "^10.1.0",
     "electron": "^42.3.3",
     "electron-builder": "^26.15.2",
+    "esbuild": "0.27.2",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-unused-imports": "^4.3.0",

--- a/scripts/github-workflow-ci.test.cjs
+++ b/scripts/github-workflow-ci.test.cjs
@@ -73,6 +73,11 @@ test("PR validation runs once per commit and includes a production build", () =>
   assert.match(testWorkflow, /push:\s*\n\s*branches:\s*\n\s*- main/);
   assert.doesNotMatch(testWorkflow, /branches:\s*\n\s*- "\*\*"/);
   assert.match(testWorkflow, /name: lint-and-test\s*\n\s*runs-on: ubuntu-latest\s*\n\s*timeout-minutes: 20/);
+  assert.match(testWorkflow, /sudo apt-get install -y fish xvfb/);
+  assert.match(
+    testWorkflow,
+    /- name: Test terminal decoration performance\s*\n\s*run: xvfb-run -a npm run test:xterm-decoration-performance/,
+  );
   assert.match(testWorkflow, /- name: Build\s*\n\s*run: npm run build/);
   assert.doesNotMatch(testWorkflow, /\n  mosh-windows-conpty:/);
 });

--- a/scripts/xterm-decoration-performance.live.test.cjs
+++ b/scripts/xterm-decoration-performance.live.test.cjs
@@ -13,19 +13,29 @@ if (!process.versions.electron) {
   const os = require("node:os");
   const path = require("node:path");
   const electron = require("electron");
+  const esbuild = require("esbuild");
 
   const appRoot = path.resolve(__dirname, "..");
   const userData = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-xterm-decoration-perf-"));
   electron.app.setPath("userData", userData);
   electron.app.on("window-all-closed", () => {});
+  let window = null;
 
   const cleanup = (exitCode) => {
-    fs.rmSync(userData, { recursive: true, force: true });
-    electron.app.exit(exitCode);
+    if (window && !window.isDestroyed()) {
+      window.destroy();
+    }
+    try {
+      fs.rmSync(userData, { recursive: true, force: true });
+    } catch (error) {
+      console.warn("Unable to remove xterm performance test data:", error);
+    } finally {
+      electron.app.exit(exitCode);
+    }
   };
 
   void electron.app.whenReady().then(async () => {
-    const window = new electron.BrowserWindow({
+    window = new electron.BrowserWindow({
       show: false,
       width: 900,
       height: 560,
@@ -44,8 +54,22 @@ if (!process.versions.electron) {
     );
 
     const xtermPath = require.resolve("@xterm/xterm", { paths: [appRoot] });
+    const keywordHighlighterPath = path.join(appRoot, "components/terminal/keywordHighlight.ts");
+    const keywordHighlighterBundle = esbuild.buildSync({
+      entryPoints: [keywordHighlighterPath],
+      bundle: true,
+      format: "cjs",
+      platform: "browser",
+      target: "chrome142",
+      write: false,
+    }).outputFiles[0].text;
     const result = await window.webContents.executeJavaScript(`(async () => {
       const { Terminal } = require(${JSON.stringify(xtermPath)});
+      const highlighterModule = { exports: {} };
+      ((module, exports) => {
+        ${keywordHighlighterBundle}
+      })(highlighterModule, highlighterModule.exports);
+      const { KeywordHighlighter } = highlighterModule.exports;
       const term = new Terminal({
         allowProposedApi: true,
         cols: 80,
@@ -56,6 +80,9 @@ if (!process.versions.electron) {
       });
       term.open(document.getElementById("terminal"));
 
+      const waitForPaint = () => new Promise(resolve => {
+        requestAnimationFrame(() => requestAnimationFrame(resolve));
+      });
       const waitForRender = (trigger, label) => new Promise((resolve, reject) => {
         const startedAt = performance.now();
         const timeout = setTimeout(() => {
@@ -63,19 +90,55 @@ if (!process.versions.electron) {
           reject(new Error("timed out waiting for terminal render: " + label));
         }, 15000);
         const disposable = term.onRender(() => {
-          clearTimeout(timeout);
           disposable.dispose();
-          resolve(performance.now() - startedAt);
+          waitForPaint().then(() => {
+            clearTimeout(timeout);
+            resolve(performance.now() - startedAt);
+          }, reject);
         });
         trigger();
       });
       const writeAndWait = data => new Promise(resolve => term.write(data, resolve));
+      const waitForCondition = async (condition, label) => {
+        const deadline = performance.now() + 15000;
+        while (!condition()) {
+          if (performance.now() >= deadline) {
+            throw new Error("timed out waiting for " + label);
+          }
+          await waitForPaint();
+        }
+      };
 
       let history = "";
       for (let line = 0; line < 500; line += 1) {
         history += "INFO WARN ERROR SUCCESS DEBUG completed failed critical\\r\\n";
       }
       await writeAndWait(history);
+
+      const highlighter = new KeywordHighlighter(term);
+      highlighter.setRules([
+        { enabled: true, patterns: ["INFO"], color: "#60a5fa" },
+        { enabled: true, patterns: ["WARN"], color: "#fbbf24" },
+        { enabled: true, patterns: ["ERROR"], color: "#f87171" },
+        { enabled: true, patterns: ["SUCCESS"], color: "#4ade80" },
+        { enabled: true, patterns: ["DEBUG"], color: "#a78bfa" },
+        { enabled: true, patterns: ["completed"], color: "#2dd4bf" },
+        { enabled: true, patterns: ["failed"], color: "#fb7185" },
+        { enabled: true, patterns: ["critical"], color: "#f43f5e" },
+      ], true);
+      const countNetcattyDecorations = () => Array.from(highlighter.lineDecorations.values())
+        .reduce((count, state) => count + state.decorations.length, 0);
+      await waitForCondition(
+        () => countNetcattyDecorations() >= term.rows * 8,
+        "Netcatty keyword decorations",
+      );
+      const netcattyDecorationCount = countNetcattyDecorations();
+      const netcattyRefreshMs = await waitForRender(
+        () => term.refresh(0, term.rows - 1),
+        "Netcatty keyword highlight paint",
+      );
+      highlighter.dispose();
+      await waitForPaint();
 
       const cursorLine = term.buffer.normal.baseY + term.buffer.normal.cursorY;
       const markers = [];
@@ -110,6 +173,8 @@ if (!process.versions.electron) {
       const state = {
         decorationCount: decorations.length,
         markerCount: markers.length,
+        netcattyDecorationCount,
+        netcattyRefreshMs,
         registrationPaintMs,
         refreshMs,
         worstRefreshMs: Math.max(...refreshMs),
@@ -122,12 +187,16 @@ if (!process.versions.electron) {
 
     assert.equal(result.markerCount, 500, JSON.stringify(result));
     assert.equal(result.decorationCount, 20000, JSON.stringify(result));
+    assert.ok(result.netcattyDecorationCount >= 240, JSON.stringify(result));
+    assert.ok(
+      result.netcattyRefreshMs < 150,
+      `Netcatty keyword highlighting blocked terminal paint: ${JSON.stringify(result)}`,
+    );
     assert.ok(
       result.worstRefreshMs < 150,
       `dense keyword-style decorations blocked terminal repaint: ${JSON.stringify(result)}`,
     );
     process.stdout.write(`XTERM_DECORATION_PERFORMANCE_OK ${JSON.stringify(result)}\n`);
-    window.destroy();
     cleanup(0);
   }).catch((error) => {
     console.error(error);

--- a/scripts/xterm-decoration-performance.live.test.cjs
+++ b/scripts/xterm-decoration-performance.live.test.cjs
@@ -1,0 +1,136 @@
+"use strict";
+
+/* global process, __dirname, console */
+
+if (!process.versions.electron) {
+  const test = require("node:test");
+  test("xterm keeps dense keyword-style decorations responsive", {
+    skip: "run with Electron so the real DOM renderer is available",
+  }, () => {});
+} else {
+  const assert = require("node:assert/strict");
+  const fs = require("node:fs");
+  const os = require("node:os");
+  const path = require("node:path");
+  const electron = require("electron");
+
+  const appRoot = path.resolve(__dirname, "..");
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-xterm-decoration-perf-"));
+  electron.app.setPath("userData", userData);
+  electron.app.on("window-all-closed", () => {});
+
+  const cleanup = (exitCode) => {
+    fs.rmSync(userData, { recursive: true, force: true });
+    electron.app.exit(exitCode);
+  };
+
+  void electron.app.whenReady().then(async () => {
+    const window = new electron.BrowserWindow({
+      show: false,
+      width: 900,
+      height: 560,
+      paintWhenInitiallyHidden: true,
+      webPreferences: {
+        backgroundThrottling: false,
+        contextIsolation: false,
+        nodeIntegration: true,
+        sandbox: false,
+      },
+    });
+    await window.loadURL(
+      "data:text/html;charset=utf-8," + encodeURIComponent(
+        "<!doctype html><style>html,body,#terminal{width:800px;height:480px;margin:0}</style><div id=terminal></div>",
+      ),
+    );
+
+    const xtermPath = require.resolve("@xterm/xterm", { paths: [appRoot] });
+    const result = await window.webContents.executeJavaScript(`(async () => {
+      const { Terminal } = require(${JSON.stringify(xtermPath)});
+      const term = new Terminal({
+        allowProposedApi: true,
+        cols: 80,
+        cursorBlink: false,
+        rendererType: "dom",
+        rows: 30,
+        scrollback: 1000,
+      });
+      term.open(document.getElementById("terminal"));
+
+      const waitForRender = (trigger, label) => new Promise((resolve, reject) => {
+        const startedAt = performance.now();
+        const timeout = setTimeout(() => {
+          disposable.dispose();
+          reject(new Error("timed out waiting for terminal render: " + label));
+        }, 15000);
+        const disposable = term.onRender(() => {
+          clearTimeout(timeout);
+          disposable.dispose();
+          resolve(performance.now() - startedAt);
+        });
+        trigger();
+      });
+      const writeAndWait = data => new Promise(resolve => term.write(data, resolve));
+
+      let history = "";
+      for (let line = 0; line < 500; line += 1) {
+        history += "INFO WARN ERROR SUCCESS DEBUG completed failed critical\\r\\n";
+      }
+      await writeAndWait(history);
+
+      const cursorLine = term.buffer.normal.baseY + term.buffer.normal.cursorY;
+      const markers = [];
+      const decorations = [];
+      for (let line = term.buffer.normal.length - 500; line < term.buffer.normal.length; line += 1) {
+        const marker = term.registerMarker(line - cursorLine);
+        if (!marker) continue;
+        markers.push(marker);
+        for (let x = 0; x < term.cols; x += 2) {
+          const decoration = term.registerDecoration({
+            marker,
+            x,
+            width: 1,
+            foregroundColor: "#f87171",
+          });
+          if (decoration) decorations.push(decoration);
+        }
+      }
+
+      const registrationPaintMs = await waitForRender(
+        () => term.refresh(0, term.rows - 1),
+        "registration paint",
+      );
+      const refreshMs = [];
+      for (let iteration = 0; iteration < 3; iteration += 1) {
+        refreshMs.push(await waitForRender(
+          () => term.refresh(0, term.rows - 1),
+          "measured refresh " + iteration,
+        ));
+      }
+
+      const state = {
+        decorationCount: decorations.length,
+        markerCount: markers.length,
+        registrationPaintMs,
+        refreshMs,
+        worstRefreshMs: Math.max(...refreshMs),
+      };
+      decorations.forEach(decoration => decoration.dispose());
+      markers.forEach(marker => marker.dispose());
+      term.dispose();
+      return state;
+    })()`);
+
+    assert.equal(result.markerCount, 500, JSON.stringify(result));
+    assert.equal(result.decorationCount, 20000, JSON.stringify(result));
+    assert.ok(
+      result.worstRefreshMs < 150,
+      `dense keyword-style decorations blocked terminal repaint: ${JSON.stringify(result)}`,
+    );
+    process.stdout.write(`XTERM_DECORATION_PERFORMANCE_OK ${JSON.stringify(result)}\n`);
+    window.destroy();
+    cleanup(0);
+  }).catch((error) => {
+    console.error(error);
+    cleanup(1);
+  });
+}

--- a/scripts/xterm-decoration-performance.live.test.cjs
+++ b/scripts/xterm-decoration-performance.live.test.cjs
@@ -10,13 +10,13 @@ if (!process.versions.electron) {
 } else {
   const assert = require("node:assert/strict");
   const fs = require("node:fs");
-  const os = require("node:os");
   const path = require("node:path");
   const electron = require("electron");
   const esbuild = require("esbuild");
+  const tempDirBridge = require("../electron/bridges/tempDirBridge.cjs");
 
   const appRoot = path.resolve(__dirname, "..");
-  const userData = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-xterm-decoration-perf-"));
+  const userData = fs.mkdtempSync(`${tempDirBridge.getTempFilePath("xterm-decoration-perf")}-`);
   electron.app.setPath("userData", userData);
   electron.app.on("window-all-closed", () => {});
   let window = null;


### PR DESCRIPTION
## Summary

Upgrade the terminal core to the first build containing xterm.js's decoration lookup optimization, addressing the dense keyword-highlighting repaint cost identified in the latest #2251 reproduction.

This PR intentionally targets the proven dense-decoration bottleneck. It does not claim that every Vim or command-history lag path in #2251 is resolved; affected Windows verification is still required.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [x] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #2251

## Changes Made

- Upgrade `@xterm/xterm` from `6.1.0-beta.220` to `6.1.0-beta.221`, which contains xtermjs/xterm.js#5902.
- Keep `@xterm/addon-webgl` pinned at `0.20.0-beta.219`, preserving Netcatty's existing atlas safety patch.
- Exercise Netcatty's real `KeywordHighlighter` against representative log output, then run the 20,000-decoration upstream stress regression.
- Measure through two browser paint frames and make failure cleanup reliable on Windows.
- Run the live Electron regression in required Linux CI under Xvfb.

## Screenshots / Demo

Same-machine comparison for the 20,000-decoration bottleneck:

- Before: 267–269 ms to reach xterm's render completion.
- After: 13–19 ms to reach xterm's render completion.
- Final test also waits for two browser paint frames; current worst complete-paint result is about 50 ms.
- Netcatty's real highlighter path retained 712 decorations and completed the same paint guard in about 46 ms.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test` — 8,222 tests, 0 failures)
- [x] Generated capability tool specs are updated when applicable (not applicable; catalog unchanged)
- [x] No new console errors or warnings, if this affects app behavior

Additional checks:

- `npm run build`
- `npm run test:xterm-decoration-performance`
- `npm run test:xterm-webgl-overflow`
- Focused terminal and workflow suites
- `npx tsc --noEmit` remains red on pre-existing repository-wide type errors; none point to the changed files.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant regression coverage
- [x] I have not introduced any breaking changes
