### PR TITLE
fix(system-manager): show Ascend 910B NPU info from CANN 24.x npu-smi tables

### DIFF
--- a/components/systemManager/GpuManagerTab.test.ts
+++ b/components/systemManager/GpuManagerTab.test.ts
@@ -27,3 +27,18 @@ test("gpu tab passes null utilization to ResourceBar instead of zero", () => {
   assert.doesNotMatch(source, /value=\{util \?\? 0\}/);
   assert.doesNotMatch(source, /value=\{memPct \?\? 0\}/);
 });
+
+test("gpu tab keeps a compact sparkline history like overview/nvtop charts", () => {
+  const source = readFileSync(new URL("./GpuManagerTab.tsx", import.meta.url), "utf8");
+  assert.match(source, /HISTORY_LIMIT/);
+  assert.match(source, /GpuSparkline/);
+  assert.match(source, /historyByDevice/);
+  assert.match(source, /setHistoryByDevice/);
+});
+
+test("resource bar animates width and uses load-aware tones", () => {
+  const source = readFileSync(new URL("./ResourceBar.tsx", import.meta.url), "utf8");
+  assert.match(source, /transition-\[width,background-color\]/);
+  assert.match(source, /bg-amber-500/);
+  assert.match(source, /bg-destructive/);
+});

--- a/components/systemManager/GpuManagerTab.tsx
+++ b/components/systemManager/GpuManagerTab.tsx
@@ -7,6 +7,7 @@ import type {
   AcceleratorProcessInfo,
   AcceleratorSnapshot,
 } from '../../domain/systemManager/types';
