### PR TITLE
fix(ui): stop CJK labels clipping under tight line-height

### DIFF
--- a/components/HostTreeView.tsx
+++ b/components/HostTreeView.tsx
@@ -807,9 +807,9 @@ const HostTreeItem: React.FC<HostTreeItemProps> = ({
             <DistroAvatar host={host} fallback={(host.os || "L")[0].toUpperCase()} size="tree" />
           )}
           content={(
-            <div className="min-w-0 flex-1 leading-tight">
-              <div className="flex items-center gap-1.5 truncate font-medium leading-4">
-                <span className="truncate">{host.label}</span>
+            <div className="min-w-0 flex-1">
+              <div className="flex min-w-0 items-center gap-1.5 font-medium leading-5">
+                <span className="min-w-0 truncate">{host.label}</span>
                 <button
                   aria-label={`Edit ${host.label}`}
                   tabIndex={-1}

--- a/components/LogView.tsx
+++ b/components/LogView.tsx
@@ -261,10 +261,10 @@ const LogViewComponent: React.FC<LogViewProps> = ({
                         <FileText size={14} />
                     </div>
                     <div className="flex min-w-0 flex-1 items-baseline gap-2">
-                        <div className="min-w-0 text-sm font-medium leading-none truncate">
+                        <div className="min-w-0 text-sm font-medium leading-5 truncate">
                             {isLocal ? t("logs.localTerminal") : log.hostname}
                         </div>
-                        <div className="text-xs leading-none text-muted-foreground truncate">
+                        <div className="text-xs leading-4 truncate text-muted-foreground">
                             {formattedDate} • {log.localUsername}@{log.localHostname}
                         </div>
                     </div>

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -1790,7 +1790,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
 
         {isMultiSelectMode && (
           <div className="px-4 py-1.5 bg-background border-b border-border/40 flex items-center gap-2">
-            <span className="flex items-center h-7 text-xs text-muted-foreground leading-none">
+            <span className="flex h-7 items-center text-xs leading-4 text-muted-foreground">
               {t('snippets.selection.selected', { count: selectedSnippetIds.size })}
             </span>
             <div className="flex-1" />

--- a/components/editor/TextEditorPane.tsx
+++ b/components/editor/TextEditorPane.tsx
@@ -350,20 +350,20 @@ const TextEditorPaneInner: React.FC<TextEditorPaneProps> = ({
       <div className="h-9 px-3 py-1.5 border-b border-border/60 flex-shrink-0">
         <div className="flex h-full items-center justify-between gap-3">
           <div className="flex items-center gap-2 flex-1 min-w-0">
-            <span className="text-sm font-semibold leading-none truncate flex-shrink-0">
+            <span className="flex-shrink-0 truncate text-sm font-semibold leading-5">
               {fileName}
             </span>
             {subtitle && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <span className="text-xs leading-none text-muted-foreground truncate cursor-default">
+                  <span className="cursor-default truncate text-xs leading-4 text-muted-foreground">
                     {subtitle}
                   </span>
                 </TooltipTrigger>
                 <TooltipContent>{subtitle}</TooltipContent>
               </Tooltip>
             )}
-            {saveError && <span className="text-xs leading-none text-destructive truncate">{saveError}</span>}
+            {saveError && <span className="truncate text-xs leading-4 text-destructive">{saveError}</span>}
           </div>
           <div className="flex h-6 items-center gap-2 min-w-0">
             {/* Search button */}

--- a/components/notes/NotesManager.tsx
+++ b/components/notes/NotesManager.tsx
@@ -1516,7 +1516,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
               <div className="flex min-h-[54px] shrink-0 items-center gap-3 px-8 pt-6 pb-1" data-note-title-row>
                 <div className="min-w-0 flex-1">
                   <input
-                    className="h-7 w-full bg-transparent text-lg font-semibold outline-none placeholder:text-muted-foreground"
+                    className="h-8 w-full bg-transparent text-lg font-semibold leading-8 outline-none placeholder:text-muted-foreground"
                     value={selectedNote.title}
                     placeholder={t("notes.title.placeholder")}
                     onChange={(event) => saveNote({
@@ -1594,7 +1594,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
               </TooltipTrigger>
               <TooltipContent side="bottom">{t("common.back")}</TooltipContent>
             </Tooltip>
-            <div className="min-w-0 flex-1 truncate px-1 text-xs font-medium text-foreground">
+            <div className="min-w-0 flex-1 truncate px-1 text-xs font-medium leading-4 text-foreground">
               {overlayNote.title || t("notes.title.placeholder")}
             </div>
           </div>
@@ -1602,7 +1602,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
             <div className="flex min-h-[54px] shrink-0 items-center gap-3 px-4 pt-5 pb-1" data-note-title-row>
               <div className="min-w-0 flex-1">
                 <input
-                  className="h-7 w-full bg-transparent text-lg font-semibold outline-none placeholder:text-muted-foreground"
+                  className="h-8 w-full bg-transparent text-lg font-semibold leading-8 outline-none placeholder:text-muted-foreground"
                   value={overlayNote.title}
                   placeholder={t("notes.title.placeholder")}
                   onChange={(event) => saveNote({

--- a/components/scripts/ScriptDialogHost.tsx
+++ b/components/scripts/ScriptDialogHost.tsx
@@ -295,7 +295,7 @@ export function ScriptDialogFormFields({
           aria-describedby={describedBy}
           aria-invalid={fieldError ? true : undefined}
         >
-          <legend className="text-sm font-medium leading-none">{field.label}</legend>
+          <legend className="text-sm font-medium leading-5">{field.label}</legend>
           {fieldDescription}
           <div className="space-y-2">
             {field.options.map((option, index) => {
@@ -384,7 +384,7 @@ export function ScriptDialogFormFields({
             className="mt-0.5 h-4 w-4 accent-primary"
           />
           <span className="min-w-0">
-            <span className="block font-medium leading-none">{field.label}</span>
+            <span className="block font-medium leading-5">{field.label}</span>
             {inlineDescription}
             {inlineErrorMessage}
           </span>

--- a/components/scripts/ScriptEditorModal.tsx
+++ b/components/scripts/ScriptEditorModal.tsx
@@ -102,7 +102,7 @@ export const ScriptEditorModal: React.FC<ScriptEditorModalProps> = ({
           <div className="h-full flex flex-col min-h-0">
             <div className="h-9 px-3 py-1.5 border-b border-border/60 flex-shrink-0">
               <div className="flex h-full items-center justify-between gap-3">
-                <span className="text-sm font-semibold leading-none truncate">{title}</span>
+                <span className="truncate text-sm font-semibold leading-5">{title}</span>
                 <div className="flex h-6 items-center gap-1.5">
                   <Button
                     variant="outline"

--- a/components/terminal/ScriptExecutionOverlay.tsx
+++ b/components/terminal/ScriptExecutionOverlay.tsx
@@ -165,7 +165,7 @@ function ScriptStatusLine({
   ) : null;
 
   return (
-    <span className="flex min-w-0 flex-1 items-center gap-1.5 leading-none">
+    <span className="flex min-w-0 flex-1 items-center gap-1.5 leading-4">
       <ScriptStatusIcon status={run.status} />
       <span className="shrink-0 whitespace-nowrap font-semibold text-foreground">{label}</span>
       <span className="inline-flex min-w-0 flex-1 items-center truncate">
@@ -245,12 +245,12 @@ export const ScriptExecutionOverlay: React.FC<ScriptExecutionOverlayProps> = ({
       data-compact-top-chrome={compactTopChrome ? "true" : "false"}
     >
       <div className="flex items-center gap-2 min-w-0">
-        <div className="min-w-0 flex flex-1 items-center text-[11px] leading-none">
+        <div className="flex min-w-0 flex-1 items-center text-[11px] leading-4">
           {statusLine}
         </div>
         {errorMessage ? (
           <div
-            className="min-w-0 max-w-[42%] shrink text-[11px] leading-none text-destructive truncate text-right"
+            className="min-w-0 max-w-[42%] shrink truncate text-right text-[11px] leading-4 text-destructive"
             title={errorMessage}
           >
             {errorMessage}

--- a/components/terminalLayer/TerminalFocusSidebar.tsx
+++ b/components/terminalLayer/TerminalFocusSidebar.tsx
@@ -176,18 +176,18 @@ const WorkspaceFocusSessionRow = memo<WorkspaceFocusSessionRowProps>(({
               className={cn('absolute bottom-0 right-0 fill-current', statusColor)}
             />
           </div>
-          <div className="flex h-6 flex-1 min-w-0 flex-col justify-center self-center text-left">
+          <div className="flex min-h-6 min-w-0 flex-1 flex-col justify-center self-center text-left">
             {isRenaming ? (
               <SessionInlineRenameInput
                 initialName={renameValue}
                 onCommit={onSubmitRename}
                 onCancel={onCancelRename}
-                className="h-5 text-xs leading-none"
+                className="h-5 text-xs leading-4"
               />
             ) : (
               <>
                 <div
-                  className={cn('truncate text-xs leading-none', isSelected ? 'font-semibold' : 'font-medium')}
+                  className={cn('truncate text-xs leading-4', isSelected ? 'font-semibold' : 'font-medium')}
                   onDoubleClick={(e) => {
                     e.stopPropagation();
                     onStartRename(session.id);
@@ -195,7 +195,7 @@ const WorkspaceFocusSessionRow = memo<WorkspaceFocusSessionRowProps>(({
                 >
                   {resolveSessionTabTitle(session, dynamicTabTitleMode)}
                 </div>
-                <div className="mt-0.5 truncate text-[10px] leading-none" style={{ color: mutedFg }}>
+                <div className="mt-0.5 truncate text-[10px] leading-4" style={{ color: mutedFg }}>
                   {session.username}@{session.hostname}
                 </div>
               </>

--- a/components/top-tabs/TopTabItems.tsx
+++ b/components/top-tabs/TopTabItems.tsx
@@ -511,7 +511,7 @@ export const PluginViewTopTab: React.FC<PluginViewTopTabProps> = memo(({
           {showDropIndicatorAfter && isDraggingForReorder && <div className="absolute -right-0.5 bottom-1 top-1 w-0.5 rounded-full bg-primary" />}
           <div className="flex min-w-0 flex-1 items-center gap-2">
             <PluginContributionIcon pluginId={tab.pluginId} icon={tab.icon} className="shrink-0" />
-            <span className="truncate">{tab.title}</span>
+            <span className="truncate leading-5">{tab.title}</span>
           </div>
           <button onClick={close} className="flex h-5 w-5 shrink-0 items-center justify-center rounded hover:bg-muted" aria-label={t('tabs.closePluginViewAria', { title: tab.title })}><X size={12} /></button>
         </div>
@@ -645,10 +645,10 @@ export const EditorTopTab: React.FC<EditorTopTabProps> = memo(({
               className="shrink-0"
               style={{ color: isActive ? 'var(--top-tabs-accent, hsl(var(--accent)))' : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
             />
-            <span className="truncate flex items-center gap-0.5">
-              {dirty && <span className="text-primary mr-0.5">●</span>}
+            <span className="flex items-center gap-0.5 truncate leading-5">
+              {dirty && <span className="mr-0.5 text-primary">●</span>}
               {editorTab.fileName}
-              {suffix && <span className="text-muted-foreground ml-1">{suffix}</span>}
+              {suffix && <span className="ml-1 text-muted-foreground">{suffix}</span>}
             </span>
           </div>
           <button
@@ -790,7 +790,7 @@ export const SessionTopTab: React.FC<SessionTopTabProps> = memo(({
           shellIcon={session.localShellIcon}
           dynamicTabTitleMode={dynamicTabTitleMode}
         />
-        <span className="truncate">{tabTitle}</span>
+        <span className="truncate leading-5">{tabTitle}</span>
         <div className="flex-shrink-0">{sessionStatusDot(session.status, hasActivity)}</div>
       </div>
       <button
@@ -986,7 +986,7 @@ export const WorkspaceTopTab: React.FC<WorkspaceTopTabProps> = memo(({
               className="shrink-0"
               style={{ color: isActive ? 'var(--top-tabs-accent, hsl(var(--accent)))' : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
             />
-            <span className="truncate">{workspace.title}</span>
+            <span className="truncate leading-5">{workspace.title}</span>
           </div>
           <div className="flex items-center gap-1.5 shrink-0">
             {hasActivity && sessionStatusDot('connected', true)}
@@ -1135,7 +1135,7 @@ export const LogViewTopTab: React.FC<LogViewTopTabProps> = memo(({
           className="shrink-0"
           style={{ color: isActive ? 'var(--top-tabs-accent, hsl(var(--accent)))' : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
         />
-        <span className="truncate">
+        <span className="truncate leading-5">
           {t('tabs.logPrefix')} {isLocal ? t('tabs.logLocal') : logView.log.hostname}
         </span>
       </div>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -106,7 +106,7 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
+      "text-lg font-semibold leading-snug tracking-tight",
       className
     )}
     {...props}

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -8,7 +8,7 @@ const Label = React.forwardRef<
   <label
     ref={ref}
     className={cn(
-      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      "text-sm font-medium leading-5 peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
       className
     )}
     {...props}

--- a/components/vault/VaultTreeRow.test.tsx
+++ b/components/vault/VaultTreeRow.test.tsx
@@ -67,6 +67,21 @@ test("VaultTreeItemRow exposes shared selected item state", () => {
   assert.match(markup, /Failover checklist/);
 });
 
+test("VaultTree labels use CJK-safe line-height under truncate", () => {
+  const groupMarkup = renderToStaticMarkup(
+    <VaultTreeGroupRow name="服务器配置" depth={0} count={1} />,
+  );
+  const itemMarkup = renderToStaticMarkup(
+    <VaultTreeItemRow label="机器安全检查报告" depth={0} />,
+  );
+
+  // leading-none clips CJK (PingFang etc.) when truncate applies overflow:hidden.
+  assert.match(groupMarkup, /leading-5/);
+  assert.doesNotMatch(groupMarkup, /leading-none/);
+  assert.match(itemMarkup, /leading-5/);
+  assert.doesNotMatch(itemMarkup, /leading-none/);
+});
+
 test("VaultTreeInlineRenameInput uses shared inline edit marker", () => {
   const markup = renderToStaticMarkup(
     <VaultTreeInlineRenameInput

--- a/components/vault/VaultTreeRow.tsx
+++ b/components/vault/VaultTreeRow.tsx
@@ -163,7 +163,8 @@ export const VaultTreeGroupRow: React.FC<VaultTreeGroupRowProps> = ({
           className="flex-1 font-semibold"
         />
       ) : (
-        <span className="flex h-5 min-w-0 flex-1 translate-y-px items-center gap-1.5 leading-none">
+        // leading-5 (not leading-none): CJK fallbacks like PingFang paint outside a 1.0 em box and get clipped by truncate.
+        <span className="flex min-h-5 min-w-0 flex-1 items-center gap-1.5 leading-5">
           <span className="min-w-0 truncate">{name}</span>
           {labelActions}
         </span>
@@ -235,9 +236,10 @@ export const VaultTreeItemRow: React.FC<VaultTreeItemRowProps> = ({
             onCancel={onRenameCancel}
           />
         ) : (
-          <div className="flex min-w-0 items-center truncate leading-none">{label}</div>
+          // leading-5 keeps CJK glyphs inside the line box under truncate overflow.
+          <div className="min-w-0 truncate leading-5">{label}</div>
         )}
-        {detail && <div className="truncate text-xs text-muted-foreground">{detail}</div>}
+        {detail && <div className="truncate text-xs leading-4 text-muted-foreground">{detail}</div>}
       </div>
     )}
     {actions}

--- a/components/vault/VaultViewLayout.tsx
+++ b/components/vault/VaultViewLayout.tsx
@@ -954,7 +954,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
 
             {isMultiSelectMode && isHostsSectionActive && (
               <div className="px-4 py-1.5 bg-background border-b border-border/40 flex items-center gap-2">
-                <span className="flex items-center h-7 text-xs text-muted-foreground leading-none">
+                <span className="flex h-7 items-center text-xs leading-4 text-muted-foreground">
                   {t("vault.hosts.selectedSummary", {
                     hosts: selectedHostIds.size,
                     groups: selectedGroupPaths.size,

--- a/index.css
+++ b/index.css
@@ -192,6 +192,8 @@ html.platform-win32 {
   white-space: nowrap;
   vertical-align: middle;
   max-width: 4.5rem;
+  /* Avoid line-height:1 clipping CJK under overflow:hidden on h-7 tabs. */
+  line-height: 1.25rem;
   opacity: 1;
   transition:
     max-width 220ms cubic-bezier(0.4, 0, 0.2, 1),


### PR DESCRIPTION
## Summary

- Fix Chinese (CJK) text being vertically clipped in vault trees, notes, tabs, dialogs, and other dense labels.
- Root cause: `leading-none` / too-tight line-height combined with `truncate` (`overflow: hidden`); CJK fallbacks like PingFang paint outside a 1.0 em box.
- Pure styling changes; no behavior or data model changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Vault tree rows (`VaultTreeRow`): `leading-none` → `leading-5`; drop fixed `h-5` / `translate-y-px` that worsened top clip.
- Host tree labels, notes title inputs, top tabs, log/editor/script headers, focus sidebar, script overlay.
- Shared `DialogTitle` / `Label` line-height for safer Chinese form/dialog titles.
- Regression test: vault tree labels must keep CJK-safe line-height under truncate.

## Screenshots / Demo

Notes sidebar Chinese folder/note titles no longer clip at top/bottom.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — `VaultTreeRow` + `NotesManager` unit tests
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)