### PR TITLE
fix(terminal): restore macOS Option block selection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,10 +72,12 @@ on:
       - "scripts/mosh-extra-resources.cjs"
       - "scripts/nodePtyConptyPatch.cjs"
       - "scripts/patch-xterm-webgl-atlas.cjs"
+      - "scripts/patch-xterm-macos-column-selection.cjs"
       - "scripts/rebuildPatchedNodePty.cjs"
       - "scripts/resolve-et-bin-release.cjs"
       - "scripts/resolve-mosh-bin-release.cjs"
       - "scripts/verify-linux-*.sh"
+      - "scripts/xterm-macos-column-selection.live.test.cjs"
       - "skills/**"
 
 # A newer run for the same main push or PR cancels older in-progress work.
@@ -242,6 +244,10 @@ jobs:
 
       - name: Install deps
         run: npm ci
+
+      - name: Test macOS Option column selection
+        if: matrix.name == 'macos'
+        run: npm run test:xterm-macos-selection
 
       - name: Compile ConPTY test helpers
         if: matrix.name == 'windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,6 @@ on:
       - "scripts/nodePtyConptyPatch.cjs"
       - "scripts/patch-xterm-macos-column-selection.cjs"
       - "scripts/patch-xterm-webgl-atlas.cjs"
-      - "scripts/patch-xterm-macos-column-selection.cjs"
       - "scripts/rebuildPatchedNodePty.cjs"
       - "scripts/resolve-et-bin-release.cjs"
       - "scripts/resolve-mosh-bin-release.cjs"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,11 +71,13 @@ on:
       - "scripts/linux/**"
       - "scripts/mosh-extra-resources.cjs"
       - "scripts/nodePtyConptyPatch.cjs"
+      - "scripts/patch-xterm-macos-column-selection.cjs"
       - "scripts/patch-xterm-webgl-atlas.cjs"
       - "scripts/rebuildPatchedNodePty.cjs"
       - "scripts/resolve-et-bin-release.cjs"
       - "scripts/resolve-mosh-bin-release.cjs"
       - "scripts/verify-linux-*.sh"
+      - "scripts/xterm-macos-column-selection.live.test.cjs"
       - "skills/**"
 
 # A newer run for the same main push or PR cancels older in-progress work.
@@ -242,6 +244,10 @@ jobs:
 
       - name: Install deps
         run: npm ci
+
+      - name: Test macOS Option column selection
+        if: matrix.name == 'macos'
+        run: npm run test:xterm-macos-selection
 
       - name: Compile ConPTY test helpers
         if: matrix.name == 'windows'

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "pack:linux": "npm run build && cross-env NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --linux --publish=never",
     "pack:linux-x64": "npm run build && cross-env npm_config_arch=x64 NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --linux --x64 --publish=never",
     "pack:linux-arm64": "npm run build && cross-env npm_config_arch=arm64 NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --linux --arm64 --publish=never",
-    "postinstall": "patch-package && electron-builder install-app-deps && node scripts/rebuildPatchedNodePty.cjs && node scripts/patch-xterm-webgl-atlas.cjs",
+    "postinstall": "patch-package && node scripts/patch-xterm-macos-column-selection.cjs && electron-builder install-app-deps && node scripts/rebuildPatchedNodePty.cjs && node scripts/patch-xterm-webgl-atlas.cjs",
     "rebuild": "electron-builder install-app-deps",
     "tool:cli": "node electron/cli/netcatty-tool-cli.cjs",
     "generate:capability-tools": "node scripts/generate-capability-tools.cjs",
@@ -65,6 +65,7 @@
     "test:ssh-mfa-models": "node --test electron/bridges/sshMfaModels.live.test.cjs",
     "test:ssh-mfa-models:live": "SSH_MFA_LIVE=1 node --test electron/bridges/sshMfaModels.live.test.cjs",
     "test:xterm-webgl-overflow": "electron scripts/xterm-webgl-atlas-overflow.live.test.cjs",
+    "test:xterm-macos-selection": "electron scripts/xterm-macos-column-selection.live.test.cjs",
     "test:xterm-keyword-highlight-performance": "electron scripts/xterm-keyword-highlight-performance.live.test.cjs",
     "test:xterm-keyword-highlight-throughput": "electron scripts/xterm-keyword-highlight-throughput.live.test.cjs"
   },

--- a/scripts/github-workflow-ci.test.cjs
+++ b/scripts/github-workflow-ci.test.cjs
@@ -78,6 +78,10 @@ test("PR validation runs once per commit and includes a production build", () =>
     testWorkflow,
     /- name: Test terminal keyword highlight performance\s*\n\s*env:\s*\n\s*NETCATTY_TERMINAL_PERF_SHOW_WINDOW: "1"\s*\n\s*# GitHub-hosted runners do not configure Electron's SUID sandbox helper\.\s*\n\s*run: xvfb-run -a \.\/node_modules\/\.bin\/electron --no-sandbox scripts\/xterm-keyword-highlight-performance\.live\.test\.cjs/,
   );
+  assert.match(
+    buildWorkflow,
+    /- name: Test macOS Option column selection\s*\n\s*if: matrix\.name == 'macos'\s*\n\s*run: npm run test:xterm-macos-selection/,
+  );
   assert.match(testWorkflow, /- name: Build\s*\n\s*run: npm run build/);
   assert.doesNotMatch(testWorkflow, /\n  mosh-windows-conpty:/);
 });
@@ -112,6 +116,8 @@ test("package validation avoids duplicate branch runs and scopes PR builds", () 
     "scripts/afterPackMacUuid.cjs",
     "scripts/beforePackCursorSdk.cjs",
     "scripts/nodePtyConptyPatch.cjs",
+    "scripts/patch-xterm-macos-column-selection.cjs",
+    "scripts/xterm-macos-column-selection.live.test.cjs",
     "scripts/linux/**",
     "skills/**",
   ]) {

--- a/scripts/patch-xterm-macos-column-selection.cjs
+++ b/scripts/patch-xterm-macos-column-selection.cjs
@@ -26,17 +26,20 @@ const PATCHES = [
   {
     file: "node_modules/@xterm/xterm/src/browser/services/SelectionService.ts",
     original: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionClickForcesSelection);",
-    replacement: "return event.altKey;",
+    replacement: "return event.altKey && true;",
+    preserveStatementLength: true,
   },
   {
     file: "node_modules/@xterm/xterm/lib/xterm.js.map",
     original: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionClickForcesSelection);",
-    replacement: "return event.altKey;",
+    replacement: "return event.altKey && true;",
+    preserveStatementLength: true,
   },
   {
     file: "node_modules/@xterm/xterm/lib/xterm.mjs.map",
     original: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionClickForcesSelection);",