+import { cn } from '../../lib/utils';
 import { ResourceBar } from './ResourceBar';
 import {
   SystemPanelEmpty,
@@ -31,6 +32,13 @@ interface GpuManagerTabProps {
   refreshIntervalSec: number;
 }
 
+const HISTORY_LIMIT = 24;
+
+interface DeviceHistorySample {
+  util: number;
+  memory: number;
+}
+
 function formatMb(mb: number | null | undefined): string {
   if (!Number.isFinite(mb)) return '--';
   const value = Number(mb);
@@ -53,14 +61,63 @@ function vendorLabel(
     : t('systemManager.gpu.vendor.ascend');
 }
 
+function deviceKey(device: AcceleratorDeviceInfo): string {
+  return `${device.vendor}-${device.index}-${device.uuid || device.name}`;
+}
+
+/** Compact nvtop-style sparkline (area + stroke), reusing the overview chart feel. */
+function GpuSparkline({
+  values,
+  className,
+}: {
+  values: number[];
+  className?: string;
+}) {
+  const width = 120;
+  const height = 28;
+  const safeValues = values.length > 1 ? values : [values[0] ?? 0, values[0] ?? 0];
+  const points = safeValues.map((value, index) => {
+    const x = safeValues.length === 1 ? width : (index / (safeValues.length - 1)) * width;
+    const clamped = Math.max(0, Math.min(100, Number.isFinite(value) ? value : 0));
+    const y = height - (clamped / 100) * (height - 4) - 2;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+  const area = `M0,${height} L${points.join(' L')} L${width},${height} Z`;
+
+  return (
+    <svg
+      className={cn('h-7 w-full overflow-visible', className)}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-hidden
+    >
+      <path d={area} fill="currentColor" opacity="0.12" />
+      <polyline
+        points={points.join(' ')}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="transition-opacity duration-300"
+      />
+    </svg>
+  );
+}
+
 const DeviceCard = memo(function DeviceCard({
   device,
+  utilHistory,
+  memHistory,
 }: {
   device: AcceleratorDeviceInfo;
+  utilHistory: number[];
+  memHistory: number[];
 }) {
   const { t } = useI18n();
   const memPct = memoryPercent(device);
   const util = Number.isFinite(device.utilizationPercent) ? Number(device.utilizationPercent) : null;
+  const tone = device.vendor === 'ascend' ? 'text-orange-500' : 'text-emerald-500';
 
   return (
     <div className="border-b border-border/30 px-3 py-2.5 space-y-2">
@@ -102,20 +159,35 @@ const DeviceCard = memo(function DeviceCard({
           ) : null}
         </div>
       </div>
-      <ResourceBar
-        label={t('systemManager.gpu.util')}
-        value={util}
-      />
-      <div className="flex items-center gap-2 min-w-0">
-        <ResourceBar
-          label={device.vendor === 'ascend' ? t('systemManager.gpu.hbm') : t('systemManager.gpu.memory')}
-          value={memPct}
-          className="flex-1"
-        />
-        <span className="text-[10px] tabular-nums text-muted-foreground shrink-0">
-          {formatMb(device.memoryUsedMb)} / {formatMb(device.memoryTotalMb)}
-        </span>
+
+      <div className="grid grid-cols-[minmax(0,1fr)_72px] gap-2 items-end">
+        <div className="min-w-0 space-y-1.5">
+          <ResourceBar
+            label={t('systemManager.gpu.util')}
+            value={util}
+            size="md"
+          />
+          <div className="flex items-center gap-2 min-w-0">
+            <ResourceBar
+              label={device.vendor === 'ascend' ? t('systemManager.gpu.hbm') : t('systemManager.gpu.memory')}
+              value={memPct}
+              className="flex-1"
+              size="md"
+            />
+            <span className="text-[10px] tabular-nums text-muted-foreground shrink-0">
+              {formatMb(device.memoryUsedMb)} / {formatMb(device.memoryTotalMb)}
+            </span>
+          </div>
+        </div>
+        <div className={cn('min-w-0', tone)} title={t('systemManager.gpu.util')}>
+          <GpuSparkline values={utilHistory.length ? utilHistory : [util ?? 0]} />
+          <GpuSparkline
+            values={memHistory.length ? memHistory : [memPct ?? 0]}
+            className="opacity-80"
+          />
+        </div>
       </div>
+
       {Number.isFinite(device.fanPercent) ? (
         <div className="text-[10px] text-muted-foreground">
           {t('systemManager.gpu.fan', { value: Math.round(Number(device.fanPercent)) })}
@@ -155,9 +227,11 @@ export const GpuManagerTab = memo(function GpuManagerTab({
   const stableT = useStableTranslate();
   const intervalMs = Math.max(2, refreshIntervalSec) * 1000;
   const [gpuListPending, setGpuListPending] = useState(false);
+  const [historyByDevice, setHistoryByDevice] = useState<Record<string, DeviceHistorySample[]>>({});
 
   useEffect(() => {
     setGpuListPending(false);
+    setHistoryByDevice({});
   }, [sessionId]);
 
   const fetcher = useCallback(async (): Promise<AcceleratorSnapshot | null> => {
@@ -189,6 +263,23 @@ export const GpuManagerTab = memo(function GpuManagerTab({
   const devices = useMemo(() => data?.devices ?? [], [data?.devices]);
   const processes = useMemo(() => data?.processes ?? [], [data?.processes]);
   const isRefreshActive = loading || gpuListPending;
+
+  useEffect(() => {
+    if (!isVisible || !devices.length) return;
+    setHistoryByDevice((prev) => {
+      const next: Record<string, DeviceHistorySample[]> = { ...prev };
+      for (const device of devices) {
+        const key = deviceKey(device);
+        const sample: DeviceHistorySample = {
+          util: Number.isFinite(device.utilizationPercent) ? Number(device.utilizationPercent) : 0,
+          memory: memoryPercent(device) ?? 0,
+        };
+        const series = [...(next[key] || []), sample].slice(-HISTORY_LIMIT);
+        next[key] = series;
+      }
+      return next;
+    });
+  }, [devices, isVisible, data?.probedAt]);
 
   const meta = useMemo(() => {
     const nvidiaCount = devices.filter((d) => d.vendor === 'nvidia').length;
@@ -269,9 +360,18 @@ export const GpuManagerTab = memo(function GpuManagerTab({
             {t('systemManager.gpu.empty')}
           </div>
         ) : (
-          devices.map((device) => (
-            <DeviceCard key={`${device.vendor}-${device.index}-${device.uuid || device.name}`} device={device} />
-          ))
+          devices.map((device) => {
+            const key = deviceKey(device);
+            const series = historyByDevice[key] || [];
+            return (
+              <DeviceCard
+                key={key}
+                device={device}
+                utilHistory={series.map((sample) => sample.util)}
+                memHistory={series.map((sample) => sample.memory)}
+              />
+            );
+          })
         )}
         <div className="px-3 pt-3 pb-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
           {t('systemManager.gpu.processes')}

--- a/components/systemManager/ResourceBar.tsx
+++ b/components/systemManager/ResourceBar.tsx
@@ -5,20 +5,39 @@ interface ResourceBarProps {
   label: string;
   value: number | null | undefined;
   className?: string;
+  /** Slightly taller track for GPU cards. */
+  size?: 'sm' | 'md';
 }
 
-export const ResourceBar = memo(function ResourceBar({ label, value, className }: ResourceBarProps) {
+function barTone(clamped: number): string {
+  if (clamped > 85) return 'bg-destructive/80';
+  if (clamped > 60) return 'bg-amber-500/80';
+  return 'bg-primary/75';
+}
+
+export const ResourceBar = memo(function ResourceBar({
+  label,
+  value,
+  className,
+  size = 'sm',
+}: ResourceBarProps) {
   const finite = typeof value === 'number' && Number.isFinite(value);
   const clamped = finite ? Math.max(0, Math.min(100, value)) : 0;
   return (
     <div className={cn('flex items-center gap-2 min-w-0', className)}>
-      <span className="text-[10px] text-muted-foreground w-7 shrink-0">{label}</span>
-      <div className="flex-1 h-1 rounded-full bg-muted/50 overflow-hidden min-w-[48px]">
+      {label ? (
+        <span className="text-[10px] text-muted-foreground w-7 shrink-0">{label}</span>
+      ) : null}
+      <div
+        className={cn(
+          'flex-1 rounded-full bg-muted/50 overflow-hidden min-w-[48px]',
+          size === 'md' ? 'h-1.5' : 'h-1',
+        )}
+      >
         <div
           className={cn(
-            'h-full rounded-full',
-            finite && clamped > 85 ? 'bg-destructive/70' : 'bg-primary/70',
-            !finite && 'opacity-0',
+            'h-full rounded-full transition-[width,background-color] duration-500 ease-out motion-reduce:transition-none',
+            finite ? barTone(clamped) : 'opacity-0',
           )}
           style={{ width: `${clamped}%` }}
         />

--- a/electron/bridges/systemManager/gpuOps.cjs
+++ b/electron/bridges/systemManager/gpuOps.cjs
@@ -80,9 +80,49 @@ const ACCELERATOR_COLLECT_SCRIPT = `exec sh -c ${JSON.stringify(ACCELERATOR_COLL
 
 function parseCsvNumber(raw) {
   const text = String(raw ?? "").trim();
-  if (!text || /^\[?n\/?a\]?$/i.test(text) || /^not\s+supported$/i.test(text)) return null;
+  if (
+    !text
+    || text === "-"
+    || /^\[?n\/?a\]?$/i.test(text)
+    || /^not\s+supported$/i.test(text)
+  ) {
+    return null;
+  }
   const n = Number.parseFloat(text.replace(/[,%]/g, ""));
   return Number.isFinite(n) ? n : null;
+}
+
+function extractAscendDriverVersion(text) {
+  const match = String(text || "").match(
+    /\|\s*npu-smi\s+(\S+)\s+.*?Version:\s*(\S+)/i,
+  );
+  if (!match) return null;
+  const version = (match[2] || match[1] || "").replace(/\|/g, "").trim();
+  return version || null;
+}
+
+function applyMemPair(device, used, total, { aggregate = false } = {}) {
+  const usedN = parseCsvNumber(used);
+  const totalN = parseCsvNumber(total);
+  if (!Number.isFinite(usedN) && !Number.isFinite(totalN)) return;
+  if (
+    aggregate
+    && Number.isFinite(device.memoryUsedMb)
+    && Number.isFinite(usedN)
+  ) {
+    device.memoryUsedMb = Number(device.memoryUsedMb) + usedN;
+    device.memoryTotalMb = Number(device.memoryTotalMb || 0)
+      + (Number.isFinite(totalN) ? totalN : 0);
+    return;
+  }
+  if (Number.isFinite(usedN)) device.memoryUsedMb = usedN;
+  if (Number.isFinite(totalN)) device.memoryTotalMb = totalN;
+}
+
+function maxFinite(current, next) {
+  if (!Number.isFinite(next)) return current;
+  if (!Number.isFinite(current)) return next;
+  return Math.max(current, next);
 }
 
 function parseCsvFields(line) {
@@ -254,15 +294,19 @@ function parseAscendDeviceBlock(index, block) {
  * Modern CANN (24.x+) rows look like nputop's fixture:
  *   | 6     910B1 | OK | 100.8  33  0 / 0 |
  *   | 0           | 0000:01:00.0 | 0  0 / 0  3384 / 65536 |
- * Chip-ID on the second row is NOT the NPU ID — attach metrics to the
+ * Chip-ID on the second row is NOT the NPU ID; attach metrics to the
  * preceding NPU summary row (same approach as youyve/nputop libascend).
+ *
+ * Multi-chip cards (Atlas A3 / 310P) repeat the NPU summary once per chip.
+ * Sidebar shows one row per NPU ID and aggregates chip memory / util.
  */
 function parseAscendInfoTable(sectionText) {
   const devices = [];
   const lines = String(sectionText || "").split("\n");
+  const driverVersion = extractAscendDriverVersion(sectionText);
 
-  // Summary: NPU ID, Name, Health, Power, Temp — tolerate Hugepages column after Temp.
-  // Power may be "NA" / "-"; Name is a single token like 910B1 / 910B3.
+  // Summary: NPU ID, Name, Health, Power, Temp; tolerate Hugepages column after Temp.
+  // Power may be "NA" / "-"; Name is a single token like 910B1 / Ascend910.
   const summaryRe =
     /^\|\s*(\d+)\s+(\S+)\s+\|\s*(\S+)\s+\|\s*(\S+)\s+(\d+(?:\.\d+)?)\b/;
   // Bus-Id chip row (CANN 24.x): | ChipID [PhyID] | Bus-Id | AICore(%) ... mem pairs ... |
@@ -281,10 +325,10 @@ function parseAscendInfoTable(sectionText) {
     if (summary) {
       const index = Number.parseInt(summary[1], 10);
       if (!Number.isFinite(index)) continue;
-      // Skip header-ish rows that reuse the same shape poorly; require a real name token.
       const name = summary[2].trim();
       if (!name || /^(?:NPU|Chip|Name)$/i.test(name)) continue;
       let device = devices.find((d) => d.index === index);
+      const isNew = !device;
       if (!device) {
         device = {
           vendor: "ascend",
@@ -298,68 +342,83 @@ function parseAscendInfoTable(sectionText) {
           powerDrawW: parseCsvNumber(summary[4]),
           powerLimitW: null,
           fanPercent: null,
-          driverVersion: null,
+          driverVersion,
           health: summary[3].trim(),
+          _chipCount: 0,
         };
         devices.push(device);
       } else {
         if (!device.name) device.name = name;
-        if (device.temperatureC == null) device.temperatureC = parseCsvNumber(summary[5]);
+        device.temperatureC = maxFinite(device.temperatureC, parseCsvNumber(summary[5]));
         if (device.powerDrawW == null) device.powerDrawW = parseCsvNumber(summary[4]);
-        if (!device.health) device.health = summary[3].trim();
+        if (!device.health || /^ok$/i.test(device.health)) {
+          const health = summary[3].trim();
+          if (health) device.health = health;
+        }
+        if (!device.driverVersion && driverVersion) device.driverVersion = driverVersion;
       }
       lastDevice = device;
 
-      // Prefer pairing with the immediate next chip line (nputop style).
       const next = (lines[i + 1] || "").trim();
       const busChip = next.match(busChipRe);
       if (busChip) {
         i += 1;
-        if (device.utilizationPercent == null) {
-          device.utilizationPercent = parseCsvNumber(busChip[4]);
-        }
+        const util = parseCsvNumber(busChip[4]);
+        device.utilizationPercent = maxFinite(device.utilizationPercent, util);
         const pairs = [...next.matchAll(/(\d+(?:\.\d+)?)\s*\/\s*(\d+(?:\.\d+)?)/g)];
         if (pairs.length > 0) {
           const hbm = pairs[pairs.length - 1];
-          device.memoryUsedMb = parseCsvNumber(hbm[1]);
-          device.memoryTotalMb = parseCsvNumber(hbm[2]);
+          applyMemPair(device, hbm[1], hbm[2], { aggregate: !isNew && device._chipCount > 0 });
         }
+        device._chipCount = (device._chipCount || 0) + 1;
         continue;
       }
       const legacyNext = next.match(legacyChipRe);
       if (legacyNext) {
         i += 1;
-        device.utilizationPercent = parseCsvNumber(legacyNext[2]);
-        device.memoryUsedMb = parseCsvNumber(legacyNext[5]);
-        device.memoryTotalMb = parseCsvNumber(legacyNext[6]);
+        device.utilizationPercent = maxFinite(
+          device.utilizationPercent,
+          parseCsvNumber(legacyNext[2]),
+        );
+        applyMemPair(device, legacyNext[5], legacyNext[6], {
+          aggregate: !isNew && device._chipCount > 0,
+        });
+        device._chipCount = (device._chipCount || 0) + 1;
       }
       continue;
     }
 
-    // Orphan legacy chip row: match by NPU index when possible, else last summary.
     const legacy = line.match(legacyChipRe);
     if (legacy) {
       const index = Number.parseInt(legacy[1], 10);
       const device = devices.find((d) => d.index === index) || lastDevice;
       if (!device) continue;
-      device.utilizationPercent = parseCsvNumber(legacy[2]);
-      device.memoryUsedMb = parseCsvNumber(legacy[5]);
-      device.memoryTotalMb = parseCsvNumber(legacy[6]);
+      device.utilizationPercent = maxFinite(
+        device.utilizationPercent,
+        parseCsvNumber(legacy[2]),
+      );
+      applyMemPair(device, legacy[5], legacy[6], { aggregate: (device._chipCount || 0) > 0 });
+      device._chipCount = (device._chipCount || 0) + 1;
       continue;
     }
 
     const busChip = line.match(busChipRe);
     if (busChip && lastDevice) {
-      if (lastDevice.utilizationPercent == null) {
-        lastDevice.utilizationPercent = parseCsvNumber(busChip[4]);
-      }
+      const util = parseCsvNumber(busChip[4]);
+      lastDevice.utilizationPercent = maxFinite(lastDevice.utilizationPercent, util);
       const pairs = [...line.matchAll(/(\d+(?:\.\d+)?)\s*\/\s*(\d+(?:\.\d+)?)/g)];
       if (pairs.length > 0) {
         const hbm = pairs[pairs.length - 1];
-        lastDevice.memoryUsedMb = parseCsvNumber(hbm[1]);
-        lastDevice.memoryTotalMb = parseCsvNumber(hbm[2]);
+        applyMemPair(lastDevice, hbm[1], hbm[2], {
+          aggregate: (lastDevice._chipCount || 0) > 0,
+        });
       }
+      lastDevice._chipCount = (lastDevice._chipCount || 0) + 1;
     }
+  }
+
+  for (const device of devices) {
+    delete device._chipCount;
   }
   return devices;
 }
@@ -383,8 +442,11 @@ function parseAscendTypedSections(sectionText) {
 function parseAscendProcesses(sectionText) {
   const processes = [];
   for (const line of String(sectionText || "").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || /no running processes/i.test(trimmed)) continue;
+
     // Common proc-mem lines include NPU/Chip/Pid/Name/Memory
-    const match = line.match(
+    const match = trimmed.match(
       /(?:NPU|Device)?\s*I?D?\s*[:=]?\s*(\d+).*?\b(?:PID|Pid)\s*[:=]?\s*(\d+).*?\b(?:Name|Process)\s*[:=]?\s*(\S+).*?(?:Memory|Mem)\s*[:=]?\s*(\d+(?:\.\d+)?)/i,
     );
     if (match) {
@@ -398,8 +460,24 @@ function parseAscendProcesses(sectionText) {
       continue;
     }
 
+    // nputop / npu-smi info process table:
+    // | 0       0                 | 124528        | python3.8                | 17400                   |
+    const infoProc = trimmed.match(
+      /^\|\s*(\d+)\s+(\d+)\s+\|\s+(\d+)\s+\|\s*([^|]+?)\s*\|\s*(\d+(?:\.\d+)?)/,
+    );
+    if (infoProc) {
+      processes.push({
+        vendor: "ascend",
+        gpuIndex: Number.parseInt(infoProc[1], 10) || 0,
+        pid: Number.parseInt(infoProc[3], 10),
+        processName: infoProc[4].trim(),
+        memoryUsedMb: parseCsvNumber(infoProc[5]),
+      });
+      continue;
+    }
+
     // Pipe-separated: | 0 | 0 | 12345 | python | 1024 |
-    const pipeTable = line.match(
+    const pipeTable = trimmed.match(
       /^\|\s*(\d+)\s*\|\s*\d+\s*\|\s*(\d+)\s*\|\s*([^|]+?)\s*\|\s*(\d+(?:\.\d+)?)/,
     );
     if (pipeTable) {
@@ -414,7 +492,7 @@ function parseAscendProcesses(sectionText) {
     }
 
     // Whitespace-delimited inside one outer |: | 0 0 12345 python 1024 |
-    const wsTable = line.match(
+    const wsTable = trimmed.match(
       /^\|\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(\d+(?:\.\d+)?)\s*\|?\s*$/,
     );
     if (!wsTable) continue;
@@ -427,6 +505,18 @@ function parseAscendProcesses(sectionText) {
     });
   }
   return processes.filter((p) => Number.isFinite(p.pid) && p.pid > 0);
+}
+
+function dedupeAcceleratorProcesses(processes) {
+  const seen = new Set();
+  const out = [];
+  for (const processInfo of processes) {
+    const key = `${processInfo.vendor}:${processInfo.gpuIndex}:${processInfo.pid}:${processInfo.processName}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(processInfo);
+  }
+  return out;
 }
 
 function sliceMarkedSection(text, beginMarker, endMarkers) {
@@ -495,7 +585,18 @@ function parseAcceleratorSnapshot(stdout) {
   const ascendProcText = sliceMarkedSection(npuSection, "__NC_NPU_PROCS__", [
     "__NC_NPU_END__",
   ]);
-  const ascendProcesses = parseAscendProcesses(ascendProcText);
+  // Processes often live in the `npu-smi info` dump (nputop fixtures), not only -t proc-mem.
+  const ascendProcesses = dedupeAcceleratorProcesses([
+    ...parseAscendProcesses(ascendProcText),
+    ...parseAscendProcesses(infoDump || npuSection),
+  ]);
+
+  const ascendDriverVersion = extractAscendDriverVersion(infoDump || npuSection);
+  if (ascendDriverVersion) {
+    for (const device of ascendDevices) {
+      if (!device.driverVersion) device.driverVersion = ascendDriverVersion;
+    }
+  }
 
   const devices = [...nvidiaDevices, ...ascendDevices].sort((a, b) => {
     if (a.vendor !== b.vendor) return a.vendor.localeCompare(b.vendor);

--- a/electron/bridges/systemManager/gpuOps.cjs
+++ b/electron/bridges/systemManager/gpuOps.cjs
@@ -51,7 +51,11 @@ const ACCELERATOR_COLLECT_INNER = [
   "fi; ",
   'if command -v npu-smi >/dev/null 2>&1; then ',
   'printf "%s\\n" "__NC_NPU_BEGIN__"; ',
+  // Prefer info -l; fall back to info -m (SwanLab / Ascend mapping table).
   "ids=$(npu-smi info -l 2>/dev/null | sed -n 's/^[[:space:]]*NPU ID[[:space:]]*:[[:space:]]*\\([0-9][0-9]*\\).*/\\1/p'); ",
+  'if [ -z "$ids" ]; then ',
+  "ids=$(npu-smi info -m 2>/dev/null | awk 'NR>1 && $1 ~ /^[0-9]+$/ {print $1}' | sort -nu); ",
+  "fi; ",
   'if [ -n "$ids" ]; then ',
   'for id in $ids; do ',
   'printf "%s\\n" "__NC_NPU_DEVICE__=$id"; ',
@@ -60,10 +64,11 @@ const ACCELERATOR_COLLECT_INNER = [
   'npu-smi info -t usages -i "$id" 2>/dev/null || true; ',
   'npu-smi info -t memory -i "$id" 2>/dev/null || true; ',
   "done; ",
-  "else ",
+  "fi; ",
+  // Always keep the summary table; typed queries can be empty on ModelArts /
+  // containers, and Windows collectors only emit this dump.
   'printf "%s\\n" "__NC_NPU_INFO__"; ',
   "npu-smi info 2>/dev/null || true; ",
-  "fi; ",
   'printf "%s\\n" "__NC_NPU_PROCS__"; ',
   "npu-smi info -t proc-mem 2>/dev/null || true; ",
   'printf "%s\\n" "__NC_NPU_END__"; ',
@@ -243,48 +248,118 @@ function parseAscendDeviceBlock(index, block) {
   };
 }
 
+/**
+ * Parse `npu-smi info` summary tables.
+ *
+ * Modern CANN (24.x+) rows look like nputop's fixture:
+ *   | 6     910B1 | OK | 100.8  33  0 / 0 |
+ *   | 0           | 0000:01:00.0 | 0  0 / 0  3384 / 65536 |
+ * Chip-ID on the second row is NOT the NPU ID — attach metrics to the
+ * preceding NPU summary row (same approach as youyve/nputop libascend).
+ */
 function parseAscendInfoTable(sectionText) {
   const devices = [];
   const lines = String(sectionText || "").split("\n");
-  for (const line of lines) {
-    // | 0     910B3                   | OK              | 71.8       42                             |
-    const match = line.match(
-      /^\|\s*(\d+)\s+(\S+(?:\s+\S+)*?)\s+\|\s*(\S+)\s+\|\s*([0-9.]+)\s+([0-9.]+)\s*\|/,
-    );
-    if (!match) continue;
-    const index = Number.parseInt(match[1], 10);
-    if (!Number.isFinite(index)) continue;
-    if (devices.some((d) => d.index === index)) continue;
-    devices.push({
-      vendor: "ascend",
-      index,
-      uuid: "",
-      name: match[2].trim(),
-      utilizationPercent: null,
-      memoryUsedMb: null,
-      memoryTotalMb: null,
-      temperatureC: parseCsvNumber(match[5]),
-      powerDrawW: parseCsvNumber(match[4]),
-      powerLimitW: null,
-      fanPercent: null,
-      driverVersion: null,
-      health: match[3].trim(),
-    });
-  }
 
-  // Chip rows: | 0      0        0               12          1234 / 32768        0 / 32768     |
-  for (const line of lines) {
-    const chip = line.match(
-      /^\|\s*(\d+)\s+\d+\s+\d+\s+(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)\s*\/\s*(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)\s*\/\s*(\d+(?:\.\d+)?)/,
-    );
-    if (!chip) continue;
-    const index = Number.parseInt(chip[1], 10);
-    const device = devices.find((d) => d.index === index);
-    if (!device) continue;
-    device.utilizationPercent = parseCsvNumber(chip[2]);
-    // Prefer HBM pair (last) when present
-    device.memoryUsedMb = parseCsvNumber(chip[5]);
-    device.memoryTotalMb = parseCsvNumber(chip[6]);
+  // Summary: NPU ID, Name, Health, Power, Temp — tolerate Hugepages column after Temp.
+  // Power may be "NA" / "-"; Name is a single token like 910B1 / 910B3.
+  const summaryRe =
+    /^\|\s*(\d+)\s+(\S+)\s+\|\s*(\S+)\s+\|\s*(\S+)\s+(\d+(?:\.\d+)?)\b/;
+  // Bus-Id chip row (CANN 24.x): | ChipID [PhyID] | Bus-Id | AICore(%) ... mem pairs ... |
+  const busChipRe =
+    /^\|\s*(\d+)\s*(\d*)\s*\|\s*([0-9A-Fa-f:.]+|NA)\s*\|\s*(\d+(?:\.\d+)?)\b/;
+  // Legacy whitespace chip row: | NPU Chip Logic AICore Mem/Tot HBM/Tot |
+  const legacyChipRe =
+    /^\|\s*(\d+)\s+\d+\s+\d+\s+(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)\s*\/\s*(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)\s*\/\s*(\d+(?:\.\d+)?)/;
+
+  let lastDevice = null;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i].trim();
+    if (!line.startsWith("|")) continue;
+
+    const summary = line.match(summaryRe);
+    if (summary) {
+      const index = Number.parseInt(summary[1], 10);
+      if (!Number.isFinite(index)) continue;
+      // Skip header-ish rows that reuse the same shape poorly; require a real name token.
+      const name = summary[2].trim();
+      if (!name || /^(?:NPU|Chip|Name)$/i.test(name)) continue;
+      let device = devices.find((d) => d.index === index);
+      if (!device) {
+        device = {
+          vendor: "ascend",
+          index,
+          uuid: "",
+          name,
+          utilizationPercent: null,
+          memoryUsedMb: null,
+          memoryTotalMb: null,
+          temperatureC: parseCsvNumber(summary[5]),
+          powerDrawW: parseCsvNumber(summary[4]),
+          powerLimitW: null,
+          fanPercent: null,
+          driverVersion: null,
+          health: summary[3].trim(),
+        };
+        devices.push(device);
+      } else {
+        if (!device.name) device.name = name;
+        if (device.temperatureC == null) device.temperatureC = parseCsvNumber(summary[5]);
+        if (device.powerDrawW == null) device.powerDrawW = parseCsvNumber(summary[4]);
+        if (!device.health) device.health = summary[3].trim();
+      }
+      lastDevice = device;
+
+      // Prefer pairing with the immediate next chip line (nputop style).
+      const next = (lines[i + 1] || "").trim();
+      const busChip = next.match(busChipRe);
+      if (busChip) {
+        i += 1;
+        if (device.utilizationPercent == null) {
+          device.utilizationPercent = parseCsvNumber(busChip[4]);
+        }
+        const pairs = [...next.matchAll(/(\d+(?:\.\d+)?)\s*\/\s*(\d+(?:\.\d+)?)/g)];
+        if (pairs.length > 0) {
+          const hbm = pairs[pairs.length - 1];
+          device.memoryUsedMb = parseCsvNumber(hbm[1]);
+          device.memoryTotalMb = parseCsvNumber(hbm[2]);
+        }
+        continue;
+      }
+      const legacyNext = next.match(legacyChipRe);
+      if (legacyNext) {
+        i += 1;
+        device.utilizationPercent = parseCsvNumber(legacyNext[2]);
+        device.memoryUsedMb = parseCsvNumber(legacyNext[5]);
+        device.memoryTotalMb = parseCsvNumber(legacyNext[6]);
+      }
+      continue;
+    }
+
+    // Orphan legacy chip row: match by NPU index when possible, else last summary.
+    const legacy = line.match(legacyChipRe);
+    if (legacy) {
+      const index = Number.parseInt(legacy[1], 10);
+      const device = devices.find((d) => d.index === index) || lastDevice;
+      if (!device) continue;
+      device.utilizationPercent = parseCsvNumber(legacy[2]);
+      device.memoryUsedMb = parseCsvNumber(legacy[5]);
+      device.memoryTotalMb = parseCsvNumber(legacy[6]);
+      continue;
+    }
+
+    const busChip = line.match(busChipRe);
+    if (busChip && lastDevice) {
+      if (lastDevice.utilizationPercent == null) {
+        lastDevice.utilizationPercent = parseCsvNumber(busChip[4]);
+      }
+      const pairs = [...line.matchAll(/(\d+(?:\.\d+)?)\s*\/\s*(\d+(?:\.\d+)?)/g)];
+      if (pairs.length > 0) {
+        const hbm = pairs[pairs.length - 1];
+        lastDevice.memoryUsedMb = parseCsvNumber(hbm[1]);
+        lastDevice.memoryTotalMb = parseCsvNumber(hbm[2]);
+      }
+    }
   }
   return devices;
 }
@@ -383,12 +458,39 @@ function parseAcceleratorSnapshot(stdout) {
   const nvidiaProcesses = parseNvidiaProcesses(nvidiaProcessesText, nvidiaDevices);
 
   let ascendDevices = parseAscendTypedSections(npuSection);
+  const infoDump = sliceMarkedSection(npuSection, "__NC_NPU_INFO__", [
+    "__NC_NPU_PROCS__",
+    "__NC_NPU_END__",
+  ]);
+  const tableDevices = parseAscendInfoTable(infoDump || npuSection);
   if (ascendDevices.length === 0) {
-    const infoDump = sliceMarkedSection(npuSection, "__NC_NPU_INFO__", [
-      "__NC_NPU_PROCS__",
-      "__NC_NPU_END__",
-    ]);
-    ascendDevices = parseAscendInfoTable(infoDump || npuSection);
+    ascendDevices = tableDevices;
+  } else if (tableDevices.length > 0) {
+    // Fill gaps when typed -t queries returned stubs but the summary table is rich.
+    const byIndex = new Map(ascendDevices.map((d) => [d.index, d]));
+    for (const tableDevice of tableDevices) {
+      const existing = byIndex.get(tableDevice.index);
+      if (!existing) {
+        ascendDevices.push(tableDevice);
+        byIndex.set(tableDevice.index, tableDevice);
+        continue;
+      }
+      if (!existing.name || /^Ascend NPU\b/i.test(existing.name)) {
+        existing.name = tableDevice.name;
+      }
+      for (const key of [
+        "utilizationPercent",
+        "memoryUsedMb",
+        "memoryTotalMb",
+        "temperatureC",
+        "powerDrawW",
+        "health",
+      ]) {
+        if (existing[key] == null && tableDevice[key] != null) {
+          existing[key] = tableDevice[key];
+        }
+      }
+    }
   }
   const ascendProcText = sliceMarkedSection(npuSection, "__NC_NPU_PROCS__", [
     "__NC_NPU_END__",

--- a/electron/bridges/systemManager/gpuOps.test.cjs
+++ b/electron/bridges/systemManager/gpuOps.test.cjs
@@ -97,6 +97,10 @@ test("POSIX accelerator collector keeps sed quotes inside JSON-wrapped sh -c", (
   assert.match(ACCELERATOR_COLLECT_SCRIPT, /sed -n '/);
   // Outer wrapper must not use raw single quotes around the whole script body.
   assert.doesNotMatch(ACCELERATOR_COLLECT_SCRIPT, /^exec sh -c '/);
+  // Always dump npu-smi info; discover IDs via info -l then info -m.
+  assert.match(ACCELERATOR_COLLECT_SCRIPT, /__NC_NPU_INFO__/);
+  assert.match(ACCELERATOR_COLLECT_SCRIPT, /npu-smi info -m/);
+  assert.match(ACCELERATOR_COLLECT_SCRIPT, /npu-smi info 2>\/dev\/null/);
 });
 
 test("POSIX accelerator collector is syntactically valid for sh -c", () => {
@@ -152,6 +156,52 @@ test("parseAscendInfoTable reads summary and chip rows", () => {
   assert.equal(devices[0].temperatureC, 42);
 });
 
+test("parseAscendInfoTable reads CANN 24.x Bus-Id table with Hugepages column", () => {
+  // Fixture from GitHub issue #2811 (ModelArts / Ascend 910B1, npu-smi 24.1.rc2).
+  // Chip row Chip-ID is 0 while NPU ID is 6; metrics must attach to the NPU row.
+  const devices = parseAscendInfoTable(`
++------------------------------------------------------------------------------------------------+
+| npu-smi 24.1.rc2                       Version: 24.1.rc2                                       |
++---------------------------+---------------+----------------------------------------------------+
+| NPU   Name                | Health          | Power(W)    Temp(C)           Hugepages-Usage(page)|
+| Chip                      | Bus-Id          | AICore(%)   Memory-Usage(MB)  HBM-Usage(MB)        |
++===========================+===============+====================================================+
+| 6     910B1               | OK            | 100.8       33                0    / 0             |
+| 0                         | 0000:01:00.0  | 0           0    / 0          3384 / 65536         |
++===========================+===============+====================================================+
+| No running processes found in NPU 6                                                            |
++===========================+===============+====================================================+
+`);
+  assert.equal(devices.length, 1);
+  assert.equal(devices[0].index, 6);
+  assert.equal(devices[0].name, "910B1");
+  assert.equal(devices[0].health, "OK");
+  assert.equal(devices[0].powerDrawW, 100.8);
+  assert.equal(devices[0].temperatureC, 33);
+  assert.equal(devices[0].utilizationPercent, 0);
+  assert.equal(devices[0].memoryUsedMb, 3384);
+  assert.equal(devices[0].memoryTotalMb, 65536);
+});
+
+test("parseAcceleratorSnapshot falls back to modern npu-smi info table", () => {
+  const snapshot = parseAcceleratorSnapshot(`
+__NC_ACCEL_BEGIN__
+__NC_NPU_BEGIN__
+__NC_NPU_INFO__
+| NPU   Name                | Health          | Power(W)    Temp(C)           Hugepages-Usage(page)|
+| Chip                      | Bus-Id          | AICore(%)   Memory-Usage(MB)  HBM-Usage(MB)        |
+| 6     910B1               | OK            | 100.8       33                0    / 0             |
+| 0                         | 0000:01:00.0  | 0           0    / 0          3384 / 65536         |
+__NC_NPU_PROCS__
+__NC_NPU_END__
+__NC_ACCEL_END__
+`);
+  assert.equal(snapshot.devices.length, 1);
+  assert.equal(snapshot.devices[0].vendor, "ascend");
+  assert.equal(snapshot.devices[0].index, 6);
+  assert.equal(snapshot.devices[0].memoryTotalMb, 65536);
+});
+
 test("parseAcceleratorSnapshot merges nvidia and ascend marked sections", () => {
   const snapshot = parseAcceleratorSnapshot(`
 __NC_ACCEL_BEGIN__
@@ -176,4 +226,27 @@ __NC_ACCEL_END__
   assert.equal(snapshot.devices[1].vendor, "nvidia");
   assert.equal(snapshot.processes.length, 1);
   assert.equal(snapshot.nvidiaDriverVersion, "550.54");
+});
+
+test("parseAcceleratorSnapshot enriches typed Ascend stubs from info table", () => {
+  const snapshot = parseAcceleratorSnapshot(`
+__NC_ACCEL_BEGIN__
+__NC_NPU_BEGIN__
+__NC_NPU_DEVICE__=6
+__NC_NPU_INFO__
+| NPU   Name                | Health          | Power(W)    Temp(C)           Hugepages-Usage(page)|
+| Chip                      | Bus-Id          | AICore(%)   Memory-Usage(MB)  HBM-Usage(MB)        |
+| 6     910B1               | OK            | 100.8       33                0    / 0             |
+| 0                         | 0000:01:00.0  | 0           0    / 0          3384 / 65536         |
+__NC_NPU_PROCS__
+__NC_NPU_END__
+__NC_ACCEL_END__
+`);
+  assert.equal(snapshot.devices.length, 1);
+  assert.equal(snapshot.devices[0].index, 6);
+  assert.equal(snapshot.devices[0].name, "910B1");
+  assert.equal(snapshot.devices[0].memoryUsedMb, 3384);
+  assert.equal(snapshot.devices[0].memoryTotalMb, 65536);
+  assert.equal(snapshot.devices[0].temperatureC, 33);
+  assert.equal(snapshot.devices[0].powerDrawW, 100.8);
 });

--- a/electron/bridges/systemManager/gpuOps.test.cjs
+++ b/electron/bridges/systemManager/gpuOps.test.cjs
@@ -250,3 +250,107 @@ __NC_ACCEL_END__
   assert.equal(snapshot.devices[0].temperatureC, 33);
   assert.equal(snapshot.devices[0].powerDrawW, 100.8);
 });
+
+// Fixtures adapted from youyve/nputop tests/test_libascend.py (Apache-2.0).
+// Valuable because we do not have Ascend hardware in CI.
+
+test("parseAscendInfoTable reads nputop 910B2C dual-NPU fixture", () => {
+  const devices = parseAscendInfoTable(`
++------------------------------------------------------------------------------------------------+
+| npu-smi 23.0.2.1                 Version: 23.0.2.1                                             |
++---------------------------+---------------+----------------------------------------------------+
+| NPU   Name                | Health        | Power(W)    Temp(C)           Hugepages-Usage(page)|
+| Chip                      | Bus-Id        | AICore(%)   Memory-Usage(MB)  HBM-Usage(MB)        |
++===========================+===============+====================================================+
+| 0     910B2C              | OK            | 88.6        51                0    / 0             |
+| 0                         | 0000:5A:00.0  | 0           0    / 0          20701/ 65536         |
++===========================+===============+====================================================+
+| 1     910B2C              | OK            | 99.6        50                0    / 0             |
+| 0                         | 0000:19:00.0  | 0           0    / 0          20687/ 65536         |
++===========================+===============+====================================================+
+`);
+  assert.equal(devices.length, 2);
+  assert.equal(devices[0].name, "910B2C");
+  assert.equal(devices[0].memoryUsedMb, 20701);
+  assert.equal(devices[0].memoryTotalMb, 65536);
+  assert.equal(devices[0].powerDrawW, 88.6);
+  assert.equal(devices[0].driverVersion, "23.0.2.1");
+  assert.equal(devices[1].memoryUsedMb, 20687);
+});
+
+test("parseAscendInfoTable reads nputop 310B4 no-HBM column fixture", () => {
+  const devices = parseAscendInfoTable(`
+| npu-smi 23.0.0                                   Version: 23.0.0                                       |
+| NPU     Name                  | Health          | Power(W)     Temp(C)           Hugepages-Usage(page) |
+| Chip    Device                | Bus-Id          | AICore(%)    Memory-Usage(MB)                        |
+| 0       310B4                 | Alarm           | 0.0          65                15    / 15            |
+| 0       0                     | NA              | 0            3628 / 15609                            |
+`);
+  assert.equal(devices.length, 1);
+  assert.equal(devices[0].name, "310B4");
+  assert.equal(devices[0].health, "Alarm");
+  assert.equal(devices[0].memoryUsedMb, 3628);
+  assert.equal(devices[0].memoryTotalMb, 15609);
+  assert.equal(devices[0].temperatureC, 65);
+});
+
+test("parseAscendInfoTable aggregates Atlas A3 multi-chip NPU rows", () => {
+  const devices = parseAscendInfoTable(`
+| npu-smi 25.2.0                   Version: 25.2.0                                               |
+| NPU   Name                | Health        | Power(W)    Temp(C)           Hugepages-Usage(page)|
+| Chip  Phy-ID              | Bus-Id        | AICore(%)   Memory-Usage(MB)  HBM-Usage(MB)        |
+| 0     Ascend910           | OK            | 162.8       37                0    / 0             |
+| 0     0                   | 0000:9C:00.0  | 0           0    / 0          3133 / 65536         |
+| 0     Ascend910           | OK            | -           37                0    / 0             |
+| 1     1                   | 0000:9E:00.0  | 0           0    / 0          2876 / 65536         |
+| 1     Ascend910           | OK            | 167.1       38                0    / 0             |
+| 0     2                   | 0000:37:00.0  | 0           0    / 0          3116 / 65536         |
+| 1     Ascend910           | OK            | -           38                0    / 0             |
+| 1     3                   | 0000:39:00.0  | 0           0    / 0          10568/ 65536         |
+`);
+  assert.equal(devices.length, 2);
+  assert.equal(devices[0].name, "Ascend910");
+  assert.equal(devices[0].powerDrawW, 162.8);
+  assert.equal(devices[0].memoryUsedMb, 3133 + 2876);
+  assert.equal(devices[0].memoryTotalMb, 65536 + 65536);
+  assert.equal(devices[1].memoryUsedMb, 3116 + 10568);
+  assert.equal(devices[1].powerDrawW, 167.1);
+});
+
+test("parseAcceleratorSnapshot reads nputop 310P3 processes from info dump", () => {
+  const snapshot = parseAcceleratorSnapshot(`
+__NC_ACCEL_BEGIN__
+__NC_NPU_BEGIN__
+__NC_NPU_INFO__
+| npu-smi 24.1.0.1                                 Version: 24.1.0.1                                     |
+| NPU     Name                  | Health          | Power(W)     Temp(C)           Hugepages-Usage(page) |
+| Chip    Device                | Bus-Id          | AICore(%)    Memory-Usage(MB)                        |
+| 1       310P3                 | OK              | NA           62                7210  / 7210          |
+| 0       0                     | 0000:01:00.0    | 0            16302/ 44280                            |
+| 1       310P3                 | OK              | NA           62                7210  / 7210          |
+| 1       1                     | 0000:01:00.0    | 0            15543/ 43693                            |
+| 2       310P3                 | OK              | NA           61                17057 / 17057         |
+| 0       2                     | 0000:02:00.0    | 0            35563/ 44280                            |
+| 2       310P3                 | OK              | NA           61                16823 / 16823         |
+| 1       3                     | 0000:02:00.0    | 0            35204/ 43693                            |
+| NPU     Chip                  | Process id      | Process name             | Process memory(MB)        |
+| 1       0                     | 3277562         | mindie_llm_back          | 14513                     |
+| 1       1                     | 3277565         | mindie_llm_back          | 14513                     |
+| 2       0                     | 3034986         | mindie_llm_back          | 34207                     |
+| 2       1                     | 3034989         | mindie_llm_back          | 33740                     |
+__NC_NPU_PROCS__
+__NC_NPU_END__
+__NC_ACCEL_END__
+`);
+  assert.equal(snapshot.devices.length, 2);
+  assert.equal(snapshot.devices[0].index, 1);
+  assert.equal(snapshot.devices[0].name, "310P3");
+  assert.equal(snapshot.devices[0].memoryUsedMb, 16302 + 15543);
+  assert.equal(snapshot.devices[0].powerDrawW, null);
+  assert.equal(snapshot.devices[0].driverVersion, "24.1.0.1");
+  assert.equal(snapshot.processes.length, 4);
+  assert.equal(snapshot.processes[0].pid, 3277562);
+  assert.equal(snapshot.processes[0].processName, "mindie_llm_back");
+  assert.equal(snapshot.processes[0].memoryUsedMb, 14513);
+  assert.equal(snapshot.processes[0].gpuIndex, 1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#2811](https://github.com/binaricat/Netcatty/issues/2811) (Ascend 910B GPU tab empty) and hardens accelerator recognition using real `npu-smi` samples from open-source monitors. GPU cards also get a lighter nvtop-style pulse: animated bars + short util/HBM sparklines.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2811

## Changes Made

### Recognition (inspired by open source, not vendored)

| Project | License | What we used |
| --- | --- | --- |
| [youyve/nputop](https://github.com/youyve/nputop) | Apache-2.0 (api) | Table pair parsing idea + **test fixtures** for 910B2C / 310B4 / Atlas A3 / 310P3 |
| [SwanLab Ascend probe](https://github.com/SwanHubX/SwanLab) | — | `npu-smi info -m` ID discovery fallback |
| [Syllo/nvtop](https://github.com/Syllo/nvtop) | GPL-3.0 | Visual inspiration only (no code copied; nvtop Ascend path uses DCMI, not text) |

Concrete parser upgrades:

- CANN 24.x Hugepages + Bus-Id chip rows (issue screenshot)
- Multi-chip aggregation per NPU ID (Atlas A3 / 310P)
- Process table rows from the `npu-smi info` dump (nputop shape)
- Driver version from the `npu-smi … Version:` header
- Always collect the info dump; merge into typed `-t` stubs

### UI

- `ResourceBar`: smooth width transition + load-aware colors
- `GpuManagerTab`: compact dual sparklines (util / memory) with rolling history, similar energy to overview metrics / nvtop charts, still inside System Manager chrome

## Screenshots / Demo

Issue #2811 showed GPU tab empty while terminal listed NPU 6 / 910B1. That exact table shape is now a unit fixture, plus four nputop-derived fixtures.

## Testing

- [x] `node --test electron/bridges/systemManager/gpuOps.test.cjs` (22/22)
- [x] `node --test components/systemManager/GpuManagerTab.test.ts` (5/5)
- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fdc56-0381-7b2b-8328-940eefdd8bb0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fdc56-0381-7b2b-8328-940eefdd8bb0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

