### PR TITLE
fix(ui): remove top-tabs local terminal fallback button

### DIFF
--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -137,14 +137,6 @@ function AppViewInner({ domains }: AppViewProps) {
     VaultViewContainer, SftpViewMount, TerminalLayerMount, LogViewWrapper,
   } = ctx;
 
-  // Stable no-arg wrapper: the top-bar terminal icon passes an onClick event we
-  // must not forward as handleCreateLocalTerminal's `shell` arg, and an inline
-  // arrow here would defeat the memoized TopTabs onCreateLocalTerminal check.
-  // Top-tabs shows this only when the host-tree toolbar is not available.
-  const handleCreateLocalTerminalNoArg = useCallback(() => {
-    handleCreateLocalTerminal();
-  }, [handleCreateLocalTerminal]);
-
   const handleTerminalCommandExecuted = useCallback((
     command: string,
     hostId: string,
@@ -286,7 +278,6 @@ function AppViewInner({ domains }: AppViewProps) {
         onCloseLogView={closeLogView}
         onCloseTabsBatch={closeTabsBatch}
         onOpenQuickSwitcher={handleOpenQuickSwitcher}
-        onCreateLocalTerminal={handleCreateLocalTerminalNoArg}
         onThemeChange={settings.setTheme}
         onOpenSettings={handleOpenSettings}
         externalMcpEnabled={externalMcpToggle.enabled}

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -1,4 +1,4 @@
-import { Folder, FolderLock, Menu, MoreHorizontal, Plus, Settings, Sparkles, Terminal } from 'lucide-react';
+import { Folder, FolderLock, Menu, MoreHorizontal, Plus, Settings, Sparkles } from 'lucide-react';
 import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { fromEditorTabId, isEditorTabId, useActiveTabId } from '../application/state/activeTabStore';
 import { topTabsSessionsEqual } from '../domain/topTabsSessionsEqual';
@@ -137,8 +137,6 @@ interface TopTabsProps {
   onCloseLogView: (logViewId: string) => void;
   onCloseTabsBatch: (targetIds: string[]) => void;
   onOpenQuickSwitcher: () => void;
-  /** Fallback one-click local shell when the host-tree toolbar is not available. */
-  onCreateLocalTerminal: () => void;
   onThemeChange: (theme: 'dark' | 'light' | 'system') => void;
   onOpenSettings: () => void;
   externalMcpEnabled: boolean;
@@ -185,7 +183,6 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   onCloseLogView,
   onCloseTabsBatch,
   onOpenQuickSwitcher,
-  onCreateLocalTerminal,
   onThemeChange,
   onOpenSettings,
   externalMcpEnabled,
@@ -347,14 +344,6 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
     activeWorkTabCount,
   });
   const effectiveShowHostTreeToggle = hostTreeChromeReady;
-  // Host-tree toolbar already exposes local shell when the sidebar is open on a
-  // work surface. Keep the top-tabs control only as a fallback when that path
-  // is disabled, collapsed, or not on the host-tree surface (Vault / SFTP / …).
-  const showTopTabsLocalTerminal = !(
-    showHostTreeSidebar &&
-    isHostTreeOpen &&
-    showHostTreeToggle
-  );
 
   useEffect(() => {
     cancelHostTreeChromeReadyRef.current?.();
@@ -1103,23 +1092,6 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
           style={dragRegionStyle}
           data-section="top-tabs-toolbar-actions"
         >
-          {showTopTabsLocalTerminal && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  data-section="top-tabs-new-local-terminal"
-                  className="h-7 w-7 shrink-0 app-no-drag top-tab-utility-btn"
-                  style={{ color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
-                  onClick={onCreateLocalTerminal}
-                >
-                  <Terminal size={16} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>{t('topTabs.newLocalTerminal')}</TooltipContent>
-            </Tooltip>
-          )}
           <GlobalSftpTransferCenter />
           <Tooltip>
             <TooltipTrigger asChild>
@@ -1197,7 +1169,6 @@ export const topTabsAreEqual = (prev: TopTabsProps, next: TopTabsProps): boolean
     prev.draggingSessionId === next.draggingSessionId &&
     prev.isMacClient === next.isMacClient &&
     prev.onCopySession === next.onCopySession &&
-    prev.onCreateLocalTerminal === next.onCreateLocalTerminal &&
     prev.onCopySessionToNewWindow === next.onCopySessionToNewWindow &&
     prev.onCopyWorkspace === next.onCopyWorkspace &&
     prev.onOpenSettings === next.onOpenSettings &&

--- a/components/terminalLayer/TerminalHostTreeToolbar.test.ts
+++ b/components/terminalLayer/TerminalHostTreeToolbar.test.ts
@@ -125,10 +125,9 @@ test('host tree sidebar wires expand/collapse and host creation availability', (
   assert.doesNotMatch(source, /shouldCompactTerminalHostTreeToolbar/);
 });
 
-test('top tabs keep a local-terminal fallback when the host tree toolbar is unavailable', () => {
+test('top tabs do not show a local-terminal utility button', () => {
   const topTabsSource = readFileSync(new URL('../TopTabs.tsx', import.meta.url), 'utf8');
-  assert.match(topTabsSource, /top-tabs-new-local-terminal/);
-  assert.match(topTabsSource, /topTabs\.newLocalTerminal/);
-  assert.match(topTabsSource, /showTopTabsLocalTerminal/);
-  assert.match(topTabsSource, /showHostTreeSidebar &&\s*\n\s*isHostTreeOpen &&\s*\n\s*showHostTreeToggle/);
+  assert.doesNotMatch(topTabsSource, /top-tabs-new-local-terminal/);
+  assert.doesNotMatch(topTabsSource, /showTopTabsLocalTerminal/);
+  assert.doesNotMatch(topTabsSource, /onCreateLocalTerminal/);
 });


### PR DESCRIPTION
## Summary

Removes the small **New Local Terminal** icon from the top-right title-bar utility strip. It only appeared as a fallback on Vault/SFTP (and similar) surfaces and disappeared once the terminal host-tree toolbar was available, which felt redundant and inconsistent.

Local shell is still available from:
- Terminal host-tree toolbar
- Quick Switcher / hotkeys
- Vault content header **Terminal** button (unchanged)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Remove `showTopTabsLocalTerminal` and the top-tabs utility button from `TopTabs`
- Drop the unused `onCreateLocalTerminal` prop wiring from `AppView` → `TopTabs`
- Update host-tree toolbar source tests to assert the top-tabs control is gone

## Screenshots / Demo

N/A — removes a title-bar control that appeared on non-terminal pages.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass — `node --test --import tsx components/terminalLayer/TerminalHostTreeToolbar.test.ts` (8/8)
- [ ] Generated capability tool specs are updated when applicable
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes