### PR TITLE
feat(terminal): scale mounted-disk capacity into T and P units

### DIFF
--- a/components/terminal/TerminalServerStats.tsx
+++ b/components/terminal/TerminalServerStats.tsx
@@ -7,7 +7,7 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from '../ui/hover-card'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { formatNetSpeed } from './terminalHelpers';
 import { useServerStats } from '../../application/state/useServerStats';
-import { formatDiskCapacityGb, resolveTerminalDiskSummary } from './serverStatsFormat';
+import { formatDiskCapacityRange, resolveTerminalDiskSummary } from './serverStatsFormat';
 
 interface TerminalServerStatsProps {
   sessionId: string;
@@ -263,7 +263,7 @@ export const TerminalServerStats: React.FC<TerminalServerStatsProps> = ({
                         diskSummary.percent !== null && diskSummary.percent >= 80 && diskSummary.percent < 90 && "text-amber-400"
                       )}>
                         {diskSummary.used !== null && diskSummary.total !== null && diskSummary.percent !== null
-                          ? `${formatDiskCapacityGb(diskSummary.used)}/${formatDiskCapacityGb(diskSummary.total)}G (${diskSummary.percent}%)`
+                          ? `${formatDiskCapacityRange(diskSummary.used, diskSummary.total)} (${diskSummary.percent}%)`
                           : diskSummary.percent !== null
                             ? `${diskSummary.percent}%`
                             : '--'}
@@ -295,7 +295,7 @@ export const TerminalServerStats: React.FC<TerminalServerStatsProps> = ({
                                   "text-[11px] font-medium whitespace-nowrap",
                                   disk.percent >= 90 ? "text-red-400" : disk.percent >= 80 ? "text-amber-400" : "text-emerald-400"
                                 )}>
-                                  {formatDiskCapacityGb(disk.used)}/{formatDiskCapacityGb(disk.total)}G ({disk.percent}%)
+                                  {formatDiskCapacityRange(disk.used, disk.total)} ({disk.percent}%)
                                 </span>
                               </div>
                               <div className="w-full h-1.5 bg-muted rounded-full overflow-hidden">

--- a/components/terminal/serverStatsFormat.test.ts
+++ b/components/terminal/serverStatsFormat.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   formatDiskCapacityGb,
+  formatDiskCapacityRange,
   resolveTerminalDiskSummary,
 } from "./serverStatsFormat.ts";
 
