### PR TITLE
fix(sftp): ignore ctime drift when upload content is digest-verified

### DIFF
--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -1516,7 +1516,9 @@ async function uploadFile(
         await createUploadDigestBaseline(localPath, digestPath, fileSize, transfer);
         if (isTransferCancelled(transfer)) throw new Error("Transfer cancelled");
         const sourceAfterBaseline = await fs.promises.stat(localPath);
-        assertSourceMetadataUnchanged(initialSource, sourceAfterBaseline, fileSize);
+        assertSourceMetadataUnchanged(initialSource, sourceAfterBaseline, fileSize, {
+          contentVerifiedSeparately: true,
+        });
         if (typeof onBytesCommitted === "function") {
           await createVerifiedUploadSnapshot(
             localPath,
@@ -1550,7 +1552,9 @@ async function uploadFile(
       if (isTransferCancelled(transfer)) throw new Error("Transfer cancelled");
       if (digestPath && !snapshotPath) {
         const latestSource = await fs.promises.stat(localPath);
-        assertSourceMetadataUnchanged(initialSource, latestSource, fileSize);
+        assertSourceMetadataUnchanged(initialSource, latestSource, fileSize, {
+          contentVerifiedSeparately: true,
+        });
         await verifyUploadDigestBaseline(localPath, digestPath, fileSize, transfer);
       }
       onBytesCommitted?.();
@@ -1587,7 +1591,10 @@ async function uploadFile(
     );
     if (isTransferCancelled(transfer)) throw new Error("Transfer cancelled");
     const sourceAfterBaseline = await fs.promises.stat(originalLocalPath);
-    assertSourceMetadataUnchanged(initialSource, sourceAfterBaseline, fileSize);
+    // Digest was just built + verified; only size/content matter from here.
+    assertSourceMetadataUnchanged(initialSource, sourceAfterBaseline, fileSize, {
+      contentVerifiedSeparately: true,
+    });
   }
 
   const cleanupSourceDigest = async () => {
@@ -1601,7 +1608,11 @@ async function uploadFile(
     try {
       if (initialSource) {
         const latestSource = await fs.promises.stat(originalLocalPath);
-        assertSourceMetadataUnchanged(initialSource, latestSource, fileSize);
+        // Prefer digest re-scan for same-size rewrites. Hard-failing on ctime
+        // alone false-positives long pause/resume uploads on macOS.
+        assertSourceMetadataUnchanged(initialSource, latestSource, fileSize, {
+          contentVerifiedSeparately: Boolean(transfer.sourceDigestPath),
+        });
       }
       // Metadata alone cannot catch same-size rewrites with unchanged/coarse
       // timestamps (e.g. all ranges already verified before the rewrite).
@@ -2186,13 +2197,32 @@ async function readVerifiedUploadRange(
   return output;
 }
 
-function assertSourceMetadataUnchanged(initialSource, latestSource, expectedSize) {
+/**
+ * Reject when the source identity is no longer safe to trust.
+ *
+ * Size always fails hard. Timestamp / inode fields are only a *cheap early
+ * reject* when we have no separate content proof (e.g. remote download with no
+ * digest). When a digest baseline already verifies bytes — or every range was
+ * already verified against one — treat metadata as soft:
+ * macOS routinely bumps ctime for xattr / quarantine / Spotlight without
+ * rewriting file data, and repeated pause/resume makes long uploads much more
+ * likely to hit that drift right at the finish revalidation.
+ *
+ * @param {object|null|undefined} initialSource
+ * @param {object|null|undefined} latestSource
+ * @param {number} expectedSize
+ * @param {{ contentVerifiedSeparately?: boolean }} [options]
+ */
+function assertSourceMetadataUnchanged(initialSource, latestSource, expectedSize, options = {}) {
   const latestSize = Number(latestSource?.size);
   if (latestSize !== expectedSize) {
     throw createSourceSizeChangedError(expectedSize, latestSize);
   }
-  // Soft signal only — content fingerprint is the durable check for same-size
-  // rewrites. Keep metadata as a cheap early reject when timestamps move.
+  if (options.contentVerifiedSeparately) {
+    return;
+  }
+  // No digest / per-range content proof: timestamps + inode are the durable
+  // same-size rewrite signal (remote SFTP download path).
   const versionFields = ["mtimeMs", "ctimeMs", "mtime", "ctime", "ino"];
   const changed = versionFields.some((field) => {
     const before = Number(initialSource?.[field]);
@@ -2488,7 +2518,9 @@ async function uploadFileConcurrent(
       await createUploadDigestBaseline(localPath, ephemeralDigestPath, fileSize, transfer);
       if (transfer.cancelled) throw new Error("Transfer cancelled");
       const sourceAfterBaseline = await localHandle.stat();
-      assertSourceMetadataUnchanged(initialSource, sourceAfterBaseline, fileSize);
+      assertSourceMetadataUnchanged(initialSource, sourceAfterBaseline, fileSize, {
+        contentVerifiedSeparately: true,
+      });
       digestHandle = await fs.promises.open(ephemeralDigestPath, "r");
     }
     if (transfer.cancelled) throw new Error("Transfer cancelled");
@@ -2529,9 +2561,12 @@ async function uploadFileConcurrent(
       // published at this point, so stop accepting cancellation before source
       // revalidation and handle cleanup; staged uploads pass no callback.
       options.onBytesCommitted?.();
+      const contentVerifiedSeparately = Boolean(digestHandle || ephemeralDigestPath || transfer.sourceDigestPath);
       if (initialSource) {
         const latestSource = await localHandle.stat();
-        assertSourceMetadataUnchanged(initialSource, latestSource, fileSize);
+        assertSourceMetadataUnchanged(initialSource, latestSource, fileSize, {
+          contentVerifiedSeparately,
+        });
       }
       if (ephemeralDigestPath) {
         await verifyUploadDigestBaseline(localPath, ephemeralDigestPath, fileSize, transfer);
@@ -5033,4 +5068,5 @@ module.exports = {
   _getPendingCancelCountForTests: () => pendingCancelTransferIds.size,
   _getActiveTransferCountForTests: () => activeTransfers.size,
   _execSshCommandCancellableForTests: execSshCommandCancellable,
+  _assertSourceMetadataUnchangedForTests: assertSourceMetadataUnchanged,
 };

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -2473,6 +2473,142 @@ test("resumable concurrent uploads reject a source rewritten mid-transfer", asyn
   assert.equal(stagedDeleted, true);
 });
 
+test("assertSourceMetadataUnchanged ignores ctime drift when content is verified separately", () => {
+  const initial = {
+    size: 100,
+    mtimeMs: 1,
+    ctimeMs: 1,
+    mtime: 0.001,
+    ctime: 0.001,
+    ino: 42,
+  };
+  const drifted = {
+    ...initial,
+    ctimeMs: 999,
+    ctime: 0.999,
+  };
+  // Without a separate content proof, timestamp drift is a hard fail (download path).
+  assert.throws(
+    () => transferBridge._assertSourceMetadataUnchangedForTests(initial, drifted, 100),
+    /source content changed/i,
+  );
+  // With digest / per-range verification, macOS xattr ctime bumps must not abort.
+  assert.doesNotThrow(() => transferBridge._assertSourceMetadataUnchangedForTests(
+    initial,
+    drifted,
+    100,
+    { contentVerifiedSeparately: true },
+  ));
+  // Size still fails hard even when content is verified separately.
+  assert.throws(
+    () => transferBridge._assertSourceMetadataUnchangedForTests(
+      initial,
+      { ...drifted, size: 99 },
+      100,
+      { contentVerifiedSeparately: true },
+    ),
+    /source size changed/i,
+  );
+});
+
+test("resumable upload succeeds when only source ctime drifts (pause/resume false positive)", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-upload-ctime-drift-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  // Reproduce the user-facing finish-path false positive: content bytes are
+  // stable (digest matches) but ctime moved — common on macOS after long
+  // pause/resume cycles (Spotlight / quarantine / xattr).
+  const payload = Buffer.alloc(16 * 1024, 43);
+  const localPath = path.join(tempDir, "ChatGPT.dmg");
+  await fs.promises.writeFile(localPath, payload);
+  const baseline = await fs.promises.stat(localPath);
+  let allowCtimeDrift = false;
+  const driftedStat = () => {
+    if (!allowCtimeDrift) return baseline;
+    return {
+      ...baseline,
+      ctimeMs: baseline.ctimeMs + 60_000,
+      ctime: (baseline.ctimeMs + 60_000) / 1000,
+      // mtime intentionally stable — content not rewritten.
+    };
+  };
+  const realStat = fs.promises.stat.bind(fs.promises);
+  const realOpen = fs.promises.open.bind(fs.promises);
+  fs.promises.stat = async (p, ...args) => {
+    if (path.resolve(String(p)) === path.resolve(localPath)) return driftedStat();
+    return realStat(p, ...args);
+  };
+  fs.promises.open = async (p, flags, ...args) => {
+    const handle = await realOpen(p, flags, ...args);
+    if (path.resolve(String(p)) === path.resolve(localPath) && String(flags).includes("r")) {
+      handle.stat = async () => driftedStat();
+    }
+    return handle;
+  };
+  t.after(() => {
+    fs.promises.stat = realStat;
+    fs.promises.open = realOpen;
+  });
+
+  let remoteBytes = 0;
+  let promoted = false;
+  const fastSftp = createFastSftp({
+    open(_remotePath, _flags, callback) {
+      callback(null, Buffer.from("remote-handle"));
+    },
+    write(_handle, _buffer, _offset, length, position, callback) {
+      remoteBytes = Math.max(remoteBytes, position + length);
+      // After the first remote WRITE, simulate metadata-only drift as if the
+      // transfer had been pause/resumed for a long wall-clock time.
+      allowCtimeDrift = true;
+      callback(null);
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+  });
+  const client = {
+    sftp: createFastSftp({}),
+    stat() {
+      return Promise.resolve({ size: remoteBytes });
+    },
+    rename() {
+      promoted = true;
+      return Promise.resolve();
+    },
+    delete() {
+      return Promise.resolve();
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const result = await transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-ctime-drift-ok",
+      sourcePath: localPath,
+      targetPath: "/tmp/ChatGPT.dmg",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: true,
+    },
+  );
+
+  assert.equal(result.error, undefined, `expected success, got: ${result.error}`);
+  assert.equal(allowCtimeDrift, true);
+  assert.equal(promoted, true);
+  assert.equal(remoteBytes, payload.length);
+});
+
 test("non-resumable shared range uploads reject a same-size source rewrite", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-nonresume-source-change-"));
   t.after(async () => {


### PR DESCRIPTION
## Summary

Repeated pause/resume during large SFTP uploads often failed near completion with `Transfer source content changed during transfer`, even when the local file bytes never changed (e.g. `ChatGPT.dmg` at 100%).

The finish-path revalidation hard-failed on `mtime`/`ctime`/`ino` drift. On macOS, Spotlight, quarantine xattrs, and similar tools routinely bump **ctime without rewriting content**. Longer pause/resume wall-clock makes that much more likely right at the end.

Uploads already have a durable content proof (SHA-256 digest baseline + per-range verification). This PR treats timestamp/inode metadata as soft when content is verified separately, while still hard-failing on size changes and still rejecting real same-size rewrites via digest.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Add `contentVerifiedSeparately` option to `assertSourceMetadataUnchanged`
- Pass it on upload finish / post-baseline paths that already use digests
- Keep strict mtime/ctime/ino checks for download paths without digests
- Regression tests for ctime-only drift (unit + resumable upload integration)

## Screenshots / Demo

N/A — behavior fix for transfer finish revalidation. Previously: 100% upload then red error after many pause/resume cycles. After: same content completes successfully; real content rewrites still fail digest checks.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — `node --test electron/bridges/transferBridge.test.cjs` (99/99)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)