### PR TITLE
fix(ssh): preserve shared sessions after PID probe timeout

### DIFF
--- a/electron/bridges/sshInteractiveShells.cjs
+++ b/electron/bridges/sshInteractiveShells.cjs
@@ -4,6 +4,7 @@ const { executeBoundedSshCommand } = require("./boundedSshExec.cjs");
 const { isSshChannelOpenRateLimitedError } = require("./boundedSshChannelOpen.cjs");
 
 const SCAN_COMPLETE_MARKER = "__NETCATTY_SHELL_SCAN_COMPLETE__";
+const discoveryDisabledConnections = new WeakSet();
 
 function buildInteractiveShellPidCommand(quoteShellArg) {
   const script = `SELF=$$
@@ -49,6 +50,15 @@ async function listInteractiveShellPids(conn, options = {}) {
   if (!conn || typeof conn.exec !== "function" || typeof options.quoteShellArg !== "function") {
     return { available: false, pids: [], ages: {} };
   }
+  const invalidateOnOpenTimeout = options.invalidateOnOpenTimeout === true;
+  if (!invalidateOnOpenTimeout && discoveryDisabledConnections.has(conn)) {
+    return { available: false, disabled: true, pids: [], ages: {} };
+  }
+  // Shell PID discovery only improves cwd recovery for reused shells. A slow
+  // auxiliary exec open must not invalidate the physical transport and close
+  // every interactive shell sharing it. After one open timeout, stop probing
+  // this connection so ssh2 cannot retain another uncancellable callback on
+  // every later reuse.
   try {
     const result = await executeBoundedSshCommand(
       conn,
@@ -59,7 +69,7 @@ async function listInteractiveShellPids(conn, options = {}) {
         maxOutputBytes: 1024 * 1024,
         setTimeoutFn: options.setTimeoutFn,
         clearTimeoutFn: options.clearTimeoutFn,
-        invalidateOnOpenTimeout: options.invalidateOnOpenTimeout,
+        invalidateOnOpenTimeout,
       },
     );
     const lines = result.stdout.split(/\r?\n/);
@@ -78,10 +88,14 @@ async function listInteractiveShellPids(conn, options = {}) {
     }
     return { available, pids, ages };
   } catch (error) {
+    const openTimedOut = error?.code === "SSH_EXEC_OPEN_TIMEOUT";
+    if (openTimedOut && !invalidateOnOpenTimeout) {
+      discoveryDisabledConnections.add(conn);
+    }
     return {
       available: false,
       rateLimited: isSshChannelOpenRateLimitedError(error),
-      openTimedOut: error?.code === "SSH_EXEC_OPEN_TIMEOUT",
+      openTimedOut,
       pids: [],
       ages: {},
     };

--- a/electron/bridges/sshInteractiveShells.test.cjs
+++ b/electron/bridges/sshInteractiveShells.test.cjs
@@ -1,0 +1,77 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+
+const { listInteractiveShellPids } = require("./sshInteractiveShells.cjs");
+const {
+  borrowTransport,
+  createTransport,
+  resetSshTransportRegistryForTests,
+} = require("./sshConnectionPool.cjs");
+
+test("shell PID discovery timeout preserves active shared shell channels", async (t) => {
+  resetSshTransportRegistryForTests({ defaultIdleTtlMs: 0 });
+  t.after(() => resetSshTransportRegistryForTests({ defaultIdleTtlMs: 0 }));
+
+  const conn = new EventEmitter();
+  conn._sock = { destroyed: false };
+  conn.endCalls = 0;
+  conn.destroyCalls = 0;
+  conn.execCalls = 0;
+  conn.exec = (_command, callback) => {
+    conn.execCalls += 1;
+    conn.pendingExecCallback = callback;
+  };
+  conn.end = () => {
+    conn.endCalls += 1;
+    conn.emit("close");
+  };
+  conn.destroy = () => {
+    conn.destroyCalls += 1;
+    conn._sock.destroyed = true;
+  };
+
+  const transport = createTransport({
+    conn,
+    endpoint: { hostname: "shared.example", username: "alice" },
+  });
+  const firstShell = { stream: new EventEmitter() };
+  const secondShell = { stream: new EventEmitter() };
+  let closedShellChannels = 0;
+  firstShell.stream.once("close", () => { closedShellChannels += 1; });
+  secondShell.stream.once("close", () => { closedShellChannels += 1; });
+  conn.once("close", () => {
+    firstShell.stream.emit("close");
+    secondShell.stream.emit("close");
+  });
+  borrowTransport(transport, {
+    kind: "shell",
+    holder: firstShell,
+    meta: { activeShellChannel: true },
+  });
+  borrowTransport(transport, {
+    kind: "shell",
+    holder: secondShell,
+    meta: { activeShellChannel: true },
+  });
+
+  const result = await listInteractiveShellPids(conn, {
+    quoteShellArg: (value) => JSON.stringify(value),
+    openingTimeoutMs: 2,
+  });
+  const skippedRetry = await listInteractiveShellPids(conn, {
+    quoteShellArg: (value) => JSON.stringify(value),
+    openingTimeoutMs: 2,
+  });
+
+  assert.equal(result.openTimedOut, true);
+  assert.equal(skippedRetry.disabled, true);
+  assert.equal(conn.execCalls, 1, "a timed-out connection must not accumulate discovery callbacks");
+  assert.equal(conn.endCalls, 0, "best-effort discovery must not end the shared connection");
+  assert.equal(conn.destroyCalls, 0, "best-effort discovery must not destroy the shared connection");
+  assert.equal(closedShellChannels, 0, "a discovery timeout must not close sibling shells");
+  assert.equal(transport.state, "live");
+  assert.equal(transport.leases.size, 2);
+});


### PR DESCRIPTION
## Summary

The August 20 logs on #1181 show one authenticated SSH connection carrying several shell channels, followed by a client-initiated disconnect that closes every shell at once.

The reused-shell setup runs a best-effort shell PID discovery command. If that auxiliary exec channel did not open within 1.5 seconds, it inherited the generic timeout behavior and called `end()` / `destroy()` on the physical SSH client. On a shared transport, that turns a non-essential discovery timeout into the exact reported disconnect sequence.

This change keeps the shared SSH connection alive when shell PID discovery times out. It also disables later PID discovery attempts on that connection so repeated shell reuse cannot accumulate uncancellable ssh2 callbacks.

This PR addresses the log-backed shared-transport failure in the latest #1181 comment. The older June reports do not contain enough client-side detail to prove that every historical disconnect had the same cause.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #1181

## Changes Made

- Treat shell PID discovery as best-effort instead of invalidating a live shared SSH transport on open timeout.
- Stop retrying PID discovery on the same connection after the first open timeout.
- Add a regression test with two active shell channels that reproduces the previous transport teardown and verifies both shells remain connected.

## Screenshots / Demo

N/A — main-process SSH lifecycle behavior with no UI change.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — 10,549 passed, 0 failed, 11 environment-gated skips
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`) — not applicable
- [x] No new console errors or warnings, if this affects app behavior

Targeted shared-transport suite: 137 passed, 0 failed.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation — no user-facing behavior or configuration change
- [x] I have not introduced any breaking changes (or I have described them above)
