### PR TITLE
fix: include setShowTabNumberBadgesState in storage sync deps

### DIFF
--- a/application/state/settingsStorageSync.ts
+++ b/application/state/settingsStorageSync.ts
@@ -568,6 +568,7 @@ export function useSettingsStorageSync({
     setShowRecentHostsState,
     setShowSftpTabState,
     setShellOnlyTabNumberShortcutsState,
+    setShowTabNumberBadgesState,
     setDisableTerminalFontZoomState,
     setRestorePreviousSessionState,
     setRestoreTerminalCwdState,


### PR DESCRIPTION
## Summary

- Fix `react-hooks/exhaustive-deps` warning in `useSettingsStorageSync` by adding the missing `setShowTabNumberBadgesState` dependency used when syncing tab number badge settings across windows.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Add `setShowTabNumberBadgesState` to the `useEffect` dependency array in `application/state/settingsStorageSync.ts` so it matches the setter used in the storage listener (same pattern as neighboring settings setters).

## Screenshots / Demo

N/A — lint-only dependency array fix; no UI change.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)