@@ -12,6 +13,32 @@ test("disk capacity uses at most two decimal places", () => {
   assert.equal(formatDiskCapacityGb(0.005907), "0.01");
   assert.equal(formatDiskCapacityGb(10), "10");
   assert.equal(formatDiskCapacityGb(10.5), "10.5");
+});
+
+test("disk capacity stays in G below a terabyte", () => {
+  assert.equal(formatDiskCapacityRange(71.12, 878.15), "71.12/878.15G");
+  assert.equal(formatDiskCapacityRange(0.01, 0.5), "0.01/0.5G");
+  // 1023 GiB is still the largest value rendered in G.
+  assert.equal(formatDiskCapacityRange(1, 1023), "1/1023G");
+});
+
+test("disk capacity switches to T once a value reaches a terabyte", () => {
+  // Both sides in terabytes: one shared suffix.
+  assert.equal(formatDiskCapacityRange(8807.55, 118736.4), "8.6/115.95T");
+  assert.equal(formatDiskCapacityRange(2048, 4096), "2/4T");
+});
+
+test("disk capacity keeps the used figure when the sides differ in scale", () => {
+  // A total-driven unit would render these as 0.13/6.93T and 0/6.93T,
+  // discarding how much is actually in use.
+  assert.equal(formatDiskCapacityRange(136.37, 7096.47), "136.37G/6.93T");
+  assert.equal(formatDiskCapacityRange(3.25, 7096.47), "3.25G/6.93T");
+  assert.equal(formatDiskCapacityRange(1, 1024), "1G/1T");
+});
+
+test("disk capacity switches to P for petabyte-scale pools", () => {
+  assert.equal(formatDiskCapacityRange(1_048_576, 2_097_152), "1/2P");
+  assert.equal(formatDiskCapacityRange(512, 2_097_152), "512G/2P");
 });
 
 test("terminal disk summary totals every mounted filesystem", () => {

--- a/components/terminal/serverStatsFormat.ts
+++ b/components/terminal/serverStatsFormat.ts
@@ -20,6 +20,42 @@ export function formatDiskCapacityGb(value: number): string {
   return Number(value.toFixed(2)).toString();
 }
 
+/** Capacity units, ascending from the GiB the collectors report in. */
+const DISK_CAPACITY_UNITS = ["G", "T", "P"] as const;
+
+/** Pick the largest unit that keeps a GiB value at or above 1. */
+export function resolveDiskCapacityUnit(valueGb: number): { unit: string; divisor: number } {
+  let divisor = 1;
+  let index = 0;
+  while (
+    Math.abs(valueGb) / divisor >= 1024
+    && index < DISK_CAPACITY_UNITS.length - 1
+  ) {
+    divisor *= 1024;
+    index += 1;
+  }
+  return { unit: DISK_CAPACITY_UNITS[index], divisor };
+}
+
+/**
+ * Render a used/total pair, both reported in GiB.
+ *
+ * Each side is scaled independently so a mostly-empty multi-terabyte pool keeps
+ * its used figure — `136.37G/6.93T` rather than the `0.13/6.93T` a total-driven
+ * unit would produce, or the unreadable `136.37/7096.47G` of a fixed one. When
+ * both land in the same unit the suffix is written once, keeping the familiar
+ * `71.12/878.15G` shape for ordinary disks.
+ */
+export function formatDiskCapacityRange(usedGb: number, totalGb: number): string {
+  const used = resolveDiskCapacityUnit(usedGb);
+  const total = resolveDiskCapacityUnit(totalGb);
+  const usedText = formatDiskCapacityGb(usedGb / used.divisor);
+  const totalText = formatDiskCapacityGb(totalGb / total.divisor);
+  return used.unit === total.unit
+    ? `${usedText}/${totalText}${total.unit}`
+    : `${usedText}${used.unit}/${totalText}${total.unit}`;
+}
+
 export function resolveTerminalDiskSummary(
   stats: TerminalDiskStats,
 ): TerminalDiskSummary {


### PR DESCRIPTION
## Summary

Mounted-disk capacity in the terminal server-stats readout is always printed in gigabytes, so a multi-terabyte pool renders as `118736.4G`. This scales the used/total pair into T and P as needed.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Add `resolveDiskCapacityUnit` in `components/terminal/serverStatsFormat.ts`, picking the largest of `G`/`T`/`P` that keeps a GiB value at or above 1.
- Add `formatDiskCapacityRange(usedGb, totalGb)`, which scales each side of the pair **independently**. A mostly-empty pool then keeps a readable used figure — `136.37G/6.93T` instead of the `0.13/6.93T` a total-driven unit gives, or the unreadable `136.37/7096.47G` of the current fixed unit.
- When both sides land in the same unit the suffix is emitted once, so ordinary disks keep the familiar `71.12/878.15G` shape and nothing changes for them.
- Point both call sites in `components/terminal/TerminalServerStats.tsx` (the summary line and the per-mount hover card) at the new helper. `formatDiskCapacityGb` is unchanged and still exported.

## Screenshots / Demo

Text-only change to the stats readout:

| capacity | before | after |
| --- | --- | --- |
| ordinary disk | `71.12/878.15G` | `71.12/878.15G` (unchanged) |
| 7 TiB pool, mostly empty | `136.37/7096.47G` | `136.37G/6.93T` |
| 116 TiB pool | `118736.4/121634.3G` | `115.95/118.78T` |

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`) — not applicable, no capability tools touched
- [x] No new console errors or warnings, if this affects app behavior

`components/terminal/serverStatsFormat.test.ts` gains cases for the shared-suffix path, mixed units, and the P boundary.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation — no docs cover this readout
- [x] I have not introduced any breaking changes (or I have described them above)
