### PR TITLE
fix(terminal): refresh history suggestions as input changes

### DIFF
--- a/components/terminal/autocomplete/completionEngine.ts
+++ b/components/terminal/autocomplete/completionEngine.ts
@@ -50,6 +50,8 @@ export interface CompletionSuggestion {
   score: number;
   /** For history entries: execution frequency */
   frequency?: number;
+  /** Matching rule used by recent history surfaced during path completion. */
+  historyMatch?: "path-argument";
   /** For path suggestions: file type */
   fileType?: "file" | "directory" | "symlink";
   /** For snippet suggestions: the source snippet (used by the accept path). */
@@ -330,6 +332,7 @@ export async function getCompletions(
         source: "history",
         score: 720 - index,
         frequency: entry.frequency,
+        historyMatch: "path-argument",
       } satisfies CompletionSuggestion;
       suggestions.push(suggestion);
       seenSuggestionTexts.add(suggestion.text);

--- a/components/terminal/autocomplete/completionEngine.ts
+++ b/components/terminal/autocomplete/completionEngine.ts
@@ -373,8 +373,16 @@ export async function getCompletions(
     seenSuggestionTexts.add(suggestion.text);
   }
 
-  // 3. Fuzzy history fallback (if prefix match yields few results)
-  if (!preferPathSuggestions && suggestions.length < 3 && input.length >= 2) {
+  // 3. Fuzzy history fallback while typing the command name. Once arguments
+  // are present, history completion is prefix-only: fuzzy matching the whole
+  // line can borrow characters from later paths and keep an incompatible
+  // middle argument visible (issue #3088).
+  if (
+    ctx.wordIndex === 0 &&
+    !preferPathSuggestions &&
+    suggestions.length < 3 &&
+    input.length >= 2
+  ) {
     const fuzzyMatches = fuzzyQueryHistory(input, {
       ...historyOpts,
       limit: 5,

--- a/components/terminal/autocomplete/terminalAutocompleteInput.ts
+++ b/components/terminal/autocomplete/terminalAutocompleteInput.ts
@@ -13,6 +13,7 @@ interface TerminalAutocompleteInputContext {
   lastAcceptedCommandRef: MutableRefObject<string | null>;
   typedInputBufferRef: MutableRefObject<string>;
   typedBufferReliableRef: MutableRefObject<boolean>;
+  previewBaselineRef: MutableRefObject<string>;
   previewActiveRef: MutableRefObject<boolean>;
   termRef: RefObject<XTerm | null>;
   hostIdRef: MutableRefObject<string>;
@@ -20,6 +21,7 @@ interface TerminalAutocompleteInputContext {
   ghostAddonRef: MutableRefObject<GhostTextAddon | null>;
   debounceTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>;
   clearState: () => void;
+  syncPopupToInput: (input: string | null) => void;
   fetchSuggestions: () => void | Promise<void>;
 }
 
@@ -34,6 +36,7 @@ export function handleTerminalAutocompleteInput(
     lastAcceptedCommandRef,
     typedInputBufferRef,
     typedBufferReliableRef,
+    previewBaselineRef,
     previewActiveRef,
     termRef,
     hostIdRef,
@@ -41,6 +44,7 @@ export function handleTerminalAutocompleteInput(
     ghostAddonRef,
     debounceTimerRef,
     clearState,
+    syncPopupToInput,
     fetchSuggestions,
   } = context;
   if (!settingsRef.current.enabled) {
@@ -207,6 +211,23 @@ export function handleTerminalAutocompleteInput(
   // text. Drop preview-active so Escape dismisses the popup without
   // reverting these edits back to the stale baseline (#1005).
   previewActiveRef.current = false;
+  if (typedBufferReliableRef.current) {
+    previewBaselineRef.current = typedInputBufferRef.current;
+  }
+
+  // The popup must follow the edited line immediately, before the debounced
+  // provider refresh runs. Reconcile stale history rows against the current
+  // input; an unreliable append-only buffer cannot validate any old row.
+  if (settingsRef.current.showPopupMenu) {
+    const currentInput = typedBufferReliableRef.current
+      ? typedInputBufferRef.current
+      : null;
+    syncPopupToInput(
+      currentInput !== null && currentInput.length >= settingsRef.current.minChars
+        ? currentInput
+        : null,
+    );
+  }
 
   // Re-align any visible ghost text to the freshly-updated buffer
   // immediately. Without this the ghost keeps the tail it captured at

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -132,6 +132,55 @@ export interface AutocompleteState {
   subDirFocusLevel: number;
 }
 
+function isSubsequence(query: string, target: string): boolean {
+  let queryIndex = 0;
+  for (let targetIndex = 0; targetIndex < target.length && queryIndex < query.length; targetIndex++) {
+    if (target[targetIndex] === query[queryIndex]) queryIndex++;
+  }
+  return queryIndex === query.length;
+}
+
+/**
+ * Remove history rows that no longer match the edited input while a debounced
+ * provider refresh is pending. Other sources keep their provider-specific
+ * matching semantics (snippet search, plugin replacement, etc.).
+ */
+export function reconcileAutocompletePopupState(
+  prev: AutocompleteState,
+  input: string | null,
+): AutocompleteState {
+  if (!prev.popupVisible || prev.suggestions.length === 0) return prev;
+  if (input === null) return { ...EMPTY_STATE };
+
+  const normalizedInput = input.toLowerCase();
+  const allowFuzzyHistory = parseCommandLine(input).wordIndex === 0;
+  const suggestions = prev.suggestions.filter((suggestion) => {
+    if (suggestion.source !== "history") return true;
+    const text = suggestion.text.toLowerCase();
+    if (text.length <= normalizedInput.length) return false;
+    return text.startsWith(normalizedInput)
+      || (allowFuzzyHistory && isSubsequence(normalizedInput, text));
+  });
+
+  if (suggestions.length === 0) return { ...EMPTY_STATE };
+  if (
+    prev.selectedIndex === -1
+    && prev.subDirFocusLevel === -1
+    && prev.subDirPanels.length === 0
+    && areSuggestionsEqual(prev.suggestions, suggestions)
+  ) {
+    return prev;
+  }
+
+  return {
+    ...prev,
+    suggestions,
+    selectedIndex: -1,
+    subDirPanels: [],
+    subDirFocusLevel: -1,
+  };
+}
+
 type HostCompletionProviderOptions = Parameters<typeof getCompletions>[1] & {
   /** Host-owned prompt identity used to gate third-party Provider access. */
   promptText: string;
@@ -410,6 +459,20 @@ export function useTerminalAutocomplete(
     setState((prev) =>
       prev.popupVisible || prev.suggestions.length > 0 ? { ...EMPTY_STATE } : prev,
     );
+  }, []);
+
+  /**
+   * Reconcile the visible popup with the newly edited input synchronously.
+   * The full provider refresh remains debounced, but rows from the previous
+   * query must not remain actionable while that refresh is pending.
+   */
+  const syncPopupToInput = useCallback((input: string | null) => {
+    completionAbortRef.current?.abort();
+    completionAbortRef.current = null;
+    fetchVersionRef.current++;
+    subDirFetchVersionRef.current++;
+
+    setState((prev) => reconcileAutocompletePopupState(prev, input));
   }, []);
 
   const repositionPopup = useCallback(() => {
@@ -1122,6 +1185,7 @@ export function useTerminalAutocomplete(
         lastAcceptedCommandRef,
         typedInputBufferRef,
         typedBufferReliableRef,
+        previewBaselineRef,
         previewActiveRef,
         termRef,
         hostIdRef,
@@ -1129,10 +1193,11 @@ export function useTerminalAutocomplete(
         ghostAddonRef,
         debounceTimerRef,
         clearState,
+        syncPopupToInput,
         fetchSuggestions,
       });
     },
-    [fetchSuggestions, termRef, clearState],
+    [fetchSuggestions, termRef, clearState, syncPopupToInput],
   );
 
   /**

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -158,7 +158,6 @@ export function reconcileAutocompletePopupState(
   const suggestions = prev.suggestions.filter((suggestion) => {
     if (suggestion.source !== "history") return true;
     const text = suggestion.text.toLowerCase();
-    if (text.length <= normalizedInput.length) return false;
     if (suggestion.historyMatch === "path-argument") {
       const suggestionContext = parseCommandLine(suggestion.text);
       const currentArgument = inputContext.currentWord
@@ -174,6 +173,7 @@ export function reconcileAutocompletePopupState(
       return suggestionContext.commandName.toLowerCase() === inputContext.commandName.toLowerCase()
         && suggestionArgument.startsWith(currentArgument);
     }
+    if (text.length <= normalizedInput.length) return false;
     return text.startsWith(normalizedInput)
       || (allowFuzzyHistory && isSubsequence(normalizedInput, text));
   });

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -153,7 +153,7 @@ export function reconcileAutocompletePopupState(
   if (input === null) return { ...EMPTY_STATE };
 
   const normalizedInput = input.toLowerCase();
-  const allowFuzzyHistory = parseCommandLine(input).wordIndex === 0;
+  const allowFuzzyHistory = input.length >= 2 && parseCommandLine(input).wordIndex === 0;
   const suggestions = prev.suggestions.filter((suggestion) => {
     if (suggestion.source !== "history") return true;
     const text = suggestion.text.toLowerCase();

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -153,11 +153,27 @@ export function reconcileAutocompletePopupState(
   if (input === null) return { ...EMPTY_STATE };
 
   const normalizedInput = input.toLowerCase();
-  const allowFuzzyHistory = input.length >= 2 && parseCommandLine(input).wordIndex === 0;
+  const inputContext = parseCommandLine(input);
+  const allowFuzzyHistory = input.length >= 2 && inputContext.wordIndex === 0;
   const suggestions = prev.suggestions.filter((suggestion) => {
     if (suggestion.source !== "history") return true;
     const text = suggestion.text.toLowerCase();
     if (text.length <= normalizedInput.length) return false;
+    if (suggestion.historyMatch === "path-argument") {
+      const suggestionContext = parseCommandLine(suggestion.text);
+      const currentArgument = inputContext.currentWord
+        .replace(/^['"]/, "")
+        .replace(/['"]$/, "")
+        .replace(/\\ /g, " ")
+        .toLowerCase();
+      const suggestionArgument = suggestionContext.currentWord
+        .replace(/^['"]/, "")
+        .replace(/['"]$/, "")
+        .replace(/\\ /g, " ")
+        .toLowerCase();
+      return suggestionContext.commandName.toLowerCase() === inputContext.commandName.toLowerCase()
+        && suggestionArgument.startsWith(currentArgument);
+    }
     return text.startsWith(normalizedInput)
       || (allowFuzzyHistory && isSubsequence(normalizedInput, text));
   });

--- a/components/terminal/completionEngine.test.ts
+++ b/components/terminal/completionEngine.test.ts
@@ -149,6 +149,23 @@ test("getCompletions prioritizes spec-driven path suggestions over history", asy
   assert.equal(completions[historyIndex]?.historyMatch, "path-argument");
 });
 
+test("path completion marks a matching history replacement even when its full line is shorter", async () => {
+  const historyCommand = "story package.json";
+  const input = "story open --number p";
+  recordCommand(historyCommand, "host-1");
+
+  const completions = await getCompletions(input, {
+    hostId: "host-1",
+    protocol: "local",
+    cwd: "/repo",
+  });
+  const history = completions.find((entry) => entry.text === historyCommand);
+
+  assert.ok(history);
+  assert.ok(history.text.length < input.length);
+  assert.equal(history.historyMatch, "path-argument");
+});
+
 test("getCompletions does not treat generator-only spec args as path contexts", async () => {
   recordCommand("story pick package-choice", "host-1");
 

--- a/components/terminal/completionEngine.test.ts
+++ b/components/terminal/completionEngine.test.ts
@@ -146,6 +146,7 @@ test("getCompletions prioritizes spec-driven path suggestions over history", asy
     entry.source === "history" && entry.text === "story open package-lock.json"
   );
   assert.ok(historyIndex > 0);
+  assert.equal(completions[historyIndex]?.historyMatch, "path-argument");
 });
 
 test("getCompletions does not treat generator-only spec args as path contexts", async () => {

--- a/components/terminal/completionEngine.test.ts
+++ b/components/terminal/completionEngine.test.ts
@@ -163,6 +163,50 @@ test("getCompletions does not treat generator-only spec args as path contexts", 
   assert.equal(completions.some((entry) => entry.source === "path"), false);
 });
 
+test("history suggestions stop when an edited argument no longer matches the command prefix", async () => {
+  const historyCommand = "python3.14 -m robot -d /home/wx0043/Desktop/suite9";
+  recordCommand(historyCommand, "host-1");
+
+  const matching = await getCompletions("python3.14 -m r", {
+    hostId: "host-1",
+    historyScope: "host",
+    protocol: "ssh",
+    sessionId: "session-1",
+  });
+  assert.equal(
+    matching.some((entry) => entry.source === "history" && entry.text === historyCommand),
+    true,
+  );
+
+  const changedArgument = await getCompletions("python3.14 -m p", {
+    hostId: "host-1",
+    historyScope: "host",
+    protocol: "ssh",
+    sessionId: "session-1",
+  });
+  assert.equal(
+    changedArgument.some((entry) => entry.source === "history" && entry.text === historyCommand),
+    false,
+  );
+});
+
+test("single-token history queries retain fuzzy command-name matching", async () => {
+  const historyCommand = "docker compose up";
+  recordCommand(historyCommand, "host-1");
+
+  const completions = await getCompletions("dcu", {
+    hostId: "host-1",
+    historyScope: "host",
+    protocol: "ssh",
+    sessionId: "session-1",
+  });
+
+  assert.equal(
+    completions.some((entry) => entry.source === "history" && entry.text === historyCommand),
+    true,
+  );
+});
+
 test("removeCommandHistoryEntry removes only the matching host's autocomplete record", async () => {
   recordCommand("bad-command --flag", "host-1");
   recordCommand("bad-command --flag", "host-2");

--- a/components/terminal/terminalAutocompleteInput.test.ts
+++ b/components/terminal/terminalAutocompleteInput.test.ts
@@ -149,6 +149,17 @@ test("rapid command-name input keeps a valid fuzzy history row", () => {
   }
 });
 
+test("deleting below the fuzzy-history threshold removes a non-prefix row", () => {
+  const state = popupState([historySuggestion("docker compose up")], -1);
+
+  const fuzzyMatch = reconcileAutocompletePopupState(state, "oc");
+  assert.equal(fuzzyMatch.suggestions.length, 1);
+
+  const singleCharacter = reconcileAutocompletePopupState(fuzzyMatch, "o");
+  assert.deepEqual(singleCharacter.suggestions, []);
+  assert.equal(singleCharacter.popupVisible, false);
+});
+
 test("provider-specific non-history rows remain until their debounced refresh", () => {
   const snippet: CompletionSuggestion = {
     text: "deploy production",

--- a/components/terminal/terminalAutocompleteInput.test.ts
+++ b/components/terminal/terminalAutocompleteInput.test.ts
@@ -160,6 +160,20 @@ test("deleting below the fuzzy-history threshold removes a non-prefix row", () =
   assert.equal(singleCharacter.popupVisible, false);
 });
 
+test("path history follows the current argument instead of the whole line", () => {
+  const suggestion: CompletionSuggestion = {
+    ...historySuggestion("cat --number package.json"),
+    historyMatch: "path-argument",
+  };
+
+  const matching = reconcileAutocompletePopupState(popupState([suggestion], -1), "cat pack");
+  assert.deepEqual(matching.suggestions, [suggestion]);
+
+  const changedArgument = reconcileAutocompletePopupState(matching, "cat src");
+  assert.deepEqual(changedArgument.suggestions, []);
+  assert.equal(changedArgument.popupVisible, false);
+});
+
 test("provider-specific non-history rows remain until their debounced refresh", () => {
   const snippet: CompletionSuggestion = {
     text: "deploy production",

--- a/components/terminal/terminalAutocompleteInput.test.ts
+++ b/components/terminal/terminalAutocompleteInput.test.ts
@@ -162,11 +162,14 @@ test("deleting below the fuzzy-history threshold removes a non-prefix row", () =
 
 test("path history follows the current argument instead of the whole line", () => {
   const suggestion: CompletionSuggestion = {
-    ...historySuggestion("cat --number package.json"),
+    ...historySuggestion("cat package.json"),
     historyMatch: "path-argument",
   };
 
-  const matching = reconcileAutocompletePopupState(popupState([suggestion], -1), "cat pack");
+  const matching = reconcileAutocompletePopupState(
+    popupState([suggestion], -1),
+    "cat --number pack",
+  );
   assert.deepEqual(matching.suggestions, [suggestion]);
 
   const changedArgument = reconcileAutocompletePopupState(matching, "cat src");

--- a/components/terminal/terminalAutocompleteInput.test.ts
+++ b/components/terminal/terminalAutocompleteInput.test.ts
@@ -1,0 +1,177 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { AutocompleteSettings } from "./autocomplete/useTerminalAutocomplete.ts";
+import type { AutocompleteState } from "./autocomplete/useTerminalAutocomplete.ts";
+import type { CompletionSuggestion } from "./autocomplete/completionEngine.ts";
+
+const { handleTerminalAutocompleteInput } = await import(
+  "./autocomplete/terminalAutocompleteInput.ts"
+);
+const { reconcileAutocompletePopupState } = await import(
+  "./autocomplete/useTerminalAutocomplete.ts"
+);
+
+const ref = <T>(current: T) => ({ current });
+
+function createContext(input: string) {
+  const syncInputs: Array<string | null> = [];
+  let clearCount = 0;
+  let fetchCount = 0;
+  const settings: AutocompleteSettings = {
+    enabled: true,
+    showGhostText: false,
+    showPopupMenu: true,
+    livePreview: true,
+    allowLineReplacement: true,
+    debounceMs: 10_000,
+    minChars: 1,
+    maxSuggestions: 50,
+    fastTypingThresholdMs: 40,
+    shiftEnterNewlineEnabled: true,
+    historyScope: "host",
+  };
+  const context = {
+    settingsRef: ref(settings),
+    lastKeystrokeRef: ref(Date.now()),
+    suppressNextEnterRecordRef: ref(false),
+    lastAcceptedCommandRef: ref<string | null>(null),
+    typedInputBufferRef: ref(input),
+    typedBufferReliableRef: ref(true),
+    previewBaselineRef: ref(input),
+    previewActiveRef: ref(false),
+    termRef: ref(null),
+    hostIdRef: ref("host-1"),
+    hostOsRef: ref<"linux" | "windows" | "macos">("linux"),
+    ghostAddonRef: ref(null),
+    debounceTimerRef: ref<ReturnType<typeof setTimeout> | null>(null),
+    clearState: () => { clearCount++; },
+    syncPopupToInput: (nextInput: string | null) => { syncInputs.push(nextInput); },
+    fetchSuggestions: () => { fetchCount++; },
+  };
+  return {
+    context,
+    syncInputs,
+    getClearCount: () => clearCount,
+    getFetchCount: () => fetchCount,
+    cleanup: () => {
+      if (context.debounceTimerRef.current) clearTimeout(context.debounceTimerRef.current);
+    },
+  };
+}
+
+test("rapid edits reconcile the popup before the debounced refresh", () => {
+  const harness = createContext("python3.14 -m r");
+  try {
+    handleTerminalAutocompleteInput("\x7f", harness.context);
+    handleTerminalAutocompleteInput("p", harness.context);
+
+    assert.deepEqual(harness.syncInputs, ["python3.14 -m ", "python3.14 -m p"]);
+    assert.equal(harness.getFetchCount(), 0);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test("cursor movement clears the popup and marks the typed buffer unreliable", () => {
+  const harness = createContext("python3.14 -m r");
+  try {
+    handleTerminalAutocompleteInput("\x1b[D", harness.context);
+
+    assert.equal(harness.context.typedBufferReliableRef.current, false);
+    assert.equal(harness.getClearCount(), 1);
+    assert.deepEqual(harness.syncInputs, []);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test("deleting below the minimum input length clears visible popup rows", () => {
+  const harness = createContext("r");
+  try {
+    handleTerminalAutocompleteInput("\x7f", harness.context);
+
+    assert.deepEqual(harness.syncInputs, [null]);
+    assert.equal(harness.getFetchCount(), 0);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+const historySuggestion = (text: string): CompletionSuggestion => ({
+  text,
+  displayText: text,
+  source: "history",
+  score: 1000,
+});
+
+const popupState = (
+  suggestions: CompletionSuggestion[],
+  selectedIndex = 0,
+): AutocompleteState => ({
+  suggestions,
+  selectedIndex,
+  popupVisible: true,
+  popupAnchorViewport: { left: 0, top: 0, bottom: 0 },
+  expandUpward: false,
+  subDirPanels: [{
+    entries: [{ name: "old", type: "directory" }],
+    selectedIndex: 0,
+    dirPath: "/tmp/",
+  }],
+  subDirFocusLevel: 0,
+});
+
+test("edited arguments immediately discard incompatible history rows and selection", () => {
+  const next = reconcileAutocompletePopupState(
+    popupState([
+      historySuggestion("python3.14 -m robot -d /home/user/Desktop/suite9"),
+      historySuggestion("python3.14 -m pip list --outdated"),
+    ]),
+    "python3.14 -m p",
+  );
+
+  assert.deepEqual(next.suggestions.map((suggestion) => suggestion.text), [
+    "python3.14 -m pip list --outdated",
+  ]);
+  assert.equal(next.selectedIndex, -1);
+  assert.deepEqual(next.subDirPanels, []);
+  assert.equal(next.subDirFocusLevel, -1);
+});
+
+test("rapid command-name input keeps a valid fuzzy history row", () => {
+  const suggestion = historySuggestion("docker compose up");
+  let state = popupState([suggestion], -1);
+
+  for (const input of ["d", "dc", "dcu"]) {
+    state = reconcileAutocompletePopupState(state, input);
+    assert.deepEqual(state.suggestions, [suggestion]);
+  }
+});
+
+test("provider-specific non-history rows remain until their debounced refresh", () => {
+  const snippet: CompletionSuggestion = {
+    text: "deploy production",
+    displayText: "deploy production",
+    source: "snippet",
+    score: 2000,
+  };
+
+  const next = reconcileAutocompletePopupState(popupState([snippet]), "dp");
+  assert.deepEqual(next.suggestions, [snippet]);
+  assert.equal(next.selectedIndex, -1);
+});
+
+test("editing a live preview advances the restore baseline", () => {
+  const harness = createContext("docker compose up");
+  harness.context.previewBaselineRef.current = "dc";
+  harness.context.previewActiveRef.current = true;
+  try {
+    handleTerminalAutocompleteInput(" ", harness.context);
+
+    assert.equal(harness.context.previewActiveRef.current, false);
+    assert.equal(harness.context.previewBaselineRef.current, "docker compose up ");
+  } finally {
+    harness.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Keep the terminal autocomplete popup aligned with the command currently being edited. History rows that no longer match an edited argument are removed immediately instead of remaining selectable until a delayed refresh.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3088

## Changes Made

- Restrict fuzzy history fallback to command-name input, where fuzzy matching is intended.
- Reconcile visible history rows immediately after typing and deletion while preserving non-history matching behavior.
- Reset stale popup selection state and keep live-preview edits as the new restore point.
- Add regression coverage for rapid edits, deletion, cursor movement, changed arguments, fuzzy command names, and edited live previews.

## Screenshots / Demo

Validated in a real local terminal session using the reporter's command pattern. Matching `python3.14 -m robot ...` history appeared for `python3.14 -m r`; after changing the argument to `python3.14 -m p`, those rows disappeared within the same input update and stayed absent after the delayed refresh. Deletion, cursor movement, and switching between two terminal sessions were also checked.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Targeted autocomplete tests pass (29/29). The full suite reaches two failures in unrelated, unchanged NotesManager and electron-builder retry tests; both reproduce when rerun and none of their files differ from `main`. The latest GitHub run passes the full test suite, performance checks, and build in a clean environment.

Capability tool specs are not affected by this change.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

No documentation update is needed for this behavior-only bug fix.
