### PR TITLE
fix(sftp): close bookmark popover after path selection

### DIFF
--- a/components/sftp/SftpPaneToolbar.interaction.test.ts
+++ b/components/sftp/SftpPaneToolbar.interaction.test.ts
@@ -1,0 +1,157 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+
+test("selecting an inline SFTP bookmark closes its popover", async () => {
+  const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+    pretendToBeVisual: true,
+    url: "http://localhost",
+  });
+  const window = dom.window;
+  const previousGlobals = new Map<string, PropertyDescriptor | undefined>();
+  const installGlobal = (key: string, value: unknown) => {
+    previousGlobals.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      writable: true,
+      value,
+    });
+  };
+
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  installGlobal("window", window);
+  installGlobal("document", window.document);
+  installGlobal("navigator", window.navigator);
+  installGlobal("HTMLElement", window.HTMLElement);
+  installGlobal("HTMLInputElement", window.HTMLInputElement);
+  installGlobal("HTMLTextAreaElement", window.HTMLTextAreaElement);
+  installGlobal("Element", window.Element);
+  installGlobal("SVGElement", window.SVGElement);
+  installGlobal("Node", window.Node);
+  installGlobal("NodeFilter", window.NodeFilter);
+  installGlobal("MutationObserver", window.MutationObserver);
+  installGlobal("CustomEvent", window.CustomEvent);
+  installGlobal("Event", window.Event);
+  installGlobal("StorageEvent", window.StorageEvent);
+  installGlobal("localStorage", window.localStorage);
+  installGlobal("sessionStorage", window.sessionStorage);
+  installGlobal("getComputedStyle", window.getComputedStyle.bind(window));
+  installGlobal("requestAnimationFrame", window.requestAnimationFrame.bind(window));
+  installGlobal("cancelAnimationFrame", window.cancelAnimationFrame.bind(window));
+  installGlobal("ResizeObserver", ResizeObserverStub);
+  installGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+
+  const { default: React, act } = await import("react");
+  const { createRoot } = await import("react-dom/client");
+  const { SftpPaneToolbar } = await import("./SftpPaneToolbar.tsx");
+  const rootNode = window.document.getElementById("root");
+  assert.ok(rootNode);
+  const root = createRoot(rootNode);
+  const navigatedPaths: string[] = [];
+
+  try {
+    await act(async () => {
+      root.render(
+        React.createElement(SftpPaneToolbar, {
+          t: (key) => ({
+            "sftp.bookmark.list": "Bookmarked paths",
+            "sftp.bookmark.remove": "Remove bookmark",
+            "sftp.viewMode.switchToTree": "Switch to tree view",
+          }[key] ?? key),
+          pane: {
+            id: "pane-1",
+            connection: {
+              id: "conn-1",
+              hostId: "host-1",
+              name: "Example",
+              currentPath: "/home/app",
+              homeDir: "/home/app",
+              isLocal: false,
+            },
+            files: [],
+            loading: false,
+            reconnecting: false,
+            error: null,
+            connectionLogs: [],
+            selectedFiles: new Set(),
+            filter: "",
+            filenameEncoding: "auto",
+            showHiddenFiles: false,
+            transferMutationToken: 0,
+          },
+          onNavigateTo: () => {},
+          onSetFilter: () => {},
+          onSetFilenameEncoding: () => {},
+          onRefresh: () => {},
+          showFilterBar: false,
+          setShowFilterBar: () => {},
+          filterInputRef: { current: null },
+          isEditingPath: false,
+          editingPathValue: "",
+          setEditingPathValue: () => {},
+          setShowPathSuggestions: () => {},
+          showPathSuggestions: false,
+          setPathSuggestionIndex: () => {},
+          pathSuggestions: [],
+          pathSuggestionIndex: -1,
+          pathInputRef: { current: null },
+          pathDropdownRef: { current: null },
+          handlePathBlur: () => {},
+          handlePathKeyDown: () => {},
+          handlePathDoubleClick: () => {},
+          handlePathSubmit: () => {},
+          getNextUntitledName: () => "untitled",
+          setNewFileName: () => {},
+          setFileNameError: () => {},
+          setShowNewFileDialog: () => {},
+          setShowNewFolderDialog: () => {},
+          setNewFolderName: () => {},
+          bookmarks: [{ id: "bm-1", path: "/srv/www", label: "Web root" }],
+          isCurrentPathBookmarked: false,
+          onToggleBookmark: () => {},
+          onAddGlobalBookmark: () => {},
+          isCurrentPathGlobalBookmarked: false,
+          onNavigateToBookmark: (path) => navigatedPaths.push(path),
+          onDeleteBookmark: () => {},
+          showHiddenFiles: false,
+          onToggleShowHiddenFiles: () => {},
+          viewMode: "list",
+          onSetViewMode: () => {},
+        }),
+      );
+    });
+
+    const trigger = window.document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Bookmarked paths"]',
+    );
+    assert.ok(trigger);
+    await act(async () => trigger.click());
+
+    const bookmark = Array.from(window.document.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Web root"),
+    );
+    assert.ok(bookmark, "bookmark path should be visible after opening the popover");
+    await act(async () => bookmark.click());
+
+    assert.deepEqual(navigatedPaths, ["/srv/www"]);
+    assert.equal(
+      Array.from(window.document.querySelectorAll("button")).some((button) =>
+        button.textContent?.includes("Web root"),
+      ),
+      false,
+      "bookmark popover should close after selecting a path",
+    );
+  } finally {
+    await act(async () => root.unmount());
+    dom.window.close();
+    for (const [key, descriptor] of previousGlobals) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+      else delete (globalThis as Record<string, unknown>)[key];
+    }
+  }
+});

