### PR TITLE
fix(sftp): make fastPut pending OPEN gate wait cancelable

### DIFF
--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -336,15 +336,32 @@ function remoteOpenPathMatchesStaged(openPath, stagedRemote) {
  * if the stale OPEN lands after the retry has begun writing, the server
  * truncates the retry stage and a later size check can promote sparse data
  * (Codex P1 on 42a27ef7). Wait for any prior OPEN on the path to settle before
- * issuing another truncating OPEN; release on OPEN callback and on drain
- * force-complete so a dead channel cannot block retries forever.
+ * issuing another truncating OPEN; release on OPEN callback so a late truncating
+ * OPEN cannot race a retry. When an OPEN dies without a callback, fail() poisons
+ * the entry so later waiters reject promptly (fail-closed) instead of hanging
+ * forever on waitForPrior (#2755 / Codex P2 on dca41093).
  *
- * @type {Map<string, { promise: Promise<void>, resolve: () => void, released: boolean }>}
+ * @type {Map<string, {
+ *   promise: Promise<void>,
+ *   resolve: () => void,
+ *   reject: (err: Error) => void,
+ *   released: boolean,
+ *   failed: boolean,
+ *   failError: Error | null,
+ * }>}
  */
 const truncatingSharedWriteOpenGates = new Map();
 /** @type {WeakMap<object, string>} */
 const truncatingSharedWriteSftpKeys = new WeakMap();
 let truncatingSharedWriteSftpSeq = 0;
+
+function createPoisonedWriteOpenPathGateError(message) {
+  const err = new Error(
+    message || "Prior write OPEN never settled; path gate is fail-closed",
+  );
+  err.noTransferFallback = true;
+  return err;
+}
 
 function sharedWriteOpenPathKey(filePath) {
   if (Buffer.isBuffer(filePath)) return `b:${filePath.toString("hex")}`;
@@ -387,25 +404,47 @@ function sharedWriteOpenSessionKey(sftp, transfer) {
 /**
  * @param {string | Buffer} filePath
  * @param {string} [sessionKey]
- * @returns {{ waitForPrior: Promise<void>, release: () => void }}
+ * @returns {{ waitForPrior: Promise<void>, release: () => void, fail: (err?: Error) => void }}
  */
 function beginTruncatingSharedWriteOpen(filePath, sessionKey = "unknown") {
   const key = `${sessionKey}|${sharedWriteOpenPathKey(filePath)}`;
   const prior = truncatingSharedWriteOpenGates.get(key);
+
+  // Poisoned prior: keep the fail-closed barrier. Do not replace the map entry
+  // with a fresh waiter that could release and let a later OPEN race a still-
+  // pending truncate. New callers fail promptly on waitForPrior.
+  if (prior?.failed) {
+    const err = prior.failError || createPoisonedWriteOpenPathGateError();
+    return {
+      waitForPrior: Promise.reject(err),
+      release: () => {},
+      fail: () => {},
+    };
+  }
+
   const waitForPrior = prior && !prior.released
     ? prior.promise
     : Promise.resolve();
 
   let resolve;
-  const promise = new Promise((r) => {
-    resolve = r;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
   });
+  // Avoid unhandledRejection when nobody awaits yet (fail before waiters attach).
+  promise.catch(() => {});
   const entry = {
     promise,
     resolve: () => {
       resolve();
     },
+    reject: (err) => {
+      reject(err);
+    },
     released: false,
+    failed: false,
+    failError: null,
   };
   truncatingSharedWriteOpenGates.set(key, entry);
 
@@ -415,10 +454,25 @@ function beginTruncatingSharedWriteOpen(filePath, sessionKey = "unknown") {
     if (truncatingSharedWriteOpenGates.get(key) === entry) {
       truncatingSharedWriteOpenGates.delete(key);
     }
+    // Already failed: promise rejected; just drop the barrier once OPEN settled.
+    if (entry.failed) return;
     entry.resolve();
   };
 
-  return { waitForPrior, release };
+  const fail = (error) => {
+    if (entry.released || entry.failed) return;
+    const err = error instanceof Error
+      ? error
+      : createPoisonedWriteOpenPathGateError(String(error?.message || error || ""));
+    if (!err.noTransferFallback) err.noTransferFallback = true;
+    entry.failed = true;
+    entry.failError = err;
+    // Keep entry in the map so later beginTruncatingSharedWriteOpen sees failed
+    // and rejects promptly without clearing the fail-closed barrier.
+    entry.reject(err);
+  };
+
+  return { waitForPrior, release, fail };
 }
 
 /**
@@ -1970,11 +2024,20 @@ async function uploadFile(
             };
             const timer = setTimeout(() => {
               // Fail closed: do not fall through to another writer on the
-              // same stage while a truncating OPEN may still land.
+              // same stage while a truncating OPEN may still land. Poison the
+              // shared path gate so a later same-path upload fails promptly
+              // instead of awaiting the unresolved entry forever (Codex P2).
               const err = new Error(
                 "Timed out waiting for prior write OPEN to settle before fastPut",
               );
               err.noTransferFallback = true;
+              try {
+                transfer._failPendingWriteOpenPathGate?.(
+                  createPoisonedWriteOpenPathGateError(
+                    "Prior write OPEN never settled; path gate is fail-closed",
+                  ),
+                );
+              } catch { /* ignore */ }
               finish(reject, err);
             }, 2000);
             const onAbort = () => {
@@ -2189,7 +2252,9 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     : null;
   // Expose a promise that resolves when this OPEN's path gate is released so
   // same-transfer fallbacks (fastPut) can wait instead of racing a still-
-  // pending truncating OPEN (Codex P1 on 7872a304).
+  // pending truncating OPEN (Codex P1 on 7872a304). Also expose fail so a
+  // fail-closed fastPut timeout can poison the shared path gate for later
+  // same-path waiters (Codex P2 on dca41093).
   if (pathGate && transfer && typeof transfer === "object") {
     let resolvePathGate;
     const pending = new Promise((resolve) => { resolvePathGate = resolve; });
@@ -2200,6 +2265,10 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
         transfer.pendingWriteOpenPathGate = null;
       }
       transfer._resolvePendingWriteOpenPathGate = null;
+      transfer._failPendingWriteOpenPathGate = null;
+    };
+    transfer._failPendingWriteOpenPathGate = (error) => {
+      try { pathGate.fail?.(error); } catch { /* ignore */ }
     };
   }
   // Re-check ownership at unlink time: a same-id retry may already own
@@ -2721,7 +2790,16 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       });
     };
 
-    pathGate.waitForPrior.then(startOpen, startOpen);
+    pathGate.waitForPrior.then(
+      startOpen,
+      (err) => {
+        const error = err instanceof Error
+          ? err
+          : createPoisonedWriteOpenPathGateError(String(err?.message || err || ""));
+        if (!error.noTransferFallback) error.noTransferFallback = true;
+        abandonGateWait(error);
+      },
+    );
   });
 }
 

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -404,7 +404,13 @@ function sharedWriteOpenSessionKey(sftp, transfer) {
 /**
  * @param {string | Buffer} filePath
  * @param {string} [sessionKey]
- * @returns {{ waitForPrior: Promise<void>, release: () => void, fail: (err?: Error) => void }}
+ * @returns {{
+ *   waitForPrior: Promise<void>,
+ *   release: () => void,
+ *   fail: (err?: Error, options?: { reinstall?: boolean }) => void,
+ *   markOpenIssued: () => void,
+ *   releaseAfterTransportGone: () => void,
+ * }}
  */
 function beginTruncatingSharedWriteOpen(filePath, sessionKey = "unknown") {
   const key = `${sessionKey}|${sharedWriteOpenPathKey(filePath)}`;
@@ -419,6 +425,8 @@ function beginTruncatingSharedWriteOpen(filePath, sessionKey = "unknown") {
       waitForPrior: Promise.reject(err),
       release: () => {},
       fail: () => {},
+      markOpenIssued: () => {},
+      releaseAfterTransportGone: () => {},
     };
   }
 
@@ -445,8 +453,13 @@ function beginTruncatingSharedWriteOpen(filePath, sessionKey = "unknown") {
     released: false,
     failed: false,
     failError: null,
+    // True once this entry has started the remote OPEN. Waiters that only
+    // block on a prior must not act as the OPEN owner for poison cleanup.
+    openIssued: false,
+    priorEntry: prior && !prior.released ? prior : null,
     transportGone: false,
     transportGoneTimer: null,
+    releaseAfterTransportGone: null,
   };
   truncatingSharedWriteOpenGates.set(key, entry);
 
@@ -480,17 +493,21 @@ function beginTruncatingSharedWriteOpen(filePath, sessionKey = "unknown") {
       release();
     }, 2000);
   };
