### PR TITLE
feat(ai): Grok Build managed agent

### DIFF
--- a/application/i18n/locales/en/ai.ts
+++ b/application/i18n/locales/en/ai.ts
@@ -268,6 +268,12 @@ export const enAiMessages: Messages = {
   'ai.grok.customPathPlaceholder': 'e.g. /usr/local/bin/grok',
   'ai.grok.check': 'Check',
   'ai.grok.resetPath': 'Reset',
+  'ai.grok.runtime.acp.title': 'Use Grok ACP (agent stdio)',
+  'ai.grok.runtime.acp.default': 'Default',
+  'ai.grok.runtime.acp.description':
+    'Talk to Grok over Agent Client Protocol (grok agent stdio). Injects Netcatty MCP on session/new. Turn off to use the original headless streaming-json CLI path.',
+  'ai.grok.runtime.streamingJson.hint':
+    'Using headless streaming-json (grok -p --output-format streaming-json). Project .grok/config.toml is used for MCP injection.',
 
   // AI Default Agent
   'ai.defaultAgent': 'Default Agent',

--- a/application/i18n/locales/en/ai.ts
+++ b/application/i18n/locales/en/ai.ts
@@ -257,6 +257,18 @@ export const enAiMessages: Messages = {
   'ai.opencode.check': 'Check',
   'ai.opencode.resetPath': 'Reset',
 
+  // AI Grok Build (in-app managed agent — distinct from External MCP client install)
+  'ai.grok.title': 'Grok Build',
+  'ai.grok.description': "xAI's Grok Build coding agent CLI. Install the Grok CLI, sign in with `grok login` or set XAI_API_KEY, then select it as an external agent.",
+  'ai.grok.detecting': 'Detecting...',
+  'ai.grok.detected': 'Detected',
+  'ai.grok.notFound': 'Not found',
+  'ai.grok.path': 'Path:',
+  'ai.grok.notFoundHint': 'Could not find grok in PATH. Install Grok Build CLI or specify the executable path below.',
+  'ai.grok.customPathPlaceholder': 'e.g. /usr/local/bin/grok',
+  'ai.grok.check': 'Check',
+  'ai.grok.resetPath': 'Reset',
+
   // AI Default Agent
   'ai.defaultAgent': 'Default Agent',
   'ai.defaultAgent.description': 'Agent to use when starting a new AI session',

--- a/application/i18n/locales/ru/ai.ts
+++ b/application/i18n/locales/ru/ai.ts
@@ -221,6 +221,12 @@ export const ruAiMessages: Messages = {
   'ai.grok.customPathPlaceholder': 'например, /usr/local/bin/grok',
   'ai.grok.check': 'Проверить',
   'ai.grok.resetPath': 'Сбросить',
+  'ai.grok.runtime.acp.title': 'Использовать Grok ACP (agent stdio)',
+  'ai.grok.runtime.acp.default': 'По умолчанию',
+  'ai.grok.runtime.acp.description':
+    'Подключение к Grok через Agent Client Protocol (grok agent stdio). Netcatty MCP внедряется в session/new. Выключите, чтобы использовать исходный headless streaming-json CLI.',
+  'ai.grok.runtime.streamingJson.hint':
+    'Режим headless streaming-json (grok -p --output-format streaming-json). MCP внедряется через .grok/config.toml проекта.',
 
   // AI Default Agent
   'ai.defaultAgent': 'Агент по умолчанию',

--- a/application/i18n/locales/ru/ai.ts
+++ b/application/i18n/locales/ru/ai.ts
@@ -210,6 +210,18 @@ export const ruAiMessages: Messages = {
   'ai.codebuddy.elicitation.validation.format': 'Поле «{field}» должно соответствовать формату {format}.',
   'ai.codebuddy.elicitation.validation.option': 'Выберите допустимый вариант для «{field}».',
 
+  // AI Grok Build (in-app managed agent — distinct from External MCP client install)
+  'ai.grok.title': 'Grok Build',
+  'ai.grok.description': 'Агент программирования Grok Build от xAI (CLI). Установите Grok CLI, выполните `grok login` или задайте XAI_API_KEY, затем выберите его как внешнего агента.',
+  'ai.grok.detecting': 'Обнаружение...',
+  'ai.grok.detected': 'Обнаружен',
+  'ai.grok.notFound': 'Не найден',
+  'ai.grok.path': 'Путь:',
+  'ai.grok.notFoundHint': 'Не удалось найти grok в PATH. Установите Grok Build CLI или укажите путь к исполняемому файлу ниже.',
+  'ai.grok.customPathPlaceholder': 'например, /usr/local/bin/grok',
+  'ai.grok.check': 'Проверить',
+  'ai.grok.resetPath': 'Сбросить',
+
   // AI Default Agent
   'ai.defaultAgent': 'Агент по умолчанию',
   'ai.defaultAgent.description': 'Агент, который будет использоваться при запуске новой AI-сессии',

--- a/application/i18n/locales/zh-CN/ai.ts
+++ b/application/i18n/locales/zh-CN/ai.ts
@@ -268,6 +268,12 @@ export const zhCNAiMessages: Messages = {
   'ai.grok.customPathPlaceholder': '例如 /usr/local/bin/grok',
   'ai.grok.check': '检查',
   'ai.grok.resetPath': '重置',
+  'ai.grok.runtime.acp.title': '使用 Grok ACP（agent stdio）',
+  'ai.grok.runtime.acp.default': '默认',
+  'ai.grok.runtime.acp.description':
+    '通过 Agent Client Protocol（grok agent stdio）接入 Grok。在 session/new 注入 Netcatty MCP。关闭后使用原始 headless streaming-json CLI 路径。',
+  'ai.grok.runtime.streamingJson.hint':
+    '当前为 headless streaming-json（grok -p --output-format streaming-json）。MCP 通过项目 .grok/config.toml 注入。',
 
   // AI Default Agent
   'ai.defaultAgent': '默认 Agent',

--- a/application/i18n/locales/zh-CN/ai.ts
+++ b/application/i18n/locales/zh-CN/ai.ts
@@ -257,6 +257,18 @@ export const zhCNAiMessages: Messages = {
   'ai.opencode.check': '检查',
   'ai.opencode.resetPath': '重置',
 
+  // AI Grok Build（应用内托管 Agent，与 External MCP「添加到 Grok」不同）
+  'ai.grok.title': 'Grok Build',
+  'ai.grok.description': 'xAI 的 Grok Build 编程 Agent CLI。安装 Grok CLI，使用 `grok login` 登录或设置 XAI_API_KEY 后，即可作为外部 Agent 选择。',
+  'ai.grok.detecting': '检测中...',
+  'ai.grok.detected': '已检测到',
+  'ai.grok.notFound': '未找到',
+  'ai.grok.path': '路径：',
+  'ai.grok.notFoundHint': '在 PATH 中未找到 grok。请安装 Grok Build CLI 或在下方指定可执行文件路径。',
+  'ai.grok.customPathPlaceholder': '例如 /usr/local/bin/grok',
+  'ai.grok.check': '检查',
+  'ai.grok.resetPath': '重置',
+
   // AI Default Agent
   'ai.defaultAgent': '默认 Agent',
   'ai.defaultAgent.description': '创建新 AI 会话时使用的 Agent',

--- a/application/i18n/locales/zh-TW/ai.ts
+++ b/application/i18n/locales/zh-TW/ai.ts
@@ -268,6 +268,12 @@ export const zhTWAiMessages: Messages = {
   'ai.grok.customPathPlaceholder': '例如 /usr/local/bin/grok',
   'ai.grok.check': '檢查',
   'ai.grok.resetPath': '重置',
+  'ai.grok.runtime.acp.title': '使用 Grok ACP（agent stdio）',
+  'ai.grok.runtime.acp.default': '預設',
+  'ai.grok.runtime.acp.description':
+    '透過 Agent Client Protocol（grok agent stdio）接入 Grok。在 session/new 注入 Netcatty MCP。關閉後使用原始 headless streaming-json CLI 路徑。',
+  'ai.grok.runtime.streamingJson.hint':
+    '目前為 headless streaming-json（grok -p --output-format streaming-json）。MCP 透過專案 .grok/config.toml 注入。',
 
   // AI Default Agent
   'ai.defaultAgent': '預設 Agent',

--- a/application/i18n/locales/zh-TW/ai.ts
+++ b/application/i18n/locales/zh-TW/ai.ts
@@ -257,6 +257,18 @@ export const zhTWAiMessages: Messages = {
   'ai.opencode.check': '檢查',
   'ai.opencode.resetPath': '重置',
 
+  // AI Grok Build（應用內託管 Agent，與 External MCP「新增到 Grok」不同）
+  'ai.grok.title': 'Grok Build',
+  'ai.grok.description': 'xAI 的 Grok Build 程式設計 Agent CLI。安裝 Grok CLI，使用 `grok login` 登入或設定 XAI_API_KEY 後，即可作為外部 Agent 選擇。',
+  'ai.grok.detecting': '偵測中...',
+  'ai.grok.detected': '已偵測到',
+  'ai.grok.notFound': '未找到',
+  'ai.grok.path': '路徑：',
+  'ai.grok.notFoundHint': '在 PATH 中未找到 grok。請安裝 Grok Build CLI 或在下方指定執行檔路徑。',
+  'ai.grok.customPathPlaceholder': '例如 /usr/local/bin/grok',
+  'ai.grok.check': '檢查',
+  'ai.grok.resetPath': '重置',
+
   // AI Default Agent
   'ai.defaultAgent': '預設 Agent',
   'ai.defaultAgent.description': '建立新 AI 工作階段時使用的 Agent',

--- a/components/AIChatSidePanelHelpers.test.tsx
+++ b/components/AIChatSidePanelHelpers.test.tsx
@@ -91,6 +91,7 @@ test('shouldLoadSdkRuntimeModels includes SDK agents with model catalogs', () =>
   assert.equal(shouldLoadSdkRuntimeModels(agent('cursor')), true);
   assert.equal(shouldLoadSdkRuntimeModels(agent('codebuddy')), true);
   assert.equal(shouldLoadSdkRuntimeModels(agent('opencode')), true);
+  assert.equal(shouldLoadSdkRuntimeModels(agent('grok')), true);
   assert.equal(shouldLoadSdkRuntimeModels(agent('codex')), false);
   assert.equal(shouldLoadSdkRuntimeModels({ ...agent('codex'), codexRuntime: 'app-server' }), true);
   assert.equal(shouldLoadSdkRuntimeModels(undefined), false);

--- a/components/AIChatSidePanelHelpers.ts
+++ b/components/AIChatSidePanelHelpers.ts
@@ -189,7 +189,8 @@ export function shouldLoadSdkRuntimeModels(agent?: ExternalAgentConfig): boolean
     || sdkBackend === 'copilot'
     || sdkBackend === 'cursor'
     || sdkBackend === 'codebuddy'
-    || sdkBackend === 'opencode';
+    || sdkBackend === 'opencode'
+    || sdkBackend === 'grok';
 }
 
 export function shouldAdoptSdkCurrentModel(

--- a/components/AIChatSidePanelHelpers.ts
+++ b/components/AIChatSidePanelHelpers.ts
@@ -83,6 +83,7 @@ export function buildSdkRuntimeModelCacheKey(agent: {
   acpCommand?: string;
   env?: Record<string, string>;
   codexRuntime?: 'sdk' | 'app-server';
+  grokRuntime?: 'acp' | 'streaming-json';
   cursorAuthMode?: 'cli-login' | 'api-key';
 }): string {
   const sdkBackend = agent.sdkBackend || agent.acpCommand || '';
@@ -92,7 +93,10 @@ export function buildSdkRuntimeModelCacheKey(agent: {
   const cursorAuth = sdkBackend === 'cursor'
     ? (agent.cursorAuthMode === 'cli-login' ? 'cli-login' : 'api-key')
     : '';
-  return [agent.id, sdkBackend, agent.command ?? '', agent.codexRuntime ?? 'sdk', cursorAuth, ...envHints].join('\u0000');
+  const grokRuntime = sdkBackend === 'grok'
+    ? (agent.grokRuntime === 'streaming-json' ? 'streaming-json' : 'acp')
+    : '';
+  return [agent.id, sdkBackend, agent.command ?? '', agent.codexRuntime ?? 'sdk', grokRuntime, cursorAuth, ...envHints].join('\u0000');
 }
 
 export function createSdkRuntimeModelCache(options: SdkRuntimeModelCacheOptions = {}) {

--- a/components/ai/managedAgentState.test.ts
+++ b/components/ai/managedAgentState.test.ts
@@ -126,6 +126,26 @@ test('buildManagedAgentState preserves the experimental Codex runtime across pat
   assert.equal(state.agents[0].command, '/new/codex');
 });
 
+test('buildManagedAgentState preserves Grok runtime across path refreshes', () => {
+  const state = buildManagedAgentState(
+    [{
+      id: 'discovered_grok',
+      name: 'Grok Build',
+      command: '/old/grok',
+      enabled: true,
+      sdkBackend: 'grok',
+      grokRuntime: 'streaming-json',
+    }],
+    'discovered_grok',
+    'grok',
+    { path: '/new/grok', version: '0.2.118', available: true },
+  );
+
+  assert.equal(state.agents[0].grokRuntime, 'streaming-json');
+  assert.equal(state.agents[0].command, '/new/grok');
+  assert.equal(state.agents[0].sdkBackend, 'grok');
+});
+
 test('getInitialManagedAgentPaths ignores auto-detected command paths', () => {
   const state = buildManagedAgentState(
     [],

--- a/components/settings/tabs/SettingsAITab.tsx
+++ b/components/settings/tabs/SettingsAITab.tsx
@@ -37,6 +37,7 @@ import type {
   UserSkillsStatusResult,
 } from "./ai/types";
 import {
+  AGENT_DEFAULTS,
   getBridge,
   isCursorAvailableForMode,
   normalizeCodexBridgeError,
@@ -703,6 +704,30 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
     )));
   }, [setExternalAgents]);
 
+  const handleGrokRuntimeChange = useCallback((runtime: 'acp' | 'streaming-json') => {
+    setExternalAgents((agents) => {
+      const managedId = "discovered_grok";
+      const existing = agents.find((agent) => agent.id === managedId);
+      if (existing) {
+        return agents.map((agent) => (
+          agent.id === managedId ? { ...agent, grokRuntime: runtime } : agent
+        ));
+      }
+      // Path not yet resolved: still persist preference on a disabled placeholder.
+      return [
+        ...agents,
+        {
+          ...AGENT_DEFAULTS.grok,
+          id: managedId,
+          command: "grok",
+          enabled: false,
+          available: false,
+          grokRuntime: runtime,
+        },
+      ];
+    });
+  }, [setExternalAgents]);
+
   // Validate a custom path for an agent.
   const handleCheckCustomPath = useCallback(async (agentKey: ManagedAgentKey) => {
     const customPath = agentKey === "codex"
@@ -1148,6 +1173,12 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
               onRecheckPath={() => void handleCheckCustomPath("grok")}
               onResetPath={() => void handleResetCustomPath("grok")}
               i18nPrefix="ai.grok"
+              grokRuntime={
+                externalAgents.find((a) => a.id === "discovered_grok")?.grokRuntime === "streaming-json"
+                  ? "streaming-json"
+                  : "acp"
+              }
+              onGrokRuntimeChange={handleGrokRuntimeChange}
             />
           </SettingsSection>
 

--- a/components/settings/tabs/SettingsAITab.tsx
+++ b/components/settings/tabs/SettingsAITab.tsx
@@ -218,6 +218,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
     cursor: string;
     codebuddy: string;
     opencode: string;
+    grok: string;
   } | null>(null);
   if (!initialManagedPathsRef.current) {
     initialManagedPathsRef.current = getInitialManagedAgentPaths(externalAgents);
@@ -283,6 +284,12 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
   const [opencodeCustomPath, setOpencodeCustomPath] = useState(() => initialManagedPathsRef.current?.opencode ?? "");
   const [isResolvingOpencode, setIsResolvingOpencode] = useState(false);
 
+  const [grokPathInfo, setGrokPathInfo] = useState<AgentPathInfo | null>(
+    () => getSavedManagedAgentPathInfo(externalAgents, "grok"),
+  );
+  const [grokCustomPath, setGrokCustomPath] = useState(() => initialManagedPathsRef.current?.grok ?? "");
+  const [isResolvingGrok, setIsResolvingGrok] = useState(false);
+
   const codebuddyManagedAgent = useMemo(
     () => externalAgents.find((a) => a.id === "discovered_codebuddy"),
     [externalAgents],
@@ -330,7 +337,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
   useEffect(() => () => {
     mountedRef.current = false;
     codexRequestIdRef.current += 1;
-    for (const key of ["codex", "claude", "copilot", "cursor", "codebuddy", "opencode"] as ManagedAgentKey[]) {
+    for (const key of ["codex", "claude", "copilot", "cursor", "codebuddy", "opencode", "grok"] as ManagedAgentKey[]) {
       agentPathRequestIdRef.current[key] = (agentPathRequestIdRef.current[key] ?? 0) + 1;
     }
   }, []);
@@ -350,7 +357,9 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
             ? setCursorPathInfo
             : agentKey === "codebuddy"
               ? setCodebuddyPathInfo
-              : setOpencodePathInfo;
+              : agentKey === "opencode"
+                ? setOpencodePathInfo
+                : setGrokPathInfo;
 
     setInfo(result);
 
@@ -391,7 +400,9 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
             ? setIsResolvingCursor
             : agentKey === "codebuddy"
               ? setIsResolvingCodebuddy
-              : setIsResolvingOpencode;
+              : agentKey === "opencode"
+                ? setIsResolvingOpencode
+                : setIsResolvingGrok;
 
     setResolving(true);
     const requestId = (agentPathRequestIdRef.current[agentKey] ?? 0) + 1;
@@ -430,7 +441,9 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
                 ? setCursorPathInfo
                 : agentKey === "codebuddy"
                   ? setCodebuddyPathInfo
-                  : setOpencodePathInfo;
+                  : agentKey === "opencode"
+                    ? setOpencodePathInfo
+                    : setGrokPathInfo;
         setInfo(result);
         return result;
       }
@@ -468,6 +481,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
       },
       { key: "codebuddy", delayMs: 1280, path: initialPaths?.codebuddy ?? "" },
       { key: "opencode", delayMs: 1560, path: initialPaths?.opencode ?? "" },
+      { key: "grok", delayMs: 1840, path: initialPaths?.grok ?? "" },
     ];
     const cancelTasks = tasks
       .filter((task) => !autoResolvedAgentStateRef.current[task.key])
@@ -701,7 +715,9 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
             ? codebuddyCustomPath
             : agentKey === "opencode"
               ? opencodeCustomPath
-              : "";
+              : agentKey === "grok"
+                ? grokCustomPath
+                : "";
     const result = await resolveAgentPath(agentKey, customPath, {
       refreshShellEnv: true,
       commandSource: customPath.trim() ? "manual" : "auto",
@@ -713,7 +729,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
         codexPath: result?.path || customPath.trim() || undefined,
       });
     }
-  }, [claudeCustomPath, codexCustomPath, copilotCustomPath, codebuddyCustomPath, opencodeCustomPath, resolveAgentPath, refreshCodexIntegration]);
+  }, [claudeCustomPath, codexCustomPath, copilotCustomPath, codebuddyCustomPath, opencodeCustomPath, grokCustomPath, resolveAgentPath, refreshCodexIntegration]);
 
   const handleResetCustomPath = useCallback(async (agentKey: ManagedAgentKey) => {
     if (agentKey === "codex") {
@@ -726,6 +742,8 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
       setCodebuddyCustomPath("");
     } else if (agentKey === "opencode") {
       setOpencodeCustomPath("");
+    } else if (agentKey === "grok") {
+      setGrokCustomPath("");
     }
 
     const result = await resolveAgentPath(agentKey, "", {
@@ -1115,6 +1133,21 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
               onRecheckPath={() => void handleCheckCustomPath("opencode")}
               onResetPath={() => void handleResetCustomPath("opencode")}
               i18nPrefix="ai.opencode"
+            />
+          </SettingsSection>
+
+          <SettingsSection
+            title={t('ai.grok.title')}
+            leading={<AgentIconBadge agent={{ id: "grok", icon: "grok", name: "Grok Build" }} variant="plain" className="h-5 w-5 text-muted-foreground/90" />}
+          >
+            <CopilotCliCard
+              pathInfo={grokPathInfo}
+              isResolvingPath={isResolvingGrok}
+              customPath={grokCustomPath}
+              onCustomPathChange={setGrokCustomPath}
+              onRecheckPath={() => void handleCheckCustomPath("grok")}
+              onResetPath={() => void handleResetCustomPath("grok")}
+              i18nPrefix="ai.grok"
             />
           </SettingsSection>
 

--- a/components/settings/tabs/ai/CopilotCliCard.test.tsx
+++ b/components/settings/tabs/ai/CopilotCliCard.test.tsx
@@ -38,3 +38,38 @@ test("Copilot check button still requires a custom path", () => {
 
   assert.equal(firstButton(markup).includes("disabled=\"\""), true);
 });
+
+test("Grok card surfaces ACP runtime toggle when detected", () => {
+  const markup = renderToStaticMarkup(
+    <CopilotCliCard
+      pathInfo={{ path: "/usr/bin/grok", version: "0.2.118", available: true }}
+      isResolvingPath={false}
+      customPath=""
+      onCustomPathChange={() => {}}
+      onRecheckPath={() => {}}
+      i18nPrefix="ai.grok"
+      grokRuntime="acp"
+      onGrokRuntimeChange={() => {}}
+    />,
+  );
+
+  assert.match(markup, /ai\.grok\.runtime\.acp\.title|Use Grok ACP/);
+  assert.match(markup, /role="switch"/);
+});
+
+test("Grok card hides ACP toggle without runtime change handler", () => {
+  const markup = renderToStaticMarkup(
+    <CopilotCliCard
+      pathInfo={{ path: "/usr/bin/grok", version: "0.2.118", available: true }}
+      isResolvingPath={false}
+      customPath=""
+      onCustomPathChange={() => {}}
+      onRecheckPath={() => {}}
+      i18nPrefix="ai.grok"
+      grokRuntime="acp"
+    />,
+  );
+
+  assert.doesNotMatch(markup, /role="switch"/);
+  assert.doesNotMatch(markup, /ai\.grok\.runtime\.acp\.title|Use Grok ACP \(agent stdio\)/);
+});

--- a/components/settings/tabs/ai/CopilotCliCard.tsx
+++ b/components/settings/tabs/ai/CopilotCliCard.tsx
@@ -12,7 +12,7 @@ export const CopilotCliCard: React.FC<{
   onCustomPathChange: (path: string) => void;
   onRecheckPath: () => void;
   onResetPath?: () => void;
-  i18nPrefix?: "ai.copilot" | "ai.cursor" | "ai.opencode";
+  i18nPrefix?: "ai.copilot" | "ai.cursor" | "ai.opencode" | "ai.grok";
   allowEmptyCheck?: boolean;
   showCustomPathInput?: boolean;
 }> = ({

--- a/components/settings/tabs/ai/CopilotCliCard.tsx
+++ b/components/settings/tabs/ai/CopilotCliCard.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import { RefreshCw, RotateCcw } from "lucide-react";
 import { useI18n } from "../../../../application/i18n/I18nProvider";
 import { Button } from "../../../ui/button";
+import { Switch } from "../../../ui/switch";
 import { cn } from "../../../../lib/utils";
+import type { GrokRuntime } from "../../../../infrastructure/ai/types";
 import type { AgentPathInfo } from "./types";
 
 export const CopilotCliCard: React.FC<{
@@ -15,6 +17,9 @@ export const CopilotCliCard: React.FC<{
   i18nPrefix?: "ai.copilot" | "ai.cursor" | "ai.opencode" | "ai.grok";
   allowEmptyCheck?: boolean;
   showCustomPathInput?: boolean;
+  /** Grok only: ACP (default) vs headless streaming-json. */
+  grokRuntime?: GrokRuntime;
+  onGrokRuntimeChange?: (runtime: GrokRuntime) => void;
 }> = ({
   pathInfo,
   isResolvingPath,
@@ -25,9 +30,12 @@ export const CopilotCliCard: React.FC<{
   i18nPrefix = "ai.copilot",
   allowEmptyCheck = false,
   showCustomPathInput = true,
+  grokRuntime = "acp",
+  onGrokRuntimeChange,
 }) => {
   const { t } = useI18n();
   const found = pathInfo?.available;
+  const showGrokRuntime = i18nPrefix === "ai.grok" && typeof onGrokRuntimeChange === "function";
 
   const statusText = isResolvingPath
     ? t(`${i18nPrefix}.detecting`)
@@ -93,6 +101,34 @@ export const CopilotCliCard: React.FC<{
               </Button>
             )}
           </div>
+        </div>
+      )}
+
+      {showGrokRuntime && found && (
+        <div className="border-t border-border/40 pt-3 flex items-start justify-between gap-4">
+          <div className="min-w-0 space-y-1">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium">{t("ai.grok.runtime.acp.title")}</span>
+              <span className="rounded border border-primary/30 bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+                {t("ai.grok.runtime.acp.default")}
+              </span>
+            </div>
+            <p className="text-xs text-muted-foreground leading-5">
+              {t("ai.grok.runtime.acp.description")}
+            </p>
+            {grokRuntime === "streaming-json" && (
+              <p className="text-xs text-muted-foreground leading-5">
+                {t("ai.grok.runtime.streamingJson.hint")}
+              </p>
+            )}
+          </div>
+          <Switch
+            checked={grokRuntime === "acp"}
+            aria-label={t("ai.grok.runtime.acp.title")}
+            onCheckedChange={(checked) =>
+              onGrokRuntimeChange?.(checked ? "acp" : "streaming-json")
+            }
+          />
         </div>
       )}
     </div>

--- a/components/settings/tabs/ai/managedAgentState.ts
+++ b/components/settings/tabs/ai/managedAgentState.ts
@@ -234,5 +234,6 @@ export function getInitialManagedAgentPaths(agents: ExternalAgentConfig[]) {
     cursor: getAutoManagedAgentStoredPath(agents, "cursor") ?? "",
     codebuddy: getAutoManagedAgentStoredPath(agents, "codebuddy") ?? "",
     opencode: getAutoManagedAgentStoredPath(agents, "opencode") ?? "",
+    grok: getAutoManagedAgentStoredPath(agents, "grok") ?? "",
   };
 }

--- a/components/settings/tabs/ai/types.ts
+++ b/components/settings/tabs/ai/types.ts
@@ -206,6 +206,12 @@ export const AGENT_DEFAULTS: Record<string, Omit<ExternalAgentConfig, "id" | "co
     icon: "opencode",
     sdkBackend: "opencode",
   },
+  grok: {
+    name: "Grok Build",
+    args: [],
+    icon: "grok",
+    sdkBackend: "grok",
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/domain/agentIcon.ts
+++ b/domain/agentIcon.ts
@@ -21,6 +21,7 @@ export type AgentIconKey =
   | 'opencode'
   | 'kimi'
   | 'codebuddy'
+  | 'grok'
   | 'terminal'
   | 'plus';
 
@@ -116,6 +117,11 @@ export const AGENT_ICON_VISUALS: Record<AgentIconKey, AgentIconVisual> = {
     badgeClassName: 'border-indigo-500/22 bg-indigo-500/12',
     imageClassName: 'object-contain dark:brightness-0 dark:invert opacity-90',
   },
+  grok: {
+    src: '/ai/providers/grok.svg',
+    badgeClassName: 'border-zinc-500/22 bg-zinc-500/12',
+    imageClassName: 'object-contain dark:brightness-0 dark:invert opacity-90',
+  },
   terminal: {
     src: '/ai/agents/terminal.svg',
     badgeClassName: 'border-white/8 bg-white/[0.04]',
@@ -204,6 +210,9 @@ export function resolveAgentIconKey(source: AgentIconSource | 'add-more'): Agent
   }
   if (tokens.some((token) => token.includes('factory'))) {
     return 'atom';
+  }
+  if (tokens.some((token) => token.includes('grok') || token.includes('xai'))) {
+    return 'grok';
   }
 
   return 'terminal';

--- a/domain/codingCliProviderMatch.test.ts
+++ b/domain/codingCliProviderMatch.test.ts
@@ -16,6 +16,8 @@ test('matchCodingCliProviderFromCommand resolves known CLIs', () => {
   assert.equal(matchCodingCliProviderFromCommand('opencode')?.id, 'opencode');
   assert.equal(matchCodingCliProviderFromCommand('droid')?.id, 'droid');
   assert.equal(matchCodingCliProviderFromCommand('factory')?.id, 'droid');
+  assert.equal(matchCodingCliProviderFromCommand('grok')?.id, 'grok');
+  assert.equal(matchCodingCliProviderFromCommand('C:\\\\Tools\\\\grok.exe')?.id, 'grok');
 });
 
 test('matchCodingCliProviderFromTitle detects Claude Code and Codex titles', () => {

--- a/domain/codingCliProviders.ts
+++ b/domain/codingCliProviders.ts
@@ -9,7 +9,8 @@ export type CodingCliProviderId =
   | 'droid'
   | 'copilot'
   | 'cursor'
-  | 'codebuddy';
+  | 'codebuddy'
+  | 'grok';
 
 export type CodingCliProvider = {
   id: CodingCliProviderId;
@@ -92,6 +93,13 @@ export const CODING_CLI_PROVIDERS: readonly CodingCliProvider[] = [
     command: 'codebuddy',
     titleHints: ['codebuddy'],
     iconKey: 'codebuddy',
+  },
+  {
+    id: 'grok',
+    label: 'Grok Build',
+    command: 'grok',
+    titleHints: ['grok build', 'grok'],
+    iconKey: 'grok',
   },
 ] as const;
 

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -27,7 +27,7 @@ const {
 const { registerProviderHandlers } = require("./aiBridge/providerHandlers.cjs"), { registerCattyExecHandlers } = require("./aiBridge/cattyExecHandlers.cjs"), { createAgentCliHelpers } = require("./aiBridge/agentCliHelpers.cjs");
 const { createVaultAgentBridge } = require("./aiBridge/vaultAgentBridge.cjs");
 const { registerAgentDiscoveryHandlers } = require("./aiBridge/agentDiscoveryHandlers.cjs"), { registerAgentProcessHandlers } = require("./aiBridge/agentProcessHandlers.cjs"), { registerSdkStreamHandlers } = require("./aiBridge/sdk/sdkStreamHandlers.cjs");
-const { probeClaudeAuth, probeCopilotAuth, probeCodexAuth, probeCodebuddyAuth, probeCursorCliAuth } = require("./aiBridge/agentAuthProbes.cjs");
+const { probeClaudeAuth, probeCopilotAuth, probeCodexAuth, probeCodebuddyAuth, probeCursorCliAuth, probeGrokAuth } = require("./aiBridge/agentAuthProbes.cjs");
 
 // ── Extracted modules ──
 const {
@@ -823,6 +823,7 @@ function createHandlerContext(ipcMain) {
     probeCodexAuth,
     probeCodebuddyAuth,
     probeCursorCliAuth,
+    probeGrokAuth,
     isPlausibleCliVersionOutput,
     getShellEnv,
     getFreshIdlePrompt,

--- a/electron/bridges/aiBridge.test.cjs
+++ b/electron/bridges/aiBridge.test.cjs
@@ -150,6 +150,10 @@ function loadBridgeWithMocks(options = {}) {
         typeof options.probeCursorCliAuth === "function"
           ? options.probeCursorCliAuth(...args)
           : { authenticated: false, authSource: null, email: null, binPath: null },
+      probeGrokAuth: (...args) =>
+        typeof options.probeGrokAuth === "function"
+          ? options.probeGrokAuth(...args)
+          : { authenticated: false, authSource: null },
     },
     "./ai/ptyExec.cjs": {
       execViaPty: async () => {

--- a/electron/bridges/aiBridge/agentAuthProbes.cjs
+++ b/electron/bridges/aiBridge/agentAuthProbes.cjs
@@ -231,12 +231,32 @@ function probeCursorCliAuth({ env, resolveBinary, runStatus } = {}) {
   };
 }
 
+// ── Grok Build ──
+function probeGrokAuth({ env, fileExists, homeDir } = {}) {
+  const e = env || process.env;
+  const fx = fileExists || defaultFileExists;
+  const home = homeDir || os.homedir();
+
+  const apiKey = typeof e.XAI_API_KEY === "string" ? e.XAI_API_KEY.trim() : "";
+  if (apiKey) return { authenticated: true, authSource: "env" };
+
+  // OAuth / account login persists under ~/.grok/auth.json (or GROK_CONFIG_DIR).
+  const configDir = typeof e.GROK_CONFIG_DIR === "string" && e.GROK_CONFIG_DIR.trim()
+    ? e.GROK_CONFIG_DIR.trim()
+    : path.join(home, ".grok");
+  if (fx(path.join(configDir, "auth.json"))) {
+    return { authenticated: true, authSource: "auth-file" };
+  }
+  return { authenticated: false, authSource: null };
+}
+
 module.exports = {
   probeClaudeAuth,
   probeCopilotAuth,
   probeCodexAuth,
   probeCodebuddyAuth,
   probeCursorCliAuth,
+  probeGrokAuth,
   CURSOR_CLI_BINARY_CANDIDATES,
   defaultRunSecurity,
   defaultRunGhAuthStatus,

--- a/electron/bridges/aiBridge/agentAuthProbes.test.cjs
+++ b/electron/bridges/aiBridge/agentAuthProbes.test.cjs
@@ -1,7 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const {
-  probeClaudeAuth, probeCopilotAuth, probeCodexAuth, probeCodebuddyAuth, probeCursorCliAuth,
+  probeClaudeAuth, probeCopilotAuth, probeCodexAuth, probeCodebuddyAuth, probeCursorCliAuth, probeGrokAuth,
 } = require("./agentAuthProbes.cjs");
 
 test("probeClaudeAuth: env ANTHROPIC_API_KEY -> authenticated env", () => {
@@ -206,6 +206,40 @@ test("probeCursorCliAuth: does not fall back to bare agent binary", () => {
   assert.deepEqual(statusCalls, []);
   assert.equal(r.authenticated, false);
   assert.equal(r.binPath, null);
+});
+
+// ── Grok Build ──
+test("probeGrokAuth: env XAI_API_KEY -> authenticated env", () => {
+  const r = probeGrokAuth({
+    env: { XAI_API_KEY: "xai-test" },
+    fileExists: () => false,
+    homeDir: "/home/user",
+  });
+  assert.equal(r.authenticated, true);
+  assert.equal(r.authSource, "env");
+});
+
+test("probeGrokAuth: auth.json fallback -> authenticated auth-file", () => {
+  const path = require("node:path");
+  const homeDir = path.join("home", "user");
+  const authPath = path.join(homeDir, ".grok", "auth.json");
+  const r = probeGrokAuth({
+    env: {},
+    homeDir,
+    fileExists: (p) => p === authPath,
+  });
+  assert.equal(r.authenticated, true);
+  assert.equal(r.authSource, "auth-file");
+});
+
+test("probeGrokAuth: nothing -> not authenticated", () => {
+  const r = probeGrokAuth({
+    env: {},
+    homeDir: "/home/user",
+    fileExists: () => false,
+  });
+  assert.equal(r.authenticated, false);
+  assert.equal(r.authSource, null);
 });
 
 test("probeCursorCliAuth: unauthenticated JSON -> not authenticated but keeps binPath", () => {

--- a/electron/bridges/aiBridge/agentDiscoveryHandlers.cjs
+++ b/electron/bridges/aiBridge/agentDiscoveryHandlers.cjs
@@ -82,6 +82,8 @@ function registerAgentDiscoveryHandlers(ctx) {
         description: "Tencent's coding agent CLI (Agent SDK)", sdkBackend: "codebuddy", args: [] },
       { command: "opencode", name: "OpenCode", icon: "opencode",
         description: "Open source coding agent via the official OpenCode SDK", sdkBackend: "opencode", args: [] },
+      { command: "grok", name: "Grok Build", icon: "grok",
+        description: "xAI's Grok Build coding agent CLI", sdkBackend: "grok", args: [] },
     ];
 
     const shellEnv = await getShellEnv();
@@ -130,6 +132,8 @@ function registerAgentDiscoveryHandlers(ctx) {
           auth = probeCodebuddyAuth({ env: shellEnv });
         } else if (agent.command === "opencode") {
           auth = { authenticated: true, authSource: "opencode-config" };
+        } else if (agent.command === "grok") {
+          auth = probeGrokAuth({ env: shellEnv });
         }
       } catch { /* auth probe is best-effort */ }
 

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -74,23 +74,28 @@ function resolveGrokAcpCwd(cwd) {
 }
 
 /**
- * Build argv for `grok --no-auto-update agent [flags] stdio`.
- * MCP mode also passes --disallowed-tools when the CLI accepts common flags.
+ * Build argv for `grok [global flags] agent [agent flags] stdio`.
+ *
+ * Live CLI (grok 0.2.x): `--disallowed-tools` and `--no-auto-update` are
+ * top-level options. Placing them after `agent` fails with:
+ *   unexpected argument '--disallowed-tools' found
+ * Agent-local flags (`--always-approve`, `-m`) stay after `agent`.
  */
 function buildGrokAcpSpawnArgs({
   model,
   permissionMode,
   toolIntegrationMode,
 } = {}) {
-  // Headless/ACP automation: skip background update checks (xAI headless docs).
-  const args = ["--no-auto-update", "agent"];
+  // Global top-level flags MUST precede the `agent` subcommand.
+  const args = ["--no-auto-update"];
+  // MCP lockdown is a top-level flag (same as headless `grok -p ...`).
+  args.push(...resolveGrokToolIntegrationFlags(toolIntegrationMode));
+  args.push("agent");
   const mode = String(permissionMode || "confirm").toLowerCase();
   // Non-interactive Netcatty turns cannot answer ACP permission prompts.
   if (mode !== "observer") {
     args.push("--always-approve");
   }
-  // Align with headless MCP lockdown when the agent CLI honors common flags.
-  args.push(...resolveGrokToolIntegrationFlags(toolIntegrationMode));
   const modelId = String(model || "").trim();
   if (modelId) {
     args.push("-m", modelId);

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -539,6 +539,12 @@ function handleGrokAcpMessage(message, { emitter, state, pending, onPromptComple
           message.error.message || message.error.data || JSON.stringify(message.error),
         ));
       } else {
+        // Mark turn completed synchronously on successful session/prompt so a
+        // same-tick process "close" (forced teardown) does not race ahead of
+        // promise .then() and mis-classify the exit as a mid-turn failure.
+        if (state.promptRequestId != null && message.id === state.promptRequestId) {
+          state.turnCompleted = true;
+        }
         waiter.resolve(message.result);
       }
     }
@@ -683,6 +689,10 @@ async function runGrokAcpTurn({
     reasoningOpen: false,
     streamedAssistantText: false,
     failed: false,
+    // True after session/prompt resolves successfully. Process teardown (SIGTERM /
+    // taskkill) often yields a non-zero exit on Windows; that must not flip a
+    // completed tool-only turn into emitError (no assistant text).
+    turnCompleted: false,
     // Suppress session/load history replay until session/prompt starts.
     acceptUpdates: false,
     autoAllowPermissions: String(permissionMode || "confirm").toLowerCase() !== "observer",
@@ -719,6 +729,7 @@ async function runGrokAcpTurn({
         "session/prompt",
         buildGrokAcpPromptParams(state.sessionId, effectivePrompt),
       );
+      state.turnCompleted = true;
       closeReasoning(state, emitter);
       if (!state.failed && !signal?.aborted) emitter.emitDone();
     } catch (err) {
@@ -854,7 +865,17 @@ async function runGrokAcpTurn({
         stderrEnded = true;
         if (!stderrTruncated || stderrDecoder.lastNeed === 0) stderrText += stderrDecoder.end();
       }
-      if (!state.failed && !signal?.aborted && code && code !== 0 && !state.streamedAssistantText) {
+      // Do not treat teardown after a successful prompt as failure. Windows
+      // taskkill / forced exit often reports code 1; tool-only turns never set
+      // streamedAssistantText.
+      if (
+        !state.failed
+        && !signal?.aborted
+        && !state.turnCompleted
+        && code
+        && code !== 0
+        && !state.streamedAssistantText
+      ) {
         const stderr = stderrText.trim();
         state.failed = true;
         emitter.emitError(formatGrokErrorForUser(stderr || `Grok ACP exited with code ${code}`));
@@ -919,6 +940,8 @@ async function runGrokAcpTurn({
     state.acceptUpdates = true;
 
     // session/prompt resolves when the turn finishes; also wait for process end.
+    // turnCompleted is set in handleGrokAcpMessage on successful prompt result
+    // (must be sync before any teardown close event).
     await Promise.race([
       rpc.request(
         "session/prompt",

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -25,6 +25,7 @@ const {
   formatGrokErrorForUser,
   resolveGrokToolIntegrationFlags,
   resolveGrokTurnPrompt,
+  spawnGrokProcess,
 } = require("./grokDriver.cjs");
 
 const GROK_ACP_ABORT_GRACE_MS = 1_500;
@@ -729,10 +730,9 @@ async function runGrokAcpTurn({
     return { sessionId: state.sessionId, runtime: "acp" };
   }
 
-  const spawnFn = spawnImpl || spawn;
   let child;
   try {
-    child = spawnFn(cliPath, spawnArgs, {
+    child = spawnGrokProcess(spawnImpl, cliPath, spawnArgs, {
       cwd: effectiveCwd,
       env: childEnv,
       stdio: ["pipe", "pipe", "pipe"],

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -25,6 +25,7 @@ const {
   formatGrokErrorForUser,
   resolveGrokToolIntegrationFlags,
   resolveGrokTurnPrompt,
+  emitGrokUsage,
   spawnGrokProcess,
 } = require("./grokDriver.cjs");
 
@@ -725,11 +726,17 @@ async function runGrokAcpTurn({
       });
       // Only accept updates for this turn's prompt (not session/load replay).
       state.acceptUpdates = true;
-      await client.request(
+      const promptResult = await client.request(
         "session/prompt",
         buildGrokAcpPromptParams(state.sessionId, effectivePrompt),
       );
       state.turnCompleted = true;
+      emitGrokUsage(
+        emitter,
+        promptResult?.usage
+        ?? promptResult?._meta?.usage
+        ?? promptResult?.meta?.usage,
+      );
       closeReasoning(state, emitter);
       if (!state.failed && !signal?.aborted) emitter.emitDone();
     } catch (err) {
@@ -942,14 +949,21 @@ async function runGrokAcpTurn({
     // session/prompt resolves when the turn finishes; also wait for process end.
     // turnCompleted is set in handleGrokAcpMessage on successful prompt result
     // (must be sync before any teardown close event).
-    await Promise.race([
+    const promptOutcome = await Promise.race([
       rpc.request(
         "session/prompt",
         buildGrokAcpPromptParams(state.sessionId, effectivePrompt),
         { timeoutMs: 30 * 60_000 },
-      ),
-      promptDone,
+      ).then((result) => ({ kind: "prompt", result })),
+      promptDone.then(() => ({ kind: "closed" })),
     ]);
+    // ACP may return optional usage on the prompt result (not only as stream updates).
+    if (promptOutcome?.kind === "prompt") {
+      const usage = promptOutcome.result?.usage
+        ?? promptOutcome.result?._meta?.usage
+        ?? promptOutcome.result?.meta?.usage;
+      emitGrokUsage(emitter, usage);
+    }
   } catch (err) {
     if (!state.failed && !signal?.aborted) {
       state.failed = true;

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -769,13 +769,44 @@ async function runGrokAcpTurn({
   let settled = false;
   let forceKillTimer = null;
   let abortHandler = null;
+  let promptDoneResolve = null;
+  /** @type {ReturnType<typeof createJsonRpcClient>|null} */
+  let rpc = null;
+
+  // Match processErrorGuards / terminalBridge: EPIPE after peer exit is benign.
+  // Without a listener, Node treats async stdin errors as unhandled and can
+  // take down the Electron main process.
+  const isBenignStdinError = (err) => {
+    const code = err?.code;
+    return code === "EPIPE" || code === "ERR_STREAM_DESTROYED";
+  };
+  const failTurnFromStdin = (err) => {
+    if (settled || state.failed || signal?.aborted || state.turnCompleted) return;
+    if (isBenignStdinError(err)) return;
+    state.failed = true;
+    emitter.emitError(formatGrokErrorForUser(err?.message || String(err)));
+    try { rpc?.rejectAll?.(err || new Error("Grok ACP stdin error")); } catch { /* ignore */ }
+    promptDoneResolve?.();
+  };
+  if (typeof child.stdin?.on === "function") {
+    child.stdin.on("error", (err) => {
+      // Benign teardown races (peer closed): ignore, same as processErrorGuards.
+      if (isBenignStdinError(err) || settled || state.failed || signal?.aborted || state.turnCompleted) {
+        return;
+      }
+      failTurnFromStdin(err);
+    });
+  }
 
   const writeLine = (line) => {
-    if (!child?.stdin || child.stdin.destroyed) return;
+    const stdin = child?.stdin;
+    if (!stdin || stdin.destroyed || stdin.writable === false) return;
     try {
-      child.stdin.write(line);
-    } catch {
-      /* ignore */
+      stdin.write(line, (err) => {
+        if (err) failTurnFromStdin(err);
+      });
+    } catch (err) {
+      failTurnFromStdin(err);
     }
   };
 
@@ -783,12 +814,11 @@ async function runGrokAcpTurn({
     writeLine(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
   };
 
-  let promptDoneResolve;
   const promptDone = new Promise((resolve) => {
     promptDoneResolve = resolve;
   });
 
-  const rpc = createJsonRpcClient({
+  rpc = createJsonRpcClient({
     write: writeLine,
     onMessage: (message, pending) => {
       if (signal?.aborted) return;

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -27,6 +27,7 @@ const {
   resolveGrokTurnPrompt,
   extractGrokAcpPromptUsage,
   emitGrokUsage,
+  normalizeGrokPlanUpdate,
   shouldReportGrokProcessExitFailure,
   spawnGrokProcess,
 } = require("./grokDriver.cjs");
@@ -494,22 +495,11 @@ function translateGrokAcpUpdate(update, emitter, state = {}) {
     }
 
     case "plan": {
-      const entries = Array.isArray(update.entries) ? update.entries : [];
-      if (entries.length && typeof emitter.planUpdate === "function") {
-        const items = entries.map((entry, index) => {
-          if (typeof entry === "string") {
-            return { id: `plan-${index}`, content: entry, status: "pending" };
-          }
-          if (entry && typeof entry === "object") {
-            return {
-              id: String(entry.id || `plan-${index}`),
-              content: String(entry.content || entry.text || entry.title || ""),
-              status: String(entry.status || "pending"),
-            };
-          }
-          return { id: `plan-${index}`, content: String(entry ?? ""), status: "pending" };
-        }).filter((item) => item.content);
-        if (items.length) emitter.planUpdate("grok-plan", items, "updated");
+      // Canonical activity shape: [{ text, completed }] + "running"|"completed"
+      // (sdkAgentAdapter / AgentActivityGroup read text+completed, not content+status).
+      const plan = normalizeGrokPlanUpdate(Array.isArray(update.entries) ? update.entries : []);
+      if (plan && typeof emitter.planUpdate === "function") {
+        emitter.planUpdate("grok-plan", plan.items, plan.status);
       }
       return false;
     }

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -541,21 +541,19 @@ function handleGrokAcpMessage(message, { emitter, state, pending, onPromptComple
         waiter.reject(new Error(
           message.error.message || message.error.data || JSON.stringify(message.error),
         ));
+        // Do NOT call onPromptComplete on error — that used to resolve a race
+        // peer and swallow the rejection (async request wrap + microtask hop).
       } else {
         // Mark turn completed + emit usage synchronously on successful
-        // session/prompt. Must not wait for Promise.race after await: onPromptComplete
-        // resolves promptDone in the same tick, so race often wins with "closed"
-        // and drops usage → UI falls back to estimated Token ~1.
+        // session/prompt so teardown/close cannot race past usage emission
+        // (UI would fall back to estimated Token ~1).
         if (state.promptRequestId != null && message.id === state.promptRequestId) {
           state.turnCompleted = true;
           emitGrokUsage(emitter, extractGrokAcpPromptUsage(message.result));
+          onPromptComplete?.(message);
         }
         waiter.resolve(message.result);
       }
-    }
-    // session/prompt resolves when the turn completes (unblocks race / teardown).
-    if (state.promptRequestId != null && message.id === state.promptRequestId) {
-      onPromptComplete?.(message);
     }
     return;
   }
@@ -811,7 +809,6 @@ async function runGrokAcpTurn({
   let settled = false;
   let forceKillTimer = null;
   let abortHandler = null;
-  let promptDoneResolve = null;
   /** @type {ReturnType<typeof createJsonRpcClient>|null} */
   let rpc = null;
 
@@ -828,7 +825,6 @@ async function runGrokAcpTurn({
     state.failed = true;
     emitter.emitError(formatGrokErrorForUser(err?.message || String(err)));
     try { rpc?.rejectAll?.(err || new Error("Grok ACP stdin error")); } catch { /* ignore */ }
-    promptDoneResolve?.();
   };
   if (typeof child.stdin?.on === "function") {
     child.stdin.on("error", (err) => {
@@ -856,10 +852,6 @@ async function runGrokAcpTurn({
     writeLine(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
   };
 
-  const promptDone = new Promise((resolve) => {
-    promptDoneResolve = resolve;
-  });
-
   rpc = createJsonRpcClient({
     write: writeLine,
     onMessage: (message, pending) => {
@@ -868,16 +860,16 @@ async function runGrokAcpTurn({
         emitter,
         state,
         pending,
-        onPromptComplete: () => {
-          promptDoneResolve?.();
-        },
       });
     },
   });
 
-  // Track prompt request id so completion is detected
+  // Track prompt request id so completion is detected.
+  // IMPORTANT: keep this wrapper synchronous — an `async` function adds a
+  // microtask hop that lets a concurrent promptDone resolve win Promise.race
+  // and swallow session/prompt rejections (silent success + unhandledRejection).
   const originalRequest = rpc.request.bind(rpc);
-  rpc.request = async (method, params, options) => {
+  rpc.request = (method, params, options) => {
     const idBefore = rpc.getNextId();
     if (method === "session/prompt") {
       state.promptRequestId = idBefore;
@@ -935,7 +927,6 @@ async function runGrokAcpTurn({
         emitter.emitError(formatGrokErrorForUser(err?.message || String(err)));
       }
       rpc.rejectAll(err || new Error("Grok ACP process error"));
-      promptDoneResolve?.();
       finish();
     });
     child.on("close", (code, exitSignal) => {
@@ -943,18 +934,18 @@ async function runGrokAcpTurn({
         stderrEnded = true;
         if (!stderrTruncated || stderrDecoder.lastNeed === 0) stderrText += stderrDecoder.end();
       }
-      // Only ignore abnormal exit after session/prompt succeeded (turnCompleted).
-      // Signal kills report code=null — still fail if turn not completed.
+      // Only ignore exit after session/prompt succeeded (turnCompleted).
+      // Incomplete turns fail even on exit 0; signal kills report code=null.
       if (shouldReportGrokProcessExitFailure(state, signal, code, exitSignal)) {
         const stderr = stderrText.trim();
         const detail = code != null && code !== 0
           ? `exited with code ${code}`
-          : (exitSignal ? `terminated by signal ${exitSignal}` : "exited unexpectedly");
+          : (exitSignal ? `terminated by signal ${exitSignal}` : "exited before the turn completed");
         state.failed = true;
         emitter.emitError(formatGrokErrorForUser(stderr || `Grok ACP ${detail}`));
       }
+      // Unblock any in-flight RPC (initialize/prompt) so await rejects into catch.
       rpc.rejectAll(new Error("Grok ACP process closed"));
-      promptDoneResolve?.();
       finish();
     });
 
@@ -1012,16 +1003,14 @@ async function runGrokAcpTurn({
     // Accept streamed updates only for this turn's prompt (not session/load replay).
     state.acceptUpdates = true;
 
-    // session/prompt resolves when the turn finishes; also wait for process end.
-    // Usage is emitted inside handleGrokAcpMessage (must be sync — see above).
-    await Promise.race([
-      rpc.request(
-        "session/prompt",
-        buildGrokAcpPromptParams(state.sessionId, effectivePrompt),
-        { timeoutMs: 30 * 60_000 },
-      ),
-      promptDone,
-    ]);
+    // Await the prompt RPC only (no race with promptDone). Process death
+    // rejects via rejectAll on close; success sets turnCompleted + usage in
+    // handleGrokAcpMessage before resolve.
+    await rpc.request(
+      "session/prompt",
+      buildGrokAcpPromptParams(state.sessionId, effectivePrompt),
+      { timeoutMs: 30 * 60_000 },
+    );
   } catch (err) {
     if (!state.failed && !signal?.aborted) {
       state.failed = true;
@@ -1042,8 +1031,17 @@ async function runGrokAcpTurn({
   }
 
   closeReasoning(state, emitter);
-  if (!state.failed && !signal?.aborted) {
+  // Hard gate: incomplete protocol must not look like success (exit 0 / swallowed
+  // RPC error previously fell through to emitDone).
+  if (signal?.aborted) {
+    // User cancel.
+  } else if (state.failed) {
+    // Already reported.
+  } else if (state.turnCompleted) {
     emitter.emitDone();
+  } else {
+    state.failed = true;
+    emitter.emitError(formatGrokErrorForUser("Grok ACP ended before the turn completed"));
   }
 
   return { sessionId: state.sessionId, runtime: "acp" };

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -361,6 +361,15 @@ function handleGrokAcpMessage(message, { emitter, state, pending, onPromptComple
   const params = message.params && typeof message.params === "object" ? message.params : {};
 
   if (method === "session/update" || method === "x.ai/session/update") {
+    // session/load may re-broadcast historical agent_message_chunk events for
+    // client UI rebuild. Those must not be written into the *current* Netcatty
+    // assistant bubble — only accept updates after session/prompt is in flight.
+    if (state.acceptUpdates === false) {
+      if (params.sessionId && !state.sessionId) {
+        state.sessionId = params.sessionId;
+      }
+      return;
+    }
     const update = params.update || params.sessionUpdate || params;
     // Nested: params.update.sessionUpdate
     const payload = update?.sessionUpdate || update?.type
@@ -481,6 +490,8 @@ async function runGrokAcpTurn({
     reasoningOpen: false,
     streamedAssistantText: false,
     failed: false,
+    // Suppress session/load history replay until session/prompt starts.
+    acceptUpdates: false,
     autoAllowPermissions: String(permissionMode || "confirm").toLowerCase() !== "observer",
     promptRequestId: null,
     writeResponse: null,
@@ -511,6 +522,7 @@ async function runGrokAcpTurn({
           emitter.sessionId?.(sessionId);
         }
       }
+      state.acceptUpdates = true;
       await client.request(
         "session/prompt",
         buildGrokAcpPromptParams(state.sessionId, prompt),
@@ -734,6 +746,9 @@ async function runGrokAcpTurn({
     if (!state.sessionId) {
       throw new Error("Grok ACP session/new did not return a sessionId");
     }
+
+    // Accept streamed updates only for this turn's prompt (not session/load replay).
+    state.acceptUpdates = true;
 
     // session/prompt resolves when the turn finishes; also wait for process end.
     await Promise.race([

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -3,19 +3,27 @@
 /**
  * Grok Build ACP turn runner — `grok agent … stdio` JSON-RPC client.
  *
- * Lifecycle (Agent Client Protocol):
- *   initialize → session/new (cwd + mcpServers) → session/prompt
+ * Lifecycle (Agent Client Protocol / xAI docs):
+ *   initialize → authenticate (when authMethods exist)
+ *   → session/resume | session/load | session/new
+ *   → session/prompt
  *   session/update notifications → canonical Netcatty emitter events
+ *
+ * Prefer session/resume (no history replay) over session/load when the agent
+ * advertises it; keep acceptUpdates=false until session/prompt so load replay
+ * never pollutes the current assistant bubble.
  *
  * Prefer session-level mcpServers over project `.grok/config.toml` merge.
  * Keep the headless streaming-json driver as an explicit fallback runtime.
  */
+const path = require("node:path");
 const { spawn } = require("node:child_process");
 const { StringDecoder } = require("node:string_decoder");
 const {
   GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS,
   createLineBuffer,
   formatGrokErrorForUser,
+  resolveGrokToolIntegrationFlags,
 } = require("./grokDriver.cjs");
 
 const GROK_ACP_ABORT_GRACE_MS = 1_500;
@@ -54,19 +62,35 @@ function signalProcessTree(child, signal, forceKillImpl) {
 }
 
 /**
- * Build argv for `grok agent [flags] stdio`.
+ * Resolve absolute cwd for ACP session lifecycle (protocol requires absolute path).
+ */
+function resolveGrokAcpCwd(cwd) {
+  const raw = String(cwd || process.cwd() || ".").trim() || ".";
+  try {
+    return path.resolve(raw);
+  } catch {
+    return raw;
+  }
+}
+
+/**
+ * Build argv for `grok --no-auto-update agent [flags] stdio`.
+ * MCP mode also passes --disallowed-tools when the CLI accepts common flags.
  */
 function buildGrokAcpSpawnArgs({
   model,
   permissionMode,
   toolIntegrationMode,
 } = {}) {
-  const args = ["agent"];
+  // Headless/ACP automation: skip background update checks (xAI headless docs).
+  const args = ["--no-auto-update", "agent"];
   const mode = String(permissionMode || "confirm").toLowerCase();
   // Non-interactive Netcatty turns cannot answer ACP permission prompts.
   if (mode !== "observer") {
     args.push("--always-approve");
   }
+  // Align with headless MCP lockdown when the agent CLI honors common flags.
+  args.push(...resolveGrokToolIntegrationFlags(toolIntegrationMode));
   const modelId = String(model || "").trim();
   if (modelId) {
     args.push("-m", modelId);
@@ -132,7 +156,7 @@ function buildGrokAcpSessionNewParams({
   const mode = String(permissionMode || "confirm").toLowerCase();
   const toolMode = String(toolIntegrationMode || "mcp").toLowerCase();
   const params = {
-    cwd: String(cwd || process.cwd() || "."),
+    cwd: resolveGrokAcpCwd(cwd),
     mcpServers: toAcpMcpServers(injectedMcpServers),
     _meta: {},
   };
@@ -176,6 +200,167 @@ function buildGrokAcpPromptParams(sessionId, prompt) {
     sessionId: String(sessionId || ""),
     prompt: [{ type: "text", text: String(prompt || "") }],
   };
+}
+
+/**
+ * Parse initialize result into resume/load capability flags.
+ * When the agent omits capability fields, treat them as "unknown" so we still
+ * try resume then load (Grok versions vary in what they advertise).
+ */
+function parseGrokAcpAgentCapabilities(initResult) {
+  const caps = initResult && typeof initResult === "object"
+    ? (initResult.agentCapabilities || {})
+    : {};
+  const sessionCaps = caps.sessionCapabilities && typeof caps.sessionCapabilities === "object"
+    ? caps.sessionCapabilities
+    : {};
+  const hasLoadField = Object.prototype.hasOwnProperty.call(caps, "loadSession");
+  const hasResumeField = Object.prototype.hasOwnProperty.call(sessionCaps, "resume");
+  return {
+    loadSession: caps.loadSession === true,
+    resume: sessionCaps.resume != null && sessionCaps.resume !== false,
+    hasCapabilityInfo: hasLoadField || hasResumeField,
+  };
+}
+
+/**
+ * Ordered session establish methods for this turn.
+ * Prefer session/resume (no history replay) → session/load → session/new.
+ */
+function planGrokAcpSessionEstablish({ resumeSessionId, agentCapabilities } = {}) {
+  if (!resumeSessionId) return ["new"];
+  const caps = agentCapabilities || parseGrokAcpAgentCapabilities(null);
+  const methods = [];
+  if (caps.resume || !caps.hasCapabilityInfo) methods.push("resume");
+  if (caps.loadSession || !caps.hasCapabilityInfo) methods.push("load");
+  methods.push("new");
+  return [...new Set(methods)];
+}
+
+/**
+ * Params for session/resume or session/load (same shape per ACP session-setup).
+ */
+function buildGrokAcpSessionResumeOrLoadParams({
+  sessionId,
+  cwd,
+  injectedMcpServers,
+} = {}) {
+  return {
+    sessionId: String(sessionId || ""),
+    cwd: resolveGrokAcpCwd(cwd),
+    mcpServers: toAcpMcpServers(injectedMcpServers),
+  };
+}
+
+/**
+ * Select authenticate methodId per xAI ACP sample:
+ * XAI_API_KEY + xai.api_key → xai.api_key; else cached_token; else null.
+ * Empty authMethods → skip (already authenticated / no gate).
+ */
+function selectGrokAcpAuthMethodId(initResult, env = {}) {
+  const methods = Array.isArray(initResult?.authMethods) ? initResult.authMethods : [];
+  if (methods.length === 0) return { methodId: null, required: false };
+  const ids = new Set(
+    methods.map((m) => (m && typeof m.id === "string" ? m.id : "")).filter(Boolean),
+  );
+  const hasApiKey = Boolean(String(env.XAI_API_KEY || process.env.XAI_API_KEY || "").trim());
+  if (hasApiKey && ids.has("xai.api_key")) {
+    return { methodId: "xai.api_key", required: true };
+  }
+  if (ids.has("cached_token")) {
+    return { methodId: "cached_token", required: true };
+  }
+  if (ids.has("xai.api_key")) {
+    // Advertised but no key in env — still attempt so Grok can read config;
+    // missing credentials surface as auth errors after authenticate fails.
+    return { methodId: "xai.api_key", required: true };
+  }
+  return { methodId: null, required: true };
+}
+
+/**
+ * Run authenticate when the agent advertises methods (xAI official ACP sample).
+ */
+async function authenticateGrokAcp(rpc, initResult, env = {}) {
+  const selected = selectGrokAcpAuthMethodId(initResult, env);
+  if (!selected.methodId) {
+    if (selected.required) {
+      throw new Error("Run `grok login` first, or set XAI_API_KEY.");
+    }
+    return { skipped: true, methodId: null };
+  }
+  await rpc.request(
+    "authenticate",
+    { methodId: selected.methodId, _meta: { headless: true } },
+    { timeoutMs: 60_000 },
+  );
+  return { skipped: false, methodId: selected.methodId };
+}
+
+/**
+ * Establish session: try plan methods until one succeeds.
+ * Caller MUST keep acceptUpdates=false until after this returns (load may replay).
+ */
+async function establishGrokAcpSession(rpc, {
+  resumeSessionId,
+  cwd,
+  injectedMcpServers,
+  permissionMode,
+  toolIntegrationMode,
+  systemContext,
+  agentCapabilities,
+} = {}) {
+  const methods = planGrokAcpSessionEstablish({ resumeSessionId, agentCapabilities });
+  let lastError = null;
+  for (const method of methods) {
+    try {
+      if (method === "new") {
+        const created = await rpc.request(
+          "session/new",
+          buildGrokAcpSessionNewParams({
+            cwd,
+            injectedMcpServers,
+            permissionMode,
+            toolIntegrationMode,
+            systemContext,
+          }),
+          { timeoutMs: 30_000 },
+        );
+        const sessionId = created?.sessionId || created?.session_id;
+        if (!sessionId) throw new Error("Grok ACP session/new did not return a sessionId");
+        return { sessionId, method: "new" };
+      }
+      if (method === "resume") {
+        const result = await rpc.request(
+          "session/resume",
+          buildGrokAcpSessionResumeOrLoadParams({
+            sessionId: resumeSessionId,
+            cwd,
+            injectedMcpServers,
+          }),
+          { timeoutMs: 30_000 },
+        );
+        const sessionId = result?.sessionId || result?.session_id || resumeSessionId;
+        return { sessionId, method: "resume" };
+      }
+      if (method === "load") {
+        const result = await rpc.request(
+          "session/load",
+          buildGrokAcpSessionResumeOrLoadParams({
+            sessionId: resumeSessionId,
+            cwd,
+            injectedMcpServers,
+          }),
+          { timeoutMs: 30_000 },
+        );
+        const sessionId = result?.sessionId || result?.session_id || resumeSessionId;
+        return { sessionId, method: "load" };
+      }
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError || new Error("Grok ACP session establish failed");
 }
 
 function resultToText(result) {
@@ -477,7 +662,7 @@ async function runGrokAcpTurn({
     return { sessionId: resumeSessionId || null, runtime: "acp" };
   }
 
-  const effectiveCwd = String(cwd || process.cwd() || "").trim() || process.cwd();
+  const effectiveCwd = resolveGrokAcpCwd(cwd);
   const childEnv = { ...(env || process.env) };
   const spawnArgs = buildGrokAcpSpawnArgs({
     model,
@@ -501,27 +686,20 @@ async function runGrokAcpTurn({
   if (typeof rpcClientFactory === "function") {
     const client = rpcClientFactory({ state, emitter });
     try {
-      await client.request("initialize", buildGrokAcpInitializeParams());
-      if (resumeSessionId) {
-        state.sessionId = resumeSessionId;
-        emitter.sessionId?.(resumeSessionId);
-      } else {
-        const created = await client.request(
-          "session/new",
-          buildGrokAcpSessionNewParams({
-            cwd: effectiveCwd,
-            injectedMcpServers,
-            permissionMode,
-            toolIntegrationMode,
-            systemContext: systemPrompt,
-          }),
-        );
-        const sessionId = created?.sessionId || created?.session_id;
-        if (sessionId) {
-          state.sessionId = sessionId;
-          emitter.sessionId?.(sessionId);
-        }
-      }
+      const initResult = await client.request("initialize", buildGrokAcpInitializeParams());
+      await authenticateGrokAcp(client, initResult, childEnv);
+      const established = await establishGrokAcpSession(client, {
+        resumeSessionId,
+        cwd: effectiveCwd,
+        injectedMcpServers,
+        permissionMode,
+        toolIntegrationMode,
+        systemContext: systemPrompt,
+        agentCapabilities: parseGrokAcpAgentCapabilities(initResult),
+      });
+      state.sessionId = established.sessionId;
+      emitter.sessionId?.(established.sessionId);
+      // Only accept updates for this turn's prompt (not session/load replay).
       state.acceptUpdates = true;
       await client.request(
         "session/prompt",
@@ -677,6 +855,12 @@ async function runGrokAcpTurn({
     abortHandler = () => {
       if (settled || terminationStarted) return;
       terminationStarted = true;
+      // Prefer protocol cancel when a session is active (ACP prompt-turn).
+      if (state.sessionId) {
+        try {
+          rpc.notify("session/cancel", { sessionId: state.sessionId });
+        } catch { /* ignore */ }
+      }
       forceKillTimer = setTimeout(() => {
         if (settled) return;
         signalProcessTree(child, "SIGKILL", forceKillImpl);
@@ -693,59 +877,24 @@ async function runGrokAcpTurn({
   });
 
   try {
-    await rpc.request("initialize", buildGrokAcpInitializeParams(), { timeoutMs: 30_000 });
+    const initResult = await rpc.request(
+      "initialize",
+      buildGrokAcpInitializeParams(),
+      { timeoutMs: 30_000 },
+    );
+    await authenticateGrokAcp(rpc, initResult, childEnv);
 
-    if (resumeSessionId) {
-      // Best-effort resume via session/load when supported; otherwise new session.
-      try {
-        const loaded = await rpc.request("session/load", {
-          sessionId: resumeSessionId,
-          cwd: effectiveCwd,
-          mcpServers: toAcpMcpServers(injectedMcpServers),
-        }, { timeoutMs: 30_000 });
-        const sessionId = loaded?.sessionId || loaded?.session_id || resumeSessionId;
-        state.sessionId = sessionId;
-        emitter.sessionId?.(sessionId);
-      } catch {
-        const created = await rpc.request(
-          "session/new",
-          buildGrokAcpSessionNewParams({
-            cwd: effectiveCwd,
-            injectedMcpServers,
-            permissionMode,
-            toolIntegrationMode,
-            systemContext: systemPrompt,
-          }),
-          { timeoutMs: 30_000 },
-        );
-        const sessionId = created?.sessionId || created?.session_id;
-        if (sessionId) {
-          state.sessionId = sessionId;
-          emitter.sessionId?.(sessionId);
-        }
-      }
-    } else {
-      const created = await rpc.request(
-        "session/new",
-        buildGrokAcpSessionNewParams({
-          cwd: effectiveCwd,
-          injectedMcpServers,
-          permissionMode,
-          toolIntegrationMode,
-          systemContext: systemPrompt,
-        }),
-        { timeoutMs: 30_000 },
-      );
-      const sessionId = created?.sessionId || created?.session_id;
-      if (sessionId) {
-        state.sessionId = sessionId;
-        emitter.sessionId?.(sessionId);
-      }
-    }
-
-    if (!state.sessionId) {
-      throw new Error("Grok ACP session/new did not return a sessionId");
-    }
+    const established = await establishGrokAcpSession(rpc, {
+      resumeSessionId,
+      cwd: effectiveCwd,
+      injectedMcpServers,
+      permissionMode,
+      toolIntegrationMode,
+      systemContext: systemPrompt,
+      agentCapabilities: parseGrokAcpAgentCapabilities(initResult),
+    });
+    state.sessionId = established.sessionId;
+    emitter.sessionId?.(established.sessionId);
 
     // Accept streamed updates only for this turn's prompt (not session/load replay).
     state.acceptUpdates = true;
@@ -788,13 +937,20 @@ async function runGrokAcpTurn({
 
 module.exports = {
   ACP_PROTOCOL_VERSION,
+  authenticateGrokAcp,
   buildGrokAcpInitializeParams,
   buildGrokAcpPromptParams,
   buildGrokAcpSessionNewParams,
+  buildGrokAcpSessionResumeOrLoadParams,
   buildGrokAcpSpawnArgs,
   createJsonRpcClient,
+  establishGrokAcpSession,
   handleGrokAcpMessage,
+  parseGrokAcpAgentCapabilities,
+  planGrokAcpSessionEstablish,
+  resolveGrokAcpCwd,
   runGrokAcpTurn,
+  selectGrokAcpAuthMethodId,
   toAcpMcpEnvPairs,
   toAcpMcpServers,
   translateGrokAcpUpdate,

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -12,7 +12,6 @@
  */
 const { spawn } = require("node:child_process");
 const { StringDecoder } = require("node:string_decoder");
-const { mcpEnvPairsToObject } = require("./injectMcp.cjs");
 const {
   GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS,
   createLineBuffer,
@@ -77,7 +76,31 @@ function buildGrokAcpSpawnArgs({
 }
 
 /**
+ * Normalize injectMcp env ([{name,value}] or plain object) into Grok ACP's
+ * required pair-array shape. A plain {KEY:VALUE} object is rejected by
+ * `session/new` (`Invalid params` / McpServer enum).
+ */
+function toAcpMcpEnvPairs(env) {
+  if (Array.isArray(env)) {
+    return env
+      .filter((pair) => pair && typeof pair.name === "string" && typeof pair.value === "string")
+      .map((pair) => ({ name: pair.name, value: pair.value }));
+  }
+  if (env && typeof env === "object") {
+    const out = [];
+    for (const [name, value] of Object.entries(env)) {
+      if (typeof name === "string" && typeof value === "string") {
+        out.push({ name, value });
+      }
+    }
+    return out;
+  }
+  return [];
+}
+
+/**
  * Convert Netcatty injectMcp configs into ACP session/new mcpServers entries.
+ * Grok agent stdio expects stdio servers with env as [{name,value}, ...].
  */
 function toAcpMcpServers(injectedMcpServers) {
   const out = [];
@@ -85,9 +108,11 @@ function toAcpMcpServers(injectedMcpServers) {
     if (!cfg || !cfg.name || !cfg.command) continue;
     const entry = {
       name: String(cfg.name),
+      // Optional for Grok, but documents stdio transport for the McpServer enum.
+      type: "stdio",
       command: String(cfg.command),
       args: Array.isArray(cfg.args) ? cfg.args.map(String) : [],
-      env: mcpEnvPairsToObject(cfg.env),
+      env: toAcpMcpEnvPairs(cfg.env),
     };
     out.push(entry);
   }
@@ -755,6 +780,7 @@ module.exports = {
   createJsonRpcClient,
   handleGrokAcpMessage,
   runGrokAcpTurn,
+  toAcpMcpEnvPairs,
   toAcpMcpServers,
   translateGrokAcpUpdate,
 };

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -27,6 +27,7 @@ const {
   resolveGrokTurnPrompt,
   extractGrokAcpPromptUsage,
   emitGrokUsage,
+  shouldReportGrokProcessExitFailure,
   spawnGrokProcess,
 } = require("./grokDriver.cjs");
 
@@ -587,18 +588,59 @@ function handleGrokAcpMessage(message, { emitter, state, pending, onPromptComple
 
   if (method === "session/request_permission" || method === "request_permission") {
     // Non-interactive: auto-allow when yolo was requested; otherwise deny.
+    // optionId MUST come from params.options (ACP); do not invent ids.
     const id = message.id;
     if (id == null) return;
     const allow = state.autoAllowPermissions !== false;
-    const result = allow
-      ? { outcome: { outcome: "selected", optionId: "allow-once" } }
-      : { outcome: { outcome: "cancelled" } };
+    const result = buildGrokAcpPermissionResponse(params, allow);
     // Caller writes responses via pending write hook
     if (typeof state.writeResponse === "function") {
       state.writeResponse(id, result);
     }
     return;
   }
+}
+
+/**
+ * Build ACP permission result using an offered option's real optionId.
+ * Prefers allow_always / allow_once kinds when allowing; reject/cancel when denying.
+ */
+function buildGrokAcpPermissionResponse(params, allow) {
+  const options = Array.isArray(params?.options) ? params.options : [];
+  const optionKey = (opt) => {
+    const optionId = String(opt?.optionId ?? opt?.id ?? "").trim();
+    const kind = String(opt?.kind ?? opt?.name ?? "").trim();
+    return { optionId, kind, blob: `${optionId} ${kind}`.toLowerCase() };
+  };
+  if (allow) {
+    let best = null;
+    let bestScore = 0;
+    for (const opt of options) {
+      if (!opt || typeof opt !== "object") continue;
+      const { optionId, blob } = optionKey(opt);
+      if (!optionId) continue;
+      let score = 0;
+      if (/allow[_-]?always|always[_-]?allow|allow_for_session|allow-session/.test(blob)) score = 3;
+      else if (/allow[_-]?once|once|allow_this|allow-this/.test(blob)) score = 2;
+      else if (/\ballow\b/.test(blob)) score = 1;
+      if (score > bestScore) {
+        bestScore = score;
+        best = optionId;
+      }
+    }
+    if (best) return { outcome: { outcome: "selected", optionId: best } };
+    // Agent omitted options: last-resort ACP-ish id (prefer underscore form).
+    return { outcome: { outcome: "selected", optionId: "allow_once" } };
+  }
+  for (const opt of options) {
+    if (!opt || typeof opt !== "object") continue;
+    const { optionId, blob } = optionKey(opt);
+    if (!optionId) continue;
+    if (/reject|cancel|deny|refuse|disallow/.test(blob)) {
+      return { outcome: { outcome: "selected", optionId } };
+    }
+  }
+  return { outcome: { outcome: "cancelled" } };
 }
 
 function createJsonRpcClient({ write, onMessage }) {
@@ -896,24 +938,20 @@ async function runGrokAcpTurn({
       promptDoneResolve?.();
       finish();
     });
-    child.on("close", (code) => {
+    child.on("close", (code, exitSignal) => {
       if (!stderrEnded) {
         stderrEnded = true;
         if (!stderrTruncated || stderrDecoder.lastNeed === 0) stderrText += stderrDecoder.end();
       }
-      // Only ignore nonzero exit after session/prompt succeeded (turnCompleted).
-      // Partial text without prompt completion is a mid-turn crash — still error.
-      // Windows teardown after success often exits 1; turnCompleted covers that.
-      if (
-        !state.failed
-        && !signal?.aborted
-        && !state.turnCompleted
-        && code
-        && code !== 0
-      ) {
+      // Only ignore abnormal exit after session/prompt succeeded (turnCompleted).
+      // Signal kills report code=null — still fail if turn not completed.
+      if (shouldReportGrokProcessExitFailure(state, signal, code, exitSignal)) {
         const stderr = stderrText.trim();
+        const detail = code != null && code !== 0
+          ? `exited with code ${code}`
+          : (exitSignal ? `terminated by signal ${exitSignal}` : "exited unexpectedly");
         state.failed = true;
-        emitter.emitError(formatGrokErrorForUser(stderr || `Grok ACP exited with code ${code}`));
+        emitter.emitError(formatGrokErrorForUser(stderr || `Grok ACP ${detail}`));
       }
       rpc.rejectAll(new Error("Grok ACP process closed"));
       promptDoneResolve?.();
@@ -1015,6 +1053,7 @@ module.exports = {
   ACP_PROTOCOL_VERSION,
   authenticateGrokAcp,
   buildGrokAcpInitializeParams,
+  buildGrokAcpPermissionResponse,
   buildGrokAcpPromptParams,
   buildGrokAcpSessionNewParams,
   buildGrokAcpSessionResumeOrLoadParams,

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -24,6 +24,7 @@ const {
   createLineBuffer,
   formatGrokErrorForUser,
   resolveGrokToolIntegrationFlags,
+  resolveGrokTurnPrompt,
 } = require("./grokDriver.cjs");
 
 const GROK_ACP_ABORT_GRACE_MS = 1_500;
@@ -650,6 +651,7 @@ async function runGrokAcpTurn({
   permissionMode,
   toolIntegrationMode,
   resumeSessionId,
+  historySeed,
   injectedMcpServers,
   emitter,
   signal,
@@ -704,11 +706,17 @@ async function runGrokAcpTurn({
       });
       state.sessionId = established.sessionId;
       emitter.sessionId?.(established.sessionId);
+      const effectivePrompt = resolveGrokTurnPrompt({
+        turnPrompt: prompt,
+        historySeed,
+        resumeSessionId,
+        establishMethod: established.method,
+      });
       // Only accept updates for this turn's prompt (not session/load replay).
       state.acceptUpdates = true;
       await client.request(
         "session/prompt",
-        buildGrokAcpPromptParams(state.sessionId, prompt),
+        buildGrokAcpPromptParams(state.sessionId, effectivePrompt),
       );
       closeReasoning(state, emitter);
       if (!state.failed && !signal?.aborted) emitter.emitDone();
@@ -900,6 +908,12 @@ async function runGrokAcpTurn({
     });
     state.sessionId = established.sessionId;
     emitter.sessionId?.(established.sessionId);
+    const effectivePrompt = resolveGrokTurnPrompt({
+      turnPrompt: prompt,
+      historySeed,
+      resumeSessionId,
+      establishMethod: established.method,
+    });
 
     // Accept streamed updates only for this turn's prompt (not session/load replay).
     state.acceptUpdates = true;
@@ -908,7 +922,7 @@ async function runGrokAcpTurn({
     await Promise.race([
       rpc.request(
         "session/prompt",
-        buildGrokAcpPromptParams(state.sessionId, prompt),
+        buildGrokAcpPromptParams(state.sessionId, effectivePrompt),
         { timeoutMs: 30 * 60_000 },
       ),
       promptDone,

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -25,6 +25,7 @@ const {
   formatGrokErrorForUser,
   resolveGrokToolIntegrationFlags,
   resolveGrokTurnPrompt,
+  extractGrokAcpPromptUsage,
   emitGrokUsage,
   spawnGrokProcess,
 } = require("./grokDriver.cjs");
@@ -540,16 +541,18 @@ function handleGrokAcpMessage(message, { emitter, state, pending, onPromptComple
           message.error.message || message.error.data || JSON.stringify(message.error),
         ));
       } else {
-        // Mark turn completed synchronously on successful session/prompt so a
-        // same-tick process "close" (forced teardown) does not race ahead of
-        // promise .then() and mis-classify the exit as a mid-turn failure.
+        // Mark turn completed + emit usage synchronously on successful
+        // session/prompt. Must not wait for Promise.race after await: onPromptComplete
+        // resolves promptDone in the same tick, so race often wins with "closed"
+        // and drops usage → UI falls back to estimated Token ~1.
         if (state.promptRequestId != null && message.id === state.promptRequestId) {
           state.turnCompleted = true;
+          emitGrokUsage(emitter, extractGrokAcpPromptUsage(message.result));
         }
         waiter.resolve(message.result);
       }
     }
-    // session/prompt resolves when the turn completes
+    // session/prompt resolves when the turn completes (unblocks race / teardown).
     if (state.promptRequestId != null && message.id === state.promptRequestId) {
       onPromptComplete?.(message);
     }
@@ -731,12 +734,8 @@ async function runGrokAcpTurn({
         buildGrokAcpPromptParams(state.sessionId, effectivePrompt),
       );
       state.turnCompleted = true;
-      emitGrokUsage(
-        emitter,
-        promptResult?.usage
-        ?? promptResult?._meta?.usage
-        ?? promptResult?.meta?.usage,
-      );
+      // Fixture/RPC inject path has no process race; still emit from the result.
+      emitGrokUsage(emitter, extractGrokAcpPromptUsage(promptResult));
       closeReasoning(state, emitter);
       if (!state.failed && !signal?.aborted) emitter.emitDone();
     } catch (err) {
@@ -947,23 +946,15 @@ async function runGrokAcpTurn({
     state.acceptUpdates = true;
 
     // session/prompt resolves when the turn finishes; also wait for process end.
-    // turnCompleted is set in handleGrokAcpMessage on successful prompt result
-    // (must be sync before any teardown close event).
-    const promptOutcome = await Promise.race([
+    // Usage is emitted inside handleGrokAcpMessage (must be sync — see above).
+    await Promise.race([
       rpc.request(
         "session/prompt",
         buildGrokAcpPromptParams(state.sessionId, effectivePrompt),
         { timeoutMs: 30 * 60_000 },
-      ).then((result) => ({ kind: "prompt", result })),
-      promptDone.then(() => ({ kind: "closed" })),
+      ),
+      promptDone,
     ]);
-    // ACP may return optional usage on the prompt result (not only as stream updates).
-    if (promptOutcome?.kind === "prompt") {
-      const usage = promptOutcome.result?.usage
-        ?? promptOutcome.result?._meta?.usage
-        ?? promptOutcome.result?.meta?.usage;
-      emitGrokUsage(emitter, usage);
-    }
   } catch (err) {
     if (!state.failed && !signal?.aborted) {
       state.failed = true;

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -871,16 +871,15 @@ async function runGrokAcpTurn({
         stderrEnded = true;
         if (!stderrTruncated || stderrDecoder.lastNeed === 0) stderrText += stderrDecoder.end();
       }
-      // Do not treat teardown after a successful prompt as failure. Windows
-      // taskkill / forced exit often reports code 1; tool-only turns never set
-      // streamedAssistantText.
+      // Only ignore nonzero exit after session/prompt succeeded (turnCompleted).
+      // Partial text without prompt completion is a mid-turn crash — still error.
+      // Windows teardown after success often exits 1; turnCompleted covers that.
       if (
         !state.failed
         && !signal?.aborted
         && !state.turnCompleted
         && code
         && code !== 0
-        && !state.streamedAssistantText
       ) {
         const stderr = stderrText.trim();
         state.failed = true;

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -1,0 +1,760 @@
+"use strict";
+
+/**
+ * Grok Build ACP turn runner — `grok agent … stdio` JSON-RPC client.
+ *
+ * Lifecycle (Agent Client Protocol):
+ *   initialize → session/new (cwd + mcpServers) → session/prompt
+ *   session/update notifications → canonical Netcatty emitter events
+ *
+ * Prefer session-level mcpServers over project `.grok/config.toml` merge.
+ * Keep the headless streaming-json driver as an explicit fallback runtime.
+ */
+const { spawn } = require("node:child_process");
+const { StringDecoder } = require("node:string_decoder");
+const { mcpEnvPairsToObject } = require("./injectMcp.cjs");
+const {
+  GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS,
+  createLineBuffer,
+  formatGrokErrorForUser,
+} = require("./grokDriver.cjs");
+
+const GROK_ACP_ABORT_GRACE_MS = 1_500;
+const MAX_GROK_ACP_LINE_BYTES = 10 * 1024 * 1024;
+const MAX_GROK_ACP_STDERR_CHARS = 64 * 1024;
+const ACP_PROTOCOL_VERSION = 1;
+
+function signalProcessTree(child, signal, forceKillImpl) {
+  if (!child) return;
+  if (typeof forceKillImpl === "function") {
+    try { forceKillImpl(child, signal); } catch { /* ignore */ }
+    return;
+  }
+  if (process.platform === "win32" && signal === "SIGKILL" && child.pid) {
+    try {
+      const killer = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+        stdio: "ignore",
+        windowsHide: true,
+      });
+      killer.on("error", () => {});
+      killer.unref?.();
+      return;
+    } catch {
+      // fall through
+    }
+  }
+  if (process.platform !== "win32" && child.pid) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // fall through
+    }
+  }
+  try { child.kill(signal); } catch { /* ignore */ }
+}
+
+/**
+ * Build argv for `grok agent [flags] stdio`.
+ */
+function buildGrokAcpSpawnArgs({
+  model,
+  permissionMode,
+  toolIntegrationMode,
+} = {}) {
+  const args = ["agent"];
+  const mode = String(permissionMode || "confirm").toLowerCase();
+  // Non-interactive Netcatty turns cannot answer ACP permission prompts.
+  if (mode !== "observer") {
+    args.push("--always-approve");
+  }
+  const modelId = String(model || "").trim();
+  if (modelId) {
+    args.push("-m", modelId);
+  }
+  args.push("stdio");
+  return args;
+}
+
+/**
+ * Convert Netcatty injectMcp configs into ACP session/new mcpServers entries.
+ */
+function toAcpMcpServers(injectedMcpServers) {
+  const out = [];
+  for (const cfg of injectedMcpServers || []) {
+    if (!cfg || !cfg.name || !cfg.command) continue;
+    const entry = {
+      name: String(cfg.name),
+      command: String(cfg.command),
+      args: Array.isArray(cfg.args) ? cfg.args.map(String) : [],
+      env: mcpEnvPairsToObject(cfg.env),
+    };
+    out.push(entry);
+  }
+  return out;
+}
+
+/**
+ * Build session/new params including MCP servers and permission meta.
+ */
+function buildGrokAcpSessionNewParams({
+  cwd,
+  injectedMcpServers,
+  permissionMode,
+  toolIntegrationMode,
+  systemContext,
+} = {}) {
+  const mode = String(permissionMode || "confirm").toLowerCase();
+  const toolMode = String(toolIntegrationMode || "mcp").toLowerCase();
+  const params = {
+    cwd: String(cwd || process.cwd() || "."),
+    mcpServers: toAcpMcpServers(injectedMcpServers),
+    _meta: {},
+  };
+  if (mode !== "observer") {
+    params._meta.yoloMode = true;
+  } else {
+    // Soft read-oriented path when no interactive approval UI is available.
+    params._meta.autoMode = true;
+  }
+  if (toolMode !== "skills") {
+    params._meta.rules = [
+      "Netcatty MCP mode is active. Do not use local shell, search_replace, or write tools for side effects.",
+      "Operate on remote terminal sessions only through the injected netcatty-remote-hosts MCP server.",
+      `Disallowed local built-ins (policy): ${GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS.join(", ")}.`,
+    ].join(" ");
+  }
+  if (systemContext && String(systemContext).trim()) {
+    // Prefer additive rules so Grok keeps its agent profile; overflow goes to rules.
+    const existing = params._meta.rules ? `${params._meta.rules} ` : "";
+    params._meta.rules = `${existing}${String(systemContext).trim()}`.slice(0, 16_000);
+  }
+  return params;
+}
+
+function buildGrokAcpInitializeParams() {
+  return {
+    protocolVersion: ACP_PROTOCOL_VERSION,
+    clientCapabilities: {
+      fs: { readTextFile: false, writeTextFile: false },
+      terminal: false,
+    },
+    clientInfo: {
+      name: "netcatty",
+      version: "0.0.0",
+    },
+  };
+}
+
+function buildGrokAcpPromptParams(sessionId, prompt) {
+  return {
+    sessionId: String(sessionId || ""),
+    prompt: [{ type: "text", text: String(prompt || "") }],
+  };
+}
+
+function resultToText(result) {
+  if (result == null) return "";
+  if (typeof result === "string") return result;
+  if (typeof result === "number" || typeof result === "boolean") return String(result);
+  if (typeof result === "object") {
+    if (typeof result.content === "string") return result.content;
+    if (typeof result.text === "string") return result.text;
+    try { return JSON.stringify(result); } catch { return String(result); }
+  }
+  return String(result);
+}
+
+function closeReasoning(state, emitter) {
+  if (state?.reasoningOpen) {
+    emitter.reasoningEnd();
+    state.reasoningOpen = false;
+  }
+}
+
+/**
+ * Map one ACP session/update payload (or x.ai notification) to emitter calls.
+ * @returns {boolean} true when the stream should stop on error
+ */
+function translateGrokAcpUpdate(update, emitter, state = {}) {
+  if (!update || typeof update !== "object") return false;
+  const kind = String(
+    update.sessionUpdate
+    || update.type
+    || update.kind
+    || "",
+  );
+
+  switch (kind) {
+    case "agent_message_chunk":
+    case "message_chunk":
+    case "text": {
+      closeReasoning(state, emitter);
+      const text = update.content?.text
+        ?? update.text
+        ?? update.data
+        ?? (typeof update.content === "string" ? update.content : "");
+      if (text) {
+        emitter.text(String(text));
+        state.streamedAssistantText = true;
+      }
+      return false;
+    }
+
+    case "agent_thought_chunk":
+    case "thought_chunk":
+    case "thought": {
+      const text = update.content?.text
+        ?? update.text
+        ?? update.data
+        ?? "";
+      if (text) {
+        emitter.reasoning(String(text));
+        state.reasoningOpen = true;
+      }
+      return false;
+    }
+
+    case "tool_call": {
+      closeReasoning(state, emitter);
+      const id = update.toolCallId || update.tool_call_id || update.id;
+      if (!id) return false;
+      if (!state.emittedToolCalls) state.emittedToolCalls = new Set();
+      if (!state.toolNames) state.toolNames = new Map();
+      const name = String(
+        update.toolName
+        || update.tool_name
+        || update.title
+        || update.kind
+        || "tool",
+      );
+      const args = update.rawInput && typeof update.rawInput === "object"
+        ? update.rawInput
+        : (update.input && typeof update.input === "object" ? update.input : {});
+      state.toolNames.set(id, name);
+      if (!state.emittedToolCalls.has(id)) {
+        state.emittedToolCalls.add(id);
+        emitter.toolCall(name, args, id);
+      }
+      return false;
+    }
+
+    case "tool_call_update": {
+      closeReasoning(state, emitter);
+      const id = update.toolCallId || update.tool_call_id || update.id;
+      if (!id) return false;
+      if (!state.emittedToolResults) state.emittedToolResults = new Set();
+      if (!state.emittedToolCalls) state.emittedToolCalls = new Set();
+      if (!state.toolNames) state.toolNames = new Map();
+      const status = String(update.status || "").toLowerCase();
+      const name = state.toolNames.get(id)
+        || String(update.toolName || update.tool_name || update.title || "tool");
+      if (!state.emittedToolCalls.has(id)) {
+        state.emittedToolCalls.add(id);
+        state.toolNames.set(id, name);
+        emitter.toolCall(name, {}, id);
+      }
+      if (
+        status === "completed"
+        || status === "failed"
+        || status === "error"
+        || status === "cancelled"
+        || update.rawOutput != null
+      ) {
+        if (!state.emittedToolResults.has(id)) {
+          state.emittedToolResults.add(id);
+          emitter.toolResult(
+            id,
+            resultToText(update.rawOutput ?? update.content ?? update.error ?? ""),
+            name,
+          );
+        }
+      }
+      return false;
+    }
+
+    case "plan": {
+      const entries = Array.isArray(update.entries) ? update.entries : [];
+      if (entries.length && typeof emitter.planUpdate === "function") {
+        const items = entries.map((entry, index) => {
+          if (typeof entry === "string") {
+            return { id: `plan-${index}`, content: entry, status: "pending" };
+          }
+          if (entry && typeof entry === "object") {
+            return {
+              id: String(entry.id || `plan-${index}`),
+              content: String(entry.content || entry.text || entry.title || ""),
+              status: String(entry.status || "pending"),
+            };
+          }
+          return { id: `plan-${index}`, content: String(entry ?? ""), status: "pending" };
+        }).filter((item) => item.content);
+        if (items.length) emitter.planUpdate("grok-plan", items, "updated");
+      }
+      return false;
+    }
+
+    case "error": {
+      closeReasoning(state, emitter);
+      state.failed = true;
+      emitter.emitError(formatGrokErrorForUser(update.message || update.error || "Grok ACP turn failed"));
+      return true;
+    }
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * Handle a parsed JSON-RPC message from grok agent stdio.
+ */
+function handleGrokAcpMessage(message, { emitter, state, pending, onPromptComplete }) {
+  if (!message || typeof message !== "object") return;
+
+  // Response to a request
+  if (Object.prototype.hasOwnProperty.call(message, "id") && message.id != null && !message.method) {
+    const waiter = pending.get(message.id);
+    if (waiter) {
+      pending.delete(message.id);
+      if (message.error) {
+        waiter.reject(new Error(
+          message.error.message || message.error.data || JSON.stringify(message.error),
+        ));
+      } else {
+        waiter.resolve(message.result);
+      }
+    }
+    // session/prompt resolves when the turn completes
+    if (state.promptRequestId != null && message.id === state.promptRequestId) {
+      onPromptComplete?.(message);
+    }
+    return;
+  }
+
+  const method = String(message.method || "");
+  const params = message.params && typeof message.params === "object" ? message.params : {};
+
+  if (method === "session/update" || method === "x.ai/session/update") {
+    const update = params.update || params.sessionUpdate || params;
+    // Nested: params.update.sessionUpdate
+    const payload = update?.sessionUpdate || update?.type
+      ? update
+      : (params.sessionUpdate ? { sessionUpdate: params.sessionUpdate, ...params } : update);
+    if (payload) translateGrokAcpUpdate(payload, emitter, state);
+    if (params.sessionId && !state.sessionId) {
+      state.sessionId = params.sessionId;
+      emitter.sessionId?.(params.sessionId);
+    }
+    return;
+  }
+
+  if (method === "session/request_permission" || method === "request_permission") {
+    // Non-interactive: auto-allow when yolo was requested; otherwise deny.
+    const id = message.id;
+    if (id == null) return;
+    const allow = state.autoAllowPermissions !== false;
+    const result = allow
+      ? { outcome: { outcome: "selected", optionId: "allow-once" } }
+      : { outcome: { outcome: "cancelled" } };
+    // Caller writes responses via pending write hook
+    if (typeof state.writeResponse === "function") {
+      state.writeResponse(id, result);
+    }
+    return;
+  }
+}
+
+function createJsonRpcClient({ write, onMessage }) {
+  let nextId = 1;
+  const pending = new Map();
+
+  function request(method, params, { timeoutMs = 120_000 } = {}) {
+    const id = nextId++;
+    const payload = { jsonrpc: "2.0", id, method, params };
+    write(`${JSON.stringify(payload)}\n`);
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`Grok ACP request timed out: ${method}`));
+      }, timeoutMs);
+      timer.unref?.();
+      pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (err) => {
+          clearTimeout(timer);
+          reject(err);
+        },
+      });
+    });
+  }
+
+  function notify(method, params) {
+    write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
+  }
+
+  function handleLine(line) {
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      return;
+    }
+    onMessage(message, pending);
+  }
+
+  function rejectAll(err) {
+    for (const [, waiter] of pending) {
+      try { waiter.reject(err); } catch { /* ignore */ }
+    }
+    pending.clear();
+  }
+
+  return { request, notify, handleLine, pending, rejectAll, getNextId: () => nextId };
+}
+
+async function runGrokAcpTurn({
+  prompt,
+  systemPrompt,
+  binPath,
+  cwd,
+  model,
+  env,
+  permissionMode,
+  toolIntegrationMode,
+  resumeSessionId,
+  injectedMcpServers,
+  emitter,
+  signal,
+  spawnImpl,
+  abortGraceMs = GROK_ACP_ABORT_GRACE_MS,
+  forceKillImpl,
+  // inject for tests: skip real spawn
+  rpcClientFactory,
+}) {
+  const cliPath = String(binPath || "").trim();
+  if (!cliPath) {
+    emitter.emitError(
+      "Grok Build CLI not found. Install the Grok CLI (`grok`) and ensure it is on PATH, or set the path in Settings → AI.",
+    );
+    return { sessionId: resumeSessionId || null, runtime: "acp" };
+  }
+
+  const effectiveCwd = String(cwd || process.cwd() || "").trim() || process.cwd();
+  const childEnv = { ...(env || process.env) };
+  const spawnArgs = buildGrokAcpSpawnArgs({
+    model,
+    permissionMode,
+    toolIntegrationMode,
+  });
+
+  const state = {
+    sessionId: resumeSessionId || null,
+    reasoningOpen: false,
+    streamedAssistantText: false,
+    failed: false,
+    autoAllowPermissions: String(permissionMode || "confirm").toLowerCase() !== "observer",
+    promptRequestId: null,
+    writeResponse: null,
+  };
+
+  // Test inject path: pure RPC loop without process
+  if (typeof rpcClientFactory === "function") {
+    const client = rpcClientFactory({ state, emitter });
+    try {
+      await client.request("initialize", buildGrokAcpInitializeParams());
+      if (resumeSessionId) {
+        state.sessionId = resumeSessionId;
+        emitter.sessionId?.(resumeSessionId);
+      } else {
+        const created = await client.request(
+          "session/new",
+          buildGrokAcpSessionNewParams({
+            cwd: effectiveCwd,
+            injectedMcpServers,
+            permissionMode,
+            toolIntegrationMode,
+            systemContext: systemPrompt,
+          }),
+        );
+        const sessionId = created?.sessionId || created?.session_id;
+        if (sessionId) {
+          state.sessionId = sessionId;
+          emitter.sessionId?.(sessionId);
+        }
+      }
+      await client.request(
+        "session/prompt",
+        buildGrokAcpPromptParams(state.sessionId, prompt),
+      );
+      closeReasoning(state, emitter);
+      if (!state.failed && !signal?.aborted) emitter.emitDone();
+    } catch (err) {
+      if (!state.failed && !signal?.aborted) {
+        state.failed = true;
+        emitter.emitError(formatGrokErrorForUser(err?.message || String(err)));
+      }
+    }
+    return { sessionId: state.sessionId, runtime: "acp" };
+  }
+
+  const spawnFn = spawnImpl || spawn;
+  let child;
+  try {
+    child = spawnFn(cliPath, spawnArgs, {
+      cwd: effectiveCwd,
+      env: childEnv,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+      detached: process.platform !== "win32",
+    });
+  } catch (err) {
+    emitter.emitError(formatGrokErrorForUser(err?.message || String(err)));
+    return { sessionId: state.sessionId, runtime: "acp" };
+  }
+
+  let stderrText = "";
+  let stderrBytes = 0;
+  let stderrTruncated = false;
+  let stderrEnded = false;
+  const stderrDecoder = new StringDecoder("utf8");
+  let settled = false;
+  let forceKillTimer = null;
+  let abortHandler = null;
+
+  const writeLine = (line) => {
+    if (!child?.stdin || child.stdin.destroyed) return;
+    try {
+      child.stdin.write(line);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  state.writeResponse = (id, result) => {
+    writeLine(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+  };
+
+  let promptDoneResolve;
+  const promptDone = new Promise((resolve) => {
+    promptDoneResolve = resolve;
+  });
+
+  const rpc = createJsonRpcClient({
+    write: writeLine,
+    onMessage: (message, pending) => {
+      if (signal?.aborted) return;
+      handleGrokAcpMessage(message, {
+        emitter,
+        state,
+        pending,
+        onPromptComplete: () => {
+          promptDoneResolve?.();
+        },
+      });
+    },
+  });
+
+  // Track prompt request id so completion is detected
+  const originalRequest = rpc.request.bind(rpc);
+  rpc.request = async (method, params, options) => {
+    const idBefore = rpc.getNextId();
+    if (method === "session/prompt") {
+      state.promptRequestId = idBefore;
+    }
+    return originalRequest(method, params, options);
+  };
+
+  const lineBuffer = createLineBuffer((line) => {
+    if (signal?.aborted) return;
+    try {
+      rpc.handleLine(line);
+    } catch (err) {
+      if (!state.failed) {
+        state.failed = true;
+        emitter.emitError(formatGrokErrorForUser(err?.message || String(err)));
+      }
+    }
+  }, MAX_GROK_ACP_LINE_BYTES);
+
+  child.stdout?.on("data", (chunk) => {
+    if (signal?.aborted) return;
+    try {
+      lineBuffer.push(chunk);
+    } catch (err) {
+      if (!state.failed) {
+        state.failed = true;
+        emitter.emitError(formatGrokErrorForUser(err?.message || String(err)));
+      }
+      signalProcessTree(child, "SIGKILL", forceKillImpl);
+    }
+  });
+  child.stderr?.on("data", (chunk) => {
+    if (signal?.aborted) return;
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+    const remaining = Math.max(0, MAX_GROK_ACP_STDERR_CHARS - stderrBytes);
+    const accepted = buffer.length <= remaining ? buffer : buffer.subarray(0, remaining);
+    if (accepted.length > 0) stderrText += stderrDecoder.write(accepted);
+    stderrBytes += accepted.length;
+    if (accepted.length < buffer.length) stderrTruncated = true;
+  });
+
+  const closePromise = new Promise((resolve) => {
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(forceKillTimer);
+      if (!signal?.aborted) {
+        try { lineBuffer.flush(); } catch { /* ignore */ }
+      }
+      resolve();
+    };
+    child.on("error", (err) => {
+      if (!state.failed && !signal?.aborted) {
+        state.failed = true;
+        emitter.emitError(formatGrokErrorForUser(err?.message || String(err)));
+      }
+      rpc.rejectAll(err || new Error("Grok ACP process error"));
+      promptDoneResolve?.();
+      finish();
+    });
+    child.on("close", (code) => {
+      if (!stderrEnded) {
+        stderrEnded = true;
+        if (!stderrTruncated || stderrDecoder.lastNeed === 0) stderrText += stderrDecoder.end();
+      }
+      if (!state.failed && !signal?.aborted && code && code !== 0 && !state.streamedAssistantText) {
+        const stderr = stderrText.trim();
+        state.failed = true;
+        emitter.emitError(formatGrokErrorForUser(stderr || `Grok ACP exited with code ${code}`));
+      }
+      rpc.rejectAll(new Error("Grok ACP process closed"));
+      promptDoneResolve?.();
+      finish();
+    });
+
+    let terminationStarted = false;
+    abortHandler = () => {
+      if (settled || terminationStarted) return;
+      terminationStarted = true;
+      forceKillTimer = setTimeout(() => {
+        if (settled) return;
+        signalProcessTree(child, "SIGKILL", forceKillImpl);
+        finish();
+      }, Math.max(0, abortGraceMs));
+      forceKillTimer.unref?.();
+      signalProcessTree(child, "SIGTERM");
+      try { child.stdin?.end(); } catch { /* ignore */ }
+    };
+    if (signal) {
+      if (signal.aborted) abortHandler();
+      else signal.addEventListener("abort", abortHandler, { once: true });
+    }
+  });
+
+  try {
+    await rpc.request("initialize", buildGrokAcpInitializeParams(), { timeoutMs: 30_000 });
+
+    if (resumeSessionId) {
+      // Best-effort resume via session/load when supported; otherwise new session.
+      try {
+        const loaded = await rpc.request("session/load", {
+          sessionId: resumeSessionId,
+          cwd: effectiveCwd,
+          mcpServers: toAcpMcpServers(injectedMcpServers),
+        }, { timeoutMs: 30_000 });
+        const sessionId = loaded?.sessionId || loaded?.session_id || resumeSessionId;
+        state.sessionId = sessionId;
+        emitter.sessionId?.(sessionId);
+      } catch {
+        const created = await rpc.request(
+          "session/new",
+          buildGrokAcpSessionNewParams({
+            cwd: effectiveCwd,
+            injectedMcpServers,
+            permissionMode,
+            toolIntegrationMode,
+            systemContext: systemPrompt,
+          }),
+          { timeoutMs: 30_000 },
+        );
+        const sessionId = created?.sessionId || created?.session_id;
+        if (sessionId) {
+          state.sessionId = sessionId;
+          emitter.sessionId?.(sessionId);
+        }
+      }
+    } else {
+      const created = await rpc.request(
+        "session/new",
+        buildGrokAcpSessionNewParams({
+          cwd: effectiveCwd,
+          injectedMcpServers,
+          permissionMode,
+          toolIntegrationMode,
+          systemContext: systemPrompt,
+        }),
+        { timeoutMs: 30_000 },
+      );
+      const sessionId = created?.sessionId || created?.session_id;
+      if (sessionId) {
+        state.sessionId = sessionId;
+        emitter.sessionId?.(sessionId);
+      }
+    }
+
+    if (!state.sessionId) {
+      throw new Error("Grok ACP session/new did not return a sessionId");
+    }
+
+    // session/prompt resolves when the turn finishes; also wait for process end.
+    await Promise.race([
+      rpc.request(
+        "session/prompt",
+        buildGrokAcpPromptParams(state.sessionId, prompt),
+        { timeoutMs: 30 * 60_000 },
+      ),
+      promptDone,
+    ]);
+  } catch (err) {
+    if (!state.failed && !signal?.aborted) {
+      state.failed = true;
+      const message = err?.message || String(err);
+      const stderr = stderrText.trim();
+      emitter.emitError(formatGrokErrorForUser(
+        stderr && !message.includes(stderr) ? `${message} (${stderr})` : message,
+      ));
+    }
+  } finally {
+    try { child.stdin?.end(); } catch { /* ignore */ }
+    // Give the process a moment to exit cleanly after prompt completes.
+    if (!settled && child.exitCode == null && !child.killed) {
+      signalProcessTree(child, "SIGTERM", forceKillImpl);
+    }
+    await closePromise;
+    if (signal) signal.removeEventListener("abort", abortHandler);
+  }
+
+  closeReasoning(state, emitter);
+  if (!state.failed && !signal?.aborted) {
+    emitter.emitDone();
+  }
+
+  return { sessionId: state.sessionId, runtime: "acp" };
+}
+
+module.exports = {
+  ACP_PROTOCOL_VERSION,
+  buildGrokAcpInitializeParams,
+  buildGrokAcpPromptParams,
+  buildGrokAcpSessionNewParams,
+  buildGrokAcpSpawnArgs,
+  createJsonRpcClient,
+  handleGrokAcpMessage,
+  runGrokAcpTurn,
+  toAcpMcpServers,
+  translateGrokAcpUpdate,
+};

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -524,6 +524,94 @@ test("runGrokAcpTurn drives initialize/authenticate/session/new/prompt via fixtu
   assert.ok(emitter.calls.some((c) => c[0] === "done"));
 });
 
+test("runGrokAcpTurn seeds history when resume/load fail and session/new is used", async () => {
+  const emitter = makeEmitter();
+  const methods = [];
+  const historySeed = [
+    "[Conversation context replay: the agent SDK may be starting from a fresh local session, so use these prior turns as context and answer only the latest user request.]",
+    "USER: earlier question",
+    "ASSISTANT: earlier answer",
+  ].join("\n");
+  await runGrokAcpTurn({
+    prompt: "latest only",
+    binPath: "/usr/bin/grok",
+    resumeSessionId: "stale-sess",
+    historySeed,
+    permissionMode: "auto",
+    emitter,
+    rpcClientFactory: () => ({
+      async request(method, params) {
+        methods.push([method, params]);
+        if (method === "initialize") {
+          return {
+            protocolVersion: ACP_PROTOCOL_VERSION,
+            agentCapabilities: {
+              loadSession: true,
+              sessionCapabilities: { resume: {} },
+            },
+            authMethods: [],
+          };
+        }
+        if (method === "session/resume") throw new Error("missing session");
+        if (method === "session/load") throw new Error("cannot load");
+        if (method === "session/new") return { sessionId: "fresh-sess" };
+        if (method === "session/prompt") {
+          assert.equal(params.sessionId, "fresh-sess");
+          const text = params.prompt?.[0]?.text || "";
+          assert.match(text, /Conversation context replay/);
+          assert.match(text, /earlier question/);
+          assert.match(text, /latest only$/);
+          return { stopReason: "end_turn" };
+        }
+        throw new Error(`unexpected method ${method}`);
+      },
+    }),
+  });
+  assert.deepEqual(methods.map((m) => m[0]), [
+    "initialize",
+    "session/resume",
+    "session/load",
+    "session/new",
+    "session/prompt",
+  ]);
+  assert.ok(emitter.calls.some((c) => c[0] === "sessionId" && c[1] === "fresh-sess"));
+});
+
+test("runGrokAcpTurn does not seed history when session/resume succeeds", async () => {
+  const emitter = makeEmitter();
+  const historySeed = "USER: earlier\nASSISTANT: earlier answer";
+  await runGrokAcpTurn({
+    prompt: "latest only",
+    binPath: "/usr/bin/grok",
+    resumeSessionId: "live-sess",
+    historySeed,
+    permissionMode: "auto",
+    emitter,
+    rpcClientFactory: () => ({
+      async request(method, params) {
+        if (method === "initialize") {
+          return {
+            protocolVersion: ACP_PROTOCOL_VERSION,
+            agentCapabilities: {
+              loadSession: true,
+              sessionCapabilities: { resume: {} },
+            },
+            authMethods: [],
+          };
+        }
+        if (method === "session/resume") return {};
+        if (method === "session/prompt") {
+          const text = params.prompt?.[0]?.text || "";
+          assert.equal(text, "latest only");
+          assert.doesNotMatch(text, /earlier/);
+          return { stopReason: "end_turn" };
+        }
+        throw new Error(`unexpected method ${method}`);
+      },
+    }),
+  });
+});
+
 test("runGrokAcpTurn prefers session/resume and keeps load history off the emitter", async () => {
   const emitter = makeEmitter();
   const methods = [];

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -63,27 +63,47 @@ test("buildGrokAcpSpawnArgs uses agent stdio, no-auto-update, and always-approve
   assert.deepEqual(observer, ["--no-auto-update", "agent", "stdio"]);
 });
 
-test("buildGrokAcpSpawnArgs applies MCP-mode local-tool lockdown", () => {
+test("buildGrokAcpSpawnArgs places global MCP lockdown before agent subcommand", () => {
   const args = buildGrokAcpSpawnArgs({
+    model: "grok-4.5",
     permissionMode: "auto",
     toolIntegrationMode: "mcp",
   });
+  const agentIdx = args.indexOf("agent");
   const denyIdx = args.indexOf("--disallowed-tools");
+  const noUpdateIdx = args.indexOf("--no-auto-update");
+  const alwaysIdx = args.indexOf("--always-approve");
+  const modelIdx = args.indexOf("-m");
+  assert.ok(agentIdx >= 0, "must include agent subcommand");
   assert.ok(denyIdx >= 0, "MCP mode must pass --disallowed-tools on ACP spawn");
+  // Live grok rejects --disallowed-tools AFTER `agent` (unexpected argument).
+  assert.ok(noUpdateIdx < agentIdx, "--no-auto-update must be before agent");
+  assert.ok(denyIdx < agentIdx, "--disallowed-tools must be before agent");
+  assert.ok(alwaysIdx > agentIdx, "--always-approve is agent-local (after agent)");
+  assert.ok(modelIdx > agentIdx, "-m is agent-local (after agent)");
+  assert.equal(args[args.length - 1], "stdio");
+  assert.deepEqual(args, [
+    "--no-auto-update",
+    "--disallowed-tools",
+    GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS.join(","),
+    "agent",
+    "--always-approve",
+    "-m",
+    "grok-4.5",
+    "stdio",
+  ]);
   const denied = String(args[denyIdx + 1] || "");
   assert.match(denied, /run_terminal_command/);
   assert.match(denied, /search_replace/);
   assert.match(denied, /write/);
   assert.doesNotMatch(denied, /mcp|netcatty/i);
-  assert.ok(args.includes("--no-auto-update"));
-  assert.ok(args.includes("--always-approve"));
-  assert.equal(args[args.length - 1], "stdio");
-  // Skills mode: no lockdown list
+  // Skills mode: no lockdown list; global flags still precede agent.
   const skills = buildGrokAcpSpawnArgs({
     permissionMode: "auto",
     toolIntegrationMode: "skills",
   });
   assert.ok(!skills.includes("--disallowed-tools"));
+  assert.ok(skills.indexOf("--no-auto-update") < skills.indexOf("agent"));
 });
 
 test("toAcpMcpEnvPairs keeps Grok session/new pair-array shape", () => {

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -5,6 +5,7 @@ const {
   ACP_PROTOCOL_VERSION,
   authenticateGrokAcp,
   buildGrokAcpInitializeParams,
+  buildGrokAcpPermissionResponse,
   buildGrokAcpPromptParams,
   buildGrokAcpSessionNewParams,
   buildGrokAcpSessionResumeOrLoadParams,
@@ -23,6 +24,7 @@ const {
 } = require("./grokAcpDriver.cjs");
 const {
   GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS,
+  shouldReportGrokProcessExitFailure,
 } = require("./grokDriver.cjs");
 const { getDriver, listBackends } = require("./index.cjs");
 
@@ -1274,4 +1276,171 @@ test("registry grok backend defaults to ACP path and keeps streaming-json fallba
   });
   assert.equal(acp.runtime, "acp");
   assert.match(String(emitter2.calls[0]?.[1] || ""), /not found/i);
+});
+
+test("buildGrokAcpPermissionResponse selects offered optionId, never invents allow-once", () => {
+  // Live ACP uses optionId values like "allow-once" / "allow-always" / "reject".
+  const allowOnce = buildGrokAcpPermissionResponse({
+    options: [
+      { optionId: "allow-once", kind: "allow_once", name: "Allow once" },
+      { optionId: "allow-always", kind: "allow_always", name: "Allow always" },
+      { optionId: "reject", kind: "reject_once", name: "Reject" },
+    ],
+  }, true);
+  assert.deepEqual(allowOnce, {
+    outcome: { outcome: "selected", optionId: "allow-always" },
+  });
+
+  const allowOnlyOnce = buildGrokAcpPermissionResponse({
+    options: [
+      { optionId: "allow-once", name: "Allow once" },
+      { optionId: "reject", name: "Reject" },
+    ],
+  }, true);
+  assert.deepEqual(allowOnlyOnce, {
+    outcome: { outcome: "selected", optionId: "allow-once" },
+  });
+
+  const deny = buildGrokAcpPermissionResponse({
+    options: [
+      { optionId: "allow-once", kind: "allow_once" },
+      { optionId: "reject", kind: "reject_once" },
+    ],
+  }, false);
+  assert.deepEqual(deny, {
+    outcome: { outcome: "selected", optionId: "reject" },
+  });
+
+  // No options offered: deny cancels; allow falls back to underscore form only as last resort.
+  assert.deepEqual(
+    buildGrokAcpPermissionResponse({}, false),
+    { outcome: { outcome: "cancelled" } },
+  );
+  assert.deepEqual(
+    buildGrokAcpPermissionResponse({ options: [] }, true),
+    { outcome: { outcome: "selected", optionId: "allow_once" } },
+  );
+});
+
+test("handleGrokAcpMessage permission reply uses real optionId from params.options", () => {
+  const written = [];
+  const state = {
+    autoAllowPermissions: true,
+    writeResponse: (id, result) => written.push([id, result]),
+  };
+  handleGrokAcpMessage({
+    jsonrpc: "2.0",
+    id: 42,
+    method: "session/request_permission",
+    params: {
+      options: [
+        { optionId: "allow-once", kind: "allow_once" },
+        { optionId: "reject", kind: "reject_once" },
+      ],
+    },
+  }, { emitter: makeEmitter(), state, pending: new Map() });
+
+  assert.equal(written.length, 1);
+  assert.equal(written[0][0], 42);
+  // Must echo the offered id (hyphen form), not invent underscore "allow_once".
+  assert.equal(written[0][1].outcome.optionId, "allow-once");
+});
+
+test("shouldReportGrokProcessExitFailure treats signal kills before completion as failures", () => {
+  // Node close(null, "SIGTERM") when killed — must fail unfinished turns.
+  assert.equal(
+    shouldReportGrokProcessExitFailure({ turnCompleted: false }, null, null, "SIGTERM"),
+    true,
+  );
+  assert.equal(
+    shouldReportGrokProcessExitFailure({ turnCompleted: false }, null, 1, null),
+    true,
+  );
+  assert.equal(
+    shouldReportGrokProcessExitFailure({ turnCompleted: true }, null, 1, "SIGTERM"),
+    false,
+  );
+  assert.equal(
+    shouldReportGrokProcessExitFailure({ turnCompleted: false }, { aborted: true }, null, "SIGTERM"),
+    false,
+  );
+  assert.equal(
+    shouldReportGrokProcessExitFailure({ turnCompleted: false, failed: true }, null, 1, null),
+    false,
+  );
+  assert.equal(
+    shouldReportGrokProcessExitFailure({ turnCompleted: false }, null, 0, null),
+    false,
+  );
+});
+
+test("runGrokAcpTurn fails when process is signal-killed mid-turn (code=null)", async () => {
+  // Node reports close(null, "SIGTERM") for signal kills — must not silently succeed.
+  const emitter = makeEmitter();
+  const { EventEmitter } = require("node:events");
+
+  function makeFakeChild() {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    const stdin = new EventEmitter();
+    stdin.write = (chunk, cb) => {
+      const msg = JSON.parse(String(chunk).trim());
+      queueMicrotask(() => {
+        if (msg.method === "initialize") {
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: { protocolVersion: ACP_PROTOCOL_VERSION, authMethods: [] },
+          })}\n`));
+        } else if (msg.method === "session/new") {
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: { sessionId: "s-sig" },
+          })}\n`));
+        } else if (msg.method === "session/prompt") {
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            method: "session/update",
+            params: {
+              sessionId: "s-sig",
+              update: { sessionUpdate: "agent_message_chunk", content: { text: "half…" } },
+            },
+          })}\n`));
+          // Crash mid-prompt: signal kill, code=null (Node convention).
+          queueMicrotask(() => child.emit("close", null, "SIGTERM"));
+        } else {
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: {},
+          })}\n`));
+        }
+        if (typeof cb === "function") cb();
+      });
+      return true;
+    };
+    stdin.end = () => {};
+    child.stdin = stdin;
+    child.pid = 7;
+    child.killed = false;
+    child.exitCode = null;
+    child.kill = () => { child.killed = true; };
+    return child;
+  }
+
+  await runGrokAcpTurn({
+    prompt: "long",
+    binPath: "C:\\fake\\grok.exe",
+    permissionMode: "auto",
+    emitter,
+    spawnImpl: () => makeFakeChild(),
+  });
+
+  assert.ok(emitter.calls.some((c) => c[0] === "text" && c[1] === "half…"));
+  const err = emitter.calls.find((c) => c[0] === "error");
+  assert.ok(err, "signal kill mid-turn must emitError");
+  assert.match(String(err[1]), /SIGTERM|signal/i);
+  assert.ok(!emitter.calls.some((c) => c[0] === "done"));
 });

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -1346,7 +1346,7 @@ test("handleGrokAcpMessage permission reply uses real optionId from params.optio
   assert.equal(written[0][1].outcome.optionId, "allow-once");
 });
 
-test("shouldReportGrokProcessExitFailure treats signal kills before completion as failures", () => {
+test("shouldReportGrokProcessExitFailure treats any incomplete close as failure", () => {
   // Node close(null, "SIGTERM") when killed — must fail unfinished turns.
   assert.equal(
     shouldReportGrokProcessExitFailure({ turnCompleted: false }, null, null, "SIGTERM"),
@@ -1354,6 +1354,11 @@ test("shouldReportGrokProcessExitFailure treats signal kills before completion a
   );
   assert.equal(
     shouldReportGrokProcessExitFailure({ turnCompleted: false }, null, 1, null),
+    true,
+  );
+  // Exit 0 without session/prompt success is still a failure.
+  assert.equal(
+    shouldReportGrokProcessExitFailure({ turnCompleted: false }, null, 0, null),
     true,
   );
   assert.equal(
@@ -1368,10 +1373,148 @@ test("shouldReportGrokProcessExitFailure treats signal kills before completion a
     shouldReportGrokProcessExitFailure({ turnCompleted: false, failed: true }, null, 1, null),
     false,
   );
-  assert.equal(
-    shouldReportGrokProcessExitFailure({ turnCompleted: false }, null, 0, null),
-    false,
-  );
+});
+
+test("runGrokAcpTurn fails on session/prompt JSON-RPC error (no silent done)", async () => {
+  // Regression: async request wrap + promptDone race used to swallow the reject
+  // and emitDone when the process later exited 0.
+  const emitter = makeEmitter();
+  const { EventEmitter } = require("node:events");
+  const unhandled = [];
+  const onUnhandled = (err) => unhandled.push(err);
+  process.on("unhandledRejection", onUnhandled);
+
+  function makeFakeChild() {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    const stdin = new EventEmitter();
+    stdin.write = (chunk, cb) => {
+      const msg = JSON.parse(String(chunk).trim());
+      queueMicrotask(() => {
+        if (msg.method === "initialize") {
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: { protocolVersion: ACP_PROTOCOL_VERSION, authMethods: [] },
+          })}\n`));
+        } else if (msg.method === "session/new") {
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: { sessionId: "s-err" },
+          })}\n`));
+        } else if (msg.method === "session/prompt") {
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id,
+            error: { code: -32000, message: "model overloaded" },
+          })}\n`));
+          queueMicrotask(() => child.emit("close", 0));
+        } else {
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: {},
+          })}\n`));
+        }
+        if (typeof cb === "function") cb();
+      });
+      return true;
+    };
+    stdin.end = () => {};
+    child.stdin = stdin;
+    child.pid = 8;
+    child.killed = false;
+    child.exitCode = null;
+    child.kill = () => { child.killed = true; };
+    return child;
+  }
+
+  try {
+    await runGrokAcpTurn({
+      prompt: "hi",
+      binPath: "C:\\fake\\grok.exe",
+      permissionMode: "auto",
+      emitter,
+      spawnImpl: () => makeFakeChild(),
+    });
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+
+  const err = emitter.calls.find((c) => c[0] === "error");
+  assert.ok(err, "prompt JSON-RPC error must emitError");
+  assert.match(String(err[1]), /overloaded|error|fail/i);
+  assert.ok(!emitter.calls.some((c) => c[0] === "done"), "must not emitDone on prompt error");
+  assert.equal(unhandled.length, 0, "must not leave unhandledRejection from swallowed race");
+});
+
+test("runGrokAcpTurn fails when process exits 0 mid-prompt without result", async () => {
+  const emitter = makeEmitter();
+  const { EventEmitter } = require("node:events");
+
+  function makeFakeChild() {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    const stdin = new EventEmitter();
+    stdin.write = (chunk, cb) => {
+      const msg = JSON.parse(String(chunk).trim());
+      queueMicrotask(() => {
+        if (msg.method === "initialize") {
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: { protocolVersion: ACP_PROTOCOL_VERSION, authMethods: [] },
+          })}\n`));
+        } else if (msg.method === "session/new") {
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: { sessionId: "s-zero" },
+          })}\n`));
+        } else if (msg.method === "session/prompt") {
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            method: "session/update",
+            params: {
+              sessionId: "s-zero",
+              update: { sessionUpdate: "agent_message_chunk", content: { text: "half…" } },
+            },
+          })}\n`));
+          queueMicrotask(() => child.emit("close", 0));
+        } else {
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: {},
+          })}\n`));
+        }
+        if (typeof cb === "function") cb();
+      });
+      return true;
+    };
+    stdin.end = () => {};
+    child.stdin = stdin;
+    child.pid = 9;
+    child.killed = false;
+    child.exitCode = null;
+    child.kill = () => { child.killed = true; };
+    return child;
+  }
+
+  await runGrokAcpTurn({
+    prompt: "long",
+    binPath: "C:\\fake\\grok.exe",
+    permissionMode: "auto",
+    emitter,
+    spawnImpl: () => makeFakeChild(),
+  });
+
+  assert.ok(emitter.calls.some((c) => c[0] === "text" && c[1] === "half…"));
+  assert.ok(emitter.calls.some((c) => c[0] === "error"), "exit 0 mid-prompt must emitError");
+  assert.ok(!emitter.calls.some((c) => c[0] === "done"));
 });
 
 test("runGrokAcpTurn fails when process is signal-killed mid-turn (code=null)", async () => {

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -37,6 +37,7 @@ function makeEmitter() {
     toolResult: (id, result, name) => calls.push(["toolResult", id, result, name]),
     sessionId: (id) => calls.push(["sessionId", id]),
     planUpdate: (itemId, items, status) => calls.push(["planUpdate", itemId, items, status]),
+    usage: (usage) => calls.push(["usage", usage]),
     emitDone: () => calls.push(["done"]),
     emitError: (message) => calls.push(["error", message]),
   };
@@ -771,6 +772,51 @@ test("runGrokAcpTurn reports missing CLI clearly", async () => {
   assert.equal(result.sessionId, null);
   assert.equal(result.runtime, "acp");
   assert.match(String(emitter.calls[0]?.[1] || ""), /not found/i);
+});
+
+test("runGrokAcpTurn forwards usage from session/prompt result", async () => {
+  const emitter = makeEmitter();
+  await runGrokAcpTurn({
+    prompt: "hi",
+    binPath: "/usr/bin/grok",
+    permissionMode: "auto",
+    emitter,
+    rpcClientFactory: ({ emitter: em, state }) => ({
+      async request(method) {
+        if (method === "initialize") {
+          return { protocolVersion: ACP_PROTOCOL_VERSION, authMethods: [] };
+        }
+        if (method === "session/new") return { sessionId: "s-usage" };
+        if (method === "session/prompt") {
+          translateGrokAcpUpdate({
+            sessionUpdate: "agent_message_chunk",
+            content: { text: "ok" },
+          }, em, state);
+          return {
+            stopReason: "end_turn",
+            usage: {
+              input_tokens: 11,
+              output_tokens: 7,
+              cache_read_input_tokens: 2,
+              reasoning_tokens: 3,
+              total_tokens: 23,
+            },
+          };
+        }
+        throw new Error(`unexpected ${method}`);
+      },
+    }),
+  });
+  const usage = emitter.calls.find((c) => c[0] === "usage");
+  assert.ok(usage);
+  assert.deepEqual(usage[1], {
+    inputTokens: 11,
+    cachedInputTokens: 2,
+    outputTokens: 7,
+    reasoningTokens: 3,
+    totalTokens: 23,
+  });
+  assert.ok(emitter.calls.some((c) => c[0] === "done"));
 });
 
 test("runGrokAcpTurn does not treat post-prompt exit code 1 as failure for tool-only turns", async () => {

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -774,6 +774,101 @@ test("runGrokAcpTurn reports missing CLI clearly", async () => {
   assert.match(String(emitter.calls[0]?.[1] || ""), /not found/i);
 });
 
+test("runGrokAcpTurn ignores benign stdin EPIPE after turn completes", async () => {
+  // Matches processErrorGuards: EPIPE must not crash main or fail a completed turn.
+  const { EventEmitter } = require("node:events");
+  const emitter = makeEmitter();
+  let stdinRef = null;
+
+  function makeFakeChild() {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    const stdin = new EventEmitter();
+    stdin.destroyed = false;
+    stdin.writable = true;
+    stdin.write = (line, cb) => {
+      let msg;
+      try { msg = JSON.parse(String(line).trim()); } catch {
+        if (typeof cb === "function") cb();
+        return true;
+      }
+      if (msg?.id == null) {
+        if (typeof cb === "function") cb();
+        return true;
+      }
+      queueMicrotask(() => {
+        if (msg.method === "initialize") {
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: { protocolVersion: ACP_PROTOCOL_VERSION, authMethods: [] },
+          })}\n`));
+        } else if (msg.method === "session/new") {
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: { sessionId: "s-epipe" },
+          })}\n`));
+        } else if (msg.method === "session/prompt") {
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            method: "session/update",
+            params: {
+              sessionId: "s-epipe",
+              update: { sessionUpdate: "agent_message_chunk", content: { text: "ok" } },
+            },
+          })}\n`));
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: { stopReason: "end_turn" },
+          })}\n`));
+          // Teardown race: peer closed stdin after prompt success.
+          queueMicrotask(() => {
+            const err = new Error("write EPIPE");
+            err.code = "EPIPE";
+            stdin.emit("error", err);
+            child.emit("close", 1);
+          });
+        } else {
+          child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id,
+            result: {},
+          })}\n`));
+        }
+        if (typeof cb === "function") cb();
+      });
+      return true;
+    };
+    stdin.end = () => {};
+    child.stdin = stdin;
+    stdinRef = stdin;
+    child.pid = 3;
+    child.killed = false;
+    child.exitCode = null;
+    child.kill = () => {
+      child.killed = true;
+      queueMicrotask(() => child.emit("close", 1));
+    };
+    return child;
+  }
+
+  await runGrokAcpTurn({
+    prompt: "hi",
+    binPath: "C:\\fake\\grok.exe",
+    permissionMode: "auto",
+    emitter,
+    spawnImpl: () => makeFakeChild(),
+    forceKillImpl: (c) => { c.kill(); },
+  });
+
+  assert.ok(stdinRef, "stdin must have been wired");
+  assert.ok(emitter.calls.some((c) => c[0] === "done"));
+  assert.ok(!emitter.calls.some((c) => c[0] === "error"), "post-completion EPIPE is benign");
+});
+
 test("runGrokAcpTurn forwards usage from session/prompt result", async () => {
   const emitter = makeEmitter();
   await runGrokAcpTurn({

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -1,18 +1,29 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const path = require("node:path");
 const {
   ACP_PROTOCOL_VERSION,
+  authenticateGrokAcp,
   buildGrokAcpInitializeParams,
   buildGrokAcpPromptParams,
   buildGrokAcpSessionNewParams,
+  buildGrokAcpSessionResumeOrLoadParams,
   buildGrokAcpSpawnArgs,
   createJsonRpcClient,
+  establishGrokAcpSession,
   handleGrokAcpMessage,
+  parseGrokAcpAgentCapabilities,
+  planGrokAcpSessionEstablish,
+  resolveGrokAcpCwd,
   runGrokAcpTurn,
+  selectGrokAcpAuthMethodId,
   toAcpMcpEnvPairs,
   toAcpMcpServers,
   translateGrokAcpUpdate,
 } = require("./grokAcpDriver.cjs");
+const {
+  GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS,
+} = require("./grokDriver.cjs");
 const { getDriver, listBackends } = require("./index.cjs");
 
 function makeEmitter() {
@@ -31,15 +42,48 @@ function makeEmitter() {
   };
 }
 
-test("buildGrokAcpSpawnArgs uses agent stdio and always-approve for non-observer", () => {
-  assert.deepEqual(
-    buildGrokAcpSpawnArgs({ model: "grok-4.5", permissionMode: "auto" }),
-    ["agent", "--always-approve", "-m", "grok-4.5", "stdio"],
-  );
-  assert.deepEqual(
-    buildGrokAcpSpawnArgs({ permissionMode: "observer" }),
-    ["agent", "stdio"],
-  );
+test("buildGrokAcpSpawnArgs uses agent stdio, no-auto-update, and always-approve for non-observer", () => {
+  const args = buildGrokAcpSpawnArgs({
+    model: "grok-4.5",
+    permissionMode: "auto",
+    toolIntegrationMode: "skills",
+  });
+  assert.deepEqual(args, [
+    "--no-auto-update",
+    "agent",
+    "--always-approve",
+    "-m",
+    "grok-4.5",
+    "stdio",
+  ]);
+  const observer = buildGrokAcpSpawnArgs({
+    permissionMode: "observer",
+    toolIntegrationMode: "skills",
+  });
+  assert.deepEqual(observer, ["--no-auto-update", "agent", "stdio"]);
+});
+
+test("buildGrokAcpSpawnArgs applies MCP-mode local-tool lockdown", () => {
+  const args = buildGrokAcpSpawnArgs({
+    permissionMode: "auto",
+    toolIntegrationMode: "mcp",
+  });
+  const denyIdx = args.indexOf("--disallowed-tools");
+  assert.ok(denyIdx >= 0, "MCP mode must pass --disallowed-tools on ACP spawn");
+  const denied = String(args[denyIdx + 1] || "");
+  assert.match(denied, /run_terminal_command/);
+  assert.match(denied, /search_replace/);
+  assert.match(denied, /write/);
+  assert.doesNotMatch(denied, /mcp|netcatty/i);
+  assert.ok(args.includes("--no-auto-update"));
+  assert.ok(args.includes("--always-approve"));
+  assert.equal(args[args.length - 1], "stdio");
+  // Skills mode: no lockdown list
+  const skills = buildGrokAcpSpawnArgs({
+    permissionMode: "auto",
+    toolIntegrationMode: "skills",
+  });
+  assert.ok(!skills.includes("--disallowed-tools"));
 });
 
 test("toAcpMcpEnvPairs keeps Grok session/new pair-array shape", () => {
@@ -102,7 +146,7 @@ test("buildGrokAcpSessionNewParams injects MCP servers and MCP-mode rules", () =
       env: [{ name: "NETCATTY_MCP_PORT", value: "1" }],
     }],
   });
-  assert.equal(params.cwd, "/repo");
+  assert.equal(params.cwd, resolveGrokAcpCwd("/repo"));
   assert.equal(params.mcpServers[0].name, "netcatty-remote-hosts");
   assert.equal(params.mcpServers[0].type, "stdio");
   assert.ok(Array.isArray(params.mcpServers[0].env));
@@ -112,6 +156,10 @@ test("buildGrokAcpSessionNewParams injects MCP servers and MCP-mode rules", () =
   assert.equal(params._meta.yoloMode, true);
   assert.match(String(params._meta.rules || ""), /netcatty-remote-hosts|MCP mode/i);
   assert.match(String(params._meta.rules || ""), /run_terminal_command|search_replace|write/);
+  // Soft rules list the same local tools as the hard CLI deny list.
+  for (const tool of GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS) {
+    assert.match(String(params._meta.rules || ""), new RegExp(tool));
+  }
 
   const skills = buildGrokAcpSessionNewParams({
     cwd: "/repo",
@@ -121,6 +169,155 @@ test("buildGrokAcpSessionNewParams injects MCP servers and MCP-mode rules", () =
   });
   assert.equal(skills._meta.yoloMode, true);
   assert.equal(skills._meta.rules, undefined);
+});
+
+test("planGrokAcpSessionEstablish prefers resume then load then new", () => {
+  assert.deepEqual(planGrokAcpSessionEstablish({ resumeSessionId: null }), ["new"]);
+  assert.deepEqual(planGrokAcpSessionEstablish({
+    resumeSessionId: "s1",
+    agentCapabilities: { resume: true, loadSession: true, hasCapabilityInfo: true },
+  }), ["resume", "load", "new"]);
+  assert.deepEqual(planGrokAcpSessionEstablish({
+    resumeSessionId: "s1",
+    agentCapabilities: { resume: true, loadSession: false, hasCapabilityInfo: true },
+  }), ["resume", "new"]);
+  assert.deepEqual(planGrokAcpSessionEstablish({
+    resumeSessionId: "s1",
+    agentCapabilities: { resume: false, loadSession: true, hasCapabilityInfo: true },
+  }), ["load", "new"]);
+  // Unknown capabilities: try resume + load then new (Grok versions vary).
+  assert.deepEqual(planGrokAcpSessionEstablish({
+    resumeSessionId: "s1",
+    agentCapabilities: { resume: false, loadSession: false, hasCapabilityInfo: false },
+  }), ["resume", "load", "new"]);
+});
+
+test("parseGrokAcpAgentCapabilities reads loadSession and sessionCapabilities.resume", () => {
+  assert.deepEqual(parseGrokAcpAgentCapabilities({
+    agentCapabilities: {
+      loadSession: true,
+      sessionCapabilities: { resume: {} },
+    },
+  }), { loadSession: true, resume: true, hasCapabilityInfo: true });
+  assert.deepEqual(parseGrokAcpAgentCapabilities({}), {
+    loadSession: false,
+    resume: false,
+    hasCapabilityInfo: false,
+  });
+});
+
+test("selectGrokAcpAuthMethodId follows xAI sample precedence", () => {
+  assert.deepEqual(
+    selectGrokAcpAuthMethodId({ authMethods: [] }, {}),
+    { methodId: null, required: false },
+  );
+  assert.deepEqual(
+    selectGrokAcpAuthMethodId({
+      authMethods: [{ id: "xai.api_key" }, { id: "cached_token" }],
+    }, { XAI_API_KEY: "xai-test" }),
+    { methodId: "xai.api_key", required: true },
+  );
+  assert.deepEqual(
+    selectGrokAcpAuthMethodId({
+      authMethods: [{ id: "xai.api_key" }, { id: "cached_token" }],
+    }, {}),
+    { methodId: "cached_token", required: true },
+  );
+  assert.deepEqual(
+    selectGrokAcpAuthMethodId({ authMethods: [{ id: "other" }] }, {}),
+    { methodId: null, required: true },
+  );
+});
+
+test("authenticateGrokAcp skips when no methods; errors when required method missing", async () => {
+  const calls = [];
+  const rpc = {
+    async request(method, params) {
+      calls.push([method, params]);
+      return {};
+    },
+  };
+  const skipped = await authenticateGrokAcp(rpc, { authMethods: [] }, {});
+  assert.equal(skipped.skipped, true);
+  assert.deepEqual(calls, []);
+
+  await assert.rejects(
+    () => authenticateGrokAcp(rpc, { authMethods: [{ id: "unknown" }] }, {}),
+    /grok login|XAI_API_KEY/i,
+  );
+
+  const ok = await authenticateGrokAcp(
+    rpc,
+    { authMethods: [{ id: "cached_token" }] },
+    {},
+  );
+  assert.equal(ok.methodId, "cached_token");
+  assert.equal(calls[0][0], "authenticate");
+  assert.equal(calls[0][1].methodId, "cached_token");
+  assert.equal(calls[0][1]._meta.headless, true);
+});
+
+test("establishGrokAcpSession tries resume then falls back to load then new", async () => {
+  const methods = [];
+  const rpc = {
+    async request(method, params) {
+      methods.push([method, params]);
+      if (method === "session/resume") throw new Error("resume unsupported");
+      if (method === "session/load") {
+        // Simulate history replay side-channel; caller keeps acceptUpdates false.
+        return { sessionId: "loaded-1" };
+      }
+      throw new Error(`unexpected ${method}`);
+    },
+  };
+  const result = await establishGrokAcpSession(rpc, {
+    resumeSessionId: "prev-1",
+    cwd: "/repo",
+    injectedMcpServers: [],
+    agentCapabilities: { resume: true, loadSession: true, hasCapabilityInfo: true },
+  });
+  assert.equal(result.method, "load");
+  assert.equal(result.sessionId, "loaded-1");
+  assert.deepEqual(methods.map((m) => m[0]), ["session/resume", "session/load"]);
+  assert.equal(methods[0][1].sessionId, "prev-1");
+  assert.equal(methods[0][1].cwd, resolveGrokAcpCwd("/repo"));
+});
+
+test("establishGrokAcpSession prefers resume when it succeeds", async () => {
+  const methods = [];
+  const rpc = {
+    async request(method, params) {
+      methods.push(method);
+      if (method === "session/resume") return {};
+      throw new Error(`unexpected ${method}`);
+    },
+  };
+  const result = await establishGrokAcpSession(rpc, {
+    resumeSessionId: "prev-2",
+    cwd: path.resolve("/repo"),
+    injectedMcpServers: [],
+    agentCapabilities: { resume: true, loadSession: true, hasCapabilityInfo: true },
+  });
+  assert.equal(result.method, "resume");
+  assert.equal(result.sessionId, "prev-2");
+  assert.deepEqual(methods, ["session/resume"]);
+});
+
+test("buildGrokAcpSessionResumeOrLoadParams keeps absolute cwd and MCP pairs", () => {
+  const params = buildGrokAcpSessionResumeOrLoadParams({
+    sessionId: "s1",
+    cwd: "relative-dir",
+    injectedMcpServers: [{
+      name: "netcatty-remote-hosts",
+      command: "node",
+      args: ["x"],
+      env: { A: "1" },
+    }],
+  });
+  assert.equal(params.sessionId, "s1");
+  assert.equal(params.cwd, resolveGrokAcpCwd("relative-dir"));
+  assert.ok(path.isAbsolute(params.cwd));
+  assert.deepEqual(params.mcpServers[0].env, [{ name: "A", value: "1" }]);
 });
 
 test("buildGrokAcpInitializeParams and prompt params follow ACP shapes", () => {
@@ -241,7 +438,7 @@ test("handleGrokAcpMessage suppresses session/load history until prompt accepts 
   assert.deepEqual(emitter.calls, [["text", "only this turn"]]);
 });
 
-test("runGrokAcpTurn drives initialize/session/new/prompt via fixture RPC", async () => {
+test("runGrokAcpTurn drives initialize/authenticate/session/new/prompt via fixture RPC", async () => {
   const emitter = makeEmitter();
   const methods = [];
   const result = await runGrokAcpTurn({
@@ -250,6 +447,7 @@ test("runGrokAcpTurn drives initialize/session/new/prompt via fixture RPC", asyn
     cwd: "/repo",
     permissionMode: "auto",
     toolIntegrationMode: "mcp",
+    env: { XAI_API_KEY: "xai-test" },
     injectedMcpServers: [{
       name: "netcatty-remote-hosts",
       command: "node",
@@ -260,9 +458,19 @@ test("runGrokAcpTurn drives initialize/session/new/prompt via fixture RPC", asyn
     rpcClientFactory: ({ emitter: em, state }) => ({
       async request(method, params) {
         methods.push([method, params]);
-        if (method === "initialize") return { protocolVersion: ACP_PROTOCOL_VERSION };
+        if (method === "initialize") {
+          return {
+            protocolVersion: ACP_PROTOCOL_VERSION,
+            authMethods: [{ id: "xai.api_key" }, { id: "cached_token" }],
+          };
+        }
+        if (method === "authenticate") {
+          assert.equal(params.methodId, "xai.api_key");
+          assert.equal(params._meta.headless, true);
+          return {};
+        }
         if (method === "session/new") {
-          assert.equal(params.cwd, "/repo");
+          assert.equal(params.cwd, resolveGrokAcpCwd("/repo"));
           assert.equal(params.mcpServers[0].name, "netcatty-remote-hosts");
           assert.equal(params.mcpServers[0].type, "stdio");
           assert.ok(Array.isArray(params.mcpServers[0].env));
@@ -287,10 +495,162 @@ test("runGrokAcpTurn drives initialize/session/new/prompt via fixture RPC", asyn
 
   assert.equal(result.runtime, "acp");
   assert.equal(result.sessionId, "acp-sess-1");
-  assert.deepEqual(methods.map((m) => m[0]), ["initialize", "session/new", "session/prompt"]);
+  assert.deepEqual(
+    methods.map((m) => m[0]),
+    ["initialize", "authenticate", "session/new", "session/prompt"],
+  );
   assert.ok(emitter.calls.some((c) => c[0] === "text" && c[1] === "hello-acp"));
   assert.ok(emitter.calls.some((c) => c[0] === "sessionId" && c[1] === "acp-sess-1"));
   assert.ok(emitter.calls.some((c) => c[0] === "done"));
+});
+
+test("runGrokAcpTurn prefers session/resume and keeps load history off the emitter", async () => {
+  const emitter = makeEmitter();
+  const methods = [];
+  const result = await runGrokAcpTurn({
+    prompt: "follow up",
+    binPath: "/usr/bin/grok",
+    cwd: "/repo",
+    resumeSessionId: "prior-sess",
+    permissionMode: "auto",
+    toolIntegrationMode: "mcp",
+    emitter,
+    rpcClientFactory: ({ emitter: em, state }) => ({
+      async request(method, params) {
+        methods.push(method);
+        if (method === "initialize") {
+          return {
+            protocolVersion: ACP_PROTOCOL_VERSION,
+            agentCapabilities: {
+              loadSession: true,
+              sessionCapabilities: { resume: {} },
+            },
+            authMethods: [],
+          };
+        }
+        if (method === "session/resume") {
+          assert.equal(params.sessionId, "prior-sess");
+          // Resume must not replay; even if a rogue update arrives pre-prompt, suppress it.
+          handleGrokAcpMessage({
+            jsonrpc: "2.0",
+            method: "session/update",
+            params: {
+              sessionId: "prior-sess",
+              update: {
+                sessionUpdate: "agent_message_chunk",
+                content: { text: "SHOULD NOT APPEAR" },
+              },
+            },
+          }, { emitter: em, state, pending: new Map() });
+          return {};
+        }
+        if (method === "session/prompt") {
+          assert.equal(state.acceptUpdates, true);
+          translateGrokAcpUpdate({
+            sessionUpdate: "agent_message_chunk",
+            content: { text: "only this turn" },
+          }, em, state);
+          return { stopReason: "end_turn" };
+        }
+        throw new Error(`unexpected method ${method}`);
+      },
+    }),
+  });
+
+  assert.equal(result.sessionId, "prior-sess");
+  assert.deepEqual(methods, ["initialize", "session/resume", "session/prompt"]);
+  assert.deepEqual(
+    emitter.calls.filter((c) => c[0] === "text"),
+    [["text", "only this turn"]],
+  );
+  assert.ok(!emitter.calls.some((c) => c[0] === "text" && String(c[1]).includes("SHOULD NOT")));
+});
+
+test("runGrokAcpTurn falls back to session/load and suppresses history replay text", async () => {
+  const emitter = makeEmitter();
+  const methods = [];
+  const result = await runGrokAcpTurn({
+    prompt: "follow up",
+    binPath: "/usr/bin/grok",
+    resumeSessionId: "prior-load",
+    permissionMode: "auto",
+    emitter,
+    rpcClientFactory: ({ emitter: em, state }) => ({
+      async request(method) {
+        methods.push(method);
+        if (method === "initialize") {
+          return {
+            protocolVersion: ACP_PROTOCOL_VERSION,
+            agentCapabilities: {
+              loadSession: true,
+              sessionCapabilities: { resume: {} },
+            },
+            authMethods: [],
+          };
+        }
+        if (method === "session/resume") throw new Error("resume not available");
+        if (method === "session/load") {
+          assert.equal(state.acceptUpdates, false);
+          // Load-style history replay must not hit the current bubble.
+          handleGrokAcpMessage({
+            jsonrpc: "2.0",
+            method: "session/update",
+            params: {
+              sessionId: "prior-load",
+              update: {
+                sessionUpdate: "agent_message_chunk",
+                content: { text: "previous turn reply" },
+              },
+            },
+          }, { emitter: em, state, pending: new Map() });
+          return { sessionId: "prior-load" };
+        }
+        if (method === "session/prompt") {
+          translateGrokAcpUpdate({
+            sessionUpdate: "agent_message_chunk",
+            content: { text: "fresh reply" },
+          }, em, state);
+          return { stopReason: "end_turn" };
+        }
+        throw new Error(`unexpected method ${method}`);
+      },
+    }),
+  });
+
+  assert.equal(result.sessionId, "prior-load");
+  assert.deepEqual(methods, [
+    "initialize",
+    "session/resume",
+    "session/load",
+    "session/prompt",
+  ]);
+  assert.deepEqual(
+    emitter.calls.filter((c) => c[0] === "text"),
+    [["text", "fresh reply"]],
+  );
+});
+
+test("runGrokAcpTurn maps missing auth methods to a clear user error", async () => {
+  const emitter = makeEmitter();
+  await runGrokAcpTurn({
+    prompt: "hi",
+    binPath: "/usr/bin/grok",
+    emitter,
+    rpcClientFactory: () => ({
+      async request(method) {
+        if (method === "initialize") {
+          return {
+            protocolVersion: ACP_PROTOCOL_VERSION,
+            authMethods: [{ id: "weird-method" }],
+          };
+        }
+        throw new Error(`unexpected method ${method}`);
+      },
+    }),
+  });
+  const err = emitter.calls.find((c) => c[0] === "error");
+  assert.ok(err);
+  assert.match(String(err[1]), /not logged in|grok login|XAI_API_KEY/i);
 });
 
 test("runGrokAcpTurn reports missing CLI clearly", async () => {

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -187,7 +187,7 @@ test("createJsonRpcClient correlates request ids and parses lines", async () => 
 
 test("handleGrokAcpMessage routes session/update notifications", () => {
   const emitter = makeEmitter();
-  const state = {};
+  const state = { acceptUpdates: true };
   const pending = new Map();
   handleGrokAcpMessage({
     jsonrpc: "2.0",
@@ -205,6 +205,40 @@ test("handleGrokAcpMessage routes session/update notifications", () => {
     ["text", "ok"],
     ["sessionId", "s1"],
   ]);
+});
+
+test("handleGrokAcpMessage suppresses session/load history until prompt accepts updates", () => {
+  const emitter = makeEmitter();
+  const state = { acceptUpdates: false };
+  const pending = new Map();
+  // Historical replay during session/load must not pollute the current turn.
+  handleGrokAcpMessage({
+    jsonrpc: "2.0",
+    method: "session/update",
+    params: {
+      sessionId: "s1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { text: "previous turn reply" },
+      },
+    },
+  }, { emitter, state, pending });
+  assert.equal(state.sessionId, "s1");
+  assert.deepEqual(emitter.calls, []);
+
+  state.acceptUpdates = true;
+  handleGrokAcpMessage({
+    jsonrpc: "2.0",
+    method: "session/update",
+    params: {
+      sessionId: "s1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { text: "only this turn" },
+      },
+    },
+  }, { emitter, state, pending });
+  assert.deepEqual(emitter.calls, [["text", "only this turn"]]);
 });
 
 test("runGrokAcpTurn drives initialize/session/new/prompt via fixture RPC", async () => {

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -1,0 +1,259 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  ACP_PROTOCOL_VERSION,
+  buildGrokAcpInitializeParams,
+  buildGrokAcpPromptParams,
+  buildGrokAcpSessionNewParams,
+  buildGrokAcpSpawnArgs,
+  createJsonRpcClient,
+  handleGrokAcpMessage,
+  runGrokAcpTurn,
+  toAcpMcpServers,
+  translateGrokAcpUpdate,
+} = require("./grokAcpDriver.cjs");
+const { getDriver, listBackends } = require("./index.cjs");
+
+function makeEmitter() {
+  const calls = [];
+  return {
+    calls,
+    text: (value) => calls.push(["text", value]),
+    reasoning: (value) => calls.push(["reasoning", value]),
+    reasoningEnd: () => calls.push(["reasoningEnd"]),
+    toolCall: (name, args, id) => calls.push(["toolCall", name, args, id]),
+    toolResult: (id, result, name) => calls.push(["toolResult", id, result, name]),
+    sessionId: (id) => calls.push(["sessionId", id]),
+    planUpdate: (itemId, items, status) => calls.push(["planUpdate", itemId, items, status]),
+    emitDone: () => calls.push(["done"]),
+    emitError: (message) => calls.push(["error", message]),
+  };
+}
+
+test("buildGrokAcpSpawnArgs uses agent stdio and always-approve for non-observer", () => {
+  assert.deepEqual(
+    buildGrokAcpSpawnArgs({ model: "grok-4.5", permissionMode: "auto" }),
+    ["agent", "--always-approve", "-m", "grok-4.5", "stdio"],
+  );
+  assert.deepEqual(
+    buildGrokAcpSpawnArgs({ permissionMode: "observer" }),
+    ["agent", "stdio"],
+  );
+});
+
+test("toAcpMcpServers maps injectMcp env pairs for session/new", () => {
+  assert.deepEqual(
+    toAcpMcpServers([{
+      name: "netcatty-remote-hosts",
+      command: "node",
+      args: ["mcp.cjs"],
+      env: [{ name: "NETCATTY_MCP_PORT", value: "9" }, { name: "NETCATTY_MCP_TOKEN", value: "t" }],
+    }]),
+    [{
+      name: "netcatty-remote-hosts",
+      command: "node",
+      args: ["mcp.cjs"],
+      env: { NETCATTY_MCP_PORT: "9", NETCATTY_MCP_TOKEN: "t" },
+    }],
+  );
+});
+
+test("buildGrokAcpSessionNewParams injects MCP servers and MCP-mode rules", () => {
+  const params = buildGrokAcpSessionNewParams({
+    cwd: "/repo",
+    permissionMode: "auto",
+    toolIntegrationMode: "mcp",
+    injectedMcpServers: [{
+      name: "netcatty-remote-hosts",
+      command: "node",
+      args: ["mcp.cjs"],
+      env: [{ name: "NETCATTY_MCP_PORT", value: "1" }],
+    }],
+  });
+  assert.equal(params.cwd, "/repo");
+  assert.equal(params.mcpServers[0].name, "netcatty-remote-hosts");
+  assert.equal(params._meta.yoloMode, true);
+  assert.match(String(params._meta.rules || ""), /netcatty-remote-hosts|MCP mode/i);
+  assert.match(String(params._meta.rules || ""), /run_terminal_command|search_replace|write/);
+
+  const skills = buildGrokAcpSessionNewParams({
+    cwd: "/repo",
+    permissionMode: "auto",
+    toolIntegrationMode: "skills",
+    injectedMcpServers: [],
+  });
+  assert.equal(skills._meta.yoloMode, true);
+  assert.equal(skills._meta.rules, undefined);
+});
+
+test("buildGrokAcpInitializeParams and prompt params follow ACP shapes", () => {
+  const init = buildGrokAcpInitializeParams();
+  assert.equal(init.protocolVersion, ACP_PROTOCOL_VERSION);
+  assert.equal(init.clientInfo.name, "netcatty");
+  assert.deepEqual(
+    buildGrokAcpPromptParams("sess-1", "hello"),
+    { sessionId: "sess-1", prompt: [{ type: "text", text: "hello" }] },
+  );
+});
+
+test("translateGrokAcpUpdate maps text, thought, tools to canonical emitter events", () => {
+  const emitter = makeEmitter();
+  const state = {};
+  translateGrokAcpUpdate({
+    sessionUpdate: "agent_thought_chunk",
+    content: { text: "plan" },
+  }, emitter, state);
+  translateGrokAcpUpdate({
+    sessionUpdate: "agent_message_chunk",
+    content: { text: "Hi" },
+  }, emitter, state);
+  translateGrokAcpUpdate({
+    sessionUpdate: "tool_call",
+    toolCallId: "c1",
+    toolName: "mcp__netcatty-remote-hosts__get_environment",
+    rawInput: { x: 1 },
+  }, emitter, state);
+  translateGrokAcpUpdate({
+    sessionUpdate: "tool_call_update",
+    toolCallId: "c1",
+    status: "completed",
+    rawOutput: { ok: true },
+  }, emitter, state);
+
+  assert.deepEqual(emitter.calls, [
+    ["reasoning", "plan"],
+    ["reasoningEnd"],
+    ["text", "Hi"],
+    ["toolCall", "mcp__netcatty-remote-hosts__get_environment", { x: 1 }, "c1"],
+    ["toolResult", "c1", "{\"ok\":true}", "mcp__netcatty-remote-hosts__get_environment"],
+  ]);
+});
+
+test("createJsonRpcClient correlates request ids and parses lines", async () => {
+  const written = [];
+  const client = createJsonRpcClient({
+    write: (line) => written.push(line),
+    onMessage: (message, pending) => {
+      if (message.id != null && pending.has(message.id)) {
+        const waiter = pending.get(message.id);
+        pending.delete(message.id);
+        waiter.resolve(message.result);
+      }
+    },
+  });
+  const pending = client.request("initialize", { protocolVersion: 1 });
+  assert.match(written[0], /"method":"initialize"/);
+  const sent = JSON.parse(written[0]);
+  client.handleLine(JSON.stringify({ jsonrpc: "2.0", id: sent.id, result: { ok: true } }));
+  assert.deepEqual(await pending, { ok: true });
+});
+
+test("handleGrokAcpMessage routes session/update notifications", () => {
+  const emitter = makeEmitter();
+  const state = {};
+  const pending = new Map();
+  handleGrokAcpMessage({
+    jsonrpc: "2.0",
+    method: "session/update",
+    params: {
+      sessionId: "s1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { text: "ok" },
+      },
+    },
+  }, { emitter, state, pending });
+  assert.equal(state.sessionId, "s1");
+  assert.deepEqual(emitter.calls, [
+    ["text", "ok"],
+    ["sessionId", "s1"],
+  ]);
+});
+
+test("runGrokAcpTurn drives initialize/session/new/prompt via fixture RPC", async () => {
+  const emitter = makeEmitter();
+  const methods = [];
+  const result = await runGrokAcpTurn({
+    prompt: "hi",
+    binPath: "/usr/bin/grok",
+    cwd: "/repo",
+    permissionMode: "auto",
+    toolIntegrationMode: "mcp",
+    injectedMcpServers: [{
+      name: "netcatty-remote-hosts",
+      command: "node",
+      args: ["mcp.cjs"],
+      env: [{ name: "NETCATTY_MCP_PORT", value: "7" }],
+    }],
+    emitter,
+    rpcClientFactory: ({ emitter: em, state }) => ({
+      async request(method, params) {
+        methods.push([method, params]);
+        if (method === "initialize") return { protocolVersion: ACP_PROTOCOL_VERSION };
+        if (method === "session/new") {
+          assert.equal(params.cwd, "/repo");
+          assert.equal(params.mcpServers[0].name, "netcatty-remote-hosts");
+          assert.equal(params.mcpServers[0].env.NETCATTY_MCP_PORT, "7");
+          return { sessionId: "acp-sess-1" };
+        }
+        if (method === "session/prompt") {
+          // Simulate streamed ACP updates during the prompt
+          translateGrokAcpUpdate({
+            sessionUpdate: "agent_message_chunk",
+            content: { text: "hello-acp" },
+          }, em, state);
+          return { stopReason: "end_turn" };
+        }
+        throw new Error(`unexpected method ${method}`);
+      },
+    }),
+  });
+
+  assert.equal(result.runtime, "acp");
+  assert.equal(result.sessionId, "acp-sess-1");
+  assert.deepEqual(methods.map((m) => m[0]), ["initialize", "session/new", "session/prompt"]);
+  assert.ok(emitter.calls.some((c) => c[0] === "text" && c[1] === "hello-acp"));
+  assert.ok(emitter.calls.some((c) => c[0] === "sessionId" && c[1] === "acp-sess-1"));
+  assert.ok(emitter.calls.some((c) => c[0] === "done"));
+});
+
+test("runGrokAcpTurn reports missing CLI clearly", async () => {
+  const emitter = makeEmitter();
+  const result = await runGrokAcpTurn({
+    prompt: "hi",
+    binPath: "",
+    emitter,
+  });
+  assert.equal(result.sessionId, null);
+  assert.equal(result.runtime, "acp");
+  assert.match(String(emitter.calls[0]?.[1] || ""), /not found/i);
+});
+
+test("registry grok backend defaults to ACP path and keeps streaming-json fallback", async () => {
+  assert.ok(listBackends().includes("grok"));
+  const driver = getDriver("grok");
+  assert.equal(typeof driver.runTurn, "function");
+
+  // Fallback runtime uses streaming-json builder path (no real binary).
+  const emitter = makeEmitter();
+  const fallback = await driver.runTurn({
+    prompt: "x",
+    binPath: "",
+    grokRuntime: "streaming-json",
+    emitter,
+    env: {},
+  });
+  assert.equal(fallback.sessionId, null);
+  assert.match(String(emitter.calls[0]?.[1] || ""), /not found/i);
+
+  // Default ACP path also surfaces missing CLI without hanging.
+  const emitter2 = makeEmitter();
+  const acp = await driver.runTurn({
+    prompt: "x",
+    binPath: "",
+    emitter: emitter2,
+    env: {},
+  });
+  assert.equal(acp.runtime, "acp");
+  assert.match(String(emitter2.calls[0]?.[1] || ""), /not found/i);
+});

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -773,6 +773,164 @@ test("runGrokAcpTurn reports missing CLI clearly", async () => {
   assert.match(String(emitter.calls[0]?.[1] || ""), /not found/i);
 });
 
+test("runGrokAcpTurn does not treat post-prompt exit code 1 as failure for tool-only turns", async () => {
+  // Repro: successful session/prompt (tools only, no assistant text) then
+  // process teardown with code 1 (Windows taskkill). Must emitDone, not error.
+  const { EventEmitter } = require("node:events");
+  const emitter = makeEmitter();
+
+  function makeFakeChild() {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin = {
+      destroyed: false,
+      write(line) {
+        let msg;
+        try { msg = JSON.parse(String(line).trim()); } catch { return; }
+        if (msg?.id == null) return;
+        queueMicrotask(() => {
+          if (msg.method === "initialize") {
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0",
+              id: msg.id,
+              result: { protocolVersion: ACP_PROTOCOL_VERSION, authMethods: [] },
+            })}\n`));
+          } else if (msg.method === "session/new") {
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0",
+              id: msg.id,
+              result: { sessionId: "s-tool" },
+            })}\n`));
+          } else if (msg.method === "session/prompt") {
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0",
+              method: "session/update",
+              params: {
+                sessionId: "s-tool",
+                update: {
+                  sessionUpdate: "tool_call",
+                  toolCallId: "t1",
+                  toolName: "read_file",
+                  rawInput: {},
+                },
+              },
+            })}\n`));
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0",
+              method: "session/update",
+              params: {
+                sessionId: "s-tool",
+                update: {
+                  sessionUpdate: "tool_call_update",
+                  toolCallId: "t1",
+                  status: "completed",
+                  rawOutput: "ok",
+                },
+              },
+            })}\n`));
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0",
+              id: msg.id,
+              result: { stopReason: "end_turn" },
+            })}\n`));
+            queueMicrotask(() => child.emit("close", 1));
+          } else {
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0",
+              id: msg.id,
+              result: {},
+            })}\n`));
+          }
+        });
+      },
+      end() {},
+    };
+    child.pid = 4242;
+    child.killed = false;
+    child.exitCode = null;
+    child.kill = () => {
+      child.killed = true;
+      queueMicrotask(() => child.emit("close", 1));
+    };
+    return child;
+  }
+
+  const result = await runGrokAcpTurn({
+    prompt: "tool only",
+    binPath: "C:\\fake\\grok.exe",
+    permissionMode: "auto",
+    emitter,
+    spawnImpl: () => makeFakeChild(),
+    forceKillImpl: (child) => { child.kill(); },
+  });
+
+  assert.equal(result.sessionId, "s-tool");
+  assert.ok(emitter.calls.some((c) => c[0] === "toolCall"));
+  assert.ok(emitter.calls.some((c) => c[0] === "done"));
+  assert.ok(!emitter.calls.some((c) => c[0] === "error"), "post-prompt exit 1 must not emitError");
+});
+
+test("runGrokAcpTurn still errors when process dies mid-turn with no completion", async () => {
+  const { EventEmitter } = require("node:events");
+  const emitter = makeEmitter();
+
+  function makeFakeChild() {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin = {
+      destroyed: false,
+      write(line) {
+        let msg;
+        try { msg = JSON.parse(String(line).trim()); } catch { return; }
+        if (msg?.id == null) return;
+        queueMicrotask(() => {
+          if (msg.method === "initialize") {
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0",
+              id: msg.id,
+              result: { protocolVersion: ACP_PROTOCOL_VERSION, authMethods: [] },
+            })}\n`));
+          } else if (msg.method === "session/new") {
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0",
+              id: msg.id,
+              result: { sessionId: "s-die" },
+            })}\n`));
+          } else if (msg.method === "session/prompt") {
+            // Die before answering prompt — turn never completed.
+            queueMicrotask(() => child.emit("close", 1));
+          } else {
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0",
+              id: msg.id,
+              result: {},
+            })}\n`));
+          }
+        });
+      },
+      end() {},
+    };
+    child.pid = 1;
+    child.killed = false;
+    child.exitCode = null;
+    child.kill = () => { child.killed = true; };
+    return child;
+  }
+
+  await runGrokAcpTurn({
+    prompt: "die mid turn",
+    binPath: "C:\\fake\\grok.exe",
+    permissionMode: "auto",
+    emitter,
+    spawnImpl: () => makeFakeChild(),
+  });
+
+  assert.ok(emitter.calls.some((c) => c[0] === "error"));
+  assert.ok(!emitter.calls.some((c) => c[0] === "done"));
+});
+
 test("registry grok backend defaults to ACP path and keeps streaming-json fallback", async () => {
   assert.ok(listBackends().includes("grok"));
   const driver = getDriver("grok");

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -386,6 +386,26 @@ test("translateGrokAcpUpdate maps text, thought, tools to canonical emitter even
   ]);
 });
 
+test("translateGrokAcpUpdate plan uses shared { text, completed } shape not content/status", () => {
+  const emitter = makeEmitter();
+  translateGrokAcpUpdate({
+    sessionUpdate: "plan",
+    entries: [
+      { content: "Map APIs", status: "completed" },
+      { text: "Write tests", status: "pending" },
+    ],
+  }, emitter, {});
+  const planCall = emitter.calls.find((c) => c[0] === "planUpdate");
+  assert.ok(planCall, "plan must emit planUpdate");
+  assert.deepEqual(planCall[2], [
+    { text: "Map APIs", completed: true },
+    { text: "Write tests", completed: false },
+  ]);
+  assert.equal(planCall[3], "running");
+  // Adapter only treats top-level "completed" as done; "updated" stuck as running forever.
+  assert.notEqual(planCall[3], "updated");
+});
+
 test("createJsonRpcClient correlates request ids and parses lines", async () => {
   const written = [];
   const client = createJsonRpcClient({

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -9,6 +9,7 @@ const {
   createJsonRpcClient,
   handleGrokAcpMessage,
   runGrokAcpTurn,
+  toAcpMcpEnvPairs,
   toAcpMcpServers,
   translateGrokAcpUpdate,
 } = require("./grokAcpDriver.cjs");
@@ -41,7 +42,24 @@ test("buildGrokAcpSpawnArgs uses agent stdio and always-approve for non-observer
   );
 });
 
-test("toAcpMcpServers maps injectMcp env pairs for session/new", () => {
+test("toAcpMcpEnvPairs keeps Grok session/new pair-array shape", () => {
+  // Live Grok rejects plain object env (Invalid params / McpServer enum).
+  assert.deepEqual(
+    toAcpMcpEnvPairs([{ name: "NETCATTY_MCP_PORT", value: "9" }]),
+    [{ name: "NETCATTY_MCP_PORT", value: "9" }],
+  );
+  // If a plain object sneaks in, still emit pairs (not a map).
+  assert.deepEqual(
+    toAcpMcpEnvPairs({ NETCATTY_MCP_PORT: "9", NETCATTY_MCP_TOKEN: "t" }),
+    [
+      { name: "NETCATTY_MCP_PORT", value: "9" },
+      { name: "NETCATTY_MCP_TOKEN", value: "t" },
+    ],
+  );
+  assert.deepEqual(toAcpMcpEnvPairs(undefined), []);
+});
+
+test("toAcpMcpServers maps injectMcp env as name/value pairs for session/new", () => {
   assert.deepEqual(
     toAcpMcpServers([{
       name: "netcatty-remote-hosts",
@@ -51,11 +69,25 @@ test("toAcpMcpServers maps injectMcp env pairs for session/new", () => {
     }]),
     [{
       name: "netcatty-remote-hosts",
+      type: "stdio",
       command: "node",
       args: ["mcp.cjs"],
-      env: { NETCATTY_MCP_PORT: "9", NETCATTY_MCP_TOKEN: "t" },
+      env: [
+        { name: "NETCATTY_MCP_PORT", value: "9" },
+        { name: "NETCATTY_MCP_TOKEN", value: "t" },
+      ],
     }],
   );
+  // Must never emit object-map env (Grok session/new rejects it).
+  const mapped = toAcpMcpServers([{
+    name: "x",
+    command: "node",
+    args: [],
+    env: { A: "1" },
+  }]);
+  assert.ok(Array.isArray(mapped[0].env));
+  assert.equal(mapped[0].type, "stdio");
+  assert.deepEqual(mapped[0].env, [{ name: "A", value: "1" }]);
 });
 
 test("buildGrokAcpSessionNewParams injects MCP servers and MCP-mode rules", () => {
@@ -72,6 +104,11 @@ test("buildGrokAcpSessionNewParams injects MCP servers and MCP-mode rules", () =
   });
   assert.equal(params.cwd, "/repo");
   assert.equal(params.mcpServers[0].name, "netcatty-remote-hosts");
+  assert.equal(params.mcpServers[0].type, "stdio");
+  assert.ok(Array.isArray(params.mcpServers[0].env));
+  assert.deepEqual(params.mcpServers[0].env, [{ name: "NETCATTY_MCP_PORT", value: "1" }]);
+  // Explicitly forbid the broken object-map shape in the shipped builder output.
+  assert.equal(typeof params.mcpServers[0].env.NETCATTY_MCP_PORT, "undefined");
   assert.equal(params._meta.yoloMode, true);
   assert.match(String(params._meta.rules || ""), /netcatty-remote-hosts|MCP mode/i);
   assert.match(String(params._meta.rules || ""), /run_terminal_command|search_replace|write/);
@@ -193,7 +230,12 @@ test("runGrokAcpTurn drives initialize/session/new/prompt via fixture RPC", asyn
         if (method === "session/new") {
           assert.equal(params.cwd, "/repo");
           assert.equal(params.mcpServers[0].name, "netcatty-remote-hosts");
-          assert.equal(params.mcpServers[0].env.NETCATTY_MCP_PORT, "7");
+          assert.equal(params.mcpServers[0].type, "stdio");
+          assert.ok(Array.isArray(params.mcpServers[0].env));
+          assert.deepEqual(
+            params.mcpServers[0].env,
+            [{ name: "NETCATTY_MCP_PORT", value: "7" }],
+          );
           return { sessionId: "acp-sess-1" };
         }
         if (method === "session/prompt") {

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -792,14 +792,22 @@ test("runGrokAcpTurn forwards usage from session/prompt result", async () => {
             sessionUpdate: "agent_message_chunk",
             content: { text: "ok" },
           }, em, state);
+          // Live Grok shape under _meta.usage (camelCase + cachedReadTokens).
           return {
             stopReason: "end_turn",
-            usage: {
-              input_tokens: 11,
-              output_tokens: 7,
-              cache_read_input_tokens: 2,
-              reasoning_tokens: 3,
-              total_tokens: 23,
+            _meta: {
+              inputTokens: 27144,
+              outputTokens: 29,
+              totalTokens: 27174,
+              cachedReadTokens: 2560,
+              reasoningTokens: 24,
+              usage: {
+                inputTokens: 27144,
+                outputTokens: 29,
+                totalTokens: 27173,
+                cachedReadTokens: 2560,
+                reasoningTokens: 24,
+              },
             },
           };
         }
@@ -810,13 +818,107 @@ test("runGrokAcpTurn forwards usage from session/prompt result", async () => {
   const usage = emitter.calls.find((c) => c[0] === "usage");
   assert.ok(usage);
   assert.deepEqual(usage[1], {
-    inputTokens: 11,
-    cachedInputTokens: 2,
-    outputTokens: 7,
-    reasoningTokens: 3,
-    totalTokens: 23,
+    inputTokens: 27144,
+    cachedInputTokens: 2560,
+    outputTokens: 29,
+    reasoningTokens: 24,
+    totalTokens: 27173,
   });
   assert.ok(emitter.calls.some((c) => c[0] === "done"));
+});
+
+test("runGrokAcpTurn emits usage on prompt response even when process closes same tick", async () => {
+  // Repro of Token ~1: onPromptComplete resolves promptDone in the same turn as
+  // the prompt RPC result; Promise.race often returns "closed" and used to skip usage.
+  const { EventEmitter } = require("node:events");
+  const emitter = makeEmitter();
+
+  function makeFakeChild() {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin = {
+      destroyed: false,
+      write(line) {
+        let msg;
+        try { msg = JSON.parse(String(line).trim()); } catch { return; }
+        if (msg?.id == null) return;
+        queueMicrotask(() => {
+          if (msg.method === "initialize") {
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0", id: msg.id,
+              result: { protocolVersion: ACP_PROTOCOL_VERSION, authMethods: [] },
+            })}\n`));
+          } else if (msg.method === "session/new") {
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0", id: msg.id, result: { sessionId: "s-race" },
+            })}\n`));
+          } else if (msg.method === "session/prompt") {
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0", method: "session/update",
+              params: {
+                sessionId: "s-race",
+                update: { sessionUpdate: "agent_message_chunk", content: { text: "long reply…" } },
+              },
+            })}\n`));
+            // Prompt result with real Grok usage, then same-tick process close
+            // (simulates onPromptComplete → promptDone racing the await).
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0",
+              id: msg.id,
+              result: {
+                stopReason: "end_turn",
+                _meta: {
+                  usage: {
+                    inputTokens: 1200,
+                    outputTokens: 800,
+                    totalTokens: 2000,
+                    cachedReadTokens: 100,
+                    reasoningTokens: 50,
+                  },
+                },
+              },
+            })}\n`));
+            queueMicrotask(() => child.emit("close", 1));
+          } else {
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0", id: msg.id, result: {},
+            })}\n`));
+          }
+        });
+      },
+      end() {},
+    };
+    child.pid = 7;
+    child.killed = false;
+    child.exitCode = null;
+    child.kill = () => {
+      child.killed = true;
+      queueMicrotask(() => child.emit("close", 1));
+    };
+    return child;
+  }
+
+  await runGrokAcpTurn({
+    prompt: "write a long essay",
+    binPath: "C:\\fake\\grok.exe",
+    permissionMode: "auto",
+    emitter,
+    spawnImpl: () => makeFakeChild(),
+    forceKillImpl: (c) => { c.kill(); },
+  });
+
+  const usage = emitter.calls.find((c) => c[0] === "usage");
+  assert.ok(usage, "usage must be emitted even if process closes in the same tick");
+  assert.deepEqual(usage[1], {
+    inputTokens: 1200,
+    cachedInputTokens: 100,
+    outputTokens: 800,
+    reasoningTokens: 50,
+    totalTokens: 2000,
+  });
+  assert.ok(emitter.calls.some((c) => c[0] === "done"));
+  assert.ok(!emitter.calls.some((c) => c[0] === "error"));
 });
 
 test("runGrokAcpTurn does not treat post-prompt exit code 1 as failure for tool-only turns", async () => {

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -1079,6 +1079,79 @@ test("runGrokAcpTurn still errors when process dies mid-turn with no completion"
   assert.ok(!emitter.calls.some((c) => c[0] === "done"));
 });
 
+test("runGrokAcpTurn errors when process dies after partial text without prompt result", async () => {
+  // Partial assistant text is not success — must not suppress exit failure.
+  const { EventEmitter } = require("node:events");
+  const emitter = makeEmitter();
+
+  function makeFakeChild() {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin = {
+      destroyed: false,
+      write(line) {
+        let msg;
+        try { msg = JSON.parse(String(line).trim()); } catch { return; }
+        if (msg?.id == null) return;
+        queueMicrotask(() => {
+          if (msg.method === "initialize") {
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0",
+              id: msg.id,
+              result: { protocolVersion: ACP_PROTOCOL_VERSION, authMethods: [] },
+            })}\n`));
+          } else if (msg.method === "session/new") {
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0",
+              id: msg.id,
+              result: { sessionId: "s-partial" },
+            })}\n`));
+          } else if (msg.method === "session/prompt") {
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0",
+              method: "session/update",
+              params: {
+                sessionId: "s-partial",
+                update: {
+                  sessionUpdate: "agent_message_chunk",
+                  content: { text: "half…" },
+                },
+              },
+            })}\n`));
+            // Crash before session/prompt result (turnCompleted stays false).
+            queueMicrotask(() => child.emit("close", 1));
+          } else {
+            child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+              jsonrpc: "2.0",
+              id: msg.id,
+              result: {},
+            })}\n`));
+          }
+        });
+      },
+      end() {},
+    };
+    child.pid = 2;
+    child.killed = false;
+    child.exitCode = null;
+    child.kill = () => { child.killed = true; };
+    return child;
+  }
+
+  await runGrokAcpTurn({
+    prompt: "long answer",
+    binPath: "C:\\fake\\grok.exe",
+    permissionMode: "auto",
+    emitter,
+    spawnImpl: () => makeFakeChild(),
+  });
+
+  assert.ok(emitter.calls.some((c) => c[0] === "text" && c[1] === "half…"));
+  assert.ok(emitter.calls.some((c) => c[0] === "error"), "partial text + crash must error");
+  assert.ok(!emitter.calls.some((c) => c[0] === "done"));
+});
+
 test("registry grok backend defaults to ACP path and keeps streaming-json fallback", async () => {
   assert.ok(listBackends().includes("grok"));
   const driver = getDriver("grok");

--- a/electron/bridges/aiBridge/sdk/grokDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.cjs
@@ -545,6 +545,22 @@ function extractGrokAcpPromptUsage(promptResult) {
 }
 
 /**
+ * Whether a process close should fail the turn.
+ * - turnCompleted: protocol finished (end / session/prompt) → ignore teardown noise
+ * - user abort: not a failure
+ * - nonzero code OR non-null exit signal before completion → failure
+ *   (Node reports code=null when killed by signal)
+ */
+function shouldReportGrokProcessExitFailure(state, abortSignal, code, exitSignal) {
+  if (state?.failed) return false;
+  if (abortSignal?.aborted) return false;
+  if (state?.turnCompleted) return false;
+  if (code != null && code !== 0) return true;
+  if (exitSignal) return true;
+  return false;
+}
+
+/**
  * Forward Grok/ACP usage onto the canonical emitter.
  * Supports Anthropic snake_case and Grok ACP camelCase (cachedReadTokens).
  */
@@ -764,23 +780,19 @@ async function runGrokTurn({
       }
       finish();
     });
-    child.on("close", (code) => {
+    child.on("close", (code, exitSignal) => {
       if (!stderrEnded) {
         stderrEnded = true;
         if (!stderrTruncated || stderrDecoder.lastNeed === 0) stderrText += stderrDecoder.end();
       }
-      // Only ignore nonzero exit after protocol completion (end event).
-      // Do NOT use streamedAssistantText: partial text + crash must still error.
-      // Windows kill after a completed turn often exits 1 — turnCompleted covers that.
-      if (
-        !state.failed
-        && !signal?.aborted
-        && !state.turnCompleted
-        && code
-        && code !== 0
-      ) {
+      // Only ignore abnormal exit after protocol completion (end event).
+      // Signal kills report code=null — still fail if turn not completed.
+      if (shouldReportGrokProcessExitFailure(state, signal, code, exitSignal)) {
         const stderr = stderrText.trim();
-        const message = stderr || `Grok Build exited with code ${code}`;
+        const detail = code != null && code !== 0
+          ? `exited with code ${code}`
+          : (exitSignal ? `terminated by signal ${exitSignal}` : "exited unexpectedly");
+        const message = stderr || `Grok Build ${detail}`;
         state.failed = true;
         emitter.emitError(formatGrokErrorForUser(message));
       }
@@ -964,6 +976,7 @@ module.exports = {
   resolveGrokTurnPrompt,
   extractGrokAcpPromptUsage,
   emitGrokUsage,
+  shouldReportGrokProcessExitFailure,
   runGrokTurn,
   spawnGrokProcess,
   stripGrokMcpServerSection,

--- a/electron/bridges/aiBridge/sdk/grokDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.cjs
@@ -14,6 +14,7 @@ const { spawn } = require("node:child_process");
 const { StringDecoder } = require("node:string_decoder");
 const fs = require("node:fs");
 const path = require("node:path");
+const { prepareCommandForSpawn } = require("../../ai/shellUtils.cjs");
 const { mcpEnvPairsToObject } = require("./injectMcp.cjs");
 
 const NETCATTY_MCP_NAME = "netcatty-remote-hosts";
@@ -21,6 +22,30 @@ const GROK_ABORT_GRACE_MS = 1_500;
 const MAX_GROK_STDERR_CHARS = 64 * 1024;
 const MAX_GROK_MODEL_STDOUT_CHARS = 1024 * 1024;
 const MAX_GROK_LINE_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Resolve Grok CLI spawn target for Windows .cmd/.bat shims.
+ * Matches other managed agents (agentCliHelpers / Codex login).
+ */
+function resolveGrokSpawnSpec(cliPath, args) {
+  return prepareCommandForSpawn(String(cliPath || "").trim(), Array.isArray(args) ? args : []);
+}
+
+/**
+ * Spawn grok via prepareCommandForSpawn so Windows npm/installer shims work.
+ * @param {Function|undefined} spawnImpl
+ * @param {string} cliPath
+ * @param {string[]} args
+ * @param {import('node:child_process').SpawnOptionsWithoutStdio & object} options
+ */
+function spawnGrokProcess(spawnImpl, cliPath, args, options = {}) {
+  const spawnFn = spawnImpl || spawn;
+  const spawnSpec = resolveGrokSpawnSpec(cliPath, args);
+  return spawnFn(spawnSpec.command, spawnSpec.args, {
+    ...options,
+    shell: spawnSpec.shell,
+  });
+}
 
 function signalGrokProcessTree(child, signal, forceKillImpl) {
   if (!child) return;
@@ -601,7 +626,6 @@ async function runGrokTurn({
     failed: false,
   };
 
-  const spawnFn = spawnImpl || spawn;
   let child = null;
   let settled = false;
 
@@ -610,7 +634,7 @@ async function runGrokTurn({
   };
 
   try {
-    child = spawnFn(cliPath, args, {
+    child = spawnGrokProcess(spawnImpl, cliPath, args, {
       cwd: effectiveCwd,
       env: childEnv,
       stdio: ["ignore", "pipe", "pipe"],
@@ -784,7 +808,6 @@ async function listGrokModels({
   if (abortSignal?.aborted) return { currentModelId: null, models: [] };
 
   const childEnv = { ...(env || process.env) };
-  const spawnFn = spawnImpl || spawn;
 
   return await new Promise((resolve) => {
     let stdout = "";
@@ -807,7 +830,7 @@ async function listGrokModels({
 
     let child;
     try {
-      child = spawnFn(cliPath, ["models"], {
+      child = spawnGrokProcess(spawnImpl, cliPath, ["models"], {
         env: childEnv,
         stdio: ["ignore", "pipe", "pipe"],
         windowsHide: true,
@@ -868,9 +891,11 @@ module.exports = {
   resetGrokMcpMergeRefcountsForTests,
   resolveGrokPermissionFlags,
   resolveGrokRuntime,
+  resolveGrokSpawnSpec,
   resolveGrokToolIntegrationFlags,
   resolveGrokTurnPrompt,
   runGrokTurn,
+  spawnGrokProcess,
   stripGrokMcpServerSection,
   translateGrokStreamEvent,
 };

--- a/electron/bridges/aiBridge/sdk/grokDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.cjs
@@ -487,6 +487,24 @@ function resolveGrokRuntime(value) {
   return "acp";
 }
 
+/**
+ * After establish: only inject historySeed when we asked to resume but landed
+ * on session/new (stale/missing Grok session). Successful resume/load must not
+ * seed or prior turns duplicate into the current bubble.
+ */
+function resolveGrokTurnPrompt({
+  turnPrompt,
+  historySeed,
+  resumeSessionId,
+  establishMethod,
+} = {}) {
+  const prompt = String(turnPrompt || "");
+  const seed = String(historySeed || "").trim();
+  if (!resumeSessionId || !seed) return prompt;
+  if (String(establishMethod || "").toLowerCase() !== "new") return prompt;
+  return prompt ? `${seed}\n\n${prompt}` : seed;
+}
+
 function createLineBuffer(onLine, maxBufferBytes = MAX_GROK_LINE_BYTES) {
   let buffer = "";
   let bufferedBytes = 0;
@@ -851,6 +869,7 @@ module.exports = {
   resolveGrokPermissionFlags,
   resolveGrokRuntime,
   resolveGrokToolIntegrationFlags,
+  resolveGrokTurnPrompt,
   runGrokTurn,
   stripGrokMcpServerSection,
   translateGrokStreamEvent,

--- a/electron/bridges/aiBridge/sdk/grokDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.cjs
@@ -433,15 +433,7 @@ function translateGrokStreamEvent(event, emitter, state = {}) {
 
     case "usage": {
       const usage = event.usage && typeof event.usage === "object" ? event.usage : event;
-      if (usage && typeof emitter.usage === "function") {
-        emitter.usage({
-          inputTokens: usage.input_tokens ?? usage.inputTokens,
-          cachedInputTokens: usage.cache_read_input_tokens ?? usage.cachedInputTokens,
-          outputTokens: usage.output_tokens ?? usage.outputTokens,
-          reasoningTokens: usage.reasoning_tokens ?? usage.reasoningTokens,
-          totalTokens: usage.total_tokens ?? usage.totalTokens,
-        });
-      }
+      emitGrokUsage(emitter, usage);
       return false;
     }
 
@@ -454,15 +446,7 @@ function translateGrokStreamEvent(event, emitter, state = {}) {
         emitter.sessionId?.(sessionId);
       }
       const usage = event.usage && typeof event.usage === "object" ? event.usage : null;
-      if (usage && typeof emitter.usage === "function") {
-        emitter.usage({
-          inputTokens: usage.input_tokens ?? usage.inputTokens,
-          cachedInputTokens: usage.cache_read_input_tokens ?? usage.cachedInputTokens,
-          outputTokens: usage.output_tokens ?? usage.outputTokens,
-          reasoningTokens: usage.reasoning_tokens ?? usage.reasoningTokens,
-          totalTokens: usage.total_tokens ?? usage.totalTokens,
-        });
-      }
+      emitGrokUsage(emitter, usage);
       return false;
     }
 
@@ -529,6 +513,21 @@ function resolveGrokTurnPrompt({
   if (!resumeSessionId || !seed) return prompt;
   if (String(establishMethod || "").toLowerCase() !== "new") return prompt;
   return prompt ? `${seed}\n\n${prompt}` : seed;
+}
+
+/**
+ * Forward Grok/ACP usage objects onto the canonical emitter (snake or camel).
+ */
+function emitGrokUsage(emitter, usage) {
+  if (!usage || typeof usage !== "object" || typeof emitter?.usage !== "function") return false;
+  emitter.usage({
+    inputTokens: usage.input_tokens ?? usage.inputTokens,
+    cachedInputTokens: usage.cache_read_input_tokens ?? usage.cachedInputTokens,
+    outputTokens: usage.output_tokens ?? usage.outputTokens,
+    reasoningTokens: usage.reasoning_tokens ?? usage.reasoningTokens,
+    totalTokens: usage.total_tokens ?? usage.totalTokens,
+  });
+  return true;
 }
 
 function createLineBuffer(onLine, maxBufferBytes = MAX_GROK_LINE_BYTES) {
@@ -907,6 +906,7 @@ module.exports = {
   resolveGrokSpawnSpec,
   resolveGrokToolIntegrationFlags,
   resolveGrokTurnPrompt,
+  emitGrokUsage,
   runGrokTurn,
   spawnGrokProcess,
   stripGrokMcpServerSection,

--- a/electron/bridges/aiBridge/sdk/grokDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.cjs
@@ -332,6 +332,41 @@ function closeReasoning(state, emitter) {
 }
 
 /**
+ * Normalize Grok/ACP plan entries to the shared activity shape:
+ *   items: [{ text, completed }], status: "running" | "completed"
+ * (see domain/agentActivity.ts, emit.planUpdate, Codex App Server turn/plan/updated).
+ */
+function normalizeGrokPlanUpdate(entries) {
+  const items = [];
+  for (let index = 0; index < (entries || []).length; index += 1) {
+    const entry = entries[index];
+    let text = "";
+    let statusRaw = "";
+    if (typeof entry === "string") {
+      text = entry;
+    } else if (entry && typeof entry === "object") {
+      text = String(entry.content || entry.text || entry.title || entry.step || "");
+      statusRaw = String(entry.status || entry.state || "");
+    } else if (entry != null) {
+      text = String(entry);
+    }
+    text = text.trim();
+    if (!text) continue;
+    const status = statusRaw.toLowerCase();
+    const completed = status === "completed"
+      || status === "complete"
+      || status === "done"
+      || status === "finished"
+      || status === "success"
+      || entry?.completed === true;
+    items.push({ text, completed: Boolean(completed) });
+  }
+  if (items.length === 0) return null;
+  const status = items.every((item) => item.completed) ? "completed" : "running";
+  return { items, status };
+}
+
+/**
  * Map one Grok streaming-json event into canonical emitter calls.
  * Returns true when the stream should stop (terminal error).
  */
@@ -419,22 +454,9 @@ function translateGrokStreamEvent(event, emitter, state = {}) {
     }
 
     case "plan": {
-      const entries = Array.isArray(event.entries) ? event.entries : [];
-      const items = entries.map((entry, index) => {
-        if (typeof entry === "string") {
-          return { id: `plan-${index}`, content: entry, status: "pending" };
-        }
-        if (entry && typeof entry === "object") {
-          return {
-            id: String(entry.id || `plan-${index}`),
-            content: String(entry.content || entry.text || entry.title || ""),
-            status: String(entry.status || "pending"),
-          };
-        }
-        return { id: `plan-${index}`, content: String(entry ?? ""), status: "pending" };
-      }).filter((item) => item.content);
-      if (items.length > 0 && typeof emitter.planUpdate === "function") {
-        emitter.planUpdate(event.itemId || "grok-plan", items, "updated");
+      const plan = normalizeGrokPlanUpdate(Array.isArray(event.entries) ? event.entries : []);
+      if (plan && typeof emitter.planUpdate === "function") {
+        emitter.planUpdate(event.itemId || "grok-plan", plan.items, plan.status);
       }
       return false;
     }
@@ -992,6 +1014,7 @@ module.exports = {
   resolveGrokTurnPrompt,
   extractGrokAcpPromptUsage,
   emitGrokUsage,
+  normalizeGrokPlanUpdate,
   shouldReportGrokProcessExitFailure,
   runGrokTurn,
   spawnGrokProcess,

--- a/electron/bridges/aiBridge/sdk/grokDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.cjs
@@ -447,6 +447,7 @@ function translateGrokStreamEvent(event, emitter, state = {}) {
 
     case "end": {
       closeReasoning(state, emitter);
+      state.turnCompleted = true;
       if (event.sessionId || event.session_id) {
         const sessionId = event.sessionId || event.session_id;
         state.sessionId = sessionId;
@@ -624,6 +625,9 @@ async function runGrokTurn({
     reasoningOpen: false,
     streamedAssistantText: false,
     failed: false,
+    // True after a terminal stream event (end/result). Avoid treating forced
+    // process teardown exit codes as failures on tool-only turns.
+    turnCompleted: false,
   };
 
   let child = null;
@@ -710,7 +714,16 @@ async function runGrokTurn({
         stderrEnded = true;
         if (!stderrTruncated || stderrDecoder.lastNeed === 0) stderrText += stderrDecoder.end();
       }
-      if (!state.failed && !signal?.aborted && code && code !== 0 && !state.streamedAssistantText) {
+      // Same as ACP: ignore non-zero teardown codes after a completed turn
+      // (Windows kill often exits 1; tool-only turns have no assistant text).
+      if (
+        !state.failed
+        && !signal?.aborted
+        && !state.turnCompleted
+        && code
+        && code !== 0
+        && !state.streamedAssistantText
+      ) {
         const stderr = stderrText.trim();
         const message = stderr || `Grok Build exited with code ${code}`;
         state.failed = true;

--- a/electron/bridges/aiBridge/sdk/grokDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.cjs
@@ -1,0 +1,803 @@
+"use strict";
+
+/**
+ * Grok Build CLI turn runner — headless streaming-json path.
+ *
+ * Spawns the system `grok` binary with `-p` / `--output-format streaming-json`
+ * and maps ACP-derived NDJSON events into the canonical Netcatty emitter shapes.
+ *
+ * Netcatty MCP is injected by merging a project-scoped
+ * `.grok/config.toml` `[mcp_servers.<name>]` section (restored after the turn),
+ * matching the Cursor CLI workspace MCP merge pattern.
+ */
+const { spawn } = require("node:child_process");
+const { StringDecoder } = require("node:string_decoder");
+const fs = require("node:fs");
+const path = require("node:path");
+const { mcpEnvPairsToObject } = require("./injectMcp.cjs");
+
+const NETCATTY_MCP_NAME = "netcatty-remote-hosts";
+const GROK_ABORT_GRACE_MS = 1_500;
+const MAX_GROK_STDERR_CHARS = 64 * 1024;
+const MAX_GROK_MODEL_STDOUT_CHARS = 1024 * 1024;
+const MAX_GROK_LINE_BYTES = 10 * 1024 * 1024;
+
+function signalGrokProcessTree(child, signal, forceKillImpl) {
+  if (!child) return;
+  if (typeof forceKillImpl === "function") {
+    try { forceKillImpl(child, signal); } catch { /* ignore */ }
+    return;
+  }
+  if (process.platform === "win32" && signal === "SIGKILL" && child.pid) {
+    try {
+      const killer = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+        stdio: "ignore",
+        windowsHide: true,
+      });
+      killer.on("error", () => {});
+      killer.unref?.();
+      return;
+    } catch {
+      // Fall through.
+    }
+  }
+  if (process.platform !== "win32" && child.pid) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // Fall through.
+    }
+  }
+  try { child.kill(signal); } catch { /* ignore */ }
+}
+
+function escapeTomlBasicString(value) {
+  return String(value ?? "")
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, "\\\"");
+}
+
+function formatTomlEnvTable(envObject) {
+  if (!envObject || typeof envObject !== "object") return "{}";
+  const parts = [];
+  for (const [key, value] of Object.entries(envObject)) {
+    if (typeof key !== "string" || typeof value !== "string") continue;
+    parts.push(`${key} = "${escapeTomlBasicString(value)}"`);
+  }
+  if (parts.length === 0) return "{}";
+  return `{ ${parts.join(", ")} }`;
+}
+
+function formatTomlStringArray(values) {
+  if (!Array.isArray(values) || values.length === 0) return "[]";
+  return `[${values.map((v) => `"${escapeTomlBasicString(v)}"`).join(", ")}]`;
+}
+
+/**
+ * Build a `[mcp_servers.<name>]` TOML block for Grok project config.
+ */
+function buildGrokMcpServerTomlSection(cfg) {
+  if (!cfg || !cfg.name || !cfg.command) return "";
+  const name = String(cfg.name).replace(/[^a-zA-Z0-9_-]/g, "_") || NETCATTY_MCP_NAME;
+  const env = mcpEnvPairsToObject(cfg.env);
+  const lines = [
+    `[mcp_servers.${name}]`,
+    `command = "${escapeTomlBasicString(cfg.command)}"`,
+    `args = ${formatTomlStringArray(cfg.args || [])}`,
+    `env = ${formatTomlEnvTable(env)}`,
+    "enabled = true",
+    "",
+  ];
+  return lines.join("\n");
+}
+
+/**
+ * Remove prior `[mcp_servers.<name>]` (and nested tables under that prefix).
+ */
+function stripGrokMcpServerSection(tomlText, serverName) {
+  const name = String(serverName || NETCATTY_MCP_NAME).replace(/[^a-zA-Z0-9_-]/g, "_");
+  const lines = String(tomlText || "").split(/\r?\n/);
+  const out = [];
+  let skipping = false;
+  const headerExact = `[mcp_servers.${name}]`;
+  const headerNestedPrefix = `[mcp_servers.${name}.`;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+      if (trimmed === headerExact || trimmed.startsWith(headerNestedPrefix)) {
+        skipping = true;
+        continue;
+      }
+      skipping = false;
+    }
+    if (!skipping) out.push(line);
+  }
+
+  // Drop trailing blank lines that strip left behind; keep a single trailing newline later.
+  while (out.length > 0 && out[out.length - 1].trim() === "") out.pop();
+  return out.join("\n");
+}
+
+// Per-path refcount so concurrent turns share one original snapshot.
+const grokMcpMergeRefcounts = new Map();
+
+function mergeWorkspaceGrokMcpToml(cwd, injectedMcpServers, {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  unlinkSync,
+} = {}) {
+  const read = readFileSync || fs.readFileSync;
+  const write = writeFileSync || fs.writeFileSync;
+  const mkdir = mkdirSync || fs.mkdirSync;
+  const exists = existsSync || fs.existsSync;
+  const unlink = unlinkSync || ((p) => fs.unlinkSync(p));
+
+  const grokDir = path.join(cwd || process.cwd(), ".grok");
+  const configPath = path.join(grokDir, "config.toml");
+
+  let state = grokMcpMergeRefcounts.get(configPath);
+  if (!state) {
+    let previousRaw = null;
+    let previousExisted = false;
+    if (exists(configPath)) {
+      previousExisted = true;
+      previousRaw = read(configPath, "utf8");
+    }
+    state = { refCount: 0, previousRaw, previousExisted };
+    grokMcpMergeRefcounts.set(configPath, state);
+  }
+  state.refCount += 1;
+
+  let baseText = "";
+  if (exists(configPath)) {
+    try {
+      baseText = String(read(configPath, "utf8") || "");
+    } catch {
+      baseText = state.previousRaw || "";
+    }
+  } else if (state.previousExisted && state.previousRaw) {
+    baseText = state.previousRaw;
+  }
+
+  let nextText = baseText;
+  const sections = [];
+  for (const cfg of injectedMcpServers || []) {
+    if (!cfg || !cfg.name || !cfg.command) continue;
+    nextText = stripGrokMcpServerSection(nextText, cfg.name);
+    const section = buildGrokMcpServerTomlSection(cfg);
+    if (section) sections.push(section.trimEnd());
+  }
+
+  if (sections.length > 0) {
+    const body = nextText.trimEnd();
+    nextText = body
+      ? `${body}\n\n${sections.join("\n\n")}\n`
+      : `${sections.join("\n\n")}\n`;
+  }
+
+  try {
+    if (!exists(grokDir)) {
+      mkdir(grokDir, { recursive: true });
+    }
+    write(configPath, nextText, "utf8");
+  } catch (err) {
+    state.refCount = Math.max(0, state.refCount - 1);
+    if (state.refCount === 0) grokMcpMergeRefcounts.delete(configPath);
+    throw err;
+  }
+
+  let restored = false;
+  return {
+    configPath,
+    restore() {
+      if (restored) return;
+      restored = true;
+      const current = grokMcpMergeRefcounts.get(configPath);
+      if (!current) return;
+      current.refCount = Math.max(0, current.refCount - 1);
+      if (current.refCount > 0) return;
+      grokMcpMergeRefcounts.delete(configPath);
+      try {
+        if (current.previousExisted) write(configPath, current.previousRaw, "utf8");
+        else if (exists(configPath)) unlink(configPath);
+      } catch {
+        /* best effort */
+      }
+    },
+  };
+}
+
+function resetGrokMcpMergeRefcountsForTests() {
+  grokMcpMergeRefcounts.clear();
+}
+
+function resolveGrokPermissionFlags(permissionMode) {
+  const mode = String(permissionMode || "confirm").toLowerCase();
+  if (mode === "observer") {
+    // Plan mode keeps the agent from applying side-effecting edits without
+    // interactive approval UI (which headless cannot provide).
+    return ["--permission-mode", "plan"];
+  }
+  // confirm / auto / unknown: non-interactive headless must not hang on prompts.
+  return ["--always-approve"];
+}
+
+function buildGrokCliArgs({
+  prompt,
+  model,
+  cwd,
+  resumeSessionId,
+  permissionMode,
+}) {
+  const args = [
+    "-p",
+    String(prompt || ""),
+    "--output-format",
+    "streaming-json",
+  ];
+  const modelId = String(model || "").trim();
+  if (modelId) {
+    args.push("-m", modelId);
+  }
+  if (cwd) {
+    args.push("--cwd", String(cwd));
+  }
+  if (resumeSessionId) {
+    args.push("-r", String(resumeSessionId));
+  }
+  args.push(...resolveGrokPermissionFlags(permissionMode));
+  return args;
+}
+
+function resultToText(result) {
+  if (result == null) return "";
+  if (typeof result === "string") return result;
+  if (typeof result === "number" || typeof result === "boolean") return String(result);
+  if (typeof result === "object") {
+    if (typeof result.content === "string") return result.content;
+    if (typeof result.text === "string") return result.text;
+    if (typeof result.message === "string") return result.message;
+    try { return JSON.stringify(result); } catch { return String(result); }
+  }
+  return String(result);
+}
+
+function closeReasoning(state, emitter) {
+  if (state?.reasoningOpen) {
+    emitter.reasoningEnd();
+    state.reasoningOpen = false;
+  }
+}
+
+/**
+ * Map one Grok streaming-json event into canonical emitter calls.
+ * Returns true when the stream should stop (terminal error).
+ */
+function translateGrokStreamEvent(event, emitter, state = {}) {
+  if (!event || typeof event !== "object") return false;
+  const type = String(event.type || "");
+
+  switch (type) {
+    case "thought": {
+      const data = event.data != null ? String(event.data) : "";
+      if (data) {
+        emitter.reasoning(data);
+        state.reasoningOpen = true;
+      }
+      return false;
+    }
+
+    case "text": {
+      closeReasoning(state, emitter);
+      const data = event.data != null ? String(event.data) : "";
+      if (data) {
+        emitter.text(data);
+        state.streamedAssistantText = true;
+      }
+      return false;
+    }
+
+    case "tool_call": {
+      closeReasoning(state, emitter);
+      const id = event.toolCallId || event.tool_call_id || event.id;
+      if (!id) return false;
+      if (!state.emittedToolCalls) state.emittedToolCalls = new Set();
+      if (!state.toolNames) state.toolNames = new Map();
+      const name = String(event.toolName || event.tool_name || event.title || "tool");
+      const args = event.rawInput && typeof event.rawInput === "object"
+        ? event.rawInput
+        : (event.input && typeof event.input === "object" ? event.input : {});
+      state.toolNames.set(id, name);
+      if (!state.emittedToolCalls.has(id)) {
+        state.emittedToolCalls.add(id);
+        emitter.toolCall(name, args, id);
+      }
+      return false;
+    }
+
+    case "tool_call_update": {
+      closeReasoning(state, emitter);
+      const id = event.toolCallId || event.tool_call_id || event.id;
+      if (!id) return false;
+      if (!state.emittedToolResults) state.emittedToolResults = new Set();
+      if (!state.emittedToolCalls) state.emittedToolCalls = new Set();
+      if (!state.toolNames) state.toolNames = new Map();
+
+      const status = String(event.status || "").toLowerCase();
+      const name = state.toolNames.get(id)
+        || String(event.toolName || event.tool_name || event.title || "tool");
+      const args = event.rawInput && typeof event.rawInput === "object"
+        ? event.rawInput
+        : {};
+
+      if (!state.emittedToolCalls.has(id)) {
+        state.emittedToolCalls.add(id);
+        state.toolNames.set(id, name);
+        emitter.toolCall(name, args, id);
+      }
+
+      if (status === "completed" || status === "failed" || status === "error" || status === "cancelled") {
+        if (!state.emittedToolResults.has(id)) {
+          state.emittedToolResults.add(id);
+          const output = event.rawOutput != null
+            ? resultToText(event.rawOutput)
+            : resultToText(event.content || event.error || "");
+          emitter.toolResult(id, output, name);
+        }
+      }
+      return false;
+    }
+
+    case "plan": {
+      const entries = Array.isArray(event.entries) ? event.entries : [];
+      const items = entries.map((entry, index) => {
+        if (typeof entry === "string") {
+          return { id: `plan-${index}`, content: entry, status: "pending" };
+        }
+        if (entry && typeof entry === "object") {
+          return {
+            id: String(entry.id || `plan-${index}`),
+            content: String(entry.content || entry.text || entry.title || ""),
+            status: String(entry.status || "pending"),
+          };
+        }
+        return { id: `plan-${index}`, content: String(entry ?? ""), status: "pending" };
+      }).filter((item) => item.content);
+      if (items.length > 0 && typeof emitter.planUpdate === "function") {
+        emitter.planUpdate(event.itemId || "grok-plan", items, "updated");
+      }
+      return false;
+    }
+
+    case "usage": {
+      const usage = event.usage && typeof event.usage === "object" ? event.usage : event;
+      if (usage && typeof emitter.usage === "function") {
+        emitter.usage({
+          inputTokens: usage.input_tokens ?? usage.inputTokens,
+          cachedInputTokens: usage.cache_read_input_tokens ?? usage.cachedInputTokens,
+          outputTokens: usage.output_tokens ?? usage.outputTokens,
+          reasoningTokens: usage.reasoning_tokens ?? usage.reasoningTokens,
+          totalTokens: usage.total_tokens ?? usage.totalTokens,
+        });
+      }
+      return false;
+    }
+
+    case "end": {
+      closeReasoning(state, emitter);
+      if (event.sessionId || event.session_id) {
+        const sessionId = event.sessionId || event.session_id;
+        state.sessionId = sessionId;
+        emitter.sessionId?.(sessionId);
+      }
+      const usage = event.usage && typeof event.usage === "object" ? event.usage : null;
+      if (usage && typeof emitter.usage === "function") {
+        emitter.usage({
+          inputTokens: usage.input_tokens ?? usage.inputTokens,
+          cachedInputTokens: usage.cache_read_input_tokens ?? usage.cachedInputTokens,
+          outputTokens: usage.output_tokens ?? usage.outputTokens,
+          reasoningTokens: usage.reasoning_tokens ?? usage.reasoningTokens,
+          totalTokens: usage.total_tokens ?? usage.totalTokens,
+        });
+      }
+      return false;
+    }
+
+    case "error": {
+      closeReasoning(state, emitter);
+      state.failed = true;
+      const message = String(event.message || event.error || "Grok Build turn failed");
+      emitter.emitError(formatGrokErrorForUser(message));
+      return true;
+    }
+
+    case "available_commands":
+    case "max_turns_reached":
+    case "auto_compact_start":
+    case "auto_compact_end":
+      return false;
+
+    default:
+      return false;
+  }
+}
+
+function formatGrokErrorForUser(message) {
+  const text = String(message || "").trim();
+  if (
+    /not authenticated|not logged in|please run .*login|unauthenticated|unauthorized|sign in/i.test(text)
+  ) {
+    return "Grok Build is not logged in. Run `grok login` or set XAI_API_KEY, then retry.";
+  }
+  if (/\bxai[_\s-]?api[_\s-]?key\b/i.test(text) && /invalid|missing|required|auth/i.test(text)) {
+    return "Grok Build authentication failed. Run `grok login` or set XAI_API_KEY in your environment.";
+  }
+  return text || "Grok Build turn failed";
+}
+
+function createLineBuffer(onLine, maxBufferBytes = MAX_GROK_LINE_BYTES) {
+  let buffer = "";
+  let bufferedBytes = 0;
+  let overflowed = false;
+  const decoder = new StringDecoder("utf8");
+  return {
+    push(chunk) {
+      if (overflowed) return;
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk || ""));
+      bufferedBytes += bytes.length;
+      buffer += decoder.write(bytes);
+      let idx;
+      let consumedLine = false;
+      while ((idx = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, idx).trim();
+        buffer = buffer.slice(idx + 1);
+        consumedLine = true;
+        if (line) onLine(line);
+      }
+      if (consumedLine) bufferedBytes = Buffer.byteLength(buffer, "utf8") + decoder.lastNeed;
+      if (bufferedBytes > maxBufferBytes) {
+        overflowed = true;
+        buffer = "";
+        const error = new Error(`Grok Build message exceeded ${maxBufferBytes} bytes`);
+        error.code = "GROK_LINE_LIMIT";
+        throw error;
+      }
+    },
+    flush() {
+      if (overflowed) return;
+      buffer += decoder.end();
+      const line = buffer.trim();
+      buffer = "";
+      if (line) onLine(line);
+    },
+  };
+}
+
+async function runGrokTurn({
+  prompt,
+  binPath,
+  cwd,
+  model,
+  env,
+  permissionMode,
+  resumeSessionId,
+  injectedMcpServers,
+  emitter,
+  signal,
+  spawnImpl,
+  mergeMcp,
+  abortGraceMs = GROK_ABORT_GRACE_MS,
+  forceKillImpl,
+}) {
+  const cliPath = String(binPath || "").trim();
+  if (!cliPath) {
+    emitter.emitError(
+      "Grok Build CLI not found. Install the Grok CLI (`grok`) and ensure it is on PATH, or set the path in Settings → AI.",
+    );
+    return { sessionId: resumeSessionId || null };
+  }
+
+  const effectiveCwd = String(cwd || process.cwd() || "").trim() || process.cwd();
+  const childEnv = { ...(env || process.env) };
+  const args = buildGrokCliArgs({
+    prompt,
+    model,
+    cwd: effectiveCwd,
+    resumeSessionId,
+    permissionMode,
+  });
+
+  const doMerge = mergeMcp || mergeWorkspaceGrokMcpToml;
+  let mcpHandle = null;
+  if (Array.isArray(injectedMcpServers) && injectedMcpServers.length > 0) {
+    try {
+      mcpHandle = doMerge(effectiveCwd, injectedMcpServers);
+    } catch (err) {
+      emitter.emitError(
+        "Failed to prepare Netcatty MCP for Grok Build "
+        + `(cannot write project .grok/config.toml: ${err?.message || err}). `
+        + "Terminal tools will be unavailable.",
+      );
+      return { sessionId: resumeSessionId || null };
+    }
+  }
+
+  const state = {
+    sessionId: resumeSessionId || null,
+    reasoningOpen: false,
+    streamedAssistantText: false,
+    failed: false,
+  };
+
+  const spawnFn = spawnImpl || spawn;
+  let child = null;
+  let settled = false;
+
+  const cleanup = () => {
+    try { mcpHandle?.restore?.(); } catch { /* ignore */ }
+  };
+
+  try {
+    child = spawnFn(cliPath, args, {
+      cwd: effectiveCwd,
+      env: childEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      detached: process.platform !== "win32",
+    });
+  } catch (err) {
+    cleanup();
+    emitter.emitError(formatGrokErrorForUser(err?.message || String(err)));
+    return { sessionId: state.sessionId };
+  }
+
+  const handleLine = (line) => {
+    if (signal?.aborted) return;
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      return;
+    }
+    const stop = translateGrokStreamEvent(event, emitter, state);
+    if (stop && !signal?.aborted) state.failed = true;
+  };
+
+  const stdoutBuffer = createLineBuffer(handleLine);
+  let stderrText = "";
+  let stderrBytes = 0;
+  let stderrTruncated = false;
+  let stderrEnded = false;
+  const stderrDecoder = new StringDecoder("utf8");
+
+  child.stdout?.on("data", (chunk) => {
+    if (signal?.aborted) return;
+    try {
+      stdoutBuffer.push(chunk);
+    } catch (error) {
+      if (!state.failed) {
+        state.failed = true;
+        emitter.emitError(formatGrokErrorForUser(error?.message || String(error)));
+      }
+      signalGrokProcessTree(child, "SIGKILL", forceKillImpl);
+    }
+  });
+  child.stderr?.on("data", (chunk) => {
+    if (signal?.aborted) return;
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+    const remaining = Math.max(0, MAX_GROK_STDERR_CHARS - stderrBytes);
+    const accepted = buffer.length <= remaining ? buffer : buffer.subarray(0, remaining);
+    if (accepted.length > 0) stderrText += stderrDecoder.write(accepted);
+    stderrBytes += accepted.length;
+    if (accepted.length < buffer.length) stderrTruncated = true;
+  });
+
+  let abortHandler = null;
+  let forceKillTimer = null;
+  await new Promise((resolve) => {
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(forceKillTimer);
+      if (!signal?.aborted) stdoutBuffer.flush();
+      resolve();
+    };
+    child.on("error", (err) => {
+      if (!state.failed && !signal?.aborted) {
+        state.failed = true;
+        emitter.emitError(formatGrokErrorForUser(err?.message || String(err)));
+      }
+      finish();
+    });
+    child.on("close", (code) => {
+      if (!stderrEnded) {
+        stderrEnded = true;
+        if (!stderrTruncated || stderrDecoder.lastNeed === 0) stderrText += stderrDecoder.end();
+      }
+      if (!state.failed && !signal?.aborted && code && code !== 0 && !state.streamedAssistantText) {
+        const stderr = stderrText.trim();
+        const message = stderr || `Grok Build exited with code ${code}`;
+        state.failed = true;
+        emitter.emitError(formatGrokErrorForUser(message));
+      }
+      finish();
+    });
+
+    let terminationStarted = false;
+    abortHandler = () => {
+      if (settled || terminationStarted) return;
+      terminationStarted = true;
+      forceKillTimer = setTimeout(() => {
+        if (settled) return;
+        signalGrokProcessTree(child, "SIGKILL", forceKillImpl);
+        finish();
+      }, Math.max(0, abortGraceMs));
+      forceKillTimer.unref?.();
+      signalGrokProcessTree(child, "SIGTERM");
+    };
+    if (signal) {
+      if (signal.aborted) abortHandler();
+      else signal.addEventListener("abort", abortHandler, { once: true });
+    }
+  });
+
+  if (signal) signal.removeEventListener("abort", abortHandler);
+  cleanup();
+  closeReasoning(state, emitter);
+
+  if (!state.failed && !signal?.aborted) {
+    emitter.emitDone();
+  }
+
+  return { sessionId: state.sessionId };
+}
+
+/**
+ * Parse `grok models` plain-text output into { currentModelId, models }.
+ */
+function parseGrokModelsOutput(stdout) {
+  const models = [];
+  const seen = new Set();
+  let currentModelId = null;
+  let defaultFromHeader = null;
+
+  for (const line of String(stdout || "").split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const defaultMatch = trimmed.match(/^Default model:\s*(\S+)/i);
+    if (defaultMatch) {
+      defaultFromHeader = defaultMatch[1];
+      continue;
+    }
+
+    // "* grok-4.5 (default)" or "  * model-id"
+    const bullet = trimmed.match(/^\*+\s*([a-zA-Z0-9][a-zA-Z0-9._-]*)\s*(.*)$/);
+    if (!bullet) continue;
+    const id = bullet[1];
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const rest = bullet[2] || "";
+    const isDefault = /\(\s*default\s*\)/i.test(rest);
+    if (isDefault) currentModelId = id;
+    const name = rest
+      .replace(/\s*\(\s*default\s*\)\s*/ig, " ")
+      .replace(/\s{2,}/g, " ")
+      .trim() || id;
+    models.push({ id, name });
+  }
+
+  if (!currentModelId && defaultFromHeader) {
+    currentModelId = defaultFromHeader;
+    if (!seen.has(defaultFromHeader)) {
+      models.unshift({ id: defaultFromHeader, name: defaultFromHeader });
+    }
+  }
+
+  return { currentModelId, models };
+}
+
+async function listGrokModels({
+  binPath,
+  env,
+  spawnImpl,
+  abortController,
+  signal,
+  abortGraceMs = GROK_ABORT_GRACE_MS,
+  forceKillImpl,
+} = {}) {
+  const cliPath = String(binPath || "").trim();
+  if (!cliPath) return { currentModelId: null, models: [] };
+  const abortSignal = signal || abortController?.signal;
+  if (abortSignal?.aborted) return { currentModelId: null, models: [] };
+
+  const childEnv = { ...(env || process.env) };
+  const spawnFn = spawnImpl || spawn;
+
+  return await new Promise((resolve) => {
+    let stdout = "";
+    let stdoutBytes = 0;
+    let stdoutTruncated = false;
+    let stdoutEnded = false;
+    const stdoutDecoder = new StringDecoder("utf8");
+    let settled = false;
+    let abortHandler = null;
+    let forceKillTimer = null;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(forceKillTimer);
+      if (abortSignal && abortHandler) {
+        abortSignal.removeEventListener("abort", abortHandler);
+      }
+      resolve(value);
+    };
+
+    let child;
+    try {
+      child = spawnFn(cliPath, ["models"], {
+        env: childEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+        detached: process.platform !== "win32",
+      });
+    } catch {
+      finish({ currentModelId: null, models: [] });
+      return;
+    }
+
+    child.stdout?.on("data", (chunk) => {
+      if (abortSignal?.aborted) return;
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+      const remaining = Math.max(0, MAX_GROK_MODEL_STDOUT_CHARS - stdoutBytes);
+      const accepted = buffer.length <= remaining ? buffer : buffer.subarray(0, remaining);
+      if (accepted.length > 0) stdout += stdoutDecoder.write(accepted);
+      stdoutBytes += accepted.length;
+      if (accepted.length < buffer.length) stdoutTruncated = true;
+    });
+    child.on("error", () => finish({ currentModelId: null, models: [] }));
+    child.on("close", () => {
+      if (!stdoutEnded) {
+        stdoutEnded = true;
+        if (!stdoutTruncated || stdoutDecoder.lastNeed === 0) stdout += stdoutDecoder.end();
+      }
+      finish(parseGrokModelsOutput(stdout));
+    });
+
+    abortHandler = () => {
+      if (settled) return;
+      forceKillTimer = setTimeout(() => {
+        if (settled) return;
+        signalGrokProcessTree(child, "SIGKILL", forceKillImpl);
+        finish({ currentModelId: null, models: [] });
+      }, Math.max(0, abortGraceMs));
+      forceKillTimer.unref?.();
+      signalGrokProcessTree(child, "SIGTERM", forceKillImpl);
+    };
+    if (abortSignal) {
+      if (abortSignal.aborted) abortHandler();
+      else abortSignal.addEventListener("abort", abortHandler, { once: true });
+    }
+  });
+}
+
+module.exports = {
+  NETCATTY_MCP_NAME,
+  MAX_GROK_LINE_BYTES,
+  buildGrokCliArgs,
+  buildGrokMcpServerTomlSection,
+  createLineBuffer,
+  formatGrokErrorForUser,
+  listGrokModels,
+  mergeWorkspaceGrokMcpToml,
+  parseGrokModelsOutput,
+  resetGrokMcpMergeRefcountsForTests,
+  resolveGrokPermissionFlags,
+  runGrokTurn,
+  stripGrokMcpServerSection,
+  translateGrokStreamEvent,
+};

--- a/electron/bridges/aiBridge/sdk/grokDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.cjs
@@ -398,7 +398,15 @@ function translateGrokStreamEvent(event, emitter, state = {}) {
         emitter.toolCall(name, args, id);
       }
 
-      if (status === "completed" || status === "failed" || status === "error" || status === "cancelled") {
+      // Align with ACP: emit result on terminal status OR when rawOutput is present
+      // (some CLI builds omit status on the final tool_call_update).
+      if (
+        status === "completed"
+        || status === "failed"
+        || status === "error"
+        || status === "cancelled"
+        || event.rawOutput != null
+      ) {
         if (!state.emittedToolResults.has(id)) {
           state.emittedToolResults.add(id);
           const output = event.rawOutput != null
@@ -548,16 +556,15 @@ function extractGrokAcpPromptUsage(promptResult) {
  * Whether a process close should fail the turn.
  * - turnCompleted: protocol finished (end / session/prompt) → ignore teardown noise
  * - user abort: not a failure
- * - nonzero code OR non-null exit signal before completion → failure
+ * - otherwise any close before completion is a failure — including exit 0
+ *   (CLI can die without an end/prompt result) and code=null + signal
  *   (Node reports code=null when killed by signal)
  */
-function shouldReportGrokProcessExitFailure(state, abortSignal, code, exitSignal) {
+function shouldReportGrokProcessExitFailure(state, abortSignal, _code, _exitSignal) {
   if (state?.failed) return false;
   if (abortSignal?.aborted) return false;
   if (state?.turnCompleted) return false;
-  if (code != null && code !== 0) return true;
-  if (exitSignal) return true;
-  return false;
+  return true;
 }
 
 /**
@@ -785,13 +792,13 @@ async function runGrokTurn({
         stderrEnded = true;
         if (!stderrTruncated || stderrDecoder.lastNeed === 0) stderrText += stderrDecoder.end();
       }
-      // Only ignore abnormal exit after protocol completion (end event).
-      // Signal kills report code=null — still fail if turn not completed.
+      // Only ignore exit after protocol completion (end event).
+      // Incomplete turns fail even on exit 0; signal kills report code=null.
       if (shouldReportGrokProcessExitFailure(state, signal, code, exitSignal)) {
         const stderr = stderrText.trim();
         const detail = code != null && code !== 0
           ? `exited with code ${code}`
-          : (exitSignal ? `terminated by signal ${exitSignal}` : "exited unexpectedly");
+          : (exitSignal ? `terminated by signal ${exitSignal}` : "exited before the turn completed");
         const message = stderr || `Grok Build ${detail}`;
         state.failed = true;
         emitter.emitError(formatGrokErrorForUser(message));
@@ -821,8 +828,17 @@ async function runGrokTurn({
   cleanup();
   closeReasoning(state, emitter);
 
-  if (!state.failed && !signal?.aborted) {
+  // Hard gate: never treat an incomplete protocol turn as success (exit 0 without
+  // end/result used to fall through to emitDone).
+  if (signal?.aborted) {
+    // User cancel: no terminal success/error event.
+  } else if (state.failed) {
+    // Already reported.
+  } else if (state.turnCompleted) {
     emitter.emitDone();
+  } else {
+    state.failed = true;
+    emitter.emitError(formatGrokErrorForUser("Grok Build ended before the turn completed"));
   }
 
   return { sessionId: state.sessionId, runtime: "streaming-json" };

--- a/electron/bridges/aiBridge/sdk/grokDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.cjs
@@ -263,7 +263,9 @@ function buildGrokCliArgs({
   permissionMode,
   toolIntegrationMode,
 }) {
+  // Headless automation: skip background update checks (xAI headless docs).
   const args = [
+    "--no-auto-update",
     "-p",
     String(prompt || ""),
     "--output-format",
@@ -457,17 +459,32 @@ function translateGrokStreamEvent(event, emitter, state = {}) {
   }
 }
 
-function formatGrokErrorForUser(message) {
-  const text = String(message || "").trim();
+function isGrokAuthFailureMessage(message) {
+  const text = String(message || "");
   if (
-    /not authenticated|not logged in|please run .*login|unauthenticated|unauthorized|sign in/i.test(text)
+    /not authenticated|not logged in|please run .*login|unauthenticated|unauthorized|sign in|auth(?:entication)? (?:failed|required|missing)/i.test(text)
   ) {
-    return "Grok Build is not logged in. Run `grok login` or set XAI_API_KEY, then retry.";
+    return true;
   }
   if (/\bxai[_\s-]?api[_\s-]?key\b/i.test(text) && /invalid|missing|required|auth/i.test(text)) {
-    return "Grok Build authentication failed. Run `grok login` or set XAI_API_KEY in your environment.";
+    return true;
+  }
+  return false;
+}
+
+function formatGrokErrorForUser(message) {
+  const text = String(message || "").trim();
+  if (isGrokAuthFailureMessage(text)) {
+    return "Grok Build is not logged in. Run `grok login` or set XAI_API_KEY, then retry.";
   }
   return text || "Grok Build turn failed";
+}
+
+/** Normalize dual Grok runtime tokens (ACP vs headless streaming-json). */
+function resolveGrokRuntime(value) {
+  const raw = String(value || "").trim().toLowerCase();
+  if (raw === "streaming-json" || raw === "cli" || raw === "headless") return "streaming-json";
+  return "acp";
 }
 
 function createLineBuffer(onLine, maxBufferBytes = MAX_GROK_LINE_BYTES) {
@@ -530,7 +547,7 @@ async function runGrokTurn({
     emitter.emitError(
       "Grok Build CLI not found. Install the Grok CLI (`grok`) and ensure it is on PATH, or set the path in Settings → AI.",
     );
-    return { sessionId: resumeSessionId || null };
+    return { sessionId: resumeSessionId || null, runtime: "streaming-json" };
   }
 
   const effectiveCwd = String(cwd || process.cwd() || "").trim() || process.cwd();
@@ -555,7 +572,7 @@ async function runGrokTurn({
         + `(cannot write project .grok/config.toml: ${err?.message || err}). `
         + "Terminal tools will be unavailable.",
       );
-      return { sessionId: resumeSessionId || null };
+      return { sessionId: resumeSessionId || null, runtime: "streaming-json" };
     }
   }
 
@@ -585,7 +602,7 @@ async function runGrokTurn({
   } catch (err) {
     cleanup();
     emitter.emitError(formatGrokErrorForUser(err?.message || String(err)));
-    return { sessionId: state.sessionId };
+    return { sessionId: state.sessionId, runtime: "streaming-json" };
   }
 
   const handleLine = (line) => {
@@ -686,7 +703,7 @@ async function runGrokTurn({
     emitter.emitDone();
   }
 
-  return { sessionId: state.sessionId };
+  return { sessionId: state.sessionId, runtime: "streaming-json" };
 }
 
 /**
@@ -826,11 +843,13 @@ module.exports = {
   buildGrokMcpServerTomlSection,
   createLineBuffer,
   formatGrokErrorForUser,
+  isGrokAuthFailureMessage,
   listGrokModels,
   mergeWorkspaceGrokMcpToml,
   parseGrokModelsOutput,
   resetGrokMcpMergeRefcountsForTests,
   resolveGrokPermissionFlags,
+  resolveGrokRuntime,
   resolveGrokToolIntegrationFlags,
   runGrokTurn,
   stripGrokMcpServerSection,

--- a/electron/bridges/aiBridge/sdk/grokDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.cjs
@@ -226,12 +226,42 @@ function resolveGrokPermissionFlags(permissionMode) {
   return ["--always-approve"];
 }
 
+/**
+ * Local Grok built-ins that must not run side effects on the desktop machine
+ * when Tool Access is MCP. Remote session work goes through injected Netcatty
+ * MCP (meta-tools remain available under --disallowed-tools per Grok docs).
+ * Both historical (`run_terminal_cmd`) and current (`run_terminal_command`)
+ * shell IDs are listed so older/newer CLIs stay covered.
+ */
+const GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS = [
+  "run_terminal_command",
+  "run_terminal_cmd",
+  "search_replace",
+  "write",
+  "Agent",
+];
+
+/**
+ * Build --disallowed-tools flags for the active tool-integration mode.
+ * - mcp (default): strip local shell/edit/write so Claude-style MCP path is used.
+ * - skills: no lockdown here; Netcatty CLI skill needs local shell.
+ */
+function resolveGrokToolIntegrationFlags(toolIntegrationMode) {
+  const mode = String(toolIntegrationMode || "mcp").toLowerCase();
+  if (mode === "skills") return [];
+  return [
+    "--disallowed-tools",
+    GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS.join(","),
+  ];
+}
+
 function buildGrokCliArgs({
   prompt,
   model,
   cwd,
   resumeSessionId,
   permissionMode,
+  toolIntegrationMode,
 }) {
   const args = [
     "-p",
@@ -250,6 +280,7 @@ function buildGrokCliArgs({
     args.push("-r", String(resumeSessionId));
   }
   args.push(...resolveGrokPermissionFlags(permissionMode));
+  args.push(...resolveGrokToolIntegrationFlags(toolIntegrationMode));
   return args;
 }
 
@@ -484,6 +515,7 @@ async function runGrokTurn({
   model,
   env,
   permissionMode,
+  toolIntegrationMode,
   resumeSessionId,
   injectedMcpServers,
   emitter,
@@ -509,6 +541,7 @@ async function runGrokTurn({
     cwd: effectiveCwd,
     resumeSessionId,
     permissionMode,
+    toolIntegrationMode,
   });
 
   const doMerge = mergeMcp || mergeWorkspaceGrokMcpToml;
@@ -788,6 +821,7 @@ async function listGrokModels({
 module.exports = {
   NETCATTY_MCP_NAME,
   MAX_GROK_LINE_BYTES,
+  GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS,
   buildGrokCliArgs,
   buildGrokMcpServerTomlSection,
   createLineBuffer,
@@ -797,6 +831,7 @@ module.exports = {
   parseGrokModelsOutput,
   resetGrokMcpMergeRefcountsForTests,
   resolveGrokPermissionFlags,
+  resolveGrokToolIntegrationFlags,
   runGrokTurn,
   stripGrokMcpServerSection,
   translateGrokStreamEvent,

--- a/electron/bridges/aiBridge/sdk/grokDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.cjs
@@ -769,15 +769,15 @@ async function runGrokTurn({
         stderrEnded = true;
         if (!stderrTruncated || stderrDecoder.lastNeed === 0) stderrText += stderrDecoder.end();
       }
-      // Same as ACP: ignore non-zero teardown codes after a completed turn
-      // (Windows kill often exits 1; tool-only turns have no assistant text).
+      // Only ignore nonzero exit after protocol completion (end event).
+      // Do NOT use streamedAssistantText: partial text + crash must still error.
+      // Windows kill after a completed turn often exits 1 — turnCompleted covers that.
       if (
         !state.failed
         && !signal?.aborted
         && !state.turnCompleted
         && code
         && code !== 0
-        && !state.streamedAssistantText
       ) {
         const stderr = stderrText.trim();
         const message = stderr || `Grok Build exited with code ${code}`;

--- a/electron/bridges/aiBridge/sdk/grokDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.cjs
@@ -516,16 +516,72 @@ function resolveGrokTurnPrompt({
 }
 
 /**
- * Forward Grok/ACP usage objects onto the canonical emitter (snake or camel).
+ * Pick usage from a Grok ACP session/prompt result.
+ * Live Grok 0.2.x shape (verified):
+ *   { stopReason, _meta: { inputTokens, outputTokens, cachedReadTokens,
+ *     reasoningTokens, totalTokens, usage: { …same camelCase… } } }
+ * There is no top-level result.usage.
+ */
+function extractGrokAcpPromptUsage(promptResult) {
+  if (!promptResult || typeof promptResult !== "object") return null;
+  const meta = promptResult._meta && typeof promptResult._meta === "object"
+    ? promptResult._meta
+    : (promptResult.meta && typeof promptResult.meta === "object" ? promptResult.meta : null);
+  if (promptResult.usage && typeof promptResult.usage === "object") return promptResult.usage;
+  if (meta?.usage && typeof meta.usage === "object") return meta.usage;
+  if (
+    meta
+    && (
+      meta.inputTokens != null
+      || meta.outputTokens != null
+      || meta.totalTokens != null
+      || meta.input_tokens != null
+      || meta.output_tokens != null
+    )
+  ) {
+    return meta;
+  }
+  return null;
+}
+
+/**
+ * Forward Grok/ACP usage onto the canonical emitter.
+ * Supports Anthropic snake_case and Grok ACP camelCase (cachedReadTokens).
  */
 function emitGrokUsage(emitter, usage) {
   if (!usage || typeof usage !== "object" || typeof emitter?.usage !== "function") return false;
+  const inputTokens = Number(
+    usage.input_tokens ?? usage.inputTokens ?? usage.prompt_tokens ?? usage.promptTokens,
+  ) || 0;
+  const outputTokens = Number(
+    usage.output_tokens ?? usage.outputTokens ?? usage.completion_tokens ?? usage.completionTokens,
+  ) || 0;
+  const cachedInputTokens = Number(
+    usage.cache_read_input_tokens
+    ?? usage.cached_input_tokens
+    ?? usage.cachedInputTokens
+    ?? usage.cachedReadTokens
+    ?? usage.cached_read_tokens
+  ) || 0;
+  const reasoningTokens = Number(
+    usage.reasoning_tokens
+    ?? usage.reasoningTokens
+    ?? usage.reasoning_output_tokens
+    ?? usage.reasoningOutputTokens
+  ) || 0;
+  let totalTokens = Number(usage.total_tokens ?? usage.totalTokens) || 0;
+  if (!totalTokens && (inputTokens || outputTokens)) {
+    totalTokens = inputTokens + outputTokens;
+  }
+  if (!inputTokens && !outputTokens && !totalTokens && !cachedInputTokens && !reasoningTokens) {
+    return false;
+  }
   emitter.usage({
-    inputTokens: usage.input_tokens ?? usage.inputTokens,
-    cachedInputTokens: usage.cache_read_input_tokens ?? usage.cachedInputTokens,
-    outputTokens: usage.output_tokens ?? usage.outputTokens,
-    reasoningTokens: usage.reasoning_tokens ?? usage.reasoningTokens,
-    totalTokens: usage.total_tokens ?? usage.totalTokens,
+    inputTokens,
+    cachedInputTokens,
+    outputTokens,
+    reasoningTokens,
+    totalTokens,
   });
   return true;
 }
@@ -906,6 +962,7 @@ module.exports = {
   resolveGrokSpawnSpec,
   resolveGrokToolIntegrationFlags,
   resolveGrokTurnPrompt,
+  extractGrokAcpPromptUsage,
   emitGrokUsage,
   runGrokTurn,
   spawnGrokProcess,

--- a/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
@@ -1,0 +1,338 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const {
+  buildGrokCliArgs,
+  buildGrokMcpServerTomlSection,
+  createLineBuffer,
+  formatGrokErrorForUser,
+  listGrokModels,
+  mergeWorkspaceGrokMcpToml,
+  parseGrokModelsOutput,
+  resetGrokMcpMergeRefcountsForTests,
+  resolveGrokPermissionFlags,
+  runGrokTurn,
+  stripGrokMcpServerSection,
+  translateGrokStreamEvent,
+} = require("./grokDriver.cjs");
+
+function makeEmitter() {
+  const calls = [];
+  return {
+    calls,
+    text: (value) => calls.push(["text", value]),
+    reasoning: (value) => calls.push(["reasoning", value]),
+    reasoningEnd: () => calls.push(["reasoningEnd"]),
+    toolCall: (name, args, id) => calls.push(["toolCall", name, args, id]),
+    toolResult: (id, result, name) => calls.push(["toolResult", id, result, name]),
+    sessionId: (id) => calls.push(["sessionId", id]),
+    planUpdate: (itemId, items, status) => calls.push(["planUpdate", itemId, items, status]),
+    usage: (usage) => calls.push(["usage", usage]),
+    emitDone: () => calls.push(["done"]),
+    emitError: (message) => calls.push(["error", message]),
+  };
+}
+
+test("resolveGrokPermissionFlags maps observer to plan and others to always-approve", () => {
+  assert.deepEqual(resolveGrokPermissionFlags("observer"), ["--permission-mode", "plan"]);
+  assert.deepEqual(resolveGrokPermissionFlags("confirm"), ["--always-approve"]);
+  assert.deepEqual(resolveGrokPermissionFlags("auto"), ["--always-approve"]);
+});
+
+test("buildGrokCliArgs uses streaming-json and optional model/resume/cwd", () => {
+  assert.deepEqual(
+    buildGrokCliArgs({
+      prompt: "hi",
+      model: "grok-4.5",
+      cwd: "/repo",
+      resumeSessionId: "sess-1",
+      permissionMode: "observer",
+    }),
+    [
+      "-p",
+      "hi",
+      "--output-format",
+      "streaming-json",
+      "-m",
+      "grok-4.5",
+      "--cwd",
+      "/repo",
+      "-r",
+      "sess-1",
+      "--permission-mode",
+      "plan",
+    ],
+  );
+
+  const autoArgs = buildGrokCliArgs({
+    prompt: "go",
+    permissionMode: "auto",
+  });
+  assert.ok(autoArgs.includes("--always-approve"));
+  assert.ok(!autoArgs.includes("-m"));
+});
+
+test("createLineBuffer rejects and releases an unterminated oversized message", () => {
+  const lines = [];
+  const lineBuffer = createLineBuffer((line) => lines.push(line), 8);
+  lineBuffer.push(Buffer.from("12345678"));
+  assert.throws(
+    () => lineBuffer.push(Buffer.from("9")),
+    (error) => error?.code === "GROK_LINE_LIMIT",
+  );
+  lineBuffer.flush();
+  assert.deepEqual(lines, []);
+});
+
+test("formatGrokErrorForUser maps auth failures without over-matching bare login strings", () => {
+  assert.match(
+    formatGrokErrorForUser("Not authenticated"),
+    /not logged in/i,
+  );
+  assert.equal(
+    formatGrokErrorForUser("Failed to run login form validation"),
+    "Failed to run login form validation",
+  );
+});
+
+test("translateGrokStreamEvent maps thought, text, tools, usage, end", () => {
+  const emitter = makeEmitter();
+  const state = {};
+
+  translateGrokStreamEvent({ type: "thought", data: "plan" }, emitter, state);
+  translateGrokStreamEvent({ type: "text", data: "Hi" }, emitter, state);
+  translateGrokStreamEvent({
+    type: "tool_call",
+    toolCallId: "c1",
+    toolName: "read_file",
+    status: "in_progress",
+    rawInput: { path: "a.ts" },
+  }, emitter, state);
+  translateGrokStreamEvent({
+    type: "tool_call_update",
+    toolCallId: "c1",
+    status: "completed",
+    rawOutput: { lines: 2 },
+  }, emitter, state);
+  translateGrokStreamEvent({
+    type: "usage",
+    usage: {
+      input_tokens: 10,
+      output_tokens: 3,
+      cache_read_input_tokens: 1,
+      reasoning_tokens: 2,
+      total_tokens: 16,
+    },
+  }, emitter, state);
+  translateGrokStreamEvent({
+    type: "end",
+    stopReason: "end_turn",
+    sessionId: "s1",
+    usage: { input_tokens: 10, output_tokens: 3, total_tokens: 13 },
+  }, emitter, state);
+
+  assert.deepEqual(emitter.calls, [
+    ["reasoning", "plan"],
+    ["reasoningEnd"],
+    ["text", "Hi"],
+    ["toolCall", "read_file", { path: "a.ts" }, "c1"],
+    ["toolResult", "c1", "{\"lines\":2}", "read_file"],
+    ["usage", {
+      inputTokens: 10,
+      cachedInputTokens: 1,
+      outputTokens: 3,
+      reasoningTokens: 2,
+      totalTokens: 16,
+    }],
+    ["sessionId", "s1"],
+    ["usage", {
+      inputTokens: 10,
+      cachedInputTokens: undefined,
+      outputTokens: 3,
+      reasoningTokens: undefined,
+      totalTokens: 13,
+    }],
+  ]);
+  assert.equal(state.sessionId, "s1");
+  assert.equal(state.streamedAssistantText, true);
+});
+
+test("translateGrokStreamEvent maps error events to emitError and stop", () => {
+  const emitter = makeEmitter();
+  const state = {};
+  const stop = translateGrokStreamEvent(
+    { type: "error", message: "Couldn't start session" },
+    emitter,
+    state,
+  );
+  assert.equal(stop, true);
+  assert.equal(state.failed, true);
+  assert.deepEqual(emitter.calls, [["error", "Couldn't start session"]]);
+});
+
+test("buildGrokMcpServerTomlSection escapes paths and env", () => {
+  const section = buildGrokMcpServerTomlSection({
+    name: "netcatty-remote-hosts",
+    command: "C:\\Program Files\\node.exe",
+    args: ["mcp.cjs", "--flag"],
+    env: [{ name: "TOKEN", value: 'a"b' }],
+  });
+  assert.match(section, /\[mcp_servers\.netcatty-remote-hosts\]/);
+  assert.match(section, /command = "C:\\\\Program Files\\\\node\.exe"/);
+  assert.match(section, /args = \["mcp\.cjs", "--flag"\]/);
+  assert.match(section, /TOKEN = "a\\"b"/);
+  assert.match(section, /enabled = true/);
+});
+
+test("stripGrokMcpServerSection removes only the named server block", () => {
+  const input = [
+    "[ui]",
+    "compact_mode = true",
+    "",
+    "[mcp_servers.other]",
+    'command = "echo"',
+    "",
+    "[mcp_servers.netcatty-remote-hosts]",
+    'command = "node"',
+    "enabled = true",
+    "",
+    "[mcp_servers.other.nested]",
+    "x = 1",
+  ].join("\n");
+
+  const stripped = stripGrokMcpServerSection(input, "netcatty-remote-hosts");
+  assert.match(stripped, /\[mcp_servers\.other\]/);
+  assert.match(stripped, /\[ui\]/);
+  assert.doesNotMatch(stripped, /netcatty-remote-hosts/);
+});
+
+test("mergeWorkspaceGrokMcpToml upserts netcatty without dropping other servers", () => {
+  resetGrokMcpMergeRefcountsForTests();
+  const path = require("node:path");
+  const repo = path.join("repo-fixture");
+  const grokDir = path.join(repo, ".grok");
+  const configPath = path.join(grokDir, "config.toml");
+  const original = [
+    "[mcp_servers.other]",
+    'command = "echo"',
+    "enabled = true",
+    "",
+  ].join("\n");
+  const files = new Map();
+  files.set(configPath, original);
+
+  const handle = mergeWorkspaceGrokMcpToml(repo, [{
+    name: "netcatty-remote-hosts",
+    command: "node",
+    args: ["mcp.cjs"],
+    env: [{ name: "TOKEN", value: "x" }],
+  }], {
+    existsSync: (p) => files.has(p) || p === grokDir,
+    readFileSync: (p) => files.get(p),
+    writeFileSync: (p, data) => { files.set(p, data); },
+    mkdirSync: () => {},
+    unlinkSync: (p) => { files.delete(p); },
+  });
+
+  const written = files.get(configPath);
+  assert.match(written, /\[mcp_servers\.other\]/);
+  assert.match(written, /\[mcp_servers\.netcatty-remote-hosts\]/);
+  assert.match(written, /TOKEN = "x"/);
+
+  handle.restore();
+  assert.equal(files.get(configPath), original);
+});
+
+test("parseGrokModelsOutput reads default and bullet list", () => {
+  const parsed = parseGrokModelsOutput([
+    "You are logged in with grok.com.",
+    "",
+    "Default model: grok-4.5",
+    "",
+    "Available models:",
+    "  * grok-4.5 (default)",
+    "  * grok-code-fast",
+  ].join("\n"));
+  assert.equal(parsed.currentModelId, "grok-4.5");
+  assert.deepEqual(parsed.models, [
+    { id: "grok-4.5", name: "grok-4.5" },
+    { id: "grok-code-fast", name: "grok-code-fast" },
+  ]);
+});
+
+test("runGrokTurn streams fixture lines and emits done", async () => {
+  const emitter = makeEmitter();
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.pid = 4242;
+  child.kill = () => {};
+
+  const spawnImpl = (bin, args) => {
+    assert.equal(bin, "/usr/bin/grok");
+    assert.ok(args.includes("streaming-json"));
+    assert.ok(args.includes("--always-approve"));
+    queueMicrotask(() => {
+      child.stdout.emit("data", Buffer.from(
+        [
+          '{"type":"thought","data":"thinking"}',
+          '{"type":"text","data":"hello"}',
+          '{"type":"end","sessionId":"sess-xyz","stopReason":"end_turn"}',
+          "",
+        ].join("\n"),
+      ));
+      child.emit("close", 0);
+    });
+    return child;
+  };
+
+  const result = await runGrokTurn({
+    prompt: "hi",
+    binPath: "/usr/bin/grok",
+    cwd: "/repo",
+    permissionMode: "auto",
+    injectedMcpServers: [],
+    emitter,
+    spawnImpl,
+    mergeMcp: () => ({ restore() {} }),
+  });
+
+  assert.equal(result.sessionId, "sess-xyz");
+  assert.ok(emitter.calls.some((c) => c[0] === "text" && c[1] === "hello"));
+  assert.ok(emitter.calls.some((c) => c[0] === "done"));
+  assert.ok(emitter.calls.some((c) => c[0] === "sessionId" && c[1] === "sess-xyz"));
+});
+
+test("runGrokTurn reports missing CLI clearly", async () => {
+  const emitter = makeEmitter();
+  const result = await runGrokTurn({
+    prompt: "hi",
+    binPath: "",
+    emitter,
+  });
+  assert.equal(result.sessionId, null);
+  assert.match(String(emitter.calls[0]?.[1] || ""), /not found/i);
+});
+
+test("listGrokModels parses spawn stdout", async () => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.pid = 1;
+  child.kill = () => {};
+
+  const spawnImpl = () => {
+    queueMicrotask(() => {
+      child.stdout.emit("data", Buffer.from("Default model: grok-4.5\n* grok-4.5 (default)\n"));
+      child.emit("close", 0);
+    });
+    return child;
+  };
+
+  const result = await listGrokModels({
+    binPath: "/usr/bin/grok",
+    spawnImpl,
+  });
+  assert.equal(result.currentModelId, "grok-4.5");
+  assert.equal(result.models[0].id, "grok-4.5");
+});

--- a/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
@@ -52,6 +52,7 @@ test("buildGrokCliArgs uses streaming-json and optional model/resume/cwd", () =>
       toolIntegrationMode: "skills",
     }),
     [
+      "--no-auto-update",
       "-p",
       "hi",
       "--output-format",
@@ -73,6 +74,7 @@ test("buildGrokCliArgs uses streaming-json and optional model/resume/cwd", () =>
     toolIntegrationMode: "skills",
   });
   assert.ok(autoArgs.includes("--always-approve"));
+  assert.ok(autoArgs.includes("--no-auto-update"));
   assert.ok(!autoArgs.includes("-m"));
 });
 

--- a/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
@@ -17,6 +17,7 @@ const {
   resolveGrokTurnPrompt,
   extractGrokAcpPromptUsage,
   emitGrokUsage,
+  shouldReportGrokProcessExitFailure,
   runGrokTurn,
   spawnGrokProcess,
   stripGrokMcpServerSection,
@@ -520,6 +521,48 @@ test("runGrokTurn reports error when process dies after partial text without end
   assert.ok(emitter.calls.some((c) => c[0] === "text" && c[1] === "partial…"));
   assert.ok(emitter.calls.some((c) => c[0] === "error"), "partial stream + exit 1 must emitError");
   assert.ok(!emitter.calls.some((c) => c[0] === "done"), "must not emitDone on mid-turn crash");
+});
+
+test("runGrokTurn fails when process is signal-killed mid-turn (code=null)", async () => {
+  // Node close(null, "SIGTERM") — previously skipped because code was not a nonzero number.
+  const emitter = makeEmitter();
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.pid = 98;
+  child.kill = () => {};
+
+  const spawnImpl = () => {
+    queueMicrotask(() => {
+      child.stdout.emit("data", Buffer.from('{"type":"text","data":"partial…"}\n'));
+      child.emit("close", null, "SIGTERM");
+    });
+    return child;
+  };
+
+  await runGrokTurn({
+    prompt: "write a lot",
+    binPath: "/usr/bin/grok",
+    permissionMode: "auto",
+    injectedMcpServers: [],
+    emitter,
+    spawnImpl,
+    mergeMcp: () => ({ restore() {} }),
+  });
+
+  assert.ok(emitter.calls.some((c) => c[0] === "text" && c[1] === "partial…"));
+  const err = emitter.calls.find((c) => c[0] === "error");
+  assert.ok(err, "signal kill mid-turn must emitError");
+  assert.match(String(err[1]), /SIGTERM|signal/i);
+  assert.ok(!emitter.calls.some((c) => c[0] === "done"));
+});
+
+test("shouldReportGrokProcessExitFailure covers signal and code cases", () => {
+  assert.equal(shouldReportGrokProcessExitFailure({ turnCompleted: false }, null, null, "SIGTERM"), true);
+  assert.equal(shouldReportGrokProcessExitFailure({ turnCompleted: false }, null, 143, null), true);
+  assert.equal(shouldReportGrokProcessExitFailure({ turnCompleted: true }, null, null, "SIGTERM"), false);
+  assert.equal(shouldReportGrokProcessExitFailure({ turnCompleted: false }, { aborted: true }, null, "SIGKILL"), false);
+  assert.equal(shouldReportGrokProcessExitFailure({ turnCompleted: false }, null, 0, null), false);
 });
 
 test("runGrokTurn ignores exit code 1 after end event (Windows teardown)", async () => {

--- a/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
@@ -557,12 +557,60 @@ test("runGrokTurn fails when process is signal-killed mid-turn (code=null)", asy
   assert.ok(!emitter.calls.some((c) => c[0] === "done"));
 });
 
-test("shouldReportGrokProcessExitFailure covers signal and code cases", () => {
+test("runGrokTurn fails when process exits 0 after partial text without end", async () => {
+  // Quiet CLI death must not look like a successful turn.
+  const emitter = makeEmitter();
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.pid = 97;
+  child.kill = () => {};
+
+  const spawnImpl = () => {
+    queueMicrotask(() => {
+      child.stdout.emit("data", Buffer.from('{"type":"text","data":"partial…"}\n'));
+      child.emit("close", 0);
+    });
+    return child;
+  };
+
+  await runGrokTurn({
+    prompt: "write a lot",
+    binPath: "/usr/bin/grok",
+    permissionMode: "auto",
+    injectedMcpServers: [],
+    emitter,
+    spawnImpl,
+    mergeMcp: () => ({ restore() {} }),
+  });
+
+  assert.ok(emitter.calls.some((c) => c[0] === "text" && c[1] === "partial…"));
+  assert.ok(emitter.calls.some((c) => c[0] === "error"), "exit 0 without end must emitError");
+  assert.ok(!emitter.calls.some((c) => c[0] === "done"));
+});
+
+test("translateGrokStreamEvent emits toolResult when rawOutput present without status", () => {
+  const emitter = makeEmitter();
+  const state = {};
+  translateGrokStreamEvent({
+    type: "tool_call_update",
+    toolCallId: "t1",
+    toolName: "read",
+    rawOutput: { content: "file body" },
+  }, emitter, state);
+  assert.ok(emitter.calls.some((c) => c[0] === "toolCall" && c[3] === "t1"));
+  assert.ok(emitter.calls.some((c) => c[0] === "toolResult" && c[1] === "t1"));
+});
+
+test("shouldReportGrokProcessExitFailure fails any incomplete close (incl exit 0)", () => {
   assert.equal(shouldReportGrokProcessExitFailure({ turnCompleted: false }, null, null, "SIGTERM"), true);
   assert.equal(shouldReportGrokProcessExitFailure({ turnCompleted: false }, null, 143, null), true);
+  // Exit 0 without protocol completion is still a failure (CLI can die quietly).
+  assert.equal(shouldReportGrokProcessExitFailure({ turnCompleted: false }, null, 0, null), true);
   assert.equal(shouldReportGrokProcessExitFailure({ turnCompleted: true }, null, null, "SIGTERM"), false);
+  assert.equal(shouldReportGrokProcessExitFailure({ turnCompleted: true }, null, 1, null), false);
   assert.equal(shouldReportGrokProcessExitFailure({ turnCompleted: false }, { aborted: true }, null, "SIGKILL"), false);
-  assert.equal(shouldReportGrokProcessExitFailure({ turnCompleted: false }, null, 0, null), false);
+  assert.equal(shouldReportGrokProcessExitFailure({ turnCompleted: false, failed: true }, null, 1, null), false);
 });
 
 test("runGrokTurn ignores exit code 1 after end event (Windows teardown)", async () => {

--- a/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
@@ -13,6 +13,7 @@ const {
   resetGrokMcpMergeRefcountsForTests,
   resolveGrokPermissionFlags,
   resolveGrokToolIntegrationFlags,
+  resolveGrokTurnPrompt,
   runGrokTurn,
   stripGrokMcpServerSection,
   translateGrokStreamEvent,
@@ -137,6 +138,58 @@ test("formatGrokErrorForUser maps auth failures without over-matching bare login
   assert.equal(
     formatGrokErrorForUser("Failed to run login form validation"),
     "Failed to run login form validation",
+  );
+});
+
+test("resolveGrokTurnPrompt seeds history only when resume falls back to session/new", () => {
+  const seed = "[Conversation context replay]\nUSER: earlier";
+  const turn = "latest question";
+  assert.equal(
+    resolveGrokTurnPrompt({
+      turnPrompt: turn,
+      historySeed: seed,
+      resumeSessionId: "old-sess",
+      establishMethod: "new",
+    }),
+    `${seed}\n\n${turn}`,
+  );
+  // Successful resume/load must not inject seed (avoids stacked prior replies).
+  assert.equal(
+    resolveGrokTurnPrompt({
+      turnPrompt: turn,
+      historySeed: seed,
+      resumeSessionId: "old-sess",
+      establishMethod: "resume",
+    }),
+    turn,
+  );
+  assert.equal(
+    resolveGrokTurnPrompt({
+      turnPrompt: turn,
+      historySeed: seed,
+      resumeSessionId: "old-sess",
+      establishMethod: "load",
+    }),
+    turn,
+  );
+  // No resume attempt → never seed (first-turn replay is handled upstream).
+  assert.equal(
+    resolveGrokTurnPrompt({
+      turnPrompt: turn,
+      historySeed: seed,
+      resumeSessionId: undefined,
+      establishMethod: "new",
+    }),
+    turn,
+  );
+  assert.equal(
+    resolveGrokTurnPrompt({
+      turnPrompt: turn,
+      historySeed: "",
+      resumeSessionId: "old-sess",
+      establishMethod: "new",
+    }),
+    turn,
   );
 });
 

--- a/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
@@ -17,6 +17,7 @@ const {
   resolveGrokTurnPrompt,
   extractGrokAcpPromptUsage,
   emitGrokUsage,
+  normalizeGrokPlanUpdate,
   shouldReportGrokProcessExitFailure,
   runGrokTurn,
   spawnGrokProcess,
@@ -600,6 +601,58 @@ test("translateGrokStreamEvent emits toolResult when rawOutput present without s
   }, emitter, state);
   assert.ok(emitter.calls.some((c) => c[0] === "toolCall" && c[3] === "t1"));
   assert.ok(emitter.calls.some((c) => c[0] === "toolResult" && c[1] === "t1"));
+});
+
+test("normalizeGrokPlanUpdate maps to shared { text, completed } activity shape", () => {
+  assert.deepEqual(
+    normalizeGrokPlanUpdate([
+      { content: "Explore", status: "completed" },
+      { text: "Edit", status: "pending" },
+      "Ship it",
+    ]),
+    {
+      items: [
+        { text: "Explore", completed: true },
+        { text: "Edit", completed: false },
+        { text: "Ship it", completed: false },
+      ],
+      status: "running",
+    },
+  );
+  assert.deepEqual(
+    normalizeGrokPlanUpdate([
+      { content: "A", status: "done" },
+      { content: "B", completed: true },
+    ]),
+    {
+      items: [
+        { text: "A", completed: true },
+        { text: "B", completed: true },
+      ],
+      status: "completed",
+    },
+  );
+  assert.equal(normalizeGrokPlanUpdate([]), null);
+});
+
+test("translateGrokStreamEvent plan uses text/completed and running|completed status", () => {
+  const emitter = makeEmitter();
+  translateGrokStreamEvent({
+    type: "plan",
+    entries: [
+      { content: "Step one", status: "completed" },
+      { content: "Step two", status: "in_progress" },
+    ],
+  }, emitter, {});
+  const planCall = emitter.calls.find((c) => c[0] === "planUpdate");
+  assert.ok(planCall);
+  assert.equal(planCall[1], "grok-plan");
+  assert.deepEqual(planCall[2], [
+    { text: "Step one", completed: true },
+    { text: "Step two", completed: false },
+  ]);
+  assert.equal(planCall[3], "running");
+  assert.notEqual(planCall[3], "updated");
 });
 
 test("shouldReportGrokProcessExitFailure fails any incomplete close (incl exit 0)", () => {

--- a/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
@@ -12,9 +12,11 @@ const {
   parseGrokModelsOutput,
   resetGrokMcpMergeRefcountsForTests,
   resolveGrokPermissionFlags,
+  resolveGrokSpawnSpec,
   resolveGrokToolIntegrationFlags,
   resolveGrokTurnPrompt,
   runGrokTurn,
+  spawnGrokProcess,
   stripGrokMcpServerSection,
   translateGrokStreamEvent,
 } = require("./grokDriver.cjs");
@@ -139,6 +141,60 @@ test("formatGrokErrorForUser maps auth failures without over-matching bare login
     formatGrokErrorForUser("Failed to run login form validation"),
     "Failed to run login form validation",
   );
+});
+
+test("resolveGrokSpawnSpec matches prepareCommandForSpawn for cmd shims and exes", () => {
+  const { prepareCommandForSpawn } = require("../../ai/shellUtils.cjs");
+  // On win32, .cmd needs shell (or native-exe rewrite). Elsewhere shell stays false.
+  const shim = "C:\\Users\\me\\AppData\\Roaming\\npm\\grok.cmd";
+  const expected = prepareCommandForSpawn(shim, ["agent", "stdio"]);
+  const actual = resolveGrokSpawnSpec(shim, ["agent", "stdio"]);
+  assert.deepEqual(actual, expected);
+  if (process.platform === "win32") {
+    assert.equal(actual.shell, true);
+    assert.equal(actual.args.length, 0);
+  } else {
+    assert.equal(actual.shell, false);
+  }
+
+  const exePath = process.platform === "win32" ? "C:\\Tools\\grok.exe" : "/usr/bin/grok";
+  const exe = resolveGrokSpawnSpec(exePath, ["-p", "hi"]);
+  assert.equal(exe.shell, false);
+  assert.equal(exe.command, exePath);
+  assert.deepEqual(exe.args, ["-p", "hi"]);
+});
+
+test("spawnGrokProcess forwards shell from prepareCommandForSpawn into spawnImpl", () => {
+  const calls = [];
+  const fakeChild = {
+    stdout: { on() {} },
+    stderr: { on() {} },
+    stdin: null,
+    on() {},
+    kill() {},
+  };
+  const shim = "C:\\Users\\me\\AppData\\Roaming\\npm\\grok.cmd";
+  const child = spawnGrokProcess(
+    (command, args, options) => {
+      calls.push({ command, args, options });
+      return fakeChild;
+    },
+    shim,
+    ["agent", "stdio"],
+    { cwd: "D:\\repo", windowsHide: true },
+  );
+  assert.equal(child, fakeChild);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].options.cwd, "D:\\repo");
+  assert.equal(calls[0].options.windowsHide, true);
+  assert.equal(calls[0].options.shell, process.platform === "win32");
+  if (process.platform === "win32") {
+    assert.match(String(calls[0].command), /grok\.cmd/i);
+    assert.deepEqual(calls[0].args, []);
+  } else {
+    assert.equal(calls[0].command, shim);
+    assert.deepEqual(calls[0].args, ["agent", "stdio"]);
+  }
 });
 
 test("resolveGrokTurnPrompt seeds history only when resume falls back to session/new", () => {

--- a/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
@@ -490,6 +490,74 @@ test("runGrokTurn streams fixture lines and emits done", async () => {
   assert.ok(emitter.calls.some((c) => c[0] === "sessionId" && c[1] === "sess-xyz"));
 });
 
+test("runGrokTurn reports error when process dies after partial text without end", async () => {
+  // Mid-response crash: text already streamed, no end → must not emitDone.
+  const emitter = makeEmitter();
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.pid = 99;
+  child.kill = () => {};
+
+  const spawnImpl = () => {
+    queueMicrotask(() => {
+      child.stdout.emit("data", Buffer.from('{"type":"text","data":"partial…"}\n'));
+      child.emit("close", 1);
+    });
+    return child;
+  };
+
+  await runGrokTurn({
+    prompt: "write a lot",
+    binPath: "/usr/bin/grok",
+    permissionMode: "auto",
+    injectedMcpServers: [],
+    emitter,
+    spawnImpl,
+    mergeMcp: () => ({ restore() {} }),
+  });
+
+  assert.ok(emitter.calls.some((c) => c[0] === "text" && c[1] === "partial…"));
+  assert.ok(emitter.calls.some((c) => c[0] === "error"), "partial stream + exit 1 must emitError");
+  assert.ok(!emitter.calls.some((c) => c[0] === "done"), "must not emitDone on mid-turn crash");
+});
+
+test("runGrokTurn ignores exit code 1 after end event (Windows teardown)", async () => {
+  const emitter = makeEmitter();
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.pid = 100;
+  child.kill = () => {};
+
+  const spawnImpl = () => {
+    queueMicrotask(() => {
+      child.stdout.emit("data", Buffer.from(
+        [
+          '{"type":"text","data":"done"}',
+          '{"type":"end","sessionId":"s-end","stopReason":"end_turn"}',
+          "",
+        ].join("\n"),
+      ));
+      child.emit("close", 1);
+    });
+    return child;
+  };
+
+  await runGrokTurn({
+    prompt: "hi",
+    binPath: "/usr/bin/grok",
+    permissionMode: "auto",
+    injectedMcpServers: [],
+    emitter,
+    spawnImpl,
+    mergeMcp: () => ({ restore() {} }),
+  });
+
+  assert.ok(emitter.calls.some((c) => c[0] === "done"));
+  assert.ok(!emitter.calls.some((c) => c[0] === "error"));
+});
+
 test("runGrokTurn reports missing CLI clearly", async () => {
   const emitter = makeEmitter();
   const result = await runGrokTurn({

--- a/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
@@ -15,6 +15,8 @@ const {
   resolveGrokSpawnSpec,
   resolveGrokToolIntegrationFlags,
   resolveGrokTurnPrompt,
+  extractGrokAcpPromptUsage,
+  emitGrokUsage,
   runGrokTurn,
   spawnGrokProcess,
   stripGrokMcpServerSection,
@@ -197,6 +199,37 @@ test("spawnGrokProcess forwards shell from prepareCommandForSpawn into spawnImpl
   }
 });
 
+test("extractGrokAcpPromptUsage maps live Grok _meta.usage and cachedReadTokens", () => {
+  const promptResult = {
+    stopReason: "end_turn",
+    _meta: {
+      inputTokens: 27144,
+      outputTokens: 29,
+      totalTokens: 27174,
+      cachedReadTokens: 2560,
+      reasoningTokens: 24,
+      usage: {
+        inputTokens: 27144,
+        outputTokens: 29,
+        totalTokens: 27173,
+        cachedReadTokens: 2560,
+        reasoningTokens: 24,
+      },
+    },
+  };
+  const extracted = extractGrokAcpPromptUsage(promptResult);
+  assert.equal(extracted.cachedReadTokens, 2560);
+  const calls = [];
+  emitGrokUsage({ usage: (u) => calls.push(u) }, extracted);
+  assert.deepEqual(calls[0], {
+    inputTokens: 27144,
+    cachedInputTokens: 2560,
+    outputTokens: 29,
+    reasoningTokens: 24,
+    totalTokens: 27173,
+  });
+});
+
 test("resolveGrokTurnPrompt seeds history only when resume falls back to session/new", () => {
   const seed = "[Conversation context replay]\nUSER: earlier";
   const turn = "latest question";
@@ -301,9 +334,9 @@ test("translateGrokStreamEvent maps thought, text, tools, usage, end", () => {
     ["sessionId", "s1"],
     ["usage", {
       inputTokens: 10,
-      cachedInputTokens: undefined,
+      cachedInputTokens: 0,
       outputTokens: 3,
-      reasoningTokens: undefined,
+      reasoningTokens: 0,
       totalTokens: 13,
     }],
   ]);

--- a/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
@@ -2,6 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const { EventEmitter } = require("node:events");
 const {
+  GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS,
   buildGrokCliArgs,
   buildGrokMcpServerTomlSection,
   createLineBuffer,
@@ -11,6 +12,7 @@ const {
   parseGrokModelsOutput,
   resetGrokMcpMergeRefcountsForTests,
   resolveGrokPermissionFlags,
+  resolveGrokToolIntegrationFlags,
   runGrokTurn,
   stripGrokMcpServerSection,
   translateGrokStreamEvent,
@@ -47,6 +49,7 @@ test("buildGrokCliArgs uses streaming-json and optional model/resume/cwd", () =>
       cwd: "/repo",
       resumeSessionId: "sess-1",
       permissionMode: "observer",
+      toolIntegrationMode: "skills",
     }),
     [
       "-p",
@@ -67,9 +70,49 @@ test("buildGrokCliArgs uses streaming-json and optional model/resume/cwd", () =>
   const autoArgs = buildGrokCliArgs({
     prompt: "go",
     permissionMode: "auto",
+    toolIntegrationMode: "skills",
   });
   assert.ok(autoArgs.includes("--always-approve"));
   assert.ok(!autoArgs.includes("-m"));
+});
+
+test("resolveGrokToolIntegrationFlags locks local side-effect tools only in MCP mode", () => {
+  assert.deepEqual(resolveGrokToolIntegrationFlags("skills"), []);
+  assert.deepEqual(resolveGrokToolIntegrationFlags("mcp"), [
+    "--disallowed-tools",
+    GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS.join(","),
+  ]);
+  // Default/unknown → MCP lockdown (align with Claude MCP-mode empty local tools).
+  assert.deepEqual(resolveGrokToolIntegrationFlags(undefined), [
+    "--disallowed-tools",
+    GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS.join(","),
+  ]);
+  assert.ok(GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS.includes("run_terminal_command"));
+  assert.ok(GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS.includes("search_replace"));
+  assert.ok(GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS.includes("write"));
+});
+
+test("buildGrokCliArgs applies MCP-mode local-tool lockdown via real builder", () => {
+  const mcpArgs = buildGrokCliArgs({
+    prompt: "list sessions",
+    permissionMode: "auto",
+    toolIntegrationMode: "mcp",
+  });
+  const denyIdx = mcpArgs.indexOf("--disallowed-tools");
+  assert.ok(denyIdx >= 0, "MCP mode must pass --disallowed-tools");
+  const denied = String(mcpArgs[denyIdx + 1] || "");
+  assert.match(denied, /run_terminal_command/);
+  assert.match(denied, /search_replace/);
+  assert.match(denied, /write/);
+  // MCP meta-tools must not appear in the deny list (Netcatty remote path).
+  assert.doesNotMatch(denied, /mcp|netcatty/i);
+
+  const skillsArgs = buildGrokCliArgs({
+    prompt: "list sessions",
+    permissionMode: "auto",
+    toolIntegrationMode: "skills",
+  });
+  assert.ok(!skillsArgs.includes("--disallowed-tools"), "skills mode must not apply MCP lockdown");
 });
 
 test("createLineBuffer rejects and releases an unterminated oversized message", () => {

--- a/electron/bridges/aiBridge/sdk/index.cjs
+++ b/electron/bridges/aiBridge/sdk/index.cjs
@@ -321,6 +321,7 @@ const DRIVER_REGISTRY = {
         model: ctx.model,
         env: ctx.env,
         permissionMode: ctx.permissionMode,
+        toolIntegrationMode: ctx.toolIntegrationMode,
         resumeSessionId: ctx.resumeSessionId,
         injectedMcpServers: ctx.injectedMcpServers,
         emitter: ctx.emitter,

--- a/electron/bridges/aiBridge/sdk/index.cjs
+++ b/electron/bridges/aiBridge/sdk/index.cjs
@@ -324,6 +324,9 @@ const DRIVER_REGISTRY = {
         || "acp",
       ).toLowerCase();
       if (runtime === "streaming-json" || runtime === "cli" || runtime === "headless") {
+        // Headless cannot know if -r restored history before the prompt is sent.
+        // Prefer native -r without seed (common success path). Stale-id fallback
+        // is handled on ACP (default runtime) via historySeed + session/new.
         return grok.runGrokTurn({
           prompt: ctx.prompt,
           binPath: ctx.binPath,
@@ -348,6 +351,7 @@ const DRIVER_REGISTRY = {
         permissionMode: ctx.permissionMode,
         toolIntegrationMode: ctx.toolIntegrationMode,
         resumeSessionId: ctx.resumeSessionId,
+        historySeed: ctx.historySeed,
         injectedMcpServers: ctx.injectedMcpServers,
         emitter: ctx.emitter,
         signal: ctx.signal || ctx.abortController?.signal,

--- a/electron/bridges/aiBridge/sdk/index.cjs
+++ b/electron/bridges/aiBridge/sdk/index.cjs
@@ -17,6 +17,7 @@ const cursorCli = require("./cursorCliDriver.cjs");
 const codebuddy = require("./codebuddyDriver.cjs");
 const opencode = require("./opencodeDriver.cjs");
 const grok = require("./grokDriver.cjs");
+const grokAcp = require("./grokAcpDriver.cjs");
 const { codebuddySessionManager } = require("./codebuddySessionManager.cjs");
 
 function hasCodebuddyQueryOnlyOptions(options) {
@@ -314,8 +315,32 @@ const DRIVER_REGISTRY = {
   },
   grok: {
     async runTurn(ctx) {
-      return grok.runGrokTurn({
+      // Default: ACP (`grok agent stdio`) with session-level mcpServers.
+      // Explicit fallback: NETCATTY_GROK_RUNTIME=streaming-json or ctx.grokRuntime.
+      const runtime = String(
+        ctx.grokRuntime
+        || ctx.env?.NETCATTY_GROK_RUNTIME
+        || process.env.NETCATTY_GROK_RUNTIME
+        || "acp",
+      ).toLowerCase();
+      if (runtime === "streaming-json" || runtime === "cli" || runtime === "headless") {
+        return grok.runGrokTurn({
+          prompt: ctx.prompt,
+          binPath: ctx.binPath,
+          cwd: ctx.cwd,
+          model: ctx.model,
+          env: ctx.env,
+          permissionMode: ctx.permissionMode,
+          toolIntegrationMode: ctx.toolIntegrationMode,
+          resumeSessionId: ctx.resumeSessionId,
+          injectedMcpServers: ctx.injectedMcpServers,
+          emitter: ctx.emitter,
+          signal: ctx.signal || ctx.abortController?.signal,
+        });
+      }
+      return grokAcp.runGrokAcpTurn({
         prompt: ctx.prompt,
+        systemPrompt: ctx.systemPrompt,
         binPath: ctx.binPath,
         cwd: ctx.cwd,
         model: ctx.model,

--- a/electron/bridges/aiBridge/sdk/index.cjs
+++ b/electron/bridges/aiBridge/sdk/index.cjs
@@ -16,6 +16,7 @@ const cursor = require("./cursorDriver.cjs");
 const cursorCli = require("./cursorCliDriver.cjs");
 const codebuddy = require("./codebuddyDriver.cjs");
 const opencode = require("./opencodeDriver.cjs");
+const grok = require("./grokDriver.cjs");
 const { codebuddySessionManager } = require("./codebuddySessionManager.cjs");
 
 function hasCodebuddyQueryOnlyOptions(options) {
@@ -308,6 +309,30 @@ const DRIVER_REGISTRY = {
         binPath: ctx.binPath,
         abortController: ctx.abortController,
         signal: ctx.abortController?.signal || ctx.signal,
+      });
+    },
+  },
+  grok: {
+    async runTurn(ctx) {
+      return grok.runGrokTurn({
+        prompt: ctx.prompt,
+        binPath: ctx.binPath,
+        cwd: ctx.cwd,
+        model: ctx.model,
+        env: ctx.env,
+        permissionMode: ctx.permissionMode,
+        resumeSessionId: ctx.resumeSessionId,
+        injectedMcpServers: ctx.injectedMcpServers,
+        emitter: ctx.emitter,
+        signal: ctx.signal || ctx.abortController?.signal,
+      });
+    },
+    async listModels(ctx) {
+      return grok.listGrokModels({
+        binPath: ctx.binPath,
+        env: ctx.env,
+        abortController: ctx.abortController,
+        signal: ctx.signal || ctx.abortController?.signal,
       });
     },
   },

--- a/electron/bridges/aiBridge/sdk/index.test.cjs
+++ b/electron/bridges/aiBridge/sdk/index.test.cjs
@@ -8,11 +8,11 @@ const {
 const { codebuddySessionManager } = require("./codebuddySessionManager.cjs");
 
 test("registry exposes SDK backends", () => {
-  assert.deepEqual(listBackends().sort(), ["claude", "codebuddy", "codex", "copilot", "cursor", "opencode"]);
+  assert.deepEqual(listBackends().sort(), ["claude", "codebuddy", "codex", "copilot", "cursor", "grok", "opencode"]);
 });
 
 test("getDriver returns a driver with runTurn", () => {
-  for (const key of ["claude", "codebuddy", "codex", "copilot", "cursor", "opencode"]) {
+  for (const key of ["claude", "codebuddy", "codex", "copilot", "cursor", "grok", "opencode"]) {
     const d = getDriver(key);
     assert.equal(typeof d.runTurn, "function", `${key} must expose runTurn`);
   }
@@ -23,7 +23,7 @@ test("getDriver throws on unknown backend", () => {
 });
 
 test("SDK drivers expose listModels; codex returns [] (no catalog)", async () => {
-  for (const key of ["claude", "codebuddy", "codex", "copilot", "cursor", "opencode"]) {
+  for (const key of ["claude", "codebuddy", "codex", "copilot", "cursor", "grok", "opencode"]) {
     assert.equal(typeof getDriver(key).listModels, "function", `${key} must expose listModels`);
   }
   assert.deepEqual(await getDriver("codex").listModels({}), []);

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
@@ -426,10 +426,15 @@ function shouldReplaySdkHistory({
   resumeSessionId,
   hasInMemorySession,
 }) {
-  // CodeBuddy and Codex App Server resumes restore their own conversation
-  // history. Replaying renderer history as well duplicates every prior turn
-  // after the main-process session map is recreated.
-  if (backendKey === "codebuddy" || codexRuntime === "app-server") {
+  // CodeBuddy, Codex App Server, and Grok ACP resumes restore their own
+  // conversation history. Replaying renderer history as well duplicates every
+  // prior turn (Grok also re-hydrates via session/load on a fresh agent stdio
+  // process each turn).
+  if (
+    backendKey === "codebuddy"
+    || backendKey === "grok"
+    || codexRuntime === "app-server"
+  ) {
     return !resumeSessionId;
   }
   return !hasInMemorySession;

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
@@ -191,6 +191,36 @@ function expireSiblingCursorCliModeSessions(sdkSessionIds, {
   return true;
 }
 
+/**
+ * Grok ACP vs streaming-json sessions must not resume across each other.
+ * When the active runtime flips without restarting Netcatty, drop the inactive
+ * runtime's in-memory session so a switch-back cannot revive a pre-switch
+ * thread and skip renderer history for intervening turns (same idea as Cursor
+ * CLI ask/agent isolation).
+ */
+function expireSiblingGrokRuntimeSessions(sdkSessionIds, {
+  chatSessionId,
+  backendKey,
+  binPath,
+  runtime = "acp",
+} = {}) {
+  if (!sdkSessionIds || backendKey !== "grok") return false;
+  const activeRuntime = normalizeSdkRuntime(runtime);
+  if (activeRuntime !== "acp" && activeRuntime !== "streaming-json") return false;
+  const siblingRuntime = activeRuntime === "acp" ? "streaming-json" : "acp";
+  const siblingKey = buildSdkSessionKey(
+    chatSessionId,
+    backendKey,
+    binPath,
+    siblingRuntime,
+    "",
+    "",
+  );
+  if (!sdkSessionIds.has(siblingKey)) return false;
+  sdkSessionIds.delete(siblingKey);
+  return true;
+}
+
 function resolveSdkResumeSessionId({
   sdkSessionIds,
   sdkSessionKey,
@@ -621,6 +651,16 @@ function registerSdkStreamHandlers(ctx) {
               runtime: sessionRuntime,
               authMode: cursorSessionAuthMode,
               cliMode: cursorCliMode,
+            });
+          }
+          // ACP ↔ streaming-json: drop the other Grok runtime's in-memory id so
+          // switch-back does not resume a pre-switch session without intervening turns.
+          if (backendKey === "grok") {
+            expireSiblingGrokRuntimeSessions(sdkSessionIds, {
+              chatSessionId,
+              backendKey,
+              binPath: sessionBinPath,
+              runtime: sessionRuntime,
             });
           }
           const sdkSessionKey = buildSdkSessionKey(
@@ -1178,6 +1218,7 @@ module.exports = {
   resolveSdkPromptPlacement,
   resolveSdkResumeSessionId,
   expireSiblingCursorCliModeSessions,
+  expireSiblingGrokRuntimeSessions,
   shouldCacheSdkRuntimeModels,
   normalizeHistoryMessages,
   formatSdkHistoryReplaySection,

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
@@ -27,7 +27,11 @@ const MODEL_CACHE_MAX_ENTRIES = 32;
 const MODEL_LIST_TIMEOUT_MS = 10000;
 const sdkModelCache = new Map();
 const sdkModelInFlight = new Map();
-const { parseSdkSessionIdentity: parseSdkSessionIdentityPayload, SDK_SESSION_ID_PREFIX } = require("../../../shared/sdkSessionIdentity.cjs");
+const {
+  parseSdkSessionIdentity: parseSdkSessionIdentityPayload,
+  normalizeSdkRuntime,
+  SDK_SESSION_ID_PREFIX,
+} = require("../../../shared/sdkSessionIdentity.cjs");
 const { isPathLikeCommand } = require("../../../shared/pathLikeCommand.cjs");
 
 function parseSdkSessionIdentity(value) {
@@ -37,10 +41,17 @@ function parseSdkSessionIdentity(value) {
     sessionId: parsed.id,
     backendKey: parsed.backend,
     binPath: parsed.binPath || "",
-    runtime: parsed.runtime === "app-server" ? "app-server" : "sdk",
+    runtime: normalizeSdkRuntime(parsed.runtime),
     authMode: parsed.authMode === "cli-login" ? "cli-login" : parsed.authMode === "api-key" ? "api-key" : "",
     cliMode: parsed.cliMode === "ask" ? "ask" : parsed.cliMode === "agent" ? "agent" : "",
   };
+}
+
+/** Resolve Grok dual runtime from explicit ctx / agent env. */
+function resolveGrokRuntimeToken(env, explicit) {
+  return normalizeSdkRuntime(
+    explicit || env?.NETCATTY_GROK_RUNTIME || process.env.NETCATTY_GROK_RUNTIME || "acp",
+  );
 }
 
 function buildSdkSessionKey(chatSessionId, backendKey, binPath, runtime = "sdk", authMode = "", cliMode = "") {
@@ -568,9 +579,16 @@ function registerSdkStreamHandlers(ctx) {
           const codexRuntime = backendKey === "codex" && requestedCodexRuntime === "app-server"
             ? "app-server"
             : "sdk";
+          // Grok ACP vs streaming-json must not share resume identity (like Codex dual runtime).
+          const grokRuntime = backendKey === "grok"
+            ? resolveGrokRuntimeToken(env, env?.NETCATTY_GROK_RUNTIME)
+            : "sdk";
+          const sessionRuntime = backendKey === "grok" ? grokRuntime : codexRuntime;
           sdkRequestRuntimes.set(requestId, {
             backendKey,
             codexRuntime,
+            grokRuntime,
+            sessionRuntime,
             binPath,
             toolIntegrationMode: effectiveMode,
           });
@@ -592,7 +610,7 @@ function registerSdkStreamHandlers(ctx) {
               chatSessionId,
               backendKey,
               binPath: sessionBinPath,
-              runtime: codexRuntime,
+              runtime: sessionRuntime,
               authMode: cursorSessionAuthMode,
               cliMode: cursorCliMode,
             });
@@ -601,7 +619,7 @@ function registerSdkStreamHandlers(ctx) {
             chatSessionId,
             backendKey,
             sessionBinPath,
-            codexRuntime,
+            sessionRuntime,
             cursorSessionAuthMode,
             cursorCliMode,
           );
@@ -612,7 +630,7 @@ function registerSdkStreamHandlers(ctx) {
             existingSessionId,
             backendKey,
             binPath: sessionBinPath,
-            runtime: codexRuntime,
+            runtime: sessionRuntime,
             authMode: cursorSessionAuthMode,
             cliMode: cursorCliMode,
             hasConfiguredCommand,
@@ -657,7 +675,7 @@ function registerSdkStreamHandlers(ctx) {
                   sessionId,
                   sdkBackend: backendKey,
                   binPath: sessionBinPath || "",
-                  runtime: codexRuntime,
+                  runtime: sessionRuntime,
                   ...(cursorSessionAuthMode ? { authMode: cursorSessionAuthMode } : {}),
                   ...(cursorCliMode ? { cliMode: cursorCliMode } : {}),
                 });
@@ -697,6 +715,7 @@ function registerSdkStreamHandlers(ctx) {
             binPath,
             cursorAuthMode: backendKey === "cursor" ? cursorAuthMode : undefined,
             cursorCliBinPath: backendKey === "cursor" ? cursorCliBinPath : undefined,
+            grokRuntime: backendKey === "grok" ? grokRuntime : undefined,
             getTempDir: () => tempDirBridge.getTempDir(),
             injectedMcpServers,
             claudeSettings,

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
@@ -371,6 +371,19 @@ function defaultWriteAttachmentToTemp(attachment) {
   return target;
 }
 
+/**
+ * Format renderer history into the shared SDK conversation-context section.
+ * Used for normal replay and as a Grok resume-fallback seed (same wording).
+ */
+function formatSdkHistoryReplaySection(historyMessages) {
+  const history = normalizeHistoryMessages(historyMessages);
+  if (history.length === 0) return "";
+  return [
+    "[Conversation context replay: the agent SDK may be starting from a fresh local session, so use these prior turns as context and answer only the latest user request.]",
+    ...history.map((msg) => `${msg.role === "assistant" ? "ASSISTANT" : "USER"}: ${msg.content}`),
+  ].join("\n");
+}
+
 function buildSdkTurnPrompt({
   prompt,
   historyMessages,
@@ -381,14 +394,9 @@ function buildSdkTurnPrompt({
   onStagedAttachment,
 }) {
   const sections = [];
-  const history = replayHistory ? normalizeHistoryMessages(historyMessages) : [];
-  if (history.length > 0) {
-    sections.push(
-      [
-        "[Conversation context replay: the agent SDK may be starting from a fresh local session, so use these prior turns as context and answer only the latest user request.]",
-        ...history.map((msg) => `${msg.role === "assistant" ? "ASSISTANT" : "USER"}: ${msg.content}`),
-      ].join("\n"),
-    );
+  if (replayHistory) {
+    const historySection = formatSdkHistoryReplaySection(historyMessages);
+    if (historySection) sections.push(historySection);
   }
 
   if (Array.isArray(attachments) && attachments.length > 0) {
@@ -636,19 +644,25 @@ function registerSdkStreamHandlers(ctx) {
             hasConfiguredCommand,
           });
           const stagedAttachments = [];
+          const replayHistory = shouldReplaySdkHistory({
+            backendKey,
+            codexRuntime,
+            resumeSessionId,
+            hasInMemorySession,
+          });
           const turnPrompt = buildSdkTurnPrompt({
             prompt,
             historyMessages: payload?.historyMessages,
-            replayHistory: shouldReplaySdkHistory({
-              backendKey,
-              codexRuntime,
-              resumeSessionId,
-              hasInMemorySession,
-            }),
+            replayHistory,
             attachments: payload?.images,
             toolIntegrationMode: effectiveMode,
             onStagedAttachment: (attachment) => stagedAttachments.push(attachment),
           });
+          // Grok may fall back to session/new when resume/load fails; keep a
+          // history seed so that path is not history-less (Codex review #2666).
+          const historySeed = backendKey === "grok" && resumeSessionId && !replayHistory
+            ? formatSdkHistoryReplaySection(payload?.historyMessages)
+            : "";
           mcpServerBridge.updateAttachmentMetadata?.(stagedAttachments, chatSessionId);
 
           const systemContext = buildExternalAgentSystemContext({
@@ -716,6 +730,7 @@ function registerSdkStreamHandlers(ctx) {
             cursorAuthMode: backendKey === "cursor" ? cursorAuthMode : undefined,
             cursorCliBinPath: backendKey === "cursor" ? cursorCliBinPath : undefined,
             grokRuntime: backendKey === "grok" ? grokRuntime : undefined,
+            historySeed: backendKey === "grok" ? historySeed : undefined,
             getTempDir: () => tempDirBridge.getTempDir(),
             injectedMcpServers,
             claudeSettings,
@@ -1165,6 +1180,7 @@ module.exports = {
   expireSiblingCursorCliModeSessions,
   shouldCacheSdkRuntimeModels,
   normalizeHistoryMessages,
+  formatSdkHistoryReplaySection,
   buildSdkTurnPrompt,
   shouldReplaySdkHistory,
 };

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs
@@ -489,7 +489,8 @@ test("CodeBuddy does not replay renderer history when a persisted session can re
 });
 
 test("Grok does not replay renderer history when an ACP session can resume", () => {
-  // Mirrors CodeBuddy: session/load already restores Grok transcript.
+  // Mirrors CodeBuddy: session/load / resume already restores Grok transcript.
+  // Applies to both ACP and streaming-json once a resume id is present.
   assert.equal(shouldReplaySdkHistory({
     backendKey: "grok",
     codexRuntime: "sdk",
@@ -509,6 +510,83 @@ test("Grok does not replay renderer history when an ACP session can resume", () 
     resumeSessionId: "s1",
     hasInMemorySession: true,
   }), false);
+  // First turn (no resume) still seeds context even if in-memory key exists.
+  assert.equal(shouldReplaySdkHistory({
+    backendKey: "grok",
+    codexRuntime: "sdk",
+    resumeSessionId: undefined,
+    hasInMemorySession: true,
+  }), true);
+});
+
+test("Grok ACP and streaming-json session identities never cross-resume", () => {
+  const acpIdentity = `netcatty-sdk-session:${encodeURIComponent(JSON.stringify({
+    v: 1,
+    id: "grok-acp-thread",
+    backend: "grok",
+    binPath: "/usr/bin/grok",
+    runtime: "acp",
+  }))}`;
+  const headlessIdentity = `netcatty-sdk-session:${encodeURIComponent(JSON.stringify({
+    v: 1,
+    id: "grok-headless-thread",
+    backend: "grok",
+    binPath: "/usr/bin/grok",
+    runtime: "streaming-json",
+  }))}`;
+
+  // ACP identity must not resume onto streaming-json runtime.
+  assert.equal(resolveSdkResumeSessionId({
+    sdkSessionIds: new Map(),
+    sdkSessionKey: buildSdkSessionKey("chat-1", "grok", "/usr/bin/grok", "streaming-json"),
+    existingSessionId: acpIdentity,
+    backendKey: "grok",
+    binPath: "/usr/bin/grok",
+    runtime: "streaming-json",
+    hasConfiguredCommand: false,
+  }), undefined);
+
+  // streaming-json identity must not resume onto ACP runtime.
+  assert.equal(resolveSdkResumeSessionId({
+    sdkSessionIds: new Map(),
+    sdkSessionKey: buildSdkSessionKey("chat-1", "grok", "/usr/bin/grok", "acp"),
+    existingSessionId: headlessIdentity,
+    backendKey: "grok",
+    binPath: "/usr/bin/grok",
+    runtime: "acp",
+    hasConfiguredCommand: false,
+  }), undefined);
+
+  // Matching runtime resumes.
+  assert.equal(resolveSdkResumeSessionId({
+    sdkSessionIds: new Map(),
+    sdkSessionKey: buildSdkSessionKey("chat-1", "grok", "/usr/bin/grok", "acp"),
+    existingSessionId: acpIdentity,
+    backendKey: "grok",
+    binPath: "/usr/bin/grok",
+    runtime: "acp",
+    hasConfiguredCommand: false,
+  }), "grok-acp-thread");
+  assert.equal(resolveSdkResumeSessionId({
+    sdkSessionIds: new Map(),
+    sdkSessionKey: buildSdkSessionKey("chat-1", "grok", "/usr/bin/grok", "streaming-json"),
+    existingSessionId: headlessIdentity,
+    backendKey: "grok",
+    binPath: "/usr/bin/grok",
+    runtime: "streaming-json",
+    hasConfiguredCommand: false,
+  }), "grok-headless-thread");
+
+  // Bare legacy ids are only safe for runtime "sdk" — not Grok dual runtimes.
+  assert.equal(resolveSdkResumeSessionId({
+    sdkSessionIds: new Map(),
+    sdkSessionKey: buildSdkSessionKey("chat-1", "grok", "/usr/bin/grok", "acp"),
+    existingSessionId: "legacy-bare-id",
+    backendKey: "grok",
+    binPath: "/usr/bin/grok",
+    runtime: "acp",
+    hasConfiguredCommand: false,
+  }), undefined);
 });
 
 test("buildSdkTurnPrompt stages attachments as local file hints", () => {

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs
@@ -488,6 +488,29 @@ test("CodeBuddy does not replay renderer history when a persisted session can re
   }), true);
 });
 
+test("Grok does not replay renderer history when an ACP session can resume", () => {
+  // Mirrors CodeBuddy: session/load already restores Grok transcript.
+  assert.equal(shouldReplaySdkHistory({
+    backendKey: "grok",
+    codexRuntime: "sdk",
+    resumeSessionId: "resumed-grok",
+    hasInMemorySession: false,
+  }), false);
+  assert.equal(shouldReplaySdkHistory({
+    backendKey: "grok",
+    codexRuntime: "sdk",
+    resumeSessionId: undefined,
+    hasInMemorySession: false,
+  }), true);
+  // Even with an in-memory map miss, resume id alone must suppress replay.
+  assert.equal(shouldReplaySdkHistory({
+    backendKey: "grok",
+    codexRuntime: "sdk",
+    resumeSessionId: "s1",
+    hasInMemorySession: true,
+  }), false);
+});
+
 test("buildSdkTurnPrompt stages attachments as local file hints", () => {
   const staged = [];
   const prompt = buildSdkTurnPrompt({

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs
@@ -13,6 +13,7 @@ const {
   resolveSdkResumeSessionId,
   shouldReplaySdkHistory,
   expireSiblingCursorCliModeSessions,
+  expireSiblingGrokRuntimeSessions,
   resolveBackendKey,
   resolveSdkBackendBinPath,
   shouldCacheSdkRuntimeModels,
@@ -538,6 +539,72 @@ test("Grok does not replay renderer history when an ACP session can resume", () 
     resumeSessionId: undefined,
     hasInMemorySession: true,
   }), true);
+});
+
+test("expireSiblingGrokRuntimeSessions drops the inactive Grok runtime", () => {
+  const acpKey = buildSdkSessionKey("chat-1", "grok", "/usr/bin/grok", "acp");
+  const headlessKey = buildSdkSessionKey("chat-1", "grok", "/usr/bin/grok", "streaming-json");
+  const otherChatAcpKey = buildSdkSessionKey("chat-2", "grok", "/usr/bin/grok", "acp");
+  const sessions = new Map([
+    [acpKey, "acp-session"],
+    [headlessKey, "json-session"],
+    [otherChatAcpKey, "other-acp"],
+  ]);
+
+  // Switch to streaming-json: expire ACP so switch-back cannot revive it.
+  assert.equal(
+    expireSiblingGrokRuntimeSessions(sessions, {
+      chatSessionId: "chat-1",
+      backendKey: "grok",
+      binPath: "/usr/bin/grok",
+      runtime: "streaming-json",
+    }),
+    true,
+  );
+  assert.equal(sessions.has(acpKey), false);
+  assert.equal(sessions.get(headlessKey), "json-session");
+  assert.equal(sessions.get(otherChatAcpKey), "other-acp");
+
+  // Switch back to ACP: expire headless; ACP was already gone → fresh resume.
+  sessions.set(headlessKey, "json-session-2");
+  assert.equal(
+    expireSiblingGrokRuntimeSessions(sessions, {
+      chatSessionId: "chat-1",
+      backendKey: "grok",
+      binPath: "/usr/bin/grok",
+      runtime: "acp",
+    }),
+    true,
+  );
+  assert.equal(sessions.has(headlessKey), false);
+  assert.equal(
+    resolveSdkResumeSessionId({
+      sdkSessionIds: sessions,
+      sdkSessionKey: acpKey,
+      existingSessionId: `netcatty-sdk-session:${encodeURIComponent(JSON.stringify({
+        v: 1,
+        id: "json-session-2",
+        backend: "grok",
+        binPath: "/usr/bin/grok",
+        runtime: "streaming-json",
+      }))}`,
+      backendKey: "grok",
+      binPath: "/usr/bin/grok",
+      runtime: "acp",
+      hasConfiguredCommand: false,
+    }),
+    undefined,
+  );
+  // Non-grok backends no-op.
+  assert.equal(
+    expireSiblingGrokRuntimeSessions(sessions, {
+      chatSessionId: "chat-1",
+      backendKey: "claude",
+      binPath: "/usr/bin/claude",
+      runtime: "sdk",
+    }),
+    false,
+  );
 });
 
 test("Grok ACP and streaming-json session identities never cross-resume", () => {

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 const {
   registerSdkStreamHandlers,
   buildSdkTurnPrompt,
+  formatSdkHistoryReplaySection,
   buildSdkModelCacheKey,
   getSdkModelCacheEntry,
   setSdkModelCacheEntry,
@@ -465,6 +466,26 @@ test("buildSdkTurnPrompt replays history only when requested", () => {
     historyMessages: [{ role: "user", content: "previous question" }],
   });
   assert.equal(steadyStatePrompt, "latest question");
+});
+
+test("formatSdkHistoryReplaySection matches buildSdkTurnPrompt history wording", () => {
+  const messages = [
+    { role: "user", content: "previous question" },
+    { role: "assistant", content: "previous answer" },
+  ];
+  const section = formatSdkHistoryReplaySection(messages);
+  assert.match(section, /Conversation context replay/);
+  assert.match(section, /USER: previous question/);
+  assert.match(section, /ASSISTANT: previous answer/);
+  // Same section is embedded when replayHistory is true.
+  const full = buildSdkTurnPrompt({
+    prompt: "latest",
+    replayHistory: true,
+    historyMessages: messages,
+  });
+  assert.ok(full.startsWith(section));
+  assert.equal(formatSdkHistoryReplaySection([]), "");
+  assert.equal(formatSdkHistoryReplaySection(undefined), "");
 });
 
 test("CodeBuddy does not replay renderer history when a persisted session can resume", () => {

--- a/electron/shared/sdkSessionIdentity.cjs
+++ b/electron/shared/sdkSessionIdentity.cjs
@@ -10,6 +10,15 @@ function normalizeCursorCliMode(cliMode) {
   return cliMode === "ask" ? "ask" : cliMode === "agent" ? "agent" : undefined;
 }
 
+/** Codex app-server | Grok acp/streaming-json | default sdk. */
+function normalizeSdkRuntime(runtime) {
+  const raw = String(runtime || "").trim().toLowerCase();
+  if (raw === "app-server") return "app-server";
+  if (raw === "acp") return "acp";
+  if (raw === "streaming-json" || raw === "cli" || raw === "headless") return "streaming-json";
+  return "sdk";
+}
+
 function encodeSdkSessionIdentity(sessionId, sdkBackend, binPath, runtime = "sdk", authMode, cliMode) {
   if (!sessionId || !sdkBackend) return sessionId;
   const payload = {
@@ -17,7 +26,7 @@ function encodeSdkSessionIdentity(sessionId, sdkBackend, binPath, runtime = "sdk
     id: sessionId,
     backend: sdkBackend,
     binPath: binPath || "",
-    runtime: runtime === "app-server" ? "app-server" : "sdk",
+    runtime: normalizeSdkRuntime(runtime),
   };
   const normalizedAuthMode = normalizeCursorAuthMode(authMode);
   if (normalizedAuthMode) payload.authMode = normalizedAuthMode;
@@ -36,7 +45,7 @@ function parseSdkSessionIdentity(value) {
     const cliMode = normalizeCursorCliMode(parsed.cliMode);
     return {
       ...parsed,
-      runtime: parsed.runtime === "app-server" ? "app-server" : "sdk",
+      runtime: normalizeSdkRuntime(parsed.runtime),
       ...(authMode ? { authMode } : {}),
       ...(cliMode ? { cliMode } : {}),
     };
@@ -50,5 +59,6 @@ module.exports = {
   encodeSdkSessionIdentity,
   normalizeCursorAuthMode,
   normalizeCursorCliMode,
+  normalizeSdkRuntime,
   parseSdkSessionIdentity,
 };

--- a/infrastructure/ai/harness/sdkSessionIdentity.test.ts
+++ b/infrastructure/ai/harness/sdkSessionIdentity.test.ts
@@ -38,3 +38,32 @@ test('SDK session identities preserve Cursor auth mode', () => {
     cliMode: 'agent',
   });
 });
+
+test('SDK session identities preserve Grok ACP and streaming-json runtimes', () => {
+  const acp = encodeSdkSessionIdentity('sess-acp', 'grok', '/usr/bin/grok', 'acp');
+  assert.deepEqual(parseSdkSessionIdentity(acp), {
+    v: 1,
+    id: 'sess-acp',
+    backend: 'grok',
+    binPath: '/usr/bin/grok',
+    runtime: 'acp',
+  });
+
+  const headless = encodeSdkSessionIdentity(
+    'sess-json',
+    'grok',
+    '/usr/bin/grok',
+    'streaming-json',
+  );
+  assert.deepEqual(parseSdkSessionIdentity(headless), {
+    v: 1,
+    id: 'sess-json',
+    backend: 'grok',
+    binPath: '/usr/bin/grok',
+    runtime: 'streaming-json',
+  });
+
+  // Aliases normalize to streaming-json.
+  const alias = encodeSdkSessionIdentity('sess-cli', 'grok', '/usr/bin/grok', 'headless');
+  assert.equal(parseSdkSessionIdentity(alias)?.runtime, 'streaming-json');
+});

--- a/infrastructure/ai/harness/sdkSessionIdentity.ts
+++ b/infrastructure/ai/harness/sdkSessionIdentity.ts
@@ -2,13 +2,15 @@ export const SDK_SESSION_ID_PREFIX = 'netcatty-sdk-session:';
 
 export type CursorAuthModeIdentity = 'api-key' | 'cli-login';
 export type CursorCliModeIdentity = 'ask' | 'agent';
+/** Codex dual runtime + Grok dual runtime. */
+export type SdkRuntimeIdentity = 'sdk' | 'app-server' | 'acp' | 'streaming-json';
 
 export interface SdkSessionIdentityPayload {
   v: 1;
   id: string;
   backend: string;
   binPath: string;
-  runtime?: 'sdk' | 'app-server';
+  runtime?: SdkRuntimeIdentity;
   authMode?: CursorAuthModeIdentity;
   cliMode?: CursorCliModeIdentity;
 }
@@ -25,11 +27,21 @@ export function normalizeCursorCliMode(
   return cliMode === 'ask' ? 'ask' : cliMode === 'agent' ? 'agent' : undefined;
 }
 
+export function normalizeSdkRuntime(
+  runtime: string | undefined | null,
+): SdkRuntimeIdentity {
+  const raw = String(runtime || '').trim().toLowerCase();
+  if (raw === 'app-server') return 'app-server';
+  if (raw === 'acp') return 'acp';
+  if (raw === 'streaming-json' || raw === 'cli' || raw === 'headless') return 'streaming-json';
+  return 'sdk';
+}
+
 export function encodeSdkSessionIdentity(
   sessionId: string,
   sdkBackend?: string,
   binPath?: string,
-  runtime: 'sdk' | 'app-server' = 'sdk',
+  runtime: string = 'sdk',
   authMode?: string,
   cliMode?: string,
 ): string {
@@ -39,7 +51,7 @@ export function encodeSdkSessionIdentity(
     id: sessionId,
     backend: sdkBackend,
     binPath: binPath || '',
-    runtime,
+    runtime: normalizeSdkRuntime(runtime),
   };
   const normalizedAuthMode = normalizeCursorAuthMode(authMode);
   if (normalizedAuthMode) payload.authMode = normalizedAuthMode;
@@ -58,7 +70,7 @@ export function parseSdkSessionIdentity(value: string | undefined | null): SdkSe
     const cliMode = normalizeCursorCliMode(parsed.cliMode);
     return {
       ...parsed,
-      runtime: parsed.runtime === 'app-server' ? 'app-server' : 'sdk',
+      runtime: normalizeSdkRuntime(parsed.runtime),
       ...(authMode ? { authMode } : {}),
       ...(cliMode ? { cliMode } : {}),
     };

--- a/infrastructure/ai/managedAgents.test.ts
+++ b/infrastructure/ai/managedAgents.test.ts
@@ -65,3 +65,18 @@ test('legacy backend field is still accepted for saved settings', () => {
     'codex',
   );
 });
+
+test('grok managed config matches by sdk backend and discovered id', () => {
+  assert.equal(
+    matchesManagedAgentConfig({ id: 'discovered_grok', command: 'grok', sdkBackend: 'grok' }, 'grok'),
+    true,
+  );
+  assert.equal(
+    matchesManagedAgentConfig({ id: 'x', command: 'other', sdkBackend: 'grok' }, 'grok'),
+    true,
+  );
+  assert.equal(
+    matchesManagedAgentConfig({ id: 'x', command: 'C:\\\\Tools\\\\grok.exe', sdkBackend: 'grok' }, 'grok'),
+    true,
+  );
+});

--- a/infrastructure/ai/managedAgents.ts
+++ b/infrastructure/ai/managedAgents.ts
@@ -3,7 +3,7 @@ import { getCommandBasename, isPathLikeCommand } from './shared/pathLikeCommand'
 
 export { isPathLikeCommand, getCommandBasename };
 
-export type ManagedAgentKey = 'codex' | 'claude' | 'copilot' | 'cursor' | 'codebuddy' | 'opencode';
+export type ManagedAgentKey = 'codex' | 'claude' | 'copilot' | 'cursor' | 'codebuddy' | 'opencode' | 'grok';
 
 const MANAGED_AGENT_META: Record<ManagedAgentKey, { commandNames: string[]; sdkBackend: string }> = {
   codex: { commandNames: ['codex'], sdkBackend: 'codex' },
@@ -12,6 +12,7 @@ const MANAGED_AGENT_META: Record<ManagedAgentKey, { commandNames: string[]; sdkB
   cursor: { commandNames: ['cursor'], sdkBackend: 'cursor' },
   codebuddy: { commandNames: ['codebuddy'], sdkBackend: 'codebuddy' },
   opencode: { commandNames: ['opencode'], sdkBackend: 'opencode' },
+  grok: { commandNames: ['grok'], sdkBackend: 'grok' },
 };
 
 function matchesPrimaryCliBasename(command: string | undefined, agentKey: ManagedAgentKey): boolean {
@@ -27,7 +28,8 @@ export function isSettingsManagedDiscoveredAgent(
     || agent.command === 'copilot'
     || agent.command === 'cursor'
     || agent.command === 'codebuddy'
-    || agent.command === 'opencode';
+    || agent.command === 'opencode'
+    || agent.command === 'grok';
 }
 
 export function matchesManagedAgentConfig(

--- a/infrastructure/ai/sdkAgentAdapter.ts
+++ b/infrastructure/ai/sdkAgentAdapter.ts
@@ -256,7 +256,14 @@ export async function runSdkAgentTurn(
     return true;
   };
 
-  const agentEnv = await buildAgentEnvWithStoredApiKey(sdkBackend, config);
+  const baseAgentEnv = await buildAgentEnvWithStoredApiKey(sdkBackend, config);
+  // Grok dual runtime: prefer Settings grokRuntime; env override still works in main.
+  const agentEnv = sdkBackend === 'grok'
+    ? {
+        ...baseAgentEnv,
+        NETCATTY_GROK_RUNTIME: config.grokRuntime === 'streaming-json' ? 'streaming-json' : 'acp',
+      }
+    : baseAgentEnv;
   const agentCommand = getManualAgentCommand(config);
 
   // Set up event listeners before starting stream

--- a/infrastructure/ai/sdkAgentAdapter.ts
+++ b/infrastructure/ai/sdkAgentAdapter.ts
@@ -496,11 +496,13 @@ function handleStreamEvent(event: StreamEvent, callbacks: SdkAgentCallbacks): bo
     case 'session-id': {
       const sessionId = (event.sessionId as string) || '';
       if (sessionId) {
+        const runtimeRaw = String(event.runtime || 'sdk');
         callbacks.onSessionId?.(encodeSdkSessionIdentity(
           sessionId,
           event.sdkBackend as string | undefined,
           event.binPath as string | undefined,
-          event.runtime === 'app-server' ? 'app-server' : 'sdk',
+          // Preserve Codex + Grok dual-runtime tokens (do not collapse Grok to "sdk").
+          runtimeRaw,
           event.authMode as string | undefined,
           event.cliMode as string | undefined,
         ));

--- a/infrastructure/ai/types.test.ts
+++ b/infrastructure/ai/types.test.ts
@@ -7,6 +7,7 @@ import {
   CODEX_GPT_5_6_MIN_CLI_VERSION,
   CODEX_MODEL_PRESETS,
   CURSOR_MODEL_PRESETS,
+  GROK_MODEL_PRESETS,
   extractCliSemver,
   filterAgentModelPresetsForCliVersion,
   getAgentModelPresets,
@@ -34,6 +35,21 @@ test('getAgentModelPresets returns Cursor presets for cursor-agent paths and sdk
 test('getAgentModelPresets keeps Codex presets separate from CodeBuddy presets', () => {
   assert.deepEqual(getAgentModelPresets('codex'), CODEX_MODEL_PRESETS);
   assert.notDeepEqual(CODEBUDDY_MODEL_PRESETS, CODEX_MODEL_PRESETS);
+});
+
+test('getAgentModelPresets returns curated Grok fallback when runtime catalog is empty', () => {
+  assert.ok(GROK_MODEL_PRESETS.length > 0);
+  assert.deepEqual(getAgentModelPresets(undefined, 'grok'), GROK_MODEL_PRESETS);
+  assert.deepEqual(getAgentModelPresets('/usr/local/bin/grok'), GROK_MODEL_PRESETS);
+  assert.deepEqual(getAgentModelPresets('C:\\\\Tools\\\\grok.exe', 'grok'), GROK_MODEL_PRESETS);
+  assert.equal(getAgentModelPresets(undefined, 'grok')[0]?.id, 'grok-4.5');
+  // Empty/failed runtime catalog path: shared resolver still yields a non-empty list.
+  const runtimeCatalog: Array<{ id: string; name: string }> = [];
+  const resolved = runtimeCatalog.length > 0
+    ? runtimeCatalog
+    : getAgentModelPresets('grok', 'grok');
+  assert.ok(resolved.length > 0);
+  assert.deepEqual(resolved, GROK_MODEL_PRESETS);
 });
 
 test('CODEX_MODEL_PRESETS lists GPT-5.6 Sol/Terra/Luna with official reasoning levels', () => {

--- a/infrastructure/ai/types.ts
+++ b/infrastructure/ai/types.ts
@@ -701,8 +701,6 @@ export const OPENCODE_MODEL_PRESETS: AgentModelPreset[] = [
 // public Grok Build / xAI coding agent lineup; live discovery still overrides.
 export const GROK_MODEL_PRESETS: AgentModelPreset[] = [
   { id: 'grok-4.5', name: 'Grok 4.5', description: 'Default' },
-  { id: 'grok-4.5-build', name: 'Grok 4.5 Build', description: 'Coding agent' },
-  { id: 'grok-code-fast', name: 'Grok Code Fast', description: 'Faster coding' },
 ];
 
 export function getAgentModelPresets(

--- a/infrastructure/ai/types.ts
+++ b/infrastructure/ai/types.ts
@@ -231,6 +231,8 @@ export interface AgentInfo {
 
 // External agent config. Managed agents route through official SDK backends.
 export type CodexRuntime = 'sdk' | 'app-server';
+/** Grok Build turn transport: ACP (`grok agent stdio`) or headless streaming-json. */
+export type GrokRuntime = 'acp' | 'streaming-json';
 export type CursorAuthMode = 'api-key' | 'cli-login';
 
 export interface ExternalAgentConfig {
@@ -249,6 +251,11 @@ export interface ExternalAgentConfig {
   cursorAuthMode?: CursorAuthMode;
   /** Experimental Codex transport. Missing values keep the existing SDK behavior. */
   codexRuntime?: CodexRuntime;
+  /**
+   * Grok Build transport. Missing values default to ACP (`grok agent stdio`).
+   * `streaming-json` is the original headless `grok -p --output-format streaming-json` path.
+   */
+  grokRuntime?: GrokRuntime;
   /** Internal: whether the managed command was set manually or auto-detected. */
   commandSource?: "manual" | "auto";
   /**

--- a/infrastructure/ai/types.ts
+++ b/infrastructure/ai/types.ts
@@ -243,7 +243,7 @@ export interface ExternalAgentConfig {
   icon?: string;
   enabled: boolean;
   available?: boolean;
-  /** SDK backend key for managed agents (claude|codex|copilot|cursor|codebuddy|opencode). */
+  /** SDK backend key for managed agents (claude|codex|copilot|cursor|codebuddy|opencode|grok). */
   sdkBackend?: string;
   /** Cursor only: mutually exclusive auth — API key vs local `cursor-agent` CLI login. */
   cursorAuthMode?: CursorAuthMode;
@@ -296,8 +296,8 @@ export interface DiscoveredAgent {
   /** @deprecated Legacy discovery field from the pre-SDK migration. */
   acpCommand?: string;
   acpArgs?: string[];
-  /** SDK backend key (claude|codex|copilot|cursor|codebuddy|opencode) — the routing value. */
-  sdkBackend?: 'claude' | 'codex' | 'copilot' | 'cursor' | 'codebuddy' | 'opencode';
+  /** SDK backend key (claude|codex|copilot|cursor|codebuddy|opencode|grok) — the routing value. */
+  sdkBackend?: 'claude' | 'codex' | 'copilot' | 'cursor' | 'codebuddy' | 'opencode' | 'grok';
   /** Absolute resolved CLI path (preferred over `path`). */
   binPath?: string;
   installed?: boolean;

--- a/infrastructure/ai/types.ts
+++ b/infrastructure/ai/types.ts
@@ -690,6 +690,14 @@ export const OPENCODE_MODEL_PRESETS: AgentModelPreset[] = [
   { id: 'ollama/llama3.3', name: 'Ollama Llama 3.3' },
 ];
 
+// Curated Grok Build models when `grok models` is unavailable. IDs mirror the
+// public Grok Build / xAI coding agent lineup; live discovery still overrides.
+export const GROK_MODEL_PRESETS: AgentModelPreset[] = [
+  { id: 'grok-4.5', name: 'Grok 4.5', description: 'Default' },
+  { id: 'grok-4.5-build', name: 'Grok 4.5 Build', description: 'Coding agent' },
+  { id: 'grok-code-fast', name: 'Grok Code Fast', description: 'Faster coding' },
+];
+
 export function getAgentModelPresets(
   agentCommand?: string,
   sdkBackend?: string,
@@ -702,6 +710,7 @@ export function getAgentModelPresets(
   if (backend === 'cursor') return CURSOR_MODEL_PRESETS;
   if (backend === 'codebuddy') return CODEBUDDY_MODEL_PRESETS;
   if (backend === 'opencode') return OPENCODE_MODEL_PRESETS;
+  if (backend === 'grok') return GROK_MODEL_PRESETS;
 
   if (!agentCommand) return [];
   // Split on both POSIX (/) and Windows (\) separators so command paths like
@@ -720,6 +729,7 @@ export function getAgentModelPresets(
   }
   if (basename.startsWith('codebuddy')) return CODEBUDDY_MODEL_PRESETS;
   if (basename.startsWith('opencode')) return OPENCODE_MODEL_PRESETS;
+  if (basename.startsWith('grok')) return GROK_MODEL_PRESETS;
   return [];
 }
 


### PR DESCRIPTION
## Summary

Add first-class Grok Build managed agent support (discover, settings, dual runtime ACP / headless streaming-json), with multi-turn resume, auth, session-identity isolation, and MCP-mode local tool lockdown.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2213 

## Changes Made

- Discover / match Grok CLI; settings UI + i18n; model preset fallback
- Default ACP path (`grok agent stdio`) with session MCP inject; optional headless `streaming-json`
- Multi-turn: prefer `session/resume` → load → new; suppress history replay; no dual renderer history when resume id exists
- ACP `authenticate` + clear auth errors; isolate `acp` vs `streaming-json` session identities
- MCP mode: `--disallowed-tools` (global flags before `agent`); Skills mode unchanged
- Unit tests for drivers, identity, history policy, spawn flag order

## Screenshots / Demo

Settings → AI → Agent: Grok card + ACP runtime toggle.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
