### PR TITLE
fix: prevent keyword highlights flashing on Enter

### DIFF
--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -828,6 +828,49 @@ test("Enter replaces a queued write refresh with input-quiet work", () => {
   }
 });
 
+test("Enter dirty work continues after a queued full refresh", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const {
+      term,
+      decorationStates,
+      handlers,
+      setLineText,
+    } = createFakeTerminal("hello DEPLOY world", { lineCount: 40 });
+    term.buffer.active.viewportY = 20;
+    term.buffer.active.baseY = 20;
+    term.buffer.active.cursorY = 2;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+    const originalDecoration = decorationStates.find(({ line }) => line === 22);
+    assert.ok(originalDecoration);
+
+    handlers.resize?.();
+    handlers.data?.("\r");
+    setLineText(22, "redrawn without a keyword");
+    handlers.writeParsed?.();
+    await new Promise((resolve) => { setTimeout(resolve, 340); });
+    raf.flush();
+
+    const originalDisposed = originalDecoration.isDisposed;
+    highlighter.dispose();
+    assert.equal(
+      originalDisposed,
+      true,
+      "Enter changes should be consumed after a queued full refresh completes",
+    );
+  } finally {
+    raf.restore();
+  }
+});
+
 test("continuous Enter output lets multi-frame refreshes finish", () => {
   const raf = installAnimationFrameQueue();
   try {

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -720,6 +720,52 @@ test("large output delays keyword highlight scans until output quiets", async ()
   }
 });
 
+test("Enter cancels queued scroll pruning before large-output deferral", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, decorationStates, handlers } = createFakeTerminal("hello DEPLOY world", {
+      lineCount: 40,
+    });
+    term.buffer.active.viewportY = 20;
+    term.buffer.active.baseY = 20;
+    term.buffer.active.cursorY = 2;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+    const existingDecorations = [...decorationStates];
+    assert.ok(existingDecorations.length > 0);
+
+    handlers.data?.("\r");
+    term.buffer.active.viewportY += 1;
+    term.buffer.active.baseY += 1;
+    term.buffer.active.length += 1;
+    handlers.scroll?.();
+    noteTerminalOutputPressureData(
+      term as never,
+      "x\n".repeat(Math.ceil(TERMINAL_LONG_LINE_PRESSURE_BYTES / 2)),
+    );
+    handlers.writeParsed?.();
+    await new Promise((resolve) => { setTimeout(resolve, 220); });
+
+    const disposedDecorationCount = existingDecorations.filter(({ isDisposed }) => isDisposed).length;
+    highlighter.dispose();
+    resetTerminalOutputPressure(term as never);
+    assert.equal(
+      disposedDecorationCount,
+      0,
+      "large Enter output should not leave a queued scroll prune behind",
+    );
+  } finally {
+    raf.restore();
+  }
+});
+
 test("recent user input delays keyword highlight scans until typing is quiet", async () => {
   const raf = installAnimationFrameQueue();
   try {

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -839,7 +839,7 @@ test("pasted Enter remains protected when more input arrives before output", asy
   }
 });
 
-test("an unrelated parsed write does not consume pending Enter protection", async () => {
+test("multi-command Enter protection survives earlier buffer movement until idle", async () => {
   const raf = installAnimationFrameQueue();
   try {
     const { term, decorationStates, handlers } = createFakeTerminal("hello DEPLOY world", {
@@ -861,6 +861,7 @@ test("an unrelated parsed write does not consume pending Enter protection", asyn
 
     const internals = highlighter as unknown as {
       dirtyAllInRenderRange: boolean;
+      enterInputPending: boolean;
       lastBufferSnapshot: unknown;
       readBufferSnapshot: () => unknown;
       writePruningDeferred: boolean;
@@ -878,7 +879,11 @@ test("an unrelated parsed write does not consume pending Enter protection", asyn
     const retainedDecorations = decorationStates.filter(({ isDisposed }) => !isDisposed);
     assert.ok(retainedDecorations.length > 64);
 
-    handlers.data?.("\r");
+    handlers.data?.("\u001b[200~echo one\r\necho two\r\n\u001b[201~");
+    term.buffer.active.viewportY += 1;
+    term.buffer.active.baseY += 1;
+    term.buffer.active.length += 1;
+    handlers.scroll?.();
     handlers.writeParsed?.();
     await new Promise((resolve) => { setTimeout(resolve, 220); });
 
@@ -892,7 +897,43 @@ test("an unrelated parsed write does not consume pending Enter protection", asyn
     assert.equal(
       retainedDecorations.filter(({ isDisposed }) => isDisposed).length,
       0,
-      "a write without buffer movement should not consume pending Enter protection",
+      "an earlier moving write should not consume protection for later Enter output",
+    );
+    assert.equal(internals.enterInputPending, true);
+
+    await new Promise((resolve) => { setTimeout(resolve, 700); });
+    assert.equal(internals.enterInputPending, false, "Enter protection should end after output is idle");
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("a new Enter cancels the previous output idle deadline", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, handlers } = createFakeTerminal("hello DEPLOY world");
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+    const internals = highlighter as unknown as { enterInputPending: boolean };
+
+    handlers.data?.("\r");
+    handlers.writeParsed?.();
+    await new Promise((resolve) => { setTimeout(resolve, 400); });
+    handlers.data?.("\r");
+    await new Promise((resolve) => { setTimeout(resolve, 250); });
+
+    assert.equal(
+      internals.enterInputPending,
+      true,
+      "the previous command's idle timer should not clear a newer Enter",
     );
     highlighter.dispose();
   } finally {

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -1145,9 +1145,8 @@ test("late Enter output stays protected after the pending hint expires", async (
   const raf = installAnimationFrameQueue();
   try {
     const { term, decorationStates, handlers } = createFakeTerminal("hello DEPLOY world", {
-      lineCount: 400,
+      lineCount: 40,
     });
-    term.rows = 3;
     term.buffer.active.viewportY = 20;
     term.buffer.active.baseY = 20;
     term.buffer.active.cursorY = 2;
@@ -1160,28 +1159,8 @@ test("late Enter output stays protected after the pending hint expires", async (
       enabled: true,
     }], true);
     raf.flush();
-
-    const internals = highlighter as unknown as {
-      dirtyAllInRenderRange: boolean;
-      lastBufferSnapshot: unknown;
-      readBufferSnapshot: () => unknown;
-      refreshViewport: (reason: "write") => void;
-    };
-    for (let index = 0; index < 150; index += 1) {
-      term.buffer.active.viewportY += 1;
-      term.buffer.active.baseY += 1;
-      term.buffer.active.length += 1;
-      internals.dirtyAllInRenderRange = true;
-      internals.refreshViewport("write");
-    }
-    internals.lastBufferSnapshot = internals.readBufferSnapshot();
     const retainedDecorations = decorationStates.filter(({ isDisposed }) => !isDisposed);
-    assert.ok(retainedDecorations.length > 64);
-    const viewportStart = term.buffer.active.viewportY;
-    const visibleDecorations = retainedDecorations.filter(
-      ({ line }) => line > viewportStart && line < viewportStart + term.rows,
-    );
-    assert.ok(visibleDecorations.length > 0);
+    assert.ok(retainedDecorations.length > 0);
 
     handlers.data?.("\r");
     handlers.writeParsed?.();
@@ -1195,9 +1174,9 @@ test("late Enter output stays protected after the pending hint expires", async (
     await new Promise((resolve) => { setTimeout(resolve, 220); });
 
     assert.equal(
-      visibleDecorations.filter(({ isDisposed }) => isDisposed).length,
+      retainedDecorations.filter(({ isDisposed }) => isDisposed).length,
       0,
-      "late Enter output should not replace visible decorations",
+      "late Enter output should treat its queued scroll as output-driven",
     );
     highlighter.dispose();
   } finally {

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -720,12 +720,16 @@ test("large output delays keyword highlight scans until output quiets", async ()
   }
 });
 
-test("Enter cancels queued scroll pruning before large-output deferral", async () => {
+test("Enter cancels queued scroll work before large-output deferral", async () => {
   const raf = installAnimationFrameQueue();
   try {
-    const { term, decorationStates, handlers } = createFakeTerminal("hello DEPLOY world", {
-      lineCount: 40,
-    });
+    const {
+      term,
+      decorationStates,
+      handlers,
+      getTranslateCount,
+      resetTranslateCount,
+    } = createFakeTerminal("hello DEPLOY world", { lineCount: 40 });
     term.buffer.active.viewportY = 20;
     term.buffer.active.baseY = 20;
     term.buffer.active.cursorY = 2;
@@ -740,6 +744,7 @@ test("Enter cancels queued scroll pruning before large-output deferral", async (
     raf.flush();
     const existingDecorations = [...decorationStates];
     assert.ok(existingDecorations.length > 0);
+    resetTranslateCount();
 
     handlers.data?.("\r");
     term.buffer.active.viewportY += 1;
@@ -754,6 +759,7 @@ test("Enter cancels queued scroll pruning before large-output deferral", async (
     await new Promise((resolve) => { setTimeout(resolve, 220); });
 
     const disposedDecorationCount = existingDecorations.filter(({ isDisposed }) => isDisposed).length;
+    const translateCountBeforeQuiet = getTranslateCount();
     highlighter.dispose();
     resetTerminalOutputPressure(term as never);
     assert.equal(
@@ -761,6 +767,45 @@ test("Enter cancels queued scroll pruning before large-output deferral", async (
       0,
       "large Enter output should not leave a queued scroll prune behind",
     );
+    assert.equal(translateCountBeforeQuiet, 0, "large output should wait for the quiet catch-up scan");
+  } finally {
+    raf.restore();
+  }
+});
+
+test("continuous Enter output still refreshes highlights periodically", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, decorationStates, handlers, setLineText } = createFakeTerminal("no match", {
+      lineCount: 40,
+    });
+    term.buffer.active.viewportY = 20;
+    term.buffer.active.baseY = 20;
+    term.buffer.active.cursorY = 2;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+    assert.equal(decorationStates.filter(({ isDisposed }) => !isDisposed).length, 0);
+
+    handlers.data?.("\r");
+    setLineText(22, "DEPLOY");
+    for (let index = 0; index < 20; index += 1) {
+      handlers.writeParsed?.();
+      raf.flush();
+      await new Promise((resolve) => { setTimeout(resolve, 50); });
+    }
+
+    assert.ok(
+      decorationStates.some(({ isDisposed }) => !isDisposed),
+      "ongoing output should not postpone new highlights until the stream stops",
+    );
+    highlighter.dispose();
   } finally {
     raf.restore();
   }

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -33,13 +33,18 @@ function installAnimationFrameQueue() {
     callbacks.delete(id);
   }) as typeof cancelAnimationFrame;
 
+  const flushOne = () => {
+    const next = callbacks.entries().next().value as [number, RafCallback] | undefined;
+    if (!next) return;
+    callbacks.delete(next[0]);
+    next[1](performance.now());
+  };
+
   return {
+    flushOne,
     flush() {
       while (callbacks.size > 0) {
-        const next = callbacks.entries().next().value as [number, RafCallback] | undefined;
-        if (!next) break;
-        callbacks.delete(next[0]);
-        next[1](performance.now());
+        flushOne();
       }
     },
     restore() {
@@ -818,6 +823,69 @@ test("Enter replaces a queued write refresh with input-quiet work", () => {
       "the pre-Enter write frame should not scan during the input quiet window",
     );
     highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("continuous Enter output lets multi-frame refreshes finish", () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const {
+      term,
+      handlers,
+      getTranslatedLineIndexes,
+      resetTranslateCount,
+    } = createFakeTerminal("hello DEPLOY world", { lineCount: 140 });
+    term.rows = 100;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+    resetTranslateCount();
+
+    const internals = highlighter as unknown as {
+      lastRefreshTime: number;
+      lastUserInputAt: number;
+    };
+    handlers.data?.("\r");
+    internals.lastUserInputAt = Number.NEGATIVE_INFINITY;
+
+    const originalPerformance = globalThis.performance;
+    let simulatedNow = 0;
+    Object.defineProperty(globalThis, "performance", {
+      configurable: true,
+      value: {
+        now: () => {
+          simulatedNow += 5;
+          return simulatedNow;
+        },
+      },
+    });
+    try {
+      for (let index = 0; index < 3; index += 1) {
+        internals.lastRefreshTime = Number.NEGATIVE_INFINITY;
+        handlers.writeParsed?.();
+        raf.flushOne();
+      }
+    } finally {
+      Object.defineProperty(globalThis, "performance", {
+        configurable: true,
+        value: originalPerformance,
+      });
+    }
+
+    const reachedViewportEnd = getTranslatedLineIndexes().includes(98);
+    highlighter.dispose();
+    assert.ok(
+      reachedViewportEnd,
+      "continuation work should reach the end of a large viewport during ongoing output",
+    );
   } finally {
     raf.restore();
   }

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -204,11 +204,13 @@ function createFakeTerminal(lineText: string, options: { lineCount?: number } = 
   const lineCount = options.lineCount ?? 1;
   let translateCount = 0;
   const translatedLineIndexes: number[] = [];
-  const lines = Array.from({ length: lineCount }, (_, index) =>
-    createFakeLine(`${lineText} ${index}`, () => {
+  const createLineAtIndex = (text: string, index: number) =>
+    createFakeLine(text, () => {
       translateCount += 1;
       translatedLineIndexes.push(index);
-    })
+    });
+  const lines = Array.from({ length: lineCount }, (_, index) =>
+    createLineAtIndex(`${lineText} ${index}`, index)
   );
   const decorations: Array<{ x: number; width: number; foregroundColor: string }> = [];
   const decorationStates: Array<{
@@ -304,6 +306,9 @@ function createFakeTerminal(lineText: string, options: { lineCount?: number } = 
     },
     resetRefreshCalls: () => {
       refreshCalls.length = 0;
+    },
+    setLineText: (lineY: number, text: string) => {
+      lines[lineY] = createLineAtIndex(text, lineY);
     },
   };
 }
@@ -823,7 +828,81 @@ test("pressing Enter rescans only the cursor neighborhood", async () => {
   }
 });
 
-test("pressing Enter does not force an extra repaint after markers move", async () => {
+test("non-Enter input still detects redraws away from the cursor", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, handlers, setLineText } = createFakeTerminal("hello DEPLOY world", {
+      lineCount: 60,
+    });
+    term.rows = 10;
+    term.buffer.active.viewportY = 20;
+    term.buffer.active.baseY = 20;
+    term.buffer.active.cursorY = 9;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+    assert.notDeepEqual(highlighter.getForegroundRanges(20), []);
+
+    handlers.data?.("a");
+    setLineText(20, "redrawn without a keyword");
+    handlers.writeParsed?.();
+    await new Promise((resolve) => { setTimeout(resolve, 220); });
+
+    assert.deepEqual(highlighter.getForegroundRanges(20), []);
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("write-only scrolling keeps retained decorations bounded", () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, decorationStates } = createFakeTerminal("hello DEPLOY world", {
+      lineCount: 400,
+    });
+    term.buffer.active.viewportY = 20;
+    term.buffer.active.baseY = 20;
+    term.buffer.active.cursorY = 2;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+
+    const internals = highlighter as unknown as {
+      dirtyAllInRenderRange: boolean;
+      refreshViewport: (reason: "write") => void;
+    };
+    for (let index = 0; index < 250; index += 1) {
+      term.buffer.active.viewportY += 1;
+      term.buffer.active.baseY += 1;
+      term.buffer.active.length += 1;
+      internals.dirtyAllInRenderRange = true;
+      internals.refreshViewport("write");
+    }
+
+    assert.ok(
+      decorationStates.filter(({ isDisposed }) => !isDisposed).length <= 64,
+      "write-only output should not retain every highlighted scrollback line",
+    );
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("pressing Enter limits marker-move repaint to the cursor row", async () => {
   const raf = installAnimationFrameQueue();
   try {
     const {
@@ -855,7 +934,7 @@ test("pressing Enter does not force an extra repaint after markers move", async 
     handlers.writeParsed?.();
     await new Promise((resolve) => { setTimeout(resolve, 220); });
 
-    assert.deepEqual(refreshCalls, []);
+    assert.deepEqual(refreshCalls, [{ start: 2, end: 2 }]);
     highlighter.dispose();
   } finally {
     raf.restore();

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -864,7 +864,6 @@ test("multi-command Enter protection survives earlier buffer movement until idle
       enterInputPending: boolean;
       lastBufferSnapshot: unknown;
       readBufferSnapshot: () => unknown;
-      writePruningDeferred: boolean;
       refreshViewport: (reason: "write") => void;
     };
     for (let index = 0; index < 250; index += 1) {
@@ -872,7 +871,6 @@ test("multi-command Enter protection survives earlier buffer movement until idle
       term.buffer.active.baseY += 1;
       term.buffer.active.length += 1;
       internals.dirtyAllInRenderRange = true;
-      internals.writePruningDeferred = true;
       internals.refreshViewport("write");
     }
     internals.lastBufferSnapshot = internals.readBufferSnapshot();
@@ -1051,7 +1049,7 @@ test("Enter input still detects redraws away from the cursor", async () => {
   }
 });
 
-test("write-only scrolling keeps retained decorations bounded", () => {
+test("write-only scrolling batches pruning but stays hard-bounded", async () => {
   const raf = installAnimationFrameQueue();
   try {
     const { term, decorationStates } = createFakeTerminal("hello DEPLOY world", {
@@ -1082,9 +1080,14 @@ test("write-only scrolling keeps retained decorations bounded", () => {
       internals.refreshViewport("write");
     }
 
+    const liveDuringOutput = decorationStates.filter(({ isDisposed }) => !isDisposed).length;
+    assert.ok(liveDuringOutput > 64, "active output should not prune at the soft threshold");
+    assert.ok(liveDuringOutput <= 256, "active output should remain hard-bounded");
+
+    await new Promise((resolve) => { setTimeout(resolve, 700); });
     assert.ok(
       decorationStates.filter(({ isDisposed }) => !isDisposed).length <= 64,
-      "write-only output should not retain every highlighted scrollback line",
+      "idle cleanup should return retained decorations to the soft bound",
     );
     highlighter.dispose();
   } finally {
@@ -1092,7 +1095,71 @@ test("write-only scrolling keeps retained decorations bounded", () => {
   }
 });
 
-test("Enter defers batched decoration pruning until input is idle", async () => {
+test("late Enter output stays protected after the pending hint expires", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, decorationStates, handlers } = createFakeTerminal("hello DEPLOY world", {
+      lineCount: 400,
+    });
+    term.rows = 3;
+    term.buffer.active.viewportY = 20;
+    term.buffer.active.baseY = 20;
+    term.buffer.active.cursorY = 2;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+
+    const internals = highlighter as unknown as {
+      dirtyAllInRenderRange: boolean;
+      lastBufferSnapshot: unknown;
+      readBufferSnapshot: () => unknown;
+      refreshViewport: (reason: "write") => void;
+    };
+    for (let index = 0; index < 150; index += 1) {
+      term.buffer.active.viewportY += 1;
+      term.buffer.active.baseY += 1;
+      term.buffer.active.length += 1;
+      internals.dirtyAllInRenderRange = true;
+      internals.refreshViewport("write");
+    }
+    internals.lastBufferSnapshot = internals.readBufferSnapshot();
+    const retainedDecorations = decorationStates.filter(({ isDisposed }) => !isDisposed);
+    assert.ok(retainedDecorations.length > 64);
+    const viewportStart = term.buffer.active.viewportY;
+    const visibleDecorations = retainedDecorations.filter(
+      ({ line }) => line > viewportStart && line < viewportStart + term.rows,
+    );
+    assert.ok(visibleDecorations.length > 0);
+
+    handlers.data?.("\r");
+    handlers.writeParsed?.();
+    await new Promise((resolve) => { setTimeout(resolve, 650); });
+
+    term.buffer.active.viewportY += 1;
+    term.buffer.active.baseY += 1;
+    term.buffer.active.length += 1;
+    handlers.scroll?.();
+    handlers.writeParsed?.();
+    await new Promise((resolve) => { setTimeout(resolve, 220); });
+
+    assert.equal(
+      visibleDecorations.filter(({ isDisposed }) => isDisposed).length,
+      0,
+      "late Enter output should not replace visible decorations",
+    );
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("write pruning enforces a hard bound and delays soft cleanup until idle", async () => {
   const raf = installAnimationFrameQueue();
   try {
     const { term, decorationStates } = createFakeTerminal("hello DEPLOY world", {
@@ -1113,7 +1180,6 @@ test("Enter defers batched decoration pruning until input is idle", async () => 
 
     const internals = highlighter as unknown as {
       dirtyAllInRenderRange: boolean;
-      writePruningDeferred: boolean;
       refreshViewport: (reason: "write") => void;
     };
     for (let index = 0; index < 250; index += 1) {
@@ -1121,15 +1187,13 @@ test("Enter defers batched decoration pruning until input is idle", async () => 
       term.buffer.active.baseY += 1;
       term.buffer.active.length += 1;
       internals.dirtyAllInRenderRange = true;
-      internals.writePruningDeferred = true;
       internals.refreshViewport("write");
     }
 
-    assert.equal(
-      decorationStates.filter(({ isDisposed }) => isDisposed).length,
-      0,
-      "Enter refreshes should not remove decorations while input is settling",
-    );
+    const liveDuringOutput = decorationStates.filter(({ isDisposed }) => !isDisposed).length;
+    const disposedDuringHardTrim = decorationStates.filter(({ isDisposed }) => isDisposed).length;
+    assert.ok(liveDuringOutput > 64, "active output should retain more than the soft bound");
+    assert.ok(liveDuringOutput <= 256, "active output should stay within the hard bound");
 
     const originalPerformance = globalThis.performance;
     let simulatedNow = 0;
@@ -1145,7 +1209,6 @@ test("Enter defers batched decoration pruning until input is idle", async () => 
     try {
       term.rows = 30;
       internals.dirtyAllInRenderRange = true;
-      internals.writePruningDeferred = true;
       internals.refreshViewport("write");
     } finally {
       Object.defineProperty(globalThis, "performance", {
@@ -1158,8 +1221,8 @@ test("Enter defers batched decoration pruning until input is idle", async () => 
 
     assert.equal(
       decorationStates.filter(({ isDisposed }) => isDisposed).length,
-      0,
-      "continuation scans should preserve Enter pruning deferral",
+      disposedDuringHardTrim,
+      "continuation scans should not trigger another prune below the hard bound",
     );
     await new Promise((resolve) => { setTimeout(resolve, 700); });
     assert.ok(

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -18,20 +18,28 @@ import {
 type RafCallback = (time: number) => void;
 
 function installAnimationFrameQueue() {
-  const callbacks: RafCallback[] = [];
+  const callbacks = new Map<number, RafCallback>();
+  let nextId = 1;
   const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
   const previousCancelAnimationFrame = globalThis.cancelAnimationFrame;
 
   globalThis.requestAnimationFrame = ((callback: RafCallback) => {
-    callbacks.push(callback);
-    return callbacks.length;
+    const id = nextId;
+    nextId += 1;
+    callbacks.set(id, callback);
+    return id;
   }) as typeof requestAnimationFrame;
-  globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+  globalThis.cancelAnimationFrame = ((id: number) => {
+    callbacks.delete(id);
+  }) as typeof cancelAnimationFrame;
 
   return {
     flush() {
-      while (callbacks.length > 0) {
-        callbacks.shift()?.(performance.now());
+      while (callbacks.size > 0) {
+        const next = callbacks.entries().next().value as [number, RafCallback] | undefined;
+        if (!next) break;
+        callbacks.delete(next[0]);
+        next[1](performance.now());
       }
     },
     restore() {
@@ -768,6 +776,48 @@ test("Enter cancels queued scroll work before large-output deferral", async () =
       "large Enter output should not leave a queued scroll prune behind",
     );
     assert.equal(translateCountBeforeQuiet, 0, "large output should wait for the quiet catch-up scan");
+  } finally {
+    raf.restore();
+  }
+});
+
+test("Enter replaces a queued write refresh with input-quiet work", () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const {
+      term,
+      handlers,
+      getTranslateCount,
+      resetTranslateCount,
+    } = createFakeTerminal("hello DEPLOY world", { lineCount: 40 });
+    term.buffer.active.viewportY = 20;
+    term.buffer.active.baseY = 20;
+    term.buffer.active.cursorY = 2;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+    resetTranslateCount();
+
+    const internals = highlighter as unknown as { lastRefreshTime: number };
+    internals.lastRefreshTime = Number.NEGATIVE_INFINITY;
+    handlers.writeParsed?.();
+    handlers.data?.("\r");
+    handlers.writeParsed?.();
+    resetTranslateCount();
+    raf.flush();
+
+    assert.equal(
+      getTranslateCount(),
+      0,
+      "the pre-Enter write frame should not scan during the input quiet window",
+    );
+    highlighter.dispose();
   } finally {
     raf.restore();
   }

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -783,6 +783,7 @@ test("pressing Enter keeps unchanged keyword decorations mounted", async () => {
     term.buffer.active.viewportY += 1;
     term.buffer.active.baseY += 1;
     term.buffer.active.length += 1;
+    handlers.scroll?.();
     handlers.writeParsed?.();
     await new Promise((resolve) => { setTimeout(resolve, 220); });
 

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -880,12 +880,14 @@ test("multi-command Enter protection survives earlier buffer movement until idle
     assert.ok(retainedDecorations.length > 64);
 
     handlers.data?.("\u001b[200~echo one\r\necho two\r\n\u001b[201~");
-    term.buffer.active.viewportY += 1;
-    term.buffer.active.baseY += 1;
-    term.buffer.active.length += 1;
-    handlers.scroll?.();
-    handlers.writeParsed?.();
-    await new Promise((resolve) => { setTimeout(resolve, 220); });
+    for (let index = 0; index < 12; index += 1) {
+      term.buffer.active.viewportY += 1;
+      term.buffer.active.baseY += 1;
+      term.buffer.active.length += 1;
+      handlers.scroll?.();
+      handlers.writeParsed?.();
+      await new Promise((resolve) => { setTimeout(resolve, 50); });
+    }
 
     term.buffer.active.viewportY += 1;
     term.buffer.active.baseY += 1;
@@ -897,7 +899,7 @@ test("multi-command Enter protection survives earlier buffer movement until idle
     assert.equal(
       retainedDecorations.filter(({ isDisposed }) => isDisposed).length,
       0,
-      "an earlier moving write should not consume protection for later Enter output",
+      "continuous Enter output should postpone decoration pruning until idle",
     );
     assert.equal(internals.enterInputPending, true);
 

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -891,6 +891,76 @@ test("continuous Enter output lets multi-frame refreshes finish", () => {
   }
 });
 
+test("large output cancels active Enter continuation work until quiet", () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const {
+      term,
+      handlers,
+      getTranslateCount,
+      resetTranslateCount,
+    } = createFakeTerminal("hello DEPLOY world", { lineCount: 140 });
+    term.rows = 100;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+
+    const internals = highlighter as unknown as {
+      lastRefreshTime: number;
+      lastUserInputAt: number;
+    };
+    handlers.data?.("\r");
+    internals.lastUserInputAt = Number.NEGATIVE_INFINITY;
+    internals.lastRefreshTime = Number.NEGATIVE_INFINITY;
+
+    const originalPerformance = globalThis.performance;
+    let simulatedNow = 0;
+    Object.defineProperty(globalThis, "performance", {
+      configurable: true,
+      value: {
+        now: () => {
+          simulatedNow += 5;
+          return simulatedNow;
+        },
+      },
+    });
+    try {
+      handlers.writeParsed?.();
+      raf.flushOne();
+    } finally {
+      Object.defineProperty(globalThis, "performance", {
+        configurable: true,
+        value: originalPerformance,
+      });
+    }
+
+    noteTerminalOutputPressureData(
+      term as never,
+      "x\n".repeat(Math.ceil(TERMINAL_LONG_LINE_PRESSURE_BYTES / 2)),
+    );
+    handlers.writeParsed?.();
+    resetTranslateCount();
+    raf.flushOne();
+    const scansDuringPressure = getTranslateCount();
+    highlighter.dispose();
+    resetTerminalOutputPressure(term as never);
+
+    assert.equal(
+      scansDuringPressure,
+      0,
+      "large output should cancel continuation scans until the quiet catch-up",
+    );
+  } finally {
+    raf.restore();
+  }
+});
+
 test("continuous Enter output still refreshes highlights periodically", async () => {
   const raf = installAnimationFrameQueue();
   try {

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -211,6 +211,16 @@ function createFakeTerminal(lineText: string, options: { lineCount?: number } = 
     })
   );
   const decorations: Array<{ x: number; width: number; foregroundColor: string }> = [];
+  const decorationStates: Array<{
+    isDisposed: boolean;
+    dispose: () => void;
+  }> = [];
+  const markers: Array<{
+    line: number;
+    isDisposed: boolean;
+    dispose: () => void;
+  }> = [];
+  const refreshCalls: Array<{ start: number; end: number }> = [];
   const noopDisposable = { dispose() {} };
   const handlers: {
     scroll?: () => void;
@@ -253,35 +263,47 @@ function createFakeTerminal(lineText: string, options: { lineCount?: number } = 
       return noopDisposable;
     },
     registerMarker(offset: number) {
-      return {
-        line: offset,
+      const marker = {
+        line: term.buffer.active.baseY + term.buffer.active.cursorY + offset,
         isDisposed: false,
         dispose() {
           this.isDisposed = true;
         },
       };
+      markers.push(marker);
+      return marker;
     },
     registerDecoration(options: { x: number; width: number; foregroundColor: string }) {
       decorations.push(options);
-      return {
+      const state = {
         isDisposed: false,
         dispose() {
           this.isDisposed = true;
         },
       };
+      decorationStates.push(state);
+      return state;
     },
-    refresh() {},
+    refresh(start: number, end: number) {
+      refreshCalls.push({ start, end });
+    },
   };
 
   return {
     term,
     decorations,
+    decorationStates,
+    markers,
+    refreshCalls,
     handlers,
     getTranslateCount: () => translateCount,
     getTranslatedLineIndexes: () => [...translatedLineIndexes],
     resetTranslateCount: () => {
       translateCount = 0;
       translatedLineIndexes.length = 0;
+    },
+    resetRefreshCalls: () => {
+      refreshCalls.length = 0;
     },
   };
 }
@@ -716,6 +738,124 @@ test("recent user input delays keyword highlight scans until typing is quiet", a
 
     await new Promise((resolve) => { setTimeout(resolve, 100); });
     assert.ok(getTranslateCount() > 0);
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("pressing Enter keeps unchanged keyword decorations mounted", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, decorationStates, handlers } = createFakeTerminal("hello DEPLOY world", {
+      lineCount: 40,
+    });
+    term.buffer.active.viewportY = 20;
+    term.buffer.active.baseY = 20;
+    term.buffer.active.cursorY = 2;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+    const existingDecorations = [...decorationStates];
+    assert.ok(existingDecorations.length > 0);
+
+    handlers.data?.("\r");
+    term.buffer.active.viewportY += 1;
+    term.buffer.active.baseY += 1;
+    term.buffer.active.length += 1;
+    handlers.writeParsed?.();
+    await new Promise((resolve) => { setTimeout(resolve, 220); });
+
+    assert.equal(
+      existingDecorations.filter(({ isDisposed }) => isDisposed).length,
+      0,
+      "unchanged decorations should remain mounted while Enter output settles",
+    );
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("pressing Enter rescans only the cursor neighborhood", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const {
+      term,
+      handlers,
+      getTranslatedLineIndexes,
+      resetTranslateCount,
+    } = createFakeTerminal("hello DEPLOY world", { lineCount: 40 });
+    term.buffer.active.viewportY = 20;
+    term.buffer.active.baseY = 20;
+    term.buffer.active.cursorY = 2;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+    resetTranslateCount();
+
+    handlers.data?.("\r");
+    term.buffer.active.viewportY += 1;
+    term.buffer.active.baseY += 1;
+    term.buffer.active.length += 1;
+    handlers.writeParsed?.();
+    await new Promise((resolve) => { setTimeout(resolve, 220); });
+
+    const scannedLines = getTranslatedLineIndexes();
+    assert.ok(scannedLines.includes(22));
+    assert.equal(scannedLines.includes(15), false);
+    assert.equal(scannedLines.includes(29), false);
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("pressing Enter does not force an extra repaint after markers move", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const {
+      term,
+      markers,
+      refreshCalls,
+      handlers,
+      resetRefreshCalls,
+    } = createFakeTerminal("hello DEPLOY world", { lineCount: 40 });
+    term.buffer.active.viewportY = 20;
+    term.buffer.active.baseY = 20;
+    term.buffer.active.cursorY = 2;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+    resetRefreshCalls();
+
+    for (const marker of markers) marker.line += 1;
+    handlers.data?.("\r");
+    term.buffer.active.viewportY += 1;
+    term.buffer.active.baseY += 1;
+    term.buffer.active.length += 1;
+    handlers.writeParsed?.();
+    await new Promise((resolve) => { setTimeout(resolve, 220); });
+
+    assert.deepEqual(refreshCalls, []);
     highlighter.dispose();
   } finally {
     raf.restore();

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -798,6 +798,47 @@ test("pressing Enter keeps unchanged keyword decorations mounted", async () => {
   }
 });
 
+test("pasted Enter remains protected when more input arrives before output", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, decorationStates, handlers } = createFakeTerminal("hello DEPLOY world", {
+      lineCount: 40,
+    });
+    term.buffer.active.viewportY = 20;
+    term.buffer.active.baseY = 20;
+    term.buffer.active.cursorY = 2;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+    const existingDecorations = [...decorationStates];
+    assert.ok(existingDecorations.length > 0);
+
+    handlers.data?.("\u001b[200~echo DEPLOY\r\u001b[201~");
+    handlers.data?.("x");
+    term.buffer.active.viewportY += 1;
+    term.buffer.active.baseY += 1;
+    term.buffer.active.length += 1;
+    handlers.scroll?.();
+    handlers.writeParsed?.();
+    await new Promise((resolve) => { setTimeout(resolve, 220); });
+
+    assert.equal(
+      existingDecorations.filter(({ isDisposed }) => isDisposed).length,
+      0,
+      "a submitted Enter should stay protected until its output is processed",
+    );
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
 test("pressing Enter avoids rescanning overscan edges", async () => {
   const raf = installAnimationFrameQueue();
   try {

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -984,6 +984,37 @@ test("Enter defers batched decoration pruning until input is idle", async () => 
       0,
       "Enter refreshes should not remove decorations while input is settling",
     );
+
+    const originalPerformance = globalThis.performance;
+    let simulatedNow = 0;
+    Object.defineProperty(globalThis, "performance", {
+      configurable: true,
+      value: {
+        now: () => {
+          simulatedNow += 5;
+          return simulatedNow;
+        },
+      },
+    });
+    try {
+      term.rows = 30;
+      internals.dirtyAllInRenderRange = true;
+      internals.writePruningDeferred = true;
+      internals.refreshViewport("write");
+    } finally {
+      Object.defineProperty(globalThis, "performance", {
+        configurable: true,
+        value: originalPerformance,
+      });
+    }
+    raf.flush();
+    term.rows = 3;
+
+    assert.equal(
+      decorationStates.filter(({ isDisposed }) => isDisposed).length,
+      0,
+      "continuation scans should preserve Enter pruning deferral",
+    );
     await new Promise((resolve) => { setTimeout(resolve, 700); });
     assert.ok(
       decorationStates.filter(({ isDisposed }) => !isDisposed).length <= 64,

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -1229,6 +1229,49 @@ test("late Enter output stays protected after the pending hint expires", async (
   }
 });
 
+test("late Enter output detects content shifts after scrollback saturates", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, decorationStates, handlers, markers } = createFakeTerminal("hello DEPLOY world", {
+      lineCount: 40,
+    });
+    term.buffer.active.viewportY = 20;
+    term.buffer.active.baseY = 20;
+    term.buffer.active.cursorY = 2;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+    const retainedDecorations = decorationStates.filter(({ isDisposed }) => !isDisposed);
+    assert.ok(retainedDecorations.length > 0);
+
+    handlers.data?.("\r");
+    handlers.writeParsed?.();
+    await new Promise((resolve) => { setTimeout(resolve, 650); });
+
+    for (const marker of markers) {
+      if (!marker.isDisposed) marker.line -= 1;
+    }
+    handlers.scroll?.();
+    handlers.writeParsed?.();
+    await new Promise((resolve) => { setTimeout(resolve, 220); });
+
+    assert.equal(
+      retainedDecorations.filter(({ isDisposed }) => isDisposed).length,
+      0,
+      "marker shifts should identify delayed output when buffer positions are saturated",
+    );
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
 test("write pruning enforces a hard bound and delays soft cleanup until idle", async () => {
   const raf = installAnimationFrameQueue();
   try {

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -214,6 +214,7 @@ function createFakeTerminal(lineText: string, options: { lineCount?: number } = 
   );
   const decorations: Array<{ x: number; width: number; foregroundColor: string }> = [];
   const decorationStates: Array<{
+    readonly line: number;
     isDisposed: boolean;
     dispose: () => void;
   }> = [];
@@ -275,9 +276,17 @@ function createFakeTerminal(lineText: string, options: { lineCount?: number } = 
       markers.push(marker);
       return marker;
     },
-    registerDecoration(options: { x: number; width: number; foregroundColor: string }) {
+    registerDecoration(options: {
+      marker?: { line: number };
+      x: number;
+      width: number;
+      foregroundColor: string;
+    }) {
       decorations.push(options);
       const state = {
+        get line() {
+          return options.marker?.line ?? -1;
+        },
         isDisposed: false,
         dispose() {
           this.isDisposed = true;
@@ -788,7 +797,7 @@ test("pressing Enter keeps unchanged keyword decorations mounted", async () => {
   }
 });
 
-test("pressing Enter rescans only the cursor neighborhood", async () => {
+test("pressing Enter avoids rescanning overscan edges", async () => {
   const raf = installAnimationFrameQueue();
   try {
     const {
@@ -831,7 +840,7 @@ test("pressing Enter rescans only the cursor neighborhood", async () => {
 test("non-Enter input still detects redraws away from the cursor", async () => {
   const raf = installAnimationFrameQueue();
   try {
-    const { term, handlers, setLineText } = createFakeTerminal("hello DEPLOY world", {
+    const { term, decorationStates, handlers, setLineText } = createFakeTerminal("hello DEPLOY world", {
       lineCount: 60,
     });
     term.rows = 10;
@@ -847,14 +856,49 @@ test("non-Enter input still detects redraws away from the cursor", async () => {
       enabled: true,
     }], true);
     raf.flush();
-    assert.notDeepEqual(highlighter.getForegroundRanges(20), []);
+    const originalDecoration = decorationStates.find(({ line }) => line === 20);
+    assert.ok(originalDecoration);
 
     handlers.data?.("a");
     setLineText(20, "redrawn without a keyword");
     handlers.writeParsed?.();
     await new Promise((resolve) => { setTimeout(resolve, 220); });
 
-    assert.deepEqual(highlighter.getForegroundRanges(20), []);
+    assert.equal(originalDecoration.isDisposed, true);
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("Enter input still detects redraws away from the cursor", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, decorationStates, handlers, setLineText } = createFakeTerminal("hello DEPLOY world", {
+      lineCount: 60,
+    });
+    term.rows = 10;
+    term.buffer.active.viewportY = 20;
+    term.buffer.active.baseY = 20;
+    term.buffer.active.cursorY = 9;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+    const originalDecoration = decorationStates.find(({ line }) => line === 20);
+    assert.ok(originalDecoration);
+
+    handlers.data?.("\r");
+    setLineText(20, "redrawn without a keyword");
+    handlers.writeParsed?.();
+    await new Promise((resolve) => { setTimeout(resolve, 220); });
+
+    assert.equal(originalDecoration.isDisposed, true);
     highlighter.dispose();
   } finally {
     raf.restore();
@@ -902,7 +946,56 @@ test("write-only scrolling keeps retained decorations bounded", () => {
   }
 });
 
-test("pressing Enter limits marker-move repaint to the cursor row", async () => {
+test("Enter defers batched decoration pruning until input is idle", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, decorationStates } = createFakeTerminal("hello DEPLOY world", {
+      lineCount: 400,
+    });
+    term.buffer.active.viewportY = 20;
+    term.buffer.active.baseY = 20;
+    term.buffer.active.cursorY = 2;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+
+    const internals = highlighter as unknown as {
+      dirtyAllInRenderRange: boolean;
+      writePruningDeferred: boolean;
+      refreshViewport: (reason: "write") => void;
+    };
+    for (let index = 0; index < 250; index += 1) {
+      term.buffer.active.viewportY += 1;
+      term.buffer.active.baseY += 1;
+      term.buffer.active.length += 1;
+      internals.dirtyAllInRenderRange = true;
+      internals.writePruningDeferred = true;
+      internals.refreshViewport("write");
+    }
+
+    assert.equal(
+      decorationStates.filter(({ isDisposed }) => isDisposed).length,
+      0,
+      "Enter refreshes should not remove decorations while input is settling",
+    );
+    await new Promise((resolve) => { setTimeout(resolve, 700); });
+    assert.ok(
+      decorationStates.filter(({ isDisposed }) => !isDisposed).length <= 64,
+      "idle cleanup should return retained decorations to the bounded range",
+    );
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("pressing Enter does not repaint after keyword markers move", async () => {
   const raf = installAnimationFrameQueue();
   try {
     const {
@@ -934,7 +1027,7 @@ test("pressing Enter limits marker-move repaint to the cursor row", async () => 
     handlers.writeParsed?.();
     await new Promise((resolve) => { setTimeout(resolve, 220); });
 
-    assert.deepEqual(refreshCalls, [{ start: 2, end: 2 }]);
+    assert.deepEqual(refreshCalls, []);
     highlighter.dispose();
   } finally {
     raf.restore();

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -839,6 +839,67 @@ test("pasted Enter remains protected when more input arrives before output", asy
   }
 });
 
+test("an unrelated parsed write does not consume pending Enter protection", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, decorationStates, handlers } = createFakeTerminal("hello DEPLOY world", {
+      lineCount: 400,
+    });
+    term.rows = 3;
+    term.buffer.active.viewportY = 20;
+    term.buffer.active.baseY = 20;
+    term.buffer.active.cursorY = 2;
+    const highlighter = new KeywordHighlighter(term as never);
+    highlighter.setRules([{
+      id: "deploy",
+      label: "Deploy",
+      patterns: ["DEPLOY"],
+      color: "#F87171",
+      enabled: true,
+    }], true);
+    raf.flush();
+
+    const internals = highlighter as unknown as {
+      dirtyAllInRenderRange: boolean;
+      lastBufferSnapshot: unknown;
+      readBufferSnapshot: () => unknown;
+      writePruningDeferred: boolean;
+      refreshViewport: (reason: "write") => void;
+    };
+    for (let index = 0; index < 250; index += 1) {
+      term.buffer.active.viewportY += 1;
+      term.buffer.active.baseY += 1;
+      term.buffer.active.length += 1;
+      internals.dirtyAllInRenderRange = true;
+      internals.writePruningDeferred = true;
+      internals.refreshViewport("write");
+    }
+    internals.lastBufferSnapshot = internals.readBufferSnapshot();
+    const retainedDecorations = decorationStates.filter(({ isDisposed }) => !isDisposed);
+    assert.ok(retainedDecorations.length > 64);
+
+    handlers.data?.("\r");
+    handlers.writeParsed?.();
+    await new Promise((resolve) => { setTimeout(resolve, 220); });
+
+    term.buffer.active.viewportY += 1;
+    term.buffer.active.baseY += 1;
+    term.buffer.active.length += 1;
+    handlers.scroll?.();
+    handlers.writeParsed?.();
+    await new Promise((resolve) => { setTimeout(resolve, 220); });
+
+    assert.equal(
+      retainedDecorations.filter(({ isDisposed }) => isDisposed).length,
+      0,
+      "a write without buffer movement should not consume pending Enter protection",
+    );
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
 test("pressing Enter avoids rescanning overscan edges", async () => {
   const raf = installAnimationFrameQueue();
   try {

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -103,6 +103,7 @@ export class KeywordHighlighter implements IDisposable {
   private debounceTimer: NodeJS.Timeout | null = null;
   /** Single quiet-window catch-up after bulk dumps (no per-write schedule). */
   private bulkPressureCatchUpTimer: NodeJS.Timeout | null = null;
+  private writePruneTimer: NodeJS.Timeout | null = null;
   private animationFrameId: number | null = null;
   private lastRefreshTime: number = 0;
   private matchCache = new Map<string, CachedDecorationRange[]>();
@@ -123,6 +124,7 @@ export class KeywordHighlighter implements IDisposable {
   private lastBurstDecayAt = 0;
   private lastUserInputAt = 0;
   private lastUserInputWasEnter = false;
+  private writePruningDeferred = false;
   private scrollRefreshJob: ScrollRefreshJob | null = null;
   private scrollRefreshGeneration = 0;
   private static readonly DIRTY_SCAN_PADDING = XTERM_PERFORMANCE_CONFIG.highlighting.dirtyScanPadding;
@@ -137,6 +139,7 @@ export class KeywordHighlighter implements IDisposable {
   private static readonly WRITE_BURST_DEBOUNCE_MS = 180;
   private static readonly WRITE_BURST_IMMEDIATE_MIN_INTERVAL_MS = 48;
   private static readonly WRITE_BURST_HIGHLIGHT_PAUSE_MS = 260;
+  private static readonly WRITE_PRUNE_IDLE_MS = 600;
 
   constructor(term: XTerm) {
     this.term = term;
@@ -182,6 +185,9 @@ export class KeywordHighlighter implements IDisposable {
         if (this.isInputProtectionActive(performance.now())) {
           if (this.lastUserInputWasEnter) {
             this.markDirtyFromWrite({ includeViewportProbe: false });
+            const buffer = this.term.buffer.active;
+            this.addDirtyRange(buffer.viewportY, buffer.viewportY + this.term.rows - 1);
+            this.writePruningDeferred = true;
           } else {
             this.updateWriteBurst();
             this.markVisibleRangeDirty();
@@ -293,6 +299,10 @@ export class KeywordHighlighter implements IDisposable {
     if (this.bulkPressureCatchUpTimer) {
       clearTimeout(this.bulkPressureCatchUpTimer);
       this.bulkPressureCatchUpTimer = null;
+    }
+    if (this.writePruneTimer) {
+      clearTimeout(this.writePruneTimer);
+      this.writePruneTimer = null;
     }
     if (this.animationFrameId !== null) {
       cancelAnimationFrame(this.animationFrameId);
@@ -647,6 +657,7 @@ export class KeywordHighlighter implements IDisposable {
     const rangeEnd = viewportEnd + overscan;
 
     const previousRange = this.lastRenderRange;
+    const deferWritePruning = reason === "write" && this.writePruningDeferred;
     this.beginTerminalRefreshTracking(viewportStart, viewportEnd);
     try {
       this.reindexLineDecorationsFromMarkers();
@@ -668,7 +679,7 @@ export class KeywordHighlighter implements IDisposable {
       }
 
       if (reason === "write") {
-        this.pruneWriteDecorationsIfNeeded(rangeStart, rangeEnd);
+        this.pruneWriteDecorationsIfNeeded(rangeStart, rangeEnd, deferWritePruning);
       } else {
         for (const [lineY, state] of this.lineDecorations) {
           if (lineY < rangeStart || lineY > rangeEnd || state.marker.isDisposed) {
@@ -688,6 +699,7 @@ export class KeywordHighlighter implements IDisposable {
         this.lastRenderRange = { start: rangeStart, end: rangeEnd };
       }
     } finally {
+      if (reason === "write") this.writePruningDeferred = false;
       this.flushTerminalRefresh();
     }
   }
@@ -810,10 +822,18 @@ export class KeywordHighlighter implements IDisposable {
     }
   }
 
-  private pruneWriteDecorationsIfNeeded(rangeStart: number, rangeEnd: number): void {
+  private pruneWriteDecorationsIfNeeded(
+    rangeStart: number,
+    rangeEnd: number,
+    deferUntilIdle = false,
+  ): void {
     const renderLineCount = Math.max(1, rangeEnd - rangeStart + 1);
     const highWaterMark = Math.max(64, renderLineCount * 2);
     if (this.lineDecorations.size <= highWaterMark) return;
+    if (deferUntilIdle) {
+      this.scheduleDeferredWritePrune();
+      return;
+    }
 
     // Decoration registration/removal makes xterm repaint the full viewport.
     // Prune in batches so ordinary one-line output keeps existing highlights
@@ -823,6 +843,27 @@ export class KeywordHighlighter implements IDisposable {
         this.disposeLineDecorations(lineY, state);
       }
     }
+  }
+
+  private scheduleDeferredWritePrune(): void {
+    if (this.writePruneTimer) clearTimeout(this.writePruneTimer);
+    this.writePruneTimer = setTimeout(() => {
+      this.writePruneTimer = null;
+      if (!this.enabled || this.compiledRules.length === 0) return;
+      const now = performance.now();
+      if (
+        this.lastUserInputAt > 0
+        && now - this.lastUserInputAt < KeywordHighlighter.WRITE_PRUNE_IDLE_MS
+      ) {
+        this.scheduleDeferredWritePrune();
+        return;
+      }
+      const buffer = this.term.buffer.active;
+      const overscan = this.getOverscanLines("write");
+      const rangeStart = Math.max(0, buffer.viewportY - overscan);
+      const rangeEnd = buffer.viewportY + this.term.rows - 1 + overscan;
+      this.pruneWriteDecorationsIfNeeded(rangeStart, rangeEnd);
+    }, KeywordHighlighter.WRITE_PRUNE_IDLE_MS);
   }
 
   private mergeRefreshReason(current: RefreshReason, next: RefreshReason): RefreshReason {

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -195,6 +195,13 @@ export class KeywordHighlighter implements IDisposable {
         }
         this.enterQueuedWriteCancellationPending = false;
         const pressure = getTerminalOutputPressure(this.term);
+        if (pressure.background || pressure.longLine || pressure.largeOutput) {
+          if (this.pendingRefreshReason === "write") {
+            this.cancelQueuedRefreshSchedule();
+          }
+          this.enterViewportScanInProgress = false;
+          this.enterViewportScanNeedsRepeat = false;
+        }
         if (pressure.background) {
           // Hidden panes: avoid immediate scans that fight xterm, but still arm a
           // debounced refresh. Reveal only flushes writes/repaints — without a

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -167,6 +167,10 @@ export class KeywordHighlighter implements IDisposable {
       this.term.onWriteParsed(() => {
         if (this.enterInputPending) {
           this.scheduleEnterInputIdleClear();
+          this.cancelScrollRefresh();
+          if (this.pendingRefreshReason === "scroll") {
+            this.pendingRefreshReason = "write";
+          }
         }
         const pressure = getTerminalOutputPressure(this.term);
         if (pressure.background) {
@@ -194,10 +198,6 @@ export class KeywordHighlighter implements IDisposable {
         const inputProtectionActive = this.isInputProtectionActive(performance.now());
         if (inputProtectionActive || this.enterInputPending) {
           if (this.enterInputPending) {
-            this.cancelScrollRefresh();
-            if (this.pendingRefreshReason === "scroll") {
-              this.pendingRefreshReason = "write";
-            }
             this.markDirtyFromWrite({ includeViewportProbe: false });
             const buffer = this.term.buffer.active;
             this.addDirtyRange(buffer.viewportY, buffer.viewportY + this.term.rows - 1);

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -658,12 +658,18 @@ export class KeywordHighlighter implements IDisposable {
 
     const previousRange = this.lastRenderRange;
     const deferWritePruning = reason === "write" && this.writePruningDeferred;
+    let writeContinuationScheduled = false;
     this.beginTerminalRefreshTracking(viewportStart, viewportEnd);
     try {
       this.reindexLineDecorationsFromMarkers();
 
       if (reason === "write") {
-        this.processDirtyLinesInRange(rangeStart, rangeEnd, cursorAbsoluteY, "write");
+        writeContinuationScheduled = this.processDirtyLinesInRange(
+          rangeStart,
+          rangeEnd,
+          cursorAbsoluteY,
+          "write",
+        );
       } else if (reason === "scroll") {
         this.startScrollRefresh(viewportStart, viewportEnd, cursorAbsoluteY);
         return;
@@ -699,7 +705,9 @@ export class KeywordHighlighter implements IDisposable {
         this.lastRenderRange = { start: rangeStart, end: rangeEnd };
       }
     } finally {
-      if (reason === "write") this.writePruningDeferred = false;
+      if (reason === "write" && !writeContinuationScheduled) {
+        this.writePruningDeferred = false;
+      }
       this.flushTerminalRefresh();
     }
   }
@@ -773,7 +781,7 @@ export class KeywordHighlighter implements IDisposable {
     rangeEnd: number,
     cursorAbsoluteY: number,
     continuationReason: RefreshReason
-  ) {
+  ): boolean {
     if (this.dirtyAllInRenderRange) {
       this.dirtySegments = [{ start: rangeStart, end: rangeEnd }];
       this.rebuildDirtyLineCount();
@@ -781,7 +789,7 @@ export class KeywordHighlighter implements IDisposable {
     }
 
     if (this.dirtySegments.length === 0) {
-      return;
+      return false;
     }
 
     const dirtyInRange: DirtyLineSegment[] = [];
@@ -795,7 +803,7 @@ export class KeywordHighlighter implements IDisposable {
     }
 
     if (dirtyInRange.length === 0) {
-      return;
+      return false;
     }
 
     const { writeRefreshBudgetMs, dirtySegmentChunkSize } = this.getAdaptiveHighlightingProfile();
@@ -812,14 +820,18 @@ export class KeywordHighlighter implements IDisposable {
 
         if (chunkStart <= segment.end && performance.now() - startTime >= writeRefreshBudgetMs) {
           this.triggerRefresh("continuation", continuationReason);
-          return;
+          return true;
         }
       }
-      if (performance.now() - startTime >= writeRefreshBudgetMs) {
+      if (
+        this.dirtySegments.length > 0
+        && performance.now() - startTime >= writeRefreshBudgetMs
+      ) {
         this.triggerRefresh("continuation", continuationReason);
-        return;
+        return true;
       }
     }
+    return false;
   }
 
   private pruneWriteDecorationsIfNeeded(

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -123,7 +123,7 @@ export class KeywordHighlighter implements IDisposable {
   private lastWriteAt = 0;
   private lastBurstDecayAt = 0;
   private lastUserInputAt = 0;
-  private lastUserInputWasEnter = false;
+  private enterInputPending = false;
   private writePruningDeferred = false;
   private scrollRefreshJob: ScrollRefreshJob | null = null;
   private scrollRefreshGeneration = 0;
@@ -154,7 +154,7 @@ export class KeywordHighlighter implements IDisposable {
       // once typing pauses.
       this.term.onData((data) => {
         this.lastUserInputAt = performance.now();
-        this.lastUserInputWasEnter = data === "\r" || data === "\n" || data === "\r\n";
+        this.enterInputPending ||= data.includes("\r") || data.includes("\n");
       }),
       // When new data is written, refresh on the next frame so highlights land
       // with the freshly rendered content instead of trailing behind it.
@@ -182,8 +182,10 @@ export class KeywordHighlighter implements IDisposable {
           this.scheduleBulkPressureCatchUp();
           return;
         }
-        if (this.isInputProtectionActive(performance.now())) {
-          if (this.lastUserInputWasEnter) {
+        const inputProtectionActive = this.isInputProtectionActive(performance.now());
+        if (inputProtectionActive || this.enterInputPending) {
+          if (this.enterInputPending) {
+            this.enterInputPending = false;
             this.cancelScrollRefresh();
             if (this.pendingRefreshReason === "scroll") {
               this.pendingRefreshReason = "write";

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -178,8 +178,7 @@ export class KeywordHighlighter implements IDisposable {
           return;
         }
         if (this.isInputProtectionActive(performance.now())) {
-          this.updateWriteBurst();
-          this.markVisibleRangeDirty();
+          this.markDirtyFromWrite({ includeViewportProbe: false });
           this.triggerRefresh("debounced", "write");
           return;
         }
@@ -661,9 +660,11 @@ export class KeywordHighlighter implements IDisposable {
         this.processLineRange(rangeStart, rangeEnd, cursorAbsoluteY);
       }
 
-      for (const [lineY, state] of this.lineDecorations) {
-        if (lineY < rangeStart || lineY > rangeEnd || state.marker.isDisposed) {
-          this.disposeLineDecorations(lineY, state);
+      if (reason !== "write") {
+        for (const [lineY, state] of this.lineDecorations) {
+          if (lineY < rangeStart || lineY > rangeEnd || state.marker.isDisposed) {
+            this.disposeLineDecorations(lineY, state);
+          }
         }
       }
 
@@ -716,7 +717,6 @@ export class KeywordHighlighter implements IDisposable {
     if (this.lineDecorations.size === 0) return;
     const nextLineDecorations = new Map<number, LineDecorationState>();
     const staleStates = new Set<LineDecorationState>();
-    const changedLines = new Set<number>();
 
     for (const state of this.lineDecorations.values()) {
       if (state.marker.isDisposed || state.marker.line < 0) {
@@ -735,16 +735,7 @@ export class KeywordHighlighter implements IDisposable {
       staleStates.delete(state);
     }
 
-    for (const [lineY, state] of this.lineDecorations) {
-      if (nextLineDecorations.get(lineY) !== state) {
-        changedLines.add(lineY);
-      }
-    }
-    for (const [lineY, state] of nextLineDecorations) {
-      if (this.lineDecorations.get(lineY) !== state) changedLines.add(lineY);
-    }
     this.lineDecorations = nextLineDecorations;
-    for (const lineY of changedLines) this.markTerminalRefreshNeeded(lineY);
 
     for (const state of staleStates) {
       const markerLineBeforeDispose = state.marker.isDisposed ? -1 : state.marker.line;
@@ -968,9 +959,9 @@ export class KeywordHighlighter implements IDisposable {
     return Math.min(maxDirtyLines, Math.max(minDirtyLines, dynamicDirtyLines));
   }
 
-  private markDirtyFromWrite() {
+  private markDirtyFromWrite({ includeViewportProbe = true }: { includeViewportProbe?: boolean } = {}) {
     this.updateWriteBurst();
-    const snapshot = this.readBufferSnapshot();
+    const snapshot = this.readBufferSnapshot({ includeViewportProbe });
     if (!snapshot) {
       this.markVisibleRangeDirty();
       return;

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -185,7 +185,7 @@ export class KeywordHighlighter implements IDisposable {
         const inputProtectionActive = this.isInputProtectionActive(performance.now());
         if (inputProtectionActive || this.enterInputPending) {
           if (this.enterInputPending) {
-            this.enterInputPending = false;
+            const enterOutputObserved = this.hasBufferPositionChangedSinceLastSnapshot();
             this.cancelScrollRefresh();
             if (this.pendingRefreshReason === "scroll") {
               this.pendingRefreshReason = "write";
@@ -194,6 +194,9 @@ export class KeywordHighlighter implements IDisposable {
             const buffer = this.term.buffer.active;
             this.addDirtyRange(buffer.viewportY, buffer.viewportY + this.term.rows - 1);
             this.writePruningDeferred = true;
+            if (enterOutputObserved) {
+              this.enterInputPending = false;
+            }
           } else {
             this.updateWriteBurst();
             this.markVisibleRangeDirty();
@@ -902,6 +905,18 @@ export class KeywordHighlighter implements IDisposable {
       cursorAbsoluteY: buffer.baseY + buffer.cursorY,
       viewportProbe: includeViewportProbe ? this.buildViewportProbe(buffer, this.term.rows) : [],
     };
+  }
+
+  private hasBufferPositionChangedSinceLastSnapshot(): boolean {
+    const previous = this.lastBufferSnapshot;
+    const current = this.readBufferSnapshot({ includeViewportProbe: false });
+    if (!previous || !current) return false;
+    return (
+      current.length !== previous.length
+      || current.baseY !== previous.baseY
+      || current.viewportY !== previous.viewportY
+      || current.cursorAbsoluteY !== previous.cursorAbsoluteY
+    );
   }
 
   private buildViewportProbe(buffer: IBuffer, rows: number): readonly ViewportProbeSample[] {

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -167,6 +167,11 @@ export class KeywordHighlighter implements IDisposable {
       this.term.onWriteParsed(() => {
         if (this.enterInputPending) {
           this.scheduleEnterInputIdleClear();
+        }
+        const outputDrivenPendingScroll =
+          this.pendingRefreshReason === "scroll"
+          && this.hasOutputPositionChangedSinceLastSnapshot();
+        if (this.enterInputPending || outputDrivenPendingScroll) {
           this.cancelScrollRefresh();
           if (this.pendingRefreshReason === "scroll") {
             this.pendingRefreshReason = "write";
@@ -209,6 +214,9 @@ export class KeywordHighlighter implements IDisposable {
           return;
         }
         this.markDirtyFromWrite();
+        if (outputDrivenPendingScroll) {
+          this.markVisibleRangeDirty();
+        }
         this.triggerRefresh(
           "immediate",
           "write",
@@ -940,6 +948,17 @@ export class KeywordHighlighter implements IDisposable {
       cursorAbsoluteY: buffer.baseY + buffer.cursorY,
       viewportProbe: includeViewportProbe ? this.buildViewportProbe(buffer, this.term.rows) : [],
     };
+  }
+
+  private hasOutputPositionChangedSinceLastSnapshot(): boolean {
+    const previous = this.lastBufferSnapshot;
+    const current = this.readBufferSnapshot({ includeViewportProbe: false });
+    if (!previous || !current) return false;
+    return (
+      current.length !== previous.length
+      || current.baseY !== previous.baseY
+      || current.cursorAbsoluteY !== previous.cursorAbsoluteY
+    );
   }
 
   private buildViewportProbe(buffer: IBuffer, rows: number): readonly ViewportProbeSample[] {

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -883,8 +883,15 @@ export class KeywordHighlighter implements IDisposable {
       if (!this.enabled || this.compiledRules.length === 0) return;
       const now = performance.now();
       if (
-        this.lastUserInputAt > 0
-        && now - this.lastUserInputAt < KeywordHighlighter.WRITE_PRUNE_IDLE_MS
+        (
+          this.lastUserInputAt > 0
+          && now - this.lastUserInputAt < KeywordHighlighter.WRITE_PRUNE_IDLE_MS
+        )
+        || (
+          this.enterInputPending
+          && this.lastWriteAt > 0
+          && now - this.lastWriteAt < KeywordHighlighter.WRITE_PRUNE_IDLE_MS
+        )
       ) {
         this.scheduleDeferredWritePrune();
         return;

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -184,6 +184,10 @@ export class KeywordHighlighter implements IDisposable {
         }
         if (this.isInputProtectionActive(performance.now())) {
           if (this.lastUserInputWasEnter) {
+            this.cancelScrollRefresh();
+            if (this.pendingRefreshReason === "scroll") {
+              this.pendingRefreshReason = "write";
+            }
             this.markDirtyFromWrite({ includeViewportProbe: false });
             const buffer = this.term.buffer.active;
             this.addDirtyRange(buffer.viewportY, buffer.viewportY + this.term.rows - 1);

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -103,6 +103,7 @@ export class KeywordHighlighter implements IDisposable {
   private debounceTimer: NodeJS.Timeout | null = null;
   /** Single quiet-window catch-up after bulk dumps (no per-write schedule). */
   private bulkPressureCatchUpTimer: NodeJS.Timeout | null = null;
+  private enterInputIdleTimer: NodeJS.Timeout | null = null;
   private writePruneTimer: NodeJS.Timeout | null = null;
   private animationFrameId: number | null = null;
   private lastRefreshTime: number = 0;
@@ -154,11 +155,20 @@ export class KeywordHighlighter implements IDisposable {
       // once typing pauses.
       this.term.onData((data) => {
         this.lastUserInputAt = performance.now();
-        this.enterInputPending ||= data.includes("\r") || data.includes("\n");
+        if (data.includes("\r") || data.includes("\n")) {
+          this.enterInputPending = true;
+          if (this.enterInputIdleTimer) {
+            clearTimeout(this.enterInputIdleTimer);
+            this.enterInputIdleTimer = null;
+          }
+        }
       }),
       // When new data is written, refresh on the next frame so highlights land
       // with the freshly rendered content instead of trailing behind it.
       this.term.onWriteParsed(() => {
+        if (this.enterInputPending) {
+          this.scheduleEnterInputIdleClear();
+        }
         const pressure = getTerminalOutputPressure(this.term);
         if (pressure.background) {
           // Hidden panes: avoid immediate scans that fight xterm, but still arm a
@@ -185,7 +195,6 @@ export class KeywordHighlighter implements IDisposable {
         const inputProtectionActive = this.isInputProtectionActive(performance.now());
         if (inputProtectionActive || this.enterInputPending) {
           if (this.enterInputPending) {
-            const enterOutputObserved = this.hasBufferPositionChangedSinceLastSnapshot();
             this.cancelScrollRefresh();
             if (this.pendingRefreshReason === "scroll") {
               this.pendingRefreshReason = "write";
@@ -194,9 +203,6 @@ export class KeywordHighlighter implements IDisposable {
             const buffer = this.term.buffer.active;
             this.addDirtyRange(buffer.viewportY, buffer.viewportY + this.term.rows - 1);
             this.writePruningDeferred = true;
-            if (enterOutputObserved) {
-              this.enterInputPending = false;
-            }
           } else {
             this.updateWriteBurst();
             this.markVisibleRangeDirty();
@@ -308,6 +314,10 @@ export class KeywordHighlighter implements IDisposable {
     if (this.bulkPressureCatchUpTimer) {
       clearTimeout(this.bulkPressureCatchUpTimer);
       this.bulkPressureCatchUpTimer = null;
+    }
+    if (this.enterInputIdleTimer) {
+      clearTimeout(this.enterInputIdleTimer);
+      this.enterInputIdleTimer = null;
     }
     if (this.writePruneTimer) {
       clearTimeout(this.writePruneTimer);
@@ -887,6 +897,14 @@ export class KeywordHighlighter implements IDisposable {
     }, KeywordHighlighter.WRITE_PRUNE_IDLE_MS);
   }
 
+  private scheduleEnterInputIdleClear(): void {
+    if (this.enterInputIdleTimer) clearTimeout(this.enterInputIdleTimer);
+    this.enterInputIdleTimer = setTimeout(() => {
+      this.enterInputIdleTimer = null;
+      this.enterInputPending = false;
+    }, KeywordHighlighter.WRITE_PRUNE_IDLE_MS);
+  }
+
   private mergeRefreshReason(current: RefreshReason, next: RefreshReason): RefreshReason {
     // Scroll refresh must outrank write refresh. During rapid wheel scroll with
     // concurrent output, choosing "write" can skip viewport line scans and leave
@@ -905,18 +923,6 @@ export class KeywordHighlighter implements IDisposable {
       cursorAbsoluteY: buffer.baseY + buffer.cursorY,
       viewportProbe: includeViewportProbe ? this.buildViewportProbe(buffer, this.term.rows) : [],
     };
-  }
-
-  private hasBufferPositionChangedSinceLastSnapshot(): boolean {
-    const previous = this.lastBufferSnapshot;
-    const current = this.readBufferSnapshot({ includeViewportProbe: false });
-    if (!previous || !current) return false;
-    return (
-      current.length !== previous.length
-      || current.baseY !== previous.baseY
-      || current.viewportY !== previous.viewportY
-      || current.cursorAbsoluteY !== previous.cursorAbsoluteY
-    );
   }
 
   private buildViewportProbe(buffer: IBuffer, rows: number): readonly ViewportProbeSample[] {

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -170,7 +170,10 @@ export class KeywordHighlighter implements IDisposable {
         }
         const outputDrivenPendingScroll =
           this.pendingRefreshReason === "scroll"
-          && this.hasOutputPositionChangedSinceLastSnapshot();
+          && (
+            this.hasOutputPositionChangedSinceLastSnapshot()
+            || this.hasDecorationMarkerShiftSinceLastRefresh()
+          );
         if (this.enterInputPending || outputDrivenPendingScroll) {
           this.cancelScrollRefresh();
           if (this.pendingRefreshReason === "scroll") {
@@ -960,6 +963,13 @@ export class KeywordHighlighter implements IDisposable {
       || current.baseY !== previous.baseY
       || current.cursorAbsoluteY !== previous.cursorAbsoluteY
     );
+  }
+
+  private hasDecorationMarkerShiftSinceLastRefresh(): boolean {
+    for (const [lineY, state] of this.lineDecorations) {
+      if (state.marker.isDisposed || state.marker.line !== lineY) return true;
+    }
+    return false;
   }
 
   private buildViewportProbe(buffer: IBuffer, rows: number): readonly ViewportProbeSample[] {

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -765,6 +765,9 @@ export class KeywordHighlighter implements IDisposable {
       } else {
         this.lastViewportRange = { start: viewportStart, end: viewportEnd };
         this.lastRenderRange = { start: rangeStart, end: rangeEnd };
+        if (reason === "full" && this.enterViewportScanInProgress) {
+          this.triggerRefresh("debounced", "write");
+        }
       }
     } finally {
       this.flushTerminalRefresh();

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -174,6 +174,7 @@ export class KeywordHighlighter implements IDisposable {
         if (this.enterInputPending || outputDrivenPendingScroll) {
           this.cancelScrollRefresh();
           if (this.pendingRefreshReason === "scroll") {
+            this.cancelQueuedRefreshSchedule();
             this.pendingRefreshReason = "write";
           }
         }
@@ -210,7 +211,7 @@ export class KeywordHighlighter implements IDisposable {
             this.updateWriteBurst();
             this.markVisibleRangeDirty();
           }
-          this.triggerRefresh("debounced", "write");
+          this.triggerRefresh(inputProtectionActive ? "debounced" : "immediate", "write");
           return;
         }
         this.markDirtyFromWrite();
@@ -1279,6 +1280,9 @@ export class KeywordHighlighter implements IDisposable {
   ): boolean {
     if (mode !== "immediate") return false;
     if (!this.isWriteBurstActive(now)) return false;
+    if (now - this.lastRefreshTime >= KeywordHighlighter.WRITE_BURST_HIGHLIGHT_PAUSE_MS) {
+      return false;
+    }
     return reason === "write";
   }
 
@@ -1419,6 +1423,17 @@ export class KeywordHighlighter implements IDisposable {
   private cancelScrollRefresh() {
     this.scrollRefreshJob = null;
     this.scrollRefreshGeneration += 1;
+  }
+
+  private cancelQueuedRefreshSchedule() {
+    if (this.animationFrameId !== null) {
+      cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = null;
+    }
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
   }
 
   private clearLineDecorationsOutsideRange(start: number, end: number) {

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -122,6 +122,7 @@ export class KeywordHighlighter implements IDisposable {
   private lastWriteAt = 0;
   private lastBurstDecayAt = 0;
   private lastUserInputAt = 0;
+  private lastUserInputWasEnter = false;
   private scrollRefreshJob: ScrollRefreshJob | null = null;
   private scrollRefreshGeneration = 0;
   private static readonly DIRTY_SCAN_PADDING = XTERM_PERFORMANCE_CONFIG.highlighting.dirtyScanPadding;
@@ -148,8 +149,9 @@ export class KeywordHighlighter implements IDisposable {
       }),
       // User input should keep terminal echo responsive; highlight can catch up
       // once typing pauses.
-      this.term.onData(() => {
+      this.term.onData((data) => {
         this.lastUserInputAt = performance.now();
+        this.lastUserInputWasEnter = data === "\r" || data === "\n" || data === "\r\n";
       }),
       // When new data is written, refresh on the next frame so highlights land
       // with the freshly rendered content instead of trailing behind it.
@@ -178,7 +180,12 @@ export class KeywordHighlighter implements IDisposable {
           return;
         }
         if (this.isInputProtectionActive(performance.now())) {
-          this.markDirtyFromWrite({ includeViewportProbe: false });
+          if (this.lastUserInputWasEnter) {
+            this.markDirtyFromWrite({ includeViewportProbe: false });
+          } else {
+            this.updateWriteBurst();
+            this.markVisibleRangeDirty();
+          }
           this.triggerRefresh("debounced", "write");
           return;
         }
@@ -660,7 +667,9 @@ export class KeywordHighlighter implements IDisposable {
         this.processLineRange(rangeStart, rangeEnd, cursorAbsoluteY);
       }
 
-      if (reason !== "write") {
+      if (reason === "write") {
+        this.pruneWriteDecorationsIfNeeded(rangeStart, rangeEnd);
+      } else {
         for (const [lineY, state] of this.lineDecorations) {
           if (lineY < rangeStart || lineY > rangeEnd || state.marker.isDisposed) {
             this.disposeLineDecorations(lineY, state);
@@ -797,6 +806,21 @@ export class KeywordHighlighter implements IDisposable {
       if (performance.now() - startTime >= writeRefreshBudgetMs) {
         this.triggerRefresh("continuation", continuationReason);
         return;
+      }
+    }
+  }
+
+  private pruneWriteDecorationsIfNeeded(rangeStart: number, rangeEnd: number): void {
+    const renderLineCount = Math.max(1, rangeEnd - rangeStart + 1);
+    const highWaterMark = Math.max(64, renderLineCount * 2);
+    if (this.lineDecorations.size <= highWaterMark) return;
+
+    // Decoration registration/removal makes xterm repaint the full viewport.
+    // Prune in batches so ordinary one-line output keeps existing highlights
+    // stable while long-running output remains bounded.
+    for (const [lineY, state] of this.lineDecorations) {
+      if (lineY < rangeStart || lineY > rangeEnd || state.marker.isDisposed) {
+        this.disposeLineDecorations(lineY, state);
       }
     }
   }

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -125,6 +125,9 @@ export class KeywordHighlighter implements IDisposable {
   private lastBurstDecayAt = 0;
   private lastUserInputAt = 0;
   private enterInputPending = false;
+  private enterQueuedWriteCancellationPending = false;
+  private enterViewportScanInProgress = false;
+  private enterViewportScanNeedsRepeat = false;
   private scrollRefreshJob: ScrollRefreshJob | null = null;
   private scrollRefreshGeneration = 0;
   private static readonly DIRTY_SCAN_PADDING = XTERM_PERFORMANCE_CONFIG.highlighting.dirtyScanPadding;
@@ -156,6 +159,7 @@ export class KeywordHighlighter implements IDisposable {
         this.lastUserInputAt = performance.now();
         if (data.includes("\r") || data.includes("\n")) {
           this.enterInputPending = true;
+          this.enterQueuedWriteCancellationPending = true;
           if (this.enterInputIdleTimer) {
             clearTimeout(this.enterInputIdleTimer);
             this.enterInputIdleTimer = null;
@@ -173,12 +177,15 @@ export class KeywordHighlighter implements IDisposable {
           && (
             this.hasOutputPositionChangedSinceLastSnapshot()
             || this.hasDecorationMarkerShiftSinceLastRefresh()
-        );
+          );
+        const cancelQueuedWriteForEnter =
+          this.enterQueuedWriteCancellationPending
+          && this.pendingRefreshReason === "write";
         if (this.enterInputPending || outputDrivenPendingScroll) {
           this.cancelScrollRefresh();
           if (
             this.pendingRefreshReason === "scroll"
-            || (this.enterInputPending && this.pendingRefreshReason === "write")
+            || cancelQueuedWriteForEnter
           ) {
             this.cancelQueuedRefreshSchedule();
           }
@@ -186,6 +193,7 @@ export class KeywordHighlighter implements IDisposable {
             this.pendingRefreshReason = "write";
           }
         }
+        this.enterQueuedWriteCancellationPending = false;
         const pressure = getTerminalOutputPressure(this.term);
         if (pressure.background) {
           // Hidden panes: avoid immediate scans that fight xterm, but still arm a
@@ -212,9 +220,15 @@ export class KeywordHighlighter implements IDisposable {
         const inputProtectionActive = this.isInputProtectionActive(performance.now());
         if (inputProtectionActive || this.enterInputPending) {
           if (this.enterInputPending) {
-            this.markDirtyFromWrite({ includeViewportProbe: false });
-            const buffer = this.term.buffer.active;
-            this.addDirtyRange(buffer.viewportY, buffer.viewportY + this.term.rows - 1);
+            if (this.enterViewportScanInProgress) {
+              this.updateWriteBurst();
+              this.enterViewportScanNeedsRepeat = true;
+            } else {
+              this.markDirtyFromWrite({ includeViewportProbe: false });
+              const buffer = this.term.buffer.active;
+              this.addDirtyRange(buffer.viewportY, buffer.viewportY + this.term.rows - 1);
+              this.enterViewportScanInProgress = true;
+            }
           } else {
             this.updateWriteBurst();
             this.markVisibleRangeDirty();
@@ -406,6 +420,9 @@ export class KeywordHighlighter implements IDisposable {
     this.lastRenderRange = null;
     this.clearDirtySegments();
     this.dirtyAllInRenderRange = false;
+    this.enterQueuedWriteCancellationPending = false;
+    this.enterViewportScanInProgress = false;
+    this.enterViewportScanNeedsRepeat = false;
     if (hadDecorations) {
       this.term.refresh(0, this.term.rows - 1);
     }
@@ -692,11 +709,12 @@ export class KeywordHighlighter implements IDisposable {
 
     const previousRange = this.lastRenderRange;
     this.beginTerminalRefreshTracking(viewportStart, viewportEnd);
+    let writeContinuationPending = false;
     try {
       this.reindexLineDecorationsFromMarkers();
 
       if (reason === "write") {
-        this.processDirtyLinesInRange(
+        writeContinuationPending = this.processDirtyLinesInRange(
           rangeStart,
           rangeEnd,
           cursorAbsoluteY,
@@ -718,6 +736,11 @@ export class KeywordHighlighter implements IDisposable {
 
       if (reason === "write") {
         this.pruneWriteDecorationsIfNeeded(rangeStart, rangeEnd, true);
+        this.finishEnterViewportScan(
+          writeContinuationPending,
+          viewportStart,
+          viewportEnd,
+        );
       } else {
         for (const [lineY, state] of this.lineDecorations) {
           if (lineY < rangeStart || lineY > rangeEnd || state.marker.isDisposed) {
@@ -739,6 +762,21 @@ export class KeywordHighlighter implements IDisposable {
     } finally {
       this.flushTerminalRefresh();
     }
+  }
+
+  private finishEnterViewportScan(
+    continuationPending: boolean,
+    viewportStart: number,
+    viewportEnd: number,
+  ): void {
+    if (!this.enterViewportScanInProgress || continuationPending) return;
+    this.enterViewportScanInProgress = false;
+    if (!this.enterViewportScanNeedsRepeat) return;
+
+    this.enterViewportScanNeedsRepeat = false;
+    this.addDirtyRange(viewportStart, viewportEnd);
+    this.enterViewportScanInProgress = true;
+    this.triggerRefresh("continuation", "write");
   }
 
   private beginTerminalRefreshTracking(viewportStart: number, viewportEnd: number) {

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -125,7 +125,6 @@ export class KeywordHighlighter implements IDisposable {
   private lastBurstDecayAt = 0;
   private lastUserInputAt = 0;
   private enterInputPending = false;
-  private writePruningDeferred = false;
   private scrollRefreshJob: ScrollRefreshJob | null = null;
   private scrollRefreshGeneration = 0;
   private static readonly DIRTY_SCAN_PADDING = XTERM_PERFORMANCE_CONFIG.highlighting.dirtyScanPadding;
@@ -202,7 +201,6 @@ export class KeywordHighlighter implements IDisposable {
             this.markDirtyFromWrite({ includeViewportProbe: false });
             const buffer = this.term.buffer.active;
             this.addDirtyRange(buffer.viewportY, buffer.viewportY + this.term.rows - 1);
-            this.writePruningDeferred = true;
           } else {
             this.updateWriteBurst();
             this.markVisibleRangeDirty();
@@ -676,14 +674,12 @@ export class KeywordHighlighter implements IDisposable {
     const rangeEnd = viewportEnd + overscan;
 
     const previousRange = this.lastRenderRange;
-    const deferWritePruning = reason === "write" && this.writePruningDeferred;
-    let writeContinuationScheduled = false;
     this.beginTerminalRefreshTracking(viewportStart, viewportEnd);
     try {
       this.reindexLineDecorationsFromMarkers();
 
       if (reason === "write") {
-        writeContinuationScheduled = this.processDirtyLinesInRange(
+        this.processDirtyLinesInRange(
           rangeStart,
           rangeEnd,
           cursorAbsoluteY,
@@ -704,7 +700,7 @@ export class KeywordHighlighter implements IDisposable {
       }
 
       if (reason === "write") {
-        this.pruneWriteDecorationsIfNeeded(rangeStart, rangeEnd, deferWritePruning);
+        this.pruneWriteDecorationsIfNeeded(rangeStart, rangeEnd, true);
       } else {
         for (const [lineY, state] of this.lineDecorations) {
           if (lineY < rangeStart || lineY > rangeEnd || state.marker.isDisposed) {
@@ -724,9 +720,6 @@ export class KeywordHighlighter implements IDisposable {
         this.lastRenderRange = { start: rangeStart, end: rangeEnd };
       }
     } finally {
-      if (reason === "write" && !writeContinuationScheduled) {
-        this.writePruningDeferred = false;
-      }
       this.flushTerminalRefresh();
     }
   }
@@ -862,6 +855,11 @@ export class KeywordHighlighter implements IDisposable {
     const highWaterMark = Math.max(64, renderLineCount * 2);
     if (this.lineDecorations.size <= highWaterMark) return;
     if (deferUntilIdle) {
+      const hardLimit = Math.max(256, highWaterMark * 4);
+      if (this.lineDecorations.size > hardLimit) {
+        const trimTarget = Math.max(highWaterMark, Math.floor(hardLimit * 0.75));
+        this.pruneWriteDecorationsToLimit(rangeStart, rangeEnd, trimTarget);
+      }
       this.scheduleDeferredWritePrune();
       return;
     }
@@ -870,6 +868,19 @@ export class KeywordHighlighter implements IDisposable {
     // Prune in batches so ordinary one-line output keeps existing highlights
     // stable while long-running output remains bounded.
     for (const [lineY, state] of this.lineDecorations) {
+      if (lineY < rangeStart || lineY > rangeEnd || state.marker.isDisposed) {
+        this.disposeLineDecorations(lineY, state);
+      }
+    }
+  }
+
+  private pruneWriteDecorationsToLimit(
+    rangeStart: number,
+    rangeEnd: number,
+    targetSize: number,
+  ): void {
+    for (const [lineY, state] of this.lineDecorations) {
+      if (this.lineDecorations.size <= targetSize) return;
       if (lineY < rangeStart || lineY > rangeEnd || state.marker.isDisposed) {
         this.disposeLineDecorations(lineY, state);
       }
@@ -888,8 +899,7 @@ export class KeywordHighlighter implements IDisposable {
           && now - this.lastUserInputAt < KeywordHighlighter.WRITE_PRUNE_IDLE_MS
         )
         || (
-          this.enterInputPending
-          && this.lastWriteAt > 0
+          this.lastWriteAt > 0
           && now - this.lastWriteAt < KeywordHighlighter.WRITE_PRUNE_IDLE_MS
         )
       ) {

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -173,11 +173,16 @@ export class KeywordHighlighter implements IDisposable {
           && (
             this.hasOutputPositionChangedSinceLastSnapshot()
             || this.hasDecorationMarkerShiftSinceLastRefresh()
-          );
+        );
         if (this.enterInputPending || outputDrivenPendingScroll) {
           this.cancelScrollRefresh();
-          if (this.pendingRefreshReason === "scroll") {
+          if (
+            this.pendingRefreshReason === "scroll"
+            || (this.enterInputPending && this.pendingRefreshReason === "write")
+          ) {
             this.cancelQueuedRefreshSchedule();
+          }
+          if (this.pendingRefreshReason === "scroll") {
             this.pendingRefreshReason = "write";
           }
         }


### PR DESCRIPTION
## Summary

Prevent unchanged terminal keyword highlights from being removed and repainted after pressing Enter.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2684

## Changes Made

- Keep unchanged keyword highlights mounted during normal terminal output.
- Limit post-input highlight work to the cursor neighborhood.
- Avoid a redundant terminal repaint when highlight markers already moved with the buffer.
- Add regression coverage for the Enter path.

## Screenshots / Demo

Behavior is covered by terminal event regression tests because the visible flash depends on terminal repaint timing.

## Testing

- [ ] I have tested these changes locally (npm run dev)
- [x] Linting passes (npm run lint)
- [x] Tests pass (targeted keyword and cursor-line highlight suites: 36/36)
- [x] Generated capability tool specs are updated when applicable (not applicable)
- [x] No new console errors or warnings, if this affects app behavior
- [x] Production build passes (npm run build)

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation (regression tests document the behavior)
- [x] I have not introduced any breaking changes (or I have described them above)