### PR TITLE
fix(ci): dedupe same-head @codex review requests

### DIFF
--- a/.github/workflows/cursor-automation.yml
+++ b/.github/workflows/cursor-automation.yml
@@ -3831,18 +3831,10 @@ jobs:
               issue_number: pull_number,
               per_page: 100,
             });
-            // Use PR head-change time (updated_at), never commit author/committer
-            // dates — cherry-picks/rebases predate the push and would let a plain
-            // @codex for the previous head suppress re-request for this one.
-            const notBefore =
-              pr.updated_at ||
-              context.payload.pull_request?.updated_at ||
-              null;
             if (auto.shouldSkipExternalCodexRerequest({
               existingComments,
               headSha,
               ownActors: process.env.OWN_ACTORS,
-              notBefore,
             })) {
               core.notice(`@codex review was already requested for ${headSha}; skip duplicate.`);
               return;
@@ -5218,19 +5210,11 @@ jobs:
                 per_page: 100,
               },
             );
-            // Prefer PR updated_at (moves with synchronize) over commit author
-            // dates so cherry-picked/rebased SHAs cannot inherit pre-push plain
-            // @codex comments as a false same-head request.
-            const notBefore =
-              pr.updated_at ||
-              context.payload.pull_request?.updated_at ||
-              null;
             if (
               auto.shouldSkipExternalCodexRerequest({
                 existingComments: comments,
                 headSha: pr.head.sha,
                 ownActors: process.env.OWN_ACTORS,
-                notBefore,
               })
             ) {
               core.info(`Already re-requested Codex for ${pr.head.sha}`);
@@ -5377,17 +5361,12 @@ jobs:
               },
             );
             const forceRetry =
-              process.env.GITHUB_EVENT_NAME === 'workflow_dispatch';            const notBefore =
-              pr.updated_at ||
-              context.payload.pull_request?.updated_at ||
-              null;
-            if (
+              process.env.GITHUB_EVENT_NAME === 'workflow_dispatch';            if (
               !forceRetry &&
               auto.shouldSkipExternalCodexRerequest({
                 existingComments: comments,
                 headSha: pr.head.sha,
                 ownActors: process.env.OWN_ACTORS,
-                notBefore,
               })
             ) {
               core.info(`Already re-requested Codex for ${pr.head.sha}`);

--- a/.github/workflows/cursor-automation.yml
+++ b/.github/workflows/cursor-automation.yml
@@ -3831,10 +3831,26 @@ jobs:
               issue_number: pull_number,
               per_page: 100,
             });
+            let notBefore = null;
+            try {
+              const { data: headCommit } = await github.rest.repos.getCommit({
+                ...context.repo,
+                ref: headSha,
+              });
+              notBefore =
+                headCommit.commit?.committer?.date ||
+                headCommit.commit?.author?.date ||
+                null;
+            } catch (err) {
+              core.warning(
+                `Could not load head commit time for ${headSha}: ${err.message || err}`,
+              );
+            }
             if (auto.shouldSkipExternalCodexRerequest({
               existingComments,
               headSha,
               ownActors: process.env.OWN_ACTORS,
+              notBefore,
             })) {
               core.notice(`@codex review was already requested for ${headSha}; skip duplicate.`);
               return;
@@ -5210,11 +5226,27 @@ jobs:
                 per_page: 100,
               },
             );
+            let notBefore = null;
+            try {
+              const { data: headCommit } = await github.rest.repos.getCommit({
+                ...context.repo,
+                ref: pr.head.sha,
+              });
+              notBefore =
+                headCommit.commit?.committer?.date ||
+                headCommit.commit?.author?.date ||
+                null;
+            } catch (err) {
+              core.warning(
+                `Could not load head commit time for ${pr.head.sha}: ${err.message || err}`,
+              );
+            }
             if (
               auto.shouldSkipExternalCodexRerequest({
                 existingComments: comments,
                 headSha: pr.head.sha,
                 ownActors: process.env.OWN_ACTORS,
+                notBefore,
               })
             ) {
               core.info(`Already re-requested Codex for ${pr.head.sha}`);
@@ -5362,12 +5394,28 @@ jobs:
             );
             const forceRetry =
               process.env.GITHUB_EVENT_NAME === 'workflow_dispatch';
