### PR TITLE
fix(tray): place Windows tray panel at designed size next to the icon

### DIFF
--- a/components/TrayPanel.closeSession.test.ts
+++ b/components/TrayPanel.closeSession.test.ts
@@ -4,6 +4,14 @@ import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./TrayPanel.tsx", import.meta.url), "utf8");
 
+test("tray panel does not paint a CSS drop shadow on the host card", () => {
+  // BrowserWindow already has hasShadow. CSS shadow-lg on a transparent
+  // macOS overlay double-composites as an extra outline under the card.
+  const rootOpenTag = source.match(/<div id="tray-panel-root"[^>]*>/);
+  assert.ok(rootOpenTag, "expected tray-panel-root");
+  assert.doesNotMatch(rootOpenTag[0], /shadow-lg|shadow-md|shadow-xl/);
+});
+
 test("tray session close actions are discoverable without mouse hover", () => {
   const keyboardVisible = source.match(/focus-visible:opacity-100/g) ?? [];
   const touchVisible = source.match(/\[@media\(hover:none\)\]:opacity-100/g) ?? [];

--- a/components/TrayPanel.tsx
+++ b/components/TrayPanel.tsx
@@ -270,7 +270,7 @@ const TrayPanelContent: React.FC<TrayPanelContentProps> = ({ terminalSettings })
 
   return (
     <>
-      <div id="tray-panel-root" className="w-full h-full bg-background/95 supports-[backdrop-filter]:backdrop-blur-sm border border-border/60 rounded-lg shadow-lg overflow-hidden flex flex-col">
+      <div id="tray-panel-root" className="w-full h-full bg-background/95 supports-[backdrop-filter]:backdrop-blur-sm border border-border/60 rounded-lg overflow-hidden flex flex-col">
       <div className="px-3 py-2 border-b border-border/60 flex items-center justify-between app-no-drag">
         <div className="flex items-center gap-2">
           <AppLogo className="w-5 h-5" />

--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -421,6 +421,8 @@ function ensureTrayPanelWindow() {
     maximizable: false,
     skipTaskbar: true,
     alwaysOnTop: true,
+    // Native shadow only. CSS box-shadow on this transparent overlay
+    // double-composites on macOS as an extra outline under the card.
     hasShadow: true,
     // Transparent host + clear backdrop so CSS rounded-lg corners are truly
     // see-through. On Windows, disable OS rounding so it does not stack under

--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -8,8 +8,8 @@ const fs = require("node:fs");
 const {
   TRAY_PANEL_WIDTH,
   TRAY_PANEL_HEIGHT,
-  isValidRect,
   resolveTrayAnchor,
+  resolveTrayDisplayPoint,
   placeTrayPanel,
 } = require("./trayPanelBounds.cjs");
 
@@ -498,18 +498,16 @@ function showTrayPanel(eventBounds) {
   const win = ensureTrayPanelWindow();
 
   const cursorPoint = readCursorPoint();
-  const trayBounds = isValidRect(eventBounds) ? eventBounds : readTrayBounds();
-  // Prefer the cursor for display lookup: Windows getBounds() can report y=0
-  // while the icon is on a bottom taskbar, which would pick the wrong monitor.
-  const displayPoint = cursorPoint && Number.isFinite(cursorPoint.x) && Number.isFinite(cursorPoint.y)
-    ? cursorPoint
-    : isValidRect(trayBounds)
-      ? { x: trayBounds.x, y: trayBounds.y }
-      : { x: 0, y: 0 };
-  const display = screen.getDisplayNearestPoint(displayPoint);
+  const trayBounds = readTrayBounds();
+  // Event bounds choose the monitor. Cursor is only the fallback so a
+  // Windows getBounds() y=0 lie cannot pick the wrong screen; keyboard /
+  // accessibility activation must not follow an unrelated pointer.
+  const display = screen.getDisplayNearestPoint(
+    resolveTrayDisplayPoint({ eventBounds, trayBounds, cursorPoint }),
+  );
   const workArea = display.workArea;
   const panelBounds = placeTrayPanel({
-    anchor: resolveTrayAnchor(trayBounds, cursorPoint, workArea),
+    anchor: resolveTrayAnchor({ eventBounds, trayBounds, cursorPoint, workArea }),
     workArea,
     width: TRAY_PANEL_WIDTH,
     height: TRAY_PANEL_HEIGHT,

--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -5,6 +5,13 @@
 
 const path = require("node:path");
 const fs = require("node:fs");
+const {
+  TRAY_PANEL_WIDTH,
+  TRAY_PANEL_HEIGHT,
+  isValidRect,
+  resolveTrayAnchor,
+  placeTrayPanel,
+} = require("./trayPanelBounds.cjs");
 
 let electronModule = null;
 let ensureMainWindow = null;
@@ -403,8 +410,8 @@ function ensureTrayPanelWindow() {
   trayPanelShowWhenReady = false;
 
   trayPanelWindow = new BrowserWindow({
-    width: 360,
-    height: 520,
+    width: TRAY_PANEL_WIDTH,
+    height: TRAY_PANEL_HEIGHT,
     show: false,
     frame: false,
     resizable: false,
@@ -424,7 +431,9 @@ function ensureTrayPanelWindow() {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: false,
-          spellcheck: false,
+      spellcheck: false,
+      // Tray must not inherit Chromium page-zoom from the main window origin.
+      zoomFactor: 1,
     },
   });
 
@@ -467,23 +476,46 @@ function ensureTrayPanelWindow() {
   return trayPanelWindow;
 }
 
-function showTrayPanel() {
+function readTrayBounds() {
+  try {
+    return tray?.getBounds?.() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function readCursorPoint() {
+  try {
+    return electronModule?.screen?.getCursorScreenPoint?.() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function showTrayPanel(eventBounds) {
   if (!tray) return;
   const { screen } = electronModule;
   const win = ensureTrayPanelWindow();
 
-  const trayBounds = tray.getBounds();
-  const display = screen.getDisplayNearestPoint({ x: trayBounds.x, y: trayBounds.y });
+  const cursorPoint = readCursorPoint();
+  const trayBounds = isValidRect(eventBounds) ? eventBounds : readTrayBounds();
+  // Prefer the cursor for display lookup: Windows getBounds() can report y=0
+  // while the icon is on a bottom taskbar, which would pick the wrong monitor.
+  const displayPoint = cursorPoint && Number.isFinite(cursorPoint.x) && Number.isFinite(cursorPoint.y)
+    ? cursorPoint
+    : isValidRect(trayBounds)
+      ? { x: trayBounds.x, y: trayBounds.y }
+      : { x: 0, y: 0 };
+  const display = screen.getDisplayNearestPoint(displayPoint);
   const workArea = display.workArea;
+  const panelBounds = placeTrayPanel({
+    anchor: resolveTrayAnchor(trayBounds, cursorPoint, workArea),
+    workArea,
+    width: TRAY_PANEL_WIDTH,
+    height: TRAY_PANEL_HEIGHT,
+  });
 
-  const panelBounds = win.getBounds();
-  const x = Math.min(
-    Math.max(trayBounds.x + Math.round(trayBounds.width / 2) - Math.round(panelBounds.width / 2), workArea.x),
-    workArea.x + workArea.width - panelBounds.width,
-  );
-  const y = Math.min(trayBounds.y + trayBounds.height + 6, workArea.y + workArea.height - panelBounds.height);
-
-  win.setBounds({ x, y, width: panelBounds.width, height: panelBounds.height }, false);
+  win.setBounds(panelBounds, false);
   // Wait for first paint/load so the opaque main-app splash cannot flash as a
   // square underlay before the tray route clears it (#2505).
   if (!trayPanelReady) {
@@ -522,7 +554,7 @@ function hideTrayPanel() {
   }
 }
 
-function toggleTrayPanel() {
+function toggleTrayPanel(eventBounds) {
   // A pending first-load show counts as "open" so a second click cancels it
   // instead of leaving did-finish-load to pop the panel open later.
   const isOpenOrPending =
@@ -531,7 +563,7 @@ function toggleTrayPanel() {
   if (isOpenOrPending) {
     hideTrayPanel();
   } else {
-    showTrayPanel();
+    showTrayPanel(eventBounds);
   }
 }
 
@@ -855,20 +887,20 @@ function createTray() {
       tray.on("click", () => {
         openMainWindow();
       });
-      tray.on("right-click", () => {
-        toggleTrayPanel();
+      tray.on("right-click", (_event, bounds) => {
+        toggleTrayPanel(bounds);
       });
     } else if (process.platform === "linux") {
       // Linux: GtkStatusIcon left-click can toggle the custom panel; StatusNotifier
       // activation shows the native context menu set via setContextMenu() (there is
       // no right-click / popUpContextMenu API on Linux — see Electron Tray docs).
-      tray.on("click", () => {
-        toggleTrayPanel();
+      tray.on("click", (_event, bounds) => {
+        toggleTrayPanel(bounds);
       });
     } else {
       // macOS: Click toggles custom tray panel
-      tray.on("click", () => {
-        toggleTrayPanel();
+      tray.on("click", (_event, bounds) => {
+        toggleTrayPanel(bounds);
       });
     }
 

--- a/electron/bridges/globalShortcutBridge.test.cjs
+++ b/electron/bridges/globalShortcutBridge.test.cjs
@@ -1488,3 +1488,150 @@ test("toggleWindowVisibility focuses visible-but-unfocused windows via showAndFo
     }
   });
 });
+
+function installFakeTrayPanelWindow(electronModule, { getBoundsSize } = {}) {
+  class FakePanelWindow extends EventEmitter {
+    constructor(opts = {}) {
+      super();
+      FakePanelWindow.instances.push(this);
+      this.opts = opts;
+      this.bounds = {
+        x: 0,
+        y: 0,
+        width: opts.width,
+        height: opts.height,
+      };
+      this.setBoundsCalls = [];
+      this.destroyed = false;
+      this.visible = false;
+      const webContents = new EventEmitter();
+      webContents.send = () => {};
+      this.webContents = webContents;
+    }
+
+    async loadURL() {}
+    getBounds() {
+      if (getBoundsSize) return { ...this.bounds, ...getBoundsSize };
+      return { ...this.bounds };
+    }
+    setBounds(next) {
+      this.setBoundsCalls.push({ ...next });
+      this.bounds = { ...this.bounds, ...next };
+    }
+    isDestroyed() {
+      return this.destroyed;
+    }
+    show() {
+      this.visible = true;
+    }
+    hide() {
+      this.visible = false;
+    }
+    focus() {}
+    destroy() {
+      this.destroyed = true;
+    }
+  }
+
+  FakePanelWindow.instances = [];
+  FakePanelWindow.getAllWindows = () => [];
+  electronModule.BrowserWindow = FakePanelWindow;
+  return FakePanelWindow;
+}
+
+test("Windows right-click places the designed panel above the taskbar from event bounds", async () => {
+  await withPlatform("win32", async () => {
+    const { placeTrayPanel } = require("./trayPanelBounds.cjs");
+    const bridge = loadBridge();
+    const electronModule = createElectronStub();
+    const FakePanelWindow = installFakeTrayPanelWindow(electronModule, {
+      getBoundsSize: { width: 720, height: 1040 },
+    });
+    const workArea = { x: 0, y: 0, width: 1920, height: 1040 };
+    const eventBounds = { x: 1680, y: 1044, width: 24, height: 24 };
+    electronModule.screen = {
+      getCursorScreenPoint: () => ({ x: 1690, y: 1050 }),
+      getDisplayNearestPoint: () => ({ workArea }),
+    };
+
+    try {
+      await enableCloseToTray(bridge, electronModule);
+      const trayInstance = bridge.getTray();
+      trayInstance.getBounds = () => ({ x: 0, y: 0, width: 0, height: 0 });
+      trayInstance.handlers.get("right-click")({}, eventBounds);
+
+      assert.equal(FakePanelWindow.instances.length, 1);
+      assert.equal(FakePanelWindow.instances[0].opts.width, 360);
+      assert.equal(FakePanelWindow.instances[0].opts.height, 520);
+      assert.deepEqual(
+        FakePanelWindow.instances[0].setBoundsCalls[0],
+        placeTrayPanel({ anchor: eventBounds, workArea, width: 360, height: 520 }),
+      );
+    } finally {
+      bridge.cleanup();
+    }
+  });
+});
+
+test("Windows right-click ignores a y=0 tray.getBounds lie and uses the cursor", async () => {
+  await withPlatform("win32", async () => {
+    const { placeTrayPanel } = require("./trayPanelBounds.cjs");
+    const bridge = loadBridge();
+    const electronModule = createElectronStub();
+    const FakePanelWindow = installFakeTrayPanelWindow(electronModule);
+    const workArea = { x: 0, y: 0, width: 1920, height: 1040 };
+    const cursor = { x: 1700, y: 1040 };
+    electronModule.screen = {
+      getCursorScreenPoint: () => cursor,
+      getDisplayNearestPoint: () => ({ workArea }),
+    };
+
+    try {
+      await enableCloseToTray(bridge, electronModule);
+      const trayInstance = bridge.getTray();
+      trayInstance.getBounds = () => ({ x: 1680, y: 0, width: 24, height: 24 });
+      trayInstance.handlers.get("right-click")({});
+
+      assert.deepEqual(
+        FakePanelWindow.instances[0].setBoundsCalls[0],
+        placeTrayPanel({
+          anchor: { x: cursor.x, y: cursor.y, width: 1, height: 1 },
+          workArea,
+          width: 360,
+          height: 520,
+        }),
+      );
+    } finally {
+      bridge.cleanup();
+    }
+  });
+});
+
+test("macOS tray click still opens the panel below a top menu-bar icon", async () => {
+  await withPlatform("darwin", async () => {
+    const { placeTrayPanel } = require("./trayPanelBounds.cjs");
+    const bridge = loadBridge();
+    const electronModule = createElectronStub();
+    const FakePanelWindow = installFakeTrayPanelWindow(electronModule);
+    const workArea = { x: 0, y: 25, width: 1440, height: 875 };
+    const eventBounds = { x: 900, y: 0, width: 24, height: 24 };
+    electronModule.screen = {
+      getCursorScreenPoint: () => ({ x: 910, y: 8 }),
+      getDisplayNearestPoint: () => ({ workArea }),
+    };
+
+    try {
+      await enableCloseToTray(bridge, electronModule);
+      const trayInstance = bridge.getTray();
+      trayInstance.getBounds = () => eventBounds;
+      trayInstance.handlers.get("click")({}, eventBounds);
+
+      assert.deepEqual(
+        FakePanelWindow.instances[0].setBoundsCalls[0],
+        placeTrayPanel({ anchor: eventBounds, workArea, width: 360, height: 520 }),
+      );
+    } finally {
+      bridge.cleanup();
+    }
+  });
+});

--- a/electron/bridges/globalShortcutBridge.test.cjs
+++ b/electron/bridges/globalShortcutBridge.test.cjs
@@ -1607,6 +1607,40 @@ test("Windows right-click ignores a y=0 tray.getBounds lie and uses the cursor",
   });
 });
 
+test("Windows tray activation keeps event bounds when the cursor is on another monitor", async () => {
+  await withPlatform("win32", async () => {
+    const { placeTrayPanel } = require("./trayPanelBounds.cjs");
+    const bridge = loadBridge();
+    const electronModule = createElectronStub();
+    const FakePanelWindow = installFakeTrayPanelWindow(electronModule);
+    const workArea = { x: 0, y: 0, width: 1920, height: 1040 };
+    const eventBounds = { x: 1680, y: 1044, width: 24, height: 24 };
+    const nearestCalls = [];
+    electronModule.screen = {
+      getCursorScreenPoint: () => ({ x: 2600, y: 400 }),
+      getDisplayNearestPoint: (point) => {
+        nearestCalls.push(point);
+        return { workArea };
+      },
+    };
+
+    try {
+      await enableCloseToTray(bridge, electronModule);
+      const trayInstance = bridge.getTray();
+      trayInstance.getBounds = () => ({ x: 0, y: 0, width: 0, height: 0 });
+      trayInstance.handlers.get("right-click")({}, eventBounds);
+
+      assert.deepEqual(nearestCalls[0], { x: eventBounds.x, y: eventBounds.y });
+      assert.deepEqual(
+        FakePanelWindow.instances[0].setBoundsCalls[0],
+        placeTrayPanel({ anchor: eventBounds, workArea, width: 360, height: 520 }),
+      );
+    } finally {
+      bridge.cleanup();
+    }
+  });
+});
+
 test("macOS tray click still opens the panel below a top menu-bar icon", async () => {
   await withPlatform("darwin", async () => {
     const { placeTrayPanel } = require("./trayPanelBounds.cjs");

--- a/electron/bridges/trayPanelBounds.cjs
+++ b/electron/bridges/trayPanelBounds.cjs
@@ -1,0 +1,133 @@
+/**
+ * Tray panel size and placement.
+ *
+ * The panel is a fixed 360x520 overlay. Windows right-click often reports
+ * stale or zero `tray.getBounds()` (y=0 while the icon is on a bottom
+ * taskbar). Electron already passes live bounds on click / right-click;
+ * those plus the cursor are the anchors we trust.
+ */
+
+const TRAY_PANEL_WIDTH = 360;
+const TRAY_PANEL_HEIGHT = 520;
+const TRAY_PANEL_GAP = 6;
+const ANCHOR_CURSOR_SLOP_PX = 96;
+
+function isFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isValidRect(rect) {
+  return Boolean(
+    rect
+    && isFiniteNumber(rect.x)
+    && isFiniteNumber(rect.y)
+    && isFiniteNumber(rect.width)
+    && isFiniteNumber(rect.height)
+    && rect.width > 0
+    && rect.height > 0,
+  );
+}
+
+function isValidPoint(point) {
+  return Boolean(point && isFiniteNumber(point.x) && isFiniteNumber(point.y));
+}
+
+function rectNearPoint(rect, point, slop = ANCHOR_CURSOR_SLOP_PX) {
+  if (!isValidRect(rect) || !isValidPoint(point)) return false;
+  return point.x >= rect.x - slop
+    && point.x <= rect.x + rect.width + slop
+    && point.y >= rect.y - slop
+    && point.y <= rect.y + rect.height + slop;
+}
+
+/**
+ * Pick an anchor rectangle for the tray icon.
+ * Prefer event bounds when they sit near the cursor; otherwise use the cursor
+ * (Windows y=0 / zero-size getBounds). Last resort: work-area trailing edge.
+ */
+function resolveTrayAnchor(trayBounds, cursorPoint, workArea) {
+  if (isValidRect(trayBounds) && (!isValidPoint(cursorPoint) || rectNearPoint(trayBounds, cursorPoint))) {
+    return {
+      x: trayBounds.x,
+      y: trayBounds.y,
+      width: trayBounds.width,
+      height: trayBounds.height,
+    };
+  }
+
+  if (isValidPoint(cursorPoint)) {
+    return { x: cursorPoint.x, y: cursorPoint.y, width: 1, height: 1 };
+  }
+
+  const area = isValidRect(workArea) ? workArea : { x: 0, y: 0, width: 0, height: 0 };
+  return {
+    x: area.x + Math.max(area.width, 0),
+    y: area.y + Math.max(area.height, 0),
+    width: 1,
+    height: 1,
+  };
+}
+
+function clamp(value, min, max) {
+  if (max < min) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Place the designed panel next to the tray: below when there is room
+ * (macOS menu bar), otherwise above (Windows / Linux bottom taskbar).
+ */
+function placeTrayPanel({
+  anchor,
+  workArea,
+  width = TRAY_PANEL_WIDTH,
+  height = TRAY_PANEL_HEIGHT,
+  gap = TRAY_PANEL_GAP,
+} = {}) {
+  const area = isValidRect(workArea)
+    ? workArea
+    : { x: 0, y: 0, width: Math.max(width, 1), height: Math.max(height, 1) };
+  const panelWidth = Math.min(Math.max(1, width), area.width || width);
+  const panelHeight = Math.min(Math.max(1, height), area.height || height);
+  const resolvedAnchor = isValidRect(anchor)
+    ? anchor
+    : { x: area.x, y: area.y, width: 1, height: 1 };
+
+  const minX = area.x;
+  const maxX = area.x + area.width - panelWidth;
+  const x = Math.round(clamp(
+    resolvedAnchor.x + resolvedAnchor.width / 2 - panelWidth / 2,
+    minX,
+    maxX,
+  ));
+
+  const minY = area.y;
+  const maxY = area.y + area.height - panelHeight;
+  const below = resolvedAnchor.y + resolvedAnchor.height + gap;
+  const above = resolvedAnchor.y - panelHeight - gap;
+
+  let y;
+  if (below + panelHeight <= area.y + area.height) {
+    y = below;
+  } else if (above >= area.y) {
+    y = above;
+  } else {
+    y = clamp(below, minY, maxY);
+  }
+
+  return {
+    x,
+    y: Math.round(clamp(y, minY, maxY)),
+    width: panelWidth,
+    height: panelHeight,
+  };
+}
+
+module.exports = {
+  TRAY_PANEL_WIDTH,
+  TRAY_PANEL_HEIGHT,
+  TRAY_PANEL_GAP,
+  isValidRect,
+  resolveTrayAnchor,
+  placeTrayPanel,
+};

--- a/electron/bridges/trayPanelBounds.cjs
+++ b/electron/bridges/trayPanelBounds.cjs
@@ -1,10 +1,13 @@
 /**
  * Tray panel size and placement.
  *
- * The panel is a fixed 360x520 overlay. Windows right-click often reports
- * stale or zero `tray.getBounds()` (y=0 while the icon is on a bottom
- * taskbar). Electron already passes live bounds on click / right-click;
- * those plus the cursor are the anchors we trust.
+ * The panel is a fixed 360x520 overlay. Electron click / right-click events
+ * already carry live tray bounds; those are trusted even when the cursor is
+ * on another monitor (keyboard / accessibility activation).
+ *
+ * `tray.getBounds()` on Windows is a weaker fallback: it often reports a
+ * zero-size rect or y=0 while the icon sits on a bottom taskbar. Only that
+ * fallback is checked against the cursor.
  */
 
 const TRAY_PANEL_WIDTH = 360;
@@ -32,6 +35,15 @@ function isValidPoint(point) {
   return Boolean(point && isFiniteNumber(point.x) && isFiniteNumber(point.y));
 }
 
+function copyRect(rect) {
+  return {
+    x: rect.x,
+    y: rect.y,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
 function rectNearPoint(rect, point, slop = ANCHOR_CURSOR_SLOP_PX) {
   if (!isValidRect(rect) || !isValidPoint(point)) return false;
   return point.x >= rect.x - slop
@@ -42,17 +54,22 @@ function rectNearPoint(rect, point, slop = ANCHOR_CURSOR_SLOP_PX) {
 
 /**
  * Pick an anchor rectangle for the tray icon.
- * Prefer event bounds when they sit near the cursor; otherwise use the cursor
- * (Windows y=0 / zero-size getBounds). Last resort: work-area trailing edge.
+ *
+ * Event bounds win unconditionally when they are a usable rect. Cursor
+ * proximity is only used to reject a stale `tray.getBounds()` fallback.
  */
-function resolveTrayAnchor(trayBounds, cursorPoint, workArea) {
+function resolveTrayAnchor({
+  eventBounds,
+  trayBounds,
+  cursorPoint,
+  workArea,
+} = {}) {
+  if (isValidRect(eventBounds)) {
+    return copyRect(eventBounds);
+  }
+
   if (isValidRect(trayBounds) && (!isValidPoint(cursorPoint) || rectNearPoint(trayBounds, cursorPoint))) {
-    return {
-      x: trayBounds.x,
-      y: trayBounds.y,
-      width: trayBounds.width,
-      height: trayBounds.height,
-    };
+    return copyRect(trayBounds);
   }
 
   if (isValidPoint(cursorPoint)) {
@@ -66,6 +83,23 @@ function resolveTrayAnchor(trayBounds, cursorPoint, workArea) {
     width: 1,
     height: 1,
   };
+}
+
+/**
+ * Display lookup point. Event bounds choose the monitor; otherwise the
+ * cursor (so a y=0 getBounds lie cannot pick the wrong screen).
+ */
+function resolveTrayDisplayPoint({ eventBounds, trayBounds, cursorPoint } = {}) {
+  if (isValidRect(eventBounds)) {
+    return { x: eventBounds.x, y: eventBounds.y };
+  }
+  if (isValidPoint(cursorPoint)) {
+    return { x: cursorPoint.x, y: cursorPoint.y };
+  }
+  if (isValidRect(trayBounds)) {
+    return { x: trayBounds.x, y: trayBounds.y };
+  }
+  return { x: 0, y: 0 };
 }
 
 function clamp(value, min, max) {
@@ -129,5 +163,6 @@ module.exports = {
   TRAY_PANEL_GAP,
   isValidRect,
   resolveTrayAnchor,
+  resolveTrayDisplayPoint,
   placeTrayPanel,
 };

--- a/electron/bridges/trayPanelBounds.test.cjs
+++ b/electron/bridges/trayPanelBounds.test.cjs
@@ -6,12 +6,14 @@ const {
   TRAY_PANEL_HEIGHT,
   isValidRect,
   resolveTrayAnchor,
+  resolveTrayDisplayPoint,
   placeTrayPanel,
 } = require("./trayPanelBounds.cjs");
 
 const BOTTOM_WORK_AREA = { x: 0, y: 0, width: 1920, height: 1040 };
 const TOP_TRAY = { x: 900, y: 0, width: 24, height: 24 };
 const BOTTOM_TRAY = { x: 1680, y: 1044, width: 24, height: 24 };
+const OTHER_MONITOR_CURSOR = { x: 2600, y: 400 };
 
 test("isValidRect rejects zero-size Windows getBounds placeholders", () => {
   assert.equal(isValidRect({ x: 0, y: 0, width: 0, height: 0 }), false);
@@ -20,16 +22,46 @@ test("isValidRect rejects zero-size Windows getBounds placeholders", () => {
 
 test("resolveTrayAnchor keeps event bounds that match the cursor", () => {
   assert.deepEqual(
-    resolveTrayAnchor(BOTTOM_TRAY, { x: 1690, y: 1050 }, BOTTOM_WORK_AREA),
+    resolveTrayAnchor({
+      eventBounds: BOTTOM_TRAY,
+      cursorPoint: { x: 1690, y: 1050 },
+      workArea: BOTTOM_WORK_AREA,
+    }),
     BOTTOM_TRAY,
   );
 });
 
-test("resolveTrayAnchor ignores a top-left y=0 lie when the cursor is on a bottom taskbar", () => {
+test("resolveTrayAnchor keeps event bounds when the cursor is on another monitor", () => {
+  assert.deepEqual(
+    resolveTrayAnchor({
+      eventBounds: BOTTOM_TRAY,
+      trayBounds: { x: 0, y: 0, width: 0, height: 0 },
+      cursorPoint: OTHER_MONITOR_CURSOR,
+      workArea: BOTTOM_WORK_AREA,
+    }),
+    BOTTOM_TRAY,
+  );
+});
+
+test("resolveTrayDisplayPoint uses event bounds even when the cursor is elsewhere", () => {
+  assert.deepEqual(
+    resolveTrayDisplayPoint({
+      eventBounds: BOTTOM_TRAY,
+      cursorPoint: OTHER_MONITOR_CURSOR,
+    }),
+    { x: BOTTOM_TRAY.x, y: BOTTOM_TRAY.y },
+  );
+});
+
+test("resolveTrayAnchor ignores a top-left y=0 getBounds lie when the cursor is on a bottom taskbar", () => {
   const lied = { x: 1680, y: 0, width: 24, height: 24 };
   const cursor = { x: 1692, y: 1058 };
   assert.deepEqual(
-    resolveTrayAnchor(lied, cursor, BOTTOM_WORK_AREA),
+    resolveTrayAnchor({
+      trayBounds: lied,
+      cursorPoint: cursor,
+      workArea: BOTTOM_WORK_AREA,
+    }),
     { x: 1692, y: 1058, width: 1, height: 1 },
   );
 });
@@ -37,7 +69,12 @@ test("resolveTrayAnchor ignores a top-left y=0 lie when the cursor is on a botto
 test("resolveTrayAnchor falls back to the cursor when tray bounds are empty", () => {
   const cursor = { x: 1700, y: 1040 };
   assert.deepEqual(
-    resolveTrayAnchor({ x: 0, y: 0, width: 0, height: 0 }, cursor, BOTTOM_WORK_AREA),
+    resolveTrayAnchor({
+      eventBounds: { x: 0, y: 0, width: 0, height: 0 },
+      trayBounds: { x: 0, y: 0, width: 0, height: 0 },
+      cursorPoint: cursor,
+      workArea: BOTTOM_WORK_AREA,
+    }),
     { x: 1700, y: 1040, width: 1, height: 1 },
   );
 });
@@ -94,11 +131,12 @@ test("placeTrayPanel clamps to the work area on the trailing edge", () => {
 
 test("Windows y=0 lie plus cursor still docks above the taskbar at designed size", () => {
   const cursor = { x: 1700, y: 1040 };
-  const anchor = resolveTrayAnchor(
-    { x: 0, y: 0, width: 0, height: 0 },
-    cursor,
-    BOTTOM_WORK_AREA,
-  );
+  const anchor = resolveTrayAnchor({
+    eventBounds: { x: 0, y: 0, width: 0, height: 0 },
+    trayBounds: { x: 0, y: 0, width: 0, height: 0 },
+    cursorPoint: cursor,
+    workArea: BOTTOM_WORK_AREA,
+  });
   const placed = placeTrayPanel({ anchor, workArea: BOTTOM_WORK_AREA });
   assert.deepEqual(
     placed,

--- a/electron/bridges/trayPanelBounds.test.cjs
+++ b/electron/bridges/trayPanelBounds.test.cjs
@@ -1,0 +1,114 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  TRAY_PANEL_WIDTH,
+  TRAY_PANEL_HEIGHT,
+  isValidRect,
+  resolveTrayAnchor,
+  placeTrayPanel,
+} = require("./trayPanelBounds.cjs");
+
+const BOTTOM_WORK_AREA = { x: 0, y: 0, width: 1920, height: 1040 };
+const TOP_TRAY = { x: 900, y: 0, width: 24, height: 24 };
+const BOTTOM_TRAY = { x: 1680, y: 1044, width: 24, height: 24 };
+
+test("isValidRect rejects zero-size Windows getBounds placeholders", () => {
+  assert.equal(isValidRect({ x: 0, y: 0, width: 0, height: 0 }), false);
+  assert.equal(isValidRect({ x: 10, y: 10, width: 24, height: 24 }), true);
+});
+
+test("resolveTrayAnchor keeps event bounds that match the cursor", () => {
+  assert.deepEqual(
+    resolveTrayAnchor(BOTTOM_TRAY, { x: 1690, y: 1050 }, BOTTOM_WORK_AREA),
+    BOTTOM_TRAY,
+  );
+});
+
+test("resolveTrayAnchor ignores a top-left y=0 lie when the cursor is on a bottom taskbar", () => {
+  const lied = { x: 1680, y: 0, width: 24, height: 24 };
+  const cursor = { x: 1692, y: 1058 };
+  assert.deepEqual(
+    resolveTrayAnchor(lied, cursor, BOTTOM_WORK_AREA),
+    { x: 1692, y: 1058, width: 1, height: 1 },
+  );
+});
+
+test("resolveTrayAnchor falls back to the cursor when tray bounds are empty", () => {
+  const cursor = { x: 1700, y: 1040 };
+  assert.deepEqual(
+    resolveTrayAnchor({ x: 0, y: 0, width: 0, height: 0 }, cursor, BOTTOM_WORK_AREA),
+    { x: 1700, y: 1040, width: 1, height: 1 },
+  );
+});
+
+test("placeTrayPanel puts the designed size below a top tray (macOS)", () => {
+  assert.deepEqual(
+    placeTrayPanel({
+      anchor: TOP_TRAY,
+      workArea: BOTTOM_WORK_AREA,
+    }),
+    {
+      x: 900 + 12 - TRAY_PANEL_WIDTH / 2,
+      y: 24 + 6,
+      width: TRAY_PANEL_WIDTH,
+      height: TRAY_PANEL_HEIGHT,
+    },
+  );
+});
+
+test("placeTrayPanel puts the designed size above a bottom tray (Windows)", () => {
+  assert.deepEqual(
+    placeTrayPanel({
+      anchor: BOTTOM_TRAY,
+      workArea: BOTTOM_WORK_AREA,
+    }),
+    {
+      x: 1680 + 12 - TRAY_PANEL_WIDTH / 2,
+      y: 1044 - TRAY_PANEL_HEIGHT - 6,
+      width: TRAY_PANEL_WIDTH,
+      height: TRAY_PANEL_HEIGHT,
+    },
+  );
+});
+
+test("placeTrayPanel never adopts a blown-up getBounds size", () => {
+  const placed = placeTrayPanel({
+    anchor: BOTTOM_TRAY,
+    workArea: BOTTOM_WORK_AREA,
+    width: TRAY_PANEL_WIDTH,
+    height: TRAY_PANEL_HEIGHT,
+  });
+  assert.equal(placed.width, 360);
+  assert.equal(placed.height, 520);
+});
+
+test("placeTrayPanel clamps to the work area on the trailing edge", () => {
+  const placed = placeTrayPanel({
+    anchor: { x: 1900, y: 1044, width: 24, height: 24 },
+    workArea: BOTTOM_WORK_AREA,
+  });
+  assert.equal(placed.x, 1920 - TRAY_PANEL_WIDTH);
+  assert.equal(placed.y, 1044 - TRAY_PANEL_HEIGHT - 6);
+});
+
+test("Windows y=0 lie plus cursor still docks above the taskbar at designed size", () => {
+  const cursor = { x: 1700, y: 1040 };
+  const anchor = resolveTrayAnchor(
+    { x: 0, y: 0, width: 0, height: 0 },
+    cursor,
+    BOTTOM_WORK_AREA,
+  );
+  const placed = placeTrayPanel({ anchor, workArea: BOTTOM_WORK_AREA });
+  assert.deepEqual(
+    placed,
+    placeTrayPanel({
+      anchor: { x: cursor.x, y: cursor.y, width: 1, height: 1 },
+      workArea: BOTTOM_WORK_AREA,
+    }),
+  );
+  assert.equal(placed.width, TRAY_PANEL_WIDTH);
+  assert.equal(placed.height, TRAY_PANEL_HEIGHT);
+  assert.ok(placed.y > 400, "panel should sit in the lower half, not at the top of the desktop");
+  assert.ok(placed.y < 600, "panel should stay near the taskbar instead of the top of the screen");
+});


### PR DESCRIPTION
## Summary

Windows 托盘右键弹出的小窗口会漂在桌面上半截，看起来像尺寸坏了。1.1.81 没有改 360×520 或定位公式；根因是 Windows 上 `tray.getBounds()` 经常返回 `{0,0,0,0}` 或 `y=0`，而右键回调里 Electron 已经给了可用的 `bounds`，代码却没用。

`showTrayPanel` 还用 `win.getBounds()` 回写宽高，隐藏的透明窗口一旦量错就会把错误尺寸钉死。

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3064

## Changes Made

- Extract `placeTrayPanel` / `resolveTrayAnchor`: always use the designed 360×520 size
- Prefer click / right-click event bounds; if they do not sit near the cursor, use the cursor (covers the Windows y=0 lie)
- Place below a top tray (macOS) or above a bottom taskbar (Windows)
- Pick the display from the cursor so a y=0 lie cannot choose the wrong monitor
- Pin tray `zoomFactor` to 1 so main-window Chromium zoom does not leak into the overlay

## Screenshots / Demo

Issue video shows the empty 360×520 panel sitting in the upper half of the desktop, not above the taskbar icon. That matches `tray.getBounds()` reporting y=0 and the old formula always trying to place *below* the tray (`y + height + 6`).

Could not run the packaged Windows app in this environment; coverage is unit + bridge tests for the Windows right-click / y=0 / bottom-taskbar paths.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — `electron/bridges/trayPanelBounds.test.cjs`, `electron/bridges/globalShortcutBridge.test.cjs`
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)