--- a/components/sftp/SftpPaneToolbar.test.ts
+++ b/components/sftp/SftpPaneToolbar.test.ts
@@ -19,6 +19,7 @@ import {
   SftpPaneToolbar,
 } from "./SftpPaneToolbar.tsx";
 import type { SftpPane } from "../../application/state/sftp/types.ts";
+import { Popover } from "../ui/popover.tsx";
 import { TooltipProvider } from "../ui/tooltip.tsx";
 
 const toolbarSource = fs.readFileSync(
@@ -495,14 +496,18 @@ test("bookmark list renders saved paths as selectable rows", () => {
     React.createElement(
       TooltipProvider,
       null,
-      React.createElement(SftpBookmarkList, {
-        bookmarks: [{ id: "bm-1", path: "/srv/www", label: "Web root" }],
-        onNavigateToBookmark: () => {},
-        onDeleteBookmark: () => {},
-        t: (key: string) => ({
-          "sftp.bookmark.remove": "Remove bookmark",
-        }[key] ?? key),
-      }),
+      React.createElement(
+        Popover,
+        null,
+        React.createElement(SftpBookmarkList, {
+          bookmarks: [{ id: "bm-1", path: "/srv/www", label: "Web root" }],
+          onNavigateToBookmark: () => {},
+          onDeleteBookmark: () => {},
+          t: (key: string) => ({
+            "sftp.bookmark.remove": "Remove bookmark",
+          }[key] ?? key),
+        }),
+      ),
     ),
   );
 

--- a/components/sftp/SftpPaneToolbar.tsx
+++ b/components/sftp/SftpPaneToolbar.tsx
@@ -251,14 +251,16 @@ export const SftpBookmarkList: React.FC<SftpBookmarkListProps> = ({
           )}
           <Tooltip>
             <TooltipTrigger asChild>
-              <button
-                type="button"
-                className="flex-1 text-left text-xs truncate font-mono"
-                onClick={() => onNavigateToBookmark(bm.path)}
-              >
-                {bm.label}
-                <span className="ml-1.5 text-muted-foreground text-[10px]">{bm.path}</span>
-              </button>
+              <PopoverClose asChild>
+                <button
+                  type="button"
+                  className="flex-1 text-left text-xs truncate font-mono"
+                  onClick={() => onNavigateToBookmark(bm.path)}
+                >
+                  {bm.label}
+                  <span className="ml-1.5 text-muted-foreground text-[10px]">{bm.path}</span>
+                </button>
+              </PopoverClose>
             </TooltipTrigger>
             <TooltipContent>{bm.path}</TooltipContent>
           </Tooltip>


### PR DESCRIPTION
## Summary

Fixes the SFTP path bookmark popover staying open after a saved path is selected. The path still navigates as before, and the popover now closes immediately after that selection.

The bookmark row only invoked navigation and never signaled the surrounding popover to close. Other SFTP popover choices already use the shared close action.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3053

## Changes Made

- Close the active bookmark popover when a saved path is selected.
- Keep the existing path navigation and narrow-toolbar overflow behavior unchanged.
- Add an interaction regression test that opens the inline bookmark popover, selects a path, and verifies both navigation and immediate dismissal.

## Screenshots / Demo

Verified in the built Electron app with the local SFTP pane: created a temporary bookmark, opened the bookmark popover, selected the saved path, and confirmed the popover disappeared immediately. The temporary bookmark was removed afterward.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Validation performed:

- `node --test --import tsx components/sftp/SftpPaneToolbar.interaction.test.ts components/sftp/SftpPaneToolbar.test.ts` — 23 passed
- `npm run lint` — passed
- `npm run build` — passed
- `git diff --check` — passed
- `npm test` — 10,408 passed, 11 skipped, 7 unrelated plugin archive tests failed; the same 7 failures reproduce on an unchanged `origin/main` worktree under the same Node 26 environment
- Built Electron app interaction — passed

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

No documentation or generated capability changes are applicable to this focused interaction fix.
