### PR TITLE
perf(ai): defer heavy side-panel UI while hidden and streaming

### DIFF
--- a/components/AIChatSidePanel.mountRetention.test.ts
+++ b/components/AIChatSidePanel.mountRetention.test.ts
@@ -183,6 +183,40 @@ test('AI side panel re-renders when retained content becomes visible again', () 
   ), false);
 });
 
+test('hidden retained AI side panel skips chat input and message content', () => {
+  const markup = renderToStaticMarkup(
+    React.createElement(
+      I18nProvider,
+      { locale: 'en' },
+      React.createElement(
+        TooltipProvider,
+        null,
+        React.createElement(AIChatSidePanel, baseProps({
+          isVisible: false,
+          activeSessionIdMap: { 'terminal:terminal-1': 'session-1' },
+          sessions: [
+            session({
+              messages: [
+                { id: 'm1', role: 'user', content: 'hidden-user-message', timestamp: 1 },
+                { id: 'm2', role: 'assistant', content: 'hidden-assistant-message', timestamp: 2 },
+              ],
+            }),
+          ],
+          draftsByScope: {
+            'terminal:terminal-1': draft({ text: 'draft still retained' }),
+          },
+        })),
+      ),
+    ),
+  );
+
+  assert.match(markup, /data-section="ai-chat-panel-retained"/);
+  assert.doesNotMatch(markup, /textarea/);
+  assert.doesNotMatch(markup, /hidden-user-message/);
+  assert.doesNotMatch(markup, /hidden-assistant-message/);
+  assert.doesNotMatch(markup, /draft still retained/);
+});
+
 test('AI side panel re-renders when command timeout changes', () => {
   const props = baseProps({
     isVisible: true,

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -1313,6 +1313,41 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     setShowHistory(false);
   }, [ensureScopeDraft, showScopeDraftView, updateScopeDraft]);
 
+  // Warm the Streamdown/markdown chunk while the panel is visible but idle, so
+  // the first completed assistant reply does not pay the full parse cost mid-interaction.
+  useEffect(() => {
+    if (!isVisible) return;
+    let cancelled = false;
+    const loadMarkdown = () => {
+      if (cancelled) return;
+      void import('./ai-elements/messageResponse');
+    };
+    if (typeof requestIdleCallback === 'function') {
+      const idleId = requestIdleCallback(loadMarkdown, { timeout: 2500 });
+      return () => {
+        cancelled = true;
+        cancelIdleCallback(idleId);
+      };
+    }
+    const timeoutId = window.setTimeout(loadMarkdown, 0);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, [isVisible]);
+
+  // Keep streaming/session hooks alive for retained hidden panels, but do not
+  // mount ChatMessageList / Streamdown / ChatInput while CSS-hidden — those trees
+  // are the main tab-switch and cross-tab re-render cost.
+  if (!isVisible) {
+    return (
+      <div
+        className="h-full min-h-0 bg-background"
+        data-section="ai-chat-panel-retained"
+        aria-hidden="true"
+      />
+    );
+  }
 
   return (
     <React.Profiler {...getAIPanelProfilerProps('AIChatSidePanel.Active')}>

--- a/components/ai-elements/LazyMessageResponse.tsx
+++ b/components/ai-elements/LazyMessageResponse.tsx
@@ -10,7 +10,7 @@ type LazyMessageResponseProps = {
 };
 
 const MessageResponse = lazy(() =>
-  import('./message').then((module) => ({ default: module.MessageResponse })),
+  import('./messageResponse').then((module) => ({ default: module.MessageResponse })),
 );
 
 const PlainTextFallback = ({ children, className }: LazyMessageResponseProps) => (

--- a/components/ai-elements/message.tsx
+++ b/components/ai-elements/message.tsx
@@ -1,85 +1,11 @@
-import { cn } from '../../lib/utils';
-import { cjk } from '@streamdown/cjk';
-import { code } from '@streamdown/code';
-import type { ComponentProps, HTMLAttributes } from 'react';
-import { memo } from 'react';
-import { Streamdown } from 'streamdown';
-import { createSafeCodeHighlighter } from './streamdownCodeHighlighter';
-
-export type MessageProps = HTMLAttributes<HTMLDivElement> & {
-  from: 'user' | 'assistant' | 'system' | 'tool';
-};
-
-// Public CSS hooks for user customization (Settings → Appearance → Custom CSS):
-//   .ai-chat-message[data-role="user"]      — outer row, user-authored
-//   .ai-chat-message[data-role="assistant"] — outer row, assistant reply
-//   .ai-chat-message-content[data-role=...] — inner bubble / content area
-// These attributes are part of the UI's stable contract; do not rename
-// without updating Custom CSS docs.
-export const Message = ({ className, from, ...props }: MessageProps) => (
-  <div
-    className={cn(
-      'ai-chat-message group flex w-full max-w-[95%] flex-col gap-1.5',
-      from === 'user' ? 'is-user ml-auto' : 'is-assistant',
-      className,
-    )}
-    data-role={from}
-    {...props}
-  />
-);
-
-export type MessageContentProps = HTMLAttributes<HTMLDivElement> & {
-  from?: 'user' | 'assistant' | 'system' | 'tool';
-};
-
-export const MessageContent = ({ children, className, from, ...props }: MessageContentProps) => (
-  <div
-    className={cn(
-      'ai-chat-message-content flex w-fit min-w-0 max-w-full flex-col gap-1.5 text-[13px] leading-relaxed',
-      'group-[.is-user]:ml-auto group-[.is-user]:overflow-hidden group-[.is-user]:rounded-lg group-[.is-user]:border group-[.is-user]:border-border/50 group-[.is-user]:bg-muted/50 group-[.is-user]:px-2.5 group-[.is-user]:py-[7px]',
-      'group-[.is-assistant]:w-full group-[.is-assistant]:text-foreground/90',
-      className,
-    )}
-    data-role={from}
-    {...props}
-  >
-    {children}
-  </div>
-);
-
-const safeCode = createSafeCodeHighlighter(code);
-const streamdownPlugins = { cjk, code: safeCode };
-
-export type MessageResponseProps = ComponentProps<typeof Streamdown>;
-
-export const MessageResponse = memo(
-  ({ className, ...props }: MessageResponseProps) => (
-    <Streamdown
-      className={cn(
-        'size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0',
-        // Style the rendered markdown
-        // Code: base styles (code-block overrides are in index.css)
-        '[&_code]:text-[12px] [&_code]:font-mono',
-        '[&_p_code]:px-[0.4em] [&_p_code]:py-[0.15em] [&_p_code]:rounded [&_p_code]:bg-foreground/[0.06] [&_p_code]:text-[85%] [&_p_code]:whitespace-normal [&_p_code]:[overflow-wrap:anywhere]',
-        '[&_p]:my-1.5',
-        '[&_ul]:my-1.5 [&_ul]:pl-4 [&_ul]:list-disc',
-        '[&_ol]:my-1.5 [&_ol]:pl-4 [&_ol]:list-decimal',
-        '[&_li]:my-0.5',
-        '[&_h1]:text-base [&_h1]:font-semibold [&_h1]:mt-4 [&_h1]:mb-2',
-        '[&_h2]:text-sm [&_h2]:font-semibold [&_h2]:mt-3 [&_h2]:mb-1.5',
-        '[&_h3]:text-sm [&_h3]:font-medium [&_h3]:mt-2 [&_h3]:mb-1',
-        '[&_blockquote]:border-l-2 [&_blockquote]:border-border/50 [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground',
-        '[&_a]:text-primary [&_a]:underline',
-        '[&_hr]:border-border/30 [&_hr]:my-3',
-        '[&_table]:text-[12px] [&_th]:px-2 [&_th]:py-1 [&_th]:border [&_th]:border-border/30 [&_th]:bg-muted/20 [&_td]:px-2 [&_td]:py-1 [&_td]:border [&_td]:border-border/30',
-        className,
-      )}
-      plugins={streamdownPlugins}
-      {...props}
-    />
-  ),
-  (prevProps, nextProps) =>
-    prevProps.children === nextProps.children &&
-    nextProps.isAnimating === prevProps.isAnimating,
-);
-MessageResponse.displayName = 'MessageResponse';
+/** Barrel re-export. Prefer messageShell (layout) or LazyMessageResponse (markdown). */
+export {
+  Message,
+  MessageContent,
+  type MessageContentProps,
+  type MessageProps,
+} from './messageShell';
+export {
+  MessageResponse,
+  type MessageResponseProps,
+} from './messageResponse';

--- a/components/ai-elements/messageResponse.tsx
+++ b/components/ai-elements/messageResponse.tsx
@@ -1,0 +1,45 @@
+import { cn } from '../../lib/utils';
+import { cjk } from '@streamdown/cjk';
+import { code } from '@streamdown/code';
+import type { ComponentProps } from 'react';
+import { memo } from 'react';
+import { Streamdown } from 'streamdown';
+import { createSafeCodeHighlighter } from './streamdownCodeHighlighter';
+
+const safeCode = createSafeCodeHighlighter(code);
+const streamdownPlugins = { cjk, code: safeCode };
+
+export type MessageResponseProps = ComponentProps<typeof Streamdown>;
+
+/** Heavy markdown renderer — load via LazyMessageResponse, not the chat list critical path. */
+export const MessageResponse = memo(
+  ({ className, ...props }: MessageResponseProps) => (
+    <Streamdown
+      className={cn(
+        'size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0',
+        // Style the rendered markdown
+        // Code: base styles (code-block overrides are in index.css)
+        '[&_code]:text-[12px] [&_code]:font-mono',
+        '[&_p_code]:px-[0.4em] [&_p_code]:py-[0.15em] [&_p_code]:rounded [&_p_code]:bg-foreground/[0.06] [&_p_code]:text-[85%] [&_p_code]:whitespace-normal [&_p_code]:[overflow-wrap:anywhere]',
+        '[&_p]:my-1.5',
+        '[&_ul]:my-1.5 [&_ul]:pl-4 [&_ul]:list-disc',
+        '[&_ol]:my-1.5 [&_ol]:pl-4 [&_ol]:list-decimal',
+        '[&_li]:my-0.5',
+        '[&_h1]:text-base [&_h1]:font-semibold [&_h1]:mt-4 [&_h1]:mb-2',
+        '[&_h2]:text-sm [&_h2]:font-semibold [&_h2]:mt-3 [&_h2]:mb-1.5',
+        '[&_h3]:text-sm [&_h3]:font-medium [&_h3]:mt-2 [&_h3]:mb-1',
+        '[&_blockquote]:border-l-2 [&_blockquote]:border-border/50 [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground',
+        '[&_a]:text-primary [&_a]:underline',
+        '[&_hr]:border-border/30 [&_hr]:my-3',
+        '[&_table]:text-[12px] [&_th]:px-2 [&_th]:py-1 [&_th]:border [&_th]:border-border/30 [&_th]:bg-muted/20 [&_td]:px-2 [&_td]:py-1 [&_td]:border [&_td]:border-border/30',
+        className,
+      )}
+      plugins={streamdownPlugins}
+      {...props}
+    />
+  ),
+  (prevProps, nextProps) =>
+    prevProps.children === nextProps.children &&
+    nextProps.isAnimating === prevProps.isAnimating,
+);
+MessageResponse.displayName = 'MessageResponse';

--- a/components/ai-elements/messageShell.tsx
+++ b/components/ai-elements/messageShell.tsx
@@ -1,0 +1,43 @@
+import { cn } from '../../lib/utils';
+import type { HTMLAttributes } from 'react';
+
+export type MessageProps = HTMLAttributes<HTMLDivElement> & {
+  from: 'user' | 'assistant' | 'system' | 'tool';
+};
+
+// Public CSS hooks for user customization (Settings → Appearance → Custom CSS):
+//   .ai-chat-message[data-role="user"]      — outer row, user-authored
+//   .ai-chat-message[data-role="assistant"] — outer row, assistant reply
+//   .ai-chat-message-content[data-role=...] — inner bubble / content area
+// These attributes are part of the UI's stable contract; do not rename
+// without updating Custom CSS docs.
+export const Message = ({ className, from, ...props }: MessageProps) => (
+  <div
+    className={cn(
+      'ai-chat-message group flex w-full max-w-[95%] flex-col gap-1.5',
+      from === 'user' ? 'is-user ml-auto' : 'is-assistant',
+      className,
+    )}
+    data-role={from}
+    {...props}
+  />
+);
+
+export type MessageContentProps = HTMLAttributes<HTMLDivElement> & {
+  from?: 'user' | 'assistant' | 'system' | 'tool';
+};
+
+export const MessageContent = ({ children, className, from, ...props }: MessageContentProps) => (
+  <div
+    className={cn(
+      'ai-chat-message-content flex w-fit min-w-0 max-w-full flex-col gap-1.5 text-[13px] leading-relaxed',
+      'group-[.is-user]:ml-auto group-[.is-user]:overflow-hidden group-[.is-user]:rounded-lg group-[.is-user]:border group-[.is-user]:border-border/50 group-[.is-user]:bg-muted/50 group-[.is-user]:px-2.5 group-[.is-user]:py-[7px]',
+      'group-[.is-assistant]:w-full group-[.is-assistant]:text-foreground/90',
+      className,
+    )}
+    data-role={from}
+    {...props}
+  >
+    {children}
+  </div>
+);

--- a/components/ai/ChatMessageList.test.tsx
+++ b/components/ai/ChatMessageList.test.tsx
@@ -10,6 +10,7 @@ import ChatMessageList, {
   buildCodexApprovalRenderPlan,
   pruneResolvedApprovals,
   shouldProvideVaultArtifactNavigation,
+  shouldRenderAssistantAsPlainText,
 } from "./ChatMessageList.tsx";
 import { TooltipProvider } from "../ui/tooltip.tsx";
 
@@ -34,6 +35,79 @@ test("resolved approval state retains only tool calls still present in messages"
 
   const next = pruneResolvedApprovals(previous, messages);
   assert.deepEqual([...next], [["live-call", false]]);
+});
+
+test("assistant content stays plain while streaming or when markdown is hidden", () => {
+  assert.equal(shouldRenderAssistantAsPlainText({
+    hideMarkdown: false,
+    isStreamingMessage: true,
+  }), true);
+  assert.equal(shouldRenderAssistantAsPlainText({
+    hideMarkdown: true,
+    isStreamingMessage: false,
+  }), true);
+  assert.equal(shouldRenderAssistantAsPlainText({
+    hideMarkdown: false,
+    isStreamingMessage: false,
+  }), false);
+});
+
+test("ChatMessageList uses plain text for the streaming assistant message", () => {
+  const messages: ChatMessage[] = [
+    {
+      id: "user-1",
+      role: "user",
+      content: "hello",
+      timestamp: 1,
+    },
+    {
+      id: "assistant-1",
+      role: "assistant",
+      content: "streaming-body",
+      timestamp: 2,
+    },
+  ];
+
+  const markup = renderToStaticMarkup(
+    React.createElement(
+      I18nProvider,
+      { locale: "en" },
+      React.createElement(
+        TooltipProvider,
+        null,
+        React.createElement(ChatMessageList, { messages, isStreaming: true }),
+      ),
+    ),
+  );
+
+  assert.match(markup, /data-ai-content="plain"/);
+  assert.match(markup, /streaming-body/);
+  assert.doesNotMatch(markup, /data-ai-content="markdown"/);
+});
+
+test("ChatMessageList hydrates markdown after streaming settles", () => {
+  const messages: ChatMessage[] = [{
+    id: "assistant-1",
+    role: "assistant",
+    content: "settled-body",
+    timestamp: 1,
+  }];
+
+  const markup = renderToStaticMarkup(
+    React.createElement(
+      I18nProvider,
+      { locale: "en" },
+      React.createElement(
+        TooltipProvider,
+        null,
+        React.createElement(ChatMessageList, { messages, isStreaming: false }),
+      ),
+    ),
+  );
+
+  assert.match(markup, /data-ai-content="markdown"/);
+  assert.match(markup, /settled-body/);
+  assert.doesNotMatch(markup, /data-ai-content="plain"/);
 });
 
 test("ChatMessageList only renders the recent message batch by default", () => {

--- a/components/ai/ChatMessageList.tsx
+++ b/components/ai/ChatMessageList.tsx
@@ -16,7 +16,8 @@ import {
   ConversationContent,
   ConversationScrollButton,
 } from '../ai-elements/conversation';
-import { Message, MessageContent, MessageResponse } from '../ai-elements/message';
+import { LazyMessageResponse } from '../ai-elements/LazyMessageResponse';
+import { Message, MessageContent } from '../ai-elements/messageShell';
 import { ToolCall } from '../ai-elements/tool-call';
 import ThinkingBlock from './ThinkingBlock';
 import AgentActivityGroup from './AgentActivityGroup';
@@ -103,6 +104,20 @@ export function shouldProvideVaultArtifactNavigation({
 }: VaultArtifactNavigationCallbackOptions): boolean {
   return Boolean(onOpenVaultNote || onOpenVaultHost || onOpenVaultSnippet || onOpenVaultSection);
 }
+
+/**
+ * Streamdown + shiki re-parse is too expensive for per-frame streaming updates.
+ * Use plain text while the assistant message is still animating; hydrate markdown
+ * once the turn settles.
+ */
+export function shouldRenderAssistantAsPlainText(options: {
+  hideMarkdown: boolean;
+  isStreamingMessage: boolean;
+}): boolean {
+  return options.hideMarkdown || options.isStreamingMessage;
+}
+
+const ASSISTANT_PLAIN_TEXT_CLASS = 'whitespace-pre-wrap break-words text-[13px] leading-[1.45]';
 
 export interface CodexApprovalRenderEntry {
   approvalId: string;
@@ -637,14 +652,26 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
 
                 {message.content && (
                   isUser
-                    ? <div className="whitespace-pre-wrap break-words text-[13px] leading-[1.45]">{message.content}</div>
-                    : hideMarkdown
-                      ? <div className="whitespace-pre-wrap break-words text-[13px] leading-[1.45]">{message.content}</div>
+                    ? <div className={ASSISTANT_PLAIN_TEXT_CLASS}>{message.content}</div>
+                    : shouldRenderAssistantAsPlainText({
+                        hideMarkdown,
+                        isStreamingMessage: !!isThisStreaming,
+                      })
+                      ? (
+                          <div
+                            className={ASSISTANT_PLAIN_TEXT_CLASS}
+                            data-ai-content="plain"
+                          >
+                            {message.content}
+                          </div>
+                        )
                       : (
                           <React.Profiler {...getAIPanelProfilerProps('AIChatPanel.Markdown')}>
-                            <MessageResponse isAnimating={isThisStreaming}>
-                              {message.content}
-                            </MessageResponse>
+                            <div data-ai-content="markdown">
+                              <LazyMessageResponse>
+                                {message.content}
+                              </LazyMessageResponse>
+                            </div>
                           </React.Profiler>
                         )
                 )}


### PR DESCRIPTION
## Summary

AI side panel open/jank and tab-switch lag while the panel is retained come largely from mounting Streamdown/ChatInput trees for CSS-hidden panels and re-parsing markdown on every stream frame.

This PR applies the P0 mitigations:

- **Hidden retained panels** keep session/stream hooks alive but render only a light shell (`ai-chat-panel-retained`) — no `ChatMessageList` / `ChatInput` / Streamdown while not visible.
- **Streaming assistant text** stays plain (`data-ai-content="plain"`); markdown hydrates after the turn settles via `LazyMessageResponse`.
- **Split message modules**: layout shell vs Streamdown response chunk so opening the panel no longer eagerly pulls streamdown/shiki on the critical path; warm the markdown chunk on idle while visible.

## Type of Change

- [x] Other (please describe): performance improvement for AI side panel

## Related Issue (optional)

N/A

## Changes Made

- `AIChatSidePanel`: early light return when `!isVisible`; idle prefetch of `messageResponse`
- `ChatMessageList`: plain text while streaming; lazy markdown after settle; layout import from `messageShell`
- Split `messageShell.tsx` / `messageResponse.tsx` (barrel `message.tsx` unchanged for re-exports)
- Tests for retained hidden shell, plain streaming, and settled markdown hydration

## Screenshots / Demo

N/A — performance path. Local check: open AI panel, stream a long reply, switch terminal tabs with retained chat history; UI should stay more responsive.

## Testing

- [x] Targeted tests: `node --test --import tsx components/AIChatSidePanel.mountRetention.test.ts components/ai/ChatMessageList.test.tsx components/ai/aiPanelDiagnostics.test.ts`
- [x] Lint on touched files
- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Full `npm test` / `npm run lint` suite

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation (tests only)
- [x] I have not introduced any breaking changes (or I have described them above)

## Follow-ups (not in this PR)

- Session store selectors so streaming updates only the active panel
- Worker/idle Shiki highlighting for large completed code blocks