### PR TITLE
fix(vault): hide inactive host focus selection

### DIFF
--- a/components/vault/VaultHostListSection.tsx
+++ b/components/vault/VaultHostListSection.tsx
@@ -18,6 +18,7 @@ import {
 } from "./vaultReorderDrag";
 import {
   hostCardFocusClassName,
+  isHostClickFocusSelected,
   resolveGroupActivateAction,
   resolveHostActivateAction,
   shouldClearHostFocusOnBackgroundClick,
@@ -215,6 +216,17 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
     (focusedGroupIsVisible ? focusedGroupPath === groupPath : initialKeyboardGroupPath === groupPath)
       ? 0
       : -1
+  );
+  const isHostFocusSelected = (hostId: string) => (
+    isHostClickFocusSelected({
+      behavior: hostClickBehavior,
+      isMultiSelectMode,
+      focusedHostId,
+      hostId,
+    })
+  );
+  const isGroupFocusSelected = (groupPath: string) => (
+    hostClickBehavior === "select" && !isMultiSelectMode && focusedGroupPath === groupPath
   );
 
   const activateGroup = React.useCallback((groupPath: string) => {
@@ -500,11 +512,11 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                       ? cn(
                                         "soft-card elevate rounded-xl h-[68px] px-3 py-2 will-change-transform transition-[opacity,box-shadow,border-color,background-color] duration-150",
                                         draggingHostId === host.id && "opacity-45",
-                                        hostCardFocusClassName(viewMode, focusedHostId === host.id),
+                                        hostCardFocusClassName(viewMode, isHostFocusSelected(host.id)),
                                       )
                                       : cn(
                                         "h-14 px-2 py-2 rounded-lg transition-colors",
-                                        focusedHostId === host.id
+                                        isHostFocusSelected(host.id)
                                           ? hostCardFocusClassName("list", true)
                                           : "hover:bg-secondary/60",
                                       ),
@@ -619,11 +631,11 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                       ? cn(
                                         "soft-card elevate rounded-xl h-[68px] px-3 py-2 will-change-transform transition-[opacity,box-shadow,border-color,background-color] duration-150",
                                         draggingHostId === host.id && "opacity-45",
-                                        hostCardFocusClassName(viewMode, focusedHostId === host.id),
+                                        hostCardFocusClassName(viewMode, isHostFocusSelected(host.id)),
                                       )
                                       : cn(
                                         "h-14 px-2 py-2 rounded-lg transition-colors",
-                                        focusedHostId === host.id
+                                        isHostFocusSelected(host.id)
                                           ? hostCardFocusClassName("list", true)
                                           : "hover:bg-secondary/60",
                                       ),
@@ -750,12 +762,12 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                     "soft-card elevate rounded-xl h-[68px] px-3 py-2 will-change-transform transition-[box-shadow,border-color,background-color] duration-150",
                                     hostCardFocusClassName(
                                       "grid",
-                                      focusedGroupPath === node.path || multiSelectedGroupPaths.has(node.path),
+                                      isGroupFocusSelected(node.path) || multiSelectedGroupPaths.has(node.path),
                                     ),
                                   )
                                   : cn(
                                     "h-14 px-2 py-2 rounded-lg transition-colors",
-                                    focusedGroupPath === node.path || multiSelectedGroupPaths.has(node.path)
+                                    isGroupFocusSelected(node.path) || multiSelectedGroupPaths.has(node.path)
                                       ? hostCardFocusClassName("list", true)
                                       : "hover:bg-secondary/60",
                                   ),
@@ -978,11 +990,11 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                             ? cn(
                                               "soft-card elevate rounded-xl h-[68px] px-3 py-2 will-change-transform transition-[opacity,box-shadow,border-color,background-color] duration-150",
                                               draggingHostId === host.id && "opacity-45",
-                                              hostCardFocusClassName(viewMode, focusedHostId === host.id),
+                                              hostCardFocusClassName(viewMode, isHostFocusSelected(host.id)),
                                             )
                                             : cn(
                                               "h-14 px-2 py-2 rounded-lg transition-colors",
-                                              focusedHostId === host.id
+                                              isHostFocusSelected(host.id)
                                                 ? hostCardFocusClassName("list", true)
                                                 : "hover:bg-secondary/60",
                                             ),
@@ -1122,11 +1134,11 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                       ? cn(
                                         "soft-card elevate rounded-xl h-[68px] px-3 py-2 will-change-transform transition-[opacity,box-shadow,border-color,background-color] duration-150",
                                         draggingHostId === host.id && "opacity-45",
-                                        hostCardFocusClassName(viewMode, focusedHostId === host.id),
+                                        hostCardFocusClassName(viewMode, isHostFocusSelected(host.id)),
                                       )
                                       : cn(
                                         "h-14 px-2 py-2 rounded-lg transition-colors",
-                                        focusedHostId === host.id
+                                        isHostFocusSelected(host.id)
                                           ? hostCardFocusClassName("list", true)
                                           : "hover:bg-secondary/60",
                                       ),

--- a/domain/hostClickBehavior.test.ts
+++ b/domain/hostClickBehavior.test.ts
@@ -4,6 +4,7 @@ import { test } from 'node:test';
 import {
   DEFAULT_HOST_CLICK_BEHAVIOR,
   hostCardFocusClassName,
+  isHostClickFocusSelected,
   isHostClickBehavior,
   resolveGroupActivateAction,
   resolveHostActivateAction,
@@ -90,6 +91,36 @@ test('resolveHostActivateAction: select mode focuses then connects', () => {
       hostId: 'a',
     }),
     'connect',
+  );
+});
+
+test('isHostClickFocusSelected only shows a selection in select-before-connect mode', () => {
+  assert.equal(
+    isHostClickFocusSelected({
+      behavior: 'connect',
+      isMultiSelectMode: false,
+      focusedHostId: 'a',
+      hostId: 'a',
+    }),
+    false,
+  );
+  assert.equal(
+    isHostClickFocusSelected({
+      behavior: 'select',
+      isMultiSelectMode: false,
+      focusedHostId: 'a',
+      hostId: 'a',
+    }),
+    true,
+  );
+  assert.equal(
+    isHostClickFocusSelected({
+      behavior: 'select',
+      isMultiSelectMode: true,
+      focusedHostId: 'a',
+      hostId: 'a',
+    }),
+    false,
   );
 });
 

--- a/domain/hostClickBehavior.ts
+++ b/domain/hostClickBehavior.ts
@@ -24,6 +24,19 @@ export function resolveHostActivateAction(input: {
   return 'select';
 }
 
+export function isHostClickFocusSelected(input: {
+  behavior: HostClickBehavior;
+  isMultiSelectMode: boolean;
+  focusedHostId: string | null | undefined;
+  hostId: string;
+}): boolean {
+  return (
+    input.behavior === 'select'
+    && !input.isMultiSelectMode
+    && input.focusedHostId === input.hostId
+  );
+}
+
 export function resolveGroupActivateAction(input: {
   behavior: HostClickBehavior;
   focusedGroupPath: string | null | undefined;


### PR DESCRIPTION
## Summary

Prevent Vault host and group cards from appearing selected in single-click connect mode. Keyboard focus remains available without showing the persistent accent border.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Render focused host/group cards as selected only in select-before-connect mode.
- Preserve multi-select visual feedback.
- Add coverage for the focused-selection predicate.

## Screenshots / Demo

In single-click connect mode, clicking or keyboard-focusing a host no longer leaves an accent selection border.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

`git diff --check` passes. Focused tests and ESLint could not run because this worktree has no installed dependencies (`tsx` and `@eslint/js` are unavailable).

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)