### PR TITLE
perf(app): cut remaining top-tab switch jank

### DIFF
--- a/application/app/AppActiveTabChrome.tsx
+++ b/application/app/AppActiveTabChrome.tsx
@@ -140,7 +140,19 @@ export function AppActiveTabChrome({
   }, [activeTabId, editorTabFileNameCounts, editorTabs, logViews, sessionById, t, workspaceById]);
 
   useEffect(() => {
-    void netcattyBridge.get()?.setWindowTitle?.(activeWindowTitle);
+    // Title is already memoized by activeTabId; skip redundant IPC when the
+    // string did not change (e.g. two tabs sharing the same host label).
+    let cancelled = false;
+    const bridge = netcattyBridge.get();
+    if (!bridge?.setWindowTitle) return;
+    // Defer slightly so the title write does not compete with tab-switch paint.
+    const timer = window.setTimeout(() => {
+      if (!cancelled) void bridge.setWindowTitle?.(activeWindowTitle);
+    }, 0);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
   }, [activeWindowTitle]);
 
   return null;

--- a/application/app/AppHostEditorLayer.tsx
+++ b/application/app/AppHostEditorLayer.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo, useState } from 'react';
 
 import type { WorkSurfaceHostEditorTarget } from '../state/useWorkSurfaceHostEditor';
+import type { EditorTabChrome } from '../state/editorTabStore';
+import type { LogView } from '../state/logViewState';
 import { useI18n } from '../i18n/I18nProvider';
 import HostDetailsPanel from '../../components/HostDetailsPanel';
 import SerialHostDetailsPanel from '../../components/SerialHostDetailsPanel';
@@ -15,7 +17,10 @@ import type {
   ProxyProfile,
   Snippet,
   SSHKey,
+  TerminalSession,
+  Workspace,
 } from '../../types';
+import { useWorkSurfaceVisible } from './AppHostEditorSurface';
 
 export type WorkSurfaceHostEditorKind = 'standard' | 'serial';
 
