### PR TITLE
fix(terminal): start command popups after vault hydration

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -227,6 +227,7 @@ import type { CreateXTermRuntimeContext } from "./terminal/runtime/createXTermRu
 import { TerminalView } from "./terminal/TerminalView";
 import {
   getInitialTerminalStatus,
+  resolveTerminalVaultInitialized,
   shouldSuppressHostStartupCommandOnReconnect,
   shouldStartTerminalBackend,
 } from "./terminal/restoredSessionGate";
@@ -270,6 +271,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   sessionId,
   workspaceId,
   restoreState,
+  vaultInitializedOverride,
   pendingInitialCwd,
   shellType,
   lastCwd,
@@ -359,7 +361,11 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   }, []);
   // Reactive vault-ready flag so restored panes re-arm boot after hydration
   // (module isVaultInitialized() alone is not a React dependency).
-  const vaultInitialized = useVaultSnapshotField("isVaultInitialized");
+  const sharedVaultInitialized = useVaultSnapshotField("isVaultInitialized");
+  const vaultInitialized = resolveTerminalVaultInitialized(
+    sharedVaultInitialized,
+    vaultInitializedOverride,
+  );
   const connectScriptsConsumedRef = useRef(false);
   const connectScriptsCompletedIdsRef = useRef(new Set<string>());
   const connectScriptsInFlightRef = useRef(false);

--- a/components/TerminalPopupPage.test.ts
+++ b/components/TerminalPopupPage.test.ts
@@ -141,6 +141,10 @@ test('popup terminals resolve complete host config and pass jump hosts into Term
   assert.match(source, /onDeleteSnippets=\{deleteSelectedSnippets\}/);
 });
 
