### PR TITLE
[Bug] Keep local forwarding listener alive after client disconnect

### DIFF
--- a/electron/bridges/portForwardingBridge.cjs
+++ b/electron/bridges/portForwardingBridge.cjs
@@ -284,24 +284,29 @@ function destroyTunnelPipeEndpoint(endpoint) {
   try { endpoint.end?.(); } catch { /* ignore */ }
 }
 
-function destroyTunnelPipeEntry(tunnelState, entry) {
-  if (!entry || entry.closed) return;
+function destroyTunnelPipeEntry(tunnelState, entry, { abortOpen = true, remove = true } = {}) {
+  if (!entry) return;
   entry.closed = true;
   const openAbortController = entry.openAbortController;
-  entry.openAbortController = null;
-  if (openAbortController && !openAbortController.signal.aborted) {
+  const shouldDestroyEndpoints = !entry.endpointsDestroyed;
+  entry.endpointsDestroyed = true;
+  if (abortOpen && openAbortController && !openAbortController.signal.aborted) {
     try { openAbortController.abort(new Error("Port forward client closed during SSH channel open")); } catch { /* ignore */ }
   }
-  try { tunnelState?.activePipes?.delete(entry); } catch { /* ignore */ }
-  destroyTunnelPipeEndpoint(entry.socket);
-  destroyTunnelPipeEndpoint(entry.stream);
+  if (remove) {
+    entry.openAbortController = null;
+    try { tunnelState?.activePipes?.delete(entry); } catch { /* ignore */ }
+  }
+  if (shouldDestroyEndpoints) {
+    destroyTunnelPipeEndpoint(entry.socket);
+    destroyTunnelPipeEndpoint(entry.stream);
+  }
 }
 
 function attachTunnelPipeStream(tunnelState, entry, stream) {
   if (!entry || entry.closed || isTunnelCancelled(tunnelState)) {
-    destroyTunnelPipeEndpoint(entry?.socket);
+    if (entry) destroyTunnelPipeEntry(tunnelState, entry, { abortOpen: false });
     destroyTunnelPipeEndpoint(stream);
-    if (entry) destroyTunnelPipeEntry(tunnelState, entry);
     return false;
   }
   entry.openAbortController = null;
@@ -319,10 +324,24 @@ function trackTunnelPipe(tunnelState, socket, stream = null) {
     socket,
     stream: null,
     closed: false,
+    openStarted: false,
+    endpointsDestroyed: false,
     openAbortController: stream ? null : new AbortController(),
   };
   tunnelState.activePipes.add(entry);
-  const drop = () => destroyTunnelPipeEntry(tunnelState, entry);
+  // A client disconnect only abandons this channel open. The bounded open
+  // helper invalidates the physical SSH connection when its signal aborts;
+  // doing that here would tear down a shared local-forward listener. Tunnel-
+  // wide cleanup still aborts pending opens through destroyTunnelPipes(). Keep
+  // a pending entry tracked until its late channel callback is closed, so a
+  // later tunnel stop can still cancel the underlying request.
+  const drop = () => {
+    const pendingOpen = Boolean(entry.openStarted && entry.openAbortController);
+    destroyTunnelPipeEntry(tunnelState, entry, {
+      abortOpen: false,
+      remove: !pendingOpen,
+    });
+  };
   try { socket?.once?.("close", drop); } catch { /* ignore */ }
   try { socket?.once?.("error", drop); } catch { /* ignore */ }
   if (stream) attachTunnelPipeStream(tunnelState, entry, stream);
@@ -579,6 +598,7 @@ function bindPortForwardChannels({
     if (type === "local") {
       const server = net.createServer((socket) => {
         const pipeEntry = trackTunnelPipe(tunnelState, socket);
+        pipeEntry.openStarted = true;
         openBoundedForwardOutCallback(
           conn,
           bindAddress,
@@ -588,7 +608,7 @@ function bindPortForwardChannels({
           (err, stream) => {
             if (err) {
               console.error(`[PortForward] Forward error:`, err.message);
-              destroyTunnelPipeEntry(tunnelState, pipeEntry);
+              destroyTunnelPipeEntry(tunnelState, pipeEntry, { abortOpen: false });
               return;
             }
             if (!attachTunnelPipeStream(tunnelState, pipeEntry, stream)) return;
@@ -772,6 +792,7 @@ function bindPortForwardChannels({
         const pipeEntry = trackTunnelPipe(tunnelState, socket);
         socket.once("data", (data) => {
           if (data[0] !== 0x05) {
+            destroyTunnelPipeEntry(tunnelState, pipeEntry, { abortOpen: false });
             socket.end();
             return;
           }
@@ -780,6 +801,7 @@ function bindPortForwardChannels({
             if (request[0] !== 0x05 || request[1] !== 0x01) {
               socket.write(Buffer.from([0x05, 0x07, 0x00, 0x01, 0, 0, 0, 0, 0, 0]));
               socket.end();
+              destroyTunnelPipeEntry(tunnelState, pipeEntry, { abortOpen: false });
               return;
             }
 
@@ -797,13 +819,16 @@ function bindPortForwardChannels({
             } else if (addressType === 0x04) {
               socket.write(Buffer.from([0x05, 0x08, 0x00, 0x01, 0, 0, 0, 0, 0, 0]));
               socket.end();
+              destroyTunnelPipeEntry(tunnelState, pipeEntry, { abortOpen: false });
               return;
             } else {
               socket.write(Buffer.from([0x05, 0x08, 0x00, 0x01, 0, 0, 0, 0, 0, 0]));
               socket.end();
+              destroyTunnelPipeEntry(tunnelState, pipeEntry, { abortOpen: false });
               return;
             }
 
+            pipeEntry.openStarted = true;
             openBoundedForwardOutCallback(
               conn,
               bindAddress,
@@ -814,6 +839,7 @@ function bindPortForwardChannels({
                 if (err) {
                   socket.write(Buffer.from([0x05, 0x05, 0x00, 0x01, 0, 0, 0, 0, 0, 0]));
                   socket.end();
+                  destroyTunnelPipeEntry(tunnelState, pipeEntry, { abortOpen: false });
                   return;
                 }
                 if (!attachTunnelPipeStream(tunnelState, pipeEntry, stream)) return;

--- a/electron/bridges/portForwardingBridge.pipeLifecycle.test.cjs
+++ b/electron/bridges/portForwardingBridge.pipeLifecycle.test.cjs
@@ -1,17 +1,25 @@
 const assert = require("node:assert/strict");
-const { EventEmitter } = require("node:events");
+const { EventEmitter, once } = require("node:events");
+const net = require("node:net");
 const test = require("node:test");
 
 const {
+  _bindPortForwardChannelsForTests: bindPortForwardChannels,
   _attachTunnelPipeStreamForTests: attachTunnelPipeStream,
+  _clearPortForwardTunnelsForTests: clearPortForwardTunnels,
   _destroyTunnelPipesForTests: destroyTunnelPipes,
   _trackTunnelPipeForTests: trackTunnelPipe,
+  cancelTunnel,
 } = require("./portForwardingBridge.cjs");
 
 function fakeEndpoint() {
   const endpoint = new EventEmitter();
   endpoint.destroyedByTest = false;
-  endpoint.destroy = () => { endpoint.destroyedByTest = true; };
+  endpoint.destroyCalls = 0;
+  endpoint.destroy = () => {
+    endpoint.destroyCalls += 1;
+    endpoint.destroyedByTest = true;
+  };
   endpoint.end = () => { endpoint.destroyedByTest = true; };
   endpoint.close = () => { endpoint.destroyedByTest = true; };
   return endpoint;
@@ -20,12 +28,181 @@ function fakeEndpoint() {
 test("accepted sockets are tracked before forwardOut finishes and stop destroys them", () => {
   const tunnel = { cancelled: false, activePipes: new Set() };
   const socket = fakeEndpoint();
-  trackTunnelPipe(tunnel, socket);
+  const entry = trackTunnelPipe(tunnel, socket);
   assert.equal(tunnel.activePipes.size, 1);
 
   destroyTunnelPipes(tunnel);
   assert.equal(socket.destroyedByTest, true);
+  assert.equal(entry.openAbortController, null);
   assert.equal(tunnel.activePipes.size, 0);
+});
+
+test("client disconnect drops only its pending channel open", () => {
+  const tunnel = { cancelled: false, activePipes: new Set() };
+  const socket = fakeEndpoint();
+  const entry = trackTunnelPipe(tunnel, socket);
+  entry.openStarted = true;
+  let aborts = 0;
+  entry.openAbortController.signal.addEventListener("abort", () => { aborts += 1; });
+
+  socket.emit("close");
+
+  assert.equal(aborts, 0);
+  assert.equal(entry.closed, true);
+  assert.equal(entry.openAbortController.signal.aborted, false);
+  assert.equal(tunnel.activePipes.size, 1);
+  const destroyCalls = socket.destroyCalls;
+
+  socket.emit("error", new Error("client closed"));
+  assert.equal(socket.destroyCalls, destroyCalls);
+
+  destroyTunnelPipes(tunnel);
+
+  assert.equal(aborts, 1);
+  assert.equal(tunnel.activePipes.size, 0);
+});
+
+test("a client disconnect does not close the local forwarding listener", async () => {
+  let finishForwardOut;
+  let transportEnds = 0;
+  let transportDestroys = 0;
+  const conn = new EventEmitter();
+  conn.forwardOut = (_sourceAddress, _sourcePort, _targetAddress, _targetPort, callback) => {
+    finishForwardOut = callback;
+  };
+  conn.end = () => { transportEnds += 1; };
+  conn.destroy = () => { transportDestroys += 1; };
+  const tunnel = {
+    tunnelId: "pf-client-disconnect",
+    cancelled: false,
+    activePipes: new Set(),
+    chainConnections: [],
+    sshTransportManaged: false,
+  };
+  const sender = { id: 1, isDestroyed: () => false };
+
+  const started = await bindPortForwardChannels({
+    type: "local",
+    conn,
+    tunnelId: tunnel.tunnelId,
+    tunnelState: tunnel,
+    sender,
+    bindAddress: "127.0.0.1",
+    localPort: 0,
+    remoteHost: "127.0.0.1",
+    remotePort: 22,
+    chainConnections: [],
+    sendStatus() {},
+  });
+  assert.equal(started.success, true);
+
+  const client = net.connect(tunnel.server.address().port, "127.0.0.1");
+  await once(client, "connect");
+  client.destroy();
+  await once(client, "close");
+  assert.equal(tunnel.server.listening, true);
+
+  finishForwardOut(new Error("client closed"));
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(transportEnds, 0);
+  assert.equal(transportDestroys, 0);
+
+  await new Promise((resolve, reject) => tunnel.server.close((error) => error ? reject(error) : resolve()));
+});
+
+test("a disconnected SOCKS client remains cancellable until its channel open settles", async () => {
+  let finishForwardOut;
+  let forwardOutStarted;
+  const conn = new EventEmitter();
+  conn.forwardOut = (_sourceAddress, _sourcePort, _targetAddress, _targetPort, callback) => {
+    finishForwardOut = callback;
+    forwardOutStarted?.();
+  };
+  conn.end = () => {};
+  conn.destroy = () => {};
+  const tunnel = {
+    tunnelId: "pf-socks-client-disconnect",
+    cancelled: false,
+    activePipes: new Set(),
+    chainConnections: [],
+    sshTransportManaged: false,
+  };
+  const sender = { id: 2, isDestroyed: () => false };
+
+  try {
+    const started = await bindPortForwardChannels({
+      type: "dynamic",
+      conn,
+      tunnelId: tunnel.tunnelId,
+      tunnelState: tunnel,
+      sender,
+      bindAddress: "127.0.0.1",
+      localPort: 0,
+      remoteHost: "127.0.0.1",
+      remotePort: 22,
+      chainConnections: [],
+      sendStatus() {},
+    });
+    assert.equal(started.success, true);
+
+    const client = net.connect(tunnel.server.address().port, "127.0.0.1");
+    await once(client, "connect");
+    client.write(Buffer.from([0x05, 0x01, 0x00]));
+    await once(client, "data");
+    const channelStarted = new Promise((resolve) => { forwardOutStarted = resolve; });
+    client.write(Buffer.from([0x05, 0x01, 0x00, 0x01, 127, 0, 0, 1, 0, 22]));
+    await channelStarted;
+    client.destroy();
+    await once(client, "close");
+    assert.equal(tunnel.server.listening, true);
+    assert.equal(tunnel.activePipes.size, 1);
+
+    await cancelTunnel(tunnel.tunnelId, tunnel, () => {});
+    assert.equal(tunnel.activePipes.size, 0);
+  } finally {
+    clearPortForwardTunnels();
+  }
+});
+
+test("an invalid SOCKS client is removed before opening an SSH channel", async () => {
+  const conn = new EventEmitter();
+  conn.end = () => {};
+  conn.destroy = () => {};
+  const tunnel = {
+    tunnelId: "pf-socks-invalid-client",
+    cancelled: false,
+    activePipes: new Set(),
+    chainConnections: [],
+    sshTransportManaged: false,
+  };
+  const sender = { id: 3, isDestroyed: () => false };
+
+  try {
+    const started = await bindPortForwardChannels({
+      type: "dynamic",
+      conn,
+      tunnelId: tunnel.tunnelId,
+      tunnelState: tunnel,
+      sender,
+      bindAddress: "127.0.0.1",
+      localPort: 0,
+      remoteHost: "127.0.0.1",
+      remotePort: 22,
+      chainConnections: [],
+      sendStatus() {},
+    });
+    assert.equal(started.success, true);
+
+    const client = net.connect(tunnel.server.address().port, "127.0.0.1");
+    await once(client, "connect");
+    client.write(Buffer.from([0x04, 0x01, 0x00]));
+    await once(client, "close");
+    assert.equal(tunnel.activePipes.size, 0);
+    assert.equal(tunnel.server.listening, true);
+  } finally {
+    await new Promise((resolve, reject) => tunnel.server.close((error) => error ? reject(error) : resolve()));
+    clearPortForwardTunnels();
+  }
 });
 
 test("a late forwardOut stream after stop is rejected and destroyed", () => {


### PR DESCRIPTION
## Summary

Fixes the local port-forwarding listener stopping when a client connects and immediately disconnects during SSH channel setup.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue

Closes #2893

## Changes Made

- Treat a client disconnect as cleanup for that client connection only.
- Keep a genuinely pending channel-open entry tracked until its late callback settles, so stopping the whole tunnel can still cancel it.
- Remove handshake-only and already-settled dynamic forwarding clients immediately.
- Make repeated socket cleanup safe.
- Add regression coverage for local and dynamic forwarding listeners, tunnel-stop cancellation, invalid SOCKS clients, and late channel results.

The root cause was the per-client cleanup aborting a bounded SSH channel open. That abort invalidated the shared SSH transport, which closed the local forwarding listener as a side effect.

## Screenshots / Demo

Not applicable; this is a backend behavior fix.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`) — the port-forwarding tests pass; the full suite still has 9 unrelated Cursor SDK environment failures because Cursor SDK is not installed in this workspace.
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Targeted port-forwarding checks: 51 tests passed.