### PR TITLE
fix(sftp): open filter with search shortcut

### DIFF
--- a/application/state/sftp/sftpFilterFocusStore.ts
+++ b/application/state/sftp/sftpFilterFocusStore.ts
@@ -1,0 +1,22 @@
+type SftpFilterFocusListener = () => void;
+
+const listenersByPaneId = new Map<string, Set<SftpFilterFocusListener>>();
+
+export const sftpFilterFocusStore = {
+  request(paneId: string): void {
+    listenersByPaneId.get(paneId)?.forEach((listener) => listener());
+  },
+
+  subscribe(paneId: string, listener: SftpFilterFocusListener): () => void {
+    const listeners = listenersByPaneId.get(paneId) ?? new Set<SftpFilterFocusListener>();
+    listeners.add(listener);
+    listenersByPaneId.set(paneId, listeners);
+
+    return () => {
+      listeners.delete(listener);
+      if (listeners.size === 0) {
+        listenersByPaneId.delete(paneId);
+      }
+    };
+  },
+};

--- a/components/sftp/SftpFilterShortcut.interaction.test.ts
+++ b/components/sftp/SftpFilterShortcut.interaction.test.ts
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+
+import type { SftpStateApi } from "../../application/state/useSftpState.ts";
+
+test("Ctrl+F opens and refocuses the active SFTP pane filter without handling inactive panes", async () => {
+  const dom = new JSDOM(
+    '<!doctype html><html><body><div id="root"></div><button id="terminal-focus" class="xterm">terminal</button></body></html>',
+    { pretendToBeVisual: true, url: "http://localhost" },
+  );
+  const window = dom.window;
+  const previousGlobals = new Map<string, PropertyDescriptor | undefined>();
+  const installGlobal = (key: string, value: unknown) => {
+    previousGlobals.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      writable: true,
+      value,
+    });
+  };
+
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  installGlobal("window", window);
+  installGlobal("document", window.document);
+  installGlobal("navigator", window.navigator);
+  installGlobal("HTMLElement", window.HTMLElement);
+  installGlobal("HTMLInputElement", window.HTMLInputElement);
+  installGlobal("HTMLTextAreaElement", window.HTMLTextAreaElement);
+  installGlobal("Element", window.Element);
+  installGlobal("SVGElement", window.SVGElement);
+  installGlobal("Node", window.Node);
+  installGlobal("NodeFilter", window.NodeFilter);
+  installGlobal("MutationObserver", window.MutationObserver);
+  installGlobal("CustomEvent", window.CustomEvent);
+  installGlobal("Event", window.Event);
+  installGlobal("KeyboardEvent", window.KeyboardEvent);
+  installGlobal("StorageEvent", window.StorageEvent);
+  installGlobal("localStorage", window.localStorage);
+  installGlobal("sessionStorage", window.sessionStorage);
+  installGlobal("getComputedStyle", window.getComputedStyle.bind(window));
+  installGlobal("requestAnimationFrame", window.requestAnimationFrame.bind(window));
+  installGlobal("cancelAnimationFrame", window.cancelAnimationFrame.bind(window));
+  installGlobal("ResizeObserver", ResizeObserverStub);
+  installGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+
+  const { default: React, act } = await import("react");
+  const { createRoot } = await import("react-dom/client");
+  const { DEFAULT_KEY_BINDINGS } = await import("../../domain/models/keyBindings.ts");
+  const { sftpFocusStore } = await import("../../application/state/sftp/sftpFocusStore.ts");
+  const { useSftpKeyboardShortcuts } = await import("./hooks/useSftpKeyboardShortcuts.ts");
+  const { SftpPaneToolbar } = await import("./SftpPaneToolbar.tsx");
+
+  const pane = {
+    id: "pane-1",
+    connection: {
+      id: "conn-1",
+      hostId: "host-1",
+      name: "Example",
+      currentPath: "/home/app",
+      homeDir: "/home/app",
+      isLocal: false,
+    },
+    files: [],
+    loading: false,
+    reconnecting: false,
+    error: null,
+    connectionLogs: [],
+    selectedFiles: new Set<string>(),
+    filter: "",
+    filenameEncoding: "auto" as const,
+    showHiddenFiles: false,
+    transferMutationToken: 0,
+  };
+
+  const Harness = ({ isActive }: { isActive: boolean }) => {
+    const [showFilterBar, setShowFilterBar] = React.useState(false);
+    const filterInputRef = React.useRef<HTMLInputElement>(null);
+    const sftpRef = React.useRef({
+      leftTabs: { tabs: [pane], activeTabId: pane.id },
+      rightTabs: { tabs: [], activeTabId: null },
+    } as unknown as SftpStateApi);
+
+    useSftpKeyboardShortcuts({
+      keyBindings: DEFAULT_KEY_BINDINGS,
+      hotkeyScheme: "pc",
+      sftpRef,
+      dialogActionScopeId: "test-scope",
+      isActive,
+    });
+
+    return React.createElement(
+      React.Fragment,
+      null,
+      React.createElement("button", { id: "sftp-focus-target" }, "files"),
+      React.createElement(SftpPaneToolbar, {
+        t: (key: string) => ({
+          "sftp.filter": "Filter files",
+          "sftp.filter.placeholder": "Filter files",
+          "sftp.viewMode.switchToTree": "Switch to tree view",
+          "sftp.bookmark.add": "Bookmark current path",
+          "common.refresh": "Refresh",
+          "common.close": "Close",
+        }[key] ?? key),
+        pane,
+        onNavigateTo: () => {},
+        onSetFilter: () => {},
+        onSetFilenameEncoding: () => {},
+        onRefresh: () => {},
+        showFilterBar,
+        setShowFilterBar,
+        filterInputRef,
+        isEditingPath: false,
+        editingPathValue: "",
+        setEditingPathValue: () => {},
+        setShowPathSuggestions: () => {},
+        showPathSuggestions: false,
+        setPathSuggestionIndex: () => {},
+        pathSuggestions: [],
+        pathSuggestionIndex: -1,
+        pathInputRef: { current: null },
+        pathDropdownRef: { current: null },
+        handlePathBlur: () => {},
+        handlePathKeyDown: () => {},
+        handlePathDoubleClick: () => {},
+        handlePathSubmit: () => {},
+        getNextUntitledName: () => "untitled",
+        setNewFileName: () => {},
+        setFileNameError: () => {},
+        setShowNewFileDialog: () => {},
+        setShowNewFolderDialog: () => {},
+        setNewFolderName: () => {},
+        bookmarks: [],
+        isCurrentPathBookmarked: false,
+        onToggleBookmark: () => {},
+        onAddGlobalBookmark: () => {},
+        isCurrentPathGlobalBookmarked: false,
+        onNavigateToBookmark: () => {},
+        onDeleteBookmark: () => {},
+        showHiddenFiles: false,
+        onToggleShowHiddenFiles: () => {},
+        viewMode: "list",
+        onSetViewMode: () => {},
+      }),
+    );
+  };
+
+  const rootNode = window.document.getElementById("root");
+  assert.ok(rootNode);
+  const root = createRoot(rootNode);
+  const pressCtrlF = async (target: Element) => {
+    await act(async () => {
+      target.dispatchEvent(new window.KeyboardEvent("keydown", {
+        key: "f",
+        code: "KeyF",
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      }));
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+  };
+
+  try {
+    sftpFocusStore.setFocusedSide("left");
+    await act(async () => root.render(React.createElement(Harness, { isActive: true })));
+
+    const sftpTarget = window.document.getElementById("sftp-focus-target");
+    assert.ok(sftpTarget);
+    sftpTarget.focus();
+    await pressCtrlF(sftpTarget);
+
+    const filterInput = window.document.querySelector<HTMLInputElement>(
+      '[data-section="terminal-sftp-filter-bar"] input',
+    );
+    assert.ok(filterInput, "Ctrl+F should open the SFTP filter bar");
+    assert.equal(window.document.activeElement, filterInput, "Ctrl+F should focus the SFTP filter input");
+
+    sftpTarget.focus();
+    await pressCtrlF(sftpTarget);
+    assert.equal(window.document.activeElement, filterInput, "repeated Ctrl+F should refocus the open filter");
+
+    const closeButton = window.document.querySelector<HTMLButtonElement>(
+      '[data-section="terminal-sftp-filter-bar"] button',
+    );
+    assert.ok(closeButton);
+    await act(async () => closeButton.click());
+    assert.equal(
+      window.document.querySelector('[data-section="terminal-sftp-filter-bar"]'),
+      null,
+      "the filter should close normally",
+    );
+
+    sftpTarget.focus();
+    await pressCtrlF(sftpTarget);
+    const reopenedFilterInput = window.document.querySelector<HTMLInputElement>(
+      '[data-section="terminal-sftp-filter-bar"] input',
+    );
+    assert.ok(reopenedFilterInput, "Ctrl+F should reopen the filter after it was closed");
+    assert.equal(
+      window.document.activeElement,
+      reopenedFilterInput,
+      "a reopened filter should receive focus",
+    );
+
+    const reopenedCloseButton = window.document.querySelector<HTMLButtonElement>(
+      '[data-section="terminal-sftp-filter-bar"] button',
+    );
+    assert.ok(reopenedCloseButton);
+    await act(async () => reopenedCloseButton.click());
+
+    await act(async () => root.render(React.createElement(Harness, { isActive: false })));
+    const terminalTarget = window.document.getElementById("terminal-focus");
+    assert.ok(terminalTarget);
+    terminalTarget.focus();
+    await pressCtrlF(terminalTarget);
+    assert.equal(
+      window.document.querySelector('[data-section="terminal-sftp-filter-bar"]'),
+      null,
+      "an inactive SFTP pane must not consume terminal Ctrl+F",
+    );
+  } finally {
+    await act(async () => root.unmount());
+    dom.window.close();
+    for (const [key, descriptor] of previousGlobals) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+      else delete (globalThis as Record<string, unknown>)[key];
+    }
+  }
+});

