### PR TITLE
fix(notes): keep MDX link preview toolbar over the link

### DIFF
--- a/components/notes/InlineMarkdownEditor.test.tsx
+++ b/components/notes/InlineMarkdownEditor.test.tsx
@@ -189,6 +189,12 @@ test("note markdown toolbar remains usable in narrow panes", () => {
     styles,
     /\.netcatty-mdx-editor\s*\{[^}]*container-type:\s*inline-size;/s,
   );
+  // Keep fixed-containing-block in sync with MDX linkDialog coordinate math
+  // (container-type alone is not a fixed CB in browsers).
+  assert.match(
+    styles,
+    /\.netcatty-mdx-editor\s*\{[^}]*transform:\s*translateZ\(0\);/s,
+  );
   assert.match(
     styles,
     /\.netcatty-note-markdown-toolbar\s*\{[^}]*max-width:\s*100%;[^}]*height:\s*auto\s*!important;[^}]*overflow:\s*visible\s*!important;/s,

--- a/index.css
+++ b/index.css
@@ -952,6 +952,12 @@ html[data-theme-transition] *::after {
 
 .netcatty-mdx-editor {
   container-type: inline-size;
+  /* MDX linkDialog uses position:fixed anchors with coords adjusted whenever
+   * getFixedContainingBlock sees container-type. Browsers do not treat
+   * container-type alone as a fixed CB, so unadjusted viewport coords + those
+   * offsets park the preview toolbar over the notes tree. A zero transform
+   * makes the fixed CB real so the adjustment matches. */
+  transform: translateZ(0);
   min-width: 0;
   --basePageBg: hsl(var(--background));
   --baseBase: hsl(var(--background));


### PR DESCRIPTION
## Summary

MDXEditor link preview toolbar (URL + open/edit/copy/unlink) was shifted into the notes tree when selecting a link in edit mode.

`.netcatty-mdx-editor` uses `container-type: inline-size` for narrow toolbar layout. MDX's `getSelectionRectangle` treats any `container-type` as a fixed containing block and subtracts the editor offset, but browsers do not create a fixed CB from `container-type` alone. The fixed anchor then used container-relative coords against the viewport and landed too far left.

## Type of Change

- [x] Bug fix

## Related Issue (optional)

N/A

## Changes Made

- Add `transform: translateZ(0)` on `.netcatty-mdx-editor` so the fixed containing block matches MDX coordinate math
- Guard with a unit assertion next to the existing toolbar container-type check

## Testing

- [x] Tests pass — `components/notes/InlineMarkdownEditor.test.tsx`
- Manual: edit mode, select a link near the left edge of the note body → preview bar should sit on the link, not over the notes tree

## Checklist

- [x] My code follows the existing project style
- [x] I have not introduced any breaking changes