### PR TITLE
fix: serialize snippet saves with bulk-delete vault lock (PR #2828 follow-up)

### DIFF
--- a/application/app/AppSideEffects.snippetsDelete.test.ts
+++ b/application/app/AppSideEffects.snippetsDelete.test.ts
@@ -9,7 +9,7 @@ test("snippets delete handler cleans host bindings via deleteSelectedSnippets", 
   assert.match(source, /deleteSelectedSnippets/);
   assert.match(
     source,
-    /netcatty:snippets:delete[\s\S]*deleteSelectedSnippets\(ids\)/,
+    /netcatty:snippets:delete[\s\S]*void deleteSelectedSnippets\(ids\)/,
   );
   assert.doesNotMatch(
     source,

--- a/application/app/AppSideEffects.snippetsDelete.test.ts
+++ b/application/app/AppSideEffects.snippetsDelete.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./AppSideEffects.tsx", import.meta.url), "utf8");
+
+test("snippets delete handler cleans host bindings via deleteSelectedSnippetsFromVault", () => {
+  assert.match(source, /collectSnippetDeleteIds/);
+  assert.match(source, /deleteSelectedSnippetsFromVault/);
+  assert.match(
+    source,
+    /netcatty:snippets:delete[\s\S]*deleteSelectedSnippetsFromVault\([\s\S]*updateHosts/,
+  );
+  assert.doesNotMatch(
+    source,
+    /updateSnippets\(snippets\.filter\(\(s\) => !ids\.has\(s\.id\)\)\)/,
+  );
+});

--- a/application/app/AppSideEffects.snippetsDelete.test.ts
+++ b/application/app/AppSideEffects.snippetsDelete.test.ts
@@ -16,3 +16,13 @@ test("snippets delete handler cleans host bindings via deleteSelectedSnippetsFro
     /updateSnippets\(snippets\.filter\(\(s\) => !ids\.has\(s\.id\)\)\)/,
   );
 });
+
+test("snippets delete handler reads vault state from refs to avoid stale closures", () => {
+  // Rapid/double confirms must see the latest snippets/hosts, not the
+  // values closed over when the listener was last registered.
+  assert.match(source, /snippetsRef\.current\s*=\s*snippets/);
+  assert.match(
+    source,
+    /deleteSelectedSnippetsFromVault\(\s*snippetsRef\.current\s*,\s*hostsRef\.current\s*,\s*ids,?\s*\)/,
+  );
+});

--- a/application/app/AppSideEffects.snippetsDelete.test.ts
+++ b/application/app/AppSideEffects.snippetsDelete.test.ts
@@ -25,4 +25,10 @@ test("snippets delete handler reads vault state from refs to avoid stale closure
     source,
     /deleteSelectedSnippetsFromVault\(\s*snippetsRef\.current\s*,\s*hostsRef\.current\s*,\s*ids,?\s*\)/,
   );
+  // Same-tick follow-up deletes must observe the just-applied vault, which
+  // only happens if we write refs before the next listener invocation.
+  assert.match(
+    source,
+    /snippetsRef\.current\s*=\s*result\.snippets[\s\S]*hostsRef\.current\s*=\s*result\.hosts[\s\S]*updateSnippets\(result\.snippets\)/,
+  );
 });

--- a/application/app/AppSideEffects.snippetsDelete.test.ts
+++ b/application/app/AppSideEffects.snippetsDelete.test.ts
@@ -4,12 +4,12 @@ import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./AppSideEffects.tsx", import.meta.url), "utf8");
 
