### PR TITLE
fix: remove lint warnings

### DIFF
--- a/application/state/useAutoSync.ts
+++ b/application/state/useAutoSync.ts
@@ -495,7 +495,7 @@ export const useAutoSync = (config: AutoSyncConfig) => {
     } finally {
       isSyncRunningRef.current = false;
     }
-  }, [enabled, sync, buildPayload, getDataHash, onApplyConvergentPayload, onApplyPayload, t]);
+  }, [enabled, sync, buildPayload, onApplyConvergentPayload, onApplyPayload, t]);
 
   const syncNowRef = useRef(syncNow);
   useEffect(() => {

--- a/components/ai/ChatMessageList.test.tsx
+++ b/components/ai/ChatMessageList.test.tsx
@@ -185,7 +185,7 @@ test("jump pin ignores streaming isAtBottom flips and releases on scroll button"
   assert.match(jumpSource, /isStreaming\?: boolean/);
   assert.match(jumpSource, /if \(isStreaming\) return;/);
   assert.match(jumpSource, /window\.setTimeout/);
-  assert.match(listSource, /isStreaming=\{\!\!isStreaming\}/);
+  assert.match(listSource, /isStreaming=\{!!isStreaming\}/);
   assert.match(listSource, /<ConversationScrollButton onClick=\{handleReleaseJumpPin\} \/>/);
 });
 


### PR DESCRIPTION
## Summary

Remove the three ESLint warnings reported on the latest main branch.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Removed the unused `getDataHash` dependency from the `syncNow` callback.
- Removed unnecessary escape characters from the `isStreaming` assertion regex.

## Screenshots / Demo

Not applicable.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Targeted tests also pass for `application/state/useAutoSync.test.ts` and `components/ai/ChatMessageList.test.tsx`.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
