### PR TITLE
fix(ai): stop first-type hitch after expanding the chat panel

### DIFF
--- a/application/state/aiDraftState.test.ts
+++ b/application/state/aiDraftState.test.ts
@@ -18,7 +18,59 @@ import {
   setDraftView,
   setSessionView,
   updateDraftForScope,
+  draftsByScopeEqualIgnoringComposerText,
+  draftsByScopeEqualIgnoringAllComposerText,
 } from "./aiDraftState.ts";
+
+test("draftsByScopeEqualIgnoringComposerText ignores typing in the active scope", () => {
+  const base = createEmptyDraft("catty");
+  const prev = { "terminal:1": { ...base, text: "" } };
+  const next = { "terminal:1": { ...base, text: "你好", updatedAt: base.updatedAt + 1 } };
+  assert.equal(draftsByScopeEqualIgnoringComposerText(prev, next, "terminal:1"), true);
+  assert.equal(
+    draftsByScopeEqualIgnoringComposerText(
+      prev,
+      { "terminal:1": { ...base, text: "你好", attachments: [{ id: "a" } as never] } },
+      "terminal:1",
+    ),
+    false,
+  );
+  assert.equal(
+    draftsByScopeEqualIgnoringComposerText(
+      prev,
+      { "terminal:1": prev["terminal:1"], "workspace:2": base },
+      "terminal:1",
+    ),
+    false,
+  );
+});
+
+test("draftsByScopeEqualIgnoringAllComposerText ignores typing in every scope", () => {
+  const base = createEmptyDraft("catty");
+  const prev = {
+    "terminal:1": { ...base, text: "a" },
+    "terminal:2": { ...base, text: "b", attachments: [] },
+  };
+  const next = {
+    "terminal:1": { ...prev["terminal:1"], text: "aa", updatedAt: base.updatedAt + 1 },
+    "terminal:2": { ...prev["terminal:2"], text: "bb", updatedAt: base.updatedAt + 2 },
+  };
+  assert.equal(draftsByScopeEqualIgnoringAllComposerText(prev, next), true);
+  assert.equal(
+    draftsByScopeEqualIgnoringAllComposerText(prev, {
+      ...next,
+      "terminal:2": { ...next["terminal:2"], attachments: [{ id: "a" } as never] },
+    }),
+    false,
+  );
+});
+
+test("updateDraftForScope keeps the original map when the updater is a no-op", () => {
+  const draft = createEmptyDraft("catty");
+  const prev = { "terminal:1": draft };
+  const next = updateDraftForScope(prev, "terminal:1", "catty", (current) => current);
+  assert.equal(next, prev);
+});
 
 test("createEmptyDraft seeds selected agent and empty inputs", () => {
   const draft = createEmptyDraft("agent-alpha");

--- a/application/state/aiDraftState.ts
+++ b/application/state/aiDraftState.ts
@@ -11,6 +11,49 @@ type DraftUploadGenerationByScope = Record<string, number>;
 
 const DEFAULT_PANEL_VIEW: AIPanelView = { mode: 'draft' };
 
+/** Typing only changes text/updatedAt. Panel chrome can ignore that identity churn. */
+export function draftsByScopeEqualIgnoringComposerText(
+  prev: DraftsByScope,
+  next: DraftsByScope,
+  scopeKey: string,
+): boolean {
+  if (prev === next) return true;
+  const keys = new Set([...Object.keys(prev), ...Object.keys(next)]);
+  for (const key of keys) {
+    const left = prev[key];
+    const right = next[key];
+    if (key !== scopeKey) {
+      if (left !== right) return false;
+      continue;
+    }
+    if (left === right) continue;
+    if (!left || !right) return false;
+    if (left.agentId !== right.agentId) return false;
+    if (left.attachments !== right.attachments) return false;
+    if (left.selectedUserSkillSlugs !== right.selectedUserSkillSlugs) return false;
+  }
+  return true;
+}
+
+/** True when every scope is unchanged except composer text/updatedAt. */
+export function draftsByScopeEqualIgnoringAllComposerText(
+  prev: DraftsByScope,
+  next: DraftsByScope,
+): boolean {
+  if (prev === next) return true;
+  const keys = new Set([...Object.keys(prev), ...Object.keys(next)]);
+  for (const key of keys) {
+    const left = prev[key];
+    const right = next[key];
+    if (left === right) continue;
+    if (!left || !right) return false;
+    if (left.agentId !== right.agentId) return false;
+    if (left.attachments !== right.attachments) return false;
+    if (left.selectedUserSkillSlugs !== right.selectedUserSkillSlugs) return false;
+  }
+  return true;
+}
+
 export function createEmptyDraft(agentId: string): AIDraft {
   return {
     text: '',
@@ -142,6 +185,9 @@ export function updateDraftForScope(
 ): DraftsByScope {
   const currentDraft = draftsByScope[scopeKey] ?? createEmptyDraft(fallbackAgentId);
   const nextDraft = updater(currentDraft);
+  if (nextDraft === currentDraft && draftsByScope[scopeKey] === currentDraft) {
+    return draftsByScope;
+  }
 
   return {
     ...draftsByScope,

--- a/application/state/aiSessionsStore.test.ts
+++ b/application/state/aiSessionsStore.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createEmptyDraft } from './aiDraftState.ts';
+import { aiSessionsStore } from './aiSessionsStore.ts';
+
+test('AI sessions store does not notify listeners when only composer text changes', () => {
+  const previous = aiSessionsStore.getSnapshot();
+  const draft = createEmptyDraft('catty');
+  const base = {
+    sessions: Object.freeze([]),
+    activeSessionIdMap: Object.freeze({}),
+    draftsByScope: { 'terminal:1': draft },
+    panelViewByScope: {},
+  };
+
+  try {
+    aiSessionsStore.setSnapshot(base);
+
+    let notified = 0;
+    const unsubscribe = aiSessionsStore.subscribe(() => {
+      notified += 1;
+    });
+
+    aiSessionsStore.setSnapshot({
+      ...base,
+      draftsByScope: {
+        'terminal:1': { ...draft, text: 'hello', updatedAt: draft.updatedAt + 1 },
+      },
+    });
+    assert.equal(notified, 0);
+    assert.equal(aiSessionsStore.getSnapshot().draftsByScope['terminal:1']?.text, 'hello');
+
+    aiSessionsStore.setSnapshot({
+      ...base,
+      draftsByScope: {
+        'terminal:1': { ...draft, text: 'hello', attachments: [{ id: 'a' } as never] },
+      },
+    });
+    assert.equal(notified, 1);
+    unsubscribe();
+  } finally {
+    aiSessionsStore.setSnapshot(previous);
+  }
+});

--- a/application/state/aiSessionsStore.ts
+++ b/application/state/aiSessionsStore.ts
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from 'react';
 
 import type { AISession } from '../../infrastructure/ai/types';
+import { draftsByScopeEqualIgnoringAllComposerText } from './aiDraftState';
 import type { DraftsByScope, PanelViewByScope } from './aiStateSnapshots';
 
 type Listener = () => void;
@@ -50,7 +51,16 @@ class AISessionsStore {
     ) {
       return;
     }
+    const textOnlyDraftChange =
+      this.snapshot.sessions === next.sessions
+      && this.snapshot.activeSessionIdMap === next.activeSessionIdMap
+      && this.snapshot.panelViewByScope === next.panelViewByScope
+      && draftsByScopeEqualIgnoringAllComposerText(
+        this.snapshot.draftsByScope,
+        next.draftsByScope,
+      );
     this.snapshot = next;
+    if (textOnlyDraftChange) return;
     for (const listener of this.listeners) {
       listener();
     }

--- a/application/state/useAIState.ts
+++ b/application/state/useAIState.ts
@@ -812,12 +812,15 @@ export function useAIState() {
         scopeKey,
         fallbackAgentId,
         (draft) => {
+          const updated = updater(draft);
+          if (updated === draft) return draft;
           return {
-            ...updater(draft),
+            ...updated,
             updatedAt: Date.now(),
           };
         },
       );
+      if (next === prev) return prev;
       setLatestAIDraftsByScopeSnapshot(next);
       emitAIStateChanged(AI_STATE_CHANGED_DRAFTS_BY_SCOPE);
       return next;

--- a/application/state/useAgentDiscovery.ts
+++ b/application/state/useAgentDiscovery.ts
@@ -22,10 +22,16 @@ let agentDiscoveryWriteGeneration = 0;
 export function useAgentDiscovery(
   externalAgents: ExternalAgentConfig[],
   setExternalAgents?: (value: ExternalAgentConfig[] | ((prev: ExternalAgentConfig[]) => ExternalAgentConfig[])) => void,
-  options?: { enabled?: boolean },
+  options?: {
+    enabled?: boolean;
+    schedule?: (task: () => void) => () => void;
+  },
 ) {
   const enabled = options?.enabled ?? true;
-  const [discoveredAgents, setDiscoveredAgents] = useState<DiscoveredAgent[]>([]);
+  const schedule = options?.schedule;
+  const [discoveredAgents, setDiscoveredAgents] = useState<DiscoveredAgent[]>(
+    () => agentDiscoveryCache?.agents ?? [],
+  );
   const [isDiscovering, setIsDiscovering] = useState(false);
   const discoverSeqRef = useRef(0);
   const mountedRef = useRef(true);
@@ -116,8 +122,16 @@ export function useAgentDiscovery(
       if (!cancelled) void discover();
     };
 
+    if (schedule) {
+      const cancel = schedule(runDiscover);
+      return () => {
+        cancelled = true;
+        cancel();
+      };
+    }
+
     if (typeof requestIdleCallback === 'function') {
-      const idleId = requestIdleCallback(runDiscover, { timeout: 2000 });
+      const idleId = requestIdleCallback(runDiscover);
       return () => {
         cancelled = true;
         cancelIdleCallback(idleId);
@@ -129,7 +143,7 @@ export function useAgentDiscovery(
       cancelled = true;
       clearTimeout(timeoutId);
     };
-  }, [discover, enabled]);
+  }, [discover, enabled, schedule]);
 
   // Auto-update args for already-configured discovered agents when
   // the canonical args from discovery change (e.g. after an app update).

--- a/components/AIChatPanelContent.tsx
+++ b/components/AIChatPanelContent.tsx
@@ -91,6 +91,8 @@ interface AIChatPanelContentProps {
   onOpenVaultSection?: (section: 'notes' | 'hosts') => void;
   /** Hidden retained panels keep the composer warm without the message tree. */
   parked?: boolean;
+  /** Disable header transitions while send preflight is in flight. */
+  sending?: boolean;
 }
 
 export const AIChatPanelContent: React.FC<AIChatPanelContentProps> = ({
@@ -155,6 +157,7 @@ export const AIChatPanelContent: React.FC<AIChatPanelContentProps> = ({
   onOpenVaultHost,
   onOpenVaultSection,
   parked = false,
+  sending = false,
 }) => {
   const hiddenParts = getAIPanelDiagnosticHiddenParts();
   const hideHeader = isAIPanelDiagnosticPartHidden('header', hiddenParts);
@@ -178,6 +181,7 @@ export const AIChatPanelContent: React.FC<AIChatPanelContentProps> = ({
               discoveredAgents={discoveredAgents}
               isDiscovering={isDiscovering}
               parked={parked}
+              disabled={sending}
               onSelectAgent={handleAgentChange}
               onEnableDiscoveredAgent={handleEnableDiscoveredAgent}
               onRediscover={rediscover}
@@ -195,6 +199,7 @@ export const AIChatPanelContent: React.FC<AIChatPanelContentProps> = ({
                     variant="ghost"
                     size="icon"
                     className="h-6 w-6 rounded-md text-muted-foreground/62 hover:bg-white/[0.05] hover:text-foreground"
+                    disabled={sending}
                     onClick={() => setShowHistory(!showHistory)}
                   >
                     <History size={12} />
@@ -208,6 +213,7 @@ export const AIChatPanelContent: React.FC<AIChatPanelContentProps> = ({
                     variant="ghost"
                     size="icon"
                     className="h-6 w-6 rounded-md text-primary/82 hover:bg-primary/[0.10] hover:text-primary"
+                    disabled={sending}
                     onClick={handleNewChat}
                   >
                     <Plus size={13} />
@@ -226,7 +232,7 @@ export const AIChatPanelContent: React.FC<AIChatPanelContentProps> = ({
           <SessionHistoryDrawer
             sessions={historySessions}
             activeSessionId={activeSessionId}
-            onSelect={handleSelectSession}
+            onSelect={sending ? () => undefined : handleSelectSession}
             onDelete={handleDeleteSession}
             onClose={() => setShowHistory(false)}
           />
@@ -266,8 +272,9 @@ export const AIChatPanelContent: React.FC<AIChatPanelContentProps> = ({
                 {historySessions.slice(0, 3).map((session) => (
                   <button
                     key={session.id}
+                    disabled={sending}
                     onClick={() => handleSelectSession(session.id)}
-                    className="w-full flex items-baseline justify-between py-1.5 text-left hover:text-foreground transition-colors cursor-pointer"
+                    className="w-full flex items-baseline justify-between py-1.5 text-left hover:text-foreground transition-colors cursor-pointer disabled:pointer-events-none disabled:opacity-50"
                   >
                     <span className="text-[13px] text-foreground/60 truncate pr-4">
                       {session.title || t('ai.chat.untitled')}

--- a/components/AIChatPanelContent.tsx
+++ b/components/AIChatPanelContent.tsx
@@ -89,6 +89,8 @@ interface AIChatPanelContentProps {
   onOpenVaultNote?: (noteId: string) => void;
   onOpenVaultHost?: (hostId: string) => void;
   onOpenVaultSection?: (section: 'notes' | 'hosts') => void;
+  /** Hidden retained panels keep the composer warm without the message tree. */
+  parked?: boolean;
 }
 
 export const AIChatPanelContent: React.FC<AIChatPanelContentProps> = ({
@@ -152,6 +154,7 @@ export const AIChatPanelContent: React.FC<AIChatPanelContentProps> = ({
   onOpenVaultNote,
   onOpenVaultHost,
   onOpenVaultSection,
+  parked = false,
 }) => {
   const hiddenParts = getAIPanelDiagnosticHiddenParts();
   const hideHeader = isAIPanelDiagnosticPartHidden('header', hiddenParts);
@@ -217,7 +220,7 @@ export const AIChatPanelContent: React.FC<AIChatPanelContentProps> = ({
       )}
 
       {/* ── Main content ── */}
-      {showHistory && !hideHistory ? (
+      {!parked && showHistory && !hideHistory ? (
         <React.Profiler {...getAIPanelProfilerProps('AIChatPanel.History')}>
           <SessionHistoryDrawer
             sessions={historySessions}
@@ -230,7 +233,7 @@ export const AIChatPanelContent: React.FC<AIChatPanelContentProps> = ({
       ) : (
         <>
           {/* Chat messages */}
-          {!hideMessages && (
+          {!parked && !hideMessages && (
             <React.Profiler {...getAIPanelProfilerProps('AIChatPanel.Messages')}>
               <ChatMessageList
                 messages={messages}
@@ -247,7 +250,7 @@ export const AIChatPanelContent: React.FC<AIChatPanelContentProps> = ({
           )}
 
           {/* Recent sessions (Zed-style, shown when no messages) */}
-          {messages.length === 0 && historySessions.length > 0 && !hideRecent && (
+          {!parked && messages.length === 0 && historySessions.length > 0 && !hideRecent && (
             <React.Profiler {...getAIPanelProfilerProps('AIChatPanel.Recent')}>
               <div className="shrink-0 px-4 pb-1">
                 <div className="flex items-baseline justify-between mb-2">

--- a/components/AIChatPanelContent.tsx
+++ b/components/AIChatPanelContent.tsx
@@ -177,6 +177,7 @@ export const AIChatPanelContent: React.FC<AIChatPanelContentProps> = ({
               externalAgents={externalAgents}
               discoveredAgents={discoveredAgents}
               isDiscovering={isDiscovering}
+              parked={parked}
               onSelectAgent={handleAgentChange}
               onEnableDiscoveredAgent={handleEnableDiscoveredAgent}
               onRediscover={rediscover}
@@ -294,6 +295,7 @@ export const AIChatPanelContent: React.FC<AIChatPanelContentProps> = ({
                   </div>
                 ) : null}
                 <ChatInput
+                  parked={parked}
                   value={inputValue}
                   onChange={setInputValue}
                   onSend={handleSend}

--- a/components/AIChatSidePanel.mountRetention.test.ts
+++ b/components/AIChatSidePanel.mountRetention.test.ts
@@ -109,6 +109,12 @@ const baseProps = (overrides: Partial<AIChatSidePanelProps> = {}): AIChatSidePan
   ...overrides,
 });
 
+test('first send awaits provider sync instead of idle-deferring it', () => {
+  const source = readFileSync(new URL('./AIChatSidePanel.tsx', import.meta.url), 'utf8');
+  assert.match(source, /await sendBridge\.aiSyncProviders\(providers\)/);
+  assert.doesNotMatch(source, /scheduleWhenAiComposerIdle\(\(\) => \{\s*void bridge\.aiSyncProviders/);
+});
+
 test('send and new chat discard pending composer text', () => {
   const source = readFileSync(new URL('./AIChatSidePanel.tsx', import.meta.url), 'utf8');
   assert.match(source, /discardPendingComposerText/);

--- a/components/AIChatSidePanel.mountRetention.test.ts
+++ b/components/AIChatSidePanel.mountRetention.test.ts
@@ -184,7 +184,7 @@ test('AI side panel re-renders when retained content becomes visible again', () 
   ), false);
 });
 
-test('hidden retained AI side panel skips chat input and message content', () => {
+test('hidden retained AI side panel keeps the composer and skips message content', () => {
   const markup = renderToStaticMarkup(
     React.createElement(
       I18nProvider,
@@ -212,10 +212,9 @@ test('hidden retained AI side panel skips chat input and message content', () =>
   );
 
   assert.match(markup, /data-section="ai-chat-panel-retained"/);
-  assert.doesNotMatch(markup, /textarea/);
+  assert.match(markup, /textarea/);
   assert.doesNotMatch(markup, /hidden-user-message/);
   assert.doesNotMatch(markup, /hidden-assistant-message/);
-  assert.doesNotMatch(markup, /draft still retained/);
 });
 
 test('AI side panel re-renders when command timeout changes', () => {
@@ -251,6 +250,25 @@ test('AI side panel skips re-render when only a sibling scope session object cha
     aiChatSidePanelPropsAreEqual(prev, { ...prev, sessions: [ownStreamed, siblingA] }),
     false,
   );
+});
+
+test('AI side panel skips re-render when only the composer draft text changes', () => {
+  const empty = draft({ text: '' });
+  const prev = baseProps({
+    isVisible: true,
+    scopeType: 'terminal',
+    scopeTargetId: 'terminal-1',
+    draftsByScope: {
+      'terminal:terminal-1': empty,
+    },
+  });
+  const next = {
+    ...prev,
+    draftsByScope: {
+      'terminal:terminal-1': { ...empty, text: '你好', updatedAt: 2 },
+    },
+  };
+  assert.equal(aiChatSidePanelPropsAreEqual(prev, next), true);
 });
 
 test('workspace AI panel memo follows visible inherited session, not hidden terminal maps', () => {

--- a/components/AIChatSidePanel.mountRetention.test.ts
+++ b/components/AIChatSidePanel.mountRetention.test.ts
@@ -112,13 +112,14 @@ const baseProps = (overrides: Partial<AIChatSidePanelProps> = {}): AIChatSidePan
 test('first send awaits provider sync instead of idle-deferring it', () => {
   const source = readFileSync(new URL('./AIChatSidePanel.tsx', import.meta.url), 'utf8');
   assert.match(source, /await sendBridge\.aiSyncProviders\(providers\)/);
+  assert.match(source, /await sendBridge\.aiSyncWebSearch\(/);
   assert.doesNotMatch(source, /scheduleWhenAiComposerIdle\(\(\) => \{\s*void bridge\.aiSyncProviders/);
 });
 
 test('send and new chat discard pending composer text', () => {
   const source = readFileSync(new URL('./AIChatSidePanel.tsx', import.meta.url), 'utf8');
   assert.match(source, /discardPendingComposerText/);
-  assert.match(source, /const clearScopeDraft = useCallback\(\(\) => \{\s*discardPendingComposerText\(\);/s);
+  assert.match(source, /if \(!options\?\.keepPendingText\) discardPendingComposerText\(\)/);
 });
 
 test('hidden empty AI side panel can release its subtree', () => {

--- a/components/AIChatSidePanel.mountRetention.test.ts
+++ b/components/AIChatSidePanel.mountRetention.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { readFileSync } from 'node:fs';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
@@ -108,6 +109,12 @@ const baseProps = (overrides: Partial<AIChatSidePanelProps> = {}): AIChatSidePan
   ...overrides,
 });
 
+test('send and new chat discard pending composer text', () => {
+  const source = readFileSync(new URL('./AIChatSidePanel.tsx', import.meta.url), 'utf8');
+  assert.match(source, /discardPendingComposerText/);
+  assert.match(source, /const clearScopeDraft = useCallback\(\(\) => \{\s*discardPendingComposerText\(\);/s);
+});
+
 test('hidden empty AI side panel can release its subtree', () => {
   const props = baseProps();
 
@@ -212,6 +219,8 @@ test('hidden retained AI side panel keeps the composer and skips message content
   );
 
   assert.match(markup, /data-section="ai-chat-panel-retained"/);
+  assert.match(markup, /inert/);
+  assert.match(markup, /aria-hidden/);
   assert.match(markup, /textarea/);
   assert.doesNotMatch(markup, /hidden-user-message/);
   assert.doesNotMatch(markup, /hidden-assistant-message/);

--- a/components/AIChatSidePanel.mountRetention.test.ts
+++ b/components/AIChatSidePanel.mountRetention.test.ts
@@ -109,6 +109,15 @@ const baseProps = (overrides: Partial<AIChatSidePanelProps> = {}): AIChatSidePan
   ...overrides,
 });
 
+test('send preflight locks header agent and new-chat controls', () => {
+  const panel = readFileSync(new URL('./AIChatSidePanel.tsx', import.meta.url), 'utf8');
+  const content = readFileSync(new URL('./AIChatPanelContent.tsx', import.meta.url), 'utf8');
+  assert.match(panel, /sending=\{isSending\}/);
+  assert.match(content, /disabled=\{sending\}/);
+  const selector = readFileSync(new URL('./ai/AgentSelector.tsx', import.meta.url), 'utf8');
+  assert.match(selector, /if \(parked \|\| disabled\) setOpen\(false\)/);
+});
+
 test('first send awaits provider sync instead of idle-deferring it', () => {
   const source = readFileSync(new URL('./AIChatSidePanel.tsx', import.meta.url), 'utf8');
   assert.match(source, /await sendBridge\.aiSyncProviders\(providers\)/);

--- a/components/AIChatSidePanel.mountRetention.test.ts
+++ b/components/AIChatSidePanel.mountRetention.test.ts
@@ -109,6 +109,12 @@ const baseProps = (overrides: Partial<AIChatSidePanelProps> = {}): AIChatSidePan
   ...overrides,
 });
 
+test('send preflight aborts after the panel unmounts or the scope changes', () => {
+  const source = readFileSync(new URL('./AIChatSidePanel.tsx', import.meta.url), 'utf8');
+  assert.match(source, /sendEpochRef/);
+  assert.match(source, /if \(isSendStale\(\)\) return;/);
+});
+
 test('send preflight locks header agent and new-chat controls', () => {
   const panel = readFileSync(new URL('./AIChatSidePanel.tsx', import.meta.url), 'utf8');
   const content = readFileSync(new URL('./AIChatPanelContent.tsx', import.meta.url), 'utf8');

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -526,9 +526,18 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     showSessionView(scopeKey, sessionId);
   }, [scopeKey, showSessionView]);
 
+  const discardPendingComposerText = useCallback(() => {
+    if (draftTextFlushTimerRef.current != null) {
+      window.clearTimeout(draftTextFlushTimerRef.current);
+      draftTextFlushTimerRef.current = null;
+    }
+    pendingComposerTextRef.current = null;
+  }, []);
+
   const clearScopeDraft = useCallback(() => {
+    discardPendingComposerText();
     clearDraftForScope(scopeKey);
-  }, [clearDraftForScope, scopeKey]);
+  }, [clearDraftForScope, discardPendingComposerText, scopeKey]);
 
   const enterScopeDraftMode = useCallback((agentId: string, preserveSessionView = false) => {
     applyDraftEntrySelection({
@@ -592,8 +601,8 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   }, [flushDraftText, scopeKey]);
 
   useEffect(() => {
-    pendingComposerTextRef.current = null;
-  }, [scopeKey, activeSessionId]);
+    flushDraftText();
+  }, [activeSessionId, flushDraftText]);
 
   useEffect(() => {
     if (!isVisible) return;

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -1175,6 +1175,16 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       }
       setIsSending(false);
       const sendPermissionMode = permissionModeRef.current;
+      if (currentAgentId !== sendAgentId) return;
+      const liveView = panelViewRef.current;
+      if (liveView.mode !== currentPanelView.mode) return;
+      if (
+        currentPanelView.mode === 'session'
+        && liveView.mode === 'session'
+        && liveView.sessionId !== currentPanelView.sessionId
+      ) {
+        return;
+      }
       void warmAiMarkdownRenderer();
       let sessionId = currentSessionView?.id ?? null;
       let currentSession = currentSessionView ?? null;
@@ -1594,6 +1604,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       >
       <AIChatPanelContent
         parked={!isVisible}
+        sending={isSending}
         t={t}
         currentAgentId={currentAgentId}
         externalAgents={externalAgents}

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -405,18 +405,25 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   panelViewRef.current = normalizedPanelView;
   const currentDraftRef = useRef(currentDraft);
   if (pendingComposerTextRef.current != null) {
-    const base = currentDraft ?? currentDraftRef.current ?? {
-      text: '',
-      agentId: currentAgentId,
-      attachments: [],
-      selectedUserSkillSlugs: [],
-      updatedAt: Date.now(),
-    };
-    if (currentDraft && currentDraft.text === pendingComposerTextRef.current) {
+    const pending = pendingComposerTextRef.current;
+    if (currentDraft && currentDraft.text === pending) {
       pendingComposerTextRef.current = null;
       currentDraftRef.current = currentDraft;
+    } else if (currentDraftRef.current?.text === pending) {
+      if (currentDraft && currentDraftRef.current) {
+        currentDraftRef.current.attachments = currentDraft.attachments;
+        currentDraftRef.current.selectedUserSkillSlugs = currentDraft.selectedUserSkillSlugs;
+        currentDraftRef.current.agentId = currentDraft.agentId;
+      }
     } else {
-      currentDraftRef.current = { ...base, text: pendingComposerTextRef.current };
+      const base = currentDraft ?? currentDraftRef.current ?? {
+        text: '',
+        agentId: currentAgentId,
+        attachments: [],
+        selectedUserSkillSlugs: [],
+        updatedAt: Date.now(),
+      };
+      currentDraftRef.current = { ...base, text: pending };
     }
   } else {
     currentDraftRef.current = currentDraft;
@@ -1126,12 +1133,6 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     const isDraftMode = currentPanelView.mode === 'draft';
 
     flushDraftText();
-    const sendBridge = getNetcattyBridge();
-    if (sendBridge?.aiSyncProviders && providers.length > 0) {
-      await sendBridge.aiSyncProviders(providers);
-    }
-    void warmAiMarkdownRenderer();
-
     const sendGateKey = currentSessionView?.id ?? `draft:${scopeKey}`;
     if (!tryBeginSendForKey(sendGateKey)) {
       return;
@@ -1139,6 +1140,11 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     let sessionSendGateKey: string | null = null;
 
     try {
+      const sendBridge = getNetcattyBridge();
+      if (sendBridge?.aiSyncProviders && providers.length > 0) {
+        await sendBridge.aiSyncProviders(providers);
+      }
+      void warmAiMarkdownRenderer();
       let sessionId = currentSessionView?.id ?? null;
       let currentSession = currentSessionView ?? null;
       if (isDraftMode) {

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -38,7 +38,7 @@ import {
   endSendForKey,
   tryBeginSendForKey,
 } from './ai/draftSendGate';
-import { selectDraftForAgentSwitch } from '../application/state/aiDraftState';
+import { draftsByScopeEqualIgnoringComposerText, selectDraftForAgentSwitch } from '../application/state/aiDraftState';
 import {
   buildPromptWithTerminalSelectionAttachments,
   isTerminalSelectionAttachment,
@@ -79,6 +79,7 @@ import {
   getAIPanelProfilerProps,
   profileAIPanelCalculation,
 } from './ai/aiPanelDiagnostics';
+import { scheduleWhenAiComposerIdle, warmAiMarkdownRenderer } from './ai/aiMarkdownWarmup';
 
 type UserSkillsStatusResult = { ok: boolean; skills?: Array<{
   id: string;
@@ -198,15 +199,9 @@ export function shouldKeepAIChatSidePanelMounted(props: AIChatSidePanelProps): b
   return isAIChatSessionStreaming(sessionId);
 }
 
-function shouldDelayAIChatSidePanelActivation(props: AIChatSidePanelProps): boolean {
-  if (!(props.isVisible ?? true)) return false;
-  const scopeKey = `${props.scopeType}:${props.scopeTargetId ?? ''}`;
-  if (props.draftsByScope[scopeKey] || props.panelViewByScope[scopeKey]?.mode === 'draft') {
-    return false;
-  }
-  const sessionId = props.activeSessionIdMap[scopeKey] ?? null;
-  if (isAIChatSessionStreaming(sessionId)) return false;
-  return !hasAIChatSidePanelRetainedContent(props);
+function shouldDelayAIChatSidePanelActivation(_props: AIChatSidePanelProps): boolean {
+  // Empty-panel activation delay used to land in the expand → first-type window.
+  return false;
 }
 
 function schedulePanelActivation(callback: () => void): () => void {
@@ -377,6 +372,8 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
 
   const explicitPanelView = panelViewByScope[scopeKey];
   const currentDraft = draftsByScope[scopeKey] ?? null;
+  const pendingComposerTextRef = useRef<string | null>(null);
+  const draftTextFlushTimerRef = useRef<number | null>(null);
   const visibleHistorySessionIds = useMemo(
     () => new Set(historySessions.map((session) => session.id)),
     [historySessions],
@@ -402,12 +399,28 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   const isSteering = activeSessionId != null && steeringSessionId === activeSessionId;
   const currentAgentId = activeSession?.agentId ?? currentDraft?.agentId ?? defaultAgentId;
   const observedContextUsage = useAgentContextUsage(activeSessionId);
-  const inputValue = currentDraft?.text ?? '';
+  const inputValue = pendingComposerTextRef.current ?? currentDraft?.text ?? '';
   const files = currentDraft?.attachments ?? [];
   const panelViewRef = useRef(normalizedPanelView);
   panelViewRef.current = normalizedPanelView;
   const currentDraftRef = useRef(currentDraft);
-  currentDraftRef.current = currentDraft;
+  if (pendingComposerTextRef.current != null) {
+    const base = currentDraft ?? currentDraftRef.current ?? {
+      text: '',
+      agentId: currentAgentId,
+      attachments: [],
+      selectedUserSkillSlugs: [],
+      updatedAt: Date.now(),
+    };
+    if (currentDraft && currentDraft.text === pendingComposerTextRef.current) {
+      pendingComposerTextRef.current = null;
+      currentDraftRef.current = currentDraft;
+    } else {
+      currentDraftRef.current = { ...base, text: pendingComposerTextRef.current };
+    }
+  } else {
+    currentDraftRef.current = currentDraft;
+  }
   const activeSessionRef = useRef(activeSession);
   activeSessionRef.current = activeSession;
 
@@ -439,13 +452,9 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     const bridge = getNetcattyBridge();
     if (!bridge?.aiMcpUpdateSessions) return;
 
-    const timeoutId = window.setTimeout(() => {
+    return scheduleWhenAiComposerIdle(() => {
       void bridge.aiMcpUpdateSessions(terminalSessions, activeSessionId ?? undefined);
-    }, 250);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
+    }, { initialDelayMs: 250 });
   }, [isVisible, terminalSessions, activeSessionId]);
 
   useEffect(() => {
@@ -529,13 +538,39 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     });
   }, [ensureScopeDraft, showScopeDraftView]);
 
+  const flushDraftText = useCallback(() => {
+    if (draftTextFlushTimerRef.current != null) {
+      window.clearTimeout(draftTextFlushTimerRef.current);
+      draftTextFlushTimerRef.current = null;
+    }
+    const pending = pendingComposerTextRef.current;
+    if (pending == null) return;
+    updateScopeDraft(currentAgentId, (current) => (
+      current.text === pending ? current : { ...current, text: pending }
+    ));
+  }, [currentAgentId, updateScopeDraft]);
+
   const setInputValue = useCallback((value: string) => {
-    enterScopeDraftMode(currentAgentId, panelViewRef.current.mode === 'session');
-    updateScopeDraft(currentAgentId, (draft) => ({
-      ...draft,
-      text: value,
-    }));
-  }, [currentAgentId, enterScopeDraftMode, updateScopeDraft]);
+    if (panelViewRef.current.mode !== 'draft' || !currentDraftRef.current) {
+      enterScopeDraftMode(currentAgentId, panelViewRef.current.mode === 'session');
+    }
+    const base = currentDraftRef.current ?? {
+      text: '',
+      agentId: currentAgentId,
+      attachments: [],
+      selectedUserSkillSlugs: [],
+      updatedAt: Date.now(),
+    };
+    pendingComposerTextRef.current = value;
+    currentDraftRef.current = { ...base, text: value, updatedAt: Date.now() };
+    if (draftTextFlushTimerRef.current != null) {
+      window.clearTimeout(draftTextFlushTimerRef.current);
+    }
+    draftTextFlushTimerRef.current = window.setTimeout(() => {
+      draftTextFlushTimerRef.current = null;
+      flushDraftText();
+    }, 120);
+  }, [currentAgentId, enterScopeDraftMode, flushDraftText]);
 
   const addFiles = useCallback(async (inputFiles: File[]) => {
     enterScopeDraftMode(currentAgentId, panelViewRef.current.mode === 'session');
@@ -545,6 +580,20 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   const removeFile = useCallback((fileId: string) => {
     removeDraftFile(scopeKey, currentAgentId, fileId);
   }, [removeDraftFile, scopeKey, currentAgentId]);
+
+  useEffect(() => {
+    if (isVisible) return undefined;
+    flushDraftText();
+    return undefined;
+  }, [flushDraftText, isVisible]);
+
+  useEffect(() => () => {
+    flushDraftText();
+  }, [flushDraftText, scopeKey]);
+
+  useEffect(() => {
+    pendingComposerTextRef.current = null;
+  }, [scopeKey, activeSessionId]);
 
   useEffect(() => {
     if (!isVisible) return;
@@ -586,16 +635,19 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     };
 
     const bridge = getNetcattyBridge();
-    void loadUserSkillsStatus(bridge)
-      .then((result) => {
-        if (cancelled) return;
-        if (result === undefined) return;
-        applyUserSkillsStatus(result);
-      })
-      .catch(() => {});
+    const cancelIdle = scheduleWhenAiComposerIdle(() => {
+      void loadUserSkillsStatus(bridge)
+        .then((result) => {
+          if (cancelled) return;
+          if (result === undefined) return;
+          applyUserSkillsStatus(result);
+        })
+        .catch(() => {});
+    });
 
     return () => {
       cancelled = true;
+      cancelIdle();
     };
   }, [isVisible, scopeKey, toolIntegrationMode, updateScopeDraft, userSkillsStatusVersion]);
 
@@ -609,17 +661,19 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   useEffect(() => {
     if (!isVisible) return;
     const bridge = getNetcattyBridge();
-    if (bridge?.aiSyncProviders && providers.length > 0) {
+    if (!bridge?.aiSyncProviders || providers.length === 0) return;
+    return scheduleWhenAiComposerIdle(() => {
       void bridge.aiSyncProviders(providers);
-    }
+    });
   }, [isVisible, providers]);
 
   useEffect(() => {
     if (!isVisible) return;
     const bridge = getNetcattyBridge();
-    if (bridge?.aiSyncWebSearch) {
+    if (!bridge?.aiSyncWebSearch) return;
+    return scheduleWhenAiComposerIdle(() => {
       void bridge.aiSyncWebSearch(webSearchConfig?.apiHost || null, webSearchConfig?.apiKey || null);
-    }
+    });
   }, [isVisible, webSearchConfig?.apiHost, webSearchConfig?.apiKey, webSearchConfig?.enabled]);
 
   const {
@@ -627,7 +681,10 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     isDiscovering,
     rediscover,
     enableAgent,
-  } = useAgentDiscovery(externalAgents, setExternalAgents, { enabled: isVisible });
+  } = useAgentDiscovery(externalAgents, setExternalAgents, {
+    enabled: isVisible,
+    schedule: scheduleWhenAiComposerIdle,
+  });
 
   const handleEnableDiscoveredAgent = useCallback(
     (agent: DiscoveredAgent) => {
@@ -732,20 +789,25 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     const bridge = getNetcattyBridge();
     if (!bridge?.aiCodexGetIntegration) return;
     let cancelled = false;
-    void Promise.resolve(
-      bridge.aiCodexGetIntegration({ codexPath: getManualAgentCommand(currentAgentConfig) }) as Promise<CodexIntegrationStatus>,
-    ).then((info) => {
-      if (cancelled) return;
-      const hasCustom = info?.state === 'connected_custom_config';
-      setCodexConfigModel(info?.customConfig?.model ?? null);
-      setCodexCustomConfigResolved(hasCustom);
-    }).catch(() => {
-      if (!cancelled) {
-        setCodexConfigModel(null);
-        setCodexCustomConfigResolved(false);
-      }
+    const cancelIdle = scheduleWhenAiComposerIdle(() => {
+      void Promise.resolve(
+        bridge.aiCodexGetIntegration({ codexPath: getManualAgentCommand(currentAgentConfig) }) as Promise<CodexIntegrationStatus>,
+      ).then((info) => {
+        if (cancelled) return;
+        const hasCustom = info?.state === 'connected_custom_config';
+        setCodexConfigModel(info?.customConfig?.model ?? null);
+        setCodexCustomConfigResolved(hasCustom);
+      }).catch(() => {
+        if (!cancelled) {
+          setCodexConfigModel(null);
+          setCodexCustomConfigResolved(false);
+        }
+      });
     });
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+      cancelIdle();
+    };
   }, [isVisible, isCodexManagedAgent, currentAgentId, currentAgentConfig]);
 
   const agentModelMapRef = useRef(agentModelMap);
@@ -868,15 +930,19 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     // Respect renderer TTL / in-flight coalescing for all SDK agents including
     // OpenCode. Forced refresh used to re-spawn opencode on every effect re-run
     // even when the user never selected OpenCode (#2184). Manual refresh still
-    // passes force via the model selector path.
+    // passes force via the model selector path. Defer the network refresh so
+    // expand → first type does not wait on CLI model listing.
     let cancelled = false;
-    void loadSdkRuntimeModelCatalog(target).then((catalog) => {
-      if (cancelled || !catalog) return;
-      applySdkRuntimeModelCatalog(target.agentId, catalog, { adoptCurrentModel: true });
+    const cancelIdle = scheduleWhenAiComposerIdle(() => {
+      void loadSdkRuntimeModelCatalog(target).then((catalog) => {
+        if (cancelled || !catalog) return;
+        applySdkRuntimeModelCatalog(target.agentId, catalog, { adoptCurrentModel: true });
+      });
     });
 
     return () => {
       cancelled = true;
+      cancelIdle();
     };
   }, [
     isVisible,
@@ -1052,6 +1118,9 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     const modelAttachments = attachments.filter((attachment) => !isTerminalSelectionAttachment(attachment));
     const isDraftMode = currentPanelView.mode === 'draft';
 
+    flushDraftText();
+    void warmAiMarkdownRenderer();
+
     const sendGateKey = currentSessionView?.id ?? `draft:${scopeKey}`;
     if (!tryBeginSendForKey(sendGateKey)) {
       return;
@@ -1205,6 +1274,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     scopeType, scopeTargetId, scopeHostIds, scopeLabel, globalPermissionMode, commandBlocklist, commandTimeout, webSearchConfig, buildExecutorContextForScope,
     toolIntegrationMode,
     clearScopeDraft, showScopeSessionView, setActiveSessionId,
+    flushDraftText,
   ]);
 
   const handleCompact = useCallback(async () => {
@@ -1462,45 +1532,18 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     setShowHistory(false);
   }, [ensureScopeDraft, showScopeDraftView, updateScopeDraft]);
 
-  // Warm the Streamdown/markdown chunk while the panel is visible but idle, so
-  // the first completed assistant reply does not pay the full parse cost mid-interaction.
-  useEffect(() => {
-    if (!isVisible) return;
-    let cancelled = false;
-    const loadMarkdown = () => {
-      if (cancelled) return;
-      void import('./ai-elements/messageResponse');
-    };
-    if (typeof requestIdleCallback === 'function') {
-      const idleId = requestIdleCallback(loadMarkdown, { timeout: 2500 });
-      return () => {
-        cancelled = true;
-        cancelIdleCallback(idleId);
-      };
-    }
-    const timeoutId = window.setTimeout(loadMarkdown, 0);
-    return () => {
-      cancelled = true;
-      window.clearTimeout(timeoutId);
-    };
-  }, [isVisible]);
-
-  // Keep streaming/session hooks alive for retained hidden panels, but do not
-  // mount ChatMessageList / Streamdown / ChatInput while CSS-hidden — those trees
-  // are the main tab-switch and cross-tab re-render cost.
-  if (!isVisible) {
-    return (
-      <div
-        className="h-full min-h-0 bg-background"
-        data-section="ai-chat-panel-retained"
-        aria-hidden="true"
-      />
-    );
-  }
-
+  // Hidden retained panels keep the composer mounted (parent is `hidden` +
+  // inert) so reopen does not remount ChatInput. Skip the message list.
   return (
     <React.Profiler {...getAIPanelProfilerProps('AIChatSidePanel.Active')}>
+      <div
+        className="h-full min-h-0"
+        data-section={isVisible ? undefined : 'ai-chat-panel-retained'}
+        aria-hidden={isVisible ? undefined : true}
+        inert={isVisible ? undefined : true}
+      >
       <AIChatPanelContent
+        parked={!isVisible}
         t={t}
         currentAgentId={currentAgentId}
         externalAgents={externalAgents}
@@ -1566,6 +1609,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
         onOpenVaultSnippet={onOpenVaultSnippet}
         onOpenVaultSection={onOpenVaultSection}
       />
+      </div>
     </React.Profiler>
   );
 };
@@ -1641,6 +1685,22 @@ export function aiChatSidePanelPropsAreEqual(
   if (prev.onOpenVaultSnippet !== next.onOpenVaultSnippet) return false;
   if (prev.onOpenVaultSection !== next.onOpenVaultSection) return false;
 
+  const scopeKey = `${prev.scopeType}:${prev.scopeTargetId ?? ''}`;
+  if (
+    prev.sessions === next.sessions
+    && draftsByScopeEqualIgnoringComposerText(prev.draftsByScope, next.draftsByScope, scopeKey)
+  ) {
+    let restEqual = true;
+    for (const key of AI_CHAT_SIDE_PANEL_AI_STATE_KEYS) {
+      if (key === 'sessions' || key === 'draftsByScope') continue;
+      if (prev[key] !== next[key]) {
+        restEqual = false;
+        break;
+      }
+    }
+    if (restEqual) return true;
+  }
+
   // Sibling stream thrash: full sessions array identity always changes. Only
   // exact-scope session object refs matter for this panel's active chat —
   // plus the currently selected session, which may be a host-matched history
@@ -1706,6 +1766,12 @@ export function aiChatSidePanelPropsAreEqual(
 
   for (const key of AI_CHAT_SIDE_PANEL_AI_STATE_KEYS) {
     if (key === 'sessions') continue;
+    if (key === 'draftsByScope') {
+      if (!draftsByScopeEqualIgnoringComposerText(prev.draftsByScope, next.draftsByScope, scopeKey)) {
+        return false;
+      }
+      continue;
+    }
     if (prev[key] !== next[key]) return false;
   }
   return true;

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -298,6 +298,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   const scopeKey = `${scopeType}:${scopeTargetId ?? ''}`;
 
   const [showHistory, setShowHistory] = useState(false);
+  const [isSending, setIsSending] = useState(false);
   const [runtimeAgentModelPresets, setRuntimeAgentModelPresets] = useState<Record<string, AgentModelPreset[]>>({});
   const [runtimeModelWarnings, setRuntimeModelWarnings] = useState<Record<string, string>>({});
   const [steerWarnings, setSteerWarnings] = useState<Record<string, SteerWarning>>({});
@@ -1014,8 +1015,8 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
 
   const inputAgentId = activeSession?.agentId ?? currentDraft?.agentId ?? currentAgentId;
   const canSendCurrentAgent = useMemo(
-    () => canSendWithAgent(inputAgentId, externalAgents),
-    [inputAgentId, externalAgents],
+    () => !isSending && canSendWithAgent(inputAgentId, externalAgents),
+    [inputAgentId, externalAgents, isSending],
   );
 
   const handleAgentModelSelect = useCallback((modelId: string) => {
@@ -1138,6 +1139,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       return;
     }
     let sessionSendGateKey: string | null = null;
+    setIsSending(true);
 
     try {
       const sendBridge = getNetcattyBridge();
@@ -1146,6 +1148,15 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       }
       if (sendBridge?.aiSyncWebSearch) {
         await sendBridge.aiSyncWebSearch(webSearchConfig?.apiHost || null, webSearchConfig?.apiKey || null);
+      }
+      if (currentAgentConfig && shouldLoadSdkRuntimeModels(currentAgentConfig)) {
+        const runtimeTarget = buildExternalAgentRuntimeModelTarget(currentAgentConfig);
+        if (runtimeTarget) {
+          const catalog = await loadSdkRuntimeModelCatalog(runtimeTarget);
+          if (catalog) {
+            applySdkRuntimeModelCatalog(runtimeTarget.agentId, catalog, { adoptCurrentModel: true });
+          }
+        }
       }
       void warmAiMarkdownRenderer();
       let sessionId = currentSessionView?.id ?? null;
@@ -1279,6 +1290,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
         }, modelAttachments.length > 0 ? modelAttachments : undefined);
       }
     } finally {
+      setIsSending(false);
       endSendForKey(sendGateKey);
       if (sessionSendGateKey && sessionSendGateKey !== sendGateKey) {
         endSendForKey(sessionSendGateKey);
@@ -1294,7 +1306,8 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     scopeType, scopeTargetId, scopeHostIds, scopeLabel, globalPermissionMode, commandBlocklist, commandTimeout, webSearchConfig, buildExecutorContextForScope,
     toolIntegrationMode,
     clearScopeDraft, showScopeSessionView, setActiveSessionId,
-    flushDraftText,
+    flushDraftText, currentAgentConfig, buildExternalAgentRuntimeModelTarget,
+    loadSdkRuntimeModelCatalog, applySdkRuntimeModelCatalog,
   ]);
 
   const handleCompact = useCallback(async () => {

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -671,9 +671,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     if (!isVisible) return;
     const bridge = getNetcattyBridge();
     if (!bridge?.aiSyncProviders || providers.length === 0) return;
-    return scheduleWhenAiComposerIdle(() => {
-      void bridge.aiSyncProviders(providers);
-    });
+    void bridge.aiSyncProviders(providers);
   }, [isVisible, providers]);
 
   useEffect(() => {
@@ -1128,6 +1126,10 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     const isDraftMode = currentPanelView.mode === 'draft';
 
     flushDraftText();
+    const sendBridge = getNetcattyBridge();
+    if (sendBridge?.aiSyncProviders && providers.length > 0) {
+      await sendBridge.aiSyncProviders(providers);
+    }
     void warmAiMarkdownRenderer();
 
     const sendGateKey = currentSessionView?.id ?? `draft:${scopeKey}`;

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -404,6 +404,8 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   const files = currentDraft?.attachments ?? [];
   const panelViewRef = useRef(normalizedPanelView);
   panelViewRef.current = normalizedPanelView;
+  const permissionModeRef = useRef(globalPermissionMode);
+  permissionModeRef.current = globalPermissionMode;
   const currentDraftRef = useRef(currentDraft);
   if (pendingComposerTextRef.current != null) {
     const pending = pendingComposerTextRef.current;
@@ -1149,15 +1151,30 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       if (sendBridge?.aiSyncWebSearch) {
         await sendBridge.aiSyncWebSearch(webSearchConfig?.apiHost || null, webSearchConfig?.apiKey || null);
       }
+      let sendSelectedAgentModel = selectedAgentModel;
       if (currentAgentConfig && shouldLoadSdkRuntimeModels(currentAgentConfig)) {
         const runtimeTarget = buildExternalAgentRuntimeModelTarget(currentAgentConfig);
         if (runtimeTarget) {
           const catalog = await loadSdkRuntimeModelCatalog(runtimeTarget);
           if (catalog) {
             applySdkRuntimeModelCatalog(runtimeTarget.agentId, catalog, { adoptCurrentModel: true });
+            const runtimePresets = normalizeSdkRuntimeModelPresets(catalog.models, catalog.currentModelId);
+            const storedModelId = agentModelMapRef.current[sendAgentId];
+            if (
+              catalog.currentModelId
+              && shouldAdoptSdkCurrentModel(catalog.currentModelId, storedModelId, runtimePresets)
+            ) {
+              sendSelectedAgentModel = catalog.currentModelId;
+            } else if (shouldUseStoredAgentModel(storedModelId, runtimePresets)) {
+              sendSelectedAgentModel = storedModelId ?? sendSelectedAgentModel;
+            } else if (runtimePresets[0]) {
+              sendSelectedAgentModel = runtimePresets[0].id;
+            }
           }
         }
       }
+      setIsSending(false);
+      const sendPermissionMode = permissionModeRef.current;
       void warmAiMarkdownRenderer();
       let sessionId = currentSessionView?.id ?? null;
       let currentSession = currentSessionView ?? null;
@@ -1230,7 +1247,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       addMessageToSession(sessionId, {
         id: assistantMsgId, role: 'assistant', content: '', timestamp: Date.now(),
         model: isExternalAgent
-          ? (selectedAgentModel || agentConfig?.name || 'external')
+          ? (sendSelectedAgentModel || agentConfig?.name || 'external')
           : (sendActiveModelId || sendActiveProvider?.defaultModel || ''),
         providerId: isExternalAgent ? undefined : sendActiveProvider?.providerId,
       });
@@ -1254,10 +1271,10 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
             terminalSessions,
             defaultTargetSession,
             providers,
-            selectedAgentModel,
+            selectedAgentModel: sendSelectedAgentModel,
             toolIntegrationMode,
             selectedUserSkillSlugs: selectedSkillSlugs,
-            permissionMode: globalPermissionMode,
+            permissionMode: sendPermissionMode,
           });
         } catch (err) {
           reportStreamError(sessionId, abortController.signal, err);
@@ -1278,7 +1295,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
           scopeType,
           scopeTargetId,
           scopeLabel,
-          globalPermissionMode,
+          globalPermissionMode: sendPermissionMode,
           commandBlocklist,
           commandTimeout,
           terminalSessions,
@@ -1303,7 +1320,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     setStreamingForScope,
     sendToExternalAgent, sendToCattyAgent, reportStreamError, autoTitleSession, t,
     abortControllersRef, terminalSessions, defaultTargetSession, providers, selectedAgentModel, updateSessionExternalSessionId,
-    scopeType, scopeTargetId, scopeHostIds, scopeLabel, globalPermissionMode, commandBlocklist, commandTimeout, webSearchConfig, buildExecutorContextForScope,
+    scopeType, scopeTargetId, scopeHostIds, scopeLabel, commandBlocklist, commandTimeout, webSearchConfig, buildExecutorContextForScope,
     toolIntegrationMode,
     clearScopeDraft, showScopeSessionView, setActiveSessionId,
     flushDraftText, currentAgentConfig, buildExternalAgentRuntimeModelTarget,
@@ -1611,7 +1628,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
         canSteer={canSteerCurrentTurn}
         isSteering={isSteering}
         steerWarning={steerWarning}
-        lockTurnConfiguration={Boolean(isStreaming && isCodexAppServer)}
+        lockTurnConfiguration={Boolean(isSending || (isStreaming && isCodexAppServer))}
         canSendCurrentAgent={canSendCurrentAgent}
         providerDisplayName={providerDisplayName}
         modelDisplayName={modelDisplayName}

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -406,6 +406,10 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   panelViewRef.current = normalizedPanelView;
   const permissionModeRef = useRef(globalPermissionMode);
   permissionModeRef.current = globalPermissionMode;
+  const sendEpochRef = useRef(0);
+  useEffect(() => () => {
+    sendEpochRef.current += 1;
+  }, [scopeKey]);
   const currentDraftRef = useRef(currentDraft);
   if (pendingComposerTextRef.current != null) {
     const pending = pendingComposerTextRef.current;
@@ -1141,6 +1145,8 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       return;
     }
     let sessionSendGateKey: string | null = null;
+    const sendEpoch = sendEpochRef.current;
+    const isSendStale = () => sendEpochRef.current !== sendEpoch;
     setIsSending(true);
 
     try {
@@ -1175,6 +1181,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       }
       setIsSending(false);
       const sendPermissionMode = permissionModeRef.current;
+      if (isSendStale()) return;
       if (currentAgentId !== sendAgentId) return;
       const liveView = panelViewRef.current;
       if (liveView.mode !== currentPanelView.mode) return;

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -541,8 +541,8 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     pendingComposerTextRef.current = null;
   }, []);
 
-  const clearScopeDraft = useCallback(() => {
-    discardPendingComposerText();
+  const clearScopeDraft = useCallback((options?: { keepPendingText?: boolean }) => {
+    if (!options?.keepPendingText) discardPendingComposerText();
     clearDraftForScope(scopeKey);
   }, [clearDraftForScope, discardPendingComposerText, scopeKey]);
 
@@ -685,9 +685,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     if (!isVisible) return;
     const bridge = getNetcattyBridge();
     if (!bridge?.aiSyncWebSearch) return;
-    return scheduleWhenAiComposerIdle(() => {
-      void bridge.aiSyncWebSearch(webSearchConfig?.apiHost || null, webSearchConfig?.apiKey || null);
-    });
+    void bridge.aiSyncWebSearch(webSearchConfig?.apiHost || null, webSearchConfig?.apiKey || null);
   }, [isVisible, webSearchConfig?.apiHost, webSearchConfig?.apiKey, webSearchConfig?.enabled]);
 
   const {
@@ -803,24 +801,21 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     const bridge = getNetcattyBridge();
     if (!bridge?.aiCodexGetIntegration) return;
     let cancelled = false;
-    const cancelIdle = scheduleWhenAiComposerIdle(() => {
-      void Promise.resolve(
-        bridge.aiCodexGetIntegration({ codexPath: getManualAgentCommand(currentAgentConfig) }) as Promise<CodexIntegrationStatus>,
-      ).then((info) => {
-        if (cancelled) return;
-        const hasCustom = info?.state === 'connected_custom_config';
-        setCodexConfigModel(info?.customConfig?.model ?? null);
-        setCodexCustomConfigResolved(hasCustom);
-      }).catch(() => {
-        if (!cancelled) {
-          setCodexConfigModel(null);
-          setCodexCustomConfigResolved(false);
-        }
-      });
+    void Promise.resolve(
+      bridge.aiCodexGetIntegration({ codexPath: getManualAgentCommand(currentAgentConfig) }) as Promise<CodexIntegrationStatus>,
+    ).then((info) => {
+      if (cancelled) return;
+      const hasCustom = info?.state === 'connected_custom_config';
+      setCodexConfigModel(info?.customConfig?.model ?? null);
+      setCodexCustomConfigResolved(hasCustom);
+    }).catch(() => {
+      if (!cancelled) {
+        setCodexConfigModel(null);
+        setCodexCustomConfigResolved(false);
+      }
     });
     return () => {
       cancelled = true;
-      cancelIdle();
     };
   }, [isVisible, isCodexManagedAgent, currentAgentId, currentAgentConfig]);
 
@@ -1133,6 +1128,11 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     const isDraftMode = currentPanelView.mode === 'draft';
 
     flushDraftText();
+    const submittedText = draft?.text ?? '';
+    const keepPendingAfterSend = () => {
+      const pending = pendingComposerTextRef.current;
+      return pending != null && pending !== submittedText;
+    };
     const sendGateKey = currentSessionView?.id ?? `draft:${scopeKey}`;
     if (!tryBeginSendForKey(sendGateKey)) {
       return;
@@ -1144,6 +1144,9 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       if (sendBridge?.aiSyncProviders && providers.length > 0) {
         await sendBridge.aiSyncProviders(providers);
       }
+      if (sendBridge?.aiSyncWebSearch) {
+        await sendBridge.aiSyncWebSearch(webSearchConfig?.apiHost || null, webSearchConfig?.apiKey || null);
+      }
       void warmAiMarkdownRenderer();
       let sessionId = currentSessionView?.id ?? null;
       let currentSession = currentSessionView ?? null;
@@ -1152,7 +1155,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
         const createdSession = createSession(scope, sendAgentId);
         sessionId = createdSession.id;
         currentSession = createdSession;
-        clearScopeDraft();
+        clearScopeDraft({ keepPendingText: keepPendingAfterSend() });
         showScopeSessionView(createdSession.id);
         setActiveSessionId(createdSession.id);
         sessionSendGateKey = sessionId;
@@ -1182,7 +1185,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
         });
         addMessageToSession(sessionId, { id: generateId(), role: 'assistant', content: t('ai.chat.noProvider'), timestamp: Date.now() });
         if (currentPanelView.mode === 'session') {
-          clearScopeDraft();
+          clearScopeDraft({ keepPendingText: keepPendingAfterSend() });
           showScopeSessionView(sessionId);
         }
         return;
@@ -1196,7 +1199,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
         });
         addMessageToSession(sessionId, { id: generateId(), role: 'assistant', content: t('ai.chat.noProviderModel'), timestamp: Date.now() });
         if (currentPanelView.mode === 'session') {
-          clearScopeDraft();
+          clearScopeDraft({ keepPendingText: keepPendingAfterSend() });
           showScopeSessionView(sessionId);
         }
         return;
@@ -1207,7 +1210,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
         ...(attachments.length > 0 ? { attachments } : {}),
         timestamp: Date.now(),
       });
-      clearScopeDraft();
+      clearScopeDraft({ keepPendingText: keepPendingAfterSend() });
       showScopeSessionView(sessionId);
       setActiveSessionId(sessionId);
       setStreamingForScope(sessionId, true);

--- a/components/ai-elements/LazyMessageResponse.tsx
+++ b/components/ai-elements/LazyMessageResponse.tsx
@@ -1,12 +1,23 @@
-import React, { lazy, Suspense } from 'react';
+import React, { lazy, Suspense, useEffect, useState } from 'react';
 
 import { cn } from '../../lib/utils';
+import {
+  enqueueChatMarkdownHydrate,
+  isAiMarkdownRendererReady,
+  subscribeAiMarkdownRendererReady,
+  warmAiMarkdownRenderer,
+} from '../ai/aiMarkdownWarmup';
 import { LazyLoadBoundary } from '../ui/lazy-load-boundary';
 
 type LazyMessageResponseProps = {
   children?: React.ReactNode;
   className?: string;
   isAnimating?: boolean;
+  /**
+   * Keep plaintext until Streamdown is already warmed. Chat history uses this
+   * so expanding the panel cannot start the ~350KB parse during first typing.
+   */
+  deferUntilWarm?: boolean;
 };
 
 const MessageResponse = lazy(() =>
@@ -20,11 +31,28 @@ const PlainTextFallback = ({ children, className }: LazyMessageResponseProps) =>
 );
 
 export function LazyMessageResponse(props: LazyMessageResponseProps) {
-  const resetKey = typeof props.children === 'string' ? props.children : undefined;
+  const { deferUntilWarm = false, ...rendererProps } = props;
+  const [ready, setReady] = useState(() => !deferUntilWarm && isAiMarkdownRendererReady());
+  const resetKey = typeof rendererProps.children === 'string' ? rendererProps.children : undefined;
+
+  useEffect(() => {
+    if (ready) return undefined;
+    if (!deferUntilWarm) {
+      const unsubscribe = subscribeAiMarkdownRendererReady(() => setReady(true));
+      void warmAiMarkdownRenderer();
+      return unsubscribe;
+    }
+    return enqueueChatMarkdownHydrate(() => setReady(true));
+  }, [deferUntilWarm, ready]);
+
+  if (deferUntilWarm && !ready) {
+    return <PlainTextFallback {...rendererProps} />;
+  }
+
   return (
-    <LazyLoadBoundary fallback={<PlainTextFallback {...props} />} resetKey={resetKey}>
-      <Suspense fallback={<PlainTextFallback {...props} />}>
-        <MessageResponse {...props} />
+    <LazyLoadBoundary fallback={<PlainTextFallback {...rendererProps} />} resetKey={resetKey}>
+      <Suspense fallback={<PlainTextFallback {...rendererProps} />}>
+        <MessageResponse {...rendererProps} />
       </Suspense>
     </LazyLoadBoundary>
   );

--- a/components/ai-elements/LazyMessageResponse.tsx
+++ b/components/ai-elements/LazyMessageResponse.tsx
@@ -4,6 +4,7 @@ import { cn } from '../../lib/utils';
 import {
   enqueueChatMarkdownHydrate,
   isAiMarkdownRendererReady,
+  scheduleWhenAiComposerIdle,
   subscribeAiMarkdownRendererReady,
   warmAiMarkdownRenderer,
 } from '../ai/aiMarkdownWarmup';
@@ -39,8 +40,14 @@ export function LazyMessageResponse(props: LazyMessageResponseProps) {
     if (ready) return undefined;
     if (!deferUntilWarm) {
       const unsubscribe = subscribeAiMarkdownRendererReady(() => setReady(true));
-      void warmAiMarkdownRenderer();
-      return unsubscribe;
+      if (isAiMarkdownRendererReady()) return unsubscribe;
+      const cancelIdle = scheduleWhenAiComposerIdle(() => {
+        void warmAiMarkdownRenderer();
+      });
+      return () => {
+        unsubscribe();
+        cancelIdle();
+      };
     }
     return enqueueChatMarkdownHydrate(() => setReady(true));
   }, [deferUntilWarm, ready]);

--- a/components/ai/AgentSelector.tsx
+++ b/components/ai/AgentSelector.tsx
@@ -6,7 +6,7 @@
  */
 
 import { ChevronDown, RefreshCw, Plus, Settings } from 'lucide-react';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { cn } from '../../lib/utils';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import {
@@ -32,6 +32,7 @@ interface AgentSelectorProps {
   onEnableDiscoveredAgent?: (agent: DiscoveredAgent) => void;
   onRediscover?: () => void;
   onManageAgents?: () => void;
+  parked?: boolean;
 }
 
 const BUILTIN_AGENTS: AgentInfo[] = [
@@ -125,9 +126,14 @@ const AgentSelector: React.FC<AgentSelectorProps> = ({
   onEnableDiscoveredAgent,
   onRediscover,
   onManageAgents,
+  parked = false,
 }) => {
   const { t } = useI18n();
   const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (parked) setOpen(false);
+  }, [parked]);
 
   const enabledExternalAgents = useMemo(
     () =>

--- a/components/ai/AgentSelector.tsx
+++ b/components/ai/AgentSelector.tsx
@@ -33,6 +33,7 @@ interface AgentSelectorProps {
   onRediscover?: () => void;
   onManageAgents?: () => void;
   parked?: boolean;
+  disabled?: boolean;
 }
 
 const BUILTIN_AGENTS: AgentInfo[] = [
@@ -127,13 +128,14 @@ const AgentSelector: React.FC<AgentSelectorProps> = ({
   onRediscover,
   onManageAgents,
   parked = false,
+  disabled = false,
 }) => {
   const { t } = useI18n();
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    if (parked) setOpen(false);
-  }, [parked]);
+    if (parked || disabled) setOpen(false);
+  }, [disabled, parked]);
 
   const enabledExternalAgents = useMemo(
     () =>
@@ -206,7 +208,8 @@ const AgentSelector: React.FC<AgentSelectorProps> = ({
       <DropdownTrigger asChild>
         <button
           type="button"
-          className="group flex h-6 min-w-0 max-w-[170px] items-center gap-1.5 rounded-md px-1.5 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/28"
+          disabled={disabled}
+          className="group flex h-6 min-w-0 max-w-[170px] items-center gap-1.5 rounded-md px-1.5 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/28 disabled:pointer-events-none disabled:opacity-50"
         >
           <AgentIconBadge
             agent={currentAgent}

--- a/components/ai/ChatInput.test.tsx
+++ b/components/ai/ChatInput.test.tsx
@@ -62,6 +62,12 @@ test('expanded composer grows the text area while keeping controls at the bottom
   assert.doesNotMatch(source, /setExpanded/);
 });
 
+test('parked composer closes body-portaled menus', () => {
+  const source = readFileSync(new URL('./ChatInput.tsx', import.meta.url), 'utf8');
+  assert.match(source, /parked = false/);
+  assert.match(source, /if \(parked\) closeAllMenus\(\)/);
+});
+
 test('composer resizing also ends when pointer capture is unexpectedly lost', () => {
   const source = readFileSync(new URL('./ChatInput.tsx', import.meta.url), 'utf8');
 

--- a/components/ai/ChatInput.test.tsx
+++ b/components/ai/ChatInput.test.tsx
@@ -198,6 +198,11 @@ test('renders the Catty context usage ring after the model chip', () => {
   assert.match(html, /aria-valuenow="50"/);
 });
 
+test('slash picker system commands clear the local composer', () => {
+  const source = readFileSync(new URL('./ChatInput.tsx', import.meta.url), 'utf8');
+  assert.match(source, /if \(command === 'stop'\) onStop\?\.\(\);\s*commitComposerText\(''\);/s);
+});
+
 test('ChatInput wires /compact through getSystemSlashCommand and canCompact', () => {
   const source = readFileSync(new URL('./ChatInput.tsx', import.meta.url), 'utf8');
   assert.match(source, /getSystemSlashCommand/);

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -38,6 +38,7 @@ import { ProviderIconBadge } from '../settings/tabs/ai/ProviderIconBadge';
 import { VariableSizeVirtualList, type VariableSizeVirtualListHandle } from '../ui/VariableSizeVirtualList';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import type { AgentContextUsage } from '../../application/state/useAgentCompactionUi';
+import { markAiComposerActivity } from './aiMarkdownWarmup';
 import {
   CHAT_INPUT_DEFAULT_HEIGHT,
   CHAT_INPUT_MAX_HEIGHT,
@@ -180,6 +181,8 @@ const ChatInput: React.FC<ChatInputProps> = ({
   const { t } = useI18n();
   const hasTerminalSelectionAttachment = files.some((file) => file.terminalSelection);
   const composerDisabled = disabled || isSteering;
+  const [composerText, setComposerText] = useState(value);
+  const pushedParentTextRef = useRef(value);
   const [composerHeight, setComposerHeight] = useState<number | null>(null);
   const [composerMaxHeight, setComposerMaxHeight] = useState(CHAT_INPUT_MAX_HEIGHT);
   const composerDesiredHeightRef = useRef<number | null>(null);
@@ -337,6 +340,18 @@ const ChatInput: React.FC<ChatInputProps> = ({
     document.body.style.userSelect = resizeStart.previousUserSelect;
   }, []);
 
+  useEffect(() => {
+    if (value === pushedParentTextRef.current) return;
+    pushedParentTextRef.current = value;
+    setComposerText(value);
+  }, [value]);
+
+  const commitComposerText = useCallback((next: string) => {
+    pushedParentTextRef.current = next;
+    setComposerText(next);
+    onChange(next);
+  }, [onChange]);
+
   const findSlashTrigger = useCallback((text: string, caretPosition: number) => {
     const beforeCaret = text.slice(0, caretPosition);
     const match = /(^|\s)\/([a-z0-9-]*)$/i.exec(beforeCaret);
@@ -363,12 +378,13 @@ const ChatInput: React.FC<ChatInputProps> = ({
   }, []);
 
   const handleInputChange = useCallback((newValue: string) => {
-    onChange(newValue);
+    markAiComposerActivity();
+    commitComposerText(newValue);
     const caretPosition = textareaRef.current?.selectionStart ?? newValue.length;
     // Detect if user just typed @
     if (
       hosts.length > 0 &&
-      newValue.length > value.length &&
+      newValue.length > composerText.length &&
       newValue.endsWith('@')
     ) {
       // Position the popover near the textarea
@@ -396,18 +412,18 @@ const ChatInput: React.FC<ChatInputProps> = ({
     } else if (showSlashCommandPicker) {
       closeAllMenus();
     }
-  }, [onChange, value, hosts.length, showAtMention, findSlashTrigger, showSlashCommandPicker, closeAllMenus, getInputPanelMenuPos]);
+  }, [commitComposerText, composerText, hosts.length, showAtMention, findSlashTrigger, showSlashCommandPicker, closeAllMenus, getInputPanelMenuPos]);
 
   const handleSelectAtMention = useCallback((host: { label: string; hostname: string }) => {
     // Replace the trailing @ with @hostname
     const name = host.label || host.hostname;
-    const lastAt = value.lastIndexOf('@');
+    const lastAt = composerText.lastIndexOf('@');
     const newValue = lastAt >= 0
-      ? value.slice(0, lastAt) + `@${name} `
-      : value + `@${name} `;
-    onChange(newValue);
+      ? composerText.slice(0, lastAt) + `@${name} `
+      : composerText + `@${name} `;
+    commitComposerText(newValue);
     closeAllMenus();
-  }, [value, onChange, closeAllMenus]);
+  }, [composerText, commitComposerText, closeAllMenus]);
 
   const openInputPanelMenu = useCallback((menu: 'atMention' | 'slashCommand') => {
     const pos = getInputPanelMenuPos();
@@ -415,8 +431,8 @@ const ChatInput: React.FC<ChatInputProps> = ({
     setMenuPos(null);
     setInputPanelPos(pos);
     if (menu === 'slashCommand') {
-      const caret = textareaRef.current?.selectionStart ?? value.length;
-      const trigger = findSlashTrigger(value, caret);
+      const caret = textareaRef.current?.selectionStart ?? composerText.length;
+      const trigger = findSlashTrigger(composerText, caret);
       if (trigger) {
         setSlashQuery(trigger.query);
         setSlashRange({ start: trigger.start, end: trigger.end });
@@ -426,7 +442,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
       }
     }
     setActiveMenu(menu);
-  }, [findSlashTrigger, getInputPanelMenuPos, value]);
+  }, [findSlashTrigger, getInputPanelMenuPos, composerText]);
 
   const userSkillOptions = useMemo<UserSkillSlashOption[]>(
     () => (lockTurnConfiguration ? [] : userSkills).map((skill) => ({
@@ -492,37 +508,37 @@ const ChatInput: React.FC<ChatInputProps> = ({
   const showSlashPickerUI = showSlashCommandPicker && (inputPanelPos != null || menuPos != null);
 
   const removeSlashQueryFromInput = useCallback(() => {
-    if (!slashRange) return value;
-    const before = value.slice(0, slashRange.start);
-    const after = value.slice(slashRange.end);
+    if (!slashRange) return composerText;
+    const before = composerText.slice(0, slashRange.start);
+    const after = composerText.slice(slashRange.end);
     if (/\s$/.test(before) && /^\s/.test(after)) {
       return `${before}${after.slice(1)}`;
     }
     return `${before}${after}`;
-  }, [slashRange, value]);
+  }, [slashRange, composerText]);
 
   const insertUserSkillToken = useCallback((skill: { slug: string }) => {
     if (lockTurnConfiguration) return;
     onAddUserSkill?.(skill.slug);
     if (slashRange) {
-      onChange(removeSlashQueryFromInput());
+      commitComposerText(removeSlashQueryFromInput());
     }
     closeAllMenus();
-  }, [closeAllMenus, lockTurnConfiguration, onAddUserSkill, onChange, removeSlashQueryFromInput, slashRange]);
+  }, [closeAllMenus, lockTurnConfiguration, onAddUserSkill, commitComposerText, removeSlashQueryFromInput, slashRange]);
 
   const insertQuickMessage = useCallback((message: AIQuickMessage) => {
     if (slashRange) {
-      const before = value.slice(0, slashRange.start);
-      const after = value.slice(slashRange.end);
+      const before = composerText.slice(0, slashRange.start);
+      const after = composerText.slice(slashRange.end);
       const spacerBefore = before.length > 0 && !/\s$/.test(before) ? ' ' : '';
       const spacerAfter = after.length > 0 && !/^\s/.test(after) ? ' ' : '';
-      onChange(`${before}${spacerBefore}${message.content}${spacerAfter}${after}`);
+      commitComposerText(`${before}${spacerBefore}${message.content}${spacerAfter}${after}`);
     } else {
-      const spacer = value.length > 0 && !/\s$/.test(value) ? ' ' : '';
-      onChange(`${value}${spacer}${message.content}`);
+      const spacer = composerText.length > 0 && !/\s$/.test(composerText) ? ' ' : '';
+      commitComposerText(`${composerText}${spacer}${message.content}`);
     }
     closeAllMenus();
-  }, [closeAllMenus, onChange, slashRange, value]);
+  }, [closeAllMenus, commitComposerText, composerText, slashRange]);
 
   const handleSelectSlashCommandItem = useCallback((item: SlashCommandItem) => {
     if (item.kind === 'system') {
@@ -677,17 +693,17 @@ const ChatInput: React.FC<ChatInputProps> = ({
 
   const handleSubmit = useCallback(
     (_text: string, _event: FormEvent<HTMLFormElement>) => {
-      const systemCommand = getSystemSlashCommand(value);
+      const systemCommand = getSystemSlashCommand(composerText);
       if (systemCommand) {
         if (systemCommand === 'compact') {
           if (!canCompact) return;
           onCompact?.();
-          onChange('');
+          commitComposerText('');
           return;
         }
         if (systemCommand === 'stop') {
           onStop?.();
-          onChange('');
+          commitComposerText('');
           return;
         }
         return;
@@ -698,7 +714,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
       }
       onSend();
     },
-    [canCompact, canSteer, isStreaming, onCompact, onSend, onSteer, onStop, onChange, value],
+    [canCompact, canSteer, commitComposerText, composerText, isStreaming, onCompact, onSend, onSteer, onStop],
   );
 
   const status: PromptInputStatus = isStreaming ? 'streaming' : 'idle';
@@ -912,8 +928,11 @@ const ChatInput: React.FC<ChatInputProps> = ({
           )}
           <PromptInputTextarea
             ref={textareaRef}
-            value={value}
+            value={composerText}
             onChange={(e) => handleInputChange(e.target.value)}
+            onFocus={() => markAiComposerActivity()}
+            onCompositionStart={() => markAiComposerActivity()}
+            onCompositionUpdate={() => markAiComposerActivity()}
             onKeyDown={handleTextareaKeyDown}
             placeholder={placeholder || (isStreaming && canSteer ? t('ai.codex.steer.placeholder') : defaultPlaceholder)}
             disabled={composerDisabled}
@@ -1426,7 +1445,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
                   <TooltipTrigger asChild>
                     <button
                       type="submit"
-                      disabled={(!value.trim() && !hasTerminalSelectionAttachment) || composerDisabled}
+                      disabled={(!composerText.trim() && !hasTerminalSelectionAttachment) || composerDisabled}
                       aria-label={isSteering ? t('ai.codex.steer.sending') : t('ai.codex.steer.addInstruction')}
                       className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-foreground/20 bg-foreground text-background shadow-sm transition-colors hover:bg-foreground/90 disabled:border-border/80 disabled:bg-muted/52 disabled:text-foreground/72"
                     >
@@ -1441,7 +1460,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
               <PromptInputSubmit
                 status={status}
                 onStop={onStop}
-                disabled={(!value.trim() && !hasTerminalSelectionAttachment) || disabled}
+                disabled={(!composerText.trim() && !hasTerminalSelectionAttachment) || disabled}
               />
             )}
           </div>

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -558,7 +558,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
         onCompact?.();
       }
       if (command === 'stop') onStop?.();
-      onChange('');
+      commitComposerText('');
       closeAllMenus();
       return;
     }
@@ -567,7 +567,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
       return;
     }
     insertUserSkillToken(item.skill);
-  }, [canCompact, closeAllMenus, insertQuickMessage, insertUserSkillToken, onChange, onCompact, onStop]);
+  }, [canCompact, closeAllMenus, commitComposerText, insertQuickMessage, insertUserSkillToken, onCompact, onStop]);
 
   // Reset active highlight when a menu opens or when the *identity* of the
   // visible items changes. Watching only `.length` misses cases where the

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -142,6 +142,8 @@ interface ChatInputProps {
    * `modelPresets` dropdown because their provider is wired inside the CLI.
    */
   providerSwitcher?: ProviderSwitcherConfig;
+  /** Hidden retained panels must not leave body-portaled menus open. */
+  parked?: boolean;
 }
 
 const ChatInput: React.FC<ChatInputProps> = ({
@@ -177,6 +179,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
   permissionMode,
   onPermissionModeChange,
   providerSwitcher,
+  parked = false,
 }) => {
   const { t } = useI18n();
   const hasTerminalSelectionAttachment = files.some((file) => file.terminalSelection);
@@ -212,6 +215,10 @@ const ChatInput: React.FC<ChatInputProps> = ({
     setSlashQuery('');
     setSlashRange(null);
   }, []);
+
+  useEffect(() => {
+    if (parked) closeAllMenus();
+  }, [closeAllMenus, parked]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const inputShellRef = useRef<HTMLDivElement>(null);
   const resizeStartRef = useRef<{

--- a/components/ai/ChatMessageList.tsx
+++ b/components/ai/ChatMessageList.tsx
@@ -18,6 +18,11 @@ import {
 } from '../ai-elements/conversation';
 import { LazyMessageResponse } from '../ai-elements/LazyMessageResponse';
 import { Message, MessageContent } from '../ai-elements/messageShell';
+import {
+  AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS,
+  AI_MARKDOWN_WARMUP_RESUME_DELAY_MS,
+  scheduleAiMarkdownWarmup,
+} from './aiMarkdownWarmup';
 import { ToolCall } from '../ai-elements/tool-call';
 import ThinkingBlock from './ThinkingBlock';
 import AgentActivityGroup from './AgentActivityGroup';
@@ -371,6 +376,22 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
     setPendingJumpMessageId(null);
   }, [activeSessionId]);
 
+  const hasAssistantMarkdown = useMemo(
+    () => messages.some((message) => message.role === 'assistant' && Boolean(message.content)),
+    [messages],
+  );
+
+  // Do not start Streamdown on expand. Import cannot be cancelled, and idle
+  // right after open collides with the first few keystrokes. History stays
+  // plaintext until send, composer blur, or a long unfocused delay.
+  useEffect(() => {
+    if (!hasAssistantMarkdown) return undefined;
+    return scheduleAiMarkdownWarmup({
+      initialDelayMs: AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS,
+      resumeDelayMs: AI_MARKDOWN_WARMUP_RESUME_DELAY_MS,
+    });
+  }, [hasAssistantMarkdown]);
+
   const visibleMessages = useMemo(
     () => messages.filter((message) => message.role !== 'system'),
     [messages],
@@ -714,7 +735,7 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
                       : (
                           <React.Profiler {...getAIPanelProfilerProps('AIChatPanel.Markdown')}>
                             <div data-ai-content="markdown">
-                              <LazyMessageResponse isAnimating={!!isThisStreaming}>
+                              <LazyMessageResponse deferUntilWarm isAnimating={!!isThisStreaming}>
                                 {message.content}
                               </LazyMessageResponse>
                             </div>

--- a/components/ai/aiMarkdownWarmup.test.ts
+++ b/components/ai/aiMarkdownWarmup.test.ts
@@ -37,6 +37,7 @@ test('composer-idle IPC waits the same expand grace as history markdown', () => 
   assert.match(warmup, /initialDelayMs:\s*options\?\.initialDelayMs \?\? AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS/);
   assert.match(warmup, /isBusy: isAiComposerRecentlyActive/);
   assert.match(warmup, /markAiComposerActivity\(\);\n\s*arm\(\);/);
+  assert.match(warmup, /if \(isAiComposerRecentlyActive\(\)\) \{\s*hydrateScheduled = true;/s);
 });
 
 test('history markdown waits after expand, then resumes quickly after blur', () => {

--- a/components/ai/aiMarkdownWarmup.test.ts
+++ b/components/ai/aiMarkdownWarmup.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+import {
+  AI_COMPOSER_IDLE_MS,
+  AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS,
+  AI_MARKDOWN_WARMUP_RESUME_DELAY_MS,
+  isAiComposerBusy,
+  isAiComposerTarget,
+  markAiComposerActivity,
+  resolveAiMarkdownWarmupDelay,
+  shouldDeferAiMarkdownWarmup,
+} from './aiMarkdownWarmup';
+
+test('defers markdown warmup while the composer is focused, composing, or recently active', () => {
+  assert.equal(shouldDeferAiMarkdownWarmup({}), false);
+  assert.equal(shouldDeferAiMarkdownWarmup({ composerFocused: true }), true);
+  assert.equal(shouldDeferAiMarkdownWarmup({ isComposing: true }), true);
+  assert.equal(shouldDeferAiMarkdownWarmup({ recentlyActive: true }), true);
+});
+
+test('recent composer activity counts as busy', () => {
+  markAiComposerActivity();
+  assert.equal(isAiComposerBusy(), true);
+  assert.ok(AI_COMPOSER_IDLE_MS >= 600);
+});
+
+test('recognizes the chat composer as a busy warmup target', () => {
+  const body = { closest: (sel: string) => (sel.includes('ai-chat-input-body') ? {} : null) };
+  assert.equal(isAiComposerTarget(body as unknown as EventTarget), true);
+  assert.equal(isAiComposerTarget(null), false);
+});
+
+test('history markdown waits after expand, then resumes quickly after blur', () => {
+  assert.equal(AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS, 4000);
+  assert.equal(AI_MARKDOWN_WARMUP_RESUME_DELAY_MS, 600);
+  assert.equal(resolveAiMarkdownWarmupDelay({
+    hasArmed: false,
+    initialDelayMs: AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS,
+    resumeDelayMs: AI_MARKDOWN_WARMUP_RESUME_DELAY_MS,
+  }), 4000);
+  assert.equal(resolveAiMarkdownWarmupDelay({
+    hasArmed: true,
+    initialDelayMs: AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS,
+    resumeDelayMs: AI_MARKDOWN_WARMUP_RESUME_DELAY_MS,
+  }), 600);
+});
+
+test('AI panel no longer starts Streamdown just because it became visible', () => {
+  const panel = readFileSync(new URL('../AIChatSidePanel.tsx', import.meta.url), 'utf8');
+  assert.doesNotMatch(panel, /scheduleAiMarkdownWarmup/);
+  assert.match(panel, /warmAiMarkdownRenderer/);
+  assert.doesNotMatch(panel, /timeout:\s*2500/);
+  assert.doesNotMatch(panel, /import\('\.\/ai-elements\/messageResponse'\)/);
+});
+
+test('chat history defers Streamdown until warmup is already done', () => {
+  const list = readFileSync(new URL('./ChatMessageList.tsx', import.meta.url), 'utf8');
+  assert.match(list, /deferUntilWarm/);
+  assert.match(list, /scheduleAiMarkdownWarmup/);
+  assert.match(list, /AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS/);
+  assert.match(list, /AI_MARKDOWN_WARMUP_RESUME_DELAY_MS/);
+});
+
+test('LazyMessageResponse keeps plaintext while chat asks to defer', () => {
+  const source = readFileSync(new URL('../ai-elements/LazyMessageResponse.tsx', import.meta.url), 'utf8');
+  assert.match(source, /deferUntilWarm/);
+  assert.match(source, /enqueueChatMarkdownHydrate/);
+  assert.match(source, /isAiMarkdownRendererReady/);
+});

--- a/components/ai/aiMarkdownWarmup.test.ts
+++ b/components/ai/aiMarkdownWarmup.test.ts
@@ -35,6 +35,8 @@ test('recognizes the chat composer as a busy warmup target', () => {
 test('composer-idle IPC waits the same expand grace as history markdown', () => {
   const warmup = readFileSync(new URL('./aiMarkdownWarmup.ts', import.meta.url), 'utf8');
   assert.match(warmup, /initialDelayMs:\s*options\?\.initialDelayMs \?\? AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS/);
+  assert.match(warmup, /isBusy: isAiComposerRecentlyActive/);
+  assert.match(warmup, /markAiComposerActivity\(\);\n\s*arm\(\);/);
 });
 
 test('history markdown waits after expand, then resumes quickly after blur', () => {

--- a/components/ai/aiMarkdownWarmup.test.ts
+++ b/components/ai/aiMarkdownWarmup.test.ts
@@ -32,6 +32,11 @@ test('recognizes the chat composer as a busy warmup target', () => {
   assert.equal(isAiComposerTarget(null), false);
 });
 
+test('composer-idle IPC waits the same expand grace as history markdown', () => {
+  const warmup = readFileSync(new URL('./aiMarkdownWarmup.ts', import.meta.url), 'utf8');
+  assert.match(warmup, /initialDelayMs:\s*options\?\.initialDelayMs \?\? AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS/);
+});
+
 test('history markdown waits after expand, then resumes quickly after blur', () => {
   assert.equal(AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS, 4000);
   assert.equal(AI_MARKDOWN_WARMUP_RESUME_DELAY_MS, 600);

--- a/components/ai/aiMarkdownWarmup.ts
+++ b/components/ai/aiMarkdownWarmup.ts
@@ -143,7 +143,7 @@ export function scheduleWhenAiComposerIdle(
 ): () => void {
   return scheduleAiMarkdownWarmup({
     load: task,
-    initialDelayMs: options?.initialDelayMs ?? 0,
+    initialDelayMs: options?.initialDelayMs ?? AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS,
     resumeDelayMs: options?.resumeDelayMs ?? AI_COMPOSER_IDLE_MS,
   });
 }

--- a/components/ai/aiMarkdownWarmup.ts
+++ b/components/ai/aiMarkdownWarmup.ts
@@ -143,6 +143,7 @@ export function scheduleWhenAiComposerIdle(
 ): () => void {
   return scheduleAiMarkdownWarmup({
     load: task,
+    isBusy: isAiComposerRecentlyActive,
     initialDelayMs: options?.initialDelayMs ?? AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS,
     resumeDelayMs: options?.resumeDelayMs ?? AI_COMPOSER_IDLE_MS,
   });
@@ -223,7 +224,7 @@ export function scheduleAiMarkdownWarmup(options?: {
   const onFocusIn = (event: FocusEvent) => {
     if (isAiComposerTarget(event.target)) {
       markAiComposerActivity();
-      clearTimers();
+      arm();
     }
   };
   const onFocusOut = (event: FocusEvent) => {
@@ -232,7 +233,7 @@ export function scheduleAiMarkdownWarmup(options?: {
   const onComposerEvent = (event: Event) => {
     if (!isAiComposerTarget(event.target)) return;
     markAiComposerActivity();
-    clearTimers();
+    arm();
   };
 
   if (typeof window !== 'undefined') {

--- a/components/ai/aiMarkdownWarmup.ts
+++ b/components/ai/aiMarkdownWarmup.ts
@@ -1,0 +1,257 @@
+const AI_COMPOSER_FOCUS_SELECTOR =
+  '[data-section="ai-chat-input-body"], [data-section="ai-chat-panel"] textarea';
+
+/** Wait after expand before history markdown can start — covers the type-a-few-chars window. */
+export const AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS = 4000;
+/** After the composer blurs, a short pause is enough to know typing stopped. */
+export const AI_MARKDOWN_WARMUP_RESUME_DELAY_MS = 600;
+/** Treat recent keystrokes as busy even if focus already moved. */
+export const AI_COMPOSER_IDLE_MS = 800;
+const CHAT_MARKDOWN_HYDRATE_BATCH = 2;
+
+let markdownWarmupPromise: Promise<unknown> | null = null;
+let markdownWarmupResolved = false;
+let lastComposerActivityAt = 0;
+const readyListeners = new Set<() => void>();
+const hydrateQueue: Array<() => void> = [];
+let hydrateScheduled = false;
+
+function notifyAiMarkdownRendererReady(): void {
+  markdownWarmupResolved = true;
+  for (const listener of readyListeners) listener();
+  readyListeners.clear();
+  pumpChatMarkdownHydrate();
+}
+
+export function isAiComposerTarget(target: EventTarget | null): boolean {
+  if (!target || typeof (target as Element).closest !== 'function') return false;
+  return Boolean((target as Element).closest(AI_COMPOSER_FOCUS_SELECTOR));
+}
+
+export function markAiComposerActivity(): void {
+  lastComposerActivityAt = Date.now();
+}
+
+export function isAiComposerRecentlyActive(now = Date.now()): boolean {
+  return lastComposerActivityAt > 0 && now - lastComposerActivityAt < AI_COMPOSER_IDLE_MS;
+}
+
+export function shouldDeferAiMarkdownWarmup(input: {
+  composerFocused?: boolean;
+  isComposing?: boolean;
+  recentlyActive?: boolean;
+}): boolean {
+  return Boolean(input.composerFocused || input.isComposing || input.recentlyActive);
+}
+
+export function isAiComposerBusy(): boolean {
+  const active = typeof document === 'undefined' ? null : document.activeElement;
+  return shouldDeferAiMarkdownWarmup({
+    composerFocused: isAiComposerTarget(active),
+    recentlyActive: isAiComposerRecentlyActive(),
+  });
+}
+
+export function isAiMarkdownRendererReady(): boolean {
+  return markdownWarmupResolved;
+}
+
+export function subscribeAiMarkdownRendererReady(listener: () => void): () => void {
+  if (markdownWarmupResolved) {
+    listener();
+    return () => {};
+  }
+  readyListeners.add(listener);
+  return () => {
+    readyListeners.delete(listener);
+  };
+}
+
+export function resolveAiMarkdownWarmupDelay(input: {
+  hasArmed: boolean;
+  initialDelayMs: number;
+  resumeDelayMs: number;
+}): number {
+  return input.hasArmed ? input.resumeDelayMs : input.initialDelayMs;
+}
+
+/** Prefetch Streamdown off the first-keystroke path. Safe to call repeatedly. */
+export function warmAiMarkdownRenderer(): Promise<unknown> {
+  markdownWarmupPromise ??= import('../ai-elements/messageResponse').then((module) => {
+    notifyAiMarkdownRendererReady();
+    return module;
+  }, (error) => {
+    markdownWarmupPromise = null;
+    throw error;
+  });
+  return markdownWarmupPromise;
+}
+
+function pumpChatMarkdownHydrate(): void {
+  if (hydrateScheduled) return;
+  hydrateScheduled = true;
+  const run = () => {
+    hydrateScheduled = false;
+    if (hydrateQueue.length === 0) return;
+    if (!markdownWarmupResolved) return;
+    if (isAiComposerBusy()) {
+      hydrateScheduled = true;
+      window.setTimeout(() => {
+        hydrateScheduled = false;
+        pumpChatMarkdownHydrate();
+      }, AI_COMPOSER_IDLE_MS);
+      return;
+    }
+    const batch = hydrateQueue.splice(0, CHAT_MARKDOWN_HYDRATE_BATCH);
+    for (const task of batch) task();
+    if (hydrateQueue.length > 0) {
+      pumpChatMarkdownHydrate();
+    }
+  };
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(run);
+    return;
+  }
+  queueMicrotask(run);
+}
+
+/** Upgrade deferred chat rows a few at a time, never while the composer is busy. */
+export function enqueueChatMarkdownHydrate(onReady: () => void): () => void {
+  let cancelled = false;
+  const task = () => {
+    if (!cancelled) onReady();
+  };
+  hydrateQueue.push(task);
+  pumpChatMarkdownHydrate();
+  return () => {
+    cancelled = true;
+    const index = hydrateQueue.indexOf(task);
+    if (index >= 0) hydrateQueue.splice(index, 1);
+  };
+}
+
+/**
+ * Run `task` only when the composer is idle. Import/IPC cannot be cancelled
+ * once started, so this must not fire during expand → first type.
+ */
+export function scheduleWhenAiComposerIdle(
+  task: () => void,
+  options?: {
+    initialDelayMs?: number;
+    resumeDelayMs?: number;
+  },
+): () => void {
+  return scheduleAiMarkdownWarmup({
+    load: task,
+    initialDelayMs: options?.initialDelayMs ?? 0,
+    resumeDelayMs: options?.resumeDelayMs ?? AI_COMPOSER_IDLE_MS,
+  });
+}
+
+/**
+ * Load markdown only when the browser is idle and the composer is not focused.
+ * Import() cannot be cancelled, so this must not start during expand → first type.
+ */
+export function scheduleAiMarkdownWarmup(options?: {
+  isBusy?: () => boolean;
+  load?: () => void;
+  initialDelayMs?: number;
+  resumeDelayMs?: number;
+}): () => void {
+  const isBusy = options?.isBusy ?? isAiComposerBusy;
+  const load = options?.load ?? (() => {
+    void warmAiMarkdownRenderer();
+  });
+  const initialDelayMs = options?.initialDelayMs ?? 0;
+  const resumeDelayMs = options?.resumeDelayMs ?? 0;
+
+  let idleId: number | null = null;
+  let timeoutId: number | null = null;
+  let cancelled = false;
+  let hasArmed = false;
+
+  const clearTimers = () => {
+    if (idleId != null && typeof cancelIdleCallback === 'function') {
+      cancelIdleCallback(idleId);
+    }
+    idleId = null;
+    if (timeoutId != null) {
+      window.clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  };
+
+  const tryLoad = () => {
+    idleId = null;
+    timeoutId = null;
+    if (cancelled) return;
+    if (isBusy()) {
+      timeoutId = window.setTimeout(armIdle, Math.max(resumeDelayMs, AI_COMPOSER_IDLE_MS));
+      return;
+    }
+    load();
+  };
+
+  const armIdle = () => {
+    if (cancelled) return;
+    if (typeof requestIdleCallback === 'function') {
+      idleId = requestIdleCallback(tryLoad);
+      return;
+    }
+    timeoutId = window.setTimeout(tryLoad, 2000);
+  };
+
+  const arm = () => {
+    if (cancelled) return;
+    clearTimers();
+    const delay = resolveAiMarkdownWarmupDelay({
+      hasArmed,
+      initialDelayMs,
+      resumeDelayMs,
+    });
+    hasArmed = true;
+    if (delay > 0) {
+      timeoutId = window.setTimeout(() => {
+        timeoutId = null;
+        armIdle();
+      }, delay);
+      return;
+    }
+    armIdle();
+  };
+
+  const onFocusIn = (event: FocusEvent) => {
+    if (isAiComposerTarget(event.target)) {
+      markAiComposerActivity();
+      clearTimers();
+    }
+  };
+  const onFocusOut = (event: FocusEvent) => {
+    if (isAiComposerTarget(event.target)) arm();
+  };
+  const onComposerEvent = (event: Event) => {
+    if (!isAiComposerTarget(event.target)) return;
+    markAiComposerActivity();
+    clearTimers();
+  };
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('focusin', onFocusIn);
+    window.addEventListener('focusout', onFocusOut);
+    window.addEventListener('keydown', onComposerEvent, true);
+    window.addEventListener('compositionstart', onComposerEvent, true);
+    window.addEventListener('compositionupdate', onComposerEvent, true);
+  }
+  arm();
+
+  return () => {
+    cancelled = true;
+    clearTimers();
+    if (typeof window === 'undefined') return;
+    window.removeEventListener('focusin', onFocusIn);
+    window.removeEventListener('focusout', onFocusOut);
+    window.removeEventListener('keydown', onComposerEvent, true);
+    window.removeEventListener('compositionstart', onComposerEvent, true);
+    window.removeEventListener('compositionupdate', onComposerEvent, true);
+  };
+}

--- a/components/ai/aiMarkdownWarmup.ts
+++ b/components/ai/aiMarkdownWarmup.ts
@@ -94,7 +94,7 @@ function pumpChatMarkdownHydrate(): void {
     hydrateScheduled = false;
     if (hydrateQueue.length === 0) return;
     if (!markdownWarmupResolved) return;
-    if (isAiComposerBusy()) {
+    if (isAiComposerRecentlyActive()) {
       hydrateScheduled = true;
       window.setTimeout(() => {
         hydrateScheduled = false;

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -56,6 +56,12 @@ const LazyAIChatSidePanel = lazy(() =>
   import('../AIChatSidePanel').then((module) => ({ default: module.AIChatSidePanel })),
 );
 
+if (typeof requestIdleCallback === 'function') {
+  requestIdleCallback(() => {
+    void import('../AIChatSidePanel');
+  });
+}
+
 const AIChatSidePanelFallback = memo(function AIChatSidePanelFallback() {
   return (
     <div className="netcatty-lazy-fade-in h-full min-h-0 bg-background" aria-hidden="true" />


### PR DESCRIPTION
## Summary

Opening the AI chat panel and typing a few characters could hitch once, then feel fine. Streamdown parse, composer remount, draft-store fan-out, and expand-time IPC all raced the first keystrokes. `import()` cannot be cancelled, so the heavy markdown renderer must not start while the composer is busy.

This keeps typing off that path: the composer stays mounted on hidden retained panels, composer-text updates no longer notify the AI host, and discovery/skills/model work waits until the composer is idle. History stays plaintext until Streamdown is warm, then hydrates a few rows at a time.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Keep `ChatInput` mounted on hidden retained panels; park only the message list.
- Skip the empty-panel Preparing delay so the first expand can type immediately.
- Debounce composer-text store writes and skip `aiSessionsStore` listener notify when only draft text changed.
- Fast-path `aiChatSidePanelPropsAreEqual` before scoped history ranking.
- Defer agent discovery, user skills, model catalog, and provider sync until the composer is idle. Remove the 2s forced discovery timeout.
- Defer Streamdown until send / idle / blur; hydrate deferred history rows in small batches.
- Prefetch the AI panel chunk on terminal idle (no forced timeout).

## Screenshots / Demo

Expand the AI panel and type immediately. The first few characters should no longer hitch. History may stay plaintext until you send, blur, or leave the composer idle.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Checked the focused suites for this change (`aiMarkdownWarmup`, mount retention, draft/session store, ChatMessageList, ChatInput) and eslint on the touched files. Full `npm test` / `npm run lint` were not re-run as a complete repo pass.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)