### PR TITLE
[fix] restore MCP permission on startup

### DIFF
--- a/application/state/useExternalMcpToggleState.test.ts
+++ b/application/state/useExternalMcpToggleState.test.ts
@@ -199,6 +199,36 @@ describe('useExternalMcpToggleState startup ready gate', () => {
     assert.match(hookSource, /if \(isPeerSessionWindow \|\| !enabled\) return;/);
   });
 
+  it('restores saved permission before enabling persistent External MCP', async () => {
+    const restore = installMemoryLocalStorage();
+    try {
+      const storageKeys = await import('../../infrastructure/config/storageKeys.ts');
+      globalThis.localStorage.setItem(storageKeys.STORAGE_KEY_AI_EXTERNAL_MCP_ENABLED, 'true');
+      globalThis.localStorage.setItem(storageKeys.STORAGE_KEY_AI_EXTERNAL_MCP_MODE, 'persistent');
+      globalThis.localStorage.setItem(storageKeys.STORAGE_KEY_AI_PERMISSION_MODE, 'auto');
+
+      const calls: string[] = [];
+      await syncExternalMcpStartupState({
+        aiMcpSetPermissionMode: async (mode) => {
+          calls.push(`permission:${mode}`);
+          return { ok: true };
+        },
+        externalMcpSetConfig: async () => {
+          calls.push('config');
+          return { ok: true };
+        },
+        externalMcpSetEnabled: async (enabled) => {
+          calls.push(`enabled:${enabled}`);
+          return { ok: true, enabled };
+        },
+      });
+
+      assert.deepEqual(calls, ['permission:auto', 'config', 'enabled:true']);
+    } finally {
+      restore();
+    }
+  });
+
   it('re-reads storage after config await so concurrent top-bar toggles win', async () => {
     const restore = installMemoryLocalStorage();
     try {

--- a/application/state/useExternalMcpToggleState.ts
+++ b/application/state/useExternalMcpToggleState.ts
@@ -5,8 +5,10 @@ import {
   STORAGE_KEY_AI_EXTERNAL_MCP_IDLE_TIMEOUT_MINUTES,
   STORAGE_KEY_AI_EXTERNAL_MCP_MODE,
   STORAGE_KEY_AI_EXTERNAL_MCP_SILENT_SESSIONS,
+  STORAGE_KEY_AI_PERMISSION_MODE,
   STORAGE_KEY_AI_SESSION_IDLE_TIMEOUT_MINUTES,
 } from '../../infrastructure/config/storageKeys';
+import type { AIPermissionMode } from '../../infrastructure/ai/types';
 import { localStorageAdapter } from '../../infrastructure/persistence/localStorageAdapter';
 import { netcattyBridge } from '../../infrastructure/services/netcattyBridge';
 import { AI_STATE_CHANGED_EVENT, emitAIStateChanged } from './aiStateEvents';
@@ -105,6 +107,7 @@ type ExternalMcpConfig = {
 };
 
 type ExternalMcpBridge = {
+  aiMcpSetPermissionMode?: (mode: AIPermissionMode) => Promise<unknown> | unknown;
   externalMcpSetConfig?: (config: ExternalMcpConfig) => Promise<unknown> | unknown;
   externalMcpSetEnabled?: (enabled: boolean) => Promise<unknown> | unknown;
   externalMcpGetStatus?: () => Promise<{
@@ -124,6 +127,11 @@ export type ExternalMcpStartupSyncPlan = {
 
 export function normalizeExternalMcpMode(value: string | null): ExternalMcpMode {
   return value === 'persistent' ? 'persistent' : 'temporary';
+}
+
+function readAIPermissionMode(): AIPermissionMode {
+  const stored = localStorageAdapter.readString(STORAGE_KEY_AI_PERMISSION_MODE);
+  return stored === 'observer' || stored === 'auto' ? stored : 'confirm';
 }
 
 export function normalizeExternalMcpIdleTimeoutMinutes(value: number | null): number {
@@ -280,6 +288,13 @@ export async function syncExternalMcpStartupState(
   // toggle during boot wins over a stale enable/disable decision.
   const startupGeneration = externalMcpEnableGeneration;
   const initialPlan = readExternalMcpStartupSyncPlan();
+  try {
+    // External MCP discovery is written while enabling, so restore the saved
+    // permission first instead of exposing the main-process default (confirm).
+    await Promise.resolve(bridge?.aiMcpSetPermissionMode?.(readAIPermissionMode()));
+  } catch {
+    // Permission sync is best-effort; the main process keeps its safe default.
+  }
   try {
     await Promise.resolve(bridge?.externalMcpSetConfig?.(initialPlan.config));
   } catch {


### PR DESCRIPTION
## Summary

Netcatty has been a really useful and convenient tool for me. While using External MCP, I ran into the same issue reported in #2789: after a cold start, the saved mode was still `auto`, but External MCP started in `confirm`.

I traced it to the startup order. This change restores the saved permission mode before starting External MCP.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #2789

## Changes Made

- Restore the saved permission mode before External MCP starts.
- Add a regression test for the startup order.

## Screenshots / Demo

### Before

The saved mode is `auto`, but External MCP starts in `confirm`.

<img width="1600" height="1200" alt="Before fix: External MCP starts in confirm mode" src="https://github.com/user-attachments/assets/75f28055-2aa7-4478-a972-d7df8363e27a" />

### After

After the fix, External MCP starts in `auto` as expected.

<img width="1600" height="1200" alt="After fix: External MCP starts in auto mode" src="https://github.com/user-attachments/assets/f5f505c2-dd61-4e8c-adc3-88d3b8763825" />

## Testing

- [x] Verified with `npm run dev`
- [x] Focused tests pass (16/16)
- [x] `npm run lint` passes
- [x] `npm run build` passes

## Checklist

- [x] Follows the existing project style
- [x] No breaking changes