### PR TITLE
fix(terminal): drop leftover search highlights after Esc

### DIFF
--- a/components/terminal/hooks/useTerminalSearch.ts
+++ b/components/terminal/hooks/useTerminalSearch.ts
@@ -67,6 +67,9 @@ export const SEARCH_DECORATION_TRACKER_KEY = "__netcattySearchDecorationTracker"
 export type SearchDecorationTracker = {
   disposeAll: () => number;
   size: () => number;
+  markSearched: () => void;
+  hasSearched: () => boolean;
+  consumeSearched: () => boolean;
 };
 
 type TrackableTerminal = Pick<XTerm, "registerDecoration"> & {
@@ -118,6 +121,7 @@ export const installSearchDecorationTracker = (
   if (existing) return existing;
 
   const tracked = new Set<{ dispose: () => void }>();
+  let searched = false;
   const originalRegister = term.registerDecoration.bind(term);
   term.registerDecoration = (options) => {
     // Keep search fill on the HTML overlay only. Passing backgroundColor into
@@ -149,6 +153,15 @@ export const installSearchDecorationTracker = (
       return leftover.length;
     },
     size: () => tracked.size,
+    markSearched: () => {
+      searched = true;
+    },
+    hasSearched: () => searched,
+    consumeSearched: () => {
+      const value = searched;
+      searched = false;
+      return value;
+    },
   };
   term[SEARCH_DECORATION_TRACKER_KEY] = tracker;
   return tracker;
@@ -274,6 +287,12 @@ export const settleTerminalSearchAfterLayout = (
   term?: TerminalSearchResetTarget,
   onRepaint?: () => void,
 ): void => {
+  // Search-open state is shared across terminals. A sibling that never
+  // searched still sees the bar close and would otherwise lose a manual
+  // selection via clearSelection().
+  const tracker = getSearchDecorationTracker(term);
+  if (tracker && !tracker.hasSearched()) return;
+  tracker?.consumeSearched();
   clearTerminalSearchHighlights(searchAddon, term);
   term?.clearSelection();
   term?.clearTextureAtlas?.();
@@ -489,6 +508,8 @@ export const useTerminalSearch = ({
       // Incremental typing (ro -> root) can leave the previous term's
       // decorations in xterm even after clearDecorations(). Drop our tracked
       // leftovers before painting the new matches.
+      if (termRef.current) installSearchDecorationTracker(termRef.current);
+      getSearchDecorationTracker(termRef.current)?.markSearched();
       disposeStaleSearchDecorations(termRef.current);
       searchAddon.clearDecorations();
 

--- a/components/terminal/hooks/useTerminalSearch.ts
+++ b/components/terminal/hooks/useTerminalSearch.ts
@@ -70,6 +70,8 @@ export type SearchDecorationTracker = {
   markSearched: () => void;
   hasSearched: () => boolean;
   consumeSearched: () => boolean;
+  noteEmptyQueryReset: () => void;
+  consumeCloseSweep: () => boolean;
 };
 
 type TrackableTerminal = Pick<XTerm, "registerDecoration"> & {
@@ -122,6 +124,7 @@ export const installSearchDecorationTracker = (
 
   const tracked = new Set<{ dispose: () => void }>();
   let searched = false;
+  let pendingCloseSweep = false;
   const originalRegister = term.registerDecoration.bind(term);
   term.registerDecoration = (options) => {
     // Keep search fill on the HTML overlay only. Passing backgroundColor into
@@ -155,11 +158,20 @@ export const installSearchDecorationTracker = (
     size: () => tracked.size,
     markSearched: () => {
       searched = true;
+      pendingCloseSweep = true;
     },
     hasSearched: () => searched,
     consumeSearched: () => {
       const value = searched;
       searched = false;
+      return value;
+    },
+    noteEmptyQueryReset: () => {
+      searched = false;
+    },
+    consumeCloseSweep: () => {
+      const value = pendingCloseSweep;
+      pendingCloseSweep = false;
       return value;
     },
   };
@@ -289,12 +301,16 @@ export const settleTerminalSearchAfterLayout = (
 ): void => {
   // Search-open state is shared across terminals. A sibling that never
   // searched still sees the bar close and would otherwise lose a manual
-  // selection via clearSelection().
+  // selection via clearSelection(). Emptying the query resets highlights
+  // while the bar stays open; keep the close-time repaint, but do not
+  // treat that stale search as a reason to wipe a later manual selection.
   const tracker = getSearchDecorationTracker(term);
-  if (tracker && !tracker.hasSearched()) return;
-  tracker?.consumeSearched();
+  const shouldClearSelection = tracker ? tracker.consumeSearched() : true;
+  const shouldSweepLeftovers = tracker ? tracker.consumeCloseSweep() : true;
+  const shouldSweep = !tracker || shouldClearSelection || shouldSweepLeftovers;
+  if (!shouldSweep) return;
   clearTerminalSearchHighlights(searchAddon, term);
-  term?.clearSelection();
+  if (shouldClearSelection) term?.clearSelection();
   term?.clearTextureAtlas?.();
   onRepaint?.();
 };
@@ -499,6 +515,8 @@ export const useTerminalSearch = ({
       const searchAddon = searchAddonRef.current;
       if (!searchAddon || !term) {
         runReset();
+        if (termRef.current) installSearchDecorationTracker(termRef.current);
+        getSearchDecorationTracker(termRef.current)?.noteEmptyQueryReset();
         setSearchMatchCount(null);
         return false;
       }

--- a/components/terminal/hooks/useTerminalSearch.ts
+++ b/components/terminal/hooks/useTerminalSearch.ts
@@ -8,8 +8,14 @@ import { STORAGE_KEY_TERMINAL_SEARCH_OPEN } from "../../../infrastructure/config
 type SearchMatchCount = { current: number; total: number } | null;
 
 type SearchAddonResetTarget = Pick<SearchAddon, "findNext" | "clearDecorations"> | null;
-type TerminalSearchResetTarget = Pick<XTerm, "refresh" | "rows" | "clearSelection"> | null;
-type TerminalSearchGuardTarget = Pick<XTerm, "refresh" | "rows" | "clearSelection"> | null;
+type TerminalSearchVisualElement = {
+  querySelectorAll: (selector: string) => ArrayLike<{ remove: () => void }>;
+};
+type TerminalSearchResetTarget = Pick<XTerm, "refresh" | "rows" | "clearSelection"> & {
+  element?: TerminalSearchVisualElement | null;
+  clearTextureAtlas?: () => void;
+} | null;
+type TerminalSearchGuardTarget = TerminalSearchResetTarget;
 
 const SEARCH_DECORATIONS = {
   matchBackground: "#FFFF0044",
@@ -19,6 +25,53 @@ const SEARCH_DECORATIONS = {
   activeMatchBorder: "#FF8800",
   activeMatchColorOverviewRuler: "#FF8800",
 } as const;
+
+const SEARCH_DECORATION_BACKGROUNDS = new Set<string>([
+  SEARCH_DECORATIONS.matchBackground.toLowerCase(),
+  SEARCH_DECORATIONS.activeMatchBackground.toLowerCase(),
+]);
+
+type StaleSearchDecoration = {
+  dispose: () => void;
+  options?: { backgroundColor?: string };
+  element?: {
+    classList?: { contains: (name: string) => boolean };
+    style?: { backgroundColor?: string };
+  };
+};
+
+type CellDecorationService = {
+  decorations?: Iterable<StaleSearchDecoration>;
+  forEachDecorationAtCell?: (
+    x: number,
+    y: number,
+    layer: "bottom" | "top" | undefined,
+    callback: (decoration: StaleSearchDecoration) => void,
+  ) => void;
+};
+
+type SearchAddonInternals = {
+  clearDecorations?: () => void;
+  clearActiveDecoration?: () => void;
+  _highlightTimeout?: { clear?: () => void };
+  _state?: { reset?: () => void };
+};
+
+type TerminalDecorationHost = {
+  _core?: { _decorationService?: CellDecorationService };
+  _decorationService?: CellDecorationService;
+};
+
+export const SEARCH_DECORATION_TRACKER_KEY = "__netcattySearchDecorationTracker";
+
+export type SearchDecorationTracker = {
+  disposeAll: () => number;
+  size: () => number;
+};
+
+type TrackableTerminal = Pick<XTerm, "registerDecoration"> & {
+  [SEARCH_DECORATION_TRACKER_KEY]?: SearchDecorationTracker;
+};
 
 const SEARCH_OPTIONS = {
   regex: false,
@@ -36,18 +89,195 @@ const SEARCH_OPTIONS = {
 export const SEARCH_HIGHLIGHT_REVIVAL_GUARD_MS = 250;
 
 /**
+ * SearchAddon paints matches as HTML overlays (`.xterm-find-result-decoration`).
+ * Disposing the addon decoration does not always detach that node — after Esc
+ * closes the search bar and the terminal refits, the first two cells of the
+ * last hit can stay outlined on top of the buffer.
+ */
+export const SEARCH_DECORATION_NODE_SELECTOR =
+  ".xterm-find-result-decoration, .xterm-find-active-result-decoration";
+
+export const stripStaleSearchDecorationNodes = (
+  term?: { element?: TerminalSearchVisualElement | null } | null,
+): void => {
+  const nodes = term?.element?.querySelectorAll(SEARCH_DECORATION_NODE_SELECTOR);
+  if (!nodes) return;
+  for (let i = 0; i < nodes.length; i += 1) {
+    nodes[i]?.remove();
+  }
+};
+
+export const isSearchDecorationBackground = (color?: string): boolean => (
+  Boolean(color) && SEARCH_DECORATION_BACKGROUNDS.has(color.trim().toLowerCase())
+);
+
+export const installSearchDecorationTracker = (
+  term: TrackableTerminal,
+): SearchDecorationTracker => {
+  const existing = term[SEARCH_DECORATION_TRACKER_KEY];
+  if (existing) return existing;
+
+  const tracked = new Set<{ dispose: () => void }>();
+  const originalRegister = term.registerDecoration.bind(term);
+  term.registerDecoration = (options) => {
+    // Keep search fill on the HTML overlay only. Passing backgroundColor into
+    // xterm lets WebGL bake the yellow into the glyph atlas, and those cells
+    // stay stained after Esc even when the decoration handle is gone.
+    const searchBackground = isSearchDecorationBackground(options.backgroundColor)
+      ? options.backgroundColor
+      : undefined;
+    const decoration = originalRegister(
+      searchBackground ? { ...options, backgroundColor: undefined } : options,
+    );
+    if (!decoration) return decoration;
+    if (!searchBackground) return decoration;
+    tracked.add(decoration);
+    decoration.onRender((element) => {
+      element.style.backgroundColor = searchBackground;
+    });
+    decoration.onDispose(() => {
+      tracked.delete(decoration);
+    });
+    return decoration;
+  };
+
+  const tracker: SearchDecorationTracker = {
+    disposeAll: () => {
+      const leftover = [...tracked];
+      tracked.clear();
+      for (const decoration of leftover) decoration.dispose();
+      return leftover.length;
+    },
+    size: () => tracked.size,
+  };
+  term[SEARCH_DECORATION_TRACKER_KEY] = tracker;
+  return tracker;
+};
+
+export const getSearchDecorationTracker = (term?: unknown): SearchDecorationTracker | null => {
+  if (!term || typeof term !== "object") return null;
+  const tracker = (term as TrackableTerminal)[SEARCH_DECORATION_TRACKER_KEY];
+  return tracker && typeof tracker.disposeAll === "function" ? tracker : null;
+};
+
+const isStaleSearchDecoration = (decoration: StaleSearchDecoration): boolean => (
+  isSearchDecorationBackground(decoration.options?.backgroundColor)
+  || isSearchDecorationBackground(decoration.element?.style?.backgroundColor)
+  || decoration.element?.classList?.contains("xterm-find-result-decoration") === true
+  || decoration.element?.classList?.contains("xterm-find-active-result-decoration") === true
+);
+
+const readDecorationService = (term?: unknown): CellDecorationService | null => {
+  const host = term as TerminalDecorationHost & {
+    _core?: Record<string, unknown>;
+  } | null | undefined;
+  const direct = host?._core?._decorationService ?? host?._decorationService;
+  if (direct && (direct.decorations || direct.forEachDecorationAtCell)) {
+    return direct;
+  }
+  const core = host?._core;
+  if (!core || typeof core !== "object") return null;
+  for (const value of Object.values(core)) {
+    const candidate = value as CellDecorationService | undefined;
+    if (candidate && typeof candidate.forEachDecorationAtCell === "function") {
+      return candidate;
+    }
+  }
+  return null;
+};
+
+const readDecorationIterable = (
+  term?: unknown,
+): Iterable<StaleSearchDecoration> | null => (
+  readDecorationService(term)?.decorations ?? null
+);
+
+export const disposeSearchDecorationsInViewport = (term?: unknown): number => {
+  const service = readDecorationService(term);
+  const view = term as {
+    cols?: number;
+    rows?: number;
+    buffer?: { active?: { viewportY?: number } };
+  } | null | undefined;
+  if (!service?.forEachDecorationAtCell || !view?.cols || !view.rows) return 0;
+  const viewportY = view.buffer?.active?.viewportY ?? 0;
+  const stale = new Set<StaleSearchDecoration>();
+  for (let y = viewportY; y < viewportY + view.rows; y += 1) {
+    for (let x = 0; x < view.cols; x += 1) {
+      service.forEachDecorationAtCell(x, y, undefined, (decoration) => {
+        if (isStaleSearchDecoration(decoration)) stale.add(decoration);
+      });
+    }
+  }
+  for (const decoration of stale) decoration.dispose();
+  return stale.size;
+};
+
+/**
+ * WebGL paints decoration backgroundColor into the cell. SearchAddon can lose
+ * a couple of those handles on Esc+refit, so walk the terminal decoration
+ * service and dispose anything still using the search yellow/orange.
+ */
+export const disposeStaleSearchDecorations = (term?: unknown): number => {
+  if (term && typeof term === "object" && "registerDecoration" in term) {
+    installSearchDecorationTracker(term as TrackableTerminal);
+  }
+  const trackedCount = getSearchDecorationTracker(term)?.disposeAll() ?? 0;
+  const viewportCount = disposeSearchDecorationsInViewport(term);
+  const decorations = readDecorationIterable(term);
+  if (!decorations) return trackedCount + viewportCount;
+  const stale: StaleSearchDecoration[] = [];
+  for (const decoration of decorations) {
+    if (isStaleSearchDecoration(decoration)) stale.push(decoration);
+  }
+  for (const decoration of stale) decoration.dispose();
+  return trackedCount + viewportCount + stale.length;
+};
+
+/** Cancel SearchAddon's 200ms _updateMatches timer and drop cached term/options. */
+export const disarmSearchAddonRevival = (searchAddon?: unknown): void => {
+  const addon = searchAddon as SearchAddonInternals | null | undefined;
+  if (!addon) return;
+  addon._highlightTimeout?.clear?.();
+  addon._state?.reset?.();
+  addon.clearActiveDecoration?.();
+  addon.clearDecorations?.();
+};
+
+/**
  * Delayed re-clear for addon decoration revival only. Do not clearSelection
  * here: reset already cleared the search selection, and a user may have made
  * a new manual selection during the guard window.
  */
 export const clearTerminalSearchHighlights = (
   searchAddon: Pick<SearchAddon, "clearDecorations"> | null,
-  term?: Pick<XTerm, "refresh" | "rows"> | null,
+  term?: Pick<XTerm, "refresh" | "rows"> & {
+    element?: TerminalSearchVisualElement | null;
+    clearTextureAtlas?: () => void;
+  } | null,
 ): void => {
-  searchAddon?.clearDecorations();
+  disarmSearchAddonRevival(searchAddon);
+  disposeStaleSearchDecorations(term);
+  stripStaleSearchDecorationNodes(term);
   if (term && term.rows > 0) {
     term.refresh(0, term.rows - 1);
   }
+};
+
+/**
+ * After the search bar unmounts the terminal grows and is force-fitted.
+ * Re-sweep leftover overlays and the addon selection that a resize can revive
+ * as a 2-cell sliver of the last match.
+ */
+export const settleTerminalSearchAfterLayout = (
+  searchAddon: Pick<SearchAddon, "clearDecorations"> | null,
+  term?: TerminalSearchResetTarget,
+  onRepaint?: () => void,
+): void => {
+  clearTerminalSearchHighlights(searchAddon, term);
+  term?.clearSelection();
+  term?.clearTextureAtlas?.();
+  onRepaint?.();
 };
 
 export const resetTerminalSearch = (
@@ -58,7 +288,7 @@ export const resetTerminalSearch = (
   searchTermRef.current = "";
   // Drop decorations and cachedSearchTerm first so any not-yet-running addon
   // `_updateMatches` timeout observes an empty cache and does not revive.
-  searchAddon?.clearDecorations();
+  disarmSearchAddonRevival(searchAddon);
   // clearDecorations() leaves the active-match selection; clear it explicitly.
   term?.clearSelection();
   // Empty find clears selection via the addon path. Do NOT pass SEARCH_OPTIONS:
@@ -72,6 +302,14 @@ export const resetTerminalSearch = (
   // findNext("") assigns cachedSearchTerm back to "". Clear again so the cache
   // is undefined rather than an empty string.
   searchAddon?.clearDecorations();
+  // SearchAddon can drop a couple of decoration handles on Esc+refit. Those
+  // leftover yellow cells are still in xterm's decoration service and WebGL
+  // keeps painting them until we dispose them directly.
+  disposeStaleSearchDecorations(term);
+  // Disposing search decorations does not always detach the overlay nodes
+  // (Esc close leaves the first two cells of the last hit). Sweep them
+  // before refresh so WebGL/DOM cannot keep the yellow outline.
+  stripStaleSearchDecorationNodes(term);
   // Disposing search decorations does not always repaint cells (observed on
   // Windows after clearing or closing search). Keyword highlighting already
   // forces a refresh after dispose; do the same here so yellow match
@@ -180,6 +418,12 @@ export const useTerminalSearch = ({
   const searchTermRef = useRef<string>("");
   const revivalGuardRef = useRef<ReturnType<typeof armSearchHighlightRevivalGuard> | null>(null);
 
+  // Existing sessions (and Vite HMR) never go back through createXTermRuntime.
+  // Install on the live term so Esc can still find leaked decorations.
+  if (termRef.current) {
+    installSearchDecorationTracker(termRef.current);
+  }
+
   if (revivalGuardRef.current === null) {
     revivalGuardRef.current = armSearchHighlightRevivalGuard({
       getSearchAddon: () => searchAddonRef.current,
@@ -242,6 +486,10 @@ export const useTerminalSearch = ({
 
       searchTermRef.current = term;
       revivalGuardRef.current?.dispose();
+      // Incremental typing (ro -> root) can leave the previous term's
+      // decorations in xterm even after clearDecorations(). Drop our tracked
+      // leftovers before painting the new matches.
+      disposeStaleSearchDecorations(termRef.current);
       searchAddon.clearDecorations();
 
       const found = searchAddon.findNext(term, SEARCH_OPTIONS);
@@ -254,7 +502,7 @@ export const useTerminalSearch = ({
 
       return found;
     },
-    [runReset, searchAddonRef],
+    [runReset, searchAddonRef, termRef],
   );
 
   const handleFindNext = useCallback((): boolean => {

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../application/state/useGlobalHotkeys";
 import { fontStore } from "../../../application/state/fontStore";
 import { KeywordHighlighter } from "../keywordHighlight";
+import { installSearchDecorationTracker } from "../hooks/useTerminalSearch";
 import { CursorLineHighlighter } from "./cursorLineHighlight";
 import { resolveCursorLineHighlightBackground } from "../../../domain/cursorLineHighlight";
 import {
@@ -558,6 +559,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       scrollbarSliderActiveBackground: ctx.terminalTheme.colors.foreground + '80', // 50% opacity
     },
   });
+  installSearchDecorationTracker(term);
 
   type MaybeRenderer = {
     constructor?: { name?: string };

--- a/components/terminal/terminalSearch.test.ts
+++ b/components/terminal/terminalSearch.test.ts
@@ -326,6 +326,40 @@ test("stripStaleSearchDecorationNodes removes both result and active overlays", 
   assert.equal(activeNode.removed, true);
 });
 
+test("settling search after layout skips terminals that never searched", () => {
+  const leftover = leftoverDecoration("xterm-find-result-decoration");
+  const calls: string[] = [];
+  const term = {
+    rows: 12,
+    registerDecoration() {
+      return undefined;
+    },
+    refresh() {
+      calls.push("refresh");
+    },
+    clearSelection() {
+      calls.push("clearSelection");
+    },
+    element: {
+      querySelectorAll() {
+        return [leftover];
+      },
+    },
+  };
+  installSearchDecorationTracker(term);
+  settleTerminalSearchAfterLayout(
+    {
+      clearDecorations() {
+        calls.push("clearDecorations");
+      },
+    },
+    term,
+    () => calls.push("atlas"),
+  );
+  assert.deepEqual(calls, []);
+  assert.equal(leftover.removed, false);
+});
+
 test("settling search after layout re-clears decorations, selection, leftover nodes, and repaints", () => {
   const leftover = leftoverDecoration("xterm-find-result-decoration");
   const calls: string[] = [];
@@ -479,6 +513,8 @@ test("search decoration tracker disposes leaked incremental matches", () => {
   assert.deepEqual(registeredBackgrounds, [undefined, undefined, "#1e293b"]);
   assert.equal(match?.overlayBackground, "#FFFF0044");
   assert.equal(tracker.size(), 2);
+  tracker.markSearched();
+  assert.equal(tracker.hasSearched(), true);
   assert.equal(tracker.disposeAll(), 2);
   assert.equal(live.filter((item) => item.disposed).length, 2);
   assert.equal(live.some((item) => item.registeredBackground === "#1e293b" && !item.disposed), true);

--- a/components/terminal/terminalSearch.test.ts
+++ b/components/terminal/terminalSearch.test.ts
@@ -326,6 +326,44 @@ test("stripStaleSearchDecorationNodes removes both result and active overlays", 
   assert.equal(activeNode.removed, true);
 });
 
+test("settling search after an emptied query keeps a later manual selection", () => {
+  const leftover = leftoverDecoration("xterm-find-result-decoration");
+  const calls: string[] = [];
+  const term = {
+    rows: 12,
+    registerDecoration() {
+      return undefined;
+    },
+    refresh() {
+      calls.push("refresh");
+    },
+    clearSelection() {
+      calls.push("clearSelection");
+    },
+    element: {
+      querySelectorAll() {
+        return [leftover];
+      },
+    },
+  };
+  const tracker = installSearchDecorationTracker(term);
+  tracker.markSearched();
+  tracker.noteEmptyQueryReset();
+  settleTerminalSearchAfterLayout(
+    {
+      clearDecorations() {
+        calls.push("clearDecorations");
+      },
+    },
+    term,
+    () => calls.push("atlas"),
+  );
+  assert.equal(calls.includes("clearSelection"), false);
+  assert.ok(calls.includes("clearDecorations"));
+  assert.ok(calls.includes("atlas"));
+  assert.equal(leftover.removed, true);
+});
+
 test("settling search after layout skips terminals that never searched", () => {
   const leftover = leftoverDecoration("xterm-find-result-decoration");
   const calls: string[] = [];

--- a/components/terminal/terminalSearch.test.ts
+++ b/components/terminal/terminalSearch.test.ts
@@ -596,8 +596,10 @@ test("search-bar close fit settles leftover highlights after layout", () => {
   const source = readFileSync(new URL("./useTerminalEffects.ts", import.meta.url), "utf8");
   assert.match(source, /settleTerminalSearchAfterLayout/);
   assert.match(source, /closingSearch = wasSearchOpen && !isSearchOpen/);
+  assert.match(source, /if \(!closingSearch \|\| prevIsSearchOpenRef\.current\) return/);
+  assert.match(source, /if \(raf\) cancelAnimationFrame\(raf\)/);
   assert.match(
     source,
-    /safeFit\(\{ force: true, requireVisible: true \}\);[\s\S]*if \(closingSearch\) \{[\s\S]*settleTerminalSearchAfterLayout/,
+    /safeFit\(\{ force: true, requireVisible: true \}\);[\s\S]*settleClosedSearch/,
   );
 });

--- a/components/terminal/terminalSearch.test.ts
+++ b/components/terminal/terminalSearch.test.ts
@@ -1,12 +1,18 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { notifyTerminalSearchTermChange } from "./TerminalSearchBar.tsx";
 import {
   armSearchHighlightRevivalGuard,
+  disarmSearchAddonRevival,
+  disposeStaleSearchDecorations,
+  installSearchDecorationTracker,
   resetTerminalSearch,
   SEARCH_HIGHLIGHT_REVIVAL_GUARD_MS,
+  settleTerminalSearchAfterLayout,
   shouldResetOnSharedSearchClose,
+  stripStaleSearchDecorationNodes,
   subscribeTerminalUserSelection,
 } from "./hooks/useTerminalSearch.ts";
 
@@ -266,4 +272,258 @@ test("revival guard subscribes to user selection only while armed", () => {
 test("shared search close only resets terminals that have a local query", () => {
   assert.equal(shouldResetOnSharedSearchClose(""), false);
   assert.equal(shouldResetOnSharedSearchClose("needle"), true);
+});
+
+const leftoverDecoration = (className: string) => {
+  const node = {
+    className,
+    removed: false,
+    remove() {
+      this.removed = true;
+    },
+  };
+  return node;
+};
+
+test("resetting terminal search strips leftover find-result decoration nodes", () => {
+  // Esc close disposes SearchAddon decorations, but the last match's HTML
+  // overlay can remain — typically the first two cells of the previous hit.
+  const leftover = leftoverDecoration("xterm-find-result-decoration");
+  const searchAddon = {
+    findNext() {
+      return false;
+    },
+    clearDecorations() {},
+  };
+  const term = {
+    rows: 24,
+    refresh() {},
+    clearSelection() {},
+    element: {
+      querySelectorAll(selector: string) {
+        assert.match(selector, /xterm-find-result-decoration/);
+        return [leftover];
+      },
+    },
+  };
+
+  resetTerminalSearch(searchAddon, { current: "pro" }, term);
+
+  assert.equal(leftover.removed, true);
+});
+
+test("stripStaleSearchDecorationNodes removes both result and active overlays", () => {
+  const resultNode = leftoverDecoration("xterm-find-result-decoration");
+  const activeNode = leftoverDecoration("xterm-find-active-result-decoration");
+  stripStaleSearchDecorationNodes({
+    element: {
+      querySelectorAll() {
+        return [resultNode, activeNode];
+      },
+    },
+  });
+  assert.equal(resultNode.removed, true);
+  assert.equal(activeNode.removed, true);
+});
+
+test("settling search after layout re-clears decorations, selection, leftover nodes, and repaints", () => {
+  const leftover = leftoverDecoration("xterm-find-result-decoration");
+  const calls: string[] = [];
+  const searchAddon = {
+    clearDecorations() {
+      calls.push("clearDecorations");
+    },
+  };
+  const term = {
+    rows: 12,
+    refresh(start: number, end: number) {
+      calls.push(`refresh:${start}:${end}`);
+    },
+    clearSelection() {
+      calls.push("clearSelection");
+    },
+    element: {
+      querySelectorAll() {
+        calls.push("queryLeftover");
+        return [leftover];
+      },
+    },
+  };
+
+  settleTerminalSearchAfterLayout(searchAddon, term, () => {
+    calls.push("atlas");
+  });
+
+  assert.equal(leftover.removed, true);
+  assert.deepEqual(calls, [
+    "clearDecorations",
+    "queryLeftover",
+    "refresh:0:11",
+    "clearSelection",
+    "atlas",
+  ]);
+});
+
+test("disposeStaleSearchDecorations drops leaked search backgrounds and keeps others", () => {
+  const searchMatch = {
+    disposed: false,
+    options: { backgroundColor: "#FFFF0044" },
+    dispose() {
+      this.disposed = true;
+    },
+  };
+  const activeMatch = {
+    disposed: false,
+    options: { backgroundColor: "#FF880088" },
+    dispose() {
+      this.disposed = true;
+    },
+  };
+  const cursorLine = {
+    disposed: false,
+    options: { backgroundColor: "#1e293b" },
+    dispose() {
+      this.disposed = true;
+    },
+  };
+  const count = disposeStaleSearchDecorations({
+    _core: {
+      _decorationService: {
+        decorations: [searchMatch, activeMatch, cursorLine],
+      },
+    },
+  });
+  assert.equal(count, 2);
+  assert.equal(searchMatch.disposed, true);
+  assert.equal(activeMatch.disposed, true);
+  assert.equal(cursorLine.disposed, false);
+});
+
+test("resetting terminal search disposes leaked WebGL search decorations", () => {
+  const leaked = {
+    disposed: false,
+    options: { backgroundColor: "#ffff0044" },
+    dispose() {
+      this.disposed = true;
+    },
+  };
+  resetTerminalSearch(
+    {
+      findNext() {
+        return false;
+      },
+      clearDecorations() {},
+    },
+    { current: "s" },
+    {
+      rows: 24,
+      refresh() {},
+      clearSelection() {},
+      _core: {
+        _decorationService: {
+          decorations: [leaked],
+        },
+      },
+    } as never,
+  );
+  assert.equal(leaked.disposed, true);
+});
+
+test("search decoration tracker disposes leaked incremental matches", () => {
+  const live: Array<{
+    registeredBackground?: string;
+    overlayBackground?: string;
+    disposed: boolean;
+    dispose: () => void;
+    onDispose: (cb: () => void) => { dispose: () => void };
+    onRender: (cb: (el: { style: { backgroundColor: string } }) => void) => { dispose: () => void };
+  }> = [];
+  const registeredBackgrounds: Array<string | undefined> = [];
+  const term = {
+    registerDecoration(options: { backgroundColor?: string }) {
+      registeredBackgrounds.push(options.backgroundColor);
+      const disposeListeners: Array<() => void> = [];
+      const renderListeners: Array<(el: { style: { backgroundColor: string } }) => void> = [];
+      const decoration = {
+        registeredBackground: options.backgroundColor,
+        overlayBackground: undefined as string | undefined,
+        disposed: false,
+        dispose() {
+          if (this.disposed) return;
+          this.disposed = true;
+          for (const listener of disposeListeners) listener();
+        },
+        onDispose(cb: () => void) {
+          disposeListeners.push(cb);
+          return { dispose() {} };
+        },
+        onRender(cb: (el: { style: { backgroundColor: string } }) => void) {
+          renderListeners.push(cb);
+          return { dispose() {} };
+        },
+        paint() {
+          const el = { style: { backgroundColor: "" } };
+          for (const listener of renderListeners) listener(el);
+          this.overlayBackground = el.style.backgroundColor;
+        },
+      };
+      live.push(decoration);
+      return decoration;
+    },
+  };
+  const tracker = installSearchDecorationTracker(term);
+  const match = term.registerDecoration({ backgroundColor: "#FFFF0044" });
+  term.registerDecoration({ backgroundColor: "#FF880088" });
+  term.registerDecoration({ backgroundColor: "#1e293b" });
+  match?.paint();
+  assert.deepEqual(registeredBackgrounds, [undefined, undefined, "#1e293b"]);
+  assert.equal(match?.overlayBackground, "#FFFF0044");
+  assert.equal(tracker.size(), 2);
+  assert.equal(tracker.disposeAll(), 2);
+  assert.equal(live.filter((item) => item.disposed).length, 2);
+  assert.equal(live.some((item) => item.registeredBackground === "#1e293b" && !item.disposed), true);
+  assert.equal(tracker.size(), 0);
+});
+
+test("xterm runtime installs the search decoration tracker", () => {
+  const source = readFileSync(new URL("./runtime/createXTermRuntime.ts", import.meta.url), "utf8");
+  assert.match(source, /installSearchDecorationTracker\(term\)/);
+});
+
+test("disarmSearchAddonRevival cancels the addon timer and resets cached state", () => {
+  const calls: string[] = [];
+  disarmSearchAddonRevival({
+    _highlightTimeout: {
+      clear() {
+        calls.push("clearTimeout");
+      },
+    },
+    _state: {
+      reset() {
+        calls.push("resetState");
+      },
+    },
+    clearActiveDecoration() {
+      calls.push("clearActive");
+    },
+    clearDecorations() {
+      calls.push("clearDecorations");
+    },
+  });
+  assert.deepEqual(calls, [
+    "clearTimeout",
+    "resetState",
+    "clearActive",
+    "clearDecorations",
+  ]);
+});
+
+test("search-bar close fit settles leftover highlights after layout", () => {
+  const source = readFileSync(new URL("./useTerminalEffects.ts", import.meta.url), "utf8");
+  assert.match(source, /settleTerminalSearchAfterLayout/);
+  assert.match(source, /closingSearch = wasSearchOpen && !isSearchOpen/);
+  assert.match(
+    source,
+    /safeFit\(\{ force: true, requireVisible: true \}\);[\s\S]*if \(closingSearch\) \{[\s\S]*settleTerminalSearchAfterLayout/,
+  );
 });

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -1592,23 +1592,22 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
     const wasAtBottom = buffer.viewportY >= buffer.baseY;
     const prevViewportY = buffer.viewportY;
     const closingSearch = wasSearchOpen && !isSearchOpen;
+    let raf = 0;
+    const settleClosedSearch = () => {
+      // A later open flips prevIsSearchOpenRef before this stale frame runs.
+      if (!closingSearch || prevIsSearchOpenRef.current) return;
+      settleTerminalSearchAfterLayout(
+        searchAddonRef.current,
+        term,
+        () => xtermRuntimeRef.current?.clearTextureAtlas(),
+      );
+    };
     const timer = setTimeout(() => {
       safeFit({ force: true, requireVisible: true });
-      if (closingSearch) {
-        settleTerminalSearchAfterLayout(
-          searchAddonRef.current,
-          term,
-          () => xtermRuntimeRef.current?.clearTextureAtlas(),
-        );
-      }
-      requestAnimationFrame(() => {
-        if (closingSearch) {
-          settleTerminalSearchAfterLayout(
-            searchAddonRef.current,
-            term,
-            () => xtermRuntimeRef.current?.clearTextureAtlas(),
-          );
-        }
+      settleClosedSearch();
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        settleClosedSearch();
         if (wasAtBottom) {
           term.scrollToBottom();
         } else {
@@ -1616,7 +1615,10 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         }
       });
     }, 0);
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      if (raf) cancelAnimationFrame(raf);
+    };
   }, [isSearchOpen]);
 
   // When compose bar opens/closes, re-fit terminal and maintain scroll position

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -48,6 +48,7 @@ import {
   type XTermFontRemeasureTarget,
 } from './runtime/terminalFontRemeasure';
 import { shouldClaimTerminalKeyboardFocus } from '../../domain/terminalKeyboardFocus';
+import { settleTerminalSearchAfterLayout } from './hooks/useTerminalSearch';
 import {
   isTerminalCloseGenerationCurrent,
   resolveConnectionLogCapturePayload,
@@ -172,6 +173,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
     effectiveTerminalProtocol,
   ) && !kittyKeyboardProtocolEnabledForSession;
   ctx.pluginDecorationRulesRef.current = pluginDecorationRules;
+  const prevIsSearchOpenRef = useRef(isSearchOpen);
   const pluginAwareOnCommandSubmitted = (...args: Parameters<NonNullable<typeof onCommandSubmitted>>) => {
     markTerminalCommandCompletionPending(promptLineBreakStateRef);
     publishPluginTerminalRuntimeLifecycleEvent(pluginTerminalLifecycle, 'commandSubmitted');
@@ -1583,13 +1585,30 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
   // When search bar opens/closes, re-fit terminal and maintain scroll position
   useEffect(() => {
     const term = termRef.current;
+    const wasSearchOpen = prevIsSearchOpenRef.current;
+    prevIsSearchOpenRef.current = isSearchOpen;
     if (!term || !fitAddonRef.current) return;
     const buffer = term.buffer.active;
     const wasAtBottom = buffer.viewportY >= buffer.baseY;
     const prevViewportY = buffer.viewportY;
+    const closingSearch = wasSearchOpen && !isSearchOpen;
     const timer = setTimeout(() => {
       safeFit({ force: true, requireVisible: true });
+      if (closingSearch) {
+        settleTerminalSearchAfterLayout(
+          searchAddonRef.current,
+          term,
+          () => xtermRuntimeRef.current?.clearTextureAtlas(),
+        );
+      }
       requestAnimationFrame(() => {
+        if (closingSearch) {
+          settleTerminalSearchAfterLayout(
+            searchAddonRef.current,
+            term,
+            () => xtermRuntimeRef.current?.clearTextureAtlas(),
+          );
+        }
         if (wasAtBottom) {
           term.scrollToBottom();
         } else {


### PR DESCRIPTION
## Summary

Escaping terminal search still left yellow/orange cells behind after #2981. Incremental typing (`r` → `ro` → `root`) leaked earlier match decorations, and WebGL baked those search backgrounds into the glyph atlas, so the stain survived `clearDecorations()`.

This keeps search fill on the HTML overlay only, tracks every search decoration we register, and resweeps after the search bar closes and the terminal refits.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #2980

## Changes Made

- Wrap `registerDecoration` so search yellow/orange never goes through WebGL cell backgrounds.
- Track those decorations and dispose them on query change, Esc reset, and search-bar close.
- After the close refit, strip leftover overlay nodes, clear the selection, and refresh the texture atlas.
- Cover the tracker, leaked-decoration dispose path, and close-fit settle in unit tests.

## Screenshots / Demo

Before: Esc after searching `root` left the first `root` and fragments like `from`/`Fri` stained. After: new sessions clear completely on Esc.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Lint and unit tests were run on the touched files (`components/terminal/terminalSearch.test.ts`). Full-app verification was a local Electron session: search, type incrementally, Esc, confirm no leftover highlight on a fresh terminal.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)