### PR TITLE
feat(sftp): show file owner column in the SFTP list

### DIFF
--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -208,6 +208,7 @@ export const enVaultMessages: Messages = {
   'sftp.columns.modified': 'Modified',
   'sftp.columns.size': 'Size',
   'sftp.columns.kind': 'Kind',
+  'sftp.columns.owner': 'Owner',
   'sftp.columns.configure': 'Choose visible columns',
   'sftp.columns.actions': 'Actions',
   'sftp.sort.directoriesFirst': 'Folders first',

--- a/application/i18n/locales/es/vault.ts
+++ b/application/i18n/locales/es/vault.ts
@@ -208,6 +208,7 @@ export const esVaultMessages: Messages = {
   'sftp.columns.modified': 'Modificado',
   'sftp.columns.size': 'Tamaño',
   'sftp.columns.kind': 'Tipo',
+  'sftp.columns.owner': 'Propietario',
   'sftp.columns.configure': 'Elegir columnas visibles',
   'sftp.columns.actions': 'Acciones',
   'sftp.sort.directoriesFirst': 'Carpetas primero',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -245,6 +245,7 @@ export const ruVaultMessages: Messages = {
   'sftp.columns.modified': 'Изменён',
   'sftp.columns.size': 'Размер',
   'sftp.columns.kind': 'Тип',
+  'sftp.columns.owner': 'Владелец',
   'sftp.columns.configure': 'Выбрать видимые столбцы',
   'sftp.columns.actions': 'Действия',
   'sftp.sort.directoriesFirst': 'Папки сверху',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -892,6 +892,7 @@ export const zhCNCoreMessages: Messages = {
   'sftp.columns.modified': '修改时间',
   'sftp.columns.size': '大小',
   'sftp.columns.kind': '类型',
+  'sftp.columns.owner': '所有者',
   'sftp.columns.actions': '操作',
   'sftp.sort.directoriesFirst': '目录置顶',
   'sftp.emptyDirectory': '空目录',

--- a/application/i18n/locales/zh-TW/core.ts
+++ b/application/i18n/locales/zh-TW/core.ts
@@ -813,6 +813,7 @@ export const zhTWCoreMessages: Messages = {
   'sftp.columns.modified': '修改時間',
   'sftp.columns.size': '大小',
   'sftp.columns.kind': '型別',
+  'sftp.columns.owner': '擁有者',
   'sftp.columns.actions': '操作',
   'sftp.sort.directoriesFirst': '資料夾置頂',
   'sftp.emptyDirectory': '空目錄',

--- a/application/state/sftp/columnLayout.ts
+++ b/application/state/sftp/columnLayout.ts
@@ -1,4 +1,4 @@
-export type SortField = "name" | "size" | "modified" | "type";
+export type SortField = "name" | "size" | "modified" | "type" | "owner";
 export type SortOrder = "asc" | "desc";
 
 export interface ColumnWidths {
@@ -6,6 +6,7 @@ export interface ColumnWidths {
   modified: number;
   size: number;
   type: number;
+  owner: number;
 }
 
 export type SftpColumnVisibility = Record<keyof ColumnWidths, boolean>;
@@ -15,6 +16,7 @@ export const DEFAULT_SFTP_COLUMN_VISIBILITY: SftpColumnVisibility = {
   modified: true,
   size: true,
   type: true,
+  owner: true,
 };
 
 export const normalizeSftpColumnVisibility = (value: unknown): SftpColumnVisibility => {
@@ -28,5 +30,6 @@ export const normalizeSftpColumnVisibility = (value: unknown): SftpColumnVisibil
     modified: stored.modified !== false,
     size: stored.size !== false,
     type: stored.type !== false,
+    owner: stored.owner !== false,
   };
 };

--- a/application/state/sftp/useSftpDirectoryListing.ts
+++ b/application/state/sftp/useSftpDirectoryListing.ts
@@ -28,6 +28,7 @@ export const useSftpDirectoryListing = () => {
           lastModifiedFormatted: formatDate(lastModified),
           linkTarget: f.linkTarget as "file" | "directory" | null | undefined,
           hidden: f.hidden,
+          owner: f.owner,
         };
       });
     },
@@ -50,6 +51,7 @@ export const useSftpDirectoryListing = () => {
           lastModified,
           lastModifiedFormatted: formatDate(lastModified),
           permissions: f.permissions,
+          owner: f.owner,
           linkTarget: f.linkTarget as "file" | "directory" | null | undefined,
         };
       });

