### PR TITLE
fix(sftp): 复用 SSH 会话打开 sudo SFTP

### DIFF
--- a/application/state/sftp/dedicatedTransferResume.ts
+++ b/application/state/sftp/dedicatedTransferResume.ts
@@ -162,7 +162,6 @@ export async function openTransferSftpSession(
     if (
       !wantDedicated
       && options?.sourceSessionId
-      && !host.sftpSudo
       && bridge.openSftpForSession
     ) {
       try {

--- a/application/state/sftp/useSftpConnections.test.ts
+++ b/application/state/sftp/useSftpConnections.test.ts
@@ -3,8 +3,10 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import {
+  runSftpConnectOnceByKey,
   createSftpConnectionId,
   createPinnedReconnectSideResolver,
   openSftpConnectionOnce,
@@ -19,6 +21,28 @@ test("connection ids stay unique even when connects start in the same millisecon
   const ids = ["uuid-a", "uuid-b"];
   assert.equal(createSftpConnectionId("left", () => ids.shift()!), "left-uuid-a");
   assert.equal(createSftpConnectionId("left", () => ids.shift()!), "left-uuid-b");
+});
+
+test("runSftpConnectOnceByKey shares an in-flight connect for the same tab and endpoint", async () => {
+  const inFlight = new Map<string, Promise<void>>();
+  let runs = 0;
+  let releaseFirst: (() => void) | undefined;
+
+  const first = runSftpConnectOnceByKey(inFlight, "left:tab-1:host-key:ssh-session-1:/home", async () => {
+    runs += 1;
+    await new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+  });
+  const second = runSftpConnectOnceByKey(inFlight, "left:tab-1:host-key:ssh-session-1:/home", async () => {
+    runs += 1;
+  });
+
+  assert.equal(runs, 1);
+  releaseFirst?.();
+  await Promise.all([first, second]);
+  assert.equal(runs, 1);
+  assert.equal(inFlight.size, 0);
 });
 
 const openOptions = {
@@ -71,6 +95,43 @@ test("openSftpWithSessionPreference falls back to normal SFTP when session reuse
 
   assert.equal(sftpId, "fresh-sftp");
   assert.deepEqual(calls, ["openForSession:ssh-session-1", "openSftp:sftp-request-1"]);
+});
+
+test("openSftpWithSessionPreference tries session reuse for sudo SFTP before fresh auth", async () => {
+  const calls: string[] = [];
+  let passedOptions: NetcattySSHOptions | undefined;
+  const sftpId = await openSftpWithSessionPreference({
+    bridge: {
+      openSftpForSession: async (sessionId: string, options?: NetcattySSHOptions) => {
+        calls.push(`openForSession:${sessionId}`);
+        passedOptions = options;
+        return "sudo-session-backed-sftp";
+      },
+      openSftp: async () => {
+        calls.push("openSftp");
+        return "fresh-sftp";
+      },
+    },
+    sourceSessionId: "ssh-session-1",
+    openOptions: {
+      ...openOptions,
+      sudo: true,
+      password: "sudo-pass",
+    },
+  });
+
+  assert.equal(sftpId, "sudo-session-backed-sftp");
+  assert.deepEqual(calls, ["openForSession:ssh-session-1"]);
+  assert.equal(passedOptions?.sudo, true);
+  assert.equal(passedOptions?.password, "sudo-pass");
+});
+
+test("remote browse connect does not discard sourceSessionId for sudo hosts", () => {
+  const source = readFileSync(new URL("./useSftpConnections.ts", import.meta.url), "utf8");
+  assert.doesNotMatch(
+    source,
+    /host\.sftpSudo\s*\?\s*undefined\s*:\s*options\?\.sourceSessionId/,
+  );
 });
 
 test("openSftpWithSessionPreference opens normal SFTP without a source session", async () => {

--- a/application/state/sftp/useSftpConnections.test.ts
+++ b/application/state/sftp/useSftpConnections.test.ts
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 import {
+  buildSftpConnectInFlightKey,
   runSftpConnectOnceByKey,
   createSftpConnectionId,
   createPinnedReconnectSideResolver,
@@ -43,6 +44,27 @@ test("runSftpConnectOnceByKey shares an in-flight connect for the same tab and e
   await Promise.all([first, second]);
   assert.equal(runs, 1);
   assert.equal(inFlight.size, 0);
+});
+
+test("buildSftpConnectInFlightKey uses the allocated tab id for forced new tabs", () => {
+  const first = buildSftpConnectInFlightKey({
+    side: "left",
+    tabId: "new-tab-a",
+    targetConnectionKey: "host-key",
+    sourceSessionId: "ssh-session-1",
+    initialPath: "/home",
+    forceNewTab: true,
+  });
+  const second = buildSftpConnectInFlightKey({
+    side: "left",
+    tabId: "new-tab-b",
+    targetConnectionKey: "host-key",
+    sourceSessionId: "ssh-session-1",
+    initialPath: "/home",
+    forceNewTab: true,
+  });
+
+  assert.notEqual(first, second);
 });
 
 const openOptions = {

--- a/application/state/sftp/useSftpConnections.ts
+++ b/application/state/sftp/useSftpConnections.ts
@@ -193,6 +193,24 @@ export function runSftpConnectOnceByKey(
   return promise;
 }
 
+export function buildSftpConnectInFlightKey(params: {
+  side: "left" | "right";
+  tabId: string;
+  targetConnectionKey: string;
+  sourceSessionId?: string;
+  initialPath?: string;
+  forceNewTab?: boolean;
+}): string {
+  return [
+    params.side,
+    params.tabId,
+    params.targetConnectionKey,
+    params.sourceSessionId ?? "",
+    params.initialPath ?? "",
+    params.forceNewTab ? "force-new-tab" : "",
+  ].join("\u0000");
+}
+
 interface UseSftpConnectionsResult {
   connect: (side: "left" | "right", host: Host | "local", options?: SftpConnectOptions) => Promise<void>;
   disconnect: (side: "left" | "right") => Promise<void>;
@@ -359,7 +377,6 @@ export const useSftpConnections = ({
 
       let activeTabId: string | null = null;
       const sideTabs = side === "left" ? leftTabsRef.current : rightTabsRef.current;
-      const connectTargetSlot = options?.tabId ?? sideTabs.activeTabId ?? `new:${side}`;
 
       if (options?.tabId) {
         // Background reconnect for a pinned upload must not retarget the focused tab.
@@ -445,32 +462,31 @@ export const useSftpConnections = ({
       // immediately, avoiding race conditions with deferred effects.
       options?.onTabCreated?.(activeTabId);
 
-      const connectInFlightKey = [
+      const connectInFlightKey = buildSftpConnectInFlightKey({
         side,
-        connectTargetSlot,
+        tabId: activeTabId,
         targetConnectionKey,
-        host === "local" ? "" : (options?.sourceSessionId ?? ""),
-        effectiveInitialPath ?? "",
-        options?.forceNewTab ? "force-new-tab" : "",
-      ].join("\u0000");
+        sourceSessionId: host === "local" ? undefined : options?.sourceSessionId,
+        initialPath: effectiveInitialPath,
+        forceNewTab: options?.forceNewTab,
+      });
 
       return runSftpConnectOnceByKey(connectInFlightRef.current, connectInFlightKey, async () => {
+        const connectionId = createSftpConnectionId(side);
 
-      const connectionId = createSftpConnectionId(side);
-
-      navSeqRef.current[side] += 1;
-      const connectRequestId = navSeqRef.current[side];
-      const getTargetPane = () => {
-        const targetSide = resolveTargetSide();
-        const tabs = targetSide === "left" ? leftTabsRef.current.tabs : rightTabsRef.current.tabs;
-        return tabs.find((tab) => tab.id === activeTabId) ?? null;
-      };
-      const isTargetConnectionCurrent = () => {
-        const pane = getTargetPane();
-        if (!pane) return false;
-        if (pane.connection?.id === connectionId) return true;
-        return !pane.connection && navSeqRef.current[side] === connectRequestId;
-      };
+        navSeqRef.current[side] += 1;
+        const connectRequestId = navSeqRef.current[side];
+        const getTargetPane = () => {
+          const targetSide = resolveTargetSide();
+          const tabs = targetSide === "left" ? leftTabsRef.current.tabs : rightTabsRef.current.tabs;
+          return tabs.find((tab) => tab.id === activeTabId) ?? null;
+        };
+        const isTargetConnectionCurrent = () => {
+          const pane = getTargetPane();
+          if (!pane) return false;
+          if (pane.connection?.id === connectionId) return true;
+          return !pane.connection && navSeqRef.current[side] === connectRequestId;
+        };
       const isTargetConnectionAtPath = (path: string) => {
         const connection = getTargetPane()?.connection;
         if (!connection) return navSeqRef.current[side] === connectRequestId;

--- a/application/state/sftp/useSftpConnections.ts
+++ b/application/state/sftp/useSftpConnections.ts
@@ -176,6 +176,23 @@ export function createPinnedReconnectSideResolver(
   };
 }
 
+export function runSftpConnectOnceByKey(
+  inFlight: Map<string, Promise<void>>,
+  key: string,
+  run: () => Promise<void>,
+): Promise<void> {
+  const existing = inFlight.get(key);
+  if (existing) return existing;
+
+  const promise = run().finally(() => {
+    if (inFlight.get(key) === promise) {
+      inFlight.delete(key);
+    }
+  });
+  inFlight.set(key, promise);
+  return promise;
+}
+
 interface UseSftpConnectionsResult {
   connect: (side: "left" | "right", host: Host | "local", options?: SftpConnectOptions) => Promise<void>;
   disconnect: (side: "left" | "right") => Promise<void>;
@@ -249,6 +266,7 @@ export const useSftpConnections = ({
   const [hostKeyVerification, setHostKeyVerification] = useState<SftpHostKeyVerificationState | null>(null);
   const hostKeyVerificationRef = useRef<(SftpHostKeyVerificationState & { requestId: string; sessionId: string }) | null>(null);
   const activeHostKeySessionsRef = useRef<Map<string, { side: "left" | "right"; tabId: string }>>(new Map());
+  const connectInFlightRef = useRef<Map<string, Promise<void>>>(new Map());
 
   const setPendingHostKeyVerification = useCallback((
     next: (SftpHostKeyVerificationState & { requestId: string; sessionId: string }) | null,
@@ -341,6 +359,7 @@ export const useSftpConnections = ({
 
       let activeTabId: string | null = null;
       const sideTabs = side === "left" ? leftTabsRef.current : rightTabsRef.current;
+      const connectTargetSlot = options?.tabId ?? sideTabs.activeTabId ?? `new:${side}`;
 
       if (options?.tabId) {
         // Background reconnect for a pinned upload must not retarget the focused tab.
@@ -425,6 +444,17 @@ export const useSftpConnections = ({
       // This allows callers to map metadata (e.g. connection keys) to the tab
       // immediately, avoiding race conditions with deferred effects.
       options?.onTabCreated?.(activeTabId);
+
+      const connectInFlightKey = [
+        side,
+        connectTargetSlot,
+        targetConnectionKey,
+        host === "local" ? "" : (options?.sourceSessionId ?? ""),
+        effectiveInitialPath ?? "",
+        options?.forceNewTab ? "force-new-tab" : "",
+      ].join("\u0000");
+
+      return runSftpConnectOnceByKey(connectInFlightRef.current, connectInFlightKey, async () => {
 
       const connectionId = createSftpConnectionId(side);
 
@@ -573,9 +603,7 @@ export const useSftpConnections = ({
           sharedHostCache?.path,
         );
 
-        // Sudo never reuses a terminal shell; normalize before UI state so
-        // reusedConnection (spinner/overlay) matches the actual open path.
-        const sourceSessionId = host.sftpSudo ? undefined : options?.sourceSessionId;
+        const sourceSessionId = options?.sourceSessionId;
 
         const connection: SftpConnection = {
           id: connectionId,
@@ -855,6 +883,7 @@ export const useSftpConnections = ({
           unsubSftpProgress?.();
         }
       }
+      });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [

--- a/application/state/useSftpState.ts
+++ b/application/state/useSftpState.ts
@@ -316,9 +316,7 @@ export const useSftpState = (
       // Prefer borrowing the live (or parked) terminal SSH transport so MFA is
       // not repeated. Transport leases keep the shared conn alive after the
       // terminal tab closes until the transfer SFTP lease is returned.
-      const sourceSessionId = !host.sftpSudo
-        ? resolveTransferSourceSessionId?.(host.id, host)
-        : undefined;
+      const sourceSessionId = resolveTransferSourceSessionId?.(host.id, host);
       if (sourceSessionId) {
         try {
           logger.info(
@@ -704,6 +702,12 @@ export const useSftpState = (
         const pane = getActivePane(side);
         if (!pane?.connection || pane.connection.isLocal) continue;
         if (sftpSessionsRef.current.has(pane.connection.id)) continue;
+        const connectedHost = connectedHostByTabIdRef.current.get(pane.id) ?? null;
+        const vaultHost = hosts.find((host) => host.id === pane.connection?.hostId) ?? null;
+        const targetHost = connectedHost && connectedHost !== "local" ? connectedHost : vaultHost;
+        const resolvedSourceSessionId = targetHost
+          ? resolveBrowseSourceSessionId?.(targetHost.id, targetHost)
+          : undefined;
         try {
           await ensureRemoteSftpSession({
             side,
@@ -713,7 +717,9 @@ export const useSftpState = (
             connect,
             resolveConnectedHost: (id) => connectedHostByTabIdRef.current.get(id) ?? null,
             resolveHostById: (hostId) => hosts.find((host) => host.id === hostId) ?? null,
-            resolveSourceSessionId: resolveBrowseSourceSessionId,
+            resolveSourceSessionId: resolvedSourceSessionId
+              ? () => resolvedSourceSessionId
+              : resolveBrowseSourceSessionId,
             probeSession: async (sftpId) => {
               const bridge = netcattyBridge.get();
               if (!bridge?.getSftpHomeDir) return true;

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -560,6 +560,19 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
       activeHost.username,
       activeHost.sftpFileProtocol,
     );
+    const pendingSameEndpointSession = sessions.find((session) => (
+      session.hostId === activeHost.id
+      && session.status !== "connected"
+      && session.hostname === activeHost.hostname
+      && (session.port ?? 22) === (activeHost.port ?? 22)
+      && session.username === activeHost.username
+      && (session.protocol === "ssh" || session.protocol === undefined)
+      && !session.moshEnabled
+      && !session.etEnabled
+    ));
+    if (!activeSessionId && pendingSameEndpointSession) {
+      return;
+    }
     const sessionChanged = shouldResetSftpSidePanelSourceSession(
       lastSourceSessionIdRef.current,
       activeSessionId,
@@ -737,7 +750,7 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
         tabConnectionKeyMapRef.current.set(tabId, connectionKey);
       },
     });
-  }, [activeHost, activeSessionId, initialLocation, interactiveWorkActive]);
+  }, [activeHost, activeSessionId, initialLocation, interactiveWorkActive, sessions]);
 
   useEffect(() => {
     if (!activeHost || !isVisible) return;

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -86,6 +86,7 @@ import { scheduleDeferredTerminalFocus } from "./systemManager/tmuxActionFocus";
 import {
   connectionKeyMatchesHost,
   findReusableSftpSidePanelTab,
+  isPendingSameEndpointSshSession,
   shouldAcceptPendingSftpUpload,
   shouldResetSftpSidePanelSourceSession,
   shouldSkipSftpSidePanelAutoConnect,
@@ -561,14 +562,7 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
       activeHost.sftpFileProtocol,
     );
     const pendingSameEndpointSession = sessions.find((session) => (
-      session.hostId === activeHost.id
-      && session.status !== "connected"
-      && session.hostname === activeHost.hostname
-      && (session.port ?? 22) === (activeHost.port ?? 22)
-      && session.username === activeHost.username
-      && (session.protocol === "ssh" || session.protocol === undefined)
-      && !session.moshEnabled
-      && !session.etEnabled
+      isPendingSameEndpointSshSession(session, activeHost)
     ));
     if (!activeSessionId && pendingSameEndpointSession) {
       return;

--- a/components/sftp/SftpHostPicker.test.ts
+++ b/components/sftp/SftpHostPicker.test.ts
@@ -50,7 +50,7 @@ test("sftp host picker uses single-line quick switcher row layout", () => {
   assert.doesNotMatch(source, /text-xs text-muted-foreground truncate/);
 });
 
-test("sftp host picker omits sourceSessionId for sudo connected hosts", () => {
+test("sftp host picker passes sourceSessionId for sudo connected hosts", () => {
   assert.match(source, /sftpSourceSessionIdForHost/);
   assert.match(
     source,
@@ -59,11 +59,6 @@ test("sftp host picker omits sourceSessionId for sudo connected hosts", () => {
   assert.match(
     source,
     /onSelectHost\(\s*item\.entry\.host,\s*sourceSessionId \? \{ sourceSessionId \} : undefined,\s*\)/,
-  );
-  // Must not always pass sessionId as a reuse hint (sudo would hide the spinner).
-  assert.doesNotMatch(
-    source,
-    /onSelectHost\(item\.entry\.host, \{ sourceSessionId: item\.entry\.sessionId \}\)/,
   );
 });
 

--- a/components/sftp/sftpSidePanelAutoConnect.test.ts
+++ b/components/sftp/sftpSidePanelAutoConnect.test.ts
@@ -4,6 +4,7 @@ import type { SftpPane } from "../../application/state/sftp/types";
 import {
   connectionKeyMatchesHost,
   findReusableSftpSidePanelTab,
+  isPendingSameEndpointSshSession,
   isRemoteSftpTabHealthy,
   shouldAcceptPendingSftpUpload,
   shouldResetSftpSidePanelSourceSession,
@@ -73,6 +74,35 @@ test("shouldSkipSftpSidePanelAutoConnect rejects when the active tab has no endp
   const tab = remoteConnectedTab();
   assert.equal(
     shouldSkipSftpSidePanelAutoConnect("host-a-key", "host-a-key", tab, true, null),
+    false,
+  );
+});
+
+test("isPendingSameEndpointSshSession only waits for actively connecting SSH sessions", () => {
+  const host = {
+    id: "host-1",
+    hostname: "server.example",
+    port: 22,
+    username: "root",
+  };
+  const baseSession = {
+    hostId: "host-1",
+    hostname: "server.example",
+    port: 22,
+    username: "root",
+    protocol: "ssh",
+  };
+
+  assert.equal(
+    isPendingSameEndpointSshSession({ ...baseSession, status: "connecting" }, host),
+    true,
+  );
+  assert.equal(
+    isPendingSameEndpointSshSession({ ...baseSession, status: "disconnected" }, host),
+    false,
+  );
+  assert.equal(
+    isPendingSameEndpointSshSession({ ...baseSession, status: "connected" }, host),
     false,
   );
 });

--- a/components/sftp/sftpSidePanelAutoConnect.ts
+++ b/components/sftp/sftpSidePanelAutoConnect.ts
@@ -33,6 +33,36 @@ export function shouldSkipSftpSidePanelAutoConnect(
   return isRemoteSftpTabHealthy(activeTab, hasBackendSession);
 }
 
+export function isPendingSameEndpointSshSession(
+  session: {
+    hostId?: string | null;
+    status?: string;
+    hostname?: string | null;
+    port?: number | null;
+    username?: string | null;
+    protocol?: string | null;
+    moshEnabled?: boolean;
+    etEnabled?: boolean;
+  },
+  host: {
+    id: string;
+    hostname: string;
+    port?: number | null;
+    username: string;
+  },
+): boolean {
+  return Boolean(
+    session.hostId === host.id
+    && session.status === "connecting"
+    && session.hostname === host.hostname
+    && (session.port ?? 22) === (host.port ?? 22)
+    && session.username === host.username
+    && (session.protocol === "ssh" || session.protocol === undefined)
+    && !session.moshEnabled
+    && !session.etEnabled,
+  );
+}
+
 /** Whether a stored endpoint key still belongs to the live connection's host. */
 export function connectionKeyMatchesHost(
   connectionKey: string | null | undefined,

--- a/domain/sftpConnectedHosts.test.ts
+++ b/domain/sftpConnectedHosts.test.ts
@@ -117,23 +117,23 @@ test("listSftpConnectedHosts includes hosts with SFTP sudo for picker display", 
   assert.equal(result.length, 1);
   assert.equal(result[0]?.sessionId, "s-sudo");
   assert.equal(result[0]?.host.sftpSudo, true);
-  // Transfer/open must still refuse shell reuse for sudo.
+  // Sudo SFTP still opens a new subsystem/channel, but it should borrow the
+  // already-authenticated SSH transport before falling back to fresh auth.
   assert.equal(
     resolveSftpTransferSourceSessionId(sessions, hostsById, "a", result[0]?.host),
-    undefined,
+    "s-sudo",
   );
-  // Picker/connect must not pass sessionId as a reuse hint for sudo hosts.
-  assert.equal(sftpSourceSessionIdForHost(result[0]?.host, result[0]?.sessionId), undefined);
+  assert.equal(sftpSourceSessionIdForHost(result[0]?.host, result[0]?.sessionId), "s-sudo");
 });
 
-test("sftpSourceSessionIdForHost keeps non-sudo reuse and drops sudo", () => {
+test("sftpSourceSessionIdForHost keeps sudo and non-sudo reuse hints", () => {
   assert.equal(
     sftpSourceSessionIdForHost(host({ id: "a", label: "Alpha" }), "s1"),
     "s1",
   );
   assert.equal(
     sftpSourceSessionIdForHost(host({ id: "a", label: "Alpha", sftpSudo: true }), "s1"),
-    undefined,
+    "s1",
   );
   assert.equal(sftpSourceSessionIdForHost(undefined, "s1"), "s1");
   assert.equal(sftpSourceSessionIdForHost(host({ id: "a", label: "Alpha" }), undefined), undefined);
@@ -311,6 +311,34 @@ test("resolveSftpTransferSourceSessionId matches among multi-tab same hostId end
   );
   // Without endpoint preference, last reusable session for hostId wins.
   assert.equal(resolveSftpTransferSourceSessionId(sessions, hostsById, "h1"), "s-new");
+});
+
+test("resolveSftpTransferSourceSessionId ignores SFTP browse connection ids", () => {
+  const vault = host({ id: "h1", label: "Prod", hostname: "prod.example.test", username: "alice", port: 22 });
+  const hostsById = new Map([["h1", vault]]);
+  const sessions = [
+    session({
+      id: "terminal-ssh-1",
+      hostId: "h1",
+      status: "connected",
+      hostname: "prod.example.test",
+      username: "alice",
+      port: 22,
+    }),
+    session({
+      id: "sftp-left-accidental-browse-id",
+      hostId: "h1",
+      status: "connected",
+      hostname: "prod.example.test",
+      username: "alice",
+      port: 22,
+    }),
+  ];
+
+  assert.equal(
+    resolveSftpTransferSourceSessionId(sessions, hostsById, "h1", vault),
+    "terminal-ssh-1",
+  );
 });
 
 test("sftpPickerSessionsEqual ignores title-only changes", () => {

--- a/domain/sftpConnectedHosts.ts
+++ b/domain/sftpConnectedHosts.ts
@@ -26,6 +26,7 @@ export type SftpPickerSessionFields = Pick<
  * Connecting sessions and Mosh/ET transports have no reusable ssh2 shell conn.
  */
 const isReusableSftpSourceSession = (session: SftpPickerSessionFields): boolean => {
+  if (session.id.startsWith("sftp-")) return false;
   if (session.status !== "connected") return false;
   if (session.moshEnabled || session.etEnabled) return false;
   const protocol = session.protocol;
@@ -99,8 +100,8 @@ export const sftpPickerSessionsEqual = (
  * One entry per hostId — keeps the most recently listed SSH terminal session.
  *
  * Includes hosts with sftpSudo: they still belong under "Connected" when a
- * terminal is open, but connect paths must not reuse the shell (see
- * resolveSftpTransferSourceSessionId and useSftpConnections sudo guards).
+ * terminal is open, and SFTP can borrow the already-authenticated SSH transport
+ * before silently falling back to a fresh connection.
  */
 export const listSftpConnectedHosts = (
   sessions: ReadonlyArray<SftpPickerSessionFields>,
@@ -131,15 +132,14 @@ export const listSftpConnectedHosts = (
 };
 
 /**
- * Drop terminal-session reuse when the host requires a dedicated sudo SFTP
- * channel. Used by the picker and browse connect path so UI state
- * (`reusedConnection`) and the actual open agree.
+ * Return the live terminal session id that SFTP should try before fresh auth.
+ * The main process validates that the hinted session really matches the target.
  */
 export const sftpSourceSessionIdForHost = (
   host: Pick<Host, "sftpSudo"> | null | undefined,
   sourceSessionId: string | undefined,
 ): string | undefined => {
-  if (!sourceSessionId || host?.sftpSudo) return undefined;
+  if (!sourceSessionId) return undefined;
   return sourceSessionId;
 };
 
@@ -160,7 +160,6 @@ export const resolveSftpTransferSourceSessionId = (
   hostId: string,
   host?: Pick<Host, "hostname" | "username" | "port" | "sftpSudo" | "protocol">,
 ): string | undefined => {
-  if (host?.sftpSudo) return undefined;
   let lastMatch: string | undefined;
   for (const session of sessions) {
     if (session.hostId !== hostId) continue;
@@ -168,7 +167,6 @@ export const resolveSftpTransferSourceSessionId = (
     const vaultHost = hostsById.get(session.hostId);
     if (!vaultHost) continue;
     if (vaultHost.protocol === "serial" || isPluginHostProtocol(vaultHost.protocol)) continue;
-    if (vaultHost.sftpSudo) continue;
     const liveHost = hostForLiveSession(vaultHost, session);
     if (host && !sftpHostEndpointsEqual(liveHost, host)) continue;
     lastMatch = session.id;

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -1945,6 +1945,7 @@ async function openSftpForSession(_event, payload) {
   const probeTimeoutMs = Number.isFinite(payload?.timeoutMs) && payload.timeoutMs > 0
     ? payload.timeoutMs
     : SCP_PROBE_TIMEOUT_MS;
+  const sudoRequested = Boolean(payload?.sudo);
 
   async function probeScpCapability() {
     const bounded = createBoundedProbeSignal(payload?.abortSignal || null, probeTimeoutMs);
@@ -1970,6 +1971,18 @@ async function openSftpForSession(_event, payload) {
   }
 
   try {
+    if (sudoRequested) {
+      const sftpWrapper = await connectSudoSftp(sshClient, payload?.password || "");
+      client.sftp = sftpWrapper;
+      client.__netcattyFileProtocol = "sftp";
+      client.__netcattySudoMode = true;
+      sftpWrapper.on?.("close", () => client.end());
+      throwIfAborted(payload?.abortSignal);
+      copySftpEncodingState(payload?.encodingStateKey, sftpId);
+      sftpClients.set(sftpId, client);
+      return { ok: true, sftpId, fileProtocol: "sftp", sourceSessionId };
+    }
+
     if (fileProtocol === "scp") {
       client.__netcattyFileProtocol = "scp";
       client.sftp = null;

--- a/electron/bridges/sshConnectionPool.cjs
+++ b/electron/bridges/sshConnectionPool.cjs
@@ -607,6 +607,25 @@ function sameEndpoint(a, b) {
     && left.keepaliveCountMax === right.keepaliveCountMax;
 }
 
+function sameTransportEndpoint(a, b) {
+  const left = normalizeEndpoint(a);
+  const right = normalizeEndpoint(b);
+  if (!left || !right) return false;
+  // SFTP sudo changes the channel/subsystem setup, not the authenticated SSH
+  // transport. Channel borrowers (SFTP/port forwarding) may reuse the terminal
+  // connection and apply sudo when opening their own channel.
+  if (left.hostId && right.hostId && left.hostId !== right.hostId) return false;
+  return left.hostname === right.hostname
+    && left.port === right.port
+    && left.username === right.username
+    && left.protocol === right.protocol
+    && left.jumpFingerprint === right.jumpFingerprint
+    && left.proxyFingerprint === right.proxyFingerprint
+    && left.authFingerprint === right.authFingerprint
+    && left.keepaliveIntervalMs === right.keepaliveIntervalMs
+    && left.keepaliveCountMax === right.keepaliveCountMax;
+}
+
 /**
  * True when a requested open can reuse an existing transport/session endpoint.
  *
@@ -619,7 +638,11 @@ function sameEndpoint(a, b) {
  *     transport; cannot use a nofwd transport when the request needs ForwardAgent.
  */
 function endpointAllowsReuse(requested, existing, kind = "channel") {
-  if (!sameEndpoint(requested, existing)) return false;
+  if (kind === "shell") {
+    if (!sameEndpoint(requested, existing)) return false;
+  } else if (!sameTransportEndpoint(requested, existing)) {
+    return false;
+  }
   const req = normalizeEndpoint(requested);
   const have = normalizeEndpoint(existing);
   if (!req || !have) return false;

--- a/electron/bridges/sshConnectionPool.test.cjs
+++ b/electron/bridges/sshConnectionPool.test.cjs
@@ -958,6 +958,16 @@ test("connection endpoint can record negotiated agent forwarding instead of the 
   assert.equal(normalizeEndpoint(endpoint).agentForwarding, false);
 });
 
+test("channel reuse can borrow a normal SSH transport for sudo SFTP", () => {
+  const base = { hostname: "sudo.example", username: "root", port: 22 };
+  const normalShell = buildConnectionReuseEndpoint(base, { sftpSudo: false });
+  const sudoSftp = buildConnectionReuseEndpoint(base, { sftpSudo: true });
+
+  assert.notEqual(buildEndpointKey(normalShell), buildEndpointKey(sudoSftp));
+  assert.equal(endpointAllowsReuse(sudoSftp, normalShell, "channel"), true);
+  assert.equal(endpointAllowsReuse(sudoSftp, normalShell, "shell"), false);
+});
+
 test("endpointAllowsReuse: shell exact vs channel asymmetric for agentForwarding", () => {
   const base = { hostname: "a.example", username: "root", port: 22 };
   // Channel (default): request needs ForwardAgent, existing never enabled it -> reject.

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -811,10 +811,11 @@ function createPreloadApi(ctx) {
       const result = await ipcRenderer.invoke("netcatty:sftp:open", options);
       return result.sftpId;
     },
-  openSftpForSession: async (sessionId, expectedEndpoint) => {
+  openSftpForSession: async (sessionId, options) => {
     const result = await ipcRenderer.invoke("netcatty:sftp:openForSession", {
+      ...(options || {}),
       sessionId,
-      expectedEndpoint,
+      expectedEndpoint: options,
     });
     return result.sftpId;
   },

--- a/electron/preload/api.stageUploadFile.test.cjs
+++ b/electron/preload/api.stageUploadFile.test.cjs
@@ -191,3 +191,31 @@ test("listLocalTree keeps the entries listener until the tree-end marker arrives
   assert.equal(batches[0][0].relativePath, "project/nested/deep.txt");
   assert.equal(removed, true);
 });
+
+test("openSftpForSession keeps the SSH source session id when options include an SFTP session id", async () => {
+  const invoked = [];
+  const api = createPreloadApi({
+    webUtils: {},
+    ipcRenderer: {
+      on() {},
+      removeListener() {},
+      async invoke(channel, payload) {
+        invoked.push({ channel, payload });
+        return { sftpId: "opened-sftp" };
+      },
+    },
+  });
+
+  const sftpId = await api.openSftpForSession("ssh-session-1", {
+    sessionId: "sftp-left-browse-session",
+    hostname: "192.168.9.138",
+    port: 22,
+    username: "zlhrs",
+  });
+
+  assert.equal(sftpId, "opened-sftp");
+  assert.equal(invoked.length, 1);
+  assert.equal(invoked[0].channel, "netcatty:sftp:openForSession");
+  assert.equal(invoked[0].payload.sessionId, "ssh-session-1");
+  assert.equal(invoked[0].payload.expectedEndpoint.sessionId, "sftp-left-browse-session");
+});

--- a/types/global/netcatty-bridge-sftp.d.ts
+++ b/types/global/netcatty-bridge-sftp.d.ts
@@ -4,7 +4,7 @@ declare global {
   interface NetcattyBridge {
     // SFTP operations
     openSftp(options: NetcattySSHOptions): Promise<string>;
-    openSftpForSession?(sessionId: string, expectedEndpoint?: NetcattySSHOptions): Promise<string>;
+    openSftpForSession?(sessionId: string, options?: NetcattySSHOptions): Promise<string>;
     listSftp(sftpId: string, path: string, encoding?: SftpFilenameEncoding): Promise<RemoteFile[]>;
     realpathSftp?(sftpId: string, path: string, encoding?: SftpFilenameEncoding): Promise<string>;
     readSftp(sftpId: string, path: string, encoding?: SftpFilenameEncoding): Promise<string>;


### PR DESCRIPTION
## Summary

修复 1.1.77 中 SSH 已完成 EDR/MFA 二次认证后，打开 SFTP 或从“系统”页卡切回 SFTP 仍重复弹二次验证的问题。

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #2150

## Changes Made

- 允许 SFTP sudo 场景继续携带 `sourceSessionId`，优先复用已认证 SSH transport。
- 将 SSH transport 复用判断和 shell 复用判断拆开：sudo 只影响 SFTP channel/subsystem，不应阻止复用已认证 transport；shell 复用仍保持严格 endpoint 匹配。
- `openSftpForSession` 在复用 SSH session 时支持 sudo SFTP channel，复用失败仍由现有路径静默回退到新连接。
- 修复 preload 参数覆盖问题，避免 SFTP session id 覆盖 SSH source session id。
- 侧栏自动连接会等待同 endpoint 的 SSH 连接完成，并对同 tab/endpoint/source/path 的并发 SFTP connect 去重，避免抢跑触发重复 MFA。
- 补充 sudo sourceSessionId、transport reuse、preload 参数和侧栏自动连接相关测试。

## Screenshots / Demo

用户已在真实环境验证：sudo SFTP 下 SSH 完成二次认证后，打开 SFTP、切到“系统”页卡再切回 SFTP，不再重复弹二次验证。

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

验证命令：

- `node --test electron/bridges/sshConnectionPool.test.cjs`
- `node --test electron/preload/api.stageUploadFile.test.cjs`
- `node --test electron/bridges/sftpBridge.cleanup.test.cjs electron/bridges/sftpBridge.sessionBackedUpload.test.cjs electron/bridges/sftpBridge.sessionActivity.test.cjs`
- `node --test --import tsx components/sftp/sftpSidePanelAutoConnect.test.ts components/sftp/SftpHostPicker.test.ts application/state/sftp/useSftpConnections.test.ts domain/sftpConnectedHosts.test.ts`
- `npm run lint`（0 errors，保留既有 `application/state/settingsStorageSync.ts` hook dependency warning）
- `git diff --check`

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)