### PR TITLE
[Bug] Fix host connect script queue selection (#2705)

### DIFF
--- a/application/app/AppHostEditorLayer.tsx
+++ b/application/app/AppHostEditorLayer.tsx
@@ -92,7 +92,7 @@ interface AppHostEditorLayerProps {
   onCreateGroup: (groupPath: string) => void;
   onImportOrReuseKey: (draft: Partial<SSHKey>) => SSHKey;
   onUpdateSnippets: (snippets: Snippet[]) => void;
-  onUpdateHosts?: (hosts: Host[]) => void;
+  onUpdateHosts?: (hosts: Host[] | ((prev: Host[]) => Host[])) => void;
 }
 
 export const AppHostEditorLayer: React.FC<AppHostEditorLayerProps> = ({

--- a/application/app/AppHostEditorLayer.tsx
+++ b/application/app/AppHostEditorLayer.tsx
@@ -92,6 +92,7 @@ interface AppHostEditorLayerProps {
   onCreateGroup: (groupPath: string) => void;
   onImportOrReuseKey: (draft: Partial<SSHKey>) => SSHKey;
   onUpdateSnippets: (snippets: Snippet[]) => void;
+  onUpdateHosts?: (hosts: Host[]) => void;
 }
 
 export const AppHostEditorLayer: React.FC<AppHostEditorLayerProps> = ({
@@ -117,6 +118,7 @@ export const AppHostEditorLayer: React.FC<AppHostEditorLayerProps> = ({
   onCreateGroup,
   onImportOrReuseKey,
   onUpdateSnippets,
+  onUpdateHosts,
 }) => {
   const { t } = useI18n();
   const derivedSurfaceVisible = useWorkSurfaceVisible({
@@ -189,6 +191,7 @@ export const AppHostEditorLayer: React.FC<AppHostEditorLayerProps> = ({
             groupConfigs={groupConfigs}
             snippets={snippets}
             onSnippetsChange={onUpdateSnippets}
+            onHostsChange={onUpdateHosts}
             onImportKey={onImportOrReuseKey}
             onSave={onSave}
             onCancel={onCancel}

--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -345,6 +345,7 @@ function AppViewInner({ domains }: AppViewProps) {
           onCreateGroup={handleCreateWorkSurfaceHostGroup}
           onImportOrReuseKey={importOrReuseKey}
           onUpdateSnippets={updateSnippets}
+          onUpdateHosts={updateHosts}
         />
 
         <VaultViewContainer appThemeStyle={appThemeStyle}>

--- a/application/state/useWorkSurfaceHostEditor.ts
+++ b/application/state/useWorkSurfaceHostEditor.ts
@@ -134,15 +134,20 @@ export function useWorkSurfaceHostEditor({
 
   const save = useCallback((draft: Host) => {
     if (!target) return;
-    const nextHosts = saveWorkSurfaceHostDraft(hosts, target, draft);
-    if (!nextHosts) {
+    let saved = false;
+    onUpdateHosts((prevHosts) => {
+      const nextHosts = saveWorkSurfaceHostDraft(prevHosts, target, draft);
+      if (!nextHosts) return prevHosts;
+      saved = true;
+      return nextHosts;
+    });
+    if (!saved) {
       close();
       return;
     }
-    onUpdateHosts(nextHosts);
     onSaved?.(target.mode);
     close();
-  }, [close, hosts, onSaved, onUpdateHosts, target]);
+  }, [close, onSaved, onUpdateHosts, target]);
 
   useEffect(() => {
     if (shouldCloseDeletedWorkSurfaceHost(hosts, target)) {

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -153,6 +153,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
   const { checkSshAgent } = useApplicationBackend();
   const baselineSnippetsRef = useRef(snippets);
   const baselineHydratedRef = useRef(snippets.length > 0);
+  const openingQueueIdsRef = useRef<string[]>([]);
   const [form, setForm] = useState<Host>(
     () =>
       (initialData ? normalizePrimaryTelnetState(initialData) : null) ||
@@ -243,6 +244,15 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
   useEffect(() => {
     baselineSnippetsRef.current = snippets;
     baselineHydratedRef.current = snippets.length > 0;
+    if (!initialData) {
+      openingQueueIdsRef.current = [];
+    } else {
+      const normalized = normalizePrimaryTelnetState(initialData);
+      const ensured = snippets.length > 0
+        ? ensureHostConnectScriptIds(normalized, snippets)
+        : normalized;
+      openingQueueIdsRef.current = getEditableHostConnectScriptIds(ensured, snippets);
+    }
     // Snapshot only when opening/reopening a host editor, not on live snippet edits.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialHostId]);
@@ -254,7 +264,12 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
     if (snippets.length === 0) return;
     baselineSnippetsRef.current = snippets;
     baselineHydratedRef.current = true;
-  }, [snippets]);
+    if (initialData) {
+      const normalized = normalizePrimaryTelnetState(initialData);
+      const ensured = ensureHostConnectScriptIds(normalized, snippets);
+      openingQueueIdsRef.current = getEditableHostConnectScriptIds(ensured, snippets);
+    }
+  }, [initialData, snippets]);
 
   useEffect(() => {
     if (!initialData) return;
@@ -617,9 +632,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
         // Vault may publish hosts before snippets hydrate. Do not wipe unresolved
         // connectScriptIds while the script catalog is still empty.
       } else {
-        const savedQueueIds = initialData
-          ? getEditableHostConnectScriptIds(initialData, snippets)
-          : [];
+        const savedQueueIds = openingQueueIdsRef.current;
         const finalQueueIds = getEditableHostConnectScriptIds(cleaned, snippets);
         const synced = syncSnippetsForHostConnectQueueSave(
           snippets,
@@ -647,8 +660,8 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
             return original !== undefined && original !== host;
           });
           if (peerChanged) {
-            // Append only the script IDs this save newly queued onto each peer,
-            // preserving concurrent peer-queue edits against the latest state.
+            // Append only the script IDs this save newly queued onto each peer.
+            // Leave the edited host alone so onSave can three-way merge it.
             onHostsChange((prevHosts) => {
               const peerAdds = new Map<string, string[]>();
               for (const syncedHost of synced.hosts) {
@@ -661,8 +674,8 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
                 );
                 if (addedIds.length > 0) peerAdds.set(syncedHost.id, addedIds);
               }
-              const nextHosts = prevHosts.map((host) => {
-                if (host.id === cleaned.id) return cleaned;
+              return prevHosts.map((host) => {
+                if (host.id === cleaned.id) return host;
                 const addedIds = peerAdds.get(host.id);
                 if (!addedIds || addedIds.length === 0) return host;
                 const currentIds = host.connectScriptIds ?? [];
@@ -678,10 +691,6 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
                 }
                 return { ...host, connectScriptIds: mergedIds };
               });
-              if (!nextHosts.some((host) => host.id === cleaned.id)) {
-                nextHosts.push(cleaned);
-              }
-              return nextHosts;
             });
           }
         }

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -70,7 +70,7 @@ import {
 } from "./host-details";
 import { HostNotesEditor } from "./host/HostNotesEditor";
 import { HostDetailsScriptsSection } from "./host/HostDetailsScriptsSection";
-import { ensureHostConnectScriptIds, getHostConnectScriptIds, prepareSnippetForHostConnectQueue } from "@/domain/hostConnectScripts.ts";
+import { ensureHostConnectScriptIds, getEditableHostConnectScriptIds, syncSnippetsForHostConnectQueueSave } from "@/domain/hostConnectScripts.ts";
 import { isScriptSnippet } from "@/domain/snippetScript.ts";
 import { unlinkHostFromScripts } from "@/domain/snippetTargets.ts";
 import {
@@ -595,34 +595,16 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
     }
     if (onSnippetsChange && initialData) {
       const hostId = cleaned.id;
-      const savedQueueIds = initialData.connectScriptIds ?? getHostConnectScriptIds(initialData, snippets);
-      const finalQueueIds = cleaned.connectScriptIds ?? getHostConnectScriptIds(cleaned, snippets);
-      const savedSet = new Set(savedQueueIds);
-      const finalSet = new Set(finalQueueIds);
-      let nextSnippets = snippets;
-      let changed = false;
-
-      for (const scriptId of finalQueueIds) {
-        if (!savedSet.has(scriptId)) {
-          nextSnippets = nextSnippets.map((item) => (
-            item.id === scriptId && isScriptSnippet(item)
-              ? prepareSnippetForHostConnectQueue(item, hostId)
-              : item
-          ));
-          changed = true;
-        }
-      }
-      for (const scriptId of savedQueueIds) {
-        if (!finalSet.has(scriptId)) {
-          const unlinked = unlinkHostFromScripts(nextSnippets, hostId, scriptId);
-          if (unlinked !== nextSnippets) {
-            nextSnippets = unlinked;
-            changed = true;
-          }
-        }
-      }
-      if (changed) {
-        onSnippetsChange(nextSnippets);
+      const savedQueueIds = getEditableHostConnectScriptIds(initialData, snippets);
+      const finalQueueIds = getEditableHostConnectScriptIds(cleaned, snippets);
+      const synced = syncSnippetsForHostConnectQueueSave(
+        snippets,
+        hostId,
+        savedQueueIds,
+        finalQueueIds,
+      );
+      if (synced.changed) {
+        onSnippetsChange(synced.snippets);
       }
     }
     onSave(stripBuiltInConnectionFieldsForPluginHost(cleaned));

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -9,7 +9,7 @@ import {
   Tag,
   X,
 } from "lucide-react";
-import React, { useEffect, useMemo, useState, useCallback } from "react";
+import React, { useEffect, useMemo, useState, useCallback, useRef } from "react";
 import { useI18n } from "../application/i18n/I18nProvider";
 import { useApplicationBackend, type SshAgentStatus } from "../application/state/useApplicationBackend";
 import { applyGroupDefaults, resolveGroupDefaults, resolveGroupTerminalThemeId } from "../domain/groupConfig";
@@ -110,6 +110,7 @@ interface HostDetailsPanelProps {
   onImportKey?: (draft: Partial<SSHKey>) => SSHKey;
   snippets?: Snippet[];
   onSnippetsChange?: (snippets: Snippet[]) => void;
+  onHostsChange?: (hosts: Host[]) => void;
   className?: string;
 }
 
@@ -137,6 +138,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
   onImportKey,
   snippets = [],
   onSnippetsChange,
+  onHostsChange,
   className,
   resizable,
   persistWidthStorageKey,
@@ -149,6 +151,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
     resizeAriaLabel,
   };
   const { checkSshAgent } = useApplicationBackend();
+  const baselineSnippetsRef = useRef(snippets);
   const [form, setForm] = useState<Host>(
     () =>
       (initialData ? normalizePrimaryTelnetState(initialData) : null) ||
@@ -235,6 +238,12 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
   const [groupInputValue, setGroupInputValue] = useState(form.group || "");
 
   const initialHostId = initialData?.id;
+
+  useEffect(() => {
+    baselineSnippetsRef.current = snippets;
+    // Snapshot only when opening/reopening a host editor, not on live snippet edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialHostId]);
 
   useEffect(() => {
     if (!initialData) return;
@@ -591,7 +600,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
     if ((cleaned.protocol && cleaned.protocol !== "ssh") || cleaned.moshEnabled || cleaned.etEnabled) {
       delete cleaned.x11Forwarding;
     }
-    if (onSnippetsChange) {
+    if (onSnippetsChange || onHostsChange) {
       const hostId = cleaned.id;
       const savedQueueIds = initialData
         ? getEditableHostConnectScriptIds(initialData, snippets)
@@ -602,9 +611,32 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
         hostId,
         savedQueueIds,
         finalQueueIds,
+        {
+          baselineSnippets: baselineSnippetsRef.current,
+          hosts: allHosts,
+        },
       );
-      if (synced.changed) {
+      cleaned = {
+        ...cleaned,
+        connectScriptIds: synced.connectScriptIds.length > 0
+          ? synced.connectScriptIds
+          : undefined,
+      };
+      if (synced.changed && onSnippetsChange) {
         onSnippetsChange(synced.snippets);
+      }
+      if (onHostsChange && synced.hosts.length > 0) {
+        const peerChanged = synced.hosts.some((host) => {
+          if (host.id === cleaned.id) return false;
+          const original = allHosts.find((entry) => entry.id === host.id);
+          return original !== undefined && original !== host;
+        });
+        if (peerChanged) {
+          onHostsChange(allHosts.map((host) => {
+            if (host.id === cleaned.id) return host;
+            return synced.hosts.find((entry) => entry.id === host.id) ?? host;
+          }));
+        }
       }
     }
     onSave(stripBuiltInConnectionFieldsForPluginHost(cleaned));

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -632,10 +632,16 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
           return original !== undefined && original !== host;
         });
         if (peerChanged) {
-          onHostsChange(allHosts.map((host) => {
-            if (host.id === cleaned.id) return host;
+          // Persist peers + the edited host together so a following onSave
+          // cannot rebuild from a stale hosts snapshot and drop peer queues.
+          const nextHosts = allHosts.map((host) => {
+            if (host.id === cleaned.id) return cleaned;
             return synced.hosts.find((entry) => entry.id === host.id) ?? host;
-          }));
+          });
+          if (!nextHosts.some((host) => host.id === cleaned.id)) {
+            nextHosts.push(cleaned);
+          }
+          onHostsChange(nextHosts);
         }
       }
     }

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -71,8 +71,6 @@ import {
 import { HostNotesEditor } from "./host/HostNotesEditor";
 import { HostDetailsScriptsSection } from "./host/HostDetailsScriptsSection";
 import { ensureHostConnectScriptIds, getEditableHostConnectScriptIds, syncSnippetsForHostConnectQueueSave } from "@/domain/hostConnectScripts.ts";
-import { isScriptSnippet } from "@/domain/snippetScript.ts";
-import { unlinkHostFromScripts } from "@/domain/snippetTargets.ts";
 import {
   isPluginHostProtocol,
   sanitizePluginConnection,

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -628,9 +628,9 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
     }
     if (onSnippetsChange || onHostsChange) {
       const hostId = cleaned.id;
-      if (snippets.length === 0) {
+      if (snippets.length === 0 && !baselineHydratedRef.current) {
         // Vault may publish hosts before snippets hydrate. Do not wipe unresolved
-        // connectScriptIds while the script catalog is still empty.
+        // connectScriptIds while the script catalog is still incomplete.
       } else {
         const savedQueueIds = openingQueueIdsRef.current;
         const finalQueueIds = getEditableHostConnectScriptIds(cleaned, snippets);

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -152,6 +152,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
   };
   const { checkSshAgent } = useApplicationBackend();
   const baselineSnippetsRef = useRef(snippets);
+  const baselineHydratedRef = useRef(snippets.length > 0);
   const [form, setForm] = useState<Host>(
     () =>
       (initialData ? normalizePrimaryTelnetState(initialData) : null) ||
@@ -241,9 +242,19 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
 
   useEffect(() => {
     baselineSnippetsRef.current = snippets;
+    baselineHydratedRef.current = snippets.length > 0;
     // Snapshot only when opening/reopening a host editor, not on live snippet edits.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialHostId]);
+
+  useEffect(() => {
+    // If the editor opened before snippets hydrated, capture the first non-empty
+    // catalog as baseline so concurrent-edit guards still have a reference.
+    if (baselineHydratedRef.current) return;
+    if (snippets.length === 0) return;
+    baselineSnippetsRef.current = snippets;
+    baselineHydratedRef.current = true;
+  }, [snippets]);
 
   useEffect(() => {
     if (!initialData) return;
@@ -636,26 +647,36 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
             return original !== undefined && original !== host;
           });
           if (peerChanged) {
-            // Apply only edited-host + peer-queue deltas onto the latest vault
-            // state so concurrent host updates are not reverted.
+            // Append only the script IDs this save newly queued onto each peer,
+            // preserving concurrent peer-queue edits against the latest state.
             onHostsChange((prevHosts) => {
-              const syncedPeerById = new Map(
-                synced.hosts
-                  .filter((host) => host.id !== cleaned.id)
-                  .filter((host) => {
-                    const snapshot = allHosts.find((entry) => entry.id === host.id);
-                    return snapshot !== undefined && snapshot !== host;
-                  })
-                  .map((host) => [host.id, host] as const),
-              );
+              const peerAdds = new Map<string, string[]>();
+              for (const syncedHost of synced.hosts) {
+                if (syncedHost.id === cleaned.id) continue;
+                const snapshot = allHosts.find((entry) => entry.id === syncedHost.id);
+                if (!snapshot || snapshot === syncedHost) continue;
+                const snapshotIds = snapshot.connectScriptIds ?? [];
+                const addedIds = (syncedHost.connectScriptIds ?? []).filter(
+                  (id) => !snapshotIds.includes(id),
+                );
+                if (addedIds.length > 0) peerAdds.set(syncedHost.id, addedIds);
+              }
               const nextHosts = prevHosts.map((host) => {
                 if (host.id === cleaned.id) return cleaned;
-                const syncedPeer = syncedPeerById.get(host.id);
-                if (!syncedPeer) return host;
-                return {
-                  ...host,
-                  connectScriptIds: syncedPeer.connectScriptIds,
-                };
+                const addedIds = peerAdds.get(host.id);
+                if (!addedIds || addedIds.length === 0) return host;
+                const currentIds = host.connectScriptIds ?? [];
+                const mergedIds = [...currentIds];
+                for (const id of addedIds) {
+                  if (!mergedIds.includes(id)) mergedIds.push(id);
+                }
+                if (
+                  mergedIds.length === currentIds.length
+                  && mergedIds.every((id, index) => id === currentIds[index])
+                ) {
+                  return host;
+                }
+                return { ...host, connectScriptIds: mergedIds };
               });
               if (!nextHosts.some((host) => host.id === cleaned.id)) {
                 nextHosts.push(cleaned);

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -649,6 +649,11 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
           connectScriptIds: synced.connectScriptIds.length > 0
             ? synced.connectScriptIds
             : undefined,
+          // sanitizeHost reconstitutes connectScriptIds from loginScriptId when
+          // the explicit queue is absent; clear the legacy field when emptied.
+          ...(synced.connectScriptIds.length === 0
+            ? { loginScriptId: undefined }
+            : {}),
         };
         if (synced.changed && onSnippetsChange) {
           onSnippetsChange(synced.snippets);

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -110,7 +110,7 @@ interface HostDetailsPanelProps {
   onImportKey?: (draft: Partial<SSHKey>) => SSHKey;
   snippets?: Snippet[];
   onSnippetsChange?: (snippets: Snippet[]) => void;
-  onHostsChange?: (hosts: Host[]) => void;
+  onHostsChange?: (hosts: Host[] | ((prev: Host[]) => Host[])) => void;
   className?: string;
 }
 
@@ -636,16 +636,32 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
             return original !== undefined && original !== host;
           });
           if (peerChanged) {
-            // Persist peers + the edited host together so a following onSave
-            // cannot rebuild from a stale hosts snapshot and drop peer queues.
-            const nextHosts = allHosts.map((host) => {
-              if (host.id === cleaned.id) return cleaned;
-              return synced.hosts.find((entry) => entry.id === host.id) ?? host;
+            // Apply only edited-host + peer-queue deltas onto the latest vault
+            // state so concurrent host updates are not reverted.
+            onHostsChange((prevHosts) => {
+              const syncedPeerById = new Map(
+                synced.hosts
+                  .filter((host) => host.id !== cleaned.id)
+                  .filter((host) => {
+                    const snapshot = allHosts.find((entry) => entry.id === host.id);
+                    return snapshot !== undefined && snapshot !== host;
+                  })
+                  .map((host) => [host.id, host] as const),
+              );
+              const nextHosts = prevHosts.map((host) => {
+                if (host.id === cleaned.id) return cleaned;
+                const syncedPeer = syncedPeerById.get(host.id);
+                if (!syncedPeer) return host;
+                return {
+                  ...host,
+                  connectScriptIds: syncedPeer.connectScriptIds,
+                };
+              });
+              if (!nextHosts.some((host) => host.id === cleaned.id)) {
+                nextHosts.push(cleaned);
+              }
+              return nextHosts;
             });
-            if (!nextHosts.some((host) => host.id === cleaned.id)) {
-              nextHosts.push(cleaned);
-            }
-            onHostsChange(nextHosts);
           }
         }
       }

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -602,46 +602,51 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
     }
     if (onSnippetsChange || onHostsChange) {
       const hostId = cleaned.id;
-      const savedQueueIds = initialData
-        ? getEditableHostConnectScriptIds(initialData, snippets)
-        : [];
-      const finalQueueIds = getEditableHostConnectScriptIds(cleaned, snippets);
-      const synced = syncSnippetsForHostConnectQueueSave(
-        snippets,
-        hostId,
-        savedQueueIds,
-        finalQueueIds,
-        {
-          baselineSnippets: baselineSnippetsRef.current,
-          hosts: allHosts,
-        },
-      );
-      cleaned = {
-        ...cleaned,
-        connectScriptIds: synced.connectScriptIds.length > 0
-          ? synced.connectScriptIds
-          : undefined,
-      };
-      if (synced.changed && onSnippetsChange) {
-        onSnippetsChange(synced.snippets);
-      }
-      if (onHostsChange && synced.hosts.length > 0) {
-        const peerChanged = synced.hosts.some((host) => {
-          if (host.id === cleaned.id) return false;
-          const original = allHosts.find((entry) => entry.id === host.id);
-          return original !== undefined && original !== host;
-        });
-        if (peerChanged) {
-          // Persist peers + the edited host together so a following onSave
-          // cannot rebuild from a stale hosts snapshot and drop peer queues.
-          const nextHosts = allHosts.map((host) => {
-            if (host.id === cleaned.id) return cleaned;
-            return synced.hosts.find((entry) => entry.id === host.id) ?? host;
+      if (snippets.length === 0) {
+        // Vault may publish hosts before snippets hydrate. Do not wipe unresolved
+        // connectScriptIds while the script catalog is still empty.
+      } else {
+        const savedQueueIds = initialData
+          ? getEditableHostConnectScriptIds(initialData, snippets)
+          : [];
+        const finalQueueIds = getEditableHostConnectScriptIds(cleaned, snippets);
+        const synced = syncSnippetsForHostConnectQueueSave(
+          snippets,
+          hostId,
+          savedQueueIds,
+          finalQueueIds,
+          {
+            baselineSnippets: baselineSnippetsRef.current,
+            hosts: allHosts,
+          },
+        );
+        cleaned = {
+          ...cleaned,
+          connectScriptIds: synced.connectScriptIds.length > 0
+            ? synced.connectScriptIds
+            : undefined,
+        };
+        if (synced.changed && onSnippetsChange) {
+          onSnippetsChange(synced.snippets);
+        }
+        if (onHostsChange && synced.hosts.length > 0) {
+          const peerChanged = synced.hosts.some((host) => {
+            if (host.id === cleaned.id) return false;
+            const original = allHosts.find((entry) => entry.id === host.id);
+            return original !== undefined && original !== host;
           });
-          if (!nextHosts.some((host) => host.id === cleaned.id)) {
-            nextHosts.push(cleaned);
+          if (peerChanged) {
+            // Persist peers + the edited host together so a following onSave
+            // cannot rebuild from a stale hosts snapshot and drop peer queues.
+            const nextHosts = allHosts.map((host) => {
+              if (host.id === cleaned.id) return cleaned;
+              return synced.hosts.find((entry) => entry.id === host.id) ?? host;
+            });
+            if (!nextHosts.some((host) => host.id === cleaned.id)) {
+              nextHosts.push(cleaned);
+            }
+            onHostsChange(nextHosts);
           }
-          onHostsChange(nextHosts);
         }
       }
     }

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -591,9 +591,11 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
     if ((cleaned.protocol && cleaned.protocol !== "ssh") || cleaned.moshEnabled || cleaned.etEnabled) {
       delete cleaned.x11Forwarding;
     }
-    if (onSnippetsChange && initialData) {
+    if (onSnippetsChange) {
       const hostId = cleaned.id;
-      const savedQueueIds = getEditableHostConnectScriptIds(initialData, snippets);
+      const savedQueueIds = initialData
+        ? getEditableHostConnectScriptIds(initialData, snippets)
+        : [];
       const finalQueueIds = getEditableHostConnectScriptIds(cleaned, snippets);
       const synced = syncSnippetsForHostConnectQueueSave(
         snippets,

--- a/components/host/HostDetailsScriptsSection.tsx
+++ b/components/host/HostDetailsScriptsSection.tsx
@@ -3,8 +3,8 @@ import React, { useCallback, useMemo, useState, type DragEvent } from 'react';
 import type { Host, Snippet } from '@/domain/models';
 import {
   appendHostConnectScript,
+  getEditableHostConnectScriptIds,
   getGlobalConnectScripts,
-  getHostConnectScriptIds,
   removeHostConnectScript,
   reorderHostConnectScript,
 } from '@/domain/hostConnectScripts.ts';
@@ -60,7 +60,7 @@ export const HostDetailsScriptsSection: React.FC<HostDetailsScriptsSectionProps>
     [snippets],
   );
   const queueIds = useMemo(
-    () => getHostConnectScriptIds(host, snippets),
+    () => getEditableHostConnectScriptIds(host, snippets),
     [host, snippets],
   );
   const queuedScripts = useMemo(
@@ -71,15 +71,16 @@ export const HostDetailsScriptsSection: React.FC<HostDetailsScriptsSectionProps>
   );
   const linkableScripts = useMemo(
     () => scripts.filter((script) => {
+      if (!script.id) return false;
       if (script.targetsAllHosts) return false;
-      if (script.id && queueIds.includes(script.id)) return false;
+      if (queueIds.includes(script.id)) return false;
       return true;
     }),
     [queueIds, scripts],
   );
   const linkOptions = useMemo(
     () => linkableScripts.map((script) => ({
-      value: script.id,
+      value: script.id!,
       label: script.label || t('scripts.running.unnamed'),
     })),
     [linkableScripts, t],

--- a/components/vault/VaultViewLayout.tsx
+++ b/components/vault/VaultViewLayout.tsx
@@ -1373,6 +1373,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
                 groupConfigs={groupConfigs}
                 snippets={snippets}
                 onSnippetsChange={onUpdateSnippets}
+                onHostsChange={onUpdateHosts}
                 onImportKey={onImportOrReuseKey}
                 onSave={(host) => {
                   const latestHost = hosts.find(

--- a/components/vault/VaultViewLayout.tsx
+++ b/components/vault/VaultViewLayout.tsx
@@ -1384,7 +1384,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
                     openedHost: editingHost,
                     latestHost,
                   });
-                  onUpdateHosts(upsertHostById(hosts, nextHost));
+                  onUpdateHosts((prevHosts) => upsertHostById(prevHosts, nextHost));
                   setIsHostPanelOpen(false);
                   setEditingHost(null);
                   setNewHostGroupPath(null);

--- a/domain/hostConnectScripts.test.ts
+++ b/domain/hostConnectScripts.test.ts
@@ -239,6 +239,20 @@ test('syncSnippetsForHostConnectQueueSave preserves concurrent non-onConnect tri
   assert.deepEqual(connectScriptIds, []);
 });
 
+test('syncSnippetsForHostConnectQueueSave preserves concurrent target removals', () => {
+  const baseline = [script({ id: 'run', trigger: 'onConnect', targets: ['host-a', 'host-b'] })];
+  const unlinked = [script({ id: 'run', trigger: 'onConnect', targets: ['host-b'] })];
+  const { snippets: next, connectScriptIds } = syncSnippetsForHostConnectQueueSave(
+    unlinked,
+    'host-a',
+    ['run'],
+    ['run'],
+    { baselineSnippets: baseline },
+  );
+  assert.deepEqual(next[0].targets, ['host-b']);
+  assert.deepEqual(connectScriptIds, []);
+});
+
 test('syncSnippetsForHostConnectQueueSave syncs other targeted hosts after promote', () => {
   const hostB: Host = {
     id: 'host-b',

--- a/domain/hostConnectScripts.test.ts
+++ b/domain/hostConnectScripts.test.ts
@@ -224,6 +224,21 @@ test('syncSnippetsForHostConnectQueueSave does not re-promote concurrently demot
   assert.deepEqual(connectScriptIds, []);
 });
 
+test('syncSnippetsForHostConnectQueueSave preserves concurrent non-onConnect trigger edits', () => {
+  const baseline = [script({ id: 'run', trigger: 'manual', targets: ['host-a'] })];
+  const retargeted = [script({ id: 'run', trigger: 'onOutput', triggerPattern: 'ERR', targets: ['host-a'] })];
+  const { snippets: next, connectScriptIds } = syncSnippetsForHostConnectQueueSave(
+    retargeted,
+    'host-a',
+    ['run'],
+    ['run'],
+    { baselineSnippets: baseline },
+  );
+  assert.equal(next[0].trigger, 'onOutput');
+  assert.equal(next[0].triggerPattern, 'ERR');
+  assert.deepEqual(connectScriptIds, []);
+});
+
 test('syncSnippetsForHostConnectQueueSave syncs other targeted hosts after promote', () => {
   const hostB: Host = {
     id: 'host-b',

--- a/domain/hostConnectScripts.test.ts
+++ b/domain/hostConnectScripts.test.ts
@@ -176,6 +176,19 @@ test('syncSnippetsForHostConnectQueueSave promotes already-persisted manual queu
   assert.equal(next.find((item) => item.id === 'ready'), snippets[1]);
 });
 
+test('syncSnippetsForHostConnectQueueSave leaves global onConnect scripts untouched', () => {
+  const global = script({ id: 'both', targetsAllHosts: true, targets: ['host-a'] });
+  const { snippets: next, changed } = syncSnippetsForHostConnectQueueSave(
+    [global],
+    'host-a',
+    ['both'],
+    ['both'],
+  );
+  assert.equal(changed, false);
+  assert.equal(next[0], global);
+  assert.equal(next[0].targetsAllHosts, true);
+});
+
 test('syncHostsForSnippetTargetChange appends and removes queue entries', () => {
   const snippets = [script({ id: 'run', targets: ['host-a'], trigger: 'onConnect' })];
   const hosts = syncHostsForSnippetTargetChange(

--- a/domain/hostConnectScripts.test.ts
+++ b/domain/hostConnectScripts.test.ts
@@ -136,7 +136,7 @@ test('append updates host connectScriptIds order', () => {
 
 test('append keeps default manual scripts in the editable host queue', () => {
   const snippets = [
-    script({ id: 'reset', label: '重置密码', trigger: 'manual' }),
+    script({ id: 'reset', label: 'reset-password', trigger: 'manual' }),
     script({ id: 'teest', label: 'teest', trigger: 'manual' }),
   ];
 
@@ -164,7 +164,7 @@ test('syncSnippetsForHostConnectQueueSave promotes already-persisted manual queu
     script({ id: 'reset', trigger: 'manual', targets: [] }),
     script({ id: 'ready', trigger: 'onConnect', targets: ['host-a'] }),
   ];
-  const { snippets: next, changed } = syncSnippetsForHostConnectQueueSave(
+  const { snippets: next, changed, connectScriptIds } = syncSnippetsForHostConnectQueueSave(
     snippets,
     'host-a',
     ['reset', 'ready'],
@@ -174,11 +174,12 @@ test('syncSnippetsForHostConnectQueueSave promotes already-persisted manual queu
   assert.equal(next.find((item) => item.id === 'reset')?.trigger, 'onConnect');
   assert.deepEqual(next.find((item) => item.id === 'reset')?.targets, ['host-a']);
   assert.equal(next.find((item) => item.id === 'ready'), snippets[1]);
+  assert.deepEqual(connectScriptIds, ['reset', 'ready']);
 });
 
 test('syncSnippetsForHostConnectQueueSave leaves global onConnect scripts untouched', () => {
   const global = script({ id: 'both', targetsAllHosts: true, targets: ['host-a'] });
-  const { snippets: next, changed } = syncSnippetsForHostConnectQueueSave(
+  const { snippets: next, changed, connectScriptIds } = syncSnippetsForHostConnectQueueSave(
     [global],
     'host-a',
     ['both'],
@@ -187,6 +188,67 @@ test('syncSnippetsForHostConnectQueueSave leaves global onConnect scripts untouc
   assert.equal(changed, false);
   assert.equal(next[0], global);
   assert.equal(next[0].targetsAllHosts, true);
+  assert.deepEqual(connectScriptIds, ['both']);
+});
+
+test('syncSnippetsForHostConnectQueueSave promotes global manual without clearing targetsAllHosts', () => {
+  const globalManual = script({
+    id: 'everywhere',
+    trigger: 'manual',
+    targetsAllHosts: true,
+  });
+  const { snippets: next, changed, connectScriptIds } = syncSnippetsForHostConnectQueueSave(
+    [globalManual],
+    'host-a',
+    ['everywhere'],
+    ['everywhere'],
+  );
+  assert.equal(changed, true);
+  assert.equal(next[0].trigger, 'onConnect');
+  assert.equal(next[0].targetsAllHosts, true);
+  assert.deepEqual(connectScriptIds, ['everywhere']);
+});
+
+test('syncSnippetsForHostConnectQueueSave does not re-promote concurrently demoted scripts', () => {
+  const baseline = [script({ id: 'run', trigger: 'onConnect', targets: ['host-a'] })];
+  const demoted = [script({ id: 'run', trigger: 'manual', targets: ['host-a'] })];
+  const { snippets: next, changed, connectScriptIds } = syncSnippetsForHostConnectQueueSave(
+    demoted,
+    'host-a',
+    ['run'],
+    ['run'],
+    { baselineSnippets: baseline },
+  );
+  assert.equal(changed, true);
+  assert.equal(next[0].trigger, 'manual');
+  assert.deepEqual(connectScriptIds, []);
+});
+
+test('syncSnippetsForHostConnectQueueSave syncs other targeted hosts after promote', () => {
+  const hostB: Host = {
+    id: 'host-b',
+    label: 'B',
+    hostname: 'b.example',
+    username: 'root',
+    os: 'linux',
+    protocol: 'ssh',
+    tags: [],
+    connectScriptIds: [],
+  };
+  const snippets = [
+    script({ id: 'shared', trigger: 'manual', targets: ['host-b'] }),
+  ];
+  const { snippets: next, hosts, changed } = syncSnippetsForHostConnectQueueSave(
+    snippets,
+    'host-a',
+    [],
+    ['shared'],
+    { hosts: [host, hostB] },
+  );
+  assert.equal(changed, true);
+  assert.equal(next[0].trigger, 'onConnect');
+  assert.deepEqual(next[0].targets, ['host-b', 'host-a']);
+  assert.deepEqual(hosts?.find((item) => item.id === 'host-b')?.connectScriptIds, ['shared']);
 });
 
 test('syncHostsForSnippetTargetChange appends and removes queue entries', () => {

--- a/domain/hostConnectScripts.test.ts
+++ b/domain/hostConnectScripts.test.ts
@@ -15,6 +15,7 @@ import {
   shouldMarkConnectAutomationConsumed,
   shouldUseFreshSshConnectionForAutomation,
   syncHostsForSnippetTargetChange,
+  syncSnippetsForHostConnectQueueSave,
 } from './hostConnectScripts.ts';
 
 const host: Host = {
@@ -156,6 +157,23 @@ test('ensureHostConnectScriptIds preserves pending manual queue entries while ed
   assert.deepEqual(ensured.connectScriptIds, ['reset']);
   assert.deepEqual(getEditableHostConnectScriptIds(ensured, snippets), ['reset']);
   assert.deepEqual(getHostConnectScriptIds(ensured, snippets), []);
+});
+
+test('syncSnippetsForHostConnectQueueSave promotes already-persisted manual queue entries', () => {
+  const snippets = [
+    script({ id: 'reset', trigger: 'manual', targets: [] }),
+    script({ id: 'ready', trigger: 'onConnect', targets: ['host-a'] }),
+  ];
+  const { snippets: next, changed } = syncSnippetsForHostConnectQueueSave(
+    snippets,
+    'host-a',
+    ['reset', 'ready'],
+    ['reset', 'ready'],
+  );
+  assert.equal(changed, true);
+  assert.equal(next.find((item) => item.id === 'reset')?.trigger, 'onConnect');
+  assert.deepEqual(next.find((item) => item.id === 'reset')?.targets, ['host-a']);
+  assert.equal(next.find((item) => item.id === 'ready'), snippets[1]);
 });
 
 test('syncHostsForSnippetTargetChange appends and removes queue entries', () => {

--- a/domain/hostConnectScripts.test.ts
+++ b/domain/hostConnectScripts.test.ts
@@ -253,6 +253,21 @@ test('syncSnippetsForHostConnectQueueSave preserves concurrent target removals',
   assert.deepEqual(connectScriptIds, []);
 });
 
+test('syncSnippetsForHostConnectQueueSave preserves concurrent target removals for manual scripts', () => {
+  const baseline = [script({ id: 'run', trigger: 'manual', targets: ['host-a', 'host-b'] })];
+  const unlinked = [script({ id: 'run', trigger: 'manual', targets: ['host-b'] })];
+  const { snippets: next, connectScriptIds } = syncSnippetsForHostConnectQueueSave(
+    unlinked,
+    'host-a',
+    ['run'],
+    ['run'],
+    { baselineSnippets: baseline },
+  );
+  assert.equal(next[0].trigger, 'manual');
+  assert.deepEqual(next[0].targets, ['host-b']);
+  assert.deepEqual(connectScriptIds, []);
+});
+
 test('syncSnippetsForHostConnectQueueSave syncs other targeted hosts after promote', () => {
   const hostB: Host = {
     id: 'host-b',

--- a/domain/hostConnectScripts.test.ts
+++ b/domain/hostConnectScripts.test.ts
@@ -3,6 +3,8 @@ import test from 'node:test';
 import type { Host, Snippet } from './models';
 import {
   appendHostConnectScript,
+  ensureHostConnectScriptIds,
+  getEditableHostConnectScriptIds,
   getGlobalConnectScripts,
   getHostConnectScriptIds,
   hasHostConnectAutomation,
@@ -129,6 +131,31 @@ test('append updates host connectScriptIds order', () => {
   let next = appendHostConnectScript(host, 'a', snippets);
   next = appendHostConnectScript(next, 'b', snippets);
   assert.deepEqual(getHostConnectScriptIds(next, snippets), ['a', 'b']);
+});
+
+test('append keeps default manual scripts in the editable host queue', () => {
+  const snippets = [
+    script({ id: 'reset', label: '重置密码', trigger: 'manual' }),
+    script({ id: 'teest', label: 'teest', trigger: 'manual' }),
+  ];
+
+  let next = appendHostConnectScript(host, 'reset', snippets);
+  assert.deepEqual(getEditableHostConnectScriptIds(next, snippets), ['reset']);
+  // Runtime still ignores non-onConnect until host save promotes the trigger.
+  assert.deepEqual(getHostConnectScriptIds(next, snippets), []);
+
+  next = appendHostConnectScript(next, 'teest', snippets);
+  assert.deepEqual(getEditableHostConnectScriptIds(next, snippets), ['reset', 'teest']);
+  assert.deepEqual(next.connectScriptIds, ['reset', 'teest']);
+});
+
+test('ensureHostConnectScriptIds preserves pending manual queue entries while editing', () => {
+  const snippets = [script({ id: 'reset', trigger: 'manual' })];
+  const draft = { ...host, connectScriptIds: ['reset', 'missing'] };
+  const ensured = ensureHostConnectScriptIds(draft, snippets);
+  assert.deepEqual(ensured.connectScriptIds, ['reset']);
+  assert.deepEqual(getEditableHostConnectScriptIds(ensured, snippets), ['reset']);
+  assert.deepEqual(getHostConnectScriptIds(ensured, snippets), []);
 });
 
 test('syncHostsForSnippetTargetChange appends and removes queue entries', () => {

--- a/domain/hostConnectScripts.ts
+++ b/domain/hostConnectScripts.ts
@@ -326,13 +326,21 @@ export function syncSnippetsForHostConnectQueueSave(
 
     const newlyAdded = !previousSet.has(scriptId);
     const baselineItem = baseline.find((entry) => entry.id === scriptId);
-    const wasOnConnectAtBaseline = Boolean(
-      baselineItem
-      && isScriptSnippet(baselineItem)
-      && baselineItem.trigger === 'onConnect',
-    );
-    if (!newlyAdded && wasOnConnectAtBaseline) {
+    const baselineTrigger = baselineItem && isScriptSnippet(baselineItem)
+      ? baselineItem.trigger
+      : undefined;
+    if (!newlyAdded && baselineTrigger === 'onConnect' && item.trigger !== 'onConnect') {
       // Concurrent demotion while the editor stayed open: keep demotion, drop stale queue id.
+      demotedDropIds.add(scriptId);
+      continue;
+    }
+    if (
+      !newlyAdded
+      && baselineTrigger
+      && baselineTrigger !== 'onConnect'
+      && item.trigger !== baselineTrigger
+    ) {
+      // Concurrent non-onConnect trigger edit (e.g. manual -> onOutput): do not overwrite.
       demotedDropIds.add(scriptId);
       continue;
     }

--- a/domain/hostConnectScripts.ts
+++ b/domain/hostConnectScripts.ts
@@ -4,6 +4,7 @@ import {
   getScriptsLinkedToHost,
   linkHostToScript,
   snippetAppliesToHost,
+  unlinkHostFromScripts,
 } from './snippetTargets.ts';
 import { sortByVaultOrder } from './vaultOrder.ts';
 
@@ -232,6 +233,49 @@ export function prepareSnippetForHostConnectQueue(snippet: Snippet, hostId: stri
     ...linkHostToScript(snippet, hostId),
     trigger: 'onConnect',
   };
+}
+
+function connectQueueSnippetNeedsPromote(snippet: Snippet, hostId: string): boolean {
+  if (!isScriptSnippet(snippet)) return false;
+  if (snippet.trigger !== 'onConnect') return true;
+  if (snippet.targetsAllHosts) return true;
+  return !snippetAppliesToHost(snippet, hostId);
+}
+
+/**
+ * Sync script metadata when saving a host connect queue.
+ * Promotes every queued script to onConnect + host target, including IDs that
+ * were already persisted as draft/manual entries before this save.
+ */
+export function syncSnippetsForHostConnectQueueSave(
+  snippets: Snippet[],
+  hostId: string,
+  previousQueueIds: string[],
+  nextQueueIds: string[],
+): { snippets: Snippet[]; changed: boolean } {
+  const nextSet = new Set(nextQueueIds);
+  let nextSnippets = snippets;
+  let changed = false;
+
+  for (const scriptId of nextQueueIds) {
+    nextSnippets = nextSnippets.map((item) => {
+      if (item.id !== scriptId || !isScriptSnippet(item)) return item;
+      if (!connectQueueSnippetNeedsPromote(item, hostId)) return item;
+      changed = true;
+      return prepareSnippetForHostConnectQueue(item, hostId);
+    });
+  }
+
+  for (const scriptId of previousQueueIds) {
+    if (nextSet.has(scriptId)) continue;
+    const unlinked = unlinkHostFromScripts(nextSnippets, hostId, scriptId);
+    if (unlinked !== nextSnippets) {
+      nextSnippets = unlinked;
+      changed = true;
+    }
+  }
+
+  return { snippets: nextSnippets, changed };
 }
 
 export function syncHostsForSnippetTargetChange(

--- a/domain/hostConnectScripts.ts
+++ b/domain/hostConnectScripts.ts
@@ -28,6 +28,23 @@ function pruneConnectScriptIds(ids: string[], snippets: Snippet[]): string[] {
   return result;
 }
 
+/**
+ * Draft/edit queue prune: keep any existing script IDs.
+ * Host save promotes non-onConnect scripts via prepareSnippetForHostConnectQueue.
+ */
+function pruneEditableConnectScriptIds(ids: string[], snippets: Snippet[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const id of ids) {
+    if (!id || seen.has(id)) continue;
+    const snippet = scriptById(snippets, id);
+    if (!snippet) continue;
+    seen.add(id);
+    result.push(id);
+  }
+  return result;
+}
+
 /** Global onConnect scripts (targetsAllHosts), sorted by vault order. */
 export function getGlobalConnectScripts(snippets: Snippet[]): Snippet[] {
   return sortByVaultOrder(
@@ -77,9 +94,20 @@ export function getHostConnectScriptIds(host: Host, snippets: Snippet[]): string
   return migrateHostConnectScriptIds(host, snippets);
 }
 
+/**
+ * Host-details draft queue: includes scripts pending promote-to-onConnect on save.
+ * Runtime connect still uses getHostConnectScriptIds (onConnect only).
+ */
+export function getEditableHostConnectScriptIds(host: Host, snippets: Snippet[]): string[] {
+  if (host.connectScriptIds !== undefined) {
+    return pruneEditableConnectScriptIds(host.connectScriptIds, snippets);
+  }
+  return migrateHostConnectScriptIds(host, snippets);
+}
+
 export function ensureHostConnectScriptIds(host: Host, snippets: Snippet[]): Host {
   if (host.connectScriptIds !== undefined) {
-    const pruned = pruneConnectScriptIds(host.connectScriptIds, snippets);
+    const pruned = pruneEditableConnectScriptIds(host.connectScriptIds, snippets);
     if (pruned.length === host.connectScriptIds.length
       && pruned.every((id, index) => id === host.connectScriptIds![index])) {
       return host;
@@ -164,7 +192,7 @@ export function shouldMarkConnectAutomationConsumed(options: {
 export function appendHostConnectScript(host: Host, scriptId: string, snippets: Snippet[]): Host {
   const snippet = scriptById(snippets, scriptId);
   if (!snippet) return host;
-  const current = getHostConnectScriptIds(host, snippets);
+  const current = getEditableHostConnectScriptIds(host, snippets);
   if (current.includes(scriptId)) {
     return { ...host, connectScriptIds: current };
   }
@@ -172,7 +200,7 @@ export function appendHostConnectScript(host: Host, scriptId: string, snippets: 
 }
 
 export function removeHostConnectScript(host: Host, scriptId: string, snippets: Snippet[]): Host {
-  const current = getHostConnectScriptIds(host, snippets);
+  const current = getEditableHostConnectScriptIds(host, snippets);
   const next = current.filter((id) => id !== scriptId);
   return { ...host, connectScriptIds: next };
 }
@@ -185,7 +213,7 @@ export function reorderHostConnectScript(
   snippets: Snippet[],
 ): Host {
   if (draggedScriptId === targetScriptId) return host;
-  const current = [...getHostConnectScriptIds(host, snippets)];
+  const current = [...getEditableHostConnectScriptIds(host, snippets)];
   const fromIndex = current.indexOf(draggedScriptId);
   const targetIndex = current.indexOf(targetScriptId);
   if (fromIndex === -1 || targetIndex === -1) return host;

--- a/domain/hostConnectScripts.ts
+++ b/domain/hostConnectScripts.ts
@@ -229,6 +229,11 @@ export function reorderHostConnectScript(
 
 export function prepareSnippetForHostConnectQueue(snippet: Snippet, hostId: string): Snippet {
   if (!isScriptSnippet(snippet)) return snippet;
+  if (snippet.targetsAllHosts) {
+    return snippet.trigger === 'onConnect'
+      ? snippet
+      : { ...snippet, trigger: 'onConnect' };
+  }
   return {
     ...linkHostToScript(snippet, hostId),
     trigger: 'onConnect',
@@ -237,38 +242,127 @@ export function prepareSnippetForHostConnectQueue(snippet: Snippet, hostId: stri
 
 function connectQueueSnippetNeedsPromote(snippet: Snippet, hostId: string): boolean {
   if (!isScriptSnippet(snippet)) return false;
-  // Never demote vault-wide onConnect scripts just because they appear in a host queue.
-  if (snippet.targetsAllHosts) return false;
   if (snippet.trigger !== 'onConnect') return true;
+  if (snippet.targetsAllHosts) return false;
   return !snippetAppliesToHost(snippet, hostId);
 }
 
+function snippetTargetsEqual(left: Snippet, right: Snippet): boolean {
+  if (Boolean(left.targetsAllHosts) !== Boolean(right.targetsAllHosts)) return false;
+  const leftTargets = left.targets ?? [];
+  const rightTargets = right.targets ?? [];
+  if (leftTargets.length !== rightTargets.length) return false;
+  return leftTargets.every((id, index) => id === rightTargets[index]);
+}
+
+/**
+ * After promoting a script to onConnect, ensure every remaining target host with an
+ * explicit connectScriptIds queue includes it. Hosts without an explicit queue still
+ * pick the script up via migrateHostConnectScriptIds.
+ */
+export function ensureTargetHostsHaveConnectScript(
+  hosts: Host[],
+  snippet: Snippet,
+  snippets: Snippet[],
+  excludeHostId?: string,
+): Host[] {
+  if (!snippet.id || !isScriptSnippet(snippet) || snippet.trigger !== 'onConnect') return hosts;
+  if (snippet.targetsAllHosts) return hosts;
+  const targetIds = new Set(snippet.targets ?? []);
+  if (targetIds.size === 0) return hosts;
+
+  let changed = false;
+  const nextHosts = hosts.map((host) => {
+    if (host.id === excludeHostId) return host;
+    if (!targetIds.has(host.id)) return host;
+    if (host.connectScriptIds === undefined) return host;
+    const updated = appendHostConnectScript(host, snippet.id!, snippets);
+    if (updated !== host) changed = true;
+    return updated;
+  });
+  return changed ? nextHosts : hosts;
+}
+
+export type SyncHostConnectQueueSaveOptions = {
+  /** Snippets snapshot from when the host editor opened (detect concurrent demotion). */
+  baselineSnippets?: Snippet[];
+  /** When provided, promote also syncs other hosts that remain in targets. */
+  hosts?: Host[];
+};
+
 /**
  * Sync script metadata when saving a host connect queue.
- * Promotes every queued script to onConnect + host target, including IDs that
- * were already persisted as draft/manual entries before this save.
+ * Promotes draft/manual queue entries, preserves global onConnect scripts,
+ * drops concurrently demoted entries, and optionally syncs peer host queues.
  */
 export function syncSnippetsForHostConnectQueueSave(
   snippets: Snippet[],
   hostId: string,
   previousQueueIds: string[],
   nextQueueIds: string[],
-): { snippets: Snippet[]; changed: boolean } {
-  const nextSet = new Set(nextQueueIds);
+  options: SyncHostConnectQueueSaveOptions = {},
+): {
+  snippets: Snippet[];
+  hosts: Host[];
+  connectScriptIds: string[];
+  changed: boolean;
+} {
+  const previousSet = new Set(previousQueueIds);
+  const baseline = options.baselineSnippets ?? snippets;
   let nextSnippets = snippets;
+  let nextHosts = options.hosts ?? [];
   let changed = false;
+  const retainedIds: string[] = [];
+  const demotedDropIds = new Set<string>();
 
   for (const scriptId of nextQueueIds) {
-    nextSnippets = nextSnippets.map((item) => {
-      if (item.id !== scriptId || !isScriptSnippet(item)) return item;
-      if (!connectQueueSnippetNeedsPromote(item, hostId)) return item;
+    const item = nextSnippets.find((entry) => entry.id === scriptId && isScriptSnippet(entry));
+    if (!item) continue;
+
+    if (!connectQueueSnippetNeedsPromote(item, hostId)) {
+      retainedIds.push(scriptId);
+      continue;
+    }
+
+    const newlyAdded = !previousSet.has(scriptId);
+    const baselineItem = baseline.find((entry) => entry.id === scriptId);
+    const wasOnConnectAtBaseline = Boolean(
+      baselineItem
+      && isScriptSnippet(baselineItem)
+      && baselineItem.trigger === 'onConnect',
+    );
+    if (!newlyAdded && wasOnConnectAtBaseline) {
+      // Concurrent demotion while the editor stayed open: keep demotion, drop stale queue id.
+      demotedDropIds.add(scriptId);
+      continue;
+    }
+
+    const prepared = prepareSnippetForHostConnectQueue(item, hostId);
+    if (
+      prepared.trigger !== item.trigger
+      || !snippetTargetsEqual(prepared, item)
+    ) {
+      nextSnippets = nextSnippets.map((entry) => (entry.id === scriptId ? prepared : entry));
       changed = true;
-      return prepareSnippetForHostConnectQueue(item, hostId);
-    });
+      if (options.hosts) {
+        const syncedHosts = ensureTargetHostsHaveConnectScript(
+          nextHosts,
+          prepared,
+          nextSnippets,
+          hostId,
+        );
+        if (syncedHosts !== nextHosts) {
+          nextHosts = syncedHosts;
+          changed = true;
+        }
+      }
+    }
+    retainedIds.push(scriptId);
   }
 
   for (const scriptId of previousQueueIds) {
-    if (nextSet.has(scriptId)) continue;
+    if (retainedIds.includes(scriptId)) continue;
+    if (demotedDropIds.has(scriptId)) continue;
     const unlinked = unlinkHostFromScripts(nextSnippets, hostId, scriptId);
     if (unlinked !== nextSnippets) {
       nextSnippets = unlinked;
@@ -276,7 +370,19 @@ export function syncSnippetsForHostConnectQueueSave(
     }
   }
 
-  return { snippets: nextSnippets, changed };
+  if (
+    retainedIds.length !== nextQueueIds.length
+    || retainedIds.some((id, index) => id !== nextQueueIds[index])
+  ) {
+    changed = true;
+  }
+
+  return {
+    snippets: nextSnippets,
+    hosts: nextHosts,
+    connectScriptIds: retainedIds,
+    changed,
+  };
 }
 
 export function syncHostsForSnippetTargetChange(

--- a/domain/hostConnectScripts.ts
+++ b/domain/hostConnectScripts.ts
@@ -336,6 +336,19 @@ export function syncSnippetsForHostConnectQueueSave(
     }
     if (
       !newlyAdded
+      && baselineItem
+      && isScriptSnippet(baselineItem)
+      && baselineItem.trigger === 'onConnect'
+      && item.trigger === 'onConnect'
+      && (Boolean(baselineItem.targetsAllHosts) || snippetAppliesToHost(baselineItem, hostId))
+      && !(Boolean(item.targetsAllHosts) || snippetAppliesToHost(item, hostId))
+    ) {
+      // Concurrent target removal for this host: do not re-link on save.
+      demotedDropIds.add(scriptId);
+      continue;
+    }
+    if (
+      !newlyAdded
       && baselineTrigger
       && baselineTrigger !== 'onConnect'
       && item.trigger !== baselineTrigger

--- a/domain/hostConnectScripts.ts
+++ b/domain/hostConnectScripts.ts
@@ -338,8 +338,6 @@ export function syncSnippetsForHostConnectQueueSave(
       !newlyAdded
       && baselineItem
       && isScriptSnippet(baselineItem)
-      && baselineItem.trigger === 'onConnect'
-      && item.trigger === 'onConnect'
       && (Boolean(baselineItem.targetsAllHosts) || snippetAppliesToHost(baselineItem, hostId))
       && !(Boolean(item.targetsAllHosts) || snippetAppliesToHost(item, hostId))
     ) {

--- a/domain/hostConnectScripts.ts
+++ b/domain/hostConnectScripts.ts
@@ -237,8 +237,9 @@ export function prepareSnippetForHostConnectQueue(snippet: Snippet, hostId: stri
 
 function connectQueueSnippetNeedsPromote(snippet: Snippet, hostId: string): boolean {
   if (!isScriptSnippet(snippet)) return false;
+  // Never demote vault-wide onConnect scripts just because they appear in a host queue.
+  if (snippet.targetsAllHosts) return false;
   if (snippet.trigger !== 'onConnect') return true;
-  if (snippet.targetsAllHosts) return true;
   return !snippetAppliesToHost(snippet, hostId);
 }
 


### PR DESCRIPTION
## Summary

- Host details **Automation / Add script to queue** listed default `manual` scripts, but `getHostConnectScriptIds` / `appendHostConnectScript` immediately pruned anything that was not already `onConnect`, so selection looked successful and then vanished (repro video on #2705).
- Introduce an editable draft queue (`getEditableHostConnectScriptIds`) that keeps existing script IDs while editing; runtime connect still uses onConnect-only pruning. Host save continues to promote via `prepareSnippetForHostConnectQueue`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2705

## Changes Made

- Add `getEditableHostConnectScriptIds` and soft-prune for draft editing / `ensureHostConnectScriptIds`
- Route append / remove / reorder through the editable queue
- Host details scripts section renders the editable queue
- Tests for selecting default manual scripts and preserving draft entries

## Screenshots / Demo

N/A — domain/UI queue wiring; covered by unit tests matching the reported select-but-not-apply path.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — `node --test --import tsx domain/hostConnectScripts.test.ts domain/snippetAgentOps.test.ts domain/snippetSelection.test.ts`
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

## Test plan

- [ ] Create a new automation script (default trigger: manual)
- [ ] Edit a host → Automation → add that script to the queue
- [ ] Confirm it appears in the queue immediately
- [ ] Save the host and confirm the script trigger becomes “Run on connect” / is linked
- [ ] Connect and confirm the script runs
- [ ] Add a second manual script without losing the first queued entry


Made with [Cursor](https://cursor.com)