### PR TITLE
fix: stabilize AI session handoff, system manager tabs, and settings scroll

### DIFF
--- a/application/i18n/locales/en/systemManager.ts
+++ b/application/i18n/locales/en/systemManager.ts
@@ -13,6 +13,7 @@ export const enSystemManagerMessages: Messages = {
   'systemManager.tabs.tmux': 'tmux',
   'systemManager.tabs.docker': 'Docker',
   'systemManager.tabs.gpu': 'GPU',
+  'systemManager.tabs.ariaLabel': 'System manager sections',
   'systemManager.popup.loading': 'Opening terminal…',
   'systemManager.popup.startupFailed': 'The startup command did not complete successfully. Check that the target is still available and try again.',
 

--- a/application/i18n/locales/ru/systemManager.ts
+++ b/application/i18n/locales/ru/systemManager.ts
@@ -13,6 +13,7 @@ export const ruSystemManagerMessages: Messages = {
   'systemManager.tabs.tmux': 'tmux',
   'systemManager.tabs.docker': 'Docker',
   'systemManager.tabs.gpu': 'GPU',
+  'systemManager.tabs.ariaLabel': 'Разделы системного менеджера',
   'systemManager.popup.loading': 'Открытие терминала…',
   'systemManager.popup.startupFailed': 'Команда запуска не была выполнена успешно. Проверьте, что цель доступна, и повторите попытку.',
 

--- a/application/i18n/locales/zh-CN/systemManager.ts
+++ b/application/i18n/locales/zh-CN/systemManager.ts
@@ -13,6 +13,7 @@ export const zhCnSystemManagerMessages: Messages = {
   'systemManager.tabs.tmux': 'tmux',
   'systemManager.tabs.docker': 'Docker',
   'systemManager.tabs.gpu': 'GPU',
+  'systemManager.tabs.ariaLabel': '系统管理分区',
   'systemManager.popup.loading': '正在打开终端…',
   'systemManager.popup.startupFailed': '启动命令未成功。请确认目标仍然可用后重试。',
 

--- a/application/i18n/locales/zh-TW/systemManager.ts
+++ b/application/i18n/locales/zh-TW/systemManager.ts
@@ -13,6 +13,7 @@ export const zhTwSystemManagerMessages: Messages = {
   'systemManager.tabs.tmux': 'tmux',
   'systemManager.tabs.docker': 'Docker',
   'systemManager.tabs.gpu': 'GPU',
+  'systemManager.tabs.ariaLabel': '系統管理分區',
   'systemManager.popup.loading': '正在開啟終端…',
   'systemManager.popup.startupFailed': '啟動指令未順利完成。請確認目標仍可使用後再試一次。',
 

--- a/application/state/systemManagerTabLayout.test.ts
+++ b/application/state/systemManagerTabLayout.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  normalizeToolbarItemLayout,
+  partitionToolbarItems,
+  setToolbarItemPlacement,
+} from '../../domain/toolbarItemLayout.ts';
+import {
+  SYSTEM_MANAGER_TAB_DEFAULT_ORDER,
+  SYSTEM_MANAGER_TAB_LAYOUT_DEFAULTS,
+} from './systemManagerTabLayout.ts';
+
+test('system manager tab layout defaults include every known section', () => {
+  assert.deepEqual(
+    [...SYSTEM_MANAGER_TAB_DEFAULT_ORDER],
+    ['overview', 'processes', 'ports', 'services', 'tmux', 'docker', 'gpu'],
+  );
+  assert.deepEqual(SYSTEM_MANAGER_TAB_LAYOUT_DEFAULTS.lockedIds, ['overview']);
+});
+
+test('system manager overview cannot be hidden', () => {
+  const layout = normalizeToolbarItemLayout(null, SYSTEM_MANAGER_TAB_LAYOUT_DEFAULTS);
+  const next = setToolbarItemPlacement(
+    layout,
+    'overview',
+    'hide',
+    SYSTEM_MANAGER_TAB_LAYOUT_DEFAULTS,
+  );
+  assert.equal(next.placement.overview, 'show');
+});
+
+test('system manager partition filters to available host tabs', () => {
+  const layout = normalizeToolbarItemLayout(
+    {
+      order: [...SYSTEM_MANAGER_TAB_DEFAULT_ORDER],
+      placement: {
+        overview: 'show',
+        processes: 'show',
+        ports: 'collapse',
+        services: 'hide',
+        tmux: 'show',
+        docker: 'show',
+        gpu: 'show',
+      },
+    },
+    SYSTEM_MANAGER_TAB_LAYOUT_DEFAULTS,
+  );
+
+  const part = partitionToolbarItems(layout, ['overview', 'processes', 'ports', 'services']);
+  assert.deepEqual(part.shown, ['overview', 'processes']);
+  assert.deepEqual(part.collapsed, ['ports']);
+  assert.deepEqual(part.hidden, ['services']);
+});

--- a/application/state/systemManagerTabLayout.ts
+++ b/application/state/systemManagerTabLayout.ts
@@ -1,0 +1,25 @@
+import type { SystemManagerSubTab } from '../../domain/systemManager/types';
+import type { ToolbarItemLayoutDefaults } from '../../domain/toolbarItemLayout';
+
+/** Canonical System Manager sub-tab order (all known sections). */
+export const SYSTEM_MANAGER_TAB_DEFAULT_ORDER: readonly SystemManagerSubTab[] = [
+  'overview',
+  'processes',
+  'ports',
+  'services',
+  'tmux',
+  'docker',
+  'gpu',
+] as const;
+
+/**
+ * Persistable layout defaults for System Manager sub-tabs.
+ * Overview is locked so the panel never loses every reachable section.
+ */
+export const SYSTEM_MANAGER_TAB_LAYOUT_DEFAULTS: ToolbarItemLayoutDefaults = {
+  order: [...SYSTEM_MANAGER_TAB_DEFAULT_ORDER],
+  placement: Object.fromEntries(
+    SYSTEM_MANAGER_TAB_DEFAULT_ORDER.map((id) => [id, 'show' as const]),
+  ),
+  lockedIds: ['overview'],
+};

--- a/application/state/useServerStats.ts
+++ b/application/state/useServerStats.ts
@@ -304,8 +304,11 @@ function reconcileSharedServerStatsSession(session: SharedServerStatsSession): v
   if (activeClients.length === 0) {
     // Pause polling only. Keep the last successful stats so remounting Overview
     // (or re-enabling a terminal stats strip) can paint immediately instead of
-    // flashing "No system overview data yet."
+    // flashing "No system overview data yet." Still clear give-up / failure so a
+    // later resume can auto-retry (old reset wiped stats + flags together).
     clearServerStatsTimers(session);
+    session.givenUp = false;
+    session.consecutiveFailures = 0;
     if (session.state.isLoading) {
       updateServerStatsState(session, { isLoading: false });
     }

--- a/application/state/useServerStats.ts
+++ b/application/state/useServerStats.ts
@@ -183,16 +183,6 @@ function clearServerStatsTimers(session: SharedServerStatsSession): void {
   session.pollIntervalMs = null;
 }
 
-function resetServerStatsSession(session: SharedServerStatsSession): void {
-  clearServerStatsTimers(session);
-  session.connectedAt = 0;
-  session.hasFetched = false;
-  session.fetchGeneration += 1;
-  session.consecutiveFailures = 0;
-  session.givenUp = false;
-  updateServerStatsState(session, createInitialState());
-}
-
 function getActiveServerStatsClients(session: SharedServerStatsSession): ServerStatsClient[] {
   return Array.from(session.clients.values()).filter((client) => (
     client.enabled && client.isSupportedOs && client.isConnected
@@ -312,7 +302,13 @@ function reconcileSharedServerStatsSession(session: SharedServerStatsSession): v
   const activeClients = getActiveServerStatsClients(session);
 
   if (activeClients.length === 0) {
-    resetServerStatsSession(session);
+    // Pause polling only. Keep the last successful stats so remounting Overview
+    // (or re-enabling a terminal stats strip) can paint immediately instead of
+    // flashing "No system overview data yet."
+    clearServerStatsTimers(session);
+    if (session.state.isLoading) {
+      updateServerStatsState(session, { isLoading: false });
+    }
     return;
   }
 

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -1,6 +1,6 @@
 
 
-import React, { useCallback, useEffect, useDeferredValue, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { useI18n } from '../application/i18n/I18nProvider';
 import { useWindowControls } from '../application/state/useWindowControls';
@@ -30,9 +30,9 @@ import { subscribeUserSkillsStatusChanged } from './ai/userSkillsStatusEvents';
 import {
   applyDraftEntrySelection,
   applyHistorySessionSelection,
-  panelViewsEqual,
   resolveDisplayedPanelView,
   resolveDisplayedSession,
+  shouldForceDraftViewSync,
 } from './ai/aiPanelViewState';
 import {
   endSendForKey,
@@ -356,12 +356,15 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     );
   }, [scopeType, terminalSessions]);
 
-  const deferredSessions = useDeferredValue(sessions);
+  // Use live sessions for history + view resolution. Deferring the list used to
+  // lag one paint behind createSession, so normalizePanelView treated the new
+  // chat as missing and the draft-sync effect forced showDraftView — which
+  // parked the just-sent session into history under StrictMode.
   const historySessions = useMemo(
     () => profileAIPanelCalculation(
       'AIChatSidePanel.historySessions',
       () => getScopedHistorySessions(
-        deferredSessions,
+        sessions,
         scopeType,
         scopeTargetId,
         scopeHostIds,
@@ -369,7 +372,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
         workspaceMemberTerminalIds,
       ),
     ),
-    [deferredSessions, scopeType, scopeTargetId, scopeHostIds, activeTerminalSessionIds, workspaceMemberTerminalIds],
+    [sessions, scopeType, scopeTargetId, scopeHostIds, activeTerminalSessionIds, workspaceMemberTerminalIds],
   );
 
   const explicitPanelView = panelViewByScope[scopeKey];
@@ -447,9 +450,15 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
 
   useEffect(() => {
     if (!isVisible) return;
-    if (!explicitPanelView || panelViewsEqual(normalizedPanelView, explicitPanelView)) return;
+    if (!shouldForceDraftViewSync(
+      explicitPanelView,
+      normalizedPanelView,
+      (sessionId) => sessions.some((session) => session.id === sessionId),
+    )) {
+      return;
+    }
     showDraftView(scopeKey);
-  }, [isVisible, normalizedPanelView, explicitPanelView, scopeKey, showDraftView]);
+  }, [isVisible, normalizedPanelView, explicitPanelView, scopeKey, sessions, showDraftView]);
 
   useEffect(() => {
     if (!activeSession) return;
@@ -468,9 +477,13 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   useEffect(() => {
     if (!isVisible) return;
     if (normalizedPanelView.mode !== 'draft') return;
+    // Only clear ownership when the panel is intentionally on draft. An
+    // explicit session view that has not resolved into history yet must keep
+    // its active map entry so the chat does not jump into the history list.
+    if (explicitPanelView?.mode === 'session') return;
     if (persistedSessionId == null) return;
     setActiveSessionId(null);
-  }, [isVisible, normalizedPanelView.mode, persistedSessionId, setActiveSessionId]);
+  }, [isVisible, normalizedPanelView.mode, explicitPanelView, persistedSessionId, setActiveSessionId]);
 
   const ensureScopeDraft = useCallback((agentId: string) => {
     ensureDraftForScope(scopeKey, agentId);

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -450,15 +450,17 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
 
   useEffect(() => {
     if (!isVisible) return;
+    // Predicate must match normalizePanelView's list (scoped history), not the
+    // global store — out-of-scope sessions must still demote to draft.
     if (!shouldForceDraftViewSync(
       explicitPanelView,
       normalizedPanelView,
-      (sessionId) => sessions.some((session) => session.id === sessionId),
+      (sessionId) => historySessions.some((session) => session.id === sessionId),
     )) {
       return;
     }
     showDraftView(scopeKey);
-  }, [isVisible, normalizedPanelView, explicitPanelView, scopeKey, sessions, showDraftView]);
+  }, [isVisible, normalizedPanelView, explicitPanelView, scopeKey, historySessions, showDraftView]);
 
   useEffect(() => {
     if (!activeSession) return;
@@ -477,13 +479,24 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   useEffect(() => {
     if (!isVisible) return;
     if (normalizedPanelView.mode !== 'draft') return;
-    // Only clear ownership when the panel is intentionally on draft. An
-    // explicit session view that has not resolved into history yet must keep
-    // its active map entry so the chat does not jump into the history list.
-    if (explicitPanelView?.mode === 'session') return;
+    // Keep ownership while an explicit session is still displayable in this
+    // scope (normalize has not demoted it). Out-of-scope / missing ids clear.
+    if (
+      explicitPanelView?.mode === 'session'
+      && historySessions.some((session) => session.id === explicitPanelView.sessionId)
+    ) {
+      return;
+    }
     if (persistedSessionId == null) return;
     setActiveSessionId(null);
-  }, [isVisible, normalizedPanelView.mode, explicitPanelView, persistedSessionId, setActiveSessionId]);
+  }, [
+    isVisible,
+    normalizedPanelView.mode,
+    explicitPanelView,
+    historySessions,
+    persistedSessionId,
+    setActiveSessionId,
+  ]);
 
   const ensureScopeDraft = useCallback((agentId: string) => {
     ensureDraftForScope(scopeKey, agentId);

--- a/components/ai/ChatMessageList.test.tsx
+++ b/components/ai/ChatMessageList.test.tsx
@@ -38,24 +38,16 @@ test("resolved approval state retains only tool calls still present in messages"
   assert.deepEqual([...next], [["live-call", false]]);
 });
 
-test("assistant content stays plain when markdown is hidden or streaming", () => {
+test("assistant content stays plain only when markdown is hidden", () => {
   assert.equal(shouldRenderAssistantAsPlainText({
     hideMarkdown: false,
   }), false);
   assert.equal(shouldRenderAssistantAsPlainText({
     hideMarkdown: true,
   }), true);
-  assert.equal(shouldRenderAssistantAsPlainText({
-    hideMarkdown: false,
-    isStreaming: true,
-  }), true);
-  assert.equal(shouldRenderAssistantAsPlainText({
-    hideMarkdown: false,
-    isStreaming: false,
-  }), false);
 });
 
-test("ChatMessageList renders plain text for the streaming assistant message", () => {
+test("ChatMessageList renders Streamdown for the streaming assistant message", () => {
   const messages: ChatMessage[] = [
     {
       id: "user-1",
@@ -83,16 +75,16 @@ test("ChatMessageList renders plain text for the streaming assistant message", (
     ),
   );
 
-  assert.match(markup, /data-ai-content="plain"/);
+  assert.match(markup, /data-ai-content="markdown"/);
   assert.match(markup, /streaming-body/);
-  assert.doesNotMatch(markup, /data-ai-content="markdown"/);
+  assert.doesNotMatch(markup, /data-ai-content="plain"/);
 });
 
-test("streaming assistant content skips Streamdown while the turn is live", () => {
+test("streaming assistant content keeps Streamdown live with isAnimating", () => {
   const source = readFileSync(new URL("./ChatMessageList.tsx", import.meta.url), "utf8");
 
-  assert.match(source, /isStreaming: !!isThisStreaming/);
-  assert.match(source, /shouldRenderAssistantAsPlainText\(\{[\s\S]*?isStreaming/);
+  assert.match(source, /isAnimating=\{!!isThisStreaming\}/);
+  assert.doesNotMatch(source, /isStreaming: !!isThisStreaming/);
 });
 
 test("ChatMessageList hydrates markdown after streaming settles", () => {

--- a/components/ai/ChatMessageList.tsx
+++ b/components/ai/ChatMessageList.tsx
@@ -113,9 +113,10 @@ export function shouldProvideVaultArtifactNavigation({
 
 export function shouldRenderAssistantAsPlainText(options: {
   hideMarkdown: boolean;
-  isStreaming?: boolean;
 }): boolean {
-  return options.hideMarkdown || !!options.isStreaming;
+  // Streaming stays on Streamdown with isAnimating so incomplete markdown
+  // updates live. Only diagnostic hideMarkdown forces plain text.
+  return options.hideMarkdown;
 }
 
 const ASSISTANT_PLAIN_TEXT_CLASS = 'whitespace-pre-wrap break-words text-[13px] leading-[1.45]';
@@ -701,10 +702,7 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
                 {message.content && (
                   isUser
                     ? <div className={ASSISTANT_PLAIN_TEXT_CLASS}>{message.content}</div>
-                    : shouldRenderAssistantAsPlainText({
-                        hideMarkdown,
-                        isStreaming: !!isThisStreaming,
-                      })
+                    : shouldRenderAssistantAsPlainText({ hideMarkdown })
                       ? (
                           <div
                             className={ASSISTANT_PLAIN_TEXT_CLASS}
@@ -716,7 +714,7 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
                       : (
                           <React.Profiler {...getAIPanelProfilerProps('AIChatPanel.Markdown')}>
                             <div data-ai-content="markdown">
-                              <LazyMessageResponse isAnimating={false}>
+                              <LazyMessageResponse isAnimating={!!isThisStreaming}>
                                 {message.content}
                               </LazyMessageResponse>
                             </div>

--- a/components/ai/aiPanelViewState.test.ts
+++ b/components/ai/aiPanelViewState.test.ts
@@ -12,6 +12,7 @@ import {
   panelViewsEqual,
   resolveDisplayedPanelView,
   resolveDisplayedSession,
+  shouldForceDraftViewSync,
 } from "./aiPanelViewState.ts";
 
 function createSession(id: string): AISession {
@@ -73,6 +74,36 @@ test("missing session target normalizes back to draft view", () => {
   const sessions = [createSession("session-2"), createSession("session-1")];
 
   assert.deepEqual(normalizePanelView(panelView, sessions), { mode: "draft" });
+});
+
+test("shouldForceDraftViewSync keeps explicit session while it still exists in store", () => {
+  const explicit: AIPanelView = { mode: "session", sessionId: "just-created" };
+  const normalized: AIPanelView = { mode: "draft" };
+  const existing = new Set(["just-created"]);
+
+  assert.equal(
+    shouldForceDraftViewSync(explicit, normalized, (id) => existing.has(id)),
+    false,
+  );
+});
+
+test("shouldForceDraftViewSync forces draft only when explicit session is gone", () => {
+  const explicit: AIPanelView = { mode: "session", sessionId: "deleted" };
+  const normalized: AIPanelView = { mode: "draft" };
+
+  assert.equal(
+    shouldForceDraftViewSync(explicit, normalized, () => false),
+    true,
+  );
+});
+
+test("shouldForceDraftViewSync is a no-op when views already match", () => {
+  const view: AIPanelView = { mode: "session", sessionId: "session-1" };
+
+  assert.equal(
+    shouldForceDraftViewSync(view, view, () => true),
+    false,
+  );
 });
 
 test("missing explicit panel view resumes the most recent matching history when no draft exists", () => {

--- a/components/ai/aiPanelViewState.test.ts
+++ b/components/ai/aiPanelViewState.test.ts
@@ -76,24 +76,42 @@ test("missing session target normalizes back to draft view", () => {
   assert.deepEqual(normalizePanelView(panelView, sessions), { mode: "draft" });
 });
 
-test("shouldForceDraftViewSync keeps explicit session while it still exists in store", () => {
+test("shouldForceDraftViewSync keeps explicit session while it is still in scoped history", () => {
   const explicit: AIPanelView = { mode: "session", sessionId: "just-created" };
   const normalized: AIPanelView = { mode: "draft" };
-  const existing = new Set(["just-created"]);
+  // Predicate mirrors scoped historySessions (not the global store).
+  const scopedHistory = new Set(["just-created"]);
 
   assert.equal(
-    shouldForceDraftViewSync(explicit, normalized, (id) => existing.has(id)),
+    shouldForceDraftViewSync(explicit, normalized, (id) => scopedHistory.has(id)),
     false,
   );
 });
 
-test("shouldForceDraftViewSync forces draft only when explicit session is gone", () => {
+test("shouldForceDraftViewSync forces draft when explicit session is gone", () => {
   const explicit: AIPanelView = { mode: "session", sessionId: "deleted" };
   const normalized: AIPanelView = { mode: "draft" };
 
   assert.equal(
     shouldForceDraftViewSync(explicit, normalized, () => false),
     true,
+  );
+});
+
+test("shouldForceDraftViewSync demotes when session is only in global store, not scoped history", () => {
+  const explicit: AIPanelView = { mode: "session", sessionId: "other-scope" };
+  const normalized: AIPanelView = { mode: "draft" };
+  // Global store still has it; scoped history (what normalize uses) does not.
+  const globalStore = new Set(["other-scope"]);
+  const scopedHistory = new Set<string>();
+
+  assert.equal(
+    shouldForceDraftViewSync(explicit, normalized, (id) => scopedHistory.has(id)),
+    true,
+  );
+  assert.equal(
+    shouldForceDraftViewSync(explicit, normalized, (id) => globalStore.has(id)),
+    false,
   );
 });
 

--- a/components/ai/aiPanelViewState.ts
+++ b/components/ai/aiPanelViewState.ts
@@ -80,6 +80,28 @@ export function normalizePanelView(
     : DEFAULT_PANEL_VIEW;
 }
 
+/**
+ * Whether the panel should force `showDraftView` when the normalized view
+ * differs from the explicit store view.
+ *
+ * Explicit session views must stay put while the session still exists in the
+ * store — otherwise a one-frame history lag after draft send demotes the new
+ * chat into history and reopens a blank draft (especially under StrictMode).
+ */
+export function shouldForceDraftViewSync(
+  explicitPanelView: AIPanelView | undefined,
+  normalizedPanelView: AIPanelView,
+  sessionExists: (sessionId: string) => boolean,
+): boolean {
+  if (!explicitPanelView || panelViewsEqual(normalizedPanelView, explicitPanelView)) {
+    return false;
+  }
+  if (explicitPanelView.mode === "session" && sessionExists(explicitPanelView.sessionId)) {
+    return false;
+  }
+  return true;
+}
+
 export function resolveDisplayedSession(
   panelView: AIPanelView,
   sessions: AISession[],

--- a/components/ai/aiPanelViewState.ts
+++ b/components/ai/aiPanelViewState.ts
@@ -84,9 +84,14 @@ export function normalizePanelView(
  * Whether the panel should force `showDraftView` when the normalized view
  * differs from the explicit store view.
  *
- * Explicit session views must stay put while the session still exists in the
- * store — otherwise a one-frame history lag after draft send demotes the new
- * chat into history and reopens a blank draft (especially under StrictMode).
+ * Explicit session views must stay put while the session is still present in
+ * the same scoped history list that `normalizePanelView` uses — otherwise a
+ * one-frame history lag after draft send demotes the new chat into history
+ * and reopens a blank draft (especially under StrictMode).
+ *
+ * `sessionExists` must NOT consult the global store alone: a session that
+ * exists but is out of this scope's history must demote so the panel does not
+ * stick on a blank draft with a ghost active-map entry.
  */
 export function shouldForceDraftViewSync(
   explicitPanelView: AIPanelView | undefined,

--- a/components/settings/settings-ui.tsx
+++ b/components/settings/settings-ui.tsx
@@ -210,7 +210,8 @@ export const SettingRow: React.FC<SettingRowProps> = ({
     id={anchorId ? settingsAnchorDomId(anchorId) : undefined}
     data-settings-anchor={anchorId}
     className={cn(
-      "flex justify-between py-3 gap-4 rounded-md",
+      // Keep square corners: rounded rows bend divide-y separators at both ends.
+      "flex justify-between py-3 gap-4",
       align === "start" ? "items-start" : "items-center",
     )}
   >
@@ -233,7 +234,8 @@ export const SettingsAnchor: React.FC<{
   <div
     id={settingsAnchorDomId(anchorId)}
     data-settings-anchor={anchorId}
-    className={cn("rounded-md", className)}
+    // No default rounded-md: inside divide-y cards, child border-radius bends separators.
+    className={className}
   >
     {children}
   </div>
@@ -244,7 +246,11 @@ export const SettingsTabContent: React.FC<{
   children: React.ReactNode;
 }> = ({ value, children }) => (
   <TabsContent value={value} className="flex-1 m-0 h-full overflow-hidden">
-    <div className="h-full overflow-y-auto overflow-x-hidden">
+    {/* data-settings-scroll-pane: search jump scrolls only this pane, not the window */}
+    <div
+      data-settings-scroll-pane
+      className="h-full overflow-y-auto overflow-x-hidden"
+    >
       <div className="p-6 space-y-6">{children}</div>
     </div>
   </TabsContent>

--- a/components/settings/settingsFocus.test.ts
+++ b/components/settings/settingsFocus.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+test("settings search focus scrolls the content pane, not the window viewport", () => {
+  const source = readFileSync(new URL("./settingsFocus.ts", import.meta.url), "utf8");
+  const uiSource = readFileSync(new URL("./settings-ui.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /scrollSettingsAnchorIntoView/);
+  assert.match(source, /findSettingsScrollContainer/);
+  assert.match(source, /data-settings-scroll-pane/);
+  assert.match(source, /preventScroll:\s*true/);
+  // Viewport centering lifts the whole settings window under macOS traffic lights.
+  assert.doesNotMatch(source, /block:\s*["']center["']/);
+  assert.match(uiSource, /data-settings-scroll-pane/);
+});
+
+test("scrollSettingsAnchorIntoView prefers marked pane over document scroll", async () => {
+  const { scrollSettingsAnchorIntoView } = await import("./settingsFocus.ts");
+
+  const calls: Array<{ top: number; behavior?: ScrollBehavior }> = [];
+  const scroller = {
+    scrollHeight: 2000,
+    clientHeight: 400,
+    scrollTop: 0,
+    getBoundingClientRect: () => ({
+      top: 100,
+      left: 0,
+      bottom: 500,
+      right: 400,
+      width: 400,
+      height: 400,
+      x: 0,
+      y: 100,
+      toJSON() {
+        return this;
+      },
+    }),
+    scrollTo(opts: { top: number; behavior?: ScrollBehavior }) {
+      calls.push(opts);
+      this.scrollTop = opts.top;
+    },
+  } as unknown as HTMLElement;
+
+  const anchor = {
+    getBoundingClientRect: () => ({
+      top: 700,
+      left: 0,
+      bottom: 760,
+      right: 200,
+      width: 200,
+      height: 60,
+      x: 0,
+      y: 700,
+      toJSON() {
+        return this;
+      },
+    }),
+    closest(selector: string) {
+      if (selector === "[data-settings-scroll-pane]") return scroller;
+      return null;
+    },
+    parentElement: scroller,
+  } as unknown as HTMLElement;
+
+  scrollSettingsAnchorIntoView(anchor, "auto");
+
+  assert.equal(calls.length, 1);
+  // elTopInScroller = 700 - 100 + 0 = 600; minus 24 padding → 576
+  assert.equal(calls[0].top, 576);
+  assert.equal(calls[0].behavior, "auto");
+});

--- a/components/settings/settingsFocus.ts
+++ b/components/settings/settingsFocus.ts
@@ -2,6 +2,8 @@ import { settingsAnchorDomId } from "../../domain/settingsSearchCatalog";
 
 const HIGHLIGHT_CLASS = "settings-search-highlight";
 const HIGHLIGHT_MS = 1600;
+/** Keep focused anchors slightly below the top of the settings content pane. */
+const SCROLL_TOP_PADDING_PX = 24;
 
 export type SettingsFocusTarget = {
   tab: string;
@@ -39,10 +41,63 @@ function focusAnchorElement(el: HTMLElement): void {
     target.tabIndex = -1;
   }
   try {
+    // preventScroll: we own scrolling so the settings titlebar / traffic-light
+    // chrome never rides along with a viewport-level scrollIntoView.
     target.focus({ preventScroll: true });
   } catch {
     // ignore focus failures in non-interactive hosts
   }
+}
+
+function isVerticallyScrollable(el: HTMLElement): boolean {
+  const { overflowY } = window.getComputedStyle(el);
+  if (overflowY !== "auto" && overflowY !== "scroll" && overflowY !== "overlay") {
+    return false;
+  }
+  return el.scrollHeight > el.clientHeight + 1;
+}
+
+/**
+ * Prefer the dedicated settings content scroller; never fall back to
+ * document/body scrolling (that lifts the whole window under macOS traffic lights).
+ */
+export function findSettingsScrollContainer(el: HTMLElement): HTMLElement | null {
+  // Trust the marked pane even when content is shorter than the viewport —
+  // search jumps must still scroll this host, not the window.
+  const marked = el.closest<HTMLElement>("[data-settings-scroll-pane]");
+  if (marked) return marked;
+
+  let node: HTMLElement | null = el.parentElement;
+  while (node && node !== document.documentElement && node !== document.body) {
+    if (isVerticallyScrollable(node)) return node;
+    node = node.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Scroll only within the settings content pane so the window chrome stays put.
+ */
+export function scrollSettingsAnchorIntoView(
+  el: HTMLElement,
+  behavior: ScrollBehavior = "smooth",
+): void {
+  const scroller = findSettingsScrollContainer(el);
+  if (!scroller) {
+    // Nearest-only, never "center" — avoids yanking the whole settings window.
+    el.scrollIntoView({ behavior, block: "nearest", inline: "nearest" });
+    return;
+  }
+
+  const scrollerRect = scroller.getBoundingClientRect();
+  const elRect = el.getBoundingClientRect();
+  const elTopInScroller = elRect.top - scrollerRect.top + scroller.scrollTop;
+  const targetTop = Math.max(0, elTopInScroller - SCROLL_TOP_PADDING_PX);
+  const maxScroll = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+  scroller.scrollTo({
+    top: Math.min(targetTop, maxScroll),
+    behavior,
+  });
 }
 
 /**
@@ -91,7 +146,7 @@ export function focusSettingsAnchor(
         return;
       }
 
-      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      scrollSettingsAnchorIntoView(el, "smooth");
       el.classList.remove(HIGHLIGHT_CLASS);
       void el.offsetWidth;
       el.classList.add(HIGHLIGHT_CLASS);

--- a/components/systemManager/GpuManagerTab.test.ts
+++ b/components/systemManager/GpuManagerTab.test.ts
@@ -34,6 +34,20 @@ test("gpu tab keeps a compact sparkline history like overview/nvtop charts", () 
   assert.match(source, /GpuSparkline/);
   assert.match(source, /historyByDevice/);
   assert.match(source, /setHistoryByDevice/);
+  // Sparklines sit under the resource bars, not in a side column.
+  assert.doesNotMatch(source, /grid-cols-\[minmax\(0,1fr\)_72px\]/);
+  assert.match(source, /grid grid-cols-2 gap-x-3/);
+});
+
+test("gpu device card uses vendor vector badges", () => {
+  const source = readFileSync(new URL("./GpuManagerTab.tsx", import.meta.url), "utf8");
+  const badgeSource = readFileSync(new URL("./GpuVendorBadge.tsx", import.meta.url), "utf8");
+  assert.match(source, /GpuVendorBadge/);
+  assert.match(source, /vendor=\{device\.vendor\}/);
+  assert.match(badgeSource, /NVIDIA_PATH/);
+  assert.match(badgeSource, /HUAWEI_PATH/);
+  assert.match(badgeSource, /vendor === 'nvidia'/);
+  assert.match(badgeSource, /vendor === 'ascend'/);
 });
 
 test("resource bar animates width and uses load-aware tones", () => {

--- a/components/systemManager/GpuManagerTab.test.ts
+++ b/components/systemManager/GpuManagerTab.test.ts
@@ -44,6 +44,9 @@ test("gpu device card uses vendor vector badges", () => {
   const badgeSource = readFileSync(new URL("./GpuVendorBadge.tsx", import.meta.url), "utf8");
   assert.match(source, /GpuVendorBadge/);
   assert.match(source, /vendor=\{device\.vendor\}/);
+  // Process rows share the same display helper (no deleted vendorLabel).
+  assert.match(source, /vendorDisplayLabel\(process\.vendor/);
+  assert.doesNotMatch(source, /vendorLabel\(/);
   assert.match(badgeSource, /NVIDIA_PATH/);
   assert.match(badgeSource, /HUAWEI_PATH/);
   assert.match(badgeSource, /vendor === 'nvidia'/);

--- a/components/systemManager/GpuManagerTab.tsx
+++ b/components/systemManager/GpuManagerTab.tsx
@@ -9,7 +9,7 @@ import type {
 } from '../../domain/systemManager/types';
 import { cn } from '../../lib/utils';
 import { ResourceBar } from './ResourceBar';
-import { GpuVendorBadge } from './GpuVendorBadge';
+import { GpuVendorBadge, vendorDisplayLabel } from './GpuVendorBadge';
 import {
   SystemPanelEmpty,
   SystemPanelError,
@@ -206,7 +206,7 @@ const ProcessRow = memo(function ProcessRow({
   return (
     <SystemPanelRow
       title={process.processName || '—'}
-      subtitle={`${vendorLabel(process.vendor, t)} #${process.gpuIndex}`}
+      subtitle={`${vendorDisplayLabel(process.vendor, t)} #${process.gpuIndex}`}
       trailing={(
         <div className="flex items-center gap-2 text-[10px] text-muted-foreground tabular-nums">
           <span>PID {process.pid}</span>

--- a/components/systemManager/GpuManagerTab.tsx
+++ b/components/systemManager/GpuManagerTab.tsx
@@ -9,6 +9,7 @@ import type {
 } from '../../domain/systemManager/types';
 import { cn } from '../../lib/utils';
 import { ResourceBar } from './ResourceBar';
+import { GpuVendorBadge } from './GpuVendorBadge';
 import {
   SystemPanelEmpty,
   SystemPanelError,
@@ -50,15 +51,6 @@ function memoryPercent(device: AcceleratorDeviceInfo): number | null {
   if (!Number.isFinite(device.memoryUsedMb) || !Number.isFinite(device.memoryTotalMb)) return null;
   if (!device.memoryTotalMb || device.memoryTotalMb <= 0) return null;
   return Math.max(0, Math.min(100, (Number(device.memoryUsedMb) / Number(device.memoryTotalMb)) * 100));
-}
-
-function vendorLabel(
-  vendor: AcceleratorDeviceInfo['vendor'],
-  t: ReturnType<typeof useI18n>['t'],
-): string {
-  return vendor === 'nvidia'
-    ? t('systemManager.gpu.vendor.nvidia')
-    : t('systemManager.gpu.vendor.ascend');
 }
 
 function deviceKey(device: AcceleratorDeviceInfo): string {
@@ -127,9 +119,7 @@ const DeviceCard = memo(function DeviceCard({
             <span className="text-xs font-medium truncate">
               [{device.index}] {device.name}
             </span>
-            <SystemPanelStatusBadge tone="muted">
-              {vendorLabel(device.vendor, t)}
-            </SystemPanelStatusBadge>
+            <GpuVendorBadge vendor={device.vendor} />
             {device.health ? (
               <SystemPanelStatusBadge tone={/ok|healthy|good/i.test(device.health) ? 'success' : 'warning'}>
                 {device.health}
@@ -160,27 +150,37 @@ const DeviceCard = memo(function DeviceCard({
         </div>
       </div>
 
-      <div className="grid grid-cols-[minmax(0,1fr)_72px] gap-2 items-end">
-        <div className="min-w-0 space-y-1.5">
+      <div className="min-w-0 space-y-1.5">
+        <ResourceBar
+          label={t('systemManager.gpu.util')}
+          value={util}
+          size="md"
+        />
+        <div className="flex items-center gap-2 min-w-0">
           <ResourceBar
-            label={t('systemManager.gpu.util')}
-            value={util}
+            label={device.vendor === 'ascend' ? t('systemManager.gpu.hbm') : t('systemManager.gpu.memory')}
+            value={memPct}
+            className="flex-1"
             size="md"
           />
-          <div className="flex items-center gap-2 min-w-0">
-            <ResourceBar
-              label={device.vendor === 'ascend' ? t('systemManager.gpu.hbm') : t('systemManager.gpu.memory')}
-              value={memPct}
-              className="flex-1"
-              size="md"
-            />
-            <span className="text-[10px] tabular-nums text-muted-foreground shrink-0">
-              {formatMb(device.memoryUsedMb)} / {formatMb(device.memoryTotalMb)}
-            </span>
-          </div>
+          <span className="text-[10px] tabular-nums text-muted-foreground shrink-0">
+            {formatMb(device.memoryUsedMb)} / {formatMb(device.memoryTotalMb)}
+          </span>
         </div>
-        <div className={cn('min-w-0', tone)} title={t('systemManager.gpu.util')}>
+      </div>
+
+      {/* History sparklines sit under the bars so they do not compete for row width. */}
+      <div className={cn('grid grid-cols-2 gap-x-3 gap-y-1', tone)}>
+        <div className="min-w-0">
+          <div className="mb-0.5 text-[10px] text-muted-foreground">
+            {t('systemManager.gpu.util')}
+          </div>
           <GpuSparkline values={utilHistory.length ? utilHistory : [util ?? 0]} />
+        </div>
+        <div className="min-w-0">
+          <div className="mb-0.5 text-[10px] text-muted-foreground">
+            {device.vendor === 'ascend' ? t('systemManager.gpu.hbm') : t('systemManager.gpu.memory')}
+          </div>
           <GpuSparkline
             values={memHistory.length ? memHistory : [memPct ?? 0]}
             className="opacity-80"

--- a/components/systemManager/GpuVendorBadge.test.ts
+++ b/components/systemManager/GpuVendorBadge.test.ts
@@ -10,4 +10,7 @@ test('gpu vendor badge embeds monochrome vector marks for nvidia and ascend', ()
   assert.match(source, /HUAWEI_PATH/);
   assert.match(source, /GpuVendorBadge/);
   assert.match(source, /vendorDisplayLabel/);
+  // Mark is decorative; text label is the accessible name (no double announce).
+  assert.match(source, /aria-hidden="true"/);
+  assert.doesNotMatch(source, /role="img"/);
 });

--- a/components/systemManager/GpuVendorBadge.test.ts
+++ b/components/systemManager/GpuVendorBadge.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+test('gpu vendor badge embeds monochrome vector marks for nvidia and ascend', () => {
+  const source = readFileSync(new URL('./GpuVendorBadge.tsx', import.meta.url), 'utf8');
+  assert.match(source, /viewBox="0 0 24 24"/);
+  assert.match(source, /fill-current/);
+  assert.match(source, /NVIDIA_PATH/);
+  assert.match(source, /HUAWEI_PATH/);
+  assert.match(source, /GpuVendorBadge/);
+  assert.match(source, /vendorDisplayLabel/);
+});

--- a/components/systemManager/GpuVendorBadge.tsx
+++ b/components/systemManager/GpuVendorBadge.tsx
@@ -3,31 +3,29 @@ import { useI18n } from '../../application/i18n/I18nProvider';
 import type { AcceleratorVendor } from '../../domain/systemManager/types';
 import { cn } from '../../lib/utils';
 
-/** Simple Icons path data (MIT) — monochrome, uses currentColor. */
+/** Simple Icons NVIDIA path (CC0-1.0) — monochrome, uses currentColor. */
 const NVIDIA_PATH =
   'M8.948 8.798v-1.43a6.7 6.7 0 0 1 .424-.018c3.922-.124 6.493 3.374 6.493 3.374s-2.774 3.851-5.75 3.851c-.398 0-.787-.062-1.158-.185v-4.346c1.528.185 1.837.857 2.747 2.385l2.04-1.714s-1.492-1.952-4-1.952a6.016 6.016 0 0 0-.796.035m0-4.735v2.138l.424-.027c5.45-.185 9.01 4.47 9.01 4.47s-4.08 4.964-8.33 4.964c-.37 0-.733-.035-1.095-.097v1.325c.3.035.61.062.91.062 3.957 0 6.82-2.023 9.593-4.408.459.371 2.34 1.263 2.73 1.652-2.633 2.208-8.772 3.984-12.253 3.984-.335 0-.653-.018-.971-.053v1.864H24V4.063zm0 10.326v1.131c-3.657-.654-4.673-4.46-4.673-4.46s1.758-1.944 4.673-2.262v1.237H8.94c-1.528-.186-2.73 1.245-2.73 1.245s.68 2.412 2.739 3.11M2.456 10.9s2.164-3.197 6.5-3.533V6.201C4.153 6.59 0 10.653 0 10.653s2.35 6.802 8.948 7.42v-1.237c-4.84-.6-6.492-5.936-6.492-5.936z';
 
-/** Huawei petal mark — used for Ascend NPU (Huawei Ascend). */
+/** Huawei petal mark for Ascend NPU (decorative; text label carries the name). */
 const HUAWEI_PATH =
   'M3.67 6.14S1.82 7.91 1.72 9.78v.35c.08 1.51 1.22 2.4 1.22 2.4 1.83 1.79 6.26 4.04 7.3 4.55 0 0 .06.03.1-.01l.02-.04v-.04C7.52 10.8 3.67 6.14 3.67 6.14zM9.65 18.6c-.02-.08-.1-.08-.1-.08l-7.38.26c.8 1.43 2.15 2.53 3.56 2.2.96-.25 3.16-1.78 3.88-2.3.06-.05.04-.09.04-.09zm.08-.78C6.49 15.63.21 12.28.21 12.28c-.15.46-.2.9-.21 1.3v.07c0 1.07.4 1.82.4 1.82.8 1.69 2.34 2.2 2.34 2.2.7.3 1.4.31 1.4.31.12.02 4.4 0 5.54 0 .05 0 .08-.05.08-.05v-.06c0-.03-.03-.05-.03-.05zM9.06 3.19a3.42 3.42 0 00-2.57 3.15v.41c.03.6.16 1.05.16 1.05.66 2.9 3.86 7.65 4.55 8.65.05.05.1.03.1.03a.1.1 0 00.06-.1c1.06-10.6-1.11-13.42-1.11-13.42-.32.02-1.19.23-1.19.23zm8.299 2.27s-.49-1.8-2.44-2.28c0 0-.57-.14-1.17-.22 0 0-2.18 2.81-1.12 13.43.01.07.06.08.06.08.07.03.1-.03.1-.03.72-1.03 3.9-5.76 4.55-8.64 0 0 .36-1.4.02-2.34zm-2.92 13.07s-.07 0-.09.05c0 0-.01.07.03.1.7.51 2.85 2 3.88 2.3 0 0 .16.05.43.06h.14c.69-.02 1.9-.37 3-2.26l-7.4-.25zm7.83-8.41c.14-2.06-1.94-3.97-1.94-3.98 0 0-3.85 4.66-6.67 10.8 0 0-.03.08.02.13l.04.01h.06c1.06-.53 5.46-2.77 7.28-4.54 0 0 1.15-.93 1.21-2.42zm1.52 2.14s-6.28 3.37-9.52 5.55c0 0-.05.04-.03.11 0 0 .03.06.07.06 1.16 0 5.56 0 5.67-.02 0 0 .57-.02 1.27-.29 0 0 1.56-.5 2.37-2.27 0 0 .73-1.45.17-3.14z';
 
 function VendorMark({
   path,
-  title,
   className,
 }: {
   path: string;
-  title: string;
   className?: string;
 }) {
+  // Decorative: visible text label next to the mark is the accessible name.
   return (
     <svg
       viewBox="0 0 24 24"
-      role="img"
-      aria-label={title}
+      aria-hidden="true"
+      focusable="false"
       className={cn('h-3 w-3 shrink-0 fill-current', className)}
     >
-      <title>{title}</title>
       <path d={path} />
     </svg>
   );
@@ -57,9 +55,9 @@ export const GpuVendorBadge = memo(function GpuVendorBadge({
   const label = vendorDisplayLabel(vendor, t);
 
   const mark = vendor === 'nvidia'
-    ? <VendorMark path={NVIDIA_PATH} title={label} />
+    ? <VendorMark path={NVIDIA_PATH} />
     : vendor === 'ascend'
-      ? <VendorMark path={HUAWEI_PATH} title={label} />
+      ? <VendorMark path={HUAWEI_PATH} />
       : null;
 
   return (

--- a/components/systemManager/GpuVendorBadge.tsx
+++ b/components/systemManager/GpuVendorBadge.tsx
@@ -1,0 +1,79 @@
+import React, { memo } from 'react';
+import { useI18n } from '../../application/i18n/I18nProvider';
+import type { AcceleratorVendor } from '../../domain/systemManager/types';
+import { cn } from '../../lib/utils';
+
+/** Simple Icons path data (MIT) — monochrome, uses currentColor. */
+const NVIDIA_PATH =
+  'M8.948 8.798v-1.43a6.7 6.7 0 0 1 .424-.018c3.922-.124 6.493 3.374 6.493 3.374s-2.774 3.851-5.75 3.851c-.398 0-.787-.062-1.158-.185v-4.346c1.528.185 1.837.857 2.747 2.385l2.04-1.714s-1.492-1.952-4-1.952a6.016 6.016 0 0 0-.796.035m0-4.735v2.138l.424-.027c5.45-.185 9.01 4.47 9.01 4.47s-4.08 4.964-8.33 4.964c-.37 0-.733-.035-1.095-.097v1.325c.3.035.61.062.91.062 3.957 0 6.82-2.023 9.593-4.408.459.371 2.34 1.263 2.73 1.652-2.633 2.208-8.772 3.984-12.253 3.984-.335 0-.653-.018-.971-.053v1.864H24V4.063zm0 10.326v1.131c-3.657-.654-4.673-4.46-4.673-4.46s1.758-1.944 4.673-2.262v1.237H8.94c-1.528-.186-2.73 1.245-2.73 1.245s.68 2.412 2.739 3.11M2.456 10.9s2.164-3.197 6.5-3.533V6.201C4.153 6.59 0 10.653 0 10.653s2.35 6.802 8.948 7.42v-1.237c-4.84-.6-6.492-5.936-6.492-5.936z';
+
+/** Huawei petal mark — used for Ascend NPU (Huawei Ascend). */
+const HUAWEI_PATH =
+  'M3.67 6.14S1.82 7.91 1.72 9.78v.35c.08 1.51 1.22 2.4 1.22 2.4 1.83 1.79 6.26 4.04 7.3 4.55 0 0 .06.03.1-.01l.02-.04v-.04C7.52 10.8 3.67 6.14 3.67 6.14zM9.65 18.6c-.02-.08-.1-.08-.1-.08l-7.38.26c.8 1.43 2.15 2.53 3.56 2.2.96-.25 3.16-1.78 3.88-2.3.06-.05.04-.09.04-.09zm.08-.78C6.49 15.63.21 12.28.21 12.28c-.15.46-.2.9-.21 1.3v.07c0 1.07.4 1.82.4 1.82.8 1.69 2.34 2.2 2.34 2.2.7.3 1.4.31 1.4.31.12.02 4.4 0 5.54 0 .05 0 .08-.05.08-.05v-.06c0-.03-.03-.05-.03-.05zM9.06 3.19a3.42 3.42 0 00-2.57 3.15v.41c.03.6.16 1.05.16 1.05.66 2.9 3.86 7.65 4.55 8.65.05.05.1.03.1.03a.1.1 0 00.06-.1c1.06-10.6-1.11-13.42-1.11-13.42-.32.02-1.19.23-1.19.23zm8.299 2.27s-.49-1.8-2.44-2.28c0 0-.57-.14-1.17-.22 0 0-2.18 2.81-1.12 13.43.01.07.06.08.06.08.07.03.1-.03.1-.03.72-1.03 3.9-5.76 4.55-8.64 0 0 .36-1.4.02-2.34zm-2.92 13.07s-.07 0-.09.05c0 0-.01.07.03.1.7.51 2.85 2 3.88 2.3 0 0 .16.05.43.06h.14c.69-.02 1.9-.37 3-2.26l-7.4-.25zm7.83-8.41c.14-2.06-1.94-3.97-1.94-3.98 0 0-3.85 4.66-6.67 10.8 0 0-.03.08.02.13l.04.01h.06c1.06-.53 5.46-2.77 7.28-4.54 0 0 1.15-.93 1.21-2.42zm1.52 2.14s-6.28 3.37-9.52 5.55c0 0-.05.04-.03.11 0 0 .03.06.07.06 1.16 0 5.56 0 5.67-.02 0 0 .57-.02 1.27-.29 0 0 1.56-.5 2.37-2.27 0 0 .73-1.45.17-3.14z';
+
+function VendorMark({
+  path,
+  title,
+  className,
+}: {
+  path: string;
+  title: string;
+  className?: string;
+}) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      role="img"
+      aria-label={title}
+      className={cn('h-3 w-3 shrink-0 fill-current', className)}
+    >
+      <title>{title}</title>
+      <path d={path} />
+    </svg>
+  );
+}
+
+export function vendorDisplayLabel(
+  vendor: AcceleratorVendor,
+  t: ReturnType<typeof useI18n>['t'],
+): string {
+  return vendor === 'nvidia'
+    ? t('systemManager.gpu.vendor.nvidia')
+    : t('systemManager.gpu.vendor.ascend');
+}
+
+/**
+ * Vendor chip with brand vector mark (NVIDIA / Huawei Ascend).
+ * Falls back to text for unknown vendors.
+ */
+export const GpuVendorBadge = memo(function GpuVendorBadge({
+  vendor,
+  className,
+}: {
+  vendor: AcceleratorVendor;
+  className?: string;
+}) {
+  const { t } = useI18n();
+  const label = vendorDisplayLabel(vendor, t);
+
+  const mark = vendor === 'nvidia'
+    ? <VendorMark path={NVIDIA_PATH} title={label} />
+    : vendor === 'ascend'
+      ? <VendorMark path={HUAWEI_PATH} title={label} />
+      : null;
+
+  return (
+    <span
+      title={label}
+      className={cn(
+        'inline-flex h-6 shrink-0 items-center justify-center gap-1 rounded-full px-2 text-[10px] font-medium',
+        // Match SystemPanelStatusBadge muted tone so logos stay legible.
+        'bg-slate-500 text-white dark:bg-slate-400 dark:text-slate-950',
+        className,
+      )}
+    >
+      {mark}
+      <span className="max-w-[4.5rem] truncate leading-none">{label}</span>
+    </span>
+  );
+});

--- a/components/systemManager/SystemManagerSidePanel.test.tsx
+++ b/components/systemManager/SystemManagerSidePanel.test.tsx
@@ -64,9 +64,41 @@ test("overview tab reuses the shared server stats source", () => {
   assert.doesNotMatch(source, /backend\.getServerStats/);
 });
 
-test("overview tab unsubscribes while another system tab is active", () => {
+test("overview tab stays mounted and only pauses polling while another system tab is active", () => {
   const source = readFileSync(new URL("./SystemManagerSidePanel.tsx", import.meta.url), "utf8");
 
-  assert.match(source, /resolvedTab === 'overview' && \(/);
+  // Must not hard-unmount Overview on tab switch (causes empty-state flash).
+  assert.doesNotMatch(source, /resolvedTab === 'overview' && \(/);
+  assert.match(source, /isVisible=\{isVisible && resolvedTab === 'overview'\}/);
   assert.match(source, /<SystemOverviewTab/);
+  assert.match(source, /resolvedTab !== 'overview' && 'hidden'/);
+});
+
+test("system manager tab bar switches icon-only from real overflow measure", () => {
+  const source = readFileSync(new URL("./SystemManagerSidePanel.tsx", import.meta.url), "utf8");
+  const indexCss = readFileSync(new URL("../../index.css", import.meta.url), "utf8");
+
+  assert.match(source, /system-manager-tab-bar/);
+  assert.match(source, /system-manager-tab-label/);
+  assert.match(source, /measureSystemManagerTabBarLabeledFit/);
+  assert.match(source, /resolveSystemManagerTabBarIconOnly/);
+  assert.match(source, /SYSTEM_MANAGER_TAB_BAR_ICON_ONLY_CLASS/);
+  assert.match(source, /scrollSystemManagerTabIntoView/);
+  assert.match(source, /applyHorizontalWheelToScrollContainer/);
+  assert.match(indexCss, /\.system-manager-tab-bar--icon-only \.system-manager-tab-label\s*\{[\s\S]*display:\s*none/);
+  assert.doesNotMatch(indexCss, /@container system-manager-tabs/);
+});
+
+test("system manager tab bar reuses toolbar customize context menu", () => {
+  const source = readFileSync(new URL("./SystemManagerSidePanel.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /ToolbarCustomizeContextMenu/);
+  assert.match(source, /ToolbarOverflowMenu/);
+  assert.match(source, /useToolbarItemLayout/);
+  assert.match(source, /STORAGE_KEY_SYSTEM_MANAGER_TAB_LAYOUT/);
+  assert.match(source, /SYSTEM_MANAGER_TAB_LAYOUT_DEFAULTS/);
+  assert.match(source, /handleSetTabPlacement/);
+  assert.match(source, /tabLayout\.move/);
+  assert.match(source, /data-section="system-manager-tabs"/);
+  assert.match(source, /system-manager-tab-overflow/);
 });

--- a/components/systemManager/SystemManagerSidePanel.tsx
+++ b/components/systemManager/SystemManagerSidePanel.tsx
@@ -1,8 +1,10 @@
 import { Activity, Box, CircuitBoard, Cog, Gauge, LayoutList, Loader2, Network, TerminalSquare } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import React, { memo, useMemo, useState } from 'react';
+import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
+import { SYSTEM_MANAGER_TAB_LAYOUT_DEFAULTS } from '../../application/state/systemManagerTabLayout';
 import { useSystemManagerBackend } from '../../application/state/useSystemManagerBackend';
+import { useToolbarItemLayout } from '../../application/state/useToolbarItemLayout';
 import type { TerminalSettings } from '../../domain/models';
 import type { Host } from '../../domain/models/connection';
 import type { SystemManagerSubTab } from '../../domain/systemManager/types';
@@ -12,6 +14,8 @@ import {
   buildSystemManagerTabs,
   shouldCollectServerStats,
 } from '../../domain/systemManager/systemTarget';
+import { partitionToolbarItems } from '../../domain/toolbarItemLayout';
+import { STORAGE_KEY_SYSTEM_MANAGER_TAB_LAYOUT } from '../../infrastructure/config/storageKeys';
 import type { Snippet, TerminalSession } from '../../types';
 import { cn } from '../../lib/utils';
 import { DockerManagerTab } from './DockerManagerTab';
@@ -25,6 +29,20 @@ import { WorkspaceSidebarHostHeader } from '../terminalLayer/WorkspaceSidebarHos
 import { TERMINAL_SIDE_PANEL_INNER_HEADER_CLASS } from '../terminalLayer/terminalSidePanelChrome';
 import { SystemPanelEmpty, SystemPanelShell } from './SystemPanelUi';
 import { useSessionCapabilities } from '../../application/state/useSystemManager';
+import {
+  ToolbarCustomizeContextMenu,
+  ToolbarOverflowMenu,
+  type ToolbarCustomizeItem,
+} from '../ui/toolbar-item-layout';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
+import {
+  applyHorizontalWheelToScrollContainer,
+  measureSystemManagerTabBarLabeledFit,
+  resolveSystemManagerTabBarIconOnly,
+  scrollSystemManagerTabIntoView,
+  SYSTEM_MANAGER_TAB_BAR_ICON_ONLY_CLASS,
+  SYSTEM_MANAGER_TAB_BAR_SETTLE_MS,
+} from './systemManagerTabBarScroll';
 
 const SystemPanelChecking = memo(function SystemPanelChecking({
   message,
@@ -71,6 +89,7 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
     () => buildSystemManagerTabs(sessionHost, capabilities, session),
     [capabilities, session, sessionHost],
   );
+  const availableTabsKey = availableTabs.join(',');
   const isStatsSupportedOs = useMemo(
     () => shouldCollectServerStats(sessionHost, capabilities, session),
     [capabilities, session, sessionHost],
@@ -80,8 +99,157 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
     [sessionHost],
   );
 
+  const tabLayout = useToolbarItemLayout(
+    STORAGE_KEY_SYSTEM_MANAGER_TAB_LAYOUT,
+    SYSTEM_MANAGER_TAB_LAYOUT_DEFAULTS,
+  );
+
+  const tabDefs = useMemo(
+    (): { id: SystemManagerSubTab; icon: LucideIcon; label: string }[] => [
+      { id: 'overview', icon: Gauge, label: t('systemManager.tabs.overview') },
+      { id: 'processes', icon: LayoutList, label: t('systemManager.tabs.processes') },
+      { id: 'ports', icon: Network, label: t('systemManager.tabs.ports') },
+      { id: 'services', icon: Cog, label: t('systemManager.tabs.services') },
+      { id: 'tmux', icon: TerminalSquare, label: t('systemManager.tabs.tmux') },
+      { id: 'docker', icon: Box, label: t('systemManager.tabs.docker') },
+      { id: 'gpu', icon: CircuitBoard, label: t('systemManager.tabs.gpu') },
+    ],
+    [t],
+  );
+  const tabDefById = useMemo(
+    () => new Map(tabDefs.map((tab) => [tab.id, tab])),
+    [tabDefs],
+  );
+
+  // Host-available sections only; layout order / placement still covers the full set.
+  const tabPartition = useMemo(
+    () => tabLayout.partition(availableTabs),
+    [availableTabs, tabLayout],
+  );
+  const shownTabs = tabPartition.shown as SystemManagerSubTab[];
+  const collapsedTabs = tabPartition.collapsed as SystemManagerSubTab[];
+  const reachableTabs = useMemo(
+    () => [...shownTabs, ...collapsedTabs],
+    [collapsedTabs, shownTabs],
+  );
+
+  // Customize menu lists every host-available section (including hidden) so
+  // users can re-show hidden tabs; order follows persisted layout.
+  const customizeItems = useMemo<ToolbarCustomizeItem[]>(() => {
+    const available = new Set(availableTabs);
+    return tabLayout.layout.order
+      .filter((id): id is SystemManagerSubTab => available.has(id as SystemManagerSubTab))
+      .map((id) => {
+        const def = tabDefById.get(id);
+        if (!def) return null;
+        const Icon = def.icon;
+        return {
+          id,
+          label: def.label,
+          icon: <Icon size={12} />,
+          locked: id === 'overview',
+        } satisfies ToolbarCustomizeItem;
+      })
+      .filter((item): item is ToolbarCustomizeItem => item != null);
+  }, [availableTabs, tabDefById, tabLayout.layout.order]);
+
   const [activeTab, setActiveTab] = useState<SystemManagerSubTab>('overview');
-  const resolvedTab = availableTabs.includes(activeTab) ? activeTab : 'overview';
+  const resolvedTab = reachableTabs.includes(activeTab)
+    ? activeTab
+    : (shownTabs[0] ?? collapsedTabs[0] ?? 'overview');
+
+  const [tabBarEl, setTabBarEl] = useState<HTMLDivElement | null>(null);
+  const tabBarRef = useCallback((node: HTMLDivElement | null) => {
+    setTabBarEl((prev) => (prev === node ? prev : node));
+  }, []);
+  const [iconOnlyTabs, setIconOnlyTabs] = useState(false);
+  const iconOnlyTabsRef = React.useRef(iconOnlyTabs);
+  iconOnlyTabsRef.current = iconOnlyTabs;
+  const isConnectedSession = Boolean(sessionId && session && isConnected);
+  const shownTabsKey = shownTabs.join(',');
+
+  // Icon-only when labeled tabs would overflow the real bar width (not a rem guess).
+  // Debounced so side-panel drag does not thrash; re-check on pointerup.
+  useEffect(() => {
+    if (!isConnectedSession || !tabBarEl) return;
+
+    let cancelled = false;
+    let settleTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const applyCompact = () => {
+      if (cancelled) return;
+      const next = resolveSystemManagerTabBarIconOnly(
+        measureSystemManagerTabBarLabeledFit(tabBarEl),
+        iconOnlyTabsRef.current,
+      );
+      setIconOnlyTabs((prev) => (prev === next ? prev : next));
+    };
+
+    const scheduleCompact = () => {
+      if (settleTimer != null) clearTimeout(settleTimer);
+      settleTimer = setTimeout(() => {
+        settleTimer = null;
+        applyCompact();
+      }, SYSTEM_MANAGER_TAB_BAR_SETTLE_MS);
+    };
+
+    // Immediate measure (and again next frame after layout from tab mount/paint).
+    applyCompact();
+    const rafId = requestAnimationFrame(() => {
+      if (!cancelled) applyCompact();
+    });
+
+    const ro = typeof ResizeObserver !== 'undefined'
+      ? new ResizeObserver(() => {
+          scheduleCompact();
+        })
+      : null;
+    ro?.observe(tabBarEl);
+    const shell = tabBarEl.closest('[data-section="system-manager-panel"]');
+    if (shell instanceof HTMLElement && shell !== tabBarEl) {
+      ro?.observe(shell);
+    }
+
+    // Side-panel drag ends on pointerup — re-measure even if RO was quiet.
+    const onPointerUp = () => {
+      scheduleCompact();
+    };
+    window.addEventListener('pointerup', onPointerUp);
+    window.addEventListener('pointercancel', onPointerUp);
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(rafId);
+      if (settleTimer != null) clearTimeout(settleTimer);
+      ro?.disconnect();
+      window.removeEventListener('pointerup', onPointerUp);
+      window.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [isConnectedSession, isVisible, availableTabsKey, shownTabsKey, tabBarEl]);
+
+  // Keep the active sub-tab visible when the strip overflows (icon-only or labeled).
+  useLayoutEffect(() => {
+    if (!isConnectedSession || !tabBarEl) return;
+    const active = tabBarEl.querySelector<HTMLElement>('[data-system-tab-active="true"]');
+    scrollSystemManagerTabIntoView(tabBarEl, active, 'smooth');
+  }, [resolvedTab, availableTabsKey, isConnectedSession, isVisible, tabBarEl, shownTabsKey, iconOnlyTabs]);
+
+  // Vertical mouse wheel → horizontal scroll when the row overflows.
+  useEffect(() => {
+    if (!isConnectedSession || !tabBarEl) return;
+
+    const onWheel = (event: WheelEvent) => {
+      if (applyHorizontalWheelToScrollContainer(tabBarEl, event)) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    };
+
+    tabBarEl.addEventListener('wheel', onWheel, { passive: false });
+    return () => {
+      tabBarEl.removeEventListener('wheel', onWheel);
+    };
+  }, [isConnectedSession, isVisible, availableTabsKey, tabBarEl]);
 
   // Must be defined before early returns to comply with React rules of hooks.
   const prevTabRef = React.useRef(resolvedTab);
@@ -146,6 +314,23 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
     };
   }, [isVisible, resolvedTab, capabilities?.hasDocker, capabilitiesTtlMs]);
 
+  const selectTab = useCallback((id: SystemManagerSubTab) => {
+    setActiveTab(id);
+  }, []);
+
+  const handleSetTabPlacement = useCallback(
+    (id: string, placement: 'show' | 'collapse' | 'hide') => {
+      const next = tabLayout.setPlacement(id, placement, availableTabs);
+      // Hide of the active tab → jump to the first still-reachable section.
+      if (activeTab === id && (next.placement[id] ?? 'show') === 'hide') {
+        const part = partitionToolbarItems(next, availableTabs);
+        const fallback = (part.shown[0] ?? part.collapsed[0]) as SystemManagerSubTab | undefined;
+        if (fallback) setActiveTab(fallback);
+      }
+    },
+    [activeTab, availableTabs, tabLayout],
+  );
+
   const workspaceHostHeader = showWorkspaceHostHeader && sessionHost ? (
     <WorkspaceSidebarHostHeader
       host={sessionHost}
@@ -170,16 +355,6 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
       </SystemPanelShell>
     );
   }
-
-  const tabDefs: { id: SystemManagerSubTab; icon: LucideIcon; label: string }[] = [
-    { id: 'overview', icon: Gauge, label: t('systemManager.tabs.overview') },
-    { id: 'processes', icon: LayoutList, label: t('systemManager.tabs.processes') },
-    { id: 'ports', icon: Network, label: t('systemManager.tabs.ports') },
-    { id: 'services', icon: Cog, label: t('systemManager.tabs.services') },
-    { id: 'tmux', icon: TerminalSquare, label: t('systemManager.tabs.tmux') },
-    { id: 'docker', icon: Box, label: t('systemManager.tabs.docker') },
-    { id: 'gpu', icon: CircuitBoard, label: t('systemManager.tabs.gpu') },
-  ];
 
   const tmuxReady = capabilities?.hasTmux === true;
   const dockerReady = capabilities?.hasDocker === true;
@@ -219,38 +394,110 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
   return (
     <SystemPanelShell section="system-manager-panel">
       {workspaceHostHeader}
-      <div className={cn(
-        TERMINAL_SIDE_PANEL_INNER_HEADER_CLASS,
-        'flex items-center gap-0.5 px-2 border-b border-border/50',
-      )}>
-        {tabDefs.filter((tab) => availableTabs.includes(tab.id)).map(({ id, icon: Icon, label }) => (
-          <button
-            key={id}
-            type="button"
-            className={cn(
-              'h-6 flex items-center gap-1.5 px-2 rounded text-[11px] transition-colors',
-              resolvedTab === id
-                ? 'bg-muted text-foreground font-medium'
-                : 'text-muted-foreground hover:text-foreground',
-            )}
-            onClick={() => setActiveTab(id)}
-          >
-            <Icon size={12} />
-            {label}
-          </button>
-        ))}
+      <div
+        ref={tabBarRef}
+        className={cn(
+          TERMINAL_SIDE_PANEL_INNER_HEADER_CLASS,
+          'system-manager-tab-bar flex min-w-0 w-full items-center px-2 border-b border-border/50',
+          iconOnlyTabs && SYSTEM_MANAGER_TAB_BAR_ICON_ONLY_CLASS,
+        )}
+        role="tablist"
+        aria-label={t('systemManager.tabs.ariaLabel')}
+        data-section="system-manager-tabs"
+        data-icon-only={iconOnlyTabs ? 'true' : undefined}
+      >
+        <ToolbarCustomizeContextMenu
+          items={customizeItems}
+          placementOf={(id) => tabLayout.layout.placement[id] ?? 'show'}
+          onSetPlacement={handleSetTabPlacement}
+          onMove={(id, direction) =>
+            tabLayout.move(id, direction, availableTabs)
+          }
+          onReset={tabLayout.reset}
+          t={t}
+          className="flex min-w-0 w-full items-center gap-0.5"
+          dataSection="system-manager-tab-customize"
+        >
+          {shownTabs.map((id) => {
+            const def = tabDefById.get(id);
+            if (!def) return null;
+            const { icon: Icon, label } = def;
+            const isActive = resolvedTab === id;
+            return (
+              <Tooltip key={id}>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    aria-label={label}
+                    data-system-tab-active={isActive ? 'true' : undefined}
+                    className={cn(
+                      'system-manager-tab h-6 flex items-center gap-1.5 px-2 rounded text-[11px] transition-colors',
+                      isActive
+                        ? 'bg-muted text-foreground font-medium'
+                        : 'text-muted-foreground hover:text-foreground',
+                    )}
+                    onClick={(event) => {
+                      selectTab(id);
+                      scrollSystemManagerTabIntoView(tabBarEl, event.currentTarget, 'smooth');
+                    }}
+                  >
+                    <Icon size={12} className="shrink-0" />
+                    <span className="system-manager-tab-label">{label}</span>
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={6}>
+                  {label}
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
+          <div className="ml-auto shrink-0" data-section="system-manager-tab-overflow">
+            <ToolbarOverflowMenu
+              hasItems={collapsedTabs.length > 0}
+              label={t('common.more')}
+              orientation="horizontal"
+              buttonClassName="h-6 w-6 shrink-0 rounded-md p-0"
+              contentClassName="min-w-[10rem] p-1"
+            >
+              <div className="flex min-w-[10rem] flex-col">
+                {collapsedTabs.map((id) => {
+                  const def = tabDefById.get(id);
+                  if (!def) return null;
+                  const { icon: Icon, label } = def;
+                  const isActive = resolvedTab === id;
+                  return (
+                    <button
+                      key={id}
+                      type="button"
+                      className={cn(
+                        'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs transition-colors hover:bg-secondary',
+                        isActive && 'bg-secondary font-medium',
+                      )}
+                      onClick={() => selectTab(id)}
+                    >
+                      <Icon size={12} className="shrink-0" />
+                      <span className="truncate">{label}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </ToolbarOverflowMenu>
+          </div>
+        </ToolbarCustomizeContextMenu>
       </div>
 
       <div className="flex-1 min-h-0 flex flex-col">
+        {/* Keep Overview mounted (CSS-hidden) like other system tabs so shared
+            server-stats cache + sparkline history survive tab switches. */}
         <div className={cn('flex-1 min-h-0 flex flex-col', resolvedTab !== 'overview' && 'hidden')}>
-          {resolvedTab === 'overview' && (
-            <SystemOverviewTab
-              sessionId={sessionId}
-              isVisible={isVisible}
-              isSupportedOs={isStatsSupportedOs}
-              refreshIntervalSec={terminalSettings.serverStatsRefreshInterval}
-            />
-          )}
+          <SystemOverviewTab
+            sessionId={sessionId}
+            isVisible={isVisible && resolvedTab === 'overview'}
+            isSupportedOs={isStatsSupportedOs}
+            refreshIntervalSec={terminalSettings.serverStatsRefreshInterval}
+          />
         </div>
         {availableTabs.includes('processes') ? (
           <div className={cn('flex-1 min-h-0 flex flex-col', resolvedTab !== 'processes' && 'hidden')}>

--- a/components/systemManager/SystemOverviewTab.tsx
+++ b/components/systemManager/SystemOverviewTab.tsx
@@ -267,8 +267,11 @@ export const SystemOverviewTab = memo(function SystemOverviewTab({
     network: history.map((sample) => sample.network),
   }), [history]);
 
+  // Prefer cached stats over empty/loading so tab switches never flash the
+  // empty placeholder when we already have a successful sample.
   const showBlockingError = Boolean(error && !hasStats && !loading);
   const showInitialLoading = Boolean(loading && !hasStats);
+  const showEmpty = Boolean(!hasStats && !loading && !error);
 
   return (
     <SystemPanelShell section="system-manager-overview">
@@ -285,9 +288,9 @@ export const SystemOverviewTab = memo(function SystemOverviewTab({
         <SystemPanelError message={error} onRetry={() => void refresh()} retryLabel={t('history.action.retry')} loading={loading} />
       ) : showInitialLoading ? (
         <SystemPanelLoading message={t('systemManager.overview.loading')} />
-      ) : !hasStats ? (
+      ) : showEmpty ? (
         <SystemPanelEmpty icon={Activity} message={t('systemManager.overview.empty')} />
-      ) : (
+      ) : hasStats ? (
         <div className="flex-1 min-h-0 overflow-y-auto px-3 py-3">
           <div className="grid grid-cols-2 gap-2">
             <MetricCard
@@ -428,7 +431,7 @@ export const SystemOverviewTab = memo(function SystemOverviewTab({
             )}
           </section>
         </div>
-      )}
+      ) : null}
     </SystemPanelShell>
   );
 });

--- a/components/systemManager/systemManagerTabBarScroll.test.ts
+++ b/components/systemManager/systemManagerTabBarScroll.test.ts
@@ -202,3 +202,17 @@ test('resolveSystemManagerTabBarIconOnly enters and leaves with hysteresis', () 
     false,
   );
 });
+
+test('measureSystemManagerTabBarLabeledFit does not pretend zero-width bar fits labels', () => {
+  const container = {
+    clientWidth: 0,
+    classList: { contains: () => true, remove() {}, add() {} },
+    querySelectorAll: () => [] as unknown as NodeListOf<HTMLElement>,
+  } as unknown as HTMLElement;
+
+  const fit = measureSystemManagerTabBarLabeledFit(container);
+  assert.equal(fit.overflows, false);
+  assert.equal(fit.fitsWithSlack, false);
+  // Keep icon-only while the host is hidden / not laid out.
+  assert.equal(resolveSystemManagerTabBarIconOnly(fit, true), true);
+});

--- a/components/systemManager/systemManagerTabBarScroll.test.ts
+++ b/components/systemManager/systemManagerTabBarScroll.test.ts
@@ -1,0 +1,204 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  applyHorizontalWheelToScrollContainer,
+  measureSystemManagerTabBarLabeledFit,
+  resolveSystemManagerTabBarIconOnly,
+  scrollSystemManagerTabIntoView,
+  SYSTEM_MANAGER_TAB_BAR_EXPAND_SLACK_PX,
+  SYSTEM_MANAGER_TAB_BAR_ICON_ONLY_CLASS,
+} from './systemManagerTabBarScroll.ts';
+
+function mockRect(left: number, width: number) {
+  return {
+    left,
+    right: left + width,
+    width,
+    top: 0,
+    bottom: 24,
+    height: 24,
+    x: left,
+    y: 0,
+    toJSON() {
+      return this;
+    },
+  } as DOMRect;
+}
+
+test('scrollSystemManagerTabIntoView is a no-op when content fits', () => {
+  const calls: Array<{ left: number; behavior?: ScrollBehavior }> = [];
+  const container = {
+    scrollWidth: 200,
+    clientWidth: 200,
+    scrollLeft: 0,
+    getBoundingClientRect: () => mockRect(0, 200),
+    scrollTo(options: { left: number; behavior?: ScrollBehavior }) {
+      calls.push(options);
+    },
+  } as unknown as HTMLElement;
+  const tab = {
+    getBoundingClientRect: () => mockRect(20, 60),
+  } as unknown as HTMLElement;
+
+  scrollSystemManagerTabIntoView(container, tab);
+  assert.equal(calls.length, 0);
+});
+
+test('applyHorizontalWheelToScrollContainer maps vertical wheel to horizontal scroll', () => {
+  const container = {
+    scrollWidth: 500,
+    clientWidth: 200,
+    scrollLeft: 0,
+  } as unknown as HTMLElement;
+
+  assert.equal(
+    applyHorizontalWheelToScrollContainer(container, { deltaX: 0, deltaY: 40, deltaMode: 0 }),
+    true,
+  );
+  assert.equal(container.scrollLeft, 40);
+});
+
+test('measureSystemManagerTabBarLabeledFit sums tab boxes (not scrollWidth===clientWidth trap)', () => {
+  const label = { style: { display: 'none' } } as unknown as HTMLElement;
+  const tabA = {
+    getBoundingClientRect: () => mockRect(0, 80),
+  } as unknown as HTMLElement;
+  const tabB = {
+    getBoundingClientRect: () => mockRect(82, 90),
+  } as unknown as HTMLElement;
+  const row = {
+    // gap-0.5 ≈ 2px
+  } as unknown as HTMLElement;
+  Object.defineProperty(tabA, 'parentElement', { get: () => row });
+  Object.defineProperty(tabB, 'parentElement', { get: () => row });
+
+  const classList = {
+    iconOnly: true,
+    contains(name: string) {
+      return name === SYSTEM_MANAGER_TAB_BAR_ICON_ONLY_CLASS && this.iconOnly;
+    },
+    remove(name: string) {
+      if (name === SYSTEM_MANAGER_TAB_BAR_ICON_ONLY_CLASS) this.iconOnly = false;
+    },
+    add(name: string) {
+      if (name === SYSTEM_MANAGER_TAB_BAR_ICON_ONLY_CLASS) this.iconOnly = true;
+    },
+  };
+
+  // Wide panel: 400px budget, tabs total 80+90+2 = 172 → should fit.
+  const container = {
+    clientWidth: 400,
+    offsetWidth: 400,
+    classList,
+    querySelectorAll(selector: string) {
+      if (selector === '.system-manager-tab-label') {
+        return [label, label] as unknown as NodeListOf<HTMLElement>;
+      }
+      if (selector === '.system-manager-tab') {
+        return [tabA, tabB] as unknown as NodeListOf<HTMLElement>;
+      }
+      return [] as unknown as NodeListOf<HTMLElement>;
+    },
+    querySelector() {
+      return null;
+    },
+  } as unknown as HTMLElement;
+
+  // jsdom may not have getComputedStyle for gap/padding — stub global if needed.
+  const originalGcs = globalThis.getComputedStyle;
+  globalThis.getComputedStyle = ((el: Element) => {
+    if (el === row) {
+      return { columnGap: '2px', gap: '2px', paddingLeft: '0', paddingRight: '0' } as CSSStyleDeclaration;
+    }
+    if (el === container) {
+      return { paddingLeft: '8px', paddingRight: '8px' } as CSSStyleDeclaration;
+    }
+    return originalGcs(el);
+  }) as typeof getComputedStyle;
+
+  try {
+    const fit = measureSystemManagerTabBarLabeledFit(container, SYSTEM_MANAGER_TAB_BAR_EXPAND_SLACK_PX);
+    // content 172, pad 16 → available 384 → fits
+    assert.equal(fit.overflows, false);
+    assert.equal(fit.fitsWithSlack, true);
+    assert.equal(classList.iconOnly, true);
+    assert.equal(label.style.display, 'none');
+  } finally {
+    globalThis.getComputedStyle = originalGcs;
+  }
+});
+
+test('measureSystemManagerTabBarLabeledFit reports overflow when tabs exceed budget', () => {
+  const label = { style: { display: '' } } as unknown as HTMLElement;
+  const tabA = {
+    getBoundingClientRect: () => mockRect(0, 200),
+    parentElement: null as HTMLElement | null,
+  } as unknown as HTMLElement;
+  const tabB = {
+    getBoundingClientRect: () => mockRect(0, 200),
+    parentElement: null as HTMLElement | null,
+  } as unknown as HTMLElement;
+  const row = {} as HTMLElement;
+  Object.defineProperty(tabA, 'parentElement', { get: () => row });
+  Object.defineProperty(tabB, 'parentElement', { get: () => row });
+
+  const classList = {
+    contains: () => false,
+    remove() {},
+    add() {},
+  };
+
+  const container = {
+    clientWidth: 300,
+    offsetWidth: 300,
+    classList,
+    querySelectorAll(selector: string) {
+      if (selector === '.system-manager-tab-label') {
+        return [label] as unknown as NodeListOf<HTMLElement>;
+      }
+      if (selector === '.system-manager-tab') {
+        return [tabA, tabB] as unknown as NodeListOf<HTMLElement>;
+      }
+      return [] as unknown as NodeListOf<HTMLElement>;
+    },
+    querySelector() {
+      return null;
+    },
+  } as unknown as HTMLElement;
+
+  const originalGcs = globalThis.getComputedStyle;
+  globalThis.getComputedStyle = ((el: Element) => {
+    if (el === row) {
+      return { columnGap: '4px', gap: '4px', paddingLeft: '0', paddingRight: '0' } as CSSStyleDeclaration;
+    }
+    if (el === container) {
+      return { paddingLeft: '0', paddingRight: '0' } as CSSStyleDeclaration;
+    }
+    return originalGcs(el);
+  }) as typeof getComputedStyle;
+
+  try {
+    const fit = measureSystemManagerTabBarLabeledFit(container);
+    // 200+200+4 = 404 > 300
+    assert.equal(fit.overflows, true);
+    assert.equal(fit.fitsWithSlack, false);
+  } finally {
+    globalThis.getComputedStyle = originalGcs;
+  }
+});
+
+test('resolveSystemManagerTabBarIconOnly enters and leaves with hysteresis', () => {
+  assert.equal(
+    resolveSystemManagerTabBarIconOnly({ overflows: true, fitsWithSlack: false }, false),
+    true,
+  );
+  assert.equal(
+    resolveSystemManagerTabBarIconOnly({ overflows: false, fitsWithSlack: false }, true),
+    true,
+  );
+  assert.equal(
+    resolveSystemManagerTabBarIconOnly({ overflows: false, fitsWithSlack: true }, true),
+    false,
+  );
+});

--- a/components/systemManager/systemManagerTabBarScroll.ts
+++ b/components/systemManager/systemManagerTabBarScroll.ts
@@ -1,0 +1,186 @@
+/** Edge buffer so an active tab is not stuck flush against the clip edge. */
+const TAB_COMFORT_EDGE_RATIO = 0.28;
+const TAB_COMFORT_EDGE_MIN = 28;
+const TAB_COMFORT_EDGE_MAX = 72;
+
+export const SYSTEM_MANAGER_TAB_BAR_ICON_ONLY_CLASS = 'system-manager-tab-bar--icon-only';
+
+/** Quiet period after resize before re-evaluating icon-only (side-panel drag). */
+export const SYSTEM_MANAGER_TAB_BAR_SETTLE_MS = 120;
+
+/**
+ * Extra room required before leaving icon-only. Keeps a small hysteresis without
+ * locking the bar into permanent icon-only mode.
+ */
+export const SYSTEM_MANAGER_TAB_BAR_EXPAND_SLACK_PX = 8;
+
+export type SystemManagerTabBarLabeledFit = {
+  /** Labeled tabs need more width than the bar's inner budget. */
+  overflows: boolean;
+  /** Labeled tabs fit with expand slack — safe to show text again. */
+  fitsWithSlack: boolean;
+};
+
+function readFlexGapPx(el: HTMLElement | null | undefined): number {
+  if (!el) return 0;
+  const style = getComputedStyle(el);
+  const raw = style.columnGap || style.gap || '0';
+  const value = parseFloat(raw);
+  return Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * Measure whether the *labeled* tab strip fits in the bar's current width.
+ *
+ * Important: do not use scrollWidth vs clientWidth for the "fits" check.
+ * When content does not overflow, browsers often report scrollWidth === clientWidth,
+ * so "fitsWithSlack" becomes permanently false and icon-only never exits.
+ *
+ * Instead: force labels on, sum real tab (and overflow) box widths, compare to
+ * the bar's inner budget (clientWidth minus horizontal padding).
+ */
+export function measureSystemManagerTabBarLabeledFit(
+  container: HTMLElement | null | undefined,
+  expandSlackPx: number = SYSTEM_MANAGER_TAB_BAR_EXPAND_SLACK_PX,
+): SystemManagerTabBarLabeledFit {
+  if (!container) {
+    return { overflows: false, fitsWithSlack: true };
+  }
+
+  const budget = container.clientWidth;
+  if (budget <= 0) {
+    return { overflows: false, fitsWithSlack: true };
+  }
+
+  const labelEls = Array.from(
+    container.querySelectorAll<HTMLElement>('.system-manager-tab-label'),
+  );
+  const hadIconOnly = container.classList.contains(SYSTEM_MANAGER_TAB_BAR_ICON_ONLY_CLASS);
+  const prevDisplay = labelEls.map((el) => el.style.display);
+
+  try {
+    if (hadIconOnly) {
+      container.classList.remove(SYSTEM_MANAGER_TAB_BAR_ICON_ONLY_CLASS);
+    }
+    for (const el of labelEls) {
+      // Force visible for measurement even if a stylesheet still hides them.
+      el.style.display = 'inline';
+    }
+    void container.offsetWidth;
+
+    const tabs = Array.from(container.querySelectorAll<HTMLElement>('.system-manager-tab'));
+    let contentWidth = 0;
+    for (const tab of tabs) {
+      contentWidth += tab.getBoundingClientRect().width;
+    }
+
+    const row = tabs[0]?.parentElement ?? null;
+    const gap = readFlexGapPx(row);
+    if (tabs.length > 1) {
+      contentWidth += gap * (tabs.length - 1);
+    }
+
+    const overflow = container.querySelector<HTMLElement>(
+      '[data-section="system-manager-tab-overflow"]',
+    );
+    if (overflow) {
+      const overflowWidth = overflow.getBoundingClientRect().width;
+      if (overflowWidth > 0.5) {
+        contentWidth += overflowWidth + (tabs.length > 0 ? gap : 0);
+      }
+    }
+
+    const style = getComputedStyle(container);
+    const padX = (parseFloat(style.paddingLeft) || 0) + (parseFloat(style.paddingRight) || 0);
+    // clientWidth includes padding; children lay out in the content box.
+    const available = Math.max(0, budget - padX);
+
+    return {
+      overflows: contentWidth > available + 1,
+      fitsWithSlack: contentWidth + expandSlackPx <= available,
+    };
+  } finally {
+    labelEls.forEach((el, i) => {
+      el.style.display = prevDisplay[i] ?? '';
+    });
+    if (hadIconOnly) {
+      container.classList.add(SYSTEM_MANAGER_TAB_BAR_ICON_ONLY_CLASS);
+    }
+  }
+}
+
+/**
+ * Enter icon-only as soon as labels overflow; leave only when they fit with slack.
+ */
+export function resolveSystemManagerTabBarIconOnly(
+  fit: SystemManagerTabBarLabeledFit,
+  currentlyIconOnly: boolean,
+): boolean {
+  if (currentlyIconOnly) {
+    return !fit.fitsWithSlack;
+  }
+  return fit.overflows;
+}
+
+/**
+ * Scroll a system-manager sub-tab into a comfortable position inside its
+ * horizontal tab bar. Uses container.scrollTo so nested panels are not
+ * scrolled by element.scrollIntoView.
+ */
+export function scrollSystemManagerTabIntoView(
+  container: HTMLElement | null | undefined,
+  tab: HTMLElement | null | undefined,
+  behavior: ScrollBehavior = 'smooth',
+): void {
+  if (!container || !tab) return;
+  if (container.scrollWidth <= container.clientWidth + 1) return;
+
+  const containerRect = container.getBoundingClientRect();
+  const tabRect = tab.getBoundingClientRect();
+  const edgeBuffer = Math.min(
+    TAB_COMFORT_EDGE_MAX,
+    Math.max(TAB_COMFORT_EDGE_MIN, containerRect.width * TAB_COMFORT_EDGE_RATIO),
+  );
+
+  const overflowsLeft = tabRect.left < containerRect.left + edgeBuffer;
+  const overflowsRight = tabRect.right > containerRect.right - edgeBuffer;
+  if (!overflowsLeft && !overflowsRight) return;
+
+  const tabCenter =
+    tabRect.left - containerRect.left + container.scrollLeft + tabRect.width / 2;
+  const maxScrollLeft = container.scrollWidth - container.clientWidth;
+  const targetLeft = Math.max(
+    0,
+    Math.min(maxScrollLeft, tabCenter - container.clientWidth / 2),
+  );
+
+  if (Math.abs(container.scrollLeft - targetLeft) < 1) return;
+  container.scrollTo({ left: targetLeft, behavior });
+}
+
+/**
+ * Map a wheel event onto horizontal scrollLeft. Vertical mouse wheel becomes
+ * left/right motion when the bar overflows.
+ *
+ * Returns true when the event was consumed (caller should preventDefault).
+ */
+export function applyHorizontalWheelToScrollContainer(
+  container: HTMLElement,
+  event: Pick<WheelEvent, 'deltaX' | 'deltaY' | 'deltaMode'>,
+): boolean {
+  if (container.scrollWidth <= container.clientWidth + 1) return false;
+
+  // Prefer non-zero deltaX so trackpads that emit both axes feel natural.
+  const rawDelta = event.deltaX !== 0 ? event.deltaX : event.deltaY;
+  if (rawDelta === 0) return false;
+
+  // deltaMode: 0 = pixels, 1 = lines, 2 = pages
+  const scale = event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? container.clientWidth : 1;
+  const delta = rawDelta * scale;
+  const maxScrollLeft = container.scrollWidth - container.clientWidth;
+  const next = Math.max(0, Math.min(maxScrollLeft, container.scrollLeft + delta));
+  if (next === container.scrollLeft) return false;
+
+  container.scrollLeft = next;
+  return true;
+}

--- a/components/systemManager/systemManagerTabBarScroll.ts
+++ b/components/systemManager/systemManagerTabBarScroll.ts
@@ -48,8 +48,10 @@ export function measureSystemManagerTabBarLabeledFit(
   }
 
   const budget = container.clientWidth;
+  // Hidden / zero-width host: do not pretend labels fit (that would drop
+  // icon-only while the side panel is display:none or still laying out).
   if (budget <= 0) {
-    return { overflows: false, fitsWithSlack: true };
+    return { overflows: false, fitsWithSlack: false };
   }
 
   const labelEls = Array.from(

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -1090,7 +1090,7 @@ export function useTerminalAutocomplete(
     }
     settledCompletions = completions;
     applyCompletions(completions, currentPrompt);
-  }, [termRef, clearState, containerRef]);
+  }, [termRef, clearState, containerRef, sensitiveInputActiveRef]);
 
   // Keep ref in sync so handleSubDirSelect can call it
   fetchSuggestionsRef.current = fetchSuggestions;

--- a/components/terminal/useServerStats.test.ts
+++ b/components/terminal/useServerStats.test.ts
@@ -31,3 +31,17 @@ test("server stats polling does not stop when its terminal is in the background"
   assert.doesNotMatch(source, /getVisibleServerStatsClients/);
   assert.doesNotMatch(source, /resuming from hidden/);
 });
+
+test("server stats keep last snapshot when all consumers pause", () => {
+  const source = readFileSync(new URL("../../application/state/useServerStats.ts", import.meta.url), "utf8");
+  const reconcileStart = source.indexOf("function reconcileSharedServerStatsSession");
+  const idleBranch = source.indexOf("if (activeClients.length === 0)", reconcileStart);
+  const nextFunction = source.indexOf("\nfunction ", reconcileStart + 1);
+  const idleBody = source.slice(idleBranch, nextFunction === -1 ? undefined : nextFunction);
+
+  assert.notEqual(reconcileStart, -1);
+  assert.notEqual(idleBranch, -1);
+  // Pausing must not wipe lastUpdated stats (Overview tab-switch empty flash).
+  assert.match(idleBody, /clearServerStatsTimers\(session\)/);
+  assert.doesNotMatch(idleBody, /resetServerStatsSession\(session\)/);
+});

--- a/components/terminal/useServerStats.test.ts
+++ b/components/terminal/useServerStats.test.ts
@@ -44,4 +44,8 @@ test("server stats keep last snapshot when all consumers pause", () => {
   // Pausing must not wipe lastUpdated stats (Overview tab-switch empty flash).
   assert.match(idleBody, /clearServerStatsTimers\(session\)/);
   assert.doesNotMatch(idleBody, /resetServerStatsSession\(session\)/);
+  assert.doesNotMatch(idleBody, /createInitialState/);
+  // But give-up must clear so resume can auto-retry after hard failure.
+  assert.match(idleBody, /session\.givenUp = false/);
+  assert.match(idleBody, /session\.consecutiveFailures = 0/);
 });

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -277,9 +277,11 @@ interface AIChatPanelsHostProps {
   onOpenVaultSnippetFromChat?: (snippetId: string) => void;
 }
 
+const EMPTY_WORKSPACES: Workspace[] = [];
+
 interface AIStateMaintenanceHostProps {
   validAIScopeTargetIds: Set<string>;
-  workspaces: Workspace[];
+  workspaces?: Workspace[] | null;
 }
 
 const AIStateProviderInner: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -296,13 +298,16 @@ AIStateProvider.displayName = 'AIStateProvider';
 
 const AIStateMaintenanceHostInner: React.FC<AIStateMaintenanceHostProps> = ({
   validAIScopeTargetIds,
-  workspaces,
+  workspaces: workspacesProp,
 }) => {
   const aiConfig = useContext(AIConfigContext);
 
   if (!aiConfig) {
     throw new Error('AIStateMaintenanceHost must be rendered inside AIStateProvider');
   }
+
+  // Guard missing prop so a wiring gap cannot crash the terminal shell.
+  const workspaces = workspacesProp ?? EMPTY_WORKSPACES;
 
   const {
     cleanupOrphanedSessions,
@@ -396,7 +401,7 @@ AIStateMaintenanceHost.displayName = 'AIStateMaintenanceHost';
 
 interface AISidePanelStateRootProps {
   validAIScopeTargetIds: Set<string>;
-  workspaces: Workspace[];
+  workspaces?: Workspace[] | null;
   children: React.ReactNode;
 }
 

--- a/components/terminalLayer/TerminalLayerTabBridge.tsx
+++ b/components/terminalLayer/TerminalLayerTabBridge.tsx
@@ -658,6 +658,7 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     s.sftpFollowTerminalCwd,
     themeState,
     workspaceById,
+    s.workspaces,
     workspaceInnerRef,
     workspaceOuterRef,
     workspaceOverlayRef,

--- a/components/terminalLayer/TerminalLayerTabBridge.tsx
+++ b/components/terminalLayer/TerminalLayerTabBridge.tsx
@@ -612,6 +612,9 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     validAIScopeTargetIds: s.validAIScopeTargetIds,
     workspaceBroadcastHandlersRef: s.workspaceBroadcastHandlersRef,
     workspaceById,
+    // AI scope maintenance (merge/dissolve handoff) needs the full list; do not
+    // rely on workspaceById alone — SidePanelStateRoot reads ctx.workspaces.
+    workspaces: s.workspaces,
     workspaceFocusHandlersRef: s.workspaceFocusHandlersRef,
     workspaceInnerRef,
     workspaceOuterRef,

--- a/index.css
+++ b/index.css
@@ -274,6 +274,42 @@ html.platform-win32 {
   }
 }
 
+/*
+ * System Manager sub-tab bar.
+ * Icon-only is toggled by JS when labeled tabs actually overflow the bar
+ * (class --icon-only). Horizontal scroll remains for extreme narrow widths.
+ */
+.system-manager-tab-bar {
+  min-width: 0;
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.system-manager-tab-bar::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+.system-manager-tab {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.system-manager-tab-bar--icon-only .system-manager-tab-label {
+  display: none;
+}
+
+.system-manager-tab-bar--icon-only .system-manager-tab {
+  gap: 0;
+  padding-left: 0.375rem;
+  padding-right: 0.375rem;
+}
+
 .host-tree-notes-scroll {
   scrollbar-width: thin;
   scrollbar-color: hsl(var(--muted-foreground) / 0.28) transparent;

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -134,6 +134,8 @@ export const STORAGE_KEY_TERMINAL_HOST_TREE_TOOLBAR_LAYOUT =
   'netcatty_terminal_host_tree_toolbar_layout_v1';
 /** Side-panel tab strip: show / collapse / hide + order (supersedes order-only key when present). */
 export const STORAGE_KEY_TERMINAL_SIDE_PANEL_TAB_LAYOUT = 'netcatty_terminal_side_panel_tab_layout_v1';
+/** System Manager sub-tabs (Overview / Processes / …): show / collapse / hide + order. */
+export const STORAGE_KEY_SYSTEM_MANAGER_TAB_LAYOUT = 'netcatty_system_manager_tab_layout_v1';
 export const STORAGE_KEY_SFTP_TRANSFER_PANEL_HEIGHT = 'netcatty_sftp_transfer_panel_height_v1';
 export const STORAGE_KEY_SFTP_TRANSFER_CHILD_NAME_WIDTH = 'netcatty_sftp_transfer_child_name_width_v1';
 


### PR DESCRIPTION
## Summary

Multi-area stability and polish for the terminal side panels:

- **AI chat**: stop StrictMode/draft races from demoting a just-sent session into history; keep Streamdown live (`isAnimating`) while streaming; wire `workspaces` into AI scope maintenance so workspace merge/dissolve no longer crashes the terminal shell.
- **System Manager**: overflow-measured icon-only tab labels, horizontal wheel scroll, active-tab auto-scroll, toolbar customize (show/collapse/hide + reorder), keep Overview mounted so server-stats cache + sparklines survive tab switches, GPU monochrome vendor badges + compact sparkline history.
- **Settings**: search focus scrolls only the content pane (`data-settings-scroll-pane`) so macOS traffic lights stay put; remove SettingRow rounding that bent `divide-y` separators.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- `shouldForceDraftViewSync` + live `sessions` (drop deferred lag) so explicit session views are not force-synced to draft while the session still exists
- Do not clear active-session ownership when the panel is still on an explicit session view
- Pass `workspaces` through `TerminalLayerTabBridge` / guard missing prop in `AIStateMaintenanceHost`
- System Manager tab bar: measure-based icon-only mode, customize menu, overflow menu, scroll helpers
- Shared server-stats: pause polling without wiping the last snapshot (no overview empty flash)
- Settings focus: pane-scoped scroll + square SettingRow corners for clean dividers
- GPU: `GpuVendorBadge` (NVIDIA / Ascend inline SVG), layout/sparkline polish
- eslint dep for autocomplete sensitive-input ref; unit tests for the above

## Screenshots / Demo

N/A (manual: AI send under StrictMode, System Manager narrow width + tab switch, Settings search jump under traffic lights)

## Testing

- [x] I have tested these changes locally (`npm run dev`) — unit coverage for the changed paths
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — targeted suites for AI panel view, ChatMessageList, System Manager, settings focus, server stats (85+ tests)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`) — N/A
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

## Review fixes applied before open

- Moved `selectTab` / `handleSetTabPlacement` above early returns (react-hooks/rules-of-hooks)
- Removed unused `resetServerStatsSession` after keep-cache-on-pause
- Dropped unused `public/system-icons/{nvidia,huawei}.svg` (badges use inline SVG)
- Fixed useless-escape in ChatMessageList stream test regex