### PR TITLE
fix: harden CI and Cursor automation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,12 @@ permissions:
   pull-requests: read
 
 env:
+  # npm retries only transient registry fetches; deterministic install or
+  # postinstall failures still fail immediately.
+  NPM_CONFIG_FETCH_RETRIES: "4"
+  NPM_CONFIG_FETCH_RETRY_FACTOR: "2"
+  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "1000"
+  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "10000"
   MOSH_BIN_RELEASE: ${{ github.event.inputs.mosh_bin_release || vars.MOSH_BIN_RELEASE || '' }}
   BUNDLE_MOSH: ${{ (startsWith(github.ref, 'refs/tags/v') && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish_release))) || (github.event_name == 'workflow_dispatch' && inputs.mosh_bin_release != '') }}
   ET_BIN_RELEASE: ${{ github.event.inputs.et_bin_release || vars.ET_BIN_RELEASE || '' }}
@@ -224,6 +230,8 @@ jobs:
             ~/Library/Caches/electron-builder
             ~/AppData/Local/electron-builder/Cache
           key: electron-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            electron-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install deps
         run: npm ci
@@ -335,7 +343,10 @@ jobs:
       && (needs.resolve-et.result == 'success' || needs.resolve-et.result == 'skipped')
     runs-on: ubuntu-latest
     container:
-      image: almalinux:8
+      # The GitHub runner already retries container pulls three times. Use the
+      # official Quay mirror to avoid the Docker Hub endpoint that repeatedly
+      # timed out in package validation.
+      image: quay.io/almalinuxorg/almalinux:8
     env:
       MOSH_BIN_RELEASE: ${{ needs.resolve-mosh.outputs.mosh_bin_release }}
       ET_BIN_RELEASE: ${{ needs.resolve-et.outputs.et_bin_release }}
@@ -374,8 +385,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          dnf -y install epel-release
-          dnf -y install \
+          dnf -y --setopt=retries=4 --setopt=timeout=30 install epel-release
+          dnf -y --setopt=retries=4 --setopt=timeout=30 install \
             curl ca-certificates \
             gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make \
             python3.11 python3.11-pip \
@@ -408,7 +419,8 @@ jobs:
             BSDTAR_DEB_OK=0
             for url in "${BSDTAR_DEB_URLS[@]}"; do
               echo "trying ${url}"
-              if curl -fsSL -o /tmp/libarchive-tools.deb "${url}"; then
+              if curl -fsSL --retry 4 --retry-connrefused --connect-timeout 20 --max-time 300 \
+                -o /tmp/libarchive-tools.deb "${url}"; then
                 BSDTAR_DEB_OK=1
                 break
               fi
@@ -497,7 +509,8 @@ jobs:
           rpmbuild --version
           bsdtar --version | head -n 1
           # Official Node 22 linux-x64 tarball (same major as other package jobs).
-          NODE_VERSION="$(curl -fsSL https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt \
+          NODE_VERSION="$(curl -fsSL --retry 4 --retry-connrefused --connect-timeout 20 --max-time 300 \
+            https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt \
             | awk '/node-v[0-9.]+-linux-x64\.tar\.xz$/{print $2; exit}' \
             | sed -E 's/^node-(v[0-9.]+)-linux-x64\.tar\.xz$/\1/')"
           if [[ -z "${NODE_VERSION}" ]]; then
@@ -505,7 +518,8 @@ jobs:
             exit 1
           fi
           echo "Installing Node ${NODE_VERSION} from nodejs.org"
-          curl -fsSL "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.xz" \
+          curl -fsSL --retry 4 --retry-connrefused --connect-timeout 20 --max-time 300 \
+            "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.xz" \
             | tar -xJ -C /usr/local --strip-components=1
           node -v
           npm -v
@@ -525,6 +539,8 @@ jobs:
             ~/.cache/electron
             ~/.cache/electron-builder
           key: electron-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            electron-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install deps
         run: |
@@ -650,13 +666,15 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          apt-get update
-          apt-get install -y curl build-essential python3 git libfuse2 file rpm \
+          set -euo pipefail
+          apt-get -o Acquire::Retries=4 update
+          apt-get -o Acquire::Retries=4 install -y curl build-essential python3 git libfuse2 file rpm \
             libarchive-tools \
             libglib2.0-0 libgtk-3-0 libnss3 libxss1 libxtst6 libasound2 \
             libatk-bridge2.0-0 libdrm2 libgbm1 libx11-xcb1 libxcb-dri3-0
-          curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-          apt-get install -y nodejs
+          curl -fsSL --retry 4 --retry-all-errors --connect-timeout 20 --max-time 300 \
+            https://deb.nodesource.com/setup_22.x | bash -
+          apt-get -o Acquire::Retries=4 install -y nodejs
 
       - name: Checkout
         uses: actions/checkout@v7
@@ -668,6 +686,8 @@ jobs:
             ~/.cache/electron
             ~/.cache/electron-builder
           key: electron-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            electron-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install deps
         run: npm ci
@@ -866,7 +886,10 @@ jobs:
       - name: Propose Nix release metadata
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          # RELEASE_TOKEN remains the checkout credential for branch pushes.
+          # PR creation prefers the triage PAT, whose repository permissions
+          # include pull requests, and falls back to this job's scoped token.
+          GH_TOKEN: ${{ secrets.TRIAGE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           REPO_OWNER: ${{ github.repository_owner }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -665,6 +665,7 @@ jobs:
           fi
 
       - name: Install build dependencies
+        shell: bash
         run: |
           set -euo pipefail
           apt-get -o Acquire::Retries=4 update

--- a/.github/workflows/cursor-automation.yml
+++ b/.github/workflows/cursor-automation.yml
@@ -1361,6 +1361,16 @@ jobs:
             const auto = require(`${process.env.RUNNER_TEMP}/cursor-automation.cjs`);
             const issueNumber = Number(process.env.ISSUE_NUMBER);
             const pullNumber = Number(process.env.PULL_NUMBER) || null;
+            const queuePullReadinessCheck = async () => {
+              if (!pullNumber) return;
+              await github.rest.actions.createWorkflowDispatch({
+                ...context.repo,
+                workflow_id: 'cursor-automation.yml',
+                ref: context.payload.repository.default_branch,
+                inputs: { pull_number: String(pullNumber) },
+              });
+              core.info(`Queued a readiness check for PR #${pullNumber}.`);
+            };
             const { data: issue } = await github.rest.issues.get({
               ...context.repo,
               issue_number: issueNumber,
@@ -1378,6 +1388,7 @@ jobs:
             const liveKind = auto.classifySimpleIssueFollowup(livePending);
             if (changed.length || !liveKind) {
               if (!livePending.length) {
+                await queuePullReadinessCheck();
                 core.info('The simple follow-up was removed before reply; nothing to process.');
                 return;
               }
@@ -1408,17 +1419,7 @@ jobs:
                 pullNumber,
               }),
             });
-            if (pullNumber) {
-              await github.rest.actions.createWorkflowDispatch({
-                ...context.repo,
-                workflow_id: 'cursor-automation.yml',
-                ref: context.payload.repository.default_branch,
-                inputs: { pull_number: String(pullNumber) },
-              });
-              core.info(
-                `Queued a readiness check for PR #${pullNumber} after the simple follow-up reply.`,
-              );
-            }
+            await queuePullReadinessCheck();
 
       - name: Pause linked pull request during follow-up review
         if: steps.prepare.outputs.should_run == 'true' && steps.prepare.outputs.has_pull == 'true'

--- a/.github/workflows/cursor-automation.yml
+++ b/.github/workflows/cursor-automation.yml
@@ -1348,7 +1348,6 @@ jobs:
                 pullNumber,
               }),
             });
-
       - name: Handle simple resolution or acknowledgement
         if: steps.prepare.outputs.simple_kind != ''
         uses: actions/github-script@v9
@@ -1409,6 +1408,17 @@ jobs:
                 pullNumber,
               }),
             });
+            if (pullNumber) {
+              await github.rest.actions.createWorkflowDispatch({
+                ...context.repo,
+                workflow_id: 'cursor-automation.yml',
+                ref: context.payload.repository.default_branch,
+                inputs: { pull_number: String(pullNumber) },
+              });
+              core.info(
+                `Queued a readiness check for PR #${pullNumber} after the simple follow-up reply.`,
+              );
+            }
 
       - name: Pause linked pull request during follow-up review
         if: steps.prepare.outputs.should_run == 'true' && steps.prepare.outputs.has_pull == 'true'

--- a/.github/workflows/cursor-automation.yml
+++ b/.github/workflows/cursor-automation.yml
@@ -10,7 +10,7 @@ on:
   # Route all PR lifecycle events through the default-branch workflow. This avoids
   # approval-blocked pull_request / pull_request_review runs from fork authors.
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, closed]
   # Reaction-only clean (👍 on @codex request) does not emit review events;
   # poll open automation PRs so the loop can observe and mark ready.
   schedule:
@@ -273,6 +273,16 @@ jobs:
                 ownActors,
                 repository: `${context.repo.owner}/${context.repo.repo}`,
               });
+              if (
+                sameRepo &&
+                context.payload.action === 'closed' &&
+                auto.shouldGatePullOnSourceIssueFollowups(pr)
+              ) {
+                return set('source_issue_cleanup', {
+                  pull_number: String(pr.number),
+                  reason: pr.merged ? 'automation PR merged' : 'automation PR closed',
+                });
+              }
               if (sameRepo) {
                 if (eligible) {
                   if (['opened', 'ready_for_review', 'reopened'].includes(context.payload.action)) {
@@ -317,6 +327,59 @@ jobs:
             }
 
             return set('skip', { reason: `unhandled ${event}` });
+
+  cleanup_source_issue:
+    name: Clean source issue state
+    needs: route
+    if: needs.route.outputs.kind == 'source_issue_cleanup'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout helpers
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Clear stale workflow labels
+        uses: actions/github-script@v9
+        env:
+          PULL_NUMBER: ${{ needs.route.outputs.pull_number }}
+        with:
+          github-token: ${{ secrets.TRIAGE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const auto = require(`${process.env.GITHUB_WORKSPACE}/scripts/cursor-automation.cjs`);
+            const pullNumber = Number(process.env.PULL_NUMBER);
+            const { data: pull } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: pullNumber,
+            });
+            const issueNumber = auto.extractSourceIssueNumber(pull);
+            if (!issueNumber) return;
+            const { data: issue } = await github.rest.issues.get({
+              ...context.repo,
+              issue_number: issueNumber,
+            });
+            const labels = auto.nextSourceIssueLabelsAfterPull(
+              issue.labels || [],
+              Boolean(pull.merged),
+            );
+            await github.rest.issues.update({
+              ...context.repo,
+              issue_number: issueNumber,
+              labels,
+            });
+            const pullLabels = (pull.labels || [])
+              .map((label) => typeof label === 'string' ? label : label.name)
+              .filter((label) => !['automation:codex-loop', 'ready-for-human'].includes(label));
+            await github.rest.issues.update({
+              ...context.repo,
+              issue_number: pullNumber,
+              labels: pullLabels,
+            });
 
   classify:
     name: Classify issue
@@ -1159,11 +1222,13 @@ jobs:
           set -euo pipefail
           git fetch --depth=1 origin "$DEFAULT_BRANCH"
           git show "FETCH_HEAD:scripts/cursor-automation.cjs" > "$RUNNER_TEMP/cursor-automation.cjs"
+          git show "FETCH_HEAD:scripts/compare-ci-test-baseline.cjs" > "$RUNNER_TEMP/compare-ci-test-baseline.cjs"
           git show "FETCH_HEAD:scripts/prepare-cursor-research-input.sh" > "$RUNNER_TEMP/prepare-cursor-research-input.sh"
           git show "FETCH_HEAD:.github/cursor/prompts/followup.md" > "$RUNNER_TEMP/followup.md"
           git show "FETCH_HEAD:.github/cursor/prompts/research.md" > "$RUNNER_TEMP/research.md"
           chmod 0555 "$RUNNER_TEMP/prepare-cursor-research-input.sh"
           test -s "$RUNNER_TEMP/cursor-automation.cjs"
+          test -s "$RUNNER_TEMP/compare-ci-test-baseline.cjs"
           test -s "$RUNNER_TEMP/prepare-cursor-research-input.sh"
           test -s "$RUNNER_TEMP/followup.md"
           test -s "$RUNNER_TEMP/research.md"
@@ -1254,6 +1319,35 @@ jobs:
               }),
             });
 
+      - name: Handle simple resolution or acknowledgement
+        if: steps.prepare.outputs.simple_kind != ''
+        uses: actions/github-script@v9
+        env:
+          SIMPLE_KIND: ${{ steps.prepare.outputs.simple_kind }}
+          PENDING_IDS: ${{ steps.prepare.outputs.pending_ids }}
+        with:
+          github-token: ${{ secrets.TRIAGE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const auto = require(`${process.env.RUNNER_TEMP}/cursor-automation.cjs`);
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const { data: issue } = await github.rest.issues.get({
+              ...context.repo,
+              issue_number: issueNumber,
+            });
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: issueNumber,
+              body: auto.buildIssueFollowupReply({
+                commentIds: process.env.PENDING_IDS.split(',').filter(Boolean),
+                result: 'no_change',
+                reply: auto.buildSimpleIssueFollowupReply(
+                  issue,
+                  process.env.SIMPLE_KIND,
+                ),
+                pullNumber: Number(process.env.PULL_NUMBER) || null,
+              }),
+            });
+
       - name: Pause linked pull request during follow-up review
         if: steps.prepare.outputs.should_run == 'true' && steps.prepare.outputs.has_pull == 'true'
         uses: actions/github-script@v9
@@ -1295,6 +1389,17 @@ jobs:
       - name: Install dependencies
         if: steps.prepare.outputs.should_run == 'true' && steps.prepare.outputs.has_pull == 'true'
         run: npm ci
+
+      - name: Capture follow-up exact-base test baseline
+        if: steps.prepare.outputs.should_run == 'true' && steps.prepare.outputs.has_pull == 'true'
+        run: |
+          mkdir -p .cursor-runtime
+          set +e
+          npm test > .cursor-runtime/followup-base-tests.log 2>&1
+          status=$?
+          set -e
+          echo "$status" > .cursor-runtime/followup-base-tests.exit
+          tail -80 .cursor-runtime/followup-base-tests.log || true
 
       - name: Install Cursor CLI
         if: steps.prepare.outputs.should_run == 'true'
@@ -1591,22 +1696,41 @@ jobs:
         if: steps.decision.outputs.action == 'updated'
         id: verify
         run: |
+          mkdir -p .cursor-runtime
+          set -o pipefail
           set +e
-          npm run lint
+          npm run lint 2>&1 | tee .cursor-runtime/followup-candidate-lint.log
           lint=$?
-          npm test
+          npm test 2>&1 | tee .cursor-runtime/followup-candidate-tests.log
           tests=$?
-          npm run build
+          node "$RUNNER_TEMP/compare-ci-test-baseline.cjs" \
+            --baseline-log .cursor-runtime/followup-base-tests.log \
+            --baseline-exit "$(cat .cursor-runtime/followup-base-tests.exit)" \
+            --candidate-log .cursor-runtime/followup-candidate-tests.log \
+            --candidate-exit "$tests" \
+            --output .cursor-runtime/followup-test-comparison.json
+          tests_compared=$?
+          npm run build 2>&1 | tee .cursor-runtime/followup-candidate-build.log
           build=$?
           set -e
-          if [[ "$lint" != "0" || "$tests" != "0" || "$build" != "0" ]]; then
+          node -e '
+            const fs = require("node:fs");
+            const result = {
+              lint: Number(process.argv[1]),
+              tests: Number(process.argv[2]),
+              testComparison: Number(process.argv[3]),
+              build: Number(process.argv[4]),
+            };
+            fs.writeFileSync(".cursor-runtime/followup-verify-result.json", JSON.stringify(result, null, 2) + "\n");
+          ' "$lint" "$tests" "$tests_compared" "$build"
+          if [[ "$lint" != "0" || "$tests_compared" != "0" || "$build" != "0" ]]; then
             echo "passed=false" >> "$GITHUB_OUTPUT"
-            exit 1
+            exit 0
           fi
           echo "passed=true" >> "$GITHUB_OUTPUT"
 
       - name: Prepare follow-up patch
-        if: steps.decision.outputs.action == 'updated' && steps.verify.outputs.passed == 'true'
+        if: steps.decision.outputs.action == 'updated'
         id: patch
         env:
           BASE_SHA: ${{ steps.snapshot.outputs.base_sha }}
@@ -1640,10 +1764,11 @@ jobs:
           test -s .cursor-runtime/followup.patch
           printf '%s' "${{ steps.prepare.outputs.pending_ids }}" > .cursor-runtime/followup-pending-ids.txt
           printf '%s' '${{ steps.prepare.outputs.pending_snapshots }}' > .cursor-runtime/followup-pending-snapshots.json
-          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          echo "artifact_ready=true" >> "$GITHUB_OUTPUT"
+          echo "should_publish=${{ steps.verify.outputs.passed == 'true' }}" >> "$GITHUB_OUTPUT"
 
       - name: Scan follow-up patch for secret leaks
-        if: steps.patch.outputs.should_publish == 'true'
+        if: steps.patch.outputs.artifact_ready == 'true'
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
         run: |
@@ -1655,6 +1780,8 @@ jobs:
                 ".cursor-runtime/followup-reply.out.md",
                 ".cursor-runtime/followup-pending-ids.txt",
                 ".cursor-runtime/followup-pending-snapshots.json",
+                ".cursor-runtime/followup-verify-result.json",
+                ".cursor-runtime/followup-test-comparison.json",
               ],
               process.env.CURSOR_API_KEY,
               "issue-followup-publish",
@@ -1662,7 +1789,7 @@ jobs:
           '
 
       - name: Upload follow-up patch
-        if: steps.patch.outputs.should_publish == 'true'
+        if: steps.patch.outputs.artifact_ready == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: issue-followup-${{ github.run_id }}
@@ -1671,7 +1798,15 @@ jobs:
             .cursor-runtime/followup-reply.out.md
             .cursor-runtime/followup-pending-ids.txt
             .cursor-runtime/followup-pending-snapshots.json
+            .cursor-runtime/followup-verify-result.json
+            .cursor-runtime/followup-test-comparison.json
           if-no-files-found: error
+
+      - name: Fail after preserving rejected follow-up
+        if: steps.patch.outputs.artifact_ready == 'true' && steps.verify.outputs.passed != 'true'
+        run: |
+          echo "Follow-up patch was preserved, but candidate-specific verification failed." >&2
+          exit 1
 
       - name: Finish follow-up without code changes
         if: steps.decision.outputs.action == 'no_change' || steps.decision.outputs.action == 'blocked'
@@ -2525,7 +2660,9 @@ jobs:
           test -s scripts/cursor-automation.cjs
 
       - name: Freeze trusted helper
-        run: cp scripts/cursor-automation.cjs "$RUNNER_TEMP/cursor-automation.cjs"
+        run: |
+          cp scripts/cursor-automation.cjs "$RUNNER_TEMP/cursor-automation.cjs"
+          cp scripts/compare-ci-test-baseline.cjs "$RUNNER_TEMP/compare-ci-test-baseline.cjs"
 
       - name: Skip if bot PR already open
         id: existing
@@ -2572,6 +2709,17 @@ jobs:
       - name: Install dependencies
         if: steps.existing.outputs.exists != 'true'
         run: npm ci
+
+      - name: Capture exact-base test baseline
+        if: steps.existing.outputs.exists != 'true'
+        run: |
+          mkdir -p .cursor-runtime
+          set +e
+          npm test > .cursor-runtime/base-tests.log 2>&1
+          status=$?
+          set -e
+          echo "$status" > .cursor-runtime/base-tests.exit
+          tail -80 .cursor-runtime/base-tests.log || true
 
       - name: Install Cursor CLI
         if: steps.existing.outputs.exists != 'true'
@@ -2676,6 +2824,7 @@ jobs:
 
       - name: Check protected paths (tree + commits)
         if: steps.existing.outputs.exists != 'true' && steps.changes.outputs.present == 'true'
+        id: check_protected
         run: |
           status="$(git status --porcelain --untracked-files=all -- . ':(exclude).cursor-runtime' ':(exclude).cursor-runtime/**')"
           names="$(git diff --name-only "${{ steps.branch.outputs.base_sha }}" HEAD 2>/dev/null || true)"
@@ -2700,11 +2849,19 @@ jobs:
           github-token: ${{ secrets.TRIAGE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const auto = require(`${process.env.RUNNER_TEMP}/cursor-automation.cjs`);
+            const { data: issue } = await github.rest.issues.get({
+              ...context.repo,
+              issue_number: Number(process.env.ISSUE_NUMBER),
+            });
             await auto.markNeedsHuman({
               github,
               context,
               issueNumber: process.env.ISSUE_NUMBER,
-              message: 'The automatic implementation pass did not produce a safe focused change. A maintainer needs to take a look.',
+              message: auto.buildImplementationFailureMessage(issue, {
+                kind: 'no_changes',
+                workflowUrl: `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              }),
+              dedupeMarker: `<!-- cursor-implement-failure:base=${{ steps.branch.outputs.base_sha }};kind=no_changes -->`,
             });
 
       - name: Install test shell dependencies
@@ -2718,22 +2875,43 @@ jobs:
         if: steps.existing.outputs.exists != 'true' && steps.changes.outputs.present == 'true'
         id: verify
         run: |
+          mkdir -p .cursor-runtime
+          set -o pipefail
           set +e
-          npm run lint
+          npm run lint 2>&1 | tee .cursor-runtime/candidate-lint.log
           lint=$?
-          npm test
+          npm test 2>&1 | tee .cursor-runtime/candidate-tests.log
           tests=$?
-          npm run build
+          node "$RUNNER_TEMP/compare-ci-test-baseline.cjs" \
+            --baseline-log .cursor-runtime/base-tests.log \
+            --baseline-exit "$(cat .cursor-runtime/base-tests.exit)" \
+            --candidate-log .cursor-runtime/candidate-tests.log \
+            --candidate-exit "$tests" \
+            --output .cursor-runtime/test-comparison.json
+          tests_compared=$?
+          npm run build 2>&1 | tee .cursor-runtime/candidate-build.log
           build=$?
           set -e
-          if [[ "$lint" != "0" || "$tests" != "0" || "$build" != "0" ]]; then
+          node -e '
+            const fs = require("node:fs");
+            const result = {
+              lint: Number(process.argv[1]),
+              tests: Number(process.argv[2]),
+              testComparison: Number(process.argv[3]),
+              build: Number(process.argv[4]),
+            };
+            fs.writeFileSync(".cursor-runtime/verify-result.json", JSON.stringify(result, null, 2) + "\n");
+          ' "$lint" "$tests" "$tests_compared" "$build"
+          if [[ "$lint" != "0" || "$tests_compared" != "0" || "$build" != "0" ]]; then
             echo "passed=false" >> "$GITHUB_OUTPUT"
-            exit 1
+            echo "kind=candidate_verification" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           echo "passed=true" >> "$GITHUB_OUTPUT"
+          echo "kind=clean_or_baseline_only" >> "$GITHUB_OUTPUT"
 
       - name: Prepare patch for isolated publish
-        if: steps.existing.outputs.exists != 'true' && steps.changes.outputs.present == 'true' && steps.verify.outputs.passed == 'true'
+        if: steps.existing.outputs.exists != 'true' && steps.changes.outputs.present == 'true'
         id: patch
         # No CURSOR_API_KEY here: agent may have installed hooks. Git runs with hooks disabled.
         env:
@@ -2780,10 +2958,11 @@ jobs:
           else
             : > .cursor-runtime/implement-pr-body.out.md
           fi
-          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          echo "artifact_ready=true" >> "$GITHUB_OUTPUT"
+          echo "should_publish=${{ steps.verify.outputs.passed == 'true' }}" >> "$GITHUB_OUTPUT"
 
       - name: Scan implement patch for secret leaks
-        if: steps.patch.outputs.should_publish == 'true'
+        if: steps.patch.outputs.artifact_ready == 'true'
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
         run: |
@@ -2798,6 +2977,8 @@ jobs:
                 ".cursor-runtime/implement-status.txt",
                 ".cursor-runtime/implement-pr-body.out.md",
                 ".cursor-runtime/implement-pr-body.md",
+                ".cursor-runtime/verify-result.json",
+                ".cursor-runtime/test-comparison.json",
               ],
               process.env.CURSOR_API_KEY,
               "implement-publish",
@@ -2805,7 +2986,7 @@ jobs:
           '
 
       - name: Upload implement patch
-        if: steps.patch.outputs.should_publish == 'true'
+        if: steps.patch.outputs.artifact_ready == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: implement-patch-${{ github.run_id }}
@@ -2813,7 +2994,15 @@ jobs:
             .cursor-runtime/implement.patch
             .cursor-runtime/implement-status.out.txt
             .cursor-runtime/implement-pr-body.out.md
+            .cursor-runtime/verify-result.json
+            .cursor-runtime/test-comparison.json
           if-no-files-found: error
+
+      - name: Fail after preserving rejected implementation
+        if: steps.patch.outputs.artifact_ready == 'true' && steps.verify.outputs.passed != 'true'
+        run: |
+          echo "Candidate patch was preserved, but candidate-specific verification failed." >&2
+          exit 1
 
       - name: Mark needs human on implement failure
         if: failure() && steps.existing.outputs.exists != 'true'
@@ -2826,12 +3015,29 @@ jobs:
               ? `${process.env.RUNNER_TEMP}/cursor-automation.cjs`
               : `${process.env.GITHUB_WORKSPACE}/scripts/cursor-automation.cjs`;
             const auto = require(helper);
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const { data: issue } = await github.rest.issues.get({
+              ...context.repo,
+              issue_number: issueNumber,
+            });
+            const protectedFailure = '${{ steps.check_protected.outcome }}' === 'failure';
+            const artifactReady = '${{ steps.patch.outputs.artifact_ready }}' === 'true';
+            const verifyFailed = '${{ steps.verify.outputs.passed }}' === 'false';
+            const kind = protectedFailure
+              ? 'protected_path'
+              : artifactReady && verifyFailed
+                ? 'verification_failed'
+                : 'processing_failed';
             await auto.markNeedsHuman({
               github,
               context,
-              issueNumber: process.env.ISSUE_NUMBER,
-              message:
-                'Automatic implementation did not finish cleanly (agent, protected paths, or verification failed). A maintainer needs to take a look.',
+              issueNumber,
+              message: auto.buildImplementationFailureMessage(issue, {
+                kind,
+                workflowUrl: `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                artifactName: artifactReady ? `implement-patch-${context.runId}` : '',
+              }),
+              dedupeMarker: `<!-- cursor-implement-failure:base=${{ steps.branch.outputs.base_sha }};kind=${kind} -->`,
             });
 
   publish_implement:
@@ -3297,7 +3503,9 @@ jobs:
           helper_supports_followups
 
       - name: Freeze trusted helper
-        run: cp scripts/cursor-automation.cjs "$RUNNER_TEMP/cursor-automation.cjs"
+        run: |
+          cp scripts/cursor-automation.cjs "$RUNNER_TEMP/cursor-automation.cjs"
+          cp scripts/compare-ci-test-baseline.cjs "$RUNNER_TEMP/compare-ci-test-baseline.cjs"
 
       - name: Inspect Codex outcome
         id: codex
@@ -3658,8 +3866,12 @@ jobs:
             gh api --method POST \
               "repos/${GITHUB_REPOSITORY}/issues/${PULL_NUMBER}/labels" \
               -f 'labels[]=ready-for-human' >/dev/null 2>&1 || true
-            gh pr comment "$PULL_NUMBER" --repo "$GITHUB_REPOSITORY" --body \
-              "Codex reported no major issues, but the automation token cannot change draft state. A maintainer can mark this PR ready." 2>/dev/null || true
+            blocked_marker="<!-- cursor-codex-ready-blocked:${live_head} -->"
+            existing_comments="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PULL_NUMBER}/comments" --jq '.[].body' 2>/dev/null || true)"
+            if ! grep -Fq "$blocked_marker" <<<"$existing_comments"; then
+              blocked_body="$(printf '%s\n\n%s' "$blocked_marker" 'Codex reported no major issues, but the automation token cannot change draft state. A maintainer can mark this PR ready.')"
+              gh pr comment "$PULL_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$blocked_body" 2>/dev/null || true
+            fi
             exit 0
           fi
           # Re-check head after gh pr ready (another push could race).
@@ -3694,8 +3906,15 @@ jobs:
             echo "Failed to convert PR out of draft (token may lack draft permission); labels still applied." >&2
             exit 0
           fi
-          gh pr comment "$PULL_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$(cat <<'EOF'
+          clean_marker="<!-- cursor-codex-clean-head:${live_head} -->"
+          existing_comments="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PULL_NUMBER}/comments" --jq '.[].body')"
+          if grep -Fq "$clean_marker" <<<"$existing_comments"; then
+            echo "Clean handoff already recorded for ${live_head}."
+            exit 0
+          fi
+          gh pr comment "$PULL_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF
           <!-- cursor-automation -->
