### PR TITLE
fix(sftp): restore SSH session reuse for side-panel browse

### DIFF
--- a/application/state/sftp/ensureRemoteSftpSession.test.ts
+++ b/application/state/sftp/ensureRemoteSftpSession.test.ts
@@ -72,6 +72,31 @@ test("reconnects when the mapped session is missing", async () => {
   assert.equal(sftpId, "sftp-reconnected");
 });
 
+test("resolves source session when restoring a missing browse session", async () => {
+  let connectOptions: { initialPath?: string; sourceSessionId?: string } | undefined;
+  let resolvedHost: Host | undefined;
+  const sessions = { current: new Map<string, string>() };
+  const sftpId = await ensureRemoteSftpSession({
+    side: "left",
+    getActivePane: () => remotePane("conn-1"),
+    sftpSessionsRef: sessions,
+    lastConnectedHostRef: { current: { left: host, right: null } },
+    resolveSourceSessionId: (hostId, reconnectHost) => {
+      resolvedHost = reconnectHost;
+      return hostId === "host-1" ? "term-1" : undefined;
+    },
+    connect: async (_side, _host, options) => {
+      connectOptions = options;
+      sessions.current.set("conn-1", "sftp-restored");
+    },
+    releaseConnection: noopReleaseConnection,
+  });
+  assert.equal(sftpId, "sftp-restored");
+  assert.equal(resolvedHost?.hostname, "ci.example");
+  assert.equal(connectOptions?.initialPath, "/root");
+  assert.equal(connectOptions?.sourceSessionId, "term-1");
+});
+
 test("forceReconnect reopens even when a mapping exists", async () => {
   let connectCalls = 0;
   const released: string[] = [];

--- a/application/state/sftp/ensureRemoteSftpSession.ts
+++ b/application/state/sftp/ensureRemoteSftpSession.ts
@@ -11,8 +11,12 @@ export interface EnsureRemoteSftpSessionParams {
   connect: (
     side: "left" | "right",
     host: Host | "local",
-    options?: { initialPath?: string; ignoreSharedCache?: boolean; tabId?: string },
+    options?: { initialPath?: string; ignoreSharedCache?: boolean; tabId?: string; sourceSessionId?: string },
   ) => Promise<void>;
+  /** Preferred already-authenticated SSH session for this reconnect. */
+  sourceSessionId?: string;
+  /** Resolve an SSH session after the reconnect host has been resolved. */
+  resolveSourceSessionId?: (hostId: string, host: Host) => string | undefined;
   /**
    * Per-tab connect-time host (includes session hostname/port/user overrides).
    * Prefer this over the vault entry so upload reconnects keep the same endpoint.
@@ -47,6 +51,8 @@ export async function ensureRemoteSftpSession(
     releaseConnection,
     forceReconnect = false,
     tabId,
+    sourceSessionId,
+    resolveSourceSessionId,
   } = params;
 
   const resolveHost = (): Host => {
@@ -115,10 +121,12 @@ export async function ensureRemoteSftpSession(
   const paneBefore = getActivePane(side);
   const resumePath = paneBefore?.connection?.currentPath;
   const host = resolveHost();
+  const resolvedSourceSessionId = sourceSessionId ?? resolveSourceSessionId?.(host.id, host);
   await connect(side, host, {
     initialPath: resumePath,
     ignoreSharedCache: true,
     ...(tabId ? { tabId } : {}),
+    ...(resolvedSourceSessionId ? { sourceSessionId: resolvedSourceSessionId } : {}),
   });
 
   const sftpId = readMappedId();

--- a/application/state/sftp/types.ts
+++ b/application/state/sftp/types.ts
@@ -107,6 +107,11 @@ export interface SftpStateOptions {
    */
   resolveTransferSourceSessionId?: (hostId: string, host?: Host) => string | undefined;
   /**
+   * Resolve a live terminal session id for restoring parked browse sessions.
+   * This keeps side-panel tab switches on the already-authenticated SSH transport.
+   */
+  resolveBrowseSourceSessionId?: (hostId: string, host?: Host) => string | undefined;
+  /**
    * @deprecated Transfer channels no longer park independently. SSH keep-alive
    * is controlled by sshTransportIdleTtlMs in settings.
    */

--- a/application/state/useSftpState.ts
+++ b/application/state/useSftpState.ts
@@ -305,6 +305,7 @@ export const useSftpState = (
     [hosts, identities, keys, transferKnownHosts, transferTerminalSettings],
   );
   const resolveTransferSourceSessionId = options?.resolveTransferSourceSessionId;
+  const resolveBrowseSourceSessionId = options?.resolveBrowseSourceSessionId;
 
   const openPoolSftpSession = useCallback(
     async (host: Host) => {
@@ -709,6 +710,7 @@ export const useSftpState = (
             connect,
             resolveConnectedHost: (id) => connectedHostByTabIdRef.current.get(id) ?? null,
             resolveHostById: (hostId) => hosts.find((host) => host.id === hostId) ?? null,
+            resolveSourceSessionId: resolveBrowseSourceSessionId,
             probeSession: async (sftpId) => {
               const bridge = netcattyBridge.get();
               if (!bridge?.getSftpHomeDir) return true;
@@ -740,6 +742,7 @@ export const useSftpState = (
     getActivePane,
     hosts,
     lastConnectedHostRef,
+    resolveBrowseSourceSessionId,
     sftpSessionsRef,
     releaseConnection,
   ]);

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -75,7 +75,12 @@ import {
   recallSftpSidePanelPath,
   rememberSftpSidePanelPath,
 } from "./sftp/sftpSidePanelConnectionMemory";
-import { listSftpConnectedHosts, resolveSftpTransferSourceSessionId, sftpPickerSessionsEqual } from "../domain/sftpConnectedHosts";
+import {
+  listSftpConnectedHosts,
+  resolveSftpTransferSourceSessionId,
+  sftpHostEndpointsEqual,
+  sftpPickerSessionsEqual,
+} from "../domain/sftpConnectedHosts";
 import type { TerminalSession } from "../domain/models";
 
 interface SftpSidePanelProps {
@@ -181,6 +186,20 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     return resolveSftpTransferSourceSessionId(sessions, hostsById, hostId, host);
   }, [hosts, sessions]);
 
+  // Browse restore can run before the session list reflects the focused tab;
+  // prefer the active source when its visible endpoint matches the pane host.
+  const resolveBrowseSourceSessionId = useCallback((hostId: string, host?: Host) => {
+    if (
+      activeSessionId
+      && activeHost
+      && activeHost.id === hostId
+      && (!host || sftpHostEndpointsEqual(activeHost, host))
+    ) {
+      return activeSessionId;
+    }
+    return resolveTransferSourceSessionId(hostId, host);
+  }, [activeHost, activeSessionId, resolveTransferSourceSessionId]);
+
   const fileWatchHandlers = useMemo(() => ({
     onFileWatchSynced: (payload: { remotePath: string }) => {
       const fileName = payload.remotePath.split('/').pop() || payload.remotePath;
@@ -221,6 +240,7 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     knownHosts,
     onAddKnownHost,
     resolveTransferSourceSessionId,
+    resolveBrowseSourceSessionId,
   }), [
     fileWatchHandlers,
     hasOwnedEditorTab,
@@ -232,6 +252,7 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     knownHosts,
     onAddKnownHost,
     resolveTransferSourceSessionId,
+    resolveBrowseSourceSessionId,
   ]);
 
   const sftp = useSftpState(hosts, keys, identities, sftpOptions);


### PR DESCRIPTION
## Summary

Fixes an SFTP side-panel regression after #2555: after SSH finished EDR/MFA secondary auth, switching the side panel from SFTP to **System** and back could re-trigger secondary auth because browse-session restore omitted the source SSH session.

#2520 covered a similar issue under the old architecture but was closed when #2555 unified connection management. Users could still reproduce the side-panel switch regression after #2555, so this is a smaller fix on the new architecture.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #2150

## Changes Made

- When restoring a parked browse SFTP session, resolve a reusable authenticated SSH source session and pass it to `connect` in reconnect options.
- Side-panel restore prefers the current active SSH session; if the endpoint does not match, fall back to existing session-list endpoint matching.
- Keep compatibility for `sftpSudo`, standalone SFTP View, and multiple same-`hostId` sessions; the backend still validates the source hint against the full route/endpoint.
- Add regression tests that restoring a missing browse session passes the source session back into `connect`.

## Screenshots / Demo

Verified on a real host: after SSH secondary auth, open SFTP, switch to the System tab and back to SFTP — no second secondary-auth prompt.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Focused verification actually run:

- `node --test --import tsx application/state/sftp/ensureRemoteSftpSession.test.ts application/state/sftp/useSftpConnections.test.ts application/state/sftp/browseSessionLifecycle.test.ts components/sftp/sftpSidePanelConnectionMemory.test.ts components/terminalLayer/sftpPanelLifecycle.test.ts domain/sftpConnectedHosts.test.ts`: 58 pass
- `npx eslint application/state/sftp/ensureRemoteSftpSession.ts application/state/sftp/ensureRemoteSftpSession.test.ts application/state/sftp/types.ts application/state/useSftpState.ts components/SftpSidePanel.tsx --quiet`
- `git diff --check`
- `npm run dev` starts successfully; user-environment confirmation passed

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)