### PR TITLE
feat(terminal): expose session names to automation scripts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1213,6 +1213,7 @@ function App({ settings }: { settings: SettingsState }) {
     stopRuleTunnels,
     openHost: openHostForVaultAgent,
     closeSession: closeSessionForVaultAgent,
+    getScriptSessionMeta: (sessionId) => sessions.find((session) => session.id === sessionId),
   });
 
   const _handleSshDeepLink = useEffectEvent((payload: { url?: string }) => {

--- a/application/state/scriptAutomationCoordinator.ts
+++ b/application/state/scriptAutomationCoordinator.ts
@@ -45,6 +45,7 @@ export async function runAutomationScript(params: {
   mode?: 'sequential' | 'parallel';
   sessionMeta?: {
     connected?: boolean;
+    name?: string;
     hostname?: string;
     username?: string;
   };
@@ -135,6 +136,7 @@ export async function runConnectScriptsSequential(params: {
   onScriptComplete?: (snippet: Snippet) => void;
   sessionMeta?: {
     connected?: boolean;
+    name?: string;
     hostname?: string;
     username?: string;
   };

--- a/application/state/useVaultAgentBridge.ts
+++ b/application/state/useVaultAgentBridge.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { applyGroupDefaults, resolveGroupDefaults } from '../../domain/groupConfig';
-import type { GroupConfig, Host, Identity, KnownHost, ManagedSource, PortForwardingRule, ProxyProfile, Snippet, SSHKey, TerminalSettings, VaultNote } from '../../domain/models';
+import type { GroupConfig, Host, Identity, KnownHost, ManagedSource, PortForwardingRule, ProxyProfile, Snippet, SSHKey, TerminalSession, TerminalSettings, VaultNote } from '../../domain/models';
 import { materializeHostProxyProfile } from '../../domain/proxyProfiles';
 import {
   handleVaultAgentOp,
@@ -42,6 +42,7 @@ export interface UseVaultAgentBridgeInput {
   stopRuleTunnels: VaultAgentApiDeps['stopRuleTunnels'];
   openHost?: VaultAgentApiDeps['openHost'];
   closeSession?: VaultAgentApiDeps['closeSession'];
+  getScriptSessionMeta?: (sessionId: string) => Pick<TerminalSession, 'status' | 'customName' | 'hostLabel' | 'hostname' | 'username'> | undefined;
 }
 
 type VaultAgentSnapshot = {
@@ -199,6 +200,16 @@ export function useVaultAgentBridge(input: UseVaultAgentBridgeInput): void {
         closeSession: current.closeSession
           ? (sessionId) => current.closeSession!(sessionId)
           : undefined,
+        getScriptSessionMeta: (sessionId) => {
+          const session = current.getScriptSessionMeta?.(sessionId);
+          if (!session) return undefined;
+          return {
+            connected: session.status === 'connected',
+            name: session.customName || session.hostLabel,
+            hostname: session.hostname,
+            username: session.username,
+          };
+        },
       });
     });
     return setupVaultAgentBridge();

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -400,11 +400,21 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }
     setActiveScriptRun(undefined);
   }, [activeScriptRun]);
+  const scriptSessionName = sessionDisplayName || host.label;
   const outputTriggers = useOutputTriggers({
     sessionId,
     hostId: host.id,
     snippets,
-    onRunScript: (snippet, sid) => runAutomationScript({ snippet, sessionId: sid }).catch((err) => {
+    onRunScript: (snippet, sid) => runAutomationScript({
+      snippet,
+      sessionId: sid,
+      sessionMeta: {
+        connected: true,
+        name: scriptSessionName,
+        hostname: host.hostname,
+        username: host.username,
+      },
+    }).catch((err) => {
       const message = err instanceof Error ? err.message : String(err);
       toast.error(message.includes('Observer mode') ? t('scripts.observer.blocked') : message);
       throw err;
@@ -2363,7 +2373,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         sessionId,
         sessionMeta: {
           connected: true,
-          name: host.label,
+          name: scriptSessionName,
           hostname: host.hostname,
           username: host.username,
         },
@@ -2408,7 +2418,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
               sessionId,
               sessionMeta: {
                 connected: true,
-                name: host.label,
+                name: scriptSessionName,
                 hostname: host.hostname,
                 username: host.username,
               },
@@ -2431,7 +2441,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }, 400);
 
     return () => window.clearTimeout(timer);
-  }, [effectiveTerminalProtocol, host, isPendingScriptAlreadyHandled, moshShellReady, pendingScript, pendingScriptId, sessionId, snippets, status, t]);
+  }, [effectiveTerminalProtocol, host, isPendingScriptAlreadyHandled, moshShellReady, pendingScript, pendingScriptId, scriptSessionName, sessionId, snippets, status, t]);
 
   useEffect(() => {
     return registerScreenSnapshotProvider(sessionId, () => {
@@ -2818,7 +2828,16 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const executeSnippet = useCallback(async (snippet: Snippet) => {
     if (isScriptSnippet(snippet)) {
       try {
-        await runAutomationScript({ snippet, sessionId });
+        await runAutomationScript({
+          snippet,
+          sessionId,
+          sessionMeta: {
+            connected: true,
+            name: scriptSessionName,
+            hostname: host.hostname,
+            username: host.username,
+          },
+        });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         toast.error(message.includes('Observer mode') ? t('scripts.observer.blocked') : message);
@@ -2830,7 +2849,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     executeSnippetCommand(command, snippet.noAutoRun, {
       multiLineRunMode: snippet.multiLineRunMode,
     });
-  }, [executeSnippetCommand, sessionId, t]);
+  }, [executeSnippetCommand, host.hostname, host.username, scriptSessionName, sessionId, t]);
 
   const onSnippetShortkeyRef = useRef(executeSnippet);
   onSnippetShortkeyRef.current = executeSnippet;

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -2363,6 +2363,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         sessionId,
         sessionMeta: {
           connected: true,
+          name: host.label,
           hostname: host.hostname,
           username: host.username,
         },
@@ -2407,6 +2408,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
               sessionId,
               sessionMeta: {
                 connected: true,
+                name: host.label,
                 hostname: host.hostname,
                 username: host.username,
               },

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -147,7 +147,7 @@ function buildScriptSessionMeta(
   const host = hosts.find((entry) => entry.id === session.hostId);
   return {
     connected: session.status === 'connected',
-    name: host?.label ?? session.hostLabel,
+    name: session.customName || session.hostLabel || host?.label,
     hostname: host?.hostname ?? session.hostname,
     username: host?.username ?? session.username,
   };

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -147,6 +147,7 @@ function buildScriptSessionMeta(
   const host = hosts.find((entry) => entry.id === session.hostId);
   return {
     connected: session.status === 'connected',
+    name: host?.label ?? session.hostLabel,
     hostname: host?.hostname ?? session.hostname,
     username: host?.username ?? session.username,
   };

--- a/domain/scriptApiReference.ts
+++ b/domain/scriptApiReference.ts
@@ -41,7 +41,10 @@ Use \`waitForText("请选择SSH资源")\` for literal prompts.
 Use \`waitForRegex(".*请选择SSH资源.*登录方式.*")\` for regex or output split across terminal lines.
 
 ### nct.session
-- \`nct.session.connected\`, \`hostname\`, \`username\`
+- \`nct.session.connected\` — whether the current terminal session is connected
+- \`nct.session.name\` — session display name, usually the saved host label
+- \`nct.session.hostname\` — hostname or address of the current session
+- \`nct.session.username\` — username of the current session
 - \`await nct.session.sleep(ms)\` — alias \`await nct.sleep(ms)\`
 - \`await nct.session.startLog(path)\` / \`stopLog()\`
 - \`await nct.session.disconnect()\`

--- a/domain/snippetAgentOps.test.ts
+++ b/domain/snippetAgentOps.test.ts
@@ -26,6 +26,7 @@ const host: Host = {
 test('getScriptApiReference includes nct API and wrapper rules', () => {
   const ref = getScriptApiReference();
   assert.match(ref, /nct\.screen\.waitForPrompt/);
+  assert.match(ref, /nct\.session\.name/);
   assert.match(ref, /Only JavaScript is executed/);
   assert.match(ref, /onConnect/);
 });

--- a/domain/snippetScript.ts
+++ b/domain/snippetScript.ts
@@ -46,7 +46,7 @@ async function main() {
   const tag = \`nc-it-\${Date.now().toString(36)}\`;
   nct.log('=== Netcatty Integration Test START ===');
   nct.log(\`tag=\${tag}  nct.version=\${nct.version}\`);
-  nct.log(\`session: host=\${nct.session.hostname} user=\${nct.session.username} connected=\${nct.session.connected}\`);
+  nct.log(\`session: name=\${nct.session.name} host=\${nct.session.hostname} user=\${nct.session.username} connected=\${nct.session.connected}\`);
 
   if (!nct.session.connected) {
     throw new Error('Session not connected');
@@ -160,6 +160,7 @@ export const DEFAULT_SCRIPT_TEMPLATE = `// Netcatty automation script - async JS
 // nct.screen.waitForAny([patterns], ms?) wait until any pattern matches
 // nct.screen.sendLine(cmd)                type command + Enter; send(text) raw keys only
 // nct.screen.getText(start?, end?) | clear()
+// nct.session.connected | name | hostname | username (read-only metadata)
 // nct.session.sleep(ms) | startLog(path) | stopLog() | disconnect()
 // nct.dialog.confirm(msg)->bool | prompt(msg, def?)->string | alert(msg)
 // nct.dialog.form({ fields })->object; fields: select/radio/checkbox/textarea/number, optional visibleWhen

--- a/electron/bridges/scriptBridge.cjs
+++ b/electron/bridges/scriptBridge.cjs
@@ -41,7 +41,7 @@ const scriptLogTokens = new Map();
 const sessionRunChains = new Map();
 /** @type {Map<string, { abort: (reason?: Error) => void }>} */
 const runAbortControls = new Map();
-/** @type {Map<string, { connected?: boolean, hostname?: string, username?: string }>} */
+/** @type {Map<string, { connected?: boolean, name?: string, hostname?: string, username?: string }>} */
 const rendererSessionMetaById = new Map();
 let disposeTerminalDataTap = null;
 let disposeWorkerOutputTap = null;
@@ -188,6 +188,7 @@ function getSessionMeta(sessionId) {
   if (session) {
     return {
       connected: session.status !== "disconnected",
+      name: rendererMeta?.name || session.hostLabel || "",
       hostname: session.hostname || session.hostLabel || rendererMeta?.hostname || "",
       username: session.username || rendererMeta?.username || "",
     };
@@ -195,11 +196,12 @@ function getSessionMeta(sessionId) {
   if (isSessionConnected(sessionId)) {
     return {
       connected: true,
+      name: rendererMeta?.name || "",
       hostname: rendererMeta?.hostname || "",
       username: rendererMeta?.username || "",
     };
   }
-  return { connected: false, hostname: "", username: "" };
+  return { connected: false, name: "", hostname: "", username: "" };
 }
 
 function notifyScriptSessionInput(sessionId, data) {

--- a/electron/bridges/scriptBridge.cjs
+++ b/electron/bridges/scriptBridge.cjs
@@ -188,7 +188,7 @@ function getSessionMeta(sessionId) {
   if (session) {
     return {
       connected: session.status !== "disconnected",
-      name: rendererMeta?.name || session.hostLabel || "",
+      name: rendererMeta?.name || session.label || session.hostLabel || "",
       hostname: session.hostname || session.hostLabel || rendererMeta?.hostname || "",
       username: session.username || rendererMeta?.username || "",
     };

--- a/electron/bridges/scriptBridge.test.cjs
+++ b/electron/bridges/scriptBridge.test.cjs
@@ -1035,6 +1035,56 @@ test("script run uses renderer sessionMeta when main-process session map is empt
   assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /Production:10\.0\.0\.1@root/);
 });
 
+test("script run uses the main-process session label when renderer metadata is absent", async () => {
+  const handlers = new Map();
+  const sentRunUpdates = [];
+
+  scriptBridge.init({
+    sessions: new Map([["session-local", {
+      status: "connected",
+      label: "Local Terminal",
+      hostname: "localhost",
+      username: "local",
+    }]]),
+    electronModule: {
+      app: {
+        getVersion: () => "test",
+        getPath: () => process.cwd(),
+      },
+    },
+    terminalBridge: {
+      writeToSession() {},
+    },
+    terminalWorkerManager: null,
+    getMainWindow: () => ({
+      webContents: {
+        send(channel, payload) {
+          if (channel === "netcatty:script:runs-updated") {
+            sentRunUpdates.push(payload.runs);
+          }
+        },
+      },
+    }),
+  });
+  scriptBridge.registerHandlers({
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  });
+
+  await handlers.get("netcatty:script:run")({}, {
+    scriptId: "local-session-name",
+    scriptLabel: "Local session name",
+    sessionId: "session-local",
+    content: "nct.log(nct.session.name);",
+    permissionMode: "auto",
+  });
+
+  const finalRun = sentRunUpdates.at(-1).find((run) => run.scriptId === "local-session-name");
+  assert.equal(finalRun.status, "completed");
+  assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /Local Terminal/);
+});
+
 test("script run sends form dialog requests and resolves object responses", async () => {
   const handlers = new Map();
   const sentRunUpdates = [];

--- a/electron/bridges/scriptBridge.test.cjs
+++ b/electron/bridges/scriptBridge.test.cjs
@@ -1020,19 +1020,19 @@ test("script run uses renderer sessionMeta when main-process session map is empt
     scriptId: "renderer-meta",
     scriptLabel: "Renderer meta",
     sessionId: "session-renderer",
-    sessionMeta: { connected: true, hostname: "10.0.0.1", username: "root" },
+    sessionMeta: { connected: true, name: "Production", hostname: "10.0.0.1", username: "root" },
     content: `
       if (!nct.session.connected) {
         throw new Error("Session not connected");
       }
-      nct.log(\`\${nct.session.hostname}@\${nct.session.username}\`);
+      nct.log(\`\${nct.session.name}:\${nct.session.hostname}@\${nct.session.username}\`);
     `,
     permissionMode: "auto",
   });
 
   const finalRun = sentRunUpdates.at(-1).find((run) => run.scriptId === "renderer-meta");
   assert.equal(finalRun.status, "completed");
-  assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /10\.0\.0\.1@root/);
+  assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /Production:10\.0\.0\.1@root/);
 });
 
 test("script run sends form dialog requests and resolves object responses", async () => {

--- a/electron/scripts/scriptExecutionWorker.cjs
+++ b/electron/scripts/scriptExecutionWorker.cjs
@@ -81,6 +81,7 @@ function notifyHost(method, args = []) {
 
 const sessionApi = {
   get connected() { return runtimeSnapshot.session.connected; },
+  get name() { return runtimeSnapshot.session.name; },
   get hostname() { return runtimeSnapshot.session.hostname; },
   get username() { return runtimeSnapshot.session.username; },
   sleep: (ms) => callHost("session.sleep", [ms]),
@@ -163,6 +164,7 @@ async function run(config) {
   runtimeSnapshot = {
     session: {
       connected: Boolean(config.snapshot?.session?.connected),
+      name: String(config.snapshot?.session?.name || ""),
       hostname: String(config.snapshot?.session?.hostname || ""),
       username: String(config.snapshot?.session?.username || ""),
     },

--- a/electron/scripts/scriptRuntime.cjs
+++ b/electron/scripts/scriptRuntime.cjs
@@ -108,6 +108,7 @@ function readRuntimeSnapshot(nct) {
   return {
     session: {
       connected: Boolean(nct.session.connected),
+      name: String(nct.session.name || ""),
       hostname: String(nct.session.hostname || ""),
       username: String(nct.session.username || ""),
     },
@@ -1007,6 +1008,9 @@ function createScriptRuntime(deps) {
     get connected() {
       const meta = getSessionMeta?.(sessionId);
       return Boolean(meta?.connected);
+    },
+    get name() {
+      return getSessionMeta?.(sessionId)?.name || "";
     },
     get hostname() {
       return getSessionMeta?.(sessionId)?.hostname || "";

--- a/electron/scripts/scriptRuntime.test.cjs
+++ b/electron/scripts/scriptRuntime.test.cjs
@@ -72,7 +72,7 @@ await main();
   assert.deepEqual(logs, ["from-main"]);
 });
 
-test("createScriptRuntime executes simple log script", async () => {
+test("createScriptRuntime exposes the session name", async () => {
   const logs = [];
   const runtime = createScriptRuntime({
     sessionId: "s1",
@@ -84,15 +84,15 @@ test("createScriptRuntime executes simple log script", async () => {
       waitForAny: async () => 0,
       getText: () => "",
     }),
-    getSessionMeta: () => ({ connected: true, hostname: "host", username: "user" }),
+    getSessionMeta: () => ({ connected: true, name: "Production", hostname: "host", username: "user" }),
     showDialog: async () => true,
     isPaused: () => false,
     isAborted: () => false,
     onStatusChange: () => {},
   });
 
-  await runtime.execute("nct.log('hello');");
-  assert.deepEqual(logs, ["hello"]);
+  await runtime.execute("nct.log(nct.session.name);");
+  assert.deepEqual(logs, ["Production"]);
 });
 
 test("createScriptRuntime releases its isolated worker after normal completion", async () => {

--- a/infrastructure/ai/vaultAgentBridgeClient.ts
+++ b/infrastructure/ai/vaultAgentBridgeClient.ts
@@ -333,6 +333,7 @@ async function executeSnippetOrScriptRun(
   snippet: Snippet,
   sessionId: string,
   params: Record<string, unknown>,
+  sessionMeta?: { connected?: boolean; name?: string; hostname?: string; username?: string },
 ): Promise<Record<string, unknown>> {
   if (isScriptSnippet(snippet)) {
     const wait = parseOptionalBoolean(params.wait) ?? false;
@@ -340,6 +341,7 @@ async function executeSnippetOrScriptRun(
       const { runId } = await runAutomationScript({
         snippet,
         sessionId,
+        sessionMeta,
       });
       if (!wait) {
         return { ok: true, sessionId, snippetId: snippet.id, runId, kind: 'script' };
@@ -461,6 +463,12 @@ export interface VaultAgentApiDeps {
     ok: false;
     error: string;
   };
+  getScriptSessionMeta?: (sessionId: string) => {
+    connected?: boolean;
+    name?: string;
+    hostname?: string;
+    username?: string;
+  } | undefined;
 }
 
 function resolveEffectiveHostKeyPath(host: Host, deps: VaultAgentApiDeps): string | undefined {
@@ -1073,7 +1081,7 @@ export async function handleVaultAgentOp(
       const snippet = deps.snippets.find((entry) => entry.id === snippetId);
       if (!snippet) return { ok: false, error: `Snippet "${snippetId}" was not found.` };
       if (!sessionId) return { ok: false, error: 'sessionId is required.' };
-      return executeSnippetOrScriptRun(snippet, sessionId, params);
+      return executeSnippetOrScriptRun(snippet, sessionId, params, deps.getScriptSessionMeta?.(sessionId));
     }
     case 'scripts.list': {
       return {
@@ -1136,7 +1144,7 @@ export async function handleVaultAgentOp(
       const script = deps.snippets.find((entry) => entry.id === scriptId && isScriptSnippet(entry));
       if (!script) return { ok: false, error: `Script "${scriptId}" was not found.` };
       if (!sessionId) return { ok: false, error: 'sessionId is required.' };
-      return executeSnippetOrScriptRun(script, sessionId, params);
+      return executeSnippetOrScriptRun(script, sessionId, params, deps.getScriptSessionMeta?.(sessionId));
     }
     case 'scripts.reference': {
       return { ok: true, reference: getScriptApiReference() };

--- a/types/global/netcatty-bridge-script.d.ts
+++ b/types/global/netcatty-bridge-script.d.ts
@@ -127,6 +127,7 @@ export interface ScriptRunParams {
   /** Renderer-provided session state (worker SSH sessions are not in main-process map). */
   sessionMeta?: {
     connected?: boolean;
+    name?: string;
     hostname?: string;
     username?: string;
   };


### PR DESCRIPTION

  ## Summary

  Expose the current terminal session name to automation scripts through `nct.session.name`.

  The session name is derived from the host label and propagated through the renderer session metadata, Electron script bridge, isolated script runtime, and execution worker. This allows scripts to identify the terminal
  session or target host they are running against, which is especially useful for multi-host automation.

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor / code cleanup
  - [x] Documentation update
  - [ ] Build / CI change
  - [ ] Other (please describe):

  ## Related Issue (optional)

  N/A

  ## Changes Made

  - Added an optional `name` field to script session metadata and its TypeScript definitions.
  - Populated the session name from the host label when starting automation and connection scripts.
  - Added host-label fallback handling when building session metadata in the terminal layer.
  - Propagated the session name through the Electron script bridge and runtime snapshot.
  - Exposed the session name to scripts as `nct.session.name`.
  - Ensured unavailable session names safely fall back to an empty string.
  - Updated script bridge and runtime tests to verify that session names are available inside automation scripts.

  ## Screenshots / Demo

  No UI changes.
<img width="820" height="1732" alt="Clipboard_Screenshot_1785316888" src="https://github.com/user-attachments/assets/a3fcfecf-b0e0-40d5-99f0-4d29eb74df76" />

<img width="1846" height="450" alt="Clipboard_Screenshot_1785316744" src="https://github.com/user-attachments/assets/150d8a87-ceb5-4837-a447-425f6e086c79" />

  Automation scripts can now access the current session name:

  ```javascript
  nct.log(`Running on session: ${nct.session.name}`);

  ## Testing

  - [x] I have tested these changes locally (npm run dev)
  - [x] Linting passes (npm run lint)
  - [x] Generated capability tool specs are updated when applicable (npm run generate:capability-tools) — not applicable; no capability catalog changes
  - [x] No new console errors or warnings, if this affects app behavior
  - [x] Packaged application was manually tested and no issues were observed
  - [x] Feature-specific script bridge, runtime, and domain tests pass (70 tests)
  - [ ] Full test suite passes (`npm test`) — blocked locally by pre-existing Node hook and CLI stdout truncation failures unrelated to this change

<img width="2178" height="984" alt="Clipboard_Screenshot_1785317407" src="https://github.com/user-attachments/assets/05d61903-0f33-44de-8d92-5e03346da67e" />

  ## Checklist

  - [x] My code follows the existing project style
  - [x] I have added or updated relevant documentation
  - [x] I have not introduced any breaking changes (or I have described them above)