+          ${clean_marker}
 
           Codex reported no major issues. This PR is marked ready for human review/merge.
           EOF
@@ -3885,6 +4104,17 @@ jobs:
         id: base
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Capture Codex-fix exact-base test baseline
+        if: steps.codex.outputs.action == 'fix'
+        run: |
+          mkdir -p .cursor-runtime
+          set +e
+          npm test > .cursor-runtime/fix-base-tests.log 2>&1
+          status=$?
+          set -e
+          echo "$status" > .cursor-runtime/fix-base-tests.exit
+          tail -80 .cursor-runtime/fix-base-tests.log || true
+
       - name: Stage Cursor API key for fixes
         if: steps.codex.outputs.action == 'fix'
         env:
@@ -3985,11 +4215,40 @@ jobs:
 
       - name: Verify fix
         if: steps.codex.outputs.action == 'fix'
+        id: fixverify
         run: |
+          mkdir -p .cursor-runtime
+          set -o pipefail
           set +e
-          npm run lint || exit 1
-          npm test || exit 1
-          npm run build || exit 1
+          npm run lint 2>&1 | tee .cursor-runtime/fix-candidate-lint.log
+          lint=$?
+          npm test 2>&1 | tee .cursor-runtime/fix-candidate-tests.log
+          tests=$?
+          node "$RUNNER_TEMP/compare-ci-test-baseline.cjs" \
+            --baseline-log .cursor-runtime/fix-base-tests.log \
+            --baseline-exit "$(cat .cursor-runtime/fix-base-tests.exit)" \
+            --candidate-log .cursor-runtime/fix-candidate-tests.log \
+            --candidate-exit "$tests" \
+            --output .cursor-runtime/fix-test-comparison.json
+          tests_compared=$?
+          npm run build 2>&1 | tee .cursor-runtime/fix-candidate-build.log
+          build=$?
+          set -e
+          node -e '
+            const fs = require("node:fs");
+            const result = {
+              lint: Number(process.argv[1]),
+              tests: Number(process.argv[2]),
+              testComparison: Number(process.argv[3]),
+              build: Number(process.argv[4]),
+            };
+            fs.writeFileSync(".cursor-runtime/fix-verify-result.json", JSON.stringify(result, null, 2) + "\n");
+          ' "$lint" "$tests" "$tests_compared" "$build"
+          if [[ "$lint" != "0" || "$tests_compared" != "0" || "$build" != "0" ]]; then
+            echo "passed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "passed=true" >> "$GITHUB_OUTPUT"
 
       - name: Prepare fix patch for isolated publish
         if: steps.codex.outputs.action == 'fix'
@@ -4034,10 +4293,11 @@ jobs:
           $GITH format-patch --stdout "${BASE_SHA}" > .cursor-runtime/fix.patch
           test -s .cursor-runtime/fix.patch
           echo "empty=false" >> "$GITHUB_OUTPUT"
-          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          echo "artifact_ready=true" >> "$GITHUB_OUTPUT"
+          echo "should_publish=${{ steps.fixverify.outputs.passed == 'true' }}" >> "$GITHUB_OUTPUT"
 
       - name: Scan fix patch for secret leaks
-        if: steps.codex.outputs.action == 'fix' && steps.fixpatch.outputs.should_publish == 'true'
+        if: steps.codex.outputs.action == 'fix' && steps.fixpatch.outputs.artifact_ready == 'true'
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
         run: |
@@ -4045,19 +4305,32 @@ jobs:
           node -e '
             const auto = require(process.env.RUNNER_TEMP + "/cursor-automation.cjs");
             auto.assertFilesDoNotContainSecret(
-              [".cursor-runtime/fix.patch"],
+              [
+                ".cursor-runtime/fix.patch",
+                ".cursor-runtime/fix-verify-result.json",
+                ".cursor-runtime/fix-test-comparison.json",
+              ],
               process.env.CURSOR_API_KEY,
               "fix-publish",
             );
           '
 
       - name: Upload fix patch
-        if: steps.codex.outputs.action == 'fix' && steps.fixpatch.outputs.should_publish == 'true'
+        if: steps.codex.outputs.action == 'fix' && steps.fixpatch.outputs.artifact_ready == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: codex-fix-patch-${{ github.run_id }}
-          path: .cursor-runtime/fix.patch
+          path: |
+            .cursor-runtime/fix.patch
+            .cursor-runtime/fix-verify-result.json
+            .cursor-runtime/fix-test-comparison.json
           if-no-files-found: error
+
+      - name: Fail after preserving rejected Codex fix
+        if: steps.codex.outputs.action == 'fix' && steps.fixpatch.outputs.artifact_ready == 'true' && steps.fixverify.outputs.passed != 'true'
+        run: |
+          echo "Codex fix patch was preserved, but candidate-specific verification failed." >&2
+          exit 1
 
       - name: Mark needs human when no fix produced
         if: steps.codex.outputs.action == 'fix' && steps.fixpatch.outputs.empty == 'true'

--- a/.github/workflows/cursor-automation.yml
+++ b/.github/workflows/cursor-automation.yml
@@ -276,9 +276,13 @@ jobs:
               if (
                 sameRepo &&
                 context.payload.action === 'closed' &&
-                auto.shouldGatePullOnSourceIssueFollowups(pr)
+                auto.shouldGatePullOnSourceIssueFollowups(pr, {
+                  ownActors,
+                  repository: `${context.repo.owner}/${context.repo.repo}`,
+                })
               ) {
                 return set('source_issue_cleanup', {
+                  issue_number: String(auto.extractSourceIssueNumber(pr)),
                   pull_number: String(pr.number),
                   reason: pr.merged ? 'automation PR merged' : 'automation PR closed',
                 });
@@ -333,6 +337,9 @@ jobs:
     needs: route
     if: needs.route.outputs.kind == 'source_issue_cleanup'
     runs-on: ubuntu-latest
+    concurrency:
+      group: cursor-source-issue-${{ needs.route.outputs.issue_number || github.run_id }}
+      cancel-in-progress: false
     permissions:
       contents: read
       issues: write
@@ -348,6 +355,7 @@ jobs:
         uses: actions/github-script@v9
         env:
           PULL_NUMBER: ${{ needs.route.outputs.pull_number }}
+          OWN_ACTORS: ${{ vars.AUTOMATION_OWN_ACTORS || 'binaricat,netcatty-bot,github-actions[bot]' }}
         with:
           github-token: ${{ secrets.TRIAGE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -357,29 +365,39 @@ jobs:
               ...context.repo,
               pull_number: pullNumber,
             });
+            if (!auto.shouldGatePullOnSourceIssueFollowups(pull, {
+              ownActors: process.env.OWN_ACTORS,
+              repository: `${context.repo.owner}/${context.repo.repo}`,
+            })) {
+              core.warning(`PR #${pullNumber} is not a trusted automation pull request; skipping source cleanup.`);
+              return;
+            }
             const issueNumber = auto.extractSourceIssueNumber(pull);
             if (!issueNumber) return;
-            const { data: issue } = await github.rest.issues.get({
-              ...context.repo,
-              issue_number: issueNumber,
-            });
-            const labels = auto.nextSourceIssueLabelsAfterPull(
-              issue.labels || [],
-              Boolean(pull.merged),
-            );
-            await github.rest.issues.update({
-              ...context.repo,
-              issue_number: issueNumber,
-              labels,
-            });
-            const pullLabels = (pull.labels || [])
-              .map((label) => typeof label === 'string' ? label : label.name)
-              .filter((label) => !['automation:codex-loop', 'ready-for-human'].includes(label));
-            await github.rest.issues.update({
-              ...context.repo,
-              issue_number: pullNumber,
-              labels: pullLabels,
-            });
+            const removeLabel = async (issue_number, name) => {
+              try {
+                await github.rest.issues.removeLabel({
+                  ...context.repo,
+                  issue_number,
+                  name,
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            };
+            for (const name of ['ready-for-agent', 'needs-info', 'ready-for-human']) {
+              await removeLabel(issueNumber, name);
+            }
+            if (!pull.merged) {
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: issueNumber,
+                labels: ['ready-for-human'],
+              });
+            }
+            for (const name of ['automation:codex-loop', 'ready-for-human']) {
+              await removeLabel(pullNumber, name);
+            }
 
   classify:
     name: Classify issue
@@ -397,7 +415,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-      actions: read
+      actions: write
     outputs:
       category: ${{ steps.apply.outputs.category }}
       should_implement: ${{ steps.apply.outputs.should_implement }}
@@ -1187,6 +1205,9 @@ jobs:
     if: needs.route.outputs.kind == 'issue_followup'
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    concurrency:
+      group: cursor-source-issue-${{ needs.route.outputs.issue_number || github.run_id }}
+      cancel-in-progress: false
     permissions:
       contents: read
       issues: write
@@ -1325,26 +1346,58 @@ jobs:
         env:
           SIMPLE_KIND: ${{ steps.prepare.outputs.simple_kind }}
           PENDING_IDS: ${{ steps.prepare.outputs.pending_ids }}
+          PENDING_SNAPSHOTS: ${{ steps.prepare.outputs.pending_snapshots }}
         with:
           github-token: ${{ secrets.TRIAGE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const auto = require(`${process.env.RUNNER_TEMP}/cursor-automation.cjs`);
             const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const pullNumber = Number(process.env.PULL_NUMBER) || null;
             const { data: issue } = await github.rest.issues.get({
               ...context.repo,
               issue_number: issueNumber,
             });
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { ...context.repo, issue_number: issueNumber, per_page: 100 },
+            );
+            const snapshots = JSON.parse(process.env.PENDING_SNAPSHOTS || '[]');
+            const changed = auto.getChangedIssueCommentSnapshotIds(comments, snapshots);
+            const pendingIds = process.env.PENDING_IDS.split(',').filter(Boolean);
+            const livePending = comments.filter((comment) =>
+              pendingIds.includes(String(comment.id)),
+            );
+            const liveKind = auto.classifySimpleIssueFollowup(livePending);
+            if (changed.length || !liveKind) {
+              if (!livePending.length) {
+                core.info('The simple follow-up was removed before reply; nothing to process.');
+                return;
+              }
+              const inputs = { issue_number: String(issueNumber) };
+              if (pullNumber) {
+                inputs.pull_number = String(pullNumber);
+                inputs.drain_backlog = 'true';
+              }
+              await github.rest.actions.createWorkflowDispatch({
+                ...context.repo,
+                workflow_id: 'cursor-automation.yml',
+                ref: context.payload.repository.default_branch,
+                inputs,
+              });
+              core.info(`Follow-up changed before the simple reply; dispatched a fresh review for issue #${issueNumber}.`);
+              return;
+            }
             await github.rest.issues.createComment({
               ...context.repo,
               issue_number: issueNumber,
               body: auto.buildIssueFollowupReply({
-                commentIds: process.env.PENDING_IDS.split(',').filter(Boolean),
+                commentIds: pendingIds,
                 result: 'no_change',
                 reply: auto.buildSimpleIssueFollowupReply(
                   issue,
-                  process.env.SIMPLE_KIND,
+                  liveKind,
                 ),
-                pullNumber: Number(process.env.PULL_NUMBER) || null,
+                pullNumber,
               }),
             });
 
@@ -1389,6 +1442,13 @@ jobs:
       - name: Install dependencies
         if: steps.prepare.outputs.should_run == 'true' && steps.prepare.outputs.has_pull == 'true'
         run: npm ci
+
+      - name: Install test shell dependencies
+        if: steps.prepare.outputs.should_run == 'true' && steps.prepare.outputs.has_pull == 'true'
+        run: |
+          # Match .github/workflows/test.yml — osc7Setup.test.ts requires fish in CI.
+          sudo apt-get update
+          sudo apt-get install -y fish
 
       - name: Capture follow-up exact-base test baseline
         if: steps.prepare.outputs.should_run == 'true' && steps.prepare.outputs.has_pull == 'true'
@@ -1686,23 +1746,38 @@ jobs:
             }
           ' "$status" "$names" "$name_status"
 
-      - name: Install test shell dependencies
-        if: steps.decision.outputs.action == 'updated'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y fish
-
       - name: Verify updated pull request
         if: steps.decision.outputs.action == 'updated'
         id: verify
+        env:
+          BASE_SHA: ${{ steps.snapshot.outputs.base_sha }}
         run: |
           mkdir -p .cursor-runtime
           set -o pipefail
           set +e
-          npm run lint 2>&1 | tee .cursor-runtime/followup-candidate-lint.log
-          lint=$?
-          npm test 2>&1 | tee .cursor-runtime/followup-candidate-tests.log
-          tests=$?
+          node -e '
+            const fs = require("node:fs");
+            const { execFileSync } = require("node:child_process");
+            const base = JSON.parse(execFileSync("git", ["show", `${process.argv[1]}:package.json`], { encoding: "utf8" }));
+            const current = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            const names = ["lint", "test", "build"];
+            const changed = names.filter((name) => base.scripts?.[name] !== current.scripts?.[name]);
+            if (changed.length) throw new Error(`Validation scripts changed: ${changed.join(", ")}`);
+          ' "$BASE_SHA"
+          script_guard=$?
+          if [[ "$script_guard" == "0" ]]; then
+            npm run lint 2>&1 | tee .cursor-runtime/followup-candidate-lint.log
+            lint=$?
+            npm test 2>&1 | tee .cursor-runtime/followup-candidate-tests.log
+            tests=$?
+            npm run build 2>&1 | tee .cursor-runtime/followup-candidate-build.log
+            build=$?
+          else
+            lint=2
+            tests=2
+            build=2
+            echo "Skipped because package.json changed a validation script." | tee .cursor-runtime/followup-candidate-lint.log .cursor-runtime/followup-candidate-tests.log .cursor-runtime/followup-candidate-build.log
+          fi
           node "$RUNNER_TEMP/compare-ci-test-baseline.cjs" \
             --baseline-log .cursor-runtime/followup-base-tests.log \
             --baseline-exit "$(cat .cursor-runtime/followup-base-tests.exit)" \
@@ -1710,8 +1785,6 @@ jobs:
             --candidate-exit "$tests" \
             --output .cursor-runtime/followup-test-comparison.json
           tests_compared=$?
-          npm run build 2>&1 | tee .cursor-runtime/followup-candidate-build.log
-          build=$?
           set -e
           node -e '
             const fs = require("node:fs");
@@ -1720,10 +1793,11 @@ jobs:
               tests: Number(process.argv[2]),
               testComparison: Number(process.argv[3]),
               build: Number(process.argv[4]),
+              scriptGuard: Number(process.argv[5]),
             };
             fs.writeFileSync(".cursor-runtime/followup-verify-result.json", JSON.stringify(result, null, 2) + "\n");
-          ' "$lint" "$tests" "$tests_compared" "$build"
-          if [[ "$lint" != "0" || "$tests_compared" != "0" || "$build" != "0" ]]; then
+          ' "$lint" "$tests" "$tests_compared" "$build" "$script_guard"
+          if [[ "$script_guard" != "0" || "$lint" != "0" || "$tests_compared" != "0" || "$build" != "0" ]]; then
             echo "passed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -1782,6 +1856,9 @@ jobs:
                 ".cursor-runtime/followup-pending-snapshots.json",
                 ".cursor-runtime/followup-verify-result.json",
                 ".cursor-runtime/followup-test-comparison.json",
+                ".cursor-runtime/followup-candidate-lint.log",
+                ".cursor-runtime/followup-candidate-tests.log",
+                ".cursor-runtime/followup-candidate-build.log",
               ],
               process.env.CURSOR_API_KEY,
               "issue-followup-publish",
@@ -1800,6 +1877,9 @@ jobs:
             .cursor-runtime/followup-pending-snapshots.json
             .cursor-runtime/followup-verify-result.json
             .cursor-runtime/followup-test-comparison.json
+            .cursor-runtime/followup-candidate-lint.log
+            .cursor-runtime/followup-candidate-tests.log
+            .cursor-runtime/followup-candidate-build.log
           if-no-files-found: error
 
       - name: Fail after preserving rejected follow-up
@@ -1985,6 +2065,32 @@ jobs:
               process.env.ISSUE_BOT_LOGINS,
             );
             const remainingIds = pendingIds.filter((id) => !processed.has(id));
+            if (pullNumber) {
+              const { data: livePull } = await github.rest.pulls.get({
+                ...context.repo,
+                pull_number: pullNumber,
+              });
+              if (livePull.merged || livePull.merged_at) {
+                if (remainingIds.length) {
+                  const chinese = /[\u3400-\u9fff]/u.test(`${issue.title || ''}\n${issue.body || ''}`);
+                  await github.rest.issues.createComment({
+                    ...context.repo,
+                    issue_number: issueNumber,
+                    body: auto.buildIssueFollowupReply({
+                      commentIds: remainingIds,
+                      result: 'blocked',
+                      reply: chinese
+                        ? '相关修复已在本次处理期间合并，因此没有重新打开这条 Issue 或改回旧状态。如果合并后的版本仍有问题，请提交一条新的问题报告。'
+                        : 'The related fix merged while this follow-up was being processed, so the issue was not reopened and its old state was not restored. If the merged version is still affected, please open a new report.',
+                      pullNumber,
+                      headSha: process.env.HEAD_SHA,
+                    }),
+                  });
+                }
+                core.info(`PR #${pullNumber} is merged; skipped stale follow-up handoff state changes.`);
+                return;
+              }
+            }
             const labels = (issue.labels || []).map((label) =>
               typeof label === 'string' ? label : label.name,
             );
@@ -2033,6 +2139,17 @@ jobs:
           github-token: ${{ secrets.TRIAGE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const pullNumber = Number(process.env.PULL_NUMBER) || null;
+            if (pullNumber) {
+              const { data: livePull } = await github.rest.pulls.get({
+                ...context.repo,
+                pull_number: pullNumber,
+              });
+              if (livePull.merged || livePull.merged_at) {
+                core.info(`PR #${pullNumber} is merged; emergency handoff will not reopen the source issue.`);
+                return;
+              }
+            }
             const { data: issue } = await github.rest.issues.get({
               ...context.repo,
               issue_number: issueNumber,
@@ -2710,6 +2827,13 @@ jobs:
         if: steps.existing.outputs.exists != 'true'
         run: npm ci
 
+      - name: Install test shell dependencies
+        if: steps.existing.outputs.exists != 'true'
+        run: |
+          # Match .github/workflows/test.yml — osc7Setup.test.ts requires fish in CI.
+          sudo apt-get update
+          sudo apt-get install -y fish
+
       - name: Capture exact-base test baseline
         if: steps.existing.outputs.exists != 'true'
         run: |
@@ -2864,24 +2988,38 @@ jobs:
               dedupeMarker: `<!-- cursor-implement-failure:base=${{ steps.branch.outputs.base_sha }};kind=no_changes -->`,
             });
 
-      - name: Install test shell dependencies
-        if: steps.existing.outputs.exists != 'true' && steps.changes.outputs.present == 'true'
-        run: |
-          # Match .github/workflows/test.yml — osc7Setup.test.ts requires fish in CI.
-          sudo apt-get update
-          sudo apt-get install -y fish
-
       - name: Verify
         if: steps.existing.outputs.exists != 'true' && steps.changes.outputs.present == 'true'
         id: verify
+        env:
+          BASE_SHA: ${{ steps.branch.outputs.base_sha }}
         run: |
           mkdir -p .cursor-runtime
           set -o pipefail
           set +e
-          npm run lint 2>&1 | tee .cursor-runtime/candidate-lint.log
-          lint=$?
-          npm test 2>&1 | tee .cursor-runtime/candidate-tests.log
-          tests=$?
+          node -e '
+            const fs = require("node:fs");
+            const { execFileSync } = require("node:child_process");
+            const base = JSON.parse(execFileSync("git", ["show", `${process.argv[1]}:package.json`], { encoding: "utf8" }));
+            const current = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            const names = ["lint", "test", "build"];
+            const changed = names.filter((name) => base.scripts?.[name] !== current.scripts?.[name]);
+            if (changed.length) throw new Error(`Validation scripts changed: ${changed.join(", ")}`);
+          ' "$BASE_SHA"
+          script_guard=$?
+          if [[ "$script_guard" == "0" ]]; then
+            npm run lint 2>&1 | tee .cursor-runtime/candidate-lint.log
+            lint=$?
+            npm test 2>&1 | tee .cursor-runtime/candidate-tests.log
+            tests=$?
+            npm run build 2>&1 | tee .cursor-runtime/candidate-build.log
+            build=$?
+          else
+            lint=2
+            tests=2
+            build=2
+            echo "Skipped because package.json changed a validation script." | tee .cursor-runtime/candidate-lint.log .cursor-runtime/candidate-tests.log .cursor-runtime/candidate-build.log
+          fi
           node "$RUNNER_TEMP/compare-ci-test-baseline.cjs" \
             --baseline-log .cursor-runtime/base-tests.log \
             --baseline-exit "$(cat .cursor-runtime/base-tests.exit)" \
@@ -2889,8 +3027,6 @@ jobs:
             --candidate-exit "$tests" \
             --output .cursor-runtime/test-comparison.json
           tests_compared=$?
-          npm run build 2>&1 | tee .cursor-runtime/candidate-build.log
-          build=$?
           set -e
           node -e '
             const fs = require("node:fs");
@@ -2899,10 +3035,11 @@ jobs:
               tests: Number(process.argv[2]),
               testComparison: Number(process.argv[3]),
               build: Number(process.argv[4]),
+              scriptGuard: Number(process.argv[5]),
             };
             fs.writeFileSync(".cursor-runtime/verify-result.json", JSON.stringify(result, null, 2) + "\n");
-          ' "$lint" "$tests" "$tests_compared" "$build"
-          if [[ "$lint" != "0" || "$tests_compared" != "0" || "$build" != "0" ]]; then
+          ' "$lint" "$tests" "$tests_compared" "$build" "$script_guard"
+          if [[ "$script_guard" != "0" || "$lint" != "0" || "$tests_compared" != "0" || "$build" != "0" ]]; then
             echo "passed=false" >> "$GITHUB_OUTPUT"
             echo "kind=candidate_verification" >> "$GITHUB_OUTPUT"
             exit 0
@@ -2979,6 +3116,9 @@ jobs:
                 ".cursor-runtime/implement-pr-body.md",
                 ".cursor-runtime/verify-result.json",
                 ".cursor-runtime/test-comparison.json",
+                ".cursor-runtime/candidate-lint.log",
+                ".cursor-runtime/candidate-tests.log",
+                ".cursor-runtime/candidate-build.log",
               ],
               process.env.CURSOR_API_KEY,
               "implement-publish",
