### PR TITLE
fix(ai): prevent stuck OpenCode questions

### DIFF
--- a/electron/bridges/aiBridge/sdk/opencodeDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/opencodeDriver.cjs
@@ -65,6 +65,9 @@ function buildOpenCodeConfig({ model, injectedMcpServers, toolIntegrationMode, s
     edit: "deny",
     bash: allowBash ? "allow" : "deny",
     webfetch: "deny",
+    // Netcatty does not yet bridge OpenCode's question reply API to the UI.
+    // Leaving it enabled creates a tool call that can never be completed.
+    question: "deny",
     // Keep external access locked down, but let OpenCode's native skills
     // (e.g. ~/.opencode/skills, ~/.config/opencode/skills) read their own
     // reference files in every mode (issue #1939).

--- a/electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs
@@ -56,6 +56,7 @@ test("buildOpenCodeConfig isolates local tools and injects Netcatty MCP", () => 
   assert.equal(cfg.permission.edit, "deny");
   assert.equal(cfg.permission.bash, "deny");
   assert.equal(cfg.permission.webfetch, "deny");
+  assert.equal(cfg.permission.question, "deny");
   assert.equal(cfg.permission.skill, "allow");
   assert.equal(cfg.permission.external_directory["*"], "deny");
   // Native OpenCode skill directories stay readable in MCP mode (issue #1939).


### PR DESCRIPTION
## Summary

Disable OpenCode's `question` tool until Netcatty bridges its question-reply API. This prevents question calls that leave the AI turn permanently waiting.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2585

## Changes Made

- Deny the OpenCode `question` tool in Netcatty's isolated OpenCode configuration.
- Cover the permission setting in the OpenCode driver test.

## Screenshots / Demo

Not applicable. OpenCode now rejects unsupported question calls instead of leaving the turn pending.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Focused verification: `node --test electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs` (31 passing).

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)