### PR TITLE
fix: honor fullscreen app context menu setting

### DIFF
--- a/components/terminal/TerminalContextMenu.test.ts
+++ b/components/terminal/TerminalContextMenu.test.ts
@@ -20,6 +20,7 @@ const shouldSuppressMouseTrackingContextMenu = (
   terminalContextMenu as {
     shouldSuppressMouseTrackingContextMenu?: (options: {
       isAlternateScreen?: boolean;
+      terminalMouseTrackingMode?: string;
       showReconnectAction?: boolean;
       forceMenuInAlternateScreen?: boolean;
     }) => boolean;
@@ -41,6 +42,7 @@ const shouldOpenTerminalContextMenu = (
       event: { shiftKey?: boolean; nativeEvent: MouseEvent };
       rightClickBehavior?: "context-menu" | "paste" | "select-word";
       isAlternateScreen?: boolean;
+      terminalMouseTrackingMode?: string;
       showReconnectAction?: boolean;
       forceMenuInAlternateScreen?: boolean;
     }) => boolean;
@@ -50,6 +52,7 @@ const shouldRenderTerminalContextMenuContent = (
   terminalContextMenu as {
     shouldRenderTerminalContextMenuContent?: (options: {
       isAlternateScreen?: boolean;
+      terminalMouseTrackingMode?: string;
       showReconnectAction?: boolean;
       allowSuppressedMenuContent?: boolean;
     }) => boolean;
@@ -60,6 +63,7 @@ const shouldAllowSuppressedTerminalContextMenuContent = (
     shouldAllowSuppressedTerminalContextMenuContent?: (options: {
       event: { shiftKey?: boolean; nativeEvent: MouseEvent };
       isAlternateScreen?: boolean;
+      terminalMouseTrackingMode?: string;
       showReconnectAction?: boolean;
     }) => boolean;
   }
@@ -331,6 +335,65 @@ test("opens and renders middle-click menu while alternate-screen mouse tracking 
   assert.equal(
     shouldRenderTerminalContextMenuContent({
       isAlternateScreen: true,
+      showReconnectAction: false,
+      allowSuppressedMenuContent: false,
+    }),
+    false,
+  );
+});
+
+test("uses the current mouse tracking mode when the cached state is stale", () => {
+  assert.equal(typeof shouldOpenTerminalContextMenu, "function");
+  assert.equal(typeof shouldRenderTerminalContextMenuContent, "function");
+  if (
+    typeof shouldOpenTerminalContextMenu !== "function" ||
+    typeof shouldRenderTerminalContextMenuContent !== "function"
+  ) {
+    return;
+  }
+
+  const event = {
+    nativeEvent: {} as MouseEvent,
+  };
+
+  // xterm has already stopped reporting mouse events, but React still has
+  // the previous tracking state: paste/select-word must not be dropped.
+  assert.equal(
+    shouldOpenTerminalContextMenu({
+      event,
+      rightClickBehavior: "paste",
+      isAlternateScreen: true,
+      terminalMouseTrackingMode: "none",
+      showReconnectAction: false,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldRenderTerminalContextMenuContent({
+      isAlternateScreen: true,
+      terminalMouseTrackingMode: "none",
+      showReconnectAction: false,
+      allowSuppressedMenuContent: false,
+    }),
+    true,
+  );
+
+  // Conversely, a newly active xterm mode must still suppress the app menu
+  // while the cached React state has not caught up.
+  assert.equal(
+    shouldOpenTerminalContextMenu({
+      event,
+      rightClickBehavior: "context-menu",
+      isAlternateScreen: false,
+      terminalMouseTrackingMode: "vt200",
+      showReconnectAction: false,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldRenderTerminalContextMenuContent({
+      isAlternateScreen: false,
+      terminalMouseTrackingMode: "vt200",
       showReconnectAction: false,
       allowSuppressedMenuContent: false,
     }),

--- a/components/terminal/TerminalContextMenu.tsx
+++ b/components/terminal/TerminalContextMenu.tsx
@@ -27,7 +27,7 @@ import {
   ContextMenuShortcut,
   ContextMenuTrigger,
 } from '../ui/context-menu';
-import { isMiddleClickContextMenuEvent } from './runtime/middleClickBehavior';
+import { isMiddleClickContextMenuEvent, isMouseTrackingActive } from './runtime/middleClickBehavior';
 import { collectOwnedPluginMenus, comparePluginMenus, usePluginContributions } from '../../application/state/usePluginContributions';
 import { buildTerminalPluginContributionContext } from '../../application/state/pluginContributionContexts';
 import { PluginContributionIcon } from '../plugins/PluginContributionIcon';
@@ -44,6 +44,8 @@ export interface TerminalContextMenuProps {
   keyBindings?: KeyBinding[];
   rightClickBehavior?: RightClickBehavior;
   isAlternateScreen?: boolean;
+  /** Read the current xterm mouse-tracking mode when handling a right-click. */
+  getMouseTrackingMode?: () => string | undefined;
   /** When true, show the app context menu even while a fullscreen app (tmux/vim) holds mouse tracking. */
   showContextMenuOverFullscreenApps?: boolean;
   onCopy?: () => void;
@@ -75,13 +77,22 @@ export const shouldShowReconnectAction = ({
 
 export const shouldSuppressMouseTrackingContextMenu = ({
   isAlternateScreen,
+  terminalMouseTrackingMode,
   showReconnectAction,
   forceMenuInAlternateScreen,
 }: {
   isAlternateScreen?: boolean;
+  terminalMouseTrackingMode?: string;
   showReconnectAction?: boolean;
   forceMenuInAlternateScreen?: boolean;
-}): boolean => Boolean(isAlternateScreen && !showReconnectAction && !forceMenuInAlternateScreen);
+}): boolean => Boolean(
+  isMouseTrackingActive({
+    mouseTracking: Boolean(isAlternateScreen),
+    terminalMouseTrackingMode,
+  })
+  && !showReconnectAction
+  && !forceMenuInAlternateScreen,
+);
 
 export const shouldShowAddSelectionToAIContextMenuAction = (
   onAddSelectionToAI?: () => void,
@@ -93,42 +104,48 @@ export const shouldShowUploadClipboardImageContextMenuAction = (
 
 export const shouldRenderTerminalContextMenuContent = ({
   isAlternateScreen,
+  terminalMouseTrackingMode,
   showReconnectAction,
   allowSuppressedMenuContent,
   forceMenuInAlternateScreen,
 }: {
   isAlternateScreen?: boolean;
+  terminalMouseTrackingMode?: string;
   showReconnectAction?: boolean;
   allowSuppressedMenuContent?: boolean;
   forceMenuInAlternateScreen?: boolean;
 }): boolean =>
   allowSuppressedMenuContent ||
-  !shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction, forceMenuInAlternateScreen });
+  !shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, terminalMouseTrackingMode, showReconnectAction, forceMenuInAlternateScreen });
 
 export const shouldAllowSuppressedTerminalContextMenuContent = ({
   event,
   isAlternateScreen,
+  terminalMouseTrackingMode,
   showReconnectAction,
   forceMenuInAlternateScreen,
 }: {
   event: { shiftKey?: boolean; nativeEvent: MouseEvent };
   isAlternateScreen?: boolean;
+  terminalMouseTrackingMode?: string;
   showReconnectAction?: boolean;
   forceMenuInAlternateScreen?: boolean;
 }): boolean =>
   isMiddleClickContextMenuEvent(event.nativeEvent)
-  || Boolean(event.shiftKey && shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction, forceMenuInAlternateScreen }));
+  || Boolean(event.shiftKey && shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, terminalMouseTrackingMode, showReconnectAction, forceMenuInAlternateScreen }));
 
 export const shouldOpenTerminalContextMenu = ({
   event,
   rightClickBehavior = 'context-menu',
   isAlternateScreen,
+  terminalMouseTrackingMode,
   showReconnectAction,
   forceMenuInAlternateScreen,
 }: {
   event: { shiftKey?: boolean; nativeEvent: MouseEvent };
   rightClickBehavior?: RightClickBehavior;
   isAlternateScreen?: boolean;
+  terminalMouseTrackingMode?: string;
   showReconnectAction?: boolean;
   forceMenuInAlternateScreen?: boolean;
 }): boolean => {
@@ -140,7 +157,7 @@ export const shouldOpenTerminalContextMenu = ({
     return true;
   }
 
-  if (shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction, forceMenuInAlternateScreen })) {
+  if (shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, terminalMouseTrackingMode, showReconnectAction, forceMenuInAlternateScreen })) {
     return false;
   }
 
@@ -159,6 +176,7 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
   keyBindings,
   rightClickBehavior = 'context-menu',
   isAlternateScreen = false,
+  getMouseTrackingMode,
   showContextMenuOverFullscreenApps = false,
   onCopy,
   onPaste,
@@ -233,6 +251,8 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
   const clearShortcut = getShortcut('clear-buffer');
   const showReconnectAction = shouldShowReconnectAction({ isReconnectable, onReconnect });
 
+  const terminalMouseTrackingMode = getMouseTrackingMode?.();
+
   // Handle right-click: intercept for paste/select-word unless Shift is held
   // or rightClickBehavior is 'context-menu'. The ContextMenuTrigger stays always
   // enabled so Shift+Right-Click opens the menu on the first click.
@@ -241,15 +261,17 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
       // In alternate screen (tmux, vim, etc.), let the terminal application
       // handle right-click natively to avoid conflicting menus. Reconnect is
       // still available after disconnect, even if mouse tracking was left on.
+      const currentMouseTrackingMode = getMouseTrackingMode?.();
       const shouldOpenMenu = shouldOpenTerminalContextMenu({
         event: e,
         rightClickBehavior,
         isAlternateScreen,
+        terminalMouseTrackingMode: currentMouseTrackingMode,
         showReconnectAction,
         forceMenuInAlternateScreen: showContextMenuOverFullscreenApps,
       });
 
-      if (!shouldOpenMenu && shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction, forceMenuInAlternateScreen: showContextMenuOverFullscreenApps })) {
+      if (!shouldOpenMenu && shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, terminalMouseTrackingMode: currentMouseTrackingMode, showReconnectAction, forceMenuInAlternateScreen: showContextMenuOverFullscreenApps })) {
         e.preventDefault();
         return;
       }
