### PR TITLE
fix(ui): use Terminal icon for new local terminal button

### DIFF
--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -1,4 +1,4 @@
-import { Folder, FolderLock, Menu, MoreHorizontal, Plus, Settings, Sparkles, SquareTerminal } from 'lucide-react';
+import { Folder, FolderLock, Menu, MoreHorizontal, Plus, Settings, Sparkles, Terminal } from 'lucide-react';
 import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { fromEditorTabId, isEditorTabId, useActiveTabId } from '../application/state/activeTabStore';
 import { isHostTreeWorkTabSurface } from '../application/app/workTabSurface';
@@ -1110,7 +1110,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
                 style={{ color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
                 onClick={onCreateLocalTerminal}
               >
-                <SquareTerminal size={16} />
+                <Terminal size={16} />
               </Button>
             </TooltipTrigger>
             <TooltipContent>{t('topTabs.newLocalTerminal')}</TooltipContent>


### PR DESCRIPTION
## Summary

Replace the top-tabs **New Local Terminal** icon from `SquareTerminal` (boxed `>_`) with Lucide `Terminal` (plain `>_` without the square frame).

## Type of Change

- [x] Other (please describe): UI polish / icon tweak

## Related Issue (optional)

N/A

## Changes Made

- `components/TopTabs.tsx`: swap `SquareTerminal` → `Terminal` for the new local terminal toolbar button

## Screenshots / Demo

Before: square-framed terminal glyph in top-right utility row  
After: simple terminal prompt glyph without the square border

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Icon-only swap; no logic changes.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)