### PR TITLE
fix: send Content-Length for AI request bodies instead of chunked encoding

### DIFF
--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -561,6 +561,22 @@ function raceAgainstAbort(promise, signal) {
   });
 }
 
+/**
+ * Node's http.request falls back to `Transfer-Encoding: chunked` when no
+ * Content-Length header is present. Some HTTP proxies mishandle large chunked
+ * request bodies — Xray's HTTP inbound drops the connection above ~8KB, which
+ * surfaces to the renderer as an opaque "socket hang up". The body is always a
+ * fully-buffered string here, so send an explicit Content-Length instead.
+ */
+function withContentLength(headers, body) {
+  if (body == null || body === "") return headers;
+  const alreadySet = Object.keys(headers).some(
+    (k) => k.toLowerCase() === "content-length",
+  );
+  if (alreadySet) return headers;
+  return { ...headers, "content-length": String(Buffer.byteLength(body)) };
+}
+
 async function streamRequest(url, options, event, requestId, skipTLS) {
   const parsedUrl = new URL(url);
   // Register cancellation before any await so Stop during PAC/proxy lookup works.
@@ -670,7 +686,7 @@ async function streamRequest(url, options, event, requestId, skipTLS) {
 
     const reqOpts = {
         method: options.method || "POST",
-        headers: options.headers || {},
+        headers: withContentLength(options.headers || {}, options.body),
         timeout: 120000, // 2 min connection timeout
     };
     if (skipTLS && isHttps) reqOpts.rejectUnauthorized = false;
@@ -820,6 +836,7 @@ function createHandlerContext(ipcMain) {
     fs,
     existsSync,
     mcpServerBridge,
+    withContentLength,
     getExternalMcpController: () => externalMcpController,
     getCliLauncherPath,
     TOOL_CLI_DISCOVERY_ENV_VAR,

--- a/electron/bridges/aiBridge.test.cjs
+++ b/electron/bridges/aiBridge.test.cjs
@@ -1372,3 +1372,168 @@ test("discover can refresh shell env before scanning Cursor", async () => {
     restore();
   }
 });
+
+/** Boot the bridge with a local HTTP server and capture the request it receives. */
+async function withCapturingServer(t, options, respond) {
+  const received = {};
+  let handleStreamEvent = () => {};
+  const { bridge, restore } = loadBridgeWithMocks({
+    safeSend: (_sender, channel, payload) => handleStreamEvent(channel, payload),
+    ...options,
+  });
+  const ipcMain = createIpcMainStub();
+  const server = http.createServer((req, res) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      received.headers = req.headers;
+      received.body = Buffer.concat(chunks);
+      respond(res);
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const baseURL = `http://127.0.0.1:${address.port}`;
+  const sender = { id: 1 };
+  await ipcMain.handlers.get("netcatty:ai:sync-providers")(
+    { sender },
+    { providers: [{ id: "content-length", baseURL }] },
+  );
+
+  return {
+    received,
+    baseURL,
+    sender,
+    ipcMain,
+    restore,
+    onStreamEvent: (fn) => {
+      handleStreamEvent = fn;
+    },
+  };
+}
+
+test("streaming AI requests send Content-Length instead of chunked encoding", { timeout: 5_000 }, async (t) => {
+  const ctx = await withCapturingServer(t, {}, (res) => {
+    res.writeHead(200, { "content-type": "text/event-stream" });
+    res.end('data: {"choices":[{"delta":{"content":"ok"}}]}\n\n');
+  });
+
+  try {
+    const body = JSON.stringify({
+      stream: true,
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    const streamFinished = new Promise((resolve, reject) => {
+      ctx.onStreamEvent((channel, payload) => {
+        if (channel === "netcatty:ai:stream:end") resolve();
+        else if (channel === "netcatty:ai:stream:error") reject(new Error(payload.error));
+      });
+    });
+
+    const result = await ctx.ipcMain.handlers.get("netcatty:ai:chat:stream")(
+      { sender: ctx.sender },
+      {
+        requestId: "content-length-stream",
+        url: `${ctx.baseURL}/v1/messages`,
+        headers: { "content-type": "application/json" },
+        body,
+        providerId: "content-length",
+      },
+    );
+    await streamFinished;
+
+    assert.equal(result.ok, true);
+    assert.equal(ctx.received.headers["content-length"], String(Buffer.byteLength(body)));
+    assert.equal(ctx.received.headers["transfer-encoding"], undefined);
+    assert.equal(ctx.received.body.toString("utf8"), body);
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("Content-Length for AI request bodies counts bytes, not UTF-16 code units", { timeout: 5_000 }, async (t) => {
+  const ctx = await withCapturingServer(t, {}, (res) => {
+    res.writeHead(200, { "content-type": "text/event-stream" });
+    res.end('data: {"choices":[{"delta":{"content":"ok"}}]}\n\n');
+  });
+
+  try {
+    // A realistic system prompt: multi-byte characters make the UTF-16 length
+    // shorter than the UTF-8 byte length, so `body.length` would truncate.
+    const body = JSON.stringify({
+      stream: true,
+      system: "你是 Catty Agent，一个内置于 netcatty 的终端自动化助手。请检查磁盘使用率。",
+      messages: [{ role: "user", content: "检查系统状态" }],
+    });
+    assert.notEqual(body.length, Buffer.byteLength(body));
+
+    const streamFinished = new Promise((resolve, reject) => {
+      ctx.onStreamEvent((channel, payload) => {
+        if (channel === "netcatty:ai:stream:end") resolve();
+        else if (channel === "netcatty:ai:stream:error") reject(new Error(payload.error));
+      });
+    });
+
+    const result = await ctx.ipcMain.handlers.get("netcatty:ai:chat:stream")(
+      { sender: ctx.sender },
+      {
+        requestId: "content-length-multibyte",
+        url: `${ctx.baseURL}/v1/messages`,
+        headers: { "content-type": "application/json" },
+        body,
+        providerId: "content-length",
+      },
+    );
+    await streamFinished;
+
+    assert.equal(result.ok, true);
+    assert.equal(ctx.received.headers["content-length"], String(Buffer.byteLength(body)));
+    assert.equal(ctx.received.body.toString("utf8"), body);
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("non-streaming AI requests send Content-Length instead of chunked encoding", { timeout: 5_000 }, async (t) => {
+  const ctx = await withCapturingServer(t, {}, (res) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end('{"data":[]}');
+  });
+
+  try {
+    const body = JSON.stringify({ model: "test-model", input: "hi" });
+
+    const result = await ctx.ipcMain.handlers.get("netcatty:ai:fetch")(
+      { sender: ctx.sender },
+      {
+        url: `${ctx.baseURL}/v1/messages`,
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+        providerId: "content-length",
+      },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(ctx.received.headers["content-length"], String(Buffer.byteLength(body)));
+    assert.equal(ctx.received.headers["transfer-encoding"], undefined);
+    assert.equal(ctx.received.body.toString("utf8"), body);
+  } finally {
+    ctx.restore();
+  }
+});

--- a/electron/bridges/aiBridge/providerHandlers.cjs
+++ b/electron/bridges/aiBridge/providerHandlers.cjs
@@ -419,7 +419,11 @@ function registerProviderHandlers(ctx) {
         const isHttps = parsedUrl.protocol === "https:";
         const lib = isHttps ? https : http;
 
-        const fetchOpts = { method: method || "GET", headers: resolvedHeaders || {}, timeout: 30000 };
+        const fetchOpts = {
+          method: method || "GET",
+          headers: withContentLength(resolvedHeaders || {}, body),
+          timeout: 30000,
+        };
         if (skipTLS && isHttps) fetchOpts.rejectUnauthorized = false;
         if (proxyAgent) fetchOpts.agent = proxyAgent;
         const req = lib.request(parsedUrl, fetchOpts,


### PR DESCRIPTION
## Summary

Node's `http.request()` falls back to `Transfer-Encoding: chunked` when no
`Content-Length` header is present. Both AI request paths pass the AI SDK's headers
through unchanged, and those headers carry no `content-length` (in the browser `fetch`
computes it), so every AI request body was sent chunked.

The body is already a fully-buffered string at that point, so its length is known.
This PR sends an explicit `Content-Length` instead.

Chunked request bodies are the less interoperable choice: on the plain-HTTP path an
HTTP proxy has to de-frame and re-serialize them, and some fail on larger bodies.
Concretely, Xray's HTTP inbound drops the connection once the chunked body exceeds
roughly 8&nbsp;KB. Because Catty's system prompt plus tool definitions measures about
48&nbsp;KB, every chat turn against an `http://` provider behind a system HTTP proxy
failed with an opaque `AI_APICallError: socket hang up` — while the connection test
kept passing, since it issues `GET /v1/models` with no body and therefore never
exercises this path.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3083

## Changes Made

- `electron/bridges/aiBridge.cjs`
  - Added `withContentLength(headers, body)`, which sets `content-length` from
    `Buffer.byteLength(body)` when a body is present and the caller has not already
    supplied the header (matched case-insensitively).
  - Applied it to `reqOpts.headers` in `streamRequest()` (the streaming chat path).
  - Exposed it on the handler context so `providerHandlers.cjs` can reuse it.
- `electron/bridges/aiBridge/providerHandlers.cjs`
  - Applied it to `fetchOpts.headers` in `doFetch()` (the non-streaming path used by
    model listing and provider validation).
- `electron/bridges/aiBridge.test.cjs`
  - Three tests: the streaming path sends `Content-Length` and no
    `Transfer-Encoding`; the length is measured in bytes rather than UTF-16 code units
    and multi-byte bodies arrive intact; the non-streaming path does the same.

`Buffer.byteLength` rather than `body.length` is load-bearing here — the system prompt
contains multi-byte characters, so string length would understate the byte count and
truncate the body. `aiBridge.cjs` already uses `Buffer.byteLength` elsewhere for the
same reason.

## Screenshots / Demo

No UI change. The behavior change is on the wire only:

```
# before
POST /v1/messages HTTP/1.1
content-type: application/json
Transfer-Encoding: chunked

# after
POST /v1/messages HTTP/1.1
content-type: application/json
content-length: 48605
```

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`) — not applicable, no capability changes
- [x] No new console errors or warnings, if this affects app behavior

### Verification

Reproduced and fixed end to end against the failing setup: v2rayN 7.22.5 / Xray-core
26.6.1 mixed inbound on `127.0.0.1:10808` as the system proxy, with a plain-`http://`
self-hosted gateway as the provider.

| Check | Result |
|---|---|
| `npm run lint` | clean |
| `npm test` | 10079/10271 pass; all 149 failures pre-existing (see note) |
| `npm run dev` | launches clean, all bridges registered, no errors or warnings |
| Chat in the running dev build, system-proxy mode, `http://` provider | **works** (fails on the release build) |

The three added tests fail without the fix and pass with it.

Transport-level replay of a captured 48,605-byte request body, changing only the body
framing and route:

| Route | Body framing | Result |
|---|---|---|
| Direct, no proxy | chunked | HTTP 200 |
| Proxy HTTP inbound | chunked | fails — `socket hang up` |
| Proxy HTTP inbound | Content-Length | HTTP 200 |
| Proxy SOCKS5 inbound | chunked | HTTP 200 |

The size threshold for the chunked failure through that proxy is between 8&nbsp;KB and
16&nbsp;KB. Routing the same request over the proxy's SOCKS5 inbound (a plain TCP
tunnel) always worked, which is also why `https://` providers were unaffected —
`HttpsProxyAgent` uses CONNECT, so the proxy never parses the request.

**Note on the 149 test failures:** they are unrelated to this change. `npm ci`'s
postinstall aborts at `electron-builder install-app-deps` because node-gyp has no
Visual Studio toolchain on my machine, leaving native modules and plugin-runtime deps
incomplete (mosh/PTY/clipboard/tempdir/compress-upload suites). I confirmed this by
re-running the 42 failing files against a pristine checkout: per-file failure counts
are identical and zero files differ. For `npm run dev` I used the prebuilt native
modules from an installed 1.1.81-era build (identical Electron 42.3.3 ABI) rather than
compiling them locally.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
