### PR TITLE
Fix theme header button alignment

### DIFF
--- a/components/terminal/ThemeSidePanel.test.ts
+++ b/components/terminal/ThemeSidePanel.test.ts
@@ -13,3 +13,10 @@ test("hidden selected theme uses the normal theme item row", () => {
   assert.match(source, /hiddenSelectedTheme && \(\s*<ThemeItem/);
   assert.doesNotMatch(source, /terminal\.hiddenTheme\.title[\s\S]*terminal\.hiddenTheme\.desc/);
 });
+
+test("theme side panel tabs are vertically centered in the header", () => {
+  assert.match(
+    source,
+    /TERMINAL_SIDE_PANEL_INNER_HEADER_CLASS, 'flex items-center px-1\.5 gap-0\.5 border-b'/,
+  );
+});

--- a/components/terminal/ThemeSidePanel.tsx
+++ b/components/terminal/ThemeSidePanel.tsx
@@ -311,7 +311,7 @@ const ThemeSidePanelInner: React.FC<ThemeSidePanelProps> = ({
       >
         {/* Tab Bar */}
         <div
-          className={cn(TERMINAL_SIDE_PANEL_INNER_HEADER_CLASS, 'flex px-1.5 gap-0.5 border-b')}
+          className={cn(TERMINAL_SIDE_PANEL_INNER_HEADER_CLASS, 'flex items-center px-1.5 gap-0.5 border-b')}
           style={{ borderColor: 'var(--terminal-panel-border)' }}
         >
           <button


### PR DESCRIPTION
## Summary

Vertically centers the Theme and Font buttons in the terminal sidebar header.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Centered the Theme and Font buttons within the shared header height.
- Added a regression check for the alignment rule.

## Screenshots / Demo

Verified locally against the terminal theme sidebar; the two buttons are vertically centered.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes for the changed files
- [x] Focused tests pass
- [x] Production build passes
- [x] Generated capability tool specs are updated when applicable
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [x] Documentation is not required for this visual fix
- [x] I have not introduced any breaking changes