### PR TITLE
fix(sftp): serialize write OPENs and harden late/supersede cleanup

### DIFF
--- a/application/app/useAppStartupEffects.ts
+++ b/application/app/useAppStartupEffects.ts
@@ -423,7 +423,33 @@ export function useAppStartupEffects(ctx: StartupEffectsContext) {
             });
           },
         );
-        if (result?.cancelled || result?.error === "Transfer cancelled") {
+        // Same-id retry stole ownership; wait for the live owner's terminal
+        // status instead of treating this invoke as completed (Codex P2).
+        if (result?.superseded === true) {
+          const deadline = Date.now() + 30 * 60 * 1000;
+          for (;;) {
+            const latest = sftpTransferCenterStore.getSnapshot().tasks.find((candidate) => candidate.id === task.id);
+            const status = latest?.status;
+            if (status === "completed" || status === "cancelled" || status === "failed") {
+              if (status === "failed") {
+                throw new Error(latest?.error || "Transfer failed");
+              }
+              if (status === "cancelled") {
+                sftpTransferCenterStore.ingestBackgroundEvent({
+                  type: "cancelled",
+                  transferId: task.id,
+                  endedAt: Date.now(),
+                });
+              }
+              // completed: events already applied; cancelled handled above.
+              break;
+            }
+            if (Date.now() > deadline) {
+              throw new Error("Transfer superseded wait timed out");
+            }
+            await new Promise((resolve) => setTimeout(resolve, 200));
+          }
+        } else if (result?.cancelled || result?.error === "Transfer cancelled") {
           sftpTransferCenterStore.ingestBackgroundEvent({ type: "cancelled", transferId: task.id, endedAt: Date.now() });
         } else if (result?.error) {
           throw new Error(result.error);

--- a/application/app/useAppStartupEffects.ts
+++ b/application/app/useAppStartupEffects.ts
@@ -409,6 +409,9 @@ export function useAppStartupEffects(ctx: StartupEffectsContext) {
               targetType: task.direction === "download" ? "local" : "sftp",
               sourceSftpId: task.direction === "download" ? sftpId : undefined,
               targetSftpId: task.direction === "upload" ? sftpId : undefined,
+              // Keep host-scoped path gates across session reopen (Codex P1).
+              sourceHostId: task.sourceHostId,
+              targetHostId: task.targetHostId,
               totalBytes: task.totalBytes,
               resumable: task.resumable !== false,
               checkpointBytes,

--- a/application/app/useAppStartupEffects.ts
+++ b/application/app/useAppStartupEffects.ts
@@ -426,7 +426,7 @@ export function useAppStartupEffects(ctx: StartupEffectsContext) {
         // Same-id retry stole ownership; wait for the live owner's terminal
         // status instead of treating this invoke as completed (Codex P2).
         if (result?.superseded === true) {
-          const deadline = Date.now() + 30 * 60 * 1000;
+          // Wait for live owner terminal status only (no fixed deadline).
           for (;;) {
             const latest = sftpTransferCenterStore.getSnapshot().tasks.find((candidate) => candidate.id === task.id);
             const status = latest?.status;
@@ -443,9 +443,6 @@ export function useAppStartupEffects(ctx: StartupEffectsContext) {
               }
               // completed: events already applied; cancelled handled above.
               break;
-            }
-            if (Date.now() > deadline) {
-              throw new Error("Transfer superseded wait timed out");
             }
             await new Promise((resolve) => setTimeout(resolve, 200));
           }

--- a/application/state/sftp/dedicatedTransferResume.ts
+++ b/application/state/sftp/dedicatedTransferResume.ts
@@ -29,6 +29,7 @@ import {
   isMissingDirectoryReplacePathError,
   promoteDirectoryReplaceStage as promoteDirectoryReplacePaths,
 } from "./directoryReplacePromotion";
+import { sftpTransferCenterStore } from "../sftpTransferCenterStore";
 
 export interface DedicatedResumeDeps {
   hosts: readonly Host[];
@@ -708,8 +709,21 @@ async function resumeSingleFileWithDedicatedSession(
             skipAdmission: true,
           });
 
-          if (streamResult?.error) {
-            throw new Error(streamResult.error);
+          if (streamResult?.superseded === true) {
+            // Live same-id owner still running; wait for terminal events.
+            const deadline = Date.now() + 30 * 60 * 1000;
+            for (;;) {
+              if (shouldAbort?.()) throw new Error("Transfer cancelled");
+              const latest = sftpTransferCenterStore.getTask(task.id);
+              const status = latest?.status;
+              if (status === "completed") break;
+              if (status === "failed") throw new Error(latest?.error || "Transfer failed");
+              if (status === "cancelled") throw new Error("Transfer cancelled");
+              if (Date.now() > deadline) throw new Error("Transfer superseded wait timed out");
+              await new Promise((resolve) => setTimeout(resolve, 200));
+            }
+          } else if (streamResult?.error || streamResult?.cancelled) {
+            throw new Error(streamResult.error || "Transfer cancelled");
           }
         }, { retries: 1, delayMs: 600 });
         return { transferId: task.id };
@@ -1258,7 +1272,19 @@ async function resumeDirectoryWithDedicatedSession(
                 skipAdmission: true,
               });
 
-              if (streamResult?.error || streamResult?.cancelled) {
+              if (streamResult?.superseded === true) {
+                const deadline = Date.now() + 30 * 60 * 1000;
+                for (;;) {
+                  if (options?.shouldAbort?.()) throw new Error("Transfer cancelled");
+                  const latest = sftpTransferCenterStore.getTask(childBase.id);
+                  const status = latest?.status;
+                  if (status === "completed") break;
+                  if (status === "failed") throw new Error(latest?.error || "Transfer failed");
+                  if (status === "cancelled") throw new Error("Transfer cancelled");
+                  if (Date.now() > deadline) throw new Error("Transfer superseded wait timed out");
+                  await new Promise((resolve) => setTimeout(resolve, 200));
+                }
+              } else if (streamResult?.error || streamResult?.cancelled) {
                 throw new Error(streamResult.error || "Transfer cancelled");
               }
 

--- a/application/state/sftp/dedicatedTransferResume.ts
+++ b/application/state/sftp/dedicatedTransferResume.ts
@@ -710,8 +710,7 @@ async function resumeSingleFileWithDedicatedSession(
           });
 
           if (streamResult?.superseded === true) {
-            // Live same-id owner still running; wait for terminal events.
-            const deadline = Date.now() + 30 * 60 * 1000;
+            // Live same-id owner still running; wait for terminal events only.
             for (;;) {
               if (shouldAbort?.()) throw new Error("Transfer cancelled");
               const latest = sftpTransferCenterStore.getTask(task.id);
@@ -719,7 +718,6 @@ async function resumeSingleFileWithDedicatedSession(
               if (status === "completed") break;
               if (status === "failed") throw new Error(latest?.error || "Transfer failed");
               if (status === "cancelled") throw new Error("Transfer cancelled");
-              if (Date.now() > deadline) throw new Error("Transfer superseded wait timed out");
               await new Promise((resolve) => setTimeout(resolve, 200));
             }
           } else if (streamResult?.error || streamResult?.cancelled) {
@@ -1273,7 +1271,6 @@ async function resumeDirectoryWithDedicatedSession(
               });
 
               if (streamResult?.superseded === true) {
-                const deadline = Date.now() + 30 * 60 * 1000;
                 for (;;) {
                   if (options?.shouldAbort?.()) throw new Error("Transfer cancelled");
                   const latest = sftpTransferCenterStore.getTask(childBase.id);
@@ -1281,7 +1278,6 @@ async function resumeDirectoryWithDedicatedSession(
                   if (status === "completed") break;
                   if (status === "failed") throw new Error(latest?.error || "Transfer failed");
                   if (status === "cancelled") throw new Error("Transfer cancelled");
-                  if (Date.now() > deadline) throw new Error("Transfer superseded wait timed out");
                   await new Promise((resolve) => setTimeout(resolve, 200));
                 }
               } else if (streamResult?.error || streamResult?.cancelled) {

--- a/application/state/sftp/transferDirectoryOps.ts
+++ b/application/state/sftp/transferDirectoryOps.ts
@@ -357,12 +357,41 @@ export function useSftpDirectoryTransferOps({
                     await new Promise((resolve) => setTimeout(resolve, 80));
                   }
                 })();
-                let result: { error?: string; cancelled?: boolean } | undefined;
+                let result: { error?: string; cancelled?: boolean; superseded?: boolean } | undefined;
                 try {
                   result = await transferPromise;
                 } finally {
                   watchPaused = false;
                   await pauseWatch.catch(() => {});
+                }
+                // Same-id retry stole ownership while OPEN was pending. The live
+                // owner still drives progress/completion events; this invoke must
+                // not mark the child completed or failed (Codex P2 on b17f64e9).
+                if (result?.superseded === true) {
+                  const deadline = Date.now() + 30 * 60 * 1000;
+                  for (;;) {
+                    if (
+                      cancelledTasksRef.current.has(task.id)
+                      || cancelledTasksRef.current.has(rootTaskId)
+                    ) {
+                      throw new Error("Transfer cancelled");
+                    }
+                    const latest = sftpTransferCenterStore.getTask(task.id)
+                      ?? transfersRef.current.find((candidate) => candidate.id === task.id);
+                    const status = latest?.status;
+                    if (status === "completed") break;
+                    if (status === "failed") {
+                      throw new Error(latest?.error || "Transfer failed");
+                    }
+                    if (status === "cancelled") {
+                      throw new Error("Transfer cancelled");
+                    }
+                    if (Date.now() > deadline) {
+                      throw new Error("Transfer superseded wait timed out");
+                    }
+                    await new Promise((resolve) => setTimeout(resolve, 200));
+                  }
+                  break;
                 }
                 if (result?.error || result?.cancelled) {
                   throw new Error(result.error || "Transfer cancelled");

--- a/application/state/sftp/transferDirectoryOps.ts
+++ b/application/state/sftp/transferDirectoryOps.ts
@@ -368,7 +368,8 @@ export function useSftpDirectoryTransferOps({
                 // owner still drives progress/completion events; this invoke must
                 // not mark the child completed or failed (Codex P2 on b17f64e9).
                 if (result?.superseded === true) {
-                  const deadline = Date.now() + 30 * 60 * 1000;
+                  // Wait for the live same-id owner only — no fixed deadline so
+                  // long transfers are not failed while still running (Codex P2).
                   for (;;) {
                     if (
                       cancelledTasksRef.current.has(task.id)
@@ -385,9 +386,6 @@ export function useSftpDirectoryTransferOps({
                     }
                     if (status === "cancelled") {
                       throw new Error("Transfer cancelled");
-                    }
-                    if (Date.now() > deadline) {
-                      throw new Error("Transfer superseded wait timed out");
                     }
                     await new Promise((resolve) => setTimeout(resolve, 200));
                   }

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2176,20 +2176,35 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       }, 2000);
     };
 
+    // Best-effort remote unlink with a hard bound. A dead shared channel that
+    // never invokes the unlink callback must not pin finishCancel / drain
+    // settle forever (lease + admission slot hang). Same 2s grace as the
+    // shared-write drain force-complete.
     const unlinkSharedWritePathBestEffort = () => new Promise((resolveUnlink) => {
+      let settledUnlink = false;
+      const finishUnlink = () => {
+        if (settledUnlink) return;
+        settledUnlink = true;
+        if (unlinkTimer) {
+          clearTimeout(unlinkTimer);
+          unlinkTimer = null;
+        }
+        resolveUnlink();
+      };
+      let unlinkTimer = setTimeout(finishUnlink, 2000);
       // Ownership can change between close and unlink (retry start).
       if (!canUnlinkLateGeneratedStageNow()) {
-        resolveUnlink();
+        finishUnlink();
         return;
       }
       if (typeof sftp.unlink !== "function") {
-        resolveUnlink();
+        finishUnlink();
         return;
       }
       try {
-        sftp.unlink(filePath, () => resolveUnlink());
+        sftp.unlink(filePath, () => finishUnlink());
       } catch {
-        resolveUnlink();
+        finishUnlink();
       }
     });
 

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2204,9 +2204,16 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     const previousAbort = transfer.abort;
     let pathGateReleased = false;
 
+    let pathGateForceTimer = null;
+    const clearPathGateForceTimer = () => {
+      if (!pathGateForceTimer) return;
+      clearTimeout(pathGateForceTimer);
+      pathGateForceTimer = null;
+    };
     const releasePathGate = () => {
       if (!pathGate || pathGateReleased) return;
       pathGateReleased = true;
+      clearPathGateForceTimer();
       pathGate.release();
     };
 
@@ -2226,10 +2233,12 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
 
     // OPEN wait may settle without a callback (channel error, or cancel settle
     // timeout). Force-complete the drain so cleanup/lease cannot hang, but
-    // NEVER release the path gate here: a still-in-flight truncating OPEN can
-    // land later and wipe a same-path retry that already wrote (Codex P1 on
+    // NEVER release the path gate here for shared channels: a still-in-flight
+    // truncating OPEN can land later and wipe a same-path retry (Codex P1 on
     // a0b2ce01 / late-unlink-retry). Gate is only released from the OPEN
-    // callback paths (success, error, late finishLateSharedWriteOpen).
+    // callback paths (success, error, late finishLateSharedWriteOpen), or via
+    // armPathGateForceRelease after isolated sftp.end() when the callback is
+    // never expected to arrive.
     const armSharedWriteDrainForceComplete = () => {
       if (!trackSharedWriteDrain || !resolveSharedWriteDrain || drainForceTimer) return;
       drainForceTimer = setTimeout(() => {
@@ -2238,6 +2247,17 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
         // callback actually settles (or never, if the channel is dead — safer
         // than reusing a path that a stale truncating OPEN can still wipe).
         completeSharedWriteDrain();
+      }, 2000);
+    };
+
+    // Isolated write OPEN: after sftp.end() the OPEN callback may never fire.
+    // Force-release the path gate so same-path retries are not stuck forever,
+    // while late callbacks still run finishLateSharedWriteOpen (Codex P1).
+    const armPathGateForceRelease = () => {
+      if (!pathGate || pathGateReleased || pathGateForceTimer) return;
+      pathGateForceTimer = setTimeout(() => {
+        pathGateForceTimer = null;
+        releasePathGate();
       }, 2000);
     };
 
@@ -2342,17 +2362,22 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
 
     const abortDuringOpen = () => {
       transfer.cancelled = true;
-      // Shared write OPEN can truncate/create the remote path. A settle timeout
-      // unblocks the transfer UX; sharedWriteOpenDrain stays pending until the
-      // OPEN callback finishes (or drain force-complete) so cleanup usually
-      // waits. Late truncating generated stages still unlink after close if
-      // cancel won; in-place finals only close.
-      if (!disposeChannel && isWriteOpen && !settled) {
+      // Any write OPEN (shared or isolated) can truncate/create the remote path.
+      // A settle timeout unblocks the transfer UX; the path gate stays held until
+      // the OPEN callback finishes (or isolated force-release after end()) so a
+      // same-path retry cannot race a still-in-flight truncating OPEN (Codex P1
+      // on 76015575). Shared drain stays pending until callback/force-complete.
+      if (isWriteOpen && !settled) {
         try { abortChannel?.(); } catch { /* ignore */ }
         if (!openDrainTimer) {
           openDrainTimer = setTimeout(() => {
             settle(reject, new Error("Transfer cancelled"));
-            armSharedWriteDrainForceComplete();
+            if (trackSharedWriteDrain) {
+              armSharedWriteDrainForceComplete();
+            } else {
+              // Isolated: sftp.end() was requested; OPEN may never return.
+              armPathGateForceRelease();
+            }
           }, 2000);
         }
         return;
@@ -2361,21 +2386,21 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       // sftp.end() cannot win the promise with a channel-close error first.
       settle(reject, new Error("Transfer cancelled"));
       try { abortChannel?.(); } catch { /* ignore */ }
-      if (!trackSharedWriteDrain) {
-        completeSharedWriteDrain();
-        releasePathGate();
-      }
+      completeSharedWriteDrain();
+      releasePathGate();
     };
 
     const onOpenChannelError = (error) => {
       settle(reject, error || new Error("SFTP channel error"));
-      // Shared write: keep drain pending for a late OPEN close, but bound it so
-      // a dead channel that never invokes the OPEN callback cannot hang forever.
-      if (!trackSharedWriteDrain) {
+      // Write OPEN: keep path gate until OPEN callback (or isolated force-release).
+      // Shared drain also stays pending until callback/force-complete.
+      if (trackSharedWriteDrain) {
+        armSharedWriteDrainForceComplete();
+      } else if (isWriteOpen) {
+        armPathGateForceRelease();
+      } else {
         completeSharedWriteDrain();
         releasePathGate();
-      } else {
-        armSharedWriteDrainForceComplete();
       }
     };
 
@@ -2393,9 +2418,9 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       sftp.open(filePath, resolveFlags(), (error, handle) => {
         if (settled) {
           // Cancel / channel error already settled (possibly via drain timeout).
-          // Still close a late shared handle; cancel + truncating "w" also
-          // unlinks so a force-completed drain cannot orphan a recreated stage.
-          if (!error && handle && !disposeChannel) {
+          // Late write OPEN (shared or isolated) still invalidates same-path
+          // writers and releases the gate (Codex P1 on 76015575).
+          if (!error && handle && isWriteOpen) {
             finishLateSharedWriteOpen(handle);
             return;
           }
@@ -2421,7 +2446,7 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
           const supersededErr = new Error("Transfer superseded");
           supersededErr.noTransferFallback = true;
           settle(reject, supersededErr);
-          if (handle && !disposeChannel) {
+          if (handle && isWriteOpen) {
             finishLateSharedWriteOpen(handle);
             return;
           }

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -4529,8 +4529,11 @@ async function startTransferNow(event, payload, onProgress) {
   const sendError = (error) => {
     cleanupTransfer();
     const message = error?.message || String(error);
+    // Same-id retries supersede the previous attempt's late OPEN path. Do not
+    // broadcast a terminal "failed" for that transferId or the live retry task
+    // is marked failed in the transfer center (Codex P2 on 5d8e232).
+    const cancelled = /cancel/i.test(message) || /superseded/i.test(message);
     sender.send("netcatty:transfer:error", { transferId, error: message });
-    const cancelled = /cancel/i.test(message);
     broadcastGlobalTransferEvent({
       type: cancelled ? "cancelled" : "failed",
       transferId,

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -1943,6 +1943,13 @@ async function uploadFile(
       let fastPutSourcePath = localPath;
       let fastPutSnapshotPath = null;
       try {
+        // Wait for any prior/in-flight write OPEN on this path (including our
+        // own concurrent attempt's still-pending OPEN) before fastPut truncates
+        // the same stage (Codex P1 on 7872a304).
+        if (typeof transfer.pendingWriteOpenPathGate?.then === "function") {
+          await transfer.pendingWriteOpenPathGate;
+        }
+        if (transfer.cancelled) throw new Error("Transfer cancelled");
         transfer.uploadStrategy = "fastPut-isolated";
         logTransferDiag(transfer, "strategy", { strategy: "fastPut-isolated" });
         transfer.pauseSupported = false;
@@ -2125,6 +2132,21 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
   const pathGate = isWriteOpen
     ? beginTruncatingSharedWriteOpen(filePath, sharedWriteOpenSessionKey(sftp, transfer))
     : null;
+  // Expose a promise that resolves when this OPEN's path gate is released so
+  // same-transfer fallbacks (fastPut) can wait instead of racing a still-
+  // pending truncating OPEN (Codex P1 on 7872a304).
+  if (pathGate && transfer && typeof transfer === "object") {
+    let resolvePathGate;
+    const pending = new Promise((resolve) => { resolvePathGate = resolve; });
+    transfer.pendingWriteOpenPathGate = pending;
+    transfer._resolvePendingWriteOpenPathGate = () => {
+      try { resolvePathGate(); } catch { /* ignore */ }
+      if (transfer.pendingWriteOpenPathGate === pending) {
+        transfer.pendingWriteOpenPathGate = null;
+      }
+      transfer._resolvePendingWriteOpenPathGate = null;
+    };
+  }
   // Re-check ownership at unlink time: a same-id retry may already own
   // activeTransfers. Only suppress unlink when the retry's *actual* staged
   // remote path matches this OPEN path. Do not infer ownership from
@@ -2223,6 +2245,7 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       if (!pathGate || pathGateReleased) return;
       pathGateReleased = true;
       pathGate.release();
+      try { transfer._resolvePendingWriteOpenPathGate?.(); } catch { /* ignore */ }
     };
 
     const clearDrainForceTimer = () => {
@@ -2538,8 +2561,14 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       // same-path attempts with no barrier while the prior OPEN is still in
       // flight (stale truncating OPEN race). Chain our release to the prior.
       pathGate.waitForPrior.then(
-        () => pathGate.release(),
-        () => pathGate.release(),
+        () => {
+          pathGate.release();
+          try { transfer._resolvePendingWriteOpenPathGate?.(); } catch { /* ignore */ }
+        },
+        () => {
+          pathGate.release();
+          try { transfer._resolvePendingWriteOpenPathGate?.(); } catch { /* ignore */ }
+        },
       );
       if (resolveSharedWriteDrain) {
         const resolveDrain = resolveSharedWriteDrain;

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2144,12 +2144,23 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
    * rather than allow a sparse promote (Codex P1 on 42a27ef7).
    */
   const invalidateRetryStageIfStaleOpen = () => {
-    if (!shouldUnlinkLateGeneratedStage) return;
+    // Truncating OPEN on either a generated stage or an in-place final can wipe
+    // a same-id retry that already accepted its own OPEN (Codex P1 on 709b27a1).
+    if (!isTruncatingOpen) return;
     const transferId = transfer?.transferId;
     if (transferId == null || transferId === "") return;
     const active = activeTransfers.get(transferId);
     if (!active || active === transfer) return;
-    if (!remoteOpenPathMatchesStaged(filePath, active.stagedRemote)) return;
+    const matchesStage = remoteOpenPathMatchesStaged(filePath, active.stagedRemote);
+    const matchesInPlace = !active.stagedRemote && (
+      remoteOpenPathMatchesStaged(filePath, {
+        path: active.targetPath,
+        sftpId: active.targetSftpId,
+        encoding: active.targetEncoding,
+      })
+      || String(filePath ?? "") === String(active.targetPath ?? "")
+    );
+    if (!matchesStage && !matchesInPlace) return;
     // Only abort once the retry has accepted its own OPEN; otherwise the path
     // gate is about to let the retry open cleanly after this late callback.
     if (active.sharedWriteOpenAccepted !== true) return;
@@ -2202,15 +2213,10 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       drainForceTimer = setTimeout(() => {
         drainForceTimer = null;
         completeSharedWriteDrain();
-        // In-place opens can free the path gate immediately. Generated/reusable
-        // stages must keep the gate held until a late OPEN callback settles
-        // (finishLateSharedWriteOpen / cancel path) so a same-id retry cannot
-        // promote while the server still processes the stale OPEN "w". Cap the
-        // hold so a permanently dead channel cannot block forever (Codex P1).
-        if (!generatedStagePath) {
-          releasePathGate();
-          return;
-        }
+        // Keep the path gate held until a late OPEN callback settles (or a 10s
+        // hard cap). Releasing immediately — even for in-place finals — lets a
+        // same-id retry open/write the same target while the old OPEN "w" is
+        // still pending and can still truncate it (Codex P1 on 709b27a1).
         setTimeout(() => releasePathGate(), 10000);
       }, 2000);
     };

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -342,6 +342,9 @@ function remoteOpenPathMatchesStaged(openPath, stagedRemote) {
  * @type {Map<string, { promise: Promise<void>, resolve: () => void, released: boolean }>}
  */
 const truncatingSharedWriteOpenGates = new Map();
+/** @type {WeakMap<object, string>} */
+const truncatingSharedWriteSftpKeys = new WeakMap();
+let truncatingSharedWriteSftpSeq = 0;
 
 function sharedWriteOpenPathKey(filePath) {
   if (Buffer.isBuffer(filePath)) return `b:${filePath.toString("hex")}`;
@@ -349,11 +352,38 @@ function sharedWriteOpenPathKey(filePath) {
 }
 
 /**
+ * Scope path gates per SFTP endpoint so two hosts with the same remote path do
+ * not serialize each other (Codex P2 on c3682460).
+ * @param {object | null | undefined} sftp
+ * @param {object | null | undefined} transfer
+ */
+function sharedWriteOpenSessionKey(sftp, transfer) {
+  const fromTransfer = transfer?.targetSftpId
+    || transfer?.sourceSftpId
+    || transfer?.sftpId
+    || transfer?.sessionId;
+  if (fromTransfer != null && String(fromTransfer).length > 0) {
+    return `id:${String(fromTransfer)}`;
+  }
+  if (sftp && typeof sftp === "object") {
+    let key = truncatingSharedWriteSftpKeys.get(sftp);
+    if (!key) {
+      truncatingSharedWriteSftpSeq += 1;
+      key = `obj:${truncatingSharedWriteSftpSeq}`;
+      truncatingSharedWriteSftpKeys.set(sftp, key);
+    }
+    return key;
+  }
+  return "unknown";
+}
+
+/**
  * @param {string | Buffer} filePath
+ * @param {string} [sessionKey]
  * @returns {{ waitForPrior: Promise<void>, release: () => void }}
  */
-function beginTruncatingSharedWriteOpen(filePath) {
-  const key = sharedWriteOpenPathKey(filePath);
+function beginTruncatingSharedWriteOpen(filePath, sessionKey = "unknown") {
+  const key = `${sessionKey}|${sharedWriteOpenPathKey(filePath)}`;
   const prior = truncatingSharedWriteOpenGates.get(key);
   const waitForPrior = prior && !prior.released
     ? prior.promise
@@ -2080,7 +2110,7 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
   // Path gate only for truncating shared writes — non-truncating "r+" resume
   // opens do not wipe peer bytes if ordered loosely.
   const pathGate = trackSharedWriteDrain && isTruncatingOpen
-    ? beginTruncatingSharedWriteOpen(filePath)
+    ? beginTruncatingSharedWriteOpen(filePath, sharedWriteOpenSessionKey(sftp, transfer))
     : null;
   // Late truncating OPEN after settle (cancel or channel-error force-complete)
   // must unlink generated stages so cleanup cannot leave a recreate orphan.

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2111,12 +2111,13 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
   // Match sftpBridge.runFastPutOnChannel: only unlink planner-generated stages.
   const generatedStagePath = options.generatedStagePath === true;
   // flags may be a getter so afterPathGate can shrink the resume checkpoint and
-  // switch r+ → w before the actual OPEN (Codex P2).
+  // switch r+ → w before the actual OPEN (Codex P2). Resolve at OPEN/unlink time
+  // so a post-gate shrink from r+ → w still unlinks generated stages.
   const resolveFlags = () => (typeof flags === "function" ? flags() : flags);
   // ssh2 string flags: "r" is read-only; anything else can create/truncate.
   // Treat function flags as write opens (caller only uses r+/w for transfers).
   const isWriteOpen = typeof flags === "function" || String(flags ?? "r") !== "r";
-  const isTruncatingOpen = typeof flags !== "function" && String(flags ?? "r") === "w";
+  const isTruncatingOpenNow = () => String(resolveFlags() ?? "r") === "w";
   const trackSharedWriteDrain = !disposeChannel && isWriteOpen;
   // Path-gate EVERY write open (shared and isolated, "w" and "r+"). An isolated
   // recovery OPEN must still wait for a stale shared truncating OPEN on the same
@@ -2124,10 +2125,6 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
   const pathGate = isWriteOpen
     ? beginTruncatingSharedWriteOpen(filePath, sharedWriteOpenSessionKey(sftp, transfer))
     : null;
-  // Late truncating OPEN after settle (cancel or channel-error force-complete)
-  // must unlink generated stages so cleanup cannot leave a recreate orphan.
-  // In-place finals never unlink.
-  const shouldUnlinkLateGeneratedStage = generatedStagePath && isTruncatingOpen;
   // Re-check ownership at unlink time: a same-id retry may already own
   // activeTransfers. Only suppress unlink when the retry's *actual* staged
   // remote path matches this OPEN path. Do not infer ownership from
@@ -2136,8 +2133,9 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
   // destinations), and a stale late OPEN on a leftover .part must still unlink.
   // Compare in the same representation: OPEN filePath may be a session-encoded
   // Buffer while stagedRemote.path is the logical string.
+  // Truncating is re-resolved so getter flags that collapse to "w" still unlink.
   const canUnlinkLateGeneratedStageNow = () => {
-    if (!shouldUnlinkLateGeneratedStage) return false;
+    if (!generatedStagePath || !isTruncatingOpenNow()) return false;
     const transferId = transfer?.transferId;
     if (transferId == null || transferId === "") return true;
     const active = activeTransfers.get(transferId);
@@ -2151,33 +2149,45 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
   };
 
   /**
-   * When a late truncating OPEN lands after a same-id retry already opened the
-   * same stage, the server may have wiped retry bytes. Fail the live attempt
-   * rather than allow a sparse promote (Codex P1 on 42a27ef7).
+   * When a late truncating OPEN lands after another attempt already opened the
+   * same stage/in-place path, the server may have wiped those bytes. Fail the
+   * live attempt rather than allow a sparse promote (Codex P1 on 42a27ef7 /
+   * cross-id same-path P1 on 2165).
    */
   const invalidateRetryStageIfStaleOpen = () => {
     // Truncating OPEN on either a generated stage or an in-place final can wipe
-    // a same-id retry that already accepted its own OPEN (Codex P1 on 709b27a1).
-    if (!isTruncatingOpen) return;
-    const transferId = transfer?.transferId;
-    if (transferId == null || transferId === "") return;
-    const active = activeTransfers.get(transferId);
-    if (!active || active === transfer) return;
-    const matchesStage = remoteOpenPathMatchesStaged(filePath, active.stagedRemote);
-    const matchesInPlace = !active.stagedRemote && (
-      remoteOpenPathMatchesStaged(filePath, {
-        path: active.targetPath,
-        sftpId: active.targetSftpId,
-        encoding: active.targetEncoding,
-      })
-      || String(filePath ?? "") === String(active.targetPath ?? "")
-    );
-    if (!matchesStage && !matchesInPlace) return;
-    // Only abort once the retry has accepted its own OPEN; otherwise the path
-    // gate is about to let the retry open cleanly after this late callback.
-    if (active.sharedWriteOpenAccepted !== true) return;
-    active.staleOpenTruncatedStage = true;
-    try { active.abort?.(); } catch { /* ignore */ }
+    // a concurrent same-path writer — same-id retry or a new transferId.
+    if (!isTruncatingOpenNow()) return;
+    const openHost = transfer?.targetHostId || transfer?.hostId || transfer?.sourceHostId;
+    for (const active of activeTransfers.values()) {
+      if (!active || active === transfer) continue;
+      const matchesStage = remoteOpenPathMatchesStaged(filePath, active.stagedRemote);
+      const matchesInPlace = !active.stagedRemote && (
+        remoteOpenPathMatchesStaged(filePath, {
+          path: active.targetPath,
+          sftpId: active.targetSftpId,
+          encoding: active.targetEncoding,
+        })
+        || String(filePath ?? "") === String(active.targetPath ?? "")
+      );
+      if (!matchesStage && !matchesInPlace) continue;
+      const activeHost = active.targetHostId || active.hostId || active.sourceHostId;
+      if (
+        openHost != null && String(openHost).length > 0
+        && activeHost != null && String(activeHost).length > 0
+        && String(openHost) !== String(activeHost)
+      ) {
+        continue;
+      }
+      active.staleOpenTruncatedStage = true;
+      // Not yet accepted OPEN: shrink checkpoint so afterPathGate / r+ restart
+      // from zero instead of writing a sparse prefix into a wiped stage.
+      if (active.sharedWriteOpenAccepted !== true) {
+        try { active.checkpointBytes = 0; } catch { /* ignore */ }
+        continue;
+      }
+      try { active.abort?.(); } catch { /* ignore */ }
+    }
   };
 
   let resolveSharedWriteDrain = null;
@@ -2218,8 +2228,8 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     // timeout). Force-complete the drain so cleanup/lease cannot hang, but
     // NEVER release the path gate here: a still-in-flight truncating OPEN can
     // land later and wipe a same-path retry that already wrote (Codex P1 on
-    // a0b2ce01). Gate is only released from the OPEN callback paths
-    // (success, error, late finishLateSharedWriteOpen).
+    // a0b2ce01 / late-unlink-retry). Gate is only released from the OPEN
+    // callback paths (success, error, late finishLateSharedWriteOpen).
     const armSharedWriteDrainForceComplete = () => {
       if (!trackSharedWriteDrain || !resolveSharedWriteDrain || drainForceTimer) return;
       drainForceTimer = setTimeout(() => {
@@ -2231,14 +2241,9 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       }, 2000);
     };
 
-    // Best-effort remote unlink with a hard bound. A dead shared channel that
-    // never invokes the unlink callback must not pin finishCancel / drain
-    // settle forever (lease + admission slot hang). Same 2s grace as the
-    // shared-write drain force-complete.
-    // Unlink without a local timeout so the path gate stays held until the
-    // server callback (or sync throw). A 2s force-resolve let retries write a
-    // deterministic stage while a delayed unlink could still delete it
-    // (Codex P2 on 0ee64386).
+    // Best-effort remote unlink. A dead shared channel that never invokes the
+    // unlink callback is bounded by boundUnlinkThen so finishCancel / gate
+    // release cannot hang the transfer or same-path waiters (Codex P2 hang).
     const unlinkSharedWritePathBestEffort = () => new Promise((resolveUnlink) => {
       let settledUnlink = false;
       const finishUnlink = () => {
@@ -2262,6 +2267,20 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       }
     });
 
+    /** Unlink with 2s bound so a dead channel cannot pin settle/gate forever. */
+    const boundUnlinkThen = (thenFn) => {
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        thenFn();
+      };
+      const timer = setTimeout(finish, 2000);
+      unlinkSharedWritePathBestEffort().then(
+        () => { clearTimeout(timer); finish(); },
+        () => { clearTimeout(timer); finish(); },
+      );
+    };
 
     /** Close with 2s bound so a dead channel cannot pin the path gate. */
     const boundCloseSftpHandle = (handle, thenFn) => {
@@ -2284,8 +2303,8 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     // (Codex P2 on 0cda4a39 / cd57d960 / bd42c51c). Never unlink in-place
     // final targets (Codex P1 on a9f748c8). Skip unlink only when a same-id
     // retry owns a reusable resume stage at this path (Codex P2 on d19ecb88).
-    // Bound close so a dead channel that never invokes CLOSE cannot pin the
-    // path gate forever after drain force-complete (Codex P2 on 1a8cac20).
+    // Bound close/unlink so a dead channel cannot pin the path gate forever
+    // after drain force-complete (Codex P2 on 1a8cac20).
     const finishLateSharedWriteOpen = (handle) => {
       invalidateRetryStageIfStaleOpen();
       const afterClose = () => {
@@ -2294,7 +2313,7 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
           releasePathGate();
         };
         if (canUnlinkLateGeneratedStageNow()) {
-          unlinkSharedWritePathBestEffort().then(finish, finish);
+          boundUnlinkThen(finish);
           return;
         }
         finish();
@@ -2423,10 +2442,10 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
             // already raced. In-place finals are close-only. Same-id retries
             // that re-own activeTransfers skip unlink (resume stage reuse).
             if (canUnlinkLateGeneratedStageNow()) {
-              // Bound close so a dead channel cannot pin the path gate forever
-              // when cancel wins before settle (Codex P2 on e6dfdc9e).
+              // Bound close + unlink so a dead channel cannot pin settle/gate
+              // when cancel wins before settle (Codex P2 on e6dfdc9e / hang).
               boundCloseSftpHandle(handle, () => {
-                unlinkSharedWritePathBestEffort().then(finishCancel, finishCancel);
+                boundUnlinkThen(finishCancel);
               });
               return;
             }
@@ -3401,8 +3420,18 @@ async function uploadFileConcurrent(
         abortChannel,
         generatedStagePath,
         afterPathGate: async () => {
+          // A late stale OPEN may have zeroed the stage while we waited; force
+          // a full rewrite rather than sparse r+ from an obsolete offset.
+          if (transfer.staleOpenTruncatedStage) {
+            checkpoint = 0;
+            transfer.checkpointBytes = 0;
+            try {
+              sendProgress(0, fileSize, { force: true, checkpointBytes: 0 });
+            } catch { /* best-effort */ }
+            return;
+          }
           // Re-read durable stage size after waiting; a prior OPEN "w" may have
-          // truncated the file while we were queued (Codex P2).
+          // truncated the file while we were queued (Codex P2 / P1 on 2178).
           if (checkpoint <= 0 || !transfer.stagedRemote) return;
           try {
             const staged = transfer.stagedRemote;

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2203,22 +2203,19 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     };
 
     // OPEN wait may settle without a callback (channel error, or cancel settle
-    // timeout). Keep drain pending for a late truncating OPEN, but force-
-    // complete if the callback never arrives so cleanup/lease cannot hang.
-    // Also release the path gate so a dead channel cannot pin same-path retries
-    // forever. A still-late OPEN callback then closes and, if a retry already
-    // accepted its own OPEN on this path, invalidates that retry (Codex P1).
+    // timeout). Force-complete the drain so cleanup/lease cannot hang, but
+    // NEVER release the path gate here: a still-in-flight truncating OPEN can
+    // land later and wipe a same-path retry that already wrote (Codex P1 on
+    // a0b2ce01). Gate is only released from the OPEN callback paths
+    // (success, error, late finishLateSharedWriteOpen).
     const armSharedWriteDrainForceComplete = () => {
       if (!trackSharedWriteDrain || !resolveSharedWriteDrain || drainForceTimer) return;
       drainForceTimer = setTimeout(() => {
         drainForceTimer = null;
-        // Free the transfer/lease, but keep the path gate held until the OPEN
-        // callback settles (late path releases it). Releasing here lets a
-        // same-id retry OPEN the stage while the stale OPEN is still pending
-        // (Codex P1 on 9d87df6c). If the callback never arrives, free after a
-        // long grace so a dead channel cannot pin same-path uploads forever.
+        // Free the transfer/lease only. Path gate stays held until the OPEN
+        // callback actually settles (or never, if the channel is dead — safer
+        // than reusing a path that a stale truncating OPEN can still wipe).
         completeSharedWriteDrain();
-        setTimeout(() => releasePathGate(), 30000);
       }, 2000);
     };
 

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2145,6 +2145,15 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       }
       return true;
     }
+    // Same transfer moved to another strategy (e.g. fastPut after concurrent
+    // OPEN channel-error) still owns the stage — do not unlink the file that
+    // the fallback just wrote (Codex P2 on 98b26f31).
+    if (active === transfer) {
+      if (active.sharedWriteOpenAccepted === true) return false;
+      if (remoteOpenPathMatchesStaged(filePath, active.stagedRemote)) return false;
+      const strategy = String(active.uploadStrategy || active.strategy || "");
+      if (/fastput|stream/i.test(strategy)) return false;
+    }
     return true;
   };
 

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -5261,6 +5261,12 @@ async function startTransferNow(event, payload, onProgress) {
       }
       sendError(err);
     }
+    // Superseded attempts lost ownership to a same-id retry. Do not return
+    // result.error — renderer directory ops treat any error as task failure
+    // and would mark the live retry failed (Codex P2 on f4a92074).
+    if (/superseded/i.test(err?.message || String(err))) {
+      return { transferId, superseded: true };
+    }
     return { transferId, error: err.message };
   }
 }

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -358,6 +358,13 @@ function sharedWriteOpenPathKey(filePath) {
  * @param {object | null | undefined} transfer
  */
 function sharedWriteOpenSessionKey(sftp, transfer) {
+  // Prefer host identity so an isolated-channel retry still waits for a stale
+  // shared OPEN on the same host path (Codex P1 on 294b7a4b). Fall back to
+  // sftp/session ids when host is unknown.
+  const hostKey = transfer?.targetHostId || transfer?.hostId || transfer?.sourceHostId;
+  if (hostKey != null && String(hostKey).length > 0) {
+    return `host:${String(hostKey)}`;
+  }
   const fromTransfer = transfer?.targetSftpId
     || transfer?.sourceSftpId
     || transfer?.sftpId

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2529,10 +2529,49 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     const startOpen = () => {
       if (!waiting) return;
       waiting = false;
+      // Keep cancel + channel-error wiring active through afterPathGate. A hung
+      // post-gate stage stat must still yield to cancel/channel death so the
+      // path gate and lease are not pinned forever (Codex P2 on f642580d).
+      let afterGateDone = false;
+      const releaseGateAndDrain = () => {
+        pathGate.release();
+        if (resolveSharedWriteDrain) {
+          const resolveDrain = resolveSharedWriteDrain;
+          resolveSharedWriteDrain = null;
+          resolveDrain();
+        }
+      };
+      const onChannelErrorDuringAfterGate = (error) => {
+        const err = error instanceof Error
+          ? error
+          : new Error(String(error?.message || error || "SFTP channel error"));
+        failAfterGate(err);
+      };
+      const detachAfterGateHooks = () => {
+        detachChannelErrorWhileWaiting();
+        try { sftp.removeListener?.("error", onChannelErrorDuringAfterGate); } catch { /* ignore */ }
+        if (transfer.abort === abortDuringAfterGate) {
+          transfer.abort = previousAbort;
+        }
+      };
+      const failAfterGate = (error) => {
+        if (afterGateDone) return;
+        afterGateDone = true;
+        detachAfterGateHooks();
+        releaseGateAndDrain();
+        reject(error instanceof Error ? error : new Error(String(error?.message || error)));
+      };
+      const abortDuringAfterGate = () => {
+        try { previousAbort?.(); } catch { /* ignore */ }
+        transfer.cancelled = true;
+        failAfterGate(new Error("Transfer cancelled"));
+      };
+
+      // Swap gate-wait channel listener for the after-gate one; keep cancel live.
       detachChannelErrorWhileWaiting();
-      if (transfer.abort === wrappedAbort) {
-        transfer.abort = previousAbort;
-      }
+      transfer.abort = abortDuringAfterGate;
+      try { sftp.on?.("error", onChannelErrorDuringAfterGate); } catch { /* ignore */ }
+
       // After waiting on a prior OPEN, re-validate resume checkpoints so a
       // truncating OPEN that landed while we waited cannot leave us writing
       // past a wiped stage (Codex P2 on 294b7a4b).
@@ -2540,26 +2579,17 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
         ? Promise.resolve().then(() => options.afterPathGate())
         : Promise.resolve();
       afterGate.then(() => {
+        if (afterGateDone) return;
         if (transfer.cancelled) {
-          // Prior has resolved (or never existed); safe to release our gate now.
-          pathGate.release();
-          if (resolveSharedWriteDrain) {
-            const resolveDrain = resolveSharedWriteDrain;
-            resolveSharedWriteDrain = null;
-            resolveDrain();
-          }
-          reject(new Error("Transfer cancelled"));
+          failAfterGate(new Error("Transfer cancelled"));
           return;
         }
+        afterGateDone = true;
+        // Hand off to runOpen: drop after-gate hooks so OPEN owns abort/error.
+        detachAfterGateHooks();
         runOpen().then(resolve, reject);
       }, (err) => {
-        pathGate.release();
-        if (resolveSharedWriteDrain) {
-          const resolveDrain = resolveSharedWriteDrain;
-          resolveSharedWriteDrain = null;
-          resolveDrain();
-        }
-        reject(err instanceof Error ? err : new Error(String(err?.message || err)));
+        failAfterGate(err);
       });
     };
 

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2362,11 +2362,16 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
         }
         // Ownership moved to a same-id retry before this OPEN applied: treat as
         // late so we never hand the stale truncating handle to the old attempt.
+        // Mark noTransferFallback so uploadFile does not run
+        // prepareUploadFallbackCheckpoint and truncate the retry's shared stage
+        // (Codex P1 on 6834bed1).
         const activeOwner = transfer?.transferId != null
           ? activeTransfers.get(transfer.transferId)
           : null;
         if (activeOwner && activeOwner !== transfer) {
-          settle(reject, new Error("Transfer superseded"));
+          const supersededErr = new Error("Transfer superseded");
+          supersededErr.noTransferFallback = true;
+          settle(reject, supersededErr);
           if (handle && !disposeChannel) {
             finishLateSharedWriteOpen(handle);
             return;

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2107,9 +2107,10 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
   const isWriteOpen = String(flags ?? "r") !== "r";
   const isTruncatingOpen = String(flags ?? "r") === "w";
   const trackSharedWriteDrain = !disposeChannel && isWriteOpen;
-  // Path gate only for truncating shared writes — non-truncating "r+" resume
-  // opens do not wipe peer bytes if ordered loosely.
-  const pathGate = trackSharedWriteDrain && isTruncatingOpen
+  // Path-gate all shared writes (including "r+" resume). A pending truncating
+  // OPEN "w" can still zero the stage after an "r+" retry has started writing
+  // (Codex P1 on 30308203).
+  const pathGate = trackSharedWriteDrain
     ? beginTruncatingSharedWriteOpen(filePath, sharedWriteOpenSessionKey(sftp, transfer))
     : null;
   // Late truncating OPEN after settle (cancel or channel-error force-complete)
@@ -4559,8 +4560,18 @@ async function startTransferNow(event, payload, onProgress) {
     // Superseded always means this attempt lost ownership. Suppress terminal
     // events even after the retry has finished and left activeTransfers, or
     // the completed retry is rewritten as cancelled (Codex P2 on 52f0248c).
-    // Do not release SFTP leases — a live same-id retry may still hold them.
+    // Release only leases the live same-id retry did not also acquire (Codex P2).
     if (superseded) {
+      const liveOwner = activeTransfers.get(transferId);
+      const liveLeaseIds = new Set(
+        Array.isArray(liveOwner?.leasedSftpIds) ? liveOwner.leasedSftpIds : [],
+      );
+      const oldLeaseIds = (transfer.leasedSftpIds || leasedSftpIds || []).filter(
+        (id) => id != null && !liveLeaseIds.has(id),
+      );
+      if (oldLeaseIds.length > 0) {
+        releaseTransferSessionLeases(transferId, oldLeaseIds);
+      }
       cleanupTransfer({ releaseLeases: false });
       return;
     }

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -4527,13 +4527,18 @@ async function startTransferNow(event, payload, onProgress) {
   };
 
   const sendError = (error) => {
-    cleanupTransfer();
     const message = error?.message || String(error);
-    // Same-id retries supersede the previous attempt's late OPEN path. Worker
-    // fan-out maps transfer:error as cancelled only for /cancel/ messages; emit
-    // cancelled channel for superseded so the live retry is not marked failed
-    // (Codex P2 on d777a66a).
-    const cancelled = /cancel/i.test(message) || /superseded/i.test(message);
+    const superseded = /superseded/i.test(message);
+    // If a same-id retry already owns activeTransfers, this is a stale attempt.
+    // Do not emit terminal cancelled/failed for that transferId or the live
+    // retry is stuck cancelled in the transfer center (Codex P2 on dbfb411a).
+    const liveOwner = activeTransfers.get(transferId);
+    const isStaleSuperseded = superseded && liveOwner && liveOwner !== transfer;
+    cleanupTransfer();
+    if (isStaleSuperseded) {
+      return;
+    }
+    const cancelled = /cancel/i.test(message) || superseded;
     if (cancelled) {
       sender.send("netcatty:transfer:cancelled", { transferId, error: message });
       broadcastGlobalTransferEvent({

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2219,16 +2219,9 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     const previousAbort = transfer.abort;
     let pathGateReleased = false;
 
-    let pathGateForceTimer = null;
-    const clearPathGateForceTimer = () => {
-      if (!pathGateForceTimer) return;
-      clearTimeout(pathGateForceTimer);
-      pathGateForceTimer = null;
-    };
     const releasePathGate = () => {
       if (!pathGate || pathGateReleased) return;
       pathGateReleased = true;
-      clearPathGateForceTimer();
       pathGate.release();
     };
 
@@ -2265,16 +2258,6 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       }, 2000);
     };
 
-    // Isolated write OPEN: after sftp.end() the OPEN callback may never fire.
-    // Force-release the path gate so same-path retries are not stuck forever,
-    // while late callbacks still run finishLateSharedWriteOpen (Codex P1).
-    const armPathGateForceRelease = () => {
-      if (!pathGate || pathGateReleased || pathGateForceTimer) return;
-      pathGateForceTimer = setTimeout(() => {
-        pathGateForceTimer = null;
-        releasePathGate();
-      }, 2000);
-    };
 
     // Best-effort remote unlink. A dead shared channel that never invokes the
     // unlink callback is bounded by boundUnlinkThen so finishCancel / gate
@@ -2389,10 +2372,11 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
             settle(reject, new Error("Transfer cancelled"));
             if (trackSharedWriteDrain) {
               armSharedWriteDrainForceComplete();
-            } else {
-              // Isolated: sftp.end() was requested; OPEN may never return.
-              armPathGateForceRelease();
             }
+            // Isolated write: keep path gate until OPEN callback too. Force-
+            // releasing after sftp.end() lets a same-path retry finish, then a
+            // late truncating OPEN can wipe its destination with no live
+            // activeTransfers entry to invalidate (Codex P1 on c30e1734).
           }, 2000);
         }
         return;
@@ -2412,7 +2396,7 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       if (trackSharedWriteDrain) {
         armSharedWriteDrainForceComplete();
       } else if (isWriteOpen) {
-        armPathGateForceRelease();
+        // Isolated write: hold path gate until OPEN callback (same as cancel).
       } else {
         completeSharedWriteDrain();
         releasePathGate();

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2212,12 +2212,13 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       if (!trackSharedWriteDrain || !resolveSharedWriteDrain || drainForceTimer) return;
       drainForceTimer = setTimeout(() => {
         drainForceTimer = null;
-        // Free the transfer/lease. Also release the path gate so later same-path
-        // uploads are not stuck forever when the OPEN callback never arrives
-        // (dead shared channel). Late OPEN still invalidates an accepted retry
-        // via staleOpenTruncatedStage (Codex P2 on f45f6a77).
+        // Free the transfer/lease, but keep the path gate held until the OPEN
+        // callback settles (late path releases it). Releasing here lets a
+        // same-id retry OPEN the stage while the stale OPEN is still pending
+        // (Codex P1 on 9d87df6c). If the callback never arrives, free after a
+        // long grace so a dead channel cannot pin same-path uploads forever.
         completeSharedWriteDrain();
-        releasePathGate();
+        setTimeout(() => releasePathGate(), 30000);
       }, 2000);
     };
 

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -3423,6 +3423,12 @@ async function uploadFileConcurrent(
     }
     try { sftp.removeListener?.("error", onChannelError); } catch { /* ignore */ }
     if (remoteCloseError) throw remoteCloseError;
+    // After the drain barrier, a late stale OPEN may have zeroed the stage while
+    // this attempt already finished writing. Fail closed so promotion cannot
+    // rename a corrupt stage (Codex P1 on 2898c4c0).
+    if (!failed && !transfer.cancelled && transfer.staleOpenTruncatedStage) {
+      throw new Error("Remote stage truncated by stale OPEN");
+    }
   }
 }
 
@@ -4606,6 +4612,12 @@ async function startTransferNow(event, payload, onProgress) {
         signal: transfer.signal,
         assertCanPromote() {
           if (isTransferCancelled(transfer)) throw new Error("Transfer cancelled");
+          // Late force-completed OPEN "w" from a prior same-id attempt can
+          // truncate the stage after concurrent write finished; do not rename
+          // a zeroed/corrupt stage to the final path (Codex P1 on 2898c4c0).
+          if (transfer.staleOpenTruncatedStage) {
+            throw new Error("Remote stage truncated by stale OPEN");
+          }
         },
         commitPromotion() {
           transfer.completionCommitted = true;
@@ -5030,6 +5042,9 @@ async function startTransferNow(event, payload, onProgress) {
           signal: transfer.signal,
           assertCanPromote() {
             if (isTransferCancelled(transfer)) throw new Error("Transfer cancelled");
+            if (transfer.staleOpenTruncatedStage) {
+              throw new Error("Remote stage truncated by stale OPEN");
+            }
           },
           commitPromotion() {
             transfer.completionCommitted = true;

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2212,12 +2212,11 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       if (!trackSharedWriteDrain || !resolveSharedWriteDrain || drainForceTimer) return;
       drainForceTimer = setTimeout(() => {
         drainForceTimer = null;
+        // Free the transfer/lease, but keep the path gate held until the OPEN
+        // callback actually settles. A hard timeout would let a different
+        // transferId reopen the same target while the stale OPEN is still
+        // pending and can still truncate it (Codex P1 on 7f1f3c00).
         completeSharedWriteDrain();
-        // Keep the path gate held until a late OPEN callback settles (or a 10s
-        // hard cap). Releasing immediately — even for in-place finals — lets a
-        // same-id retry open/write the same target while the old OPEN "w" is
-        // still pending and can still truncate it (Codex P1 on 709b27a1).
-        setTimeout(() => releasePathGate(), 10000);
       }, 2000);
     };
 

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2212,11 +2212,12 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       if (!trackSharedWriteDrain || !resolveSharedWriteDrain || drainForceTimer) return;
       drainForceTimer = setTimeout(() => {
         drainForceTimer = null;
-        // Free the transfer/lease, but keep the path gate held until the OPEN
-        // callback actually settles. A hard timeout would let a different
-        // transferId reopen the same target while the stale OPEN is still
-        // pending and can still truncate it (Codex P1 on 7f1f3c00).
+        // Free the transfer/lease. Also release the path gate so later same-path
+        // uploads are not stuck forever when the OPEN callback never arrives
+        // (dead shared channel). Late OPEN still invalidates an accepted retry
+        // via staleOpenTruncatedStage (Codex P2 on f45f6a77).
         completeSharedWriteDrain();
+        releasePathGate();
       }, 2000);
     };
 

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -1933,9 +1933,10 @@ async function uploadFile(
  * Shared write opens ("w" / "r+" / …) publish transfer.sharedWriteOpenDrain and
  * keep it pending until the OPEN callback finishes (including late opens after
  * a cancel settle timeout), so upload cleanup awaits the drain before deleting
- * the remote stage. Channel-error / cancel-settle paths that never receive an
- * OPEN callback arm a short drain force-complete so a dead channel cannot hold
- * the transfer and SFTP lease forever.
+ * the remote stage. Channel-error paths that never receive an OPEN callback arm
+ * a short drain force-complete so a dead channel cannot hold the transfer and
+ * SFTP lease forever. Cancel keeps the drain gated on the OPEN callback — a
+ * healthy shared channel may still deliver a late truncating OPEN.
  *
  * @param {{ disposeChannel?: boolean, abortChannel?: (() => void) | null }} [options]
  */
@@ -1974,9 +1975,10 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       resolveDrain();
     };
 
-    // When OPEN wait settles without an OPEN callback (channel error, or cancel
-    // settle timeout), keep drain pending for a late truncating OPEN — but force
-    // complete if the callback never arrives so cleanup/lease cannot hang.
+    // Channel error may never invoke the OPEN callback. Keep drain pending for
+    // a late truncating OPEN, but force-complete if the callback never arrives
+    // so cleanup/lease cannot hang. Cancel must NOT arm this — a healthy shared
+    // channel can still deliver a late OPEN after the settle timeout.
     const armSharedWriteDrainForceComplete = () => {
       if (!trackSharedWriteDrain || !resolveSharedWriteDrain || drainForceTimer) return;
       drainForceTimer = setTimeout(() => {
@@ -2003,14 +2005,12 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       transfer.cancelled = true;
       // Shared write OPEN can truncate/create the remote path. A settle timeout
       // unblocks the transfer UX, but sharedWriteOpenDrain stays pending until
-      // the OPEN callback finishes (or the drain force-complete) so cleanup
-      // cannot race a late truncating OPEN.
+      // the OPEN callback finishes so cleanup cannot race a late truncating OPEN.
       if (!disposeChannel && isWriteOpen && !settled) {
         try { abortChannel?.(); } catch { /* ignore */ }
         if (!openDrainTimer) {
           openDrainTimer = setTimeout(() => {
             settle(reject, new Error("Transfer cancelled"));
-            armSharedWriteDrainForceComplete();
           }, 2000);
         }
         return;
@@ -2993,9 +2993,9 @@ async function uploadFileConcurrent(
     // Shared write OPEN may still be in flight after a cancel settle timeout or
     // channel error. Await the drain barrier before returning so
     // runRemoteUploadTransaction cannot clean up the stage before a late
-    // truncating OPEN finishes (Codex P2 on 747847e7). openSftpHandleForTransfer
-    // force-completes the drain if the OPEN callback never arrives on a dead
-    // channel, so this await cannot hang forever.
+    // truncating OPEN finishes (Codex P2 on 747847e7). On channel error,
+    // openSftpHandleForTransfer force-completes the drain if the OPEN callback
+    // never arrives; cancel keeps the drain gated on the callback.
     const sharedWriteOpenDrain = transfer.sharedWriteOpenDrain;
     if (sharedWriteOpenDrain) {
       await sharedWriteOpenDrain.catch(() => {});

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2145,12 +2145,11 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       }
       return true;
     }
-    // Same transfer moved to another strategy (e.g. fastPut after concurrent
+    // Same transfer moved to a non-gated strategy (e.g. fastPut after concurrent
     // OPEN channel-error) still owns the stage — do not unlink the file that
-    // the fallback just wrote (Codex P2 on 98b26f31).
+    // the fallback just wrote (Codex P2 on 98b26f31). Only strategy-move counts:
+    // ordinary cancel still has stagedRemote set and must unlink (Codex P1).
     if (active === transfer) {
-      if (active.sharedWriteOpenAccepted === true) return false;
-      if (remoteOpenPathMatchesStaged(filePath, active.stagedRemote)) return false;
       const strategy = String(active.uploadStrategy || active.strategy || "");
       if (/fastput|stream/i.test(strategy)) return false;
     }

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -5430,6 +5430,13 @@ async function startTransferNow(event, payload, onProgress) {
         transfer.stagedRemote = null;
       }
     }
+    // Superseded before cancelled: a cancelled attempt can still lose ownership
+    // to a same-id retry while OPEN is pending. Treat as superseded so we do not
+    // delete the retry stage, release its leases, or emit cancelled (Codex P2).
+    if (/superseded/i.test(err?.message || String(err))) {
+      sendError(err);
+      return { transferId, superseded: true };
+    }
     if (!err?.recoveryFailed && (transfer.cancelled || err.message === 'Transfer cancelled')) {
       if (transfer.stagedLocalPath) {
         try { await fs.promises.unlink(transfer.stagedLocalPath); } catch { }
@@ -5453,12 +5460,6 @@ async function startTransferNow(event, payload, onProgress) {
         transfer.stagedLocalPath = null;
       }
       sendError(err);
-    }
-    // Superseded attempts lost ownership to a same-id retry. Do not return
-    // result.error — renderer directory ops treat any error as task failure
-    // and would mark the live retry failed (Codex P2 on f4a92074).
-    if (/superseded/i.test(err?.message || String(err))) {
-      return { transferId, superseded: true };
     }
     return { transferId, error: err.message };
   }

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2223,18 +2223,17 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     // never invokes the unlink callback must not pin finishCancel / drain
     // settle forever (lease + admission slot hang). Same 2s grace as the
     // shared-write drain force-complete.
+    // Unlink without a local timeout so the path gate stays held until the
+    // server callback (or sync throw). A 2s force-resolve let retries write a
+    // deterministic stage while a delayed unlink could still delete it
+    // (Codex P2 on 0ee64386).
     const unlinkSharedWritePathBestEffort = () => new Promise((resolveUnlink) => {
       let settledUnlink = false;
       const finishUnlink = () => {
         if (settledUnlink) return;
         settledUnlink = true;
-        if (unlinkTimer) {
-          clearTimeout(unlinkTimer);
-          unlinkTimer = null;
-        }
         resolveUnlink();
       };
-      let unlinkTimer = setTimeout(finishUnlink, 2000);
       // Ownership can change between close and unlink (retry start).
       if (!canUnlinkLateGeneratedStageNow()) {
         finishUnlink();

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -3422,7 +3422,11 @@ async function uploadFileConcurrent(
         afterPathGate: async () => {
           // A late stale OPEN may have zeroed the stage while we waited; force
           // a full rewrite rather than sparse r+ from an obsolete offset.
+          // Consume the flag here: a gated restart from zero is the recovery
+          // path. Leaving it set makes the post-upload guard fail a successful
+          // full rewrite (Codex P2 on 81979ebb).
           if (transfer.staleOpenTruncatedStage) {
+            transfer.staleOpenTruncatedStage = false;
             checkpoint = 0;
             transfer.checkpointBytes = 0;
             try {

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2373,7 +2373,61 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
 
   if (!pathGate) return runOpen();
   // Wait for any prior truncating OPEN on this path before issuing ours.
-  return pathGate.waitForPrior.then(runOpen, runOpen);
+  // The wait must be cancelable: a cancelled transfer must release its gate
+  // entry and settle drain without waiting forever on a stuck prior OPEN
+  // (lease/admission hang + blocking later same-path attempts).
+  return new Promise((resolve, reject) => {
+    let waiting = true;
+    const previousAbort = transfer.abort;
+
+    const abandonGateWait = (error) => {
+      if (!waiting) return;
+      waiting = false;
+      if (transfer.abort === wrappedAbort) {
+        transfer.abort = previousAbort;
+      }
+      pathGate.release();
+      if (resolveSharedWriteDrain) {
+        const resolveDrain = resolveSharedWriteDrain;
+        resolveSharedWriteDrain = null;
+        resolveDrain();
+      }
+      reject(error);
+    };
+
+    const wrappedAbort = () => {
+      try { previousAbort?.(); } catch { /* ignore */ }
+      transfer.cancelled = true;
+      abandonGateWait(new Error("Transfer cancelled"));
+    };
+    transfer.abort = wrappedAbort;
+
+    if (transfer.cancelled) {
+      abandonGateWait(new Error("Transfer cancelled"));
+      return;
+    }
+
+    const startOpen = () => {
+      if (!waiting) return;
+      waiting = false;
+      if (transfer.abort === wrappedAbort) {
+        transfer.abort = previousAbort;
+      }
+      if (transfer.cancelled) {
+        pathGate.release();
+        if (resolveSharedWriteDrain) {
+          const resolveDrain = resolveSharedWriteDrain;
+          resolveSharedWriteDrain = null;
+          resolveDrain();
+        }
+        reject(new Error("Transfer cancelled"));
+        return;
+      }
+      runOpen().then(resolve, reject);
+    };
+
+    pathGate.waitForPrior.then(startOpen, startOpen);
+  });
 }
 
 function closeSftpHandle(sftp, handle) {

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -1956,7 +1956,10 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
   const isWriteOpen = String(flags ?? "r") !== "r";
   const isTruncatingOpen = String(flags ?? "r") === "w";
   const trackSharedWriteDrain = !disposeChannel && isWriteOpen;
-  const shouldUnlinkOnCancelOpen = generatedStagePath && isTruncatingOpen;
+  // Late truncating OPEN after settle (cancel or channel-error force-complete)
+  // must unlink generated stages so cleanup cannot leave a recreate orphan.
+  // In-place finals never unlink.
+  const shouldUnlinkLateGeneratedStage = generatedStagePath && isTruncatingOpen;
   let resolveSharedWriteDrain = null;
   if (trackSharedWriteDrain) {
     transfer.sharedWriteOpenDrain = new Promise((resolve) => {
@@ -2007,14 +2010,15 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       }
     });
 
-    // Late shared write OPEN after settle: close handle, and on cancel +
-    // generated truncating stage also unlink so a force-completed drain /
-    // stage delete cannot leave a recreate orphan (Codex P2 on 0cda4a39 /
-    // cd57d960). Never unlink in-place final targets (Codex P1 on a9f748c8).
+    // Late shared write OPEN after settle: close handle, and for generated
+    // truncating stages also unlink so a force-completed drain / stage delete
+    // cannot leave a recreate orphan after cancel OR channel-error settle
+    // (Codex P2 on 0cda4a39 / cd57d960 / bd42c51c). Never unlink in-place
+    // final targets (Codex P1 on a9f748c8).
     const finishLateSharedWriteOpen = (handle) => {
       const afterClose = () => {
         const finish = () => completeSharedWriteDrain();
-        if (transfer.cancelled && shouldUnlinkOnCancelOpen) {
+        if (shouldUnlinkLateGeneratedStage) {
           unlinkSharedWritePathBestEffort().then(finish, finish);
           return;
         }
@@ -2113,7 +2117,7 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
             // truncating OPEN handle is released. Cancel + generated stage
             // "w": unlink too so a staged recreate cannot survive if cleanup
             // already raced. In-place finals are close-only.
-            if (shouldUnlinkOnCancelOpen) {
+            if (shouldUnlinkLateGeneratedStage) {
               closeSftpHandle(sftp, handle)
                 .catch(() => {})
                 .then(() => unlinkSharedWritePathBestEffort())

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -1933,10 +1933,11 @@ async function uploadFile(
  * Shared write opens ("w" / "r+" / …) publish transfer.sharedWriteOpenDrain and
  * keep it pending until the OPEN callback finishes (including late opens after
  * a cancel settle timeout), so upload cleanup awaits the drain before deleting
- * the remote stage. Channel-error paths that never receive an OPEN callback arm
- * a short drain force-complete so a dead channel cannot hold the transfer and
- * SFTP lease forever. Cancel keeps the drain gated on the OPEN callback — a
- * healthy shared channel may still deliver a late truncating OPEN.
+ * the remote stage. Channel-error and cancel-settle paths that never receive an
+ * OPEN callback arm a short drain force-complete so a dead/stalled channel
+ * cannot hold the transfer and SFTP lease forever. A late truncating `"w"` OPEN
+ * after cancel still closes the handle and best-effort unlinks the path so
+ * stage cleanup cannot race a recreate/orphan.
  *
  * @param {{ disposeChannel?: boolean, abortChannel?: (() => void) | null }} [options]
  */
@@ -1947,6 +1948,7 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     : null;
   // ssh2 string flags: "r" is read-only; anything else can create/truncate.
   const isWriteOpen = String(flags ?? "r") !== "r";
+  const isTruncatingOpen = String(flags ?? "r") === "w";
   const trackSharedWriteDrain = !disposeChannel && isWriteOpen;
   let resolveSharedWriteDrain = null;
   if (trackSharedWriteDrain) {
@@ -1975,16 +1977,46 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       resolveDrain();
     };
 
-    // Channel error may never invoke the OPEN callback. Keep drain pending for
-    // a late truncating OPEN, but force-complete if the callback never arrives
-    // so cleanup/lease cannot hang. Cancel must NOT arm this — a healthy shared
-    // channel can still deliver a late OPEN after the settle timeout.
+    // OPEN wait may settle without a callback (channel error, or cancel settle
+    // timeout). Keep drain pending for a late truncating OPEN, but force-
+    // complete if the callback never arrives so cleanup/lease cannot hang.
     const armSharedWriteDrainForceComplete = () => {
       if (!trackSharedWriteDrain || !resolveSharedWriteDrain || drainForceTimer) return;
       drainForceTimer = setTimeout(() => {
         drainForceTimer = null;
         completeSharedWriteDrain();
       }, 2000);
+    };
+
+    const unlinkSharedWritePathBestEffort = () => new Promise((resolveUnlink) => {
+      if (typeof sftp.unlink !== "function") {
+        resolveUnlink();
+        return;
+      }
+      try {
+        sftp.unlink(filePath, () => resolveUnlink());
+      } catch {
+        resolveUnlink();
+      }
+    });
+
+    // Late shared write OPEN after settle: close handle, and on cancel +
+    // truncating "w" also unlink so a force-completed drain / stage delete
+    // cannot leave a recreate orphan (Codex P2 on 0cda4a39 / cd57d960).
+    const finishLateSharedWriteOpen = (handle) => {
+      const afterClose = () => {
+        const finish = () => completeSharedWriteDrain();
+        if (transfer.cancelled && isTruncatingOpen) {
+          unlinkSharedWritePathBestEffort().then(finish, finish);
+          return;
+        }
+        finish();
+      };
+      if (handle) {
+        closeSftpHandle(sftp, handle).then(afterClose, afterClose);
+        return;
+      }
+      afterClose();
     };
 
     const settle = (fn, value) => {
@@ -2004,13 +2036,15 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     const abortDuringOpen = () => {
       transfer.cancelled = true;
       // Shared write OPEN can truncate/create the remote path. A settle timeout
-      // unblocks the transfer UX, but sharedWriteOpenDrain stays pending until
-      // the OPEN callback finishes so cleanup cannot race a late truncating OPEN.
+      // unblocks the transfer UX; sharedWriteOpenDrain stays pending until the
+      // OPEN callback finishes (or drain force-complete) so cleanup usually
+      // waits. Late truncating opens still unlink after close if cancel won.
       if (!disposeChannel && isWriteOpen && !settled) {
         try { abortChannel?.(); } catch { /* ignore */ }
         if (!openDrainTimer) {
           openDrainTimer = setTimeout(() => {
             settle(reject, new Error("Transfer cancelled"));
+            armSharedWriteDrainForceComplete();
           }, 2000);
         }
         return;
@@ -2046,13 +2080,10 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       sftp.open(filePath, flags, (error, handle) => {
         if (settled) {
           // Cancel / channel error already settled (possibly via drain timeout).
-          // Still close a late shared handle, then release the drain barrier so
-          // cleanup can run.
+          // Still close a late shared handle; cancel + truncating "w" also
+          // unlinks so a force-completed drain cannot orphan a recreated stage.
           if (!error && handle && !disposeChannel) {
-            closeSftpHandle(sftp, handle).then(
-              completeSharedWriteDrain,
-              completeSharedWriteDrain,
-            );
+            finishLateSharedWriteOpen(handle);
             return;
           }
           completeSharedWriteDrain();
@@ -2070,7 +2101,15 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
           };
           if (handle && !disposeChannel) {
             // Close before settle/drain so shared write cleanup runs after the
-            // truncating OPEN handle is released.
+            // truncating OPEN handle is released. Cancel + "w": unlink too so
+            // a staged recreate cannot survive if cleanup already raced.
+            if (isTruncatingOpen) {
+              closeSftpHandle(sftp, handle)
+                .catch(() => {})
+                .then(() => unlinkSharedWritePathBestEffort())
+                .then(finishCancel, finishCancel);
+              return;
+            }
             closeSftpHandle(sftp, handle).then(finishCancel, finishCancel);
             return;
           }
@@ -2993,9 +3032,10 @@ async function uploadFileConcurrent(
     // Shared write OPEN may still be in flight after a cancel settle timeout or
     // channel error. Await the drain barrier before returning so
     // runRemoteUploadTransaction cannot clean up the stage before a late
-    // truncating OPEN finishes (Codex P2 on 747847e7). On channel error,
-    // openSftpHandleForTransfer force-completes the drain if the OPEN callback
-    // never arrives; cancel keeps the drain gated on the callback.
+    // truncating OPEN finishes (Codex P2 on 747847e7). openSftpHandleForTransfer
+    // force-completes the drain if the OPEN callback never arrives; late cancel
+    // truncating opens also unlink after close so a force-complete cannot
+    // orphan a recreated stage.
     const sharedWriteOpenDrain = transfer.sharedWriteOpenDrain;
     if (sharedWriteOpenDrain) {
       await sharedWriteOpenDrain.catch(() => {});

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2424,9 +2424,14 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     let waiting = true;
     const previousAbort = transfer.abort;
 
+    const detachChannelErrorWhileWaiting = () => {
+      try { sftp.removeListener?.("error", onChannelErrorWhileWaiting); } catch { /* ignore */ }
+    };
+
     const abandonGateWait = (error) => {
       if (!waiting) return;
       waiting = false;
+      detachChannelErrorWhileWaiting();
       if (transfer.abort === wrappedAbort) {
         transfer.abort = previousAbort;
       }
@@ -2446,6 +2451,13 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       reject(error);
     };
 
+    const onChannelErrorWhileWaiting = (error) => {
+      // Prior OPEN may never settle after a dead channel; reject this waiter so
+      // lease/admission are not held until manual cancel (Codex P2 on 1f08f82c).
+      const err = error instanceof Error ? error : new Error(String(error?.message || error || "SFTP channel error"));
+      abandonGateWait(err);
+    };
+
     const wrappedAbort = () => {
       try { previousAbort?.(); } catch { /* ignore */ }
       transfer.cancelled = true;
@@ -2458,9 +2470,12 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       return;
     }
 
+    try { sftp.on?.("error", onChannelErrorWhileWaiting); } catch { /* ignore */ }
+
     const startOpen = () => {
       if (!waiting) return;
       waiting = false;
+      detachChannelErrorWhileWaiting();
       if (transfer.abort === wrappedAbort) {
         transfer.abort = previousAbort;
       }

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2159,6 +2159,7 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     // a concurrent same-path writer — same-id retry or a new transferId.
     if (!isTruncatingOpenNow()) return;
     const openHost = transfer?.targetHostId || transfer?.hostId || transfer?.sourceHostId;
+    const openSession = transfer?.targetSftpId || transfer?.sourceSftpId || transfer?.sftpId;
     for (const active of activeTransfers.values()) {
       if (!active || active === transfer) continue;
       const matchesStage = remoteOpenPathMatchesStaged(filePath, active.stagedRemote);
@@ -2172,11 +2173,17 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       );
       if (!matchesStage && !matchesInPlace) continue;
       const activeHost = active.targetHostId || active.hostId || active.sourceHostId;
-      if (
-        openHost != null && String(openHost).length > 0
-        && activeHost != null && String(activeHost).length > 0
-        && String(openHost) !== String(activeHost)
-      ) {
+      const activeSession = active.targetSftpId || active.sourceSftpId || active.sftpId;
+      // Require a matching host or session identity. Do not treat a missing host
+      // as a wildcard — clipboard/agent uploads share common paths like /tmp
+      // across unrelated endpoints (Codex P2 on 4d194041).
+      if (openHost != null && String(openHost).length > 0
+        && activeHost != null && String(activeHost).length > 0) {
+        if (String(openHost) !== String(activeHost)) continue;
+      } else if (openSession != null && String(openSession).length > 0
+        && activeSession != null && String(activeSession).length > 0) {
+        if (String(openSession) !== String(activeSession)) continue;
+      } else {
         continue;
       }
       active.staleOpenTruncatedStage = true;

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2416,7 +2416,14 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       if (transfer.abort === wrappedAbort) {
         transfer.abort = previousAbort;
       }
-      pathGate.release();
+      // Do not release this waiter immediately: beginTruncatingSharedWriteOpen
+      // already replaced the map entry with us. Releasing now would leave later
+      // same-path attempts with no barrier while the prior OPEN is still in
+      // flight (stale truncating OPEN race). Chain our release to the prior.
+      pathGate.waitForPrior.then(
+        () => pathGate.release(),
+        () => pathGate.release(),
+      );
       if (resolveSharedWriteDrain) {
         const resolveDrain = resolveSharedWriteDrain;
         resolveSharedWriteDrain = null;
@@ -2444,6 +2451,7 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
         transfer.abort = previousAbort;
       }
       if (transfer.cancelled) {
+        // Prior has resolved (or never existed); safe to release our gate now.
         pathGate.release();
         if (resolveSharedWriteDrain) {
           const resolveDrain = resolveSharedWriteDrain;

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -329,6 +329,62 @@ function remoteOpenPathMatchesStaged(openPath, stagedRemote) {
 }
 
 /**
+ * Serialize truncating shared-write OPENs on the same remote path.
+ *
+ * A drain force-complete can let attempt N return while its OPEN "w" is still
+ * in flight. Same-id retries reuse deterministic `.netcatty-<id>.part` stages;
+ * if the stale OPEN lands after the retry has begun writing, the server
+ * truncates the retry stage and a later size check can promote sparse data
+ * (Codex P1 on 42a27ef7). Wait for any prior OPEN on the path to settle before
+ * issuing another truncating OPEN; release on OPEN callback and on drain
+ * force-complete so a dead channel cannot block retries forever.
+ *
+ * @type {Map<string, { promise: Promise<void>, resolve: () => void, released: boolean }>}
+ */
+const truncatingSharedWriteOpenGates = new Map();
+
+function sharedWriteOpenPathKey(filePath) {
+  if (Buffer.isBuffer(filePath)) return `b:${filePath.toString("hex")}`;
+  return `s:${String(filePath ?? "")}`;
+}
+
+/**
+ * @param {string | Buffer} filePath
+ * @returns {{ waitForPrior: Promise<void>, release: () => void }}
+ */
+function beginTruncatingSharedWriteOpen(filePath) {
+  const key = sharedWriteOpenPathKey(filePath);
+  const prior = truncatingSharedWriteOpenGates.get(key);
+  const waitForPrior = prior && !prior.released
+    ? prior.promise
+    : Promise.resolve();
+
+  let resolve;
+  const promise = new Promise((r) => {
+    resolve = r;
+  });
+  const entry = {
+    promise,
+    resolve: () => {
+      resolve();
+    },
+    released: false,
+  };
+  truncatingSharedWriteOpenGates.set(key, entry);
+
+  const release = () => {
+    if (entry.released) return;
+    entry.released = true;
+    if (truncatingSharedWriteOpenGates.get(key) === entry) {
+      truncatingSharedWriteOpenGates.delete(key);
+    }
+    entry.resolve();
+  };
+
+  return { waitForPrior, release };
+}
+
+/**
  * Reconcile a claimed resume offset with durable staged bytes.
  *
  * Progress events update checkpointBytes as soon as data is handed to the write
@@ -2004,7 +2060,9 @@ async function uploadFile(
  * this OPEN path. Path-shape / resumable+targetPath heuristics are not used:
  * an in-place retry leaves stagedRemote null while still looking "resumable",
  * and a stale late OPEN on a leftover `.part` must still unlink (Codex P2 on
- * 39e20bfa / 7c446c7 / d19ecb88).
+ * 39e20bfa / 7c446c7 / d19ecb88). Truncating shared opens also take a
+ * path-level gate so a same-id retry cannot issue OPEN "w" on a stage while a
+ * prior attempt's truncating OPEN is still unsettled (Codex P1 on 42a27ef7).
  *
  * @param {{ disposeChannel?: boolean, abortChannel?: (() => void) | null, generatedStagePath?: boolean }} [options]
  */
@@ -2019,6 +2077,11 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
   const isWriteOpen = String(flags ?? "r") !== "r";
   const isTruncatingOpen = String(flags ?? "r") === "w";
   const trackSharedWriteDrain = !disposeChannel && isWriteOpen;
+  // Path gate only for truncating shared writes — non-truncating "r+" resume
+  // opens do not wipe peer bytes if ordered loosely.
+  const pathGate = trackSharedWriteDrain && isTruncatingOpen
+    ? beginTruncatingSharedWriteOpen(filePath)
+    : null;
   // Late truncating OPEN after settle (cancel or channel-error force-complete)
   // must unlink generated stages so cleanup cannot leave a recreate orphan.
   // In-place finals never unlink.
@@ -2044,6 +2107,26 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     }
     return true;
   };
+
+  /**
+   * When a late truncating OPEN lands after a same-id retry already opened the
+   * same stage, the server may have wiped retry bytes. Fail the live attempt
+   * rather than allow a sparse promote (Codex P1 on 42a27ef7).
+   */
+  const invalidateRetryStageIfStaleOpen = () => {
+    if (!shouldUnlinkLateGeneratedStage) return;
+    const transferId = transfer?.transferId;
+    if (transferId == null || transferId === "") return;
+    const active = activeTransfers.get(transferId);
+    if (!active || active === transfer) return;
+    if (!remoteOpenPathMatchesStaged(filePath, active.stagedRemote)) return;
+    // Only abort once the retry has accepted its own OPEN; otherwise the path
+    // gate is about to let the retry open cleanly after this late callback.
+    if (active.sharedWriteOpenAccepted !== true) return;
+    active.staleOpenTruncatedStage = true;
+    try { active.abort?.(); } catch { /* ignore */ }
+  };
+
   let resolveSharedWriteDrain = null;
   if (trackSharedWriteDrain) {
     transfer.sharedWriteOpenDrain = new Promise((resolve) => {
@@ -2051,11 +2134,18 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     });
   }
 
-  return new Promise((resolve, reject) => {
+  const runOpen = () => new Promise((resolve, reject) => {
     let settled = false;
     let openDrainTimer = null;
     let drainForceTimer = null;
     const previousAbort = transfer.abort;
+    let pathGateReleased = false;
+
+    const releasePathGate = () => {
+      if (!pathGate || pathGateReleased) return;
+      pathGateReleased = true;
+      pathGate.release();
+    };
 
     const clearDrainForceTimer = () => {
       if (!drainForceTimer) return;
@@ -2074,11 +2164,15 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     // OPEN wait may settle without a callback (channel error, or cancel settle
     // timeout). Keep drain pending for a late truncating OPEN, but force-
     // complete if the callback never arrives so cleanup/lease cannot hang.
+    // Also release the path gate so a dead channel cannot pin same-path retries
+    // forever. A still-late OPEN callback then closes and, if a retry already
+    // accepted its own OPEN on this path, invalidates that retry (Codex P1).
     const armSharedWriteDrainForceComplete = () => {
       if (!trackSharedWriteDrain || !resolveSharedWriteDrain || drainForceTimer) return;
       drainForceTimer = setTimeout(() => {
         drainForceTimer = null;
         completeSharedWriteDrain();
+        releasePathGate();
       }, 2000);
     };
 
@@ -2106,8 +2200,12 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     // final targets (Codex P1 on a9f748c8). Skip unlink only when a same-id
     // retry owns a reusable resume stage at this path (Codex P2 on d19ecb88).
     const finishLateSharedWriteOpen = (handle) => {
+      invalidateRetryStageIfStaleOpen();
       const afterClose = () => {
-        const finish = () => completeSharedWriteDrain();
+        const finish = () => {
+          completeSharedWriteDrain();
+          releasePathGate();
+        };
         if (canUnlinkLateGeneratedStageNow()) {
           unlinkSharedWritePathBestEffort().then(finish, finish);
           return;
@@ -2156,7 +2254,10 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       // sftp.end() cannot win the promise with a channel-close error first.
       settle(reject, new Error("Transfer cancelled"));
       try { abortChannel?.(); } catch { /* ignore */ }
-      if (!trackSharedWriteDrain) completeSharedWriteDrain();
+      if (!trackSharedWriteDrain) {
+        completeSharedWriteDrain();
+        releasePathGate();
+      }
     };
 
     const onOpenChannelError = (error) => {
@@ -2165,6 +2266,7 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       // a dead channel that never invokes the OPEN callback cannot hang forever.
       if (!trackSharedWriteDrain) {
         completeSharedWriteDrain();
+        releasePathGate();
       } else {
         armSharedWriteDrainForceComplete();
       }
@@ -2172,6 +2274,7 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
 
     if (transfer.cancelled) {
       completeSharedWriteDrain();
+      releasePathGate();
       reject(new Error("Transfer cancelled"));
       return;
     }
@@ -2190,17 +2293,35 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
             return;
           }
           completeSharedWriteDrain();
+          releasePathGate();
           return;
         }
         if (error) {
           settle(reject, error);
           completeSharedWriteDrain();
+          releasePathGate();
+          return;
+        }
+        // Ownership moved to a same-id retry before this OPEN applied: treat as
+        // late so we never hand the stale truncating handle to the old attempt.
+        const activeOwner = transfer?.transferId != null
+          ? activeTransfers.get(transfer.transferId)
+          : null;
+        if (activeOwner && activeOwner !== transfer) {
+          settle(reject, new Error("Transfer superseded"));
+          if (handle && !disposeChannel) {
+            finishLateSharedWriteOpen(handle);
+            return;
+          }
+          completeSharedWriteDrain();
+          releasePathGate();
           return;
         }
         if (transfer.cancelled) {
           const finishCancel = () => {
             settle(reject, new Error("Transfer cancelled"));
             completeSharedWriteDrain();
+            releasePathGate();
           };
           if (handle && !disposeChannel) {
             // Close before settle/drain so shared write cleanup runs after the
@@ -2221,16 +2342,23 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
           finishCancel();
           return;
         }
+        transfer.sharedWriteOpenAccepted = true;
         settle(resolve, handle);
         completeSharedWriteDrain();
+        releasePathGate();
       });
     } catch (error) {
       // Sync throw (destroyed channel / bad state) must still settle and drop
       // the error listener; otherwise the shared browse channel leaks listeners.
       settle(reject, error);
       completeSharedWriteDrain();
+      releasePathGate();
     }
   });
+
+  if (!pathGate) return runOpen();
+  // Wait for any prior truncating OPEN on this path before issuing ours.
+  return pathGate.waitForPrior.then(runOpen, runOpen);
 }
 
 function closeSftpHandle(sftp, handle) {

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2202,7 +2202,16 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       drainForceTimer = setTimeout(() => {
         drainForceTimer = null;
         completeSharedWriteDrain();
-        releasePathGate();
+        // In-place opens can free the path gate immediately. Generated/reusable
+        // stages must keep the gate held until a late OPEN callback settles
+        // (finishLateSharedWriteOpen / cancel path) so a same-id retry cannot
+        // promote while the server still processes the stale OPEN "w". Cap the
+        // hold so a permanently dead channel cannot block forever (Codex P1).
+        if (!generatedStagePath) {
+          releasePathGate();
+          return;
+        }
+        setTimeout(() => releasePathGate(), 10000);
       }, 2000);
     };
 

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -1941,7 +1941,10 @@ async function uploadFile(
  * after cancel still closes the handle and, when the path is an explicit
  * generated stage (`generatedStagePath`), best-effort unlinks it so stage
  * cleanup cannot race a recreate/orphan. In-place final targets are never
- * unlinked here.
+ * unlinked here. Same-id retries that already re-own the active transfer
+ * slot also skip unlink: resumable stages reuse
+ * `.netcatty-<transferId>.part`, and a stale late OPEN must not delete the
+ * new attempt's stage (Codex P2 on d19ecb88).
  *
  * @param {{ disposeChannel?: boolean, abortChannel?: (() => void) | null, generatedStagePath?: boolean }} [options]
  */
@@ -1960,6 +1963,16 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
   // must unlink generated stages so cleanup cannot leave a recreate orphan.
   // In-place finals never unlink.
   const shouldUnlinkLateGeneratedStage = generatedStagePath && isTruncatingOpen;
+  // Re-check ownership at unlink time: a same-id retry may already own
+  // activeTransfers and the deterministic resume stage path.
+  const canUnlinkLateGeneratedStageNow = () => {
+    if (!shouldUnlinkLateGeneratedStage) return false;
+    const transferId = transfer?.transferId;
+    if (transferId == null || transferId === "") return true;
+    const active = activeTransfers.get(transferId);
+    if (active && active !== transfer) return false;
+    return true;
+  };
   let resolveSharedWriteDrain = null;
   if (trackSharedWriteDrain) {
     transfer.sharedWriteOpenDrain = new Promise((resolve) => {
@@ -1999,6 +2012,11 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     };
 
     const unlinkSharedWritePathBestEffort = () => new Promise((resolveUnlink) => {
+      // Ownership can change between close and unlink (retry start).
+      if (!canUnlinkLateGeneratedStageNow()) {
+        resolveUnlink();
+        return;
+      }
       if (typeof sftp.unlink !== "function") {
         resolveUnlink();
         return;
@@ -2014,11 +2032,12 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     // truncating stages also unlink so a force-completed drain / stage delete
     // cannot leave a recreate orphan after cancel OR channel-error settle
     // (Codex P2 on 0cda4a39 / cd57d960 / bd42c51c). Never unlink in-place
-    // final targets (Codex P1 on a9f748c8).
+    // final targets (Codex P1 on a9f748c8). Skip unlink when a same-id retry
+    // already owns the active transfer (Codex P2 on d19ecb88).
     const finishLateSharedWriteOpen = (handle) => {
       const afterClose = () => {
         const finish = () => completeSharedWriteDrain();
-        if (shouldUnlinkLateGeneratedStage) {
+        if (canUnlinkLateGeneratedStageNow()) {
           unlinkSharedWritePathBestEffort().then(finish, finish);
           return;
         }
@@ -2116,8 +2135,9 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
             // Close before settle/drain so shared write cleanup runs after the
             // truncating OPEN handle is released. Cancel + generated stage
             // "w": unlink too so a staged recreate cannot survive if cleanup
-            // already raced. In-place finals are close-only.
-            if (shouldUnlinkLateGeneratedStage) {
+            // already raced. In-place finals are close-only. Same-id retries
+            // that re-own activeTransfers skip unlink (resume stage reuse).
+            if (canUnlinkLateGeneratedStageNow()) {
               closeSftpHandle(sftp, handle)
                 .catch(() => {})
                 .then(() => unlinkSharedWritePathBestEffort())

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -4164,6 +4164,11 @@ async function startTransferNow(event, payload, onProgress) {
     targetPath,
     sourceSftpId,
     targetSftpId,
+    // Host IDs must ride on the transfer object so path-gate keys stay host-
+    // scoped when a dedicated-resume opens a new sftpId (Codex P1 on d44886e6).
+    sourceHostId: payload.sourceHostId,
+    targetHostId: payload.targetHostId,
+    hostId: payload.hostId || payload.targetHostId || payload.sourceHostId,
     parentTaskId: payload.parentTaskId,
     directoryEntryIndex: payload.directoryEntryIndex,
     directoryEntryIdentity: payload.directoryEntryIdentity,

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -271,6 +271,25 @@ function buildRemoteTransferStagePath(targetPath, transferId) {
 }
 
 /**
+ * True when `filePath` is a deterministic resumable stage that same-id retries
+ * reuse (`.${base}.netcatty-${transferId}.part`). Non-resumable uploads use a
+ * fresh `.netcatty-upload-...` path per attempt and must not match.
+ */
+function isReusableRemoteTransferStagePath(filePath, transferId) {
+  if (transferId == null || transferId === "") return false;
+  const safeId = String(transferId).replace(/[^A-Za-z0-9_-]/g, "_");
+  if (!safeId) return false;
+  const base = path.posix.basename(String(filePath || ""));
+  // buildRemoteTransferStagePath → `.${name}.netcatty-${safeId}.part`
+  // non-resumable stages → `.netcatty-upload-${uuid}-....part`
+  return (
+    base.startsWith(".")
+    && base.endsWith(`.netcatty-${safeId}.part`)
+    && !base.startsWith(".netcatty-upload-")
+  );
+}
+
+/**
  * Reconcile a claimed resume offset with durable staged bytes.
  *
  * Progress events update checkpointBytes as soon as data is handed to the write
@@ -1942,9 +1961,10 @@ async function uploadFile(
  * generated stage (`generatedStagePath`), best-effort unlinks it so stage
  * cleanup cannot race a recreate/orphan. In-place final targets are never
  * unlinked here. Same-id retries that already re-own the active transfer
- * slot also skip unlink: resumable stages reuse
- * `.netcatty-<transferId>.part`, and a stale late OPEN must not delete the
- * new attempt's stage (Codex P2 on d19ecb88).
+ * slot skip unlink only for reusable resume stages
+ * (`.netcatty-<transferId>.part`); non-resumable `.netcatty-upload-*` paths
+ * are unique per attempt and must still be unlinked so a stale late OPEN
+ * cannot leave an orphan (Codex P2 on d19ecb88 / 7c446c7).
  *
  * @param {{ disposeChannel?: boolean, abortChannel?: (() => void) | null, generatedStagePath?: boolean }} [options]
  */
@@ -1964,13 +1984,30 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
   // In-place finals never unlink.
   const shouldUnlinkLateGeneratedStage = generatedStagePath && isTruncatingOpen;
   // Re-check ownership at unlink time: a same-id retry may already own
-  // activeTransfers and the deterministic resume stage path.
+  // activeTransfers and the deterministic resume stage path. Only suppress
+  // unlink for that reusable path — not every generatedStagePath.
   const canUnlinkLateGeneratedStageNow = () => {
     if (!shouldUnlinkLateGeneratedStage) return false;
     const transferId = transfer?.transferId;
     if (transferId == null || transferId === "") return true;
     const active = activeTransfers.get(transferId);
-    if (active && active !== transfer) return false;
+    if (active && active !== transfer) {
+      // Retry already owns this transfer id. Protect only the stage path that
+      // resumable retries actually reuse; unique non-resumable stage paths
+      // from the failed attempt must still be cleaned up.
+      if (active.stagedRemote?.path && active.stagedRemote.path === filePath) {
+        return false;
+      }
+      if (active.resumable && active.targetPath) {
+        if (buildRemoteTransferStagePath(active.targetPath, transferId) === filePath) {
+          return false;
+        }
+      }
+      if (isReusableRemoteTransferStagePath(filePath, transferId)) {
+        return false;
+      }
+      return true;
+    }
     return true;
   };
   let resolveSharedWriteDrain = null;
@@ -2032,8 +2069,8 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     // truncating stages also unlink so a force-completed drain / stage delete
     // cannot leave a recreate orphan after cancel OR channel-error settle
     // (Codex P2 on 0cda4a39 / cd57d960 / bd42c51c). Never unlink in-place
-    // final targets (Codex P1 on a9f748c8). Skip unlink when a same-id retry
-    // already owns the active transfer (Codex P2 on d19ecb88).
+    // final targets (Codex P1 on a9f748c8). Skip unlink only when a same-id
+    // retry owns a reusable resume stage at this path (Codex P2 on d19ecb88).
     const finishLateSharedWriteOpen = (handle) => {
       const afterClose = () => {
         const finish = () => completeSharedWriteDrain();

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -4545,16 +4545,14 @@ async function startTransferNow(event, payload, onProgress) {
   const sendError = (error) => {
     const message = error?.message || String(error);
     const superseded = /superseded/i.test(message);
-    // If a same-id retry already owns activeTransfers, this is a stale attempt.
-    // Do not emit terminal cancelled/failed for that transferId or the live
-    // retry is stuck cancelled in the transfer center (Codex P2 on dbfb411a).
-    const liveOwner = activeTransfers.get(transferId);
-    const isStaleSuperseded = superseded && liveOwner && liveOwner !== transfer;
+    // Superseded always means this attempt lost ownership. Suppress terminal
+    // events even after the retry has finished and left activeTransfers, or
+    // the completed retry is rewritten as cancelled (Codex P2 on 52f0248c).
     cleanupTransfer();
-    if (isStaleSuperseded) {
+    if (superseded) {
       return;
     }
-    const cancelled = /cancel/i.test(message) || superseded;
+    const cancelled = /cancel/i.test(message);
     if (cancelled) {
       sender.send("netcatty:transfer:cancelled", { transferId, error: message });
       broadcastGlobalTransferEvent({

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2251,6 +2251,22 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       }
     });
 
+
+    /** Close with 2s bound so a dead channel cannot pin the path gate. */
+    const boundCloseSftpHandle = (handle, thenFn) => {
+      let closed = false;
+      const finishClose = () => {
+        if (closed) return;
+        closed = true;
+        thenFn();
+      };
+      const closeTimer = setTimeout(finishClose, 2000);
+      closeSftpHandle(sftp, handle).then(
+        () => { clearTimeout(closeTimer); finishClose(); },
+        () => { clearTimeout(closeTimer); finishClose(); },
+      );
+    };
+
     // Late shared write OPEN after settle: close handle, and for generated
     // truncating stages also unlink so a force-completed drain / stage delete
     // cannot leave a recreate orphan after cancel OR channel-error settle
@@ -2273,21 +2289,12 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
         finish();
       };
       if (handle) {
-        let closed = false;
-        const finishClose = () => {
-          if (closed) return;
-          closed = true;
-          afterClose();
-        };
-        const closeTimer = setTimeout(finishClose, 2000);
-        closeSftpHandle(sftp, handle).then(
-          () => { clearTimeout(closeTimer); finishClose(); },
-          () => { clearTimeout(closeTimer); finishClose(); },
-        );
+        boundCloseSftpHandle(handle, afterClose);
         return;
       }
       afterClose();
     };
+
 
     const settle = (fn, value) => {
       if (settled) return;
@@ -2405,13 +2412,14 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
             // already raced. In-place finals are close-only. Same-id retries
             // that re-own activeTransfers skip unlink (resume stage reuse).
             if (canUnlinkLateGeneratedStageNow()) {
-              closeSftpHandle(sftp, handle)
-                .catch(() => {})
-                .then(() => unlinkSharedWritePathBestEffort())
-                .then(finishCancel, finishCancel);
+              // Bound close so a dead channel cannot pin the path gate forever
+              // when cancel wins before settle (Codex P2 on e6dfdc9e).
+              boundCloseSftpHandle(handle, () => {
+                unlinkSharedWritePathBestEffort().then(finishCancel, finishCancel);
+              });
               return;
             }
-            closeSftpHandle(sftp, handle).then(finishCancel, finishCancel);
+            boundCloseSftpHandle(handle, finishCancel);
             return;
           }
           finishCancel();

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2285,18 +2285,32 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       }
     });
 
-    /** Unlink with 2s bound so a dead channel cannot pin settle/gate forever. */
-    const boundUnlinkThen = (thenFn) => {
-      let done = false;
-      const finish = () => {
-        if (done) return;
-        done = true;
-        thenFn();
+    /**
+     * Unlink, then settle transfer and release the path gate.
+     * Transfer settle is 2s-bounded so a dead unlink cannot hang the invoke;
+     * the path gate stays held until unlink actually settles so a delayed
+     * unlink cannot delete a same-path retry that already wrote (Codex P2 on
+     * 46ed3722).
+     */
+    const unlinkThenSettleAndReleaseGate = (settleFn) => {
+      let transferSettled = false;
+      const settleTransfer = () => {
+        if (transferSettled) return;
+        transferSettled = true;
+        settleFn();
       };
-      const timer = setTimeout(finish, 2000);
+      const settleTimer = setTimeout(settleTransfer, 2000);
       unlinkSharedWritePathBestEffort().then(
-        () => { clearTimeout(timer); finish(); },
-        () => { clearTimeout(timer); finish(); },
+        () => {
+          clearTimeout(settleTimer);
+          settleTransfer();
+          releasePathGate();
+        },
+        () => {
+          clearTimeout(settleTimer);
+          settleTransfer();
+          releasePathGate();
+        },
       );
     };
 
@@ -2331,7 +2345,8 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
           releasePathGate();
         };
         if (canUnlinkLateGeneratedStageNow()) {
-          boundUnlinkThen(finish);
+          // Gate stays held until unlink settles (no 2s force-release).
+          unlinkSharedWritePathBestEffort().then(finish, finish);
           return;
         }
         finish();
@@ -2467,10 +2482,14 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
             // already raced. In-place finals are close-only. Same-id retries
             // that re-own activeTransfers skip unlink (resume stage reuse).
             if (canUnlinkLateGeneratedStageNow()) {
-              // Bound close + unlink so a dead channel cannot pin settle/gate
-              // when cancel wins before settle (Codex P2 on e6dfdc9e / hang).
+              // Bound close. Unlink: settle transfer after 2s if needed, but keep
+              // the path gate until unlink actually settles (Codex P2 hang +
+              // delayed-unlink race on 46ed3722).
               boundCloseSftpHandle(handle, () => {
-                boundUnlinkThen(finishCancel);
+                unlinkThenSettleAndReleaseGate(() => {
+                  settle(reject, new Error("Transfer cancelled"));
+                  completeSharedWriteDrain();
+                });
               });
               return;
             }

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2110,14 +2110,18 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     : null;
   // Match sftpBridge.runFastPutOnChannel: only unlink planner-generated stages.
   const generatedStagePath = options.generatedStagePath === true;
+  // flags may be a getter so afterPathGate can shrink the resume checkpoint and
+  // switch r+ → w before the actual OPEN (Codex P2).
+  const resolveFlags = () => (typeof flags === "function" ? flags() : flags);
   // ssh2 string flags: "r" is read-only; anything else can create/truncate.
-  const isWriteOpen = String(flags ?? "r") !== "r";
-  const isTruncatingOpen = String(flags ?? "r") === "w";
+  // Treat function flags as write opens (caller only uses r+/w for transfers).
+  const isWriteOpen = typeof flags === "function" || String(flags ?? "r") !== "r";
+  const isTruncatingOpen = typeof flags !== "function" && String(flags ?? "r") === "w";
   const trackSharedWriteDrain = !disposeChannel && isWriteOpen;
-  // Path-gate all shared writes (including "r+" resume). A pending truncating
-  // OPEN "w" can still zero the stage after an "r+" retry has started writing
-  // (Codex P1 on 30308203).
-  const pathGate = trackSharedWriteDrain
+  // Path-gate EVERY write open (shared and isolated, "w" and "r+"). An isolated
+  // recovery OPEN must still wait for a stale shared truncating OPEN on the same
+  // host path (Codex P1 on 294b7a4b / 40db393f).
+  const pathGate = isWriteOpen
     ? beginTruncatingSharedWriteOpen(filePath, sharedWriteOpenSessionKey(sftp, transfer))
     : null;
   // Late truncating OPEN after settle (cancel or channel-error force-complete)
@@ -2367,7 +2371,7 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     sftp.on?.("error", onOpenChannelError);
 
     try {
-      sftp.open(filePath, flags, (error, handle) => {
+      sftp.open(filePath, resolveFlags(), (error, handle) => {
         if (settled) {
           // Cancel / channel error already settled (possibly via drain timeout).
           // Still close a late shared handle; cancel + truncating "w" also
@@ -2510,18 +2514,34 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       if (transfer.abort === wrappedAbort) {
         transfer.abort = previousAbort;
       }
-      if (transfer.cancelled) {
-        // Prior has resolved (or never existed); safe to release our gate now.
+      // After waiting on a prior OPEN, re-validate resume checkpoints so a
+      // truncating OPEN that landed while we waited cannot leave us writing
+      // past a wiped stage (Codex P2 on 294b7a4b).
+      const afterGate = typeof options.afterPathGate === "function"
+        ? Promise.resolve().then(() => options.afterPathGate())
+        : Promise.resolve();
+      afterGate.then(() => {
+        if (transfer.cancelled) {
+          // Prior has resolved (or never existed); safe to release our gate now.
+          pathGate.release();
+          if (resolveSharedWriteDrain) {
+            const resolveDrain = resolveSharedWriteDrain;
+            resolveSharedWriteDrain = null;
+            resolveDrain();
+          }
+          reject(new Error("Transfer cancelled"));
+          return;
+        }
+        runOpen().then(resolve, reject);
+      }, (err) => {
         pathGate.release();
         if (resolveSharedWriteDrain) {
           const resolveDrain = resolveSharedWriteDrain;
           resolveSharedWriteDrain = null;
           resolveDrain();
         }
-        reject(new Error("Transfer cancelled"));
-        return;
-      }
-      runOpen().then(resolve, reject);
+        reject(err instanceof Error ? err : new Error(String(err?.message || err)));
+      });
     };
 
     pathGate.waitForPrior.then(startOpen, startOpen);
@@ -3304,7 +3324,9 @@ async function uploadFileConcurrent(
 ) {
   const disposeChannel = options.disposeChannel !== false;
   const generatedStagePath = options.generatedStagePath === true;
-  const checkpoint = Math.max(0, Math.min(transfer.checkpointBytes || 0, fileSize));
+  // Mutable: may shrink after path-gate wait if a stale truncating OPEN wiped
+  // the stage while we were waiting (Codex P2 on 294b7a4b).
+  let checkpoint = Math.max(0, Math.min(transfer.checkpointBytes || 0, fileSize));
   let channelError = null;
   const onChannelError = (error) => {
     channelError = channelError || error;
@@ -3371,9 +3393,43 @@ async function uploadFileConcurrent(
     remoteHandle = await openSftpHandleForTransfer(
       sftp,
       remotePath,
-      checkpoint > 0 ? "r+" : "w",
+      // Getter so afterPathGate can shrink checkpoint and switch r+ → w.
+      () => (checkpoint > 0 ? "r+" : "w"),
       transfer,
-      { disposeChannel, abortChannel, generatedStagePath },
+      {
+        disposeChannel,
+        abortChannel,
+        generatedStagePath,
+        afterPathGate: async () => {
+          // Re-read durable stage size after waiting; a prior OPEN "w" may have
+          // truncated the file while we were queued (Codex P2).
+          if (checkpoint <= 0 || !transfer.stagedRemote) return;
+          try {
+            const staged = transfer.stagedRemote;
+            let size = null;
+            if (isScpModeClient(staged.client)) {
+              const st = await getScpBackendForClient(staged.client).stat(staged.path, {
+                encoding: staged.encoding,
+              });
+              size = Number(st?.size);
+            } else if (typeof staged.client?.stat === "function") {
+              const st = await staged.client.stat(
+                encodePathForSession(staged.sftpId, staged.path, staged.encoding),
+              );
+              size = Number(st?.size);
+            }
+            if (Number.isFinite(size) && size >= 0 && size < checkpoint) {
+              checkpoint = size;
+              transfer.checkpointBytes = size;
+              try {
+                sendProgress(size, fileSize, { force: true, checkpointBytes: size });
+              } catch { /* best-effort */ }
+            }
+          } catch {
+            // Missing stage → fall through; OPEN "w" or r+ will fail and retry.
+          }
+        },
+      },
     );
     if (channelError) throw channelError;
     if (transfer.cancelled) throw new Error("Transfer cancelled");

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -4198,12 +4198,16 @@ async function startTransferNow(event, payload, onProgress) {
   };
 
   let leasesReleased = false;
-  const cleanupTransfer = () => {
+  const cleanupTransfer = (options = {}) => {
     // A stale completion must never unregister a newer transfer that reused the
     // same id after this one became terminal.
     if (activeTransfers.get(transferId) === transfer) {
       activeTransfers.delete(transferId);
     }
+    // Superseded attempts share the lease Set entry with a same-id retry —
+    // releasing here would drop the only lease and hard-close SFTP under the
+    // live retry (Codex P2 on 5f3e3e2a).
+    if (options.releaseLeases === false) return;
     if (!leasesReleased) {
       leasesReleased = true;
       releaseTransferSessionLeases(transferId, transfer.leasedSftpIds || leasedSftpIds);
@@ -4548,10 +4552,12 @@ async function startTransferNow(event, payload, onProgress) {
     // Superseded always means this attempt lost ownership. Suppress terminal
     // events even after the retry has finished and left activeTransfers, or
     // the completed retry is rewritten as cancelled (Codex P2 on 52f0248c).
-    cleanupTransfer();
+    // Do not release SFTP leases — a live same-id retry may still hold them.
     if (superseded) {
+      cleanupTransfer({ releaseLeases: false });
       return;
     }
+    cleanupTransfer();
     const cancelled = /cancel/i.test(message);
     if (cancelled) {
       sender.send("netcatty:transfer:cancelled", { transferId, error: message });

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2418,9 +2418,10 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       sftp.open(filePath, resolveFlags(), (error, handle) => {
         if (settled) {
           // Cancel / channel error already settled (possibly via drain timeout).
-          // Late write OPEN (shared or isolated) still invalidates same-path
-          // writers and releases the gate (Codex P1 on 76015575).
-          if (!error && handle && isWriteOpen) {
+          // Shared/sudo late handles always close (read or write) so the long-
+          // lived session cannot leak. Isolated late write OPENs still run
+          // invalidation/unlink (Codex P1 on 76015575 / 298d155e).
+          if (!error && handle && (isWriteOpen || !disposeChannel)) {
             finishLateSharedWriteOpen(handle);
             return;
           }

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -1961,10 +1961,11 @@ async function uploadFile(
  * generated stage (`generatedStagePath`), best-effort unlinks it so stage
  * cleanup cannot race a recreate/orphan. In-place final targets are never
  * unlinked here. Same-id retries that already re-own the active transfer
- * slot skip unlink only for reusable resume stages
- * (`.netcatty-<transferId>.part`); non-resumable `.netcatty-upload-*` paths
- * are unique per attempt and must still be unlinked so a stale late OPEN
- * cannot leave an orphan (Codex P2 on d19ecb88 / 7c446c7).
+ * slot skip unlink only when the retry's actual `stagedRemote.path` matches
+ * this OPEN path. Path-shape / resumable+targetPath heuristics are not used:
+ * an in-place retry leaves stagedRemote null while still looking "resumable",
+ * and a stale late OPEN on a leftover `.part` must still unlink (Codex P2 on
+ * 39e20bfa / 7c446c7 / d19ecb88).
  *
  * @param {{ disposeChannel?: boolean, abortChannel?: (() => void) | null, generatedStagePath?: boolean }} [options]
  */
@@ -1984,26 +1985,18 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
   // In-place finals never unlink.
   const shouldUnlinkLateGeneratedStage = generatedStagePath && isTruncatingOpen;
   // Re-check ownership at unlink time: a same-id retry may already own
-  // activeTransfers and the deterministic resume stage path. Only suppress
-  // unlink for that reusable path — not every generatedStagePath.
+  // activeTransfers. Only suppress unlink when the retry's *actual* staged
+  // remote path matches this OPEN path. Do not infer ownership from
+  // resumable+targetPath or path-shape alone — in-place retries keep
+  // resumable/targetPath while stagedRemote is null (e.g. symlink / no-lstat
+  // destinations), and a stale late OPEN on a leftover .part must still unlink.
   const canUnlinkLateGeneratedStageNow = () => {
     if (!shouldUnlinkLateGeneratedStage) return false;
     const transferId = transfer?.transferId;
     if (transferId == null || transferId === "") return true;
     const active = activeTransfers.get(transferId);
     if (active && active !== transfer) {
-      // Retry already owns this transfer id. Protect only the stage path that
-      // resumable retries actually reuse; unique non-resumable stage paths
-      // from the failed attempt must still be cleaned up.
       if (active.stagedRemote?.path && active.stagedRemote.path === filePath) {
-        return false;
-      }
-      if (active.resumable && active.targetPath) {
-        if (buildRemoteTransferStagePath(active.targetPath, transferId) === filePath) {
-          return false;
-        }
-      }
-      if (isReusableRemoteTransferStagePath(filePath, transferId)) {
         return false;
       }
       return true;

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -1555,7 +1555,9 @@ async function uploadFile(
   sendProgress,
   encoding = "utf-8",
   onBytesCommitted = null,
+  options = {},
 ) {
+  const generatedStagePath = options.generatedStagePath === true;
   if (isScpModeClient(client)) {
     transfer.pauseSupported = false;
     transfer.pauseUnavailableReason = "Pause is unavailable for SCP transfers";
@@ -1738,7 +1740,7 @@ async function uploadFile(
           fileSize,
           transfer,
           sendProgress,
-          { disposeChannel: true, onBytesCommitted },
+          { disposeChannel: true, onBytesCommitted, generatedStagePath },
         );
         concurrentIsolatedOk = true;
       } catch (err) {
@@ -1881,7 +1883,7 @@ async function uploadFile(
         fileSize,
         transfer,
         sendProgress,
-        { disposeChannel: false, onBytesCommitted },
+        { disposeChannel: false, onBytesCommitted, generatedStagePath },
       );
       sharedOk = true;
     } catch (err) {
@@ -1936,20 +1938,25 @@ async function uploadFile(
  * the remote stage. Channel-error and cancel-settle paths that never receive an
  * OPEN callback arm a short drain force-complete so a dead/stalled channel
  * cannot hold the transfer and SFTP lease forever. A late truncating `"w"` OPEN
- * after cancel still closes the handle and best-effort unlinks the path so
- * stage cleanup cannot race a recreate/orphan.
+ * after cancel still closes the handle and, when the path is an explicit
+ * generated stage (`generatedStagePath`), best-effort unlinks it so stage
+ * cleanup cannot race a recreate/orphan. In-place final targets are never
+ * unlinked here.
  *
- * @param {{ disposeChannel?: boolean, abortChannel?: (() => void) | null }} [options]
+ * @param {{ disposeChannel?: boolean, abortChannel?: (() => void) | null, generatedStagePath?: boolean }} [options]
  */
 function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}) {
   const disposeChannel = options.disposeChannel !== false;
   const abortChannel = typeof options.abortChannel === "function"
     ? options.abortChannel
     : null;
+  // Match sftpBridge.runFastPutOnChannel: only unlink planner-generated stages.
+  const generatedStagePath = options.generatedStagePath === true;
   // ssh2 string flags: "r" is read-only; anything else can create/truncate.
   const isWriteOpen = String(flags ?? "r") !== "r";
   const isTruncatingOpen = String(flags ?? "r") === "w";
   const trackSharedWriteDrain = !disposeChannel && isWriteOpen;
+  const shouldUnlinkOnCancelOpen = generatedStagePath && isTruncatingOpen;
   let resolveSharedWriteDrain = null;
   if (trackSharedWriteDrain) {
     transfer.sharedWriteOpenDrain = new Promise((resolve) => {
@@ -2001,12 +2008,13 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     });
 
     // Late shared write OPEN after settle: close handle, and on cancel +
-    // truncating "w" also unlink so a force-completed drain / stage delete
-    // cannot leave a recreate orphan (Codex P2 on 0cda4a39 / cd57d960).
+    // generated truncating stage also unlink so a force-completed drain /
+    // stage delete cannot leave a recreate orphan (Codex P2 on 0cda4a39 /
+    // cd57d960). Never unlink in-place final targets (Codex P1 on a9f748c8).
     const finishLateSharedWriteOpen = (handle) => {
       const afterClose = () => {
         const finish = () => completeSharedWriteDrain();
-        if (transfer.cancelled && isTruncatingOpen) {
+        if (transfer.cancelled && shouldUnlinkOnCancelOpen) {
           unlinkSharedWritePathBestEffort().then(finish, finish);
           return;
         }
@@ -2038,7 +2046,8 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       // Shared write OPEN can truncate/create the remote path. A settle timeout
       // unblocks the transfer UX; sharedWriteOpenDrain stays pending until the
       // OPEN callback finishes (or drain force-complete) so cleanup usually
-      // waits. Late truncating opens still unlink after close if cancel won.
+      // waits. Late truncating generated stages still unlink after close if
+      // cancel won; in-place finals only close.
       if (!disposeChannel && isWriteOpen && !settled) {
         try { abortChannel?.(); } catch { /* ignore */ }
         if (!openDrainTimer) {
@@ -2101,9 +2110,10 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
           };
           if (handle && !disposeChannel) {
             // Close before settle/drain so shared write cleanup runs after the
-            // truncating OPEN handle is released. Cancel + "w": unlink too so
-            // a staged recreate cannot survive if cleanup already raced.
-            if (isTruncatingOpen) {
+            // truncating OPEN handle is released. Cancel + generated stage
+            // "w": unlink too so a staged recreate cannot survive if cleanup
+            // already raced. In-place finals are close-only.
+            if (shouldUnlinkOnCancelOpen) {
               closeSftpHandle(sftp, handle)
                 .catch(() => {})
                 .then(() => unlinkSharedWritePathBestEffort())
@@ -2887,9 +2897,11 @@ async function runPausableConcurrentRanges({
 /**
  * Pipelined SFTP WRITE upload (same fanout as ssh2 fastPut).
  *
- * @param {{ disposeChannel?: boolean, onBytesCommitted?: (() => void) | null }} [options]
+ * @param {{ disposeChannel?: boolean, onBytesCommitted?: (() => void) | null, generatedStagePath?: boolean }} [options]
  *   disposeChannel — when true (isolated channel), end the SFTP subsystem on
  *   cancel/finish. When false (shared browse session), never call sftp.end().
+ *   generatedStagePath — when true, cancel may best-effort unlink this path
+ *   after a truncating OPEN; in-place finals must leave this false.
  */
 async function uploadFileConcurrent(
   localPath,
@@ -2901,6 +2913,7 @@ async function uploadFileConcurrent(
   options = {},
 ) {
   const disposeChannel = options.disposeChannel !== false;
+  const generatedStagePath = options.generatedStagePath === true;
   const checkpoint = Math.max(0, Math.min(transfer.checkpointBytes || 0, fileSize));
   let channelError = null;
   const onChannelError = (error) => {
@@ -2970,7 +2983,7 @@ async function uploadFileConcurrent(
       remotePath,
       checkpoint > 0 ? "r+" : "w",
       transfer,
-      { disposeChannel, abortChannel },
+      { disposeChannel, abortChannel, generatedStagePath },
     );
     if (channelError) throw channelError;
     if (transfer.cancelled) throw new Error("Transfer cancelled");
@@ -3034,8 +3047,8 @@ async function uploadFileConcurrent(
     // runRemoteUploadTransaction cannot clean up the stage before a late
     // truncating OPEN finishes (Codex P2 on 747847e7). openSftpHandleForTransfer
     // force-completes the drain if the OPEN callback never arrives; late cancel
-    // truncating opens also unlink after close so a force-complete cannot
-    // orphan a recreated stage.
+    // truncating opens on generated stages also unlink after close so a
+    // force-complete cannot orphan a recreated stage.
     const sharedWriteOpenDrain = transfer.sharedWriteOpenDrain;
     if (sharedWriteOpenDrain) {
       await sharedWriteOpenDrain.catch(() => {});
@@ -4319,6 +4332,7 @@ async function startTransferNow(event, payload, onProgress) {
             sendProgress,
             resolvedTargetEncoding,
             usesStage ? null : () => { transfer.completionCommitted = true; },
+            { generatedStagePath: usesStage },
           );
         },
       });
@@ -4747,6 +4761,7 @@ async function startTransferNow(event, payload, onProgress) {
               uploadProgress,
               resolvedTargetEncoding,
               usesStage ? null : () => { transfer.completionCommitted = true; },
+              { generatedStagePath: usesStage },
             );
           },
         });

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -4529,13 +4529,27 @@ async function startTransferNow(event, payload, onProgress) {
   const sendError = (error) => {
     cleanupTransfer();
     const message = error?.message || String(error);
-    // Same-id retries supersede the previous attempt's late OPEN path. Do not
-    // broadcast a terminal "failed" for that transferId or the live retry task
-    // is marked failed in the transfer center (Codex P2 on 5d8e232).
+    // Same-id retries supersede the previous attempt's late OPEN path. Worker
+    // fan-out maps transfer:error as cancelled only for /cancel/ messages; emit
+    // cancelled channel for superseded so the live retry is not marked failed
+    // (Codex P2 on d777a66a).
     const cancelled = /cancel/i.test(message) || /superseded/i.test(message);
+    if (cancelled) {
+      sender.send("netcatty:transfer:cancelled", { transferId, error: message });
+      broadcastGlobalTransferEvent({
+        type: "cancelled",
+        transferId,
+        endedAt: Date.now(),
+        error: message,
+        parentTaskId: transfer.parentTaskId,
+        directoryEntryIndex: transfer.directoryEntryIndex,
+        directoryEntryIdentity: transfer.directoryEntryIdentity,
+      });
+      return;
+    }
     sender.send("netcatty:transfer:error", { transferId, error: message });
     broadcastGlobalTransferEvent({
-      type: cancelled ? "cancelled" : "failed",
+      type: "failed",
       transferId,
       endedAt: Date.now(),
       error: message,

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -290,6 +290,45 @@ function isReusableRemoteTransferStagePath(filePath, transferId) {
 }
 
 /**
+ * True when an OPEN path refers to the same remote stage as `stagedRemote`.
+ *
+ * OPEN may receive a session-encoded Buffer (non-utf8 / non-ascii) while
+ * stagedRemote.path stays the logical string. Compare both representations.
+ *
+ * @param {string | Buffer | null | undefined} openPath
+ * @param {{ path?: string, sftpId?: string, encoding?: string } | null | undefined} stagedRemote
+ */
+function remoteOpenPathMatchesStaged(openPath, stagedRemote) {
+  const logical = stagedRemote?.path;
+  if (openPath == null || logical == null || logical === "") return false;
+  if (openPath === logical) return true;
+  let encoded = logical;
+  if (stagedRemote.sftpId) {
+    try {
+      encoded = encodePathForSession(
+        stagedRemote.sftpId,
+        logical,
+        stagedRemote.encoding,
+      );
+    } catch {
+      encoded = logical;
+    }
+  }
+  if (openPath === encoded) return true;
+  if (Buffer.isBuffer(openPath) && Buffer.isBuffer(encoded)) {
+    return openPath.equals(encoded);
+  }
+  // OPEN Buffer vs logical/encoded string (utf-8/ascii encodePath returns string).
+  if (Buffer.isBuffer(openPath) && typeof encoded === "string") {
+    return openPath.equals(Buffer.from(encoded));
+  }
+  if (typeof openPath === "string" && Buffer.isBuffer(encoded)) {
+    return encoded.equals(Buffer.from(openPath));
+  }
+  return false;
+}
+
+/**
  * Reconcile a claimed resume offset with durable staged bytes.
  *
  * Progress events update checkpointBytes as soon as data is handed to the write
@@ -1990,13 +2029,15 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
   // resumable+targetPath or path-shape alone — in-place retries keep
   // resumable/targetPath while stagedRemote is null (e.g. symlink / no-lstat
   // destinations), and a stale late OPEN on a leftover .part must still unlink.
+  // Compare in the same representation: OPEN filePath may be a session-encoded
+  // Buffer while stagedRemote.path is the logical string.
   const canUnlinkLateGeneratedStageNow = () => {
     if (!shouldUnlinkLateGeneratedStage) return false;
     const transferId = transfer?.transferId;
     if (transferId == null || transferId === "") return true;
     const active = activeTransfers.get(transferId);
     if (active && active !== transfer) {
-      if (active.stagedRemote?.path && active.stagedRemote.path === filePath) {
+      if (remoteOpenPathMatchesStaged(filePath, active.stagedRemote)) {
         return false;
       }
       return true;
@@ -5818,4 +5859,5 @@ module.exports = {
   _assertSourceMetadataUnchangedForTests: assertSourceMetadataUnchanged,
   _assertDownloadSourceAfterTransferForTests: assertDownloadSourceAfterTransfer,
   _assertLocalDownloadMatchesRemotePrefixForTests: assertLocalDownloadMatchesRemotePrefix,
+  _remoteOpenPathMatchesStagedForTests: remoteOpenPathMatchesStaged,
 };

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -2257,6 +2257,8 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     // (Codex P2 on 0cda4a39 / cd57d960 / bd42c51c). Never unlink in-place
     // final targets (Codex P1 on a9f748c8). Skip unlink only when a same-id
     // retry owns a reusable resume stage at this path (Codex P2 on d19ecb88).
+    // Bound close so a dead channel that never invokes CLOSE cannot pin the
+    // path gate forever after drain force-complete (Codex P2 on 1a8cac20).
     const finishLateSharedWriteOpen = (handle) => {
       invalidateRetryStageIfStaleOpen();
       const afterClose = () => {
@@ -2271,7 +2273,17 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
         finish();
       };
       if (handle) {
-        closeSftpHandle(sftp, handle).then(afterClose, afterClose);
+        let closed = false;
+        const finishClose = () => {
+          if (closed) return;
+          closed = true;
+          afterClose();
+        };
+        const closeTimer = setTimeout(finishClose, 2000);
+        closeSftpHandle(sftp, handle).then(
+          () => { clearTimeout(closeTimer); finishClose(); },
+          () => { clearTimeout(closeTimer); finishClose(); },
+        );
         return;
       }
       afterClose();

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -4893,6 +4893,223 @@ test("shared upload OPEN drain unlinks late staged OPEN after channel-error forc
   );
 });
 
+test("late shared OPEN unlink still cleans non-resumable stage under same-id retry", async (t) => {
+  // Codex P2 on 7c446c7: retry ownership must not suppress unlink for every
+  // generatedStagePath. Non-resumable uploads use a unique
+  // `.netcatty-upload-*` path per attempt; a stale late OPEN on attempt 1's
+  // path must still unlink so the orphan is not left behind when a same-id
+  // retry already owns activeTransfers.
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-shared-open-late-unlink-nonresume-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(TRANSFER_CHUNK_SIZE, 59));
+  const targetPath = "/tmp/upload-late-unlink-nonresume.bin";
+  const transferId = "upload-shared-open-late-unlink-nonresume";
+
+  const remoteFiles = new Map();
+  const eventLog = [];
+  /** @type {null | (() => void)} */
+  let releaseFirstOpen = null;
+  let openGeneration = 0;
+  let endCalls = 0;
+  /** @type {null | (() => void)} */
+  let releaseRetryWrites = null;
+  const retryWritesReleased = new Promise((resolve) => {
+    releaseRetryWrites = resolve;
+  });
+  /** @type {string | null} */
+  let firstStagePath = null;
+  /** @type {string | null} */
+  let retryStagePath = null;
+  const sharedSftp = createFastSftp({
+    open(remotePath, flags, callback) {
+      assert.equal(flags, "w");
+      const key = String(remotePath);
+      openGeneration += 1;
+      const generation = openGeneration;
+      if (generation === 1) {
+        firstStagePath = key;
+        assert.match(key, /\.netcatty-upload-.*\.part$/, "first attempt must OPEN unique non-resumable stage");
+        releaseFirstOpen = () => {
+          if (!remoteFiles.has(key)) {
+            remoteFiles.set(key, Buffer.alloc(0));
+          }
+          eventLog.push(`open-created-1:${key}`);
+          callback(null, Buffer.from(`handle-1:${key}`));
+        };
+        return;
+      }
+      retryStagePath = key;
+      assert.match(key, /\.netcatty-upload-.*\.part$/, "retry must OPEN a fresh non-resumable stage");
+      assert.notEqual(key, firstStagePath, "non-resumable retry must not reuse first stage path");
+      remoteFiles.set(key, Buffer.from("retry-stage"));
+      eventLog.push(`open-created-${generation}:${key}`);
+      callback(null, Buffer.from(`handle-${generation}:${key}`));
+    },
+    write(handle, buffer, offset, length, position, callback) {
+      void retryWritesReleased.then(() => {
+        const key = String(handle).replace(/^handle-\d+:/, "");
+        const current = remoteFiles.get(key) || Buffer.alloc(0);
+        const end = position + length;
+        const next = Buffer.alloc(Math.max(current.length, end));
+        current.copy(next);
+        buffer.copy(next, position, offset, offset + length);
+        remoteFiles.set(key, next);
+        eventLog.push(`write:${key}:${length}@${position}`);
+        setImmediate(() => callback(null));
+      });
+    },
+    close(handle, callback) {
+      eventLog.push(`close:${String(handle)}`);
+      callback(null);
+    },
+    unlink(remotePath, callback) {
+      const key = String(remotePath);
+      eventLog.push(`unlink:${key}`);
+      remoteFiles.delete(key);
+      callback(null);
+    },
+    end() {
+      endCalls += 1;
+    },
+  });
+
+  const client = {
+    __netcattySudoMode: true,
+    sftp: sharedSftp,
+    async stat(remotePath) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        throw error;
+      }
+      return { size: remoteFiles.get(key).length };
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    async delete(remotePath) {
+      const key = String(remotePath);
+      eventLog.push(`delete:${key}`);
+      remoteFiles.delete(key);
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const firstSender = createSender();
+  const firstRunning = transferBridge.startTransfer(
+    { sender: firstSender },
+    {
+      transferId,
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: TRANSFER_CHUNK_SIZE,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+
+  const firstOpenReady = await waitUntil(() => typeof releaseFirstOpen === "function", 2000);
+  assert.ok(firstOpenReady, "expected first shared write OPEN to stall");
+
+  sharedSftp.emit("error", new Error("shared SFTP channel died before first OPEN callback"));
+
+  const firstResult = await Promise.race([
+    firstRunning,
+    new Promise((_, reject) => {
+      setTimeout(
+        () => reject(new Error("first transfer hung awaiting shared write OPEN drain after channel error")),
+        5000,
+      );
+    }),
+  ]);
+  assert.ok(firstResult.error, "expected first transfer to fail after channel error");
+  assert.match(firstResult.error, /shared SFTP channel died before first OPEN callback/i);
+  assert.equal(endCalls, 0, "shared sudo channel must not be ended");
+
+  // Same transfer id retry (non-resumable) owns a different stage path before
+  // the stale OPEN callback from attempt 1 arrives.
+  transferBridge.clearPendingCancel(transferId);
+  const retrySender = createSender();
+  const retryRunning = transferBridge.startTransfer(
+    { sender: retrySender },
+    {
+      transferId,
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: TRANSFER_CHUNK_SIZE,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+
+  const retryOpenReady = await waitUntil(
+    () => eventLog.some((entry) => entry.startsWith("open-created-2:")),
+    3000,
+  );
+  assert.ok(retryOpenReady, `expected retry OPEN, log=${eventLog.join(",")}`);
+  assert.ok(retryStagePath, "retry must have opened a stage");
+  assert.ok(
+    remoteFiles.has(retryStagePath),
+    "retry must own its unique stage before stale late OPEN",
+  );
+  const retryStageBeforeLateOpen = Buffer.from(remoteFiles.get(retryStagePath));
+
+  // Stale late OPEN from attempt 1: must close + unlink attempt-1 stage only.
+  releaseFirstOpen?.();
+  const lateCleanup = await waitUntil(
+    () => eventLog.some((entry) => entry.startsWith("close:handle-1:"))
+      && eventLog.some((entry) => entry === `unlink:${firstStagePath}`),
+    2000,
+  );
+  assert.ok(
+    lateCleanup,
+    `expected late close+unlink of first non-resumable stage, log=${eventLog.join(",")}`,
+  );
+  assert.equal(
+    eventLog.some((entry) => entry === `unlink:${retryStagePath}`),
+    false,
+    `stale late OPEN must not unlink retry stage, log=${eventLog.join(",")}`,
+  );
+  assert.ok(
+    remoteFiles.has(retryStagePath),
+    "retry stage must survive stale late OPEN on a different path",
+  );
+  assert.ok(
+    remoteFiles.get(retryStagePath).equals(retryStageBeforeLateOpen),
+    "retry stage bytes must not be removed by stale late OPEN unlink",
+  );
+  assert.equal(
+    remoteFiles.has(firstStagePath),
+    false,
+    "first attempt non-resumable stage must be unlinked (no orphan)",
+  );
+
+  releaseRetryWrites?.();
+  await transferBridge.cancelTransfer(null, { transferId });
+  const retryResult = await Promise.race([
+    retryRunning,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("retry transfer hung after cancel")), 5000);
+    }),
+  ]);
+  assert.ok(
+    retryResult.cancelled === true || /cancel/i.test(String(retryResult.error || "")),
+    `expected retry cancel settle, result=${JSON.stringify(retryResult)}`,
+  );
+  assert.equal(endCalls, 0, "shared sudo channel must not be ended");
+});
+
 test("late shared OPEN unlink skips same-id retry resume stage", async (t) => {
   // Codex P2 on d19ecb88: after OPEN drain force-complete, a late truncating
   // "w" callback unlinked the generated stage unconditionally. Resumable

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -5337,10 +5337,9 @@ test("late shared OPEN unlink skips same-id retry resume stage", async (t) => {
   assert.match(firstResult.error, /shared SFTP channel died before first OPEN callback/i);
   assert.equal(endCalls, 0, "shared sudo channel must not be ended");
 
-  // Same-id retry reuses the deterministic stage. Generated-stage drain
-  // force-complete holds the path gate for another 10s (2s + 10s) unless the
-  // stale OPEN settles first. Wait past that hold so the retry can OPEN while
-  // the first OPEN callback is still held for the late-truncation race below.
+  // Same-id retry reuses the deterministic stage. Drain force-complete does
+  // not release the path gate: the retry must wait until the stale OPEN
+  // callback settles (Codex P1 — no hard-cap race for different transferIds).
   transferBridge.clearPendingCancel(transferId);
   const retrySender = createSender();
   const retryRunning = transferBridge.startTransfer(
@@ -5358,50 +5357,42 @@ test("late shared OPEN unlink skips same-id retry resume stage", async (t) => {
     },
   );
 
-  const retryOpenReady = await waitUntil(
-    () => eventLog.some((entry) => entry.startsWith("open-created-2:")),
-    15000,
-  );
-  assert.ok(retryOpenReady, `expected retry OPEN after path gate force-release, log=${eventLog.join(",")}`);
-  assert.ok(
-    remoteFiles.get(deterministicStagePath)?.equals(Buffer.from("retry-stage")),
-    "retry must own deterministic stage before stale late OPEN",
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  assert.equal(
+    eventLog.some((entry) => entry.startsWith("open-created-2:")),
+    false,
+    `retry must not OPEN while prior gate is held, log=${eventLog.join(",")}`,
   );
 
-  // Stale late OPEN: server re-truncates the retry stage. Client must close
-  // without unlink, and must invalidate the accepted retry attempt.
+  // Settling the first OPEN frees the gate; then the retry may proceed.
   releaseFirstOpen?.();
   const lateClose = await waitUntil(
     () => eventLog.some((entry) => entry.startsWith("close:handle-1:")),
     2000,
   );
-  assert.ok(lateClose, `expected late close of first OPEN handle, log=${eventLog.join(",")}`);
-  assert.equal(
-    eventLog.some((entry) => entry === `unlink:${deterministicStagePath}`),
-    false,
-    `stale late OPEN must not unlink retry stage, log=${eventLog.join(",")}`,
+  assert.ok(lateClose, `expected close of first OPEN handle, log=${eventLog.join(",")}`);
+
+  const retryOpenReady = await waitUntil(
+    () => eventLog.some((entry) => entry.startsWith("open-created-2:")),
+    5000,
   );
-  assert.ok(
-    remoteFiles.has(deterministicStagePath),
-    "retry stage path must survive stale late OPEN unlink",
-  );
-  assert.ok(
-    remoteFiles.get(deterministicStagePath).equals(Buffer.alloc(0)),
-    "stale truncating OPEN must have wiped retry stage bytes (server race)",
-  );
+  assert.ok(retryOpenReady, `expected retry OPEN after prior gate release, log=${eventLog.join(",")}`);
 
   releaseRetryWrites?.();
   const retryResult = await Promise.race([
     retryRunning,
     new Promise((_, reject) => {
-      setTimeout(() => reject(new Error("retry transfer hung after stale OPEN invalidate")), 5000);
+      setTimeout(() => reject(new Error("retry transfer hung after prior OPEN settled")), 8000);
     }),
   ]);
+  // Retry should complete or fail cleanly — not hang on the path gate.
   assert.ok(
-    retryResult.cancelled === true
+    retryResult
+    && (retryResult.success === true
+      || retryResult.cancelled === true
       || retryResult.error
-      || /cancel|superseded|stale/i.test(String(retryResult.error || "")),
-    `expected retry to fail/cancel after stale OPEN truncated its stage, result=${JSON.stringify(retryResult)}`,
+      || retryResult.transferred != null),
+    `expected retry to settle after gate release, result=${JSON.stringify(retryResult)}`,
   );
   assert.equal(endCalls, 0, "shared sudo channel must not be ended");
 });

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -4893,6 +4893,211 @@ test("shared upload OPEN drain unlinks late staged OPEN after channel-error forc
   );
 });
 
+test("late shared OPEN unlink skips same-id retry resume stage", async (t) => {
+  // Codex P2 on d19ecb88: after OPEN drain force-complete, a late truncating
+  // "w" callback unlinked the generated stage unconditionally. Resumable
+  // retries reuse `.netcatty-<transferId>.part` via buildRemoteTransferStagePath,
+  // so a stale callback can delete the new attempt's stage/checkpoint.
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-shared-open-late-unlink-retry-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(TRANSFER_CHUNK_SIZE, 57));
+  const targetPath = "/tmp/upload-late-unlink-retry.bin";
+  const transferId = "upload-shared-open-late-unlink-retry";
+  const deterministicStagePath = `/tmp/.upload-late-unlink-retry.bin.netcatty-${transferId}.part`;
+
+  const remoteFiles = new Map();
+  const eventLog = [];
+  /** @type {null | (() => void)} */
+  let releaseFirstOpen = null;
+  let openGeneration = 0;
+  let endCalls = 0;
+  /** @type {null | (() => void)} */
+  let releaseRetryWrites = null;
+  const retryWritesReleased = new Promise((resolve) => {
+    releaseRetryWrites = resolve;
+  });
+  const sharedSftp = createFastSftp({
+    open(remotePath, flags, callback) {
+      assert.equal(flags, "w");
+      const key = String(remotePath);
+      openGeneration += 1;
+      const generation = openGeneration;
+      if (generation === 1) {
+        assert.equal(key, deterministicStagePath, "first attempt must OPEN deterministic resume stage");
+        releaseFirstOpen = () => {
+          // Late callback only: do not re-truncate an already-owned retry stage.
+          // The regression under test is the client-side unlink after close, not
+          // a second remote OPEN "w" race (which the server already applied).
+          if (!remoteFiles.has(key)) {
+            remoteFiles.set(key, Buffer.alloc(0));
+          }
+          eventLog.push(`open-created-1:${key}`);
+          callback(null, Buffer.from(`handle-1:${key}`));
+        };
+        return;
+      }
+      // Retry: complete OPEN immediately so the new attempt owns the stage.
+      remoteFiles.set(key, Buffer.from("retry-stage"));
+      eventLog.push(`open-created-${generation}:${key}`);
+      callback(null, Buffer.from(`handle-${generation}:${key}`));
+    },
+    write(handle, buffer, offset, length, position, callback) {
+      // Hold retry WRITEs until after the stale late OPEN ownership check.
+      void retryWritesReleased.then(() => {
+        const key = String(handle).replace(/^handle-\d+:/, "");
+        const current = remoteFiles.get(key) || Buffer.alloc(0);
+        const end = position + length;
+        const next = Buffer.alloc(Math.max(current.length, end));
+        current.copy(next);
+        buffer.copy(next, position, offset, offset + length);
+        remoteFiles.set(key, next);
+        eventLog.push(`write:${key}:${length}@${position}`);
+        setImmediate(() => callback(null));
+      });
+    },
+    close(handle, callback) {
+      eventLog.push(`close:${String(handle)}`);
+      callback(null);
+    },
+    unlink(remotePath, callback) {
+      const key = String(remotePath);
+      eventLog.push(`unlink:${key}`);
+      remoteFiles.delete(key);
+      callback(null);
+    },
+    end() {
+      endCalls += 1;
+    },
+  });
+
+  const client = {
+    __netcattySudoMode: true,
+    sftp: sharedSftp,
+    async stat(remotePath) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        throw error;
+      }
+      return { size: remoteFiles.get(key).length };
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    async delete(remotePath) {
+      const key = String(remotePath);
+      eventLog.push(`delete:${key}`);
+      remoteFiles.delete(key);
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const firstSender = createSender();
+  const firstRunning = transferBridge.startTransfer(
+    { sender: firstSender },
+    {
+      transferId,
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: TRANSFER_CHUNK_SIZE,
+      resumable: true,
+      skipAdmission: true,
+    },
+  );
+
+  const firstOpenReady = await waitUntil(() => typeof releaseFirstOpen === "function", 2000);
+  assert.ok(firstOpenReady, "expected first shared write OPEN to stall");
+
+  sharedSftp.emit("error", new Error("shared SFTP channel died before first OPEN callback"));
+
+  const firstResult = await Promise.race([
+    firstRunning,
+    new Promise((_, reject) => {
+      setTimeout(
+        () => reject(new Error("first transfer hung awaiting shared write OPEN drain after channel error")),
+        5000,
+      );
+    }),
+  ]);
+  assert.ok(firstResult.error, "expected first transfer to fail after channel error");
+  assert.match(firstResult.error, /shared SFTP channel died before first OPEN callback/i);
+  assert.equal(endCalls, 0, "shared sudo channel must not be ended");
+
+  // Same transfer id retry owns the deterministic resume stage before the
+  // stale OPEN callback from attempt 1 arrives.
+  transferBridge.clearPendingCancel(transferId);
+  const retrySender = createSender();
+  const retryRunning = transferBridge.startTransfer(
+    { sender: retrySender },
+    {
+      transferId,
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: TRANSFER_CHUNK_SIZE,
+      resumable: true,
+      skipAdmission: true,
+    },
+  );
+
+  const retryOpenReady = await waitUntil(
+    () => eventLog.some((entry) => entry.startsWith("open-created-2:")),
+    3000,
+  );
+  assert.ok(retryOpenReady, `expected retry OPEN, log=${eventLog.join(",")}`);
+  assert.ok(
+    remoteFiles.has(deterministicStagePath),
+    "retry must own deterministic stage before stale late OPEN",
+  );
+  const stageBeforeLateOpen = Buffer.from(remoteFiles.get(deterministicStagePath));
+
+  // Stale late OPEN from attempt 1: close only — must not unlink under retry.
+  releaseFirstOpen?.();
+  const lateClose = await waitUntil(
+    () => eventLog.some((entry) => entry.startsWith("close:handle-1:")),
+    2000,
+  );
+  assert.ok(lateClose, `expected late close of first OPEN handle, log=${eventLog.join(",")}`);
+  assert.equal(
+    eventLog.some((entry) => entry === `unlink:${deterministicStagePath}`),
+    false,
+    `stale late OPEN must not unlink retry stage, log=${eventLog.join(",")}`,
+  );
+  assert.ok(
+    remoteFiles.has(deterministicStagePath),
+    "retry stage must survive stale late OPEN unlink",
+  );
+  assert.ok(
+    remoteFiles.get(deterministicStagePath).equals(stageBeforeLateOpen),
+    "retry stage bytes must not be removed by stale late OPEN unlink",
+  );
+
+  // Let the retry finish (or cancel cleanly) so the test does not leak actives.
+  releaseRetryWrites?.();
+  await transferBridge.cancelTransfer(null, { transferId });
+  const retryResult = await Promise.race([
+    retryRunning,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("retry transfer hung after cancel")), 5000);
+    }),
+  ]);
+  assert.ok(
+    retryResult.cancelled === true || /cancel/i.test(String(retryResult.error || "")),
+    `expected retry cancel settle, result=${JSON.stringify(retryResult)}`,
+  );
+  assert.equal(endCalls, 0, "shared sudo channel must not be ended");
+});
+
 test("sudo SFTP downloads prefer concurrent shared READ over serial createReadStream", async (t) => {
   // Sudo cannot open an isolated channel, so downloads used to fall straight to
   // createReadStream (1-in-flight READs → hundreds of KB/s). Uploads already

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -4330,8 +4330,9 @@ test("shared upload OPEN drain force-completes when cancel has no OPEN callback"
 
 test("shared upload OPEN drain survives cancel settle timeout", async (t) => {
   // Codex P2 on af9cef2e / 0cda4a39 / cd57d960: cancel settle + drain
-  // force-complete must not hang, and a late truncating OPEN after that must
-  // close + unlink so stage cleanup cannot leave a recreate orphan.
+  // force-complete must not hang, and a late truncating OPEN on a generated
+  // stage after that must close + unlink so stage cleanup cannot leave a
+  // recreate orphan.
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-shared-upload-open-drain-timeout-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
@@ -4440,6 +4441,143 @@ test("shared upload OPEN drain survives cancel settle timeout", async (t) => {
     false,
     `expected no orphan staged upload, remaining=${[...remoteFiles.keys()].join(",")}`,
   );
+});
+
+test("in-place shared upload cancel does not unlink final target after late OPEN", async (t) => {
+  // Codex P1 on a9f748c8: cancel+truncating "w" unlinked filePath unconditionally,
+  // so late OPEN on an in-place/symlink destination could delete the final target.
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-shared-inplace-open-cancel-nounlink-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(TRANSFER_CHUNK_SIZE, 53));
+  const targetPath = "/tmp/inplace-link.bin";
+  const existingPayload = Buffer.from("keep-me");
+
+  const remoteFiles = new Map([[targetPath, Buffer.from(existingPayload)]]);
+  const eventLog = [];
+  let releaseOpen = null;
+  let endCalls = 0;
+  const sharedSftp = createFastSftp({
+    lstat(remotePath, callback) {
+      const key = String(remotePath);
+      if (key.includes(".netcatty-backup-") || key.includes(".netcatty-upload-")) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        callback(error);
+        return;
+      }
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        callback(error);
+        return;
+      }
+      callback(null, {
+        size: remoteFiles.get(key).length,
+        mode: 0o120777,
+        isDirectory: () => false,
+        isSymbolicLink: () => true,
+      });
+    },
+    open(remotePath, flags, callback) {
+      assert.equal(flags, "w");
+      const key = String(remotePath);
+      assert.equal(key, targetPath, "in-place upload must OPEN the final target");
+      releaseOpen = () => {
+        remoteFiles.set(key, Buffer.alloc(0));
+        eventLog.push(`open-created:${key}`);
+        callback(null, Buffer.from(`handle:${key}`));
+      };
+    },
+    write() {
+      throw new Error("WRITE must not run after cancel during OPEN");
+    },
+    close(_handle, callback) {
+      eventLog.push("close");
+      callback(null);
+    },
+    unlink(remotePath, callback) {
+      const key = String(remotePath);
+      eventLog.push(`unlink:${key}`);
+      remoteFiles.delete(key);
+      callback(null);
+    },
+    end() {
+      endCalls += 1;
+    },
+  });
+
+  const client = {
+    __netcattySudoMode: true,
+    sftp: sharedSftp,
+    async stat(remotePath) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        throw error;
+      }
+      return { size: remoteFiles.get(key).length };
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    async delete(remotePath) {
+      const key = String(remotePath);
+      eventLog.push(`delete:${key}`);
+      remoteFiles.delete(key);
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const sender = createSender();
+  const transferId = "upload-shared-inplace-open-cancel-nounlink";
+  const running = transferBridge.startTransfer(
+    { sender },
+    {
+      transferId,
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: TRANSFER_CHUNK_SIZE,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+
+  const ready = await waitUntil(() => typeof releaseOpen === "function", 2000);
+  assert.ok(ready, "expected shared in-place write OPEN to stall");
+
+  await transferBridge.cancelTransfer(null, { transferId });
+
+  const result = await Promise.race([
+    running,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("transfer hung after in-place cancel OPEN drain force-complete")), 5500);
+    }),
+  ]);
+  assert.match(result.error || "", /cancel/i);
+  assert.equal(endCalls, 0, "shared sudo channel must not be ended");
+
+  releaseOpen?.();
+  const lateClose = await waitUntil(() => eventLog.includes("close"), 2000);
+  assert.ok(lateClose, `expected late OPEN close, log=${eventLog.join(",")}`);
+  assert.equal(
+    eventLog.some((entry) => entry.startsWith("unlink:")),
+    false,
+    `in-place cancel must not unlink final target, log=${eventLog.join(",")}`,
+  );
+  assert.equal(
+    eventLog.some((entry) => entry === `delete:${targetPath}`),
+    false,
+    `in-place cancel must not delete final target, log=${eventLog.join(",")}`,
+  );
+  assert.ok(remoteFiles.has(targetPath), "final in-place target must still exist after cancel");
 });
 
 test("shared upload OPEN drain survives channel error before OPEN callback", async (t) => {

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -4328,6 +4328,96 @@ test("shared upload OPEN drain force-completes when cancel has no OPEN callback"
   assert.equal(sender.sent.some((entry) => entry.channel === "netcatty:transfer:complete"), false);
 });
 
+test("shared upload cancel settle does not hang when best-effort unlink never callbacks", async (t) => {
+  // Codex P2 on 3f0f4608: cancel + OPEN "w" waited for unlink before finishCancel.
+  // A dead shared channel that never invokes unlink left the transfer/lease active.
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-shared-upload-unlink-hang-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(TRANSFER_CHUNK_SIZE, 61));
+
+  let openCalls = 0;
+  let unlinkCalls = 0;
+  let endCalls = 0;
+  let openCallback = null;
+  const sharedSftp = createFastSftp({
+    open(_remotePath, flags, callback) {
+      assert.equal(flags, "w");
+      openCalls += 1;
+      openCallback = callback;
+    },
+    unlink(_remotePath, _callback) {
+      unlinkCalls += 1;
+      // Never invoke unlink callback (stalled shared channel).
+    },
+    write() {
+      throw new Error("WRITE must not run after cancel during OPEN");
+    },
+    close(_handle, callback) {
+      callback?.(null);
+    },
+    end() {
+      endCalls += 1;
+    },
+  });
+
+  const client = {
+    __netcattySudoMode: true,
+    sftp: sharedSftp,
+    stat() {
+      const error = new Error("ENOENT");
+      error.code = 2;
+      return Promise.reject(error);
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    async delete() {},
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const sender = createSender();
+  const transferId = "upload-shared-open-cancel-unlink-hang";
+  const running = transferBridge.startTransfer(
+    { sender },
+    {
+      transferId,
+      sourcePath: localPath,
+      targetPath: "/tmp/upload-cancel-unlink-hang.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: TRANSFER_CHUNK_SIZE,
+      resumable: true,
+      skipAdmission: true,
+    },
+  );
+
+  const ready = await waitUntil(() => openCalls >= 1 && openCallback, 2000);
+  assert.ok(ready, "expected shared write OPEN to stall with callback held");
+
+  await transferBridge.cancelTransfer(null, { transferId });
+  // OPEN returns after cancel — triggers close + best-effort unlink path.
+  openCallback(null, Buffer.from("handle:hang-unlink"));
+
+  const result = await Promise.race([
+    running,
+    new Promise((_, reject) => {
+      setTimeout(
+        () => reject(new Error("transfer hung awaiting best-effort unlink after cancel")),
+        5500,
+      );
+    }),
+  ]);
+
+  assert.match(result.error || "", /cancel/i);
+  assert.ok(unlinkCalls >= 1, "expected best-effort unlink after cancel OPEN");
+  assert.equal(endCalls, 0, "shared sudo channel must not be ended");
+});
+
 test("shared upload OPEN drain survives cancel settle timeout", async (t) => {
   // Codex P2 on af9cef2e / 0cda4a39 / cd57d960: cancel settle + drain
   // force-complete must not hang, and a late truncating OPEN on a generated

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -5111,10 +5111,13 @@ test("late shared OPEN unlink still cleans non-resumable stage under same-id ret
 });
 
 test("late shared OPEN unlink skips same-id retry resume stage", async (t) => {
-  // Codex P2 on d19ecb88: after OPEN drain force-complete, a late truncating
-  // "w" callback unlinked the generated stage unconditionally. Resumable
-  // retries reuse `.netcatty-<transferId>.part` via buildRemoteTransferStagePath,
-  // so a stale callback can delete the new attempt's stage/checkpoint.
+  // Codex P2 on d19ecb88 + P1 on 42a27ef7:
+  // - After drain force-complete, a late truncating "w" must not unlink a
+  //   same-id retry's deterministic resume stage.
+  // - Path gate serializes truncating OPENs on that path; if force-complete
+  //   already released the gate and the retry accepted its own OPEN, a late
+  //   stale OPEN that re-truncates must invalidate the retry rather than allow
+  //   a sparse promote.
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-shared-open-late-unlink-retry-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
@@ -5146,24 +5149,20 @@ test("late shared OPEN unlink skips same-id retry resume stage", async (t) => {
       if (generation === 1) {
         assert.equal(key, deterministicStagePath, "first attempt must OPEN deterministic resume stage");
         releaseFirstOpen = () => {
-          // Late callback only: do not re-truncate an already-owned retry stage.
-          // The regression under test is the client-side unlink after close, not
-          // a second remote OPEN "w" race (which the server already applied).
-          if (!remoteFiles.has(key)) {
-            remoteFiles.set(key, Buffer.alloc(0));
-          }
+          // Model a late server-side truncating OPEN: wipe whatever is at the
+          // path when the stale OPEN finally applies.
+          remoteFiles.set(key, Buffer.alloc(0));
           eventLog.push(`open-created-1:${key}`);
           callback(null, Buffer.from(`handle-1:${key}`));
         };
         return;
       }
-      // Retry: complete OPEN immediately so the new attempt owns the stage.
       remoteFiles.set(key, Buffer.from("retry-stage"));
       eventLog.push(`open-created-${generation}:${key}`);
       callback(null, Buffer.from(`handle-${generation}:${key}`));
     },
     write(handle, buffer, offset, length, position, callback) {
-      // Hold retry WRITEs until after the stale late OPEN ownership check.
+      // Hold retry WRITEs so the stale OPEN can land mid-attempt.
       void retryWritesReleased.then(() => {
         const key = String(handle).replace(/^handle-\d+:/, "");
         const current = remoteFiles.get(key) || Buffer.alloc(0);
@@ -5248,8 +5247,9 @@ test("late shared OPEN unlink skips same-id retry resume stage", async (t) => {
   assert.match(firstResult.error, /shared SFTP channel died before first OPEN callback/i);
   assert.equal(endCalls, 0, "shared sudo channel must not be ended");
 
-  // Same transfer id retry owns the deterministic resume stage before the
-  // stale OPEN callback from attempt 1 arrives.
+  // Same-id retry reuses the deterministic stage. Drain force-complete released
+  // the path gate so the retry can OPEN; hold its WRITEs until after the stale
+  // OPEN lands.
   transferBridge.clearPendingCancel(transferId);
   const retrySender = createSender();
   const retryRunning = transferBridge.startTransfer(
@@ -5271,14 +5271,14 @@ test("late shared OPEN unlink skips same-id retry resume stage", async (t) => {
     () => eventLog.some((entry) => entry.startsWith("open-created-2:")),
     3000,
   );
-  assert.ok(retryOpenReady, `expected retry OPEN, log=${eventLog.join(",")}`);
+  assert.ok(retryOpenReady, `expected retry OPEN after path gate force-release, log=${eventLog.join(",")}`);
   assert.ok(
-    remoteFiles.has(deterministicStagePath),
+    remoteFiles.get(deterministicStagePath)?.equals(Buffer.from("retry-stage")),
     "retry must own deterministic stage before stale late OPEN",
   );
-  const stageBeforeLateOpen = Buffer.from(remoteFiles.get(deterministicStagePath));
 
-  // Stale late OPEN from attempt 1: close only — must not unlink under retry.
+  // Stale late OPEN: server re-truncates the retry stage. Client must close
+  // without unlink, and must invalidate the accepted retry attempt.
   releaseFirstOpen?.();
   const lateClose = await waitUntil(
     () => eventLog.some((entry) => entry.startsWith("close:handle-1:")),
@@ -5292,26 +5292,205 @@ test("late shared OPEN unlink skips same-id retry resume stage", async (t) => {
   );
   assert.ok(
     remoteFiles.has(deterministicStagePath),
-    "retry stage must survive stale late OPEN unlink",
+    "retry stage path must survive stale late OPEN unlink",
   );
   assert.ok(
-    remoteFiles.get(deterministicStagePath).equals(stageBeforeLateOpen),
-    "retry stage bytes must not be removed by stale late OPEN unlink",
+    remoteFiles.get(deterministicStagePath).equals(Buffer.alloc(0)),
+    "stale truncating OPEN must have wiped retry stage bytes (server race)",
   );
 
-  // Let the retry finish (or cancel cleanly) so the test does not leak actives.
+  releaseRetryWrites?.();
+  const retryResult = await Promise.race([
+    retryRunning,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("retry transfer hung after stale OPEN invalidate")), 5000);
+    }),
+  ]);
+  assert.ok(
+    retryResult.cancelled === true
+      || retryResult.error
+      || /cancel|superseded|stale/i.test(String(retryResult.error || "")),
+    `expected retry to fail/cancel after stale OPEN truncated its stage, result=${JSON.stringify(retryResult)}`,
+  );
+  assert.equal(endCalls, 0, "shared sudo channel must not be ended");
+});
+
+test("truncating shared OPEN path gate serializes same-path retry until prior OPEN settles", async (t) => {
+  // Codex P1 on 42a27ef7: while attempt-1's truncating OPEN is still pending
+  // (no force-complete yet), a same-id retry must not issue OPEN "w" on the
+  // deterministic stage — wait for the prior gate.
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-shared-open-path-gate-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(TRANSFER_CHUNK_SIZE, 61));
+  const targetPath = "/tmp/upload-path-gate.bin";
+  const transferId = "upload-shared-open-path-gate";
+  const deterministicStagePath = `/tmp/.upload-path-gate.bin.netcatty-${transferId}.part`;
+
+  const remoteFiles = new Map();
+  const eventLog = [];
+  /** @type {null | (() => void)} */
+  let releaseFirstOpen = null;
+  let openGeneration = 0;
+  let endCalls = 0;
+  /** @type {null | (() => void)} */
+  let releaseRetryWrites = null;
+  const retryWritesReleased = new Promise((resolve) => {
+    releaseRetryWrites = resolve;
+  });
+  const sharedSftp = createFastSftp({
+    open(remotePath, flags, callback) {
+      assert.equal(flags, "w");
+      const key = String(remotePath);
+      openGeneration += 1;
+      const generation = openGeneration;
+      if (generation === 1) {
+        releaseFirstOpen = () => {
+          remoteFiles.set(key, Buffer.alloc(0));
+          eventLog.push(`open-created-1:${key}`);
+          callback(null, Buffer.from(`handle-1:${key}`));
+        };
+        return;
+      }
+      remoteFiles.set(key, Buffer.from("retry-after-gate"));
+      eventLog.push(`open-created-${generation}:${key}`);
+      callback(null, Buffer.from(`handle-${generation}:${key}`));
+    },
+    write(handle, buffer, offset, length, position, callback) {
+      void retryWritesReleased.then(() => {
+        const key = String(handle).replace(/^handle-\d+:/, "");
+        const current = remoteFiles.get(key) || Buffer.alloc(0);
+        const end = position + length;
+        const next = Buffer.alloc(Math.max(current.length, end));
+        current.copy(next);
+        buffer.copy(next, position, offset, offset + length);
+        remoteFiles.set(key, next);
+        setImmediate(() => callback(null));
+      });
+    },
+    close(handle, callback) {
+      eventLog.push(`close:${String(handle)}`);
+      callback(null);
+    },
+    unlink(remotePath, callback) {
+      eventLog.push(`unlink:${String(remotePath)}`);
+      remoteFiles.delete(String(remotePath));
+      callback(null);
+    },
+    end() {
+      endCalls += 1;
+    },
+  });
+
+  const client = {
+    __netcattySudoMode: true,
+    sftp: sharedSftp,
+    async stat(remotePath) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        throw error;
+      }
+      return { size: remoteFiles.get(key).length };
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    async delete(remotePath) {
+      remoteFiles.delete(String(remotePath));
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const firstSender = createSender();
+  // Do not emit channel error: keep OPEN pending without force-complete so the
+  // path gate stays held until the OPEN callback.
+  const firstRunning = transferBridge.startTransfer(
+    { sender: firstSender },
+    {
+      transferId,
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: TRANSFER_CHUNK_SIZE,
+      resumable: true,
+      skipAdmission: true,
+    },
+  );
+
+  const firstOpenReady = await waitUntil(() => typeof releaseFirstOpen === "function", 2000);
+  assert.ok(firstOpenReady, "expected first shared write OPEN to stall");
+
+  // Start same-id retry while first OPEN is still pending (gate held).
+  // Overwrite activeTransfers; first attempt is still awaiting OPEN.
+  transferBridge.clearPendingCancel(transferId);
+  const retrySender = createSender();
+  const retryRunning = transferBridge.startTransfer(
+    { sender: retrySender },
+    {
+      transferId,
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: TRANSFER_CHUNK_SIZE,
+      resumable: true,
+      skipAdmission: true,
+    },
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  assert.equal(
+    eventLog.some((entry) => entry.startsWith("open-created-2:")),
+    false,
+    `retry must wait on path gate while prior truncating OPEN is pending, log=${eventLog.join(",")}`,
+  );
+
+  // Settle first OPEN (cancel it via late path): release callback as success
+  // but first transfer may still be the waiter — force cancel first attempt.
+  await transferBridge.cancelTransfer(null, { transferId: `${transferId}-noop` }).catch(() => {});
+  // First attempt is no longer active (retry replaced it). Release OPEN.
+  releaseFirstOpen?.();
+  const lateClose = await waitUntil(
+    () => eventLog.some((entry) => entry.startsWith("close:handle-1:")),
+    2000,
+  );
+  assert.ok(lateClose, `expected first OPEN to close after gate release, log=${eventLog.join(",")}`);
+
+  const retryOpenReady = await waitUntil(
+    () => eventLog.some((entry) => entry.startsWith("open-created-2:")),
+    3000,
+  );
+  assert.ok(
+    retryOpenReady,
+    `expected retry OPEN after prior OPEN settled, log=${eventLog.join(",")}`,
+  );
+  assert.ok(
+    remoteFiles.get(deterministicStagePath)?.equals(Buffer.from("retry-after-gate")),
+    "retry stage must be written by retry OPEN after gate, not wiped by ordering race",
+  );
+
   releaseRetryWrites?.();
   await transferBridge.cancelTransfer(null, { transferId });
   const retryResult = await Promise.race([
     retryRunning,
     new Promise((_, reject) => {
-      setTimeout(() => reject(new Error("retry transfer hung after cancel")), 5000);
+      setTimeout(() => reject(new Error("retry hung after path-gate test")), 5000);
     }),
   ]);
   assert.ok(
     retryResult.cancelled === true || /cancel/i.test(String(retryResult.error || "")),
     `expected retry cancel settle, result=${JSON.stringify(retryResult)}`,
   );
+  // First attempt may still be pending cancel/error; do not leave it hanging.
+  void firstRunning.catch(() => {});
   assert.equal(endCalls, 0, "shared sudo channel must not be ended");
 });
 

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -5315,6 +5315,49 @@ test("late shared OPEN unlink skips same-id retry resume stage", async (t) => {
   assert.equal(endCalls, 0, "shared sudo channel must not be ended");
 });
 
+test("remoteOpenPathMatchesStaged compares logical and encoded OPEN paths", () => {
+  // Codex: filePath can be a session-encoded Buffer while stagedRemote.path is
+  // the logical string — strict === would fail and wrongly allow unlink of the
+  // retry-owned stage.
+  const match = transferBridge._remoteOpenPathMatchesStagedForTests;
+  assert.equal(typeof match, "function");
+  const logical = "/tmp/.upload.bin.netcatty-tid.part";
+  assert.equal(
+    match(logical, { path: logical, sftpId: null }),
+    true,
+    "identical logical strings match",
+  );
+  assert.equal(
+    match(Buffer.from(logical), { path: logical, sftpId: null }),
+    true,
+    "OPEN Buffer of logical path matches staged logical path",
+  );
+  assert.equal(
+    match(Buffer.from(logical), {
+      path: logical,
+      sftpId: "missing-session",
+      encoding: "utf-8",
+    }),
+    true,
+    "utf-8 encode of logical path still matches OPEN Buffer",
+  );
+  assert.equal(
+    match("/tmp/other.part", { path: logical, sftpId: null }),
+    false,
+    "different paths must not match",
+  );
+  assert.equal(
+    match(logical, null),
+    false,
+    "missing stagedRemote must not match",
+  );
+  assert.equal(
+    match(logical, { path: "" }),
+    false,
+    "empty staged path must not match",
+  );
+});
+
 test("late shared OPEN unlink still cleans stage when same-id retry is in-place", async (t) => {
   // Codex P2 on 39e20bfa: skip late unlink only when active.stagedRemote.path
   // matches. A same-id in-place retry (symlink destination → writeInPlace)

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -5337,9 +5337,10 @@ test("late shared OPEN unlink skips same-id retry resume stage", async (t) => {
   assert.match(firstResult.error, /shared SFTP channel died before first OPEN callback/i);
   assert.equal(endCalls, 0, "shared sudo channel must not be ended");
 
-  // Same-id retry reuses the deterministic stage. Drain force-complete released
-  // the path gate so the retry can OPEN; hold its WRITEs until after the stale
-  // OPEN lands.
+  // Same-id retry reuses the deterministic stage. Generated-stage drain
+  // force-complete holds the path gate for another 10s (2s + 10s) unless the
+  // stale OPEN settles first. Wait past that hold so the retry can OPEN while
+  // the first OPEN callback is still held for the late-truncation race below.
   transferBridge.clearPendingCancel(transferId);
   const retrySender = createSender();
   const retryRunning = transferBridge.startTransfer(
@@ -5359,7 +5360,7 @@ test("late shared OPEN unlink skips same-id retry resume stage", async (t) => {
 
   const retryOpenReady = await waitUntil(
     () => eventLog.some((entry) => entry.startsWith("open-created-2:")),
-    3000,
+    15000,
   );
   assert.ok(retryOpenReady, `expected retry OPEN after path gate force-release, log=${eventLog.join(",")}`);
   assert.ok(

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -4775,6 +4775,124 @@ test("shared upload OPEN drain force-completes when channel error has no OPEN ca
   assert.equal(sender.sent.some((entry) => entry.channel === "netcatty:transfer:complete"), false);
 });
 
+test("shared upload OPEN drain unlinks late staged OPEN after channel-error force-complete", async (t) => {
+  // Codex P2 on bd42c51c: late truncating OPEN after channel-error drain
+  // force-complete is not a cancel (`transfer.cancelled` false). Non-resumable
+  // staged uploads already cleaned the stage after the forced drain; the late
+  // "w" OPEN must still unlink the recreated `.netcatty-upload-*` orphan.
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-shared-upload-open-channel-error-late-unlink-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(TRANSFER_CHUNK_SIZE, 55));
+
+  const remoteFiles = new Map();
+  const eventLog = [];
+  let releaseOpen = null;
+  let endCalls = 0;
+  const sharedSftp = createFastSftp({
+    open(remotePath, flags, callback) {
+      assert.equal(flags, "w");
+      const key = String(remotePath);
+      releaseOpen = () => {
+        remoteFiles.set(key, Buffer.alloc(0));
+        eventLog.push(`open-created:${key}`);
+        callback(null, Buffer.from(`handle:${key}`));
+      };
+    },
+    write() {
+      throw new Error("WRITE must not run after channel error during OPEN");
+    },
+    close(_handle, callback) {
+      eventLog.push("close");
+      callback(null);
+    },
+    unlink(remotePath, callback) {
+      const key = String(remotePath);
+      eventLog.push(`unlink:${key}`);
+      remoteFiles.delete(key);
+      callback(null);
+    },
+    end() {
+      endCalls += 1;
+    },
+  });
+
+  const client = {
+    __netcattySudoMode: true,
+    sftp: sharedSftp,
+    async stat(remotePath) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        throw error;
+      }
+      return { size: remoteFiles.get(key).length };
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    async delete(remotePath) {
+      const key = String(remotePath);
+      eventLog.push(`delete:${key}`);
+      remoteFiles.delete(key);
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const sender = createSender();
+  const transferId = "upload-shared-open-channel-error-late-unlink";
+  const running = transferBridge.startTransfer(
+    { sender },
+    {
+      transferId,
+      sourcePath: localPath,
+      targetPath: "/tmp/upload-channel-error-late-unlink.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: TRANSFER_CHUNK_SIZE,
+      // Non-resumable → cleanupStage runs after failure (no preserve-on-error).
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+
+  const ready = await waitUntil(() => typeof releaseOpen === "function", 2000);
+  assert.ok(ready, "expected shared write OPEN to stall");
+
+  sharedSftp.emit("error", new Error("shared SFTP channel died before OPEN callback"));
+
+  const result = await Promise.race([
+    running,
+    new Promise((_, reject) => {
+      setTimeout(
+        () => reject(new Error("transfer hung awaiting shared write OPEN drain after channel error")),
+        5000,
+      );
+    }),
+  ]);
+  assert.ok(result.error, "expected transfer to fail after channel error");
+  assert.match(result.error, /shared SFTP channel died before OPEN callback/i);
+  assert.equal(endCalls, 0, "shared sudo channel must not be ended");
+
+  // Late OPEN after drain force-complete — must close + unlink generated stage.
+  releaseOpen?.();
+  const lateCleanup = await waitUntil(
+    () => eventLog.includes("close") && eventLog.some((entry) => entry.startsWith("unlink:")),
+    2000,
+  );
+  assert.ok(lateCleanup, `expected late OPEN close+unlink after channel error, log=${eventLog.join(",")}`);
+  assert.equal(
+    [...remoteFiles.keys()].some((key) => key.includes(".netcatty-upload-")),
+    false,
+    `expected no orphan staged upload, remaining=${[...remoteFiles.keys()].join(",")}`,
+  );
+});
+
 test("sudo SFTP downloads prefer concurrent shared READ over serial createReadStream", async (t) => {
   // Sudo cannot open an isolated channel, so downloads used to fall straight to
   // createReadStream (1-in-flight READs → hundreds of KB/s). Uploads already

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -4245,11 +4245,93 @@ test("cancel during stalled shared upload OPEN drains before remote cleanup", as
   );
 });
 
+test("shared upload OPEN drain force-completes when cancel has no OPEN callback", async (t) => {
+  // Codex P2 on cd57d960: cancel settle without force-complete left
+  // sharedWriteOpenDrain pending forever when OPEN never arrived and no
+  // channel error fired, hanging the transfer and SFTP lease.
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-shared-upload-open-cancel-no-callback-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(TRANSFER_CHUNK_SIZE, 51));
+
+  let endCalls = 0;
+  let openCalls = 0;
+  const sharedSftp = createFastSftp({
+    open(_remotePath, flags, _callback) {
+      assert.equal(flags, "w");
+      openCalls += 1;
+      // Never invoke the OPEN callback (stalled shared channel, no error).
+    },
+    write() {
+      throw new Error("WRITE must not run after cancel during OPEN");
+    },
+    close() {
+      throw new Error("CLOSE must not run without an OPEN handle");
+    },
+    end() {
+      endCalls += 1;
+    },
+  });
+
+  const client = {
+    __netcattySudoMode: true,
+    sftp: sharedSftp,
+    stat() {
+      const error = new Error("ENOENT");
+      error.code = 2;
+      return Promise.reject(error);
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    async delete() {},
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const sender = createSender();
+  const transferId = "upload-shared-open-cancel-no-callback";
+  const running = transferBridge.startTransfer(
+    { sender },
+    {
+      transferId,
+      sourcePath: localPath,
+      targetPath: "/tmp/upload-cancel-hang.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: TRANSFER_CHUNK_SIZE,
+      resumable: true,
+      skipAdmission: true,
+    },
+  );
+
+  const ready = await waitUntil(() => openCalls >= 1, 2000);
+  assert.ok(ready, "expected shared write OPEN to stall");
+
+  await transferBridge.cancelTransfer(null, { transferId });
+
+  const result = await Promise.race([
+    running,
+    new Promise((_, reject) => {
+      setTimeout(
+        () => reject(new Error("transfer hung awaiting shared write OPEN drain after cancel")),
+        5500,
+      );
+    }),
+  ]);
+
+  assert.match(result.error || "", /cancel/i);
+  assert.equal(endCalls, 0, "shared sudo channel must not be ended");
+  assert.equal(sender.sent.some((entry) => entry.channel === "netcatty:transfer:complete"), false);
+});
+
 test("shared upload OPEN drain survives cancel settle timeout", async (t) => {
-  // Codex P2 on af9cef2e / 0cda4a39: 2s settle timeout unblocks cancel UX, but
-  // cleanup must still wait for the OPEN callback (including past any channel-
-  // error drain force-complete window). Cancel must not arm drain force-
-  // complete — that would let stage delete race a late truncating OPEN.
+  // Codex P2 on af9cef2e / 0cda4a39 / cd57d960: cancel settle + drain
+  // force-complete must not hang, and a late truncating OPEN after that must
+  // close + unlink so stage cleanup cannot leave a recreate orphan.
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-shared-upload-open-drain-timeout-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
@@ -4277,6 +4359,12 @@ test("shared upload OPEN drain survives cancel settle timeout", async (t) => {
     },
     close(_handle, callback) {
       eventLog.push("close");
+      callback(null);
+    },
+    unlink(remotePath, callback) {
+      const key = String(remotePath);
+      eventLog.push(`unlink:${key}`);
+      remoteFiles.delete(key);
       callback(null);
     },
     end() {
@@ -4329,29 +4417,24 @@ test("shared upload OPEN drain survives cancel settle timeout", async (t) => {
 
   await transferBridge.cancelTransfer(null, { transferId });
 
-  // Past cancel settle (2s) and the channel-error drain force-complete window
-  // (another 2s). Cleanup must still be gated on the OPEN callback.
-  await new Promise((resolve) => setTimeout(resolve, 4500));
-  assert.ok(typeof releaseOpen === "function", "OPEN must still be pending after settle timeout");
-  assert.equal(eventLog.some((entry) => entry.startsWith("delete:")), false,
-    "cleanup must not run before late OPEN drain");
-
-  // Late OPEN after settle timeout — must close then delete, no orphan.
-  releaseOpen?.();
+  // Past cancel settle (2s) + drain force-complete (2s): transfer must settle
+  // without an OPEN callback so lease/admission cannot hang.
   const result = await Promise.race([
     running,
     new Promise((_, reject) => {
-      setTimeout(() => reject(new Error("transfer did not settle after late shared write OPEN")), 5000);
+      setTimeout(() => reject(new Error("transfer hung after cancel OPEN drain force-complete")), 5500);
     }),
   ]);
-
   assert.match(result.error || "", /cancel/i);
   assert.equal(endCalls, 0, "shared sudo channel must not be ended");
-  const closeIdx = eventLog.indexOf("close");
-  const deleteIdx = eventLog.findIndex((entry) => entry.startsWith("delete:"));
-  assert.ok(closeIdx >= 0, `expected CLOSE after late OPEN, log=${eventLog.join(",")}`);
-  assert.ok(deleteIdx >= 0, `expected stage delete after drain, log=${eventLog.join(",")}`);
-  assert.ok(closeIdx < deleteIdx, `CLOSE must precede cleanup delete, log=${eventLog.join(",")}`);
+
+  // Late OPEN after force-complete — must close + unlink, no orphan stage.
+  releaseOpen?.();
+  const lateCleanup = await waitUntil(
+    () => eventLog.includes("close") && eventLog.some((entry) => entry.startsWith("unlink:")),
+    2000,
+  );
+  assert.ok(lateCleanup, `expected late OPEN close+unlink, log=${eventLog.join(",")}`);
   assert.equal(
     [...remoteFiles.keys()].some((key) => key.includes(".netcatty-upload-")),
     false,

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -5315,6 +5315,236 @@ test("late shared OPEN unlink skips same-id retry resume stage", async (t) => {
   assert.equal(endCalls, 0, "shared sudo channel must not be ended");
 });
 
+test("late shared OPEN unlink still cleans stage when same-id retry is in-place", async (t) => {
+  // Codex P2 on 39e20bfa: skip late unlink only when active.stagedRemote.path
+  // matches. A same-id in-place retry (symlink destination → writeInPlace)
+  // keeps resumable + targetPath but stagedRemote is null; a stale late OPEN
+  // on the leftover `.netcatty-<id>.part` must still unlink the orphan.
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-shared-open-late-unlink-inplace-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const localPath = path.join(tempDir, "upload.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(TRANSFER_CHUNK_SIZE, 61));
+  const targetPath = "/tmp/upload-late-unlink-inplace.bin";
+  const transferId = "upload-shared-open-late-unlink-inplace";
+  const deterministicStagePath = `/tmp/.upload-late-unlink-inplace.bin.netcatty-${transferId}.part`;
+
+  const remoteFiles = new Map();
+  // After the first attempt fails, the destination appears as a symlink so the
+  // retry is planned in-place (no stagedRemote).
+  let destinationIsSymlink = false;
+  const eventLog = [];
+  /** @type {null | (() => void)} */
+  let releaseFirstOpen = null;
+  let openGeneration = 0;
+  let endCalls = 0;
+  /** @type {null | (() => void)} */
+  let releaseRetryWrites = null;
+  const retryWritesReleased = new Promise((resolve) => {
+    releaseRetryWrites = resolve;
+  });
+  const sharedSftp = createFastSftp({
+    lstat(remotePath, callback) {
+      const key = String(remotePath);
+      if (destinationIsSymlink && key === targetPath) {
+        callback(null, {
+          size: 0,
+          mode: 0o120777,
+          isDirectory: () => false,
+          isSymbolicLink: () => true,
+        });
+        return;
+      }
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        callback(error);
+        return;
+      }
+      callback(null, {
+        size: remoteFiles.get(key).length,
+        mode: 0o100644,
+        isDirectory: () => false,
+        isSymbolicLink: () => false,
+      });
+    },
+    open(remotePath, flags, callback) {
+      assert.equal(flags, "w");
+      const key = String(remotePath);
+      openGeneration += 1;
+      const generation = openGeneration;
+      if (generation === 1) {
+        assert.equal(key, deterministicStagePath, "first attempt must OPEN deterministic resume stage");
+        releaseFirstOpen = () => {
+          if (!remoteFiles.has(key)) {
+            remoteFiles.set(key, Buffer.alloc(0));
+          }
+          eventLog.push(`open-created-1:${key}`);
+          callback(null, Buffer.from(`handle-1:${key}`));
+        };
+        return;
+      }
+      // In-place retry opens the final target, not the stage.
+      assert.equal(key, targetPath, "in-place retry must OPEN final target");
+      remoteFiles.set(key, Buffer.from("retry-inplace"));
+      eventLog.push(`open-created-${generation}:${key}`);
+      callback(null, Buffer.from(`handle-${generation}:${key}`));
+    },
+    write(handle, buffer, offset, length, position, callback) {
+      void retryWritesReleased.then(() => {
+        const key = String(handle).replace(/^handle-\d+:/, "");
+        const current = remoteFiles.get(key) || Buffer.alloc(0);
+        const end = position + length;
+        const next = Buffer.alloc(Math.max(current.length, end));
+        current.copy(next);
+        buffer.copy(next, position, offset, offset + length);
+        remoteFiles.set(key, next);
+        eventLog.push(`write:${key}:${length}@${position}`);
+        setImmediate(() => callback(null));
+      });
+    },
+    close(handle, callback) {
+      eventLog.push(`close:${String(handle)}`);
+      callback(null);
+    },
+    unlink(remotePath, callback) {
+      const key = String(remotePath);
+      eventLog.push(`unlink:${key}`);
+      remoteFiles.delete(key);
+      callback(null);
+    },
+    end() {
+      endCalls += 1;
+    },
+  });
+
+  const client = {
+    __netcattySudoMode: true,
+    sftp: sharedSftp,
+    async stat(remotePath) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        throw error;
+      }
+      return { size: remoteFiles.get(key).length };
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    async delete(remotePath) {
+      const key = String(remotePath);
+      eventLog.push(`delete:${key}`);
+      remoteFiles.delete(key);
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const firstSender = createSender();
+  const firstRunning = transferBridge.startTransfer(
+    { sender: firstSender },
+    {
+      transferId,
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: TRANSFER_CHUNK_SIZE,
+      resumable: true,
+      skipAdmission: true,
+    },
+  );
+
+  const firstOpenReady = await waitUntil(() => typeof releaseFirstOpen === "function", 2000);
+  assert.ok(firstOpenReady, "expected first shared write OPEN to stall");
+
+  sharedSftp.emit("error", new Error("shared SFTP channel died before first OPEN callback"));
+
+  const firstResult = await Promise.race([
+    firstRunning,
+    new Promise((_, reject) => {
+      setTimeout(
+        () => reject(new Error("first transfer hung awaiting shared write OPEN drain after channel error")),
+        5000,
+      );
+    }),
+  ]);
+  assert.ok(firstResult.error, "expected first transfer to fail after channel error");
+  assert.match(firstResult.error, /shared SFTP channel died before first OPEN callback/i);
+
+  // Force the retry into writeInPlace (symlink) while still resumable.
+  destinationIsSymlink = true;
+  // Seed a leftover stage orphan the late OPEN would otherwise protect via
+  // resumable+targetPath heuristics.
+  remoteFiles.set(deterministicStagePath, Buffer.from("orphan-stage"));
+  transferBridge.clearPendingCancel(transferId);
+  const retrySender = createSender();
+  const retryRunning = transferBridge.startTransfer(
+    { sender: retrySender },
+    {
+      transferId,
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: TRANSFER_CHUNK_SIZE,
+      resumable: true,
+      skipAdmission: true,
+    },
+  );
+
+  const retryOpenReady = await waitUntil(
+    () => eventLog.some((entry) => entry.startsWith("open-created-2:")),
+    3000,
+  );
+  assert.ok(retryOpenReady, `expected in-place retry OPEN, log=${eventLog.join(",")}`);
+  assert.ok(
+    remoteFiles.has(deterministicStagePath),
+    "orphan stage must still exist before stale late OPEN",
+  );
+
+  // Stale late OPEN from attempt 1 on the stage path: must close + unlink even
+  // though a same-id resumable retry owns activeTransfers (in-place, no stage).
+  releaseFirstOpen?.();
+  const lateCleanup = await waitUntil(
+    () => eventLog.some((entry) => entry.startsWith("close:handle-1:"))
+      && eventLog.some((entry) => entry === `unlink:${deterministicStagePath}`),
+    2000,
+  );
+  assert.ok(
+    lateCleanup,
+    `expected late close+unlink of orphan stage under in-place retry, log=${eventLog.join(",")}`,
+  );
+  assert.equal(
+    remoteFiles.has(deterministicStagePath),
+    false,
+    "orphan stage must be unlinked when retry is not using it",
+  );
+  assert.ok(
+    remoteFiles.has(targetPath),
+    "in-place retry final target must not be unlinked",
+  );
+
+  releaseRetryWrites?.();
+  await transferBridge.cancelTransfer(null, { transferId });
+  const retryResult = await Promise.race([
+    retryRunning,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("retry transfer hung after cancel")), 5000);
+    }),
+  ]);
+  assert.ok(
+    retryResult.cancelled === true || /cancel/i.test(String(retryResult.error || "")),
+    `expected retry cancel settle, result=${JSON.stringify(retryResult)}`,
+  );
+  assert.equal(endCalls, 0, "shared sudo channel must not be ended");
+});
+
 test("sudo SFTP downloads prefer concurrent shared READ over serial createReadStream", async (t) => {
   // Sudo cannot open an isolated channel, so downloads used to fall straight to
   // createReadStream (1-in-flight READs → hundreds of KB/s). Uploads already

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -5385,13 +5385,14 @@ test("late shared OPEN unlink skips same-id retry resume stage", async (t) => {
       setTimeout(() => reject(new Error("retry transfer hung after prior OPEN settled")), 8000);
     }),
   ]);
-  // Retry should complete or fail cleanly — not hang on the path gate.
+  // Normal success is { transferId, totalBytes }; cancel/error also settle.
   assert.ok(
     retryResult
-    && (retryResult.success === true
+    && (
+      (retryResult.transferId && retryResult.error == null && retryResult.cancelled !== true)
       || retryResult.cancelled === true
       || retryResult.error
-      || retryResult.transferred != null),
+    ),
     `expected retry to settle after gate release, result=${JSON.stringify(retryResult)}`,
   );
   assert.equal(endCalls, 0, "shared sudo channel must not be ended");

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -4246,9 +4246,10 @@ test("cancel during stalled shared upload OPEN drains before remote cleanup", as
 });
 
 test("shared upload OPEN drain survives cancel settle timeout", async (t) => {
-  // Codex P2 on af9cef2e: 2s settle timeout unblocked cancel, but cleanup could
-  // still race a later truncating OPEN. sharedWriteOpenDrain must outlive the
-  // settle timeout so finally awaits close before stage delete.
+  // Codex P2 on af9cef2e / 0cda4a39: 2s settle timeout unblocks cancel UX, but
+  // cleanup must still wait for the OPEN callback (including past any channel-
+  // error drain force-complete window). Cancel must not arm drain force-
+  // complete — that would let stage delete race a late truncating OPEN.
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-shared-upload-open-drain-timeout-"));
   t.after(async () => {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
@@ -4328,8 +4329,9 @@ test("shared upload OPEN drain survives cancel settle timeout", async (t) => {
 
   await transferBridge.cancelTransfer(null, { transferId });
 
-  // Let the 2s OPEN cancel settle timeout fire while OPEN is still pending.
-  await new Promise((resolve) => setTimeout(resolve, 2100));
+  // Past cancel settle (2s) and the channel-error drain force-complete window
+  // (another 2s). Cleanup must still be gated on the OPEN callback.
+  await new Promise((resolve) => setTimeout(resolve, 4500));
   assert.ok(typeof releaseOpen === "function", "OPEN must still be pending after settle timeout");
   assert.equal(eventLog.some((entry) => entry.startsWith("delete:")), false,
     "cleanup must not run before late OPEN drain");


### PR DESCRIPTION
## Summary

Hardens SFTP upload write-OPEN handling so cancel, channel death, same-id retry, and strategy fallback cannot race a still-in-flight truncating `OPEN` into a sparse/corrupt stage or a wrong terminal result.

This PR grew from a narrow cancel-drain follow-up to #2720 into a write-path serialization patch set. Scope is intentional at merge time: one coherent race family (pending/late truncating OPEN), not unrelated feature work.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

- Related to #2720
- Residual follow-up: #2755 (fastPut wait on `pendingWriteOpenPathGate` cancelability)

## Changes Made

- **Path gate:** serialize write OPENs (shared and isolated, `w` / `r+`) by host+path (with session fallback); revalidate resume checkpoint after the gate; keep cancel/channel-error live during post-gate revalidation.
- **Late OPEN:** close late shared handles (read and write); unlink generated truncating stages only when safe; invalidate same-path live writers with host/session identity; hold the gate until OPEN/unlink settle rather than force-freeing into a late truncate.
- **Same-id supersede:** return `{ superseded: true }` without `result.error`; release only leases not held by the live owner; classify superseded before cancelled cleanup; directory/dedicated-resume/background-restart callers wait on the live owner's terminal status (no fixed timeout).
- **Callers:** pass host IDs through `startTransferNow` and background restart so path-gate keys stay host-scoped across session reopen; wait for pending write OPEN before non-resumable fastPut fallback.
- **Tests:** transferBridge coverage for drain, path gate, late unlink, and supersede-related settle paths.

## Screenshots / Demo

N/A (transfer bridge race safety).

## Testing

- [x] Focused `transferBridge` tests for shared/isolated OPEN drain, path gate, and late unlink paths
- [x] Linting / unit suite via CI `lint-and-test`
- [ ] Full package matrix (tracked by PR checks)

## Checklist

- [x] My code follows the existing project style
- [x] Residual Codex finding tracked as #2755 (not blocking merge)
- [x] No intentional public API break; internal transfer invoke may return `superseded: true`

## Known residual (not blocking)

Codex P2 on head `667e9115`: fastPut's await of `pendingWriteOpenPathGate` is not cancelable if the prior isolated OPEN never callbacks. Tracked in #2755.