### PR TITLE
feat(settings): one-click clear all session logs

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -197,6 +197,9 @@ export const enCoreMessages: Messages = {
   'settings.sessionLogs.timestamps': 'Add timestamps',
   'settings.sessionLogs.timestampsDesc': 'Prefix each line in plain text and HTML logs with the local time.',
   'settings.sessionLogs.hint': 'Session logs capture all terminal output for troubleshooting and auditing purposes.',
+  'settings.sessionLogs.clearAll': 'Clear all logs',
+  'settings.sessionLogs.clearAllDesc': 'Delete all saved session log files and host subdirectories from the save directory.',
+  'settings.sessionLogs.clearConfirm': 'This will permanently delete all session log files in the save directory. This cannot be undone. Continue?',
 
   // Settings > SSH Debug Logs
   'settings.sshDebugLogs.title': 'SSH Debug Logs',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -185,6 +185,9 @@ export const ruCoreMessages: Messages = {
   'settings.sessionLogs.timestamps': 'Добавлять метки времени',
   'settings.sessionLogs.timestampsDesc': 'Добавлять локальное время в начало каждой строки в текстовых и HTML-журналах.',
   'settings.sessionLogs.hint': 'Журналы сессий сохраняют весь вывод терминала для диагностики и аудита.',
+  'settings.sessionLogs.clearAll': 'Очистить все журналы',
+  'settings.sessionLogs.clearAllDesc': 'Удалить все сохранённые файлы журналов сессий и вложенные папки хостов из папки сохранения.',
+  'settings.sessionLogs.clearConfirm': 'Это приведёт к безвозвратному удалению всех файлов журналов сессий в папке сохранения. Это действие нельзя отменить. Продолжить?',
 
   // Settings > SSH Debug Logs
   'settings.sshDebugLogs.title': 'Отладочные журналы SSH',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -194,6 +194,9 @@ export const zhCNCoreMessages: Messages = {
   'settings.sessionLogs.timestamps': '添加时间戳',
   'settings.sessionLogs.timestampsDesc': '为纯文本和 HTML 日志的每一行添加本地时间。',
   'settings.sessionLogs.hint': '会话日志用于记录终端输出，便于故障排查和审计。',
+  'settings.sessionLogs.clearAll': '清空所有日志',
+  'settings.sessionLogs.clearAllDesc': '删除保存目录中所有会话日志文件及主机子目录。',
+  'settings.sessionLogs.clearConfirm': '此操作将永久删除保存目录中的所有会话日志文件，且无法撤销，是否继续？',
 
   // Settings > SSH Debug Logs
   'settings.sshDebugLogs.title': 'SSH 调试日志',

--- a/application/i18n/locales/zh-TW/core.ts
+++ b/application/i18n/locales/zh-TW/core.ts
@@ -194,6 +194,9 @@ export const zhTWCoreMessages: Messages = {
   'settings.sessionLogs.timestamps': '新增時間戳',
   'settings.sessionLogs.timestampsDesc': '為純文字和 HTML 日誌的每一行新增本機時間。',
   'settings.sessionLogs.hint': '工作階段日誌用於記錄終端輸出，便於故障排查和審計。',
+  'settings.sessionLogs.clearAll': '清空所有日誌',
+  'settings.sessionLogs.clearAllDesc': '刪除儲存目錄中所有工作階段日誌檔案及主機子目錄。',
+  'settings.sessionLogs.clearConfirm': '此操作將永久刪除儲存目錄中的所有工作階段日誌檔案，且無法復原，是否繼續？',
 
   // Settings > SSH Debug Logs
   'settings.sshDebugLogs.title': 'SSH 除錯日誌',

--- a/components/settings/tabs/SettingsSystemTab.tsx
+++ b/components/settings/tabs/SettingsSystemTab.tsx
@@ -175,6 +175,8 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
   const [crashLogClearResult, setCrashLogClearResult] = useState<{ deletedCount: number } | null>(null);
   const [sshDebugLogInfo, setSshDebugLogInfo] = useState<SshDebugLogInfo | null>(null);
   const [isLoadingSshDebugLogInfo, setIsLoadingSshDebugLogInfo] = useState(false);
+  const [isClearingSessionLogs, setIsClearingSessionLogs] = useState(false);
+  const [sessionLogsClearResult, setSessionLogsClearResult] = useState<{ deletedCount: number; failedCount: number } | null>(null);
 
   const [appVersion, setAppVersion] = useState('');
 
@@ -354,6 +356,25 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
       console.error("[SettingsSystemTab] Failed to open directory:", err);
     }
   }, [sessionLogsDir]);
+
+  const handleClearSessionLogs = useCallback(async () => {
+    const bridge = netcattyBridge.get();
+    if (!sessionLogsDir || !bridge?.clearSessionLogsDir) return;
+    if (!window.confirm(t("settings.sessionLogs.clearConfirm"))) return;
+
+    setIsClearingSessionLogs(true);
+    setSessionLogsClearResult(null);
+    try {
+      const result = await bridge.clearSessionLogsDir(sessionLogsDir);
+      if (result.success) {
+        setSessionLogsClearResult({ deletedCount: result.deletedCount, failedCount: result.failedCount });
+      }
+    } catch (err) {
+      console.error("[SettingsSystemTab] Failed to clear session logs:", err);
+    } finally {
+      setIsClearingSessionLogs(false);
+    }
+  }, [sessionLogsDir, t]);
 
   const handleOpenSshDebugLogDir = useCallback(async () => {
     const bridge = netcattyBridge.get();
@@ -984,6 +1005,34 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
                   onChange={setSessionLogsTimestampsEnabled}
                 />
               </SettingRow>
+
+              {/* Clear All Logs */}
+              <div className="space-y-2 pt-2 border-t border-border/60">
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <p className="text-sm font-medium">{t("settings.sessionLogs.clearAll")}</p>
+                    <p className="text-xs text-muted-foreground">{t("settings.sessionLogs.clearAllDesc")}</p>
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleClearSessionLogs}
+                    disabled={isClearingSessionLogs || !sessionLogsDir}
+                    className="gap-1.5 shrink-0 text-destructive hover:text-destructive hover:bg-destructive/10"
+                  >
+                    <Trash2 size={14} />
+                    {isClearingSessionLogs ? t("settings.system.clearing") : t("settings.sessionLogs.clearAll")}
+                  </Button>
+                </div>
+                {sessionLogsClearResult && (
+                  <p className="text-sm text-muted-foreground">
+                    {t("settings.system.clearResult", {
+                      deleted: sessionLogsClearResult.deletedCount,
+                      failed: sessionLogsClearResult.failedCount,
+                    })}
+                  </p>
+                )}
+              </div>
             </SettingCard>
 
             <p className="text-xs text-muted-foreground">

--- a/electron/bridges/sessionLogStreamManager.cjs
+++ b/electron/bridges/sessionLogStreamManager.cjs
@@ -484,6 +484,20 @@ function hasStream(sessionId) {
 }
 
 /**
+ * Absolute paths of files currently open by active log streams.
+ * Used by clear-all so it never unlinks a live write target.
+ * @returns {string[]}
+ */
+function getActiveLogPaths() {
+  const paths = [];
+  for (const entry of activeStreams.values()) {
+    if (!entry?.filePath || entry.disabled) continue;
+    paths.push(path.resolve(entry.filePath));
+  }
+  return paths;
+}
+
+/**
  * Cleanup all active streams (called on app quit).
  */
 async function cleanupAll() {
@@ -500,5 +514,6 @@ module.exports = {
   registerProgrammaticCommandLogRewrite,
   stopStream,
   hasStream,
+  getActiveLogPaths,
   cleanupAll,
 };

--- a/electron/bridges/sessionLogsBridge.cjs
+++ b/electron/bridges/sessionLogsBridge.cjs
@@ -278,6 +278,9 @@ function isSessionLogArtifactName(name) {
  *
  * Never deletes unrelated top-level files/folders (e.g. Documents/Downloads
  * when the user pointed the save directory at a shared folder).
+ *
+ * Active auto-save / continuous-log write targets are skipped so clear-all
+ * never unlinks a live stream (orphan inode / silent stop).
  */
 async function clearSessionLogsDir(event, payload = {}) {
   const { directory } = payload;
@@ -288,6 +291,16 @@ async function clearSessionLogsDir(event, payload = {}) {
 
   let deletedCount = 0;
   let failedCount = 0;
+
+  // Live write targets from sessionLogStreamManager — skip these paths.
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+  const activeLogPaths = new Set(
+    (typeof sessionLogStreamManager.getActiveLogPaths === "function"
+      ? sessionLogStreamManager.getActiveLogPaths()
+      : []
+    ).map((p) => path.resolve(p)),
+  );
+  const isActiveLogPath = (filePath) => activeLogPaths.has(path.resolve(filePath));
 
   try {
     const entries = await fs.promises.readdir(directory, { withFileTypes: true });
@@ -315,6 +328,7 @@ async function clearSessionLogsDir(event, payload = {}) {
       try {
         if (isFile) {
           if (!isSessionLogArtifactName(entry.name)) continue;
+          if (isActiveLogPath(entryPath)) continue;
           await fs.promises.rm(entryPath, { force: true });
           deletedCount++;
           continue;
@@ -324,6 +338,7 @@ async function clearSessionLogsDir(event, payload = {}) {
         const nested = await fs.promises.readdir(entryPath, { withFileTypes: true });
         const logFiles = [];
         let hasNonLogEntry = false;
+        let hasActiveLog = false;
 
         for (const nestedEntry of nested) {
           const nestedPath = path.join(entryPath, nestedEntry.name);
@@ -342,23 +357,27 @@ async function clearSessionLogsDir(event, payload = {}) {
             }
           }
           if (nestedIsFile && isSessionLogArtifactName(nestedEntry.name)) {
-            logFiles.push(nestedPath);
+            if (isActiveLogPath(nestedPath)) {
+              hasActiveLog = true;
+            } else {
+              logFiles.push(nestedPath);
+            }
           } else {
             hasNonLogEntry = true;
           }
         }
 
-        if (logFiles.length === 0) {
+        if (logFiles.length === 0 && !hasActiveLog) {
           // Not an app host-log folder (or empty / only non-log content) — leave it alone.
           continue;
         }
 
-        if (!hasNonLogEntry) {
-          // Pure session-log host folder: remove the whole directory as one artifact.
+        if (!hasNonLogEntry && !hasActiveLog) {
+          // Pure session-log host folder with no live streams: remove as one artifact.
           await fs.promises.rm(entryPath, { recursive: true, force: true });
           deletedCount++;
         } else {
-          // Mixed directory: only delete known log files; keep the rest.
+          // Mixed directory and/or active streams: only delete inactive known log files.
           for (const logPath of logFiles) {
             try {
               await fs.promises.rm(logPath, { force: true });

--- a/electron/bridges/sessionLogsBridge.cjs
+++ b/electron/bridges/sessionLogsBridge.cjs
@@ -253,6 +253,42 @@ async function openSessionLogsDir(event, payload) {
   }
 }
 
+/**
+ * Delete all files and host subdirectories inside the configured session
+ * logs directory (used by the "clear all logs" action in Settings).
+ */
+async function clearSessionLogsDir(event, payload = {}) {
+  const { directory } = payload;
+
+  if (!directory) {
+    return { success: false, deletedCount: 0, failedCount: 0, error: "No directory specified" };
+  }
+
+  let deletedCount = 0;
+  let failedCount = 0;
+
+  try {
+    const entries = await fs.promises.readdir(directory);
+    for (const entry of entries) {
+      const entryPath = path.join(directory, entry);
+      try {
+        await fs.promises.rm(entryPath, { recursive: true, force: true });
+        deletedCount++;
+      } catch (err) {
+        failedCount++;
+        console.error(`[SessionLogs] Could not delete ${entry}:`, err.message);
+      }
+    }
+    return { success: true, deletedCount, failedCount };
+  } catch (err) {
+    if (err?.code === "ENOENT") {
+      return { success: true, deletedCount: 0, failedCount: 0 };
+    }
+    console.error("[SessionLogs] Failed to clear session logs directory:", err);
+    return { success: false, deletedCount, failedCount, error: err.message };
+  }
+}
+
 async function startManualSessionLog(event, payload = {}) {
   const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
   const { sessionId, sessionName, preferredDirectory, initialLine } = payload;
@@ -384,6 +420,7 @@ function registerHandlers(ipcMain, options = {}) {
   ipcMain.handle("netcatty:sessionLogs:selectDir", selectSessionLogsDir);
   ipcMain.handle("netcatty:sessionLogs:autoSave", autoSaveSessionLog);
   ipcMain.handle("netcatty:sessionLogs:openDir", openSessionLogsDir);
+  ipcMain.handle("netcatty:sessionLogs:clear", clearSessionLogsDir);
   ipcMain.handle("netcatty:sessionLog:manualStart", startManualSessionLog);
   ipcMain.handle("netcatty:sessionLog:manualStop", stopManualSessionLog);
   ipcMain.handle("netcatty:sessionLog:manualStatus", getManualSessionLogStatus);
@@ -409,6 +446,7 @@ module.exports = {
   selectSessionLogsDir,
   autoSaveSessionLog,
   openSessionLogsDir,
+  clearSessionLogsDir,
   startManualSessionLog,
   stopManualSessionLog,
   getManualSessionLogStatus,

--- a/electron/bridges/sessionLogsBridge.cjs
+++ b/electron/bridges/sessionLogsBridge.cjs
@@ -253,9 +253,31 @@ async function openSessionLogsDir(event, payload) {
   }
 }
 
+// Auto-save writes `{hostDir}/{YYYY-MM-DDTHH-MM-SS}.{txt|log|html}`.
+// Manual export / continuous logs commonly write `{label}_{YYYY-MM-DDTHH-MM-SS}.{ext}`.
+const SESSION_LOG_TIMESTAMP_FILE = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.(txt|log|html)$/i;
+const SESSION_LOG_LABELED_FILE = /^.+_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.(txt|log|html)$/i;
+
 /**
- * Delete all files and host subdirectories inside the configured session
- * logs directory (used by the "clear all logs" action in Settings).
+ * True when a basename matches a Netcatty session-log artifact filename.
+ * Used so "clear all" never wipes unrelated files in a shared save directory.
+ */
+function isSessionLogArtifactName(name) {
+  const base = path.basename(String(name || ""));
+  return SESSION_LOG_TIMESTAMP_FILE.test(base) || SESSION_LOG_LABELED_FILE.test(base);
+}
+
+/**
+ * Delete known session-log artifacts inside the configured save directory
+ * (used by the "clear all logs" action in Settings).
+ *
+ * Only removes:
+ * - Top-level files matching session-log filename patterns
+ * - Host subdirectories that exclusively contain session-log files
+ * - Session-log files inside mixed host subdirectories (other entries kept)
+ *
+ * Never deletes unrelated top-level files/folders (e.g. Documents/Downloads
+ * when the user pointed the save directory at a shared folder).
  */
 async function clearSessionLogsDir(event, payload = {}) {
   const { directory } = payload;
@@ -268,15 +290,88 @@ async function clearSessionLogsDir(event, payload = {}) {
   let failedCount = 0;
 
   try {
-    const entries = await fs.promises.readdir(directory);
+    const entries = await fs.promises.readdir(directory, { withFileTypes: true });
     for (const entry of entries) {
-      const entryPath = path.join(directory, entry);
+      const entryPath = path.join(directory, entry.name);
+
+      // Skip anything that is not a plain file or directory (symlinks, sockets, …).
+      // Use dirent type when available; fall back to lstat for exotic FS entries.
+      let isFile = entry.isFile();
+      let isDirectory = entry.isDirectory();
+      if ((!isFile && !isDirectory) || entry.isSymbolicLink()) {
+        // Dirent may report the target type for some platforms; re-check with lstat
+        // so we never follow or delete symlink targets outside the save directory.
+        try {
+          const st = await fs.promises.lstat(entryPath);
+          if (st.isSymbolicLink()) continue;
+          isFile = st.isFile();
+          isDirectory = st.isDirectory();
+        } catch {
+          continue;
+        }
+      }
+      if (!isFile && !isDirectory) continue;
+
       try {
-        await fs.promises.rm(entryPath, { recursive: true, force: true });
-        deletedCount++;
+        if (isFile) {
+          if (!isSessionLogArtifactName(entry.name)) continue;
+          await fs.promises.rm(entryPath, { force: true });
+          deletedCount++;
+          continue;
+        }
+
+        // Host subdirectory created by auto-save: only touch known log files.
+        const nested = await fs.promises.readdir(entryPath, { withFileTypes: true });
+        const logFiles = [];
+        let hasNonLogEntry = false;
+
+        for (const nestedEntry of nested) {
+          const nestedPath = path.join(entryPath, nestedEntry.name);
+          let nestedIsFile = nestedEntry.isFile();
+          if (nestedEntry.isSymbolicLink() || (!nestedIsFile && !nestedEntry.isDirectory())) {
+            try {
+              const st = await fs.promises.lstat(nestedPath);
+              if (st.isSymbolicLink() || !st.isFile()) {
+                hasNonLogEntry = true;
+                continue;
+              }
+              nestedIsFile = true;
+            } catch {
+              hasNonLogEntry = true;
+              continue;
+            }
+          }
+          if (nestedIsFile && isSessionLogArtifactName(nestedEntry.name)) {
+            logFiles.push(nestedPath);
+          } else {
+            hasNonLogEntry = true;
+          }
+        }
+
+        if (logFiles.length === 0) {
+          // Not an app host-log folder (or empty / only non-log content) — leave it alone.
+          continue;
+        }
+
+        if (!hasNonLogEntry) {
+          // Pure session-log host folder: remove the whole directory as one artifact.
+          await fs.promises.rm(entryPath, { recursive: true, force: true });
+          deletedCount++;
+        } else {
+          // Mixed directory: only delete known log files; keep the rest.
+          for (const logPath of logFiles) {
+            try {
+              await fs.promises.rm(logPath, { force: true });
+              deletedCount++;
+            } catch (err) {
+              failedCount++;
+              console.error(`[SessionLogs] Could not delete ${path.basename(logPath)}:`, err.message);
+            }
+          }
+        }
       } catch (err) {
         failedCount++;
-        console.error(`[SessionLogs] Could not delete ${entry}:`, err.message);
+        console.error(`[SessionLogs] Could not delete ${entry.name}:`, err.message);
       }
     }
     return { success: true, deletedCount, failedCount };
@@ -447,6 +542,7 @@ module.exports = {
   autoSaveSessionLog,
   openSessionLogsDir,
   clearSessionLogsDir,
+  isSessionLogArtifactName,
   startManualSessionLog,
   stopManualSessionLog,
   getManualSessionLogStatus,

--- a/electron/bridges/sessionLogsBridge.cjs
+++ b/electron/bridges/sessionLogsBridge.cjs
@@ -268,6 +268,69 @@ function isSessionLogArtifactName(name) {
 }
 
 /**
+ * Live write targets from this process's sessionLogStreamManager.
+ * Main and terminal worker each own a separate module instance.
+ * @returns {string[]}
+ */
+function getLocalActiveLogPaths() {
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+  if (typeof sessionLogStreamManager.getActiveLogPaths !== "function") return [];
+  return sessionLogStreamManager.getActiveLogPaths()
+    .filter((p) => typeof p === "string" && p.length > 0)
+    .map((p) => path.resolve(p));
+}
+
+/**
+ * True when the terminal worker process is already running (or the manager
+ * does not expose a probe — unit-test mocks that only provide request()).
+ * Avoids cold-starting the utilityProcess solely for clear-all.
+ * @param {object|null} terminalWorkerManager
+ * @returns {boolean}
+ */
+function isTerminalWorkerRunning(terminalWorkerManager) {
+  if (!terminalWorkerManager) return false;
+  if (typeof terminalWorkerManager.isRunning === "function") {
+    return Boolean(terminalWorkerManager.isRunning());
+  }
+  // Mocks that only supply request() — treat as queryable.
+  return typeof terminalWorkerManager.request === "function";
+}
+
+/**
+ * Union of active log paths from the main process and the terminal worker.
+ * Worker-owned auto-save streams are invisible to the main-process manager.
+ * @param {object|null} terminalWorkerManager
+ * @returns {Promise<Set<string>>}
+ */
+async function collectActiveLogPaths(terminalWorkerManager = null) {
+  const activeLogPaths = new Set(getLocalActiveLogPaths());
+
+  if (!isTerminalWorkerRunning(terminalWorkerManager)) {
+    return activeLogPaths;
+  }
+
+  try {
+    const result = await terminalWorkerManager.request(
+      "netcatty:sessionLogs:getActivePaths",
+      {},
+      {},
+    );
+    const workerPaths = Array.isArray(result)
+      ? result
+      : (Array.isArray(result?.paths) ? result.paths : []);
+    for (const p of workerPaths) {
+      if (typeof p === "string" && p.length > 0) {
+        activeLogPaths.add(path.resolve(p));
+      }
+    }
+  } catch {
+    // Worker unavailable or channel missing — main-process paths only.
+  }
+
+  return activeLogPaths;
+}
+
+/**
  * Delete known session-log artifacts inside the configured save directory
  * (used by the "clear all logs" action in Settings).
  *
@@ -280,9 +343,11 @@ function isSessionLogArtifactName(name) {
  * when the user pointed the save directory at a shared folder).
  *
  * Active auto-save / continuous-log write targets are skipped so clear-all
- * never unlinks a live stream (orphan inode / silent stop).
+ * never unlinks a live stream (orphan inode / silent stop). Paths include
+ * both main-process streams and worker-owned streams when a terminal worker
+ * is running.
  */
-async function clearSessionLogsDir(event, payload = {}) {
+async function clearSessionLogsDir(event, payload = {}, terminalWorkerManager = null) {
   const { directory } = payload;
 
   if (!directory) {
@@ -292,14 +357,8 @@ async function clearSessionLogsDir(event, payload = {}) {
   let deletedCount = 0;
   let failedCount = 0;
 
-  // Live write targets from sessionLogStreamManager — skip these paths.
-  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
-  const activeLogPaths = new Set(
-    (typeof sessionLogStreamManager.getActiveLogPaths === "function"
-      ? sessionLogStreamManager.getActiveLogPaths()
-      : []
-    ).map((p) => path.resolve(p)),
-  );
+  // Live write targets (main + worker) — skip these paths.
+  const activeLogPaths = await collectActiveLogPaths(terminalWorkerManager);
   const isActiveLogPath = (filePath) => activeLogPaths.has(path.resolve(filePath));
 
   try {
@@ -538,14 +597,29 @@ async function getManualSessionLogStatus(event, payload = {}) {
 }
 
 /**
+ * Worker-side handlers only. The terminal utilityProcess has its own
+ * sessionLogStreamManager instance; main queries these paths before clear-all.
+ */
+function registerWorkerHandlers(ipcMain) {
+  ipcMain.handle("netcatty:sessionLogs:getActivePaths", async () => getLocalActiveLogPaths());
+}
+
+/**
  * Register IPC handlers for session logs operations
  */
 function registerHandlers(ipcMain, options = {}) {
+  const terminalWorkerManager = options.terminalWorkerManager || null;
+
   ipcMain.handle("netcatty:sessionLogs:export", exportSessionLog);
   ipcMain.handle("netcatty:sessionLogs:selectDir", selectSessionLogsDir);
   ipcMain.handle("netcatty:sessionLogs:autoSave", autoSaveSessionLog);
   ipcMain.handle("netcatty:sessionLogs:openDir", openSessionLogsDir);
-  ipcMain.handle("netcatty:sessionLogs:clear", clearSessionLogsDir);
+  ipcMain.handle(
+    "netcatty:sessionLogs:clear",
+    (event, payload) => clearSessionLogsDir(event, payload, terminalWorkerManager),
+  );
+  // Main can also answer this (manual / script streams) for symmetry / tests.
+  ipcMain.handle("netcatty:sessionLogs:getActivePaths", async () => getLocalActiveLogPaths());
   ipcMain.handle("netcatty:sessionLog:manualStart", startManualSessionLog);
   ipcMain.handle("netcatty:sessionLog:manualStop", stopManualSessionLog);
   ipcMain.handle("netcatty:sessionLog:manualStatus", getManualSessionLogStatus);
@@ -559,7 +633,7 @@ function registerHandlers(ipcMain, options = {}) {
   // mirrors every output chunk to the main process for script output buffers;
   // feed that same stream into the main-process log streams. appendData() is
   // a no-op for sessions without an active main-process stream.
-  options.terminalWorkerManager?.addOutputTap?.((sessionId, data) => {
+  terminalWorkerManager?.addOutputTap?.((sessionId, data) => {
     if (typeof data !== "string" || data.length === 0) return;
     require("./sessionLogStreamManager.cjs").appendData(sessionId, data);
   });
@@ -567,11 +641,14 @@ function registerHandlers(ipcMain, options = {}) {
 
 module.exports = {
   registerHandlers,
+  registerWorkerHandlers,
   exportSessionLog,
   selectSessionLogsDir,
   autoSaveSessionLog,
   openSessionLogsDir,
   clearSessionLogsDir,
+  collectActiveLogPaths,
+  getLocalActiveLogPaths,
   isSessionLogArtifactName,
   startManualSessionLog,
   stopManualSessionLog,

--- a/electron/bridges/sessionLogsBridge.cjs
+++ b/electron/bridges/sessionLogsBridge.cjs
@@ -339,6 +339,17 @@ async function clearSessionLogsDir(event, payload = {}) {
         const logFiles = [];
         let hasNonLogEntry = false;
         let hasActiveLog = false;
+        const resolvedEntryPath = path.resolve(entryPath);
+
+        // txt/html streams may not create a file until the first snapshot flush, so
+        // the active path may be absent from readdir. Any registered active path
+        // whose parent is this host dir still counts as live work.
+        for (const activePath of activeLogPaths) {
+          if (path.dirname(activePath) === resolvedEntryPath) {
+            hasActiveLog = true;
+            break;
+          }
+        }
 
         for (const nestedEntry of nested) {
           const nestedPath = path.join(entryPath, nestedEntry.name);

--- a/electron/bridges/sessionLogsBridge.test.cjs
+++ b/electron/bridges/sessionLogsBridge.test.cjs
@@ -107,6 +107,47 @@ test("auto-save host directory falls back when the sanitized host label is empty
   }
 });
 
+test("clearSessionLogsDir deletes host subdirectories and files from the save directory", async () => {
+  const directory = path.join(TEMP_ROOT, `clear-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const { clearSessionLogsDir } = loadBridgeWithDialog({});
+
+  try {
+    const hostDir = path.join(directory, "my-host");
+    fs.mkdirSync(hostDir, { recursive: true });
+    fs.writeFileSync(path.join(hostDir, "2026-01-01T00-00-00.txt"), "hello\n");
+    fs.writeFileSync(path.join(directory, "stray.log"), "stray\n");
+
+    const result = await clearSessionLogsDir(null, { directory });
+
+    assert.equal(result.success, true);
+    assert.equal(result.deletedCount, 2);
+    assert.equal(result.failedCount, 0);
+    assert.deepEqual(fs.readdirSync(directory), []);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("clearSessionLogsDir is a no-op when the directory does not exist", async () => {
+  const directory = path.join(TEMP_ROOT, `clear-missing-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const { clearSessionLogsDir } = loadBridgeWithDialog({});
+
+  const result = await clearSessionLogsDir(null, { directory });
+
+  assert.deepEqual(result, { success: true, deletedCount: 0, failedCount: 0 });
+});
+
+test("clearSessionLogsDir reports an error when no directory is specified", async () => {
+  const { clearSessionLogsDir } = loadBridgeWithDialog({});
+
+  const result = await clearSessionLogsDir(null, {});
+
+  assert.equal(result.success, false);
+  assert.equal(result.deletedCount, 0);
+  assert.equal(result.failedCount, 0);
+  assert.ok(result.error);
+});
+
 test("manual session logs survive tokenless stale stops and stop through the bridge", async () => {
   const directory = path.join(TEMP_ROOT, `manual-token-${Date.now()}-${Math.random().toString(16).slice(2)}`);
   const filePath = path.join(directory, "manual.log");

--- a/electron/bridges/sessionLogsBridge.test.cjs
+++ b/electron/bridges/sessionLogsBridge.test.cjs
@@ -240,6 +240,74 @@ test("clearSessionLogsDir preserves active auto-save stream files and host dirs"
   }
 });
 
+test("clearSessionLogsDir unions worker-owned active paths with main-process streams", async () => {
+  const directory = path.join(TEMP_ROOT, `clear-worker-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const { clearSessionLogsDir } = loadBridgeWithDialog({});
+
+  try {
+    const hostDir = path.join(directory, "worker-host");
+    fs.mkdirSync(hostDir, { recursive: true });
+    // Simulate a live worker-owned auto-save file (invisible to main manager).
+    const workerLivePath = path.join(hostDir, "2026-01-05T06-07-08.log");
+    fs.writeFileSync(workerLivePath, "worker live body\n");
+    // Stale sibling in the same host dir should still be cleared.
+    fs.writeFileSync(path.join(hostDir, "2026-01-01T00-00-00.log"), "stale\n");
+    // Unrelated pure host folder still cleared.
+    const staleHostDir = path.join(directory, "stale-worker-host");
+    fs.mkdirSync(staleHostDir, { recursive: true });
+    fs.writeFileSync(path.join(staleHostDir, "2026-01-03T00-00-00.txt"), "old\n");
+
+    let requestedChannel = null;
+    const terminalWorkerManager = {
+      isRunning: () => true,
+      request: async (channel) => {
+        requestedChannel = channel;
+        return [workerLivePath];
+      },
+    };
+
+    const result = await clearSessionLogsDir(null, { directory }, terminalWorkerManager);
+
+    assert.equal(requestedChannel, "netcatty:sessionLogs:getActivePaths");
+    assert.equal(result.success, true);
+    assert.equal(result.failedCount, 0);
+    assert.equal(result.deletedCount, 2); // stale sibling + pure stale host
+    assert.deepEqual(fs.readdirSync(directory).sort(), ["worker-host"]);
+    assert.ok(fs.existsSync(workerLivePath), "worker-owned active stream must survive clear-all");
+    assert.deepEqual(fs.readdirSync(hostDir), [path.basename(workerLivePath)]);
+    assert.equal(fs.readFileSync(workerLivePath, "utf8"), "worker live body\n");
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("clearSessionLogsDir does not cold-start a stopped terminal worker", async () => {
+  const directory = path.join(TEMP_ROOT, `clear-no-worker-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const { clearSessionLogsDir } = loadBridgeWithDialog({});
+
+  try {
+    fs.mkdirSync(directory, { recursive: true });
+    fs.writeFileSync(path.join(directory, "host_2026-01-01T00-00-00.txt"), "export\n");
+
+    let requestCalls = 0;
+    const terminalWorkerManager = {
+      isRunning: () => false,
+      request: async () => {
+        requestCalls += 1;
+        return [];
+      },
+    };
+
+    const result = await clearSessionLogsDir(null, { directory }, terminalWorkerManager);
+
+    assert.equal(requestCalls, 0, "must not request worker paths when worker is stopped");
+    assert.equal(result.success, true);
+    assert.equal(result.deletedCount, 1);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("clearSessionLogsDir preserves snapshot-only host dirs before the first file exists", async () => {
   const directory = path.join(TEMP_ROOT, `clear-snap-${Date.now()}-${Math.random().toString(16).slice(2)}`);
   const sessionId = `session-snap-${Date.now()}-${Math.random().toString(16).slice(2)}`;

--- a/electron/bridges/sessionLogsBridge.test.cjs
+++ b/electron/bridges/sessionLogsBridge.test.cjs
@@ -6,6 +6,15 @@ const Module = require("node:module");
 
 const TEMP_ROOT = path.join(__dirname, ".tmp-session-logs-bridge-tests");
 
+async function waitForPath(targetPath, { timeoutMs = 2000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(targetPath)) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for path: ${targetPath}`);
+}
+
 function loadBridgeWithDialog(dialogMock) {
   const originalLoad = Module._load;
   Module._load = function patchedLoad(request, parent, isMain) {
@@ -170,6 +179,63 @@ test("clearSessionLogsDir only removes log files inside mixed host directories",
     assert.deepEqual(fs.readdirSync(hostDir), ["user-notes.md"]);
     assert.equal(fs.readFileSync(path.join(hostDir, "user-notes.md"), "utf8"), "do not delete\n");
   } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("clearSessionLogsDir preserves active auto-save stream files and host dirs", async () => {
+  const directory = path.join(TEMP_ROOT, `clear-active-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const sessionId = `session-active-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const { clearSessionLogsDir } = loadBridgeWithDialog({});
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+
+  try {
+    const startToken = sessionLogStreamManager.startStream(sessionId, {
+      hostLabel: "live-host",
+      hostname: "live.example",
+      directory,
+      format: "raw",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+    });
+    assert.ok(startToken);
+    sessionLogStreamManager.appendData(sessionId, "live body\n");
+
+    // Prefer stream manager paths: createWriteStream open is async, so the
+    // file may not appear in readdir until the open/write settles.
+    const activePaths = sessionLogStreamManager.getActiveLogPaths();
+    assert.equal(activePaths.length, 1);
+    const activePath = activePaths[0];
+    const hostDir = path.dirname(activePath);
+    assert.equal(path.basename(hostDir), "live-host");
+
+    // Wait for the live target to materialize on disk (async open).
+    await waitForPath(activePath);
+    // Stale sibling log in the same host folder should still be cleared.
+    fs.writeFileSync(path.join(hostDir, "2026-01-01T00-00-00.log"), "stale\n");
+    // Inactive pure host folder should still be removed.
+    const staleHostDir = path.join(directory, "stale-host");
+    fs.mkdirSync(staleHostDir, { recursive: true });
+    fs.writeFileSync(path.join(staleHostDir, "2026-01-03T00-00-00.txt"), "old\n");
+
+    const result = await clearSessionLogsDir(null, { directory });
+
+    assert.equal(result.success, true);
+    assert.equal(result.failedCount, 0);
+    assert.equal(result.deletedCount, 2); // stale sibling log + pure stale-host folder
+    assert.deepEqual(fs.readdirSync(directory).sort(), ["live-host"]);
+    assert.ok(fs.existsSync(activePath), "active stream path must survive clear-all");
+    assert.deepEqual(fs.readdirSync(hostDir), [path.basename(activePath)]);
+
+    // Stream must still accept writes after clear-all (not unlinked/orphaned).
+    sessionLogStreamManager.appendData(sessionId, "after clear\n");
+    assert.equal(sessionLogStreamManager.hasStream(sessionId), true);
+    const stoppedPath = await sessionLogStreamManager.stopStream(sessionId, startToken);
+    assert.equal(path.resolve(stoppedPath), path.resolve(activePath));
+    const content = fs.readFileSync(activePath, "utf8");
+    assert.match(content, /live body/);
+    assert.match(content, /after clear/);
+  } finally {
+    await sessionLogStreamManager.cleanupAll();
     fs.rmSync(directory, { recursive: true, force: true });
   }
 });

--- a/electron/bridges/sessionLogsBridge.test.cjs
+++ b/electron/bridges/sessionLogsBridge.test.cjs
@@ -240,6 +240,59 @@ test("clearSessionLogsDir preserves active auto-save stream files and host dirs"
   }
 });
 
+test("clearSessionLogsDir preserves snapshot-only host dirs before the first file exists", async () => {
+  const directory = path.join(TEMP_ROOT, `clear-snap-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const sessionId = `session-snap-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const { clearSessionLogsDir } = loadBridgeWithDialog({});
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+
+  try {
+    // txt streams keep renderer state in memory and only materialize the file
+    // on snapshot flush — clear-all must still treat the registered path as live.
+    const startToken = sessionLogStreamManager.startStream(sessionId, {
+      hostLabel: "snap-host",
+      hostname: "snap.example",
+      directory,
+      format: "txt",
+      startTime: Date.UTC(2026, 0, 4, 5, 6, 7),
+    });
+    assert.ok(startToken);
+
+    const activePaths = sessionLogStreamManager.getActiveLogPaths();
+    assert.equal(activePaths.length, 1);
+    const activePath = activePaths[0];
+    const hostDir = path.dirname(activePath);
+    assert.equal(path.basename(hostDir), "snap-host");
+    assert.equal(fs.existsSync(activePath), false, "snapshot file must not exist yet");
+
+    // Sibling inactive log would make the host dir look like a pure log folder
+    // if we only inspected readdir and missed the not-yet-created active path.
+    fs.writeFileSync(path.join(hostDir, "2026-01-01T00-00-00.txt"), "stale\n");
+    const staleHostDir = path.join(directory, "stale-snap-host");
+    fs.mkdirSync(staleHostDir, { recursive: true });
+    fs.writeFileSync(path.join(staleHostDir, "2026-01-03T00-00-00.txt"), "old\n");
+
+    const result = await clearSessionLogsDir(null, { directory });
+
+    assert.equal(result.success, true);
+    assert.equal(result.failedCount, 0);
+    assert.equal(result.deletedCount, 2); // stale sibling + pure stale host
+    assert.deepEqual(fs.readdirSync(directory).sort(), ["snap-host"]);
+    assert.ok(fs.existsSync(hostDir), "active snapshot host dir must survive clear-all");
+    assert.deepEqual(fs.readdirSync(hostDir), []);
+
+    // Stream must still be able to write its first snapshot after clear-all.
+    sessionLogStreamManager.appendData(sessionId, "first snapshot body\n");
+    const stoppedPath = await sessionLogStreamManager.stopStream(sessionId, startToken);
+    assert.equal(path.resolve(stoppedPath), path.resolve(activePath));
+    await waitForPath(activePath);
+    assert.match(fs.readFileSync(activePath, "utf8"), /first snapshot body/);
+  } finally {
+    await sessionLogStreamManager.cleanupAll();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("clearSessionLogsDir leaves unrelated empty or non-log folders alone", async () => {
   const directory = path.join(TEMP_ROOT, `clear-unrelated-${Date.now()}-${Math.random().toString(16).slice(2)}`);
   const { clearSessionLogsDir } = loadBridgeWithDialog({});

--- a/electron/bridges/sessionLogsBridge.test.cjs
+++ b/electron/bridges/sessionLogsBridge.test.cjs
@@ -107,7 +107,21 @@ test("auto-save host directory falls back when the sanitized host label is empty
   }
 });
 
-test("clearSessionLogsDir deletes host subdirectories and files from the save directory", async () => {
+test("isSessionLogArtifactName matches auto-save and labeled export filenames", () => {
+  const { isSessionLogArtifactName } = loadBridgeWithDialog({});
+
+  assert.equal(isSessionLogArtifactName("2026-01-01T00-00-00.txt"), true);
+  assert.equal(isSessionLogArtifactName("2026-01-01T00-00-00.log"), true);
+  assert.equal(isSessionLogArtifactName("2026-01-01T00-00-00.html"), true);
+  assert.equal(isSessionLogArtifactName("my-host_2026-01-01T00-00-00.txt"), true);
+  assert.equal(isSessionLogArtifactName("生产_服务器_2026-08-05T15-33-00.log"), true);
+  assert.equal(isSessionLogArtifactName("stray.log"), false);
+  assert.equal(isSessionLogArtifactName("notes.txt"), false);
+  assert.equal(isSessionLogArtifactName("2026-01-01.txt"), false);
+  assert.equal(isSessionLogArtifactName("readme.md"), false);
+});
+
+test("clearSessionLogsDir deletes host log folders and labeled exports only", async () => {
   const directory = path.join(TEMP_ROOT, `clear-${Date.now()}-${Math.random().toString(16).slice(2)}`);
   const { clearSessionLogsDir } = loadBridgeWithDialog({});
 
@@ -115,14 +129,66 @@ test("clearSessionLogsDir deletes host subdirectories and files from the save di
     const hostDir = path.join(directory, "my-host");
     fs.mkdirSync(hostDir, { recursive: true });
     fs.writeFileSync(path.join(hostDir, "2026-01-01T00-00-00.txt"), "hello\n");
+    fs.writeFileSync(path.join(hostDir, "2026-01-02T12-30-00.log"), "raw\n");
+    // Labeled export-style artifact at the save-dir root (manual export / continuous log).
+    fs.writeFileSync(path.join(directory, "my-host_2026-01-03T01-02-03.txt"), "export\n");
+    // Unrelated user content in a shared save directory must survive clear-all.
     fs.writeFileSync(path.join(directory, "stray.log"), "stray\n");
+    fs.writeFileSync(path.join(directory, "notes.txt"), "keep me\n");
+    fs.mkdirSync(path.join(directory, "Photos"), { recursive: true });
+    fs.writeFileSync(path.join(directory, "Photos", "vacation.jpg"), "jpeg");
 
     const result = await clearSessionLogsDir(null, { directory });
 
     assert.equal(result.success, true);
-    assert.equal(result.deletedCount, 2);
+    assert.equal(result.deletedCount, 2); // pure host folder + labeled export file
     assert.equal(result.failedCount, 0);
-    assert.deepEqual(fs.readdirSync(directory), []);
+    assert.deepEqual(fs.readdirSync(directory).sort(), ["Photos", "notes.txt", "stray.log"]);
+    assert.equal(fs.readFileSync(path.join(directory, "stray.log"), "utf8"), "stray\n");
+    assert.equal(fs.readFileSync(path.join(directory, "Photos", "vacation.jpg"), "utf8"), "jpeg");
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("clearSessionLogsDir only removes log files inside mixed host directories", async () => {
+  const directory = path.join(TEMP_ROOT, `clear-mixed-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const { clearSessionLogsDir } = loadBridgeWithDialog({});
+
+  try {
+    const hostDir = path.join(directory, "shared-host-folder");
+    fs.mkdirSync(hostDir, { recursive: true });
+    fs.writeFileSync(path.join(hostDir, "2026-01-01T00-00-00.txt"), "log\n");
+    fs.writeFileSync(path.join(hostDir, "user-notes.md"), "do not delete\n");
+
+    const result = await clearSessionLogsDir(null, { directory });
+
+    assert.equal(result.success, true);
+    assert.equal(result.deletedCount, 1);
+    assert.equal(result.failedCount, 0);
+    assert.deepEqual(fs.readdirSync(directory), ["shared-host-folder"]);
+    assert.deepEqual(fs.readdirSync(hostDir), ["user-notes.md"]);
+    assert.equal(fs.readFileSync(path.join(hostDir, "user-notes.md"), "utf8"), "do not delete\n");
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("clearSessionLogsDir leaves unrelated empty or non-log folders alone", async () => {
+  const directory = path.join(TEMP_ROOT, `clear-unrelated-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const { clearSessionLogsDir } = loadBridgeWithDialog({});
+
+  try {
+    fs.mkdirSync(path.join(directory, "empty-folder"), { recursive: true });
+    fs.mkdirSync(path.join(directory, "docs"), { recursive: true });
+    fs.writeFileSync(path.join(directory, "docs", "readme.md"), "hi\n");
+
+    const result = await clearSessionLogsDir(null, { directory });
+
+    assert.equal(result.success, true);
+    assert.equal(result.deletedCount, 0);
+    assert.equal(result.failedCount, 0);
+    assert.deepEqual(fs.readdirSync(directory).sort(), ["docs", "empty-folder"]);
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }

--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -1980,6 +1980,10 @@ function createTerminalWorkerManager(options = {}) {
 
   return {
     ensureStarted,
+    /** True when the utilityProcess child is currently alive. */
+    isRunning() {
+      return Boolean(child);
+    },
     request,
     send,
     startExternalSession,

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -1238,6 +1238,8 @@ function createPreloadApi(ctx) {
     ipcRenderer.invoke("netcatty:sessionLogs:autoSave", payload),
   openSessionLogsDir: (directory) =>
     ipcRenderer.invoke("netcatty:sessionLogs:openDir", { directory }),
+  clearSessionLogsDir: (directory) =>
+    ipcRenderer.invoke("netcatty:sessionLogs:clear", { directory }),
   startManualSessionLog: (payload) =>
     ipcRenderer.invoke("netcatty:sessionLog:manualStart", payload),
   stopManualSessionLog: (payload) =>

--- a/electron/terminalWorker/process.cjs
+++ b/electron/terminalWorker/process.cjs
@@ -298,6 +298,9 @@ function main() {
         parentPort,
         sessionLogStreamManager,
       });
+      // Expose worker-owned active log paths so main-process clear-all can
+      // skip live auto-save streams (separate module instance from main).
+      require("../bridges/sessionLogsBridge.cjs").registerWorkerHandlers(ipcMain);
       const { createSystemManagerBridge } = require("../bridges/systemManagerBridge.cjs");
       createSystemManagerBridge({
         getSessions: () => sessions,

--- a/types/global/netcatty-bridge-files.d.ts
+++ b/types/global/netcatty-bridge-files.d.ts
@@ -97,6 +97,7 @@ declare global {
       directory: string;
     }): Promise<{ success: boolean; error?: string; filePath?: string }>;
     openSessionLogsDir?(directory: string): Promise<{ success: boolean; error?: string }>;
+    clearSessionLogsDir?(directory: string): Promise<{ success: boolean; deletedCount: number; failedCount: number; error?: string }>;
     startManualSessionLog?(payload: {
       sessionId: string;
       sessionName?: string;


### PR DESCRIPTION
## Summary

Adds a **Clear all logs** button on Settings → System → Session logs. Deletes every session log file and host subdirectory under the configured save directory in one action.

## Type of Change

- [x] New feature

## Related Issue (optional)

N/A

## Changes Made

- `electron/bridges/sessionLogsBridge.cjs`: add `clearSessionLogsDir` to recursively clear the session-logs save directory (including per-host subdirs); missing dir is a no-op; register IPC handler `netcatty:sessionLogs:clear`.
- `electron/preload/api.cjs`: expose `clearSessionLogsDir` to the renderer.
- `types/global/netcatty-bridge-files.d.ts`: add matching type signature.
- `components/settings/tabs/SettingsSystemTab.tsx`: Clear all logs button with confirm dialog; shows deleted/failed counts; disabled when no save directory is configured.
- `application/i18n/locales/{en,zh-CN,zh-TW,ru}/core.ts`: add `clearAll` / `clearAllDesc` / `clearConfirm` keys.
- `electron/bridges/sessionLogsBridge.test.cjs`: three unit tests for normal clear, missing dir, and unset directory.

## Screenshots / Demo

UI depends on Electron IPC; no standalone preview. Logic covered by unit tests.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)