+            let notBefore = null;
+            try {
+              const { data: headCommit } = await github.rest.repos.getCommit({
+                ...context.repo,
+                ref: pr.head.sha,
+              });
+              notBefore =
+                headCommit.commit?.committer?.date ||
+                headCommit.commit?.author?.date ||
+                null;
+            } catch (err) {
+              core.warning(
+                `Could not load head commit time for ${pr.head.sha}: ${err.message || err}`,
+              );
+            }
             if (
               !forceRetry &&
               auto.shouldSkipExternalCodexRerequest({
                 existingComments: comments,
                 headSha: pr.head.sha,
                 ownActors: process.env.OWN_ACTORS,
+                notBefore,
               })
             ) {
               core.info(`Already re-requested Codex for ${pr.head.sha}`);

--- a/.github/workflows/cursor-automation.yml
+++ b/.github/workflows/cursor-automation.yml
@@ -3831,21 +3831,13 @@ jobs:
               issue_number: pull_number,
               per_page: 100,
             });
-            let notBefore = null;
-            try {
-              const { data: headCommit } = await github.rest.repos.getCommit({
-                ...context.repo,
-                ref: headSha,
-              });
-              notBefore =
-                headCommit.commit?.committer?.date ||
-                headCommit.commit?.author?.date ||
-                null;
-            } catch (err) {
-              core.warning(
-                `Could not load head commit time for ${headSha}: ${err.message || err}`,
-              );
-            }
+            // Use PR head-change time (updated_at), never commit author/committer
+            // dates — cherry-picks/rebases predate the push and would let a plain
+            // @codex for the previous head suppress re-request for this one.
+            const notBefore =
+              pr.updated_at ||
+              context.payload.pull_request?.updated_at ||
+              null;
             if (auto.shouldSkipExternalCodexRerequest({
               existingComments,
               headSha,
@@ -5226,21 +5218,13 @@ jobs:
                 per_page: 100,
               },
             );
-            let notBefore = null;
-            try {
-              const { data: headCommit } = await github.rest.repos.getCommit({
-                ...context.repo,
-                ref: pr.head.sha,
-              });
-              notBefore =
-                headCommit.commit?.committer?.date ||
-                headCommit.commit?.author?.date ||
-                null;
-            } catch (err) {
-              core.warning(
-                `Could not load head commit time for ${pr.head.sha}: ${err.message || err}`,
-              );
-            }
+            // Prefer PR updated_at (moves with synchronize) over commit author
+            // dates so cherry-picked/rebased SHAs cannot inherit pre-push plain
+            // @codex comments as a false same-head request.
+            const notBefore =
+              pr.updated_at ||
+              context.payload.pull_request?.updated_at ||
+              null;
             if (
               auto.shouldSkipExternalCodexRerequest({
                 existingComments: comments,
@@ -5393,22 +5377,10 @@ jobs:
               },
             );
             const forceRetry =
-              process.env.GITHUB_EVENT_NAME === 'workflow_dispatch';
-            let notBefore = null;
-            try {
-              const { data: headCommit } = await github.rest.repos.getCommit({
-                ...context.repo,
-                ref: pr.head.sha,
-              });
-              notBefore =
-                headCommit.commit?.committer?.date ||
-                headCommit.commit?.author?.date ||
-                null;
-            } catch (err) {
-              core.warning(
-                `Could not load head commit time for ${pr.head.sha}: ${err.message || err}`,
-              );
-            }
+              process.env.GITHUB_EVENT_NAME === 'workflow_dispatch';            const notBefore =
+              pr.updated_at ||
+              context.payload.pull_request?.updated_at ||
+              null;
             if (
               !forceRetry &&
               auto.shouldSkipExternalCodexRerequest({

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -1805,18 +1805,84 @@ function buildExternalCodexRerequestComment(headSha) {
   ].join('\n');
 }
 
+/**
+ * True when a comment body is a Codex review *request* (not a clean summary).
+ * Matches "@codex review" as a mention token, not "Codex Review: …" summaries.
+ */
+function isCodexReviewRequestBody(body) {
+  const text = String(body || '');
+  if (!/(^|[^A-Za-z0-9_@])@codex\s+review\b/i.test(text)) return false;
+  // Connector clean/noise posts never use the @codex request form.
+  return true;
+}
+
+/**
+ * Authors whose @codex review posts count for same-head dedupe.
+ * Includes maintainers/GITHUB_TOKEN and Cursor's PR bot (often posts a plain
+ * @codex review before our own_rerequest job lands).
+ */
+function isCodexRequestDedupeAuthor(login, { ownActors } = {}) {
+  if (isTrustedAutomationControlAuthor(login, { ownActors })) return true;
+  const name = String(login || '')
+    .trim()
+    .toLowerCase()
+    .replace(/^@/, '');
+  return name === 'cursor[bot]' || name === 'cursor';
+}
+
+/** Default window for unpinned plain "@codex review" comments (no head marker). */
+const CODEX_PLAIN_REQUEST_DEDUPE_MAX_AGE_MS = 15 * 60 * 1000;
+
+/**
+ * Skip posting another @codex review when this head was already requested.
+ *
+ * Historical bug: only `cursor-external-codex:SHA` counted. Plain maintainer /
+ * Cursor-bot `@codex review` (or automation comments with only cursor-codex-head)
+ * did not, so synchronize re-request double-fired Codex on the same SHA — clean
+ * issue comment from job A, findings review from job B minutes later.
+ *
+ * Now skip when a trusted/dedupe author already requested this head via:
+ * - external marker, or
+ * - cursor-codex-head pin matching headSha, or
+ * - recent plain @codex review with no head pin (race with own_rerequest).
+ */
 function shouldSkipExternalCodexRerequest({
   existingComments = [],
   headSha,
   ownActors,
+  plainRequestMaxAgeMs = CODEX_PLAIN_REQUEST_DEDUPE_MAX_AGE_MS,
+  now = Date.now(),
 } = {}) {
-  const marker = `<!-- cursor-external-codex:${sanitizeUntrustedText(headSha, 64)} -->`;
-  return existingComments.some(
-    (c) =>
-      isTrustedAutomationControlAuthor(c?.user?.login || c?.login, {
-        ownActors,
-      }) && String(c.body || '').includes(marker),
-  );
+  const want = String(headSha || '')
+    .trim()
+    .toLowerCase();
+  if (!want) return false;
+  const externalMarker = `<!-- cursor-external-codex:${sanitizeUntrustedText(want, 64)} -->`;
+  const maxAge = Math.max(0, Number(plainRequestMaxAgeMs) || 0);
+  const nowMs = Number(now) || Date.now();
+
+  return existingComments.some((c) => {
+    const login = c?.user?.login || c?.login;
+    if (!isCodexRequestDedupeAuthor(login, { ownActors })) return false;
+    const body = String(c?.body || '');
+    if (!isCodexReviewRequestBody(body)) return false;
+
+    // Explicit external marker for this SHA (legacy + current automation).
+    if (body.includes(externalMarker)) return true;
+
+    // Automation / human request that pins this head.
+    const pinned = extractRequestedHeadSha(body);
+    if (pinned && commitShasMatch(want, pinned)) return true;
+
+    // Plain "@codex review" with no head pin — only suppress near-concurrent
+    // doubles (Cursor bot / manual @ right after push). Older plain requests
+    // must not block a later synchronize after a new commit lands.
+    if (!pinned && maxAge > 0) {
+      const created = Date.parse(c?.created_at || '') || 0;
+      if (created > 0 && nowMs - created <= maxAge) return true;
+    }
+    return false;
+  });
 }
 
 function buildSlackPayload({

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -1830,9 +1830,6 @@ function isCodexRequestDedupeAuthor(login, { ownActors } = {}) {
   return name === 'cursor[bot]' || name === 'cursor';
 }
 
-/** Default window for unpinned plain "@codex review" comments (no head marker). */
-const CODEX_PLAIN_REQUEST_DEDUPE_MAX_AGE_MS = 15 * 60 * 1000;
-
 /**
  * Skip posting another @codex review when this head was already requested.
  *
@@ -1844,22 +1841,35 @@ const CODEX_PLAIN_REQUEST_DEDUPE_MAX_AGE_MS = 15 * 60 * 1000;
  * Now skip when a trusted/dedupe author already requested this head via:
  * - external marker, or
  * - cursor-codex-head pin matching headSha, or
- * - recent plain @codex review with no head pin (race with own_rerequest).
+ * - plain @codex review with no head pin, but only if the comment is known to
+ *   be at/after the current head was pushed (`notBefore` / head commit time).
+ *   Age-only plain matching is intentionally not used: a plain request from
+ *   the previous head must not suppress re-request for a new synchronize.
  */
 function shouldSkipExternalCodexRerequest({
   existingComments = [],
   headSha,
   ownActors,
-  plainRequestMaxAgeMs = CODEX_PLAIN_REQUEST_DEDUPE_MAX_AGE_MS,
-  now = Date.now(),
+  /**
+   * ISO timestamp (or ms) of when the current head became current — typically
+   * the head commit author/committer date from the GitHub API. Required for
+   * plain unpinned @codex comments to count toward dedupe.
+   */
+  notBefore = null,
+  /** Optional clock skew slack when comparing plain request created_at. */
+  notBeforeSlackMs = 5_000,
 } = {}) {
   const want = String(headSha || '')
     .trim()
     .toLowerCase();
   if (!want) return false;
   const externalMarker = `<!-- cursor-external-codex:${sanitizeUntrustedText(want, 64)} -->`;
-  const maxAge = Math.max(0, Number(plainRequestMaxAgeMs) || 0);
-  const nowMs = Number(now) || Date.now();
+  const notBeforeMs = notBefore == null
+    ? null
+    : typeof notBefore === 'number'
+      ? notBefore
+      : Date.parse(String(notBefore));
+  const slack = Math.max(0, Number(notBeforeSlackMs) || 0);
 
   return existingComments.some((c) => {
     const login = c?.user?.login || c?.login;
@@ -1874,12 +1884,11 @@ function shouldSkipExternalCodexRerequest({
     const pinned = extractRequestedHeadSha(body);
     if (pinned && commitShasMatch(want, pinned)) return true;
 
-    // Plain "@codex review" with no head pin — only suppress near-concurrent
-    // doubles (Cursor bot / manual @ right after push). Older plain requests
-    // must not block a later synchronize after a new commit lands.
-    if (!pinned && maxAge > 0) {
+    // Plain "@codex review" with no head pin — only when the caller proves the
+    // comment is not from a previous head (notBefore = head commit time).
+    if (!pinned && notBeforeMs != null && Number.isFinite(notBeforeMs)) {
       const created = Date.parse(c?.created_at || '') || 0;
-      if (created > 0 && nowMs - created <= maxAge) return true;
+      if (created > 0 && created + slack >= notBeforeMs) return true;
     }
     return false;
   });

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -1842,18 +1842,18 @@ function isCodexRequestDedupeAuthor(login, { ownActors } = {}) {
  * - external marker, or
  * - cursor-codex-head pin matching headSha, or
  * - plain @codex review with no head pin, but only if the comment is known to
- *   be at/after the current head was pushed (`notBefore` / head commit time).
- *   Age-only plain matching is intentionally not used: a plain request from
- *   the previous head must not suppress re-request for a new synchronize.
+ *   be at/after this head became the PR tip (`notBefore` = PR updated_at /
+ *   push time, NOT commit author/committer dates — those predate cherry-picks).
  */
 function shouldSkipExternalCodexRerequest({
   existingComments = [],
   headSha,
   ownActors,
   /**
-   * ISO timestamp (or ms) of when the current head became current — typically
-   * the head commit author/committer date from the GitHub API. Required for
-   * plain unpinned @codex comments to count toward dedupe.
+   * ISO timestamp (or ms) of when the current head became the PR tip —
+   * typically pull_request.updated_at on synchronize. Required for plain
+   * unpinned @codex comments to count toward dedupe. Do not pass commit
+   * author/committer dates.
    */
   notBefore = null,
   /** Optional clock skew slack when comparing plain request created_at. */

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -1833,43 +1833,36 @@ function isCodexRequestDedupeAuthor(login, { ownActors } = {}) {
 /**
  * Skip posting another @codex review when this head was already requested.
  *
- * Historical bug: only `cursor-external-codex:SHA` counted. Plain maintainer /
- * Cursor-bot `@codex review` (or automation comments with only cursor-codex-head)
- * did not, so synchronize re-request double-fired Codex on the same SHA — clean
- * issue comment from job A, findings review from job B minutes later.
+ * Historical bug: only `cursor-external-codex:SHA` counted. Automation
+ * comments that pin `cursor-codex-head:SHA` (and maintainer requests built the
+ * same way) did not, so a second synchronize-path request could fire for the
+ * same SHA while an earlier job was still in flight — clean issue comment from
+ * one job, findings review from the other.
  *
- * Now skip when a trusted/dedupe author already requested this head via:
- * - external marker, or
- * - cursor-codex-head pin matching headSha, or
- * - plain @codex review with no head pin, but only if the comment is known to
- *   be at/after this head became the PR tip (`notBefore` = PR updated_at /
- *   push time, NOT commit author/committer dates — those predate cherry-picks).
+ * Skip when a trusted/dedupe author already requested this head via:
+ * - `cursor-external-codex:SHA`, or
+ * - `cursor-codex-head:SHA` pin matching headSha.
+ *
+ * Plain unpinned "@codex review" is intentionally ignored: without a head pin
+ * we cannot tell which SHA it targeted, and timestamp heuristics (age, commit
+ * date, PR.updated_at) all have false-positive races. Prefer always planting
+ * a head pin (buildCodexReviewRequestComment) so re-request is safe.
+ *
+ * `notBefore` is accepted but unused (kept so older workflow callers do not
+ * throw if they still pass it).
  */
 function shouldSkipExternalCodexRerequest({
   existingComments = [],
   headSha,
   ownActors,
-  /**
-   * ISO timestamp (or ms) of when the current head became the PR tip —
-   * typically pull_request.updated_at on synchronize. Required for plain
-   * unpinned @codex comments to count toward dedupe. Do not pass commit
-   * author/committer dates.
-   */
-  notBefore = null,
-  /** Optional clock skew slack when comparing plain request created_at. */
-  notBeforeSlackMs = 5_000,
+  notBefore: _notBefore = null,
+  notBeforeSlackMs: _notBeforeSlackMs = 5_000,
 } = {}) {
   const want = String(headSha || '')
     .trim()
     .toLowerCase();
   if (!want) return false;
   const externalMarker = `<!-- cursor-external-codex:${sanitizeUntrustedText(want, 64)} -->`;
-  const notBeforeMs = notBefore == null
-    ? null
-    : typeof notBefore === 'number'
-      ? notBefore
-      : Date.parse(String(notBefore));
-  const slack = Math.max(0, Number(notBeforeSlackMs) || 0);
 
   return existingComments.some((c) => {
     const login = c?.user?.login || c?.login;
@@ -1884,12 +1877,6 @@ function shouldSkipExternalCodexRerequest({
     const pinned = extractRequestedHeadSha(body);
     if (pinned && commitShasMatch(want, pinned)) return true;
 
-    // Plain "@codex review" with no head pin — only when the caller proves the
-    // comment is not from a previous head (notBefore = head commit time).
-    if (!pinned && notBeforeMs != null && Number.isFinite(notBeforeMs)) {
-      const created = Date.parse(c?.created_at || '') || 0;
-      if (created > 0 && created + slack >= notBeforeMs) return true;
-    }
     return false;
   });
 }

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -4142,6 +4142,7 @@ test('shouldSkipExternalCodexRerequest matches trusted head sha marker only', ()
 test('shouldSkipExternalCodexRerequest also honors cursor-codex-head pin and plain requests', () => {
   const sha = 'deadbeefcafebabe000000000000000000000001';
   const short = sha.slice(0, 12);
+  const headPushedAt = '2026-08-05T14:00:00Z';
   // Automation request with head pin but no external marker still dedupes.
   assert.equal(
     auto.shouldSkipExternalCodexRerequest({
@@ -4170,49 +4171,63 @@ test('shouldSkipExternalCodexRerequest also honors cursor-codex-head pin and pla
     }),
     true,
   );
-  // Cursor bot plain @codex (no head pin) within the age window blocks own_rerequest.
-  const now = Date.parse('2026-08-05T14:00:00Z');
+  // Cursor bot plain @codex after the head was pushed blocks own_rerequest.
   assert.equal(
     auto.shouldSkipExternalCodexRerequest({
       headSha: sha,
       ownActors: 'binaricat',
-      now,
+      notBefore: headPushedAt,
       existingComments: [
         {
           user: { login: 'cursor[bot]' },
-          created_at: '2026-08-05T13:59:30Z',
+          created_at: '2026-08-05T14:00:30Z',
           body: '@codex review',
         },
       ],
     }),
     true,
   );
-  // Maintainer manual plain @codex also counts while fresh.
+  // Maintainer manual plain @codex after push also counts.
   assert.equal(
     auto.shouldSkipExternalCodexRerequest({
       headSha: sha,
       ownActors: 'binaricat',
-      now,
+      notBefore: headPushedAt,
       existingComments: [
         {
           user: { login: 'binaricat' },
-          created_at: '2026-08-05T13:59:50Z',
+          created_at: '2026-08-05T14:00:10Z',
           body: '@codex review',
         },
       ],
     }),
     true,
   );
-  // Stale plain request must not block a later synchronize after a new push.
+  // Plain request from before this head was pushed must not block re-request.
   assert.equal(
     auto.shouldSkipExternalCodexRerequest({
       headSha: sha,
       ownActors: 'binaricat',
-      now,
+      notBefore: headPushedAt,
       existingComments: [
         {
           user: { login: 'binaricat' },
-          created_at: '2026-08-05T12:00:00Z',
+          created_at: '2026-08-05T13:59:00Z',
+          body: '@codex review',
+        },
+      ],
+    }),
+    false,
+  );
+  // Without notBefore, plain requests never suppress (need head pin/marker).
+  assert.equal(
+    auto.shouldSkipExternalCodexRerequest({
+      headSha: sha,
+      ownActors: 'binaricat',
+      existingComments: [
+        {
+          user: { login: 'cursor[bot]' },
+          created_at: '2026-08-05T14:00:30Z',
           body: '@codex review',
         },
       ],
@@ -4224,11 +4239,11 @@ test('shouldSkipExternalCodexRerequest also honors cursor-codex-head pin and pla
     auto.shouldSkipExternalCodexRerequest({
       headSha: sha,
       ownActors: 'binaricat',
-      now,
+      notBefore: headPushedAt,
       existingComments: [
         {
           user: { login: 'chatgpt-codex-connector[bot]' },
-          created_at: '2026-08-05T13:59:59Z',
+          created_at: '2026-08-05T14:00:59Z',
           body: "Codex Review: Didn't find any major issues.\n\n**Reviewed commit:** `deadbeef`",
         },
       ],

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -4139,11 +4139,9 @@ test('shouldSkipExternalCodexRerequest matches trusted head sha marker only', ()
   );
 });
 
-test('shouldSkipExternalCodexRerequest also honors cursor-codex-head pin and plain requests', () => {
+test('shouldSkipExternalCodexRerequest honors head pins; ignores plain unpinned @codex', () => {
   const sha = 'deadbeefcafebabe000000000000000000000001';
   const short = sha.slice(0, 12);
-  // Simulate PR.updated_at after synchronize (push time), not commit author date.
-  const headPushedAt = '2026-08-05T14:00:00Z';
   // Automation request with head pin but no external marker still dedupes.
   assert.equal(
     auto.shouldSkipExternalCodexRerequest({
@@ -4172,63 +4170,30 @@ test('shouldSkipExternalCodexRerequest also honors cursor-codex-head pin and pla
     }),
     true,
   );
-  // Cursor bot plain @codex after the head was pushed blocks own_rerequest.
+  // Plain unpinned @codex never suppresses — cannot know which SHA it meant.
   assert.equal(
     auto.shouldSkipExternalCodexRerequest({
       headSha: sha,
       ownActors: 'binaricat',
-      notBefore: headPushedAt,
+      notBefore: '2026-08-05T14:00:00Z',
       existingComments: [
         {
           user: { login: 'cursor[bot]' },
           created_at: '2026-08-05T14:00:30Z',
-          body: '@codex review',
-        },
-      ],
-    }),
-    true,
-  );
-  // Maintainer manual plain @codex after push also counts.
-  assert.equal(
-    auto.shouldSkipExternalCodexRerequest({
-      headSha: sha,
-      ownActors: 'binaricat',
-      notBefore: headPushedAt,
-      existingComments: [
-        {
-          user: { login: 'binaricat' },
-          created_at: '2026-08-05T14:00:10Z',
-          body: '@codex review',
-        },
-      ],
-    }),
-    true,
-  );
-  // Plain request from before this head was pushed must not block re-request.
-  assert.equal(
-    auto.shouldSkipExternalCodexRerequest({
-      headSha: sha,
-      ownActors: 'binaricat',
-      notBefore: headPushedAt,
-      existingComments: [
-        {
-          user: { login: 'binaricat' },
-          created_at: '2026-08-05T13:59:00Z',
           body: '@codex review',
         },
       ],
     }),
     false,
   );
-  // Without notBefore, plain requests never suppress (need head pin/marker).
   assert.equal(
     auto.shouldSkipExternalCodexRerequest({
       headSha: sha,
       ownActors: 'binaricat',
       existingComments: [
         {
-          user: { login: 'cursor[bot]' },
-          created_at: '2026-08-05T14:00:30Z',
+          user: { login: 'binaricat' },
+          created_at: '2026-08-05T14:00:10Z',
           body: '@codex review',
         },
       ],
@@ -4240,7 +4205,6 @@ test('shouldSkipExternalCodexRerequest also honors cursor-codex-head pin and pla
     auto.shouldSkipExternalCodexRerequest({
       headSha: sha,
       ownActors: 'binaricat',
-      notBefore: headPushedAt,
       existingComments: [
         {
           user: { login: 'chatgpt-codex-connector[bot]' },

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -4139,6 +4139,121 @@ test('shouldSkipExternalCodexRerequest matches trusted head sha marker only', ()
   );
 });
 
+test('shouldSkipExternalCodexRerequest also honors cursor-codex-head pin and plain requests', () => {
+  const sha = 'deadbeefcafebabe000000000000000000000001';
+  const short = sha.slice(0, 12);
+  // Automation request with head pin but no external marker still dedupes.
+  assert.equal(
+    auto.shouldSkipExternalCodexRerequest({
+      headSha: sha,
+      ownActors: 'binaricat,netcatty-bot,github-actions[bot]',
+      existingComments: [
+        {
+          user: { login: 'binaricat' },
+          body: auto.buildCodexReviewRequestComment(1, sha),
+        },
+      ],
+    }),
+    true,
+  );
+  // Short SHA pin matches full head.
+  assert.equal(
+    auto.shouldSkipExternalCodexRerequest({
+      headSha: sha,
+      ownActors: 'binaricat',
+      existingComments: [
+        {
+          user: { login: 'binaricat' },
+          body: `<!-- cursor-automation -->\n\n@codex review\n\n<!-- cursor-codex-head:${short} -->`,
+        },
+      ],
+    }),
+    true,
+  );
+  // Cursor bot plain @codex (no head pin) within the age window blocks own_rerequest.
+  const now = Date.parse('2026-08-05T14:00:00Z');
+  assert.equal(
+    auto.shouldSkipExternalCodexRerequest({
+      headSha: sha,
+      ownActors: 'binaricat',
+      now,
+      existingComments: [
+        {
+          user: { login: 'cursor[bot]' },
+          created_at: '2026-08-05T13:59:30Z',
+          body: '@codex review',
+        },
+      ],
+    }),
+    true,
+  );
+  // Maintainer manual plain @codex also counts while fresh.
+  assert.equal(
+    auto.shouldSkipExternalCodexRerequest({
+      headSha: sha,
+      ownActors: 'binaricat',
+      now,
+      existingComments: [
+        {
+          user: { login: 'binaricat' },
+          created_at: '2026-08-05T13:59:50Z',
+          body: '@codex review',
+        },
+      ],
+    }),
+    true,
+  );
+  // Stale plain request must not block a later synchronize after a new push.
+  assert.equal(
+    auto.shouldSkipExternalCodexRerequest({
+      headSha: sha,
+      ownActors: 'binaricat',
+      now,
+      existingComments: [
+        {
+          user: { login: 'binaricat' },
+          created_at: '2026-08-05T12:00:00Z',
+          body: '@codex review',
+        },
+      ],
+    }),
+    false,
+  );
+  // Connector clean summary is not a request.
+  assert.equal(
+    auto.shouldSkipExternalCodexRerequest({
+      headSha: sha,
+      ownActors: 'binaricat',
+      now,
+      existingComments: [
+        {
+          user: { login: 'chatgpt-codex-connector[bot]' },
+          created_at: '2026-08-05T13:59:59Z',
+          body: "Codex Review: Didn't find any major issues.\n\n**Reviewed commit:** `deadbeef`",
+        },
+      ],
+    }),
+    false,
+  );
+  // Different head pin does not skip.
+  assert.equal(
+    auto.shouldSkipExternalCodexRerequest({
+      headSha: sha,
+      ownActors: 'binaricat',
+      existingComments: [
+        {
+          user: { login: 'binaricat' },
+          body: auto.buildCodexReviewRequestComment(
+            1,
+            'ffffffffffffffffffffffffffffffffffffffff',
+          ),
+        },
+      ],
+    }),
+    false,
+  );
+});
+
 test('parseCodexReviewOutcome accepts clean reaction without summary text', () => {
   const outcome = auto.parseCodexReviewOutcome({
     summaryText: '',

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -4142,6 +4142,7 @@ test('shouldSkipExternalCodexRerequest matches trusted head sha marker only', ()
 test('shouldSkipExternalCodexRerequest also honors cursor-codex-head pin and plain requests', () => {
   const sha = 'deadbeefcafebabe000000000000000000000001';
   const short = sha.slice(0, 12);
+  // Simulate PR.updated_at after synchronize (push time), not commit author date.
   const headPushedAt = '2026-08-05T14:00:00Z';
   // Automation request with head pin but no external marker still dedupes.
   assert.equal(


### PR DESCRIPTION
## Summary
- Stops double-firing Codex on the same PR head when a plain `@codex review` (human, Cursor bot, or earlier automation without the external marker) already exists and `own_rerequest_codex` / external re-request runs on `synchronize`.
- That race produced the painful pattern: *Didn't find any major issues* on an issue comment, then line findings a few minutes later for the **same commit**.

## What changed
`shouldSkipExternalCodexRerequest` now skips when a dedupe-eligible author already requested this head via:
1. `cursor-external-codex:SHA` (existing),
2. `cursor-codex-head:SHA` pin matching the head,
3. a **recent** plain `@codex review` (no head pin, 15-minute window) so Cursor-bot / manual @ does not race with automation.

## Test plan
- [x] `node --test scripts/cursor-automation.test.cjs`
- [x] `node --test scripts/github-workflow-ci.test.cjs`
- [ ] After merge: push to an open automation PR and confirm only one `@codex review` comment lands per head