### PR TITLE
fix(settings): include App Lock in settings search

### DIFF
--- a/components/settings/tabs/AppLockSettingsSection.tsx
+++ b/components/settings/tabs/AppLockSettingsSection.tsx
@@ -230,7 +230,7 @@ export const AppLockSettingsSection: React.FC<AppLockSettingsSectionProps> = ({
 
   return (
     <>
-      <SectionHeader title={t('settings.appLock.title')} />
+      <SectionHeader title={t('settings.appLock.title')} anchorId="system-app-lock" />
       <SettingCard divided>
         {!hasPassword ? (
           <SettingRow

--- a/components/settings/tabs/SettingsSystemTab.test.ts
+++ b/components/settings/tabs/SettingsSystemTab.test.ts
@@ -26,6 +26,12 @@ test("app lock setup starts with password setup instead of a misleading enable t
   );
 });
 
+test("app lock section exposes settings-search anchors", () => {
+  const source = readAppLockSectionSource();
+
+  assert.match(source, /anchorId="system-app-lock"/);
+});
+
 test("app lock disable handler uses its modal current password field", () => {
   const source = readAppLockSectionSource();
   const handlerStart = source.indexOf("const handleDisable = useCallback");

--- a/domain/settingsSearch.test.ts
+++ b/domain/settingsSearch.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import zhCN from "../application/i18n/locales/zh-CN.ts";
 import { filterSettingsSearchCatalog } from "./settingsSearch.ts";
 import { SETTINGS_SEARCH_CATALOG } from "./settingsSearchCatalog.ts";
 
@@ -22,6 +23,8 @@ const EN: Record<string, string> = {
   "settings.system.networkProxy.mode": "Proxy mode",
   "settings.system.networkProxy.description": "HTTP(S) proxy for cloud sync and AI",
   "settings.system.networkProxy.title": "Network Proxy",
+  "settings.appLock.title": "App Lock",
+  "settings.appLock.description": "Require a local lock password when Netcatty opens",
   "ai.safety.permissionMode": "Permission mode",
   "ai.safety.permissionMode.description": "Control tool approvals",
   "ai.safety.title": "Safety",
@@ -35,6 +38,8 @@ const ZH: Record<string, string> = {
   "settings.terminal.behavior.copyOnSelect": "选中即复制",
   "settings.system.networkProxy.mode": "代理模式",
   "settings.system.networkProxy.title": "网络代理",
+  "settings.appLock.title": "应用锁定",
+  "settings.appLock.description": "在 Netcatty 打开、长时间无操作或手动锁定后，要求输入本地锁定密码。",
   "ai.safety.permissionMode": "权限模式",
 };
 
@@ -65,6 +70,27 @@ test("filterSettingsSearchCatalog matches keywords and tab labels", () => {
 
   const syncHits = filterSettingsSearchCatalog("backup", tEn);
   assert.ok(syncHits.some((hit) => hit.entry.id === "sync-local-backups"));
+});
+
+test("filterSettingsSearchCatalog matches App Lock by title and aliases", () => {
+  const byEnglish = filterSettingsSearchCatalog("app lock", tEn);
+  assert.ok(byEnglish.some((hit) => hit.entry.id === "system-app-lock"));
+
+  const byChineseTitle = filterSettingsSearchCatalog("应用锁定", tZh);
+  assert.ok(byChineseTitle.some((hit) => hit.entry.id === "system-app-lock"));
+
+  // Users commonly search the shorter "应用锁" alias rather than "应用锁定".
+  const byChineseAlias = filterSettingsSearchCatalog("应用锁", tZh);
+  assert.ok(byChineseAlias.some((hit) => hit.entry.id === "system-app-lock"));
+
+  const byTimeout = filterSettingsSearchCatalog("无操作", tZh);
+  assert.ok(byTimeout.some((hit) => hit.entry.id === "system-app-lock"));
+});
+
+test("settings search finds App Lock from the zh-CN locale", () => {
+  const t = (key: string) => zhCN[key] ?? key;
+  const hits = filterSettingsSearchCatalog("应用锁", t);
+  assert.ok(hits.some((hit) => hit.entry.id === "system-app-lock"));
 });
 
 test("filterSettingsSearchCatalog can exclude plugins tab", () => {

--- a/domain/settingsSearchCatalog.ts
+++ b/domain/settingsSearchCatalog.ts
@@ -802,6 +802,13 @@ export const SETTINGS_SEARCH_CATALOG: readonly SettingsSearchEntry[] = [
     keywords: ["proxy", "http", "代理"],
   },
   {
+    id: "system-app-lock",
+    tab: "system",
+    labelKey: "settings.appLock.title",
+    descriptionKey: "settings.appLock.description",
+    keywords: ["app lock", "applock", "lock", "应用锁", "锁屏", "idle", "timeout", "无操作"],
+  },
+  {
     id: "system-credentials",
     tab: "system",
     labelKey: "settings.system.credentials.title",


### PR DESCRIPTION
## Summary

Settings search could not find App Lock. The System tab already has the section, but it was missing from the static search catalog, so queries such as `应用锁` showed no matches.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3069

## Changes Made

- Add a `system-app-lock` catalog entry with title, description, and aliases (`应用锁`, `锁屏`, `app lock`, idle/timeout terms).
- Attach the matching `anchorId` on the App Lock section header so search can jump to it.
- Cover English/Chinese aliases and the zh-CN locale query from the report.

## Screenshots / Demo

Searching `应用锁` / `App Lock` in Settings now returns the System > App Lock section instead of an empty result list.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Ran:

```
node --test --import tsx domain/settingsSearch.test.ts domain/settingsSearchCatalog.anchors.test.ts components/settings/tabs/SettingsSystemTab.test.ts
```

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)