### PR TITLE
feat(terminal): add setting to show context menu over fullscreen apps (tmux/vim)

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -546,6 +546,9 @@ Highlight the focused split pane:
     'Adjust colors to meet contrast requirements (1 = disabled, 21 = max)',
   'settings.terminal.behavior.rightClick': 'Right-click behavior',
   'settings.terminal.behavior.rightClick.desc': 'Action when right-clicking in terminal',
+  'settings.terminal.behavior.rightClick.fullscreenMenu': 'Show menu over fullscreen apps',
+  'settings.terminal.behavior.rightClick.fullscreenMenu.desc':
+    'Show the context menu even when tmux, vim or other fullscreen apps take over the mouse. When off, right-click is passed to the app (Shift+Right-Click still opens the menu).',
   'settings.terminal.behavior.autoCloseOnExit': 'Auto-close terminal on exit',
   'settings.terminal.behavior.autoCloseOnExit.desc':
     'Allow terminal tabs and windows to close automatically after session exit. Turn this off to keep them open after every exit.',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -507,6 +507,9 @@ export const ruCoreMessages: Messages = {
     'Подстраивать цвета под требования контрастности (1 = отключено, 21 = максимум)',
   'settings.terminal.behavior.rightClick': 'Поведение правой кнопки мыши',
   'settings.terminal.behavior.rightClick.desc': 'Действие при щелчке правой кнопкой в терминале',
+  'settings.terminal.behavior.rightClick.fullscreenMenu': 'Показывать меню поверх полноэкранных приложений',
+  'settings.terminal.behavior.rightClick.fullscreenMenu.desc':
+    'Показывать контекстное меню, даже когда tmux, vim или другие полноэкранные приложения перехватывают мышь. Когда выключено, правый щелчок передаётся приложению (Shift+правый щелчок всё равно открывает меню).',
   'settings.terminal.behavior.autoCloseOnExit': 'Автоматически закрывать терминал при выходе',
   'settings.terminal.behavior.autoCloseOnExit.desc':
     'Разрешить автоматическое закрытие вкладок и окон терминала после завершения сеанса. Отключите, чтобы сохранять их после любого выхода.',

--- a/application/i18n/locales/zh-CN/terminal.ts
+++ b/application/i18n/locales/zh-CN/terminal.ts
@@ -281,6 +281,9 @@ export const zhCNTerminalMessages: Messages = {
   'settings.terminal.accessibility.minimumContrastRatio.desc': '调整颜色以满足对比度要求 (1 = 禁用, 21 = 最大)',
   'settings.terminal.behavior.rightClick': '右键行为',
   'settings.terminal.behavior.rightClick.desc': '在终端中右键时执行的操作',
+  'settings.terminal.behavior.rightClick.fullscreenMenu': '在全屏应用中也显示菜单',
+  'settings.terminal.behavior.rightClick.fullscreenMenu.desc':
+    '即使 tmux、vim 等全屏应用接管了鼠标，也显示右键菜单。关闭时右键会交给应用处理（Shift+右键仍可打开菜单）。',
   'settings.terminal.behavior.autoCloseOnExit': '退出后自动关闭终端',
   'settings.terminal.behavior.autoCloseOnExit.desc': '允许终端标签页和窗口在会话退出后自动关闭。关闭此项后，无论退出结果如何都会保留。',
   'settings.terminal.behavior.rightClick.menu': '显示菜单',

--- a/application/i18n/locales/zh-TW/terminal.ts
+++ b/application/i18n/locales/zh-TW/terminal.ts
@@ -281,6 +281,9 @@ export const zhTWTerminalMessages: Messages = {
   'settings.terminal.accessibility.minimumContrastRatio.desc': '調整顏色以滿足對比度要求 (1 = 停用, 21 = 最大)',
   'settings.terminal.behavior.rightClick': '右鍵行為',
   'settings.terminal.behavior.rightClick.desc': '在終端中右鍵時執行的操作',
+  'settings.terminal.behavior.rightClick.fullscreenMenu': '在全螢幕應用中也顯示選單',
+  'settings.terminal.behavior.rightClick.fullscreenMenu.desc':
+    '即使 tmux、vim 等全螢幕應用接管了滑鼠，也顯示右鍵選單。關閉時右鍵會交給應用處理（Shift+右鍵仍可開啟選單）。',
   'settings.terminal.behavior.autoCloseOnExit': '結束後自動關閉終端',
   'settings.terminal.behavior.autoCloseOnExit.desc': '允許終端標籤頁和視窗在工作階段結束後自動關閉。關閉此項後，無論結束結果如何都會保留。',
   'settings.terminal.behavior.rightClick.menu': '顯示選單',

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -206,7 +206,7 @@ const SYNCABLE_TERMINAL_KEYS = [
   'kittyKeyboardProtocolEnabled',
   'scrollOnInput', 'scrollOnOutput', 'scrollOnKeyPress', 'scrollOnPaste',
   'smoothScrolling',
-  'rightClickBehavior', 'middleClickBehavior', 'copyOnSelect', 'normalizeTextOnCopy', 'middleClickPaste', 'wordSeparators',
+  'rightClickBehavior', 'showContextMenuOverFullscreenApps', 'middleClickBehavior', 'copyOnSelect', 'normalizeTextOnCopy', 'middleClickPaste', 'wordSeparators',
   'linkModifier', 'keywordHighlightEnabled', 'keywordHighlightRules',
   'keepaliveInterval', 'keepaliveCountMax', 'disableBracketedPaste', 'clearWipesScrollback',
   'preserveSelectionOnInput', 'forcePromptNewLine', 'osc52Clipboard', 'dynamicTabTitleMode',

--- a/components/settings/tabs/TerminalBehaviorSettings.tsx
+++ b/components/settings/tabs/TerminalBehaviorSettings.tsx
@@ -66,6 +66,16 @@ export const TerminalBehaviorSettings: React.FC<TerminalBehaviorSettingsProps> =
         </SettingRow>
 
         <SettingRow
+          label={t("settings.terminal.behavior.rightClick.fullscreenMenu")}
+          description={t("settings.terminal.behavior.rightClick.fullscreenMenu.desc")}
+        >
+          <Toggle
+            checked={terminalSettings.showContextMenuOverFullscreenApps}
+            onChange={(v) => updateTerminalSetting("showContextMenuOverFullscreenApps", v)}
+          />
+        </SettingRow>
+
+        <SettingRow
           label={t("settings.terminal.behavior.copyOnSelect")}
           description={t("settings.terminal.behavior.copyOnSelect.desc")}
         >

--- a/components/terminal/TerminalContextMenu.test.ts
+++ b/components/terminal/TerminalContextMenu.test.ts
@@ -21,6 +21,7 @@ const shouldSuppressMouseTrackingContextMenu = (
     shouldSuppressMouseTrackingContextMenu?: (options: {
       isAlternateScreen?: boolean;
       showReconnectAction?: boolean;
+      forceMenuInAlternateScreen?: boolean;
     }) => boolean;
   }
 ).shouldSuppressMouseTrackingContextMenu;
@@ -41,6 +42,7 @@ const shouldOpenTerminalContextMenu = (
       rightClickBehavior?: "context-menu" | "paste" | "select-word";
       isAlternateScreen?: boolean;
       showReconnectAction?: boolean;
+      forceMenuInAlternateScreen?: boolean;
     }) => boolean;
   }
 ).shouldOpenTerminalContextMenu;
