### PR TITLE
Fix macOS Bitwarden SSH agent forwarding

### DIFF
--- a/application/state/useApplicationBackend.ts
+++ b/application/state/useApplicationBackend.ts
@@ -35,6 +35,7 @@ export const useApplicationBackend = () => {
 
   const checkSshAgent = useCallback(async (options?: {
     identityAgent?: string;
+    agentForwarding?: boolean;
     hostname?: string;
     port?: number;
     username?: string;

--- a/components/HostDetailsAdvancedSections.test.ts
+++ b/components/HostDetailsAdvancedSections.test.ts
@@ -29,3 +29,8 @@ test('editing enabled SSH agent controls persists the enabled state', () => {
 test('enabling SSH agent login clears an imported none sentinel', () => {
   assert.match(source, /resolveSshAgentToggleUpdate/);
 });
+
+test('login and forwarding warnings use independent agent status', () => {
+  assert.match(source, /systemSshAgentEnabled && sshAgentStatus && !sshAgentStatus\.running/);
+  assert.match(source, /form\.agentForwarding && sshForwardingAgentStatus && !sshForwardingAgentStatus\.running/);
+});

--- a/components/HostDetailsAdvancedSections.tsx
+++ b/components/HostDetailsAdvancedSections.tsx
@@ -41,6 +41,7 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
   effectiveFontSize,
   hasEffectiveFontSizeOverride,
   sshAgentStatus,
+  sshForwardingAgentStatus,
   effectiveGroupDefaults,
   effectiveAuthMethod,
   showAlgorithmOverrides,
@@ -319,7 +320,7 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
             enabled={!!form.agentForwarding}
             onToggle={() => update("agentForwarding", !form.agentForwarding)}
           />
-          {form.agentForwarding && sshAgentStatus && !sshAgentStatus.running && (
+          {form.agentForwarding && sshForwardingAgentStatus && !sshForwardingAgentStatus.running && (
             <div className="flex items-start gap-2 p-2 rounded-md bg-yellow-500/10 border border-yellow-500/20">
               <AlertTriangle size={14} className="text-yellow-500 mt-0.5 flex-shrink-0" />
               <div className="space-y-1">

--- a/components/HostDetailsPanel.sshAgentStatus.test.ts
+++ b/components/HostDetailsPanel.sshAgentStatus.test.ts
@@ -4,10 +4,14 @@ import test from 'node:test';
 
 const source = readFileSync(new URL('./HostDetailsPanel.tsx', import.meta.url), 'utf8');
 
-test('SSH agent availability ignores stale async responses', () => {
-  assert.match(source, /let cancelled = false/);
+test('login and forwarding agent availability are checked independently', () => {
+  assert.equal(source.match(/let cancelled = false/g)?.length, 2);
   assert.match(source, /if \(!cancelled\) setSshAgentStatus\(status\)/);
-  assert.match(source, /return \(\) => \{\s*cancelled = true/);
+  assert.match(source, /if \(!cancelled\) setSshForwardingAgentStatus\(status\)/);
+  assert.match(source, /if \(form\.useSshAgent === true\) \{\s*void checkSshAgent\(\{\s*identityAgent: form\.identityAgent,\s*hostname:/);
+  assert.match(source, /if \(form\.agentForwarding\) \{\s*void checkSshAgent\(\{\s*identityAgent: form\.identityAgent,\s*agentForwarding: true,/);
+  assert.equal(source.match(/return \(\) => \{\s*cancelled = true/g)?.length, 2);
+  assert.match(source, /sshForwardingAgentStatus=\{sshForwardingAgentStatus\}/);
 });
 
 test('inherited identity actions use the resolved authentication username', () => {

--- a/components/HostDetailsPanel.sshAgentStatus.test.ts
+++ b/components/HostDetailsPanel.sshAgentStatus.test.ts
@@ -8,7 +8,7 @@ test('login and forwarding agent availability are checked independently', () => 
   assert.equal(source.match(/let cancelled = false/g)?.length, 2);
   assert.match(source, /if \(!cancelled\) setSshAgentStatus\(status\)/);
   assert.match(source, /if \(!cancelled\) setSshForwardingAgentStatus\(status\)/);
-  assert.match(source, /if \(form\.useSshAgent === true\) \{\s*void checkSshAgent\(\{\s*identityAgent: form\.identityAgent,\s*hostname:/);
+  assert.match(source, /if \(form\.agentForwarding \|\| form\.useSshAgent === true\) \{\s*void checkSshAgent\(\{\s*identityAgent: form\.useSshAgent === true \? form\.identityAgent : undefined,\s*hostname:/);
   assert.match(source, /if \(form\.agentForwarding\) \{\s*void checkSshAgent\(\{\s*identityAgent: form\.identityAgent,\s*agentForwarding: true,/);
   assert.equal(source.match(/return \(\) => \{\s*cancelled = true/g)?.length, 2);
   assert.match(source, /sshForwardingAgentStatus=\{sshForwardingAgentStatus\}/);

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -11,7 +11,7 @@ import {
 } from "lucide-react";
 import React, { useEffect, useMemo, useState, useCallback } from "react";
 import { useI18n } from "../application/i18n/I18nProvider";
-import { useApplicationBackend } from "../application/state/useApplicationBackend";
+import { useApplicationBackend, type SshAgentStatus } from "../application/state/useApplicationBackend";
 import { applyGroupDefaults, resolveGroupDefaults, resolveGroupTerminalThemeId } from "../domain/groupConfig";
 import {
   getEffectiveHostDistro,
@@ -192,20 +192,14 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
   const [newGroupName, setNewGroupName] = useState("");
   const [newGroupParent, setNewGroupParent] = useState("");
 
-  const [sshAgentStatus, setSshAgentStatus] = useState<{
-    running: boolean;
-    startupType: string | null;
-    error: string | null;
-  } | null>(null);
+  const [sshAgentStatus, setSshAgentStatus] = useState<SshAgentStatus | null>(null);
+  const [sshForwardingAgentStatus, setSshForwardingAgentStatus] = useState<SshAgentStatus | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    if (form.agentForwarding || form.useSshAgent === true) {
+    if (form.useSshAgent === true) {
       void checkSshAgent({
-        identityAgent: form.useSshAgent === true || form.agentForwarding
-          ? form.identityAgent
-          : undefined,
-        agentForwarding: form.agentForwarding,
+        identityAgent: form.identityAgent,
         hostname: form.hostname,
         port: form.port,
         username: form.username,
@@ -218,7 +212,27 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
     return () => {
       cancelled = true;
     };
-  }, [form.agentForwarding, form.useSshAgent, form.identityAgent, form.hostname, form.port, form.username, checkSshAgent]);
+  }, [form.useSshAgent, form.identityAgent, form.hostname, form.port, form.username, checkSshAgent]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (form.agentForwarding) {
+      void checkSshAgent({
+        identityAgent: form.identityAgent,
+        agentForwarding: true,
+        hostname: form.hostname,
+        port: form.port,
+        username: form.username,
+      }).then((status) => {
+        if (!cancelled) setSshForwardingAgentStatus(status);
+      });
+    } else {
+      setSshForwardingAgentStatus(null);
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [form.agentForwarding, form.identityAgent, form.hostname, form.port, form.username, checkSshAgent]);
 
   const [groupInputValue, setGroupInputValue] = useState(form.group || "");
 
@@ -1053,6 +1067,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
           effectiveFontSize={effectiveFontSize}
           hasEffectiveFontSizeOverride={hasEffectiveFontSizeOverride}
           sshAgentStatus={sshAgentStatus}
+          sshForwardingAgentStatus={sshForwardingAgentStatus}
           effectiveGroupDefaults={effectiveGroupDefaults}
           effectiveAuthMethod={effectiveAuthMethod}
           showAlgorithmOverrides={showAlgorithmOverrides}

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -203,6 +203,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
     if (form.agentForwarding || form.useSshAgent === true) {
       void checkSshAgent({
         identityAgent: form.useSshAgent === true ? form.identityAgent : undefined,
+        agentForwarding: form.agentForwarding,
         hostname: form.hostname,
         port: form.port,
         username: form.username,

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -197,9 +197,9 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
 
   useEffect(() => {
     let cancelled = false;
-    if (form.useSshAgent === true) {
+    if (form.agentForwarding || form.useSshAgent === true) {
       void checkSshAgent({
-        identityAgent: form.identityAgent,
+        identityAgent: form.useSshAgent === true ? form.identityAgent : undefined,
         hostname: form.hostname,
         port: form.port,
         username: form.username,
@@ -212,7 +212,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
     return () => {
       cancelled = true;
     };
-  }, [form.useSshAgent, form.identityAgent, form.hostname, form.port, form.username, checkSshAgent]);
+  }, [form.agentForwarding, form.useSshAgent, form.identityAgent, form.hostname, form.port, form.username, checkSshAgent]);
 
   useEffect(() => {
     let cancelled = false;

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -202,7 +202,9 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
     let cancelled = false;
     if (form.agentForwarding || form.useSshAgent === true) {
       void checkSshAgent({
-        identityAgent: form.useSshAgent === true ? form.identityAgent : undefined,
+        identityAgent: form.useSshAgent === true || form.agentForwarding
+          ? form.identityAgent
+          : undefined,
         agentForwarding: form.agentForwarding,
         hostname: form.hostname,
         port: form.port,

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -586,9 +586,13 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
           sessionLog: ctx.sessionLog?.enabled ? ctx.sessionLog : undefined,
           sshDebugLogEnabled: ctx.sshDebugLogEnabled,
           identityFilePaths: attempt.useIdentityFiles ? targetIdentityFilePaths : undefined,
-          ...(attempt.useSshAgent === false
-            ? { useSshAgent: false }
-            : resolveBridgeSshAgentAuth(ctx.host, attempt.key, authMethod)),
+          ...resolveBridgeSshAgentAuth(
+            attempt.useSshAgent === false
+              ? { ...ctx.host, useSshAgent: false }
+              : ctx.host,
+            attempt.key,
+            authMethod,
+          ),
           knownHosts: ctx.knownHosts,
           sudoAutofillPassword: resolveSavedSudoAutofillPassword(),
           // Ask the bridge to reuse the source tab's authenticated connection

--- a/domain/sshAuth.test.ts
+++ b/domain/sshAuth.test.ts
@@ -192,6 +192,22 @@ test("resolveBridgeSshAgentAuth leaves the ambient agent available in automatic 
   );
 });
 
+test("resolveBridgeSshAgentAuth keeps an explicit forwarding agent separate from login", () => {
+  assert.deepEqual(
+    resolveBridgeSshAgentAuth({
+      ...autofillBaseHost,
+      authMethod: "password",
+      useSshAgent: false,
+      agentForwarding: true,
+      identityAgent: "/tmp/forwarding-agent.sock",
+    }, undefined, "password"),
+    {
+      useSshAgent: false,
+      identityAgent: "/tmp/forwarding-agent.sock",
+    },
+  );
+});
+
 test("resolveBridgeSshAgentAuth lets explicit auth override a stale agent toggle", () => {
   const staleAgentHost = { ...autofillBaseHost, useSshAgent: true };
   assert.deepEqual(

--- a/domain/sshAuth.test.ts
+++ b/domain/sshAuth.test.ts
@@ -208,6 +208,19 @@ test("resolveBridgeSshAgentAuth keeps an explicit forwarding agent separate from
   );
 });
 
+test("resolveBridgeSshAgentAuth does not forward the login-only IdentityAgent none directive", () => {
+  assert.deepEqual(
+    resolveBridgeSshAgentAuth({
+      ...autofillBaseHost,
+      authMethod: "password",
+      useSshAgent: false,
+      agentForwarding: true,
+      identityAgent: "none",
+    }, undefined, "password"),
+    { useSshAgent: false },
+  );
+});
+
 test("resolveBridgeSshAgentAuth lets explicit auth override a stale agent toggle", () => {
   const staleAgentHost = { ...autofillBaseHost, useSshAgent: true };
   assert.deepEqual(

--- a/domain/sshAuth.ts
+++ b/domain/sshAuth.ts
@@ -252,7 +252,7 @@ export const resolveBridgeKeyAuth = (args: {
 };
 
 export const resolveBridgeSshAgentAuth = (
-  host: Pick<Host, "authMethod" | "useSshAgent" | "identityAgent" | "identityFilePaths" | "identitiesOnly" | "addKeysToAgent" | "useKeychain">,
+  host: Pick<Host, "authMethod" | "useSshAgent" | "identityAgent" | "identityFilePaths" | "identitiesOnly" | "addKeysToAgent" | "useKeychain" | "agentForwarding">,
   key?: Pick<SSHKey, "certificate" | "publicKey" | "source" | "filePath">,
   authMethod?: HostAuthMethod,
 ): {
@@ -263,8 +263,11 @@ export const resolveBridgeSshAgentAuth = (
   useKeychain?: boolean;
   agentPublicKeys?: string[];
 } => {
+  const forwardingAgent = host.agentForwarding && host.identityAgent !== undefined
+    ? { identityAgent: host.identityAgent }
+    : {};
   if (authMethod === "password" || authMethod === "certificate" || key?.certificate?.trim()) {
-    return { useSshAgent: false };
+    return { useSshAgent: false, ...forwardingAgent };
   }
   if (authMethod === "key") {
     const hasAgentSelector = Boolean(
@@ -273,7 +276,7 @@ export const resolveBridgeSshAgentAuth = (
       || host.identityFilePaths?.some((filePath) => filePath.trim()),
     );
     if (host.useSshAgent !== true || !hasAgentSelector) {
-      return { useSshAgent: false };
+      return { useSshAgent: false, ...forwardingAgent };
     }
     return {
       useSshAgent: true,
@@ -286,8 +289,8 @@ export const resolveBridgeSshAgentAuth = (
   }
   if (host.useSshAgent !== true) {
     return authMethod === "auto" && host.useSshAgent !== false
-      ? {}
-      : { useSshAgent: false };
+      ? forwardingAgent
+      : { useSshAgent: false, ...forwardingAgent };
   }
   return {
     useSshAgent: true,

--- a/domain/sshAuth.ts
+++ b/domain/sshAuth.ts
@@ -263,7 +263,9 @@ export const resolveBridgeSshAgentAuth = (
   useKeychain?: boolean;
   agentPublicKeys?: string[];
 } => {
-  const forwardingAgent = host.agentForwarding && host.identityAgent !== undefined
+  const forwardingAgent = host.agentForwarding
+    && host.identityAgent !== undefined
+    && !isSshAgentNoneValue(host.identityAgent)
     ? { identityAgent: host.identityAgent }
     : {};
   if (authMethod === "password" || authMethod === "certificate" || key?.certificate?.trim()) {

--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -660,6 +660,49 @@ function socketAgentConnectable(agentPath, options = {}) {
   });
 }
 
+function socketAgentIdentityCount(agentPath, options = {}) {
+  const createConnection = options.createConnectionImpl || require("node:net").createConnection;
+  const timeoutMs = options.timeoutMs ?? 1000;
+  return new Promise((resolve) => {
+    let settled = false;
+    let socket = null;
+    let response = Buffer.alloc(0);
+    const finish = (count) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (socket) {
+        socket.removeAllListeners();
+        socket.destroy();
+      }
+      resolve(count);
+    };
+    const timer = setTimeout(() => finish(null), timeoutMs);
+    try {
+      socket = createConnection(agentPath);
+      socket.once("connect", () => {
+        socket.write(Buffer.from([0, 0, 0, 1, 11]));
+      });
+      socket.on("data", (chunk) => {
+        response = Buffer.concat([response, chunk]);
+        if (response.length < 5) return;
+        const payloadLength = response.readUInt32BE(0);
+        if (payloadLength < 1 || payloadLength > 1024 * 1024) return finish(null);
+        if (response.length < payloadLength + 4) return;
+        const responseType = response[4];
+        if (responseType === 5) return finish(0);
+        if (responseType !== 12 || payloadLength < 5) return finish(null);
+        finish(response.readUInt32BE(5));
+      });
+      socket.once("error", () => finish(null));
+      socket.once("end", () => finish(null));
+      socket.once("close", () => finish(null));
+    } catch {
+      finish(null);
+    }
+  });
+}
+
 /**
  * Check if an SSH agent is available on Windows.
  * Probes the well-known named pipe via net.connect(). This supports any
@@ -756,6 +799,37 @@ async function getAvailableAgentSocket(identityAgent, injected = {}) {
   return running ? socketPath : null;
 }
 
+async function getAvailableForwardingAgentSocket(identityAgent, injected = {}) {
+  const resolveAvailable = injected.getAvailableAgentSocketImpl || getAvailableAgentSocket;
+  const platform = injected.platform || process.platform;
+  if (identityAgent || platform !== "darwin") {
+    return resolveAvailable(identityAgent, injected);
+  }
+
+  const env = injected.env || process.env;
+  const home = injected.homedir || os.homedir();
+  const candidates = [...new Set([
+    env.SSH_AUTH_SOCK,
+    env.SSH_AUTH_SOCKET,
+    path.join(home, ".bitwarden-ssh-agent.sock"),
+    path.join(home, "Library", "Containers", "com.bitwarden.desktop", "Data", ".bitwarden-ssh-agent.sock"),
+  ].filter(Boolean))];
+  const countIdentities = injected.socketAgentIdentityCount || socketAgentIdentityCount;
+  let fallbackSocket = null;
+
+  for (const candidate of candidates) {
+    const socketPath = await resolveAvailable(candidate, injected);
+    if (!socketPath) continue;
+    fallbackSocket ||= socketPath;
+    const identityCount = await countIdentities(socketPath, injected);
+    if (Number.isInteger(identityCount) && identityCount > 0) {
+      return socketPath;
+    }
+  }
+
+  return fallbackSocket;
+}
+
 async function getNativeOpenSshAgentSocket(identityAgent, injected = {}) {
   const socketPath = await getAvailableAgentSocket(identityAgent, injected);
   const platform = injected.platform || process.platform;
@@ -769,9 +843,25 @@ async function getNativeOpenSshAgentSocket(identityAgent, injected = {}) {
   return socketPath;
 }
 
+async function getNativeOpenSshForwardingAgentSocket(identityAgent, injected = {}) {
+  const socketPath = await getAvailableForwardingAgentSocket(identityAgent, injected);
+  const platform = injected.platform || process.platform;
+  if (platform === "win32" && socketPath && !isWindowsNamedPipe(socketPath)) {
+    const error = new Error(
+      "This SSH agent is available only to Netcatty's built-in SSH client. Mosh and EternalTerminal require a Windows named-pipe agent.",
+    );
+    error.code = "ERR_SSH_AGENT_NATIVE_UNSUPPORTED";
+    throw error;
+  }
+  return socketPath;
+}
+
 async function prepareSystemSshAgentForAuth(options, logPrefix = "[SSHAuth]") {
   if (options?.useSshAgent !== true) return null;
-  const socketPath = await getAvailableAgentSocket(options.identityAgent, {
+  const resolveSocket = options.agentForwarding
+    ? getAvailableForwardingAgentSocket
+    : getAvailableAgentSocket;
+  const socketPath = await resolveSocket(options.identityAgent, {
     hostname: options.hostname,
     port: options.port,
     username: options.username,
@@ -1939,11 +2029,14 @@ module.exports = {
   findAllDefaultPrivateKeys,
   getSshAgentSocket,
   getAvailableAgentSocket,
+  getAvailableForwardingAgentSocket,
   getNativeOpenSshAgentSocket,
+  getNativeOpenSshForwardingAgentSocket,
   isWindowsNamedPipe,
   ssh2AgentConnectable,
   cygwinAgentConnectable,
   socketAgentConnectable,
+  socketAgentIdentityCount,
   resolveIdentityAgentPath,
   prepareSystemSshAgentForAuth,
   buildAuthHandler,

--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -802,8 +802,12 @@ async function getAvailableAgentSocket(identityAgent, injected = {}) {
 async function getAvailableForwardingAgentSocket(identityAgent, injected = {}) {
   const resolveAvailable = injected.getAvailableAgentSocketImpl || getAvailableAgentSocket;
   const platform = injected.platform || process.platform;
-  if (identityAgent || platform !== "darwin") {
-    return resolveAvailable(identityAgent, injected);
+  const forwardingIdentityAgent = typeof identityAgent === "string"
+    && identityAgent.trim().replace(/^["']|["']$/g, "").trim().toLowerCase() === "none"
+    ? undefined
+    : identityAgent;
+  if (forwardingIdentityAgent || platform !== "darwin") {
+    return resolveAvailable(forwardingIdentityAgent, injected);
   }
 
   const env = injected.localEnv || process.env;
@@ -861,10 +865,7 @@ async function getNativeOpenSshForwardingAgentSocket(identityAgent, injected = {
 
 async function prepareSystemSshAgentForAuth(options, logPrefix = "[SSHAuth]") {
   if (options?.useSshAgent !== true) return null;
-  const resolveSocket = options.agentForwarding
-    ? getAvailableForwardingAgentSocket
-    : getAvailableAgentSocket;
-  const socketPath = await resolveSocket(options.identityAgent, {
+  const socketPath = await getAvailableAgentSocket(options.identityAgent, {
     hostname: options.hostname,
     port: options.port,
     username: options.username,
@@ -1587,9 +1588,11 @@ function shouldSkipKiPasswordAutoFill(authPhase) {
  * @param {{ hadPartialSuccess: boolean, passwordAlreadySucceeded?: boolean, keyboardInteractiveSuccessCount?: number }} authPhase
  * @param {(label: string) => void} [onAuthAttempt] - optional progress callback
  *   (jump/SFTP connection logs). Mirrors the dynamic authHandler's onAuthAttempt.
+ * @param {{ username?: string, agent?: unknown }} [agentAuth] - optional
+ *   login-only agent override when the connection's agent is reserved for forwarding.
  * @returns {(methodsLeft: string[]|null, partialSuccess: boolean, callback: Function) => void}
  */
-function createOrderedStringAuthHandler(order, authPhase, onAuthAttempt) {
+function createOrderedStringAuthHandler(order, authPhase, onAuthAttempt, agentAuth = {}) {
   // Methods we actually offered (server got a chance to accept/reject).
   let attempted = new Set();
   // Methods that contributed a successful factor; never retried.
@@ -1605,6 +1608,13 @@ function createOrderedStringAuthHandler(order, authPhase, onAuthAttempt) {
     if (method === "agent") return "SSH agent";
     return method;
   };
+  const resolveAttempt = (method) => method === "agent" && agentAuth.agent
+    ? {
+      type: "agent",
+      username: agentAuth.username,
+      agent: agentAuth.agent,
+    }
+    : method;
 
   return (methodsLeft, partialSuccess, callback) => {
     if (partialSuccess) {
@@ -1674,7 +1684,7 @@ function createOrderedStringAuthHandler(order, authPhase, onAuthAttempt) {
         );
       }
       onAuthAttempt?.(attemptLabel(method));
-      return callback(method);
+      return callback(resolveAttempt(method));
     }
     onAuthAttempt?.("all methods exhausted");
     return callback(false);

--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -806,21 +806,24 @@ async function getAvailableForwardingAgentSocket(identityAgent, injected = {}) {
     return resolveAvailable(identityAgent, injected);
   }
 
-  const env = injected.env || process.env;
+  const env = injected.localEnv || process.env;
   const home = injected.homedir || os.homedir();
+  const inheritedCandidates = [env.SSH_AUTH_SOCK, env.SSH_AUTH_SOCKET].filter(Boolean);
   const candidates = [...new Set([
-    env.SSH_AUTH_SOCK,
-    env.SSH_AUTH_SOCKET,
+    ...inheritedCandidates,
     path.join(home, ".bitwarden-ssh-agent.sock"),
     path.join(home, "Library", "Containers", "com.bitwarden.desktop", "Data", ".bitwarden-ssh-agent.sock"),
-  ].filter(Boolean))];
+  ])];
+  const inheritedCandidateSet = new Set(inheritedCandidates);
   const countIdentities = injected.socketAgentIdentityCount || socketAgentIdentityCount;
   let fallbackSocket = null;
 
   for (const candidate of candidates) {
     const socketPath = await resolveAvailable(candidate, injected);
     if (!socketPath) continue;
-    fallbackSocket ||= socketPath;
+    if (inheritedCandidateSet.has(candidate)) {
+      fallbackSocket ||= socketPath;
+    }
     const identityCount = await countIdentities(socketPath, injected);
     if (Number.isInteger(identityCount) && identityCount > 0) {
       return socketPath;

--- a/electron/bridges/sshAuthHelper.kbdInteractive.test.cjs
+++ b/electron/bridges/sshAuthHelper.kbdInteractive.test.cjs
@@ -594,6 +594,26 @@ test("createOrderedStringAuthHandler sets hadPartialSuccess on partialSuccess", 
   assert.equal(authPhase.hadPartialSuccess, true);
 });
 
+test("createOrderedStringAuthHandler can use a login agent that differs from forwarding", () => {
+  const loginAgent = { kind: "login-agent" };
+  const authPhase = createAuthPhase();
+  const handler = createOrderedStringAuthHandler(
+    ["none", "agent"],
+    authPhase,
+    undefined,
+    { username: "alice", agent: loginAgent },
+  );
+
+  const offered = [];
+  handler(null, false, (method) => offered.push(method));
+  handler(["publickey"], false, (method) => offered.push(method));
+
+  assert.deepEqual(offered, [
+    "none",
+    { type: "agent", username: "alice", agent: loginAgent },
+  ]);
+});
+
 test("createOrderedStringAuthHandler re-offers methods skipped as unavailable after partialSuccess (#2151 P2)", () => {
   // Server first only advertises publickey. password sits in our order before
   // publickey but is not advertised yet — it must NOT be permanently skipped.

--- a/electron/bridges/sshAuthHelper.systemAgent.test.cjs
+++ b/electron/bridges/sshAuthHelper.systemAgent.test.cjs
@@ -58,6 +58,20 @@ test("forwarding keeps an explicitly configured agent authoritative", async () =
   assert.equal(identityChecks, 0);
 });
 
+test("IdentityAgent none disables login but still allows forwarding discovery", async () => {
+  const inheritedSocket = "/private/tmp/com.apple.launchd.test/Listeners";
+  const bitwardenSocket = "/Users/alice/.bitwarden-ssh-agent.sock";
+  const result = await getAvailableForwardingAgentSocket("none", {
+    platform: "darwin",
+    localEnv: { SSH_AUTH_SOCK: inheritedSocket },
+    homedir: "/Users/alice",
+    getAvailableAgentSocketImpl: async (candidate) => candidate,
+    socketAgentIdentityCount: async (candidate) => candidate === bitwardenSocket ? 1 : 0,
+  });
+
+  assert.equal(result, bitwardenSocket);
+});
+
 test("macOS forwarding preserves the inherited agent when discovered providers are empty", async () => {
   const inheritedSocket = "/private/tmp/com.apple.launchd.test/Listeners";
   const result = await getAvailableForwardingAgentSocket(undefined, {

--- a/electron/bridges/sshAuthHelper.systemAgent.test.cjs
+++ b/electron/bridges/sshAuthHelper.systemAgent.test.cjs
@@ -28,7 +28,7 @@ test("macOS forwarding prefers a Bitwarden agent with identities over an empty i
 
   const result = await getAvailableForwardingAgentSocket(undefined, {
     platform: "darwin",
-    env: { SSH_AUTH_SOCK: inheritedSocket },
+    localEnv: { SSH_AUTH_SOCK: inheritedSocket },
     homedir: "/Users/alice",
     getAvailableAgentSocketImpl: async (candidate) => {
       checked.push(candidate);
@@ -62,13 +62,60 @@ test("macOS forwarding preserves the inherited agent when discovered providers a
   const inheritedSocket = "/private/tmp/com.apple.launchd.test/Listeners";
   const result = await getAvailableForwardingAgentSocket(undefined, {
     platform: "darwin",
-    env: { SSH_AUTH_SOCK: inheritedSocket },
+    localEnv: { SSH_AUTH_SOCK: inheritedSocket },
     homedir: "/Users/alice",
     getAvailableAgentSocketImpl: async (candidate) => candidate,
     socketAgentIdentityCount: async () => 0,
   });
 
   assert.equal(result, inheritedSocket);
+});
+
+test("forwarding ignores a remote terminal env when reading the local agent", async () => {
+  const inheritedSocket = "/private/tmp/com.apple.launchd.test/Listeners";
+  const checked = [];
+  await getAvailableForwardingAgentSocket(undefined, {
+    platform: "darwin",
+    env: { TERM: "xterm-256color" },
+    localEnv: { SSH_AUTH_SOCK: inheritedSocket },
+    homedir: "/Users/alice",
+    getAvailableAgentSocketImpl: async (candidate) => {
+      checked.push(candidate);
+      return null;
+    },
+    socketAgentIdentityCount: async () => 0,
+  });
+
+  assert.equal(checked[0], inheritedSocket);
+});
+
+test("forwarding does not report an empty auto-discovered provider as available", async () => {
+  const result = await getAvailableForwardingAgentSocket(undefined, {
+    platform: "darwin",
+    localEnv: {},
+    homedir: "/Users/alice",
+    getAvailableAgentSocketImpl: async (candidate) => candidate,
+    socketAgentIdentityCount: async () => 0,
+  });
+
+  assert.equal(result, null);
+});
+
+test("non-macOS forwarding keeps the existing agent resolution path", async () => {
+  const calls = [];
+  const result = await getAvailableForwardingAgentSocket(undefined, {
+    platform: "linux",
+    getAvailableAgentSocketImpl: async (candidate) => {
+      calls.push(candidate);
+      return "/tmp/agent.sock";
+    },
+    socketAgentIdentityCount: async () => {
+      throw new Error("must not inspect identities outside macOS discovery");
+    },
+  });
+
+  assert.equal(result, "/tmp/agent.sock");
+  assert.deepEqual(calls, [undefined]);
 });
 
 test("explicit agent opt-out suppresses automatic socket fallback", () => {

--- a/electron/bridges/sshAuthHelper.systemAgent.test.cjs
+++ b/electron/bridges/sshAuthHelper.systemAgent.test.cjs
@@ -11,13 +11,65 @@ const { Duplex } = require("node:stream");
 const {
   buildAuthHandler,
   getAvailableAgentSocket,
+  getAvailableForwardingAgentSocket,
   getNativeOpenSshAgentSocket,
   cygwinAgentConnectable,
   isWindowsNamedPipe,
   socketAgentConnectable,
+  socketAgentIdentityCount,
   ssh2AgentConnectable,
   resolveIdentityAgentPath,
 } = require("./sshAuthHelper.cjs");
+
+test("macOS forwarding prefers a Bitwarden agent with identities over an empty inherited agent", async () => {
+  const inheritedSocket = "/private/tmp/com.apple.launchd.test/Listeners";
+  const bitwardenSocket = "/Users/alice/.bitwarden-ssh-agent.sock";
+  const checked = [];
+
+  const result = await getAvailableForwardingAgentSocket(undefined, {
+    platform: "darwin",
+    env: { SSH_AUTH_SOCK: inheritedSocket },
+    homedir: "/Users/alice",
+    getAvailableAgentSocketImpl: async (candidate) => {
+      checked.push(candidate);
+      return candidate;
+    },
+    socketAgentIdentityCount: async (candidate) => (
+      candidate === bitwardenSocket ? 1 : 0
+    ),
+  });
+
+  assert.equal(result, bitwardenSocket);
+  assert.deepEqual(checked, [inheritedSocket, bitwardenSocket]);
+});
+
+test("forwarding keeps an explicitly configured agent authoritative", async () => {
+  let identityChecks = 0;
+  const result = await getAvailableForwardingAgentSocket("/tmp/selected-agent.sock", {
+    platform: "darwin",
+    getAvailableAgentSocketImpl: async (candidate) => candidate,
+    socketAgentIdentityCount: async () => {
+      identityChecks += 1;
+      return 0;
+    },
+  });
+
+  assert.equal(result, "/tmp/selected-agent.sock");
+  assert.equal(identityChecks, 0);
+});
+
+test("macOS forwarding preserves the inherited agent when discovered providers are empty", async () => {
+  const inheritedSocket = "/private/tmp/com.apple.launchd.test/Listeners";
+  const result = await getAvailableForwardingAgentSocket(undefined, {
+    platform: "darwin",
+    env: { SSH_AUTH_SOCK: inheritedSocket },
+    homedir: "/Users/alice",
+    getAvailableAgentSocketImpl: async (candidate) => candidate,
+    socketAgentIdentityCount: async () => 0,
+  });
+
+  assert.equal(result, inheritedSocket);
+});
 
 test("explicit agent opt-out suppresses automatic socket fallback", () => {
   const auth = buildAuthHandler({
@@ -328,6 +380,26 @@ test("Unix agent protocol probe closes a connection that never responds", async 
     new Promise((_, reject) => setTimeout(() => reject(new Error("agent probe connection stayed open")), 500)),
   ]);
   assert.equal(acceptedSocket?.destroyed, true);
+});
+
+test("Unix agent identity probe reads the advertised identity count", async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-agent-identities-"));
+  const socketPath = path.join(dir, "agent.sock");
+  const server = net.createServer((socket) => {
+    socket.once("data", () => {
+      socket.write(Buffer.from([0, 0, 0, 5, 12, 0, 0, 0, 2]));
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, resolve);
+  });
+  t.after(() => {
+    server.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  assert.equal(await socketAgentIdentityCount(socketPath), 2);
 });
 
 test("native OpenSSH modes reject Pageant and Cygwin-only adapters clearly", async () => {

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -33,6 +33,7 @@ const {
   findAllDefaultPrivateKeys: findAllDefaultPrivateKeysFromHelper,
   getSshAgentSocket,
   getAvailableAgentSocket: getAvailableSystemAgentSocket,
+  getAvailableForwardingAgentSocket,
   prepareSystemSshAgentForAuth,
   readFileNoFollow,
   expandIdentityFilePath,
@@ -959,7 +960,7 @@ const startSessionApi = createStartSessionApi({
   trackSessionIdlePrompt, looksLikeIdleAutoLogout, createZmodemSentry, enableSshNoDelay, enableTcpNoDelay,
   iconv, getSessionDecoder, resetSessionDecoders, sessionEncodings, sessionDecoders, encodeTerminalInput,
   normalizeTerminalEncoding,
-  connectThroughChain, getAvailableAgentSocket, getCachedAuthMethod, setCachedAuthMethod, clearCachedAuthMethod,
+  connectThroughChain, getAvailableAgentSocket, getAvailableForwardingAgentSocket, getCachedAuthMethod, setCachedAuthMethod, clearCachedAuthMethod,
   attachSshDebugLogger, logSshAlgorithms, safeSend, zmodemOverwritePending,
   shouldLogSshDebugMessage, log, createSshDiagnosticLogger,
   buildAlgorithms, randomUUID, findDefaultPrivateKey, findAllDefaultPrivateKeys,
@@ -1465,7 +1466,9 @@ function registerHandlers(ipcMain, options = {}) {
     if (process.platform === "win32" && !identityAgent) {
       return await checkWindowsSshAgent();
     }
-    const socketPath = await getAvailableSystemAgentSocket(identityAgent, typeof options === "string" ? {} : options);
+    const socketPath = options?.agentForwarding
+      ? await getAvailableForwardingAgentSocket(identityAgent, typeof options === "string" ? {} : options)
+      : await getAvailableSystemAgentSocket(identityAgent, typeof options === "string" ? {} : options);
     return {
       running: Boolean(socketPath),
       startupType: socketPath ? "running" : "stopped",

--- a/electron/bridges/sshBridge/startSession.agentForwarding.test.cjs
+++ b/electron/bridges/sshBridge/startSession.agentForwarding.test.cjs
@@ -9,7 +9,40 @@ const {
   shouldOfferAgentForLogin,
   shouldPrepareSystemAgentForLogin,
   shouldPromoteCachedAuthMethod,
+  prepareAgentForwardingOptions,
 } = require("./startSession.cjs");
+
+test("forwarding agent selection is resolved before connection reuse", async () => {
+  const calls = [];
+  const prepared = await prepareAgentForwardingOptions(
+    { agentForwarding: true, identityAgent: "none" },
+    async (identityAgent) => {
+      calls.push(identityAgent);
+      return "/Users/alice/.bitwarden-ssh-agent.sock";
+    },
+  );
+
+  assert.deepEqual(calls, ["none"]);
+  assert.equal(prepared._resolvedForwardingAgentSocket, "/Users/alice/.bitwarden-ssh-agent.sock");
+  assert.equal(prepared.forwardingAgentSocket, "/Users/alice/.bitwarden-ssh-agent.sock");
+});
+
+test("pre-resolved forwarding agent selection is reused during SSH setup", async () => {
+  const connectOptions = {};
+  await applyAgentForwarding(
+    {
+      agentForwarding: true,
+      _resolvedForwardingAgentSocket: "/Users/alice/.bitwarden-ssh-agent.sock",
+    },
+    connectOptions,
+    async () => {
+      throw new Error("forwarding socket should not be resolved twice");
+    },
+  );
+
+  assert.equal(connectOptions.agent, "/Users/alice/.bitwarden-ssh-agent.sock");
+  assert.equal(connectOptions.agentForward, true);
+});
 
 test("agent forwarding resolves the forwarding socket independently from login auth", async () => {
   const connectOptions = { password: "login-password" };

--- a/electron/bridges/sshBridge/startSession.agentForwarding.test.cjs
+++ b/electron/bridges/sshBridge/startSession.agentForwarding.test.cjs
@@ -43,7 +43,7 @@ test("agent forwarding replaces an automatically discovered empty login agent", 
   assert.equal(connectOptions.agentForward, true);
 });
 
-test("agent forwarding preserves an explicitly prepared login agent", async () => {
+test("agent forwarding configures ssh2 separately from an explicitly prepared login agent", async () => {
   const explicitAgent = { kind: "selected-agent" };
   const connectOptions = { agent: explicitAgent };
   let resolutions = 0;
@@ -57,9 +57,9 @@ test("agent forwarding preserves an explicitly prepared login agent", async () =
     },
   );
 
-  assert.equal(connectOptions.agent, explicitAgent);
+  assert.equal(connectOptions.agent, "/tmp/other-agent.sock");
   assert.equal(connectOptions.agentForward, true);
-  assert.equal(resolutions, 0);
+  assert.equal(resolutions, 1);
 });
 
 test("agent forwarding does not enable agent login after an explicit opt-out", () => {

--- a/electron/bridges/sshBridge/startSession.agentForwarding.test.cjs
+++ b/electron/bridges/sshBridge/startSession.agentForwarding.test.cjs
@@ -29,6 +29,39 @@ test("agent forwarding resolves the forwarding socket independently from login a
   assert.equal(connectOptions.agentForward, true);
 });
 
+test("agent forwarding replaces an automatically discovered empty login agent", async () => {
+  const connectOptions = { agent: "/private/tmp/com.apple.launchd.test/Listeners" };
+
+  await applyAgentForwarding(
+    { agentForwarding: true },
+    connectOptions,
+    async () => "/Users/alice/.bitwarden-ssh-agent.sock",
+    { replaceExistingAgent: true },
+  );
+
+  assert.equal(connectOptions.agent, "/Users/alice/.bitwarden-ssh-agent.sock");
+  assert.equal(connectOptions.agentForward, true);
+});
+
+test("agent forwarding preserves an explicitly prepared login agent", async () => {
+  const explicitAgent = { kind: "selected-agent" };
+  const connectOptions = { agent: explicitAgent };
+  let resolutions = 0;
+
+  await applyAgentForwarding(
+    { agentForwarding: true, identityAgent: "/tmp/selected-agent.sock" },
+    connectOptions,
+    async () => {
+      resolutions += 1;
+      return "/tmp/other-agent.sock";
+    },
+  );
+
+  assert.equal(connectOptions.agent, explicitAgent);
+  assert.equal(connectOptions.agentForward, true);
+  assert.equal(resolutions, 0);
+});
+
 test("agent forwarding does not enable agent login after an explicit opt-out", () => {
   assert.equal(shouldOfferAgentForLogin(
     { useSshAgent: false, agentForwarding: true },

--- a/electron/bridges/sshBridge/startSession.agentForwarding.test.cjs
+++ b/electron/bridges/sshBridge/startSession.agentForwarding.test.cjs
@@ -5,10 +5,29 @@ const assert = require("node:assert/strict");
 
 const {
   resolveUnlockedEncryptedKeysForAuth,
+  applyAgentForwarding,
   shouldOfferAgentForLogin,
   shouldPrepareSystemAgentForLogin,
   shouldPromoteCachedAuthMethod,
 } = require("./startSession.cjs");
+
+test("agent forwarding resolves the forwarding socket independently from login auth", async () => {
+  const connectOptions = { password: "login-password" };
+  const resolved = [];
+
+  await applyAgentForwarding(
+    { agentForwarding: true, useSshAgent: false },
+    connectOptions,
+    async (identityAgent) => {
+      resolved.push(identityAgent);
+      return "/Users/alice/.bitwarden-ssh-agent.sock";
+    },
+  );
+
+  assert.deepEqual(resolved, [undefined]);
+  assert.equal(connectOptions.agent, "/Users/alice/.bitwarden-ssh-agent.sock");
+  assert.equal(connectOptions.agentForward, true);
+});
 
 test("agent forwarding does not enable agent login after an explicit opt-out", () => {
   assert.equal(shouldOfferAgentForLogin(

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -153,12 +153,34 @@ async function applyAgentForwarding(
   resolveForwardingAgentSocket,
 ) {
   if (!options?.agentForwarding) return connectOpts;
-  const forwardingAgent = await resolveForwardingAgentSocket(options.identityAgent, options);
+  const alreadyResolved = Object.prototype.hasOwnProperty.call(
+    options,
+    "_resolvedForwardingAgentSocket",
+  );
+  const forwardingAgent = alreadyResolved
+    ? options._resolvedForwardingAgentSocket
+    : await resolveForwardingAgentSocket(options.identityAgent, options);
   if (forwardingAgent) {
     connectOpts.agent = forwardingAgent;
     connectOpts.agentForward = true;
   }
   return connectOpts;
+}
+
+async function prepareAgentForwardingOptions(options, resolveForwardingAgentSocket) {
+  if (!options?.agentForwarding) return options;
+  if (Object.prototype.hasOwnProperty.call(options, "_resolvedForwardingAgentSocket")) {
+    return {
+      ...options,
+      forwardingAgentSocket: options._resolvedForwardingAgentSocket || "",
+    };
+  }
+  const forwardingAgent = await resolveForwardingAgentSocket(options.identityAgent, options);
+  return {
+    ...options,
+    _resolvedForwardingAgentSocket: forwardingAgent || null,
+    forwardingAgentSocket: forwardingAgent || "",
+  };
 }
 
 function createStartSessionApi(ctx) {
@@ -831,6 +853,11 @@ printf '%s\n' '${scanCompleteMarker}'`;
           });
         }
       };
+
+      // Resolve forwarding before connection reuse so an agent-provider change
+      // (for example Bitwarden becoming available after unlock) cannot attach a
+      // new shell to a transport that still forwards the previous socket.
+      options = await prepareAgentForwardingOptions(options, getAvailableForwardingAgentSocket);
 
       // Connection reuse (issue #1204): when a tab is duplicated we try to open
       // a new shell channel on the source tab's already-authenticated
@@ -2177,4 +2204,5 @@ module.exports = {
   resolveUnlockedEncryptedKeysForAuth,
   shouldPromoteCachedAuthMethod,
   applyAgentForwarding,
+  prepareAgentForwardingOptions,
 };

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -151,13 +151,11 @@ async function applyAgentForwarding(
   options,
   connectOpts,
   resolveForwardingAgentSocket,
-  { replaceExistingAgent = false } = {},
 ) {
   if (!options?.agentForwarding) return connectOpts;
-  if (!connectOpts.agent || replaceExistingAgent) {
-    connectOpts.agent = await resolveForwardingAgentSocket(options.identityAgent, options);
-  }
-  if (connectOpts.agent) {
+  const forwardingAgent = await resolveForwardingAgentSocket(options.identityAgent, options);
+  if (forwardingAgent) {
+    connectOpts.agent = forwardingAgent;
     connectOpts.agentForward = true;
   }
   return connectOpts;
@@ -1045,7 +1043,6 @@ printf '%s\n' '${scanCompleteMarker}'`;
         });
 
         let authAgent = null;
-        let hasAutomaticallyDiscoveredAgent = false;
         const systemAuthAgent = shouldPrepareSystemAgentForLogin(options)
           ? await prepareSystemSshAgentForAuth(options, "[SSH]")
           : null;
@@ -1182,7 +1179,6 @@ printf '%s\n' '${scanCompleteMarker}'`;
           const automaticAgentSocket = await getAvailableAgentSocket();
           if (automaticAgentSocket) {
             connectOpts.agent = automaticAgentSocket;
-            hasAutomaticallyDiscoveredAgent = true;
             log("Automatic auth found SSH agent", { agentSocket: automaticAgentSocket });
           }
         }
@@ -1199,7 +1195,6 @@ printf '%s\n' '${scanCompleteMarker}'`;
           if (sshAgentSocket) {
             log("No auth method configured, trying ssh-agent first", { agentSocket: sshAgentSocket });
             connectOpts.agent = sshAgentSocket;
-            hasAutomaticallyDiscoveredAgent = true;
           }
 
           // Mark that we need to try all default keys (handled in authMethods below)
@@ -1221,14 +1216,13 @@ printf '%s\n' '${scanCompleteMarker}'`;
           isPasswordOnlyAuth,
         });
 
+        // ssh2 uses connectOpts.agent for forwarding, but authHandler agent
+        // objects may select a different agent for login.
+        const loginAgent = connectOpts.agent;
+
         // Agent forwarding
         if (options.agentForwarding) {
-          await applyAgentForwarding(
-            options,
-            connectOpts,
-            getAvailableForwardingAgentSocket,
-            { replaceExistingAgent: hasAutomaticallyDiscoveredAgent },
-          );
+          await applyAgentForwarding(options, connectOpts, getAvailableForwardingAgentSocket);
           if (!connectOpts.agentForward) {
             log("Agent forwarding requested but no agent available, skipping");
           }
@@ -1265,7 +1259,12 @@ printf '%s\n' '${scanCompleteMarker}'`;
           if (!order.includes("keyboard-interactive")) order.push("keyboard-interactive");
           // Function form so authPhase.hadPartialSuccess updates for cert/agent
           // first-factor + keyboard-interactive second-factor (#2150).
-          connectOpts.authHandler = createOrderedStringAuthHandler(order, authPhase);
+          connectOpts.authHandler = createOrderedStringAuthHandler(
+            order,
+            authPhase,
+            undefined,
+            { username: connectOpts.username, agent: authAgent },
+          );
           connectOpts._shouldRetryKeyboardInteractiveFirst = () => Boolean(authPhase.retryKeyboardInteractiveFirst);
           log("Auth order (agent mode)", { order, skipPasswordMethod: !!options._skipPasswordMethod });
         } else {
@@ -1276,8 +1275,8 @@ printf '%s\n' '${scanCompleteMarker}'`;
             if (options.requiresMfa && !connectOpts.password && !options._skipPasswordMethod) {
               authMethods.push({ type: "keyboard-interactive", id: "keyboard-interactive" });
             }
-            if (shouldOfferAgentForLogin(options, connectOpts)) {
-              authMethods.push({ type: "agent", id: "agent" });
+            if (shouldOfferAgentForLogin(options, { agent: loginAgent })) {
+              authMethods.push({ type: "agent", agent: loginAgent, id: "agent" });
             }
             if (connectOpts.privateKey && !usedDefaultKeyAsPrimary) {
               authMethods.push({ type: "publickey", key: connectOpts.privateKey, passphrase: connectOpts.passphrase, id: "publickey-user" });
@@ -1303,8 +1302,8 @@ printf '%s\n' '${scanCompleteMarker}'`;
             }
 
             // Then try agent if configured (try agent before password since it's usually faster)
-            if (shouldOfferAgentForLogin(options, connectOpts)) {
-              authMethods.push({ type: "agent", id: "agent" });
+            if (shouldOfferAgentForLogin(options, { agent: loginAgent })) {
+              authMethods.push({ type: "agent", agent: loginAgent, id: "agent" });
             }
 
             // MFA/PAM hosts can reject the SSH "password" method while accepting
@@ -1511,9 +1510,13 @@ printf '%s\n' '${scanCompleteMarker}'`;
                       password: connectOpts.password,
                     });
                   } else if (matchingMethod.type === "agent") {
-                    const agentType = typeof connectOpts.agent === "string" ? "path" : "NetcattyAgent";
+                    const agentType = typeof matchingMethod.agent === "string" ? "path" : "NetcattyAgent";
                     log("Trying agent auth (partial success)", { id: matchingMethod.id, agentType });
-                    return callback("agent");
+                    return callback({
+                      type: "agent",
+                      username: connectOpts.username,
+                      agent: matchingMethod.agent,
+                    });
                   } else if (matchingMethod.type === "publickey") {
                     log("Trying publickey auth (partial success)", { id: matchingMethod.id });
                     return callback({
@@ -1552,11 +1555,14 @@ printf '%s\n' '${scanCompleteMarker}'`;
 
                 if (method.type === "agent") {
                   // Only log safe identifier, not the full agent object which may contain private keys
-                  const agentType = typeof connectOpts.agent === "string" ? "path" : "NetcattyAgent";
+                  const agentType = typeof method.agent === "string" ? "path" : "NetcattyAgent";
                   log("Trying agent auth", { id: method.id, agentType });
                   sendProgress(totalHops, totalHops, options.hostname, 'auth-attempt', 'SSH agent');
-                  // Return "agent" string to use SSH agent for authentication
-                  return callback("agent");
+                  return callback({
+                    type: "agent",
+                    username: connectOpts.username,
+                    agent: method.agent,
+                  });
                 } else if (method.type === "publickey") {
                   log("Trying publickey auth", { id: method.id, isDefault: method.isDefault || false });
                   const keyLabel = method.id.startsWith("publickey-default-")
@@ -2092,14 +2098,19 @@ printf '%s\n' '${scanCompleteMarker}'`;
             // Using array format is more reliable - ssh2 uses connectOpts credentials directly
             const authMethods = [];
             // Try agent FIRST (this is what regular SSH does - it checks ssh-agent before key files)
-            if (connectOpts.agent) authMethods.push("agent");
+            if (loginAgent) authMethods.push("agent");
             if (connectOpts.privateKey) authMethods.push("publickey");
             if (connectOpts.password && !options._skipPasswordMethod) {
               authMethods.push("password");
             }
             authMethods.push("keyboard-interactive");
             const dedupedAuthMethods = Array.from(new Set(authMethods));
-            connectOpts.authHandler = dedupedAuthMethods;
+            connectOpts.authHandler = createOrderedStringAuthHandler(
+              dedupedAuthMethods,
+              createAuthPhase(),
+              undefined,
+              { username: connectOpts.username, agent: loginAgent },
+            );
             log("Using simple array authHandler", {
               authMethods: dedupedAuthMethods,
               usedDefaultKeyAsPrimary,

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -147,9 +147,14 @@ function shouldPromoteCachedAuthMethod(authMethod, cachedMethod) {
   return true;
 }
 
-async function applyAgentForwarding(options, connectOpts, resolveForwardingAgentSocket) {
+async function applyAgentForwarding(
+  options,
+  connectOpts,
+  resolveForwardingAgentSocket,
+  { replaceExistingAgent = false } = {},
+) {
   if (!options?.agentForwarding) return connectOpts;
-  if (!connectOpts.agent) {
+  if (!connectOpts.agent || replaceExistingAgent) {
     connectOpts.agent = await resolveForwardingAgentSocket(options.identityAgent, options);
   }
   if (connectOpts.agent) {
@@ -1040,6 +1045,7 @@ printf '%s\n' '${scanCompleteMarker}'`;
         });
 
         let authAgent = null;
+        let hasAutomaticallyDiscoveredAgent = false;
         const systemAuthAgent = shouldPrepareSystemAgentForLogin(options)
           ? await prepareSystemSshAgentForAuth(options, "[SSH]")
           : null;
@@ -1176,6 +1182,7 @@ printf '%s\n' '${scanCompleteMarker}'`;
           const automaticAgentSocket = await getAvailableAgentSocket();
           if (automaticAgentSocket) {
             connectOpts.agent = automaticAgentSocket;
+            hasAutomaticallyDiscoveredAgent = true;
             log("Automatic auth found SSH agent", { agentSocket: automaticAgentSocket });
           }
         }
@@ -1192,6 +1199,7 @@ printf '%s\n' '${scanCompleteMarker}'`;
           if (sshAgentSocket) {
             log("No auth method configured, trying ssh-agent first", { agentSocket: sshAgentSocket });
             connectOpts.agent = sshAgentSocket;
+            hasAutomaticallyDiscoveredAgent = true;
           }
 
           // Mark that we need to try all default keys (handled in authMethods below)
@@ -1215,7 +1223,12 @@ printf '%s\n' '${scanCompleteMarker}'`;
 
         // Agent forwarding
         if (options.agentForwarding) {
-          await applyAgentForwarding(options, connectOpts, getAvailableForwardingAgentSocket);
+          await applyAgentForwarding(
+            options,
+            connectOpts,
+            getAvailableForwardingAgentSocket,
+            { replaceExistingAgent: hasAutomaticallyDiscoveredAgent },
+          );
           if (!connectOpts.agentForward) {
             log("Agent forwarding requested but no agent available, skipping");
           }

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -1290,7 +1290,9 @@ printf '%s\n' '${scanCompleteMarker}'`;
             order,
             authPhase,
             undefined,
-            { username: connectOpts.username, agent: authAgent },
+            authAgent !== connectOpts.agent
+              ? { username: connectOpts.username, agent: authAgent }
+              : undefined,
           );
           connectOpts._shouldRetryKeyboardInteractiveFirst = () => Boolean(authPhase.retryKeyboardInteractiveFirst);
           log("Auth order (agent mode)", { order, skipPasswordMethod: !!options._skipPasswordMethod });
@@ -1539,11 +1541,13 @@ printf '%s\n' '${scanCompleteMarker}'`;
                   } else if (matchingMethod.type === "agent") {
                     const agentType = typeof matchingMethod.agent === "string" ? "path" : "NetcattyAgent";
                     log("Trying agent auth (partial success)", { id: matchingMethod.id, agentType });
-                    return callback({
-                      type: "agent",
-                      username: connectOpts.username,
-                      agent: matchingMethod.agent,
-                    });
+                    return matchingMethod.agent === connectOpts.agent
+                      ? callback("agent")
+                      : callback({
+                        type: "agent",
+                        username: connectOpts.username,
+                        agent: matchingMethod.agent,
+                      });
                   } else if (matchingMethod.type === "publickey") {
                     log("Trying publickey auth (partial success)", { id: matchingMethod.id });
                     return callback({
@@ -1585,11 +1589,13 @@ printf '%s\n' '${scanCompleteMarker}'`;
                   const agentType = typeof method.agent === "string" ? "path" : "NetcattyAgent";
                   log("Trying agent auth", { id: method.id, agentType });
                   sendProgress(totalHops, totalHops, options.hostname, 'auth-attempt', 'SSH agent');
-                  return callback({
-                    type: "agent",
-                    username: connectOpts.username,
-                    agent: method.agent,
-                  });
+                  return method.agent === connectOpts.agent
+                    ? callback("agent")
+                    : callback({
+                      type: "agent",
+                      username: connectOpts.username,
+                      agent: method.agent,
+                    });
                 } else if (method.type === "publickey") {
                   log("Trying publickey auth", { id: method.id, isDefault: method.isDefault || false });
                   const keyLabel = method.id.startsWith("publickey-default-")
@@ -2136,7 +2142,9 @@ printf '%s\n' '${scanCompleteMarker}'`;
               dedupedAuthMethods,
               createAuthPhase(),
               undefined,
-              { username: connectOpts.username, agent: loginAgent },
+              loginAgent !== connectOpts.agent
+                ? { username: connectOpts.username, agent: loginAgent }
+                : undefined,
             );
             log("Using simple array authHandler", {
               authMethods: dedupedAuthMethods,

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -147,6 +147,17 @@ function shouldPromoteCachedAuthMethod(authMethod, cachedMethod) {
   return true;
 }
 
+async function applyAgentForwarding(options, connectOpts, resolveForwardingAgentSocket) {
+  if (!options?.agentForwarding) return connectOpts;
+  if (!connectOpts.agent) {
+    connectOpts.agent = await resolveForwardingAgentSocket(options.identityAgent, options);
+  }
+  if (connectOpts.agent) {
+    connectOpts.agentForward = true;
+  }
+  return connectOpts;
+}
+
 function createStartSessionApi(ctx) {
   with (ctx) {
     const listInteractiveShellPids = async (conn) => {
@@ -1204,13 +1215,8 @@ printf '%s\n' '${scanCompleteMarker}'`;
 
         // Agent forwarding
         if (options.agentForwarding) {
-          if (!connectOpts.agent) {
-            connectOpts.agent = await getAvailableAgentSocket();
-          }
-          // Only enable forwarding when an agent is actually available
-          if (connectOpts.agent) {
-            connectOpts.agentForward = true;
-          } else {
+          await applyAgentForwarding(options, connectOpts, getAvailableForwardingAgentSocket);
+          if (!connectOpts.agentForward) {
             log("Agent forwarding requested but no agent available, skipping");
           }
         }
@@ -2146,4 +2152,5 @@ module.exports = {
   shouldPrepareSystemAgentForLogin,
   resolveUnlockedEncryptedKeysForAuth,
   shouldPromoteCachedAuthMethod,
+  applyAgentForwarding,
 };

--- a/electron/bridges/sshConnectionPool.cjs
+++ b/electron/bridges/sshConnectionPool.cjs
@@ -450,6 +450,9 @@ function fingerprintAuth(endpoint) {
     addKeysToAgent: endpoint.addKeysToAgent ?? null,
     useKeychain: endpoint.useKeychain ?? null,
     agentPublicKeys: endpoint.agentPublicKeys ?? null,
+    forwardingAgentSocket: endpoint.agentForwarding
+      ? endpoint.forwardingAgentSocket ?? null
+      : null,
     legacyAlgorithms: endpoint.legacyAlgorithms ?? null,
     skipEcdsaHostKey: endpoint.skipEcdsaHostKey ?? null,
     algorithmOverrides: endpoint.algorithmOverrides ?? null,
@@ -509,6 +512,7 @@ function buildConnectionReuseEndpoint(options = {}, overrides = {}) {
     useKeychain: options.useKeychain,
     agentPublicKeys: options.agentPublicKeys,
     agentForwarding: Boolean(overrides.agentForwarding ?? options.agentForwarding),
+    forwardingAgentSocket: options.forwardingAgentSocket || "",
     ...keepalive,
     password: options.password,
     privateKey: options.privateKey,

--- a/electron/bridges/sshConnectionPool.cjs
+++ b/electron/bridges/sshConnectionPool.cjs
@@ -450,9 +450,6 @@ function fingerprintAuth(endpoint) {
     addKeysToAgent: endpoint.addKeysToAgent ?? null,
     useKeychain: endpoint.useKeychain ?? null,
     agentPublicKeys: endpoint.agentPublicKeys ?? null,
-    forwardingAgentSocket: endpoint.agentForwarding
-      ? endpoint.forwardingAgentSocket ?? null
-      : null,
     legacyAlgorithms: endpoint.legacyAlgorithms ?? null,
     skipEcdsaHostKey: endpoint.skipEcdsaHostKey ?? null,
     algorithmOverrides: endpoint.algorithmOverrides ?? null,
@@ -559,6 +556,11 @@ function normalizeEndpoint(endpoint) {
     // A transport opened with ForwardAgent can serve SFTP/PF; a transport
     // without it cannot satisfy a later shell open that needs agentForwarding.
     agentForwarding: Boolean(endpoint.agentForwarding),
+    forwardingAgentFingerprint: endpoint.forwardingAgentFingerprint
+      ? String(endpoint.forwardingAgentFingerprint)
+      : endpoint.agentForwarding && endpoint.forwardingAgentSocket
+        ? secureDigest(String(endpoint.forwardingAgentSocket))
+        : "-",
     ...keepalive,
   };
 }
@@ -622,7 +624,9 @@ function endpointAllowsReuse(requested, existing, kind = "channel") {
   const have = normalizeEndpoint(existing);
   if (!req || !have) return false;
   if (kind === "shell") {
-    return req.agentForwarding === have.agentForwarding;
+    return req.agentForwarding === have.agentForwarding
+      && (!req.agentForwarding
+        || req.forwardingAgentFingerprint === have.forwardingAgentFingerprint);
   }
   if (req.agentForwarding && !have.agentForwarding) return false;
   return true;
@@ -1216,6 +1220,7 @@ function createConnectionRef(session, conn, chainConnections) {
       verifyHostKeys: session._reuseEndpoint.verifyHostKeys,
       useSshAgent: session._reuseEndpoint.useSshAgent,
       agentForwarding: session._reuseEndpoint.agentForwarding,
+      forwardingAgentFingerprint: session._reuseEndpoint.forwardingAgentFingerprint,
       keepaliveIntervalMs: session._reuseEndpoint.keepaliveIntervalMs,
       keepaliveCountMax: session._reuseEndpoint.keepaliveCountMax,
       authFingerprint: session._reuseEndpoint.authFingerprint,

--- a/electron/bridges/sshConnectionPool.test.cjs
+++ b/electron/bridges/sshConnectionPool.test.cjs
@@ -635,7 +635,7 @@ test("fingerprintAuth changes when credential material rotates under same keyId"
   );
 });
 
-test("forwarding socket changes invalidate connection reuse", () => {
+test("forwarding socket changes invalidate shell reuse without blocking channel reuse", () => {
   const base = {
     hostname: "h.example",
     username: "alice",
@@ -643,14 +643,31 @@ test("forwarding socket changes invalidate connection reuse", () => {
     password: "secret",
     agentForwarding: true,
   };
-  assert.notEqual(
-    fingerprintAuth({ ...base, forwardingAgentSocket: "/tmp/apple-agent.sock" }),
-    fingerprintAuth({ ...base, forwardingAgentSocket: "/Users/alice/.bitwarden-ssh-agent.sock" }),
-  );
+  const apple = { ...base, forwardingAgentSocket: "/tmp/apple-agent.sock" };
+  const bitwarden = {
+    ...base,
+    forwardingAgentSocket: "/Users/alice/.bitwarden-ssh-agent.sock",
+  };
   assert.equal(
-    fingerprintAuth({ ...base, agentForwarding: false, forwardingAgentSocket: "/tmp/one.sock" }),
-    fingerprintAuth({ ...base, agentForwarding: false, forwardingAgentSocket: "/tmp/two.sock" }),
+    fingerprintAuth(apple),
+    fingerprintAuth(bitwarden),
   );
+  assert.equal(buildEndpointKey(apple), buildEndpointKey(bitwarden));
+  assert.equal(endpointAllowsReuse(bitwarden, apple, "shell"), false);
+  assert.equal(endpointAllowsReuse(
+    { ...base, agentForwarding: false },
+    apple,
+    "channel",
+  ), true);
+
+  resetSshTransportRegistryForTests({ defaultIdleTtlMs: 0 });
+  const transport = createTransport({ conn: makeConn(), endpoint: apple });
+  assert.equal(
+    findTransportByEndpoint({ ...base, agentForwarding: false }),
+    transport,
+  );
+  assert.equal(findTransportByEndpoint(bitwarden, { kind: "shell" }), null);
+  resetSshTransportRegistryForTests({ defaultIdleTtlMs: 0 });
 });
 
 test("automatic key success reuses an unchanged endpoint without exposing credentials", () => {

--- a/electron/bridges/sshConnectionPool.test.cjs
+++ b/electron/bridges/sshConnectionPool.test.cjs
@@ -635,6 +635,24 @@ test("fingerprintAuth changes when credential material rotates under same keyId"
   );
 });
 
+test("forwarding socket changes invalidate connection reuse", () => {
+  const base = {
+    hostname: "h.example",
+    username: "alice",
+    authType: "password",
+    password: "secret",
+    agentForwarding: true,
+  };
+  assert.notEqual(
+    fingerprintAuth({ ...base, forwardingAgentSocket: "/tmp/apple-agent.sock" }),
+    fingerprintAuth({ ...base, forwardingAgentSocket: "/Users/alice/.bitwarden-ssh-agent.sock" }),
+  );
+  assert.equal(
+    fingerprintAuth({ ...base, agentForwarding: false, forwardingAgentSocket: "/tmp/one.sock" }),
+    fingerprintAuth({ ...base, agentForwarding: false, forwardingAgentSocket: "/tmp/two.sock" }),
+  );
+});
+
 test("automatic key success reuses an unchanged endpoint without exposing credentials", () => {
   const endpoint = buildConnectionReuseEndpoint({
     hostId: "auto-key-profile",

--- a/electron/bridges/terminalBridge.bareMoshClient.test.cjs
+++ b/electron/bridges/terminalBridge.bareMoshClient.test.cjs
@@ -329,6 +329,32 @@ test("Mosh keeps its login agent separate from the discovered forwarding agent",
   }
 });
 
+test("Mosh forwards a Windows named-pipe agent through SSH_AUTH_SOCK", async () => {
+  const forwardingAgent = "\\\\.\\pipe\\openssh-ssh-agent";
+  const processMock = Object.create(process);
+  Object.defineProperty(processMock, "platform", { value: "win32" });
+  processMock.env = {};
+  const api = createMoshSessionApi({
+    os,
+    path,
+    fs,
+    process: processMock,
+    randomUUID: () => "fixed",
+  });
+  const prepared = {
+    useSshAgent: false,
+    agentForwarding: true,
+    _resolvedForwardingAgentSocket: forwardingAgent,
+  };
+
+  const env = api.applyMoshSshAgentEnvironment({}, prepared);
+  const auth = await api.buildMoshSshAuthArgs(prepared, "session-windows-forwarding");
+
+  assert.equal(env.SSH_AUTH_SOCK, forwardingAgent);
+  assert.ok(auth.sshArgs.includes("ForwardAgent=${SSH_AUTH_SOCK}"));
+  assert.equal(auth.sshArgs.some((arg) => arg.includes(forwardingAgent)), false);
+});
+
 test("Mosh automatic mode discovers custom local keys in preferred order", async (t) => {
   const tempBase = makeTmp();
   const fakeHome = path.join(tempBase, "home");

--- a/electron/bridges/terminalBridge.bareMoshClient.test.cjs
+++ b/electron/bridges/terminalBridge.bareMoshClient.test.cjs
@@ -292,21 +292,23 @@ test("Mosh explicitly disables native agent login after an opt-out", async () =>
   );
   assert.deepEqual(forwardingAuth.sshArgs, [
     "-o", "IdentityAgent=none",
-    "-o", "ForwardAgent=${SSH_AUTH_SOCK}",
     "-o", "StrictHostKeyChecking=ask",
   ]);
-  assert.equal(forwardingEnv.SSH_AUTH_SOCK, "/tmp/forwarded-agent.sock");
+  assert.equal(forwardingEnv.SSH_AUTH_SOCK, undefined);
 });
 
-test("Mosh forwarding replaces an empty inherited agent with the discovered agent", async () => {
+test("Mosh keeps its login agent separate from the discovered forwarding agent", async () => {
+  const localAgent = "/private/tmp/com.apple.launchd.test/Listeners";
+  const forwardingAgent = "/Users/alice/.bitwarden-ssh-agent.sock";
   const api = createMoshSessionApi({
     os,
     path,
     fs,
-    process,
+    process: { ...process, env: { SSH_AUTH_SOCK: localAgent } },
     randomUUID: () => "fixed",
     prepareSystemSshAgentForAuth: async () => {},
-    getAvailableForwardingAgentSocket: async () => "/Users/alice/.bitwarden-ssh-agent.sock",
+    getAvailableAgentSocket: async () => localAgent,
+    getAvailableForwardingAgentSocket: async () => forwardingAgent,
   });
 
   for (const useSshAgent of [false, undefined, true]) {
@@ -315,14 +317,15 @@ test("Mosh forwarding replaces an empty inherited agent with the discovered agen
       agentForwarding: true,
     });
     const env = api.applyMoshSshAgentEnvironment(
-      { SSH_AUTH_SOCK: "/private/tmp/com.apple.launchd.test/Listeners" },
+      { SSH_AUTH_SOCK: "/tmp/remote-agent.sock" },
       prepared,
     );
     const auth = await api.buildMoshSshAuthArgs(prepared, `session-forwarding-${String(useSshAgent)}`);
 
-    assert.equal(prepared._resolvedSshAgentSocket, "/Users/alice/.bitwarden-ssh-agent.sock");
-    assert.equal(env.SSH_AUTH_SOCK, "/Users/alice/.bitwarden-ssh-agent.sock");
-    assert.ok(auth.sshArgs.includes("ForwardAgent=${SSH_AUTH_SOCK}"));
+    assert.equal(prepared._resolvedSshAgentSocket, useSshAgent === true ? localAgent : undefined);
+    assert.equal(prepared._resolvedForwardingAgentSocket, forwardingAgent);
+    assert.equal(env.SSH_AUTH_SOCK, useSshAgent === false ? undefined : localAgent);
+    assert.ok(auth.sshArgs.includes(`ForwardAgent=${forwardingAgent}`));
   }
 });
 

--- a/electron/bridges/terminalBridge.bareMoshClient.test.cjs
+++ b/electron/bridges/terminalBridge.bareMoshClient.test.cjs
@@ -298,6 +298,29 @@ test("Mosh explicitly disables native agent login after an opt-out", async () =>
   assert.equal(forwardingEnv.SSH_AUTH_SOCK, "/tmp/forwarded-agent.sock");
 });
 
+test("Mosh forwarding replaces an empty inherited agent with the discovered agent", async () => {
+  const api = createMoshSessionApi({
+    os,
+    path,
+    fs,
+    process,
+    randomUUID: () => "fixed",
+    getAvailableForwardingAgentSocket: async () => "/Users/alice/.bitwarden-ssh-agent.sock",
+  });
+
+  const prepared = await api.prepareMoshSshAgentOptions({
+    useSshAgent: false,
+    agentForwarding: true,
+  });
+  const env = api.applyMoshSshAgentEnvironment(
+    { SSH_AUTH_SOCK: "/private/tmp/com.apple.launchd.test/Listeners" },
+    prepared,
+  );
+
+  assert.equal(prepared._resolvedSshAgentSocket, "/Users/alice/.bitwarden-ssh-agent.sock");
+  assert.equal(env.SSH_AUTH_SOCK, "/Users/alice/.bitwarden-ssh-agent.sock");
+});
+
 test("Mosh automatic mode discovers custom local keys in preferred order", async (t) => {
   const tempBase = makeTmp();
   const fakeHome = path.join(tempBase, "home");

--- a/electron/bridges/terminalBridge.bareMoshClient.test.cjs
+++ b/electron/bridges/terminalBridge.bareMoshClient.test.cjs
@@ -305,20 +305,25 @@ test("Mosh forwarding replaces an empty inherited agent with the discovered agen
     fs,
     process,
     randomUUID: () => "fixed",
+    prepareSystemSshAgentForAuth: async () => {},
     getAvailableForwardingAgentSocket: async () => "/Users/alice/.bitwarden-ssh-agent.sock",
   });
 
-  const prepared = await api.prepareMoshSshAgentOptions({
-    useSshAgent: false,
-    agentForwarding: true,
-  });
-  const env = api.applyMoshSshAgentEnvironment(
-    { SSH_AUTH_SOCK: "/private/tmp/com.apple.launchd.test/Listeners" },
-    prepared,
-  );
+  for (const useSshAgent of [false, undefined, true]) {
+    const prepared = await api.prepareMoshSshAgentOptions({
+      useSshAgent,
+      agentForwarding: true,
+    });
+    const env = api.applyMoshSshAgentEnvironment(
+      { SSH_AUTH_SOCK: "/private/tmp/com.apple.launchd.test/Listeners" },
+      prepared,
+    );
+    const auth = await api.buildMoshSshAuthArgs(prepared, `session-forwarding-${String(useSshAgent)}`);
 
-  assert.equal(prepared._resolvedSshAgentSocket, "/Users/alice/.bitwarden-ssh-agent.sock");
-  assert.equal(env.SSH_AUTH_SOCK, "/Users/alice/.bitwarden-ssh-agent.sock");
+    assert.equal(prepared._resolvedSshAgentSocket, "/Users/alice/.bitwarden-ssh-agent.sock");
+    assert.equal(env.SSH_AUTH_SOCK, "/Users/alice/.bitwarden-ssh-agent.sock");
+    assert.ok(auth.sshArgs.includes("ForwardAgent=${SSH_AUTH_SOCK}"));
+  }
 });
 
 test("Mosh automatic mode discovers custom local keys in preferred order", async (t) => {

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -71,6 +71,7 @@ const { isTerminalReportSequence } = require("./terminalReportSequence.cjs");
 const { receiveYmodemFiles, sendYmodemCancel, sendYmodemFile } = require("./ymodemTransfer.cjs");
 const {
   getNativeOpenSshAgentSocket,
+  getNativeOpenSshForwardingAgentSocket,
   prepareSystemSshAgentForAuth,
 } = require("./sshAuthHelper.cjs");
 
@@ -1112,6 +1113,7 @@ const moshSessionApi = createMoshSessionApi({
   get selectZmodemDownloadDirectory() { return selectZmodemDownloadDirectory; },
   ensureMoshStatsConnection: (...args) => require("./sshBridge.cjs").ensureMoshStatsConnection(...args),
   getAvailableAgentSocket: getNativeOpenSshAgentSocket,
+  getAvailableForwardingAgentSocket: getNativeOpenSshForwardingAgentSocket,
   prepareSystemSshAgentForAuth,
   bundledMoshClient: (...args) => bundledMoshClient(...args),
 });
@@ -1143,6 +1145,7 @@ const etSessionApi = createEtSessionApi({
   findExecutable,
   openTerminalOutputSession, closeTerminalOutputSession,
   getAvailableAgentSocket: getNativeOpenSshAgentSocket,
+  getAvailableForwardingAgentSocket: getNativeOpenSshForwardingAgentSocket,
   prepareSystemSshAgentForAuth,
   get selectZmodemUploadFiles() { return selectZmodemUploadFiles; },
   get selectZmodemDownloadDirectory() { return selectZmodemDownloadDirectory; },

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -476,10 +476,10 @@ main();
 
       if (options.useSshAgent === false) {
         configLines.push("IdentityAgent none");
-        if (options.agentForwarding) configLines.push("ForwardAgent ${SSH_AUTH_SOCK}");
       } else if (options.useSshAgent && options._resolvedSshAgentSocket) {
         configLines.push(`IdentityAgent ${quoteRawSshConfigValue(options._resolvedSshAgentSocket)}`);
       }
+      if (options.agentForwarding) configLines.push("ForwardAgent ${SSH_AUTH_SOCK}");
 
       // Private key
       const identityPaths = [];

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -478,10 +478,6 @@ main();
       } else if (options.useSshAgent && options._resolvedSshAgentSocket) {
         configLines.push(`IdentityAgent ${quoteRawSshConfigValue(options._resolvedSshAgentSocket)}`);
       }
-      if (options.agentForwarding && options._resolvedForwardingAgentSocket) {
-        configLines.push(`ForwardAgent ${quoteRawSshConfigValue(options._resolvedForwardingAgentSocket)}`);
-      }
-
       // Private key
       const identityPaths = [];
       let tempKeyPath = null;
@@ -1170,7 +1166,7 @@ main();
         const preparedOptions = await prepareEtSshAgentOptions(options);
         options = preparedOptions;
         if (options.agentForwarding && options._resolvedForwardingAgentSocket) {
-          args.push("-f");
+          args.push("-f", "--ssh-socket", options._resolvedForwardingAgentSocket);
         }
         sshEnvironment = prepareEtSshEnvironment(sessionId, preparedOptions);
       } catch (err) {

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -161,11 +161,19 @@ main();
 
     async function prepareEtSshAgentOptions(options) {
       const prepareOne = async (connectionOptions, logPrefix) => {
-        if (connectionOptions?.useSshAgent !== true) return connectionOptions;
-        await prepareSystemSshAgentForAuth(connectionOptions, logPrefix);
-        const socketPath = await getAvailableAgentSocket(connectionOptions.identityAgent, connectionOptions);
+        if (connectionOptions?.useSshAgent !== true && !connectionOptions?.agentForwarding) return connectionOptions;
+        if (connectionOptions.useSshAgent === true) {
+          await prepareSystemSshAgentForAuth(connectionOptions, logPrefix);
+        }
+        const resolveSocket = connectionOptions.agentForwarding
+          ? getAvailableForwardingAgentSocket
+          : getAvailableAgentSocket;
+        const socketPath = await resolveSocket(connectionOptions.identityAgent, connectionOptions);
         if (!socketPath) {
-          throw new Error("System SSH agent is unavailable. Start or unlock it, or configure a valid agent socket.");
+          if (connectionOptions.useSshAgent === true) {
+            throw new Error("System SSH agent is unavailable. Start or unlock it, or configure a valid agent socket.");
+          }
+          return connectionOptions;
         }
         return { ...connectionOptions, _resolvedSshAgentSocket: socketPath };
       };
@@ -187,7 +195,9 @@ main();
           jump?.authMethod === "auto" && jump.useSshAgent !== false
         ));
         if (options.agentForwarding || automaticJumpNeedsAmbientAgent) {
-          if (!env.SSH_AUTH_SOCK && process.env.SSH_AUTH_SOCK) {
+          if (options._resolvedSshAgentSocket) {
+            env.SSH_AUTH_SOCK = options._resolvedSshAgentSocket;
+          } else if (!env.SSH_AUTH_SOCK && process.env.SSH_AUTH_SOCK) {
             env.SSH_AUTH_SOCK = process.env.SSH_AUTH_SOCK;
           }
         } else {

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -162,20 +162,25 @@ main();
     async function prepareEtSshAgentOptions(options) {
       const prepareOne = async (connectionOptions, logPrefix) => {
         if (connectionOptions?.useSshAgent !== true && !connectionOptions?.agentForwarding) return connectionOptions;
+        let prepared = connectionOptions;
         if (connectionOptions.useSshAgent === true) {
           await prepareSystemSshAgentForAuth(connectionOptions, logPrefix);
-        }
-        const resolveSocket = connectionOptions.agentForwarding
-          ? getAvailableForwardingAgentSocket
-          : getAvailableAgentSocket;
-        const socketPath = await resolveSocket(connectionOptions.identityAgent, connectionOptions);
-        if (!socketPath) {
-          if (connectionOptions.useSshAgent === true) {
+          const loginSocketPath = await getAvailableAgentSocket(connectionOptions.identityAgent, connectionOptions);
+          if (!loginSocketPath) {
             throw new Error("System SSH agent is unavailable. Start or unlock it, or configure a valid agent socket.");
           }
-          return connectionOptions;
+          prepared = { ...prepared, _resolvedSshAgentSocket: loginSocketPath };
         }
-        return { ...connectionOptions, _resolvedSshAgentSocket: socketPath };
+        if (connectionOptions.agentForwarding) {
+          const forwardingSocketPath = await getAvailableForwardingAgentSocket(
+            connectionOptions.identityAgent,
+            connectionOptions,
+          );
+          if (forwardingSocketPath) {
+            prepared = { ...prepared, _resolvedForwardingAgentSocket: forwardingSocketPath };
+          }
+        }
+        return prepared;
       };
 
       const preparedTarget = await prepareOne(options, "[ET]");
@@ -190,23 +195,17 @@ main();
     }
 
     function applyEtSshAgentEnvironment(env, options) {
+      delete env.SSH_AUTH_SOCK;
       if (options?.useSshAgent === false) {
         const automaticJumpNeedsAmbientAgent = options.jumpHosts?.some((jump) => (
           jump?.authMethod === "auto" && jump.useSshAgent !== false
         ));
-        if (options.agentForwarding || automaticJumpNeedsAmbientAgent) {
-          if (options._resolvedSshAgentSocket) {
-            env.SSH_AUTH_SOCK = options._resolvedSshAgentSocket;
-          } else if (!env.SSH_AUTH_SOCK && process.env.SSH_AUTH_SOCK) {
-            env.SSH_AUTH_SOCK = process.env.SSH_AUTH_SOCK;
-          }
-        } else {
-          delete env.SSH_AUTH_SOCK;
+        if (automaticJumpNeedsAmbientAgent && process.env.SSH_AUTH_SOCK) {
+          env.SSH_AUTH_SOCK = process.env.SSH_AUTH_SOCK;
         }
         return env;
       }
-      const socketPath = options?._resolvedSshAgentSocket
-        || (options?.agentForwarding ? process.env.SSH_AUTH_SOCK : undefined);
+      const socketPath = options?._resolvedSshAgentSocket || process.env.SSH_AUTH_SOCK;
       if (socketPath) env.SSH_AUTH_SOCK = socketPath;
       return env;
     }
@@ -479,7 +478,9 @@ main();
       } else if (options.useSshAgent && options._resolvedSshAgentSocket) {
         configLines.push(`IdentityAgent ${quoteRawSshConfigValue(options._resolvedSshAgentSocket)}`);
       }
-      if (options.agentForwarding) configLines.push("ForwardAgent ${SSH_AUTH_SOCK}");
+      if (options.agentForwarding && options._resolvedForwardingAgentSocket) {
+        configLines.push(`ForwardAgent ${quoteRawSshConfigValue(options._resolvedForwardingAgentSocket)}`);
+      }
 
       // Private key
       const identityPaths = [];
@@ -1164,15 +1165,13 @@ main();
         args.push("-p", String(options.etPort));
       }
 
-      // SSH Agent forwarding (ET supports -f natively)
-      if (options.agentForwarding) {
-        args.push("-f");
-      }
-
       let sshEnvironment;
       try {
         const preparedOptions = await prepareEtSshAgentOptions(options);
         options = preparedOptions;
+        if (options.agentForwarding && options._resolvedForwardingAgentSocket) {
+          args.push("-f");
+        }
         sshEnvironment = prepareEtSshEnvironment(sessionId, preparedOptions);
       } catch (err) {
         throw new Error(err instanceof Error ? err.message : String(err));

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -599,22 +599,31 @@ test("ET explicitly disables native agent login for target and jump hosts", (t) 
 
 test("ET forwarding replaces an empty inherited agent with the discovered agent", async (t) => {
   const { api } = makeApi(t, {
+    prepareSystemSshAgentForAuth: async () => {},
     getAvailableForwardingAgentSocket: async () => "/Users/alice/.bitwarden-ssh-agent.sock",
   });
 
-  const prepared = await api.prepareEtSshAgentOptions({
-    hostname: "host.example",
-    username: "alice",
-    useSshAgent: false,
-    agentForwarding: true,
-  });
-  const env = api.applyEtSshAgentEnvironment(
-    { SSH_AUTH_SOCK: "/private/tmp/com.apple.launchd.test/Listeners" },
-    prepared,
-  );
+  for (const useSshAgent of [false, undefined, true]) {
+    const prepared = await api.prepareEtSshAgentOptions({
+      hostname: `host-${String(useSshAgent)}.example`,
+      username: "alice",
+      useSshAgent,
+      agentForwarding: true,
+    });
+    const env = api.applyEtSshAgentEnvironment(
+      { SSH_AUTH_SOCK: "/private/tmp/com.apple.launchd.test/Listeners" },
+      prepared,
+    );
+    const preparedEnvironment = api.prepareEtSshEnvironment(
+      `session-forwarding-${String(useSshAgent)}`,
+      prepared,
+    );
+    const config = fs.readFileSync(path.join(preparedEnvironment.env.HOME, ".ssh", "config"), "utf8");
 
-  assert.equal(prepared._resolvedSshAgentSocket, "/Users/alice/.bitwarden-ssh-agent.sock");
-  assert.equal(env.SSH_AUTH_SOCK, "/Users/alice/.bitwarden-ssh-agent.sock");
+    assert.equal(prepared._resolvedSshAgentSocket, "/Users/alice/.bitwarden-ssh-agent.sock");
+    assert.equal(env.SSH_AUTH_SOCK, "/Users/alice/.bitwarden-ssh-agent.sock");
+    assert.match(config, /ForwardAgent \$\{SSH_AUTH_SOCK\}/);
+  }
 });
 
 test("ET prepares target and jump agents before generating their host config", async (t) => {

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -114,6 +114,46 @@ test("startEtSession preserves discovered automatic identities for host informat
   assert.equal(sessions.get("sess-auto-stats").etStatsAuth.authMethod, "auto");
 });
 
+test("startEtSession passes the selected forwarding socket to the bundled ET client", async (t) => {
+  const forwardingAgent = "/Users/alice/.bitwarden-ssh-agent.sock";
+  let spawnArgs = null;
+  const proc = {
+    onData() {},
+    onExit() {},
+    write() {},
+  };
+  const { api } = makeApi(t, {
+    bundledEtClient: () => "/fake/et",
+    getAvailableForwardingAgentSocket: async () => forwardingAgent,
+    pty: {
+      spawn: (_command, args) => {
+        spawnArgs = args;
+        return proc;
+      },
+    },
+    electronModule: { webContents: { fromId: () => null } },
+    openTerminalOutputSession: () => {},
+    selectZmodemUploadFiles: null,
+    selectZmodemDownloadDirectory: null,
+  });
+
+  await api.startEtSession({ sender: { id: 7 } }, {
+    sessionId: "sess-forwarding-socket",
+    hostname: "host.example",
+    username: "alice",
+    useSshAgent: false,
+    agentForwarding: true,
+  });
+
+  const forwardingFlag = spawnArgs.indexOf("-f");
+  assert.notEqual(forwardingFlag, -1);
+  assert.deepEqual(spawnArgs.slice(forwardingFlag, forwardingFlag + 3), [
+    "-f",
+    "--ssh-socket",
+    forwardingAgent,
+  ]);
+});
+
 test("ET PTY explicitly enables bundled ConPTY clear support only on Windows", async (t) => {
   const spawnForPlatform = async (platform) => {
     let spawnOptions = null;
@@ -618,16 +658,9 @@ test("ET keeps its login agent separate from the discovered forwarding agent", a
       { SSH_AUTH_SOCK: "/tmp/remote-agent.sock" },
       prepared,
     );
-    const preparedEnvironment = api.prepareEtSshEnvironment(
-      `session-forwarding-${String(useSshAgent)}`,
-      prepared,
-    );
-    const config = fs.readFileSync(path.join(preparedEnvironment.env.HOME, ".ssh", "config"), "utf8");
-
     assert.equal(prepared._resolvedSshAgentSocket, useSshAgent === true ? localAgent : undefined);
     assert.equal(prepared._resolvedForwardingAgentSocket, forwardingAgent);
     assert.equal(env.SSH_AUTH_SOCK, useSshAgent === false ? undefined : localAgent);
-    assert.match(config, new RegExp(`ForwardAgent "${forwardingAgent}"`));
   }
 });
 

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -583,8 +583,8 @@ test("ET explicitly disables native agent login for target and jump hosts", (t) 
     { useSshAgent: false, agentForwarding: true },
   );
   assert.match(forwardingConfig, /IdentityAgent none/);
-  assert.match(forwardingConfig, /ForwardAgent \$\{SSH_AUTH_SOCK\}/);
-  assert.equal(forwardingEnv.SSH_AUTH_SOCK, "/tmp/forwarded-agent.sock");
+  assert.doesNotMatch(forwardingConfig, /ForwardAgent/);
+  assert.equal(forwardingEnv.SSH_AUTH_SOCK, undefined);
 
   const automaticJumpEnv = api.applyEtSshAgentEnvironment(
     { SSH_AUTH_SOCK: "/tmp/jump-agent.sock" },
@@ -594,13 +594,17 @@ test("ET explicitly disables native agent login for target and jump hosts", (t) 
       jumpHosts: [{ authMethod: "auto" }],
     },
   );
-  assert.equal(automaticJumpEnv.SSH_AUTH_SOCK, "/tmp/jump-agent.sock");
+  assert.equal(automaticJumpEnv.SSH_AUTH_SOCK, process.env.SSH_AUTH_SOCK);
 });
 
-test("ET forwarding replaces an empty inherited agent with the discovered agent", async (t) => {
+test("ET keeps its login agent separate from the discovered forwarding agent", async (t) => {
+  const localAgent = "/private/tmp/com.apple.launchd.test/Listeners";
+  const forwardingAgent = "/Users/alice/.bitwarden-ssh-agent.sock";
   const { api } = makeApi(t, {
     prepareSystemSshAgentForAuth: async () => {},
-    getAvailableForwardingAgentSocket: async () => "/Users/alice/.bitwarden-ssh-agent.sock",
+    getAvailableAgentSocket: async () => localAgent,
+    getAvailableForwardingAgentSocket: async () => forwardingAgent,
+    process: { ...process, env: { SSH_AUTH_SOCK: localAgent } },
   });
 
   for (const useSshAgent of [false, undefined, true]) {
@@ -611,7 +615,7 @@ test("ET forwarding replaces an empty inherited agent with the discovered agent"
       agentForwarding: true,
     });
     const env = api.applyEtSshAgentEnvironment(
-      { SSH_AUTH_SOCK: "/private/tmp/com.apple.launchd.test/Listeners" },
+      { SSH_AUTH_SOCK: "/tmp/remote-agent.sock" },
       prepared,
     );
     const preparedEnvironment = api.prepareEtSshEnvironment(
@@ -620,9 +624,10 @@ test("ET forwarding replaces an empty inherited agent with the discovered agent"
     );
     const config = fs.readFileSync(path.join(preparedEnvironment.env.HOME, ".ssh", "config"), "utf8");
 
-    assert.equal(prepared._resolvedSshAgentSocket, "/Users/alice/.bitwarden-ssh-agent.sock");
-    assert.equal(env.SSH_AUTH_SOCK, "/Users/alice/.bitwarden-ssh-agent.sock");
-    assert.match(config, /ForwardAgent \$\{SSH_AUTH_SOCK\}/);
+    assert.equal(prepared._resolvedSshAgentSocket, useSshAgent === true ? localAgent : undefined);
+    assert.equal(prepared._resolvedForwardingAgentSocket, forwardingAgent);
+    assert.equal(env.SSH_AUTH_SOCK, useSshAgent === false ? undefined : localAgent);
+    assert.match(config, new RegExp(`ForwardAgent "${forwardingAgent}"`));
   }
 });
 

--- a/electron/bridges/terminalBridge/etSession.test.cjs
+++ b/electron/bridges/terminalBridge/etSession.test.cjs
@@ -597,6 +597,26 @@ test("ET explicitly disables native agent login for target and jump hosts", (t) 
   assert.equal(automaticJumpEnv.SSH_AUTH_SOCK, "/tmp/jump-agent.sock");
 });
 
+test("ET forwarding replaces an empty inherited agent with the discovered agent", async (t) => {
+  const { api } = makeApi(t, {
+    getAvailableForwardingAgentSocket: async () => "/Users/alice/.bitwarden-ssh-agent.sock",
+  });
+
+  const prepared = await api.prepareEtSshAgentOptions({
+    hostname: "host.example",
+    username: "alice",
+    useSshAgent: false,
+    agentForwarding: true,
+  });
+  const env = api.applyEtSshAgentEnvironment(
+    { SSH_AUTH_SOCK: "/private/tmp/com.apple.launchd.test/Listeners" },
+    prepared,
+  );
+
+  assert.equal(prepared._resolvedSshAgentSocket, "/Users/alice/.bitwarden-ssh-agent.sock");
+  assert.equal(env.SSH_AUTH_SOCK, "/Users/alice/.bitwarden-ssh-agent.sock");
+});
+
 test("ET prepares target and jump agents before generating their host config", async (t) => {
   const calls = [];
   const { api } = makeApi(t, {

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -350,14 +350,14 @@ function createMoshSessionApi(ctx) {
 
         if (options.useSshAgent === false) {
           sshArgs.push("-o", "IdentityAgent=none");
-          if (options.agentForwarding) {
-            sshArgs.push("-o", "ForwardAgent=${SSH_AUTH_SOCK}");
-          }
         } else if (options.useSshAgent && options._resolvedSshAgentSocket) {
           sshArgs.push("-o", `IdentityAgent=${options._resolvedSshAgentSocket}`);
           if (options.identitiesOnly && !sshArgs.includes("IdentitiesOnly=yes")) {
             sshArgs.push("-o", "IdentitiesOnly=yes");
           }
+        }
+        if (options.agentForwarding) {
+          sshArgs.push("-o", "ForwardAgent=${SSH_AUTH_SOCK}");
         }
 
         if (options.authMethod === "password") {

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -154,6 +154,16 @@ function createMoshSessionApi(ctx) {
 
     function applyMoshSshAgentEnvironment(env, options) {
       delete env.SSH_AUTH_SOCK;
+      if (
+        process.platform === "win32"
+        && options?.agentForwarding
+        && options._resolvedForwardingAgentSocket
+      ) {
+        // Windows OpenSSH reparses backslashes in a direct ForwardAgent value.
+        // Keep the named pipe intact by expanding the standard socket variable.
+        env.SSH_AUTH_SOCK = options._resolvedForwardingAgentSocket;
+        return env;
+      }
       if (options?.useSshAgent === false) {
         return env;
       }
@@ -350,7 +360,10 @@ function createMoshSessionApi(ctx) {
           }
         }
         if (options.agentForwarding && options._resolvedForwardingAgentSocket) {
-          sshArgs.push("-o", `ForwardAgent=${options._resolvedForwardingAgentSocket}`);
+          const forwardingValue = process.platform === "win32"
+            ? "${SSH_AUTH_SOCK}"
+            : options._resolvedForwardingAgentSocket;
+          sshArgs.push("-o", `ForwardAgent=${forwardingValue}`);
         }
 
         if (options.authMethod === "password") {

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -133,11 +133,19 @@ function createMoshSessionApi(ctx) {
     }
 
     async function prepareMoshSshAgentOptions(options) {
-      if (options?.useSshAgent !== true) return options;
-      await prepareSystemSshAgentForAuth(options, "[Mosh]");
-      const socketPath = await getAvailableAgentSocket(options.identityAgent, options);
+      if (options?.useSshAgent !== true && !options?.agentForwarding) return options;
+      if (options.useSshAgent === true) {
+        await prepareSystemSshAgentForAuth(options, "[Mosh]");
+      }
+      const resolveSocket = options.agentForwarding
+        ? getAvailableForwardingAgentSocket
+        : getAvailableAgentSocket;
+      const socketPath = await resolveSocket(options.identityAgent, options);
       if (!socketPath) {
-        throw new Error("System SSH agent is unavailable. Start or unlock it, or configure a valid agent socket.");
+        if (options.useSshAgent === true) {
+          throw new Error("System SSH agent is unavailable. Start or unlock it, or configure a valid agent socket.");
+        }
+        return options;
       }
       return { ...options, _resolvedSshAgentSocket: socketPath };
     }
@@ -145,7 +153,9 @@ function createMoshSessionApi(ctx) {
     function applyMoshSshAgentEnvironment(env, options) {
       if (options?.useSshAgent === false) {
         if (options.agentForwarding) {
-          if (!env.SSH_AUTH_SOCK && process.env.SSH_AUTH_SOCK) {
+          if (options._resolvedSshAgentSocket) {
+            env.SSH_AUTH_SOCK = options._resolvedSshAgentSocket;
+          } else if (!env.SSH_AUTH_SOCK && process.env.SSH_AUTH_SOCK) {
             env.SSH_AUTH_SOCK = process.env.SSH_AUTH_SOCK;
           }
         } else {

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -134,37 +134,30 @@ function createMoshSessionApi(ctx) {
 
     async function prepareMoshSshAgentOptions(options) {
       if (options?.useSshAgent !== true && !options?.agentForwarding) return options;
+      let prepared = options;
       if (options.useSshAgent === true) {
         await prepareSystemSshAgentForAuth(options, "[Mosh]");
-      }
-      const resolveSocket = options.agentForwarding
-        ? getAvailableForwardingAgentSocket
-        : getAvailableAgentSocket;
-      const socketPath = await resolveSocket(options.identityAgent, options);
-      if (!socketPath) {
-        if (options.useSshAgent === true) {
+        const loginSocketPath = await getAvailableAgentSocket(options.identityAgent, options);
+        if (!loginSocketPath) {
           throw new Error("System SSH agent is unavailable. Start or unlock it, or configure a valid agent socket.");
         }
-        return options;
+        prepared = { ...prepared, _resolvedSshAgentSocket: loginSocketPath };
       }
-      return { ...options, _resolvedSshAgentSocket: socketPath };
+      if (options.agentForwarding) {
+        const forwardingSocketPath = await getAvailableForwardingAgentSocket(options.identityAgent, options);
+        if (forwardingSocketPath) {
+          prepared = { ...prepared, _resolvedForwardingAgentSocket: forwardingSocketPath };
+        }
+      }
+      return prepared;
     }
 
     function applyMoshSshAgentEnvironment(env, options) {
+      delete env.SSH_AUTH_SOCK;
       if (options?.useSshAgent === false) {
-        if (options.agentForwarding) {
-          if (options._resolvedSshAgentSocket) {
-            env.SSH_AUTH_SOCK = options._resolvedSshAgentSocket;
-          } else if (!env.SSH_AUTH_SOCK && process.env.SSH_AUTH_SOCK) {
-            env.SSH_AUTH_SOCK = process.env.SSH_AUTH_SOCK;
-          }
-        } else {
-          delete env.SSH_AUTH_SOCK;
-        }
         return env;
       }
-      const socketPath = options?._resolvedSshAgentSocket
-        || (options?.agentForwarding ? process.env.SSH_AUTH_SOCK : undefined);
+      const socketPath = options?._resolvedSshAgentSocket || process.env.SSH_AUTH_SOCK;
       if (socketPath) env.SSH_AUTH_SOCK = socketPath;
       return env;
     }
@@ -356,8 +349,8 @@ function createMoshSessionApi(ctx) {
             sshArgs.push("-o", "IdentitiesOnly=yes");
           }
         }
-        if (options.agentForwarding) {
-          sshArgs.push("-o", "ForwardAgent=${SSH_AUTH_SOCK}");
+        if (options.agentForwarding && options._resolvedForwardingAgentSocket) {
+          sshArgs.push("-o", `ForwardAgent=${options._resolvedForwardingAgentSocket}`);
         }
 
         if (options.authMethod === "password") {

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -179,6 +179,7 @@ declare global {
     }): Promise<{ success: boolean; privateKey?: string; publicKey?: string; error?: string }>;
     checkSshAgent?(options?: {
       identityAgent?: string;
+      agentForwarding?: boolean;
       hostname?: string;
       port?: number;
       username?: string;


### PR DESCRIPTION
## Summary

Fix macOS agent forwarding when Netcatty inherits a reachable but empty launchd SSH agent while Bitwarden exposes the user's actual keys through its own socket.

When forwarding is enabled and no agent was explicitly selected, Netcatty now checks the inherited and documented Bitwarden socket locations and chooses the first agent that actually advertises identities. An explicitly configured agent remains authoritative, and the inherited agent remains the fallback when discovered providers are empty.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2677

## Changes Made

- discover the documented Bitwarden agent sockets on macOS for forwarding-only sessions
- avoid replacing an explicitly configured agent or changing non-macOS selection
- use the selected forwarding agent consistently for built-in SSH, Mosh, and EternalTerminal
- report forwarding-agent availability accurately in host settings
- add regression coverage for empty inherited agents, explicit selections, provider fallback, and all three session paths

## Screenshots / Demo

No visual layout change. The existing agent status warning now reflects the agent that forwarding will actually use.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`) — not applicable
- [x] No new console errors or warnings, if this affects app behavior

Validation performed:

- 96 targeted SSH, Mosh, ET, and agent tests pass
- production build passes
- full suite: 8,751 pass; one unrelated connection-reuse timing test failed in the full parallel run and then passed 5/5 in isolation; seven plugin ZIP tests fail identically on an untouched `origin/main` worktree under local Node 26

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation — no documentation change required; regression tests added
- [x] I have not introduced any breaking changes (or I have described them above)