@@ -2996,6 +3136,9 @@ jobs:
             .cursor-runtime/implement-pr-body.out.md
             .cursor-runtime/verify-result.json
             .cursor-runtime/test-comparison.json
+            .cursor-runtime/candidate-lint.log
+            .cursor-runtime/candidate-tests.log
+            .cursor-runtime/candidate-build.log
           if-no-files-found: error
 
       - name: Fail after preserving rejected implementation
@@ -3816,8 +3959,14 @@ jobs:
           GH_TOKEN: ${{ secrets.TRIAGE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           EXPECTED_HEAD: ${{ steps.codex.outputs.head_sha }}
           PULL_NUMBER: ${{ needs.route.outputs.pull_number }}
+          OWN_ACTORS: ${{ vars.AUTOMATION_OWN_ACTORS || 'binaricat,netcatty-bot,github-actions[bot]' }}
         run: |
           set -euo pipefail
+          trusted_comment_authors="$(jq -Rn --arg raw "$OWN_ACTORS,github-actions[bot],github-actions" '$raw | split(",") | map(ascii_downcase) | unique')"
+          trusted_comment_bodies() {
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PULL_NUMBER}/comments" 2>/dev/null \
+              | jq -r --argjson trusted "$trusted_comment_authors" '.[] | select((.user.login | ascii_downcase) as $login | $trusted | index($login)) | .body'
+          }
           # Closed / missing PRs are not an automation failure.
           state="$(gh pr view "$PULL_NUMBER" --repo "$GITHUB_REPOSITORY" --json state -q .state 2>/dev/null || echo MISSING)"
           if [[ "$state" != "OPEN" ]]; then
@@ -3867,7 +4016,7 @@ jobs:
               "repos/${GITHUB_REPOSITORY}/issues/${PULL_NUMBER}/labels" \
               -f 'labels[]=ready-for-human' >/dev/null 2>&1 || true
             blocked_marker="<!-- cursor-codex-ready-blocked:${live_head} -->"
-            existing_comments="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PULL_NUMBER}/comments" --jq '.[].body' 2>/dev/null || true)"
+            existing_comments="$(trusted_comment_bodies || true)"
             if ! grep -Fq "$blocked_marker" <<<"$existing_comments"; then
               blocked_body="$(printf '%s\n\n%s' "$blocked_marker" 'Codex reported no major issues, but the automation token cannot change draft state. A maintainer can mark this PR ready.')"
               gh pr comment "$PULL_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$blocked_body" 2>/dev/null || true
@@ -3907,7 +4056,7 @@ jobs:
             exit 0
           fi
           clean_marker="<!-- cursor-codex-clean-head:${live_head} -->"
-          existing_comments="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PULL_NUMBER}/comments" --jq '.[].body')"
+          existing_comments="$(trusted_comment_bodies)"
           if grep -Fq "$clean_marker" <<<"$existing_comments"; then
             echo "Clean handoff already recorded for ${live_head}."
             exit 0
@@ -4054,6 +4203,13 @@ jobs:
       - name: Install dependencies
         if: steps.codex.outputs.action == 'fix'
         run: npm ci
+
+      - name: Install test shell dependencies
+        if: steps.codex.outputs.action == 'fix'
+        run: |
+          # Match .github/workflows/test.yml — osc7Setup.test.ts requires fish in CI.
+          sudo apt-get update
+          sudo apt-get install -y fish
 
       - name: Install Cursor CLI
         if: steps.codex.outputs.action == 'fix'
@@ -4206,24 +4362,38 @@ jobs:
             }
           ' "$status" "$names" "$name_status"
 
-      - name: Install test shell dependencies
-        if: steps.codex.outputs.action == 'fix'
-        run: |
-          # Match .github/workflows/test.yml — osc7Setup.test.ts requires fish in CI.
-          sudo apt-get update
-          sudo apt-get install -y fish
-
       - name: Verify fix
         if: steps.codex.outputs.action == 'fix'
         id: fixverify
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
         run: |
           mkdir -p .cursor-runtime
           set -o pipefail
           set +e
-          npm run lint 2>&1 | tee .cursor-runtime/fix-candidate-lint.log
-          lint=$?
-          npm test 2>&1 | tee .cursor-runtime/fix-candidate-tests.log
-          tests=$?
+          node -e '
+            const fs = require("node:fs");
+            const { execFileSync } = require("node:child_process");
+            const base = JSON.parse(execFileSync("git", ["show", `${process.argv[1]}:package.json`], { encoding: "utf8" }));
+            const current = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            const names = ["lint", "test", "build"];
+            const changed = names.filter((name) => base.scripts?.[name] !== current.scripts?.[name]);
+            if (changed.length) throw new Error(`Validation scripts changed: ${changed.join(", ")}`);
+          ' "$BASE_SHA"
+          script_guard=$?
+          if [[ "$script_guard" == "0" ]]; then
+            npm run lint 2>&1 | tee .cursor-runtime/fix-candidate-lint.log
+            lint=$?
+            npm test 2>&1 | tee .cursor-runtime/fix-candidate-tests.log
+            tests=$?
+            npm run build 2>&1 | tee .cursor-runtime/fix-candidate-build.log
+            build=$?
+          else
+            lint=2
+            tests=2
+            build=2
+            echo "Skipped because package.json changed a validation script." | tee .cursor-runtime/fix-candidate-lint.log .cursor-runtime/fix-candidate-tests.log .cursor-runtime/fix-candidate-build.log
+          fi
           node "$RUNNER_TEMP/compare-ci-test-baseline.cjs" \
             --baseline-log .cursor-runtime/fix-base-tests.log \
             --baseline-exit "$(cat .cursor-runtime/fix-base-tests.exit)" \
@@ -4231,8 +4401,6 @@ jobs:
             --candidate-exit "$tests" \
             --output .cursor-runtime/fix-test-comparison.json
           tests_compared=$?
-          npm run build 2>&1 | tee .cursor-runtime/fix-candidate-build.log
-          build=$?
           set -e
           node -e '
             const fs = require("node:fs");
@@ -4241,10 +4409,11 @@ jobs:
               tests: Number(process.argv[2]),
               testComparison: Number(process.argv[3]),
               build: Number(process.argv[4]),
+              scriptGuard: Number(process.argv[5]),
             };
             fs.writeFileSync(".cursor-runtime/fix-verify-result.json", JSON.stringify(result, null, 2) + "\n");
-          ' "$lint" "$tests" "$tests_compared" "$build"
-          if [[ "$lint" != "0" || "$tests_compared" != "0" || "$build" != "0" ]]; then
+          ' "$lint" "$tests" "$tests_compared" "$build" "$script_guard"
+          if [[ "$script_guard" != "0" || "$lint" != "0" || "$tests_compared" != "0" || "$build" != "0" ]]; then
             echo "passed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -4309,6 +4478,9 @@ jobs:
                 ".cursor-runtime/fix.patch",
                 ".cursor-runtime/fix-verify-result.json",
                 ".cursor-runtime/fix-test-comparison.json",
+                ".cursor-runtime/fix-candidate-lint.log",
+                ".cursor-runtime/fix-candidate-tests.log",
+                ".cursor-runtime/fix-candidate-build.log",
               ],
               process.env.CURSOR_API_KEY,
               "fix-publish",
@@ -4324,6 +4496,9 @@ jobs:
             .cursor-runtime/fix.patch
             .cursor-runtime/fix-verify-result.json
             .cursor-runtime/fix-test-comparison.json
+            .cursor-runtime/fix-candidate-lint.log
+            .cursor-runtime/fix-candidate-tests.log
+            .cursor-runtime/fix-candidate-build.log
           if-no-files-found: error
 
       - name: Fail after preserving rejected Codex fix

--- a/.github/workflows/cursor-automation.yml
+++ b/.github/workflows/cursor-automation.yml
@@ -1786,7 +1786,13 @@ jobs:
           ' "$BASE_SHA"
           script_guard=$?
           if [[ "$script_guard" == "0" ]]; then
-            npm run lint 2>&1 | tee .cursor-runtime/followup-candidate-lint.log
+            npm ci 2>&1 | tee .cursor-runtime/followup-candidate-lint.log
+            deps=$?
+          else
+            deps=2
+          fi
+          if [[ "$script_guard" == "0" && "$deps" == "0" ]]; then
+            npm run lint 2>&1 | tee -a .cursor-runtime/followup-candidate-lint.log
             lint=$?
             npm test 2>&1 | tee .cursor-runtime/followup-candidate-tests.log
             tests=$?
@@ -1796,7 +1802,13 @@ jobs:
             lint=2
             tests=2
             build=2
-            echo "Skipped because package.json changed a validation script." | tee .cursor-runtime/followup-candidate-lint.log .cursor-runtime/followup-candidate-tests.log .cursor-runtime/followup-candidate-build.log
+            if [[ "$script_guard" != "0" ]]; then
+              reason="Skipped because package.json changed a validation script."
+            else
+              reason="Skipped because restoring locked dependencies failed."
+            fi
+            echo "$reason" | tee -a .cursor-runtime/followup-candidate-lint.log
+            echo "$reason" | tee .cursor-runtime/followup-candidate-tests.log .cursor-runtime/followup-candidate-build.log
           fi
           node "$RUNNER_TEMP/compare-ci-test-baseline.cjs" \
             --baseline-log .cursor-runtime/followup-base-tests.log \
@@ -3028,7 +3040,13 @@ jobs:
           ' "$BASE_SHA"
           script_guard=$?
           if [[ "$script_guard" == "0" ]]; then
-            npm run lint 2>&1 | tee .cursor-runtime/candidate-lint.log
+            npm ci 2>&1 | tee .cursor-runtime/candidate-lint.log
+            deps=$?
+          else
+            deps=2
+          fi
+          if [[ "$script_guard" == "0" && "$deps" == "0" ]]; then
+            npm run lint 2>&1 | tee -a .cursor-runtime/candidate-lint.log
             lint=$?
             npm test 2>&1 | tee .cursor-runtime/candidate-tests.log
             tests=$?
@@ -3038,7 +3056,13 @@ jobs:
             lint=2
             tests=2
             build=2
-            echo "Skipped because package.json changed a validation script." | tee .cursor-runtime/candidate-lint.log .cursor-runtime/candidate-tests.log .cursor-runtime/candidate-build.log
+            if [[ "$script_guard" != "0" ]]; then
+              reason="Skipped because package.json changed a validation script."
+            else
+              reason="Skipped because restoring locked dependencies failed."
+            fi
+            echo "$reason" | tee -a .cursor-runtime/candidate-lint.log
+            echo "$reason" | tee .cursor-runtime/candidate-tests.log .cursor-runtime/candidate-build.log
           fi
           node "$RUNNER_TEMP/compare-ci-test-baseline.cjs" \
             --baseline-log .cursor-runtime/base-tests.log \
@@ -4402,7 +4426,13 @@ jobs:
           ' "$BASE_SHA"
           script_guard=$?
           if [[ "$script_guard" == "0" ]]; then
-            npm run lint 2>&1 | tee .cursor-runtime/fix-candidate-lint.log
+            npm ci 2>&1 | tee .cursor-runtime/fix-candidate-lint.log
+            deps=$?
+          else
+            deps=2
+          fi
+          if [[ "$script_guard" == "0" && "$deps" == "0" ]]; then
+            npm run lint 2>&1 | tee -a .cursor-runtime/fix-candidate-lint.log
             lint=$?
             npm test 2>&1 | tee .cursor-runtime/fix-candidate-tests.log
             tests=$?
@@ -4412,7 +4442,13 @@ jobs:
             lint=2
             tests=2
             build=2
-            echo "Skipped because package.json changed a validation script." | tee .cursor-runtime/fix-candidate-lint.log .cursor-runtime/fix-candidate-tests.log .cursor-runtime/fix-candidate-build.log
+            if [[ "$script_guard" != "0" ]]; then
+              reason="Skipped because package.json changed a validation script."
+            else
+              reason="Skipped because restoring locked dependencies failed."
+            fi
+            echo "$reason" | tee -a .cursor-runtime/fix-candidate-lint.log
+            echo "$reason" | tee .cursor-runtime/fix-candidate-tests.log .cursor-runtime/fix-candidate-build.log
           fi
           node "$RUNNER_TEMP/compare-ci-test-baseline.cjs" \
             --baseline-log .cursor-runtime/fix-base-tests.log \

--- a/.github/workflows/cursor-automation.yml
+++ b/.github/workflows/cursor-automation.yml
@@ -355,6 +355,7 @@ jobs:
         uses: actions/github-script@v9
         env:
           PULL_NUMBER: ${{ needs.route.outputs.pull_number }}
+          SOURCE_ISSUE_NUMBER: ${{ needs.route.outputs.issue_number }}
           OWN_ACTORS: ${{ vars.AUTOMATION_OWN_ACTORS || 'binaricat,netcatty-bot,github-actions[bot]' }}
         with:
           github-token: ${{ secrets.TRIAGE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -365,6 +366,10 @@ jobs:
               ...context.repo,
               pull_number: pullNumber,
             });
