### PR TITLE
fix(lint): remove unused eslint-disable in monaco paste test

### DIFF
--- a/infrastructure/monaco/monacoClipboardPaste.test.ts
+++ b/infrastructure/monaco/monacoClipboardPaste.test.ts
@@ -193,7 +193,6 @@ test('pasteForMonacoEditorCommand aborts if focus leaves the find field mid clip
     });
   } finally {
     if (previousDocument === undefined) {
-      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete (globalThis as { document?: Document }).document;
     } else {
       Object.defineProperty(globalThis, 'document', {


### PR DESCRIPTION
## Summary

Remove an unused `eslint-disable-next-line` for `@typescript-eslint/no-dynamic-delete` in `monacoClipboardPaste.test.ts`. ESLint reports no problem on that `delete`, so the directive is unused and produces a warning.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Drop unused `eslint-disable-next-line @typescript-eslint/no-dynamic-delete` in the monaco clipboard paste test cleanup path

## Screenshots / Demo

N/A — lint-only cleanup

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Verified with:
`npx eslint infrastructure/monaco/monacoClipboardPaste.test.ts`

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)