### PR TITLE
fix(terminal): keep newest scrollback after hibernate wake

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -3691,7 +3691,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       disposeDataRef.current = null;
     };
 
-    const stopHibernateListeners = () => {
+    const stopHibernateListeners = (opts?: { keepPaused?: boolean }) => {
       const backendId = sessionRef.current;
       stopHibernateDataListener();
       disposeExitRef.current?.();
@@ -3699,7 +3699,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       if (backendId) {
         flushTerminalSessionFlowAck(backendId);
         clearTerminalSessionFlowAck(backendId);
-        terminalBackend.setSessionFlowPaused?.(backendId, false);
+        if (!opts?.keepPaused) {
+          terminalBackend.setSessionFlowPaused?.(backendId, false);
+        }
       }
     };
 
@@ -3708,13 +3710,27 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       runtimeContext,
       container,
       getPayload,
+      prepareWakeFlow: async () => {
+        if (!options.sessionConnected) return;
+        const backendId = sessionRef.current;
+        if (!backendId) return;
+        // Drain in-flight output into the hibernate pending buffer while the
+        // listener is still attached, then keep the backend paused through
+        // history replay and reattach.
+        await terminalBackend.setSessionFlowPausedAndWait?.(backendId, true);
+      },
       takePendingBuffer: () => {
         const pending = hibernatePendingBufferRef.current;
         hibernatePendingBufferRef.current = "";
         return pending;
       },
       stopHibernateDataListener,
-      stopHibernateListeners,
+      stopHibernateListeners: () => stopHibernateListeners({ keepPaused: true }),
+      resumeWakeFlow: () => {
+        const backendId = sessionRef.current;
+        if (!backendId) return;
+        terminalBackend.setSessionFlowPaused?.(backendId, false);
+      },
       sessionConnected: options.sessionConnected,
       getSessionConnected: () => getSessionConnectedRef.current(),
       reattachSession: (term) => {

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -3716,14 +3716,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       container,
       getPayload,
       prepareWakeFlow: async () => {
-        if (!options.sessionConnected) return true;
         const backendId = sessionRef.current;
         if (!backendId) return true;
-        // Drain in-flight output into the hibernate pending buffer while the
-        // listener is still attached, then keep the backend paused through
-        // history replay and reattach. A failed drain still pauses the
-        // backend; the wake path keeps an uncapped pending listener until
-        // after history replay so ACKed bytes are not dropped.
+        // Always pause when a backend exists — including reconnect wakes
+        // (sessionConnected=false) that will not reattach. Stopping the
+        // hibernate listener without a pause drops live output into the
+        // preload backlog without flow ACKs until cleanupSession.
         if (terminalBackend.setSessionFlowPausedAndWait) {
           const result = await terminalBackend.setSessionFlowPausedAndWait(backendId, true);
           return result?.success === true;
@@ -3741,8 +3739,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         hibernatePendingCapDisabledRef.current = disabled;
       },
       stopHibernateListeners: () => stopHibernateListeners({ keepPaused: true }),
-      resumeWakeFlow: () => {
+      resumeWakeFlow: (shouldResume) => {
         hibernatePendingCapDisabledRef.current = false;
+        if (!shouldResume) return;
         const backendId = sessionRef.current;
         if (!backendId) return;
         terminalBackend.setSessionFlowPaused?.(backendId, false);

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -448,6 +448,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const hibernateContextViewportSnapshotRef = useRef("");
   const hibernateContextScrollbackSnapshotRef = useRef("");
   const hibernatePendingBufferRef = useRef("");
+  const hibernatePendingCapDisabledRef = useRef(false);
   const hibernateAlternateScreenRef = useRef(false);
   const hibernateRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fullHibernateRuntimeRef = useRef<(() => Promise<boolean>) | null>(null);
@@ -1785,10 +1786,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       backendId,
       (chunk, meta) => {
         observeTerminalInputPrompt(chunk, meta);
-        hibernatePendingBufferRef.current = appendHibernatePendingBuffer(
-          hibernatePendingBufferRef.current,
-          chunk,
-        );
+        hibernatePendingBufferRef.current = hibernatePendingCapDisabledRef.current
+          ? hibernatePendingBufferRef.current + chunk
+          : appendHibernatePendingBuffer(
+            hibernatePendingBufferRef.current,
+            chunk,
+          );
         const pluginPipelineIngressBytes = Number.isFinite(meta?.pluginPipelineIngressBytes)
           ? Math.max(0, Number(meta.pluginPipelineIngressBytes))
           : chunk.length;
@@ -1808,10 +1811,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         setError(evt.error);
       }
       const exitMessage = `\r\n[session closed${evt?.exitCode !== undefined ? ` (code ${evt.exitCode})` : ""}]`;
-      hibernatePendingBufferRef.current = appendHibernatePendingBuffer(
-        hibernatePendingBufferRef.current,
-        exitMessage,
-      );
+      hibernatePendingBufferRef.current = hibernatePendingCapDisabledRef.current
+        ? hibernatePendingBufferRef.current + exitMessage
+        : appendHibernatePendingBuffer(
+          hibernatePendingBufferRef.current,
+          exitMessage,
+        );
       onSessionExitRef.current?.(sessionId, evt);
       scheduleAutoReconnect({ evt });
     });
@@ -3711,13 +3716,20 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       container,
       getPayload,
       prepareWakeFlow: async () => {
-        if (!options.sessionConnected) return;
+        if (!options.sessionConnected) return true;
         const backendId = sessionRef.current;
-        if (!backendId) return;
+        if (!backendId) return true;
         // Drain in-flight output into the hibernate pending buffer while the
         // listener is still attached, then keep the backend paused through
-        // history replay and reattach.
-        await terminalBackend.setSessionFlowPausedAndWait?.(backendId, true);
+        // history replay and reattach. A failed drain still pauses the
+        // backend; the wake path keeps an uncapped pending listener until
+        // after history replay so ACKed bytes are not dropped.
+        if (terminalBackend.setSessionFlowPausedAndWait) {
+          const result = await terminalBackend.setSessionFlowPausedAndWait(backendId, true);
+          return result?.success === true;
+        }
+        terminalBackend.setSessionFlowPaused?.(backendId, true);
+        return false;
       },
       takePendingBuffer: () => {
         const pending = hibernatePendingBufferRef.current;
@@ -3725,8 +3737,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         return pending;
       },
       stopHibernateDataListener,
+      setHibernatePendingCapDisabled: (disabled) => {
+        hibernatePendingCapDisabledRef.current = disabled;
+      },
       stopHibernateListeners: () => stopHibernateListeners({ keepPaused: true }),
       resumeWakeFlow: () => {
+        hibernatePendingCapDisabledRef.current = false;
         const backendId = sessionRef.current;
         if (!backendId) return;
         terminalBackend.setSessionFlowPaused?.(backendId, false);

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -3718,7 +3718,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       prepareWakeFlow: async () => {
         const backendId = sessionRef.current;
         if (!backendId) return true;
-        // Always pause when a backend exists — including reconnect wakes
+        // Always pause when a backend exists, including reconnect wakes
         // (sessionConnected=false) that will not reattach. Stopping the
         // hibernate listener without a pause drops live output into the
         // preload backlog without flow ACKs until cleanupSession.
@@ -3739,9 +3739,24 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         hibernatePendingCapDisabledRef.current = disabled;
       },
       stopHibernateListeners: () => stopHibernateListeners({ keepPaused: true }),
-      resumeWakeFlow: (shouldResume) => {
+      restoreAfterFailedWake: () => {
         hibernatePendingCapDisabledRef.current = false;
-        if (!shouldResume) return;
+        const pending = hibernatePendingBufferRef.current;
+        disposeRuntimeOnly();
+        const backendId = sessionRef.current;
+        if (!backendId) return;
+        beginHibernatedSessionListeners(backendId);
+        // beginHibernatedSessionListeners clears pending; restore any bytes
+        // captured during the failed wake window.
+        if (pending) {
+          hibernatePendingBufferRef.current = appendHibernatePendingBuffer(
+            pending,
+            hibernatePendingBufferRef.current,
+          );
+        }
+      },
+      resumeAfterReattach: () => {
+        hibernatePendingCapDisabledRef.current = false;
         const backendId = sessionRef.current;
         if (!backendId) return;
         terminalBackend.setSessionFlowPaused?.(backendId, false);
@@ -3771,7 +3786,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     });
     wakePromiseRef.current = wakePromise;
     return wakePromise;
-  }, [sessionId, terminalBackend, terminalRuntimeRefs, resizeSession, terminalSettings]);
+  }, [sessionId, terminalBackend, terminalRuntimeRefs, resizeSession, terminalSettings, beginHibernatedSessionListeners]);
 
   const wakeHibernatedRuntime = useCallback(async (sessionConnected: boolean): Promise<boolean> => {
     if (!hibernatedRef.current) {

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -3739,18 +3739,30 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         hibernatePendingCapDisabledRef.current = disabled;
       },
       stopHibernateListeners: () => stopHibernateListeners({ keepPaused: true }),
-      restoreAfterFailedWake: () => {
+      restoreAfterFailedWake: (takenPending) => {
         hibernatePendingCapDisabledRef.current = false;
-        const pending = hibernatePendingBufferRef.current;
+        const pendingStillInRef = hibernatePendingBufferRef.current;
         disposeRuntimeOnly();
         const backendId = sessionRef.current;
-        if (!backendId) return;
-        beginHibernatedSessionListeners(backendId);
-        // beginHibernatedSessionListeners clears pending; restore any bytes
-        // captured during the failed wake window.
-        if (pending) {
+        if (!backendId) {
+          // No backend to reattach listeners to; still keep taken bytes for a
+          // later wake of a disconnected hibernated tab.
           hibernatePendingBufferRef.current = appendHibernatePendingBuffer(
-            pending,
+            takenPending || "",
+            pendingStillInRef,
+          );
+          return;
+        }
+        beginHibernatedSessionListeners(backendId);
+        // beginHibernatedSessionListeners clears pending; restore take-and-cleared
+        // bytes from this wake plus anything that arrived after the last take.
+        const restored = appendHibernatePendingBuffer(
+          takenPending || "",
+          pendingStillInRef,
+        );
+        if (restored) {
+          hibernatePendingBufferRef.current = appendHibernatePendingBuffer(
+            restored,
             hibernatePendingBufferRef.current,
           );
         }

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -3686,10 +3686,14 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     wakeInProgressRef.current = true;
     setPasswordPickerState(null);
 
-    const stopHibernateListeners = () => {
-      const backendId = sessionRef.current;
+    const stopHibernateDataListener = () => {
       disposeDataRef.current?.();
       disposeDataRef.current = null;
+    };
+
+    const stopHibernateListeners = () => {
+      const backendId = sessionRef.current;
+      stopHibernateDataListener();
       disposeExitRef.current?.();
       disposeExitRef.current = null;
       if (backendId) {
@@ -3709,6 +3713,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         hibernatePendingBufferRef.current = "";
         return pending;
       },
+      stopHibernateDataListener,
       stopHibernateListeners,
       sessionConnected: options.sessionConnected,
       getSessionConnected: () => getSessionConnectedRef.current(),

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -3704,6 +3704,11 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       runtimeContext,
       container,
       getPayload,
+      takePendingBuffer: () => {
+        const pending = hibernatePendingBufferRef.current;
+        hibernatePendingBufferRef.current = "";
+        return pending;
+      },
       stopHibernateListeners,
       sessionConnected: options.sessionConnected,
       getSessionConnected: () => getSessionConnectedRef.current(),

--- a/components/terminal/hibernateWakeChunking.test.ts
+++ b/components/terminal/hibernateWakeChunking.test.ts
@@ -37,16 +37,15 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
   const terminalSource = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
 
   assert.match(mountSource, /prepareWakeFlow\?:\s*\(\) => Promise<boolean>/);
-  assert.match(mountSource, /resumeWakeFlow\?:\s*\(\) => void/);
+  assert.match(mountSource, /resumeWakeFlow\?:\s*\(shouldResume: boolean\) => void/);
   assert.match(mountSource, /takePendingBuffer: \(\) => string/);
   assert.match(mountSource, /stopHibernateDataListener: \(\) => void/);
   assert.match(mountSource, /const drainOk = \(await prepareWakeFlow\?\.\(\)\) \?\? true;/);
   assert.match(mountSource, /stopHibernateDataListener\(\);/);
   assert.match(mountSource, /const pendingAtApplyStart = takePendingBuffer\(\);/);
   assert.match(mountSource, /const latePending = takePendingBuffer\(\);/);
+  assert.match(mountSource, /const exitTail = takePendingBuffer\(\);/);
   assert.doesNotMatch(mountSource, /pending\.slice\(replayedPendingLength\)/);
-  // No multi-pass drain while the hibernate listener is live: that races the
-  // 512 KiB pending cap and can drop ACKed bytes under sustained output.
   assert.doesNotMatch(mountSource, /for \(let drainPass = 0;/);
   assert.doesNotMatch(mountSource, /finalPendingDelta/);
 
@@ -55,13 +54,14 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
   const stopDataBeforeReplay = mountSource.indexOf("if (drainOk) {\n      stopHibernateDataListener();");
   const pendingIndex = mountSource.indexOf("const pendingAtApplyStart = takePendingBuffer();");
   const applyIndex = mountSource.indexOf("await applyHibernateWakeToTerminal(");
+  const latePendingIndex = mountSource.indexOf("const latePending = takePendingBuffer();");
+  const exitTailIndex = mountSource.indexOf("const exitTail = takePendingBuffer();");
   const shouldReattachIndex = mountSource.indexOf(
     "const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);",
   );
-  const latePendingIndex = mountSource.indexOf("const latePending = takePendingBuffer();");
   const stopAllIndex = mountSource.indexOf("stopHibernateListeners();", shouldReattachIndex);
   const reattachIndex = mountSource.indexOf("reattachSession(term);", shouldReattachIndex);
-  const resumeIndex = mountSource.indexOf("resumeWakeFlow?.();", shouldReattachIndex);
+  const resumeIndex = mountSource.indexOf("resumeWakeFlow?.(didReattach || !wakeSucceeded);");
 
   assert.ok(prepareIndex >= 0, "wake must pause backend flow before history replay");
   assert.ok(
@@ -72,21 +72,24 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
   assert.ok(pendingIndex > stopDataBeforeReplay, "pending take must run after drain handling");
   assert.ok(applyIndex > pendingIndex, "history replay follows the pending capture");
   assert.ok(
-    shouldReattachIndex > applyIndex,
-    "reattach decision must observe exit status after history replay",
-  );
-  assert.ok(
-    latePendingIndex > shouldReattachIndex,
+    latePendingIndex > applyIndex,
     "late pending take must run after history replay to keep exit/live tails",
   );
   assert.ok(
-    stopAllIndex > latePendingIndex,
-    "full hibernate listener teardown must wait until after the late pending drain",
+    exitTailIndex > latePendingIndex,
+    "exit-tail take must follow the late pending await",
+  );
+  assert.ok(
+    shouldReattachIndex > exitTailIndex,
+    "reattach decision must run after late pending/exit-tail replay",
+  );
+  assert.ok(
+    stopAllIndex > shouldReattachIndex,
+    "full hibernate listener teardown must wait until after the reattach decision",
   );
   assert.ok(reattachIndex > stopAllIndex, "reattach runs after hibernate listeners are cleared");
   assert.ok(resumeIndex > reattachIndex, "flow resume must wait until after reattach");
-  // Prefer finally so a failed wake cannot leave the backend paused forever.
-  assert.match(mountSource, /finally\s*\{\s*[\s\S]*?resumeWakeFlow\?\.\(\);/);
+  assert.match(mountSource, /finally\s*\{\s*[\s\S]*?resumeWakeFlow\?\.\(didReattach \|\| !wakeSucceeded\);/);
 
   assert.match(
     terminalSource,
@@ -96,13 +99,19 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
     terminalSource,
     /setSessionFlowPausedAndWait\(backendId,\s*true\)/,
   );
+  // Reconnect wakes (sessionConnected=false) must still pause when a backend
+  // session exists — otherwise stopping the hibernate listener drops live output.
+  assert.doesNotMatch(
+    terminalSource,
+    /prepareWakeFlow: async \(\) => \{\s*if \(!options\.sessionConnected\) return true;/,
+  );
   assert.match(
     terminalSource,
     /stopHibernateListeners\(\{\s*keepPaused:\s*true\s*\}\)/,
   );
   assert.match(
     terminalSource,
-    /resumeWakeFlow:\s*\(\)\s*=>\s*\{[\s\S]*?setSessionFlowPaused\?\.\(backendId,\s*false\)/,
+    /resumeWakeFlow:\s*\(shouldResume\)\s*=>\s*\{[\s\S]*?if \(!shouldResume\) return;[\s\S]*?setSessionFlowPaused\?\.\(backendId,\s*false\)/,
   );
   assert.match(
     terminalSource,

--- a/components/terminal/hibernateWakeChunking.test.ts
+++ b/components/terminal/hibernateWakeChunking.test.ts
@@ -29,37 +29,69 @@ const writeAndWait = (term: XTerm, data: string): Promise<void> =>
     term.write(data, () => resolve());
   });
 
-test("hibernate wake consumes pending via take-and-clear so capped arrivals are not skipped", () => {
+test("hibernate wake pauses flow before replay and resumes only after reattach", () => {
+  // #2762 / Codex: full-history wake must not race the capped pending buffer or
+  // the 64 KiB preload backlog. Pause+wait drains into pending, then stop the
+  // data listener, take pending once, replay, reattach, and only then resume.
   const mountSource = readFileSync(new URL("./terminalRuntimeMount.ts", import.meta.url), "utf8");
   const terminalSource = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
 
+  assert.match(mountSource, /prepareWakeFlow\?:\s*\(\) => Promise<void>/);
+  assert.match(mountSource, /resumeWakeFlow\?:\s*\(\) => void/);
   assert.match(mountSource, /takePendingBuffer: \(\) => string/);
   assert.match(mountSource, /stopHibernateDataListener: \(\) => void/);
+  assert.match(mountSource, /await prepareWakeFlow\?\.\(\);/);
+  assert.match(mountSource, /stopHibernateDataListener\(\);/);
   assert.match(mountSource, /const pendingAtApplyStart = takePendingBuffer\(\);/);
-  assert.match(mountSource, /const pendingDelta = takePendingBuffer\(\);/);
-  assert.match(mountSource, /const finalPendingDelta = takePendingBuffer\(\);/);
   assert.doesNotMatch(mountSource, /pending\.slice\(replayedPendingLength\)/);
+  // No multi-pass drain while the hibernate listener is live: that races the
+  // 512 KiB pending cap and can drop ACKed bytes under sustained output.
+  assert.doesNotMatch(mountSource, /for \(let drainPass = 0;/);
+  assert.doesNotMatch(mountSource, /finalPendingDelta/);
 
+  const prepareIndex = mountSource.indexOf("await prepareWakeFlow?.();");
   const stopDataIndex = mountSource.indexOf("stopHibernateDataListener();");
-  const finalPendingIndex = mountSource.indexOf("const finalPendingDelta = takePendingBuffer();");
+  const pendingIndex = mountSource.indexOf("const pendingAtApplyStart = takePendingBuffer();");
+  const applyIndex = mountSource.indexOf("await applyHibernateWakeToTerminal(");
   const shouldReattachIndex = mountSource.indexOf(
     "const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);",
   );
   const stopAllIndex = mountSource.indexOf("stopHibernateListeners();", shouldReattachIndex - 80);
-  assert.ok(stopDataIndex >= 0, "wake must stop the hibernate data listener before final drain");
-  assert.ok(finalPendingIndex > stopDataIndex, "final pending take must run after data listener stops");
+  const reattachIndex = mountSource.indexOf("reattachSession(term);", shouldReattachIndex);
+  const resumeIndex = mountSource.indexOf("resumeWakeFlow?.();", shouldReattachIndex);
+
+  assert.ok(prepareIndex >= 0, "wake must pause backend flow before history replay");
+  assert.ok(stopDataIndex > prepareIndex, "data listener stops only after flow pause drains");
+  assert.ok(pendingIndex > stopDataIndex, "pending take must run after data listener stops");
+  assert.ok(applyIndex > pendingIndex, "history replay follows the single pending capture");
   assert.ok(
-    shouldReattachIndex > finalPendingIndex,
-    "reattach decision must observe exit status after final replay",
+    shouldReattachIndex > applyIndex,
+    "reattach decision must observe exit status after replay",
   );
   assert.ok(
     stopAllIndex > shouldReattachIndex,
     "full hibernate listener teardown must wait until after the reattach decision",
   );
+  assert.ok(reattachIndex > stopAllIndex, "reattach runs after hibernate listeners are cleared");
+  assert.ok(resumeIndex > reattachIndex, "flow resume must wait until after reattach");
+  // Prefer finally so a failed wake cannot leave the backend paused forever.
+  assert.match(mountSource, /finally\s*\{\s*[\s\S]*?resumeWakeFlow\?\.\(\);/);
 
   assert.match(
     terminalSource,
     /takePendingBuffer:\s*\(\)\s*=>\s*\{\s*const pending = hibernatePendingBufferRef\.current;\s*hibernatePendingBufferRef\.current = "";\s*return pending;\s*\}/,
+  );
+  assert.match(
+    terminalSource,
+    /setSessionFlowPausedAndWait\?\.\(backendId,\s*true\)/,
+  );
+  assert.match(
+    terminalSource,
+    /stopHibernateListeners\(\{\s*keepPaused:\s*true\s*\}\)/,
+  );
+  assert.match(
+    terminalSource,
+    /resumeWakeFlow:\s*\(\)\s*=>\s*\{[\s\S]*?setSessionFlowPaused\?\.\(backendId,\s*false\)/,
   );
 });
 

--- a/components/terminal/hibernateWakeChunking.test.ts
+++ b/components/terminal/hibernateWakeChunking.test.ts
@@ -29,6 +29,21 @@ const writeAndWait = (term: XTerm, data: string): Promise<void> =>
     term.write(data, () => resolve());
   });
 
+test("hibernate wake consumes pending via take-and-clear so capped arrivals are not skipped", () => {
+  const mountSource = readFileSync(new URL("./terminalRuntimeMount.ts", import.meta.url), "utf8");
+  const terminalSource = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
+
+  assert.match(mountSource, /takePendingBuffer: \(\) => string/);
+  assert.match(mountSource, /const pendingAtApplyStart = takePendingBuffer\(\);/);
+  assert.match(mountSource, /const pendingDelta = takePendingBuffer\(\);/);
+  assert.doesNotMatch(mountSource, /pending\.slice\(replayedPendingLength\)/);
+
+  assert.match(
+    terminalSource,
+    /takePendingBuffer:\s*\(\)\s*=>\s*\{\s*const pending = hibernatePendingBufferRef\.current;\s*hibernatePendingBufferRef\.current = "";\s*return pending;\s*\}/,
+  );
+});
+
 test("writeTerminalPayloadChunked splits large buffers (shipped wake helper)", async () => {
   const writes: string[] = [];
   const term = {

--- a/components/terminal/hibernateWakeChunking.test.ts
+++ b/components/terminal/hibernateWakeChunking.test.ts
@@ -44,27 +44,28 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
   assert.match(mountSource, /const drainOk = \(await prepareWakeFlow\?\.\(\)\) \?\? true;/);
   assert.match(mountSource, /const takeAndTrackPending = \(\): string =>/);
   assert.match(mountSource, /const pendingAtApplyStart = takeAndTrackPending\(\);/);
-  assert.match(mountSource, /const latePending = takeAndTrackPending\(\);/);
-  assert.match(mountSource, /const exitTail = takeAndTrackPending\(\);/);
-  assert.match(mountSource, /const finalTail = takeAndTrackPending\(\);/);
-  assert.match(mountSource, /const preTeardownTail = takeAndTrackPending\(\);/);
+  assert.match(mountSource, /const pendingTail = takeAndTrackPending\(\);/);
+  assert.match(mountSource, /if \(!pendingTail\) break;/);
   assert.match(mountSource, /restoreAfterFailedWake\?\.\(takenPendingForRestore\)/);
   assert.doesNotMatch(mountSource, /pending\.slice\(replayedPendingLength\)/);
   assert.doesNotMatch(mountSource, /for \(let drainPass = 0;/);
   assert.doesNotMatch(mountSource, /finalPendingDelta/);
+  assert.doesNotMatch(mountSource, /preTeardownTail/);
 
   const prepareIndex = mountSource.indexOf("const drainOk = (await prepareWakeFlow?.()) ?? true;");
   const disableCapIndex = mountSource.indexOf("setHibernatePendingCapDisabled?.(true);");
   const stopDataBeforeReplay = mountSource.indexOf("if (drainOk) {\n      stopHibernateDataListener();");
   const pendingIndex = mountSource.indexOf("const pendingAtApplyStart = takeAndTrackPending();");
   const applyIndex = mountSource.indexOf("await applyHibernateWakeToTerminal(");
-  const latePendingIndex = mountSource.indexOf("const latePending = takeAndTrackPending();");
-  const exitTailIndex = mountSource.indexOf("const exitTail = takeAndTrackPending();");
-  const finalTailIndex = mountSource.indexOf("const finalTail = takeAndTrackPending();");
+  const stopDataBeforeTail = mountSource.indexOf(
+    "stopHibernateDataListener();",
+    applyIndex,
+  );
+  const pendingTailIndex = mountSource.indexOf("const pendingTail = takeAndTrackPending();");
+  const emptyBreakIndex = mountSource.indexOf("if (!pendingTail) break;");
   const shouldReattachIndex = mountSource.indexOf(
     "const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);",
   );
-  const preTeardownIndex = mountSource.indexOf("const preTeardownTail = takeAndTrackPending();");
   const stopAllIndex = mountSource.indexOf("stopHibernateListeners();", shouldReattachIndex);
   const reattachIndex = mountSource.indexOf("reattachSession(term);", shouldReattachIndex);
   const failedRestoreIndex = mountSource.indexOf("restoreAfterFailedWake?.(takenPendingForRestore);");
@@ -79,18 +80,20 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
   assert.ok(pendingIndex > stopDataBeforeReplay, "pending take must run after drain handling");
   assert.ok(applyIndex > pendingIndex, "history replay follows the pending capture");
   assert.ok(
-    latePendingIndex > applyIndex,
-    "late pending take must run after history replay to keep exit/live tails",
-  );
-  assert.ok(exitTailIndex > latePendingIndex, "exit-tail take must follow the late pending await");
-  assert.ok(finalTailIndex > exitTailIndex, "final tail take must follow exit-tail await");
-  assert.ok(
-    preTeardownIndex > finalTailIndex,
-    "pre-teardown pending take must follow final tail",
+    stopDataBeforeTail > applyIndex,
+    "data listener must stop again before residual pending drain",
   );
   assert.ok(
-    shouldReattachIndex > preTeardownIndex,
-    "reattach decision must run after all pending/exit drains",
+    pendingTailIndex > stopDataBeforeTail,
+    "residual pending drain must run after history replay",
+  );
+  assert.ok(
+    emptyBreakIndex > pendingTailIndex,
+    "residual drain must end with an empty take before teardown",
+  );
+  assert.ok(
+    shouldReattachIndex > emptyBreakIndex,
+    "reattach decision must run after until-empty pending drain",
   );
   assert.ok(
     stopAllIndex > shouldReattachIndex,

--- a/components/terminal/hibernateWakeChunking.test.ts
+++ b/components/terminal/hibernateWakeChunking.test.ts
@@ -34,15 +34,28 @@ test("hibernate wake consumes pending via take-and-clear so capped arrivals are 
   const terminalSource = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
 
   assert.match(mountSource, /takePendingBuffer: \(\) => string/);
+  assert.match(mountSource, /stopHibernateDataListener: \(\) => void/);
   assert.match(mountSource, /const pendingAtApplyStart = takePendingBuffer\(\);/);
   assert.match(mountSource, /const pendingDelta = takePendingBuffer\(\);/);
   assert.match(mountSource, /const finalPendingDelta = takePendingBuffer\(\);/);
   assert.doesNotMatch(mountSource, /pending\.slice\(replayedPendingLength\)/);
 
-  const stopListenersIndex = mountSource.indexOf("stopHibernateListeners();");
+  const stopDataIndex = mountSource.indexOf("stopHibernateDataListener();");
   const finalPendingIndex = mountSource.indexOf("const finalPendingDelta = takePendingBuffer();");
-  assert.ok(stopListenersIndex >= 0, "wake must stop hibernate listeners");
-  assert.ok(finalPendingIndex > stopListenersIndex, "final pending take must run after listeners stop");
+  const shouldReattachIndex = mountSource.indexOf(
+    "const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);",
+  );
+  const stopAllIndex = mountSource.indexOf("stopHibernateListeners();", shouldReattachIndex - 80);
+  assert.ok(stopDataIndex >= 0, "wake must stop the hibernate data listener before final drain");
+  assert.ok(finalPendingIndex > stopDataIndex, "final pending take must run after data listener stops");
+  assert.ok(
+    shouldReattachIndex > finalPendingIndex,
+    "reattach decision must observe exit status after final replay",
+  );
+  assert.ok(
+    stopAllIndex > shouldReattachIndex,
+    "full hibernate listener teardown must wait until after the reattach decision",
+  );
 
   assert.match(
     terminalSource,

--- a/components/terminal/hibernateWakeChunking.test.ts
+++ b/components/terminal/hibernateWakeChunking.test.ts
@@ -39,6 +39,11 @@ test("hibernate wake consumes pending via take-and-clear so capped arrivals are 
   assert.match(mountSource, /const finalPendingDelta = takePendingBuffer\(\);/);
   assert.doesNotMatch(mountSource, /pending\.slice\(replayedPendingLength\)/);
 
+  const stopListenersIndex = mountSource.indexOf("stopHibernateListeners();");
+  const finalPendingIndex = mountSource.indexOf("const finalPendingDelta = takePendingBuffer();");
+  assert.ok(stopListenersIndex >= 0, "wake must stop hibernate listeners");
+  assert.ok(finalPendingIndex > stopListenersIndex, "final pending take must run after listeners stop");
+
   assert.match(
     terminalSource,
     /takePendingBuffer:\s*\(\)\s*=>\s*\{\s*const pending = hibernatePendingBufferRef\.current;\s*hibernatePendingBufferRef\.current = "";\s*return pending;\s*\}/,

--- a/components/terminal/hibernateWakeChunking.test.ts
+++ b/components/terminal/hibernateWakeChunking.test.ts
@@ -36,6 +36,7 @@ test("hibernate wake consumes pending via take-and-clear so capped arrivals are 
   assert.match(mountSource, /takePendingBuffer: \(\) => string/);
   assert.match(mountSource, /const pendingAtApplyStart = takePendingBuffer\(\);/);
   assert.match(mountSource, /const pendingDelta = takePendingBuffer\(\);/);
+  assert.match(mountSource, /const finalPendingDelta = takePendingBuffer\(\);/);
   assert.doesNotMatch(mountSource, /pending\.slice\(replayedPendingLength\)/);
 
   assert.match(

--- a/components/terminal/hibernateWakeChunking.test.ts
+++ b/components/terminal/hibernateWakeChunking.test.ts
@@ -37,15 +37,18 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
   const terminalSource = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
 
   assert.match(mountSource, /prepareWakeFlow\?:\s*\(\) => Promise<boolean>/);
-  assert.match(mountSource, /restoreAfterFailedWake\?:\s*\(\) => void/);
+  assert.match(mountSource, /restoreAfterFailedWake\?:\s*\(takenPending: string\) => void/);
   assert.match(mountSource, /resumeAfterReattach\?:\s*\(\) => void/);
   assert.match(mountSource, /takePendingBuffer: \(\) => string/);
   assert.match(mountSource, /stopHibernateDataListener: \(\) => void/);
   assert.match(mountSource, /const drainOk = \(await prepareWakeFlow\?\.\(\)\) \?\? true;/);
-  assert.match(mountSource, /const pendingAtApplyStart = takePendingBuffer\(\);/);
-  assert.match(mountSource, /const latePending = takePendingBuffer\(\);/);
-  assert.match(mountSource, /const exitTail = takePendingBuffer\(\);/);
-  assert.match(mountSource, /const finalTail = takePendingBuffer\(\);/);
+  assert.match(mountSource, /const takeAndTrackPending = \(\): string =>/);
+  assert.match(mountSource, /const pendingAtApplyStart = takeAndTrackPending\(\);/);
+  assert.match(mountSource, /const latePending = takeAndTrackPending\(\);/);
+  assert.match(mountSource, /const exitTail = takeAndTrackPending\(\);/);
+  assert.match(mountSource, /const finalTail = takeAndTrackPending\(\);/);
+  assert.match(mountSource, /const preTeardownTail = takeAndTrackPending\(\);/);
+  assert.match(mountSource, /restoreAfterFailedWake\?\.\(takenPendingForRestore\)/);
   assert.doesNotMatch(mountSource, /pending\.slice\(replayedPendingLength\)/);
   assert.doesNotMatch(mountSource, /for \(let drainPass = 0;/);
   assert.doesNotMatch(mountSource, /finalPendingDelta/);
@@ -53,17 +56,18 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
   const prepareIndex = mountSource.indexOf("const drainOk = (await prepareWakeFlow?.()) ?? true;");
   const disableCapIndex = mountSource.indexOf("setHibernatePendingCapDisabled?.(true);");
   const stopDataBeforeReplay = mountSource.indexOf("if (drainOk) {\n      stopHibernateDataListener();");
-  const pendingIndex = mountSource.indexOf("const pendingAtApplyStart = takePendingBuffer();");
+  const pendingIndex = mountSource.indexOf("const pendingAtApplyStart = takeAndTrackPending();");
   const applyIndex = mountSource.indexOf("await applyHibernateWakeToTerminal(");
-  const latePendingIndex = mountSource.indexOf("const latePending = takePendingBuffer();");
-  const exitTailIndex = mountSource.indexOf("const exitTail = takePendingBuffer();");
-  const finalTailIndex = mountSource.indexOf("const finalTail = takePendingBuffer();");
+  const latePendingIndex = mountSource.indexOf("const latePending = takeAndTrackPending();");
+  const exitTailIndex = mountSource.indexOf("const exitTail = takeAndTrackPending();");
+  const finalTailIndex = mountSource.indexOf("const finalTail = takeAndTrackPending();");
   const shouldReattachIndex = mountSource.indexOf(
     "const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);",
   );
+  const preTeardownIndex = mountSource.indexOf("const preTeardownTail = takeAndTrackPending();");
   const stopAllIndex = mountSource.indexOf("stopHibernateListeners();", shouldReattachIndex);
   const reattachIndex = mountSource.indexOf("reattachSession(term);", shouldReattachIndex);
-  const failedRestoreIndex = mountSource.indexOf("restoreAfterFailedWake?.();");
+  const failedRestoreIndex = mountSource.indexOf("restoreAfterFailedWake?.(takenPendingForRestore);");
   const resumeIndex = mountSource.indexOf("resumeAfterReattach?.();");
 
   assert.ok(prepareIndex >= 0, "wake must pause backend flow before history replay");
@@ -81,7 +85,11 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
   assert.ok(exitTailIndex > latePendingIndex, "exit-tail take must follow the late pending await");
   assert.ok(finalTailIndex > exitTailIndex, "final tail take must follow exit-tail await");
   assert.ok(
-    shouldReattachIndex > finalTailIndex,
+    preTeardownIndex > finalTailIndex,
+    "pre-teardown pending take must follow final tail",
+  );
+  assert.ok(
+    shouldReattachIndex > preTeardownIndex,
     "reattach decision must run after all pending/exit drains",
   );
   assert.ok(
@@ -89,11 +97,11 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
     "full hibernate listener teardown must wait until after the reattach decision",
   );
   assert.ok(reattachIndex > stopAllIndex, "reattach runs after hibernate listeners are cleared");
-  assert.ok(failedRestoreIndex >= 0, "failed wakes must restore hibernate listeners");
+  assert.ok(failedRestoreIndex >= 0, "failed wakes must restore take-and-cleared pending");
   assert.ok(resumeIndex > reattachIndex, "flow resume must wait until after reattach");
   assert.match(
     mountSource,
-    /if \(!wakeSucceeded\) \{[\s\S]*?restoreAfterFailedWake\?\.\(\);[\s\S]*?\} else if \(didReattach\) \{[\s\S]*?resumeAfterReattach\?\.\(\);/,
+    /if \(!wakeSucceeded\) \{[\s\S]*?restoreAfterFailedWake\?\.\(takenPendingForRestore\);[\s\S]*?\} else if \(didReattach\) \{[\s\S]*?resumeAfterReattach\?\.\(\);/,
   );
 
   assert.match(
@@ -116,7 +124,11 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
   );
   assert.match(
     terminalSource,
-    /restoreAfterFailedWake:\s*\(\)\s*=>\s*\{[\s\S]*?disposeRuntimeOnly\(\);[\s\S]*?beginHibernatedSessionListeners\(backendId\)/,
+    /restoreAfterFailedWake:\s*\(takenPending\)\s*=>\s*\{[\s\S]*?disposeRuntimeOnly\(\);[\s\S]*?beginHibernatedSessionListeners\(backendId\)/,
+  );
+  assert.match(
+    terminalSource,
+    /appendHibernatePendingBuffer\(\s*takenPending \|\| "",\s*pendingStillInRef,\s*\)/,
   );
   assert.match(
     terminalSource,

--- a/components/terminal/hibernateWakeChunking.test.ts
+++ b/components/terminal/hibernateWakeChunking.test.ts
@@ -36,41 +36,52 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
   const mountSource = readFileSync(new URL("./terminalRuntimeMount.ts", import.meta.url), "utf8");
   const terminalSource = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
 
-  assert.match(mountSource, /prepareWakeFlow\?:\s*\(\) => Promise<void>/);
+  assert.match(mountSource, /prepareWakeFlow\?:\s*\(\) => Promise<boolean>/);
   assert.match(mountSource, /resumeWakeFlow\?:\s*\(\) => void/);
   assert.match(mountSource, /takePendingBuffer: \(\) => string/);
   assert.match(mountSource, /stopHibernateDataListener: \(\) => void/);
-  assert.match(mountSource, /await prepareWakeFlow\?\.\(\);/);
+  assert.match(mountSource, /const drainOk = \(await prepareWakeFlow\?\.\(\)\) \?\? true;/);
   assert.match(mountSource, /stopHibernateDataListener\(\);/);
   assert.match(mountSource, /const pendingAtApplyStart = takePendingBuffer\(\);/);
+  assert.match(mountSource, /const latePending = takePendingBuffer\(\);/);
   assert.doesNotMatch(mountSource, /pending\.slice\(replayedPendingLength\)/);
   // No multi-pass drain while the hibernate listener is live: that races the
   // 512 KiB pending cap and can drop ACKed bytes under sustained output.
   assert.doesNotMatch(mountSource, /for \(let drainPass = 0;/);
   assert.doesNotMatch(mountSource, /finalPendingDelta/);
 
-  const prepareIndex = mountSource.indexOf("await prepareWakeFlow?.();");
-  const stopDataIndex = mountSource.indexOf("stopHibernateDataListener();");
+  const prepareIndex = mountSource.indexOf("const drainOk = (await prepareWakeFlow?.()) ?? true;");
+  const disableCapIndex = mountSource.indexOf("setHibernatePendingCapDisabled?.(true);");
+  const stopDataBeforeReplay = mountSource.indexOf("if (drainOk) {\n      stopHibernateDataListener();");
   const pendingIndex = mountSource.indexOf("const pendingAtApplyStart = takePendingBuffer();");
   const applyIndex = mountSource.indexOf("await applyHibernateWakeToTerminal(");
   const shouldReattachIndex = mountSource.indexOf(
     "const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);",
   );
-  const stopAllIndex = mountSource.indexOf("stopHibernateListeners();", shouldReattachIndex - 80);
+  const latePendingIndex = mountSource.indexOf("const latePending = takePendingBuffer();");
+  const stopAllIndex = mountSource.indexOf("stopHibernateListeners();", shouldReattachIndex);
   const reattachIndex = mountSource.indexOf("reattachSession(term);", shouldReattachIndex);
   const resumeIndex = mountSource.indexOf("resumeWakeFlow?.();", shouldReattachIndex);
 
   assert.ok(prepareIndex >= 0, "wake must pause backend flow before history replay");
-  assert.ok(stopDataIndex > prepareIndex, "data listener stops only after flow pause drains");
-  assert.ok(pendingIndex > stopDataIndex, "pending take must run after data listener stops");
-  assert.ok(applyIndex > pendingIndex, "history replay follows the single pending capture");
+  assert.ok(
+    disableCapIndex > prepareIndex,
+    "drain failure must disable the pending cap before keeping the live listener",
+  );
+  assert.ok(stopDataBeforeReplay > prepareIndex, "successful drain stops the data listener before replay");
+  assert.ok(pendingIndex > stopDataBeforeReplay, "pending take must run after drain handling");
+  assert.ok(applyIndex > pendingIndex, "history replay follows the pending capture");
   assert.ok(
     shouldReattachIndex > applyIndex,
-    "reattach decision must observe exit status after replay",
+    "reattach decision must observe exit status after history replay",
   );
   assert.ok(
-    stopAllIndex > shouldReattachIndex,
-    "full hibernate listener teardown must wait until after the reattach decision",
+    latePendingIndex > shouldReattachIndex,
+    "late pending take must run after history replay to keep exit/live tails",
+  );
+  assert.ok(
+    stopAllIndex > latePendingIndex,
+    "full hibernate listener teardown must wait until after the late pending drain",
   );
   assert.ok(reattachIndex > stopAllIndex, "reattach runs after hibernate listeners are cleared");
   assert.ok(resumeIndex > reattachIndex, "flow resume must wait until after reattach");
@@ -83,7 +94,7 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
   );
   assert.match(
     terminalSource,
-    /setSessionFlowPausedAndWait\?\.\(backendId,\s*true\)/,
+    /setSessionFlowPausedAndWait\(backendId,\s*true\)/,
   );
   assert.match(
     terminalSource,
@@ -92,6 +103,14 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
   assert.match(
     terminalSource,
     /resumeWakeFlow:\s*\(\)\s*=>\s*\{[\s\S]*?setSessionFlowPaused\?\.\(backendId,\s*false\)/,
+  );
+  assert.match(
+    terminalSource,
+    /hibernatePendingCapDisabledRef\.current\s*\?\s*hibernatePendingBufferRef\.current \+ chunk/,
+  );
+  assert.match(
+    terminalSource,
+    /result\?\.success === true/,
   );
 });
 

--- a/components/terminal/hibernateWakeChunking.test.ts
+++ b/components/terminal/hibernateWakeChunking.test.ts
@@ -2,10 +2,27 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
+import xterm from "@xterm/xterm";
 import type { Terminal as XTerm } from "@xterm/xterm";
 
 import { applyHibernateWakeToTerminal } from "./terminalHibernateRuntime.ts";
 import { writeTerminalPayloadChunked } from "./terminalReplay.ts";
+
+const { Terminal } = xterm;
+
+const readActiveBufferText = (term: XTerm): string => {
+  const buffer = term.buffer.active;
+  const lines: string[] = [];
+  for (let index = 0; index < buffer.length; index += 1) {
+    lines.push(buffer.getLine(index)?.translateToString(true) ?? "");
+  }
+  return lines.join("\n");
+};
+
+const writeAndWait = (term: XTerm, data: string): Promise<void> =>
+  new Promise((resolve) => {
+    term.write(data, () => resolve());
+  });
 
 test("writeTerminalPayloadChunked splits large buffers (shipped wake helper)", async () => {
   const writes: string[] = [];
@@ -22,7 +39,7 @@ test("writeTerminalPayloadChunked splits large buffers (shipped wake helper)", a
   assert.equal(writes.join(""), payload);
 });
 
-test("applyHibernateWakeToTerminal defers scrollback to idle and chunks viewport first", async () => {
+test("applyHibernateWakeToTerminal replays scrollback before viewport without idle append", async () => {
   const writes: string[] = [];
   const term = {
     rows: 24,
@@ -43,38 +60,34 @@ test("applyHibernateWakeToTerminal defers scrollback to idle and chunks viewport
   // @ts-expect-error test override
   globalThis.requestIdleCallback = (cb: () => void) => {
     idleScheduled = true;
-    // Do not run immediately — proves scrollback is deferred off the wake path.
     setTimeout(cb, 0);
     return 1;
   };
 
   try {
-    const viewport = "VIEWPORT";
-    const scrollback = "S".repeat(40_000);
+    const viewport = "VIEWPORT_END\r\n";
+    const scrollback = "SCROLLBACK_START\r\n";
+    const pending = "PENDING_TAIL\r\n";
     await applyHibernateWakeToTerminal(
       term,
       runtime as never,
       {
-        snapshot: viewport,
+        snapshot: `${scrollback}${viewport}`,
         viewportSnapshot: viewport,
         scrollbackSnapshot: scrollback,
-        pendingBuffer: "",
+        pendingBuffer: pending,
         alternateScreen: false,
       },
       { replayOptions: { chunkBytes: 8_192 } },
     );
 
-    // Viewport written on the wake path; scrollback scheduled idle.
-    assert.ok(writes.join("").includes(viewport));
-    assert.equal(idleScheduled, true);
-    assert.ok(
-      !writes.join("").includes(scrollback.slice(0, 1000)),
-      "scrollback must not be written synchronously on wake",
+    const joined = writes.join("");
+    assert.equal(joined, `${scrollback}${viewport}${pending}`);
+    assert.equal(
+      idleScheduled,
+      false,
+      "scrollback must not be deferred to idle after viewport (append would evict the end)",
     );
-
-    // Flush idle callback.
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    assert.ok(writes.join("").includes(scrollback.slice(0, 100)), "scrollback eventually applied");
   } finally {
     if (originalRic) {
       globalThis.requestIdleCallback = originalRic;
@@ -85,9 +98,94 @@ test("applyHibernateWakeToTerminal defers scrollback to idle and chunks viewport
   }
 });
 
-test("hibernate runtime source schedules scrollback via requestIdleCallback", () => {
+test("hibernate wake keeps the newest viewport rows under a finite scrollback cap", async () => {
+  // #2762: appending older scrollback after viewport under scrollback=N evicts the
+  // newest rows (the just-restored viewport). Replay must be scrollback → viewport.
+  const rows = 5;
+  const scrollbackCap = 10;
+  const term = new Terminal({
+    cols: 40,
+    rows,
+    scrollback: scrollbackCap,
+    allowProposedApi: true,
+  });
+
+  const runtime = {
+    ensureWebglRenderer: () => {},
+    clearTextureAtlas: () => {},
+  };
+
+  try {
+    const olderLines = Array.from({ length: scrollbackCap }, (_, index) => `old-${index}`);
+    const newestLines = Array.from({ length: rows }, (_, index) => `new-${index}`);
+    const scrollback = `${olderLines.join("\r\n")}\r\n`;
+    const viewport = `${newestLines.join("\r\n")}\r\n`;
+
+    await applyHibernateWakeToTerminal(
+      term,
+      runtime as never,
+      {
+        snapshot: `${scrollback}${viewport}`,
+        viewportSnapshot: viewport,
+        scrollbackSnapshot: scrollback,
+        pendingBuffer: "",
+        alternateScreen: false,
+      },
+      { replayOptions: { chunkBytes: 1024 } },
+    );
+
+    // Drain any stray idle work the old buggy path might have scheduled.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const text = readActiveBufferText(term);
+    for (const line of newestLines) {
+      assert.match(text, new RegExp(line), `newest viewport line missing after wake: ${line}`);
+    }
+    assert.match(text, /old-/, "some older scrollback should still be present");
+  } finally {
+    term.dispose();
+  }
+});
+
+test("wrong wake order (viewport then scrollback append) drops newest rows under scrollback cap", async () => {
+  // Guardrail: documents why idle-append-after-viewport is unsafe.
+  const rows = 5;
+  const scrollbackCap = 10;
+  const term = new Terminal({
+    cols: 40,
+    rows,
+    scrollback: scrollbackCap,
+    allowProposedApi: true,
+  });
+
+  try {
+    // Overflow by a full viewport so every newest row is trimmed as oldest.
+    const olderLines = Array.from({ length: scrollbackCap + rows }, (_, index) => `old-${index}`);
+    const newestLines = Array.from({ length: rows }, (_, index) => `new-${index}`);
+    await writeAndWait(term, `${newestLines.join("\r\n")}\r\n`);
+    await writeAndWait(term, `${olderLines.join("\r\n")}\r\n`);
+
+    const text = readActiveBufferText(term);
+    for (const line of newestLines) {
+      assert.equal(
+        text.includes(line),
+        false,
+        `viewport-first append must evict newest line under the cap: ${line}`,
+      );
+    }
+    assert.match(text, /old-14/);
+  } finally {
+    term.dispose();
+  }
+});
+test("hibernate runtime source replays scrollback before viewport on the wake path", () => {
   const source = readFileSync(new URL("./terminalHibernateRuntime.ts", import.meta.url), "utf8");
-  assert.match(source, /requestIdleCallback|scheduleIdle/);
-  assert.match(source, /writeTerminalPayloadChunked\(term, scrollback/);
-  assert.match(source, /writeTerminalReplaySequence\(term, \[viewport, payload\.pendingBuffer\]/);
+  assert.match(
+    source,
+    /writeTerminalReplaySequence\(\s*term,\s*\[\s*scrollback,\s*viewport,\s*payload\.pendingBuffer\s*\]/,
+  );
+  assert.doesNotMatch(
+    source,
+    /scheduleIdle\(\(\)\s*=>\s*\{\s*void writeTerminalPayloadChunked\(term, scrollback/,
+  );
 });

--- a/components/terminal/hibernateWakeChunking.test.ts
+++ b/components/terminal/hibernateWakeChunking.test.ts
@@ -3,12 +3,17 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 import xterm from "@xterm/xterm";
+import serializeMod from "@xterm/addon-serialize";
 import type { Terminal as XTerm } from "@xterm/xterm";
 
-import { applyHibernateWakeToTerminal } from "./terminalHibernateRuntime.ts";
+import {
+  applyHibernateWakeToTerminal,
+  resolveHibernateWakeHistory,
+} from "./terminalHibernateRuntime.ts";
 import { writeTerminalPayloadChunked } from "./terminalReplay.ts";
 
 const { Terminal } = xterm;
+const { SerializeAddon } = serializeMod;
 
 const readActiveBufferText = (term: XTerm): string => {
   const buffer = term.buffer.active;
@@ -39,7 +44,43 @@ test("writeTerminalPayloadChunked splits large buffers (shipped wake helper)", a
   assert.equal(writes.join(""), payload);
 });
 
-test("applyHibernateWakeToTerminal replays scrollback before viewport without idle append", async () => {
+test("resolveHibernateWakeHistory prefers the coherent full snapshot", () => {
+  assert.equal(
+    resolveHibernateWakeHistory({
+      snapshot: "FULL",
+      viewportSnapshot: "VIEW",
+      scrollbackSnapshot: "SCROLL",
+      pendingBuffer: "",
+      alternateScreen: false,
+    }),
+    "FULL",
+  );
+});
+
+test("resolveHibernateWakeHistory falls back to scrollback before viewport with a seam newline", () => {
+  assert.equal(
+    resolveHibernateWakeHistory({
+      snapshot: "",
+      viewportSnapshot: "VIEWPORT_END\r\n",
+      scrollbackSnapshot: "SCROLLBACK_START",
+      pendingBuffer: "",
+      alternateScreen: false,
+    }),
+    "SCROLLBACK_START\r\nVIEWPORT_END\r\n",
+  );
+  assert.equal(
+    resolveHibernateWakeHistory({
+      snapshot: "",
+      viewportSnapshot: "VIEWPORT_END\r\n",
+      scrollbackSnapshot: "SCROLLBACK_START\r\n",
+      pendingBuffer: "",
+      alternateScreen: false,
+    }),
+    "SCROLLBACK_START\r\nVIEWPORT_END\r\n",
+  );
+});
+
+test("applyHibernateWakeToTerminal replays snapshot then pending without idle append", async () => {
   const writes: string[] = [];
   const term = {
     rows: 24,
@@ -65,24 +106,22 @@ test("applyHibernateWakeToTerminal replays scrollback before viewport without id
   };
 
   try {
-    const viewport = "VIEWPORT_END\r\n";
-    const scrollback = "SCROLLBACK_START\r\n";
+    const snapshot = "SCROLLBACK_START\r\nVIEWPORT_END\r\n";
     const pending = "PENDING_TAIL\r\n";
     await applyHibernateWakeToTerminal(
       term,
       runtime as never,
       {
-        snapshot: `${scrollback}${viewport}`,
-        viewportSnapshot: viewport,
-        scrollbackSnapshot: scrollback,
+        snapshot,
+        viewportSnapshot: "VIEWPORT_END\r\n",
+        scrollbackSnapshot: "SCROLLBACK_START\r\n",
         pendingBuffer: pending,
         alternateScreen: false,
       },
       { replayOptions: { chunkBytes: 8_192 } },
     );
 
-    const joined = writes.join("");
-    assert.equal(joined, `${scrollback}${viewport}${pending}`);
+    assert.equal(writes.join(""), `${snapshot}${pending}`);
     assert.equal(
       idleScheduled,
       false,
@@ -98,50 +137,70 @@ test("applyHibernateWakeToTerminal replays scrollback before viewport without id
   }
 });
 
-test("hibernate wake keeps the newest viewport rows under a finite scrollback cap", async () => {
-  // #2762: appending older scrollback after viewport under scrollback=N evicts the
-  // newest rows (the just-restored viewport). Replay must be scrollback → viewport.
+test("hibernate wake keeps newest rows from a SerializeAddon snapshot under a finite scrollback cap", async () => {
+  // #2762: idle-appending older scrollback after viewport under scrollback=N
+  // evicts the newest rows. Prefer the full SerializeAddon snapshot.
   const rows = 5;
-  const scrollbackCap = 10;
+  const scrollbackCap = 8;
+  const source = new Terminal({
+    cols: 40,
+    rows,
+    scrollback: 50,
+    allowProposedApi: true,
+  });
+  const serializeAddon = new SerializeAddon();
+  source.loadAddon(serializeAddon);
+
+  const olderLines = Array.from({ length: 20 }, (_, index) => `old-${index}`);
+  const newestLines = Array.from({ length: rows }, (_, index) => `new-${index}`);
+  await writeAndWait(source, `${olderLines.join("\r\n")}\r\n${newestLines.join("\r\n")}\r\n`);
+
+  const snapshot = serializeAddon.serialize();
+  const bufferLength = source.buffer.active.length;
+  const viewportStart = Math.max(0, bufferLength - rows);
+  const scrollbackSnapshot = serializeAddon.serialize({
+    range: { start: Math.max(0, viewportStart - 20), end: viewportStart - 1 },
+  });
+  const viewportSnapshot = serializeAddon.serialize({
+    range: { start: viewportStart, end: bufferLength - 1 },
+  });
+  source.dispose();
+
+  // Range concat is not byte-identical to the full snapshot (missing seam newline).
+  assert.notEqual(scrollbackSnapshot + viewportSnapshot, snapshot);
+
   const term = new Terminal({
     cols: 40,
     rows,
     scrollback: scrollbackCap,
     allowProposedApi: true,
   });
-
   const runtime = {
     ensureWebglRenderer: () => {},
     clearTextureAtlas: () => {},
   };
 
   try {
-    const olderLines = Array.from({ length: scrollbackCap }, (_, index) => `old-${index}`);
-    const newestLines = Array.from({ length: rows }, (_, index) => `new-${index}`);
-    const scrollback = `${olderLines.join("\r\n")}\r\n`;
-    const viewport = `${newestLines.join("\r\n")}\r\n`;
-
     await applyHibernateWakeToTerminal(
       term,
       runtime as never,
       {
-        snapshot: `${scrollback}${viewport}`,
-        viewportSnapshot: viewport,
-        scrollbackSnapshot: scrollback,
+        snapshot,
+        viewportSnapshot,
+        scrollbackSnapshot,
         pendingBuffer: "",
         alternateScreen: false,
       },
       { replayOptions: { chunkBytes: 1024 } },
     );
 
-    // Drain any stray idle work the old buggy path might have scheduled.
     await new Promise((resolve) => setTimeout(resolve, 30));
 
     const text = readActiveBufferText(term);
     for (const line of newestLines) {
       assert.match(text, new RegExp(line), `newest viewport line missing after wake: ${line}`);
     }
-    assert.match(text, /old-/, "some older scrollback should still be present");
+    assert.doesNotMatch(text, /new-0new-1/, "seam must not merge adjacent snapshot lines");
   } finally {
     term.dispose();
   }
@@ -159,7 +218,6 @@ test("wrong wake order (viewport then scrollback append) drops newest rows under
   });
 
   try {
-    // Overflow by a full viewport so every newest row is trimmed as oldest.
     const olderLines = Array.from({ length: scrollbackCap + rows }, (_, index) => `old-${index}`);
     const newestLines = Array.from({ length: rows }, (_, index) => `new-${index}`);
     await writeAndWait(term, `${newestLines.join("\r\n")}\r\n`);
@@ -178,11 +236,13 @@ test("wrong wake order (viewport then scrollback append) drops newest rows under
     term.dispose();
   }
 });
-test("hibernate runtime source replays scrollback before viewport on the wake path", () => {
+
+test("hibernate runtime source prefers resolveHibernateWakeHistory on the wake path", () => {
   const source = readFileSync(new URL("./terminalHibernateRuntime.ts", import.meta.url), "utf8");
+  assert.match(source, /export function resolveHibernateWakeHistory/);
   assert.match(
     source,
-    /writeTerminalReplaySequence\(\s*term,\s*\[\s*scrollback,\s*viewport,\s*payload\.pendingBuffer\s*\]/,
+    /writeTerminalReplaySequence\(\s*term,\s*\[\s*history,\s*payload\.pendingBuffer\s*\]/,
   );
   assert.doesNotMatch(
     source,

--- a/components/terminal/hibernateWakeChunking.test.ts
+++ b/components/terminal/hibernateWakeChunking.test.ts
@@ -37,14 +37,15 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
   const terminalSource = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
 
   assert.match(mountSource, /prepareWakeFlow\?:\s*\(\) => Promise<boolean>/);
-  assert.match(mountSource, /resumeWakeFlow\?:\s*\(shouldResume: boolean\) => void/);
+  assert.match(mountSource, /restoreAfterFailedWake\?:\s*\(\) => void/);
+  assert.match(mountSource, /resumeAfterReattach\?:\s*\(\) => void/);
   assert.match(mountSource, /takePendingBuffer: \(\) => string/);
   assert.match(mountSource, /stopHibernateDataListener: \(\) => void/);
   assert.match(mountSource, /const drainOk = \(await prepareWakeFlow\?\.\(\)\) \?\? true;/);
-  assert.match(mountSource, /stopHibernateDataListener\(\);/);
   assert.match(mountSource, /const pendingAtApplyStart = takePendingBuffer\(\);/);
   assert.match(mountSource, /const latePending = takePendingBuffer\(\);/);
   assert.match(mountSource, /const exitTail = takePendingBuffer\(\);/);
+  assert.match(mountSource, /const finalTail = takePendingBuffer\(\);/);
   assert.doesNotMatch(mountSource, /pending\.slice\(replayedPendingLength\)/);
   assert.doesNotMatch(mountSource, /for \(let drainPass = 0;/);
   assert.doesNotMatch(mountSource, /finalPendingDelta/);
@@ -56,12 +57,14 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
   const applyIndex = mountSource.indexOf("await applyHibernateWakeToTerminal(");
   const latePendingIndex = mountSource.indexOf("const latePending = takePendingBuffer();");
   const exitTailIndex = mountSource.indexOf("const exitTail = takePendingBuffer();");
+  const finalTailIndex = mountSource.indexOf("const finalTail = takePendingBuffer();");
   const shouldReattachIndex = mountSource.indexOf(
     "const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);",
   );
   const stopAllIndex = mountSource.indexOf("stopHibernateListeners();", shouldReattachIndex);
   const reattachIndex = mountSource.indexOf("reattachSession(term);", shouldReattachIndex);
-  const resumeIndex = mountSource.indexOf("resumeWakeFlow?.(didReattach || !wakeSucceeded);");
+  const failedRestoreIndex = mountSource.indexOf("restoreAfterFailedWake?.();");
+  const resumeIndex = mountSource.indexOf("resumeAfterReattach?.();");
 
   assert.ok(prepareIndex >= 0, "wake must pause backend flow before history replay");
   assert.ok(
@@ -75,21 +78,23 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
     latePendingIndex > applyIndex,
     "late pending take must run after history replay to keep exit/live tails",
   );
+  assert.ok(exitTailIndex > latePendingIndex, "exit-tail take must follow the late pending await");
+  assert.ok(finalTailIndex > exitTailIndex, "final tail take must follow exit-tail await");
   assert.ok(
-    exitTailIndex > latePendingIndex,
-    "exit-tail take must follow the late pending await",
-  );
-  assert.ok(
-    shouldReattachIndex > exitTailIndex,
-    "reattach decision must run after late pending/exit-tail replay",
+    shouldReattachIndex > finalTailIndex,
+    "reattach decision must run after all pending/exit drains",
   );
   assert.ok(
     stopAllIndex > shouldReattachIndex,
     "full hibernate listener teardown must wait until after the reattach decision",
   );
   assert.ok(reattachIndex > stopAllIndex, "reattach runs after hibernate listeners are cleared");
+  assert.ok(failedRestoreIndex >= 0, "failed wakes must restore hibernate listeners");
   assert.ok(resumeIndex > reattachIndex, "flow resume must wait until after reattach");
-  assert.match(mountSource, /finally\s*\{\s*[\s\S]*?resumeWakeFlow\?\.\(didReattach \|\| !wakeSucceeded\);/);
+  assert.match(
+    mountSource,
+    /if \(!wakeSucceeded\) \{[\s\S]*?restoreAfterFailedWake\?\.\(\);[\s\S]*?\} else if \(didReattach\) \{[\s\S]*?resumeAfterReattach\?\.\(\);/,
+  );
 
   assert.match(
     terminalSource,
@@ -100,7 +105,7 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
     /setSessionFlowPausedAndWait\(backendId,\s*true\)/,
   );
   // Reconnect wakes (sessionConnected=false) must still pause when a backend
-  // session exists — otherwise stopping the hibernate listener drops live output.
+  // session exists; otherwise stopping the hibernate listener drops live output.
   assert.doesNotMatch(
     terminalSource,
     /prepareWakeFlow: async \(\) => \{\s*if \(!options\.sessionConnected\) return true;/,
@@ -111,7 +116,11 @@ test("hibernate wake pauses flow before replay and resumes only after reattach",
   );
   assert.match(
     terminalSource,
-    /resumeWakeFlow:\s*\(shouldResume\)\s*=>\s*\{[\s\S]*?if \(!shouldResume\) return;[\s\S]*?setSessionFlowPaused\?\.\(backendId,\s*false\)/,
+    /restoreAfterFailedWake:\s*\(\)\s*=>\s*\{[\s\S]*?disposeRuntimeOnly\(\);[\s\S]*?beginHibernatedSessionListeners\(backendId\)/,
+  );
+  assert.match(
+    terminalSource,
+    /resumeAfterReattach:\s*\(\)\s*=>\s*\{[\s\S]*?setSessionFlowPaused\?\.\(backendId,\s*false\)/,
   );
   assert.match(
     terminalSource,

--- a/components/terminal/terminalHibernateRuntime.ts
+++ b/components/terminal/terminalHibernateRuntime.ts
@@ -295,6 +295,24 @@ export type ApplyHibernateWakeOptions = {
   deferWebgl?: boolean;
 };
 
+/**
+ * Resolve the pre-pending history bytes to replay on hibernate wake.
+ * Prefer the coherent full snapshot: SerializeAddon range slices omit a
+ * trailing newline at the boundary, so concatenating scrollback+viewport can
+ * merge the seam lines. Fall back to scrollback → viewport when snapshot is
+ * empty (still never viewport-first — that evicts newest rows under a finite
+ * scrollback cap; #2762).
+ */
+export function resolveHibernateWakeHistory(payload: TerminalHibernateWakePayload): string {
+  if (payload.snapshot) return payload.snapshot;
+  const viewport = payload.viewportSnapshot ?? "";
+  const scrollback = payload.scrollbackSnapshot ?? "";
+  if (!scrollback) return viewport;
+  if (!viewport) return scrollback;
+  if (/\r?\n$/.test(scrollback)) return `${scrollback}${viewport}`;
+  return `${scrollback}\r\n${viewport}`;
+}
+
 export async function applyHibernateWakeToTerminal(
   term: XTerm,
   runtime: XTermRuntime,
@@ -302,16 +320,14 @@ export async function applyHibernateWakeToTerminal(
   options: ApplyHibernateWakeOptions = {},
 ): Promise<void> {
   const replayOptions = options.replayOptions;
-  const viewport = payload.viewportSnapshot ?? payload.snapshot;
-  const scrollback = payload.scrollbackSnapshot ?? "";
+  const history = resolveHibernateWakeHistory(payload);
 
-  // Replay older scrollback before the viewport. Appending scrollback after the
-  // viewport (or deferring it to idle) lets a finite xterm scrollback cap trim
-  // the just-restored newest rows — exactly the #2762 "end of output vanished"
-  // failure. Chunking already yields to the event loop for large buffers.
+  // Chunked writes already yield to the event loop for large buffers. Do not
+  // idle-append older scrollback after the viewport: under a finite xterm
+  // scrollback cap that trims the just-restored newest rows (#2762).
   await writeTerminalReplaySequence(
     term,
-    [scrollback, viewport, payload.pendingBuffer],
+    [history, payload.pendingBuffer],
     replayOptions,
   );
 

--- a/components/terminal/terminalHibernateRuntime.ts
+++ b/components/terminal/terminalHibernateRuntime.ts
@@ -299,8 +299,8 @@ export type ApplyHibernateWakeOptions = {
  * Resolve the pre-pending history bytes to replay on hibernate wake.
  * Prefer the coherent full snapshot: SerializeAddon range slices omit a
  * trailing newline at the boundary, so concatenating scrollback+viewport can
- * merge the seam lines. Fall back to scrollback → viewport when snapshot is
- * empty (still never viewport-first — that evicts newest rows under a finite
+ * merge the seam lines. Fall back to scrollback -> viewport when snapshot is
+ * empty (still never viewport-first -- that evicts newest rows under a finite
  * scrollback cap; #2762).
  */
 export function resolveHibernateWakeHistory(payload: TerminalHibernateWakePayload): string {

--- a/components/terminal/terminalHibernateRuntime.ts
+++ b/components/terminal/terminalHibernateRuntime.ts
@@ -295,14 +295,6 @@ export type ApplyHibernateWakeOptions = {
   deferWebgl?: boolean;
 };
 
-const scheduleIdle = (callback: () => void): void => {
-  if (typeof requestIdleCallback === "function") {
-    requestIdleCallback(() => callback(), { timeout: 500 });
-    return;
-  }
-  setTimeout(callback, 0);
-};
-
 export async function applyHibernateWakeToTerminal(
   term: XTerm,
   runtime: XTermRuntime,
@@ -313,7 +305,15 @@ export async function applyHibernateWakeToTerminal(
   const viewport = payload.viewportSnapshot ?? payload.snapshot;
   const scrollback = payload.scrollbackSnapshot ?? "";
 
-  await writeTerminalReplaySequence(term, [viewport, payload.pendingBuffer], replayOptions);
+  // Replay older scrollback before the viewport. Appending scrollback after the
+  // viewport (or deferring it to idle) lets a finite xterm scrollback cap trim
+  // the just-restored newest rows — exactly the #2762 "end of output vanished"
+  // failure. Chunking already yields to the event loop for large buffers.
+  await writeTerminalReplaySequence(
+    term,
+    [scrollback, viewport, payload.pendingBuffer],
+    replayOptions,
+  );
 
   if (!options.deferWebgl) {
     runtime.ensureWebglRenderer();
@@ -322,12 +322,6 @@ export async function applyHibernateWakeToTerminal(
 
   if (payload.alternateScreen) {
     refreshTerminalViewport(term);
-  }
-
-  if (scrollback) {
-    scheduleIdle(() => {
-      void writeTerminalPayloadChunked(term, scrollback, replayOptions);
-    });
   }
 }
 

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -12,6 +12,7 @@ import {
   type XTermRuntime,
 } from "./runtime/createXTermRuntime";
 import {
+  appendTerminalReplayData,
   applyHibernateWakeToTerminal,
   nudgeAlternateScreenRedraw,
 } from "./terminalHibernateRuntime";
@@ -50,11 +51,12 @@ export type WakeTerminalFromHibernateOptions = {
   getPayload: () => TerminalHibernateWakePayload;
   /**
    * Pause backend output and wait for in-flight chunks to drain into the
-   * hibernate pending buffer before history replay. Prevents the 512 KiB
-   * pending cap and the 64 KiB preload backlog from dropping ACKed bytes
-   * during a long full-history wake (#2762).
+   * hibernate pending buffer before history replay. Returns true when the
+   * drain succeeded (safe to detach the data listener). Returns false when
+   * pause/drain was best-effort only — caller must keep a live uncapped
+   * pending listener through history replay (#2762).
    */
-  prepareWakeFlow?: () => Promise<void>;
+  prepareWakeFlow?: () => Promise<boolean>;
   /**
    * Atomically read and clear hibernate pending output after the data listener
    * has been stopped (and preferably after prepareWakeFlow).
@@ -62,6 +64,11 @@ export type WakeTerminalFromHibernateOptions = {
   takePendingBuffer: () => string;
   /** Stop only the hibernate data listener so pending stops growing. */
   stopHibernateDataListener: () => void;
+  /**
+   * When prepareWakeFlow returns false, disable the 512 KiB pending cap so
+   * ACKed bytes that arrive during history replay are not trimmed.
+   */
+  setHibernatePendingCapDisabled?: (disabled: boolean) => void;
   /**
    * Stop hibernate data+exit listeners and clear flow-ack state.
    * Must keep the backend paused until resumeWakeFlow runs after reattach.
@@ -95,6 +102,7 @@ export async function wakeTerminalFromHibernate(
     prepareWakeFlow,
     takePendingBuffer,
     stopHibernateDataListener,
+    setHibernatePendingCapDisabled,
     stopHibernateListeners,
     resumeWakeFlow,
     reattachSession,
@@ -148,12 +156,19 @@ export async function wakeTerminalFromHibernate(
   // buffer open (or leaving no display listener while flow is live) drops
   // ACKed bytes under sustained `cat` output (#2762).
   try {
-    await prepareWakeFlow?.();
-    stopHibernateDataListener();
+    const drainOk = (await prepareWakeFlow?.()) ?? true;
+    if (drainOk) {
+      stopHibernateDataListener();
+    } else {
+      // Drain timed out / unavailable: keep the hibernate data listener so
+      // in-flight ACKed bytes still land in pending, but disable the 512 KiB
+      // cap for the wake window so a busy `cat` cannot trim the front.
+      setHibernatePendingCapDisabled?.(true);
+    }
     const initialPayload = getPayload();
     const pendingAtApplyStart = takePendingBuffer();
     const replayOptions = { chunkBytes: replayChunkBytes };
-    const replayedPendingChars = pendingAtApplyStart.length;
+    let replayedPendingChars = pendingAtApplyStart.length;
 
     await applyHibernateWakeToTerminal(term, runtime, {
       ...initialPayload,
@@ -167,6 +182,18 @@ export async function wakeTerminalFromHibernate(
     // Exit listener stays alive through replay so a close during wake still
     // updates status before we decide whether to reattach.
     const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);
+
+    // Stop the data listener before the late take. Captures:
+    // - exit "[session closed]" tails appended during history replay
+    // - uncapped live arrivals when drainOk was false
+    stopHibernateDataListener();
+    setHibernatePendingCapDisabled?.(false);
+    const latePending = takePendingBuffer();
+    if (latePending) {
+      await appendTerminalReplayData(term, latePending, replayOptions);
+      replayedPendingChars += latePending.length;
+    }
+
     stopHibernateListeners();
     if (shouldReattach) {
       reattachSession(term);
@@ -211,6 +238,7 @@ export async function wakeTerminalFromHibernate(
     });
     return true;
   } finally {
+    setHibernatePendingCapDisabled?.(false);
     // Resume only after the live display listener is installed (or after we
     // choose not to reattach / wake fails). Keeps the preload backlog from
     // absorbing a burst that would exceed its 64 KiB trim.

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -150,6 +150,14 @@ export async function wakeTerminalFromHibernate(
     await appendTerminalReplayData(term, pendingDelta, replayOptions);
     replayedPendingChars += pendingDelta.length;
   }
+  // Final catch-all before tearing down hibernate listeners: anything still in
+  // the pending ref (or that landed after the loop saw an empty buffer) must be
+  // written once more, or flow-acked hibernate chunks are permanently dropped.
+  const finalPendingDelta = takePendingBuffer();
+  if (finalPendingDelta) {
+    await appendTerminalReplayData(term, finalPendingDelta, replayOptions);
+    replayedPendingChars += finalPendingDelta.length;
+  }
 
   stopHibernateListeners();
   const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -74,8 +74,8 @@ export type WakeTerminalFromHibernateOptions = {
    * Must keep the backend paused until resumeWakeFlow runs after reattach.
    */
   stopHibernateListeners: () => void;
-  /** Resume backend output after the live display listener is attached. */
-  resumeWakeFlow?: () => void;
+  /** Resume backend output when true (reattached, or failed wake cleanup). */
+  resumeWakeFlow?: (shouldResume: boolean) => void;
   reattachSession: (term: XTerm) => void;
   safeFit: (options?: { force?: boolean; requireVisible?: boolean }) => void;
   resizeSession: () => void;
@@ -155,6 +155,7 @@ export async function wakeTerminalFromHibernate(
   // Full-history replay can take many frames; leaving the capped pending
   // buffer open (or leaving no display listener while flow is live) drops
   // ACKed bytes under sustained `cat` output (#2762).
+  let didReattach = false;
   try {
     const drainOk = (await prepareWakeFlow?.()) ?? true;
     if (drainOk) {
@@ -179,10 +180,6 @@ export async function wakeTerminalFromHibernate(
     });
     runtime.cursorLineHighlighter.refresh({ force: true });
 
-    // Exit listener stays alive through replay so a close during wake still
-    // updates status before we decide whether to reattach.
-    const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);
-
     // Stop the data listener before the late take. Captures:
     // - exit "[session closed]" tails appended during history replay
     // - uncapped live arrivals when drainOk was false
@@ -193,11 +190,21 @@ export async function wakeTerminalFromHibernate(
       await appendTerminalReplayData(term, latePending, replayOptions);
       replayedPendingChars += latePending.length;
     }
+    // Exit (or residual uncapped output) may arrive during the late await.
+    const exitTail = takePendingBuffer();
+    if (exitTail) {
+      await appendTerminalReplayData(term, exitTail, replayOptions);
+      replayedPendingChars += exitTail.length;
+    }
 
+    // Recompute after late drains so an exit during those awaits cannot leave
+    // shouldReattach stale (would reattach a dead session as connected).
+    const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);
     stopHibernateListeners();
     if (shouldReattach) {
       reattachSession(term);
       updateStatus("connected");
+      didReattach = true;
     }
 
     runtime.ensureWebglRenderer();
@@ -239,9 +246,8 @@ export async function wakeTerminalFromHibernate(
     return true;
   } finally {
     setHibernatePendingCapDisabled?.(false);
-    // Resume only after the live display listener is installed (or after we
-    // choose not to reattach / wake fails). Keeps the preload backlog from
-    // absorbing a burst that would exceed its 64 KiB trim.
-    resumeWakeFlow?.();
+    // Resume only after a live display listener is installed. Reconnect wakes
+    // that do not reattach leave the backend paused until cleanupSession.
+    resumeWakeFlow?.(didReattach);
   }
 }

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -12,7 +12,6 @@ import {
   type XTermRuntime,
 } from "./runtime/createXTermRuntime";
 import {
-  appendTerminalReplayData,
   applyHibernateWakeToTerminal,
   nudgeAlternateScreenRedraw,
 } from "./terminalHibernateRuntime";
@@ -50,15 +49,26 @@ export type WakeTerminalFromHibernateOptions = {
   container: HTMLDivElement;
   getPayload: () => TerminalHibernateWakePayload;
   /**
-   * Atomically read and clear hibernate pending output. Required so chunked
-   * full-history replay cannot race the capped pending buffer: length-based
-   * slicing misses bytes when capHibernateBuffer trims the front during wake.
+   * Pause backend output and wait for in-flight chunks to drain into the
+   * hibernate pending buffer before history replay. Prevents the 512 KiB
+   * pending cap and the 64 KiB preload backlog from dropping ACKed bytes
+   * during a long full-history wake (#2762).
+   */
+  prepareWakeFlow?: () => Promise<void>;
+  /**
+   * Atomically read and clear hibernate pending output after the data listener
+   * has been stopped (and preferably after prepareWakeFlow).
    */
   takePendingBuffer: () => string;
   /** Stop only the hibernate data listener so pending stops growing. */
   stopHibernateDataListener: () => void;
-  /** Stop hibernate data+exit listeners and release flow pause state. */
+  /**
+   * Stop hibernate data+exit listeners and clear flow-ack state.
+   * Must keep the backend paused until resumeWakeFlow runs after reattach.
+   */
   stopHibernateListeners: () => void;
+  /** Resume backend output after the live display listener is attached. */
+  resumeWakeFlow?: () => void;
   reattachSession: (term: XTerm) => void;
   safeFit: (options?: { force?: boolean; requireVisible?: boolean }) => void;
   resizeSession: () => void;
@@ -82,9 +92,11 @@ export async function wakeTerminalFromHibernate(
     runtimeContext,
     container,
     getPayload,
+    prepareWakeFlow,
     takePendingBuffer,
     stopHibernateDataListener,
     stopHibernateListeners,
+    resumeWakeFlow,
     reattachSession,
     safeFit,
     resizeSession,
@@ -130,82 +142,78 @@ export async function wakeTerminalFromHibernate(
   );
 
   const term = runtime.term;
-  const initialPayload = getPayload();
-  // Capture pending for this replay pass and clear the live buffer so arrivals
-  // during chunked history replay accumulate as a pure delta (survives the
-  // 512 KiB pending cap without length-slice gaps).
-  const pendingAtApplyStart = takePendingBuffer();
-  const replayOptions = { chunkBytes: replayChunkBytes };
+  // Pause first so in-flight output drains into pending via the still-live
+  // hibernate listener, then detach that listener before capturing pending.
+  // Full-history replay can take many frames; leaving the capped pending
+  // buffer open (or leaving no display listener while flow is live) drops
+  // ACKed bytes under sustained `cat` output (#2762).
+  try {
+    await prepareWakeFlow?.();
+    stopHibernateDataListener();
+    const initialPayload = getPayload();
+    const pendingAtApplyStart = takePendingBuffer();
+    const replayOptions = { chunkBytes: replayChunkBytes };
+    const replayedPendingChars = pendingAtApplyStart.length;
 
-  await applyHibernateWakeToTerminal(term, runtime, {
-    ...initialPayload,
-    pendingBuffer: pendingAtApplyStart,
-  }, {
-    replayOptions,
-    deferWebgl: true,
-  });
-  runtime.cursorLineHighlighter.refresh({ force: true });
+    await applyHibernateWakeToTerminal(term, runtime, {
+      ...initialPayload,
+      pendingBuffer: pendingAtApplyStart,
+    }, {
+      replayOptions,
+      deferWebgl: true,
+    });
+    runtime.cursorLineHighlighter.refresh({ force: true });
 
-  let replayedPendingChars = pendingAtApplyStart.length;
-  for (let drainPass = 0; drainPass < 16; drainPass += 1) {
-    const pendingDelta = takePendingBuffer();
-    if (!pendingDelta) break;
-    await appendTerminalReplayData(term, pendingDelta, replayOptions);
-    replayedPendingChars += pendingDelta.length;
-  }
+    // Exit listener stays alive through replay so a close during wake still
+    // updates status before we decide whether to reattach.
+    const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);
+    stopHibernateListeners();
+    if (shouldReattach) {
+      reattachSession(term);
+      updateStatus("connected");
+    }
 
-  // Stop only the data listener so pending stops growing, but keep the exit
-  // listener alive through the final replay. An exit during that await must
-  // still update session status before we decide whether to reattach.
-  stopHibernateDataListener();
-  const finalPendingDelta = takePendingBuffer();
-  if (finalPendingDelta) {
-    await appendTerminalReplayData(term, finalPendingDelta, replayOptions);
-    replayedPendingChars += finalPendingDelta.length;
-  }
+    runtime.ensureWebglRenderer();
+    runtime.clearTextureAtlas();
 
-  const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);
-  stopHibernateListeners();
-  if (shouldReattach) {
-    reattachSession(term);
-    updateStatus("connected");
-  }
-
-  runtime.ensureWebglRenderer();
-  runtime.clearTextureAtlas();
-
-  safeFit({ force: true });
-  resizeSession();
-  forceSyncRenderAfterResize(term);
-  if (initialPayload.alternateScreen) {
-    nudgeAlternateScreenRedraw(term);
-  } else {
-    term.scrollToBottom();
-  }
-
-  window.setTimeout(() => safeFit({ force: true }), 0);
-  window.setTimeout(() => {
     safeFit({ force: true });
+    resizeSession();
     forceSyncRenderAfterResize(term);
     if (initialPayload.alternateScreen) {
       nudgeAlternateScreenRedraw(term);
+    } else {
+      term.scrollToBottom();
     }
-  }, 100);
-  window.setTimeout(() => {
-    safeFit({ force: true });
-    forceSyncRenderAfterResize(term);
-    if (initialPayload.alternateScreen) {
-      nudgeAlternateScreenRedraw(term);
-    }
-  }, 350);
 
-  logger.info("[Terminal] Resumed from hibernate", {
-    sessionId,
-    snapshotChars: initialPayload.snapshot.length,
-    viewportChars: initialPayload.viewportSnapshot?.length ?? initialPayload.snapshot.length,
-    scrollbackChars: initialPayload.scrollbackSnapshot?.length ?? 0,
-    pendingChars: replayedPendingChars,
-    alternateScreen: initialPayload.alternateScreen,
-  });
-  return true;
+    window.setTimeout(() => safeFit({ force: true }), 0);
+    window.setTimeout(() => {
+      safeFit({ force: true });
+      forceSyncRenderAfterResize(term);
+      if (initialPayload.alternateScreen) {
+        nudgeAlternateScreenRedraw(term);
+      }
+    }, 100);
+    window.setTimeout(() => {
+      safeFit({ force: true });
+      forceSyncRenderAfterResize(term);
+      if (initialPayload.alternateScreen) {
+        nudgeAlternateScreenRedraw(term);
+      }
+    }, 350);
+
+    logger.info("[Terminal] Resumed from hibernate", {
+      sessionId,
+      snapshotChars: initialPayload.snapshot.length,
+      viewportChars: initialPayload.viewportSnapshot?.length ?? initialPayload.snapshot.length,
+      scrollbackChars: initialPayload.scrollbackSnapshot?.length ?? 0,
+      pendingChars: replayedPendingChars,
+      alternateScreen: initialPayload.alternateScreen,
+    });
+    return true;
+  } finally {
+    // Resume only after the live display listener is installed (or after we
+    // choose not to reattach / wake fails). Keeps the preload backlog from
+    // absorbing a burst that would exceed its 64 KiB trim.
+    resumeWakeFlow?.();
+  }
 }

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -49,6 +49,12 @@ export type WakeTerminalFromHibernateOptions = {
   runtimeContext: Omit<CreateXTermRuntimeContext, "container" | "initiallyVisible" | "deferWebglUntilReplayComplete">;
   container: HTMLDivElement;
   getPayload: () => TerminalHibernateWakePayload;
+  /**
+   * Atomically read and clear hibernate pending output. Required so chunked
+   * full-history replay cannot race the capped pending buffer: length-based
+   * slicing misses bytes when capHibernateBuffer trims the front during wake.
+   */
+  takePendingBuffer: () => string;
   /** Stop hibernate IPC listeners before reading the final replay payload. */
   stopHibernateListeners: () => void;
   reattachSession: (term: XTerm) => void;
@@ -74,6 +80,7 @@ export async function wakeTerminalFromHibernate(
     runtimeContext,
     container,
     getPayload,
+    takePendingBuffer,
     stopHibernateListeners,
     reattachSession,
     safeFit,
@@ -121,34 +128,27 @@ export async function wakeTerminalFromHibernate(
 
   const term = runtime.term;
   const initialPayload = getPayload();
-  const pendingAtApplyStart = initialPayload.pendingBuffer;
+  // Capture pending for this replay pass and clear the live buffer so arrivals
+  // during chunked history replay accumulate as a pure delta (survives the
+  // 512 KiB pending cap without length-slice gaps).
+  const pendingAtApplyStart = takePendingBuffer();
   const replayOptions = { chunkBytes: replayChunkBytes };
 
-  await applyHibernateWakeToTerminal(term, runtime, initialPayload, {
+  await applyHibernateWakeToTerminal(term, runtime, {
+    ...initialPayload,
+    pendingBuffer: pendingAtApplyStart,
+  }, {
     replayOptions,
     deferWebgl: true,
   });
   runtime.cursorLineHighlighter.refresh({ force: true });
 
-  let replayedPendingLength = pendingAtApplyStart.length;
+  let replayedPendingChars = pendingAtApplyStart.length;
   for (let drainPass = 0; drainPass < 16; drainPass += 1) {
-    const pending = getPayload().pendingBuffer;
-    if (pending.length <= replayedPendingLength) break;
-    await appendTerminalReplayData(
-      term,
-      pending.slice(replayedPendingLength),
-      replayOptions,
-    );
-    replayedPendingLength = pending.length;
-  }
-  const finalPending = getPayload().pendingBuffer;
-  if (finalPending.length > replayedPendingLength) {
-    await appendTerminalReplayData(
-      term,
-      finalPending.slice(replayedPendingLength),
-      replayOptions,
-    );
-    replayedPendingLength = finalPending.length;
+    const pendingDelta = takePendingBuffer();
+    if (!pendingDelta) break;
+    await appendTerminalReplayData(term, pendingDelta, replayOptions);
+    replayedPendingChars += pendingDelta.length;
   }
 
   stopHibernateListeners();
@@ -191,7 +191,7 @@ export async function wakeTerminalFromHibernate(
     snapshotChars: initialPayload.snapshot.length,
     viewportChars: initialPayload.viewportSnapshot?.length ?? initialPayload.snapshot.length,
     scrollbackChars: initialPayload.scrollbackSnapshot?.length ?? 0,
-    pendingChars: replayedPendingLength,
+    pendingChars: replayedPendingChars,
     alternateScreen: initialPayload.alternateScreen,
   });
   return true;

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -53,7 +53,7 @@ export type WakeTerminalFromHibernateOptions = {
    * Pause backend output and wait for in-flight chunks to drain into the
    * hibernate pending buffer before history replay. Returns true when the
    * drain succeeded (safe to detach the data listener). Returns false when
-   * pause/drain was best-effort only — caller must keep a live uncapped
+   * pause/drain was best-effort only; caller must keep a live uncapped
    * pending listener through history replay (#2762).
    */
   prepareWakeFlow?: () => Promise<boolean>;
@@ -71,11 +71,17 @@ export type WakeTerminalFromHibernateOptions = {
   setHibernatePendingCapDisabled?: (disabled: boolean) => void;
   /**
    * Stop hibernate data+exit listeners and clear flow-ack state.
-   * Must keep the backend paused until resumeWakeFlow runs after reattach.
+   * Must keep the backend paused until resumeAfterReattach runs.
    */
   stopHibernateListeners: () => void;
-  /** Resume backend output when true (reattached, or failed wake cleanup). */
-  resumeWakeFlow?: (shouldResume: boolean) => void;
+  /**
+   * On a thrown/failed wake: dispose the partial xterm runtime and restore
+   * hibernate listeners so output is ACKed again (never unpause without a
+   * listener).
+   */
+  restoreAfterFailedWake?: () => void;
+  /** Resume backend output after the live display listener is attached. */
+  resumeAfterReattach?: () => void;
   reattachSession: (term: XTerm) => void;
   safeFit: (options?: { force?: boolean; requireVisible?: boolean }) => void;
   resizeSession: () => void;
@@ -104,7 +110,8 @@ export async function wakeTerminalFromHibernate(
     stopHibernateDataListener,
     setHibernatePendingCapDisabled,
     stopHibernateListeners,
-    resumeWakeFlow,
+    restoreAfterFailedWake,
+    resumeAfterReattach,
     reattachSession,
     safeFit,
     resizeSession,
@@ -156,6 +163,7 @@ export async function wakeTerminalFromHibernate(
   // buffer open (or leaving no display listener while flow is live) drops
   // ACKed bytes under sustained `cat` output (#2762).
   let didReattach = false;
+  let wakeSucceeded = false;
   try {
     const drainOk = (await prepareWakeFlow?.()) ?? true;
     if (drainOk) {
@@ -195,6 +203,12 @@ export async function wakeTerminalFromHibernate(
     if (exitTail) {
       await appendTerminalReplayData(term, exitTail, replayOptions);
       replayedPendingChars += exitTail.length;
+    }
+    // Final sync capture after all awaits, before tearing down the exit listener.
+    const finalTail = takePendingBuffer();
+    if (finalTail) {
+      await appendTerminalReplayData(term, finalTail, replayOptions);
+      replayedPendingChars += finalTail.length;
     }
 
     // Recompute after late drains so an exit during those awaits cannot leave
@@ -243,11 +257,18 @@ export async function wakeTerminalFromHibernate(
       pendingChars: replayedPendingChars,
       alternateScreen: initialPayload.alternateScreen,
     });
+    wakeSucceeded = true;
     return true;
   } finally {
     setHibernatePendingCapDisabled?.(false);
-    // Resume only after a live display listener is installed. Reconnect wakes
-    // that do not reattach leave the backend paused until cleanupSession.
-    resumeWakeFlow?.(didReattach);
+    if (!wakeSucceeded) {
+      // Dispose the partial runtime and restore hibernate listeners so a
+      // failed wake never unpauses into a listener-less backlog gap, and so a
+      // retry can re-enter wake (hasRuntimeRef stays false).
+      restoreAfterFailedWake?.();
+    } else if (didReattach) {
+      resumeAfterReattach?.();
+    }
+    // Successful reconnect wakes (!didReattach) keep the pause until cleanupSession.
   }
 }

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -55,7 +55,9 @@ export type WakeTerminalFromHibernateOptions = {
    * slicing misses bytes when capHibernateBuffer trims the front during wake.
    */
   takePendingBuffer: () => string;
-  /** Stop hibernate IPC listeners before reading the final replay payload. */
+  /** Stop only the hibernate data listener so pending stops growing. */
+  stopHibernateDataListener: () => void;
+  /** Stop hibernate data+exit listeners and release flow pause state. */
   stopHibernateListeners: () => void;
   reattachSession: (term: XTerm) => void;
   safeFit: (options?: { force?: boolean; requireVisible?: boolean }) => void;
@@ -81,6 +83,7 @@ export async function wakeTerminalFromHibernate(
     container,
     getPayload,
     takePendingBuffer,
+    stopHibernateDataListener,
     stopHibernateListeners,
     reattachSession,
     safeFit,
@@ -151,10 +154,10 @@ export async function wakeTerminalFromHibernate(
     replayedPendingChars += pendingDelta.length;
   }
 
-  // Stop hibernate IPC first so no further bytes land in the pending ref, then
-  // take any remainder once. Awaiting a final write while listeners are still
-  // live can lose already-acked chunks that arrive during that write.
-  stopHibernateListeners();
+  // Stop only the data listener so pending stops growing, but keep the exit
+  // listener alive through the final replay. An exit during that await must
+  // still update session status before we decide whether to reattach.
+  stopHibernateDataListener();
   const finalPendingDelta = takePendingBuffer();
   if (finalPendingDelta) {
     await appendTerminalReplayData(term, finalPendingDelta, replayOptions);
@@ -162,6 +165,7 @@ export async function wakeTerminalFromHibernate(
   }
 
   const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);
+  stopHibernateListeners();
   if (shouldReattach) {
     reattachSession(term);
     updateStatus("connected");

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -199,36 +199,22 @@ export async function wakeTerminalFromHibernate(
     });
     runtime.cursorLineHighlighter.refresh({ force: true });
 
-    // Stop the data listener before the late take. Captures:
+    // Stop the data listener before draining residual pending. Captures:
     // - exit "[session closed]" tails appended during history replay
     // - uncapped live arrivals when drainOk was false
+    // Only the exit listener can still append after this point, so a short
+    // until-empty loop is enough; the last take before teardown must be empty
+    // after any awaited replay.
     stopHibernateDataListener();
     setHibernatePendingCapDisabled?.(false);
-    const latePending = takeAndTrackPending();
-    if (latePending) {
-      await appendTerminalReplayData(term, latePending, replayOptions);
-      replayedPendingChars += latePending.length;
-    }
-    // Exit (or residual uncapped output) may arrive during the late await.
-    const exitTail = takeAndTrackPending();
-    if (exitTail) {
-      await appendTerminalReplayData(term, exitTail, replayOptions);
-      replayedPendingChars += exitTail.length;
-    }
-    // Final capture after all awaits, before tearing down the exit listener.
-    const finalTail = takeAndTrackPending();
-    if (finalTail) {
-      await appendTerminalReplayData(term, finalTail, replayOptions);
-      replayedPendingChars += finalTail.length;
-    }
-    // Last sync take immediately before teardown (covers exit during finalTail).
-    const preTeardownTail = takeAndTrackPending();
-    if (preTeardownTail) {
-      await appendTerminalReplayData(term, preTeardownTail, replayOptions);
-      replayedPendingChars += preTeardownTail.length;
+    for (;;) {
+      const pendingTail = takeAndTrackPending();
+      if (!pendingTail) break;
+      await appendTerminalReplayData(term, pendingTail, replayOptions);
+      replayedPendingChars += pendingTail.length;
     }
 
-    // Recompute after late drains so an exit during those awaits cannot leave
+    // Recompute after drains so an exit during those awaits cannot leave
     // shouldReattach stale (would reattach a dead session as connected).
     const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);
     stopHibernateListeners();

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -150,16 +150,17 @@ export async function wakeTerminalFromHibernate(
     await appendTerminalReplayData(term, pendingDelta, replayOptions);
     replayedPendingChars += pendingDelta.length;
   }
-  // Final catch-all before tearing down hibernate listeners: anything still in
-  // the pending ref (or that landed after the loop saw an empty buffer) must be
-  // written once more, or flow-acked hibernate chunks are permanently dropped.
+
+  // Stop hibernate IPC first so no further bytes land in the pending ref, then
+  // take any remainder once. Awaiting a final write while listeners are still
+  // live can lose already-acked chunks that arrive during that write.
+  stopHibernateListeners();
   const finalPendingDelta = takePendingBuffer();
   if (finalPendingDelta) {
     await appendTerminalReplayData(term, finalPendingDelta, replayOptions);
     replayedPendingChars += finalPendingDelta.length;
   }
 
-  stopHibernateListeners();
   const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);
   if (shouldReattach) {
     reattachSession(term);

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -77,9 +77,11 @@ export type WakeTerminalFromHibernateOptions = {
   /**
    * On a thrown/failed wake: dispose the partial xterm runtime and restore
    * hibernate listeners so output is ACKed again (never unpause without a
-   * listener).
+   * listener). `takenPending` is every byte already take-and-cleared during
+   * this wake attempt; it must be restored because those bytes no longer
+   * live in the pending ref and the partial xterm is disposed.
    */
-  restoreAfterFailedWake?: () => void;
+  restoreAfterFailedWake?: (takenPending: string) => void;
   /** Resume backend output after the live display listener is attached. */
   resumeAfterReattach?: () => void;
   reattachSession: (term: XTerm) => void;
@@ -164,6 +166,15 @@ export async function wakeTerminalFromHibernate(
   // ACKed bytes under sustained `cat` output (#2762).
   let didReattach = false;
   let wakeSucceeded = false;
+  // Bytes take-and-cleared from the pending ref during this wake. On failure
+  // they must be handed back: the partial xterm is disposed and the ref no
+  // longer holds them.
+  let takenPendingForRestore = "";
+  const takeAndTrackPending = (): string => {
+    const pending = takePendingBuffer();
+    if (pending) takenPendingForRestore += pending;
+    return pending;
+  };
   try {
     const drainOk = (await prepareWakeFlow?.()) ?? true;
     if (drainOk) {
@@ -175,7 +186,7 @@ export async function wakeTerminalFromHibernate(
       setHibernatePendingCapDisabled?.(true);
     }
     const initialPayload = getPayload();
-    const pendingAtApplyStart = takePendingBuffer();
+    const pendingAtApplyStart = takeAndTrackPending();
     const replayOptions = { chunkBytes: replayChunkBytes };
     let replayedPendingChars = pendingAtApplyStart.length;
 
@@ -193,22 +204,28 @@ export async function wakeTerminalFromHibernate(
     // - uncapped live arrivals when drainOk was false
     stopHibernateDataListener();
     setHibernatePendingCapDisabled?.(false);
-    const latePending = takePendingBuffer();
+    const latePending = takeAndTrackPending();
     if (latePending) {
       await appendTerminalReplayData(term, latePending, replayOptions);
       replayedPendingChars += latePending.length;
     }
     // Exit (or residual uncapped output) may arrive during the late await.
-    const exitTail = takePendingBuffer();
+    const exitTail = takeAndTrackPending();
     if (exitTail) {
       await appendTerminalReplayData(term, exitTail, replayOptions);
       replayedPendingChars += exitTail.length;
     }
-    // Final sync capture after all awaits, before tearing down the exit listener.
-    const finalTail = takePendingBuffer();
+    // Final capture after all awaits, before tearing down the exit listener.
+    const finalTail = takeAndTrackPending();
     if (finalTail) {
       await appendTerminalReplayData(term, finalTail, replayOptions);
       replayedPendingChars += finalTail.length;
+    }
+    // Last sync take immediately before teardown (covers exit during finalTail).
+    const preTeardownTail = takeAndTrackPending();
+    if (preTeardownTail) {
+      await appendTerminalReplayData(term, preTeardownTail, replayOptions);
+      replayedPendingChars += preTeardownTail.length;
     }
 
     // Recompute after late drains so an exit during those awaits cannot leave
@@ -264,8 +281,9 @@ export async function wakeTerminalFromHibernate(
     if (!wakeSucceeded) {
       // Dispose the partial runtime and restore hibernate listeners so a
       // failed wake never unpauses into a listener-less backlog gap, and so a
-      // retry can re-enter wake (hasRuntimeRef stays false).
-      restoreAfterFailedWake?.();
+      // retry can re-enter wake (hasRuntimeRef stays false). Hand back every
+      // take-and-cleared pending byte so it is not lost with the disposed term.
+      restoreAfterFailedWake?.(takenPendingForRestore);
     } else if (didReattach) {
       resumeAfterReattach?.();
     }

--- a/domain/terminalHibernate.ts
+++ b/domain/terminalHibernate.ts
@@ -160,7 +160,7 @@ export function shouldSkipHibernateForAltScreen(
 
 /** Snapshot + buffered output to replay when recreating xterm after hibernate. */
 export type TerminalHibernateWakePayload = {
-  /** Full serialized terminal state — preferred wake history (coherent ANSI). */
+  /** Full serialized terminal state -- preferred wake history (coherent ANSI). */
   snapshot: string;
   /** Visible viewport rows; used with scrollback only when snapshot is empty. */
   viewportSnapshot?: string;

--- a/domain/terminalHibernate.ts
+++ b/domain/terminalHibernate.ts
@@ -160,11 +160,11 @@ export function shouldSkipHibernateForAltScreen(
 
 /** Snapshot + buffered output to replay when recreating xterm after hibernate. */
 export type TerminalHibernateWakePayload = {
-  /** Full serialized terminal state (legacy combined snapshot). */
+  /** Full serialized terminal state — preferred wake history (coherent ANSI). */
   snapshot: string;
-  /** Visible viewport rows restored after scrollback during wake. */
+  /** Visible viewport rows; used with scrollback only when snapshot is empty. */
   viewportSnapshot?: string;
-  /** Older scrollback rows replayed before viewport + pending. */
+  /** Older scrollback rows; used with viewport only when snapshot is empty. */
   scrollbackSnapshot?: string;
   pendingBuffer: string;
   /** True when the pane was hibernated while a full-screen app owned the alt buffer. */

--- a/domain/terminalHibernate.ts
+++ b/domain/terminalHibernate.ts
@@ -162,9 +162,9 @@ export function shouldSkipHibernateForAltScreen(
 export type TerminalHibernateWakePayload = {
   /** Full serialized terminal state (legacy combined snapshot). */
   snapshot: string;
-  /** Visible viewport rows for fast first paint during wake. */
+  /** Visible viewport rows restored after scrollback during wake. */
   viewportSnapshot?: string;
-  /** Older scrollback rows replayed lazily after viewport + pending. */
+  /** Older scrollback rows replayed before viewport + pending. */
   scrollbackSnapshot?: string;
   pendingBuffer: string;
   /** True when the pane was hibernated while a full-screen app owned the alt buffer. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes [#2762](https://github.com/binaricat/Netcatty/issues/2762): hibernate wake could permanently drop the newest terminal output after switching tabs (especially after large `cat` output).
- Root cause: wake replay ordered/raced scrollback vs viewport and the capped pending buffer incorrectly under a finite xterm scrollback / 512 KiB pending / 64 KiB preload backlog.
- Wake now prefers the coherent SerializeAddon `snapshot`, then pending.
- Connected wakes **pause-and-wait** backend flow, stop the hibernate data listener (or keep an uncapped listener if drain fails), take pending, replay, then drain residual pending **until an empty take**, reattach, then resume.
- Reconnect wakes (`sessionConnected=false`) still pause while a backend exists and stay paused until `cleanupSession`.
- Failed wakes restore hibernate listeners and hand back take-and-cleared pending so a thrown replay cannot permanently drop buffered output.

## Test plan
- [x] Unit: `hibernateWakeChunking.test.ts` (SerializeAddon seam + pause/take/until-empty/reattach source contract)
- [x] Codex clean on `45b87781` ("Didn't find any major issues. Chef's kiss.")
- [x] netcatty-bot marked ready for human review/merge
- [ ] CI `lint-and-test`
- [ ] Manual: enable hibernate hidden tabs, `cat` a large log, copy, switch tab for 5–10 min, switch back — newest lines remain

Closes #2762

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af32771d-717e-4e12-a89d-4eaaf0bbb250?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af32771d-717e-4e12-a89d-4eaaf0bbb250&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

