### PR TITLE
fix(terminal): keep cursor-row background behind keyword highlights

### DIFF
--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -313,7 +313,7 @@ test("setRules immediately highlights a newly added rule against visible termina
   }
 });
 
-test("marker reindexing invalidates cursor-line protected ranges", () => {
+test("marker reindexing moves keyword decorations to the current buffer line", () => {
   const raf = installAnimationFrameQueue();
   try {
     const { term } = createFakeTerminal("hello DEPLOY world");
@@ -328,18 +328,16 @@ test("marker reindexing invalidates cursor-line protected ranges", () => {
     raf.flush();
 
     const internals = highlighter as unknown as {
-      decorationsVersion: number;
       lineDecorations: Map<number, { marker: { line: number } }>;
       reindexLineDecorationsFromMarkers: () => void;
     };
     const state = internals.lineDecorations.get(0);
     assert.ok(state);
-    const previousVersion = internals.decorationsVersion;
     state.marker.line = 1;
 
     internals.reindexLineDecorationsFromMarkers();
 
-    assert.equal(internals.decorationsVersion, previousVersion + 1);
+    assert.equal(internals.lineDecorations.has(0), false);
     assert.equal(internals.lineDecorations.get(1), state);
     highlighter.dispose();
   } finally {

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -29,8 +29,6 @@ interface CachedDecorationRange {
   priority: number;
 }
 
-type HighlightRange = Pick<CachedDecorationRange, 'x' | 'width'>;
-
 interface LogicalDecorationRange {
   start: number;
   length: number;
@@ -46,7 +44,6 @@ interface DirtyLineSegment {
 interface LineDecorationState {
   marker: IMarker;
   decorations: IDecoration[];
-  ranges: readonly CachedDecorationRange[];
   signature: string;
 }
 
@@ -103,7 +100,6 @@ export class KeywordHighlighter implements IDisposable {
   private term: XTerm;
   private compiledRules: CompiledRule[] = [];
   private lineDecorations = new Map<number, LineDecorationState>();
-  private decorationsVersion = 0;
   private debounceTimer: NodeJS.Timeout | null = null;
   /** Single quiet-window catch-up after bulk dumps (no per-write schedule). */
   private bulkPressureCatchUpTimer: NodeJS.Timeout | null = null;
@@ -279,14 +275,6 @@ export class KeywordHighlighter implements IDisposable {
     }
   }
 
-  public getForegroundRanges(lineY: number): readonly HighlightRange[] {
-    return this.lineDecorations.get(lineY)?.ranges ?? EMPTY_RANGES;
-  }
-
-  public getForegroundRangesVersion(): number {
-    return this.decorationsVersion;
-  }
-
   public dispose() {
     this.cancelScrollRefresh();
     this.clearDecorations();
@@ -364,7 +352,6 @@ export class KeywordHighlighter implements IDisposable {
       this.disposeLineDecorations(lineY, state);
     }
     this.lineDecorations.clear();
-    if (hadDecorations) this.decorationsVersion += 1;
     this.lastViewportRange = null;
     this.lastRenderRange = null;
     this.clearDirtySegments();
@@ -389,13 +376,13 @@ export class KeywordHighlighter implements IDisposable {
     if (lineHint != null) {
       const hinted = this.lineDecorations.get(lineHint);
       if (hinted === target) {
-        if (this.lineDecorations.delete(lineHint)) this.decorationsVersion += 1;
+        this.lineDecorations.delete(lineHint);
         return lineHint;
       }
     }
     for (const [mappedLineY, mappedState] of this.lineDecorations) {
       if (mappedState === target) {
-        if (this.lineDecorations.delete(mappedLineY)) this.decorationsVersion += 1;
+        this.lineDecorations.delete(mappedLineY);
         return mappedLineY;
       }
     }
@@ -420,7 +407,7 @@ export class KeywordHighlighter implements IDisposable {
     const offset = lineY - cursorAbsoluteY;
     const marker = this.term.registerMarker(offset);
     if (!marker) {
-      if (this.lineDecorations.delete(lineY)) this.decorationsVersion += 1;
+      this.lineDecorations.delete(lineY);
       return;
     }
 
@@ -439,17 +426,15 @@ export class KeywordHighlighter implements IDisposable {
 
     if (decorations.length === 0) {
       marker.dispose();
-      if (this.lineDecorations.delete(lineY)) this.decorationsVersion += 1;
+      this.lineDecorations.delete(lineY);
       return;
     }
 
     this.lineDecorations.set(lineY, {
       marker,
       decorations,
-      ranges,
       signature,
     });
-    this.decorationsVersion += 1;
     this.markTerminalRefreshNeeded(lineY);
   }
 
@@ -750,20 +735,15 @@ export class KeywordHighlighter implements IDisposable {
       staleStates.delete(state);
     }
 
-    let mappingChanged = this.lineDecorations.size !== nextLineDecorations.size;
     for (const [lineY, state] of this.lineDecorations) {
       if (nextLineDecorations.get(lineY) !== state) {
-        mappingChanged = true;
         changedLines.add(lineY);
       }
     }
     for (const [lineY, state] of nextLineDecorations) {
       if (this.lineDecorations.get(lineY) !== state) changedLines.add(lineY);
     }
-    if (staleStates.size > 0) mappingChanged = true;
-
     this.lineDecorations = nextLineDecorations;
-    if (mappingChanged) this.decorationsVersion += 1;
     for (const lineY of changedLines) this.markTerminalRefreshNeeded(lineY);
 
     for (const state of staleStates) {

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -2044,11 +2044,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   const keywordHighlighter = new KeywordHighlighter(term);
   keywordHighlighter.setRules(keywordHighlightRules, keywordHighlightEnabled);
 
-  const cursorLineHighlighter = new CursorLineHighlighter(
-    term,
-    (absoluteLine) => keywordHighlighter.getForegroundRanges(absoluteLine),
-    () => keywordHighlighter.getForegroundRangesVersion(),
-  );
+  const cursorLineHighlighter = new CursorLineHighlighter(term);
   cursorLineHighlighter.setBackgroundColor(
     resolveCursorLineHighlightBackground(ctx.terminalTheme.colors),
   );

--- a/components/terminal/runtime/cursorLineHighlight.test.ts
+++ b/components/terminal/runtime/cursorLineHighlight.test.ts
@@ -246,71 +246,39 @@ test('CursorLineHighlighter gives selection and search matches priority', () => 
 
 test('CursorLineHighlighter refreshes after hidden writes become visible', () => {
   const term = createFakeTerm(10);
-  let protectedRanges: Array<{ x: number; width: number }> = [];
-  const highlighter = new CursorLineHighlighter(
-    term as never,
-    () => protectedRanges,
-  );
+  const highlighter = new CursorLineHighlighter(term as never);
   highlighter.setEnabled(true);
-  assert.equal(term.decorations.at(-1)?.options.width, 10);
+  assert.equal(term.markers.at(-1)?.line, 0);
 
   term.writeHiddenOutput(1);
-  protectedRanges = [{ x: 0, width: 2 }];
+  assert.equal(term.decorations.length, 1);
   term.render();
 
-  assert.deepEqual(
-    term.decorations
-      .filter(({ disposed }) => !disposed)
-      .map(({ options }) => ({ x: options.x, width: options.width })),
-    [
-      { x: 2, width: 8 },
-    ],
-  );
+  assert.equal(term.decorations.length, 2);
+  assert.equal(term.decorations[0]?.disposed, true);
+  assert.equal(term.markers.at(-1)?.line, 1);
   highlighter.dispose();
 });
 
-test('CursorLineHighlighter refreshes after keyword ranges are removed', () => {
+test('CursorLineHighlighter keeps a continuous background under keyword decorations', () => {
   const term = createFakeTerm(10);
-  let protectedRanges: Array<{ x: number; width: number }> = [{ x: 0, width: 2 }];
-  let protectedRangesVersion = 1;
-  const highlighter = new CursorLineHighlighter(
-    term as never,
-    () => protectedRanges,
-    () => protectedRangesVersion,
-  );
-  highlighter.setEnabled(true);
-  assert.deepEqual(
-    term.decorations.filter(({ disposed }) => !disposed).map(({ options }) => options.width),
-    [8],
-  );
-
-  protectedRanges = [];
-  protectedRangesVersion += 1;
-  term.render();
-
-  assert.deepEqual(
-    term.decorations.filter(({ disposed }) => !disposed).map(({ options }) => options.width),
-    [10],
-  );
-  highlighter.dispose();
-});
-
-test('CursorLineHighlighter leaves keyword decoration ranges untouched', () => {
-  const term = createFakeTerm(10);
-  const highlighter = new CursorLineHighlighter(
-    term as never,
-    () => [{ x: 2, width: 2 }],
-  );
+  const keywordMarker = term.registerMarker(0);
+  term.registerDecoration({
+    marker: keywordMarker,
+    x: 2,
+    width: 2,
+    foregroundColor: '#F87171',
+  });
+  const highlighter = new CursorLineHighlighter(term as never);
   highlighter.setBackgroundColor('#263449');
   highlighter.setEnabled(true);
 
-  assert.deepEqual(
-    term.decorations.map(({ options }) => ({ x: options.x, width: options.width })),
-    [
-      { x: 0, width: 2 },
-      { x: 4, width: 6 },
-    ],
-  );
+  assert.equal(term.decorations[0]?.options.foregroundColor, '#F87171');
+  assert.equal(term.decorations[0]?.options.backgroundColor, undefined);
+  assert.equal(term.decorations[1]?.options.x, 0);
+  assert.equal(term.decorations[1]?.options.width, 10);
+  assert.equal(term.decorations[1]?.options.backgroundColor, '#263449');
+  assert.equal(term.decorations[1]?.options.layer, 'bottom');
   highlighter.dispose();
 });
 

--- a/components/terminal/runtime/cursorLineHighlight.ts
+++ b/components/terminal/runtime/cursorLineHighlight.ts
@@ -37,24 +37,16 @@ export class CursorLineHighlighter implements IDisposable {
   private activeColor: string | null = null;
   private activeRanges: HighlightRange[] = [];
   private activeTailRanges: HighlightRange[] = [];
-  private activeProtectedRangesVersion = 0;
   private readonly disposables: IDisposable[] = [];
   private pendingRefresh = false;
   private disposed = false;
 
-  constructor(
-    private readonly term: CursorLineTerminal,
-    private readonly getProtectedRanges: (absoluteLine: number) => readonly HighlightRange[] = () => [],
-    private readonly getProtectedRangesVersion: () => number = () => 0,
-  ) {
+  constructor(private readonly term: CursorLineTerminal) {
     this.disposables.push(
       this.term.onCursorMove(() => this.markPendingRefresh()),
       this.term.onWriteParsed(() => this.markPendingRefresh()),
       this.term.onRender(() => {
-        if (
-          this.pendingRefresh ||
-          this.getProtectedRangesVersion() !== this.activeProtectedRangesVersion
-        ) {
+        if (this.pendingRefresh) {
           this.pendingRefresh = false;
           this.refresh();
         }
@@ -109,10 +101,8 @@ export class CursorLineHighlighter implements IDisposable {
       line,
       cols,
       buffer.getNullCell(),
-      this.getProtectedRanges(absoluteLine),
     );
     const tailRanges = this.getTailRanges(contentEnd, cols);
-    const protectedRangesVersion = this.getProtectedRangesVersion();
 
     if (
       !options.force &&
@@ -125,7 +115,6 @@ export class CursorLineHighlighter implements IDisposable {
       !this.marker.isDisposed &&
       this.marker.line === absoluteLine
     ) {
-      this.activeProtectedRangesVersion = protectedRangesVersion;
       return;
     }
 
@@ -175,7 +164,6 @@ export class CursorLineHighlighter implements IDisposable {
     this.activeColor = color;
     this.activeRanges = ranges;
     this.activeTailRanges = tailRanges;
-    this.activeProtectedRangesVersion = protectedRangesVersion;
   }
 
   dispose(): void {
@@ -192,7 +180,6 @@ export class CursorLineHighlighter implements IDisposable {
     line: ReturnType<CursorLineTerminal['buffer']['active']['getLine']>,
     cols: number,
     cell: ReturnType<CursorLineTerminal['buffer']['active']['getNullCell']>,
-    protectedRanges: readonly HighlightRange[],
   ): { ranges: HighlightRange[]; contentEnd: number } {
     const ranges: HighlightRange[] = [];
     let rangeStart: number | null = null;
@@ -205,15 +192,11 @@ export class CursorLineHighlighter implements IDisposable {
       ) {
         contentEnd = Math.min(cols, x + Math.max(1, currentCell.getWidth()));
       }
-      const isProtected = protectedRanges.some(
-        (range) => x >= range.x && x < range.x + range.width,
-      );
       const isHighlightable =
-        !isProtected &&
-        (currentCell === undefined ||
-          (currentCell.isBgDefault() &&
-            currentCell.isFgDefault() &&
-            !currentCell.isInverse()));
+        currentCell === undefined ||
+        (currentCell.isBgDefault() &&
+          currentCell.isFgDefault() &&
+          !currentCell.isInverse());
       if (isHighlightable && rangeStart === null) rangeStart = x;
       if ((!isHighlightable || x === cols - 1) && rangeStart !== null) {
         const end = isHighlightable && x === cols - 1 ? x + 1 : x;


### PR DESCRIPTION
## Summary

Keep the current-row highlight continuous when a keyword, such as a host name, is highlighted on the same terminal row.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2682

## Changes Made

- Paint the cursor-row background continuously under foreground-only keyword decorations.
- Remove the keyword-range exclusion path that created the default-background gap.
- Add regression coverage for the combined cursor-row and keyword decoration case.
- Preserve keyword marker reindexing coverage without the removed coupling.

## Screenshots / Demo

The cursor-row background now stays continuous under the highlighted host name; the keyword foreground color remains unchanged.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes locally and in CI
- [x] Relevant local tests pass (32/32 cursor-row and keyword-highlight tests)
- [x] Full test suite passes in CI
- [x] Production build passes locally and in CI
- [x] Generated capability tool specs and Codex App Server schema checks pass in CI
- [x] No new console errors or warnings in the focused test/build output

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation (not applicable)
- [x] I have not introduced any breaking changes