### PR TITLE
fix(ssh): keep server stats safe for Dropbear

### DIFF
--- a/electron/bridges/sshBridge.sessionOps.et.test.cjs
+++ b/electron/bridges/sshBridge.sessionOps.et.test.cjs
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 const { EventEmitter } = require("node:events");
 
 const { createSessionOpsApi } = require("./sshBridge/sessionOps.cjs");
+const { selectServerStatsFixtureOutput } = require("./sshBridge/serverStatsTestHelpers.cjs");
 
 function fakeStream(stdout, waitForWrite = false) {
   const stream = new EventEmitter();
@@ -25,10 +26,7 @@ function fakeStream(stdout, waitForWrite = false) {
 function fakeConn(stdout) {
   return {
     exec(command, cb) {
-      const output = command.includes("NC_LATENCY_MARK") && !stdout.includes("NC_LATENCY_MARK")
-        ? `NC_LATENCY_MARK|${stdout}`
-        : stdout;
-      cb(null, fakeStream(output));
+      cb(null, fakeStream(selectServerStatsFixtureOutput(command, stdout)));
     },
   };
 }
@@ -120,7 +118,7 @@ test("getServerStats opens an ET stats companion connection for direct ET sessio
 });
 
 test("getServerStats falls back to execOnEtSession for jumped ET sessions", async () => {
-  let command = "";
+  const commands = [];
   let ensureCalls = 0;
   const api = makeApi(
     {
@@ -131,8 +129,12 @@ test("getServerStats falls back to execOnEtSession for jumped ET sessions", asyn
       etStatsAuth: { hostname: "example.test", hasJumpHost: true },
     },
     async (_session, cmd) => {
-      command = cmd;
-      return { success: true, stdout: LINUX_STATS, stderr: "" };
+      commands.push(cmd);
+      return {
+        success: true,
+        stdout: cmd.includes('echo "DISKS:$disks"') ? "DISKS:" : LINUX_STATS,
+        stderr: "",
+      };
     },
     {
       ensureEtStatsConnection: async () => {
@@ -145,11 +147,14 @@ test("getServerStats falls back to execOnEtSession for jumped ET sessions", asyn
   const result = await api.getServerStats(null, { sessionId: "et-1" });
 
   assert.equal(ensureCalls, 0);
-  assert.match(command, /CPURAW|UNSUPPORTED_OS/);
+  assert.equal(commands.length, 2);
+  assert.match(commands[0], /CPURAW|UNSUPPORTED_OS/);
+  assert.match(commands[1], /DISKS:/);
+  assert.ok(commands.every((command) => Buffer.byteLength(command, "utf8") <= 9000));
   assert.equal(result.success, true);
   assert.equal(result.stats.memTotal, 8000);
   assert.equal(result.stats.latencyMs, null);
-  assert.doesNotMatch(command, /read -r nc_latency_probe/);
+  assert.ok(commands.every((command) => !/read -r nc_latency_probe/.test(command)));
 });
 
 test("getServerStats falls back to execOnEtSession when the direct ET companion is unavailable", async () => {
@@ -163,9 +168,13 @@ test("getServerStats falls back to execOnEtSession when the direct ET companion 
       etStatsAuth: { hostname: "example.test" },
       etStatsConnFailed: true,
     },
-    async () => {
+    async (_session, command) => {
       execFallbackCalls += 1;
-      return { success: true, stdout: LINUX_STATS, stderr: "" };
+      return {
+        success: true,
+        stdout: command.includes('echo "DISKS:$disks"') ? "DISKS:" : LINUX_STATS,
+        stderr: "",
+      };
     },
     {
       ensureEtStatsConnection: async () => {
@@ -176,7 +185,7 @@ test("getServerStats falls back to execOnEtSession when the direct ET companion 
 
   const result = await api.getServerStats(null, { sessionId: "et-1" });
 
-  assert.equal(execFallbackCalls, 1);
+  assert.equal(execFallbackCalls, 2);
   assert.equal(result.success, true);
   assert.equal(result.stats.memTotal, 8000);
   assert.equal(result.stats.latencyMs, 3);

--- a/electron/bridges/sshBridge/serverStatsTestHelpers.cjs
+++ b/electron/bridges/sshBridge/serverStatsTestHelpers.cjs
@@ -1,0 +1,14 @@
+"use strict";
+
+function selectServerStatsFixtureOutput(command, stdout) {
+  const parts = String(stdout || "").split("|");
+  const diskPart = parts.find((part) => part.startsWith("DISKS:")) || "DISKS:";
+  const baseOutput = parts.filter((part) => !part.startsWith("DISKS:")).join("|");
+  if (command.includes('echo "DISKS:$disks"')) return diskPart;
+  if (command.includes("NC_LATENCY_MARK") && !baseOutput.includes("NC_LATENCY_MARK")) {
+    return `NC_LATENCY_MARK|${baseOutput}`;
+  }
+  return baseOutput;
+}
+
+module.exports = { selectServerStatsFixtureOutput };

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -1089,7 +1089,7 @@ function createSessionOpsApi(ctx) {
       const linuxDiskTable = `{ LC_ALL=C mount 2>/dev/null; printf "%s\\n" "__NETCATTY_DF__"; LC_ALL=C df -kPT 2>/dev/null || LC_ALL=C df -kP 2>/dev/null; }`;
       const linuxDiskRoot = `{ LC_ALL=C mount 2>/dev/null; printf "%s\\n" "__NETCATTY_DF__"; LC_ALL=C df -kPT / 2>/dev/null || LC_ALL=C df -kP / 2>/dev/null; }`;
     
-      // Command to get CPU (overall + per-core), Memory, Disk, and Network stats
+      // Command to get CPU (overall + per-core), Memory, and Network stats
       // This command is designed to work across most Linux distributions
       // Note: Using semicolons and avoiding comments for single-line execution
       // CPU: Output raw values (total and idle) instead of percentage - we calculate delta on backend
@@ -1107,19 +1107,6 @@ function createSessionOpsApi(ctx) {
         // GNU ps: ps -eo pid,%mem,comm --sort=-%mem
         // BusyBox fallback: top exposes %VSZ/%CPU; minimal builds without top use plain ps VSZ.
         `procs=$(if procraw=$(ps -eo pid,%mem,comm --sort=-%mem 2>/dev/null); then printf "%s\n" "$procraw" | awk 'NR>1 && NR<=11 {gsub(/;/, "_", $3); printf "%s;%.1f;%s,", $1, $2, $3}' | sed 's/,$//'; elif topraw=$(top -b -n 1 2>/dev/null); then printf "%s\n" "$topraw" | awk '$1 == "PID" {for(i=1;i<=NF;i++){if($i=="%VSZ") mem_col=i; else if($i=="COMMAND") cmd_col=i} next} $1 ~ /^[0-9]+$/ && mem_col && cmd_col {pct=$(mem_col); gsub(/%/, "", pct); cmd=$(cmd_col); gsub(/;/, "_", cmd); print pct ";" $1 ";" cmd}' | sort -t ';' -k1,1rn | head -10 | awk -F';' '{printf "%s;%.1f;%s,", $2, $1, $3}' | sed 's/,$//'; else ps ww 2>/dev/null | awk -v total=$(awk '/^MemTotal:/{print $2}' /proc/meminfo) '$1 ~ /^[0-9]+$/ {v=$3; unit=substr(v,length(v),1); mult=1; if(unit=="m"||unit=="M")mult=1024; else if(unit=="g"||unit=="G")mult=1048576; sub(/[mMgG]$/, "", v); pct=total>0?v*mult*100/total:0; cmd=$5; gsub(/;/, "_", cmd); print pct, $1, cmd}' | sort -rn | head -10 | awk '{printf "%s;%.1f;%s,", $2, $1, $3}' | sed 's/,$//'; fi)`,
-        // Get mounted disk info. GNU and BusyBox support df -T; the awk
-        // parser also accepts the legacy POSIX -kP layout as a fallback.
-        // PVE/LXC guests often expose ZFS datasets and host bind mounts without a
-        // /dev/* source, so keep non-pseudo filesystems (not only block devices).
-        // Skip FUSE/cloud/NFS/CIFS network mounts (rclone, CloudDrive, mergerfs,
-        // nfs, cifs, …): their quotas inflate System Overview totals and are not
-        // local block capacity. Keep a loop-backed rootfs (some CT images) while
-        // still dropping snap loop mounts under /snap.
-        // When Capacity is "-" (some CT/cgroup views), derive percent from used/total.
-        // If the full table yields nothing, fall back to df on "/" alone.
-        // Do not blanket-skip /run: udisks may mount real volumes under /run/media;
-        // tmpfs/udev/shm rows are dropped by filesystem-source checks instead.
-        `disks=$( { ${linuxDiskTable}; } | ${linuxDiskAwk} | sed 's/,$//' ); [ -n "$disks" ] || disks=$( { ${linuxDiskRoot}; } | ${linuxDiskAwk} | sed 's/,$//' )`,
         // Get network interface stats from /proc/net/dev (interface:rx_bytes:tx_bytes), excluding lo and virtual interfaces
         `net=$(cat /proc/net/dev 2>/dev/null | awk 'NR>2 {gsub(/^[ \\t]+/, ""); split($0, a, ":"); iface=a[1]; if(iface != "lo" && iface !~ /^veth/ && iface !~ /^docker/ && iface !~ /^br-/) {split(a[2], b); printf "%s:%s:%s,", iface, b[1], b[9]}}' | sed 's/,$//' || echo "")`,
         `hostname_value=$(hostname 2>/dev/null || uname -n 2>/dev/null || echo "")`,
@@ -1128,16 +1115,53 @@ function createSessionOpsApi(ctx) {
         `uptime=$(awk '{printf "%.0f",$1}' /proc/uptime 2>/dev/null || echo "")`,
         `loadavg=$(awk '{print $1" "$2" "$3}' /proc/loadavg 2>/dev/null || echo "")`,
         // Output all stats (using CPURAW and PERCORERAW instead of CPU and PERCORE)
-        `echo "CPURAW:$cpuraw|CORES:$cores|PERCORERAW:$percoreraw|MEMINFO:$meminfo|PROCS:$procs|DISKS:$disks|NET:$net|HOST:$hostname_value|OS:$osname|KERNEL:$kernel|UPTIME:$uptime|LOAD:$loadavg"`
+        `echo "CPURAW:$cpuraw|CORES:$cores|PERCORERAW:$percoreraw|MEMINFO:$meminfo|PROCS:$procs|NET:$net|HOST:$hostname_value|OS:$osname|KERNEL:$kernel|UPTIME:$uptime|LOAD:$loadavg"`
       ].join('; ');
-    
-      // Auto-detect OS via uname — only Linux and macOS are supported
+
+      // Get mounted disk info. GNU and BusyBox support df -T; the awk parser
+      // also accepts the legacy POSIX -kP layout as a fallback. PVE/LXC guests
+      // often expose ZFS datasets and host bind mounts without a /dev/* source,
+      // so keep non-pseudo filesystems. Skip FUSE/cloud/NFS/CIFS network mounts:
+      // their quotas are not local capacity. Keep a loop-backed rootfs while
+      // dropping snap loops, derive missing percentages, and fall back to "/".
+      const linuxDiskStatsCommand = [
+        `disks=$( { ${linuxDiskTable}; } | ${linuxDiskAwk} | sed 's/,$//' )`,
+        `[ -n "$disks" ] || disks=$( { ${linuxDiskRoot}; } | ${linuxDiskAwk} | sed 's/,$//' )`,
+        `echo "DISKS:$disks"`,
+      ].join('; ');
+
+      // Dropbear rejects command requests larger than 9000 bytes by closing
+      // the entire SSH transport, including an already-open interactive shell.
+      // Keep Linux's large disk parser in its own request so future stats
+      // additions cannot repeat issue #2924.
+      const dropbearMaxCommandBytes = 9000;
       const latencyMarker = "NC_LATENCY_MARK";
       const statsCommand = `printf "${latencyMarker}|"; ostype=$(uname -s 2>/dev/null || echo "Unknown"); if [ "$ostype" = "Darwin" ]; then ${macosStatsCommand}; elif [ "$ostype" = "Linux" ]; then ${linuxStatsCommand}; else echo "UNSUPPORTED_OS:$ostype"; fi`;
+      const statsExecOptions = {
+        openingTimeoutMs: 10000,
+        runTimeoutMs: 10000,
+        maxOutputBytes: 1024 * 1024,
+        setTimeoutFn: setTimeout,
+        clearTimeoutFn: clearTimeout,
+      };
+      const executeStatsCommand = (command, options = statsExecOptions) => {
+        const commandBytes = Buffer.byteLength(command, 'utf8');
+        if (commandBytes > dropbearMaxCommandBytes) {
+          const error = new Error(`Server stats command exceeds Dropbear limit (${commandBytes} bytes)`);
+          error.code = "SSH_EXEC_COMMAND_LIMIT";
+          return Promise.reject(error);
+        }
+        return executeBoundedSshCommand(conn, command, options);
+      };
       const tcpLatencyTarget = getTcpLatencyTarget(session);
       const tcpLatencyPromise = tcpLatencyTarget && typeof measureTcpConnectLatency === 'function'
         ? Promise.resolve(measureTcpConnectLatency(tcpLatencyTarget)).catch(() => null)
         : Promise.resolve(null);
+      const formatStatsError = (error) => (
+        error?.code === "SSH_EXEC_OPEN_TIMEOUT" || error?.code === "SSH_EXEC_RUN_TIMEOUT"
+          ? "Timeout getting server stats"
+          : error?.message || String(error)
+      );
       return new Promise((resolve) => {
         let settled = false;
         const settle = (result) => {
@@ -1146,20 +1170,24 @@ function createSessionOpsApi(ctx) {
           resolve(result);
           return true;
         };
-        void executeBoundedSshCommand(conn, statsCommand, {
-          openingTimeoutMs: 10000,
-          runTimeoutMs: 10000,
-          maxOutputBytes: 1024 * 1024,
-          setTimeoutFn: setTimeout,
-          clearTimeoutFn: clearTimeout,
-        }).then(async ({ stdout }) => {
+        void (async () => {
+          try {
+            const { stdout } = await executeStatsCommand(statsCommand);
             if (settled) return;
+            let combinedStdout = String(stdout || '').trim();
+            const primaryOutput = combinedStdout.replace(new RegExp(`^${latencyMarker}\\|?`), '');
+            if (primaryOutput.startsWith('CPURAW:')) {
+              const diskResult = await executeStatsCommand(linuxDiskStatsCommand);
+              combinedStdout = [combinedStdout, String(diskResult.stdout || '').trim()]
+                .filter(Boolean)
+                .join('|');
+            }
             const measuredLatency = await tcpLatencyPromise;
             if (settled) return;
             const latencyMs = Number.isFinite(measuredLatency) ? measuredLatency : null;
     
             // Parse the output
-            const output = stdout.trim().replace(new RegExp(`^${latencyMarker}\\|?`), '');
+            const output = combinedStdout.replace(new RegExp(`^${latencyMarker}\\|?`), '');
     
             // Unsupported OS — stop polling this session
             if (output.startsWith('UNSUPPORTED_OS:')) {
@@ -1487,14 +1515,10 @@ function createSessionOpsApi(ctx) {
                 loadAverage,
               },
             });
-          }, (error) => {
-            settle({
-              success: false,
-              error: error?.code === "SSH_EXEC_OPEN_TIMEOUT" || error?.code === "SSH_EXEC_RUN_TIMEOUT"
-                ? "Timeout getting server stats"
-                : error?.message || String(error),
-            });
-          });
+          } catch (error) {
+            settle({ success: false, error: formatStatsError(error) });
+          }
+        })();
       });
     }
     

--- a/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
+++ b/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
@@ -4,6 +4,7 @@ const { spawnSync } = require("node:child_process");
 const { EventEmitter } = require("node:events");
 
 const { createSessionOpsApi } = require("./sessionOps.cjs");
+const { selectServerStatsFixtureOutput } = require("./serverStatsTestHelpers.cjs");
 const {
   borrowTransport,
   createTransport,
@@ -33,10 +34,7 @@ function fakeStream(stdout) {
 function fakeConn(stdout) {
   return {
     exec(command, cb) {
-      const output = command.includes("NC_LATENCY_MARK") && !stdout.includes("NC_LATENCY_MARK")
-        ? `NC_LATENCY_MARK|${stdout}`
-        : stdout;
-      cb(null, fakeStream(output));
+      cb(null, fakeStream(selectServerStatsFixtureOutput(command, stdout)));
     },
   };
 }
@@ -856,6 +854,64 @@ test("getServerStats parses macOS stats and avoids blocking top command", async 
   assert.equal(result.stats.netInterfaces[0].rxBytes, 1000);
   assert.equal(result.stats.netInterfaces[0].txBytes, 3000);
   assert.equal(typeof result.stats.latencyMs, "number");
+});
+
+test("getServerStats keeps every remote command within Dropbear's command limit", async () => {
+  const commands = [];
+  const sessions = new Map();
+  sessions.set("sid", {
+    type: "ssh",
+    _reuseEndpoint: { hostname: "openwrt.example.test", port: 22 },
+    conn: {
+      exec(command, cb) {
+        commands.push(command);
+        const output = command.includes("CPURAW:")
+          ? `NC_LATENCY_MARK|${LINUX_STATS}`
+          : command.includes("DISKS:")
+            ? "DISKS:"
+            : "";
+        cb(null, fakeStream(output));
+      },
+    },
+  });
+
+  const api = makeSessionOps(sessions);
+  const result = await api.getServerStats({ sender: {} }, { sessionId: "sid" });
+
+  assert.equal(result.success, true);
+  assert.equal(commands.length, 2, "Linux base and disk stats must use separate commands");
+  for (const command of commands) {
+    assert.ok(
+      Buffer.byteLength(command, "utf8") <= 9000,
+      `remote command is ${Buffer.byteLength(command, "utf8")} bytes`,
+    );
+  }
+});
+
+test("getServerStats settles when the split disk command fails", async () => {
+  const sessions = new Map();
+  sessions.set("sid", {
+    type: "ssh",
+    conn: {
+      exec(command, cb) {
+        if (command.includes('echo "DISKS:$disks"')) {
+          cb(new Error("disk stats rejected"));
+          return;
+        }
+        cb(null, fakeStream(`NC_LATENCY_MARK|${LINUX_STATS}`));
+      },
+    },
+  });
+
+  const api = makeSessionOps(sessions);
+  const result = await Promise.race([
+    api.getServerStats({ sender: {} }, { sessionId: "sid" }),
+    new Promise((resolve) => setTimeout(() => resolve({ timedOut: true }), 100)),
+  ]);
+
+  assert.notEqual(result.timedOut, true);
+  assert.equal(result.success, false);
+  assert.equal(result.error, "disk stats rejected");
 });
 
 test("getServerStats reports pending (not a hard failure) for a Mosh session before the handshake swap", async () => {


### PR DESCRIPTION
## Summary

Fix OpenWrt/Dropbear SSH sessions disconnecting immediately after the prompt appears in Netcatty 1.1.78.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2924

## Changes Made

- Split Linux server statistics into base and disk requests so neither request exceeds Dropbear's 9,000-byte command limit.
- Reject any future oversized server-statistics request locally before it can terminate the shared SSH connection.
- Preserve Linux disk filtering, macOS statistics, Mosh companion connections, and direct or jumped ET fallback behavior.
- Ensure a failure in either split request returns an error instead of leaving statistics polling pending.
- Add regression coverage for the Dropbear byte limit and second-request failure path.

## Root Cause

The Linux server-statistics command grew from about 6,685 bytes in 1.1.77 to 12,135 bytes in 1.1.78. Dropbear accepts at most 9,000 bytes and closes the entire SSH transport for a larger command. Because the terminal shell and statistics request share that transport, the prompt rendered and then disconnected immediately.

The fixed requests are 5,817 and 7,396 bytes, and both pass through a 9,000-byte guard before execution.

## Screenshots / Demo

No UI changes. The affected OpenWrt terminal remains connected while background system statistics are collected.

## Testing

- [x] Linting passes (`npm run lint`; one unrelated existing warning)
- [x] Tests pass (`npm test`)
- [x] Production build passes (`npm run build`)
- [x] Focused SSH/Mosh/ET server-statistics tests pass (35/35)
- [x] Generated capability tool specs are updated when applicable (not applicable)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes