### PR TITLE
fix(sync): rehydrate follow-app theme and guard groupConfig wipes

### DIFF
--- a/application/state/appearanceSync.test.ts
+++ b/application/state/appearanceSync.test.ts
@@ -343,3 +343,26 @@ test("the race guards are wired into the real settings paths", () => {
   assert.match(popupSource, /terminalTheme=\{settings\.currentTerminalTheme\}/);
   assert.match(popupSource, /followAppTerminalTheme=\{settings\.followAppTerminalTheme\}/);
 });
+
+test("cloud sync rehydrate picks up follow-app terminal theme from storage", () => {
+  // applySyncPayload writes followAppTerminalTheme to localStorage, then calls
+  // rehydrateAllFromStorage. Without reading TERM_FOLLOW_APP_THEME there, the
+  // open window keeps the pre-sync follow-app flag while terminalThemeId updates
+  // — black default vs synced yellow theme flicker (#2757).
+  const stateSource = readFileSync(new URL("./useSettingsState.ts", import.meta.url), "utf8");
+  const rehydrateIndex = stateSource.indexOf("const rehydrateAllFromStorage = useCallback(() => {");
+  assert.ok(rehydrateIndex >= 0, "rehydrateAllFromStorage must exist");
+  const nextCallbackIndex = stateSource.indexOf("}, [applyIncomingCustomKeyBindings", rehydrateIndex);
+  assert.ok(nextCallbackIndex > rehydrateIndex, "rehydrate callback body must be bounded");
+  const rehydrateBody = stateSource.slice(rehydrateIndex, nextCallbackIndex);
+  assert.match(
+    rehydrateBody,
+    /STORAGE_KEY_TERM_FOLLOW_APP_THEME/,
+    "rehydrate must read the follow-app terminal theme key written by applySyncableSettings",
+  );
+  assert.match(
+    rehydrateBody,
+    /setFollowAppTerminalThemeState/,
+    "rehydrate must update React follow-app state from storage after cloud sync",
+  );
+});

--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -833,6 +833,13 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     // Terminal
     const storedTermTheme = readStoredString(STORAGE_KEY_TERM_THEME);
     if (storedTermTheme) setTerminalThemeId(storedTermTheme);
+    // Cloud sync writes follow-app via applySyncableSettings; without this the
+    // open window keeps the pre-sync flag while terminalThemeId updates, which
+    // flickers between the local default theme and the synced one (#2757).
+    const storedFollowAppTermTheme = readStoredString(STORAGE_KEY_TERM_FOLLOW_APP_THEME);
+    if (storedFollowAppTermTheme === 'true' || storedFollowAppTermTheme === 'false') {
+      setFollowAppTerminalThemeState(storedFollowAppTermTheme === 'true');
+    }
     const storedTermThemeDark = readStoredString(STORAGE_KEY_TERM_THEME_DARK);
     if (storedTermThemeDark) setTerminalThemeDarkId(storedTermThemeDark);
     const storedTermThemeLight = readStoredString(STORAGE_KEY_TERM_THEME_LIGHT);

--- a/application/syncPayload.test.ts
+++ b/application/syncPayload.test.ts
@@ -139,6 +139,56 @@ test("sync payloads preserve opaque plugin hosts without requiring the plugin to
   assert.deepEqual(imported?.hosts, [pluginHost]);
 });
 