--- a/application/state/sftp/useSftpPaneSorting.ts
+++ b/application/state/sftp/useSftpPaneSorting.ts
@@ -31,10 +31,11 @@ export const useSftpPaneSorting = (): UseSftpPaneSortingResult => {
   const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
   const { directoriesFirst, toggleDirectoriesFirst } = useSftpDirectoriesFirst();
   const [columnWidths, setColumnWidths] = useState<ColumnWidths>({
-    name: 56,
-    modified: 28,
+    name: 50,
+    modified: 24,
     size: 7,
     type: 9,
+    owner: 10,
   });
   const [visibleColumns, setVisibleColumns] = useState<SftpColumnVisibility>(() =>
     normalizeSftpColumnVisibility(
@@ -107,6 +108,7 @@ export const useSftpPaneSorting = (): UseSftpPaneSortingResult => {
       modified: { min: 18, max: 42 },
       size: { min: 5, max: 16 },
       type: { min: 6, max: 18 },
+      owner: { min: 6, max: 20 },
     };
     const { min, max } = limits[field];
     const newWidth = Math.max(

--- a/components/sftp/SftpColumnMenuItems.tsx
+++ b/components/sftp/SftpColumnMenuItems.tsx
@@ -26,7 +26,7 @@ export const SftpColumnMenuItems: React.FC<SftpColumnMenuItemsProps> = ({
       <ContextMenuCheckboxItem checked disabled>
         {t('sftp.columns.name')}
       </ContextMenuCheckboxItem>
-      {(['modified', 'size', 'type'] as const).map((field) => (
+      {(['modified', 'size', 'type', 'owner'] as const).map((field) => (
         <ContextMenuCheckboxItem
           key={field}
           checked={visibleColumns[field]}

--- a/components/sftp/SftpFileRow.tsx
+++ b/components/sftp/SftpFileRow.tsx
@@ -141,6 +141,11 @@ const SftpFileRowInner: React.FC<SftpFileRowProps> = ({
                     {isSymlinkToDirectory ? 'link → folder' : entry.type === 'directory' ? 'folder' : entry.type === 'symlink' ? 'link' : entry.name.split('.').pop()?.toLowerCase() || 'file'}
                 </span>
             )}
+            {visibleColumns.owner && (
+                <span className={cn("text-xs truncate text-right", isSelectionVisible ? "text-accent-foreground/85" : "text-muted-foreground")}>
+                    {isParentDir ? '' : (entry.owner || '--')}
+                </span>
+            )}
         </div>
     );
 };
@@ -155,9 +160,11 @@ const areEqual = (prev: SftpFileRowProps, next: SftpFileRowProps): boolean => {
     if (prev.columnWidths.modified !== next.columnWidths.modified) return false;
     if (prev.columnWidths.size !== next.columnWidths.size) return false;
     if (prev.columnWidths.type !== next.columnWidths.type) return false;
+    if (prev.columnWidths.owner !== next.columnWidths.owner) return false;
     if (prev.visibleColumns.modified !== next.visibleColumns.modified) return false;
     if (prev.visibleColumns.size !== next.visibleColumns.size) return false;
     if (prev.visibleColumns.type !== next.visibleColumns.type) return false;
+    if (prev.visibleColumns.owner !== next.visibleColumns.owner) return false;
     // Compare callbacks - important for ".." entry which has static properties
     if (prev.onOpen !== next.onOpen) return false;
     if (prev.onSelect !== next.onSelect) return false;
@@ -170,7 +177,8 @@ const areEqual = (prev: SftpFileRowProps, next: SftpFileRowProps): boolean => {
         prevEntry.lastModified === nextEntry.lastModified &&
         prevEntry.linkTarget === nextEntry.linkTarget &&
         prevEntry.sizeFormatted === nextEntry.sizeFormatted &&
-        prevEntry.lastModifiedFormatted === nextEntry.lastModifiedFormatted
+        prevEntry.lastModifiedFormatted === nextEntry.lastModifiedFormatted &&
+        prevEntry.owner === nextEntry.owner
     );
 };
 

--- a/components/sftp/SftpPaneFileList.tsx
+++ b/components/sftp/SftpPaneFileList.tsx
@@ -607,7 +607,7 @@ export const SftpPaneFileList: React.FC<SftpPaneFileListProps> = React.memo(({
           )}
           {visibleColumns.type && (
             <div
-              className="flex min-w-0 items-center gap-1 cursor-pointer hover:text-foreground justify-end overflow-hidden"
+              className="flex min-w-0 items-center gap-1 cursor-pointer hover:text-foreground relative pr-2 justify-end overflow-hidden"
               onClick={() => handleSort("type")}
             >
               {sortField === "type" && (
@@ -616,6 +616,23 @@ export const SftpPaneFileList: React.FC<SftpPaneFileListProps> = React.memo(({
                 </span>
               )}
               <span className="truncate whitespace-nowrap">{t("sftp.columns.kind")}</span>
+              <div
+                className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/50 transition-colors"
+                onMouseDown={(e) => handleResizeStart("type", e)}
+              />
+            </div>
+          )}
+          {visibleColumns.owner && (
+            <div
+              className="flex min-w-0 items-center gap-1 cursor-pointer hover:text-foreground justify-end overflow-hidden"
+              onClick={() => handleSort("owner")}
+            >
+              {sortField === "owner" && (
+                <span className="shrink-0 text-primary">
+                  {sortOrder === "asc" ? "↑" : "↓"}
+                </span>
+              )}
+              <span className="truncate whitespace-nowrap">{t("sftp.columns.owner")}</span>
             </div>
           )}
         </div>

--- a/components/sftp/SftpPaneTreeNode.tsx
+++ b/components/sftp/SftpPaneTreeNode.tsx
@@ -121,6 +121,11 @@ export const TreeNode = React.memo<TreeNodeProps>(({
           {isParentEntry ? '' : (isDir ? t('sftp.kind.folder') : (entry.name.split('.').pop()?.toUpperCase() ?? '--'))}
         </span>
       )}
+      {visibleColumns.owner && (
+        <span className="min-w-0 text-right text-muted-foreground text-xs truncate">
+          {isParentEntry ? '' : (entry.owner || '--')}
+        </span>
+      )}
     </div>
   );
 });

--- a/components/sftp/SftpPaneTreeView.tsx
+++ b/components/sftp/SftpPaneTreeView.tsx
@@ -1000,7 +1000,7 @@ export const SftpPaneTreeView = React.memo<SftpPaneTreeViewProps>(({
             )}
             {visibleColumns.type && (
               <div
-                className="flex items-center justify-end gap-1 cursor-pointer hover:text-foreground min-w-0 overflow-hidden"
+                className="flex items-center justify-end gap-1 cursor-pointer hover:text-foreground relative pr-2 min-w-0 overflow-hidden"
                 onClick={() => handleSort('type')}
               >
                 {sortField === 'type' && (
@@ -1009,6 +1009,23 @@ export const SftpPaneTreeView = React.memo<SftpPaneTreeViewProps>(({
                   </span>
                 )}
                 <span className="truncate whitespace-nowrap">{t('sftp.columns.kind')}</span>
+                <div
+                  className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/50 transition-colors"
+                  onMouseDown={(e) => handleResizeStart('type', e)}
+                />
+              </div>
+            )}
+            {visibleColumns.owner && (
+              <div
+                className="flex items-center justify-end gap-1 cursor-pointer hover:text-foreground min-w-0 overflow-hidden"
+                onClick={() => handleSort('owner')}
+              >
+                {sortField === 'owner' && (
+                  <span className="shrink-0 text-primary">
+                    {sortOrder === 'asc' ? '↑' : '↓'}
+                  </span>
+                )}
+                <span className="truncate whitespace-nowrap">{t('sftp.columns.owner')}</span>
               </div>
             )}
           </div>

--- a/components/sftp/hooks/useSftpViewPaneCallbacks.ts
+++ b/components/sftp/hooks/useSftpViewPaneCallbacks.ts
@@ -90,6 +90,7 @@ export const useSftpViewPaneCallbacks = ({
               lastModified: ms,
               lastModifiedFormatted: formatDate(ms),
               permissions: f.permissions,
+              owner: f.owner,
               linkTarget: f.linkTarget as 'file' | 'directory' | null | undefined,
               hidden: f.hidden,
             };

--- a/components/sftp/sftpColumnVisibility.test.ts
+++ b/components/sftp/sftpColumnVisibility.test.ts
@@ -14,6 +14,7 @@ const widths: ColumnWidths = {
   modified: 28,
   size: 7,
   type: 9,
+  owner: 10,
 };
 
 test('normalizes missing and invalid SFTP column preferences to all columns', () => {
@@ -23,8 +24,15 @@ test('normalizes missing and invalid SFTP column preferences to all columns', ()
 
 test('keeps the name column visible while restoring optional column preferences', () => {
   assert.deepEqual(
-    normalizeSftpColumnVisibility({ name: false, modified: false, size: true, type: false }),
-    { name: true, modified: false, size: true, type: false },
+    normalizeSftpColumnVisibility({ name: false, modified: false, size: true, type: false, owner: false }),
+    { name: true, modified: false, size: true, type: false, owner: false },
+  );
+});
+
+test('treats a missing owner preference as visible', () => {
+  assert.equal(
+    normalizeSftpColumnVisibility({ name: true, modified: true, size: true, type: true }).owner,
+    true,
   );
 });
 
@@ -34,9 +42,22 @@ test('builds a grid containing only visible SFTP columns', () => {
     modified: false,
     size: true,
     type: false,
+    owner: false,
   });
 
   assert.equal(template, 'minmax(140px, 56fr) minmax(52px, 7fr)');
+});
+
+test('includes the owner column when it is visible', () => {
+  const template = buildSftpColumnTemplate(widths, {
+    name: true,
+    modified: false,
+    size: false,
+    type: false,
+    owner: true,
+  });
+
+  assert.equal(template, 'minmax(140px, 56fr) minmax(56px, 10fr)');
 });
 
 test('can reduce the SFTP file list to only the name column', () => {
@@ -46,6 +67,7 @@ test('can reduce the SFTP file list to only the name column', () => {
       modified: false,
       size: false,
       type: false,
+      owner: false,
     }),
     'minmax(140px, 56fr)',
   );

--- a/components/sftp/sftpColumnVisibilityIntegration.test.ts
+++ b/components/sftp/sftpColumnVisibilityIntegration.test.ts
@@ -29,4 +29,7 @@ test('list and tree SFTP views share column visibility and keyboard-accessible m
   assert.match(treeNodeSource, /visibleColumns\.type/);
   assert.match(treeNodeSource, /visibleColumns\.owner/);
   assert.match(columnMenuSource, /'modified', 'size', 'type', 'owner'/);
+
+  const paneCallbacksSource = readFileSync(new URL('./hooks/useSftpViewPaneCallbacks.ts', import.meta.url), 'utf8');
+  assert.match(paneCallbacksSource, /owner: f\.owner/);
 });

--- a/components/sftp/sftpColumnVisibilityIntegration.test.ts
+++ b/components/sftp/sftpColumnVisibilityIntegration.test.ts
@@ -27,4 +27,6 @@ test('list and tree SFTP views share column visibility and keyboard-accessible m
   assert.match(treeNodeSource, /visibleColumns\.modified/);
   assert.match(treeNodeSource, /visibleColumns\.size/);
   assert.match(treeNodeSource, /visibleColumns\.type/);
+  assert.match(treeNodeSource, /visibleColumns\.owner/);
+  assert.match(columnMenuSource, /'modified', 'size', 'type', 'owner'/);
 });

--- a/components/sftp/sftpSorting.test.ts
+++ b/components/sftp/sftpSorting.test.ts
@@ -59,6 +59,18 @@ test('SFTP descending kind sorting keeps directories first when enabled', () => 
   assert.deepEqual(sorted.map(({ name }) => name), ['src', 'archive.zip', 'BUILD']);
 });
 
+test('SFTP owner sorting compares usernames and keeps directories first', () => {
+  const ownerEntries = [
+    { ...entry('www.log', 'file', 100), owner: 'www-data' },
+    { ...entry('root.txt', 'file', 100), owner: 'root' },
+    { ...entry('home', 'directory', 100), owner: 'alice' },
+  ];
+
+  const sorted = sortSftpEntries(ownerEntries, 'owner', 'asc', true);
+
+  assert.deepEqual(sorted.map(({ name }) => name), ['home', 'root.txt', 'www.log']);
+});
+
 test('SFTP kind sorting can mix files and directories when folders first is disabled', () => {
   const kindEntries = [
     entry('BUILD', 'file', 100),

--- a/components/sftp/utils.ts
+++ b/components/sftp/utils.ts
@@ -265,6 +265,7 @@ export const buildSftpColumnTemplate = (
     if (visibleColumns.modified) columns.push(`minmax(0, ${columnWidths.modified}fr)`);
     if (visibleColumns.size) columns.push(`minmax(52px, ${columnWidths.size}fr)`);
     if (visibleColumns.type) columns.push(`minmax(64px, ${columnWidths.type}fr)`);
+    if (visibleColumns.owner) columns.push(`minmax(56px, ${columnWidths.owner}fr)`);
     return columns.join(' ');
 };
 
@@ -306,6 +307,9 @@ export const sortSftpEntries = (
                 cmp = extA.localeCompare(extB);
                 break;
             }
+            case 'owner':
+                cmp = (a.owner || '').localeCompare(b.owner || '');
+                break;
         }
         return sortOrder === 'asc' ? cmp : -cmp;
     });

--- a/domain/models/workspace.ts
+++ b/domain/models/workspace.ts
@@ -5,6 +5,7 @@ export interface RemoteFile {
   lastModified: string;
   linkTarget?: 'file' | 'directory' | null; // For symlinks: the type of the target, or null if broken
   permissions?: string; // rwx format for owner/group/others e.g. "rwxr-xr-x"
+  owner?: string;
   hidden?: boolean; // Windows hidden attribute (only set for local Windows filesystem)
 }
 

--- a/electron/bridges/localFsBridge.cjs
+++ b/electron/bridges/localFsBridge.cjs
@@ -183,7 +183,9 @@ async function listLocalDir(event, payload) {
         // Windows hidden attribute: resolved from the batched lookup.
         const hidden = isWindows ? hiddenSet.has(entry.name) : false;
 
-        const owner = localOwnerFromStat(stat);
+        // Follow the target for size/mtime/type; owner is the directory entry itself.
+        const ownerStat = type === "symlink" ? await fs.promises.lstat(fullPath) : stat;
+        const owner = localOwnerFromStat(ownerStat);
         result[i] = {
           name: entry.name,
           type,

--- a/electron/bridges/localFsBridge.cjs
+++ b/electron/bridges/localFsBridge.cjs
@@ -18,6 +18,21 @@ function normalizeLocalTreeLimit(value, fallback) {
   return Number.isSafeInteger(value) && value >= 0 ? value : fallback;
 }
 
+let cachedLocalUserInfo;
+function localOwnerFromStat(stat) {
+  if (process.platform === "win32") return undefined;
+  if (!stat || typeof stat.uid !== "number") return undefined;
+  try {
+    cachedLocalUserInfo ??= os.userInfo();
+    if (cachedLocalUserInfo.uid === stat.uid && cachedLocalUserInfo.username) {
+      return cachedLocalUserInfo.username;
+    }
+  } catch {
+    // userInfo() can throw when the process has no passwd entry.
+  }
+  return String(stat.uid);
+}
+
 function createLocalTreeTraversalBudget(limits = {}) {
   return {
     directories: 0,
@@ -168,6 +183,7 @@ async function listLocalDir(event, payload) {
         // Windows hidden attribute: resolved from the batched lookup.
         const hidden = isWindows ? hiddenSet.has(entry.name) : false;
 
+        const owner = localOwnerFromStat(stat);
         result[i] = {
           name: entry.name,
           type,
@@ -175,6 +191,7 @@ async function listLocalDir(event, payload) {
           size: `${stat.size} bytes`,
           lastModified: stat.mtime.toISOString(),
           hidden,
+          ...(owner ? { owner } : {}),
         };
       } catch (err) {
         // Handle broken symlinks - lstat doesn't follow symlinks
@@ -186,6 +203,7 @@ async function listLocalDir(event, payload) {
             if (lstat.isSymbolicLink()) {
               // Broken symlink
               const hidden = isWindows ? hiddenSet.has(brokenEntry.name) : false;
+              const owner = localOwnerFromStat(lstat);
               result[i] = {
                 name: brokenEntry.name,
                 type: "symlink",
@@ -193,6 +211,7 @@ async function listLocalDir(event, payload) {
                 size: `${lstat.size} bytes`,
                 lastModified: lstat.mtime.toISOString(),
                 hidden,
+                ...(owner ? { owner } : {}),
               };
               return;
             }

--- a/electron/bridges/sftpBridge/fileOps.cjs
+++ b/electron/bridges/sftpBridge/fileOps.cjs
@@ -200,6 +200,7 @@ function createFileOpsApi(ctx) {
                   size: `${rec.size || 0} bytes`,
                   lastModified: new Date(rec.modifyTime || Date.now()).toISOString(),
                   permissions: rec.permissions,
+                  ...(rec.owner ? { owner: rec.owner } : {}),
                 };
                 if (rec.type === "symlink") {
                   try {
@@ -285,6 +286,7 @@ function createFileOpsApi(ctx) {
       const resolvedEncoding = updateResolvedEncoding(payload.sftpId, requestedEncoding, detectedEncoding);
     
       // Process items and resolve symlinks
+      const { resolveListingOwner } = require("./scpShell.cjs");
       const results = await Promise.all(list.map(async (item) => {
         const filenameRaw = item.filenameRaw || (item.filename ? Buffer.from(item.filename, "utf8") : null);
         const longnameRaw = item.longnameRaw || (item.longname ? Buffer.from(item.longname, "utf8") : null);
@@ -339,6 +341,10 @@ function createFileOpsApi(ctx) {
         }
     
         const modifyTime = item.attrs?.mtime ? item.attrs.mtime * 1000 : Date.now();
+        const owner = resolveListingOwner({
+          longname,
+          uid: item.attrs?.uid,
+        });
         return {
           name,
           type,
@@ -346,6 +352,7 @@ function createFileOpsApi(ctx) {
           size: `${item.attrs?.size || 0} bytes`,
           lastModified: new Date(modifyTime).toISOString(),
           permissions,
+          ...(owner ? { owner } : {}),
         };
       }));
     

--- a/electron/bridges/sftpBridge/fileOps.test.cjs
+++ b/electron/bridges/sftpBridge/fileOps.test.cjs
@@ -460,3 +460,55 @@ test("non-UTF-8 expected symlink delete stays non-recursive after the type check
   assert.equal(unlinkCalls, 1);
   assert.equal(removeCalls, 0);
 });
+
+test("listSftp includes owner from longname and falls back to uid", async () => {
+  const channel = {
+    readdir(_path, callback) {
+      callback(null, [
+        {
+          filename: "root.txt",
+          longname: "-rw-r--r--    1 root     root         12 Jan  1 00:00 root.txt",
+          attrs: {
+            size: 12,
+            mtime: 1700000000,
+            uid: 0,
+            mode: 0o100644,
+            isDirectory: () => false,
+            isSymbolicLink: () => false,
+          },
+        },
+        {
+          filename: "uid-only.bin",
+          longname: "",
+          attrs: {
+            size: 1,
+            mtime: 1700000000,
+            uid: 1000,
+            mode: 0o100644,
+            isDirectory: () => false,
+            isSymbolicLink: () => false,
+          },
+        },
+      ]);
+    },
+  };
+  const api = createFileOpsApi({
+    sftpClients: new Map([["sftp-1", { sftp: channel }]]),
+    path: require("node:path"),
+    normalizeEncoding: (value) => value || "utf-8",
+    resolveEncodingForRequest: () => "utf-8",
+    encodePath: (remotePath) => remotePath,
+    requireSftpChannel: async () => channel,
+    detectEncodingFromList: () => "utf-8",
+    updateResolvedEncoding: (_id, _req, detected) => detected,
+    decodeName: (raw) => (raw ? Buffer.from(raw).toString("utf8") : ""),
+    isAsciiString: () => true,
+    sftpEncodingState: new Map(),
+  });
+
+  const entries = await api.listSftp(null, { sftpId: "sftp-1", path: "/home" });
+  assert.equal(entries[0].name, "root.txt");
+  assert.equal(entries[0].owner, "root");
+  assert.equal(entries[1].name, "uid-only.bin");
+  assert.equal(entries[1].owner, "1000");
+});

--- a/electron/bridges/sftpBridge/scpBackend.cjs
+++ b/electron/bridges/sftpBridge/scpBackend.cjs
@@ -180,6 +180,7 @@ function createScpBackend(deps = {}) {
       size: `${sizeNum} bytes`,
       lastModified: new Date(rec.modifyTime || Date.now()).toISOString(),
       permissions: rec.permissions,
+      ...(rec.owner ? { owner: rec.owner } : {}),
       // raw fields for internal use
       _size: sizeNum,
       _modifyTime: rec.modifyTime,

--- a/electron/bridges/sftpBridge/scpProtocol.test.cjs
+++ b/electron/bridges/sftpBridge/scpProtocol.test.cjs
@@ -181,6 +181,11 @@ describe("scpShell quoting and commands", () => {
     );
     assert.equal(lsRows[0]?.name, "notes.txt");
     assert.equal(lsRows[0]?.owner, "root");
+
+    const aclRows = parseLsLaOutput(
+      "-rw-r--r--+ 1 alice staff 12 Jan  1 00:00 notes.txt\n",
+    );
+    assert.equal(aclRows[0]?.owner, "alice");
   });
 
   it("resolves listing owner from longname, then uid", () => {
@@ -194,6 +199,18 @@ describe("scpShell quoting and commands", () => {
     );
     assert.equal(resolveListingOwner({ uid: 1000 }), "1000");
     assert.equal(resolveListingOwner({ owner: "UNKNOWN", uid: 0 }), "0");
+    assert.equal(
+      ownerFromSftpLongname("-rw-r--r--+  1 alice  staff  12 Jan  1 00:00 notes.txt"),
+      "alice",
+    );
+    assert.equal(
+      ownerFromSftpLongname("-rw-r--r--@  1 alice  staff  12 Jan  1 00:00 notes.txt"),
+      "alice",
+    );
+    assert.equal(
+      ownerFromSftpLongname("-rw-r--r--.  1 alice  staff  12 Jan  1 00:00 notes.txt"),
+      "alice",
+    );
   });
 
   it("list command includes owner in the record", () => {

--- a/electron/bridges/sftpBridge/scpProtocol.test.cjs
+++ b/electron/bridges/sftpBridge/scpProtocol.test.cjs
@@ -28,6 +28,9 @@ const {
   buildRenameCommand,
   buildChmodCommand,
   parseListRecords,
+  parseLsLaOutput,
+  ownerFromSftpLongname,
+  resolveListingOwner,
   normalizeFileProtocol,
 } = require("./scpShell.cjs");
 
@@ -163,6 +166,39 @@ describe("scpShell quoting and commands", () => {
     const b64 = iconv.encode(name, "gb18030").toString("base64");
     const rows = parseListRecords(`f|-rw-r--r--|1|1700000000|${b64}\n`, "gb18030");
     assert.equal(rows[0]?.name, name);
+  });
+
+  it("parses optional owner from list records and ls -la fallback", () => {
+    const b64 = Buffer.from("notes.txt", "utf8").toString("base64");
+    const rows = parseListRecords(`f|-rw-r--r--|12|1700000000|${b64}|www-data\n`);
+    assert.equal(rows[0]?.owner, "www-data");
+
+    const legacy = parseListRecords(`f|-rw-r--r--|12|1700000000|${b64}\n`);
+    assert.equal(legacy[0]?.owner, undefined);
+
+    const lsRows = parseLsLaOutput(
+      "total 4\n-rw-r--r--  1 root  wheel  12 Jan  1 00:00 notes.txt\n",
+    );
+    assert.equal(lsRows[0]?.name, "notes.txt");
+    assert.equal(lsRows[0]?.owner, "root");
+  });
+
+  it("resolves listing owner from longname, then uid", () => {
+    assert.equal(
+      ownerFromSftpLongname("-rwxr-xr-x  1 alice  staff  4096 Jan  1 00:00 bin"),
+      "alice",
+    );
+    assert.equal(
+      resolveListingOwner({ longname: "drwxr-xr-x  2 www-data www-data 4096 Jan 1 00:00 html" }),
+      "www-data",
+    );
+    assert.equal(resolveListingOwner({ uid: 1000 }), "1000");
+    assert.equal(resolveListingOwner({ owner: "UNKNOWN", uid: 0 }), "0");
+  });
+
+  it("list command includes owner in the record", () => {
+    assert.match(buildListCommand("/tmp"), /awk '\{print \$3\}'/);
+    assert.match(buildListCommand("/tmp"), /%s\\|%s\\|%s\\|%s\\|%s\\|%s/);
   });
 
   it("list command keeps broken symlinks", () => {

--- a/electron/bridges/sftpBridge/scpShell.cjs
+++ b/electron/bridges/sftpBridge/scpShell.cjs
@@ -232,7 +232,7 @@ function shellQuotePath(remotePath, encoding = "utf-8") {
  */
 function ownerFromSftpLongname(longname) {
   if (!longname) return undefined;
-  const match = String(longname).match(/^[dlbcps\-][rwxsStT\-]{9}\s+\d+\s+(\S+)\s+\S+\s+/);
+  const match = String(longname).match(/^[dlbcps\-][rwxsStT\-]{9}[+.@]?\s+\d+\s+(\S+)\s+\S+\s+/);
   const owner = match?.[1]?.trim();
   return owner || undefined;
 }
@@ -293,7 +293,7 @@ function parseLsLaOutput(stdout, { basePath = "" } = {}) {
     if (!line || line.startsWith("total ")) continue;
     // permissions links owner group size month day time/year name
     const match = line.match(
-      /^([dlbcps\-])([rwxsStT\-]{9})\s+\d+\s+(\S+)\s+\S+\s+(\d+)\s+(\S+\s+\S+\s+\S+)\s+(.+)$/,
+      /^([dlbcps\-])([rwxsStT\-]{9})[+.@]?\s+\d+\s+(\S+)\s+\S+\s+(\d+)\s+(\S+\s+\S+\s+\S+)\s+(.+)$/,
     );
     if (!match) continue;
     const typeChar = match[1];

--- a/electron/bridges/sftpBridge/scpShell.cjs
+++ b/electron/bridges/sftpBridge/scpShell.cjs
@@ -85,7 +85,9 @@ function buildListCommand(remotePath, encoding = "utf-8") {
     '  if [ -L "$f" ]; then t=l',
     '  elif [ -d "$f" ]; then t=d',
     '  else t=f; fi',
-    '  mode=$(ls -ld -- "$f" 2>/dev/null | awk \'{print $1}\')',
+    '  lsline=$(ls -ld -- "$f" 2>/dev/null)',
+    '  mode=$(printf "%s\\n" "$lsline" | awk \'{print $1}\')',
+    '  owner=$(printf "%s\\n" "$lsline" | awk \'{print $3}\')',
     // Use metadata only — never open the file (FIFOs/special files would hang on wc -c).
     '  size=$(stat -c %s -- "$f" 2>/dev/null || stat -f %z -- "$f" 2>/dev/null || echo 0)',
     '  [ -z "$size" ] && size=0',
@@ -96,7 +98,7 @@ function buildListCommand(remotePath, encoding = "utf-8") {
     '  if command -v base64 >/dev/null 2>&1; then b64=$(printf "%s" "$f" | base64 2>/dev/null | tr -d "\\r\\n")',
     '  elif command -v openssl >/dev/null 2>&1; then b64=$(printf "%s" "$f" | openssl base64 2>/dev/null | tr -d "\\r\\n")',
     '  else b64=; fi',
-    '  printf "%s|%s|%s|%s|%s\\n" "$t" "${mode:-?}" "$size" "$mtime" "$b64"',
+    '  printf "%s|%s|%s|%s|%s|%s\\n" "$t" "${mode:-?}" "$size" "$mtime" "$b64" "${owner:-}"',
     "done",
   ].join("\n");
   return `cd ${q} || exit 1; ${loop}`;
@@ -225,8 +227,37 @@ function shellQuotePath(remotePath, encoding = "utf-8") {
 }
 
 /**
+ * Parse a username from an SFTP longname / `ls -l` line.
+ * Example: "-rwxr-xr-x  1 root  root  4096 Jan 1 00:00 filename"
+ */
+function ownerFromSftpLongname(longname) {
+  if (!longname) return undefined;
+  const match = String(longname).match(/^[dlbcps\-][rwxsStT\-]{9}\s+\d+\s+(\S+)\s+\S+\s+/);
+  const owner = match?.[1]?.trim();
+  return owner || undefined;
+}
+
+function ownerFromUid(uid) {
+  if (typeof uid !== "number" || !Number.isFinite(uid)) return undefined;
+  return String(uid);
+}
+
+function normalizeListingOwner(value) {
+  if (typeof value !== "string") return undefined;
+  const owner = value.trim();
+  if (!owner || owner === "?" || owner === "UNKNOWN") return undefined;
+  return owner;
+}
+
+function resolveListingOwner({ owner, longname, uid } = {}) {
+  return normalizeListingOwner(owner)
+    || ownerFromSftpLongname(longname)
+    || ownerFromUid(uid);
+}
+
+/**
  * Parse records from buildListCommand output.
- * @returns {Array<{ name: string, type: 'file'|'directory'|'symlink', size: number, modifyTime: number, permissions?: string }>}
+ * @returns {Array<{ name: string, type: 'file'|'directory'|'symlink', size: number, modifyTime: number, permissions?: string, owner?: string }>}
  */
 function parseListRecords(stdout, encoding = "utf-8") {
   const lines = String(stdout || "").split(/\r?\n/).filter(Boolean);
@@ -234,7 +265,7 @@ function parseListRecords(stdout, encoding = "utf-8") {
   for (const line of lines) {
     const parts = line.split("|");
     if (parts.length < 5) continue;
-    const [t, modeStr, sizeStr, mtimeStr, b64] = parts;
+    const [t, modeStr, sizeStr, mtimeStr, b64, ownerRaw] = parts;
     let name;
     try {
       name = decodeListBasename(b64, encoding);
@@ -246,7 +277,8 @@ function parseListRecords(stdout, encoding = "utf-8") {
     const size = Number(sizeStr) || 0;
     const modifyTime = (Number(mtimeStr) || 0) * 1000;
     const permissions = parseLsModeToPermissions(modeStr);
-    results.push({ name, type, size, modifyTime, permissions });
+    const owner = resolveListingOwner({ owner: ownerRaw });
+    results.push({ name, type, size, modifyTime, permissions, ...(owner ? { owner } : {}) });
   }
   return results;
 }
@@ -261,13 +293,14 @@ function parseLsLaOutput(stdout, { basePath = "" } = {}) {
     if (!line || line.startsWith("total ")) continue;
     // permissions links owner group size month day time/year name
     const match = line.match(
-      /^([dlbcps\-])([rwxsStT\-]{9})\s+\d+\s+\S+\s+\S+\s+(\d+)\s+(\S+\s+\S+\s+\S+)\s+(.+)$/,
+      /^([dlbcps\-])([rwxsStT\-]{9})\s+\d+\s+(\S+)\s+\S+\s+(\d+)\s+(\S+\s+\S+\s+\S+)\s+(.+)$/,
     );
     if (!match) continue;
     const typeChar = match[1];
     const perm = match[2];
-    const size = Number(match[3]) || 0;
-    let name = match[5];
+    const owner = resolveListingOwner({ owner: match[3] });
+    const size = Number(match[4]) || 0;
+    let name = match[6];
     // strip " -> target" only for symlink rows (backslash filenames may contain " -> ")
     if (typeChar === "l") {
       const arrow = name.indexOf(" -> ");
@@ -288,6 +321,7 @@ function parseLsLaOutput(stdout, { basePath = "" } = {}) {
       size,
       modifyTime: Date.now(),
       permissions: perm,
+      ...(owner ? { owner } : {}),
     });
   }
   return results;
@@ -395,6 +429,9 @@ module.exports = {
   buildRealpathCommand,
   parseListRecords,
   parseLsLaOutput,
+  ownerFromSftpLongname,
+  ownerFromUid,
+  resolveListingOwner,
   parseStatRecord,
   parseLsModeToPermissions,
   lsModeToNumber,


### PR DESCRIPTION
## Summary

SFTP file lists now show the file/directory owner as a toggleable column, matching other SSH clients.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3073

## Changes Made

- Parse owner from SFTP `longname` (or `uid` when the name is missing) and from SCP `ls` listings
- Pass owner through remote and local directory listings
- Add an Owner column to the list/tree views, column menu, sort, and saved visibility prefs
- Local Unix listings show the current username or numeric uid; Windows local listings stay blank

## Screenshots / Demo

Right-click the SFTP column header to show or hide Owner. The column is on by default.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Targeted coverage (all passed):

- `components/sftp/sftpColumnVisibility.test.ts`
- `components/sftp/sftpColumnVisibilityIntegration.test.ts`
- `components/sftp/sftpSorting.test.ts`
- `electron/bridges/sftpBridge/scpProtocol.test.cjs`
- `electron/bridges/sftpBridge/fileOps.test.cjs`
- `electron/bridges/sftpBridge/scpSessionOps.test.cjs`

ESLint was run on the changed files. Full `npm test` / `npm run dev` were not run here (no live SFTP host in this environment).

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)