### PR TITLE
fix(plugins): address residual Codex sync secret and backup gaps

### DIFF
--- a/application/pluginSyncConnectWithSecrets.test.ts
+++ b/application/pluginSyncConnectWithSecrets.test.ts
@@ -103,4 +103,29 @@ describe('storePluginSyncSecretsThenConnect', () => {
     );
     assert.deepEqual(deletedKeys, [['sync-credential']]);
   });
+
+  it('keeps overwritten secrets when reconnect connect rejects', async () => {
+    const deletedKeys: string[][] = [];
+    await assert.rejects(
+      () => storePluginSyncSecretsThenConnect({
+        providerId: 'plugin:sync.example',
+        secrets: [{ secretKey: 'sync-credential', value: 'bad-password' }],
+        putSecret: async ({ key }) => ({
+          kind: 'secret',
+          id: 'ref-overwritten',
+          key,
+          created: false,
+        }),
+        deleteSecrets: async ({ keys }) => {
+          deletedKeys.push([...keys]);
+          return { deleted: keys.length };
+        },
+        connect: async () => {
+          throw new Error('auth failed');
+        },
+      }),
+      /auth failed/,
+    );
+    assert.deepEqual(deletedKeys, []);
+  });
 });

--- a/application/pluginSyncConnectWithSecrets.test.ts
+++ b/application/pluginSyncConnectWithSecrets.test.ts
@@ -106,6 +106,7 @@ describe('storePluginSyncSecretsThenConnect', () => {
 
   it('keeps overwritten secrets when reconnect connect rejects', async () => {
     const deletedKeys: string[][] = [];
+    const restoredKeys: string[][] = [];
     await assert.rejects(
       () => storePluginSyncSecretsThenConnect({
         providerId: 'plugin:sync.example',
@@ -120,6 +121,10 @@ describe('storePluginSyncSecretsThenConnect', () => {
           deletedKeys.push([...keys]);
           return { deleted: keys.length };
         },
+        restoreSecrets: async ({ keys }) => {
+          restoredKeys.push([...keys]);
+          return { restored: keys.length };
+        },
         connect: async () => {
           throw new Error('auth failed');
         },
@@ -127,5 +132,6 @@ describe('storePluginSyncSecretsThenConnect', () => {
       /auth failed/,
     );
     assert.deepEqual(deletedKeys, []);
+    assert.deepEqual(restoredKeys, [['sync-credential']]);
   });
 });

--- a/application/pluginSyncConnectWithSecrets.ts
+++ b/application/pluginSyncConnectWithSecrets.ts
@@ -1,8 +1,8 @@
 /**
  * Persist plugin sync secrets then connect; roll back just-created secrets if
  * connect (or a later put) fails so bad passwords are not left in OS storage.
- * Overwritten keys are kept on failure so a reconnect that rejects does not
- * delete the previously working credential still referenced by the connection.
+ * Overwritten keys are restored from the host-side overwrite stash so a
+ * rejected reconnect does not leave a broken SecretRef / rejected credential.
  */
 
 export type PluginSyncSecretRef = { kind: 'secret'; id: string; key: string };
@@ -31,6 +31,15 @@ export interface StorePluginSyncSecretsThenConnectParams {
     providerId: string;
     keys: string[];
   }) => Promise<unknown>;
+  /**
+   * Restore host-stashed plaintext for overwritten keys (`discard: false`),
+   * or drop the stash after a successful connect (`discard: true`).
+   */
+  restoreSecrets?: (params: {
+    providerId: string;
+    keys: string[];
+    discard?: boolean;
+  }) => Promise<unknown>;
   connect: (credential: PluginSyncSecretRef | undefined) => Promise<void>;
 }
 
@@ -38,6 +47,7 @@ export async function storePluginSyncSecretsThenConnect(
   params: StorePluginSyncSecretsThenConnectParams,
 ): Promise<void> {
   const createdKeys: string[] = [];
+  const overwrittenKeys: string[] = [];
   let credential: PluginSyncSecretRef | undefined = params.existingCredential;
 
   try {
@@ -49,9 +59,9 @@ export async function storePluginSyncSecretsThenConnect(
           key: secret.secretKey,
           value: secret.value,
         });
-        // Only roll back keys that did not exist before this attempt. Deleting an
-        // overwritten key would also remove the prior working credential.
-        if (ref.created !== false) {
+        if (ref.created === false) {
+          overwrittenKeys.push(secret.secretKey);
+        } else {
           createdKeys.push(secret.secretKey);
         }
         // SyncConnectPayload.credential carries the primary (first) secret;
@@ -60,12 +70,33 @@ export async function storePluginSyncSecretsThenConnect(
       }
     }
     await params.connect(credential);
+    if (overwrittenKeys.length > 0 && params.restoreSecrets) {
+      try {
+        await params.restoreSecrets({
+          providerId: params.providerId,
+          keys: [...overwrittenKeys],
+          discard: true,
+        });
+      } catch {
+        /* best-effort stash cleanup */
+      }
+    }
   } catch (error) {
     if (createdKeys.length > 0) {
       try {
         await params.deleteSecrets({
           providerId: params.providerId,
           keys: [...createdKeys],
+        });
+      } catch {
+        /* best-effort; surface the original connect/put error */
+      }
+    }
+    if (overwrittenKeys.length > 0 && params.restoreSecrets) {
+      try {
+        await params.restoreSecrets({
+          providerId: params.providerId,
+          keys: [...overwrittenKeys],
         });
       } catch {
         /* best-effort; surface the original connect/put error */

--- a/application/pluginSyncConnectWithSecrets.ts
+++ b/application/pluginSyncConnectWithSecrets.ts
@@ -1,6 +1,8 @@
 /**
  * Persist plugin sync secrets then connect; roll back just-created secrets if
  * connect (or a later put) fails so bad passwords are not left in OS storage.
+ * Overwritten keys are kept on failure so a reconnect that rejects does not
+ * delete the previously working credential still referenced by the connection.
  */
 
 export type PluginSyncSecretRef = { kind: 'secret'; id: string; key: string };
@@ -8,6 +10,11 @@ export type PluginSyncSecretRef = { kind: 'secret'; id: string; key: string };
 export interface PluginSyncConnectSecretInput {
   secretKey: string;
   value: string;
+}
+
+export interface PluginSyncPutSecretResult extends PluginSyncSecretRef {
+  /** False when the durable (plugin,key) row already existed and was overwritten. */
+  created?: boolean;
 }
 
 export interface StorePluginSyncSecretsThenConnectParams {
@@ -19,7 +26,7 @@ export interface StorePluginSyncSecretsThenConnectParams {
     providerId: string;
     key: string;
     value: string;
-  }) => Promise<PluginSyncSecretRef>;
+  }) => Promise<PluginSyncPutSecretResult>;
   deleteSecrets: (params: {
     providerId: string;
     keys: string[];
@@ -42,7 +49,11 @@ export async function storePluginSyncSecretsThenConnect(
           key: secret.secretKey,
           value: secret.value,
         });
-        createdKeys.push(secret.secretKey);
+        // Only roll back keys that did not exist before this attempt. Deleting an
+        // overwritten key would also remove the prior working credential.
+        if (ref.created !== false) {
+          createdKeys.push(secret.secretKey);
+        }
         // SyncConnectPayload.credential carries the primary (first) secret;
         // additional secrets remain addressable via secrets.get(key).
         if (!credential) credential = ref;

--- a/application/syncPayload.test.ts
+++ b/application/syncPayload.test.ts
@@ -819,7 +819,7 @@ test("buildLocalVaultPayload includes last-known plugin sidecars for protective 
   }
 });
 
-test("buildLocalVaultPayloadAsync keeps last-known when live collect is empty", async () => {
+test("buildLocalVaultPayloadAsync prefers live empty over last-known for backups", async () => {
   const previousWindow = (globalThis as { window?: unknown }).window;
   Object.defineProperty(globalThis, "window", {
     value: {
@@ -847,8 +847,7 @@ test("buildLocalVaultPayloadAsync keeps last-known when live collect is empty", 
   try {
     const { buildLocalVaultPayloadAsync } = await import("./syncPayload.ts");
     const payload = await buildLocalVaultPayloadAsync(vault([]));
-    assert.equal(payload.pluginSidecars?.entries?.length, 1);
-    assert.equal(payload.pluginSidecars?.entries?.[0].value, "dark");
+    assert.equal(payload.pluginSidecars?.entries?.length, 0);
   } finally {
     localStorage.removeItem("netcatty_plugin_sidecars_last_known_v1");
     Object.defineProperty(globalThis, "window", {

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -1049,15 +1049,9 @@ export async function buildLocalVaultPayloadAsync(
   try {
     const live = await collectPluginSyncSidecarsFromHost();
     if (live) {
-      // Live collect may return authoritative-empty while still deferring the
-      // last-known cache wipe until a successful sync commit. Protective
-      // backups must keep the non-empty last-known already attached to `base`.
-      const liveEmpty = !Array.isArray(live.entries) || live.entries.length === 0;
-      const baseHasEntries = Array.isArray(base.pluginSidecars?.entries)
-        && base.pluginSidecars.entries.length > 0;
-      if (liveEmpty && baseHasEntries) {
-        return base;
-      }
+      // Uploads may still defer wiping last-known until a successful sync
+      // commit, but protective/version-change backups must snapshot the live
+      // authoritative-empty bundle so restore cannot resurrect cleared plugin data.
       return withPluginSyncSidecars(base, live);
     }
   } catch (error) {

--- a/components/cloud-sync/CloudSyncDashboardTabs.tsx
+++ b/components/cloud-sync/CloudSyncDashboardTabs.tsx
@@ -181,11 +181,12 @@ export const CloudSyncDashboardTabs: React.FC<CloudSyncDashboardTabsProps> = ({
           ? stored as { kind: 'secret'; id: string; key: string }
           : undefined;
       if (credentialPlan.secrets.length > 0) {
-        const { putPluginSyncSecret, deletePluginSyncSecrets } = await import(
+        const { putPluginSyncSecret, deletePluginSyncSecrets, restorePluginSyncSecrets } = await import(
           '../../infrastructure/services/adapters/pluginSyncIpcHost'
         );
         // Put secrets before connect; roll back just-created keys if connect fails
         // so a rejected password/token is not left readable in plugin_secrets.
+        // Overwrites restore the previous plaintext from the host stash.
         await storePluginSyncSecretsThenConnect({
           providerId,
           secrets: credentialPlan.secrets.map((secret) => ({
@@ -194,6 +195,7 @@ export const CloudSyncDashboardTabs: React.FC<CloudSyncDashboardTabsProps> = ({
           })),
           putSecret: putPluginSyncSecret,
           deleteSecrets: deletePluginSyncSecrets,
+          restoreSecrets: restorePluginSyncSecrets,
           connect: async (credential) => {
             await sync.connectPluginProvider(
               providerId,

--- a/electron/plugins/database.cjs
+++ b/electron/plugins/database.cjs
@@ -759,6 +759,14 @@ class PluginDatabase {
     return Number(result?.changes) || 0;
   }
 
+  /** Find secret rows by exact key across all plugins (sync provider cleanup). */
+  findSecretsByKey(key) {
+    return this.db.prepare(`
+      SELECT plugin_id, key, secret_ref, ciphertext, created_at, updated_at
+      FROM plugin_secrets WHERE key = ?
+    `).all(key).map((row) => this.#mapSecret(row));
+  }
+
   recordSecurityAudit(pluginId, event, details) {
     let detailsJson = JSON.stringify(details ?? {});
     const originalBytes = Buffer.byteLength(detailsJson);

--- a/electron/plugins/database.cjs
+++ b/electron/plugins/database.cjs
@@ -5,7 +5,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const { DatabaseSync } = require("node:sqlite");
 
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 3;
 const MAX_SECURITY_AUDIT_DETAILS_BYTES = 16 * 1024;
 const MAX_SECURITY_AUDIT_RECORDS_PER_PLUGIN = 1_000;
 const REQUIRED_SCHEMA_COLUMNS = Object.freeze({
@@ -21,6 +21,8 @@ const REQUIRED_SCHEMA_COLUMNS = Object.freeze({
   plugin_security_audit: ["id", "plugin_id", "event", "details_json", "created_at"],
   // User-owned encrypted-sync sidecars: no FK cascade on package uninstall.
   plugin_sync_sidecars: ["plugin_id", "kind", "key", "value_json", "updated_at"],
+  // Host-owned sync provider→plugin bindings (not plugin-writable secrets).
+  plugin_sync_provider_bindings: ["provider_id", "plugin_id", "created_at", "updated_at"],
 });
 
 function parseJson(text, label) {
@@ -164,12 +166,18 @@ class PluginDatabase {
           );
           CREATE INDEX plugin_sync_sidecars_lookup
             ON plugin_sync_sidecars(plugin_id, kind, key);
-          PRAGMA user_version = 2;
+          CREATE TABLE plugin_sync_provider_bindings (
+            provider_id TEXT PRIMARY KEY,
+            plugin_id TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+          );
+          PRAGMA user_version = 3;
         `);
       });
     } else if (version === 1) {
       // Pre-sidecar schema-1 databases only created the original tables.
-      // Migrate in place to schema 2 with the non-cascade sidecar table.
+      // Migrate in place to schema 3 with sidecar + provider binding tables.
       this.transaction(() => {
         this.db.exec(`
           CREATE TABLE IF NOT EXISTS plugin_sync_sidecars (
@@ -182,7 +190,25 @@ class PluginDatabase {
           );
           CREATE INDEX IF NOT EXISTS plugin_sync_sidecars_lookup
             ON plugin_sync_sidecars(plugin_id, kind, key);
-          PRAGMA user_version = 2;
+          CREATE TABLE IF NOT EXISTS plugin_sync_provider_bindings (
+            provider_id TEXT PRIMARY KEY,
+            plugin_id TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+          );
+          PRAGMA user_version = 3;
+        `);
+      });
+    } else if (version === 2) {
+      this.transaction(() => {
+        this.db.exec(`
+          CREATE TABLE IF NOT EXISTS plugin_sync_provider_bindings (
+            provider_id TEXT PRIMARY KEY,
+            plugin_id TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+          );
+          PRAGMA user_version = 3;
         `);
       });
     }
@@ -765,6 +791,38 @@ class PluginDatabase {
       SELECT plugin_id, key, secret_ref, ciphertext, created_at, updated_at
       FROM plugin_secrets WHERE key = ?
     `).all(key).map((row) => this.#mapSecret(row));
+  }
+
+  upsertSyncProviderBinding(providerId, pluginId) {
+    const now = this.clock();
+    this.db.prepare(`
+      INSERT INTO plugin_sync_provider_bindings(provider_id, plugin_id, created_at, updated_at)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(provider_id) DO UPDATE SET
+        plugin_id = excluded.plugin_id,
+        updated_at = excluded.updated_at
+    `).run(providerId, pluginId, now, now);
+  }
+
+  getSyncProviderBinding(providerId) {
+    const row = this.db.prepare(`
+      SELECT provider_id, plugin_id, created_at, updated_at
+      FROM plugin_sync_provider_bindings WHERE provider_id = ?
+    `).get(providerId);
+    if (!row) return null;
+    return {
+      providerId: row.provider_id,
+      pluginId: row.plugin_id,
+      createdAt: Number(row.created_at),
+      updatedAt: Number(row.updated_at),
+    };
+  }
+
+  deleteSyncProviderBinding(providerId) {
+    const result = this.db.prepare(`
+      DELETE FROM plugin_sync_provider_bindings WHERE provider_id = ?
+    `).run(providerId);
+    return Number(result?.changes) || 0;
   }
 
   recordSecurityAudit(pluginId, event, details) {

--- a/electron/plugins/database.test.cjs
+++ b/electron/plugins/database.test.cjs
@@ -59,7 +59,7 @@ test("obsolete unpublished v1 layouts fail with an explicit reset instruction", 
   );
 });
 
-test("complete schema-1 databases migrate in place to schema 2 with sidecar table", (context) => {
+test("complete schema-1 databases migrate in place to schema 3 with sidecar and binding tables", (context) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-plugin-v1-migrate-"));
   context.after(() => fs.rmSync(root, { recursive: true, force: true }));
   const file = path.join(root, "plugins.sqlite");
@@ -164,6 +164,10 @@ test("complete schema-1 databases migrate in place to schema 2 with sidecar tabl
     database.db.prepare("PRAGMA table_info(plugin_sync_sidecars)").all().map(({ name }) => name),
     ["plugin_id", "kind", "key", "value_json", "updated_at"],
   );
+  assert.deepEqual(
+    database.db.prepare("PRAGMA table_info(plugin_sync_provider_bindings)").all().map(({ name }) => name),
+    ["provider_id", "plugin_id", "created_at", "updated_at"],
+  );
   // Existing rows survive the in-place migration.
   assert.equal(database.db.prepare("SELECT id FROM plugins").get().id, "com.example.v1");
   database.setSyncSidecar("com.example.v1", "settings", "theme\0application\0application", "dark", 2);
@@ -171,6 +175,8 @@ test("complete schema-1 databases migrate in place to schema 2 with sidecar tabl
     database.getSyncSidecar("com.example.v1", "settings", "theme\0application\0application")?.value,
     "dark",
   );
+  database.upsertSyncProviderBinding("com.example.v1.sync", "com.example.v1");
+  assert.equal(database.getSyncProviderBinding("com.example.v1.sync")?.pluginId, "com.example.v1");
   database.close();
 });
 
@@ -211,6 +217,10 @@ test("initial schema scopes runtime and crash state to immutable plugin versions
   assert.deepEqual(
     database.db.prepare("PRAGMA table_info(plugin_sync_sidecars)").all().map(({ name }) => name),
     ["plugin_id", "kind", "key", "value_json", "updated_at"],
+  );
+  assert.deepEqual(
+    database.db.prepare("PRAGMA table_info(plugin_sync_provider_bindings)").all().map(({ name }) => name),
+    ["provider_id", "plugin_id", "created_at", "updated_at"],
   );
   assert.deepEqual(database.db.prepare("PRAGMA foreign_key_list(plugin_settings)").all(), []);
   assert.deepEqual(database.db.prepare("PRAGMA foreign_key_list(plugin_view_state)").all(), []);

--- a/electron/plugins/pluginBridge.cjs
+++ b/electron/plugins/pluginBridge.cjs
@@ -46,6 +46,7 @@ const CHANNELS = Object.freeze({
   syncDeleteObject: "netcatty:plugins:sync-delete-object",
   syncPutSecret: "netcatty:plugins:sync-put-secret",
   syncDeleteSecrets: "netcatty:plugins:sync-delete-secrets",
+  syncRestoreSecrets: "netcatty:plugins:sync-restore-secrets",
   syncSidecarsCollect: "netcatty:plugins:sync-sidecars-collect",
   syncSidecarsApply: "netcatty:plugins:sync-sidecars-apply",
   hostAvailableSync: "netcatty:plugins:host-available-sync",
@@ -1124,6 +1125,50 @@ function registerPluginBridge(ipcMain, options) {
       }
     }
     return { deleted };
+  });
+
+  ipcMain.handle(CHANNELS.syncRestoreSecrets, async (event, payload) => {
+    if (!isTrustedSender(event)) throw new Error("Untrusted plugin management sender");
+    if (!secretStore) {
+      throw new Error("Plugin sync secret restore is unavailable");
+    }
+    if (!extensionProviderService) throw new Error("Plugin sync Providers are unavailable");
+    const providerId = payload?.providerId;
+    if (typeof providerId !== "string" || providerId.length < 1) {
+      throw new TypeError("Sync provider ID is invalid");
+    }
+    const keys = Array.isArray(payload?.keys) ? payload.keys : [];
+    if (keys.length < 1) return { restored: 0, discarded: 0 };
+    const providers = extensionProviderService.listProviders({ kind: "sync" });
+    const match = Array.isArray(providers)
+      ? providers.find((entry) => entry?.provider?.id === providerId || entry?.id === providerId)
+      : null;
+    let pluginId = match && typeof match.pluginId === "string" ? match.pluginId : null;
+    if (!pluginId && typeof secretStore.resolveSyncProviderPlugin === "function") {
+      pluginId = secretStore.resolveSyncProviderPlugin(providerId) ?? null;
+    }
+    if (!pluginId) return { restored: 0, discarded: 0 };
+    const discard = payload?.discard === true;
+    let restored = 0;
+    let discarded = 0;
+    for (const rawKey of keys) {
+      if (typeof rawKey !== "string" || rawKey.length < 1) continue;
+      const key = assertSecretKey(rawKey);
+      try {
+        if (discard) {
+          if (typeof secretStore.clearOverwriteStash === "function") {
+            secretStore.clearOverwriteStash(pluginId, key);
+            discarded += 1;
+          }
+        } else if (typeof secretStore.restoreOverwrite === "function"
+          && secretStore.restoreOverwrite(pluginId, key)) {
+          restored += 1;
+        }
+      } catch {
+        /* best-effort restore/discard */
+      }
+    }
+    return { restored, discarded };
   });
 
   handlePassive(CHANNELS.credentialCatalogUpdate, 0, async (_activeManager, payload) => {

--- a/electron/plugins/pluginBridge.cjs
+++ b/electron/plugins/pluginBridge.cjs
@@ -1054,7 +1054,20 @@ function registerPluginBridge(ipcMain, options) {
     if (!match || typeof match.pluginId !== "string") {
       throw new Error(`Plugin sync provider is unavailable: ${providerId}`);
     }
-    return secretStore.set(match.pluginId, key, value);
+    const existing = typeof secretStore.getReference === "function"
+      ? secretStore.getReference(match.pluginId, key)
+      : null;
+    const stored = secretStore.set(match.pluginId, key, value);
+    // Remember which plugin owns this provider so disconnect can clean secrets
+    // after the contribution is gone (disabled/uninstalled).
+    if (typeof secretStore.bindSyncProviderPlugin === "function") {
+      try {
+        secretStore.bindSyncProviderPlugin(match.pluginId, providerId);
+      } catch {
+        /* binding is best-effort; credential write already succeeded */
+      }
+    }
+    return Object.freeze({ ...stored, created: !existing });
   });
 
   ipcMain.handle(CHANNELS.syncDeleteSecrets, async (event, payload) => {
@@ -1071,8 +1084,12 @@ function registerPluginBridge(ipcMain, options) {
     const match = Array.isArray(providers)
       ? providers.find((entry) => entry?.provider?.id === providerId || entry?.id === providerId)
       : null;
-    if (!match || typeof match.pluginId !== "string") {
-      // Provider may already be uninstalled; treat as no-op cleanup.
+    let pluginId = match && typeof match.pluginId === "string" ? match.pluginId : null;
+    if (!pluginId && typeof secretStore.resolveSyncProviderPlugin === "function") {
+      pluginId = secretStore.resolveSyncProviderPlugin(providerId) ?? null;
+    }
+    if (!pluginId) {
+      // No live contribution and no retained binding — nothing to delete.
       return { deleted: 0 };
     }
     const keys = Array.isArray(payload?.keys) && payload.keys.length > 0
@@ -1080,10 +1097,14 @@ function registerPluginBridge(ipcMain, options) {
       : null;
     if (!keys) {
       // Wipe every sync-credential* key (well-known + schema writeOnly fields).
+      let deleted = 0;
       if (typeof secretStore.deleteByKeyPrefix === "function") {
-        const deleted = secretStore.deleteByKeyPrefix(match.pluginId, "sync-credential");
-        return { deleted: Number(deleted) || 0 };
+        deleted = Number(secretStore.deleteByKeyPrefix(pluginId, "sync-credential")) || 0;
       }
+      if (typeof secretStore.unbindSyncProviderPlugin === "function") {
+        secretStore.unbindSyncProviderPlugin(pluginId, providerId);
+      }
+      return { deleted };
     }
     let deleted = 0;
     for (const rawKey of keys ?? [
@@ -1096,7 +1117,7 @@ function registerPluginBridge(ipcMain, options) {
       if (typeof rawKey !== "string" || rawKey.length < 1) continue;
       const key = assertSecretKey(rawKey);
       try {
-        secretStore.delete(match.pluginId, key);
+        secretStore.delete(pluginId, key);
         deleted += 1;
       } catch {
         /* ignore missing / unavailable keys */

--- a/electron/plugins/pluginBridge.cjs
+++ b/electron/plugins/pluginBridge.cjs
@@ -1058,7 +1058,12 @@ function registerPluginBridge(ipcMain, options) {
     const existing = typeof secretStore.getReference === "function"
       ? secretStore.getReference(match.pluginId, key)
       : null;
-    const stored = secretStore.set(match.pluginId, key, value);
+    const stored = typeof secretStore.set === "function"
+      ? secretStore.set(match.pluginId, key, value, { stashPrevious: true })
+      : null;
+    if (!stored) {
+      throw new Error("Plugin sync secret storage is unavailable");
+    }
     // Remember which plugin owns this provider so disconnect can clean secrets
     // after the contribution is gone (disabled/uninstalled).
     if (typeof secretStore.bindSyncProviderPlugin === "function") {

--- a/electron/plugins/pluginBridge.test.cjs
+++ b/electron/plugins/pluginBridge.test.cjs
@@ -1548,5 +1548,54 @@ test("sync read/write shuttle Uint8Array inline and stream large writes", async 
     key: "sync-credential",
     value: "pw",
   });
-  assert.deepEqual(secret, { kind: "secret", id: "sec-1", key: "sync-credential", pluginId: "com.example", value: "pw" });
+  assert.deepEqual(secret, {
+    kind: "secret",
+    id: "sec-1",
+    key: "sync-credential",
+    pluginId: "com.example",
+    value: "pw",
+    created: true,
+  });
+});
+
+test("syncDeleteSecrets uses retained provider binding when contribution is missing", async () => {
+  const deleted = [];
+  const unbound = [];
+  const ipcMain = createIpcMain();
+  registerPluginBridge(ipcMain, {
+    manager: { async initialize() {} },
+    extensionProviderService: {
+      listProviders() {
+        return [];
+      },
+    },
+    secretStore: {
+      set() {
+        throw new Error("set should not run");
+      },
+      delete(pluginId, key) {
+        deleted.push([pluginId, key]);
+      },
+      deleteByKeyPrefix(pluginId, prefix) {
+        deleted.push([pluginId, `prefix:${prefix}`]);
+        return 2;
+      },
+      resolveSyncProviderPlugin(providerId) {
+        assert.equal(providerId, "com.example.sync");
+        return "com.example";
+      },
+      unbindSyncProviderPlugin(pluginId, providerId) {
+        unbound.push([pluginId, providerId]);
+      },
+    },
+    env: { NETCATTY_PLUGIN_DEV: "1" },
+    isTrustedSender: () => true,
+  });
+  const event = { sender: { id: 99, once() {}, isDestroyed: () => false } };
+  const result = await ipcMain.handlers.get(CHANNELS.syncDeleteSecrets)(event, {
+    providerId: "com.example.sync",
+  });
+  assert.deepEqual(result, { deleted: 2 });
+  assert.deepEqual(deleted, [["com.example", "prefix:sync-credential"]]);
+  assert.deepEqual(unbound, [["com.example", "com.example.sync"]]);
 });

--- a/electron/plugins/secretStore.cjs
+++ b/electron/plugins/secretStore.cjs
@@ -83,7 +83,9 @@ class PluginSecretStore {
     const stashPrevious = options.stashPrevious === true;
     const stashKey = this.#stashKey(pluginId, key);
     let stashed = false;
-    if (stashPrevious) {
+    if (stashPrevious && !this.#overwriteStash.has(stashKey)) {
+      // Keep an existing stash (e.g. after a failed restore) so a later retry
+      // still recovers the original SecretRef, not a rejected replacement.
       const existing = this.getReference(pluginId, key);
       if (existing) {
         try {
@@ -154,11 +156,22 @@ class PluginSecretStore {
 
   deleteByKeyPrefix(pluginId, prefix) {
     assertSecretKey(prefix);
+    let deleted = 0;
     if (typeof this.database.deleteSecretsByKeyPrefix !== "function") {
       this.delete(pluginId, prefix);
-      return 1;
+      deleted = 1;
+    } else {
+      deleted = this.database.deleteSecretsByKeyPrefix(pluginId, prefix);
     }
-    return this.database.deleteSecretsByKeyPrefix(pluginId, prefix);
+    const pluginPrefix = `${pluginId}\0`;
+    for (const stashKey of [...this.#overwriteStash.keys()]) {
+      if (!stashKey.startsWith(pluginPrefix)) continue;
+      const secretKey = stashKey.slice(pluginPrefix.length);
+      if (secretKey === prefix || secretKey.startsWith(`${prefix}:`)) {
+        this.#overwriteStash.delete(stashKey);
+      }
+    }
+    return deleted;
   }
 
   /**

--- a/electron/plugins/secretStore.cjs
+++ b/electron/plugins/secretStore.cjs
@@ -96,6 +96,38 @@ class PluginSecretStore {
     return this.database.deleteSecretsByKeyPrefix(pluginId, prefix);
   }
 
+  /**
+   * Durable providerId → pluginId binding so disconnect can wipe sync secrets
+   * after the contribution disappears (disabled/uninstalled plugin).
+   */
+  syncProviderBindingKey(providerId) {
+    return `sync-provider-map:${assertSecretKey(providerId)}`;
+  }
+
+  bindSyncProviderPlugin(pluginId, providerId) {
+    const key = this.syncProviderBindingKey(providerId);
+    if (this.getReference(pluginId, key)) return;
+    this.set(pluginId, key, pluginId);
+  }
+
+  resolveSyncProviderPlugin(providerId) {
+    const key = this.syncProviderBindingKey(providerId);
+    if (typeof this.database.findSecretsByKey === "function") {
+      const rows = this.database.findSecretsByKey(key);
+      const pluginId = rows?.[0]?.pluginId;
+      return typeof pluginId === "string" && pluginId.length > 0 ? pluginId : undefined;
+    }
+    return undefined;
+  }
+
+  unbindSyncProviderPlugin(pluginId, providerId) {
+    try {
+      this.delete(pluginId, this.syncProviderBindingKey(providerId));
+    } catch {
+      /* ignore missing binding */
+    }
+  }
+
   resolve(pluginId, secret) {
     this.#assertAvailable();
     const record = this.getRecordByReference(pluginId, secret);

--- a/electron/plugins/secretStore.cjs
+++ b/electron/plugins/secretStore.cjs
@@ -80,7 +80,7 @@ class PluginSecretStore {
     if (typeof value !== "string" || Buffer.byteLength(value, "utf8") > MAX_SECRET_BYTES) {
       throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Plugin secret value is invalid or too large");
     }
-    const stashPrevious = options.stashPrevious !== false;
+    const stashPrevious = options.stashPrevious === true;
     if (stashPrevious) {
       const existing = this.getReference(pluginId, key);
       if (existing) {

--- a/electron/plugins/secretStore.cjs
+++ b/electron/plugins/secretStore.cjs
@@ -125,7 +125,6 @@ class PluginSecretStore {
     if (!previous || typeof previous.value !== "string" || typeof previous.secretRef !== "string") {
       return false;
     }
-    this.#overwriteStash.delete(stashKey);
     const ciphertext = this.safeStorage.encryptString(previous.value);
     if (!Buffer.isBuffer(ciphertext) || ciphertext.byteLength < 1) {
       throw new PluginRpcError(RPC_ERRORS.unavailable, "OS-backed plugin secret encryption failed");
@@ -136,6 +135,9 @@ class PluginSecretStore {
       secretRef: previous.secretRef,
       ciphertext,
     });
+    // Drop the stash only after the prior value is durably written so a failed
+    // encrypt/upsert can still be retried.
+    this.#overwriteStash.delete(stashKey);
     return true;
   }
 

--- a/electron/plugins/secretStore.cjs
+++ b/electron/plugins/secretStore.cjs
@@ -81,27 +81,36 @@ class PluginSecretStore {
       throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Plugin secret value is invalid or too large");
     }
     const stashPrevious = options.stashPrevious === true;
+    const stashKey = this.#stashKey(pluginId, key);
+    let stashed = false;
     if (stashPrevious) {
       const existing = this.getReference(pluginId, key);
       if (existing) {
         try {
-          this.#overwriteStash.set(this.#stashKey(pluginId, key), {
+          this.#overwriteStash.set(stashKey, {
             value: this.resolve(pluginId, existing),
             // Keep the prior SecretRef id so saved provider connections still resolve.
             secretRef: existing.id,
           });
+          stashed = true;
         } catch {
           /* keep going; restore may be unavailable for this key */
         }
       }
     }
-    const secretRef = this.randomBytes(24).toString("base64url");
-    const ciphertext = this.safeStorage.encryptString(value);
-    if (!Buffer.isBuffer(ciphertext) || ciphertext.byteLength < 1) {
-      throw new PluginRpcError(RPC_ERRORS.unavailable, "OS-backed plugin secret encryption failed");
+    try {
+      const secretRef = this.randomBytes(24).toString("base64url");
+      const ciphertext = this.safeStorage.encryptString(value);
+      if (!Buffer.isBuffer(ciphertext) || ciphertext.byteLength < 1) {
+        throw new PluginRpcError(RPC_ERRORS.unavailable, "OS-backed plugin secret encryption failed");
+      }
+      this.database.upsertSecret({ pluginId, key, secretRef, ciphertext });
+      return Object.freeze({ kind: "secret", id: secretRef, key });
+    } catch (error) {
+      // Failed replacement must not leave prior plaintext stranded in memory.
+      if (stashed) this.#overwriteStash.delete(stashKey);
+      throw error;
     }
-    this.database.upsertSecret({ pluginId, key, secretRef, ciphertext });
-    return Object.freeze({ kind: "secret", id: secretRef, key });
   }
 
   /**
@@ -153,33 +162,43 @@ class PluginSecretStore {
   /**
    * Durable providerId → pluginId binding so disconnect can wipe sync secrets
    * after the contribution disappears (disabled/uninstalled plugin).
+   * Stored in a host-owned table, not plugin-writable secrets.
    */
-  syncProviderBindingKey(providerId) {
-    return `sync-provider-map:${assertSecretKey(providerId)}`;
-  }
-
   bindSyncProviderPlugin(pluginId, providerId) {
-    const key = this.syncProviderBindingKey(providerId);
-    if (this.getReference(pluginId, key)) return;
-    this.set(pluginId, key, pluginId);
+    if (typeof pluginId !== "string" || pluginId.length < 1) {
+      throw new TypeError("Plugin id is invalid");
+    }
+    assertSecretKey(providerId);
+    if (
+      providerId !== pluginId
+      && !providerId.startsWith(`${pluginId}.`)
+    ) {
+      throw new TypeError("Sync provider id is outside the plugin namespace");
+    }
+    if (typeof this.database.upsertSyncProviderBinding !== "function") {
+      throw new Error("Plugin sync provider binding storage is unavailable");
+    }
+    this.database.upsertSyncProviderBinding(providerId, pluginId);
   }
 
   resolveSyncProviderPlugin(providerId) {
-    const key = this.syncProviderBindingKey(providerId);
-    if (typeof this.database.findSecretsByKey === "function") {
-      const rows = this.database.findSecretsByKey(key);
-      const pluginId = rows?.[0]?.pluginId;
-      return typeof pluginId === "string" && pluginId.length > 0 ? pluginId : undefined;
+    assertSecretKey(providerId);
+    if (typeof this.database.getSyncProviderBinding !== "function") return undefined;
+    const row = this.database.getSyncProviderBinding(providerId);
+    const pluginId = row?.pluginId;
+    if (typeof pluginId !== "string" || pluginId.length < 1) return undefined;
+    if (providerId !== pluginId && !providerId.startsWith(`${pluginId}.`)) {
+      return undefined;
     }
-    return undefined;
+    return pluginId;
   }
 
   unbindSyncProviderPlugin(pluginId, providerId) {
-    try {
-      this.delete(pluginId, this.syncProviderBindingKey(providerId));
-    } catch {
-      /* ignore missing binding */
-    }
+    assertSecretKey(providerId);
+    if (typeof this.database.deleteSyncProviderBinding !== "function") return;
+    const existing = this.database.getSyncProviderBinding(providerId);
+    if (existing && existing.pluginId !== pluginId) return;
+    this.database.deleteSyncProviderBinding(providerId);
   }
 
   resolve(pluginId, secret) {

--- a/electron/plugins/secretStore.cjs
+++ b/electron/plugins/secretStore.cjs
@@ -31,10 +31,17 @@ function assertSecretRef(secret) {
 }
 
 class PluginSecretStore {
+  /** @type {Map<string, { value: string, secretRef: string }>} */
+  #overwriteStash = new Map();
+
   constructor(options) {
     this.database = options.database;
     this.safeStorage = options.safeStorage ?? null;
     this.randomBytes = options.randomBytes ?? randomBytes;
+  }
+
+  #stashKey(pluginId, key) {
+    return `${pluginId}\0${key}`;
   }
 
   #assertAvailable() {
@@ -67,11 +74,26 @@ class PluginSecretStore {
     return record;
   }
 
-  set(pluginId, key, value) {
+  set(pluginId, key, value, options = {}) {
     this.#assertAvailable();
     assertSecretKey(key);
     if (typeof value !== "string" || Buffer.byteLength(value, "utf8") > MAX_SECRET_BYTES) {
       throw new PluginRpcError(RPC_ERRORS.invalidArgument, "Plugin secret value is invalid or too large");
+    }
+    const stashPrevious = options.stashPrevious !== false;
+    if (stashPrevious) {
+      const existing = this.getReference(pluginId, key);
+      if (existing) {
+        try {
+          this.#overwriteStash.set(this.#stashKey(pluginId, key), {
+            value: this.resolve(pluginId, existing),
+            // Keep the prior SecretRef id so saved provider connections still resolve.
+            secretRef: existing.id,
+          });
+        } catch {
+          /* keep going; restore may be unavailable for this key */
+        }
+      }
     }
     const secretRef = this.randomBytes(24).toString("base64url");
     const ciphertext = this.safeStorage.encryptString(value);
@@ -82,8 +104,40 @@ class PluginSecretStore {
     return Object.freeze({ kind: "secret", id: secretRef, key });
   }
 
+  /**
+   * Restore the plaintext (and SecretRef id) stashed by the last overwrite.
+   * Returns true when a stashed value was written back.
+   */
+  restoreOverwrite(pluginId, key) {
+    this.#assertAvailable();
+    assertSecretKey(key);
+    const stashKey = this.#stashKey(pluginId, key);
+    const previous = this.#overwriteStash.get(stashKey);
+    if (!previous || typeof previous.value !== "string" || typeof previous.secretRef !== "string") {
+      return false;
+    }
+    this.#overwriteStash.delete(stashKey);
+    const ciphertext = this.safeStorage.encryptString(previous.value);
+    if (!Buffer.isBuffer(ciphertext) || ciphertext.byteLength < 1) {
+      throw new PluginRpcError(RPC_ERRORS.unavailable, "OS-backed plugin secret encryption failed");
+    }
+    this.database.upsertSecret({
+      pluginId,
+      key,
+      secretRef: previous.secretRef,
+      ciphertext,
+    });
+    return true;
+  }
+
+  clearOverwriteStash(pluginId, key) {
+    assertSecretKey(key);
+    this.#overwriteStash.delete(this.#stashKey(pluginId, key));
+  }
+
   delete(pluginId, key) {
     assertSecretKey(key);
+    this.#overwriteStash.delete(this.#stashKey(pluginId, key));
     this.database.deleteSecret(pluginId, key);
   }
 

--- a/electron/plugins/secretStore.test.cjs
+++ b/electron/plugins/secretStore.test.cjs
@@ -380,3 +380,31 @@ test("sync provider bindings live outside plugin secrets and reject namespace mi
   assert.equal(store.resolveSyncProviderPlugin("com.example.sync"), undefined);
   database.close();
 });
+
+test("failed restoreOverwrite keeps stash for retry", (context) => {
+  const database = createDatabase(context);
+  let failEncrypt = false;
+  const safeStorage = {
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => {
+      if (failEncrypt) return Buffer.alloc(0);
+      return Buffer.from(`sealed:${Buffer.from(value).toString("base64")}`);
+    },
+    decryptString: (value) => {
+      const encoded = value.toString().slice("sealed:".length);
+      return Buffer.from(encoded, "base64").toString();
+    },
+  };
+  const store = new PluginSecretStore({ database, safeStorage });
+  const first = store.set("com.example", "sync-credential", "good-password");
+  store.set("com.example", "sync-credential", "bad-password", { stashPrevious: true });
+  failEncrypt = true;
+  assert.throws(
+    () => store.restoreOverwrite("com.example", "sync-credential"),
+    (error) => error.code === RPC_ERRORS.unavailable,
+  );
+  failEncrypt = false;
+  assert.equal(store.restoreOverwrite("com.example", "sync-credential"), true);
+  assert.equal(store.resolve("com.example", first), "good-password");
+  database.close();
+});

--- a/electron/plugins/secretStore.test.cjs
+++ b/electron/plugins/secretStore.test.cjs
@@ -312,7 +312,7 @@ test("overwrite stash restores previous plaintext and discard clears it", (conte
   });
   const first = store.set("com.example.one", "sync-credential", "good-password");
   assert.equal(store.resolve("com.example.one", first), "good-password");
-  const second = store.set("com.example.one", "sync-credential", "bad-password");
+  const second = store.set("com.example.one", "sync-credential", "bad-password", { stashPrevious: true });
   assert.equal(store.resolve("com.example.one", second), "bad-password");
   assert.equal(store.restoreOverwrite("com.example.one", "sync-credential"), true);
   const restored = store.getReference("com.example.one", "sync-credential");
@@ -320,12 +320,16 @@ test("overwrite stash restores previous plaintext and discard clears it", (conte
   assert.equal(store.resolve("com.example.one", first), "good-password");
   assert.equal(store.restoreOverwrite("com.example.one", "sync-credential"), false);
 
-  store.set("com.example.one", "sync-credential", "another-bad");
+  store.set("com.example.one", "sync-credential", "another-bad", { stashPrevious: true });
   store.clearOverwriteStash("com.example.one", "sync-credential");
   assert.equal(store.restoreOverwrite("com.example.one", "sync-credential"), false);
   assert.equal(
     store.resolve("com.example.one", store.getReference("com.example.one", "sync-credential")),
     "another-bad",
   );
+  // Ordinary secrets.set-style overwrites must not stash plaintext by default.
+  store.set("com.example.one", "api-key", "one");
+  store.set("com.example.one", "api-key", "two");
+  assert.equal(store.restoreOverwrite("com.example.one", "api-key"), false);
   database.close();
 });

--- a/electron/plugins/secretStore.test.cjs
+++ b/electron/plugins/secretStore.test.cjs
@@ -301,3 +301,31 @@ test("credential lease resolution cannot return plaintext after operation cancel
   leaseStore.shutdown();
   database.close();
 });
+
+test("overwrite stash restores previous plaintext and discard clears it", (context) => {
+  const database = createDatabase(context);
+  let random = 0;
+  const store = new PluginSecretStore({
+    database,
+    safeStorage: fakeSafeStorage(),
+    randomBytes: () => Buffer.alloc(24, ++random),
+  });
+  const first = store.set("com.example.one", "sync-credential", "good-password");
+  assert.equal(store.resolve("com.example.one", first), "good-password");
+  const second = store.set("com.example.one", "sync-credential", "bad-password");
+  assert.equal(store.resolve("com.example.one", second), "bad-password");
+  assert.equal(store.restoreOverwrite("com.example.one", "sync-credential"), true);
+  const restored = store.getReference("com.example.one", "sync-credential");
+  assert.equal(restored.id, first.id, "restore must keep the prior SecretRef id");
+  assert.equal(store.resolve("com.example.one", first), "good-password");
+  assert.equal(store.restoreOverwrite("com.example.one", "sync-credential"), false);
+
+  store.set("com.example.one", "sync-credential", "another-bad");
+  store.clearOverwriteStash("com.example.one", "sync-credential");
+  assert.equal(store.restoreOverwrite("com.example.one", "sync-credential"), false);
+  assert.equal(
+    store.resolve("com.example.one", store.getReference("com.example.one", "sync-credential")),
+    "another-bad",
+  );
+  database.close();
+});

--- a/electron/plugins/secretStore.test.cjs
+++ b/electron/plugins/secretStore.test.cjs
@@ -333,3 +333,50 @@ test("overwrite stash restores previous plaintext and discard clears it", (conte
   assert.equal(store.restoreOverwrite("com.example.one", "api-key"), false);
   database.close();
 });
+
+test("failed overwrite clears stashed plaintext", (context) => {
+  const database = createDatabase(context);
+  let failEncrypt = false;
+  const safeStorage = {
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => {
+      if (failEncrypt) return Buffer.alloc(0);
+      return Buffer.from(`sealed:${Buffer.from(value).toString("base64")}`);
+    },
+    decryptString: (value) => {
+      const encoded = value.toString().slice("sealed:".length);
+      return Buffer.from(encoded, "base64").toString();
+    },
+  };
+  const store = new PluginSecretStore({ database, safeStorage });
+  store.set("com.example", "sync-credential", "good-password");
+  failEncrypt = true;
+  assert.throws(
+    () => store.set("com.example", "sync-credential", "bad-password", { stashPrevious: true }),
+    (error) => error.code === RPC_ERRORS.unavailable,
+  );
+  assert.equal(store.restoreOverwrite("com.example", "sync-credential"), false);
+  failEncrypt = false;
+  const ref = store.getReference("com.example", "sync-credential");
+  assert.equal(store.resolve("com.example", ref), "good-password");
+  database.close();
+});
+
+test("sync provider bindings live outside plugin secrets and reject namespace mismatches", (context) => {
+  const database = createDatabase(context);
+  const store = new PluginSecretStore({
+    database,
+    safeStorage: fakeSafeStorage(),
+  });
+  store.bindSyncProviderPlugin("com.example", "com.example.sync");
+  assert.equal(store.resolveSyncProviderPlugin("com.example.sync"), "com.example");
+  assert.throws(
+    () => store.bindSyncProviderPlugin("com.example", "com.other.sync"),
+    /outside the plugin namespace/,
+  );
+  store.set("com.attacker", "sync-provider-map:com.example.sync", "com.attacker");
+  assert.equal(store.resolveSyncProviderPlugin("com.example.sync"), "com.example");
+  store.unbindSyncProviderPlugin("com.example", "com.example.sync");
+  assert.equal(store.resolveSyncProviderPlugin("com.example.sync"), undefined);
+  database.close();
+});

--- a/electron/plugins/secretStore.test.cjs
+++ b/electron/plugins/secretStore.test.cjs
@@ -408,3 +408,38 @@ test("failed restoreOverwrite keeps stash for retry", (context) => {
   assert.equal(store.resolve("com.example", first), "good-password");
   database.close();
 });
+
+test("existing overwrite stash is preserved across retry puts and cleared by prefix delete", (context) => {
+  const database = createDatabase(context);
+  let failEncrypt = false;
+  const safeStorage = {
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => {
+      if (failEncrypt) return Buffer.alloc(0);
+      return Buffer.from(`sealed:${Buffer.from(value).toString("base64")}`);
+    },
+    decryptString: (value) => {
+      const encoded = value.toString().slice("sealed:".length);
+      return Buffer.from(encoded, "base64").toString();
+    },
+  };
+  const store = new PluginSecretStore({ database, safeStorage });
+  const first = store.set("com.example", "sync-credential", "good-password");
+  store.set("com.example", "sync-credential", "bad-password", { stashPrevious: true });
+  failEncrypt = true;
+  assert.throws(
+    () => store.restoreOverwrite("com.example", "sync-credential"),
+    (error) => error.code === RPC_ERRORS.unavailable,
+  );
+  failEncrypt = false;
+  // Retry put must not replace the original good-password stash with bad-password.
+  store.set("com.example", "sync-credential", "worse-password", { stashPrevious: true });
+  assert.equal(store.restoreOverwrite("com.example", "sync-credential"), true);
+  assert.equal(store.resolve("com.example", first), "good-password");
+
+  store.set("com.example", "sync-credential", "temp", { stashPrevious: true });
+  store.deleteByKeyPrefix("com.example", "sync-credential");
+  assert.equal(store.restoreOverwrite("com.example", "sync-credential"), false);
+  assert.equal(store.getReference("com.example", "sync-credential"), undefined);
+  database.close();
+});

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -183,6 +183,7 @@ function createPreloadApi(ctx) {
   },
   pluginSyncPutSecret: (request) => ipcRenderer.invoke("netcatty:plugins:sync-put-secret", request ?? {}),
   pluginSyncDeleteSecrets: (request) => ipcRenderer.invoke("netcatty:plugins:sync-delete-secrets", request ?? {}),
+  pluginSyncRestoreSecrets: (request) => ipcRenderer.invoke("netcatty:plugins:sync-restore-secrets", request ?? {}),
   collectPluginSyncSidecars: () => ipcRenderer.invoke("netcatty:plugins:sync-sidecars-collect", {}),
   applyPluginSyncSidecars: (bundle) => ipcRenderer.invoke("netcatty:plugins:sync-sidecars-apply", bundle ?? { version: 1, entries: [] }),
   /** True only when the main-process plugin host wired a sidecar service. */

--- a/global.d.ts
+++ b/global.d.ts
@@ -439,6 +439,11 @@ declare global {
       providerId: string;
       keys?: string[];
     }): Promise<{ deleted: number }>;
+    pluginSyncRestoreSecrets?(request: {
+      providerId: string;
+      keys: string[];
+      discard?: boolean;
+    }): Promise<{ restored: number; discarded?: number }>;
     collectPluginSyncSidecars?(): Promise<unknown>;
     applyPluginSyncSidecars?(bundle: unknown): Promise<{ applied: boolean; count?: number; entries?: unknown }>;
     pluginHostReady?(): boolean;

--- a/global.d.ts
+++ b/global.d.ts
@@ -434,7 +434,7 @@ declare global {
       providerId: string;
       key: string;
       value: string;
-    }): Promise<{ kind: 'secret'; id: string; key: string }>;
+    }): Promise<{ kind: 'secret'; id: string; key: string; created?: boolean }>;
     pluginSyncDeleteSecrets?(request: {
       providerId: string;
       keys?: string[];

--- a/infrastructure/services/adapters/pluginSyncIpcHost.ts
+++ b/infrastructure/services/adapters/pluginSyncIpcHost.ts
@@ -103,7 +103,7 @@ type ElectronPluginSyncApi = {
     providerId: string;
     key: string;
     value: string;
-  }) => Promise<{ kind: 'secret'; id: string; key: string }>;
+  }) => Promise<{ kind: 'secret'; id: string; key: string; created?: boolean }>;
   pluginSyncDeleteSecrets?: (params: {
     providerId: string;
     keys?: string[];
@@ -387,7 +387,7 @@ export async function putPluginSyncSecret(params: {
   providerId: string;
   key?: string;
   value: string;
-}): Promise<{ kind: 'secret'; id: string; key: string }> {
+}): Promise<{ kind: 'secret'; id: string; key: string; created?: boolean }> {
   const api = getPluginSyncApi();
   if (typeof api?.pluginSyncPutSecret !== 'function') {
     throw new Error('Plugin sync secret storage is unavailable');

--- a/infrastructure/services/adapters/pluginSyncIpcHost.ts
+++ b/infrastructure/services/adapters/pluginSyncIpcHost.ts
@@ -108,6 +108,11 @@ type ElectronPluginSyncApi = {
     providerId: string;
     keys?: string[];
   }) => Promise<{ deleted: number }>;
+  pluginSyncRestoreSecrets?: (params: {
+    providerId: string;
+    keys: string[];
+    discard?: boolean;
+  }) => Promise<{ restored: number; discarded?: number }>;
 };
 
 function getPluginSyncApi(): ElectronPluginSyncApi | null {
@@ -411,5 +416,22 @@ export async function deletePluginSyncSecrets(params: {
   return api.pluginSyncDeleteSecrets({
     providerId: params.providerId,
     ...(params.keys ? { keys: [...params.keys] } : {}),
+  });
+}
+
+/** Restore host-stashed plaintext after a rejected overwrite during reconnect. */
+export async function restorePluginSyncSecrets(params: {
+  providerId: string;
+  keys: string[];
+  discard?: boolean;
+}): Promise<{ restored: number; discarded?: number }> {
+  const api = getPluginSyncApi();
+  if (typeof api?.pluginSyncRestoreSecrets !== 'function') {
+    return { restored: 0, discarded: 0 };
+  }
+  return api.pluginSyncRestoreSecrets({
+    providerId: params.providerId,
+    keys: [...params.keys],
+    ...(params.discard === true ? { discard: true } : {}),
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #2713 addressing residual Codex review findings on plugin sync secrets and protective backups.

Codex reviewed `c849bf6a73` and reported no major issues.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #2713

## Changes Made

- Host-owned `plugin_sync_provider_bindings` table (schema v3) so disconnect can wipe secrets after a plugin is gone without trusting plugin-writable secret keys
- Reject provider bindings outside the plugin namespace
- Opt-in overwrite stash on sync put only; preserve stash across failed restore retries; clear stash on successful restore, failed replacement writes, prefix deletes, and successful connect
- Prefer live authoritative-empty sidecar bundles in protective backups
- Unit coverage for the above

## Screenshots / Demo

N/A

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass — targeted: `secretStore`, `database`, `pluginBridge`, `pluginSyncConnectWithSecrets`, `syncPayload`
- [ ] Generated capability tool specs are updated when applicable
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d67b117-68c4-4dec-add9-e3d7797d7cf6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d67b117-68c4-4dec-add9-e3d7797d7cf6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

