### PR TITLE
fix(ai): clear unfinished terminal input before agent inject

### DIFF
--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -18,6 +18,7 @@ const {
   subscribeToPtyData,
   hasExpectedPromptSuffix,
   resolveEffectiveShellKind,
+  buildPendingInputClearPrefix,
   buildWrappedCommand,
   findEndMarker,
   normalizePtyOutput,
@@ -581,7 +582,8 @@ function startPtyJob(ptyStream, command, options) {
     }
   }
 
-  ptyStream.write(buildWrappedCommand(command, resolvedShellKind, marker));
+  const wrapped = buildWrappedCommand(command, resolvedShellKind, marker);
+  ptyStream.write(`${buildPendingInputClearPrefix(resolvedShellKind)}${wrapped}`);
 
   return {
     marker,

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -12,15 +12,18 @@ const {
   DEFAULT_FOREGROUND_PTY_CAPTURE_CHARS,
   resolveEffectiveShellKind,
   execViaChannel,
+  execViaRawPty,
 } = require("./ptyExec.cjs");
 const {
+  buildPendingInputClearPrefix,
   buildWrappedCommand,
 } = require("./ptyExecHelpers.cjs");
 
 class ShellBackedPty extends EventEmitter {
   write(data) {
     if (data === "\x03") return;
-    const result = spawnSync("sh", ["-c", String(data)], { encoding: "utf8" });
+    const script = String(data).replace(/^\x15\x0b/, "");
+    const result = spawnSync("sh", ["-c", script], { encoding: "utf8" });
     queueMicrotask(() => {
       this.emit("data", Buffer.from(result.stdout));
     });
@@ -322,6 +325,53 @@ test("loginShellHint selects fish/posix/powershell/cmd without pinning confirmed
     resolveEffectiveShellKind("posix", "user@host:~$", { loginShellHint: "fish" }),
     "posix",
   );
+});
+
+test("pending-input clear prefix covers interactive shells and skips raw devices", () => {
+  assert.equal(buildPendingInputClearPrefix("posix"), "\x15\x0b");
+  assert.equal(buildPendingInputClearPrefix("fish"), "\x15\x0b");
+  assert.equal(buildPendingInputClearPrefix("powershell"), "\x1b\x15\x0b");
+  assert.equal(buildPendingInputClearPrefix("cmd"), "\x1b");
+  assert.equal(buildPendingInputClearPrefix("raw"), "");
+});
+
+test("startPtyJob writes the clear prefix before the wrapper", async () => {
+  const writes = [];
+  class CapturePty extends EventEmitter {
+    write(data) {
+      writes.push(String(data));
+    }
+  }
+  const pty = new CapturePty();
+  const job = startPtyJob(pty, "echo hi", {
+    shellKind: "posix",
+    timeoutMs: 50,
+    expectedPrompt: "$ ",
+  });
+  assert.equal(writes.length, 1);
+  assert.ok(writes[0].startsWith("\x15\x0b"));
+  assert.match(writes[0], /__NCMCP_/);
+  job.cancel();
+  pty.emit("data", Buffer.from("$ "));
+  await job.resultPromise;
+});
+
+test("execViaRawPty does not prepend a line-clear before device commands", async () => {
+  const writes = [];
+  const port = new EventEmitter();
+  port.write = (data) => {
+    writes.push(String(data));
+  };
+  const abort = new AbortController();
+  const resultPromise = execViaRawPty(port, "show version", {
+    timeoutMs: 200,
+    idleMs: 20,
+    abortSignal: abort.signal,
+  });
+  assert.deepEqual(writes, ["show version\r"]);
+  abort.abort();
+  const result = await resultPromise;
+  assert.equal(result.ok, false);
 });
 
 test("cmd wrapper uses interactive cmd variable expansion", () => {

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -178,6 +178,24 @@ function resolveEffectiveShellKind(shellKind, expectedPrompt, options = {}) {
   return "posix";
 }
 
+// Discard unfinished prompt-line input before the agent wrapper so typed-but-
+// not-entered text is not concatenated onto the injected command (#2962).
+// Raw/serial devices have no portable line-kill binding; leave them alone.
+function buildPendingInputClearPrefix(shellKind) {
+  switch (shellKind) {
+    case "raw":
+      return "";
+    case "cmd":
+      return "\x1b";
+    case "powershell":
+      // Escape = Windows-mode PSReadLine RevertLine (issue reporter default).
+      // Ctrl+U/Ctrl+K also fire for Emacs/Vi when those bindings exist.
+      return "\x1b\x15\x0b";
+    default:
+      return "\x15\x0b";
+  }
+}
+
 function buildPosixWrapperBody(command, marker) {
   const noPager = "PAGER=cat SYSTEMD_PAGER= GIT_PAGER=cat LESS= ";
   const commandLines = String(command || "").replace(/\r\n?/g, "\n").split("\n");
@@ -430,6 +448,7 @@ module.exports = {
   subscribeToPtyData,
   hasExpectedPromptSuffix,
   resolveEffectiveShellKind,
+  buildPendingInputClearPrefix,
   buildWrappedCommand,
   findEndMarker,
   normalizePtyOutput,


### PR DESCRIPTION
## Summary

Before AI writes a command into an interactive PTY, discard any unfinished prompt-line input so the wrapper is not concatenated onto what the user already typed (`ls` + agent command, or worse `rm -rf * `).

This is the slim replacement for #2964. That PR grew a terminal input state machine under the Codex review loop and still did not fully fix #2962. This one only prefixes the existing `startPtyJob` write.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Fixes #2962
Supersedes #2964

## Changes Made

- `buildPendingInputClearPrefix(shellKind)`:
  - posix/fish: Ctrl+U + Ctrl+K
  - PowerShell: Escape (Windows-mode RevertLine) then Ctrl+U/Ctrl+K
  - cmd: Escape
  - raw/serial: empty
- `startPtyJob` writes that prefix immediately before the existing wrapper
- `execViaRawPty` is unchanged
- Unit tests for the prefix table, write order, and raw skip

Out of scope on purpose: Ctrl+C, vi-mode restore, continuation-prompt reset, fail-closed input tracking, plugin interceptors, startup-command recovery.

## Screenshots / Demo

Manual: type `ls` without Enter, ask the agent to run a command, confirm the line is cleared and only the agent command runs.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Targeted: `npx eslint` on the 3 changed files; `node --test electron/bridges/ai/ptyExec.test.cjs` (38 pass). Also ran `sessionShellKind` + worker `aiExec` tests (77 pass combined).

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)