### PR TITLE
fix(windows): stop shipping broken arm64 installers from x64 CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,9 +176,10 @@ jobs:
             pack_script: pack:mac
           - name: windows
             os: windows-latest
-            # The mosh binary workflow currently produces win32-x64 only.
-            # Keep official packages aligned with bundled-mosh coverage
-            # until Cygwin arm64 is stable enough to build win32-arm64.
+            # Official Windows releases are x64-only for now. Bundled mosh/et
+            # are win32-x64, and win.target must not hard-code arm64 or the
+            # x64 job still emits broken win-arm64 / universal NSIS packages
+            # (#2570). Use pack:win-x64 until a dedicated arm64 job exists.
             pack_script: pack:win-x64
     env:
       MOSH_BIN_RELEASE: ${{ needs.resolve-mosh.outputs.mosh_bin_release }}

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -214,19 +214,14 @@ module.exports = {
     },
     win: {
         icon: 'public/icon-win.png',
-        target: [
-            {
-                target: 'nsis',
-                arch: ['x64', 'arm64']
-            },
-            {
-                target: 'portable',
-                arch: ['x64', 'arm64']
-            },
-            {
-                target: 'zip'
-            }
-        ],
+        // Do not hard-code arch here. pack:win-x64 / pack:win pass --x64/--arm64,
+        // and electron-builder unions config arch with the CLI set. Hard-coding
+        // ['x64', 'arm64'] made the official x64 CI job also emit win-arm64 and
+        // a universal win.exe whose 32-bit NSIS stub can mis-detect on ARM
+        // Windows, install to Program Files (x86), and leave Netcatty.exe
+        // missing (#2570). Keep official releases on pack:win-x64 until win32
+        // arm64 bundled mosh/et + native rebuilds are ready.
+        target: ['nsis', 'portable', 'zip'],
         extraResources: [...moshExtraResources('win32'), ...etExtraResources('win32')]
     },
     portable: {

--- a/scripts/electron-builder-config.test.cjs
+++ b/scripts/electron-builder-config.test.cjs
@@ -193,8 +193,18 @@ test("rpm packaging uses gzip compression for RHEL-family package hosts", () => 
   );
 });
 
+test("Windows package arch is controlled by pack script CLI flags", () => {
+  assert.deepEqual(
+    config.win.target,
+    ["nsis", "portable", "zip"],
+    "win.target must not hard-code x64 and arm64 or pack:win-x64 will still emit broken arm64 installers",
+  );
+});
+
 test("windows packaging includes a zip archive target", () => {
-  const winTargets = config.win.target.map((entry) => entry.target);
+  const winTargets = config.win.target.map((entry) => (
+    typeof entry === "string" ? entry : entry.target
+  ));
   assert.ok(
     winTargets.includes("zip"),
     "windows package builds must publish a zip archive for no-install environments",
@@ -244,13 +254,15 @@ test("windows zip follows the requested build architecture", () => {
     Platform.WINDOWS,
   );
 
-  assert.ok(
-    targetsByArch.get(Arch.x64)?.includes("zip"),
-    "pack:win-x64 must publish an x64 zip archive",
+  assert.deepEqual(
+    targetsByArch.get(Arch.x64)?.slice().sort(),
+    ["nsis", "portable", "zip"].sort(),
+    "pack:win-x64 must publish x64 nsis, portable, and zip",
   );
-  assert.ok(
-    !targetsByArch.get(Arch.arm64)?.includes("zip"),
-    "pack:win-x64 must not publish an arm64 zip archive without arm64 bundled binaries",
+  assert.equal(
+    targetsByArch.has(Arch.arm64),
+    false,
+    "pack:win-x64 must not publish arm64 nsis/portable/zip without a dedicated arm64 job",
   );
 });
 


### PR DESCRIPTION
## Summary

- Official `pack:win-x64` was still emitting `win-arm64` and a universal `win.exe` because `win.target` hard-coded `arch: ['x64', 'arm64']`, and electron-builder unions that with the CLI arch set.
- Those arm64/universal NSIS packages are incomplete or mis-detect on ARM Windows (install to Program Files (x86), missing `Netcatty.exe`), matching #2570; x64 packages work via emulation.
- Remove the hard-coded arches so packaging follows `--x64` / `--arm64`, restore a regression test, and clarify the CI comment.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [x] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2570

## Changes Made

- `electron-builder.config.cjs`: `win.target` is now `['nsis', 'portable', 'zip']` (CLI-controlled arch).
- `scripts/electron-builder-config.test.cjs`: assert `pack:win-x64` does not emit arm64 targets.
- `.github/workflows/build.yml`: document why official Windows releases stay on `pack:win-x64`.

## Screenshots / Demo

N/A (packaging config). Users on ARM Windows should keep using `Netcatty-*-win-x64.exe` until a dedicated native arm64 pipeline exists.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — ran `node --test scripts/electron-builder-config.test.cjs scripts/github-workflow-ci.test.cjs`
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Also verified with `computeArchToTargetNamesMap` that `--x64` no longer maps arm64 nsis/portable.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)


Made with [Cursor](https://cursor.com)