### PR TITLE
fix(mcp): accept omitted arguments for no-arg tools

### DIFF
--- a/electron/capabilities/codegen/mcpToolRegistry.cjs
+++ b/electron/capabilities/codegen/mcpToolRegistry.cjs
@@ -45,6 +45,10 @@ function buildZodSchema(inputShape) {
   return z.object(buildZodShapeObject(inputShape));
 }
 
+function isEmptyMcpInputShape(inputShape) {
+  return Object.keys(inputShape || {}).length === 0;
+}
+
 function formatRpcError(result) {
   if (result?.error) return `Error: ${result.error}`;
   if (result?.code) return `Error: Operation failed (${result.code})`;
@@ -229,10 +233,15 @@ function registerMcpTools(server, deps) {
   const tools = listMcpTools();
   for (const toolDef of tools) {
     if (!toolDef.mcpTool || !toolDef.rpcMethod) continue;
-    const schemaShape = buildZodShapeObject(toolDef.inputShape);
     const handler = createToolHandler(toolDef, deps);
     const toolDescription = deps.catalogDescription(toolDef.mcpTool, toolDef.description);
-    server.tool(toolDef.mcpTool, toolDescription, schemaShape, handler);
+    // Empty Zod objects reject omitted `arguments`. MCP allows omitting them
+    // for no-arg tools; skip the schema so both omitted and {} are valid.
+    if (isEmptyMcpInputShape(toolDef.inputShape)) {
+      server.tool(toolDef.mcpTool, toolDescription, async () => handler({}));
+      continue;
+    }
+    server.tool(toolDef.mcpTool, toolDescription, buildZodShapeObject(toolDef.inputShape), handler);
   }
   return tools.length;
 }
@@ -240,6 +249,7 @@ function registerMcpTools(server, deps) {
 module.exports = {
   buildZodSchema,
   buildZodShapeObject,
+  isEmptyMcpInputShape,
   formatRpcError,
   formatTerminalExecuteResult,
   formatTerminalExecuteMcpResponse,

--- a/electron/capabilities/codegen/toolSurfaces.test.cjs
+++ b/electron/capabilities/codegen/toolSurfaces.test.cjs
@@ -11,7 +11,11 @@ const {
   CATTY_CAPABILITY_DENYLIST,
   isCattyEligible,
 } = require("./toolSurfaces.cjs");
-const { registerMcpTools, buildZodShapeObject } = require("./mcpToolRegistry.cjs");
+const { registerMcpTools, buildZodShapeObject, isEmptyMcpInputShape } = require("./mcpToolRegistry.cjs");
+
+function mcpToolHandler(schemaOrHandler, maybeHandler) {
+  return typeof schemaOrHandler === "function" ? schemaOrHandler : maybeHandler;
+}
 
 test("listCattyToolSpecs includes terminal long-running tools", () => {
   const specs = listCattyToolSpecs();
@@ -229,8 +233,8 @@ test("mcp registry builds zod shapes for every MCP tool", () => {
 test("registerMcpTools registers one handler per catalog MCP tool", () => {
   const registered = [];
   const fakeServer = {
-    tool(name, _description, _shape, handler) {
-      registered.push({ name, handler: typeof handler });
+    tool(name, _description, schemaOrHandler, maybeHandler) {
+      registered.push({ name, handler: typeof mcpToolHandler(schemaOrHandler, maybeHandler) });
     },
   };
   const count = registerMcpTools(fakeServer, {
@@ -243,12 +247,70 @@ test("registerMcpTools registers one handler per catalog MCP tool", () => {
   assert.equal(registered.length, listMcpTools().length);
 });
 
+test("no-arg MCP tools register without a params schema so omitted arguments are valid (#3049)", () => {
+  const registrations = [];
+  const fakeServer = {
+    tool(name, _description, schemaOrHandler, maybeHandler) {
+      registrations.push({
+        name,
+        hasSchema: typeof schemaOrHandler !== "function",
+        handler: mcpToolHandler(schemaOrHandler, maybeHandler),
+      });
+    },
+  };
+  registerMcpTools(fakeServer, {
+    rpcCall: async () => ({ ok: true }),
+    scopeParams: {},
+    guardWriteOperation: () => null,
+    catalogDescription: (_name, fallback) => fallback,
+  });
+
+  const noArgNames = listMcpTools()
+    .filter((tool) => isEmptyMcpInputShape(tool.inputShape))
+    .map((tool) => tool.mcpTool);
+  assert.ok(noArgNames.includes("get_environment"));
+  assert.ok(noArgNames.includes("list_attachments"));
+
+  for (const name of noArgNames) {
+    const registration = registrations.find((entry) => entry.name === name);
+    assert.equal(registration?.hasSchema, false, `${name} should omit the params schema`);
+  }
+
+  const execute = registrations.find((entry) => entry.name === "terminal_execute");
+  assert.equal(execute?.hasSchema, true);
+});
+
+test("get_environment handler runs when MCP arguments are omitted (#3049)", async () => {
+  let handler = null;
+  const fakeServer = {
+    tool(name, _description, schemaOrHandler, maybeHandler) {
+      if (name === "get_environment") handler = mcpToolHandler(schemaOrHandler, maybeHandler);
+    },
+  };
+  let rpcMethod = null;
+  registerMcpTools(fakeServer, {
+    rpcCall: async (method) => {
+      rpcMethod = method;
+      return { sessions: [] };
+    },
+    scopeParams: { chatSessionId: "chat-1" },
+    guardWriteOperation: () => null,
+    catalogDescription: (_name, fallback) => fallback,
+  });
+
+  assert.ok(handler, "get_environment handler registered");
+  const result = await handler();
+  assert.equal(result.isError, undefined);
+  assert.equal(rpcMethod, "netcatty/getContext");
+  assert.match(result.content?.[0]?.text || "", /sessions/);
+});
+
 test("session_close remains available as a cleanup action in observer mode", async () => {
   let handler = null;
   let guardCalls = 0;
   const fakeServer = {
-    tool(name, _description, _shape, candidate) {
-      if (name === "session_close") handler = candidate;
+    tool(name, _description, schemaOrHandler, maybeHandler) {
+      if (name === "session_close") handler = mcpToolHandler(schemaOrHandler, maybeHandler);
     },
   };
   registerMcpTools(fakeServer, {
@@ -269,8 +331,8 @@ test("session_close remains available as a cleanup action in observer mode", asy
 test("terminal_execute MCP response preserves stdout/exitCode on non-zero exit (#2718)", async () => {
   let handler = null;
   const fakeServer = {
-    tool(name, _description, _shape, candidate) {
-      if (name === "terminal_execute") handler = candidate;
+    tool(name, _description, schemaOrHandler, maybeHandler) {
+      if (name === "terminal_execute") handler = mcpToolHandler(schemaOrHandler, maybeHandler);
     },
   };
   registerMcpTools(fakeServer, {
@@ -297,8 +359,8 @@ test("terminal_execute MCP response preserves stdout/exitCode on non-zero exit (
 test("terminal_execute MCP response keeps operational failures as isError", async () => {
   let handler = null;
   const fakeServer = {
-    tool(name, _description, _shape, candidate) {
-      if (name === "terminal_execute") handler = candidate;
+    tool(name, _description, schemaOrHandler, maybeHandler) {
+      if (name === "terminal_execute") handler = mcpToolHandler(schemaOrHandler, maybeHandler);
     },
   };
   registerMcpTools(fakeServer, {
@@ -316,8 +378,8 @@ test("terminal_execute MCP response keeps operational failures as isError", asyn
 test("terminal_execute MCP response includes partial output on timeout", async () => {
   let handler = null;
   const fakeServer = {
-    tool(name, _description, _shape, candidate) {
-      if (name === "terminal_execute") handler = candidate;
+    tool(name, _description, schemaOrHandler, maybeHandler) {
+      if (name === "terminal_execute") handler = mcpToolHandler(schemaOrHandler, maybeHandler);
     },
   };
   registerMcpTools(fakeServer, {
@@ -344,8 +406,8 @@ test("terminal_execute MCP response includes partial output on timeout", async (
 test("terminal_execute MCP response uses neutral text for successful empty output (#2724)", async () => {
   let handler = null;
   const fakeServer = {
-    tool(name, _description, _shape, candidate) {
-      if (name === "terminal_execute") handler = candidate;
+    tool(name, _description, schemaOrHandler, maybeHandler) {
+      if (name === "terminal_execute") handler = mcpToolHandler(schemaOrHandler, maybeHandler);
     },
   };
   // Serial/network-device raw PTY success: ok true, empty streams, exitCode null.
@@ -370,8 +432,8 @@ test("terminal_execute MCP response uses neutral text for successful empty outpu
 test("terminal_execute MCP response keeps exit-only non-zero without isError", async () => {
   let handler = null;
   const fakeServer = {
-    tool(name, _description, _shape, candidate) {
-      if (name === "terminal_execute") handler = candidate;
+    tool(name, _description, schemaOrHandler, maybeHandler) {
+      if (name === "terminal_execute") handler = mcpToolHandler(schemaOrHandler, maybeHandler);
     },
   };
   registerMcpTools(fakeServer, {

--- a/electron/mcp/netcatty-mcp-server.cjs
+++ b/electron/mcp/netcatty-mcp-server.cjs
@@ -13,6 +13,7 @@ const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
 const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
 const { getCatalogToolDescription } = require("./catalogToolMetadata.cjs");
 const { registerMcpTools } = require("../capabilities/codegen/mcpToolRegistry.cjs");
+const { normalizeMcpJsonRpcMessage } = require("./normalizeMcpCallArguments.cjs");
 
 function catalogDescription(toolName, fallback) {
   return getCatalogToolDescription(toolName) || fallback;
@@ -255,6 +256,10 @@ async function main() {
   process.stderr.write("[netcatty-mcp] Authenticated with TCP bridge\n");
 
   const transport = new StdioServerTransport();
+  // Protocol.connect keeps this callback and runs it before request dispatch.
+  transport.onmessage = (message) => {
+    normalizeMcpJsonRpcMessage(message);
+  };
   await server.connect(transport);
 }
 

--- a/electron/mcp/normalizeMcpCallArguments.cjs
+++ b/electron/mcp/normalizeMcpCallArguments.cjs
@@ -1,0 +1,27 @@
+"use strict";
+
+/**
+ * MCP tools/call `arguments` is optional. Clients may omit it for no-arg
+ * tools or send {}. The SDK still parses omitted args as `undefined`, and
+ * Zod object schemas reject that. Treat missing/null as {}.
+ */
+
+function normalizeMcpToolArguments(args) {
+  return args == null ? {} : args;
+}
+
+function normalizeMcpJsonRpcMessage(message) {
+  if (!message || typeof message !== "object") return message;
+  if (message.method !== "tools/call") return message;
+  const params = message.params;
+  if (!params || typeof params !== "object" || Array.isArray(params)) return message;
+  if (params.arguments == null) {
+    params.arguments = {};
+  }
+  return message;
+}
+
+module.exports = {
+  normalizeMcpToolArguments,
+  normalizeMcpJsonRpcMessage,
+};

--- a/electron/mcp/normalizeMcpCallArguments.test.cjs
+++ b/electron/mcp/normalizeMcpCallArguments.test.cjs
@@ -1,0 +1,66 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  normalizeMcpToolArguments,
+  normalizeMcpJsonRpcMessage,
+} = require("./normalizeMcpCallArguments.cjs");
+
+test("normalizeMcpToolArguments treats omitted and null as empty object", () => {
+  assert.deepEqual(normalizeMcpToolArguments(undefined), {});
+  assert.deepEqual(normalizeMcpToolArguments(null), {});
+});
+
+test("normalizeMcpToolArguments leaves provided arguments unchanged", () => {
+  const args = { sessionId: "s1" };
+  assert.equal(normalizeMcpToolArguments(args), args);
+  assert.deepEqual(normalizeMcpToolArguments({}), {});
+});
+
+test("tools/call with omitted arguments becomes an empty object (#3049)", () => {
+  const message = {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name: "get_environment" },
+  };
+  const out = normalizeMcpJsonRpcMessage(message);
+  assert.equal(out, message);
+  assert.deepEqual(out.params.arguments, {});
+  assert.equal(out.params.name, "get_environment");
+});
+
+test("tools/call with null arguments becomes an empty object (#3049)", () => {
+  const message = {
+    method: "tools/call",
+    params: { name: "list_attachments", arguments: null },
+  };
+  normalizeMcpJsonRpcMessage(message);
+  assert.deepEqual(message.params.arguments, {});
+});
+
+test("tools/call with {} or real arguments is left alone", () => {
+  const empty = {};
+  const emptyMessage = {
+    method: "tools/call",
+    params: { name: "get_environment", arguments: empty },
+  };
+  assert.equal(normalizeMcpJsonRpcMessage(emptyMessage).params.arguments, empty);
+
+  const args = { sessionId: "s1", command: "uptime" };
+  const realMessage = {
+    method: "tools/call",
+    params: { name: "terminal_execute", arguments: args },
+  };
+  assert.equal(normalizeMcpJsonRpcMessage(realMessage).params.arguments, args);
+});
+
+test("non tools/call messages are unchanged", () => {
+  const initialize = { method: "initialize", params: { protocolVersion: "2024-11-05" } };
+  assert.equal(normalizeMcpJsonRpcMessage(initialize), initialize);
+  assert.equal(initialize.params.arguments, undefined);
+
+  const notification = { method: "notifications/initialized" };
+  assert.equal(normalizeMcpJsonRpcMessage(notification), notification);
+});


### PR DESCRIPTION
## Summary

External MCP clients that omit `tools/call` `arguments` for no-arg tools were rejected. The MCP spec allows omitting `arguments` or sending `{}`. Netcatty registered empty Zod object schemas, and the SDK then parsed omitted args as `undefined`, which those schemas reject.

No-arg tools now register without a params schema, and inbound `tools/call` messages normalize missing/null `arguments` to `{}` so optional-only tools stay compatible too. Tools with required fields still fail validation against `{}`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3049

## Changes Made

- Skip the Zod params schema when a catalog MCP tool has no input fields (`get_environment`, `list_attachments`, list tools, …).
- Normalize omitted/null `tools/call` arguments to `{}` on the stdio transport before SDK dispatch.
- Add unit tests for the protocol helper and for no-arg tool registration/handler invocation.

## Screenshots / Demo

No UI change. External MCP no-arg tools accept both omitted `arguments` and `{}`.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Targeted: `node --test electron/mcp/normalizeMcpCallArguments.test.cjs electron/capabilities/codegen/toolSurfaces.test.cjs` (34 passed). ESLint on the touched files passed.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)