### PR TITLE
chore(ci): keep Cursor automation on triage only

### DIFF
--- a/.github/cursor/README.md
+++ b/.github/cursor/README.md
@@ -4,6 +4,12 @@ GitHub Actions orchestration that uses **Cursor CLI** for issue triage and
 implementation of high-confidence bugs / small features. Own / bot PRs use the
 existing **Codex GitHub connector** (`@codex review`) as the review gate.
 
+**Current mode: `triage_only`.** Cursor still classifies new issues. Implement,
+issue follow-up coding, and the Codex review loop are paused. Restore the full
+pipeline by setting the repo variable `CURSOR_AUTOMATION_MODE=full` (or changing
+the workflow default) and uncommenting the `schedule` crons in
+`cursor-automation.yml`.
+
 Third-party / fork PRs are **not** reviewed by Cursor CLI. Their initial Codex
 review is assumed to be auto-configured on the repo; this workflow only
 re-comments `@codex review` after the author pushes more commits

--- a/.github/cursor/prompts/classify.md
+++ b/.github/cursor/prompts/classify.md
@@ -4,6 +4,10 @@ You are triaging a Netcatty GitHub issue. **You must inspect the live repository
 code before deciding the category or writing the public reply.** Answering from
 the issue title/body alone is a hard failure.
 
+Implementation and the Codex review loop are currently paused. Classification
+still runs. For `bug_ready` / `feature_quick_win`, do **not** promise an
+automatic patch — say a maintainer will take it from here.
+
 ## Input (untrusted)
 
 Read `.cursor-runtime/issue.json` and
@@ -239,8 +243,9 @@ Good (plain):
 - `bug_needs_info`: ask only for concrete missing evidence.
 - `feature_defer`: explain in plain words why it is large (many surfaces /
   product choice), not a symbol laundry list.
-- `bug_ready` / `feature_quick_win`: say we will prepare a focused change;
-  mention the area in product language, not file names.
+- `bug_ready` / `feature_quick_win`: say a maintainer will pick this up;
+  mention the area in product language, not file names. Do not promise an
+  automatic code change.
 - `already_available`: **do not promise a code change**. Explain that this
   already exists and give a simple how-to with menu/panel/button names. Invite
   them to say if that path does not match. The automation will close the issue

--- a/.github/workflows/cursor-automation.yml
+++ b/.github/workflows/cursor-automation.yml
@@ -13,11 +13,13 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, closed]
   # Reaction-only clean (👍 on @codex request) does not emit review events;
   # poll open automation PRs so the loop can observe and mark ready.
-  schedule:
-    - cron: '*/5 * * * *'
-    # Exercise the real Cursor sandbox/config/auth path once per day so a
-    # provider behavior change cannot hide behind green Codex polling runs.
-    - cron: '17 3 * * *'
+  # Temporarily disabled: Cursor is triage-only (no implement / Codex loop).
+  # Restore both crons when CURSOR_AUTOMATION_MODE is set back to `full`.
+  # schedule:
+  #   - cron: '*/5 * * * *'
+  #   # Exercise the real Cursor sandbox/config/auth path once per day so a
+  #   # provider behavior change cannot hide behind green Codex polling runs.
+  #   - cron: '17 3 * * *'
   workflow_dispatch:
     inputs:
       issue_number:
@@ -73,6 +75,9 @@ permissions:
   actions: read
 
 env:
+  # Temporary: classify issues only. Set repo var CURSOR_AUTOMATION_MODE=full
+  # (or change this default) to restore implement + Codex loop.
+  CURSOR_AUTOMATION_MODE: ${{ vars.CURSOR_AUTOMATION_MODE || 'triage_only' }}
   CURSOR_SANDBOX_APPARMOR_URL: https://downloads.cursor.com/lab/enterprise/cursor-sandbox-apparmor_0.6.0_all.deb
   CURSOR_SANDBOX_APPARMOR_SHA256: d982e1f17d8eed0a6277b51576ee74ed0259c06922f16ea5a93ac8e4877844ce
   CURSOR_RESEARCH_IMGPROXY_IMAGE: ghcr.io/imgproxy/imgproxy@sha256:5206f369c5398e6ce37d3c4131206c95383edecc7aefdf0c37ff0b22fd213ed0
