### PR TITLE
perf(app): isolate App shell domains, TopTabs titles, AI contexts, Vault history

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -42,6 +42,7 @@ import {
 } from './domain/terminalAppearance';
 import { selectConnectionLogForTerminalDataCapture } from './domain/connectionLog';
 import { collectSessionIds } from './domain/workspace';
+import { retainStableSessionsIgnoringPresentation } from './domain/terminalPaneSessionsEqual';
 import { resolveCloseIntent } from './application/state/resolveCloseIntent';
 import { resolveSnippetsShortcutIntent } from './application/state/resolveSnippetsShortcutIntent';
 import { resolveWindowCommandCloseIntent } from './application/state/windowCommandClose';
@@ -140,7 +141,6 @@ function App({ settings }: { settings: SettingsState }) {
   const isPeerSessionWindow = typeof window !== 'undefined' && window.location.hash.startsWith('#/session-window');
 
   const {
-    theme,
     setTheme,
     setLightUiThemeId,
     setDarkUiThemeId,
@@ -228,7 +228,6 @@ function App({ settings }: { settings: SettingsState }) {
     notes,
     noteGroups,
     knownHosts,
-    shellHistory,
     connectionLogs,
     managedSources,
     updateHosts,
@@ -336,6 +335,22 @@ function App({ settings }: { settings: SettingsState }) {
     updateSessionDynamicTitle,
     updateSessionCodingCliProvider,
   } = useSessionState({ persistSessionRestore: !isPeerSessionWindow });
+
+  // Title/provider live updates are store-driven; if sessions arrays still
+  // change only on presentation fields, keep prior identity for App domain
+  // memos so AppView does not re-render Terminal/Vault solely for tab chrome.
+  const sessionsForShellRef = useRef(sessions);
+  const sessionsForShell = retainStableSessionsIgnoringPresentation(
+    sessionsForShellRef.current,
+    sessions,
+  );
+  sessionsForShellRef.current = sessionsForShell as typeof sessions;
+  const orphanSessionsForShellRef = useRef(orphanSessions);
+  const orphanSessionsForShell = retainStableSessionsIgnoringPresentation(
+    orphanSessionsForShellRef.current,
+    orphanSessions,
+  );
+  orphanSessionsForShellRef.current = orphanSessionsForShell as typeof orphanSessions;
 
   const handleRunSnippet = useCallback(
     async (snippet: Snippet, targetHosts: Host[]) => {
@@ -1553,6 +1568,220 @@ function App({ settings }: { settings: SettingsState }) {
 
   const handleRootContextMenu = useCallback((e: React.MouseEvent<HTMLDivElement>) => { return handleRootContextMenuImpl(() => ({ e }), e); }, []);
 
+
+  const appVaultDomain = useMemo(() => ({
+    addShellHistoryEntry,
+    commitPluginImporterData,
+    commitVaultImportTransaction,
+    connectionLogs,
+    convertKnownHostToHost,
+    customGroups,
+    deepLinkHostDraft,
+    effectiveKnownHosts,
+    groupConfigs,
+    handleAddKnownHost,
+    handleDeleteHost,
+    handleOpenHostFromVaultNote,
+    handleOpenVaultHostFromChat,
+    handleOpenVaultNoteFromChat,
+    handleOpenVaultSectionFromChat,
+    handleOpenVaultSnippetFromChat,
+    hosts,
+    identities,
+    importOrReuseKey,
+    keys,
+    managedSources,
+    navigateToSection,
+    noteGroups,
+    notes,
+    proxyProfiles,
+    readPersistedHosts,
+    readPersistedManagedSources,
+    setDeepLinkHostDraft,
+    setNavigateToSection,
+    setVaultFocusRequest,
+    snippetPackages,
+    snippets,
+    unmanageSource,
+    updateCustomGroups,
+    updateGroupConfigs,
+    updateHosts,
+    updateIdentities,
+    updateKeys,
+    updateKnownHosts,
+    updateManagedSources,
+    updateNoteGroups,
+    updateNotes,
+    updateProxyProfiles,
+    updateSnippetPackages,
+    updateSnippets,
+    vaultFocusRequest,
+  }), [addShellHistoryEntry, commitPluginImporterData, commitVaultImportTransaction, connectionLogs, convertKnownHostToHost, customGroups, deepLinkHostDraft, effectiveKnownHosts, groupConfigs, handleAddKnownHost, handleDeleteHost, handleOpenHostFromVaultNote, handleOpenVaultHostFromChat, handleOpenVaultNoteFromChat, handleOpenVaultSectionFromChat, handleOpenVaultSnippetFromChat, hosts, identities, importOrReuseKey, keys, managedSources, navigateToSection, noteGroups, notes, proxyProfiles, readPersistedHosts, readPersistedManagedSources, setDeepLinkHostDraft, setNavigateToSection, setVaultFocusRequest, snippetPackages, snippets, unmanageSource, updateCustomGroups, updateGroupConfigs, updateHosts, updateIdentities, updateKeys, updateKnownHosts, updateManagedSources, updateNoteGroups, updateNotes, updateProxyProfiles, updateSnippetPackages, updateSnippets, vaultFocusRequest]);
+
+  const appTerminalDomain = useMemo(() => ({
+    addSessionToWorkspace,
+    appendHostToWorkspace,
+    appendLocalTerminalToWorkspace,
+    clearSessionFontSizeOverride,
+    closeSession,
+    closeTabsBatch,
+    copySessionWithCurrentShell,
+    copyWorkspaceWithCurrentShell,
+    copySessionToNewWindowWithCurrentShell,
+    closeWorkspace,
+    createWorkspaceFromSessions,
+    createWorkspaceFromTargets: createWorkspaceFromEffectiveTargets,
+    createWorkspaceWithHosts: createWorkspaceWithEffectiveHosts,
+    currentTerminalTheme,
+    draggingSessionId,
+    editorWordWrap,
+    followAppTerminalTheme,
+    clearThemeIntent: themeRuntime.clearIntent,
+    settleManualThemeIntent: themeRuntime.settleManualIntent,
+    pickTerminalTheme: themeRuntime.pickTheme,
+    resolveSessionAppearance: themeRuntime.resolveFocusedAppearance,
+    handleConnectSerial,
+    handleConnectToHost,
+    handleCreateLocalTerminal,
+    handleDefaultTerminalThemeChange,
+    handleFollowAppTerminalThemeChange,
+    handleHotkeyAction,
+    handleSessionStatusChange,
+    handleTerminalDataCapture,
+    handleUpdateHostFromTerminal,
+    hostById,
+    terminalHosts,
+    updateTerminalHosts,
+    hotkeyScheme,
+    isBroadcastEnabled,
+    keyBindings,
+    openNoteRequest,
+    portForwardingRules,
+    removeSessionFromWorkspace,
+    reorderWorkspaceSessions,
+    runSnippet: handleRunSnippet,
+    sessionLogsDir,
+    sessionLogsEnabled,
+    sessionLogsFormat,
+    sessionLogsTimestampsEnabled,
+    sessions: sessionsForShell,
+    setDraggingSessionId,
+    setEditorWordWrap,
+    setTerminalFontFamilyId,
+    setTerminalFontSize,
+    setWorkspaceFocusedSession,
+    sftpAutoOpenSidebar,
+    sftpFollowTerminalCwd,
+    setSftpFollowTerminalCwd,
+    sftpAutoSync,
+    sftpDefaultViewMode,
+    sftpDoubleClickBehavior,
+    sftpShowHiddenFiles,
+    sftpUseCompressedUpload,
+    splitSessionWithCurrentShell,
+    sshDebugLogsEnabled: settings.sshDebugLogsEnabled,
+    terminalFontFamilyId,
+    terminalFontSize,
+    terminalSettings,
+    terminalThemeId,
+    toggleBroadcast,
+    toggleScriptsSidePanelRef,
+    toggleSidePanelRef,
+    toggleWorkspaceViewMode,
+    updateHostDistro,
+    updateSplitSizes,
+    updateSessionFontSize,
+    updateSessionRestoreCwd,
+    updateSessionDynamicTitle,
+    updateSessionCodingCliProvider,
+    updateTerminalSetting,
+    workspaces,
+  }), [addSessionToWorkspace, appendHostToWorkspace, appendLocalTerminalToWorkspace, clearSessionFontSizeOverride, closeSession, closeTabsBatch, copySessionWithCurrentShell, copyWorkspaceWithCurrentShell, copySessionToNewWindowWithCurrentShell, closeWorkspace, createWorkspaceFromSessions, createWorkspaceFromEffectiveTargets, createWorkspaceWithEffectiveHosts, currentTerminalTheme, draggingSessionId, editorWordWrap, followAppTerminalTheme, themeRuntime, handleConnectSerial, handleConnectToHost, handleCreateLocalTerminal, handleDefaultTerminalThemeChange, handleFollowAppTerminalThemeChange, handleHotkeyAction, handleSessionStatusChange, handleTerminalDataCapture, handleUpdateHostFromTerminal, hostById, terminalHosts, updateTerminalHosts, hotkeyScheme, isBroadcastEnabled, keyBindings, openNoteRequest, portForwardingRules, removeSessionFromWorkspace, reorderWorkspaceSessions, handleRunSnippet, sessionLogsDir, sessionLogsEnabled, sessionLogsFormat, sessionLogsTimestampsEnabled, sessionsForShell, setDraggingSessionId, setEditorWordWrap, setTerminalFontFamilyId, setTerminalFontSize, setWorkspaceFocusedSession, sftpAutoOpenSidebar, sftpFollowTerminalCwd, setSftpFollowTerminalCwd, sftpAutoSync, sftpDefaultViewMode, sftpDoubleClickBehavior, sftpShowHiddenFiles, sftpUseCompressedUpload, splitSessionWithCurrentShell, settings, terminalFontFamilyId, terminalFontSize, terminalSettings, terminalThemeId, toggleBroadcast, toggleScriptsSidePanelRef, toggleSidePanelRef, toggleWorkspaceViewMode, updateHostDistro, updateSplitSizes, updateSessionFontSize, updateSessionRestoreCwd, updateSessionDynamicTitle, updateSessionCodingCliProvider, updateTerminalSetting, workspaces]);
+
+  const appChromeDomain = useMemo(() => ({
+    accentMode,
+    clearUnsavedConnectionLogs,
+    closeLogView,
+    customAccent,
+    deleteConnectionLog,
+    handleEndSessionDrag,
+    handleOpenQuickSwitcher,
+    handleOpenSettings,
+    handleRootContextMenu,
+    handleSyncNowManual,
+    isMacClient,
+    logViews,
+    openLogView,
+    orderedTabsWithEditors,
+    orphanSessions: orphanSessionsForShell,
+    reorderWorkTabs,
+    resetSessionRename,
+    resetWorkspaceRename,
+    resolvedTheme,
+    sessionRenameTarget,
+    sessionRenameValue,
+    setActiveTabId,
+    setSessionRenameValue,
+    setWorkspaceRenameValue,
+    settings,
+    startSessionRename,
+    renameSessionInline,
+    startWorkspaceRename,
+    submitSessionRename,
+    submitWorkspaceRename,
+    t,
+    themeById,
+    toggleConnectionLogSaved,
+    updateConnectionLog,
+    workspaceRenameTarget,
+    workspaceRenameValue,
+  }), [accentMode, clearUnsavedConnectionLogs, closeLogView, customAccent, deleteConnectionLog, handleEndSessionDrag, handleOpenQuickSwitcher, handleOpenSettings, handleRootContextMenu, handleSyncNowManual, isMacClient, logViews, openLogView, orderedTabsWithEditors, orphanSessionsForShell, reorderWorkTabs, resetSessionRename, resetWorkspaceRename, resolvedTheme, sessionRenameTarget, sessionRenameValue, setActiveTabId, setSessionRenameValue, setWorkspaceRenameValue, settings, startSessionRename, renameSessionInline, startWorkspaceRename, submitSessionRename, submitWorkspaceRename, t, themeById, toggleConnectionLogSaved, updateConnectionLog, workspaceRenameTarget, workspaceRenameValue]);
+
+  const appDialogsDomain = useMemo(() => ({
+    addToWorkspaceDialog,
+    clearAndRemoveSource,
+    clearAndRemoveSources,
+    editorTabs,
+    emptyVaultConflict,
+    handleHostConnectWithProtocolCheck,
+    handleKeyboardInteractiveCancel,
+    handleKeyboardInteractiveSubmit,
+    handlePassphraseCancel,
+    handlePassphraseSkip,
+    handlePassphraseSubmit,
+    handleProtocolSelect,
+    handleRequestCloseEditorTabRef,
+    isCreateWorkspaceOpen,
+    isQuickSwitcherOpen,
+    keyboardInteractiveQueue,
+    passphraseQueue,
+    protocolSelectHost,
+    quickResults,
+    quickSearch,
+    resolveEmptyVaultConflict,
+    setAddToWorkspaceDialog,
+    setIsCreateWorkspaceOpen,
+    setIsQuickSwitcherOpen,
+    setProtocolSelectHost,
+    setQuickSearch,
+  }), [addToWorkspaceDialog, clearAndRemoveSource, clearAndRemoveSources, editorTabs, emptyVaultConflict, handleHostConnectWithProtocolCheck, handleKeyboardInteractiveCancel, handleKeyboardInteractiveSubmit, handlePassphraseCancel, handlePassphraseSkip, handlePassphraseSubmit, handleProtocolSelect, handleRequestCloseEditorTabRef, isCreateWorkspaceOpen, isQuickSwitcherOpen, keyboardInteractiveQueue, passphraseQueue, protocolSelectHost, quickResults, quickSearch, resolveEmptyVaultConflict, setAddToWorkspaceDialog, setIsCreateWorkspaceOpen, setIsQuickSwitcherOpen, setProtocolSelectHost, setQuickSearch]);
+
+  // Mount components are module-level lazy wrappers — stable for the app lifetime.
+  const appMountsDomain = useMemo(() => ({
+    VaultViewContainer,
+    SftpViewMount,
+    TerminalLayerMount,
+    LogViewWrapper,
+  }), []);
+
+  const appViewDomains = useMemo(() => ({
+    vault: appVaultDomain,
+    terminal: appTerminalDomain,
+    chrome: appChromeDomain,
+    dialogs: appDialogsDomain,
+    mounts: appMountsDomain,
+  }), [appVaultDomain, appTerminalDomain, appChromeDomain, appDialogsDomain, appMountsDomain]);
+
   return (
     <>
       <PortForwardHostKeyDialog onAddKnownHost={handleAddKnownHost} />
@@ -1583,7 +1812,7 @@ function App({ settings }: { settings: SettingsState }) {
         resolveSessionAppearance={themeRuntime.resolveFocusedAppearance}
         t={t}
       />
-      <AppView ctx={{ accentMode, addShellHistoryEntry, addSessionToWorkspace, addToWorkspaceDialog, appendHostToWorkspace, appendLocalTerminalToWorkspace, clearAndRemoveSource, clearAndRemoveSources, clearUnsavedConnectionLogs, clearSessionFontSizeOverride, closeLogView, closeSession, closeTabsBatch, commitPluginImporterData, commitVaultImportTransaction, copySessionWithCurrentShell, copyWorkspaceWithCurrentShell, copySessionToNewWindowWithCurrentShell, closeWorkspace, connectionLogs, convertKnownHostToHost, createWorkspaceFromSessions, createWorkspaceFromTargets: createWorkspaceFromEffectiveTargets, createWorkspaceWithHosts: createWorkspaceWithEffectiveHosts, customAccent, customGroups, currentTerminalTheme, deepLinkHostDraft, deleteConnectionLog, draggingSessionId, effectiveKnownHosts, editorTabs, editorWordWrap, emptyVaultConflict, followAppTerminalTheme, clearThemeIntent: themeRuntime.clearIntent, settleManualThemeIntent: themeRuntime.settleManualIntent, pickTerminalTheme: themeRuntime.pickTheme, resolveSessionAppearance: themeRuntime.resolveFocusedAppearance, groupConfigs, handleAddKnownHost, handleConnectSerial, handleConnectToHost, handleCreateLocalTerminal, handleDefaultTerminalThemeChange, handleDeleteHost, handleEndSessionDrag, handleFollowAppTerminalThemeChange, handleHostConnectWithProtocolCheck, handleHotkeyAction, handleOpenHostFromVaultNote, handleOpenVaultHostFromChat, handleOpenVaultNoteFromChat, handleOpenVaultSectionFromChat, handleOpenVaultSnippetFromChat, handleKeyboardInteractiveCancel, handleKeyboardInteractiveSubmit, handleOpenQuickSwitcher, handleOpenSettings, handleRootContextMenu, handlePassphraseCancel, handlePassphraseSkip, handlePassphraseSubmit, handleProtocolSelect, handleRequestCloseEditorTabRef, handleSessionStatusChange, handleSyncNowManual, handleTerminalDataCapture, handleUpdateHostFromTerminal, hostById, hosts, terminalHosts, updateTerminalHosts, hotkeyScheme, identities, importOrReuseKey, isBroadcastEnabled, isCreateWorkspaceOpen, isMacClient, isQuickSwitcherOpen, keyBindings, keyboardInteractiveQueue, keys, logViews, managedSources, navigateToSection, noteGroups, notes, openLogView, openNoteRequest, orderedTabsWithEditors, orphanSessions, passphraseQueue, protocolSelectHost, proxyProfiles, portForwardingRules, quickResults, quickSearch, readPersistedHosts, readPersistedManagedSources, removeSessionFromWorkspace, reorderWorkTabs, reorderWorkspaceSessions, resetSessionRename, resetWorkspaceRename, resolveEmptyVaultConflict, resolvedTheme, runSnippet: handleRunSnippet, sessionLogsDir, sessionLogsEnabled, sessionLogsFormat, sessionLogsTimestampsEnabled, sessionRenameTarget, sessionRenameValue, sessions, setActiveTabId, setAddToWorkspaceDialog, setDeepLinkHostDraft, setDraggingSessionId, setEditorWordWrap, setIsCreateWorkspaceOpen, setIsQuickSwitcherOpen, setNavigateToSection, setProtocolSelectHost, setQuickSearch, setSessionRenameValue, setTerminalFontFamilyId, setTerminalFontSize, setVaultFocusRequest, setWorkspaceFocusedSession, setWorkspaceRenameValue, settings, sftpAutoOpenSidebar, sftpFollowTerminalCwd, setSftpFollowTerminalCwd, sftpAutoSync, sftpDefaultViewMode, sftpDoubleClickBehavior, sftpShowHiddenFiles, sftpUseCompressedUpload, shellHistory, snippetPackages, snippets, splitSessionWithCurrentShell, sshDebugLogsEnabled: settings.sshDebugLogsEnabled, startSessionRename, renameSessionInline, startWorkspaceRename, submitSessionRename, submitWorkspaceRename, t, terminalFontFamilyId, terminalFontSize, terminalSettings, terminalThemeId, themeById, toggleBroadcast, toggleConnectionLogSaved, toggleScriptsSidePanelRef, toggleSidePanelRef, toggleWorkspaceViewMode, unmanageSource, updateConnectionLog, updateCustomGroups, updateGroupConfigs, updateHostDistro, updateHosts, updateIdentities, updateKeys, updateKnownHosts, updateManagedSources, updateNoteGroups, updateNotes, updateProxyProfiles, updateSnippetPackages, updateSnippets, updateSplitSizes, updateSessionFontSize, updateSessionRestoreCwd, updateSessionDynamicTitle, updateSessionCodingCliProvider, updateTerminalSetting, vaultFocusRequest, workspaceRenameTarget, workspaceRenameValue, workspaces, VaultViewContainer, SftpViewMount, TerminalLayerMount, LogViewWrapper }} />
+      <AppView domains={appViewDomains} />
     </>
   );
 }

--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { Suspense, lazy, useCallback, useEffect, useMemo } from 'react';
+import React, { Suspense, lazy, memo, useCallback, useEffect, useMemo } from 'react';
 import { AlertTriangle, Download, Trash2 } from 'lucide-react';
 import { activeTabStore, toEditorTabId, useActiveTabId, useIsEditorTabActive } from '../state/activeTabStore';
 import { editorTabStore } from '../state/editorTabStore';
@@ -34,6 +34,11 @@ import { pluginViewTabStore, usePluginViewTabs } from '../state/pluginViewTabSto
 import { buildPluginSettingScopeCatalog } from '../state/usePluginSettingScopeCatalog';
 import { useWorkSurfaceHostEditor } from '../state/useWorkSurfaceHostEditor';
 import { isHostTreeWorkTabSurface } from './workTabSurface';
+import {
+  appViewDomainsEqual,
+  mergeAppViewDomains,
+  type AppViewDomains,
+} from './appViewDomains';
 
 const LazyProtocolSelectDialog = lazy(() => import('../../components/ProtocolSelectDialog'));
 const LazyQuickSwitcher = lazy(() =>
@@ -62,11 +67,21 @@ const TextEditorTabFallback = ({ tabId }: { tabId: string }) => {
   );
 };
 
-type AppViewContext = Record<string, any>;
+export type AppViewProps = {
+  domains: AppViewDomains;
+};
 
-export function AppView({ ctx }: { ctx: AppViewContext }) {
+function AppViewInner({ domains }: AppViewProps) {
   const activeTabId = useActiveTabId();
   const pluginViewTabs = usePluginViewTabs();
+  // Merge domain slices once per AppView render. AppView only re-renders when a
+  // domain slice identity changes (see appViewDomainsEqual). Depend on the
+  // domain bag so the hook graph stays honest; bag identity only changes when
+  // App rebuilds a domain slice.
+  const ctx = useMemo(
+    () => mergeAppViewDomains(domains),
+    [domains],
+  ) as Record<string, any>;
   const {
     resetSessionRename,
     resetWorkspaceRename,
@@ -114,7 +129,7 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
     sessionRenameValue, sessions, setActiveTabId, setDeepLinkHostDraft, setDraggingSessionId, setEditorWordWrap,
     setNavigateToSection, setSessionRenameValue, setTerminalFontFamilyId, setTerminalFontSize, setVaultFocusRequest, updateSessionFontSize, updateSessionRestoreCwd, updateSessionDynamicTitle, updateSessionCodingCliProvider, clearSessionFontSizeOverride,
     setWorkspaceFocusedSession, setWorkspaceRenameValue, settings, sftpAutoOpenSidebar, sftpFollowTerminalCwd, setSftpFollowTerminalCwd, sftpAutoSync, sftpDefaultViewMode, sftpDoubleClickBehavior,
-    sftpShowHiddenFiles, sftpUseCompressedUpload, shellHistory, snippetPackages, snippets, splitSessionWithCurrentShell, startSessionRename,
+    sftpShowHiddenFiles, sftpUseCompressedUpload, snippetPackages, snippets, splitSessionWithCurrentShell, startSessionRename,
     startWorkspaceRename, submitSessionRename, submitWorkspaceRename, t, terminalFontFamilyId, terminalFontSize, terminalSettings, terminalThemeId, themeById,
     toggleBroadcast, toggleConnectionLogSaved, toggleScriptsSidePanelRef, toggleSidePanelRef, toggleWorkspaceViewMode, unmanageSource, updateConnectionLog,
     readPersistedHosts, readPersistedManagedSources, updateCustomGroups, updateGroupConfigs, updateHostDistro, updateHosts, updateIdentities, updateKeys, updateKnownHosts, updateManagedSources,
@@ -362,7 +377,6 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
             noteGroups={noteGroups}
             customGroups={customGroups}
             knownHosts={effectiveKnownHosts}
-            shellHistory={shellHistory}
             connectionLogs={connectionLogs}
             managedSources={managedSources}
             sessionCount={sessions.filter((s) => !s.hiddenFromTabs).length}
@@ -856,3 +870,8 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
     </SnippetExecutionProvider>
   );
 }
+
+export const AppView = memo(AppViewInner, (prev, next) => (
+  appViewDomainsEqual(prev.domains, next.domains)
+));
+AppView.displayName = 'AppView';

--- a/application/app/appViewDomains.test.ts
+++ b/application/app/appViewDomains.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  appViewDomainsEqual,
+  mergeAppViewDomains,
+  type AppViewDomains,
+} from './appViewDomains.ts';
+
+test('appViewDomainsEqual is true only when all domain slice refs match', () => {
+  const vault = { hosts: [] };
+  const terminal = { sessions: [] };
+  const chrome = { theme: 'dark' };
+  const dialogs = { open: false };
+  const mounts = { TerminalLayerMount: null };
+  const a: AppViewDomains = { vault, terminal, chrome, dialogs, mounts };
+  const b: AppViewDomains = { vault, terminal, chrome, dialogs, mounts };
+  assert.equal(appViewDomainsEqual(a, b), true);
+  assert.equal(
+    appViewDomainsEqual(a, { ...b, terminal: { sessions: [{ id: 'x' }] } }),
+    false,
+  );
+  assert.equal(
+    appViewDomainsEqual(a, { ...b, vault: { hosts: [{ id: 'h' }] } }),
+    false,
+  );
+});
+
+test('mergeAppViewDomains flattens domains without shellHistory requirement', () => {
+  const merged = mergeAppViewDomains({
+    vault: { hosts: [1], notes: [] },
+    terminal: { sessions: [2] },
+    chrome: { orderedTabs: [] },
+    dialogs: { isQuickSwitcherOpen: false },
+    mounts: { VaultViewContainer: 'V' },
+  });
+  assert.deepEqual(merged.hosts, [1]);
+  assert.deepEqual(merged.sessions, [2]);
+  assert.equal(merged.VaultViewContainer, 'V');
+  assert.equal(Object.prototype.hasOwnProperty.call(merged, 'shellHistory'), false);
+});
+
+test('appViewDomainsEqual keeps AppView stable when only unrelated domain ref is same', () => {
+  const vault = { hosts: [] };
+  const terminal = { sessions: [] };
+  const chrome = { theme: 'dark' };
+  const dialogs = { open: false };
+  const mounts = { TerminalLayerMount: null };
+  const base: AppViewDomains = { vault, terminal, chrome, dialogs, mounts };
+  // Same domain refs → equal (title churn must not replace these refs).
+  assert.equal(appViewDomainsEqual(base, { vault, terminal, chrome, dialogs, mounts }), true);
+  // Terminal domain identity change (structural session change) → unequal.
+  assert.equal(
+    appViewDomainsEqual(base, { vault, terminal: { sessions: [] }, chrome, dialogs, mounts }),
+    false,
+  );
+});

--- a/application/app/appViewDomains.ts
+++ b/application/app/appViewDomains.ts
@@ -1,0 +1,41 @@
+/**
+ * Domain-scoped wiring for the main window shell.
+ * App re-renders may rebuild the parent, but AppView only re-renders when one
+ * of these domain slice identities changes.
+ */
+
+export type AppViewDomainBag = Record<string, unknown>;
+
+export type AppViewDomains = {
+  /** Vault hosts/keys/notes/snippets (not shellHistory — that uses shellHistoryStore). */
+  vault: AppViewDomainBag;
+  /** Terminal sessions/workspaces/SFTP settings and terminal-layer handlers. */
+  terminal: AppViewDomainBag;
+  /** Top chrome: tabs, theme chrome, sync, host tree related. */
+  chrome: AppViewDomainBag;
+  /** Modals, queues, rename targets, quick switcher. */
+  dialogs: AppViewDomainBag;
+  /** Lazy mount components (stable module references). */
+  mounts: AppViewDomainBag;
+};
+
+export function mergeAppViewDomains(domains: AppViewDomains): AppViewDomainBag {
+  return {
+    ...domains.vault,
+    ...domains.terminal,
+    ...domains.chrome,
+    ...domains.dialogs,
+    ...domains.mounts,
+  };
+}
+
+export function appViewDomainsEqual(
+  prev: AppViewDomains,
+  next: AppViewDomains,
+): boolean {
+  return prev.vault === next.vault
+    && prev.terminal === next.terminal
+    && prev.chrome === next.chrome
+    && prev.dialogs === next.dialogs
+    && prev.mounts === next.mounts;
+}

--- a/application/state/sessionPresentationStore.test.ts
+++ b/application/state/sessionPresentationStore.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  retainStableSessionsIgnoringPresentation,
+  terminalPaneSessionsEqual,
+} from '../../domain/terminalPaneSessionsEqual.ts';
+import { topTabsSessionsEqual } from '../../domain/topTabsSessionsEqual.ts';
+import {
+  applySessionPresentation,
+  publishSessionCodingCliProvider,
+  publishSessionDynamicTitle,
+  sessionPresentationStore,
+} from './sessionPresentationStore.ts';
+
+const session = (overrides: Record<string, unknown> = {}) => ({
+  id: 's1',
+  hostId: 'h1',
+  hostLabel: 'host',
+  username: 'root',
+  hostname: 'example.test',
+  status: 'connected' as const,
+  ...overrides,
+});
+
+test('presentation store notifies on title and provider updates', () => {
+  sessionPresentationStore.clearSession('s1');
+  const versions: number[] = [];
+  const unsub = sessionPresentationStore.subscribe(() => {
+    versions.push(sessionPresentationStore.getVersion());
+  });
+  const base = sessionPresentationStore.getVersion();
+  publishSessionDynamicTitle('s1', 'Claude Code');
+  assert.equal(sessionPresentationStore.getPresentation('s1')?.dynamicTitle, 'Claude Code');
+  publishSessionCodingCliProvider('s1', 'claude');
+  assert.equal(sessionPresentationStore.getPresentation('s1')?.codingCliProviderId, 'claude');
+  assert.ok(sessionPresentationStore.getVersion() > base);
+  assert.ok(versions.length >= 2);
+  unsub();
+  sessionPresentationStore.clearSession('s1');
+});
+
+test('title-only session changes stay equal for TopTabs structural compare', () => {
+  const prev = [session({ dynamicTitle: 'old' })];
+  const next = [session({ dynamicTitle: 'new', codingCliProviderId: 'claude' })];
+  assert.equal(topTabsSessionsEqual(prev, next), true);
+  assert.equal(terminalPaneSessionsEqual(prev, next), true);
+  assert.equal(
+    topTabsSessionsEqual(prev, [session({ status: 'disconnected' })]),
+    false,
+  );
+});
+
+test('applySessionPresentation overlays store onto orphan-style snapshots', () => {
+  sessionPresentationStore.clearSession('orphan-1');
+  publishSessionDynamicTitle('orphan-1', 'agent: refactor');
+  publishSessionCodingCliProvider('orphan-1', 'claude');
+  const base = session({ id: 'orphan-1', dynamicTitle: 'stale', codingCliProviderId: undefined });
+  const merged = applySessionPresentation(base);
+  assert.equal(merged.dynamicTitle, 'agent: refactor');
+  assert.equal(merged.codingCliProviderId, 'claude');
+  // Same store values → retain object identity when already up to date.
+  assert.equal(applySessionPresentation(merged), merged);
+  sessionPresentationStore.clearSession('orphan-1');
+});
+
+test('retainStableSessionsIgnoringPresentation keeps array identity on title-only churn', () => {
+  const prev = [session({ dynamicTitle: 'old' })];
+  const next = [session({ dynamicTitle: 'new', codingCliProviderId: 'codex' })];
+  const retained = retainStableSessionsIgnoringPresentation(prev, next);
+  assert.equal(retained, prev);
+  const structural = [session({ status: 'disconnected' })];
+  assert.notEqual(retainStableSessionsIgnoringPresentation(prev, structural), prev);
+});

--- a/application/state/sessionPresentationStore.ts
+++ b/application/state/sessionPresentationStore.ts
@@ -1,0 +1,110 @@
+import type { CodingCliProviderId } from '../../domain/codingCliProviders';
+
+export type SessionPresentation = {
+  dynamicTitle?: string | null;
+  codingCliProviderId?: CodingCliProviderId | null;
+};
+
+type Listener = () => void;
+
+/**
+ * Presentation-only session chrome (tab title / coding-CLI icon) separate from
+ * structural session identity used by TerminalLayer pane equality.
+ */
+class SessionPresentationStore {
+  private bySession = new Map<string, SessionPresentation>();
+  private version = 0;
+  private listeners = new Set<Listener>();
+
+  getVersion = (): number => this.version;
+
+  getPresentation = (sessionId: string): SessionPresentation | undefined =>
+    this.bySession.get(sessionId);
+
+  subscribe = (listener: Listener): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  setPresentation(sessionId: string, patch: SessionPresentation): void {
+    const prev = this.bySession.get(sessionId) ?? {};
+    const next: SessionPresentation = { ...prev, ...patch };
+    if (
+      (prev.dynamicTitle ?? null) === (next.dynamicTitle ?? null)
+      && (prev.codingCliProviderId ?? null) === (next.codingCliProviderId ?? null)
+    ) {
+      return;
+    }
+    this.bySession.set(sessionId, next);
+    this.version += 1;
+    for (const listener of this.listeners) listener();
+  }
+
+  clearSession(sessionId: string): void {
+    if (!this.bySession.has(sessionId)) return;
+    this.bySession.delete(sessionId);
+    this.version += 1;
+    for (const listener of this.listeners) listener();
+  }
+
+  prune(validSessionIds: ReadonlySet<string>): void {
+    let changed = false;
+    for (const id of this.bySession.keys()) {
+      if (!validSessionIds.has(id)) {
+        this.bySession.delete(id);
+        changed = true;
+      }
+    }
+    if (!changed) return;
+    this.version += 1;
+    for (const listener of this.listeners) listener();
+  }
+}
+
+export const sessionPresentationStore = new SessionPresentationStore();
+
+export function publishSessionDynamicTitle(sessionId: string, title: string | null): void {
+  sessionPresentationStore.setPresentation(sessionId, { dynamicTitle: title });
+}
+
+export function publishSessionCodingCliProvider(
+  sessionId: string,
+  providerId: CodingCliProviderId | null,
+): void {
+  sessionPresentationStore.setPresentation(sessionId, { codingCliProviderId: providerId });
+}
+
+type SessionWithPresentation = {
+  id: string;
+  dynamicTitle?: string;
+  codingCliProviderId?: CodingCliProviderId;
+};
+
+/**
+ * Overlay live presentation chrome onto a session snapshot.
+ * Used by TopTabs for both main sessions and orphanSessionMap so title/provider
+ * updates never freeze for either tab surface.
+ */
+export function applySessionPresentation<T extends SessionWithPresentation>(session: T): T {
+  const presentation = sessionPresentationStore.getPresentation(session.id);
+  if (!presentation) return session;
+  const nextTitle = presentation.dynamicTitle === undefined
+    ? session.dynamicTitle
+    : (presentation.dynamicTitle ?? undefined);
+  const nextProvider = presentation.codingCliProviderId === undefined
+    ? session.codingCliProviderId
+    : (presentation.codingCliProviderId ?? undefined);
+  if (
+    nextTitle === session.dynamicTitle
+    && nextProvider === session.codingCliProviderId
+  ) {
+    return session;
+  }
+  return {
+    ...session,
+    dynamicTitle: nextTitle,
+    codingCliProviderId: nextProvider,
+  };
+}

--- a/application/state/shellHistoryIsolation.test.ts
+++ b/application/state/shellHistoryIsolation.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { vaultViewAreEqual } from '../../components/VaultView.tsx';
+import {
+  getShellHistorySnapshot,
+  publishShellHistorySnapshot,
+  subscribeShellHistory,
+} from './shellHistoryStore.ts';
+
+const vaultBase = {
+  hosts: [],
+  keys: [],
+  identities: [],
+  proxyProfiles: [],
+  snippets: [],
+  snippetPackages: [],
+  notes: [],
+  noteGroups: [],
+  customGroups: [],
+  knownHosts: [],
+  connectionLogs: [],
+  sessions: [],
+  managedSources: [],
+  groupConfigs: {},
+  terminalThemeId: 'default',
+  terminalFontSize: 14,
+  navigateToSection: null,
+};
+
+test('history-only store updates notify subscribers without failing vault memo', () => {
+  const seen: number[] = [];
+  const unsub = subscribeShellHistory(() => {
+    seen.push(getShellHistorySnapshot().length);
+  });
+
+  const first = [{
+    id: 'h1',
+    command: 'ls',
+    hostId: 'host',
+    hostLabel: 'host',
+    sessionId: 's1',
+    timestamp: 1,
+  }];
+  publishShellHistorySnapshot(first);
+  assert.equal(getShellHistorySnapshot().length, 1);
+  assert.ok(seen.includes(1));
+
+  // Vault equal stays true for identical vault props (history is not a prop).
+  assert.equal(
+    vaultViewAreEqual(vaultBase as never, { ...vaultBase } as never),
+    true,
+  );
+
+  publishShellHistorySnapshot([
+    ...first,
+    {
+      id: 'h2',
+      command: 'pwd',
+      hostId: 'host',
+      hostLabel: 'host',
+      sessionId: 's1',
+      timestamp: 2,
+    },
+  ]);
+  assert.equal(getShellHistorySnapshot().length, 2);
+  assert.equal(
+    vaultViewAreEqual(vaultBase as never, { ...vaultBase } as never),
+    true,
+  );
+
+  unsub();
+});

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -28,6 +28,11 @@ import { clearSessionFontSizeOverride as clearSessionFontSizeOverrideFields } fr
 import { buildOrderedWorkTabIds, reorderWorkTabIds } from '../app/workTabSurface';
 import { activeTabStore } from './activeTabStore';
 import {
+  publishSessionCodingCliProvider,
+  publishSessionDynamicTitle,
+  sessionPresentationStore,
+} from './sessionPresentationStore';
+import {
   closeSessionsState,
   detachSessionFromWorkspaceState,
   replaceDissolvedWorkspaceTabOrder,
@@ -388,38 +393,17 @@ export const useSessionState = ({
   const updateSessionDynamicTitle = useCallback((sessionId: string, title: string | null) => {
     const normalizedTitle = title ? normalizeCodingCliDynamicTitleForStorage(title) : '';
     const nextTitle = normalizedTitle.length > 0 ? normalizedTitle : null;
-    setSessions((prev) => {
-      const session = prev.find((candidate) => candidate.id === sessionId);
-      if (!session) return prev;
-      if ((session.dynamicTitle ?? null) === nextTitle) return prev;
-      return prev.map((candidate) => {
-        if (candidate.id !== sessionId) return candidate;
-        if (!nextTitle) {
-          const { dynamicTitle: _removed, ...rest } = candidate;
-          return rest;
-        }
-        return { ...candidate, dynamicTitle: nextTitle };
-      });
-    });
+    // Presentation-only: write the external store so TopTabs refreshes without
+    // setSessions thrashing appTerminalDomain / TerminalLayer parents.
+    publishSessionDynamicTitle(sessionId, nextTitle);
   }, []);
 
   const updateSessionCodingCliProvider = useCallback((
     sessionId: string,
     providerId: CodingCliProviderId | null,
   ) => {
-    setSessions((prev) => {
-      const session = prev.find((candidate) => candidate.id === sessionId);
-      if (!session) return prev;
-      if ((session.codingCliProviderId ?? null) === providerId) return prev;
-      return prev.map((candidate) => {
-        if (candidate.id !== sessionId) return candidate;
-        if (!providerId) {
-          const { codingCliProviderId: _removed, ...rest } = candidate;
-          return rest;
-        }
-        return { ...candidate, codingCliProviderId: providerId };
-      });
-    });
+    // Presentation-only: store-driven icon chrome (see sessionPresentationStore).
+    publishSessionCodingCliProvider(sessionId, providerId);
   }, []);
 
   const createLocalTerminal = useCallback((options?: LocalTerminalOptions) => {
@@ -462,9 +446,13 @@ export const useSessionState = ({
   }, []);
 
   const closeWorkspace = useCallback((workspaceId: string) => {
-    cleanupClosedTerminalSessions(
-      sessionsRef.current.filter(session => session.workspaceId === workspaceId).map(session => session.id),
-    );
+    const closedIds = sessionsRef.current
+      .filter(session => session.workspaceId === workspaceId)
+      .map(session => session.id);
+    cleanupClosedTerminalSessions(closedIds);
+    for (const sessionId of closedIds) {
+      sessionPresentationStore.clearSession(sessionId);
+    }
     setWorkspaces(prevWorkspaces => {
       const remainingWorkspaces = prevWorkspaces.filter(w => w.id !== workspaceId);
 
@@ -485,6 +473,9 @@ export const useSessionState = ({
 
   const closeSessions = useCallback((sessionIds: string[]) => {
     cleanupClosedTerminalSessions(sessionIds);
+    for (const sessionId of sessionIds) {
+      sessionPresentationStore.clearSession(sessionId);
+    }
     const result = closeSessionsState({
       sessions: sessionsRef.current,
       workspaces: workspacesRef.current,

--- a/components/SnippetsManager.transfer.test.tsx
+++ b/components/SnippetsManager.transfer.test.tsx
@@ -47,7 +47,6 @@ test("SnippetsManager renders import and multi-select controls", () => {
         snippets={[snippet]}
         packages={["ops"]}
         hosts={[]}
-        shellHistory={[]}
         hotkeyScheme="mac"
         keyBindings={[]}
         onSave={noop}

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -1,10 +1,14 @@
 import { CheckSquare, ChevronDown, Clock, Copy, Download, Edit2, FileCode, FolderPlus, LayoutGrid, List as ListIcon, Package, Play, Plus, Search, Square, Trash2, Upload, X, Zap } from 'lucide-react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { useI18n } from '../application/i18n/I18nProvider';
 import { useStoredViewMode } from '../application/state/useStoredViewMode';
 import { STORAGE_KEY_VAULT_SNIPPETS_VIEW_MODE } from '../infrastructure/config/storageKeys';
 import { cn, isMacPlatform } from '../lib/utils';
 import { Host, ProxyProfile, ShellHistoryEntry, Snippet, SSHKey } from '../types';
+import {
+  getShellHistorySnapshot,
+  subscribeShellHistory,
+} from '../application/state/shellHistoryStore';
 import { HotkeyScheme, KeyBinding, keyEventToString, ManagedSource, matchesKeyBinding, parseKeyCombo } from '../domain/models';
 import {
   buildSnippetExportPayload,
@@ -59,7 +63,8 @@ interface SnippetsManagerProps {
   packages: string[];
   hosts: Host[];
   customGroups?: string[];
-  shellHistory: ShellHistoryEntry[];
+  /** @deprecated Prefer shellHistoryStore; optional override for tests only. */
+  shellHistory?: ShellHistoryEntry[];
   hotkeyScheme: HotkeyScheme;
   keyBindings: KeyBinding[];
   onSave: (snippet: Snippet) => void;
@@ -447,7 +452,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
   packages,
   hosts,
   customGroups = [],
-  shellHistory,
+  shellHistory: shellHistoryProp,
   hotkeyScheme,
   keyBindings,
   onSave,
@@ -466,6 +471,12 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
   onOpenSnippetIdHandled,
 }) => {
   const { t } = useI18n();
+  const shellHistoryFromStore = useSyncExternalStore(
+    subscribeShellHistory,
+    getShellHistorySnapshot,
+    getShellHistorySnapshot,
+  );
+  const shellHistory = shellHistoryProp ?? (shellHistoryFromStore as ShellHistoryEntry[]);
   const [rightPanelMode, setRightPanelMode] = useState<RightPanelMode>('none');
   const [editingSnippet, setEditingSnippet] = useState<Partial<Snippet>>({
     label: '',

--- a/components/TopTabs.test.ts
+++ b/components/TopTabs.test.ts
@@ -570,3 +570,26 @@ test("host tree toggle is hidden on root pages", () => {
     workspaceIds: new Set(),
   }), false);
 });
+
+test("TopTabs merges presentation store into orphanSessionMap and sessions", () => {
+  assert.match(topTabsSource, /applySessionPresentation/);
+  assert.match(topTabsSource, /sessionPresentationStore\.subscribe/);
+  assert.match(topTabsSource, /presentationVersion/);
+  assert.ok(
+    topTabsSource.includes("map.set(s.id, applySessionPresentation(s))"),
+    "orphanSessionMap must overlay store presentation like sessions",
+  );
+});
+
+test("topTabsAreEqual tracks editorTabs for dirty chrome", () => {
+  assert.match(topTabsSource, /prev\.editorTabs === next\.editorTabs/);
+  assert.match(topTabsSource, /prev\.onRequestCloseEditorTab === next\.onRequestCloseEditorTab/);
+});
+
+test("App shell retains presentation-stable sessions for domain memos", () => {
+  assert.match(appSource, /retainStableSessionsIgnoringPresentation/);
+  assert.match(appSource, /sessionsForShell/);
+  assert.match(appSource, /orphanSessionsForShell/);
+  assert.match(appSource, /sessions: sessionsForShell/);
+  assert.match(appSource, /orphanSessions: orphanSessionsForShell/);
+});

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -1,6 +1,11 @@
 import { Folder, FolderLock, Menu, MoreHorizontal, Plus, Settings, Sparkles, Terminal } from 'lucide-react';
-import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { fromEditorTabId, isEditorTabId, useActiveTabId } from '../application/state/activeTabStore';
+import {
+  applySessionPresentation,
+  sessionPresentationStore,
+} from '../application/state/sessionPresentationStore';
+import { topTabsSessionsEqual } from '../domain/topTabsSessionsEqual';
 import { isHostTreeWorkTabSurface } from '../application/app/workTabSurface';
 import type { EditorTab } from '../application/state/editorTabStore';
 import { buildWorkspaceActivityMap } from '../application/state/sessionActivity';
@@ -168,7 +173,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   theme,
   themePreference,
   hosts,
-  sessions,
+  sessions: sessionsProp,
   orphanSessions,
   workspaces,
   logViews,
@@ -214,6 +219,17 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   const hostTreeLayoutWidth = useTerminalHostTreeLayoutWidth();
   const toggleHostTree = useToggleTerminalHostTree();
   const activeTabId = useActiveTabId();
+  // Title/provider chrome: subscribe so presentation updates re-render TopTabs
+  // even when parent session arrays are treated as structurally equal.
+  const presentationVersion = useSyncExternalStore(
+    sessionPresentationStore.subscribe,
+    sessionPresentationStore.getVersion,
+    sessionPresentationStore.getVersion,
+  );
+  const sessions = useMemo(() => {
+    void presentationVersion;
+    return sessionsProp.map((session) => applySessionPresentation(session));
+  }, [sessionsProp, presentationVersion]);
   const { getTabAnimationClass } = useTopTabLifecycleAnimations(orderedTabs);
   const fixedLeftTabsRef = useRef<HTMLDivElement>(null);
   const hostTreeToggleSlotRef = useRef<HTMLDivElement>(null);
@@ -291,12 +307,17 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
     }
   }, [updateScrollState, orderedTabs]);
 
-  // Pre-compute lookup maps for O(1) access instead of O(n) find operations
+  // Pre-compute lookup maps for O(1) access instead of O(n) find operations.
+  // Merge live title/provider the same way as `sessions` so orphan tabs never
+  // freeze while agents stream presentation-only updates.
   const orphanSessionMap = useMemo(() => {
+    void presentationVersion;
     const map = new Map<string, TerminalSession>();
-    for (const s of orphanSessions) map.set(s.id, s);
+    for (const s of orphanSessions) {
+      map.set(s.id, applySessionPresentation(s));
+    }
     return map;
-  }, [orphanSessions]);
+  }, [orphanSessions, presentationVersion]);
 
   const workspaceMap = useMemo(() => {
     const map = new Map<string, Workspace>();
@@ -1173,15 +1194,20 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
 };
 
 // Custom comparison: only re-render when data props change - activeTabId is now managed internally via store subscription
-const topTabsAreEqual = (prev: TopTabsProps, next: TopTabsProps): boolean => {
+export const topTabsAreEqual = (prev: TopTabsProps, next: TopTabsProps): boolean => {
   return (
     prev.theme === next.theme &&
     prev.hosts === next.hosts &&
-    prev.sessions === next.sessions &&
-    prev.orphanSessions === next.orphanSessions &&
+    // Ignore presentation-only session fields; TopTabsInner merges live titles
+    // from sessionPresentationStore via useSyncExternalStore.
+    topTabsSessionsEqual(prev.sessions, next.sessions) &&
+    topTabsSessionsEqual(prev.orphanSessions, next.orphanSessions) &&
     prev.workspaces === next.workspaces &&
     prev.orderedTabs === next.orderedTabs &&
     prev.logViews === next.logViews &&
+    // Editor dirty chrome / renames ride the editorTabs array identity.
+    prev.editorTabs === next.editorTabs &&
+    prev.onRequestCloseEditorTab === next.onRequestCloseEditorTab &&
     prev.pluginViewTabs === next.pluginViewTabs &&
     prev.onClosePluginViewTab === next.onClosePluginViewTab &&
     prev.draggingSessionId === next.draggingSessionId &&
@@ -1201,7 +1227,8 @@ const topTabsAreEqual = (prev: TopTabsProps, next: TopTabsProps): boolean => {
     prev.onThemeChange === next.onThemeChange &&
     prev.showSftpTab === next.showSftpTab &&
     prev.showHostTreeSidebar === next.showHostTreeSidebar &&
-    prev.dynamicTabTitleMode === next.dynamicTabTitleMode
+    prev.dynamicTabTitleMode === next.dynamicTabTitleMode &&
+    prev.hostById === next.hostById
   );
 };
 

--- a/components/VaultView.memo.test.tsx
+++ b/components/VaultView.memo.test.tsx
@@ -15,7 +15,6 @@ test("VaultView re-renders when an external section navigation request changes",
     noteGroups: [],
     customGroups: [],
     knownHosts: [],
-    shellHistory: [],
     connectionLogs: [],
     sessions: [],
     managedSources: [],
@@ -34,6 +33,37 @@ test("VaultView re-renders when an external section navigation request changes",
   );
 });
 
+test("VaultView memo does not depend on shellHistory prop identity", () => {
+  const baseProps = {
+    hosts: [],
+    keys: [],
+    identities: [],
+    proxyProfiles: [],
+    snippets: [],
+    snippetPackages: [],
+    notes: [],
+    noteGroups: [],
+    customGroups: [],
+    knownHosts: [],
+    connectionLogs: [],
+    sessions: [],
+    managedSources: [],
+    groupConfigs: {},
+    terminalThemeId: "default",
+    terminalFontSize: 14,
+    navigateToSection: null,
+  };
+  // History-only updates must not be part of VaultView equality (store path).
+  assert.equal(
+    vaultViewAreEqual(baseProps as never, { ...baseProps } as never),
+    true,
+  );
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(baseProps, "shellHistory"),
+    false,
+  );
+});
+
 test("VaultView re-renders when proxy profiles change", () => {
   const baseProps = {
     hosts: [],
@@ -46,7 +76,6 @@ test("VaultView re-renders when proxy profiles change", () => {
     noteGroups: [],
     customGroups: [],
     knownHosts: [],
-    shellHistory: [],
     connectionLogs: [],
     sessions: [],
     managedSources: [],
@@ -87,7 +116,6 @@ test("VaultView re-renders when host-key verification setting changes", () => {
     noteGroups: [],
     customGroups: [],
     knownHosts: [],
-    shellHistory: [],
     connectionLogs: [],
     sessions: [],
     managedSources: [],

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -92,7 +92,6 @@ import {
   ProxyProfile,
   SerialConfig,
   SSHKey,
-  ShellHistoryEntry,
   Snippet,
   VaultNote,
 } from "../types";
@@ -215,7 +214,6 @@ interface VaultViewProps {
   noteGroups: string[];
   customGroups: string[];
   knownHosts: KnownHost[];
-  shellHistory: ShellHistoryEntry[];
   connectionLogs: ConnectionLog[];
   managedSources: ManagedSource[];
   sessionCount: number;
@@ -310,7 +308,6 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   noteGroups,
   customGroups,
   knownHosts,
-  shellHistory,
   connectionLogs,
   managedSources,
   sessionCount,
@@ -1615,7 +1612,6 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           setTargetParentPath,
           Settings,
           setViewMode,
-          shellHistory,
           shouldHideEmptyRootHostsSection,
           showRecentHosts,
           hostClickBehavior,
@@ -1682,7 +1678,7 @@ export const vaultViewAreEqual = (
     prev.noteGroups === next.noteGroups &&
     prev.customGroups === next.customGroups &&
     prev.knownHosts === next.knownHosts &&
-    prev.shellHistory === next.shellHistory &&
+    // shellHistory is not a VaultView prop; SnippetsManager reads shellHistoryStore.
     prev.connectionLogs === next.connectionLogs &&
     prev.sessionCount === next.sessionCount &&
     prev.managedSources === next.managedSources &&

--- a/components/terminalLayer/terminalLayerViewMemo.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { aiPanelContextsEqual } from '../../domain/aiPanelContextsEqual';
 import { sftpPickerSessionsEqual } from '../../domain/sftpConnectedHosts';
 
 type Ctx = Record<string, any>;
@@ -174,6 +175,9 @@ function sidePanelCtxKeyEqual(prev: Ctx, next: Ctx, key: string): boolean {
     // Focus-only workspace map identity changes must not invalidate every mounted
     // side-panel slot; System reads focused session from sidePanelLiveStore.
     return sidePanelWorkspaceByIdEqual(prev.workspaceById, next.workspaceById);
+  }
+  if (key === 'aiContextsByTabId') {
+    return aiPanelContextsEqual(prev.aiContextsByTabId, next.aiContextsByTabId);
   }
   return prev[key] === next[key];
 }

--- a/components/terminalLayer/useTerminalAiContexts.ts
+++ b/components/terminalLayer/useTerminalAiContexts.ts
@@ -1,6 +1,7 @@
 import type React from 'react';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
+import { retainStableAiPanelContexts } from '../../domain/aiPanelContextsEqual';
 import { collectSessionIds } from '../../domain/workspace';
 import type { TerminalContextReader } from '../../domain/terminalContextRead';
 import { detectLocalOs } from '../../lib/localShell';
@@ -34,6 +35,7 @@ export function useTerminalAiContexts({
   workspaces,
   workspacesRef,
 }: UseTerminalAiContextsOptions) {
+  const previousAiContextsRef = useRef<Map<string, AIPanelContext> | null>(null);
   const aiContextsByTabId = useMemo(() => {
     const localOs = detectLocalOs(navigator.userAgent || navigator.platform);
     const sessionById = new Map<string, TerminalSession>(sessions.map((session) => [session.id, session]));
@@ -85,7 +87,9 @@ export function useTerminalAiContexts({
       });
     }
 
-    return contexts;
+    const retained = retainStableAiPanelContexts(previousAiContextsRef.current, contexts);
+    previousAiContextsRef.current = retained;
+    return retained;
   }, [sessions, workspaces, mountedAiTabIds, sessionHostsMap, hosts, portForwardingRules]);
 
   const resolveAIExecutorContext = useCallback((scope: {

--- a/components/vault/VaultViewLayout.tsx
+++ b/components/vault/VaultViewLayout.tsx
@@ -233,7 +233,6 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
     setTargetParentPath,
     Settings,
     setViewMode,
-    shellHistory,
     shouldHideEmptyRootHostsSection,
     showRecentHosts,
     hostClickBehavior,
@@ -1143,7 +1142,6 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
                       packages={snippetPackages}
                       hosts={hosts}
                       customGroups={customGroups}
-                      shellHistory={shellHistory}
                       hotkeyScheme={hotkeyScheme}
                       keyBindings={keyBindings}
                       onPackagesChange={onUpdateSnippetPackages}

--- a/domain/aiPanelContextsEqual.test.ts
+++ b/domain/aiPanelContextsEqual.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  aiPanelContextsEqual,
+  retainStableAiPanelContexts,
+  type AIPanelContextLike,
+} from './aiPanelContextsEqual.ts';
+import type { AITerminalSessionInfo } from '../components/terminalLayer/buildAITerminalSessionInfo.ts';
+
+const sessionInfo = (overrides: Partial<AITerminalSessionInfo> = {}): AITerminalSessionInfo => ({
+  sessionId: 's1',
+  hostId: 'h1',
+  hostname: 'example.test',
+  label: 'example',
+  connected: true,
+  ...overrides,
+});
+
+const context = (
+  overrides: Partial<AIPanelContextLike> = {},
+): AIPanelContextLike => ({
+  scopeType: 'terminal',
+  scopeTargetId: 's1',
+  scopeHostIds: ['h1'],
+  scopeLabel: 'example',
+  terminalSessions: [sessionInfo()],
+  ...overrides,
+});
+
+test('aiPanelContextsEqual is true for structurally equal maps with different identity', () => {
+  const a = new Map([['s1', context()]]);
+  const b = new Map([['s1', context()]]);
+  assert.equal(aiPanelContextsEqual(a, b), true);
+  assert.equal(retainStableAiPanelContexts(a, b), a);
+});
+
+test('aiPanelContextsEqual is false when connection status changes', () => {
+  const a = new Map([['s1', context({ terminalSessions: [sessionInfo({ connected: true })] })]]);
+  const b = new Map([['s1', context({ terminalSessions: [sessionInfo({ connected: false })] })]]);
+  assert.equal(aiPanelContextsEqual(a, b), false);
+  assert.equal(retainStableAiPanelContexts(a, b), b);
+});
+
+test('aiPanelContextsEqual is false when port-forward status changes', () => {
+  const a = new Map([['s1', context({
+    terminalSessions: [sessionInfo({
+      activePortForwards: [{ ruleId: 'r1', status: 'active', localPort: 8080 }],
+    })],
+  })]]);
+  const b = new Map([['s1', context({
+    terminalSessions: [sessionInfo({
+      activePortForwards: [{ ruleId: 'r1', status: 'connecting', localPort: 8080 }],
+    })],
+  })]]);
+  assert.equal(aiPanelContextsEqual(a, b), false);
+});

--- a/domain/aiPanelContextsEqual.ts
+++ b/domain/aiPanelContextsEqual.ts
@@ -1,0 +1,122 @@
+import type { AITerminalSessionInfo } from '../components/terminalLayer/buildAITerminalSessionInfo';
+
+/** Minimal AI panel context shape used for structural equality. */
+export type AIPanelContextLike = {
+  scopeType: 'terminal' | 'workspace';
+  scopeTargetId?: string;
+  scopeHostIds: string[];
+  scopeLabel: string;
+  terminalSessions: AITerminalSessionInfo[];
+};
+
+function hostChainEqual(
+  a: AITerminalSessionInfo['hostChain'] | undefined,
+  b: AITerminalSessionInfo['hostChain'] | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (
+      a[i].hostId !== b[i].hostId
+      || a[i].label !== b[i].label
+      || a[i].hostname !== b[i].hostname
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function portForwardsEqual(
+  a: AITerminalSessionInfo['activePortForwards'] | undefined,
+  b: AITerminalSessionInfo['activePortForwards'] | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (
+      a[i].ruleId !== b[i].ruleId
+      || a[i].label !== b[i].label
+      || a[i].type !== b[i].type
+      || a[i].localPort !== b[i].localPort
+      || a[i].status !== b[i].status
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function aiTerminalSessionInfoEqual(
+  a: AITerminalSessionInfo,
+  b: AITerminalSessionInfo,
+): boolean {
+  return a.sessionId === b.sessionId
+    && a.hostId === b.hostId
+    && a.hostname === b.hostname
+    && a.label === b.label
+    && a.os === b.os
+    && a.username === b.username
+    && a.protocol === b.protocol
+    && a.shellType === b.shellType
+    && a.deviceType === b.deviceType
+    && a.connected === b.connected
+    && hostChainEqual(a.hostChain, b.hostChain)
+    && portForwardsEqual(a.activePortForwards, b.activePortForwards);
+}
+
+function scopeHostIdsEqual(a: string[], b: string[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function aiPanelContextEqual(a: AIPanelContextLike, b: AIPanelContextLike): boolean {
+  if (a === b) return true;
+  if (a.scopeType !== b.scopeType) return false;
+  if (a.scopeTargetId !== b.scopeTargetId) return false;
+  if (a.scopeLabel !== b.scopeLabel) return false;
+  if (!scopeHostIdsEqual(a.scopeHostIds, b.scopeHostIds)) return false;
+  if (a.terminalSessions.length !== b.terminalSessions.length) return false;
+  for (let i = 0; i < a.terminalSessions.length; i += 1) {
+    if (!aiTerminalSessionInfoEqual(a.terminalSessions[i], b.terminalSessions[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Structural equal for AI side-panel context maps. Ignores Map identity and
+ * presentation-only terminal noise by comparing AI-relevant session/host fields.
+ */
+export function aiPanelContextsEqual(
+  prev: Map<string, AIPanelContextLike> | null | undefined,
+  next: Map<string, AIPanelContextLike> | null | undefined,
+): boolean {
+  if (prev === next) return true;
+  if (!prev || !next) return false;
+  if (prev.size !== next.size) return false;
+  for (const [tabId, context] of prev) {
+    const other = next.get(tabId);
+    if (!other || !aiPanelContextEqual(context, other)) return false;
+  }
+  return true;
+}
+
+/**
+ * Return `next` unless it is structurally equal to `previous`, in which case
+ * keep the previous Map identity for React memo consumers.
+ */
+export function retainStableAiPanelContexts<T extends AIPanelContextLike>(
+  previous: Map<string, T> | null | undefined,
+  next: Map<string, T>,
+): Map<string, T> {
+  if (previous && aiPanelContextsEqual(previous, next)) {
+    return previous;
+  }
+  return next;
+}

--- a/domain/terminalPaneSessionsEqual.test.ts
+++ b/domain/terminalPaneSessionsEqual.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { terminalPaneSessionsEqual } from './terminalPaneSessionsEqual.ts';
+import {
+  retainStableSessionsIgnoringPresentation,
+  terminalPaneSessionsEqual,
+} from './terminalPaneSessionsEqual.ts';
 import type { TerminalSession } from './models.ts';
 
 const session = (overrides: Partial<TerminalSession> = {}): TerminalSession => ({
@@ -54,5 +57,15 @@ test('terminalPaneSessionsEqual detects pendingInitialCwd clear and startupComma
       [session({ startupCommand: 'top' })],
     ),
     false,
+  );
+});
+
+test('retainStableSessionsIgnoringPresentation keeps prior identity for title-only churn', () => {
+  const prev = [session({ dynamicTitle: 'old' })];
+  const next = [session({ dynamicTitle: 'new', codingCliProviderId: 'claude' })];
+  assert.equal(retainStableSessionsIgnoringPresentation(prev, next), prev);
+  assert.notEqual(
+    retainStableSessionsIgnoringPresentation(prev, [session({ status: 'connecting' })]),
+    prev,
   );
 });

--- a/domain/terminalPaneSessionsEqual.ts
+++ b/domain/terminalPaneSessionsEqual.ts
@@ -98,3 +98,18 @@ export function terminalPaneSessionsEqual(
   }
   return true;
 }
+
+/**
+ * Keep the previous sessions array identity when only TopTabs presentation
+ * fields changed. Used by App domain memos so title/provider live updates do
+ * not rebuild appTerminalDomain / appChromeDomain.
+ */
+export function retainStableSessionsIgnoringPresentation(
+  previous: readonly TerminalSession[] | null | undefined,
+  next: readonly TerminalSession[],
+): readonly TerminalSession[] {
+  if (previous && terminalPaneSessionsEqual(previous, next)) {
+    return previous;
+  }
+  return next;
+}

--- a/domain/topTabsSessionsEqual.ts
+++ b/domain/topTabsSessionsEqual.ts
@@ -1,0 +1,14 @@
+import { terminalPaneSessionsEqual } from './terminalPaneSessionsEqual';
+import type { TerminalSession } from './models';
+
+/**
+ * TopTabs session list equality: structural pane-critical fields only.
+ * Presentation (dynamicTitle / codingCliProviderId) is merged from
+ * sessionPresentationStore inside TopTabsInner.
+ */
+export function topTabsSessionsEqual(
+  prev: readonly TerminalSession[] | null | undefined,
+  next: readonly TerminalSession[] | null | undefined,
+): boolean {
+  return terminalPaneSessionsEqual(prev, next);
+}


### PR DESCRIPTION
## Summary

Land the next architecture isolation layer on top of the TerminalLayer store/memo work (#2621):

- **App mega-ctx** — domain-scoped `AppView` wiring (`vault` / `terminal` / `chrome` / `dialogs` / `mounts`) with `appViewDomainsEqual` memo so unrelated domain churn no longer rebuilds the whole shell bag.
- **TopTabs title store** — `sessionPresentationStore` for live `dynamicTitle` / coding-CLI provider chrome; store-only updates from `useSessionState` (no `setSessions` thrash); TopTabs merges presentation into both main sessions and **orphanSessionMap**; structural session equal for memo.
- **AI contexts** — `aiPanelContextsEqual` + `retainStableAiPanelContexts` so AI side-panel context Maps keep identity when only ignored presentation noise changes.
- **Vault shellHistory** — Vault/Snippets subscribe to `shellHistoryStore`; history is not a Vault domain/prop identity.

## Type of Change

- [x] Other (please describe): Performance / re-render isolation architecture

## Related Issue (optional)

N/A — stacks on #2621

## Changes Made

- Introduce `application/app/appViewDomains.ts` and rewire `App.tsx` → `AppView domains={...}`
- Add `sessionPresentationStore` + `applySessionPresentation`; title/provider publish is store-only; clear on session/workspace close
- `retainStableSessionsIgnoringPresentation` for domain session/orphan arrays
- TopTabs: presentation subscribe, orphan merge, `editorTabs` in `topTabsAreEqual`
- AI: structural equal/retain for panel contexts
- Vault: drop shellHistory prop path; isolation unit tests across surfaces

## Screenshots / Demo

N/A (render-isolation; no product UI change intended)

## Testing

- [x] Unit tests for shell-history isolation, TopTabs presentation, AI context equal, App domain helpers, TopTabs source guards
- [x] Linting passes on changed files (`npx eslint … --max-warnings 0`)
- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Full `npm test` suite
- [x] Generated capability tool specs N/A

## Checklist

- [x] Code follows existing project style
- [x] No intentional breaking API changes
- [x] Multi-agent review of tip returned **STOP** (no high-ROI same-PR leftovers)

## Stack

Base: `perf/terminal-layer-rerender-p0-p1` (#2621). Merge after that PR, or retarget to `main` once #2621 lands.