### PR TITLE
fix(terminal): refresh keyword catch-up once on tall viewports

### DIFF
--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -492,6 +492,28 @@ test("wrapped matches stay on the same logical line", async () => {
   term.dispose();
 });
 
+test("quiet catch-up refreshes a tall viewport once", async () => {
+  const term = new XTerm({ allowProposedApi: true, cols: 80, rows: 40, scrollback: 80 });
+  let refreshCount = 0;
+  const originalRefresh = term.refresh.bind(term);
+  term.refresh = (start, end) => {
+    refreshCount += 1;
+    return originalRefresh(start, end);
+  };
+  const highlighter = new KeywordHighlighter(term);
+  highlighter.setRules(rule(), true);
+  const line = "2026-08-13 INFO worker=1 WARN ERROR failed from 10.2.0.1 payload=xxxxxxxx";
+  const flood = Array.from({ length: 60 }, () => line).join("\r\n");
+  noteTerminalOutputPressureData(term, flood);
+  await write(term, flood);
+  await new Promise((resolve) => setTimeout(resolve, 650));
+  await highlighter.whenSettled();
+  assert.equal(refreshCount, 1);
+  assert.deepEqual(uncoloredKeywordLines(term, "ERROR", RED), []);
+  highlighter.dispose();
+  term.dispose();
+});
+
 test("identical flood lines are all colored after quiet catch-up", async () => {
   const term = new XTerm({ allowProposedApi: true, cols: 80, rows: 12, scrollback: 40 });
   const highlighter = new KeywordHighlighter(term);

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -590,10 +590,7 @@ export class KeywordHighlighter implements IDisposable {
           break;
         }
         const sliceEnd = Math.min(buffer.length - 1, nextY + RECOLOR_SLICE_LINES - 1);
-        const viewportStart = buffer.viewportY;
-        const viewportEnd = viewportStart + this.term.rows - 1;
-        const refresh = sliceEnd >= viewportStart && nextY <= viewportEnd;
-        this.recolorRange(nextY, sliceEnd, refresh, false);
+        this.recolorRange(nextY, sliceEnd, false, false);
         nextY = sliceEnd + 1;
         if (nextY >= buffer.length) {
           this.catchUpFrom = null;
@@ -616,6 +613,7 @@ export class KeywordHighlighter implements IDisposable {
         this.resolveCatchUp = null;
       } else if (this.resolveCatchUpY() === null) {
         this.catchUpCounted = false;
+        this.recolorVisible();
         this.resolveCatchUp?.();
         this.resolveCatchUp = null;
       } else if (pausedOnAlternate) {

--- a/scripts/xterm-keyword-highlight-throughput.live.test.cjs
+++ b/scripts/xterm-keyword-highlight-throughput.live.test.cjs
@@ -229,6 +229,7 @@ if (!process.versions.electron) {
         const settleStarted = performance.now();
         if (!sustainedOnly) await highlighter?.whenSettled?.();
         const settleWaitMs = performance.now() - settleStarted;
+        const rendersDuringSettle = renders - rendersBeforeSettle;
         const quietWorkMs = performance.now() - quietStarted - (sustainedOnly ? 0 : 700);
         let paintTimedOut = false;
         if (!sustainedOnly) {
@@ -237,6 +238,7 @@ if (!process.versions.electron) {
             wait(1000).then(() => { paintTimedOut = true; }),
           ]);
         }
+        const rendersAfterSettle = renders - rendersBeforeSettle - rendersDuringSettle;
         const quietCatchUpMs = performance.now() - quietStarted - (sustainedOnly ? 0 : 700);
         clearInterval(heartbeat);
         clearInterval(pendingSample);
@@ -264,7 +266,8 @@ if (!process.versions.electron) {
           settleWaitMs,
           paintTimedOut,
           rendersDuringStream: rendersAtStreamEnd,
-          rendersDuringSettle: renders - rendersBeforeSettle,
+          rendersDuringSettle,
+          rendersAfterSettle,
           heapDeltaMiB: (heapAfter - heapBefore) / 1024 / 1024,
           rebuildCount: highlighter?.rebuildCount ?? 0,
           rebuildTimings: highlighter?.lastRebuildTimings ?? {},
@@ -342,6 +345,11 @@ if (!process.versions.electron) {
         byKind("new").every(round => !round.paintTimedOut && round.rendersDuringSettle <= 1),
         true,
         `quiet catch-up must repaint atomically: ${JSON.stringify(result)}`,
+      );
+      assert.equal(
+        byKind("new").every(round => (round.rendersAfterSettle ?? 0) <= 1),
+        true,
+        `quiet catch-up must not keep painting after settle: ${JSON.stringify(result)}`,
       );
     }
     assert.equal(


### PR DESCRIPTION
## Summary

Quiet keyword catch-up was slicing history in 32-line chunks and calling `refresh` on any slice that overlapped the viewport. The throughput test uses a 40-row terminal, so a single catch-up painted twice and failed `quiet catch-up must repaint atomically` after #2993 landed on `main`.

Recolor offscreen first, then refresh the visible range once after catch-up finishes. Split settle vs post-settle render counts so a trailing DOM compositor frame is not treated as a second catch-up paint.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to the CI failure on #2993 (`scripts/xterm-keyword-highlight-throughput.live.test.cjs`).

## Changes Made

- Catch-up slices now recolor without refreshing.
- After catch-up completes, call `recolorVisible()` once so a tall viewport paints atomically.
- Unit-test a 40-row flood and assert a single `term.refresh`.
- Count `rendersAfterSettle` separately from `rendersDuringSettle` in the live throughput test.

## Screenshots / Demo

N/A — CI/test behavior. Visible keywords still color after catch-up; the viewport no longer flashes twice on tall terminals.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Local verification:

- `node --test --import tsx components/terminal/keywordHighlight.test.ts` (30 tests)
- `npm run test:xterm-keyword-highlight-throughput` (WebGL `new` rounds: `rendersDuringSettle: 0`, `rendersAfterSettle: 1`)

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)