### PR TITLE
fix(sftp): stop skipped conflicts from reopening after restart

### DIFF
--- a/application/state/sftp/useSftpTransfers.ts
+++ b/application/state/sftp/useSftpTransfers.ts
@@ -178,10 +178,12 @@ export const useSftpTransfers = ({
   const surfaceVisibleRef = useRef(surfaceVisible);
   surfaceVisibleRef.current = surfaceVisible;
   const [transfers, setTransfersState] = useState<TransferTask[]>(() => sftpTransferCenterStore.getOwnerTasks(ownerId));
+  // Only re-surface live attention conflicts. Terminal rows may still carry a
+  // stale conflict payload after older Skip paths — those must not reopen the dialog.
   const [conflicts, setConflicts] = useState<FileConflict[]>(() => sftpTransferCenterStore
     .getOwnerTasks(ownerId)
-    .map((task) => task.conflict)
-    .filter((conflict): conflict is FileConflict => !!conflict));
+    .filter((task) => task.status === "attention" && !!task.conflict)
+    .map((task) => task.conflict as FileConflict));
 
   // Track cancelled task IDs. has() also sees process-global cancel flags set by
   // the transfer center after the React owner unmounts.
@@ -1393,8 +1395,20 @@ export const useSftpTransfers = ({
 
       const task = transfersRef.current.find((t) => t.id === conflictId);
       if (!task) {
+        // Dialog can show a store-owned conflict before the panel adopts the row.
+        // Clearing only React state leaves attention+conflict in localStorage and
+        // the prompt returns on the next SFTP open (issue #2636).
         conflictsRef.current = conflictsRef.current.filter((c) => c.transferId !== conflictId);
         setConflicts(conflictsRef.current);
+        if (action === "stop" || action === "skip") {
+          sftpTransferCenterStore.patchTask(conflictId, {
+            status: "cancelled",
+            conflict: undefined,
+            endTime: Date.now(),
+            speed: 0,
+            error: undefined,
+          });
+        }
         return;
       }
 
@@ -1436,9 +1450,18 @@ export const useSftpTransfers = ({
         for (const affectedTask of affectedTasks) {
           cancelledTasksRef.current.add(affectedTask.id);
         }
+        // Drop conflict so remount / restart cannot rehydrate the dialog from a
+        // cancelled row that still carries conflict metadata.
         setTransfers((prev) =>
           prev.map((t) => affectedConflictIds.has(t.id)
-              ? { ...t, status: "cancelled" as TransferStatus, endTime: Date.now() }
+              ? {
+                  ...t,
+                  status: "cancelled" as TransferStatus,
+                  endTime: Date.now(),
+                  conflict: undefined,
+                  error: undefined,
+                  speed: 0,
+                }
               : t,
           ),
         );

--- a/domain/sftpTransferCenter.test.ts
+++ b/domain/sftpTransferCenter.test.ts
@@ -123,6 +123,39 @@ test("restoring a paused task also marks it interrupted after restart", () => {
   assert.equal(restored.tasks[0]?.lifecycleEpoch, undefined);
 });
 
+test("restoring terminal tasks strips stale conflict payloads (skip-without-clear legacy)", () => {
+  const conflict = {
+    transferId: "css-dir",
+    fileName: "css",
+    sourcePath: "/src/css",
+    targetPath: "/dst/css",
+    isDirectory: true,
+    existingType: "directory" as const,
+    existingSize: 8192,
+    newSize: 0,
+    existingModified: 1,
+    newModified: 2,
+  };
+  const restored = deserializeSftpTransferCenter(JSON.stringify({
+    version: 1,
+    tasks: [{
+      ...task("css-dir", "cancelled", 1),
+      isDirectory: true,
+      conflict,
+      endTime: Date.now(),
+    }, {
+      ...task("still-open", "attention", 2),
+      isDirectory: true,
+      conflict: { ...conflict, transferId: "still-open" },
+    }],
+  }));
+
+  assert.equal(restored.tasks[0]?.status, "cancelled");
+  assert.equal(restored.tasks[0]?.conflict, undefined);
+  assert.equal(restored.tasks[1]?.status, "attention");
+  assert.equal(restored.tasks[1]?.conflict?.fileName, "css");
+});
+
 test("history keeps unfinished tasks and caps terminal tasks by age and count", () => {
   const now = Date.UTC(2026, 6, 23);
   const old = now - 31 * 24 * 60 * 60 * 1000;

--- a/domain/sftpTransferCenter.ts
+++ b/domain/sftpTransferCenter.ts
@@ -92,6 +92,12 @@ export function sanitizeSftpTransferTask(value: unknown): TransferTask | null {
     // progress after dedicated reconnect.
     task.lifecycleEpoch = undefined;
   }
+  // Terminal rows must not keep conflict payloads. Older Skip paths cancelled the
+  // task without clearing conflict, so SFTP remount reopened the conflict dialog
+  // while the transfer center looked empty (no attention bucket row).
+  if (TERMINAL_STATUSES.has(task.status) && task.conflict) {
+    task.conflict = undefined;
+  }
   return task;
 }
 


### PR DESCRIPTION
## Summary

- Fix SFTP conflict dialog reappearing after Skip / app restart even when the transfer center looks empty (#2636).
- Clear `conflict` metadata when Skip/Stop resolves a conflict, and only rehydrate live `attention` conflicts into the dialog.
- Strip stale conflict payloads from terminal tasks when restoring persisted transfer history so already-affected installs self-heal on upgrade.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2636

## Changes Made

- `useSftpTransfers`: Skip marks tasks `cancelled` and clears `conflict`; orphan dialog actions also patch the transfer-center store.
- `useSftpTransfers`: dialog conflict state only restores rows with `status === "attention"`.
- `sanitizeSftpTransferTask`: terminal statuses drop leftover `conflict` on load/persist restore.
- Unit test covers legacy cancelled+conflict history payload.

## Screenshots / Demo

N/A (behavior fix for conflict dialog lifecycle). Repro was: open SFTP after a prior name conflict, Skip, quit, reopen SFTP → dialog returned with empty transfer center.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — ran `node --test --import tsx domain/sftpTransferCenter.test.ts`
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)