### PR TITLE
fix(ui): use borderless quick-connect tab icon

### DIFF
--- a/components/top-tabs/TopTabItems.tsx
+++ b/components/top-tabs/TopTabItems.tsx
@@ -1,4 +1,4 @@
-import { Copy, FileCode, FileText, LayoutGrid, Minus, Server, Square, TerminalSquare, Usb, X } from 'lucide-react';
+import { Copy, FileCode, FileText, LayoutGrid, Minus, Server, Square, Terminal, TerminalSquare, Usb, X } from 'lucide-react';
 import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { activeTabStore, useActiveTabId, useIsTabActive } from '../../application/state/activeTabStore';
 import {
@@ -154,7 +154,7 @@ const SessionTabIcon: React.FC<{
       </div>
     );
   }
-  return <TerminalSquare className={iconSize} style={fallbackStyle} />;
+  return <Terminal className={iconSize} style={fallbackStyle} />;
 });
 SessionTabIcon.displayName = 'SessionTabIcon';
 


### PR DESCRIPTION
## Summary

Replaces the bordered terminal symbol used by temporary Quick Connect tabs with the borderless terminal symbol shown in the design.

## Type of Change

- [x] Bug fix

## Related Issue (optional)

N/A

## Changes Made

- Updated the default icon for an unsaved Quick Connect tab.
- Left local-terminal icons and saved-host icons unchanged.

## Screenshots / Demo

The temporary Quick Connect tab now uses the borderless terminal icon.

## Testing

- [x] Linting passes
- [x] Production build passes

## Checklist

- [x] My code follows the existing project style
- [x] I have not introduced any breaking changes