### PR TITLE
fix(snippets): paste into Monaco find widget, not script body

### DIFF
--- a/components/SnippetScriptEditor.test.ts
+++ b/components/SnippetScriptEditor.test.ts
@@ -54,3 +54,9 @@ test('script code editor restores Electron clipboard paste for Cmd/Ctrl+V and na
   assert.match(codeEditorSource, /contextmenu:\s*false/);
   assert.match(codeEditorSource, /editor\.action\.clipboardPasteAction/);
 });
+
+test('script code editor pastes into Monaco find widget instead of script body', () => {
+  assert.match(codeEditorSource, /pasteForMonacoEditorCommand/);
+  assert.match(codeEditorSource, /activeElement:\s*document\.activeElement/);
+  assert.match(codeEditorSource, /pasteIntoEditor:\s*\(\)\s*=>\s*handlePasteRef\.current\(\)/);
+});

--- a/components/editor/TextEditorPane.tsx
+++ b/components/editor/TextEditorPane.tsx
@@ -25,6 +25,7 @@ loader.config({ paths: { vs: monacoBasePath } });
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { useClipboardBackend } from '../../application/state/useClipboardBackend';
 import { HotkeyScheme, KeyBinding, matchesKeyBinding } from '../../domain/models';
+import { pasteForMonacoEditorCommand } from '../../infrastructure/monaco/monacoClipboardPaste';
 import { useNetcattyMonacoTheme } from '../../infrastructure/monaco/useNetcattyMonacoTheme';
 import { getLanguageName, getSupportedLanguages } from '../../lib/sftpFileUtils';
 import { Button } from '../ui/button';
@@ -277,31 +278,13 @@ const TextEditorPaneInner: React.FC<TextEditorPaneProps> = ({
     });
 
     // Fallback paste path for Electron environments where Monaco paste can fail.
-    // Skip custom paste when focus is inside the find/replace widget so that
-    // its input fields receive the pasted text via default browser behavior.
+    // When focus is in the find/replace widget, paste into that input instead of the body.
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV, () => {
-      const active = document.activeElement;
-      if (active?.closest('.find-widget')) {
-        // Read clipboard and insert into the find/replace input field.
-        void (async () => {
-          try {
-            const text = await readClipboardTextRef.current();
-            if (!text) return;
-            // Monaco find widget inputs are <textarea> elements inside .monaco-inputbox
-            if (active instanceof HTMLTextAreaElement || active instanceof HTMLInputElement) {
-              const start = active.selectionStart ?? active.value.length;
-              const end = active.selectionEnd ?? active.value.length;
-              active.focus();
-              active.setSelectionRange(start, end);
-              document.execCommand('insertText', false, text);
-            }
-          } catch {
-            // Ignore – paste simply won't work
-          }
-        })();
-        return;
-      }
-      void handlePasteRef.current();
+      void pasteForMonacoEditorCommand({
+        activeElement: document.activeElement,
+        readClipboardText: () => readClipboardTextRef.current(),
+        pasteIntoEditor: () => handlePasteRef.current(),
+      });
     });
 
     editor.focus();

--- a/components/scripts/ScriptCodeEditor.tsx
+++ b/components/scripts/ScriptCodeEditor.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useImperativeHandle, useRef } from 'reac
 import { useClipboardBackend } from '@/application/state/useClipboardBackend';
 import {
   buildMonacoPasteEdits,
+  pasteForMonacoEditorCommand,
   readClipboardTextWithFallbacks,
 } from '@/infrastructure/monaco/monacoClipboardPaste';
 import { useNetcattyMonacoTheme } from '@/infrastructure/monaco/useNetcattyMonacoTheme';
@@ -64,6 +65,7 @@ export const ScriptCodeEditor = React.forwardRef<ScriptCodeEditorHandle, ScriptC
   const onSubmitShortcutRef = useRef(onSubmitShortcut);
   onSubmitShortcutRef.current = onSubmitShortcut;
   const handlePasteRef = useRef<() => Promise<void>>(() => Promise.resolve());