-    replacement: "return event.altKey;",
+    replacement: "return event.altKey && true;",
+    preserveStatementLength: true,
   },
 ];
 
@@ -46,11 +49,24 @@ function sameLengthTrueExpression(length) {
   return `(!0${" ".repeat(length - 4)})`;
 }
 
+function sameLengthStatement(statement, length) {
+  if (!statement.endsWith(";") || statement.length > length) {
+    throw new Error("replacement statement cannot preserve the target length");
+  }
+  return `${statement.slice(0, -1)}${" ".repeat(length - statement.length)};`;
+}
+
+function replacementForPatch(patch) {
+  if (patch.preserveLength) return sameLengthTrueExpression(patch.original.length);
+  if (!patch.replacement) throw new Error(`missing replacement for ${patch.file}`);
+  if (patch.preserveStatementLength) {
+    return sameLengthStatement(patch.replacement, patch.original.length);
+  }
+  return patch.replacement;
+}
+
 function patchXtermSource(source, patch) {
-  const replacement = patch.preserveLength
-    ? sameLengthTrueExpression(patch.original.length)
-    : patch.replacement;
-  if (!replacement) throw new Error(`missing replacement for ${patch.file}`);
+  const replacement = replacementForPatch(patch);
 
   const originalCount = source.split(patch.original).length - 1;
   const patchedCount = source.split(replacement).length - 1;
@@ -106,5 +122,7 @@ module.exports = {
   PATCHES,
   patchInstalledXterm,
   patchXtermSource,
+  replacementForPatch,
+  sameLengthStatement,
   sameLengthTrueExpression,
 };

--- a/scripts/patch-xterm-macos-column-selection.cjs
+++ b/scripts/patch-xterm-macos-column-selection.cjs
@@ -6,6 +6,8 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const EXPECTED_XTERM_VERSION = "6.1.0-beta.292";
+const FORCE_SELECTION_OPTION = "macOptionClickForcesSelection";
+const META_OPTION = "macOptionIsMeta".padEnd(FORCE_SELECTION_OPTION.length, " ");
 
 // xterm normally treats macOptionClickForcesSelection and column selection as
 // mutually exclusive. Netcatty needs both when Option is not Meta: Option must
@@ -17,31 +19,31 @@ const PATCHES = [
   {
     file: "node_modules/@xterm/xterm/lib/xterm.js",
     original: "!(f.isMac&&this._optionsService.rawOptions.macOptionClickForcesSelection)",
-    replacement: "(!f.isMac||!this._optionsService.rawOptions.macOptionIsMeta)",
+    replacement: `!(f.isMac&&this._optionsService.rawOptions.${META_OPTION})`,
     preserveLength: true,
   },
   {
     file: "node_modules/@xterm/xterm/lib/xterm.mjs",
     original: "!(ie&&this._optionsService.rawOptions.macOptionClickForcesSelection)",
-    replacement: "(!ie||!this._optionsService.rawOptions.macOptionIsMeta)",
+    replacement: `!(ie&&this._optionsService.rawOptions.${META_OPTION})`,
     preserveLength: true,
   },
   {
     file: "node_modules/@xterm/xterm/src/browser/services/SelectionService.ts",
     original: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionClickForcesSelection);",
-    replacement: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionIsMeta);",
+    replacement: `return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.${META_OPTION});`,
     preserveStatementLength: true,
   },
   {
     file: "node_modules/@xterm/xterm/lib/xterm.js.map",
     original: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionClickForcesSelection);",
-    replacement: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionIsMeta);",
+    replacement: `return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.${META_OPTION});`,
     preserveStatementLength: true,
   },
   {
     file: "node_modules/@xterm/xterm/lib/xterm.mjs.map",
     original: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionClickForcesSelection);",
-    replacement: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionIsMeta);",
+    replacement: `return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.${META_OPTION});`,
     preserveStatementLength: true,
   },
 ];

