### PR TITLE
fix(ssh): forward resolved Local Network first hop on direct starts

### DIFF
--- a/electron/bridges/macLocalNetworkAccess.cjs
+++ b/electron/bridges/macLocalNetworkAccess.cjs
@@ -298,6 +298,20 @@ function extractRemoteUnreachableAddresses(text) {
   return [...new Set(found)];
 }
 
+/**
+ * Attach the LAN address resolved by ensureAccess onto start options so both
+ * the worker path and the direct main-process fallback can annotate errors.
+ */
+function attachMacLocalNetworkProbeResult(options, probeResult) {
+  const base = options && typeof options === "object" ? { ...options } : {};
+  const resolvedFirstHop = probeResult && typeof probeResult.hostname === "string"
+    ? String(probeResult.hostname).trim()
+    : "";
+  if (!resolvedFirstHop) return base;
+  base._macLocalNetworkResolvedFirstHop = resolvedFirstHop;
+  return base;
+}
+
 function annotateMacLocalNetworkErrorMessage(message, options = {}) {
   const platform = options.platform || process.platform;
   const text = String(message || "");
@@ -559,6 +573,7 @@ module.exports = {
   resolveFirstTcpEndpoint,
   resolveLanProbeTarget,
   annotateMacLocalNetworkErrorMessage,
+  attachMacLocalNetworkProbeResult,
   createMacLocalNetworkAccessGate,
   ensureMacLocalNetworkAccess: (options) => defaultGate.ensureAccess(options),
   annotateMacLocalNetworkError: (message, options) => defaultGate.annotateErrorMessage(message, options),

--- a/electron/bridges/macLocalNetworkAccess.test.cjs
+++ b/electron/bridges/macLocalNetworkAccess.test.cjs
@@ -13,6 +13,7 @@ const {
   resolveFirstTcpEndpoint,
   resolveLanProbeTarget,
   annotateMacLocalNetworkErrorMessage,
+  attachMacLocalNetworkProbeResult,
   createMacLocalNetworkAccessGate,
 } = require("./macLocalNetworkAccess.cjs");
 
@@ -399,6 +400,32 @@ test("annotateMacLocalNetworkErrorMessage uses carried resolved first-hop addres
       firstHopHostname: "bastion.example.com",
     }),
     message,
+  );
+});
+
+test("attachMacLocalNetworkProbeResult forwards resolved first-hop for direct starts", () => {
+  const options = {
+    hostname: "app.example.com",
+    jumpHosts: [{ hostname: "bastion.example.com", port: 22 }],
+  };
+  const attached = attachMacLocalNetworkProbeResult(options, {
+    probed: true,
+    hostname: "192.168.1.20",
+  });
+  assert.equal(attached._macLocalNetworkResolvedFirstHop, "192.168.1.20");
+  assert.match(
+    annotateMacLocalNetworkErrorMessage("connect EHOSTUNREACH 192.168.1.20:22", {
+      platform: "darwin",
+      hostname: attached.hostname,
+      firstHopHostname: "bastion.example.com",
+      firstHopResolvedAddress: attached._macLocalNetworkResolvedFirstHop,
+    }),
+    /Local Network/i,
+  );
+  assert.equal(
+    attachMacLocalNetworkProbeResult(options, { skipped: true, reason: "not-local-network" })
+      ._macLocalNetworkResolvedFirstHop,
+    undefined,
   );
 });
 

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -68,7 +68,7 @@ const {
   createStartSessionApi,
   resolveSshConnectionTimeouts,
 } = require("./sshBridge/startSession.cjs");
-const { ensureMacLocalNetworkAccess } = require("./macLocalNetworkAccess.cjs");
+const { ensureMacLocalNetworkAccess, attachMacLocalNetworkProbeResult } = require("./macLocalNetworkAccess.cjs");
 
 function quoteShellArg(value) {
   return "'" + String(value).replace(/'/g, "'\\''") + "'";
@@ -1320,10 +1320,11 @@ async function startSSHSessionWrapper(event, options) {
   try {
     // Main-process UDP Local Network probe (TN3179 discard-port connect) so
     // TCC attributes to Netcatty before the (possibly worker-hosted) SSH dial.
-    // See #2663 / #2673.
-    await ensureMacLocalNetworkAccess(options);
+    // See #2663 / #2673. Carry the resolved first-hop address so direct-start
+    // annotation (no terminal worker) still sees split-DNS LAN evidence.
+    const probeResult = await ensureMacLocalNetworkAccess(options);
     return await startSSHSessionWithRetries(event, {
-      ...options,
+      ...attachMacLocalNetworkProbeResult(options, probeResult),
       ...(sourceReuseState ? { _sourceReuseState: sourceReuseState } : {}),
     }, pendingDialState);
   } catch (err) {
@@ -1408,15 +1409,12 @@ function registerWorkerHandle(ipcMain, terminalWorkerManager, channel) {
     let workerPayload = payload;
     if (channel === "netcatty:start") {
       const probeResult = await ensureMacLocalNetworkAccess(payload);
-      const resolvedFirstHop = probeResult && typeof probeResult.hostname === "string"
-        ? String(probeResult.hostname).trim()
-        : "";
       workerPayload = {
-        ...(payload && typeof payload === "object" ? payload : {}),
+        ...attachMacLocalNetworkProbeResult(
+          payload && typeof payload === "object" ? payload : {},
+          probeResult,
+        ),
         _macLocalNetworkMainProbed: true,
-        ...(resolvedFirstHop
-          ? { _macLocalNetworkResolvedFirstHop: resolvedFirstHop }
-          : {}),
       };
     }
     return terminalWorkerManager.request(channel, workerPayload, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #2766. When the terminal worker is disabled (`NETCATTY_TERMINAL_WORKER=0`) or `utilityProcess` is unavailable, the direct `netcatty:start` path probed Local Network access but did not forward the resolved first-hop LAN address into `startSSHSessionWithRetries`. Split-DNS FQDN first hops (e.g. `bastion.example.com` → `192.168.1.20`) then lost the Local Network error hint.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #2673 / follow-up to #2766 (Codex P2 after merge)

## Changes Made

- Add `attachMacLocalNetworkProbeResult()` to carry `probeResult.hostname` as `_macLocalNetworkResolvedFirstHop`
- Use it on both the direct `startSSHSessionWrapper` path and the worker `netcatty:start` path
- Cover the helper with a unit test that asserts annotation still receives the resolved address

## Screenshots / Demo

N/A (error-message annotation wiring only)

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`macLocalNetworkAccess.test.cjs` + `terminalWorkerProxyRegistration.test.cjs`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1f4189f-a995-4ffb-9341-94fc46e242b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1f4189f-a995-4ffb-9341-94fc46e242b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

