### PR TITLE
fix(terminal): copy history preview while vim owns the screen

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -134,6 +134,7 @@ import { createConnectionLogBuffer } from "./terminal/connectionLogBuffer";
 import { createProgrammaticCommandLogRewriter, type ProgrammaticCommandLogRewrite } from "./terminal/programmaticCommandLog";
 import { getSessionLogInitialLine } from "./terminal/sessionLogInitialLine";
 import { getTerminalSelectionForClipboard } from "./terminal/normalizeTerminalSelection";
+import { getHistoryPreviewSelectionFromRoot } from "./terminal/runtime/terminalHistoryScrollOverride";
 import { useZmodemTransfer } from "./terminal/hooks/useZmodemTransfer";
 import {
   createTerminalSessionStarters,
@@ -3147,10 +3148,11 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const handleAddSelectionToAI = useCallback(() => {
     const term = termRef.current;
     if (!term) return;
-    const selection = getTerminalSelectionForClipboard(
-      term,
-      terminalSettings?.normalizeTextOnCopy ?? true,
-    );
+    const selection = getHistoryPreviewSelectionFromRoot(term.element?.parentElement)
+      || getTerminalSelectionForClipboard(
+        term,
+        terminalSettings?.normalizeTextOnCopy ?? true,
+      );
     if (!selection.trim()) return;
     onAddSelectionToAI?.(sessionId, selection);
   }, [onAddSelectionToAI, sessionId, terminalSettings?.normalizeTextOnCopy]);

--- a/components/terminal/TerminalContextMenu.test.ts
+++ b/components/terminal/TerminalContextMenu.test.ts
@@ -241,6 +241,26 @@ test("forceMenuInAlternateScreen opts out of alternate-screen suppression", () =
     }),
     true,
   );