@@ -190,6 +192,47 @@ test("allows reconnect menu while stale mouse tracking is still active", () => {
     shouldSuppressMouseTrackingContextMenu({
       isAlternateScreen: true,
       showReconnectAction: false,
+    }),
+    true,
+  );
+});
+
+test("forceMenuInAlternateScreen opts out of alternate-screen suppression", () => {
+  assert.equal(typeof shouldSuppressMouseTrackingContextMenu, "function");
+  assert.equal(typeof shouldOpenTerminalContextMenu, "function");
+  if (
+    typeof shouldSuppressMouseTrackingContextMenu !== "function" ||
+    typeof shouldOpenTerminalContextMenu !== "function"
+  ) {
+    return;
+  }
+
+  // Setting on: no suppression, right-click opens the app menu in tmux/vim.
+  assert.equal(
+    shouldSuppressMouseTrackingContextMenu({
+      isAlternateScreen: true,
+      showReconnectAction: false,
+      forceMenuInAlternateScreen: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldOpenTerminalContextMenu({
+      event: { shiftKey: false, nativeEvent: {} as MouseEvent },
+      rightClickBehavior: "context-menu",
+      isAlternateScreen: true,
+      showReconnectAction: false,
+      forceMenuInAlternateScreen: true,
+    }),
+    true,
+  );
+
+  // Setting off (default): alternate screen still suppresses the menu.
+  assert.equal(
+    shouldSuppressMouseTrackingContextMenu({
+      isAlternateScreen: true,
+      showReconnectAction: false,
+      forceMenuInAlternateScreen: false,
     }),
     true,
   );

--- a/components/terminal/TerminalContextMenu.tsx
+++ b/components/terminal/TerminalContextMenu.tsx
@@ -44,6 +44,8 @@ export interface TerminalContextMenuProps {
   keyBindings?: KeyBinding[];
   rightClickBehavior?: RightClickBehavior;
   isAlternateScreen?: boolean;
+  /** When true, show the app context menu even while a fullscreen app (tmux/vim) holds mouse tracking. */
+  showContextMenuOverFullscreenApps?: boolean;
   onCopy?: () => void;
   onPaste?: () => void;
   onUploadClipboardImage?: () => void;
@@ -74,10 +76,12 @@ export const shouldShowReconnectAction = ({
 export const shouldSuppressMouseTrackingContextMenu = ({
   isAlternateScreen,
   showReconnectAction,
+  forceMenuInAlternateScreen,
 }: {
   isAlternateScreen?: boolean;
   showReconnectAction?: boolean;
-}): boolean => Boolean(isAlternateScreen && !showReconnectAction);
+  forceMenuInAlternateScreen?: boolean;
+}): boolean => Boolean(isAlternateScreen && !showReconnectAction && !forceMenuInAlternateScreen);
 
 export const shouldShowAddSelectionToAIContextMenuAction = (
   onAddSelectionToAI?: () => void,
@@ -91,36 +95,42 @@ export const shouldRenderTerminalContextMenuContent = ({
   isAlternateScreen,
   showReconnectAction,
   allowSuppressedMenuContent,
+  forceMenuInAlternateScreen,
 }: {
   isAlternateScreen?: boolean;
   showReconnectAction?: boolean;
   allowSuppressedMenuContent?: boolean;
+  forceMenuInAlternateScreen?: boolean;
 }): boolean =>
   allowSuppressedMenuContent ||
-  !shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction });
+  !shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction, forceMenuInAlternateScreen });
 
 export const shouldAllowSuppressedTerminalContextMenuContent = ({
   event,
   isAlternateScreen,
   showReconnectAction,
+  forceMenuInAlternateScreen,
 }: {
   event: { shiftKey?: boolean; nativeEvent: MouseEvent };
   isAlternateScreen?: boolean;
   showReconnectAction?: boolean;
+  forceMenuInAlternateScreen?: boolean;
 }): boolean =>
   isMiddleClickContextMenuEvent(event.nativeEvent)
-  || Boolean(event.shiftKey && shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction }));
+  || Boolean(event.shiftKey && shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction, forceMenuInAlternateScreen }));
 
 export const shouldOpenTerminalContextMenu = ({
   event,
   rightClickBehavior = 'context-menu',
   isAlternateScreen,
   showReconnectAction,
+  forceMenuInAlternateScreen,
 }: {
   event: { shiftKey?: boolean; nativeEvent: MouseEvent };
   rightClickBehavior?: RightClickBehavior;
   isAlternateScreen?: boolean;
   showReconnectAction?: boolean;
+  forceMenuInAlternateScreen?: boolean;
 }): boolean => {
   if (isMiddleClickContextMenuEvent(event.nativeEvent)) {
     return true;
@@ -130,7 +140,7 @@ export const shouldOpenTerminalContextMenu = ({
     return true;
   }
 
-  if (shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction })) {
+  if (shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction, forceMenuInAlternateScreen })) {
     return false;
   }
 
