### PR TITLE
fix(notes): truncate tree titles when sidebar is narrowed

### DIFF
--- a/components/notes/NotesManager.test.tsx
+++ b/components/notes/NotesManager.test.tsx
@@ -83,6 +83,25 @@ test("NotesManager balances folder and note tree icon sizes", () => {
   assert.match(markup, /width="16" height="16"[^>]*class="lucide lucide-file-text/);
 });
 
+test("NotesManager tree scroll area constrains width so titles can truncate", () => {
+  const markup = renderNotes();
+
+  // Radix ScrollArea viewport child is display:table by default; force block +
+  // min-w-0 so narrowing the notes sidebar ellipsizes long titles instead of
+  // clipping them. React encodes `&` / `>` in class attributes.
+  assert.match(
+    markup,
+    /data-radix-scroll-area-viewport\](?:&gt;|>)div\]:!block/,
+  );
+  assert.match(
+    markup,
+    /data-radix-scroll-area-viewport\](?:&gt;|>)div\]:!min-w-0/,
+  );
+  assert.match(markup, /data-notes-drop-zone="root"/);
+  assert.match(markup, /min-h-full min-w-0 space-y-1 overflow-hidden/);
+  assert.match(markup, /aside class="[^"]*min-w-0[^"]*overflow-hidden/);
+});
+
 test("NotesManager selection helpers keep note and folder selection exclusive", () => {
   const notes = [note(), note({ id: "note-2", title: "Deploy", group: "Deploy" })];
   const noteSelection = getNoteSelectionState(notes[0], false);

--- a/components/notes/NotesManager.test.tsx
+++ b/components/notes/NotesManager.test.tsx
@@ -99,7 +99,12 @@ test("NotesManager tree scroll area constrains width so titles can truncate", ()
   );
   assert.match(markup, /data-notes-drop-zone="root"/);
   assert.match(markup, /min-h-full min-w-0 space-y-1 overflow-hidden/);
-  assert.match(markup, /aside class="[^"]*min-w-0[^"]*overflow-hidden/);
+  // Aside stays unclipped so the resize handle's outer half remains hit-testable;
+  // truncation is enforced by the inner tree shell + ScrollArea constraints.
+  assert.match(markup, /aside class="[^"]*min-w-0[^"]*flex-col bg-background/);
+  assert.match(markup, /flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden/);
+  assert.match(markup, /role="separator"/);
+  assert.match(markup, /translate-x-1\/2 cursor-col-resize/);
 });
 
 test("NotesManager selection helpers keep note and folder selection exclusive", () => {

--- a/components/notes/NotesManager.tsx
+++ b/components/notes/NotesManager.tsx
@@ -1493,13 +1493,14 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
         {shouldShowNotesTree && (
           <aside
             className={cn(
-              // min-w-0 + overflow-hidden so tree rows can shrink with the resizable
-              // sidebar and truncate long titles instead of clipping mid-glyph.
-              "relative flex min-w-0 flex-col overflow-hidden bg-background",
+              // min-w-0 on the aside; overflow-hidden stays on the inner tree shell
+              // so the resize separator's translate-x-1/2 hit area is not clipped.
+              "relative flex min-w-0 flex-col bg-background",
               isSidebarMode ? "flex-1" : "shrink-0 border-r border-border/60",
             )}
             style={isSidebarMode ? undefined : { width: treeWidth }}
           >
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
           <div className="min-w-0 flex-shrink-0 overflow-hidden">
             <div className={cn(
               TERMINAL_SIDE_PANEL_INNER_HEADER_CLASS,
@@ -1674,6 +1675,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
               )}
             </div>
           </ScrollArea>
+          </div>
           {!isSidebarMode && (
             <div
               role="separator"

--- a/components/notes/NotesManager.tsx
+++ b/components/notes/NotesManager.tsx
@@ -100,7 +100,8 @@ type NotesToolbarPanel = "search" | null;
 const toolbarIconButtonClass = "netcatty-tab h-6 w-6 shrink-0 rounded-md p-0 hover:bg-transparent";
 const menuItemClass = "flex h-8 w-full items-center rounded-md px-3 text-left text-sm hover:bg-secondary";
 const NOTES_TREE_DEFAULT_WIDTH = 300;
-const NOTES_TREE_MIN_WIDTH = 220;
+/** Narrow enough for nested folders + ellipsis; toolbar scrolls if needed. */
+const NOTES_TREE_MIN_WIDTH = 160;
 const NOTES_TREE_MAX_WIDTH = 520;
 const NOTE_DRAG_TYPE = "application/x-netcatty-note-id";
 const NOTE_GROUP_DRAG_TYPE = "application/x-netcatty-note-group-path";
@@ -1232,7 +1233,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
     return (
       <div
         key={`new-folder-${parent || "root"}`}
-        className="flex h-7 items-center px-2 text-sm"
+        className="flex h-7 min-w-0 items-center px-2 text-sm"
         style={{ paddingLeft: depth * 16 + 4 }}
       >
         <div className="mr-1 h-5 w-4 shrink-0" />
@@ -1492,15 +1493,17 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
         {shouldShowNotesTree && (
           <aside
             className={cn(
-              "relative flex flex-col bg-background",
-              isSidebarMode ? "min-w-0 flex-1" : "shrink-0 border-r border-border/60",
+              // min-w-0 + overflow-hidden so tree rows can shrink with the resizable
+              // sidebar and truncate long titles instead of clipping mid-glyph.
+              "relative flex min-w-0 flex-col overflow-hidden bg-background",
+              isSidebarMode ? "flex-1" : "shrink-0 border-r border-border/60",
             )}
             style={isSidebarMode ? undefined : { width: treeWidth }}
           >
-          <div className="flex-shrink-0">
+          <div className="min-w-0 flex-shrink-0 overflow-hidden">
             <div className={cn(
               TERMINAL_SIDE_PANEL_INNER_HEADER_CLASS,
-              "flex items-center gap-1 border-b border-border/60 px-1.5",
+              "flex min-w-0 items-center gap-1 overflow-x-auto border-b border-border/60 px-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
             )}>
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -1645,9 +1648,13 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
               </div>
             </div>
           </div>
-          <ScrollArea className="flex-1">
+          {/* Radix ScrollArea viewport child defaults to display:table, which
+              expands to content width and blocks title ellipsis on narrow trees.
+              Force block + min-w-0 so rows shrink with the sidebar (same pattern
+              as AsidePanelContent). */}
+          <ScrollArea className="min-w-0 flex-1 [&>[data-radix-scroll-area-viewport]>div]:!block [&>[data-radix-scroll-area-viewport]>div]:!min-w-0">
             <div
-              className="min-h-full space-y-1 px-1.5 pt-1.5 pb-4"
+              className="min-h-full min-w-0 space-y-1 overflow-hidden px-1.5 pt-1.5 pb-4"
               data-notes-drop-zone="root"
               onDragOver={(event) => {
                 if (!hasNotesTreeDrag(event.dataTransfer)) return;

--- a/components/vault/VaultTreeRow.test.tsx
+++ b/components/vault/VaultTreeRow.test.tsx
@@ -82,6 +82,30 @@ test("VaultTree labels use CJK-safe line-height under truncate", () => {
   assert.doesNotMatch(itemMarkup, /leading-none/);
 });
 
+test("VaultTree labels expose full title and keep actions from shrinking", () => {
+  const groupMarkup = renderToStaticMarkup(
+    <VaultTreeGroupRow
+      name="Dokploy服务信息"
+      depth={0}
+      actions={<button type="button" data-row-action="menu">…</button>}
+    />,
+  );
+  const itemMarkup = renderToStaticMarkup(
+    <VaultTreeItemRow
+      label="Security Audit Report - 完整版"
+      depth={1}
+      actions={<button type="button" data-row-action="menu">…</button>}
+    />,
+  );
+
+  assert.match(groupMarkup, /title="Dokploy服务信息"/);
+  assert.match(groupMarkup, /min-w-0 truncate/);
+  assert.match(groupMarkup, /shrink-0[^>]*>[\s\S]*data-row-action="menu"/);
+  assert.match(itemMarkup, /title="Security Audit Report - 完整版"/);
+  assert.match(itemMarkup, /min-w-0 truncate leading-5/);
+  assert.match(itemMarkup, /shrink-0[^>]*>[\s\S]*data-row-action="menu"/);
+});
+
 test("VaultTreeInlineRenameInput uses shared inline edit marker", () => {
   const markup = renderToStaticMarkup(
     <VaultTreeInlineRenameInput

--- a/components/vault/VaultTreeRow.tsx
+++ b/components/vault/VaultTreeRow.tsx
@@ -165,17 +165,17 @@ export const VaultTreeGroupRow: React.FC<VaultTreeGroupRowProps> = ({
       ) : (
         // leading-5 (not leading-none): CJK fallbacks like PingFang paint outside a 1.0 em box and get clipped by truncate.
         <span className="flex min-h-5 min-w-0 flex-1 items-center gap-1.5 leading-5">
-          <span className="min-w-0 truncate">{name}</span>
-          {labelActions}
+          <span className="min-w-0 truncate" title={name}>{name}</span>
+          {labelActions ? <span className="shrink-0">{labelActions}</span> : null}
         </span>
       )}
-      {meta}
+      {meta ? <div className="shrink-0">{meta}</div> : null}
       {typeof count === "number" && count > 0 && (
         <span className="shrink-0 rounded-full border border-border bg-background/50 px-1.5 py-0 text-[10px] opacity-70">
           {count}
         </span>
       )}
-      {actions}
+      {actions ? <div className="shrink-0">{actions}</div> : null}
     </div>
   );
 };
@@ -228,7 +228,7 @@ export const VaultTreeItemRow: React.FC<VaultTreeItemRowProps> = ({
     {leading ?? <div className="mr-1 h-5 w-4 flex-shrink-0" />}
     {icon ? <div className="mr-2 flex shrink-0 items-center self-center">{icon}</div> : <FileText size={14} className="mr-2 shrink-0 text-muted-foreground" />}
     {content ?? (
-      <div className="min-w-0 flex-1">
+      <div className="min-w-0 flex-1 overflow-hidden">
         {editing && onRenameCommit && onRenameCancel ? (
           <VaultTreeInlineRenameInput
             initialName={editingInitialName ?? label}
@@ -237,11 +237,11 @@ export const VaultTreeItemRow: React.FC<VaultTreeItemRowProps> = ({
           />
         ) : (
           // leading-5 keeps CJK glyphs inside the line box under truncate overflow.
-          <div className="min-w-0 truncate leading-5">{label}</div>
+          <div className="min-w-0 truncate leading-5" title={label}>{label}</div>
         )}
         {detail && <div className="truncate text-xs leading-4 text-muted-foreground">{detail}</div>}
       </div>
     )}
-    {actions}
+    {actions ? <div className="shrink-0">{actions}</div> : null}
   </div>
 );


### PR DESCRIPTION
## Summary

When the notes tree sidebar is dragged narrower, long folder/note titles no longer clip mid-glyph. Titles shrink with the panel and show an ellipsis when they do not fit; hover still reveals the full name via `title`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Constrain the notes tree width chain (`min-w-0` / `overflow-hidden`) so rows can shrink with the resizable sidebar.
- Override Radix ScrollArea’s `display:table` viewport child (same pattern as `AsidePanelContent`) so `truncate` works.
- Keep row actions from flex-shrinking; add `title` on truncated labels.
- Allow the tree toolbar to scroll horizontally when very narrow; lower min tree width to 160px.
- Add unit coverage for the ScrollArea width constraint and vault tree truncate/action shrink behavior.

## Screenshots / Demo

Before: narrowing the notes tree cut titles hard at the panel edge.
After: titles adaptively narrow and end with `…` when overflowed.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — ran `components/notes/NotesManager.test.tsx` and `components/vault/VaultTreeRow.test.tsx` (28/28)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)