### PR TITLE
fix(ssh): reject identity files without private key material

### DIFF
--- a/electron/bridges/privateKeyNormalizer.cjs
+++ b/electron/bridges/privateKeyNormalizer.cjs
@@ -44,6 +44,14 @@ class UnsupportedPrivateKeyError extends Error {
   }
 }
 
+class InvalidPrivateKeyError extends Error {
+  constructor(message) {
+    super(message || "SSH key does not contain private key material");
+    this.name = "InvalidPrivateKeyError";
+    this.code = "ERR_PRIVATE_KEY_INVALID";
+  }
+}
+
 // Matches a private-key PEM block by its BEGIN/END markers (which survive even
 // when the surrounding newlines are lost), capturing the label and raw body.
 const PEM_BLOCK_RE =
@@ -77,6 +85,22 @@ function repairMalformedPem(text) {
 }
 
 /**
+ * Return true when an ssh2 parser result contains private key material.
+ * parseKey() may return either one key object or an array of key objects.
+ */
+function hasPrivateKeyMaterial(parsed) {
+  const candidates = Array.isArray(parsed) ? parsed : [parsed];
+  return candidates.some((candidate) => {
+    if (!candidate || candidate instanceof Error) return false;
+    if (typeof candidate.isPrivateKey === "function" && candidate.isPrivateKey() === true) {
+      return true;
+    }
+    return typeof candidate.getPrivatePEM === "function"
+      && candidate.getPrivatePEM() !== null;
+  });
+}
+
+/**
  * Normalize a private key into a form ssh2 can parse.
  *
  * @param {string} privateKey - PEM private key contents.
@@ -90,9 +114,11 @@ function normalizePrivateKeyForSsh2(privateKey, passphrase) {
     return { privateKey, passphrase, converted: false };
   }
 
-  // If ssh2 already understands the key, leave it exactly as-is.
+  // If ssh2 already understands the key and it contains private material,
+  // leave it exactly as-is. A public key can also parse successfully, but it
+  // must never be treated as a value for Client.connect({ privateKey }).
   const parsed = sshUtils.parseKey(privateKey, passphrase);
-  if (parsed && !(parsed instanceof Error)) {
+  if (hasPrivateKeyMaterial(parsed)) {
     return { privateKey, passphrase, converted: false };
   }
 
@@ -102,7 +128,7 @@ function normalizePrivateKeyForSsh2(privateKey, passphrase) {
   const repaired = repairMalformedPem(privateKey);
   if (repaired && repaired !== privateKey) {
     const reparsed = sshUtils.parseKey(repaired, passphrase);
-    if (reparsed && !(reparsed instanceof Error)) {
+    if (hasPrivateKeyMaterial(reparsed)) {
       return { privateKey: repaired, passphrase, converted: true };
     }
   }
@@ -167,4 +193,6 @@ module.exports = {
   repairMalformedPem,
   PrivateKeyPassphraseError,
   UnsupportedPrivateKeyError,
+  InvalidPrivateKeyError,
+  hasPrivateKeyMaterial,
 };

--- a/electron/bridges/privateKeyNormalizer.test.cjs
+++ b/electron/bridges/privateKeyNormalizer.test.cjs
@@ -7,6 +7,7 @@ const {
   normalizePrivateKeyForSsh2,
   PrivateKeyPassphraseError,
   UnsupportedPrivateKeyError,
+  hasPrivateKeyMaterial,
 } = require("./privateKeyNormalizer.cjs");
 
 function genRsa(encoding) {
@@ -37,6 +38,22 @@ function parseOk(key) {
   const r = sshUtils.parseKey(key);
   return r && !(r instanceof Error) ? r : null;
 }
+
+test("checks private material on ssh2 parser objects and arrays", () => {
+  const privateKey = {
+    isPrivateKey: () => true,
+    getPrivatePEM: () => "private",
+  };
+  const publicKey = {
+    isPrivateKey: () => false,
+    getPrivatePEM: () => null,
+  };
+
+  assert.equal(hasPrivateKeyMaterial(privateKey), true);
+  assert.equal(hasPrivateKeyMaterial(publicKey), false);
+  assert.equal(hasPrivateKeyMaterial([publicKey, privateKey]), true);
+  assert.equal(hasPrivateKeyMaterial([publicKey]), false);
+});
 
 test("converts unencrypted RSA PKCS#8 into an ssh2-parseable key", () => {
   const result = normalizePrivateKeyForSsh2(rsaPkcs8());

--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -16,6 +16,8 @@ const {
   normalizePrivateKeyForSsh2,
   repairMalformedPem,
   PrivateKeyPassphraseError,
+  InvalidPrivateKeyError,
+  hasPrivateKeyMaterial,
 } = require("./privateKeyNormalizer.cjs");
 
 // Default SSH key names in priority order
@@ -40,6 +42,18 @@ class PassphraseCancelledError extends Error {
 
 function isPassphraseCancelledError(err) {
   return Boolean(err?.cancelled || err?.code === "ERR_PASSPHRASE_CANCELLED");
+}
+
+function createInvalidPrivateKeyError(keyPath, keyName) {
+  if (keyPath) {
+    return new InvalidPrivateKeyError(
+      `Selected SSH identity file does not contain a private key: ${keyPath}`,
+    );
+  }
+  const label = keyName ? ` "${keyName}"` : "";
+  return new InvalidPrivateKeyError(
+    `Selected SSH key${label} does not contain a private key`,
+  );
 }
 
 async function readFileNoFollow(filePath) {
@@ -168,7 +182,7 @@ function resolveKeyForAuth(privateKey, passphrase) {
     throw err;
   }
   const parsed = sshUtils.parseKey(normalized.privateKey, normalized.passphrase);
-  if (parsed && !(parsed instanceof Error)) {
+  if (hasPrivateKeyMaterial(parsed)) {
     return { privateKey: normalized.privateKey, passphrase: normalized.passphrase };
   }
   return null;
@@ -193,7 +207,8 @@ async function preparePrivateKeyForAuth({
 
   if (!isKeyEncrypted(privateKey)) {
     const resolved = resolveKeyForAuth(privateKey, undefined);
-    return { privateKey: resolved ? resolved.privateKey : privateKey, keyPath, keyName };
+    if (!resolved) throw createInvalidPrivateKeyError(keyPath, keyName);
+    return { privateKey: resolved.privateKey, keyPath, keyName };
   }
 
   const promptKeyPath = keyPath || `SSH key for ${keyName || hostname || "connection"}`;
@@ -265,7 +280,8 @@ async function loadIdentityFileForAuth({
 
   if (!isKeyEncrypted(privateKey)) {
     const resolved = resolveKeyForAuth(privateKey, undefined);
-    return { privateKey: resolved ? resolved.privateKey : privateKey, keyPath: resolvedPath, keyName };
+    if (!resolved) throw createInvalidPrivateKeyError(resolvedPath, keyName);
+    return { privateKey: resolved.privateKey, keyPath: resolvedPath, keyName };
   }
 
   let passphraseInvalid = false;
@@ -334,6 +350,7 @@ async function loadFirstIdentityFileForAuth({
     return null;
   }
 
+  let lastInvalidPrivateKeyError = null;
   for (const keyPath of identityFilePaths) {
     try {
       const identityFile = await loadIdentityFileForAuth({
@@ -358,9 +375,13 @@ async function loadFirstIdentityFileForAuth({
         throw err;
       }
       onError?.(err, keyPath);
+      if (err?.code === "ERR_PRIVATE_KEY_INVALID") {
+        lastInvalidPrivateKeyError = err;
+      }
     }
   }
 
+  if (lastInvalidPrivateKeyError) throw lastInvalidPrivateKeyError;
   return null;
 }
 

--- a/electron/bridges/sshAuthHelper.identityFile.test.cjs
+++ b/electron/bridges/sshAuthHelper.identityFile.test.cjs
@@ -12,7 +12,7 @@ const {
 } = require("./sshAuthHelper.cjs");
 const passphraseHandler = require("./passphraseHandler.cjs");
 
-function createEncryptedKey(t) {
+function createKey(t, passphrase) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-identity-file-"));
   t.after(() => {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -24,7 +24,7 @@ function createEncryptedKey(t) {
     "-t",
     "ed25519",
     "-N",
-    "secret",
+    passphrase,
     "-f",
     keyPath,
     "-C",
@@ -39,6 +39,10 @@ function createEncryptedKey(t) {
   return keyPath;
 }
 
+function createEncryptedKey(t) {
+  return createKey(t, "secret");
+}
+
 function createSender() {
   const events = [];
   return {
@@ -51,6 +55,79 @@ function createSender() {
     },
   };
 }
+
+test("loadIdentityFileForAuth accepts an unencrypted Ed25519 private key", async (t) => {
+  const keyPath = createKey(t, "");
+  if (!keyPath) return;
+
+  const identityFile = await loadIdentityFileForAuth({
+    keyPath,
+    hostname: "example.test",
+  });
+
+  assert.equal(identityFile.keyPath, keyPath);
+  assert.match(identityFile.privateKey, /BEGIN OPENSSH PRIVATE KEY/);
+});
+
+test("loadIdentityFileForAuth rejects a public-only identity file", async (t) => {
+  const keyPath = createKey(t, "");
+  if (!keyPath) return;
+
+  const publicKeyPath = `${keyPath}.pub`;
+  const publicKey = fs.readFileSync(publicKeyPath, "utf8");
+
+  await assert.rejects(
+    () => loadIdentityFileForAuth({
+      keyPath: publicKeyPath,
+      hostname: "example.test",
+    }),
+    (err) => {
+      assert.equal(err.code, "ERR_PRIVATE_KEY_INVALID");
+      assert.ok(err.message.includes(publicKeyPath));
+      assert.equal(err.message.includes(publicKey.trim()), false);
+      return true;
+    },
+  );
+});
+
+test("preparePrivateKeyForAuth rejects a public-only inline key", async (t) => {
+  const keyPath = createKey(t, "");
+  if (!keyPath) return;
+
+  const publicKey = fs.readFileSync(`${keyPath}.pub`, "utf8");
+
+  await assert.rejects(
+    () => preparePrivateKeyForAuth({
+      privateKey: publicKey,
+      keyName: "public-only",
+      hostname: "example.test",
+    }),
+    (err) => {
+      assert.equal(err.code, "ERR_PRIVATE_KEY_INVALID");
+      assert.equal(err.message.includes(publicKey.trim()), false);
+      return true;
+    },
+  );
+});
+
+test("loadIdentityFileForAuth rejects malformed key content without a raw fallback", async (t) => {
+  const keyPath = createKey(t, "");
+  if (!keyPath) return;
+  fs.writeFileSync(keyPath, "not a private key");
+
+  await assert.rejects(
+    () => loadIdentityFileForAuth({
+      keyPath,
+      hostname: "example.test",
+    }),
+    (err) => {
+      assert.equal(err.code, "ERR_PRIVATE_KEY_INVALID");
+      assert.ok(err.message.includes(keyPath));
+      assert.equal(err.message.includes("not a private key"), false);
+      return true;
+    },
+  );
+});
 
 test("loadIdentityFileForAuth uses a valid saved passphrase without prompting", async (t) => {
   const keyPath = createEncryptedKey(t);


### PR DESCRIPTION
## Summary

Netcatty could allow SSH key material that parsed successfully but did not actually contain a private half to reach ssh2 as `privateKey`.

Some unencrypted-key paths also fell back to the raw file contents after Netcatty's own key resolution failed. ssh2 then aborted later with the opaque error:

`privateKey value does not contain a (valid) private key`

The local Windows `%USERPROFILE%\\.ssh\\id_ed25519` file passed both `ssh-keygen` private-key validation and ssh2 private-key parsing. This confirms the generic validation gap, but does not claim to reproduce the reporter's exact server/session setup.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue

Fixes #3109

## Changes Made

- Validate ssh2 parser results for actual private key material, including object and array results.
- Prevent raw unvalidated key contents from reaching authentication after resolution failure.
- Reject public-only and malformed identity inputs with an actionable error that includes the selected path but never key material.
- Preserve existing encrypted-key and passphrase behavior.

## Screenshots / Demo

Not applicable; this is an SSH authentication boundary fix.

## Testing

- [x] `node --test electron/bridges/privateKeyNormalizer.test.cjs electron/bridges/sshAuthHelper.identityFile.test.cjs`
- [x] Related SSH auth, PPK, PKCS#8, renderer auth-resolution, and terminal starter tests
- [x] `npm run lint`
- [ ] `npm test` — attempted, but the local environment could not complete the suite because native postinstall lacked Python and Electron binary download failed with `TypeError: fetch failed`; the changed-file focused tests pass.
- [x] Generated capability tool specs are not applicable.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
