### PR TITLE
fix(ssh): decrypt encrypted PuTTY ed25519 PPK keys

### DIFF
--- a/electron/bridges/ppkConverter.cjs
+++ b/electron/bridges/ppkConverter.cjs
@@ -203,9 +203,6 @@ function deriveV3Keys(passphrase, encryption, kdf) {
     // PuTTYgen 0.85 and the SshAgentLib ed25519 v3-none fixture.
     return { cipherKey: null, iv: null, macKey: Buffer.alloc(0), macAlgo: "sha256" };
   }
-  if (typeof argon2Sync !== "function") {
-    throw new Error("PPK_V3_ARGON2_UNAVAILABLE");
-  }
   const algorithm = String(kdf?.name || "").toLowerCase();
   if (algorithm !== "argon2id" && algorithm !== "argon2i" && algorithm !== "argon2d") {
     throw new Error(`Unsupported PPK key derivation "${kdf?.name}"`);
@@ -215,6 +212,9 @@ function deriveV3Keys(passphrase, encryption, kdf) {
   }
   assertArgon2WorkFactors(kdf);
   const salt = parseArgon2Salt(kdf.saltHex);
+  if (typeof argon2Sync !== "function") {
+    throw new Error("PPK_V3_ARGON2_UNAVAILABLE");
+  }
   const derived = argon2Sync(algorithm, {
     message: passphrase,
     nonce: salt,

--- a/electron/bridges/ppkConverter.cjs
+++ b/electron/bridges/ppkConverter.cjs
@@ -26,6 +26,16 @@ const PPK_V2_SEQ0 = Buffer.from([0, 0, 0, 0]);
 const PPK_V2_SEQ1 = Buffer.from([0, 0, 0, 1]);
 const PPK_V3_DERIVED_LEN = 80; // 32-byte key + 16-byte IV + 32-byte MAC key
 const OPENSSH_MAGIC = Buffer.from("openssh-key-v1\0");
+// Caps keep a crafted PPK from stalling the Electron main process. Defaults
+// from current PuTTYgen (8 MiB, ~13-34 passes, parallelism 1) sit well inside.
+const ARGON2_MIN_MEMORY_KIB = 8;
+const ARGON2_MAX_MEMORY_KIB = 65536;
+const ARGON2_MIN_PASSES = 1;
+const ARGON2_MAX_PASSES = 128;
+const ARGON2_MIN_PARALLELISM = 1;
+const ARGON2_MAX_PARALLELISM = 4;
+const ARGON2_MIN_SALT_BYTES = 8;
+const ARGON2_MAX_SALT_BYTES = 64;
 
 const SUPPORTED_TYPES = new Set([
   "ssh-ed25519",
@@ -159,6 +169,34 @@ function deriveV2Keys(passphrase) {
   };
 }
 
+function inRange(value, min, max) {
+  return Number.isInteger(value) && value >= min && value <= max;
+}
+
+function parseArgon2Salt(saltHex) {
+  if (typeof saltHex !== "string" || !/^[0-9a-fA-F]+$/.test(saltHex) || saltHex.length % 2 !== 0) {
+    throw new Error("Malformed PPK Argon2 salt");
+  }
+  const salt = Buffer.from(saltHex, "hex");
+  if (salt.length < ARGON2_MIN_SALT_BYTES || salt.length > ARGON2_MAX_SALT_BYTES) {
+    throw new Error("Malformed PPK Argon2 salt");
+  }
+  return salt;
+}
+
+function assertArgon2WorkFactors(kdf) {
+  if (!inRange(kdf.memory, ARGON2_MIN_MEMORY_KIB, ARGON2_MAX_MEMORY_KIB)
+      || !inRange(kdf.passes, ARGON2_MIN_PASSES, ARGON2_MAX_PASSES)
+      || !inRange(kdf.parallelism, ARGON2_MIN_PARALLELISM, ARGON2_MAX_PARALLELISM)) {
+    throw new Error(
+      `PPK Argon2 parameters exceed supported limits ` +
+        `(memory ${ARGON2_MIN_MEMORY_KIB}-${ARGON2_MAX_MEMORY_KIB} KiB, ` +
+        `passes ${ARGON2_MIN_PASSES}-${ARGON2_MAX_PASSES}, ` +
+        `parallelism ${ARGON2_MIN_PARALLELISM}-${ARGON2_MAX_PARALLELISM})`,
+    );
+  }
+}
+
 function deriveV3Keys(passphrase, encryption, kdf) {
   if (encryption === "none") {
     return { cipherKey: null, iv: null, macKey: Buffer.alloc(0), macAlgo: "sha256" };
@@ -170,12 +208,14 @@ function deriveV3Keys(passphrase, encryption, kdf) {
   if (algorithm !== "argon2id" && algorithm !== "argon2i" && algorithm !== "argon2d") {
     throw new Error(`Unsupported PPK key derivation "${kdf?.name}"`);
   }
-  if (!kdf?.saltHex || !Number.isInteger(kdf.memory) || !Number.isInteger(kdf.passes) || !Number.isInteger(kdf.parallelism)) {
+  if (!kdf) {
     throw new Error("Malformed PPK Argon2 parameters");
   }
+  assertArgon2WorkFactors(kdf);
+  const salt = parseArgon2Salt(kdf.saltHex);
   const derived = argon2Sync(algorithm, {
     message: passphrase,
-    nonce: Buffer.from(kdf.saltHex, "hex"),
+    nonce: salt,
     parallelism: kdf.parallelism,
     tagLength: PPK_V3_DERIVED_LEN,
     memory: kdf.memory,

--- a/electron/bridges/ppkConverter.cjs
+++ b/electron/bridges/ppkConverter.cjs
@@ -199,6 +199,8 @@ function assertArgon2WorkFactors(kdf) {
 
 function deriveV3Keys(passphrase, encryption, kdf) {
   if (encryption === "none") {
+    // Unencrypted PPK v3 uses HMAC-SHA256 with an empty key. Confirmed against
+    // PuTTYgen 0.85 and the SshAgentLib ed25519 v3-none fixture.
     return { cipherKey: null, iv: null, macKey: Buffer.alloc(0), macAlgo: "sha256" };
   }
   if (typeof argon2Sync !== "function") {

--- a/electron/bridges/ppkConverter.cjs
+++ b/electron/bridges/ppkConverter.cjs
@@ -1,0 +1,501 @@
+/**
+ * Convert PuTTY PPK private keys into unencrypted OpenSSH PEM.
+ *
+ * ssh2 only parses PPK v2 RSA/DSA (`PuTTY-User-Key-File-2: ssh-rsa|ssh-dss`).
+ * Encrypted Ed25519/ECDSA keys and all PPK v3 files therefore fail even with
+ * the correct passphrase. We decrypt the PPK ourselves and emit OpenSSH PEM
+ * that ssh2 already understands.
+ *
+ * Format: https://the.earth.li/~sgtatham/putty/0.83/htmldoc/AppendixC.html
+ */
+
+const {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  createHmac,
+  randomBytes,
+  argon2Sync,
+} = require("node:crypto");
+
+const PPK_HEADER_RE = /^\s*PuTTY-User-Key-File-([23]):\s*(\S+)\s*$/m;
+const AES_BLOCK = 16;
+const AES_KEY_LEN = 32;
+const PPK_V2_IV = Buffer.alloc(16, 0);
+const PPK_V2_SEQ0 = Buffer.from([0, 0, 0, 0]);
+const PPK_V2_SEQ1 = Buffer.from([0, 0, 0, 1]);
+const PPK_V3_DERIVED_LEN = 80; // 32-byte key + 16-byte IV + 32-byte MAC key
+const OPENSSH_MAGIC = Buffer.from("openssh-key-v1\0");
+
+const SUPPORTED_TYPES = new Set([
+  "ssh-ed25519",
+  "ssh-rsa",
+  "ssh-dss",
+  "ecdsa-sha2-nistp256",
+  "ecdsa-sha2-nistp384",
+  "ecdsa-sha2-nistp521",
+]);
+
+function isPpkPrivateKey(text) {
+  return typeof text === "string" && PPK_HEADER_RE.test(text);
+}
+
+function passphraseBytes(passphrase) {
+  if (passphrase == null) return Buffer.alloc(0);
+  if (Buffer.isBuffer(passphrase)) return passphrase;
+  return Buffer.from(String(passphrase), "utf8");
+}
+
+function writeU32(value) {
+  const buf = Buffer.allocUnsafe(4);
+  buf.writeUInt32BE(value);
+  return buf;
+}
+
+function writeBytes(buf) {
+  return Buffer.concat([writeU32(buf.length), buf]);
+}
+
+function writeString(value) {
+  return writeBytes(Buffer.from(value, "utf8"));
+}
+
+function readString(buf, offset) {
+  if (offset + 4 > buf.length) return undefined;
+  const length = buf.readUInt32BE(offset);
+  const start = offset + 4;
+  const end = start + length;
+  if (end > buf.length) return undefined;
+  return { value: buf.subarray(start, end), next: end };
+}
+
+function readRequiredString(buf, offset, label) {
+  const field = readString(buf, offset);
+  if (!field) {
+    throw new Error(`Malformed PPK ${label}`);
+  }
+  return field;
+}
+
+function wrapBase64(buf, width = 64) {
+  const raw = buf.toString("base64");
+  const lines = [];
+  for (let i = 0; i < raw.length; i += width) {
+    lines.push(raw.slice(i, i + width));
+  }
+  return lines;
+}
+
+function parsePpk(text) {
+  const lines = String(text).replace(/^\uFEFF/, "").split(/\r?\n/);
+  while (lines.length && lines[0].trim() === "") lines.shift();
+  const header = PPK_HEADER_RE.exec(lines[0] || "");
+  if (!header) return null;
+
+  const version = Number(header[1]);
+  const type = header[2];
+  let index = 1;
+
+  const readHeader = (name) => {
+    const line = lines[index++];
+    if (line == null) {
+      throw new Error(`Truncated PPK: missing ${name}`);
+    }
+    const match = new RegExp(`^${name}:\\s*(.*)$`).exec(line);
+    if (!match) {
+      throw new Error(`Malformed PPK: expected ${name}`);
+    }
+    return match[1];
+  };
+
+  const readBase64Block = (count) => {
+    const chunk = lines.slice(index, index + count);
+    if (chunk.length !== count) {
+      throw new Error("Truncated PPK key data");
+    }
+    index += count;
+    return Buffer.from(chunk.join(""), "base64");
+  };
+
+  const encryption = readHeader("Encryption");
+  const comment = readHeader("Comment");
+  const publicLines = Number(readHeader("Public-Lines"));
+  if (!Number.isInteger(publicLines) || publicLines < 1) {
+    throw new Error("Malformed PPK public key");
+  }
+  const publicBlob = readBase64Block(publicLines);
+
+  let kdf;
+  if (version === 3 && encryption !== "none") {
+    kdf = {
+      name: readHeader("Key-Derivation"),
+      memory: Number(readHeader("Argon2-Memory")),
+      passes: Number(readHeader("Argon2-Passes")),
+      parallelism: Number(readHeader("Argon2-Parallelism")),
+      saltHex: readHeader("Argon2-Salt"),
+    };
+  }
+
+  const privateLines = Number(readHeader("Private-Lines"));
+  if (!Number.isInteger(privateLines) || privateLines < 1) {
+    throw new Error("Malformed PPK private key");
+  }
+  const privateBlob = readBase64Block(privateLines);
+  const mac = readHeader("Private-MAC").trim().toLowerCase();
+
+  return { version, type, encryption, comment, publicBlob, privateBlob, mac, kdf };
+}
+
+function deriveV2Keys(passphrase) {
+  const material = Buffer.concat([
+    createHash("sha1").update(PPK_V2_SEQ0).update(passphrase).digest(),
+    createHash("sha1").update(PPK_V2_SEQ1).update(passphrase).digest(),
+  ]);
+  return {
+    cipherKey: material.subarray(0, AES_KEY_LEN),
+    iv: PPK_V2_IV,
+    macKey: createHash("sha1").update("putty-private-key-file-mac-key").update(passphrase).digest(),
+    macAlgo: "sha1",
+  };
+}
+
+function deriveV3Keys(passphrase, encryption, kdf) {
+  if (encryption === "none") {
+    return { cipherKey: null, iv: null, macKey: Buffer.alloc(0), macAlgo: "sha256" };
+  }
+  if (typeof argon2Sync !== "function") {
+    throw new Error("PPK_V3_ARGON2_UNAVAILABLE");
+  }
+  const algorithm = String(kdf?.name || "").toLowerCase();
+  if (algorithm !== "argon2id" && algorithm !== "argon2i" && algorithm !== "argon2d") {
+    throw new Error(`Unsupported PPK key derivation "${kdf?.name}"`);
+  }
+  if (!kdf?.saltHex || !Number.isInteger(kdf.memory) || !Number.isInteger(kdf.passes) || !Number.isInteger(kdf.parallelism)) {
+    throw new Error("Malformed PPK Argon2 parameters");
+  }
+  const derived = argon2Sync(algorithm, {
+    message: passphrase,
+    nonce: Buffer.from(kdf.saltHex, "hex"),
+    parallelism: kdf.parallelism,
+    tagLength: PPK_V3_DERIVED_LEN,
+    memory: kdf.memory,
+    passes: kdf.passes,
+  });
+  return {
+    cipherKey: derived.subarray(0, AES_KEY_LEN),
+    iv: derived.subarray(AES_KEY_LEN, AES_KEY_LEN + AES_BLOCK),
+    macKey: derived.subarray(AES_KEY_LEN + AES_BLOCK),
+    macAlgo: "sha256",
+  };
+}
+
+function aes256Cbc(blob, key, iv, decrypt) {
+  const fn = decrypt ? createDecipheriv : createCipheriv;
+  const cipher = fn("aes-256-cbc", key, iv);
+  cipher.setAutoPadding(false);
+  return Buffer.concat([cipher.update(blob), cipher.final()]);
+}
+
+function macPayload({ type, encryption, comment, publicBlob, privateBlob }) {
+  return Buffer.concat([
+    writeString(type),
+    writeString(encryption),
+    writeString(comment),
+    writeBytes(publicBlob),
+    writeBytes(privateBlob),
+  ]);
+}
+
+function verifyMac(parsed, keys) {
+  const expected = createHmac(keys.macAlgo, keys.macKey)
+    .update(macPayload(parsed))
+    .digest("hex");
+  return expected === parsed.mac;
+}
+
+function buildOpenSshPrivate({ publicBlob, privateInner, comment }) {
+  const check = randomBytes(4);
+  let inner = Buffer.concat([
+    check,
+    check,
+    privateInner,
+    writeString(comment || ""),
+  ]);
+  const padLen = (8 - (inner.length % 8)) % 8;
+  if (padLen) {
+    const pad = Buffer.allocUnsafe(padLen);
+    for (let i = 0; i < padLen; i++) pad[i] = i + 1;
+    inner = Buffer.concat([inner, pad]);
+  }
+
+  const blob = Buffer.concat([
+    OPENSSH_MAGIC,
+    writeString("none"),
+    writeString("none"),
+    writeBytes(Buffer.alloc(0)),
+    writeU32(1),
+    writeBytes(publicBlob),
+    writeBytes(inner),
+  ]);
+
+  const body = wrapBase64(blob, 70).join("\n");
+  return `-----BEGIN OPENSSH PRIVATE KEY-----\n${body}\n-----END OPENSSH PRIVATE KEY-----\n`;
+}
+
+function ed25519PrivateInner(publicBlob, privateBlob) {
+  const pubType = readRequiredString(publicBlob, 0, "public key type");
+  const pubKey = readRequiredString(publicBlob, pubType.next, "public key");
+  const seedField = readRequiredString(privateBlob, 0, "Ed25519 seed");
+  if (pubKey.value.length !== 32 || seedField.value.length !== 32) {
+    throw new Error("Malformed PPK Ed25519 key");
+  }
+  return Buffer.concat([
+    writeString("ssh-ed25519"),
+    writeBytes(pubKey.value),
+    writeBytes(Buffer.concat([seedField.value, pubKey.value])),
+  ]);
+}
+
+function rsaPrivateInner(publicBlob, privateBlob) {
+  const pubType = readRequiredString(publicBlob, 0, "public key type");
+  const e = readRequiredString(publicBlob, pubType.next, "RSA e");
+  const n = readRequiredString(publicBlob, e.next, "RSA n");
+  const d = readRequiredString(privateBlob, 0, "RSA d");
+  const p = readRequiredString(privateBlob, d.next, "RSA p");
+  const q = readRequiredString(privateBlob, p.next, "RSA q");
+  const iqmp = readRequiredString(privateBlob, q.next, "RSA iqmp");
+  return Buffer.concat([
+    writeString("ssh-rsa"),
+    writeBytes(n.value),
+    writeBytes(e.value),
+    writeBytes(d.value),
+    writeBytes(iqmp.value),
+    writeBytes(p.value),
+    writeBytes(q.value),
+  ]);
+}
+
+function dssPrivateInner(publicBlob, privateBlob) {
+  const pubType = readRequiredString(publicBlob, 0, "public key type");
+  const p = readRequiredString(publicBlob, pubType.next, "DSA p");
+  const q = readRequiredString(publicBlob, p.next, "DSA q");
+  const g = readRequiredString(publicBlob, q.next, "DSA g");
+  const y = readRequiredString(publicBlob, g.next, "DSA y");
+  const x = readRequiredString(privateBlob, 0, "DSA x");
+  return Buffer.concat([
+    writeString("ssh-dss"),
+    writeBytes(p.value),
+    writeBytes(q.value),
+    writeBytes(g.value),
+    writeBytes(y.value),
+    writeBytes(x.value),
+  ]);
+}
+
+function ecdsaPrivateInner(type, publicBlob, privateBlob) {
+  const curve = type.slice("ecdsa-sha2-".length);
+  const pubType = readRequiredString(publicBlob, 0, "public key type");
+  const curveName = readRequiredString(publicBlob, pubType.next, "ECDSA curve");
+  const point = readRequiredString(publicBlob, curveName.next, "ECDSA point");
+  const scalar = readRequiredString(privateBlob, 0, "ECDSA scalar");
+  return Buffer.concat([
+    writeString(type),
+    writeBytes(curveName.value.length ? curveName.value : Buffer.from(curve, "utf8")),
+    writeBytes(point.value),
+    writeBytes(scalar.value),
+  ]);
+}
+
+function privateInnerForType(type, publicBlob, privateBlob) {
+  switch (type) {
+    case "ssh-ed25519":
+      return ed25519PrivateInner(publicBlob, privateBlob);
+    case "ssh-rsa":
+      return rsaPrivateInner(publicBlob, privateBlob);
+    case "ssh-dss":
+      return dssPrivateInner(publicBlob, privateBlob);
+    case "ecdsa-sha2-nistp256":
+    case "ecdsa-sha2-nistp384":
+    case "ecdsa-sha2-nistp521":
+      return ecdsaPrivateInner(type, publicBlob, privateBlob);
+    default:
+      throw new Error(`Unsupported PPK key type "${type}"`);
+  }
+}
+
+/**
+ * Convert a PPK private key to unencrypted OpenSSH PEM.
+ *
+ * @returns {{ privateKey: string, comment: string } | null}
+ *   `null` when the text is not a PPK. Throws on decrypt / format errors.
+ */
+function convertPpkToOpenSsh(text, passphrase) {
+  let parsed;
+  try {
+    parsed = parsePpk(text);
+  } catch (err) {
+    if (!isPpkPrivateKey(text)) return null;
+    const fail = new Error(`Malformed PPK private key: ${err.message}`);
+    fail.code = "ERR_PPK_MALFORMED";
+    fail.cause = err;
+    throw fail;
+  }
+  if (!parsed) return null;
+
+  if (!SUPPORTED_TYPES.has(parsed.type)) {
+    const err = new Error(
+      `PuTTY keys of type "${parsed.type}" are not supported. ` +
+        "Export an OpenSSH key from PuTTYgen and try again.",
+    );
+    err.code = "ERR_PPK_UNSUPPORTED_TYPE";
+    throw err;
+  }
+
+  const encrypted = parsed.encryption !== "none";
+  if (encrypted && parsed.encryption !== "aes256-cbc") {
+    const err = new Error(`Unsupported PPK encryption "${parsed.encryption}"`);
+    err.code = "ERR_PPK_UNSUPPORTED_CIPHER";
+    throw err;
+  }
+  if (encrypted && (passphrase == null || passphraseBytes(passphrase).length === 0)) {
+    const err = new Error("Encrypted PPK private key detected, but no passphrase given");
+    err.code = "ERR_PPK_PASSPHRASE";
+    throw err;
+  }
+
+  const secret = passphraseBytes(encrypted ? passphrase : "");
+  let keys;
+  try {
+    keys = parsed.version === 3
+      ? deriveV3Keys(secret, parsed.encryption, parsed.kdf)
+      : deriveV2Keys(secret);
+  } catch (err) {
+    if (err && err.message === "PPK_V3_ARGON2_UNAVAILABLE") {
+      const missing = new Error(
+        "Encrypted PuTTY PPK v3 keys require Argon2, which is unavailable in this runtime.",
+      );
+      missing.code = "ERR_PPK_UNSUPPORTED_KDF";
+      throw missing;
+    }
+    throw err;
+  }
+
+  let privateBlob = parsed.privateBlob;
+  if (encrypted) {
+    if (privateBlob.length % AES_BLOCK !== 0) {
+      const err = new Error("Malformed encrypted PPK private key");
+      err.code = "ERR_PPK_MALFORMED";
+      throw err;
+    }
+    try {
+      privateBlob = aes256Cbc(privateBlob, keys.cipherKey, keys.iv, true);
+    } catch (err) {
+      const fail = new Error("Could not decrypt the PPK private key with the provided passphrase");
+      fail.code = "ERR_PPK_PASSPHRASE";
+      fail.cause = err;
+      throw fail;
+    }
+  }
+
+  const decrypted = { ...parsed, privateBlob };
+  if (!verifyMac(decrypted, keys)) {
+    const err = new Error(
+      encrypted
+        ? "PPK private key integrity check failed -- bad passphrase?"
+        : "PPK private key integrity check failed",
+    );
+    err.code = encrypted ? "ERR_PPK_PASSPHRASE" : "ERR_PPK_MALFORMED";
+    throw err;
+  }
+
+  const privateInner = privateInnerForType(parsed.type, parsed.publicBlob, privateBlob);
+  return {
+    privateKey: buildOpenSshPrivate({
+      publicBlob: parsed.publicBlob,
+      privateInner,
+      comment: parsed.comment,
+    }),
+    comment: parsed.comment,
+  };
+}
+
+// Test helper: serialize an already-assembled PPK (public/private SSH blobs).
+function serializePpk({
+  version = 2,
+  type,
+  comment = "",
+  publicBlob,
+  privateBlob,
+  passphrase,
+  argon2 = {
+    name: "Argon2id",
+    memory: 8192,
+    passes: 2,
+    parallelism: 1,
+  },
+}) {
+  const encryption = passphrase ? "aes256-cbc" : "none";
+  const secret = passphraseBytes(passphrase || "");
+  let kdf;
+  let keys;
+  let storedPrivate = privateBlob;
+
+  if (version === 3) {
+    if (encryption === "aes256-cbc") {
+      kdf = {
+        ...argon2,
+        saltHex: randomBytes(16).toString("hex"),
+      };
+    }
+    keys = deriveV3Keys(secret, encryption, kdf);
+  } else {
+    keys = deriveV2Keys(secret);
+  }
+
+  if (encryption === "aes256-cbc") {
+    const padLen = (AES_BLOCK - (storedPrivate.length % AES_BLOCK)) % AES_BLOCK;
+    if (padLen) {
+      storedPrivate = Buffer.concat([storedPrivate, randomBytes(padLen)]);
+    }
+  }
+
+  const mac = createHmac(keys.macAlgo, keys.macKey)
+    .update(macPayload({ type, encryption, comment, publicBlob, privateBlob: storedPrivate }))
+    .digest("hex");
+
+  if (encryption === "aes256-cbc") {
+    storedPrivate = aes256Cbc(storedPrivate, keys.cipherKey, keys.iv, false);
+  }
+
+  const publicLines = wrapBase64(publicBlob);
+  const privateLines = wrapBase64(storedPrivate);
+  const lines = [
+    `PuTTY-User-Key-File-${version}: ${type}`,
+    `Encryption: ${encryption}`,
+    `Comment: ${comment}`,
+    `Public-Lines: ${publicLines.length}`,
+    ...publicLines,
+  ];
+  if (kdf) {
+    lines.push(
+      `Key-Derivation: ${kdf.name}`,
+      `Argon2-Memory: ${kdf.memory}`,
+      `Argon2-Passes: ${kdf.passes}`,
+      `Argon2-Parallelism: ${kdf.parallelism}`,
+      `Argon2-Salt: ${kdf.saltHex}`,
+    );
+  }
+  lines.push(
+    `Private-Lines: ${privateLines.length}`,
+    ...privateLines,
+    `Private-MAC: ${mac}`,
+    "",
+  );
+  return lines.join("\n");
+}
+
+module.exports = {
+  isPpkPrivateKey,
+  convertPpkToOpenSsh,
+  serializePpk,
+};

--- a/electron/bridges/ppkConverter.test.cjs
+++ b/electron/bridges/ppkConverter.test.cjs
@@ -9,7 +9,7 @@ const {
   PrivateKeyPassphraseError,
   UnsupportedPrivateKeyError,
 } = require("./privateKeyNormalizer.cjs");
-const { preparePrivateKeyForAuth } = require("./sshAuthHelper.cjs");
+const { preparePrivateKeyForAuth, isKeyEncrypted } = require("./sshAuthHelper.cjs");
 
 const hasArgon2 = typeof crypto.argon2Sync === "function";
 
@@ -130,36 +130,37 @@ test("converts an encrypted Ed25519 PPK with CRLF line endings", () => {
   assert.ok(parseOk(result.privateKey));
 });
 
+function stubEncryptedPpkV3({ memory = 8192, passes = 2, parallelism = 1 } = {}) {
+  return [
+    "PuTTY-User-Key-File-3: ssh-ed25519",
+    "Encryption: aes256-cbc",
+    "Comment: stub",
+    "Public-Lines: 1",
+    "AAAA",
+    "Key-Derivation: Argon2id",
+    `Argon2-Memory: ${memory}`,
+    `Argon2-Passes: ${passes}`,
+    `Argon2-Parallelism: ${parallelism}`,
+    "Argon2-Salt: 00112233445566778899aabbccddeeff",
+    "Private-Lines: 1",
+    "AAAA",
+    "Private-MAC: 00",
+    "",
+  ].join("\n");
+}
+
 test("rejects an encrypted PPK v3 with unbounded Argon2 memory before deriving keys", () => {
-  const { publicBlob, privateBlob } = ed25519Blobs();
-  const ppk = serializePpk({
-    version: 3,
-    type: "ssh-ed25519",
-    comment: "dos",
-    publicBlob,
-    privateBlob,
-    passphrase: "secret",
-  }).replace(/^Argon2-Memory: \d+$/m, "Argon2-Memory: 999999999");
   const started = Date.now();
   assert.throws(
-    () => normalizePrivateKeyForSsh2(ppk, "secret"),
+    () => normalizePrivateKeyForSsh2(stubEncryptedPpkV3({ memory: 999999999 }), "secret"),
     (err) => err instanceof UnsupportedPrivateKeyError && /Argon2 parameters exceed supported limits/.test(err.message),
   );
   assert.ok(Date.now() - started < 250, "oversized Argon2 work factors must be rejected without deriving");
 });
 
 test("rejects an encrypted PPK v3 with a non-positive Argon2 pass count", () => {
-  const { publicBlob, privateBlob } = ed25519Blobs();
-  const ppk = serializePpk({
-    version: 3,
-    type: "ssh-ed25519",
-    comment: "zero-passes",
-    publicBlob,
-    privateBlob,
-    passphrase: "secret",
-  }).replace(/^Argon2-Passes: \d+$/m, "Argon2-Passes: 0");
   assert.throws(
-    () => normalizePrivateKeyForSsh2(ppk, "secret"),
+    () => normalizePrivateKeyForSsh2(stubEncryptedPpkV3({ passes: 0 }), "secret"),
     (err) => err instanceof UnsupportedPrivateKeyError && /Argon2 parameters exceed supported limits/.test(err.message),
   );
 });
@@ -280,6 +281,17 @@ ssG0o2XpU0dez67/t5sffDp5j41eXMt7ViZpeB7O1jtA7NLOQ3Q3UjAPBQJCR/Vs
 Private-MAC: 8d45d4218f19b0677d6b51529ef43236468f0de9
 `;
 
+const PUTTYGEN_ED25519_V3_NONE = `PuTTY-User-Key-File-3: ssh-ed25519
+Encryption: none
+Comment: eddsa-key-20220506
+Public-Lines: 2
+AAAAC3NzaC1lZDI1NTE5AAAAIH+QE+UNYtz7N9RX2FseJmmzIroOs24UzTsJP6kj
+0gxU
+Private-Lines: 1
+AAAAIAOsb28qs/Ob4JfyCCGqcONFEtlWkqquOryLlfbjebBp
+Private-MAC: fd89c96303e82b9c7f3ddbec3884ebd5a3500da8d4f2e9716c0494f3c207fffa
+`;
+
 const PUTTYGEN_ED25519_V3 = `PuTTY-User-Key-File-3: ssh-ed25519
 Encryption: aes256-cbc
 Comment: eddsa-key-20220506
@@ -297,6 +309,39 @@ Private-MAC: 0a0cc345089719caa38a7990ed9b6dd9b38792fd553a84e54be01885d240df83
 `;
 
 const PUTTYGEN_PASSPHRASE = "correct horse battery staple";
+
+test("converts a real PuTTYgen unencrypted Ed25519 PPK v3", () => {
+  const result = normalizePrivateKeyForSsh2(PUTTYGEN_ED25519_V3_NONE);
+  assert.equal(result.converted, true);
+  const parsed = parseOk(result.privateKey);
+  assert.ok(parsed);
+  assert.equal(parsed.type, "ssh-ed25519");
+});
+
+test("converts an unencrypted generated Ed25519 PPK v3", () => {
+  const { ppk } = ed25519Ppk({ version: 3 });
+  assert.match(ppk, /^PuTTY-User-Key-File-3: ssh-ed25519/m);
+  assert.match(ppk, /^Encryption: none/m);
+  const result = normalizePrivateKeyForSsh2(ppk);
+  assert.equal(result.converted, true);
+  assert.ok(parseOk(result.privateKey));
+});
+
+test("preparePrivateKeyForAuth returns an unlocked OpenSSH key for encrypted PPK", async () => {
+  const { ppk } = ed25519Ppk({ passphrase: "secret" });
+  const result = await preparePrivateKeyForAuth({
+    sender: { isDestroyed: () => false, send: () => {} },
+    privateKey: ppk,
+    keyName: "putty-ed25519.ppk",
+    hostname: "example.test",
+    initialPassphrase: "secret",
+    logPrefix: "[Test]",
+  });
+  assert.ok(result);
+  assert.equal(isKeyEncrypted(ppk), true);
+  assert.equal(isKeyEncrypted(result.privateKey), false);
+  assert.equal(result.passphrase, undefined);
+});
 
 test("decrypts a real PuTTYgen encrypted Ed25519 PPK v2", () => {
   assert.ok(sshUtils.parseKey(PUTTYGEN_ED25519_V2, PUTTYGEN_PASSPHRASE) instanceof Error);

--- a/electron/bridges/ppkConverter.test.cjs
+++ b/electron/bridges/ppkConverter.test.cjs
@@ -130,6 +130,40 @@ test("converts an encrypted Ed25519 PPK with CRLF line endings", () => {
   assert.ok(parseOk(result.privateKey));
 });
 
+test("rejects an encrypted PPK v3 with unbounded Argon2 memory before deriving keys", () => {
+  const { publicBlob, privateBlob } = ed25519Blobs();
+  const ppk = serializePpk({
+    version: 3,
+    type: "ssh-ed25519",
+    comment: "dos",
+    publicBlob,
+    privateBlob,
+    passphrase: "secret",
+  }).replace(/^Argon2-Memory: \d+$/m, "Argon2-Memory: 999999999");
+  const started = Date.now();
+  assert.throws(
+    () => normalizePrivateKeyForSsh2(ppk, "secret"),
+    (err) => err instanceof UnsupportedPrivateKeyError && /Argon2 parameters exceed supported limits/.test(err.message),
+  );
+  assert.ok(Date.now() - started < 250, "oversized Argon2 work factors must be rejected without deriving");
+});
+
+test("rejects an encrypted PPK v3 with a non-positive Argon2 pass count", () => {
+  const { publicBlob, privateBlob } = ed25519Blobs();
+  const ppk = serializePpk({
+    version: 3,
+    type: "ssh-ed25519",
+    comment: "zero-passes",
+    publicBlob,
+    privateBlob,
+    passphrase: "secret",
+  }).replace(/^Argon2-Passes: \d+$/m, "Argon2-Passes: 0");
+  assert.throws(
+    () => normalizePrivateKeyForSsh2(ppk, "secret"),
+    (err) => err instanceof UnsupportedPrivateKeyError && /Argon2 parameters exceed supported limits/.test(err.message),
+  );
+});
+
 test("throws PrivateKeyPassphraseError for encrypted Ed25519 PPK with the wrong passphrase", () => {
   const { ppk } = ed25519Ppk({ passphrase: "secret" });
   assert.throws(

--- a/electron/bridges/ppkConverter.test.cjs
+++ b/electron/bridges/ppkConverter.test.cjs
@@ -1,0 +1,300 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const { utils: sshUtils } = require("ssh2");
+
+const { convertPpkToOpenSsh, serializePpk } = require("./ppkConverter.cjs");
+const {
+  normalizePrivateKeyForSsh2,
+  PrivateKeyPassphraseError,
+  UnsupportedPrivateKeyError,
+} = require("./privateKeyNormalizer.cjs");
+const { preparePrivateKeyForAuth } = require("./sshAuthHelper.cjs");
+
+const hasArgon2 = typeof crypto.argon2Sync === "function";
+
+function u32(value) {
+  const buf = Buffer.allocUnsafe(4);
+  buf.writeUInt32BE(value);
+  return buf;
+}
+
+function writeBytes(buf) {
+  return Buffer.concat([u32(buf.length), buf]);
+}
+
+function writeString(value) {
+  return writeBytes(Buffer.from(value, "utf8"));
+}
+
+function writeMpint(buf) {
+  let value = buf;
+  while (value.length > 1 && value[0] === 0) value = value.subarray(1);
+  if (value[0] & 0x80) value = Buffer.concat([Buffer.from([0]), value]);
+  return writeBytes(value);
+}
+
+function parseOk(key) {
+  const parsed = sshUtils.parseKey(key);
+  return parsed && !(parsed instanceof Error) ? parsed : null;
+}
+
+function ed25519Blobs() {
+  const { privateKey } = crypto.generateKeyPairSync("ed25519");
+  const jwk = privateKey.export({ format: "jwk" });
+  const seed = Buffer.from(jwk.d, "base64url");
+  const pub = Buffer.from(jwk.x, "base64url");
+  return {
+    seed,
+    pub,
+    publicBlob: Buffer.concat([writeString("ssh-ed25519"), writeBytes(pub)]),
+    privateBlob: writeBytes(seed),
+  };
+}
+
+function ecdsaP256Blobs() {
+  const { privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+  const jwk = privateKey.export({ format: "jwk" });
+  const x = Buffer.from(jwk.x, "base64url");
+  const y = Buffer.from(jwk.y, "base64url");
+  const d = Buffer.from(jwk.d, "base64url");
+  const point = Buffer.concat([Buffer.from([0x04]), x, y]);
+  return {
+    publicBlob: Buffer.concat([
+      writeString("ecdsa-sha2-nistp256"),
+      writeString("nistp256"),
+      writeBytes(point),
+    ]),
+    privateBlob: writeMpint(d),
+  };
+}
+
+function rsaBlobs() {
+  const { privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const jwk = privateKey.export({ format: "jwk" });
+  const n = Buffer.from(jwk.n, "base64url");
+  const e = Buffer.from(jwk.e, "base64url");
+  const d = Buffer.from(jwk.d, "base64url");
+  const p = Buffer.from(jwk.p, "base64url");
+  const q = Buffer.from(jwk.q, "base64url");
+  const qi = Buffer.from(jwk.qi, "base64url");
+  return {
+    publicBlob: Buffer.concat([writeString("ssh-rsa"), writeMpint(e), writeMpint(n)]),
+    privateBlob: Buffer.concat([writeMpint(d), writeMpint(p), writeMpint(q), writeMpint(qi)]),
+  };
+}
+
+function ed25519Ppk(options = {}) {
+  const blobs = ed25519Blobs();
+  const ppk = serializePpk({
+    version: options.version ?? 2,
+    type: "ssh-ed25519",
+    comment: options.comment ?? "ed25519-test",
+    publicBlob: blobs.publicBlob,
+    privateBlob: blobs.privateBlob,
+    passphrase: options.passphrase,
+  });
+  return { ...blobs, ppk };
+}
+
+test("ssh2 cannot parse an encrypted Ed25519 PPK v2 even with the correct passphrase", () => {
+  const { ppk } = ed25519Ppk({ passphrase: "correct horse" });
+  assert.match(ppk, /^PuTTY-User-Key-File-2: ssh-ed25519/m);
+  const parsed = sshUtils.parseKey(ppk, "correct horse");
+  assert.ok(parsed instanceof Error, "ssh2 should reject Ed25519 PPK");
+});
+
+test("converts an encrypted Ed25519 PPK v2 into an ssh2-parseable OpenSSH key", () => {
+  const { ppk, pub } = ed25519Ppk({ passphrase: "secret" });
+  const result = normalizePrivateKeyForSsh2(ppk, "secret");
+  assert.equal(result.converted, true);
+  assert.equal(result.passphrase, undefined);
+  const parsed = parseOk(result.privateKey);
+  assert.ok(parsed);
+  assert.equal(parsed.type, "ssh-ed25519");
+  assert.deepEqual(parsed.getPublicSSH().subarray(-32), pub);
+});
+
+test("converts an unencrypted Ed25519 PPK v2", () => {
+  const { ppk } = ed25519Ppk();
+  const result = normalizePrivateKeyForSsh2(ppk);
+  assert.equal(result.converted, true);
+  assert.ok(parseOk(result.privateKey));
+});
+
+test("converts an encrypted Ed25519 PPK with CRLF line endings", () => {
+  const { ppk } = ed25519Ppk({ passphrase: "secret" });
+  const crlf = ppk.replace(/\n/g, "\r\n");
+  const result = normalizePrivateKeyForSsh2(crlf, "secret");
+  assert.equal(result.converted, true);
+  assert.ok(parseOk(result.privateKey));
+});
+
+test("throws PrivateKeyPassphraseError for encrypted Ed25519 PPK with the wrong passphrase", () => {
+  const { ppk } = ed25519Ppk({ passphrase: "secret" });
+  assert.throws(
+    () => normalizePrivateKeyForSsh2(ppk, "wrong"),
+    (err) => err instanceof PrivateKeyPassphraseError,
+  );
+});
+
+test("throws PrivateKeyPassphraseError when an encrypted PPK has no passphrase", () => {
+  const { ppk } = ed25519Ppk({ passphrase: "secret" });
+  assert.throws(
+    () => normalizePrivateKeyForSsh2(ppk),
+    (err) => err instanceof PrivateKeyPassphraseError,
+  );
+});
+
+test("converts an encrypted Ed25519 PPK v3 using Argon2id", { skip: !hasArgon2 }, () => {
+  const { ppk, pub } = ed25519Ppk({ version: 3, passphrase: "secret" });
+  assert.match(ppk, /^PuTTY-User-Key-File-3: ssh-ed25519/m);
+  assert.match(ppk, /^Key-Derivation: Argon2id/m);
+  const ssh2Parsed = sshUtils.parseKey(ppk, "secret");
+  assert.ok(ssh2Parsed instanceof Error, "ssh2 should reject PPK v3");
+  const result = normalizePrivateKeyForSsh2(ppk, "secret");
+  assert.equal(result.converted, true);
+  const parsed = parseOk(result.privateKey);
+  assert.ok(parsed);
+  assert.equal(parsed.type, "ssh-ed25519");
+  assert.deepEqual(parsed.getPublicSSH().subarray(-32), pub);
+});
+
+test("converts an encrypted ECDSA P-256 PPK v2", () => {
+  const blobs = ecdsaP256Blobs();
+  const ppk = serializePpk({
+    version: 2,
+    type: "ecdsa-sha2-nistp256",
+    comment: "ecdsa-test",
+    publicBlob: blobs.publicBlob,
+    privateBlob: blobs.privateBlob,
+    passphrase: "secret",
+  });
+  const result = normalizePrivateKeyForSsh2(ppk, "secret");
+  assert.equal(result.converted, true);
+  const parsed = parseOk(result.privateKey);
+  assert.ok(parsed);
+  assert.equal(parsed.type, "ecdsa-sha2-nistp256");
+});
+
+test("converts an encrypted RSA PPK v3 that ssh2 cannot parse", { skip: !hasArgon2 }, () => {
+  const blobs = rsaBlobs();
+  const ppk = serializePpk({
+    version: 3,
+    type: "ssh-rsa",
+    comment: "rsa-v3",
+    publicBlob: blobs.publicBlob,
+    privateBlob: blobs.privateBlob,
+    passphrase: "secret",
+  });
+  assert.ok(sshUtils.parseKey(ppk, "secret") instanceof Error);
+  const result = normalizePrivateKeyForSsh2(ppk, "secret");
+  assert.equal(result.converted, true);
+  const parsed = parseOk(result.privateKey);
+  assert.ok(parsed);
+  assert.equal(parsed.type, "ssh-rsa");
+});
+
+test("leaves a PPK v2 RSA key to ssh2 when it can already parse it", () => {
+  const blobs = rsaBlobs();
+  const ppk = serializePpk({
+    version: 2,
+    type: "ssh-rsa",
+    comment: "rsa-v2",
+    publicBlob: blobs.publicBlob,
+    privateBlob: blobs.privateBlob,
+    passphrase: "secret",
+  });
+  const ssh2Parsed = sshUtils.parseKey(ppk, "secret");
+  assert.ok(ssh2Parsed && !(ssh2Parsed instanceof Error), "ssh2 should still parse RSA PPK v2");
+  const result = normalizePrivateKeyForSsh2(ppk, "secret");
+  assert.equal(result.converted, false);
+  assert.equal(result.privateKey, ppk);
+});
+
+test("convertPpkToOpenSsh returns null for non-PPK input", () => {
+  assert.equal(convertPpkToOpenSsh("-----BEGIN OPENSSH PRIVATE KEY-----"), null);
+});
+
+test("rejects an unsupported PPK algorithm with UnsupportedPrivateKeyError", () => {
+  const ppk = [
+    "PuTTY-User-Key-File-2: ssh-unknown",
+    "Encryption: none",
+    "Comment: nope",
+    "Public-Lines: 1",
+    "AAAA",
+    "Private-Lines: 1",
+    "AAAA",
+    "Private-MAC: 00",
+    "",
+  ].join("\n");
+  assert.throws(
+    () => normalizePrivateKeyForSsh2(ppk),
+    (err) => err instanceof UnsupportedPrivateKeyError && /ssh-unknown/.test(err.message),
+  );
+});
+
+// Real PuTTYgen fixtures from SshAgentLib (passphrase: "correct horse battery staple").
+const PUTTYGEN_ED25519_V2 = `PuTTY-User-Key-File-2: ssh-ed25519
+Encryption: aes256-cbc
+Comment: eddsa-key-20220506
+Public-Lines: 2
+AAAAC3NzaC1lZDI1NTE5AAAAIH+QE+UNYtz7N9RX2FseJmmzIroOs24UzTsJP6kj
+0gxU
+Private-Lines: 1
+ssG0o2XpU0dez67/t5sffDp5j41eXMt7ViZpeB7O1jtA7NLOQ3Q3UjAPBQJCR/Vs
+Private-MAC: 8d45d4218f19b0677d6b51529ef43236468f0de9
+`;
+
+const PUTTYGEN_ED25519_V3 = `PuTTY-User-Key-File-3: ssh-ed25519
+Encryption: aes256-cbc
+Comment: eddsa-key-20220506
+Public-Lines: 2
+AAAAC3NzaC1lZDI1NTE5AAAAIH+QE+UNYtz7N9RX2FseJmmzIroOs24UzTsJP6kj
+0gxU
+Key-Derivation: Argon2id
+Argon2-Memory: 8192
+Argon2-Passes: 1
+Argon2-Parallelism: 1
+Argon2-Salt: 28cb68bdb97eaae0d3a71cb285dff1e0
+Private-Lines: 1
+mqR8KyKjLx8vZlOMIaP5ira+8z5uV9DsmiChSpOK0ut4FyQJtYkRKi6InQcdz1Sa
+Private-MAC: 0a0cc345089719caa38a7990ed9b6dd9b38792fd553a84e54be01885d240df83
+`;
+
+const PUTTYGEN_PASSPHRASE = "correct horse battery staple";
+
+test("decrypts a real PuTTYgen encrypted Ed25519 PPK v2", () => {
+  assert.ok(sshUtils.parseKey(PUTTYGEN_ED25519_V2, PUTTYGEN_PASSPHRASE) instanceof Error);
+  const result = normalizePrivateKeyForSsh2(PUTTYGEN_ED25519_V2, PUTTYGEN_PASSPHRASE);
+  assert.equal(result.converted, true);
+  const parsed = parseOk(result.privateKey);
+  assert.ok(parsed);
+  assert.equal(parsed.type, "ssh-ed25519");
+  assert.equal(parsed.comment, "eddsa-key-20220506");
+});
+
+test("decrypts a real PuTTYgen encrypted Ed25519 PPK v3 (Argon2id)", { skip: !hasArgon2 }, () => {
+  assert.ok(sshUtils.parseKey(PUTTYGEN_ED25519_V3, PUTTYGEN_PASSPHRASE) instanceof Error);
+  const result = normalizePrivateKeyForSsh2(PUTTYGEN_ED25519_V3, PUTTYGEN_PASSPHRASE);
+  assert.equal(result.converted, true);
+  const parsed = parseOk(result.privateKey);
+  assert.ok(parsed);
+  assert.equal(parsed.type, "ssh-ed25519");
+  assert.equal(parsed.comment, "eddsa-key-20220506");
+});
+
+test("preparePrivateKeyForAuth decrypts an encrypted Ed25519 PPK", async () => {
+  const { ppk } = ed25519Ppk({ passphrase: "secret" });
+  const result = await preparePrivateKeyForAuth({
+    sender: { isDestroyed: () => false, send: () => {} },
+    privateKey: ppk,
+    keyName: "putty-ed25519.ppk",
+    hostname: "example.test",
+    initialPassphrase: "secret",
+    logPrefix: "[Test]",
+  });
+  assert.ok(result);
+  assert.ok(parseOk(result.privateKey));
+  assert.equal(result.passphrase, undefined);
+});

--- a/electron/bridges/privateKeyNormalizer.cjs
+++ b/electron/bridges/privateKeyNormalizer.cjs
@@ -11,10 +11,14 @@
  * forms ssh2 accepts, so we transparently convert them before handing the key
  * to ssh2. Ed25519 (and other) PKCS#8 keys have no legacy PEM representation
  * and surface a clear, actionable error instead of ssh2's opaque one.
+ *
+ * PuTTY PPK is similar: ssh2 only accepts v2 RSA/DSA, so encrypted Ed25519
+ * (and all PPK v3) keys are decrypted here and rewritten as OpenSSH PEM.
  */
 
 const crypto = require("node:crypto");
 const { utils: sshUtils } = require("ssh2");
+const { convertPpkToOpenSsh, isPpkPrivateKey } = require("./ppkConverter.cjs");
 
 const PKCS8_HEADER_RE = /-----BEGIN (?:ENCRYPTED )?PRIVATE KEY-----/;
 
@@ -78,8 +82,8 @@ function repairMalformedPem(text) {
  * @param {string} privateKey - PEM private key contents.
  * @param {string} [passphrase] - Passphrase, if the key is encrypted.
  * @returns {{ privateKey: string, passphrase: string|undefined, converted: boolean }}
- * @throws {PrivateKeyPassphraseError} Encrypted PKCS#8 with a wrong/missing passphrase.
- * @throws {UnsupportedPrivateKeyError} PKCS#8 key whose type has no legacy PEM form (e.g. Ed25519).
+ * @throws {PrivateKeyPassphraseError} Encrypted PKCS#8/PPK with a wrong/missing passphrase.
+ * @throws {UnsupportedPrivateKeyError} Key that cannot be converted into a form ssh2 accepts.
  */
 function normalizePrivateKeyForSsh2(privateKey, passphrase) {
   if (typeof privateKey !== "string" || privateKey.length === 0) {
@@ -103,6 +107,24 @@ function normalizePrivateKeyForSsh2(privateKey, passphrase) {
     }
   }
   const candidate = repaired || privateKey;
+
+  if (isPpkPrivateKey(candidate)) {
+    try {
+      const converted = convertPpkToOpenSsh(candidate, passphrase);
+      if (converted) {
+        return { privateKey: converted.privateKey, passphrase: undefined, converted: true };
+      }
+    } catch (err) {
+      if (err?.code === "ERR_PPK_PASSPHRASE") {
+        throw new PrivateKeyPassphraseError(
+          "Could not decrypt the PPK private key with the provided passphrase",
+        );
+      }
+      throw new UnsupportedPrivateKeyError(
+        err?.message || "Unable to convert the PuTTY PPK private key.",
+      );
+    }
+  }
 
   // We can only rescue PKCS#8 keys, which Node's crypto can read.
   if (!PKCS8_HEADER_RE.test(candidate)) {

--- a/electron/bridges/sftpBridge/openConnection.cjs
+++ b/electron/bridges/sftpBridge/openConnection.cjs
@@ -278,7 +278,7 @@ function createOpenConnectionApi(ctx) {
             connOpts.privateKey = effectivePrivateKey;
             if (effectivePassphrase) {
               connOpts.passphrase = effectivePassphrase;
-            } else if (jump.privateKey && isKeyEncrypted(jump.privateKey)) {
+            } else if (isKeyEncrypted(effectivePrivateKey)) {
               // Key is encrypted but no passphrase provided — prompt the user
               console.log(`[SFTP Chain] Hop ${i + 1}: key is encrypted, requesting passphrase`);
               const keyLabel = jump.label || hopLabel;
@@ -1020,7 +1020,7 @@ function createOpenConnectionApi(ctx) {
         connectOpts.privateKey = effectivePrivateKey;
         if (effectivePassphrase) {
           connectOpts.passphrase = effectivePassphrase;
-        } else if (options.privateKey && isKeyEncrypted(options.privateKey)) {
+        } else if (isKeyEncrypted(effectivePrivateKey)) {
           // Key is encrypted but no passphrase provided — prompt the user
           console.log(`[SFTP] Key is encrypted, requesting passphrase for ${options.hostname}`);
           const result = await passphraseHandler.requestPassphrase(

--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -152,7 +152,7 @@ function notifyPassphraseAuthFailed(sender, keyPath, resolvedPath, keyIds) {
 
 /**
  * Resolve a private key (and optional passphrase) into a form ssh2 can parse.
- * PKCS#8 keys, which ssh2 rejects, are transparently converted to a legacy PEM
+ * PKCS#8 keys and PuTTY PPK files that ssh2 rejects are converted first
  * (see privateKeyNormalizer.cjs).
  *
  * @returns {{ privateKey: string, passphrase: string|undefined } | null}

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -690,7 +690,7 @@ async function connectThroughChain(event, options, jumpHosts, targetHost, target
         connOpts.privateKey = effectivePrivateKey;
         if (effectivePassphrase) {
           connOpts.passphrase = effectivePassphrase;
-        } else if (jump.privateKey && isKeyEncrypted(jump.privateKey)) {
+        } else if (isKeyEncrypted(effectivePrivateKey)) {
           // Key is encrypted but no passphrase provided — prompt the user
           console.log(`[Chain] Hop ${i + 1}: key is encrypted, requesting passphrase`);
           sendProgress(i + 1, totalHops + 1, hopLabel, 'auth-attempt', 'waiting for user input...');


### PR DESCRIPTION
## Summary

PuTTY-generated encrypted Ed25519 `.ppk` files could not be decrypted in Netcatty even with the correct passphrase. Termius and Tabby worked. Reported on [NodeSeek](https://www.nodeseek.com/post-817162-12).

**Cause:** `ssh2@1.17.0` only parses PPK v2 RSA/DSA:

```
PuTTY-User-Key-File-2: (ssh-(?:rsa|dss))
```

Modern PuTTYgen writes `ssh-ed25519` (and PPK v3 + Argon2id when a passphrase is set). `parseKey` returns `Unsupported key format`, and the passphrase prompt treats that as a wrong password.

**Fix:** Decrypt PPK v2/v3 ourselves (SHA-1 KDF or Argon2 via `node:crypto.argon2Sync`) and rewrite the key as unencrypted OpenSSH PEM, which ssh2 already accepts. Covers Ed25519, ECDSA, and RSA. Existing RSA PPK v2 still goes through ssh2 unchanged.

Verified against:
- ssh2 rejecting the raw encrypted Ed25519 PPK (the original failure)
- real PuTTYgen fixtures (v2 + v3 Argon2id)
- a live PuTTYgen 0.85 Ed25519 key (`Argon2-Passes: 34`)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A — community report (NodeSeek #112), no matching GitHub issue.

## Changes Made

- Add `ppkConverter.cjs` to parse/decrypt PPK v2 and v3 and emit OpenSSH PEM
- Hook conversion into `normalizePrivateKeyForSsh2` so keychain import and identity files both work
- Regression tests, including real PuTTYgen Ed25519 fixtures and wrong-passphrase handling

## Screenshots / Demo

No UI change. Importing an encrypted PuTTY Ed25519 PPK and entering the correct passphrase now unlocks the key instead of looping on “wrong password”.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Targeted lint and tests:

```
npx eslint electron/bridges/ppkConverter.cjs electron/bridges/ppkConverter.test.cjs electron/bridges/privateKeyNormalizer.cjs electron/bridges/sshAuthHelper.cjs
node --test electron/bridges/ppkConverter.test.cjs electron/bridges/privateKeyNormalizer.test.cjs electron/bridges/sshAuthHelper.pkcs8.test.cjs
```

32 tests passed. Did not start the Electron app; this path is main-process key parsing with no UI change. Also verified with a live `puttygen` 0.85 encrypted Ed25519 key.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)