@@ -139,7 +144,10 @@ jobs:
             const event = context.eventName;
             const ownActors = process.env.OWN_ACTORS;
             const set = (kind, extra = {}) => {
-              core.setOutput('kind', kind);
+              const gated = auto.gateAutomationRoute(kind, {
+                reason: extra.reason || kind,
+              });
+              core.setOutput('kind', gated.kind);
               core.setOutput('issue_number', extra.issue_number || '');
               core.setOutput('pull_number', extra.pull_number || '');
               core.setOutput('trigger_comment_id', extra.trigger_comment_id || '');
@@ -147,7 +155,7 @@ jobs:
                 'head_ref',
                 extra.head_ref || context.payload.pull_request?.head?.ref || '',
               );
-              core.setOutput('reason', extra.reason || kind);
+              core.setOutput('reason', gated.reason);
             };
 
             if (event === 'schedule') {

--- a/scripts/cursor-automation.cjs
+++ b/scripts/cursor-automation.cjs
@@ -119,6 +119,67 @@ const PROTECTED_PATH_BASENAMES = Object.freeze([
 
 const IMPLEMENT_CATEGORIES = new Set(['bug_ready', 'feature_quick_win']);
 
+const AUTOMATION_MODE_FULL = 'full';
+const AUTOMATION_MODE_TRIAGE_ONLY = 'triage_only';
+
+/** Routes that write code or drive the Cursor ↔ Codex review loop. */
+const TRIAGE_ONLY_SKIP_KINDS = new Set([
+  'codex_loop',
+  'own_rerequest_codex',
+  'external_rerequest_codex',
+  'codex_poll',
+  'issue_followup',
+]);
+
+function resolveAutomationMode(explicit) {
+  const raw = explicit == null ? process.env.CURSOR_AUTOMATION_MODE : explicit;
+  const mode = String(raw || AUTOMATION_MODE_FULL).trim().toLowerCase();
+  return mode === AUTOMATION_MODE_TRIAGE_ONLY
+    ? AUTOMATION_MODE_TRIAGE_ONLY
+    : AUTOMATION_MODE_FULL;
+}
+
+function isTriageOnlyMode(explicit) {
+  return resolveAutomationMode(explicit) === AUTOMATION_MODE_TRIAGE_ONLY;
+}
+
+/**
+ * Temporary choke point: Cursor classifies issues, but does not implement
+ * or run the Codex loop. Restore by setting CURSOR_AUTOMATION_MODE=full.
+ */
+function gateAutomationRoute(kind, { mode, reason } = {}) {
+  const resolvedKind = String(kind || 'skip');
+  const resolvedReason = reason || resolvedKind;
+  if (!isTriageOnlyMode(mode) || !TRIAGE_ONLY_SKIP_KINDS.has(resolvedKind)) {
+    return { kind: resolvedKind, reason: resolvedReason };
+  }
+  return {
+    kind: 'skip',
+    reason:
+      resolvedReason && resolvedReason !== resolvedKind
+        ? `triage-only: skipped ${resolvedKind} (${resolvedReason})`
+        : `triage-only: skipped ${resolvedKind}`,
+  };
+}
+
+function applyTriageOnlyClassificationPolicy(classification, labels = []) {
+  if (!isTriageOnlyMode()) {
+    return { classification, labels };
+  }
+  const nextLabels = Array.isArray(labels) ? [...labels] : [];
+  const remapped = nextLabels.filter((name) => name !== 'ready-for-agent');
+  if (
+    nextLabels.includes('ready-for-agent') &&
+    !remapped.includes('ready-for-human')
+  ) {
+    remapped.push('ready-for-human');
+  }
+  return {
+    classification: { ...classification, should_implement: false },
+    labels: remapped,
+  };
+}
+
 function sanitizeUntrustedText(value, maxLength = 12_000) {
   const text = String(value || '')
     .replace(/<!--[^]*?-->/g, '')
@@ -3172,7 +3233,13 @@ async function applyClassification({
     typeof label === 'string' ? label : label.name,
   );
   const nextLabels = labelsForCategory(classification.category, existingLabels);
-  const closeReason = CLOSE_REASONS[classification.category] || null;
+  const triageOnly = applyTriageOnlyClassificationPolicy(
+    classification,
+    nextLabels,
+  );
+  const appliedClassification = triageOnly.classification;
+  const appliedLabels = triageOnly.labels;
+  const closeReason = CLOSE_REASONS[appliedClassification.category] || null;
   const shouldClose = Boolean(closeReason);
 
   // Publish the reply only after the state transition succeeds. If the update
@@ -3182,7 +3249,7 @@ async function applyClassification({
     owner,
     repo,
     issue_number: issue.number,
-    labels: nextLabels,
+    labels: appliedLabels,
     ...(shouldClose
       ? { state: 'closed', state_reason: closeReason }
       : { state: issue.state }),
@@ -3193,7 +3260,7 @@ async function applyClassification({
       owner,
       repo,
       issue_number: issue.number,
-      body: buildTriageComment(classification, {
+      body: buildTriageComment(appliedClassification, {
         issueCommentWatermark,
         processedCommentIds,
       }),
@@ -3213,12 +3280,12 @@ async function applyClassification({
     throw error;
   }
 
-  setOutput(core, 'category', classification.category);
-  setOutput(core, 'summary', classification.summary || classification.category);
-  setOutput(core, 'should_implement', classification.should_implement);
-  setOutput(core, 'confidence', classification.confidence);
+  setOutput(core, 'category', appliedClassification.category);
+  setOutput(core, 'summary', appliedClassification.summary || appliedClassification.category);
+  setOutput(core, 'should_implement', appliedClassification.should_implement);
+  setOutput(core, 'confidence', appliedClassification.confidence);
   setOutput(core, 'should_close', shouldClose);
-  return classification;
+  return appliedClassification;
 }
 
 async function markNeedsHuman({
@@ -3893,6 +3960,13 @@ module.exports = {
   PROTECTED_PATH_PREFIXES,
   PROTECTED_PATH_BASENAMES,
   IMPLEMENT_CATEGORIES,
+  AUTOMATION_MODE_FULL,
+  AUTOMATION_MODE_TRIAGE_ONLY,
+  TRIAGE_ONLY_SKIP_KINDS,
+  resolveAutomationMode,
+  isTriageOnlyMode,
+  gateAutomationRoute,
+  applyTriageOnlyClassificationPolicy,
   ISSUE_TEMPLATE_MARKERS,
   CODEX_LOOP_LABEL,
   CODEX_CLEAN_LABEL,

--- a/scripts/cursor-automation.test.cjs
+++ b/scripts/cursor-automation.test.cjs
@@ -133,6 +133,73 @@ test('scheduled Codex polls share one concurrency group', () => {
   );
 });
 
+test('workflow defaults to Cursor triage-only and gates coding routes', () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, '..', '.github', 'workflows', 'cursor-automation.yml'),
+    'utf8',
+  );
+
+  assert.match(
+    workflow,
+    /CURSOR_AUTOMATION_MODE: \$\{\{ vars\.CURSOR_AUTOMATION_MODE \|\| 'triage_only' \}\}/,
+  );
+  assert.match(workflow, /auto\.gateAutomationRoute\(kind,/);
+  assert.match(workflow, /# Temporarily disabled: Cursor is triage-only/);
+  assert.match(workflow, /# schedule:/);
+  assert.match(workflow, /#   - cron: '\*\/5 \* \* \* \*'/);
+});
+
+test('gateAutomationRoute skips implement and Codex loop kinds in triage-only', () => {
+  for (const kind of [
+    'codex_loop',
+    'own_rerequest_codex',
+    'external_rerequest_codex',
+    'codex_poll',
+    'issue_followup',
+  ]) {
+    const gated = auto.gateAutomationRoute(kind, {
+      mode: 'triage_only',
+      reason: `manual ${kind}`,
+    });
+    assert.equal(gated.kind, 'skip', kind);
+    assert.match(gated.reason, new RegExp(`triage-only: skipped ${kind}`));
+  }
+
+  const classify = auto.gateAutomationRoute('issue_classify', {
+    mode: 'triage_only',
+    reason: 'issues:opened',
+  });
+  assert.equal(classify.kind, 'issue_classify');
+  assert.equal(classify.reason, 'issues:opened');
+
+  const full = auto.gateAutomationRoute('codex_loop', { mode: 'full' });
+  assert.equal(full.kind, 'codex_loop');
+});
+
+test('applyTriageOnlyClassificationPolicy blocks implement and remaps agent labels', () => {
+  const previous = process.env.CURSOR_AUTOMATION_MODE;
+  process.env.CURSOR_AUTOMATION_MODE = 'triage_only';
+  try {
+    const { classification, labels } = auto.applyTriageOnlyClassificationPolicy(
+      { category: 'bug_ready', should_implement: true, reply: 'Will fix.' },
+      ['bug', 'triage', 'triage:bug-ready', 'ready-for-agent'],
+    );
+    assert.equal(classification.should_implement, false);
+    assert.ok(labels.includes('ready-for-human'));
+    assert.ok(!labels.includes('ready-for-agent'));
+  } finally {
+    if (previous == null) delete process.env.CURSOR_AUTOMATION_MODE;
+    else process.env.CURSOR_AUTOMATION_MODE = previous;
+  }
+
+  const unchanged = auto.applyTriageOnlyClassificationPolicy(
+    { category: 'bug_ready', should_implement: true },
+    ['ready-for-agent'],
+  );
+  assert.equal(unchanged.classification.should_implement, true);
+  assert.ok(unchanged.labels.includes('ready-for-agent'));
+});
+
 test('no-PR follow-ups use a writable Cursor agent mode', () => {
   const workflow = fs.readFileSync(
     path.join(__dirname, '..', '.github', 'workflows', 'cursor-automation.yml'),
@@ -4572,6 +4639,76 @@ test('applyClassification updates state before posting the final reply', async (
   assert.ok(calls[0][1].labels.includes('triage:already-available'));
   assert.equal(calls[1][0], 'createComment');
   assert.match(calls[1][1].body, /AsidePanel/);
+});
+
+test('applyClassification in triage-only never starts implement', async () => {
+  const previous = process.env.CURSOR_AUTOMATION_MODE;
+  process.env.CURSOR_AUTOMATION_MODE = 'triage_only';
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-auto-triage-only-'));
+  const classificationPath = path.join(dir, 'classification.json');
+  fs.writeFileSync(
+    classificationPath,
+    JSON.stringify(
+      grounded({
+        category: 'bug_ready',
+        confidence: 0.92,
+        summary: 'clear local bug',
+        reasoning: 'KeychainManager.tsx drops the selected key on refresh.',
+        reply: '维护者会接着看这个密钥刷新的问题。',
+      }),
+    ),
+  );
+
+  const calls = [];
+  const github = {
+    rest: {
+      issues: {
+        async get() {
+          return {
+            data: {
+              number: 99,
+              state: 'open',
+              labels: [{ name: 'bug' }, { name: 'triage' }],
+            },
+          };
+        },
+        async createComment(args) {
+          calls.push(['createComment', args]);
+          return { data: { id: 1 } };
+        },
+        async update(args) {
+          calls.push(['update', args]);
+          return { data: {} };
+        },
+      },
+    },
+  };
+  const outputs = {};
+  const core = {
+    setOutput(key, value) {
+      outputs[key] = value;
+    },
+  };
+
+  try {
+    const classification = await auto.applyClassification({
+      github,
+      context: { repo: { owner: 'binaricat', repo: 'Netcatty' } },
+      core,
+      issueNumber: 99,
+      classificationPath,
+    });
+
+    assert.equal(classification.category, 'bug_ready');
+    assert.equal(classification.should_implement, false);
+    assert.equal(outputs.should_implement, 'false');
+    assert.ok(calls[0][1].labels.includes('ready-for-human'));
+    assert.ok(!calls[0][1].labels.includes('ready-for-agent'));
+  } finally {
+    if (previous == null) delete process.env.CURSOR_AUTOMATION_MODE;
+    else process.env.CURSOR_AUTOMATION_MODE = previous;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('applyClassification restores the original issue when its reply fails', async () => {


### PR DESCRIPTION
## Summary

Temporarily pause Cursor auto-implementation and the Codex review loop. New issues still go through Cursor classification; coding jobs and Codex polling do not run until the mode is restored.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [x] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Default `CURSOR_AUTOMATION_MODE` to `triage_only` (override with the repo variable).
- Gate implement / follow-up / Codex loop routes to `skip`.
- Force `should_implement=false` and remap `ready-for-agent` to `ready-for-human`.
- Comment out the 5-minute Codex poll and daily sandbox smoke crons.
- Update classify prompt and Cursor automation README so replies do not promise an automatic patch.

Restore later by setting `CURSOR_AUTOMATION_MODE=full` and uncommenting the `schedule` crons in `cursor-automation.yml`.

## Screenshots / Demo

N/A — CI / automation change only.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Ran `node --test scripts/cursor-automation.test.cjs` (183 pass) and `node --test scripts/github-workflow-ci.test.cjs` (20 pass). Capability codegen is not applicable.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

This is an intentional temporary behavior change: Cursor no longer opens implement PRs or drives the Codex loop.