### PR TITLE
fix(terminal): keep broadcast through command colons

### DIFF
--- a/domain/terminalPromptSecurity.test.ts
+++ b/domain/terminalPromptSecurity.test.ts
@@ -107,6 +107,9 @@ test('ordinary shell commands ending with a colon are not untrusted input prompt
   assert.equal(isUntrustedTerminalInputPrompt('router> show ip:'), true);
   // Mid-label `#` is not a prompt boundary (no whitespace after `#`).
   assert.equal(isUntrustedTerminalInputPrompt('Challenge #1:'), true);
+  // Markers inside English challenge labels must not look like a shell PS1.
+  assert.equal(isUntrustedTerminalInputPrompt('Challenge # 1:'), true);
+  assert.equal(isUntrustedTerminalInputPrompt('Account $ code:'), true);
   // Standalone auth-shaped lines without a confirmed shell prompt still fail closed.
   assert.equal(isUntrustedTerminalInputPrompt('Please authenticate: '), true);
   assert.equal(isUntrustedTerminalInputPrompt('Token: '), true);

--- a/domain/terminalPromptSecurity.test.ts
+++ b/domain/terminalPromptSecurity.test.ts
@@ -85,3 +85,30 @@ test('unknown prompt-shaped authentication boundaries fail closed', () => {
   assert.equal(isUntrustedTerminalInputPrompt('router> ', { allowHostStyleGreaterThan: true }), false);
   assert.equal(isUntrustedTerminalInputPrompt('router> '), true);
 });
+
+test('ordinary shell commands ending with a colon are not untrusted input prompts (#2709)', () => {
+  // Broadcast pauses while passwordPromptActive is sticky. Typing `lsof -i:`
+  // must not trip the fail-closed colon heuristic, or peers miss the rest.
+  const commandLines = [
+    'user@host:~$ lsof -i:',
+    'bash-5.2$ lsof -i:',
+    'root# lsof -i:',
+    'PS C:\\Users\\alice> lsof -i:',
+    'C:\\Users\\alice> lsof -i:',
+  ];
+  for (const line of commandLines) {
+    assert.equal(isUntrustedTerminalInputPrompt(line), false, line);
+  }
+  assert.equal(
+    isUntrustedTerminalInputPrompt('router> show ip:', { allowHostStyleGreaterThan: true }),
+    false,
+  );
+  // Bare host-style prompts stay fail-closed unless explicitly allowed.
+  assert.equal(isUntrustedTerminalInputPrompt('router> show ip:'), true);
+  // Mid-label `#` is not a prompt boundary (no whitespace after `#`).
+  assert.equal(isUntrustedTerminalInputPrompt('Challenge #1:'), true);
+  // Standalone auth-shaped lines without a confirmed shell prompt still fail closed.
+  assert.equal(isUntrustedTerminalInputPrompt('Please authenticate: '), true);
+  assert.equal(isUntrustedTerminalInputPrompt('Token: '), true);
+  assert.equal(isUntrustedTerminalInputPrompt('Password: '), true);
+});

--- a/domain/terminalPromptSecurity.ts
+++ b/domain/terminalPromptSecurity.ts
@@ -135,12 +135,28 @@ export function shouldUsePluginTerminalCompletionProvider(input: {
 }
 
 /**
+ * Body text before a `$` / `#` / `%` terminator that is plausible as a shell
+ * PS1 (bare marker, user@host, path, shell-version, or lowercase identity).
+ * Rejects English challenge labels that only happen to end with those markers
+ * (`Challenge #`, `Account $`).
+ */
+function isPlausibleShellPromptBody(body: string): boolean {
+  const trimmed = body.trim();
+  if (!trimmed) return true;
+  if (/@|[/\\~:]/u.test(trimmed)) return true;
+  if (/^(?:bash|zsh|sh|fish|ksh|csh|tcsh|dash)(?:-[\d.]+)?$/iu.test(trimmed)) return true;
+  // Single lowercase identity token: root, ubuntu, pi — not Title-Case labels.
+  return /^[a-z0-9_.-]+$/u.test(trimmed);
+}
+
+/**
  * True when a confirmed shell/device prompt is followed by typed text on the
  * same logical line (e.g. `user@host:~$ lsof -i:`). Trailing `:` / `>` in that
  * typed text is ordinary command input, not an authentication boundary.
  *
  * Requires a real prompt boundary (terminator + whitespace) so mid-label
- * shapes like `Challenge #1:` stay fail-closed.
+ * shapes like `Challenge #1:` stay fail-closed. For `$`/`#`/`%`, also requires
+ * a plausible PS1 body so `Challenge # 1:` / `Account $ code:` stay untrusted.
  */
 function hasTypedInputAfterConfirmedPrompt(
   line: string,
@@ -154,7 +170,12 @@ function hasTypedInputAfterConfirmedPrompt(
     const rest = line.slice(i + 1);
     // Prompt terminators are followed by whitespace before typed input.
     if (!/^\s+\S/u.test(rest)) continue;
-    if (isConfirmedTerminalShellPrompt(line.slice(0, i + 1), options)) return true;
+    const candidate = line.slice(0, i + 1);
+    if (!isConfirmedTerminalShellPrompt(candidate, options)) continue;
+    if ((ch === '$' || ch === '#' || ch === '%') && !isPlausibleShellPromptBody(candidate.slice(0, -1))) {
+      continue;
+    }
+    return true;
   }
   return false;
 }

--- a/domain/terminalPromptSecurity.ts
+++ b/domain/terminalPromptSecurity.ts
@@ -135,6 +135,31 @@ export function shouldUsePluginTerminalCompletionProvider(input: {
 }
 
 /**
+ * True when a confirmed shell/device prompt is followed by typed text on the
+ * same logical line (e.g. `user@host:~$ lsof -i:`). Trailing `:` / `>` in that
+ * typed text is ordinary command input, not an authentication boundary.
+ *
+ * Requires a real prompt boundary (terminator + whitespace) so mid-label
+ * shapes like `Challenge #1:` stay fail-closed.
+ */
+function hasTypedInputAfterConfirmedPrompt(
+  line: string,
+  options: ConfirmedPromptOptions = {},
+): boolean {
+  for (let i = 0; i < line.length - 1; i += 1) {
+    const ch = line[i];
+    // Only terminators that can end a confirmed prompt without relying on a
+    // glyph appearing later in the typed command.
+    if (ch !== '$' && ch !== '#' && ch !== '%' && ch !== '>') continue;
+    const rest = line.slice(i + 1);
+    // Prompt terminators are followed by whitespace before typed input.
+    if (!/^\s+\S/u.test(rest)) continue;
+    if (isConfirmedTerminalShellPrompt(line.slice(0, i + 1), options)) return true;
+  }
+  return false;
+}
+
+/**
  * Fail closed for prompt-shaped input boundaries that are not positively
  * identified as an ordinary shell/device prompt. This protects custom PAM,
  * bastion, and appliance challenges whose labels contain no known vocabulary.
@@ -147,6 +172,9 @@ export function isUntrustedTerminalInputPrompt(
   if (!prompt) return false;
   if (isSensitiveTerminalChallenge(prompt)) return true;
   if (!/[:：>›»]\s*$/u.test(prompt)) return false;
+  // Mid-command punctuation after a real shell prompt must keep broadcasting
+  // (#2709). Standalone `Label:` / `Custom>` challenges still fail closed.
+  if (hasTypedInputAfterConfirmedPrompt(prompt, options)) return false;
   return !isConfirmedTerminalShellPrompt(prompt, options);
 }
 


### PR DESCRIPTION
## Summary

- Workspace broadcast was pausing after typing a mid-command colon (e.g. `lsof -i:`) because `isUntrustedTerminalInputPrompt` treated any line ending in `:` as a fail-closed auth boundary, and the sticky sensitive flag then blocked peer sync for the rest of the input (`443`).
- Skip that heuristic when a confirmed shell/device prompt is already followed by typed text on the same logical line (terminator + whitespace), while keeping standalone `Label:` / custom challenges fail-closed.
- Scope is intentionally limited to #2709 only (no PowerShell/cmdlet allowlists or challenge-vocabulary expansion).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2709

## Changes Made

- `domain/terminalPromptSecurity.ts`: detect typed input after a confirmed prompt before classifying trailing `:`/`>` as untrusted.
- `domain/terminalPromptSecurity.test.ts`: regression for `lsof -i:`-style lines and preserved fail-closed auth prompts.

## Screenshots / Demo

N/A (domain classification logic).

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — `node --test --import tsx domain/terminalPromptSecurity.test.ts`
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

## Test plan

- [ ] Open two terminals in one workspace, enable broadcast
- [ ] Type `lsof -i:443` and confirm both sessions receive the full command including `443`
- [ ] Confirm real password prompts (e.g. `Password:`, `Please authenticate:`) still suppress broadcast
- [ ] Confirm Windows-style prompts (`PS C:\\...>`) and `root#` behave the same for mid-command colons