### PR TITLE
fix(terminal): forward Cmd+C to Kitty when there is no xterm selection (#2728)

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -1476,8 +1476,8 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
           ) {
             return true;
           }
-          // When copy is bound specifically to Ctrl+C and there is no text
-          // selected, pass the event through so xterm can send SIGINT.
+          // No xterm selection: pass Ctrl+C through for SIGINT, and Cmd+C for
+          // Kitty Super+C (nested TUIs). Other copy chords stay a safe no-op.
           const shouldForwardCopyToTerminal =
             shouldPassThroughCopyShortcut(action, term.hasSelection(), e);
           if (shouldForwardCopyToTerminal && !kittySequenceForKeyDown) return true;

--- a/components/terminal/runtime/terminalCopyShortcut.test.ts
+++ b/components/terminal/runtime/terminalCopyShortcut.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   isPlainCtrlCInterruptChord,
+  isPlainMetaCCopyChord,
   shouldPassThroughCopyShortcut,
 } from "./terminalCopyShortcut.ts";
 
@@ -27,10 +28,20 @@ test("plain Ctrl+C copy with no selection passes through for SIGINT", () => {
   assert.equal(shouldPassThroughCopyShortcut("copy", false, event), true);
 });
 
-test("copy shortcut does not pass through when text is selected", () => {
-  const event = keyboardEvent("c", "KeyC", { ctrlKey: true });
+test("plain Cmd+C copy with no selection passes through for Kitty Super+C", () => {
+  const event = keyboardEvent("c", "KeyC", { metaKey: true });
 
-  assert.equal(shouldPassThroughCopyShortcut("copy", true, event), false);
+  assert.equal(isPlainMetaCCopyChord(event), true);
+  assert.equal(isPlainCtrlCInterruptChord(event), false);
+  assert.equal(shouldPassThroughCopyShortcut("copy", false, event), true);
+});
+
+test("copy shortcut does not pass through when text is selected", () => {
+  const ctrlC = keyboardEvent("c", "KeyC", { ctrlKey: true });
+  const cmdC = keyboardEvent("c", "KeyC", { metaKey: true });
+
+  assert.equal(shouldPassThroughCopyShortcut("copy", true, ctrlC), false);
+  assert.equal(shouldPassThroughCopyShortcut("copy", true, cmdC), false);
 });
 
 test("copy shortcut does not pass through for shifted or alternate chords", () => {
@@ -39,11 +50,23 @@ test("copy shortcut does not pass through for shifted or alternate chords", () =
     false,
   );
   assert.equal(
+    shouldPassThroughCopyShortcut("copy", false, keyboardEvent("C", "KeyC", { metaKey: true, shiftKey: true })),
+    false,
+  );
+  assert.equal(
     shouldPassThroughCopyShortcut("copy", false, keyboardEvent("l", "KeyL", { ctrlKey: true })),
     false,
   );
   assert.equal(
+    shouldPassThroughCopyShortcut("copy", false, keyboardEvent("c", "KeyC", { metaKey: true, ctrlKey: true })),
+    false,
+  );
+  assert.equal(
     shouldPassThroughCopyShortcut("paste", false, keyboardEvent("c", "KeyC", { ctrlKey: true })),
+    false,
+  );
+  assert.equal(
+    shouldPassThroughCopyShortcut("paste", false, keyboardEvent("c", "KeyC", { metaKey: true })),
     false,
   );
 });
@@ -52,5 +75,12 @@ test("plain Ctrl+C copy passthrough follows the physical C key on non-Latin layo
   const event = keyboardEvent("\u0441", "KeyC", { ctrlKey: true });
 
   assert.equal(isPlainCtrlCInterruptChord(event), true);
+  assert.equal(shouldPassThroughCopyShortcut("copy", false, event), true);
+});
+
+test("plain Cmd+C copy passthrough follows the physical C key on non-Latin layouts", () => {
+  const event = keyboardEvent("\u0441", "KeyC", { metaKey: true });
+
+  assert.equal(isPlainMetaCCopyChord(event), true);
   assert.equal(shouldPassThroughCopyShortcut("copy", false, event), true);
 });

--- a/components/terminal/runtime/terminalCopyShortcut.ts
+++ b/components/terminal/runtime/terminalCopyShortcut.ts
@@ -3,18 +3,43 @@ type CopyShortcutKeyEvent = Pick<
   "key" | "code" | "ctrlKey" | "shiftKey" | "altKey" | "metaKey"
 >;
 
+function isPhysicalCKey(e: CopyShortcutKeyEvent): boolean {
+  return e.key.toLowerCase() === "c" || e.code === "KeyC";
+}
+
 export function isPlainCtrlCInterruptChord(e: CopyShortcutKeyEvent): boolean {
   return e.ctrlKey
     && !e.shiftKey
     && !e.altKey
     && !e.metaKey
-    && (e.key.toLowerCase() === "c" || e.code === "KeyC");
+    && isPhysicalCKey(e);
 }
 
+/** macOS Cmd+C / Super+C — forward when there is no xterm selection. */
+export function isPlainMetaCCopyChord(e: CopyShortcutKeyEvent): boolean {
+  return e.metaKey
+    && !e.ctrlKey
+    && !e.shiftKey
+    && !e.altKey
+    && isPhysicalCKey(e);
+}
+
+/**
+ * When copy matches with no xterm selection, pass the chord through instead of
+ * consuming an empty clipboard write.
+ *
+ * - Ctrl+C → SIGINT (or Kitty Ctrl+C)
+ * - Cmd+C → Kitty Super+C for nested TUIs (e.g. Herdr)
+ *
+ * Other no-selection copy bindings stay consumed as a safe no-op so keys like
+ * F5 / Ctrl+L are not forwarded to the remote (#1461).
+ */
 export function shouldPassThroughCopyShortcut(
   action: string,
   hasSelection: boolean,
   e: CopyShortcutKeyEvent,
 ): boolean {
-  return action === "copy" && !hasSelection && isPlainCtrlCInterruptChord(e);
+  return action === "copy"
+    && !hasSelection
+    && (isPlainCtrlCInterruptChord(e) || isPlainMetaCCopyChord(e));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On macOS, the default terminal copy shortcut is Cmd+C. When the terminal had no xterm selection, Netcatty still consumed that chord as an empty clipboard write, so nested Kitty-protocol apps (e.g. Herdr) never received Super+C.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2728

## Changes Made

- Treat plain Meta+C (Cmd+C / Super+C) like Ctrl+C for no-selection copy passthrough
- Keep other no-selection copy bindings as a safe no-op (preserves #1461)
- Extend unit coverage for Cmd+C, selection present, shifted chords, and non-Latin layouts

## Screenshots / Demo

N/A — keyboard shortcut behavior; covered by unit tests.

## Testing

- [x] I have tested these changes locally (`npm run dev`) — unit tests for the shortcut helper
- [x] Linting passes (`npm run lint`) — eslint on touched files
- [x] Tests pass (`npm test`) — `node --test --import tsx components/terminal/runtime/terminalCopyShortcut.test.ts`
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96c5fee3-2c93-4dc6-b439-3f1f3d85f632?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96c5fee3-2c93-4dc6-b439-3f1f3d85f632&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

