### PR TITLE
fix(settings): give system footer hints space under cards

### DIFF
--- a/components/settings/settings-ui.tsx
+++ b/components/settings/settings-ui.tsx
@@ -161,6 +161,16 @@ export const SettingsSection: React.FC<{
   </section>
 );
 
+/** Footer note under a SettingCard. Keep a gap so it does not kiss the card. */
+export const settingHintClassName = "mt-3 text-xs text-muted-foreground";
+
+export const SettingHint: React.FC<{
+  children: React.ReactNode;
+  className?: string;
+}> = ({ children, className }) => (
+  <p className={cn(settingHintClassName, className)}>{children}</p>
+);
+
 export const settingCardClassName = "rounded-lg border bg-card";
 
 interface SettingCardProps {

--- a/components/settings/settingsFocus.test.ts
+++ b/components/settings/settingsFocus.test.ts
@@ -2,6 +2,20 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
+test("system setting hints sit below their cards with a shared top gap", () => {
+  const uiSource = readFileSync(new URL("./settings-ui.tsx", import.meta.url), "utf8");
+  const systemSource = readFileSync(new URL("./tabs/SettingsSystemTab.tsx", import.meta.url), "utf8");
+
+  assert.match(uiSource, /export const settingHintClassName = "mt-3 text-xs text-muted-foreground"/);
+  assert.match(uiSource, /export const SettingHint/);
+  assert.match(systemSource, /SettingHint/);
+  assert.match(systemSource, /settings\.system\.crashLogs\.hint/);
+  assert.doesNotMatch(
+    systemSource,
+    /<p className="text-xs text-muted-foreground">\s*\{t\("settings\.system\.crashLogs\.hint"\)\}/,
+  );
+});
+
 test("settings search focus scrolls the content pane, not the window viewport", () => {
   const source = readFileSync(new URL("./settingsFocus.ts", import.meta.url), "utf8");
   const uiSource = readFileSync(new URL("./settings-ui.tsx", import.meta.url), "utf8");

--- a/components/settings/tabs/SettingsSystemTab.tsx
+++ b/components/settings/tabs/SettingsSystemTab.tsx
@@ -11,7 +11,7 @@ import { SessionLogFormat, keyEventToString } from "../../../domain/models";
 import type { HttpNetworkProxyMode, HttpNetworkProxySettings } from "../../../domain/httpNetworkProxy";
 import { Button } from "../../ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
-import { Toggle, Select, SettingRow, SectionHeader, SettingCard, SettingsAnchor, SettingsTabContent } from "../settings-ui";
+import { Toggle, Select, SettingRow, SectionHeader, SettingCard, SettingHint, SettingsAnchor, SettingsTabContent } from "../settings-ui";
 import { cn } from "../../../lib/utils";
 
 interface CrashLogFile {
@@ -569,7 +569,7 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
                 />
               </SettingRow>
             </SettingCard>
-            <p className="text-xs text-muted-foreground">
+            <SettingHint>
               {updateState.lastCheckedAt && (
                 <span>
                   {t('settings.update.lastCheckedPrefix')}
@@ -578,7 +578,7 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
                 </span>
               )}
               {t('settings.update.hint')}
-            </p>
+            </SettingHint>
 
           <SectionHeader title={t("settings.system.networkProxy.title")} />
             <SettingCard className="space-y-4 py-4">
@@ -639,9 +639,9 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
                 </>
               )}
             </SettingCard>
-            <p className="text-xs text-muted-foreground">
+            <SettingHint>
               {t("settings.system.networkProxy.hint")}
-            </p>
+            </SettingHint>
 
           <SectionHeader title={t("settings.system.credentials.title")} />
             <SettingsAnchor anchorId="system-credentials">
@@ -832,9 +832,9 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
               )}
             </SettingCard>
 
-            <p className="text-xs text-muted-foreground">
+            <SettingHint>
               {t("settings.system.crashLogs.hint")}
-            </p>
+            </SettingHint>
             </SettingsAnchor>
 
           <SectionHeader title={t("settings.system.tempDirectory")} />
@@ -915,9 +915,9 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
               )}
             </SettingCard>
 
-            <p className="text-xs text-muted-foreground">
+            <SettingHint>
               {t("settings.system.tempDirectoryHint")}
-            </p>
+            </SettingHint>
             </SettingsAnchor>
 
           <SectionHeader title={t("settings.sessionRestore.title")} />
@@ -1068,9 +1068,9 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
               </div>
             </SettingCard>
 
-            <p className="text-xs text-muted-foreground">
+            <SettingHint>
               {t("settings.sessionLogs.hint")}
-            </p>
+            </SettingHint>
 
           <SectionHeader title={t('settings.sshDeepLink.title')} />
             <SettingCard>
@@ -1183,9 +1183,9 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
               </div>
             </SettingCard>
 
-            <p className="text-xs text-muted-foreground">
+            <SettingHint>
               {t("settings.sshDebugLogs.hint")}
-            </p>
+            </SettingHint>
 
           <SectionHeader title={t("settings.globalHotkey.title")} />
             <SettingCard className="space-y-4 py-4">
@@ -1258,9 +1258,9 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
               </SettingRow>
             </SettingCard>
 
-            <p className="text-xs text-muted-foreground">
+            <SettingHint>
               {t("settings.globalHotkey.hint")}
-            </p>
+            </SettingHint>
     </SettingsTabContent>
   );
 };


### PR DESCRIPTION
## Summary

Footer notes on Settings → System (for example “崩溃日志保留 30 天，超期自动清理”) sat too close to the card above, especially when the card and hint were wrapped together in `SettingsAnchor` and skipped the page `space-y-6` gap.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Add a shared `SettingHint` with `mt-3`.
- Use it for every system-tab footer note: updates, proxy, crash logs, temp files, session logs, SSH debug logs, and global hotkey.

## Screenshots / Demo

The hint under Crash Logs now has a clear gap above it. Same spacing on the other system sections that use the same footer note.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Ran `node --test --import tsx components/settings/settingsFocus.test.ts` and eslint on the touched files.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)