@@ -149,6 +159,7 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
   keyBindings,
   rightClickBehavior = 'context-menu',
   isAlternateScreen = false,
+  showContextMenuOverFullscreenApps = false,
   onCopy,
   onPaste,
   onUploadClipboardImage,
@@ -235,9 +246,10 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
         rightClickBehavior,
         isAlternateScreen,
         showReconnectAction,
+        forceMenuInAlternateScreen: showContextMenuOverFullscreenApps,
       });
 
-      if (!shouldOpenMenu && shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction })) {
+      if (!shouldOpenMenu && shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction, forceMenuInAlternateScreen: showContextMenuOverFullscreenApps })) {
         e.preventDefault();
         return;
       }
@@ -254,6 +266,7 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
           event: e,
           isAlternateScreen,
           showReconnectAction,
+          forceMenuInAlternateScreen: showContextMenuOverFullscreenApps,
         }));
         return;
       }
@@ -266,7 +279,7 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
         onSelectWord?.();
       }
     },
-    [rightClickBehavior, onPaste, onSelectWord, isAlternateScreen, showReconnectAction],
+    [rightClickBehavior, onPaste, onSelectWord, isAlternateScreen, showReconnectAction, showContextMenuOverFullscreenApps],
   );
 
   // Always use ContextMenu wrapper to maintain consistent React tree structure
