### PR TITLE
fix: auto-dismiss completed script overlays

### DIFF
--- a/application/state/scriptAutomationCoordinator.test.ts
+++ b/application/state/scriptAutomationCoordinator.test.ts
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  selectScriptOverlayRun,
   setScriptRuns,
   waitForScriptRun,
 } from './scriptAutomationCoordinator.ts';
+import type { ScriptRun } from '@/types/global/netcatty-bridge-script.d.ts';
 
 test('waitForScriptRun resolves when run is already completed on subscribe', async () => {
   const runId = 'run-already-done';
@@ -38,4 +40,27 @@ test('waitForScriptRun rejects when run already failed on subscribe', async () =
     () => waitForScriptRun(runId, { timeoutMs: 5000 }),
     /boom/,
   );
+});
+
+test('selectScriptOverlayRun does not resurface older completed runs after dismissal', () => {
+  const dismissedRunIds = new Set<string>();
+  const completed = (runId: string, endedAt: number): ScriptRun => ({
+    runId,
+    sessionId: 'sess1',
+    status: 'completed',
+    startedAt: endedAt - 100,
+    endedAt,
+    logs: [],
+  });
+  const olderRun = completed('older-run', 1_000);
+  const latestRun = completed('latest-run', 2_000);
+
+  assert.equal(
+    selectScriptOverlayRun([olderRun, latestRun], 'sess1', dismissedRunIds)?.runId,
+    latestRun.runId,
+  );
+  assert.ok(dismissedRunIds.has(olderRun.runId));
+
+  dismissedRunIds.add(latestRun.runId);
+  assert.equal(selectScriptOverlayRun([olderRun, latestRun], 'sess1', dismissedRunIds), undefined);
 });

--- a/application/state/scriptAutomationCoordinator.ts
+++ b/application/state/scriptAutomationCoordinator.ts
@@ -32,6 +32,43 @@ export function setScriptRuns(nextRuns: ScriptRun[]) {
   runsListeners.forEach((listener) => listener(runs));
 }
 
