### PR TITLE
fix(tabs): restore previous tab after closing temporary session

### DIFF
--- a/application/state/activeChromeThemeSync.test.ts
+++ b/application/state/activeChromeThemeSync.test.ts
@@ -7,7 +7,7 @@ const chromeThemeSource = readFileSync(new URL("./useActiveChromeTheme.ts", impo
 const storeSource = readFileSync(new URL("./activeTabStore.ts", import.meta.url), "utf8");
 
 test("active tab changes notify chrome theme before react subscribers", () => {
-  const setActiveTabIdBody = storeSource.match(/setActiveTabId = \(id: string\) => \{[\s\S]*?\n {2}\};/)?.[0] ?? "";
+  const setActiveTabIdBody = storeSource.match(/setActiveTabId = \(id: string(?:, options\?: \w+)?\) => \{[\s\S]*?\n {2}\};/)?.[0] ?? "";
   assert.match(setActiveTabIdBody, /this\.syncListeners\.forEach\(\(listener\) => listener\(id\)\)/);
   assert.match(setActiveTabIdBody, /this\.scheduleNotify\(\)/);
   assert.ok(

--- a/application/state/activeTabStore.test.ts
+++ b/application/state/activeTabStore.test.ts
@@ -4,6 +4,37 @@ import test from 'node:test';
 import { activeTabStore, fromEditorTabId, isEditorTabId, toEditorTabId } from './activeTabStore';
 import { terminalLayoutSuppressStore } from './terminalLayoutSuppressStore';
 
+test('active tab store remembers the previous tab for restore-on-close', () => {
+  const previousWindow = (globalThis as { window?: unknown }).window;
+  (globalThis as { window?: unknown }).window ??= globalThis;
+
+  const marker = `prev-tab-${Date.now()}`;
+  const first = `${marker}-a`;
+  const second = `${marker}-b`;
+  const third = `${marker}-c`;
+  const before = activeTabStore.getActiveTabId();
+
+  try {
+    activeTabStore.setActiveTabId(first);
+    activeTabStore.setActiveTabId(second);
+    assert.equal(activeTabStore.getPreviousActiveTabId(), first);
+
+    activeTabStore.setActiveTabId(third);
+    assert.equal(activeTabStore.getPreviousActiveTabId(), second);
+
+    activeTabStore.setActiveTabId(first, { recordPrevious: false });
+    assert.equal(activeTabStore.getActiveTabId(), first);
+    assert.equal(activeTabStore.getPreviousActiveTabId(), second);
+  } finally {
+    activeTabStore.setActiveTabId(before, { recordPrevious: false });
+    if (previousWindow === undefined) {
+      delete (globalThis as { window?: unknown }).window;
+    } else {
+      (globalThis as { window?: unknown }).window = previousWindow;
+    }
+  }
+});
+
 test('editor tab helpers round trip ids', () => {
   assert.equal(toEditorTabId('file-1'), 'editor:file-1');
   assert.equal(fromEditorTabId('editor:file-1'), 'file-1');

--- a/application/state/activeTabStore.ts
+++ b/application/state/activeTabStore.ts
@@ -16,13 +16,21 @@ export const toEditorTabId = (editorId: string): string => `${EDITOR_PREFIX}${ed
 /** Strip the "editor:" prefix to recover the internal editorTab id. */
 export const fromEditorTabId = (tabId: string): string => tabId.slice(EDITOR_PREFIX.length);
 
+type SetActiveTabOptions = {
+  /** When false, keep the previous-tab pointer unchanged (used for close restore). */
+  recordPrevious?: boolean;
+};
+
 class ActiveTabStore {
   private activeTabId: string = 'vault';
+  private previousActiveTabId: string | null = null;
   private listeners = new Set<Listener>();
   private syncListeners = new Set<SyncListener>();
   private notifyRafId: number | null = null;
 
   getActiveTabId = () => this.activeTabId;
+
+  getPreviousActiveTabId = () => this.previousActiveTabId;
 
   private scheduleNotify = () => {
     if (this.notifyRafId !== null) return;
@@ -35,8 +43,11 @@ class ActiveTabStore {
     });
   };
 
-  setActiveTabId = (id: string) => {
+  setActiveTabId = (id: string, options?: SetActiveTabOptions) => {
     if (this.activeTabId !== id) {
+      if (options?.recordPrevious !== false) {
+        this.previousActiveTabId = this.activeTabId;
+      }
       this.activeTabId = id;
       this.syncListeners.forEach((listener) => listener(id));
       // Coalesce rapid tab switches into one notification per frame and avoid

--- a/application/state/sessionWorkspaceDetach.test.ts
+++ b/application/state/sessionWorkspaceDetach.test.ts
@@ -147,6 +147,7 @@ test("closing one split pane keeps the other terminal as an orphan tab", () => {
       workspaceId: "ws-1",
       layoutResult,
       remainingSessions: nextSessions,
+      preferredTabId: "s-outside",
     }),
     "s2",
   );
@@ -195,6 +196,81 @@ test("closing the last visible solo tab does not fall back to a hidden MCP sessi
     }),
     "vault",
   );
+});
+
+test("closing a temporary solo tab restores the previously focused tab", () => {
+  const standalone = (id: string, status: TerminalSession["status"] = "connected"): TerminalSession => ({
+    ...session(id),
+    workspaceId: undefined,
+    status,
+  });
+  const remainingSessions = [
+    standalone("s1", "disconnected"),
+    standalone("s2"),
+    standalone("s3"),
+    standalone("s4"),
+    standalone("s5", "disconnected"),
+    standalone("s6"),
+  ];
+  const layoutResult = closeSessionWorkspaceLayoutState([], undefined, "s7");
+
+  assert.equal(
+    resolveActiveTabAfterCloseSession({
+      currentActiveTabId: "s7",
+      closedSessionId: "s7",
+      workspaceId: undefined,
+      layoutResult,
+      remainingSessions,
+      preferredTabId: "s5",
+    }),
+    "s5",
+  );
+});
+
+test("closing a temporary solo tab ignores a preferred tab that no longer exists", () => {
+  const standalone = (id: string): TerminalSession => ({
+    ...session(id),
+    workspaceId: undefined,
+  });
+  const remainingSessions = [standalone("s1"), standalone("s2"), standalone("s6")];
+  const layoutResult = closeSessionWorkspaceLayoutState([], undefined, "s7");
+
+  assert.equal(
+    resolveActiveTabAfterCloseSession({
+      currentActiveTabId: "s7",
+      closedSessionId: "s7",
+      workspaceId: undefined,
+      layoutResult,
+      remainingSessions,
+      preferredTabId: "s5",
+    }),
+    "s6",
+  );
+});
+
+test("closeSessionsState restores the previous tab instead of the newest remaining tab", () => {
+  const standaloneSession = (id: string): TerminalSession => ({
+    ...session(id),
+    workspaceId: undefined,
+  });
+
+  const result = closeSessionsState({
+    sessions: [
+      standaloneSession("s1"),
+      standaloneSession("s2"),
+      standaloneSession("s5"),
+      standaloneSession("s6"),
+      standaloneSession("s7"),
+    ],
+    workspaces: [],
+    sessionIds: ["s7"],
+    currentActiveTabId: "s7",
+    preferredTabId: "s5",
+    tabOrder: ["s1", "s2", "s5", "s6", "s7"],
+  });
+
+  assert.equal(result.activeTabId, "s5");
+  assert.deepEqual(result.sessions.map((candidate) => candidate.id), ["s1", "s2", "s5", "s6"]);
 });
 
 test("closing several standalone sessions removes the whole batch", () => {

--- a/application/state/sessionWorkspaceDetach.ts
+++ b/application/state/sessionWorkspaceDetach.ts
@@ -129,22 +129,64 @@ export function applyCloseSessionToSessions(
   ));
 }
 
+export function isPreferredTabAvailableAfterClose(
+  input: {
+    preferredTabId: string | null | undefined;
+    closedSessionId: string;
+    layoutResult: CloseSessionWorkspaceLayoutResult;
+    remainingSessions: readonly TerminalSession[];
+  },
+): input is {
+  preferredTabId: string;
+  closedSessionId: string;
+  layoutResult: CloseSessionWorkspaceLayoutResult;
+  remainingSessions: readonly TerminalSession[];
+} {
+  const { preferredTabId, closedSessionId, layoutResult, remainingSessions } = input;
+  if (!preferredTabId || preferredTabId === closedSessionId) return false;
+  if (
+    preferredTabId === layoutResult.dissolvedWorkspaceId
+    || preferredTabId === layoutResult.removedWorkspaceId
+  ) {
+    return false;
+  }
+  if (preferredTabId === "vault" || preferredTabId === "sftp") return true;
+  if (layoutResult.workspaces.some((workspace) => workspace.id === preferredTabId)) return true;
+  return remainingSessions.some((session) => (
+    session.id === preferredTabId
+    && !session.workspaceId
+    && !session.hiddenFromTabs
+  ));
+}
+
 export function resolveActiveTabAfterCloseSession({
   currentActiveTabId,
   closedSessionId,
   workspaceId,
   layoutResult,
   remainingSessions,
+  preferredTabId,
 }: {
   currentActiveTabId: string | null;
   closedSessionId: string;
   workspaceId: string | undefined;
   layoutResult: CloseSessionWorkspaceLayoutResult;
   remainingSessions: readonly TerminalSession[];
+  preferredTabId?: string | null;
 }): string | null {
   const fallbackWorkspace = layoutResult.workspaces[layoutResult.workspaces.length - 1];
   const fallbackSolo = remainingSessions.filter((session) => !session.workspaceId && !session.hiddenFromTabs).slice(-1)[0];
+  const preferredInput = {
+    preferredTabId,
+    closedSessionId,
+    layoutResult,
+    remainingSessions,
+  };
+  const preferredFallback = isPreferredTabAvailableAfterClose(preferredInput)
+    ? preferredInput.preferredTabId
+    : undefined;
   const fallback = layoutResult.lastRemainingSessionId
+    ?? preferredFallback
     ?? fallbackWorkspace?.id
     ?? fallbackSolo?.id
     ?? "vault";
@@ -166,12 +208,14 @@ export function closeSessionsState({
   workspaces,
   sessionIds,
   currentActiveTabId,
+  preferredTabId,
   tabOrder,
 }: {
   sessions: readonly TerminalSession[];
   workspaces: readonly Workspace[];
   sessionIds: readonly string[];
   currentActiveTabId: string | null;
+  preferredTabId?: string | null;
   tabOrder: readonly string[];
 }): CloseSessionsStateResult {
   let nextSessions = [...sessions];
@@ -207,6 +251,7 @@ export function closeSessionsState({
       workspaceId,
       layoutResult,
       remainingSessions: nextSessions,
+      preferredTabId,
     });
     if (activeTabAfterClose) {
       nextActiveTabId = activeTabAfterClose;

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -542,6 +542,7 @@ export const useSessionState = ({
       workspaces: workspacesRef.current,
       sessionIds,
       currentActiveTabId: activeTabStore.getActiveTabId(),
+      preferredTabId: activeTabStore.getPreviousActiveTabId(),
       tabOrder: tabOrderRef.current,
     });
 
@@ -549,9 +550,10 @@ export const useSessionState = ({
     setSessions(result.sessions);
     setTabOrder(result.tabOrder);
     if (result.activeTabId) {
-      setActiveTabId(result.activeTabId);
+      // Closing must not rewrite previous-tab history to the closed tab.
+      activeTabStore.setActiveTabId(result.activeTabId, { recordPrevious: false });
     }
-  }, [setActiveTabId]);
+  }, []);
 
   const closeSession = useCallback((sessionId: string, e?: MouseEvent) => {
     e?.stopPropagation();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closing a temporary session tab restored focus via last-workspace / last-solo heuristics instead of the previously active work tab. Working on tab 5, opening temp tab 7, then closing 7 jumped away from tab 5.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2788

## Changes Made

- Track previous active tab in `activeTabStore` (`recordPrevious` option)
- Prefer previous tab when closing the active session (after workspace dissolve remaining)
- Restore focus with `recordPrevious: false` so history is not poisoned
- Keep chrome-theme sync source-shape test compatible with optional second arg

## Screenshots / Demo

N/A (tab focus after close)

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — activeTabStore / sessionWorkspaceDetach / activeChromeThemeSync
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-539160f8-57d7-4639-8ede-4edbaf700416?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-539160f8-57d7-4639-8ede-4edbaf700416&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

