### PR TITLE
fix(linux): always set chrome-sandbox SUID bit in deb/rpm postinst

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -257,7 +257,8 @@ module.exports = {
     deb: {
         // Use gzip instead of default xz(lzma) for better compatibility with
         // Deepin OS and other distros that have issues with lzma decompression
-        compression: 'gz'
+        compression: 'gz',
+        afterInstall: 'scripts/linux/after-install.tpl'
     },
     rpm: {
         // Default fpm/electron-builder RPM compression is "xzmt" (multi-threaded
@@ -265,6 +266,7 @@ module.exports = {
         // rpmbuild fails with exit 127 during packaging. gzip is portable and
         // matches our deb preference for older distros.
         compression: 'gzip',
+        afterInstall: 'scripts/linux/after-install.tpl',
         fpm: [
             // Avoid rpm's generated /usr/lib/.build-id symlinks. Those hashes
             // are global on the host, so owning them can conflict with other RPMs.

--- a/scripts/electron-builder-config.test.cjs
+++ b/scripts/electron-builder-config.test.cjs
@@ -254,22 +254,28 @@ test("windows zip follows the requested build architecture", () => {
   );
 });
 
-test("linux FPM packages refresh the hicolor icon cache after install and remove", () => {
+test("linux FPM packages use the custom post-install template", () => {
   const fs = require("node:fs");
   const path = require("node:path");
 
-  assert.equal(
-    config.pacman.afterInstall,
-    "scripts/linux/after-install.tpl",
-    "pacman.afterInstall must point at the custom FPM post-install template",
-  );
+  for (const [target, afterInstall] of Object.entries({
+    deb: config.deb.afterInstall,
+    rpm: config.rpm.afterInstall,
+    pacman: config.pacman.afterInstall,
+  })) {
+    assert.equal(
+      afterInstall,
+      "scripts/linux/after-install.tpl",
+      `${target}.afterInstall must point at the custom FPM post-install template`,
+    );
+  }
   assert.equal(
     config.pacman.afterRemove,
     "scripts/linux/after-remove.tpl",
     "pacman.afterRemove must point at the custom FPM post-remove template",
   );
 
-  for (const relPath of [config.pacman.afterInstall, config.pacman.afterRemove]) {
+  for (const relPath of [config.deb.afterInstall, config.pacman.afterRemove]) {
     const file = path.join(__dirname, "..", relPath);
     const contents = fs.readFileSync(file, "utf8");
     assert.match(

--- a/scripts/linux/after-install.tpl
+++ b/scripts/linux/after-install.tpl
@@ -10,7 +10,7 @@ else
     ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
 fi
 
-# Always mark chrome-sandbox as SUID root so the SUID sandbox works as a fallback.
+# Always set the chrome-sandbox SUID bit so its sandbox works as a fallback.
 #
 # The upstream electron-builder template gates this on a `unshare --user true`
 # probe and only sets 4755 when unprivileged user namespaces look unavailable.

--- a/scripts/linux/after-install.tpl
+++ b/scripts/linux/after-install.tpl
@@ -10,13 +10,23 @@ else
     ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
 fi
 
-# Check if user namespaces are supported by the kernel and working with a quick test:
-if ! { [[ -L /proc/self/ns/user ]] && unshare --user true; }; then
-    # Use SUID chrome-sandbox only on systems without user namespaces:
-    chmod 4755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
-else
-    chmod 0755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
-fi
+# Always mark chrome-sandbox as SUID root so the SUID sandbox works as a fallback.
+#
+# The upstream electron-builder template gates this on a `unshare --user true`
+# probe and only sets 4755 when unprivileged user namespaces look unavailable.
+# But this post-install script runs as root under dpkg/rpm, and root can create
+# a user namespace even when unprivileged userns is restricted (e.g. Ubuntu 23.10+
+# with kernel.apparmor_restrict_unprivileged_userns=1). The probe therefore always
+# passes at install time and leaves chrome-sandbox at 0755, so on machines where
+# the app itself cannot use the userns sandbox Chromium aborts with:
+#   "The SUID sandbox helper binary was found, but is not configured correctly ...
+#    must be owned by root and have mode 4755".
+#
+# Setting 4755 unconditionally is the historical electron/chrome default and is a
+# safe fallback: on hosts where the bundled AppArmor profile grants userns, Chromium
+# still prefers the namespace sandbox; elsewhere the SUID sandbox keeps the app
+# launchable. See https://github.com/binaricat/Netcatty/issues/2607.
+chmod 4755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
 
 if hash update-mime-database 2>/dev/null; then
     update-mime-database /usr/share/mime || true


### PR DESCRIPTION
## Summary

On Linux, the `.deb` / `.rpm` post-install script can leave `chrome-sandbox` at mode `0755`, so on machines where the app cannot use the unprivileged user-namespace sandbox, Chromium aborts on startup:

```
[FATAL:sandbox/linux/suid/client/setuid_sandbox_host.cc:166] The SUID sandbox helper
binary was found, but is not configured correctly ... must be owned by root and have
mode 4755.
```

The post-install userns probe (`unshare --user true`) runs **as root** under `dpkg`/`rpm`. Root can create a user namespace even when unprivileged userns is restricted (e.g. Ubuntu 23.10+ with `kernel.apparmor_restrict_unprivileged_userns=1`), so the probe always passes at install time and the script picks `chmod 0755`. When the app itself then cannot use the userns sandbox, no sandbox is usable → FATAL.

This sets `chrome-sandbox` to `4755` unconditionally — the historical electron/chrome default and a safe fallback: where the bundled AppArmor profile grants userns, Chromium still prefers the namespace sandbox; elsewhere the SUID sandbox keeps the app launchable.

## Type of Change

- [x] Bug fix

## Related Issue (optional)

Closes #2607

## Changes Made

- `scripts/linux/after-install.tpl`: replace the root-context userns probe (which always passes and can leave `chrome-sandbox` at `0755`) with an unconditional `chmod 4755`, with a comment explaining why.

## Screenshots / Demo

Reproduced on Ubuntu 24.04.4 (`apparmor_restrict_unprivileged_userns=1`, `/opt` symlinked so the bundled AppArmor profile did not attach):

- Before: launching `netcatty` aborted with the SUID sandbox FATAL above; `ls -l /opt/Netcatty/chrome-sandbox` → `-rwxr-xr-x` (0755).
- After `sudo chmod 4755 /opt/Netcatty/chrome-sandbox` (the state this change produces at install time): app launches cleanly, no sandbox error.

## Testing

- [x] Tests pass (`node --test --import tsx scripts/electron-builder-config.test.cjs` → 18/18)

Note: this only changes the packaged post-install shell template, so `npm run dev` / lint / capability-spec regen are not affected.

## Checklist

- [x] My code follows the existing project style
- [x] I have not introduced any breaking changes