+/**
+ * Chooses the single overlay worth showing while retaining dismissed history
+ * so global run broadcasts cannot bring old completion banners back.
+ */
+export function selectScriptOverlayRun(
+  allRuns: ScriptRun[],
+  sessionId: string,
+  dismissedRunIds: Set<string>,
+): ScriptRun | undefined {
+  const sessionRuns = allRuns.filter((run) => run.sessionId === sessionId);
+  const activeRunIds = new Set(sessionRuns.map((run) => run.runId));
+  for (const runId of dismissedRunIds) {
+    if (!activeRunIds.has(runId)) dismissedRunIds.delete(runId);
+  }
+
+  const liveRun = sessionRuns.find((run) => run.status === 'running' || run.status === 'paused');
+  if (liveRun) {
+    for (const run of sessionRuns) {
+      if (run.status === 'completed' || run.status === 'failed') {
+        dismissedRunIds.add(run.runId);
+      }
+    }
+    return liveRun;
+  }
+
+  const finishedRuns = sessionRuns
+    .filter((run) => run.status === 'completed' || run.status === 'failed')
+    .sort((a, b) => (b.endedAt ?? 0) - (a.endedAt ?? 0));
+  const latestRun = finishedRuns.find((run) => !dismissedRunIds.has(run.runId));
+  if (!latestRun) return undefined;
+
+  for (const run of finishedRuns) {
+    if (run.runId !== latestRun.runId) dismissedRunIds.add(run.runId);
+  }
+  return latestRun;
+}
+
 export function getActiveScriptRunForSession(sessionId: string): ScriptRun | undefined {
   return runs.find((run) =>
     run.sessionId === sessionId && (run.status === 'running' || run.status === 'paused'),

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -102,6 +102,7 @@ import { getScriptRecordingSnapshot, setScriptRecordingState } from "@/applicati
 import {
   runAutomationScript,
   runConnectScriptsSequential,
+  selectScriptOverlayRun,
   subscribeScriptRuns,
   pauseScriptRun,
   resumeScriptRun,
@@ -371,32 +372,17 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   ), [sessionId]);
   const sensitivePromptOutputTailRef = useRef("");
   const [activeScriptRun, setActiveScriptRun] = useState<import('@/types/global/netcatty-bridge-script.d.ts').ScriptRun | undefined>(undefined);
-  const dismissedScriptRunIdRef = useRef<string | null>(null);
+  const dismissedScriptRunIdsRef = useRef(new Set<string>());
 
   useEffect(() => {
     return subscribeScriptRuns((runs) => {
-      const sessionRuns = runs.filter((run) => run.sessionId === sessionId);
-      const liveRun = sessionRuns.find((run) => run.status === 'running' || run.status === 'paused');
-      if (liveRun) {
-        dismissedScriptRunIdRef.current = null;
-        setActiveScriptRun(liveRun);
-        return;
-      }
-
-      const finishedRun = sessionRuns
-        .filter((run) =>
-          (run.status === 'completed' || run.status === 'failed')
-          && run.runId !== dismissedScriptRunIdRef.current,
-        )
-        .sort((a, b) => (b.endedAt ?? 0) - (a.endedAt ?? 0))[0];
-
-      setActiveScriptRun(finishedRun);
+      setActiveScriptRun(selectScriptOverlayRun(runs, sessionId, dismissedScriptRunIdsRef.current));
     });
   }, [sessionId]);
 
   const dismissScriptOverlay = useCallback(() => {
     if (activeScriptRun) {
-      dismissedScriptRunIdRef.current = activeScriptRun.runId;
+      dismissedScriptRunIdsRef.current.add(activeScriptRun.runId);
     }
     setActiveScriptRun(undefined);
   }, [activeScriptRun]);

--- a/components/terminal/ScriptExecutionOverlay.test.ts
+++ b/components/terminal/ScriptExecutionOverlay.test.ts
@@ -1,12 +1,26 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import test from "node:test";
+import { mock, test } from "node:test";
 import { fileURLToPath } from "node:url";
+import React from "react";
+import { act, create } from "react-test-renderer";
 
 import {
   SCRIPT_OVERLAY_TOP_COMPACT_PX,
   SCRIPT_OVERLAY_TOP_DEFAULT_PX,
+  SCRIPT_OVERLAY_FINISHED_DISMISS_DELAY_MS,
+  ScriptExecutionOverlay,
 } from "./ScriptExecutionOverlay.tsx";
+import type { ScriptRun } from "@/types/global/netcatty-bridge-script.d.ts";
+
+const completedRun: ScriptRun = {
+  runId: "completed-run",
+  sessionId: "session-1",
+  status: "completed",
+  startedAt: 0,
+  endedAt: 1_000,
+  logs: [],
+};
 
 test("script overlay sits lower under the full host toolbar than under compact chrome", () => {
   assert.equal(SCRIPT_OVERLAY_TOP_DEFAULT_PX, 34);
@@ -33,4 +47,31 @@ test("script overlay covers compact speed-dial full-width instead of reserving a
     terminalSource,
     /compactTopChrome=\{terminalSettings\?\.showHostInfoBar === false\}/,
   );
+});
+
+test("script overlay dismisses a completed run after five seconds", () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  let dismissCount = 0;
+
+  try {
+    act(() => {
+      create(
+        React.createElement(ScriptExecutionOverlay, {
+          run: completedRun,
+          onPause: () => {},
+          onResume: () => {},
+          onStop: () => {},
+          onDismiss: () => { dismissCount += 1; },
+        }),
+      );
+    });
+
+    mock.timers.tick(SCRIPT_OVERLAY_FINISHED_DISMISS_DELAY_MS - 1);
+    assert.equal(dismissCount, 0);
+
+    mock.timers.tick(1);
+    assert.equal(dismissCount, 1);
+  } finally {
+    mock.timers.reset();
+  }
 });

