### PR TITLE
fix(ai): keep composer typing off the draft notify path

### DIFF
--- a/application/state/aiDraftState.test.ts
+++ b/application/state/aiDraftState.test.ts
@@ -57,11 +57,26 @@ test("draftsByScopeEqualIgnoringComposerText ignores typing in the active scope"
 });
 
 test("first composer draft is treated as text-only identity churn", () => {
-  const created = { ...createEmptyDraft("catty"), text: "你" };
+  const empty = createEmptyDraft("catty");
+  const created = { ...empty, text: "你" };
   assert.equal(draftsByScopeEqualIgnoringAllComposerText({}, { "terminal:1": created }), true);
   assert.equal(
     draftsByScopeEqualIgnoringComposerText({}, { "terminal:1": created }, "terminal:1"),
     true,
+  );
+  assert.equal(
+    draftsByScopeEqualIgnoringAllComposerText(
+      { "terminal:1": empty },
+      { "terminal:1": created },
+    ),
+    true,
+  );
+  assert.equal(
+    draftsByScopeEqualIgnoringAllComposerText(
+      { "terminal:1": created },
+      { "terminal:1": empty },
+    ),
+    false,
   );
   assert.equal(
     draftsByScopeEqualIgnoringAllComposerText(

--- a/application/state/aiDraftState.test.ts
+++ b/application/state/aiDraftState.test.ts
@@ -59,6 +59,7 @@ test("draftsByScopeEqualIgnoringComposerText ignores typing in the active scope"
 test("first composer draft is treated as text-only identity churn", () => {
   const empty = createEmptyDraft("catty");
   const created = { ...empty, text: "你" };
+  assert.equal(draftsByScopeEqualIgnoringAllComposerText({}, { "terminal:1": empty }), false);
   assert.equal(draftsByScopeEqualIgnoringAllComposerText({}, { "terminal:1": created }), true);
   assert.equal(
     draftsByScopeEqualIgnoringComposerText({}, { "terminal:1": created }, "terminal:1"),

--- a/application/state/aiDraftState.test.ts
+++ b/application/state/aiDraftState.test.ts
@@ -41,6 +41,33 @@ test("draftsByScopeEqualIgnoringComposerText ignores typing in the active scope"
       { "terminal:1": prev["terminal:1"], "workspace:2": base },
       "terminal:1",
     ),
+    true,
+  );
+  assert.equal(
+    draftsByScopeEqualIgnoringComposerText(
+      prev,
+      {
+        "terminal:1": prev["terminal:1"],
+        "workspace:2": { ...base, attachments: [{ id: "a" } as never] },
+      },
+      "terminal:1",
+    ),
+    false,
+  );
+});
+
+test("first composer draft is treated as text-only identity churn", () => {
+  const created = { ...createEmptyDraft("catty"), text: "你" };
+  assert.equal(draftsByScopeEqualIgnoringAllComposerText({}, { "terminal:1": created }), true);
+  assert.equal(
+    draftsByScopeEqualIgnoringComposerText({}, { "terminal:1": created }, "terminal:1"),
+    true,
+  );
+  assert.equal(
+    draftsByScopeEqualIgnoringAllComposerText(
+      {},
+      { "terminal:1": { ...created, attachments: [{ id: "a" } as never] } },
+    ),
     false,
   );
 });

--- a/application/state/aiDraftState.ts
+++ b/application/state/aiDraftState.ts
@@ -21,7 +21,8 @@ function isComposerOnlyDraft(draft: AIDraft | undefined): boolean {
 
 /**
  * First keystroke creates a missing → composer-only draft. That is still just
- * typing. Clearing a draft (`right` missing) is a real lifecycle change.
+ * typing. Clearing a draft (`right` missing or emptied) is a real lifecycle
+ * change so New Chat / send can reset the uncontrolled composer.
  */
 function draftsEquivalentIgnoringComposerText(
   left: AIDraft | undefined,
@@ -33,6 +34,9 @@ function draftsEquivalentIgnoringComposerText(
   if (left.agentId !== right.agentId) return false;
   if (left.attachments !== right.attachments) return false;
   if (left.selectedUserSkillSlugs !== right.selectedUserSkillSlugs) return false;
+  const leftEmpty = left.text.trim().length === 0;
+  const rightEmpty = right.text.trim().length === 0;
+  if (leftEmpty !== rightEmpty) return leftEmpty;
   return true;
 }
 

--- a/application/state/aiDraftState.ts
+++ b/application/state/aiDraftState.ts
@@ -29,7 +29,7 @@ function draftsEquivalentIgnoringComposerText(
   right: AIDraft | undefined,
 ): boolean {
   if (left === right) return true;
-  if (!left) return isComposerOnlyDraft(right);
+  if (!left) return Boolean(isComposerOnlyDraft(right) && right.text.trim().length > 0);
   if (!right) return false;
   if (left.agentId !== right.agentId) return false;
   if (left.attachments !== right.attachments) return false;
@@ -53,13 +53,21 @@ export function draftsByScopeEqualIgnoringAllComposerText(
   return true;
 }
 
-/** Typing only changes text/updatedAt. The scope key is kept for call-site compatibility. */
+/** Typing only changes text/updatedAt. Sibling empty-draft creates stay ignored. */
 export function draftsByScopeEqualIgnoringComposerText(
   prev: DraftsByScope,
   next: DraftsByScope,
-  _scopeKey?: string,
+  scopeKey: string,
 ): boolean {
-  return draftsByScopeEqualIgnoringAllComposerText(prev, next);
+  if (prev === next) return true;
+  const keys = new Set([...Object.keys(prev), ...Object.keys(next)]);
+  for (const key of keys) {
+    const left = prev[key];
+    const right = next[key];
+    if (key !== scopeKey && !left && isComposerOnlyDraft(right)) continue;
+    if (!draftsEquivalentIgnoringComposerText(left, right)) return false;
+  }
+  return true;
 }
 
 export function createEmptyDraft(agentId: string): AIDraft {

--- a/application/state/aiDraftState.ts
+++ b/application/state/aiDraftState.ts
@@ -11,27 +11,28 @@ type DraftUploadGenerationByScope = Record<string, number>;
 
 const DEFAULT_PANEL_VIEW: AIPanelView = { mode: 'draft' };
 
-/** Typing only changes text/updatedAt. Panel chrome can ignore that identity churn. */
-export function draftsByScopeEqualIgnoringComposerText(
-  prev: DraftsByScope,
-  next: DraftsByScope,
-  scopeKey: string,
+function isComposerOnlyDraft(draft: AIDraft | undefined): boolean {
+  return Boolean(
+    draft
+    && draft.attachments.length === 0
+    && draft.selectedUserSkillSlugs.length === 0,
+  );
+}
+
+/**
+ * First keystroke creates a missing → composer-only draft. That is still just
+ * typing. Clearing a draft (`right` missing) is a real lifecycle change.
+ */
+function draftsEquivalentIgnoringComposerText(
+  left: AIDraft | undefined,
+  right: AIDraft | undefined,
 ): boolean {
-  if (prev === next) return true;
-  const keys = new Set([...Object.keys(prev), ...Object.keys(next)]);
-  for (const key of keys) {
-    const left = prev[key];
-    const right = next[key];
-    if (key !== scopeKey) {
-      if (left !== right) return false;
-      continue;
-    }
-    if (left === right) continue;
-    if (!left || !right) return false;
-    if (left.agentId !== right.agentId) return false;
-    if (left.attachments !== right.attachments) return false;
-    if (left.selectedUserSkillSlugs !== right.selectedUserSkillSlugs) return false;
-  }
+  if (left === right) return true;
+  if (!left) return isComposerOnlyDraft(right);
+  if (!right) return false;
+  if (left.agentId !== right.agentId) return false;
+  if (left.attachments !== right.attachments) return false;
+  if (left.selectedUserSkillSlugs !== right.selectedUserSkillSlugs) return false;
   return true;
 }
 
@@ -43,15 +44,18 @@ export function draftsByScopeEqualIgnoringAllComposerText(
   if (prev === next) return true;
   const keys = new Set([...Object.keys(prev), ...Object.keys(next)]);
   for (const key of keys) {
-    const left = prev[key];
-    const right = next[key];
-    if (left === right) continue;
-    if (!left || !right) return false;
-    if (left.agentId !== right.agentId) return false;
-    if (left.attachments !== right.attachments) return false;
-    if (left.selectedUserSkillSlugs !== right.selectedUserSkillSlugs) return false;
+    if (!draftsEquivalentIgnoringComposerText(prev[key], next[key])) return false;
   }
   return true;
+}
+
+/** Typing only changes text/updatedAt. The scope key is kept for call-site compatibility. */
+export function draftsByScopeEqualIgnoringComposerText(
+  prev: DraftsByScope,
+  next: DraftsByScope,
+  _scopeKey?: string,
+): boolean {
+  return draftsByScopeEqualIgnoringAllComposerText(prev, next);
 }
 
 export function createEmptyDraft(agentId: string): AIDraft {

--- a/application/state/aiSessionsStore.test.ts
+++ b/application/state/aiSessionsStore.test.ts
@@ -33,6 +33,19 @@ test('AI sessions store does not notify listeners when only composer text change
 
     aiSessionsStore.setSnapshot({
       ...base,
+      draftsByScope: {},
+    });
+    notified = 0;
+    aiSessionsStore.setSnapshot({
+      ...base,
+      draftsByScope: {
+        'terminal:1': { ...draft, text: '你好' },
+      },
+    });
+    assert.equal(notified, 0);
+
+    aiSessionsStore.setSnapshot({
+      ...base,
       draftsByScope: {
         'terminal:1': { ...draft, text: 'hello', attachments: [{ id: 'a' } as never] },
       },

--- a/application/state/aiSessionsStore.test.ts
+++ b/application/state/aiSessionsStore.test.ts
@@ -44,6 +44,16 @@ test('AI sessions store does not notify listeners when only composer text change
     });
     assert.equal(notified, 0);
 
+    notified = 0;
+    aiSessionsStore.setSnapshot({
+      ...base,
+      draftsByScope: {
+        'terminal:1': { ...draft, text: '' },
+      },
+    });
+    assert.equal(notified, 1);
+
+    notified = 0;
     aiSessionsStore.setSnapshot({
       ...base,
       draftsByScope: {

--- a/application/state/useAIState.ts
+++ b/application/state/useAIState.ts
@@ -42,6 +42,7 @@ import {
 import {
   activateDraftView,
   clearScopeDraftState,
+  draftsByScopeEqualIgnoringAllComposerText,
   ensureDraftForScopeState,
   pruneStaleSessionPanelViews,
   setDraftView,
@@ -786,18 +787,21 @@ export function useAIState() {
 
   const ensureDraftForScope = useCallback((scopeKey: string, agentId: string): void => {
     let nextDraftsByScope: DraftsByScope | null = null;
+    let textOnly = false;
 
     setDraftsByScopeRaw((prev) => {
       const next = ensureDraftForScopeState(prev, scopeKey, agentId);
       if (next === prev) return prev;
       nextDraftsByScope = next;
+      textOnly = draftsByScopeEqualIgnoringAllComposerText(prev, next);
       return next;
     });
 
     if (!nextDraftsByScope) return;
 
-    bumpDraftMutationVersion(scopeKey);
     setLatestAIDraftsByScopeSnapshot(nextDraftsByScope);
+    if (textOnly) return;
+    bumpDraftMutationVersion(scopeKey);
     emitAIStateChanged(AI_STATE_CHANGED_DRAFTS_BY_SCOPE);
   }, []);
 
@@ -806,6 +810,9 @@ export function useAIState() {
     fallbackAgentId: string,
     updater: (draft: AIDraft) => AIDraft,
   ): void => {
+    let nextDraftsByScope: DraftsByScope | null = null;
+    let textOnly = false;
+
     setDraftsByScopeRaw((prev) => {
       const next = updateDraftForScope(
         prev,
@@ -821,40 +828,51 @@ export function useAIState() {
         },
       );
       if (next === prev) return prev;
-      setLatestAIDraftsByScopeSnapshot(next);
-      emitAIStateChanged(AI_STATE_CHANGED_DRAFTS_BY_SCOPE);
+      nextDraftsByScope = next;
+      textOnly = draftsByScopeEqualIgnoringAllComposerText(prev, next);
       return next;
     });
+
+    if (!nextDraftsByScope) return;
+    setLatestAIDraftsByScopeSnapshot(nextDraftsByScope);
+    if (textOnly) return;
     bumpDraftMutationVersion(scopeKey);
+    emitAIStateChanged(AI_STATE_CHANGED_DRAFTS_BY_SCOPE);
   }, []);
 
   const updateDraftIfPresent = useCallback((
     scopeKey: string,
     updater: (draft: AIDraft) => AIDraft,
   ): void => {
-    let updated = false;
+    let nextDraftsByScope: DraftsByScope | null = null;
+    let textOnly = false;
 
     setDraftsByScopeRaw((prev) => {
       const currentDraft = prev[scopeKey];
       if (!currentDraft) return prev;
 
-      const nextDraft = {
-        ...updater(currentDraft),
-        updatedAt: Date.now(),
-      };
+      const updated = updater(currentDraft);
+      const nextDraft = updated === currentDraft
+        ? currentDraft
+        : {
+          ...updated,
+          updatedAt: Date.now(),
+        };
+      if (nextDraft === currentDraft) return prev;
       const next = {
         ...prev,
         [scopeKey]: nextDraft,
       };
-      updated = true;
-      setLatestAIDraftsByScopeSnapshot(next);
-      emitAIStateChanged(AI_STATE_CHANGED_DRAFTS_BY_SCOPE);
+      nextDraftsByScope = next;
+      textOnly = draftsByScopeEqualIgnoringAllComposerText(prev, next);
       return next;
     });
 
-    if (updated) {
-      bumpDraftMutationVersion(scopeKey);
-    }
+    if (!nextDraftsByScope) return;
+    setLatestAIDraftsByScopeSnapshot(nextDraftsByScope);
+    if (textOnly) return;
+    bumpDraftMutationVersion(scopeKey);
+    emitAIStateChanged(AI_STATE_CHANGED_DRAFTS_BY_SCOPE);
   }, []);
 
   const showDraftView = useCallback((scopeKey: string) => {

--- a/components/AIChatSidePanel.mountRetention.test.ts
+++ b/components/AIChatSidePanel.mountRetention.test.ts
@@ -137,6 +137,22 @@ test('send and new chat discard pending composer text', () => {
   assert.match(source, /if \(!options\?\.keepPendingText\) discardPendingComposerText\(\)/);
 });
 
+test('text-only draft writes do not emit AI state changes', () => {
+  const source = readFileSync(new URL('../application/state/useAIState.ts', import.meta.url), 'utf8');
+  assert.match(source, /draftsByScopeEqualIgnoringAllComposerText/);
+  assert.match(source, /if \(textOnly\) return;/);
+});
+
+test('first composer keystroke does not create a store draft synchronously', () => {
+  const source = readFileSync(new URL('./AIChatSidePanel.tsx', import.meta.url), 'utf8');
+  const setter = source.slice(
+    source.indexOf('const setInputValue = useCallback'),
+    source.indexOf('const addFiles = useCallback'),
+  );
+  assert.match(setter, /pendingComposerTextRef\.current = value/);
+  assert.doesNotMatch(setter, /enterScopeDraftMode/);
+});
+
 test('hidden empty AI side panel can release its subtree', () => {
   const props = baseProps();
 

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -568,15 +568,15 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     }
     const pending = pendingComposerTextRef.current;
     if (pending == null) return;
+    if (panelViewRef.current.mode !== 'draft') {
+      enterScopeDraftMode(currentAgentId, panelViewRef.current.mode === 'session');
+    }
     updateScopeDraft(currentAgentId, (current) => (
       current.text === pending ? current : { ...current, text: pending }
     ));
-  }, [currentAgentId, updateScopeDraft]);
+  }, [currentAgentId, enterScopeDraftMode, updateScopeDraft]);
 
   const setInputValue = useCallback((value: string) => {
-    if (panelViewRef.current.mode !== 'draft' || !currentDraftRef.current) {
-      enterScopeDraftMode(currentAgentId, panelViewRef.current.mode === 'session');
-    }
     const base = currentDraftRef.current ?? {
       text: '',
       agentId: currentAgentId,
@@ -593,7 +593,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       draftTextFlushTimerRef.current = null;
       flushDraftText();
     }, 120);
-  }, [currentAgentId, enterScopeDraftMode, flushDraftText]);
+  }, [currentAgentId, flushDraftText]);
 
   const addFiles = useCallback(async (inputFiles: File[]) => {
     enterScopeDraftMode(currentAgentId, panelViewRef.current.mode === 'session');

--- a/components/ai/ChatInput.test.tsx
+++ b/components/ai/ChatInput.test.tsx
@@ -66,6 +66,20 @@ test('parked composer closes body-portaled menus', () => {
   const source = readFileSync(new URL('./ChatInput.tsx', import.meta.url), 'utf8');
   assert.match(source, /parked = false/);
   assert.match(source, /if \(parked\) closeAllMenus\(\)/);
+  assert.match(source, /becameParked/);
+});
+
+test('first keystrokes stay local so IME and Chromium spellcheck cannot stall the composer', () => {
+  const source = readFileSync(new URL('./ChatInput.tsx', import.meta.url), 'utf8');
+  assert.match(source, /spellCheck=\{false\}/);
+  assert.match(source, /autoCorrect="off"/);
+  assert.match(source, /autoCapitalize="off"/);
+  assert.match(source, /nativeEvent\.isComposing/);
+  assert.match(source, /onCompositionEnd=/);
+  assert.match(source, /onBlur=\{\(\) => commitComposerText\(readComposerText\(\)\)\}/);
+  assert.match(source, /defaultValue=\{value\}/);
+  assert.doesNotMatch(source, /value=\{composerText\}/);
+  assert.match(source, /hasComposerText/);
 });
 
 test('composer resizing also ends when pointer capture is unexpectedly lost', () => {

--- a/components/ai/ChatInput.test.tsx
+++ b/components/ai/ChatInput.test.tsx
@@ -77,6 +77,7 @@ test('first keystrokes stay local so IME and Chromium spellcheck cannot stall th
   assert.match(source, /nativeEvent\.isComposing/);
   assert.match(source, /onCompositionEnd=/);
   assert.match(source, /onBlur=\{\(\) => commitComposerText\(readComposerText\(\)\)\}/);
+  assert.match(source, /onChange\(textareaRef\.current\?\.value \?\? composerTextRef\.current\)/);
   assert.match(source, /defaultValue=\{value\}/);
   assert.doesNotMatch(source, /value=\{composerText\}/);
   assert.match(source, /hasComposerText/);

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -385,6 +385,10 @@ const ChatInput: React.FC<ChatInputProps> = ({
     commitComposerText(readComposerText());
   }, [commitComposerText, parked, readComposerText]);
 
+  useEffect(() => () => {
+    onChange(textareaRef.current?.value ?? composerTextRef.current);
+  }, [onChange]);
+
   const findSlashTrigger = useCallback((text: string, caretPosition: number) => {
     const beforeCaret = text.slice(0, caretPosition);
     const match = /(^|\s)\/([a-z0-9-]*)$/i.exec(beforeCaret);

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -184,7 +184,8 @@ const ChatInput: React.FC<ChatInputProps> = ({
   const { t } = useI18n();
   const hasTerminalSelectionAttachment = files.some((file) => file.terminalSelection);
   const composerDisabled = disabled || isSteering;
-  const [composerText, setComposerText] = useState(value);
+  const composerTextRef = useRef(value);
+  const [hasComposerText, setHasComposerText] = useState(() => value.trim().length > 0);
   const pushedParentTextRef = useRef(value);
   const [composerHeight, setComposerHeight] = useState<number | null>(null);
   const [composerMaxHeight, setComposerMaxHeight] = useState(CHAT_INPUT_MAX_HEIGHT);
@@ -347,17 +348,42 @@ const ChatInput: React.FC<ChatInputProps> = ({
     document.body.style.userSelect = resizeStart.previousUserSelect;
   }, []);
 
+  const syncHasComposerText = useCallback((text: string) => {
+    const next = text.trim().length > 0;
+    setHasComposerText((prev) => (prev === next ? prev : next));
+  }, []);
+
+  const readComposerText = useCallback(() => (
+    textareaRef.current?.value ?? composerTextRef.current
+  ), []);
+
   useEffect(() => {
     if (value === pushedParentTextRef.current) return;
     pushedParentTextRef.current = value;
-    setComposerText(value);
-  }, [value]);
+    composerTextRef.current = value;
+    if (textareaRef.current && textareaRef.current.value !== value) {
+      textareaRef.current.value = value;
+    }
+    syncHasComposerText(value);
+  }, [syncHasComposerText, value]);
 
   const commitComposerText = useCallback((next: string) => {
+    composerTextRef.current = next;
     pushedParentTextRef.current = next;
-    setComposerText(next);
+    if (textareaRef.current && textareaRef.current.value !== next) {
+      textareaRef.current.value = next;
+    }
+    syncHasComposerText(next);
     onChange(next);
-  }, [onChange]);
+  }, [onChange, syncHasComposerText]);
+
+  const parkedRef = useRef(parked);
+  useEffect(() => {
+    const becameParked = parked && !parkedRef.current;
+    parkedRef.current = parked;
+    if (!becameParked) return;
+    commitComposerText(readComposerText());
+  }, [commitComposerText, parked, readComposerText]);
 
   const findSlashTrigger = useCallback((text: string, caretPosition: number) => {
     const beforeCaret = text.slice(0, caretPosition);
@@ -384,14 +410,18 @@ const ChatInput: React.FC<ChatInputProps> = ({
     };
   }, []);
 
-  const handleInputChange = useCallback((newValue: string) => {
+  const handleInputChange = useCallback((newValue: string, composing = false) => {
     markAiComposerActivity();
+    const previousText = composerTextRef.current;
+    composerTextRef.current = newValue;
+    syncHasComposerText(newValue);
+    if (composing) return;
     commitComposerText(newValue);
     const caretPosition = textareaRef.current?.selectionStart ?? newValue.length;
     // Detect if user just typed @
     if (
       hosts.length > 0 &&
-      newValue.length > composerText.length &&
+      newValue.length > previousText.length &&
       newValue.endsWith('@')
     ) {
       // Position the popover near the textarea
@@ -419,18 +449,19 @@ const ChatInput: React.FC<ChatInputProps> = ({
     } else if (showSlashCommandPicker) {
       closeAllMenus();
     }
-  }, [commitComposerText, composerText, hosts.length, showAtMention, findSlashTrigger, showSlashCommandPicker, closeAllMenus, getInputPanelMenuPos]);
+  }, [commitComposerText, hosts.length, showAtMention, findSlashTrigger, showSlashCommandPicker, closeAllMenus, getInputPanelMenuPos, syncHasComposerText]);
 
   const handleSelectAtMention = useCallback((host: { label: string; hostname: string }) => {
     // Replace the trailing @ with @hostname
     const name = host.label || host.hostname;
-    const lastAt = composerText.lastIndexOf('@');
+    const currentText = readComposerText();
+    const lastAt = currentText.lastIndexOf('@');
     const newValue = lastAt >= 0
-      ? composerText.slice(0, lastAt) + `@${name} `
-      : composerText + `@${name} `;
+      ? currentText.slice(0, lastAt) + `@${name} `
+      : currentText + `@${name} `;
     commitComposerText(newValue);
     closeAllMenus();
-  }, [composerText, commitComposerText, closeAllMenus]);
+  }, [readComposerText, commitComposerText, closeAllMenus]);
 
   const openInputPanelMenu = useCallback((menu: 'atMention' | 'slashCommand') => {
     const pos = getInputPanelMenuPos();
@@ -438,8 +469,9 @@ const ChatInput: React.FC<ChatInputProps> = ({
     setMenuPos(null);
     setInputPanelPos(pos);
     if (menu === 'slashCommand') {
-      const caret = textareaRef.current?.selectionStart ?? composerText.length;
-      const trigger = findSlashTrigger(composerText, caret);
+      const currentText = readComposerText();
+      const caret = textareaRef.current?.selectionStart ?? currentText.length;
+      const trigger = findSlashTrigger(currentText, caret);
       if (trigger) {
         setSlashQuery(trigger.query);
         setSlashRange({ start: trigger.start, end: trigger.end });
@@ -449,7 +481,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
       }
     }
     setActiveMenu(menu);
-  }, [findSlashTrigger, getInputPanelMenuPos, composerText]);
+  }, [findSlashTrigger, getInputPanelMenuPos, readComposerText]);
 
   const userSkillOptions = useMemo<UserSkillSlashOption[]>(
     () => (lockTurnConfiguration ? [] : userSkills).map((skill) => ({
@@ -515,14 +547,15 @@ const ChatInput: React.FC<ChatInputProps> = ({
   const showSlashPickerUI = showSlashCommandPicker && (inputPanelPos != null || menuPos != null);
 
   const removeSlashQueryFromInput = useCallback(() => {
-    if (!slashRange) return composerText;
-    const before = composerText.slice(0, slashRange.start);
-    const after = composerText.slice(slashRange.end);
+    const currentText = readComposerText();
+    if (!slashRange) return currentText;
+    const before = currentText.slice(0, slashRange.start);
+    const after = currentText.slice(slashRange.end);
     if (/\s$/.test(before) && /^\s/.test(after)) {
       return `${before}${after.slice(1)}`;
     }
     return `${before}${after}`;
-  }, [slashRange, composerText]);
+  }, [slashRange, readComposerText]);
 
   const insertUserSkillToken = useCallback((skill: { slug: string }) => {
     if (lockTurnConfiguration) return;
@@ -534,18 +567,19 @@ const ChatInput: React.FC<ChatInputProps> = ({
   }, [closeAllMenus, lockTurnConfiguration, onAddUserSkill, commitComposerText, removeSlashQueryFromInput, slashRange]);
 
   const insertQuickMessage = useCallback((message: AIQuickMessage) => {
+    const currentText = readComposerText();
     if (slashRange) {
-      const before = composerText.slice(0, slashRange.start);
-      const after = composerText.slice(slashRange.end);
+      const before = currentText.slice(0, slashRange.start);
+      const after = currentText.slice(slashRange.end);
       const spacerBefore = before.length > 0 && !/\s$/.test(before) ? ' ' : '';
       const spacerAfter = after.length > 0 && !/^\s/.test(after) ? ' ' : '';
       commitComposerText(`${before}${spacerBefore}${message.content}${spacerAfter}${after}`);
     } else {
-      const spacer = composerText.length > 0 && !/\s$/.test(composerText) ? ' ' : '';
-      commitComposerText(`${composerText}${spacer}${message.content}`);
+      const spacer = currentText.length > 0 && !/\s$/.test(currentText) ? ' ' : '';
+      commitComposerText(`${currentText}${spacer}${message.content}`);
     }
     closeAllMenus();
-  }, [closeAllMenus, commitComposerText, composerText, slashRange]);
+  }, [closeAllMenus, commitComposerText, readComposerText, slashRange]);
 
   const handleSelectSlashCommandItem = useCallback((item: SlashCommandItem) => {
     if (item.kind === 'system') {
@@ -700,7 +734,9 @@ const ChatInput: React.FC<ChatInputProps> = ({
 
   const handleSubmit = useCallback(
     (_text: string, _event: FormEvent<HTMLFormElement>) => {
-      const systemCommand = getSystemSlashCommand(composerText);
+      const submittedText = readComposerText();
+      commitComposerText(submittedText);
+      const systemCommand = getSystemSlashCommand(submittedText);
       if (systemCommand) {
         if (systemCommand === 'compact') {
           if (!canCompact) return;
@@ -721,7 +757,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
       }
       onSend();
     },
-    [canCompact, canSteer, commitComposerText, composerText, isStreaming, onCompact, onSend, onSteer, onStop],
+    [canCompact, canSteer, commitComposerText, isStreaming, onCompact, onSend, onSteer, onStop, readComposerText],
   );
 
   const status: PromptInputStatus = isStreaming ? 'streaming' : 'idle';
@@ -935,11 +971,17 @@ const ChatInput: React.FC<ChatInputProps> = ({
           )}
           <PromptInputTextarea
             ref={textareaRef}
-            value={composerText}
-            onChange={(e) => handleInputChange(e.target.value)}
+            defaultValue={value}
+            spellCheck={false}
+            autoCorrect="off"
+            autoCapitalize="off"
+            autoComplete="off"
+            onChange={(e) => handleInputChange(e.target.value, e.nativeEvent.isComposing)}
             onFocus={() => markAiComposerActivity()}
             onCompositionStart={() => markAiComposerActivity()}
             onCompositionUpdate={() => markAiComposerActivity()}
+            onCompositionEnd={(e) => handleInputChange(e.currentTarget.value)}
+            onBlur={() => commitComposerText(readComposerText())}
             onKeyDown={handleTextareaKeyDown}
             placeholder={placeholder || (isStreaming && canSteer ? t('ai.codex.steer.placeholder') : defaultPlaceholder)}
             disabled={composerDisabled}
@@ -1452,7 +1494,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
                   <TooltipTrigger asChild>
                     <button
                       type="submit"
-                      disabled={(!composerText.trim() && !hasTerminalSelectionAttachment) || composerDisabled}
+                      disabled={(!hasComposerText && !hasTerminalSelectionAttachment) || composerDisabled}
                       aria-label={isSteering ? t('ai.codex.steer.sending') : t('ai.codex.steer.addInstruction')}
                       className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-foreground/20 bg-foreground text-background shadow-sm transition-colors hover:bg-foreground/90 disabled:border-border/80 disabled:bg-muted/52 disabled:text-foreground/72"
                     >
@@ -1467,7 +1509,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
               <PromptInputSubmit
                 status={status}
                 onStop={onStop}
-                disabled={(!composerText.trim() && !hasTerminalSelectionAttachment) || disabled}
+                disabled={(!hasComposerText && !hasTerminalSelectionAttachment) || disabled}
               />
             )}
           </div>


### PR DESCRIPTION
## Summary

Typing in the AI composer still hitched after #2993: the first 1-2 characters painted, then the rest dumped after a long stall. That was not Streamdown. Every keystroke re-rendered the whole ChatInput tree, the first character synchronously created a store draft and emitted AI state, IME composition forwarded every pinyin letter to the parent, and Chromium spellcheck loaded on the first word.

The textarea is now uncontrolled. Parent draft state is committed on idle, blur, park, and send. Missing → composer-only drafts are treated as text-only identity churn so store listeners do not wake. Send still reads the live box text, so the last characters are not lost.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Follow-up to #2993 (first-type jank). Streamdown warmup was not the remaining stall.

## Changes Made

- ChatInput keeps typed text in the DOM/`ref` instead of React state on every key.
- IME composition stays local until `compositionend`, blur, or park.
- Disable spellcheck/autocorrect/autocomplete on the composer.
- `setInputValue` no longer calls `enterScopeDraftMode` on the first character; flush does it after 120ms or on send/hide.
- Text-only draft writes skip `emitAIStateChanged` and mutation-version bumps.
- Parked commit runs only when the panel becomes hidden, not on every parked re-render.
- Submit commits the live textarea value before send/steer.

## Screenshots / Demo

N/A — input latency. First Chinese/IME and Latin typing in an empty AI composer should no longer freeze after 1-2 characters.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Local verification:

- `npx eslint --max-warnings 0` on the touched files
- `node --test --import tsx` for `aiDraftState`, `aiSessionsStore`, `ChatInput`, and `AIChatSidePanel.mountRetention` (59 tests)

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)