### PR TITLE
fix(terminal): do not copy SearchAddon match selections

### DIFF
--- a/components/terminal/TerminalSelectionAIOverlay.tsx
+++ b/components/terminal/TerminalSelectionAIOverlay.tsx
@@ -6,6 +6,11 @@ import React, { memo, useEffect, useState, type RefObject } from 'react';
 import type { Terminal as XTerm } from '@xterm/xterm';
 import { Sparkles } from 'lucide-react';
 import { useI18n } from '../../application/i18n/I18nProvider';
+import {
+  createCopyOnSelectUserGestureTracker,
+  shouldWriteCopyOnSelect,
+  subscribeCopyOnSelectUserGesture,
+} from './copyOnSelect';
 import { getTerminalSelectionForClipboard } from './normalizeTerminalSelection';
 import { resolveSelectionOverlayPosition } from './useTerminalEffects';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
@@ -64,6 +69,8 @@ function TerminalSelectionAIOverlayInner({
     let scrollDisposable: { dispose: () => void } | null | undefined = null;
     let resizeDisposable: { dispose: () => void } | null | undefined = null;
     let resizeObserver: ResizeObserver | null = null;
+    let userGestureUnsubscribe: (() => void) | null = null;
+    let userGestureTracker: ReturnType<typeof createCopyOnSelectUserGestureTracker> | null = null;
 
     const requestFrame = typeof requestAnimationFrame === 'function'
       ? requestAnimationFrame
@@ -89,10 +96,16 @@ function TerminalSelectionAIOverlayInner({
       resizeDisposable = null;
       resizeObserver?.disconnect();
       resizeObserver = null;
+      userGestureUnsubscribe?.();
+      userGestureUnsubscribe = null;
+      userGestureTracker?.dispose();
+      userGestureTracker = null;
     };
 
     const attach = (term: XTerm) => {
       cleanupListeners();
+      userGestureTracker = createCopyOnSelectUserGestureTracker();
+      userGestureUnsubscribe = subscribeCopyOnSelectUserGesture(term, userGestureTracker);
 
       const publishSelectionOverlayPosition = () => {
         overlayRafId = null;
@@ -131,15 +144,16 @@ function TerminalSelectionAIOverlayInner({
         }
         scheduleSelectionOverlayPosition();
 
-        // Skip programmatic restore (preserveSelectionOnInput) and the initial
-        // attach snapshot so reopening a tab does not re-copy a retained
-        // selection over the user's current clipboard.
-        if (
-          allowCopy
-          && hasText
-          && copyOnSelect
-          && !isRestoringSelectionRef?.current
-        ) {
+        // Skip programmatic selections: preserveSelectionOnInput restore,
+        // SearchAddon match highlight (issue #3007), and the initial attach
+        // snapshot so those writes cannot clobber a user copy.
+        if (shouldWriteCopyOnSelect({
+          allowCopy,
+          hasText,
+          copyOnSelect: !!copyOnSelect,
+          isRestoringSelection: !!isRestoringSelectionRef?.current,
+          isUserSelection: !!userGestureTracker?.isActive(),
+        })) {
           const selection = getTerminalSelectionForClipboard(term, normalizeTextOnCopy);
           if (!selection) return;
           copyTimer = setTimeout(() => {

--- a/components/terminal/TerminalSelectionAIOverlay.tsx
+++ b/components/terminal/TerminalSelectionAIOverlay.tsx
@@ -9,6 +9,7 @@ import { useI18n } from '../../application/i18n/I18nProvider';
 import {
   createCopyOnSelectUserGestureTracker,
   shouldWriteCopyOnSelect,
+  subscribeCopyOnSelectUserCommand,
   subscribeCopyOnSelectUserGesture,
 } from './copyOnSelect';
 import { getTerminalSelectionForClipboard } from './normalizeTerminalSelection';
@@ -105,7 +106,14 @@ function TerminalSelectionAIOverlayInner({
     const attach = (term: XTerm) => {
       cleanupListeners();
       userGestureTracker = createCopyOnSelectUserGestureTracker();
-      userGestureUnsubscribe = subscribeCopyOnSelectUserGesture(term, userGestureTracker);
+      const unsubscribePointer = subscribeCopyOnSelectUserGesture(term, userGestureTracker);
+      const unsubscribeCommand = subscribeCopyOnSelectUserCommand(() => {
+        userGestureTracker?.pulse();
+      });
+      userGestureUnsubscribe = () => {
+        unsubscribePointer();
+        unsubscribeCommand();
+      };
 
       const publishSelectionOverlayPosition = () => {
         overlayRafId = null;

--- a/components/terminal/TerminalSelectionAIOverlay.tsx
+++ b/components/terminal/TerminalSelectionAIOverlay.tsx
@@ -107,7 +107,7 @@ function TerminalSelectionAIOverlayInner({
       cleanupListeners();
       userGestureTracker = createCopyOnSelectUserGestureTracker();
       const unsubscribePointer = subscribeCopyOnSelectUserGesture(term, userGestureTracker);
-      const unsubscribeCommand = subscribeCopyOnSelectUserCommand(() => {
+      const unsubscribeCommand = subscribeCopyOnSelectUserCommand(term, () => {
         userGestureTracker?.pulse();
       });
       userGestureUnsubscribe = () => {

--- a/components/terminal/copyOnSelect.test.ts
+++ b/components/terminal/copyOnSelect.test.ts
@@ -105,38 +105,55 @@ test("marking again cancels a pending release so a new drag can copy", () => {
   tracker.dispose();
 });
 
-test("pointer listeners mark on terminal down and release on document up", () => {
+const listenerKey = (
+  type: string,
+  options?: boolean | AddEventListenerOptions,
+): string => {
+  const capture = options === true || (
+    typeof options === "object" && options?.capture === true
+  );
+  return `${type}:${capture ? "capture" : "bubble"}`;
+};
+
+const createEventTargetStub = () => {
   const listeners = new Map<string, Set<EventListener>>();
-  const add = (type: string, listener: EventListener) => {
-    const set = listeners.get(type) ?? new Set();
-    set.add(listener);
-    listeners.set(type, set);
+  return {
+    addEventListener(
+      type: string,
+      listener: EventListener,
+      options?: boolean | AddEventListenerOptions,
+    ) {
+      const key = listenerKey(type, options);
+      const set = listeners.get(key) ?? new Set();
+      set.add(listener);
+      listeners.set(key, set);
+    },
+    removeEventListener(
+      type: string,
+      listener: EventListener,
+      options?: boolean | AddEventListenerOptions,
+    ) {
+      listeners.get(listenerKey(type, options))?.delete(listener);
+    },
+    dispatch(type: string, event: Event, phase: "capture" | "bubble") {
+      for (const listener of listeners.get(`${type}:${phase}`) ?? []) {
+        listener(event);
+      }
+    },
   };
-  const remove = (type: string, listener: EventListener) => {
-    listeners.get(type)?.delete(listener);
-  };
-  const fire = (target: "el" | "root", type: string) => {
-    for (const listener of listeners.get(`${target}:${type}`) ?? []) listener(new Event(type));
-  };
+};
 
-  const el = {
-    addEventListener(type: string, listener: EventListener) {
-      add(`el:${type}`, listener);
-    },
-    removeEventListener(type: string, listener: EventListener) {
-      remove(`el:${type}`, listener);
-    },
-  };
-  const root = {
-    addEventListener(type: string, listener: EventListener) {
-      add(`root:${type}`, listener);
-    },
-    removeEventListener(type: string, listener: EventListener) {
-      remove(`root:${type}`, listener);
-    },
-  };
+const eventOn = (type: string, target: EventTarget): Event => {
+  const event = new Event(type);
+  Object.defineProperty(event, "target", { value: target });
+  return event;
+};
 
+test("pointer listeners mark on capture down and release on document up", () => {
+  const el = createEventTargetStub();
+  const root = createEventTargetStub();
   let marked = 0;
+  let pulsed = 0;
   let released = 0;
   const unsubscribe = subscribeCopyOnSelectUserGesture(
     { element: el },
@@ -147,21 +164,71 @@ test("pointer listeners mark on terminal down and release on document up", () =>
       release: () => {
         released += 1;
       },
+      pulse: () => {
+        pulsed += 1;
+      },
     },
     root,
   );
 
-  fire("el", "mousedown");
-  fire("root", "mouseup");
-  fire("el", "contextmenu");
-  assert.equal(marked, 2);
+  root.dispatch("mousedown", eventOn("mousedown", el), "capture");
+  root.dispatch("mouseup", eventOn("mouseup", el), "bubble");
+  root.dispatch("contextmenu", eventOn("contextmenu", el), "capture");
+  assert.equal(marked, 1);
   assert.equal(released, 1);
+  assert.equal(pulsed, 1);
 
   unsubscribe();
-  fire("el", "mousedown");
-  fire("root", "mouseup");
-  assert.equal(marked, 2);
+  root.dispatch("mousedown", eventOn("mousedown", el), "capture");
+  root.dispatch("mouseup", eventOn("mouseup", el), "bubble");
+  assert.equal(marked, 1);
   assert.equal(released, 1);
+  assert.equal(pulsed, 1);
+});
+
+test("late contextmenu after mouseup is a one-shot and then releases", () => {
+  const scheduled: Array<() => void> = [];
+  const tracker = createCopyOnSelectUserGestureTracker({
+    setTimeoutFn: ((cb: () => void) => {
+      scheduled.push(cb);
+      return scheduled.length as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout,
+    clearTimeoutFn: (() => {}) as typeof clearTimeout,
+  });
+
+  tracker.mark();
+  tracker.release();
+  // Windows: contextmenu after mouseup used to cancel this timer and stick.
+  tracker.pulse();
+  assert.equal(tracker.isActive(), true);
+  scheduled.at(-1)?.();
+  assert.equal(tracker.isActive(), false);
+
+  tracker.dispose();
+});
+
+test("document-capture contextmenu still counts when the terminal never sees the bubble", () => {
+  const el = createEventTargetStub();
+  const outside = createEventTargetStub();
+  const root = createEventTargetStub();
+  let pulsed = 0;
+  subscribeCopyOnSelectUserGesture(
+    { element: el },
+    {
+      mark: () => {},
+      release: () => {},
+      pulse: () => {
+        pulsed += 1;
+      },
+    },
+    root,
+  );
+
+  // tmux/vim capture handler on the container stops the event before
+  // term.element bubble listeners would run.
+  root.dispatch("contextmenu", eventOn("contextmenu", el), "capture");
+  root.dispatch("contextmenu", eventOn("contextmenu", outside), "capture");
+  assert.equal(pulsed, 1);
 });
 
 test("issue 3007: search match then later revival does not copy", () => {

--- a/components/terminal/copyOnSelect.test.ts
+++ b/components/terminal/copyOnSelect.test.ts
@@ -235,18 +235,27 @@ test("document-capture contextmenu still counts when the terminal never sees the
   assert.equal(pulsed, 1);
 });
 
-test("user-invoked Select All pulses copy-on-select without a pointer gesture", () => {
-  let pulsed = 0;
-  const unsubscribe = subscribeCopyOnSelectUserCommand(() => {
-    pulsed += 1;
+test("user-invoked Select All pulses only the selected terminal", () => {
+  let pulsedA = 0;
+  let pulsedB = 0;
+  const terminalA = { id: "a" };
+  const terminalB = { id: "b" };
+  const unsubscribeA = subscribeCopyOnSelectUserCommand(terminalA, () => {
+    pulsedA += 1;
+  });
+  const unsubscribeB = subscribeCopyOnSelectUserCommand(terminalB, () => {
+    pulsedB += 1;
   });
 
-  pulseCopyOnSelectUserCommand();
-  assert.equal(pulsed, 1);
+  pulseCopyOnSelectUserCommand(terminalA);
+  assert.equal(pulsedA, 1);
+  assert.equal(pulsedB, 0);
 
-  unsubscribe();
-  pulseCopyOnSelectUserCommand();
-  assert.equal(pulsed, 1);
+  unsubscribeA();
+  unsubscribeB();
+  pulseCopyOnSelectUserCommand(terminalA);
+  assert.equal(pulsedA, 1);
+  assert.equal(pulsedB, 0);
 });
 
 test("issue 3007: search match then later revival does not copy", () => {

--- a/components/terminal/copyOnSelect.test.ts
+++ b/components/terminal/copyOnSelect.test.ts
@@ -4,7 +4,9 @@ import test from "node:test";
 import {
   COPY_ON_SELECT_USER_GESTURE_RELEASE_MS,
   createCopyOnSelectUserGestureTracker,
+  pulseCopyOnSelectUserCommand,
   shouldWriteCopyOnSelect,
+  subscribeCopyOnSelectUserCommand,
   subscribeCopyOnSelectUserGesture,
 } from "./copyOnSelect.ts";
 
@@ -174,15 +176,17 @@ test("pointer listeners mark on capture down and release on document up", () => 
   root.dispatch("mousedown", eventOn("mousedown", el), "capture");
   root.dispatch("mouseup", eventOn("mouseup", el), "bubble");
   root.dispatch("contextmenu", eventOn("contextmenu", el), "capture");
+  root.dispatch("touchcancel", eventOn("touchcancel", el), "bubble");
   assert.equal(marked, 1);
-  assert.equal(released, 1);
+  assert.equal(released, 2);
   assert.equal(pulsed, 1);
 
   unsubscribe();
   root.dispatch("mousedown", eventOn("mousedown", el), "capture");
   root.dispatch("mouseup", eventOn("mouseup", el), "bubble");
+  root.dispatch("touchcancel", eventOn("touchcancel", el), "bubble");
   assert.equal(marked, 1);
-  assert.equal(released, 1);
+  assert.equal(released, 2);
   assert.equal(pulsed, 1);
 });
 
@@ -228,6 +232,20 @@ test("document-capture contextmenu still counts when the terminal never sees the
   // term.element bubble listeners would run.
   root.dispatch("contextmenu", eventOn("contextmenu", el), "capture");
   root.dispatch("contextmenu", eventOn("contextmenu", outside), "capture");
+  assert.equal(pulsed, 1);
+});
+
+test("user-invoked Select All pulses copy-on-select without a pointer gesture", () => {
+  let pulsed = 0;
+  const unsubscribe = subscribeCopyOnSelectUserCommand(() => {
+    pulsed += 1;
+  });
+
+  pulseCopyOnSelectUserCommand();
+  assert.equal(pulsed, 1);
+
+  unsubscribe();
+  pulseCopyOnSelectUserCommand();
   assert.equal(pulsed, 1);
 });
 

--- a/components/terminal/copyOnSelect.test.ts
+++ b/components/terminal/copyOnSelect.test.ts
@@ -154,6 +154,7 @@ const eventOn = (type: string, target: EventTarget): Event => {
 test("pointer listeners mark on capture down and release on document up", () => {
   const el = createEventTargetStub();
   const root = createEventTargetStub();
+  const view = createEventTargetStub();
   let marked = 0;
   let pulsed = 0;
   let released = 0;
@@ -171,22 +172,25 @@ test("pointer listeners mark on capture down and release on document up", () => 
       },
     },
     root,
+    view,
   );
 
   root.dispatch("mousedown", eventOn("mousedown", el), "capture");
   root.dispatch("mouseup", eventOn("mouseup", el), "bubble");
   root.dispatch("contextmenu", eventOn("contextmenu", el), "capture");
   root.dispatch("touchcancel", eventOn("touchcancel", el), "bubble");
+  view.dispatch("blur", eventOn("blur", el), "bubble");
   assert.equal(marked, 1);
-  assert.equal(released, 2);
+  assert.equal(released, 3);
   assert.equal(pulsed, 1);
 
   unsubscribe();
   root.dispatch("mousedown", eventOn("mousedown", el), "capture");
   root.dispatch("mouseup", eventOn("mouseup", el), "bubble");
   root.dispatch("touchcancel", eventOn("touchcancel", el), "bubble");
+  view.dispatch("blur", eventOn("blur", el), "bubble");
   assert.equal(marked, 1);
-  assert.equal(released, 2);
+  assert.equal(released, 3);
   assert.equal(pulsed, 1);
 });
 

--- a/components/terminal/copyOnSelect.test.ts
+++ b/components/terminal/copyOnSelect.test.ts
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  COPY_ON_SELECT_USER_GESTURE_RELEASE_MS,
+  createCopyOnSelectUserGestureTracker,
+  shouldWriteCopyOnSelect,
+  subscribeCopyOnSelectUserGesture,
+} from "./copyOnSelect.ts";
+
+test("copy-on-select writes only after a user selection gesture", () => {
+  assert.equal(shouldWriteCopyOnSelect({
+    hasText: true,
+    copyOnSelect: true,
+    isRestoringSelection: false,
+    isUserSelection: true,
+  }), true);
+});
+
+test("copy-on-select skips SearchAddon and other programmatic selections", () => {
+  assert.equal(shouldWriteCopyOnSelect({
+    hasText: true,
+    copyOnSelect: true,
+    isRestoringSelection: false,
+    isUserSelection: false,
+  }), false);
+});
+
+test("copy-on-select still skips restore and attach snapshots", () => {
+  assert.equal(shouldWriteCopyOnSelect({
+    allowCopy: false,
+    hasText: true,
+    copyOnSelect: true,
+    isRestoringSelection: false,
+    isUserSelection: true,
+  }), false);
+  assert.equal(shouldWriteCopyOnSelect({
+    hasText: true,
+    copyOnSelect: true,
+    isRestoringSelection: true,
+    isUserSelection: true,
+  }), false);
+  assert.equal(shouldWriteCopyOnSelect({
+    hasText: false,
+    copyOnSelect: true,
+    isRestoringSelection: false,
+    isUserSelection: true,
+  }), false);
+  assert.equal(shouldWriteCopyOnSelect({
+    hasText: true,
+    copyOnSelect: false,
+    isRestoringSelection: false,
+    isUserSelection: true,
+  }), false);
+});
+
+test("user gesture stays armed until shortly after pointer-up", () => {
+  assert.ok(COPY_ON_SELECT_USER_GESTURE_RELEASE_MS < 200);
+
+  const scheduled: Array<{ cb: () => void; ms: number }> = [];
+  const tracker = createCopyOnSelectUserGestureTracker({
+    setTimeoutFn: ((cb: () => void, ms?: number) => {
+      scheduled.push({ cb, ms: ms ?? 0 });
+      return scheduled.length as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout,
+    clearTimeoutFn: (() => {}) as typeof clearTimeout,
+  });
+
+  assert.equal(tracker.isActive(), false);
+  tracker.mark();
+  assert.equal(tracker.isActive(), true);
+
+  tracker.release();
+  assert.equal(tracker.isActive(), true);
+  assert.equal(scheduled.at(-1)?.ms, COPY_ON_SELECT_USER_GESTURE_RELEASE_MS);
+
+  // A later SearchAddon revival (200ms) must not still look like a drag.
+  scheduled.at(-1)?.cb();
+  assert.equal(tracker.isActive(), false);
+
+  tracker.dispose();
+});
+
+test("marking again cancels a pending release so a new drag can copy", () => {
+  const cleared: number[] = [];
+  let nextId = 1;
+  const tracker = createCopyOnSelectUserGestureTracker({
+    setTimeoutFn: ((cb: () => void) => {
+      const id = nextId;
+      nextId += 1;
+      void cb;
+      return id as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout,
+    clearTimeoutFn: ((id: ReturnType<typeof setTimeout>) => {
+      cleared.push(id as unknown as number);
+    }) as typeof clearTimeout,
+  });
+
+  tracker.mark();
+  tracker.release();
+  tracker.mark();
+
+  assert.deepEqual(cleared, [1]);
+  assert.equal(tracker.isActive(), true);
+  tracker.dispose();
+});
+
+test("pointer listeners mark on terminal down and release on document up", () => {
+  const listeners = new Map<string, Set<EventListener>>();
+  const add = (type: string, listener: EventListener) => {
+    const set = listeners.get(type) ?? new Set();
+    set.add(listener);
+    listeners.set(type, set);
+  };
+  const remove = (type: string, listener: EventListener) => {
+    listeners.get(type)?.delete(listener);
+  };
+  const fire = (target: "el" | "root", type: string) => {
+    for (const listener of listeners.get(`${target}:${type}`) ?? []) listener(new Event(type));
+  };
+
+  const el = {
+    addEventListener(type: string, listener: EventListener) {
+      add(`el:${type}`, listener);
+    },
+    removeEventListener(type: string, listener: EventListener) {
+      remove(`el:${type}`, listener);
+    },
+  };
+  const root = {
+    addEventListener(type: string, listener: EventListener) {
+      add(`root:${type}`, listener);
+    },
+    removeEventListener(type: string, listener: EventListener) {
+      remove(`root:${type}`, listener);
+    },
+  };
+
+  let marked = 0;
+  let released = 0;
+  const unsubscribe = subscribeCopyOnSelectUserGesture(
+    { element: el },
+    {
+      mark: () => {
+        marked += 1;
+      },
+      release: () => {
+        released += 1;
+      },
+    },
+    root,
+  );
+
+  fire("el", "mousedown");
+  fire("root", "mouseup");
+  fire("el", "contextmenu");
+  assert.equal(marked, 2);
+  assert.equal(released, 1);
+
+  unsubscribe();
+  fire("el", "mousedown");
+  fire("root", "mouseup");
+  assert.equal(marked, 2);
+  assert.equal(released, 1);
+});
+
+test("issue 3007: search match then later revival does not copy", () => {
+  const scheduled: Array<() => void> = [];
+  const tracker = createCopyOnSelectUserGestureTracker({
+    setTimeoutFn: ((cb: () => void) => {
+      scheduled.push(cb);
+      return scheduled.length as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout,
+    clearTimeoutFn: (() => {}) as typeof clearTimeout,
+  });
+
+  // Typing in the search bar selects the match with no terminal pointer.
+  assert.equal(shouldWriteCopyOnSelect({
+    hasText: true,
+    copyOnSelect: true,
+    isRestoringSelection: false,
+    isUserSelection: tracker.isActive(),
+  }), false);
+
+  // User drag-selects a docker image id in the buffer.
+  tracker.mark();
+  assert.equal(shouldWriteCopyOnSelect({
+    hasText: true,
+    copyOnSelect: true,
+    isRestoringSelection: false,
+    isUserSelection: tracker.isActive(),
+  }), true);
+  tracker.release();
+  scheduled.at(-1)?.();
+
+  // Opening the snippet dialog resizes the terminal; SearchAddon re-selects
+  // the search term. Clipboard must stay on the image id.
+  assert.equal(shouldWriteCopyOnSelect({
+    hasText: true,
+    copyOnSelect: true,
+    isRestoringSelection: false,
+    isUserSelection: tracker.isActive(),
+  }), false);
+
+  tracker.dispose();
+});

--- a/components/terminal/copyOnSelect.ts
+++ b/components/terminal/copyOnSelect.ts
@@ -87,6 +87,9 @@ export const subscribeCopyOnSelectUserGesture = (
   root: Pick<EventTarget, "addEventListener" | "removeEventListener"> | null = (
     typeof document === "undefined" ? null : document
   ),
+  view: Pick<EventTarget, "addEventListener" | "removeEventListener"> | null = (
+    typeof window === "undefined" ? null : window
+  ),
 ): (() => void) => {
   const el = term?.element;
   if (!el || !root) return () => {};
@@ -111,6 +114,8 @@ export const subscribeCopyOnSelectUserGesture = (
   root.addEventListener("mouseup", onPointerUp);
   root.addEventListener("touchend", onPointerUp);
   root.addEventListener("touchcancel", onPointerUp);
+  // Alt-tab / window blur drops the matching mouseup in Electron.
+  view?.addEventListener("blur", onPointerUp);
 
   return () => {
     root.removeEventListener("mousedown", onPointerDown, CAPTURE);
@@ -119,6 +124,7 @@ export const subscribeCopyOnSelectUserGesture = (
     root.removeEventListener("mouseup", onPointerUp);
     root.removeEventListener("touchend", onPointerUp);
     root.removeEventListener("touchcancel", onPointerUp);
+    view?.removeEventListener("blur", onPointerUp);
   };
 };
 

--- a/components/terminal/copyOnSelect.ts
+++ b/components/terminal/copyOnSelect.ts
@@ -12,6 +12,8 @@ export const COPY_ON_SELECT_USER_GESTURE_RELEASE_MS = 80;
 export type CopyOnSelectUserGestureTracker = {
   mark: () => void;
   release: () => void;
+  /** Mark then release — one-shot gestures such as a late contextmenu. */
+  pulse: () => void;
   isActive: () => boolean;
   dispose: () => void;
 };
@@ -47,6 +49,11 @@ export const createCopyOnSelectUserGestureTracker = ({
     }, releaseDelayMs);
   };
 
+  const pulse = () => {
+    mark();
+    release();
+  };
+
   const dispose = () => {
     clearReleaseTimer();
     active = false;
@@ -55,37 +62,61 @@ export const createCopyOnSelectUserGestureTracker = ({
   return {
     mark,
     release,
+    pulse,
     isActive: () => active,
     dispose,
   };
 };
 
+const CAPTURE = { capture: true } as const;
+
+const eventIsInsideTerminal = (
+  event: Event,
+  el: EventTarget,
+): boolean => {
+  const target = event.target;
+  if (!target) return false;
+  if (target === el) return true;
+  const host = el as { contains?: (node: EventTarget) => boolean };
+  return typeof host.contains === "function" && host.contains(target);
+};
+
 export const subscribeCopyOnSelectUserGesture = (
   term: { element?: EventTarget | null } | null | undefined,
-  tracker: Pick<CopyOnSelectUserGestureTracker, "mark" | "release">,
+  tracker: Pick<CopyOnSelectUserGestureTracker, "mark" | "release" | "pulse">,
   root: Pick<EventTarget, "addEventListener" | "removeEventListener"> | null = (
     typeof document === "undefined" ? null : document
   ),
 ): (() => void) => {
   const el = term?.element;
-  if (!el) return () => {};
+  if (!el || !root) return () => {};
 
-  const onPointerDown = () => tracker.mark();
+  const onPointerDown = (event: Event) => {
+    if (!eventIsInsideTerminal(event, el)) return;
+    tracker.mark();
+  };
+  const onContextMenu = (event: Event) => {
+    if (!eventIsInsideTerminal(event, el)) return;
+    // Capture on the document so we still see right-clicks that
+    // useTerminalEffects intercepts with stopImmediatePropagation
+    // (tmux/vim mouse tracking + select-word). Pulse so a late
+    // contextmenu after mouseup cannot leave the tracker armed.
+    tracker.pulse();
+  };
   const onPointerUp = () => tracker.release();
 
-  el.addEventListener("mousedown", onPointerDown);
-  el.addEventListener("touchstart", onPointerDown);
-  // Right-click select-word fires on contextmenu, sometimes after mouseup.
-  el.addEventListener("contextmenu", onPointerDown);
-  root?.addEventListener("mouseup", onPointerUp);
-  root?.addEventListener("touchend", onPointerUp);
+  root.addEventListener("mousedown", onPointerDown, CAPTURE);
+  root.addEventListener("touchstart", onPointerDown, CAPTURE);
+  root.addEventListener("contextmenu", onContextMenu, CAPTURE);
+  root.addEventListener("mouseup", onPointerUp);
+  root.addEventListener("touchend", onPointerUp);
 
   return () => {
-    el.removeEventListener("mousedown", onPointerDown);
-    el.removeEventListener("touchstart", onPointerDown);
-    el.removeEventListener("contextmenu", onPointerDown);
-    root?.removeEventListener("mouseup", onPointerUp);
-    root?.removeEventListener("touchend", onPointerUp);
+    root.removeEventListener("mousedown", onPointerDown, CAPTURE);
+    root.removeEventListener("touchstart", onPointerDown, CAPTURE);
+    root.removeEventListener("contextmenu", onContextMenu, CAPTURE);
+    root.removeEventListener("mouseup", onPointerUp);
+    root.removeEventListener("touchend", onPointerUp);
   };
 };
 

--- a/components/terminal/copyOnSelect.ts
+++ b/components/terminal/copyOnSelect.ts
@@ -110,6 +110,7 @@ export const subscribeCopyOnSelectUserGesture = (
   root.addEventListener("contextmenu", onContextMenu, CAPTURE);
   root.addEventListener("mouseup", onPointerUp);
   root.addEventListener("touchend", onPointerUp);
+  root.addEventListener("touchcancel", onPointerUp);
 
   return () => {
     root.removeEventListener("mousedown", onPointerDown, CAPTURE);
@@ -117,7 +118,24 @@ export const subscribeCopyOnSelectUserGesture = (
     root.removeEventListener("contextmenu", onContextMenu, CAPTURE);
     root.removeEventListener("mouseup", onPointerUp);
     root.removeEventListener("touchend", onPointerUp);
+    root.removeEventListener("touchcancel", onPointerUp);
   };
+};
+
+const userCommandPulses = new Set<() => void>();
+
+/** Select All / Select Word from a shortcut or menu — not SearchAddon. */
+export const subscribeCopyOnSelectUserCommand = (
+  pulse: () => void,
+): (() => void) => {
+  userCommandPulses.add(pulse);
+  return () => {
+    userCommandPulses.delete(pulse);
+  };
+};
+
+export const pulseCopyOnSelectUserCommand = (): void => {
+  for (const pulse of userCommandPulses) pulse();
 };
 
 export const shouldWriteCopyOnSelect = ({

--- a/components/terminal/copyOnSelect.ts
+++ b/components/terminal/copyOnSelect.ts
@@ -1,0 +1,110 @@
+/**
+ * Copy-on-select policy for the xterm selection overlay.
+ *
+ * SearchAddon (and other programmatic paths) call terminal.select() to mark
+ * the active match. Those selection-change events must not write the
+ * clipboard — otherwise a later user selection is overwritten by the search
+ * term after a resize/write revival (issue #3007).
+ */
+
+export const COPY_ON_SELECT_USER_GESTURE_RELEASE_MS = 80;
+
+export type CopyOnSelectUserGestureTracker = {
+  mark: () => void;
+  release: () => void;
+  isActive: () => boolean;
+  dispose: () => void;
+};
+
+export const createCopyOnSelectUserGestureTracker = ({
+  releaseDelayMs = COPY_ON_SELECT_USER_GESTURE_RELEASE_MS,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+}: {
+  releaseDelayMs?: number;
+  setTimeoutFn?: typeof setTimeout;
+  clearTimeoutFn?: typeof clearTimeout;
+} = {}): CopyOnSelectUserGestureTracker => {
+  let active = false;
+  let releaseTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearReleaseTimer = () => {
+    if (releaseTimer === null) return;
+    clearTimeoutFn(releaseTimer);
+    releaseTimer = null;
+  };
+
+  const mark = () => {
+    clearReleaseTimer();
+    active = true;
+  };
+
+  const release = () => {
+    clearReleaseTimer();
+    releaseTimer = setTimeoutFn(() => {
+      releaseTimer = null;
+      active = false;
+    }, releaseDelayMs);
+  };
+
+  const dispose = () => {
+    clearReleaseTimer();
+    active = false;
+  };
+
+  return {
+    mark,
+    release,
+    isActive: () => active,
+    dispose,
+  };
+};
+
+export const subscribeCopyOnSelectUserGesture = (
+  term: { element?: EventTarget | null } | null | undefined,
+  tracker: Pick<CopyOnSelectUserGestureTracker, "mark" | "release">,
+  root: Pick<EventTarget, "addEventListener" | "removeEventListener"> | null = (
+    typeof document === "undefined" ? null : document
+  ),
+): (() => void) => {
+  const el = term?.element;
+  if (!el) return () => {};
+
+  const onPointerDown = () => tracker.mark();
+  const onPointerUp = () => tracker.release();
+
+  el.addEventListener("mousedown", onPointerDown);
+  el.addEventListener("touchstart", onPointerDown);
+  // Right-click select-word fires on contextmenu, sometimes after mouseup.
+  el.addEventListener("contextmenu", onPointerDown);
+  root?.addEventListener("mouseup", onPointerUp);
+  root?.addEventListener("touchend", onPointerUp);
+
+  return () => {
+    el.removeEventListener("mousedown", onPointerDown);
+    el.removeEventListener("touchstart", onPointerDown);
+    el.removeEventListener("contextmenu", onPointerDown);
+    root?.removeEventListener("mouseup", onPointerUp);
+    root?.removeEventListener("touchend", onPointerUp);
+  };
+};
+
+export const shouldWriteCopyOnSelect = ({
+  allowCopy = true,
+  hasText,
+  copyOnSelect,
+  isRestoringSelection,
+  isUserSelection,
+}: {
+  allowCopy?: boolean;
+  hasText: boolean;
+  copyOnSelect: boolean;
+  isRestoringSelection: boolean;
+  isUserSelection: boolean;
+}): boolean => (
+  allowCopy
+  && hasText
+  && copyOnSelect
+  && !isRestoringSelection
+  && isUserSelection
+);

--- a/components/terminal/copyOnSelect.ts
+++ b/components/terminal/copyOnSelect.ts
@@ -122,20 +122,23 @@ export const subscribeCopyOnSelectUserGesture = (
   };
 };
 
-const userCommandPulses = new Set<() => void>();
+const userCommandPulses = new Map<unknown, () => void>();
 
 /** Select All / Select Word from a shortcut or menu — not SearchAddon. */
 export const subscribeCopyOnSelectUserCommand = (
+  key: unknown,
   pulse: () => void,
 ): (() => void) => {
-  userCommandPulses.add(pulse);
+  userCommandPulses.set(key, pulse);
   return () => {
-    userCommandPulses.delete(pulse);
+    if (userCommandPulses.get(key) === pulse) {
+      userCommandPulses.delete(key);
+    }
   };
 };
 
-export const pulseCopyOnSelectUserCommand = (): void => {
-  for (const pulse of userCommandPulses) pulse();
+export const pulseCopyOnSelectUserCommand = (key: unknown): void => {
+  userCommandPulses.get(key)?.();
 };
 
 export const shouldWriteCopyOnSelect = ({

--- a/components/terminal/hooks/useTerminalContextActions.ts
+++ b/components/terminal/hooks/useTerminalContextActions.ts
@@ -206,7 +206,7 @@ export const useTerminalContextActions = ({
   const onSelectAll = useCallback(() => {
     const term = termRef.current;
     if (!term) return;
-    pulseCopyOnSelectUserCommand();
+    pulseCopyOnSelectUserCommand(term);
     const previewOverlay = findHistoryPreviewOverlay(term.element?.parentElement);
     if (previewOverlay && selectHistoryPreviewAll(previewOverlay)) {
       onHasSelectionChange?.(true);
@@ -233,7 +233,7 @@ export const useTerminalContextActions = ({
   const onSelectWord = useCallback(() => {
     const term = termRef.current;
     if (!term) return;
-    pulseCopyOnSelectUserCommand();
+    pulseCopyOnSelectUserCommand(term);
     term.selectAll();
     onHasSelectionChange?.(true);
   }, [onHasSelectionChange, termRef]);

--- a/components/terminal/hooks/useTerminalContextActions.ts
+++ b/components/terminal/hooks/useTerminalContextActions.ts
@@ -10,6 +10,7 @@ import {
   type RemoteClipboardImageUploadResult,
 } from "../clipboardImagePaste";
 import { handleTerminalClipboardPaste } from "../terminalClipboardPaste";
+import { pulseCopyOnSelectUserCommand } from "../copyOnSelect";
 import { getTerminalSelectionForClipboard } from "../normalizeTerminalSelection";
 import {
   getHistoryPreviewSelectionFromRoot,
@@ -205,6 +206,7 @@ export const useTerminalContextActions = ({
   const onSelectAll = useCallback(() => {
     const term = termRef.current;
     if (!term) return;
+    pulseCopyOnSelectUserCommand();
     const previewOverlay = findHistoryPreviewOverlay(term.element?.parentElement);
     if (previewOverlay && selectHistoryPreviewAll(previewOverlay)) {
       onHasSelectionChange?.(true);
@@ -231,6 +233,7 @@ export const useTerminalContextActions = ({
   const onSelectWord = useCallback(() => {
     const term = termRef.current;
     if (!term) return;
+    pulseCopyOnSelectUserCommand();
     term.selectAll();
     onHasSelectionChange?.(true);
   }, [onHasSelectionChange, termRef]);

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -1770,7 +1770,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
               break;
             }
             case "selectAll": {
-              pulseCopyOnSelectUserCommand();
+              pulseCopyOnSelectUserCommand(term);
               if (historyPreviewOverlay && selectHistoryPreviewAll(historyPreviewOverlay)) {
                 break;
               }

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -51,6 +51,7 @@ import {
   clearTerminalViewportAndSyncPty,
   installEraseInDisplayHandlers,
 } from "../clearTerminalViewport";
+import { pulseCopyOnSelectUserCommand } from "../copyOnSelect";
 import { getTerminalSelectionForClipboard } from "../normalizeTerminalSelection";
 import {
   createKittyKeyboardSessionStateStore,
@@ -1769,6 +1770,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
               break;
             }
             case "selectAll": {
+              pulseCopyOnSelectUserCommand();
               if (historyPreviewOverlay && selectHistoryPreviewAll(historyPreviewOverlay)) {
                 break;
               }


### PR DESCRIPTION
## Summary

With copy-on-select enabled, terminal search programmatically selects the active match (`SearchAddon._selectResult` → `terminal.select()`). That selection-change was written to the clipboard. A later drag-select of other buffer text could then be overwritten when SearchAddon re-selects the match 200ms after a write/resize (`_updateMatches` → `findPrevious`), which is exactly what happens after opening the snippet variable dialog.

Copy-on-select now writes only after a user pointer gesture on the terminal. Search highlights, `preserveSelectionOnInput` restore, and attach snapshots stay out of the clipboard.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3007

## Changes Made

- Extract a copy-on-select policy that requires a user pointer gesture
- Track mousedown/touchstart/contextmenu on the terminal and release shortly after document pointer-up
- Skip clipboard writes for SearchAddon match selections and other programmatic `select()` calls
- Add unit tests covering the issue #3007 search → select image id → snippet dialog sequence

## Screenshots / Demo

Enable Settings → Terminal → Copy on select. Search the buffer for a term (e.g. `siyuan`), drag-select a different string (e.g. a docker image id), then open a snippet variable dialog and paste. The pasted text is the drag-selected string, not the search term.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Targeted unit tests for `copyOnSelect`: 7 passing. ESLint on the touched files is clean.

I did not run the full `npm test` suite or exercise the Electron app end-to-end on Windows.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)