-test("snippets delete handler cleans host bindings via deleteSelectedSnippetsFromVault", () => {
+test("snippets delete handler cleans host bindings via deleteSelectedSnippets", () => {
   assert.match(source, /collectSnippetDeleteIds/);
-  assert.match(source, /deleteSelectedSnippetsFromVault/);
+  assert.match(source, /deleteSelectedSnippets/);
   assert.match(
     source,
-    /netcatty:snippets:delete[\s\S]*deleteSelectedSnippetsFromVault\([\s\S]*updateHosts/,
+    /netcatty:snippets:delete[\s\S]*deleteSelectedSnippets\(ids\)/,
   );
   assert.doesNotMatch(
     source,
@@ -17,18 +17,14 @@ test("snippets delete handler cleans host bindings via deleteSelectedSnippetsFro
   );
 });
 
-test("snippets delete handler reads vault state from refs to avoid stale closures", () => {
-  // Rapid/double confirms must see the latest snippets/hosts, not the
-  // values closed over when the listener was last registered.
-  assert.match(source, /snippetsRef\.current\s*=\s*snippets/);
-  assert.match(
+test("snippets delete handler uses vault live snapshot instead of component refs", () => {
+  // Component-level snippetsRef/hostsRef lag concurrent vault mutations that
+  // already advanced useVaultState refs before React re-renders AppSideEffects.
+  // Deletion must go through the vault hook's atomic live-snapshot path.
+  assert.match(source, /deleteSelectedSnippets,/);
+  assert.doesNotMatch(source, /snippetsRef\.current\s*=\s*snippets/);
+  assert.doesNotMatch(
     source,
-    /deleteSelectedSnippetsFromVault\(\s*snippetsRef\.current\s*,\s*hostsRef\.current\s*,\s*ids,?\s*\)/,
-  );
-  // Same-tick follow-up deletes must observe the just-applied vault, which
-  // only happens if we write refs before the next listener invocation.
-  assert.match(
-    source,
-    /snippetsRef\.current\s*=\s*result\.snippets[\s\S]*hostsRef\.current\s*=\s*result\.hosts[\s\S]*updateSnippets\(result\.snippets\)/,
+    /deleteSelectedSnippetsFromVault\(\s*snippetsRef\.current/,
   );
 });

--- a/application/app/AppSideEffects.tsx
+++ b/application/app/AppSideEffects.tsx
@@ -202,6 +202,8 @@ export function AppSideEffects() {
 
   const hostsRef = useRef(hosts);
   hostsRef.current = hosts;
+  const snippetsRef = useRef(snippets);
+  snippetsRef.current = snippets;
   const keysRef = useRef(keys);
   keysRef.current = keys;
   const knownHostsRef = useRef(knownHosts);
@@ -1609,19 +1611,25 @@ export function AppSideEffects() {
   // here (rather than in QuickAddSnippetDialog) because delete needs no UI.
   // Must go through deleteSelectedSnippetsFromVault so login/connect script
   // bindings on hosts are cleared with the snippets (SnippetsManager parity).
+  // Read snippets/hosts from refs so rapid/double confirms do not apply deletes
+  // against a stale closed-over vault snapshot.
   useEffect(() => {
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<{ id?: string; ids?: string[] }>).detail;
       const ids = collectSnippetDeleteIds(detail);
       if (ids.size === 0) return;
-      const result = deleteSelectedSnippetsFromVault(snippets, hosts, ids);
+      const result = deleteSelectedSnippetsFromVault(
+        snippetsRef.current,
+        hostsRef.current,
+        ids,
+      );
       if (result.deletedCount === 0) return;
       updateSnippets(result.snippets);
       updateHosts(result.hosts);
     };
     window.addEventListener('netcatty:snippets:delete', handler);
     return () => window.removeEventListener('netcatty:snippets:delete', handler);
-  }, [hosts, snippets, updateHosts, updateSnippets]);
+  }, [updateHosts, updateSnippets]);
 
   const handleEndSessionDrag = useCallback(() => {
     setDraggingSessionId(null);

--- a/application/app/AppSideEffects.tsx
+++ b/application/app/AppSideEffects.tsx
@@ -1624,6 +1624,11 @@ export function AppSideEffects() {
         ids,
       );
       if (result.deletedCount === 0) return;
+      // Keep refs ahead of React render so a same-tick second delete (e.g.
+      // double-confirm) cannot re-apply against the pre-delete snapshot and
+      // resurrect already-removed snippets/host bindings.
+      snippetsRef.current = result.snippets;
+      hostsRef.current = result.hosts;
       updateSnippets(result.snippets);
       updateHosts(result.hosts);
     };

--- a/application/app/AppSideEffects.tsx
+++ b/application/app/AppSideEffects.tsx
@@ -1600,14 +1600,18 @@ export function AppSideEffects() {
     };
   }, [handleOpenSettings, t]);
 
-  // Delete-from-sidepanel plumbing: ScriptsSidePanel's right-click menu
-  // dispatches `netcatty:snippets:delete` with the snippet id. Handled here
-  // (rather than in QuickAddSnippetDialog) because delete needs no UI.
+  // Delete-from-sidepanel plumbing: ScriptsSidePanel dispatches
+  // `netcatty:snippets:delete` with `id` (single) or `ids` (bulk). Handled
+  // here (rather than in QuickAddSnippetDialog) because delete needs no UI.
   useEffect(() => {
     const handler = (e: Event) => {
-      const id = (e as CustomEvent<{ id?: string }>).detail?.id;
-      if (!id) return;
-      updateSnippets(snippets.filter((s) => s.id !== id));
+      const detail = (e as CustomEvent<{ id?: string; ids?: string[] }>).detail;
+      const ids = new Set<string>([
+        ...(detail?.ids ?? []),
+        ...(detail?.id ? [detail.id] : []),
+      ]);
+      if (ids.size === 0) return;
+      updateSnippets(snippets.filter((s) => !ids.has(s.id)));
     };
     window.addEventListener('netcatty:snippets:delete', handler);
     return () => window.removeEventListener('netcatty:snippets:delete', handler);

--- a/application/app/AppSideEffects.tsx
+++ b/application/app/AppSideEffects.tsx
@@ -82,10 +82,7 @@ import { useDiscoveredShells, resolveShellSetting } from '../../lib/useDiscovere
 import { Host, HostProtocol, KnownHost, SerialConfig, Snippet, SSHKey, TerminalSession } from '../../types';
 import { resolveSnippetCommand } from '../../components/SnippetExecutionProvider';
 import { isScriptSnippet } from '../../domain/snippetScript.ts';
-import {
-  collectSnippetDeleteIds,
-  deleteSelectedSnippetsFromVault,
-} from '../../domain/snippetSelection.ts';
+import { collectSnippetDeleteIds } from '../../domain/snippetSelection.ts';
 import { useAppStartupEffects } from './useAppStartupEffects';
 import { handleTrayJumpToSessionImpl, handleTrayTogglePortForwardImpl, handleTrayPanelConnectImpl, handleTrayPanelConnectRequestImpl, flushQueuedTrayPanelConnectHostsImpl, handleGlobalHotkeyKeyDownImpl, handleEscapeKeyDownImpl, handleKeyboardInteractiveSubmitImpl, handleKeyboardInteractiveCancelImpl, handlePassphraseSubmitImpl, handlePassphraseCancelImpl, handlePassphraseSkipImpl, createLocalTerminalWithCurrentShellImpl, splitSessionWithCurrentShellImpl, copySessionWithCurrentShellImpl, copyWorkspaceWithCurrentShellImpl, copySessionToNewWindowWithCurrentShellImpl, confirmIfBusyLocalTerminalImpl, closeTabsBatchImpl, executeHotkeyActionImpl, handleCreateLocalTerminalImpl, handleConnectToHostImpl, handleTerminalDataCaptureImpl, hasMultipleProtocolsImpl, handleHostConnectWithProtocolCheckImpl, handleProtocolSelectImpl, handleRootContextMenuImpl } from './AppHandlers';
 
@@ -188,6 +185,7 @@ export function AppSideEffects() {
     updateHosts,
     updateKeys,
     updateSnippets,
+    deleteSelectedSnippets,
     updateCustomGroups,
     updateKnownHosts,
     updateManagedSources,
@@ -202,8 +200,6 @@ export function AppSideEffects() {
 
   const hostsRef = useRef(hosts);
   hostsRef.current = hosts;
-  const snippetsRef = useRef(snippets);
-  snippetsRef.current = snippets;
   const keysRef = useRef(keys);
   keysRef.current = keys;
   const knownHostsRef = useRef(knownHosts);
@@ -1609,32 +1605,20 @@ export function AppSideEffects() {
   // Delete-from-sidepanel plumbing: ScriptsSidePanel dispatches
   // `netcatty:snippets:delete` with `id` (single) or `ids` (bulk). Handled
   // here (rather than in QuickAddSnippetDialog) because delete needs no UI.
-  // Must go through deleteSelectedSnippetsFromVault so login/connect script
-  // bindings on hosts are cleared with the snippets (SnippetsManager parity).
-  // Read snippets/hosts from refs so rapid/double confirms do not apply deletes
-  // against a stale closed-over vault snapshot.
+  // Goes through useVaultState.deleteSelectedSnippets so login/connect script
+  // bindings clear with the snippets (SnippetsManager parity) against the
+  // vault hook's live snapshot - not a component ref that can lag a concurrent
+  // updateHosts/updateSnippets that has not re-rendered yet.
   useEffect(() => {
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<{ id?: string; ids?: string[] }>).detail;
       const ids = collectSnippetDeleteIds(detail);
       if (ids.size === 0) return;
-      const result = deleteSelectedSnippetsFromVault(
-        snippetsRef.current,
-        hostsRef.current,
-        ids,
-      );
-      if (result.deletedCount === 0) return;
-      // Keep refs ahead of React render so a same-tick second delete (e.g.
-      // double-confirm) cannot re-apply against the pre-delete snapshot and
-      // resurrect already-removed snippets/host bindings.
-      snippetsRef.current = result.snippets;
-      hostsRef.current = result.hosts;
-      updateSnippets(result.snippets);
-      updateHosts(result.hosts);
+      deleteSelectedSnippets(ids);
     };
     window.addEventListener('netcatty:snippets:delete', handler);
     return () => window.removeEventListener('netcatty:snippets:delete', handler);
-  }, [updateHosts, updateSnippets]);
+  }, [deleteSelectedSnippets]);
 
   const handleEndSessionDrag = useCallback(() => {
     setDraggingSessionId(null);

--- a/application/app/AppSideEffects.tsx
+++ b/application/app/AppSideEffects.tsx
@@ -82,6 +82,10 @@ import { useDiscoveredShells, resolveShellSetting } from '../../lib/useDiscovere
 import { Host, HostProtocol, KnownHost, SerialConfig, Snippet, SSHKey, TerminalSession } from '../../types';
 import { resolveSnippetCommand } from '../../components/SnippetExecutionProvider';
 import { isScriptSnippet } from '../../domain/snippetScript.ts';
+import {
+  collectSnippetDeleteIds,
+  deleteSelectedSnippetsFromVault,
+} from '../../domain/snippetSelection.ts';
 import { useAppStartupEffects } from './useAppStartupEffects';
 import { handleTrayJumpToSessionImpl, handleTrayTogglePortForwardImpl, handleTrayPanelConnectImpl, handleTrayPanelConnectRequestImpl, flushQueuedTrayPanelConnectHostsImpl, handleGlobalHotkeyKeyDownImpl, handleEscapeKeyDownImpl, handleKeyboardInteractiveSubmitImpl, handleKeyboardInteractiveCancelImpl, handlePassphraseSubmitImpl, handlePassphraseCancelImpl, handlePassphraseSkipImpl, createLocalTerminalWithCurrentShellImpl, splitSessionWithCurrentShellImpl, copySessionWithCurrentShellImpl, copyWorkspaceWithCurrentShellImpl, copySessionToNewWindowWithCurrentShellImpl, confirmIfBusyLocalTerminalImpl, closeTabsBatchImpl, executeHotkeyActionImpl, handleCreateLocalTerminalImpl, handleConnectToHostImpl, handleTerminalDataCaptureImpl, hasMultipleProtocolsImpl, handleHostConnectWithProtocolCheckImpl, handleProtocolSelectImpl, handleRootContextMenuImpl } from './AppHandlers';
 
@@ -1603,19 +1607,21 @@ export function AppSideEffects() {
   // Delete-from-sidepanel plumbing: ScriptsSidePanel dispatches
   // `netcatty:snippets:delete` with `id` (single) or `ids` (bulk). Handled
   // here (rather than in QuickAddSnippetDialog) because delete needs no UI.
+  // Must go through deleteSelectedSnippetsFromVault so login/connect script
+  // bindings on hosts are cleared with the snippets (SnippetsManager parity).
   useEffect(() => {
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<{ id?: string; ids?: string[] }>).detail;
-      const ids = new Set<string>([
-        ...(detail?.ids ?? []),
-        ...(detail?.id ? [detail.id] : []),
-      ]);
+      const ids = collectSnippetDeleteIds(detail);
       if (ids.size === 0) return;
-      updateSnippets(snippets.filter((s) => !ids.has(s.id)));
+      const result = deleteSelectedSnippetsFromVault(snippets, hosts, ids);
+      if (result.deletedCount === 0) return;
+      updateSnippets(result.snippets);
+      updateHosts(result.hosts);
     };
     window.addEventListener('netcatty:snippets:delete', handler);
     return () => window.removeEventListener('netcatty:snippets:delete', handler);
-  }, [snippets, updateSnippets]);
+  }, [hosts, snippets, updateHosts, updateSnippets]);
 
   const handleEndSessionDrag = useCallback(() => {
     setDraggingSessionId(null);

--- a/application/app/AppSideEffects.tsx
+++ b/application/app/AppSideEffects.tsx
@@ -1607,14 +1607,13 @@ export function AppSideEffects() {
   // here (rather than in QuickAddSnippetDialog) because delete needs no UI.
   // Goes through useVaultState.deleteSelectedSnippets so login/connect script
   // bindings clear with the snippets (SnippetsManager parity) against the
-  // vault hook's live snapshot - not a component ref that can lag a concurrent
-  // updateHosts/updateSnippets that has not re-rendered yet.
+  // latest persisted vault snapshot under the shared cross-window lock.
   useEffect(() => {
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<{ id?: string; ids?: string[] }>).detail;
       const ids = collectSnippetDeleteIds(detail);
       if (ids.size === 0) return;
-      deleteSelectedSnippets(ids);
+      void deleteSelectedSnippets(ids);
     };
     window.addEventListener('netcatty:snippets:delete', handler);
     return () => window.removeEventListener('netcatty:snippets:delete', handler);

--- a/application/state/useVaultState.snippetsDelete.test.ts
+++ b/application/state/useVaultState.snippetsDelete.test.ts
@@ -4,15 +4,23 @@ import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./useVaultState.ts", import.meta.url), "utf8");
 
-test("deleteSelectedSnippets reads live vault refs before writing", () => {
-  assert.match(source, /snippetsRef\.current\s*=\s*snippets/);
-  assert.match(source, /snippetsRef\.current\s*=\s*cleaned/);
+test("deleteSelectedSnippets merges into persisted vault under the shared lock", () => {
+  assert.match(source, /const deleteSelectedSnippets = useCallback\(async/);
   assert.match(
     source,
-    /deleteSelectedSnippetsFromVault\(\s*snippetsRef\.current\s*,\s*hostsRef\.current\s*,\s*selectedSnippetIds,?\s*\)/,
+    /deleteSelectedSnippets[\s\S]*withVaultImportLock\("vault"/,
   );
   assert.match(
     source,
-    /deleteSelectedSnippets[\s\S]*updateSnippets\(result\.snippets\)[\s\S]*updateHosts\(result\.hosts\)/,
+    /deleteSelectedSnippetsFromVault\(\s*latestSnippets\s*,\s*latestHosts\s*,\s*selectedSnippetIds,?\s*\)/,
+  );
+  assert.match(
+    source,
+    /localStorageAdapter\.write\(STORAGE_KEY_HOSTS, encryptedHosts\)[\s\S]*localStorageAdapter\.write\(STORAGE_KEY_SNIPPETS, result\.snippets\)/,
+  );
+  // Must not rebuild hosts from a per-window in-memory snapshot (popup race).
+  assert.doesNotMatch(
+    source,
+    /deleteSelectedSnippetsFromVault\(\s*snippetsRef\.current\s*,\s*hostsRef\.current/,
   );
 });

--- a/application/state/useVaultState.snippetsDelete.test.ts
+++ b/application/state/useVaultState.snippetsDelete.test.ts
@@ -18,6 +18,12 @@ test("deleteSelectedSnippets merges into persisted vault under the shared lock",
     source,
     /deleteSelectedSnippets[\s\S]*commitPluginImporterTransaction\(localStorageAdapter, \[[\s\S]*STORAGE_KEY_HOSTS[\s\S]*STORAGE_KEY_SNIPPETS/,
   );
+  // Persistence rejection must be caught: callers void the promise after the
+  // confirm dialog closes, so an uncaught throw would leave no retry feedback.
+  assert.match(
+    source,
+    /deleteSelectedSnippets[\s\S]*try \{\s*commitPluginImporterTransaction[\s\S]*catch \{[\s\S]*notify\.error\([\s\S]*Snippets could not be deleted/,
+  );
   // Must not rebuild hosts from a per-window in-memory snapshot (popup race).
   assert.doesNotMatch(
     source,

--- a/application/state/useVaultState.snippetsDelete.test.ts
+++ b/application/state/useVaultState.snippetsDelete.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./useVaultState.ts", import.meta.url), "utf8");
+
+test("deleteSelectedSnippets reads live vault refs before writing", () => {
+  assert.match(source, /snippetsRef\.current\s*=\s*snippets/);
+  assert.match(source, /snippetsRef\.current\s*=\s*cleaned/);
+  assert.match(
+    source,
+    /deleteSelectedSnippetsFromVault\(\s*snippetsRef\.current\s*,\s*hostsRef\.current\s*,\s*selectedSnippetIds,?\s*\)/,
+  );
+  assert.match(
+    source,
+    /deleteSelectedSnippets[\s\S]*updateSnippets\(result\.snippets\)[\s\S]*updateHosts\(result\.hosts\)/,
+  );
+});

--- a/application/state/useVaultState.snippetsDelete.test.ts
+++ b/application/state/useVaultState.snippetsDelete.test.ts
@@ -35,3 +35,25 @@ test("deleteSelectedSnippets merges into persisted vault under the shared lock",
     /deleteSelectedSnippets[\s\S]*localStorageAdapter\.write\(STORAGE_KEY_HOSTS, encryptedHosts\)[\s\S]*localStorageAdapter\.write\(STORAGE_KEY_SNIPPETS/,
   );
 });
+
+test("updateSnippets disk writes take the shared vault lock", () => {
+  // Unlocked snippet saves can interleave with bulk-delete's journaled commit
+  // and discard concurrent edits. Ordinary writers must queue on the same lock
+  // and be visible to waitForPendingVaultWrites.
+  assert.match(
+    source,
+    /const updateSnippets = useCallback\(\(data: Snippet\[\]\) => \{[\s\S]*withVaultImportLock\("vault", async \(\) => \{[\s\S]*localStorageAdapter\.write\(STORAGE_KEY_SNIPPETS, cleaned\)/,
+  );
+  assert.match(
+    source,
+    /snippetsWritePendingRef\.current = writePromise/,
+  );
+  assert.match(
+    source,
+    /waitForPendingVaultWrites[\s\S]*snippetsWritePendingRef\.current/,
+  );
+  assert.doesNotMatch(
+    source,
+    /const updateSnippets = useCallback\(\(data: Snippet\[\]\) => \{[\s\S]*setSnippets\(cleaned\);\s*localStorageAdapter\.write\(STORAGE_KEY_SNIPPETS, cleaned\);\s*\}, \[\]\);/,
+  );
+});

--- a/application/state/useVaultState.snippetsDelete.test.ts
+++ b/application/state/useVaultState.snippetsDelete.test.ts
@@ -16,11 +16,16 @@ test("deleteSelectedSnippets merges into persisted vault under the shared lock",
   );
   assert.match(
     source,
-    /localStorageAdapter\.write\(STORAGE_KEY_HOSTS, encryptedHosts\)[\s\S]*localStorageAdapter\.write\(STORAGE_KEY_SNIPPETS, result\.snippets\)/,
+    /deleteSelectedSnippets[\s\S]*commitPluginImporterTransaction\(localStorageAdapter, \[[\s\S]*STORAGE_KEY_HOSTS[\s\S]*STORAGE_KEY_SNIPPETS/,
   );
   // Must not rebuild hosts from a per-window in-memory snapshot (popup race).
   assert.doesNotMatch(
     source,
     /deleteSelectedSnippetsFromVault\(\s*snippetsRef\.current\s*,\s*hostsRef\.current/,
+  );
+  // Paired writes must not publish in-memory state if only one key lands.
+  assert.doesNotMatch(
+    source,
+    /deleteSelectedSnippets[\s\S]*localStorageAdapter\.write\(STORAGE_KEY_HOSTS, encryptedHosts\)[\s\S]*localStorageAdapter\.write\(STORAGE_KEY_SNIPPETS/,
   );
 });

--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -323,6 +323,7 @@ export const useVaultState = () => {
   const keysWritePendingRef = useRef<Promise<unknown>>(Promise.resolve());
   const identitiesWritePendingRef = useRef<Promise<unknown>>(Promise.resolve());
   const groupConfigsWritePendingRef = useRef<Promise<unknown>>(Promise.resolve());
+  const snippetsWritePendingRef = useRef<Promise<unknown>>(Promise.resolve());
 
   const waitForPendingVaultWrites = useCallback(async () => {
     while (true) {
@@ -347,6 +348,7 @@ export const useVaultState = () => {
         keysWritePendingRef.current,
         identitiesWritePendingRef.current,
         groupConfigsWritePendingRef.current,
+        snippetsWritePendingRef.current,
       ];
       await Promise.all(writePending);
       if (
@@ -354,6 +356,7 @@ export const useVaultState = () => {
         && writePending[1] === keysWritePendingRef.current
         && writePending[2] === identitiesWritePendingRef.current
         && writePending[3] === groupConfigsWritePendingRef.current
+        && writePending[4] === snippetsWritePendingRef.current
         && encryptPending[0] === hostsEncryptPendingRef.current
         && encryptPending[1] === keysEncryptPendingRef.current
         && encryptPending[2] === identitiesEncryptPendingRef.current
@@ -597,12 +600,22 @@ export const useVaultState = () => {
 
   const updateSnippets = useCallback((data: Snippet[]) => {
     const cleaned = normalizeVaultOrder(data);
-    ++snippetsWriteVersion.current;
+    const ver = ++snippetsWriteVersion.current;
     // Keep live snapshot ahead of React commit so same-tick readers (delete,
     // agent bridge) do not observe a stale pre-write array.
     snippetsRef.current = cleaned;
     setSnippets(cleaned);
-    localStorageAdapter.write(STORAGE_KEY_SNIPPETS, cleaned);
+    // Serialize with deleteSelectedSnippets / plugin importer under the shared
+    // vault lock. A direct unlocked write can land between delete's raw read
+    // and journal commit, so bulk-delete would persist an older snapshot and
+    // discard the concurrent edit/import/reorder.
+    const writePromise = withVaultImportLock("vault", async () => {
+      if (ver !== snippetsWriteVersion.current) return "superseded" as const;
+      localStorageAdapter.write(STORAGE_KEY_SNIPPETS, cleaned);
+      return "written" as const;
+    });
+    snippetsWritePendingRef.current = writePromise;
+    return writePromise;
   }, []);
 
   // Cross-window safe: merge binding cleanup into the latest persisted
@@ -677,6 +690,7 @@ export const useVaultState = () => {
         setHosts(result.hosts);
         setSnippets(result.snippets);
         hostsWritePendingRef.current = Promise.resolve("unchanged" as const);
+        snippetsWritePendingRef.current = Promise.resolve("unchanged" as const);
         return result;
       });
       if (attempt !== null) return attempt;
@@ -1612,7 +1626,9 @@ export const useVaultState = () => {
       if (payload.keys) encryptedWrites.push(updateKeys(payload.keys));
       if (payload.identities) encryptedWrites.push(updateIdentities(payload.identities));
       if (Array.isArray(payload.proxyProfiles)) encryptedWrites.push(updateProxyProfiles(payload.proxyProfiles));
-      if (payload.snippets) updateSnippets(payload.snippets);
+      if (payload.snippets) {
+        encryptedWrites.push(updateSnippets(payload.snippets).then(() => undefined));
+      }
       if (payload.customGroups) updateCustomGroups(payload.customGroups);
       if (payload.snippetPackages) updateSnippetPackages(payload.snippetPackages);
       if (payload.notes) updateNotes(payload.notes);

--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -64,6 +64,7 @@ import {
   type ConnectionLogTerminalDataMap,
 } from "../../domain/connectionLogTerminalData";
 import { getNextVaultOrder, normalizeVaultOrder } from "../../domain/vaultOrder";
+import { deleteSelectedSnippetsFromVault } from "../../domain/snippetSelection";
 import { loadSanitizedShellHistory } from "./shellHistoryPersistence";
 import {
   publishConnectionLogsSnapshot,
@@ -290,12 +291,14 @@ export const useVaultState = () => {
   const customGroupsRef = useRef<string[]>([]);
   const managedSourcesRef = useRef<ManagedSource[]>([]);
   const hostsRef = useRef<Host[]>([]);
+  const snippetsRef = useRef<Snippet[]>([]);
   const notesRef = useRef<VaultNote[]>([]);
   const noteGroupsRef = useRef<string[]>([]);
   const notesPersistFailureNotifiedAtRef = useRef(0);
   customGroupsRef.current = customGroups;
   managedSourcesRef.current = managedSources;
   hostsRef.current = hosts;
+  snippetsRef.current = snippets;
   notesRef.current = notes;
   noteGroupsRef.current = noteGroups;
 
@@ -595,9 +598,27 @@ export const useVaultState = () => {
   const updateSnippets = useCallback((data: Snippet[]) => {
     const cleaned = normalizeVaultOrder(data);
     ++snippetsWriteVersion.current;
+    // Keep live snapshot ahead of React commit so same-tick readers (delete,
+    // agent bridge) do not observe a stale pre-write array.
+    snippetsRef.current = cleaned;
     setSnippets(cleaned);
     localStorageAdapter.write(STORAGE_KEY_SNIPPETS, cleaned);
   }, []);
+
+  // Delete against useVaultState's live hosts/snippets refs so a concurrent
+  // vault mutation that has already advanced those refs (but not yet
+  // re-rendered AppSideEffects) is not discarded by writing a stale snapshot.
+  const deleteSelectedSnippets = useCallback((selectedSnippetIds: ReadonlySet<string>) => {
+    const result = deleteSelectedSnippetsFromVault(
+      snippetsRef.current,
+      hostsRef.current,
+      selectedSnippetIds,
+    );
+    if (result.deletedCount === 0) return result;
+    updateSnippets(result.snippets);
+    void updateHosts(result.hosts);
+    return result;
+  }, [updateHosts, updateSnippets]);
 
   const updateSnippetPackages = useCallback((data: string[]) => {
     setSnippetPackages(data);
@@ -1720,6 +1741,7 @@ export const useVaultState = () => {
     updateIdentities,
     updateProxyProfiles,
     updateSnippets,
+    deleteSelectedSnippets,
     updateSnippetPackages,
     updateNotes,
     updateNoteGroups,

--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -652,8 +652,12 @@ export const useVaultState = () => {
 
         ++hostsWriteVersion.current;
         ++snippetsWriteVersion.current;
-        localStorageAdapter.write(STORAGE_KEY_HOSTS, encryptedHosts);
-        localStorageAdapter.write(STORAGE_KEY_SNIPPETS, result.snippets);
+        // Journaled pair write: a partial hosts/snippets persist would drop
+        // login/connect bindings on restart while leaving the snippets behind.
+        commitPluginImporterTransaction(localStorageAdapter, [
+          [STORAGE_KEY_HOSTS, encryptedHosts],
+          [STORAGE_KEY_SNIPPETS, result.snippets],
+        ]);
         hostsRef.current = result.hosts;
         snippetsRef.current = result.snippets;
         setHosts(result.hosts);

--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -605,20 +605,65 @@ export const useVaultState = () => {
     localStorageAdapter.write(STORAGE_KEY_SNIPPETS, cleaned);
   }, []);
 
-  // Delete against useVaultState's live hosts/snippets refs so a concurrent
-  // vault mutation that has already advanced those refs (but not yet
-  // re-rendered AppSideEffects) is not discarded by writing a stale snapshot.
-  const deleteSelectedSnippets = useCallback((selectedSnippetIds: ReadonlySet<string>) => {
-    const result = deleteSelectedSnippetsFromVault(
-      snippetsRef.current,
-      hostsRef.current,
-      selectedSnippetIds,
-    );
-    if (result.deletedCount === 0) return result;
-    updateSnippets(result.snippets);
-    void updateHosts(result.hosts);
-    return result;
-  }, [updateHosts, updateSnippets]);
+  // Cross-window safe: merge binding cleanup into the latest persisted
+  // hosts/snippets under the shared vault lock. Popup terminals own a separate
+  // useVaultState instance — writing hostsRef from that window can discard a
+  // main-window host edit, or a storage-event version bump can cancel the host
+  // write after snippets were already removed.
+  const deleteSelectedSnippets = useCallback(async (selectedSnippetIds: ReadonlySet<string>) => {
+    if (selectedSnippetIds.size === 0) {
+      return {
+        snippets: snippetsRef.current,
+        hosts: hostsRef.current,
+        deletedCount: 0,
+      };
+    }
+
+    while (true) {
+      await waitForPendingVaultWrites();
+      const attempt = await withVaultImportLock("vault", async () => {
+        const writeVersions = {
+          hosts: hostsWriteVersion.current,
+          snippets: snippetsWriteVersion.current,
+        };
+        const rawHosts = localStorageAdapter.readString(STORAGE_KEY_HOSTS);
+        const rawSnippets = localStorageAdapter.readString(STORAGE_KEY_SNIPPETS);
+        const storedHosts = readStoredArray<Host>(STORAGE_KEY_HOSTS, rawHosts);
+        const storedSnippets = readStoredArray<Snippet>(STORAGE_KEY_SNIPPETS, rawSnippets);
+        const latestHosts = normalizeVaultOrder(
+          (await decryptHosts(storedHosts)).map((host) => sanitizeHost(host)),
+        );
+        const latestSnippets = normalizeVaultOrder(storedSnippets);
+        const result = deleteSelectedSnippetsFromVault(
+          latestSnippets,
+          latestHosts,
+          selectedSnippetIds,
+        );
+        if (result.deletedCount === 0) return result;
+
+        const encryptedHosts = await encryptHosts(result.hosts);
+        const changedWhilePreparing = (
+          writeVersions.hosts !== hostsWriteVersion.current
+          || writeVersions.snippets !== snippetsWriteVersion.current
+          || localStorageAdapter.readString(STORAGE_KEY_HOSTS) !== rawHosts
+          || localStorageAdapter.readString(STORAGE_KEY_SNIPPETS) !== rawSnippets
+        );
+        if (changedWhilePreparing) return null;
+
+        ++hostsWriteVersion.current;
+        ++snippetsWriteVersion.current;
+        localStorageAdapter.write(STORAGE_KEY_HOSTS, encryptedHosts);
+        localStorageAdapter.write(STORAGE_KEY_SNIPPETS, result.snippets);
+        hostsRef.current = result.hosts;
+        snippetsRef.current = result.snippets;
+        setHosts(result.hosts);
+        setSnippets(result.snippets);
+        hostsWritePendingRef.current = Promise.resolve("unchanged" as const);
+        return result;
+      });
+      if (attempt !== null) return attempt;
+    }
+  }, [waitForPendingVaultWrites]);
 
   const updateSnippetPackages = useCallback((data: string[]) => {
     setSnippetPackages(data);

--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -654,10 +654,24 @@ export const useVaultState = () => {
         ++snippetsWriteVersion.current;
         // Journaled pair write: a partial hosts/snippets persist would drop
         // login/connect bindings on restart while leaving the snippets behind.
-        commitPluginImporterTransaction(localStorageAdapter, [
-          [STORAGE_KEY_HOSTS, encryptedHosts],
-          [STORAGE_KEY_SNIPPETS, result.snippets],
-        ]);
+        // Callers fire-and-forget this promise after closing the confirm dialog,
+        // so storage rejection must not become an unhandled rejection.
+        try {
+          commitPluginImporterTransaction(localStorageAdapter, [
+            [STORAGE_KEY_HOSTS, encryptedHosts],
+            [STORAGE_KEY_SNIPPETS, result.snippets],
+          ]);
+        } catch {
+          notify.error(
+            "Snippets could not be deleted. Free some local storage space and try again.",
+            "Scripts",
+          );
+          return {
+            snippets: latestSnippets,
+            hosts: latestHosts,
+            deletedCount: 0,
+          };
+        }
         hostsRef.current = result.hosts;
         snippetsRef.current = result.snippets;
         setHosts(result.hosts);

--- a/components/ScriptsSidePanel.test.ts
+++ b/components/ScriptsSidePanel.test.ts
@@ -92,6 +92,15 @@ test("scripts side panel confirms bulk delete and routes it through the shared d
   );
 });
 
+test("scripts side panel defers bulk-delete confirm when a parent owns the dialog", () => {
+  // Compact TerminalToolbar nests this panel in a Popover; the portalled confirm
+  // must be owned outside that tree so focus cannot unmount the prompt.
+  assert.match(source, /onBulkDeleteRequest\?:/);
+  assert.match(source, /if\s*\(\s*onBulkDeleteRequest\s*\)\s*\{/);
+  assert.match(source, /onBulkDeleteRequest\(ids\)/);
+  assert.match(source, /!onBulkDeleteRequest/);
+});
+
 test("scripts side panel clears pending bulk delete when the panel hides", () => {
   // Returning null while isVisible is false unmounts the confirm dialog; drop
   // pending deletes so a later re-show does not resurrect a half-dismissed prompt.

--- a/components/ScriptsSidePanel.test.ts
+++ b/components/ScriptsSidePanel.test.ts
@@ -79,6 +79,19 @@ test("scripts side panel toolbar exposes expand, collapse, and delete-selected a
   assert.match(source, /isMultiSelectMode/);
 });
 
+test("scripts side panel confirms bulk delete and routes it through the shared delete event", () => {
+  // Mass-delete must confirm first (SnippetsManager parity) and must not bypass
+  // AppSideEffects via onSnippetsChange filtering — that path skips host binding cleanup.
+  assert.match(source, /VaultDeleteConfirmDialog/);
+  assert.match(source, /snippets\.selection\.deleteConfirmTitle/);
+  assert.match(source, /snippets\.selection\.deleteConfirmDesc/);
+  assert.match(source, /detail:\s*\{\s*ids\s*\}/);
+  assert.doesNotMatch(
+    source,
+    /onSnippetsChange\(snippets\.filter\(\(snippet\) => !selectedSnippetIds\.has/,
+  );
+});
+
 test("scripts side panel package dialog traps focus and exposes dialog close contract", () => {
   assert.match(source, /packageDialogRef/);
   assert.match(source, /data-dialog-close="true"/);

--- a/components/ScriptsSidePanel.test.ts
+++ b/components/ScriptsSidePanel.test.ts
@@ -2,7 +2,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-import { buildScriptsSidePanelRows } from "./ScriptsSidePanel.tsx";
+import {
+  buildScriptsSidePanelRows,
+  collectScriptsSidePanelPackagePaths,
+} from "./ScriptsSidePanel.tsx";
 import type { Snippet } from "../types";
 
 const snippet = (overrides: Partial<Snippet>): Snippet => ({
@@ -54,6 +57,26 @@ test("scripts side panel add control is a split button with secondary create act
   assert.match(source, /ChevronDown/);
   assert.match(source, /snippets\.action\.newScript/);
   assert.match(source, /snippets\.action\.newSnippet/);
+});
+
+test("collectScriptsSidePanelPackagePaths includes implied ancestors", () => {
+  assert.deepEqual(
+    collectScriptsSidePanelPackagePaths(["ops/linux"], [
+      snippet({ id: "a", package: "ops/linux/disk" }),
+      snippet({ id: "b", package: "" }),
+    ]).sort(),
+    ["ops", "ops/linux", "ops/linux/disk"],
+  );
+});
+
+test("scripts side panel toolbar exposes expand, collapse, and delete-selected actions", () => {
+  assert.match(source, /vault\.tree\.expandAll/);
+  assert.match(source, /vault\.tree\.collapseAll/);
+  assert.match(source, /snippets\.selection\.deleteSelected/);
+  assert.match(source, /expandAllGroups/);
+  assert.match(source, /collapseAllGroups/);
+  assert.match(source, /deleteSelectedSnippets/);
+  assert.match(source, /isMultiSelectMode/);
 });
 
 test("scripts side panel package dialog traps focus and exposes dialog close contract", () => {

--- a/components/ScriptsSidePanel.test.ts
+++ b/components/ScriptsSidePanel.test.ts
@@ -92,6 +92,15 @@ test("scripts side panel confirms bulk delete and routes it through the shared d
   );
 });
 
+test("scripts side panel clears pending bulk delete when the panel hides", () => {
+  // Returning null while isVisible is false unmounts the confirm dialog; drop
+  // pending deletes so a later re-show does not resurrect a half-dismissed prompt.
+  assert.match(
+    source,
+    /if\s*\(\s*!isVisible\s*\)\s*setPendingDeleteIds\(\s*null\s*\)/,
+  );
+});
+
 test("scripts side panel package dialog traps focus and exposes dialog close contract", () => {
   assert.match(source, /packageDialogRef/);
   assert.match(source, /data-dialog-close="true"/);

--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -389,6 +389,10 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
     });
   }, [snippets]);
 
+  useEffect(() => {
+    if (!isVisible) setPendingDeleteIds(null);
+  }, [isVisible]);
+
   const toggleSnippetSelection = useCallback((id: string) => {
     setSelectedSnippetIds((prev) => {
       const next = new Set(prev);

--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -7,7 +7,22 @@
  * list of matching snippets regardless of package nesting.
  */
 
-import { ChevronDown, ChevronRight, Edit2, FolderPlus, Layers, Package, Play, Plus, Search, Trash2, Zap } from 'lucide-react';
+import {
+  CheckSquare,
+  ChevronDown,
+  ChevronRight,
+  Edit2,
+  Expand,
+  FolderPlus,
+  Layers,
+  Minimize2,
+  Package,
+  Play,
+  Plus,
+  Search,
+  Trash2,
+  Zap,
+} from 'lucide-react';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { useI18n } from '../application/i18n/I18nProvider';
 import { getScriptRecordingSnapshot, subscribeScriptRecording } from '../application/state/scriptRecordingStore.ts';
@@ -32,6 +47,9 @@ import { Label } from './ui/label';
 import { SnippetCommandTooltipContent } from './snippets/SnippetCommandTooltipContent';
 import { TERMINAL_SIDE_PANEL_INNER_HEADER_CLASS } from './terminalLayer/terminalSidePanelChrome';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
+
+const toolbarIconButtonClass =
+  'h-7 w-7 shrink-0 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors disabled:opacity-40 disabled:pointer-events-none';
 
 const SCRIPT_ROW_HEIGHT = 34;
 
@@ -126,15 +144,11 @@ const getVerticalDropIntent = (
 const hasDragType = (dataTransfer: DataTransfer, type: string) =>
   Array.from(dataTransfer.types).includes(type);
 
-export function buildScriptsSidePanelRows({
-  snippets,
-  packages,
-  expandedPaths,
-}: {
-  snippets: Snippet[];
-  packages: string[];
-  expandedPaths: Set<string>;
-}): TreeRow[] {
+/** Collect every package path (including implied ancestors) shown in the tree. */
+export function collectScriptsSidePanelPackagePaths(
+  packages: string[],
+  snippets: Snippet[],
+): string[] {
   const normalizedPackages = new Set<string>();
   const addWithAncestors = (raw: string) => {
     const path = raw.trim();
@@ -152,6 +166,19 @@ export function buildScriptsSidePanelRows({
   snippets.forEach((snippet) => {
     if (snippet.package) addWithAncestors(snippet.package);
   });
+  return Array.from(normalizedPackages);
+}
+
+export function buildScriptsSidePanelRows({
+  snippets,
+  packages,
+  expandedPaths,
+}: {
+  snippets: Snippet[];
+  packages: string[];
+  expandedPaths: Set<string>;
+}): TreeRow[] {
+  const normalizedPackages = new Set(collectScriptsSidePanelPackagePaths(packages, snippets));
 
   const snippetsByPackage = new Map<string, Snippet[]>();
   const descendantCountByPackage = new Map<string, number>();
@@ -255,6 +282,8 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
   const [search, setSearch] = useState('');
   const [subView, setSubView] = useState<'library' | 'running'>('library');
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
+  const [isMultiSelectMode, setIsMultiSelectMode] = useState(false);
+  const [selectedSnippetIds, setSelectedSnippetIds] = useState<Set<string>>(new Set());
   const [isPackageDialogOpen, setIsPackageDialogOpen] = useState(false);
   const [newPackageName, setNewPackageName] = useState('');
   const [packageError, setPackageError] = useState('');
@@ -290,24 +319,7 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
   // (e.g. package "a/b/c" implies roots "a" and "a/b" even when not listed).
   const normalizedPackages = useMemo(() => {
     if (!isVisible) return new Set<string>();
-    const set = new Set<string>();
-    const addWithAncestors = (raw: string) => {
-      const path = raw.trim();
-      if (!path) return;
-      const isAbs = path.startsWith('/');
-      const body = isAbs ? path.slice(1) : path;
-      const parts = body.split('/').filter(Boolean);
-      for (let i = 1; i <= parts.length; i++) {
-        const sub = parts.slice(0, i).join('/');
-        set.add(isAbs ? `/${sub}` : sub);
-      }
-    };
-    packages.forEach(addWithAncestors);
-    // A snippet may reference a package path that's not in `packages` yet.
-    snippets.forEach((s) => {
-      if (s.package) addWithAncestors(s.package);
-    });
-    return set;
+    return new Set(collectScriptsSidePanelPackagePaths(packages, snippets));
   }, [packages, snippets, isVisible]);
 
   // Track every package we've ever observed so we can tell "new" from
@@ -347,6 +359,55 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
       return next;
     });
   }, []);
+
+  const expandAllGroups = useCallback(() => {
+    setExpandedPaths(new Set(normalizedPackages));
+  }, [normalizedPackages]);
+
+  const collapseAllGroups = useCallback(() => {
+    setExpandedPaths(new Set());
+  }, []);
+
+  const clearSnippetSelection = useCallback(() => {
+    setSelectedSnippetIds(new Set());
+    setIsMultiSelectMode(false);
+  }, []);
+
+  useEffect(() => {
+    setSelectedSnippetIds((prev) => {
+      if (prev.size === 0) return prev;
+      const alive = new Set(snippets.map((snippet) => snippet.id));
+      let changed = false;
+      const next = new Set<string>();
+      prev.forEach((id) => {
+        if (alive.has(id)) next.add(id);
+        else changed = true;
+      });
+      return changed ? next : prev;
+    });
+  }, [snippets]);
+
+  const toggleSnippetSelection = useCallback((id: string) => {
+    setSelectedSnippetIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const deleteSelectedSnippets = useCallback(() => {
+    if (selectedSnippetIds.size === 0) return;
+    const ids = Array.from(selectedSnippetIds);
+    if (onSnippetsChange) {
+      onSnippetsChange(snippets.filter((snippet) => !selectedSnippetIds.has(snippet.id)));
+    } else {
+      window.dispatchEvent(
+        new CustomEvent('netcatty:snippets:delete', { detail: { ids } }),
+      );
+    }
+    clearSnippetSelection();
+  }, [clearSnippetSelection, onSnippetsChange, selectedSnippetIds, snippets]);
 
   // When search is active, flatten everything (no tree, no packages).
   const searchMatches = useMemo(() => {
@@ -400,6 +461,10 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
 
   const handleSnippetClick = useCallback(
     (snippet: Snippet) => {
+      if (isMultiSelectMode) {
+        toggleSnippetSelection(snippet.id);
+        return;
+      }
       if (isScriptSnippet(snippet)) {
         onRunScript?.(snippet);
         setSubView('running');
@@ -407,8 +472,11 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
       }
       onSnippetClick(snippet);
     },
-    [onRunScript, onSnippetClick],
+    [isMultiSelectMode, onRunScript, onSnippetClick, toggleSnippetSelection],
   );
+
+  const hasSearch = search.trim().length > 0;
+  const canExpandCollapse = normalizedPackages.size > 0 && !hasSearch;
 
   const sessionRuns = useMemo(() => {
     if (!focusedSessionId) return runs;
@@ -757,8 +825,8 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
         </div>
       ) : (
       <>
-      {/* Search + Add */}
-      <div className="shrink-0 px-2 py-1.5 border-b border-border/50 flex items-center gap-1.5">
+      {/* Search + tree actions + Add */}
+      <div className="shrink-0 px-2 py-1.5 border-b border-border/50 flex items-center gap-1">
         <div className="relative flex-1 min-w-0">
           <Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
           <Input
@@ -768,6 +836,76 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
             className="h-7 pl-7 text-xs bg-muted/30 border-none"
           />
         </div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className={toolbarIconButtonClass}
+              disabled={!canExpandCollapse}
+              aria-label={t('vault.tree.expandAll')}
+              onClick={expandAllGroups}
+            >
+              <Expand size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{t('vault.tree.expandAll')}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className={toolbarIconButtonClass}
+              disabled={!canExpandCollapse}
+              aria-label={t('vault.tree.collapseAll')}
+              onClick={collapseAllGroups}
+            >
+              <Minimize2 size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{t('vault.tree.collapseAll')}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className={cn(
+                toolbarIconButtonClass,
+                isMultiSelectMode && 'bg-muted/70 text-foreground',
+              )}
+              aria-label={t('snippets.action.selectSnippets')}
+              aria-pressed={isMultiSelectMode}
+              onClick={() => {
+                if (isMultiSelectMode) {
+                  clearSnippetSelection();
+                } else {
+                  setIsMultiSelectMode(true);
+                }
+              }}
+            >
+              <CheckSquare size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{t('snippets.action.selectSnippets')}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className={cn(
+                toolbarIconButtonClass,
+                selectedSnippetIds.size > 0 && 'text-destructive hover:text-destructive',
+              )}
+              disabled={selectedSnippetIds.size === 0}
+              aria-label={t('snippets.selection.deleteSelected', { count: selectedSnippetIds.size })}
+              onClick={deleteSelectedSnippets}
+            >
+              <Trash2 size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {t('snippets.selection.deleteSelected', { count: selectedSnippetIds.size })}
+          </TooltipContent>
+        </Tooltip>
         {/* Split add control: primary = new snippet; menu = package / automation script */}
         <div className="shrink-0 flex items-center">
           <Tooltip>
@@ -862,6 +1000,8 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
                     snippet={item.snippet}
                     depth={0}
                     subtitle={item.snippet.package || t('terminal.toolbar.library')}
+                    selected={selectedSnippetIds.has(item.snippet.id)}
+                    multiSelect={isMultiSelectMode}
                     draggable={false}
                     sortableTarget={false}
                     onDragOver={handleRowDragOver}
@@ -904,7 +1044,9 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
                   <SnippetRow
                     snippet={item.row.snippet}
                     depth={item.row.depth}
-                    draggable={Boolean(onSnippetsChange)}
+                    selected={selectedSnippetIds.has(item.row.snippet.id)}
+                    multiSelect={isMultiSelectMode}
+                    draggable={Boolean(onSnippetsChange) && !isMultiSelectMode}
                     sortableTarget={true}
                     onDragOver={handleRowDragOver}
                     onDrop={handleRowDrop}
@@ -1102,6 +1244,8 @@ interface SnippetRowProps {
   snippet: Snippet;
   depth: number;
   subtitle?: string;
+  selected?: boolean;
+  multiSelect?: boolean;
   draggable: boolean;
   sortableTarget: boolean;
   onDragOver: (event: React.DragEvent<HTMLElement>) => void;
@@ -1122,6 +1266,8 @@ const SnippetRow = memo<SnippetRowProps>(({
   snippet,
   depth,
   subtitle,
+  selected = false,
+  multiSelect = false,
   draggable,
   sortableTarget,
   onDragOver,
@@ -1157,13 +1303,25 @@ const SnippetRow = memo<SnippetRowProps>(({
             <button
               type="button"
               onClick={onClick}
-              className="w-full flex items-center gap-1.5 pr-3 py-1.5 text-left hover:bg-accent/50 transition-colors overflow-hidden"
+              aria-pressed={multiSelect ? selected : undefined}
+              className={cn(
+                'w-full flex items-center gap-1.5 pr-3 py-1.5 text-left hover:bg-accent/50 transition-colors overflow-hidden',
+                selected && 'bg-primary/10 hover:bg-primary/15',
+              )}
               style={{ paddingLeft: 8 + depth * 14 }}
             >
               {/* Hidden chevron column mirrors PackageRow's layout so the
                   snippet icon lines up exactly with the package icon above. */}
               <ChevronRight size={12} className="shrink-0 opacity-0" aria-hidden />
-              {isScriptSnippet(snippet) ? (
+              {multiSelect ? (
+                <CheckSquare
+                  size={12}
+                  className={cn(
+                    'shrink-0',
+                    selected ? 'text-primary' : 'text-muted-foreground/70',
+                  )}
+                />
+              ) : isScriptSnippet(snippet) ? (
                 <Play size={12} className="shrink-0 text-primary" />
               ) : (
                 <Zap size={12} className="shrink-0 text-muted-foreground" />

--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -26,6 +26,7 @@ import {
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { useI18n } from '../application/i18n/I18nProvider';
 import { getScriptRecordingSnapshot, subscribeScriptRecording } from '../application/state/scriptRecordingStore.ts';
+import { VaultDeleteConfirmDialog } from './vault/VaultDeleteConfirmDialog';
 import { reorderVaultItems, reorderVaultStrings, sortByVaultOrder } from '../domain/vaultOrder';
 import { isScriptSnippet } from '../domain/snippetScript.ts';
 import { cn } from '../lib/utils';
@@ -284,6 +285,7 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
   const [isMultiSelectMode, setIsMultiSelectMode] = useState(false);
   const [selectedSnippetIds, setSelectedSnippetIds] = useState<Set<string>>(new Set());
+  const [pendingDeleteIds, setPendingDeleteIds] = useState<string[] | null>(null);
   const [isPackageDialogOpen, setIsPackageDialogOpen] = useState(false);
   const [newPackageName, setNewPackageName] = useState('');
   const [packageError, setPackageError] = useState('');
@@ -397,17 +399,33 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
   }, []);
 
   const deleteSelectedSnippets = useCallback(() => {
-    if (selectedSnippetIds.size === 0) return;
-    const ids = Array.from(selectedSnippetIds);
-    if (onSnippetsChange) {
-      onSnippetsChange(snippets.filter((snippet) => !selectedSnippetIds.has(snippet.id)));
-    } else {
-      window.dispatchEvent(
-        new CustomEvent('netcatty:snippets:delete', { detail: { ids } }),
-      );
+    const ids = snippets
+      .filter((snippet) => selectedSnippetIds.has(snippet.id))
+      .map((snippet) => snippet.id);
+    if (ids.length === 0) return;
+    setPendingDeleteIds(ids);
+  }, [selectedSnippetIds, snippets]);
+
+  const existingPendingDeleteIds = pendingDeleteIds
+    ? pendingDeleteIds.filter((id) => snippets.some((snippet) => snippet.id === id))
+    : [];
+
+  const confirmDeleteSelectedSnippets = useCallback(() => {
+    const ids = (pendingDeleteIds ?? []).filter((id) =>
+      snippets.some((snippet) => snippet.id === id),
+    );
+    setPendingDeleteIds(null);
+    if (ids.length === 0) {
+      clearSnippetSelection();
+      return;
     }
+    // Always route through the shared event so AppSideEffects can clear host
+    // login/connect bindings (onSnippetsChange alone would leave them stale).
+    window.dispatchEvent(
+      new CustomEvent('netcatty:snippets:delete', { detail: { ids } }),
+    );
     clearSnippetSelection();
-  }, [clearSnippetSelection, onSnippetsChange, selectedSnippetIds, snippets]);
+  }, [clearSnippetSelection, pendingDeleteIds, snippets]);
 
   // When search is active, flatten everything (no tree, no packages).
   const searchMatches = useMemo(() => {
@@ -1193,6 +1211,18 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
           </div>
         </div>
       ) : null}
+
+      <VaultDeleteConfirmDialog
+        open={Boolean(pendingDeleteIds)}
+        title={t('snippets.selection.deleteConfirmTitle', {
+          count: existingPendingDeleteIds.length,
+        })}
+        description={t('snippets.selection.deleteConfirmDesc')}
+        onOpenChange={(open) => {
+          if (!open) setPendingDeleteIds(null);
+        }}
+        onConfirm={confirmDeleteSelectedSnippets}
+      />
     </div>
     </TooltipProvider>
   );

--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -74,6 +74,12 @@ interface ScriptsSidePanelProps {
   onResumeRun?: (runId: string) => void;
   onStartRecording?: () => void;
   focusedSessionId?: string;
+  /**
+   * When set, bulk-delete confirmation is owned by the parent. Required when
+   * this panel is nested in a Popover — the portalled confirm would otherwise
+   * steal focus, dismiss the popover, and unmount the prompt.
+   */
+  onBulkDeleteRequest?: (ids: string[]) => void;
 }
 
 type TreeRow =
@@ -278,6 +284,7 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
   onResumeRun,
   onStartRecording,
   focusedSessionId,
+  onBulkDeleteRequest,
 }) => {
   const { t } = useI18n();
   const [search, setSearch] = useState('');
@@ -393,6 +400,19 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
     if (!isVisible) setPendingDeleteIds(null);
   }, [isVisible]);
 
+  // Parent-owned confirm (compact toolbar popover) dispatches the shared delete
+  // event; clear local multi-select when that bulk delete lands.
+  useEffect(() => {
+    if (!onBulkDeleteRequest) return;
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ ids?: string[] }>).detail;
+      if (!detail?.ids?.length) return;
+      clearSnippetSelection();
+    };
+    window.addEventListener('netcatty:snippets:delete', handler);
+    return () => window.removeEventListener('netcatty:snippets:delete', handler);
+  }, [clearSnippetSelection, onBulkDeleteRequest]);
+
   const toggleSnippetSelection = useCallback((id: string) => {
     setSelectedSnippetIds((prev) => {
       const next = new Set(prev);
@@ -407,8 +427,12 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
       .filter((snippet) => selectedSnippetIds.has(snippet.id))
       .map((snippet) => snippet.id);
     if (ids.length === 0) return;
+    if (onBulkDeleteRequest) {
+      onBulkDeleteRequest(ids);
+      return;
+    }
     setPendingDeleteIds(ids);
-  }, [selectedSnippetIds, snippets]);
+  }, [onBulkDeleteRequest, selectedSnippetIds, snippets]);
 
   const existingPendingDeleteIds = pendingDeleteIds
     ? pendingDeleteIds.filter((id) => snippets.some((snippet) => snippet.id === id))
@@ -1216,17 +1240,19 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
         </div>
       ) : null}
 
-      <VaultDeleteConfirmDialog
-        open={Boolean(pendingDeleteIds)}
-        title={t('snippets.selection.deleteConfirmTitle', {
-          count: existingPendingDeleteIds.length,
-        })}
-        description={t('snippets.selection.deleteConfirmDesc')}
-        onOpenChange={(open) => {
-          if (!open) setPendingDeleteIds(null);
-        }}
-        onConfirm={confirmDeleteSelectedSnippets}
-      />
+      {!onBulkDeleteRequest ? (
+        <VaultDeleteConfirmDialog
+          open={Boolean(pendingDeleteIds)}
+          title={t('snippets.selection.deleteConfirmTitle', {
+            count: existingPendingDeleteIds.length,
+          })}
+          description={t('snippets.selection.deleteConfirmDesc')}
+          onOpenChange={(open) => {
+            if (!open) setPendingDeleteIds(null);
+          }}
+          onConfirm={confirmDeleteSelectedSnippets}
+        />
+      ) : null}
     </div>
     </TooltipProvider>
   );

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -247,6 +247,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   snippets,
   snippetPackages = [],
   compactToolbar = false,
+  onDeleteSnippets,
   lineTimestampsAvailable = true,
   chainHosts = EMPTY_CHAIN_HOSTS,
   appearanceTheme,
@@ -3615,6 +3616,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       snippets={snippets}
       snippetPackages={snippetPackages}
       onSnippetClick={(snippet) => { void executeSnippet(snippet); }}
+      onDeleteSnippets={onDeleteSnippets}
       onOpenSFTP={handleOpenSFTP}
       onSendYmodem={isSerialConnection ? handleSendYmodem : undefined}
       onReceiveYmodem={isSerialConnection ? handleReceiveYmodem : undefined}
@@ -3678,6 +3680,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     isSessionLogging,
     isWorkspaceComposeBarOpen,
     onCloseSession,
+    onDeleteSnippets,
     onOpenScripts,
     onOpenHistory,
     onOpenTheme,

--- a/components/TerminalPopupPage.test.ts
+++ b/components/TerminalPopupPage.test.ts
@@ -133,9 +133,12 @@ test('resolveTerminalPopupReuseId uses the explicit reuse id from the prepared s
 
 test('popup terminals resolve complete host config and pass jump hosts into Terminal', () => {
   assert.match(source, /proxyProfiles,\s+knownHosts,\s+snippets,\s+snippetPackages,\s+groupConfigs,/);
+  assert.match(source, /deleteSelectedSnippets,/);
   assert.match(source, /resolveTerminalPopupHost\(config,\s*hosts,\s*\{\s+groupConfigs,\s+proxyProfiles,/);
   assert.match(source, /resolveTerminalChainHosts\(\{\s+host,\s+hosts,\s+groupConfigs,\s+proxyProfiles,/);
   assert.match(source, /chainHosts=\{chainHosts\}/);
+  // Popup has no AppSideEffects listener; bulk delete must hit this vault instance.
+  assert.match(source, /onDeleteSnippets=\{deleteSelectedSnippets\}/);
 });
 
 test('popup provider tree mounts the plugin authentication host', () => {

--- a/components/TerminalPopupPage.tsx
+++ b/components/TerminalPopupPage.tsx
@@ -272,6 +272,7 @@ function TerminalPopupPageInner() {
     snippetPackages,
     groupConfigs,
     updateKnownHosts,
+    deleteSelectedSnippets,
   } = useVaultState();
   const [config, setConfig] = useState<TerminalPopupPayload | null>(null);
   const [terminalReady, setTerminalReady] = useState(false);
@@ -453,6 +454,7 @@ function TerminalPopupPageInner() {
               snippetPackages={snippetPackages}
               chainHosts={chainHosts}
               compactToolbar
+              onDeleteSnippets={deleteSelectedSnippets}
               lineTimestampsAvailable={false}
               knownHosts={effectiveKnownHosts}
               onAddKnownHost={handleAddKnownHost}

--- a/components/terminal/TerminalToolbar.test.ts
+++ b/components/terminal/TerminalToolbar.test.ts
@@ -9,10 +9,6 @@ import type { Host } from "../../types.ts";
 import { TerminalToolbar } from "./TerminalToolbar.tsx";
 
 const toolbarSource = readFileSync(new URL("./TerminalToolbar.tsx", import.meta.url), "utf8");
-const vaultDeleteConfirmSource = readFileSync(
-  new URL("../vault/VaultDeleteConfirmDialog.tsx", import.meta.url),
-  "utf8",
-);
 
 const sshHost: Host = {
   id: "host-1",
@@ -177,13 +173,20 @@ test("uses the terminal active button color for pressed toolbar actions", () => 
   );
 });
 
-test("compact scripts popover ignores dismiss while vault delete confirm is open", () => {
-  // ScriptsSidePanel's VaultDeleteConfirmDialog is portalled; without these
-  // guards the popover closes, isVisible flips, and pendingDeleteIds clears.
-  assert.match(vaultDeleteConfirmSource, /data-vault-delete-confirm="true"/);
-  assert.ok(
-    toolbarSource.includes('document.querySelector(\'[data-vault-delete-confirm="true"]\')'),
+test("compact scripts popover hosts bulk-delete confirm outside the popover", () => {
+  // Dialog focus leaves PopoverContent; if confirm stays inside ScriptsSidePanel,
+  // the popover closes, isVisible clears pendingDeleteIds, and the prompt dies.
+  assert.match(toolbarSource, /onBulkDeleteRequest=\{setPendingScriptDeleteIds\}/);
+  assert.match(toolbarSource, /<VaultDeleteConfirmDialog/);
+  assert.match(toolbarSource, /netcatty:snippets:delete/);
+  const scriptsPopoverIdx = toolbarSource.indexOf("open={scriptsPopoverOpen}");
+  const popoverEndIdx = toolbarSource.indexOf("</Popover>", scriptsPopoverIdx);
+  const dialogIdx = toolbarSource.indexOf("<VaultDeleteConfirmDialog", popoverEndIdx);
+  assert.ok(scriptsPopoverIdx >= 0, "scripts popover open binding");
+  assert.ok(popoverEndIdx > scriptsPopoverIdx, "scripts popover closes");
+  assert.ok(dialogIdx > popoverEndIdx, "confirm dialog is a sibling after the popover");
+  assert.equal(
+    toolbarSource.includes("document.querySelector('[data-vault-delete-confirm=\"true\"]')"),
+    false,
   );
-  assert.match(toolbarSource, /onFocusOutside=\{\(e\) => \{/);
-  assert.match(toolbarSource, /onInteractOutside=\{\(e\) => \{/);
 });

--- a/components/terminal/TerminalToolbar.test.ts
+++ b/components/terminal/TerminalToolbar.test.ts
@@ -1,11 +1,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { I18nProvider } from "../../application/i18n/I18nProvider.tsx";
 import type { Host } from "../../types.ts";
 import { TerminalToolbar } from "./TerminalToolbar.tsx";
+
+const toolbarSource = readFileSync(new URL("./TerminalToolbar.tsx", import.meta.url), "utf8");
+const vaultDeleteConfirmSource = readFileSync(
+  new URL("../vault/VaultDeleteConfirmDialog.tsx", import.meta.url),
+  "utf8",
+);
 
 const sshHost: Host = {
   id: "host-1",
@@ -168,4 +175,15 @@ test("uses the terminal active button color for pressed toolbar actions", () => 
     markup,
     /aria-label="Search terminal"[^>]*style="background-color:var\(--terminal-toolbar-btn-active\)"/,
   );
+});
+
+test("compact scripts popover ignores dismiss while vault delete confirm is open", () => {
+  // ScriptsSidePanel's VaultDeleteConfirmDialog is portalled; without these
+  // guards the popover closes, isVisible flips, and pendingDeleteIds clears.
+  assert.match(vaultDeleteConfirmSource, /data-vault-delete-confirm="true"/);
+  assert.ok(
+    toolbarSource.includes('document.querySelector(\'[data-vault-delete-confirm="true"]\')'),
+  );
+  assert.match(toolbarSource, /onFocusOutside=\{\(e\) => \{/);
+  assert.match(toolbarSource, /onInteractOutside=\{\(e\) => \{/);
 });

--- a/components/terminal/TerminalToolbar.test.ts
+++ b/components/terminal/TerminalToolbar.test.ts
@@ -178,6 +178,8 @@ test("compact scripts popover hosts bulk-delete confirm outside the popover", ()
   // the popover closes, isVisible clears pendingDeleteIds, and the prompt dies.
   assert.match(toolbarSource, /onBulkDeleteRequest=\{setPendingScriptDeleteIds\}/);
   assert.match(toolbarSource, /<VaultDeleteConfirmDialog/);
+  // Popup vault mutation goes through the prop; the event only clears popover selection.
+  assert.match(toolbarSource, /onDeleteSnippets\?\.\(new Set\(ids\)\)/);
   assert.match(toolbarSource, /netcatty:snippets:delete/);
   const scriptsPopoverIdx = toolbarSource.indexOf("open={scriptsPopoverOpen}");
   const popoverEndIdx = toolbarSource.indexOf("</Popover>", scriptsPopoverIdx);

--- a/components/terminal/TerminalToolbar.tsx
+++ b/components/terminal/TerminalToolbar.tsx
@@ -91,6 +91,8 @@ export interface TerminalToolbarProps {
   snippets?: Snippet[];
   snippetPackages?: string[];
   onSnippetClick?: (snippet: Snippet) => void;
+  /** Popup vault mutation path — compact toolbar has no AppSideEffects listener. */
+  onDeleteSnippets?: (ids: ReadonlySet<string>) => void;
   onOpenSFTP: () => void;
   onSendYmodem?: () => void;
   onReceiveYmodem?: () => void;
@@ -128,6 +130,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
   snippets = [],
   snippetPackages = [],
   onSnippetClick,
+  onDeleteSnippets,
   onOpenSFTP,
   onSendYmodem,
   onReceiveYmodem,
@@ -409,6 +412,9 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
             );
             setPendingScriptDeleteIds(null);
             if (ids.length === 0) return;
+            // Popup terminals own vault state locally (no AppSideEffects).
+            onDeleteSnippets?.(new Set(ids));
+            // Still emit so ScriptsSidePanel can clear multi-select in the popover.
             window.dispatchEvent(
               new CustomEvent('netcatty:snippets:delete', { detail: { ids } }),
             );

--- a/components/terminal/TerminalToolbar.tsx
+++ b/components/terminal/TerminalToolbar.tsx
@@ -356,7 +356,17 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
           <TooltipContent side="bottom">{t('terminal.toolbar.searchTerminal')}</TooltipContent>
         </Tooltip>
 
-        <Popover open={scriptsPopoverOpen} onOpenChange={setScriptsPopoverOpen}>
+        <Popover
+          open={scriptsPopoverOpen}
+          onOpenChange={(open) => {
+            // Bulk-delete confirm is a portalled Dialog; focus moving into it
+            // would otherwise dismiss this popover and clear pendingDeleteIds.
+            if (!open && document.querySelector('[data-vault-delete-confirm="true"]')) {
+              return;
+            }
+            setScriptsPopoverOpen(open);
+          }}
+        >
           <Tooltip>
             <TooltipTrigger asChild>
               <PopoverTrigger asChild>
@@ -374,7 +384,22 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
             </TooltipTrigger>
             <TooltipContent side="bottom">{t('terminal.toolbar.scripts')}</TooltipContent>
           </Tooltip>
-          <PopoverContent className="w-80 p-0 h-80 flex flex-col overflow-hidden" align="end">
+          <PopoverContent
+            className="w-80 p-0 h-80 flex flex-col overflow-hidden"
+            align="end"
+            onFocusOutside={(e) => {
+              if (document.querySelector('[data-vault-delete-confirm="true"]')) {
+                e.preventDefault();
+              }
+            }}
+            onInteractOutside={(e) => {
+              // Same guard as the encoding submenu: portalled confirm UI is
+              // "outside" this popover and must not dismiss it.
+              if (document.querySelector('[data-vault-delete-confirm="true"]')) {
+                e.preventDefault();
+              }
+            }}
+          >
             <ScriptsSidePanel
               snippets={snippets}
               packages={snippetPackages}

--- a/components/terminal/TerminalToolbar.tsx
+++ b/components/terminal/TerminalToolbar.tsx
@@ -29,6 +29,7 @@ import type { ToolbarItemLayoutDefaults } from '../../domain/toolbarItemLayout';
 import { STORAGE_KEY_TERMINAL_TOOLBAR_LAYOUT } from '../../infrastructure/config/storageKeys';
 import { Host, Snippet } from '../../types';
 import { ScriptsSidePanel } from '../ScriptsSidePanel';
+import { VaultDeleteConfirmDialog } from '../vault/VaultDeleteConfirmDialog';
 import { Button } from '../ui/button';
 import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { ToolbarCustomizeContextMenu } from '../ui/toolbar-item-layout';
@@ -179,6 +180,12 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
     .sort(comparePluginMenus);
   const [highlightPopoverOpen, setHighlightPopoverOpen] = useState(false);
   const [scriptsPopoverOpen, setScriptsPopoverOpen] = useState(false);
+  // Owned outside the scripts Popover so portalled Dialog focus cannot dismiss
+  // the menu and unmount ScriptsSidePanel before the user confirms.
+  const [pendingScriptDeleteIds, setPendingScriptDeleteIds] = useState<string[] | null>(null);
+  const pendingScriptDeleteCount = (pendingScriptDeleteIds ?? []).filter((id) =>
+    snippets.some((snippet) => snippet.id === id),
+  ).length;
   // Overflow popover + encoding submenu are both controlled so that
   // picking an encoding closes the whole chain, and so the parent popover
   // can ignore clicks that land in the submenu portal (otherwise the
@@ -356,17 +363,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
           <TooltipContent side="bottom">{t('terminal.toolbar.searchTerminal')}</TooltipContent>
         </Tooltip>
 
-        <Popover
-          open={scriptsPopoverOpen}
-          onOpenChange={(open) => {
-            // Bulk-delete confirm is a portalled Dialog; focus moving into it
-            // would otherwise dismiss this popover and clear pendingDeleteIds.
-            if (!open && document.querySelector('[data-vault-delete-confirm="true"]')) {
-              return;
-            }
-            setScriptsPopoverOpen(open);
-          }}
-        >
+        <Popover open={scriptsPopoverOpen} onOpenChange={setScriptsPopoverOpen}>
           <Tooltip>
             <TooltipTrigger asChild>
               <PopoverTrigger asChild>
@@ -384,26 +381,12 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
             </TooltipTrigger>
             <TooltipContent side="bottom">{t('terminal.toolbar.scripts')}</TooltipContent>
           </Tooltip>
-          <PopoverContent
-            className="w-80 p-0 h-80 flex flex-col overflow-hidden"
-            align="end"
-            onFocusOutside={(e) => {
-              if (document.querySelector('[data-vault-delete-confirm="true"]')) {
-                e.preventDefault();
-              }
-            }}
-            onInteractOutside={(e) => {
-              // Same guard as the encoding submenu: portalled confirm UI is
-              // "outside" this popover and must not dismiss it.
-              if (document.querySelector('[data-vault-delete-confirm="true"]')) {
-                e.preventDefault();
-              }
-            }}
-          >
+          <PopoverContent className="w-80 p-0 h-80 flex flex-col overflow-hidden" align="end">
             <ScriptsSidePanel
               snippets={snippets}
               packages={snippetPackages}
               isVisible={scriptsPopoverOpen}
+              onBulkDeleteRequest={setPendingScriptDeleteIds}
               onSnippetClick={(snippet) => {
                 onSnippetClick?.(snippet);
                 setScriptsPopoverOpen(false);
@@ -411,6 +394,26 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
             />
           </PopoverContent>
         </Popover>
+        <VaultDeleteConfirmDialog
+          open={Boolean(pendingScriptDeleteIds)}
+          title={t('snippets.selection.deleteConfirmTitle', {
+            count: pendingScriptDeleteCount,
+          })}
+          description={t('snippets.selection.deleteConfirmDesc')}
+          onOpenChange={(open) => {
+            if (!open) setPendingScriptDeleteIds(null);
+          }}
+          onConfirm={() => {
+            const ids = (pendingScriptDeleteIds ?? []).filter((id) =>
+              snippets.some((snippet) => snippet.id === id),
+            );
+            setPendingScriptDeleteIds(null);
+            if (ids.length === 0) return;
+            window.dispatchEvent(
+              new CustomEvent('netcatty:snippets:delete', { detail: { ids } }),
+            );
+          }}
+        />
         </TooltipProvider>
       </div>
     );

--- a/components/terminal/terminalHelpers.ts
+++ b/components/terminal/terminalHelpers.ts
@@ -108,6 +108,8 @@ export interface TerminalProps {
   compactToolbar?: boolean;
   /** Line timestamps are unavailable in popup terminals that stream shell output without timestamp metadata. */
   lineTimestampsAvailable?: boolean;
+  /** Compact/popup path: delete snippets against the caller's vault hook. */
+  onDeleteSnippets?: (ids: ReadonlySet<string>) => void;
   chainHosts?: Host[];
   appearanceTheme?: TerminalTheme;
   knownHosts?: KnownHost[];

--- a/components/terminal/terminalMemo.ts
+++ b/components/terminal/terminalMemo.ts
@@ -15,6 +15,7 @@ export const terminalPropsAreEqual = (
   && prev.snippetPackages === next.snippetPackages
   && prev.compactToolbar === next.compactToolbar
   && prev.lineTimestampsAvailable === next.lineTimestampsAvailable
+  && prev.onDeleteSnippets === next.onDeleteSnippets
   && prev.chainHosts === next.chainHosts
   && themeFingerprint(prev.appearanceTheme ?? prev.terminalTheme) === themeFingerprint(next.appearanceTheme ?? next.terminalTheme)
   && prev.knownHosts === next.knownHosts

--- a/components/vault/VaultDeleteConfirmDialog.tsx
+++ b/components/vault/VaultDeleteConfirmDialog.tsx
@@ -93,10 +93,6 @@ export const VaultDeleteConfirmDialog: React.FC<VaultDeleteConfirmDialogProps> =
       if (!disabled) onOpenChange(nextOpen);
     }}>
       <DialogContent
-        // Nested popovers (e.g. compact terminal Scripts menu) treat this
-        // portalled dialog as an outside focus/pointer target; the marker lets
-        // parents ignore dismiss while the confirm is open.
-        data-vault-delete-confirm="true"
         className="max-w-[calc(100vw-2rem)] overflow-hidden sm:max-w-[400px]"
         aria-describedby={descriptionId}
       >

--- a/components/vault/VaultDeleteConfirmDialog.tsx
+++ b/components/vault/VaultDeleteConfirmDialog.tsx
@@ -93,6 +93,10 @@ export const VaultDeleteConfirmDialog: React.FC<VaultDeleteConfirmDialogProps> =
       if (!disabled) onOpenChange(nextOpen);
     }}>
       <DialogContent
+        // Nested popovers (e.g. compact terminal Scripts menu) treat this
+        // portalled dialog as an outside focus/pointer target; the marker lets
+        // parents ignore dismiss while the confirm is open.
+        data-vault-delete-confirm="true"
         className="max-w-[calc(100vw-2rem)] overflow-hidden sm:max-w-[400px]"
         aria-describedby={descriptionId}
       >

--- a/domain/snippetSelection.test.ts
+++ b/domain/snippetSelection.test.ts
@@ -1,7 +1,19 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import type { Host, Snippet } from './models';
-import { deleteSelectedSnippetsFromVault } from './snippetSelection.ts';
+import {
+  collectSnippetDeleteIds,
+  deleteSelectedSnippetsFromVault,
+} from './snippetSelection.ts';
+
+test('collectSnippetDeleteIds merges id and ids payloads', () => {
+  assert.deepEqual(
+    [...collectSnippetDeleteIds({ id: 'a', ids: ['b', 'a', ''] })].sort(),
+    ['a', 'b'],
+  );
+  assert.equal(collectSnippetDeleteIds(undefined).size, 0);
+  assert.equal(collectSnippetDeleteIds({ ids: [] }).size, 0);
+});
 
 test('deleteSelectedSnippetsFromVault removes host bindings for every selected snippet', () => {
   const snippets: Snippet[] = [

--- a/domain/snippetSelection.ts
+++ b/domain/snippetSelection.ts
@@ -1,6 +1,20 @@
 import type { Host, Snippet } from './models';
 import { deleteSnippetFromVault } from './snippetAgentOps.ts';
 
+/** Normalize `netcatty:snippets:delete` detail into a set of snippet ids. */
+export function collectSnippetDeleteIds(
+  detail?: { id?: string; ids?: readonly string[] } | null,
+): Set<string> {
+  const ids = new Set<string>();
+  for (const id of detail?.ids ?? []) {
+    if (typeof id === 'string' && id.length > 0) ids.add(id);
+  }
+  if (typeof detail?.id === 'string' && detail.id.length > 0) {
+    ids.add(detail.id);
+  }
+  return ids;
+}
+
 export function deleteSelectedSnippetsFromVault(
   snippets: Snippet[],
   hosts: Host[],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up for [#2828](https://github.com/binaricat/Netcatty/pull/2828) / [#2826](https://github.com/binaricat/Netcatty/issues/2826): address the remaining Codex P2 that ordinary `updateSnippets` disk writes were not serialized with bulk delete.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #2826 (also pushed onto PR #2828 branch `cursor/issue-2826-31234551353`)

## Changes Made

- `updateSnippets` now writes `STORAGE_KEY_SNIPPETS` under `withVaultImportLock("vault")`
- Track `snippetsWritePendingRef` and include it in `waitForPendingVaultWrites`
- Guard/regression test in `useVaultState.snippetsDelete.test.ts`
- `importData` awaits the async snippet write

## Testing

- [x] I have tested these changes locally (`npm run dev`) — unit tests for the vault delete path
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — scoped: `node --test --import tsx application/state/useVaultState.snippetsDelete.test.ts application/app/AppSideEffects.snippetsDelete.test.ts domain/snippetSelection.test.ts components/ScriptsSidePanel.test.ts` (16 passed)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe6de-3494-7190-bf3e-cc4c409ce2cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe6de-3494-7190-bf3e-cc4c409ce2cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

