### PR TITLE
fix(snippets): ignore disabled app shortcuts in shortkey conflicts

### DIFF
--- a/application/i18n/locales/en/terminal.ts
+++ b/application/i18n/locales/en/terminal.ts
@@ -748,7 +748,7 @@ export const enTerminalMessages: Messages = {
   'snippets.shortkey.recording': 'Press a key combination...',
   'snippets.shortkey.hint': 'Press this shortcut in terminal to quickly send the command.',
   'snippets.shortkey.clear': 'Clear shortcut',
-  'snippets.shortkey.error.systemConflict': 'This shortcut conflicts with a system shortcut',
+  'snippets.shortkey.error.systemConflict': 'This shortcut conflicts with {name}',
   'snippets.shortkey.error.snippetConflict': 'This shortcut is already used by snippet: {name}',
 
   'snippets.variables.dialogTitle': 'Snippet variables',

--- a/application/i18n/locales/es/terminal.ts
+++ b/application/i18n/locales/es/terminal.ts
@@ -748,7 +748,7 @@ export const esTerminalMessages: Messages = {
   'snippets.shortkey.recording': 'Presiona una combinación de teclas...',
   'snippets.shortkey.hint': 'Presiona este atajo en la terminal para enviar el comando rápidamente.',
   'snippets.shortkey.clear': 'Borrar atajo',
-  'snippets.shortkey.error.systemConflict': 'Este atajo entra en conflicto con un atajo del sistema',
+  'snippets.shortkey.error.systemConflict': 'Este atajo entra en conflicto con {name}',
   'snippets.shortkey.error.snippetConflict': 'Este atajo ya lo usa el snippet: {name}',
 
   'snippets.variables.dialogTitle': 'Variables del snippet',

--- a/application/i18n/locales/ru/terminal.ts
+++ b/application/i18n/locales/ru/terminal.ts
@@ -765,7 +765,7 @@ export const ruTerminalMessages: Messages = {
   'snippets.shortkey.recording': 'Нажмите сочетание клавиш...',
   'snippets.shortkey.hint': 'Нажмите это сочетание в терминале, чтобы быстро отправить команду.',
   'snippets.shortkey.clear': 'Очистить сочетание',
-  'snippets.shortkey.error.systemConflict': 'Это сочетание конфликтует с системным сочетанием',
+  'snippets.shortkey.error.systemConflict': 'Это сочетание конфликтует с «{name}»',
   'snippets.shortkey.error.snippetConflict': 'Это сочетание уже используется сниппетом: {name}',
 
   // Serial Port

--- a/application/i18n/locales/snippetBulkDeleteLocales.test.ts
+++ b/application/i18n/locales/snippetBulkDeleteLocales.test.ts
@@ -21,6 +21,17 @@ test('snippet bulk-delete copy exists in every locale', () => {
   }
 });
 
+test('snippet shortkey system-conflict copy names the conflicting action', () => {
+  for (const [locale, messages] of Object.entries({ en, ru, es, zhCN, zhTW })) {
+    const text = messages['snippets.shortkey.error.systemConflict'];
+    assert.match(
+      text ?? '',
+      /\{name\}/,
+      `${locale} system-conflict copy should include {name}`,
+    );
+  }
+});
+
 test('English bulk-delete copy is entity-neutral and grammatical for one item', () => {
   assert.equal(
     en['snippets.selection.deleteConfirmTitle'].replace('{count}', '1'),

--- a/application/i18n/locales/zh-CN/terminal.ts
+++ b/application/i18n/locales/zh-CN/terminal.ts
@@ -833,7 +833,7 @@ export const zhCNTerminalMessages: Messages = {
   'snippets.shortkey.recording': '请按下快捷键组合...',
   'snippets.shortkey.hint': '在终端中按下此快捷键可快速发送命令。',
   'snippets.shortkey.clear': '清除快捷键',
-  'snippets.shortkey.error.systemConflict': '此快捷键与系统快捷键冲突',
+  'snippets.shortkey.error.systemConflict': '此快捷键与「{name}」冲突',
   'snippets.shortkey.error.snippetConflict': '此快捷键已被代码片段使用：{name}',
 
   'snippets.variables.dialogTitle': '填写变量',

--- a/application/i18n/locales/zh-TW/terminal.ts
+++ b/application/i18n/locales/zh-TW/terminal.ts
@@ -833,7 +833,7 @@ export const zhTWTerminalMessages: Messages = {
   'snippets.shortkey.recording': '請按下快捷鍵組合...',
   'snippets.shortkey.hint': '在終端中按下此快捷鍵可快速傳送指令。',
   'snippets.shortkey.clear': '清除快捷鍵',
-  'snippets.shortkey.error.systemConflict': '此快捷鍵與系統快捷鍵衝突',
+  'snippets.shortkey.error.systemConflict': '此快捷鍵與「{name}」衝突',
   'snippets.shortkey.error.snippetConflict': '此快捷鍵已被程式碼片段使用：{name}',
 
   'snippets.variables.dialogTitle': '填寫變數',

--- a/components/QuickAddSnippetDialog.test.tsx
+++ b/components/QuickAddSnippetDialog.test.tsx
@@ -29,6 +29,7 @@ test("quick add snippet form binds shortkeys and uses a centered Dialog modal", 
   assert.match(source, /from '\.\/ui\/dialog'/);
   assert.doesNotMatch(source, /AsidePanel/);
   assert.match(source, /snippets\.field\.shortkey/);
+  assert.match(source, /findActiveSystemShortcutConflict/);
   assert.match(source, /keyEventToString/);
   assert.match(source, /shortkey: shortkey \|\| undefined/);
   assert.match(source, /if \(e\.defaultPrevented\) return/);

--- a/components/QuickAddSnippetDialog.tsx
+++ b/components/QuickAddSnippetDialog.tsx
@@ -12,12 +12,13 @@ import { Keyboard, Package, RotateCcw } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '../application/i18n/I18nProvider';
 import type { Snippet } from '../domain/models';
+import { findActiveSystemShortcutConflict } from '../domain/activeKeyBindings';
 import {
   type HotkeyScheme,
   type KeyBinding,
   keyEventToString,
+  keyStringToKeyboardEvent,
   matchesKeyBinding,
-  parseKeyCombo,
 } from '../domain/models';
 import { isScriptSnippet } from '../domain/snippetScript.ts';
 import { cn, isMacPlatform } from '../lib/utils';
@@ -132,78 +133,6 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
     snippets.filter((s) => Boolean(s.shortkey) && s.id !== editing?.id)
   ), [snippets, editing?.id]);
 
-  const activeSystemBindings = useMemo(() => {
-    return keyBindings.flatMap((binding) => {
-      const entries: { binding: string; isMac: boolean }[] = [];
-      const macBinding = binding.mac;
-      const pcBinding = binding.pc;
-
-      if (hotkeyScheme === 'mac') {
-        if (macBinding && macBinding !== 'Disabled') {
-          entries.push({ binding: macBinding, isMac: true });
-        }
-        return entries;
-      }
-
-      if (hotkeyScheme === 'pc') {
-        if (pcBinding && pcBinding !== 'Disabled') {
-          entries.push({ binding: pcBinding, isMac: false });
-        }
-        return entries;
-      }
-
-      if (macBinding && macBinding !== 'Disabled') {
-        entries.push({ binding: macBinding, isMac: true });
-      }
-      if (pcBinding && pcBinding !== 'Disabled') {
-        entries.push({ binding: pcBinding, isMac: false });
-      }
-      return entries;
-    });
-  }, [hotkeyScheme, keyBindings]);
-
-  const buildKeyEventFromString = useCallback((keyString: string) => {
-    const parsed = parseKeyCombo(keyString);
-    if (!parsed) return null;
-
-    const modifiers = new Set(parsed.modifiers);
-    const key = parsed.key;
-    const normalizedKey = (() => {
-      switch (key) {
-        case 'Space':
-          return ' ';
-        case '↑':
-          return 'ArrowUp';
-        case '↓':
-          return 'ArrowDown';
-        case '←':
-          return 'ArrowLeft';
-        case '→':
-          return 'ArrowRight';
-        case 'Esc':
-          return 'Escape';
-        case '⌫':
-          return 'Backspace';
-        case 'Del':
-          return 'Delete';
-        case '↵':
-          return 'Enter';
-        case '⇥':
-          return 'Tab';
-        default:
-          return key.length === 1 ? key.toLowerCase() : key;
-      }
-    })();
-
-    return new KeyboardEvent('keydown', {
-      key: normalizedKey,
-      metaKey: modifiers.has('⌘') || modifiers.has('Win'),
-      ctrlKey: modifiers.has('⌃') || modifiers.has('Ctrl'),
-      altKey: modifiers.has('⌥') || modifiers.has('Alt'),
-      shiftKey: modifiers.has('Shift'),
-    });
-  }, []);
-
   const normalizeKeyString = useCallback((value: string) => (
     value.toLowerCase().replace(/\s+/g, '')
   ), []);
@@ -211,16 +140,14 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
   const validateShortkey = useCallback((key: string): string | null => {
     if (!key) return null;
 
-    const syntheticEvent = buildKeyEventFromString(key);
-    if (syntheticEvent) {
-      const conflictsSystem = activeSystemBindings.some(({ binding, isMac: bindingIsMac }) => (
-        matchesKeyBinding(syntheticEvent, binding, bindingIsMac)
-      ));
-      if (conflictsSystem) {
-        return t('snippets.shortkey.error.systemConflict');
-      }
+    const systemConflict = findActiveSystemShortcutConflict(key, hotkeyScheme, keyBindings);
+    if (systemConflict) {
+      const nameKey = `settings.shortcuts.binding.${systemConflict.id}`;
+      const name = t(nameKey) !== nameKey ? t(nameKey) : systemConflict.label;
+      return t('snippets.shortkey.error.systemConflict', { name });
     }
 
+    const syntheticEvent = keyStringToKeyboardEvent(key);
     if (syntheticEvent) {
       for (const snippet of existingShortkeys) {
         if (snippet.shortkey && matchesKeyBinding(syntheticEvent, snippet.shortkey, isMac)) {
@@ -239,10 +166,10 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
 
     return null;
   }, [
-    activeSystemBindings,
-    buildKeyEventFromString,
     existingShortkeys,
+    hotkeyScheme,
     isMac,
+    keyBindings,
     normalizeKeyString,
     t,
   ]);

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -9,7 +9,8 @@ import {
   getShellHistorySnapshot,
   subscribeShellHistory,
 } from '../application/state/shellHistoryStore';
-import { HotkeyScheme, KeyBinding, keyEventToString, ManagedSource, matchesKeyBinding, parseKeyCombo } from '../domain/models';
+import { findActiveSystemShortcutConflict } from '../domain/activeKeyBindings';
+import { HotkeyScheme, KeyBinding, keyEventToString, keyStringToKeyboardEvent, ManagedSource, matchesKeyBinding } from '../domain/models';
 import {
   buildSnippetExportPayload,
   combineSnippetImportPayloads,
@@ -576,95 +577,21 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
     hotkeyScheme === 'mac' || (hotkeyScheme === 'disabled' && isMacPlatform())
   ), [hotkeyScheme]);
 
-  const activeSystemBindings = useMemo(() => {
-    return keyBindings.flatMap((binding) => {
-      const entries: { binding: string; isMac: boolean }[] = [];
-      const macBinding = binding.mac;
-      const pcBinding = binding.pc;
-
-      if (hotkeyScheme === 'mac') {
-        if (macBinding && macBinding !== 'Disabled') {
-          entries.push({ binding: macBinding, isMac: true });
-        }
-        return entries;
-      }
-
-      if (hotkeyScheme === 'pc') {
-        if (pcBinding && pcBinding !== 'Disabled') {
-          entries.push({ binding: pcBinding, isMac: false });
-        }
-        return entries;
-      }
-
-      if (macBinding && macBinding !== 'Disabled') {
-        entries.push({ binding: macBinding, isMac: true });
-      }
-      if (pcBinding && pcBinding !== 'Disabled') {
-        entries.push({ binding: pcBinding, isMac: false });
-      }
-      return entries;
-    });
-  }, [hotkeyScheme, keyBindings]);
-
-  const buildKeyEventFromString = useCallback((keyString: string) => {
-    const parsed = parseKeyCombo(keyString);
-    if (!parsed) return null;
-
-    const modifiers = new Set(parsed.modifiers);
-    const key = parsed.key;
-    const normalizedKey = (() => {
-      switch (key) {
-        case 'Space':
-          return ' ';
-        case '↑':
-          return 'ArrowUp';
-        case '↓':
-          return 'ArrowDown';
-        case '←':
-          return 'ArrowLeft';
-        case '→':
-          return 'ArrowRight';
-        case 'Esc':
-          return 'Escape';
-        case '⌫':
-          return 'Backspace';
-        case 'Del':
-          return 'Delete';
-        case '↵':
-          return 'Enter';
-        case '⇥':
-          return 'Tab';
-        default:
-          return key.length === 1 ? key.toLowerCase() : key;
-      }
-    })();
-
-    return new KeyboardEvent('keydown', {
-      key: normalizedKey,
-      metaKey: modifiers.has('⌘') || modifiers.has('Win'),
-      ctrlKey: modifiers.has('⌃') || modifiers.has('Ctrl'),
-      altKey: modifiers.has('⌥') || modifiers.has('Alt'),
-      shiftKey: modifiers.has('Shift'),
-    });
-  }, []);
-
   const normalizeKeyString = useCallback((value: string) => (
     value.toLowerCase().replace(/\s+/g, '')
   ), []);
 
   const validateShortkey = useCallback((key: string): string | null => {
     if (!key) return null;
-    
-    const syntheticEvent = buildKeyEventFromString(key);
-    if (syntheticEvent) {
-      const conflictsSystem = activeSystemBindings.some(({ binding, isMac: bindingIsMac }) => (
-        matchesKeyBinding(syntheticEvent, binding, bindingIsMac)
-      ));
-      if (conflictsSystem) {
-        return t('snippets.shortkey.error.systemConflict');
-      }
+
+    const systemConflict = findActiveSystemShortcutConflict(key, hotkeyScheme, keyBindings);
+    if (systemConflict) {
+      const nameKey = `settings.shortcuts.binding.${systemConflict.id}`;
+      const name = t(nameKey) !== nameKey ? t(nameKey) : systemConflict.label;
+      return t('snippets.shortkey.error.systemConflict', { name });
     }
-    
+
+    const syntheticEvent = keyStringToKeyboardEvent(key);
     if (syntheticEvent) {
       for (const snippet of existingShortkeys) {
         if (snippet.shortkey && matchesKeyBinding(syntheticEvent, snippet.shortkey, isMac)) {
@@ -680,13 +607,13 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
         return t('snippets.shortkey.error.snippetConflict', { name: conflictingSnippet.label });
       }
     }
-    
+
     return null;
   }, [
-    activeSystemBindings,
-    buildKeyEventFromString,
     existingShortkeys,
+    hotkeyScheme,
     isMac,
+    keyBindings,
     normalizeKeyString,
     t,
   ]);

--- a/domain/activeKeyBindings.test.ts
+++ b/domain/activeKeyBindings.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  findActiveSystemShortcutConflict,
+  listActiveSystemBindings,
+} from './activeKeyBindings.ts';
+import { DEFAULT_KEY_BINDINGS, type KeyBinding } from './models/keyBindings.ts';
+
+const withBindingOverride = (
+  id: string,
+  override: Partial<Pick<KeyBinding, 'mac' | 'pc'>>,
+): KeyBinding[] => (
+  DEFAULT_KEY_BINDINGS.map((binding) => (
+    binding.id === id ? { ...binding, ...override } : binding
+  ))
+);
+
+test('disabled scheme exposes no active system bindings', () => {
+  assert.deepEqual(listActiveSystemBindings('disabled', DEFAULT_KEY_BINDINGS), []);
+});
+
+test('disabled scheme does not treat default tab or broadcast keys as occupied', () => {
+  assert.equal(
+    findActiveSystemShortcutConflict('Ctrl + 1', 'disabled', DEFAULT_KEY_BINDINGS),
+    null,
+  );
+  assert.equal(
+    findActiveSystemShortcutConflict('Ctrl + B', 'disabled', DEFAULT_KEY_BINDINGS),
+    null,
+  );
+  assert.equal(
+    findActiveSystemShortcutConflict('⌘ + 1', 'disabled', DEFAULT_KEY_BINDINGS),
+    null,
+  );
+});
+
+test('pc scheme reports the tab-switch binding for Ctrl+1', () => {
+  const conflict = findActiveSystemShortcutConflict('Ctrl + 1', 'pc', DEFAULT_KEY_BINDINGS);
+
+  assert.equal(conflict?.id, 'switch-tab-1-9');
+});
+
+test('pc scheme reports the broadcast binding for Ctrl+B', () => {
+  const conflict = findActiveSystemShortcutConflict('Ctrl + B', 'pc', DEFAULT_KEY_BINDINGS);
+
+  assert.equal(conflict?.id, 'broadcast');
+});
+
+test('mac scheme does not treat Ctrl+1 as a tab shortcut', () => {
+  assert.equal(
+    findActiveSystemShortcutConflict('Ctrl + 1', 'mac', DEFAULT_KEY_BINDINGS),
+    null,
+  );
+});
+
+test('mac scheme reports the tab-switch binding for Cmd+1', () => {
+  const conflict = findActiveSystemShortcutConflict('⌘ + 1', 'mac', DEFAULT_KEY_BINDINGS);
+
+  assert.equal(conflict?.id, 'switch-tab-1-9');
+});
+
+test('a Disabled individual binding is not a conflict', () => {
+  const bindings = withBindingOverride('switch-tab-1-9', { pc: 'Disabled' });
+
+  assert.equal(findActiveSystemShortcutConflict('Ctrl + 1', 'pc', bindings), null);
+  assert.equal(findActiveSystemShortcutConflict('Ctrl + B', 'pc', bindings)?.id, 'broadcast');
+});

--- a/domain/activeKeyBindings.ts
+++ b/domain/activeKeyBindings.ts
@@ -1,0 +1,52 @@
+import {
+  type HotkeyScheme,
+  type KeyBinding,
+  keyStringToKeyboardEvent,
+  matchesKeyBinding,
+} from './models/keyBindings.ts';
+
+export type ActiveSystemBinding = {
+  binding: KeyBinding;
+  key: string;
+  isMac: boolean;
+};
+
+/** App shortcuts that can actually fire for the current scheme. */
+export const listActiveSystemBindings = (
+  hotkeyScheme: HotkeyScheme,
+  keyBindings: readonly KeyBinding[],
+): ActiveSystemBinding[] => {
+  if (hotkeyScheme === 'disabled') return [];
+
+  return keyBindings.flatMap((binding) => {
+    if (hotkeyScheme === 'mac') {
+      return binding.mac && binding.mac !== 'Disabled'
+        ? [{ binding, key: binding.mac, isMac: true }]
+        : [];
+    }
+
+    if (hotkeyScheme === 'pc') {
+      return binding.pc && binding.pc !== 'Disabled'
+        ? [{ binding, key: binding.pc, isMac: false }]
+        : [];
+    }
+
+    return [];
+  });
+};
+
+export const findActiveSystemShortcutConflict = (
+  key: string,
+  hotkeyScheme: HotkeyScheme,
+  keyBindings: readonly KeyBinding[],
+): KeyBinding | null => {
+  if (!key) return null;
+
+  const event = keyStringToKeyboardEvent(key);
+  if (!event) return null;
+
+  const conflict = listActiveSystemBindings(hotkeyScheme, keyBindings).find((entry) => (
+    matchesKeyBinding(event, entry.key, entry.isMac)
+  ));
+  return conflict?.binding ?? null;
+};

--- a/domain/models.test.ts
+++ b/domain/models.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { keyEventToString, matchesKeyBinding, tabShortcutDigitFromEvent } from './models.ts';
+import { keyEventToString, keyStringToKeyboardEvent, matchesKeyBinding, tabShortcutDigitFromEvent } from './models.ts';
 
 const keyboardEvent = (
   key: string,
@@ -73,4 +73,18 @@ test('shifted digit ranges still match via physical Digit code', () => {
 test('tab shortcut digit falls back to e.key when code is missing', () => {
   assert.equal(tabShortcutDigitFromEvent({ key: '3', code: '' }), 3);
   assert.equal(tabShortcutDigitFromEvent({ key: '!', code: '' }), null);
+});
+
+test('stored shortcut strings rebuild matching keyboard events', () => {
+  const event = keyStringToKeyboardEvent('Ctrl + 1');
+  assert.ok(event);
+  assert.equal(event.key, '1');
+  assert.equal(event.ctrlKey, true);
+  assert.equal(matchesKeyBinding(event, 'Ctrl + [1...9]', false), true);
+
+  const macEvent = keyStringToKeyboardEvent('⌘ + B');
+  assert.ok(macEvent);
+  assert.equal(macEvent.key, 'b');
+  assert.equal(macEvent.metaKey, true);
+  assert.equal(matchesKeyBinding(macEvent, '⌘ + B', true), true);
 });

--- a/domain/models/keyBindings.ts
+++ b/domain/models/keyBindings.ts
@@ -21,6 +21,38 @@ export const parseKeyCombo = (keyStr: string): { modifiers: string[]; key: strin
   return { modifiers: parts, key };
 };
 
+const KEY_STRING_TO_EVENT_KEY: Record<string, string> = {
+  Space: ' ',
+  '↑': 'ArrowUp',
+  '↓': 'ArrowDown',
+  '←': 'ArrowLeft',
+  '→': 'ArrowRight',
+  Esc: 'Escape',
+  '⌫': 'Backspace',
+  Del: 'Delete',
+  '↵': 'Enter',
+  '⇥': 'Tab',
+};
+
+/** Rebuild a keydown-like event from a stored shortcut string for matching. */
+export const keyStringToKeyboardEvent = (keyString: string): KeyboardEvent | null => {
+  const parsed = parseKeyCombo(keyString);
+  if (!parsed) return null;
+
+  const modifiers = new Set(parsed.modifiers);
+  const mappedKey = KEY_STRING_TO_EVENT_KEY[parsed.key];
+  const key = mappedKey ?? (parsed.key.length === 1 ? parsed.key.toLowerCase() : parsed.key);
+
+  return {
+    key,
+    code: '',
+    metaKey: modifiers.has('⌘') || modifiers.has('Win'),
+    ctrlKey: modifiers.has('⌃') || modifiers.has('Ctrl'),
+    altKey: modifiers.has('⌥') || modifiers.has('Alt'),
+    shiftKey: modifiers.has('Shift'),
+  } as KeyboardEvent;
+};
+
 const PHYSICAL_SHORTCUT_KEY_NAMES: Record<string, string> = {
   Backquote: '`',
   Minus: '-',


### PR DESCRIPTION
## Summary

When the keyboard shortcut scheme is disabled, snippet shortcut recording still treated default Mac and PC app bindings as occupied. Recording `Ctrl+1–9` or `Ctrl+B` then showed a generic “conflicts with a system shortcut” error even though those app shortcuts no longer fire.

This PR checks only bindings that can actually fire, and the conflict message names the conflicting action.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3025

## Changes Made

- Extract `listActiveSystemBindings` / `findActiveSystemShortcutConflict` so a disabled scheme reports no system conflicts, and `mac`/`pc` only consider non-`Disabled` bindings for that scheme.
- Use the helper in both snippet shortcut editors (`SnippetsManager` and `QuickAddSnippetDialog`).
- Change the conflict copy to include the action name, falling back to the binding label when a locale has no `settings.shortcuts.binding.*` string.
- Add domain tests for disabled scheme, PC/Mac matching, and per-binding `Disabled`.

## Screenshots / Demo

With keyboard shortcuts set to Disabled, `Ctrl+1–9` and `Ctrl+B` can be saved as snippet shortcuts.

With the PC scheme still enabled, the same keys stay blocked and the error names the action, e.g. “Switch to Tab [1...9]” or “Switch the Broadcast Mode”.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Targeted verification:

```text
node --test --import tsx domain/activeKeyBindings.test.ts domain/models.test.ts \
  application/i18n/locales/snippetBulkDeleteLocales.test.ts \
  application/i18n/locales/settingsLocales.test.ts \
  components/QuickAddSnippetDialog.test.tsx
```

29 tests passed. ESLint passed on the changed files.

This is an Electron desktop app, so the recording UI was not exercised in a running app. Domain tests cover the conflict rules that previously false-positiveed.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)