### PR TITLE
feat(tabs): show host name on split-workspace tabs instead of "Workspace"

### DIFF
--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -626,7 +626,7 @@ export const useSessionState = ({
       
       setWorkspaceRenameTarget(prevTarget => {
         if (!prevTarget) return prevTarget;
-        setWorkspaces(prev => prev.map(w => w.id === prevTarget.id ? { ...w, title: name } : w));
+        setWorkspaces(prev => prev.map(w => w.id === prevTarget.id ? { ...w, title: name, autoTitle: false } : w));
         return null;
       });
       
@@ -652,6 +652,7 @@ export const useSessionState = ({
     // Create workspace
     const workspace = createWorkspaceFromSessionIds(sessionIds, {
       title: name,
+      autoTitle: false,
       viewMode: 'split',
     });
 
@@ -672,8 +673,12 @@ export const useSessionState = ({
     | { kind: 'local'; shellType?: TerminalSession['shellType']; shell?: string; shellArgs?: string[]; shellName?: string; shellIcon?: string }
     | { kind: 'host'; host: Host };
 
-  const createWorkspaceFromTargets = useCallback((targets: WorkspaceTarget[], name: string = DEFAULT_WORKSPACE_TITLE): string | null => {
+  const createWorkspaceFromTargets = useCallback((targets: WorkspaceTarget[], name?: string): string | null => {
     if (targets.length === 0) return null;
+    // A caller-provided name is an explicit title; without one the workspace is
+    // auto-titled and the tab derives a host-based label.
+    const explicitName = name?.trim();
+    const workspaceTitle = explicitName || DEFAULT_WORKSPACE_TITLE;
 
     const newSessions: TerminalSession[] = targets.map((target) => {
       if (target.kind === 'local') {
@@ -695,7 +700,8 @@ export const useSessionState = ({
     // count — matches the intent behind the QuickSwitcher "New
     // Workspace" flow, which the user expects to land in focus view.
     const workspace = createWorkspaceFromSessionIds(sessionIds, {
-      title: name,
+      title: workspaceTitle,
+      autoTitle: explicitName ? false : undefined,
       viewMode: 'focus',
     });
     const sessionsWithWorkspace = newSessions.map((s) => ({ ...s, workspaceId: workspace.id }));
@@ -1018,6 +1024,7 @@ export const useSessionState = ({
     // Create a focus mode workspace
     const workspace = createWorkspaceFromSessionIds(sessionIds, {
       title: snippet.label,
+      autoTitle: false,
       viewMode: 'focus',
       snippetId: snippet.id,
     });

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -59,6 +59,7 @@ import type { SessionRestorePayload } from '../../domain/sessionRestore';
 import { resolveRestorePreviousSessionSetting } from './sessionRestoreSettings';
 import type { CodingCliProviderId } from '../../domain/codingCliProviders';
 import { normalizeCodingCliDynamicTitleForStorage } from '../../domain/codingCliTitleParse';
+import { DEFAULT_WORKSPACE_TITLE } from '../../domain/sessionTabTitle';
 import { cleanupClosedTerminalSessions } from './aiStateSnapshots';
 
 export function addWorkspaceIfMissing(
@@ -671,7 +672,7 @@ export const useSessionState = ({
     | { kind: 'local'; shellType?: TerminalSession['shellType']; shell?: string; shellArgs?: string[]; shellName?: string; shellIcon?: string }
     | { kind: 'host'; host: Host };
 
-  const createWorkspaceFromTargets = useCallback((targets: WorkspaceTarget[], name: string = 'Workspace'): string | null => {
+  const createWorkspaceFromTargets = useCallback((targets: WorkspaceTarget[], name: string = DEFAULT_WORKSPACE_TITLE): string | null => {
     if (targets.length === 0) return null;
 
     const newSessions: TerminalSession[] = targets.map((target) => {

--- a/components/top-tabs/TopTabItems.tsx
+++ b/components/top-tabs/TopTabItems.tsx
@@ -922,7 +922,7 @@ export const WorkspaceTopTab: React.FC<WorkspaceTopTabProps> = memo(({
     [onCopyWorkspace, workspace.id],
   );
   const detachSessions = workspaceSessions ?? [];
-  const tabLabel = resolveWorkspaceTabLabel(workspace, detachSessions, dynamicTabTitleMode);
+  const tabLabel = resolveWorkspaceTabLabel(workspace, detachSessions);
 
   return (
     <ContextMenu>

--- a/components/top-tabs/TopTabItems.tsx
+++ b/components/top-tabs/TopTabItems.tsx
@@ -19,7 +19,7 @@ import { resolveHostIconAppearance, resolveHostIconColorAppearance } from '../..
 import { resolveSessionCodingCliProvider } from '../../domain/codingCliProviderMatch';
 import type { CodingCliProvider } from '../../domain/codingCliProviders';
 import { resolveCodingCliActivityPhase, type CodingCliActivityPhase } from '../../domain/codingCliTitleParse';
-import { resolveSessionTabTitle } from '../../domain/sessionTabTitle';
+import { resolveSessionTabTitle, resolveWorkspaceTabLabel } from '../../domain/sessionTabTitle';
 import type { DynamicTabTitleMode } from '../../domain/models';
 import { CodingCliProviderIcon } from '../icons/CodingCliProviderIcon';
 import { cn } from '../../lib/utils';
@@ -922,6 +922,7 @@ export const WorkspaceTopTab: React.FC<WorkspaceTopTabProps> = memo(({
     [onCopyWorkspace, workspace.id],
   );
   const detachSessions = workspaceSessions ?? [];
+  const tabLabel = resolveWorkspaceTabLabel(workspace, detachSessions, dynamicTabTitleMode);
 
   return (
     <ContextMenu>
@@ -986,7 +987,7 @@ export const WorkspaceTopTab: React.FC<WorkspaceTopTabProps> = memo(({
               className="shrink-0"
               style={{ color: isActive ? 'var(--top-tabs-accent, hsl(var(--accent)))' : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
             />
-            <span className="truncate leading-5">{workspace.title}</span>
+            <span className="truncate leading-5" title={tabLabel}>{tabLabel}</span>
           </div>
           <div className="flex items-center gap-1.5 shrink-0">
             {hasActivity && sessionStatusDot('connected', true)}

--- a/domain/models/workspace.ts
+++ b/domain/models/workspace.ts
@@ -32,4 +32,10 @@ export interface Workspace {
   focusedSessionId?: string; // Which session is focused when in focus mode
   focusSessionOrder?: string[]; // User-defined session order for the focus-mode sidebar
   snippetId?: string; // If this workspace was created from running a snippet
+  // Whether `title` is an explicit name the user/caller chose. `false` means a
+  // user rename or a named-at-creation workspace; `true`/absent means the tab
+  // may derive a host-based label instead of showing the generic default.
+  // Absent on legacy workspaces — the tab falls back to the default-title
+  // string check for those. See resolveWorkspaceTabLabel.
+  autoTitle?: boolean;
 }

--- a/domain/sessionRestore.test.ts
+++ b/domain/sessionRestore.test.ts
@@ -301,6 +301,51 @@ test("sanitizeSessionRestorePayload prunes invalid workspace panes and drops emp
   assert.equal(sanitized.activeTabId, "ws-1");
 });
 
+test("sanitizeSessionRestorePayload preserves explicit workspace autoTitle across restore", () => {
+  const workspace: Workspace = {
+    id: "ws-1",
+    title: "Workspace",
+    // User explicitly named this workspace "Workspace"; must not be relabeled.
+    autoTitle: false,
+    root: { id: "pane-1", type: "pane", sessionId: "s1" },
+    focusedSessionId: "s1",
+    focusSessionOrder: ["s1"],
+  };
+
+  const sanitized = sanitizeSessionRestorePayload({
+    version: 1,
+    savedAt: 1,
+    activeTabId: "ws-1",
+    tabOrder: ["ws-1"],
+    sessions: [session("s1", "ws-1")],
+    workspaces: [workspace],
+  });
+
+  assert.equal(sanitized.workspaces.length, 1);
+  assert.equal(sanitized.workspaces[0].autoTitle, false);
+});
+
+test("sanitizeSessionRestorePayload leaves legacy workspaces without an autoTitle flag", () => {
+  const workspace: Workspace = {
+    id: "ws-1",
+    title: "Workspace",
+    root: { id: "pane-1", type: "pane", sessionId: "s1" },
+    focusedSessionId: "s1",
+    focusSessionOrder: ["s1"],
+  };
+
+  const sanitized = sanitizeSessionRestorePayload({
+    version: 1,
+    savedAt: 1,
+    activeTabId: "ws-1",
+    tabOrder: ["ws-1"],
+    sessions: [session("s1", "ws-1")],
+    workspaces: [workspace],
+  });
+
+  assert.equal(sanitized.workspaces[0].autoTitle, undefined);
+});
+
 test("sanitizeSessionRestorePayload drops malformed session and workspace records", () => {
   const sanitized = sanitizeSessionRestorePayload({
     version: 1,

--- a/domain/sessionRestore.ts
+++ b/domain/sessionRestore.ts
@@ -355,6 +355,9 @@ const restoreWorkspace = (workspace: Workspace, root: WorkspaceNode, sessionIds:
       : sessionIds[0],
     focusSessionOrder: uniqueStrings(workspace.focusSessionOrder ?? []).filter((id) => sessionIdSet.has(id)),
     ...(workspace.snippetId ? { snippetId: workspace.snippetId } : {}),
+    // Preserve explicit-title state across restore; the boolean guard keeps a
+    // deliberate `autoTitle: false` (a user-named workspace) from being dropped.
+    ...(typeof workspace.autoTitle === "boolean" ? { autoTitle: workspace.autoTitle } : {}),
   };
 };
 

--- a/domain/sessionTabTitle.test.ts
+++ b/domain/sessionTabTitle.test.ts
@@ -171,6 +171,28 @@ test('resolveWorkspaceTabLabel shows the focused rename while counting hosts', (
   );
 });
 
+test('resolveWorkspaceTabLabel keeps a workspace explicitly named "Workspace"', () => {
+  // autoTitle:false marks the title as user-chosen even when it equals the
+  // default sentinel — it must not be replaced by a host label.
+  assert.equal(
+    resolveWorkspaceTabLabel(
+      { title: DEFAULT_WORKSPACE_TITLE, autoTitle: false, focusedSessionId: 's1' },
+      [{ id: 's1', hostLabel: 'web-01', hostId: 'host-web' }],
+    ),
+    'Workspace',
+  );
+});
+
+test('resolveWorkspaceTabLabel derives a label for an explicitly auto-titled workspace', () => {
+  assert.equal(
+    resolveWorkspaceTabLabel(
+      { title: DEFAULT_WORKSPACE_TITLE, autoTitle: true, focusedSessionId: 's1' },
+      [{ id: 's1', hostLabel: 'Localhost', hostId: 'local-terminal' }],
+    ),
+    'Localhost',
+  );
+});
+
 test('resolveWorkspaceTabLabel falls back to the default title with no sessions', () => {
   assert.equal(
     resolveWorkspaceTabLabel({ title: DEFAULT_WORKSPACE_TITLE, focusedSessionId: null }, []),

--- a/domain/sessionTabTitle.test.ts
+++ b/domain/sessionTabTitle.test.ts
@@ -142,6 +142,33 @@ test('resolveWorkspaceTabLabel shows a single host name without a suffix', () =>
   );
 });
 
+test('resolveWorkspaceTabLabel does not add a suffix when a same-host pane is renamed', () => {
+  assert.equal(
+    resolveWorkspaceTabLabel(
+      { title: DEFAULT_WORKSPACE_TITLE, focusedSessionId: 's1' },
+      [
+        { id: 's1', hostLabel: 'web-01' },
+        // Same host, but this pane was renamed by the user.
+        { id: 's2', customName: 'logs', hostLabel: 'web-01' },
+      ],
+    ),
+    'web-01',
+  );
+});
+
+test('resolveWorkspaceTabLabel shows the focused rename while counting hosts', () => {
+  assert.equal(
+    resolveWorkspaceTabLabel(
+      { title: DEFAULT_WORKSPACE_TITLE, focusedSessionId: 's1' },
+      [
+        { id: 's1', customName: 'my-web', hostLabel: 'web-01' },
+        { id: 's2', hostLabel: 'db-02' },
+      ],
+    ),
+    'my-web +1',
+  );
+});
+
 test('resolveWorkspaceTabLabel falls back to the default title with no sessions', () => {
   assert.equal(
     resolveWorkspaceTabLabel({ title: DEFAULT_WORKSPACE_TITLE, focusedSessionId: null }, []),

--- a/domain/sessionTabTitle.test.ts
+++ b/domain/sessionTabTitle.test.ts
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  DEFAULT_WORKSPACE_TITLE,
   getSessionConnectionLabel,
   resolveCodingCliProviderIconUpdate,
   resolveSessionTabTitle,
+  resolveWorkspaceTabLabel,
   shouldUpdateCodingCliTabIcon,
 } from './sessionTabTitle';
 
@@ -101,4 +103,48 @@ test('coding CLI icon updates stop without clearing the current icon when dynami
     currentProviderId: 'claude',
     nextProviderId: null,
   }), null);
+});
+
+test('resolveWorkspaceTabLabel keeps a user-renamed workspace title', () => {
+  assert.equal(
+    resolveWorkspaceTabLabel(
+      { title: 'My Cluster', focusedSessionId: 's1' },
+      [{ id: 's1', hostLabel: 'web-01' }],
+    ),
+    'My Cluster',
+  );
+});
+
+test('resolveWorkspaceTabLabel derives the focused host name from a default-title workspace', () => {
+  assert.equal(
+    resolveWorkspaceTabLabel(
+      { title: DEFAULT_WORKSPACE_TITLE, focusedSessionId: 's2' },
+      [
+        { id: 's1', hostLabel: 'Localhost' },
+        { id: 's2', hostLabel: 'prod-db' },
+      ],
+    ),
+    // Two distinct hosts: focused host + "+1" for the other.
+    'prod-db +1',
+  );
+});
+
+test('resolveWorkspaceTabLabel shows a single host name without a suffix', () => {
+  assert.equal(
+    resolveWorkspaceTabLabel(
+      { title: DEFAULT_WORKSPACE_TITLE, focusedSessionId: 's1' },
+      [
+        { id: 's1', hostLabel: 'Localhost' },
+        { id: 's2', hostLabel: 'Localhost' },
+      ],
+    ),
+    'Localhost',
+  );
+});
+
+test('resolveWorkspaceTabLabel falls back to the default title with no sessions', () => {
+  assert.equal(
+    resolveWorkspaceTabLabel({ title: DEFAULT_WORKSPACE_TITLE, focusedSessionId: null }, []),
+    DEFAULT_WORKSPACE_TITLE,
+  );
 });

--- a/domain/sessionTabTitle.test.ts
+++ b/domain/sessionTabTitle.test.ts
@@ -109,7 +109,7 @@ test('resolveWorkspaceTabLabel keeps a user-renamed workspace title', () => {
   assert.equal(
     resolveWorkspaceTabLabel(
       { title: 'My Cluster', focusedSessionId: 's1' },
-      [{ id: 's1', hostLabel: 'web-01' }],
+      [{ id: 's1', hostLabel: 'web-01', hostId: 'host-web' }],
     ),
     'My Cluster',
   );
@@ -120,8 +120,8 @@ test('resolveWorkspaceTabLabel derives the focused host name from a default-titl
     resolveWorkspaceTabLabel(
       { title: DEFAULT_WORKSPACE_TITLE, focusedSessionId: 's2' },
       [
-        { id: 's1', hostLabel: 'Localhost' },
-        { id: 's2', hostLabel: 'prod-db' },
+        { id: 's1', hostLabel: 'Localhost', hostId: 'local-terminal' },
+        { id: 's2', hostLabel: 'prod-db', hostId: 'host-db' },
       ],
     ),
     // Two distinct hosts: focused host + "+1" for the other.
@@ -134,8 +134,9 @@ test('resolveWorkspaceTabLabel shows a single host name without a suffix', () =>
     resolveWorkspaceTabLabel(
       { title: DEFAULT_WORKSPACE_TITLE, focusedSessionId: 's1' },
       [
-        { id: 's1', hostLabel: 'Localhost' },
-        { id: 's2', hostLabel: 'Localhost' },
+        // Two local terminals share the stable local hostId.
+        { id: 's1', hostLabel: 'Localhost', hostId: 'local-terminal' },
+        { id: 's2', hostLabel: 'Localhost', hostId: 'local-terminal' },
       ],
     ),
     'Localhost',
@@ -147,9 +148,10 @@ test('resolveWorkspaceTabLabel does not add a suffix when a same-host pane is re
     resolveWorkspaceTabLabel(
       { title: DEFAULT_WORKSPACE_TITLE, focusedSessionId: 's1' },
       [
-        { id: 's1', hostLabel: 'web-01' },
-        // Same host, but this pane was renamed by the user.
-        { id: 's2', customName: 'logs', hostLabel: 'web-01' },
+        { id: 's1', hostLabel: 'web-01', hostId: 'host-web' },
+        // Same host (hostId), but a rename rewrote this pane's customName AND
+        // hostLabel — hostId still ties it to the same host, so no "+1".
+        { id: 's2', customName: 'logs', hostLabel: 'logs', hostId: 'host-web' },
       ],
     ),
     'web-01',
@@ -161,8 +163,8 @@ test('resolveWorkspaceTabLabel shows the focused rename while counting hosts', (
     resolveWorkspaceTabLabel(
       { title: DEFAULT_WORKSPACE_TITLE, focusedSessionId: 's1' },
       [
-        { id: 's1', customName: 'my-web', hostLabel: 'web-01' },
-        { id: 's2', hostLabel: 'db-02' },
+        { id: 's1', customName: 'my-web', hostLabel: 'my-web', hostId: 'host-web' },
+        { id: 's2', hostLabel: 'db-02', hostId: 'host-db' },
       ],
     ),
     'my-web +1',

--- a/domain/sessionTabTitle.ts
+++ b/domain/sessionTabTitle.ts
@@ -15,7 +15,7 @@ export const getSessionConnectionLabel = (session: Pick<TerminalSession, 'custom
  */
 export const DEFAULT_WORKSPACE_TITLE = 'Workspace';
 
-type WorkspaceTabLabelSession = Pick<TerminalSession, 'id' | 'customName' | 'hostLabel'>;
+type WorkspaceTabLabelSession = Pick<TerminalSession, 'id' | 'customName' | 'hostLabel' | 'hostId'>;
 
 /**
  * Resolve the label shown on a split-workspace tab. When the user has renamed
@@ -44,11 +44,13 @@ export const resolveWorkspaceTabLabel = (
   }
   const focused = sessions.find((s) => s.id === workspace.focusedSessionId) ?? sessions[0];
   const primary = getSessionConnectionLabel(focused);
-  // Count distinct HOSTS by the host label alone, not the connection label: a
-  // per-session rename (customName) must not make two panes on the same host
-  // look like two hosts and add a spurious "+1". The focused pane may still
-  // show its rename as the primary label.
-  const distinctHosts = new Set(sessions.map((s) => s.hostLabel).filter(Boolean));
+  // Count distinct HOSTS by hostId, the only stable host identity: a rename
+  // rewrites both customName and hostLabel (useSessionState.submitSessionRename),
+  // so neither is safe to count by — a renamed pane on the same host would add a
+  // spurious "+1". hostId is shared across all local terminals and per host
+  // config, and is untouched by renames. The focused pane may still show its
+  // rename as the primary label.
+  const distinctHosts = new Set(sessions.map((s) => s.hostId).filter(Boolean));
   if (distinctHosts.size > 1) {
     return `${primary} +${distinctHosts.size - 1}`;
   }

--- a/domain/sessionTabTitle.ts
+++ b/domain/sessionTabTitle.ts
@@ -32,12 +32,17 @@ type WorkspaceTabLabelSession = Pick<TerminalSession, 'id' | 'customName' | 'hos
  * and produce a bogus "+N". The host identity is what this tab is about.
  */
 export const resolveWorkspaceTabLabel = (
-  workspace: { title?: string; focusedSessionId?: string | null },
+  workspace: { title?: string; focusedSessionId?: string | null; autoTitle?: boolean },
   sessions: readonly WorkspaceTabLabelSession[],
 ): string => {
   const title = workspace.title?.trim();
-  if (title && title !== DEFAULT_WORKSPACE_TITLE) {
-    return title;
+  // Derive a host label only for an auto-titled workspace. The `autoTitle` flag
+  // is authoritative when present (so a workspace a user explicitly named
+  // "Workspace" is kept, not overwritten); legacy workspaces without the flag
+  // fall back to matching the default-title string.
+  const isAutoTitle = workspace.autoTitle ?? (title === DEFAULT_WORKSPACE_TITLE);
+  if (!isAutoTitle) {
+    return title || DEFAULT_WORKSPACE_TITLE;
   }
   if (sessions.length === 0) {
     return title || DEFAULT_WORKSPACE_TITLE;

--- a/domain/sessionTabTitle.ts
+++ b/domain/sessionTabTitle.ts
@@ -44,9 +44,13 @@ export const resolveWorkspaceTabLabel = (
   }
   const focused = sessions.find((s) => s.id === workspace.focusedSessionId) ?? sessions[0];
   const primary = getSessionConnectionLabel(focused);
-  const distinct = new Set(sessions.map(getSessionConnectionLabel).filter(Boolean));
-  if (distinct.size > 1) {
-    return `${primary} +${distinct.size - 1}`;
+  // Count distinct HOSTS by the host label alone, not the connection label: a
+  // per-session rename (customName) must not make two panes on the same host
+  // look like two hosts and add a spurious "+1". The focused pane may still
+  // show its rename as the primary label.
+  const distinctHosts = new Set(sessions.map((s) => s.hostLabel).filter(Boolean));
+  if (distinctHosts.size > 1) {
+    return `${primary} +${distinctHosts.size - 1}`;
   }
   return primary || title || DEFAULT_WORKSPACE_TITLE;
 };

--- a/domain/sessionTabTitle.ts
+++ b/domain/sessionTabTitle.ts
@@ -8,6 +8,49 @@ export const getSessionConnectionLabel = (session: Pick<TerminalSession, 'custom
   return session.customName || session.hostLabel || '';
 };
 
+/**
+ * Default title given to a freshly created split workspace. Used as a sentinel:
+ * while the workspace still carries this title (i.e. the user has not renamed
+ * it), the tab derives a label from its sessions instead of showing "Workspace".
+ */
+export const DEFAULT_WORKSPACE_TITLE = 'Workspace';
+
+type WorkspaceTabLabelSession = Pick<
+  TerminalSession,
+  'id' | 'customName' | 'hostLabel' | 'dynamicTitle' | 'codingCliProviderId'
+>;
+
+/**
+ * Resolve the label shown on a split-workspace tab. When the user has renamed
+ * the workspace, that name wins. Otherwise derive it from the focused session's
+ * host (e.g. "Localhost" for a local shell, the host config name for SSH) so the
+ * tab reads as a concrete host instead of the generic "Workspace". If the
+ * workspace holds sessions for more than one distinct host, the focused host is
+ * shown with a "+N" suffix for the others.
+ */
+export const resolveWorkspaceTabLabel = (
+  workspace: { title?: string; focusedSessionId?: string | null },
+  sessions: readonly WorkspaceTabLabelSession[],
+  dynamicTabTitleMode: DynamicTabTitleMode = 'agent',
+): string => {
+  const title = workspace.title?.trim();
+  if (title && title !== DEFAULT_WORKSPACE_TITLE) {
+    return title;
+  }
+  if (sessions.length === 0) {
+    return title || DEFAULT_WORKSPACE_TITLE;
+  }
+  const focused = sessions.find((s) => s.id === workspace.focusedSessionId) ?? sessions[0];
+  const primary = resolveSessionTabTitle(focused, dynamicTabTitleMode);
+  const distinct = new Set(
+    sessions.map((s) => resolveSessionTabTitle(s, dynamicTabTitleMode)).filter(Boolean),
+  );
+  if (distinct.size > 1) {
+    return `${primary} +${distinct.size - 1}`;
+  }
+  return primary || title || DEFAULT_WORKSPACE_TITLE;
+};
+
 export const shouldUpdateCodingCliTabIcon = (
   dynamicTabTitleMode: DynamicTabTitleMode = 'agent',
 ): boolean => dynamicTabTitleMode !== 'off';

--- a/domain/sessionTabTitle.ts
+++ b/domain/sessionTabTitle.ts
@@ -15,10 +15,7 @@ export const getSessionConnectionLabel = (session: Pick<TerminalSession, 'custom
  */
 export const DEFAULT_WORKSPACE_TITLE = 'Workspace';
 
-type WorkspaceTabLabelSession = Pick<
-  TerminalSession,
-  'id' | 'customName' | 'hostLabel' | 'dynamicTitle' | 'codingCliProviderId'
->;
+type WorkspaceTabLabelSession = Pick<TerminalSession, 'id' | 'customName' | 'hostLabel'>;
 
 /**
  * Resolve the label shown on a split-workspace tab. When the user has renamed
@@ -27,11 +24,16 @@ type WorkspaceTabLabelSession = Pick<
  * tab reads as a concrete host instead of the generic "Workspace". If the
  * workspace holds sessions for more than one distinct host, the focused host is
  * shown with a "+N" suffix for the others.
+ *
+ * Uses the stable connection label (rename / host label) rather than the
+ * dynamic shell/agent title: those live titles are published only to the
+ * session presentation store (not the plain session records passed here), and
+ * they can differ per-pane on a single host — counting them would both go stale
+ * and produce a bogus "+N". The host identity is what this tab is about.
  */
 export const resolveWorkspaceTabLabel = (
   workspace: { title?: string; focusedSessionId?: string | null },
   sessions: readonly WorkspaceTabLabelSession[],
-  dynamicTabTitleMode: DynamicTabTitleMode = 'agent',
 ): string => {
   const title = workspace.title?.trim();
   if (title && title !== DEFAULT_WORKSPACE_TITLE) {
@@ -41,10 +43,8 @@ export const resolveWorkspaceTabLabel = (
     return title || DEFAULT_WORKSPACE_TITLE;
   }
   const focused = sessions.find((s) => s.id === workspace.focusedSessionId) ?? sessions[0];
-  const primary = resolveSessionTabTitle(focused, dynamicTabTitleMode);
-  const distinct = new Set(
-    sessions.map((s) => resolveSessionTabTitle(s, dynamicTabTitleMode)).filter(Boolean),
-  );
+  const primary = getSessionConnectionLabel(focused);
+  const distinct = new Set(sessions.map(getSessionConnectionLabel).filter(Boolean));
   if (distinct.size > 1) {
     return `${primary} +${distinct.size - 1}`;
   }

--- a/domain/workspace.ts
+++ b/domain/workspace.ts
@@ -1,4 +1,5 @@
 import { Workspace,WorkspaceNode,WorkspaceViewMode } from './models';
+import { DEFAULT_WORKSPACE_TITLE } from './sessionTabTitle';
 
 export type SplitDirection = 'horizontal' | 'vertical';
 type SplitPosition = 'left' | 'right' | 'top' | 'bottom';
@@ -146,7 +147,7 @@ export const createWorkspaceFromSessions = (
 
   return {
     id: `ws-${crypto.randomUUID()}`,
-    title: 'Workspace',
+    title: DEFAULT_WORKSPACE_TITLE,
     focusedSessionId: baseSessionId, // Initialize with the base session focused
     focusSessionOrder: [baseSessionId, joiningSessionId],
     root: {

--- a/domain/workspace.ts
+++ b/domain/workspace.ts
@@ -228,6 +228,8 @@ export const createWorkspaceFromSessionIds = (
     title: string;
     viewMode?: WorkspaceViewMode;
     snippetId?: string;
+    /** false = the title is an explicit name; omit for an auto default title. */
+    autoTitle?: boolean;
   }
 ): Workspace => {
   if (sessionIds.length === 0) {
@@ -239,6 +241,7 @@ export const createWorkspaceFromSessionIds = (
     return {
       id: `ws-${crypto.randomUUID()}`,
       title: options.title,
+      autoTitle: options.autoTitle,
       viewMode: options.viewMode,
       snippetId: options.snippetId,
       focusedSessionId: sessionIds[0],
@@ -261,6 +264,7 @@ export const createWorkspaceFromSessionIds = (
   return {
     id: `ws-${crypto.randomUUID()}`,
     title: options.title,
+    autoTitle: options.autoTitle,
     viewMode: options.viewMode,
     snippetId: options.snippetId,
     focusedSessionId: sessionIds[0],


### PR DESCRIPTION
## Summary

A tab that holds a **split workspace** showed the generic default title **"Workspace"**, so with several tabs open you couldn't tell which host each one belonged to. This derives the tab label from the workspace's focused session instead, so the tab reads as a concrete host.

Before / after:

- Local shell split → `Localhost` (its host label) instead of `Workspace`
- SSH split → the configured host name instead of `Workspace`
- Mixed hosts in one workspace → focused host name + `+N` suffix for the rest
- A **user-renamed** workspace keeps its custom title (unchanged)

## Type of Change

- [x] New feature

## Related Issue (optional)

N/A

## Changes Made

- `domain/sessionTabTitle.ts` — add `DEFAULT_WORKSPACE_TITLE` sentinel and `resolveWorkspaceTabLabel()`, reusing `resolveSessionTabTitle` so workspace labels match exactly what single-pane tabs already show.
- `domain/workspace.ts`, `application/state/useSessionState.ts` — reference the shared `DEFAULT_WORKSPACE_TITLE` constant for the default title (single source of truth for the sentinel).
- `components/top-tabs/TopTabItems.tsx` — render the derived label (with a `title` tooltip for the full name) instead of `workspace.title`.
- `domain/sessionTabTitle.test.ts` — cover rename kept, multi-host `+N`, single host, and empty-session fallback.

The label only overrides while the workspace still carries the default title, so a renamed workspace is never touched.

## Screenshots / Demo

Split-workspace tab previously labeled `Workspace` now shows e.g. `Localhost` (local) or the SSH host's configured name.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`) — on touched files
- [x] Tests pass (`npm test`) — new `resolveWorkspaceTabLabel` cases (13/13 in `sessionTabTitle.test.ts`); touched files typecheck clean
- [ ] Generated capability tool specs are updated when applicable
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
