### PR TITLE
fix(terminal): keep wrap-boundary spaces when copying

### DIFF
--- a/components/terminal/normalizeTerminalSelection.test.ts
+++ b/components/terminal/normalizeTerminalSelection.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 import test from "node:test";
+import type { Terminal as XTermType } from "@xterm/xterm";
 import {
   getNormalizedTerminalSelection,
   getTerminalSelectionForClipboard,
@@ -9,6 +11,11 @@ import {
   type SelectionTerminal,
 } from "./normalizeTerminalSelection.ts";
 
+const require = createRequire(import.meta.url);
+const { Terminal: XTerm } = require("@xterm/xterm") as {
+  Terminal: typeof XTermType;
+};
+
 /**
  * Fake line that matches real xterm translateToString(true) semantics:
  * trimRight only drops *empty* cells (trailing chars that were never written),
@@ -16,7 +23,16 @@ import {
  */
 function makeLine(
   text: string,
-  options: { isWrapped?: boolean; emptyCells?: number; cellWidths?: number[] } = {},
+  options: {
+    isWrapped?: boolean;
+    emptyCells?: number;
+    cellWidths?: number[];
+    /**
+     * Model xterm.js 6 string-cache: a no-endColumn translateToString(true)
+     * drops written trailing spaces via String.trimEnd().
+     */
+    canonicalTrimEnd?: boolean;
+  } = {},
 ): SelectionBufferLine {
   const emptyCells = options.emptyCells ?? 0;
   // Optional per-character terminal widths (default 1). Used to model CJK.
@@ -59,8 +75,9 @@ function makeLine(
         getWidth: () => width,
       };
     },
-    translateToString(trimRight = false, startColumn = 0, endColumn = fullCols) {
-      let end = Math.max(startColumn, Math.min(endColumn, fullCols));
+    translateToString(trimRight = false, startColumn = 0, endColumn?: number) {
+      const endSpecified = arguments.length >= 3;
+      let end = Math.max(startColumn, Math.min(endColumn ?? fullCols, fullCols));
       if (trimRight) {
         while (end > startColumn && (cols[end - 1] === "\0" || cols[end - 1] === "")) {
           end -= 1;
@@ -71,13 +88,22 @@ function makeLine(
         const cell = cols[c];
         if (cell && cell !== "\0") result += cell;
       }
+      if (trimRight && options.canonicalTrimEnd && !endSpecified) {
+        return result.trimEnd();
+      }
       return result;
     },
   };
 }
 
 function makeTerm(
-  lines: Array<{ text: string; isWrapped?: boolean; emptyCells?: number; cellWidths?: number[] }>,
+  lines: Array<{
+    text: string;
+    isWrapped?: boolean;
+    emptyCells?: number;
+    cellWidths?: number[];
+    canonicalTrimEnd?: boolean;
+  }>,
   range: { start: { x: number; y: number }; end: { x: number; y: number } } | null,
   options: {
     rawSelection?: string;
@@ -89,6 +115,7 @@ function makeTerm(
       isWrapped: line.isWrapped,
       emptyCells: line.emptyCells,
       cellWidths: line.cellWidths,
+      canonicalTrimEnd: line.canonicalTrimEnd,
     }),
   );
   return {
@@ -361,4 +388,40 @@ test("soft-wrapped CJK with padding joins without inserted spaces", () => {
     { start: { x: 0, y: 0 }, end: { x: 18, y: 1 } },
   );
   assert.equal(getNormalizedTerminalSelection(term), "Pi: 用 /copy 最稳");
+});
+
+test("keeps a wrap-boundary space that canonical translateToString trimEnd would drop", () => {
+  const term = makeTerm(
+    [
+      { text: "|hbase ", canonicalTrimEnd: true },
+      { text: "shell", isWrapped: true, canonicalTrimEnd: true },
+    ],
+    { start: { x: 0, y: 0 }, end: { x: 5, y: 1 } },
+  );
+  assert.equal(getNormalizedTerminalSelection(term), "|hbase shell");
+});
+
+test("real xterm keeps a wrap-boundary space after an untrimmed string-cache prime", async () => {
+  const xterm = new XTerm({ cols: 20, rows: 8, scrollback: 20, allowProposedApi: true });
+  try {
+    await new Promise<void>((resolve) => {
+      xterm.write("12345678901234hbase shell\r\n", resolve);
+    });
+    // Prompt detector / autocomplete / keyword highlight all call this first.
+    xterm.buffer.active.getLine(0)?.translateToString(false);
+
+    const wrapped: SelectionTerminal = {
+      getSelection: () => xterm.getSelection(),
+      getSelectionPosition: () => ({ start: { x: 0, y: 0 }, end: { x: 5, y: 1 } }),
+      buffer: xterm.buffer,
+    };
+
+    assert.equal(
+      xterm.buffer.active.getLine(0)?.translateToString(true),
+      "12345678901234hbase",
+    );
+    assert.equal(getNormalizedTerminalSelection(wrapped), "12345678901234hbase shell");
+  } finally {
+    xterm.dispose();
+  }
 });

--- a/components/terminal/normalizeTerminalSelection.ts
+++ b/components/terminal/normalizeTerminalSelection.ts
@@ -155,13 +155,11 @@ function buildLinearSelection(
     }
 
     const startCol = y === start.y ? start.x : 0;
-    // Match xterm: on multi-row selections the first row runs to the line end
-    // (undefined endCol → line length), not only to the selection's end.x.
-    const endCol = y === end.y ? end.x : undefined;
-    const rowText =
-      endCol === undefined
-        ? line.translateToString(true, startCol)
-        : line.translateToString(true, startCol, endCol);
+    // Always pass an exclusive end column. xterm.js 6 may serve a no-endCol
+    // translateToString(true) from its string cache via String.trimEnd(),
+    // which drops a wrap-boundary space (#3023).
+    const endCol = y === end.y ? end.x : line.length;
+    const rowText = line.translateToString(true, startCol, endCol);
 
     if (y === start.y) {
       current = rowText;


### PR DESCRIPTION
## Summary

Long terminal lines that wrap exactly on a space lose that space when copied, so `|hbase shell` becomes `|hbaseshell`. This is 100% reproducible when the space sits in the last column, and turning off **Normalize terminal text on copy** does not help.

xterm.js 6 treats `translateToString(true)` without an end column as a canonical request. After any untrimmed `translateToString(false)` (prompt detector, autocomplete, keyword highlight), the string cache satisfies the trimmed request via `String.trimEnd()`, which cannot distinguish a real wrap-boundary space from empty-cell padding. Both the normalizer and raw `getSelection()` then join the wrapped rows with no space.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3023

## Changes Made

- Always pass an exclusive end column when reading physical rows for copy, so xterm uses `getTrimmedLength()` instead of the cache `trimEnd()` path.
- Add a fake-buffer test that models the cache `trimEnd()` behavior.
- Add a real xterm.js 6 test that primes the string cache, then copies a line that wraps on a space.

Keep **Normalize terminal text on copy** enabled (the default). The opt-out still uses raw xterm `getSelection()`, which has the same cache bug.

## Screenshots / Demo

N/A — copy/clipboard path. Covered by unit + real xterm tests.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — `components/terminal/normalizeTerminalSelection.test.ts` (29 tests)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Could not verify in the Electron UI in this environment. Confirmed against a real `@xterm/xterm@6.1.0-beta.292` Terminal: after `translateToString(false)`, canonical `translateToString(true)` drops the last-column space while `translateToString(true, 0, line.length)` keeps it, and the normalizer now returns `hbase shell`.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant tests
- [x] I have not introduced any breaking changes (or I have described them above)