### PR TITLE
fix(windows): restore frameless rounded corners and tray corner transparency (#2505)

### DIFF
--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -269,6 +269,10 @@ function ensureTrayPanelWindow() {
   const { BrowserWindow } = electronModule;
   if (trayPanelWindow && !trayPanelWindow.isDestroyed()) return trayPanelWindow;
 
+  const {
+    windowsCssRoundedOverlayChromeOptions,
+  } = require("./windowManager/windowsWindowChrome.cjs");
+
   trayPanelWindow = new BrowserWindow({
     width: 360,
     height: 520,
@@ -281,8 +285,11 @@ function ensureTrayPanelWindow() {
     maximizable: false,
     skipTaskbar: true,
     alwaysOnTop: true,
-    transparent: true,
     hasShadow: true,
+    // Transparent host + clear backdrop so CSS rounded-lg corners are truly
+    // see-through. On Windows, disable OS rounding so it does not stack under
+    // the CSS radius (#2505 / Electron #46468).
+    ...windowsCssRoundedOverlayChromeOptions(),
     webPreferences: {
       preload: path.join(__dirname, "../preload.cjs"),
       contextIsolation: true,

--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -36,7 +36,9 @@ let trayMenuData = {
 };
 
 let trayPanelWindow = null;
-
+/** True after the tray panel renderer finishes its first load. */
+let trayPanelReady = false;
+let trayPanelShowWhenReady = false;
 let trayPanelRefreshTimer = null;
 // Watchdog: if `leave-full-screen` never arrives (edge case / stuck transition)
 // we eventually give up and force a hide attempt. Better a visible window than
@@ -273,6 +275,9 @@ function ensureTrayPanelWindow() {
     windowsCssRoundedOverlayChromeOptions,
   } = require("./windowManager/windowsWindowChrome.cjs");
 
+  trayPanelReady = false;
+  trayPanelShowWhenReady = false;
+
   trayPanelWindow = new BrowserWindow({
     width: 360,
     height: 520,
@@ -316,7 +321,17 @@ function ensureTrayPanelWindow() {
   void trayPanelWindow.loadURL(url);
 
   trayPanelWindow.webContents.on("did-finish-load", () => {
+    trayPanelReady = true;
     pushTrayMenuDataToPanel();
+    if (trayPanelShowWhenReady && trayPanelWindow && !trayPanelWindow.isDestroyed()) {
+      trayPanelShowWhenReady = false;
+      try {
+        trayPanelWindow.show();
+        trayPanelWindow.focus();
+      } catch {
+        // ignore
+      }
+    }
   });
 
   return trayPanelWindow;
@@ -339,8 +354,14 @@ function showTrayPanel() {
   const y = Math.min(trayBounds.y + trayBounds.height + 6, workArea.y + workArea.height - panelBounds.height);
 
   win.setBounds({ x, y, width: panelBounds.width, height: panelBounds.height }, false);
-  win.show();
-  win.focus();
+  // Wait for first paint/load so the opaque main-app splash cannot flash as a
+  // square underlay before the tray route clears it (#2505).
+  if (!trayPanelReady) {
+    trayPanelShowWhenReady = true;
+  } else {
+    win.show();
+    win.focus();
+  }
 
   pushTrayMenuDataToPanel();
 
@@ -1080,6 +1101,8 @@ function cleanup() {
     }
     trayPanelWindow = null;
   }
+  trayPanelReady = false;
+  trayPanelShowWhenReady = false;
 }
 
 module.exports = {

--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -377,6 +377,7 @@ function showTrayPanel() {
 }
 
 function hideTrayPanel() {
+  trayPanelShowWhenReady = false;
   if (trayPanelWindow && !trayPanelWindow.isDestroyed()) {
     trayPanelWindow.hide();
   }
@@ -388,7 +389,12 @@ function hideTrayPanel() {
 }
 
 function toggleTrayPanel() {
-  if (trayPanelWindow && !trayPanelWindow.isDestroyed() && trayPanelWindow.isVisible()) {
+  // A pending first-load show counts as "open" so a second click cancels it
+  // instead of leaving did-finish-load to pop the panel open later.
+  const isOpenOrPending =
+    trayPanelShowWhenReady
+    || (trayPanelWindow && !trayPanelWindow.isDestroyed() && trayPanelWindow.isVisible());
+  if (isOpenOrPending) {
     hideTrayPanel();
   } else {
     showTrayPanel();

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -1106,13 +1106,9 @@ function registerWindowHandlers(ipcMain, nativeTheme) {
       ? (nativeTheme?.shouldUseDarkColors ? "dark" : "light")
       : theme;
     const themeConfig = THEME_COLORS[effectiveTheme] || THEME_COLORS.light;
-    const {
-      resolveFramelessHostBackgroundColor,
-    } = require("./windowManager/windowsWindowChrome.cjs");
-    const hostBackground = resolveFramelessHostBackgroundColor(themeConfig.background);
-    forEachMainWindow((win) => win.setBackgroundColor(hostBackground));
+    forEachMainWindow((win) => win.setBackgroundColor(themeConfig.background));
     if (settingsWindow && !settingsWindow.isDestroyed()) {
-      settingsWindow.setBackgroundColor(hostBackground);
+      settingsWindow.setBackgroundColor(themeConfig.background);
     }
     return true;
   });
@@ -1120,13 +1116,9 @@ function registerWindowHandlers(ipcMain, nativeTheme) {
   ipcMain.handle("netcatty:setBackgroundColor", (_event, color) => {
     const normalized = normalizeBackgroundColor(color);
     if (!normalized) return false;
-    const {
-      resolveFramelessHostBackgroundColor,
-    } = require("./windowManager/windowsWindowChrome.cjs");
-    const hostBackground = resolveFramelessHostBackgroundColor(normalized);
-    forEachMainWindow((win) => win.setBackgroundColor(hostBackground));
+    forEachMainWindow((win) => win.setBackgroundColor(normalized));
     if (settingsWindow && !settingsWindow.isDestroyed()) {
-      settingsWindow.setBackgroundColor(hostBackground);
+      settingsWindow.setBackgroundColor(normalized);
     }
     return true;
   });

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -1106,9 +1106,13 @@ function registerWindowHandlers(ipcMain, nativeTheme) {
       ? (nativeTheme?.shouldUseDarkColors ? "dark" : "light")
       : theme;
     const themeConfig = THEME_COLORS[effectiveTheme] || THEME_COLORS.light;
-    forEachMainWindow((win) => win.setBackgroundColor(themeConfig.background));
+    const {
+      resolveFramelessHostBackgroundColor,
+    } = require("./windowManager/windowsWindowChrome.cjs");
+    const hostBackground = resolveFramelessHostBackgroundColor(themeConfig.background);
+    forEachMainWindow((win) => win.setBackgroundColor(hostBackground));
     if (settingsWindow && !settingsWindow.isDestroyed()) {
-      settingsWindow.setBackgroundColor(themeConfig.background);
+      settingsWindow.setBackgroundColor(hostBackground);
     }
     return true;
   });
@@ -1116,9 +1120,13 @@ function registerWindowHandlers(ipcMain, nativeTheme) {
   ipcMain.handle("netcatty:setBackgroundColor", (_event, color) => {
     const normalized = normalizeBackgroundColor(color);
     if (!normalized) return false;
-    forEachMainWindow((win) => win.setBackgroundColor(normalized));
+    const {
+      resolveFramelessHostBackgroundColor,
+    } = require("./windowManager/windowsWindowChrome.cjs");
+    const hostBackground = resolveFramelessHostBackgroundColor(normalized);
+    forEachMainWindow((win) => win.setBackgroundColor(hostBackground));
     if (settingsWindow && !settingsWindow.isDestroyed()) {
-      settingsWindow.setBackgroundColor(normalized);
+      settingsWindow.setBackgroundColor(hostBackground);
     }
     return true;
   });

--- a/electron/bridges/windowManager/mainWindow.cjs
+++ b/electron/bridges/windowManager/mainWindow.cjs
@@ -121,6 +121,11 @@ function createMainWindowApi(ctx) {
         }
       }
     
+      const {
+        windowsFramelessContentChromeOptions,
+      } = require("./windowsWindowChrome.cjs");
+      const windowsChrome = !isMac ? windowsFramelessContentChromeOptions() : {};
+
       const win = new BrowserWindow({
         ...windowBounds,
         minWidth: MIN_WINDOW_WIDTH,
@@ -131,6 +136,7 @@ function createMainWindowApi(ctx) {
         frame: isMac,
         titleBarStyle: isMac ? "hiddenInset" : undefined,
         trafficLightPosition: isMac ? { x: 12, y: 12 } : undefined,
+        ...windowsChrome,
         webPreferences: {
           preload,
           contextIsolation: true,
@@ -436,8 +442,12 @@ function createMainWindowApi(ctx) {
       });
     
       // Ensure native background matches frontend background, even before first paint.
+      // On Windows the host stays clear so DWM rounded corners do not show a dark rim.
       try {
-        win.setBackgroundColor(backgroundColor);
+        const {
+          resolveFramelessHostBackgroundColor,
+        } = require("./windowsWindowChrome.cjs");
+        win.setBackgroundColor(resolveFramelessHostBackgroundColor(backgroundColor));
       } catch {
         // ignore
       }

--- a/electron/bridges/windowManager/mainWindow.cjs
+++ b/electron/bridges/windowManager/mainWindow.cjs
@@ -1,7 +1,6 @@
 /* eslint-disable no-undef */
 const {
   windowsFramelessContentChromeOptions,
-  resolveFramelessHostBackgroundColor,
 } = require("./windowsWindowChrome.cjs");
 
 function createMainWindowApi(ctx) {
@@ -444,9 +443,8 @@ function createMainWindowApi(ctx) {
       });
     
       // Ensure native background matches frontend background, even before first paint.
-      // On Windows the host stays clear so DWM rounded corners do not show a dark rim.
       try {
-        win.setBackgroundColor(resolveFramelessHostBackgroundColor(backgroundColor));
+        win.setBackgroundColor(backgroundColor);
       } catch {
         // ignore
       }

--- a/electron/bridges/windowManager/mainWindow.cjs
+++ b/electron/bridges/windowManager/mainWindow.cjs
@@ -1,4 +1,9 @@
 /* eslint-disable no-undef */
+const {
+  windowsFramelessContentChromeOptions,
+  resolveFramelessHostBackgroundColor,
+} = require("./windowsWindowChrome.cjs");
+
 function createMainWindowApi(ctx) {
   with (ctx) {
     async function createWindow(electronModule, options) {
@@ -121,9 +126,6 @@ function createMainWindowApi(ctx) {
         }
       }
     
-      const {
-        windowsFramelessContentChromeOptions,
-      } = require("./windowsWindowChrome.cjs");
       const windowsChrome = !isMac ? windowsFramelessContentChromeOptions() : {};
 
       const win = new BrowserWindow({
@@ -444,9 +446,6 @@ function createMainWindowApi(ctx) {
       // Ensure native background matches frontend background, even before first paint.
       // On Windows the host stays clear so DWM rounded corners do not show a dark rim.
       try {
-        const {
-          resolveFramelessHostBackgroundColor,
-        } = require("./windowsWindowChrome.cjs");
         win.setBackgroundColor(resolveFramelessHostBackgroundColor(backgroundColor));
       } catch {
         // ignore

--- a/electron/bridges/windowManager/settingsWindow.cjs
+++ b/electron/bridges/windowManager/settingsWindow.cjs
@@ -125,6 +125,11 @@ function createSettingsWindowApi(ctx) {
         settingsHeight,
       });
     
+      const {
+        windowsFramelessContentChromeOptions,
+      } = require("./windowsWindowChrome.cjs");
+      const windowsChrome = !isMac ? windowsFramelessContentChromeOptions() : {};
+
       const win = new BrowserWindow({
         title: "netcatty Settings",
         width: settingsWidth,
@@ -144,6 +149,7 @@ function createSettingsWindowApi(ctx) {
         frame: isMac,
         titleBarStyle: isMac ? "hiddenInset" : undefined,
         trafficLightPosition: isMac ? { x: 12, y: 12 } : undefined,
+        ...windowsChrome,
         webPreferences: {
           preload,
           contextIsolation: true,
@@ -233,7 +239,10 @@ function createSettingsWindowApi(ctx) {
     
       // Ensure native background matches frontend background, even before first paint.
       try {
-        win.setBackgroundColor(backgroundColor);
+        const {
+          resolveFramelessHostBackgroundColor,
+        } = require("./windowsWindowChrome.cjs");
+        win.setBackgroundColor(resolveFramelessHostBackgroundColor(backgroundColor));
       } catch {
         // ignore
       }

--- a/electron/bridges/windowManager/settingsWindow.cjs
+++ b/electron/bridges/windowManager/settingsWindow.cjs
@@ -1,7 +1,6 @@
 /* eslint-disable no-undef */
 const {
   windowsFramelessContentChromeOptions,
-  resolveFramelessHostBackgroundColor,
 } = require("./windowsWindowChrome.cjs");
 
 function createSettingsWindowApi(ctx) {
@@ -241,7 +240,7 @@ function createSettingsWindowApi(ctx) {
     
       // Ensure native background matches frontend background, even before first paint.
       try {
-        win.setBackgroundColor(resolveFramelessHostBackgroundColor(backgroundColor));
+        win.setBackgroundColor(backgroundColor);
       } catch {
         // ignore
       }

--- a/electron/bridges/windowManager/settingsWindow.cjs
+++ b/electron/bridges/windowManager/settingsWindow.cjs
@@ -1,4 +1,9 @@
 /* eslint-disable no-undef */
+const {
+  windowsFramelessContentChromeOptions,
+  resolveFramelessHostBackgroundColor,
+} = require("./windowsWindowChrome.cjs");
+
 function createSettingsWindowApi(ctx) {
   // The extracted window helpers intentionally share the parent window-manager state.
   with (ctx) {
@@ -125,9 +130,6 @@ function createSettingsWindowApi(ctx) {
         settingsHeight,
       });
     
-      const {
-        windowsFramelessContentChromeOptions,
-      } = require("./windowsWindowChrome.cjs");
       const windowsChrome = !isMac ? windowsFramelessContentChromeOptions() : {};
 
       const win = new BrowserWindow({
@@ -239,9 +241,6 @@ function createSettingsWindowApi(ctx) {
     
       // Ensure native background matches frontend background, even before first paint.
       try {
-        const {
-          resolveFramelessHostBackgroundColor,
-        } = require("./windowsWindowChrome.cjs");
         win.setBackgroundColor(resolveFramelessHostBackgroundColor(backgroundColor));
       } catch {
         // ignore

--- a/electron/bridges/windowManager/terminalPopupWindow.cjs
+++ b/electron/bridges/windowManager/terminalPopupWindow.cjs
@@ -73,6 +73,11 @@ function createTerminalPopupWindowApi(ctx) {
         popupY,
       });
 
+      const {
+        windowsFramelessContentChromeOptions,
+      } = require("./windowsWindowChrome.cjs");
+      const windowsChrome = windowsFramelessContentChromeOptions();
+
       const win = new BrowserWindow({
         title,
         width: popupWidth,
@@ -85,6 +90,7 @@ function createTerminalPopupWindowApi(ctx) {
         show: false,
         frame: false,
         ...(isMac ? { trafficLightPosition: { x: 12, y: 12 } } : {}),
+        ...windowsChrome,
         webPreferences: {
           preload,
           contextIsolation: true,
@@ -204,7 +210,10 @@ function createTerminalPopupWindowApi(ctx) {
       win.on("page-title-updated", (e) => { e.preventDefault(); });
 
       try {
-        win.setBackgroundColor(backgroundColor);
+        const {
+          resolveFramelessHostBackgroundColor,
+        } = require("./windowsWindowChrome.cjs");
+        win.setBackgroundColor(resolveFramelessHostBackgroundColor(backgroundColor));
       } catch {
         // ignore
       }

--- a/electron/bridges/windowManager/terminalPopupWindow.cjs
+++ b/electron/bridges/windowManager/terminalPopupWindow.cjs
@@ -11,7 +11,6 @@ const {
 } = require("../terminalAttachRestore.cjs");
 const {
   windowsFramelessContentChromeOptions,
-  resolveFramelessHostBackgroundColor,
 } = require("./windowsWindowChrome.cjs");
 
 const ATTACH_CLOSE_PREPARE_TIMEOUT_MS = 2000;
@@ -211,7 +210,7 @@ function createTerminalPopupWindowApi(ctx) {
       win.on("page-title-updated", (e) => { e.preventDefault(); });
 
       try {
-        win.setBackgroundColor(resolveFramelessHostBackgroundColor(backgroundColor));
+        win.setBackgroundColor(backgroundColor);
       } catch {
         // ignore
       }

--- a/electron/bridges/windowManager/terminalPopupWindow.cjs
+++ b/electron/bridges/windowManager/terminalPopupWindow.cjs
@@ -9,6 +9,10 @@ const {
   releaseAttachPopupAuthorization,
   restoreAttachedSessionOutput,
 } = require("../terminalAttachRestore.cjs");
+const {
+  windowsFramelessContentChromeOptions,
+  resolveFramelessHostBackgroundColor,
+} = require("./windowsWindowChrome.cjs");
 
 const ATTACH_CLOSE_PREPARE_TIMEOUT_MS = 2000;
 
@@ -73,9 +77,6 @@ function createTerminalPopupWindowApi(ctx) {
         popupY,
       });
 
-      const {
-        windowsFramelessContentChromeOptions,
-      } = require("./windowsWindowChrome.cjs");
       const windowsChrome = windowsFramelessContentChromeOptions();
 
       const win = new BrowserWindow({
@@ -210,9 +211,6 @@ function createTerminalPopupWindowApi(ctx) {
       win.on("page-title-updated", (e) => { e.preventDefault(); });
 
       try {
-        const {
-          resolveFramelessHostBackgroundColor,
-        } = require("./windowsWindowChrome.cjs");
         win.setBackgroundColor(resolveFramelessHostBackgroundColor(backgroundColor));
       } catch {
         // ignore

--- a/electron/bridges/windowManager/windowsWindowChrome.cjs
+++ b/electron/bridges/windowManager/windowsWindowChrome.cjs
@@ -5,11 +5,11 @@
  * - Frameless Win11 windows need an explicit `roundedCorners: true` so DWM
  *   applies the system round clip (Electron 34+).
  * - Transparent tray popups that keep the default opaque white backdrop + CSS
- *   `border-radius` produce the "直角底上叠圆角 / 冒尖" look.
+ *   `border-radius` produce square tips under a rounded panel.
  *
  * Approach:
  * - App content windows (resizable): solid host + native `roundedCorners`.
- *   Do NOT set `transparent: true` here — Electron documents transparent
+ *   Do NOT set `transparent: true` here - Electron documents transparent
  *   windows as not resizable, and `resizable: true` can break them
  *   (https://www.electronjs.org/docs/latest/tutorial/custom-window-styles).
  * - Tray / CSS-shaped popovers (`resizable: false`): transparent host + clear
@@ -26,7 +26,7 @@ function isWindowsPlatform(platform = process.platform) {
 
 /**
  * Options for full-bleed app windows (main / settings / terminal popup).
- * Safe to spread on non-Windows — returns an empty object.
+ * Safe to spread on non-Windows - returns an empty object.
  */
 function windowsFramelessContentChromeOptions(platform = process.platform) {
   if (!isWindowsPlatform(platform)) return {};

--- a/electron/bridges/windowManager/windowsWindowChrome.cjs
+++ b/electron/bridges/windowManager/windowsWindowChrome.cjs
@@ -2,17 +2,20 @@
  * Windows frameless window chrome helpers.
  *
  * Background (#2505):
- * - Solid `backgroundColor` on frameless Win11 windows shows up as a dark rim
- *   inside DWM's rounded clip ("黑边"), and Win10 never gets OS rounding at all.
+ * - Frameless Win11 windows need an explicit `roundedCorners: true` so DWM
+ *   applies the system round clip (Electron 34+).
  * - Transparent tray popups that keep the default opaque white backdrop + CSS
  *   `border-radius` produce the "直角底上叠圆角 / 冒尖" look.
  *
  * Approach:
- * - App content windows: transparent host + clear backdrop + native
- *   `roundedCorners` so DWM clips the opaque page without a dark under-layer.
- * - Tray / CSS-shaped popovers: transparent host + clear backdrop +
- *   `roundedCorners: false` so only the CSS radius defines the silhouette
- *   (Electron #46468: Win11 otherwise forces OS rounding on transparent windows).
+ * - App content windows (resizable): solid host + native `roundedCorners`.
+ *   Do NOT set `transparent: true` here — Electron documents transparent
+ *   windows as not resizable, and `resizable: true` can break them
+ *   (https://www.electronjs.org/docs/latest/tutorial/custom-window-styles).
+ * - Tray / CSS-shaped popovers (`resizable: false`): transparent host + clear
+ *   backdrop + `roundedCorners: false` so only the CSS radius defines the
+ *   silhouette (Electron #46468: Win11 otherwise forces OS rounding on
+ *   transparent windows).
  */
 
 const CLEAR_BACKGROUND = "#00000000";
@@ -28,8 +31,6 @@ function isWindowsPlatform(platform = process.platform) {
 function windowsFramelessContentChromeOptions(platform = process.platform) {
   if (!isWindowsPlatform(platform)) return {};
   return {
-    transparent: true,
-    backgroundColor: CLEAR_BACKGROUND,
     roundedCorners: true,
   };
 }
@@ -47,20 +48,9 @@ function windowsCssRoundedOverlayChromeOptions(platform = process.platform) {
   };
 }
 
-/**
- * Host backdrop color for setBackgroundColor / theme sync.
- * On Windows content windows the host stays fully clear so theme paints live
- * in the page; a solid host color reintroduces the dark rim under DWM rounding.
- */
-function resolveFramelessHostBackgroundColor(requestedColor, platform = process.platform) {
-  if (isWindowsPlatform(platform)) return CLEAR_BACKGROUND;
-  return requestedColor;
-}
-
 module.exports = {
   CLEAR_BACKGROUND,
   isWindowsPlatform,
   windowsFramelessContentChromeOptions,
   windowsCssRoundedOverlayChromeOptions,
-  resolveFramelessHostBackgroundColor,
 };

--- a/electron/bridges/windowManager/windowsWindowChrome.cjs
+++ b/electron/bridges/windowManager/windowsWindowChrome.cjs
@@ -1,0 +1,66 @@
+/**
+ * Windows frameless window chrome helpers.
+ *
+ * Background (#2505):
+ * - Solid `backgroundColor` on frameless Win11 windows shows up as a dark rim
+ *   inside DWM's rounded clip ("黑边"), and Win10 never gets OS rounding at all.
+ * - Transparent tray popups that keep the default opaque white backdrop + CSS
+ *   `border-radius` produce the "直角底上叠圆角 / 冒尖" look.
+ *
+ * Approach:
+ * - App content windows: transparent host + clear backdrop + native
+ *   `roundedCorners` so DWM clips the opaque page without a dark under-layer.
+ * - Tray / CSS-shaped popovers: transparent host + clear backdrop +
+ *   `roundedCorners: false` so only the CSS radius defines the silhouette
+ *   (Electron #46468: Win11 otherwise forces OS rounding on transparent windows).
+ */
+
+const CLEAR_BACKGROUND = "#00000000";
+
+function isWindowsPlatform(platform = process.platform) {
+  return platform === "win32";
+}
+
+/**
+ * Options for full-bleed app windows (main / settings / terminal popup).
+ * Safe to spread on non-Windows — returns an empty object.
+ */
+function windowsFramelessContentChromeOptions(platform = process.platform) {
+  if (!isWindowsPlatform(platform)) return {};
+  return {
+    transparent: true,
+    backgroundColor: CLEAR_BACKGROUND,
+    roundedCorners: true,
+  };
+}
+
+/**
+ * Options for CSS-rounded overlay windows (tray panel).
+ * Always apply when creating those windows; callers already opt into transparency.
+ */
+function windowsCssRoundedOverlayChromeOptions(platform = process.platform) {
+  return {
+    transparent: true,
+    backgroundColor: CLEAR_BACKGROUND,
+    // Overlay shape comes from CSS; keep OS rounding off on Win11.
+    ...(isWindowsPlatform(platform) ? { roundedCorners: false } : {}),
+  };
+}
+
+/**
+ * Host backdrop color for setBackgroundColor / theme sync.
+ * On Windows content windows the host stays fully clear so theme paints live
+ * in the page; a solid host color reintroduces the dark rim under DWM rounding.
+ */
+function resolveFramelessHostBackgroundColor(requestedColor, platform = process.platform) {
+  if (isWindowsPlatform(platform)) return CLEAR_BACKGROUND;
+  return requestedColor;
+}
+
+module.exports = {
+  CLEAR_BACKGROUND,
+  isWindowsPlatform,
+  windowsFramelessContentChromeOptions,
+  windowsCssRoundedOverlayChromeOptions,
+  resolveFramelessHostBackgroundColor,
+};

--- a/electron/bridges/windowManager/windowsWindowChrome.test.cjs
+++ b/electron/bridges/windowManager/windowsWindowChrome.test.cjs
@@ -83,7 +83,9 @@ test("main/settings/tray call sites wire Windows chrome helpers", () => {
   assert.match(tray, /windowsCssRoundedOverlayChromeOptions/);
   assert.match(tray, /#2505/);
   assert.match(css, /html\.tray-window/);
+  assert.match(css, /html\.tray-window \.splash-screen/);
   assert.match(html, /tray-window/);
+  assert.match(html, /removeTraySplash|splash\.remove\(\)/);
   assert.match(helper, /not resizable/);
   const contentHelperMatch = helper.match(
     /function windowsFramelessContentChromeOptions\([\s\S]*?\n\}/,

--- a/electron/bridges/windowManager/windowsWindowChrome.test.cjs
+++ b/electron/bridges/windowManager/windowsWindowChrome.test.cjs
@@ -68,9 +68,20 @@ test("main/settings/tray call sites wire Windows chrome helpers", () => {
   const css = readFileSync(path.join(here, "../../../index.css"), "utf8");
   const html = readFileSync(path.join(here, "../../../index.html"), "utf8");
 
-  for (const source of [main, settings, popup]) {
-    assert.match(source, /windowsFramelessContentChromeOptions/);
-    assert.match(source, /resolveFramelessHostBackgroundColor/);
+  for (const [label, source] of [
+    ["mainWindow", main],
+    ["settingsWindow", settings],
+    ["terminalPopupWindow", popup],
+  ]) {
+    assert.match(source, /require\("\.\/windowsWindowChrome\.cjs"\)/, `${label} must require chrome helpers`);
+    assert.match(source, /windowsFramelessContentChromeOptions/, `${label} must use content chrome helper`);
+    assert.match(source, /resolveFramelessHostBackgroundColor/, `${label} must use host backdrop helper`);
+    const requireIndex = source.indexOf('require("./windowsWindowChrome.cjs")');
+    const withIndex = source.indexOf("with (ctx)");
+    assert.ok(
+      requireIndex !== -1 && withIndex !== -1 && requireIndex < withIndex,
+      `${label}: require chrome helpers before with(ctx) so injected require cannot remount the path`,
+    );
   }
   assert.match(tray, /windowsCssRoundedOverlayChromeOptions/);
   assert.match(tray, /#2505/);

--- a/electron/bridges/windowManager/windowsWindowChrome.test.cjs
+++ b/electron/bridges/windowManager/windowsWindowChrome.test.cjs
@@ -1,0 +1,79 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  CLEAR_BACKGROUND,
+  isWindowsPlatform,
+  windowsFramelessContentChromeOptions,
+  windowsCssRoundedOverlayChromeOptions,
+  resolveFramelessHostBackgroundColor,
+} = require("./windowsWindowChrome.cjs");
+
+test("CLEAR_BACKGROUND is fully transparent ARGB", () => {
+  assert.equal(CLEAR_BACKGROUND, "#00000000");
+});
+
+test("isWindowsPlatform detects win32 only", () => {
+  assert.equal(isWindowsPlatform("win32"), true);
+  assert.equal(isWindowsPlatform("darwin"), false);
+  assert.equal(isWindowsPlatform("linux"), false);
+});
+
+test("content chrome is a no-op outside Windows", () => {
+  assert.deepEqual(windowsFramelessContentChromeOptions("darwin"), {});
+  assert.deepEqual(windowsFramelessContentChromeOptions("linux"), {});
+});
+
+test("content chrome uses transparent host + native rounding on Windows", () => {
+  assert.deepEqual(windowsFramelessContentChromeOptions("win32"), {
+    transparent: true,
+    backgroundColor: CLEAR_BACKGROUND,
+    roundedCorners: true,
+  });
+});
+
+test("CSS overlay chrome clears the opaque backdrop on every platform", () => {
+  assert.deepEqual(windowsCssRoundedOverlayChromeOptions("darwin"), {
+    transparent: true,
+    backgroundColor: CLEAR_BACKGROUND,
+  });
+  assert.deepEqual(windowsCssRoundedOverlayChromeOptions("linux"), {
+    transparent: true,
+    backgroundColor: CLEAR_BACKGROUND,
+  });
+});
+
+test("CSS overlay chrome disables OS rounding on Windows", () => {
+  assert.deepEqual(windowsCssRoundedOverlayChromeOptions("win32"), {
+    transparent: true,
+    backgroundColor: CLEAR_BACKGROUND,
+    roundedCorners: false,
+  });
+});
+
+test("host backdrop stays clear on Windows after theme sync", () => {
+  assert.equal(resolveFramelessHostBackgroundColor("#1a1a1a", "win32"), CLEAR_BACKGROUND);
+  assert.equal(resolveFramelessHostBackgroundColor("#ffffff", "darwin"), "#ffffff");
+  assert.equal(resolveFramelessHostBackgroundColor("#0b1220", "linux"), "#0b1220");
+});
+
+test("main/settings/tray call sites wire Windows chrome helpers", () => {
+  const { readFileSync } = require("node:fs");
+  const path = require("node:path");
+  const here = __dirname;
+  const main = readFileSync(path.join(here, "mainWindow.cjs"), "utf8");
+  const settings = readFileSync(path.join(here, "settingsWindow.cjs"), "utf8");
+  const popup = readFileSync(path.join(here, "terminalPopupWindow.cjs"), "utf8");
+  const tray = readFileSync(path.join(here, "../globalShortcutBridge.cjs"), "utf8");
+  const css = readFileSync(path.join(here, "../../../index.css"), "utf8");
+  const html = readFileSync(path.join(here, "../../../index.html"), "utf8");
+
+  for (const source of [main, settings, popup]) {
+    assert.match(source, /windowsFramelessContentChromeOptions/);
+    assert.match(source, /resolveFramelessHostBackgroundColor/);
+  }
+  assert.match(tray, /windowsCssRoundedOverlayChromeOptions/);
+  assert.match(tray, /#2505/);
+  assert.match(css, /html\.tray-window/);
+  assert.match(html, /tray-window/);
+});

--- a/electron/bridges/windowManager/windowsWindowChrome.test.cjs
+++ b/electron/bridges/windowManager/windowsWindowChrome.test.cjs
@@ -1,12 +1,13 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const path = require("node:path");
+const { readFileSync } = require("node:fs");
 
 const {
   CLEAR_BACKGROUND,
   isWindowsPlatform,
   windowsFramelessContentChromeOptions,
   windowsCssRoundedOverlayChromeOptions,
-  resolveFramelessHostBackgroundColor,
 } = require("./windowsWindowChrome.cjs");
 
 test("CLEAR_BACKGROUND is fully transparent ARGB", () => {
@@ -24,12 +25,15 @@ test("content chrome is a no-op outside Windows", () => {
   assert.deepEqual(windowsFramelessContentChromeOptions("linux"), {});
 });
 
-test("content chrome uses transparent host + native rounding on Windows", () => {
+test("content chrome enables native rounding without transparency on Windows", () => {
   assert.deepEqual(windowsFramelessContentChromeOptions("win32"), {
-    transparent: true,
-    backgroundColor: CLEAR_BACKGROUND,
     roundedCorners: true,
   });
+  assert.equal(
+    Object.hasOwn(windowsFramelessContentChromeOptions("win32"), "transparent"),
+    false,
+    "resizable app windows must not use transparent hosts",
+  );
 });
 
 test("CSS overlay chrome clears the opaque backdrop on every platform", () => {
@@ -51,15 +55,7 @@ test("CSS overlay chrome disables OS rounding on Windows", () => {
   });
 });
 
-test("host backdrop stays clear on Windows after theme sync", () => {
-  assert.equal(resolveFramelessHostBackgroundColor("#1a1a1a", "win32"), CLEAR_BACKGROUND);
-  assert.equal(resolveFramelessHostBackgroundColor("#ffffff", "darwin"), "#ffffff");
-  assert.equal(resolveFramelessHostBackgroundColor("#0b1220", "linux"), "#0b1220");
-});
-
 test("main/settings/tray call sites wire Windows chrome helpers", () => {
-  const { readFileSync } = require("node:fs");
-  const path = require("node:path");
   const here = __dirname;
   const main = readFileSync(path.join(here, "mainWindow.cjs"), "utf8");
   const settings = readFileSync(path.join(here, "settingsWindow.cjs"), "utf8");
@@ -67,6 +63,7 @@ test("main/settings/tray call sites wire Windows chrome helpers", () => {
   const tray = readFileSync(path.join(here, "../globalShortcutBridge.cjs"), "utf8");
   const css = readFileSync(path.join(here, "../../../index.css"), "utf8");
   const html = readFileSync(path.join(here, "../../../index.html"), "utf8");
+  const helper = readFileSync(path.join(here, "windowsWindowChrome.cjs"), "utf8");
 
   for (const [label, source] of [
     ["mainWindow", main],
@@ -75,7 +72,7 @@ test("main/settings/tray call sites wire Windows chrome helpers", () => {
   ]) {
     assert.match(source, /require\("\.\/windowsWindowChrome\.cjs"\)/, `${label} must require chrome helpers`);
     assert.match(source, /windowsFramelessContentChromeOptions/, `${label} must use content chrome helper`);
-    assert.match(source, /resolveFramelessHostBackgroundColor/, `${label} must use host backdrop helper`);
+    assert.doesNotMatch(source, /resolveFramelessHostBackgroundColor/, `${label} should not clear host backdrop`);
     const requireIndex = source.indexOf('require("./windowsWindowChrome.cjs")');
     const withIndex = source.indexOf("with (ctx)");
     assert.ok(
@@ -87,4 +84,15 @@ test("main/settings/tray call sites wire Windows chrome helpers", () => {
   assert.match(tray, /#2505/);
   assert.match(css, /html\.tray-window/);
   assert.match(html, /tray-window/);
+  assert.match(helper, /not resizable/);
+  const contentHelperMatch = helper.match(
+    /function windowsFramelessContentChromeOptions\([\s\S]*?\n\}/,
+  );
+  assert.ok(contentHelperMatch, "content chrome helper must exist");
+  assert.match(contentHelperMatch[0], /roundedCorners:\s*true/);
+  assert.doesNotMatch(
+    contentHelperMatch[0],
+    /transparent/,
+    "content chrome must stay opaque/resizable",
+  );
 });

--- a/electron/bridges/windowManager/windowsWindowChrome.test.cjs
+++ b/electron/bridges/windowManager/windowsWindowChrome.test.cjs
@@ -86,7 +86,10 @@ test("main/settings/tray call sites wire Windows chrome helpers", () => {
   assert.match(css, /html\.tray-window \.splash-screen/);
   assert.match(html, /tray-window/);
   assert.match(html, /removeTraySplash|splash\.remove\(\)/);
+  assert.match(tray, /trayPanelShowWhenReady|trayPanelReady/);
+  assert.match(helper, /square tips under a rounded panel/);
   assert.match(helper, /not resizable/);
+  assert.doesNotMatch(helper, /[^\x00-\x7F]/, "helper comments must stay ASCII-only");
   const contentHelperMatch = helper.match(
     /function windowsFramelessContentChromeOptions\([\s\S]*?\n\}/,
   );

--- a/electron/bridges/windowManager/windowsWindowChrome.test.cjs
+++ b/electron/bridges/windowManager/windowsWindowChrome.test.cjs
@@ -87,6 +87,7 @@ test("main/settings/tray call sites wire Windows chrome helpers", () => {
   assert.match(html, /tray-window/);
   assert.match(html, /removeTraySplash|splash\.remove\(\)/);
   assert.match(tray, /trayPanelShowWhenReady|trayPanelReady/);
+  assert.match(tray, /isOpenOrPending/);
   assert.match(helper, /square tips under a rounded panel/);
   assert.match(helper, /not resizable/);
   assert.doesNotMatch(helper, /[^\x00-\x7F]/, "helper comments must stay ASCII-only");

--- a/index.css
+++ b/index.css
@@ -409,6 +409,11 @@ html.tray-window #root {
   background-color: transparent !important;
 }
 
+html.tray-window .splash-screen {
+  display: none !important;
+  background: transparent !important;
+}
+
 ::view-transition-old(root),
 ::view-transition-new(root) {
   animation-duration: 220ms;

--- a/index.css
+++ b/index.css
@@ -401,6 +401,14 @@ body {
   color: hsl(var(--foreground));
 }
 
+/* Tray overlay window: opaque body would show as square tips outside CSS radius (#2505). */
+html.tray-window,
+html.tray-window body,
+html.tray-window #root {
+  background: transparent !important;
+  background-color: transparent !important;
+}
+
 ::view-transition-old(root),
 ::view-transition-new(root) {
   animation-duration: 220ms;

--- a/index.html
+++ b/index.html
@@ -133,9 +133,14 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background: hsl(var(--background));
+      background: transparent;
       z-index: 9999;
       transition: opacity 0.2s ease-out;
+    }
+
+    /* Main app only: opaque splash fill. Tray overlay stays clear (#2505). */
+    html:not(.tray-window) .splash-screen {
+      background: hsl(var(--background));
     }
 
     .splash-screen.fade-out {

--- a/index.html
+++ b/index.html
@@ -71,6 +71,14 @@
       color: hsl(var(--foreground));
     }
 
+    /* Tray panel: keep the host fully clear so CSS rounded corners are see-through. */
+    html.tray-window,
+    html.tray-window body,
+    html.tray-window #root {
+      background: transparent !important;
+      background-color: transparent !important;
+    }
+
     /* Windows flag/emoji fallbacks live on --font-sans (not a body font-family
        override) so Appearance UI font still reaches portaled panels (#2647). */
     html.platform-win32 {
@@ -195,6 +203,12 @@
         var ua = navigator.userAgent || '';
         if (/Win/i.test(ua)) {
           root.classList.add('platform-win32');
+        }
+
+        // Tray overlay uses CSS border-radius over a transparent BrowserWindow.
+        // Mark it before first paint so body/root never flash an opaque backdrop (#2505).
+        if ((window.location.hash || '') === '#/tray' || (window.location.hash || '').indexOf('#/tray') === 0) {
+          root.classList.add('tray-window');
         }
       } catch (e) {
         // ignore

--- a/index.html
+++ b/index.html
@@ -79,6 +79,11 @@
       background-color: transparent !important;
     }
 
+    html.tray-window .splash-screen {
+      display: none !important;
+      background: transparent !important;
+    }
+
     /* Windows flag/emoji fallbacks live on --font-sans (not a body font-family
        override) so Appearance UI font still reaches portaled panels (#2647). */
     html.platform-win32 {
@@ -206,9 +211,19 @@
         }
 
         // Tray overlay uses CSS border-radius over a transparent BrowserWindow.
-        // Mark it before first paint so body/root never flash an opaque backdrop (#2505).
+        // Mark it before first paint so body/root/splash never flash an opaque
+        // backdrop (#2505). Splash lives in <body>, so remove it on DOM ready.
         if ((window.location.hash || '') === '#/tray' || (window.location.hash || '').indexOf('#/tray') === 0) {
           root.classList.add('tray-window');
+          var removeTraySplash = function () {
+            var splash = document.getElementById('splash');
+            if (splash) splash.remove();
+          };
+          if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', removeTraySplash, { once: true });
+          } else {
+            removeTraySplash();
+          }
         }
       } catch (e) {
         // ignore

--- a/index.tsx
+++ b/index.tsx
@@ -144,6 +144,7 @@ const syncTrayWindowClass = (route: string) => {
   const rootEl = document.documentElement;
   if (route === 'tray') {
     rootEl.classList.add('tray-window');
+    document.getElementById('splash')?.remove();
   } else {
     rootEl.classList.remove('tray-window');
   }

--- a/index.tsx
+++ b/index.tsx
@@ -140,8 +140,18 @@ const getRoute = () => {
 
 const root = ReactDOM.createRoot(rootElement);
 
+const syncTrayWindowClass = (route: string) => {
+  const rootEl = document.documentElement;
+  if (route === 'tray') {
+    rootEl.classList.add('tray-window');
+  } else {
+    rootEl.classList.remove('tray-window');
+  }
+};
+
 const renderApp = () => {
   const route = getRoute();
+  syncTrayWindowClass(route);
   if (route === 'settings') {
     root.render(
       <ToastProvider>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#2505](https://github.com/binaricat/Netcatty/issues/2505): Windows main-window rounded corners / black edges, and tray popup corners that looked sharp under a rounded overlay (peeking corners).

## Type of Change

- [x] Bug fix

## Related Issue

Closes #2505

## Changes Made

- **Tray overlay:** transparent host + `#00000000` + `roundedCorners: false`; CSS `rounded-lg` defines the silhouette.
- **App content windows:** Windows-only `roundedCorners: true` (opaque/resizable — no `transparent`).
- Tray route: `html.tray-window`, transparent page chrome, splash transparent by default / removed on tray, first `show()` deferred until `did-finish-load`, second toggle cancels pending show.
- Chrome helpers required at module scope (outside `with (ctx)`).

## Codex review loop

| Round | Finding | Fix |
|-------|---------|-----|
| P0 | Injected `require` path `MODULE_NOT_FOUND` | Module-scope require |
| P2 | Transparent breaks resizable windows | Drop transparent on content windows |
| P2 | Opaque splash flash on tray | Hide/remove splash; defer first show |
| P2 | Non-ASCII helper comment | ASCII-only English |
| P2 | Pending show survives second toggle | Cancel pending on hide/toggle |

**Codex final:** "Didn't find any major issues. Nice work!" on `f66c090793`.

## Testing

- [x] `windowsWindowChrome` + `globalShortcutBridge` + `windowManagerReadiness` tests pass
- [ ] Windows GUI verification still recommended

<!-- CURSOR_AGENT_PR_BODY_END -->