### PR TITLE
fix(sftp): show sudo hosts under Connected in host picker

### DIFF
--- a/application/state/sftp/useSftpConnections.ts
+++ b/application/state/sftp/useSftpConnections.ts
@@ -568,6 +568,10 @@ export const useSftpConnections = ({
           sharedHostCache?.path,
         );
 
+        // Sudo never reuses a terminal shell; normalize before UI state so
+        // reusedConnection (spinner/overlay) matches the actual open path.
+        const sourceSessionId = host.sftpSudo ? undefined : options?.sourceSessionId;
+
         const connection: SftpConnection = {
           id: connectionId,
           hostId: host.id,
@@ -579,7 +583,7 @@ export const useSftpConnections = ({
           // If the backend falls back to a fresh connection, the pane stays
           // non-interactive (loading=true) with stale cached files visible —
           // no worse than the previous UX of always showing a spinner.
-          reusedConnection: !!options?.sourceSessionId,
+          reusedConnection: !!sourceSessionId,
           fileProtocol: host.sftpFileProtocol ?? 'auto',
         };
 
@@ -652,7 +656,7 @@ export const useSftpConnections = ({
           // immediately repeated after a shared-channel attempt fails.
           const sftpId = await openSftpConnectionOnce({
             bridge,
-            sourceSessionId: !host.sftpSudo ? options?.sourceSessionId : undefined,
+            sourceSessionId,
             openOptions: {
               sessionId: sftpSessionId,
               ...credentials,

--- a/components/sftp/SftpHostPicker.test.ts
+++ b/components/sftp/SftpHostPicker.test.ts
@@ -50,6 +50,23 @@ test("sftp host picker uses single-line quick switcher row layout", () => {
   assert.doesNotMatch(source, /text-xs text-muted-foreground truncate/);
 });
 
+test("sftp host picker omits sourceSessionId for sudo connected hosts", () => {
+  assert.match(source, /sftpSourceSessionIdForHost/);
+  assert.match(
+    source,
+    /const sourceSessionId = sftpSourceSessionIdForHost\(\s*item\.entry\.host,\s*item\.entry\.sessionId,\s*\);/,
+  );
+  assert.match(
+    source,
+    /onSelectHost\(\s*item\.entry\.host,\s*sourceSessionId \? \{ sourceSessionId \} : undefined,\s*\)/,
+  );
+  // Must not always pass sessionId as a reuse hint (sudo would hide the spinner).
+  assert.doesNotMatch(
+    source,
+    /onSelectHost\(item\.entry\.host, \{ sourceSessionId: item\.entry\.sessionId \}\)/,
+  );
+});
+
 test("sftp host picker virtualizes the host list", () => {
   assert.match(source, /VariableSizeVirtualList/);
   assert.match(source, /data-host-picker-virtual="sftp"/);

--- a/components/sftp/SftpHostPicker.tsx
+++ b/components/sftp/SftpHostPicker.tsx
@@ -7,6 +7,7 @@ import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from '
 import { useI18n } from '../../application/i18n/I18nProvider';
 import {
     sftpHostEndpointsEqual,
+    sftpSourceSessionIdForHost,
     type SftpConnectedHostEntry,
 } from '../../domain/sftpConnectedHosts';
 import { isPluginHostProtocol } from '../../domain/pluginConnection';
@@ -193,7 +194,16 @@ const SftpHostPickerInner: React.FC<SftpHostPickerProps> = ({
         if (item.type === 'local') {
             onSelectLocal();
         } else if (item.type === 'connected') {
-            onSelectHost(item.entry.host, { sourceSessionId: item.entry.sessionId });
+            // Sudo SFTP cannot reuse the terminal shell; omit the hint so connect
+            // UI (reusedConnection / spinner) matches the dedicated open path.
+            const sourceSessionId = sftpSourceSessionIdForHost(
+                item.entry.host,
+                item.entry.sessionId,
+            );
+            onSelectHost(
+                item.entry.host,
+                sourceSessionId ? { sourceSessionId } : undefined,
+            );
         } else {
             onSelectHost(item.host);
         }

--- a/domain/sftpConnectedHosts.test.ts
+++ b/domain/sftpConnectedHosts.test.ts
@@ -7,6 +7,7 @@ import {
   resolveSftpTransferSourceSessionId,
   sftpHostEndpointsEqual,
   sftpPickerSessionsEqual,
+  sftpSourceSessionIdForHost,
 } from "./sftpConnectedHosts";
 
 const host = (overrides: Partial<Host> & Pick<Host, "id" | "label">): Host => ({
@@ -121,6 +122,21 @@ test("listSftpConnectedHosts includes hosts with SFTP sudo for picker display", 
     resolveSftpTransferSourceSessionId(sessions, hostsById, "a", result[0]?.host),
     undefined,
   );
+  // Picker/connect must not pass sessionId as a reuse hint for sudo hosts.
+  assert.equal(sftpSourceSessionIdForHost(result[0]?.host, result[0]?.sessionId), undefined);
+});
+
+test("sftpSourceSessionIdForHost keeps non-sudo reuse and drops sudo", () => {
+  assert.equal(
+    sftpSourceSessionIdForHost(host({ id: "a", label: "Alpha" }), "s1"),
+    "s1",
+  );
+  assert.equal(
+    sftpSourceSessionIdForHost(host({ id: "a", label: "Alpha", sftpSudo: true }), "s1"),
+    undefined,
+  );
+  assert.equal(sftpSourceSessionIdForHost(undefined, "s1"), "s1");
+  assert.equal(sftpSourceSessionIdForHost(host({ id: "a", label: "Alpha" }), undefined), undefined);
 });
 
 test("listSftpConnectedHosts uses the live session endpoint when the vault host was edited", () => {

--- a/domain/sftpConnectedHosts.test.ts
+++ b/domain/sftpConnectedHosts.test.ts
@@ -104,7 +104,7 @@ test("listSftpConnectedHosts keeps plain SSH sessions even when vault host defau
   assert.equal(result[0]?.sessionId, "s-ssh-deeplink");
 });
 
-test("listSftpConnectedHosts skips hosts with SFTP sudo enabled", () => {
+test("listSftpConnectedHosts includes hosts with SFTP sudo for picker display", () => {
   const hostsById = new Map([
     ["a", host({ id: "a", label: "Alpha", sftpSudo: true })],
   ]);
@@ -112,7 +112,15 @@ test("listSftpConnectedHosts skips hosts with SFTP sudo enabled", () => {
     session({ id: "s-sudo", hostId: "a", status: "connected" }),
   ];
 
-  assert.deepEqual(listSftpConnectedHosts(sessions, hostsById), []);
+  const result = listSftpConnectedHosts(sessions, hostsById);
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.sessionId, "s-sudo");
+  assert.equal(result[0]?.host.sftpSudo, true);
+  // Transfer/open must still refuse shell reuse for sudo.
+  assert.equal(
+    resolveSftpTransferSourceSessionId(sessions, hostsById, "a", result[0]?.host),
+    undefined,
+  );
 });
 
 test("listSftpConnectedHosts uses the live session endpoint when the vault host was edited", () => {

--- a/domain/sftpConnectedHosts.ts
+++ b/domain/sftpConnectedHosts.ts
@@ -131,6 +131,19 @@ export const listSftpConnectedHosts = (
 };
 
 /**
+ * Drop terminal-session reuse when the host requires a dedicated sudo SFTP
+ * channel. Used by the picker and browse connect path so UI state
+ * (`reusedConnection`) and the actual open agree.
+ */
+export const sftpSourceSessionIdForHost = (
+  host: Pick<Host, "sftpSudo"> | null | undefined,
+  sourceSessionId: string | undefined,
+): string | undefined => {
+  if (!sourceSessionId || host?.sftpSudo) return undefined;
+  return sourceSessionId;
+};
+
+/**
  * Resolve a terminal session id for transfer-pool opens that can reuse the
  * live SSH transport. Unlike the picker list, this keeps every reusable
  * session so same-hostId tabs with different live endpoints can still match.

--- a/domain/sftpConnectedHosts.ts
+++ b/domain/sftpConnectedHosts.ts
@@ -96,7 +96,11 @@ export const sftpPickerSessionsEqual = (
 
 /**
  * Build the "currently connected" host list for the SFTP host picker.
- * One entry per hostId — keeps the most recently listed reusable session.
+ * One entry per hostId — keeps the most recently listed SSH terminal session.
+ *
+ * Includes hosts with sftpSudo: they still belong under "Connected" when a
+ * terminal is open, but connect paths must not reuse the shell (see
+ * resolveSftpTransferSourceSessionId and useSftpConnections sudo guards).
  */
 export const listSftpConnectedHosts = (
   sessions: ReadonlyArray<SftpPickerSessionFields>,
@@ -109,10 +113,9 @@ export const listSftpConnectedHosts = (
     const host = hostsById.get(session.hostId);
     if (!host) continue;
     if (host.protocol === "serial" || isPluginHostProtocol(host.protocol)) continue;
-    // SFTP sudo never reuses a terminal shell conn (bridge requires !options.sudo).
-    if (host.sftpSudo) continue;
     // Use session transport flags only. Vault hosts may still have mosh/et
     // defaults while the live terminal was opened as plain SSH (e.g. ssh://).
+    // Do not filter sftpSudo here — picker display only; reuse is stripped later.
 
     // Later sessions overwrite earlier ones for the same hostId.
     bestByHostId.set(host.id, {


### PR DESCRIPTION
## Summary

SFTP host picker no longer hides hosts with SFTP sudo enabled from the **Connected** section when a terminal is already open.

Display-only change: connect still uses a dedicated sudo SFTP open and does **not** reuse the terminal SSH shell (existing `sourceSessionId` / transfer guards unchanged).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2656

## Changes Made

- `listSftpConnectedHosts` includes hosts with `sftpSudo` when a connected SSH terminal exists
- Keep `resolveSftpTransferSourceSessionId` (and connect-path) sudo reuse blocks intact
- Update unit tests for picker display vs transfer-source behavior

## Screenshots / Demo

N/A — list placement only. Hosts with Sudo mode + open terminal now appear under Connected instead of only under Hosts.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — `domain/sftpConnectedHosts.test.ts` (16/16)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)