### PR TITLE
修复 SFTP 虚拟根目录会话的传输失败

### DIFF
--- a/application/state/sftp/ensureRemoteSftpSession.test.ts
+++ b/application/state/sftp/ensureRemoteSftpSession.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import type { Host } from "../../../domain/models";
-import { ensureRemoteSftpSession } from "./ensureRemoteSftpSession";
+import { ensureRemoteSftpSession, probeSftpSession } from "./ensureRemoteSftpSession";
 import type { SftpPane } from "./types";
 
 const host = {
@@ -36,6 +36,24 @@ const remotePane = (connectionId: string): SftpPane => ({
 } as unknown as SftpPane);
 
 const noopReleaseConnection = async () => {};
+
+test("SFTP session probe accepts a virtual root directory", async () => {
+  const calls: Array<[string, string]> = [];
+  const ok = await probeSftpSession({
+    realpathSftp: async (sftpId, remotePath) => {
+      calls.push([sftpId, remotePath]);
+      return "/";
+    },
+  }, "sftp-jumpserver");
+
+  assert.equal(ok, true);
+  assert.deepEqual(calls, [["sftp-jumpserver", "."]]);
+});
+
+test("SFTP session probe does not require home discovery", async () => {
+  const ok = await probeSftpSession(undefined, "sftp-live");
+  assert.equal(ok, true);
+});
 
 test("returns an existing mapped SFTP session without reconnecting", async () => {
   let connectCalls = 0;

--- a/application/state/sftp/ensureRemoteSftpSession.ts
+++ b/application/state/sftp/ensureRemoteSftpSession.ts
@@ -3,6 +3,24 @@ import type { MutableRefObject } from "react";
 import { isSessionError } from "./errors";
 import type { SftpPane } from "./types";
 
+export interface SftpSessionProbeBridge {
+  realpathSftp?: (sftpId: string, path: string) => Promise<string>;
+}
+
+/**
+ * Probe the SFTP protocol itself instead of using remote home discovery.
+ * Restricted/chroot servers can deny SSH exec or expose '/' as their virtual
+ * root while the SFTP session remains fully usable.
+ */
+export async function probeSftpSession(
+  bridge: SftpSessionProbeBridge | null | undefined,
+  sftpId: string,
+): Promise<boolean> {
+  if (!bridge?.realpathSftp) return true;
+  await bridge.realpathSftp(sftpId, ".");
+  return true;
+}
+
 export interface EnsureRemoteSftpSessionParams {
   side: "left" | "right";
   getActivePane: (side: "left" | "right") => SftpPane | null;

--- a/application/state/useSftpState.ts
+++ b/application/state/useSftpState.ts
@@ -30,7 +30,7 @@ import { buildSftpHostCredentials } from "./sftp/useSftpHostCredentials";
 import { useSftpFileWatch } from "./sftp/useSftpFileWatch";
 import { useSftpSessionCleanup } from "./sftp/useSftpSessionCleanup";
 import { useSftpSessionErrors } from "./sftp/useSftpSessionErrors";
-import { ensureRemoteSftpSession } from "./sftp/ensureRemoteSftpSession";
+import { ensureRemoteSftpSession, probeSftpSession } from "./sftp/ensureRemoteSftpSession";
 import { openTransferSftpSession } from "./sftp/dedicatedTransferResume";
 import {
   createTransferPoolKeyCache,
@@ -608,16 +608,7 @@ export const useSftpState = (
         forceReconnect: ensureOptions?.forceReconnect,
         releaseConnection,
         tabId,
-        probeSession: async (sftpId) => {
-          // Lightweight liveness check; any session-error from the bridge
-          // triggers a reconnect in ensureRemoteSftpSession.
-          if (!bridge?.getSftpHomeDir) return true;
-          const result = await bridge.getSftpHomeDir(sftpId);
-          if (result && result.success === false) {
-            throw new Error(result.error || "SFTP session not found");
-          }
-          return true;
-        },
+        probeSession: (sftpId) => probeSftpSession(bridge, sftpId),
       });
     },
     resolveConnectedHost: (tabId) => connectedHostByTabIdRef.current.get(tabId) ?? null,
@@ -714,15 +705,7 @@ export const useSftpState = (
             resolveConnectedHost: (id) => connectedHostByTabIdRef.current.get(id) ?? null,
             resolveHostById: (hostId) => hosts.find((host) => host.id === hostId) ?? null,
             resolveSourceSessionId: resolveBrowseSourceSessionId,
-            probeSession: async (sftpId) => {
-              const bridge = netcattyBridge.get();
-              if (!bridge?.getSftpHomeDir) return true;
-              const result = await bridge.getSftpHomeDir(sftpId);
-              if (result && result.success === false) {
-                throw new Error(result.error || "SFTP session not found");
-              }
-              return true;
-            },
+            probeSession: (sftpId) => probeSftpSession(netcattyBridge.get(), sftpId),
             releaseConnection,
           });
           logger.info(`[SFTP] Restored browse session on ${side}`);

--- a/electron/bridges/sftpBridge/fileOps.cjs
+++ b/electron/bridges/sftpBridge/fileOps.cjs
@@ -932,8 +932,9 @@ function createFileOpsApi(ctx) {
         }
       }
     
-      // Method 2: SFTP realpath('.') — skip if result is '/' for non-root users
-      // because some SFTP servers start in '/' rather than the user's home
+      // Method 2: SFTP realpath('.'). A virtual/chroot SFTP server (including
+      // bastion products such as JumpServer) can legitimately expose '/' as
+      // the authenticated user's root even when SSH exec channels are denied.
       try {
         const sftp = await requireSftpChannel(client, {
           signal,
@@ -942,7 +943,7 @@ function createFileOpsApi(ctx) {
         throwIfAborted(signal);
         const absPath = await realpathAsync(sftp, ".");
         throwIfAborted(signal);
-        if (absPath && absPath !== "/") {
+        if (absPath && absPath.startsWith("/")) {
           return { success: true, homeDir: absPath };
         }
       } catch (err) {

--- a/electron/bridges/sftpBridge/fileOps.test.cjs
+++ b/electron/bridges/sftpBridge/fileOps.test.cjs
@@ -1,0 +1,22 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { createFileOpsApi } = require("./fileOps.cjs");
+
+test("home discovery accepts a virtual SFTP root when SSH exec is unavailable", async () => {
+  const channel = {};
+  const api = createFileOpsApi({
+    sftpClients: new Map([["jumpserver", { sftp: channel }]]),
+    throwIfAborted() {},
+    requireSftpChannel: async () => channel,
+    realpathAsync: async (resolvedChannel, remotePath) => {
+      assert.equal(resolvedChannel, channel);
+      assert.equal(remotePath, ".");
+      return "/";
+    },
+  });
+
+  const result = await api.getSftpHomeDir(null, { sftpId: "jumpserver" });
+
+  assert.deepEqual(result, { success: true, homeDir: "/" });
+});


### PR DESCRIPTION
## 概要

修复受限或 chroot SFTP 服务将远端根目录暴露为 `/` 时，客户端错误判定无法获取主目录并阻止上传、下载的问题。

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构 / 代码清理
- [ ] 文档更新
- [ ] 构建 / CI 变更
- [ ] 其他

## 关联 Issue（可选）

N/A

## 主要改动

- 将 SFTP `realpath(".")` 返回的绝对路径（包括虚拟根目录 `/`）视为有效起始目录。
- 上传、下载及浏览会话恢复前，改用 SFTP 协议自身的 `realpath(".")` 检查会话存活状态。
- 不再使用 SSH home 目录探测作为传输前健康检查，避免受限服务器拒绝 exec channel 时误判会话失效。
- 增加虚拟根目录和受限会话场景的回归测试。

## 截图 / 演示

无 UI 变更。已在 Windows 开发版中连接实际受限 SFTP 环境，上传和下载均验证通过。

## 测试

- [x] 已在本地运行并测试（`npm run dev`）
- [x] Lint 通过（`npm run lint`，仅有仓库既有 warning）
- [x] 相关 SFTP 测试通过（347 通过，10 跳过，0 失败）
- [x] 生产构建通过（`npm run build`）
- [ ] 完整测试套件通过（`npm test`，本次未运行完整套件）
- [x] Capability tool specs：本次不涉及
- [x] 此行为变更未引入新的控制台错误或警告

## Checklist

- [x] 代码遵循现有项目风格
- [x] 已添加相关回归测试
- [x] 未引入破坏性变更
- [x] 文档：本次无需更新