@@ -283,6 +296,7 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
         isAlternateScreen,
         showReconnectAction,
         allowSuppressedMenuContent,
+        forceMenuInAlternateScreen: showContextMenuOverFullscreenApps,
       }) && (
         <ContextMenuContent className="w-max">
           <ContextMenuItem onClick={onCopy} disabled={!hasSelection}>

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -418,6 +418,7 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
       keyBindings={keyBindings}
       rightClickBehavior={terminalSettings?.rightClickBehavior}
       isAlternateScreen={hasMouseTracking}
+      showContextMenuOverFullscreenApps={terminalSettings?.showContextMenuOverFullscreenApps}
       onCopy={terminalContextActions.onCopy}
       onPaste={terminalContextActions.onPaste}
       onUploadClipboardImage={status === "connected" ? terminalContextActions.onUploadClipboardImage : undefined}

--- a/components/terminal/runtime/middleClickBehavior.test.ts
+++ b/components/terminal/runtime/middleClickBehavior.test.ts
@@ -68,6 +68,42 @@ test("mouse-tracking context menu capture lets Shift-modified mouse events pass 
   );
 });
 
+test("mouse-tracking context menu capture yields to the fullscreen-apps menu setting for context-menu clicks", () => {
+  // Setting on + context-menu behavior: do NOT intercept, so Radix opens the menu.
+  assert.equal(
+    shouldInterceptMouseTrackingContextMenu({
+      event: { shiftKey: false } as MouseEvent,
+      mouseTracking: true,
+      status: "connected",
+      rightClickBehavior: "context-menu",
+      forceMenuInAlternateScreen: true,
+    }),
+    false,
+  );
+  // Setting on but paste behavior: still intercept (setting is menu-only).
+  assert.equal(
+    shouldInterceptMouseTrackingContextMenu({
+      event: { shiftKey: false } as MouseEvent,
+      mouseTracking: true,
+      status: "connected",
+      rightClickBehavior: "paste",
+      forceMenuInAlternateScreen: true,
+    }),
+    true,
+  );
+  // Setting off (default): still intercept even for context-menu behavior.
+  assert.equal(
+    shouldInterceptMouseTrackingContextMenu({
+      event: { shiftKey: false } as MouseEvent,
+      mouseTracking: true,
+      status: "connected",
+      rightClickBehavior: "context-menu",
+      forceMenuInAlternateScreen: false,
+    }),
+    true,
+  );
+});
+
 test("Shift selection replay events are identifiable", () => {
   const event = {} as MouseEvent;
 
@@ -189,6 +225,31 @@ test("Shift right-click mousedown is stopped while connected mouse tracking is a
       status: "connected",
     }),
     true,
+  );
+});
+
+test("right-click mousedown is stopped when the fullscreen-apps menu setting forces the context menu", () => {
+  // Unmodified right-click + setting on + context-menu behavior: stop it, like Shift+right-click.
+  assert.equal(
+    shouldStopShiftRightClickMouseTrackingMouseDown({
+      event: { button: 2, shiftKey: false } as MouseEvent,
+      mouseTracking: true,
+      status: "connected",
+      rightClickBehavior: "context-menu",
+      forceMenuInAlternateScreen: true,
+    }),
+    true,
+  );
+  // Setting on but paste behavior: do not stop (menu-only setting).
+  assert.equal(
+    shouldStopShiftRightClickMouseTrackingMouseDown({
+      event: { button: 2, shiftKey: false } as MouseEvent,
+      mouseTracking: true,
+      status: "connected",
+      rightClickBehavior: "paste",
+      forceMenuInAlternateScreen: true,
+    }),
+    false,
   );
 });
 