+  entry.releaseAfterTransportGone = releaseAfterTransportGone;
+
+  const markOpenIssued = () => {
+    entry.openIssued = true;
+  };
 
   /**
    * @param {Error} [error]
    * @param {{ reinstall?: boolean }} [options]
-   *   reinstall — when true (default), make this entry the durable map barrier.
-   *   Successor waiters that only propagate a prior poison must pass false so
-   *   they cannot steal the slot from the OPEN owner; otherwise a later
-   *   owner release cannot clear the barrier (Codex P2 on 64450bfd).
+   *   reinstall — when true (default), make the OPEN-owning entry the durable
+   *   map barrier. Successor waiters that only propagate a prior poison must
+   *   pass false so they cannot steal the slot (Codex P2 on 64450bfd).
    */
   const fail = (error, options = {}) => {
-    const reinstall = options.reinstall !== false;
+    const wantReinstall = options.reinstall !== false;
     const err = error instanceof Error
       ? error
       : createPoisonedWriteOpenPathGateError(String(error?.message || error || ""));
@@ -512,21 +529,34 @@ function beginTruncatingSharedWriteOpen(filePath, sessionKey = "unknown") {
       current.reject(err);
     }
 
-    // Reinstall this poisoned entry as the durable fail-closed barrier even if
-    // a successor replaced us. Successor-propagated fail must not steal the
-    // slot from the OPEN owner (Codex P2 on 64450bfd).
-    if (reinstall && !entry.released) {
-      truncatingSharedWriteOpenGates.set(key, entry);
-      // Owner poison is raised from the isolated fastPut fallback after
-      // uploadFileConcurrent already ended that channel. Arm the post-close
-      // clear here instead of installing end/close listeners on every write
-      // OPEN (shared channels would accumulate listeners until teardown —
-      // Codex P2 on fe92b22c).
-      releaseAfterTransportGone();
+    if (!wantReinstall || entry.released) return;
+
+    // Prefer the OPEN-owning ancestor as the durable barrier. A waiter that
+    // reaches fastPut timeout must not reinstall itself and arm transport
+    // cleanup while the prior OPEN's channel may still deliver a late truncate
+    // (Codex P1 on 251bf9ec).
+    let barrier = entry;
+    if (!entry.openIssued) {
+      let cursor = entry.priorEntry;
+      while (cursor && !cursor.released) {
+        barrier = cursor;
+        if (cursor.openIssued || !cursor.priorEntry || cursor.priorEntry.released) break;
+        cursor = cursor.priorEntry;
+      }
+      if (!barrier.failed) {
+        barrier.failed = true;
+        barrier.failError = err;
+        try { barrier.reject(err); } catch { /* ignore */ }
+      }
+    }
+    truncatingSharedWriteOpenGates.set(key, barrier);
+    // Only the OPEN owner arms post-transport clear.
+    if (barrier.openIssued) {
+      try { barrier.releaseAfterTransportGone?.(); } catch { /* ignore */ }
     }
   };
 
-  return { waitForPrior, release, fail, releaseAfterTransportGone };
+  return { waitForPrior, release, fail, markOpenIssued, releaseAfterTransportGone };
 }
 
 /**
@@ -2798,6 +2828,7 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     const startOpen = () => {
       if (!waiting) return;
       waiting = false;
+      try { pathGate.markOpenIssued?.(); } catch { /* ignore */ }
       // Keep cancel + channel-error wiring active through afterPathGate. A hung
       // post-gate stage stat must still yield to cancel/channel death so the
       // path gate and lease are not pinned forever (Codex P2 on f642580d).

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -454,22 +454,38 @@ function beginTruncatingSharedWriteOpen(filePath, sessionKey = "unknown") {
     if (truncatingSharedWriteOpenGates.get(key) === entry) {
       truncatingSharedWriteOpenGates.delete(key);
     }
-    // Already failed: promise rejected; just drop the barrier once OPEN settled.
+    // Already failed: promise rejected; drop the barrier once OPEN settled.
     if (entry.failed) return;
     entry.resolve();
   };
 
   const fail = (error) => {
-    if (entry.released || entry.failed) return;
     const err = error instanceof Error
       ? error
       : createPoisonedWriteOpenPathGateError(String(error?.message || error || ""));
     if (!err.noTransferFallback) err.noTransferFallback = true;
-    entry.failed = true;
-    entry.failError = err;
-    // Keep entry in the map so later beginTruncatingSharedWriteOpen sees failed
-    // and rejects promptly without clearing the fail-closed barrier.
-    entry.reject(err);
+
+    if (!entry.released && !entry.failed) {
+      entry.failed = true;
+      entry.failError = err;
+      entry.reject(err);
+    }
+
+    // A successor waiter may already own the map slot. Poison that head too so
+    // its promise cannot resolve and clear the barrier for a third upload while
+    // the original truncating OPEN may still land (Codex P1 on 0292802c).
+    const current = truncatingSharedWriteOpenGates.get(key);
+    if (current && current !== entry && !current.released && !current.failed) {
+      current.failed = true;
+      current.failError = err;
+      current.reject(err);
+    }
+
+    // Reinstall this poisoned entry as the durable fail-closed barrier even if
+    // a successor replaced us. Successor release must not delete the poison.
+    if (!entry.released) {
+      truncatingSharedWriteOpenGates.set(key, entry);
+    }
   };
 
   return { waitForPrior, release, fail };