--- a/scripts/patch-xterm-macos-column-selection.cjs
+++ b/scripts/patch-xterm-macos-column-selection.cjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/* global process, console */
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const EXPECTED_XTERM_VERSION = "6.1.0-beta.292";
+
+// xterm normally treats macOptionClickForcesSelection and column selection as
+// mutually exclusive. Netcatty needs both: Option must keep forcing local
+// selection inside mouse-aware programs, and that local selection must retain
+// the standard macOS rectangular shape. Patch the pinned bundles at install
+// time and fail closed if upstream changes the expected code shape.
+const PATCHES = [
+  {
+    file: "node_modules/@xterm/xterm/lib/xterm.js",
+    original: "!(f.isMac&&this._optionsService.rawOptions.macOptionClickForcesSelection)",
+    preserveLength: true,
+  },
+  {
+    file: "node_modules/@xterm/xterm/lib/xterm.mjs",
+    original: "!(ie&&this._optionsService.rawOptions.macOptionClickForcesSelection)",
+    preserveLength: true,
+  },
+  {
+    file: "node_modules/@xterm/xterm/src/browser/services/SelectionService.ts",
+    original: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionClickForcesSelection);",
+    replacement: "return event.altKey;",
+  },
+  {
+    file: "node_modules/@xterm/xterm/lib/xterm.js.map",
+    original: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionClickForcesSelection);",
+    replacement: "return event.altKey;",
+  },
+  {
+    file: "node_modules/@xterm/xterm/lib/xterm.mjs.map",
+    original: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionClickForcesSelection);",
+    replacement: "return event.altKey;",
+  },
+];
+
+function sameLengthTrueExpression(length) {
+  if (length < 4) throw new Error("replacement target is too short");
+  // Keep generated bundle offsets stable so the shipped source maps remain valid.
+  return `(!0${" ".repeat(length - 4)})`;
+}
+
+function patchXtermSource(source, patch) {
+  const replacement = patch.preserveLength
+    ? sameLengthTrueExpression(patch.original.length)
+    : patch.replacement;
+  if (!replacement) throw new Error(`missing replacement for ${patch.file}`);
+
+  const originalCount = source.split(patch.original).length - 1;
+  const patchedCount = source.split(replacement).length - 1;
+  if (originalCount === 1 && patchedCount === 0) {
+    return { source: source.replace(patch.original, replacement), changed: true };
+  }
+  if (originalCount === 0 && patchedCount === 1) {
+    return { source, changed: false };
+  }
+  throw new Error(
+    `${patch.file}: expected exactly one original or patched selection predicate ` +
+      `(original=${originalCount}, patched=${patchedCount})`,
+  );
+}
+
+function patchInstalledXterm(root = process.cwd()) {
+  const packageJsonPath = path.resolve(root, "node_modules/@xterm/xterm/package.json");
+  const version = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")).version;
+  if (version !== EXPECTED_XTERM_VERSION) {
+    throw new Error(
+      `unsupported @xterm/xterm version ${version}; expected ${EXPECTED_XTERM_VERSION}`,
+    );
+  }
+
+  let changed = 0;
+  for (const patch of PATCHES) {
+    const absolutePath = path.resolve(root, patch.file);
+    const source = fs.readFileSync(absolutePath, "utf8");
+    const result = patchXtermSource(source, patch);
+    if (result.changed) {
+      fs.writeFileSync(absolutePath, result.source);
+      changed++;
+    }
+  }
+  return { changed, checked: PATCHES.length, version };
+}
+
+if (require.main === module) {
+  try {
+    const result = patchInstalledXterm();
+    console.log(
+      `[patch-xterm-macos-column-selection] version=${result.version} ` +
+        `changed=${result.changed} checked=${result.checked}`,
+    );
+  } catch (error) {
+    console.error(`[patch-xterm-macos-column-selection] ERROR: ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  EXPECTED_XTERM_VERSION,
+  PATCHES,
+  patchInstalledXterm,
+  patchXtermSource,
+  sameLengthTrueExpression,
+};

--- a/scripts/patch-xterm-macos-column-selection.cjs
+++ b/scripts/patch-xterm-macos-column-selection.cjs
@@ -8,47 +8,50 @@ const path = require("node:path");
 const EXPECTED_XTERM_VERSION = "6.1.0-beta.292";
 
 // xterm normally treats macOptionClickForcesSelection and column selection as
-// mutually exclusive. Netcatty needs both: Option must keep forcing local
-// selection inside mouse-aware programs, and that local selection must retain
-// the standard macOS rectangular shape. Patch the pinned bundles at install
-// time and fail closed if upstream changes the expected code shape.
+// mutually exclusive. Netcatty needs both when Option is not Meta: Option must
+// keep forcing local selection inside mouse-aware programs, and that local
+// selection must retain the standard macOS rectangular shape. Patch the pinned
+// bundles at install time and fail closed if upstream changes the expected code
+// shape.
 const PATCHES = [
   {
     file: "node_modules/@xterm/xterm/lib/xterm.js",
     original: "!(f.isMac&&this._optionsService.rawOptions.macOptionClickForcesSelection)",
+    replacement: "(!f.isMac||!this._optionsService.rawOptions.macOptionIsMeta)",
     preserveLength: true,
   },
   {
     file: "node_modules/@xterm/xterm/lib/xterm.mjs",
     original: "!(ie&&this._optionsService.rawOptions.macOptionClickForcesSelection)",
+    replacement: "(!ie||!this._optionsService.rawOptions.macOptionIsMeta)",
     preserveLength: true,
   },
   {
     file: "node_modules/@xterm/xterm/src/browser/services/SelectionService.ts",
     original: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionClickForcesSelection);",
-    replacement: "return event.altKey;",
+    replacement: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionIsMeta);",
   },
   {
     file: "node_modules/@xterm/xterm/lib/xterm.js.map",
     original: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionClickForcesSelection);",
-    replacement: "return event.altKey;",
+    replacement: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionIsMeta);",
   },
   {
     file: "node_modules/@xterm/xterm/lib/xterm.mjs.map",
     original: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionClickForcesSelection);",
-    replacement: "return event.altKey;",
+    replacement: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionIsMeta);",
   },
 ];
 
-function sameLengthTrueExpression(length) {
-  if (length < 4) throw new Error("replacement target is too short");
+function sameLengthExpression(expression, length) {
+  if (expression.length > length) throw new Error("replacement expression is too long");
   // Keep generated bundle offsets stable so the shipped source maps remain valid.
-  return `(!0${" ".repeat(length - 4)})`;
+  return `${expression}${" ".repeat(length - expression.length)}`;
 }
 
 function patchXtermSource(source, patch) {
   const replacement = patch.preserveLength
-    ? sameLengthTrueExpression(patch.original.length)
+    ? sameLengthExpression(patch.replacement, patch.original.length)
     : patch.replacement;
   if (!replacement) throw new Error(`missing replacement for ${patch.file}`);
 
@@ -106,5 +109,5 @@ module.exports = {
   PATCHES,
   patchInstalledXterm,
   patchXtermSource,
-  sameLengthTrueExpression,
+  sameLengthExpression,
 };

--- a/scripts/patch-xterm-macos-column-selection.cjs
+++ b/scripts/patch-xterm-macos-column-selection.cjs
@@ -30,16 +30,19 @@ const PATCHES = [
     file: "node_modules/@xterm/xterm/src/browser/services/SelectionService.ts",
     original: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionClickForcesSelection);",
     replacement: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionIsMeta);",
+    preserveStatementLength: true,
   },
   {
     file: "node_modules/@xterm/xterm/lib/xterm.js.map",
     original: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionClickForcesSelection);",
     replacement: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionIsMeta);",
+    preserveStatementLength: true,
   },
   {
     file: "node_modules/@xterm/xterm/lib/xterm.mjs.map",
     original: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionClickForcesSelection);",
     replacement: "return event.altKey && !(Browser.isMac && this._optionsService.rawOptions.macOptionIsMeta);",
+    preserveStatementLength: true,
   },
 ];
 
@@ -49,11 +52,26 @@ function sameLengthExpression(expression, length) {
   return `${expression}${" ".repeat(length - expression.length)}`;
 }
 
+function sameLengthStatement(statement, length) {
+  if (!statement.endsWith(";") || statement.length > length) {
+    throw new Error("replacement statement cannot preserve the target length");
+  }
+  return `${statement.slice(0, -1)}${" ".repeat(length - statement.length)};`;
+}
+
+function replacementForPatch(patch) {
+  if (!patch.replacement) throw new Error(`missing replacement for ${patch.file}`);
+  if (patch.preserveLength) {
+    return sameLengthExpression(patch.replacement, patch.original.length);
+  }
+  if (patch.preserveStatementLength) {
+    return sameLengthStatement(patch.replacement, patch.original.length);
+  }
+  return patch.replacement;
+}
+
 function patchXtermSource(source, patch) {
-  const replacement = patch.preserveLength
-    ? sameLengthExpression(patch.replacement, patch.original.length)
-    : patch.replacement;
-  if (!replacement) throw new Error(`missing replacement for ${patch.file}`);
+  const replacement = replacementForPatch(patch);
 
   const originalCount = source.split(patch.original).length - 1;
   const patchedCount = source.split(replacement).length - 1;
@@ -67,6 +85,16 @@ function patchXtermSource(source, patch) {
     `${patch.file}: expected exactly one original or patched selection predicate ` +
       `(original=${originalCount}, patched=${patchedCount})`,
   );
+}
+
+/**
+ * @param {string} root
+ * @param {Pick<typeof fs, "rmSync">} fsImpl
+ */
+function invalidateViteCache(root = process.cwd(), fsImpl = fs) {
+  const cachePath = path.resolve(root, "node_modules/.vite");
+  fsImpl.rmSync(cachePath, { recursive: true, force: true });
+  return cachePath;
 }
 
 function patchInstalledXterm(root = process.cwd()) {
@@ -88,7 +116,8 @@ function patchInstalledXterm(root = process.cwd()) {
       changed++;
     }
   }
-  return { changed, checked: PATCHES.length, version };
+  const viteCachePath = invalidateViteCache(root);
+  return { changed, checked: PATCHES.length, version, viteCachePath };
 }
 
 if (require.main === module) {
@@ -96,7 +125,7 @@ if (require.main === module) {
     const result = patchInstalledXterm();
     console.log(
       `[patch-xterm-macos-column-selection] version=${result.version} ` +
-        `changed=${result.changed} checked=${result.checked}`,
+        `changed=${result.changed} checked=${result.checked} vite-cache=invalidated`,
     );
   } catch (error) {
     console.error(`[patch-xterm-macos-column-selection] ERROR: ${error.message}`);
@@ -107,7 +136,10 @@ if (require.main === module) {
 module.exports = {
   EXPECTED_XTERM_VERSION,
   PATCHES,
+  invalidateViteCache,
   patchInstalledXterm,
   patchXtermSource,
+  replacementForPatch,
   sameLengthExpression,
+  sameLengthStatement,
 };

--- a/scripts/patch-xterm-macos-column-selection.test.cjs
+++ b/scripts/patch-xterm-macos-column-selection.test.cjs
@@ -6,7 +6,7 @@ const test = require("node:test");
 const {
   PATCHES,
   patchXtermSource,
-  sameLengthTrueExpression,
+  sameLengthExpression,
 } = require("./patch-xterm-macos-column-selection.cjs");
 
 test("patches both distributed bundles without shifting source-map offsets", () => {
@@ -17,7 +17,7 @@ test("patches both distributed bundles without shifting source-map offsets", () 
     assert.equal(result.source.length, input.length);
     assert.equal(result.source.includes(patch.original), false);
     assert.equal(
-      result.source.includes(sameLengthTrueExpression(patch.original.length)),
+      result.source.includes(sameLengthExpression(patch.replacement, patch.original.length)),
       true,
     );
   }
@@ -34,7 +34,7 @@ test("patches readable xterm sources and source-map content", () => {
 test("is idempotent and fails closed on an unknown package shape", () => {
   for (const patch of PATCHES) {
     const replacement = patch.preserveLength
-      ? sameLengthTrueExpression(patch.original.length)
+      ? sameLengthExpression(patch.replacement, patch.original.length)
       : patch.replacement;
     assert.deepEqual(patchXtermSource(`before:${replacement}:after`, patch), {
       source: `before:${replacement}:after`,
@@ -45,4 +45,11 @@ test("is idempotent and fails closed on an unknown package shape", () => {
       /expected exactly one original or patched selection predicate/,
     );
   }
+});
+
+test("fails closed when a generated-bundle replacement would shift offsets", () => {
+  assert.throws(
+    () => sameLengthExpression("replacement is longer", 4),
+    /replacement expression is too long/,
+  );
 });

--- a/scripts/patch-xterm-macos-column-selection.test.cjs
+++ b/scripts/patch-xterm-macos-column-selection.test.cjs
@@ -1,0 +1,48 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  PATCHES,
+  patchXtermSource,
+  sameLengthTrueExpression,
+} = require("./patch-xterm-macos-column-selection.cjs");
+
+test("patches both distributed bundles without shifting source-map offsets", () => {
+  for (const patch of PATCHES.filter((entry) => entry.preserveLength)) {
+    const input = `before:${patch.original}:after`;
+    const result = patchXtermSource(input, patch);
+    assert.equal(result.changed, true);
+    assert.equal(result.source.length, input.length);
+    assert.equal(result.source.includes(patch.original), false);
+    assert.equal(
+      result.source.includes(sameLengthTrueExpression(patch.original.length)),
+      true,
+    );
+  }
+});
+
+test("patches readable xterm sources and source-map content", () => {
+  for (const patch of PATCHES.filter((entry) => !entry.preserveLength)) {
+    const result = patchXtermSource(`before:${patch.original}:after`, patch);
+    assert.equal(result.changed, true);
+    assert.equal(result.source, `before:${patch.replacement}:after`);
+  }
+});
+
+test("is idempotent and fails closed on an unknown package shape", () => {
+  for (const patch of PATCHES) {
+    const replacement = patch.preserveLength
+      ? sameLengthTrueExpression(patch.original.length)
+      : patch.replacement;
+    assert.deepEqual(patchXtermSource(`before:${replacement}:after`, patch), {
+      source: `before:${replacement}:after`,
+      changed: false,
+    });
+    assert.throws(
+      () => patchXtermSource("unrecognized source", patch),
+      /expected exactly one original or patched selection predicate/,
+    );
+  }
+});

--- a/scripts/patch-xterm-macos-column-selection.test.cjs
+++ b/scripts/patch-xterm-macos-column-selection.test.cjs
@@ -6,6 +6,7 @@ const test = require("node:test");
 const {
   PATCHES,
   patchXtermSource,
+  replacementForPatch,
   sameLengthTrueExpression,
 } = require("./patch-xterm-macos-column-selection.cjs");
 
@@ -25,17 +26,17 @@ test("patches both distributed bundles without shifting source-map offsets", () 
 
 test("patches readable xterm sources and source-map content", () => {
   for (const patch of PATCHES.filter((entry) => !entry.preserveLength)) {
-    const result = patchXtermSource(`before:${patch.original}:after`, patch);
+    const input = `before:${patch.original}:after`;
+    const result = patchXtermSource(input, patch);
     assert.equal(result.changed, true);
-    assert.equal(result.source, `before:${patch.replacement}:after`);
+    assert.equal(result.source, `before:${replacementForPatch(patch)}:after`);
+    assert.equal(result.source.length, input.length);
   }
 });
 
 test("is idempotent and fails closed on an unknown package shape", () => {
   for (const patch of PATCHES) {
-    const replacement = patch.preserveLength
-      ? sameLengthTrueExpression(patch.original.length)
-      : patch.replacement;
+    const replacement = replacementForPatch(patch);
     assert.deepEqual(patchXtermSource(`before:${replacement}:after`, patch), {
       source: `before:${replacement}:after`,
       changed: false,

--- a/scripts/patch-xterm-macos-column-selection.test.cjs
+++ b/scripts/patch-xterm-macos-column-selection.test.cjs
@@ -1,11 +1,14 @@
 "use strict";
 
 const assert = require("node:assert/strict");
+const path = require("node:path");
 const test = require("node:test");
 
 const {
   PATCHES,
+  invalidateViteCache,
   patchXtermSource,
+  replacementForPatch,
   sameLengthExpression,
 } = require("./patch-xterm-macos-column-selection.cjs");
 
@@ -25,17 +28,17 @@ test("patches both distributed bundles without shifting source-map offsets", () 
 
 test("patches readable xterm sources and source-map content", () => {
   for (const patch of PATCHES.filter((entry) => !entry.preserveLength)) {
-    const result = patchXtermSource(`before:${patch.original}:after`, patch);
+    const input = `before:${patch.original}:after`;
+    const result = patchXtermSource(input, patch);
     assert.equal(result.changed, true);
-    assert.equal(result.source, `before:${patch.replacement}:after`);
+    assert.equal(result.source, `before:${replacementForPatch(patch)}:after`);
+    assert.equal(result.source.length, input.length);
   }
 });
 
 test("is idempotent and fails closed on an unknown package shape", () => {
   for (const patch of PATCHES) {
-    const replacement = patch.preserveLength
-      ? sameLengthExpression(patch.replacement, patch.original.length)
-      : patch.replacement;
+    const replacement = replacementForPatch(patch);
     assert.deepEqual(patchXtermSource(`before:${replacement}:after`, patch), {
       source: `before:${replacement}:after`,
       changed: false,
@@ -52,4 +55,19 @@ test("fails closed when a generated-bundle replacement would shift offsets", () 
     () => sameLengthExpression("replacement is longer", 4),
     /replacement expression is too long/,
   );
+});
+
+test("invalidates Vite's optimized dependency cache after patching xterm", () => {
+  const calls = [];
+  const cachePath = invalidateViteCache("/repo", {
+    rmSync(target, options) {
+      calls.push({ target, options });
+    },
+  });
+
+  assert.equal(cachePath, path.resolve("/repo/node_modules/.vite"));
+  assert.deepEqual(calls, [{
+    target: cachePath,
+    options: { recursive: true, force: true },
+  }]);
 });

--- a/scripts/patch-xterm-macos-column-selection.test.cjs
+++ b/scripts/patch-xterm-macos-column-selection.test.cjs
@@ -36,6 +36,19 @@ test("patches readable xterm sources and source-map content", () => {
   }
 });
 
+test("keeps source-map token columns stable inside every patched expression", () => {
+  for (const patch of PATCHES) {
+    const replacement = replacementForPatch(patch);
+    for (const token of ["this", "_optionsService", "rawOptions", ")", ";"]) {
+      assert.equal(
+        replacement.lastIndexOf(token),
+        patch.original.lastIndexOf(token),
+        `${patch.file}: ${token} moved to a different generated column`,
+      );
+    }
+  }
+});
+
 test("is idempotent and fails closed on an unknown package shape", () => {
   for (const patch of PATCHES) {
     const replacement = replacementForPatch(patch);

--- a/scripts/xterm-macos-column-selection.live.test.cjs
+++ b/scripts/xterm-macos-column-selection.live.test.cjs
@@ -1,0 +1,145 @@
+"use strict";
+
+if (!process.versions.electron) {
+  const test = require("node:test");
+  test("macOS Option drag keeps rectangular and remote mouse behavior", {
+    skip: "run with Electron on macOS",
+  }, () => {});
+} else if (process.platform !== "darwin") {
+  const skipElectron = require("electron");
+  process.stdout.write("XTERM_MACOS_COLUMN_SELECTION_SKIP platform is not macOS\n");
+  skipElectron.app.exit(0);
+} else {
+  const assert = require("node:assert/strict");
+  const fs = require("node:fs");
+  const os = require("node:os");
+  const path = require("node:path");
+  const electron = require("electron");
+
+  const appRoot = path.resolve(__dirname, "..");
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-xterm-macos-selection-"));
+  electron.app.setPath("userData", userData);
+  electron.app.on("window-all-closed", () => {});
+
+  const cleanup = (exitCode) => {
+    fs.rmSync(userData, { recursive: true, force: true });
+    electron.app.exit(exitCode);
+  };
+  const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+  void electron.app.whenReady().then(async () => {
+    const window = new electron.BrowserWindow({
+      show: process.env.NETCATTY_XTERM_SELECTION_SHOW_WINDOW === "1",
+      width: 860,
+      height: 400,
+      paintWhenInitiallyHidden: true,
+      webPreferences: {
+        contextIsolation: false,
+        nodeIntegration: true,
+        sandbox: false,
+        backgroundThrottling: false,
+      },
+    });
+    await window.loadURL(
+      "data:text/html;charset=utf-8," + encodeURIComponent(
+        "<!doctype html><style>html,body{margin:0;background:#111}#terminal{width:800px;height:320px;padding:20px}</style><div id=terminal></div>",
+      ),
+    );
+
+    const xtermPath = require.resolve("@xterm/xterm", { paths: [appRoot] });
+    await window.webContents.executeJavaScript(`(() => {
+      const { Terminal } = require(${JSON.stringify(xtermPath)});
+      const term = new Terminal({
+        cols: 20,
+        rows: 6,
+        fontFamily: "Menlo",
+        fontSize: 18,
+        allowProposedApi: true,
+        macOptionClickForcesSelection: true,
+        altClickMovesCursor: true,
+      });
+      let data = "";
+      term.onData(value => { data += value; });
+      term.open(document.getElementById("terminal"));
+      const content = [
+        "ABCDEFGHIJKLMNOPQRST",
+        "abcdefghijklmnopqrst",
+        "01234567890123456789",
+        "!@#$%^&*()_+-=[]{}|;",
+      ].join("\\r\\n");
+      window.harness = {
+        reset: mouseTracking => new Promise(resolve => {
+          data = "";
+          term.reset();
+          term.clearSelection();
+          term.write((mouseTracking ? "\\x1b[?1002h\\x1b[?1006h" : "\\x1b[?1002l\\x1b[?1006l") + content, resolve);
+        }),
+        geometry: () => {
+          const screen = term.element.querySelector(".xterm-screen").getBoundingClientRect();
+          return {
+            left: screen.left,
+            top: screen.top,
+            cellWidth: screen.width / term.cols,
+            cellHeight: screen.height / term.rows,
+          };
+        },
+        state: () => ({
+          selection: term.getSelection(),
+          data,
+          mouseTrackingMode: term.modes.mouseTrackingMode,
+        }),
+      };
+    })()`);
+
+    const drag = async ({ alt = false } = {}) => {
+      const geometry = await window.webContents.executeJavaScript("window.harness.geometry()");
+      const point = (column, row) => ({
+        x: Math.round(geometry.left + geometry.cellWidth * (column + 0.5)),
+        y: Math.round(geometry.top + geometry.cellHeight * (row + 0.5)),
+      });
+      const start = point(1, 0);
+      const end = point(5, 2);
+      /** @type {Array<"alt">} */
+      const modifiers = alt ? ["alt"] : [];
+      window.webContents.sendInputEvent({ type: "mouseDown", ...start, button: "left", clickCount: 1, modifiers });
+      window.webContents.sendInputEvent({ type: "mouseMove", ...end, button: "left", modifiers });
+      window.webContents.sendInputEvent({ type: "mouseUp", ...end, button: "left", clickCount: 1, modifiers });
+      await delay(100);
+      return window.webContents.executeJavaScript("window.harness.state()");
+    };
+    const runScenario = async (mouseTracking, alt) => {
+      await window.webContents.executeJavaScript(`window.harness.reset(${mouseTracking})`);
+      return drag({ alt });
+    };
+
+    const normal = await runScenario(false, false);
+    const option = await runScenario(false, true);
+    const remote = await runScenario(true, false);
+    const remoteOption = await runScenario(true, true);
+    const expectedColumn = "BCDEF\nbcdef\n12345";
+
+    assert.equal(
+      normal.selection,
+      "BCDEFGHIJKLMNOPQRST\nabcdefghijklmnopqrst\n012345",
+      `ordinary drag must remain a normal selection: ${JSON.stringify(normal)}`,
+    );
+    assert.equal(option.selection, expectedColumn, `Option drag must select columns: ${JSON.stringify(option)}`);
+    assert.equal(remote.selection, "", `remote drag must not create a local selection: ${JSON.stringify(remote)}`);
+    assert.match(remote.data, /\x1b\[</, `remote drag must emit mouse reports: ${JSON.stringify(remote)}`);
+    assert.equal(
+      remoteOption.selection,
+      expectedColumn,
+      `Option drag must force rectangular selection in mouse mode: ${JSON.stringify(remoteOption)}`,
+    );
+    assert.equal(remoteOption.data, "", `forced local selection must not emit mouse reports: ${JSON.stringify(remoteOption)}`);
+
+    process.stdout.write(
+      `XTERM_MACOS_COLUMN_SELECTION_OK ${JSON.stringify({ normal, option, remote, remoteOption })}\n`,
+    );
+    window.destroy();
+    cleanup(0);
+  }).catch((error) => {
+    console.error(error);
+    cleanup(1);
+  });
+}

--- a/scripts/xterm-macos-column-selection.live.test.cjs
+++ b/scripts/xterm-macos-column-selection.live.test.cjs
@@ -12,23 +12,32 @@ if (!process.versions.electron) {
 } else {
   const assert = require("node:assert/strict");
   const fs = require("node:fs");
-  const os = require("node:os");
   const path = require("node:path");
   const electron = require("electron");
+  const tempDirBridge = require("../electron/bridges/tempDirBridge.cjs");
 
   const appRoot = path.resolve(__dirname, "..");
-  const userData = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-xterm-macos-selection-"));
+  const userData = fs.mkdtempSync(
+    `${tempDirBridge.getTempFilePath("xterm-macos-selection")}-`,
+  );
   electron.app.setPath("userData", userData);
   electron.app.on("window-all-closed", () => {});
+  let window = null;
 
   const cleanup = (exitCode) => {
-    fs.rmSync(userData, { recursive: true, force: true });
-    electron.app.exit(exitCode);
+    if (window && !window.isDestroyed()) window.destroy();
+    try {
+      fs.rmSync(userData, { recursive: true, force: true });
+    } catch (error) {
+      console.warn("Unable to remove xterm selection test data:", error);
+    } finally {
+      electron.app.exit(exitCode);
+    }
   };
   const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
 
   void electron.app.whenReady().then(async () => {
-    const window = new electron.BrowserWindow({
+    window = new electron.BrowserWindow({
       show: process.env.NETCATTY_XTERM_SELECTION_SHOW_WINDOW === "1",
       width: 860,
       height: 400,
@@ -56,6 +65,7 @@ if (!process.versions.electron) {
         fontSize: 18,
         allowProposedApi: true,
         macOptionClickForcesSelection: true,
+        macOptionIsMeta: false,
         altClickMovesCursor: true,
       });
       let data = "";
@@ -68,10 +78,12 @@ if (!process.versions.electron) {
         "!@#$%^&*()_+-=[]{}|;",
       ].join("\\r\\n");
       window.harness = {
-        reset: mouseTracking => new Promise(resolve => {
+        reset: (mouseTracking, optionAsMeta) => new Promise(resolve => {
           data = "";
           term.reset();
           term.clearSelection();
+          term.options.macOptionIsMeta = optionAsMeta;
+          term.options.altClickMovesCursor = !optionAsMeta;
           term.write((mouseTracking ? "\\x1b[?1002h\\x1b[?1006h" : "\\x1b[?1002l\\x1b[?1006l") + content, resolve);
         }),
         geometry: () => {
@@ -87,6 +99,7 @@ if (!process.versions.electron) {
           selection: term.getSelection(),
           data,
           mouseTrackingMode: term.modes.mouseTrackingMode,
+          optionAsMeta: term.options.macOptionIsMeta,
         }),
       };
     })()`);
@@ -107,8 +120,10 @@ if (!process.versions.electron) {
       await delay(100);
       return window.webContents.executeJavaScript("window.harness.state()");
     };
-    const runScenario = async (mouseTracking, alt) => {
-      await window.webContents.executeJavaScript(`window.harness.reset(${mouseTracking})`);
+    const runScenario = async (mouseTracking, alt, optionAsMeta = false) => {
+      await window.webContents.executeJavaScript(
+        `window.harness.reset(${mouseTracking}, ${optionAsMeta})`,
+      );
       return drag({ alt });
     };
 
@@ -116,11 +131,15 @@ if (!process.versions.electron) {
     const option = await runScenario(false, true);
     const remote = await runScenario(true, false);
     const remoteOption = await runScenario(true, true);
+    const optionAsMeta = await runScenario(false, true, true);
+    const remoteOptionAsMeta = await runScenario(true, true, true);
+    const optionAfterMeta = await runScenario(false, true, false);
     const expectedColumn = "BCDEF\nbcdef\n12345";
+    const expectedNormal = "BCDEFGHIJKLMNOPQRST\nabcdefghijklmnopqrst\n012345";
 
     assert.equal(
       normal.selection,
-      "BCDEFGHIJKLMNOPQRST\nabcdefghijklmnopqrst\n012345",
+      expectedNormal,
       `ordinary drag must remain a normal selection: ${JSON.stringify(normal)}`,
     );
     assert.equal(option.selection, expectedColumn, `Option drag must select columns: ${JSON.stringify(option)}`);
@@ -132,11 +151,30 @@ if (!process.versions.electron) {
       `Option drag must force rectangular selection in mouse mode: ${JSON.stringify(remoteOption)}`,
     );
     assert.equal(remoteOption.data, "", `forced local selection must not emit mouse reports: ${JSON.stringify(remoteOption)}`);
+    assert.equal(
+      optionAsMeta.selection,
+      expectedNormal,
+      `Option-as-Meta must disable rectangular selection: ${JSON.stringify(optionAsMeta)}`,
+    );
+    assert.equal(
+      remoteOptionAsMeta.selection,
+      expectedNormal,
+      `Option-as-Meta must disable rectangular selection in mouse mode: ${JSON.stringify(remoteOptionAsMeta)}`,
+    );
+    assert.equal(
+      remoteOptionAsMeta.data,
+      "",
+      `Option must still force local selection in mouse mode: ${JSON.stringify(remoteOptionAsMeta)}`,
+    );
+    assert.equal(
+      optionAfterMeta.selection,
+      expectedColumn,
+      `turning Option-as-Meta off must restore rectangular selection: ${JSON.stringify(optionAfterMeta)}`,
+    );
 
     process.stdout.write(
-      `XTERM_MACOS_COLUMN_SELECTION_OK ${JSON.stringify({ normal, option, remote, remoteOption })}\n`,
+      `XTERM_MACOS_COLUMN_SELECTION_OK ${JSON.stringify({ normal, option, remote, remoteOption, optionAsMeta, remoteOptionAsMeta, optionAfterMeta })}\n`,
     );
-    window.destroy();
     cleanup(0);
   }).catch((error) => {
     console.error(error);

--- a/scripts/xterm-macos-column-selection.live.test.cjs
+++ b/scripts/xterm-macos-column-selection.live.test.cjs
@@ -13,6 +13,7 @@ if (!process.versions.electron) {
   const assert = require("node:assert/strict");
   const fs = require("node:fs");
   const path = require("node:path");
+  const { pathToFileURL } = require("node:url");
   const electron = require("electron");
   const tempDirBridge = require("../electron/bridges/tempDirBridge.cjs");
 
@@ -46,6 +47,8 @@ if (!process.versions.electron) {
         contextIsolation: false,
         nodeIntegration: true,
         sandbox: false,
+        // The harness imports the shipped ESM bundle directly from disk.
+        webSecurity: false,
         backgroundThrottling: false,
       },
     });
@@ -56,8 +59,9 @@ if (!process.versions.electron) {
     );
 
     const xtermPath = require.resolve("@xterm/xterm", { paths: [appRoot] });
-    await window.webContents.executeJavaScript(`(() => {
-      const { Terminal } = require(${JSON.stringify(xtermPath)});
+    const xtermEsmUrl = pathToFileURL(path.join(path.dirname(xtermPath), "xterm.mjs")).href;
+    await window.webContents.executeJavaScript(`(async () => {
+      const { Terminal } = await import(${JSON.stringify(xtermEsmUrl)});
       const term = new Terminal({
         cols: 20,
         rows: 6,
@@ -114,8 +118,10 @@ if (!process.versions.electron) {
       const end = point(5, 2);
       /** @type {Array<"alt">} */
       const modifiers = alt ? ["alt"] : [];
+      /** @type {Array<"alt" | "leftbuttondown">} */
+      const moveModifiers = alt ? ["alt", "leftbuttondown"] : ["leftbuttondown"];
       window.webContents.sendInputEvent({ type: "mouseDown", ...start, button: "left", clickCount: 1, modifiers });
-      window.webContents.sendInputEvent({ type: "mouseMove", ...end, button: "left", modifiers });
+      window.webContents.sendInputEvent({ type: "mouseMove", ...end, button: "left", modifiers: moveModifiers });
       window.webContents.sendInputEvent({ type: "mouseUp", ...end, button: "left", clickCount: 1, modifiers });
       await delay(100);
       return window.webContents.executeJavaScript("window.harness.state()");

--- a/scripts/xterm-macos-column-selection.live.test.cjs
+++ b/scripts/xterm-macos-column-selection.live.test.cjs
@@ -150,7 +150,9 @@ if (!process.versions.electron) {
     );
     assert.equal(option.selection, expectedColumn, `Option drag must select columns: ${JSON.stringify(option)}`);
     assert.equal(remote.selection, "", `remote drag must not create a local selection: ${JSON.stringify(remote)}`);
-    assert.match(remote.data, /\x1b\[</, `remote drag must emit mouse reports: ${JSON.stringify(remote)}`);
+    assert.match(remote.data, /\x1b\[<0;\d+;\d+M/, `remote drag must report mouse down: ${JSON.stringify(remote)}`);
+    assert.match(remote.data, /\x1b\[<32;\d+;\d+M/, `remote drag must report mouse movement: ${JSON.stringify(remote)}`);
+    assert.match(remote.data, /\x1b\[<0;\d+;\d+m/, `remote drag must report mouse up: ${JSON.stringify(remote)}`);
     assert.equal(
       remoteOption.selection,
       expectedColumn,

--- a/scripts/xterm-macos-column-selection.live.test.cjs
+++ b/scripts/xterm-macos-column-selection.live.test.cjs
@@ -14,6 +14,7 @@ if (!process.versions.electron) {
   const fs = require("node:fs");
   const os = require("node:os");
   const path = require("node:path");
+  const { pathToFileURL } = require("node:url");
   const electron = require("electron");
 
   const appRoot = path.resolve(__dirname, "..");
@@ -37,6 +38,8 @@ if (!process.versions.electron) {
         contextIsolation: false,
         nodeIntegration: true,
         sandbox: false,
+        // The harness imports the shipped ESM bundle directly from disk.
+        webSecurity: false,
         backgroundThrottling: false,
       },
     });
@@ -47,8 +50,9 @@ if (!process.versions.electron) {
     );
 
     const xtermPath = require.resolve("@xterm/xterm", { paths: [appRoot] });
-    await window.webContents.executeJavaScript(`(() => {
-      const { Terminal } = require(${JSON.stringify(xtermPath)});
+    const xtermEsmUrl = pathToFileURL(path.join(path.dirname(xtermPath), "xterm.mjs")).href;
+    await window.webContents.executeJavaScript(`(async () => {
+      const { Terminal } = await import(${JSON.stringify(xtermEsmUrl)});
       const term = new Terminal({
         cols: 20,
         rows: 6,
@@ -101,8 +105,10 @@ if (!process.versions.electron) {
       const end = point(5, 2);
       /** @type {Array<"alt">} */
       const modifiers = alt ? ["alt"] : [];
+      /** @type {Array<"alt" | "leftbuttondown">} */
+      const moveModifiers = alt ? ["alt", "leftbuttondown"] : ["leftbuttondown"];
       window.webContents.sendInputEvent({ type: "mouseDown", ...start, button: "left", clickCount: 1, modifiers });
-      window.webContents.sendInputEvent({ type: "mouseMove", ...end, button: "left", modifiers });
+      window.webContents.sendInputEvent({ type: "mouseMove", ...end, button: "left", modifiers: moveModifiers });
       window.webContents.sendInputEvent({ type: "mouseUp", ...end, button: "left", clickCount: 1, modifiers });
       await delay(100);
       return window.webContents.executeJavaScript("window.harness.state()");


### PR DESCRIPTION
## Summary

Restores rectangular Option-drag selection on macOS without regressing Option-as-Meta, local selection inside mouse-aware terminal programs, or unmodified remote mouse reporting.

The pinned terminal library treats forced Option selection and rectangular Option selection as mutually exclusive. Netcatty needs both behaviors when Option is not configured as Meta, so installation now applies a version-locked, fail-closed compatibility adjustment.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [x] Build / CI change
- [ ] Other (please describe):

## Related Issue

Closes #3114

## Changes Made

- preserve Option as the local-selection override in mouse-aware programs
- make that Option selection rectangular on macOS when Option-as-Meta is off
- preserve normal selection when Option-as-Meta is on, including in mouse-aware programs
- keep ordinary selection and unmodified remote mouse reporting unchanged
- add an idempotent version guard around the pinned terminal-library adjustment
- invalidate Vite's optimized dependency cache after applying the adjustment
- add a real Electron mouse-interaction regression test and run it in macOS package validation

## Screenshots / Demo

Validated in a visible macOS Electron terminal using native mouse input and the shipped ESM build. The test covers rectangular Option drag, ordinary drag, remote mouse reporting, Option-forced selection while remote mouse mode is active, and turning Option-as-Meta on and back off.

## Testing

- [x] `npm run test:xterm-macos-selection`
- [x] related terminal, patch, and workflow tests
- [x] targeted checked-JavaScript type check for the patch scripts
- [x] Linting passes (`npm run lint`)
- [x] Production build passes (`npm run build`)
- [x] stale Vite cache removal verified on initial and idempotent patch runs
- [x] `git diff --check`
- [x] No new console errors or warnings in the tested flow

## Checklist

- [x] My code follows the existing project style
- [x] I have added regression coverage
- [x] I have not introduced any breaking changes