--- a/components/terminal/ScriptExecutionOverlay.test.ts
+++ b/components/terminal/ScriptExecutionOverlay.test.ts
@@ -52,26 +52,36 @@ test("script overlay covers compact speed-dial full-width instead of reserving a
 test("script overlay dismisses a completed run after five seconds", () => {
   mock.timers.enable({ apis: ["setTimeout"] });
   let dismissCount = 0;
+  let renderer: ReturnType<typeof create> | undefined;
+
+  const renderOverlay = (onDismiss: () => void) => React.createElement(ScriptExecutionOverlay, {
+    run: completedRun,
+    onPause: () => {},
+    onResume: () => {},
+    onStop: () => {},
+    onDismiss,
+  });
 
   try {
     act(() => {
-      create(
-        React.createElement(ScriptExecutionOverlay, {
-          run: completedRun,
-          onPause: () => {},
-          onResume: () => {},
-          onStop: () => {},
-          onDismiss: () => { dismissCount += 1; },
-        }),
-      );
+      renderer = create(renderOverlay(() => { dismissCount += 1; }));
     });
 
-    mock.timers.tick(SCRIPT_OVERLAY_FINISHED_DISMISS_DELAY_MS - 1);
+    mock.timers.tick(SCRIPT_OVERLAY_FINISHED_DISMISS_DELAY_MS - 1_000);
+    assert.equal(dismissCount, 0);
+
+    // Script run broadcasts replace the callback without changing this run.
+    act(() => {
+      renderer?.update(renderOverlay(() => { dismissCount += 1; }));
+    });
+
+    mock.timers.tick(999);
     assert.equal(dismissCount, 0);
 
     mock.timers.tick(1);
     assert.equal(dismissCount, 1);
   } finally {
+    renderer?.unmount();
     mock.timers.reset();
   }
 });

--- a/components/terminal/ScriptExecutionOverlay.tsx
+++ b/components/terminal/ScriptExecutionOverlay.tsx
@@ -22,6 +22,8 @@ export interface ScriptExecutionOverlayProps {
 export const SCRIPT_OVERLAY_TOP_DEFAULT_PX = 34;
 /** Top offset when only the compact speed-dial is present. */
 export const SCRIPT_OVERLAY_TOP_COMPACT_PX = 8;
+/** Completed script results remain visible briefly before dismissing themselves. */
+export const SCRIPT_OVERLAY_FINISHED_DISMISS_DELAY_MS = 5_000;
 
 function formatElapsed(ms: number) {
   const seconds = Math.max(0, Math.floor(ms / 1000));
@@ -206,6 +208,12 @@ export const ScriptExecutionOverlay: React.FC<ScriptExecutionOverlayProps> = ({
     const timer = window.setInterval(() => setTick((value) => value + 1), 1000);
     return () => window.clearInterval(timer);
   }, [isFinished, run.runId]);
+
+  useEffect(() => {
+    if (!isFinished) return undefined;
+    const timer = setTimeout(onDismiss, SCRIPT_OVERLAY_FINISHED_DISMISS_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [isFinished, onDismiss, run.runId]);
 
   void tick;
 

--- a/components/terminal/ScriptExecutionOverlay.tsx
+++ b/components/terminal/ScriptExecutionOverlay.tsx
@@ -1,5 +1,5 @@
 import { Check, Loader2, Pause, Play, Square, X } from 'lucide-react';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useEffectEvent, useMemo, useState } from 'react';
 import { useI18n } from '@/application/i18n/I18nProvider';
 import type { ScriptRun } from '@/types/global/netcatty-bridge-script.d.ts';
 import { Button } from '@/components/ui/button';
@@ -202,6 +202,7 @@ export const ScriptExecutionOverlay: React.FC<ScriptExecutionOverlayProps> = ({
   const { t } = useI18n();
   const [tick, setTick] = useState(0);
   const isFinished = run.status === 'completed' || run.status === 'failed';
+  const dismissFinishedRun = useEffectEvent(onDismiss);
 
   useEffect(() => {
     if (isFinished) return undefined;
@@ -211,9 +212,9 @@ export const ScriptExecutionOverlay: React.FC<ScriptExecutionOverlayProps> = ({
 
   useEffect(() => {
     if (!isFinished) return undefined;
-    const timer = setTimeout(onDismiss, SCRIPT_OVERLAY_FINISHED_DISMISS_DELAY_MS);
+    const timer = setTimeout(dismissFinishedRun, SCRIPT_OVERLAY_FINISHED_DISMISS_DELAY_MS);
     return () => clearTimeout(timer);
-  }, [isFinished, onDismiss, run.runId]);
+  }, [isFinished, run.runId]);
 
   void tick;
 


### PR DESCRIPTION
## Summary

Dismiss completed or failed script execution overlays five seconds after completion so they no longer obscure the terminal input.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2614

## Changes Made

- Schedule a cancellable five-second dismissal for completed and failed script runs.
- Add a timer-driven regression test that verifies the overlay remains visible through 4,999ms and closes at 5,000ms.

## Screenshots / Demo

Completed script overlays now disappear automatically after five seconds.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npx eslint components/terminal/ScriptExecutionOverlay.tsx components/terminal/ScriptExecutionOverlay.test.ts`)
- [x] Tests pass (`node --test --import tsx components/terminal/ScriptExecutionOverlay.test.ts`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)