### PR TITLE
fix(sftp): treat IPC-wrapped lstat absence as no conflict

### DIFF
--- a/application/state/sftp/errors.test.ts
+++ b/application/state/sftp/errors.test.ts
@@ -11,6 +11,19 @@ test("isMissingStatError accepts only true path absence codes", () => {
   assert.equal(isMissingStatError(new Error("ENOENT")), true);
 });
 
+test("isMissingStatError treats Electron-wrapped SFTP absence as missing", () => {
+  // ipcRenderer.invoke strips custom `code` and wraps the ssh2 message.
+  // New-file uploads lstat the destination first; this is the toast users see.
+  assert.equal(
+    isMissingStatError(
+      new Error("Error invoking remote method 'netcatty:sftp:lstat': Error: No such file"),
+    ),
+    true,
+  );
+  assert.equal(isMissingStatError(new Error("No such file")), true);
+  assert.equal(isMissingStatError(new Error("No such file or directory")), true);
+});
+
 test("isMissingStatError rejects unsupported LSTAT and other failures", () => {
   const enotsup = new Error("Remote server does not support LSTAT") as Error & {
     code: string;
@@ -24,4 +37,10 @@ test("isMissingStatError rejects unsupported LSTAT and other failures", () => {
   eperm.code = "EPERM";
   assert.equal(isMissingStatError(eperm), false);
   assert.equal(isMissingStatError(new Error("channel closed")), false);
+  assert.equal(
+    isMissingStatError(
+      new Error("Error invoking remote method 'netcatty:sftp:lstat': Error: Permission denied"),
+    ),
+    false,
+  );
 });

--- a/application/state/sftp/errors.test.ts
+++ b/application/state/sftp/errors.test.ts
@@ -22,6 +22,11 @@ test("isMissingStatError treats Electron-wrapped SFTP absence as missing", () =>
   );
   assert.equal(isMissingStatError(new Error("No such file")), true);
   assert.equal(isMissingStatError(new Error("No such file or directory")), true);
+  assert.equal(isMissingStatError(new Error("No such file: /tmp/tool.sh")), true);
+  assert.equal(
+    isMissingStatError(new Error("ENOENT: no such file or directory, lstat '/tmp/tool.sh'")),
+    true,
+  );
 });
 
 test("isMissingStatError rejects unsupported LSTAT and other failures", () => {
@@ -40,6 +45,21 @@ test("isMissingStatError rejects unsupported LSTAT and other failures", () => {
   assert.equal(
     isMissingStatError(
       new Error("Error invoking remote method 'netcatty:sftp:lstat': Error: Permission denied"),
+    ),
+    false,
+  );
+  // Path names are user-controlled; do not treat a substring hit as absence.
+  assert.equal(
+    isMissingStatError(
+      new Error("EACCES: permission denied, lstat '/private/enoent/report.txt'"),
+    ),
+    false,
+  );
+  assert.equal(
+    isMissingStatError(
+      new Error(
+        "Error invoking remote method 'netcatty:sftp:lstat': Error: EACCES: permission denied, lstat '/private/enoent/report.txt'",
+      ),
     ),
     false,
   );

--- a/application/state/sftp/errors.ts
+++ b/application/state/sftp/errors.ts
@@ -18,12 +18,4 @@ export const isSessionError = (err: unknown): boolean => {
   );
 };
 
-/** True absence only — ENOTSUP / unknown inspection must not map to "no conflict". */
-export const isMissingStatError = (error: unknown): boolean => {
-  const code = (error as { code?: string | number } | null)?.code;
-  return code === 2
-    || code === "ENOENT"
-    || code === "NO_SUCH_FILE"
-    || code === "SSH_FX_NO_SUCH_FILE"
-    || String((error as { message?: string } | null)?.message || "").trim() === "ENOENT";
-};
+export { isMissingStatError } from "../../../domain/sftpStatError";

--- a/application/state/uploadService.test.ts
+++ b/application/state/uploadService.test.ts
@@ -659,6 +659,39 @@ test("ENOENT from lstat still means absent destination for conflict check", asyn
   assert.equal(results[0].success, true);
 });
 
+test("Electron-wrapped lstat absence still means absent destination", async () => {
+  const file = new File(["new-bytes"], "tool.sh", { lastModified: 1234 });
+  Object.defineProperty(file, "path", { value: "/local/tool.sh" });
+  const uploadedPaths: string[] = [];
+
+  const results = await uploadFromFileList(
+    [file],
+    {
+      targetPath: "/usr/local/bin",
+      sftpId: "sftp-1",
+      isLocal: false,
+      bridge: {
+        mkdirSftp: async () => {},
+        lstatSftp: async () => {
+          throw new Error("Error invoking remote method 'netcatty:sftp:lstat': Error: No such file");
+        },
+        startStreamTransfer: async ({ targetPath: path }) => {
+          uploadedPaths.push(path);
+          return { transferId: "upload-1" };
+        },
+      },
+      joinPath: (base, name) => `${base}/${name}`,
+      resolveConflict: async () => {
+        throw new Error("absent destination must not prompt for conflict");
+      },
+    },
+  );
+
+  assert.deepEqual(uploadedPaths, ["/usr/local/bin/tool.sh"]);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].success, true);
+});
+
 test("compressed-upload LSTAT ENOTSUP is not treated as an absent destination", async (t) => {
   let compressedStarts = 0;
   installCompressedUploadBridge(t, {

--- a/domain/sftpStatError.test.ts
+++ b/domain/sftpStatError.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isMissingStatError } from "./sftpStatError";
+
+test("isMissingStatError recognizes ssh2 and Electron-wrapped absence", () => {
+  assert.equal(isMissingStatError(new Error("No such file")), true);
+  assert.equal(
+    isMissingStatError(
+      new Error("Error invoking remote method 'netcatty:sftp:lstat': Error: No such file"),
+    ),
+    true,
+  );
+});

--- a/domain/sftpStatError.test.ts
+++ b/domain/sftpStatError.test.ts
@@ -11,3 +11,12 @@ test("isMissingStatError recognizes ssh2 and Electron-wrapped absence", () => {
     true,
   );
 });
+
+test("isMissingStatError does not treat path substrings as absence", () => {
+  assert.equal(
+    isMissingStatError(
+      new Error("EACCES: permission denied, lstat '/private/enoent/report.txt'"),
+    ),
+    false,
+  );
+});

--- a/domain/sftpStatError.ts
+++ b/domain/sftpStatError.ts
@@ -1,3 +1,11 @@
+const ELECTRON_INVOKE_PREFIX = /^error invoking remote method '[^']+': error:\s*/i;
+
+/** ssh2 / Node / SCP absence kinds. Must not search the whole message: paths are user-controlled. */
+const ABSENCE_KIND = /^(?:enoent|no such file(?: or directory)?|no_such_file|ssh_fx_no_such_file)(?:\b|:|$)/;
+
+const unwrapStatErrorMessage = (message: string): string =>
+  message.replace(ELECTRON_INVOKE_PREFIX, "").trim();
+
 /** True absence only — ENOTSUP / unknown inspection must not map to "no conflict". */
 export const isMissingStatError = (error: unknown): boolean => {
   const code = (error as { code?: string | number } | null)?.code;
@@ -18,11 +26,5 @@ export const isMissingStatError = (error: unknown): boolean => {
   // ssh2 StatusCodeError is "No such file". ipcRenderer.invoke strips `code`
   // and wraps it as:
   // Error invoking remote method 'netcatty:sftp:lstat': Error: No such file
-  return (
-    message === "enoent"
-    || message.includes("enoent")
-    || message.includes("no such file")
-    || message.includes("no_such_file")
-    || message.includes("ssh_fx_no_such_file")
-  );
+  return ABSENCE_KIND.test(unwrapStatErrorMessage(message));
 };

--- a/domain/sftpStatError.ts
+++ b/domain/sftpStatError.ts
@@ -1,0 +1,28 @@
+/** True absence only — ENOTSUP / unknown inspection must not map to "no conflict". */
+export const isMissingStatError = (error: unknown): boolean => {
+  const code = (error as { code?: string | number } | null)?.code;
+  if (
+    code === 2
+    || code === "ENOENT"
+    || code === "NO_SUCH_FILE"
+    || code === "SSH_FX_NO_SUCH_FILE"
+  ) {
+    return true;
+  }
+
+  const message = String((error as { message?: string } | null)?.message || "")
+    .trim()
+    .toLowerCase();
+  if (!message) return false;
+
+  // ssh2 StatusCodeError is "No such file". ipcRenderer.invoke strips `code`
+  // and wraps it as:
+  // Error invoking remote method 'netcatty:sftp:lstat': Error: No such file
+  return (
+    message === "enoent"
+    || message.includes("enoent")
+    || message.includes("no such file")
+    || message.includes("no_such_file")
+    || message.includes("ssh_fx_no_such_file")
+  );
+};

--- a/electron/bridges/sftpBridge/fileOps.cjs
+++ b/electron/bridges/sftpBridge/fileOps.cjs
@@ -27,6 +27,15 @@ function createSftpReadTimeoutError(timeoutMs) {
   return error;
 }
 
+/** ssh2 / SCP absence — classify here so IPC cannot strip `code`. */
+function isMissingRemotePathError(error) {
+  const code = error?.code;
+  return code === 2
+    || code === "ENOENT"
+    || code === "NO_SUCH_FILE"
+    || code === "SSH_FX_NO_SUCH_FILE";
+}
+
 async function runBoundedSftpMemoryRead(payload, operation) {
   const requestedTimeout = Number(payload?.timeoutMs);
   const timeoutMs = Number.isFinite(requestedTimeout) && requestedTimeout > 0
@@ -923,15 +932,20 @@ function createFileOpsApi(ctx) {
       if (isScpModeClient(client)) {
         // SCP shell stat already reports the link node (no follow).
         const encoding = resolveEncodingForRequest(payload.sftpId, payload.encoding);
-        const st = await getScpBackendForClient(client).stat(payload.path, {
-          encoding,
-          signal: payload?.abortSignal || null,
-        });
-        return formatSftpStatResult(
-          payload.path,
-          st,
-          st.mode ? (st.mode & 0o777).toString(8) : st.permissions,
-        );
+        try {
+          const st = await getScpBackendForClient(client).stat(payload.path, {
+            encoding,
+            signal: payload?.abortSignal || null,
+          });
+          return formatSftpStatResult(
+            payload.path,
+            st,
+            st.mode ? (st.mode & 0o777).toString(8) : st.permissions,
+          );
+        } catch (error) {
+          if (isMissingRemotePathError(error)) return null;
+          throw error;
+        }
       }
 
       const sftp = await requireSftpChannel(client);
@@ -949,6 +963,9 @@ function createFileOpsApi(ctx) {
       try {
         attrs = await lstatAsync(sftp, encodedPath);
       } catch (error) {
+        // Return null before throw so ipcRenderer.invoke cannot strip code 2
+        // and leave a localized "File not found" as a hard upload error.
+        if (isMissingRemotePathError(error)) return null;
         const code = error?.code;
         const lstatUnsupported = code === 8
           || code === "ENOTSUP"

--- a/electron/bridges/sftpBridge/fileOps.test.cjs
+++ b/electron/bridges/sftpBridge/fileOps.test.cjs
@@ -212,6 +212,51 @@ test("lstatSftp refuses followed STAT when LSTAT is unsupported", async () => {
   assert.equal(statCalls, 0, "must not classify via followed STAT");
 });
 
+test("lstatSftp returns null for SSH_FX_NO_SUCH_FILE even with a localized message", async () => {
+  const channel = { lstat() {} };
+  const api = createFileOpsApi({
+    sftpClients: new Map([["sftp-1", { sftp: channel }]]),
+    requireSftpChannel: async () => channel,
+    resolveEncodingForRequest: () => "utf-8",
+    encodePath: (remotePath) => remotePath,
+    lstatAsync: async () => {
+      const error = new Error("File not found");
+      error.code = 2;
+      throw error;
+    },
+  });
+
+  const result = await api.lstatSftp(null, {
+    sftpId: "sftp-1",
+    path: "/usr/local/bin/new-file.sh",
+  });
+  assert.equal(result, null);
+});
+
+test("lstatSftp still throws permission errors on an existing path", async () => {
+  const channel = { lstat() {} };
+  const api = createFileOpsApi({
+    sftpClients: new Map([["sftp-1", { sftp: channel }]]),
+    requireSftpChannel: async () => channel,
+    resolveEncodingForRequest: () => "utf-8",
+    encodePath: (remotePath) => remotePath,
+    lstatAsync: async () => {
+      const error = new Error("Permission denied");
+      error.code = "EACCES";
+      throw error;
+    },
+  });
+
+  await assert.rejects(
+    () => api.lstatSftp(null, { sftpId: "sftp-1", path: "/root/secret" }),
+    (error) => {
+      assert.equal(error.code, "EACCES");
+      assert.match(String(error.message), /Permission denied/);
+      return true;
+    },
+  );
+});
+
 test("lstatSftp refuses a channel without native LSTAT", async () => {
   const channel = { stat() {} };
   let lstatCalls = 0;

--- a/lib/uploadService.ts
+++ b/lib/uploadService.ts
@@ -15,6 +15,7 @@ import {
   describeSftpIncomingKind,
   getSftpConflictTypeKey,
 } from "../domain/sftpConflict";
+import { isMissingStatError } from "../domain/sftpStatError";
 
 // ============================================================================
 // Types
@@ -36,16 +37,6 @@ import type { UploadBridge, UploadCallbacks, UploadConfig, UploadResult } from "
 
 const formatUploadError = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
-
-/** Only true absence may map to "no conflict"; ENOTSUP/etc. must not. */
-const isMissingStatError = (error: unknown): boolean => {
-  const code = (error as { code?: string | number } | null)?.code;
-  return code === 2
-    || code === "ENOENT"
-    || code === "NO_SUCH_FILE"
-    || code === "SSH_FX_NO_SUCH_FILE"
-    || String((error as { message?: string } | null)?.message || "").trim() === "ENOENT";
-};
 
 const getDropEntrySize = (entry: DropEntry): number => (
   entry.isDirectory ? 0 : entry.file?.size ?? entry.size ?? 0

--- a/types/global/netcatty-bridge-sftp.d.ts
+++ b/types/global/netcatty-bridge-sftp.d.ts
@@ -23,8 +23,8 @@ declare global {
     ): Promise<void>;
     renameSftp?(sftpId: string, oldPath: string, newPath: string, encoding?: SftpFilenameEncoding): Promise<void>;
     statSftp?(sftpId: string, path: string, encoding?: SftpFilenameEncoding): Promise<SftpStatResult>;
-    /** No-follow remote metadata for conflict detection (symlink vs target). */
-    lstatSftp?(sftpId: string, path: string, encoding?: SftpFilenameEncoding): Promise<SftpStatResult>;
+    /** No-follow remote metadata for conflict detection (symlink vs target). Missing path → null. */
+    lstatSftp?(sftpId: string, path: string, encoding?: SftpFilenameEncoding): Promise<SftpStatResult | null>;
     chmodSftp?(sftpId: string, path: string, mode: string, encoding?: SftpFilenameEncoding): Promise<void>;
     getSftpHomeDir?(sftpId: string, encoding?: SftpFilenameEncoding): Promise<{ success: boolean; homeDir?: string; error?: string }>;
 


### PR DESCRIPTION
## Summary

SFTP uploads of new files now fail 100% of the time with:

`Error invoking remote method 'netcatty:sftp:lstat': Error: No such file`

After #2955, conflict checks `lstat` the destination so Replace can unlink a symlink instead of writing through it. A new file's destination is absent, so ssh2 throws `No such file` with `code: ENOENT`. `ipcRenderer.invoke` strips that `code` and wraps the message. `isMissingStatError` only accepted absence codes or the exact message `ENOENT`, so "file does not exist yet" became a hard error toast.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Recognize ssh2 `No such file` and the Electron invoke wrap as true path absence.
- Keep a single `isMissingStatError` in `domain/` so upload and transfer conflict checks cannot drift.
- Leave ENOTSUP / permission / session failures fail-closed.

## Screenshots / Demo

New-file SFTP upload proceeds instead of toasting the wrapped lstat absence. Existing-file conflict prompts are unchanged.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Ran `node --test --import tsx application/state/sftp/errors.test.ts application/state/uploadService.test.ts domain/sftpStatError.test.ts` (31 pass) and eslint on the touched files.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)