--- a/components/terminal/runtime/middleClickBehavior.ts
+++ b/components/terminal/runtime/middleClickBehavior.ts
@@ -1,4 +1,4 @@
-import type { MiddleClickBehavior, TerminalSettings } from "../../../domain/models";
+import type { MiddleClickBehavior, RightClickBehavior, TerminalSettings } from "../../../domain/models";
 
 type MiddleClickSettings = Partial<Pick<TerminalSettings, "middleClickBehavior" | "middleClickPaste">>;
 const MIDDLE_CONTEXT_MENU_EVENT_KEY = "__netcattyMiddleContextMenu";
@@ -17,6 +17,10 @@ export interface MouseTrackingContextMenuCaptureState {
   event: MouseEvent;
   mouseTracking: boolean;
   status?: string | null;
+  /** The user's configured right-click action. */
+  rightClickBehavior?: RightClickBehavior;
+  /** When true, show the app context menu over fullscreen apps (tmux/vim). */
+  forceMenuInAlternateScreen?: boolean;
 }
 
 export interface ShiftMouseSelectionReplayState {
@@ -30,6 +34,10 @@ export interface ShiftRightClickMouseDownCaptureState {
   event: MouseEvent;
   mouseTracking: boolean;
   status?: string | null;
+  /** The user's configured right-click action. */
+  rightClickBehavior?: RightClickBehavior;
+  /** When true, show the app context menu over fullscreen apps (tmux/vim). */
+  forceMenuInAlternateScreen?: boolean;
 }
 
 export const resolveMiddleClickBehavior = (
@@ -69,15 +77,31 @@ export const markShiftSelectionReplayMouseEvent = (event: MouseEvent): MouseEven
 export const isShiftSelectionReplayMouseEvent = (event: MouseEvent): boolean =>
   (event as ShiftSelectionReplayMouseEvent)[SHIFT_SELECTION_REPLAY_EVENT_KEY] === true;
 
+// When the "show context menu over fullscreen apps" setting is on and the
+// right-click action is the context menu, an unmodified right-click should
+// behave like Shift+right-click: let the contextmenu event through so Radix
+// opens the app menu, and stop the button press from reaching the TUI. Paste /
+// select-word actions are unaffected — the setting is about the menu only.
+const forcesMenuOverMouseTracking = ({
+  rightClickBehavior,
+  forceMenuInAlternateScreen,
+}: {
+  rightClickBehavior?: RightClickBehavior;
+  forceMenuInAlternateScreen?: boolean;
+}): boolean => Boolean(forceMenuInAlternateScreen && rightClickBehavior === "context-menu");
+
 export const shouldInterceptMouseTrackingContextMenu = ({
   event,
   mouseTracking,
   status,
+  rightClickBehavior,
+  forceMenuInAlternateScreen,
 }: MouseTrackingContextMenuCaptureState): boolean =>
   mouseTracking
   && status === "connected"
   && !event.shiftKey
-  && !isMiddleClickContextMenuEvent(event);
+  && !isMiddleClickContextMenuEvent(event)
+  && !forcesMenuOverMouseTracking({ rightClickBehavior, forceMenuInAlternateScreen });
 
 export const shouldReplayShiftMouseSelectionAsMacOption = ({
   event,
@@ -99,11 +123,13 @@ export const shouldStopShiftRightClickMouseTrackingMouseDown = ({
   event,
   mouseTracking,
   status,
+  rightClickBehavior,
+  forceMenuInAlternateScreen,
 }: ShiftRightClickMouseDownCaptureState): boolean =>
   mouseTracking
   && status === "connected"
   && event.button === 2
-  && event.shiftKey;
+  && (event.shiftKey || forcesMenuOverMouseTracking({ rightClickBehavior, forceMenuInAlternateScreen }));
 
 export const createMacOptionForcedSelectionMouseEvent = (event: MouseEvent): MouseEvent =>
   markShiftSelectionReplayMouseEvent(new MouseEvent(event.type, {

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -1573,6 +1573,8 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         event: e,
         mouseTracking: mouseTrackingRef.current,
         status: statusRef.current,
+        rightClickBehavior: terminalSettingsRef.current?.rightClickBehavior,
+        forceMenuInAlternateScreen: terminalSettingsRef.current?.showContextMenuOverFullscreenApps,
       })) {
         return;
       }
@@ -1603,6 +1605,8 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         event: e,
         mouseTracking: mouseTrackingRef.current,
         status: statusRef.current,
+        rightClickBehavior: terminalSettingsRef.current?.rightClickBehavior,
+        forceMenuInAlternateScreen: terminalSettingsRef.current?.showContextMenuOverFullscreenApps,
       })) {
         e.stopImmediatePropagation();
         return;

--- a/domain/models/terminal.ts
+++ b/domain/models/terminal.ts
@@ -91,6 +91,8 @@ export interface TerminalSettings {
 
   // Mouse
   rightClickBehavior: RightClickBehavior;
+  // Show the app context menu even when a fullscreen app (tmux/vim) holds mouse tracking
+  showContextMenuOverFullscreenApps: boolean;
   middleClickBehavior: MiddleClickBehavior;
   copyOnSelect: boolean; // Automatically copy selected text
   /**
@@ -432,6 +434,7 @@ const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   scrollOnPaste: true,
   smoothScrolling: false,
   rightClickBehavior: 'context-menu',
+  showContextMenuOverFullscreenApps: false,
   middleClickBehavior: 'paste',
   copyOnSelect: false,
   normalizeTextOnCopy: true, // Clean soft wraps + padding on copy (opt-out available)


### PR DESCRIPTION
## Summary

Adds an opt-in terminal setting **"Show menu over fullscreen apps"** so users can get the right-click context menu even while a fullscreen app (tmux, vim, less) holds mouse tracking. Previously the right-click was always passed through to the app in the alternate screen, and the app menu was unreachable except via Shift+Right-Click.

The setting (`showContextMenuOverFullscreenApps`) defaults to **off**, so existing behavior is unchanged unless the user opts in.

## Type of Change

- [x] New feature

## Related Issue (optional)

N/A

## Changes Made

- `domain/models/terminal.ts` — new `showContextMenuOverFullscreenApps` field + default `false`.
- `application/syncPayload.ts` — include the key in the synced terminal settings.
- `components/terminal/TerminalContextMenu.tsx` — thread a new `forceMenuInAlternateScreen` flag through `shouldSuppressMouseTrackingContextMenu` (single source of truth) and its callers; new `showContextMenuOverFullscreenApps` prop.
- `components/terminal/TerminalView.tsx` — wire the setting to the prop.
- `components/settings/tabs/TerminalBehaviorSettings.tsx` — toggle row under "Right-click behavior".
- i18n `en`/`ru`/`zh-CN`/`zh-TW` — label + description.
- `components/terminal/TerminalContextMenu.test.ts` — coverage for the opt-out.

**Behavior/trade-off:** when the toggle is **on**, tmux/vim no longer receive native right-click (the app menu intercepts it). When **off** (default), Shift+Right-Click remains the escape hatch — documented in the setting description.

Note: this only affects the context menu. The absent scrollbar in tmux is unrelated — the alternate buffer has no scrollback for xterm to render; not touched here.

## Screenshots / Demo

Settings → Terminal → Behavior → new toggle "Show menu over fullscreen apps" beneath "Right-click behavior".

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`) — on touched files
- [x] Tests pass (`npm test`) — new case + full suite; remaining failures are pre-existing/flaky (SFTP transfer, scp abort, ssh-agent, script-runtime env), reproduced on clean `main` with these changes stashed
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
