### PR TITLE
fix(sftp): keep home candidates when realpath root is not listable

### DIFF
--- a/application/state/sftp/useSftpConnections.test.ts
+++ b/application/state/sftp/useSftpConnections.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  buildSftpHomeDirCandidates,
   createSftpConnectionId,
   createPinnedReconnectSideResolver,
   openSftpConnectionOnce,
@@ -14,6 +15,13 @@ import {
   releaseSftpConnectionMetadata,
   resolvePinnedReconnectSide,
 } from "./useSftpConnections.ts";
+
+test("home dir candidates prefer user home then root", () => {
+  assert.deepEqual(buildSftpHomeDirCandidates("deploy"), ["/home/deploy", "/root"]);
+  assert.deepEqual(buildSftpHomeDirCandidates("root"), ["/root"]);
+  assert.deepEqual(buildSftpHomeDirCandidates(undefined), ["/root"]);
+  assert.deepEqual(buildSftpHomeDirCandidates(null), ["/root"]);
+});
 
 test("connection ids stay unique even when connects start in the same millisecond", () => {
   const ids = ["uuid-a", "uuid-b"];

--- a/application/state/sftp/useSftpConnections.ts
+++ b/application/state/sftp/useSftpConnections.ts
@@ -97,6 +97,13 @@ export async function releaseSftpConnectionMetadata(params: {
   params.onRemoteSessionClosed?.(sftpId);
 }
 
+/** Hardcoded home-path candidates when SSH exec / listable realpath fail. */
+export function buildSftpHomeDirCandidates(username?: string | null): string[] {
+  if (username === "root") return ["/root"];
+  if (username) return [`/home/${username}`, "/root"];
+  return ["/root"];
+}
+
 export function createSftpConnectionId(
   side: "left" | "right",
   randomUUID: () => string = () => crypto.randomUUID(),
@@ -698,15 +705,7 @@ export const useSftpConnections = ({
             }
 
             if (!detected) {
-              const candidates: string[] = [];
-              if (credentials.username === "root") {
-                candidates.push("/root");
-              } else if (credentials.username) {
-                candidates.push(`/home/${credentials.username}`);
-                candidates.push("/root");
-              } else {
-                candidates.push("/root");
-              }
+              const candidates = buildSftpHomeDirCandidates(credentials.username);
               const statSftp = bridge?.statSftp;
               if (statSftp) {
                 for (const candidate of candidates) {
@@ -782,6 +781,23 @@ export const useSftpConnections = ({
                 fallbackSucceeded = true;
               } catch {
                 // root also failed
+              }
+            }
+            // Last resort: home candidates. Covers provisional "/" from realpath
+            // when discovery treated root as home and listing it failed, so
+            // /home/<user> or /root can still recover the session.
+            if (!fallbackSucceeded) {
+              for (const candidate of buildSftpHomeDirCandidates(credentials.username)) {
+                if (candidate === startPath) continue;
+                try {
+                  files = await listRemoteFiles(sftpId, candidate, filenameEncoding);
+                  startPath = candidate;
+                  homeDir = candidate;
+                  fallbackSucceeded = true;
+                  break;
+                } catch {
+                  // Ignore missing/permission errors
+                }
               }
             }
             if (!fallbackSucceeded) {

--- a/electron/bridges/sftpBridge/fileOps.cjs
+++ b/electron/bridges/sftpBridge/fileOps.cjs
@@ -935,6 +935,11 @@ function createFileOpsApi(ctx) {
       // Method 2: SFTP realpath('.'). A virtual/chroot SFTP server (including
       // bastion products such as JumpServer) can legitimately expose '/' as
       // the authenticated user's root even when SSH exec channels are denied.
+      //
+      // Accept non-root absolute paths immediately. Accept '/' only when it is
+      // actually listable so we do not suppress renderer candidate probing
+      // (/home/<user>, /root) on servers that merely start cwd at '/' without
+      // granting readdir on the real filesystem root.
       try {
         const sftp = await requireSftpChannel(client, {
           signal,
@@ -943,8 +948,32 @@ function createFileOpsApi(ctx) {
         throwIfAborted(signal);
         const absPath = await realpathAsync(sftp, ".");
         throwIfAborted(signal);
-        if (absPath && absPath.startsWith("/")) {
+        if (absPath && absPath.startsWith("/") && absPath !== "/") {
           return { success: true, homeDir: absPath };
+        }
+        if (absPath === "/") {
+          try {
+            if (typeof readdirAsync === "function") {
+              await readdirAsync(sftp, "/");
+            } else if (sftp && typeof sftp.readdir === "function") {
+              await new Promise((resolve, reject) => {
+                sftp.readdir("/", (err, items) => {
+                  if (err) reject(err);
+                  else resolve(items || []);
+                });
+              });
+            } else {
+              // No list probe available — keep virtual-root acceptance from #2934.
+              return { success: true, homeDir: "/" };
+            }
+            throwIfAborted(signal);
+            return { success: true, homeDir: "/" };
+          } catch (listErr) {
+            if (signal?.aborted) {
+              throw listErr;
+            }
+            // Non-listable root: fall through so candidate probing can run.
+          }
         }
       } catch (err) {
         if (signal?.aborted) {

--- a/electron/bridges/sftpBridge/fileOps.test.cjs
+++ b/electron/bridges/sftpBridge/fileOps.test.cjs
@@ -5,6 +5,7 @@ const { createFileOpsApi } = require("./fileOps.cjs");
 
 test("home discovery accepts a virtual SFTP root when SSH exec is unavailable", async () => {
   const channel = {};
+  const listed = [];
   const api = createFileOpsApi({
     sftpClients: new Map([["jumpserver", { sftp: channel }]]),
     throwIfAborted() {},
@@ -14,9 +15,54 @@ test("home discovery accepts a virtual SFTP root when SSH exec is unavailable", 
       assert.equal(remotePath, ".");
       return "/";
     },
+    readdirAsync: async (resolvedChannel, remotePath) => {
+      listed.push([resolvedChannel, remotePath]);
+      return [{ filename: "data" }];
+    },
   });
 
   const result = await api.getSftpHomeDir(null, { sftpId: "jumpserver" });
 
   assert.deepEqual(result, { success: true, homeDir: "/" });
+  assert.deepEqual(listed, [[channel, "/"]]);
+});
+
+test("home discovery rejects non-listable root so candidate probing can run", async () => {
+  const channel = {};
+  const api = createFileOpsApi({
+    sftpClients: new Map([["restricted", { sftp: channel }]]),
+    throwIfAborted() {},
+    requireSftpChannel: async () => channel,
+    realpathAsync: async () => "/",
+    readdirAsync: async () => {
+      const error = new Error("Permission denied");
+      error.code = "EACCES";
+      throw error;
+    },
+  });
+
+  const result = await api.getSftpHomeDir(null, { sftpId: "restricted" });
+
+  assert.equal(result.success, false);
+  assert.match(result.error || "", /Could not determine home directory/);
+});
+
+test("home discovery still accepts non-root realpath without listing", async () => {
+  const channel = {};
+  let readdirCalls = 0;
+  const api = createFileOpsApi({
+    sftpClients: new Map([["normal", { sftp: channel }]]),
+    throwIfAborted() {},
+    requireSftpChannel: async () => channel,
+    realpathAsync: async () => "/home/deploy",
+    readdirAsync: async () => {
+      readdirCalls += 1;
+      return [];
+    },
+  });
+
+  const result = await api.getSftpHomeDir(null, { sftpId: "normal" });
+
+  assert.deepEqual(result, { success: true, homeDir: "/home/deploy" });
+  assert.equal(readdirCalls, 0);
 });


### PR DESCRIPTION
## Summary

Follow-up to #2934 / Codex review: accepting `realpath('.') === '/'` as home was correct for listable virtual/chroot roots, but skipped `/home/<user>` and `/root` probing when `/` was only a non-listable CWD. This keeps the virtual-root fix and restores candidate fallback for that residual case.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2940

Related to Codex review on #2934: https://github.com/binaricat/Netcatty/pull/2934#discussion_r3764895618

## Changes Made

- `getSftpHomeDir`: accept non-root absolute realpath immediately; accept `/` only after a successful readdir (virtual/chroot roots remain valid)
- When `/` is not listable, return discovery failure so renderer candidate probing still runs
- `useSftpConnections`: if home/`/` listing fails, last-resort probe `/home/<user>` and `/root`
- Extract `buildSftpHomeDirCandidates()` and add regression tests

## Screenshots / Demo

No UI change. Behavior matrix:

| Scenario | After #2934 | This PR |
|---|---|---|
| Listable virtual root `/` (JumpServer/chroot) | works | still works |
| Non-listable `/` + listable `/home/user` | connection fails | recovers via candidates |
| Normal home `/home/user` | works | works |

## Testing

- [x] I have tested these changes locally (`npm run dev`) — unit tests for the changed paths
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — targeted: `fileOps.test.cjs`, `useSftpConnections.test.ts`, `ensureRemoteSftpSession.test.ts` (all pass)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`) — N/A
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation — regression tests
- [x] I have not introduced any breaking changes (or I have described them above)