+
+  assert.equal(
+    shouldSuppressMouseTrackingContextMenu({
+      isAlternateScreen: true,
+      showReconnectAction: false,
+      forceMenuInAlternateScreen: false,
+      isHistoryPreviewTarget: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldOpenTerminalContextMenu({
+      event: { shiftKey: false, nativeEvent: {} as MouseEvent },
+      rightClickBehavior: "paste",
+      isAlternateScreen: true,
+      showReconnectAction: false,
+      isHistoryPreviewTarget: true,
+    }),
+    true,
+  );
 });
 
 test("opens a middle-click menu even when right-click is configured to paste", () => {

--- a/components/terminal/TerminalContextMenu.tsx
+++ b/components/terminal/TerminalContextMenu.tsx
@@ -28,6 +28,7 @@ import {
   ContextMenuTrigger,
 } from '../ui/context-menu';
 import { isMiddleClickContextMenuEvent, isMouseTrackingActive } from './runtime/middleClickBehavior';
+import { isHistoryPreviewContextMenuTarget } from './runtime/terminalHistoryScrollOverride';
 import { collectOwnedPluginMenus, comparePluginMenus, usePluginContributions } from '../../application/state/usePluginContributions';
 import { buildTerminalPluginContributionContext } from '../../application/state/pluginContributionContexts';
 import { PluginContributionIcon } from '../plugins/PluginContributionIcon';
@@ -80,13 +81,16 @@ export const shouldSuppressMouseTrackingContextMenu = ({
   terminalMouseTrackingMode,
   showReconnectAction,
   forceMenuInAlternateScreen,
+  isHistoryPreviewTarget,
 }: {
   isAlternateScreen?: boolean;
   terminalMouseTrackingMode?: string;
   showReconnectAction?: boolean;
   forceMenuInAlternateScreen?: boolean;
+  isHistoryPreviewTarget?: boolean;
 }): boolean => Boolean(
-  isMouseTrackingActive({
+  !isHistoryPreviewTarget
+  && isMouseTrackingActive({
     mouseTracking: Boolean(isAlternateScreen),
     terminalMouseTrackingMode,
   })
@@ -108,15 +112,23 @@ export const shouldRenderTerminalContextMenuContent = ({
   showReconnectAction,
   allowSuppressedMenuContent,
   forceMenuInAlternateScreen,
+  isHistoryPreviewTarget,
 }: {
   isAlternateScreen?: boolean;
   terminalMouseTrackingMode?: string;
   showReconnectAction?: boolean;
   allowSuppressedMenuContent?: boolean;
   forceMenuInAlternateScreen?: boolean;
+  isHistoryPreviewTarget?: boolean;
 }): boolean =>
   allowSuppressedMenuContent ||
-  !shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, terminalMouseTrackingMode, showReconnectAction, forceMenuInAlternateScreen });
+  !shouldSuppressMouseTrackingContextMenu({
+    isAlternateScreen,
+    terminalMouseTrackingMode,
+    showReconnectAction,
+    forceMenuInAlternateScreen,
+    isHistoryPreviewTarget,
+  });
 
 export const shouldAllowSuppressedTerminalContextMenuContent = ({
   event,
@@ -124,15 +136,23 @@ export const shouldAllowSuppressedTerminalContextMenuContent = ({
   terminalMouseTrackingMode,
   showReconnectAction,
   forceMenuInAlternateScreen,
+  isHistoryPreviewTarget,
 }: {
   event: { shiftKey?: boolean; nativeEvent: MouseEvent };
   isAlternateScreen?: boolean;
   terminalMouseTrackingMode?: string;
   showReconnectAction?: boolean;
   forceMenuInAlternateScreen?: boolean;
+  isHistoryPreviewTarget?: boolean;
 }): boolean =>
   isMiddleClickContextMenuEvent(event.nativeEvent)
-  || Boolean(event.shiftKey && shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, terminalMouseTrackingMode, showReconnectAction, forceMenuInAlternateScreen }));
+  || Boolean(isHistoryPreviewTarget)
+  || Boolean(event.shiftKey && shouldSuppressMouseTrackingContextMenu({
+    isAlternateScreen,
+    terminalMouseTrackingMode,
+    showReconnectAction,
+    forceMenuInAlternateScreen,
+  }));
 
 export const shouldOpenTerminalContextMenu = ({
   event,
@@ -141,6 +161,7 @@ export const shouldOpenTerminalContextMenu = ({
   terminalMouseTrackingMode,
   showReconnectAction,
   forceMenuInAlternateScreen,
+  isHistoryPreviewTarget,
 }: {
   event: { shiftKey?: boolean; nativeEvent: MouseEvent };
   rightClickBehavior?: RightClickBehavior;
@@ -148,16 +169,23 @@ export const shouldOpenTerminalContextMenu = ({
   terminalMouseTrackingMode?: string;
   showReconnectAction?: boolean;
   forceMenuInAlternateScreen?: boolean;
+  isHistoryPreviewTarget?: boolean;
 }): boolean => {
   if (isMiddleClickContextMenuEvent(event.nativeEvent)) {
     return true;
   }
 
-  if (event.shiftKey) {
+  if (event.shiftKey || isHistoryPreviewTarget) {
     return true;
   }
 
-  if (shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, terminalMouseTrackingMode, showReconnectAction, forceMenuInAlternateScreen })) {
+  if (shouldSuppressMouseTrackingContextMenu({
+    isAlternateScreen,
+    terminalMouseTrackingMode,
+    showReconnectAction,
+    forceMenuInAlternateScreen,
+    isHistoryPreviewTarget,
+  })) {
     return false;
   }
 
@@ -262,6 +290,7 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
       // handle right-click natively to avoid conflicting menus. Reconnect is
       // still available after disconnect, even if mouse tracking was left on.
       const currentMouseTrackingMode = getMouseTrackingMode?.();
+      const isHistoryPreviewTarget = isHistoryPreviewContextMenuTarget(e.target);
       const shouldOpenMenu = shouldOpenTerminalContextMenu({
         event: e,
         rightClickBehavior,
@@ -269,9 +298,16 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
         terminalMouseTrackingMode: currentMouseTrackingMode,
         showReconnectAction,
         forceMenuInAlternateScreen: showContextMenuOverFullscreenApps,
+        isHistoryPreviewTarget,
       });
 
-      if (!shouldOpenMenu && shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, terminalMouseTrackingMode: currentMouseTrackingMode, showReconnectAction, forceMenuInAlternateScreen: showContextMenuOverFullscreenApps })) {
+      if (!shouldOpenMenu && shouldSuppressMouseTrackingContextMenu({
+        isAlternateScreen,
+        terminalMouseTrackingMode: currentMouseTrackingMode,
+        showReconnectAction,
+        forceMenuInAlternateScreen: showContextMenuOverFullscreenApps,
+        isHistoryPreviewTarget,
+      })) {
         e.preventDefault();
         return;
       }
@@ -290,6 +326,7 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
           terminalMouseTrackingMode: currentMouseTrackingMode,
           showReconnectAction,
           forceMenuInAlternateScreen: showContextMenuOverFullscreenApps,
+          isHistoryPreviewTarget,
         }));
         return;
       }

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -25,6 +25,7 @@ import {
   DialogTitle,
 } from '../ui/dialog';
 import { TerminalSelectionAIOverlay } from './TerminalSelectionAIOverlay';
+import { getHistoryPreviewSelectionFromRoot } from './runtime/terminalHistoryScrollOverride';
 
 type TerminalViewContext = Record<string, any>;
 type HostLineTimestampToggle = {
@@ -514,7 +515,11 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
     >
       <div
         onContextMenu={() => {
-          setContextMenuHasSelection(Boolean(termRef.current?.hasSelection()));
+          const term = termRef.current;
+          setContextMenuHasSelection(Boolean(
+            term?.hasSelection()
+            || getHistoryPreviewSelectionFromRoot(term?.element?.parentElement),
+          ));
         }}
         className={cn(
           "relative h-full w-full flex min-h-0 overflow-hidden",

--- a/components/terminal/hooks/useTerminalContextActions.ts
+++ b/components/terminal/hooks/useTerminalContextActions.ts
@@ -116,6 +116,8 @@ export const useTerminalContextActions = ({
   const onPaste = useCallback(async () => {
     const term = termRef.current;
     if (!term) return;
+    requestHistoryPreviewHide(term.element?.parentElement);
+    term.focus();
     try {
       const bridge = netcattyBridge.get();
       await handleTerminalClipboardPaste({

--- a/components/terminal/hooks/useTerminalContextActions.ts
+++ b/components/terminal/hooks/useTerminalContextActions.ts
@@ -11,6 +11,11 @@ import {
 } from "../clipboardImagePaste";
 import { handleTerminalClipboardPaste } from "../terminalClipboardPaste";
 import { getTerminalSelectionForClipboard } from "../normalizeTerminalSelection";
+import {
+  getHistoryPreviewSelectionFromRoot,
+  selectHistoryPreviewAll,
+  findHistoryPreviewOverlay,
+} from "../runtime/terminalHistoryScrollOverride";
 
 type BroadcastPasteRefs = {
   sourceSessionId: string;
@@ -97,10 +102,11 @@ export const useTerminalContextActions = ({
   const onCopy = useCallback(() => {
     const term = termRef.current;
     if (!term) return;
-    const selection = getTerminalSelectionForClipboard(
-      term,
-      normalizeTextOnCopyRef?.current ?? true,
-    );
+    const selection = getHistoryPreviewSelectionFromRoot(term.element?.parentElement)
+      || getTerminalSelectionForClipboard(
+        term,
+        normalizeTextOnCopyRef?.current ?? true,
+      );
     if (selection) {
       navigator.clipboard.writeText(selection);
     }
@@ -179,10 +185,11 @@ export const useTerminalContextActions = ({
   const onPasteSelection = useCallback(() => {
     const term = termRef.current;
     if (!term) return;
-    const selection = getTerminalSelectionForClipboard(
-      term,
-      normalizeTextOnCopyRef?.current ?? true,
-    );
+    const selection = getHistoryPreviewSelectionFromRoot(term.element?.parentElement)
+      || getTerminalSelectionForClipboard(
+        term,
+        normalizeTextOnCopyRef?.current ?? true,
+      );
     if (!selection || !sessionRef.current) return;
     pasteTextIntoTerminal(term, selection, {
       scrollOnPaste: scrollOnPasteRef?.current ?? false,
@@ -193,6 +200,11 @@ export const useTerminalContextActions = ({
   const onSelectAll = useCallback(() => {
     const term = termRef.current;
     if (!term) return;
+    const previewOverlay = findHistoryPreviewOverlay(term.element?.parentElement);
+    if (previewOverlay && selectHistoryPreviewAll(previewOverlay)) {
+      onHasSelectionChange?.(true);
+      return;
+    }
     term.selectAll();
     onHasSelectionChange?.(true);
   }, [onHasSelectionChange, termRef]);

--- a/components/terminal/hooks/useTerminalContextActions.ts
+++ b/components/terminal/hooks/useTerminalContextActions.ts
@@ -13,6 +13,7 @@ import { handleTerminalClipboardPaste } from "../terminalClipboardPaste";
 import { getTerminalSelectionForClipboard } from "../normalizeTerminalSelection";
 import {
   getHistoryPreviewSelectionFromRoot,
+  requestHistoryPreviewHide,
   selectHistoryPreviewAll,
   findHistoryPreviewOverlay,
 } from "../runtime/terminalHistoryScrollOverride";
@@ -191,6 +192,8 @@ export const useTerminalContextActions = ({
         normalizeTextOnCopyRef?.current ?? true,
       );
     if (!selection || !sessionRef.current) return;
+    requestHistoryPreviewHide(term.element?.parentElement);
+    term.focus();
     pasteTextIntoTerminal(term, selection, {
       scrollOnPaste: scrollOnPasteRef?.current ?? false,
       onPasteData: broadcastUserPasteData,

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -952,4 +952,5 @@ test("alternate-screen history preview stays selectable and copyable", async () 
   assert.match(source, /isHistoryPreviewDismissClick/);
   assert.match(source, /HISTORY_PREVIEW_WRAP_ATTR/);
   assert.match(source, /HISTORY_PREVIEW_HIDE_EVENT/);
+  assert.match(source, /document\.addEventListener\("copy", handlePreviewNativeCopy, true\)/);
 });

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -937,3 +937,15 @@ test("command execution records direct sends from host-style greater-than prompt
     assert.equal(commandBufferRef.current, "", lineText);
   }
 });
+
+test("alternate-screen history preview stays selectable and copyable", async () => {
+  const { readFileSync } = await import("node:fs");
+  const source = readFileSync(new URL("./createXTermRuntime.ts", import.meta.url), "utf8");
+
+  assert.match(source, /pointerEvents:\s*"auto"/);
+  assert.match(source, /userSelect:\s*"text"/);
+  assert.match(source, /shouldHideHistoryPreviewOnMouseDown/);
+  assert.match(source, /shouldKeepHistoryPreviewOnKey/);
+  assert.match(source, /previewSelection \|\| getTerminalSelectionForClipboard/);
+  assert.match(source, /term\.hasSelection\(\) \|\| Boolean\(previewSelection\)/);
+});

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -949,4 +949,6 @@ test("alternate-screen history preview stays selectable and copyable", async () 
   assert.match(source, /previewSelection \|\| getTerminalSelectionForClipboard/);
   assert.match(source, /hasCopyableSelection = term\.hasSelection\(\) \|\| Boolean\(previewSelection\)/);
   assert.match(source, /shouldUseUrgentTerminalInterrupt\(e, \{ hasSelection: hasCopyableSelection \}\)/);
+  assert.match(source, /isHistoryPreviewDismissClick/);
+  assert.match(source, /HISTORY_PREVIEW_WRAP_ATTR/);
 });

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -947,5 +947,6 @@ test("alternate-screen history preview stays selectable and copyable", async () 
   assert.match(source, /shouldHideHistoryPreviewOnMouseDown/);
   assert.match(source, /shouldKeepHistoryPreviewOnKey/);
   assert.match(source, /previewSelection \|\| getTerminalSelectionForClipboard/);
-  assert.match(source, /term\.hasSelection\(\) \|\| Boolean\(previewSelection\)/);
+  assert.match(source, /hasCopyableSelection = term\.hasSelection\(\) \|\| Boolean\(previewSelection\)/);
+  assert.match(source, /shouldUseUrgentTerminalInterrupt\(e, \{ hasSelection: hasCopyableSelection \}\)/);
 });

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -951,4 +951,5 @@ test("alternate-screen history preview stays selectable and copyable", async () 
   assert.match(source, /shouldUseUrgentTerminalInterrupt\(e, \{ hasSelection: hasCopyableSelection \}\)/);
   assert.match(source, /isHistoryPreviewDismissClick/);
   assert.match(source, /HISTORY_PREVIEW_WRAP_ATTR/);
+  assert.match(source, /HISTORY_PREVIEW_HIDE_EVENT/);
 });

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -1458,6 +1458,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     }
 
     const previewSelection = getHistoryPreviewSelectionFromRoot(ctx.container);
+    const hasCopyableSelection = term.hasSelection() || Boolean(previewSelection);
     const forcedHistoryScrollPages = forcedHistoryScrollPagesForKey(e);
     if (forcedHistoryScrollPages !== null) {
       e.preventDefault();
@@ -1541,7 +1542,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       // the interrupt path hard-aborts instead (#2191).
       if (
         e.key.length === 1
-        && !shouldUseUrgentTerminalInterrupt(e, { hasSelection: term.hasSelection() })
+        && !shouldUseUrgentTerminalInterrupt(e, { hasSelection: hasCopyableSelection })
       ) {
         sudoAutofill.cancelHint();
         // fall through: key becomes the first char of the manually typed password
@@ -1574,7 +1575,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         : null;
     if (
       (!kittySequenceForKeyDown || kittySequenceForKeyDown === "\x03") &&
-      shouldUseUrgentTerminalInterrupt(e, { hasSelection: term.hasSelection() })
+      shouldUseUrgentTerminalInterrupt(e, { hasSelection: hasCopyableSelection })
     ) {
       const id = ctx.sessionRef.current;
       if (id && ctx.statusRef.current === "connected") {
@@ -1704,7 +1705,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
           const shouldForwardCopyToTerminal =
             shouldPassThroughCopyShortcut(
               action,
-              term.hasSelection() || Boolean(previewSelection),
+              hasCopyableSelection,
               e,
             );
           if (shouldForwardCopyToTerminal && !kittySequenceForKeyDown) return true;
@@ -1857,7 +1858,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         event: kittyEvent,
         fallbackToLegacy: true,
         urgentInterrupt: shouldUseUrgentTerminalInterrupt(e, {
-          hasSelection: term.hasSelection(),
+          hasSelection: hasCopyableSelection,
         }),
       });
       if (forwarded) {

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -115,12 +115,16 @@ import {
 } from "./terminalFontZoom";
 import {
   HISTORY_PREVIEW_OVERLAY_ATTR,
-  getHistoryPreviewLines,
+  HISTORY_PREVIEW_WRAP_ATTR,
+  encodeHistoryPreviewWrapFlags,
+  getHistoryPreviewRows,
   getHistoryPreviewSelectionFromRoot,
   forcedHistoryScrollLinesForWheel,
   forcedHistoryScrollPageToLines,
   forcedHistoryScrollPagesForKey,
   forcedHistoryScrollWheelListenerOptions,
+  isHistoryPreviewDismissClick,
+  isHistoryPreviewPointerTarget,
   nextHistoryPreviewTop,
   selectHistoryPreviewAll,
   shouldHideHistoryPreviewOnMouseDown,
@@ -917,10 +921,17 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   };
   let historyPreviewOverlay: HTMLPreElement | null = null;
   let historyPreviewTop: number | null = null;
+  let historyPreviewPointerDown: { clientX: number; clientY: number } | null = null;
   const hideHistoryPreview = () => {
-    historyPreviewOverlay?.remove();
+    if (!historyPreviewOverlay) {
+      historyPreviewPointerDown = null;
+      return;
+    }
+    historyPreviewOverlay.remove();
     historyPreviewOverlay = null;
     historyPreviewTop = null;
+    historyPreviewPointerDown = null;
+    term.focus();
   };
   const copyHistoryPreviewSelectionIfEnabled = () => {
     if (!ctx.terminalSettingsRef.current?.copyOnSelect) return;
@@ -955,7 +966,6 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       color: ctx.terminalTheme.colors.foreground,
       background: ctx.terminalTheme.colors.background,
     } satisfies Partial<CSSStyleDeclaration>);
-    overlay.addEventListener("mouseup", copyHistoryPreviewSelectionIfEnabled);
     ctx.container.appendChild(overlay);
     historyPreviewOverlay = overlay;
     return overlay;
@@ -972,11 +982,13 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     overlay.style.fontSize = `${currentTerminalFontSize()}px`;
     overlay.style.fontFamily = String(term.options.fontFamily ?? fontFamily);
     overlay.style.lineHeight = String(term.options.lineHeight ?? lineHeight);
-    overlay.textContent = getHistoryPreviewLines({
+    const previewRows = getHistoryPreviewRows({
       buffer: normalBuffer,
       rows: term.rows,
       top: historyPreviewTop,
-    }).join("\n");
+    });
+    overlay.textContent = previewRows.map((row) => row.text).join("\n");
+    overlay.setAttribute(HISTORY_PREVIEW_WRAP_ATTR, encodeHistoryPreviewWrapFlags(previewRows));
     return true;
   };
   const scrollForcedHistoryLines = (lines: number) => {
@@ -1958,12 +1970,29 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   };
 
   const handleHistoryPreviewMouseDown = (event: MouseEvent) => {
+    if (isHistoryPreviewPointerTarget(event.target, historyPreviewOverlay)) {
+      if (event.button === 0) {
+        historyPreviewPointerDown = { clientX: event.clientX, clientY: event.clientY };
+      }
+      return;
+    }
     if (!shouldHideHistoryPreviewOnMouseDown(event.target, historyPreviewOverlay)) return;
     hideHistoryPreview();
+  };
+  const handleHistoryPreviewMouseUp = (event: MouseEvent) => {
+    const down = historyPreviewPointerDown;
+    historyPreviewPointerDown = null;
+    if (!down || !isHistoryPreviewPointerTarget(event.target, historyPreviewOverlay)) return;
+    if (isHistoryPreviewDismissClick(down, event)) {
+      hideHistoryPreview();
+      return;
+    }
+    copyHistoryPreviewSelectionIfEnabled();
   };
   ctx.container.addEventListener("mousedown", captureMiddleClickTerminalMouseEvent, true);
   ctx.container.addEventListener("mouseup", captureMiddleClickTerminalMouseEvent, true);
   ctx.container.addEventListener("mousedown", handleHistoryPreviewMouseDown, true);
+  ctx.container.addEventListener("mouseup", handleHistoryPreviewMouseUp, true);
   ctx.container.addEventListener("auxclick", handleMiddleClick);
 
   fitAddon.fit();
@@ -2383,6 +2412,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       ctx.container.removeEventListener("mousedown", captureMiddleClickTerminalMouseEvent, true);
       ctx.container.removeEventListener("mouseup", captureMiddleClickTerminalMouseEvent, true);
       ctx.container.removeEventListener("mousedown", handleHistoryPreviewMouseDown, true);
+      ctx.container.removeEventListener("mouseup", handleHistoryPreviewMouseUp, true);
       hideHistoryPreview();
       historyPreviewBufferChangeDisposable.dispose();
       stopDprWatch();

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -705,18 +705,26 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
 
   // Intercept native copy (Edit > Copy, browser/Electron copy event) before
   // xterm's built-in handler writes selectionText, so normalizeTextOnCopy applies.
+  const writePreviewSelectionToClipboard = (event: ClipboardEvent, previewSelection: string) => {
+    if (event.clipboardData) {
+      event.clipboardData.setData("text/plain", previewSelection);
+    } else {
+      void navigator.clipboard.writeText(previewSelection).catch((err) => {
+        logger.warn("[XTerm] History preview copy failed:", err);
+      });
+    }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+  const handlePreviewNativeCopy = (event: ClipboardEvent) => {
+    const previewSelection = getHistoryPreviewSelectionFromRoot(ctx.container);
+    if (!previewSelection) return;
+    writePreviewSelectionToClipboard(event, previewSelection);
+  };
   const handleNativeCopy = (event: ClipboardEvent) => {
     const previewSelection = getHistoryPreviewSelectionFromRoot(ctx.container);
     if (previewSelection) {
-      if (event.clipboardData) {
-        event.clipboardData.setData("text/plain", previewSelection);
-      } else {
-        void navigator.clipboard.writeText(previewSelection).catch((err) => {
-          logger.warn("[XTerm] History preview copy failed:", err);
-        });
-      }
-      event.preventDefault();
-      event.stopImmediatePropagation();
+      writePreviewSelectionToClipboard(event, previewSelection);
       return;
     }
     if (!term.hasSelection()) return;
@@ -926,12 +934,14 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   const hideHistoryPreview = () => {
     if (!historyPreviewOverlay) {
       historyPreviewPointerDown = null;
+      document.removeEventListener("copy", handlePreviewNativeCopy, true);
       return;
     }
     historyPreviewOverlay.remove();
     historyPreviewOverlay = null;
     historyPreviewTop = null;
     historyPreviewPointerDown = null;
+    document.removeEventListener("copy", handlePreviewNativeCopy, true);
     term.focus();
   };
   const copyHistoryPreviewSelectionIfEnabled = () => {
@@ -950,6 +960,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     overlay.setAttribute(HISTORY_PREVIEW_OVERLAY_ATTR, "");
     overlay.setAttribute("role", "document");
     overlay.addEventListener(HISTORY_PREVIEW_HIDE_EVENT, hideHistoryPreview);
+    document.addEventListener("copy", handlePreviewNativeCopy, true);
     Object.assign(overlay.style, {
       position: "absolute",
       inset: "0",

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -114,12 +114,17 @@ import {
   terminalFontSizeWheelListenerOptions,
 } from "./terminalFontZoom";
 import {
+  HISTORY_PREVIEW_OVERLAY_ATTR,
   getHistoryPreviewLines,
+  getHistoryPreviewSelectionFromRoot,
   forcedHistoryScrollLinesForWheel,
   forcedHistoryScrollPageToLines,
   forcedHistoryScrollPagesForKey,
   forcedHistoryScrollWheelListenerOptions,
   nextHistoryPreviewTop,
+  selectHistoryPreviewAll,
+  shouldHideHistoryPreviewOnMouseDown,
+  shouldKeepHistoryPreviewOnKey,
 } from "./terminalHistoryScrollOverride";
 import { shouldPassThroughCopyShortcut } from "./terminalCopyShortcut";
 import { shouldUseUrgentTerminalInterrupt } from "./terminalInterruptShortcut";
@@ -696,6 +701,19 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   // Intercept native copy (Edit > Copy, browser/Electron copy event) before
   // xterm's built-in handler writes selectionText, so normalizeTextOnCopy applies.
   const handleNativeCopy = (event: ClipboardEvent) => {
+    const previewSelection = getHistoryPreviewSelectionFromRoot(ctx.container);
+    if (previewSelection) {
+      if (event.clipboardData) {
+        event.clipboardData.setData("text/plain", previewSelection);
+      } else {
+        void navigator.clipboard.writeText(previewSelection).catch((err) => {
+          logger.warn("[XTerm] History preview copy failed:", err);
+        });
+      }
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
     if (!term.hasSelection()) return;
     const normalize = ctx.terminalSettingsRef.current?.normalizeTextOnCopy ?? true;
     if (!normalize) return; // let xterm write raw selectionText
@@ -712,6 +730,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     event.stopImmediatePropagation();
   };
   term.element?.addEventListener("copy", handleNativeCopy, true);
+  ctx.container.addEventListener("copy", handleNativeCopy, true);
 
   let webglLoaded = false;
   let runtimeDisposed = false;
@@ -903,10 +922,21 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     historyPreviewOverlay = null;
     historyPreviewTop = null;
   };
+  const copyHistoryPreviewSelectionIfEnabled = () => {
+    if (!ctx.terminalSettingsRef.current?.copyOnSelect) return;
+    if (ctx.isRestoringSelectionRef?.current) return;
+    const selection = getHistoryPreviewSelectionFromRoot(ctx.container);
+    if (selection) {
+      void navigator.clipboard.writeText(selection).catch((err) => {
+        logger.warn("[XTerm] History preview copy-on-select failed:", err);
+      });
+    }
+  };
   const ensureHistoryPreviewOverlay = () => {
     if (historyPreviewOverlay) return historyPreviewOverlay;
     const overlay = document.createElement("pre");
-    overlay.setAttribute("aria-hidden", "true");
+    overlay.setAttribute(HISTORY_PREVIEW_OVERLAY_ATTR, "");
+    overlay.setAttribute("role", "document");
     Object.assign(overlay.style, {
       position: "absolute",
       inset: "0",
@@ -914,7 +944,10 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       margin: "0",
       padding: "0 6px",
       overflow: "hidden",
-      pointerEvents: "none",
+      pointerEvents: "auto",
+      userSelect: "text",
+      webkitUserSelect: "text",
+      cursor: "text",
       whiteSpace: "pre",
       fontFamily: String(term.options.fontFamily ?? fontFamily),
       fontSize: `${currentTerminalFontSize()}px`,
@@ -922,6 +955,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       color: ctx.terminalTheme.colors.foreground,
       background: ctx.terminalTheme.colors.background,
     } satisfies Partial<CSSStyleDeclaration>);
+    overlay.addEventListener("mouseup", copyHistoryPreviewSelectionIfEnabled);
     ctx.container.appendChild(overlay);
     historyPreviewOverlay = overlay;
     return overlay;
@@ -1423,6 +1457,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       markKittyCompositionPending(true);
     }
 
+    const previewSelection = getHistoryPreviewSelectionFromRoot(ctx.container);
     const forcedHistoryScrollPages = forcedHistoryScrollPagesForKey(e);
     if (forcedHistoryScrollPages !== null) {
       e.preventDefault();
@@ -1435,7 +1470,24 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       term.scrollPages(forcedHistoryScrollPages);
       return false;
     }
-    hideHistoryPreview();
+    const previewKeepAliveScheme = ctx.hotkeySchemeRef.current;
+    const previewKeepAliveIsMac =
+      previewKeepAliveScheme === "mac"
+      || (previewKeepAliveScheme === "disabled" && isMacPlatform());
+    const previewKeepAliveBindings = ctx.keyBindingsRef.current;
+    const previewKeepAliveAction =
+      previewKeepAliveScheme !== "disabled" && previewKeepAliveBindings.length > 0
+        ? checkAppShortcut(e, previewKeepAliveBindings, previewKeepAliveIsMac)?.action
+        : undefined;
+    if (
+      !shouldKeepHistoryPreviewOnKey(e, {
+        action: previewKeepAliveAction,
+        hasPreviewSelection: Boolean(previewSelection),
+        overlayVisible: Boolean(historyPreviewOverlay),
+      })
+    ) {
+      hideHistoryPreview();
+    }
 
     // Password prompt assist (sudo/su): while pending, Enter confirms the
     // selected/host password; arrows move the picker; Esc soft-dismisses (keeps
@@ -1650,14 +1702,18 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
           // No xterm selection: pass Ctrl+C through for SIGINT, and Cmd+C for
           // Kitty Super+C (nested TUIs). Other copy chords stay a safe no-op.
           const shouldForwardCopyToTerminal =
-            shouldPassThroughCopyShortcut(action, term.hasSelection(), e);
+            shouldPassThroughCopyShortcut(
+              action,
+              term.hasSelection() || Boolean(previewSelection),
+              e,
+            );
           if (shouldForwardCopyToTerminal && !kittySequenceForKeyDown) return true;
           if (!shouldForwardCopyToTerminal) {
             e.preventDefault();
             e.stopPropagation();
             switch (action) {
             case "copy": {
-              const selection = getTerminalSelectionForClipboard(
+              const selection = previewSelection || getTerminalSelectionForClipboard(
                 term,
                 ctx.terminalSettingsRef.current?.normalizeTextOnCopy ?? true,
               );
@@ -1672,12 +1728,13 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
               break;
             }
             case "pasteSelection": {
-              const selection = getTerminalSelectionForClipboard(
+              const selection = previewSelection || getTerminalSelectionForClipboard(
                 term,
                 ctx.terminalSettingsRef.current?.normalizeTextOnCopy ?? true,
               );
               const id = ctx.sessionRef.current;
               if (selection && id) {
+                hideHistoryPreview();
                 pasteTextIntoTerminal(term, selection, {
                   scrollOnPaste: shouldScrollOnTerminalPaste(ctx.terminalSettingsRef.current),
                   onPasteData: broadcastUserPasteData,
@@ -1686,6 +1743,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
               break;
             }
             case "selectAll": {
+              if (historyPreviewOverlay && selectHistoryPreviewAll(historyPreviewOverlay)) {
+                break;
+              }
               term.selectAll();
               break;
             }
@@ -1896,9 +1956,13 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     ctx.container.dispatchEvent(contextMenuEvent);
   };
 
+  const handleHistoryPreviewMouseDown = (event: MouseEvent) => {
+    if (!shouldHideHistoryPreviewOnMouseDown(event.target, historyPreviewOverlay)) return;
+    hideHistoryPreview();
+  };
   ctx.container.addEventListener("mousedown", captureMiddleClickTerminalMouseEvent, true);
   ctx.container.addEventListener("mouseup", captureMiddleClickTerminalMouseEvent, true);
-  ctx.container.addEventListener("mousedown", hideHistoryPreview, true);
+  ctx.container.addEventListener("mousedown", handleHistoryPreviewMouseDown, true);
   ctx.container.addEventListener("auxclick", handleMiddleClick);
 
   fitAddon.fit();
@@ -2303,6 +2367,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       resizeScheduler.dispose();
       webglController.dispose();
       term.element?.removeEventListener("copy", handleNativeCopy, true);
+      ctx.container.removeEventListener("copy", handleNativeCopy, true);
       ctx.container.removeEventListener(
         "wheel",
         handleForcedHistoryScrollWheel,
@@ -2316,7 +2381,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       ctx.container.removeEventListener("auxclick", handleMiddleClick);
       ctx.container.removeEventListener("mousedown", captureMiddleClickTerminalMouseEvent, true);
       ctx.container.removeEventListener("mouseup", captureMiddleClickTerminalMouseEvent, true);
-      ctx.container.removeEventListener("mousedown", hideHistoryPreview, true);
+      ctx.container.removeEventListener("mousedown", handleHistoryPreviewMouseDown, true);
       hideHistoryPreview();
       historyPreviewBufferChangeDisposable.dispose();
       stopDprWatch();

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -114,6 +114,7 @@ import {
   terminalFontSizeWheelListenerOptions,
 } from "./terminalFontZoom";
 import {
+  HISTORY_PREVIEW_HIDE_EVENT,
   HISTORY_PREVIEW_OVERLAY_ATTR,
   HISTORY_PREVIEW_WRAP_ATTR,
   encodeHistoryPreviewWrapFlags,
@@ -948,6 +949,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     const overlay = document.createElement("pre");
     overlay.setAttribute(HISTORY_PREVIEW_OVERLAY_ATTR, "");
     overlay.setAttribute("role", "document");
+    overlay.addEventListener(HISTORY_PREVIEW_HIDE_EVENT, hideHistoryPreview);
     Object.assign(overlay.style, {
       position: "absolute",
       inset: "0",

--- a/components/terminal/runtime/terminalHistoryScrollOverride.test.ts
+++ b/components/terminal/runtime/terminalHistoryScrollOverride.test.ts
@@ -147,6 +147,20 @@ test("history preview stays up for pointer selection and copy chords", () => {
   assert.equal(
     shouldKeepHistoryPreviewOnKey(key({ key: "c", ctrlKey: true, shiftKey: false }), {
       action: "copy",
+      hasPreviewSelection: true,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldKeepHistoryPreviewOnKey(key({ key: "c", ctrlKey: true, shiftKey: false }), {
+      action: "copy",
+    }),
+    false,
+  );
+  assert.equal(
+    shouldKeepHistoryPreviewOnKey(key({ key: "a", metaKey: true, shiftKey: false }), {
+      action: "selectAll",
+      overlayVisible: true,
     }),
     true,
   );
@@ -154,7 +168,7 @@ test("history preview stays up for pointer selection and copy chords", () => {
     shouldKeepHistoryPreviewOnKey(key({ key: "a", metaKey: true, shiftKey: false }), {
       overlayVisible: true,
     }),
-    true,
+    false,
   );
   assert.equal(
     shouldKeepHistoryPreviewOnKey(key({ key: "j", shiftKey: false })),

--- a/components/terminal/runtime/terminalHistoryScrollOverride.test.ts
+++ b/components/terminal/runtime/terminalHistoryScrollOverride.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   HISTORY_PREVIEW_OVERLAY_ATTR,
+  HISTORY_PREVIEW_WRAP_ATTR,
   encodeHistoryPreviewWrapFlags,
   getHistoryPreviewLines,
   getHistoryPreviewRows,
@@ -220,6 +221,30 @@ test("history preview click dismisses and a drag keeps the overlay", () => {
     ),
     false,
   );
+});
+
+test("select-all overlay ranges still join soft-wrapped preview rows", () => {
+  const text = "ssh host long-command-name\n --flag";
+  const overlay = {
+    firstChild: "text",
+    textContent: text,
+    contains() {
+      return true;
+    },
+    getAttribute(name: string) {
+      return name === HISTORY_PREVIEW_WRAP_ATTR ? "01" : null;
+    },
+  };
+  const copied = getHistoryPreviewSelectionText(overlay, {
+    rangeCount: 1,
+    anchorNode: overlay,
+    focusNode: overlay,
+    anchorOffset: 0,
+    focusOffset: 1,
+    toString: () => text,
+  });
+  assert.equal(copied.includes("\n"), false);
+  assert.match(copied, /long-command-name\s*--flag/);
 });
 
 test("history preview copy joins soft-wrapped buffer rows", () => {

--- a/components/terminal/runtime/terminalHistoryScrollOverride.test.ts
+++ b/components/terminal/runtime/terminalHistoryScrollOverride.test.ts
@@ -3,13 +3,17 @@ import test from "node:test";
 
 import {
   HISTORY_PREVIEW_OVERLAY_ATTR,
+  encodeHistoryPreviewWrapFlags,
   getHistoryPreviewLines,
+  getHistoryPreviewRows,
   getHistoryPreviewSelectionText,
   forcedHistoryScrollLinesForWheel,
   forcedHistoryScrollPageToLines,
   forcedHistoryScrollPagesForKey,
   forcedHistoryScrollWheelListenerOptions,
   isHistoryPreviewContextMenuTarget,
+  isHistoryPreviewDismissClick,
+  joinHistoryPreviewSelectionText,
   nextHistoryPreviewTop,
   shouldHideHistoryPreviewOnMouseDown,
   shouldKeepHistoryPreviewOnKey,
@@ -192,6 +196,70 @@ test("history preview copy uses only overlay-owned DOM selection", () => {
     }),
     "",
   );
+});
+
+test("history preview click dismisses and a drag keeps the overlay", () => {
+  assert.equal(
+    isHistoryPreviewDismissClick(
+      { clientX: 10, clientY: 10 },
+      { button: 0, clientX: 11, clientY: 12 },
+    ),
+    true,
+  );
+  assert.equal(
+    isHistoryPreviewDismissClick(
+      { clientX: 10, clientY: 10 },
+      { button: 0, clientX: 40, clientY: 30 },
+    ),
+    false,
+  );
+  assert.equal(
+    isHistoryPreviewDismissClick(
+      { clientX: 10, clientY: 10 },
+      { button: 2, clientX: 10, clientY: 10 },
+    ),
+    false,
+  );
+});
+
+test("history preview copy joins soft-wrapped buffer rows", () => {
+  const text = "ssh user@host tail -f /var/log/very-long-name.log\n | grep error";
+  const joined = joinHistoryPreviewSelectionText({
+    text,
+    startOffset: 0,
+    endOffset: text.length,
+    wrapFlags: [false, true],
+  });
+  assert.equal(joined.includes("\n"), false);
+  assert.match(joined, /very-long-name\.log\s*\| grep error/);
+
+  const rows = getHistoryPreviewRows({
+    buffer: {
+      baseY: 1,
+      length: 2,
+      type: "normal",
+      viewportY: 1,
+      getLine(y: number) {
+        if (y === 0) {
+          return {
+            isWrapped: false,
+            translateToString() {
+              return "ssh user@host tail -f /var/log/very-long-name.log";
+            },
+          };
+        }
+        return {
+          isWrapped: true,
+          translateToString() {
+            return " | grep error";
+          },
+        };
+      },
+    },
+    rows: 2,
+    top: 0,
+  });
+  assert.equal(encodeHistoryPreviewWrapFlags(rows), "01");
 });
 
 test("history preview right-click is recognized as an app-menu target", () => {

--- a/components/terminal/runtime/terminalHistoryScrollOverride.test.ts
+++ b/components/terminal/runtime/terminalHistoryScrollOverride.test.ts
@@ -2,12 +2,17 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  HISTORY_PREVIEW_OVERLAY_ATTR,
   getHistoryPreviewLines,
+  getHistoryPreviewSelectionText,
   forcedHistoryScrollLinesForWheel,
   forcedHistoryScrollPageToLines,
   forcedHistoryScrollPagesForKey,
   forcedHistoryScrollWheelListenerOptions,
+  isHistoryPreviewContextMenuTarget,
   nextHistoryPreviewTop,
+  shouldHideHistoryPreviewOnMouseDown,
+  shouldKeepHistoryPreviewOnKey,
 } from "./terminalHistoryScrollOverride.ts";
 
 const wheel = (
@@ -117,4 +122,89 @@ test("alternate-screen history preview reads normal-buffer history", () => {
     alternateBuffer.getLine(0)?.translateToString(),
     alternateBuffer.getLine(1)?.translateToString(),
   ]);
+});
+
+test("history preview stays up for pointer selection and copy chords", () => {
+  const overlay = { contains: (node: unknown) => node === "inside" };
+
+  assert.equal(shouldHideHistoryPreviewOnMouseDown("inside", overlay), false);
+  assert.equal(shouldHideHistoryPreviewOnMouseDown("outside", overlay), true);
+  assert.equal(shouldHideHistoryPreviewOnMouseDown("inside", null), false);
+
+  assert.equal(shouldKeepHistoryPreviewOnKey(key({ key: "Shift" })), true);
+  assert.equal(shouldKeepHistoryPreviewOnKey(key({ key: "Meta" })), true);
+  assert.equal(
+    shouldKeepHistoryPreviewOnKey(key({ key: "c", metaKey: true, shiftKey: false }), {
+      hasPreviewSelection: true,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldKeepHistoryPreviewOnKey(key({ key: "c", ctrlKey: true, shiftKey: false }), {
+      action: "copy",
+    }),
+    true,
+  );
+  assert.equal(
+    shouldKeepHistoryPreviewOnKey(key({ key: "a", metaKey: true, shiftKey: false }), {
+      overlayVisible: true,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldKeepHistoryPreviewOnKey(key({ key: "j", shiftKey: false })),
+    false,
+  );
+});
+
+test("history preview copy uses only overlay-owned DOM selection", () => {
+  const overlay = {
+    contains(node: unknown) {
+      return node === "preview";
+    },
+  };
+
+  assert.equal(
+    getHistoryPreviewSelectionText(overlay, {
+      rangeCount: 1,
+      anchorNode: "preview",
+      focusNode: "preview",
+      toString: () => "old prompt output",
+    }),
+    "old prompt output",
+  );
+  assert.equal(
+    getHistoryPreviewSelectionText(overlay, {
+      rangeCount: 1,
+      anchorNode: "xterm",
+      focusNode: "xterm",
+      toString: () => "vim buffer",
+    }),
+    "",
+  );
+  assert.equal(
+    getHistoryPreviewSelectionText(overlay, {
+      rangeCount: 1,
+      isCollapsed: true,
+      anchorNode: "preview",
+      focusNode: "preview",
+      toString: () => "old prompt output",
+    }),
+    "",
+  );
+});
+
+test("history preview right-click is recognized as an app-menu target", () => {
+  assert.equal(
+    isHistoryPreviewContextMenuTarget({
+      closest: (selector: string) => selector === `[${HISTORY_PREVIEW_OVERLAY_ATTR}]` ? {} as Element : null,
+    }),
+    true,
+  );
+  assert.equal(
+    isHistoryPreviewContextMenuTarget({
+      closest: () => null,
+    }),
+    false,
+  );
 });

--- a/components/terminal/runtime/terminalHistoryScrollOverride.test.ts
+++ b/components/terminal/runtime/terminalHistoryScrollOverride.test.ts
@@ -247,6 +247,36 @@ test("select-all overlay ranges still join soft-wrapped preview rows", () => {
   assert.match(copied, /long-command-name\s*--flag/);
 });
 
+test("history preview copy keeps a selected hard line break", () => {
+  assert.equal(
+    joinHistoryPreviewSelectionText({
+      text: "abc\ndef",
+      startOffset: 0,
+      endOffset: 4,
+      wrapFlags: [false, false],
+    }),
+    "abc\n",
+  );
+  assert.equal(
+    joinHistoryPreviewSelectionText({
+      text: "abc\ndef",
+      startOffset: 3,
+      endOffset: 4,
+      wrapFlags: [false, false],
+    }),
+    "\n",
+  );
+  assert.equal(
+    joinHistoryPreviewSelectionText({
+      text: "abc\ndef",
+      startOffset: 0,
+      endOffset: 4,
+      wrapFlags: [false, true],
+    }),
+    "abc",
+  );
+});
+
 test("history preview copy joins soft-wrapped buffer rows", () => {
   const text = "ssh user@host tail -f /var/log/very-long-name.log\n | grep error";
   const joined = joinHistoryPreviewSelectionText({

--- a/components/terminal/runtime/terminalHistoryScrollOverride.ts
+++ b/components/terminal/runtime/terminalHistoryScrollOverride.ts
@@ -96,3 +96,111 @@ export const getHistoryPreviewLines = ({
   }
   return lines;
 };
+
+export const HISTORY_PREVIEW_OVERLAY_ATTR = "data-terminal-history-preview";
+
+const MODIFIER_ONLY_KEYS = new Set(["Shift", "Control", "Meta", "Alt"]);
+
+export type HistoryPreviewSelectionLike = {
+  rangeCount: number;
+  isCollapsed?: boolean;
+  anchorNode: { nodeType?: number } | null;
+  focusNode: { nodeType?: number } | null;
+  toString(): string;
+};
+
+export type HistoryPreviewNodeLike = {
+  contains(node: { nodeType?: number } | null): boolean;
+};
+
+export const isHistoryPreviewPointerTarget = (
+  target: EventTarget | null | undefined,
+  overlay: EventTarget | null | undefined,
+): boolean => {
+  if (!target || !overlay) return false;
+  if (target === overlay) return true;
+  if (typeof (overlay as HistoryPreviewNodeLike).contains === "function") {
+    return (overlay as HistoryPreviewNodeLike).contains(target as HistoryPreviewNodeLike);
+  }
+  return false;
+};
+
+export const shouldHideHistoryPreviewOnMouseDown = (
+  target: EventTarget | null | undefined,
+  overlay: EventTarget | null | undefined,
+): boolean => Boolean(overlay) && !isHistoryPreviewPointerTarget(target, overlay);
+
+export const isHistoryPreviewContextMenuTarget = (
+  target: EventTarget | null | undefined,
+): boolean => {
+  if (!target || typeof target !== "object") return false;
+  const element = target as { closest?: (selector: string) => Element | null };
+  return Boolean(element.closest?.(`[${HISTORY_PREVIEW_OVERLAY_ATTR}]`));
+};
+
+export const shouldKeepHistoryPreviewOnKey = (
+  event: KeyLike,
+  options: {
+    action?: string | null;
+    hasPreviewSelection?: boolean;
+    overlayVisible?: boolean;
+  } = {},
+): boolean => {
+  if (forcedHistoryScrollPagesForKey(event) !== null) return true;
+  if (MODIFIER_ONLY_KEYS.has(event.key)) return true;
+  if (options.action === "copy" || options.action === "selectAll") return true;
+  if (
+    options.overlayVisible
+    && event.key.toLowerCase() === "a"
+    && (event.metaKey || event.ctrlKey)
+    && !event.altKey
+  ) {
+    return true;
+  }
+  return Boolean(
+    options.hasPreviewSelection
+    && (event.metaKey || event.ctrlKey)
+    && !event.altKey
+    && event.key.toLowerCase() === "c",
+  );
+};
+
+export const getHistoryPreviewSelectionText = (
+  overlay: HistoryPreviewNodeLike | null | undefined,
+  selection: HistoryPreviewSelectionLike | null | undefined,
+): string => {
+  if (!overlay || !selection || selection.rangeCount === 0 || selection.isCollapsed) {
+    return "";
+  }
+  const { anchorNode, focusNode } = selection;
+  if (!anchorNode || !focusNode) return "";
+  if (!overlay.contains(anchorNode) || !overlay.contains(focusNode)) return "";
+  return selection.toString();
+};
+
+export const findHistoryPreviewOverlay = (
+  root: ParentNode | Element | null | undefined,
+): HTMLElement | null => {
+  if (!root || !("querySelector" in root)) return null;
+  return root.querySelector<HTMLElement>(`[${HISTORY_PREVIEW_OVERLAY_ATTR}]`);
+};
+
+export const getHistoryPreviewSelectionFromRoot = (
+  root: ParentNode | Element | null | undefined,
+  selection?: HistoryPreviewSelectionLike | null,
+): string => {
+  const overlay = findHistoryPreviewOverlay(root);
+  const activeSelection = selection ?? overlay?.ownerDocument.getSelection() ?? null;
+  return getHistoryPreviewSelectionText(overlay, activeSelection);
+};
+
+export const selectHistoryPreviewAll = (overlay: HTMLElement | null | undefined): boolean => {
+  if (!overlay) return false;
+  const selection = overlay.ownerDocument.getSelection();
+  if (!selection) return false;
+  const range = overlay.ownerDocument.createRange();
+  range.selectNodeContents(overlay);
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return !selection.isCollapsed;
+};

--- a/components/terminal/runtime/terminalHistoryScrollOverride.ts
+++ b/components/terminal/runtime/terminalHistoryScrollOverride.ts
@@ -1,3 +1,5 @@
+import { joinSoftWrappedRows } from "../normalizeTerminalSelection";
+
 type WheelLike = Pick<
   WheelEvent,
   "altKey" | "ctrlKey" | "deltaMode" | "deltaY" | "metaKey" | "shiftKey"
@@ -9,6 +11,7 @@ type KeyLike = Pick<
 >;
 
 type BufferLineLike = {
+  isWrapped?: boolean;
   translateToString(trimRight?: boolean): string;
 };
 
@@ -79,6 +82,33 @@ export const nextHistoryPreviewTop = ({
   buffer,
 );
 
+export type HistoryPreviewRow = {
+  isWrapped: boolean;
+  text: string;
+};
+
+export const getHistoryPreviewRows = ({
+  buffer,
+  rows,
+  top,
+}: {
+  buffer: BufferLike;
+  rows: number;
+  top: number;
+}): HistoryPreviewRow[] => {
+  const clampedTop = clampHistoryPreviewTop(top, buffer);
+  const visibleRows = Math.max(1, rows);
+  const lines: HistoryPreviewRow[] = [];
+  for (let row = 0; row < visibleRows; row += 1) {
+    const line = buffer.getLine(clampedTop + row);
+    lines.push({
+      isWrapped: Boolean(line?.isWrapped),
+      text: line?.translateToString(true) ?? "",
+    });
+  }
+  return lines;
+};
+
 export const getHistoryPreviewLines = ({
   buffer,
   rows,
@@ -87,17 +117,14 @@ export const getHistoryPreviewLines = ({
   buffer: BufferLike;
   rows: number;
   top: number;
-}): string[] => {
-  const clampedTop = clampHistoryPreviewTop(top, buffer);
-  const visibleRows = Math.max(1, rows);
-  const lines: string[] = [];
-  for (let row = 0; row < visibleRows; row += 1) {
-    lines.push(buffer.getLine(clampedTop + row)?.translateToString(true) ?? "");
-  }
-  return lines;
-};
+}): string[] => getHistoryPreviewRows({ buffer, rows, top }).map((row) => row.text);
+
+export const encodeHistoryPreviewWrapFlags = (rows: Array<Pick<HistoryPreviewRow, "isWrapped">>): string =>
+  rows.map((row) => (row.isWrapped ? "1" : "0")).join("");
 
 export const HISTORY_PREVIEW_OVERLAY_ATTR = "data-terminal-history-preview";
+export const HISTORY_PREVIEW_WRAP_ATTR = "data-terminal-history-preview-wraps";
+export const HISTORY_PREVIEW_CLICK_SLOP_PX = 4;
 
 const MODIFIER_ONLY_KEYS = new Set(["Shift", "Control", "Meta", "Alt"]);
 
@@ -106,11 +133,16 @@ export type HistoryPreviewSelectionLike = {
   isCollapsed?: boolean;
   anchorNode: { nodeType?: number } | null;
   focusNode: { nodeType?: number } | null;
+  anchorOffset?: number;
+  focusOffset?: number;
   toString(): string;
 };
 
 export type HistoryPreviewNodeLike = {
   contains(node: { nodeType?: number } | null): boolean;
+  firstChild?: { nodeType?: number } | null;
+  getAttribute?(name: string): string | null;
+  textContent?: string | null;
 };
 
 export const isHistoryPreviewPointerTarget = (
@@ -165,6 +197,84 @@ export const shouldKeepHistoryPreviewOnKey = (
   );
 };
 
+export const isHistoryPreviewDismissClick = (
+  down: Pick<MouseEvent, "clientX" | "clientY">,
+  up: Pick<MouseEvent, "button" | "clientX" | "clientY">,
+  slop = HISTORY_PREVIEW_CLICK_SLOP_PX,
+): boolean => {
+  if (up.button !== 0) return false;
+  return Math.hypot(up.clientX - down.clientX, up.clientY - down.clientY) <= slop;
+};
+
+const lineOffsetsForPreviewText = (text: string): number[] => {
+  const offsets = [0];
+  for (let index = 0; index < text.length; index += 1) {
+    if (text.charCodeAt(index) === 10) offsets.push(index + 1);
+  }
+  return offsets;
+};
+
+export const joinHistoryPreviewSelectionText = ({
+  text,
+  startOffset,
+  endOffset,
+  wrapFlags,
+}: {
+  text: string;
+  startOffset: number;
+  endOffset: number;
+  wrapFlags: boolean[];
+}): string => {
+  const start = Math.max(0, Math.min(startOffset, endOffset));
+  const end = Math.max(0, Math.max(startOffset, endOffset));
+  if (end <= start) return "";
+
+  const lineStarts = lineOffsetsForPreviewText(text);
+  const lineIndexAt = (offset: number): number => {
+    let index = 0;
+    while (index + 1 < lineStarts.length && lineStarts[index + 1]! <= offset) {
+      index += 1;
+    }
+    return index;
+  };
+  const startLine = lineIndexAt(start);
+  const endLine = lineIndexAt(Math.max(start, end - 1));
+  const sliceLine = (line: number, from: number, to: number): string => {
+    const lineStart = lineStarts[line] ?? 0;
+    const lineEnd = line + 1 < lineStarts.length ? lineStarts[line + 1]! - 1 : text.length;
+    return text.slice(Math.max(lineStart, from), Math.min(lineEnd, to));
+  };
+
+  let current = sliceLine(startLine, start, startLine === endLine ? end : Number.POSITIVE_INFINITY);
+  const logical: string[] = [];
+  for (let line = startLine + 1; line <= endLine; line += 1) {
+    const row = sliceLine(line, 0, line === endLine ? end : Number.POSITIVE_INFINITY);
+    if (wrapFlags[line]) {
+      current = joinSoftWrappedRows(current, row);
+      continue;
+    }
+    logical.push(current);
+    current = row;
+  }
+  logical.push(current);
+  return logical.join("\n");
+};
+
+const selectionOffsetsInOverlay = (
+  overlay: HistoryPreviewNodeLike,
+  selection: HistoryPreviewSelectionLike,
+): { start: number; end: number } | null => {
+  const textNode = overlay.firstChild;
+  if (!textNode) return null;
+  const { anchorNode, focusNode, anchorOffset, focusOffset } = selection;
+  if (anchorOffset == null || focusOffset == null) return null;
+  if (anchorNode !== textNode || focusNode !== textNode) return null;
+  return {
+    start: Math.min(anchorOffset, focusOffset),
+    end: Math.max(anchorOffset, focusOffset),
+  };
+};
+
 export const getHistoryPreviewSelectionText = (
   overlay: HistoryPreviewNodeLike | null | undefined,
   selection: HistoryPreviewSelectionLike | null | undefined,
@@ -175,7 +285,16 @@ export const getHistoryPreviewSelectionText = (
   const { anchorNode, focusNode } = selection;
   if (!anchorNode || !focusNode) return "";
   if (!overlay.contains(anchorNode) || !overlay.contains(focusNode)) return "";
-  return selection.toString();
+  const raw = selection.toString();
+  const wrapAttr = overlay.getAttribute?.(HISTORY_PREVIEW_WRAP_ATTR);
+  const offsets = selectionOffsetsInOverlay(overlay, selection);
+  if (!wrapAttr || !offsets) return raw;
+  return joinHistoryPreviewSelectionText({
+    text: overlay.textContent ?? "",
+    startOffset: offsets.start,
+    endOffset: offsets.end,
+    wrapFlags: [...wrapAttr].map((flag) => flag === "1"),
+  });
 };
 
 export const findHistoryPreviewOverlay = (

--- a/components/terminal/runtime/terminalHistoryScrollOverride.ts
+++ b/components/terminal/runtime/terminalHistoryScrollOverride.ts
@@ -260,6 +260,17 @@ export const joinHistoryPreviewSelectionText = ({
   return logical.join("\n");
 };
 
+const resolveOverlayTextOffset = (
+  overlay: HistoryPreviewNodeLike,
+  textNode: { nodeType?: number },
+  node: { nodeType?: number } | null,
+  offset: number,
+): number | null => {
+  if (node === textNode) return offset;
+  if (node === overlay) return offset <= 0 ? 0 : overlay.textContent?.length ?? 0;
+  return null;
+};
+
 const selectionOffsetsInOverlay = (
   overlay: HistoryPreviewNodeLike,
   selection: HistoryPreviewSelectionLike,
@@ -268,10 +279,12 @@ const selectionOffsetsInOverlay = (
   if (!textNode) return null;
   const { anchorNode, focusNode, anchorOffset, focusOffset } = selection;
   if (anchorOffset == null || focusOffset == null) return null;
-  if (anchorNode !== textNode || focusNode !== textNode) return null;
+  const start = resolveOverlayTextOffset(overlay, textNode, anchorNode, anchorOffset);
+  const end = resolveOverlayTextOffset(overlay, textNode, focusNode, focusOffset);
+  if (start == null || end == null) return null;
   return {
-    start: Math.min(anchorOffset, focusOffset),
-    end: Math.max(anchorOffset, focusOffset),
+    start: Math.min(start, end),
+    end: Math.max(start, end),
   };
 };
 
@@ -313,12 +326,25 @@ export const getHistoryPreviewSelectionFromRoot = (
   return getHistoryPreviewSelectionText(overlay, activeSelection);
 };
 
+export const HISTORY_PREVIEW_HIDE_EVENT = "netcatty-history-preview-hide";
+
+export const requestHistoryPreviewHide = (
+  root: ParentNode | Element | null | undefined,
+): boolean => {
+  const overlay = findHistoryPreviewOverlay(root);
+  if (!overlay) return false;
+  overlay.dispatchEvent(new Event(HISTORY_PREVIEW_HIDE_EVENT, { bubbles: true }));
+  return true;
+};
+
 export const selectHistoryPreviewAll = (overlay: HTMLElement | null | undefined): boolean => {
   if (!overlay) return false;
   const selection = overlay.ownerDocument.getSelection();
   if (!selection) return false;
   const range = overlay.ownerDocument.createRange();
-  range.selectNodeContents(overlay);
+  const textNode = overlay.firstChild;
+  if (textNode) range.selectNodeContents(textNode);
+  else range.selectNodeContents(overlay);
   selection.removeAllRanges();
   selection.addRange(range);
   return !selection.isCollapsed;

--- a/components/terminal/runtime/terminalHistoryScrollOverride.ts
+++ b/components/terminal/runtime/terminalHistoryScrollOverride.ts
@@ -180,17 +180,11 @@ export const shouldKeepHistoryPreviewOnKey = (
 ): boolean => {
   if (forcedHistoryScrollPagesForKey(event) !== null) return true;
   if (MODIFIER_ONLY_KEYS.has(event.key)) return true;
-  if (options.action === "copy" || options.action === "selectAll") return true;
-  if (
-    options.overlayVisible
-    && event.key.toLowerCase() === "a"
-    && (event.metaKey || event.ctrlKey)
-    && !event.altKey
-  ) {
-    return true;
-  }
+  if (options.action === "selectAll" && options.overlayVisible) return true;
+  if (options.action === "copy" && options.hasPreviewSelection) return true;
   return Boolean(
     options.hasPreviewSelection
+    && options.action == null
     && (event.metaKey || event.ctrlKey)
     && !event.altKey
     && event.key.toLowerCase() === "c",

--- a/components/terminal/runtime/terminalHistoryScrollOverride.ts
+++ b/components/terminal/runtime/terminalHistoryScrollOverride.ts
@@ -239,6 +239,8 @@ export const joinHistoryPreviewSelectionText = ({
   };
   const startLine = lineIndexAt(start);
   const endLine = lineIndexAt(Math.max(start, end - 1));
+  const boundaryLine = lineStarts.indexOf(end);
+  const includesTrailingHardBreak = boundaryLine > 0 && !wrapFlags[boundaryLine];
   const sliceLine = (line: number, from: number, to: number): string => {
     const lineStart = lineStarts[line] ?? 0;
     const lineEnd = line + 1 < lineStarts.length ? lineStarts[line + 1]! - 1 : text.length;
@@ -257,7 +259,8 @@ export const joinHistoryPreviewSelectionText = ({
     current = row;
   }
   logical.push(current);
-  return logical.join("\n");
+  const joined = logical.join("\n");
+  return includesTrailingHardBreak ? `${joined}\n` : joined;
 };
 
 const resolveOverlayTextOffset = (
@@ -307,7 +310,7 @@ export const getHistoryPreviewSelectionText = (
     startOffset: offsets.start,
     endOffset: offsets.end,
     wrapFlags: [...wrapAttr].map((flag) => flag === "1"),
-  });
+  }) || raw;
 };
 
 export const findHistoryPreviewOverlay = (

--- a/components/terminal/useTerminalContextActions.test.ts
+++ b/components/terminal/useTerminalContextActions.test.ts
@@ -36,6 +36,12 @@ test("terminal context paste reports false when broadcast is disabled", () => {
   assert.equal(didBroadcast, false);
 });
 
+test("paste selection dismisses the history preview before sending text", async () => {
+  const { readFileSync } = await import("node:fs");
+  const source = readFileSync(new URL("./hooks/useTerminalContextActions.ts", import.meta.url), "utf8");
+  assert.match(source, /requestHistoryPreviewHide\(term\.element\?\.parentElement\)/);
+});
+
 test("terminal context paste never broadcasts password-prompt input", () => {
   const didBroadcast = broadcastTerminalPasteData("secret", {
     sourceSessionId: "workspace-session-1",

--- a/components/terminal/useTerminalContextActions.test.ts
+++ b/components/terminal/useTerminalContextActions.test.ts
@@ -40,6 +40,7 @@ test("paste selection dismisses the history preview before sending text", async 
   const { readFileSync } = await import("node:fs");
   const source = readFileSync(new URL("./hooks/useTerminalContextActions.ts", import.meta.url), "utf8");
   assert.match(source, /requestHistoryPreviewHide\(term\.element\?\.parentElement\)/);
+  assert.equal(source.split("requestHistoryPreviewHide(term.element?.parentElement)").length - 1, 2);
 });
 
 test("terminal context paste never broadcasts password-prompt input", () => {


### PR DESCRIPTION
## Summary

vi/vim (and other full-screen TUIs) switch the terminal to the alternate screen. Shift+wheel / Shift+PageUp already overlay the pre-vi scrollback, but that overlay was view-only: it used `pointer-events: none`, and any mousedown or copy shortcut tore it down. That is why history could be seen but not copied into the file being edited.

This change keeps the existing Shift+scroll preview gesture and makes that preview selectable and copyable.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3026

## Changes Made

- History preview overlay now accepts pointer events and text selection
- Mousedown on the overlay no longer dismisses the preview
- Copy / Select All chords keep the preview and copy overlay text instead of forwarding Ctrl+C / Cmd+C into vim
- Context menu Copy works over the preview even while mouse tracking is active
- Copy-on-select and Add selection to AI also use overlay text when present

Unshifted wheel in vim is unchanged. That still belongs to the TUI; SecureCRT-style scroll-without-Shift would steal vim's own mouse wheel.

## Screenshots / Demo

In vim: Shift+wheel (or Shift+PageUp) to preview earlier terminal output, drag to select, then Cmd/Ctrl+C or the context-menu Copy. The selected history is on the clipboard and can be pasted back into the editor.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Targeted unit tests for `terminalHistoryScrollOverride`, `createXTermRuntime`, `TerminalContextMenu`, and context actions: 50 passing. ESLint on the touched files is clean.

I did not run the full `npm test` suite or exercise a live vim session in the Electron app.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)