### PR TITLE
fix(ai): support Grok Build reasoning effort

### DIFF
--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -67,6 +67,7 @@ import {
   buildSdkRuntimeModelCacheKey,
   sdkRuntimeModelCache,
   generateId,
+  normalizeStoredAgentModelSelection,
   normalizeSdkRuntimeModelPresets,
   shouldAdoptSdkCurrentModel,
   shouldLoadSdkRuntimeModels,
@@ -853,6 +854,15 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       }));
     }
 
+    const normalizedStoredModelId = normalizeStoredAgentModelSelection(
+      storedModelId,
+      runtimePresets,
+    );
+    if (normalizedStoredModelId && normalizedStoredModelId !== storedModelId) {
+      setAgentModel(agentId, normalizedStoredModelId);
+      return;
+    }
+
     if (
       options.adoptCurrentModel
       && catalog.currentModelId
@@ -988,7 +998,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   const selectedAgentModel = useMemo(() => {
     const stored = agentModelMap[currentAgentId];
     if (shouldUseStoredAgentModel(stored, agentModelPresets, currentAgentConfig)) {
-      return stored;
+      return normalizeStoredAgentModelSelection(stored, agentModelPresets) ?? stored;
     }
     if (agentModelPresets.length > 0) {
       // Cursor CLI login defaults to `auto` (subscription quota routing).
@@ -1156,9 +1166,12 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
             ) {
               sendSelectedAgentModel = catalog.currentModelId;
             } else if (shouldUseStoredAgentModel(storedModelId, runtimePresets)) {
-              sendSelectedAgentModel = storedModelId ?? sendSelectedAgentModel;
+              sendSelectedAgentModel = normalizeStoredAgentModelSelection(
+                storedModelId,
+                runtimePresets,
+              ) ?? storedModelId ?? sendSelectedAgentModel;
             } else if (runtimePresets[0]) {
-              sendSelectedAgentModel = runtimePresets[0].id;
+              sendSelectedAgentModel = resolveAgentModelSelection(runtimePresets[0]);
             }
           }
         }

--- a/components/AIChatSidePanelHelpers.test.tsx
+++ b/components/AIChatSidePanelHelpers.test.tsx
@@ -6,6 +6,7 @@ import {
   buildSdkRuntimeModelCacheKey,
   createSdkRuntimeModelCache,
   modelPresetsContainId,
+  normalizeStoredAgentModelSelection,
   normalizeSdkRuntimeModelPresets,
   shouldAdoptSdkCurrentModel,
   shouldLoadSdkRuntimeModels,
@@ -123,6 +124,28 @@ test('shouldAdoptSdkCurrentModel keeps SDK defaults when no runtime list is retu
     false,
   );
   assert.equal(shouldAdoptSdkCurrentModel(null, undefined, []), false);
+});
+
+test('legacy plain model selections keep their model and gain its default reasoning effort', () => {
+  const presets: AgentModelPreset[] = [{
+    id: 'grok-4.5',
+    name: 'Grok 4.5',
+    thinkingLevels: ['high', 'medium', 'low'],
+    defaultThinkingLevel: 'high',
+  }, {
+    id: 'grok-4.6',
+    name: 'Grok 4.6',
+    thinkingLevels: ['xhigh', 'high', 'medium', 'low'],
+    defaultThinkingLevel: 'high',
+  }];
+
+  assert.equal(modelPresetsContainId(presets, 'grok-4.5'), true);
+  assert.equal(normalizeStoredAgentModelSelection('grok-4.5', presets), 'grok-4.5/high');
+  assert.equal(normalizeStoredAgentModelSelection('grok-4.5/medium', presets), 'grok-4.5/medium');
+  assert.equal(
+    shouldAdoptSdkCurrentModel('grok-4.6/high', 'grok-4.5', presets),
+    false,
+  );
 });
 
 test('normalizeSdkRuntimeModelPresets preserves SDK current model without a catalog', () => {

--- a/components/AIChatSidePanelHelpers.ts
+++ b/components/AIChatSidePanelHelpers.ts
@@ -1,4 +1,8 @@
-import type { AgentModelPreset, ExternalAgentConfig } from '../infrastructure/ai/types';
+import {
+  resolveAgentModelSelection,
+  type AgentModelPreset,
+  type ExternalAgentConfig,
+} from '../infrastructure/ai/types';
 import { getExternalAgentSdkBackend } from '../infrastructure/ai/managedAgents';
 
 export type SdkRuntimeModelCatalog = {
@@ -177,13 +181,26 @@ export const sdkRuntimeModelCache = createSdkRuntimeModelCache();
 
 export function modelPresetMatchesId(preset: AgentModelPreset, modelId: string): boolean {
   if (preset.thinkingLevels?.length) {
-    return preset.thinkingLevels.some((level) => `${preset.id}/${level}` === modelId);
+    return preset.id === modelId
+      || preset.thinkingLevels.some((level) => `${preset.id}/${level}` === modelId);
   }
   return preset.id === modelId;
 }
 
 export function modelPresetsContainId(presets: AgentModelPreset[], modelId: string): boolean {
   return presets.some((preset) => modelPresetMatchesId(preset, modelId));
+}
+
+export function normalizeStoredAgentModelSelection(
+  storedModelId: string | null | undefined,
+  presets: AgentModelPreset[],
+): string | undefined {
+  if (!storedModelId) return undefined;
+  const preset = presets.find((candidate) => modelPresetMatchesId(candidate, storedModelId));
+  if (!preset) return undefined;
+  return storedModelId === preset.id
+    ? resolveAgentModelSelection(preset)
+    : storedModelId;
 }
 
 export function shouldLoadSdkRuntimeModels(agent?: ExternalAgentConfig): boolean {

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -28,6 +28,7 @@ const {
   extractGrokAcpPromptUsage,
   emitGrokUsage,
   normalizeGrokPlanUpdate,
+  parseGrokModelSelection,
   shouldReportGrokProcessExitFailure,
   spawnGrokProcess,
 } = require("./grokDriver.cjs");
@@ -36,6 +37,17 @@ const GROK_ACP_ABORT_GRACE_MS = 1_500;
 const MAX_GROK_ACP_LINE_BYTES = 10 * 1024 * 1024;
 const MAX_GROK_ACP_STDERR_CHARS = 64 * 1024;
 const ACP_PROTOCOL_VERSION = 1;
+const GROK_ACP_MODEL_LIST_TIMEOUT_MS = 10_000;
+const GROK_FALLBACK_REASONING_EFFORTS = ["low", "medium", "high", "xhigh"];
+const GROK_REASONING_EFFORTS = new Set([
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]);
 
 function signalProcessTree(child, signal, forceKillImpl) {
   if (!child) return;
@@ -102,9 +114,12 @@ function buildGrokAcpSpawnArgs({
   if (mode !== "observer") {
     args.push("--always-approve");
   }
-  const modelId = String(model || "").trim();
-  if (modelId) {
-    args.push("-m", modelId);
+  const selection = parseGrokModelSelection(model);
+  if (selection.model) {
+    args.push("-m", selection.model);
+  }
+  if (selection.effort) {
+    args.push("--reasoning-effort", selection.effort);
   }
   args.push("stdio");
   return args;
@@ -204,6 +219,185 @@ function buildGrokAcpInitializeParams() {
       version: "0.0.0",
     },
   };
+}
+
+/**
+ * Convert Grok's ACP initialize modelState into Netcatty's shared model picker
+ * shape. Reasoning levels are model-specific and come from the live catalog;
+ * non-reasoning models intentionally remain plain model rows.
+ */
+function parseGrokAcpModelCatalog(initResult) {
+  const modelState = initResult?._meta?.modelState
+    || initResult?.modelState
+    || initResult?.agentCapabilities?._meta?.modelState;
+  if (!modelState || typeof modelState !== "object") {
+    return { currentModelId: null, models: [] };
+  }
+
+  const models = [];
+  for (const entry of Array.isArray(modelState.availableModels) ? modelState.availableModels : []) {
+    const id = String(entry?.modelId || entry?.id || "").trim();
+    if (!id) continue;
+    const preset = {
+      id,
+      name: String(entry?.name || id),
+    };
+    if (entry?.description) preset.description = String(entry.description);
+
+    const meta = entry?._meta && typeof entry._meta === "object"
+      ? entry._meta
+      : (entry?.meta && typeof entry.meta === "object" ? entry.meta : {});
+    const supportsReasoning = meta.supportsReasoningEffort === true
+      || meta.supports_reasoning_effort === true;
+    if (supportsReasoning) {
+      const rawOptions = Array.isArray(meta.reasoningEfforts)
+        ? meta.reasoningEfforts
+        : (Array.isArray(meta.reasoning_efforts) ? meta.reasoning_efforts : []);
+      const levels = [];
+      for (const option of rawOptions) {
+        const value = String(option?.value || option?.id || "").trim().toLowerCase();
+        if (GROK_REASONING_EFFORTS.has(value) && !levels.includes(value)) {
+          levels.push(value);
+        }
+      }
+      if (levels.length === 0) levels.push(...GROK_FALLBACK_REASONING_EFFORTS);
+      preset.thinkingLevels = levels;
+
+      const advertisedDefault = String(
+        meta.reasoningEffort || meta.reasoning_effort || "",
+      ).trim().toLowerCase();
+      const optionDefault = rawOptions.find((option) => option?.default === true);
+      const optionDefaultValue = String(
+        optionDefault?.value || optionDefault?.id || "",
+      ).trim().toLowerCase();
+      if (levels.includes(advertisedDefault)) {
+        preset.defaultThinkingLevel = advertisedDefault;
+      } else if (levels.includes(optionDefaultValue)) {
+        preset.defaultThinkingLevel = optionDefaultValue;
+      } else if (levels.includes("high")) {
+        preset.defaultThinkingLevel = "high";
+      } else {
+        preset.defaultThinkingLevel = levels[0];
+      }
+    }
+    models.push(preset);
+  }
+
+  const currentModelId = String(
+    modelState.currentModelId || modelState.current_model_id || "",
+  ).trim() || null;
+  return { currentModelId, models };
+}
+
+/**
+ * Read the live Grok model catalog from ACP initialize. Unlike `grok models`,
+ * this response includes per-model reasoning support, available levels, and
+ * the default effort. Authentication is not required for the initialize step.
+ */
+async function listGrokAcpModels({
+  binPath,
+  env,
+  spawnImpl,
+  abortController,
+  signal,
+  timeoutMs = GROK_ACP_MODEL_LIST_TIMEOUT_MS,
+  forceKillImpl,
+} = {}) {
+  const cliPath = String(binPath || "").trim();
+  if (!cliPath) return { currentModelId: null, models: [] };
+  const abortSignal = signal || abortController?.signal;
+  if (abortSignal?.aborted) return { currentModelId: null, models: [] };
+
+  return await new Promise((resolve) => {
+    let child;
+    let settled = false;
+    let timer = null;
+    let abortHandler = null;
+    const empty = { currentModelId: null, models: [] };
+
+    const finish = (value, terminate = true) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (abortSignal && abortHandler) {
+        abortSignal.removeEventListener("abort", abortHandler);
+      }
+      if (terminate && child && child.exitCode == null && !child.killed) {
+        signalProcessTree(child, "SIGTERM", forceKillImpl);
+      }
+      try { child?.stdin?.end?.(); } catch { /* ignore */ }
+      resolve(value);
+    };
+
+    try {
+      child = spawnGrokProcess(spawnImpl, cliPath, ["agent", "stdio"], {
+        env: { ...(env || process.env) },
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+        detached: process.platform !== "win32",
+      });
+    } catch {
+      finish(empty, false);
+      return;
+    }
+
+    const lineBuffer = createLineBuffer((line) => {
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        return;
+      }
+      if (message?.id !== 1) return;
+      if (message.error) {
+        finish(empty);
+        return;
+      }
+      finish(parseGrokAcpModelCatalog(message.result));
+    }, MAX_GROK_ACP_LINE_BYTES);
+
+    child.stdout?.on("data", (chunk) => {
+      if (settled || abortSignal?.aborted) return;
+      try {
+        lineBuffer.push(chunk);
+      } catch {
+        finish(empty);
+      }
+    });
+    child.stdin?.on?.("error", () => finish(empty));
+    child.on("error", () => finish(empty, false));
+    child.on("close", () => {
+      if (!settled) {
+        try { lineBuffer.flush(); } catch { /* ignore */ }
+      }
+      finish(empty, false);
+    });
+
+    abortHandler = () => finish(empty);
+    if (abortSignal) {
+      if (abortSignal.aborted) {
+        abortHandler();
+        return;
+      }
+      abortSignal.addEventListener("abort", abortHandler, { once: true });
+    }
+    timer = setTimeout(() => finish(empty), Math.max(1, timeoutMs));
+    timer.unref?.();
+
+    const request = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: buildGrokAcpInitializeParams(),
+    };
+    try {
+      child.stdin?.write?.(`${JSON.stringify(request)}\n`, (err) => {
+        if (err) finish(empty);
+      });
+    } catch {
+      finish(empty);
+    }
+  });
 }
 
 function buildGrokAcpPromptParams(sessionId, prompt) {
@@ -1050,9 +1244,11 @@ module.exports = {
   establishGrokAcpSession,
   handleGrokAcpMessage,
   parseGrokAcpAgentCapabilities,
+  parseGrokAcpModelCatalog,
   planGrokAcpSessionEstablish,
   resolveGrokAcpCwd,
   runGrokAcpTurn,
+  listGrokAcpModels,
   selectGrokAcpAuthMethodId,
   toAcpMcpEnvPairs,
   toAcpMcpServers,

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -301,6 +301,7 @@ async function listGrokAcpModels({
   abortController,
   signal,
   timeoutMs = GROK_ACP_MODEL_LIST_TIMEOUT_MS,
+  abortGraceMs = GROK_ACP_ABORT_GRACE_MS,
   forceKillImpl,
 } = {}) {
   const cliPath = String(binPath || "").trim();
@@ -312,8 +313,23 @@ async function listGrokAcpModels({
     let child;
     let settled = false;
     let timer = null;
+    let forceKillTimer = null;
     let abortHandler = null;
+    let childClosed = false;
+    let terminationStarted = false;
     const empty = { currentModelId: null, models: [] };
+
+    const terminateChild = () => {
+      if (terminationStarted || childClosed || !child || child.exitCode != null) return;
+      terminationStarted = true;
+      signalProcessTree(child, "SIGTERM", forceKillImpl);
+      forceKillTimer = setTimeout(() => {
+        if (!childClosed && child?.exitCode == null) {
+          signalProcessTree(child, "SIGKILL", forceKillImpl);
+        }
+      }, Math.max(1, abortGraceMs));
+      forceKillTimer.unref?.();
+    };
 
     const finish = (value, terminate = true) => {
       if (settled) return;
@@ -322,15 +338,13 @@ async function listGrokAcpModels({
       if (abortSignal && abortHandler) {
         abortSignal.removeEventListener("abort", abortHandler);
       }
-      if (terminate && child && child.exitCode == null && !child.killed) {
-        signalProcessTree(child, "SIGTERM", forceKillImpl);
-      }
+      if (terminate) terminateChild();
       try { child?.stdin?.end?.(); } catch { /* ignore */ }
       resolve(value);
     };
 
     try {
-      child = spawnGrokProcess(spawnImpl, cliPath, ["agent", "stdio"], {
+      child = spawnGrokProcess(spawnImpl, cliPath, ["--no-auto-update", "agent", "stdio"], {
         env: { ...(env || process.env) },
         stdio: ["pipe", "pipe", "pipe"],
         windowsHide: true,
@@ -367,6 +381,8 @@ async function listGrokAcpModels({
     child.stdin?.on?.("error", () => finish(empty));
     child.on("error", () => finish(empty, false));
     child.on("close", () => {
+      childClosed = true;
+      clearTimeout(forceKillTimer);
       if (!settled) {
         try { lineBuffer.flush(); } catch { /* ignore */ }
       }

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -28,6 +28,7 @@ const {
   extractGrokAcpPromptUsage,
   emitGrokUsage,
   normalizeGrokPlanUpdate,
+  applyGrokReasoningFallback,
   parseGrokModelSelection,
   shouldReportGrokProcessExitFailure,
   spawnGrokProcess,
@@ -249,6 +250,10 @@ function parseGrokAcpModelCatalog(initResult) {
       : (entry?.meta && typeof entry.meta === "object" ? entry.meta : {});
     const supportsReasoning = meta.supportsReasoningEffort === true
       || meta.supports_reasoning_effort === true;
+    const explicitlyUnsupported = !supportsReasoning && (
+      meta.supportsReasoningEffort === false
+      || meta.supports_reasoning_effort === false
+    );
     if (supportsReasoning) {
       const rawOptions = Array.isArray(meta.reasoningEfforts)
         ? meta.reasoningEfforts
@@ -279,6 +284,8 @@ function parseGrokAcpModelCatalog(initResult) {
       } else {
         preset.defaultThinkingLevel = levels[0];
       }
+    } else if (!explicitlyUnsupported) {
+      Object.assign(preset, applyGrokReasoningFallback(preset));
     }
     models.push(preset);
   }

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.cjs
@@ -29,6 +29,7 @@ const {
   emitGrokUsage,
   normalizeGrokPlanUpdate,
   applyGrokReasoningFallback,
+  resolveGrokCatalogCurrentModelId,
   parseGrokModelSelection,
   shouldReportGrokProcessExitFailure,
   spawnGrokProcess,
@@ -38,7 +39,9 @@ const GROK_ACP_ABORT_GRACE_MS = 1_500;
 const MAX_GROK_ACP_LINE_BYTES = 10 * 1024 * 1024;
 const MAX_GROK_ACP_STDERR_CHARS = 64 * 1024;
 const ACP_PROTOCOL_VERSION = 1;
-const GROK_ACP_MODEL_LIST_TIMEOUT_MS = 10_000;
+// The outer SDK model-list request has a 10s deadline. Leave enough time for
+// the legacy `grok models` fallback when ACP initialize hangs.
+const GROK_ACP_MODEL_LIST_TIMEOUT_MS = 4_000;
 const GROK_FALLBACK_REASONING_EFFORTS = ["low", "medium", "high", "xhigh"];
 const GROK_REASONING_EFFORTS = new Set([
   "none",
@@ -265,7 +268,14 @@ function parseGrokAcpModelCatalog(initResult) {
           levels.push(value);
         }
       }
-      if (levels.length === 0) levels.push(...GROK_FALLBACK_REASONING_EFFORTS);
+      if (levels.length === 0) {
+        const knownFallback = applyGrokReasoningFallback(preset);
+        if (Array.isArray(knownFallback?.thinkingLevels)) {
+          levels.push(...knownFallback.thinkingLevels);
+        } else {
+          levels.push(...GROK_FALLBACK_REASONING_EFFORTS);
+        }
+      }
       preset.thinkingLevels = levels;
 
       const advertisedDefault = String(
@@ -290,9 +300,10 @@ function parseGrokAcpModelCatalog(initResult) {
     models.push(preset);
   }
 
-  const currentModelId = String(
+  const advertisedCurrentModelId = String(
     modelState.currentModelId || modelState.current_model_id || "",
   ).trim() || null;
+  const currentModelId = resolveGrokCatalogCurrentModelId(models, advertisedCurrentModelId);
   return { currentModelId, models };
 }
 

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -118,7 +118,7 @@ test("parseGrokAcpModelCatalog exposes only each model's advertised reasoning ef
   });
 
   assert.deepEqual(catalog, {
-    currentModelId: "grok-4.6",
+    currentModelId: "grok-4.6/high",
     models: [
       {
         id: "grok-4.6",
@@ -158,6 +158,29 @@ test("parseGrokAcpModelCatalog fills known legacy models without overriding expl
     },
     { id: "grok-4.6", name: "Grok 4.6" },
   ]);
+  assert.equal(catalog.currentModelId, "grok-4.5/high");
+});
+
+test("parseGrokAcpModelCatalog uses a model-specific fallback when advertised options are empty", () => {
+  const catalog = parseGrokAcpModelCatalog({
+    _meta: {
+      modelState: {
+        currentModelId: "grok-4.5",
+        availableModels: [{
+          modelId: "grok-4.5",
+          name: "Grok 4.5",
+          _meta: {
+            supportsReasoningEffort: true,
+            reasoningEfforts: [],
+          },
+        }],
+      },
+    },
+  });
+
+  assert.equal(catalog.currentModelId, "grok-4.5/high");
+  assert.deepEqual(catalog.models[0].thinkingLevels, ["high", "medium", "low"]);
+  assert.ok(!catalog.models[0].thinkingLevels.includes("xhigh"));
 });
 
 test("listGrokAcpModels reads reasoning metadata from the initialize response", async () => {
@@ -222,7 +245,7 @@ test("listGrokAcpModels reads reasoning metadata from the initialize response", 
     },
   });
 
-  assert.equal(catalog.currentModelId, "grok-4.6");
+  assert.equal(catalog.currentModelId, "grok-4.6/high");
   assert.deepEqual(catalog.models[0].thinkingLevels, ["high", "low"]);
   assert.equal(catalog.models[0].defaultThinkingLevel, "high");
   assert.deepEqual(signals, ["SIGTERM"]);
@@ -240,14 +263,20 @@ test("listGrokAcpModels force-kills a model probe that ignores timeout shutdown"
   child.pid = 43;
   const signals = [];
 
-  const catalog = await listGrokAcpModels({
-    binPath: "/usr/bin/grok",
-    spawnImpl: () => child,
-    timeoutMs: 2,
-    abortGraceMs: 2,
-    forceKillImpl: (_child, signal) => signals.push(signal),
-  });
-  await new Promise((resolve) => setTimeout(resolve, 10));
+  const keepAlive = setTimeout(() => {}, 50);
+  let catalog;
+  try {
+    catalog = await listGrokAcpModels({
+      binPath: "/usr/bin/grok",
+      spawnImpl: () => child,
+      timeoutMs: 2,
+      abortGraceMs: 2,
+      forceKillImpl: (_child, signal) => signals.push(signal),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  } finally {
+    clearTimeout(keepAlive);
+  }
 
   assert.deepEqual(catalog, { currentModelId: null, models: [] });
   assert.deepEqual(signals, ["SIGTERM", "SIGKILL"]);
@@ -294,7 +323,7 @@ test("registry Grok model discovery enriches legacy fallback reasoning levels", 
   });
   try {
     const catalog = await getDriver("grok").listModels({});
-    assert.equal(catalog.currentModelId, "grok-4.6");
+    assert.equal(catalog.currentModelId, "grok-4.6/high");
     assert.deepEqual(catalog.models[0].thinkingLevels, ["xhigh", "high", "medium", "low"]);
     assert.equal(catalog.models[0].defaultThinkingLevel, "high");
   } finally {
@@ -312,7 +341,7 @@ test("registry Grok model discovery keeps ACP current model when its list is inc
   grokModule.listGrokModels = async () => ({ currentModelId: "grok-4.5", models: [] });
   try {
     const catalog = await getDriver("grok").listModels({});
-    assert.equal(catalog.currentModelId, "grok-4.6");
+    assert.equal(catalog.currentModelId, "grok-4.6/high");
     assert.deepEqual(catalog.models, [{
       id: "grok-4.6",
       name: "grok-4.6",

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -13,7 +13,9 @@ const {
   createJsonRpcClient,
   establishGrokAcpSession,
   handleGrokAcpMessage,
+  listGrokAcpModels,
   parseGrokAcpAgentCapabilities,
+  parseGrokAcpModelCatalog,
   planGrokAcpSessionEstablish,
   resolveGrokAcpCwd,
   runGrokAcpTurn,
@@ -64,6 +66,129 @@ test("buildGrokAcpSpawnArgs uses agent stdio, no-auto-update, and always-approve
     toolIntegrationMode: "skills",
   });
   assert.deepEqual(observer, ["--no-auto-update", "agent", "stdio"]);
+});
+
+test("buildGrokAcpSpawnArgs passes a selected reasoning effort separately from the model", () => {
+  assert.deepEqual(buildGrokAcpSpawnArgs({
+    model: "grok-4.6/high",
+    permissionMode: "auto",
+    toolIntegrationMode: "skills",
+  }), [
+    "--no-auto-update",
+    "agent",
+    "--always-approve",
+    "-m",
+    "grok-4.6",
+    "--reasoning-effort",
+    "high",
+    "stdio",
+  ]);
+});
+
+test("parseGrokAcpModelCatalog exposes only each model's advertised reasoning efforts", () => {
+  const catalog = parseGrokAcpModelCatalog({
+    _meta: {
+      modelState: {
+        currentModelId: "grok-4.6",
+        availableModels: [
+          {
+            modelId: "grok-4.6",
+            name: "Grok 4.6",
+            description: "Latest",
+            _meta: {
+              supportsReasoningEffort: true,
+              reasoningEffort: "high",
+              reasoningEfforts: [
+                { id: "deep", value: "xhigh", label: "Extra High" },
+                { id: "high", value: "high", label: "High" },
+                { id: "medium", value: "medium", label: "Medium" },
+                { id: "low", value: "low", label: "Low" },
+              ],
+            },
+          },
+          {
+            modelId: "ocx-fast",
+            name: "OCX Fast",
+            _meta: { supportsReasoningEffort: false },
+          },
+        ],
+      },
+    },
+  });
+
+  assert.deepEqual(catalog, {
+    currentModelId: "grok-4.6",
+    models: [
+      {
+        id: "grok-4.6",
+        name: "Grok 4.6",
+        description: "Latest",
+        thinkingLevels: ["xhigh", "high", "medium", "low"],
+        defaultThinkingLevel: "high",
+      },
+      { id: "ocx-fast", name: "OCX Fast" },
+    ],
+  });
+});
+
+test("listGrokAcpModels reads reasoning metadata from the initialize response", async () => {
+  const { EventEmitter } = require("node:events");
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = new EventEmitter();
+  child.stdin.end = () => {};
+  child.exitCode = null;
+  child.killed = false;
+  child.pid = 42;
+  child.kill = () => { child.killed = true; };
+  child.stdin.write = (line, callback) => {
+    const request = JSON.parse(String(line));
+    assert.equal(request.method, "initialize");
+    queueMicrotask(() => {
+      child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+        jsonrpc: "2.0",
+        id: request.id,
+        result: {
+          _meta: {
+            modelState: {
+              currentModelId: "grok-4.6",
+              availableModels: [{
+                modelId: "grok-4.6",
+                name: "Grok 4.6",
+                _meta: {
+                  supportsReasoningEffort: true,
+                  reasoningEffort: "high",
+                  reasoningEfforts: [
+                    { id: "high", value: "high" },
+                    { id: "low", value: "low" },
+                  ],
+                },
+              }],
+            },
+          },
+        },
+      })}\n`));
+      callback?.();
+    });
+    return true;
+  };
+
+  const signals = [];
+  const catalog = await listGrokAcpModels({
+    binPath: "/usr/bin/grok",
+    spawnImpl: (bin, args) => {
+      assert.equal(bin, "/usr/bin/grok");
+      assert.deepEqual(args, ["agent", "stdio"]);
+      return child;
+    },
+    forceKillImpl: (_child, signal) => signals.push(signal),
+  });
+
+  assert.equal(catalog.currentModelId, "grok-4.6");
+  assert.deepEqual(catalog.models[0].thinkingLevels, ["high", "low"]);
+  assert.equal(catalog.models[0].defaultThinkingLevel, "high");
+  assert.deepEqual(signals, ["SIGTERM"]);
 });
 
 test("buildGrokAcpSpawnArgs places global MCP lockdown before agent subcommand", () => {

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -132,6 +132,34 @@ test("parseGrokAcpModelCatalog exposes only each model's advertised reasoning ef
   });
 });
 
+test("parseGrokAcpModelCatalog fills known legacy models without overriding explicit no-reasoning metadata", () => {
+  const catalog = parseGrokAcpModelCatalog({
+    _meta: {
+      modelState: {
+        currentModelId: "grok-4.5",
+        availableModels: [
+          { modelId: "grok-4.5", name: "Grok 4.5" },
+          {
+            modelId: "grok-4.6",
+            name: "Grok 4.6",
+            _meta: { supportsReasoningEffort: false },
+          },
+        ],
+      },
+    },
+  });
+
+  assert.deepEqual(catalog.models, [
+    {
+      id: "grok-4.5",
+      name: "Grok 4.5",
+      thinkingLevels: ["high", "medium", "low"],
+      defaultThinkingLevel: "high",
+    },
+    { id: "grok-4.6", name: "Grok 4.6" },
+  ]);
+});
+
 test("listGrokAcpModels reads reasoning metadata from the initialize response", async () => {
   const { EventEmitter } = require("node:events");
   const child = new EventEmitter();

--- a/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokAcpDriver.test.cjs
@@ -1,5 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
 const path = require("node:path");
 const {
   ACP_PROTOCOL_VERSION,
@@ -179,16 +180,121 @@ test("listGrokAcpModels reads reasoning metadata from the initialize response", 
     binPath: "/usr/bin/grok",
     spawnImpl: (bin, args) => {
       assert.equal(bin, "/usr/bin/grok");
-      assert.deepEqual(args, ["agent", "stdio"]);
+      assert.deepEqual(args, ["--no-auto-update", "agent", "stdio"]);
       return child;
     },
-    forceKillImpl: (_child, signal) => signals.push(signal),
+    forceKillImpl: (_child, signal) => {
+      signals.push(signal);
+      if (signal === "SIGTERM") {
+        queueMicrotask(() => {
+          child.exitCode = 0;
+          child.emit("close", 0);
+        });
+      }
+    },
   });
 
   assert.equal(catalog.currentModelId, "grok-4.6");
   assert.deepEqual(catalog.models[0].thinkingLevels, ["high", "low"]);
   assert.equal(catalog.models[0].defaultThinkingLevel, "high");
   assert.deepEqual(signals, ["SIGTERM"]);
+});
+
+test("listGrokAcpModels force-kills a model probe that ignores timeout shutdown", async () => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = new EventEmitter();
+  child.stdin.write = () => true;
+  child.stdin.end = () => {};
+  child.exitCode = null;
+  child.killed = false;
+  child.pid = 43;
+  const signals = [];
+
+  const catalog = await listGrokAcpModels({
+    binPath: "/usr/bin/grok",
+    spawnImpl: () => child,
+    timeoutMs: 2,
+    abortGraceMs: 2,
+    forceKillImpl: (_child, signal) => signals.push(signal),
+  });
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.deepEqual(catalog, { currentModelId: null, models: [] });
+  assert.deepEqual(signals, ["SIGTERM", "SIGKILL"]);
+});
+
+test("listGrokAcpModels force-kills a model probe that ignores abort shutdown", async () => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = new EventEmitter();
+  child.stdin.write = () => true;
+  child.stdin.end = () => {};
+  child.exitCode = null;
+  child.killed = false;
+  child.pid = 44;
+  const signals = [];
+  const controller = new AbortController();
+
+  const pending = listGrokAcpModels({
+    binPath: "/usr/bin/grok",
+    spawnImpl: () => child,
+    signal: controller.signal,
+    timeoutMs: 100,
+    abortGraceMs: 2,
+    forceKillImpl: (_child, signal) => signals.push(signal),
+  });
+  controller.abort();
+  const catalog = await pending;
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.deepEqual(catalog, { currentModelId: null, models: [] });
+  assert.deepEqual(signals, ["SIGTERM", "SIGKILL"]);
+});
+
+test("registry Grok model discovery enriches legacy fallback reasoning levels", async () => {
+  const grokModule = require("./grokDriver.cjs");
+  const grokAcpModule = require("./grokAcpDriver.cjs");
+  const originalAcp = grokAcpModule.listGrokAcpModels;
+  const originalLegacy = grokModule.listGrokModels;
+  grokAcpModule.listGrokAcpModels = async () => ({ currentModelId: null, models: [] });
+  grokModule.listGrokModels = async () => ({
+    currentModelId: "grok-4.6",
+    models: [grokModule.applyGrokReasoningFallback({ id: "grok-4.6", name: "Grok 4.6" })],
+  });
+  try {
+    const catalog = await getDriver("grok").listModels({});
+    assert.equal(catalog.currentModelId, "grok-4.6");
+    assert.deepEqual(catalog.models[0].thinkingLevels, ["xhigh", "high", "medium", "low"]);
+    assert.equal(catalog.models[0].defaultThinkingLevel, "high");
+  } finally {
+    grokAcpModule.listGrokAcpModels = originalAcp;
+    grokModule.listGrokModels = originalLegacy;
+  }
+});
+
+test("registry Grok model discovery keeps ACP current model when its list is incomplete", async () => {
+  const grokModule = require("./grokDriver.cjs");
+  const grokAcpModule = require("./grokAcpDriver.cjs");
+  const originalAcp = grokAcpModule.listGrokAcpModels;
+  const originalLegacy = grokModule.listGrokModels;
+  grokAcpModule.listGrokAcpModels = async () => ({ currentModelId: "grok-4.6", models: [] });
+  grokModule.listGrokModels = async () => ({ currentModelId: "grok-4.5", models: [] });
+  try {
+    const catalog = await getDriver("grok").listModels({});
+    assert.equal(catalog.currentModelId, "grok-4.6");
+    assert.deepEqual(catalog.models, [{
+      id: "grok-4.6",
+      name: "grok-4.6",
+      thinkingLevels: ["xhigh", "high", "medium", "low"],
+      defaultThinkingLevel: "high",
+    }]);
+  } finally {
+    grokAcpModule.listGrokAcpModels = originalAcp;
+    grokModule.listGrokModels = originalLegacy;
+  }
 });
 
 test("buildGrokAcpSpawnArgs places global MCP lockdown before agent subcommand", () => {

--- a/electron/bridges/aiBridge/sdk/grokDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.cjs
@@ -22,6 +22,15 @@ const GROK_ABORT_GRACE_MS = 1_500;
 const MAX_GROK_STDERR_CHARS = 64 * 1024;
 const MAX_GROK_MODEL_STDOUT_CHARS = 1024 * 1024;
 const MAX_GROK_LINE_BYTES = 10 * 1024 * 1024;
+const GROK_REASONING_EFFORTS = new Set([
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]);
 
 /**
  * Resolve Grok CLI spawn target for Windows .cmd/.bat shims.
@@ -280,6 +289,21 @@ function resolveGrokToolIntegrationFlags(toolIntegrationMode) {
   ];
 }
 
+/**
+ * The renderer encodes a reasoning selection as `<model>/<effort>`. Grok's
+ * CLI requires those values as separate flags, and model ids may themselves
+ * contain `/`, so split only a recognized trailing effort token.
+ */
+function parseGrokModelSelection(model) {
+  const value = String(model || "").trim();
+  const slash = value.lastIndexOf("/");
+  const effort = slash > 0 ? value.slice(slash + 1).toLowerCase() : "";
+  if (slash > 0 && GROK_REASONING_EFFORTS.has(effort)) {
+    return { model: value.slice(0, slash), effort };
+  }
+  return { model: value || undefined, effort: undefined };
+}
+
 function buildGrokCliArgs({
   prompt,
   model,
@@ -296,9 +320,12 @@ function buildGrokCliArgs({
     "--output-format",
     "streaming-json",
   ];
-  const modelId = String(model || "").trim();
-  if (modelId) {
-    args.push("-m", modelId);
+  const selection = parseGrokModelSelection(model);
+  if (selection.model) {
+    args.push("-m", selection.model);
+  }
+  if (selection.effort) {
+    args.push("--reasoning-effort", selection.effort);
   }
   if (cwd) {
     args.push("--cwd", String(cwd));
@@ -1015,6 +1042,7 @@ module.exports = {
   extractGrokAcpPromptUsage,
   emitGrokUsage,
   normalizeGrokPlanUpdate,
+  parseGrokModelSelection,
   shouldReportGrokProcessExitFailure,
   runGrokTurn,
   spawnGrokProcess,

--- a/electron/bridges/aiBridge/sdk/grokDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.cjs
@@ -31,6 +31,18 @@ const GROK_REASONING_EFFORTS = new Set([
   "xhigh",
   "max",
 ]);
+const GROK_REASONING_FALLBACKS = Object.freeze({
+  "grok-4.5": {
+    name: "Grok 4.5",
+    thinkingLevels: ["high", "medium", "low"],
+    defaultThinkingLevel: "high",
+  },
+  "grok-4.6": {
+    name: "Grok 4.6",
+    thinkingLevels: ["xhigh", "high", "medium", "low"],
+    defaultThinkingLevel: "high",
+  },
+});
 
 /**
  * Resolve Grok CLI spawn target for Windows .cmd/.bat shims.
@@ -935,7 +947,21 @@ function parseGrokModelsOutput(stdout) {
     }
   }
 
-  return { currentModelId, models };
+  return { currentModelId, models: models.map(applyGrokReasoningFallback) };
+}
+
+function applyGrokReasoningFallback(model) {
+  const id = String(model?.id || "").trim();
+  const fallback = GROK_REASONING_FALLBACKS[id];
+  if (!fallback || (Array.isArray(model?.thinkingLevels) && model.thinkingLevels.length > 0)) {
+    return model;
+  }
+  return {
+    ...model,
+    name: String(model?.name || fallback.name),
+    thinkingLevels: [...fallback.thinkingLevels],
+    defaultThinkingLevel: fallback.defaultThinkingLevel,
+  };
 }
 
 async function listGrokModels({
@@ -975,7 +1001,7 @@ async function listGrokModels({
 
     let child;
     try {
-      child = spawnGrokProcess(spawnImpl, cliPath, ["models"], {
+      child = spawnGrokProcess(spawnImpl, cliPath, ["--no-auto-update", "models"], {
         env: childEnv,
         stdio: ["ignore", "pipe", "pipe"],
         windowsHide: true,
@@ -1025,6 +1051,7 @@ module.exports = {
   NETCATTY_MCP_NAME,
   MAX_GROK_LINE_BYTES,
   GROK_MCP_MODE_DISALLOWED_LOCAL_TOOLS,
+  applyGrokReasoningFallback,
   buildGrokCliArgs,
   buildGrokMcpServerTomlSection,
   createLineBuffer,

--- a/electron/bridges/aiBridge/sdk/grokDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.cjs
@@ -964,6 +964,19 @@ function applyGrokReasoningFallback(model) {
   };
 }
 
+function resolveGrokCatalogCurrentModelId(models, currentModelId) {
+  const advertised = String(currentModelId || "").trim();
+  if (!advertised) return null;
+  const selection = parseGrokModelSelection(advertised);
+  const preset = (Array.isArray(models) ? models : [])
+    .find((entry) => entry?.id === selection.model);
+  if (!preset?.thinkingLevels?.length) return advertised;
+  const effort = preset.thinkingLevels.includes(selection.effort)
+    ? selection.effort
+    : (preset.defaultThinkingLevel || preset.thinkingLevels[0]);
+  return effort ? `${preset.id}/${effort}` : preset.id;
+}
+
 async function listGrokModels({
   binPath,
   env,
@@ -1062,6 +1075,7 @@ module.exports = {
   parseGrokModelsOutput,
   resetGrokMcpMergeRefcountsForTests,
   resolveGrokPermissionFlags,
+  resolveGrokCatalogCurrentModelId,
   resolveGrokRuntime,
   resolveGrokSpawnSpec,
   resolveGrokToolIntegrationFlags,

--- a/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
@@ -467,7 +467,12 @@ test("parseGrokModelsOutput reads default and bullet list", () => {
   ].join("\n"));
   assert.equal(parsed.currentModelId, "grok-4.5");
   assert.deepEqual(parsed.models, [
-    { id: "grok-4.5", name: "grok-4.5" },
+    {
+      id: "grok-4.5",
+      name: "grok-4.5",
+      thinkingLevels: ["high", "medium", "low"],
+      defaultThinkingLevel: "high",
+    },
     { id: "grok-code-fast", name: "grok-code-fast" },
   ]);
 });
@@ -743,7 +748,8 @@ test("listGrokModels parses spawn stdout", async () => {
   child.pid = 1;
   child.kill = () => {};
 
-  const spawnImpl = () => {
+  const spawnImpl = (_bin, args) => {
+    assert.deepEqual(args, ["--no-auto-update", "models"]);
     queueMicrotask(() => {
       child.stdout.emit("data", Buffer.from("Default model: grok-4.5\n* grok-4.5 (default)\n"));
       child.emit("close", 0);

--- a/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/grokDriver.test.cjs
@@ -18,6 +18,7 @@ const {
   extractGrokAcpPromptUsage,
   emitGrokUsage,
   normalizeGrokPlanUpdate,
+  parseGrokModelSelection,
   shouldReportGrokProcessExitFailure,
   runGrokTurn,
   spawnGrokProcess,
@@ -83,6 +84,28 @@ test("buildGrokCliArgs uses streaming-json and optional model/resume/cwd", () =>
   assert.ok(autoArgs.includes("--always-approve"));
   assert.ok(autoArgs.includes("--no-auto-update"));
   assert.ok(!autoArgs.includes("-m"));
+});
+
+test("buildGrokCliArgs passes a selected reasoning effort separately from the model", () => {
+  assert.deepEqual(parseGrokModelSelection("grok-4.6/xhigh"), {
+    model: "grok-4.6",
+    effort: "xhigh",
+  });
+  assert.deepEqual(parseGrokModelSelection("provider/model"), {
+    model: "provider/model",
+    effort: undefined,
+  });
+
+  const args = buildGrokCliArgs({
+    prompt: "hi",
+    model: "grok-4.6/xhigh",
+    permissionMode: "auto",
+    toolIntegrationMode: "skills",
+  });
+  const modelIdx = args.indexOf("-m");
+  const effortIdx = args.indexOf("--reasoning-effort");
+  assert.equal(args[modelIdx + 1], "grok-4.6");
+  assert.equal(args[effortIdx + 1], "xhigh");
 });
 
 test("resolveGrokToolIntegrationFlags locks local side-effect tools only in MCP mode", () => {

--- a/electron/bridges/aiBridge/sdk/index.cjs
+++ b/electron/bridges/aiBridge/sdk/index.cjs
@@ -364,15 +364,22 @@ const DRIVER_REGISTRY = {
         abortController: ctx.abortController,
         signal: ctx.signal || ctx.abortController?.signal,
       });
-      if (acpCatalog.models.length > 0 || acpCatalog.currentModelId) {
+      if (acpCatalog.models.length > 0) {
         return acpCatalog;
       }
-      return grok.listGrokModels({
+      const fallbackCatalog = await grok.listGrokModels({
         binPath: ctx.binPath,
         env: ctx.env,
         abortController: ctx.abortController,
         signal: ctx.signal || ctx.abortController?.signal,
       });
+      const currentModelId = acpCatalog.currentModelId || fallbackCatalog.currentModelId;
+      const models = fallbackCatalog.models.length > 0
+        ? fallbackCatalog.models
+        : (currentModelId
+          ? [grok.applyGrokReasoningFallback({ id: currentModelId, name: currentModelId })]
+          : []);
+      return { currentModelId, models };
     },
   },
 };

--- a/electron/bridges/aiBridge/sdk/index.cjs
+++ b/electron/bridges/aiBridge/sdk/index.cjs
@@ -358,6 +358,15 @@ const DRIVER_REGISTRY = {
       });
     },
     async listModels(ctx) {
+      const acpCatalog = await grokAcp.listGrokAcpModels({
+        binPath: ctx.binPath,
+        env: ctx.env,
+        abortController: ctx.abortController,
+        signal: ctx.signal || ctx.abortController?.signal,
+      });
+      if (acpCatalog.models.length > 0 || acpCatalog.currentModelId) {
+        return acpCatalog;
+      }
       return grok.listGrokModels({
         binPath: ctx.binPath,
         env: ctx.env,

--- a/electron/bridges/aiBridge/sdk/index.cjs
+++ b/electron/bridges/aiBridge/sdk/index.cjs
@@ -379,7 +379,10 @@ const DRIVER_REGISTRY = {
         : (currentModelId
           ? [grok.applyGrokReasoningFallback({ id: currentModelId, name: currentModelId })]
           : []);
-      return { currentModelId, models };
+      return {
+        currentModelId: grok.resolveGrokCatalogCurrentModelId(models, currentModelId),
+        models,
+      };
     },
   },
 };

--- a/infrastructure/ai/types.test.ts
+++ b/infrastructure/ai/types.test.ts
@@ -44,11 +44,17 @@ test('getAgentModelPresets returns curated Grok fallback when runtime catalog is
   assert.deepEqual(getAgentModelPresets('C:\\\\Tools\\\\grok.exe', 'grok'), GROK_MODEL_PRESETS);
   assert.equal(getAgentModelPresets(undefined, 'grok')[0]?.id, 'grok-4.5');
   assert.deepEqual(getAgentModelPresets(undefined, 'grok')[0]?.thinkingLevels, [
-    'low',
-    'medium',
     'high',
+    'medium',
+    'low',
   ]);
   assert.equal(getAgentModelPresets(undefined, 'grok')[0]?.defaultThinkingLevel, 'high');
+  assert.deepEqual(getAgentModelPresets(undefined, 'grok')[1], {
+    id: 'grok-4.6',
+    name: 'Grok 4.6',
+    thinkingLevels: ['xhigh', 'high', 'medium', 'low'],
+    defaultThinkingLevel: 'high',
+  });
   // Empty/failed runtime catalog path: shared resolver still yields a non-empty list.
   const runtimeCatalog: Array<{ id: string; name: string }> = [];
   const resolved = runtimeCatalog.length > 0

--- a/infrastructure/ai/types.test.ts
+++ b/infrastructure/ai/types.test.ts
@@ -43,6 +43,12 @@ test('getAgentModelPresets returns curated Grok fallback when runtime catalog is
   assert.deepEqual(getAgentModelPresets('/usr/local/bin/grok'), GROK_MODEL_PRESETS);
   assert.deepEqual(getAgentModelPresets('C:\\\\Tools\\\\grok.exe', 'grok'), GROK_MODEL_PRESETS);
   assert.equal(getAgentModelPresets(undefined, 'grok')[0]?.id, 'grok-4.5');
+  assert.deepEqual(getAgentModelPresets(undefined, 'grok')[0]?.thinkingLevels, [
+    'low',
+    'medium',
+    'high',
+  ]);
+  assert.equal(getAgentModelPresets(undefined, 'grok')[0]?.defaultThinkingLevel, 'high');
   // Empty/failed runtime catalog path: shared resolver still yields a non-empty list.
   const runtimeCatalog: Array<{ id: string; name: string }> = [];
   const resolved = runtimeCatalog.length > 0

--- a/infrastructure/ai/types.ts
+++ b/infrastructure/ai/types.ts
@@ -489,7 +489,7 @@ export interface AgentModelPreset {
   id: string;
   name: string;
   description?: string;
-  /** Codex thinking levels (model ID sent as `id/thinking`) */
+  /** Supported reasoning levels (renderer selection encoded as `id/thinking`). */
   thinkingLevels?: string[];
   /**
    * Default effort used when auto-selecting a model with thinkingLevels.
@@ -708,7 +708,13 @@ export const OPENCODE_MODEL_PRESETS: AgentModelPreset[] = [
 // Curated Grok Build models when `grok models` is unavailable. IDs mirror the
 // public Grok Build / xAI coding agent lineup; live discovery still overrides.
 export const GROK_MODEL_PRESETS: AgentModelPreset[] = [
-  { id: 'grok-4.5', name: 'Grok 4.5', description: 'Default' },
+  {
+    id: 'grok-4.5',
+    name: 'Grok 4.5',
+    description: 'Default',
+    thinkingLevels: ['low', 'medium', 'high'],
+    defaultThinkingLevel: 'high',
+  },
 ];
 
 export function getAgentModelPresets(

--- a/infrastructure/ai/types.ts
+++ b/infrastructure/ai/types.ts
@@ -712,7 +712,13 @@ export const GROK_MODEL_PRESETS: AgentModelPreset[] = [
     id: 'grok-4.5',
     name: 'Grok 4.5',
     description: 'Default',
-    thinkingLevels: ['low', 'medium', 'high'],
+    thinkingLevels: ['high', 'medium', 'low'],
+    defaultThinkingLevel: 'high',
+  },
+  {
+    id: 'grok-4.6',
+    name: 'Grok 4.6',
+    thinkingLevels: ['xhigh', 'high', 'medium', 'low'],
     defaultThinkingLevel: 'high',
   },
 ];


### PR DESCRIPTION
## Summary

Add Grok Build reasoning-effort selection using the model-specific capabilities advertised by Grok itself. This fixes the missing thinking-depth picker reported in #3054 without changing the separate model-default behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3054

## Changes Made

- Read Grok's live model capability list, including supported reasoning levels and defaults.
- Show reasoning choices only for Grok models that advertise support.
- Pass the selected model and reasoning effort separately in both supported Grok execution paths.
- Keep a compatible Grok 4.5 fallback when live discovery is unavailable.
- Preserve known reasoning choices when live discovery is incomplete, and bound the model probe's shutdown.
- Disable Grok's background update checks during both live and fallback model discovery.
- Add regression coverage for model discovery, fallback behavior, selection parsing, and launch arguments.

## Screenshots / Demo

Verified in a locally built, isolated Netcatty profile with the installed Grok Build client:

- Grok 4.6 showed Extra High, High, Medium, and Low; High was selected by default.
- Selecting Extra High persisted when the model menu was reopened.
- Grok 4.5 showed High, Medium, and Low.
- Models that do not support reasoning effort did not show a nested effort menu.

No prompt was sent during this verification.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Additional validation:

- Focused Grok and model-picker tests: 101 passed.
- Broader AI SDK and UI tests: 617 passed.
- Full suite: 10,425 passed, 11 skipped, 0 failed.
- Production build completed successfully.
- `git diff --check` passed.
- Live Grok discovery returned the expected model-specific effort lists.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

No standalone documentation update is needed because this restores an existing shared model-picker capability for Grok Build.
