### PR TITLE
fix(terminal): raise autocomplete suggestion cap for snippet matches

### DIFF
--- a/components/terminal/autocomplete/terminalAutocompleteSettings.ts
+++ b/components/terminal/autocomplete/terminalAutocompleteSettings.ts
@@ -27,7 +27,7 @@ export function resolveTerminalAutocompleteSettings(input: {
       allowLineReplacement: false,
       debounceMs: terminalSettings?.autocompleteDebounceMs ?? 100,
       minChars: terminalSettings?.autocompleteMinChars ?? 1,
-      maxSuggestions: terminalSettings?.autocompleteMaxSuggestions ?? 8,
+      maxSuggestions: terminalSettings?.autocompleteMaxSuggestions ?? 50,
       historyScope: terminalSettings?.autocompleteHistoryScope ?? "host",
       shiftEnterNewlineEnabled: terminalSettings?.shiftEnterNewlineEnabled ?? true,
     };
@@ -43,7 +43,7 @@ export function resolveTerminalAutocompleteSettings(input: {
     allowLineReplacement: true,
     debounceMs: terminalSettings.autocompleteDebounceMs ?? 100,
     minChars: terminalSettings.autocompleteMinChars ?? 1,
-    maxSuggestions: terminalSettings.autocompleteMaxSuggestions ?? 8,
+    maxSuggestions: terminalSettings.autocompleteMaxSuggestions ?? 50,
     historyScope: terminalSettings.autocompleteHistoryScope ?? "host",
     shiftEnterNewlineEnabled: terminalSettings.shiftEnterNewlineEnabled ?? true,
   };

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -66,7 +66,7 @@ export const DEFAULT_AUTOCOMPLETE_SETTINGS: AutocompleteSettings = {
   allowLineReplacement: true,
   debounceMs: 100,
   minChars: 1,
-  maxSuggestions: 8,
+  maxSuggestions: 50,
   fastTypingThresholdMs: 40,
   shiftEnterNewlineEnabled: true,
   historyScope: "host",

--- a/components/terminal/completionEngineSnippets.test.ts
+++ b/components/terminal/completionEngineSnippets.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { getCompletions } from "./autocomplete/completionEngine";
+import { DEFAULT_AUTOCOMPLETE_SETTINGS } from "./autocomplete/useTerminalAutocomplete";
 import type { Snippet } from "../../domain/models";
 
 const deploySnippet: Snippet = { id: "d", label: "deploy", command: "kubectl apply -f ." };
@@ -16,4 +17,28 @@ test("getCompletions includes snippet suggestions at the command position", asyn
 test("getCompletions does not surface snippets past the command position", async () => {
   const out = await getCompletions("git dep", { snippets: [deploySnippet] });
   assert.equal(out.find((s) => s.source === "snippet"), undefined);
+});
+
+test("getCompletions returns more than 8 snippet matches when default maxSuggestions allows it", async () => {
+  const snippets: Snippet[] = Array.from({ length: 20 }, (_, i) => ({
+    id: `s${i}`,
+    label: `deploy-${String(i).padStart(2, "0")}`,
+    command: `echo deploy-${i}`,
+  }));
+
+  assert.ok(
+    DEFAULT_AUTOCOMPLETE_SETTINGS.maxSuggestions > 8,
+    `expected raised default maxSuggestions (>8), got ${DEFAULT_AUTOCOMPLETE_SETTINGS.maxSuggestions}`,
+  );
+
+  const out = await getCompletions("dep", {
+    snippets,
+    maxResults: DEFAULT_AUTOCOMPLETE_SETTINGS.maxSuggestions,
+  });
+  const snippetMatches = out.filter((s) => s.source === "snippet");
+  assert.ok(
+    snippetMatches.length > 8,
+    `expected more than 8 snippet matches for scrolling popup, got ${snippetMatches.length}`,
+  );
+  assert.equal(snippetMatches.length, 20);
 });

--- a/components/terminal/terminalAutocompleteSettings.test.ts
+++ b/components/terminal/terminalAutocompleteSettings.test.ts
@@ -72,3 +72,21 @@ test("defaults autocomplete history scope to host when unset", () => {
     "host",
   );
 });
+
+test("falls back to raised maxSuggestions default when unset", () => {
+  assert.equal(
+    resolveTerminalAutocompleteSettings({
+      protocol: "ssh",
+      terminalSettings: {
+        autocompleteEnabled: true,
+      },
+    })?.maxSuggestions,
+    50,
+  );
+  assert.equal(
+    resolveTerminalAutocompleteSettings({
+      protocol: "serial",
+    })?.maxSuggestions,
+    50,
+  );
+});

--- a/domain/models/terminal.ts
+++ b/domain/models/terminal.ts
@@ -517,7 +517,7 @@ const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   autocompletePopupMenu: true, // Popup menu enabled by default
   autocompleteDebounceMs: 100, // 100ms debounce
   autocompleteMinChars: 1, // Start suggesting after 1 character
-  autocompleteMaxSuggestions: 8, // Show up to 8 suggestions
+  autocompleteMaxSuggestions: 50, // Show up to 50 suggestions (popup scrolls)
   autocompleteHistoryScope: 'host', // Per-host history suggestions by default (#2595)
   passwordPromptAssist: 'hint', // Historical sudo confirm-to-fill; picker is opt-in (#2156)
 };

--- a/domain/models/terminal.ts
+++ b/domain/models/terminal.ts
@@ -396,9 +396,16 @@ export const normalizeTerminalSettings = (
     ? 'dom' as const
     : mergedSettings.rendererType;
 
+  // Persisted installs wrote the old default (8) into localStorage with no UI
+  // to change it; bump that sentinel to the new default while keeping custom caps.
+  const autocompleteMaxSuggestions = mergedSettings.autocompleteMaxSuggestions === 8
+    ? DEFAULT_TERMINAL_SETTINGS.autocompleteMaxSuggestions
+    : mergedSettings.autocompleteMaxSuggestions;
+
   return {
     ...mergedSettings,
     rendererType,
+    autocompleteMaxSuggestions,
     hibernateHiddenTabsDelaySec: normalizeHibernateHiddenTabsDelaySec(
       mergedSettings.hibernateHiddenTabsDelaySec,
     ),

--- a/domain/terminalSettings.test.ts
+++ b/domain/terminalSettings.test.ts
@@ -226,3 +226,21 @@ test("normalizeTerminalSettings prefers explicit middle-click behavior over lega
   assert.equal(settings.middleClickBehavior, "context-menu");
   assert.equal(settings.middleClickPaste, false);
 });
+
+test("normalizeTerminalSettings migrates legacy autocompleteMaxSuggestions default 8 to 50", () => {
+  assert.equal(
+    normalizeTerminalSettings({ autocompleteMaxSuggestions: 8 }).autocompleteMaxSuggestions,
+    50,
+  );
+});
+
+test("normalizeTerminalSettings preserves intentional custom autocompleteMaxSuggestions", () => {
+  assert.equal(
+    normalizeTerminalSettings({ autocompleteMaxSuggestions: 6 }).autocompleteMaxSuggestions,
+    6,
+  );
+  assert.equal(
+    normalizeTerminalSettings({ autocompleteMaxSuggestions: 20 }).autocompleteMaxSuggestions,
+    20,
+  );
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Terminal keyword autocomplete truncated merged suggestions at a default of 8, so users with many matching snippets could not scroll to the rest even though the floating popup already supports scrolling.

Existing installs also persisted that old default into localStorage (no settings UI), so this PR raises the default to 50 and migrates the legacy sentinel value `8` → `50` while preserving intentional custom caps.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2793

## Changes Made

- Raised default `autocompleteMaxSuggestions` from 8 to 50 (still configurable)
- Migrated persisted legacy default `8` → `50` in `normalizeTerminalSettings`
- Updated defaults/fallbacks in terminal models, autocomplete hook, and settings resolver
- Added regression coverage for snippet match count and legacy migration

## Screenshots / Demo

N/A (behavior: floating list can now include more than 8 matching scripts and scroll)

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — completionEngine / autocomplete settings / normalizeTerminalSettings migration
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-539160f8-57d7-4639-8ede-4edbaf700416?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-539160f8-57d7-4639-8ede-4edbaf700416&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