+  const readClipboardTextRef = useRef<() => Promise<string | null>>(() => Promise.resolve(null));
 
   useImperativeHandle(forwardedRef, () => ({
     focus: () => editorRef.current?.focus(),
@@ -82,16 +84,24 @@ export const ScriptCodeEditor = React.forwardRef<ScriptCodeEditorHandle, ScriptC
     return () => cancelAnimationFrame(frame);
   }, [active, fill, height]);
 
-  const handlePaste = useCallback(async () => {
-    const editor = editorRef.current;
-    if (!editor) return;
-
-    const text = await readClipboardTextWithFallbacks({
+  const readClipboardText = useCallback(async (): Promise<string | null> => (
+    readClipboardTextWithFallbacks({
       readNavigator: navigator.clipboard?.readText
         ? () => navigator.clipboard.readText()
         : undefined,
       readBridge: readClipboardTextFromBridge,
-    });
+    })
+  ), [readClipboardTextFromBridge]);
+
+  useEffect(() => {
+    readClipboardTextRef.current = readClipboardText;
+  }, [readClipboardText]);
+
+  const handlePaste = useCallback(async () => {
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    const text = await readClipboardText();
 
     if (text === null) {
       // Clipboard read unavailable; fall back to Monaco's native paste.
@@ -105,7 +115,7 @@ export const ScriptCodeEditor = React.forwardRef<ScriptCodeEditorHandle, ScriptC
 
     editor.executeEdits('netcatty-paste', buildMonacoPasteEdits(text, selections));
     editor.focus();
-  }, [readClipboardTextFromBridge]);
+  }, [readClipboardText]);
 
   useEffect(() => {
     handlePasteRef.current = handlePaste;
@@ -124,10 +134,15 @@ export const ScriptCodeEditor = React.forwardRef<ScriptCodeEditorHandle, ScriptC
       );
     }
     // Fallback paste path for Electron where Monaco clipboardPasteAction can fail.
+    // When focus is in the find/replace widget, paste into that input instead of the body.
     editor.addCommand(
       monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.KeyV,
       () => {
-        void handlePasteRef.current();
+        void pasteForMonacoEditorCommand({
+          activeElement: document.activeElement,
+          readClipboardText: () => readClipboardTextRef.current(),
+          pasteIntoEditor: () => handlePasteRef.current(),
+        });
       },
     );
     requestAnimationFrame(() => editor.layout());

--- a/infrastructure/monaco/monacoClipboardPaste.test.ts
+++ b/infrastructure/monaco/monacoClipboardPaste.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   buildMonacoPasteEdits,
   isMonacoFindWidgetFocused,
+  isStillFocusedFindPasteTarget,
   pasteForMonacoEditorCommand,
   pasteTextIntoFocusedInput,
   readClipboardTextWithFallbacks,
@@ -160,4 +161,48 @@ test('pasteForMonacoEditorCommand falls through to editor body outside find widg
     },
   });
   assert.equal(bodyPasteCount, 1);
+});
+
+test('isStillFocusedFindPasteTarget rejects targets no longer inside the find widget', () => {
+  const leftFind = {
+    closest: () => null,
+  };
+  assert.equal(isStillFocusedFindPasteTarget(leftFind), false);
+  assert.equal(isStillFocusedFindPasteTarget(null), false);
+});
+
+test('pasteForMonacoEditorCommand aborts if focus leaves the find field mid clipboard read', async () => {
+  const input = Object.assign(createMockTextInput('keep'), {
+    closest: (selector: string) => (selector === '.find-widget' ? {} : null),
+  });
+  // Simulate a browser document where focus moved away during the await.
+  const previousDocument = (globalThis as { document?: Document }).document;
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: { activeElement: { id: 'editor-body' } },
+  });
+
+  let bodyPasteCount = 0;
+  try {
+    await pasteForMonacoEditorCommand({
+      activeElement: input,
+      readClipboardText: async () => 'should-not-apply',
+      pasteIntoEditor: () => {
+        bodyPasteCount += 1;
+      },
+    });
+  } finally {
+    if (previousDocument === undefined) {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete (globalThis as { document?: Document }).document;
+    } else {
+      Object.defineProperty(globalThis, 'document', {
+        configurable: true,
+        value: previousDocument,
+      });
+    }
+  }
+
+  assert.equal(input.value, 'keep');
+  assert.equal(bodyPasteCount, 0);
 });

--- a/infrastructure/monaco/monacoClipboardPaste.test.ts
+++ b/infrastructure/monaco/monacoClipboardPaste.test.ts
@@ -3,8 +3,40 @@ import test from 'node:test';
 
 import {
   buildMonacoPasteEdits,
+  isMonacoFindWidgetFocused,
+  pasteForMonacoEditorCommand,
+  pasteTextIntoFocusedInput,
   readClipboardTextWithFallbacks,
+  type FocusedTextInput,
 } from './monacoClipboardPaste.ts';
