### PR TITLE
feat(ui): expose toolbar icon CSS hooks

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -343,6 +343,7 @@ Because many styles come from Tailwind utilities, you often need \`!important\` 
 
 - \`terminal-workspace\`
 - \`terminal-toolbar\` — Terminal action toolbar
+- \`terminal-toolbar-menu\` — Terminal toolbar overflow and submenu
 - \`terminal-workspace-sidebar\` — Focus-mode terminal list
 - \`terminal-host-tree-sidebar\`
 - \`terminal-host-tree-sidebar-content\`
@@ -386,7 +387,8 @@ Increase menu and toolbar icon sizes:
 
 \`\`\`css
 [data-section="top-tabs-toolbar-actions"] button > svg,
-[data-section="terminal-toolbar"] button > svg {
+[data-section="terminal-toolbar"] button > svg,
+[data-section="terminal-toolbar-menu"] button > svg {
   width: 20px !important;
   height: 20px !important;
 }

--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -388,7 +388,8 @@ Increase menu and toolbar icon sizes:
 \`\`\`css
 [data-section="top-tabs-toolbar-actions"] button > svg,
 [data-section="terminal-toolbar"] button > svg,
-[data-section="terminal-toolbar-menu"] button > svg {
+[data-section="terminal-toolbar-menu"] button > svg,
+[data-section="terminal-toolbar"] button [data-plugin-icon-kind="package"] {
   width: 20px !important;
   height: 20px !important;
 }

--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -327,6 +327,7 @@ Because many styles come from Tailwind utilities, you often need \`!important\` 
 ### Top tabs
 
 - \`top-tabs\`
+- \`top-tabs-toolbar-actions\` — Right-side menu and utility toolbar
 - \`top-tabs-host-tree-toggle\`
 - \`top-tabs-quick-switcher-toggle\`
 
@@ -341,6 +342,7 @@ Because many styles come from Tailwind utilities, you often need \`!important\` 
 ### Terminal workspace
 
 - \`terminal-workspace\`
+- \`terminal-toolbar\` — Terminal action toolbar
 - \`terminal-workspace-sidebar\` — Focus-mode terminal list
 - \`terminal-host-tree-sidebar\`
 - \`terminal-host-tree-sidebar-content\`
@@ -379,6 +381,16 @@ Because many styles come from Tailwind utilities, you often need \`!important\` 
 - \`ai-chat-panel\`
 
 ### Examples
+
+Increase menu and toolbar icon sizes:
+
+\`\`\`css
+[data-section="top-tabs-toolbar-actions"] button > svg,
+[data-section="terminal-toolbar"] button > svg {
+  width: 20px !important;
+  height: 20px !important;
+}
+\`\`\`
 
 Hide the host-list toggle in the top tab bar:
 

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -324,6 +324,7 @@ export const zhCNCoreMessages: Messages = {
 ### 顶部标签栏
 
 - \`top-tabs\`
+- \`top-tabs-toolbar-actions\` — 右侧菜单和工具栏
 - \`top-tabs-host-tree-toggle\`
 - \`top-tabs-quick-switcher-toggle\`
 
@@ -338,6 +339,7 @@ export const zhCNCoreMessages: Messages = {
 ### 终端工作区
 
 - \`terminal-workspace\`
+- \`terminal-toolbar\` — 终端操作工具栏
 - \`terminal-workspace-sidebar\` — Focus 模式终端列表
 - \`terminal-host-tree-sidebar\`
 - \`terminal-host-tree-sidebar-content\`
@@ -376,6 +378,16 @@ export const zhCNCoreMessages: Messages = {
 - \`ai-chat-panel\`
 
 ### 示例
+
+放大菜单和工具栏图标：
+
+\`\`\`css
+[data-section="top-tabs-toolbar-actions"] button > svg,
+[data-section="terminal-toolbar"] button > svg {
+  width: 20px !important;
+  height: 20px !important;
+}
+\`\`\`
 
 隐藏顶部标签栏里的主机列表开关：
 

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -340,6 +340,7 @@ export const zhCNCoreMessages: Messages = {
 
 - \`terminal-workspace\`
 - \`terminal-toolbar\` — 终端操作工具栏
+- \`terminal-toolbar-menu\` — 终端工具栏溢出菜单和子菜单
 - \`terminal-workspace-sidebar\` — Focus 模式终端列表
 - \`terminal-host-tree-sidebar\`
 - \`terminal-host-tree-sidebar-content\`
@@ -383,7 +384,8 @@ export const zhCNCoreMessages: Messages = {
 
 \`\`\`css
 [data-section="top-tabs-toolbar-actions"] button > svg,
-[data-section="terminal-toolbar"] button > svg {
+[data-section="terminal-toolbar"] button > svg,
+[data-section="terminal-toolbar-menu"] button > svg {
   width: 20px !important;
   height: 20px !important;
 }

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -385,7 +385,8 @@ export const zhCNCoreMessages: Messages = {
 \`\`\`css
 [data-section="top-tabs-toolbar-actions"] button > svg,
 [data-section="terminal-toolbar"] button > svg,
-[data-section="terminal-toolbar-menu"] button > svg {
+[data-section="terminal-toolbar-menu"] button > svg,
+[data-section="terminal-toolbar"] button [data-plugin-icon-kind="package"] {
   width: 20px !important;
   height: 20px !important;
 }

--- a/application/i18n/locales/zh-TW/core.ts
+++ b/application/i18n/locales/zh-TW/core.ts
@@ -385,7 +385,8 @@ export const zhTWCoreMessages: Messages = {
 \`\`\`css
 [data-section="top-tabs-toolbar-actions"] button > svg,
 [data-section="terminal-toolbar"] button > svg,
-[data-section="terminal-toolbar-menu"] button > svg {
+[data-section="terminal-toolbar-menu"] button > svg,
+[data-section="terminal-toolbar"] button [data-plugin-icon-kind="package"] {
   width: 20px !important;
   height: 20px !important;
 }

--- a/application/i18n/locales/zh-TW/core.ts
+++ b/application/i18n/locales/zh-TW/core.ts
@@ -324,6 +324,7 @@ export const zhTWCoreMessages: Messages = {
 ### 頂部標籤列
 
 - \`top-tabs\`
+- \`top-tabs-toolbar-actions\` — 右側選單和工具列
 - \`top-tabs-host-tree-toggle\`
 - \`top-tabs-quick-switcher-toggle\`
 
@@ -338,6 +339,7 @@ export const zhTWCoreMessages: Messages = {
 ### 終端工作區
 
 - \`terminal-workspace\`
+- \`terminal-toolbar\` — 終端操作工具列
 - \`terminal-workspace-sidebar\` — Focus 模式終端列表
 - \`terminal-host-tree-sidebar\`
 - \`terminal-host-tree-sidebar-content\`
@@ -376,6 +378,16 @@ export const zhTWCoreMessages: Messages = {
 - \`ai-chat-panel\`
 
 ### 範例
+
+放大選單和工具列圖示：
+
+\`\`\`css
+[data-section="top-tabs-toolbar-actions"] button > svg,
+[data-section="terminal-toolbar"] button > svg {
+  width: 20px !important;
+  height: 20px !important;
+}
+\`\`\`
 
 隱藏頂部標籤列裡的主機列表開關：
 

--- a/application/i18n/locales/zh-TW/core.ts
+++ b/application/i18n/locales/zh-TW/core.ts
@@ -340,6 +340,7 @@ export const zhTWCoreMessages: Messages = {
 
 - \`terminal-workspace\`
 - \`terminal-toolbar\` — 終端操作工具列
+- \`terminal-toolbar-menu\` — 終端工具列溢出選單和子選單
 - \`terminal-workspace-sidebar\` — Focus 模式終端列表
 - \`terminal-host-tree-sidebar\`
 - \`terminal-host-tree-sidebar-content\`
@@ -383,7 +384,8 @@ export const zhTWCoreMessages: Messages = {
 
 \`\`\`css
 [data-section="top-tabs-toolbar-actions"] button > svg,
-[data-section="terminal-toolbar"] button > svg {
+[data-section="terminal-toolbar"] button > svg,
+[data-section="terminal-toolbar-menu"] button > svg {
   width: 20px !important;
   height: 20px !important;
 }

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -1079,6 +1079,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
                 className="h-7 w-7 flex-shrink-0 app-no-drag self-end rounded-none"
                 style={{ color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
                 onClick={onOpenQuickSwitcher}
+                data-section="top-tabs-toolbar-actions"
               >
                 <MoreHorizontal size={14} />
               </Button>

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -1091,6 +1091,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
         <div
           className="flex-shrink-0 flex items-center gap-0.5 app-drag self-end h-7 overflow-visible"
           style={dragRegionStyle}
+          data-section="top-tabs-toolbar-actions"
         >
           <GlobalSftpTransferCenter />
           <Tooltip>

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -1071,21 +1071,22 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
 
         {/* More tabs button - only when overflowing */}
         {hasOverflow && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 flex-shrink-0 app-no-drag self-end rounded-none"
-                style={{ color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
-                onClick={onOpenQuickSwitcher}
-                data-section="top-tabs-toolbar-actions"
-              >
-                <MoreHorizontal size={14} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{t('topTabs.moreTabs')}</TooltipContent>
-          </Tooltip>
+          <div className="contents" data-section="top-tabs-toolbar-actions">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 flex-shrink-0 app-no-drag self-end rounded-none"
+                  style={{ color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
+                  onClick={onOpenQuickSwitcher}
+                >
+                  <MoreHorizontal size={14} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t('topTabs.moreTabs')}</TooltipContent>
+            </Tooltip>
+          </div>
         )}
 
         {/* Fixed right controls — utility icons + window controls share one h-7 row */}

--- a/components/customCssHooks.test.tsx
+++ b/components/customCssHooks.test.tsx
@@ -66,9 +66,15 @@ test("terminal host tree exposes stable custom CSS regions", () => {
 test("toolbars expose stable custom CSS regions for icon sizing", () => {
   const topTabsSource = readProjectFile("components/TopTabs.tsx");
   const terminalToolbarSource = readProjectFile("components/terminal/TerminalToolbar.tsx");
+  const overflowSection = topTabsSource.slice(
+    topTabsSource.indexOf('{hasOverflow && ('),
+    topTabsSource.indexOf('/* Fixed right controls'),
+  );
 
   assert.match(topTabsSource, /top-tabs-toolbar-actions/);
+  assert.match(overflowSection, /data-section="top-tabs-toolbar-actions"/);
   assert.match(terminalToolbarSource, /data-section="terminal-toolbar"/);
+  assert.match(terminalToolbarSource, /terminal-toolbar-menu/);
   assert.ok(
     terminalToolbarSource.indexOf('data-section="terminal-toolbar"')
       < terminalToolbarSource.indexOf('{pluginToolbarMenus.map'),
@@ -92,5 +98,6 @@ test("custom CSS help lists the expanded terminal and SFTP hooks", () => {
     "terminal-host-tree-sidebar-content",
     "top-tabs-toolbar-actions",
     "terminal-toolbar",
+    "terminal-toolbar-menu",
   ].forEach((hook) => assert.match(source, new RegExp(hook)));
 });

--- a/components/customCssHooks.test.tsx
+++ b/components/customCssHooks.test.tsx
@@ -63,6 +63,15 @@ test("terminal host tree exposes stable custom CSS regions", () => {
   assert.match(source, /terminal-host-tree-sidebar-content/);
 });
 
+test("toolbars expose stable custom CSS regions for icon sizing", () => {
+  const topTabsSource = readProjectFile("components/TopTabs.tsx");
+  const terminalToolbarSource = readProjectFile("components/terminal/TerminalToolbar.tsx");
+
+  assert.match(topTabsSource, /top-tabs-toolbar-actions/);
+  assert.match(terminalToolbarSource, /dataSection="terminal-toolbar"/);
+  assert.match(terminalToolbarSource, /data-section="terminal-toolbar"/);
+});
+
 test("custom CSS help lists the expanded terminal and SFTP hooks", () => {
   const source = readProjectFile("application/i18n/locales/zh-CN/core.ts");
 
@@ -74,5 +83,7 @@ test("custom CSS help lists the expanded terminal and SFTP hooks", () => {
     "terminal-sftp-tree-row",
     "terminal-sftp-transfer-queue",
     "terminal-host-tree-sidebar-content",
+    "top-tabs-toolbar-actions",
+    "terminal-toolbar",
   ].forEach((hook) => assert.match(source, new RegExp(hook)));
 });

--- a/components/customCssHooks.test.tsx
+++ b/components/customCssHooks.test.tsx
@@ -100,4 +100,5 @@ test("custom CSS help lists the expanded terminal and SFTP hooks", () => {
     "terminal-toolbar",
     "terminal-toolbar-menu",
   ].forEach((hook) => assert.match(source, new RegExp(hook)));
+  assert.match(source, /\[data-plugin-icon-kind="package"\]/);
 });

--- a/components/customCssHooks.test.tsx
+++ b/components/customCssHooks.test.tsx
@@ -66,6 +66,7 @@ test("terminal host tree exposes stable custom CSS regions", () => {
 test("toolbars expose stable custom CSS regions for icon sizing", () => {
   const topTabsSource = readProjectFile("components/TopTabs.tsx");
   const terminalToolbarSource = readProjectFile("components/terminal/TerminalToolbar.tsx");
+  const terminalViewSource = readProjectFile("components/terminal/TerminalView.tsx");
   const overflowSection = topTabsSource.slice(
     topTabsSource.indexOf('{hasOverflow && ('),
     topTabsSource.indexOf('/* Fixed right controls'),
@@ -75,6 +76,8 @@ test("toolbars expose stable custom CSS regions for icon sizing", () => {
   assert.match(overflowSection, /data-section="top-tabs-toolbar-actions"/);
   assert.match(terminalToolbarSource, /data-section="terminal-toolbar"/);
   assert.match(terminalToolbarSource, /terminal-toolbar-menu/);
+  assert.match(terminalViewSource, /data-section="terminal-toolbar"/);
+  assert.ok((terminalViewSource.match(/data-section="terminal-toolbar"/g) ?? []).length >= 2);
   assert.ok(
     terminalToolbarSource.indexOf('data-section="terminal-toolbar"')
       < terminalToolbarSource.indexOf('{pluginToolbarMenus.map'),

--- a/components/customCssHooks.test.tsx
+++ b/components/customCssHooks.test.tsx
@@ -68,8 +68,15 @@ test("toolbars expose stable custom CSS regions for icon sizing", () => {
   const terminalToolbarSource = readProjectFile("components/terminal/TerminalToolbar.tsx");
 
   assert.match(topTabsSource, /top-tabs-toolbar-actions/);
-  assert.match(terminalToolbarSource, /dataSection="terminal-toolbar"/);
   assert.match(terminalToolbarSource, /data-section="terminal-toolbar"/);
+  assert.ok(
+    terminalToolbarSource.indexOf('data-section="terminal-toolbar"')
+      < terminalToolbarSource.indexOf('{pluginToolbarMenus.map'),
+  );
+  assert.ok(
+    terminalToolbarSource.indexOf('{pluginToolbarMenus.map')
+      < terminalToolbarSource.lastIndexOf('</TooltipProvider>'),
+  );
 });
 
 test("custom CSS help lists the expanded terminal and SFTP hooks", () => {

--- a/components/terminal/TerminalToolbar.tsx
+++ b/components/terminal/TerminalToolbar.tsx
@@ -320,7 +320,8 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
 
   if (compactToolbar) {
     return (
-      <TooltipProvider delayDuration={500} skipDelayDuration={100} disableHoverableContent>
+      <div data-section="terminal-toolbar">
+        <TooltipProvider delayDuration={500} skipDelayDuration={100} disableHoverableContent>
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -385,7 +386,8 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
             />
           </PopoverContent>
         </Popover>
-      </TooltipProvider>
+        </TooltipProvider>
+      </div>
     );
   }
 
@@ -940,6 +942,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
         onReset={toolbarLayout.reset}
         t={t}
         className="inline-flex items-center min-h-6 min-w-6"
+        dataSection="terminal-toolbar"
       >
         {shown.map(renderInline)}
 

--- a/components/terminal/TerminalToolbar.tsx
+++ b/components/terminal/TerminalToolbar.tsx
@@ -320,7 +320,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
 
   if (compactToolbar) {
     return (
-      <div data-section="terminal-toolbar">
+      <div className="contents" data-section="terminal-toolbar">
         <TooltipProvider delayDuration={500} skipDelayDuration={100} disableHoverableContent>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -928,8 +928,9 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
   const hasCollapsed = collapsedNodes.length > 0;
 
   return (
-    <TooltipProvider delayDuration={500} skipDelayDuration={100} disableHoverableContent>
-      <ToolbarCustomizeContextMenu
+    <div className="contents" data-section="terminal-toolbar">
+      <TooltipProvider delayDuration={500} skipDelayDuration={100} disableHoverableContent>
+        <ToolbarCustomizeContextMenu
         items={customizeItems}
         placementOf={(id) => {
           const placement = toolbarLayout.layout.placement[id] ?? 'show';
@@ -942,7 +943,6 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
         onReset={toolbarLayout.reset}
         t={t}
         className="inline-flex items-center min-h-6 min-w-6"
-        dataSection="terminal-toolbar"
       >
         {shown.map(renderInline)}
 
@@ -988,9 +988,9 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
             </PopoverContent>
           </Popover>
         )}
-      </ToolbarCustomizeContextMenu>
+        </ToolbarCustomizeContextMenu>
 
-      {pluginToolbarMenus.map((menu) => (
+        {pluginToolbarMenus.map((menu) => (
         <Tooltip key={menu.id}>
           <TooltipTrigger asChild>
             <Button
@@ -1009,11 +1009,11 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
           </TooltipTrigger>
           <TooltipContent side="bottom">{menu.title}{menu.shortcut ? ` (${menu.shortcut})` : ''}</TooltipContent>
         </Tooltip>
-      ))}
+        ))}
 
-      {recordingIndicator}
+        {recordingIndicator}
 
-      {showClose && onClose && (
+        {showClose && onClose && (
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -1030,8 +1030,9 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
           </TooltipTrigger>
           <TooltipContent side="bottom">{t('terminal.toolbar.closeSession')}</TooltipContent>
         </Tooltip>
-      )}
-    </TooltipProvider>
+        )}
+      </TooltipProvider>
+    </div>
   );
 };
 

--- a/components/terminal/TerminalToolbar.tsx
+++ b/components/terminal/TerminalToolbar.tsx
@@ -409,6 +409,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
         </PopoverTrigger>
         <PopoverContent
           data-encoding-submenu="true"
+          data-section="terminal-toolbar-menu"
           className="w-40 p-1"
           side="right"
           align="start"
@@ -972,6 +973,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
               <TooltipContent side="bottom">{t('terminal.toolbar.more')}</TooltipContent>
             </Tooltip>
             <PopoverContent
+              data-section="terminal-toolbar-menu"
               className="w-48 p-1"
               align="end"
               onInteractOutside={(e) => {

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -661,7 +661,10 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
               const compactChromeClass =
                 "h-7 rounded-full border backdrop-blur-md";
               return (
-                <div className="absolute right-1 top-1 z-30 flex flex-row-reverse items-center pointer-events-none">
+                <div
+                  className="absolute right-1 top-1 z-30 flex flex-row-reverse items-center pointer-events-none"
+                  data-section="terminal-toolbar"
+                >
                   <Tooltip open={compactActionsOpen ? false : undefined}>
                     <TooltipTrigger asChild>
                       <button
@@ -729,6 +732,7 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
                     : "ml-auto w-fit rounded-bl-md px-1 pointer-events-auto",
                 )}
                 data-host-info-visible={showHostInfoBar ? "true" : "false"}
+                data-section="terminal-toolbar"
                 style={toolbarSurfaceStyle}
               >
                 {terminalActionsBody}


### PR DESCRIPTION
## Summary

Adds stable Custom CSS hooks for top-bar and terminal toolbar icons, so users can address the small menu/toolbar icons raised in #2294 without changing defaults.

## Type of Change

- [x] New feature
- [x] Documentation update

## Related Issue (optional)

Closes #2294

## Changes Made

- Add `top-tabs-toolbar-actions` and `terminal-toolbar` CSS hooks.
- Document a copyable Custom CSS rule for icon sizing in English, Simplified Chinese, and Traditional Chinese.
- Cover the hooks and documentation with the Custom CSS hook tests.

## Screenshots / Demo

The Appearance > Custom CSS guide now includes a rule that enlarges the scoped SVG icons to 20px.

## Testing

- [x] Linting passes (`npm run lint -- --quiet`)
- [x] Targeted tests pass (`node --test --import tsx components/customCssHooks.test.tsx components/TopTabs.test.ts components/terminal/TerminalToolbar.test.ts`)
- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Generated capability tool specs are updated when applicable (not applicable)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes