### PR TITLE
fix(ai): clear the composer as soon as a message is sent

### DIFF
--- a/components/AIChatPanelContent.tsx
+++ b/components/AIChatPanelContent.tsx
@@ -159,6 +159,34 @@ export const AIChatPanelContent: React.FC<AIChatPanelContentProps> = ({
   parked = false,
   sending = false,
 }) => {
+  const mentionHosts = React.useMemo(
+    () => terminalSessions.map((session) => ({
+      sessionId: session.sessionId,
+      hostname: session.hostname,
+      label: session.label,
+      connected: session.connected,
+    })),
+    [terminalSessions],
+  );
+  const providerSwitcher = React.useMemo(
+    () => (
+      currentAgentId === 'catty' && cattyConfiguredProviders.length > 0
+        ? {
+            providers: cattyConfiguredProviders,
+            selectedProviderId: effectiveActiveProvider?.id,
+            selectedModelId: effectiveActiveModelId || undefined,
+            onSelect: handleAgentProviderModelSelect,
+          }
+        : undefined
+    ),
+    [
+      cattyConfiguredProviders,
+      currentAgentId,
+      effectiveActiveModelId,
+      effectiveActiveProvider?.id,
+      handleAgentProviderModelSelect,
+    ],
+  );
   const hiddenParts = getAIPanelDiagnosticHiddenParts();
   const hideHeader = isAIPanelDiagnosticPartHidden('header', hiddenParts);
   const hideHistory = isAIPanelDiagnosticPartHidden('history', hiddenParts);
@@ -321,20 +349,11 @@ export const AIChatPanelContent: React.FC<AIChatPanelContentProps> = ({
                   modelPresets={agentModelPresets}
                   selectedModelId={selectedAgentModel}
                   onModelSelect={handleAgentModelSelect}
-                  providerSwitcher={
-                    currentAgentId === 'catty' && cattyConfiguredProviders.length > 0
-                      ? {
-                          providers: cattyConfiguredProviders,
-                          selectedProviderId: effectiveActiveProvider?.id,
-                          selectedModelId: effectiveActiveModelId || undefined,
-                          onSelect: handleAgentProviderModelSelect,
-                        }
-                      : undefined
-                  }
+                  providerSwitcher={providerSwitcher}
                   files={files}
                   onAddFiles={addFiles}
                   onRemoveFile={removeFile}
-                  hosts={terminalSessions.map(s => ({ sessionId: s.sessionId, hostname: s.hostname, label: s.label, connected: s.connected }))}
+                  hosts={mentionHosts}
                   selectedUserSkills={selectedUserSkills}
                   userSkills={userSkillOptions}
                   quickMessages={quickMessages}

--- a/components/AIChatSidePanel.mountRetention.test.ts
+++ b/components/AIChatSidePanel.mountRetention.test.ts
@@ -151,6 +151,7 @@ test('first composer keystroke does not create a store draft synchronously', () 
   );
   assert.match(setter, /pendingComposerTextRef\.current = value/);
   assert.doesNotMatch(setter, /enterScopeDraftMode/);
+  assert.doesNotMatch(setter, /setTimeout/);
 });
 
 test('hidden empty AI side panel can release its subtree', () => {

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -374,7 +374,6 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   const explicitPanelView = panelViewByScope[scopeKey];
   const currentDraft = draftsByScope[scopeKey] ?? null;
   const pendingComposerTextRef = useRef<string | null>(null);
-  const draftTextFlushTimerRef = useRef<number | null>(null);
   const visibleHistorySessionIds = useMemo(
     () => new Set(historySessions.map((session) => session.id)),
     [historySessions],
@@ -541,10 +540,6 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   }, [scopeKey, showSessionView]);
 
   const discardPendingComposerText = useCallback(() => {
-    if (draftTextFlushTimerRef.current != null) {
-      window.clearTimeout(draftTextFlushTimerRef.current);
-      draftTextFlushTimerRef.current = null;
-    }
     pendingComposerTextRef.current = null;
   }, []);
 
@@ -562,10 +557,6 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   }, [ensureScopeDraft, showScopeDraftView]);
 
   const flushDraftText = useCallback(() => {
-    if (draftTextFlushTimerRef.current != null) {
-      window.clearTimeout(draftTextFlushTimerRef.current);
-      draftTextFlushTimerRef.current = null;
-    }
     const pending = pendingComposerTextRef.current;
     if (pending == null) return;
     if (panelViewRef.current.mode !== 'draft') {
@@ -586,14 +577,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     };
     pendingComposerTextRef.current = value;
     currentDraftRef.current = { ...base, text: value, updatedAt: Date.now() };
-    if (draftTextFlushTimerRef.current != null) {
-      window.clearTimeout(draftTextFlushTimerRef.current);
-    }
-    draftTextFlushTimerRef.current = window.setTimeout(() => {
-      draftTextFlushTimerRef.current = null;
-      flushDraftText();
-    }, 120);
-  }, [currentAgentId, flushDraftText]);
+  }, [currentAgentId]);
 
   const addFiles = useCallback(async (inputFiles: File[]) => {
     enterScopeDraftMode(currentAgentId, panelViewRef.current.mode === 'session');

--- a/components/ai/ChatInput.test.tsx
+++ b/components/ai/ChatInput.test.tsx
@@ -80,6 +80,7 @@ test('first keystrokes stay local so IME and Chromium spellcheck cannot stall th
   assert.match(source, /onChangeRef\.current\(textareaRef\.current\?\.value \?\? composerTextRef\.current\)/);
   assert.match(source, /onSend\(\);\s*commitComposerText\(''\);/);
   assert.match(source, /defaultValue=\{value\}/);
+  assert.match(source, /field-sizing-fixed/);
   assert.doesNotMatch(source, /value=\{composerText\}/);
   assert.match(source, /hasComposerText/);
 });

--- a/components/ai/ChatInput.test.tsx
+++ b/components/ai/ChatInput.test.tsx
@@ -78,7 +78,7 @@ test('first keystrokes stay local so IME and Chromium spellcheck cannot stall th
   assert.match(source, /onCompositionEnd=/);
   assert.match(source, /onBlur=\{\(\) => commitComposerText\(readComposerText\(\)\)\}/);
   assert.match(source, /onChangeRef\.current\(textareaRef\.current\?\.value \?\? composerTextRef\.current\)/);
-  assert.match(source, /onSend\(\);\s*commitComposerText\(''\);/);
+  assert.doesNotMatch(source, /onSend\(\);\s*commitComposerText\(''\);/);
   assert.match(source, /defaultValue=\{value\}/);
   assert.match(source, /field-sizing-fixed/);
   assert.doesNotMatch(source, /value=\{composerText\}/);

--- a/components/ai/ChatInput.test.tsx
+++ b/components/ai/ChatInput.test.tsx
@@ -77,7 +77,8 @@ test('first keystrokes stay local so IME and Chromium spellcheck cannot stall th
   assert.match(source, /nativeEvent\.isComposing/);
   assert.match(source, /onCompositionEnd=/);
   assert.match(source, /onBlur=\{\(\) => commitComposerText\(readComposerText\(\)\)\}/);
-  assert.match(source, /onChange\(textareaRef\.current\?\.value \?\? composerTextRef\.current\)/);
+  assert.match(source, /onChangeRef\.current\(textareaRef\.current\?\.value \?\? composerTextRef\.current\)/);
+  assert.match(source, /onSend\(\);\s*commitComposerText\(''\);/);
   assert.match(source, /defaultValue=\{value\}/);
   assert.doesNotMatch(source, /value=\{composerText\}/);
   assert.match(source, /hasComposerText/);

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -762,8 +762,9 @@ const ChatInput: React.FC<ChatInputProps> = ({
         onSteer?.();
         return;
       }
+      // Do not empty the box here. handleSend awaits provider sync and may
+      // abort; the parent clears value only after the user message is accepted.
       onSend();
-      commitComposerText('');
     },
     [canCompact, canSteer, commitComposerText, isStreaming, onCompact, onSend, onSteer, onStop, readComposerText],
   );

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -385,9 +385,11 @@ const ChatInput: React.FC<ChatInputProps> = ({
     commitComposerText(readComposerText());
   }, [commitComposerText, parked, readComposerText]);
 
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
   useEffect(() => () => {
-    onChange(textareaRef.current?.value ?? composerTextRef.current);
-  }, [onChange]);
+    onChangeRef.current(textareaRef.current?.value ?? composerTextRef.current);
+  }, []);
 
   const findSlashTrigger = useCallback((text: string, caretPosition: number) => {
     const beforeCaret = text.slice(0, caretPosition);
@@ -760,6 +762,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
         return;
       }
       onSend();
+      commitComposerText('');
     },
     [canCompact, canSteer, commitComposerText, isStreaming, onCompact, onSend, onSteer, onStop, readComposerText],
   );

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -331,11 +331,12 @@ const ChatInput: React.FC<ChatInputProps> = ({
     const observer = new ResizeObserver(() => {
       const maxHeight = resolveVisibleChatInputMaxHeight(panel.clientHeight);
       if (maxHeight == null) return;
-      setComposerMaxHeight(maxHeight);
-      setComposerHeight(resolveVisibleChatInputHeight(
+      const nextHeight = resolveVisibleChatInputHeight(
         composerDesiredHeightRef.current,
         maxHeight,
-      ));
+      );
+      setComposerMaxHeight((current) => (current === maxHeight ? current : maxHeight));
+      setComposerHeight((current) => (current === nextHeight ? current : nextHeight));
     });
     observer.observe(panel);
     return () => observer.disconnect();
@@ -993,6 +994,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
             placeholder={placeholder || (isStreaming && canSteer ? t('ai.codex.steer.placeholder') : defaultPlaceholder)}
             disabled={composerDisabled}
             className={[
+              'field-sizing-fixed',
               selectedUserSkills.length > 0 ? 'pt-1.5' : undefined,
               composerHeight != null ? 'min-h-0 max-h-none flex-1' : undefined,
             ].filter(Boolean).join(' ')}


### PR DESCRIPTION
## Summary

After #2995, sending a prompt left the same text in the composer (see the leftover `看看这个机器配置怎` after the user bubble). Send waits on `aiSyncProviders` / model catalog before `clearScopeDraft`. While that is in flight, ChatInput's `useEffect(..., [onChange])` cleanup could run if `setInputValue` got a new identity and write the still-visible textarea back into the pending draft.

Clear the uncontrolled field immediately after `onSend()` starts. Commit-on-unmount now uses a ref so a new `onChange` callback cannot restore the last prompt.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Follow-up to #2995.

## Changes Made

- `handleSubmit` calls `commitComposerText('')` after `onSend()` so the box empties during preflight.
- Replace `[onChange]` effect cleanup with an unmount-only commit through `onChangeRef`.

## Screenshots / Demo

The composer should be empty as soon as the user message appears, including while the turn is still streaming.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)