### PR TITLE
feat(vault): import saved MobaXterm passwords from .mobaconf

### DIFF
--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -91,6 +91,10 @@ export const enVaultMessages: Messages = {
   'vault.import.mobaxterm.utf8Desc': 'Use for files saved or converted as UTF-8.',
   'vault.import.mobaxterm.gb18030': 'Chinese Windows',
   'vault.import.mobaxterm.gb18030Desc': 'Use for legacy files exported on Chinese Windows.',
+  'vault.import.mobaxterm.masterPassword': 'Master password (optional)',
+  'vault.import.mobaxterm.masterPasswordPlaceholder': 'Enter the MobaXterm master password',
+  'vault.import.mobaxterm.masterPasswordHint':
+    'Needed to import saved passwords from .mobaconf or MobaXterm.ini. Leave blank to import sessions only.',
   'vault.import.sshConfig.chooseMode': 'Choose how to import your SSH config file.',
   'vault.import.sshConfig.modeQuestion': 'How would you like to import?',
   'vault.import.sshConfig.importOnly': 'Import Only',

--- a/application/i18n/locales/es/vault.ts
+++ b/application/i18n/locales/es/vault.ts
@@ -91,6 +91,10 @@ export const esVaultMessages: Messages = {
   'vault.import.mobaxterm.utf8Desc': 'Úsalo para archivos guardados o convertidos como UTF-8.',
   'vault.import.mobaxterm.gb18030': 'Windows en chino',
   'vault.import.mobaxterm.gb18030Desc': 'Úsalo para archivos antiguos exportados en Windows en chino.',
+  'vault.import.mobaxterm.masterPassword': 'Contraseña maestra (opcional)',
+  'vault.import.mobaxterm.masterPasswordPlaceholder': 'Introduce la contraseña maestra de MobaXterm',
+  'vault.import.mobaxterm.masterPasswordHint':
+    'Hace falta para importar las contraseñas guardadas de .mobaconf o MobaXterm.ini. Déjalo vacío para importar solo las sesiones.',
   'vault.import.sshConfig.chooseMode': 'Elige cómo importar tu archivo de configuración SSH.',
   'vault.import.sshConfig.modeQuestion': '¿Cómo te gustaría importar?',
   'vault.import.sshConfig.importOnly': 'Solo importar',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -128,6 +128,10 @@ export const ruVaultMessages: Messages = {
   'vault.import.mobaxterm.utf8Desc': 'Для файлов, сохранённых или преобразованных в UTF-8.',
   'vault.import.mobaxterm.gb18030': 'Китайская Windows',
   'vault.import.mobaxterm.gb18030Desc': 'Для старых файлов, экспортированных в китайской Windows.',
+  'vault.import.mobaxterm.masterPassword': 'Мастер-пароль (необязательно)',
+  'vault.import.mobaxterm.masterPasswordPlaceholder': 'Введите мастер-пароль MobaXterm',
+  'vault.import.mobaxterm.masterPasswordHint':
+    'Нужен, чтобы импортировать сохранённые пароли из .mobaconf или MobaXterm.ini. Оставьте пустым, чтобы импортировать только сеансы.',
   'vault.import.sshConfig.chooseMode': 'Выберите, как импортировать ваш файл SSH-конфига.',
   'vault.import.sshConfig.modeQuestion': 'Как вы хотите выполнить импорт?',
   'vault.import.sshConfig.importOnly': 'Только импорт',

--- a/application/i18n/locales/vaultBulkImportLocales.test.ts
+++ b/application/i18n/locales/vaultBulkImportLocales.test.ts
@@ -24,6 +24,9 @@ const KEYS = [
   "vault.import.progress.persistFailed",
   "vault.import.progress.rollbackFailed",
   "vault.import.sshConfig.managedDestinationHint",
+  "vault.import.mobaxterm.masterPassword",
+  "vault.import.mobaxterm.masterPasswordPlaceholder",
+  "vault.import.mobaxterm.masterPasswordHint",
 ] as const;
 
 test("bulk vault import and group-selection copy exists in every locale", () => {

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -719,6 +719,10 @@ export const zhCNCoreMessages: Messages = {
   'vault.import.mobaxterm.utf8Desc': '适用于已保存或转换为 UTF-8 的文件。',
   'vault.import.mobaxterm.gb18030': '中文 Windows',
   'vault.import.mobaxterm.gb18030Desc': '适用于中文 Windows 上导出的旧版文件。',
+  'vault.import.mobaxterm.masterPassword': '主密码（可选）',
+  'vault.import.mobaxterm.masterPasswordPlaceholder': '输入 MobaXterm 主密码',
+  'vault.import.mobaxterm.masterPasswordHint':
+    '导入 .mobaconf 或 MobaXterm.ini 中保存的密码时需要填写。留空则只导入会话。',
   'vault.import.sshConfig.chooseMode': '选择如何导入你的 SSH config 文件。',
   'vault.import.sshConfig.modeQuestion': '你希望如何导入？',
   'vault.import.sshConfig.importOnly': '仅导入',

--- a/application/i18n/locales/zh-TW/core.ts
+++ b/application/i18n/locales/zh-TW/core.ts
@@ -719,6 +719,10 @@ export const zhTWCoreMessages: Messages = {
   'vault.import.mobaxterm.utf8Desc': '適用於已儲存或轉換為 UTF-8 的檔案。',
   'vault.import.mobaxterm.gb18030': '中文 Windows',
   'vault.import.mobaxterm.gb18030Desc': '適用於中文 Windows 上匯出的舊版檔案。',
+  'vault.import.mobaxterm.masterPassword': '主密碼（選填）',
+  'vault.import.mobaxterm.masterPasswordPlaceholder': '輸入 MobaXterm 主密碼',
+  'vault.import.mobaxterm.masterPasswordHint':
+    '匯入 .mobaconf 或 MobaXterm.ini 中已儲存的密碼時需要填寫。留空則只匯入工作階段。',
   'vault.import.sshConfig.chooseMode': '選擇如何匯入你的 SSH config 檔案。',
   'vault.import.sshConfig.modeQuestion': '你希望如何匯入？',
   'vault.import.sshConfig.importOnly': '僅匯入',

--- a/application/state/useVaultImportHandlers.ts
+++ b/application/state/useVaultImportHandlers.ts
@@ -171,6 +171,7 @@ export function useVaultImportHandlers({
             format,
             files,
             encoding: options?.encoding,
+            masterPassword: options?.masterPassword,
             signal,
             onProgress: (progress) => {
               if (!signal.aborted) updateProgress(progress);

--- a/application/state/vaultImportOptions.ts
+++ b/application/state/vaultImportOptions.ts
@@ -6,6 +6,7 @@ export type VaultImportOptions = {
   managed?: boolean;
   filePath?: string;
   encoding?: VaultImportFileEncoding;
+  masterPassword?: string;
   destination?: VaultImportDestination;
 };
 

--- a/components/vault/ImportVaultDialog.tsx
+++ b/components/vault/ImportVaultDialog.tsx
@@ -516,7 +516,7 @@ export const ImportVaultDialog: React.FC<ImportVaultDialogProps> = ({
       setStep("format");
       pickFile("mobaxterm", ".ini,.mxtsessions,.txt,.mobaconf", {
         encoding,
-        masterPassword: mobaMasterPassword.trim() || undefined,
+        masterPassword: mobaMasterPassword === "" ? undefined : mobaMasterPassword,
       });
     },
     [mobaMasterPassword, pickFile],

--- a/components/vault/ImportVaultDialog.tsx
+++ b/components/vault/ImportVaultDialog.tsx
@@ -29,6 +29,7 @@ import type {
 } from "../../domain/vaultImport";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
+import { Input } from "../ui/input";
 import {
   Dialog,
   DialogContent,
@@ -55,7 +56,7 @@ const OPTIONS: ImportOption[] = [
     format: "mobaxterm",
     label: "MobaXterm",
     iconSrc: "/import/moba.jpg",
-    accept: ".ini,.mxtsessions,.txt",
+    accept: ".ini,.mxtsessions,.txt,.mobaconf",
   },
   {
     format: "csv",
@@ -406,6 +407,7 @@ export const ImportVaultDialog: React.FC<ImportVaultDialogProps> = ({
   const existingGroupQueryRef = useRef(existingGroupQuery);
   existingGroupQueryRef.current = existingGroupQuery;
   const [newGroup, setNewGroup] = useState("");
+  const [mobaMasterPassword, setMobaMasterPassword] = useState("");
   const destination = buildVaultImportDestination({
     mode: destinationMode,
     existingGroup,
@@ -438,6 +440,7 @@ export const ImportVaultDialog: React.FC<ImportVaultDialogProps> = ({
     setExistingGroup(groups[0] ?? "");
     setExistingGroupQuery(groups[0] ?? "");
     setNewGroup("");
+    setMobaMasterPassword("");
   }, [groups, open]);
   const pluginImporter = usePluginVaultImporter({
     open,
@@ -511,9 +514,12 @@ export const ImportVaultDialog: React.FC<ImportVaultDialogProps> = ({
   const handleMobaEncodingChoice = useCallback(
     (encoding: VaultImportFileEncoding) => {
       setStep("format");
-      pickFile("mobaxterm", ".ini,.mxtsessions,.txt", { encoding });
+      pickFile("mobaxterm", ".ini,.mxtsessions,.txt,.mobaconf", {
+        encoding,
+        masterPassword: mobaMasterPassword.trim() || undefined,
+      });
     },
-    [pickFile],
+    [mobaMasterPassword, pickFile],
   );
 
   const handleSecureCrtChoice = useCallback(
@@ -845,6 +851,25 @@ export const ImportVaultDialog: React.FC<ImportVaultDialogProps> = ({
                         </div>
                       </button>
                     ))}
+                  </div>
+                  <div className="space-y-2">
+                    <label
+                      htmlFor="moba-master-password"
+                      className="block text-center text-sm font-medium text-muted-foreground"
+                    >
+                      {t("vault.import.mobaxterm.masterPassword")}
+                    </label>
+                    <Input
+                      id="moba-master-password"
+                      type="password"
+                      autoComplete="off"
+                      value={mobaMasterPassword}
+                      onChange={(event) => setMobaMasterPassword(event.target.value)}
+                      placeholder={t("vault.import.mobaxterm.masterPasswordPlaceholder")}
+                    />
+                    <p className="text-center text-xs text-muted-foreground">
+                      {t("vault.import.mobaxterm.masterPasswordHint")}
+                    </p>
                   </div>
                   <button
                     type="button"

--- a/domain/vaultImport.test.ts
+++ b/domain/vaultImport.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { createCipheriv, createHash } from "node:crypto";
 
 import {
   importVaultHostsFromText,
@@ -796,6 +797,57 @@ test("MobaXterm import attaches master-password secrets from a full config expor
   assert.equal(web?.password, "Lw3+cZ2s.w@U@f]U");
   assert.equal(web?.savePassword, true);
   assert.equal(root?.password, "HyperSine");
+});
+
+test("MobaXterm import does not save garbage passwords for a wrong master password", () => {
+  const source = [
+    "[Misc]",
+    "SessionP=165821882556840",
+    "[Sesspass]",
+    "Administrator@WIN=dummy",
+    "[Passwords]",
+    "deploy@10.0.0.20=1du11XKQBOxud/FWh4ouWA==",
+    "[Credentials]",
+    "prod=root:0XROpGmLAYVx",
+    "[Bookmarks]",
+    "SubRep=",
+    "ImgNum=42",
+    `web-server=${mobaXtermSshSession("10.0.0.20", 2222, "deploy")}`,
+    `root-server=${mobaXtermSshSession("root.example.com", 22, "root")}`,
+  ].join("\n");
+
+  for (const masterPassword of ["wrong0", "wrong-password"]) {
+    const result = importVaultHostsFromText("mobaxterm", source, { masterPassword });
+    assert.equal(result.hosts.length, 2, masterPassword);
+    assert.equal(result.hosts.every((host) => host.password === undefined), true, masterPassword);
+    assert.match(result.issues[0]?.message ?? "", /master password/i, masterPassword);
+  }
+});
+
+test("MobaXterm import keeps leading whitespace in the master password", () => {
+  const masterPassword = " 12345678";
+  const key = createHash("sha512").update(masterPassword, "utf8").digest().subarray(0, 32);
+  const iv = createCipheriv("aes-256-ecb", key, null).update(Buffer.alloc(16));
+  const cipher = createCipheriv("aes-256-cfb8", key, iv);
+  cipher.setAutoPadding(false);
+  const ciphertext = Buffer.concat([
+    cipher.update("spaced-secret", "utf8"),
+    cipher.final(),
+  ]).toString("base64");
+
+  const result = importVaultHostsFromText("mobaxterm", [
+    "[Sesspass]",
+    "Administrator@WIN=dummy",
+    "[Passwords]",
+    `deploy@10.0.0.20=${ciphertext}`,
+    "[Bookmarks]",
+    "SubRep=",
+    "ImgNum=42",
+    `web-server=${mobaXtermSshSession("10.0.0.20", 2222, "deploy")}`,
+  ].join("\n"), { masterPassword });
+
+  assert.equal(result.hosts[0]?.password, "spaced-secret");
+  assert.equal(result.hosts[0]?.savePassword, true);
 });
 
 test("MobaXterm import leaves sessions intact when encrypted passwords need a master password", () => {

--- a/domain/vaultImport.test.ts
+++ b/domain/vaultImport.test.ts
@@ -816,12 +816,29 @@ test("MobaXterm import does not save garbage passwords for a wrong master passwo
     `root-server=${mobaXtermSshSession("root.example.com", 22, "root")}`,
   ].join("\n");
 
-  for (const masterPassword of ["wrong0", "wrong-password"]) {
+  for (const masterPassword of ["wrong0", "wrong25", "wrong-password"]) {
     const result = importVaultHostsFromText("mobaxterm", source, { masterPassword });
     assert.equal(result.hosts.length, 2, masterPassword);
     assert.equal(result.hosts.every((host) => host.password === undefined), true, masterPassword);
     assert.match(result.issues[0]?.message ?? "", /master password/i, masterPassword);
   }
+});
+
+test("MobaXterm import does not save a truncated UTF-8 prefix from a lone credential", () => {
+  const result = importVaultHostsFromText("mobaxterm", [
+    "[Sesspass]",
+    "Administrator@WIN=dummy",
+    "[Credentials]",
+    "prod=root:0XROpGmLAYVx",
+    "[Bookmarks]",
+    "SubRep=",
+    "ImgNum=42",
+    `root-server=${mobaXtermSshSession("root.example.com", 22, "root")}`,
+  ].join("\n"), { masterPassword: "wrong25" });
+
+  assert.equal(result.hosts.length, 1);
+  assert.equal(result.hosts[0].password, undefined);
+  assert.match(result.issues[0]?.message ?? "", /master password/i);
 });
 
 test("MobaXterm import keeps leading whitespace in the master password", () => {

--- a/domain/vaultImport.test.ts
+++ b/domain/vaultImport.test.ts
@@ -773,6 +773,64 @@ test("MobaXterm import handles incomplete standard session records safely", () =
   assert.equal(result.issues.length, 3);
 });
 
+test("MobaXterm import attaches master-password secrets from a full config export", () => {
+  const result = importVaultHostsFromText("mobaxterm", [
+    "[Misc]",
+    "SessionP=165821882556840",
+    "[Sesspass]",
+    "Administrator@WIN=dummy",
+    "[Passwords]",
+    "deploy@10.0.0.20=1du11XKQBOxud/FWh4ouWA==",
+    "[Credentials]",
+    "prod=root:0XROpGmLAYVx",
+    "[Bookmarks]",
+    "SubRep=",
+    "ImgNum=42",
+    `web-server=${mobaXtermSshSession("10.0.0.20", 2222, "deploy")}`,
+    `root-server=${mobaXtermSshSession("root.example.com", 22, "root")}`,
+  ].join("\n"), { masterPassword: "12345678" });
+
+  assert.equal(result.hosts.length, 2);
+  const web = result.hosts.find((host) => host.label === "web-server");
+  const root = result.hosts.find((host) => host.label === "root-server");
+  assert.equal(web?.password, "Lw3+cZ2s.w@U@f]U");
+  assert.equal(web?.savePassword, true);
+  assert.equal(root?.password, "HyperSine");
+});
+
+test("MobaXterm import leaves sessions intact when encrypted passwords need a master password", () => {
+  const result = importVaultHostsFromText("mobaxterm", [
+    "[Sesspass]",
+    "Administrator@WIN=dummy",
+    "[Passwords]",
+    "deploy@10.0.0.20=1du11XKQBOxud/FWh4ouWA==",
+    "[Bookmarks]",
+    "SubRep=",
+    "ImgNum=42",
+    `web-server=${mobaXtermSshSession("10.0.0.20", 2222, "deploy")}`,
+  ].join("\n"));
+
+  assert.equal(result.hosts.length, 1);
+  assert.equal(result.hosts[0].password, undefined);
+  assert.match(result.issues[0]?.message ?? "", /master password/i);
+});
+
+test("detectVaultImportFormat recognizes full MobaXterm configuration exports", () => {
+  assert.equal(
+    detectVaultImportFormat([
+      "[Misc]",
+      "SessionP=165821882556840",
+      "[Passwords]",
+      "deploy@10.0.0.20=1du11XKQBOxud/FWh4ouWA==",
+      "[Bookmarks]",
+      "SubRep=",
+      "ImgNum=42",
+      `server=${mobaXtermSshSession("10.0.0.1")}`,
+    ].join("\n")),
+    "mobaxterm",
+  );
+});
+
 test("applyVaultHostImport skips duplicates by default", () => {
   const existing: Host = {
     id: "existing-1",

--- a/domain/vaultImport.ts
+++ b/domain/vaultImport.ts
@@ -16,6 +16,7 @@ export {
 import { parseQuickConnectInput } from "./quickConnect";
 import { findExactHeaderIndex, findHeaderIndex, parseCsv } from "./vaultImport/csvUtils";
 import { decodeCsvKeyPath, decodeCsvPassphrase } from "./vaultImport/csvCredentialFields";
+import { attachMobaXtermPasswords } from "./vaultImport/mobaXtermPasswords";
 export {
   exportHostsToCsvWithStats,
   getVaultCsvTemplate,
@@ -1104,13 +1105,20 @@ const importFromSecureCrt = (text: string, fileName?: string): VaultImportResult
   };
 };
 
-const importFromMobaXterm = (text: string): VaultImportResult => {
+const importFromMobaXterm = (
+  text: string,
+  options?: { masterPassword?: string },
+): VaultImportResult => {
   const issues: VaultImportIssue[] = [];
   const lines = text.split(/\r?\n/);
 
   type Entry = { section: string; key: string; value: string };
   const entries: Entry[] = [];
   const sectionGroups = new Map<string, string | undefined>();
+  const passwordEntries = new Map<string, string>();
+  const credentialEntries = new Map<string, { username: string; ciphertext: string }>();
+  const misc = new Map<string, string>();
+  let hasSesspass = false;
 
   let section = "";
   for (const line of lines) {
@@ -1128,13 +1136,36 @@ const importFromMobaXterm = (text: string): VaultImportResult => {
     if (!mKv) continue;
     const key = mKv[1].trim();
     const value = mKv[2].trim();
-    const isBookmarkSection = /^bookmarks(?:_\d+)?$/i.test(section.trim());
+    const sectionName = section.trim();
+    const isBookmarkSection = /^bookmarks(?:_\d+)?$/i.test(sectionName);
 
     if (isBookmarkSection && key.toLowerCase() === "subrep") {
       sectionGroups.set(section, normalizeGroupPath(value));
       continue;
     }
     if (isBookmarkSection && key.toLowerCase() === "imgnum") continue;
+    if (/^passwords$/i.test(sectionName) && key && value) {
+      passwordEntries.set(key, value);
+      continue;
+    }
+    if (/^credentials$/i.test(sectionName) && key && value) {
+      const colon = value.indexOf(":");
+      if (colon > 0) {
+        credentialEntries.set(key, {
+          username: value.slice(0, colon),
+          ciphertext: value.slice(colon + 1),
+        });
+      }
+      continue;
+    }
+    if (/^misc$/i.test(sectionName)) {
+      misc.set(key.toLowerCase(), value);
+      continue;
+    }
+    if (/^sesspass$/i.test(sectionName)) {
+      hasSesspass = true;
+      continue;
+    }
 
     entries.push({ section, key, value });
   }
@@ -1253,7 +1284,18 @@ const importFromMobaXterm = (text: string): VaultImportResult => {
     );
   }
 
-  const { hosts, duplicates } = dedupeHosts(parsedHosts);
+  const { hosts: uniqueHosts, duplicates } = dedupeHosts(parsedHosts);
+  const attached = attachMobaXtermPasswords(uniqueHosts, {
+    passwords: passwordEntries,
+    credentials: credentialEntries,
+    sessionP: misc.get("sessionp"),
+    sysUsername: misc.get("mpsetaccount"),
+    sysHostname: misc.get("mpsetcomputer"),
+    passwordsInRegistry: misc.get("passwordsinregistry") === "1",
+    hasSesspass,
+  }, { masterPassword: options?.masterPassword });
+  issues.push(...attached.issues);
+  const hosts = attached.hosts;
   const groups = uniq(hosts.map((h) => h.group).filter(Boolean) as string[]);
   return {
     hosts,
@@ -1266,7 +1308,7 @@ const importFromMobaXterm = (text: string): VaultImportResult => {
 export const importVaultHostsFromText = (
   format: VaultImportFormat,
   text: string,
-  options?: { fileName?: string },
+  options?: { fileName?: string; masterPassword?: string },
 ): VaultImportResult => {
   const input = text ?? "";
   switch (format) {
@@ -1279,7 +1321,7 @@ export const importVaultHostsFromText = (
     case "securecrt":
       return importFromSecureCrt(input, options?.fileName);
     case "mobaxterm":
-      return importFromMobaXterm(input);
+      return importFromMobaXterm(input, options);
     default: {
       const _exhaustive: never = format;
       return _exhaustive;
@@ -1301,9 +1343,12 @@ export function detectVaultImportFormat(text: string): VaultImportFormat | null 
   const hasMobaBookmarkSection = /^\[Bookmarks(?:_\d+)?\]\s*$/im.test(input);
   const hasMobaBookmarkMetadata = /^SubRep=.*$/im.test(input) && /^ImgNum=\d+\s*$/im.test(input);
   const hasMobaSessionLine = /^[^=\r\n]+=\s*(?:; logout)?\s*#\d+#\d+%[^%\r\n]+%\d+/im.test(input);
+  const hasMobaFullConfig = /^\[Misc\]\s*$/im.test(input)
+    && (/^SessionP=/im.test(input) || /^\[Passwords\]\s*$/im.test(input) || /^\[Credentials\]\s*$/im.test(input));
   if (
     /\[MobaXterm\]/i.test(input)
-    || (hasMobaBookmarkSection && (hasMobaBookmarkMetadata || hasMobaSessionLine))
+    || (hasMobaBookmarkSection && (hasMobaBookmarkMetadata || hasMobaSessionLine || hasMobaFullConfig))
+    || (hasMobaFullConfig && hasMobaBookmarkSection)
   ) {
     return "mobaxterm";
   }

--- a/domain/vaultImport/mobaXtermCrypto.test.ts
+++ b/domain/vaultImport/mobaXtermCrypto.test.ts
@@ -78,11 +78,52 @@ test("weak connection cipher decrypts the published session-password vector", ()
 });
 
 test("wrong master password does not look like a saved secret", () => {
+  for (const masterPassword of ["wrong-password", "wrong0", "x", "0"]) {
+    assert.equal(
+      decryptMobaStoredSecret({
+        ciphertext: "1du11XKQBOxud/FWh4ouWA==",
+        masterPassword,
+      }),
+      null,
+      `session ciphertext accepted garbage for ${masterPassword}`,
+    );
+    assert.equal(
+      decryptMobaStoredSecret({
+        ciphertext: "0XROpGmLAYVx",
+        masterPassword,
+      }),
+      null,
+      `credential ciphertext accepted garbage for ${masterPassword}`,
+    );
+  }
+});
+
+test("master-password AES keeps leading and trailing whitespace in the key", () => {
+  const masterPassword = " 12345678 ";
+  const plaintext = "spaced-master";
+  const key = createHash("sha512").update(masterPassword, "utf8").digest().subarray(0, 32);
+  const iv = createCipheriv("aes-256-ecb", key, null).update(Buffer.alloc(16));
+  const cipher = createCipheriv("aes-256-cfb8", key, iv);
+  cipher.setAutoPadding(false);
+  const stored = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]).toString("base64");
+
   assert.equal(
-    decryptMobaStoredSecret({
-      ciphertext: "1du11XKQBOxud/FWh4ouWA==",
-      masterPassword: "wrong-password",
-    }),
+    decryptMobaStoredSecret({ ciphertext: stored, masterPassword }),
+    plaintext,
+  );
+  assert.equal(
+    decryptMobaStoredSecret({ ciphertext: stored, masterPassword: masterPassword.trim() }),
     null,
   );
+});
+
+test("decodeMobaPlaintext rejects high-bit Latin-1 that is not UTF-8", () => {
+  assert.equal(
+    decodeMobaPlaintext(Uint8Array.from([0xd7, 0xf4, 0x5f, 0xb8, 0x77, 0xf9, 0x9c, 0xc9, 0x40])),
+    null,
+  );
+  assert.equal(decodeMobaPlaintext(Uint8Array.from([0x48, 0x69])), "Hi");
 });

--- a/domain/vaultImport/mobaXtermCrypto.test.ts
+++ b/domain/vaultImport/mobaXtermCrypto.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { createCipheriv, createHash } from "node:crypto";
+import test from "node:test";
+
+import {
+  craftMobaConnectionKey,
+  craftMobaSessionPKey,
+  decodeMobaPlaintext,
+  decryptMobaStoredSecret,
+  decryptMobaWeakCipher,
+  sha512,
+} from "./mobaXtermCrypto.ts";
+
+test("sha512 matches Node for MobaXterm key material", () => {
+  const samples = ["12345678", "master-password", ""];
+  for (const sample of samples) {
+    assert.deepEqual(
+      Buffer.from(sha512(Buffer.from(sample, "utf8"))),
+      createHash("sha512").update(sample, "utf8").digest(),
+    );
+  }
+});
+
+test("master-password AES decrypts HyperSine session and credential vectors", () => {
+  assert.equal(
+    decryptMobaStoredSecret({
+      ciphertext: "1du11XKQBOxud/FWh4ouWA==",
+      masterPassword: "12345678",
+    }),
+    "Lw3+cZ2s.w@U@f]U",
+  );
+  assert.equal(
+    decryptMobaStoredSecret({
+      ciphertext: "0XROpGmLAYVx",
+      masterPassword: "12345678",
+    }),
+    "HyperSine",
+  );
+});
+
+test("master-password AES decrypts the v25 random-IV format", () => {
+  const masterPassword = "netcatty-master";
+  const plaintext = "imported-secret";
+  const key = createHash("sha512").update(masterPassword, "utf8").digest().subarray(0, 32);
+  const prefix = "_@ABCDEFGHIJKLMNOPQR";
+  const iv = Buffer.from(prefix.slice(2, 18), "latin1");
+  const cipher = createCipheriv("aes-256-cfb8", key, iv);
+  cipher.setAutoPadding(false);
+  const body = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const stored = `${prefix}${body.toString("base64").replaceAll("+", "@").replaceAll("/", "_")}`;
+
+  assert.equal(
+    decryptMobaStoredSecret({ ciphertext: stored, masterPassword }),
+    plaintext,
+  );
+});
+
+test("weak SessionP cipher decrypts the published credential vector", () => {
+  const key = craftMobaSessionPKey("165821882556840");
+  assert.equal(
+    decodeMobaPlaintext(decryptMobaWeakCipher(
+      "bSj4VWbHezNH3tTY9Nil2RzJX57p7/S6KqMw8VsiT/WH+I8p03pqnInAu",
+      key,
+    )),
+    "HyperSine",
+  );
+});
+
+test("weak connection cipher decrypts the published session-password vector", () => {
+  const key = craftMobaConnectionKey("DoubleSine", "ShadowSurface", "root", "45.32.110.171");
+  assert.equal(
+    decodeMobaPlaintext(decryptMobaWeakCipher(
+      "F0+wuBvbe9qPW6ypiOeYHTHhKdShRc/nXaM1Ky1jeTfw46TzQoSesX9buGm0WW36yP4lhH70ZCHZpEo4wLJhIl1",
+      key,
+    )),
+    "Lw3+cZ2s.w@U@f]U",
+  );
+});
+
+test("wrong master password does not look like a saved secret", () => {
+  assert.equal(
+    decryptMobaStoredSecret({
+      ciphertext: "1du11XKQBOxud/FWh4ouWA==",
+      masterPassword: "wrong-password",
+    }),
+    null,
+  );
+});

--- a/domain/vaultImport/mobaXtermCrypto.test.ts
+++ b/domain/vaultImport/mobaXtermCrypto.test.ts
@@ -78,7 +78,7 @@ test("weak connection cipher decrypts the published session-password vector", ()
 });
 
 test("wrong master password does not look like a saved secret", () => {
-  for (const masterPassword of ["wrong-password", "wrong0", "x", "0"]) {
+  for (const masterPassword of ["wrong-password", "wrong0", "wrong25", "x", "0"]) {
     assert.equal(
       decryptMobaStoredSecret({
         ciphertext: "1du11XKQBOxud/FWh4ouWA==",
@@ -96,6 +96,17 @@ test("wrong master password does not look like a saved secret", () => {
       `credential ciphertext accepted garbage for ${masterPassword}`,
     );
   }
+});
+
+test("decodeMobaPlaintext rejects an interior NUL left by a wrong AES key", () => {
+  assert.equal(
+    decodeMobaPlaintext(Uint8Array.from([0x4d, 0x29, 0x38, 0x25, 0x00, 0x72, 0x33, 0x8a, 0xa8])),
+    null,
+  );
+  assert.equal(
+    decodeMobaPlaintext(Uint8Array.from([0x48, 0x69, 0x00, 0x00])),
+    "Hi",
+  );
 });
 
 test("master-password AES keeps leading and trailing whitespace in the key", () => {

--- a/domain/vaultImport/mobaXtermCrypto.ts
+++ b/domain/vaultImport/mobaXtermCrypto.ts
@@ -327,13 +327,20 @@ export const decryptMobaWeakCipher = (ciphertext: string, key: Uint8Array): Uint
 export const decodeMobaPlaintext = (bytes: Uint8Array | null): string | null => {
   if (!bytes || bytes.length === 0) return null;
   const nul = bytes.indexOf(0);
-  const slice = nul === 0 ? null : nul > 0 ? bytes.subarray(0, nul) : bytes;
-  if (!slice || slice.length === 0) return null;
+  // AES-CFB is unauthenticated. A wrong key can inject an interior NUL and leave
+  // a short printable prefix (e.g. "M)8%"). Only a trailing NUL pad is a C string.
+  let slice = bytes;
+  if (nul === 0) return null;
+  if (nul > 0) {
+    for (let i = nul; i < bytes.length; i++) {
+      if (bytes[i] !== 0) return null;
+    }
+    slice = bytes.subarray(0, nul);
+  }
+  if (slice.length === 0) return null;
   for (const value of slice) {
     if (value < 0x20 && value !== 0x09) return null;
   }
-  // AES-CFB is unauthenticated: a wrong key often yields high-bit Latin-1 junk
-  // that looks "printable". Only accept valid UTF-8 so that garbage is rejected.
   try {
     return new TextDecoder("utf-8", { fatal: true }).decode(slice);
   } catch {

--- a/domain/vaultImport/mobaXtermCrypto.ts
+++ b/domain/vaultImport/mobaXtermCrypto.ts
@@ -332,12 +332,12 @@ export const decodeMobaPlaintext = (bytes: Uint8Array | null): string | null => 
   for (const value of slice) {
     if (value < 0x20 && value !== 0x09) return null;
   }
+  // AES-CFB is unauthenticated: a wrong key often yields high-bit Latin-1 junk
+  // that looks "printable". Only accept valid UTF-8 so that garbage is rejected.
   try {
     return new TextDecoder("utf-8", { fatal: true }).decode(slice);
   } catch {
-    let text = "";
-    for (const value of slice) text += String.fromCharCode(value);
-    return text || null;
+    return null;
   }
 };
 

--- a/domain/vaultImport/mobaXtermCrypto.ts
+++ b/domain/vaultImport/mobaXtermCrypto.ts
@@ -1,0 +1,395 @@
+const AES_SBOX = Uint8Array.from([
+  0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5, 0x30, 0x01, 0x67, 0x2b, 0xfe, 0xd7, 0xab, 0x76,
+  0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0, 0xad, 0xd4, 0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0,
+  0xb7, 0xfd, 0x93, 0x26, 0x36, 0x3f, 0xf7, 0xcc, 0x34, 0xa5, 0xe5, 0xf1, 0x71, 0xd8, 0x31, 0x15,
+  0x04, 0xc7, 0x23, 0xc3, 0x18, 0x96, 0x05, 0x9a, 0x07, 0x12, 0x80, 0xe2, 0xeb, 0x27, 0xb2, 0x75,
+  0x09, 0x83, 0x2c, 0x1a, 0x1b, 0x6e, 0x5a, 0xa0, 0x52, 0x3b, 0xd6, 0xb3, 0x29, 0xe3, 0x2f, 0x84,
+  0x53, 0xd1, 0x00, 0xed, 0x20, 0xfc, 0xb1, 0x5b, 0x6a, 0xcb, 0xbe, 0x39, 0x4a, 0x4c, 0x58, 0xcf,
+  0xd0, 0xef, 0xaa, 0xfb, 0x43, 0x4d, 0x33, 0x85, 0x45, 0xf9, 0x02, 0x7f, 0x50, 0x3c, 0x9f, 0xa8,
+  0x51, 0xa3, 0x40, 0x8f, 0x92, 0x9d, 0x38, 0xf5, 0xbc, 0xb6, 0xda, 0x21, 0x10, 0xff, 0xf3, 0xd2,
+  0xcd, 0x0c, 0x13, 0xec, 0x5f, 0x97, 0x44, 0x17, 0xc4, 0xa7, 0x7e, 0x3d, 0x64, 0x5d, 0x19, 0x73,
+  0x60, 0x81, 0x4f, 0xdc, 0x22, 0x2a, 0x90, 0x88, 0x46, 0xee, 0xb8, 0x14, 0xde, 0x5e, 0x0b, 0xdb,
+  0xe0, 0x32, 0x3a, 0x0a, 0x49, 0x06, 0x24, 0x5c, 0xc2, 0xd3, 0xac, 0x62, 0x91, 0x95, 0xe4, 0x79,
+  0xe7, 0xc8, 0x37, 0x6d, 0x8d, 0xd5, 0x4e, 0xa9, 0x6c, 0x56, 0xf4, 0xea, 0x65, 0x7a, 0xae, 0x08,
+  0xba, 0x78, 0x25, 0x2e, 0x1c, 0xa6, 0xb4, 0xc6, 0xe8, 0xdd, 0x74, 0x1f, 0x4b, 0xbd, 0x8b, 0x8a,
+  0x70, 0x3e, 0xb5, 0x66, 0x48, 0x03, 0xf6, 0x0e, 0x61, 0x35, 0x57, 0xb9, 0x86, 0xc1, 0x1d, 0x9e,
+  0xe1, 0xf8, 0x98, 0x11, 0x69, 0xd9, 0x8e, 0x94, 0x9b, 0x1e, 0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf,
+  0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42, 0x68, 0x41, 0x99, 0x2d, 0x0f, 0xb0, 0x54, 0xbb, 0x16,
+]);
+
+const AES_RCON = Uint8Array.from([
+  0x00, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36,
+]);
+
+const SHA512_K = [
+  0x428a2f98d728ae22n, 0x7137449123ef65cdn, 0xb5c0fbcfec4d3b2fn, 0xe9b5dba58189dbbcn,
+  0x3956c25bf348b538n, 0x59f111f1b605d019n, 0x923f82a4af194f9bn, 0xab1c5ed5da6d8118n,
+  0xd807aa98a3030242n, 0x12835b0145706fben, 0x243185be4ee4b28cn, 0x550c7dc3d5ffb4e2n,
+  0x72be5d74f27b896fn, 0x80deb1fe3b1696b1n, 0x9bdc06a725c71235n, 0xc19bf174cf692694n,
+  0xe49b69c19ef14ad2n, 0xefbe4786384f25e3n, 0x0fc19dc68b8cd5b5n, 0x240ca1cc77ac9c65n,
+  0x2de92c6f592b0275n, 0x4a7484aa6ea6e483n, 0x5cb0a9dcbd41fbd4n, 0x76f988da831153b5n,
+  0x983e5152ee66dfabn, 0xa831c66d2db43210n, 0xb00327c898fb213fn, 0xbf597fc7beef0ee4n,
+  0xc6e00bf33da88fc2n, 0xd5a79147930aa725n, 0x06ca6351e003826fn, 0x142929670a0e6e70n,
+  0x27b70a8546d22ffcn, 0x2e1b21385c26c926n, 0x4d2c6dfc5ac42aedn, 0x53380d139d95b3dfn,
+  0x650a73548baf63den, 0x766a0abb3c77b2a8n, 0x81c2c92e47edaee6n, 0x92722c851482353bn,
+  0xa2bfe8a14cf10364n, 0xa81a664bbc423001n, 0xc24b8b70d0f89791n, 0xc76c51a30654be30n,
+  0xd192e819d6ef5218n, 0xd69906245565a910n, 0xf40e35855771202an, 0x106aa07032bbd1b8n,
+  0x19a4c116b8d2d0c8n, 0x1e376c085141ab53n, 0x2748774cdf8eeb99n, 0x34b0bcb5e19b48a8n,
+  0x391c0cb3c5c95a63n, 0x4ed8aa4ae3418acbn, 0x5b9cca4f7763e373n, 0x682e6ff3d6b2b8a3n,
+  0x748f82ee5defb2fcn, 0x78a5636f43172f60n, 0x84c87814a1f0ab72n, 0x8cc702081a6439ecn,
+  0x90befffa23631e28n, 0xa4506cebde82bde9n, 0xbef9a3f7b2c67915n, 0xc67178f2e372532bn,
+  0xca273eceea26619cn, 0xd186b8c721c0c207n, 0xeada7dd6cde0eb1en, 0xf57d4f7fee6ed178n,
+  0x06f067aa72176fban, 0x0a637dc5a2c898a6n, 0x113f9804bef90daen, 0x1b710b35131c471bn,
+  0x28db77f523047d84n, 0x32caab7b40c72493n, 0x3c9ebe0a15c9bebcn, 0x431d67c49c100d4cn,
+  0x4cc5d4becb3e42b6n, 0x597f299cfc657e2an, 0x5fcb6fab3ad6faecn, 0x6c44198c4a475817n,
+];
+
+const MASK64 = 0xffffffffffffffffn;
+const WEAK_KEY_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+/";
+
+const utf8Encode = (value: string): Uint8Array => new TextEncoder().encode(value);
+
+const latin1Encode = (value: string): Uint8Array => {
+  const out = new Uint8Array(value.length);
+  for (let i = 0; i < value.length; i++) out[i] = value.charCodeAt(i) & 0xff;
+  return out;
+};
+
+const rotl32 = (value: number, n: number): number => ((value << n) | (value >>> (32 - n))) >>> 0;
+
+const subWord = (value: number): number => (
+  (AES_SBOX[value >>> 24] << 24)
+  | (AES_SBOX[(value >>> 16) & 0xff] << 16)
+  | (AES_SBOX[(value >>> 8) & 0xff] << 8)
+  | AES_SBOX[value & 0xff]
+) >>> 0;
+
+const expandAes256Key = (key: Uint8Array): Uint32Array => {
+  const w = new Uint32Array(60);
+  for (let i = 0; i < 8; i++) {
+    w[i] = (
+      (key[i * 4] << 24)
+      | (key[i * 4 + 1] << 16)
+      | (key[i * 4 + 2] << 8)
+      | key[i * 4 + 3]
+    ) >>> 0;
+  }
+  for (let i = 8; i < 60; i++) {
+    let temp = w[i - 1];
+    if (i % 8 === 0) {
+      temp = (subWord(rotl32(temp, 8)) ^ (AES_RCON[i / 8] << 24)) >>> 0;
+    } else if (i % 8 === 4) {
+      temp = subWord(temp);
+    }
+    w[i] = (w[i - 8] ^ temp) >>> 0;
+  }
+  return w;
+};
+
+const xtime = (value: number): number => ((value << 1) ^ ((value & 0x80) !== 0 ? 0x1b : 0)) & 0xff;
+
+const aesEncryptBlockWithRoundKeys = (roundKeys: Uint32Array, block: Uint8Array): Uint8Array => {
+  const state = new Uint8Array(block);
+  const addRoundKey = (round: number) => {
+    for (let c = 0; c < 4; c++) {
+      const word = roundKeys[round * 4 + c];
+      const offset = c * 4;
+      state[offset] ^= word >>> 24;
+      state[offset + 1] ^= (word >>> 16) & 0xff;
+      state[offset + 2] ^= (word >>> 8) & 0xff;
+      state[offset + 3] ^= word & 0xff;
+    }
+  };
+  const subBytes = () => {
+    for (let i = 0; i < 16; i++) state[i] = AES_SBOX[state[i]];
+  };
+  const shiftRows = () => {
+    const row1 = [state[1], state[5], state[9], state[13]];
+    state[1] = row1[1];
+    state[5] = row1[2];
+    state[9] = row1[3];
+    state[13] = row1[0];
+    const row2 = [state[2], state[6], state[10], state[14]];
+    state[2] = row2[2];
+    state[6] = row2[3];
+    state[10] = row2[0];
+    state[14] = row2[1];
+    const row3 = [state[3], state[7], state[11], state[15]];
+    state[3] = row3[3];
+    state[7] = row3[0];
+    state[11] = row3[1];
+    state[15] = row3[2];
+  };
+  const mixColumns = () => {
+    for (let c = 0; c < 4; c++) {
+      const offset = c * 4;
+      const a0 = state[offset];
+      const a1 = state[offset + 1];
+      const a2 = state[offset + 2];
+      const a3 = state[offset + 3];
+      state[offset] = (xtime(a0) ^ xtime(a1) ^ a1 ^ a2 ^ a3) & 0xff;
+      state[offset + 1] = (a0 ^ xtime(a1) ^ xtime(a2) ^ a2 ^ a3) & 0xff;
+      state[offset + 2] = (a0 ^ a1 ^ xtime(a2) ^ xtime(a3) ^ a3) & 0xff;
+      state[offset + 3] = (xtime(a0) ^ a0 ^ a1 ^ a2 ^ xtime(a3)) & 0xff;
+    }
+  };
+
+  addRoundKey(0);
+  for (let round = 1; round < 14; round++) {
+    subBytes();
+    shiftRows();
+    mixColumns();
+    addRoundKey(round);
+  }
+  subBytes();
+  shiftRows();
+  addRoundKey(14);
+  return state;
+};
+
+const aesEncryptBlock = (key: Uint8Array, block: Uint8Array): Uint8Array => (
+  aesEncryptBlockWithRoundKeys(expandAes256Key(key), block)
+);
+
+const aesCfb8Decrypt = (key: Uint8Array, iv: Uint8Array, ciphertext: Uint8Array): Uint8Array => {
+  const roundKeys = expandAes256Key(key);
+  const shift = new Uint8Array(iv);
+  const out = new Uint8Array(ciphertext.length);
+  for (let i = 0; i < ciphertext.length; i++) {
+    const encrypted = aesEncryptBlockWithRoundKeys(roundKeys, shift);
+    out[i] = ciphertext[i] ^ encrypted[0];
+    shift.copyWithin(0, 1);
+    shift[15] = ciphertext[i];
+  }
+  return out;
+};
+
+const rotr64 = (value: bigint, n: bigint): bigint => (
+  ((value >> n) | (value << (64n - n))) & MASK64
+);
+
+export const sha512 = (message: Uint8Array): Uint8Array => {
+  const bitLen = BigInt(message.length) * 8n;
+  const padLen = (256 - ((message.length + 17) % 128)) % 128;
+  const total = message.length + 1 + padLen + 16;
+  const buf = new Uint8Array(total);
+  buf.set(message);
+  buf[message.length] = 0x80;
+  const view = new DataView(buf.buffer);
+  view.setBigUint64(total - 16, bitLen >> 64n, false);
+  view.setBigUint64(total - 8, bitLen & MASK64, false);
+
+  let h0 = 0x6a09e667f3bcc908n;
+  let h1 = 0xbb67ae8584caa73bn;
+  let h2 = 0x3c6ef372fe94f82bn;
+  let h3 = 0xa54ff53a5f1d36f1n;
+  let h4 = 0x510e527fade682d1n;
+  let h5 = 0x9b05688c2b3e6c1fn;
+  let h6 = 0x1f83d9abfb41bd6bn;
+  let h7 = 0x5be0cd19137e2179n;
+
+  const w = new Array<bigint>(80);
+  for (let offset = 0; offset < total; offset += 128) {
+    for (let i = 0; i < 16; i++) {
+      w[i] = view.getBigUint64(offset + i * 8, false);
+    }
+    for (let i = 16; i < 80; i++) {
+      const s0 = rotr64(w[i - 15], 1n) ^ rotr64(w[i - 15], 8n) ^ (w[i - 15] >> 7n);
+      const s1 = rotr64(w[i - 2], 19n) ^ rotr64(w[i - 2], 61n) ^ (w[i - 2] >> 6n);
+      w[i] = (w[i - 16] + s0 + w[i - 7] + s1) & MASK64;
+    }
+
+    let a = h0;
+    let b = h1;
+    let c = h2;
+    let d = h3;
+    let e = h4;
+    let f = h5;
+    let g = h6;
+    let h = h7;
+    for (let i = 0; i < 80; i++) {
+      const S1 = rotr64(e, 14n) ^ rotr64(e, 18n) ^ rotr64(e, 41n);
+      const ch = (e & f) ^ ((~e) & g);
+      const temp1 = (h + S1 + ch + SHA512_K[i] + w[i]) & MASK64;
+      const S0 = rotr64(a, 28n) ^ rotr64(a, 34n) ^ rotr64(a, 39n);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (S0 + maj) & MASK64;
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temp1) & MASK64;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) & MASK64;
+    }
+    h0 = (h0 + a) & MASK64;
+    h1 = (h1 + b) & MASK64;
+    h2 = (h2 + c) & MASK64;
+    h3 = (h3 + d) & MASK64;
+    h4 = (h4 + e) & MASK64;
+    h5 = (h5 + f) & MASK64;
+    h6 = (h6 + g) & MASK64;
+    h7 = (h7 + h) & MASK64;
+  }
+
+  const digest = new Uint8Array(64);
+  const out = new DataView(digest.buffer);
+  out.setBigUint64(0, h0, false);
+  out.setBigUint64(8, h1, false);
+  out.setBigUint64(16, h2, false);
+  out.setBigUint64(24, h3, false);
+  out.setBigUint64(32, h4, false);
+  out.setBigUint64(40, h5, false);
+  out.setBigUint64(48, h6, false);
+  out.setBigUint64(56, h7, false);
+  return digest;
+};
+
+const decodeBase64 = (input: string, altChars = false): Uint8Array => {
+  const normalized = (altChars ? input.replaceAll("@", "+").replaceAll("_", "/") : input)
+    .replace(/\s+/g, "");
+  if (!normalized) return new Uint8Array();
+  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(padded)) return new Uint8Array();
+  try {
+    const binary = atob(padded);
+    const out = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+    return out;
+  } catch {
+    return new Uint8Array();
+  }
+};
+
+const rotateWeakKey = (key: Uint8Array): void => {
+  const last = key[key.length - 1];
+  key.copyWithin(1, 0, key.length - 1);
+  key[0] = last;
+};
+
+const repeatToLength = (value: string, minLength: number): string => {
+  if (!value) return value;
+  let out = value;
+  while (out.length < minLength) out += out;
+  return out;
+};
+
+const craftWeakKey = (keySpace: string[]): Uint8Array => {
+  const key = latin1Encode("0d5e9n1348/U2+67");
+  for (let i = 0; i < key.length; i++) {
+    const source = keySpace[(i + 1) % keySpace.length];
+    const b = source.charCodeAt(i);
+    if (!Number.isFinite(b)) continue;
+    if (!key.includes(b) && WEAK_KEY_ALPHABET.includes(String.fromCharCode(b))) {
+      key[i] = b;
+    }
+  }
+  return key;
+};
+
+export const craftMobaSessionPKey = (sessionP: string): Uint8Array => {
+  const s = repeatToLength(sessionP, 20);
+  return craftWeakKey([s.toUpperCase(), s.toUpperCase(), s.toLowerCase(), s.toLowerCase()]);
+};
+
+export const craftMobaConnectionKey = (
+  sysUsername: string,
+  sysHostname: string,
+  connUsername: string,
+  connHostname: string,
+): Uint8Array => {
+  const s1 = repeatToLength(sysUsername + sysHostname, 20);
+  const s2 = repeatToLength(connUsername + connHostname, 20);
+  return craftWeakKey([s1.toUpperCase(), s2.toUpperCase(), s1.toLowerCase(), s2.toLowerCase()]);
+};
+
+export const decryptMobaWeakCipher = (ciphertext: string, key: Uint8Array): Uint8Array | null => {
+  const filtered: number[] = [];
+  for (let i = 0; i < ciphertext.length; i++) {
+    const code = ciphertext.charCodeAt(i);
+    if (key.includes(code)) filtered.push(code);
+  }
+  if (filtered.length === 0 || filtered.length % 2 !== 0) return null;
+  const working = new Uint8Array(key);
+  const plaintext = new Uint8Array(filtered.length / 2);
+  for (let i = 0; i < filtered.length; i += 2) {
+    const low = working.indexOf(filtered[i]);
+    rotateWeakKey(working);
+    const high = working.indexOf(filtered[i + 1]);
+    rotateWeakKey(working);
+    if (low < 0 || high < 0) return null;
+    plaintext[i / 2] = ((high << 4) + low) & 0xff;
+  }
+  return plaintext;
+};
+
+export const decodeMobaPlaintext = (bytes: Uint8Array | null): string | null => {
+  if (!bytes || bytes.length === 0) return null;
+  const nul = bytes.indexOf(0);
+  const slice = nul === 0 ? null : nul > 0 ? bytes.subarray(0, nul) : bytes;
+  if (!slice || slice.length === 0) return null;
+  for (const value of slice) {
+    if (value < 0x20 && value !== 0x09) return null;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(slice);
+  } catch {
+    let text = "";
+    for (const value of slice) text += String.fromCharCode(value);
+    return text || null;
+  }
+};
+
+const decryptMasterPasswordCipher = (ciphertext: string, masterPassword: string): Uint8Array | null => {
+  const key = sha512(utf8Encode(masterPassword)).subarray(0, 32);
+  if (ciphertext.startsWith("_@") && ciphertext.length >= 20) {
+    const iv = latin1Encode(ciphertext.slice(2, 18));
+    const body = decodeBase64(ciphertext, true).subarray(15);
+    if (body.length === 0) return null;
+    return aesCfb8Decrypt(key, iv, body);
+  }
+  const standard = decodeBase64(ciphertext);
+  if (standard.length === 0) return null;
+  const iv = aesEncryptBlock(key, new Uint8Array(16));
+  return aesCfb8Decrypt(key, iv, standard);
+};
+
+export interface MobaStoredSecretInput {
+  ciphertext: string;
+  masterPassword?: string;
+  sessionP?: string;
+  sysUsername?: string;
+  sysHostname?: string;
+  connUsername?: string;
+  connHostname?: string;
+}
+
+export const decryptMobaStoredSecret = (input: MobaStoredSecretInput): string | null => {
+  const ciphertext = input.ciphertext.trim();
+  if (!ciphertext) return null;
+
+  if (input.masterPassword) {
+    return decodeMobaPlaintext(decryptMasterPasswordCipher(ciphertext, input.masterPassword));
+  }
+
+  if (input.connUsername && input.connHostname && input.sysUsername && input.sysHostname) {
+    const weak = decryptMobaWeakCipher(
+      ciphertext,
+      craftMobaConnectionKey(
+        input.sysUsername,
+        input.sysHostname,
+        input.connUsername,
+        input.connHostname,
+      ),
+    );
+    const decoded = decodeMobaPlaintext(weak);
+    if (decoded) return decoded;
+  }
+
+  if (input.sessionP) {
+    return decodeMobaPlaintext(decryptMobaWeakCipher(ciphertext, craftMobaSessionPKey(input.sessionP)));
+  }
+
+  return null;
+};

--- a/domain/vaultImport/mobaXtermPasswords.ts
+++ b/domain/vaultImport/mobaXtermPasswords.ts
@@ -1,0 +1,164 @@
+import type { Host } from "../models";
+import { decryptMobaStoredSecret } from "./mobaXtermCrypto";
+
+type VaultImportIssue = { level: "warning" | "error"; message: string };
+
+export interface MobaXtermIniSections {
+  passwords: Map<string, string>;
+  credentials: Map<string, { username: string; ciphertext: string }>;
+  sessionP?: string;
+  sysUsername?: string;
+  sysHostname?: string;
+  passwordsInRegistry: boolean;
+  hasSesspass: boolean;
+}
+
+export interface AttachMobaXtermPasswordsOptions {
+  masterPassword?: string;
+}
+
+const parsePasswordKey = (raw: string): { username?: string; hostname?: string } => {
+  const stripped = raw.replace(/^[A-Za-z]+\d*:/, "");
+  const at = stripped.lastIndexOf("@");
+  if (at <= 0 || at === stripped.length - 1) return {};
+  return {
+    username: stripped.slice(0, at),
+    hostname: stripped.slice(at + 1),
+  };
+};
+
+const sameHost = (left: string | undefined, right: string | undefined): boolean => (
+  Boolean(left && right && left.localeCompare(right, undefined, { sensitivity: "accent" }) === 0)
+);
+
+const lookupPlaintext = (
+  host: Host,
+  passwords: Map<string, string>,
+  credentialsByUser: Map<string, string[]>,
+): string | undefined => {
+  const username = host.username?.trim();
+  const hostname = host.hostname;
+  const port = host.port ?? 22;
+  if (username) {
+    const exactKeys = [
+      `${username}@${hostname}`,
+      `ssh${port}:${username}@${hostname}`,
+      `ssh:${username}@${hostname}`,
+    ];
+    for (const key of exactKeys) {
+      const value = passwords.get(key);
+      if (value) return value;
+    }
+  }
+
+  const hostMatches: string[] = [];
+  for (const [key, value] of passwords) {
+    const parsed = parsePasswordKey(key);
+    if (!sameHost(parsed.hostname, hostname)) continue;
+    if (username && parsed.username && parsed.username !== username) continue;
+    if (username && parsed.username === username) return value;
+    hostMatches.push(value);
+  }
+  if (!username && hostMatches.length === 1) return hostMatches[0];
+
+  if (username) {
+    const named = credentialsByUser.get(username);
+    if (named?.length === 1) return named[0];
+  }
+  return undefined;
+};
+
+export const attachMobaXtermPasswords = (
+  hosts: Host[],
+  sections: MobaXtermIniSections,
+  options: AttachMobaXtermPasswordsOptions = {},
+): { hosts: Host[]; issues: VaultImportIssue[]; attached: number } => {
+  const issues: VaultImportIssue[] = [];
+  const masterPassword = options.masterPassword?.trim() || undefined;
+  const hasCiphertext = sections.passwords.size > 0 || sections.credentials.size > 0;
+
+  if (sections.passwordsInRegistry && !hasCiphertext) {
+    issues.push({
+      level: "warning",
+      message: "MobaXterm saved passwords in the Windows registry, so this file has no credentials to import.",
+    });
+    return { hosts, issues, attached: 0 };
+  }
+
+  if (!hasCiphertext) return { hosts, issues, attached: 0 };
+
+  if (!masterPassword && sections.hasSesspass) {
+    issues.push({
+      level: "warning",
+      message: "This MobaXterm file encrypts saved passwords with a master password. Enter it to import credentials.",
+    });
+    return { hosts, issues, attached: 0 };
+  }
+
+  const decryptedPasswords = new Map<string, string>();
+  let failed = 0;
+  for (const [key, ciphertext] of sections.passwords) {
+    const parsed = parsePasswordKey(key);
+    const plaintext = decryptMobaStoredSecret({
+      ciphertext,
+      masterPassword,
+      sessionP: sections.sessionP,
+      sysUsername: sections.sysUsername,
+      sysHostname: sections.sysHostname,
+      connUsername: parsed.username,
+      connHostname: parsed.hostname,
+    });
+    if (plaintext) decryptedPasswords.set(key, plaintext);
+    else failed++;
+  }
+
+  const credentialsByUser = new Map<string, string[]>();
+  for (const credential of sections.credentials.values()) {
+    const plaintext = decryptMobaStoredSecret({
+      ciphertext: credential.ciphertext,
+      masterPassword,
+      sessionP: sections.sessionP,
+    });
+    if (!plaintext) {
+      failed++;
+      continue;
+    }
+    const current = credentialsByUser.get(credential.username) ?? [];
+    current.push(plaintext);
+    credentialsByUser.set(credential.username, current);
+  }
+
+  if (failed > 0 && decryptedPasswords.size === 0 && credentialsByUser.size === 0) {
+    issues.push({
+      level: "warning",
+      message: masterPassword
+        ? "Could not decrypt MobaXterm passwords. Check the master password and try again."
+        : "Could not decrypt MobaXterm passwords from this file.",
+    });
+    return { hosts, issues, attached: 0 };
+  }
+
+  if (failed > 0) {
+    issues.push({
+      level: "warning",
+      message: `Skipped ${failed} MobaXterm password(s) that could not be decrypted.`,
+    });
+  }
+
+  let attached = 0;
+  const nextHosts = hosts.map((host) => {
+    const password = lookupPlaintext(host, decryptedPasswords, credentialsByUser);
+    if (!password) return host;
+    attached++;
+    return { ...host, password, savePassword: true };
+  });
+
+  if (attached === 0) {
+    issues.push({
+      level: "warning",
+      message: "Decrypted MobaXterm passwords, but none matched the imported SSH sessions.",
+    });
+  }
+
+  return { hosts: nextHosts, issues, attached };
+};

--- a/domain/vaultImport/mobaXtermPasswords.ts
+++ b/domain/vaultImport/mobaXtermPasswords.ts
@@ -31,6 +31,10 @@ const sameHost = (left: string | undefined, right: string | undefined): boolean 
   Boolean(left && right && left.localeCompare(right, undefined, { sensitivity: "accent" }) === 0)
 );
 
+const presentMasterPassword = (value: string | undefined): string | undefined => (
+  value === undefined || value === "" ? undefined : value
+);
+
 const lookupPlaintext = (
   host: Host,
   passwords: Map<string, string>,
@@ -74,7 +78,7 @@ export const attachMobaXtermPasswords = (
   options: AttachMobaXtermPasswordsOptions = {},
 ): { hosts: Host[]; issues: VaultImportIssue[]; attached: number } => {
   const issues: VaultImportIssue[] = [];
-  const masterPassword = options.masterPassword?.trim() || undefined;
+  const masterPassword = presentMasterPassword(options.masterPassword);
   const hasCiphertext = sections.passwords.size > 0 || sections.credentials.size > 0;
 
   if (sections.passwordsInRegistry && !hasCiphertext) {
@@ -128,12 +132,18 @@ export const attachMobaXtermPasswords = (
     credentialsByUser.set(credential.username, current);
   }
 
+  if (masterPassword && failed > 0) {
+    issues.push({
+      level: "warning",
+      message: "Could not decrypt MobaXterm passwords. Check the master password and try again.",
+    });
+    return { hosts, issues, attached: 0 };
+  }
+
   if (failed > 0 && decryptedPasswords.size === 0 && credentialsByUser.size === 0) {
     issues.push({
       level: "warning",
-      message: masterPassword
-        ? "Could not decrypt MobaXterm passwords. Check the master password and try again."
-        : "Could not decrypt MobaXterm passwords from this file.",
+      message: "Could not decrypt MobaXterm passwords from this file.",
     });
     return { hosts, issues, attached: 0 };
   }

--- a/infrastructure/services/vaultImportBatch.ts
+++ b/infrastructure/services/vaultImportBatch.ts
@@ -23,6 +23,7 @@ interface ImportVaultHostFilesOptions {
   files: File[];
   relativePaths?: string[];
   encoding?: VaultImportFileEncoding;
+  masterPassword?: string;
   onProgress?: (progress: VaultImportBatchProgress) => void;
 }
 
@@ -65,6 +66,7 @@ export async function importVaultHostFiles({
   files,
   relativePaths,
   encoding,
+  masterPassword,
   onProgress,
 }: ImportVaultHostFilesOptions): Promise<VaultImportResult> {
   const sourceFiles = files.map((file, index) => ({
@@ -86,7 +88,10 @@ export async function importVaultHostFiles({
     const { file, relativePath } = selectedFiles[index];
     try {
       const text = await readVaultImportFile(format, file, encoding);
-      const result = importVaultHostsFromText(format, text, { fileName: file.name });
+      const result = importVaultHostsFromText(format, text, {
+        fileName: file.name,
+        masterPassword,
+      });
       const group = format === "securecrt"
         ? secureCrtGroupFromFile(file, relativePath)
         : undefined;

--- a/infrastructure/services/vaultImportWorkerClient.ts
+++ b/infrastructure/services/vaultImportWorkerClient.ts
@@ -21,6 +21,7 @@ export type VaultImportWorkerRequest = {
   files: File[];
   relativePaths: string[];
   encoding: VaultImportFileEncoding | undefined;
+  masterPassword?: string;
 };
 
 export type VaultImportWorkerResponse =
@@ -42,6 +43,7 @@ interface ImportVaultHostsInWorkerOptions {
   format: VaultImportFormat;
   files: File[];
   encoding?: VaultImportFileEncoding;
+  masterPassword?: string;
   signal?: AbortSignal;
   createWorker?: () => VaultImportWorkerLike;
   onProgress?: (progress: VaultImportWorkerProgress) => void;
@@ -57,6 +59,7 @@ export function importVaultHostsInWorker({
   format,
   files,
   encoding,
+  masterPassword,
   signal,
   createWorker = createVaultImportWorker,
   onProgress,
@@ -110,6 +113,7 @@ export function importVaultHostsInWorker({
       files,
       relativePaths: files.map((file) => file.webkitRelativePath),
       encoding,
+      ...(masterPassword ? { masterPassword } : {}),
     });
   });
 }

--- a/infrastructure/workers/vaultImport.worker.ts
+++ b/infrastructure/workers/vaultImport.worker.ts
@@ -22,6 +22,7 @@ workerScope.addEventListener("message", async (event: MessageEvent<VaultImportWo
       files: event.data.files,
       relativePaths: event.data.relativePaths,
       encoding: event.data.encoding,
+      masterPassword: event.data.masterPassword,
       onProgress: ({ completedFiles, totalFiles, fileName }) => {
         post({
           type: "progress",


### PR DESCRIPTION
## Summary
- Accept MobaXterm `.mobaconf` (and existing `.ini` / `.mxtsessions`) exports in vault import.
- Decrypt saved `[Passwords]` / `[Credentials]` with the master password (AES-256-CFB8, including the v25 random-IV format) or the legacy SessionP cipher, then attach them to matching SSH hosts.
- Leave sessions importable without a master password; warn when credentials are encrypted or stored only in the Windows registry.

Closes #2988

## Type of Change

- [x] New feature

## Related Issue (optional)

Closes #2988

## Changes Made

- Add a MobaXterm cipher in `domain/vaultImport` and map decrypted secrets onto imported hosts by `user@host` / named credential.
- Prompt for an optional master password on the MobaXterm encoding step and pass it through the import worker.
- Cover HyperSine vectors, v25 random-IV ciphertexts, and full-config import in unit tests.

## Screenshots / Demo

MobaXterm import now accepts `.mobaconf` and shows an optional master-password field before the file picker.

## Testing

- [x] Tests pass (`node --test --import tsx domain/vaultImport/mobaXtermCrypto.test.ts domain/vaultImport.test.ts application/i18n/locales/vaultBulkImportLocales.test.ts infrastructure/services/vaultImportWorkerClient.test.ts`)
- [x] Linting passes (`npx eslint` on changed files)
- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Test plan
- [ ] Import a `.mxtsessions` file without a master password and confirm hosts still come in without passwords.
- [ ] Export a `.mobaconf` / `MobaXterm.ini` that includes saved passwords, enter the master password, and confirm first SSH login does not prompt for that password.
- [ ] Enter a wrong master password and confirm sessions still import with a warning and no garbage passwords.
- [ ] Confirm a file that stores passwords only in the Windows registry warns that credentials are not in the file.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)


Made with [Cursor](https://cursor.com)