### PR TITLE
fix(sftp): repair pause/resume soft-control and hard reconnect reuse

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -702,9 +702,30 @@ function App({ settings }: { settings: SettingsState }) {
   const _handleGlobalHotkeyKeyDown = useEffectEvent((e: KeyboardEvent) => { return handleGlobalHotkeyKeyDownImpl(() => ({ HOTKEY_DEBUG, closeTabKeyStr, e, executeHotkeyAction, hotkeyScheme, keyBindings, matchesKeyBinding }), e); });
   const _handleEscapeKeyDown = useEffectEvent((e: KeyboardEvent) => { return handleEscapeKeyDownImpl(() => ({ e, isQuickSwitcherOpen, setIsQuickSwitcherOpen }), e); });
 
-  // Include ephemeral quick-connect / deep-link hosts (terminalHosts) so
-  // dedicated transfer resume can re-auth without "Cannot find host in your vault".
-  useAppStartupEffects({ dismissUpdate, enabled: !isPeerSessionWindow, groupConfigs, hasRuntimeTunnel, hosts: terminalHosts, identities, installUpdate, isVaultInitialized, keys, knownHosts: effectiveKnownHosts, openSettingsWindow, portForwardingRules, proxyProfiles, sessions, setKeyboardInteractiveQueue, t, terminalSettings, updateState, workspaces });
+  // Vault hosts for tray / auto-start; terminalHosts (vault + ephemeral) only for
+  // dedicated transfer resume so quick-connect rows do not break tray connect.
+  useAppStartupEffects({
+    dismissUpdate,
+    enabled: !isPeerSessionWindow,
+    groupConfigs,
+    hasRuntimeTunnel,
+    hosts,
+    resumeHosts: terminalHosts,
+    identities,
+    installUpdate,
+    isVaultInitialized,
+    keys,
+    knownHosts: effectiveKnownHosts,
+    openSettingsWindow,
+    portForwardingRules,
+    proxyProfiles,
+    sessions,
+    setKeyboardInteractiveQueue,
+    t,
+    terminalSettings,
+    updateState,
+    workspaces,
+  });
 
   useEffect(() => {
     if (isPeerSessionWindow) return;

--- a/App.tsx
+++ b/App.tsx
@@ -702,7 +702,9 @@ function App({ settings }: { settings: SettingsState }) {
   const _handleGlobalHotkeyKeyDown = useEffectEvent((e: KeyboardEvent) => { return handleGlobalHotkeyKeyDownImpl(() => ({ HOTKEY_DEBUG, closeTabKeyStr, e, executeHotkeyAction, hotkeyScheme, keyBindings, matchesKeyBinding }), e); });
   const _handleEscapeKeyDown = useEffectEvent((e: KeyboardEvent) => { return handleEscapeKeyDownImpl(() => ({ e, isQuickSwitcherOpen, setIsQuickSwitcherOpen }), e); });
 
-  useAppStartupEffects({ dismissUpdate, enabled: !isPeerSessionWindow, groupConfigs, hasRuntimeTunnel, hosts, identities, installUpdate, isVaultInitialized, keys, knownHosts: effectiveKnownHosts, openSettingsWindow, portForwardingRules, proxyProfiles, sessions, setKeyboardInteractiveQueue, t, terminalSettings, updateState, workspaces });
+  // Include ephemeral quick-connect / deep-link hosts (terminalHosts) so
+  // dedicated transfer resume can re-auth without "Cannot find host in your vault".
+  useAppStartupEffects({ dismissUpdate, enabled: !isPeerSessionWindow, groupConfigs, hasRuntimeTunnel, hosts: terminalHosts, identities, installUpdate, isVaultInitialized, keys, knownHosts: effectiveKnownHosts, openSettingsWindow, portForwardingRules, proxyProfiles, sessions, setKeyboardInteractiveQueue, t, terminalSettings, updateState, workspaces });
 
   useEffect(() => {
     if (isPeerSessionWindow) return;

--- a/application/app/useAppStartupEffects.ts
+++ b/application/app/useAppStartupEffects.ts
@@ -55,8 +55,10 @@ export function useAppStartupEffects(ctx: StartupEffectsContext) {
     sessionsRef.current = sessions;
   }, [sessions]);
 
-  // After app restart, unfinished transfers resume via a dedicated SFTP session
-  // built from vault credentials — no dependency on the original browse panel.
+  // After app restart (or soft-resume miss), unfinished transfers reconnect via
+  // a dedicated SFTP session. `hosts` must include ephemeral quick-connect rows
+  // (terminalHosts from App) — vault-only lists break resume with
+  // "Cannot find host … in your vault".
   useEffect(() => {
     if (!enabled || !isVaultInitialized) {
       sftpTransferCenterStore.setDedicatedResumeHandler(null);

--- a/application/app/useAppStartupEffects.ts
+++ b/application/app/useAppStartupEffects.ts
@@ -45,10 +45,12 @@ export function removeKeyboardInteractiveRequest<T extends KeyboardInteractiveQu
 }
 
 export function useAppStartupEffects(ctx: StartupEffectsContext) {
-  const {dismissUpdate, enabled = true, groupConfigs, hosts, identities,
+  const {dismissUpdate, enabled = true, groupConfigs, hosts, resumeHosts, identities,
     hasRuntimeTunnel, installUpdate, isVaultInitialized, keys, knownHosts, openSettingsWindow, portForwardingRules, proxyProfiles, sessions, setKeyboardInteractiveQueue,
     t, terminalSettings, updateState, workspaces,
   } = ctx;
+  // Vault hosts for tray/menu; resumeHosts may include ephemeral quick-connect rows.
+  const dedicatedResumeHosts = resumeHosts ?? hosts;
   const sessionsRef = useRef(sessions);
 
   useEffect(() => {
@@ -56,9 +58,8 @@ export function useAppStartupEffects(ctx: StartupEffectsContext) {
   }, [sessions]);
 
   // After app restart (or soft-resume miss), unfinished transfers reconnect via
-  // a dedicated SFTP session. `hosts` must include ephemeral quick-connect rows
-  // (terminalHosts from App) — vault-only lists break resume with
-  // "Cannot find host … in your vault".
+  // a dedicated SFTP session. Prefer resumeHosts (vault + ephemeral) so
+  // quick-connect transfers can re-auth without "Cannot find host in your vault".
   useEffect(() => {
     if (!enabled || !isVaultInitialized) {
       sftpTransferCenterStore.setDedicatedResumeHandler(null);
@@ -159,7 +160,7 @@ export function useAppStartupEffects(ctx: StartupEffectsContext) {
         return await resumeTransferWithDedicatedSession(
           task,
           {
-            hosts,
+            hosts: dedicatedResumeHosts,
             keys,
             identities,
             knownHosts,
@@ -199,7 +200,7 @@ export function useAppStartupEffects(ctx: StartupEffectsContext) {
       }
     });
     return () => sftpTransferCenterStore.setDedicatedResumeHandler(null);
-  }, [enabled, hosts, identities, isVaultInitialized, keys, knownHosts, terminalSettings]);
+  }, [dedicatedResumeHosts, enabled, identities, isVaultInitialized, keys, knownHosts, terminalSettings]);
 
   // Show toast notification when update is available (only when auto-download is idle)
   useEffect(() => {

--- a/application/state/sftp/dedicatedTransferResume.test.ts
+++ b/application/state/sftp/dedicatedTransferResume.test.ts
@@ -15,6 +15,7 @@ import {
   resumeTransferWithDedicatedSession,
   resolveDirectoryResumeTargetRoot,
   resolveHostForTransferEndpoint,
+  resolveResumeHosts,
   shouldSkipCompletedResumeChild,
   withDedicatedSessionOpenSlot,
 } from "./dedicatedTransferResume";
@@ -101,6 +102,242 @@ test("resolveHostForTransferEndpoint prefers id then label", () => {
   assert.equal(resolveHostForTransferEndpoint(hosts, "missing", "CI-Build-01")?.id, "id-1");
   assert.equal(resolveHostForTransferEndpoint(hosts, undefined, "ci-01.example")?.id, "id-1");
   assert.equal(resolveHostForTransferEndpoint(hosts, "missing", "gone"), null);
+});
+
+test("resolveResumeHosts accepts ephemeral quick-connect hosts in the host list", () => {
+  const ephemeral = {
+    ...host("quick-1", "10.2.0.32", "10.2.0.32"),
+    ephemeral: true,
+    password: "secret",
+  } as Host;
+  const resolved = resolveResumeHosts({
+    id: "up-1",
+    fileName: "ChatGPT.dmg",
+    sourcePath: "/local/ChatGPT.dmg",
+    targetPath: "/remote/ChatGPT.dmg",
+    sourceConnectionId: "local",
+    targetConnectionId: "sess-1",
+    targetHostId: "quick-1",
+    targetHostLabel: "10.2.0.32",
+    direction: "upload",
+    status: "paused",
+    totalBytes: 100,
+    transferredBytes: 1,
+    speed: 0,
+    startTime: 1,
+    isDirectory: false,
+  } as TransferTask, { hosts: [ephemeral], keys: [], identities: [] });
+  assert.equal(resolved.ok, true);
+  if (resolved.ok) {
+    assert.equal(resolved.endpoints.targetHost?.id, "quick-1");
+    // Live session is always attached so hard resume can borrow the transport.
+    assert.equal(resolved.endpoints.targetSessionId, "sess-1");
+  }
+});
+
+test("resolveResumeHosts prefers attaching live session even when vault host exists", () => {
+  const vaultHost = host("h1", "box", "1.2.3.4");
+  const resolved = resolveResumeHosts({
+    id: "up-shared",
+    fileName: "file.bin",
+    sourcePath: "/local/file.bin",
+    targetPath: "/remote/file.bin",
+    sourceConnectionId: "local",
+    targetConnectionId: "term-live",
+    targetHostId: "h1",
+    targetHostLabel: "box",
+    direction: "upload",
+    status: "interrupted",
+    totalBytes: 10,
+    transferredBytes: 2,
+    speed: 0,
+    startTime: 1,
+    isDirectory: false,
+  } as TransferTask, { hosts: [vaultHost], keys: [], identities: [] });
+  assert.equal(resolved.ok, true);
+  if (resolved.ok) {
+    assert.equal(resolved.endpoints.targetHost?.id, "h1");
+    assert.equal(resolved.endpoints.targetSessionId, "term-live");
+  }
+});
+
+test("resolveResumeHosts falls back to a live session when vault host is missing", () => {
+  const resolved = resolveResumeHosts({
+    id: "up-2",
+    fileName: "ChatGPT.dmg",
+    sourcePath: "/local/ChatGPT.dmg",
+    targetPath: "/remote/ChatGPT.dmg",
+    sourceConnectionId: "local",
+    targetConnectionId: "sess-live",
+    targetHostId: "quick-missing",
+    targetHostLabel: "10.2.0.32",
+    direction: "upload",
+    status: "paused",
+    totalBytes: 100,
+    transferredBytes: 1,
+    speed: 0,
+    startTime: 1,
+    isDirectory: false,
+  } as TransferTask, { hosts: [], keys: [], identities: [] });
+  assert.equal(resolved.ok, true);
+  if (resolved.ok) {
+    assert.equal(resolved.endpoints.targetHost, null);
+    assert.equal(resolved.endpoints.targetSessionId, "sess-live");
+  }
+});
+
+test("resolveResumeHosts errors when neither vault host nor live session exists", () => {
+  const resolved = resolveResumeHosts({
+    id: "up-3",
+    fileName: "ChatGPT.dmg",
+    sourcePath: "/local/ChatGPT.dmg",
+    targetPath: "/remote/ChatGPT.dmg",
+    sourceConnectionId: "local",
+    targetConnectionId: "local",
+    targetHostId: "gone",
+    targetHostLabel: "10.2.0.32",
+    direction: "upload",
+    status: "paused",
+    totalBytes: 100,
+    transferredBytes: 1,
+    speed: 0,
+    startTime: 1,
+    isDirectory: false,
+  } as TransferTask, { hosts: [], keys: [], identities: [] });
+  assert.equal(resolved.ok, false);
+  if (!resolved.ok) {
+    assert.match(resolved.error, /Cannot find host "10\.2\.0\.32"/);
+  }
+});
+
+test("dedicated resume of quick-connect host uses session when vault list is empty", async (t) => {
+  resetDedicatedSessionOpenGateForTests();
+  const previousLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: { getItem: () => "2", setItem: () => {}, removeItem: () => {} },
+  });
+  t.after(() => {
+    if (previousLocalStorage) Object.defineProperty(globalThis, "localStorage", previousLocalStorage);
+    else Reflect.deleteProperty(globalThis, "localStorage");
+  });
+  const originalGet = netcattyBridge.get;
+  let openedSession: string | undefined;
+  let startOptions: Record<string, unknown> | undefined;
+  (netcattyBridge as { get: () => unknown }).get = () => ({
+    openSftp: async () => {
+      throw new Error("must not dial vault for missing host");
+    },
+    openSftpForSession: async (sessionId: string) => {
+      openedSession = sessionId;
+      return "session-sftp";
+    },
+    closeSftp: async () => {},
+    statLocal: async () => ({ size: 100, lastModified: 123 }),
+    startStreamTransfer: async (options: Record<string, unknown>) => {
+      startOptions = options;
+      return { transferId: "qc-resume" };
+    },
+  });
+  try {
+    const result = await resumeTransferWithDedicatedSession({
+      id: "qc-resume",
+      fileName: "ChatGPT.dmg",
+      sourcePath: "/local/ChatGPT.dmg",
+      targetPath: "/remote/ChatGPT.dmg",
+      sourceConnectionId: "local",
+      targetConnectionId: "term-sess-1",
+      targetHostId: "quick-1",
+      targetHostLabel: "10.2.0.32",
+      direction: "upload",
+      status: "paused",
+      totalBytes: 100,
+      transferredBytes: 4,
+      checkpointBytes: 4,
+      speed: 0,
+      startTime: 1,
+      isDirectory: false,
+      reconnectRequired: true,
+    }, {
+      hosts: [],
+      keys: [],
+      identities: [],
+    });
+    assert.equal(result.success, true, result.error);
+    assert.equal(openedSession, "term-sess-1");
+    assert.equal(startOptions?.targetSftpId, "session-sftp");
+    assert.equal(startOptions?.checkpointBytes, 4);
+  } finally {
+    (netcattyBridge as { get: typeof originalGet }).get = originalGet;
+    resetDedicatedSessionOpenGateForTests();
+  }
+});
+
+test("hard resume with vault host + live session reuses session transport (not cold dedicated dial)", async (t) => {
+  resetDedicatedSessionOpenGateForTests();
+  const previousLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: { getItem: () => "2", setItem: () => {}, removeItem: () => {} },
+  });
+  t.after(() => {
+    if (previousLocalStorage) Object.defineProperty(globalThis, "localStorage", previousLocalStorage);
+    else Reflect.deleteProperty(globalThis, "localStorage");
+  });
+  const originalGet = netcattyBridge.get;
+  let openSftpCalls = 0;
+  let openForSessionCalls = 0;
+  let openSftpOpts: { reuseTransport?: boolean } | undefined;
+  (netcattyBridge as { get: () => unknown }).get = () => ({
+    openSftp: async (options: { reuseTransport?: boolean }) => {
+      openSftpCalls += 1;
+      openSftpOpts = options;
+      return "unexpected-cold-sftp";
+    },
+    openSftpForSession: async (sessionId: string) => {
+      openForSessionCalls += 1;
+      assert.equal(sessionId, "term-alive");
+      return "shared-sftp";
+    },
+    closeSftp: async () => {},
+    statLocal: async () => ({ size: 50, lastModified: 1 }),
+    startStreamTransfer: async (options: { targetSftpId?: string }) => {
+      assert.equal(options.targetSftpId, "shared-sftp");
+      return { transferId: "shared-resume" };
+    },
+  });
+  try {
+    const result = await resumeTransferWithDedicatedSession({
+      id: "shared-resume",
+      fileName: "file.bin",
+      sourcePath: "/local/file.bin",
+      targetPath: "/remote/file.bin",
+      sourceConnectionId: "local",
+      targetConnectionId: "term-alive",
+      targetHostId: "h1",
+      targetHostLabel: "box",
+      direction: "upload",
+      status: "interrupted",
+      totalBytes: 50,
+      transferredBytes: 10,
+      checkpointBytes: 10,
+      speed: 0,
+      startTime: 1,
+      isDirectory: false,
+      reconnectRequired: true,
+    }, {
+      hosts: [host("h1", "box", "1.2.3.4")],
+      keys: [],
+      identities: [],
+    });
+    assert.equal(result.success, true, result.error);
+    assert.equal(openForSessionCalls, 1, "must open on the live terminal transport");
+    assert.equal(openSftpCalls, 0, "must not cold-dial a dedicated SSH connection");
+    assert.equal(openSftpOpts, undefined);
+  } finally {
+    (netcattyBridge as { get: typeof originalGet }).get = originalGet;
+    resetDedicatedSessionOpenGateForTests();
+  }
 });
 
 test("classifyDedicatedResumeEndpoints detects download, upload, and remote-to-remote", () => {

--- a/application/state/sftp/dedicatedTransferResume.test.ts
+++ b/application/state/sftp/dedicatedTransferResume.test.ts
@@ -14,6 +14,7 @@ import {
   resetDedicatedSessionOpenGateForTests,
   resumeTransferWithDedicatedSession,
   resolveDirectoryResumeTargetRoot,
+  isUsableTransferSessionId,
   resolveHostForTransferEndpoint,
   resolveResumeHosts,
   shouldSkipCompletedResumeChild,
@@ -104,6 +105,15 @@ test("resolveHostForTransferEndpoint prefers id then label", () => {
   assert.equal(resolveHostForTransferEndpoint(hosts, "missing", "gone"), null);
 });
 
+test("isUsableTransferSessionId rejects SFTP pane connection ids", () => {
+  assert.equal(isUsableTransferSessionId("term-alive"), true);
+  assert.equal(isUsableTransferSessionId("local"), false);
+  assert.equal(isUsableTransferSessionId("agent"), false);
+  assert.equal(isUsableTransferSessionId("left-abc"), false);
+  assert.equal(isUsableTransferSessionId("right-deadbeef"), false);
+  assert.equal(isUsableTransferSessionId(undefined), false);
+});
+
 test("resolveResumeHosts accepts ephemeral quick-connect hosts in the host list", () => {
   const ephemeral = {
     ...host("quick-1", "10.2.0.32", "10.2.0.32"),
@@ -130,8 +140,34 @@ test("resolveResumeHosts accepts ephemeral quick-connect hosts in the host list"
   assert.equal(resolved.ok, true);
   if (resolved.ok) {
     assert.equal(resolved.endpoints.targetHost?.id, "quick-1");
-    // Live session is always attached so hard resume can borrow the transport.
+    // Pane-style ids are not terminal sessions — only real session ids attach.
     assert.equal(resolved.endpoints.targetSessionId, "sess-1");
+  }
+});
+
+test("resolveResumeHosts ignores left-/right- pane connection ids", () => {
+  const vaultHost = host("h1", "box", "1.2.3.4");
+  const resolved = resolveResumeHosts({
+    id: "up-pane",
+    fileName: "file.bin",
+    sourcePath: "/local/file.bin",
+    targetPath: "/remote/file.bin",
+    sourceConnectionId: "local",
+    targetConnectionId: "left-not-a-terminal",
+    targetHostId: "h1",
+    targetHostLabel: "box",
+    direction: "upload",
+    status: "interrupted",
+    totalBytes: 10,
+    transferredBytes: 2,
+    speed: 0,
+    startTime: 1,
+    isDirectory: false,
+  } as TransferTask, { hosts: [vaultHost], keys: [], identities: [] });
+  assert.equal(resolved.ok, true);
+  if (resolved.ok) {
+    assert.equal(resolved.endpoints.targetHost?.id, "h1");
+    assert.equal(resolved.endpoints.targetSessionId, undefined);
   }
 });
 

--- a/application/state/sftp/dedicatedTransferResume.ts
+++ b/application/state/sftp/dedicatedTransferResume.ts
@@ -436,26 +436,50 @@ type ResolvedEndpoints = {
   isRemoteToRemote: boolean;
   sourceHost: Host | null;
   targetHost: Host | null;
+  /** Live terminal/SFTP session to borrow when vault/ephemeral host is missing. */
+  sourceSessionId?: string;
+  targetSessionId?: string;
   resourceKeys: string[];
 };
 
-function resolveResumeHosts(
+function isUsableTransferSessionId(sessionId: string | undefined): sessionId is string {
+  return !!sessionId && sessionId !== "local" && sessionId !== "agent";
+}
+
+function missingHostError(label: string): string {
+  return `Cannot find host "${label}" in your vault. Re-add the host or start a new transfer.`;
+}
+
+/**
+ * Resolve remote endpoints for hard reconnect.
+ *
+ * Prefer vault/ephemeral host credentials **and** always attach any still-live
+ * terminal/SFTP connection ids so open can borrow the shared SSH transport
+ * instead of forcing a second full dial. When the host is missing entirely
+ * (quick-connect without save), session id alone is enough to reopen a channel.
+ */
+export function resolveResumeHosts(
   task: TransferTask,
   deps: DedicatedResumeDeps,
 ): { ok: true; endpoints: ResolvedEndpoints } | { ok: false; error: string } {
   const kind = classifyDedicatedResumeEndpoints(task);
+  // Prefer live sessions even when the host is known — hard resume should
+  // reuse the open terminal transport (openSftpForSession / parked registry).
+  const liveSourceSessionId = isUsableTransferSessionId(task.sourceConnectionId)
+    ? task.sourceConnectionId
+    : undefined;
+  const liveTargetSessionId = isUsableTransferSessionId(task.targetConnectionId)
+    ? task.targetConnectionId
+    : undefined;
 
   if (kind.isRemoteToRemote) {
     const sourceHost = resolveHostForTransferEndpoint(deps.hosts, task.sourceHostId, task.sourceHostLabel);
     const targetHost = resolveHostForTransferEndpoint(deps.hosts, task.targetHostId, task.targetHostLabel);
-    if (!sourceHost || !targetHost) {
-      const missing = !sourceHost
+    if ((!sourceHost && !liveSourceSessionId) || (!targetHost && !liveTargetSessionId)) {
+      const missing = !sourceHost && !liveSourceSessionId
         ? (task.sourceHostLabel || task.sourceHostId || "source")
         : (task.targetHostLabel || task.targetHostId || "target");
-      return {
-        ok: false,
-        error: `Cannot find host "${missing}" in your vault. Re-add the host or start a new transfer.`,
-      };
+      return { ok: false, error: missingHostError(missing) };
     }
     return {
       ok: true,
@@ -463,9 +487,11 @@ function resolveResumeHosts(
         ...kind,
         sourceHost,
         targetHost,
+        sourceSessionId: liveSourceSessionId,
+        targetSessionId: liveTargetSessionId,
         resourceKeys: getSftpTransferResourceKeys({
-          sourceHostId: sourceHost.id,
-          targetHostId: targetHost.id,
+          sourceHostId: sourceHost?.id ?? task.sourceHostId,
+          targetHostId: targetHost?.id ?? task.targetHostId,
         }),
       },
     };
@@ -481,15 +507,13 @@ function resolveResumeHosts(
   const remoteHost = kind.isDownload
     ? resolveHostForTransferEndpoint(deps.hosts, task.sourceHostId, task.sourceHostLabel)
     : resolveHostForTransferEndpoint(deps.hosts, task.targetHostId, task.targetHostLabel);
+  const remoteSessionId = kind.isDownload ? liveSourceSessionId : liveTargetSessionId;
 
-  if (!remoteHost) {
+  if (!remoteHost && !remoteSessionId) {
     const label = kind.isDownload
       ? (task.sourceHostLabel || task.sourceHostId || "source")
       : (task.targetHostLabel || task.targetHostId || "target");
-    return {
-      ok: false,
-      error: `Cannot find host "${label}" in your vault. Re-add the host or start a new transfer.`,
-    };
+    return { ok: false, error: missingHostError(label) };
   }
 
   return {
@@ -498,34 +522,86 @@ function resolveResumeHosts(
       ...kind,
       sourceHost: kind.isDownload ? remoteHost : null,
       targetHost: kind.isUpload ? remoteHost : null,
+      sourceSessionId: kind.isDownload ? remoteSessionId : undefined,
+      targetSessionId: kind.isUpload ? remoteSessionId : undefined,
       resourceKeys: getSftpTransferResourceKeys({
-        sourceHostId: kind.isDownload ? remoteHost.id : undefined,
-        targetHostId: kind.isUpload ? remoteHost.id : undefined,
+        sourceHostId: kind.isDownload ? (remoteHost?.id ?? task.sourceHostId) : undefined,
+        targetHostId: kind.isUpload ? (remoteHost?.id ?? task.targetHostId) : undefined,
       }),
     },
   };
+}
+
+async function openSessionBackedSftp(sessionId: string): Promise<string> {
+  const bridge = netcattyBridge.get();
+  if (!bridge?.openSftpForSession) {
+    throw new Error("Session-backed SFTP open is unavailable");
+  }
+  const sftpId = await bridge.openSftpForSession(sessionId);
+  if (!sftpId) throw new Error("Could not open SFTP on the existing server session");
+  return sftpId;
+}
+
+/**
+ * Open a hard-reconnect SFTP channel the same way the transfer pool does:
+ * prefer a live terminal session, otherwise open with transport reuse so we
+ * attach to a parked/shared SSH conn instead of a cold dedicated dial.
+ */
+async function openRemoteEndpoint(
+  host: Host | null,
+  sessionId: string | undefined,
+  deps: DedicatedResumeDeps,
+): Promise<string> {
+  if (host) {
+    return openTransferSftpSession(host, deps, {
+      dedicated: false,
+      sourceSessionId: sessionId,
+    });
+  }
+  if (sessionId) return openSessionBackedSftp(sessionId);
+  throw new Error("No remote host or session for dedicated resume");
 }
 
 async function openEndpointSessions(
   endpoints: ResolvedEndpoints,
   deps: DedicatedResumeDeps,
 ): Promise<{ sourceSftpId?: string; targetSftpId?: string }> {
-  if (endpoints.isRemoteToRemote && endpoints.sourceHost && endpoints.targetHost) {
+  if (endpoints.isRemoteToRemote) {
     // Open sequentially under the open-slot gate so we never hold 2×N dials.
-    const sourceSftpId = await openTransferSftpSession(endpoints.sourceHost, deps);
+    const sourceSftpId = await openRemoteEndpoint(
+      endpoints.sourceHost,
+      endpoints.sourceSessionId,
+      deps,
+    );
     try {
-      const targetSftpId = await openTransferSftpSession(endpoints.targetHost, deps);
+      const targetSftpId = await openRemoteEndpoint(
+        endpoints.targetHost,
+        endpoints.targetSessionId,
+        deps,
+      );
       return { sourceSftpId, targetSftpId };
     } catch (error) {
       await closeDedicatedSftpSession(sourceSftpId);
       throw error;
     }
   }
-  if (endpoints.isDownload && endpoints.sourceHost) {
-    return { sourceSftpId: await openTransferSftpSession(endpoints.sourceHost, deps) };
+  if (endpoints.isDownload) {
+    return {
+      sourceSftpId: await openRemoteEndpoint(
+        endpoints.sourceHost,
+        endpoints.sourceSessionId,
+        deps,
+      ),
+    };
   }
-  if (endpoints.isUpload && endpoints.targetHost) {
-    return { targetSftpId: await openTransferSftpSession(endpoints.targetHost, deps) };
+  if (endpoints.isUpload) {
+    return {
+      targetSftpId: await openRemoteEndpoint(
+        endpoints.targetHost,
+        endpoints.targetSessionId,
+        deps,
+      ),
+    };
   }
   throw new Error("No remote host for dedicated resume");
 }

--- a/application/state/sftp/dedicatedTransferResume.ts
+++ b/application/state/sftp/dedicatedTransferResume.ts
@@ -442,8 +442,15 @@ type ResolvedEndpoints = {
   resourceKeys: string[];
 };
 
-function isUsableTransferSessionId(sessionId: string | undefined): sessionId is string {
-  return !!sessionId && sessionId !== "local" && sessionId !== "agent";
+/**
+ * True for live terminal/SSH session ids that openSftpForSession can resolve.
+ * SFTP pane connection ids are `left-<uuid>` / `right-<uuid>` (createSftpConnectionId)
+ * and must not be passed to openSftpForSession.
+ */
+export function isUsableTransferSessionId(sessionId: string | undefined): sessionId is string {
+  if (!sessionId || sessionId === "local" || sessionId === "agent") return false;
+  if (/^(left|right)-/i.test(sessionId)) return false;
+  return true;
 }
 
 function missingHostError(label: string): string {

--- a/application/state/sftp/globalSftpTransferControl.test.ts
+++ b/application/state/sftp/globalSftpTransferControl.test.ts
@@ -79,7 +79,7 @@ test("softResumeTransfer with live walk paints transferring without requiring br
   ]);
 
   const handled = await softResumeTransfer(host, "dir");
-  assert.equal(handled, true);
+  assert.equal(handled.handled, true);
   assert.equal(getTasks().find((t) => t.id === "dir")?.status, "transferring");
   assert.equal(isTransferPauseLatched("dir"), false);
 
@@ -101,7 +101,8 @@ test("single-file softResume with live walk + bridge resume fail returns false (
   );
 
   const handled = await softResumeTransfer(host, "file-1");
-  assert.equal(handled, false, "must not soft-succeed when every bridge resume fails");
+  assert.equal(handled.handled, false, "must not soft-succeed when every bridge resume fails");
+  assert.match(handled.reason || "", /not active/i);
   // Must not paint transferring — hard reconnect path must remain available.
   assert.notEqual(getTasks().find((t) => t.id === "file-1")?.status, "transferring");
 
@@ -122,12 +123,55 @@ test("directory softResume with live walk and no bridge success still rejoins", 
   );
 
   const handled = await softResumeTransfer(host, "dir-2");
-  assert.equal(handled, true);
+  assert.equal(handled.handled, true);
   assert.equal(getTasks().find((t) => t.id === "dir-2")?.status, "transferring");
   // lifecycleEpoch cleared so child stream progress is accepted
   assert.equal(getTasks().find((t) => t.id === "dir-2")?.lifecycleEpoch, undefined);
 
   unregisterTransferWalk("dir-2");
+  resetTransferPauseLatchesForTests();
+  resetTransferWalkRegistryForTests();
+});
+
+test("single-file softPause demotes dead streams instead of painting paused", async () => {
+  resetTransferPauseLatchesForTests();
+  resetTransferWalkRegistryForTests();
+  const { host, getTasks } = createHost(
+    [makeTask("dead-file", "transferring")],
+    () => ({
+      pauseTransfer: async () => ({ success: false, reason: "Transfer is no longer active" }),
+    }),
+  );
+
+  const outcome = await softPauseTransfer(host, "dead-file");
+  assert.equal(outcome, "interrupted");
+  const row = getTasks().find((t) => t.id === "dead-file");
+  assert.equal(row?.status, "interrupted");
+  assert.equal(row?.reconnectRequired, true);
+  assert.match(row?.error || "", /no longer active/i);
+  assert.equal(isTransferPauseLatched("dead-file"), false);
+
+  resetTransferPauseLatchesForTests();
+  resetTransferWalkRegistryForTests();
+});
+
+test("soft resume without bridge lifecycleEpoch keeps a monotonic epoch (no stale re-pause)", async () => {
+  resetTransferPauseLatchesForTests();
+  resetTransferWalkRegistryForTests();
+  const { host, getTasks } = createHost(
+    [{ ...makeTask("no-epoch", "paused"), lifecycleEpoch: 3, speed: 0 }],
+    () => ({
+      // Older bridges returned only { success: true } — must not clear epoch.
+      resumeTransfer: async () => ({ success: true }),
+    }),
+  );
+
+  const result = await softResumeTransfer(host, "no-epoch");
+  assert.equal(result.handled, true);
+  const row = getTasks().find((t) => t.id === "no-epoch");
+  assert.equal(row?.status, "transferring");
+  assert.equal(row?.lifecycleEpoch, 4, "must advance past pause epoch when bridge omits epoch");
+
   resetTransferPauseLatchesForTests();
   resetTransferWalkRegistryForTests();
 });
@@ -157,7 +201,7 @@ test("soft pause/resume stamps bridge lifecycleEpoch so later progress is not st
   assert.ok(typeof pausedEpoch === "number" && pausedEpoch > 0);
 
   const handled = await softResumeTransfer(host, "stream");
-  assert.equal(handled, true);
+  assert.equal(handled.handled, true);
   const resumed = getTasks().find((t) => t.id === "stream");
   assert.equal(resumed?.status, "transferring");
   // Bridge-aligned: must equal last resume bridge epoch, not control-plane bumps.
@@ -186,7 +230,7 @@ test("directory softResume stamps bridge epoch only on successIds; queued siblin
   );
 
   const handled = await softResumeTransfer(host, "folder-mix");
-  assert.equal(handled, true);
+  assert.equal(handled.handled, true);
   const parent = getTasks().find((t) => t.id === "folder-mix");
   const live = getTasks().find((t) => t.id === "live-child");
   const queued = getTasks().find((t) => t.id === "queued-child");

--- a/application/state/sftp/globalSftpTransferControl.ts
+++ b/application/state/sftp/globalSftpTransferControl.ts
@@ -10,7 +10,11 @@
 import type { TransferTask } from "../../../domain/models";
 import { netcattyBridge } from "../../../infrastructure/services/netcattyBridge";
 import { globalSftpTransferScheduler } from "./globalTransferScheduler";
-import { isBenignPauseMiss, planPartialPauseRollback } from "./pauseTransferOutcome";
+import {
+  allPauseResultsDeadTransfer,
+  isBenignPauseMiss,
+  planPartialPauseRollback,
+} from "./pauseTransferOutcome";
 import {
   bumpTransferControlEpoch,
   isTransferControlEpochCurrent,
@@ -272,6 +276,7 @@ export async function softPauseTransfer(
     }
     return "noop";
   }
+  const bridgePauseResults = pauseResults.map((row) => row.result);
   const allBenignOrSuccess = backendIds.length === 0 || pauseResults.every(
     ({ result }) => result.success || isBenignPauseMiss(result.reason),
   );
@@ -283,6 +288,33 @@ export async function softPauseTransfer(
         }
       }
       return "noop";
+    }
+    // Dead stream painted as "paused" made Resume soft-fail and fall into
+    // dedicated vault reconnect — which cannot resolve quick-connect hosts.
+    if (allPauseResultsDeadTransfer(bridgePauseResults)) {
+      releaseTransferPauseTree(taskId, childIds);
+      for (const id of [taskId, ...childIds]) {
+        try { globalSftpTransferScheduler.resume(id); } catch { /* best-effort */ }
+      }
+      const deadReason = pauseResults.find(({ result }) => result?.reason)?.result?.reason
+        ?? "Transfer is no longer active";
+      host.setTasks(host.getTasks().map((candidate) => (
+        candidate.id === taskId || candidate.parentTaskId === taskId
+          ? {
+            ...candidate,
+            status: (["completed", "cancelled"].includes(candidate.status)
+              ? candidate.status
+              : "interrupted") as TransferTask["status"],
+            speed: 0,
+            phase: undefined,
+            reconnectRequired: true,
+            error: candidate.id === taskId
+              ? (candidate.error ?? `${deadReason}. Resume will reconnect.`)
+              : candidate.error,
+          }
+          : candidate
+      )));
+      return "interrupted";
     }
     const byId = new Map(pauseResults.map((row) => [row.id, row.result]));
     const bridgeEpoch = maxBridgeLifecycleEpoch(pauseResults.map((row) => row.result));
@@ -356,8 +388,15 @@ export async function softPauseTransfer(
   return "noop";
 }
 
+export type SoftResumeResult = {
+  /** True when soft-resume rejoined without dedicated hard reconnect. */
+  handled: boolean;
+  /** Bridge miss reason when handled is false (drives demotion policy). */
+  reason?: string;
+};
+
 /**
- * Soft-resume a live transfer. Returns true when handled without dedicated reconnect.
+ * Soft-resume a live transfer.
  *
  * Single-file: requires at least one successful bridge resume (walkAlive alone is
  * not enough — a paused/dead stream with a live walk would paint transferring and
@@ -366,14 +405,16 @@ export async function softPauseTransfer(
  *
  * task.lifecycleEpoch follows bridge epochs only (never control-plane bumps), so
  * main-process progress ingest is not stale-dropped after soft pause/resume.
+ * Soft-resume must stamp a real bridge epoch (or keep the previous one) — never
+ * clear to `undefined`, or a late pause event re-applies "paused".
  */
 export async function softResumeTransfer(
   host: TransferControlHost,
   taskId: string,
-): Promise<boolean> {
+): Promise<SoftResumeResult> {
   const tasks = host.getTasks();
   const task = tasks.find((candidate) => candidate.id === taskId);
-  if (!task) return false;
+  if (!task) return { handled: false, reason: "Transfer not found" };
 
   const childIds = unfinishedChildren(tasks, taskId);
   // Always release the full tree known to the store so orphaned child latches
@@ -398,10 +439,10 @@ export async function softResumeTransfer(
 
   const resumeIds = treeIds.length > 0 ? treeIds : [taskId];
   const results = await Promise.all(resumeIds.map(async (id) =>
-    bridge?.resumeTransfer?.(id) ?? { success: false },
+    bridge?.resumeTransfer?.(id) ?? { success: false, reason: "Resume unavailable" },
   ));
   const after = host.getTasks().find((candidate) => candidate.id === taskId);
-  if (after?.status === "cancelled") return true;
+  if (after?.status === "cancelled") return { handled: true };
 
   const successIds = resumeIds.filter((_, index) => results[index]?.success);
   const walkAlive = isTransferWalkInFlight(taskId);
@@ -417,9 +458,11 @@ export async function softResumeTransfer(
         // Clear any control-plane / stale pause epoch so child stream progress is accepted.
         null,
       ));
-      return true;
+      return { handled: true };
     }
-    return false;
+    const reason = results.find((row) => row?.reason)?.reason
+      ?? "Transfer is no longer active";
+    return { handled: false, reason };
   }
 
   const resumed = new Set(successIds);
@@ -448,8 +491,14 @@ export async function softResumeTransfer(
       return candidate;
     }
 
-    // Parent: transferring; stamp only a real bridge epoch (or clear).
+    // Parent: transferring. Prefer bridge epoch; never wipe to undefined or a
+    // late pause fanout re-applies "paused" (acceptsLifecycle treats missing as any).
     if (candidate.id === taskId) {
+      const nextEpoch = parentBridgeEpoch !== undefined
+        ? parentBridgeEpoch
+        : (Number.isFinite(candidate.lifecycleEpoch)
+          ? Math.max(0, candidate.lifecycleEpoch as number) + 1
+          : 1);
       return {
         ...candidate,
         status: "transferring" as const,
@@ -458,12 +507,18 @@ export async function softResumeTransfer(
         pauseUnavailableReason: undefined,
         phase: undefined,
         speed: 0,
-        lifecycleEpoch: parentBridgeEpoch,
+        lifecycleEpoch: nextEpoch,
       };
     }
 
     // Bridge-resumed children only: use their own stream epoch when present.
     if (resumed.has(candidate.id)) {
+      const childEpoch = bridgeEpochById.get(candidate.id);
+      const nextEpoch = childEpoch !== undefined
+        ? childEpoch
+        : (Number.isFinite(candidate.lifecycleEpoch)
+          ? Math.max(0, candidate.lifecycleEpoch as number) + 1
+          : 1);
       return {
         ...candidate,
         status: "transferring" as const,
@@ -472,7 +527,7 @@ export async function softResumeTransfer(
         pauseUnavailableReason: undefined,
         phase: undefined,
         speed: 0,
-        lifecycleEpoch: bridgeEpochById.get(candidate.id),
+        lifecycleEpoch: nextEpoch,
       };
     }
 
@@ -495,7 +550,7 @@ export async function softResumeTransfer(
       lifecycleEpoch: undefined,
     };
   }));
-  return true;
+  return { handled: true };
 }
 
 /** Default bridge accessor for Electron / tests with window.netcatty. */

--- a/application/state/sftp/pauseTransferOutcome.test.ts
+++ b/application/state/sftp/pauseTransferOutcome.test.ts
@@ -5,7 +5,9 @@ import test from "node:test";
 import { createGlobalSftpTransferScheduler } from "./globalTransferScheduler.ts";
 import {
   allPauseResultsBenignOrSuccess,
+  allPauseResultsDeadTransfer,
   isBenignPauseMiss,
+  isDeadTransferPauseMiss,
   isHardPauseFailure,
   planPartialPauseRollback,
   resolveDirectoryPauseParentOutcome,
@@ -18,6 +20,22 @@ test("benign pause misses match store regex (no longer active / not found / sess
   assert.equal(isBenignPauseMiss("SFTP session closed"), true);
   assert.equal(isBenignPauseMiss("This transfer cannot be paused safely"), false);
   assert.equal(isBenignPauseMiss("Pause unavailable"), false);
+});
+
+test("dead transfer pause misses are a strict subset of benign misses", () => {
+  assert.equal(isDeadTransferPauseMiss("Transfer is no longer active"), true);
+  assert.equal(isDeadTransferPauseMiss("session not found"), true);
+  assert.equal(isDeadTransferPauseMiss("SFTP session closed"), false);
+  assert.equal(allPauseResultsDeadTransfer([
+    { success: false, reason: "Transfer is no longer active" },
+  ]), true);
+  assert.equal(allPauseResultsDeadTransfer([
+    { success: true },
+    { success: false, reason: "Transfer is no longer active" },
+  ]), false);
+  assert.equal(allPauseResultsDeadTransfer([
+    { success: false, reason: "cannot be paused safely" },
+  ]), false);
 });
 
 test("allPauseResultsBenignOrSuccess rejects mixed hard failures", () => {

--- a/application/state/sftp/pauseTransferOutcome.ts
+++ b/application/state/sftp/pauseTransferOutcome.ts
@@ -18,6 +18,15 @@ export function isBenignPauseMiss(reason?: string): boolean {
   return /no longer active|not found|session/i.test(reason || "");
 }
 
+/**
+ * Bridge reports the live stream is gone. For a single top-level file this is
+ * not a successful pause — Resume must hard-reconnect rather than soft-unpause
+ * a dead row painted as "paused".
+ */
+export function isDeadTransferPauseMiss(reason?: string): boolean {
+  return /no longer active|not found/i.test(reason || "");
+}
+
 export function isHardPauseFailure(result: PauseBridgeResult | undefined): boolean {
   if (!result) return true;
   if (result.success) return false;
@@ -33,6 +42,14 @@ export function allPauseResultsBenignOrSuccess(
 ): boolean {
   if (results.length === 0) return true;
   return results.every((result) => result.success || isBenignPauseMiss(result.reason));
+}
+
+/** True when every bridge pause miss means the stream is already dead. */
+export function allPauseResultsDeadTransfer(
+  results: readonly PauseBridgeResult[],
+): boolean {
+  if (results.length === 0) return false;
+  return results.every((result) => !result.success && isDeadTransferPauseMiss(result.reason));
 }
 
 export type DirectoryPauseParentOutcome =

--- a/application/state/sftpTransferCenterStore.test.ts
+++ b/application/state/sftpTransferCenterStore.test.ts
@@ -2913,6 +2913,59 @@ test("publishOwner while latched does not raise transferredBytes after pause", a
   resetTransferPauseLatchesForTests();
 });
 
+test("soft-resume transient bridge miss stays paused without dedicated rehome", async (t) => {
+  // Regression: pause→resume was flipping "reconnecting" then stuck paused, and
+  // the SFTP panel queue lost the row because soft-fail always hard-reconnected.
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  t.after(() => {
+    if (previousWindow) Object.defineProperty(globalThis, "window", previousWindow);
+    else Reflect.deleteProperty(globalThis, "window");
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        resumeTransfer: async () => ({
+          success: false,
+          reason: "The current file is still finishing. Try resume again.",
+        }),
+        clearPendingTransferCancel: async () => {},
+      },
+    },
+  });
+
+  const store = createSftpTransferCenterStore();
+  let dedicated = 0;
+  store.setDedicatedResumeHandler(async () => {
+    dedicated += 1;
+    return { success: false, error: "should not hard reconnect" };
+  });
+  store.registerOwner("panel-a", {
+    pause: async () => {},
+    resume: async () => {},
+    cancel: async () => {},
+    retry: async () => {},
+    prioritize: async () => {},
+    dismiss: () => {},
+    ownsTask: () => true,
+  });
+  store.publishOwner("panel-a", [{
+    ...makeTask("live-soft-miss", "paused"),
+    sourceHostId: "host-a",
+    transferredBytes: 2_000_000,
+    checkpointBytes: 2_000_000,
+    ownerId: "panel-a",
+  }]);
+
+  await store.resume("live-soft-miss");
+  const row = store.getSnapshot().tasks.find((task) => task.id === "live-soft-miss");
+  assert.equal(dedicated, 0, "must not rehome to dedicated-resume for transient soft-miss");
+  assert.equal(row?.status, "paused");
+  assert.equal(row?.ownerId, "panel-a", "panel queue must keep the task");
+  assert.equal(row?.reconnectRequired, false);
+  assert.match(row?.error || "", /still finishing/i);
+});
+
 test("soft-resume failure demotes and uses dedicated handler even with a live owner", async (t) => {
   const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
   t.after(() => {

--- a/application/state/sftpTransferCenterStore.ts
+++ b/application/state/sftpTransferCenterStore.ts
@@ -922,18 +922,39 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
       }
 
       // Soft-resume whenever a walk may still be alive, even if reconnectRequired
-      // was set spuriously. Dedicated only when soft-resume cannot rejoin.
+      // was set spuriously. Dedicated only when the live stream is truly gone.
       const preferSoft = !needsDedicatedReconnect || isTransferWalkInFlight(taskId);
       if (preferSoft) {
-        const handled = await softResumeTransfer(controlHost, taskId);
-        if (handled) {
+        const soft = await softResumeTransfer(controlHost, taskId);
+        if (soft.handled) {
           notifyOwners();
           return;
         }
-        // Soft could not rejoin (dead walk + bridge miss). Never silent-return:
-        // demote so the hard reconnect / adopt path below can run even when a
-        // stale panel owner is still registered.
         if (action === "resume") {
+          const reason = soft.reason || "Transfer session is no longer active";
+          // Transient / verification soft-misses must NOT hard-reconnect: that
+          // rehomes ownerId to dedicated-resume (panel queue disappears) and can
+          // race a still-live paused stream → "reconnecting" then stuck paused.
+          // "Resume unavailable" / not found = no live bridge stream (restart or
+          // tests without a bridge) — those must still hard-reconnect / adopt.
+          const streamGone = /no longer active|not active|not found|session is no longer|Resume unavailable|Transfer not found/i
+            .test(reason);
+          if (!streamGone) {
+            tasks = tasks.map((candidate) => candidate.id === taskId ? {
+              ...candidate,
+              status: "paused" as const,
+              reconnectRequired: false,
+              speed: 0,
+              phase: undefined,
+              error: reason,
+              pauseUnavailableReason: undefined,
+            } : candidate);
+            emit();
+            notifyOwners();
+            return;
+          }
+          // Soft could not rejoin a dead stream. Demote so the hard reconnect /
+          // adopt path below can run even when a stale panel owner remains.
           tasks = tasks.map((candidate) => candidate.id === taskId ? {
             ...candidate,
             status: "interrupted" as const,
@@ -941,7 +962,7 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
             speed: 0,
             phase: undefined,
             error: candidate.error
-              ?? "Transfer session is no longer active. Resume will reconnect.",
+              ?? `${reason}. Resume will reconnect.`,
           } : candidate);
           emit();
           task = tasks.find((candidate) => candidate.id === taskId);

--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -68,6 +68,23 @@ function shouldForwardWorkerRendererEvent(channel) {
 }
 
 /**
+ * Lift worker-local lifecycleEpoch into main-process space when transferBridge
+ * has advanced the control epoch (pause rollback / soft-resume).
+ */
+function translateWorkerTransferLifecycleEpoch(transferId, workerEpoch) {
+  try {
+    // Lazy require avoids circular init with transferBridge.
+    const transferBridge = require("./transferBridge.cjs");
+    if (typeof transferBridge.resolveWorkerTransferLifecycleEpoch === "function") {
+      return transferBridge.resolveWorkerTransferLifecycleEpoch(transferId, workerEpoch);
+    }
+  } catch {
+    // transferBridge unavailable in pure unit fixtures
+  }
+  return workerEpoch;
+}
+
+/**
  * Map worker transfer IPC onto the global transfer-center channel.
  * The utilityProcess cannot call BrowserWindow; main must fan these out.
  * Exported for unit tests.
@@ -88,7 +105,7 @@ function mapWorkerTransferChannelToGlobalEvent(channel, payload) {
       downloadCheckpointBytes: payload.downloadCheckpointBytes,
       uploadCheckpointBytes: payload.uploadCheckpointBytes,
       sourceFingerprint: payload.sourceFingerprint,
-      lifecycleEpoch: payload.lifecycleEpoch,
+      lifecycleEpoch: translateWorkerTransferLifecycleEpoch(transferId, payload.lifecycleEpoch),
       lifecycleState: payload.lifecycleState,
       resumable: payload.resumable,
       pauseUnavailableReason: payload.pauseUnavailableReason,
@@ -102,6 +119,7 @@ function mapWorkerTransferChannelToGlobalEvent(channel, payload) {
       ...payload,
       type: channel.endsWith(":queued") ? "queued" : "started",
       transferId,
+      lifecycleEpoch: translateWorkerTransferLifecycleEpoch(transferId, payload.lifecycleEpoch),
     };
   }
   if (channel === "netcatty:transfer:complete") {

--- a/electron/bridges/terminalWorkerManager.transferFanout.test.cjs
+++ b/electron/bridges/terminalWorkerManager.transferFanout.test.cjs
@@ -37,6 +37,24 @@ test("mapWorkerTransferChannelToGlobalEvent maps progress for store ingest", () 
   assert.equal(event.resumable, undefined);
 });
 
+test("worker progress lifecycleEpoch is lifted into main-process space after soft-resume", () => {
+  const transferBridge = require("./transferBridge.cjs");
+  transferBridge._setWorkerTransferLifecycleEpochForTests("t-epoch", 5);
+  try {
+    // Worker still emits pre-resume local epoch 3; main advanced to 5 on resume.
+    const event = mapWorkerTransferChannelToGlobalEvent("netcatty:transfer:progress", {
+      transferId: "t-epoch",
+      transferred: 10,
+      totalBytes: 100,
+      lifecycleEpoch: 3,
+      lifecycleState: "transferring",
+    });
+    assert.equal(event.lifecycleEpoch, 5, "must not emit below main control epoch");
+  } finally {
+    transferBridge._clearWorkerTransferLifecycleEpochsForTests();
+  }
+});
+
 test("worker transfer events are global-only and keep complete task metadata", () => {
   const started = mapWorkerTransferChannelToGlobalEvent("netcatty:transfer:started", {
     type: "started",

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -3214,40 +3214,92 @@ async function startTransferNow(event, payload, onProgress) {
   };
 
   /**
-   * Soft-resume stays on the live stream handle. A full SHA-256 rehash of the
-   * source (multi-GB dmg/iso) made pause→resume feel frozen. Stat size only;
-   * hard reconnect after restart still uses full fingerprint verification in
+   * Soft-resume stays on the live stream handle. Avoid full-file SHA-256 (multi-GB
+   * freeze). Detect same-size in-place rewrites with size + mtime + a short
+   * head sample; hard reconnect after restart still uses full fingerprint in
    * startTransferNow.
    */
-  transfer.quickVerifySourceForSoftResume = async () => {
-    const expected = Math.max(
-      0,
-      Number(transfer.totalBytes) || 0,
-      Number(lastObservedTotal) || 0,
-    );
-    let size = expected;
+  const SOFT_RESUME_SAMPLE_BYTES = 256 * 1024;
+  const readSourceSoftIdentity = async () => {
     if (sourceType === "local") {
       const st = await fs.promises.stat(sourcePath);
-      size = st.size;
-    } else if (sourceType === "sftp") {
+      const sampleBytes = Math.min(SOFT_RESUME_SAMPLE_BYTES, Math.max(0, st.size));
+      const sample = sampleBytes > 0
+        ? await hashLocalPrefix(sourcePath, sampleBytes, { signal: transfer.signal })
+        : null;
+      return {
+        size: st.size,
+        mtimeMs: Number.isFinite(st.mtimeMs) ? st.mtimeMs : undefined,
+        sample: sample ? `sha256:${sample}` : null,
+      };
+    }
+    if (sourceType === "sftp") {
       const client = sftpClients.get(sourceSftpId);
       if (!client) throw new Error("Source SFTP session not found");
+      let size = 0;
+      let mtimeMs;
       if (isScpModeClient(client)) {
         const st = await getScpBackendForClient(client).stat(sourcePath, {
           encoding: resolveEncodingForRequest(sourceSftpId, sourceEncoding),
           signal: transfer.signal,
         });
         size = st.size;
+        mtimeMs = Number.isFinite(st.mtimeMs) ? st.mtimeMs
+          : (Number.isFinite(st.mtime) ? st.mtime * 1000 : undefined);
       } else {
         await requireSftpChannel(client);
         const encoded = encodePathForSession(sourceSftpId, sourcePath, sourceEncoding);
         const st = await client.stat(encoded);
         size = st.size;
+        // ssh2 attrs: mtime is seconds.
+        mtimeMs = Number.isFinite(st.mtimeMs) ? st.mtimeMs
+          : (Number.isFinite(st.mtime) ? st.mtime * 1000 : undefined);
       }
+      // Skip remote head samples here: open-ended SFTP reads hang on incomplete
+      // mocks and slow links. Size + mtime covers same-size rewrites that bump
+      // mtime; full SHA-256 still runs on hard reconnect.
+      return { size, mtimeMs, sample: null };
     }
-    if (expected > 0 && size !== expected) {
+    return {
+      size: Math.max(0, Number(transfer.totalBytes) || Number(lastObservedTotal) || 0),
+      mtimeMs: undefined,
+      sample: null,
+    };
+  };
+
+  transfer.captureSourceSoftIdentity = async () => {
+    try {
+      transfer.sourceSoftIdentity = await readSourceSoftIdentity();
+    } catch {
+      // Best-effort baseline for soft resume.
+    }
+  };
+
+  transfer.quickVerifySourceForSoftResume = async () => {
+    const expectedSize = Math.max(
+      0,
+      Number(transfer.sourceSoftIdentity?.size) || 0,
+      Number(transfer.totalBytes) || 0,
+      Number(lastObservedTotal) || 0,
+    );
+    const current = await readSourceSoftIdentity();
+    if (expectedSize > 0 && current.size !== expectedSize) {
       throw new Error("Resume safety check failed: the source file has changed");
     }
+    const expectedMtime = transfer.sourceSoftIdentity?.mtimeMs;
+    if (
+      Number.isFinite(expectedMtime)
+      && Number.isFinite(current.mtimeMs)
+      && current.mtimeMs !== expectedMtime
+    ) {
+      throw new Error("Resume safety check failed: the source file has changed");
+    }
+    const expectedSample = transfer.sourceSoftIdentity?.sample;
+    if (expectedSample && current.sample && current.sample !== expectedSample) {
+      throw new Error("Resume safety check failed: the source file has changed");
+    }
+    // Refresh baseline for a later pause/resume cycle in this same stream.
+    transfer.sourceSoftIdentity = current;
   };
 
   transfer.captureSourceFingerprint = () => {
@@ -3396,6 +3448,12 @@ async function startTransferNow(event, payload, onProgress) {
           fileSize = stat.size;
         }
       }
+    }
+
+    // Baseline for soft resume (size + mtime + head sample). Full SHA-256 remains
+    // for hard reconnect / crash recovery.
+    if (transfer.resumable && typeof transfer.captureSourceSoftIdentity === "function") {
+      void transfer.captureSourceSoftIdentity();
     }
 
     const sourceClient = sourceType === "sftp" ? sftpClients.get(sourceSftpId) : null;
@@ -4127,7 +4185,7 @@ function cancelQueuedTransfer(transferId) {
 
 function resumeQueuedTransfer(transferId) {
   const job = pausedAdmittedTransfers.get(transferId);
-  if (!job) return false;
+  if (!job) return null;
   pausedAdmittedTransfers.delete(transferId);
   const lifecycleEpoch = Math.max(0, Number(job.payload?.lifecycleEpoch) || 0) + 1;
   job.payload.lifecycleEpoch = lifecycleEpoch;
@@ -4137,7 +4195,8 @@ function resumeQueuedTransfer(transferId) {
   job.event?.sender?.send?.("netcatty:transfer:queued", queuedEvent);
   broadcastGlobalTransferEvent(queuedEvent);
   pumpAdmittedTransfers();
-  return true;
+  // Soft-resume must stamp this epoch; synthesizing another one freezes progress.
+  return { success: true, lifecycleEpoch };
 }
 
 function prioritizeQueuedTransfer(transferId) {
@@ -4474,7 +4533,8 @@ async function pauseTransfer(_event, payload) {
 }
 
 async function resumeTransfer(_event, payload) {
-  if (resumeQueuedTransfer(payload?.transferId)) return { success: true };
+  const queuedResume = resumeQueuedTransfer(payload?.transferId);
+  if (queuedResume) return queuedResume;
   const transfer = activeTransfers.get(payload?.transferId);
   if (!transfer) {
     return { success: false, reason: "Transfer is no longer active" };
@@ -4506,9 +4566,8 @@ async function resumeTransfer(_event, payload) {
   }
   if (transfer.resumable) {
     try {
-      // Soft resume must not re-hash multi-GB sources. Size check only; full
-      // SHA-256 remains for hard reconnect (startTransferNow). Still kick off
-      // background capture so a later crash/restart has a durable identity.
+      // Soft resume: size + mtime + head sample (not full-file SHA-256).
+      // Full fingerprint remains for hard reconnect (startTransferNow).
       if (typeof transfer.quickVerifySourceForSoftResume === "function") {
         await transfer.quickVerifySourceForSoftResume();
       } else if (transfer.verifySourceFingerprint) {
@@ -4522,7 +4581,7 @@ async function resumeTransfer(_event, payload) {
       }
       if (!transfer.sourceFingerprint) {
         void transfer.captureSourceFingerprint?.().catch(() => {
-          // Best-effort; soft resume already size-checked.
+          // Best-effort; soft resume already checked soft identity.
         });
       }
     } catch (error) {
@@ -4840,7 +4899,8 @@ function registerHandlers(ipcMain, options = {}) {
       }
     });
     ipcMain.handle("netcatty:transfer:resume", async (event, payload) => {
-      if (resumeQueuedTransfer(payload?.transferId)) return { success: true };
+      const queuedResume = resumeQueuedTransfer(payload?.transferId);
+      if (queuedResume) return queuedResume;
       const result = await workerRequest(event, "netcatty:transfer:resume", payload);
       if (result?.success) {
         const lifecycleEpoch = nextWorkerLifecycleEpoch(payload?.transferId, result.lifecycleEpoch);

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -4897,7 +4897,7 @@ function registerHandlers(ipcMain, options = {}) {
           lifecycleEpoch,
           lifecycleState: "paused",
         });
-        return result;
+        return { ...result, lifecycleEpoch };
       } catch (error) {
         const rollbackEpoch = nextWorkerLifecycleEpoch(payload?.transferId);
         broadcastGlobalTransferEvent({
@@ -4914,6 +4914,8 @@ function registerHandlers(ipcMain, options = {}) {
       if (queuedResume) return queuedResume;
       const result = await workerRequest(event, "netcatty:transfer:resume", payload);
       if (result?.success) {
+        // Normalize into main-process epoch space (may advance past worker-local).
+        // Soft-resume UI must stamp THIS epoch or later worker progress is stale.
         const lifecycleEpoch = nextWorkerLifecycleEpoch(payload?.transferId, result.lifecycleEpoch);
         broadcastGlobalTransferEvent({
           type: "resumed",
@@ -4921,6 +4923,7 @@ function registerHandlers(ipcMain, options = {}) {
           lifecycleEpoch,
           lifecycleState: "transferring",
         });
+        return { ...result, lifecycleEpoch };
       }
       return result;
     });

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -52,44 +52,23 @@ function sleepMs(ms) {
 }
 
 /**
- * Single-flight finalize for soft-drain sparse staging:
- * wait for active ranges → truncate once → clear deferredSparseTruncate.
- * Background settle and Resume both await the same promise so they cannot
- * race two truncates around unpause.
+ * Single-flight *truncate only* (after active ranges are already idle).
+ * Wait loops are per-caller so Resume can enforce its own 60s budget without
+ * joining a multi-minute background wait, and a failed attempt does not stick
+ * forever on the transfer.
  */
-function ensureDeferredSparseFinalize(transfer, transferId, options = {}) {
+function runExclusiveSparseTruncate(transfer) {
   if (!transfer) {
     return Promise.resolve({ ok: false, reason: "Transfer is no longer active" });
   }
-  if (!transfer.deferredSparseTruncate && !transfer._deferredSparseSettlePromise) {
+  if (!transfer.deferredSparseTruncate) {
     return Promise.resolve({ ok: true });
   }
-  if (transfer._deferredSparseSettlePromise) {
-    return transfer._deferredSparseSettlePromise;
+  if (transfer._sparseTruncatePromise) {
+    return transfer._sparseTruncatePromise;
   }
-  const maxWaitMs = Number.isFinite(options.maxWaitMs)
-    ? options.maxWaitMs
-    : RESUME_RANGE_SETTLE_MS;
   const run = (async () => {
     try {
-      const deadline = Date.now() + Math.max(0, maxWaitMs);
-      while (
-        transfer.paused
-        && !transfer.cancelled
-        && activeTransfers.get(transferId) === transfer
-        && transfer.deferredSparseTruncate
-        && typeof transfer.getActiveRangeCount === "function"
-        && transfer.getActiveRangeCount() > 0
-        && Date.now() < deadline
-      ) {
-        await sleepMs(RANGE_SETTLE_POLL_MS);
-      }
-      if (transfer.cancelled || activeTransfers.get(transferId) !== transfer) {
-        return { ok: false, reason: "Transfer is no longer active" };
-      }
-      if (!transfer.deferredSparseTruncate) {
-        return { ok: true };
-      }
       const activeLeft = typeof transfer.getActiveRangeCount === "function"
         ? transfer.getActiveRangeCount()
         : 0;
@@ -104,25 +83,67 @@ function ensureDeferredSparseFinalize(transfer, transferId, options = {}) {
       } catch {
         // Contiguous checkpoint remains valid for resume.
       }
-      if (transfer.cancelled || activeTransfers.get(transferId) !== transfer) {
-        return { ok: false, reason: "Transfer is no longer active" };
-      }
       transfer.deferredSparseTruncate = false;
       return { ok: true };
     } finally {
-      // Keep the settled promise on the transfer so concurrent awaiters still
-      // observe the same completion; replace only when starting a new pause.
+      // Always clear so a later Resume can retry after ranges finish.
+      if (transfer._sparseTruncatePromise === run) {
+        transfer._sparseTruncatePromise = null;
+      }
     }
   })();
-  transfer._deferredSparseSettlePromise = run;
+  transfer._sparseTruncatePromise = run;
   return run;
+}
+
+/**
+ * Wait for active concurrent ranges (caller-owned deadline), then exclusive truncate.
+ */
+async function ensureDeferredSparseFinalize(transfer, transferId, options = {}) {
+  if (!transfer) {
+    return { ok: false, reason: "Transfer is no longer active" };
+  }
+  if (!transfer.deferredSparseTruncate && !transfer._sparseTruncatePromise) {
+    return { ok: true };
+  }
+  const maxWaitMs = Number.isFinite(options.maxWaitMs)
+    ? options.maxWaitMs
+    : RESUME_RANGE_SETTLE_MS;
+  const deadline = Date.now() + Math.max(0, maxWaitMs);
+  while (
+    transfer.paused
+    && !transfer.cancelled
+    && activeTransfers.get(transferId) === transfer
+    && transfer.deferredSparseTruncate
+    && typeof transfer.getActiveRangeCount === "function"
+    && transfer.getActiveRangeCount() > 0
+    && Date.now() < deadline
+  ) {
+    await sleepMs(RANGE_SETTLE_POLL_MS);
+  }
+  if (transfer.cancelled || activeTransfers.get(transferId) !== transfer) {
+    return { ok: false, reason: "Transfer is no longer active" };
+  }
+  if (!transfer.deferredSparseTruncate) {
+    return { ok: true };
+  }
+  const activeLeft = typeof transfer.getActiveRangeCount === "function"
+    ? transfer.getActiveRangeCount()
+    : 0;
+  if (activeLeft > 0) {
+    return {
+      ok: false,
+      reason: "The current file is still finishing. Try resume again.",
+    };
+  }
+  return runExclusiveSparseTruncate(transfer);
 }
 
 /** Fire-and-forget background settle after soft-drain pause. */
 function scheduleDeferredSparseTruncateSettle(transfer, transferId) {
   if (!transfer?.deferredSparseTruncate) return;
   void ensureDeferredSparseFinalize(transfer, transferId, {
-    // Background may wait a long time for slow SSH ranges while UI stays paused.
+    // Background may wait longer for slow SSH ranges while UI stays paused.
     maxWaitMs: Math.max(RESUME_RANGE_SETTLE_MS, 5 * 60_000),
   }).catch(() => {});
 }
@@ -4430,8 +4451,8 @@ async function pauseTransfer(_event, payload) {
         }
       } else {
         transfer.deferredSparseTruncate = true;
-        // New pause owns a fresh single-flight finalize promise.
-        transfer._deferredSparseSettlePromise = null;
+        // New pause owns a fresh exclusive truncate slot.
+        transfer._sparseTruncatePromise = null;
         // Finish truncate in the background when in-flight ranges land so a
         // later Resume is not blocked by "still finishing" after a short wait.
         scheduleDeferredSparseTruncateSettle(transfer, payload?.transferId);
@@ -4464,7 +4485,7 @@ async function pauseTransfer(_event, payload) {
     // Unpausing here made folder pause look broken (amber error + children keep going).
     if (Number.isFinite(transfer.checkpointBytes) && transfer.checkpointBytes >= 0) {
       transfer.deferredSparseTruncate = true;
-      transfer._deferredSparseSettlePromise = null;
+      transfer._sparseTruncatePromise = null;
       scheduleDeferredSparseTruncateSettle(transfer, payload?.transferId);
     } else {
       transfer.deferredSparseTruncate = false;
@@ -4599,9 +4620,9 @@ async function resumeTransfer(_event, payload) {
     }
   }
   // Soft-drained concurrent pause may leave a sparse tail past the contiguous
-  // checkpoint. Single-flight finalize (background + resume share one promise)
-  // so truncate cannot race new writes after unpause.
-  if (transfer.deferredSparseTruncate || transfer._deferredSparseSettlePromise) {
+  // checkpoint. Wait with Resume's own budget, then single-flight truncate so
+  // background settle cannot race new writes after unpause.
+  if (transfer.deferredSparseTruncate || transfer._sparseTruncatePromise) {
     const settled = await ensureDeferredSparseFinalize(
       transfer,
       payload?.transferId,

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -33,9 +33,106 @@ const {
 const PAUSE_RANGE_DRAIN_MS = 50;
 /** Cap stream drain / pending-open waits for non-concurrent (pipe) pauses. */
 const PAUSE_STREAM_DRAIN_MS = 80;
-/** Resume never overlaps old range writes; report a retryable miss if they stall. */
-const RESUME_RANGE_SETTLE_MS = 1500;
+/**
+ * Max time resume waits for leftover concurrent ranges after soft-drain pause.
+ * Was 1.5s — real SSH writes often exceed that under concurrency, so a second
+ * pause→resume mid-file surfaced "still finishing" while ranges were healthy.
+ * Background settle (scheduleDeferredSparseTruncateSettle) usually clears the
+ * flag before the user clicks Resume; this is the safety wait on that click.
+ */
+const RESUME_RANGE_SETTLE_MS = Number(process.env.NETCATTY_RESUME_RANGE_SETTLE_MS) > 0
+  ? Number(process.env.NETCATTY_RESUME_RANGE_SETTLE_MS)
+  : 60_000;
+/** Poll interval while waiting for in-flight concurrent ranges to finish. */
+const RANGE_SETTLE_POLL_MS = 20;
 const internalTransferIds = new Set();
+
+function sleepMs(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * After soft-drain pause, leftover ranges keep writing under paused=true.
+ * Truncate only when active==0. Run in the background so Resume is not forced
+ * to wait for network, and clear deferredSparseTruncate once safe.
+ */
+function scheduleDeferredSparseTruncateSettle(transfer, transferId) {
+  if (!transfer?.deferredSparseTruncate) return;
+  if (transfer._deferredSparseSettlePromise) return;
+  const run = (async () => {
+    try {
+      while (
+        transfer.paused
+        && !transfer.cancelled
+        && activeTransfers.get(transferId) === transfer
+        && transfer.deferredSparseTruncate
+        && typeof transfer.getActiveRangeCount === "function"
+        && transfer.getActiveRangeCount() > 0
+      ) {
+        await sleepMs(RANGE_SETTLE_POLL_MS);
+      }
+      if (
+        !transfer.paused
+        || transfer.cancelled
+        || activeTransfers.get(transferId) !== transfer
+        || !transfer.deferredSparseTruncate
+      ) {
+        return;
+      }
+      if (typeof transfer.getActiveRangeCount === "function" && transfer.getActiveRangeCount() > 0) {
+        return;
+      }
+      try {
+        await prepareStreamFallbackAfterRangeFailure(transfer, transfer.stagedRemote?.client);
+      } catch {
+        // Contiguous checkpoint remains valid for resume.
+      }
+      if (activeTransfers.get(transferId) === transfer && transfer.paused) {
+        transfer.deferredSparseTruncate = false;
+      }
+    } finally {
+      if (transfer._deferredSparseSettlePromise === run) {
+        transfer._deferredSparseSettlePromise = null;
+      }
+    }
+  })();
+  transfer._deferredSparseSettlePromise = run;
+}
+
+/**
+ * Wait until concurrent ranges finish (or deadline). Used by resume so we do
+ * not unpause on top of sparse tail writes.
+ */
+async function waitForActiveRangesIdle(transfer, transferId, maxMs) {
+  const deadline = Date.now() + Math.max(0, maxMs);
+  while (
+    typeof transfer.getActiveRangeCount === "function"
+    && transfer.getActiveRangeCount() > 0
+    && Date.now() < deadline
+  ) {
+    if (transfer.cancelled || activeTransfers.get(transferId) !== transfer) {
+      return { ok: false, reason: "Transfer is no longer active" };
+    }
+    // Background settle may clear the flag once idle + truncated.
+    if (!transfer.deferredSparseTruncate) {
+      return { ok: true };
+    }
+    await sleepMs(RANGE_SETTLE_POLL_MS);
+  }
+  if (transfer.cancelled || activeTransfers.get(transferId) !== transfer) {
+    return { ok: false, reason: "Transfer is no longer active" };
+  }
+  const activeLeft = typeof transfer.getActiveRangeCount === "function"
+    ? transfer.getActiveRangeCount()
+    : 0;
+  if (activeLeft > 0) {
+    return {
+      ok: false,
+      reason: "The current file is still finishing. Try resume again.",
+    };
+  }
+  return { ok: true };
+}
 
 /**
  * Fan transfer lifecycle to every window so the global transfer center keeps
@@ -3116,6 +3213,43 @@ async function startTransferNow(event, payload, onProgress) {
     }
   };
 
+  /**
+   * Soft-resume stays on the live stream handle. A full SHA-256 rehash of the
+   * source (multi-GB dmg/iso) made pause→resume feel frozen. Stat size only;
+   * hard reconnect after restart still uses full fingerprint verification in
+   * startTransferNow.
+   */
+  transfer.quickVerifySourceForSoftResume = async () => {
+    const expected = Math.max(
+      0,
+      Number(transfer.totalBytes) || 0,
+      Number(lastObservedTotal) || 0,
+    );
+    let size = expected;
+    if (sourceType === "local") {
+      const st = await fs.promises.stat(sourcePath);
+      size = st.size;
+    } else if (sourceType === "sftp") {
+      const client = sftpClients.get(sourceSftpId);
+      if (!client) throw new Error("Source SFTP session not found");
+      if (isScpModeClient(client)) {
+        const st = await getScpBackendForClient(client).stat(sourcePath, {
+          encoding: resolveEncodingForRequest(sourceSftpId, sourceEncoding),
+          signal: transfer.signal,
+        });
+        size = st.size;
+      } else {
+        await requireSftpChannel(client);
+        const encoded = encodePathForSession(sourceSftpId, sourcePath, sourceEncoding);
+        const st = await client.stat(encoded);
+        size = st.size;
+      }
+    }
+    if (expected > 0 && size !== expected) {
+      throw new Error("Resume safety check failed: the source file has changed");
+    }
+  };
+
   transfer.captureSourceFingerprint = () => {
     if (transfer.sourceFingerprint) return Promise.resolve(transfer.sourceFingerprint);
     if (transfer.sourceFingerprintPromise) return transfer.sourceFingerprintPromise;
@@ -4244,6 +4378,9 @@ async function pauseTransfer(_event, payload) {
         }
       } else {
         transfer.deferredSparseTruncate = true;
+        // Finish truncate in the background when in-flight ranges land so a
+        // later Resume is not blocked by "still finishing" after a short wait.
+        scheduleDeferredSparseTruncateSettle(transfer, payload?.transferId);
       }
     } else if (transfer.stagedLocalPath) {
       try {
@@ -4273,6 +4410,7 @@ async function pauseTransfer(_event, payload) {
     // Unpausing here made folder pause look broken (amber error + children keep going).
     if (Number.isFinite(transfer.checkpointBytes) && transfer.checkpointBytes >= 0) {
       transfer.deferredSparseTruncate = true;
+      scheduleDeferredSparseTruncateSettle(transfer, payload?.transferId);
     } else {
       transfer.deferredSparseTruncate = false;
       transfer.paused = false;
@@ -4364,17 +4502,29 @@ async function resumeTransfer(_event, payload) {
       transferId: payload.transferId,
       lifecycleEpoch: transfer.lifecycleEpoch,
     });
-    return { success: true };
+    return { success: true, lifecycleEpoch: transfer.lifecycleEpoch };
   }
   if (transfer.resumable) {
     try {
-      if (!transfer.sourceFingerprint) {
-        await transfer.captureSourceFingerprint?.();
+      // Soft resume must not re-hash multi-GB sources. Size check only; full
+      // SHA-256 remains for hard reconnect (startTransferNow). Still kick off
+      // background capture so a later crash/restart has a durable identity.
+      if (typeof transfer.quickVerifySourceForSoftResume === "function") {
+        await transfer.quickVerifySourceForSoftResume();
+      } else if (transfer.verifySourceFingerprint) {
+        if (!transfer.sourceFingerprint) {
+          await transfer.captureSourceFingerprint?.();
+        }
+        if (!transfer.sourceFingerprint) {
+          return { success: false, reason: "Could not verify the source file for resume" };
+        }
+        await transfer.verifySourceFingerprint(transfer.sourceFingerprint);
       }
       if (!transfer.sourceFingerprint) {
-        return { success: false, reason: "Could not verify the source file for resume" };
+        void transfer.captureSourceFingerprint?.().catch(() => {
+          // Best-effort; soft resume already size-checked.
+        });
       }
-      await transfer.verifySourceFingerprint?.(transfer.sourceFingerprint);
     } catch (error) {
       if (transfer.cancelled || activeTransfers.get(payload?.transferId) !== transfer) {
         return { success: false, reason: "Transfer is no longer active" };
@@ -4390,44 +4540,33 @@ async function resumeTransfer(_event, payload) {
   // unpausing. No new ranges are scheduled while paused. A stalled range gets
   // a retryable failure while the transfer remains paused; resuming on top of
   // an old write can corrupt the staged file.
+  //
+  // Background settle usually clears deferredSparseTruncate before Resume.
+  // If the user clicks early, wait up to RESUME_RANGE_SETTLE_MS (bounded — do
+  // not join the background promise, which has no deadline while writes stall).
   if (transfer.deferredSparseTruncate) {
-    // Soft-drain already returned after PAUSE_RANGE_DRAIN_MS; leftover ranges
-    // almost always settle quickly. A multi-second wait made folder resume
-    // feel stuck (each child could block the resume path for up to 6s).
-    const settleDeadline = Date.now() + RESUME_RANGE_SETTLE_MS;
-    while (
-      typeof transfer.getActiveRangeCount === "function"
-      && transfer.getActiveRangeCount() > 0
-      && Date.now() < settleDeadline
-    ) {
-      if (transfer.cancelled || activeTransfers.get(payload?.transferId) !== transfer) {
-        return { success: false, reason: "Transfer is no longer active" };
-      }
-      await new Promise((resolve) => setTimeout(resolve, 10));
+    const settled = await waitForActiveRangesIdle(
+      transfer,
+      payload?.transferId,
+      RESUME_RANGE_SETTLE_MS,
+    );
+    if (!settled.ok) {
+      return { success: false, reason: settled.reason };
     }
-    if (transfer.cancelled || activeTransfers.get(payload?.transferId) !== transfer) {
-      return { success: false, reason: "Transfer is no longer active" };
-    }
-    const activeLeft = typeof transfer.getActiveRangeCount === "function"
-      ? transfer.getActiveRangeCount()
-      : 0;
-    if (activeLeft > 0) {
-      return {
-        success: false,
-        reason: "The current file is still finishing. Try resume again.",
-      };
-    }
-    if (activeLeft === 0) {
+    if (transfer.deferredSparseTruncate) {
       try {
         await prepareStreamFallbackAfterRangeFailure(transfer, transfer.stagedRemote?.client);
       } catch {
         // Best-effort; resume from contiguous checkpoint still overwrites holes.
       }
+      if (transfer.cancelled || activeTransfers.get(payload?.transferId) !== transfer) {
+        return { success: false, reason: "Transfer is no longer active" };
+      }
+      transfer.deferredSparseTruncate = false;
     }
     if (transfer.cancelled || activeTransfers.get(payload?.transferId) !== transfer) {
       return { success: false, reason: "Transfer is no longer active" };
     }
-    transfer.deferredSparseTruncate = false;
   }
   transfer.paused = false;
   transfer.pauseSuperseded = false;
@@ -4439,7 +4578,9 @@ async function resumeTransfer(_event, payload) {
     transferId: payload.transferId,
     lifecycleEpoch: transfer.lifecycleEpoch,
   });
-  return { success: true };
+  // Soft-resume UI stamps this epoch so a late pause event with an older
+  // epoch cannot paint the row back to "paused" after a successful resume.
+  return { success: true, lifecycleEpoch: transfer.lifecycleEpoch };
 }
 
 async function prioritizeTransfer(_event, payload) {

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -848,6 +848,27 @@ const activeTransfers = new Map();
 const admittedTransferQueue = [];
 const pausedAdmittedTransfers = new Map();
 const workerTransferLifecycleEpochs = new Map();
+
+/**
+ * Lift a worker-local transfer lifecycleEpoch into main-process space.
+ * Soft-resume/pause on main may advance the main epoch past the worker's;
+ * progress still carrying the lower worker epoch would be rejected as stale.
+ */
+function resolveWorkerTransferLifecycleEpoch(transferId, workerEpoch) {
+  if (!transferId) {
+    return Number.isFinite(Number(workerEpoch)) ? Number(workerEpoch) : undefined;
+  }
+  const entry = workerTransferLifecycleEpochs.get(transferId);
+  const mainEpoch = Math.max(0, Number(entry?.epoch) || 0);
+  const workerVal = Number(workerEpoch);
+  const hasWorker = Number.isFinite(workerVal);
+  if (!entry) {
+    return hasWorker ? workerVal : undefined;
+  }
+  const resolved = Math.max(mainEpoch, hasWorker ? workerVal : 0);
+  if (resolved > mainEpoch) entry.epoch = resolved;
+  return resolved;
+}
 /** Transfer ids cancelled before startTransferNow registered them (skipAdmission open window). */
 const pendingCancelTransferIds = new Map();
 const MAX_PENDING_CANCEL_TRANSFER_IDS = 4_096;
@@ -4991,6 +5012,7 @@ module.exports = {
   setGlobalTransferConcurrency,
   getGlobalTransferConcurrency,
   broadcastGlobalTransferEvent,
+  resolveWorkerTransferLifecycleEpoch,
   cleanupTransferArtifacts,
   sameHostCopyDirectory,
   // Test / integration helpers for session leases
@@ -5002,6 +5024,12 @@ module.exports = {
   _promoteLocalTransferForTests: promoteLocalTransfer,
   _stableLocalFileIdentityForTests: stableLocalFileIdentity,
   _getWorkerTransferLifecycleEpochCountForTests: () => workerTransferLifecycleEpochs.size,
+  _setWorkerTransferLifecycleEpochForTests: (transferId, epoch) => {
+    workerTransferLifecycleEpochs.set(transferId, { epoch: Math.max(0, Number(epoch) || 0) });
+  },
+  _clearWorkerTransferLifecycleEpochsForTests: () => {
+    workerTransferLifecycleEpochs.clear();
+  },
   _getPendingCancelCountForTests: () => pendingCancelTransferIds.size,
   _getActiveTransferCountForTests: () => activeTransfers.size,
   _execSshCommandCancellableForTests: execSshCommandCancellable,

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -52,15 +52,27 @@ function sleepMs(ms) {
 }
 
 /**
- * After soft-drain pause, leftover ranges keep writing under paused=true.
- * Truncate only when active==0. Run in the background so Resume is not forced
- * to wait for network, and clear deferredSparseTruncate once safe.
+ * Single-flight finalize for soft-drain sparse staging:
+ * wait for active ranges → truncate once → clear deferredSparseTruncate.
+ * Background settle and Resume both await the same promise so they cannot
+ * race two truncates around unpause.
  */
-function scheduleDeferredSparseTruncateSettle(transfer, transferId) {
-  if (!transfer?.deferredSparseTruncate) return;
-  if (transfer._deferredSparseSettlePromise) return;
+function ensureDeferredSparseFinalize(transfer, transferId, options = {}) {
+  if (!transfer) {
+    return Promise.resolve({ ok: false, reason: "Transfer is no longer active" });
+  }
+  if (!transfer.deferredSparseTruncate && !transfer._deferredSparseSettlePromise) {
+    return Promise.resolve({ ok: true });
+  }
+  if (transfer._deferredSparseSettlePromise) {
+    return transfer._deferredSparseSettlePromise;
+  }
+  const maxWaitMs = Number.isFinite(options.maxWaitMs)
+    ? options.maxWaitMs
+    : RESUME_RANGE_SETTLE_MS;
   const run = (async () => {
     try {
+      const deadline = Date.now() + Math.max(0, maxWaitMs);
       while (
         transfer.paused
         && !transfer.cancelled
@@ -68,70 +80,51 @@ function scheduleDeferredSparseTruncateSettle(transfer, transferId) {
         && transfer.deferredSparseTruncate
         && typeof transfer.getActiveRangeCount === "function"
         && transfer.getActiveRangeCount() > 0
+        && Date.now() < deadline
       ) {
         await sleepMs(RANGE_SETTLE_POLL_MS);
       }
-      if (
-        !transfer.paused
-        || transfer.cancelled
-        || activeTransfers.get(transferId) !== transfer
-        || !transfer.deferredSparseTruncate
-      ) {
-        return;
+      if (transfer.cancelled || activeTransfers.get(transferId) !== transfer) {
+        return { ok: false, reason: "Transfer is no longer active" };
       }
-      if (typeof transfer.getActiveRangeCount === "function" && transfer.getActiveRangeCount() > 0) {
-        return;
+      if (!transfer.deferredSparseTruncate) {
+        return { ok: true };
+      }
+      const activeLeft = typeof transfer.getActiveRangeCount === "function"
+        ? transfer.getActiveRangeCount()
+        : 0;
+      if (activeLeft > 0) {
+        return {
+          ok: false,
+          reason: "The current file is still finishing. Try resume again.",
+        };
       }
       try {
         await prepareStreamFallbackAfterRangeFailure(transfer, transfer.stagedRemote?.client);
       } catch {
         // Contiguous checkpoint remains valid for resume.
       }
-      if (activeTransfers.get(transferId) === transfer && transfer.paused) {
-        transfer.deferredSparseTruncate = false;
+      if (transfer.cancelled || activeTransfers.get(transferId) !== transfer) {
+        return { ok: false, reason: "Transfer is no longer active" };
       }
+      transfer.deferredSparseTruncate = false;
+      return { ok: true };
     } finally {
-      if (transfer._deferredSparseSettlePromise === run) {
-        transfer._deferredSparseSettlePromise = null;
-      }
+      // Keep the settled promise on the transfer so concurrent awaiters still
+      // observe the same completion; replace only when starting a new pause.
     }
   })();
   transfer._deferredSparseSettlePromise = run;
+  return run;
 }
 
-/**
- * Wait until concurrent ranges finish (or deadline). Used by resume so we do
- * not unpause on top of sparse tail writes.
- */
-async function waitForActiveRangesIdle(transfer, transferId, maxMs) {
-  const deadline = Date.now() + Math.max(0, maxMs);
-  while (
-    typeof transfer.getActiveRangeCount === "function"
-    && transfer.getActiveRangeCount() > 0
-    && Date.now() < deadline
-  ) {
-    if (transfer.cancelled || activeTransfers.get(transferId) !== transfer) {
-      return { ok: false, reason: "Transfer is no longer active" };
-    }
-    // Background settle may clear the flag once idle + truncated.
-    if (!transfer.deferredSparseTruncate) {
-      return { ok: true };
-    }
-    await sleepMs(RANGE_SETTLE_POLL_MS);
-  }
-  if (transfer.cancelled || activeTransfers.get(transferId) !== transfer) {
-    return { ok: false, reason: "Transfer is no longer active" };
-  }
-  const activeLeft = typeof transfer.getActiveRangeCount === "function"
-    ? transfer.getActiveRangeCount()
-    : 0;
-  if (activeLeft > 0) {
-    return {
-      ok: false,
-      reason: "The current file is still finishing. Try resume again.",
-    };
-  }
-  return { ok: true };
+/** Fire-and-forget background settle after soft-drain pause. */
+function scheduleDeferredSparseTruncateSettle(transfer, transferId) {
+  if (!transfer?.deferredSparseTruncate) return;
+  void ensureDeferredSparseFinalize(transfer, transferId, {
+    // Background may wait a long time for slow SSH ranges while UI stays paused.
+    maxWaitMs: Math.max(RESUME_RANGE_SETTLE_MS, 5 * 60_000),
+  }).catch(() => {});
 }
 
 /**
@@ -4437,6 +4430,8 @@ async function pauseTransfer(_event, payload) {
         }
       } else {
         transfer.deferredSparseTruncate = true;
+        // New pause owns a fresh single-flight finalize promise.
+        transfer._deferredSparseSettlePromise = null;
         // Finish truncate in the background when in-flight ranges land so a
         // later Resume is not blocked by "still finishing" after a short wait.
         scheduleDeferredSparseTruncateSettle(transfer, payload?.transferId);
@@ -4469,6 +4464,7 @@ async function pauseTransfer(_event, payload) {
     // Unpausing here made folder pause look broken (amber error + children keep going).
     if (Number.isFinite(transfer.checkpointBytes) && transfer.checkpointBytes >= 0) {
       transfer.deferredSparseTruncate = true;
+      transfer._deferredSparseSettlePromise = null;
       scheduleDeferredSparseTruncateSettle(transfer, payload?.transferId);
     } else {
       transfer.deferredSparseTruncate = false;
@@ -4566,10 +4562,23 @@ async function resumeTransfer(_event, payload) {
   }
   if (transfer.resumable) {
     try {
-      // Soft resume: size + mtime + head sample (not full-file SHA-256).
-      // Full fingerprint remains for hard reconnect (startTransferNow).
-      if (typeof transfer.quickVerifySourceForSoftResume === "function") {
+      // Prefer pause-time full fingerprint when available (or still capturing).
+      // Only fall back to soft identity (size/mtime/head sample) when no full
+      // SHA-256 exists — never skip a stored fingerprint before unpausing.
+      if (transfer.sourceFingerprintPromise) {
+        try { await transfer.sourceFingerprintPromise; } catch { /* fall through */ }
+      }
+      if (
+        transfer.sourceFingerprint
+        && String(transfer.sourceFingerprint).startsWith("sha256:")
+        && typeof transfer.verifySourceFingerprint === "function"
+      ) {
+        await transfer.verifySourceFingerprint(transfer.sourceFingerprint);
+      } else if (typeof transfer.quickVerifySourceForSoftResume === "function") {
         await transfer.quickVerifySourceForSoftResume();
+        if (!transfer.sourceFingerprint) {
+          void transfer.captureSourceFingerprint?.().catch(() => {});
+        }
       } else if (transfer.verifySourceFingerprint) {
         if (!transfer.sourceFingerprint) {
           await transfer.captureSourceFingerprint?.();
@@ -4578,11 +4587,6 @@ async function resumeTransfer(_event, payload) {
           return { success: false, reason: "Could not verify the source file for resume" };
         }
         await transfer.verifySourceFingerprint(transfer.sourceFingerprint);
-      }
-      if (!transfer.sourceFingerprint) {
-        void transfer.captureSourceFingerprint?.().catch(() => {
-          // Best-effort; soft resume already checked soft identity.
-        });
       }
     } catch (error) {
       if (transfer.cancelled || activeTransfers.get(payload?.transferId) !== transfer) {
@@ -4595,33 +4599,19 @@ async function resumeTransfer(_event, payload) {
     }
   }
   // Soft-drained concurrent pause may leave a sparse tail past the contiguous
-  // checkpoint. Stay paused until leftover ranges settle, then truncate before
-  // unpausing. No new ranges are scheduled while paused. A stalled range gets
-  // a retryable failure while the transfer remains paused; resuming on top of
-  // an old write can corrupt the staged file.
-  //
-  // Background settle usually clears deferredSparseTruncate before Resume.
-  // If the user clicks early, wait up to RESUME_RANGE_SETTLE_MS (bounded — do
-  // not join the background promise, which has no deadline while writes stall).
-  if (transfer.deferredSparseTruncate) {
-    const settled = await waitForActiveRangesIdle(
+  // checkpoint. Single-flight finalize (background + resume share one promise)
+  // so truncate cannot race new writes after unpause.
+  if (transfer.deferredSparseTruncate || transfer._deferredSparseSettlePromise) {
+    const settled = await ensureDeferredSparseFinalize(
       transfer,
       payload?.transferId,
-      RESUME_RANGE_SETTLE_MS,
+      { maxWaitMs: RESUME_RANGE_SETTLE_MS },
     );
-    if (!settled.ok) {
-      return { success: false, reason: settled.reason };
-    }
-    if (transfer.deferredSparseTruncate) {
-      try {
-        await prepareStreamFallbackAfterRangeFailure(transfer, transfer.stagedRemote?.client);
-      } catch {
-        // Best-effort; resume from contiguous checkpoint still overwrites holes.
-      }
-      if (transfer.cancelled || activeTransfers.get(payload?.transferId) !== transfer) {
-        return { success: false, reason: "Transfer is no longer active" };
-      }
-      transfer.deferredSparseTruncate = false;
+    if (!settled?.ok) {
+      return {
+        success: false,
+        reason: settled?.reason || "The current file is still finishing. Try resume again.",
+      };
     }
     if (transfer.cancelled || activeTransfers.get(payload?.transferId) !== transfer) {
       return { success: false, reason: "Transfer is no longer active" };

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -1168,10 +1168,11 @@ test("fast resumable uploads pause only after in-flight ranges are durable", asy
   assert.equal(paused.success, true);
   assert.equal(paused.checkpointBytes, UPLOAD_TRANSFER_CONCURRENCY * TRANSFER_CHUNK_SIZE);
 
-  assert.deepEqual(
-    await transferBridge.resumeTransfer(null, { transferId: "upload-fast-paused" }),
-    { success: true },
-  );
+  {
+    const resumed = await transferBridge.resumeTransfer(null, { transferId: "upload-fast-paused" });
+    assert.equal(resumed.success, true);
+    assert.ok(Number.isFinite(resumed.lifecycleEpoch));
+  }
   assert.equal((await running).error, undefined);
   assert.equal(durableBytes, payload.length);
 });
@@ -1275,10 +1276,9 @@ test("pause soft-drains concurrent ranges but resume waits before truncating", a
 
   holdWrites = false;
   for (const { complete } of pendingWrites.splice(0)) complete();
-  assert.deepEqual(
-    await resuming,
-    { success: true },
-  );
+  const resumeResult = await resuming;
+  assert.equal(resumeResult.success, true);
+  assert.ok(Number.isFinite(resumeResult.lifecycleEpoch));
   assert.equal((await running).error, undefined);
   assert.equal(truncatedBeforeDrain, false, "must not truncate while range writes are active");
   assert.equal(resumedBeforeDrain, false, "resume must wait for active range writes to settle");
@@ -1436,10 +1436,11 @@ test("resuming while a fast pause is pending settles the pause request", async (
   assert.equal(typeof finishWrite, "function");
 
   const pausing = transferBridge.pauseTransfer(null, { transferId: "pause-resume-race" });
-  assert.deepEqual(
-    await transferBridge.resumeTransfer(null, { transferId: "pause-resume-race" }),
-    { success: true },
-  );
+  {
+    const resumed = await transferBridge.resumeTransfer(null, { transferId: "pause-resume-race" });
+    assert.equal(resumed.success, true);
+    assert.ok(Number.isFinite(resumed.lifecycleEpoch));
+  }
   assert.deepEqual(await pausing, {
     success: false,
     reason: "Pause was superseded by resume",
@@ -1543,10 +1544,11 @@ test("pause acknowledges quickly then publishes a full source identity", async (
       `sha256:${crypto.createHash("sha256").update(payload).digest("hex")}`,
     );
 
-    assert.deepEqual(
-      await transferBridge.resumeTransfer(null, { transferId: "late-pause-race" }),
-      { success: true },
-    );
+    {
+    const resumed = await transferBridge.resumeTransfer(null, { transferId: "late-pause-race" });
+    assert.equal(resumed.success, true);
+    assert.ok(Number.isFinite(resumed.lifecycleEpoch));
+  }
   }
 
   assert.equal((await running).error, undefined);
@@ -3931,10 +3933,11 @@ test("fast resumable downloads pause only at a complete checkpoint", async (t) =
   assert.equal(paused.success, true);
   assert.equal(paused.checkpointBytes, 2 * 1024 * 1024);
 
-  assert.deepEqual(
-    await transferBridge.resumeTransfer(null, { transferId: "download-fast-paused" }),
-    { success: true },
-  );
+  {
+    const resumed = await transferBridge.resumeTransfer(null, { transferId: "download-fast-paused" });
+    assert.equal(resumed.success, true);
+    assert.ok(Number.isFinite(resumed.lifecycleEpoch));
+  }
   assert.equal((await running).error, undefined);
   assert.deepEqual(await fs.promises.readFile(targetPath), payload);
 });
@@ -4715,7 +4718,9 @@ test("resumable stream transfers pause without losing their checkpoint and conti
   assert.equal(pausedAgain.checkpointBytes, 3);
   assert.equal(pausedAgain.resumeStage, "direct");
 
-  assert.deepEqual(await transferBridge.resumeTransfer(null, { transferId: "download-paused" }), { success: true });
+  const resumed = await transferBridge.resumeTransfer(null, { transferId: "download-paused" });
+  assert.equal(resumed.success, true);
+  assert.ok(Number.isFinite(resumed.lifecycleEpoch), "soft-resume must return bridge lifecycleEpoch");
   assert.deepEqual(
     lifecycleEvents.findLast((event) => event.type === "resumed"),
     { type: "resumed", transferId: "download-paused", lifecycleEpoch: 2 },
@@ -4816,10 +4821,11 @@ test("stream local-copy pause survives write-stream drain without auto-resuming 
     "paused stream copy must not keep writing after drain",
   );
 
-  assert.deepEqual(
-    await transferBridge.resumeTransfer(null, { transferId: "local-pipe-pause" }),
-    { success: true },
-  );
+  {
+    const resumed = await transferBridge.resumeTransfer(null, { transferId: "local-pipe-pause" });
+    assert.equal(resumed.success, true);
+    assert.ok(Number.isFinite(resumed.lifecycleEpoch));
+  }
   assert.equal((await running).error, undefined);
   assert.equal(durableBytes, payload.length);
 });
@@ -4908,14 +4914,16 @@ test("repeated resume does not double-pipe the same stream pair", async (t) => {
   assert.equal(paused.success, true, paused.reason);
   const pipesAfterPause = pipeCount;
 
-  assert.deepEqual(
-    await transferBridge.resumeTransfer(null, { transferId: "local-double-resume" }),
-    { success: true },
-  );
-  assert.deepEqual(
-    await transferBridge.resumeTransfer(null, { transferId: "local-double-resume" }),
-    { success: true },
-  );
+  {
+    const resumed = await transferBridge.resumeTransfer(null, { transferId: "local-double-resume" });
+    assert.equal(resumed.success, true);
+    assert.ok(Number.isFinite(resumed.lifecycleEpoch));
+  }
+  {
+    const resumed = await transferBridge.resumeTransfer(null, { transferId: "local-double-resume" });
+    assert.equal(resumed.success, true);
+    assert.ok(Number.isFinite(resumed.lifecycleEpoch));
+  }
   assert.equal(
     pipeCount,
     pipesAfterPause + 1,


### PR DESCRIPTION
## Summary

Fixes SFTP upload/download pause → resume regressions:

- Soft resume no longer drops `lifecycleEpoch`, so late `paused` events cannot paint a healthy resume back to **Paused**.
- Soft-resume failures only hard-reconnect when the live stream is gone; transient misses (e.g. range settle) stay **paused** with a reason and keep panel ownership (queue row no longer disappears / no false **Reconnect**).
- Hard reconnect reuses the shared SSH transport pool: live terminal session first, then parked transport; vault + ephemeral (quick-connect) hosts are both resolvable.
- Concurrent range soft-drain: background sparse settle + longer resume wait so second pause/resume is less likely to show `The current file is still finishing`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- **Soft control** (`globalSftpTransferControl`, `sftpTransferCenterStore`): soft resume returns `{ handled, reason }`; stamp bridge epoch (or monotonic fallback); demote to dedicated only for dead-stream reasons.
- **Hard reconnect** (`dedicatedTransferResume`, `App`/`useAppStartupEffects`): pass `terminalHosts` (vault + ephemeral); always attach live session ids; open with `dedicated: false` / session-backed path.
- **Transfer bridge** (`transferBridge.cjs`): `resumeTransfer` returns `lifecycleEpoch`; soft resume size check instead of full SHA-256 rehash; schedule deferred sparse truncate settle after soft-drain; resume range settle timeout 60s (env-overridable).
- Dead soft-pause paints **interrupted** instead of fake **paused** when the backend stream is already gone.
- Tests for ephemeral host resolve, session reuse, soft-resume epoch, transient soft-miss (no rehome), and transferBridge resume assertions.

## Screenshots / Demo

Reproduced as: pause → resume → “Reconnect” then stuck “Paused”, panel queue row gone; second pause/resume → `The current file is still finishing`.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test` — targeted: `globalSftpTransferControl`, `sftpTransferCenterStore`, `dedicatedTransferResume`, `transferBridge` 97/97)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)