+test('popup terminals use their window-local vault readiness', () => {
+  assert.match(source, /vaultInitializedOverride=\{vaultInitialized\}/);
+});
+
 test('popup provider tree mounts the plugin authentication host', () => {
   assert.match(source, /import \{ PluginAuthenticationHost \} from '\.\/plugins\/PluginAuthenticationHost';/);
   assert.match(

--- a/components/TerminalPopupPage.tsx
+++ b/components/TerminalPopupPage.tsx
@@ -467,6 +467,7 @@ function TerminalPopupPageInner() {
               accentMode={settings.accentMode}
               customAccent={settings.customAccent}
               terminalSettings={settings.terminalSettings}
+              vaultInitializedOverride={vaultInitialized}
               disableTerminalFontZoom={settings.disableTerminalFontZoom}
               sessionId={sessionId}
               startupCommand={isAttachMode ? undefined : config.startupCommand}

--- a/components/terminal/restoredSessionGate.test.ts
+++ b/components/terminal/restoredSessionGate.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 
 import {
   getInitialTerminalStatus,
+  resolveTerminalVaultInitialized,
   shouldSuppressHostStartupCommandOnReconnect,
   shouldStartTerminalBackend,
 } from "./restoredSessionGate.ts";
@@ -39,6 +40,20 @@ test("terminal boot waits for vaultInitialized before creating a backend session
     /vaultInitialized,/,
     "vaultInitialized must be in the boot effect dependency list",
   );
+});
+
+test("terminal popup can supply its own completed vault hydration state", () => {
+  const terminalSource = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
+  const popupSource = readFileSync(new URL("../TerminalPopupPage.tsx", import.meta.url), "utf8");
+
+  assert.match(
+    terminalSource,
+    /const vaultInitialized = resolveTerminalVaultInitialized\(\s*sharedVaultInitialized,\s*vaultInitializedOverride,\s*\);/,
+  );
+  assert.match(popupSource, /vaultInitializedOverride=\{vaultInitialized\}/);
+  assert.equal(resolveTerminalVaultInitialized(false, true), true);
+  assert.equal(resolveTerminalVaultInitialized(false), false);
+  assert.equal(resolveTerminalVaultInitialized(true, false), false);
 });
 
 test("host startup command policy distinguishes restored and automatic reconnects", () => {

--- a/components/terminal/restoredSessionGate.ts
+++ b/components/terminal/restoredSessionGate.ts
@@ -7,6 +7,11 @@ export const getInitialTerminalStatus = (): TerminalSession["status"] => (
   "connecting"
 );
 
+export const resolveTerminalVaultInitialized = (
+  sharedVaultInitialized: boolean,
+  windowVaultInitialized?: boolean,
+): boolean => windowVaultInitialized ?? sharedVaultInitialized;
+
 /**
  * Backend start waits for vault hydration so restored sessions cannot dial SSH
  * with empty keys while hosts have already been published mid-init.

--- a/components/terminal/terminalHelpers.ts
+++ b/components/terminal/terminalHelpers.ts
@@ -136,6 +136,8 @@ export interface TerminalProps {
   sessionId: string;
   workspaceId?: string;
   restoreState?: TerminalSession["restoreState"];
+  /** Secondary windows hydrate their own vault state outside the main snapshot store. */
+  vaultInitializedOverride?: boolean;
   pendingInitialCwd?: string;
   shellType?: TerminalSession["shellType"];
   lastCwd?: string;

--- a/components/terminal/terminalMemo.test.ts
+++ b/components/terminal/terminalMemo.test.ts
@@ -40,6 +40,13 @@ test("terminal memo refreshes when restored local shell type changes", () => {
   );
 });
 
+test("terminal memo refreshes when a popup vault finishes hydrating", () => {
+  assert.equal(
+    terminalPropsAreEqual(baseProps, { ...baseProps, vaultInitializedOverride: true }),
+    false,
+  );
+});
+
 test("terminal memo refreshes when terminal context reader callback changes", () => {
   assert.equal(
     terminalPropsAreEqual(baseProps, {

--- a/components/terminal/terminalMemo.ts
+++ b/components/terminal/terminalMemo.ts
@@ -36,6 +36,7 @@ export const terminalPropsAreEqual = (
   && prev.terminalSettings === next.terminalSettings
   && prev.sessionId === next.sessionId
   && prev.restoreState === next.restoreState
+  && prev.vaultInitializedOverride === next.vaultInitializedOverride
   && prev.shellType === next.shellType
   && prev.lastCwd === next.lastCwd
   && prev.restoreTerminalCwd === next.restoreTerminalCwd


### PR DESCRIPTION
## Summary

Fixes command terminal popups that stay blank and eventually report a connection timeout.

The regression affects Docker Shell, Docker Logs, and tmux Attach because all three use the same popup terminal path.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## Related Issue

Related to #2891
Related to #2912
Related to #2920

## Root Cause

Version 1.1.77 added a vault-hydration gate before terminal startup. The main window publishes that readiness through the shared snapshot store, but a terminal popup is a separate renderer: it hydrates its own vault state and never publishes into the main window's store.

As a result, the popup already has the correct host, title, keys, and startup command, while the nested terminal waits forever and never creates its backend session. The popup's independent 20-second timer then reports the generic connection timeout.

## Changes Made

- Let a popup terminal use that window's completed vault-hydration state.
- Preserve the existing shared readiness guard for the main window.
- Re-render the memoized terminal when popup readiness changes.
- Add regression tests for the separate-window startup path.

## Screenshots / Demo

No visual change. The popup now starts its existing terminal connection instead of remaining blank.

## Testing

- [x] Full `npm test` suite passed
- [x] Focused popup, terminal startup, Docker command, and SSH reuse tests passed (148 tests)
- [x] `npm run lint` passed (one pre-existing unrelated warning)
- [x] `npm run build` passed
- [x] `git diff --check` passed
- [ ] Reporter environment retest after a build is available

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove the fix
- [x] New and existing unit tests pass locally with my changes
- [x] No documentation change is required
- [x] My changes generate no new warnings
- [x] No generated capability surface changed
