### PR TITLE
fix(ai): prevent empty messages after tool-step budget prune

### DIFF
--- a/infrastructure/ai/harness/contextManager.test.ts
+++ b/infrastructure/ai/harness/contextManager.test.ts
@@ -251,6 +251,53 @@ test('prepareStepContext retains handle notice after step budget guard', async (
   assert.match(String(notices[0]?.content), /\[step 2\]/);
 });
 
+test('prepareStepContext keeps post-tool turn messages when step budget prune would empty them', async () => {
+  const messages: ModelMessage[] = [
+    { role: 'user', content: 'Check disk usage on prod-web-01.' },
+    {
+      role: 'assistant',
+      content: [{
+        type: 'tool-call',
+        toolCallId: 'call-disk',
+        toolName: 'terminal_execute',
+        input: { sessionId: 'sess-1', command: 'df -h' },
+      }],
+    },
+    {
+      role: 'tool',
+      content: [{
+        type: 'tool-result',
+        toolCallId: 'call-disk',
+        toolName: 'terminal_execute',
+        output: { type: 'text', value: 'Filesystem Size Used Avail Use% Mounted on\n/dev/sda1 100G 90G 10G 90% /' },
+      }],
+    },
+  ];
+
+  const prepared = await prepareStepContext({
+    messages,
+    stepNumber: 1,
+    sessionId: 'chat-empty-guard',
+    chatSessionId: 'chat-empty-guard',
+    // Tiny window + huge reserve forces applyStepBudgetGuard into prune loop.
+    contextWindow: 2_000,
+    reservedTokens: 50_000,
+    maxOutputTokens: 256,
+    providerId: 'anthropic',
+    runtimeContext: createInitialCattyRuntimeContext({
+      chatSessionId: 'chat-empty-guard',
+      turnId: 'turn-empty-guard',
+      permissionMode: 'confirm',
+      scopeType: 'terminal',
+    }),
+  });
+
+  assert.ok(prepared.messages.length > 0, 'messages must not be empty after step budget prune');
+  const serialized = JSON.stringify(prepared.messages);
+  assert.match(serialized, /call-disk/);
+  assert.match(serialized, /tool-result|df -h|Filesystem/);
+});
+
 test('prepareStepContext never leaves orphan results from a parallel tool batch', async () => {
   const toolCallIds = ['a', 'b', 'c', 'd', 'e', 'f'];
   const messages: ModelMessage[] = [

--- a/infrastructure/ai/harness/contextManager.ts
+++ b/infrastructure/ai/harness/contextManager.ts
@@ -372,7 +372,8 @@ function applyStepBudgetGuard(
   }
   while (afterTotal >= threshold && next.length > 2) {
     const pruned = pruneFirstModelMessage(next);
-    if (pruned.length === next.length) break;
+    // Never accept a prune that empties the conversation — streamText rejects [].
+    if (pruned.length === 0 || pruned.length === next.length) break;
     next = pruned;
     didAdjust = true;
     afterTotal = computeTotalInputTokens({
@@ -430,6 +431,7 @@ export async function prepareStepContext(
     didHandleNotice = true;
   }
 
+  const preBudgetMessages = working;
   const budgetGuard = applyStepBudgetGuard(working, {
     contextWindow,
     reservedTokens: input.reservedTokens ?? 0,
@@ -437,7 +439,9 @@ export async function prepareStepContext(
     providerId: input.providerId,
     protectRecentMessages: protectRecent,
   });
-  working = budgetGuard.messages;
+  working = budgetGuard.messages.length > 0 || preBudgetMessages.length === 0
+    ? budgetGuard.messages
+    : preBudgetMessages;
   if (didHandleNotice && pendingHandles.length > 0) {
     const hasHandleNotice = working.some(
       (message) => message.role === 'user' && isStepHandleNoticeMessage(message.content),
@@ -467,8 +471,15 @@ export async function prepareStepContext(
       providerId: input.providerId,
       protectRecentMessages: protectRecent,
     });
-    working = [...notices, ...finalGuard.messages];
+    const guardedBody = finalGuard.messages.length > 0 || body.length === 0
+      ? finalGuard.messages
+      : body;
+    working = [...notices, ...guardedBody];
     budgetGuard.didAdjust = budgetGuard.didAdjust || finalGuard.didAdjust;
+  }
+  // Last-resort: never hand streamText an empty messages array when the input had content.
+  if (working.length === 0 && input.messages.length > 0) {
+    working = preBudgetMessages.length > 0 ? preBudgetMessages : input.messages;
   }
   const didBudgetAdjust = integrity.didAdjust || stale.didAdjust || typed.didAdjust || budgetGuard.didAdjust;
   const didAdjust = didBudgetAdjust || didHandleNotice;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Catty sidebar AI could abort after a successful tool call with `Invalid prompt: messages must not be empty`, because step-budget pruning emptied the post-tool message list before the follow-up model request.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2792
Closes #2796

## Changes Made

- `applyStepBudgetGuard` rejects prunes that would leave an empty message list
- `prepareStepContext` falls back to pre-budget messages if the budget guard empties a non-empty input
- Regression test: post-tool 3-message turn under reserve pressure must keep `messages.length > 0`

## Screenshots / Demo

N/A (harness / unit-tested path)

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — `contextManager.test.ts` + related compaction tests
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-539160f8-57d7-4639-8ede-4edbaf700416?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-539160f8-57d7-4639-8ede-4edbaf700416&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

