### PR TITLE
fix(ai): keep ChatInput chrome still while typing

### DIFF
--- a/components/ai-elements/hasMarkdownCodeFence.test.ts
+++ b/components/ai-elements/hasMarkdownCodeFence.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { hasMarkdownCodeFence } from './hasMarkdownCodeFence';
+
+test('detects common markdown fences', () => {
+  assert.equal(hasMarkdownCodeFence('hello'), false);
+  assert.equal(hasMarkdownCodeFence('use `code` inline'), false);
+  assert.equal(hasMarkdownCodeFence('```ts\nconst a = 1\n```'), true);
+  assert.equal(hasMarkdownCodeFence('prefix\n```\nplain\n```'), true);
+  assert.equal(hasMarkdownCodeFence('~~~\nbash\n~~~'), true);
+  assert.equal(hasMarkdownCodeFence('   ```json\n{}\n```'), true);
+});

--- a/components/ai-elements/hasMarkdownCodeFence.ts
+++ b/components/ai-elements/hasMarkdownCodeFence.ts
@@ -1,0 +1,6 @@
+const FENCE_RE = /(?:^|\n)\s{0,3}(`{3,}|~{3,})/;
+
+/** True when markdown contains a fenced code block that may want Shiki. */
+export function hasMarkdownCodeFence(text: string): boolean {
+  return FENCE_RE.test(text);
+}

--- a/components/ai-elements/messageResponse.test.ts
+++ b/components/ai-elements/messageResponse.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+test('messageResponse does not statically import Shiki', () => {
+  const source = readFileSync(new URL('./messageResponse.tsx', import.meta.url), 'utf8');
+  assert.doesNotMatch(source, /from ['"]@streamdown\/code['"]/);
+  assert.match(source, /from ['"]@streamdown\/cjk['"]/);
+  assert.match(source, /hasMarkdownCodeFence/);
+  assert.match(source, /warmAiCodeHighlighter/);
+  assert.match(source, /scheduleWhenAiComposerIdle/);
+});
+
+test('Shiki lives in an isolated plugin module', () => {
+  const plugin = readFileSync(new URL('./streamdownCodePlugin.ts', import.meta.url), 'utf8');
+  const warmup = readFileSync(new URL('./streamdownCodeWarmup.ts', import.meta.url), 'utf8');
+  assert.match(plugin, /from ['"]@streamdown\/code['"]/);
+  assert.match(warmup, /import\('\.\/streamdownCodePlugin'\)/);
+  assert.doesNotMatch(warmup, /from ['"]@streamdown\/code['"]/);
+});

--- a/components/ai-elements/messageResponse.tsx
+++ b/components/ai-elements/messageResponse.tsx
@@ -1,43 +1,66 @@
-import { cn } from '../../lib/utils';
 import { cjk } from '@streamdown/cjk';
-import { code } from '@streamdown/code';
 import type { ComponentProps } from 'react';
-import { memo } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { Streamdown } from 'streamdown';
-import { createSafeCodeHighlighter } from './streamdownCodeHighlighter';
 
-const safeCode = createSafeCodeHighlighter(code);
-const streamdownPlugins = { cjk, code: safeCode };
+import { scheduleWhenAiComposerIdle } from '../ai/aiMarkdownWarmup';
+import { cn } from '../../lib/utils';
+import { hasMarkdownCodeFence } from './hasMarkdownCodeFence';
+import {
+  getCachedStreamdownCodePlugin,
+  warmAiCodeHighlighter,
+} from './streamdownCodeWarmup';
+
+const STREAMDOWN_CLASS = [
+  'size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0',
+  '[&_code]:text-[12px] [&_code]:font-mono',
+  '[&_p_code]:px-[0.4em] [&_p_code]:py-[0.15em] [&_p_code]:rounded [&_p_code]:bg-foreground/[0.06] [&_p_code]:text-[85%] [&_p_code]:whitespace-normal [&_p_code]:[overflow-wrap:anywhere]',
+  '[&_p]:my-1.5',
+  '[&_ul]:my-1.5 [&_ul]:pl-4 [&_ul]:list-disc',
+  '[&_ol]:my-1.5 [&_ol]:pl-4 [&_ol]:list-decimal',
+  '[&_li]:my-0.5',
+  '[&_h1]:text-base [&_h1]:font-semibold [&_h1]:mt-4 [&_h1]:mb-2',
+  '[&_h2]:text-sm [&_h2]:font-semibold [&_h2]:mt-3 [&_h2]:mb-1.5',
+  '[&_h3]:text-sm [&_h3]:font-medium [&_h3]:mt-2 [&_h3]:mb-1',
+  '[&_blockquote]:border-l-2 [&_blockquote]:border-border/50 [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground',
+  '[&_a]:text-primary [&_a]:underline',
+  '[&_hr]:border-border/30 [&_hr]:my-3',
+  '[&_table]:text-[12px] [&_th]:px-2 [&_th]:py-1 [&_th]:border [&_th]:border-border/30 [&_th]:bg-muted/20 [&_td]:px-2 [&_td]:py-1 [&_td]:border [&_td]:border-border/30',
+].join(' ');
 
 export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 
-/** Heavy markdown renderer — load via LazyMessageResponse, not the chat list critical path. */
-export const MessageResponse = memo(
-  ({ className, ...props }: MessageResponseProps) => (
+function MessageResponseView({ className, children, ...props }: MessageResponseProps) {
+  const [codePlugin, setCodePlugin] = useState(getCachedStreamdownCodePlugin);
+  const source = typeof children === 'string' ? children : '';
+  const wantsCode = hasMarkdownCodeFence(source);
+
+  useEffect(() => {
+    if (!wantsCode || codePlugin) return undefined;
+    return scheduleWhenAiComposerIdle(() => {
+      void warmAiCodeHighlighter().then(setCodePlugin);
+    });
+  }, [codePlugin, wantsCode]);
+
+  const plugins = useMemo(
+    () => (codePlugin ? { cjk, code: codePlugin } : { cjk }),
+    [codePlugin],
+  );
+
+  return (
     <Streamdown
-      className={cn(
-        'size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0',
-        // Style the rendered markdown
-        // Code: base styles (code-block overrides are in index.css)
-        '[&_code]:text-[12px] [&_code]:font-mono',
-        '[&_p_code]:px-[0.4em] [&_p_code]:py-[0.15em] [&_p_code]:rounded [&_p_code]:bg-foreground/[0.06] [&_p_code]:text-[85%] [&_p_code]:whitespace-normal [&_p_code]:[overflow-wrap:anywhere]',
-        '[&_p]:my-1.5',
-        '[&_ul]:my-1.5 [&_ul]:pl-4 [&_ul]:list-disc',
-        '[&_ol]:my-1.5 [&_ol]:pl-4 [&_ol]:list-decimal',
-        '[&_li]:my-0.5',
-        '[&_h1]:text-base [&_h1]:font-semibold [&_h1]:mt-4 [&_h1]:mb-2',
-        '[&_h2]:text-sm [&_h2]:font-semibold [&_h2]:mt-3 [&_h2]:mb-1.5',
-        '[&_h3]:text-sm [&_h3]:font-medium [&_h3]:mt-2 [&_h3]:mb-1',
-        '[&_blockquote]:border-l-2 [&_blockquote]:border-border/50 [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground',
-        '[&_a]:text-primary [&_a]:underline',
-        '[&_hr]:border-border/30 [&_hr]:my-3',
-        '[&_table]:text-[12px] [&_th]:px-2 [&_th]:py-1 [&_th]:border [&_th]:border-border/30 [&_th]:bg-muted/20 [&_td]:px-2 [&_td]:py-1 [&_td]:border [&_td]:border-border/30',
-        className,
-      )}
-      plugins={streamdownPlugins}
+      className={cn(STREAMDOWN_CLASS, className)}
+      plugins={plugins}
       {...props}
-    />
-  ),
+    >
+      {children}
+    </Streamdown>
+  );
+}
+
+/** Streamdown + CJK only. Shiki loads later when a fence exists and the composer is idle. */
+export const MessageResponse = memo(
+  MessageResponseView,
   (prevProps, nextProps) =>
     prevProps.children === nextProps.children &&
     nextProps.isAnimating === prevProps.isAnimating,

--- a/components/ai-elements/messageResponse.tsx
+++ b/components/ai-elements/messageResponse.tsx
@@ -37,9 +37,16 @@ function MessageResponseView({ className, children, ...props }: MessageResponseP
 
   useEffect(() => {
     if (!wantsCode || codePlugin) return undefined;
-    return scheduleWhenAiComposerIdle(() => {
-      void warmAiCodeHighlighter().then(setCodePlugin);
+    let cancelled = false;
+    const cancelIdle = scheduleWhenAiComposerIdle(() => {
+      void warmAiCodeHighlighter().then((plugin) => {
+        if (!cancelled) setCodePlugin(plugin);
+      });
     });
+    return () => {
+      cancelled = true;
+      cancelIdle();
+    };
   }, [codePlugin, wantsCode]);
 
   const plugins = useMemo(

--- a/components/ai-elements/streamdownCodePlugin.ts
+++ b/components/ai-elements/streamdownCodePlugin.ts
@@ -1,0 +1,6 @@
+import { code } from '@streamdown/code';
+
+import { createSafeCodeHighlighter } from './streamdownCodeHighlighter';
+
+/** Isolated Shiki entry — import this file only through warmAiCodeHighlighter. */
+export const streamdownCodePlugin = createSafeCodeHighlighter(code);

--- a/components/ai-elements/streamdownCodeWarmup.ts
+++ b/components/ai-elements/streamdownCodeWarmup.ts
@@ -1,0 +1,24 @@
+import type { CodeHighlighterPlugin } from 'streamdown';
+
+let cachedCodePlugin: CodeHighlighterPlugin | null = null;
+let codePluginPromise: Promise<CodeHighlighterPlugin> | null = null;
+
+export function getCachedStreamdownCodePlugin(): CodeHighlighterPlugin | null {
+  return cachedCodePlugin;
+}
+
+export function isAiCodeHighlighterReady(): boolean {
+  return cachedCodePlugin != null;
+}
+
+/** Prefetch Shiki only when a message actually contains a code fence. */
+export function warmAiCodeHighlighter(): Promise<CodeHighlighterPlugin> {
+  codePluginPromise ??= import('./streamdownCodePlugin').then((module) => {
+    cachedCodePlugin = module.streamdownCodePlugin;
+    return module.streamdownCodePlugin;
+  }, (error) => {
+    codePluginPromise = null;
+    throw error;
+  });
+  return codePluginPromise;
+}

--- a/components/ai/ChatInput.test.tsx
+++ b/components/ai/ChatInput.test.tsx
@@ -82,7 +82,9 @@ test('first keystrokes stay local so IME and Chromium spellcheck cannot stall th
   assert.match(source, /defaultValue=\{value\}/);
   assert.match(source, /field-sizing-fixed/);
   assert.doesNotMatch(source, /value=\{composerText\}/);
-  assert.match(source, /hasComposerText/);
+  assert.match(source, /createComposerHasTextStore/);
+  assert.match(source, /ComposerSendUi/);
+  assert.match(source, /chatInputPropsAreEqual/);
 });
 
 test('composer resizing also ends when pointer capture is unexpectedly lost', () => {

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -38,7 +38,7 @@ import { ProviderIconBadge } from '../settings/tabs/ai/ProviderIconBadge';
 import { VariableSizeVirtualList, type VariableSizeVirtualListHandle } from '../ui/VariableSizeVirtualList';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import type { AgentContextUsage } from '../../application/state/useAgentCompactionUi';
-import { markAiComposerActivity } from './aiMarkdownWarmup';
+import { markAiComposerActivity, setAiComposerComposing } from './aiMarkdownWarmup';
 import {
   CHAT_INPUT_DEFAULT_HEIGHT,
   CHAT_INPUT_MAX_HEIGHT,
@@ -1071,9 +1071,12 @@ const ChatInput: React.FC<ChatInputProps> = ({
             autoComplete="off"
             onChange={(e) => handleInputChange(e.target.value, e.nativeEvent.isComposing)}
             onFocus={() => markAiComposerActivity()}
-            onCompositionStart={() => markAiComposerActivity()}
+            onCompositionStart={() => setAiComposerComposing(true)}
             onCompositionUpdate={() => markAiComposerActivity()}
-            onCompositionEnd={(e) => handleInputChange(e.currentTarget.value)}
+            onCompositionEnd={(e) => {
+              setAiComposerComposing(false);
+              handleInputChange(e.currentTarget.value);
+            }}
             onBlur={() => commitComposerText(readComposerText())}
             onKeyDown={handleTextareaKeyDown}
             placeholder={placeholder || (isStreaming && canSteer ? t('ai.codex.steer.placeholder') : defaultPlaceholder)}

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -20,7 +20,7 @@ import {
   type UserSkillSlashOption,
 } from '../../infrastructure/ai/quickMessages';
 import { SlashCommandPicker } from './SlashCommandPicker';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { createPortal } from 'react-dom';
 import type { FormEvent } from 'react';
@@ -87,6 +87,87 @@ export interface ProviderSwitcherConfig {
   /** Fires when the user picks a (providerId, modelId) pair. */
   onSelect: (providerId: string, modelId: string) => void;
 }
+
+type ComposerHasTextStore = {
+  subscribe: (listener: () => void) => () => void;
+  get: () => boolean;
+  set: (next: boolean) => void;
+};
+
+function createComposerHasTextStore(initial: boolean): ComposerHasTextStore {
+  let value = initial;
+  const listeners = new Set<() => void>();
+  return {
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    get: () => value,
+    set: (next) => {
+      if (value === next) return;
+      value = next;
+      for (const listener of listeners) listener();
+    },
+  };
+}
+
+const ComposerSendUi = React.memo(function ComposerSendUi({
+  hasTextStore,
+  hasTerminalSelectionAttachment,
+  composerDisabled,
+  disabled,
+  isStreaming,
+  canSteer,
+  isSteering,
+  status,
+  onStop,
+  steerSendingLabel,
+  steerLabel,
+}: {
+  hasTextStore: ComposerHasTextStore;
+  hasTerminalSelectionAttachment: boolean;
+  composerDisabled: boolean;
+  disabled: boolean;
+  isStreaming: boolean;
+  canSteer: boolean;
+  isSteering: boolean;
+  status: PromptInputStatus;
+  onStop?: () => void;
+  steerSendingLabel: string;
+  steerLabel: string;
+}) {
+  const hasComposerText = useSyncExternalStore(hasTextStore.subscribe, hasTextStore.get, hasTextStore.get);
+  const sendDisabled = (!hasComposerText && !hasTerminalSelectionAttachment) || disabled;
+  if (isStreaming && canSteer) {
+    return (
+      <>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="submit"
+              disabled={(!hasComposerText && !hasTerminalSelectionAttachment) || composerDisabled}
+              aria-label={isSteering ? steerSendingLabel : steerLabel}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-foreground/20 bg-foreground text-background shadow-sm transition-colors hover:bg-foreground/90 disabled:border-border/80 disabled:bg-muted/52 disabled:text-foreground/72"
+            >
+              {isSteering ? <Loader2 size={14} className="animate-spin" /> : <ArrowUp size={14} />}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>{isSteering ? steerSendingLabel : steerLabel}</TooltipContent>
+        </Tooltip>
+        <PromptInputSubmit status="streaming" onStop={onStop} />
+      </>
+    );
+  }
+  return (
+    <PromptInputSubmit
+      status={status}
+      onStop={onStop}
+      disabled={sendDisabled}
+    />
+  );
+});
 
 interface ChatInputProps {
   value: string;
@@ -185,7 +266,11 @@ const ChatInput: React.FC<ChatInputProps> = ({
   const hasTerminalSelectionAttachment = files.some((file) => file.terminalSelection);
   const composerDisabled = disabled || isSteering;
   const composerTextRef = useRef(value);
-  const [hasComposerText, setHasComposerText] = useState(() => value.trim().length > 0);
+  const hasTextStoreRef = useRef<ComposerHasTextStore | null>(null);
+  if (hasTextStoreRef.current == null) {
+    hasTextStoreRef.current = createComposerHasTextStore(value.trim().length > 0);
+  }
+  const hasTextStore = hasTextStoreRef.current;
   const pushedParentTextRef = useRef(value);
   const [composerHeight, setComposerHeight] = useState<number | null>(null);
   const [composerMaxHeight, setComposerMaxHeight] = useState(CHAT_INPUT_MAX_HEIGHT);
@@ -350,9 +435,8 @@ const ChatInput: React.FC<ChatInputProps> = ({
   }, []);
 
   const syncHasComposerText = useCallback((text: string) => {
-    const next = text.trim().length > 0;
-    setHasComposerText((prev) => (prev === next ? prev : next));
-  }, []);
+    hasTextStore.set(text.trim().length > 0);
+  }, [hasTextStore]);
 
   const readComposerText = useCallback(() => (
     textareaRef.current?.value ?? composerTextRef.current
@@ -1498,30 +1582,19 @@ const ChatInput: React.FC<ChatInputProps> = ({
           <div className="flex-1 min-w-0" />
 
           <div className="flex items-center gap-1">
-            {isStreaming && canSteer ? (
-              <>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="submit"
-                      disabled={(!hasComposerText && !hasTerminalSelectionAttachment) || composerDisabled}
-                      aria-label={isSteering ? t('ai.codex.steer.sending') : t('ai.codex.steer.addInstruction')}
-                      className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-foreground/20 bg-foreground text-background shadow-sm transition-colors hover:bg-foreground/90 disabled:border-border/80 disabled:bg-muted/52 disabled:text-foreground/72"
-                    >
-                      {isSteering ? <Loader2 size={14} className="animate-spin" /> : <ArrowUp size={14} />}
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>{isSteering ? t('ai.codex.steer.sending') : t('ai.codex.steer.addInstruction')}</TooltipContent>
-                </Tooltip>
-                <PromptInputSubmit status="streaming" onStop={onStop} />
-              </>
-            ) : (
-              <PromptInputSubmit
-                status={status}
-                onStop={onStop}
-                disabled={(!hasComposerText && !hasTerminalSelectionAttachment) || disabled}
-              />
-            )}
+            <ComposerSendUi
+              hasTextStore={hasTextStore}
+              hasTerminalSelectionAttachment={hasTerminalSelectionAttachment}
+              composerDisabled={composerDisabled}
+              disabled={disabled}
+              isStreaming={isStreaming}
+              canSteer={canSteer}
+              isSteering={isSteering}
+              status={status}
+              onStop={onStop}
+              steerSendingLabel={t('ai.codex.steer.sending')}
+              steerLabel={t('ai.codex.steer.addInstruction')}
+            />
           </div>
         </PromptInputFooter>
       </PromptInput>
@@ -1530,4 +1603,56 @@ const ChatInput: React.FC<ChatInputProps> = ({
   );
 };
 
-export default React.memo(ChatInput);
+function contextUsageEqual(
+  prev: AgentContextUsage | null | undefined,
+  next: AgentContextUsage | null | undefined,
+): boolean {
+  if (prev === next) return true;
+  if (!prev || !next) return false;
+  return (
+    prev.sessionId === next.sessionId
+    && prev.inputTokens === next.inputTokens
+    && prev.contextWindow === next.contextWindow
+    && prev.estimated === next.estimated
+  );
+}
+
+function chatInputPropsAreEqual(prev: ChatInputProps, next: ChatInputProps): boolean {
+  return (
+    prev.value === next.value
+    && prev.onChange === next.onChange
+    && prev.onSend === next.onSend
+    && prev.onCompact === next.onCompact
+    && prev.canCompact === next.canCompact
+    && contextUsageEqual(prev.contextUsage, next.contextUsage)
+    && prev.onSteer === next.onSteer
+    && prev.onStop === next.onStop
+    && prev.isStreaming === next.isStreaming
+    && prev.canSteer === next.canSteer
+    && prev.isSteering === next.isSteering
+    && prev.lockTurnConfiguration === next.lockTurnConfiguration
+    && prev.disabled === next.disabled
+    && prev.providerName === next.providerName
+    && prev.modelName === next.modelName
+    && prev.agentName === next.agentName
+    && prev.placeholder === next.placeholder
+    && prev.modelPresets === next.modelPresets
+    && prev.selectedModelId === next.selectedModelId
+    && prev.onModelSelect === next.onModelSelect
+    && prev.files === next.files
+    && prev.onAddFiles === next.onAddFiles
+    && prev.onRemoveFile === next.onRemoveFile
+    && prev.hosts === next.hosts
+    && prev.selectedUserSkills === next.selectedUserSkills
+    && prev.userSkills === next.userSkills
+    && prev.quickMessages === next.quickMessages
+    && prev.onAddUserSkill === next.onAddUserSkill
+    && prev.onRemoveUserSkill === next.onRemoveUserSkill
+    && prev.permissionMode === next.permissionMode
+    && prev.onPermissionModeChange === next.onPermissionModeChange
+    && prev.providerSwitcher === next.providerSwitcher
+    && prev.parked === next.parked
+  );
+}
+
+export default React.memo(ChatInput, chatInputPropsAreEqual);

--- a/components/ai/ChatMessageList.tsx
+++ b/components/ai/ChatMessageList.tsx
@@ -19,6 +19,7 @@ import {
 import { LazyMessageResponse } from '../ai-elements/LazyMessageResponse';
 import { Message, MessageContent } from '../ai-elements/messageShell';
 import {
+  AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS,
   AI_MARKDOWN_WARMUP_RESUME_DELAY_MS,
   isAiComposerTyping,
   scheduleAiMarkdownWarmup,
@@ -388,7 +389,7 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
     if (!hasAssistantMarkdown) return undefined;
     return scheduleAiMarkdownWarmup({
       isBusy: isAiComposerTyping,
-      initialDelayMs: 300,
+      initialDelayMs: AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS,
       resumeDelayMs: AI_MARKDOWN_WARMUP_RESUME_DELAY_MS,
     });
   }, [hasAssistantMarkdown]);

--- a/components/ai/ChatMessageList.tsx
+++ b/components/ai/ChatMessageList.tsx
@@ -19,8 +19,8 @@ import {
 import { LazyMessageResponse } from '../ai-elements/LazyMessageResponse';
 import { Message, MessageContent } from '../ai-elements/messageShell';
 import {
-  AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS,
   AI_MARKDOWN_WARMUP_RESUME_DELAY_MS,
+  isAiComposerTyping,
   scheduleAiMarkdownWarmup,
 } from './aiMarkdownWarmup';
 import { ToolCall } from '../ai-elements/tool-call';
@@ -387,7 +387,8 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
   useEffect(() => {
     if (!hasAssistantMarkdown) return undefined;
     return scheduleAiMarkdownWarmup({
-      initialDelayMs: AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS,
+      isBusy: isAiComposerTyping,
+      initialDelayMs: 300,
       resumeDelayMs: AI_MARKDOWN_WARMUP_RESUME_DELAY_MS,
     });
   }, [hasAssistantMarkdown]);

--- a/components/ai/aiMarkdownWarmup.test.ts
+++ b/components/ai/aiMarkdownWarmup.test.ts
@@ -69,6 +69,7 @@ test('chat history defers Streamdown until warmup is already done', () => {
   assert.match(list, /deferUntilWarm/);
   assert.match(list, /scheduleAiMarkdownWarmup/);
   assert.match(list, /isAiComposerTyping/);
+  assert.match(list, /AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS/);
   assert.match(list, /AI_MARKDOWN_WARMUP_RESUME_DELAY_MS/);
 });
 

--- a/components/ai/aiMarkdownWarmup.test.ts
+++ b/components/ai/aiMarkdownWarmup.test.ts
@@ -23,7 +23,7 @@ test('defers markdown warmup while the composer is focused, composing, or recent
 test('recent composer activity counts as busy', () => {
   markAiComposerActivity();
   assert.equal(isAiComposerBusy(), true);
-  assert.ok(AI_COMPOSER_IDLE_MS >= 600);
+  assert.ok(AI_COMPOSER_IDLE_MS >= 2000);
 });
 
 test('recognizes the chat composer as a busy warmup target', () => {
@@ -35,9 +35,9 @@ test('recognizes the chat composer as a busy warmup target', () => {
 test('composer-idle IPC waits the same expand grace as history markdown', () => {
   const warmup = readFileSync(new URL('./aiMarkdownWarmup.ts', import.meta.url), 'utf8');
   assert.match(warmup, /initialDelayMs:\s*options\?\.initialDelayMs \?\? AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS/);
-  assert.match(warmup, /isBusy: isAiComposerRecentlyActive/);
+  assert.match(warmup, /isBusy: isAiComposerBusy/);
   assert.match(warmup, /markAiComposerActivity\(\);\n\s*arm\(\);/);
-  assert.match(warmup, /if \(isAiComposerRecentlyActive\(\)\) \{\s*hydrateScheduled = true;/s);
+  assert.match(warmup, /if \(isAiComposerBusy\(\)\) \{\s*hydrateScheduled = true;/s);
 });
 
 test('history markdown waits after expand, then resumes quickly after blur', () => {

--- a/components/ai/aiMarkdownWarmup.test.ts
+++ b/components/ai/aiMarkdownWarmup.test.ts
@@ -37,7 +37,7 @@ test('composer-idle IPC waits the same expand grace as history markdown', () => 
   assert.match(warmup, /initialDelayMs:\s*options\?\.initialDelayMs \?\? AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS/);
   assert.match(warmup, /isBusy: isAiComposerBusy/);
   assert.match(warmup, /markAiComposerActivity\(\);\n\s*arm\(\);/);
-  assert.match(warmup, /if \(isAiComposerBusy\(\)\) \{\s*hydrateScheduled = true;/s);
+  assert.match(warmup, /if \(isAiComposerTyping\(\)\) \{\s*hydrateScheduled = true;/s);
 });
 
 test('history markdown waits after expand, then resumes quickly after blur', () => {
@@ -68,8 +68,14 @@ test('chat history defers Streamdown until warmup is already done', () => {
   const list = readFileSync(new URL('./ChatMessageList.tsx', import.meta.url), 'utf8');
   assert.match(list, /deferUntilWarm/);
   assert.match(list, /scheduleAiMarkdownWarmup/);
-  assert.match(list, /AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS/);
+  assert.match(list, /isAiComposerTyping/);
   assert.match(list, /AI_MARKDOWN_WARMUP_RESUME_DELAY_MS/);
+});
+
+test('composer focus alone does not count as typing', () => {
+  assert.equal(shouldDeferAiMarkdownWarmup({ composerFocused: true }), true);
+  assert.equal(shouldDeferAiMarkdownWarmup({ composerFocused: true, isComposing: false, recentlyActive: false }), true);
+  assert.equal(shouldDeferAiMarkdownWarmup({ isComposing: false, recentlyActive: false }), false);
 });
 
 test('LazyMessageResponse keeps plaintext while chat asks to defer', () => {

--- a/components/ai/aiMarkdownWarmup.test.ts
+++ b/components/ai/aiMarkdownWarmup.test.ts
@@ -61,6 +61,7 @@ test('AI panel no longer starts Streamdown just because it became visible', () =
   assert.match(panel, /warmAiMarkdownRenderer/);
   assert.doesNotMatch(panel, /timeout:\s*2500/);
   assert.doesNotMatch(panel, /import\('\.\/ai-elements\/messageResponse'\)/);
+  assert.doesNotMatch(panel, /@streamdown\/code/);
 });
 
 test('chat history defers Streamdown until warmup is already done', () => {

--- a/components/ai/aiMarkdownWarmup.ts
+++ b/components/ai/aiMarkdownWarmup.ts
@@ -50,6 +50,13 @@ export function shouldDeferAiMarkdownWarmup(input: {
   return Boolean(input.composerFocused || input.isComposing || input.recentlyActive);
 }
 
+export function isAiComposerTyping(): boolean {
+  return shouldDeferAiMarkdownWarmup({
+    isComposing: composerComposing,
+    recentlyActive: isAiComposerRecentlyActive(),
+  });
+}
+
 export function isAiComposerBusy(): boolean {
   const active = typeof document === 'undefined' ? null : document.activeElement;
   return shouldDeferAiMarkdownWarmup({
@@ -101,7 +108,9 @@ function pumpChatMarkdownHydrate(): void {
     hydrateScheduled = false;
     if (hydrateQueue.length === 0) return;
     if (!markdownWarmupResolved) return;
-    if (isAiComposerBusy()) {
+    // Focused but idle is fine: Streamdown+CJK is light. Only pause while
+    // the user is actually typing so history does not stay raw forever.
+    if (isAiComposerTyping()) {
       hydrateScheduled = true;
       window.setTimeout(() => {
         hydrateScheduled = false;

--- a/components/ai/aiMarkdownWarmup.ts
+++ b/components/ai/aiMarkdownWarmup.ts
@@ -6,7 +6,8 @@ export const AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS = 4000;
 /** After the composer blurs, a short pause is enough to know typing stopped. */
 export const AI_MARKDOWN_WARMUP_RESUME_DELAY_MS = 600;
 /** Treat recent keystrokes as busy even if focus already moved. */
-export const AI_COMPOSER_IDLE_MS = 800;
+export const AI_COMPOSER_IDLE_MS = 2000;
+let composerComposing = false;
 const CHAT_MARKDOWN_HYDRATE_BATCH = 2;
 
 let markdownWarmupPromise: Promise<unknown> | null = null;
@@ -32,6 +33,11 @@ export function markAiComposerActivity(): void {
   lastComposerActivityAt = Date.now();
 }
 
+export function setAiComposerComposing(next: boolean): void {
+  composerComposing = next;
+  if (next) markAiComposerActivity();
+}
+
 export function isAiComposerRecentlyActive(now = Date.now()): boolean {
   return lastComposerActivityAt > 0 && now - lastComposerActivityAt < AI_COMPOSER_IDLE_MS;
 }
@@ -48,6 +54,7 @@ export function isAiComposerBusy(): boolean {
   const active = typeof document === 'undefined' ? null : document.activeElement;
   return shouldDeferAiMarkdownWarmup({
     composerFocused: isAiComposerTarget(active),
+    isComposing: composerComposing,
     recentlyActive: isAiComposerRecentlyActive(),
   });
 }
@@ -94,7 +101,7 @@ function pumpChatMarkdownHydrate(): void {
     hydrateScheduled = false;
     if (hydrateQueue.length === 0) return;
     if (!markdownWarmupResolved) return;
-    if (isAiComposerRecentlyActive()) {
+    if (isAiComposerBusy()) {
       hydrateScheduled = true;
       window.setTimeout(() => {
         hydrateScheduled = false;
@@ -143,7 +150,7 @@ export function scheduleWhenAiComposerIdle(
 ): () => void {
   return scheduleAiMarkdownWarmup({
     load: task,
-    isBusy: isAiComposerRecentlyActive,
+    isBusy: isAiComposerBusy,
     initialDelayMs: options?.initialDelayMs ?? AI_MARKDOWN_WARMUP_INITIAL_DELAY_MS,
     resumeDelayMs: options?.resumeDelayMs ?? AI_COMPOSER_IDLE_MS,
   });


### PR DESCRIPTION
## Summary

Typing in the AI composer could still hitch after #2995/#2996. Two remaining React paths:

1. The first character flipped `hasComposerText` in `ChatInput`, so the whole model/footer tree reconciled.
2. `contextUsage` is a new object on each snapshot, which broke `React.memo` and re-rendered the composer during a live turn.

Send-button emptiness now lives in a tiny store; only that control re-renders. ChatInput memo compares usage by value.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Follow-up to #2995 and #2996.

## Changes Made

- `ComposerSendUi` reads emptiness via `useSyncExternalStore`.
- `chatInputPropsAreEqual` ignores usage-object identity.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)