### PR TITLE
fix: honor disabled close-tab shortcut on macOS

### DIFF
--- a/application/AppHandlers.globalHotkeys.test.ts
+++ b/application/AppHandlers.globalHotkeys.test.ts
@@ -6,6 +6,7 @@ import {
   getLogHostVisualSnapshot,
   handleEscapeKeyDownImpl,
   handleGlobalHotkeyKeyDownImpl,
+  markForwardedNativeShortcutEvent,
 } from './app/AppHandlers.ts';
 import { matchesKeyBinding } from '../domain/models.ts';
 import { DEFAULT_KEY_BINDINGS } from '../domain/models/keyBindings.ts';
@@ -32,6 +33,14 @@ class FakeHTMLElement {
 
   hasAttribute(name: string): boolean {
     return name === 'data-session-id';
+  }
+}
+
+class FakeMonacoHTMLElement extends FakeHTMLElement {
+  tagName = 'TEXTAREA';
+
+  closest(selector: string): FakeMonacoHTMLElement | null {
+    return selector.includes('monaco') ? this : null;
   }
 }
 
@@ -147,6 +156,48 @@ test('global hotkey handler magnifies panes from focused form inputs', () => {
   );
 
   assert.deepEqual(handledActions, ['togglePaneZoom']);
+});
+
+test('forwarded native shortcut can run a reassigned global action from Monaco', () => {
+  const target = new FakeMonacoHTMLElement();
+  const handledActions: string[] = [];
+  let prevented = false;
+  const event = markForwardedNativeShortcutEvent({
+    key: 'w',
+    code: 'KeyW',
+    ctrlKey: false,
+    metaKey: true,
+    altKey: false,
+    shiftKey: false,
+    target,
+    composedPath: () => [target],
+    preventDefault: () => {
+      prevented = true;
+    },
+    stopPropagation: () => {},
+  } as unknown as KeyboardEvent);
+  const keyBindings = DEFAULT_KEY_BINDINGS.map((binding) => {
+    if (binding.action === 'closeTab') return { ...binding, mac: 'Disabled' };
+    if (binding.action === 'newTab') return { ...binding, mac: '⌘ + W' };
+    return binding;
+  });
+
+  handleGlobalHotkeyKeyDownImpl(
+    () => ({
+      HOTKEY_DEBUG: false,
+      closeTabKeyStr: 'Disabled',
+      executeHotkeyAction: (action: string) => {
+        handledActions.push(action);
+      },
+      hotkeyScheme: 'mac',
+      keyBindings,
+      matchesKeyBinding,
+    }),
+    event,
+  );
+
+  assert.deepEqual(handledActions, ['newTab']);
+  assert.equal(prevented, true);
 });
 
 test('quick switch hotkey toggles the quick switcher open state', () => {

--- a/application/app/AppHandlers.ts
+++ b/application/app/AppHandlers.ts
@@ -14,6 +14,12 @@ import { captureInheritedCwd } from '../state/inheritedCwd';
 
 type AppContextGetter = () => Record<string, any>;
 const TERMINAL_PASSTHROUGH_ACTIONS = getTerminalPassthroughActions();
+const forwardedNativeShortcutEvents = new WeakSet<KeyboardEvent>();
+
+export function markForwardedNativeShortcutEvent(event: KeyboardEvent): KeyboardEvent {
+  forwardedNativeShortcutEvents.add(event);
+  return event;
+}
 
 async function deliverKeyboardInteractiveResponse(
   ctx: Record<string, any>,
@@ -270,6 +276,7 @@ export function handleGlobalHotkeyKeyDownImpl(getCtx: AppContextGetter, e: Keybo
       && e.key !== 'Escape'
       && !isQuickSwitchHotkey
       && !isPaneZoomHotkey
+      && !forwardedNativeShortcutEvents.has(e)
     ) {
       return;
     }

--- a/application/app/AppSideEffects.tsx
+++ b/application/app/AppSideEffects.tsx
@@ -1096,10 +1096,6 @@ export function AppSideEffects() {
     const openDialogs = Array.from(document.querySelectorAll<HTMLElement>('[role="dialog"][data-state="open"]'));
     const topmostOpenDialog = openDialogs[openDialogs.length - 1] ?? null;
     const topmostDialogClose = topmostOpenDialog?.querySelector<HTMLElement>('[data-dialog-close="true"]');
-    if (topmostDialogClose) {
-      topmostDialogClose.click();
-      return;
-    }
 
     const intent = resolveWindowCommandCloseIntent({
       activeTabId: activeTabStore.getActiveTabId(),
@@ -1108,7 +1104,37 @@ export function AppSideEffects() {
       workspaceIds: workspaces.map((workspace) => workspace.id),
       logViewIds: logViews.map((logView) => logView.id),
       pluginViewTabIds: pluginViewTabs.map((tab) => tab.id),
+      hasOpenDialog: Boolean(topmostDialogClose),
+      closeTabShortcutEnabled: Boolean(
+        closeTabKeyStr
+        && matchesKeyBinding({
+          key: 'w',
+          code: 'KeyW',
+          metaKey: true,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+        } as KeyboardEvent, closeTabKeyStr, true),
+      ),
     });
+
+    if (intent.kind === 'forwardShortcut') {
+      // The native macOS menu accelerator consumed the original key event.
+      // Re-dispatch it so a freed Cmd+W can still be assigned to another action.
+      window.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'w',
+        code: 'KeyW',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      }));
+      return;
+    }
+
+    if (intent.kind === 'closeDialog') {
+      topmostDialogClose?.click();
+      return;
+    }
 
     if (intent.kind === 'closeTab') {
       executeHotkeyAction('closeTab', new KeyboardEvent('keydown', { key: 'w', metaKey: true }));
@@ -1121,7 +1147,7 @@ export function AppSideEffects() {
     }
 
     await netcattyBridge.get()?.windowClose?.();
-  }, [closeLogView, editorTabs, executeHotkeyAction, logViews, pluginViewTabs, sessions, workspaces]);
+  }, [closeLogView, closeTabKeyStr, editorTabs, executeHotkeyAction, logViews, pluginViewTabs, sessions, workspaces]);
 
   useEffect(() => {
     // Cmd/Ctrl+W from the app menu arrives via IPC, not the keydown listener.

--- a/application/app/AppSideEffects.tsx
+++ b/application/app/AppSideEffects.tsx
@@ -90,7 +90,7 @@ import { isScriptSnippet } from '../../domain/snippetScript.ts';
 import { collectSnippetDeleteIds } from '../../domain/snippetSelection.ts';
 import { shouldOpenLocalTerminalOnStartup, resolveStartupLandingSetting } from '../../domain/startupLanding';
 import { useAppStartupEffects } from './useAppStartupEffects';
-import { handleTrayJumpToSessionImpl, handleTrayTogglePortForwardImpl, handleTrayPanelConnectImpl, handleTrayPanelConnectRequestImpl, flushQueuedTrayPanelConnectHostsImpl, handleGlobalHotkeyKeyDownImpl, handleEscapeKeyDownImpl, handleKeyboardInteractiveSubmitImpl, handleKeyboardInteractiveCancelImpl, handlePassphraseSubmitImpl, handlePassphraseCancelImpl, handlePassphraseSkipImpl, createLocalTerminalWithCurrentShellImpl, splitSessionWithCurrentShellImpl, copySessionWithCurrentShellImpl, copyWorkspaceWithCurrentShellImpl, copySessionToNewWindowWithCurrentShellImpl, confirmIfBusyLocalTerminalImpl, closeTabsBatchImpl, executeHotkeyActionImpl, handleCreateLocalTerminalImpl, handleConnectToHostImpl, handleTerminalDataCaptureImpl, hasMultipleProtocolsImpl, handleHostConnectWithProtocolCheckImpl, handleProtocolSelectImpl, handleRootContextMenuImpl } from './AppHandlers';
+import { handleTrayJumpToSessionImpl, handleTrayTogglePortForwardImpl, handleTrayPanelConnectImpl, handleTrayPanelConnectRequestImpl, flushQueuedTrayPanelConnectHostsImpl, handleGlobalHotkeyKeyDownImpl, handleEscapeKeyDownImpl, handleKeyboardInteractiveSubmitImpl, handleKeyboardInteractiveCancelImpl, handlePassphraseSubmitImpl, handlePassphraseCancelImpl, handlePassphraseSkipImpl, createLocalTerminalWithCurrentShellImpl, splitSessionWithCurrentShellImpl, copySessionWithCurrentShellImpl, copyWorkspaceWithCurrentShellImpl, copySessionToNewWindowWithCurrentShellImpl, confirmIfBusyLocalTerminalImpl, closeTabsBatchImpl, executeHotkeyActionImpl, handleCreateLocalTerminalImpl, handleConnectToHostImpl, handleTerminalDataCaptureImpl, hasMultipleProtocolsImpl, handleHostConnectWithProtocolCheckImpl, handleProtocolSelectImpl, handleRootContextMenuImpl, markForwardedNativeShortcutEvent } from './AppHandlers';
 
 type OpenSessionInNewWindowPayload = {
   title?: string;
@@ -1111,13 +1111,14 @@ export function AppSideEffects() {
     if (intent.kind === 'forwardShortcut') {
       // The native macOS menu accelerator consumed the original key event.
       // Re-dispatch it so a freed Cmd+W can still be assigned to another action.
-      (document.activeElement ?? window).dispatchEvent(new KeyboardEvent('keydown', {
+      const forwardedEvent = markForwardedNativeShortcutEvent(new KeyboardEvent('keydown', {
         key: 'w',
         code: 'KeyW',
         metaKey: true,
         bubbles: true,
         cancelable: true,
       }));
+      (document.activeElement ?? window).dispatchEvent(forwardedEvent);
       return;
     }
 

--- a/application/app/AppSideEffects.tsx
+++ b/application/app/AppSideEffects.tsx
@@ -55,7 +55,7 @@ import { collectSessionIds } from '../../domain/workspace';
 import type { PaneMagnificationController } from '../../domain/paneMagnification';
 import { resolveCloseIntent } from '../state/resolveCloseIntent';
 import { resolveSnippetsShortcutIntent } from '../state/resolveSnippetsShortcutIntent';
-import { isMacCommandWBinding, resolveWindowCommandCloseIntent } from '../state/windowCommandClose';
+import { isPrimaryModifierWBinding, resolveWindowCommandCloseIntent } from '../state/windowCommandClose';
 import type { SyncPayload } from '../../domain/sync';
 import { applySyncPayload, buildLocalVaultPayloadAsync, hasMeaningfulSyncData } from '../syncPayload';
 import {
@@ -1105,7 +1105,7 @@ export function AppSideEffects() {
       logViewIds: logViews.map((logView) => logView.id),
       pluginViewTabIds: pluginViewTabs.map((tab) => tab.id),
       hasOpenDialog: Boolean(topmostDialogClose),
-      closeTabShortcutEnabled: isMacCommandWBinding(closeTabKeyStr, matchesKeyBinding),
+      closeTabShortcutEnabled: isPrimaryModifierWBinding(closeTabKeyStr, matchesKeyBinding, true),
     });
 
     if (intent.kind === 'forwardShortcut') {

--- a/application/app/AppSideEffects.tsx
+++ b/application/app/AppSideEffects.tsx
@@ -55,7 +55,7 @@ import { collectSessionIds } from '../../domain/workspace';
 import type { PaneMagnificationController } from '../../domain/paneMagnification';
 import { resolveCloseIntent } from '../state/resolveCloseIntent';
 import { resolveSnippetsShortcutIntent } from '../state/resolveSnippetsShortcutIntent';
-import { resolveWindowCommandCloseIntent } from '../state/windowCommandClose';
+import { isMacCommandWBinding, resolveWindowCommandCloseIntent } from '../state/windowCommandClose';
 import type { SyncPayload } from '../../domain/sync';
 import { applySyncPayload, buildLocalVaultPayloadAsync, hasMeaningfulSyncData } from '../syncPayload';
 import {
@@ -1105,23 +1105,13 @@ export function AppSideEffects() {
       logViewIds: logViews.map((logView) => logView.id),
       pluginViewTabIds: pluginViewTabs.map((tab) => tab.id),
       hasOpenDialog: Boolean(topmostDialogClose),
-      closeTabShortcutEnabled: Boolean(
-        closeTabKeyStr
-        && matchesKeyBinding({
-          key: 'w',
-          code: 'KeyW',
-          metaKey: true,
-          ctrlKey: false,
-          altKey: false,
-          shiftKey: false,
-        } as KeyboardEvent, closeTabKeyStr, true),
-      ),
+      closeTabShortcutEnabled: isMacCommandWBinding(closeTabKeyStr, matchesKeyBinding),
     });
 
     if (intent.kind === 'forwardShortcut') {
       // The native macOS menu accelerator consumed the original key event.
       // Re-dispatch it so a freed Cmd+W can still be assigned to another action.
-      window.dispatchEvent(new KeyboardEvent('keydown', {
+      (document.activeElement ?? window).dispatchEvent(new KeyboardEvent('keydown', {
         key: 'w',
         code: 'KeyW',
         metaKey: true,

--- a/application/state/windowCommandClose.test.ts
+++ b/application/state/windowCommandClose.test.ts
@@ -1,7 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { resolveWindowCommandCloseIntent } from "./windowCommandClose.ts";
+import { matchesKeyBinding } from "../../domain/models.ts";
+import { isMacCommandWBinding, resolveWindowCommandCloseIntent } from "./windowCommandClose.ts";
+
+test("native Cmd+W only belongs to the matching macOS close-tab binding", () => {
+  assert.equal(isMacCommandWBinding("⌘ + W", matchesKeyBinding), true);
+  assert.equal(isMacCommandWBinding("⌘ + E", matchesKeyBinding), false);
+  assert.equal(isMacCommandWBinding("Disabled", matchesKeyBinding), false);
+  assert.equal(isMacCommandWBinding(null, matchesKeyBinding), false);
+});
 
 test("Cmd+W closes the active closable tab first", () => {
   assert.deepEqual(

--- a/application/state/windowCommandClose.test.ts
+++ b/application/state/windowCommandClose.test.ts
@@ -16,6 +16,92 @@ test("Cmd+W closes the active closable tab first", () => {
   );
 });
 
+test("disabled close-tab binding forwards native Cmd+W to other custom shortcuts", () => {
+  assert.deepEqual(
+    resolveWindowCommandCloseIntent({
+      activeTabId: "s1",
+      editorTabIds: [],
+      sessionIds: ["s1"],
+      workspaceIds: [],
+      logViewIds: [],
+      closeTabShortcutEnabled: false,
+    }),
+    { kind: "forwardShortcut" },
+  );
+});
+
+test("disabled close-tab binding forwards native Cmd+W while a dialog is open", () => {
+  assert.deepEqual(
+    resolveWindowCommandCloseIntent({
+      activeTabId: "s1",
+      editorTabIds: [],
+      sessionIds: ["s1"],
+      workspaceIds: [],
+      logViewIds: [],
+      closeTabShortcutEnabled: false,
+      hasOpenDialog: true,
+    }),
+    { kind: "forwardShortcut" },
+  );
+});
+
+test("enabled close-tab binding closes the topmost dialog before the active tab", () => {
+  assert.deepEqual(
+    resolveWindowCommandCloseIntent({
+      activeTabId: "s1",
+      editorTabIds: [],
+      sessionIds: ["s1"],
+      workspaceIds: [],
+      logViewIds: [],
+      closeTabShortcutEnabled: true,
+      hasOpenDialog: true,
+    }),
+    { kind: "closeDialog" },
+  );
+});
+
+test("disabled close-tab binding also forwards native Cmd+W on a log tab", () => {
+  assert.deepEqual(
+    resolveWindowCommandCloseIntent({
+      activeTabId: "log-1",
+      editorTabIds: [],
+      sessionIds: [],
+      workspaceIds: [],
+      logViewIds: ["log-1"],
+      closeTabShortcutEnabled: false,
+    }),
+    { kind: "forwardShortcut" },
+  );
+});
+
+test("disabled close-tab binding forwards native Cmd+W instead of closing the window", () => {
+  assert.deepEqual(
+    resolveWindowCommandCloseIntent({
+      activeTabId: "vault",
+      editorTabIds: [],
+      sessionIds: [],
+      workspaceIds: [],
+      logViewIds: [],
+      closeTabShortcutEnabled: false,
+    }),
+    { kind: "forwardShortcut" },
+  );
+});
+
+test("disabled close-tab binding forwards native Cmd+W when nothing is active", () => {
+  assert.deepEqual(
+    resolveWindowCommandCloseIntent({
+      activeTabId: null,
+      editorTabIds: [],
+      sessionIds: [],
+      workspaceIds: [],
+      logViewIds: [],
+      closeTabShortcutEnabled: false,
+    }),
+    { kind: "forwardShortcut" },
+  );
+});
+
 test("Cmd+W on a log view closes the log view", () => {
   assert.deepEqual(
     resolveWindowCommandCloseIntent({

--- a/application/state/windowCommandClose.test.ts
+++ b/application/state/windowCommandClose.test.ts
@@ -2,13 +2,14 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { matchesKeyBinding } from "../../domain/models.ts";
-import { isMacCommandWBinding, resolveWindowCommandCloseIntent } from "./windowCommandClose.ts";
+import { isPrimaryModifierWBinding, resolveWindowCommandCloseIntent } from "./windowCommandClose.ts";
 
-test("native Cmd+W only belongs to the matching macOS close-tab binding", () => {
-  assert.equal(isMacCommandWBinding("⌘ + W", matchesKeyBinding), true);
-  assert.equal(isMacCommandWBinding("⌘ + E", matchesKeyBinding), false);
-  assert.equal(isMacCommandWBinding("Disabled", matchesKeyBinding), false);
-  assert.equal(isMacCommandWBinding(null, matchesKeyBinding), false);
+test("primary-modifier W only belongs to the matching close-tab binding", () => {
+  assert.equal(isPrimaryModifierWBinding("⌘ + W", matchesKeyBinding, true), true);
+  assert.equal(isPrimaryModifierWBinding("⌘ + E", matchesKeyBinding, true), false);
+  assert.equal(isPrimaryModifierWBinding("Ctrl + W", matchesKeyBinding, false), true);
+  assert.equal(isPrimaryModifierWBinding("Disabled", matchesKeyBinding, true), false);
+  assert.equal(isPrimaryModifierWBinding(null, matchesKeyBinding, true), false);
 });
 
 test("Cmd+W closes the active closable tab first", () => {

--- a/application/state/windowCommandClose.ts
+++ b/application/state/windowCommandClose.ts
@@ -1,4 +1,6 @@
 export type WindowCommandCloseIntent =
+  | { kind: 'forwardShortcut' }
+  | { kind: 'closeDialog' }
   | { kind: 'closeTab' }
   | { kind: 'closeLogView'; tabId: string }
   | { kind: 'closeWindow' };
@@ -10,6 +12,8 @@ interface ResolveWindowCommandCloseIntentInput {
   workspaceIds: string[];
   logViewIds: string[];
   pluginViewTabIds?: string[];
+  closeTabShortcutEnabled?: boolean;
+  hasOpenDialog?: boolean;
 }
 
 export function resolveWindowCommandCloseIntent({
@@ -19,7 +23,17 @@ export function resolveWindowCommandCloseIntent({
   workspaceIds,
   logViewIds,
   pluginViewTabIds = [],
+  closeTabShortcutEnabled = true,
+  hasOpenDialog = false,
 }: ResolveWindowCommandCloseIntentInput): WindowCommandCloseIntent {
+  if (!closeTabShortcutEnabled) {
+    return { kind: 'forwardShortcut' };
+  }
+
+  if (hasOpenDialog) {
+    return { kind: 'closeDialog' };
+  }
+
   if (!activeTabId) {
     return { kind: 'closeWindow' };
   }

--- a/application/state/windowCommandClose.ts
+++ b/application/state/windowCommandClose.ts
@@ -7,17 +7,21 @@ export type WindowCommandCloseIntent =
 
 type KeyBindingMatcher = (event: KeyboardEvent, binding: string, isMac: boolean) => boolean;
 
-export function isMacCommandWBinding(binding: string | null, matcher: KeyBindingMatcher): boolean {
+export function isPrimaryModifierWBinding(
+  binding: string | null,
+  matcher: KeyBindingMatcher,
+  isMac: boolean,
+): boolean {
   return Boolean(
     binding
     && matcher({
       key: 'w',
       code: 'KeyW',
-      metaKey: true,
-      ctrlKey: false,
+      metaKey: isMac,
+      ctrlKey: !isMac,
       altKey: false,
       shiftKey: false,
-    } as KeyboardEvent, binding, true),
+    } as KeyboardEvent, binding, isMac),
   );
 }
 

--- a/application/state/windowCommandClose.ts
+++ b/application/state/windowCommandClose.ts
@@ -5,6 +5,22 @@ export type WindowCommandCloseIntent =
   | { kind: 'closeLogView'; tabId: string }
   | { kind: 'closeWindow' };
 
+type KeyBindingMatcher = (event: KeyboardEvent, binding: string, isMac: boolean) => boolean;
+
+export function isMacCommandWBinding(binding: string | null, matcher: KeyBindingMatcher): boolean {
+  return Boolean(
+    binding
+    && matcher({
+      key: 'w',
+      code: 'KeyW',
+      metaKey: true,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+    } as KeyboardEvent, binding, true),
+  );
+}
+
 interface ResolveWindowCommandCloseIntentInput {
   activeTabId: string | null;
   editorTabIds: string[];

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -347,7 +347,16 @@ const SettingsPageContent: React.FC<{ settings: SettingsState; appLock?: AppLock
 
     useEffect(() => {
         const unsubscribe = onWindowCommandCloseRequested(() => {
-            if (!nativeCommandWClosesSettings) return;
+            if (!nativeCommandWClosesSettings) {
+                (document.activeElement ?? window).dispatchEvent(new KeyboardEvent("keydown", {
+                    key: "w",
+                    code: "KeyW",
+                    metaKey: true,
+                    bubbles: true,
+                    cancelable: true,
+                }));
+                return;
+            }
             void closeSettingsWindow();
         });
         return () => unsubscribe?.();

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -25,6 +25,8 @@ import { useExternalMcpGrantPersister } from "./ai/useExternalMcpGrantPersister"
 import { setupMcpApprovalBridge } from "../infrastructure/ai/shared/approvalGate";
 import { usePluginContributions } from "../application/state/usePluginContributions";
 import { PluginContributionHost } from "./plugins/PluginContributionHost";
+import { matchesKeyBinding } from "../domain/models";
+import { isMacCommandWBinding } from "../application/state/windowCommandClose";
 
 const LazySettingsApplicationTab = lazy(() => import("./SettingsApplicationTab"));
 const LazySettingsAppearanceTab = lazy(() => import("./settings/tabs/SettingsAppearanceTab"));
@@ -314,6 +316,13 @@ const SettingsPageContent: React.FC<{ settings: SettingsState; appLock?: AppLock
     const [activeTab, setActiveTab] = useState("application");
     const [mountedTabs, setMountedTabs] = useState(() => new Set(["application"]));
     const { available: pluginRuntimeAvailable } = usePluginContributions();
+    const closeTabKeyStr = useMemo(() => {
+        if (settings.hotkeyScheme === "disabled") return null;
+        const binding = settings.keyBindings.find((item) => item.action === "closeTab");
+        if (!binding) return null;
+        return settings.hotkeyScheme === "mac" ? binding.mac : binding.pc;
+    }, [settings.hotkeyScheme, settings.keyBindings]);
+    const nativeCommandWClosesSettings = isMacCommandWBinding(closeTabKeyStr, matchesKeyBinding);
 
     useEffect(() => {
         notifyRendererReady();
@@ -338,10 +347,11 @@ const SettingsPageContent: React.FC<{ settings: SettingsState; appLock?: AppLock
 
     useEffect(() => {
         const unsubscribe = onWindowCommandCloseRequested(() => {
+            if (!nativeCommandWClosesSettings) return;
             void closeSettingsWindow();
         });
         return () => unsubscribe?.();
-    }, [closeSettingsWindow, onWindowCommandCloseRequested]);
+    }, [closeSettingsWindow, nativeCommandWClosesSettings, onWindowCommandCloseRequested]);
 
     useEffect(() => {
         setMountedTabs((prev) => {

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -26,7 +26,7 @@ import { setupMcpApprovalBridge } from "../infrastructure/ai/shared/approvalGate
 import { usePluginContributions } from "../application/state/usePluginContributions";
 import { PluginContributionHost } from "./plugins/PluginContributionHost";
 import { matchesKeyBinding } from "../domain/models";
-import { isMacCommandWBinding } from "../application/state/windowCommandClose";
+import { isPrimaryModifierWBinding } from "../application/state/windowCommandClose";
 
 const LazySettingsApplicationTab = lazy(() => import("./SettingsApplicationTab"));
 const LazySettingsAppearanceTab = lazy(() => import("./settings/tabs/SettingsAppearanceTab"));
@@ -322,7 +322,7 @@ const SettingsPageContent: React.FC<{ settings: SettingsState; appLock?: AppLock
         if (!binding) return null;
         return settings.hotkeyScheme === "mac" ? binding.mac : binding.pc;
     }, [settings.hotkeyScheme, settings.keyBindings]);
-    const nativeCommandWClosesSettings = isMacCommandWBinding(closeTabKeyStr, matchesKeyBinding);
+    const nativeCommandWClosesSettings = isPrimaryModifierWBinding(closeTabKeyStr, matchesKeyBinding, true);
 
     useEffect(() => {
         notifyRendererReady();

--- a/components/editor/TextEditorPane.test.tsx
+++ b/components/editor/TextEditorPane.test.tsx
@@ -56,10 +56,14 @@ test("Monaco Cmd+W follows the current close-tab binding", () => {
   const closeTabBinding = DEFAULT_KEY_BINDINGS.find((binding) => binding.action === "closeTab");
   assert.ok(closeTabBinding);
 
-  assert.equal(isTextEditorCommandWEnabled({ hotkeyScheme: "mac", closeTabBinding }), true);
-  assert.equal(isTextEditorCommandWEnabled({ hotkeyScheme: "disabled", closeTabBinding }), false);
+  assert.equal(isTextEditorCommandWEnabled({ hotkeyScheme: "mac", closeTabBinding, isMac: true }), true);
+  assert.equal(isTextEditorCommandWEnabled({ hotkeyScheme: "pc", closeTabBinding, isMac: false }), true);
+  assert.equal(isTextEditorCommandWEnabled({ hotkeyScheme: "pc", closeTabBinding, isMac: true }), false);
+  assert.equal(isTextEditorCommandWEnabled({ hotkeyScheme: "mac", closeTabBinding, isMac: false }), false);
+  assert.equal(isTextEditorCommandWEnabled({ hotkeyScheme: "disabled", closeTabBinding, isMac: true }), false);
   assert.equal(isTextEditorCommandWEnabled({
     hotkeyScheme: "mac",
     closeTabBinding: { ...closeTabBinding, mac: "⌘ + E" },
+    isMac: true,
   }), false);
 });

--- a/components/editor/TextEditorPane.test.tsx
+++ b/components/editor/TextEditorPane.test.tsx
@@ -6,10 +6,12 @@ import { renderToStaticMarkup } from "react-dom/server";
 import {
   canPromoteTextEditor,
   getTextEditorContentStats,
+  isTextEditorCommandWEnabled,
   isTextEditorReadOnly,
   TextEditorPromoteButton,
 } from "./TextEditorPane.tsx";
 import { TooltipProvider } from "../ui/tooltip.tsx";
+import { DEFAULT_KEY_BINDINGS } from "../../domain/models/keyBindings.ts";
 
 const wrap = (child: React.ReactElement) =>
   React.createElement(TooltipProvider, null, child);
@@ -48,4 +50,16 @@ test("renders the promote button disabled while a save is running", () => {
 test("counts editor content without allocating line arrays", () => {
   assert.deepEqual(getTextEditorContentStats(""), { lineCount: 1, charCount: 0 });
   assert.deepEqual(getTextEditorContentStats("one\ntwo\n"), { lineCount: 3, charCount: 8 });
+});
+
+test("Monaco Cmd+W follows the current close-tab binding", () => {
+  const closeTabBinding = DEFAULT_KEY_BINDINGS.find((binding) => binding.action === "closeTab");
+  assert.ok(closeTabBinding);
+
+  assert.equal(isTextEditorCommandWEnabled({ hotkeyScheme: "mac", closeTabBinding }), true);
+  assert.equal(isTextEditorCommandWEnabled({ hotkeyScheme: "disabled", closeTabBinding }), false);
+  assert.equal(isTextEditorCommandWEnabled({
+    hotkeyScheme: "mac",
+    closeTabBinding: { ...closeTabBinding, mac: "⌘ + E" },
+  }), false);
 });

--- a/components/editor/TextEditorPane.tsx
+++ b/components/editor/TextEditorPane.tsx
@@ -21,6 +21,7 @@ const monacoBasePath = viteEnv.DEV
   ? './node_modules/monaco-editor/min/vs'
   : `${viteEnv.BASE_URL}monaco/vs`;
 loader.config({ paths: { vs: monacoBasePath } });
+const isMacPlatform = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform);
 
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { useClipboardBackend } from '../../application/state/useClipboardBackend';
@@ -120,14 +121,15 @@ export function getTextEditorContentStats(content: string): { lineCount: number;
 export function isTextEditorCommandWEnabled({
   hotkeyScheme,
   closeTabBinding,
+  isMac,
 }: {
   hotkeyScheme: HotkeyScheme;
   closeTabBinding?: KeyBinding;
+  isMac: boolean;
 }): boolean {
   if (hotkeyScheme === 'disabled' || !closeTabBinding) return false;
-  const isMac = hotkeyScheme === 'mac';
   return isPrimaryModifierWBinding(
-    isMac ? closeTabBinding.mac : closeTabBinding.pc,
+    hotkeyScheme === 'mac' ? closeTabBinding.mac : closeTabBinding.pc,
     matchesKeyBinding,
     isMac,
   );
@@ -191,7 +193,11 @@ const TextEditorPaneInner: React.FC<TextEditorPaneProps> = ({
     () => keyBindings.find((binding) => binding.action === 'closeTab'),
     [keyBindings],
   );
-  closeTabCommandWEnabledRef.current = isTextEditorCommandWEnabled({ hotkeyScheme, closeTabBinding });
+  closeTabCommandWEnabledRef.current = isTextEditorCommandWEnabled({
+    hotkeyScheme,
+    closeTabBinding,
+    isMac: isMacPlatform,
+  });
 
   const handleSave = useCallback(() => {
     if (saving) return;

--- a/components/editor/TextEditorPane.tsx
+++ b/components/editor/TextEditorPane.tsx
@@ -24,6 +24,7 @@ loader.config({ paths: { vs: monacoBasePath } });
 
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { useClipboardBackend } from '../../application/state/useClipboardBackend';
+import { isPrimaryModifierWBinding } from '../../application/state/windowCommandClose';
 import { HotkeyScheme, KeyBinding, matchesKeyBinding } from '../../domain/models';
 import { pasteForMonacoEditorCommand } from '../../infrastructure/monaco/monacoClipboardPaste';
 import { useNetcattyMonacoTheme } from '../../infrastructure/monaco/useNetcattyMonacoTheme';
@@ -116,6 +117,22 @@ export function getTextEditorContentStats(content: string): { lineCount: number;
   return { lineCount, charCount: content.length };
 }
 
+export function isTextEditorCommandWEnabled({
+  hotkeyScheme,
+  closeTabBinding,
+}: {
+  hotkeyScheme: HotkeyScheme;
+  closeTabBinding?: KeyBinding;
+}): boolean {
+  if (hotkeyScheme === 'disabled' || !closeTabBinding) return false;
+  const isMac = hotkeyScheme === 'mac';
+  return isPrimaryModifierWBinding(
+    isMac ? closeTabBinding.mac : closeTabBinding.pc,
+    matchesKeyBinding,
+    isMac,
+  );
+}
+
 export const TextEditorPromoteButton: React.FC<{
   saving: boolean;
   onPromoteToTab: () => void;
@@ -166,6 +183,7 @@ const TextEditorPaneInner: React.FC<TextEditorPaneProps> = ({
   // Ref to store the latest save function to avoid stale closure in keyboard shortcut
   const handleSaveRef = useRef<() => void>(() => {});
   const handleCloseRef = useRef<(() => void) | null>(null);
+  const closeTabCommandWEnabledRef = useRef(false);
   const handlePasteRef = useRef<() => Promise<void>>(() => Promise.resolve());
   const readClipboardTextRef = useRef<() => Promise<string | null>>(() => Promise.resolve(null));
 
@@ -173,6 +191,7 @@ const TextEditorPaneInner: React.FC<TextEditorPaneProps> = ({
     () => keyBindings.find((binding) => binding.action === 'closeTab'),
     [keyBindings],
   );
+  closeTabCommandWEnabledRef.current = isTextEditorCommandWEnabled({ hotkeyScheme, closeTabBinding });
 
   const handleSave = useCallback(() => {
     if (saving) return;
@@ -268,6 +287,7 @@ const TextEditorPaneInner: React.FC<TextEditorPaneProps> = ({
     // key-event dispatcher fires first for focused editor keystrokes, so
     // registering the command here is the reliable path.
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyW, () => {
+      if (!closeTabCommandWEnabledRef.current) return;
       handleCloseRef.current?.();
     });
 

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -1264,7 +1264,7 @@ function buildAppMenu(Menu, app, isMac, language = currentLanguage, options = {}
         ? menuDeps.setAppLockWindowTitle
         : undefined),
   };
-  const closeFocusedWindow = (_menuItem, browserWindow) => {
+  const closeFocusedWindow = (_menuItem, browserWindow, event) => {
     // Block native Close while app lock is visible so popups/sessions are not
     // torn down behind the overlay (Codex P2 on 79603979).
     try {
@@ -1275,6 +1275,14 @@ function buildAppMenu(Menu, app, isMac, language = currentLanguage, options = {}
     // 只有主窗口/设置窗口会接收 command-close；其他 BrowserWindow 直接关闭。
     if (browserWindow && !isMainWindow(browserWindow) && browserWindow !== settingsWindow) {
       closeBrowserWindow(browserWindow);
+      return;
+    }
+
+    // Selecting Close Window with the mouse remains an explicit window-close
+    // action. Only the menu accelerator is routed through the configurable
+    // close-tab shortcut in the renderer.
+    if (event?.triggeredByAccelerator === false) {
+      closeBrowserWindow(browserWindow || getMainWindow());
       return;
     }
 

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -358,6 +358,9 @@ test("buildAppMenu sends Cmd+W to any registered main window renderer", () => {
   const firstMainWindow = {
     isDestroyed() { return false; },
     on() {},
+    close() {
+      calls.push("first:close");
+    },
     webContents: {
       isDestroyed() { return false; },
       send(channel) {
@@ -383,9 +386,16 @@ test("buildAppMenu sends Cmd+W to any registered main window renderer", () => {
     const windowMenu = capturedTemplate.find((item) => item.label === "Window");
     const closeItem = windowMenu.submenu.find((item) => item.accelerator === "CommandOrControl+W");
 
-    closeItem.click(null, firstMainWindow);
+    closeItem.click(null, firstMainWindow, { triggeredByAccelerator: true });
 
     assert.deepEqual(calls, ["first:netcatty:window:command-close"]);
+
+    closeItem.click(null, firstMainWindow, { triggeredByAccelerator: false });
+
+    assert.deepEqual(calls, [
+      "first:netcatty:window:command-close",
+      "first:close",
+    ]);
   } finally {
     unregisterMainWindow(firstMainWindow);
     unregisterMainWindow(secondMainWindow);


### PR DESCRIPTION
## Summary

Honor the configured Close Tab shortcut on macOS instead of always treating Command+W as a close request.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3113

## Changes Made

- Check the current Close Tab binding before handling the native macOS close accelerator in the main and settings windows.
- Make the editor's own close command follow the same current binding.
- Keep explicit menu clicks and tab close buttons working.
- Forward Command+W from the focused control to another custom action after Close Tab is disabled or rebound.
- Add regression coverage for tabs, dialogs, logs, pinned pages, editor bindings, and menu clicks.

## Screenshots / Demo

Verified in the built macOS app:

- Disabling Close Tab leaves the active terminal and settings window open when Command+W is pressed.
- The tab close button still closes the terminal.
- Restoring the default makes Command+W close the active terminal again.
- Rebinding Close Tab makes the new shortcut close the tab while the old shortcut does not.
- Assigning the freed Command+W to New Local Tab creates a tab without closing the active one.
- Assigning the freed Command+W to Terminal Search opens search while the terminal input is focused.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Focused regression tests: 78 passed.

`npm run build`: passed.

The complete local test run has four unchanged SSH authentication fixture failures under Node 26 (`ERR_PRIVATE_KEY_INVALID`); the focused suites for this change pass.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

