### PR TITLE
fix(vault): clear host drag state when the source node is unmounted mid-drag

### DIFF
--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -1881,6 +1881,12 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
                           draggingPackagePathRef.current = pkg.path;
                           setDraggingPackagePath(pkg.path);
                           lastPreviewReorderRef.current = null;
+                          const sourceNode = e.currentTarget as HTMLElement;
+                          const handleNativeDragEnd = () => {
+                            sourceNode.removeEventListener('dragend', handleNativeDragEnd);
+                            resetSnippetDragState();
+                          };
+                          sourceNode.addEventListener('dragend', handleNativeDragEnd);
                         }}
                         onDragOver={(e) => e.preventDefault()}
                         onDrop={(e) => {
@@ -1965,6 +1971,12 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
                           draggingSnippetIdRef.current = snippet.id;
                           setDraggingSnippetId(snippet.id);
                           lastPreviewReorderRef.current = null;
+                          const sourceNode = e.currentTarget as HTMLElement;
+                          const handleNativeDragEnd = () => {
+                            sourceNode.removeEventListener('dragend', handleNativeDragEnd);
+                            resetSnippetDragState();
+                          };
+                          sourceNode.addEventListener('dragend', handleNativeDragEnd);
                         }}
                         onClick={() => {
                           if (isMultiSelectMode) {

--- a/components/vault/VaultHostListSection.tsx
+++ b/components/vault/VaultHostListSection.tsx
@@ -280,6 +280,13 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
   }, [hostClickBehavior, isMultiSelectMode]);
 
 
+  const resetHostDragState = React.useCallback(() => {
+    draggingHostIdRef.current = null;
+    setDraggingHostId(null);
+    lastPreviewReorderRef.current = null;
+    setDragOverDropTarget(null);
+  }, [setDragOverDropTarget]);
+
   const handleHostDragStart = React.useCallback((e: React.DragEvent, hostId: string) => {
     // copyMove: vault reorder uses move; focus-sidebar append uses copy.
     e.dataTransfer.effectAllowed = "copyMove";
@@ -287,14 +294,19 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
     draggingHostIdRef.current = hostId;
     setDraggingHostId(hostId);
     lastPreviewReorderRef.current = null;
-  }, []);
 
-  const resetHostDragState = React.useCallback(() => {
-    draggingHostIdRef.current = null;
-    setDraggingHostId(null);
-    lastPreviewReorderRef.current = null;
-    setDragOverDropTarget(null);
-  }, [setDragOverDropTarget]);
+    // Grid preview reorder can move the card into another virtual row, and rows
+    // are separate React parents, so the source node gets unmounted mid-drag.
+    // A detached node no longer bubbles dragend up to the container handler, so
+    // bind the cleanup natively on the node itself - it still receives dragend.
+    const sourceNode = e.currentTarget as HTMLElement;
+    const handleNativeDragEnd = () => {
+      sourceNode.removeEventListener("dragend", handleNativeDragEnd);
+      clearVaultDropIndicator();
+      resetHostDragState();
+    };
+    sourceNode.addEventListener("dragend", handleNativeDragEnd);
+  }, [resetHostDragState]);
 
   const renderHostEditButton = (host: any, compact = false) => (
     <Button
@@ -398,6 +410,10 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
             const draggedHostId = e.dataTransfer.getData("host-id");
             const draggedGroupPath = e.dataTransfer.getData("group-path");
             const target = (e.target as Element | null)?.closest("[data-host-id], [data-group-path]");
+            // Always clear the dimmed drag styling: in grid view the live preview
+            // reorder can leave the dragged card itself under the cursor, which
+            // used to fall through every branch below without resetting.
+            if (draggedHostId) resetHostDragState();
             if (!(target instanceof HTMLElement)) return;
             const targetHostId = target.getAttribute("data-host-id");
             const targetGroupPath = target.getAttribute("data-group-path");

--- a/components/vault/vaultReorderDrag.ts
+++ b/components/vault/vaultReorderDrag.ts
@@ -260,7 +260,10 @@ export const useVaultItemReorder = ({
     if (disabled) return;
     const target = (event.target as Element | null)?.closest(selector);
     clearVaultDropIndicator();
-    if (!(target instanceof HTMLElement)) return;
+    if (!(target instanceof HTMLElement)) {
+      reset();
+      return;
+    }
 
     const sourceId = draggingIdRef.current || event.dataTransfer.getData(dragType);
     const targetId = target.getAttribute(targetAttribute);
@@ -300,6 +303,7 @@ export const useVaultItemReorder = ({
     dragType,
     onReorder,
     prepareGridLayoutAnimation,
+    reset,
     selector,
     targetAttribute,
     viewMode,
@@ -317,8 +321,19 @@ export const useVaultItemReorder = ({
       event.dataTransfer.setData(dragType, id);
       draggingIdRef.current = id;
       setDraggingId(id);
+
+      // The live grid preview can re-parent the dragged node (virtualised rows,
+      // section changes), and React then unmounts it. dragend still fires on the
+      // detached node but no longer reaches handleDragEndCapture on the
+      // container, so bind the cleanup natively on the source node itself.
+      const sourceNode = event.currentTarget as HTMLElement;
+      const handleNativeDragEnd = () => {
+        sourceNode.removeEventListener("dragend", handleNativeDragEnd);
+        reset();
+      };
+      sourceNode.addEventListener("dragend", handleNativeDragEnd);
     },
-  }), [disabled, dragType, draggingId, targetAttribute, viewMode]);
+  }), [disabled, dragType, draggingId, reset, targetAttribute, viewMode]);
 
   return {
     handleDragOverCapture,


### PR DESCRIPTION
## Summary

Dragging a host card in the Vault grid view leaves it stuck at `opacity-45` — the dimmed "being dragged" styling — after the drop. It only recovers when the user starts another drag on the same card.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Root cause

The grid preview reorder runs from `onDragOverCapture` in `VaultHostListSection`, so the dragged card can move into a different virtual row while the drag is still active. In `VirtualizedHostCollection` every row is rendered as its own `<div key={virtualRow.key}>` parent, so crossing a row boundary is not a DOM move — React unmounts the card from the old row and mounts a new one in the new row.

The browser dispatches `dragend` **at** the original source node. Once that node is detached, the event no longer bubbles up to the container's `onDragEndCapture`, so `draggingHostId` is never cleared and the freshly mounted card for the same host id keeps rendering with `draggingHostId === host.id && "opacity-45"`.

That also explains the "drag it again and it recovers" behaviour: a short drag that stays inside one row never unmounts the node, so its `dragend` bubbles normally and resets the state.

`onDropCapture` did not save it either. After a grid preview reorder the card under the cursor is the dragged card itself, so `draggedHostId === targetHostId` and the drop fell through every branch without resetting.

## Changes Made

- `VaultHostListSection`: bind a native `dragend` listener on the source node at `dragstart`. Because the event is dispatched at that node, the listener still fires after React unmounts it. The listener removes itself and clears the drop indicator plus the drag state.
- `VaultHostListSection`: always reset drag state in `onDropCapture` when a host was being dragged, covering the `draggedHostId === targetHostId` case described above.
- `useVaultItemReorder` (`vaultReorderDrag.ts`): same native-listener fix, and reset when a drop lands outside any reorder target. This hook backs the keychain, port forwarding, proxy profile and known-hosts lists, which can hit the same problem whenever a live preview reorder re-parents the dragged node.
- `SnippetsManager`: same fix for the snippet and package cards, which also run a live preview reorder.

## Screenshots / Demo

Reproduction before the fix: Vault → grid view → drag a host card far enough that it crosses into another row → drop. The card stays dimmed indefinitely.

## Testing

- [x] Tested locally — verified in a packaged Windows x64 portable build rather than via `npm run dev`; cards return to full opacity after a cross-row drop
- [x] Linting passes (`npm run lint`) — clean, no errors or warnings
- [x] Tests pass (`npm test`) — see note below
- [ ] Generated capability tool specs — not applicable, the capability catalog is unchanged
- [x] No new console errors or warnings

I also reproduced the mechanism in isolation with jsdom, driving `useVaultItemReorder` directly: after `dragstart` the item carries `data-vault-reorder-dragging="true"`; removing the node from the document and dispatching `dragend` on the detached node now clears the attribute, where previously nothing reset it.

Note on `npm test`: on my Windows machine the renderer suite reports 4463 tests, 4403 pass, 56 fail. I re-ran the identical suite against unmodified `main` and got a byte-identical failure list, so this PR introduces no regressions. Those 56 are environmental: tests that shell out to `/bin/sh`, tests that read source files through `new URL(..., import.meta.url).pathname` (which percent-encodes non-ASCII path segments on Windows), and CRLF-vs-LF assertions.

`components/vault/*.test.ts` and `*.test.tsx` pass in full, including the existing `vaultReorderDrag` drop-handler tests.