+
+function createMockTextInput(initialValue = ''): FocusedTextInput & {
+  selectionStart: number;
+  selectionEnd: number;
+} {
+  let selectionStart = initialValue.length;
+  let selectionEnd = initialValue.length;
+  return {
+    value: initialValue,
+    get selectionStart() {
+      return selectionStart;
+    },
+    set selectionStart(value: number) {
+      selectionStart = value;
+    },
+    get selectionEnd() {
+      return selectionEnd;
+    },
+    set selectionEnd(value: number) {
+      selectionEnd = value;
+    },
+    focus() {},
+    setSelectionRange(start: number, end: number) {
+      selectionStart = start;
+      selectionEnd = end;
+    },
+  };
+}
 
 test('buildMonacoPasteEdits pastes full text at a single cursor', () => {
   const edits = buildMonacoPasteEdits('hello\nworld', [
@@ -72,4 +104,60 @@ test('readClipboardTextWithFallbacks returns null when both paths fail', async (
     },
   });
   assert.equal(text, null);
+});
+
+test('isMonacoFindWidgetFocused detects elements inside .find-widget', () => {
+  const findInput = {
+    closest: (selector: string) => (selector === '.find-widget' ? {} : null),
+  };
+  const otherInput = {
+    closest: () => null,
+  };
+  assert.equal(isMonacoFindWidgetFocused(findInput), true);
+  assert.equal(isMonacoFindWidgetFocused(otherInput), false);
+  assert.equal(isMonacoFindWidgetFocused(null), false);
+});
+
+test('pasteTextIntoFocusedInput replaces the current selection', () => {
+  const input = createMockTextInput('hello');
+  input.setSelectionRange(0, 5);
+  assert.equal(pasteTextIntoFocusedInput(input, 'world'), true);
+  assert.equal(input.value, 'world');
+  assert.equal(input.selectionStart, 5);
+  assert.equal(input.selectionEnd, 5);
+});
+
+test('pasteTextIntoFocusedInput rejects non-input targets', () => {
+  assert.equal(pasteTextIntoFocusedInput({ closest: () => ({}) }, 'x'), false);
+});
+
+test('pasteForMonacoEditorCommand pastes into find widget and skips editor body', async () => {
+  const input = Object.assign(createMockTextInput(''), {
+    closest: (selector: string) => (selector === '.find-widget' ? {} : null),
+  });
+  let bodyPasteCount = 0;
+  await pasteForMonacoEditorCommand({
+    activeElement: input,
+    readClipboardText: async () => 'search-me',
+    pasteIntoEditor: () => {
+      bodyPasteCount += 1;
+    },
+  });
+
+  assert.equal(input.value, 'search-me');
+  assert.equal(bodyPasteCount, 0);
+});
+
+test('pasteForMonacoEditorCommand falls through to editor body outside find widget', async () => {
+  let bodyPasteCount = 0;
+  await pasteForMonacoEditorCommand({
+    activeElement: null,
+    readClipboardText: async () => {
+      throw new Error('should not read clipboard for body path');
+    },
+    pasteIntoEditor: () => {
+      bodyPasteCount += 1;
+    },
+  });
+  assert.equal(bodyPasteCount, 1);
 });

--- a/infrastructure/monaco/monacoClipboardPaste.ts
+++ b/infrastructure/monaco/monacoClipboardPaste.ts
@@ -132,6 +132,32 @@ export function pasteTextIntoFocusedInput(
 }
 
 /**
+ * After an async clipboard read, confirm the find input is still the live
+ * focus target so we do not steal focus back into a closed/hidden widget or
+ * paste via execCommand into a different field.
+ */
+export function isStillFocusedFindPasteTarget(
+  active: ClosableElement | null | undefined,
+): boolean {
+  if (!active || !isMonacoFindWidgetFocused(active)) return false;
+
+  if (typeof document !== 'undefined' && document.activeElement !== active) {
+    return false;
+  }
+
+  if (
+    typeof Element !== 'undefined'
+    && active instanceof Element
+    && 'isConnected' in active
+    && !(active as Element).isConnected
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
  * When focus is in Monaco's find widget, paste there; otherwise call body paste.
  * Used by Electron Ctrl/Cmd+V command handlers that override native paste.
  */
@@ -146,6 +172,8 @@ export async function pasteForMonacoEditorCommand(options: {
     try {
       const text = await options.readClipboardText();
       if (!text) return;
+      // Clipboard I/O is async; abort if the user left the find field meanwhile.
+      if (!isStillFocusedFindPasteTarget(active)) return;
       pasteTextIntoFocusedInput(active, text);
     } catch {
       // Clipboard or insert failed; leave the find field unchanged.

--- a/infrastructure/monaco/monacoClipboardPaste.ts
+++ b/infrastructure/monaco/monacoClipboardPaste.ts
@@ -62,3 +62,95 @@ export async function readClipboardTextWithFallbacks(
     return null;
   }
 }
+
+type ClosableElement = {
+  closest?: (selector: string) => unknown;
+};
+
+/** Editable text field shape used by Monaco find/replace inputs. */
+export type FocusedTextInput = {
+  value: string;
+  selectionStart: number | null;
+  selectionEnd: number | null;
+  focus: () => void;
+  setSelectionRange: (start: number, end: number) => void;
+  dispatchEvent?: (event: Event) => boolean;
+};
+
+/** Monaco's find/replace overlay uses the `.find-widget` class. */
+export function isMonacoFindWidgetFocused(
+  active: ClosableElement | null | undefined,
+): boolean {
+  return Boolean(active?.closest?.('.find-widget'));
+}
+
+export function isFocusedTextInput(target: unknown): target is FocusedTextInput {
+  if (typeof HTMLTextAreaElement !== 'undefined' && target instanceof HTMLTextAreaElement) {
+    return true;
+  }
+  if (typeof HTMLInputElement !== 'undefined' && target instanceof HTMLInputElement) {
+    return true;
+  }
+  if (!target || typeof target !== 'object') return false;
+  const candidate = target as Partial<FocusedTextInput>;
+  return typeof candidate.value === 'string'
+    && typeof candidate.focus === 'function'
+    && typeof candidate.setSelectionRange === 'function';
+}
+
+/**
+ * Insert clipboard text into a focused find/replace input.
+ * Custom Monaco Ctrl/Cmd+V commands steal the event, so the browser cannot
+ * paste into the widget; we write the field ourselves instead of the body.
+ */
+export function pasteTextIntoFocusedInput(
+  target: unknown,
+  text: string,
+): boolean {
+  if (!isFocusedTextInput(target)) return false;
+
+  const start = target.selectionStart ?? target.value.length;
+  const end = target.selectionEnd ?? target.value.length;
+  target.focus();
+  target.setSelectionRange(start, end);
+
+  // insertText keeps undo/input events in supporting browsers.
+  if (typeof document !== 'undefined' && typeof document.execCommand === 'function') {
+    if (document.execCommand('insertText', false, text)) {
+      return true;
+    }
+  }
+
+  const nextValue = `${target.value.slice(0, start)}${text}${target.value.slice(end)}`;
+  const nextCaret = start + text.length;
+  target.value = nextValue;
+  target.setSelectionRange(nextCaret, nextCaret);
+  if (typeof target.dispatchEvent === 'function' && typeof Event !== 'undefined') {
+    target.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+  return true;
+}
+
+/**
+ * When focus is in Monaco's find widget, paste there; otherwise call body paste.
+ * Used by Electron Ctrl/Cmd+V command handlers that override native paste.
+ */
+export async function pasteForMonacoEditorCommand(options: {
+  activeElement: ClosableElement | null | undefined;
+  readClipboardText: () => Promise<string | null>;
+  pasteIntoEditor: () => void | Promise<void>;
+}): Promise<void> {
+  if (isMonacoFindWidgetFocused(options.activeElement)) {
+    const active = options.activeElement;
+    if (!active) return;
+    try {
+      const text = await options.readClipboardText();
+      if (!text) return;
+      pasteTextIntoFocusedInput(active, text);
+    } catch {
+      // Clipboard or insert failed; leave the find field unchanged.
+    }
+    return;
+  }
+  await options.pasteIntoEditor();
+}


### PR DESCRIPTION
## Summary

When the snippet script editor's Monaco find bar was focused, Cmd/Ctrl+V still ran the custom Electron paste path and inserted clipboard text into the script body. This routes find-widget paste into the search input instead.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2661

## Changes Made

- Extract shared Monaco paste helpers for find-widget detection and input insertion
- Wire `ScriptCodeEditor` Ctrl/Cmd+V through `pasteForMonacoEditorCommand` so find/replace pastes stay in the search field
- Reuse the same helper in `TextEditorPane` (same Electron paste override pattern)
- Add unit coverage for find-widget paste routing

## Screenshots / Demo

N/A — keyboard paste behavior in Monaco find widget.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — targeted: `monacoClipboardPaste.test.ts`, `SnippetScriptEditor.test.ts`
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)