### PR TITLE
perf(notes): drive tree width resize from the DOM

### DIFF
--- a/components/notes/NotesManager.perf.test.ts
+++ b/components/notes/NotesManager.perf.test.ts
@@ -8,6 +8,25 @@ const layoutSource = readFileSync(
   "utf8",
 );
 
+test("notes tree width resize avoids React setState on every pointermove", () => {
+  // Dragging the sidebar used to call setTreeWidth per pixel and re-render the
+  // whole NotesManager (including MDXEditor). Live width must stay on the DOM
+  // until pointerup commits state + localStorage.
+  assert.match(managerSource, /treeAsideRef/);
+  assert.match(managerSource, /requestAnimationFrame/);
+  assert.match(managerSource, /aside\.style\.width = `\$\{width\}px`/);
+  assert.match(
+    managerSource,
+    /const handlePointerMove = \(moveEvent: PointerEvent\) => \{[\s\S]*?requestAnimationFrame/,
+  );
+  assert.doesNotMatch(
+    managerSource,
+    /const handlePointerMove = \(moveEvent: PointerEvent\) => \{\s*\n\s*setTreeWidth\(/,
+  );
+  assert.match(managerSource, /persistTreeWidth\(nextWidth\)/);
+  assert.match(managerSource, /isTreeResizing && "pointer-events-none"/);
+});
+
 test("note content drafts stay in refs so MDX keystrokes do not rebuild the shell", () => {
   assert.doesNotMatch(
     managerSource,

--- a/components/notes/NotesManager.test.tsx
+++ b/components/notes/NotesManager.test.tsx
@@ -8,6 +8,7 @@ import { I18nProvider } from "../../application/i18n/I18nProvider.tsx";
 import type { VaultNote } from "../../types.ts";
 import { TooltipProvider } from "../ui/tooltip.tsx";
 import {
+  clampNotesTreeWidth,
   getFallbackNoteSelectionState,
   getNoteActionTargetGroup,
   getNoteGroupSelectionState,
@@ -105,6 +106,12 @@ test("NotesManager tree scroll area constrains width so titles can truncate", ()
   assert.match(markup, /flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden/);
   assert.match(markup, /role="separator"/);
   assert.match(markup, /translate-x-1\/2 cursor-col-resize/);
+});
+
+test("clampNotesTreeWidth keeps the sidebar within the design range", () => {
+  assert.equal(clampNotesTreeWidth(100), 160);
+  assert.equal(clampNotesTreeWidth(300), 300);
+  assert.equal(clampNotesTreeWidth(900), 520);
 });
 
 test("NotesManager selection helpers keep note and folder selection exclusive", () => {

--- a/components/notes/NotesManager.tsx
+++ b/components/notes/NotesManager.tsx
@@ -106,6 +106,10 @@ const NOTES_TREE_MAX_WIDTH = 520;
 const NOTE_DRAG_TYPE = "application/x-netcatty-note-id";
 const NOTE_GROUP_DRAG_TYPE = "application/x-netcatty-note-group-path";
 
+export function clampNotesTreeWidth(value: number): number {
+  return Math.max(NOTES_TREE_MIN_WIDTH, Math.min(NOTES_TREE_MAX_WIDTH, value));
+}
+
 export const normalizeNoteEditorMode = (value: string | null): NoteEditorMode | null =>
   value === "edit" || value === "preview" ? value : null;
 
@@ -389,6 +393,9 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
     NOTES_TREE_DEFAULT_WIDTH,
     { min: NOTES_TREE_MIN_WIDTH, max: NOTES_TREE_MAX_WIDTH },
   );
+  const treeAsideRef = useRef<HTMLElement | null>(null);
+  const treeWidthRef = useRef(treeWidth);
+  treeWidthRef.current = treeWidth;
   const searchInputRef = useRef<HTMLInputElement>(null);
   const importFileInputRef = useRef<HTMLInputElement>(null);
   const isImportingMarkdownRef = useRef(false);
@@ -1445,23 +1452,53 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
     event.stopPropagation();
 
     const startX = event.clientX;
-    const startWidth = treeWidth;
+    const startWidth = treeWidthRef.current;
     const previousCursor = document.body.style.cursor;
     const previousUserSelect = document.body.style.userSelect;
+    const aside = treeAsideRef.current;
+    let frame = 0;
+    let latestWidth = startWidth;
 
+    // Avoid setState on every pointermove — NotesManager owns the MDX editor and
+    // re-rendering it per pixel makes sidebar resize feel stuck.
     setIsTreeResizing(true);
     document.body.style.cursor = "col-resize";
     document.body.style.userSelect = "none";
+    if (aside) {
+      aside.style.willChange = "width";
+    }
 
-    const clampWidth = (value: number) =>
-      Math.max(NOTES_TREE_MIN_WIDTH, Math.min(NOTES_TREE_MAX_WIDTH, value));
-
-    const handlePointerMove = (moveEvent: PointerEvent) => {
-      setTreeWidth(clampWidth(startWidth + moveEvent.clientX - startX));
+    const applyWidth = (width: number) => {
+      latestWidth = width;
+      if (aside) {
+        aside.style.width = `${width}px`;
+      }
     };
 
-    const handlePointerUp = (upEvent: PointerEvent) => {
-      const nextWidth = clampWidth(startWidth + upEvent.clientX - startX);
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const nextWidth = clampNotesTreeWidth(startWidth + moveEvent.clientX - startX);
+      if (frame) {
+        latestWidth = nextWidth;
+        return;
+      }
+      latestWidth = nextWidth;
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        applyWidth(latestWidth);
+      });
+    };
+
+    const handlePointerUp = () => {
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+        frame = 0;
+      }
+      const nextWidth = clampNotesTreeWidth(latestWidth);
+      applyWidth(nextWidth);
+      if (aside) {
+        aside.style.willChange = "";
+      }
+      treeWidthRef.current = nextWidth;
       setTreeWidth(nextWidth);
       persistTreeWidth(nextWidth);
       setIsTreeResizing(false);
@@ -1475,7 +1512,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
     window.addEventListener("pointermove", handlePointerMove);
     window.addEventListener("pointerup", handlePointerUp);
     window.addEventListener("pointercancel", handlePointerUp);
-  }, [persistTreeWidth, setTreeWidth, treeWidth]);
+  }, [persistTreeWidth, setTreeWidth]);
 
   return (
     <div className="relative flex h-full min-h-0 flex-col overflow-hidden">
@@ -1492,6 +1529,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
       <div className="flex min-h-0 flex-1">
         {shouldShowNotesTree && (
           <aside
+            ref={treeAsideRef}
             className={cn(
               // min-w-0 on the aside; overflow-hidden stays on the inner tree shell
               // so the resize separator's translate-x-1/2 hit area is not clipped.
@@ -1694,7 +1732,14 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
         )}
 
         {!isSidebarMode && (
-        <main className="flex min-w-0 flex-1 flex-col bg-background">
+        <main
+          className={cn(
+            "flex min-w-0 flex-1 flex-col bg-background",
+            // Keep the editor out of hit-testing / paint thrash while the tree
+            // width is driven from the DOM during resize.
+            isTreeResizing && "pointer-events-none",
+          )}
+        >
           {selectedNoteView ? (
             <>
               <div className="flex min-h-[54px] shrink-0 items-center gap-3 px-8 pt-6 pb-1" data-note-title-row>


### PR DESCRIPTION
## Summary

Resizing the notes tree sidebar felt janky because every `pointermove` called `setTreeWidth`, re-rendering the whole `NotesManager` (including the MDX editor) per pixel.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Live resize updates `aside.style.width` via `requestAnimationFrame` (no React setState per move)
- Commit `setTreeWidth` + `persistTreeWidth` only on pointerup
- Disable pointer events on the note editor while resizing
- Guard with source/unit tests (`clampNotesTreeWidth`, perf contract)

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Tests pass — `components/notes/NotesManager.perf.test.ts`, `NotesManager.test.tsx`
- Manual: Vault → Notes → drag the vertical separator; width should track smoothly and persist after release

## Checklist

- [x] My code follows the existing project style
- [x] I have not introduced any breaking changes