### PR TITLE
fix(dev): do not reload the app on stale Vite optimize 504s

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,9 +18,14 @@ const suppressMonacoSourcemapWarning = () => ({
   },
 });
 
-/** After git pull / npm install, stale pre-bundles return 504; force a full reload. */
-const reloadOnOutdatedOptimizeDep = (): Plugin => ({
-  name: 'reload-on-outdated-optimize-dep',
+/**
+ * Stale pre-bundles return 504 after git pull / npm install. Vite retries the
+ * module once optimize finishes — do not full-reload the Electron window.
+ * Opening the lazy AI panel pulls `ai` / streamdown; a 504 there used to flash
+ * the boot splash and wipe renderer state.
+ */
+const warnOnOutdatedOptimizeDep = (): Plugin => ({
+  name: 'warn-on-outdated-optimize-dep',
   apply: 'serve',
   configureServer(server) {
     server.middlewares.use((req, res, next) => {
@@ -29,7 +34,9 @@ const reloadOnOutdatedOptimizeDep = (): Plugin => ({
           res.statusCode === 504
           && req.url?.includes('/node_modules/.vite/deps/')
         ) {
-          server.ws.send({ type: 'full-reload', path: '*' });
+          server.config.logger.warn(
+            `[vite] stale optimize dep 504 for ${req.url} (not reloading the app)`,
+          );
         }
       });
       next();
@@ -92,7 +99,19 @@ export default defineConfig(() => {
           },
         },
       },
-      plugins: [suppressMonacoSourcemapWarning(), reloadOnOutdatedOptimizeDep(), tailwindcss(), react()],
+      plugins: [suppressMonacoSourcemapWarning(), warnOnOutdatedOptimizeDep(), tailwindcss(), react()],
+      optimizeDeps: {
+        include: [
+          'ai',
+          '@ai-sdk/openai',
+          '@ai-sdk/anthropic',
+          '@ai-sdk/google',
+          'streamdown',
+          '@streamdown/cjk',
+          '@streamdown/code',
+          'zod',
+        ],
+      },
       resolve: {
         alias: {
           '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
## Summary

In `npm run dev`, opening the AI chat panel could full-reload the Electron window and show the boot splash. The serve plugin treated a stale Vite optimize-dep 504 as a reason to `full-reload` the whole page. The AI panel is lazy-loaded, so that 504 often happened on first open after a pull or a cold pre-bundle.

Production packages are unaffected (`apply: 'serve'` only).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Stop sending Vite `full-reload` on `/node_modules/.vite/deps/` 504; log a warning and let Vite retry the module.
- Pre-optimize `ai`, the Google/OpenAI/Anthropic SDK packages, streamdown, and `zod` so the first AI-panel open is less likely to 504.

## Screenshots / Demo

Opening AI Chat in `npm run dev` no longer flashes the startup logo or remounts the whole app.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Reproduced the splash reload on AI panel open, then confirmed it is a document reload (not a renderer crash). eslint on `vite.config.ts`.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)