### PR TITLE
fix(ai): accept SSE data lines without a space after the colon

### DIFF
--- a/electron/bridges/ai/sseDataLine.cjs
+++ b/electron/bridges/ai/sseDataLine.cjs
@@ -1,0 +1,19 @@
+/**
+ * Extract the payload of an SSE `data:` field.
+ *
+ * The WHATWG EventSource spec treats the space after the colon as optional
+ * and strips at most one leading U+0020. Older AxonHub (0.9) and some
+ * intranet OpenAI-compat proxies emit `data:{json}` with no space, which
+ * a `data: ` prefix check silently drops (issue #3020).
+ *
+ * @param {unknown} line
+ * @returns {string | null}
+ */
+function extractSseDataPayload(line) {
+  const trimmed = typeof line === "string" ? line.trim() : "";
+  if (!trimmed.startsWith("data:")) return null;
+  const payload = trimmed.slice("data:".length);
+  return payload.startsWith(" ") ? payload.slice(1) : payload;
+}
+
+module.exports = { extractSseDataPayload };

--- a/electron/bridges/ai/sseDataLine.test.cjs
+++ b/electron/bridges/ai/sseDataLine.test.cjs
@@ -1,0 +1,26 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { extractSseDataPayload } = require("./sseDataLine.cjs");
+
+test("extractSseDataPayload accepts data: with or without the optional space", () => {
+  assert.equal(extractSseDataPayload('data: {"a":1}'), '{"a":1}');
+  assert.equal(extractSseDataPayload('data:{"a":1}'), '{"a":1}');
+  assert.equal(extractSseDataPayload('  data:{"a":1}  \r'), '{"a":1}');
+  assert.equal(extractSseDataPayload("data: [DONE]"), "[DONE]");
+  assert.equal(extractSseDataPayload("data:[DONE]"), "[DONE]");
+});
+
+test("extractSseDataPayload strips only one leading space after the colon", () => {
+  assert.equal(extractSseDataPayload("data:  keep"), " keep");
+  assert.equal(extractSseDataPayload("data:"), "");
+  assert.equal(extractSseDataPayload("data: "), "");
+});
+
+test("extractSseDataPayload ignores non-data SSE lines", () => {
+  assert.equal(extractSseDataPayload(""), null);
+  assert.equal(extractSseDataPayload(": comment"), null);
+  assert.equal(extractSseDataPayload("event: message"), null);
+  assert.equal(extractSseDataPayload("DATA: foo"), null);
+  assert.equal(extractSseDataPayload(null), null);
+  assert.equal(extractSseDataPayload(undefined), null);
+});

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -51,6 +51,7 @@ const {
 } = require("./ai/shellUtils.cjs");
 
 const { detectClaudeAuthPresence, expandHomePath } = require("./ai/claudeAuth.cjs");
+const { extractSseDataPayload } = require("./ai/sseDataLine.cjs");
 
 const CLAUDE_AUTH_HELP_MESSAGE =
   "Claude Code has no usable authentication. Open Settings -> AI -> Claude Code and set a Config directory (point it at a folder where you've run `claude` login) or add an ANTHROPIC_API_KEY under Environment variables. Alternatively, run `claude` in a terminal to log in.";
