### PR TITLE
perf(terminal): cut TerminalLayer re-renders from history, cwd, and title churn

### DIFF
--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -129,6 +129,23 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
     handleCreateLocalTerminal();
   }, [handleCreateLocalTerminal]);
 
+  const handleTerminalCommandExecuted = useCallback((
+    command: string,
+    hostId: string,
+    hostLabel: string,
+    sessionId: string,
+  ) => {
+    addShellHistoryEntry({ command, hostId, hostLabel, sessionId });
+  }, [addShellHistoryEntry]);
+
+  const handleUpdateTerminalFontWeight = useCallback((weight: number) => {
+    updateTerminalSetting('fontWeight', weight);
+  }, [updateTerminalSetting]);
+
+  const handleRequestAddToWorkspace = useCallback((workspaceId: string) => {
+    setAddToWorkspaceDialog({ mode: 'append', workspaceId });
+  }, [setAddToWorkspaceDialog]);
+
   const appThemeStyle = useMemo(() => {
     const tokens = getUiThemeById(
       resolvedTheme,
@@ -465,22 +482,17 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
           onUpdateSessionDynamicTitle={updateSessionDynamicTitle}
           onUpdateSessionCodingCliProvider={updateSessionCodingCliProvider}
           onClearSessionFontSizeOverride={clearSessionFontSizeOverride}
-          onUpdateTerminalFontWeight={(w) => updateTerminalSetting('fontWeight', w)}
+          onUpdateTerminalFontWeight={handleUpdateTerminalFontWeight}
           onCloseSession={closeSession}
           onUpdateSessionStatus={handleSessionStatusChange}
           onUpdateHostDistro={updateHostDistro}
           onUpdateHost={handleUpdateHostFromTerminal}
           onAddKnownHost={handleAddKnownHost}
-          onCommandExecuted={(command, hostId, hostLabel, sessionId) => {
-            addShellHistoryEntry({ command, hostId, hostLabel, sessionId });
-          }}
-          shellHistory={shellHistory}
+          onCommandExecuted={handleTerminalCommandExecuted}
           onTerminalDataCapture={handleTerminalDataCapture}
           onCreateWorkspaceFromSessions={createWorkspaceFromSessions}
           onAddSessionToWorkspace={addSessionToWorkspace}
-          onRequestAddToWorkspace={(workspaceId) =>
-            setAddToWorkspaceDialog({ mode: 'append', workspaceId })
-          }
+          onRequestAddToWorkspace={handleRequestAddToWorkspace}
           onUpdateSplitSizes={updateSplitSizes}
           onSetDraggingSessionId={setDraggingSessionId}
           onToggleWorkspaceViewMode={toggleWorkspaceViewMode}

--- a/application/state/codingCliSessionSignalController.ts
+++ b/application/state/codingCliSessionSignalController.ts
@@ -51,7 +51,18 @@ export function createCodingCliSessionSignalController(
 ): CodingCliSessionSignalController {
   const outputScanners = new Map<string, CodingCliOutputScanner>();
   const outputScanDisabled = new Set<string>();
+  // TerminalLayer may memo-skip title/provider-only session updates, so the
+  // controller keeps its own provider memory instead of trusting a stale
+  // sessionsRef from a skipped render.
+  const knownProviderBySession = new Map<string, CodingCliProviderId | null>();
   let observedDynamicTabTitleMode = deps.getDynamicTabTitleMode();
+
+  const resolveCurrentProviderId = (sessionId: string): CodingCliProviderId | null | undefined => {
+    if (knownProviderBySession.has(sessionId)) {
+      return knownProviderBySession.get(sessionId);
+    }
+    return deps.getSession(sessionId)?.codingCliProviderId;
+  };
 
   const handleDynamicTabTitleModeChange = (mode: DynamicTabTitleMode) => {
     if (mode === observedDynamicTabTitleMode) return;
@@ -73,13 +84,14 @@ export function createCodingCliSessionSignalController(
 
   const applyProvider = (sessionId: string, providerId: CodingCliProviderId | null) => {
     const session = deps.getSession(sessionId);
-    if (!session) return;
+    if (!session && !knownProviderBySession.has(sessionId)) return;
     const nextProviderId = resolveCodingCliProviderIconUpdate({
       dynamicTabTitleMode: getCurrentDynamicTabTitleMode(),
-      currentProviderId: session.codingCliProviderId,
+      currentProviderId: resolveCurrentProviderId(sessionId),
       nextProviderId: providerId,
     });
     if (nextProviderId === undefined) return;
+    knownProviderBySession.set(sessionId, nextProviderId);
     deps.onUpdateSessionCodingCliProvider?.(sessionId, nextProviderId);
   };
 
@@ -94,23 +106,24 @@ export function createCodingCliSessionSignalController(
 
   const handleTerminalTitleChange = (sessionId: string, title: string | null) => {
     const session = deps.getSession(sessionId);
-    if (!session) return;
+    if (!session && !knownProviderBySession.has(sessionId)) return;
     const dynamicTabTitleMode = getCurrentDynamicTabTitleMode();
     const trimmedTitle = title?.trim();
     const providerId = trimmedTitle
       ? inferCodingCliProviderFromTitleSignals(trimmedTitle)
       : undefined;
+    const currentProviderId = resolveCurrentProviderId(sessionId);
     const shouldStoreDynamicTitle =
       dynamicTabTitleMode === 'all'
       || (
         dynamicTabTitleMode === 'agent'
-        && Boolean(session.codingCliProviderId || providerId)
+        && Boolean(currentProviderId || providerId)
       );
     deps.onUpdateSessionDynamicTitle?.(sessionId, shouldStoreDynamicTitle ? title : null);
 
     if (!shouldUpdateCodingCliTabIcon(dynamicTabTitleMode)) return;
     if (!trimmedTitle) {
-      if (session.codingCliProviderId) {
+      if (currentProviderId) {
         outputScanners.delete(sessionId);
         outputScanDisabled.delete(sessionId);
         applyProvider(sessionId, null);
@@ -119,7 +132,7 @@ export function createCodingCliSessionSignalController(
     }
 
     if (providerId) {
-      if (!session.codingCliProviderId || session.codingCliProviderId !== providerId) {
+      if (!currentProviderId || currentProviderId !== providerId) {
         outputScanners.delete(sessionId);
         outputScanDisabled.delete(sessionId);
         applyProvider(sessionId, providerId);
@@ -128,8 +141,8 @@ export function createCodingCliSessionSignalController(
     }
 
     if (
-      session.codingCliProviderId
-      && shouldClearCodingCliProviderForTitle(trimmedTitle, session.codingCliProviderId)
+      currentProviderId
+      && shouldClearCodingCliProviderForTitle(trimmedTitle, currentProviderId)
     ) {
       outputScanners.delete(sessionId);
       outputScanDisabled.delete(sessionId);
@@ -143,12 +156,12 @@ export function createCodingCliSessionSignalController(
     if (!shouldUpdateCodingCliTabIcon(dynamicTabTitleMode)) return;
 
     const session = deps.getSession(sessionId);
-    if (!session) {
+    if (!session && !knownProviderBySession.has(sessionId)) {
       outputScanners.delete(sessionId);
       outputScanDisabled.delete(sessionId);
       return;
     }
-    if (session.codingCliProviderId) return;
+    if (resolveCurrentProviderId(sessionId)) return;
 
     let scanner = outputScanners.get(sessionId);
     if (!scanner) {
@@ -176,6 +189,7 @@ export function createCodingCliSessionSignalController(
     forgetSession: (sessionId: string) => {
       outputScanners.delete(sessionId);
       outputScanDisabled.delete(sessionId);
+      knownProviderBySession.delete(sessionId);
     },
   };
 }

--- a/application/state/scriptAutomationCoordinator.ts
+++ b/application/state/scriptAutomationCoordinator.ts
@@ -5,6 +5,7 @@ import { STORAGE_KEY_AI_PERMISSION_MODE } from '@/infrastructure/config/storageK
 import type { AIPermissionMode } from '@/infrastructure/ai/types.ts';
 import { netcattyBridge } from '@/infrastructure/services/netcattyBridge.ts';
 import type { ScriptRun } from '@/types/global/netcatty-bridge-script.d.ts';
+import { publishScriptRunsSnapshot } from './scriptRunsStore.ts';
 
 type RunsListener = (runs: ScriptRun[]) => void;
 
@@ -27,8 +28,14 @@ export function subscribeScriptRuns(listener: RunsListener): () => void {
   return () => runsListeners.delete(listener);
 }
 
+export function getScriptRuns(): readonly ScriptRun[] {
+  return runs;
+}
+
 export function setScriptRuns(nextRuns: ScriptRun[]) {
   runs = nextRuns;
+  // Keep the panel-facing store in lockstep so Scripts UI and overlays share one source.
+  publishScriptRunsSnapshot(nextRuns);
   runsListeners.forEach((listener) => listener(runs));
 }
 

--- a/application/state/scriptRunsStore.test.ts
+++ b/application/state/scriptRunsStore.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { setScriptRuns, getScriptRuns } from './scriptAutomationCoordinator.ts';
+import {
+  getScriptRunsSnapshot,
+  subscribeScriptRuns,
+} from './scriptRunsStore.ts';
+
+test('setScriptRuns publishes to scriptRunsStore for Scripts panel subscribers', () => {
+  const events: number[] = [];
+  const unsubscribe = subscribeScriptRuns(() => {
+    events.push(getScriptRunsSnapshot().length);
+  });
+
+  setScriptRuns([
+    {
+      runId: 'r1',
+      sessionId: 's1',
+      status: 'running',
+      startedAt: 1,
+      logs: [],
+    },
+  ]);
+
+  assert.equal(getScriptRuns().length, 1);
+  assert.equal(getScriptRunsSnapshot().length, 1);
+  assert.equal(getScriptRunsSnapshot()[0]?.runId, 'r1');
+  assert.ok(events.includes(1));
+
+  setScriptRuns([]);
+  assert.equal(getScriptRunsSnapshot().length, 0);
+
+  unsubscribe();
+});

--- a/application/state/scriptRunsStore.ts
+++ b/application/state/scriptRunsStore.ts
@@ -1,0 +1,43 @@
+import type { ScriptRun } from '@/types/global/netcatty-bridge-script.d.ts';
+
+type Listener = () => void;
+
+/**
+ * External store for script automation runs so Scripts side panel can update
+ * without forcing TerminalLayerInner re-renders on every log/status tick.
+ */
+class ScriptRunsStore {
+  private snapshot: readonly ScriptRun[] = [];
+  private listeners = new Set<Listener>();
+
+  getSnapshot = (): readonly ScriptRun[] => this.snapshot;
+
+  subscribe = (listener: Listener): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  setSnapshot(next: readonly ScriptRun[]): void {
+    if (this.snapshot === next) return;
+    this.snapshot = next;
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+export const scriptRunsStore = new ScriptRunsStore();
+
+export function publishScriptRunsSnapshot(runs: readonly ScriptRun[]): void {
+  scriptRunsStore.setSnapshot(runs);
+}
+
+export function getScriptRunsSnapshot(): readonly ScriptRun[] {
+  return scriptRunsStore.getSnapshot();
+}
+
+export function subscribeScriptRuns(listener: Listener): () => void {
+  return scriptRunsStore.subscribe(listener);
+}

--- a/application/state/shellHistoryStore.test.ts
+++ b/application/state/shellHistoryStore.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  getShellHistorySnapshot,
+  publishShellHistorySnapshot,
+  subscribeShellHistory,
+} from './shellHistoryStore.ts';
+
+test('shellHistoryStore notifies subscribers only when the snapshot identity changes', () => {
+  const events: number[] = [];
+  const unsubscribe = subscribeShellHistory(() => {
+    events.push(getShellHistorySnapshot().length);
+  });
+
+  const first = [{ id: '1', command: 'ls', hostId: 'h', hostLabel: 'h', sessionId: 's', timestamp: 1 }];
+  publishShellHistorySnapshot(first);
+  assert.equal(events.at(-1), 1);
+  assert.equal(getShellHistorySnapshot(), first);
+
+  publishShellHistorySnapshot(first);
+  assert.equal(events.length, 1);
+
+  const second = [...first, { id: '2', command: 'pwd', hostId: 'h', hostLabel: 'h', sessionId: 's', timestamp: 2 }];
+  publishShellHistorySnapshot(second);
+  assert.equal(events.at(-1), 2);
+
+  unsubscribe();
+});

--- a/application/state/shellHistoryStore.ts
+++ b/application/state/shellHistoryStore.ts
@@ -1,0 +1,43 @@
+import type { ShellHistoryEntry } from '../../domain/models';
+
+type Listener = () => void;
+
+/**
+ * External store for shell history so History side-panel / snippets consumers
+ * can subscribe without forcing TerminalLayer re-renders on every command.
+ */
+class ShellHistoryStore {
+  private snapshot: readonly ShellHistoryEntry[] = [];
+  private listeners = new Set<Listener>();
+
+  getSnapshot = (): readonly ShellHistoryEntry[] => this.snapshot;
+
+  subscribe = (listener: Listener): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  setSnapshot(next: readonly ShellHistoryEntry[]): void {
+    if (this.snapshot === next) return;
+    this.snapshot = next;
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+export const shellHistoryStore = new ShellHistoryStore();
+
+export function publishShellHistorySnapshot(entries: readonly ShellHistoryEntry[]): void {
+  shellHistoryStore.setSnapshot(entries);
+}
+
+export function getShellHistorySnapshot(): readonly ShellHistoryEntry[] {
+  return shellHistoryStore.getSnapshot();
+}
+
+export function subscribeShellHistory(listener: Listener): () => void {
+  return shellHistoryStore.subscribe(listener);
+}

--- a/application/state/terminalCwdStore.test.ts
+++ b/application/state/terminalCwdStore.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { terminalCwdStore } from './terminalCwdStore.ts';
+
+test('terminalCwdStore bumps version only when cwd changes', () => {
+  const versions: number[] = [];
+  const unsubscribe = terminalCwdStore.subscribe(() => {
+    versions.push(terminalCwdStore.getVersion());
+  });
+
+  const baseVersion = terminalCwdStore.getVersion();
+  assert.equal(terminalCwdStore.setCwd('s1', '/tmp'), true);
+  assert.equal(terminalCwdStore.getCwd('s1'), '/tmp');
+  assert.equal(terminalCwdStore.getVersion(), baseVersion + 1);
+
+  assert.equal(terminalCwdStore.setCwd('s1', '/tmp'), false);
+  assert.equal(terminalCwdStore.getVersion(), baseVersion + 1);
+
+  assert.equal(terminalCwdStore.setCwd('s1', '/var'), true);
+  assert.equal(terminalCwdStore.getCwd('s1'), '/var');
+
+  terminalCwdStore.prune(new Set());
+  assert.equal(terminalCwdStore.getCwd('s1'), null);
+
+  unsubscribe();
+  assert.ok(versions.length >= 2);
+});

--- a/application/state/terminalCwdStore.ts
+++ b/application/state/terminalCwdStore.ts
@@ -1,0 +1,60 @@
+type Listener = () => void;
+
+/**
+ * Live terminal CWD map + version token.
+ * OSC 7 / cwd probes update this store without setState on TerminalLayer,
+ * so only subscribers (side-panel live snapshot bridge) re-render.
+ */
+class TerminalCwdStore {
+  private cwdBySession = new Map<string, string>();
+  private version = 0;
+  private listeners = new Set<Listener>();
+
+  getVersion = (): number => this.version;
+
+  getCwd = (sessionId: string | null | undefined): string | null => {
+    if (!sessionId) return null;
+    return this.cwdBySession.get(sessionId) ?? null;
+  };
+
+  subscribe = (listener: Listener): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  setCwd(sessionId: string, cwd: string | null): boolean {
+    const current = this.cwdBySession.get(sessionId) ?? null;
+    const next = cwd && cwd.trim().length > 0 ? cwd : null;
+    if (current === next) return false;
+
+    if (next) {
+      this.cwdBySession.set(sessionId, next);
+    } else {
+      this.cwdBySession.delete(sessionId);
+    }
+    this.version += 1;
+    for (const listener of this.listeners) {
+      listener();
+    }
+    return true;
+  }
+
+  prune(validSessionIds: ReadonlySet<string>): void {
+    let changed = false;
+    for (const sessionId of this.cwdBySession.keys()) {
+      if (!validSessionIds.has(sessionId)) {
+        this.cwdBySession.delete(sessionId);
+        changed = true;
+      }
+    }
+    if (!changed) return;
+    this.version += 1;
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+export const terminalCwdStore = new TerminalCwdStore();

--- a/application/state/useScriptExecution.ts
+++ b/application/state/useScriptExecution.ts
@@ -1,42 +1,23 @@
-import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 import type { ScriptRunParams } from '@/types/global/netcatty-bridge-script.d.ts';
 import { netcattyBridge } from '@/infrastructure/services/netcattyBridge.ts';
 import {
   getScriptRunsSnapshot,
-  publishScriptRunsSnapshot,
-  subscribeScriptRuns,
+  subscribeScriptRuns as subscribeScriptRunsStore,
 } from './scriptRunsStore.ts';
 
-let scriptRunsBridgeBound = false;
-
-function ensureScriptRunsBridgeBound(): void {
-  if (scriptRunsBridgeBound) return;
-  if (typeof window === 'undefined') return;
-  const bridge = netcattyBridge.get();
-  if (!bridge?.scriptGetRuns) return;
-  scriptRunsBridgeBound = true;
-  bridge.scriptGetRuns()
-    .then((runs) => {
-      publishScriptRunsSnapshot(runs);
-    })
-    .catch(() => {});
-  bridge.onScriptRunsUpdated?.(({ runs: nextRuns }) => {
-    publishScriptRunsSnapshot(nextRuns);
-  });
-}
-
 /**
- * Script run state is externalized so TerminalLayer can avoid re-rendering on
- * every automation log tick. Call sites that need the list should subscribe
- * via this hook (or scriptRunsStore directly).
+ * Script run list for UI. Bridge → coordinator.setScriptRuns → scriptRunsStore
+ * (ScriptAutomationRoot owns the IPC bind). This hook only subscribes so Scripts
+ * side panel re-renders without TerminalLayerInner.
+ *
+ * Pass `{ enabled: false }` when the Scripts panel is not visible so retained
+ * slots do not re-render on every automation log tick.
  */
-export function useScriptExecution() {
-  useEffect(() => {
-    ensureScriptRunsBridgeBound();
-  }, []);
-
+export function useScriptExecution(options?: { enabled?: boolean }) {
+  const enabled = options?.enabled ?? true;
   const runs = useSyncExternalStore(
-    subscribeScriptRuns,
+    enabled ? subscribeScriptRunsStore : () => () => {},
     getScriptRunsSnapshot,
     getScriptRunsSnapshot,
   );

--- a/application/state/useScriptExecution.ts
+++ b/application/state/useScriptExecution.ts
@@ -1,21 +1,45 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import type { ScriptRun, ScriptRunParams } from '@/types/global/netcatty-bridge-script.d.ts';
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import type { ScriptRunParams } from '@/types/global/netcatty-bridge-script.d.ts';
 import { netcattyBridge } from '@/infrastructure/services/netcattyBridge.ts';
+import {
+  getScriptRunsSnapshot,
+  publishScriptRunsSnapshot,
+  subscribeScriptRuns,
+} from './scriptRunsStore.ts';
 
+let scriptRunsBridgeBound = false;
+
+function ensureScriptRunsBridgeBound(): void {
+  if (scriptRunsBridgeBound) return;
+  if (typeof window === 'undefined') return;
+  const bridge = netcattyBridge.get();
+  if (!bridge?.scriptGetRuns) return;
+  scriptRunsBridgeBound = true;
+  bridge.scriptGetRuns()
+    .then((runs) => {
+      publishScriptRunsSnapshot(runs);
+    })
+    .catch(() => {});
+  bridge.onScriptRunsUpdated?.(({ runs: nextRuns }) => {
+    publishScriptRunsSnapshot(nextRuns);
+  });
+}
+
+/**
+ * Script run state is externalized so TerminalLayer can avoid re-rendering on
+ * every automation log tick. Call sites that need the list should subscribe
+ * via this hook (or scriptRunsStore directly).
+ */
 export function useScriptExecution() {
-  const [runs, setRuns] = useState<ScriptRun[]>([]);
-  const runsRef = useRef(runs);
-  runsRef.current = runs;
-
   useEffect(() => {
-    const bridge = netcattyBridge.get();
-    if (!bridge?.scriptGetRuns) return undefined;
-    bridge.scriptGetRuns().then(setRuns).catch(() => {});
-    const dispose = bridge.onScriptRunsUpdated?.(({ runs: nextRuns }) => {
-      setRuns(nextRuns);
-    });
-    return dispose;
+    ensureScriptRunsBridgeBound();
   }, []);
+
+  const runs = useSyncExternalStore(
+    subscribeScriptRuns,
+    getScriptRunsSnapshot,
+    getScriptRunsSnapshot,
+  );
 
   const runScript = useCallback(async (params: ScriptRunParams) => {
     const bridge = netcattyBridge.get();
@@ -38,7 +62,7 @@ export function useScriptExecution() {
   }, []);
 
   const getRunsForSession = useCallback((sessionId: string) => {
-    return runsRef.current.filter((run) => run.sessionId === sessionId);
+    return getScriptRunsSnapshot().filter((run) => run.sessionId === sessionId);
   }, []);
 
   return {

--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { migrateHostsFromLegacyLineTimestamps, normalizeDistroId, sanitizeHost } from "../../domain/host";
 import { isEncryptedCredentialPlaceholder } from "../../domain/credentials";
 import { sanitizeGroupConfig } from "../../domain/groupConfig";
@@ -789,8 +789,9 @@ export const useVaultState = () => {
     updateGroupConfigs,
   ]);
 
-  // Publish for History side panel subscribers without TerminalLayer props.
-  useEffect(() => {
+  // Keep store in sync for storage-event / external setShellHistory paths.
+  // Append/clear/load also publish synchronously so History never flashes empty.
+  useLayoutEffect(() => {
     publishShellHistorySnapshot(shellHistory);
   }, [shellHistory]);
 
@@ -800,6 +801,7 @@ export const useVaultState = () => {
         const updated = mergeGlobalHistoryOnAppend(prev, entry);
         if (updated === prev) return prev;
         localStorageAdapter.write(STORAGE_KEY_SHELL_HISTORY, updated);
+        publishShellHistorySnapshot(updated);
         return updated;
       });
     },
@@ -809,6 +811,7 @@ export const useVaultState = () => {
   const clearShellHistory = useCallback(() => {
     setShellHistory([]);
     localStorageAdapter.write(STORAGE_KEY_SHELL_HISTORY, []);
+    publishShellHistorySnapshot([]);
   }, []);
 
   // Connection logs management
@@ -1073,6 +1076,7 @@ export const useVaultState = () => {
         const savedShellHistory = loadSanitizedShellHistory();
         if (savedShellHistory) {
           setShellHistory(savedShellHistory);
+          publishShellHistorySnapshot(savedShellHistory);
         }
 
         // Load connection logs
@@ -1259,6 +1263,7 @@ export const useVaultState = () => {
           safeParse<ShellHistoryEntry[]>(event.newValue) ?? [],
         );
         setShellHistory(next);
+        publishShellHistorySnapshot(next);
         return;
       }
 

--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -800,8 +800,9 @@ export const useVaultState = () => {
       setShellHistory((prev) => {
         const updated = mergeGlobalHistoryOnAppend(prev, entry);
         if (updated === prev) return prev;
+        // Persist immediately so crash between commit and layout effect cannot drop history.
+        // Store republish is also done in useLayoutEffect for load/storage-event paths.
         localStorageAdapter.write(STORAGE_KEY_SHELL_HISTORY, updated);
-        publishShellHistorySnapshot(updated);
         return updated;
       });
     },

--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -56,6 +56,7 @@ import {
 } from "../../domain/connectionLogTerminalData";
 import { getNextVaultOrder, normalizeVaultOrder } from "../../domain/vaultOrder";
 import { loadSanitizedShellHistory } from "./shellHistoryPersistence";
+import { publishShellHistorySnapshot } from "./shellHistoryStore";
 import { setVaultInitialized } from "./vaultInitStore";
 import {
   decryptGroupConfigs,
@@ -787,6 +788,11 @@ export const useVaultState = () => {
     updateManagedSources,
     updateGroupConfigs,
   ]);
+
+  // Publish for History side panel subscribers without TerminalLayer props.
+  useEffect(() => {
+    publishShellHistorySnapshot(shellHistory);
+  }, [shellHistory]);
 
   const addShellHistoryEntry = useCallback(
     (entry: Omit<ShellHistoryEntry, "id" | "timestamp">) => {

--- a/components/HostTreeView.tsx
+++ b/components/HostTreeView.tsx
@@ -1,6 +1,6 @@
 import { CheckSquare, Edit2, FileSymlink, Server, Square, Expand, Minimize2 } from 'lucide-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '../application/i18n/I18nProvider';
 import {
   hostTreeInlineGroupEditStore,
@@ -857,7 +857,7 @@ const HostTreeItem: React.FC<HostTreeItemProps> = ({
   );
 };
 
-export const HostTreeView: React.FC<HostTreeViewProps> = ({
+const HostTreeViewInner: React.FC<HostTreeViewProps> = ({
   groupTree,
   hosts,
   sortMode = 'az',
@@ -1252,3 +1252,46 @@ export const HostTreeView: React.FC<HostTreeViewProps> = ({
     </div>
   );
 };
+
+function hostTreeViewAreEqual(prev: HostTreeViewProps, next: HostTreeViewProps): boolean {
+  return prev.groupTree === next.groupTree
+    && prev.hosts === next.hosts
+    && prev.sortMode === next.sortMode
+    && prev.expandedPaths === next.expandedPaths
+    && prev.onTogglePath === next.onTogglePath
+    && prev.onExpandAll === next.onExpandAll
+    && prev.onCollapseAll === next.onCollapseAll
+    && prev.onConnect === next.onConnect
+    && prev.onEditHost === next.onEditHost
+    && prev.onDuplicateHost === next.onDuplicateHost
+    && prev.onDeleteHost === next.onDeleteHost
+    && prev.onCopyCredentials === next.onCopyCredentials
+    && prev.onNewGroup === next.onNewGroup
+    && prev.onRenameGroup === next.onRenameGroup
+    && prev.onEditGroup === next.onEditGroup
+    && prev.onDeleteGroup === next.onDeleteGroup
+    && prev.moveHostToGroup === next.moveHostToGroup
+    && prev.moveGroup === next.moveGroup
+    && prev.commitInlineGroupRename === next.commitInlineGroupRename
+    && prev.cancelInlineGroupEdit === next.cancelInlineGroupEdit
+    && prev.managedGroupPaths === next.managedGroupPaths
+    && prev.onUnmanageGroup === next.onUnmanageGroup
+    && prev.isMultiSelectMode === next.isMultiSelectMode
+    && prev.selectedHostIds === next.selectedHostIds
+    && prev.selectedGroupPaths === next.selectedGroupPaths
+    && prev.toggleHostSelection === next.toggleHostSelection
+    && prev.toggleGroupSelection === next.toggleGroupSelection
+    && prev.hostClickBehavior === next.hostClickBehavior
+    && prev.focusedHostId === next.focusedHostId
+    && prev.onFocusHost === next.onFocusHost
+    && prev.focusedGroupPath === next.focusedGroupPath
+    && prev.onFocusGroup === next.onFocusGroup
+    && prev.getDropTargetClasses === next.getDropTargetClasses
+    && prev.setDragOverDropTarget === next.setDragOverDropTarget
+    && prev.groupConfigs === next.groupConfigs
+    && prev.scrollRef === next.scrollRef
+    && prev.autoExpandGroupsKey === next.autoExpandGroupsKey;
+}
+
+export const HostTreeView = memo(HostTreeViewInner, hostTreeViewAreEqual);
+HostTreeView.displayName = 'HostTreeView';

--- a/components/TerminalLayer.memo.test.tsx
+++ b/components/TerminalLayer.memo.test.tsx
@@ -250,3 +250,13 @@ test("TerminalLayer re-renders when portForwardingRules change", () => {
     false,
   );
 });
+
+test("TerminalLayer re-renders when terminalFontFamilyId changes", () => {
+  assert.equal(
+    terminalLayerAreEqual(
+      { ...baseProps, terminalFontFamilyId: "jetbrain-mono" } as never,
+      { ...baseProps, terminalFontFamilyId: "sf-mono" } as never,
+    ),
+    false,
+  );
+});

--- a/components/TerminalLayer.memo.test.tsx
+++ b/components/TerminalLayer.memo.test.tsx
@@ -206,3 +206,47 @@ test("TerminalLayer re-renders when a note open request changes", () => {
     false,
   );
 });
+
+test("TerminalLayer ignores shellHistory prop churn (reads shellHistoryStore instead)", () => {
+  assert.equal(
+    terminalLayerAreEqual(
+      baseProps as never,
+      { ...baseProps, shellHistory: [{ id: "1", command: "ls", hostId: "h", hostLabel: "h", sessionId: "s", timestamp: 1 }] } as never,
+    ),
+    true,
+  );
+});
+
+test("TerminalLayer ignores sessions dynamicTitle-only updates", () => {
+  const sessionsA = [{
+    id: "s1",
+    hostId: "h1",
+    hostLabel: "host",
+    username: "root",
+    hostname: "example.test",
+    status: "connected",
+    dynamicTitle: "old",
+  }];
+  const sessionsB = [{
+    ...sessionsA[0],
+    dynamicTitle: "new",
+    codingCliProviderId: "claude",
+  }];
+  assert.equal(
+    terminalLayerAreEqual(
+      { ...baseProps, sessions: sessionsA } as never,
+      { ...baseProps, sessions: sessionsB } as never,
+    ),
+    true,
+  );
+});
+
+test("TerminalLayer re-renders when portForwardingRules change", () => {
+  assert.equal(
+    terminalLayerAreEqual(
+      baseProps as never,
+      { ...baseProps, portForwardingRules: [{ id: "pf-1" }] } as never,
+    ),
+    false,
+  );
+});

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -56,7 +56,6 @@ import { terminalCwdStore } from '../application/state/terminalCwdStore';
 import { resolveSnippetCommand } from './SnippetExecutionProvider';
 import type { Snippet } from '../types';
 import { isScriptSnippet } from '../domain/snippetScript.ts';
-import { useScriptExecution } from '../application/state/useScriptExecution';
 import {
   pauseScriptRun,
   resumeScriptRun,
@@ -254,7 +253,6 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   onRemoveSessionFromWorkspace,
 }) => {
   const { t } = useI18n();
-  const { runs } = useScriptExecution();
   const terminalRendererCwdBySessionRef = useRef<Map<string, string>>(new Map());
   const stableRef = useRef<Record<string, unknown>>({});
   const activeTabIdRef = useRef(activeTabStore.getActiveTabId());
@@ -303,7 +301,10 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     const currentCwd = terminalRendererCwdBySessionRef.current.get(sessionId) ?? null;
     const nextCwd = cwd && cwd.trim().length > 0 ? cwd : null;
     if (currentCwd === nextCwd) {
-      // Still publish OSC 7 bumps already applied above; no React setState.
+      // Heal store drift if ref already has this path but the store does not.
+      if (terminalCwdStore.getCwd(sessionId) !== nextCwd) {
+        terminalCwdStore.setCwd(sessionId, nextCwd);
+      }
       return;
     }
 
@@ -1186,6 +1187,10 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   }, [getActiveTerminalSessionId, refocusTerminalSession, syncWorkspaceFocusIfNeeded]);
 
   // Close the entire side panel for the current tab
+  const handleEndSessionDrag = useCallback(() => {
+    onSetDraggingSessionId(null);
+  }, [onSetDraggingSessionId]);
+
   const handleCloseSidePanel = useCallback(() => {
     const activeTabId = activeTabIdRef.current;
     if (!activeTabId) return;
@@ -1906,7 +1911,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     handleRunScriptFromPanel,
     handleRunScriptOnWorkspace,
     handleStartRecordingFromPanel,
-    scriptRuns: runs,
+    // scriptRuns live in scriptRunsStore; Scripts side panel subscribes directly.
     handleStopScriptRun: stopScriptRun,
     handlePauseScriptRun: pauseScriptRun,
     handleResumeScriptRun: resumeScriptRun,
@@ -1965,7 +1970,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     onSubmitSessionRename,
     onRemoveSessionFromWorkspace,
     onStartSessionDrag: onSetDraggingSessionId,
-    onEndSessionDrag: () => onSetDraggingSessionId(null),
+    onEndSessionDrag: handleEndSessionDrag,
     onSplitSession,
     onSplitSessionRef,
     onToggleBroadcastRef,

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -52,7 +52,7 @@ import { SftpSidePanel } from './SftpSidePanel';
 import { ScriptsSidePanel } from './ScriptsSidePanel';
 import { HistorySidePanel } from './HistorySidePanel';
 import { NotesManager } from './notes/NotesManager';
-import { useRemoteHistoryState } from '../application/state/useRemoteHistoryState';
+import { terminalCwdStore } from '../application/state/terminalCwdStore';
 import { resolveSnippetCommand } from './SnippetExecutionProvider';
 import type { Snippet } from '../types';
 import { isScriptSnippet } from '../domain/snippetScript.ts';
@@ -206,7 +206,6 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   onUpdateHost,
   onAddKnownHost,
   onCommandExecuted,
-  shellHistory = [],
   onTerminalDataCapture,
   onCreateWorkspaceFromSessions,
   onAddSessionToWorkspace,
@@ -262,19 +261,19 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const activeWorkspaceRef = useRef<Workspace | undefined>(undefined);
   const activeSessionRef = useRef<TerminalSession | undefined>(undefined);
   const focusedSessionIdRef = useRef<string | undefined>(undefined);
-  const terminalCwdRevisionRef = useRef(0);
-  const [terminalCwdRevision, setTerminalCwdRevision] = useState(0);
   const terminalOsc7SignalBySessionRef = useRef<Map<string, number>>(new Map());
   const cwdProbeCancelersRef = useRef<Map<string, () => void>>(new Map());
   const cwdProbeGenerationRef = useRef<Map<string, number>>(new Map());
 
   useEffect(() => {
+    const liveSessionIds = new Set(sessions.map((session) => session.id));
     pruneTerminalSessionRuntimeState({
       terminalRendererCwdBySessionRef,
       terminalOsc7SignalBySessionRef,
       cwdProbeGenerationRef,
       cwdProbeCancelersRef,
-    }, new Set(sessions.map((session) => session.id)));
+    }, liveSessionIds);
+    terminalCwdStore.prune(liveSessionIds);
   }, [sessions]);
 
   useEffect(() => {
@@ -303,7 +302,10 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
 
     const currentCwd = terminalRendererCwdBySessionRef.current.get(sessionId) ?? null;
     const nextCwd = cwd && cwd.trim().length > 0 ? cwd : null;
-    if (currentCwd === nextCwd) return;
+    if (currentCwd === nextCwd) {
+      // Still publish OSC 7 bumps already applied above; no React setState.
+      return;
+    }
 
     if (nextCwd) {
       terminalRendererCwdBySessionRef.current.set(sessionId, nextCwd);
@@ -311,13 +313,20 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       terminalRendererCwdBySessionRef.current.delete(sessionId);
     }
     onUpdateSessionRestoreCwd?.(sessionId, nextCwd);
-    terminalCwdRevisionRef.current += 1;
-    setTerminalCwdRevision(terminalCwdRevisionRef.current);
+    // External store: side-panel live snapshot subscribers update without
+    // re-rendering TerminalLayerInner.
+    terminalCwdStore.setCwd(sessionId, nextCwd);
   }, [onUpdateSessionRestoreCwd]);
 
+  // Stable while only presentation fields (title/provider) change.
+  const codingCliSessionIdsKey = sessions.map((session) => session.id).join('\0');
+  const codingCliSessionIds = useMemo(
+    () => (codingCliSessionIdsKey ? codingCliSessionIdsKey.split('\0') : []),
+    [codingCliSessionIdsKey],
+  );
   const codingCliSignalController = useCodingCliSessionSignals({
     dynamicTabTitleMode: terminalSettings?.dynamicTabTitleMode ?? 'agent',
-    sessionIds: sessions.map((session) => session.id),
+    sessionIds: codingCliSessionIds,
     getSession: (sessionId) => sessionsRef.current.find((candidate) => candidate.id === sessionId),
     onUpdateSessionCodingCliProvider,
     onUpdateSessionDynamicTitle,
@@ -1530,7 +1539,6 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     textarea?.focus();
   }, [terminalBackend]);
 
-  const remoteHistory = useRemoteHistoryState();
   const handleHistoryPaste = useCallback(
     (command: string) => handleSnippetClickForFocusedSession(command, true),
     [handleSnippetClickForFocusedSession],
@@ -1977,8 +1985,6 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     pendingTerminalSelectionForAI,
     refocusActiveTerminalSession,
     refocusTerminalSession,
-    remoteHistory,
-    shellHistory,
     resolveSftpHostForTab,
     ScriptsSidePanel,
     sessionActivityStore,
@@ -2036,7 +2042,6 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     t,
     TerminalComposeBar,
     TerminalPanesHost,
-    terminalCwdRevision,
     terminalFontFamilyId,
     terminalRendererCwdBySessionRef,
     terminalSettings,

--- a/components/terminalLayer/TerminalLayerSidePanelSection.tsx
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.tsx
@@ -5,9 +5,13 @@ import {
   buildTerminalSidePanelCssVars,
 } from '../../infrastructure/theme/terminalAppearanceTokens';
 import { injectTerminalLayerChromeSurfaceVars } from '../../infrastructure/theme/terminalAppearanceVars';
-import React, { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { memo, useCallback, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 
 import { useActiveTabId } from '../../application/state/activeTabStore';
+import {
+  getSidePanelLiveSnapshot,
+  subscribeSidePanelLiveSnapshot,
+} from '../../application/state/sidePanelLiveStore';
 import {
   reorderTerminalSidePanelTab,
   TERMINAL_SIDE_PANEL_TAB_DEFAULT_ORDER,
@@ -83,10 +87,16 @@ function hasMountedSidePanelContent(ctx: SidePanelContext): boolean {
   );
 }
 
-export function TerminalLayerSidePanelSection({ ctx }: { ctx: SidePanelContext }) {
+function TerminalLayerSidePanelSectionInner({ ctx }: { ctx: SidePanelContext }) {
   if (!hasMountedSidePanelContent(ctx)) return null;
   return <TerminalLayerSidePanelInner ctx={ctx} />;
 }
+
+/** Skip chrome rebuilds when only live/workspace-focus ticks change. */
+export const TerminalLayerSidePanelSection = memo(
+  TerminalLayerSidePanelSectionInner,
+  (prev, next) => terminalLayerSidePanelStableCtxEqual(prev.ctx, next.ctx),
+);
 TerminalLayerSidePanelSection.displayName = 'TerminalLayerSidePanelSection';
 
 function TerminalLayerSidePanelInner({ ctx }: { ctx: SidePanelContext }) {
@@ -107,7 +117,7 @@ function TerminalLayerSidePanelInner({ ctx }: { ctx: SidePanelContext }) {
     handleOpenSystem,
     handleOpenTheme,
     handleToggleSftpFromBar,
-    resolvedPreviewTheme,
+    resolvedPreviewTheme: ctxResolvedPreviewTheme,
     setSidePanelPosition,
     setSidePanelWidth,
     persistSidePanelWidth,
@@ -116,6 +126,20 @@ function TerminalLayerSidePanelInner({ ctx }: { ctx: SidePanelContext }) {
     t,
     terminalTheme,
   } = ctx;
+
+  // Live theme for chrome when panel is open and not follow-app — stable memo
+  // no longer receives focus-driven resolvedPreviewTheme via ctx.
+  const subscribeLiveTheme = isSidePanelOpenForCurrentTab && !followAppTerminalTheme;
+  const liveSnapshot = useSyncExternalStore(
+    (listener) => subscribeSidePanelLiveSnapshot(subscribeLiveTheme, listener),
+    () => getSidePanelLiveSnapshot(subscribeLiveTheme),
+    () => getSidePanelLiveSnapshot(subscribeLiveTheme),
+  );
+  const resolvedPreviewTheme = followAppTerminalTheme
+    ? null
+    : (subscribeLiveTheme
+      ? (liveSnapshot.resolvedPreviewTheme ?? ctxResolvedPreviewTheme)
+      : ctxResolvedPreviewTheme);
 
   const [resizePreviewWidth, setResizePreviewWidth] = useState<number | null>(null);
   const {

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -13,6 +13,7 @@ export { buildAITerminalSessionInfo };
 export type { AITerminalSessionInfo };
 import { collectSessionIds, SplitDirection } from '../../domain/workspace';
 import { resolveSessionTabTitle } from '../../domain/sessionTabTitle';
+import { terminalPaneSessionsEqual } from '../../domain/terminalPaneSessionsEqual';
 import {
   resolveTerminalHibernateEnabled,
   resolveTerminalHibernateEnabledForProtocol,
@@ -545,7 +546,6 @@ export interface TerminalLayerProps {
   onUpdateHost: (host: Host) => void;
   onAddKnownHost?: (knownHost: KnownHost) => void;
   onCommandExecuted?: (command: string, hostId: string, hostLabel: string, sessionId: string) => void;
-  shellHistory?: import('../../types').ShellHistoryEntry[];
   onTerminalDataCapture?: (sessionId: string, data: string) => void;
   onCreateWorkspaceFromSessions: (baseSessionId: string, joiningSessionId: string, hint: Exclude<SplitHint, null>) => void;
   onAddSessionToWorkspace: (workspaceId: string, sessionId: string, hint: Exclude<SplitHint, null>) => void;
@@ -660,7 +660,6 @@ interface TerminalPaneProps {
   onUpdateHost: (host: Host) => void;
   onAddKnownHost?: (knownHost: KnownHost) => void;
   onCommandExecuted?: (command: string, hostId: string, hostLabel: string, sessionId: string) => void;
-  shellHistory?: import('../../types').ShellHistoryEntry[];
   onCommandSubmitted?: (command: string, hostId: string, hostLabel: string, sessionId: string) => void;
   onSetWorkspaceFocusedSession?: (workspaceId: string, sessionId: string) => void;
   onSplitSession?: (sessionId: string, direction: SplitDirection) => void;
@@ -1462,7 +1461,6 @@ interface TerminalPanesHostProps {
   onUpdateHost: (host: Host) => void;
   onAddKnownHost?: (knownHost: KnownHost) => void;
   onCommandExecuted?: (command: string, hostId: string, hostLabel: string, sessionId: string) => void;
-  shellHistory?: import('../../types').ShellHistoryEntry[];
   onCommandSubmitted?: (command: string, hostId: string, hostLabel: string, sessionId: string) => void;
   onSetWorkspaceFocusedSession?: (workspaceId: string, sessionId: string) => void;
   onSplitSession?: (sessionId: string, direction: SplitDirection) => void;
@@ -1494,7 +1492,8 @@ const terminalPanesHostPropsAreEqual = (
   prev: TerminalPanesHostProps,
   next: TerminalPanesHostProps,
 ): boolean => {
-  if (prev.sessions !== next.sessions) return false;
+  // Ignore TopTabs-only presentation fields on sessions (dynamicTitle, coding CLI).
+  if (!terminalPaneSessionsEqual(prev.sessions, next.sessions)) return false;
   if (prev.sessionHostsMap !== next.sessionHostsMap) return false;
   if (prev.sessionChainHostsMap !== next.sessionChainHostsMap) return false;
   if (prev.sessionSudoAutofillPasswordsMap !== next.sessionSudoAutofillPasswordsMap) return false;

--- a/components/terminalLayer/TerminalLayerTabBridge.tsx
+++ b/components/terminalLayer/TerminalLayerTabBridge.tsx
@@ -466,7 +466,6 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     handleRunScriptFromPanel: s.handleRunScriptFromPanel,
     handleRunScriptOnWorkspace: s.handleRunScriptOnWorkspace,
     handleStartRecordingFromPanel: s.handleStartRecordingFromPanel,
-    scriptRuns: s.scriptRuns,
     handleStopScriptRun: s.handleStopScriptRun,
     handlePauseScriptRun: s.handlePauseScriptRun,
     handleResumeScriptRun: s.handleResumeScriptRun,
@@ -649,7 +648,6 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     s.terminalTheme,
     s.resolveSessionAppearance,
     s.hostMap,
-    s.scriptRuns,
   ]);
 
   return <TerminalLayerView ctx={ctx} />;

--- a/components/terminalLayer/TerminalLayerTabBridge.tsx
+++ b/components/terminalLayer/TerminalLayerTabBridge.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 
 import { useActiveTabId } from '../../application/state/activeTabStore';
 import { sessionCapabilitiesStore } from '../../application/state/sessionCapabilitiesStore';
@@ -18,6 +18,7 @@ import { useTerminalLayerEffects } from './useTerminalLayerEffects';
 import { useTerminalThemePanelState } from './useTerminalThemePanelState';
 import { useManualTerminalChromeSurfaceInjection } from '../../application/state/useManualTerminalChromeSurfaceInjection';
 import { sidePanelLiveStore, type SidePanelLiveSnapshot } from '../../application/state/sidePanelLiveStore';
+import { terminalCwdStore } from '../../application/state/terminalCwdStore';
 import { useTerminalWorkspaceLayout } from './useTerminalWorkspaceLayout';
 import type { SidePanelTab } from './TerminalLayerSupport';
 
@@ -26,6 +27,13 @@ type StableRef = React.MutableRefObject<Record<string, any>>;
 export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) {
   const s = stableRef.current;
   const activeTabId = useActiveTabId();
+  // Subscribe to cwd store so OSC 7 updates reach the side-panel live snapshot
+  // without TerminalLayerInner setState.
+  const terminalCwdVersion = useSyncExternalStore(
+    terminalCwdStore.subscribe,
+    terminalCwdStore.getVersion,
+    terminalCwdStore.getVersion,
+  );
   const systemBackend = useSystemManagerBackend();
   const terminalContextReadersRef = useRef<Map<string, TerminalContextReader>>(new Map());
 
@@ -152,12 +160,15 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     isSftpOpenForCurrentTab,
   ]);
 
-  const activeTerminalCwd = useMemo(() => {
-    if (!linkedTerminalSessionIdForSftp) return null;
-    return s.terminalRendererCwdBySessionRef.current.get(linkedTerminalSessionIdForSftp) ?? null;
-    // terminalCwdRevision bumps when any session cwd changes so linked SFTP can react.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [linkedTerminalSessionIdForSftp, s.terminalCwdRevision]);
+  // Recomputed when terminalCwdVersion changes (useSyncExternalStore above).
+  const activeTerminalCwd = linkedTerminalSessionIdForSftp
+    ? (
+      terminalCwdStore.getCwd(linkedTerminalSessionIdForSftp)
+      ?? s.terminalRendererCwdBySessionRef.current.get(linkedTerminalSessionIdForSftp)
+      ?? null
+    )
+    : null;
+  void terminalCwdVersion;
 
   const historySessionId = effectiveFocusedSessionId;
   const activeTerminalSessionForSystem = useMemo(
@@ -192,10 +203,6 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     if (!historySessionId) return null;
     return sessionHostsMap.get(historySessionId) ?? null;
   }, [historySessionId, sessionHostsMap]);
-  const focusedHostHistoryState = s.remoteHistory?.getState(
-    focusedHost?.id ?? null,
-    historySessionId,
-  );
 
   const themeState = useTerminalThemePanelState({
     accentMode: s.accentMode,
@@ -443,6 +450,7 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     History: s.History,
     historySessionId,
     HistorySidePanel: s.HistorySidePanel,
+    // remoteHistory / shellHistory are owned by History side-panel slot stores
     hibernateHiddenTabs,
     handleOsDetected: s.handleOsDetected,
     handlePendingTerminalSelectionConsumed: s.handlePendingTerminalSelectionConsumed,
@@ -533,8 +541,6 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     previewedOrVisibleThemeId: themeState.previewedOrVisibleThemeId,
     refocusActiveTerminalSession: s.refocusActiveTerminalSession,
     refocusTerminalSession: s.refocusTerminalSession,
-    remoteHistory: s.remoteHistory,
-    shellHistory: s.shellHistory,
     resizing,
     resolveAIExecutorContext,
     resolvedPreviewTheme: themeState.resolvedPreviewTheme,
@@ -614,9 +620,7 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     computeSplitHint,
     dropHint,
     focusedHost,
-    focusedHostHistoryState,
     focusedSessionId,
-    s.shellHistory,
     s.restoreTerminalCwd,
     s.notes,
     s.noteGroups,

--- a/components/terminalLayer/terminalLayerSidePanelSlots.tsx
+++ b/components/terminalLayer/terminalLayerSidePanelSlots.tsx
@@ -7,6 +7,11 @@ import {
   getSidePanelLiveSnapshot,
   subscribeSidePanelLiveSnapshot,
 } from '../../application/state/sidePanelLiveStore';
+import {
+  getShellHistorySnapshot,
+  subscribeShellHistory,
+} from '../../application/state/shellHistoryStore';
+import { useRemoteHistoryState } from '../../application/state/useRemoteHistoryState';
 import { resolveSystemSidebarSession } from '../../domain/systemManager/resolveSystemSession';
 import { shouldKeepTerminalBackgroundWorkActive } from '../../domain/terminalHibernate';
 import { resolveTerminalFontFamilyId } from '../../infrastructure/config/fonts';
@@ -19,6 +24,9 @@ import { sidePanelHiddenNotesPanelClassName, sidePanelHiddenPanelClassName } fro
 
 type SidePanelStableContext = Record<string, any>;
 const navigatorPlatform = typeof navigator !== 'undefined' ? navigator.platform : '';
+const EMPTY_VAULT_NOTES: never[] = [];
+const EMPTY_VAULT_HOSTS: never[] = [];
+const EMPTY_VAULT_SNIPPETS: never[] = [];
 
 function useSidePanelTabType(tabId: string, sidePanelOpenTabs: Map<string, SidePanelTab>): SidePanelTab | null {
   return sidePanelOpenTabs.get(tabId) ?? null;
@@ -416,11 +424,16 @@ function SidePanelHistorySlotInner({ ctx }: { ctx: SidePanelStableContext }) {
   const sidePanelTab = activeTabId ? sidePanelOpenTabs.get(activeTabId) ?? null : null;
   const isVisible = sidePanelTab === 'history';
   const live = useSidePanelLiveSnapshotForTab(activeTabId ?? '', isVisible);
+  // Own remote-history state here so fetch/loading does not re-render TerminalLayer.
+  const remoteHistory = useRemoteHistoryState();
+  const shellHistory = useSyncExternalStore(
+    subscribeShellHistory,
+    getShellHistorySnapshot,
+    getShellHistorySnapshot,
+  );
 
   const {
     HistorySidePanel,
-    remoteHistory,
-    shellHistory,
     handleHistoryPaste,
     handleHistoryRun,
   } = ctx;
@@ -433,7 +446,7 @@ function SidePanelHistorySlotInner({ ctx }: { ctx: SidePanelStableContext }) {
         focusedHost={live.focusedHost}
         focusedSessionId={live.historySessionId}
         state={remoteHistory.getState(live.focusedHost?.id, live.historySessionId)}
-        globalEntries={shellHistory}
+        globalEntries={[...shellHistory]}
         onFetch={remoteHistory.fetch}
         onPasteToTerminal={handleHistoryPaste}
         onRunInTerminal={handleHistoryRun}
@@ -476,6 +489,10 @@ function SidePanelAiSlotInner({ ctx }: { ctx: SidePanelStableContext }) {
   if (mountedAiTabIds.length === 0) return null;
   if (AI_PANEL_FORCE_HIDE_SHELL && activeSidePanelTab === 'ai') return null;
 
+  // Only the visible AI panel needs vault catalogs for artifact navigation.
+  // Hidden retained panels keep session state without re-binding huge hosts/notes.
+  const injectVaultCatalog = activeSidePanelTab === 'ai';
+
   return (
     <AISidePanelStateRoot validAIScopeTargetIds={validAIScopeTargetIds}>
       <AIChatPanelsHost
@@ -486,9 +503,9 @@ function SidePanelAiSlotInner({ ctx }: { ctx: SidePanelStableContext }) {
         resolveExecutorContext={resolveAIExecutorContext}
         pendingTerminalSelection={pendingTerminalSelectionForAI}
         onPendingTerminalSelectionConsumed={handlePendingTerminalSelectionConsumed}
-        notes={notes}
-        hosts={hosts}
-        snippets={snippets}
+        notes={injectVaultCatalog ? notes : EMPTY_VAULT_NOTES}
+        hosts={injectVaultCatalog ? hosts : EMPTY_VAULT_HOSTS}
+        snippets={injectVaultCatalog ? snippets : EMPTY_VAULT_SNIPPETS}
         onOpenVaultNoteFromChat={onOpenVaultNoteFromChat}
         onOpenVaultHostFromChat={onOpenVaultHostFromChat}
         onOpenVaultSectionFromChat={onOpenVaultSectionFromChat}

--- a/components/terminalLayer/terminalLayerSidePanelSlots.tsx
+++ b/components/terminalLayer/terminalLayerSidePanelSlots.tsx
@@ -11,6 +11,7 @@ import {
   getShellHistorySnapshot,
   subscribeShellHistory,
 } from '../../application/state/shellHistoryStore';
+import { useScriptExecution } from '../../application/state/useScriptExecution';
 import { useRemoteHistoryState } from '../../application/state/useRemoteHistoryState';
 import { resolveSystemSidebarSession } from '../../domain/systemManager/resolveSystemSession';
 import { shouldKeepTerminalBackgroundWorkActive } from '../../domain/terminalHibernate';
@@ -266,6 +267,8 @@ function SidePanelScriptsSlotInner({
   const sidePanelTab = useSidePanelTabType(tabId, sidePanelOpenTabs);
   const isVisible = isTabActive && sidePanelTab === 'scripts';
   const live = useSidePanelLiveSnapshotForTab(tabId, isVisible);
+  // Subscribe here so script log ticks only re-render Scripts, not TerminalLayer.
+  const { runs: scriptRuns } = useScriptExecution();
 
   const {
     ScriptsSidePanel,
@@ -277,7 +280,6 @@ function SidePanelScriptsSlotInner({
     handleRunScriptFromPanel,
     handleRunScriptOnWorkspace,
     handleStartRecordingFromPanel,
-    scriptRuns,
     handleStopScriptRun,
     handlePauseScriptRun,
     handleResumeScriptRun,
@@ -294,7 +296,7 @@ function SidePanelScriptsSlotInner({
         onRunScript={handleRunScriptFromPanel}
         onRunScriptOnWorkspace={handleRunScriptOnWorkspace}
         onStartRecording={handleStartRecordingFromPanel}
-        runs={scriptRuns}
+        runs={[...scriptRuns]}
         onStopRun={handleStopScriptRun}
         onPauseRun={handlePauseScriptRun}
         onResumeRun={handleResumeScriptRun}
@@ -446,7 +448,7 @@ function SidePanelHistorySlotInner({ ctx }: { ctx: SidePanelStableContext }) {
         focusedHost={live.focusedHost}
         focusedSessionId={live.historySessionId}
         state={remoteHistory.getState(live.focusedHost?.id, live.historySessionId)}
-        globalEntries={[...shellHistory]}
+        globalEntries={shellHistory as import('../../domain/models').ShellHistoryEntry[]}
         onFetch={remoteHistory.fetch}
         onPasteToTerminal={handleHistoryPaste}
         onRunInTerminal={handleHistoryRun}

--- a/components/terminalLayer/terminalLayerSidePanelSlots.tsx
+++ b/components/terminalLayer/terminalLayerSidePanelSlots.tsx
@@ -212,17 +212,25 @@ function SidePanelSystemSlotInner({
   const sidePanelTab = useSidePanelTabType(tabId, sidePanelOpenTabs);
   const panelSelected = sidePanelTab === 'system';
   const isVisible = isTabActive && panelSelected;
+  // When this tab is active, prefer live store so focus changes do not require
+  // workspaceById identity churn through the stable side-panel ctx.
+  const live = useSidePanelLiveSnapshotForTab(tabId, isTabActive && panelSelected);
   const sessions = ctx.sessions as TerminalSession[];
   const sessionHostsMap = ctx.sessionHostsMap as Map<string, Host>;
   const workspace = (ctx.workspaceById as Map<string, Workspace>).get(tabId);
   const standaloneSession = sessions.find((session) => session.id === tabId);
-  const systemSession = resolveSystemSidebarSession(
+  const resolvedSession = resolveSystemSidebarSession(
     sessions,
     workspace,
     workspace?.focusedSessionId,
     standaloneSession,
   );
-  const systemHost = systemSession ? sessionHostsMap.get(systemSession.id) ?? null : null;
+  const systemSession = (isTabActive && panelSelected
+    ? (live.activeTerminalSessionForSystem ?? resolvedSession)
+    : resolvedSession) ?? null;
+  const systemHost = (isTabActive && panelSelected && live.activeSystemSessionHost)
+    ? live.activeSystemSessionHost
+    : (systemSession ? sessionHostsMap.get(systemSession.id) ?? null : null);
   const keepSystemWorkActive = panelSelected
     && shouldKeepTerminalBackgroundWorkActive(
       ctx.terminalSettings,
@@ -267,8 +275,8 @@ function SidePanelScriptsSlotInner({
   const sidePanelTab = useSidePanelTabType(tabId, sidePanelOpenTabs);
   const isVisible = isTabActive && sidePanelTab === 'scripts';
   const live = useSidePanelLiveSnapshotForTab(tabId, isVisible);
-  // Subscribe here so script log ticks only re-render Scripts, not TerminalLayer.
-  const { runs: scriptRuns } = useScriptExecution();
+  // Subscribe only while visible so retained scripts slots skip log thrash.
+  const { runs: scriptRuns } = useScriptExecution({ enabled: isVisible });
 
   const {
     ScriptsSidePanel,
@@ -296,7 +304,7 @@ function SidePanelScriptsSlotInner({
         onRunScript={handleRunScriptFromPanel}
         onRunScriptOnWorkspace={handleRunScriptOnWorkspace}
         onStartRecording={handleStartRecordingFromPanel}
-        runs={[...scriptRuns]}
+        runs={scriptRuns as import('@/types/global/netcatty-bridge-script.d.ts').ScriptRun[]}
         onStopRun={handleStopScriptRun}
         onPauseRun={handlePauseScriptRun}
         onResumeRun={handleResumeScriptRun}
@@ -321,7 +329,9 @@ function SidePanelThemeSlotInner({
   const sidePanelOpenTabs = ctx.sidePanelOpenTabs as Map<string, SidePanelTab>;
   const sidePanelTab = useSidePanelTabType(tabId, sidePanelOpenTabs);
   const isVisible = isTabActive && sidePanelTab === 'theme';
-  const live = useSidePanelLiveSnapshotForTab(tabId, isTabActive);
+  // Only subscribe while the theme panel is visible — not merely tab-active —
+  // so cwd/focus live ticks do not thrash a retained ThemeSidePanel.
+  const live = useSidePanelLiveSnapshotForTab(tabId, isVisible);
 
   const {
     ThemeSidePanel,

--- a/components/terminalLayer/terminalLayerViewMemo.test.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.test.ts
@@ -237,13 +237,14 @@ test("terminal layer side panel stable ctx re-renders when session transport fla
   );
 });
 
-test("terminal layer side panel re-renders when linked terminal cwd changes", () => {
+test("terminal layer side panel live equal still tracks cwd; view ignores live cwd", () => {
   const baseCtx = {
     mountedSftpTabIds: ["workspace-1"],
     activeTerminalCwd: "/home/user",
     sftpFollowTerminalCwd: true,
   };
 
+  // Live equal still sees cwd (for diagnostic / full side-panel equal helpers).
   assert.equal(
     terminalLayerSidePanelCtxEqual(
       baseCtx,
@@ -251,12 +252,13 @@ test("terminal layer side panel re-renders when linked terminal cwd changes", ()
     ),
     false,
   );
+  // View equal uses stable keys only — cwd flows through sidePanelLiveStore.
   assert.equal(
     terminalLayerViewCtxEqual(
       baseCtx,
       { ...baseCtx, activeTerminalCwd: "/home/user/project" },
     ),
-    false,
+    true,
   );
 });
 

--- a/components/terminalLayer/terminalLayerViewMemo.test.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.test.ts
@@ -203,10 +203,19 @@ test("terminal layer side panel stable ctx tracks session hosts and workspaces",
     }),
     false,
   );
+  // Focus-only workspace identity changes must not bust stable side-panel equal
+  // (System/SFTP follow focus via sidePanelLiveStore).
   assert.equal(
     terminalLayerSidePanelStableCtxEqual(baseCtx, {
       ...baseCtx,
       workspaceById: new Map([["ws-1", workspace({ focusedSessionId: "session-2" })]]),
+    }),
+    true,
+  );
+  assert.equal(
+    terminalLayerSidePanelStableCtxEqual(baseCtx, {
+      ...baseCtx,
+      workspaceById: new Map([["ws-1", workspace({ title: "Renamed" })]]),
     }),
     false,
   );
@@ -280,6 +289,19 @@ test("terminal layer side panel re-renders when follow terminal cwd setting chan
     terminalLayerViewCtxEqual(
       baseCtx,
       { ...baseCtx, sftpFollowTerminalCwd: true },
+    ),
+    false,
+  );
+});
+
+test("terminal layer side panel stable ctx re-renders when knownHosts change", () => {
+  const baseCtx = {
+    knownHosts: [{ id: "kh-1", hostname: "a.example", port: 22 }],
+  };
+  assert.equal(
+    terminalLayerSidePanelStableCtxEqual(
+      baseCtx,
+      { ...baseCtx, knownHosts: [{ id: "kh-2", hostname: "b.example", port: 22 }] },
     ),
     false,
   );

--- a/components/terminalLayer/terminalLayerViewMemo.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.ts
@@ -173,13 +173,15 @@ function sidePanelCtxKeyEqual(prev: Ctx, next: Ctx, key: string): boolean {
   return prev[key] === next[key];
 }
 
+// Live fields that are also published via sidePanelLiveStore (or dedicated
+// stores like scriptRunsStore). Slots subscribe to those stores directly, so
+// TerminalLayerView must NOT re-render on these ticks — only chrome-stable keys.
 const SIDE_PANEL_LIVE_CTX_KEYS = [
   'activeTerminalSessionForSystem',
   'activeSystemSessionHost',
   'focusedHost',
   'focusedSessionId',
   'historySessionId',
-  'scriptRuns',
   'resolvedPreviewTheme',
   'previewedOrVisibleThemeId',
   'sftpActiveHost',
@@ -419,7 +421,9 @@ export function terminalLayerViewCtxEqual(prev: Ctx, next: Ctx): boolean {
   if (prev.isBroadcastEnabled !== next.isBroadcastEnabled) return false;
   if (prev.composeBarThemeColors !== next.composeBarThemeColors) return false;
   if (prev.workspaceOuterRef !== next.workspaceOuterRef) return false;
-  return terminalLayerSidePanelCtxEqual(prev, next)
+  // Use stable side-panel equal only: LIVE fields (cwd, theme focus, etc.) flow
+  // through sidePanelLiveStore and must not rebuild side-panel chrome.
+  return terminalLayerSidePanelStableCtxEqual(prev, next)
     && terminalLayerFocusSidebarPropsEqual(prev, next)
     && terminalLayerWorkspaceCtxEqual(prev, next);
 }

--- a/components/terminalLayer/terminalLayerViewMemo.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.ts
@@ -203,8 +203,6 @@ const SIDE_PANEL_STABLE_CTX_KEYS = [
   'scriptsMountedTabIds',
   'systemMountedTabIds',
   'themeMountedTabIds',
-  'remoteHistory',
-  'shellHistory',
   'handleHistoryPaste',
   'handleHistoryRun',
   'handleOpenHistory',

--- a/components/terminalLayer/terminalLayerViewMemo.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.ts
@@ -170,7 +170,29 @@ function sidePanelCtxKeyEqual(prev: Ctx, next: Ctx, key: string): boolean {
       session.workspaceId === next.sessions[index]?.workspaceId
     ));
   }
+  if (key === 'workspaceById') {
+    // Focus-only workspace map identity changes must not invalidate every mounted
+    // side-panel slot; System reads focused session from sidePanelLiveStore.
+    return sidePanelWorkspaceByIdEqual(prev.workspaceById, next.workspaceById);
+  }
   return prev[key] === next[key];
+}
+
+function sidePanelWorkspaceByIdEqual(a: any, b: any): boolean {
+  if (a === b) return true;
+  if (!(a instanceof Map) || !(b instanceof Map)) return false;
+  if (a.size !== b.size) return false;
+  for (const [workspaceId, prevWorkspace] of a) {
+    const nextWorkspace = b.get(workspaceId);
+    if (!nextWorkspace) return false;
+    if (prevWorkspace === nextWorkspace) continue;
+    if (prevWorkspace.id !== nextWorkspace.id) return false;
+    if (prevWorkspace.title !== nextWorkspace.title) return false;
+    if (prevWorkspace.viewMode !== nextWorkspace.viewMode) return false;
+    if (prevWorkspace.snippetId !== nextWorkspace.snippetId) return false;
+    if (!workspaceNodeEqual(prevWorkspace.root, nextWorkspace.root)) return false;
+  }
+  return true;
 }
 
 // Live fields that are also published via sidePanelLiveStore (or dedicated
@@ -222,13 +244,16 @@ const SIDE_PANEL_STABLE_CTX_KEYS = [
   'workspaceById',
   'keys',
   'identities',
+  'knownHosts',
   'updateHosts',
+  'handleAddKnownHost',
   'updateSnippets',
   'updateSnippetPackages',
   'sftpDefaultViewMode',
   'sftpInitialLocationForTab',
   'sftpPendingUploadsForTab',
   'handleSftpCurrentPathChange',
+  'handleSftpActiveTransfersChange',
   'sftpDoubleClickBehavior',
   'sftpAutoSync',
   'sftpShowHiddenFiles',

--- a/components/terminalLayer/useTerminalLayerEffects.ts
+++ b/components/terminalLayer/useTerminalLayerEffects.ts
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 
 import { terminalLayoutSuppressStore } from '../../application/state/terminalLayoutSuppressStore';
+import { terminalCwdStore } from '../../application/state/terminalCwdStore';
 import { useSftpBackend } from '../../application/state/useSftpBackend';
 import {
   isTransferNavigationTerminalTabId,
@@ -35,6 +36,9 @@ export function clearTerminalSessionRuntimeState(
   state.cwdProbeGenerationRef.current.delete(sessionId);
   state.terminalOsc7SignalBySessionRef.current.delete(sessionId);
   state.terminalRendererCwdBySessionRef.current.delete(sessionId);
+
+  // Keep terminalCwdStore in sync so SFTP follow does not reuse a closed session path.
+  terminalCwdStore.setCwd(sessionId, null);
 
   if (cancelProbe) {
     try {

--- a/components/terminalLayerMemo.ts
+++ b/components/terminalLayerMemo.ts
@@ -1,3 +1,5 @@
+import { terminalPaneSessionsEqual } from '../domain/terminalPaneSessionsEqual';
+
 export const terminalLayerAreEqual = (
   prev: Record<string, unknown>,
   next: Record<string, unknown>,
@@ -6,6 +8,7 @@ export const terminalLayerAreEqual = (
   prev.customGroups === next.customGroups &&
   prev.groupConfigs === next.groupConfigs &&
   prev.proxyProfiles === next.proxyProfiles &&
+  prev.portForwardingRules === next.portForwardingRules &&
   prev.keys === next.keys &&
   prev.snippets === next.snippets &&
   prev.snippetPackages === next.snippetPackages &&
@@ -16,7 +19,11 @@ export const terminalLayerAreEqual = (
   prev.onOpenVaultHostFromChat === next.onOpenVaultHostFromChat &&
   prev.onOpenVaultSectionFromChat === next.onOpenVaultSectionFromChat &&
   prev.onOpenVaultSnippetFromChat === next.onOpenVaultSnippetFromChat &&
-  prev.sessions === next.sessions &&
+  // Ignore TopTabs-only presentation fields (dynamicTitle / codingCliProviderId).
+  terminalPaneSessionsEqual(
+    prev.sessions as never,
+    next.sessions as never,
+  ) &&
   prev.workspaces === next.workspaces &&
   prev.knownHosts === next.knownHosts &&
   prev.draggingSessionId === next.draggingSessionId &&
@@ -66,6 +73,6 @@ export const terminalLayerAreEqual = (
   prev.updateNoteGroups === next.updateNoteGroups &&
   prev.toggleScriptsSidePanelRef === next.toggleScriptsSidePanelRef &&
   prev.toggleSidePanelRef === next.toggleSidePanelRef &&
-  prev.identities === next.identities &&
-  prev.shellHistory === next.shellHistory
+  prev.identities === next.identities
+  // shellHistory intentionally omitted — History panel reads shellHistoryStore.
 );

--- a/components/terminalLayerMemo.ts
+++ b/components/terminalLayerMemo.ts
@@ -36,6 +36,11 @@ export const terminalLayerAreEqual = (
   prev.customAccent === next.customAccent &&
   prev.terminalSettings === next.terminalSettings &&
   prev.fontSize === next.fontSize &&
+  prev.terminalFontFamilyId === next.terminalFontFamilyId &&
+  prev.sessionLogsEnabled === next.sessionLogsEnabled &&
+  prev.sessionLogsDir === next.sessionLogsDir &&
+  prev.sessionLogsFormat === next.sessionLogsFormat &&
+  prev.sessionLogsTimestampsEnabled === next.sessionLogsTimestampsEnabled &&
   prev.hotkeyScheme === next.hotkeyScheme &&
   prev.disableTerminalFontZoom === next.disableTerminalFontZoom &&
   prev.restoreTerminalCwd === next.restoreTerminalCwd &&

--- a/components/vault/VaultHostListSection.tsx
+++ b/components/vault/VaultHostListSection.tsx
@@ -49,10 +49,12 @@ const isRelatedTargetInside = (
   );
 };
 
+const EMPTY_GROUP_PATH_SET = new Set<string>();
+
 export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext }) {
   const { Badge, Boolean, Button, cancelInlineGroupEdit, CheckSquare, ClipboardCopy, Clock, cn, commitInlineGroupRename, ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger, Copy, displayedGroups, displayedHosts, DistroAvatar, Edit2, FileSymlink, FolderPlus, FolderTree, getDropTargetClasses, getEffectiveHostDistro, groupConfigs, groupedDisplayHosts, handleCopyCredentials, handleDuplicateHost, handleEditGroupConfig, handleEditHost, handleHostConnect, hostClickBehavior: hostClickBehaviorProp, handleUnmanageGroup, hasHostsSidePanel, hostListScrollRef, HostTreeView, isHostsSectionActive, isMultiSelectMode, lastPinnedId, LayoutGrid, managedGroupPaths, moveGroup, moveHostToGroup, onDeleteHost, Pin, pinnedHosts, Plug, recentHosts, reorderGroup, reorderHost, sanitizeHost, search, selectedGroupPath, selectedGroupPaths, selectedHostIds, selectedTags, sessionCount, setDeleteTargetPath, setDragOverDropTarget, setGroupDragOverDropTarget, setIsDeleteGroupOpen, setIsNewFolderOpen, setLastPinnedId, setNewFolderName, setSelectedGroupPath, setTargetParentPath, shouldHideEmptyRootHostsSection, showRecentHosts, sortMode, Square, Star, startInlineDeleteGroup, startInlineNewGroup, startInlineRenameGroup, t, toggleGroupSelection, toggleHostPinned, toggleHostSelection, Trash2, treeExpandedState, treeViewGroupTree, treeViewHosts, viewMode, visibleDisplayedHosts } = ctx;
   const hostClickBehavior: HostClickBehavior = hostClickBehaviorProp === 'select' ? 'select' : 'connect';
-  const multiSelectedGroupPaths: Set<string> = selectedGroupPaths ?? new Set();
+  const multiSelectedGroupPaths: Set<string> = selectedGroupPaths ?? EMPTY_GROUP_PATH_SET;
   const [draggingHostId, setDraggingHostId] = React.useState<string | null>(null);
   const draggingHostIdRef = React.useRef<string | null>(null);
   const lastPreviewReorderRef = React.useRef<string | null>(null);
@@ -70,6 +72,22 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
     sortMode,
     viewMode,
   ].join("|");
+
+  // Stable wrappers so HostTreeView memo can skip parent vault re-renders.
+  const handleTreeDeleteHost = React.useCallback(
+    (host: Host) => {
+      onDeleteHost(host.id);
+    },
+    [onDeleteHost],
+  );
+  const handleTreeGroupDropClasses = React.useCallback(
+    (path: string) => getDropTargetClasses({ kind: "group", path }),
+    [getDropTargetClasses],
+  );
+  const treeAutoExpandGroupsKey = React.useMemo(
+    () => getVaultTreeAutoExpandKey(search, selectedTags),
+    [search, selectedTags],
+  );
 
   React.useEffect(() => {
     if (isMultiSelectMode) {
@@ -891,12 +909,12 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                       onConnect={handleHostConnect}
                       onEditHost={handleEditHost}
                       onDuplicateHost={handleDuplicateHost}
-                      onDeleteHost={(host) => onDeleteHost(host.id)}
+                      onDeleteHost={handleTreeDeleteHost}
                       onCopyCredentials={handleCopyCredentials}
 
                       onNewGroup={startInlineNewGroup}
                       onRenameGroup={startInlineRenameGroup}
-                      onEditGroup={(groupPath) => handleEditGroupConfig(groupPath)}
+                      onEditGroup={handleEditGroupConfig}
                       commitInlineGroupRename={commitInlineGroupRename}
                       cancelInlineGroupEdit={cancelInlineGroupEdit}
                       onDeleteGroup={startInlineDeleteGroup}
@@ -914,13 +932,11 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                       onFocusHost={setFocusedHostId}
                       focusedGroupPath={focusedGroupPath}
                       onFocusGroup={setFocusedGroupPath}
-	                      getDropTargetClasses={(path) =>
-	                        getDropTargetClasses({ kind: "group", path })
-	                      }
+                      getDropTargetClasses={handleTreeGroupDropClasses}
                       setDragOverDropTarget={setGroupDragOverDropTarget}
                       groupConfigs={groupConfigs}
                       scrollRef={hostListScrollRef}
-                      autoExpandGroupsKey={getVaultTreeAutoExpandKey(search, selectedTags)}
+                      autoExpandGroupsKey={treeAutoExpandGroupsKey}
                     />
 	                  ) : sortMode === "group" && groupedDisplayHosts ? (
 	                    <>

--- a/domain/terminalPaneSessionsEqual.test.ts
+++ b/domain/terminalPaneSessionsEqual.test.ts
@@ -41,3 +41,18 @@ test('terminalPaneSessionsEqual detects workspace membership changes', () => {
     false,
   );
 });
+
+test('terminalPaneSessionsEqual detects pendingInitialCwd clear and startupCommand changes', () => {
+  const withSeed = session({ pendingInitialCwd: '/home/seed' });
+  assert.equal(
+    terminalPaneSessionsEqual([withSeed], [session({ pendingInitialCwd: undefined })]),
+    false,
+  );
+  assert.equal(
+    terminalPaneSessionsEqual(
+      [session({ startupCommand: 'htop' })],
+      [session({ startupCommand: 'top' })],
+    ),
+    false,
+  );
+});

--- a/domain/terminalPaneSessionsEqual.test.ts
+++ b/domain/terminalPaneSessionsEqual.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { terminalPaneSessionsEqual } from './terminalPaneSessionsEqual.ts';
+import type { TerminalSession } from './models.ts';
+
+const session = (overrides: Partial<TerminalSession> = {}): TerminalSession => ({
+  id: 's1',
+  hostId: 'h1',
+  hostLabel: 'example',
+  status: 'connected',
+  hostname: 'example.test',
+  username: 'root',
+  port: 22,
+  protocol: 'ssh',
+  ...overrides,
+});
+
+test('terminalPaneSessionsEqual ignores dynamicTitle and codingCliProviderId', () => {
+  const prev = [session({ dynamicTitle: 'old', codingCliProviderId: 'claude' })];
+  const next = [session({ dynamicTitle: 'new', codingCliProviderId: 'codex' })];
+  assert.equal(terminalPaneSessionsEqual(prev, next), true);
+});
+
+test('terminalPaneSessionsEqual detects status and fontSize changes', () => {
+  const base = session();
+  assert.equal(
+    terminalPaneSessionsEqual([base], [session({ status: 'disconnected' })]),
+    false,
+  );
+  assert.equal(
+    terminalPaneSessionsEqual([base], [session({ fontSize: 18 })]),
+    false,
+  );
+});
+
+test('terminalPaneSessionsEqual detects workspace membership changes', () => {
+  const base = session();
+  assert.equal(
+    terminalPaneSessionsEqual([base], [session({ workspaceId: 'ws-1' })]),
+    false,
+  );
+});

--- a/domain/terminalPaneSessionsEqual.ts
+++ b/domain/terminalPaneSessionsEqual.ts
@@ -1,0 +1,66 @@
+import type { TerminalSession } from './models';
+
+/**
+ * Session fields that affect terminal pane React trees (xterm host, layout,
+ * connection chrome). Presentation-only fields used by TopTabs (dynamicTitle,
+ * codingCliProviderId) are intentionally ignored so title churn does not
+ * invalidate TerminalLayer / TerminalPanesHost memoization.
+ */
+export type TerminalPaneSessionFields = Pick<
+  TerminalSession,
+  | 'id'
+  | 'hostId'
+  | 'workspaceId'
+  | 'status'
+  | 'protocol'
+  | 'hostname'
+  | 'username'
+  | 'port'
+  | 'moshEnabled'
+  | 'etEnabled'
+  | 'fontSize'
+  | 'customName'
+  | 'hostLabel'
+  | 'hiddenFromTabs'
+  | 'localShell'
+  | 'localShellName'
+>;
+
+function paneFieldEqual(
+  a: TerminalPaneSessionFields,
+  b: TerminalPaneSessionFields,
+): boolean {
+  return a.id === b.id
+    && a.hostId === b.hostId
+    && a.workspaceId === b.workspaceId
+    && a.status === b.status
+    && a.protocol === b.protocol
+    && a.hostname === b.hostname
+    && a.username === b.username
+    && (a.port ?? 22) === (b.port ?? 22)
+    && Boolean(a.moshEnabled) === Boolean(b.moshEnabled)
+    && Boolean(a.etEnabled) === Boolean(b.etEnabled)
+    && a.fontSize === b.fontSize
+    && a.customName === b.customName
+    && a.hostLabel === b.hostLabel
+    && Boolean(a.hiddenFromTabs) === Boolean(b.hiddenFromTabs)
+    && a.localShell === b.localShell
+    && a.localShellName === b.localShellName;
+}
+
+export function terminalPaneSessionsEqual(
+  prev: ReadonlyArray<TerminalPaneSessionFields> | null | undefined,
+  next: ReadonlyArray<TerminalPaneSessionFields> | null | undefined,
+): boolean {
+  if (prev === next) return true;
+  if (!prev || !next) return false;
+  if (prev.length !== next.length) return false;
+  for (let i = 0; i < prev.length; i += 1) {
+    const a = prev[i];
+    const b = next[i];
+    if (!a || !b) return false;
+    if (a === b) continue;
+    if (!paneFieldEqual(a, b)) return false;
+  }
+  return true;
+}

--- a/domain/terminalPaneSessionsEqual.ts
+++ b/domain/terminalPaneSessionsEqual.ts
@@ -2,9 +2,11 @@ import type { TerminalSession } from './models';
 
 /**
  * Session fields that affect terminal pane React trees (xterm host, layout,
- * connection chrome). Presentation-only fields used by TopTabs (dynamicTitle,
- * codingCliProviderId) are intentionally ignored so title churn does not
- * invalidate TerminalLayer / TerminalPanesHost memoization.
+ * connect/startup chrome). Presentation-only fields used by TopTabs
+ * (`dynamicTitle`, `codingCliProviderId`) are intentionally ignored so title
+ * churn does not invalidate TerminalLayer / TerminalPanesHost memoization.
+ *
+ * Keep this list aligned with props TerminalPane passes into `<Terminal />`.
  */
 export type TerminalPaneSessionFields = Pick<
   TerminalSession,
@@ -19,11 +21,27 @@ export type TerminalPaneSessionFields = Pick<
   | 'moshEnabled'
   | 'etEnabled'
   | 'fontSize'
+  | 'fontSizeOverride'
   | 'customName'
   | 'hostLabel'
   | 'hiddenFromTabs'
   | 'localShell'
   | 'localShellName'
+  | 'localShellArgs'
+  | 'localStartDir'
+  | 'shellType'
+  | 'charset'
+  | 'serialConfig'
+  | 'pluginConnection'
+  | 'restoreState'
+  | 'pendingInitialCwd'
+  | 'startupCommand'
+  | 'noAutoRun'
+  | 'multiLineRunMode'
+  | 'pendingScriptId'
+  | 'pendingScript'
+  | 'reuseConnectionFromSessionId'
+  | 'autoOpenSidePanel'
 >;
 
 function paneFieldEqual(
@@ -41,11 +59,27 @@ function paneFieldEqual(
     && Boolean(a.moshEnabled) === Boolean(b.moshEnabled)
     && Boolean(a.etEnabled) === Boolean(b.etEnabled)
     && a.fontSize === b.fontSize
+    && Boolean(a.fontSizeOverride) === Boolean(b.fontSizeOverride)
     && a.customName === b.customName
     && a.hostLabel === b.hostLabel
     && Boolean(a.hiddenFromTabs) === Boolean(b.hiddenFromTabs)
     && a.localShell === b.localShell
-    && a.localShellName === b.localShellName;
+    && a.localShellName === b.localShellName
+    && a.localShellArgs === b.localShellArgs
+    && a.localStartDir === b.localStartDir
+    && a.shellType === b.shellType
+    && a.charset === b.charset
+    && a.serialConfig === b.serialConfig
+    && a.pluginConnection === b.pluginConnection
+    && a.restoreState === b.restoreState
+    && a.pendingInitialCwd === b.pendingInitialCwd
+    && a.startupCommand === b.startupCommand
+    && Boolean(a.noAutoRun) === Boolean(b.noAutoRun)
+    && a.multiLineRunMode === b.multiLineRunMode
+    && a.pendingScriptId === b.pendingScriptId
+    && a.pendingScript === b.pendingScript
+    && a.reuseConnectionFromSessionId === b.reuseConnectionFromSessionId
+    && a.autoOpenSidePanel === b.autoOpenSidePanel;
 }
 
 export function terminalPaneSessionsEqual(


### PR DESCRIPTION
## Summary

`npm run dev` amplifies TerminalLayer re-renders that are cheap in production packs. This PR lands the P0 + P1 mitigations from the re-render audit: move high-frequency state off the TerminalLayer memo boundary, stop title/cwd/history churn from reconciling the whole terminal + side-panel tree, and stabilize a few AppView handlers.

## Type of Change

- [x] Other (please describe): performance / render fan-out reduction

## Related Issue (optional)

N/A

## Changes Made

### P0
- **shellHistory store**: vault still owns persistence; `shellHistoryStore` publishes snapshots; History side panel reads via `useSyncExternalStore` (no TerminalLayer prop).
- **terminalCwdStore**: OSC 7 / cwd probes update the store instead of `setTerminalCwdRevision` on `TerminalLayerInner`; TabBridge subscribes and refreshes side-panel live snapshot.
- **Stable AppView handlers**: `onCommandExecuted`, font-weight, add-to-workspace no longer inline arrows each render.
- **Session presentation equal**: `terminalPaneSessionsEqual` ignores `dynamicTitle` / `codingCliProviderId` for TerminalLayer + TerminalPanesHost memo (TopTabs still receives full `sessions` from App).

### P1
- **Remote history** owned by History side-panel slot (loading/fetch no longer re-renders TerminalLayer).
- **AI vault catalogs** (`notes`/`hosts`/`snippets`) only injected when the AI side panel tab is visible.
- **HostTreeView** wrapped with `memo` + prop equality.
- **portForwardingRules** included in `terminalLayerAreEqual` (correctness; avoids stale refs).

## Screenshots / Demo

N/A — performance path. Local check: `npm run dev`, type commands, `cd`, stream coding-CLI titles, open History / SFTP follow / AI side panel, switch tabs — React update highlighting on TerminalLayer should be much quieter.

## Testing

- [x] `node --test --import tsx domain/terminalPaneSessionsEqual.test.ts application/state/shellHistoryStore.test.ts application/state/terminalCwdStore.test.ts components/TerminalLayer.memo.test.tsx components/terminalLayer/useTerminalLayerEffects.test.ts components/terminalLayer/terminalLayerViewMemo.test.ts domain/sftpConnectedHosts.test.ts`
- [x] ESLint on touched files
- [ ] Full `npm test` / interactive `npm run dev` QA

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant tests
- [x] No intentional breaking API changes for public surfaces