### PR TITLE
feat(terminal): pass Esc+. through for readline yank-last-arg

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1001,6 +1001,13 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         onBroadcastInputRef.current(text, sessionId);
       }
 
+      // ESC-prefixed writes (Esc+. yank-last-arg) are shell editor commands.
+      // Walking printable bytes would append "." and leave history/completions
+      // tracking a stale line.
+      if (text.startsWith("\x1b")) {
+        return;
+      }
+
       // Update command buffer for onCommandExecuted tracking
       for (const ch of text) {
         if (handledSubmittedInput) {

--- a/components/terminal/autocomplete/terminalAutocompleteKeyEvent.ts
+++ b/components/terminal/autocomplete/terminalAutocompleteKeyEvent.ts
@@ -86,6 +86,11 @@ export function handleTerminalAutocompleteKeyEvent(
     escMetaPrefixUntilRef.current = 0;
     e.preventDefault();
     writeToTerminal(metaFollowUp);
+    // Match handleTerminalAutocompleteInput's ESC-sequence path: yank-last-arg
+    // rewrites the shell line, so the append-only typed buffer is stale.
+    typedInputBufferRef.current = "";
+    typedBufferReliableRef.current = false;
+    lastAcceptedCommandRef.current = null;
     return false;
   }
   if (e.key !== "Escape" && e.key !== "Shift" && e.key !== "Control" && e.key !== "Alt" && e.key !== "Meta") {

--- a/components/terminal/autocomplete/terminalAutocompleteKeyEvent.ts
+++ b/components/terminal/autocomplete/terminalAutocompleteKeyEvent.ts
@@ -88,7 +88,7 @@ export function handleTerminalAutocompleteKeyEvent(
     writeToTerminal(metaFollowUp);
     return false;
   }
-  if (e.key !== "Escape") {
+  if (e.key !== "Escape" && e.key !== "Shift" && e.key !== "Control" && e.key !== "Alt" && e.key !== "Meta") {
     escMetaPrefixUntilRef.current = 0;
   }
 

--- a/components/terminal/autocomplete/terminalAutocompleteKeyEvent.ts
+++ b/components/terminal/autocomplete/terminalAutocompleteKeyEvent.ts
@@ -21,6 +21,25 @@ interface TerminalAutocompleteKeyEventContext {
   renderPreviewSelection: (index: number) => void;
   acceptPreviewlessSelection: (index: number) => boolean;
   acceptSnippet: (snippet: Snippet) => boolean;
+  /** Deadline (ms) until which `.` / `_` are treated as readline Meta follow-ups. */
+  escMetaPrefixUntilRef: MutableRefObject<number>;
+  now?: () => number;
+}
+
+/** Readline keyseq-timeout default; Esc then . within this window is M-. */
+export const AUTOCOMPLETE_ESC_META_TIMEOUT_MS = 500;
+
+export function autocompleteEscMetaFollowUpSequence(e: {
+  key: string;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+}): string | null {
+  if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return null;
+  if (e.key === ".") return "\x1b.";
+  if (e.key === "_") return "\x1b_";
+  return null;
 }
 
 const isAutocompleteConfirmEnter = (
@@ -56,8 +75,21 @@ export function handleTerminalAutocompleteKeyEvent(
     renderPreviewSelection,
     acceptPreviewlessSelection,
     acceptSnippet,
+    escMetaPrefixUntilRef,
+    now = Date.now,
   } = context;
   if (!settingsRef.current.enabled || e.type !== "keydown") return true;
+
+  const metaFollowUp = autocompleteEscMetaFollowUpSequence(e);
+  if (metaFollowUp && now() < escMetaPrefixUntilRef.current) {
+    escMetaPrefixUntilRef.current = 0;
+    e.preventDefault();
+    writeToTerminal(metaFollowUp);
+    return false;
+  }
+  if (e.key !== "Escape") {
+    escMetaPrefixUntilRef.current = 0;
+  }
 
   const s = stateRef.current;
   const ghost = ghostAddonRef.current;
@@ -328,9 +360,11 @@ export function handleTerminalAutocompleteKeyEvent(
     }
   }
 
-  // Escape: close popup and hide ghost text
+  // Escape: close popup and hide ghost text.
   // Only consume Escape if popup is visible; don't block Escape for vi-mode shells
-  // when only ghost text is showing (ghost text is passive/non-intrusive)
+  // when only ghost text is showing (ghost text is passive/non-intrusive).
+  // After dismissing the popup, arm a short Meta prefix so Esc+. / Esc+_ still
+  // reach readline yank-last-arg (issue #2364) without entering vi-cmd mode.
   if (e.key === "Escape" && s.popupVisible) {
     e.preventDefault();
     if (previewActiveRef.current) {
@@ -339,6 +373,7 @@ export function handleTerminalAutocompleteKeyEvent(
     ghost?.hide();
     clearState();
     previewActiveRef.current = false;
+    escMetaPrefixUntilRef.current = now() + AUTOCOMPLETE_ESC_META_TIMEOUT_MS;
     return false;
   }
 

--- a/components/terminal/autocomplete/terminalAutocompleteKeyEvent.ts
+++ b/components/terminal/autocomplete/terminalAutocompleteKeyEvent.ts
@@ -36,8 +36,9 @@ export function autocompleteEscMetaFollowUpSequence(e: {
   metaKey: boolean;
   shiftKey: boolean;
 }): string | null {
-  if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return null;
-  if (e.key === ".") return "\x1b.";
+  if (e.altKey || e.ctrlKey || e.metaKey) return null;
+  // `_` is Shift+Minus on a standard keyboard; Shift+. is `>` and must not yank.
+  if (e.key === "." && !e.shiftKey) return "\x1b.";
   if (e.key === "_") return "\x1b_";
   return null;
 }

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -276,6 +276,8 @@ export function useTerminalAutocomplete(
   const completionAbortRef = useRef<AbortController | null>(null);
   /** Last accepted suggestion text — for accurate history recording on fast Enter after accept */
   const lastAcceptedCommandRef = useRef<string | null>(null);
+  /** Deadline for treating the next `.` / `_` as readline Meta after Esc dismissed the popup. */
+  const escMetaPrefixUntilRef = useRef(0);
   /** The user's typed input that produced the current popup suggestions (live-preview baseline). */
   const previewBaselineRef = useRef<string>("");
   /** Whether a popup candidate is currently rendered into the command line (#1005). */
@@ -1146,6 +1148,7 @@ export function useTerminalAutocomplete(
       typedBufferReliableRef,
       previewActiveRef,
       lastAcceptedCommandRef,
+      escMetaPrefixUntilRef,
       setState,
       expandSubDir,
       writeToTerminal,

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -82,6 +82,7 @@ import {
 import { installUserCursorPreferenceGuard } from "./cursorPreference";
 import { terminalAltKeyOptions } from "./altKeyOptions";
 import { optionArrowWordJumpSequence } from "./optionArrowWordJump";
+import { optionYankLastArgSequence } from "./optionYankLastArg";
 import { watchDevicePixelRatio } from "./rendererDprWatch";
 import { shouldDeferWebglUntilVisible } from "./webglRendererPolicy";
 import { createWebglRendererController } from "./webglRendererController";
@@ -1914,6 +1915,22 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         e.stopPropagation();
         handleTerminalInputData(wordJumpSequence);
         scrollToBottomAfterInput(wordJumpSequence);
+        return false;
+      }
+    }
+
+    // macOS Option+. / Option+_ → ESC+. / ESC+_ so readline yank-last-arg and
+    // zsh insert-last-word work without enabling Option-as-Meta (issue #2364).
+    const yankLastArgSequence = isKittyKeyboardModeActive(kittyKeyboardMode)
+      ? null
+      : optionYankLastArgSequence(e, isMacPlatform());
+    if (yankLastArgSequence) {
+      const id = ctx.sessionRef.current;
+      if (id) {
+        e.preventDefault();
+        e.stopPropagation();
+        handleTerminalInputData(yankLastArgSequence);
+        scrollToBottomAfterInput(yankLastArgSequence);
         return false;
       }
     }

--- a/components/terminal/runtime/optionYankLastArg.test.ts
+++ b/components/terminal/runtime/optionYankLastArg.test.ts
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { optionYankLastArgSequence } from "./optionYankLastArg";
+
+// Issue #2364: Esc+. / Alt+. is readline yank-last-arg (zsh insert-last-word).
+// Traditional terminals just pass Meta-. through. On macOS, Option+. types "≥"
+// unless Option is Meta, so map the physical period / underscore keys to ESC+.
+// / ESC+_ — same idea as Option+←/→ word-jump, but always-on because ≥ is
+// almost never wanted in a terminal.
+
+const ev = (over: Partial<Parameters<typeof optionYankLastArgSequence>[0]> = {}) => ({
+  key: ".",
+  code: "Period",
+  altKey: true,
+  ctrlKey: false,
+  metaKey: false,
+  shiftKey: false,
+  ...over,
+});
+
+test("Option+. → ESC+. (yank-last-arg) on macOS", () => {
+  assert.equal(optionYankLastArgSequence(ev(), true), "\x1b.");
+});
+
+test("Option+. with composed ≥ (US layout) still maps to ESC+.", () => {
+  assert.equal(
+    optionYankLastArgSequence(ev({ key: "≥", code: "Period" }), true),
+    "\x1b.",
+  );
+});
+
+test("Option+_ → ESC+_ (yank-last-arg synonym) on macOS", () => {
+  assert.equal(
+    optionYankLastArgSequence(ev({ key: "_", code: "Minus", shiftKey: true }), true),
+    "\x1b_",
+  );
+});
+
+test("not macOS → null (Linux/Windows Alt+. already sends Meta via xterm)", () => {
+  assert.equal(optionYankLastArgSequence(ev(), false), null);
+  assert.equal(
+    optionYankLastArgSequence(ev({ key: "_", code: "Minus", shiftKey: true }), false),
+    null,
+  );
+});
+
+test("no Option held → null", () => {
+  assert.equal(optionYankLastArgSequence(ev({ altKey: false }), true), null);
+});
+
+test("Ctrl/Cmd with Option → null (don't hijack other chords)", () => {
+  assert.equal(optionYankLastArgSequence(ev({ ctrlKey: true }), true), null);
+  assert.equal(optionYankLastArgSequence(ev({ metaKey: true }), true), null);
+});
+
+test("Option+Shift+. (>) → null", () => {
+  assert.equal(optionYankLastArgSequence(ev({ shiftKey: true }), true), null);
+});
+
+test("other Option keys → null", () => {
+  assert.equal(optionYankLastArgSequence(ev({ key: "f", code: "KeyF" }), true), null);
+  assert.equal(optionYankLastArgSequence(ev({ key: "ArrowLeft", code: "ArrowLeft" }), true), null);
+});
+
+test("runtime sends Option+. after kitty mode, same as word-jump", () => {
+  const source = readFileSync(new URL("./createXTermRuntime.ts", import.meta.url), "utf8");
+  assert.match(source, /from "\.\/optionYankLastArg"/);
+  assert.match(
+    source,
+    /optionArrowWordJumpSequence\([\s\S]*?const yankLastArgSequence = isKittyKeyboardModeActive\(kittyKeyboardMode\)\s*\? null\s*: optionYankLastArgSequence\(/s,
+  );
+});

--- a/components/terminal/runtime/optionYankLastArg.ts
+++ b/components/terminal/runtime/optionYankLastArg.ts
@@ -1,0 +1,37 @@
+export interface OptionYankLastArgKeyEvent {
+  key: string;
+  code?: string;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+}
+
+const isPeriodKey = (e: OptionYankLastArgKeyEvent): boolean => (
+  e.code === "Period" || e.key === "." || e.key === "≥"
+);
+
+const isUnderscoreKey = (e: OptionYankLastArgKeyEvent): boolean => (
+  e.key === "_" || (e.code === "Minus" && e.shiftKey)
+);
+
+/**
+ * macOS Option+. / Option+_ → readline yank-last-arg (issue #2364).
+ *
+ * Ghostty/iTerm2/kitty/VS Code do not implement this themselves — they pass
+ * Meta-. through to bash/zsh. On macOS, Option+. types "≥" unless Option is
+ * Meta, so map those two physical keys to ESC+. / ESC+_ without turning every
+ * Option chord into Meta (unlike `altAsMeta`).
+ *
+ * Gated to macOS: Linux/Windows Alt+. already sends the ESC prefix via xterm.
+ */
+export function optionYankLastArgSequence(
+  e: OptionYankLastArgKeyEvent,
+  isMac: boolean,
+): string | null {
+  if (!isMac) return null;
+  if (!e.altKey || e.ctrlKey || e.metaKey) return null;
+  if (isPeriodKey(e) && !e.shiftKey) return "\x1b.";
+  if (isUnderscoreKey(e)) return "\x1b_";
+  return null;
+}

--- a/components/terminal/terminalAutocompleteKeyEvent.test.ts
+++ b/components/terminal/terminalAutocompleteKeyEvent.test.ts
@@ -266,6 +266,26 @@ test("Esc+_ after dismissing the popup sends ESC+_ to the shell", () => {
   assert.deepEqual(writes, ["\x1b_"]);
 });
 
+test("Esc then Shift keydown then _ still yanks (Shift is a separate event)", () => {
+  const { context, writes } = createContext();
+  handleTerminalAutocompleteKeyEvent(keyEvent("Escape"), context);
+  context.stateRef.current = {
+    ...context.stateRef.current,
+    popupVisible: false,
+    suggestions: [],
+  };
+
+  const shiftDown = shiftKeyEvent("Shift");
+  assert.equal(handleTerminalAutocompleteKeyEvent(shiftDown, context), true);
+  assert.ok(context.escMetaPrefixUntilRef.current > 1_000);
+
+  const underscore = shiftKeyEvent("_");
+  const result = handleTerminalAutocompleteKeyEvent(underscore, context);
+
+  assert.equal(result, false);
+  assert.deepEqual(writes, ["\x1b_"]);
+});
+
 test("Esc then a non-Meta follow-up does not inject ESC and lets the key through", () => {
   const { context, writes } = createContext();
   handleTerminalAutocompleteKeyEvent(keyEvent("Escape"), context);

--- a/components/terminal/terminalAutocompleteKeyEvent.test.ts
+++ b/components/terminal/terminalAutocompleteKeyEvent.test.ts
@@ -232,6 +232,9 @@ test("Esc+. after dismissing the popup sends ESC+. to the shell", () => {
   assert.equal(result, false);
   assert.equal(period.defaultPrevented, true);
   assert.deepEqual(writes, ["\x1b."]);
+  assert.equal(context.typedInputBufferRef.current, "");
+  assert.equal(context.typedBufferReliableRef.current, false);
+  assert.equal(context.lastAcceptedCommandRef.current, null);
 });
 
 test("Esc then Shift+. does not yank (Shift+. is >)", () => {

--- a/components/terminal/terminalAutocompleteKeyEvent.test.ts
+++ b/components/terminal/terminalAutocompleteKeyEvent.test.ts
@@ -73,6 +73,8 @@ function createContext(overrides: Record<string, unknown> = {}) {
       typedBufferReliableRef: { current: true },
       previewActiveRef: { current: false },
       lastAcceptedCommandRef: { current: null },
+      escMetaPrefixUntilRef: { current: 0 },
+      now: () => 1_000,
       setState(update: typeof state | ((prev: typeof state) => typeof state)) {
         state = typeof update === "function" ? update(state) : update;
         stateRef.current = state;
@@ -202,3 +204,108 @@ test("serial-style popup Shift+Enter confirms candidate when terminal shortcut i
   assert.deepEqual(accepted, [0]);
   assert.deepEqual(clears, []);
 });
+
+test("Esc dismisses the popup and arms Meta prefix so Esc+. can yank-last-arg", () => {
+  const { context, clears } = createContext();
+  const event = keyEvent("Escape");
+
+  const result = handleTerminalAutocompleteKeyEvent(event, context);
+
+  assert.equal(result, false);
+  assert.equal(event.defaultPrevented, true);
+  assert.deepEqual(clears, [1]);
+  assert.ok(context.escMetaPrefixUntilRef.current > 1_000);
+});
+
+test("Esc+. after dismissing the popup sends ESC+. to the shell", () => {
+  const { context, writes } = createContext();
+  handleTerminalAutocompleteKeyEvent(keyEvent("Escape"), context);
+  context.stateRef.current = {
+    ...context.stateRef.current,
+    popupVisible: false,
+    suggestions: [],
+  };
+
+  const period = keyEvent(".");
+  const result = handleTerminalAutocompleteKeyEvent(period, context);
+
+  assert.equal(result, false);
+  assert.equal(period.defaultPrevented, true);
+  assert.deepEqual(writes, ["\x1b."]);
+});
+
+test("Esc+_ after dismissing the popup sends ESC+_ to the shell", () => {
+  const { context, writes } = createContext();
+  handleTerminalAutocompleteKeyEvent(keyEvent("Escape"), context);
+  context.stateRef.current = {
+    ...context.stateRef.current,
+    popupVisible: false,
+    suggestions: [],
+  };
+
+  const underscore = keyEvent("_");
+  const result = handleTerminalAutocompleteKeyEvent(underscore, context);
+
+  assert.equal(result, false);
+  assert.deepEqual(writes, ["\x1b_"]);
+});
+
+test("Esc then a non-Meta follow-up does not inject ESC and lets the key through", () => {
+  const { context, writes } = createContext();
+  handleTerminalAutocompleteKeyEvent(keyEvent("Escape"), context);
+  context.stateRef.current = {
+    ...context.stateRef.current,
+    popupVisible: false,
+    suggestions: [],
+  };
+
+  const letter = keyEvent("l");
+  const result = handleTerminalAutocompleteKeyEvent(letter, context);
+
+  assert.equal(result, true);
+  assert.deepEqual(writes, []);
+  assert.equal(context.escMetaPrefixUntilRef.current, 0);
+});
+
+test("Esc+. after the Meta prefix timeout does not yank", () => {
+  let now = 1_000;
+  const { context, writes } = createContext({ now: () => now });
+  handleTerminalAutocompleteKeyEvent(keyEvent("Escape"), context);
+  context.stateRef.current = {
+    ...context.stateRef.current,
+    popupVisible: false,
+    suggestions: [],
+  };
+  now = 1_000 + 501;
+
+  const period = keyEvent(".");
+  const result = handleTerminalAutocompleteKeyEvent(period, context);
+
+  assert.equal(result, true);
+  assert.deepEqual(writes, []);
+});
+
+test("subdir Escape does not arm Meta prefix", () => {
+  const { context, clears } = createContext({
+    stateRef: {
+      current: {
+        suggestions: [suggestion("show version")],
+        selectedIndex: 0,
+        popupVisible: true,
+        popupAnchorViewport: { left: 0, top: 0, bottom: 0 },
+        expandUpward: false,
+        subDirPanels: [{ entries: [{ name: "src", type: "directory" }], selectedIndex: 0, dirPath: "/src" }],
+        subDirFocusLevel: 0,
+      },
+    },
+  });
+  const event = keyEvent("Escape");
+
+  const result = handleTerminalAutocompleteKeyEvent(event, context);
+
+  assert.equal(result, false);
+  assert.equal(event.defaultPrevented, true);
+  assert.deepEqual(clears, []);
+  assert.equal(context.escMetaPrefixUntilRef.current, 0);
+});
+

--- a/components/terminal/terminalAutocompleteKeyEvent.test.ts
+++ b/components/terminal/terminalAutocompleteKeyEvent.test.ts
@@ -234,6 +234,22 @@ test("Esc+. after dismissing the popup sends ESC+. to the shell", () => {
   assert.deepEqual(writes, ["\x1b."]);
 });
 
+test("Esc then Shift+. does not yank (Shift+. is >)", () => {
+  const { context, writes } = createContext();
+  handleTerminalAutocompleteKeyEvent(keyEvent("Escape"), context);
+  context.stateRef.current = {
+    ...context.stateRef.current,
+    popupVisible: false,
+    suggestions: [],
+  };
+
+  const greaterThan = shiftKeyEvent(">");
+  const result = handleTerminalAutocompleteKeyEvent(greaterThan, context);
+
+  assert.equal(result, true);
+  assert.deepEqual(writes, []);
+});
+
 test("Esc+_ after dismissing the popup sends ESC+_ to the shell", () => {
   const { context, writes } = createContext();
   handleTerminalAutocompleteKeyEvent(keyEvent("Escape"), context);
@@ -243,7 +259,7 @@ test("Esc+_ after dismissing the popup sends ESC+_ to the shell", () => {
     suggestions: [],
   };
 
-  const underscore = keyEvent("_");
+  const underscore = shiftKeyEvent("_");
   const result = handleTerminalAutocompleteKeyEvent(underscore, context);
 
   assert.equal(result, false);


### PR DESCRIPTION
## Summary

`Esc+.` / `Alt+.` is readline `yank-last-arg` (zsh `insert-last-word`): insert the last argument of the previous command. Traditional terminals just pass Meta-. through to the shell. Autocomplete was swallowing Escape, and macOS Option+. typed `≥` instead of ESC+., so the shortcut never reached bash/zsh.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2364

## Changes Made

- After dismissing the autocomplete popup, Esc then `.` / `_` within 500ms is forwarded as ESC+. / ESC+_
- On macOS, Option+. / Option+_ map to those same sequences without enabling Option-as-Meta
- Linux/Windows Alt+. is unchanged (xterm already sends Meta)

## Screenshots / Demo

Run a command with an argument (`mkdir /tmp/foo`), type a new command (`cd `), then press Esc+. or Option+. (macOS). The last argument should be inserted.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Targeted unit tests for `optionYankLastArg` and autocomplete Esc+. follow-up: 20 passing.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)


Made with [Cursor](https://cursor.com)