@@ -731,14 +732,11 @@ async function streamRequest(url, options, event, requestId, skipTLS) {
             const line = buffer.slice(consumedUntil, newlineIndex);
             consumedUntil = newlineIndex + 1;
             searchFrom = consumedUntil;
-            const trimmed = line.trim();
-            if (!trimmed) continue;
-
-            // Forward raw SSE data line to renderer
-            if (trimmed.startsWith("data: ")) {
+            const payload = extractSseDataPayload(line);
+            if (payload != null) {
               safeSend(event.sender, "netcatty:ai:stream:data", {
                 requestId,
-                data: trimmed.slice(6),
+                data: payload,
               });
             }
           }
@@ -748,10 +746,11 @@ async function streamRequest(url, options, event, requestId, skipTLS) {
         res.on("end", () => {
           if (streamFinished) return;
           // Flush any remaining buffer
-          if (buffer.trim().startsWith("data: ")) {
+          const trailingPayload = extractSseDataPayload(buffer);
+          if (trailingPayload != null) {
             safeSend(event.sender, "netcatty:ai:stream:data", {
               requestId,
-              data: buffer.trim().slice(6),
+              data: trailingPayload,
             });
           }
           safeSend(event.sender, "netcatty:ai:stream:end", { requestId });

--- a/electron/bridges/aiBridge.test.cjs
+++ b/electron/bridges/aiBridge.test.cjs
@@ -481,6 +481,148 @@ test("streaming AI responses preserve UTF-8 characters split across network chun
   }
 });
 
+test("streaming AI responses accept SSE data: lines without a space after the colon", { timeout: 5_000 }, async (t) => {
+  const sentEvents = [];
+  let handleStreamEvent = () => {};
+  const { bridge, restore } = loadBridgeWithMocks({
+    safeSend: (_sender, channel, payload) => {
+      sentEvents.push({ channel, payload });
+      handleStreamEvent(channel, payload);
+    },
+  });
+  const ipcMain = createIpcMainStub();
+  const server = require("node:http").createServer((req, res) => {
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      // Older AxonHub 0.9 emits `data:{json}` with no space (issue #3020).
+      res.end('data:{"choices":[{"delta":{"content":"hello"}}]}\ndata:[DONE]\n\n');
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    const baseURL = `http://127.0.0.1:${address.port}`;
+    const sender = { id: 1 };
+    await ipcMain.handlers.get("netcatty:ai:sync-providers")(
+      { sender },
+      { providers: [{ id: "axonhub-legacy", baseURL }] },
+    );
+
+    const streamFinished = new Promise((resolve, reject) => {
+      handleStreamEvent = (channel, payload) => {
+        if (channel === "netcatty:ai:stream:end") resolve();
+        else if (channel === "netcatty:ai:stream:error") reject(new Error(payload.error));
+      };
+    });
+
+    const result = await ipcMain.handlers.get("netcatty:ai:chat:stream")(
+      { sender },
+      {
+        requestId: "axonhub-legacy-request",
+        url: `${baseURL}/v1/chat/completions`,
+        headers: { "content-type": "application/json" },
+        body: '{"stream":true}',
+        providerId: "axonhub-legacy",
+      },
+    );
+    await streamFinished;
+
+    assert.equal(result.ok, true);
+    const dataEvents = sentEvents
+      .filter(({ channel }) => channel === "netcatty:ai:stream:data")
+      .map(({ payload }) => payload.data);
+    assert.deepEqual(dataEvents, [
+      '{"choices":[{"delta":{"content":"hello"}}]}',
+      "[DONE]",
+    ]);
+  } finally {
+    restore();
+  }
+});
+
+test("streaming AI responses flush a trailing data: line that has no space and no newline", { timeout: 5_000 }, async (t) => {
+  const sentEvents = [];
+  let handleStreamEvent = () => {};
+  const { bridge, restore } = loadBridgeWithMocks({
+    safeSend: (_sender, channel, payload) => {
+      sentEvents.push({ channel, payload });
+      handleStreamEvent(channel, payload);
+    },
+  });
+  const ipcMain = createIpcMainStub();
+  const server = require("node:http").createServer((req, res) => {
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.end('data:{"choices":[{"delta":{"content":"tail"}}]}');
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    const baseURL = `http://127.0.0.1:${address.port}`;
+    const sender = { id: 1 };
+    await ipcMain.handlers.get("netcatty:ai:sync-providers")(
+      { sender },
+      { providers: [{ id: "flush-no-space", baseURL }] },
+    );
+
+    const streamFinished = new Promise((resolve, reject) => {
+      handleStreamEvent = (channel, payload) => {
+        if (channel === "netcatty:ai:stream:end") resolve();
+        else if (channel === "netcatty:ai:stream:error") reject(new Error(payload.error));
+      };
+    });
+
+    const result = await ipcMain.handlers.get("netcatty:ai:chat:stream")(
+      { sender },
+      {
+        requestId: "flush-no-space-request",
+        url: `${baseURL}/v1/chat/completions`,
+        headers: { "content-type": "application/json" },
+        body: '{"stream":true}',
+        providerId: "flush-no-space",
+      },
+    );
+    await streamFinished;
+
+    assert.equal(result.ok, true);
+    const dataEvent = sentEvents.find(({ channel }) => channel === "netcatty:ai:stream:data");
+    assert.equal(dataEvent?.payload.data, '{"choices":[{"delta":{"content":"tail"}}]}');
+  } finally {
+    restore();
+  }
+});
+
 test("discover returns the 3-layer contract for an installed, authenticated agent", async (t) => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-discover-contract-"));
   t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary

Catty chat against older AxonHub 0.9 (and similar intranet OpenAI-compat proxies) could finish with an empty assistant bubble even though Settings → Test Connection succeeded. Those relays emit SSE as `data:{json}` with no space after the colon. The stream parser only accepted `data: `, so every chunk was dropped and no error was raised.

The EventSource spec treats that space as optional and strips at most one leading U+0020. The parser now follows that rule on both the per-line path and the end-of-stream flush.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3020

## Changes Made

- Extract `extractSseDataPayload` to accept `data:` with or without the optional space.
- Use it in `aiBridge` stream line parsing and the trailing-buffer flush.
- Add unit tests plus stream integration coverage for AxonHub-style `data:{json}` and a no-newline flush.

## Screenshots / Demo

No UI change. Connection probe still uses the model-list path; chat now receives the same SSE payloads other clients already accepted.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Targeted: `node --test electron/bridges/ai/sseDataLine.test.cjs electron/bridges/aiBridge.test.cjs`. New SSE unit tests and both stream cases passed, including the existing UTF-8 split-chunk test.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)