--- a/components/sftp/SftpFilterShortcut.interaction.test.ts
+++ b/components/sftp/SftpFilterShortcut.interaction.test.ts
@@ -7,7 +7,7 @@ import type { HotkeyScheme, KeyBinding } from "../../domain/models/keyBindings.t
 
 test("Ctrl+F opens and refocuses the active SFTP pane filter without handling inactive panes", async () => {
   const dom = new JSDOM(
-    '<!doctype html><html><body><div id="root"></div><button id="terminal-focus" class="xterm">terminal</button></body></html>',
+    '<!doctype html><html><body><div id="root"></div><textarea id="terminal-focus" class="xterm"></textarea></body></html>',
     { pretendToBeVisual: true, url: "http://localhost" },
   );
   const window = dom.window;
@@ -107,7 +107,11 @@ test("Ctrl+F opens and refocuses the active SFTP pane filter without handling in
       React.Fragment,
       null,
       React.createElement("button", { id: "sftp-focus-target" }, "files"),
-      React.createElement("input", { id: "sftp-path-input", defaultValue: "/home/app" }),
+      React.createElement(
+        "div",
+        { "data-section": "terminal-sftp-path" },
+        React.createElement("input", { id: "sftp-path-input", defaultValue: "/home/app" }),
+      ),
       React.createElement(SftpPaneToolbar, {
         t: (key: string) => ({
           "sftp.filter": "Filter files",
@@ -239,7 +243,6 @@ test("Ctrl+F opens and refocuses the active SFTP pane filter without handling in
     assert.ok(reopenedCloseButton);
     await act(async () => reopenedCloseButton.click());
 
-    await act(async () => root.render(React.createElement(Harness, { isActive: false })));
     const terminalTarget = window.document.getElementById("terminal-focus");
     assert.ok(terminalTarget);
     terminalTarget.focus();
@@ -250,6 +253,19 @@ test("Ctrl+F opens and refocuses the active SFTP pane filter without handling in
       terminalReceiverSawPrevented = event.defaultPrevented;
     };
     window.addEventListener("keydown", terminalReceiver);
+    const staleActiveSftpEvent = await pressCtrlF(terminalTarget);
+    assert.equal(staleActiveSftpEvent.defaultPrevented, false, "SFTP must not intercept terminal input");
+    assert.equal(
+      window.document.querySelector('[data-section="terminal-sftp-filter-bar"]'),
+      null,
+      "terminal input must not reopen the SFTP filter when SFTP focus state is stale",
+    );
+    assert.equal(terminalReceiverCalled, true, "terminal listeners should receive Ctrl+F with stale SFTP focus");
+    assert.equal(terminalReceiverSawPrevented, false);
+    terminalReceiverCalled = false;
+    terminalReceiverSawPrevented = false;
+
+    await act(async () => root.render(React.createElement(Harness, { isActive: false })));
     const inactiveSftpEvent = await pressCtrlF(terminalTarget);
     window.removeEventListener("keydown", terminalReceiver);
     assert.equal(

--- a/components/sftp/SftpFilterShortcut.interaction.test.ts
+++ b/components/sftp/SftpFilterShortcut.interaction.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { JSDOM } from "jsdom";
 
 import type { SftpStateApi } from "../../application/state/useSftpState.ts";
+import type { HotkeyScheme, KeyBinding } from "../../domain/models/keyBindings.ts";
 
 test("Ctrl+F opens and refocuses the active SFTP pane filter without handling inactive panes", async () => {
   const dom = new JSDOM(
@@ -78,7 +79,15 @@ test("Ctrl+F opens and refocuses the active SFTP pane filter without handling in
     transferMutationToken: 0,
   };
 
-  const Harness = ({ isActive }: { isActive: boolean }) => {
+  const Harness = ({
+    isActive,
+    hotkeyScheme = "pc",
+    keyBindings = DEFAULT_KEY_BINDINGS,
+  }: {
+    isActive: boolean;
+    hotkeyScheme?: HotkeyScheme;
+    keyBindings?: KeyBinding[];
+  }) => {
     const [showFilterBar, setShowFilterBar] = React.useState(false);
     const filterInputRef = React.useRef<HTMLInputElement>(null);
     const sftpRef = React.useRef({
@@ -87,8 +96,8 @@ test("Ctrl+F opens and refocuses the active SFTP pane filter without handling in
     } as unknown as SftpStateApi);
 
     useSftpKeyboardShortcuts({
-      keyBindings: DEFAULT_KEY_BINDINGS,
-      hotkeyScheme: "pc",
+      keyBindings,
+      hotkeyScheme,
       sftpRef,
       dialogActionScopeId: "test-scope",
       isActive,
@@ -153,18 +162,27 @@ test("Ctrl+F opens and refocuses the active SFTP pane filter without handling in
   const rootNode = window.document.getElementById("root");
   assert.ok(rootNode);
   const root = createRoot(rootNode);
-  const pressCtrlF = async (target: Element) => {
+  const pressShortcut = async (
+    target: Element,
+    init: Pick<KeyboardEventInit, "key" | "code" | "ctrlKey" | "metaKey">,
+  ) => {
+    const event = new window.KeyboardEvent("keydown", {
+      ...init,
+      bubbles: true,
+      cancelable: true,
+    });
     await act(async () => {
-      target.dispatchEvent(new window.KeyboardEvent("keydown", {
-        key: "f",
-        code: "KeyF",
-        ctrlKey: true,
-        bubbles: true,
-        cancelable: true,
-      }));
+      target.dispatchEvent(event);
       await new Promise((resolve) => window.setTimeout(resolve, 0));
     });
+    return event;
   };
+  const pressCtrlF = (target: Element) => pressShortcut(target, {
+    key: "f",
+    code: "KeyF",
+    ctrlKey: true,
+    metaKey: false,
+  });
 
   try {
     sftpFocusStore.setFocusedSide("left");
@@ -173,7 +191,8 @@ test("Ctrl+F opens and refocuses the active SFTP pane filter without handling in
     const sftpTarget = window.document.getElementById("sftp-focus-target");
     assert.ok(sftpTarget);
     sftpTarget.focus();
-    await pressCtrlF(sftpTarget);
+    const activeSftpEvent = await pressCtrlF(sftpTarget);
+    assert.equal(activeSftpEvent.defaultPrevented, true, "active SFTP should consume its search shortcut");
 
     const filterInput = window.document.querySelector<HTMLInputElement>(
       '[data-section="terminal-sftp-filter-bar"] input',
@@ -218,12 +237,65 @@ test("Ctrl+F opens and refocuses the active SFTP pane filter without handling in
     const terminalTarget = window.document.getElementById("terminal-focus");
     assert.ok(terminalTarget);
     terminalTarget.focus();
-    await pressCtrlF(terminalTarget);
+    let terminalReceiverCalled = false;
+    let terminalReceiverSawPrevented = false;
+    const terminalReceiver = (event: KeyboardEvent) => {
+      terminalReceiverCalled = true;
+      terminalReceiverSawPrevented = event.defaultPrevented;
+    };
+    window.addEventListener("keydown", terminalReceiver);
+    const inactiveSftpEvent = await pressCtrlF(terminalTarget);
+    window.removeEventListener("keydown", terminalReceiver);
     assert.equal(
       window.document.querySelector('[data-section="terminal-sftp-filter-bar"]'),
       null,
       "an inactive SFTP pane must not consume terminal Ctrl+F",
     );
+    assert.equal(inactiveSftpEvent.defaultPrevented, false, "inactive SFTP must not prevent terminal Ctrl+F");
+    assert.equal(terminalReceiverCalled, true, "terminal listeners should still receive Ctrl+F");
+    assert.equal(terminalReceiverSawPrevented, false, "terminal listeners should receive an unhandled Ctrl+F");
+
+    const customKeyBindings = DEFAULT_KEY_BINDINGS.map((binding) => (
+      binding.action === "searchTerminal" ? { ...binding, pc: "Ctrl + G" } : binding
+    ));
+    await act(async () => root.render(React.createElement(Harness, {
+      isActive: true,
+      keyBindings: customKeyBindings,
+    })));
+    sftpTarget.focus();
+    assert.equal((await pressCtrlF(sftpTarget)).defaultPrevented, false);
+    assert.equal(window.document.querySelector('[data-section="terminal-sftp-filter-bar"]'), null);
+    assert.equal((await pressShortcut(sftpTarget, {
+      key: "g",
+      code: "KeyG",
+      ctrlKey: true,
+      metaKey: false,
+    })).defaultPrevented, true, "the configured PC search shortcut should open the filter");
+    assert.ok(window.document.querySelector('[data-section="terminal-sftp-filter-bar"]'));
+
+    await act(async () => root.render(React.createElement(Harness, {
+      isActive: true,
+      hotkeyScheme: "disabled",
+    })));
+    const disabledCloseButton = window.document.querySelector<HTMLButtonElement>(
+      '[data-section="terminal-sftp-filter-bar"] button',
+    );
+    assert.ok(disabledCloseButton);
+    await act(async () => disabledCloseButton.click());
+    assert.equal((await pressCtrlF(sftpTarget)).defaultPrevented, false);
+    assert.equal(window.document.querySelector('[data-section="terminal-sftp-filter-bar"]'), null);
+
+    await act(async () => root.render(React.createElement(Harness, {
+      isActive: true,
+      hotkeyScheme: "mac",
+    })));
+    assert.equal((await pressShortcut(sftpTarget, {
+      key: "f",
+      code: "KeyF",
+      ctrlKey: false,
+      metaKey: true,
+    })).defaultPrevented, true, "the configured Mac search shortcut should open the filter");
+    assert.ok(window.document.querySelector('[data-section="terminal-sftp-filter-bar"]'));
   } finally {
     await act(async () => root.unmount());
     dom.window.close();

--- a/components/sftp/SftpFilterShortcut.interaction.test.ts
+++ b/components/sftp/SftpFilterShortcut.interaction.test.ts
@@ -107,6 +107,7 @@ test("Ctrl+F opens and refocuses the active SFTP pane filter without handling in
       React.Fragment,
       null,
       React.createElement("button", { id: "sftp-focus-target" }, "files"),
+      React.createElement("input", { id: "sftp-path-input", defaultValue: "/home/app" }),
       React.createElement(SftpPaneToolbar, {
         t: (key: string) => ({
           "sftp.filter": "Filter files",
@@ -200,6 +201,9 @@ test("Ctrl+F opens and refocuses the active SFTP pane filter without handling in
     assert.ok(filterInput, "Ctrl+F should open the SFTP filter bar");
     assert.equal(window.document.activeElement, filterInput, "Ctrl+F should focus the SFTP filter input");
 
+    assert.equal((await pressCtrlF(filterInput)).defaultPrevented, true);
+    assert.equal(window.document.activeElement, filterInput, "Ctrl+F in the filter should keep it focused");
+
     sftpTarget.focus();
     await pressCtrlF(sftpTarget);
     assert.equal(window.document.activeElement, filterInput, "repeated Ctrl+F should refocus the open filter");
@@ -215,8 +219,10 @@ test("Ctrl+F opens and refocuses the active SFTP pane filter without handling in
       "the filter should close normally",
     );
 
-    sftpTarget.focus();
-    await pressCtrlF(sftpTarget);
+    const pathInput = window.document.getElementById("sftp-path-input");
+    assert.ok(pathInput);
+    pathInput.focus();
+    assert.equal((await pressCtrlF(pathInput)).defaultPrevented, true);
     const reopenedFilterInput = window.document.querySelector<HTMLInputElement>(
       '[data-section="terminal-sftp-filter-bar"] input',
     );

--- a/components/sftp/SftpPaneToolbar.tsx
+++ b/components/sftp/SftpPaneToolbar.tsx
@@ -24,6 +24,7 @@ import {
   shouldCommitImeControlledChange,
 } from "../../domain/imeControlledInput";
 import { toast } from "../ui/toast";
+import { sftpFilterFocusStore } from "../../application/state/sftp/sftpFilterFocusStore";
 
 export const SFTP_TOOLBAR_ITEM_IDS = [
   "bookmark",
@@ -408,6 +409,11 @@ export const SftpPaneToolbar: React.FC<SftpPaneToolbarProps> = React.memo(({
       setFilterDraft(pane.filter);
     }
   }, [showFilterBar, pane.filter]);
+
+  useEffect(() => sftpFilterFocusStore.subscribe(pane.id, () => {
+    setShowFilterBar(true);
+    window.setTimeout(() => filterInputRef.current?.focus(), 0);
+  }), [filterInputRef, pane.id, setShowFilterBar]);
 
   const commitFilterValue = useCallback((value: string) => {
     // Committing/clearing finalizes any IME session, so drop the guard here. This

--- a/components/sftp/hooks/useSftpKeyboardShortcuts.ts
+++ b/components/sftp/hooks/useSftpKeyboardShortcuts.ts
@@ -16,6 +16,7 @@ import { sftpDialogActionStore } from "../../../application/state/sftp/sftpDialo
 import { sftpTreeSelectionStore } from "../../../application/state/sftp/sftpTreeSelectionStore";
 import { sftpListOrderStore } from "./useSftpListOrderStore";
 import { sftpPaneViewModeStore } from "../../../application/state/sftp/sftpPaneViewModeStore";
+import { sftpFilterFocusStore } from "../../../application/state/sftp/sftpFilterFocusStore";
 import { keepOnlyPaneSelections } from "./selectionScope";
 import type { SftpStateApi } from "../../../application/state/useSftpState";
 import type { UploadEndpointPin } from "../../../application/state/sftp/uploadTargetPin";
@@ -556,6 +557,21 @@ export const useSftpKeyboardShortcuts = ({
       // firing while interacting with unrelated dialogs (e.g. settings, confirm).
       if (hasOpenDialog()) {
         return;
+      }
+
+      if (hotkeyScheme !== "disabled") {
+        const isMac = hotkeyScheme === "mac";
+        const searchBinding = keyBindings.find((binding) => binding.action === "searchTerminal");
+        const searchKey = searchBinding ? (isMac ? searchBinding.mac : searchBinding.pc) : null;
+        if (searchKey && matchesKeyBinding(e, searchKey, isMac)) {
+          const { pane } = getFocusedPane();
+          if (!pane?.connection) return;
+
+          e.preventDefault();
+          e.stopPropagation();
+          sftpFilterFocusStore.request(pane.id);
+          return;
+        }
       }
 
       // ── Printable keys: select the first visible name with this prefix ──

--- a/components/sftp/hooks/useSftpKeyboardShortcuts.ts
+++ b/components/sftp/hooks/useSftpKeyboardShortcuts.ts
@@ -555,6 +555,14 @@ export const useSftpKeyboardShortcuts = ({
         return;
       }
 
+      const isEditableTarget = isEditableShortcutTarget(target);
+      const isSftpSearchTarget = Boolean(target.closest?.(
+        '[data-section="terminal-sftp-path"], [data-section="terminal-sftp-filter-bar"]',
+      ));
+      if (isEditableTarget && !isSftpSearchTarget) {
+        return;
+      }
+
       if (hotkeyScheme !== "disabled") {
         const isMac = hotkeyScheme === "mac";
         const searchBinding = keyBindings.find((binding) => binding.action === "searchTerminal");
@@ -570,8 +578,8 @@ export const useSftpKeyboardShortcuts = ({
         }
       }
 
-      // Skip the remaining SFTP shortcuts when focus is on an input element.
-      if (isEditableShortcutTarget(target)) {
+      // Path/filter inputs may handle search above, but no other SFTP shortcut.
+      if (isEditableTarget) {
         return;
       }
 

--- a/components/sftp/hooks/useSftpKeyboardShortcuts.ts
+++ b/components/sftp/hooks/useSftpKeyboardShortcuts.ts
@@ -547,11 +547,7 @@ export const useSftpKeyboardShortcuts = ({
       // even if the user has disabled global/custom hotkeys.
       if (!isActive) return;
 
-      // Skip if focus is on an input element
       const target = e.target as HTMLElement;
-      if (isEditableShortcutTarget(target)) {
-        return;
-      }
 
       // Skip when a dialog or overlay is open to prevent SFTP shortcuts from
       // firing while interacting with unrelated dialogs (e.g. settings, confirm).
@@ -572,6 +568,11 @@ export const useSftpKeyboardShortcuts = ({
           sftpFilterFocusStore.request(pane.id);
           return;
         }
+      }
+
+      // Skip the remaining SFTP shortcuts when focus is on an input element.
+      if (isEditableShortcutTarget(target)) {
+        return;
       }
 
       // ── Printable keys: select the first visible name with this prefix ──


### PR DESCRIPTION
## Summary

Make the configured terminal search shortcut open and focus the file-name filter when SFTP is active. This also refocuses an already-open filter and leaves terminal Ctrl+F unchanged when SFTP is inactive.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Fixes #3090

## Changes Made

- Route the existing configured search shortcut to the focused, connected SFTP pane.
- Open and focus that pane's file-name filter, including repeated use and use after closing it.
- Add an interaction regression test covering active SFTP, repeat/close/reopen behavior, and inactive SFTP so terminal search is not intercepted.

## Screenshots / Demo

Opened a local SFTP view in the app and verified the filter can open, receive focus, close, and reopen. The shortcut behavior and terminal isolation are covered by the interaction test.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Targeted SFTP and global-shortcut tests: 33 passed. The new regression test also passed three consecutive runs. `npm run build` passed. The full test command was attempted but could not complete in this fresh worktree because its Electron install artifact was unavailable; the affected tests were run directly and passed.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
