### PR TITLE
fix(ci): launch Electron perf test without sandbox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,9 +52,9 @@ jobs:
 
       - name: Test terminal decoration performance
         env:
-          ELECTRON_DISABLE_SANDBOX: "1"
           NETCATTY_TERMINAL_PERF_SHOW_WINDOW: "1"
-        run: xvfb-run -a npm run test:xterm-decoration-performance
+        # GitHub-hosted runners do not configure Electron's SUID sandbox helper.
+        run: xvfb-run -a ./node_modules/.bin/electron --no-sandbox scripts/xterm-decoration-performance.live.test.cjs
 
       - name: Build
         run: npm run build

--- a/scripts/github-workflow-ci.test.cjs
+++ b/scripts/github-workflow-ci.test.cjs
@@ -76,7 +76,7 @@ test("PR validation runs once per commit and includes a production build", () =>
   assert.match(testWorkflow, /sudo apt-get install -y fish xvfb/);
   assert.match(
     testWorkflow,
-    /- name: Test terminal decoration performance\s*\n\s*env:\s*\n\s*ELECTRON_DISABLE_SANDBOX: "1"\s*\n\s*NETCATTY_TERMINAL_PERF_SHOW_WINDOW: "1"\s*\n\s*run: xvfb-run -a npm run test:xterm-decoration-performance/,
+    /- name: Test terminal decoration performance\s*\n\s*env:\s*\n\s*NETCATTY_TERMINAL_PERF_SHOW_WINDOW: "1"\s*\n\s*# GitHub-hosted runners do not configure Electron's SUID sandbox helper\.\s*\n\s*run: xvfb-run -a \.\/node_modules\/\.bin\/electron --no-sandbox scripts\/xterm-decoration-performance\.live\.test\.cjs/,
   );
   assert.match(testWorkflow, /- name: Build\s*\n\s*run: npm run build/);
   assert.doesNotMatch(testWorkflow, /\n  mosh-windows-conpty:/);


### PR DESCRIPTION
## Summary

Fixes the terminal decoration performance job on GitHub-hosted runners. `ELECTRON_DISABLE_SANDBOX` does not disable Electron's Chromium sandbox, so the test aborted before running when the runner lacked a configured SUID sandbox helper.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [x] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Launch the CI-only Electron performance test with `--no-sandbox`.
- Keep the test window visible under Xvfb.
- Update the workflow contract test to require the explicit launch flag.

## Screenshots / Demo

N/A

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`node --test scripts/github-workflow-ci.test.cjs`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)