@@ -265,6 +287,7 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
         setAllowSuppressedMenuContent(shouldAllowSuppressedTerminalContextMenuContent({
           event: e,
           isAlternateScreen,
+          terminalMouseTrackingMode: currentMouseTrackingMode,
           showReconnectAction,
           forceMenuInAlternateScreen: showContextMenuOverFullscreenApps,
         }));
@@ -279,7 +302,7 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
         onSelectWord?.();
       }
     },
-    [rightClickBehavior, onPaste, onSelectWord, isAlternateScreen, showReconnectAction, showContextMenuOverFullscreenApps],
+    [rightClickBehavior, onPaste, onSelectWord, isAlternateScreen, getMouseTrackingMode, showReconnectAction, showContextMenuOverFullscreenApps],
   );
 
   // Always use ContextMenu wrapper to maintain consistent React tree structure
@@ -294,6 +317,7 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
       </ContextMenuTrigger>
       {shouldRenderTerminalContextMenuContent({
         isAlternateScreen,
+        terminalMouseTrackingMode,
         showReconnectAction,
         allowSuppressedMenuContent,
         forceMenuInAlternateScreen: showContextMenuOverFullscreenApps,

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -492,6 +492,7 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
       keyBindings={keyBindings}
       rightClickBehavior={terminalSettings?.rightClickBehavior}
       isAlternateScreen={hasMouseTracking}
+      getMouseTrackingMode={() => termRef.current?.modes.mouseTrackingMode}
       showContextMenuOverFullscreenApps={terminalSettings?.showContextMenuOverFullscreenApps}
       onCopy={terminalContextActions.onCopy}
       onPaste={terminalContextActions.onPaste}

--- a/components/terminal/runtime/middleClickBehavior.test.ts
+++ b/components/terminal/runtime/middleClickBehavior.test.ts
@@ -70,6 +70,27 @@ test("mouse-tracking context menu capture lets Shift-modified mouse events pass 
   );
 });
 
+test("mouse-tracking context menu capture prefers the terminal's current mode over stale cached state", () => {
+  assert.equal(
+    shouldInterceptMouseTrackingContextMenu({
+      event: { shiftKey: false } as MouseEvent,
+      mouseTracking: false,
+      terminalMouseTrackingMode: "vt200",
+      status: "connected",
+    }),
+    true,
+  );
+  assert.equal(
+    shouldInterceptMouseTrackingContextMenu({
+      event: { shiftKey: false } as MouseEvent,
+      mouseTracking: true,
+      terminalMouseTrackingMode: "none",
+      status: "connected",
+    }),
+    false,
+  );
+});
+
 test("mouse-tracking context menu capture yields to the fullscreen-apps menu setting for context-menu clicks", () => {
   // Setting on + context-menu behavior: do NOT intercept, so Radix opens the menu.
   assert.equal(
@@ -249,6 +270,31 @@ test("right-click mousedown is stopped when the fullscreen-apps menu setting for
       mouseTracking: true,
       status: "connected",
       rightClickBehavior: "paste",
+      forceMenuInAlternateScreen: true,
+    }),
+    false,
+  );
+});
+
+test("right-click mousedown also uses the terminal's current mode", () => {
+  assert.equal(
+    shouldStopShiftRightClickMouseTrackingMouseDown({
+      event: { button: 2, shiftKey: false } as MouseEvent,
+      mouseTracking: false,
+      terminalMouseTrackingMode: "vt200",
+      status: "connected",
+      rightClickBehavior: "context-menu",
+      forceMenuInAlternateScreen: true,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldStopShiftRightClickMouseTrackingMouseDown({
+      event: { button: 2, shiftKey: false } as MouseEvent,
+      mouseTracking: true,
+      terminalMouseTrackingMode: "none",
+      status: "connected",
+      rightClickBehavior: "context-menu",
       forceMenuInAlternateScreen: true,
     }),
     false,

--- a/components/terminal/runtime/middleClickBehavior.ts
+++ b/components/terminal/runtime/middleClickBehavior.ts
@@ -16,6 +16,8 @@ type ShiftSelectionReplayMouseEvent = MouseEvent & {
 export interface MouseTrackingContextMenuCaptureState {
   event: MouseEvent;
   mouseTracking: boolean;
+  /** Current xterm mouse tracking mode, when available at event time. */
+  terminalMouseTrackingMode?: string;
   status?: string | null;
   /** The user's configured right-click action. */
   rightClickBehavior?: RightClickBehavior;
@@ -33,6 +35,8 @@ export interface ShiftMouseSelectionReplayState {
 export interface ShiftRightClickMouseDownCaptureState {
   event: MouseEvent;
   mouseTracking: boolean;
+  /** Current xterm mouse tracking mode, when available at event time. */
+  terminalMouseTrackingMode?: string;
   status?: string | null;
   /** The user's configured right-click action. */
   rightClickBehavior?: RightClickBehavior;
@@ -90,14 +94,23 @@ const forcesMenuOverMouseTracking = ({
   forceMenuInAlternateScreen?: boolean;
 }): boolean => Boolean(forceMenuInAlternateScreen && rightClickBehavior === "context-menu");
 
+const isMouseTrackingActive = ({
+  mouseTracking,
+  terminalMouseTrackingMode,
+}: Pick<MouseTrackingContextMenuCaptureState, "mouseTracking" | "terminalMouseTrackingMode">): boolean =>
+  terminalMouseTrackingMode === undefined
+    ? mouseTracking
+    : terminalMouseTrackingMode !== "none";
+
 export const shouldInterceptMouseTrackingContextMenu = ({
   event,
   mouseTracking,
+  terminalMouseTrackingMode,
   status,
   rightClickBehavior,
   forceMenuInAlternateScreen,
 }: MouseTrackingContextMenuCaptureState): boolean =>
-  mouseTracking
+  isMouseTrackingActive({ mouseTracking, terminalMouseTrackingMode })
   && status === "connected"
   && !event.shiftKey
   && !isMiddleClickContextMenuEvent(event)
@@ -122,11 +135,12 @@ export const shouldReplayShiftMouseSelectionAsMacOption = ({
 export const shouldStopShiftRightClickMouseTrackingMouseDown = ({
   event,
   mouseTracking,
+  terminalMouseTrackingMode,
   status,
   rightClickBehavior,
   forceMenuInAlternateScreen,
 }: ShiftRightClickMouseDownCaptureState): boolean =>
-  mouseTracking
+  isMouseTrackingActive({ mouseTracking, terminalMouseTrackingMode })
   && status === "connected"
   && event.button === 2
   && (event.shiftKey || forcesMenuOverMouseTracking({ rightClickBehavior, forceMenuInAlternateScreen }));

--- a/components/terminal/runtime/middleClickBehavior.ts
+++ b/components/terminal/runtime/middleClickBehavior.ts
@@ -94,7 +94,7 @@ const forcesMenuOverMouseTracking = ({
   forceMenuInAlternateScreen?: boolean;
 }): boolean => Boolean(forceMenuInAlternateScreen && rightClickBehavior === "context-menu");
 
-const isMouseTrackingActive = ({
+export const isMouseTrackingActive = ({
   mouseTracking,
   terminalMouseTrackingMode,
 }: Pick<MouseTrackingContextMenuCaptureState, "mouseTracking" | "terminalMouseTrackingMode">): boolean =>

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -1692,6 +1692,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       if (!shouldInterceptMouseTrackingContextMenu({
         event: e,
         mouseTracking: mouseTrackingRef.current,
+        terminalMouseTrackingMode: termRef.current?.modes.mouseTrackingMode,
         status: statusRef.current,
         rightClickBehavior: terminalSettingsRef.current?.rightClickBehavior,
         forceMenuInAlternateScreen: terminalSettingsRef.current?.showContextMenuOverFullscreenApps,
@@ -1724,6 +1725,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       if (rightClickPressClaim.noteMouseDown({
         event: e,
         mouseTracking: mouseTrackingRef.current,
+        terminalMouseTrackingMode: termRef.current?.modes.mouseTrackingMode,
         status: statusRef.current,
         rightClickBehavior: terminalSettingsRef.current?.rightClickBehavior,
         forceMenuInAlternateScreen: terminalSettingsRef.current?.showContextMenuOverFullscreenApps,


### PR DESCRIPTION
## Summary

Fix the terminal right-click menu behavior when fullscreen applications such as tmux or vim are capturing mouse input. The setting now takes effect reliably even when the cached mouse state is stale.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Read the terminal's current mouse-tracking mode when handling right-click events.
- Keep the cached state as a fallback for callers that do not provide the current mode.
- Add regression coverage for stale cached state in both context-menu and mousedown paths.

## Screenshots / Demo

Behavior-only change. The development app was started successfully with `npm run dev`.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`) — focused tests pass (74 tests); the full suite was not completed because unrelated local Cursor authentication and Electron environment checks blocked it.
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Additional checks:
- `npm run build` passed.
- `git diff --check` passed.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
