### PR TITLE
Polish port forwarding side panels

### DIFF
--- a/components/PortForwardingNew.tsx
+++ b/components/PortForwardingNew.tsx
@@ -916,6 +916,7 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
           managedSources={managedSources}
           onSaveHost={onSaveHost}
           onCreateGroup={_onCreateGroup}
+          width="w-[360px]"
           layout="inline"
           {...portForwardingPanelResizeProps}
         />

--- a/components/PortForwardingNew.tsx
+++ b/components/PortForwardingNew.tsx
@@ -11,6 +11,7 @@ import {
 import React, { useCallback, useMemo, useRef, useState } from "react";
 import { useI18n } from "../application/i18n/I18nProvider";
 import { usePortForwardingState } from "../application/state/usePortForwardingState";
+import { STORAGE_KEY_PORT_FORWARDING_PANEL_WIDTH } from "../infrastructure/config/storageKeys";
 import {
   GroupConfig,
   Host,
@@ -94,6 +95,11 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
   terminalSettings,
 }) => {
   const { t } = useI18n();
+  const portForwardingPanelResizeProps = {
+    resizable: true as const,
+    persistWidthStorageKey: STORAGE_KEY_PORT_FORWARDING_PANEL_WIDTH,
+    resizeAriaLabel: t("vault.panel.resizeWidth"),
+  };
   const {
     rules: _rules,
     selectedRuleId,
@@ -312,6 +318,12 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
   // Start new rule - wizard or form based on user preference
   const startNewRule = (type: PortForwardingType) => {
     setShowNewMenu(false);
+    // The new-rule flow replaces an open editor; never leave both side panels mounted.
+    setShowEditPanel(false);
+    setEditingRule(null);
+    setEditDraft({});
+    setSelectedRuleId(null);
+    setShowHostSelector(false);
 
     if (preferFormMode) {
       // Form mode: show all-in-one form
@@ -605,7 +617,6 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
       <div
         className={cn(
           "flex-1 flex flex-col min-h-0",
-          showWizard || showEditPanel || showNewForm ? "mr-[360px]" : "",
         )}
       >
         <VaultPageHeader className="z-20">
@@ -773,7 +784,7 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
       </div>
 
       {/* Edit Panel - shown when a rule is selected */}
-      {showEditPanel && editingRule && (
+      {showEditPanel && editingRule && !showHostSelector && (
         <EditPanel
           rule={editingRule}
           draft={editDraft}
@@ -789,11 +800,12 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
           }}
           onDelete={() => handleDeleteRule(editingRule)}
           onOpenHostSelector={() => setShowHostSelector(true)}
+          {...portForwardingPanelResizeProps}
         />
       )}
 
       {/* Wizard Panel */}
-      {showWizard && (
+      {showWizard && !showHostSelector && (
         <AsidePanel
           open={true}
           onClose={() => {
@@ -802,6 +814,8 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
           }}
           title={isEditing ? t("pf.wizard.editTitle") : t("pf.wizard.newTitle")}
           width="w-[360px]"
+          layout="inline"
+          {...portForwardingPanelResizeProps}
           showBackButton={!!getPrevStep()}
           onBack={
             getPrevStep()
@@ -902,11 +916,13 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
           managedSources={managedSources}
           onSaveHost={onSaveHost}
           onCreateGroup={_onCreateGroup}
+          layout="inline"
+          {...portForwardingPanelResizeProps}
         />
       )}
 
       {/* New Form Panel (skip wizard mode) */}
-      {showNewForm && (
+      {showNewForm && !showHostSelector && (
         <NewFormPanel
           draft={newFormDraft}
           hosts={hosts}
@@ -918,6 +934,7 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
           onOpenHostSelector={() => setShowHostSelector(true)}
           onOpenWizard={openWizardFromForm}
           isValid={isNewFormValid()}
+          {...portForwardingPanelResizeProps}
         />
       )}
 

--- a/components/PortForwardingNew.tsx
+++ b/components/PortForwardingNew.tsx
@@ -616,7 +616,7 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
       {/* Main Content */}
       <div
         className={cn(
-          "flex-1 flex flex-col min-h-0",
+          "flex-1 min-w-0 flex flex-col min-h-0",
         )}
       >
         <VaultPageHeader className="z-20">

--- a/components/SelectHostPanel.tsx
+++ b/components/SelectHostPanel.tsx
@@ -25,6 +25,7 @@ interface SelectHostPanelProps {
   title?: string;
   subtitle?: string;
   className?: string;
+  width?: string;
   layout?: AsidePanelLayout;
   resizable?: boolean;
   persistWidthStorageKey?: string;
@@ -50,6 +51,7 @@ const SelectHostPanel: React.FC<SelectHostPanelProps> = ({
   title,
   subtitle,
   className,
+  width,
   layout = "overlay",
   resizable = false,
   persistWidthStorageKey,
@@ -79,6 +81,7 @@ const SelectHostPanel: React.FC<SelectHostPanelProps> = ({
       showBackButton={true}
       onBack={onBack}
       className={cn(layout === "overlay" && "z-40", newHostPanelOpen && "overflow-visible", className)}
+      width={width}
       layout={layout}
       resizable={resizable}
       persistWidthStorageKey={persistWidthStorageKey}

--- a/components/SelectHostPanelContent.tsx
+++ b/components/SelectHostPanelContent.tsx
@@ -416,7 +416,10 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
           role="option"
           aria-selected={multiSelect ? groupState === 'all' : false}
           data-active={isActive ? 'true' : undefined}
-          className="flex h-full min-h-0 items-center gap-2.5 rounded-lg px-2.5 transition-colors hover:bg-muted/70"
+          className={cn(
+            'flex h-full min-h-0 items-center gap-2.5 overflow-hidden rounded-lg px-2.5 transition-colors',
+            isActive ? 'bg-primary/10 ring-1 ring-primary/40' : 'hover:bg-muted/70',
+          )}
           onClick={() => {
             if (navIndex >= 0) setActiveNavIndex(navIndex);
             setCurrentPath(row.path);

--- a/components/SelectHostPanelContent.tsx
+++ b/components/SelectHostPanelContent.tsx
@@ -416,10 +416,7 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
           role="option"
           aria-selected={multiSelect ? groupState === 'all' : false}
           data-active={isActive ? 'true' : undefined}
-          className={cn(
-            'flex h-full min-h-0 items-center gap-2.5 overflow-hidden px-2.5 rounded-lg transition-colors',
-            isActive ? 'bg-primary/10 ring-1 ring-primary/40' : 'hover:bg-muted/70',
-          )}
+          className="flex h-full min-h-0 items-center gap-2.5 rounded-lg px-2.5 transition-colors hover:bg-muted/70"
           onClick={() => {
             if (navIndex >= 0) setActiveNavIndex(navIndex);
             setCurrentPath(row.path);

--- a/components/TrafficDiagram.tsx
+++ b/components/TrafficDiagram.tsx
@@ -70,7 +70,7 @@ export const TrafficDiagram: React.FC<TrafficDiagramProps> = ({ type, isAnimatin
         <div className="relative w-full h-48 flex items-center justify-center overflow-hidden rounded-xl bg-secondary/60 border border-border/50">
             {/* ========== LOCAL FORWARDING ========== */}
             {type === 'local' && (
-                <div className="relative w-full h-full">
+                <div className="relative w-[300px] max-w-full aspect-[300/170]">
                     {/* App Logo - left (same line as firewall) */}
                     <div className={`absolute left-6 top-5 z-10 transition-opacity duration-300 ${getOpacity('app')}`}>
                         <AppLogo className="h-12 w-12" />
@@ -95,21 +95,21 @@ export const TrafficDiagram: React.FC<TrafficDiagramProps> = ({ type, isAnimatin
                     </div>
 
                     {/* SVG Lines */}
-                    <svg className="absolute inset-0 w-full h-full" style={{ zIndex: 1 }}>
+                    <svg className="absolute inset-0 w-full h-full" viewBox="0 0 300 170" preserveAspectRatio="none" style={{ zIndex: 1 }}>
                         {/* App to Firewall - blocked red line (with gap) */}
-                        <AnimatedLine x1={78} y1={40} x2={127} y2={40} isAnimating={false} isBlocked />
+                        <AnimatedLine x1={78} y1={44} x2={122} y2={44} isAnimating={false} isBlocked />
                         {/* App to SSH Server - blue animated (with gap) */}
-                        <AnimatedLine x1={78} y1={58} x2={145} y2={138} isAnimating={isAnimating} />
+                        <AnimatedLine x1={76} y1={64} x2={126} y2={110} isAnimating={isAnimating} />
                         {/* SSH Server to targets - blue animated (with gap) */}
-                        <AnimatedLine x1={178} y1={148} x2={238} y2={58} isAnimating={isAnimating} />
-                        <AnimatedLine x1={178} y1={152} x2={238} y2={88} isAnimating={isAnimating} />
+                        <AnimatedLine x1={174} y1={112} x2={242} y2={28} isAnimating={isAnimating} />
+                        <AnimatedLine x1={178} y1={120} x2={242} y2={68} isAnimating={isAnimating} />
                     </svg>
                 </div>
             )}
 
             {/* ========== REMOTE FORWARDING ========== */}
             {type === 'remote' && (
-                <div className="relative w-full h-full">
+                <div className="relative w-[300px] max-w-full aspect-[300/170]">
                     {/* Left Server - the remote SSH server where port will be opened */}
                     <div className={`absolute left-6 top-5 z-10 transition-opacity duration-300 ${getOpacity('ssh-server')}`}>
                         <ServerIcon className="h-10 w-10" />
@@ -131,20 +131,20 @@ export const TrafficDiagram: React.FC<TrafficDiagramProps> = ({ type, isAnimatin
                     </div>
 
                     {/* SVG Lines */}
-                    <svg className="absolute inset-0 w-full h-full" style={{ zIndex: 1 }}>
+                    <svg className="absolute inset-0 w-full h-full" viewBox="0 0 300 170" preserveAspectRatio="none" style={{ zIndex: 1 }}>
                         {/* Left server to Firewall - blocked (with gap) */}
-                        <AnimatedLine x1={68} y1={38} x2={128} y2={38} isAnimating={false} isBlocked />
+                        <AnimatedLine x1={70} y1={40} x2={122} y2={40} isAnimating={false} isBlocked />
                         {/* Left server to App - blue animated (with gap) */}
-                        <AnimatedLine x1={58} y1={58} x2={145} y2={135} isAnimating={isAnimating} />
+                        <AnimatedLine x1={68} y1={58} x2={124} y2={128} isAnimating={isAnimating} />
                         {/* Right server to App - blue animated (with gap) */}
-                        <AnimatedLine x1={262} y1={58} x2={175} y2={135} isAnimating={isAnimating} reverse />
+                        <AnimatedLine x1={250} y1={58} x2={176} y2={128} isAnimating={isAnimating} reverse />
                     </svg>
                 </div>
             )}
 
             {/* ========== DYNAMIC FORWARDING ========== */}
             {type === 'dynamic' && (
-                <div className="relative w-full h-full">
+                <div className="relative w-[300px] max-w-full aspect-[300/170]">
                     {/* App Logo - left (same line as firewall) */}
                     <div className={`absolute left-6 top-5 z-10 transition-opacity duration-300 ${getOpacity('app')}`}>
                         <AppLogo className="h-12 w-12" />
@@ -175,15 +175,16 @@ export const TrafficDiagram: React.FC<TrafficDiagramProps> = ({ type, isAnimatin
                     </div>
 
                     {/* SVG Lines */}
-                    <svg className="absolute inset-0 w-full h-full" style={{ zIndex: 1 }}>
+                    <svg className="absolute inset-0 w-full h-full" viewBox="0 0 300 170" preserveAspectRatio="none" style={{ zIndex: 1 }}>
                         {/* App to Firewall - blocked (with gap) */}
-                        <AnimatedLine x1={78} y1={42} x2={128} y2={42} isAnimating={false} isBlocked />
+                        <AnimatedLine x1={78} y1={44} x2={122} y2={44} isAnimating={false} isBlocked />
                         {/* App to SSH Server - blue animated (with gap) */}
-                        <AnimatedLine x1={78} y1={58} x2={145} y2={138} isAnimating={isAnimating} />
+                        <AnimatedLine x1={76} y1={64} x2={126} y2={110} isAnimating={isAnimating} />
                         {/* SSH Server to clouds - blue animated (with gap) */}
-                        <AnimatedLine x1={178} y1={142} x2={238} y2={42} isAnimating={isAnimating} />
-                        <AnimatedLine x1={178} y1={148} x2={238} y2={72} isAnimating={isAnimating} />
-                        <AnimatedLine x1={178} y1={155} x2={238} y2={148} isAnimating={isAnimating} />
+                        <AnimatedLine x1={174} y1={112} x2={246} y2={26} isAnimating={isAnimating} />
+                        <AnimatedLine x1={178} y1={120} x2={246} y2={58} isAnimating={isAnimating} />
+                        <AnimatedLine x1={178} y1={128} x2={246} y2={90} isAnimating={isAnimating} />
+                        <AnimatedLine x1={174} y1={128} x2={234} y2={130} isAnimating={isAnimating} />
                     </svg>
                 </div>
             )}

--- a/components/port-forwarding/EditPanel.tsx
+++ b/components/port-forwarding/EditPanel.tsx
@@ -8,13 +8,21 @@ import { useI18n } from '../../application/i18n/I18nProvider';
 import { Host,PortForwardingRule } from '../../domain/models';
 import { DistroAvatar } from '../DistroAvatar';
 import { TrafficDiagram } from '../TrafficDiagram';
-import { AsideActionMenu,AsideActionMenuItem,AsidePanel,AsidePanelContent,AsidePanelFooter } from '../ui/aside-panel';
+import {
+    AsideActionMenu,
+    AsideActionMenuItem,
+    AsidePanel,
+    AsidePanelContent,
+    AsidePanelFooter,
+    type AsidePanelLayout,
+    type AsidePanelResizeProps,
+} from '../ui/aside-panel';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Switch } from '../ui/switch';
 
-export interface EditPanelProps {
+export interface EditPanelProps extends AsidePanelResizeProps {
     rule: PortForwardingRule;
     draft: Partial<PortForwardingRule>;
     hosts: Host[];
@@ -24,6 +32,7 @@ export interface EditPanelProps {
     onDuplicate: () => void;
     onDelete: () => void;
     onOpenHostSelector: () => void;
+    layout?: AsidePanelLayout;
 }
 
 export const EditPanel: React.FC<EditPanelProps> = ({
@@ -36,6 +45,10 @@ export const EditPanel: React.FC<EditPanelProps> = ({
     onDuplicate,
     onDelete,
     onOpenHostSelector,
+    layout = 'inline',
+    resizable = false,
+    persistWidthStorageKey,
+    resizeAriaLabel,
 }) => {
     const { t } = useI18n();
     const selectedHost = hosts.find(h => h.id === draft.hostId);
@@ -46,6 +59,10 @@ export const EditPanel: React.FC<EditPanelProps> = ({
             onClose={onClose}
             title={t('pf.wizard.editTitle')}
             width="w-[360px]"
+            layout={layout}
+            resizable={resizable}
+            persistWidthStorageKey={persistWidthStorageKey}
+            resizeAriaLabel={resizeAriaLabel}
             actions={
                 <AsideActionMenu>
                     <AsideActionMenuItem
@@ -117,7 +134,7 @@ export const EditPanel: React.FC<EditPanelProps> = ({
                                 <DistroAvatar
                                     host={selectedHost}
                                     fallback={selectedHost.os[0].toUpperCase()}
-                                    className="h-6 w-6"
+                                    size="tree"
                                 />
                                 <span>{selectedHost.label}</span>
                             </div>

--- a/components/port-forwarding/NewFormPanel.tsx
+++ b/components/port-forwarding/NewFormPanel.tsx
@@ -9,7 +9,13 @@ import { Host,PortForwardingRule,PortForwardingType } from '../../domain/models'
 import { cn } from '../../lib/utils';
 import { DistroAvatar } from '../DistroAvatar';
 import { TrafficDiagram } from '../TrafficDiagram';
-import { AsidePanel,AsidePanelContent,AsidePanelFooter } from '../ui/aside-panel';
+import {
+    AsidePanel,
+    AsidePanelContent,
+    AsidePanelFooter,
+    type AsidePanelLayout,
+    type AsidePanelResizeProps,
+} from '../ui/aside-panel';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
@@ -17,7 +23,7 @@ import { Label } from '../ui/label';
 import { Switch } from '../ui/switch';
 import { getTypeLabel } from './utils';
 
-export interface NewFormPanelProps {
+export interface NewFormPanelProps extends AsidePanelResizeProps {
     draft: Partial<PortForwardingRule>;
     hosts: Host[];
     onDraftChange: (updates: Partial<PortForwardingRule>) => void;
@@ -26,6 +32,7 @@ export interface NewFormPanelProps {
     onOpenHostSelector: () => void;
     onOpenWizard: () => void;
     isValid: boolean;
+    layout?: AsidePanelLayout;
 }
 
 export const NewFormPanel: React.FC<NewFormPanelProps> = ({
@@ -37,6 +44,10 @@ export const NewFormPanel: React.FC<NewFormPanelProps> = ({
     onOpenHostSelector,
     onOpenWizard,
     isValid,
+    layout = 'inline',
+    resizable = false,
+    persistWidthStorageKey,
+    resizeAriaLabel,
 }) => {
     const { t } = useI18n();
     const selectedHost = hosts.find(h => h.id === draft.hostId);
@@ -47,6 +58,10 @@ export const NewFormPanel: React.FC<NewFormPanelProps> = ({
             onClose={onClose}
             title={t('pf.wizard.newTitle')}
             width="w-[360px]"
+            layout={layout}
+            resizable={resizable}
+            persistWidthStorageKey={persistWidthStorageKey}
+            resizeAriaLabel={resizeAriaLabel}
         >
             <AsidePanelContent>
                 {/* Type Selector */}
@@ -119,7 +134,7 @@ export const NewFormPanel: React.FC<NewFormPanelProps> = ({
                                 <DistroAvatar
                                     host={selectedHost}
                                     fallback={selectedHost.os[0].toUpperCase()}
-                                    className="h-6 w-6"
+                                    size="tree"
                                 />
                                 <span>{selectedHost.label}</span>
                             </div>

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -30,6 +30,8 @@ export const STORAGE_KEY_HOTKEY_RECORDING = 'netcatty_hotkey_recording_v1';
 export const STORAGE_KEY_CUSTOM_CSS = 'netcatty_custom_css_v1';
 export const STORAGE_KEY_UI_LANGUAGE = 'netcatty_ui_language_v1';
 export const STORAGE_KEY_PORT_FORWARDING = 'netcatty_port_forwarding_v1';
+/** Width (px) shared by port forwarding edit, wizard, and host picker panels. */
+export const STORAGE_KEY_PORT_FORWARDING_PANEL_WIDTH = 'netcatty_port_forwarding_panel_width_v1';
 export const STORAGE_KEY_PF_PREFER_FORM_MODE = 'netcatty_pf_prefer_form_mode_v1';
 export const STORAGE_KEY_PF_VIEW_MODE = 'netcatty_pf_view_mode_v1';
 export const STORAGE_KEY_KNOWN_HOSTS = 'netcatty_known_hosts_v1';


### PR DESCRIPTION
## Summary

Unify the port forwarding editor, new-rule flow, and host picker with the shared side-panel behavior, while correcting the traffic diagram layout and selection styling.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Make port forwarding side panels push the page content, share a resizable width, and persist that width.
- Replace the active editor cleanly when starting a new rule so both panels are not shown together.
- Reuse the shared host picker flow and align group/host row corner styling.
- Reduce the selected host icon size in the forwarding form.
- Keep the traffic diagram at a stable aspect ratio and realign nodes and connection lines across Local, Remote, and Dynamic modes.
- Adjust the final Dynamic connection so it terminates at the bottom cloud instead of spreading past it.

## Screenshots / Demo

The UI changes correspond to the reported port forwarding side-panel, host picker, and traffic diagram states. The local development app was started for manual inspection.

## Testing

- [x] I have tested these changes locally (npm run dev)
- [x] Linting passes (npm run lint)
- [ ] Tests pass (npm test)
- [ ] Generated capability tool specs are updated when applicable (npm run generate:capability-tools)
- [ ] No new console errors or warnings, if this affects app behavior

Additional checks:
- Targeted port forwarding and host-picker tests passed (12 tests).
- Vite production build passed.
- git diff --check passed.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above).