+test("applySyncPayload preserves host startup command and appearance overrides (#2757)", async () => {
+  const host = {
+    id: "host-1",
+    label: "Prod",
+    hostname: "prod.example",
+    username: "root",
+    port: 22,
+    protocol: "ssh" as const,
+    tags: [],
+    os: "linux" as const,
+    startupCommand: "tmux attach || tmux",
+    startupCommandRunMode: "lineDelay" as const,
+    theme: "solarized-dark",
+    themeOverride: true,
+  };
+  const groupConfigs = [
+    {
+      path: "prod",
+      startupCommand: "cd /srv && exec bash -l",
+      theme: "solarized-dark",
+      themeOverride: true,
+    },
+  ];
+  const payload = buildSyncPayload({
+    ...vault(),
+    hosts: [host],
+    groupConfigs,
+  });
+
+  assert.equal(payload.hosts[0]?.startupCommand, "tmux attach || tmux");
+  assert.equal(payload.hosts[0]?.theme, "solarized-dark");
+  assert.equal(payload.hosts[0]?.themeOverride, true);
+  assert.equal(payload.groupConfigs?.[0]?.startupCommand, "cd /srv && exec bash -l");
+
+  let imported: Record<string, unknown> | null = null;
+  await applySyncPayload(payload, {
+    importVaultData: (json) => { imported = JSON.parse(json); },
+  });
+
+  const importedHosts = imported?.hosts as typeof payload.hosts;
+  assert.equal(importedHosts?.[0]?.startupCommand, "tmux attach || tmux");
+  assert.equal(importedHosts?.[0]?.startupCommandRunMode, "lineDelay");
+  assert.equal(importedHosts?.[0]?.theme, "solarized-dark");
+  assert.equal(importedHosts?.[0]?.themeOverride, true);
+  assert.equal(
+    (imported?.groupConfigs as typeof groupConfigs)?.[0]?.startupCommand,
+    "cd /srv && exec bash -l",
+  );
+});
+
 test("buildCloudSyncPayload includes notes and note groups", async () => {
   const payload = await buildCloudSyncPayload({
     ...vault([]),

--- a/domain/syncGuards.test.ts
+++ b/domain/syncGuards.test.ts
@@ -201,6 +201,16 @@ test("wiping group configs while other vault data remains is suspicious (#2757)"
   }
 });
 
+test("wiping the last snippet while hosts remain is still a normal delete", () => {
+  // The groupConfigs complete-wipe guard must not broaden to every entity —
+  // deleting your only snippet with hosts present is intentional.
+  const snippets = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({ id: `s${i}`, label: `s${i}`, command: "" })) as SyncPayload["snippets"];
+  const base = payload({ hosts: hosts(1), snippets: snippets(1) });
+  const out = payload({ hosts: hosts(1), snippets: snippets(0) });
+  assert.deepEqual(detectSuspiciousShrink(out, base), { suspicious: false });
+});
+
 test("a fully empty outgoing snapshot is not a partial wipe (#2757)", () => {
   // Empty-everything against a trusted baseline is a real deletion path
   // (convergent migration). Do not flag complete wipes when no other vault

--- a/domain/syncGuards.test.ts
+++ b/domain/syncGuards.test.ts
@@ -176,6 +176,43 @@ test("proxy profile shrink is protected like other synced vault entities", () =>
   }
 });
 
+test("wiping group configs while other vault data remains is suspicious (#2757)", () => {
+  // Group defaults often hold startup commands / host appearance for a small
+  // number of folders. A hydration race that uploads hosts + groupConfigs:[]
+  // must not clear the cloud copy just because lost < BULK_SHRINK_MIN_ABSOLUTE.
+  const base = payload({
+    hosts: hosts(1),
+    groupConfigs: [
+      {
+        path: "prod",
+        startupCommand: "tmux attach || tmux",
+        theme: "solarized-dark",
+        themeOverride: true,
+      },
+    ],
+  } as Partial<SyncPayload>);
+  const out = payload({ hosts: hosts(1), groupConfigs: [] });
+  const result = detectSuspiciousShrink(out, base);
+  assert.equal(result.suspicious, true);
+  if (result.suspicious) {
+    assert.equal(result.entityType, "groupConfigs");
+    assert.equal(result.lost, 1);
+    assert.equal(result.reason, "bulk-shrink");
+  }
+});
+
+test("a fully empty outgoing snapshot is not a partial wipe (#2757)", () => {
+  // Empty-everything against a trusted baseline is a real deletion path
+  // (convergent migration). Do not flag complete wipes when no other vault
+  // content remains on the outgoing payload.
+  const base = payload({
+    hosts: hosts(1),
+    groupConfigs: [{ path: "prod", startupCommand: "echo hi" }],
+  } as Partial<SyncPayload>);
+  const out = payload();
+  assert.deepEqual(detectSuspiciousShrink(out, base), { suspicious: false });
+});
+
 test("knownHosts shrink is ignored because known hosts are local-only", () => {
   const kh = (n: number) => Array.from({ length: n }, (_, i) => ({ id: `kh${i}`, hostname: `h${i}`, port: 22, keyType: "rsa", fingerprint: "x" })) as unknown as SyncPayload["knownHosts"];
   const base = payload({ knownHosts: kh(12) });

--- a/domain/syncGuards.ts
+++ b/domain/syncGuards.ts
@@ -52,26 +52,26 @@ export function detectSuspiciousShrink(
     const lost = baseCount - outgoingCount;
     if (lost <= 0) continue;
 
-    // Complete wipe of one collection while other vault data remains is a
-    // hydration-race fingerprint (e.g. hosts arrived, groupConfigs still []).
-    // Tiny collections like a single groupConfig carrying startup commands /
-    // appearance defaults fall below the bulk/ratio gates (#2757). A fully
-    // empty outgoing snapshot is left alone — that is a real deletion path.
-    if (outgoingCount === 0 && baseCount > 0) {
-      const hasOtherVaultContent = CHECKED_ENTITIES.some(
-        (other) => other !== entityType && countOf(outgoing, other) > 0,
-      );
-      if (hasOtherVaultContent) {
-        return {
-          suspicious: true,
-          reason: lost >= LARGE_SHRINK_ABSOLUTE ? 'large-shrink' : 'bulk-shrink',
-          entityType,
-          baseCount,
-          outgoingCount,
-          lost,
-          ...(viaRemote ? { viaRemote: true } : {}),
-        };
-      }
+    // groupConfigs often hold startup commands / host appearance for only one
+    // or two folders. A hydration race that uploads hosts + groupConfigs:[]
+    // falls below the bulk/ratio gates (#2757). Only flag this entity — wiping
+    // the last snippet/note/etc. while hosts remain stays a normal delete.
+    // Fully empty outgoing snapshots remain allowed as real deletions.
+    if (
+      entityType === 'groupConfigs'
+      && outgoingCount === 0
+      && baseCount > 0
+      && CHECKED_ENTITIES.some((other) => other !== entityType && countOf(outgoing, other) > 0)
+    ) {
+      return {
+        suspicious: true,
+        reason: lost >= LARGE_SHRINK_ABSOLUTE ? 'large-shrink' : 'bulk-shrink',
+        entityType,
+        baseCount,
+        outgoingCount,
+        lost,
+        ...(viaRemote ? { viaRemote: true } : {}),
+      };
     }
 
     if (lost >= LARGE_SHRINK_ABSOLUTE) {

--- a/domain/syncGuards.ts
+++ b/domain/syncGuards.ts
@@ -52,6 +52,28 @@ export function detectSuspiciousShrink(
     const lost = baseCount - outgoingCount;
     if (lost <= 0) continue;
 
+    // Complete wipe of one collection while other vault data remains is a
+    // hydration-race fingerprint (e.g. hosts arrived, groupConfigs still []).
+    // Tiny collections like a single groupConfig carrying startup commands /
+    // appearance defaults fall below the bulk/ratio gates (#2757). A fully
+    // empty outgoing snapshot is left alone — that is a real deletion path.
+    if (outgoingCount === 0 && baseCount > 0) {
+      const hasOtherVaultContent = CHECKED_ENTITIES.some(
+        (other) => other !== entityType && countOf(outgoing, other) > 0,
+      );
+      if (hasOtherVaultContent) {
+        return {
+          suspicious: true,
+          reason: lost >= LARGE_SHRINK_ABSOLUTE ? 'large-shrink' : 'bulk-shrink',
+          entityType,
+          baseCount,
+          outgoingCount,
+          lost,
+          ...(viaRemote ? { viaRemote: true } : {}),
+        };
+      }
+    }
+
     if (lost >= LARGE_SHRINK_ABSOLUTE) {
       return {
         suspicious: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes WebDAV/cloud sync on a second device dropping peer appearance and host startup-command group defaults (#2757).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Fixes #2757

## Changes Made

- After cloud sync applies settings to `localStorage`, `rehydrateAllFromStorage` now also reads `followAppTerminalTheme` into React state (it already refreshed `terminalThemeId` and related fields).
- Shrink detection now treats a complete wipe of `groupConfigs` as suspicious when other vault data remains on the outgoing payload (hydration-race fingerprint for tiny folder defaults). Fully empty outgoing snapshots stay allowed as real deletions; wiping the last snippet/note/etc. is unchanged.
- Tests cover the rehydrate wiring, host/group startup+appearance round-trip through `applySyncPayload`, and the new shrink cases.

## Why

On a second device, sync wrote the peer's terminal theme / follow-app flag to storage, but the open window kept the local follow-app default while updating the terminal theme id. That mismatch flickers between the local dark/black default and the synced yellow theme.

Separately, group defaults often carry startup commands and host appearance for only one or two folders. A hydration race that uploaded hosts + `groupConfigs: []` was below the old bulk/ratio shrink thresholds, so cloud group defaults (and thus inherited startup commands / appearance) could be cleared even though hosts themselves still appeared.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Targeted tests pass (`appearanceSync`, `syncGuards`, `syncPayload`, `payloadMigration`)
- [x] Tests pass (`npm test` via CI `lint-and-test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

## Review status

- Bugbot: clean (no findings)
- Codex: clean on `5dd08d92` (`automation:codex-clean`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36356c62-6531-4e03-a515-906edd776c5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36356c62-6531-4e03-a515-906edd776c5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

