### PR TITLE
Improve settings controls and virtualize host lists

### DIFF
--- a/components/ai/ChatInput.test.tsx
+++ b/components/ai/ChatInput.test.tsx
@@ -1,10 +1,22 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import ChatInput from './ChatInput';
 import { TooltipProvider } from '../ui/tooltip';
+
+test('virtualizes the host mention list without changing its option contract', () => {
+  const source = readFileSync(new URL('./ChatInput.tsx', import.meta.url), 'utf8');
+
+  assert.match(source, /VariableSizeVirtualList/);
+  assert.match(source, /ref=\{atMentionListRef\}/);
+  assert.match(source, /aria-activedescendant=\{hosts\[activeMenuIndex\] \? `at-mention-/);
+  assert.match(source, /onMouseEnter=\{\(\) => setActiveMenuIndex\(idx\)\}/);
+  assert.match(source, /onClick=\{\(\) => handleSelectAtMention\(host\)\}/);
+  assert.match(source, /max-h-\[280px\]/);
+});
 
 test('does not render a standalone slash command toolbar button', () => {
   const html = renderToStaticMarkup(

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -24,7 +24,7 @@ import type { PromptInputStatus } from '../ai-elements/prompt-input';
 import { formatThinkingLabel } from '../../infrastructure/ai/types';
 import type { AgentModelPreset, AIPermissionMode, ProviderConfig, UploadedFile } from '../../infrastructure/ai/types';
 import { ProviderIconBadge } from '../settings/tabs/ai/ProviderIconBadge';
-import { ScrollArea } from '../ui/scroll-area';
+import { VariableSizeVirtualList, type VariableSizeVirtualListHandle } from '../ui/VariableSizeVirtualList';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 
 // Keep in sync with the popover's Tailwind max-width below.
@@ -173,6 +173,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
   const permBtnRef = useRef<HTMLButtonElement>(null);
   const attachBtnRef = useRef<HTMLButtonElement>(null);
   const slashPickerListRef = useRef<HTMLDivElement>(null);
+  const atMentionListRef = useRef<VariableSizeVirtualListHandle>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const findSlashTrigger = useCallback((text: string, caretPosition: number) => {
@@ -365,6 +366,10 @@ const ChatInput: React.FC<ChatInputProps> = ({
   useEffect(() => {
     if (showAtMention) setActiveMenuIndex(0);
   }, [showAtMention, atMentionKey]);
+  useEffect(() => {
+    if (!showAtMention || hosts.length === 0) return;
+    atMentionListRef.current?.scrollToIndex(activeMenuIndex);
+  }, [activeMenuIndex, atMentionKey, hosts.length, showAtMention]);
   useEffect(() => {
     if (showSlashCommandPicker) setActiveMenuIndex(0);
   }, [showSlashCommandPicker, slashCommandKey]);
@@ -681,38 +686,47 @@ const ChatInput: React.FC<ChatInputProps> = ({
               className="fixed z-[1000] overflow-hidden rounded-lg border border-border/50 bg-popover shadow-lg"
               style={{ left: inputPanelPos.left, bottom: inputPanelPos.bottom, width: 'auto', minWidth: Math.min(200, inputPanelPos.width), maxWidth: inputPanelPos.width }}
             >
-              <ScrollArea className="max-h-[280px]">
-                <div className="p-1">
-                  {hosts.map((host, idx) => {
-                    const isActive = idx === activeMenuIndex;
-                    const showHostnameLine = host.label
-                      && host.hostname !== host.label
-                      && !host.label.includes(host.hostname);
-                    return (
-                      <button
-                        id={`at-mention-${host.sessionId}`}
-                        key={host.sessionId}
-                        type="button"
-                        role="option"
-                        aria-selected={isActive}
-                        onMouseEnter={() => setActiveMenuIndex(idx)}
-                        onClick={() => handleSelectAtMention(host)}
-                        className={`w-full rounded-md px-2 py-1 text-left transition-colors cursor-pointer ${isActive ? 'bg-muted/40' : 'hover:bg-muted/30'}`}
-                      >
-                        <div className="flex items-center gap-2 text-[12px] text-foreground/90">
-                          <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${host.connected ? 'bg-green-500' : 'bg-muted-foreground/30'}`} />
-                          <span className="truncate">{host.label || host.hostname}</span>
+              <div className="max-h-[280px]" style={{ height: Math.min(280, 8 + hosts.reduce((total, host) => total + (host.label
+                && host.hostname !== host.label
+                && !host.label.includes(host.hostname) ? 52 : 36), 0)) }}>
+                <VariableSizeVirtualList
+                  ref={atMentionListRef}
+                  items={hosts}
+                  getItemHeight={(host) => host.label
+                    && host.hostname !== host.label
+                    && !host.label.includes(host.hostname) ? 52 : 36}
+                  getItemKey={(host) => host.sessionId}
+                  className="h-full"
+                  contentClassName="p-1"
+                  renderItem={(host, idx) => {
+                  const isActive = idx === activeMenuIndex;
+                  const showHostnameLine = host.label
+                    && host.hostname !== host.label
+                    && !host.label.includes(host.hostname);
+                  return (
+                    <button
+                      id={`at-mention-${host.sessionId}`}
+                      type="button"
+                      role="option"
+                      aria-selected={isActive}
+                      onMouseEnter={() => setActiveMenuIndex(idx)}
+                      onClick={() => handleSelectAtMention(host)}
+                      className={`h-full w-full rounded-md px-2 py-1 text-left transition-colors cursor-pointer ${isActive ? 'bg-muted/40' : 'hover:bg-muted/30'}`}
+                    >
+                      <div className="flex items-center gap-2 text-[12px] text-foreground/90">
+                        <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${host.connected ? 'bg-green-500' : 'bg-muted-foreground/30'}`} />
+                        <span className="truncate">{host.label || host.hostname}</span>
+                      </div>
+                      {showHostnameLine ? (
+                        <div className="pl-3.5 text-[10px] text-muted-foreground/60 truncate">
+                          {host.hostname}
                         </div>
-                        {showHostnameLine ? (
-                          <div className="pl-3.5 text-[10px] text-muted-foreground/60 truncate">
-                            {host.hostname}
-                          </div>
-                        ) : null}
-                      </button>
-                    );
-                  })}
-                </div>
-              </ScrollArea>
+                      ) : null}
+                    </button>
+                  );
+                  }}
+                />
+              </div>
             </div>
           </>,
           document.body,

--- a/components/host-details/ChainPanel.test.tsx
+++ b/components/host-details/ChainPanel.test.tsx
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+test('ChainPanel virtualizes the searchable available-host picker', () => {
+  const source = readFileSync(new URL('./ChainPanel.tsx', import.meta.url), 'utf8');
+
+  assert.match(source, /FixedSizeVirtualList/);
+  assert.match(source, /items=\{filteredHosts\}/);
+  assert.match(source, /CHAIN_HOST_VIEWPORT_HEIGHT/);
+  assert.match(source, /onClick=\{\(\) => onAddHost\(host\.id\)\}/);
+});

--- a/components/host-details/ChainPanel.tsx
+++ b/components/host-details/ChainPanel.tsx
@@ -10,8 +10,12 @@ import { DistroAvatar } from '../DistroAvatar';
 import { AsidePanel, type AsidePanelLayout, type AsidePanelResizeProps } from '../ui/aside-panel';
 import { Button } from '../ui/button';
 import { Card } from '../ui/card';
+import { FixedSizeVirtualList } from '../ui/FixedSizeVirtualList';
 import { Input } from '../ui/input';
 import { ScrollArea } from '../ui/scroll-area';
+
+const CHAIN_HOST_ROW_HEIGHT = 52;
+const CHAIN_HOST_VIEWPORT_HEIGHT = 256;
 
 export interface ChainPanelProps {
     formLabel: string;
@@ -130,21 +134,35 @@ export const ChainPanel: React.FC<ChainPanelPropsWithResize> = ({
                                     className="h-8 pl-8 text-sm"
                                 />
                             </div>
-                            <div className="space-y-1">
-                                {filteredHosts.map((host) => (
-                                    <button
-                                        key={host.id}
-                                        className="w-full flex items-center gap-2 p-2 rounded-md hover:bg-secondary transition-colors text-left overflow-hidden"
-                                        onClick={() => onAddHost(host.id)}
-                                    >
-                                        <DistroAvatar host={host} fallback={host.label.slice(0, 2).toUpperCase()} className="h-8 w-8" />
-                                        <div className="flex-1 min-w-0">
-                                            <div className="text-sm font-medium truncate">{host.label}</div>
-                                            <div className="text-xs text-muted-foreground truncate">{host.hostname}</div>
-                                        </div>
-                                        <Plus size={14} className="text-muted-foreground" />
-                                    </button>
-                                ))}
+                            <div
+                                className="max-h-64"
+                                style={{
+                                    height: Math.min(
+                                        filteredHosts.length * CHAIN_HOST_ROW_HEIGHT,
+                                        CHAIN_HOST_VIEWPORT_HEIGHT,
+                                    ),
+                                }}
+                            >
+                                <FixedSizeVirtualList
+                                    items={filteredHosts}
+                                    itemHeight={CHAIN_HOST_ROW_HEIGHT}
+                                    className="h-full"
+                                    getItemKey={(host) => host.id}
+                                    renderItem={(host, index) => (
+                                        <button
+                                            key={host.id}
+                                            className={`w-full flex items-center gap-2 p-2 rounded-md hover:bg-secondary transition-colors text-left overflow-hidden${index > 0 ? ' mt-1' : ''}`}
+                                            onClick={() => onAddHost(host.id)}
+                                        >
+                                            <DistroAvatar host={host} fallback={host.label.slice(0, 2).toUpperCase()} className="h-8 w-8" />
+                                            <div className="flex-1 min-w-0">
+                                                <div className="text-sm font-medium truncate">{host.label}</div>
+                                                <div className="text-xs text-muted-foreground truncate">{host.hostname}</div>
+                                            </div>
+                                            <Plus size={14} className="text-muted-foreground" />
+                                        </button>
+                                    )}
+                                />
                             </div>
                         </Card>
                     )}

--- a/components/notes/InlineMarkdownEditor.test.tsx
+++ b/components/notes/InlineMarkdownEditor.test.tsx
@@ -18,6 +18,16 @@ test("host picker navigation keys are handled even before a query is typed", () 
   assert.equal(shouldHandleHostPickerNavigationKey(true, "Tab", 3), true);
 });
 
+test("host picker uses a constrained virtual list and keeps pointer selection", () => {
+  const source = readFileSync(new URL("./InlineMarkdownEditor.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /FixedSizeVirtualList/);
+  assert.match(source, /ref=\{hostPickerListRef\}/);
+  assert.match(source, /HOST_PICKER_LIST_MAX_HEIGHT/);
+  assert.match(source, /onMouseDown=\{\(event\) => event\.preventDefault\(\)\}/);
+  assert.match(source, /onClick=\{\(\) => insertHostLink\(host\)\}/);
+});
+
 test("host picker still lets ordinary trigger text continue through the editor", () => {
   assert.equal(shouldHandleHostPickerNavigationKey(true, "@", 3), false);
   assert.equal(shouldHandleHostPickerNavigationKey(true, "/", 3), false);

--- a/components/notes/InlineMarkdownEditor.test.tsx
+++ b/components/notes/InlineMarkdownEditor.test.tsx
@@ -24,6 +24,10 @@ test("host picker uses a constrained virtual list and keeps pointer selection", 
   assert.match(source, /FixedSizeVirtualList/);
   assert.match(source, /ref=\{hostPickerListRef\}/);
   assert.match(source, /HOST_PICKER_LIST_MAX_HEIGHT/);
+  assert.match(
+    source,
+    /filteredHosts\.length === 0\s*\?\s*HOST_PICKER_EMPTY_HEIGHT\s*:\s*HOST_PICKER_LIST_VERTICAL_PADDING \+ filteredHosts\.length \* HOST_PICKER_ROW_HEIGHT/,
+  );
   assert.match(source, /onMouseDown=\{\(event\) => event\.preventDefault\(\)\}/);
   assert.match(source, /onClick=\{\(\) => insertHostLink\(host\)\}/);
 });

--- a/components/notes/InlineMarkdownEditor.tsx
+++ b/components/notes/InlineMarkdownEditor.tsx
@@ -40,6 +40,7 @@ import { buildSshNoteLinkOpenHost } from "../../domain/sshDeepLink";
 import { copyToClipboard } from "../keychain/utils";
 import { toast } from "../ui/toast";
 import { cn } from "../../lib/utils";
+import { FixedSizeVirtualList, type FixedSizeVirtualListHandle } from "../ui/FixedSizeVirtualList";
 import type { Host } from "../../types";
 
 export interface InlineMarkdownEditorProps {
@@ -462,6 +463,7 @@ export function InlineMarkdownEditor({
   const [linkAction, setLinkAction] = useState<LinkActionState | null>(null);
   const editorMode = controlledEditorMode ?? "edit";
   const hostPickerRangeRef = useRef<Range | null>(null);
+  const hostPickerListRef = useRef<FixedSizeVirtualListHandle>(null);
   const plugins = useMemo(() => [
     headingsPlugin(),
     listsPlugin(),
@@ -504,6 +506,11 @@ export function InlineMarkdownEditor({
       ...current,
       selectedIndex: Math.max(0, filteredHosts.length - 1),
     }));
+  }, [filteredHosts.length, hostPicker.open, hostPicker.selectedIndex]);
+
+  useEffect(() => {
+    if (!hostPicker.open || filteredHosts.length === 0) return;
+    hostPickerListRef.current?.scrollToIndex(hostPicker.selectedIndex);
   }, [filteredHosts.length, hostPicker.open, hostPicker.selectedIndex]);
 
   useEffect(() => {
@@ -890,27 +897,39 @@ export function InlineMarkdownEditor({
           <div className="border-b border-border/60 px-3 py-2 text-xs text-muted-foreground">
             {hostPicker.query ? `${hostPicker.trigger}${hostPicker.query}` : "选择主机"}
           </div>
-          <div className="max-h-64 overflow-auto p-1">
-            {filteredHosts.length === 0 ? (
-              <div className="px-3 py-2 text-sm text-muted-foreground">没有匹配的主机</div>
-            ) : filteredHosts.map((host, index) => (
-              <button
-                key={host.id}
-                type="button"
-                className={cn(
-                  "flex w-full min-w-0 items-center gap-2 rounded px-2 py-1.5 text-left text-sm",
-                  index === hostPicker.selectedIndex ? "bg-secondary text-foreground" : "hover:bg-secondary/70",
-                )}
-                onMouseDown={(event) => event.preventDefault()}
-                onClick={() => insertHostLink(host)}
-              >
-                <span className="min-w-0 flex-1 truncate">{getHostLinkLabel(host)}</span>
-                <span className="shrink-0 text-xs text-muted-foreground">
-                  {host.username ? `${host.username}@` : ""}{host.hostname}
-                </span>
-              </button>
-            ))}
-          </div>
+            <div
+              className="max-h-64"
+              style={{ height: Math.min(HOST_PICKER_LIST_MAX_HEIGHT, HOST_PICKER_LIST_VERTICAL_PADDING + filteredHosts.length * HOST_PICKER_ROW_HEIGHT) }}
+            >
+              {filteredHosts.length === 0 ? (
+                <div className="px-3 py-2 text-sm text-muted-foreground">没有匹配的主机</div>
+              ) : (
+                <FixedSizeVirtualList
+                  ref={hostPickerListRef}
+                  items={filteredHosts}
+                  itemHeight={HOST_PICKER_ROW_HEIGHT}
+                  getItemKey={(host) => host.id}
+                  className="h-full"
+                  contentClassName="p-1"
+                  renderItem={(host, index) => (
+                    <button
+                      type="button"
+                      className={cn(
+                        "flex h-full w-full min-w-0 items-center gap-2 rounded px-2 py-1.5 text-left text-sm",
+                        index === hostPicker.selectedIndex ? "bg-secondary text-foreground" : "hover:bg-secondary/70",
+                      )}
+                      onMouseDown={(event) => event.preventDefault()}
+                      onClick={() => insertHostLink(host)}
+                    >
+                      <span className="min-w-0 flex-1 truncate">{getHostLinkLabel(host)}</span>
+                      <span className="shrink-0 text-xs text-muted-foreground">
+                        {host.username ? `${host.username}@` : ""}{host.hostname}
+                      </span>
+                    </button>
+                  )}
+                />
+              )}
+            </div>
         </div>
       )}
       {editorMode === "preview" && !value.trim() ? (

--- a/components/notes/InlineMarkdownEditor.tsx
+++ b/components/notes/InlineMarkdownEditor.tsx
@@ -899,7 +899,14 @@ export function InlineMarkdownEditor({
           </div>
             <div
               className="max-h-64"
-              style={{ height: Math.min(HOST_PICKER_LIST_MAX_HEIGHT, HOST_PICKER_LIST_VERTICAL_PADDING + filteredHosts.length * HOST_PICKER_ROW_HEIGHT) }}
+              style={{
+                height: Math.min(
+                  HOST_PICKER_LIST_MAX_HEIGHT,
+                  filteredHosts.length === 0
+                    ? HOST_PICKER_EMPTY_HEIGHT
+                    : HOST_PICKER_LIST_VERTICAL_PADDING + filteredHosts.length * HOST_PICKER_ROW_HEIGHT,
+                ),
+              }}
             >
               {filteredHosts.length === 0 ? (
                 <div className="px-3 py-2 text-sm text-muted-foreground">没有匹配的主机</div>

--- a/components/settings/TerminalCjkFontSelect.tsx
+++ b/components/settings/TerminalCjkFontSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { RefreshCw } from 'lucide-react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import {
   refreshFonts,
@@ -29,6 +29,8 @@ interface Props {
   onChange: (next: string) => void;
   className?: string;
   disabled?: boolean;
+  label?: string;
+  description?: string;
 }
 
 export const TerminalCjkFontSelect: React.FC<Props> = ({
@@ -36,6 +38,8 @@ export const TerminalCjkFontSelect: React.FC<Props> = ({
   onChange,
   className,
   disabled,
+  label,
+  description,
 }) => {
   const { t } = useI18n();
   const installedFamilies = useInstalledFontFamilies();
@@ -88,58 +92,75 @@ export const TerminalCjkFontSelect: React.FC<Props> = ({
   );
   const selectedFontFamily = previewFontFamily(value);
   const previewFamily = previewFontFamily(previewValue);
+  const controls = (
+    <div className="flex items-center gap-2">
+      <Combobox
+        options={options}
+        value={value}
+        onValueChange={onChange}
+        placeholder={t('settings.terminal.font.cjk.searchPlaceholder')}
+        emptyText={t('settings.terminal.font.cjk.empty')}
+        allowCreate
+        createText={t('settings.terminal.font.cjk.useCustom')}
+        triggerClassName="h-9"
+        inputStyle={{ fontFamily: selectedFontFamily }}
+        onInputValueChange={setPreviewValue}
+        disabled={disabled}
+      />
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        className="h-9 w-9 shrink-0"
+        aria-label={t('settings.terminal.font.cjk.refresh')}
+        title={t('settings.terminal.font.cjk.refresh')}
+        disabled={disabled || isLoading}
+        onClick={() => void refreshFonts()}
+      >
+        <RefreshCw size={14} className={cn(isLoading && 'animate-spin')} />
+      </Button>
+    </div>
+  );
 
-  return (
-    <div className={cn('space-y-2', className)}>
-      <div className="flex items-center gap-2">
-        <Combobox
-          options={options}
-          value={value}
-          onValueChange={onChange}
-          placeholder={t('settings.terminal.font.cjk.searchPlaceholder')}
-          emptyText={t('settings.terminal.font.cjk.empty')}
-          allowCreate
-          createText={t('settings.terminal.font.cjk.useCustom')}
-          triggerClassName="h-9"
-          inputStyle={{ fontFamily: selectedFontFamily }}
-          onInputValueChange={setPreviewValue}
-          disabled={disabled}
-        />
-        <Button
-          type="button"
-          variant="outline"
-          size="icon"
-          className="h-9 w-9 shrink-0"
-          aria-label={t('settings.terminal.font.cjk.refresh')}
-          title={t('settings.terminal.font.cjk.refresh')}
-          disabled={disabled || isLoading}
-          onClick={() => void refreshFonts()}
-        >
-          <RefreshCw size={14} className={cn(isLoading && 'animate-spin')} />
-        </Button>
-      </div>
-
-      {previewValue.trim() && (
-        <pre
-          className="overflow-hidden rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-sm leading-5"
-          style={{ fontFamily: previewFamily }}
-        >
-          {'你好 │ ABC  │ 123\n123  │ 测试 │ ABC'}
-        </pre>
-      )}
+  const preview = previewValue.trim() && (
+    <>
+      <pre
+        className="m-0 py-2 text-center text-base leading-7 text-foreground"
+        style={{ fontFamily: previewFamily }}
+      >
+        {'你好 │ ABC  │ 123\n123  │ 测试 │ ABC'}
+      </pre>
 
       {status === 'alignment-risk' && (
-        <p className="flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-400">
-          <AlertTriangle size={13} className="mt-0.5 shrink-0" />
-          <span>{t('settings.terminal.font.cjk.alignmentWarning')}</span>
+        <p className="m-0 text-center text-xs text-amber-600 dark:text-amber-400">
+          {t('settings.terminal.font.cjk.alignmentWarning')}
         </p>
       )}
       {status === 'unavailable' && (
-        <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
-          <AlertTriangle size={13} className="mt-0.5 shrink-0" />
-          <span>{t('settings.terminal.font.cjk.unavailableWarning')}</span>
+        <p className="m-0 text-center text-xs text-muted-foreground">
+          {t('settings.terminal.font.cjk.unavailableWarning')}
         </p>
       )}
+    </>
+  );
+
+  if (label) {
+    return (
+      <div className={cn('grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-4 gap-y-2 py-3', className)}>
+        <div className="min-w-0">
+          <div className="text-sm font-medium">{label}</div>
+          {description && <div className="mt-0.5 text-xs text-muted-foreground">{description}</div>}
+        </div>
+        <div className="w-72 shrink-0">{controls}</div>
+        {preview && <div className="col-span-2 justify-self-center">{preview}</div>}
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      {controls}
+      {preview}
     </div>
   );
 };

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -518,17 +518,12 @@ function SettingsTerminalTab(props: {
           />
         </SettingRow>
 
-        <SettingRow
+        <TerminalCjkFontSelect
           label={t("settings.terminal.font.cjk")}
           description={t("settings.terminal.font.cjk.desc")}
-          align="start"
-        >
-          <TerminalCjkFontSelect
-            value={terminalSettings.fallbackFont ?? ""}
-            onChange={(next) => updateTerminalSetting("fallbackFont", next)}
-            className="w-72"
-          />
-        </SettingRow>
+          value={terminalSettings.fallbackFont ?? ""}
+          onChange={(next) => updateTerminalSetting("fallbackFont", next)}
+        />
 
         <SettingRow
           label={t("settings.terminal.font.size")}

--- a/components/settings/tabs/SettingsTerminalTabControls.tsx
+++ b/components/settings/tabs/SettingsTerminalTabControls.tsx
@@ -158,11 +158,6 @@ export const KeywordHighlightRulesEditor: React.FC<{
         const customized = builtIn && rule.customized;
         return (
           <div key={rule.id} className="flex items-center gap-2 group">
-            <Toggle
-              checked={rule.enabled}
-              onChange={() => onChange(toggleKeywordHighlightRuleEnabled(rules, rule.id))}
-              ariaLabel={`${rule.label}, ${rule.enabled ? t('common.enabled') : t('common.disabled')}`}
-            />
             <div className="flex-1 min-w-0 flex items-center gap-1.5">
               <span className={cn("text-sm truncate", !rule.enabled && "text-muted-foreground line-through")} style={rule.enabled ? { color: rule.color } : undefined}>
                 {rule.label}
@@ -210,6 +205,11 @@ export const KeywordHighlightRulesEditor: React.FC<{
                 style={{ backgroundColor: rule.color }}
               />
             </label>
+            <Toggle
+              checked={rule.enabled}
+              onChange={() => onChange(toggleKeywordHighlightRuleEnabled(rules, rule.id))}
+              ariaLabel={`${rule.label}, ${rule.enabled ? t('common.enabled') : t('common.disabled')}`}
+            />
           </div>
         );
       })}

--- a/components/vault/VaultHostListSection.test.tsx
+++ b/components/vault/VaultHostListSection.test.tsx
@@ -425,6 +425,25 @@ test("VaultHostListSection virtualizes large pinned collections", () => {
   assert.match(markup, /data-vault-virtual-collection="grid"/);
 });
 
+test("VaultHostListSection virtualizes large recently connected collections", () => {
+  const hosts = Array.from({ length: 300 }, (_, index) => (
+    makeHost(`recent-${index}`, `Recent ${index}`)
+  ));
+  const markup = renderHostList({
+    viewMode: "grid",
+    displayedGroups: [],
+    displayedHosts: [],
+    visibleDisplayedHosts: [],
+    recentHosts: hosts,
+    showRecentHosts: true,
+  });
+
+  const renderedHosts = (markup.match(/data-vault-grid-item="recent:/g) ?? []).length;
+  assert.ok(renderedHosts > 0);
+  assert.ok(renderedHosts < 100);
+  assert.match(markup, /data-vault-virtual-collection="grid"/);
+});
+
 test("VaultHostListSection virtualizes large group collections", () => {
   const groups = Array.from({ length: 300 }, (_, index): GroupNode => ({
     name: `Group ${index}`,

--- a/components/vault/VaultHostListSection.tsx
+++ b/components/vault/VaultHostListSection.tsx
@@ -2,8 +2,6 @@
 import React from "react";
 import { HostNotesIndicator } from "../host/HostNotesIndicator";
 import {
-  getNextVirtualHostIndex,
-  getVaultHostColumnCount,
   VirtualizedGroupedHostCollection,
   VirtualizedHostCollection,
 } from "./VirtualizedHostCollection";
@@ -52,7 +50,7 @@ const isRelatedTargetInside = (
 };
 
 export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext }) {
-  const { Badge, Boolean, Button, cancelInlineGroupEdit, CheckSquare, ClipboardCopy, Clock, cn, commitInlineGroupRename, ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger, Copy, displayedGroups, displayedHosts, DistroAvatar, Edit2, FileSymlink, FolderPlus, FolderTree, getDropTargetClasses, getEffectiveHostDistro, groupConfigs, groupedDisplayHosts, handleCopyCredentials, handleDuplicateHost, handleEditGroupConfig, handleEditHost, handleHostConnect, hostClickBehavior: hostClickBehaviorProp, handleUnmanageGroup, hasHostsSidePanel, hostListScrollRef, HostTreeView, isHostsSectionActive, isMultiSelectMode, lastPinnedId, LayoutGrid, managedGroupPaths, moveGroup, moveHostToGroup, onDeleteHost, Pin, pinnedHosts, Plug, recentHosts, reorderGroup, reorderHost, sanitizeHost, search, selectedGroupPath, selectedGroupPaths, selectedHostIds, selectedTags, sessionCount, setDeleteTargetPath, setDragOverDropTarget, setGroupDragOverDropTarget, setIsDeleteGroupOpen, setIsNewFolderOpen, setLastPinnedId, setNewFolderName, setSelectedGroupPath, setTargetParentPath, shouldHideEmptyRootHostsSection, showRecentHosts, sortMode, splitViewGridStyle, Square, Star, startInlineDeleteGroup, startInlineNewGroup, startInlineRenameGroup, t, toggleGroupSelection, toggleHostPinned, toggleHostSelection, Trash2, treeExpandedState, treeViewGroupTree, treeViewHosts, viewMode, visibleDisplayedHosts } = ctx;
+  const { Badge, Boolean, Button, cancelInlineGroupEdit, CheckSquare, ClipboardCopy, Clock, cn, commitInlineGroupRename, ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger, Copy, displayedGroups, displayedHosts, DistroAvatar, Edit2, FileSymlink, FolderPlus, FolderTree, getDropTargetClasses, getEffectiveHostDistro, groupConfigs, groupedDisplayHosts, handleCopyCredentials, handleDuplicateHost, handleEditGroupConfig, handleEditHost, handleHostConnect, hostClickBehavior: hostClickBehaviorProp, handleUnmanageGroup, hasHostsSidePanel, hostListScrollRef, HostTreeView, isHostsSectionActive, isMultiSelectMode, lastPinnedId, LayoutGrid, managedGroupPaths, moveGroup, moveHostToGroup, onDeleteHost, Pin, pinnedHosts, Plug, recentHosts, reorderGroup, reorderHost, sanitizeHost, search, selectedGroupPath, selectedGroupPaths, selectedHostIds, selectedTags, sessionCount, setDeleteTargetPath, setDragOverDropTarget, setGroupDragOverDropTarget, setIsDeleteGroupOpen, setIsNewFolderOpen, setLastPinnedId, setNewFolderName, setSelectedGroupPath, setTargetParentPath, shouldHideEmptyRootHostsSection, showRecentHosts, sortMode, Square, Star, startInlineDeleteGroup, startInlineNewGroup, startInlineRenameGroup, t, toggleGroupSelection, toggleHostPinned, toggleHostSelection, Trash2, treeExpandedState, treeViewGroupTree, treeViewHosts, viewMode, visibleDisplayedHosts } = ctx;
   const hostClickBehavior: HostClickBehavior = hostClickBehaviorProp === 'select' ? 'select' : 'connect';
   const multiSelectedGroupPaths: Set<string> = selectedGroupPaths ?? new Set();
   const [draggingHostId, setDraggingHostId] = React.useState<string | null>(null);
@@ -576,15 +574,17 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                         <Clock size={14} className="shrink-0 -translate-y-[1px]" />
                         {t("vault.hosts.recentlyConnected")}
                       </h3>
-                      <div className={cn(
-                        viewMode === "grid"
-                          ? cn(
-                            "grid gap-3",
-                          )
-                          : "flex flex-col gap-0",
-                      )}
-                      style={viewMode === "grid" ? splitViewGridStyle : undefined}>
-                        {recentHosts.map((host) => {
+                      <VirtualizedHostCollection<Host>
+                        items={recentHosts}
+                        itemKey={(host) => host.id}
+                        scrollRef={hostListScrollRef}
+                        viewMode={viewMode}
+                        layoutKey={`recent:${hostCollectionLayoutKey}`}
+                        ariaLabel={t("vault.hosts.recentlyConnected")}
+                        onActiveItemChange={focusHost}
+                        activeItemKey={focusedHostId}
+                        onBoundaryNavigation={(direction) => navigateHostSection("recent", direction)}
+                        renderItem={(host) => {
                           const safeHost = sanitizeHost(host);
                           const effectiveDistro = getEffectiveHostDistro(safeHost);
                           const distroBadge = {
@@ -623,35 +623,9 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                     activateHost(safeHost);
                                   }}
                                   onKeyDown={(event) => {
-                                    if (event.key === "Enter" || event.key === " ") {
-                                      event.preventDefault();
-                                      activateHost(safeHost);
-                                      return;
-                                    }
-                                    const index = recentHosts.findIndex((item) => item.id === host.id);
-                                    const nextIndex = getNextVirtualHostIndex({
-                                      currentIndex: index,
-                                      itemCount: recentHosts.length,
-                                      columns: getVaultHostColumnCount(
-                                        hostListScrollRef.current?.clientWidth ?? 0,
-                                        viewMode,
-                                      ),
-                                      viewMode,
-                                      key: event.key,
-                                    });
-                                    if (nextIndex === null) return;
+                                    if (event.key !== "Enter" && event.key !== " ") return;
                                     event.preventDefault();
-                                    const nextHost = recentHosts[nextIndex];
-                                    if (nextIndex !== index && nextHost) {
-                                      focusHostAndElement(nextHost);
-                                      return;
-                                    }
-                                    const direction = event.key === "ArrowUp" || event.key === "ArrowLeft"
-                                      ? "previous"
-                                      : event.key === "ArrowDown" || event.key === "ArrowRight"
-                                        ? "next"
-                                        : null;
-                                    if (direction) navigateHostSection("recent", direction);
+                                    activateHost(safeHost);
                                   }}
                                 >
                                   <div className="flex items-center gap-3 h-full">
@@ -703,8 +677,8 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                               </ContextMenuContent>
                             </ContextMenu>
                           );
-                        })}
-                      </div>
+                        }}
+                      />
                     </section>
                   )}
                   {viewMode !== "tree" && displayedGroups.length > 0 && (


### PR DESCRIPTION
## Summary

Refines terminal settings controls and virtualizes every unbounded host-list surface found during the audit.

## Type of Change

- [x] Bug fix
- [x] Refactor / code cleanup

## Related Issue (optional)

N/A

## Changes Made

- Move keyword highlight rule toggles to the row end.
- Center and simplify the CJK font alignment preview.
- Virtualize jump-host selection, Vault recent hosts, AI host mentions, and note host autocomplete.
- Preserve keyboard navigation, ARIA option contracts, and pointer selection; add regression coverage.

## Screenshots / Demo

Settings layout updates and large-list virtualization verified locally.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Targeted virtualization and settings tests passed. `npm run lint` retains the existing unused `theme` warning in `App.tsx`.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)