### PR TITLE
fix(ai): keep workspace chat when follow-up draft is typed after merge

### DIFF
--- a/application/state/useAIState.ts
+++ b/application/state/useAIState.ts
@@ -982,17 +982,24 @@ export function useAIState() {
       latestAIActiveSessionMapSnapshot
       ?? localStorageAdapter.read<Record<string, string | null>>(STORAGE_KEY_AI_ACTIVE_SESSION_MAP)
       ?? {};
-    const nextMap = seedWorkspaceAIActiveSessionFromMembers({
+    const currentPanelViewByScope = latestAIPanelViewByScopeSnapshot ?? {};
+    const seeded = seedWorkspaceAIActiveSessionFromMembers({
       activeSessionIdMap: currentMap,
+      panelViewByScope: currentPanelViewByScope,
       workspaceId: input.workspaceId,
       memberTerminalIds: input.memberTerminalIds,
       preferredTerminalId: input.preferredTerminalId,
     });
-    if (!nextMap) return;
-    setLatestAIActiveSessionMapSnapshot(nextMap);
-    localStorageAdapter.write(STORAGE_KEY_AI_ACTIVE_SESSION_MAP, nextMap);
+    if (!seeded) return;
+    setLatestAIActiveSessionMapSnapshot(seeded.activeSessionIdMap);
+    localStorageAdapter.write(STORAGE_KEY_AI_ACTIVE_SESSION_MAP, seeded.activeSessionIdMap);
     emitAIStateChanged(STORAGE_KEY_AI_ACTIVE_SESSION_MAP);
-    setActiveSessionIdMapRaw(nextMap);
+    setActiveSessionIdMapRaw(seeded.activeSessionIdMap);
+    if (seeded.panelViewChanged) {
+      setLatestAIPanelViewByScopeSnapshot(seeded.panelViewByScope);
+      emitAIStateChanged(AI_STATE_CHANGED_PANEL_VIEW_BY_SCOPE);
+      setPanelViewByScopeRaw(seeded.panelViewByScope);
+    }
   }, []);
 
   const handoffDissolvedWorkspaceScope = useCallback((input: {

--- a/components/ai/aiPanelViewState.test.ts
+++ b/components/ai/aiPanelViewState.test.ts
@@ -169,18 +169,44 @@ test("terminal scope without explicit view always starts from draft even when hi
   );
 });
 
-test("missing explicit panel view prefers the draft when unsent input exists", () => {
+test("missing explicit panel view prefers the draft when unsent input exists without an active chat", () => {
   const sessions = [createSession("session-2"), createSession("session-1")];
 
   assert.deepEqual(
-    resolveDisplayedPanelView(undefined, true, sessions),
+    resolveDisplayedPanelView(undefined, true, sessions, null, "workspace"),
+    { mode: "draft" },
+  );
+});
+
+test("workspace unsent draft keeps the persisted active chat after merge seed", () => {
+  // Merge often seeds activeSessionIdMap without writing panelView. Typing a
+  // follow-up must not demote to draft or send will createSession().
+  const sessions = [createSession("session-2"), createSession("session-1")];
+
+  assert.deepEqual(
+    resolveDisplayedPanelView(undefined, true, sessions, "session-1", "workspace"),
+    { mode: "session", sessionId: "session-1" },
+  );
+});
+
+test("explicit new-chat draft still wins over a stale persisted id", () => {
+  const sessions = [createSession("session-2"), createSession("session-1")];
+
+  assert.deepEqual(
+    resolveDisplayedPanelView(
+      { mode: "draft" },
+      true,
+      sessions,
+      "session-1",
+      "workspace",
+    ),
     { mode: "draft" },
   );
 });
 
 test("draft state is used when there is no implicit history to resume", () => {
   assert.deepEqual(
-    resolveDisplayedPanelView(undefined, true, []),
+    resolveDisplayedPanelView(undefined, true, [], null, "workspace"),
     { mode: "draft" },
   );
 });

--- a/components/ai/aiPanelViewState.ts
+++ b/components/ai/aiPanelViewState.ts
@@ -44,20 +44,26 @@ export function resolveDisplayedPanelView(
     return normalizePanelView(panelView, sessions);
   }
 
-  if (hasDraft) {
-    return DEFAULT_PANEL_VIEW;
-  }
-
   // New terminal sessions should always start from a blank draft. History is
   // still available in the drawer, but never auto-resumed into a fresh SSH tab.
+  // Explicit panelView above is the only way a terminal scope shows a session
+  // (e.g. after dissolve handoff writes mode:session).
   if (scopeType === "terminal") {
     return DEFAULT_PANEL_VIEW;
   }
 
-  // Honour the persisted active-session selection (survives cold mount)
-  // before falling back to the newest history entry.
+  // Workspace: keep the inherited/persisted active chat when the user starts
+  // typing a follow-up. Merge seed often writes activeSessionIdMap only, with
+  // no explicit panelView — if unsent draft outranked that selection, send
+  // would createSession() while the main area still looked like the old chat.
+  // Explicit "New Chat" clears the active map and writes mode:draft, so it
+  // still wins via the panelView branch above.
   if (persistedSessionId && sessions.some((s) => s.id === persistedSessionId)) {
     return { mode: "session", sessionId: persistedSessionId };
+  }
+
+  if (hasDraft) {
+    return DEFAULT_PANEL_VIEW;
   }
 
   if (sessions[0]) {

--- a/domain/workspaceAiScopeHandoff.test.ts
+++ b/domain/workspaceAiScopeHandoff.test.ts
@@ -18,10 +18,16 @@ test('seedWorkspaceAIActiveSessionFromMembers writes focused terminal chat onto 
     preferredTerminalId: 'term-a',
   });
 
-  assert.deepEqual(next, {
+  assert.ok(next);
+  assert.deepEqual(next.activeSessionIdMap, {
     'terminal:term-a': 'chat-a',
     'terminal:term-b': 'chat-b',
     'workspace:ws-1': 'chat-a',
+  });
+  assert.equal(next.panelViewChanged, true);
+  assert.deepEqual(next.panelViewByScope['workspace:ws-1'], {
+    mode: 'session',
+    sessionId: 'chat-a',
   });
 });
 

--- a/domain/workspaceAiScopeHandoff.ts
+++ b/domain/workspaceAiScopeHandoff.ts
@@ -18,16 +18,26 @@ export type AIPanelViewHandoffLike = {
   sessionId?: string;
 };
 
+export type SeedWorkspaceAIActiveSessionResult = {
+  activeSessionIdMap: Record<string, string | null>;
+  panelViewByScope: Record<string, AIPanelViewHandoffLike>;
+  panelViewChanged: boolean;
+};
+
 /**
  * Seed a brand-new workspace scope from member terminal maps (focused first)
  * so the first paint does not wait on a visible-panel write-back.
+ *
+ * Also materializes an explicit session panel view so follow-up typing does not
+ * fall through to draft-only resolution and create a new chat on send.
  */
 export function seedWorkspaceAIActiveSessionFromMembers(input: {
   activeSessionIdMap: AIActiveSessionIdMap;
+  panelViewByScope?: Readonly<Record<string, AIPanelViewHandoffLike | undefined>>;
   workspaceId: string;
   memberTerminalIds: readonly string[];
   preferredTerminalId?: string | null;
-}): Record<string, string | null> | null {
+}): SeedWorkspaceAIActiveSessionResult | null {
   const workspaceKey = buildAIScopeKey('workspace', input.workspaceId);
   const existing = input.activeSessionIdMap[workspaceKey];
   if (typeof existing === 'string' && existing.length > 0) {
@@ -43,9 +53,27 @@ export function seedWorkspaceAIActiveSessionFromMembers(input: {
   });
   if (!inherited) return null;
 
+  const previousPanelViewByScope = (
+    input.panelViewByScope as Record<string, AIPanelViewHandoffLike> | undefined
+  ) ?? {};
+  const existingPanelView = previousPanelViewByScope[workspaceKey];
+  const needsPanelView = !(
+    existingPanelView?.mode === 'session'
+    && existingPanelView.sessionId === inherited
+  );
+
   return {
-    ...(input.activeSessionIdMap as Record<string, string | null>),
-    [workspaceKey]: inherited,
+    activeSessionIdMap: {
+      ...(input.activeSessionIdMap as Record<string, string | null>),
+      [workspaceKey]: inherited,
+    },
+    panelViewByScope: needsPanelView
+      ? {
+          ...previousPanelViewByScope,
+          [workspaceKey]: { mode: 'session', sessionId: inherited },
+        }
+      : previousPanelViewByScope,
+    panelViewChanged: needsPanelView,
   };
 }
 


### PR DESCRIPTION
## Summary

After terminal merge, the AI side panel still showed the previous chat, but sending a follow-up created a **new** session. Merge seed only wrote `activeSessionIdMap`; typing an unsent draft demoted the panel to draft mode, so `handleSend` called `createSession()`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Prefer workspace persisted/inherited active session over `hasDraft` in `resolveDisplayedPanelView` (explicit New Chat still wins via `mode: draft`)
- Seed merge also materializes `panelView = { mode: 'session', sessionId }` (aligned with dissolve handoff)
- Wire `useAIState.seedWorkspaceActiveSessionFromMembers` to apply panel view updates
- Unit coverage for merge follow-up draft and seed panel view

## Screenshots / Demo

N/A (behavior fix; no UI chrome change)

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — targeted: `components/ai/aiPanelViewState.test.ts`, `domain/workspaceAiScopeHandoff.test.ts` (30 pass)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

## Manual smoke

1. Chat in terminal A AI panel
2. Split/merge into workspace
3. Confirm old messages still visible
4. Type follow-up and send — should stay on the same session (not New Chat)
5. Click New Chat then send — should create a new session