### PR TITLE
fix(terminal): keep hidden focus-mode panes full-size to stop \r progress spam

### DIFF
--- a/application/state/sessionWorkspaceDetach.test.ts
+++ b/application/state/sessionWorkspaceDetach.test.ts
@@ -125,6 +125,30 @@ test("closing a workspace session dissolves the workspace when one terminal rema
   );
 });
 
+test("closing the focused session hands focus to a remaining session (#3046)", () => {
+  const result = closeSessionWorkspaceLayoutState(
+    [workspace(["s1", "s2", "s3", "s4"])],
+    "ws-1",
+    "s1",
+  );
+
+  assert.equal(result.workspaces.length, 1);
+  assert.equal(result.workspaces[0].focusedSessionId, "s2");
+  assert.deepEqual(result.workspaces[0].focusSessionOrder, ["s2", "s3", "s4"]);
+});
+
+test("closing a non-focused session keeps the focused session", () => {
+  const result = closeSessionWorkspaceLayoutState(
+    [workspace(["s1", "s2", "s3", "s4"])],
+    "ws-1",
+    "s3",
+  );
+
+  assert.equal(result.workspaces.length, 1);
+  assert.equal(result.workspaces[0].focusedSessionId, "s1");
+  assert.deepEqual(result.workspaces[0].focusSessionOrder, ["s1", "s2", "s4"]);
+});
+
 test("closing one split pane keeps the other terminal as an orphan tab", () => {
   const layoutResult = closeSessionWorkspaceLayoutState(
     [workspace(["s1", "s2"])],

--- a/application/state/sessionWorkspaceDetach.ts
+++ b/application/state/sessionWorkspaceDetach.ts
@@ -96,7 +96,24 @@ export function closeSessionWorkspaceLayoutState(
         return null;
       }
 
-      return { ...workspace, root: prunedRoot };
+      // Closing the focused session must hand focus to a remaining one, or a
+      // focus-mode workspace is left with a dangling focusedSessionId: no pane
+      // qualifies as visible and the continuously rendered hidden panes all
+      // paint on top of each other (#3046).
+      const nextFocusedSessionId =
+        workspace.focusedSessionId && !remainingSessionIds.includes(workspace.focusedSessionId)
+          ? remainingSessionIds[0]
+          : workspace.focusedSessionId;
+      const nextFocusSessionOrder = workspace.focusSessionOrder?.filter(
+        (candidateId) => remainingSessionIds.includes(candidateId),
+      );
+
+      return {
+        ...workspace,
+        root: prunedRoot,
+        focusedSessionId: nextFocusedSessionId,
+        focusSessionOrder: nextFocusSessionOrder,
+      };
     })
     .filter((workspace): workspace is Workspace => Boolean(workspace));
 

--- a/components/terminal/terminalContinuousRendering.test.ts
+++ b/components/terminal/terminalContinuousRendering.test.ts
@@ -64,6 +64,13 @@ test("background split workspaces keep their live geometry without hibernate", (
     supportSource,
     /if \(isVisible && !rect\) \{[\s\S]*const observer = new ResizeObserver\(\(\) => \{[\s\S]*capturePaneSize\(\)/,
   );
+  // A split-visible pane must drop the cached full-size measurement so a later
+  // hidden full-size layout re-measures the current area instead of pinning
+  // stale pixels (#3046).
+  assert.match(
+    supportSource,
+    /if \(isVisible\) \{[\s\S]{0,400}lastVisiblePaneSizeRef\.current = null;[\s\S]{0,20}return;/,
+  );
   assert.match(
     layerEffectsSource,
     /if \(!shouldMeasureTerminalLayerLayout\) return;[\s\S]*?remeasureWorkspaceArea\(\)/,

--- a/components/terminal/terminalContinuousRendering.test.ts
+++ b/components/terminal/terminalContinuousRendering.test.ts
@@ -57,9 +57,12 @@ test("background split workspaces keep their live geometry without hibernate", (
     supportSource,
     /const initializeHiddenFullSize = !hibernateHiddenTabs[\s\S]*&& !rect[\s\S]*&& !lastVisiblePaneSizeRef\.current;[\s\S]*bumpHiddenPaneSizeVersion/,
   );
+  // Split rects must never feed the hidden-pane pinned size, or a
+  // split -> focus viewMode switch pins hidden panes (and their PTYs) at the
+  // cached fragment width (#3046).
   assert.match(
     supportSource,
-    /if \(isVisible\) \{[\s\S]*const observer = new ResizeObserver\(\(\) => \{[\s\S]*capturePaneSize\(\)/,
+    /if \(isVisible && !rect\) \{[\s\S]*const observer = new ResizeObserver\(\(\) => \{[\s\S]*capturePaneSize\(\)/,
   );
   assert.match(
     layerEffectsSource,

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -1330,7 +1330,11 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
       return true;
     };
 
-    if (isVisible) {
+    // Only full-size layouts may feed the hidden-pane pinned size. Split rects
+    // must never be cached: after a split -> focus viewMode switch the cached
+    // fragment size would pin the hidden pane (and its PTY) narrow again,
+    // recreating the \r progress-refresh scrollback spam (#3046).
+    if (isVisible && !rect) {
       capturePaneSize();
       const observer = new ResizeObserver(() => {
         capturePaneSize();
@@ -1338,6 +1342,7 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
       observer.observe(element);
       return () => observer.disconnect();
     }
+    if (isVisible) return;
 
     const initializeHiddenFullSize = !hibernateHiddenTabs
       && !rect

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -1342,7 +1342,14 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
       observer.observe(element);
       return () => observer.disconnect();
     }
-    if (isVisible) return;
+    if (isVisible) {
+      // A split-visible pane invalidates the cached full-size measurement:
+      // after an intervening viewport resize the stale pixels would pin later
+      // hidden full-size layouts at the wrong width (#3046). The hidden
+      // initialization below re-measures the current area instead.
+      lastVisiblePaneSizeRef.current = null;
+      return;
+    }
 
     const initializeHiddenFullSize = !hibernateHiddenTabs
       && !rect

--- a/components/terminalPaneVisibility.test.tsx
+++ b/components/terminalPaneVisibility.test.tsx
@@ -142,7 +142,7 @@ test("terminal pane render snapshot combines visibility and focus in one token",
   assert.equal(parsed.isFocusedPane, true);
 });
 
-test("hidden focus workspaces keep the focused pane full-size and other panes split", () => {
+test("focus workspaces never use split geometry so hidden panes keep full size (#3046)", () => {
   const workspace = createWorkspace("ws-focus", ["f-1", "f-2"], {
     viewMode: "focus",
     focusedSessionId: "f-2",
@@ -154,12 +154,15 @@ test("hidden focus workspaces keep the focused pane full-size and other panes sp
     isVisible: false,
     hibernateHiddenTabs: false,
   }), false);
+  // A hidden, non-focused pane must not fall back to its split rect: the
+  // continuously rendered xterm and the remote PTY would shrink to a 1/N-width
+  // fragment and \r progress refreshes would wrap into scrollback spam.
   assert.equal(shouldUseTerminalPaneSplitLayout({
     workspace,
     sessionId: "f-1",
     isVisible: false,
     hibernateHiddenTabs: false,
-  }), true);
+  }), false);
   assert.equal(shouldUseTerminalPaneSplitLayout({
     workspace,
     sessionId: "f-1",

--- a/components/terminalPaneVisibility.ts
+++ b/components/terminalPaneVisibility.ts
@@ -28,9 +28,6 @@ export type TerminalPaneStyle = {
 
 export function shouldUseTerminalPaneSplitLayout({
   workspace,
-  sessionId,
-  isVisible,
-  hibernateHiddenTabs,
 }: {
   workspace: Workspace | undefined;
   sessionId: string;
@@ -39,14 +36,12 @@ export function shouldUseTerminalPaneSplitLayout({
 }): boolean {
   if (!workspace) return false;
   // Default viewMode is tiled split (including undefined from createWorkspaceFromSessions).
-  // Only focus mode uses a full-size focused pane; other panes keep split geometry while
-  // continuously rendered in the background.
-  if (workspace.viewMode === "focus") {
-    return !isVisible
-      && !hibernateHiddenTabs
-      && workspace.focusedSessionId !== sessionId;
-  }
-  return true;
+  // Focus mode never uses split geometry: every pane is viewed full-size, so hidden
+  // panes must keep full-size geometry too. Laying continuously rendered background
+  // panes out at their split rects shrank the live xterm and the remote PTY to a
+  // 1/N-width fragment, so \r-refresh progress output (e.g. rsync --info=progress2)
+  // soft-wrapped and left one scrollback line per refresh (#3046).
+  return workspace.viewMode !== "focus";
 }
 
 export function shouldMeasureTerminalLayerLayout({


### PR DESCRIPTION
## Summary

In a multi-host workspace (focus view), a backgrounded SSH session running a command with `\r`-refresh progress output (e.g. `rsync --info=progress2`) flooded the terminal with one line per refresh when the host was focused again.

Root cause chain (all defaults, hence the 100% repro in #3046):

1. Multi-host workspaces created via QuickSwitcher default to `viewMode: 'focus'`.
2. Terminal hibernate is off by default, so hidden panes stay continuously rendered (#2096).
3. `shouldUseTerminalPaneSplitLayout` laid hidden non-focused focus-mode panes out at their **split rects** (~1/N of the workspace width for N hosts), even though focus-mode panes are always *viewed* full-size.
4. With the renderer active, the container `ResizeObserver` triggers `safeFit(...)` (the `requireVisible` option is not evaluated by `safeFit`), which resizes xterm and, via `term.onResize` → `resizeSession`, shrinks the **remote PTY** to the fragment width.
5. The progress line exceeds the narrow width and soft-wraps; `\r` only returns to the start of the last wrapped row, so every refresh leaves one fragment line in scrollback. Switching back reveals them all as spam — the screenshot's lines are all truncated at the same narrow column.

Fix: focus mode never uses split geometry. Hidden panes keep full-size geometry — the same size they are viewed at when focused, and consistent with how hidden solo tabs already behave under continuous rendering. This also removes the PTY resize churn (SIGWINCH to every host) on each focus switch.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3046

## Changes Made

- `application/state/sessionWorkspaceDetach.ts`: closing the focused session now hands focus to a remaining session and drops closed ids from `focusSessionOrder` (matches the detach path). Previously a focus-mode workspace was left with a dangling `focusedSessionId`, so no pane qualified as visible and the continuously rendered hidden panes painted on top of each other — the overlapping-terminals follow-up reported in #3046.
- `components/terminalPaneVisibility.ts`: `shouldUseTerminalPaneSplitLayout` returns `false` for focus-mode workspaces unconditionally (previously hidden non-focused panes returned `true` when hibernate was off).
- `components/terminalPaneVisibility.test.tsx`: updated the focus-mode expectations to assert hidden panes never fall back to split rects.

## Screenshots / Demo

Behavior change only: backgrounded focus-mode panes keep the full-size PTY, so `rsync --info=progress2` keeps refreshing a single line while the host is not focused.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

Made with [Cursor](https://cursor.com)
