### PR TITLE
fix(ai): do not abort active thinking streams at 2 minutes

### DIFF
--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -521,6 +521,13 @@ function safeReadJson(filePath) {
   }
 }
 
+// Hard cap for a single model HTTP stream. Matches Catty's 30-minute floor so
+// long reasoning can finish; runaway bodies are still bounded by time + size.
+const DEFAULT_AI_STREAM_TOTAL_TIMEOUT_MS = 30 * 60 * 1000;
+// Abort only after this much silence. Thinking tokens re-arm the timer, so an
+// active reasoning stream is not cut off at two minutes (issue #3051).
+const DEFAULT_AI_STREAM_IDLE_TIMEOUT_MS = 2 * 60 * 1000;
+
 /**
  * Start a streaming HTTP request. The returned promise resolves as soon as
  * the HTTP response headers arrive (with { statusCode, statusText }) so the
@@ -558,18 +565,29 @@ async function streamRequest(url, options, event, requestId, skipTLS) {
   const parsedUrl = new URL(url);
   // Register cancellation before any await so Stop during PAC/proxy lookup works.
   const controller = new AbortController();
-  const totalTimeoutMs = Math.max(1, Number(options.totalTimeoutMs) || 120_000);
+  const totalTimeoutMs = Math.max(1, Number(options.totalTimeoutMs) || DEFAULT_AI_STREAM_TOTAL_TIMEOUT_MS);
+  const idleTimeoutMs = Math.max(1, Number(options.idleTimeoutMs) || DEFAULT_AI_STREAM_IDLE_TIMEOUT_MS);
   const maxErrorBodyBytes = Math.max(1, Number(options.maxErrorBodyBytes) || 64 * 1024);
   let lifecycleFinished = false;
+  let idleTimer;
   const finishLifecycle = () => {
     if (lifecycleFinished) return;
     lifecycleFinished = true;
     clearTimeout(totalTimer);
+    clearTimeout(idleTimer);
     activeStreams.delete(requestId);
+  };
+  const noteStreamActivity = () => {
+    if (lifecycleFinished) return;
+    clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      controller.abort(new Error(`AI stream idle deadline exceeded after ${idleTimeoutMs} ms`));
+    }, idleTimeoutMs);
   };
   const totalTimer = setTimeout(() => {
     controller.abort(new Error(`AI stream total deadline exceeded after ${totalTimeoutMs} ms`));
   }, totalTimeoutMs);
+  noteStreamActivity();
   activeStreams.set(requestId, controller);
   if (controller.signal.aborted) {
     finishLifecycle();
@@ -665,6 +683,7 @@ async function streamRequest(url, options, event, requestId, skipTLS) {
           res.destroy?.();
           return;
         }
+        noteStreamActivity();
         // Decode the response as one continuous UTF-8 stream. Calling
         // Buffer#toString() on each network chunk corrupts multi-byte
         // characters when a chunk boundary falls in the middle of one.
@@ -678,6 +697,7 @@ async function streamRequest(url, options, event, requestId, skipTLS) {
           let errorBodyBytes = 0;
           res.on("data", (chunk) => {
             if (streamFinished) return;
+            noteStreamActivity();
             const text = chunk.toString();
             errorBodyBytes += Buffer.byteLength(text);
             if (errorBodyBytes > maxErrorBodyBytes) {
@@ -718,6 +738,7 @@ async function streamRequest(url, options, event, requestId, skipTLS) {
         const MAX_BUFFER_SIZE = 10 * 1024 * 1024; // 10MB safety limit
 
         res.on("data", (chunk) => {
+          noteStreamActivity();
           const previousBufferLength = buffer.length;
           buffer += chunk.toString();
           // Guard against unbounded buffer growth
@@ -986,5 +1007,7 @@ module.exports = {
   buildExternalAgentContextualPrompt,
   _streamRequestForTests: streamRequest,
   _getActiveStreamCountForTests: () => activeStreams.size,
+  DEFAULT_AI_STREAM_TOTAL_TIMEOUT_MS,
+  DEFAULT_AI_STREAM_IDLE_TIMEOUT_MS,
   getExternalMcpController: () => externalMcpController,
 };

--- a/electron/bridges/aiBridge.test.cjs
+++ b/electron/bridges/aiBridge.test.cjs
@@ -298,6 +298,17 @@ test("non-2xx streaming responses are bounded and actively terminated", async ()
   }
 });
 
+test("AI stream default total timeout is long enough for extended reasoning", () => {
+  const { bridge, restore } = loadBridgeWithMocks();
+  try {
+    assert.equal(bridge.DEFAULT_AI_STREAM_IDLE_TIMEOUT_MS, 120_000);
+    assert.equal(bridge.DEFAULT_AI_STREAM_TOTAL_TIMEOUT_MS, 30 * 60 * 1000);
+    assert.ok(bridge.DEFAULT_AI_STREAM_TOTAL_TIMEOUT_MS > bridge.DEFAULT_AI_STREAM_IDLE_TIMEOUT_MS);
+  } finally {
+    restore();
+  }
+});
+
 test("streaming requests enforce a total deadline even while bytes keep arriving", async () => {
   let requestClosed = false;
   let resolveRequestClosed;
@@ -335,6 +346,163 @@ test("streaming requests enforce a total deadline even while bytes keep arriving
       ),
       /total deadline exceeded/i,
     );
+    await Promise.race([
+      requestClosedPromise,
+      new Promise((_, reject) => setTimeout(() => reject(new Error("server request stayed open")), 500)),
+    ]);
+    assert.equal(requestClosed, true);
+    assert.equal(bridge._getActiveStreamCountForTests(), 0);
+  } finally {
+    restore();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("streaming requests do not abort active thinking output at the idle deadline", async () => {
+  let requestClosed = false;
+  let resolveRequestClosed;
+  const requestClosedPromise = new Promise((resolve) => { resolveRequestClosed = resolve; });
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "text/event-stream" });
+    let n = 0;
+    const interval = setInterval(() => {
+      n += 1;
+      response.write(`data:{"choices":[{"delta":{"reasoning_content":"${n}"}}]}\n`);
+      if (n >= 6) {
+        clearInterval(interval);
+        response.end("data:[DONE]\n\n");
+      }
+    }, 25);
+    response.on("close", () => {
+      clearInterval(interval);
+      requestClosed = true;
+      resolveRequestClosed();
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const sentEvents = [];
+  const { bridge, restore } = loadBridgeWithMocks({
+    safeSend: (_sender, channel, payload) => {
+      sentEvents.push({ channel, payload });
+    },
+  });
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() }, session: {} },
+  });
+
+  try {
+    const result = await bridge._streamRequestForTests(
+      `http://127.0.0.1:${address.port}/thinking`,
+      {
+        method: "GET",
+        idleTimeoutMs: 80,
+        totalTimeoutMs: 2_000,
+      },
+      { sender: { id: 1 } },
+      "thinking",
+      false,
+    );
+    assert.equal(result.statusCode, 200);
+    await Promise.race([
+      new Promise((resolve, reject) => {
+        const started = Date.now();
+        const poll = () => {
+          if (sentEvents.some(({ channel }) => channel === "netcatty:ai:stream:end")) {
+            resolve();
+            return;
+          }
+          const errorEvent = sentEvents.find(({ channel }) => channel === "netcatty:ai:stream:error");
+          if (errorEvent) {
+            reject(new Error(errorEvent.payload.error));
+            return;
+          }
+          if (Date.now() - started > 1_500) {
+            reject(new Error("thinking stream never finished"));
+            return;
+          }
+          setTimeout(poll, 10);
+        };
+        poll();
+      }),
+    ]);
+    await Promise.race([
+      requestClosedPromise,
+      new Promise((_, reject) => setTimeout(() => reject(new Error("server request stayed open")), 500)),
+    ]);
+    assert.equal(requestClosed, true);
+    assert.equal(bridge._getActiveStreamCountForTests(), 0);
+    assert.equal(
+      sentEvents.some(({ channel }) => channel === "netcatty:ai:stream:error"),
+      false,
+    );
+  } finally {
+    restore();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("streaming requests abort after the idle deadline when no more bytes arrive", async () => {
+  let requestClosed = false;
+  let resolveRequestClosed;
+  const requestClosedPromise = new Promise((resolve) => { resolveRequestClosed = resolve; });
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "text/event-stream" });
+    response.write('data:{"choices":[{"delta":{"reasoning_content":"start"}}]}\n');
+    response.on("close", () => {
+      requestClosed = true;
+      resolveRequestClosed();
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const sentEvents = [];
+  const { bridge, restore } = loadBridgeWithMocks({
+    safeSend: (_sender, channel, payload) => {
+      sentEvents.push({ channel, payload });
+    },
+  });
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() }, session: {} },
+  });
+
+  try {
+    const result = await bridge._streamRequestForTests(
+      `http://127.0.0.1:${address.port}/stalled`,
+      {
+        method: "GET",
+        idleTimeoutMs: 40,
+        totalTimeoutMs: 2_000,
+      },
+      { sender: { id: 1 } },
+      "stalled",
+      false,
+    );
+    assert.equal(result.statusCode, 200);
+    await Promise.race([
+      new Promise((resolve, reject) => {
+        const started = Date.now();
+        const poll = () => {
+          const errorEvent = sentEvents.find(({ channel }) => channel === "netcatty:ai:stream:error");
+          if (errorEvent) {
+            resolve(errorEvent.payload.error);
+            return;
+          }
+          if (Date.now() - started > 1_000) {
+            reject(new Error("stalled stream was not aborted"));
+            return;
+          }
+          setTimeout(poll, 10);
+        };
+        poll();
+      }).then((error) => {
+        assert.match(error, /idle deadline exceeded/i);
+      }),
+    ]);
     await Promise.race([
       requestClosedPromise,
       new Promise((_, reject) => setTimeout(() => reject(new Error("server request stayed open")), 500)),


### PR DESCRIPTION
## Summary

Sidebar chat was aborting long reasoning after two minutes even while thinking tokens were still arriving (`AI stream total deadline exceeded after 120000 ms`). Settings > AI safety command timeout is a different knob and did not affect this HTTP stream deadline.

This change treats the two-minute limit as an idle timeout that re-arms when bytes arrive, and keeps a 30-minute hard cap so runaway streams stay bounded.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3051

## Changes Made

- Default AI HTTP stream total deadline is now 30 minutes (same floor as Catty `streamTimeouts`).
- Incoming response headers and body chunks re-arm a 2-minute idle deadline.
- Silent / hung streams still abort after 2 minutes of no bytes.
- Never-ending streams still abort at the total deadline.
- Tests cover active thinking output, idle silence, and the existing total-deadline bound.

## Screenshots / Demo

N/A — main-process stream timeout behavior. Verified with `node --test --test-name-pattern="AI stream|streaming requests|non-2xx streaming" electron/bridges/aiBridge.test.cjs`.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Targeted stream deadline tests passed. Full `npm test` / `npm run lint` / `npm run dev` were not run in this change.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)