### PR TITLE
fix(tabs): follow custom shortcut bindings for previews

### DIFF
--- a/application/AppHandlers.globalHotkeys.test.ts
+++ b/application/AppHandlers.globalHotkeys.test.ts
@@ -272,6 +272,55 @@ test('next, previous, and number shortcuts include native plugin view tabs', () 
   assert.deepEqual(selected, [pluginTabId, 'session-1', pluginTabId]);
 });
 
+test('switchToTab uses physical Digit code when Shift remaps e.key', () => {
+  let activeTabId = 'session-1';
+  const noop = () => {};
+  const context = {
+    IS_DEV: false,
+    MOVE_FOCUS_DEBOUNCE_MS: 0,
+    activeTabStore: { getActiveTabId: () => activeTabId },
+    addConnectionLogRef: { current: noop },
+    closeSession: noop,
+    closeTabInFlightRef: { current: false },
+    closeWorkspace: noop,
+    collectSessionIds: () => [],
+    confirmIfBusyLocalTerminal: async () => true,
+    createLocalTerminalWithCurrentShell: noop,
+    editorTabs: [],
+    fromEditorTabId: () => null,
+    handleOpenSettingsRef: { current: noop },
+    handleRequestCloseEditorTabRef: { current: noop },
+    isEditorTabId: () => false,
+    isQuickSwitcherOpen: false,
+    lastMoveFocusTimeRef: { current: 0 },
+    moveFocusInWorkspace: noop,
+    orderedTabs: ['session-1', 'session-2', 'session-3'],
+    resolveCloseIntent: () => ({ kind: 'noop' }),
+    resolveSnippetsShortcutIntent: () => ({ kind: 'noop' }),
+    sessions: [],
+    setActiveTabId: (id: string) => { activeTabId = id; },
+    setAddToWorkspaceDialog: noop,
+    setIsQuickSwitcherOpen: noop,
+    setNavigateToSection: noop,
+    settings: { showSftpTab: false, shellOnlyTabNumberShortcuts: false },
+    splitSessionWithCurrentShell: noop,
+    systemInfoRef: { current: { username: 'user', hostname: 'host' } },
+    toEditorTabId: (id: string) => `editor:${id}`,
+    toggleBroadcast: noop,
+    toggleScriptsSidePanelRef: { current: noop },
+    toggleSidePanelRef: { current: noop },
+    toggleWorkspaceViewMode: noop,
+    workspaces: [],
+  };
+
+  executeHotkeyActionImpl(
+    () => context,
+    'switchToTab',
+    { key: '@', code: 'Digit3', ctrlKey: true, shiftKey: true } as KeyboardEvent,
+  );
+  assert.equal(activeTabId, 'session-2');
+});
+
 test('next tab includes pinned tabs when shell-only shortcut mode is disabled', () => {
   let activeTabId = '';
   const noop = () => {};

--- a/application/app/AppHandlers.ts
+++ b/application/app/AppHandlers.ts
@@ -7,6 +7,7 @@ import { getEffectiveHostDistro, classifyDistroId, shouldProbeSessionCwd } from 
 import { sanitizeHostIconFields } from '../../domain/hostIcon';
 import { resolveEffectiveTerminalProtocol } from '../../domain/terminalProtocol';
 import { getTerminalPassthroughActions } from '../state/useGlobalHotkeys';
+import { tabShortcutDigitFromEvent } from '../../domain/models/keyBindings';
 import { buildNumberShortcutTabTargets } from './tabShortcutTargets';
 import { captureInheritedCwd } from '../state/inheritedCwd';
 
@@ -680,12 +681,10 @@ export function executeHotkeyActionImpl(getCtx: AppContextGetter, action: string
     });
     switch (action) {
       case 'switchToTab': {
-        // Get the number key pressed (1-9)
-        const num = parseInt(e.key, 10);
-        if (num >= 1 && num <= 9) {
-          if (num <= shortcutTabs.length) {
-            setActiveTabId(shortcutTabs[num - 1]);
-          }
+        // Prefer physical Digit code so Shift+[1...9] works when e.key is "!" etc.
+        const num = tabShortcutDigitFromEvent(e);
+        if (num !== null && num <= shortcutTabs.length) {
+          setActiveTabId(shortcutTabs[num - 1]);
         }
         break;
       }

--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -473,6 +473,7 @@ function AppViewInner({ domains }: AppViewProps) {
         onRemoveSessionFromWorkspace={removeSessionFromWorkspace}
         showSftpTab={showSftpTab}
         showHostTreeSidebar={showHostTreeSidebar}
+        switchTabKeyBinding={keyBindings.find((binding) => binding.action === 'switchToTab') ?? null}
         dynamicTabTitleMode={dynamicTabTitleMode}
         editorTabs={editorTabs}
         pluginViewTabs={pluginViewTabs}

--- a/application/state/useShortcutModifierHeld.test.ts
+++ b/application/state/useShortcutModifierHeld.test.ts
@@ -2,35 +2,42 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  getShortcutModifierRequirements,
   isShortcutModifierHeld,
   shouldReleaseShortcutModifier,
   type ShortcutModifierEvent,
 } from './useShortcutModifierHeld.ts';
 
 const event = (overrides: Partial<ShortcutModifierEvent> = {}): ShortcutModifierEvent => ({
-  key: 'a',
   metaKey: false,
   ctrlKey: false,
+  altKey: false,
+  shiftKey: false,
   ...overrides,
 });
 
-test('shortcut modifier state follows the configured Mac or PC scheme', () => {
-  assert.equal(isShortcutModifierHeld(event({ key: 'Meta' }), 'mac'), true);
-  assert.equal(isShortcutModifierHeld(event({ metaKey: true }), 'mac'), true);
-  assert.equal(isShortcutModifierHeld(event({ ctrlKey: true }), 'mac'), false);
+test('shortcut modifier requirements follow the effective Mac or PC binding', () => {
+  const mac = getShortcutModifierRequirements('⌘ + [1...9]', 'mac');
+  assert.deepEqual(mac, { metaKey: true, ctrlKey: false, altKey: false, shiftKey: false });
+  assert.equal(isShortcutModifierHeld(event({ metaKey: true }), mac), true);
+  assert.equal(isShortcutModifierHeld(event({ ctrlKey: true }), mac), false);
 
-  assert.equal(isShortcutModifierHeld(event({ key: 'Control' }), 'pc'), true);
-  assert.equal(isShortcutModifierHeld(event({ ctrlKey: true }), 'pc'), true);
-  assert.equal(isShortcutModifierHeld(event({ metaKey: true }), 'pc'), false);
-  assert.equal(isShortcutModifierHeld(event({ metaKey: true, ctrlKey: true }), 'disabled'), false);
+  const pc = getShortcutModifierRequirements('Alt + Shift + [1...9]', 'pc');
+  assert.deepEqual(pc, { metaKey: false, ctrlKey: false, altKey: true, shiftKey: true });
+  assert.equal(isShortcutModifierHeld(event({ altKey: true, shiftKey: true }), pc), true);
+  assert.equal(isShortcutModifierHeld(event({ altKey: true }), pc), false);
+  assert.equal(isShortcutModifierHeld(event({ altKey: true, metaKey: true, shiftKey: true }), pc), false);
 });
 
-test('shortcut modifier state clears on modifier release or a missed modifier keyup', () => {
-  assert.equal(shouldReleaseShortcutModifier(event({ key: 'Meta' }), 'mac'), true);
-  assert.equal(shouldReleaseShortcutModifier(event({ key: 'a', metaKey: true }), 'mac'), false);
-  assert.equal(shouldReleaseShortcutModifier(event({ key: 'a' }), 'mac'), true);
+test('shortcut number preview is unavailable for disabled, non-range, or modifier-free bindings', () => {
+  assert.equal(getShortcutModifierRequirements('Disabled', 'mac'), null);
+  assert.equal(getShortcutModifierRequirements('⌘ + K', 'mac'), null);
+  assert.equal(getShortcutModifierRequirements('[1...9]', 'mac'), null);
+  assert.equal(getShortcutModifierRequirements('⌘ + [1...9]', 'disabled'), null);
+});
 
-  assert.equal(shouldReleaseShortcutModifier(event({ key: 'Control' }), 'pc'), true);
-  assert.equal(shouldReleaseShortcutModifier(event({ key: 'a', ctrlKey: true }), 'pc'), false);
-  assert.equal(shouldReleaseShortcutModifier(event({ key: 'a' }), 'pc'), true);
+test('shortcut modifier state clears when the required combination stops matching', () => {
+  const requirements = getShortcutModifierRequirements('⌘ + [1...9]', 'mac');
+  assert.equal(shouldReleaseShortcutModifier(event({ metaKey: true }), requirements), false);
+  assert.equal(shouldReleaseShortcutModifier(event(), requirements), true);
 });

--- a/application/state/useShortcutModifierHeld.test.ts
+++ b/application/state/useShortcutModifierHeld.test.ts
@@ -41,3 +41,19 @@ test('shortcut modifier state clears when the required combination stops matchin
   assert.equal(shouldReleaseShortcutModifier(event({ metaKey: true }), requirements), false);
   assert.equal(shouldReleaseShortcutModifier(event(), requirements), true);
 });
+
+test('shortcut modifier held state tracks exact combo when extras are pressed or released', () => {
+  const requirements = getShortcutModifierRequirements('⌘ + [1...9]', 'mac');
+  // Already matching, then an extra modifier: preview must clear.
+  assert.equal(isShortcutModifierHeld(event({ metaKey: true }), requirements), true);
+  assert.equal(
+    isShortcutModifierHeld(event({ metaKey: true, shiftKey: true }), requirements),
+    false,
+  );
+  // Extra pressed first, then released while required modifiers remain: preview re-arms.
+  assert.equal(
+    isShortcutModifierHeld(event({ metaKey: true, altKey: true }), requirements),
+    false,
+  );
+  assert.equal(isShortcutModifierHeld(event({ metaKey: true }), requirements), true);
+});

--- a/application/state/useShortcutModifierHeld.ts
+++ b/application/state/useShortcutModifierHeld.ts
@@ -84,15 +84,10 @@ export function useShortcutModifierHeld(
     setIsHeld(false);
     if (!requirements) return;
 
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (isShortcutModifierHeld(event, requirements)) {
-        setIsHeld(true);
-      }
-    };
-    const handleKeyUp = (event: KeyboardEvent) => {
-      if (shouldReleaseShortcutModifier(event, requirements)) {
-        setIsHeld(false);
-      }
+    // Sync on every modifier transition so extras clear the preview and
+    // releasing an extra modifier can re-arm when the exact combo remains.
+    const syncHeldState = (event: KeyboardEvent) => {
+      setIsHeld(isShortcutModifierHeld(event, requirements));
     };
     const clearHeldState = () => setIsHeld(false);
     const handleVisibilityChange = () => {
@@ -101,14 +96,14 @@ export function useShortcutModifierHeld(
       }
     };
 
-    window.addEventListener('keydown', handleKeyDown, true);
-    window.addEventListener('keyup', handleKeyUp, true);
+    window.addEventListener('keydown', syncHeldState, true);
+    window.addEventListener('keyup', syncHeldState, true);
     window.addEventListener('blur', clearHeldState);
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
-      window.removeEventListener('keydown', handleKeyDown, true);
-      window.removeEventListener('keyup', handleKeyUp, true);
+      window.removeEventListener('keydown', syncHeldState, true);
+      window.removeEventListener('keyup', syncHeldState, true);
       window.removeEventListener('blur', clearHeldState);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };

--- a/application/state/useShortcutModifierHeld.ts
+++ b/application/state/useShortcutModifierHeld.ts
@@ -1,49 +1,96 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import type { HotkeyScheme } from '../../domain/models/keyBindings';
+import { parseKeyCombo, type HotkeyScheme } from '../../domain/models/keyBindings';
 
-export type ShortcutModifierEvent = Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey'>;
+export type ShortcutModifierEvent = Pick<KeyboardEvent, 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>;
 
-function getModifierKey(scheme: Exclude<HotkeyScheme, 'disabled'>): 'Meta' | 'Control' {
-  return scheme === 'mac' ? 'Meta' : 'Control';
+export type ShortcutModifierRequirements = Readonly<ShortcutModifierEvent>;
+
+const MODIFIER_TOKENS = {
+  mac: {
+    '⌘': 'metaKey',
+    '⌃': 'ctrlKey',
+    '⌥': 'altKey',
+    Shift: 'shiftKey',
+  },
+  pc: {
+    Ctrl: 'ctrlKey',
+    Alt: 'altKey',
+    Shift: 'shiftKey',
+    Win: 'metaKey',
+  },
+} as const;
+
+/**
+ * Resolve the modifier combination for the effective [1...9] binding.
+ * A non-range or disabled binding cannot reveal tab numbers because the
+ * dispatcher does not use it for the number-switch action.
+ */
+export function getShortcutModifierRequirements(
+  keyBinding: string | null,
+  scheme: HotkeyScheme,
+): ShortcutModifierRequirements | null {
+  if (scheme === 'disabled' || !keyBinding || !keyBinding.includes('[1...9]')) return null;
+  const parsed = parseKeyCombo(keyBinding);
+  if (!parsed || parsed.modifiers.length === 0) return null;
+
+  const requirements: Record<keyof ShortcutModifierEvent, boolean> = {
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+  };
+  const tokenMap = MODIFIER_TOKENS[scheme];
+  for (const modifier of parsed.modifiers) {
+    const flag = tokenMap[modifier as keyof typeof tokenMap];
+    if (!flag) return null;
+    requirements[flag] = true;
+  }
+
+  return requirements;
 }
 
-function hasModifierFlag(event: ShortcutModifierEvent, scheme: Exclude<HotkeyScheme, 'disabled'>): boolean {
-  return scheme === 'mac' ? event.metaKey : event.ctrlKey;
-}
-
-/** Whether a keyboard event indicates that the active shortcut modifier is held. */
+/** Whether a keyboard event has exactly the modifiers required by the binding. */
 export function isShortcutModifierHeld(
   event: ShortcutModifierEvent,
-  scheme: HotkeyScheme,
+  requirements: ShortcutModifierRequirements | null,
 ): boolean {
-  if (scheme === 'disabled') return false;
-  return event.key === getModifierKey(scheme) || hasModifierFlag(event, scheme);
+  if (!requirements) return false;
+  return event.metaKey === requirements.metaKey
+    && event.ctrlKey === requirements.ctrlKey
+    && event.altKey === requirements.altKey
+    && event.shiftKey === requirements.shiftKey;
 }
 
-/** Whether a keyup event means the active shortcut modifier is no longer held. */
+/** Whether a keyup event means the required modifier combination is no longer held. */
 export function shouldReleaseShortcutModifier(
   event: ShortcutModifierEvent,
-  scheme: HotkeyScheme,
+  requirements: ShortcutModifierRequirements | null,
 ): boolean {
-  if (scheme === 'disabled') return true;
-  return event.key === getModifierKey(scheme) || !hasModifierFlag(event, scheme);
+  return !isShortcutModifierHeld(event, requirements);
 }
 
-export function useShortcutModifierHeld(scheme: HotkeyScheme): boolean {
+export function useShortcutModifierHeld(
+  keyBinding: string | null,
+  scheme: HotkeyScheme,
+): boolean {
   const [isHeld, setIsHeld] = useState(false);
+  const requirements = useMemo(
+    () => getShortcutModifierRequirements(keyBinding, scheme),
+    [keyBinding, scheme],
+  );
 
   useEffect(() => {
     setIsHeld(false);
-    if (scheme === 'disabled') return;
+    if (!requirements) return;
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (isShortcutModifierHeld(event, scheme)) {
+      if (isShortcutModifierHeld(event, requirements)) {
         setIsHeld(true);
       }
     };
     const handleKeyUp = (event: KeyboardEvent) => {
-      if (shouldReleaseShortcutModifier(event, scheme)) {
+      if (shouldReleaseShortcutModifier(event, requirements)) {
         setIsHeld(false);
       }
     };
@@ -65,7 +112,7 @@ export function useShortcutModifierHeld(scheme: HotkeyScheme): boolean {
       window.removeEventListener('blur', clearHeldState);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [scheme]);
+  }, [requirements]);
 
   return isHeld;
 }

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -7,7 +7,7 @@ import { buildTabShortcutNumberById } from '../application/app/tabShortcutTarget
 import { useShortcutModifierHeld } from '../application/state/useShortcutModifierHeld';
 import type { EditorTabChrome } from '../application/state/editorTabStore';
 import { collectSessionIds } from '../domain/workspace';
-import type { DynamicTabTitleMode } from '../domain/models';
+import type { DynamicTabTitleMode, KeyBinding } from '../domain/models';
 
 import { getTopTabInsertionTarget, getWorkspaceSessionDragId, hasWorkspaceSessionDrag } from '../application/state/terminalDragData';
 import {
@@ -158,6 +158,7 @@ interface TopTabsProps {
   ) => void;
   showSftpTab: boolean;
   showHostTreeSidebar: boolean;
+  switchTabKeyBinding: Pick<KeyBinding, 'mac' | 'pc'> | null;
   dynamicTabTitleMode?: DynamicTabTitleMode;
   editorTabs: readonly EditorTabChrome[];
   pluginViewTabs: readonly PluginViewTab[];
@@ -202,6 +203,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   onRemoveSessionFromWorkspace,
   showSftpTab,
   showHostTreeSidebar,
+  switchTabKeyBinding,
   dynamicTabTitleMode,
   editorTabs,
   pluginViewTabs,
@@ -216,7 +218,12 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
     showTabNumberBadges,
     shellOnlyTabNumberShortcuts,
   } = useSettingsChromeStore();
-  const shortcutModifierHeld = useShortcutModifierHeld(hotkeyScheme);
+  const switchTabKey = hotkeyScheme === 'mac'
+    ? switchTabKeyBinding?.mac ?? null
+    : hotkeyScheme === 'pc'
+      ? switchTabKeyBinding?.pc ?? null
+      : null;
+  const shortcutModifierHeld = useShortcutModifierHeld(switchTabKey, hotkeyScheme);
   const tabShortcutNumbers = useMemo(() => {
     // Keep the tab bar quiet until the modifier for the active shortcut scheme
     // is held, while retaining the existing setting as the master toggle.
@@ -1213,6 +1220,7 @@ export const topTabsAreEqual = (prev: TopTabsProps, next: TopTabsProps): boolean
     prev.onThemeChange === next.onThemeChange &&
     prev.showSftpTab === next.showSftpTab &&
     prev.showHostTreeSidebar === next.showHostTreeSidebar &&
+    prev.switchTabKeyBinding === next.switchTabKeyBinding &&
     prev.dynamicTabTitleMode === next.dynamicTabTitleMode &&
     prev.hostById === next.hostById
   );

--- a/domain/models.test.ts
+++ b/domain/models.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { keyEventToString, matchesKeyBinding } from './models.ts';
+import { keyEventToString, matchesKeyBinding, tabShortcutDigitFromEvent } from './models.ts';
 
 const keyboardEvent = (
   key: string,
@@ -61,4 +61,16 @@ test('shortcut matching preserves shifted number-row symbols', () => {
   assert.equal(matchesKeyBinding(event, 'Ctrl + Shift + !', false), true);
   assert.equal(matchesKeyBinding(event, 'Ctrl + Shift + 1', false), false);
   assert.equal(keyEventToString(event, false), 'Ctrl + Shift + !');
+});
+
+test('shifted digit ranges still match via physical Digit code', () => {
+  const event = keyboardEvent('!', 'Digit1', { ctrlKey: true, shiftKey: true });
+
+  assert.equal(matchesKeyBinding(event, 'Ctrl + Shift + [1...9]', false), true);
+  assert.equal(tabShortcutDigitFromEvent(event), 1);
+});
+
+test('tab shortcut digit falls back to e.key when code is missing', () => {
+  assert.equal(tabShortcutDigitFromEvent({ key: '3', code: '' }), 3);
+  assert.equal(tabShortcutDigitFromEvent({ key: '!', code: '' }), null);
 });

--- a/domain/models/keyBindings.ts
+++ b/domain/models/keyBindings.ts
@@ -35,11 +35,23 @@ const PHYSICAL_SHORTCUT_KEY_NAMES: Record<string, string> = {
   Slash: '/',
 };
 
-const physicalShortcutKeyName = (e: KeyboardEvent): string | null => {
+const physicalShortcutKeyName = (e: Pick<KeyboardEvent, 'code'>): string | null => {
   const code = e.code;
   if (/^Key[A-Z]$/.test(code)) return code.slice(3);
   if (/^Digit[0-9]$/.test(code)) return code.slice(5);
   return PHYSICAL_SHORTCUT_KEY_NAMES[code] ?? null;
+};
+
+/**
+ * Resolve the 1-9 tab shortcut digit from a key event.
+ * Prefer the physical Digit code so Shift+[1...9] still works when e.key is "!" etc.
+ */
+export const tabShortcutDigitFromEvent = (
+  e: Pick<KeyboardEvent, 'key' | 'code'>,
+): number | null => {
+  const key = physicalShortcutKeyName(e) ?? e.key;
+  if (!/^[1-9]$/.test(key)) return null;
+  return Number.parseInt(key, 10);
 };
 
 const LATIN_SHORTCUT_KEY_PATTERN = /^\p{Script=Latin}$/u;
@@ -104,8 +116,9 @@ export const matchesKeyBinding = (e: KeyboardEvent, keyStr: string, isMac: boole
   // Handle range patterns like "[1...9]"
   if (keyStr.includes('[1...9]')) {
     const basePattern = keyStr.replace('[1...9]', '');
-    const key = physicalShortcutKeyName(e) ?? shortcutEventKey(e);
-    if (!/^[1-9]$/.test(key)) return false;
+    const digit = tabShortcutDigitFromEvent(e);
+    if (digit === null) return false;
+    const key = String(digit);
     // Check modifiers match the base pattern
     const testStr = basePattern + key;
     const physicalDigitEvent = {


### PR DESCRIPTION
## Summary

- Reveal tab numbers using the effective `switch-tab-1-9` shortcut binding.
- Support customized modifier combinations such as Alt or Alt+Shift.
- Hide the preview when the binding is disabled, has no modifier, or is not the `[1...9]` range.

## Why

Follow-up to #2900 review feedback. The merged implementation only checked the selected Mac/PC scheme, so customized bindings could show numbers for a shortcut that no longer matched the actual tab-switching behavior.

## Validation

- `node --test --import tsx application/state/useShortcutModifierHeld.test.ts application/app/tabShortcutTargets.test.ts components/TopTabs.test.ts`
- `npx eslint application/state/useShortcutModifierHeld.ts application/state/useShortcutModifierHeld.test.ts components/TopTabs.tsx application/app/AppView.tsx`

Fixes the follow-up review from #2900.