### PR TITLE
fix(vault): 限制主机列表行最大宽度，避免全屏时右侧空白误触

### DIFF
--- a/components/vault/VaultHostListSection.tsx
+++ b/components/vault/VaultHostListSection.tsx
@@ -516,7 +516,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                         hostCardFocusClassName(viewMode, isHostFocusSelected(host.id)),
                                       )
                                       : cn(
-                                        "h-14 px-2 py-2 rounded-lg transition-colors",
+                                        "h-14 max-w-[480px] px-2 py-2 rounded-lg transition-colors",
                                         isHostFocusSelected(host.id)
                                           ? hostCardFocusClassName("list", true)
                                           : "hover:bg-secondary/60",
@@ -640,7 +640,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                         hostCardFocusClassName(viewMode, isHostFocusSelected(host.id)),
                                       )
                                       : cn(
-                                        "h-14 px-2 py-2 rounded-lg transition-colors",
+                                        "h-14 max-w-[480px] px-2 py-2 rounded-lg transition-colors",
                                         isHostFocusSelected(host.id)
                                           ? hostCardFocusClassName("list", true)
                                           : "hover:bg-secondary/60",
@@ -777,7 +777,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                     ),
                                   )
                                   : cn(
-                                    "h-14 px-2 py-2 rounded-lg transition-colors",
+                                    "h-14 max-w-[480px] px-2 py-2 rounded-lg transition-colors",
                                     isGroupFocusSelected(node.path) || multiSelectedGroupPaths.has(node.path)
                                       ? hostCardFocusClassName("list", true)
                                       : "hover:bg-secondary/60",
@@ -1005,7 +1005,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                               hostCardFocusClassName(viewMode, isHostFocusSelected(host.id)),
                                             )
                                             : cn(
-                                              "h-14 px-2 py-2 rounded-lg transition-colors",
+                                              "h-14 max-w-[480px] px-2 py-2 rounded-lg transition-colors",
                                               isHostFocusSelected(host.id)
                                                 ? hostCardFocusClassName("list", true)
                                                 : "hover:bg-secondary/60",
@@ -1154,7 +1154,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                         hostCardFocusClassName(viewMode, isHostFocusSelected(host.id)),
                                       )
                                       : cn(
-                                        "h-14 px-2 py-2 rounded-lg transition-colors",
+                                        "h-14 max-w-[480px] px-2 py-2 rounded-lg transition-colors",
                                         isHostFocusSelected(host.id)
                                           ? hostCardFocusClassName("list", true)
                                           : "hover:bg-secondary/60",

--- a/components/vault/VaultTreeRow.tsx
+++ b/components/vault/VaultTreeRow.tsx
@@ -129,7 +129,7 @@ export const VaultTreeGroupRow: React.FC<VaultTreeGroupRowProps> = ({
     <div
       ref={rowRef}
       className={cn(
-        "vault-drop-indicator-row group flex h-7 min-w-0 items-center px-2 text-sm font-medium cursor-pointer transition-colors select-none rounded-md",
+        "vault-drop-indicator-row group flex h-7 max-w-[480px] min-w-0 items-center px-2 text-sm font-medium cursor-pointer transition-colors select-none rounded-md",
         selected
           ? "bg-secondary text-foreground"
           : "hover:bg-secondary/60",
@@ -214,7 +214,7 @@ export const VaultTreeItemRow: React.FC<VaultTreeItemRowProps> = ({
 }) => (
   <div
     className={cn(
-      "vault-drop-indicator-row group flex h-7 min-w-0 items-center px-2 text-sm cursor-pointer transition-colors select-none rounded-md",
+      "vault-drop-indicator-row group flex h-7 max-w-[480px] min-w-0 items-center px-2 text-sm cursor-pointer transition-colors select-none rounded-md",
       selected
         ? "bg-secondary text-foreground"
         : "hover:bg-secondary/40",


### PR DESCRIPTION
## Summary

窗口全屏或容器较宽时，主机列表（树形视图 / 列表视图）的每一行会撑满可用宽度，导致主机名后面出现大片空白，这块空白仍绑定了整行的点击事件（打开/选中主机），非常容易误触。

## Type of Change

- [x] Bug fix

## Related Issue (optional)

N/A

## Changes Made

- `components/vault/VaultTreeRow.tsx`：`VaultTreeGroupRow`（分组行）和 `VaultTreeItemRow`（主机行）最外层容器加上 `max-w-[480px]`。
- `components/vault/VaultHostListSection.tsx`：列表模式（`viewMode === "list"`）下的置顶主机、最近主机、分组、常规主机（含分组内）共 5 处卡片容器加上 `max-w-[480px]`；网格（grid）视图分支未改动。

选中态背景、hover 背景均绘制在行容器自身，收窄宽度后会跟随收窄，不会出现背景与内容宽度不一致的问题。虚拟化列表的绝对定位父层未改动，仅调整内层实际渲染行的最大宽度。

## Screenshots / Demo

该应用依赖 Electron 的 `window.electron` IPC 桥接获取真实主机数据，无法在独立浏览器预览环境中渲染验证（已尝试，页面为空白但无报错，属预期的环境限制）。改动为纯 Tailwind className 调整，无 JS 逻辑变化，已通过类型检查与 lint。建议在 `npm run dev` 启动的 Electron 环境中人工验证全屏下的实际效果。

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)