@@ -62,7 +67,8 @@ export function getAppHostEditorLayerStyle(surfaceVisible: boolean): React.CSSPr
 }
 
 interface AppHostEditorLayerProps {
-  surfaceVisible: boolean;
+  /** When omitted, surface visibility is derived from activeTabId in this leaf. */
+  surfaceVisible?: boolean;
   target: WorkSurfaceHostEditorTarget | null;
   editorKey: string | null;
   hosts: Host[];
@@ -75,6 +81,12 @@ interface AppHostEditorLayerProps {
   snippets: Snippet[];
   terminalThemeId: string;
   terminalFontSize: number;
+  /** Required when surfaceVisible is not passed (leaf active-tab subscription). */
+  sessions?: TerminalSession[];
+  workspaces?: Workspace[];
+  logViews?: readonly LogView[];
+  orderedTabs?: readonly string[];
+  editorTabs?: readonly EditorTabChrome[];
   onSave: (host: Host) => void;
   onCancel: () => void;
   onCreateGroup: (groupPath: string) => void;
@@ -83,7 +95,7 @@ interface AppHostEditorLayerProps {
 }
 
 export const AppHostEditorLayer: React.FC<AppHostEditorLayerProps> = ({
-  surfaceVisible,
+  surfaceVisible: surfaceVisibleProp,
   target,
   editorKey,
   hosts,
@@ -96,6 +108,10 @@ export const AppHostEditorLayer: React.FC<AppHostEditorLayerProps> = ({
   snippets,
   terminalThemeId,
   terminalFontSize,
+  sessions = [],
+  workspaces = [],
+  logViews = [],
+  orderedTabs = [],
   onSave,
   onCancel,
   onCreateGroup,
@@ -103,6 +119,15 @@ export const AppHostEditorLayer: React.FC<AppHostEditorLayerProps> = ({
   onUpdateSnippets,
 }) => {
   const { t } = useI18n();
+  const derivedSurfaceVisible = useWorkSurfaceVisible({
+    enabled: true,
+    sessions,
+    workspaces,
+    logViews,
+    orderedTabs,
+  });
+  // Prefer explicit prop only when provided, so existing tests keep control.
+  const surfaceVisible = surfaceVisibleProp ?? derivedSurfaceVisible;
   const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(null);
   const groups = useMemo(
     () => collectWorkSurfaceHostGroups(hosts, customGroups, groupConfigs),

--- a/application/app/AppHostEditorSurface.tsx
+++ b/application/app/AppHostEditorSurface.tsx
@@ -1,0 +1,51 @@
+import { useMemo } from 'react';
+
+import type { EditorTabChrome } from '../state/editorTabStore';
+import type { LogView } from '../state/logViewState';
+import type { TerminalSession, Workspace } from '../../types';
+import { useActiveTabId } from '../state/activeTabStore';
+import { isHostTreeWorkTabSurface } from './workTabSurface';
+
+/**
+ * Subscribes to activeTabId and exposes work-surface visibility without
+ * forcing the AppView shell to re-render on every top-tab switch.
+ */
+export function useWorkSurfaceVisible({
+  enabled,
+  sessions,
+  workspaces,
+  logViews,
+  orderedTabs,
+}: {
+  enabled: boolean;
+  sessions: TerminalSession[];
+  workspaces: Workspace[];
+  logViews: readonly LogView[];
+  orderedTabs: readonly string[];
+}): boolean {
+  const activeTabId = useActiveTabId();
+  const sessionIds = useMemo(
+    () => new Set(sessions.map((session) => session.id)),
+    [sessions],
+  );
+  const workspaceIds = useMemo(
+    () => new Set(workspaces.map((workspace) => workspace.id)),
+    [workspaces],
+  );
+  const logViewIds = useMemo(
+    () => new Set(logViews.map((logView) => logView.id)),
+    [logViews],
+  );
+
+  return useMemo(() => isHostTreeWorkTabSurface({
+    enabled,
+    activeTabId,
+    logViewIds,
+    orderedTabs,
+    sessionIds,
+    workspaceIds,
+  }), [activeTabId, enabled, logViewIds, orderedTabs, sessionIds, workspaceIds]);
+}
+
+/** Tiny marker export so tests can pin the isolation helper module. */
+export type WorkSurfaceEditorTabChrome = EditorTabChrome;

--- a/application/app/AppPluginKeybindingHost.tsx
+++ b/application/app/AppPluginKeybindingHost.tsx
@@ -1,0 +1,40 @@
+import React, { useMemo } from 'react';
+
+import { PluginContributionHost } from '../../components/plugins/PluginContributionHost';
+import type { TerminalSession, Workspace } from '../../types';
+import { useActiveTabId } from '../state/activeTabStore';
+import { resolveActivePluginKeybindingContext } from '../state/pluginContributionContexts';
+
+/**
+ * Leaf host for plugin keybindings so AppView does not subscribe to activeTabId.
+ * Tab switches only re-render this small surface (and plugin lifecycle), not the shell.
+ */
+export function AppPluginKeybindingHost({
+  locale,
+  theme,
+  themeTokens,
+  sessions,
+  workspaces,
+}: {
+  locale: string;
+  theme: string;
+  themeTokens?: Record<string, string>;
+  sessions: TerminalSession[];
+  workspaces: Workspace[];
+}) {
+  const activeTabId = useActiveTabId();
+  const keybindingContext = useMemo(() => resolveActivePluginKeybindingContext({
+    activeTabId,
+    sessions,
+    workspaces,
+  }), [activeTabId, sessions, workspaces]);
+
+  return (
+    <PluginContributionHost
+      locale={locale}
+      theme={theme}
+      themeTokens={themeTokens}
+      keybindingContext={keybindingContext}
+    />
+  );
+}

--- a/application/app/AppView.activeTabIsolation.test.ts
+++ b/application/app/AppView.activeTabIsolation.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const appViewSource = readFileSync(new URL("./AppView.tsx", import.meta.url), "utf8");
+const pluginHostSource = readFileSync(new URL("./AppPluginKeybindingHost.tsx", import.meta.url), "utf8");
+const editorSurfaceSource = readFileSync(new URL("./AppHostEditorSurface.tsx", import.meta.url), "utf8");
+
+test("AppView shell does not subscribe to useActiveTabId", () => {
+  // Top-tab switches must not rebuild the AppView shell. Leaves own the subscription.
+  assert.doesNotMatch(appViewSource, /useActiveTabId\s*\(/);
+  assert.doesNotMatch(appViewSource, /useActiveTabId/);
+  // Still uses activeTabStore for imperative tab close / neighbor activation.
+  assert.match(appViewSource, /activeTabStore/);
+});
+
+test("plugin keybindings and host-editor surface subscribe as leaves", () => {
+  assert.match(pluginHostSource, /useActiveTabId/);
+  assert.match(pluginHostSource, /resolveActivePluginKeybindingContext/);
+  assert.match(editorSurfaceSource, /useWorkSurfaceVisible/);
+  assert.match(editorSurfaceSource, /useActiveTabId/);
+  assert.match(appViewSource, /AppPluginKeybindingHost/);
+});

--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { Suspense, lazy, memo, useCallback, useEffect, useMemo } from 'react';
 import { AlertTriangle, Download, Trash2 } from 'lucide-react';
-import { activeTabStore, toEditorTabId, useActiveTabId, useIsEditorTabActive } from '../state/activeTabStore';
+import { activeTabStore, toEditorTabId, useIsEditorTabActive } from '../state/activeTabStore';
 import { editorTabStore } from '../state/editorTabStore';
 import { releaseEditorTabSaveCoordinator, saveEditorTab } from '../state/editorTabSave';
 import { useTerminalHostTreeLayoutWidth } from '../state/terminalHostTreeStore';
@@ -22,18 +22,16 @@ import { LazyLoadBoundary } from '../../components/ui/lazy-load-boundary';
 import { toast } from '../../components/ui/toast';
 import { AppHostTreeLayer } from './AppHostTreeLayer';
 import { AppHostEditorLayer } from './AppHostEditorLayer';
+import { AppPluginKeybindingHost } from './AppPluginKeybindingHost';
 import { getUiThemeById } from '../../infrastructure/config/uiThemes';
 import { buildAppThemeCssVars } from '../state/settingsStateDefaults';
 import { useMainWindowInputFocusRecovery } from '../state/useMainWindowInputFocusRecovery';
 import { useExternalMcpToggleState } from '../state/useExternalMcpToggleState';
-import { PluginContributionHost } from '../../components/plugins/PluginContributionHost';
-import { resolveActivePluginKeybindingContext } from '../state/pluginContributionContexts';
 import { selectPluginThemeTokens } from '../state/pluginContributionEnvironment';
 import { netcattyBridge } from '../../infrastructure/services/netcattyBridge';
 import { pluginViewTabStore, usePluginViewTabs } from '../state/pluginViewTabStore';
 import { buildPluginSettingScopeCatalog } from '../state/usePluginSettingScopeCatalog';
 import { useWorkSurfaceHostEditor } from '../state/useWorkSurfaceHostEditor';
-import { isHostTreeWorkTabSurface } from './workTabSurface';
 import {
   appViewDomainsEqual,
   mergeAppViewDomains,
@@ -72,7 +70,9 @@ export type AppViewProps = {
 };
 
 function AppViewInner({ domains }: AppViewProps) {
-  const activeTabId = useActiveTabId();
+  // Intentionally does NOT subscribe to activeTabId — leaf surfaces
+  // (TopTabs items, mounts, host tree, chrome, plugin keybindings) own that
+  // subscription so top-tab switches do not rebuild the App shell.
   const pluginViewTabs = usePluginViewTabs();
   // Merge domain slices once per AppView render. AppView only re-renders when a
   // domain slice identity changes (see appViewDomainsEqual). Depend on the
@@ -173,11 +173,6 @@ function AppViewInner({ domains }: AppViewProps) {
     } as React.CSSProperties;
   }, [accentMode, customAccent, resolvedTheme, settings.darkUiThemeId, settings.lightUiThemeId]);
 
-  const pluginKeybindingContext = useMemo(() => resolveActivePluginKeybindingContext({
-    activeTabId,
-    sessions,
-    workspaces,
-  }), [activeTabId, sessions, workspaces]);
   const pluginThemeTokens = useMemo(
     () => selectPluginThemeTokens(appThemeStyle as Record<string, unknown>),
     [appThemeStyle],
@@ -195,14 +190,6 @@ function AppViewInner({ domains }: AppViewProps) {
     onUpdateHosts: updateHosts,
     onSaved: handleWorkSurfaceHostSaved,
   });
-  const workSurfaceVisible = useMemo(() => isHostTreeWorkTabSurface({
-    enabled: true,
-    activeTabId,
-    logViewIds: new Set(logViews.map((logView: { id: string }) => logView.id)),
-    orderedTabs: orderedTabsWithEditors,
-    sessionIds: new Set(sessions.map((session: { id: string }) => session.id)),
-    workspaceIds: new Set(workspaces.map((workspace: { id: string }) => workspace.id)),
-  }), [activeTabId, logViews, orderedTabsWithEditors, sessions, workspaces]);
   const handleCreateWorkSurfaceHostGroup = useCallback((groupPath: string) => {
     updateCustomGroups(Array.from(new Set([...customGroups, groupPath])));
   }, [customGroups, updateCustomGroups]);
@@ -346,7 +333,6 @@ function AppViewInner({ domains }: AppViewProps) {
           onCreateLocalTerminal={handleCreateLocalTerminal}
         />
         <AppHostEditorLayer
-          surfaceVisible={workSurfaceVisible}
           target={workSurfaceHostEditor.target}
           editorKey={workSurfaceHostEditor.editorKey}
           hosts={hosts}
@@ -359,6 +345,10 @@ function AppViewInner({ domains }: AppViewProps) {
           snippets={snippets}
           terminalThemeId={terminalThemeId}
           terminalFontSize={terminalFontSize}
+          sessions={sessions}
+          workspaces={workspaces}
+          logViews={logViews}
+          orderedTabs={orderedTabsWithEditors}
           onSave={workSurfaceHostEditor.save}
           onCancel={workSurfaceHostEditor.close}
           onCreateGroup={handleCreateWorkSurfaceHostGroup}
@@ -587,11 +577,12 @@ function AppViewInner({ domains }: AppViewProps) {
           </LazyLoadBoundary>
         ))}
 
-        <PluginContributionHost
+        <AppPluginKeybindingHost
           locale={settings.uiLanguage}
           theme={resolvedTheme}
           themeTokens={pluginThemeTokens}
-          keybindingContext={pluginKeybindingContext}
+          sessions={sessions}
+          workspaces={workspaces}
         />
       </div>
 

--- a/application/state/activeChromeThemeSync.test.ts
+++ b/application/state/activeChromeThemeSync.test.ts
@@ -1,12 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-
 import { readFileSync } from "node:fs";
 
-test("active tab changes notify chrome theme before react subscribers", () => {
-  const storeSource = readFileSync(new URL("./activeTabStore.ts", import.meta.url), "utf8");
-  const syncSource = readFileSync(new URL("./activeChromeThemeSync.ts", import.meta.url), "utf8");
+const source = readFileSync(new URL("./activeChromeThemeSync.ts", import.meta.url), "utf8");
+const chromeThemeSource = readFileSync(new URL("./useActiveChromeTheme.ts", import.meta.url), "utf8");
+const storeSource = readFileSync(new URL("./activeTabStore.ts", import.meta.url), "utf8");
 
+test("active tab changes notify chrome theme before react subscribers", () => {
   const setActiveTabIdBody = storeSource.match(/setActiveTabId = \(id: string\) => \{[\s\S]*?\n {2}\};/)?.[0] ?? "";
   assert.match(setActiveTabIdBody, /this\.syncListeners\.forEach\(\(listener\) => listener\(id\)\)/);
   assert.match(setActiveTabIdBody, /this\.scheduleNotify\(\)/);
@@ -14,7 +14,21 @@ test("active tab changes notify chrome theme before react subscribers", () => {
     setActiveTabIdBody.indexOf("syncListeners.forEach") < setActiveTabIdBody.indexOf("scheduleNotify"),
     "sync chrome theme listeners must run before deferred react notify",
   );
-  assert.match(syncSource, /activeTabStore\.subscribeSync\(notifyActiveChromeThemeForTab\)/);
-  assert.match(syncSource, /isActiveChromeThemeResolvable/);
-  assert.match(syncSource, /clearTopTabsChromeThemeVars/);
+  assert.match(source, /activeTabStore\.subscribeSync\(notifyActiveChromeThemeForTab\)/);
+  assert.match(source, /isActiveChromeThemeResolvable/);
+  assert.match(source, /clearTopTabsChromeThemeVars/);
+});
+
+test("tab chrome notify defers apply via rAF and short-circuits on fingerprint", () => {
+  assert.match(source, /requestAnimationFrame/);
+  assert.match(source, /themeFingerprint/);
+  assert.match(source, /export function applyChromeThemeForTab/);
+  assert.match(source, /export function notifyActiveChromeThemeForTab/);
+  // Tab path must not use view transitions.
+  assert.doesNotMatch(source, /mode:\s*['"]view['"]/);
+});
+
+test("syncActiveChromeTheme applies terminal chrome with instant mode", () => {
+  assert.match(chromeThemeSource, /mode:\s*['"]instant['"]/);
+  assert.match(chromeThemeSource, /nextFingerprint === appliedFingerprint/);
 });

--- a/application/state/activeChromeThemeSync.ts
+++ b/application/state/activeChromeThemeSync.ts
@@ -5,7 +5,7 @@ import type { Host, TerminalSession, TerminalTheme, Workspace } from '../../type
 import { activeTabStore } from './activeTabStore';
 import type { EditorTabChrome } from './editorTabStore';
 import type { LogView } from './logViewState';
-import { syncActiveChromeTheme } from './useActiveChromeTheme';
+import { syncActiveChromeTheme, themeFingerprint } from './useActiveChromeTheme';
 
 export type ActiveChromeThemeDeps = {
   accentMode: 'theme' | 'custom';
@@ -23,19 +23,58 @@ export type ActiveChromeThemeDeps = {
 };
 
 let depsRef: ActiveChromeThemeDeps | null = null;
+let pendingRafId: number | null = null;
+let pendingActiveTabId: string | null = null;
 
 export function updateActiveChromeThemeDeps(deps: ActiveChromeThemeDeps): void {
   depsRef = deps;
 }
 
-export function notifyActiveChromeThemeForTab(activeTabId: string): void {
+/**
+ * Apply chrome theme for a tab. Short-circuits when the resolved theme
+ * fingerprint matches the already-applied chrome fingerprint so rapid tab
+ * clicks do not force style work. Tab switches always use instant mode via
+ * syncActiveChromeTheme (no view transitions).
+ */
+export function applyChromeThemeForTab(activeTabId: string): void {
   if (!depsRef || typeof document === 'undefined') return;
   if (activeTabId === 'vault' || activeTabId === 'sftp') {
     clearTopTabsChromeThemeVars();
   }
+  // Non-terminal tabs: React chrome effect clears overlay theme. Do not force
+  // a full style reset here on every vault/sftp click.
   if (!isActiveChromeThemeResolvable({ ...depsRef, activeTabId })) return;
   const activeTheme = resolveActiveChromeTheme({ ...depsRef, activeTabId });
+  // Fingerprint short-circuit is also inside syncActiveChromeTheme; check here
+  // so we avoid even building transition work when the theme is unchanged.
+  if (activeTheme) {
+    const nextFp = themeFingerprint(activeTheme);
+    const applied = document.documentElement.dataset.activeChromeTheme ?? null;
+    if (nextFp === applied) return;
+  }
   syncActiveChromeTheme(activeTheme, depsRef.applyAppTheme);
+}
+
+/**
+ * Schedule chrome theme apply on the next animation frame so click handlers
+ * and React commit are not blocked by :root CSS rewrites.
+ */
+export function notifyActiveChromeThemeForTab(activeTabId: string): void {
+  pendingActiveTabId = activeTabId;
+  if (typeof document === 'undefined') {
+    applyChromeThemeForTab(activeTabId);
+    return;
+  }
+  if (pendingRafId !== null) return;
+  const schedule = typeof requestAnimationFrame === 'function'
+    ? requestAnimationFrame
+    : (cb: FrameRequestCallback) => window.setTimeout(() => cb(0), 0) as unknown as number;
+  pendingRafId = schedule(() => {
+    pendingRafId = null;
+    const tabId = pendingActiveTabId;
+    pendingActiveTabId = null;
+    if (tabId != null) applyChromeThemeForTab(tabId);
+  });
 }
 
 activeTabStore.subscribeSync(notifyActiveChromeThemeForTab);

--- a/application/state/sessionRestoreState.test.ts
+++ b/application/state/sessionRestoreState.test.ts
@@ -5,6 +5,7 @@ import {
   buildAndWriteSessionRestorePayload,
   createInitialRestoredSessionState,
   mergeSessionRestoreCwd,
+  patchSessionRestoreActiveTabId,
   updateRestoredSessionStatusState,
   shouldPersistSessionRestoreState,
 } from "./sessionRestoreState.ts";
@@ -142,6 +143,61 @@ test("session restore flush writes through the same sanitized payload path", () 
   assert.equal("terminalData" in writes[0].sessions[0], false);
   assert.equal("transientPanelState" in writes[0].workspaces[0], false);
   assert.equal(writes[0].savedAt, 42);
+});
+
+test("patchSessionRestoreActiveTabId updates only activeTabId without rebuilding sessions", () => {
+  const writes: SessionRestorePayload[] = [];
+  const storage = {
+    write: (next: SessionRestorePayload) => {
+      writes.push(next);
+      return true;
+    },
+    read: () => payload,
+  };
+
+  const first = patchSessionRestoreActiveTabId({
+    activeTabId: "session-2",
+    now: 99,
+    cachedPayload: payload,
+    storage,
+  });
+  assert.equal(first.status, "patched");
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].activeTabId, "session-2");
+  assert.equal(writes[0].savedAt, 99);
+  // Sessions array identity preserved (no rebuild from live app state).
+  assert.equal(writes[0].sessions, payload.sessions);
+  assert.equal(writes[0].workspaces, payload.workspaces);
+
+  const second = patchSessionRestoreActiveTabId({
+    activeTabId: "session-2",
+    now: 100,
+    cachedPayload: writes[0],
+    storage,
+  });
+  assert.equal(second.status, "unchanged");
+  assert.equal(writes.length, 1);
+
+  const missing = patchSessionRestoreActiveTabId({
+    activeTabId: "session-3",
+    cachedPayload: null,
+    storage: { write: storage.write, read: () => null },
+  });
+  assert.equal(missing.status, "missing");
+});
+
+test("rapid active-tab patches do not call full payload builders", async () => {
+  // Structural: patch path only spreads the cached payload; full builds go
+  // through buildAndWriteSessionRestorePayload / buildPersistableSessionRestorePayload.
+  const { readFileSync } = await import("node:fs");
+  const source = readFileSync(new URL("./sessionRestoreState.ts", import.meta.url), "utf8");
+  assert.match(source, /export function patchSessionRestoreActiveTabId/);
+  assert.match(source, /activeTabId/);
+  // patch must not call buildSessionRestorePayload or walk sessions.
+  const patchStart = source.indexOf("export function patchSessionRestoreActiveTabId");
+  const patchBody = source.slice(patchStart, patchStart + 800);
+  assert.doesNotMatch(patchBody, /buildSessionRestorePayload/);
+  assert.doesNotMatch(patchBody, /buildPersistableSessionRestorePayload/);
 });
 
 test("session restore flush clears storage instead of writing when restore is disabled", () => {

--- a/application/state/sessionRestoreState.test.ts
+++ b/application/state/sessionRestoreState.test.ts
@@ -6,6 +6,7 @@ import {
   createInitialRestoredSessionState,
   mergeSessionRestoreCwd,
   patchSessionRestoreActiveTabId,
+  resolveSessionRestoreActiveTabWrite,
   updateRestoredSessionStatusState,
   shouldPersistSessionRestoreState,
 } from "./sessionRestoreState.ts";
@@ -152,7 +153,6 @@ test("patchSessionRestoreActiveTabId updates only activeTabId without rebuilding
       writes.push(next);
       return true;
     },
-    read: () => payload,
   };
 
   const first = patchSessionRestoreActiveTabId({
@@ -181,9 +181,72 @@ test("patchSessionRestoreActiveTabId updates only activeTabId without rebuilding
   const missing = patchSessionRestoreActiveTabId({
     activeTabId: "session-3",
     cachedPayload: null,
-    storage: { write: storage.write, read: () => null },
+    storage: { write: storage.write },
   });
   assert.equal(missing.status, "missing");
+  assert.equal(writes.length, 1);
+});
+
+test("resolveSessionRestoreActiveTabWrite forces full rebuild when cache is null", () => {
+  assert.deepEqual(
+    resolveSessionRestoreActiveTabWrite({ activeTabId: "new-tab", cachedPayload: null }),
+    { kind: "full" },
+  );
+  assert.deepEqual(
+    resolveSessionRestoreActiveTabWrite({ activeTabId: "ws-1", cachedPayload: payload }),
+    { kind: "noop" },
+  );
+  assert.deepEqual(
+    resolveSessionRestoreActiveTabWrite({ activeTabId: "session-2", cachedPayload: payload }),
+    { kind: "patch", base: payload },
+  );
+});
+
+test("null cache never patches from stale storage.read (would corrupt restore)", () => {
+  // Simulated: effect recreated after connect — lastFullPayload is null, but
+  // disk still has the pre-connect payload (missing the new session).
+  const staleOnDisk: SessionRestorePayload = {
+    ...payload,
+    sessions: [{ ...payload.sessions[0], id: "old-only" }],
+    activeTabId: "old-only",
+  };
+  let diskWrite: SessionRestorePayload | null = null;
+  const writes: SessionRestorePayload[] = [];
+
+  // Decision layer: must request full rebuild, not patch.
+  assert.equal(
+    resolveSessionRestoreActiveTabWrite({
+      activeTabId: "new-session-after-connect",
+      cachedPayload: null,
+    }).kind,
+    "full",
+  );
+
+  // Shipped patch helper must refuse to write stale sessions + new activeTabId.
+  const patched = patchSessionRestoreActiveTabId({
+    activeTabId: "new-session-after-connect",
+    now: 123,
+    cachedPayload: null,
+    storage: {
+      write: (next) => {
+        writes.push(next);
+        diskWrite = next;
+        return true;
+      },
+    },
+  });
+  assert.equal(patched.status, "missing");
+  assert.equal(writes.length, 0);
+  assert.equal(diskWrite, null);
+
+  // Contrast: if we wrongly patched from disk, restore would lose the new session.
+  const wrongBase = staleOnDisk;
+  const corrupt = {
+    ...wrongBase,
+    activeTabId: "new-session-after-connect",
+  };
+  assert.equal(corrupt.sessions.some((s) => s.id === "new-session-after-connect"), false);
+  assert.equal(corrupt.activeTabId, "new-session-after-connect");
 });
 
 test("rapid active-tab patches do not call full payload builders", async () => {
@@ -192,12 +255,14 @@ test("rapid active-tab patches do not call full payload builders", async () => {
   const { readFileSync } = await import("node:fs");
   const source = readFileSync(new URL("./sessionRestoreState.ts", import.meta.url), "utf8");
   assert.match(source, /export function patchSessionRestoreActiveTabId/);
+  assert.match(source, /export function resolveSessionRestoreActiveTabWrite/);
   assert.match(source, /activeTabId/);
-  // patch must not call buildSessionRestorePayload or walk sessions.
+  // patch must not call buildSessionRestorePayload or fall back to storage.read.
   const patchStart = source.indexOf("export function patchSessionRestoreActiveTabId");
-  const patchBody = source.slice(patchStart, patchStart + 800);
+  const patchBody = source.slice(patchStart, patchStart + 1200);
   assert.doesNotMatch(patchBody, /buildSessionRestorePayload/);
   assert.doesNotMatch(patchBody, /buildPersistableSessionRestorePayload/);
+  assert.doesNotMatch(patchBody, /storage\.read/);
 });
 
 test("session restore flush clears storage instead of writing when restore is disabled", () => {

--- a/application/state/sessionRestoreState.ts
+++ b/application/state/sessionRestoreState.ts
@@ -111,14 +111,39 @@ export function buildAndWriteSessionRestorePayload({
 }
 
 /**
- * Patch only activeTabId on an already-persisted restore payload.
- * Used on top-tab switches so we avoid rebuilding/serializing every session
- * just because the active tab id changed.
+ * Decide how to persist an active-tab change without rebuilding sessions.
+ *
+ * Only the in-memory last full payload is a safe base. Disk/storage may lag
+ * behind live sessions (e.g. connect opens a session and activates its tab
+ * before the debounced full write lands) — never patch from storage alone.
+ *
+ * - full: no trusted cache → caller must rebuild from live state
+ * - noop: cache already has this activeTabId
+ * - patch: cache is trusted; only activeTabId needs updating
+ */
+export function resolveSessionRestoreActiveTabWrite({
+  activeTabId,
+  cachedPayload,
+}: {
+  activeTabId: string;
+  cachedPayload: SessionRestorePayload | null;
+}): { kind: 'full' } | { kind: 'noop' } | { kind: 'patch'; base: SessionRestorePayload } {
+  if (!cachedPayload) return { kind: 'full' };
+  if (cachedPayload.activeTabId === activeTabId) return { kind: 'noop' };
+  return { kind: 'patch', base: cachedPayload };
+}
+
+/**
+ * Patch only activeTabId on a trusted in-memory full payload.
+ * Call only after resolveSessionRestoreActiveTabWrite returns kind: 'patch'.
  *
  * Returns:
  * - 'patched' when storage was written with a new activeTabId
- * - 'unchanged' when the cached/stored activeTabId already matches
- * - 'missing' when there is no base payload to patch (caller should full-write)
+ * - 'unchanged' when the cached activeTabId already matches
+ * - 'missing' when there is no trusted base payload (caller should full-write)
+ *
+ * Intentionally does NOT fall back to storage.read() — that can pair a new
+ * activeTabId with stale sessions and corrupt restore after crash.
  */
 export function patchSessionRestoreActiveTabId({
   activeTabId,
@@ -128,23 +153,21 @@ export function patchSessionRestoreActiveTabId({
 }: {
   activeTabId: string;
   now?: number;
-  /** In-memory last full payload; preferred over storage.read() for tab clicks. */
+  /** In-memory last full payload only — never substitute disk/storage here. */
   cachedPayload: SessionRestorePayload | null;
   storage: {
-    read?(): SessionRestorePayload | null;
     write(payload: SessionRestorePayload): boolean;
   };
 }): { status: 'patched' | 'unchanged' | 'missing'; payload: SessionRestorePayload | null } {
-  const base = cachedPayload
-    ?? (typeof storage.read === 'function' ? storage.read() : null);
-  if (!base) {
+  const decision = resolveSessionRestoreActiveTabWrite({ activeTabId, cachedPayload });
+  if (decision.kind === 'full') {
     return { status: 'missing', payload: null };
   }
-  if (base.activeTabId === activeTabId) {
-    return { status: 'unchanged', payload: base };
+  if (decision.kind === 'noop') {
+    return { status: 'unchanged', payload: cachedPayload };
   }
   const next: SessionRestorePayload = {
-    ...base,
+    ...decision.base,
     activeTabId,
     savedAt: now,
   };

--- a/application/state/sessionRestoreState.ts
+++ b/application/state/sessionRestoreState.ts
@@ -110,6 +110,48 @@ export function buildAndWriteSessionRestorePayload({
   return storage.write(payload);
 }
 
+/**
+ * Patch only activeTabId on an already-persisted restore payload.
+ * Used on top-tab switches so we avoid rebuilding/serializing every session
+ * just because the active tab id changed.
+ *
+ * Returns:
+ * - 'patched' when storage was written with a new activeTabId
+ * - 'unchanged' when the cached/stored activeTabId already matches
+ * - 'missing' when there is no base payload to patch (caller should full-write)
+ */
+export function patchSessionRestoreActiveTabId({
+  activeTabId,
+  now = Date.now(),
+  cachedPayload,
+  storage,
+}: {
+  activeTabId: string;
+  now?: number;
+  /** In-memory last full payload; preferred over storage.read() for tab clicks. */
+  cachedPayload: SessionRestorePayload | null;
+  storage: {
+    read?(): SessionRestorePayload | null;
+    write(payload: SessionRestorePayload): boolean;
+  };
+}): { status: 'patched' | 'unchanged' | 'missing'; payload: SessionRestorePayload | null } {
+  const base = cachedPayload
+    ?? (typeof storage.read === 'function' ? storage.read() : null);
+  if (!base) {
+    return { status: 'missing', payload: null };
+  }
+  if (base.activeTabId === activeTabId) {
+    return { status: 'unchanged', payload: base };
+  }
+  const next: SessionRestorePayload = {
+    ...base,
+    activeTabId,
+    savedAt: now,
+  };
+  storage.write(next);
+  return { status: 'patched', payload: next };
+}
+
 export function mergeSessionRestoreCwd(
   payload: SessionRestorePayload,
   sessionId: string,

--- a/application/state/useSessionState.activeTabPersist.test.ts
+++ b/application/state/useSessionState.activeTabPersist.test.ts
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./useSessionState.ts", import.meta.url), "utf8");
+
+test("active-tab changes use patchSessionRestoreActiveTabId not full schedulePersist", () => {
+  assert.match(source, /patchSessionRestoreActiveTabId/);
+  assert.match(source, /scheduleActiveTabPatch/);
+  // Active-tab subscription must call the patch scheduler, not the full persist.
+  assert.match(
+    source,
+    /activeTabStore\.subscribeSync\(scheduleActiveTabPatch\)/,
+  );
+  // Full structural persist remains for sessions/workspaces/tabOrder + pagehide.
+  assert.match(source, /scheduleSessionRestorePersistRef\.current = schedulePersist/);
+  assert.match(source, /pagehide/);
+  assert.match(source, /beforeunload/);
+});

--- a/application/state/useSessionState.activeTabPersist.test.ts
+++ b/application/state/useSessionState.activeTabPersist.test.ts
@@ -2,7 +2,36 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
+import {
+  buildAndWriteSessionRestorePayload,
+  patchSessionRestoreActiveTabId,
+  resolveSessionRestoreActiveTabWrite,
+} from "./sessionRestoreState.ts";
+import type { SessionRestorePayload } from "../../domain/sessionRestore.ts";
+
 const source = readFileSync(new URL("./useSessionState.ts", import.meta.url), "utf8");
+
+const basePayload: SessionRestorePayload = {
+  version: 1,
+  savedAt: 1,
+  activeTabId: "ws-1",
+  tabOrder: ["ws-1"],
+  sessions: [{
+    id: "s1",
+    hostId: "host-s1",
+    hostLabel: "Host s1",
+    hostname: "s1.example.test",
+    username: "root",
+    status: "disconnected",
+    workspaceId: "ws-1",
+    restoreState: "restored-disconnected",
+  }],
+  workspaces: [{
+    id: "ws-1",
+    title: "Workspace",
+    root: { id: "pane-1", type: "pane", sessionId: "s1" },
+  }],
+};
 
 test("active-tab changes use patchSessionRestoreActiveTabId not full schedulePersist", () => {
   assert.match(source, /patchSessionRestoreActiveTabId/);
@@ -16,4 +45,103 @@ test("active-tab changes use patchSessionRestoreActiveTabId not full schedulePer
   assert.match(source, /scheduleSessionRestorePersistRef\.current = schedulePersist/);
   assert.match(source, /pagehide/);
   assert.match(source, /beforeunload/);
+  // Null cache must re-schedule full persist, never storage.read as patch base.
+  assert.match(source, /if \(!lastFullPayload\)/);
+  assert.match(source, /schedulePersist\(\)/);
+  assert.doesNotMatch(
+    source.slice(source.indexOf("scheduleActiveTabPatch"), source.indexOf("scheduleActiveTabPatch") + 900),
+    /sessionRestoreStorage\.read/,
+  );
+});
+
+/**
+ * Drives the shipped decision + write helpers the way useSessionState does:
+ * - after sessions change, lastFullPayload is null (effect recreated)
+ * - disk still has the previous (stale) snapshot
+ * - active tab flips to a new session id
+ * Correct path: kind 'full' → buildAndWriteSessionRestorePayload from LIVE state.
+ * Wrong path: patch from disk → old sessions + new activeTabId.
+ */
+test("null cache with stale disk forces full rebuild from live sessions (shipped path)", () => {
+  const staleOnDisk: SessionRestorePayload = {
+    ...basePayload,
+    sessions: [{ ...basePayload.sessions[0], id: "pre-connect-only" }],
+    tabOrder: ["pre-connect-only"],
+    activeTabId: "pre-connect-only",
+  };
+
+  // Live state after connect (what persistNow would serialize).
+  const liveSessions = [
+    staleOnDisk.sessions[0],
+    {
+      id: "new-session-after-connect",
+      hostId: "host-new",
+      hostLabel: "New host",
+      hostname: "new.example.test",
+      username: "root",
+      status: "disconnected" as const,
+    },
+  ];
+  const liveWorkspaces = basePayload.workspaces;
+  const liveTabOrder = ["pre-connect-only", "new-session-after-connect"];
+  const activeTabId = "new-session-after-connect";
+
+  // 1) Decision: no trusted cache → full.
+  const decision = resolveSessionRestoreActiveTabWrite({
+    activeTabId,
+    cachedPayload: null,
+  });
+  assert.equal(decision.kind, "full");
+
+  // 2) Patch helper must not write when cache is null (even if disk is full of data).
+  const patchWrites: SessionRestorePayload[] = [];
+  const patchResult = patchSessionRestoreActiveTabId({
+    activeTabId,
+    cachedPayload: null,
+    storage: {
+      write: (next) => {
+        patchWrites.push(next);
+        return true;
+      },
+    },
+  });
+  assert.equal(patchResult.status, "missing");
+  assert.equal(patchWrites.length, 0);
+
+  // 3) Full rebuild from live state (what schedulePersist → persistNow does).
+  const fullWrites: SessionRestorePayload[] = [];
+  const wrote = buildAndWriteSessionRestorePayload({
+    sessions: liveSessions,
+    workspaces: liveWorkspaces,
+    tabOrder: liveTabOrder,
+    activeTabId,
+    now: 500,
+    storage: {
+      write: (next) => {
+        fullWrites.push(next);
+        return true;
+      },
+      clear: () => {
+        throw new Error("should not clear when live state is non-empty");
+      },
+    },
+  });
+  assert.equal(wrote, true);
+  assert.equal(fullWrites.length, 1);
+  assert.equal(fullWrites[0].activeTabId, "new-session-after-connect");
+  assert.ok(
+    fullWrites[0].sessions.some((s) => s.id === "new-session-after-connect"),
+    "full rebuild must include the newly connected session",
+  );
+
+  // 4) Prove the corruption that storage-backed patch would have caused.
+  const corruptIfPatchedFromDisk = {
+    ...staleOnDisk,
+    activeTabId: "new-session-after-connect",
+  };
+  assert.equal(
+    corruptIfPatchedFromDisk.sessions.some((s) => s.id === "new-session-after-connect"),
+    false,
+    "stale-disk patch would drop the new session from restore",
+  );
 });

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -51,9 +51,11 @@ import { sessionRestoreStorage } from './sessionRestoreStorage';
 import {
   buildAndWriteSessionRestorePayload,
   createInitialRestoredSessionState,
+  patchSessionRestoreActiveTabId,
   shouldPersistSessionRestoreState,
   updateRestoredSessionStatusState,
 } from './sessionRestoreState';
+import type { SessionRestorePayload } from '../../domain/sessionRestore';
 import { resolveRestorePreviousSessionSetting } from './sessionRestoreSettings';
 import type { CodingCliProviderId } from '../../domain/codingCliProviders';
 import { normalizeCodingCliDynamicTitleForStorage } from '../../domain/codingCliTitleParse';
@@ -291,6 +293,10 @@ export const useSessionState = ({
     }
 
     let timeout: number | undefined;
+    let activeTabPatchTimeout: number | undefined;
+    // Last full restore payload written this session. Tab switches patch only
+    // activeTabId against this cache instead of re-serializing every session.
+    let lastFullPayload: SessionRestorePayload | null = null;
 
     const persistNow = () => {
       const sessionsForRestore = sessionsRef.current.map((session) => {
@@ -308,7 +314,7 @@ export const useSessionState = ({
         tabOrderRef.current,
       );
       const clearOnEmpty = hasSeenRestorableSessionRestoreStateRef.current && !hasRestorableState;
-      buildAndWriteSessionRestorePayload({
+      const wrote = buildAndWriteSessionRestorePayload({
         restoreEnabled: resolveRestorePreviousSessionSetting(
           localStorageAdapter.readBoolean(STORAGE_KEY_RESTORE_PREVIOUS_SESSION),
         ),
@@ -317,8 +323,20 @@ export const useSessionState = ({
         workspaces: workspacesRef.current,
         tabOrder: tabOrderRef.current,
         activeTabId: activeTabStore.getActiveTabId(),
-        storage: sessionRestoreStorage,
+        storage: {
+          write: (payload) => {
+            lastFullPayload = payload;
+            return sessionRestoreStorage.write(payload);
+          },
+          clear: () => {
+            lastFullPayload = null;
+            sessionRestoreStorage.clear();
+          },
+        },
       });
+      if (!wrote && !hasRestorableState) {
+        lastFullPayload = null;
+      }
     };
 
     const schedulePersist = () => {
@@ -331,14 +349,44 @@ export const useSessionState = ({
       }, 250);
     };
 
+    const scheduleActiveTabPatch = () => {
+      // Coalesce rapid tab clicks; never rebuild the full session tree here.
+      if (activeTabPatchTimeout !== undefined) {
+        window.clearTimeout(activeTabPatchTimeout);
+      }
+      activeTabPatchTimeout = window.setTimeout(() => {
+        activeTabPatchTimeout = undefined;
+        const activeTabId = activeTabStore.getActiveTabId();
+        const result = patchSessionRestoreActiveTabId({
+          activeTabId,
+          cachedPayload: lastFullPayload,
+          storage: {
+            read: () => sessionRestoreStorage.read(),
+            write: (payload) => {
+              lastFullPayload = payload;
+              return sessionRestoreStorage.write(payload);
+            },
+          },
+        });
+        if (result.status === "missing") {
+          // No base payload yet (first tab after empty) — fall back to full write.
+          persistNow();
+        }
+      }, 100);
+    };
+
     schedulePersist();
     scheduleSessionRestorePersistRef.current = schedulePersist;
-    const unsubscribeActiveTab = activeTabStore.subscribeSync(schedulePersist);
+    const unsubscribeActiveTab = activeTabStore.subscribeSync(scheduleActiveTabPatch);
 
     const handlePageHide = () => {
       if (timeout !== undefined) {
         window.clearTimeout(timeout);
         timeout = undefined;
+      }
+      if (activeTabPatchTimeout !== undefined) {
+        window.clearTimeout(activeTabPatchTimeout);
+        activeTabPatchTimeout = undefined;
       }
       persistNow();
     };
@@ -350,6 +398,9 @@ export const useSessionState = ({
       scheduleSessionRestorePersistRef.current = () => {};
       if (timeout !== undefined) {
         window.clearTimeout(timeout);
+      }
+      if (activeTabPatchTimeout !== undefined) {
+        window.clearTimeout(activeTabPatchTimeout);
       }
       unsubscribeActiveTab();
       window.removeEventListener("pagehide", handlePageHide);

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -350,18 +350,26 @@ export const useSessionState = ({
     };
 
     const scheduleActiveTabPatch = () => {
-      // Coalesce rapid tab clicks; never rebuild the full session tree here.
+      // Coalesce rapid tab clicks. Only patch when we hold a trusted full payload
+      // written by persistNow in this effect. Never storage.read() as a base —
+      // disk can still have pre-connect sessions while live already added a host
+      // and activated its tab (effect recreated, lastFullPayload reset to null).
       if (activeTabPatchTimeout !== undefined) {
         window.clearTimeout(activeTabPatchTimeout);
       }
       activeTabPatchTimeout = window.setTimeout(() => {
         activeTabPatchTimeout = undefined;
         const activeTabId = activeTabStore.getActiveTabId();
+        if (!lastFullPayload) {
+          // Cache empty after effect recreate or before first full write — rebuild
+          // from live sessions/workspaces (debounced with other structural persists).
+          schedulePersist();
+          return;
+        }
         const result = patchSessionRestoreActiveTabId({
           activeTabId,
           cachedPayload: lastFullPayload,
           storage: {
-            read: () => sessionRestoreStorage.read(),
             write: (payload) => {
               lastFullPayload = payload;
               return sessionRestoreStorage.write(payload);
@@ -369,8 +377,7 @@ export const useSessionState = ({
           },
         });
         if (result.status === "missing") {
-          // No base payload yet (first tab after empty) — fall back to full write.
-          persistNow();
+          schedulePersist();
         }
       }, 100);
     };

--- a/components/TopTabs.test.ts
+++ b/components/TopTabs.test.ts
@@ -571,14 +571,13 @@ test("host tree toggle is hidden on root pages", () => {
   }), false);
 });
 
-test("TopTabs merges presentation store into orphanSessionMap and sessions", () => {
-  assert.match(topTabsSource, /applySessionPresentation/);
-  assert.match(topTabsSource, /sessionPresentationStore\.subscribe/);
-  assert.match(topTabsSource, /presentationVersion/);
-  assert.ok(
-    topTabsSource.includes("map.set(s.id, applySessionPresentation(s))"),
-    "orphanSessionMap must overlay store presentation like sessions",
-  );
+test("TopTabs applies presentation per session tab, not via global version fan-out", () => {
+  // Global presentationVersion remapping was removed to stop sibling title
+  // thrash from re-rendering the whole tab bar.
+  assert.doesNotMatch(topTabsSource, /presentationVersion/);
+  assert.doesNotMatch(topTabsSource, /sessionPresentationStore\.subscribe/);
+  const topTabItemsSource = readFileSync(new URL("./top-tabs/TopTabItems.tsx", import.meta.url), "utf8");
+  assert.match(topTabItemsSource, /usePresentedSession/);
 });
 
 test("topTabsAreEqual tracks editorTabs for dirty chrome", () => {

--- a/components/TopTabs.test.ts
+++ b/components/TopTabs.test.ts
@@ -578,6 +578,25 @@ test("TopTabs applies presentation per session tab, not via global version fan-o
   assert.doesNotMatch(topTabsSource, /sessionPresentationStore\.subscribe/);
   const topTabItemsSource = readFileSync(new URL("./top-tabs/TopTabItems.tsx", import.meta.url), "utf8");
   assert.match(topTabItemsSource, /usePresentedSession/);
+  // Workspace detach menu must also apply presentation per session so labels
+  // stay live without remapping TopTabsInner.
+  assert.match(topTabItemsSource, /WorkspaceDetachSessionMenuItem/);
+  assert.match(topTabsSource, /workspaceSessions=/);
+  assert.doesNotMatch(topTabsSource, /workspaceSessionLabels/);
+});
+
+test("tab-switch focus calls refocus primitive directly without outer rAF wrap", () => {
+  const effectsSource = readFileSync(
+    new URL("./terminalLayer/useTerminalLayerEffects.ts", import.meta.url),
+    "utf8",
+  );
+  const focusBlock = effectsSource.slice(
+    effectsSource.indexOf("Restore keyboard focus after switching work tabs"),
+    effectsSource.indexOf("When focusedSessionId changes"),
+  );
+  assert.match(focusBlock, /refocusActiveTerminalSession\(\)/);
+  // Outer rAF wrapper was removed — focusTerminalSessionInput already schedules.
+  assert.doesNotMatch(focusBlock, /requestAnimationFrame\(\(\) => \{\s*refocusActiveTerminalSession/);
 });
 
 test("topTabsAreEqual tracks editorTabs for dirty chrome", () => {

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -5,7 +5,6 @@ import { topTabsSessionsEqual } from '../domain/topTabsSessionsEqual';
 import { isHostTreeWorkTabSurface } from '../application/app/workTabSurface';
 import type { EditorTabChrome } from '../application/state/editorTabStore';
 import { collectSessionIds } from '../domain/workspace';
-import { resolveSessionTabTitle } from '../domain/sessionTabTitle';
 import type { DynamicTabTitleMode } from '../domain/models';
 
 import { getTopTabInsertionTarget, getWorkspaceSessionDragId, hasWorkspaceSessionDrag } from '../application/state/terminalDragData';
@@ -832,16 +831,11 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
         const showDropIndicatorBefore = dropIndicator?.tabId === workspace.id && dropIndicator.position === 'before';
         const showDropIndicatorAfter = dropIndicator?.tabId === workspace.id && dropIndicator.position === 'after';
         const workspaceSessionIds = collectSessionIds(workspace.root);
-        const workspaceSessionLabels: Record<string, string> = {};
-        for (const sessionId of workspaceSessionIds) {
-          const wsSession = sessions.find((s) => s.id === sessionId);
-          if (wsSession) {
-            workspaceSessionLabels[sessionId] = resolveSessionTabTitle(
-              wsSession,
-              dynamicTabTitleMode,
-            );
-          }
-        }
+        // Detach-menu labels resolve presentation inside WorkspaceTopTab so
+        // dynamic title updates stay live without remapping the whole bar.
+        const workspaceSessions = workspaceSessionIds
+          .map((sessionId) => sessions.find((s) => s.id === sessionId))
+          .filter((s): s is TerminalSession => Boolean(s));
 
         return (
           <WorkspaceTopTab
@@ -849,6 +843,8 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
             workspace={workspace}
             paneCount={paneCount}
             workspaceSessionIds={workspaceSessionIds}
+            workspaceSessions={workspaceSessions}
+            dynamicTabTitleMode={dynamicTabTitleMode}
             isBeingDragged={isBeingDragged}
             isDraggingForReorder={isDraggingForReorder}
             shiftStyle={shiftStyle}
@@ -863,7 +859,6 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
             onCopyWorkspace={onCopyWorkspace}
             onCloseWorkspace={onCloseWorkspace}
             onDetachSessionFromWorkspace={(_workspaceId, sessionId) => onRemoveSessionFromWorkspace(sessionId)}
-            workspaceSessionLabels={workspaceSessionLabels}
             renderBulkCloseItems={renderBulkCloseItems}
             t={t}
             tabAnimationClass={getTabAnimationClass(workspace.id)}

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -1,10 +1,6 @@
 import { Folder, FolderLock, Menu, MoreHorizontal, Plus, Settings, Sparkles, Terminal } from 'lucide-react';
-import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { fromEditorTabId, isEditorTabId, useActiveTabId } from '../application/state/activeTabStore';
-import {
-  applySessionPresentation,
-  sessionPresentationStore,
-} from '../application/state/sessionPresentationStore';
 import { topTabsSessionsEqual } from '../domain/topTabsSessionsEqual';
 import { isHostTreeWorkTabSurface } from '../application/app/workTabSurface';
 import type { EditorTabChrome } from '../application/state/editorTabStore';
@@ -218,17 +214,10 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   const hostTreeLayoutWidth = useTerminalHostTreeLayoutWidth();
   const toggleHostTree = useToggleTerminalHostTree();
   const activeTabId = useActiveTabId();
-  // Title/provider chrome: subscribe so presentation updates re-render TopTabs
-  // even when parent session arrays are treated as structurally equal.
-  const presentationVersion = useSyncExternalStore(
-    sessionPresentationStore.subscribe,
-    sessionPresentationStore.getVersion,
-    sessionPresentationStore.getVersion,
-  );
-  const sessions = useMemo(() => {
-    void presentationVersion;
-    return sessionsProp.map((session) => applySessionPresentation(session));
-  }, [sessionsProp, presentationVersion]);
+  // Presentation (dynamic title / coding-CLI icon) is applied per-tab inside
+  // SessionTopTab via usePresentedSession — do not remap the whole bar on
+  // every sibling title tick.
+  const sessions = sessionsProp;
   const { getTabAnimationClass } = useTopTabLifecycleAnimations(orderedTabs);
   const fixedLeftTabsRef = useRef<HTMLDivElement>(null);
   const hostTreeToggleSlotRef = useRef<HTMLDivElement>(null);
@@ -307,16 +296,14 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   }, [updateScrollState, orderedTabs]);
 
   // Pre-compute lookup maps for O(1) access instead of O(n) find operations.
-  // Merge live title/provider the same way as `sessions` so orphan tabs never
-  // freeze while agents stream presentation-only updates.
+  // Presentation overlay is applied inside SessionTopTab, not here.
   const orphanSessionMap = useMemo(() => {
-    void presentationVersion;
     const map = new Map<string, TerminalSession>();
     for (const s of orphanSessions) {
-      map.set(s.id, applySessionPresentation(s));
+      map.set(s.id, s);
     }
     return map;
-  }, [orphanSessions, presentationVersion]);
+  }, [orphanSessions]);
 
   const workspaceMap = useMemo(() => {
     const map = new Map<string, Workspace>();
@@ -1200,8 +1187,8 @@ export const topTabsAreEqual = (prev: TopTabsProps, next: TopTabsProps): boolean
   return (
     prev.theme === next.theme &&
     prev.hosts === next.hosts &&
-    // Ignore presentation-only session fields; TopTabsInner merges live titles
-    // from sessionPresentationStore via useSyncExternalStore.
+    // Ignore presentation-only session fields; SessionTopTab merges live titles
+    // via usePresentedSession (per-tab snapshot).
     topTabsSessionsEqual(prev.sessions, next.sessions) &&
     topTabsSessionsEqual(prev.orphanSessions, next.orphanSessions) &&
     prev.workspaces === next.workspaces &&

--- a/components/terminal/hibernateWakeChunking.test.ts
+++ b/components/terminal/hibernateWakeChunking.test.ts
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+import { applyHibernateWakeToTerminal } from "./terminalHibernateRuntime.ts";
+import { writeTerminalPayloadChunked } from "./terminalReplay.ts";
+
+test("writeTerminalPayloadChunked splits large buffers (shipped wake helper)", async () => {
+  const writes: string[] = [];
+  const term = {
+    write: (data: string, cb: () => void) => {
+      writes.push(data);
+      cb();
+    },
+  } as unknown as XTerm;
+
+  const payload = "y".repeat(50_000);
+  await writeTerminalPayloadChunked(term, payload, { chunkBytes: 8_192 });
+  assert.ok(writes.length >= 2, `expected multiple chunks, got ${writes.length}`);
+  assert.equal(writes.join(""), payload);
+});
+
+test("applyHibernateWakeToTerminal defers scrollback to idle and chunks viewport first", async () => {
+  const writes: string[] = [];
+  const term = {
+    rows: 24,
+    write: (data: string, cb?: () => void) => {
+      writes.push(data);
+      cb?.();
+    },
+    refresh: () => {},
+  } as unknown as XTerm;
+
+  const runtime = {
+    ensureWebglRenderer: () => {},
+    clearTextureAtlas: () => {},
+  };
+
+  let idleScheduled = false;
+  const originalRic = globalThis.requestIdleCallback;
+  // @ts-expect-error test override
+  globalThis.requestIdleCallback = (cb: () => void) => {
+    idleScheduled = true;
+    // Do not run immediately — proves scrollback is deferred off the wake path.
+    setTimeout(cb, 0);
+    return 1;
+  };
+
+  try {
+    const viewport = "VIEWPORT";
+    const scrollback = "S".repeat(40_000);
+    await applyHibernateWakeToTerminal(
+      term,
+      runtime as never,
+      {
+        snapshot: viewport,
+        viewportSnapshot: viewport,
+        scrollbackSnapshot: scrollback,
+        pendingBuffer: "",
+        alternateScreen: false,
+      },
+      { replayOptions: { chunkBytes: 8_192 } },
+    );
+
+    // Viewport written on the wake path; scrollback scheduled idle.
+    assert.ok(writes.join("").includes(viewport));
+    assert.equal(idleScheduled, true);
+    assert.ok(
+      !writes.join("").includes(scrollback.slice(0, 1000)),
+      "scrollback must not be written synchronously on wake",
+    );
+
+    // Flush idle callback.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.ok(writes.join("").includes(scrollback.slice(0, 100)), "scrollback eventually applied");
+  } finally {
+    if (originalRic) {
+      globalThis.requestIdleCallback = originalRic;
+    } else {
+      // @ts-expect-error cleanup
+      delete globalThis.requestIdleCallback;
+    }
+  }
+});
+
+test("hibernate runtime source schedules scrollback via requestIdleCallback", () => {
+  const source = readFileSync(new URL("./terminalHibernateRuntime.ts", import.meta.url), "utf8");
+  assert.match(source, /requestIdleCallback|scheduleIdle/);
+  assert.match(source, /writeTerminalPayloadChunked\(term, scrollback/);
+  assert.match(source, /writeTerminalReplaySequence\(term, \[viewport, payload\.pendingBuffer\]/);
+});

--- a/components/terminalLayer/TerminalLayerWorkspaceSection.liveStore.test.ts
+++ b/components/terminalLayer/TerminalLayerWorkspaceSection.liveStore.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./TerminalLayerWorkspaceSection.tsx", import.meta.url),
+  "utf8",
+);
+
+test("workspace section uses live store only for activeWorkspace (no stale ctx fallback)", () => {
+  // After view memo omits activeWorkspace from equality, ctx can lag behind
+  // live when switching workspace → solo session (live clears to undefined).
+  // `live.x ?? ctx.x` would keep the old workspace for compose bar / resizers.
+  assert.match(source, /sidePanelLiveStore\.getSnapshot/);
+  assert.match(source, /const activeWorkspace = live\.activeWorkspace;/);
+  assert.match(source, /const focusedSessionId = live\.focusedSessionId;/);
+  assert.doesNotMatch(source, /live\.activeWorkspace\s*\?\?/);
+  assert.doesNotMatch(source, /live\.focusedSessionId\s*\?\?/);
+  assert.doesNotMatch(source, /ctx\.activeWorkspace/);
+  assert.doesNotMatch(source, /ctx\.focusedSessionId/);
+  // Focus mode must follow live workspace, not stale ctx.isFocusMode.
+  assert.match(source, /activeWorkspace\?\.viewMode === ['"]focus['"]/);
+});

--- a/components/terminalLayer/TerminalLayerWorkspaceSection.tsx
+++ b/components/terminalLayer/TerminalLayerWorkspaceSection.tsx
@@ -10,22 +10,26 @@ import { terminalLayerWorkspaceCtxEqual } from './terminalLayerViewMemo';
 type WorkspaceContext = Record<string, any>;
 
 function TerminalLayerWorkspaceSectionInner({ ctx }: { ctx: WorkspaceContext }) {
-  // Active workspace / focused session come from the live store so top-tab
+  // Active workspace / focused session come ONLY from the live store so top-tab
   // switches do not force a TerminalLayerView ctx rebuild just to flip them.
+  // Do not fall back to ctx.* — after memo omits activeWorkspace from equality,
+  // ctx can still hold a previous workspace after live has been cleared
+  // (workspace → solo session). Falling back would keep compose bar / resizer
+  // handlers bound to a stale workspace.
   // Panes already derive visibility from activeTabStore themselves.
   const live = useSyncExternalStore(
     sidePanelLiveStore.subscribe,
     sidePanelLiveStore.getSnapshot,
     () => getSidePanelLiveSnapshot(false),
   );
-  const activeWorkspace = live.activeWorkspace ?? ctx.activeWorkspace;
-  const focusedSessionId = live.focusedSessionId ?? ctx.focusedSessionId;
+  const activeWorkspace = live.activeWorkspace;
+  const focusedSessionId = live.focusedSessionId;
+  const isFocusMode = activeWorkspace?.viewMode === 'focus';
 
   const {
     workspaceInnerRef,
     workspaceOverlayRef,
     draggingSessionId,
-    isFocusMode,
     dropHint,
     setDropHint,
     computeSplitHint,

--- a/components/terminalLayer/TerminalLayerWorkspaceSection.tsx
+++ b/components/terminalLayer/TerminalLayerWorkspaceSection.tsx
@@ -1,11 +1,26 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { memo } from 'react';
+import React, { memo, useSyncExternalStore } from 'react';
 
+import {
+  getSidePanelLiveSnapshot,
+  sidePanelLiveStore,
+} from '../../application/state/sidePanelLiveStore';
 import { terminalLayerWorkspaceCtxEqual } from './terminalLayerViewMemo';
 
 type WorkspaceContext = Record<string, any>;
 
 function TerminalLayerWorkspaceSectionInner({ ctx }: { ctx: WorkspaceContext }) {
+  // Active workspace / focused session come from the live store so top-tab
+  // switches do not force a TerminalLayerView ctx rebuild just to flip them.
+  // Panes already derive visibility from activeTabStore themselves.
+  const live = useSyncExternalStore(
+    sidePanelLiveStore.subscribe,
+    sidePanelLiveStore.getSnapshot,
+    () => getSidePanelLiveSnapshot(false),
+  );
+  const activeWorkspace = live.activeWorkspace ?? ctx.activeWorkspace;
+  const focusedSessionId = live.focusedSessionId ?? ctx.focusedSessionId;
+
   const {
     workspaceInnerRef,
     workspaceOverlayRef,
@@ -81,10 +96,8 @@ function TerminalLayerWorkspaceSectionInner({ ctx }: { ctx: WorkspaceContext }) 
     handleProgrammaticCommandLogRewriteChange,
     handleAddSelectionToAI,
     activeResizers,
-    activeWorkspace,
     composeBarThemeColors,
     findSplitNode,
-    focusedSessionId,
     handleComposeSend,
     handleSnippetFromPanel,
     refocusTerminalSession,

--- a/components/terminalLayer/terminalLayerViewMemo.test.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.test.ts
@@ -74,7 +74,7 @@ test("terminal layer memo skips equivalent active workspace objects", () => {
   );
 });
 
-test("terminal layer memo re-renders when active workspace root changes", () => {
+test("terminal layer memo ignores activeWorkspace-only tab flips (live store owns them)", () => {
   const prevWorkspace = workspace();
   const nextWorkspace = cloneWorkspace(prevWorkspace);
   nextWorkspace.root = {
@@ -83,20 +83,51 @@ test("terminal layer memo re-renders when active workspace root changes", () => 
     sizes: [2, 1],
   };
 
+  // activeWorkspace is read from sidePanelLiveStore in WorkspaceSection; ctx
+  // equality must not force a full layer rebuild solely because the active
+  // workspace object identity/root changed on a tab switch.
   assert.equal(
     terminalLayerWorkspaceCtxEqual(
       { activeWorkspace: prevWorkspace },
       { activeWorkspace: nextWorkspace },
     ),
-    false,
+    true,
   );
   assert.equal(
     terminalLayerViewCtxEqual(
       { activeWorkspace: prevWorkspace },
       { activeWorkspace: nextWorkspace },
     ),
-    false,
+    true,
   );
+});
+
+test("terminal layer memo re-renders when active resizers change", () => {
+  const base = {
+    activeResizers: [
+      {
+        id: "split-1-0",
+        splitId: "split-1",
+        index: 0,
+        direction: "vertical",
+        rect: { x: 10, y: 0, w: 4, h: 100 },
+        splitArea: { w: 200, h: 100 },
+      },
+    ],
+  };
+  const next = {
+    activeResizers: [
+      {
+        id: "split-1-0",
+        splitId: "split-1",
+        index: 0,
+        direction: "vertical",
+        rect: { x: 40, y: 0, w: 4, h: 100 },
+        splitArea: { w: 200, h: 100 },
+      },
+    ],
+  };
+  assert.equal(terminalLayerWorkspaceCtxEqual(base, next), false);
 });
 
 test("terminal layer side panel stable ctx ignores linked terminal cwd changes", () => {

--- a/components/terminalLayer/terminalLayerViewMemo.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.ts
@@ -397,10 +397,11 @@ const WORKSPACE_CTX_KEYS = [
   'handleProgrammaticCommandLogRewriteChange',
   'handleAddSelectionToAI',
   'activeResizers',
-  'activeWorkspace',
+  // activeWorkspace / focusedSessionId: TerminalLayerWorkspaceSection reads
+  // these from sidePanelLiveStore so tab switches do not invalidate workspace
+  // chrome solely because the active tab id changed.
   'composeBarThemeColors',
   'findSplitNode',
-  'focusedSessionId',
   'handleComposeSend',
   'handleSnippetFromPanel',
   'refocusTerminalSession',
@@ -442,8 +443,9 @@ export function terminalLayerViewCtxEqual(prev: Ctx, next: Ctx): boolean {
   if (prev.isTerminalLayerVisible !== next.isTerminalLayerVisible) return false;
   if (prev.hibernateHiddenTabs !== next.hibernateHiddenTabs) return false;
   if (prev.isComposeBarOpen !== next.isComposeBarOpen) return false;
-  if (!activeWorkspaceEqual(prev.activeWorkspace, next.activeWorkspace)) return false;
-  if (prev.focusedSessionId !== next.focusedSessionId) return false;
+  // activeWorkspace / focusedSessionId intentionally omitted: live store +
+  // focus-sidebar equal handle those without forcing a full layer rebuild on
+  // every top-tab switch between terminal sessions.
   if (prev.handleComposeSend !== next.handleComposeSend) return false;
   if (prev.refocusTerminalSession !== next.refocusTerminalSession) return false;
   if (prev.setIsComposeBarOpen !== next.setIsComposeBarOpen) return false;

--- a/components/terminalLayer/useTerminalLayerEffects.ts
+++ b/components/terminalLayer/useTerminalLayerEffects.ts
@@ -523,8 +523,9 @@ export function useTerminalLayerEffects(ctx: TerminalLayerEffectsContext) {
   const wasTerminalLayerVisibleRef = useRef(false);
   const prevActiveTabIdRef = useRef<string | undefined>(undefined);
 
-  // Restore keyboard focus to the active terminal after switching work tabs.
-  // Single rAF only — avoid stacking sync + rAF + setTimeout focus thrash.
+  // Restore keyboard focus after switching work tabs.
+  // Call the existing focus primitive directly — it already schedules rAF +
+  // retry (focusTerminalSessionInput). An outer rAF here only delayed focus.
   useEffect(() => {
     if (!isTerminalLayerVisible) {
       prevActiveTabIdRef.current = activeTabId;
@@ -537,19 +538,7 @@ export function useTerminalLayerEffects(ctx: TerminalLayerEffectsContext) {
     prevActiveTabIdRef.current = activeTabId;
 
     if (!tabChanged || !refocusActiveTerminalSession) return;
-    let rafId: number | null = null;
-    if (typeof requestAnimationFrame === 'function') {
-      rafId = requestAnimationFrame(() => {
-        refocusActiveTerminalSession();
-      });
-    } else {
-      refocusActiveTerminalSession();
-    }
-    return () => {
-      if (rafId !== null && typeof cancelAnimationFrame === 'function') {
-        cancelAnimationFrame(rafId);
-      }
-    };
+    refocusActiveTerminalSession();
   }, [activeTabId, isTerminalLayerVisible, refocusActiveTerminalSession]);
 
   // When focusedSessionId changes or terminal layer becomes visible,

--- a/components/terminalLayer/useTerminalLayerEffects.ts
+++ b/components/terminalLayer/useTerminalLayerEffects.ts
@@ -92,7 +92,7 @@ export function pruneTerminalTabMemoryState(
 
 export function useTerminalLayerEffects(ctx: TerminalLayerEffectsContext) {
   const { openPath } = useSftpBackend();
-  const { activeSidePanelTab, activeTabId, activeTabIdRef, activeWorkspace, activityTrackedSessions, cancelAnimationFrame, ChunkedEscapeFilter, clearTimeout, clearTopTabsPreviewVars, document, dropHint, effectiveHosts, filterTabsMap, focusedSessionId, getSessionActivityIdsToClear, handleToggleAiFromTopBar, handleToggleScriptsSidePanel, handleToggleSidePanel, hasNotifiableTerminalOutput, isComposeBarOpen, isFocusMode, isTerminalLayerVisible, lastSidePanelTabRef, Map, onConnectToHost, onSessionData, onSplitSessionRef, onToggleBroadcastRef, onToggleWorkspaceViewModeRef, prevFocusedSessionIdRef, refocusActiveTerminalSession, requestAnimationFrame, ResizeObserver, sessionActivityStore, sessions, Set, setAiMountedTabIds, setDropHint, setNotesMountedTabIds, setScriptsMountedTabIds, setSystemMountedTabIds, setSftpHostForTab, setSftpInitialLocationForTab, setSftpPendingUploadsForTab, setSidePanelOpenTabs, setThemeMountedTabIds, setTimeout, setWorkspaceArea, shouldMeasureTerminalLayerLayout, sidePanelPosition, sidePanelWidth, sftpActiveHost, sftpHostForTab, shouldMarkSessionActivity, sidePanelOpenTabs, splitHorizontalHandlersRef, splitVerticalHandlersRef, toggleScriptsSidePanelRef, toggleSidePanelRef, validAIScopeTargetIds, validSessionActivityIds, window, workspaceBroadcastHandlersRef, workspaceFocusHandlersRef, workspaceInnerRef, workspaces } = ctx;
+  const { activeSidePanelTab, activeTabId, activeTabIdRef, activeWorkspace, activityTrackedSessions, cancelAnimationFrame, ChunkedEscapeFilter, clearTopTabsPreviewVars, document, dropHint, effectiveHosts, filterTabsMap, focusedSessionId, getSessionActivityIdsToClear, handleToggleAiFromTopBar, handleToggleScriptsSidePanel, handleToggleSidePanel, hasNotifiableTerminalOutput, isComposeBarOpen, isFocusMode, isTerminalLayerVisible, lastSidePanelTabRef, Map, onConnectToHost, onSessionData, onSplitSessionRef, onToggleBroadcastRef, onToggleWorkspaceViewModeRef, prevFocusedSessionIdRef, refocusActiveTerminalSession, requestAnimationFrame, ResizeObserver, sessionActivityStore, sessions, Set, setAiMountedTabIds, setDropHint, setNotesMountedTabIds, setScriptsMountedTabIds, setSystemMountedTabIds, setSftpHostForTab, setSftpInitialLocationForTab, setSftpPendingUploadsForTab, setSidePanelOpenTabs, setThemeMountedTabIds, setWorkspaceArea, shouldMeasureTerminalLayerLayout, sidePanelPosition, sidePanelWidth, sftpActiveHost, sftpHostForTab, shouldMarkSessionActivity, sidePanelOpenTabs, splitHorizontalHandlersRef, splitVerticalHandlersRef, toggleScriptsSidePanelRef, toggleSidePanelRef, validAIScopeTargetIds, validSessionActivityIds, window, workspaceBroadcastHandlersRef, workspaceFocusHandlersRef, workspaceInnerRef, workspaces } = ctx;
 
   const activeWorkspaceId = activeWorkspace?.id;
   const activeWorkspaceViewMode = activeWorkspace?.viewMode;
@@ -524,6 +524,7 @@ export function useTerminalLayerEffects(ctx: TerminalLayerEffectsContext) {
   const prevActiveTabIdRef = useRef<string | undefined>(undefined);
 
   // Restore keyboard focus to the active terminal after switching work tabs.
+  // Single rAF only — avoid stacking sync + rAF + setTimeout focus thrash.
   useEffect(() => {
     if (!isTerminalLayerVisible) {
       prevActiveTabIdRef.current = activeTabId;
@@ -535,8 +536,20 @@ export function useTerminalLayerEffects(ctx: TerminalLayerEffectsContext) {
       prevActiveTabIdRef.current !== activeTabId;
     prevActiveTabIdRef.current = activeTabId;
 
-    if (!tabChanged) return;
-    refocusActiveTerminalSession?.();
+    if (!tabChanged || !refocusActiveTerminalSession) return;
+    let rafId: number | null = null;
+    if (typeof requestAnimationFrame === 'function') {
+      rafId = requestAnimationFrame(() => {
+        refocusActiveTerminalSession();
+      });
+    } else {
+      refocusActiveTerminalSession();
+    }
+    return () => {
+      if (rafId !== null && typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(rafId);
+      }
+    };
   }, [activeTabId, isTerminalLayerVisible, refocusActiveTerminalSession]);
 
   // When focusedSessionId changes or terminal layer becomes visible,
@@ -577,18 +590,17 @@ export function useTerminalLayerEffects(ctx: TerminalLayerEffectsContext) {
         }
       };
   
+      // One sync attempt + one rAF; avoid the historical 50ms third focus.
       focusTarget();
       let rafId: number | null = null;
       if (typeof requestAnimationFrame === 'function') {
         rafId = requestAnimationFrame(focusTarget);
       }
-      const timerId = setTimeout(focusTarget, 50);
-  
+
       return () => {
         if (rafId !== null && typeof cancelAnimationFrame === 'function') {
           cancelAnimationFrame(rafId);
         }
-        clearTimeout(timerId);
       };
     }, [focusedSessionId, isFocusMode, activeWorkspace, isTerminalLayerVisible]);
 }

--- a/components/top-tabs/TopTabItems.tsx
+++ b/components/top-tabs/TopTabItems.tsx
@@ -5,6 +5,7 @@ import {
   useAnySessionActivity,
   useSessionActivity,
 } from '../../application/state/sessionActivityStore';
+import { usePresentedSession } from '../../application/state/sessionPresentationStore';
 import {
   useEditorTabDirty,
   type EditorTabChrome,
@@ -689,7 +690,7 @@ interface SessionTopTabProps {
 }
 
 export const SessionTopTab: React.FC<SessionTopTabProps> = memo(({
-  session,
+  session: sessionProp,
   host,
   isBeingDragged,
   isDraggingForReorder,
@@ -710,6 +711,8 @@ export const SessionTopTab: React.FC<SessionTopTabProps> = memo(({
   t,
   tabAnimationClass,
 }) => {
+  // Per-session presentation: sibling title/provider updates do not re-render this tab.
+  const session = usePresentedSession(sessionProp);
   const isActive = useIsTabActive(session.id);
   // Per-session store snapshot so sibling activity dots do not re-render this tab.
   const hasActivity = useSessionActivity(session.id);

--- a/components/top-tabs/TopTabItems.tsx
+++ b/components/top-tabs/TopTabItems.tsx
@@ -859,16 +859,41 @@ interface WorkspaceTopTabProps {
   onCopyWorkspace: (workspaceId: string) => void;
   onCloseWorkspace: (workspaceId: string) => void;
   onDetachSessionFromWorkspace?: (workspaceId: string, sessionId: string) => void;
-  workspaceSessionLabels?: Record<string, string>;
+  /** Sessions for Detach menu; each menu item applies live presentation itself. */
+  workspaceSessions?: TerminalSession[];
+  dynamicTabTitleMode?: DynamicTabTitleMode;
   renderBulkCloseItems: RenderBulkCloseItems;
   t: TranslateFn;
   tabAnimationClass?: string;
 }
 
+/**
+ * Detach-menu row that subscribes to presentation for one session only, so
+ * agent title updates stay live without remapping the whole TopTabs bar.
+ */
+const WorkspaceDetachSessionMenuItem: React.FC<{
+  session: TerminalSession;
+  workspaceId: string;
+  dynamicTabTitleMode?: DynamicTabTitleMode;
+  onDetach: (workspaceId: string, sessionId: string) => void;
+  t: TranslateFn;
+}> = memo(({ session: sessionProp, workspaceId, dynamicTabTitleMode, onDetach, t }) => {
+  const session = usePresentedSession(sessionProp);
+  const label = resolveSessionTabTitle(session, dynamicTabTitleMode);
+  return (
+    <ContextMenuItem onClick={() => onDetach(workspaceId, session.id)}>
+      {t('terminal.menu.detachSession', { name: label })}
+    </ContextMenuItem>
+  );
+});
+WorkspaceDetachSessionMenuItem.displayName = 'WorkspaceDetachSessionMenuItem';
+
 export const WorkspaceTopTab: React.FC<WorkspaceTopTabProps> = memo(({
   workspace,
   paneCount,
   workspaceSessionIds,
+  workspaceSessions,
+  dynamicTabTitleMode,
   isBeingDragged,
   isDraggingForReorder,
   shiftStyle,
@@ -883,7 +908,6 @@ export const WorkspaceTopTab: React.FC<WorkspaceTopTabProps> = memo(({
   onCopyWorkspace,
   onCloseWorkspace,
   onDetachSessionFromWorkspace,
-  workspaceSessionLabels,
   renderBulkCloseItems,
   t,
   tabAnimationClass,
@@ -897,6 +921,7 @@ export const WorkspaceTopTab: React.FC<WorkspaceTopTabProps> = memo(({
     () => createTopTabCopyDoubleClickHandler(onCopyWorkspace, workspace.id),
     [onCopyWorkspace, workspace.id],
   );
+  const detachSessions = workspaceSessions ?? [];
 
   return (
     <ContextMenu>
@@ -984,15 +1009,17 @@ export const WorkspaceTopTab: React.FC<WorkspaceTopTabProps> = memo(({
         <ContextMenuItem onClick={() => onCopyWorkspace(workspace.id)}>
           {t('tabs.copyTab')}
         </ContextMenuItem>
-        {onDetachSessionFromWorkspace && workspaceSessionLabels && Object.entries(workspaceSessionLabels).map(([sessionId, label]) => (
-          <ContextMenuItem
-            key={sessionId}
-            onClick={() => onDetachSessionFromWorkspace(workspace.id, sessionId)}
-          >
-            {t('terminal.menu.detachSession', { name: label })}
-          </ContextMenuItem>
+        {onDetachSessionFromWorkspace && detachSessions.map((session) => (
+          <WorkspaceDetachSessionMenuItem
+            key={session.id}
+            session={session}
+            workspaceId={workspace.id}
+            dynamicTabTitleMode={dynamicTabTitleMode}
+            onDetach={onDetachSessionFromWorkspace}
+            t={t}
+          />
         ))}
-        {onDetachSessionFromWorkspace && workspaceSessionLabels && Object.keys(workspaceSessionLabels).length > 0 && (
+        {onDetachSessionFromWorkspace && detachSessions.length > 0 && (
           <ContextMenuSeparator />
         )}
         <ContextMenuItem className="text-destructive" onClick={() => onCloseWorkspace(workspace.id)}>


### PR DESCRIPTION
## Summary

Finish the tab-switch jank work that remained after the recent App/terminal performance isolation merges. Top-tab clicks no longer rebuild the App shell or re-serialize session restore state, and terminal chrome/presentation/focus costs on the click path are reduced without changing product behavior.

## Type of Change

- [x] Other (please describe): Performance optimization (renderer tab-switch path)

## Related Issue (optional)

N/A

## Changes Made

| Jank path | Fix |
|-----------|-----|
| **AppView re-renders on every `activeTabId` change** | Shell no longer calls `useActiveTabId`. Plugin keybindings → `AppPluginKeybindingHost`; host-editor surface visibility → leaf `useWorkSurfaceVisible`. Host tree / mounts / chrome already leaf-subscribed. |
| **Terminal layer full ctx rebuild on tab flip** | Workspace section reads `activeWorkspace` / `focusedSessionId` from `sidePanelLiveStore`. View memo ignores those fields so only structural workspace keys (resizers, sessions, etc.) force rebuilds. |
| **Chrome theme CSS rewrite on every click** | `notifyActiveChromeThemeForTab` schedules apply on rAF, short-circuits on fingerprint match, keeps **instant** transition mode (no view transitions). |
| **Window title IPC on paint path** | Deferred to next timer tick when title string actually changes. |
| **Session restore full `JSON.stringify` + localStorage on tab click** | New `patchSessionRestoreActiveTabId` patches only `activeTabId` against last full payload. Full rebuild remains for sessions/workspaces/tabOrder changes and pagehide/beforeunload flush. |
| **Focus thrash (sync + rAF + 50ms)** | Single rAF for tab refocus; split-pane focus drops the 50ms third attempt. |
| **TopTabs global presentation version** | Removed whole-bar remap; `SessionTopTab` uses `usePresentedSession` (per-tab snapshot). |
| **Hibernate wake** | Confirmed/covered: viewport first, scrollback via idle + `writeTerminalPayloadChunked` (already shipped; tests lock it in). |

## Screenshots / Demo

No intentional UI visual change. Tab switch should feel snappier with many open sessions (especially after long-running title updates or frequent tab hopping).

## Testing

- [x] Linting passes (`npm run lint`)
- [x] Targeted unit tests pass (`node --test --import tsx` on touched suites — 79+ related tests)
- [ ] Full `npm test` not required for this PR gate (heavy suite); targeted coverage includes restore, chrome theme, TopTabs, terminal layer memo, hibernate wake chunking, AppView isolation
- [x] No product behavior change intended: same active tab, titles, themes, restore payload semantics, focus target, wake completeness

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated tests for the shipped paths
- [x] I have not introduced any breaking changes