+            if (pull.state !== 'closed') {
+              core.warning(`PR #${pullNumber} is no longer closed; skipping source cleanup.`);
+              return;
+            }
             if (!auto.shouldGatePullOnSourceIssueFollowups(pull, {
               ownActors: process.env.OWN_ACTORS,
               repository: `${context.repo.owner}/${context.repo.repo}`,
@@ -373,7 +378,11 @@ jobs:
               return;
             }
             const issueNumber = auto.extractSourceIssueNumber(pull);
-            if (!issueNumber) return;
+            const expectedIssueNumber = Number(process.env.SOURCE_ISSUE_NUMBER);
+            if (!issueNumber || issueNumber !== expectedIssueNumber) {
+              core.warning(`PR #${pullNumber} source issue changed while queued; skipping cleanup.`);
+              return;
+            }
             const removeLabel = async (issue_number, name) => {
               try {
                 await github.rest.issues.removeLabel({
@@ -415,7 +424,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-      actions: write
+      actions: read
     outputs:
       category: ${{ steps.apply.outputs.category }}
       should_implement: ${{ steps.apply.outputs.should_implement }}
@@ -1212,7 +1221,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-      actions: read
+      actions: write
     outputs:
       action: ${{ steps.decision.outputs.action }}
       should_publish: ${{ steps.patch.outputs.should_publish || 'false' }}

--- a/components/terminal/extractRootPaths.test.ts
+++ b/components/terminal/extractRootPaths.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { extractRootPathsFromDropEntries } from './terminalHelpers.ts';
 
 // Inline copy of extractRootPathsFromClipboardFiles for standalone test
 function extractRootPathsFromClipboardFiles(
@@ -93,6 +94,21 @@ describe('extractRootPathsFromClipboardFiles', () => {
         { path: '/home/user/c d.txt', name: 'c d.txt', isDirectory: false, size: 20 },
       ]),
       ['"/home/user/a b.txt"', '"/home/user/c d.txt"'],
+    );
+  });
+});
+
+describe('extractRootPathsFromDropEntries', () => {
+  it('uses a reconstructed DropEntry local path when File.path is unavailable', () => {
+    const fileWithoutPath = { name: 'child.txt' } as File;
+    assert.deepEqual(
+      extractRootPathsFromDropEntries([{
+        file: fileWithoutPath,
+        localPath: '/home/user/folder/child.txt',
+        relativePath: 'folder/child.txt',
+        isDirectory: false,
+      }]),
+      ['/home/user/folder'],
     );
   });
 });

--- a/components/terminal/terminalHelpers.ts
+++ b/components/terminal/terminalHelpers.ts
@@ -5,7 +5,7 @@ import type { TerminalContextReader } from "../../domain/terminalContextRead";
 import type { TerminalSessionExitEvent } from "../../application/state/resolveTerminalSessionExitIntent";
 import { resolveSessionTabTitle } from "../../domain/sessionTabTitle";
 import { logger } from "../../lib/logger";
-import { getPathForFile, type DropEntry } from "../../lib/sftpFileUtils";
+import { getDropEntryLocalPath, type DropEntry } from "../../lib/sftpFileUtils";
 import { normalizeLineEndings } from "../../lib/utils";
 import { resolveSnippetMultiLineRunMode } from "../../domain/snippetRunMode";
 import type {
@@ -46,7 +46,7 @@ export function extractRootPathsFromDropEntries(dropEntries: DropEntry[]): strin
   for (const entry of dropEntries) {
     if (!entry.file) continue;
 
-    const fullPath = getPathForFile(entry.file);
+    const fullPath = getDropEntryLocalPath(entry);
     if (!fullPath) continue;
 
     const pathParts = entry.relativePath.split("/");

--- a/lib/sftpFileUtils.ts
+++ b/lib/sftpFileUtils.ts
@@ -246,12 +246,9 @@ const createDropEntriesFromFiles = (files: FileList | File[]): DropEntry[] => {
   const results: DropEntry[] = [];
   for (let i = 0; i < files.length; i++) {
     const file = files[i];
-    const path = getPathForFile(file);
-    if (path) {
-      (file as File & { path?: string }).path = path;
-    }
     results.push({
       file,
+      localPath: getPathForFile(file),
       relativePath: (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name,
       isDirectory: false,
     });
@@ -424,15 +421,14 @@ export async function extractDropEntries(
       return createDropEntriesFromFiles(dataTransfer.files);
     }
 
-    // Restore the 'path' property for all files
-    // Try to get the path directly from webUtils.getPathForFile for each file
-    // This is more reliable than trying to reconstruct from folder paths
+    // Preserve local paths on DropEntry instead of mutating File.path. Modern
+    // runtimes expose File.path as read-only when it exists.
     for (const result of results) {
       if (result.file) {
         // First try to get path directly from the file
         const directPath = getPathForFile(result.file);
         if (directPath) {
-          (result.file as File & { path?: string }).path = directPath;
+          result.localPath = directPath;
         } else {
           // Fallback: try to reconstruct from root folder path
           const pathParts = result.relativePath.split('/');
@@ -442,14 +438,14 @@ export async function extractDropEntries(
           if (rootPath) {
             if (pathParts.length === 1) {
               // Root-level file: use the path directly
-              (result.file as File & { path?: string }).path = rootPath;
+              result.localPath = rootPath;
             } else {
               // Nested file in a folder: construct full path
               // rootPath is the path to the root folder, we need to append the rest
               const restOfPath = pathParts.slice(1).join('/');
               const separator = rootPath.includes('\\') ? '\\' : '/';
               const fullPath = rootPath + separator + restOfPath.replace(/\//g, separator);
-              (result.file as File & { path?: string }).path = fullPath;
+              result.localPath = fullPath;
             }
           }
         }

--- a/lib/sftpFileUtils.ts
+++ b/lib/sftpFileUtils.ts
@@ -242,6 +242,9 @@ export interface DropEntry {
   isDirectory: boolean;
 }
 
+export const getDropEntryLocalPath = (entry: DropEntry): string | undefined =>
+  entry.localPath ?? (entry.file ? getPathForFile(entry.file) : undefined);
+
 const createDropEntriesFromFiles = (files: FileList | File[]): DropEntry[] => {
   const results: DropEntry[] = [];
   for (let i = 0; i < files.length; i++) {

--- a/lib/uploadCompressed.test.ts
+++ b/lib/uploadCompressed.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { uploadFoldersCompressed } from "./uploadCompressed";
+import type { DropEntry } from "./sftpFileUtils";
+
+test("compressed folder uploads use reconstructed drop-entry paths", async () => {
+  const previousWindow = globalThis.window;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        checkCompressedUploadSupport: async () => ({
+          supported: false,
+          localTar: false,
+          remoteTar: false,
+        }),
+      },
+    },
+  });
+
+  try {
+    const entry: DropEntry = {
+      file: { name: "child.txt", size: 1 } as File,
+      localPath: "/tmp/example-folder/child.txt",
+      relativePath: "example-folder/child.txt",
+      isDirectory: false,
+    };
+    const results = await uploadFoldersCompressed(
+      [["example-folder", [entry]]],
+      "/remote",
+      "sftp-1",
+    );
+
+    assert.deepEqual(results, [{
+      fileName: "example-folder",
+      success: false,
+      error: "Compressed upload not supported - fallback needed",
+    }]);
+  } finally {
+    if (previousWindow === undefined) {
+      Reflect.deleteProperty(globalThis, "window");
+    } else {
+      Object.defineProperty(globalThis, "window", {
+        configurable: true,
+        value: previousWindow,
+      });
+    }
+  }
+});

--- a/lib/uploadCompressed.ts
+++ b/lib/uploadCompressed.ts
@@ -1,5 +1,5 @@
 import type { DropEntry } from "./sftpFileUtils";
-import { getPathForFile } from "./sftpFileUtils";
+import { getDropEntryLocalPath } from "./sftpFileUtils";
 import type { UploadCallbacks, UploadResult } from "./uploadService.types";
 import type { UploadController } from "./uploadController";
 
@@ -31,7 +31,7 @@ export async function uploadFoldersCompressed(
       continue;
     }
     
-    const localFilePath = getPathForFile(firstFile.file);
+    const localFilePath = getDropEntryLocalPath(firstFile);
     if (!localFilePath) {
       results.push({ fileName: folderName, success: false, error: "Could not get local file path" });
       continue;

--- a/lib/uploadService.ts
+++ b/lib/uploadService.ts
@@ -196,12 +196,9 @@ export async function uploadFromFileList(
     const localPath = getPathForFile(file);
     // Use webkitRelativePath if available (folder upload), otherwise use file.name (regular file upload)
     const relativePath = (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name;
-    if (localPath) {
-      // Set the path property on the file for stream transfer
-      (file as File & { path?: string }).path = localPath;
-    }
     return {
       file,
+      localPath,
       relativePath,
       isDirectory: false,
     };

--- a/lib/uploadService.ts
+++ b/lib/uploadService.ts
@@ -6,7 +6,7 @@
  * cancellation support, and works for both local and remote (SFTP) uploads.
  */
 
-import { extractDropEntries, DropEntry, getPathForFile } from "./sftpFileUtils";
+import { extractDropEntries, DropEntry, getDropEntryLocalPath, getPathForFile } from "./sftpFileUtils";
 import { logger } from "./logger";
 import { uploadFoldersCompressed } from "./uploadCompressed";
 import {
@@ -38,8 +38,6 @@ const formatUploadError = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
 const getDropEntrySize = (entry: DropEntry): number => entry.file?.size ?? entry.size ?? 0;
-const getDropEntryLocalPath = (entry: DropEntry): string | undefined =>
-  entry.localPath ?? (entry.file as (File & { path?: string }) | null | undefined)?.path;
 const getRootDropLocalPath = (rootName: string, entries: DropEntry[]): string | undefined => {
   const entry = entries.find((candidate) => getDropEntryLocalPath(candidate));
   const localPath = entry ? getDropEntryLocalPath(entry) : undefined;

--- a/lib/zmodemDragDrop.test.ts
+++ b/lib/zmodemDragDrop.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { DropEntry } from "./sftpFileUtils";
+import { buildZmodemDragDropFiles } from "./zmodemDragDrop";
+
+test("ZMODEM drops use reconstructed paths without buffering the file", async () => {
+  let buffered = false;
+  const entry: DropEntry = {
+    file: {
+      name: "large.bin",
+      arrayBuffer: async () => {
+        buffered = true;
+        return new ArrayBuffer(0);
+      },
+    } as File,
+    localPath: "/tmp/large.bin",
+    relativePath: "large.bin",
+    isDirectory: false,
+  };
+
+  const files = await buildZmodemDragDropFiles([entry]);
+
+  assert.deepEqual(files, [{
+    path: "/tmp/large.bin",
+    name: "large.bin",
+    remoteName: "large.bin",
+  }]);
+  assert.equal(buffered, false);
+});

--- a/lib/zmodemDragDrop.ts
+++ b/lib/zmodemDragDrop.ts
@@ -1,5 +1,5 @@
 import type { DropEntry } from "./sftpFileUtils";
-import { getPathForFile } from "./sftpFileUtils";
+import { getDropEntryLocalPath } from "./sftpFileUtils";
 import type { Host } from "../types";
 
 const ZMODEM_RZ_MISSING_MARKER_PREFIX = "\x1b]1337;NetcattyRzMissing=";
@@ -63,7 +63,7 @@ export async function buildZmodemDragDropFiles(
     if (entry.isDirectory || !entry.file) continue;
 
     const remoteName = getZmodemRemoteName(entry.relativePath, entry.file.name);
-    const localPath = getPathForFile(entry.file);
+    const localPath = getDropEntryLocalPath(entry);
 
     if (localPath) {
       files.push({

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -187,15 +187,17 @@ function countFailures(failures) {
 function compareTapResults(baseline, candidate) {
   const baselineSuccessCounts = countFailures(baseline.successes);
   const candidateSuccessCounts = countFailures(candidate.successes);
+  const candidateSuccessPool = new Map(candidateSuccessCounts);
   const missingBaselineSuccesses = [];
   for (const [success, count] of baselineSuccessCounts) {
-    const missing = count - (candidateSuccessCounts.get(success) || 0);
+    const available = candidateSuccessPool.get(success) || 0;
+    const missing = count - available;
+    candidateSuccessPool.set(success, Math.max(0, available - count));
     for (let i = 0; i < missing; i += 1) missingBaselineSuccesses.push(success);
   }
   const candidateFailurePool = countFailures(
     candidate.failureRecords.map((failure) => failure.identity),
   );
-  const candidateSuccessPool = new Map(candidateSuccessCounts);
   const missingBaselineFailures = [];
   for (const failure of baseline.failureRecords) {
     const matchingFailures = candidateFailurePool.get(failure.identity) || 0;

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -4,6 +4,18 @@ const fs = require('node:fs');
 
 const ANSI_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g;
 
+function normalizeAssertionDetail(detail) {
+  return detail
+    .replace(
+      /\b(now|timestamp|time|port|pid|nonce|random(?:Value)?)\b(['"]?\s*[:=]\s*)[^,\s}\]]+/gi,
+      '$1$2<volatile>',
+    )
+    .replace(
+      /\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\b/g,
+      '<timestamp>',
+    );
+}
+
 function parseTapResult(text, exitCode) {
   const normalized = String(text || '').replace(ANSI_RE, '').replace(/\r\n?/g, '\n');
   const lines = normalized.split('\n');
@@ -11,6 +23,7 @@ function parseTapResult(text, exitCode) {
   const failureRecords = [];
   let failCount = null;
   let cancelledCount = null;
+  let skippedCount = null;
   let testCount = null;
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
@@ -71,9 +84,7 @@ function parseTapResult(text, exitCode) {
         /^\s*code:\s*['"]?ERR_ASSERTION['"]?\s*$/.test(detail),
       );
       const stableErrorDetails = assertionFailure
-        ? errorDetails.slice(0, 1).map((detail) =>
-            detail.replace(/\b\d+(?:\.\d+)?\b/g, '<number>'),
-          )
+        ? errorDetails.map(normalizeAssertionDetail)
         : errorDetails;
       diagnostic.push(...stableErrorDetails.map((detail) => `error-detail: ${detail}`));
       failures.push(name);
@@ -86,6 +97,8 @@ function parseTapResult(text, exitCode) {
     if (failSummary) failCount = Number(failSummary[1]);
     const cancelledSummary = line.match(/^\s*# cancelled (\d+)\s*$/);
     if (cancelledSummary) cancelledCount = Number(cancelledSummary[1]);
+    const skippedSummary = line.match(/^\s*# skipped (\d+)\s*$/);
+    if (skippedSummary) skippedCount = Number(skippedSummary[1]);
     const testSummary = line.match(/^\s*# tests (\d+)\s*$/);
     if (testSummary) testCount = Number(testSummary[1]);
   }
@@ -95,9 +108,13 @@ function parseTapResult(text, exitCode) {
     failureRecords,
     failCount,
     cancelledCount,
+    skippedCount,
     testCount,
     complete:
-      failCount !== null && cancelledCount !== null && testCount !== null,
+      failCount !== null &&
+      cancelledCount !== null &&
+      skippedCount !== null &&
+      testCount !== null,
   };
 }
 
@@ -116,6 +133,7 @@ function compareTapResults(baseline, candidate) {
       candidate.complete &&
       candidate.failCount === 0 &&
       candidate.cancelledCount === 0 &&
+      candidate.skippedCount <= baseline.skippedCount &&
       candidate.testCount >= baseline.testCount;
     return {
       passed: completeCleanRun,
@@ -156,7 +174,10 @@ function compareTapResults(baseline, candidate) {
     };
   }
 
-  if (candidate.cancelledCount > 0) {
+  if (
+    candidate.cancelledCount > 0 ||
+    candidate.skippedCount > baseline.skippedCount
+  ) {
     return {
       passed: false,
       kind: 'cancelled_tests',

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -19,6 +19,7 @@ function parseTapResult(text, exitCode) {
       const name = failed[1].trim();
       const diagnostic = [];
       let inDiagnostic = false;
+      let errorBlockIndent = -1;
       let skippingStack = false;
       let stackIndent = -1;
       for (let detailIndex = index + 1; detailIndex < lines.length; detailIndex += 1) {
@@ -33,6 +34,14 @@ function parseTapResult(text, exitCode) {
         if (inDiagnostic && /^\s*\.\.\.\s*$/.test(detail)) break;
         if (!inDiagnostic) continue;
         const indent = detail.match(/^\s*/)?.[0].length || 0;
+        if (errorBlockIndent >= 0) {
+          if (!detail.trim()) continue;
+          if (indent > errorBlockIndent) {
+            diagnostic.push(`error-detail: ${detail.trim()}`);
+            continue;
+          }
+          errorBlockIndent = -1;
+        }
         if (skippingStack) {
           if (!detail.trim() || indent > stackIndent) continue;
           skippingStack = false;
@@ -43,6 +52,11 @@ function parseTapResult(text, exitCode) {
           continue;
         }
         if (/^\s*duration_ms:/.test(detail)) continue;
+        if (/^\s*error:\s*(?:\|-|>)\s*$/.test(detail)) {
+          diagnostic.push('error:');
+          errorBlockIndent = indent;
+          continue;
+        }
         if (/^\s*(?:type|location|failureType|error|code|operator):/.test(detail)) {
           diagnostic.push(
             detail.trimEnd().replace(

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -19,24 +19,39 @@ function normalizeAssertionDetail(detail) {
 function collectNonTapOutput(lines) {
   const output = [];
   let inDiagnostic = false;
-  let awaitingDiagnostic = false;
+  let diagnosticOwnerIndent = -1;
+  let awaitingDiagnosticIndent = null;
   for (const rawLine of lines) {
     const line = rawLine.trim();
     if (inDiagnostic) {
-      if (/^\s{2,}\.\.\.\s*$/.test(rawLine)) inDiagnostic = false;
-      continue;
-    }
-    if (awaitingDiagnostic) {
-      if (!line) continue;
-      if (/^\s{2,}---\s*$/.test(rawLine)) {
-        inDiagnostic = true;
-        awaitingDiagnostic = false;
+      const indent = rawLine.match(/^\s*/)?.[0].length || 0;
+      if (/^\s+\.\.\.\s*$/.test(rawLine) && indent > diagnosticOwnerIndent) {
+        inDiagnostic = false;
+        diagnosticOwnerIndent = -1;
         continue;
       }
-      awaitingDiagnostic = false;
+      const boundary = line.match(
+        /^(?:(?:ok|not ok) \d+ - |# (?:tests|suites|pass|fail|cancelled|skipped|todo|duration_ms) |1\.\.\d+$)/,
+      );
+      if (!boundary || indent > diagnosticOwnerIndent) continue;
+      output.push('<unterminated-tap-diagnostic>');
+      inDiagnostic = false;
+      diagnosticOwnerIndent = -1;
     }
-    if (/^\s*not ok \d+ - /.test(rawLine)) {
-      awaitingDiagnostic = true;
+    if (awaitingDiagnosticIndent !== null) {
+      if (!line) continue;
+      const indent = rawLine.match(/^\s*/)?.[0].length || 0;
+      if (/^\s+---\s*$/.test(rawLine) && indent > awaitingDiagnosticIndent) {
+        inDiagnostic = true;
+        diagnosticOwnerIndent = awaitingDiagnosticIndent;
+        awaitingDiagnosticIndent = null;
+        continue;
+      }
+      awaitingDiagnosticIndent = null;
+    }
+    const failed = rawLine.match(/^(\s*)not ok \d+ - /);
+    if (failed) {
+      awaitingDiagnosticIndent = failed[1].length;
       continue;
     }
     if (
@@ -55,6 +70,7 @@ function collectNonTapOutput(lines) {
         .replace(/:\d+:\d+\b/g, ':<line>:<column>'),
     );
   }
+  if (inDiagnostic) output.push('<unterminated-tap-diagnostic>');
   return output;
 }
 

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -26,6 +26,7 @@ function parseTapResult(text, exitCode) {
   let skippedCount = null;
   let todoCount = null;
   let testCount = null;
+  let lastSummaryIndex = -1;
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
     const failed = line.match(/^\s*not ok \d+ - (.+?)(?:\s+#.*)?$/);
@@ -95,16 +96,37 @@ function parseTapResult(text, exitCode) {
       });
     }
     const failSummary = line.match(/^\s*# fail (\d+)\s*$/);
-    if (failSummary) failCount = Number(failSummary[1]);
+    if (failSummary) {
+      failCount = Number(failSummary[1]);
+      lastSummaryIndex = index;
+    }
     const cancelledSummary = line.match(/^\s*# cancelled (\d+)\s*$/);
-    if (cancelledSummary) cancelledCount = Number(cancelledSummary[1]);
+    if (cancelledSummary) {
+      cancelledCount = Number(cancelledSummary[1]);
+      lastSummaryIndex = index;
+    }
     const skippedSummary = line.match(/^\s*# skipped (\d+)\s*$/);
-    if (skippedSummary) skippedCount = Number(skippedSummary[1]);
+    if (skippedSummary) {
+      skippedCount = Number(skippedSummary[1]);
+      lastSummaryIndex = index;
+    }
     const todoSummary = line.match(/^\s*# todo (\d+)\s*$/);
-    if (todoSummary) todoCount = Number(todoSummary[1]);
+    if (todoSummary) {
+      todoCount = Number(todoSummary[1]);
+      lastSummaryIndex = index;
+    }
     const testSummary = line.match(/^\s*# tests (\d+)\s*$/);
-    if (testSummary) testCount = Number(testSummary[1]);
+    if (testSummary) {
+      testCount = Number(testSummary[1]);
+      lastSummaryIndex = index;
+    }
+    if (/^\s*# duration_ms \d+(?:\.\d+)?\s*$/.test(line)) {
+      lastSummaryIndex = index;
+    }
   }
+  const trailingOutput = lastSummaryIndex >= 0
+    ? lines.slice(lastSummaryIndex + 1).filter((line) => line.trim()).join('\n')
+    : '';
   return {
     exitCode: Number(exitCode),
     failures,
@@ -114,6 +136,7 @@ function parseTapResult(text, exitCode) {
     skippedCount,
     todoCount,
     testCount,
+    trailingOutput,
     complete:
       failCount !== null &&
       cancelledCount !== null &&
@@ -171,6 +194,16 @@ function compareTapResults(baseline, candidate) {
   }
 
   if (candidate.exitCode !== baseline.exitCode) {
+    return {
+      passed: false,
+      kind: 'unclassified_failure',
+      baselineFailures: baseline.failures,
+      candidateFailures: candidate.failures,
+      newFailures: candidate.failures,
+    };
+  }
+
+  if (candidate.trailingOutput !== baseline.trailingOutput) {
     return {
       passed: false,
       kind: 'unclassified_failure',

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -1,0 +1,155 @@
+'use strict';
+
+const fs = require('node:fs');
+
+const ANSI_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+
+function parseTapResult(text, exitCode) {
+  const normalized = String(text || '').replace(ANSI_RE, '').replace(/\r\n?/g, '\n');
+  const failures = [];
+  let failCount = null;
+  let cancelledCount = null;
+  for (const line of normalized.split('\n')) {
+    const failed = line.match(/^\s*not ok \d+ - (.+?)(?:\s+#.*)?$/);
+    if (failed) failures.push(failed[1].trim());
+    const failSummary = line.match(/^\s*# fail (\d+)\s*$/);
+    if (failSummary) failCount = Number(failSummary[1]);
+    const cancelledSummary = line.match(/^\s*# cancelled (\d+)\s*$/);
+    if (cancelledSummary) cancelledCount = Number(cancelledSummary[1]);
+  }
+  return {
+    exitCode: Number(exitCode),
+    failures,
+    failCount,
+    cancelledCount,
+    complete: failCount !== null && cancelledCount !== null,
+  };
+}
+
+function countFailures(failures) {
+  const counts = new Map();
+  for (const failure of failures) {
+    counts.set(failure, (counts.get(failure) || 0) + 1);
+  }
+  return counts;
+}
+
+function compareTapResults(baseline, candidate) {
+  if (candidate.exitCode === 0) {
+    return {
+      passed: true,
+      kind: 'clean',
+      baselineFailures: baseline.failures,
+      candidateFailures: [],
+      newFailures: [],
+    };
+  }
+
+  if (baseline.exitCode === 0) {
+    return {
+      passed: false,
+      kind: 'new_failures',
+      baselineFailures: [],
+      candidateFailures: candidate.failures,
+      newFailures: candidate.failures,
+    };
+  }
+
+  if (!baseline.complete || !candidate.complete) {
+    return {
+      passed: false,
+      kind: 'unclassified_failure',
+      baselineFailures: baseline.failures,
+      candidateFailures: candidate.failures,
+      newFailures: candidate.failures,
+    };
+  }
+
+  if (candidate.cancelledCount > 0) {
+    return {
+      passed: false,
+      kind: 'cancelled_tests',
+      baselineFailures: baseline.failures,
+      candidateFailures: candidate.failures,
+      newFailures: candidate.failures,
+    };
+  }
+
+  const baselineCounts = countFailures(baseline.failures);
+  const candidateCounts = countFailures(candidate.failures);
+  const newFailures = [];
+  for (const [failure, count] of candidateCounts) {
+    const extra = count - (baselineCounts.get(failure) || 0);
+    for (let i = 0; i < extra; i += 1) newFailures.push(failure);
+  }
+  const parsedCountsMatch =
+    baseline.failures.length >= Number(baseline.failCount) &&
+    candidate.failures.length >= Number(candidate.failCount);
+  const passed = newFailures.length === 0 && parsedCountsMatch;
+  return {
+    passed,
+    kind: passed ? 'baseline_only' : 'new_failures',
+    baselineFailures: baseline.failures,
+    candidateFailures: candidate.failures,
+    newFailures,
+  };
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i];
+    if (!key?.startsWith('--') || argv[i + 1] === undefined) {
+      throw new Error('Expected --name value arguments.');
+    }
+    values[key.slice(2)] = argv[i + 1];
+  }
+  return values;
+}
+
+function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  for (const required of [
+    'baseline-log',
+    'baseline-exit',
+    'candidate-log',
+    'candidate-exit',
+    'output',
+  ]) {
+    if (!(required in args)) throw new Error(`Missing --${required}.`);
+  }
+  const baseline = parseTapResult(
+    fs.readFileSync(args['baseline-log'], 'utf8'),
+    args['baseline-exit'],
+  );
+  const candidate = parseTapResult(
+    fs.readFileSync(args['candidate-log'], 'utf8'),
+    args['candidate-exit'],
+  );
+  const result = compareTapResults(baseline, candidate);
+  fs.writeFileSync(args.output, `${JSON.stringify(result, null, 2)}\n`, 'utf8');
+  console.log(
+    result.passed
+      ? `Test comparison accepted: ${result.kind}.`
+      : `Test comparison failed: ${result.kind}.`,
+  );
+  if (result.newFailures.length) {
+    console.error(`New failures:\n- ${result.newFailures.join('\n- ')}`);
+  }
+  return result.passed ? 0 : 1;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 2;
+  }
+}
+
+module.exports = {
+  compareTapResults,
+  main,
+  parseTapResult,
+};

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -7,7 +7,7 @@ const ANSI_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g;
 function normalizeAssertionDetail(detail) {
   return detail
     .replace(
-      /\b(now|timestamp|time|port|pid|nonce|random(?:Value)?)\b(['"]?\s*[:=]\s*)[^,\s}\]]+/gi,
+      /\b(now|timestamp|pid|nonce|random(?:Value)?)\b(['"]?\s*[:=]\s*)[^,\s}\]]+/gi,
       '$1$2<volatile>',
     )
     .replace(

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -9,6 +9,7 @@ function parseTapResult(text, exitCode) {
   const failures = [];
   let failCount = null;
   let cancelledCount = null;
+  let testCount = null;
   for (const line of normalized.split('\n')) {
     const failed = line.match(/^\s*not ok \d+ - (.+?)(?:\s+#.*)?$/);
     if (failed) failures.push(failed[1].trim());
@@ -16,13 +17,17 @@ function parseTapResult(text, exitCode) {
     if (failSummary) failCount = Number(failSummary[1]);
     const cancelledSummary = line.match(/^\s*# cancelled (\d+)\s*$/);
     if (cancelledSummary) cancelledCount = Number(cancelledSummary[1]);
+    const testSummary = line.match(/^\s*# tests (\d+)\s*$/);
+    if (testSummary) testCount = Number(testSummary[1]);
   }
   return {
     exitCode: Number(exitCode),
     failures,
     failCount,
     cancelledCount,
-    complete: failCount !== null && cancelledCount !== null,
+    testCount,
+    complete:
+      failCount !== null && cancelledCount !== null && testCount !== null,
   };
 }
 
@@ -36,9 +41,14 @@ function countFailures(failures) {
 
 function compareTapResults(baseline, candidate) {
   if (candidate.exitCode === 0) {
+    const completeCleanRun =
+      candidate.complete &&
+      candidate.failCount === 0 &&
+      candidate.cancelledCount === 0 &&
+      (!baseline.complete || candidate.testCount >= baseline.testCount);
     return {
-      passed: true,
-      kind: 'clean',
+      passed: completeCleanRun,
+      kind: completeCleanRun ? 'clean' : 'unclassified_failure',
       baselineFailures: baseline.failures,
       candidateFailures: [],
       newFailures: [],
@@ -56,6 +66,16 @@ function compareTapResults(baseline, candidate) {
   }
 
   if (!baseline.complete || !candidate.complete) {
+    return {
+      passed: false,
+      kind: 'unclassified_failure',
+      baselineFailures: baseline.failures,
+      candidateFailures: candidate.failures,
+      newFailures: candidate.failures,
+    };
+  }
+
+  if (candidate.failCount === 0 || candidate.testCount < baseline.testCount) {
     return {
       passed: false,
       kind: 'unclassified_failure',

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -56,6 +56,7 @@ function parseTapResult(text, exitCode) {
   const lines = normalized.split('\n');
   const failures = [];
   const failureRecords = [];
+  const successes = [];
   let failCount = null;
   let cancelledCount = null;
   let skippedCount = null;
@@ -63,6 +64,10 @@ function parseTapResult(text, exitCode) {
   let testCount = null;
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
+    const succeeded = line.match(/^\s*ok \d+ - (.+?)(?:\s+#.*)?$/);
+    if (succeeded && !/\s+#\s*(?:SKIP|TODO)\b/i.test(line)) {
+      successes.push(succeeded[1].trim());
+    }
     const failed = line.match(/^\s*not ok \d+ - (.+?)(?:\s+#.*)?$/);
     if (failed) {
       const name = failed[1].trim();
@@ -154,6 +159,7 @@ function parseTapResult(text, exitCode) {
     exitCode: Number(exitCode),
     failures,
     failureRecords,
+    successes,
     failCount,
     cancelledCount,
     skippedCount,
@@ -178,6 +184,14 @@ function countFailures(failures) {
 }
 
 function compareTapResults(baseline, candidate) {
+  const baselineSuccessCounts = countFailures(baseline.successes);
+  const candidateSuccessCounts = countFailures(candidate.successes);
+  const missingBaselineSuccesses = [];
+  for (const [success, count] of baselineSuccessCounts) {
+    const missing = count - (candidateSuccessCounts.get(success) || 0);
+    for (let i = 0; i < missing; i += 1) missingBaselineSuccesses.push(success);
+  }
+
   if (candidate.exitCode === 0) {
     const completeCleanRun =
       baseline.complete &&
@@ -186,7 +200,8 @@ function compareTapResults(baseline, candidate) {
       candidate.cancelledCount === 0 &&
       candidate.skippedCount <= baseline.skippedCount &&
       candidate.todoCount <= baseline.todoCount &&
-      candidate.testCount >= baseline.testCount;
+      candidate.testCount >= baseline.testCount &&
+      missingBaselineSuccesses.length === 0;
     return {
       passed: completeCleanRun,
       kind: completeCleanRun ? 'clean' : 'unclassified_failure',
@@ -213,6 +228,16 @@ function compareTapResults(baseline, candidate) {
       baselineFailures: baseline.failures,
       candidateFailures: candidate.failures,
       newFailures: candidate.failures,
+    };
+  }
+
+  if (missingBaselineSuccesses.length) {
+    return {
+      passed: false,
+      kind: 'unclassified_failure',
+      baselineFailures: baseline.failures,
+      candidateFailures: candidate.failures,
+      newFailures: missingBaselineSuccesses,
     };
   }
 

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -64,12 +64,13 @@ function parseTapResult(text, exitCode) {
   let testCount = null;
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
-    const succeeded = line.match(/^\s*ok \d+ - (.+?)(?:\s+#.*)?$/);
-    if (succeeded && !/\s+#\s*(?:SKIP|TODO)\b/i.test(line)) {
+    const succeeded = line.match(/^\s*ok \d+ - (.+)$/);
+    const tapDirective = /\s+#\s*(?:SKIP|TODO)\b/i;
+    if (succeeded && !tapDirective.test(line)) {
       successes.push(succeeded[1].trim());
     }
-    const failed = line.match(/^\s*not ok \d+ - (.+?)(?:\s+#.*)?$/);
-    if (failed) {
+    const failed = line.match(/^\s*not ok \d+ - (.+)$/);
+    if (failed && !tapDirective.test(line)) {
       const name = failed[1].trim();
       const diagnostic = [];
       const errorDetails = [];

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -18,6 +18,7 @@ function parseTapResult(text, exitCode) {
     if (failed) {
       const name = failed[1].trim();
       const diagnostic = [];
+      let inDiagnostic = false;
       let skippingStack = false;
       let stackIndent = -1;
       for (let detailIndex = index + 1; detailIndex < lines.length; detailIndex += 1) {
@@ -25,6 +26,12 @@ function parseTapResult(text, exitCode) {
         if (/^\s*(?:ok|not ok) \d+ - /.test(detail) || /^\s*# (?:tests|fail|cancelled) \d+\s*$/.test(detail)) {
           break;
         }
+        if (/^\s*---\s*$/.test(detail)) {
+          inDiagnostic = true;
+          continue;
+        }
+        if (inDiagnostic && /^\s*\.\.\.\s*$/.test(detail)) break;
+        if (!inDiagnostic) continue;
         const indent = detail.match(/^\s*/)?.[0].length || 0;
         if (skippingStack) {
           if (!detail.trim() || indent > stackIndent) continue;
@@ -35,9 +42,8 @@ function parseTapResult(text, exitCode) {
           stackIndent = indent;
           continue;
         }
-        if (/^\s*(?:---|\.\.\.)\s*$/.test(detail)) continue;
         if (/^\s*duration_ms:/.test(detail)) continue;
-        if (detail.trim()) {
+        if (/^\s*(?:type|location|failureType|error|code|operator):/.test(detail)) {
           diagnostic.push(
             detail.trimEnd().replace(
               /^(\s*location:\s*['"]?.*?):\d+:\d+(['"]?\s*)$/,

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -16,6 +16,12 @@ function normalizeAssertionDetail(detail) {
     );
 }
 
+function normalizeStableDiagnosticDetail(detail) {
+  return normalizeAssertionDetail(detail)
+    .replace(/(?:\/private)?\/var\/folders\/\S+|\/tmp\/\S+/g, '<tmp-path>')
+    .replace(/:\d+:\d+\b/g, ':<line>:<column>');
+}
+
 function collectNonTapOutput(lines) {
   const output = [];
   let inDiagnostic = false;
@@ -131,25 +137,21 @@ function parseTapResult(text, exitCode) {
           continue;
         }
         if (/^\s*duration_ms:/.test(detail)) continue;
+        if (/^\s*(?:actual|expected):/.test(detail)) continue;
         if (/^\s*error:\s*(?:\|-|>)\s*$/.test(detail)) {
           diagnostic.push('error:');
           errorBlockIndent = indent;
           continue;
         }
-        if (/^\s*(?:type|location|failureType|error|code|operator):/.test(detail)) {
-          diagnostic.push(
-            detail.trimEnd().replace(
-              /^(\s*location:\s*['"]?.*?):\d+:\d+(['"]?\s*)$/,
-              '$1$2',
-            ),
-          );
+        if (detail.trim()) {
+          diagnostic.push(normalizeStableDiagnosticDetail(detail.trimEnd()));
         }
       }
       const assertionFailure = diagnostic.some((detail) =>
         /^\s*code:\s*['"]?ERR_ASSERTION['"]?\s*$/.test(detail),
       );
       const stableErrorDetails = assertionFailure
-        ? errorDetails.map(normalizeAssertionDetail)
+        ? errorDetails.map(normalizeStableDiagnosticDetail)
         : errorDetails;
       diagnostic.push(...stableErrorDetails.map((detail) => `error-detail: ${detail}`));
       failures.push(name);

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -192,6 +192,24 @@ function compareTapResults(baseline, candidate) {
     const missing = count - (candidateSuccessCounts.get(success) || 0);
     for (let i = 0; i < missing; i += 1) missingBaselineSuccesses.push(success);
   }
+  const candidateFailurePool = countFailures(
+    candidate.failureRecords.map((failure) => failure.identity),
+  );
+  const candidateSuccessPool = new Map(candidateSuccessCounts);
+  const missingBaselineFailures = [];
+  for (const failure of baseline.failureRecords) {
+    const matchingFailures = candidateFailurePool.get(failure.identity) || 0;
+    if (matchingFailures > 0) {
+      candidateFailurePool.set(failure.identity, matchingFailures - 1);
+      continue;
+    }
+    const matchingSuccesses = candidateSuccessPool.get(failure.name) || 0;
+    if (matchingSuccesses > 0) {
+      candidateSuccessPool.set(failure.name, matchingSuccesses - 1);
+      continue;
+    }
+    missingBaselineFailures.push(failure.name);
+  }
 
   if (candidate.exitCode === 0) {
     const completeCleanRun =
@@ -202,7 +220,8 @@ function compareTapResults(baseline, candidate) {
       candidate.skippedCount <= baseline.skippedCount &&
       candidate.todoCount <= baseline.todoCount &&
       candidate.testCount >= baseline.testCount &&
-      missingBaselineSuccesses.length === 0;
+      missingBaselineSuccesses.length === 0 &&
+      missingBaselineFailures.length === 0;
     return {
       passed: completeCleanRun,
       kind: completeCleanRun ? 'clean' : 'unclassified_failure',
@@ -308,13 +327,23 @@ function compareTapResults(baseline, candidate) {
   const parsedCountsMatch =
     baseline.failureRecords.length >= Number(baseline.failCount) &&
     candidate.failureRecords.length >= Number(candidate.failCount);
-  const passed = newFailures.length === 0 && parsedCountsMatch;
+  const passed =
+    newFailures.length === 0 &&
+    missingBaselineFailures.length === 0 &&
+    parsedCountsMatch;
+  const reportedFailures = newFailures.length
+    ? newFailures
+    : missingBaselineFailures;
   return {
     passed,
-    kind: passed ? 'baseline_only' : 'new_failures',
+    kind: passed
+      ? 'baseline_only'
+      : newFailures.length
+        ? 'new_failures'
+        : 'unclassified_failure',
     baselineFailures: baseline.failures,
     candidateFailures: candidate.failures,
-    newFailures,
+    newFailures: reportedFailures,
   };
 }
 

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -18,6 +18,7 @@ function parseTapResult(text, exitCode) {
     if (failed) {
       const name = failed[1].trim();
       const diagnostic = [];
+      const errorDetails = [];
       let inDiagnostic = false;
       let errorBlockIndent = -1;
       let skippingStack = false;
@@ -37,7 +38,7 @@ function parseTapResult(text, exitCode) {
         if (errorBlockIndent >= 0) {
           if (!detail.trim()) continue;
           if (indent > errorBlockIndent) {
-            diagnostic.push(`error-detail: ${detail.trim()}`);
+            errorDetails.push(detail.trim());
             continue;
           }
           errorBlockIndent = -1;
@@ -66,6 +67,15 @@ function parseTapResult(text, exitCode) {
           );
         }
       }
+      const assertionFailure = diagnostic.some((detail) =>
+        /^\s*code:\s*['"]?ERR_ASSERTION['"]?\s*$/.test(detail),
+      );
+      const stableErrorDetails = assertionFailure
+        ? errorDetails.slice(0, 1).map((detail) =>
+            detail.replace(/\b\d+(?:\.\d+)?\b/g, '<number>'),
+          )
+        : errorDetails;
+      diagnostic.push(...stableErrorDetails.map((detail) => `error-detail: ${detail}`));
       failures.push(name);
       failureRecords.push({
         name,

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -6,13 +6,45 @@ const ANSI_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g;
 
 function parseTapResult(text, exitCode) {
   const normalized = String(text || '').replace(ANSI_RE, '').replace(/\r\n?/g, '\n');
+  const lines = normalized.split('\n');
   const failures = [];
+  const failureRecords = [];
   let failCount = null;
   let cancelledCount = null;
   let testCount = null;
-  for (const line of normalized.split('\n')) {
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
     const failed = line.match(/^\s*not ok \d+ - (.+?)(?:\s+#.*)?$/);
-    if (failed) failures.push(failed[1].trim());
+    if (failed) {
+      const name = failed[1].trim();
+      const diagnostic = [];
+      let skippingStack = false;
+      let stackIndent = -1;
+      for (let detailIndex = index + 1; detailIndex < lines.length; detailIndex += 1) {
+        const detail = lines[detailIndex];
+        if (/^\s*(?:ok|not ok) \d+ - /.test(detail) || /^\s*# (?:tests|fail|cancelled) \d+\s*$/.test(detail)) {
+          break;
+        }
+        const indent = detail.match(/^\s*/)?.[0].length || 0;
+        if (skippingStack) {
+          if (!detail.trim() || indent > stackIndent) continue;
+          skippingStack = false;
+        }
+        if (/^\s*stack:\s*(?:\|-)?\s*$/.test(detail)) {
+          skippingStack = true;
+          stackIndent = indent;
+          continue;
+        }
+        if (/^\s*(?:---|\.\.\.)\s*$/.test(detail)) continue;
+        if (/^\s*duration_ms:/.test(detail)) continue;
+        if (detail.trim()) diagnostic.push(detail.trimEnd());
+      }
+      failures.push(name);
+      failureRecords.push({
+        name,
+        identity: diagnostic.length ? `${name}\n${diagnostic.join('\n')}` : name,
+      });
+    }
     const failSummary = line.match(/^\s*# fail (\d+)\s*$/);
     if (failSummary) failCount = Number(failSummary[1]);
     const cancelledSummary = line.match(/^\s*# cancelled (\d+)\s*$/);
@@ -23,6 +55,7 @@ function parseTapResult(text, exitCode) {
   return {
     exitCode: Number(exitCode),
     failures,
+    failureRecords,
     failCount,
     cancelledCount,
     testCount,
@@ -42,10 +75,11 @@ function countFailures(failures) {
 function compareTapResults(baseline, candidate) {
   if (candidate.exitCode === 0) {
     const completeCleanRun =
+      baseline.complete &&
       candidate.complete &&
       candidate.failCount === 0 &&
       candidate.cancelledCount === 0 &&
-      (!baseline.complete || candidate.testCount >= baseline.testCount);
+      candidate.testCount >= baseline.testCount;
     return {
       passed: completeCleanRun,
       kind: completeCleanRun ? 'clean' : 'unclassified_failure',
@@ -95,16 +129,23 @@ function compareTapResults(baseline, candidate) {
     };
   }
 
-  const baselineCounts = countFailures(baseline.failures);
-  const candidateCounts = countFailures(candidate.failures);
+  const baselineCounts = countFailures(
+    baseline.failureRecords.map((failure) => failure.identity),
+  );
+  const candidateCounts = countFailures(
+    candidate.failureRecords.map((failure) => failure.identity),
+  );
   const newFailures = [];
-  for (const [failure, count] of candidateCounts) {
-    const extra = count - (baselineCounts.get(failure) || 0);
-    for (let i = 0; i < extra; i += 1) newFailures.push(failure);
+  for (const [identity, count] of candidateCounts) {
+    const extra = count - (baselineCounts.get(identity) || 0);
+    const name = candidate.failureRecords.find(
+      (failure) => failure.identity === identity,
+    )?.name || identity;
+    for (let i = 0; i < extra; i += 1) newFailures.push(name);
   }
   const parsedCountsMatch =
-    baseline.failures.length >= Number(baseline.failCount) &&
-    candidate.failures.length >= Number(candidate.failCount);
+    baseline.failureRecords.length >= Number(baseline.failCount) &&
+    candidate.failureRecords.length >= Number(candidate.failCount);
   const passed = newFailures.length === 0 && parsedCountsMatch;
   return {
     passed,

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -37,7 +37,14 @@ function parseTapResult(text, exitCode) {
         }
         if (/^\s*(?:---|\.\.\.)\s*$/.test(detail)) continue;
         if (/^\s*duration_ms:/.test(detail)) continue;
-        if (detail.trim()) diagnostic.push(detail.trimEnd());
+        if (detail.trim()) {
+          diagnostic.push(
+            detail.trimEnd().replace(
+              /^(\s*location:\s*['"]?.*?):\d+:\d+(['"]?\s*)$/,
+              '$1$2',
+            ),
+          );
+        }
       }
       failures.push(name);
       failureRecords.push({

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -24,6 +24,7 @@ function parseTapResult(text, exitCode) {
   let failCount = null;
   let cancelledCount = null;
   let skippedCount = null;
+  let todoCount = null;
   let testCount = null;
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
@@ -38,7 +39,7 @@ function parseTapResult(text, exitCode) {
       let stackIndent = -1;
       for (let detailIndex = index + 1; detailIndex < lines.length; detailIndex += 1) {
         const detail = lines[detailIndex];
-        if (/^\s*(?:ok|not ok) \d+ - /.test(detail) || /^\s*# (?:tests|fail|cancelled) \d+\s*$/.test(detail)) {
+        if (/^\s*(?:ok|not ok) \d+ - /.test(detail) || /^\s*# (?:tests|fail|cancelled|skipped|todo) \d+\s*$/.test(detail)) {
           break;
         }
         if (/^\s*---\s*$/.test(detail)) {
@@ -99,6 +100,8 @@ function parseTapResult(text, exitCode) {
     if (cancelledSummary) cancelledCount = Number(cancelledSummary[1]);
     const skippedSummary = line.match(/^\s*# skipped (\d+)\s*$/);
     if (skippedSummary) skippedCount = Number(skippedSummary[1]);
+    const todoSummary = line.match(/^\s*# todo (\d+)\s*$/);
+    if (todoSummary) todoCount = Number(todoSummary[1]);
     const testSummary = line.match(/^\s*# tests (\d+)\s*$/);
     if (testSummary) testCount = Number(testSummary[1]);
   }
@@ -109,11 +112,13 @@ function parseTapResult(text, exitCode) {
     failCount,
     cancelledCount,
     skippedCount,
+    todoCount,
     testCount,
     complete:
       failCount !== null &&
       cancelledCount !== null &&
       skippedCount !== null &&
+      todoCount !== null &&
       testCount !== null,
   };
 }
@@ -134,6 +139,7 @@ function compareTapResults(baseline, candidate) {
       candidate.failCount === 0 &&
       candidate.cancelledCount === 0 &&
       candidate.skippedCount <= baseline.skippedCount &&
+      candidate.todoCount <= baseline.todoCount &&
       candidate.testCount >= baseline.testCount;
     return {
       passed: completeCleanRun,
@@ -176,7 +182,8 @@ function compareTapResults(baseline, candidate) {
 
   if (
     candidate.cancelledCount > 0 ||
-    candidate.skippedCount > baseline.skippedCount
+    candidate.skippedCount > baseline.skippedCount ||
+    candidate.todoCount > baseline.todoCount
   ) {
     return {
       passed: false,

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -4,22 +4,25 @@ const fs = require('node:fs');
 
 const ANSI_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g;
 
-function normalizeAssertionDetail(detail) {
+function normalizeRuntimeDetail(detail) {
   return detail
-    .replace(
-      /\b(now|timestamp|pid|nonce|random(?:Value)?)\b(['"]?\s*[:=]\s*)[^,\s}\]]+/gi,
-      '$1$2<volatile>',
-    )
     .replace(
       /\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\b/g,
       '<timestamp>',
-    );
+    )
+    .replace(/(?:\/private)?\/var\/folders\/\S+|\/tmp\/\S+/g, '<tmp-path>')
+    .replace(/:\d+:\d+\b/g, ':<line>:<column>');
+}
+
+function normalizeAssertionDetail(detail) {
+  return normalizeRuntimeDetail(detail).replace(
+    /\b(now|timestamp|pid|nonce|random(?:Value)?)\b(['"]?\s*[:=]\s*)[^,\s}\]]+/gi,
+    '$1$2<volatile>',
+  );
 }
 
 function normalizeStableDiagnosticDetail(detail) {
-  return normalizeAssertionDetail(detail)
-    .replace(/(?:\/private)?\/var\/folders\/\S+|\/tmp\/\S+/g, '<tmp-path>')
-    .replace(/:\d+:\d+\b/g, ':<line>:<column>');
+  return normalizeAssertionDetail(detail);
 }
 
 function collectNonTapOutput(lines) {
@@ -152,7 +155,7 @@ function parseTapResult(text, exitCode) {
       );
       const stableErrorDetails = assertionFailure
         ? errorDetails.map(normalizeStableDiagnosticDetail)
-        : errorDetails;
+        : errorDetails.map(normalizeRuntimeDetail);
       diagnostic.push(...stableErrorDetails.map((detail) => `error-detail: ${detail}`));
       failures.push(name);
       failureRecords.push({

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -19,20 +19,30 @@ function normalizeAssertionDetail(detail) {
 function collectNonTapOutput(lines) {
   const output = [];
   let inDiagnostic = false;
+  let awaitingDiagnostic = false;
   for (const rawLine of lines) {
     const line = rawLine.trim();
-    if (/^---$/.test(line)) {
-      inDiagnostic = true;
+    if (inDiagnostic) {
+      if (/^\s{2,}\.\.\.\s*$/.test(rawLine)) inDiagnostic = false;
       continue;
     }
-    if (inDiagnostic) {
-      if (/^\.\.\.$/.test(line)) inDiagnostic = false;
+    if (awaitingDiagnostic) {
+      if (!line) continue;
+      if (/^\s{2,}---\s*$/.test(rawLine)) {
+        inDiagnostic = true;
+        awaitingDiagnostic = false;
+        continue;
+      }
+      awaitingDiagnostic = false;
+    }
+    if (/^\s*not ok \d+ - /.test(rawLine)) {
+      awaitingDiagnostic = true;
       continue;
     }
     if (
       !line ||
       /^TAP version \d+$/.test(line) ||
-      /^(?:ok|not ok) \d+ - /.test(line) ||
+      /^ok \d+ - /.test(line) ||
       /^# (?:Subtest:|tests |suites |pass |fail |cancelled |skipped |todo |duration_ms )/.test(line) ||
       /^1\.\.\d+$/.test(line)
     ) {

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -16,8 +16,8 @@ function normalizeAssertionDetail(detail) {
     );
 }
 
-function collectNonTapFailures(lines) {
-  const failures = [];
+function collectNonTapOutput(lines) {
+  const output = [];
   let inDiagnostic = false;
   for (const rawLine of lines) {
     const line = rawLine.trim();
@@ -38,17 +38,14 @@ function collectNonTapFailures(lines) {
     ) {
       continue;
     }
-    if (!/\b(?:error|failed|failure|crash(?:ed)?|fatal|exception|unhandled|abort(?:ed)?)\b/i.test(line)) {
-      continue;
-    }
-    failures.push(
+    output.push(
       line
         .replace(/\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\b/g, '<timestamp>')
         .replace(/(?:\/private)?\/var\/folders\/\S+|\/tmp\/\S+/g, '<tmp-path>')
         .replace(/:\d+:\d+\b/g, ':<line>:<column>'),
     );
   }
-  return failures;
+  return output;
 }
 
 function parseTapResult(text, exitCode) {
@@ -166,7 +163,7 @@ function parseTapResult(text, exitCode) {
     skippedCount,
     todoCount,
     testCount,
-    nonTapFailures: collectNonTapFailures(lines),
+    nonTapOutput: collectNonTapOutput(lines),
     complete:
       failCount !== null &&
       cancelledCount !== null &&
@@ -273,12 +270,12 @@ function compareTapResults(baseline, candidate) {
     };
   }
 
-  const baselineNonTapCounts = countFailures(baseline.nonTapFailures);
-  const candidateNonTapCounts = countFailures(candidate.nonTapFailures);
-  const addedNonTapFailure = [...candidateNonTapCounts].some(
-    ([failure, count]) => count > (baselineNonTapCounts.get(failure) || 0),
+  const baselineNonTapCounts = countFailures(baseline.nonTapOutput);
+  const candidateNonTapCounts = countFailures(candidate.nonTapOutput);
+  const addedNonTapOutput = [...candidateNonTapCounts].some(
+    ([line, count]) => count > (baselineNonTapCounts.get(line) || 0),
   );
-  if (addedNonTapFailure) {
+  if (addedNonTapOutput) {
     return {
       passed: false,
       kind: 'unclassified_failure',

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -16,6 +16,41 @@ function normalizeAssertionDetail(detail) {
     );
 }
 
+function collectNonTapFailures(lines) {
+  const failures = [];
+  let inDiagnostic = false;
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (/^---$/.test(line)) {
+      inDiagnostic = true;
+      continue;
+    }
+    if (inDiagnostic) {
+      if (/^\.\.\.$/.test(line)) inDiagnostic = false;
+      continue;
+    }
+    if (
+      !line ||
+      /^TAP version \d+$/.test(line) ||
+      /^(?:ok|not ok) \d+ - /.test(line) ||
+      /^# (?:Subtest:|tests |suites |pass |fail |cancelled |skipped |todo |duration_ms )/.test(line) ||
+      /^1\.\.\d+$/.test(line)
+    ) {
+      continue;
+    }
+    if (!/\b(?:error|failed|failure|crash(?:ed)?|fatal|exception|unhandled|abort(?:ed)?)\b/i.test(line)) {
+      continue;
+    }
+    failures.push(
+      line
+        .replace(/\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\b/g, '<timestamp>')
+        .replace(/(?:\/private)?\/var\/folders\/\S+|\/tmp\/\S+/g, '<tmp-path>')
+        .replace(/:\d+:\d+\b/g, ':<line>:<column>'),
+    );
+  }
+  return failures;
+}
+
 function parseTapResult(text, exitCode) {
   const normalized = String(text || '').replace(ANSI_RE, '').replace(/\r\n?/g, '\n');
   const lines = normalized.split('\n');
@@ -26,7 +61,6 @@ function parseTapResult(text, exitCode) {
   let skippedCount = null;
   let todoCount = null;
   let testCount = null;
-  let lastSummaryIndex = -1;
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
     const failed = line.match(/^\s*not ok \d+ - (.+?)(?:\s+#.*)?$/);
@@ -98,35 +132,24 @@ function parseTapResult(text, exitCode) {
     const failSummary = line.match(/^\s*# fail (\d+)\s*$/);
     if (failSummary) {
       failCount = Number(failSummary[1]);
-      lastSummaryIndex = index;
     }
     const cancelledSummary = line.match(/^\s*# cancelled (\d+)\s*$/);
     if (cancelledSummary) {
       cancelledCount = Number(cancelledSummary[1]);
-      lastSummaryIndex = index;
     }
     const skippedSummary = line.match(/^\s*# skipped (\d+)\s*$/);
     if (skippedSummary) {
       skippedCount = Number(skippedSummary[1]);
-      lastSummaryIndex = index;
     }
     const todoSummary = line.match(/^\s*# todo (\d+)\s*$/);
     if (todoSummary) {
       todoCount = Number(todoSummary[1]);
-      lastSummaryIndex = index;
     }
     const testSummary = line.match(/^\s*# tests (\d+)\s*$/);
     if (testSummary) {
       testCount = Number(testSummary[1]);
-      lastSummaryIndex = index;
-    }
-    if (/^\s*# duration_ms \d+(?:\.\d+)?\s*$/.test(line)) {
-      lastSummaryIndex = index;
     }
   }
-  const trailingOutput = lastSummaryIndex >= 0
-    ? lines.slice(lastSummaryIndex + 1).filter((line) => line.trim()).join('\n')
-    : '';
   return {
     exitCode: Number(exitCode),
     failures,
@@ -136,7 +159,7 @@ function parseTapResult(text, exitCode) {
     skippedCount,
     todoCount,
     testCount,
-    trailingOutput,
+    nonTapFailures: collectNonTapFailures(lines),
     complete:
       failCount !== null &&
       cancelledCount !== null &&
@@ -203,7 +226,12 @@ function compareTapResults(baseline, candidate) {
     };
   }
 
-  if (candidate.trailingOutput !== baseline.trailingOutput) {
+  const baselineNonTapCounts = countFailures(baseline.nonTapFailures);
+  const candidateNonTapCounts = countFailures(candidate.nonTapFailures);
+  const addedNonTapFailure = [...candidateNonTapCounts].some(
+    ([failure, count]) => count > (baselineNonTapCounts.get(failure) || 0),
+  );
+  if (addedNonTapFailure) {
     return {
       passed: false,
       kind: 'unclassified_failure',

--- a/scripts/compare-ci-test-baseline.cjs
+++ b/scripts/compare-ci-test-baseline.cjs
@@ -170,6 +170,16 @@ function compareTapResults(baseline, candidate) {
     };
   }
 
+  if (candidate.exitCode !== baseline.exitCode) {
+    return {
+      passed: false,
+      kind: 'unclassified_failure',
+      baselineFailures: baseline.failures,
+      candidateFailures: candidate.failures,
+      newFailures: candidate.failures,
+    };
+  }
+
   if (candidate.failCount === 0 || candidate.testCount < baseline.testCount) {
     return {
       passed: false,

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -96,6 +96,32 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
   );
   assert.equal(changed.passed, false);
   assert.deepEqual(changed.newFailures, ['duplicate title']);
+
+  const dynamicValues = (actual, nextTitle) => [
+    'TAP version 13',
+    'not ok 1 - duplicate title',
+    '  ---',
+    "  location: '/workspace/example.test.js:10:1'",
+    "  failureType: 'testCodeFailure'",
+    "  error: 'old failure'",
+    `  actual: ${actual}`,
+    '  expected: 1',
+    "  code: 'ERR_ASSERTION'",
+    '  stack: |- ',
+    '    volatile stack line',
+    '  ...',
+    `# Subtest: ${nextTitle}`,
+    `ok 2 - ${nextTitle}`,
+    '1..2',
+    '# fail 1',
+    '# cancelled 0',
+    '# tests 2',
+  ].join('\n');
+  const dynamic = compareTapResults(
+    parseTapResult(dynamicValues(41831, 'later test'), 1),
+    parseTapResult(dynamicValues(52942, 'renamed later test'), 1),
+  );
+  assert.equal(dynamic.passed, true);
 });
 
 test('rejects added duplicate failures and cancelled tests', () => {

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -66,12 +66,19 @@ test('rejects a different candidate failure even when both runs are red', () => 
 
 test('rejects an additional runner failure after comparable TAP output', () => {
   const sameTap = tap({ failures: ['base failure'] });
-  const result = compareTapResults(
+  const differentExit = compareTapResults(
     parseTapResult(sameTap, 1),
     parseTapResult(`${sameTap}\nrunner crashed after tests`, 2),
   );
-  assert.equal(result.passed, false);
-  assert.equal(result.kind, 'unclassified_failure');
+  assert.equal(differentExit.passed, false);
+  assert.equal(differentExit.kind, 'unclassified_failure');
+
+  const sameExit = compareTapResults(
+    parseTapResult(sameTap, 1),
+    parseTapResult(`${sameTap}\nrunner crashed after tests`, 1),
+  );
+  assert.equal(sameExit.passed, false);
+  assert.equal(sameExit.kind, 'unclassified_failure');
 });
 
 test('distinguishes same-title failures by stable TAP diagnostics', () => {

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -53,6 +53,12 @@ test('rejects replacing an existing successful test with an unrelated one', () =
     }), 0),
   );
   assert.equal(issueNumberName.passed, false);
+
+  const duplicateName = compareTapResults(
+    parseTapResult(tap({ failures: ['same name'], successes: ['same name'] }), 1),
+    parseTapResult(tap({ successes: ['same name', 'unrelated replacement'] }), 0),
+  );
+  assert.equal(duplicateName.passed, false);
 });
 
 test('rejects a clean candidate when the exact-base TAP summary is incomplete', () => {

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -324,6 +324,16 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
     parseTapResult(customMultilineError('service rejected: new reason'), 1),
   );
   assert.equal(changedCustomError.passed, false);
+
+  const sameCustomErrorAcrossRuns = compareTapResults(
+    parseTapResult(customMultilineError(
+      'service failed at /tmp/run-A/result on 2026-07-31T10:00:00Z in worker.js:10:2',
+    ), 1),
+    parseTapResult(customMultilineError(
+      'service failed at /tmp/run-B/result on 2026-07-31T10:01:00Z in worker.js:11:3',
+    ), 1),
+  );
+  assert.equal(sameCustomErrorAcrossRuns.passed, true);
 });
 
 test('rejects added duplicate failures, cancellations, skipped tests, and TODOs', () => {

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -1,0 +1,68 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  compareTapResults,
+  parseTapResult,
+} = require('./compare-ci-test-baseline.cjs');
+
+const tap = ({ failures = [], fail = failures.length, cancelled = 0 } = {}) => [
+  'TAP version 13',
+  ...failures.map((name, index) => `not ok ${index + 1} - ${name}`),
+  `# fail ${fail}`,
+  `# cancelled ${cancelled}`,
+].join('\n');
+
+test('accepts a clean candidate even when the base was red', () => {
+  const result = compareTapResults(
+    parseTapResult(tap({ failures: ['base failure'] }), 1),
+    parseTapResult(tap(), 0),
+  );
+  assert.equal(result.passed, true);
+  assert.equal(result.kind, 'clean');
+});
+
+test('accepts only failures already present on the exact base', () => {
+  const result = compareTapResults(
+    parseTapResult(tap({ failures: ['base A', 'base B'] }), 1),
+    parseTapResult(tap({ failures: ['base B'] }), 1),
+  );
+  assert.equal(result.passed, true);
+  assert.equal(result.kind, 'baseline_only');
+  assert.deepEqual(result.newFailures, []);
+});
+
+test('rejects a different candidate failure even when both runs are red', () => {
+  const result = compareTapResults(
+    parseTapResult(tap({ failures: ['base failure'] }), 1),
+    parseTapResult(tap({ failures: ['candidate regression'] }), 1),
+  );
+  assert.equal(result.passed, false);
+  assert.equal(result.kind, 'new_failures');
+  assert.deepEqual(result.newFailures, ['candidate regression']);
+});
+
+test('rejects added duplicate failures and cancelled tests', () => {
+  const duplicate = compareTapResults(
+    parseTapResult(tap({ failures: ['same'] }), 1),
+    parseTapResult(tap({ failures: ['same', 'same'] }), 1),
+  );
+  assert.equal(duplicate.passed, false);
+
+  const cancelled = compareTapResults(
+    parseTapResult(tap({ failures: ['same'] }), 1),
+    parseTapResult(tap({ failures: ['same'], cancelled: 2 }), 1),
+  );
+  assert.equal(cancelled.passed, false);
+  assert.equal(cancelled.kind, 'cancelled_tests');
+});
+
+test('fails closed when a red run has no complete TAP summary', () => {
+  const result = compareTapResults(
+    parseTapResult('runner stopped early', 1),
+    parseTapResult('runner stopped early', 1),
+  );
+  assert.equal(result.passed, false);
+  assert.equal(result.kind, 'unclassified_failure');
+});

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -130,6 +130,13 @@ test('rejects an additional runner failure after comparable TAP output', () => {
   assert.equal(crashWithoutFailureKeyword.passed, false);
   assert.equal(crashWithoutFailureKeyword.kind, 'unclassified_failure');
 
+  const crashInsideUnattachedYamlMarkers = compareTapResults(
+    parseTapResult(sameTap, 1),
+    parseTapResult(`${sameTap}\n---\nSegmentation fault (core dumped)\n...`, 1),
+  );
+  assert.equal(crashInsideUnattachedYamlMarkers.passed, false);
+  assert.equal(crashInsideUnattachedYamlMarkers.kind, 'unclassified_failure');
+
   const unchangedArbitraryOutput = compareTapResults(
     parseTapResult(`starting custom runner\n${sameTap}`, 1),
     parseTapResult(`starting custom runner\n${sameTap}`, 1),

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -21,7 +21,7 @@ const tap = ({ failures = [], successes = [], fail = failures.length, cancelled 
 test('accepts a clean candidate even when the base was red', () => {
   const result = compareTapResults(
     parseTapResult(tap({ failures: ['base failure'] }), 1),
-    parseTapResult(tap(), 0),
+    parseTapResult(tap({ successes: ['base failure'] }), 0),
   );
   assert.equal(result.passed, true);
   assert.equal(result.kind, 'clean');
@@ -67,11 +67,21 @@ test('rejects a clean candidate when the exact-base TAP summary is incomplete', 
 test('accepts only failures already present on the exact base', () => {
   const result = compareTapResults(
     parseTapResult(tap({ failures: ['base A', 'base B'] }), 1),
-    parseTapResult(tap({ failures: ['base B'] }), 1),
+    parseTapResult(tap({ failures: ['base B'], successes: ['base A'] }), 1),
   );
   assert.equal(result.passed, true);
   assert.equal(result.kind, 'baseline_only');
   assert.deepEqual(result.newFailures, []);
+
+  const removedFailure = compareTapResults(
+    parseTapResult(tap({ failures: ['base A', 'base B'] }), 1),
+    parseTapResult(tap({
+      failures: ['base B'],
+      successes: ['unrelated replacement'],
+    }), 1),
+  );
+  assert.equal(removedFailure.passed, false);
+  assert.equal(removedFailure.kind, 'unclassified_failure');
 });
 
 test('rejects a different candidate failure even when both runs are red', () => {

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -7,12 +7,13 @@ const {
   parseTapResult,
 } = require('./compare-ci-test-baseline.cjs');
 
-const tap = ({ failures = [], fail = failures.length, cancelled = 0, skipped = 0, tests = 10 } = {}) => [
+const tap = ({ failures = [], fail = failures.length, cancelled = 0, skipped = 0, todo = 0, tests = 10 } = {}) => [
   'TAP version 13',
   ...failures.map((name, index) => `not ok ${index + 1} - ${name}`),
   `# fail ${fail}`,
   `# cancelled ${cancelled}`,
   `# skipped ${skipped}`,
+  `# todo ${todo}`,
   `# tests ${tests}`,
 ].join('\n');
 
@@ -78,6 +79,7 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
     '# fail 1',
     '# cancelled 0',
     '# skipped 0',
+    '# todo 0',
     '# tests 10',
   ].join('\n');
   const same = compareTapResults(
@@ -118,6 +120,7 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
     '# fail 1',
     '# cancelled 0',
     '# skipped 0',
+    '# todo 0',
     '# tests 2',
   ].join('\n');
   const dynamic = compareTapResults(
@@ -140,6 +143,7 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
     '# fail 1',
     '# cancelled 0',
     '# skipped 0',
+    '# todo 0',
     '# tests 10',
   ].join('\n');
   const changedMultilineError = compareTapResults(
@@ -166,6 +170,7 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
     '# fail 1',
     '# cancelled 0',
     '# skipped 0',
+    '# todo 0',
     '# tests 10',
   ].join('\n');
   const changedAssertionValue = compareTapResults(
@@ -197,7 +202,7 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
   assert.equal(changedCustomError.passed, false);
 });
 
-test('rejects added duplicate failures, cancellations, and skipped tests', () => {
+test('rejects added duplicate failures, cancellations, skipped tests, and TODOs', () => {
   const duplicate = compareTapResults(
     parseTapResult(tap({ failures: ['same'] }), 1),
     parseTapResult(tap({ failures: ['same', 'same'] }), 1),
@@ -217,6 +222,13 @@ test('rejects added duplicate failures, cancellations, and skipped tests', () =>
   );
   assert.equal(skipped.passed, false);
   assert.equal(skipped.kind, 'unclassified_failure');
+
+  const todo = compareTapResults(
+    parseTapResult(tap({ todo: 1 }), 0),
+    parseTapResult(tap({ todo: 10 }), 0),
+  );
+  assert.equal(todo.passed, false);
+  assert.equal(todo.kind, 'unclassified_failure');
 });
 
 test('fails closed when a red run has no complete TAP summary', () => {

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -180,6 +180,12 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
   );
   assert.equal(changedStableAssertionValue.passed, false);
 
+  const changedPortAssertion = compareTapResults(
+    parseTapResult(assertionDiff('port', 2222), 1),
+    parseTapResult(assertionDiff('port', 443), 1),
+  );
+  assert.equal(changedPortAssertion.passed, false);
+
   const customMultilineError = (reason) => multilineError(reason).replace(
     "code: 'ERR_ASSERTION'",
     "code: 'ERR_CUSTOM'",

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -43,6 +43,16 @@ test('rejects replacing an existing successful test with an unrelated one', () =
   );
   assert.equal(result.passed, false);
   assert.equal(result.kind, 'unclassified_failure');
+
+  const issueNumberName = compareTapResults(
+    parseTapResult(tap({
+      successes: ['accepts packages that ship upstream #6055/#5987/#6043'],
+    }), 0),
+    parseTapResult(tap({
+      successes: ['accepts packages that ship upstream #9999'],
+    }), 0),
+  );
+  assert.equal(issueNumberName.passed, false);
 });
 
 test('rejects a clean candidate when the exact-base TAP summary is incomplete', () => {

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -144,6 +144,38 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
   );
   assert.equal(changedMultilineError.passed, false);
   assert.deepEqual(changedMultilineError.newFailures, ['duplicate title']);
+
+  const assertionDiff = (actual) => [
+    'TAP version 13',
+    'not ok 1 - duplicate title',
+    '  ---',
+    "  failureType: 'testCodeFailure'",
+    '  error: |-',
+    '    Expected values to be strictly equal:',
+    '',
+    `    ${actual} !== 1`,
+    "  code: 'ERR_ASSERTION'",
+    "  operator: 'strictEqual'",
+    '  ...',
+    '# fail 1',
+    '# cancelled 0',
+    '# tests 10',
+  ].join('\n');
+  const changedAssertionValue = compareTapResults(
+    parseTapResult(assertionDiff(111), 1),
+    parseTapResult(assertionDiff(222), 1),
+  );
+  assert.equal(changedAssertionValue.passed, true);
+
+  const customMultilineError = (reason) => multilineError(reason).replace(
+    "code: 'ERR_ASSERTION'",
+    "code: 'ERR_CUSTOM'",
+  );
+  const changedCustomError = compareTapResults(
+    parseTapResult(customMultilineError('service rejected: old reason'), 1),
+    parseTapResult(customMultilineError('service rejected: new reason'), 1),
+  );
+  assert.equal(changedCustomError.passed, false);
 });
 
 test('rejects added duplicate failures and cancelled tests', () => {

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -122,6 +122,28 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
     parseTapResult(dynamicValues(52942, 'renamed later test'), 1),
   );
   assert.equal(dynamic.passed, true);
+
+  const multilineError = (reason) => [
+    'TAP version 13',
+    'not ok 1 - duplicate title',
+    '  ---',
+    "  location: '/workspace/example.test.js:10:1'",
+    "  failureType: 'testCodeFailure'",
+    '  error: |-',
+    `    ${reason}`,
+    "  code: 'ERR_ASSERTION'",
+    "  operator: 'strictEqual'",
+    '  ...',
+    '# fail 1',
+    '# cancelled 0',
+    '# tests 10',
+  ].join('\n');
+  const changedMultilineError = compareTapResults(
+    parseTapResult(multilineError('old failure'), 1),
+    parseTapResult(multilineError('new regression'), 1),
+  );
+  assert.equal(changedMultilineError.passed, false);
+  assert.deepEqual(changedMultilineError.newFailures, ['duplicate title']);
 });
 
 test('rejects added duplicate failures and cancelled tests', () => {

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -33,6 +33,15 @@ test('rejects a zero-exit candidate without a complete clean TAP summary', () =>
   assert.equal(result.kind, 'unclassified_failure');
 });
 
+test('rejects a clean candidate when the exact-base TAP summary is incomplete', () => {
+  const result = compareTapResults(
+    parseTapResult('base runner stopped early', 1),
+    parseTapResult(tap(), 0),
+  );
+  assert.equal(result.passed, false);
+  assert.equal(result.kind, 'unclassified_failure');
+});
+
 test('accepts only failures already present on the exact base', () => {
   const result = compareTapResults(
     parseTapResult(tap({ failures: ['base A', 'base B'] }), 1),
@@ -51,6 +60,36 @@ test('rejects a different candidate failure even when both runs are red', () => 
   assert.equal(result.passed, false);
   assert.equal(result.kind, 'new_failures');
   assert.deepEqual(result.newFailures, ['candidate regression']);
+});
+
+test('distinguishes same-title failures by stable TAP diagnostics', () => {
+  const withDiagnostic = (error) => [
+    'TAP version 13',
+    'not ok 1 - duplicate title',
+    '  ---',
+    "  location: '/workspace/example.test.js:10:1'",
+    "  failureType: 'testCodeFailure'",
+    `  error: '${error}'`,
+    "  code: 'ERR_ASSERTION'",
+    '  stack: |- ',
+    '    volatile stack line',
+    '  ...',
+    '# fail 1',
+    '# cancelled 0',
+    '# tests 10',
+  ].join('\n');
+  const same = compareTapResults(
+    parseTapResult(withDiagnostic('old failure'), 1),
+    parseTapResult(withDiagnostic('old failure'), 1),
+  );
+  assert.equal(same.passed, true);
+
+  const changed = compareTapResults(
+    parseTapResult(withDiagnostic('old failure'), 1),
+    parseTapResult(withDiagnostic('new regression'), 1),
+  );
+  assert.equal(changed.passed, false);
+  assert.deepEqual(changed.newFailures, ['duplicate title']);
 });
 
 test('rejects added duplicate failures and cancelled tests', () => {

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -7,11 +7,12 @@ const {
   parseTapResult,
 } = require('./compare-ci-test-baseline.cjs');
 
-const tap = ({ failures = [], fail = failures.length, cancelled = 0, tests = 10 } = {}) => [
+const tap = ({ failures = [], fail = failures.length, cancelled = 0, skipped = 0, tests = 10 } = {}) => [
   'TAP version 13',
   ...failures.map((name, index) => `not ok ${index + 1} - ${name}`),
   `# fail ${fail}`,
   `# cancelled ${cancelled}`,
+  `# skipped ${skipped}`,
   `# tests ${tests}`,
 ].join('\n');
 
@@ -76,6 +77,7 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
     '  ...',
     '# fail 1',
     '# cancelled 0',
+    '# skipped 0',
     '# tests 10',
   ].join('\n');
   const same = compareTapResults(
@@ -115,6 +117,7 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
     '1..2',
     '# fail 1',
     '# cancelled 0',
+    '# skipped 0',
     '# tests 2',
   ].join('\n');
   const dynamic = compareTapResults(
@@ -136,6 +139,7 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
     '  ...',
     '# fail 1',
     '# cancelled 0',
+    '# skipped 0',
     '# tests 10',
   ].join('\n');
   const changedMultilineError = compareTapResults(
@@ -145,7 +149,7 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
   assert.equal(changedMultilineError.passed, false);
   assert.deepEqual(changedMultilineError.newFailures, ['duplicate title']);
 
-  const assertionDiff = (actual) => [
+  const assertionDiff = (field, actual) => [
     'TAP version 13',
     'not ok 1 - duplicate title',
     '  ---',
@@ -153,19 +157,28 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
     '  error: |-',
     '    Expected values to be strictly equal:',
     '',
-    `    ${actual} !== 1`,
+    '    {',
+    `      ${field}: ${actual}`,
+    '    }',
     "  code: 'ERR_ASSERTION'",
     "  operator: 'strictEqual'",
     '  ...',
     '# fail 1',
     '# cancelled 0',
+    '# skipped 0',
     '# tests 10',
   ].join('\n');
   const changedAssertionValue = compareTapResults(
-    parseTapResult(assertionDiff(111), 1),
-    parseTapResult(assertionDiff(222), 1),
+    parseTapResult(assertionDiff('now', 111), 1),
+    parseTapResult(assertionDiff('now', 222), 1),
   );
   assert.equal(changedAssertionValue.passed, true);
+
+  const changedStableAssertionValue = compareTapResults(
+    parseTapResult(assertionDiff('x', 1), 1),
+    parseTapResult(assertionDiff('x', 3), 1),
+  );
+  assert.equal(changedStableAssertionValue.passed, false);
 
   const customMultilineError = (reason) => multilineError(reason).replace(
     "code: 'ERR_ASSERTION'",
@@ -178,7 +191,7 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
   assert.equal(changedCustomError.passed, false);
 });
 
-test('rejects added duplicate failures and cancelled tests', () => {
+test('rejects added duplicate failures, cancellations, and skipped tests', () => {
   const duplicate = compareTapResults(
     parseTapResult(tap({ failures: ['same'] }), 1),
     parseTapResult(tap({ failures: ['same', 'same'] }), 1),
@@ -191,6 +204,13 @@ test('rejects added duplicate failures and cancelled tests', () => {
   );
   assert.equal(cancelled.passed, false);
   assert.equal(cancelled.kind, 'cancelled_tests');
+
+  const skipped = compareTapResults(
+    parseTapResult(tap({ skipped: 1 }), 0),
+    parseTapResult(tap({ skipped: 10 }), 0),
+  );
+  assert.equal(skipped.passed, false);
+  assert.equal(skipped.kind, 'unclassified_failure');
 });
 
 test('fails closed when a red run has no complete TAP summary', () => {

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -122,6 +122,20 @@ test('rejects an additional runner failure after comparable TAP output', () => {
   );
   assert.equal(preSummaryCrash.passed, false);
   assert.equal(preSummaryCrash.kind, 'unclassified_failure');
+
+  const crashWithoutFailureKeyword = compareTapResults(
+    parseTapResult(sameTap, 1),
+    parseTapResult(`${sameTap}\nSegmentation fault (core dumped)`, 1),
+  );
+  assert.equal(crashWithoutFailureKeyword.passed, false);
+  assert.equal(crashWithoutFailureKeyword.kind, 'unclassified_failure');
+
+  const unchangedArbitraryOutput = compareTapResults(
+    parseTapResult(`starting custom runner\n${sameTap}`, 1),
+    parseTapResult(`starting custom runner\n${sameTap}`, 1),
+  );
+  assert.equal(unchangedArbitraryOutput.passed, true);
+  assert.equal(unchangedArbitraryOutput.kind, 'baseline_only');
 });
 
 test('distinguishes same-title failures by stable TAP diagnostics', () => {

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -64,6 +64,16 @@ test('rejects a different candidate failure even when both runs are red', () => 
   assert.deepEqual(result.newFailures, ['candidate regression']);
 });
 
+test('rejects an additional runner failure after comparable TAP output', () => {
+  const sameTap = tap({ failures: ['base failure'] });
+  const result = compareTapResults(
+    parseTapResult(sameTap, 1),
+    parseTapResult(`${sameTap}\nrunner crashed after tests`, 2),
+  );
+  assert.equal(result.passed, false);
+  assert.equal(result.kind, 'unclassified_failure');
+});
+
 test('distinguishes same-title failures by stable TAP diagnostics', () => {
   const withDiagnostic = (error, location = '/workspace/example.test.js:10:1') => [
     'TAP version 13',

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -7,11 +7,12 @@ const {
   parseTapResult,
 } = require('./compare-ci-test-baseline.cjs');
 
-const tap = ({ failures = [], fail = failures.length, cancelled = 0 } = {}) => [
+const tap = ({ failures = [], fail = failures.length, cancelled = 0, tests = 10 } = {}) => [
   'TAP version 13',
   ...failures.map((name, index) => `not ok ${index + 1} - ${name}`),
   `# fail ${fail}`,
   `# cancelled ${cancelled}`,
+  `# tests ${tests}`,
 ].join('\n');
 
 test('accepts a clean candidate even when the base was red', () => {
@@ -21,6 +22,15 @@ test('accepts a clean candidate even when the base was red', () => {
   );
   assert.equal(result.passed, true);
   assert.equal(result.kind, 'clean');
+});
+
+test('rejects a zero-exit candidate without a complete clean TAP summary', () => {
+  const result = compareTapResults(
+    parseTapResult(tap(), 0),
+    parseTapResult('custom test command completed', 0),
+  );
+  assert.equal(result.passed, false);
+  assert.equal(result.kind, 'unclassified_failure');
 });
 
 test('accepts only failures already present on the exact base', () => {
@@ -65,4 +75,20 @@ test('fails closed when a red run has no complete TAP summary', () => {
   );
   assert.equal(result.passed, false);
   assert.equal(result.kind, 'unclassified_failure');
+});
+
+test('rejects non-test failures and a candidate that runs fewer tests', () => {
+  const posttestFailure = compareTapResults(
+    parseTapResult(tap({ failures: ['existing'] }), 1),
+    parseTapResult(tap({ fail: 0 }), 1),
+  );
+  assert.equal(posttestFailure.passed, false);
+  assert.equal(posttestFailure.kind, 'unclassified_failure');
+
+  const fewerTests = compareTapResults(
+    parseTapResult(tap({ failures: ['existing'], tests: 20 }), 1),
+    parseTapResult(tap({ failures: ['existing'], tests: 19 }), 1),
+  );
+  assert.equal(fewerTests.passed, false);
+  assert.equal(fewerTests.kind, 'unclassified_failure');
 });

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -63,11 +63,11 @@ test('rejects a different candidate failure even when both runs are red', () => 
 });
 
 test('distinguishes same-title failures by stable TAP diagnostics', () => {
-  const withDiagnostic = (error) => [
+  const withDiagnostic = (error, location = '/workspace/example.test.js:10:1') => [
     'TAP version 13',
     'not ok 1 - duplicate title',
     '  ---',
-    "  location: '/workspace/example.test.js:10:1'",
+    `  location: '${location}'`,
     "  failureType: 'testCodeFailure'",
     `  error: '${error}'`,
     "  code: 'ERR_ASSERTION'",
@@ -83,6 +83,12 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
     parseTapResult(withDiagnostic('old failure'), 1),
   );
   assert.equal(same.passed, true);
+
+  const moved = compareTapResults(
+    parseTapResult(withDiagnostic('old failure'), 1),
+    parseTapResult(withDiagnostic('old failure', '/workspace/example.test.js:11:1'), 1),
+  );
+  assert.equal(moved.passed, true);
 
   const changed = compareTapResults(
     parseTapResult(withDiagnostic('old failure'), 1),

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -137,6 +137,26 @@ test('rejects an additional runner failure after comparable TAP output', () => {
   assert.equal(crashInsideUnattachedYamlMarkers.passed, false);
   assert.equal(crashInsideUnattachedYamlMarkers.kind, 'unclassified_failure');
 
+  const diagnosticTap = (closed) => [
+    'TAP version 13',
+    'not ok 1 - base failure',
+    '  ---',
+    "  error: 'existing failure'",
+    "  code: 'ERR_TEST_FAILURE'",
+    ...(closed ? ['  ...'] : []),
+    '# fail 1',
+    '# cancelled 0',
+    '# skipped 0',
+    '# todo 0',
+    '# tests 10',
+  ].join('\n');
+  const crashAfterUnterminatedDiagnostic = compareTapResults(
+    parseTapResult(diagnosticTap(true), 1),
+    parseTapResult(`${diagnosticTap(false)}\nSegmentation fault (core dumped)`, 1),
+  );
+  assert.equal(crashAfterUnterminatedDiagnostic.passed, false);
+  assert.equal(crashAfterUnterminatedDiagnostic.kind, 'unclassified_failure');
+
   const unchangedArbitraryOutput = compareTapResults(
     parseTapResult(`starting custom runner\n${sameTap}`, 1),
     parseTapResult(`starting custom runner\n${sameTap}`, 1),

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -79,6 +79,13 @@ test('rejects an additional runner failure after comparable TAP output', () => {
   );
   assert.equal(sameExit.passed, false);
   assert.equal(sameExit.kind, 'unclassified_failure');
+
+  const preSummaryCrash = compareTapResults(
+    parseTapResult(sameTap, 1),
+    parseTapResult(`runner crashed before summary\n${sameTap}`, 1),
+  );
+  assert.equal(preSummaryCrash.passed, false);
+  assert.equal(preSummaryCrash.kind, 'unclassified_failure');
 });
 
 test('distinguishes same-title failures by stable TAP diagnostics', () => {

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -7,9 +7,10 @@ const {
   parseTapResult,
 } = require('./compare-ci-test-baseline.cjs');
 
-const tap = ({ failures = [], fail = failures.length, cancelled = 0, skipped = 0, todo = 0, tests = 10 } = {}) => [
+const tap = ({ failures = [], successes = [], fail = failures.length, cancelled = 0, skipped = 0, todo = 0, tests = 10 } = {}) => [
   'TAP version 13',
   ...failures.map((name, index) => `not ok ${index + 1} - ${name}`),
+  ...successes.map((name, index) => `ok ${failures.length + index + 1} - ${name}`),
   `# fail ${fail}`,
   `# cancelled ${cancelled}`,
   `# skipped ${skipped}`,
@@ -30,6 +31,15 @@ test('rejects a zero-exit candidate without a complete clean TAP summary', () =>
   const result = compareTapResults(
     parseTapResult(tap(), 0),
     parseTapResult('custom test command completed', 0),
+  );
+  assert.equal(result.passed, false);
+  assert.equal(result.kind, 'unclassified_failure');
+});
+
+test('rejects replacing an existing successful test with an unrelated one', () => {
+  const result = compareTapResults(
+    parseTapResult(tap({ successes: ['kept test', 'removed test'] }), 0),
+    parseTapResult(tap({ successes: ['kept test', 'unrelated replacement'] }), 0),
   );
   assert.equal(result.passed, false);
   assert.equal(result.kind, 'unclassified_failure');
@@ -149,7 +159,7 @@ test('distinguishes same-title failures by stable TAP diagnostics', () => {
   ].join('\n');
   const dynamic = compareTapResults(
     parseTapResult(dynamicValues(41831, 'later test'), 1),
-    parseTapResult(dynamicValues(52942, 'renamed later test'), 1),
+    parseTapResult(dynamicValues(52942, 'later test'), 1),
   );
   assert.equal(dynamic.passed, true);
 

--- a/scripts/compare-ci-test-baseline.test.cjs
+++ b/scripts/compare-ci-test-baseline.test.cjs
@@ -157,6 +157,29 @@ test('rejects an additional runner failure after comparable TAP output', () => {
   assert.equal(crashAfterUnterminatedDiagnostic.passed, false);
   assert.equal(crashAfterUnterminatedDiagnostic.kind, 'unclassified_failure');
 
+  const diagnosticWithExtra = (extra) => [
+    'TAP version 13',
+    'not ok 1 - base failure',
+    '  ---',
+    "  error: 'existing failure'",
+    "  code: 'ERR_TEST_FAILURE'",
+    ...(extra ? [`  ${extra}`] : []),
+    '  ...',
+    '# fail 1',
+    '# cancelled 0',
+    '# skipped 0',
+    '# todo 0',
+    '# tests 10',
+  ].join('\n');
+  for (const extra of ['Segmentation fault (core dumped)', 'signal: SIGSEGV']) {
+    const crashInsideClosedDiagnostic = compareTapResults(
+      parseTapResult(diagnosticWithExtra(''), 1),
+      parseTapResult(diagnosticWithExtra(extra), 1),
+    );
+    assert.equal(crashInsideClosedDiagnostic.passed, false);
+    assert.equal(crashInsideClosedDiagnostic.kind, 'new_failures');
+  }
+
   const unchangedArbitraryOutput = compareTapResults(
     parseTapResult(`starting custom runner\n${sameTap}`, 1),
     parseTapResult(`starting custom runner\n${sameTap}`, 1),

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -3185,9 +3185,11 @@ async function prepareIssueFollowupContext({
     startOfDay.getTime(),
     botLogins,
   );
+  const simpleKind = classifySimpleIssueFollowup(pending);
   const rateLimited =
-    pending.length > 0 && followupsToday >= Math.max(1, Number(dailyLimit) || 20);
-  const simpleKind = rateLimited ? null : classifySimpleIssueFollowup(pending);
+    pending.length > 0 &&
+    !simpleKind &&
+    followupsToday >= Math.max(1, Number(dailyLimit) || 20);
   const labels = (issue.labels || []).map((label) =>
     typeof label === 'string' ? label : label.name,
   );

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -1306,7 +1306,7 @@ function findPendingIssueFollowups({
   const processed = extractProcessedIssueFollowupIds(list, botLogins);
   const watermark =
     extractIssueCommentWatermark(pull?.body) ||
-    (!pull ? extractIssueTriageWatermark(list, botLogins) : '');
+    extractIssueTriageWatermark(list, botLogins);
   const watermarkIndex = watermark
     ? list.findIndex((comment) => String(comment?.id) === watermark)
     : -1;
@@ -1318,7 +1318,7 @@ function findPendingIssueFollowups({
     ? list.findIndex((comment) => String(comment?.id) === triggerId)
     : -1;
   let lastAutomationReplyIndex = -1;
-  if (!pull && !watermark) {
+  if (!watermark) {
     const bots = normalizeLoginList(botLogins, [
       'netcatty-bot',
       'github-actions[bot]',
@@ -1361,12 +1361,82 @@ function findPendingIssueFollowups({
       }
       return id === triggerId;
     }
+    if (lastAutomationReplyIndex >= 0) {
+      return index > lastAutomationReplyIndex;
+    }
     if (Number.isFinite(pullCreatedAt)) {
       const createdAt = Date.parse(comment?.created_at || comment?.createdAt || '');
       return Number.isFinite(createdAt) && createdAt > pullCreatedAt;
     }
     return true;
   });
+}
+
+function classifySimpleIssueFollowup(comments = []) {
+  if (!comments.length) return null;
+  const kinds = [];
+  for (const comment of comments) {
+    const text = sanitizeUntrustedText(comment?.body, 1_000)
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('>'))
+      .join(' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    const unresolved = /(?:未解决|没解决|仍然|还是|not\s+(?:fixed|resolved|working)|still\s+(?:broken|fails?|not\s+working))/i.test(text);
+    if (unresolved) return null;
+    const resolved = /^(?:已(?:经)?解决|解决了|问题已解决|现在好了|已经好了|恢复正常|resolved|solved|fixed now|it works now|working now)[，,。.！!\s]*(?:谢谢|感谢(?:你|回复|帮助)?|thanks?(?: you)?[.!\s]*)?$/iu.test(text);
+    const thanks = /^(?:谢谢|感谢(?:你|回复|帮助)?|收到[，,。.！!\s]*(?:谢谢|感谢)?|thanks?(?: you)?|got it[,.!\s]*(?:thanks?)?)[。.！!\s]*$/iu.test(text);
+    if (!resolved && !thanks) return null;
+    kinds.push(resolved ? 'resolved' : 'acknowledgement');
+  }
+  return kinds.includes('resolved') ? 'resolved' : 'acknowledgement';
+}
+
+function buildSimpleIssueFollowupReply(issue = {}, kind = 'acknowledgement') {
+  const chinese = /[\u3400-\u9fff]/u.test(`${issue.title || ''}\n${issue.body || ''}`);
+  if (kind === 'resolved') {
+    return chinese
+      ? '收到，很高兴问题已经解决。这条补充已记录，不需要再转给维护者处理。'
+      : 'Thanks for confirming that the problem is resolved. We recorded the update; no maintainer handoff is needed.';
+  }
+  return chinese
+    ? '收到，谢谢反馈。这条回复不需要额外处理。'
+    : 'Thanks for the update. No additional action is needed for this reply.';
+}
+
+function nextSourceIssueLabelsAfterPull(existing = [], merged = false) {
+  const remove = new Set(['ready-for-agent', 'needs-info', 'ready-for-human']);
+  const labels = (existing || [])
+    .map((label) => (typeof label === 'string' ? label : label?.name))
+    .filter((label) => label && !remove.has(label));
+  if (!merged) labels.push('ready-for-human');
+  return [...new Set(labels)];
+}
+
+function buildImplementationFailureMessage(issue = {}, {
+  kind = 'processing_failed',
+  workflowUrl = '',
+  artifactName = '',
+} = {}) {
+  const chinese = /[\u3400-\u9fff]/u.test(`${issue.title || ''}\n${issue.body || ''}`);
+  const link = workflowUrl ? (chinese ? `查看本次运行：${workflowUrl}` : `View this run: ${workflowUrl}`) : '';
+  const artifact = artifactName
+    ? (chinese ? `候选补丁和验证报告已保存为 ${artifactName}。` : `The candidate patch and verification report were preserved as ${artifactName}.`)
+    : '';
+  const messages = chinese
+    ? {
+        verification_failed: '自动修改已经完成，但本次改动新增了验证失败，因此没有创建 PR。',
+        protected_path: '自动修改涉及受保护的发布或自动化文件，安全规则已停止发布。',
+        no_changes: 'Cursor 没有产出可安全提交的聚焦修改，已转给维护者继续判断。',
+        processing_failed: '自动修改流程自身没有正常完成，已转给维护者继续处理。',
+      }
+    : {
+        verification_failed: 'The automatic change completed, but it introduced a verification failure, so no PR was created.',
+        protected_path: 'The automatic change touched protected release or automation files, so the safety gate stopped publication.',
+        no_changes: 'Cursor did not produce a safe focused change. A maintainer needs to continue the investigation.',
+        processing_failed: 'The automation process itself did not finish normally. A maintainer needs to continue.',
+      };
+  return [messages[kind] || messages.processing_failed, artifact, link].filter(Boolean).join('\n\n');
 }
 
 function buildIssueFollowupReply({
@@ -2223,8 +2293,7 @@ function listProtectedPathHits(filePaths) {
         normalized.startsWith(prefix),
     );
     const baseHit = PROTECTED_PATH_BASENAMES.includes(base);
-    const builderHit = /electron-builder/i.test(normalized);
-    if (prefixHit || baseHit || builderHit) {
+    if (prefixHit || baseHit) {
       hits.push(normalized);
     }
   }
@@ -2719,7 +2788,13 @@ async function applyClassification({
   return classification;
 }
 
-async function markNeedsHuman({ github, context, issueNumber, message }) {
+async function markNeedsHuman({
+  github,
+  context,
+  issueNumber,
+  message,
+  dedupeMarker = '',
+}) {
   const owner = context.repo.owner;
   const repo = context.repo.repo;
   const { data: issue } = await github.rest.issues.get({
@@ -2741,14 +2816,27 @@ async function markNeedsHuman({ github, context, issueNumber, message }) {
     issue_number: issue.number,
     labels: next,
   });
+  const marker = String(dedupeMarker || '').trim();
+  if (marker) {
+    const comments = await github.paginate(github.rest.issues.listComments, {
+      owner,
+      repo,
+      issue_number: issue.number,
+      per_page: 100,
+    });
+    if ((comments || []).some((comment) => String(comment?.body || '').includes(marker))) {
+      return { issue, labels: next, commented: false };
+    }
+  }
   await github.rest.issues.createComment({
     owner,
     repo,
     issue_number: issue.number,
-    body: [TRIAGE_MARKER, '', sanitizeUntrustedText(message, 3_000)].join(
+    body: [TRIAGE_MARKER, marker, '', sanitizeUntrustedText(message, 3_000)].filter(Boolean).join(
       '\n',
     ),
   });
+  return { issue, labels: next, commented: true };
 }
 
 function isBotPrForIssue(pull, issueNumber) {
@@ -3063,6 +3151,7 @@ async function prepareIssueFollowupContext({
   );
   const rateLimited =
     pending.length > 0 && followupsToday >= Math.max(1, Number(dailyLimit) || 20);
+  const simpleKind = rateLimited ? null : classifySimpleIssueFollowup(pending);
   const labels = (issue.labels || []).map((label) =>
     typeof label === 'string' ? label : label.name,
   );
@@ -3114,8 +3203,9 @@ async function prepareIssueFollowupContext({
     })),
   };
   writeJson(outputPath, payload);
-  setOutput(core, 'should_run', pending.length > 0 && !rateLimited);
+  setOutput(core, 'should_run', pending.length > 0 && !rateLimited && !simpleKind);
   setOutput(core, 'rate_limited', rateLimited);
+  setOutput(core, 'simple_kind', simpleKind || '');
   setOutput(core, 'issue_number', issue.number);
   setOutput(core, 'issue_url', issue.html_url || '');
   setOutput(core, 'issue_title', issue.title || '');
@@ -3143,8 +3233,9 @@ async function prepareIssueFollowupContext({
     }))),
   );
   return {
-    shouldRun: pending.length > 0 && !rateLimited,
+    shouldRun: pending.length > 0 && !rateLimited && !simpleKind,
     rateLimited,
+    simpleKind,
     issue,
     pull,
     pending,
@@ -3210,6 +3301,10 @@ module.exports = {
   extractIssueTriageWatermark,
   isEligibleIssueFollowupComment,
   findPendingIssueFollowups,
+  classifySimpleIssueFollowup,
+  buildSimpleIssueFollowupReply,
+  nextSourceIssueLabelsAfterPull,
+  buildImplementationFailureMessage,
   buildIssueFollowupReply,
   buildIssueFollowupFallbackReply,
   buildPullRequestComment,

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -2794,6 +2794,7 @@ async function markNeedsHuman({
   issueNumber,
   message,
   dedupeMarker = '',
+  trustedCommentAuthors = 'binaricat,netcatty-bot,github-actions[bot]',
 }) {
   const owner = context.repo.owner;
   const repo = context.repo.repo;
@@ -2818,13 +2819,23 @@ async function markNeedsHuman({
   });
   const marker = String(dedupeMarker || '').trim();
   if (marker) {
+    const trusted = normalizeLoginList(trustedCommentAuthors, [
+      'binaricat',
+      'netcatty-bot',
+      'github-actions[bot]',
+    ]);
     const comments = await github.paginate(github.rest.issues.listComments, {
       owner,
       repo,
       issue_number: issue.number,
       per_page: 100,
     });
-    if ((comments || []).some((comment) => String(comment?.body || '').includes(marker))) {
+    if ((comments || []).some((comment) => {
+      const author = String(
+        comment?.user?.login || comment?.author?.login || '',
+      ).toLowerCase();
+      return trusted.has(author) && String(comment?.body || '').includes(marker);
+    })) {
       return { issue, labels: next, commented: false };
     }
   }
@@ -2910,10 +2921,28 @@ async function findOpenBotPrForIssue({ github, context, issueNumber }) {
  * Maintainer/own-actor PRs that merely say `Fixes #N` must not stay draft
  * forever because issue comments lack automation processed markers.
  */
-function shouldGatePullOnSourceIssueFollowups(pull) {
+function shouldGatePullOnSourceIssueFollowups(pull, options = {}) {
   if (!pull) return false;
-  if (!extractSourceIssueNumber(pull)) return false;
   const body = String(pull.body || '');
+  if (!SOURCE_ISSUE_RE.test(body)) return false;
+  const trustedAuthors = normalizeLoginList(options.ownActors, [
+    'binaricat',
+    'netcatty-bot',
+    'github-actions[bot]',
+    'github-actions',
+  ]);
+  const author = String(pull.user?.login || pull.author?.login || '').toLowerCase();
+  if (!trustedAuthors.has(author)) return false;
+  const repository = String(options.repository || '').toLowerCase();
+  if (repository) {
+    const headRepo = String(
+      pull.head?.repo?.full_name || pull.head?.repo?.nameWithOwner || '',
+    ).toLowerCase();
+    const baseRepo = String(
+      pull.base?.repo?.full_name || pull.base?.repo?.nameWithOwner || repository,
+    ).toLowerCase();
+    if (!headRepo || headRepo !== repository || baseRepo !== repository) return false;
+  }
   if (isBotPrMarker(body)) return true;
   return (pull.labels || []).some((label) => {
     const name = typeof label === 'string' ? label : label?.name;
@@ -2926,10 +2955,14 @@ async function getPendingIssueFollowupsForPull({
   context,
   pull,
   botLogins = ['netcatty-bot', 'github-actions[bot]'],
+  ownActors = 'binaricat,netcatty-bot,github-actions[bot]',
 }) {
   const issueNumber = extractSourceIssueNumber(pull);
   if (!issueNumber) return { issue: null, pending: [], gated: false };
-  if (!shouldGatePullOnSourceIssueFollowups(pull)) {
+  if (!shouldGatePullOnSourceIssueFollowups(pull, {
+    ownActors,
+    repository: `${context.repo.owner}/${context.repo.repo}`,
+  })) {
     return { issue: null, pending: [], gated: false };
   }
   const { data: issue } = await github.rest.issues.get({

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -91,12 +91,15 @@ const PROTECTED_PATH_PREFIXES = Object.freeze([
   '.github/',
   '.cursor/',
   'scripts/cursor-automation',
+  'scripts/compare-ci-test-baseline',
   'scripts/prepare-cursor-research-input',
   'scripts/issue-triage',
   'scripts/release',
   'nix/',
   'signing/',
   'packaging/',
+  'package.json',
+  'package-lock.json',
 ]);
 
 /** Exact / basename-sensitive packaging and signing config files. */

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -2303,6 +2303,43 @@ function listProtectedPathHits(filePaths) {
   return hits;
 }
 
+function isTestSourcePath(filePath) {
+  const normalized = String(filePath || '').replace(/\\/g, '/');
+  return (
+    /(?:^|\/)[^/]+\.(?:test|spec)\.[cm]?[jt]sx?$/.test(normalized) ||
+    /(?:^|\/)__tests__\//.test(normalized)
+  );
+}
+
+function listModifiedExistingTestPaths({
+  gitStatusPorcelain = '',
+  nameStatusText = '',
+} = {}) {
+  const hits = [];
+  for (const line of String(gitStatusPorcelain || '').split('\n')) {
+    if (!line.trim()) continue;
+    const status = line.slice(0, 2);
+    if (status === '??' || status.includes('A')) continue;
+    const rest = line.slice(3).trim();
+    const paths = rest.includes(' -> ')
+      ? rest.split(' -> ').map((value) => unquoteGitPath(value.trim()))
+      : [unquoteGitPath(rest)];
+    hits.push(...paths.filter(isTestSourcePath));
+  }
+  for (const line of String(nameStatusText || '').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const parts = trimmed.split(/\t/);
+    const status = parts[0] || '';
+    if (/^A\d*$/.test(status)) continue;
+    const paths = /^R\d*/.test(status) && parts.length >= 3
+      ? [parts[1], parts[2]]
+      : parts.slice(1, 2);
+    hits.push(...paths.map(unquoteGitPath).filter(isTestSourcePath));
+  }
+  return [...new Set(hits)];
+}
+
 function hasProtectedChanges(gitStatusPorcelain) {
   return listProtectedPathHits(pathsFromGitStatusPorcelain(gitStatusPorcelain));
 }
@@ -2316,11 +2353,15 @@ function hasProtectedChangesInSources({
   const fromStatus = pathsFromGitStatusPorcelain(gitStatusPorcelain);
   const fromCommits = (changedFiles || []).map(String);
   const fromNameStatus = pathsFromGitDiffNameStatus(nameStatusText);
-  return listProtectedPathHits([
+  const protectedHits = listProtectedPathHits([
     ...fromStatus,
     ...fromCommits,
     ...fromNameStatus,
   ]);
+  return [...new Set([
+    ...protectedHits,
+    ...listModifiedExistingTestPaths({ gitStatusPorcelain, nameStatusText }),
+  ])];
 }
 
 function getCodexRoundFromComments(comments = [], options = {}) {

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -1704,12 +1704,16 @@ test('hasProtectedChangesInSources checks commit names', () => {
     gitStatusPorcelain: '',
     changedFiles: [
       '.github/workflows/x.yml',
+      'package-lock.json',
+      'scripts/compare-ci-test-baseline.cjs',
       'scripts/prepare-cursor-research-input.sh',
       'src/a.ts',
     ],
   });
   assert.deepEqual(hits, [
     '.github/workflows/x.yml',
+    'package-lock.json',
+    'scripts/compare-ci-test-baseline.cjs',
     'scripts/prepare-cursor-research-input.sh',
   ]);
 });

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -805,6 +805,43 @@ test('implementation failure messages report the real category and preserved art
   assert.match(message, /github\.example/);
 });
 
+test('markNeedsHuman ignores forged dedupe markers from untrusted commenters', async () => {
+  let created = 0;
+  let comments = [{
+    user: { login: 'mallory' },
+    body: '<!-- cursor-implement-failure:base=abc;kind=no_changes -->',
+  }];
+  const github = {
+    rest: {
+      issues: {
+        get: async () => ({ data: { number: 42, labels: [] } }),
+        update: async () => ({ data: {} }),
+        listComments: Symbol('listComments'),
+        createComment: async () => { created += 1; return { data: {} }; },
+      },
+    },
+    paginate: async () => comments,
+  };
+  const args = {
+    github,
+    context: { repo: { owner: 'binaricat', repo: 'Netcatty' } },
+    issueNumber: 42,
+    message: 'failure details',
+    dedupeMarker: '<!-- cursor-implement-failure:base=abc;kind=no_changes -->',
+  };
+  const first = await auto.markNeedsHuman(args);
+  assert.equal(first.commented, true);
+  assert.equal(created, 1);
+
+  comments = [{
+    user: { login: 'netcatty-bot' },
+    body: args.dedupeMarker,
+  }];
+  const second = await auto.markNeedsHuman(args);
+  assert.equal(second.commented, false);
+  assert.equal(created, 1);
+});
+
 test('workflow cleans source labels on automation PR close and dedupes clean notices', () => {
   const workflow = fs.readFileSync(
     path.join(__dirname, '..', '.github', 'workflows', 'cursor-automation.yml'),
@@ -812,7 +849,13 @@ test('workflow cleans source labels on automation PR close and dedupes clean not
   );
   assert.match(workflow, /types: \[opened, synchronize, reopened, ready_for_review, closed\]/);
   assert.match(workflow, /kind == 'source_issue_cleanup'/);
-  assert.match(workflow, /nextSourceIssueLabelsAfterPull/);
+  assert.match(workflow, /shouldGatePullOnSourceIssueFollowups\(pull/);
+  assert.match(workflow, /github\.rest\.issues\.removeLabel/);
+  assert.match(workflow, /github\.rest\.issues\.addLabels/);
+  assert.match(workflow, /not a trusted automation pull request; skipping source cleanup/);
+  assert.match(workflow, /Follow-up changed before the simple reply; dispatched a fresh review/);
+  assert.match(workflow, /is merged; skipped stale follow-up handoff state changes/);
+  assert.match(workflow, /trusted_comment_bodies/);
   assert.match(workflow, /cursor-codex-clean-head:/);
   assert.match(workflow, /Clean handoff already recorded/);
 });
@@ -961,10 +1004,13 @@ test('buildIssueFollowupFallbackReply follows the reporter language', () => {
 test('getPendingIssueFollowupsForPull protects ready state with live issue comments', async () => {
   const pull = {
     number: 77,
-    body: `${auto.BOT_PR_MARKER}\n<!-- cursor-issue-watermark:comment-id=1 -->\nFixes #42`,
+    body: `${auto.BOT_PR_MARKER}\n<!-- cursor-source-issue:42 -->\n<!-- cursor-issue-watermark:comment-id=1 -->\nFixes #42`,
     created_at: '2026-07-24T10:00:00Z',
     labels: [{ name: 'automation:bot-pr' }],
     user: { login: 'netcatty-bot' },
+    user: { login: 'netcatty-bot' },
+    head: { repo: { full_name: 'binaricat/Netcatty' } },
+    base: { repo: { full_name: 'binaricat/Netcatty' } },
   };
   const github = {
     rest: {
@@ -1026,6 +1072,19 @@ test('shouldGatePullOnSourceIssueFollowups is limited to automation bot PRs', ()
       body: 'No closing keyword or automation marker',
       labels: [{ name: 'automation:bot-pr' }],
       user: { login: 'netcatty-bot' },
+    }),
+    false,
+  );
+  assert.equal(
+    auto.shouldGatePullOnSourceIssueFollowups({
+      body: `${auto.BOT_PR_MARKER}\n<!-- cursor-source-issue:42 -->\nFixes #42`,
+      labels: [{ name: 'automation:bot-pr' }],
+      user: { login: 'untrusted-collaborator' },
+      head: { repo: { full_name: 'binaricat/Netcatty' } },
+      base: { repo: { full_name: 'binaricat/Netcatty' } },
+    }, {
+      ownActors: 'binaricat,netcatty-bot,github-actions[bot]',
+      repository: 'binaricat/Netcatty',
     }),
     false,
   );
@@ -1292,6 +1351,7 @@ test('restoreCleanPullRequestAfterNoChange undoes ready when a comment races', a
     state: 'open',
     draft,
     body: `${auto.BOT_PR_MARKER}\n<!-- cursor-source-issue:42 -->\n<!-- cursor-issue-watermark:comment-id=1 -->\nFixes #42`,
+    user: { login: 'netcatty-bot' },
     head: {
       sha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       ref: 'cursor/issue-42-1',
@@ -1369,7 +1429,12 @@ test('restoreCleanPullRequestAfterNoChange ignores only the current batch', asyn
     state: 'open',
     draft,
     body: `${auto.BOT_PR_MARKER}\n<!-- cursor-source-issue:42 -->\n<!-- cursor-issue-watermark:comment-id=1 -->\nFixes #42`,
-    head: { sha: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' },
+    user: { login: 'netcatty-bot' },
+    head: {
+      sha: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      repo: { full_name: 'binaricat/Netcatty' },
+    },
+    base: { repo: { full_name: 'binaricat/Netcatty' } },
   });
   const github = {
     rest: {
@@ -1432,7 +1497,12 @@ test('restoreCleanPullRequestAfterNoChange rejects an edited current-batch comme
     state: 'open',
     draft: true,
     body: `${auto.BOT_PR_MARKER}\n<!-- cursor-source-issue:42 -->\n<!-- cursor-issue-watermark:comment-id=1 -->\nFixes #42`,
-    head: { sha: 'cccccccccccccccccccccccccccccccccccccccc' },
+    user: { login: 'netcatty-bot' },
+    head: {
+      sha: 'cccccccccccccccccccccccccccccccccccccccc',
+      repo: { full_name: 'binaricat/Netcatty' },
+    },
+    base: { repo: { full_name: 'binaricat/Netcatty' } },
   };
   const github = {
     rest: {
@@ -1749,6 +1819,12 @@ test('every code-writing Cursor path compares exact-base failures and preserves 
   assert.match(implement, /name: Fail after preserving rejected implementation/);
   assert.match(implement, /\.cursor-runtime\/verify-result\.json/);
   assert.match(implement, /\.cursor-runtime\/test-comparison\.json/);
+  assert.match(implement, /Validation scripts changed/);
+  assert.match(implement, /candidate-lint\.log/);
+  assert.ok(
+    implement.indexOf('name: Install test shell dependencies') <
+      implement.indexOf('name: Capture exact-base test baseline'),
+  );
   assert.doesNotMatch(
     implement,
     /name: Prepare patch for isolated publish\n\s+if:[^\n]*steps\.verify\.outputs\.passed/,
@@ -1758,6 +1834,11 @@ test('every code-writing Cursor path compares exact-base failures and preserves 
   assert.match(followup, /set -o pipefail/);
   assert.match(followup, /name: Fail after preserving rejected follow-up/);
   assert.match(followup, /followup-test-comparison\.json/);
+  assert.match(followup, /followup-candidate-build\.log/);
+  assert.ok(
+    followup.indexOf('name: Install test shell dependencies') <
+      followup.indexOf('name: Capture follow-up exact-base test baseline'),
+  );
   assert.doesNotMatch(
     followup,
     /name: Prepare follow-up patch\n\s+if:[^\n]*steps\.verify\.outputs\.passed/,
@@ -1768,6 +1849,11 @@ test('every code-writing Cursor path compares exact-base failures and preserves 
   assert.match(codex, /name: Fail after preserving rejected Codex fix/);
   assert.match(codex, /fix-test-comparison\.json/);
   assert.match(codex, /steps\.fixpatch\.outputs\.artifact_ready == 'true'/);
+  assert.match(codex, /fix-candidate-tests\.log/);
+  assert.ok(
+    codex.indexOf('name: Install test shell dependencies') <
+      codex.indexOf('name: Capture Codex-fix exact-base test baseline'),
+  );
 });
 
 test('classification failure handoff receives its issue number', () => {

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -853,9 +853,17 @@ test('workflow cleans source labels on automation PR close and dedupes clean not
   assert.match(workflow, /github\.rest\.issues\.removeLabel/);
   assert.match(workflow, /github\.rest\.issues\.addLabels/);
   assert.match(workflow, /not a trusted automation pull request; skipping source cleanup/);
+  assert.match(workflow, /is no longer closed; skipping source cleanup/);
+  assert.match(workflow, /source issue changed while queued; skipping cleanup/);
   assert.match(workflow, /Follow-up changed before the simple reply; dispatched a fresh review/);
   assert.match(workflow, /is merged; skipped stale follow-up handoff state changes/);
   assert.match(workflow, /trusted_comment_bodies/);
+  const classify = workflow.match(/\n  classify:\n[\s\S]*?(?=\n  cursor_smoke:|\n  issue_followup:)/)?.[0] || '';
+  const followup = workflow.match(/\n  issue_followup:\n[\s\S]*?(?=\n  publish_issue_followup:)/)?.[0] || '';
+  assert.match(classify, /actions: read/);
+  assert.doesNotMatch(classify, /actions: write/);
+  assert.match(followup, /actions: write/);
+  assert.match(followup, /createWorkflowDispatch/);
   assert.match(workflow, /cursor-codex-clean-head:/);
   assert.match(workflow, /Clean handoff already recorded/);
 });

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -1260,12 +1260,20 @@ test('prepareIssueFollowupContext shortcuts simple resolved replies without Curs
         listComments: Symbol('listComments'),
       },
     },
-    paginate: async () => [{
-      id: 9,
-      user: { login: 'alice', type: 'User' },
-      body: '已解决，谢谢',
-      created_at: '2026-07-24T10:00:00Z',
-    }],
+    paginate: async () => [
+      {
+        id: 8,
+        user: { login: 'netcatty-bot', type: 'Bot' },
+        body: '<!-- cursor-followup:comment-id=7;result=no_change -->',
+        created_at: '2026-07-24T09:00:00Z',
+      },
+      {
+        id: 9,
+        user: { login: 'alice', type: 'User' },
+        body: '已解决，谢谢',
+        created_at: '2026-07-24T10:00:00Z',
+      },
+    ],
   };
   const result = await auto.prepareIssueFollowupContext({
     github,
@@ -1274,11 +1282,14 @@ test('prepareIssueFollowupContext shortcuts simple resolved replies without Curs
     issueNumber: 42,
     triggerCommentId: 9,
     outputPath: path.join(dir, 'followup.json'),
+    dailyLimit: 1,
+    nowMs: Date.parse('2026-07-24T12:00:00Z'),
   });
   assert.equal(result.shouldRun, false);
   assert.equal(result.simpleKind, 'resolved');
   assert.equal(outputs.simple_kind, 'resolved');
   assert.equal(outputs.should_run, 'false');
+  assert.equal(outputs.rate_limited, 'false');
 });
 
 test('prepareIssueFollowupContext hands off after the daily follow-up limit', async () => {

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -1734,6 +1734,25 @@ test('hasProtectedChangesInSources checks commit names', () => {
   ]);
 });
 
+test('generated changes may add tests but cannot alter existing test sources', () => {
+  const committed = auto.hasProtectedChangesInSources({
+    nameStatusText: [
+      'M\tcomponents/existing.test.ts',
+      'A\tcomponents/new-regression.test.ts',
+      'M\tcomponents/App.tsx',
+    ].join('\n'),
+  });
+  assert.deepEqual(committed, ['components/existing.test.ts']);
+
+  const workingTree = auto.hasProtectedChangesInSources({
+    gitStatusPorcelain: [
+      ' M components/other.test.ts',
+      '?? components/new-regression-2.test.ts',
+    ].join('\n'),
+  });
+  assert.deepEqual(workingTree, ['components/other.test.ts']);
+});
+
 test('hasProtectedChangesInSources blocks electron-builder configs', () => {
   const hits = auto.hasProtectedChangesInSources({
     changedFiles: ['electron-builder.config.cjs', 'components/App.tsx', 'nix/release.nix'],

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -877,10 +877,15 @@ test('simple follow-ups immediately recheck linked clean pull requests', () => {
     /- name: Handle simple resolution or acknowledgement[\s\S]*?(?=\n\s{6}- name:)/,
   )?.[0] || '';
   const recordReply = simpleStep.indexOf('await github.rest.issues.createComment');
-  const recheckPull = simpleStep.indexOf('await github.rest.actions.createWorkflowDispatch', recordReply);
+  const recheckPull = simpleStep.indexOf('await queuePullReadinessCheck()', recordReply);
+  const removedBranch = simpleStep.match(
+    /if \(!livePending\.length\) \{[\s\S]*?return;/,
+  )?.[0] || '';
 
   assert.ok(recordReply >= 0);
   assert.ok(recheckPull > recordReply);
+  assert.match(removedBranch, /await queuePullReadinessCheck\(\)/);
+  assert.match(simpleStep, /await github\.rest\.actions\.createWorkflowDispatch/);
   assert.match(simpleStep, /inputs: \{ pull_number: String\(pullNumber\) \}/);
   assert.match(simpleStep, /Queued a readiness check for PR/);
 });

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -1918,6 +1918,13 @@ test('every code-writing Cursor path compares exact-base failures and preserves 
     codex.indexOf('name: Install test shell dependencies') <
       codex.indexOf('name: Capture Codex-fix exact-base test baseline'),
   );
+  for (const section of [implement, followup, codex]) {
+    const restoreDependencies = section.indexOf('npm ci 2>&1 | tee');
+    const lintCandidate = section.indexOf('npm run lint 2>&1 | tee -a');
+    assert.ok(restoreDependencies >= 0);
+    assert.ok(lintCandidate > restoreDependencies);
+    assert.match(section, /restoring locked dependencies failed/);
+  }
 });
 
 test('classification failure handoff receives its issue number', () => {

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -62,7 +62,7 @@ test('workflow routes PR lifecycle events through pull_request_target', () => {
   );
   const triggers = workflow.match(/^on:\n[\s\S]*?^concurrency:/m)?.[0] || '';
 
-  assert.match(triggers, /pull_request_target:\n\s+types: \[opened, synchronize, reopened, ready_for_review\]/);
+  assert.match(triggers, /pull_request_target:\n\s+types: \[opened, synchronize, reopened, ready_for_review, closed\]/);
   assert.doesNotMatch(triggers, /^  pull_request:/m);
   assert.doesNotMatch(triggers, /^  pull_request_review:/m);
 });
@@ -739,6 +739,84 @@ test('findPendingIssueFollowups falls back to PR creation time without watermark
   assert.deepEqual(pending.map((comment) => comment.id), [2]);
 });
 
+test('findPendingIssueFollowups preserves comments posted after triage but before PR creation', () => {
+  const pending = auto.findPendingIssueFollowups({
+    comments: [
+      {
+        id: 10,
+        user: { login: 'netcatty-bot', type: 'User' },
+        body: `${auto.TRIAGE_MARKER}\nThanks for the report.`,
+        created_at: '2026-07-24T09:00:00Z',
+      },
+      {
+        id: 11,
+        user: { login: 'alice', type: 'User' },
+        body: 'Keep history in the current session only.',
+        created_at: '2026-07-24T09:30:00Z',
+      },
+    ],
+    issueAuthorLogin: 'alice',
+    pull: {
+      body: `${auto.BOT_PR_MARKER}\nFixes #42`,
+      created_at: '2026-07-24T10:00:00Z',
+    },
+  });
+  assert.deepEqual(pending.map((comment) => comment.id), [11]);
+});
+
+test('simple issue follow-ups distinguish resolution and thanks from unresolved reports', () => {
+  assert.equal(
+    auto.classifySimpleIssueFollowup([{ body: '已解决，谢谢' }]),
+    'resolved',
+  );
+  assert.equal(
+    auto.classifySimpleIssueFollowup([{ body: '> previous reply\n收到，谢谢' }]),
+    'acknowledgement',
+  );
+  assert.equal(
+    auto.classifySimpleIssueFollowup([{ body: '还是没有解决，谢谢' }]),
+    null,
+  );
+});
+
+test('source issue labels clear stale agent state after PR completion', () => {
+  const existing = ['bug', 'triage', 'ready-for-agent', 'needs-info'];
+  assert.deepEqual(
+    auto.nextSourceIssueLabelsAfterPull(existing, true),
+    ['bug', 'triage'],
+  );
+  assert.deepEqual(
+    auto.nextSourceIssueLabelsAfterPull(existing, false),
+    ['bug', 'triage', 'ready-for-human'],
+  );
+});
+
+test('implementation failure messages report the real category and preserved artifact', () => {
+  const message = auto.buildImplementationFailureMessage(
+    { title: '[Bug] 上传失败' },
+    {
+      kind: 'verification_failed',
+      workflowUrl: 'https://github.example/run/1',
+      artifactName: 'implement-patch-1',
+    },
+  );
+  assert.match(message, /新增了验证失败/);
+  assert.match(message, /implement-patch-1/);
+  assert.match(message, /github\.example/);
+});
+
+test('workflow cleans source labels on automation PR close and dedupes clean notices', () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, '..', '.github', 'workflows', 'cursor-automation.yml'),
+    'utf8',
+  );
+  assert.match(workflow, /types: \[opened, synchronize, reopened, ready_for_review, closed\]/);
+  assert.match(workflow, /kind == 'source_issue_cleanup'/);
+  assert.match(workflow, /nextSourceIssueLabelsAfterPull/);
+  assert.match(workflow, /cursor-codex-clean-head:/);
+  assert.match(workflow, /Clean handoff already recorded/);
+});
+
 test('findPendingIssueFollowups coalesces rapid no-PR comments after bot triage', () => {
   const pending = auto.findPendingIssueFollowups({
     comments: [
@@ -1076,6 +1154,47 @@ test('prepareIssueFollowupContext uses the triggering comment when no PR exists'
     outputPath: path.join(dir, 'followup-with-pull.json'),
   });
   assert.deepEqual(withPull.pending.map((comment) => comment.id), [9]);
+});
+
+test('prepareIssueFollowupContext shortcuts simple resolved replies without Cursor', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-followup-simple-'));
+  const outputs = {};
+  const github = {
+    rest: {
+      issues: {
+        get: async () => ({
+          data: {
+            number: 42,
+            html_url: 'https://github.example/issues/42',
+            title: '[Bug] example',
+            body: 'details',
+            state: 'closed',
+            user: { login: 'alice' },
+            labels: [{ name: 'triage:admitted' }],
+          },
+        }),
+        listComments: Symbol('listComments'),
+      },
+    },
+    paginate: async () => [{
+      id: 9,
+      user: { login: 'alice', type: 'User' },
+      body: '已解决，谢谢',
+      created_at: '2026-07-24T10:00:00Z',
+    }],
+  };
+  const result = await auto.prepareIssueFollowupContext({
+    github,
+    context: { repo: { owner: 'o', repo: 'r' } },
+    core: { setOutput: (key, value) => { outputs[key] = String(value); } },
+    issueNumber: 42,
+    triggerCommentId: 9,
+    outputPath: path.join(dir, 'followup.json'),
+  });
+  assert.equal(result.shouldRun, false);
+  assert.equal(result.simpleKind, 'resolved');
+  assert.equal(outputs.simple_kind, 'resolved');
+  assert.equal(outputs.should_run, 'false');
 });
 
 test('prepareIssueFollowupContext hands off after the daily follow-up limit', async () => {
@@ -1596,6 +1715,59 @@ test('hasProtectedChanges flags workflow edits', () => {
     '.github/workflows/cursor-automation.yml',
     '.cursor/sandbox.json',
   ]);
+});
+
+test('protected paths allow ordinary electron-builder regression tests', () => {
+  assert.deepEqual(
+    auto.hasProtectedChanges(' M scripts/electron-builder-config.test.cjs\n'),
+    [],
+  );
+  assert.deepEqual(
+    auto.hasProtectedChanges(' M electron-builder.config.cjs\n'),
+    ['electron-builder.config.cjs'],
+  );
+});
+
+test('every code-writing Cursor path compares exact-base failures and preserves rejected patches', () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, '..', '.github', 'workflows', 'cursor-automation.yml'),
+    'utf8',
+  );
+  const implement = workflow.match(
+    /\n  implement:\n[\s\S]*?(?=\n  publish_implement:\n)/,
+  )?.[0] || '';
+  const followup = workflow.match(
+    /\n  issue_followup:\n[\s\S]*?(?=\n  publish_issue_followup:\n)/,
+  )?.[0] || '';
+  const codex = workflow.match(
+    /\n  codex_loop:\n[\s\S]*?(?=\n  publish_codex_fix:\n)/,
+  )?.[0] || '';
+  assert.match(implement, /name: Capture exact-base test baseline/);
+  assert.match(implement, /compare-ci-test-baseline\.cjs/);
+  assert.match(implement, /set -o pipefail/);
+  assert.match(implement, /steps\.patch\.outputs\.artifact_ready == 'true'/);
+  assert.match(implement, /name: Fail after preserving rejected implementation/);
+  assert.match(implement, /\.cursor-runtime\/verify-result\.json/);
+  assert.match(implement, /\.cursor-runtime\/test-comparison\.json/);
+  assert.doesNotMatch(
+    implement,
+    /name: Prepare patch for isolated publish\n\s+if:[^\n]*steps\.verify\.outputs\.passed/,
+  );
+  assert.match(followup, /name: Capture follow-up exact-base test baseline/);
+  assert.match(followup, /\$RUNNER_TEMP\/compare-ci-test-baseline\.cjs/);
+  assert.match(followup, /set -o pipefail/);
+  assert.match(followup, /name: Fail after preserving rejected follow-up/);
+  assert.match(followup, /followup-test-comparison\.json/);
+  assert.doesNotMatch(
+    followup,
+    /name: Prepare follow-up patch\n\s+if:[^\n]*steps\.verify\.outputs\.passed/,
+  );
+  assert.match(codex, /name: Capture Codex-fix exact-base test baseline/);
+  assert.match(codex, /\$RUNNER_TEMP\/compare-ci-test-baseline\.cjs/);
+  assert.match(codex, /set -o pipefail/);
+  assert.match(codex, /name: Fail after preserving rejected Codex fix/);
+  assert.match(codex, /fix-test-comparison\.json/);
+  assert.match(codex, /steps\.fixpatch\.outputs\.artifact_ready == 'true'/);
 });
 
 test('classification failure handoff receives its issue number', () => {

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -868,6 +868,23 @@ test('workflow cleans source labels on automation PR close and dedupes clean not
   assert.match(workflow, /Clean handoff already recorded/);
 });
 
+test('simple follow-ups immediately recheck linked clean pull requests', () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, '..', '.github', 'workflows', 'cursor-automation.yml'),
+    'utf8',
+  );
+  const simpleStep = workflow.match(
+    /- name: Handle simple resolution or acknowledgement[\s\S]*?(?=\n\s{6}- name:)/,
+  )?.[0] || '';
+  const recordReply = simpleStep.indexOf('await github.rest.issues.createComment');
+  const recheckPull = simpleStep.indexOf('await github.rest.actions.createWorkflowDispatch', recordReply);
+
+  assert.ok(recordReply >= 0);
+  assert.ok(recheckPull > recordReply);
+  assert.match(simpleStep, /inputs: \{ pull_number: String\(pullNumber\) \}/);
+  assert.match(simpleStep, /Queued a readiness check for PR/);
+});
+
 test('findPendingIssueFollowups coalesces rapid no-PR comments after bot triage', () => {
   const pending = auto.findPendingIssueFollowups({
     comments: [

--- a/scripts/github-workflow-build.test.cjs
+++ b/scripts/github-workflow-build.test.cjs
@@ -82,8 +82,8 @@ test("build workflow builds Linux x64 native modules in a glibc 2.28 container",
   assert.ok(x64Job, "build-linux-x64 job must be present before build-linux-arm64");
   assert.match(
     x64Job[0],
-    /container:\s*\n\s*image:\s*almalinux:8/,
-    "Linux x64 package job must build inside almalinux:8 for glibc 2.28 + modern GCC",
+    /container:[\s\S]*?image:\s*quay\.io\/almalinuxorg\/almalinux:8/,
+    "Linux x64 package job must build inside the official AlmaLinux 8 image for glibc 2.28 + modern GCC",
   );
   assert.equal(
     x64Job[0].includes("debian:buster"),

--- a/scripts/github-workflow-ci.test.cjs
+++ b/scripts/github-workflow-ci.test.cjs
@@ -170,11 +170,48 @@ test("Windows packaging reuses its dependency install for the ConPTY smoke test"
   assert.match(packageMatrix[0], /node electron\/bridges\/terminalBridge\.moshConpty\.integration\.cjs/);
 });
 
+test("package downloads use bounded retries and reusable caches", () => {
+  assert.match(buildWorkflow, /NPM_CONFIG_FETCH_RETRIES: "4"/);
+  assert.match(buildWorkflow, /NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "1000"/);
+  assert.match(buildWorkflow, /NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "10000"/);
+  assert.equal(
+    (buildWorkflow.match(/restore-keys:\s*\|\s*\n\s*electron-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-/g) ?? [])
+      .length,
+    3,
+    "all package jobs must reuse compatible Electron downloads after lockfile changes",
+  );
+
+  const linuxX64 = buildWorkflow.match(/\n  build-linux-x64:\n[\s\S]*?(?=\n  build-linux-arm64:)/)?.[0];
+  const linuxArm64 = buildWorkflow.match(/\n  build-linux-arm64:\n[\s\S]*?(?=\n  release:)/)?.[0];
+  assert.ok(linuxX64, "Linux x64 package job must be readable");
+  assert.ok(linuxArm64, "Linux arm64 package job must be readable");
+  assert.match(linuxX64, /image: quay\.io\/almalinuxorg\/almalinux:8/);
+  assert.match(linuxX64, /dnf -y --setopt=retries=4 --setopt=timeout=30 install/);
+  assert.match(
+    linuxX64,
+    /curl -fsSL --retry 4 --retry-connrefused --connect-timeout 20 --max-time 300/g,
+  );
+  assert.match(linuxArm64, /apt-get -o Acquire::Retries=4 update/);
+  assert.match(linuxArm64, /apt-get -o Acquire::Retries=4 install -y/);
+  assert.match(
+    linuxArm64,
+    /curl -fsSL --retry 4 --retry-all-errors --connect-timeout 20 --max-time 300/,
+  );
+});
+
 test("stable releases propose Nix metadata through a pull request", () => {
   const nixJob = buildWorkflow.match(/\n  update-nix-release:\n[\s\S]*?(?=\n  homebrew-tap:)/);
   assert.ok(nixJob, "update-nix-release job must exist before homebrew-tap");
   assert.doesNotMatch(nixJob[0], /git push origin HEAD:\$\{\{ github\.event\.repository\.default_branch \}\}/);
   assert.match(nixJob[0], /gh pr create/);
+  assert.ok(
+    nixJob[0].includes("GH_TOKEN: ${{ secrets.TRIAGE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}"),
+    "Nix PR creation must prefer the triage-capable token and safely fall back to the job token",
+  );
+  assert.ok(
+    nixJob[0].includes("token: ${{ secrets.RELEASE_TOKEN }}"),
+    "Nix branch pushes must keep using the release token",
+  );
   assert.match(nixJob[0], /automation\/nix-release-/);
   assert.match(nixJob[0], /candidate_tree/);
   assert.match(nixJob[0], /remote_tree/);

--- a/scripts/github-workflow-ci.test.cjs
+++ b/scripts/github-workflow-ci.test.cjs
@@ -192,6 +192,10 @@ test("package downloads use bounded retries and reusable caches", () => {
     /curl -fsSL --retry 4 --retry-connrefused --connect-timeout 20 --max-time 300/g,
   );
   assert.match(linuxArm64, /apt-get -o Acquire::Retries=4 update/);
+  assert.match(
+    linuxArm64,
+    /name: Install build dependencies\s*\n\s*shell: bash\s*\n\s*run: \|\s*\n\s*set -euo pipefail/,
+  );
   assert.match(linuxArm64, /apt-get -o Acquire::Retries=4 install -y/);
   assert.match(
     linuxArm64,


### PR DESCRIPTION
## Summary

Fix the current upload test regression and harden the CI and Cursor automation paths based on recent failure patterns.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [x] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Stop mutating read-only file path properties during SFTP upload preparation.
- Compare every Cursor-generated candidate against the exact pre-change test baseline and reject incomplete, reduced, or newly failing test runs.
- Preserve rejected patches, verification reports, and actual failure logs for maintainers.
- Revalidate edited follow-ups, PR heads, source issues, trusted authors, and closed/merged state before changing labels or publishing.
- Avoid duplicate automation comments and stale workflow labels without overwriting unrelated labels.
- Add bounded download retries, reusable Electron caches, an official AlmaLinux image, and the correct token split for Nix update PRs.

## Screenshots / Demo

Not applicable; no UI changes.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Additional validation: production build passed; workflow YAML parsing passed; focused workflow and upload tests passed; three review rounds ended with two independent CLEAN reviews on the latest head.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)