### PR TITLE
feat(portforward): make main process authoritative for runtime state (#2288)

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -234,6 +234,7 @@ export const enCoreMessages: Messages = {
   'tray.status.active': 'Active',
   'tray.status.inactive': 'Inactive',
   'tray.status.error': 'Error',
+  'tray.status.unknown': 'Unknown',
   'tray.recentHosts': 'Recent Hosts',
   'tray.empty.title': 'Nothing here yet',
   'tray.empty.subtitle': 'Go connect to a server, they miss you 🚀',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -222,6 +222,7 @@ export const ruCoreMessages: Messages = {
   'tray.status.active': 'Активно',
   'tray.status.inactive': 'Неактивно',
   'tray.status.error': 'Ошибка',
+  'tray.status.unknown': 'Неизвестно',
   'tray.recentHosts': 'Недавние хосты',
   'tray.empty.title': 'Пока здесь ничего нет',
   'tray.empty.subtitle': 'Подключитесь к серверу, они по вам скучают 🚀',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -231,6 +231,7 @@ export const zhCNCoreMessages: Messages = {
   'tray.status.active': '已启用',
   'tray.status.inactive': '未启用',
   'tray.status.error': '错误',
+  'tray.status.unknown': '未知',
   'tray.recentHosts': '最近连接的主机',
   'tray.empty.title': '一切都很安静',
   'tray.empty.subtitle': '去连接个服务器吧，它们想念你了 🚀',

--- a/application/i18n/locales/zh-TW/core.ts
+++ b/application/i18n/locales/zh-TW/core.ts
@@ -231,6 +231,7 @@ export const zhTWCoreMessages: Messages = {
   'tray.status.active': '已啟用',
   'tray.status.inactive': '未啟用',
   'tray.status.error': '錯誤',
+  'tray.status.unknown': '未知',
   'tray.recentHosts': '最近連線的主機',
   'tray.empty.title': '一切都很安靜',
   'tray.empty.subtitle': '去連線個伺服器吧，它們想念你了 🚀',

--- a/application/state/usePortForwardingAutoStart.ts
+++ b/application/state/usePortForwardingAutoStart.ts
@@ -18,6 +18,7 @@ import {
   syncWithBackend,
 } from "../../infrastructure/services/portForwardingService";
 import { logger } from "../../lib/logger";
+import { applyPortForwardingRuntimeStatus } from "./usePortForwardingState";
 
 export interface UsePortForwardingAutoStartOptions {
   enabled?: boolean;
@@ -328,24 +329,12 @@ export const usePortForwardingAutoStart = ({
     [resolveEffectiveHost],
   );
 
+  // Runtime phases stay in the in-memory projection only (#2288). Writing
+  // active/connecting/error into localStorage would churn sync hashes and
+  // fight the main-process authority model.
   const updateStoredRuleStatus = useCallback(
     (ruleId: string, status: PortForwardingRule["status"], error?: string) => {
-      const currentRules = localStorageAdapter.read<PortForwardingRule[]>(
-        STORAGE_KEY_PORT_FORWARDING,
-      ) ?? [];
-
-      const updatedRules = currentRules.map((rule) =>
-        rule.id === ruleId
-          ? {
-              ...rule,
-              status,
-              error,
-              lastUsedAt: status === "active" ? Date.now() : rule.lastUsedAt,
-            }
-          : rule,
-      );
-
-      localStorageAdapter.write(STORAGE_KEY_PORT_FORWARDING, updatedRules);
+      applyPortForwardingRuntimeStatus(ruleId, status, error);
     },
     [],
   );

--- a/application/state/usePortForwardingState.storageSync.test.ts
+++ b/application/state/usePortForwardingState.storageSync.test.ts
@@ -2,12 +2,14 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import type { Host, PortForwardingRule } from "../../domain/models.ts";
+import { toPersistedPortForwardingRules } from "../../domain/portForwardingPersistence.ts";
 import { STORAGE_KEY_PORT_FORWARDING } from "../../infrastructure/config/storageKeys.ts";
 import {
   startPortForward,
   stopAndCleanupRuleAndWait,
 } from "../../infrastructure/services/portForwardingService.ts";
 import {
+  applyPortForwardingRuntimeStatus,
   createPortForwardingStorageSyncHandlers,
   havePortForwardingRuntimeStatesChanged,
   hasPortForwardingRuntimePresenceChanged,
@@ -25,6 +27,7 @@ const rule: PortForwardingRule = {
   autoStart: true,
   createdAt: 1,
   status: "inactive",
+  bindAddress: "127.0.0.1",
 };
 
 const host: Host = {
@@ -80,32 +83,27 @@ function installEnvironment() {
   };
 }
 
-test("same-window auto-start status writes refresh the visible rule from the live tunnel", async (t) => {
+test("runtime status updates refresh the visible rule without writing storage", async (t) => {
   const env = installEnvironment();
   t.after(async () => {
     await stopAndCleanupRuleAndWait(rule.id);
     env.restore();
   });
 
-  env.storage.setItem(STORAGE_KEY_PORT_FORWARDING, JSON.stringify([rule]));
+  env.storage.setItem(
+    STORAGE_KEY_PORT_FORWARDING,
+    JSON.stringify(toPersistedPortForwardingRules([rule])),
+  );
   await startPortForward(rule, host, [host], [], [], () => undefined, true);
   env.emitStatus("active");
+  applyPortForwardingRuntimeStatus(rule.id, "active");
 
-  const snapshots: PortForwardingRule[][] = [];
-  const handlers = createPortForwardingStorageSyncHandlers({
-    onRules: (rules) => snapshots.push(rules),
-  });
-
-  handlers.handleAdapterChange({
-    type: "netcatty:local-storage-adapter-changed",
-    detail: { key: STORAGE_KEY_PORT_FORWARDING },
-  } as unknown as CustomEvent<{ key: string }>);
-
-  assert.equal(snapshots.length, 1);
-  assert.equal(snapshots[0]?.[0]?.status, "active");
+  const stored = JSON.parse(env.storage.getItem(STORAGE_KEY_PORT_FORWARDING) || "[]") as PortForwardingRule[];
+  assert.equal(stored[0]?.status, "inactive");
+  assert.equal(stored[0]?.error, undefined);
 });
 
-test("cross-window status writes stay active before this window discovers the tunnel", (t) => {
+test("legacy cross-window active status is migrated away on config sync", (t) => {
   const env = installEnvironment();
   t.after(() => env.restore());
 
@@ -125,7 +123,9 @@ test("cross-window status writes stay active before this window discovers the tu
   } as StorageEvent);
 
   assert.equal(snapshots.length, 1);
-  assert.equal(snapshots[0]?.[0]?.status, "active");
+  // Runtime is no longer trusted from storage; absence of a local connection
+  // means inactive after a successful authority baseline (default true in tests).
+  assert.equal(snapshots[0]?.[0]?.status, "inactive");
 });
 
 test("cross-window stale status cannot override a known live tunnel", async (t) => {
@@ -200,6 +200,18 @@ test("heartbeat normalization clears an error for a reconciled-away tunnel", () 
 
   assert.equal(normalized[0]?.status, "inactive");
   assert.equal(normalized[0]?.error, undefined);
+});
+
+test("snapshot failure projects unknown instead of inactive", () => {
+  const normalized = normalizeRulesWithConnections([{
+    ...rule,
+    id: "stale-rule",
+    status: "inactive",
+  }], {
+    snapshotAvailable: false,
+  });
+
+  assert.equal(normalized[0]?.status, "unknown");
 });
 
 test("heartbeat writes only when a visible runtime state changes", () => {

--- a/application/state/usePortForwardingState.storageSync.test.ts
+++ b/application/state/usePortForwardingState.storageSync.test.ts
@@ -123,9 +123,20 @@ test("legacy cross-window active status is migrated away on config sync", (t) =>
   } as StorageEvent);
 
   assert.equal(snapshots.length, 1);
-  // Runtime is no longer trusted from storage; absence of a local connection
-  // means inactive after a successful authority baseline (default true in tests).
-  assert.equal(snapshots[0]?.[0]?.status, "inactive");
+  // Runtime is no longer trusted from storage. Before an authoritative snapshot
+  // succeeds, the projection must be unknown — never a false inactive.
+  assert.equal(snapshots[0]?.[0]?.status, "unknown");
+});
+
+test("normalizeRulesWithConnections stays inactive only after authority succeeds", () => {
+  const normalized = normalizeRulesWithConnections([{
+    ...rule,
+    id: "authority-ok-rule",
+    status: "active",
+  }], {
+    snapshotAvailable: true,
+  });
+  assert.equal(normalized[0]?.status, "inactive");
 });
 
 test("cross-window stale status cannot override a known live tunnel", async (t) => {
@@ -164,6 +175,16 @@ test("same-window synchronization preserves an error without a runtime tunnel", 
     status: "error",
     error: "Host not found",
   }]));
+  // Authority already confirmed — diagnostic error may remain without a tunnel.
+  const normalized = normalizeRulesWithConnections([{
+    ...rule,
+    id: "failed-start-rule",
+    status: "error",
+    error: "Host not found",
+  }], { snapshotAvailable: true });
+  assert.equal(normalized[0]?.status, "error");
+  assert.equal(normalized[0]?.error, "Host not found");
+
   const snapshots: PortForwardingRule[][] = [];
   const handlers = createPortForwardingStorageSyncHandlers({
     onRules: (rules) => snapshots.push(rules),
@@ -174,8 +195,8 @@ test("same-window synchronization preserves an error without a runtime tunnel", 
     detail: { key: STORAGE_KEY_PORT_FORWARDING },
   } as unknown as CustomEvent<{ key: string }>);
 
-  assert.equal(snapshots[0]?.[0]?.status, "error");
-  assert.equal(snapshots[0]?.[0]?.error, "Host not found");
+  // Without a successful snapshot in this module, storage sync projects unknown.
+  assert.equal(snapshots[0]?.[0]?.status, "unknown");
 });
 
 test("heartbeat normalization preserves an error without a runtime tunnel", () => {
@@ -184,7 +205,7 @@ test("heartbeat normalization preserves an error without a runtime tunnel", () =
     id: "heartbeat-error-rule",
     status: "error",
     error: "Authentication failed",
-  }]);
+  }], { snapshotAvailable: true });
 
   assert.equal(normalized[0]?.status, "error");
   assert.equal(normalized[0]?.error, "Authentication failed");
@@ -196,7 +217,10 @@ test("heartbeat normalization clears an error for a reconciled-away tunnel", () 
     id: "cleanup-error-rule",
     status: "error",
     error: "Failed to stop tunnel",
-  }], new Set(["cleanup-error-rule"]));
+  }], {
+    reconciledGoneRuleIds: new Set(["cleanup-error-rule"]),
+    snapshotAvailable: true,
+  });
 
   assert.equal(normalized[0]?.status, "inactive");
   assert.equal(normalized[0]?.error, undefined);

--- a/application/state/usePortForwardingState.ts
+++ b/application/state/usePortForwardingState.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Host, Identity, KnownHost, PortForwardingRule, SSHKey } from "../../domain/models";
+import {
+  migratePortForwardingRulesFromStorage,
+  toPersistedPortForwardingRules,
+} from "../../domain/portForwardingPersistence";
 import { getNextVaultOrder, normalizeVaultOrder, reorderVaultItems, sortByVaultOrder, type VaultOrderPosition } from "../../domain/vaultOrder";
 import {
   STORAGE_KEY_PF_PREFER_FORM_MODE,
@@ -32,6 +36,8 @@ let reconnectCancelListenerRefs = 0;
 let reconnectCancelCleanup: (() => void) | undefined;
 let heartbeatRefs = 0;
 let heartbeatIntervalId: ReturnType<typeof setInterval> | undefined;
+let runtimeSubscriptionRefs = 0;
+let runtimeSubscriptionCleanup: (() => void) | undefined;
 
 export type { ViewMode };
 
@@ -91,6 +97,7 @@ export interface UsePortForwardingStateResult {
 // Global Store State
 let globalRules: PortForwardingRule[] = [];
 let isInitialized = false;
+let snapshotAvailable = true;
 const listeners = new Set<(rules: PortForwardingRule[]) => void>();
 
 // Store Actions
@@ -98,16 +105,50 @@ const notifyListeners = () => {
   listeners.forEach((listener) => listener(globalRules));
 };
 
+const persistPortForwardingConfig = (rules: PortForwardingRule[]) => {
+  localStorageAdapter.write(
+    STORAGE_KEY_PORT_FORWARDING,
+    toPersistedPortForwardingRules(rules),
+  );
+};
+
+/** Persist configuration only — never write runtime phases to storage. */
 const setGlobalRules = (newRules: PortForwardingRule[]) => {
   globalRules = normalizeVaultOrder(newRules);
   notifyListeners();
-  localStorageAdapter.write(STORAGE_KEY_PORT_FORWARDING, globalRules);
+  persistPortForwardingConfig(globalRules);
 };
+
+/** Update the in-memory projection without touching localStorage. */
+const setRuntimeProjection = (newRules: PortForwardingRule[]) => {
+  globalRules = normalizeVaultOrder(newRules);
+  notifyListeners();
+};
+
+export type NormalizeRulesOptions = {
+  reconciledGoneRuleIds?: ReadonlySet<string>;
+  snapshotAvailable?: boolean;
+};
+
+const isGoneRuleIdSet = (
+  value: ReadonlySet<string> | NormalizeRulesOptions,
+): value is ReadonlySet<string> => (
+  typeof (value as ReadonlySet<string>).has === "function"
+  && !("snapshotAvailable" in (value as object))
+  && !("reconciledGoneRuleIds" in (value as object))
+);
 
 export const normalizeRulesWithConnections = (
   rules: PortForwardingRule[],
-  reconciledGoneRuleIds: ReadonlySet<string> = new Set(),
+  reconciledGoneRuleIdsOrOptions: ReadonlySet<string> | NormalizeRulesOptions = new Set(),
 ): PortForwardingRule[] => {
+  const options: NormalizeRulesOptions = isGoneRuleIdSet(reconciledGoneRuleIdsOrOptions)
+    ? { reconciledGoneRuleIds: reconciledGoneRuleIdsOrOptions }
+    : reconciledGoneRuleIdsOrOptions;
+
+  const reconciledGoneRuleIds = options.reconciledGoneRuleIds ?? new Set<string>();
+  const authorityAvailable = options.snapshotAvailable ?? snapshotAvailable;
+
   return rules.map((rule): PortForwardingRule => {
     const connection = getActiveConnection(rule.id);
     if (connection) {
@@ -123,6 +164,13 @@ export const normalizeRulesWithConnections = (
         ...rule,
         status: "inactive" as const,
         error: undefined,
+      };
+    }
+
+    if (!authorityAvailable) {
+      return {
+        ...rule,
+        status: "unknown" as const,
       };
     }
 
@@ -155,15 +203,42 @@ export const hasPortForwardingRuntimePresenceChanged = (reconciliation: {
 }): boolean => reconciliation.gone.length > 0 || reconciliation.appeared.length > 0;
 
 const mergeRulesWithKnownConnections = (rules: PortForwardingRule[]): PortForwardingRule[] => {
-  return rules.map((rule): PortForwardingRule => {
-    const connection = getActiveConnection(rule.id);
-    if (!connection) return rule;
+  return normalizeRulesWithConnections(
+    migratePortForwardingRulesFromStorage(rules),
+    { snapshotAvailable },
+  );
+};
+
+/**
+ * Apply a runtime status update to the in-memory projection only.
+ * Auto-start and reconnect paths use this instead of writing localStorage.
+ */
+export const applyPortForwardingRuntimeStatus = (
+  ruleId: string,
+  status: PortForwardingRule["status"],
+  error?: string,
+): void => {
+  if (globalRules.length === 0) {
+    const stored = localStorageAdapter.read<PortForwardingRule[]>(
+      STORAGE_KEY_PORT_FORWARDING,
+    );
+    if (stored && Array.isArray(stored)) {
+      globalRules = normalizeVaultOrder(
+        migratePortForwardingRulesFromStorage(stored),
+      );
+    }
+  }
+
+  const updated = globalRules.map((rule) => {
+    if (rule.id !== ruleId) return rule;
     return {
       ...rule,
-      status: connection.status,
-      error: connection.error,
+      status,
+      error,
+      lastUsedAt: status === "active" ? Date.now() : rule.lastUsedAt,
     };
   });
+  setRuntimeProjection(updated);
 };
 
 const isPortForwardingStorageEvent = (event: Event): boolean => {
@@ -199,6 +274,22 @@ export const createPortForwardingStorageSyncHandlers = ({
   };
 };
 
+const applyRuntimeSnapshotProjection = (
+  goneRuleIds: ReadonlySet<string> = new Set(),
+  authorityAvailable = snapshotAvailable,
+) => {
+  const normalizedRules = normalizeRulesWithConnections(globalRules, {
+    reconciledGoneRuleIds: goneRuleIds,
+    snapshotAvailable: authorityAvailable,
+  });
+  if (havePortForwardingRuntimeStatesChanged(globalRules, normalizedRules)) {
+    setRuntimeProjection(normalizedRules);
+  } else {
+    globalRules = normalizedRules;
+    notifyListeners();
+  }
+};
+
 // Initialization Logic
 const initializeStore = async () => {
   if (isInitialized) return;
@@ -210,8 +301,66 @@ const initializeStore = async () => {
     STORAGE_KEY_PORT_FORWARDING,
   );
   if (saved && Array.isArray(saved)) {
-    setGlobalRules(normalizeRulesWithConnections(saved));
+    // Hydrate config from storage, then overlay the live runtime projection.
+    // Do not re-persist — that would churn storage with migrated status fields.
+    const migrated = migratePortForwardingRulesFromStorage(saved);
+    setRuntimeProjection(normalizeRulesWithConnections(migrated));
   }
+};
+
+const subscribeToPortForwardRuntime = (): (() => void) => {
+  const bridge = typeof window !== "undefined" ? window.netcatty : undefined;
+  if (!bridge?.subscribePortForwardRuntime || !bridge.onPortForwardRuntime) {
+    return () => undefined;
+  }
+
+  let disposed = false;
+  let unsubscribeEvent: (() => void) | undefined;
+  let observedEpoch: string | undefined;
+  let observedRevision = -1;
+
+  const resyncFromSnapshot = async () => {
+    try {
+      const snapshot = await bridge.subscribePortForwardRuntime!();
+      if (disposed) return;
+      observedEpoch = snapshot.epoch;
+      observedRevision = snapshot.revision;
+      snapshotAvailable = true;
+      await syncWithBackend();
+      applyRuntimeSnapshotProjection(new Set(), true);
+    } catch {
+      if (disposed) return;
+      snapshotAvailable = false;
+      applyRuntimeSnapshotProjection(new Set(), false);
+    }
+  };
+
+  unsubscribeEvent = bridge.onPortForwardRuntime((event) => {
+    if (disposed) return;
+    if (observedEpoch && event.epoch !== observedEpoch) {
+      void resyncFromSnapshot();
+      return;
+    }
+    if (observedRevision >= 0 && event.revision > observedRevision + 1) {
+      void resyncFromSnapshot();
+      return;
+    }
+    observedEpoch = event.epoch;
+    observedRevision = event.revision;
+    snapshotAvailable = true;
+    void (async () => {
+      await reconcileWithBackend();
+      applyRuntimeSnapshotProjection(new Set(), true);
+    })();
+  });
+
+  void resyncFromSnapshot();
+
+  return () => {
+    disposed = true;
+    unsubscribeEvent?.();
+    void bridge.unsubscribePortForwardRuntime?.();
+  };
 };
 
 export const usePortForwardingState = (): UsePortForwardingStateResult => {
@@ -253,9 +402,9 @@ export const usePortForwardingState = (): UsePortForwardingStateResult => {
     };
   }, [rules]);
 
-  // Listen for both browser storage events (other windows) and adapter
-  // events (this window). Auto-start writes statuses outside this hook, so
-  // relying on the browser event alone leaves the launching window stale.
+  // Config sync across windows. Runtime phases are no longer written to
+  // storage, so these handlers only refresh rule configuration and overlay
+  // whatever live tunnels this window already knows about.
   useEffect(() => {
     const target = globalThis as typeof globalThis & {
       addEventListener?: (type: string, listener: EventListener) => void;
@@ -303,6 +452,22 @@ export const usePortForwardingState = (): UsePortForwardingStateResult => {
     };
   }, []);
 
+  // Authoritative runtime subscription (snapshot + ordered events). Heartbeat
+  // below remains as a recovery fallback for revision gaps / missed events.
+  useEffect(() => {
+    runtimeSubscriptionRefs++;
+    if (runtimeSubscriptionRefs === 1) {
+      runtimeSubscriptionCleanup = subscribeToPortForwardRuntime();
+    }
+    return () => {
+      runtimeSubscriptionRefs--;
+      if (runtimeSubscriptionRefs === 0 && runtimeSubscriptionCleanup) {
+        runtimeSubscriptionCleanup();
+        runtimeSubscriptionCleanup = undefined;
+      }
+    };
+  }, []);
+
   // Periodic heartbeat: reconcile renderer state with the backend every 4s.
   // Ref-counted — same pattern as the reconnect cancel listener.
   useEffect(() => {
@@ -313,19 +478,24 @@ export const usePortForwardingState = (): UsePortForwardingStateResult => {
 
       const tick = async () => {
         const reconciliation = await reconcileWithBackend();
-        if (!reconciliation.snapshotAvailable) return;
-        // Always re-derive the visible state. This also repairs a stale
-        // cross-window storage write when the backend map itself did not change.
+        snapshotAvailable = reconciliation.snapshotAvailable;
+        if (!reconciliation.snapshotAvailable) {
+          // Snapshot failure must surface as unknown/stale — never as inactive.
+          applyRuntimeSnapshotProjection(new Set(), false);
+          return;
+        }
+        // Always re-derive the visible state from the live connection map.
+        // Runtime phases stay in memory only.
         const normalizedRules = normalizeRulesWithConnections(
           globalRules,
-          new Set(reconciliation.gone),
+          {
+            reconciledGoneRuleIds: new Set(reconciliation.gone),
+            snapshotAvailable: true,
+          },
         );
         if (havePortForwardingRuntimeStatesChanged(globalRules, normalizedRules)) {
-          setGlobalRules(normalizedRules);
+          setRuntimeProjection(normalizedRules);
         } else if (hasPortForwardingRuntimePresenceChanged(reconciliation)) {
-          // Runtime presence affects Start/Stop actions even when the visible
-          // status and error already match. Notify React without rewriting the
-          // unchanged persisted configuration.
           globalRules = normalizedRules;
           notifyListeners();
         }
@@ -470,21 +640,14 @@ export const usePortForwardingState = (): UsePortForwardingStateResult => {
         stopAndCleanupRule(existing.id);
       }
     }
-    setGlobalRules(normalizeRulesWithConnections(newRules));
+    setGlobalRules(normalizeRulesWithConnections(
+      migratePortForwardingRulesFromStorage(newRules),
+    ));
   }, []);
 
   const setRuleStatus = useCallback(
     (id: string, status: PortForwardingRule["status"], error?: string) => {
-      const updated = globalRules.map((r) => {
-        if (r.id !== id) return r;
-        return {
-          ...r,
-          status,
-          error,
-          lastUsedAt: status === "active" ? Date.now() : r.lastUsedAt,
-        };
-      });
-      setGlobalRules(updated);
+      applyPortForwardingRuntimeStatus(id, status, error);
     },
     [],
   );

--- a/application/state/usePortForwardingState.ts
+++ b/application/state/usePortForwardingState.ts
@@ -18,6 +18,7 @@ import { netcattyBridge } from "../../infrastructure/services/netcattyBridge";
 import {
   clearReconnectTimer,
   getActiveConnection,
+  getPortForwardRuntimeAuthority,
   initReconnectCancelListener,
   reconcileWithBackend,
   startPortForward,
@@ -98,7 +99,8 @@ export interface UsePortForwardingStateResult {
 // Global Store State
 let globalRules: PortForwardingRule[] = [];
 let isInitialized = false;
-let snapshotAvailable = true;
+// Until the first successful authoritative snapshot, treat runtime as unknown.
+let snapshotAvailable = false;
 const listeners = new Set<(rules: PortForwardingRule[]) => void>();
 
 // Store Actions
@@ -285,7 +287,10 @@ const applyRuntimeSnapshotProjection = (
   });
   if (havePortForwardingRuntimeStatesChanged(globalRules, normalizedRules)) {
     setRuntimeProjection(normalizedRules);
-  } else {
+  } else if (hasPortForwardingRuntimePresenceChanged({
+    gone: [...goneRuleIds],
+    appeared: [],
+  })) {
     globalRules = normalizedRules;
     notifyListeners();
   }
@@ -297,6 +302,7 @@ const initializeStore = async () => {
   isInitialized = true;
 
   await syncWithBackend();
+  snapshotAvailable = getPortForwardRuntimeAuthority().available;
 
   const saved = localStorageAdapter.read<PortForwardingRule[]>(
     STORAGE_KEY_PORT_FORWARDING,
@@ -305,7 +311,9 @@ const initializeStore = async () => {
     // Hydrate config from storage, then overlay the live runtime projection.
     // Do not re-persist — that would churn storage with migrated status fields.
     const migrated = migratePortForwardingRulesFromStorage(saved);
-    setRuntimeProjection(normalizeRulesWithConnections(migrated));
+    setRuntimeProjection(normalizeRulesWithConnections(migrated, {
+      snapshotAvailable,
+    }));
   }
 };
 
@@ -319,6 +327,15 @@ const subscribeToPortForwardRuntime = (): (() => void) => {
   let unsubscribeEvent: (() => void) | undefined;
   let observedEpoch: string | undefined;
   let observedRevision = -1;
+  let syncChain: Promise<void> = Promise.resolve();
+
+  const enqueueRuntimeSync = (task: () => Promise<void>) => {
+    syncChain = syncChain.then(async () => {
+      if (disposed) return;
+      await task();
+    }).catch(() => undefined);
+    return syncChain;
+  };
 
   const resyncFromSnapshot = async () => {
     try {
@@ -326,9 +343,15 @@ const subscribeToPortForwardRuntime = (): (() => void) => {
       if (disposed) return;
       observedEpoch = snapshot.epoch;
       observedRevision = snapshot.revision;
-      snapshotAvailable = true;
-      await syncWithBackend();
-      applyRuntimeSnapshotProjection(new Set(), true);
+      // Reconcile (not sync-only) so tunnels absent after an epoch change are pruned.
+      const reconciliation = await reconcileWithBackend();
+      if (disposed) return;
+      snapshotAvailable = reconciliation.snapshotAvailable;
+      if (!reconciliation.snapshotAvailable) {
+        applyRuntimeSnapshotProjection(new Set(), false);
+        return;
+      }
+      applyRuntimeSnapshotProjection(new Set(reconciliation.gone), true);
     } catch {
       if (disposed) return;
       snapshotAvailable = false;
@@ -339,23 +362,28 @@ const subscribeToPortForwardRuntime = (): (() => void) => {
   unsubscribeEvent = bridge.onPortForwardRuntime((event) => {
     if (disposed) return;
     if (observedEpoch && event.epoch !== observedEpoch) {
-      void resyncFromSnapshot();
+      void enqueueRuntimeSync(resyncFromSnapshot);
       return;
     }
     if (observedRevision >= 0 && event.revision > observedRevision + 1) {
-      void resyncFromSnapshot();
+      void enqueueRuntimeSync(resyncFromSnapshot);
       return;
     }
     observedEpoch = event.epoch;
     observedRevision = event.revision;
-    snapshotAvailable = true;
-    void (async () => {
-      await reconcileWithBackend();
-      applyRuntimeSnapshotProjection(new Set(), true);
-    })();
+    void enqueueRuntimeSync(async () => {
+      const reconciliation = await reconcileWithBackend();
+      if (disposed) return;
+      snapshotAvailable = reconciliation.snapshotAvailable;
+      if (!reconciliation.snapshotAvailable) {
+        applyRuntimeSnapshotProjection(new Set(), false);
+        return;
+      }
+      applyRuntimeSnapshotProjection(new Set(reconciliation.gone), true);
+    });
   });
 
-  void resyncFromSnapshot();
+  void enqueueRuntimeSync(resyncFromSnapshot);
 
   return () => {
     disposed = true;

--- a/application/state/usePortForwardingState.ts
+++ b/application/state/usePortForwardingState.ts
@@ -14,6 +14,7 @@ import {
   LOCAL_STORAGE_ADAPTER_CHANGED_EVENT,
   localStorageAdapter,
 } from "../../infrastructure/persistence/localStorageAdapter";
+import { netcattyBridge } from "../../infrastructure/services/netcattyBridge";
 import {
   clearReconnectTimer,
   getActiveConnection,
@@ -309,7 +310,7 @@ const initializeStore = async () => {
 };
 
 const subscribeToPortForwardRuntime = (): (() => void) => {
-  const bridge = typeof window !== "undefined" ? window.netcatty : undefined;
+  const bridge = netcattyBridge.get();
   if (!bridge?.subscribePortForwardRuntime || !bridge.onPortForwardRuntime) {
     return () => undefined;
   }

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -27,6 +27,7 @@ import {
   type SyncPayload,
 } from '../domain/sync';
 import { migrateHostsFromLegacyLineTimestamps } from '../domain/host';
+import { toPersistedPortForwardingRules } from '../domain/portForwardingPersistence';
 import {
   nextCustomKeyBindingsSyncVersion,
   parseCustomKeyBindingsStorageRecord,
@@ -197,10 +198,10 @@ export function sanitizePortForwardingRulesForSync(
   rules: PortForwardingRule[] | undefined,
 ): PortForwardingRule[] | undefined {
   if (!rules) return rules;
-  return rules.map((rule) => ({
+  // Runtime phases are never part of vault/cloud sync. lastUsedAt is also
+  // stripped so runtime activity cannot churn sync hashes.
+  return toPersistedPortForwardingRules(rules).map((rule) => ({
     ...rule,
-    status: 'inactive' as const,
-    error: undefined,
     lastUsedAt: undefined,
   }));
 }

--- a/components/TrayPanel.tsx
+++ b/components/TrayPanel.tsx
@@ -414,9 +414,15 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
             <div className="px-2 py-1 text-xs text-muted-foreground">{t("tray.portForwarding")}</div>
             <div className="space-y-1">
               {portForwardingRules.map((rule) => {
-                const isConnecting = rule.status === "connecting" || rule.status === "unknown";
+                const isUnknown = rule.status === "unknown";
+                const isConnecting = rule.status === "connecting";
                 const isActive = rule.status === "active";
-                const isStoppable = isConnecting || isActive || hasRuntimeTunnel(rule.id);
+                // unknown/stale: neither Start nor Stop until authority recovers,
+                // unless this window already holds a live runtime tunnel.
+                const isStoppable = !isUnknown && (
+                  isConnecting || isActive || hasRuntimeTunnel(rule.id)
+                );
+                const isActionDisabled = isConnecting || (isUnknown && !hasRuntimeTunnel(rule.id));
                 const label = rule.label || (rule.type === "dynamic"
                   ? `SOCKS:${rule.localPort}`
                   : `${rule.localPort} → ${rule.remoteHost}:${rule.remotePort}`);
@@ -425,8 +431,9 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
                   <Tooltip key={rule.id}>
                     <TooltipTrigger asChild>
                       <button
-                        disabled={isConnecting}
+                        disabled={isActionDisabled}
                         onClick={() => {
+                          if (isUnknown && !hasRuntimeTunnel(rule.id)) return;
                           const rawHost = rule.hostId ? hosts.find((h) => h.id === rule.hostId) : undefined;
                           if (!rawHost) {
                             toast.error(t("pf.error.hostNotFound"));
@@ -451,7 +458,7 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
                         }}
                         className={cn(
                           "w-full text-left px-2 py-1.5 rounded hover:bg-muted flex items-center justify-between",
-                          isConnecting ? "opacity-60" : "",
+                          isActionDisabled ? "opacity-60" : "",
                         )}
                       >
                         <span className="flex items-center gap-2 min-w-0">
@@ -459,13 +466,13 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
                             status={
                               rule.status === "active"
                                 ? "success"
-                                : rule.status === "connecting"
+                                : rule.status === "connecting" || rule.status === "unknown"
                                   ? "warning"
                                   : rule.status === "error"
                                     ? "error"
                                     : "neutral"
                             }
-                            spinning={rule.status === "connecting"}
+                            spinning={rule.status === "connecting" || rule.status === "unknown"}
                           />
                           <span className="truncate">{label}</span>
                         </span>

--- a/components/TrayPanel.tsx
+++ b/components/TrayPanel.tsx
@@ -414,7 +414,7 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
             <div className="px-2 py-1 text-xs text-muted-foreground">{t("tray.portForwarding")}</div>
             <div className="space-y-1">
               {portForwardingRules.map((rule) => {
-                const isConnecting = rule.status === "connecting";
+                const isConnecting = rule.status === "connecting" || rule.status === "unknown";
                 const isActive = rule.status === "active";
                 const isStoppable = isConnecting || isActive || hasRuntimeTunnel(rule.id);
                 const label = rule.label || (rule.type === "dynamic"

--- a/components/port-forwarding/RuleCard.tsx
+++ b/components/port-forwarding/RuleCard.tsx
@@ -49,6 +49,8 @@ export const RuleCard: React.FC<RuleCardProps> = ({
     const { t } = useI18n();
     const isActive = rule.status === 'active';
     const isStoppable = canStop || rule.status === 'active' || rule.status === 'connecting';
+    // unknown/stale means we cannot trust inactive — do not offer Start until
+    // an authoritative snapshot confirms there is no runtime.
     const isStartable = !isStoppable && (rule.status === 'inactive' || rule.status === 'error');
 
     return (

--- a/components/port-forwarding/utils.tsx
+++ b/components/port-forwarding/utils.tsx
@@ -83,6 +83,8 @@ export function getStatusColor(status: string): string {
       return 'bg-yellow-500 animate-pulse';
     case 'error':
       return 'bg-red-500';
+    case 'unknown':
+      return 'bg-muted-foreground/60 animate-pulse';
     default:
       return 'bg-muted-foreground/40';
   }

--- a/domain/models/portForwarding.ts
+++ b/domain/models/portForwarding.ts
@@ -1,6 +1,16 @@
 // Port Forwarding Types
 export type PortForwardingType = 'local' | 'remote' | 'dynamic';
-type PortForwardingStatus = 'inactive' | 'connecting' | 'active' | 'error';
+/**
+ * Display / projection status for a port-forwarding rule.
+ * `unknown` means the authoritative main-process snapshot could not be read;
+ * it must never be persisted to localStorage.
+ */
+export type PortForwardingStatus =
+  | 'inactive'
+  | 'connecting'
+  | 'active'
+  | 'error'
+  | 'unknown';
 
 export interface PortForwardingRule {
   id: string;
@@ -17,7 +27,11 @@ export interface PortForwardingRule {
   hostId?: string;
   // Auto-start: if true, this rule will automatically start when the app launches
   autoStart?: boolean;
-  // Runtime state
+  /**
+   * Runtime projection for the UI. Authoritative phase lives in the Electron
+   * main-process registry; this field is rebuilt from snapshots / events and
+   * must not be treated as durable configuration.
+   */
   status: PortForwardingStatus;
   error?: string;
   createdAt: number;

--- a/domain/portForwardingPersistence.test.ts
+++ b/domain/portForwardingPersistence.test.ts
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { PortForwardingRule } from './models/portForwarding.ts';
+import {
+  migratePortForwardingRulesFromStorage,
+  toPersistedPortForwardingRule,
+  toPersistedPortForwardingRules,
+} from './portForwardingPersistence.ts';
+
+const baseRule: PortForwardingRule = {
+  id: 'rule-1',
+  label: 'Tunnel',
+  type: 'local',
+  localPort: 8080,
+  bindAddress: '127.0.0.1',
+  remoteHost: '127.0.0.1',
+  remotePort: 80,
+  hostId: 'host-1',
+  autoStart: true,
+  createdAt: 1,
+  status: 'active',
+  error: 'stale',
+  lastUsedAt: 99,
+};
+
+test('toPersistedPortForwardingRule clears runtime phase fields', () => {
+  const persisted = toPersistedPortForwardingRule(baseRule);
+  assert.equal(persisted.status, 'inactive');
+  assert.equal(persisted.error, undefined);
+  assert.equal(persisted.label, 'Tunnel');
+  assert.equal(persisted.autoStart, true);
+  assert.equal(persisted.lastUsedAt, 99);
+});
+
+test('toPersistedPortForwardingRules maps every rule', () => {
+  const persisted = toPersistedPortForwardingRules([
+    baseRule,
+    { ...baseRule, id: 'rule-2', status: 'error', error: 'boom' },
+  ]);
+  assert.equal(persisted.length, 2);
+  assert.ok(persisted.every((rule) => rule.status === 'inactive' && rule.error === undefined));
+});
+
+test('migratePortForwardingRulesFromStorage drops legacy active/connecting', () => {
+  const migrated = migratePortForwardingRulesFromStorage([
+    baseRule,
+    { ...baseRule, id: 'rule-2', status: 'connecting' },
+    { ...baseRule, id: 'rule-3', status: 'error', error: 'auth failed' },
+    { ...baseRule, id: 'rule-4', status: 'inactive', error: undefined },
+  ]);
+
+  assert.equal(migrated[0]?.status, 'inactive');
+  assert.equal(migrated[0]?.error, undefined);
+  assert.equal(migrated[1]?.status, 'inactive');
+  assert.equal(migrated[2]?.status, 'error');
+  assert.equal(migrated[2]?.error, 'auth failed');
+  assert.equal(migrated[3]?.status, 'inactive');
+});

--- a/domain/portForwardingPersistence.ts
+++ b/domain/portForwardingPersistence.ts
@@ -1,0 +1,48 @@
+import type { PortForwardingRule } from './models/portForwarding';
+
+/**
+ * Fields that describe a rule's configuration / user metadata.
+ * Runtime phase (`status`, `error`) is owned by the main-process registry
+ * and must not be treated as durable storage.
+ */
+export type PersistedPortForwardingRule = Omit<PortForwardingRule, 'status' | 'error'> & {
+  status: 'inactive';
+  error?: undefined;
+};
+
+/** Strip live runtime fields before writing localStorage / sync payloads. */
+export function toPersistedPortForwardingRule(
+  rule: PortForwardingRule,
+): PersistedPortForwardingRule {
+  return {
+    ...rule,
+    status: 'inactive',
+    error: undefined,
+  };
+}
+
+export function toPersistedPortForwardingRules(
+  rules: readonly PortForwardingRule[],
+): PersistedPortForwardingRule[] {
+  return rules.map(toPersistedPortForwardingRule);
+}
+
+/**
+ * Migrate legacy stored rules that still carry active/connecting phases.
+ * Historical `error` is kept as a disposable diagnostic until a successful
+ * backend snapshot proves the rule inactive (or a live connection overlays it).
+ */
+export function migratePortForwardingRulesFromStorage(
+  rules: readonly PortForwardingRule[],
+): PortForwardingRule[] {
+  return rules.map((rule) => {
+    if (rule.status === 'active' || rule.status === 'connecting') {
+      return {
+        ...rule,
+        status: 'inactive' as const,
+        error: undefined,
+      };
+    }
+    return rule;
+  });
+}

--- a/electron/bridges/portForwardingBridge.cancel.test.cjs
+++ b/electron/bridges/portForwardingBridge.cancel.test.cjs
@@ -303,7 +303,14 @@ test("port forwarding can be stopped while waiting for a key passphrase", async 
     tunnelId,
     success: true,
   });
-  assert.deepEqual(adoptedStatuses, [{ tunnelId, status: "inactive", error: null }]);
+  assert.equal(adoptedStatuses.length, 1);
+  assert.equal(adoptedStatuses[0].tunnelId, tunnelId);
+  assert.equal(adoptedStatuses[0].status, "inactive");
+  assert.equal(adoptedStatuses[0].error, null);
+  assert.equal(adoptedStatuses[0].ruleId, "rule-cancel-1");
+  assert.equal(typeof adoptedStatuses[0].epoch, "string");
+  assert.equal(typeof adoptedStatuses[0].revision, "number");
+  assert.equal(adoptedStatuses[0].cleanupRequired, false);
   assert.deepEqual(await getPortForwardStatus(event, { tunnelId }), {
     tunnelId,
     status: "inactive",

--- a/electron/bridges/portForwardingBridge.cjs
+++ b/electron/bridges/portForwardingBridge.cjs
@@ -46,6 +46,130 @@ const {
 // Active port forwarding tunnels
 const portForwardingTunnels = new Map();
 
+// Process-scoped authority metadata for renderer projections (#2288).
+// Epoch changes whenever this module (main or terminal worker) boots.
+const PROCESS_EPOCH = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+let runtimeRevision = 0;
+/** @type {Map<number, { sender: any, onDestroyed?: () => void }>} */
+const runtimeEventSubscribers = new Map();
+
+function bumpRuntimeRevision() {
+  runtimeRevision += 1;
+  return runtimeRevision;
+}
+
+function resolveRuntimePhase(tunnel) {
+  if (!tunnel) return "inactive";
+  if (tunnel.cleanupInProgress) return "stopping";
+  if (tunnel.status === "connecting") return "connecting";
+  if (tunnel.status === "error") return "error";
+  if (tunnel.status === "active") return "active";
+  if (tunnel.status === "inactive") return "inactive";
+  return tunnel.status || "active";
+}
+
+function toRuntimeRecord(tunnelId, tunnel, revision = runtimeRevision) {
+  return {
+    ruleId: tunnel?.ruleId,
+    tunnelId,
+    phase: resolveRuntimePhase(tunnel),
+    ...(tunnel?.error ? { error: tunnel.error } : {}),
+    cleanupRequired: Boolean(tunnel?.cleanupFailed),
+    revision,
+    updatedAt: tunnel?.updatedAt || Date.now(),
+  };
+}
+
+function getPortForwardSnapshot() {
+  const records = [];
+  for (const [tunnelId, tunnel] of portForwardingTunnels) {
+    records.push(toRuntimeRecord(tunnelId, tunnel));
+  }
+  return {
+    epoch: PROCESS_EPOCH,
+    revision: runtimeRevision,
+    records,
+  };
+}
+
+function publishRuntimeEvent(event) {
+  const payload = {
+    epoch: PROCESS_EPOCH,
+    revision: runtimeRevision,
+    ...event,
+  };
+  for (const [subscriberId, entry] of runtimeEventSubscribers) {
+    const sender = entry?.sender;
+    if (sender?.isDestroyed?.()) {
+      runtimeEventSubscribers.delete(subscriberId);
+      continue;
+    }
+    safeSend(sender, "netcatty:portforward:runtime", payload);
+  }
+  return payload;
+}
+
+function publishRuntimeUpsert(tunnelId, tunnel) {
+  const revision = bumpRuntimeRevision();
+  if (tunnel) tunnel.updatedAt = Date.now();
+  return publishRuntimeEvent({
+    kind: "upsert",
+    record: toRuntimeRecord(tunnelId, tunnel, revision),
+  });
+}
+
+function publishRuntimeRemove(tunnelId, ruleId) {
+  bumpRuntimeRevision();
+  return publishRuntimeEvent({
+    kind: "remove",
+    tunnelId,
+    ruleId,
+  });
+}
+
+function subscribePortForwardRuntime(event) {
+  const sender = event?.sender;
+  if (sender && Number.isSafeInteger(sender.id) && !sender.isDestroyed?.()) {
+    const existing = runtimeEventSubscribers.get(sender.id);
+    if (existing?.onDestroyed) {
+      existing.sender.removeListener?.("destroyed", existing.onDestroyed);
+    }
+    const onDestroyed = () => {
+      runtimeEventSubscribers.delete(sender.id);
+    };
+    runtimeEventSubscribers.set(sender.id, { sender, onDestroyed });
+    sender.once?.("destroyed", onDestroyed);
+  }
+  // Atomic subscribe + snapshot from the same revision.
+  return getPortForwardSnapshot();
+}
+
+function unsubscribePortForwardRuntime(event) {
+  const sender = event?.sender;
+  if (!sender || !Number.isSafeInteger(sender.id)) {
+    return { success: true };
+  }
+  const existing = runtimeEventSubscribers.get(sender.id);
+  if (existing?.onDestroyed) {
+    existing.sender.removeListener?.("destroyed", existing.onDestroyed);
+  }
+  runtimeEventSubscribers.delete(sender.id);
+  return { success: true };
+}
+
+function resetPortForwardRuntimeMetaForTests() {
+  runtimeRevision = 0;
+  runtimeEventSubscribers.clear();
+}
+
+function seedPortForwardTunnelForTests(tunnelId, tunnel) {
+  portForwardingTunnels.set(tunnelId, tunnel);
+}
+
+function clearPortForwardTunnelsForTests() {
+  portForwardingTunnels.clear();
+}
+
 function buildPortForwardEndpoint(options = {}) {
   return buildConnectionReuseEndpoint({
     ...options,
@@ -771,6 +895,8 @@ function publishTunnelStatus(tunnelId, tunnel, status, error = null) {
   if (!tunnel) return;
   tunnel.status = status;
   tunnel.error = error || undefined;
+  tunnel.updatedAt = Date.now();
+  const runtimeEvent = publishRuntimeUpsert(tunnelId, tunnel);
   const subscribers = tunnel.subscribers instanceof Map
     ? Array.from(tunnel.subscribers.entries())
     : [];
@@ -779,7 +905,15 @@ function publishTunnelStatus(tunnelId, tunnel, status, error = null) {
       tunnel.subscribers.delete(subscriberId);
       continue;
     }
-    safeSend(subscriber, "netcatty:portforward:status", { tunnelId, status, error });
+    safeSend(subscriber, "netcatty:portforward:status", {
+      tunnelId,
+      status,
+      error,
+      ruleId: tunnel.ruleId,
+      epoch: runtimeEvent.epoch,
+      revision: runtimeEvent.revision,
+      cleanupRequired: Boolean(tunnel.cleanupFailed),
+    });
   }
 }
 
@@ -956,7 +1090,11 @@ async function cancelTunnel(tunnelId, tunnel, sendStatus, { deleteEntry = false 
   tunnel.cleanupInProgress = false;
   sendStatus?.('inactive');
   if (deleteEntry) {
+    const ruleId = tunnel.ruleId;
     portForwardingTunnels.delete(tunnelId);
+    // Removal is a distinct revision after the inactive upsert so subscribers
+    // can detect delete vs retained error records (cleanupRequired).
+    publishRuntimeRemove(tunnelId, ruleId);
   }
 }
 
@@ -1851,10 +1989,21 @@ function registerHandlers(ipcMain, options = {}) {
     requestWorker("netcatty:portforward:status");
     requestWorker("netcatty:portforward:subscribe", { track: true });
     requestWorker("netcatty:portforward:list");
+    requestWorker("netcatty:portforward:snapshot");
+    requestWorker("netcatty:portforward:subscribeRuntime");
+    requestWorker("netcatty:portforward:unsubscribeRuntime");
     requestWorker("netcatty:portforward:stopAll", { cleanup: "all" });
     requestWorker("netcatty:portforward:stopByRuleId", { cleanup: "rule" });
 
     terminalWorkerManager.onWorkerRendererEvent?.((message) => {
+      if (message?.channel === "netcatty:portforward:runtime") {
+        // Runtime events are already targeted at subscribed renderers by the
+        // worker; main only needs to forget tunnel tracking on remove.
+        if (message.payload?.kind === "remove") {
+          forgetTunnel(message.payload?.tunnelId);
+        }
+        return;
+      }
       if (message?.channel !== "netcatty:portforward:status") return;
       if (message.payload?.status === "inactive" || message.payload?.status === "error") {
         forgetTunnel(message.payload?.tunnelId);
@@ -1884,6 +2033,9 @@ function registerHandlers(ipcMain, options = {}) {
   ipcMain.handle("netcatty:portforward:status", getPortForwardStatus);
   ipcMain.handle("netcatty:portforward:subscribe", subscribePortForward);
   ipcMain.handle("netcatty:portforward:list", listPortForwards);
+  ipcMain.handle("netcatty:portforward:snapshot", () => getPortForwardSnapshot());
+  ipcMain.handle("netcatty:portforward:subscribeRuntime", subscribePortForwardRuntime);
+  ipcMain.handle("netcatty:portforward:unsubscribeRuntime", unsubscribePortForwardRuntime);
   ipcMain.handle("netcatty:portforward:stopAll", () => stopAllPortForwards());
   ipcMain.handle("netcatty:portforward:stopByRuleId", stopPortForwardByRuleId);
   ipcMain.handle("netcatty:portforward:unsubscribeSender", unsubscribePortForwardSender);
@@ -1897,6 +2049,9 @@ module.exports = {
   subscribePortForward,
   unsubscribePortForwardSender,
   listPortForwards,
+  getPortForwardSnapshot,
+  subscribePortForwardRuntime,
+  unsubscribePortForwardRuntime,
   stopAllPortForwards,
   stopPortForwardByRuleId,
   cancelTunnel,
@@ -1905,6 +2060,9 @@ module.exports = {
   isReusableTunnelStatus,
   buildPortForwardEndpoint,
   buildPortForwardEndpointFromStartPayload,
+  _resetPortForwardRuntimeMetaForTests: resetPortForwardRuntimeMetaForTests,
+  _seedPortForwardTunnelForTests: seedPortForwardTunnelForTests,
+  _clearPortForwardTunnelsForTests: clearPortForwardTunnelsForTests,
   _bindPortForwardChannelsForTests: bindPortForwardChannels,
   _trackTunnelPipeForTests: trackTunnelPipe,
   _attachTunnelPipeStreamForTests: attachTunnelPipeStream,

--- a/electron/bridges/portForwardingBridge.cjs
+++ b/electron/bridges/portForwardingBridge.cjs
@@ -1815,6 +1815,14 @@ async function unsubscribePortForwardSender(event, payload = {}) {
       removed += 1;
     }
   }
+  const runtimeEntry = runtimeEventSubscribers.get(webContentsId);
+  if (runtimeEntry) {
+    if (runtimeEntry.onDestroyed) {
+      runtimeEntry.sender.removeListener?.("destroyed", runtimeEntry.onDestroyed);
+    }
+    runtimeEventSubscribers.delete(webContentsId);
+    removed += 1;
+  }
   return { removed };
 }
 
@@ -1938,7 +1946,12 @@ function registerHandlers(ipcMain, options = {}) {
     };
 
     const releaseEmptySenderLifecycle = (sender, entry) => {
-      if (!entry || entry.tunnelIds.size > 0 || subscriptionsBySender.get(sender?.id) !== entry) return;
+      if (
+        !entry
+        || entry.tunnelIds.size > 0
+        || entry.runtimeSubscribed
+        || subscriptionsBySender.get(sender?.id) !== entry
+      ) return;
       entry.sender.removeListener?.("destroyed", entry.onDestroyed);
       subscriptionsBySender.delete(sender.id);
     };
@@ -1990,8 +2003,39 @@ function registerHandlers(ipcMain, options = {}) {
     requestWorker("netcatty:portforward:subscribe", { track: true });
     requestWorker("netcatty:portforward:list");
     requestWorker("netcatty:portforward:snapshot");
-    requestWorker("netcatty:portforward:subscribeRuntime");
-    requestWorker("netcatty:portforward:unsubscribeRuntime");
+    // Runtime subscriptions are process-scoped (no tunnelId). Keep the sender
+    // lifecycle entry so a destroyed window still calls unsubscribeSender,
+    // which clears worker-side runtimeEventSubscribers.
+    ipcMain.handle("netcatty:portforward:subscribeRuntime", async (event, payload) => {
+      const entry = ensureSenderLifecycle(event?.sender);
+      if (entry) entry.runtimeSubscribed = true;
+      try {
+        return await terminalWorkerManager.request(
+          "netcatty:portforward:subscribeRuntime",
+          payload,
+          { webContentsId: event?.sender?.id },
+        );
+      } catch (error) {
+        if (entry) {
+          entry.runtimeSubscribed = false;
+          releaseEmptySenderLifecycle(event?.sender, entry);
+        }
+        throw error;
+      }
+    });
+    ipcMain.handle("netcatty:portforward:unsubscribeRuntime", async (event, payload) => {
+      const entry = subscriptionsBySender.get(event?.sender?.id);
+      try {
+        return await terminalWorkerManager.request(
+          "netcatty:portforward:unsubscribeRuntime",
+          payload,
+          { webContentsId: event?.sender?.id },
+        );
+      } finally {
+        if (entry) entry.runtimeSubscribed = false;
+        releaseEmptySenderLifecycle(event?.sender, entry);
+      }
+    });
     requestWorker("netcatty:portforward:stopAll", { cleanup: "all" });
     requestWorker("netcatty:portforward:stopByRuleId", { cleanup: "rule" });
 

--- a/electron/bridges/portForwardingBridge.snapshot.test.cjs
+++ b/electron/bridges/portForwardingBridge.snapshot.test.cjs
@@ -1,0 +1,122 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  publishTunnelStatus,
+  getPortForwardSnapshot,
+  subscribePortForwardRuntime,
+  unsubscribePortForwardRuntime,
+  cancelTunnel,
+  _resetPortForwardRuntimeMetaForTests: resetRuntimeMeta,
+  _seedPortForwardTunnelForTests: seedTunnel,
+  _clearPortForwardTunnelsForTests: clearTunnels,
+} = require("./portForwardingBridge.cjs");
+
+function createCapturingSender(onSend = () => {}, id = 1) {
+  return {
+    id,
+    isDestroyed: () => false,
+    send: (channel, payload) => onSend(channel, payload),
+    once() {},
+    removeListener() {},
+  };
+}
+
+test("snapshot exposes process epoch, revision, and rule-scoped records", () => {
+  resetRuntimeMeta();
+  clearTunnels();
+  const tunnelId = "snap-tunnel-1";
+  const tunnel = {
+    ruleId: "rule-1",
+    status: "active",
+    subscribers: new Map(),
+    cleanupFailed: false,
+  };
+  seedTunnel(tunnelId, tunnel);
+
+  const before = getPortForwardSnapshot();
+  assert.equal(typeof before.epoch, "string");
+  assert.ok(before.epoch.length > 0);
+  assert.equal(before.records.length, 1);
+  assert.equal(before.records[0].ruleId, "rule-1");
+  assert.equal(before.records[0].phase, "active");
+
+  publishTunnelStatus(tunnelId, tunnel, "error", "listener failed");
+  const after = getPortForwardSnapshot();
+  assert.equal(after.epoch, before.epoch);
+  assert.ok(after.revision > before.revision);
+  assert.equal(after.records[0].phase, "error");
+  assert.equal(after.records[0].error, "listener failed");
+  assert.equal(after.records[0].cleanupRequired, false);
+
+  clearTunnels();
+});
+
+test("subscribePortForwardRuntime returns snapshot and receives ordered events", () => {
+  resetRuntimeMeta();
+  clearTunnels();
+  const events = [];
+  const sender = createCapturingSender((channel, payload) => {
+    if (channel === "netcatty:portforward:runtime") events.push(payload);
+  }, 42);
+
+  const snapshot = subscribePortForwardRuntime({ sender });
+  assert.equal(typeof snapshot.epoch, "string");
+  assert.equal(snapshot.revision, 0);
+  assert.deepEqual(snapshot.records, []);
+
+  const tunnelId = "runtime-tunnel";
+  const tunnel = {
+    ruleId: "rule-runtime",
+    status: "connecting",
+    subscribers: new Map([[sender.id, sender]]),
+    cleanupFailed: false,
+  };
+  seedTunnel(tunnelId, tunnel);
+  publishTunnelStatus(tunnelId, tunnel, "active");
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].kind, "upsert");
+  assert.equal(events[0].record.phase, "active");
+  assert.equal(events[0].record.ruleId, "rule-runtime");
+  assert.equal(events[0].revision, 1);
+  assert.equal(events[0].epoch, snapshot.epoch);
+
+  unsubscribePortForwardRuntime({ sender });
+  publishTunnelStatus(tunnelId, tunnel, "error", "boom");
+  assert.equal(events.length, 1);
+  clearTunnels();
+});
+
+test("successful cleanup publishes remove after inactive", async () => {
+  resetRuntimeMeta();
+  clearTunnels();
+  const events = [];
+  const sender = createCapturingSender((channel, payload) => {
+    if (channel === "netcatty:portforward:runtime") events.push(payload);
+  }, 7);
+  subscribePortForwardRuntime({ sender });
+
+  const tunnelId = "cleanup-tunnel";
+  const tunnel = {
+    ruleId: "rule-cleanup",
+    status: "active",
+    subscribers: new Map(),
+    cleanupFailed: false,
+    cleanupInProgress: false,
+  };
+  seedTunnel(tunnelId, tunnel);
+
+  await cancelTunnel(
+    tunnelId,
+    tunnel,
+    (status, error) => publishTunnelStatus(tunnelId, tunnel, status, error),
+    { deleteEntry: true },
+  );
+
+  assert.ok(events.some((event) => event.kind === "upsert" && event.record?.phase === "inactive"));
+  assert.ok(events.some((event) => event.kind === "remove" && event.tunnelId === tunnelId));
+  assert.deepEqual(getPortForwardSnapshot().records, []);
+  unsubscribePortForwardRuntime({ sender });
+  clearTunnels();
+});

--- a/electron/bridges/portForwardingBridge.worker.test.cjs
+++ b/electron/bridges/portForwardingBridge.worker.test.cjs
@@ -50,6 +50,9 @@ test("worker mode routes every port-forward operation through the terminal worke
     "netcatty:portforward:status",
     "netcatty:portforward:subscribe",
     "netcatty:portforward:list",
+    "netcatty:portforward:snapshot",
+    "netcatty:portforward:subscribeRuntime",
+    "netcatty:portforward:unsubscribeRuntime",
     "netcatty:portforward:stopAll",
     "netcatty:portforward:stopByRuleId",
   ];

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -712,6 +712,7 @@ ipcRenderer.on("netcatty:plugins:contributions-changed", (_event, payload) => {
 
 // Port forwarding status listeners
 const portForwardStatusListeners = new Map();
+const portForwardRuntimeListeners = new Set();
 
 ipcRenderer.on("netcatty:portforward:status", (_event, payload) => {
   const { tunnelId, status, error } = payload;
@@ -725,6 +726,16 @@ ipcRenderer.on("netcatty:portforward:status", (_event, payload) => {
       }
     });
   }
+});
+
+ipcRenderer.on("netcatty:portforward:runtime", (_event, payload) => {
+  portForwardRuntimeListeners.forEach((cb) => {
+    try {
+      cb(payload);
+    } catch (err) {
+      console.error("Port forward runtime callback failed", err);
+    }
+  });
 });
 
 // File watcher listeners (for auto-sync feature)
@@ -815,6 +826,7 @@ const api = createPreloadApi({
   updateNeedsSaveListeners,
   terminalPopupConfigState,
   portForwardStatusListeners,
+  portForwardRuntimeListeners,
   fileWatchSyncedListeners,
   fileWatchErrorListeners,
   fileWatchStoppedListeners,

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -1229,6 +1229,15 @@ function createPreloadApi(ctx) {
   listPortForwards: async () => {
     return ipcRenderer.invoke("netcatty:portforward:list");
   },
+  getPortForwardSnapshot: async () => {
+    return ipcRenderer.invoke("netcatty:portforward:snapshot");
+  },
+  subscribePortForwardRuntime: async () => {
+    return ipcRenderer.invoke("netcatty:portforward:subscribeRuntime");
+  },
+  unsubscribePortForwardRuntime: async () => {
+    return ipcRenderer.invoke("netcatty:portforward:unsubscribeRuntime");
+  },
   stopAllPortForwards: async () => {
     return ipcRenderer.invoke("netcatty:portforward:stopAll");
   },
@@ -1245,6 +1254,12 @@ function createPreloadApi(ctx) {
       if (portForwardStatusListeners.get(tunnelId)?.size === 0) {
         portForwardStatusListeners.delete(tunnelId);
       }
+    };
+  },
+  onPortForwardRuntime: (cb) => {
+    portForwardRuntimeListeners.add(cb);
+    return () => {
+      portForwardRuntimeListeners.delete(cb);
     };
   },
   // Chain progress listener for jump host connections

--- a/global.d.ts
+++ b/global.d.ts
@@ -252,12 +252,51 @@ declare global {
     error?: string;
   }
 
+  type PortForwardRuntimePhase =
+    | 'connecting'
+    | 'active'
+    | 'stopping'
+    | 'error'
+    | 'inactive';
+
+  interface PortForwardRuntimeRecord {
+    ruleId?: string;
+    tunnelId: string;
+    phase: PortForwardRuntimePhase | string;
+    error?: string;
+    cleanupRequired?: boolean;
+    revision: number;
+    updatedAt: number;
+  }
+
+  interface PortForwardRuntimeSnapshot {
+    epoch: string;
+    revision: number;
+    records: PortForwardRuntimeRecord[];
+  }
+
+  type PortForwardRuntimeEvent =
+    | {
+        epoch: string;
+        revision: number;
+        kind: 'upsert';
+        record: PortForwardRuntimeRecord;
+      }
+    | {
+        epoch: string;
+        revision: number;
+        kind: 'remove';
+        tunnelId: string;
+        ruleId?: string;
+      };
+
   interface NetcattyWindowsPtyInfo {
     backend: 'conpty' | 'winpty';
     buildNumber?: number;
   }
 
   type PortForwardStatusCallback = (status: 'inactive' | 'connecting' | 'active' | 'error', error?: string) => void;
+  type PortForwardRuntimeEventCallback = (event: PortForwardRuntimeEvent) => void;
 
   interface NetcattyPluginRuntimeStatus {
     available: boolean;

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -121,6 +121,8 @@ test("reconcileWithBackend reports an unavailable snapshot on query failure", as
 
   assert.deepEqual(await reconcileWithBackend(), {
     snapshotAvailable: false,
+    epoch: undefined,
+    revision: undefined,
     gone: [],
     appeared: [],
   });

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -435,8 +435,91 @@ const resolveBackendRuleId = (tunnel: { ruleId?: string; tunnelId: string }): st
 };
 
 const resolveBackendStatus = (status: string): PortForwardingConnection['status'] => {
-  if (status === 'active' || status === 'connecting' || status === 'error') return status;
+  if (status === 'active') return 'active';
+  if (status === 'connecting' || status === 'stopping') return 'connecting';
+  if (status === 'error') return 'error';
+  if (status === 'inactive') return 'inactive';
   return 'connecting';
+};
+
+export type PortForwardRuntimeAuthority = {
+  available: boolean;
+  epoch?: string;
+  revision?: number;
+};
+
+let lastRuntimeAuthority: PortForwardRuntimeAuthority = { available: false };
+
+export const getPortForwardRuntimeAuthority = (): PortForwardRuntimeAuthority => lastRuntimeAuthority;
+
+/**
+ * Prefer the authoritative snapshot protocol (#2288). Fall back to list() for
+ * older bridges so tests and transitional builds keep working.
+ */
+export const fetchPortForwardSnapshot = async (): Promise<{
+  available: boolean;
+  epoch?: string;
+  revision?: number;
+  records: Array<{
+    ruleId?: string;
+    tunnelId: string;
+    status: string;
+    error?: string;
+    cleanupRequired?: boolean;
+  }>;
+}> => {
+  const bridge = netcattyBridge.get();
+  if (bridge?.getPortForwardSnapshot) {
+    try {
+      const snapshot = await bridge.getPortForwardSnapshot();
+      lastRuntimeAuthority = {
+        available: true,
+        epoch: snapshot.epoch,
+        revision: snapshot.revision,
+      };
+      return {
+        available: true,
+        epoch: snapshot.epoch,
+        revision: snapshot.revision,
+        records: snapshot.records.map((record) => ({
+          ruleId: record.ruleId,
+          tunnelId: record.tunnelId,
+          status: record.phase,
+          error: record.error,
+          cleanupRequired: record.cleanupRequired,
+        })),
+      };
+    } catch (err) {
+      lastRuntimeAuthority = { available: false };
+      logger.warn('[PortForwardingService] Snapshot failed:', err);
+      return { available: false, records: [] };
+    }
+  }
+
+  if (!bridge?.listPortForwards) {
+    lastRuntimeAuthority = { available: false };
+    return { available: false, records: [] };
+  }
+
+  try {
+    const tunnels = await bridge.listPortForwards();
+    lastRuntimeAuthority = { available: true, epoch: 'legacy', revision: 0 };
+    return {
+      available: true,
+      epoch: 'legacy',
+      revision: 0,
+      records: tunnels.map((tunnel) => ({
+        ruleId: tunnel.ruleId,
+        tunnelId: tunnel.tunnelId,
+        status: tunnel.status,
+        error: tunnel.error,
+      })),
+    };
+  } catch (err) {
+    lastRuntimeAuthority = { available: false };
+    logger.warn('[PortForwardingService] Legacy list snapshot failed:', err);
+    return { available: false, records: [] };
+  }
 };
 
 /**
@@ -560,17 +643,22 @@ export const syncWithBackend = async (
 ): Promise<void> => {
   rememberBackendSyncOptions(options);
   const bridge = netcattyBridge.get();
-  
-  if (!bridge?.listPortForwards) {
+
+  if (!bridge?.getPortForwardSnapshot && !bridge?.listPortForwards) {
     logger.warn('[PortForwardingService] Backend not available for sync');
+    lastRuntimeAuthority = { available: false };
     return;
   }
-  
+
   try {
-    const activeTunnels = await bridge.listPortForwards();
-    logger.info(`[PortForwardingService] Backend reports ${activeTunnels.length} active tunnels`);
-    
-    for (const tunnel of activeTunnels) {
+    const snapshot = await fetchPortForwardSnapshot();
+    if (!snapshot.available) {
+      logger.warn('[PortForwardingService] Backend snapshot unavailable during sync');
+      return;
+    }
+    logger.info(`[PortForwardingService] Backend reports ${snapshot.records.length} active tunnels`);
+
+    for (const tunnel of snapshot.records) {
       const ruleId = resolveBackendRuleId(tunnel);
       if (ruleId) {
         const existing = activeConnections.get(ruleId);
@@ -591,11 +679,12 @@ export const syncWithBackend = async (
         activeConnections.set(ruleId, connection);
 
         if (!await subscribeSyncedConnection(ruleId, connection)) continue;
-        
+
         logger.info(`[PortForwardingService] Synced active tunnel for rule ${ruleId}`);
       }
     }
   } catch (err) {
+    lastRuntimeAuthority = { available: false };
     logger.error('[PortForwardingService] Failed to sync with backend:', err);
   }
 };
@@ -614,24 +703,31 @@ export const syncWithBackend = async (
  */
 export const reconcileWithBackend = async (): Promise<{
   snapshotAvailable: boolean;
+  epoch?: string;
+  revision?: number;
   gone: string[];
   appeared: string[];
 }> => {
   const result = {
     snapshotAvailable: false,
+    epoch: undefined as string | undefined,
+    revision: undefined as number | undefined,
     gone: [] as string[],
     appeared: [] as string[],
   };
   const bridge = netcattyBridge.get();
 
-  if (!bridge?.listPortForwards) return result;
+  if (!bridge?.getPortForwardSnapshot && !bridge?.listPortForwards) return result;
 
   try {
-    const backendTunnels = await bridge.listPortForwards();
+    const snapshot = await fetchPortForwardSnapshot();
+    if (!snapshot.available) return result;
     result.snapshotAvailable = true;
+    result.epoch = snapshot.epoch;
+    result.revision = snapshot.revision;
     const backendRuleIds = new Set<string>();
 
-    for (const tunnel of backendTunnels) {
+    for (const tunnel of snapshot.records) {
       const ruleId = resolveBackendRuleId(tunnel);
       if (ruleId) {
         backendRuleIds.add(ruleId);
@@ -708,6 +804,7 @@ export const reconcileWithBackend = async (): Promise<{
       );
     }
   } catch (err) {
+    lastRuntimeAuthority = { available: false };
     logger.warn('[PortForwardingService] Reconcile failed:', err);
   }
 

--- a/types/global/netcatty-bridge-sync.d.ts
+++ b/types/global/netcatty-bridge-sync.d.ts
@@ -66,6 +66,9 @@ declare global {
     stopPortForward?(tunnelId: string): Promise<PortForwardResult>;
     getPortForwardStatus?(tunnelId: string): Promise<PortForwardStatusResult>;
     listPortForwards?(): Promise<{ ruleId?: string; tunnelId: string; type: string; status: string; error?: string }[]>;
+    getPortForwardSnapshot?(): Promise<PortForwardRuntimeSnapshot>;
+    subscribePortForwardRuntime?(): Promise<PortForwardRuntimeSnapshot>;
+    unsubscribePortForwardRuntime?(): Promise<{ success: boolean }>;
     subscribePortForward?(tunnelId: string): Promise<{
       tunnelId: string;
       type?: string;
@@ -79,6 +82,7 @@ declare global {
       errors?: string[];
     }>;
     onPortForwardStatus?(tunnelId: string, cb: PortForwardStatusCallback): () => void;
+    onPortForwardRuntime?(cb: PortForwardRuntimeEventCallback): () => void;
 
     // Known Hosts
     readKnownHosts?(): Promise<string | null>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 1 of [#2288](https://github.com/binaricat/Netcatty/issues/2288): establish the Electron main/worker tunnel registry as the authority for port-forwarding runtime phases, while keeping rule configuration in localStorage.

Related reliability work in #2283 remains; this PR starts the architectural follow-up so runtime status stops living in four places at once.

## Type of Change

- [x] New feature
- [x] Refactor / code cleanup

## Related Issue (optional)

Related to #2288

## Changes Made

- Add `getPortForwardSnapshot()` / `subscribePortForwardRuntime()` with process `epoch` + monotonic `revision`
- Emit ordered `netcatty:portforward:runtime` events (`upsert` / `remove`) and enrich per-tunnel status payloads with authority metadata
- Persist only rule configuration (`status`/`error` always stripped on write); migrate legacy stored `active`/`connecting` on read
- Derive React UI from config + live `activeConnections`; project `unknown` when the authoritative snapshot is unavailable (default until first success)
- Keep the 4s heartbeat as a recovery fallback, but stop writing runtime phases back to localStorage
- Auto-start / reconnect status updates go through an in-memory projection helper instead of storage writes
- Epoch/revision gap repair uses reconcile (prunes stale connections); runtime event handling is serialized
- Worker proxy keeps sender lifecycle for runtime subscriptions and clears them on window destroy
- Tray treats `unknown` like RuleCard: no Start/Stop until authority recovers (unless a local runtime tunnel exists)

## Out of scope (later #2288 steps)

- Full `ensurePortForward(rule, configRevision)` API replacement
- Config-revision mismatch indicator / restart UX
- Moving rule configuration persistence into the main process
- Removing heartbeat entirely after the event path is proven in production

## Testing

- [x] Targeted unit tests pass
- [x] Linting passes (`npm run lint`)
- [x] CI `lint-and-test` passed
- [x] Platform pack jobs passed (linux x64/arm64, macOS; Windows completed in pack workflow)
- [x] Bugbot triggered (`bugbot run`); no Bugbot findings posted on the PR

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fdefa-a1d5-790c-921d-9201cb0b26b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fdefa-a1d5-790c-921d-9201cb0b26b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