@@ -2043,6 +2059,16 @@ async function uploadFile(
             const onAbort = () => {
               try { previousAbort?.(); } catch { /* ignore */ }
               transfer.cancelled = true;
+              // Same fail-closed poison as the timeout path: a dead prior OPEN
+              // leaves the shared gate unresolved, and cancel must not leave
+              // later same-path uploads hanging on waitForPrior (Codex P2).
+              try {
+                transfer._failPendingWriteOpenPathGate?.(
+                  createPoisonedWriteOpenPathGateError(
+                    "Prior write OPEN never settled; path gate is fail-closed",
+                  ),
+                );
+              } catch { /* ignore */ }
               finish(reject, new Error("Transfer cancelled"));
             };
             if (transfer.cancelled || signal?.aborted) {
@@ -2683,14 +2709,20 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
       // Do not release this waiter immediately: beginTruncatingSharedWriteOpen
       // already replaced the map entry with us. Releasing now would leave later
       // same-path attempts with no barrier while the prior OPEN is still in
-      // flight (stale truncating OPEN race). Chain our release to the prior.
+      // flight (stale truncating OPEN race). Chain our release to the prior
+      // settle; on prior *failure* (poison), propagate fail instead of resolve
+      // so a successor waiting on our promise cannot start OPEN (Codex P1).
       pathGate.waitForPrior.then(
         () => {
           pathGate.release();
           try { transfer._resolvePendingWriteOpenPathGate?.(); } catch { /* ignore */ }
         },
-        () => {
-          pathGate.release();
+        (priorErr) => {
+          const failErr = priorErr instanceof Error
+            ? priorErr
+            : createPoisonedWriteOpenPathGateError(String(priorErr?.message || priorErr || ""));
+          if (!failErr.noTransferFallback) failErr.noTransferFallback = true;
+          try { pathGate.fail?.(failErr); } catch { /* ignore */ }
           try { transfer._resolvePendingWriteOpenPathGate?.(); } catch { /* ignore */ }
         },
       );

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -459,7 +459,16 @@ function beginTruncatingSharedWriteOpen(filePath, sessionKey = "unknown") {
     entry.resolve();
   };
 
-  const fail = (error) => {
+  /**
+   * @param {Error} [error]
+   * @param {{ reinstall?: boolean }} [options]
+   *   reinstall — when true (default), make this entry the durable map barrier.
+   *   Successor waiters that only propagate a prior poison must pass false so
+   *   they cannot steal the slot from the OPEN owner; otherwise a later
+   *   owner release cannot clear the barrier (Codex P2 on 64450bfd).
+   */
+  const fail = (error, options = {}) => {
+    const reinstall = options.reinstall !== false;
     const err = error instanceof Error
       ? error
       : createPoisonedWriteOpenPathGateError(String(error?.message || error || ""));
@@ -482,8 +491,9 @@ function beginTruncatingSharedWriteOpen(filePath, sessionKey = "unknown") {
     }
 
     // Reinstall this poisoned entry as the durable fail-closed barrier even if
-    // a successor replaced us. Successor release must not delete the poison.
-    if (!entry.released) {
+    // a successor replaced us. Successor-propagated fail must not steal the
+    // slot from the OPEN owner (Codex P2 on 64450bfd).
+    if (reinstall && !entry.released) {
       truncatingSharedWriteOpenGates.set(key, entry);
     }
   };
@@ -2722,7 +2732,9 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
             ? priorErr
             : createPoisonedWriteOpenPathGateError(String(priorErr?.message || priorErr || ""));
           if (!failErr.noTransferFallback) failErr.noTransferFallback = true;
-          try { pathGate.fail?.(failErr); } catch { /* ignore */ }
+          // Propagate rejection to anyone waiting on our promise, but do not
+          // reinstall ourselves over the OPEN owner's poisoned barrier.
+          try { pathGate.fail?.(failErr, { reinstall: false }); } catch { /* ignore */ }
           try { transfer._resolvePendingWriteOpenPathGate?.(); } catch { /* ignore */ }
         },
       );

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -1953,26 +1953,48 @@ async function uploadFile(
         // timeout — skip fastPut rather than race a still-pending truncate.
         if (typeof transfer.pendingWriteOpenPathGate?.then === "function") {
           const pendingGate = transfer.pendingWriteOpenPathGate;
-          await runTransferCancelablePreflight(transfer, async () => {
-            let timer = null;
-            try {
-              await Promise.race([
-                pendingGate,
-                new Promise((_, reject) => {
-                  timer = setTimeout(() => {
-                    // Fail closed: do not fall through to another writer on the
-                    // same stage while a truncating OPEN may still land.
-                    const err = new Error(
-                      "Timed out waiting for prior write OPEN to settle before fastPut",
-                    );
-                    err.noTransferFallback = true;
-                    reject(err);
-                  }, 2000);
-                }),
-              ]);
-            } finally {
-              if (timer) clearTimeout(timer);
+          // Local cancel race (not runTransferCancelablePreflight): cancel must
+          // clear the timeout so an abandoned 2s reject cannot fire as an
+          // unhandled rejection after the outer wait already settled.
+          await new Promise((resolve, reject) => {
+            let settled = false;
+            const previousAbort = transfer.abort;
+            const signal = transfer.signal;
+            const finish = (fn, value) => {
+              if (settled) return;
+              settled = true;
+              clearTimeout(timer);
+              try { signal?.removeEventListener?.("abort", onAbort); } catch { /* ignore */ }
+              if (transfer.abort === onAbort) transfer.abort = previousAbort;
+              fn(value);
+            };
+            const timer = setTimeout(() => {
+              // Fail closed: do not fall through to another writer on the
+              // same stage while a truncating OPEN may still land.
+              const err = new Error(
+                "Timed out waiting for prior write OPEN to settle before fastPut",
+              );
+              err.noTransferFallback = true;
+              finish(reject, err);
+            }, 2000);
+            const onAbort = () => {
+              try { previousAbort?.(); } catch { /* ignore */ }
+              transfer.cancelled = true;
+              finish(reject, new Error("Transfer cancelled"));
+            };
+            if (transfer.cancelled || signal?.aborted) {
+              onAbort();
+              return;
             }
+            transfer.abort = onAbort;
+            try { signal?.addEventListener?.("abort", onAbort, { once: true }); } catch { /* ignore */ }
+            pendingGate.then(
+              () => finish(resolve),
+              (err) => finish(
+                reject,
+                err instanceof Error ? err : new Error(String(err?.message || err)),
+              ),
+            );
           });
         }
         if (transfer.cancelled) throw new Error("Transfer cancelled");
@@ -2012,6 +2034,13 @@ async function uploadFile(
         );
         fastPutOk = true;
       } catch (err) {
+        // Gate-wait / snapshot / fastPut failure: end the reopened isolated
+        // channel before nulling. Rethrow paths skip the post-block else-if
+        // end, and fallthrough also clears isolated — either way we must not
+        // leak the SSH subsystem opened for this attempt (#2755 Bugbot).
+        if (isolated && typeof isolated.end === "function") {
+          try { isolated.end(); } catch { /* ignore */ }
+        }
         isolated = null;
         // Restore pause capability for subsequent pause-aware strategies.
         transfer.pauseSupported = Boolean(transfer.resumable);

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -550,8 +550,12 @@ function beginTruncatingSharedWriteOpen(filePath, sessionKey = "unknown") {
       }
     }
     truncatingSharedWriteOpenGates.set(key, barrier);
-    // Only the OPEN owner arms post-transport clear.
-    if (barrier.openIssued) {
+    // Arm post-transport clear only when THIS entry owns the unresolved OPEN
+    // and is the one being poisoned (its isolated channel already ended before
+    // fastPut timeout). A waiter fail() that walks to an ancestor must not
+    // start that ancestor's cleanup while the ancestor's transport may still
+    // deliver a late truncating OPEN (Codex P1 on 4f2397ce).
+    if (barrier === entry && barrier.openIssued) {
       try { barrier.releaseAfterTransportGone?.(); } catch { /* ignore */ }
     }
   };

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -445,18 +445,40 @@ function beginTruncatingSharedWriteOpen(filePath, sessionKey = "unknown") {
     released: false,
     failed: false,
     failError: null,
+    transportGone: false,
+    transportGoneTimer: null,
   };
   truncatingSharedWriteOpenGates.set(key, entry);
 
   const release = () => {
     if (entry.released) return;
     entry.released = true;
+    if (entry.transportGoneTimer) {
+      clearTimeout(entry.transportGoneTimer);
+      entry.transportGoneTimer = null;
+    }
     if (truncatingSharedWriteOpenGates.get(key) === entry) {
       truncatingSharedWriteOpenGates.delete(key);
     }
     // Already failed: promise rejected; drop the barrier once OPEN settled.
     if (entry.failed) return;
     entry.resolve();
+  };
+
+  /**
+   * After the owning SFTP transport is closed/replaced, clear a poisoned
+   * barrier so reconnects to the same host/path are not fail-closed forever.
+   * Keep a short grace so a late OPEN callback that still races end() cannot
+   * wipe a same-path retry with no barrier (Codex P2 on 713719c2).
+   */
+  const releaseAfterTransportGone = () => {
+    entry.transportGone = true;
+    if (!entry.failed || entry.released || entry.transportGoneTimer) return;
+    entry.transportGoneTimer = setTimeout(() => {
+      entry.transportGoneTimer = null;
+      if (entry.released || !entry.failed) return;
+      release();
+    }, 2000);
   };
 
   /**
@@ -496,9 +518,15 @@ function beginTruncatingSharedWriteOpen(filePath, sessionKey = "unknown") {
     if (reinstall && !entry.released) {
       truncatingSharedWriteOpenGates.set(key, entry);
     }
+
+    // Channel may already have ended before poison (isolated dispose in
+    // uploadFileConcurrent finally). Arm the post-close clear now.
+    if (entry.transportGone) {
+      releaseAfterTransportGone();
+    }
   };
 
-  return { waitForPrior, release, fail };
+  return { waitForPrior, release, fail, releaseAfterTransportGone };
 }
 
 /**
@@ -2306,6 +2334,15 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     transfer._failPendingWriteOpenPathGate = (error) => {
       try { pathGate.fail?.(error); } catch { /* ignore */ }
     };
+  }
+  // When the owning transport ends, clear a poisoned barrier after a short
+  // grace so reconnects are not permanently fail-closed (Codex P2 on 713719c2).
+  if (pathGate && sftp && typeof sftp.once === "function") {
+    const onTransportGone = () => {
+      try { pathGate.releaseAfterTransportGone?.(); } catch { /* ignore */ }
+    };
+    try { sftp.once("end", onTransportGone); } catch { /* ignore */ }
+    try { sftp.once("close", onTransportGone); } catch { /* ignore */ }
   }
   // Re-check ownership at unlink time: a same-id retry may already own
   // activeTransfers. Only suppress unlink when the retry's *actual* staged

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -517,11 +517,11 @@ function beginTruncatingSharedWriteOpen(filePath, sessionKey = "unknown") {
     // slot from the OPEN owner (Codex P2 on 64450bfd).
     if (reinstall && !entry.released) {
       truncatingSharedWriteOpenGates.set(key, entry);
-    }
-
-    // Channel may already have ended before poison (isolated dispose in
-    // uploadFileConcurrent finally). Arm the post-close clear now.
-    if (entry.transportGone) {
+      // Owner poison is raised from the isolated fastPut fallback after
+      // uploadFileConcurrent already ended that channel. Arm the post-close
+      // clear here instead of installing end/close listeners on every write
+      // OPEN (shared channels would accumulate listeners until teardown —
+      // Codex P2 on fe92b22c).
       releaseAfterTransportGone();
     }
   };
@@ -2334,15 +2334,6 @@ function openSftpHandleForTransfer(sftp, filePath, flags, transfer, options = {}
     transfer._failPendingWriteOpenPathGate = (error) => {
       try { pathGate.fail?.(error); } catch { /* ignore */ }
     };
-  }
-  // When the owning transport ends, clear a poisoned barrier after a short
-  // grace so reconnects are not permanently fail-closed (Codex P2 on 713719c2).
-  if (pathGate && sftp && typeof sftp.once === "function") {
-    const onTransportGone = () => {
-      try { pathGate.releaseAfterTransportGone?.(); } catch { /* ignore */ }
-    };
-    try { sftp.once("end", onTransportGone); } catch { /* ignore */ }
-    try { sftp.once("close", onTransportGone); } catch { /* ignore */ }
   }
   // Re-check ownership at unlink time: a same-id retry may already own
   // activeTransfers. Only suppress unlink when the retry's *actual* staged

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -1945,9 +1945,35 @@ async function uploadFile(
       try {
         // Wait for any prior/in-flight write OPEN on this path (including our
         // own concurrent attempt's still-pending OPEN) before fastPut truncates
-        // the same stage (Codex P1 on 7872a304).
+        // the same stage (Codex P1 on 7872a304). The wait must be cancelable and
+        // bounded: an isolated OPEN that never callbacks after channel death
+        // leaves pendingWriteOpenPathGate unresolved by design; hanging forever
+        // (or ignoring cancel because uploadFileConcurrent cleared abort) pins
+        // the transfer/lease (#2755 / Codex P2 on 667e9115). Fail closed on
+        // timeout — skip fastPut rather than race a still-pending truncate.
         if (typeof transfer.pendingWriteOpenPathGate?.then === "function") {
-          await transfer.pendingWriteOpenPathGate;
+          const pendingGate = transfer.pendingWriteOpenPathGate;
+          await runTransferCancelablePreflight(transfer, async () => {
+            let timer = null;
+            try {
+              await Promise.race([
+                pendingGate,
+                new Promise((_, reject) => {
+                  timer = setTimeout(() => {
+                    // Fail closed: do not fall through to another writer on the
+                    // same stage while a truncating OPEN may still land.
+                    const err = new Error(
+                      "Timed out waiting for prior write OPEN to settle before fastPut",
+                    );
+                    err.noTransferFallback = true;
+                    reject(err);
+                  }, 2000);
+                }),
+              ]);
+            } finally {
+              if (timer) clearTimeout(timer);
+            }
+          });
         }
         if (transfer.cancelled) throw new Error("Transfer cancelled");
         transfer.uploadStrategy = "fastPut-isolated";

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -5142,6 +5142,205 @@ test("fastPut fallback fails closed when prior isolated write OPEN gate never se
   assert.equal(sender.sent.some((entry) => entry.channel === "netcatty:transfer:complete"), false);
 });
 
+test("later same-path upload fails promptly after prior write OPEN gate is poisoned", async (t) => {
+  // Codex P2 on dca41093: after the fail-closed fastPut gate timeout, the dead
+  // OPEN's truncatingSharedWriteOpenGates entry must not leave a later in-place
+  // upload blocked forever in pathGate.waitForPrior. Use a symlink destination
+  // so both attempts OPEN the same final path (allowInPlaceFallback). Subsequent
+  // waiters must fail promptly (noTransferFallback) while the barrier stays
+  // fail-closed — they must not hang and must not issue another truncating OPEN.
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-gate-fail-closed-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(TRANSFER_CHUNK_SIZE, 63);
+  const localPath = path.join(tempDir, "upload.bin");
+  const targetPath = "/tmp/upload-inplace-gate-fail-closed.bin";
+  const remoteFiles = new Map([[targetPath, Buffer.from("old")]]);
+  await fs.promises.writeFile(localPath, payload);
+
+  let isolatedChannelCount = 0;
+  let firstOpenStarted = false;
+  let firstOpenPath = null;
+  let firstIsolated = null;
+  let laterWriteOpens = 0;
+  const symlinkLstat = (remotePath, callback) => {
+    const key = String(remotePath);
+    if (key.includes(".netcatty-backup-") || key.includes(".netcatty-upload-") || key.includes(".netcatty-")) {
+      const error = new Error("ENOENT");
+      error.code = 2;
+      callback(error);
+      return;
+    }
+    if (!remoteFiles.has(key)) {
+      const error = new Error("ENOENT");
+      error.code = 2;
+      callback(error);
+      return;
+    }
+    callback(null, {
+      size: remoteFiles.get(key).length,
+      mode: 0o120777,
+      isDirectory: () => false,
+      isSymbolicLink: () => true,
+    });
+  };
+  const sharedSftp = createFastSftp({
+    lstat: symlinkLstat,
+    open(remotePath, flags, callback) {
+      laterWriteOpens += 1;
+      callback(null, Buffer.from(`shared-handle:${flags}:${remotePath}`));
+    },
+    write(_handle, _buffer, _offset, length, _position, callback) {
+      callback(null);
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+    createWriteStream() {
+      throw new Error("stream fallback must not run after fail-closed path gate");
+    },
+  });
+
+  const client = {
+    sftp: sharedSftp,
+    async stat(remotePath) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        throw error;
+      }
+      return { size: remoteFiles.get(key).length };
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    async delete(remotePath) {
+      remoteFiles.delete(String(remotePath));
+    },
+    client: {
+      sftp(callback) {
+        isolatedChannelCount += 1;
+        if (isolatedChannelCount === 1) {
+          firstIsolated = createFastSftp({
+            lstat: symlinkLstat,
+            open(remotePath, flags) {
+              assert.equal(flags, "w");
+              assert.equal(String(remotePath), targetPath, "first attempt must OPEN in-place final path");
+              firstOpenPath = String(remotePath);
+              firstOpenStarted = true;
+            },
+            write() {
+              throw new Error("WRITE must not run after channel error during OPEN");
+            },
+            end() {},
+          });
+          callback(null, firstIsolated);
+          return;
+        }
+        // Later isolated channels: OPEN must not be reached while the path gate
+        // is fail-closed; count attempts if the barrier is incorrectly released.
+        callback(null, createFastSftp({
+          lstat: symlinkLstat,
+          open(remotePath, flags, cb) {
+            laterWriteOpens += 1;
+            cb(null, Buffer.from(`isolated-handle:${flags}:${remotePath}`));
+          },
+          write(_handle, _buffer, _offset, length, _position, cb) {
+            cb(null);
+          },
+          close(_handle, cb) {
+            cb(null);
+          },
+          fastPut(_local, _remote, _opts, cb) {
+            cb(null);
+          },
+          end() {},
+        }));
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const firstSender = createSender();
+  const firstRunning = transferBridge.startTransfer(
+    { sender: firstSender },
+    {
+      transferId: "upload-inplace-gate-fail-closed-first",
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+
+  const openReady = await waitUntil(() => firstOpenStarted, 2000);
+  assert.ok(openReady, "expected concurrent-isolated in-place write OPEN to stall");
+  assert.equal(firstOpenPath, targetPath);
+  firstIsolated.emit("error", new Error("isolated SFTP channel died during OPEN"));
+
+  const firstResult = await Promise.race([
+    firstRunning,
+    new Promise((_, reject) => {
+      setTimeout(
+        () => reject(new Error("first transfer hung awaiting pendingWriteOpenPathGate before fastPut")),
+        5000,
+      );
+    }),
+  ]);
+  assert.match(firstResult.error || "", /Timed out waiting for prior write OPEN to settle before fastPut/i);
+
+  // Later same-path in-place upload must fail promptly — not hang on the
+  // unresolved truncatingSharedWriteOpenGates entry (Codex P2).
+  const laterSender = createSender();
+  const laterStartedAt = Date.now();
+  const laterRunning = transferBridge.startTransfer(
+    { sender: laterSender },
+    {
+      transferId: "upload-inplace-gate-fail-closed-later",
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+  const laterResult = await Promise.race([
+    laterRunning,
+    new Promise((_, reject) => {
+      setTimeout(
+        () => reject(new Error("later same-path upload hung on unresolved write OPEN path gate")),
+        1500,
+      );
+    }),
+  ]);
+
+  assert.ok(
+    Date.now() - laterStartedAt < 1500,
+    "later upload must settle promptly after fail-closed path gate",
+  );
+  assert.ok(laterResult.error, "expected later upload to fail closed on unresolved path gate");
+  assert.match(
+    laterResult.error,
+    /Timed out waiting for prior write OPEN|prior write OPEN never settled|write OPEN path gate/i,
+  );
+  assert.equal(
+    laterWriteOpens,
+    0,
+    "fail-closed path gate must not allow a later truncating write OPEN",
+  );
+  assert.equal(laterSender.sent.some((entry) => entry.channel === "netcatty:transfer:complete"), false);
+});
+
 test("shared upload OPEN drain unlinks late staged OPEN after channel-error force-complete", async (t) => {
   // Codex P2 on bd42c51c: late truncating OPEN after channel-error drain
   // force-complete is not a cancel (`transfer.cancelled` false). Non-resumable

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -5341,6 +5341,360 @@ test("later same-path upload fails promptly after prior write OPEN gate is poiso
   assert.equal(laterSender.sent.some((entry) => entry.channel === "netcatty:transfer:complete"), false);
 });
 
+test("path gate poison survives a same-path waiter queued during fastPut timeout", async (t) => {
+  // Codex P1 on 0292802c: if another upload replaces the map entry during the
+  // 2s fastPut gate wait, fail() must still leave a fail-closed barrier so a
+  // third upload cannot OPEN while the original truncating OPEN may land.
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-gate-poison-successor-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(TRANSFER_CHUNK_SIZE, 64);
+  const localPath = path.join(tempDir, "upload.bin");
+  const targetPath = "/tmp/upload-inplace-gate-poison-successor.bin";
+  const remoteFiles = new Map([[targetPath, Buffer.from("old")]]);
+  await fs.promises.writeFile(localPath, payload);
+
+  let isolatedChannelCount = 0;
+  let firstOpenStarted = false;
+  let firstIsolated = null;
+  let thirdWriteOpens = 0;
+  const symlinkLstat = (remotePath, callback) => {
+    const key = String(remotePath);
+    if (key.includes(".netcatty-backup-") || key.includes(".netcatty-upload-") || key.includes(".netcatty-")) {
+      const error = new Error("ENOENT");
+      error.code = 2;
+      callback(error);
+      return;
+    }
+    if (!remoteFiles.has(key)) {
+      const error = new Error("ENOENT");
+      error.code = 2;
+      callback(error);
+      return;
+    }
+    callback(null, {
+      size: remoteFiles.get(key).length,
+      mode: 0o120777,
+      isDirectory: () => false,
+      isSymbolicLink: () => true,
+    });
+  };
+
+  const client = {
+    sftp: createFastSftp({
+      lstat: symlinkLstat,
+      open() {
+        throw new Error("shared OPEN must not run while path gate is fail-closed");
+      },
+      createWriteStream() {
+        throw new Error("stream fallback must not run after fail-closed path gate");
+      },
+    }),
+    async stat(remotePath) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        throw error;
+      }
+      return { size: remoteFiles.get(key).length };
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    async delete(remotePath) {
+      remoteFiles.delete(String(remotePath));
+    },
+    client: {
+      sftp(callback) {
+        isolatedChannelCount += 1;
+        if (isolatedChannelCount === 1) {
+          firstIsolated = createFastSftp({
+            lstat: symlinkLstat,
+            open(remotePath, flags) {
+              assert.equal(flags, "w");
+              assert.equal(String(remotePath), targetPath);
+              firstOpenStarted = true;
+            },
+            end() {},
+          });
+          callback(null, firstIsolated);
+          return;
+        }
+        callback(null, createFastSftp({
+          lstat: symlinkLstat,
+          open(remotePath, flags, cb) {
+            thirdWriteOpens += 1;
+            cb(null, Buffer.from(`isolated-handle:${flags}:${remotePath}`));
+          },
+          write(_handle, _buffer, _offset, length, _position, cb) {
+            cb(null);
+          },
+          close(_handle, cb) {
+            cb(null);
+          },
+          fastPut(_local, _remote, _opts, cb) {
+            cb(null);
+          },
+          end() {},
+        }));
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const firstRunning = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-inplace-gate-poison-successor-first",
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+
+  const openReady = await waitUntil(() => firstOpenStarted, 2000);
+  assert.ok(openReady, "expected first in-place write OPEN to stall");
+  firstIsolated.emit("error", new Error("isolated SFTP channel died during OPEN"));
+
+  // Wait until first transfer has reopened for fastPut (second isolated channel)
+  // and is inside the 2s pendingWriteOpenPathGate wait.
+  const fastPutWaiting = await waitUntil(() => isolatedChannelCount >= 2, 2000);
+  assert.ok(fastPutWaiting, "expected fastPut reopen while prior OPEN gate pending");
+
+  // Queue a second same-path upload during the timeout window so it replaces the
+  // map entry before fail() runs.
+  const secondRunning = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-inplace-gate-poison-successor-second",
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+
+  const firstResult = await Promise.race([
+    firstRunning,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("first transfer hung on gate timeout")), 5000);
+    }),
+  ]);
+  assert.match(firstResult.error || "", /Timed out waiting for prior write OPEN to settle before fastPut/i);
+
+  const secondResult = await Promise.race([
+    secondRunning,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("second transfer hung after prior gate poison")), 1500);
+    }),
+  ]);
+  assert.ok(secondResult.error, "expected second waiter to fail closed after poison");
+  assert.match(secondResult.error, /prior write OPEN never settled|path gate is fail-closed/i);
+
+  const thirdStartedAt = Date.now();
+  const thirdRunning = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-inplace-gate-poison-successor-third",
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+  const thirdResult = await Promise.race([
+    thirdRunning,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("third upload hung or raced after successor release")), 1500);
+    }),
+  ]);
+
+  assert.ok(Date.now() - thirdStartedAt < 1500, "third upload must settle promptly");
+  assert.ok(thirdResult.error, "expected third upload to fail closed");
+  assert.match(thirdResult.error, /prior write OPEN never settled|path gate is fail-closed/i);
+  assert.equal(thirdWriteOpens, 0, "poisoned barrier must survive successor waiter release");
+});
+
+test("later same-path upload fails promptly after cancel during unresolved OPEN gate wait", async (t) => {
+  // Codex P2 on 0292802c: cancel during the fastPut pending-gate wait must
+  // poison the shared path gate, same as the idle timeout path.
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-gate-cancel-poison-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(TRANSFER_CHUNK_SIZE, 65);
+  const localPath = path.join(tempDir, "upload.bin");
+  const targetPath = "/tmp/upload-inplace-gate-cancel-poison.bin";
+  const remoteFiles = new Map([[targetPath, Buffer.from("old")]]);
+  await fs.promises.writeFile(localPath, payload);
+
+  let isolatedChannelCount = 0;
+  let firstOpenStarted = false;
+  let firstIsolated = null;
+  let laterWriteOpens = 0;
+  const symlinkLstat = (remotePath, callback) => {
+    const key = String(remotePath);
+    if (key.includes(".netcatty-backup-") || key.includes(".netcatty-upload-") || key.includes(".netcatty-")) {
+      const error = new Error("ENOENT");
+      error.code = 2;
+      callback(error);
+      return;
+    }
+    if (!remoteFiles.has(key)) {
+      const error = new Error("ENOENT");
+      error.code = 2;
+      callback(error);
+      return;
+    }
+    callback(null, {
+      size: remoteFiles.get(key).length,
+      mode: 0o120777,
+      isDirectory: () => false,
+      isSymbolicLink: () => true,
+    });
+  };
+
+  const client = {
+    sftp: createFastSftp({
+      lstat: symlinkLstat,
+      open() {
+        laterWriteOpens += 1;
+        throw new Error("shared OPEN must not run while path gate is fail-closed");
+      },
+      createWriteStream() {
+        throw new Error("stream fallback must not run after fail-closed path gate");
+      },
+    }),
+    async stat(remotePath) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        throw error;
+      }
+      return { size: remoteFiles.get(key).length };
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    async delete(remotePath) {
+      remoteFiles.delete(String(remotePath));
+    },
+    client: {
+      sftp(callback) {
+        isolatedChannelCount += 1;
+        if (isolatedChannelCount === 1) {
+          firstIsolated = createFastSftp({
+            lstat: symlinkLstat,
+            open(remotePath, flags) {
+              assert.equal(flags, "w");
+              assert.equal(String(remotePath), targetPath);
+              firstOpenStarted = true;
+            },
+            end() {},
+          });
+          callback(null, firstIsolated);
+          return;
+        }
+        callback(null, createFastSftp({
+          lstat: symlinkLstat,
+          open(remotePath, flags, cb) {
+            laterWriteOpens += 1;
+            cb(null, Buffer.from(`isolated-handle:${flags}:${remotePath}`));
+          },
+          write(_handle, _buffer, _offset, length, _position, cb) {
+            cb(null);
+          },
+          close(_handle, cb) {
+            cb(null);
+          },
+          fastPut(_local, _remote, _opts, cb) {
+            cb(null);
+          },
+          end() {},
+        }));
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const firstTransferId = "upload-inplace-gate-cancel-poison-first";
+  const firstRunning = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: firstTransferId,
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+
+  const openReady = await waitUntil(() => firstOpenStarted, 2000);
+  assert.ok(openReady, "expected first in-place write OPEN to stall");
+  firstIsolated.emit("error", new Error("isolated SFTP channel died during OPEN"));
+
+  const reopened = await waitUntil(() => isolatedChannelCount >= 2, 2000);
+  assert.ok(reopened, "expected fastPut reopen while prior OPEN gate pending");
+
+  await transferBridge.cancelTransfer(null, { transferId: firstTransferId });
+  const firstResult = await Promise.race([
+    firstRunning,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("first transfer hung on cancel during gate wait")), 1500);
+    }),
+  ]);
+  assert.match(firstResult.error || "", /cancel/i);
+
+  const laterStartedAt = Date.now();
+  const laterRunning = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-inplace-gate-cancel-poison-later",
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+  const laterResult = await Promise.race([
+    laterRunning,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("later upload hung after cancel left path gate unresolved")), 1500);
+    }),
+  ]);
+
+  assert.ok(Date.now() - laterStartedAt < 1500, "later upload must settle promptly after cancel poison");
+  assert.ok(laterResult.error, "expected later upload to fail closed");
+  assert.match(laterResult.error, /prior write OPEN never settled|path gate is fail-closed/i);
+  assert.equal(laterWriteOpens, 0, "cancel poison must not allow a later truncating write OPEN");
+});
+
 test("shared upload OPEN drain unlinks late staged OPEN after channel-error force-complete", async (t) => {
   // Codex P2 on bd42c51c: late truncating OPEN after channel-error drain
   // force-complete is not a cancel (`transfer.cancelled` false). Non-resumable

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -4865,6 +4865,275 @@ test("shared upload OPEN drain force-completes when channel error has no OPEN ca
   assert.equal(sender.sent.some((entry) => entry.channel === "netcatty:transfer:complete"), false);
 });
 
+test("fastPut fallback cancel settles while prior isolated write OPEN gate is unresolved", async (t) => {
+  // #2755 / Codex P2 on 667e9115: non-resumable concurrent-isolated OPEN emits a
+  // channel error without invoking its callback, so pendingWriteOpenPathGate
+  // stays unresolved by design. uploadFile then awaits that gate before
+  // fastPut; uploadFileConcurrent already cleared transfer.abort, so Cancel
+  // must still settle the transfer (not hang on the unconditional await).
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-fastput-gate-cancel-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(TRANSFER_CHUNK_SIZE, 61);
+  const localPath = path.join(tempDir, "upload.bin");
+  const targetPath = "/tmp/upload-fastput-gate-cancel.bin";
+  const remoteFiles = new Map([[targetPath, Buffer.from("old")]]);
+  await fs.promises.writeFile(localPath, payload);
+
+  let isolatedChannelCount = 0;
+  let firstOpenStarted = false;
+  let firstIsolated = null;
+  let fastPutCalls = 0;
+  const sharedSftp = createFastSftp({
+    lstat(remotePath, callback) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        callback(error);
+        return;
+      }
+      callback(null, {
+        size: remoteFiles.get(key).length,
+        mode: 0o100644,
+        isDirectory: () => false,
+        isSymbolicLink: () => false,
+      });
+    },
+  });
+
+  const client = {
+    sftp: sharedSftp,
+    async stat(remotePath) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        throw error;
+      }
+      return { size: remoteFiles.get(key).length };
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    async delete(remotePath) {
+      remoteFiles.delete(String(remotePath));
+    },
+    client: {
+      sftp(callback) {
+        isolatedChannelCount += 1;
+        if (isolatedChannelCount === 1) {
+          firstIsolated = createFastSftp({
+            open(_remotePath, flags, _cb) {
+              assert.equal(flags, "w");
+              firstOpenStarted = true;
+              // Never invoke the OPEN callback (dead isolated channel).
+            },
+            write() {
+              throw new Error("WRITE must not run after channel error during OPEN");
+            },
+            close() {
+              throw new Error("CLOSE must not run without an OPEN handle");
+            },
+            fastPut() {
+              throw new Error("first isolated channel must not fastPut");
+            },
+            end() {},
+          });
+          callback(null, firstIsolated);
+          return;
+        }
+        // Reopened channel for fastPut fallback — would succeed if reached.
+        callback(null, createFastSftp({
+          fastPut(_local, _remote, _opts, cb) {
+            fastPutCalls += 1;
+            cb(null);
+          },
+          end() {},
+        }));
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const sender = createSender();
+  const transferId = "upload-fastput-gate-cancel";
+  const running = transferBridge.startTransfer(
+    { sender },
+    {
+      transferId,
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+
+  const openReady = await waitUntil(() => firstOpenStarted, 2000);
+  assert.ok(openReady, "expected concurrent-isolated write OPEN to stall");
+  firstIsolated.emit("error", new Error("isolated SFTP channel died during OPEN"));
+
+  // Wait until uploadFile has fallen through concurrent and reopened for fastPut
+  // (second isolated channel), which is when it awaits pendingWriteOpenPathGate.
+  const reopened = await waitUntil(() => isolatedChannelCount >= 2, 2000);
+  assert.ok(reopened, "expected fastPut isolated channel reopen while OPEN gate pending");
+
+  await transferBridge.cancelTransfer(null, { transferId });
+  const result = await Promise.race([
+    running,
+    new Promise((_, reject) => {
+      setTimeout(
+        () => reject(new Error("transfer hung awaiting pendingWriteOpenPathGate before fastPut")),
+        1500,
+      );
+    }),
+  ]);
+
+  assert.match(result.error || "", /cancel/i);
+  assert.equal(fastPutCalls, 0, "cancel must settle before fastPut runs on unresolved gate");
+  assert.equal(sender.sent.some((entry) => entry.channel === "netcatty:transfer:cancelled"), true);
+});
+
+test("fastPut fallback fails closed when prior isolated write OPEN gate never settles", async (t) => {
+  // #2755 companion: without cancel, a dead isolated OPEN that never callbacks
+  // must not pin the transfer forever on pendingWriteOpenPathGate, and must not
+  // fall through to another writer that races the still-pending truncate.
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-fastput-gate-timeout-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(TRANSFER_CHUNK_SIZE, 62);
+  const localPath = path.join(tempDir, "upload.bin");
+  const targetPath = "/tmp/upload-fastput-gate-timeout.bin";
+  const remoteFiles = new Map([[targetPath, Buffer.from("old")]]);
+  await fs.promises.writeFile(localPath, payload);
+
+  let isolatedChannelCount = 0;
+  let firstOpenStarted = false;
+  let firstIsolated = null;
+  let fastPutCalls = 0;
+  let sharedWriteOpens = 0;
+  const sharedSftp = createFastSftp({
+    lstat(remotePath, callback) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        callback(error);
+        return;
+      }
+      callback(null, {
+        size: remoteFiles.get(key).length,
+        mode: 0o100644,
+        isDirectory: () => false,
+        isSymbolicLink: () => false,
+      });
+    },
+    open(_remotePath, flags, callback) {
+      sharedWriteOpens += 1;
+      callback(null, Buffer.from(`shared-handle:${flags}`));
+    },
+    write(_handle, _buffer, _offset, length, _position, callback) {
+      callback(null);
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+    createWriteStream() {
+      throw new Error("stream fallback must not run after noTransferFallback gate timeout");
+    },
+  });
+
+  const client = {
+    sftp: sharedSftp,
+    async stat(remotePath) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        throw error;
+      }
+      return { size: remoteFiles.get(key).length };
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    async delete(remotePath) {
+      remoteFiles.delete(String(remotePath));
+    },
+    client: {
+      sftp(callback) {
+        isolatedChannelCount += 1;
+        if (isolatedChannelCount === 1) {
+          firstIsolated = createFastSftp({
+            open(_remotePath, flags) {
+              assert.equal(flags, "w");
+              firstOpenStarted = true;
+            },
+            write() {
+              throw new Error("WRITE must not run after channel error during OPEN");
+            },
+            end() {},
+          });
+          callback(null, firstIsolated);
+          return;
+        }
+        callback(null, createFastSftp({
+          fastPut(_local, _remote, _opts, cb) {
+            fastPutCalls += 1;
+            cb(null);
+          },
+          end() {},
+        }));
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const sender = createSender();
+  const transferId = "upload-fastput-gate-timeout";
+  const running = transferBridge.startTransfer(
+    { sender },
+    {
+      transferId,
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+
+  const openReady = await waitUntil(() => firstOpenStarted, 2000);
+  assert.ok(openReady, "expected concurrent-isolated write OPEN to stall");
+  firstIsolated.emit("error", new Error("isolated SFTP channel died during OPEN"));
+
+  const result = await Promise.race([
+    running,
+    new Promise((_, reject) => {
+      setTimeout(
+        () => reject(new Error("transfer hung awaiting pendingWriteOpenPathGate before fastPut")),
+        5000,
+      );
+    }),
+  ]);
+
+  assert.match(result.error || "", /Timed out waiting for prior write OPEN to settle before fastPut/i);
+  assert.equal(fastPutCalls, 0, "must not fastPut while prior OPEN gate is unresolved");
+  assert.equal(sharedWriteOpens, 0, "must not fall through to shared write after gate timeout");
+  assert.equal(sender.sent.some((entry) => entry.channel === "netcatty:transfer:complete"), false);
+});
+
 test("shared upload OPEN drain unlinks late staged OPEN after channel-error force-complete", async (t) => {
   // Codex P2 on bd42c51c: late truncating OPEN after channel-error drain
   // force-complete is not a cancel (`transfer.cancelled` false). Non-resumable

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -4886,6 +4886,7 @@ test("fastPut fallback cancel settles while prior isolated write OPEN gate is un
   let firstOpenStarted = false;
   let firstIsolated = null;
   let fastPutCalls = 0;
+  let reopenedEnded = 0;
   const sharedSftp = createFastSftp({
     lstat(remotePath, callback) {
       const key = String(remotePath);
@@ -4951,7 +4952,9 @@ test("fastPut fallback cancel settles while prior isolated write OPEN gate is un
             fastPutCalls += 1;
             cb(null);
           },
-          end() {},
+          end() {
+            reopenedEnded += 1;
+          },
         }));
       },
     },
@@ -4997,6 +5000,7 @@ test("fastPut fallback cancel settles while prior isolated write OPEN gate is un
 
   assert.match(result.error || "", /cancel/i);
   assert.equal(fastPutCalls, 0, "cancel must settle before fastPut runs on unresolved gate");
+  assert.equal(reopenedEnded, 1, "cancel during gate wait must end the reopened isolated channel");
   assert.equal(sender.sent.some((entry) => entry.channel === "netcatty:transfer:cancelled"), true);
 });
 
@@ -5019,6 +5023,7 @@ test("fastPut fallback fails closed when prior isolated write OPEN gate never se
   let firstOpenStarted = false;
   let firstIsolated = null;
   let fastPutCalls = 0;
+  let reopenedEnded = 0;
   let sharedWriteOpens = 0;
   const sharedSftp = createFastSftp({
     lstat(remotePath, callback) {
@@ -5090,7 +5095,9 @@ test("fastPut fallback fails closed when prior isolated write OPEN gate never se
             fastPutCalls += 1;
             cb(null);
           },
-          end() {},
+          end() {
+            reopenedEnded += 1;
+          },
         }));
       },
     },
@@ -5131,6 +5138,7 @@ test("fastPut fallback fails closed when prior isolated write OPEN gate never se
   assert.match(result.error || "", /Timed out waiting for prior write OPEN to settle before fastPut/i);
   assert.equal(fastPutCalls, 0, "must not fastPut while prior OPEN gate is unresolved");
   assert.equal(sharedWriteOpens, 0, "must not fall through to shared write after gate timeout");
+  assert.equal(reopenedEnded, 1, "gate timeout must end the reopened isolated channel");
   assert.equal(sender.sent.some((entry) => entry.channel === "netcatty:transfer:complete"), false);
 });
 

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -5913,6 +5913,213 @@ test("later same-path upload fails promptly after cancel during unresolved OPEN 
   assert.equal(laterWriteOpens, 0, "cancel poison must not allow a later truncating write OPEN");
 });
 
+test("path gate poison clears after owning isolated transport ends", async (t) => {
+  // Codex P2 on 713719c2: a dead OPEN that never callbacks leaves a host-keyed
+  // poison. Once the owning isolated channel has ended and a short grace
+  // passes, clear the barrier so reconnect / later uploads are not
+  // permanently fail-closed until process restart.
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-gate-transport-clear-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(TRANSFER_CHUNK_SIZE, 67);
+  const localPath = path.join(tempDir, "upload.bin");
+  const targetPath = "/tmp/upload-inplace-gate-transport-clear.bin";
+  const remoteFiles = new Map([[targetPath, Buffer.from("old")]]);
+  await fs.promises.writeFile(localPath, payload);
+
+  let isolatedChannelCount = 0;
+  let firstOpenStarted = false;
+  let firstIsolated = null;
+  let postClearWriteOpens = 0;
+  const symlinkLstat = (remotePath, callback) => {
+    const key = String(remotePath);
+    if (key.includes(".netcatty-backup-") || key.includes(".netcatty-upload-") || key.includes(".netcatty-")) {
+      const error = new Error("ENOENT");
+      error.code = 2;
+      callback(error);
+      return;
+    }
+    if (!remoteFiles.has(key)) {
+      const error = new Error("ENOENT");
+      error.code = 2;
+      callback(error);
+      return;
+    }
+    callback(null, {
+      size: remoteFiles.get(key).length,
+      mode: 0o120777,
+      isDirectory: () => false,
+      isSymbolicLink: () => true,
+    });
+  };
+
+  const client = {
+    sftp: createFastSftp({
+      lstat: symlinkLstat,
+      open(remotePath, flags, callback) {
+        postClearWriteOpens += 1;
+        remoteFiles.set(String(remotePath), Buffer.from(payload));
+        callback(null, Buffer.from(`shared-handle:${flags}:${remotePath}`));
+      },
+      write(_handle, _buffer, _offset, length, _position, callback) {
+        callback(null);
+      },
+      close(_handle, callback) {
+        callback(null);
+      },
+      createWriteStream() {
+        throw new Error("stream fallback must not run in this test");
+      },
+    }),
+    async stat(remotePath) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        throw error;
+      }
+      return { size: remoteFiles.get(key).length };
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    async delete(remotePath) {
+      remoteFiles.delete(String(remotePath));
+    },
+    client: {
+      sftp(callback) {
+        isolatedChannelCount += 1;
+        if (isolatedChannelCount === 1) {
+          firstIsolated = createFastSftp({
+            lstat: symlinkLstat,
+            open(remotePath, flags) {
+              assert.equal(flags, "w");
+              assert.equal(String(remotePath), targetPath);
+              firstOpenStarted = true;
+            },
+            end() {
+              this.emit("end");
+              this.emit("close");
+            },
+          });
+          callback(null, firstIsolated);
+          return;
+        }
+        callback(null, createFastSftp({
+          lstat: symlinkLstat,
+          open(remotePath, flags, cb) {
+            postClearWriteOpens += 1;
+            remoteFiles.set(String(remotePath), Buffer.from(payload));
+            cb(null, Buffer.from(`isolated-handle:${flags}:${remotePath}`));
+          },
+          write(_handle, _buffer, _offset, length, _position, cb) {
+            cb(null);
+          },
+          close(_handle, cb) {
+            cb(null);
+          },
+          fastPut(local, remote, _opts, cb) {
+            postClearWriteOpens += 1;
+            remoteFiles.set(String(remote), Buffer.from(payload));
+            cb(null);
+          },
+          end() {},
+        }));
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const firstRunning = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-inplace-gate-transport-clear-first",
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+
+  const openReady = await waitUntil(() => firstOpenStarted, 2000);
+  assert.ok(openReady, "expected first in-place write OPEN to stall");
+  firstIsolated.emit("error", new Error("isolated SFTP channel died during OPEN"));
+
+  const firstResult = await Promise.race([
+    firstRunning,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("first transfer hung on gate timeout")), 5000);
+    }),
+  ]);
+  assert.match(firstResult.error || "", /Timed out waiting for prior write OPEN to settle before fastPut/i);
+
+  // Immediately after poison the barrier must still fail closed.
+  const midRunning = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-inplace-gate-transport-clear-mid",
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+  const midResult = await Promise.race([
+    midRunning,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("mid upload hung on poisoned gate")), 1500);
+    }),
+  ]);
+  assert.match(midResult.error || "", /prior write OPEN never settled|path gate is fail-closed/i);
+
+  // After transport-gone grace, the host-keyed poison must clear.
+  await new Promise((resolve) => setTimeout(resolve, 2100));
+
+  const laterRunning = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-inplace-gate-transport-clear-later",
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+  const laterResult = await Promise.race([
+    laterRunning,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("later upload hung after transport-gone poison clear")), 5000);
+    }),
+  ]);
+
+  assert.notEqual(
+    laterResult.error && /prior write OPEN never settled|path gate is fail-closed/i.test(laterResult.error),
+    true,
+    `later upload must not stay permanently fail-closed after transport end, error=${laterResult.error}`,
+  );
+  assert.ok(
+    postClearWriteOpens > 0
+    || (laterResult.transferId && laterResult.error == null && laterResult.cancelled !== true)
+    || laterResult.cancelled === true
+    || laterResult.error,
+    `expected later upload to settle after transport-gone clear, result=${JSON.stringify(laterResult)}`,
+  );
+});
+
 test("shared upload OPEN drain unlinks late staged OPEN after channel-error force-complete", async (t) => {
   // Codex P2 on bd42c51c: late truncating OPEN after channel-error drain
   // force-complete is not a cancel (`transfer.cancelled` false). Non-resumable

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -5531,6 +5531,224 @@ test("path gate poison survives a same-path waiter queued during fastPut timeout
   assert.equal(thirdWriteOpens, 0, "poisoned barrier must survive successor waiter release");
 });
 
+test("path gate poison clears after late original OPEN settles past successor", async (t) => {
+  // Codex P2 on 64450bfd: after fail() poisons a queued successor, the OPEN
+  // owner's late callback must still be able to release the barrier. Successor
+  // fail propagation must not steal the map slot, or every later upload stays
+  // fail-closed forever even though the dangerous OPEN has settled.
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-gate-poison-clear-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const payload = Buffer.alloc(TRANSFER_CHUNK_SIZE, 66);
+  const localPath = path.join(tempDir, "upload.bin");
+  const targetPath = "/tmp/upload-inplace-gate-poison-clear.bin";
+  const remoteFiles = new Map([[targetPath, Buffer.from("old")]]);
+  await fs.promises.writeFile(localPath, payload);
+
+  let isolatedChannelCount = 0;
+  let firstOpenStarted = false;
+  let releaseFirstOpen = null;
+  let firstIsolated = null;
+  let postClearWriteOpens = 0;
+  const symlinkLstat = (remotePath, callback) => {
+    const key = String(remotePath);
+    if (key.includes(".netcatty-backup-") || key.includes(".netcatty-upload-") || key.includes(".netcatty-")) {
+      const error = new Error("ENOENT");
+      error.code = 2;
+      callback(error);
+      return;
+    }
+    if (!remoteFiles.has(key)) {
+      const error = new Error("ENOENT");
+      error.code = 2;
+      callback(error);
+      return;
+    }
+    callback(null, {
+      size: remoteFiles.get(key).length,
+      mode: 0o120777,
+      isDirectory: () => false,
+      isSymbolicLink: () => true,
+    });
+  };
+
+  const client = {
+    sftp: createFastSftp({
+      lstat: symlinkLstat,
+      open(remotePath, flags, callback) {
+        postClearWriteOpens += 1;
+        callback(null, Buffer.from(`shared-handle:${flags}:${remotePath}`));
+      },
+      write(_handle, _buffer, _offset, length, _position, callback) {
+        callback(null);
+      },
+      close(_handle, callback) {
+        callback(null);
+      },
+      createWriteStream() {
+        throw new Error("stream fallback must not run in this test");
+      },
+    }),
+    async stat(remotePath) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        throw error;
+      }
+      return { size: remoteFiles.get(key).length };
+    },
+    rename() {
+      return Promise.resolve();
+    },
+    async delete(remotePath) {
+      remoteFiles.delete(String(remotePath));
+    },
+    client: {
+      sftp(callback) {
+        isolatedChannelCount += 1;
+        if (isolatedChannelCount === 1) {
+          firstIsolated = createFastSftp({
+            lstat: symlinkLstat,
+            open(remotePath, flags, openCb) {
+              assert.equal(flags, "w");
+              assert.equal(String(remotePath), targetPath);
+              firstOpenStarted = true;
+              releaseFirstOpen = () => {
+                openCb(null, Buffer.from(`late-handle:${remotePath}`));
+              };
+            },
+            close(_handle, cb) {
+              cb(null);
+            },
+            unlink(_remotePath, cb) {
+              cb(null);
+            },
+            end() {},
+          });
+          callback(null, firstIsolated);
+          return;
+        }
+        callback(null, createFastSftp({
+          lstat: symlinkLstat,
+          open(remotePath, flags, cb) {
+            postClearWriteOpens += 1;
+            remoteFiles.set(String(remotePath), Buffer.from(payload));
+            cb(null, Buffer.from(`isolated-handle:${flags}:${remotePath}`));
+          },
+          write(_handle, _buffer, _offset, length, _position, cb) {
+            cb(null);
+          },
+          close(_handle, cb) {
+            cb(null);
+          },
+          fastPut(local, remote, _opts, cb) {
+            postClearWriteOpens += 1;
+            remoteFiles.set(String(remote), Buffer.from(payload));
+            cb(null);
+          },
+          end() {},
+        }));
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const firstRunning = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-inplace-gate-poison-clear-first",
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+
+  const openReady = await waitUntil(() => firstOpenStarted, 2000);
+  assert.ok(openReady, "expected first in-place write OPEN to stall");
+  firstIsolated.emit("error", new Error("isolated SFTP channel died during OPEN"));
+
+  const fastPutWaiting = await waitUntil(() => isolatedChannelCount >= 2, 2000);
+  assert.ok(fastPutWaiting, "expected fastPut reopen while prior OPEN gate pending");
+
+  const secondRunning = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-inplace-gate-poison-clear-second",
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+
+  const firstResult = await Promise.race([
+    firstRunning,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("first transfer hung on gate timeout")), 5000);
+    }),
+  ]);
+  assert.match(firstResult.error || "", /Timed out waiting for prior write OPEN to settle before fastPut/i);
+
+  await Promise.race([
+    secondRunning,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("second transfer hung after prior gate poison")), 1500);
+    }),
+  ]);
+
+  // Late OPEN from the original attempt settles and must clear the owner's
+  // poisoned barrier even though a successor was poisoned during the wait.
+  assert.equal(typeof releaseFirstOpen, "function", "expected late OPEN callback to be capturable");
+  releaseFirstOpen();
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const thirdRunning = transferBridge.startTransfer(
+    { sender: createSender() },
+    {
+      transferId: "upload-inplace-gate-poison-clear-third",
+      sourcePath: localPath,
+      targetPath,
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+      resumable: false,
+      skipAdmission: true,
+    },
+  );
+  const thirdResult = await Promise.race([
+    thirdRunning,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("third upload hung after late OPEN should have cleared poison")), 5000);
+    }),
+  ]);
+
+  assert.notEqual(
+    thirdResult.error && /prior write OPEN never settled|path gate is fail-closed/i.test(thirdResult.error),
+    true,
+    `third upload must not stay permanently fail-closed after late OPEN release, error=${thirdResult.error}`,
+  );
+  assert.ok(
+    postClearWriteOpens > 0
+    || (thirdResult.transferId && thirdResult.error == null && thirdResult.cancelled !== true)
+    || thirdResult.cancelled === true
+    || thirdResult.error,
+    `expected third upload to settle after barrier clear, result=${JSON.stringify(thirdResult)}`,
+  );
+});
+
 test("later same-path upload fails promptly after cancel during unresolved OPEN gate wait", async (t) => {
   // Codex P2 on 0292802c: cancel during the fastPut pending-gate wait must
   // poison the shared path gate, same as the idle timeout path.


### PR DESCRIPTION
## Summary

- Make the fastPut wait on `pendingWriteOpenPathGate` cancelable and 2s-bounded after #2750.
- On timeout, fail closed with `noTransferFallback` so the transfer does not fall through into another writer that can race a still-pending truncating OPEN.
- Add regression coverage for Cancel settle and idle timeout fail-closed paths.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2755

## Changes Made

- Race `pendingWriteOpenPathGate` with cancel via `runTransferCancelablePreflight`.
- Bound the wait (2s); timeout sets `noTransferFallback` so strategy fallback cannot rewrite the same stage while OPEN may still land.
- Tests: cancel settles while gate is unresolved; timeout fails without fastPut/shared write.

## Screenshots / Demo

N/A (transfer bridge race safety).

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — focused `transferBridge` tests for the new cases + related OPEN drain / path-gate tests
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)


Made with [Cursor](https://cursor.com)