### PR TITLE
fix(terminal): keep Mosh progress until ready

### DIFF
--- a/components/terminal/runtime/createTerminalSessionStarters.mosh.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.mosh.test.ts
@@ -1376,9 +1376,10 @@ test("startMosh defers startup commands until mosh-client is ready", async () =>
 
   await createTerminalSessionStarters(ctx as never).startMosh(term as never);
 
-  // Handshake output dismisses the overlay (connected) but must not send startup input yet.
+  // Ordinary handshake output must not dismiss the connection overlay before
+  // the interactive Mosh client is ready.
   dataCb?.("ssh login banner\r\n", { moshHandshake: true });
-  assert.equal(ctx.hasConnectedRef.current, true);
+  assert.equal(ctx.hasConnectedRef.current, false);
   assert.deepEqual(sent, []);
   assert.ok(readyCb, "expected onMoshSessionReady subscription");
 
@@ -1389,6 +1390,7 @@ test("startMosh defers startup commands until mosh-client is ready", async () =>
 
   readyCb?.({ sessionId: "mosh-session" });
   await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.equal(ctx.hasConnectedRef.current, true);
   assert.ok(sent.some((chunk) => chunk.includes("echo from-snippet")));
 });
 

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -1137,10 +1137,9 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
       // handshake uses an ephemeral SSH PTY first; writing too early lands
       // input on that PTY and is lost on the swap (issue #2199).
       //
-      // Do not gate status=connected on ready: interactive password/OTP
-      // prompts during the SSH handshake need the overlay dismissed so the
-      // user can type into the terminal. Scripts wait on moshShellReady in
-      // Terminal.tsx instead.
+      // Keep the progress overlay until mosh-client is ready. The attachment
+      // path still dismisses it early for an interactive password/OTP prompt
+      // so the user can type into the terminal.
       //
       // Subscribe BEFORE startMoshSession: a fast passwordless handshake can
       // emit ready before the await returns, and the event is not replayed.
@@ -1156,6 +1155,8 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
       const runMoshStartup = () => {
         disposeMoshReady?.();
         disposeMoshReady = undefined;
+        ctx.setIsConnectionAwaitingUserInput?.(false);
+        if (!ctx.hasConnectedRef.current) ctx.updateStatus("connected");
         cancelPendingStartupCommand = scheduleStartupCommand(ctx, term, attachedSessionId, () => {
           cancelPendingStartupCommand = undefined;
         });
@@ -1226,6 +1227,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
         // hibernate detaches exit listeners without closing the session and
         // would otherwise cancel a still-pending startup command.
         onExit: cleanupMoshStartupWait,
+        deferConnectionDuringMoshHandshake: Boolean(ctx.terminalBackend.onMoshSessionReady),
         sudoAutofillPassword: resolveSavedSudoAutofillPassword(),
         sudoAutofillCandidates: resolveSudoAutofillCandidates(),
       })) {

--- a/components/terminal/runtime/createTerminalSessionStarters.types.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.types.ts
@@ -256,6 +256,8 @@ export type TerminalSessionDataMeta = {
   droppedOutputAlternateScreenAction?: 'enter' | 'leave';
   /** True while Mosh is still on the ephemeral SSH handshake PTY. */
   moshHandshake?: boolean;
+  /** The Mosh SSH bootstrap is blocked on input that Netcatty cannot answer automatically. */
+  moshHandshakeRequiresUserInput?: boolean;
   terminalPerf?: NetcattyTerminalOutputPerfMeta;
   /** Original host output units acknowledged even when an interceptor changes display length. */
   pluginPipelineIngressBytes?: number;

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -2450,11 +2450,13 @@ test("attachSessionToTerminal marks connected on metadata-only or visible first 
   assert.equal(ctx.hasConnectedRef.current, true);
 });
 
-test("Mosh handshake stays connecting until ready unless it needs terminal input", () => {
+test("Mosh handshake stays connecting until ready unless the backend needs terminal input", () => {
   const { term } = createFakeTerm();
   const statuses: string[] = [];
-  let onData: ((data: string, meta?: { moshHandshake?: boolean }) => void) | null = null;
-  const passwordPromptActiveRef = { current: false };
+  let onData: ((data: string, meta?: {
+    moshHandshake?: boolean;
+    moshHandshakeRequiresUserInput?: boolean;
+  }) => void) | null = null;
   const ctx = {
     ...createContext(false),
     sessionId: "mosh-session",
@@ -2466,10 +2468,6 @@ test("Mosh handshake stays connecting until ready unless it needs terminal input
     fitAddonRef: { current: null },
     serializeAddonRef: { current: null },
     pendingAuthRef: { current: null },
-    passwordPromptActiveRef,
-    onTerminalOutput: (data: string) => {
-      if (data.includes("Password:")) passwordPromptActiveRef.current = true;
-    },
     terminalBackend: {
       onSessionData: (_id: string, cb: typeof onData) => {
         onData = cb;
@@ -2495,5 +2493,10 @@ test("Mosh handshake stays connecting until ready unless it needs terminal input
   onData?.("login banner\r\n", { moshHandshake: true });
   assert.deepEqual(statuses, []);
   onData?.("Password:", { moshHandshake: true });
+  assert.deepEqual(statuses, []);
+  onData?.("Verification code:", {
+    moshHandshake: true,
+    moshHandshakeRequiresUserInput: true,
+  });
   assert.deepEqual(statuses, ["connected"]);
 });

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -2449,3 +2449,51 @@ test("attachSessionToTerminal marks connected on metadata-only or visible first 
   assert.deepEqual(statuses, ["connected"]);
   assert.equal(ctx.hasConnectedRef.current, true);
 });
+
+test("Mosh handshake stays connecting until ready unless it needs terminal input", () => {
+  const { term } = createFakeTerm();
+  const statuses: string[] = [];
+  let onData: ((data: string, meta?: { moshHandshake?: boolean }) => void) | null = null;
+  const passwordPromptActiveRef = { current: false };
+  const ctx = {
+    ...createContext(false),
+    sessionId: "mosh-session",
+    sessionRef: { current: null as string | null },
+    hasConnectedRef: { current: false },
+    hasRunStartupCommandRef: { current: false },
+    disposeDataRef: { current: null as (() => void) | null },
+    disposeExitRef: { current: null as (() => void) | null },
+    fitAddonRef: { current: null },
+    serializeAddonRef: { current: null },
+    pendingAuthRef: { current: null },
+    passwordPromptActiveRef,
+    onTerminalOutput: (data: string) => {
+      if (data.includes("Password:")) passwordPromptActiveRef.current = true;
+    },
+    terminalBackend: {
+      onSessionData: (_id: string, cb: typeof onData) => {
+        onData = cb;
+        return () => {};
+      },
+      onSessionExit: () => () => {},
+      writeToSession: () => {},
+      resizeSession: () => {},
+      setSessionFlowPaused: () => {},
+      ackSessionFlow: () => {},
+    },
+    updateStatus: (status: string) => {
+      statuses.push(status);
+      if (status === "connected") ctx.hasConnectedRef.current = true;
+    },
+    setError: () => {},
+    onSessionExit: () => {},
+  };
+
+  attachSessionToTerminal(ctx as never, term, "mosh-session", {
+    deferConnectionDuringMoshHandshake: true,
+  });
+  onData?.("login banner\r\n", { moshHandshake: true });
+  assert.deepEqual(statuses, []);
+  onData?.("Password:", { moshHandshake: true });
+  assert.deepEqual(statuses, ["connected"]);
+});

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -838,6 +838,7 @@ export const attachSessionToTerminal = (
     onConnected?: (meta?: TerminalSessionDataMeta) => void;
     onExit?: (evt: TerminalSessionExitEvent) => void;
     requireExplicitConnectionReady?: boolean;
+    deferConnectionDuringMoshHandshake?: boolean;
     convertLfToCrlf?: boolean;
     sudoAutofillPassword?: string;
     sudoAutofillCandidates?: SudoPasswordAutofillCandidate[];
@@ -889,7 +890,7 @@ export const attachSessionToTerminal = (
     if (
       opts?.deferConnectionDuringMoshHandshake === true
       && meta?.moshHandshake === true
-      && ctx.passwordPromptActiveRef?.current !== true
+      && meta?.moshHandshakeRequiresUserInput !== true
     ) {
       return;
     }
@@ -953,9 +954,9 @@ export const attachSessionToTerminal = (
       data = sudoAutofill?.handleOutput(data) ?? data;
       writeSessionData(ctx, term, data, ingressBytes, meta);
       ctx.onTerminalOutput?.(data, meta);
-      // Ordinary transports connect on first visible output. Mosh can defer
-      // that transition until its explicit ready event; an interactive
-      // password/OTP prompt still dismisses the overlay so input is reachable.
+      // Ordinary transports connect on first visible output. Mosh defers that
+      // transition until ready unless its SSH bootstrap explicitly reports
+      // that it is blocked on input Netcatty could not answer automatically.
       markConnectedOnFirstOutput(meta);
     },
     { replayBacklog: true },

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -775,6 +775,7 @@ export const tryAttachSessionToTerminal = (
     onConnected?: (meta?: TerminalSessionDataMeta) => void;
     onExit?: (evt: TerminalSessionExitEvent) => void;
     requireExplicitConnectionReady?: boolean;
+    deferConnectionDuringMoshHandshake?: boolean;
     convertLfToCrlf?: boolean;
     sudoAutofillPassword?: string;
     sudoAutofillCandidates?: SudoPasswordAutofillCandidate[];
@@ -885,6 +886,13 @@ export const attachSessionToTerminal = (
   const markConnectedOnFirstOutput = (meta?: TerminalSessionDataMeta) => {
     const pluginConnectionReady = meta?.pluginConnectionReady === true;
     if (opts?.requireExplicitConnectionReady === true && !pluginConnectionReady) return;
+    if (
+      opts?.deferConnectionDuringMoshHandshake === true
+      && meta?.moshHandshake === true
+      && ctx.passwordPromptActiveRef?.current !== true
+    ) {
+      return;
+    }
     if (ctx.hasConnectedRef.current && !pluginConnectionReady) return;
     if (!ctx.hasConnectedRef.current) {
       ctx.updateStatus("connected");
@@ -945,11 +953,9 @@ export const attachSessionToTerminal = (
       data = sudoAutofill?.handleOutput(data) ?? data;
       writeSessionData(ctx, term, data, ingressBytes, meta);
       ctx.onTerminalOutput?.(data, meta);
-      // Mark connected on first visible output so the connection overlay
-      // dismisses and interactive Mosh handshake prompts (password/OTP)
-      // remain reachable. Startup commands / pending scripts are gated
-      // separately on netcatty:mosh:ready so they do not hit the handshake
-      // PTY (#2199).
+      // Ordinary transports connect on first visible output. Mosh can defer
+      // that transition until its explicit ready event; an interactive
+      // password/OTP prompt still dismisses the overlay so input is reachable.
       markConnectedOnFirstOutput(meta);
     },
     { replayBacklog: true },

--- a/domain/terminalPromptSecurity.shared.cjs
+++ b/domain/terminalPromptSecurity.shared.cjs
@@ -1,0 +1,120 @@
+"use strict";
+
+const ESCAPE_SEQUENCE = "\\x" + "1b";
+const BELL_SEQUENCE = "\\x" + "07";
+const ANSI_CONTROL_PATTERN = new RegExp(`${ESCAPE_SEQUENCE}\\[[0-?]*[ -/]*[@-~]`, "gu");
+const OSC_CONTROL_PATTERN = new RegExp(
+  `${ESCAPE_SEQUENCE}\\][^${BELL_SEQUENCE}]*(?:${BELL_SEQUENCE}|${ESCAPE_SEQUENCE}\\\\)`,
+  "gu",
+);
+const MAX_PROMPT_SECURITY_TAIL_CHARS = 2_048;
+
+const SENSITIVE_ENGLISH_LABEL = [
+  String.raw`pass(?:word|phrase|code)`,
+  String.raw`one[\s-]?time(?:\s+(?:password|passcode|code|token))?`,
+  String.raw`\botp\b`,
+  String.raw`verification(?:\s+(?:code|token|passcode))?`,
+  String.raw`authentication\s+(?:code|token|passcode)`,
+  String.raw`security\s+(?:code|token|passcode|pin)`,
+  String.raw`\bpin\b`,
+  String.raw`\btoken\b`,
+  String.raw`2fa`,
+  String.raw`two[\s-]?factor`,
+  String.raw`multi[\s-]?factor`,
+  String.raw`\bmfa\b`,
+  String.raw`second\s+factor`,
+  String.raw`secondary(?:\s+\w+){0,3}\s+passw(?:ord)?`,
+  String.raw`second(?:\s+\w+){0,3}\s+passw(?:ord)?`,
+  String.raw`additional(?:\s+\w+){0,3}\s+passw(?:ord)?`,
+  String.raw`re[-\s]?enter\s+passw(?:ord)?`,
+  String.raw`confirm\s+passw(?:ord)?`,
+  String.raw`\bedr\b`,
+  String.raw`\bduo\b`,
+].join("|");
+
+const SENSITIVE_CJK_LABEL = [
+  "密码", "口令", "动态", "一次性", "验证码", "验证信息", "令牌", "双因素", "多因素",
+  "短信验证", "手机验证", "二次", "安全密码", "挑战码",
+].join("|");
+
+const SENSITIVE_LABEL_PATTERN = new RegExp(
+  `(?:${SENSITIVE_ENGLISH_LABEL}|${SENSITIVE_CJK_LABEL})`,
+  "iu",
+);
+
+function stripTerminalControlSequences(value) {
+  return String(value || "").replace(OSC_CONTROL_PATTERN, "").replace(ANSI_CONTROL_PATTERN, "");
+}
+
+function lastLogicalLine(value) {
+  const plain = stripTerminalControlSequences(value);
+  const boundary = Math.max(plain.lastIndexOf("\n"), plain.lastIndexOf("\r"));
+  return plain.slice(boundary + 1).slice(-MAX_PROMPT_SECURITY_TAIL_CHARS);
+}
+
+function isSensitiveTerminalChallenge(value) {
+  const line = lastLogicalLine(value).trim();
+  if (!line) return false;
+  const label = SENSITIVE_LABEL_PATTERN.exec(line);
+  if (!label) return false;
+  const prefix = line.slice(0, label.index || 0).trim();
+  const suffix = line.slice((label.index || 0) + label[0].length);
+  if (suffix.trim().length === 0) {
+    return prefix.length === 0
+      || /(?:^|\s)(?:enter|input|provide|type|scan|please|your|current|new|old)\s*$/iu.test(prefix)
+      || /(?:输入|请输入|请)\s*$/u.test(prefix);
+  }
+  if (/^\s+(?:for|of)\s+[^\r\n]{1,96}$/iu.test(suffix)) return true;
+  return /^[^\r\n:：>›»]{0,96}[:：>›»]\s*[^\r\n]{0,1024}$/u.test(suffix);
+}
+
+function isConfirmedTerminalShellPrompt(promptText, options = {}) {
+  const prompt = lastLogicalLine(promptText).trim();
+  if (!prompt || isSensitiveTerminalChallenge(prompt)) return false;
+  if (/[❯❮→➜➤⟩»›]/u.test(prompt)) return true;
+  for (const character of prompt) {
+    const code = character.charCodeAt(0);
+    if (code >= 0xE000 && code <= 0xF8FF) return true;
+  }
+  if (/[$#%]$/u.test(prompt)) return true;
+  if (!prompt.endsWith(">")) return false;
+  if (/^(?:PS\s+)?[A-Za-z]:[\\/].*>$/u.test(prompt)) return true;
+  if (/[@\\/~:]\S*>$/u.test(prompt)) return true;
+  return options.allowHostStyleGreaterThan === true
+    && /^[A-Za-z0-9_.-]+(?:\([^)]{1,128}\))?>$/u.test(prompt);
+}
+
+function isPlausibleShellPromptBody(body) {
+  const trimmed = body.trim();
+  if (!trimmed) return true;
+  if (/@|[/\\~:]/u.test(trimmed)) return true;
+  if (/^(?:bash|zsh|sh|fish|ksh|csh|tcsh|dash)(?:-[\d.]+)?$/iu.test(trimmed)) return true;
+  return /^[a-z0-9_.-]+$/u.test(trimmed);
+}
+
+function hasTypedInputAfterConfirmedPrompt(line, options = {}) {
+  for (let i = 0; i < line.length - 1; i += 1) {
+    const ch = line[i];
+    if (ch !== "$" && ch !== "#" && ch !== "%" && ch !== ">") continue;
+    const rest = line.slice(i + 1);
+    if (!/^\s+\S/u.test(rest)) continue;
+    const candidate = line.slice(0, i + 1);
+    if (!isConfirmedTerminalShellPrompt(candidate, options)) continue;
+    if ((ch === "$" || ch === "#" || ch === "%") && !isPlausibleShellPromptBody(candidate.slice(0, -1))) {
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+
+function isUntrustedTerminalInputPrompt(value, options = {}) {
+  const prompt = lastLogicalLine(value).trim();
+  if (!prompt) return false;
+  if (isSensitiveTerminalChallenge(prompt)) return true;
+  if (!/[:：>›»]\s*$/u.test(prompt)) return false;
+  if (hasTypedInputAfterConfirmedPrompt(prompt, options)) return false;
+  return !isConfirmedTerminalShellPrompt(prompt, options);
+}
+
+module.exports = { isUntrustedTerminalInputPrompt };

--- a/domain/terminalPromptSecurity.ts
+++ b/domain/terminalPromptSecurity.ts
@@ -1,3 +1,5 @@
+import sharedPromptSecurity from './terminalPromptSecurity.shared.cjs';
+
 const ESCAPE_SEQUENCE = "\\x" + "1b";
 const BELL_SEQUENCE = "\\x" + "07";
 const ANSI_CONTROL_PATTERN = new RegExp(`${ESCAPE_SEQUENCE}\\[[0-?]*[ -/]*[@-~]`, 'gu');
@@ -135,52 +137,6 @@ export function shouldUsePluginTerminalCompletionProvider(input: {
 }
 
 /**
- * Body text before a `$` / `#` / `%` terminator that is plausible as a shell
- * PS1 (bare marker, user@host, path, shell-version, or lowercase identity).
- * Rejects English challenge labels that only happen to end with those markers
- * (`Challenge #`, `Account $`).
- */
-function isPlausibleShellPromptBody(body: string): boolean {
-  const trimmed = body.trim();
-  if (!trimmed) return true;
-  if (/@|[/\\~:]/u.test(trimmed)) return true;
-  if (/^(?:bash|zsh|sh|fish|ksh|csh|tcsh|dash)(?:-[\d.]+)?$/iu.test(trimmed)) return true;
-  // Single lowercase identity token: root, ubuntu, pi — not Title-Case labels.
-  return /^[a-z0-9_.-]+$/u.test(trimmed);
-}
-
-/**
- * True when a confirmed shell/device prompt is followed by typed text on the
- * same logical line (e.g. `user@host:~$ lsof -i:`). Trailing `:` / `>` in that
- * typed text is ordinary command input, not an authentication boundary.
- *
- * Requires a real prompt boundary (terminator + whitespace) so mid-label
- * shapes like `Challenge #1:` stay fail-closed. For `$`/`#`/`%`, also requires
- * a plausible PS1 body so `Challenge # 1:` / `Account $ code:` stay untrusted.
- */
-function hasTypedInputAfterConfirmedPrompt(
-  line: string,
-  options: ConfirmedPromptOptions = {},
-): boolean {
-  for (let i = 0; i < line.length - 1; i += 1) {
-    const ch = line[i];
-    // Only terminators that can end a confirmed prompt without relying on a
-    // glyph appearing later in the typed command.
-    if (ch !== '$' && ch !== '#' && ch !== '%' && ch !== '>') continue;
-    const rest = line.slice(i + 1);
-    // Prompt terminators are followed by whitespace before typed input.
-    if (!/^\s+\S/u.test(rest)) continue;
-    const candidate = line.slice(0, i + 1);
-    if (!isConfirmedTerminalShellPrompt(candidate, options)) continue;
-    if ((ch === '$' || ch === '#' || ch === '%') && !isPlausibleShellPromptBody(candidate.slice(0, -1))) {
-      continue;
-    }
-    return true;
-  }
-  return false;
-}
-
-/**
  * Fail closed for prompt-shaped input boundaries that are not positively
  * identified as an ordinary shell/device prompt. This protects custom PAM,
  * bastion, and appliance challenges whose labels contain no known vocabulary.
@@ -189,14 +145,7 @@ export function isUntrustedTerminalInputPrompt(
   value: string,
   options: ConfirmedPromptOptions = {},
 ): boolean {
-  const prompt = lastLogicalLine(value).trim();
-  if (!prompt) return false;
-  if (isSensitiveTerminalChallenge(prompt)) return true;
-  if (!/[:：>›»]\s*$/u.test(prompt)) return false;
-  // Mid-command punctuation after a real shell prompt must keep broadcasting
-  // (#2709). Standalone `Label:` / `Custom>` challenges still fail closed.
-  if (hasTypedInputAfterConfirmedPrompt(prompt, options)) return false;
-  return !isConfirmedTerminalShellPrompt(prompt, options);
+  return sharedPromptSecurity.isUntrustedTerminalInputPrompt(value, options);
 }
 
 export { MAX_PROMPT_SECURITY_TAIL_CHARS };

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -65,6 +65,9 @@ module.exports = {
         // (terminalFlowAck.cjs). Must ship beside electron/ in app.asar.
         'infrastructure/config/terminalFlowConstants.cjs',
         'infrastructure/config/terminalFlowConstants.json',
+        // Renderer and Mosh's main-process bootstrap share the same
+        // fail-closed prompt classifier at runtime.
+        'domain/terminalPromptSecurity.shared.cjs',
         'lib/**/*.cjs',
         'lib/**/*.json',
         'skills/**/*',

--- a/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
+++ b/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
@@ -368,6 +368,26 @@ test("startMoshSession marks the OpenSSH first-host confirmation as interactive"
   assert.equal(prompt.payload.meta?.moshHandshakeRequiresUserInput, true);
 });
 
+test("startMoshSession exposes shared fail-closed keyboard-interactive prompts", async (t) => {
+  const h = makeHarness(t);
+  await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });
+  const prompts = [
+    "Duo two-factor login\r\nPasscode or option (1-1):",
+    "\r\nCustom authentication>",
+    "\r\n验证码：",
+  ];
+
+  for (const text of prompts) {
+    h.spawns[0].emitData(text);
+    await new Promise((resolve) => h.sessions.get("mosh-test-session").flushPendingData(resolve));
+    const prompt = h.sent.find((evt) =>
+      evt.channel === "netcatty:data" && evt.payload?.data?.includes(text.trim()),
+    );
+    assert.ok(prompt, `expected prompt to reach the renderer: ${text}`);
+    assert.equal(prompt.payload.meta?.moshHandshakeRequiresUserInput, true, text);
+  }
+});
+
 test("startMoshSession password-only mode disables public-key authentication", async (t) => {
   const h = makeHarness(t);
   await h.bridge.startMoshSession(
@@ -676,6 +696,7 @@ test("startMoshSession tags handshake output and emits ready after mosh-client s
   );
   assert.ok(handshakeData, "expected handshake data on netcatty:data");
   assert.equal(handshakeData.payload.meta?.moshHandshake, true);
+  assert.notEqual(handshakeData.payload.meta?.moshHandshakeRequiresUserInput, true);
 
   assert.equal(
     h.sent.some((evt) => evt.channel === "netcatty:mosh:ready"),

--- a/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
+++ b/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
@@ -308,8 +308,64 @@ test("startMoshSession writes the saved password when ssh prompts for one", asyn
   );
 
   h.spawns[0].emitData("(alice@example.com) Password:");
+  await new Promise((resolve) => h.sessions.get("mosh-test-session").flushPendingData(resolve));
 
   assert.deepEqual(h.spawns[0].writes, ["saved-secret\r"]);
+  const prompt = h.sent.find((evt) =>
+    evt.channel === "netcatty:data" && evt.payload?.data?.includes("Password:"),
+  );
+  assert.ok(prompt, "expected the saved-password prompt to reach the renderer");
+  assert.notEqual(prompt.payload.meta?.moshHandshakeRequiresUserInput, true);
+});
+
+test("startMoshSession marks a password prompt that has no saved answer as interactive", async (t) => {
+  const h = makeHarness(t);
+  await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });
+
+  h.spawns[0].emitData("(alice@example.com) Password:");
+  await new Promise((resolve) => h.sessions.get("mosh-test-session").flushPendingData(resolve));
+
+  assert.deepEqual(h.spawns[0].writes, []);
+  const prompt = h.sent.find((evt) =>
+    evt.channel === "netcatty:data" && evt.payload?.data?.includes("Password:"),
+  );
+  assert.ok(prompt, "expected the manual password prompt to reach the renderer");
+  assert.equal(prompt.payload.meta?.moshHandshakeRequiresUserInput, true);
+});
+
+test("startMoshSession keeps a saved primary password out of an MFA prompt", async (t) => {
+  const h = makeHarness(t);
+  await h.bridge.startMoshSession(
+    h.event,
+    { ...h.options, password: "saved-secret", requiresMfa: true },
+    { moshClientLookup: h.lookupOpts },
+  );
+
+  h.spawns[0].emitData("Verification code:");
+  await new Promise((resolve) => h.sessions.get("mosh-test-session").flushPendingData(resolve));
+
+  assert.deepEqual(h.spawns[0].writes, []);
+  const prompt = h.sent.find((evt) =>
+    evt.channel === "netcatty:data" && evt.payload?.data?.includes("Verification code:"),
+  );
+  assert.ok(prompt, "expected the MFA prompt to reach the renderer");
+  assert.equal(prompt.payload.meta?.moshHandshakeRequiresUserInput, true);
+});
+
+test("startMoshSession marks the OpenSSH first-host confirmation as interactive", async (t) => {
+  const h = makeHarness(t);
+  await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });
+
+  h.spawns[0].emitData(
+    "Are you sure you want to continue connecting (yes/no/[fingerprint])?",
+  );
+  await new Promise((resolve) => h.sessions.get("mosh-test-session").flushPendingData(resolve));
+
+  const prompt = h.sent.find((evt) =>
+    evt.channel === "netcatty:data" && evt.payload?.data?.includes("continue connecting"),
+  );
+  assert.ok(prompt, "expected the host confirmation prompt to reach the renderer");
+  assert.equal(prompt.payload.meta?.moshHandshakeRequiresUserInput, true);
 });
 
 test("startMoshSession password-only mode disables public-key authentication", async (t) => {
@@ -510,8 +566,14 @@ test("startMoshSession writes the saved passphrase when ssh prompts for the temp
   );
 
   h.spawns[0].emitData("Enter passphrase for key 'mosh-auth-key-1.pem':");
+  await new Promise((resolve) => h.sessions.get("mosh-test-session").flushPendingData(resolve));
 
   assert.deepEqual(h.spawns[0].writes, ["key-passphrase\r"]);
+  const prompt = h.sent.find((evt) =>
+    evt.channel === "netcatty:data" && evt.payload?.data?.includes("passphrase"),
+  );
+  assert.ok(prompt, "expected the saved-passphrase prompt to reach the renderer");
+  assert.notEqual(prompt.payload.meta?.moshHandshakeRequiresUserInput, true);
 });
 
 test("startMoshSession swaps to mosh-client when MOSH CONNECT has no trailing newline", async (t) => {

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -11,6 +11,9 @@ const { createSshConnExecProbe } = require("../ai/sessionShellKind.cjs");
 const { orderSshIdentityNames, SSH_KEY_PATTERN } = require("../sshAuthHelper.cjs");
 const { fanoutSessionExit } = require("../terminalAttachRestore.cjs");
 const {
+  isUntrustedTerminalInputPrompt,
+} = require("../../../domain/terminalPromptSecurity.shared.cjs");
+const {
   buildAuthoritativeKnownHostsContent,
   buildExternalHostKeySshOptions,
   vaultPinsConnectionHosts,
@@ -117,7 +120,7 @@ function createMoshSessionApi(ctx) {
         return passphrasePrompt
           || passwordPrompt
           || isMoshHostKeyConfirmationPrompt(tail)
-          || mfaPrompt;
+          || isUntrustedTerminalInputPrompt(tail);
       };
     }
     

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -78,36 +78,46 @@ function createMoshSessionApi(ctx) {
     function isMoshPasswordPrompt(tail) {
       return /(^|[\r\n]).*password:\s*$/i.test(stripMoshPromptControls(tail));
     }
+
+    function isMoshHostKeyConfirmationPrompt(tail) {
+      return /are you sure you want to continue connecting \(yes\/no(?:\/\[fingerprint\])?\)\?\s*$/i
+        .test(stripMoshPromptControls(tail));
+    }
+
+    function isMoshMfaPrompt(tail) {
+      return /(?:verification code|one[- ]time (?:password|code)|otp|passcode|authentication code|duo passcode|token):\s*$/i
+        .test(stripMoshPromptControls(tail));
+    }
     
     function createMoshSshPasswordResponder(sshPty, password, passphrase) {
-      if (
-        (typeof password !== "string" || password.length === 0) &&
-        (typeof passphrase !== "string" || passphrase.length === 0)
-      ) {
-        return () => {};
-      }
-    
       let answeredPassword = false;
       let answeredPassphrase = false;
       let tail = "";
     
       return (chunk) => {
-        if (answeredPassword && answeredPassphrase) return;
         const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk || "");
-        if (!text) return;
+        if (!text) return false;
     
         tail = (tail + text).slice(-512);
-        if (typeof passphrase === "string" && passphrase.length > 0 && !answeredPassphrase && isMoshPassphrasePrompt(tail)) {
+        const passphrasePrompt = isMoshPassphrasePrompt(tail);
+        const mfaPrompt = isMoshMfaPrompt(tail);
+        const passwordPrompt = !mfaPrompt && isMoshPasswordPrompt(tail);
+        if (typeof passphrase === "string" && passphrase.length > 0 && !answeredPassphrase && passphrasePrompt) {
           answeredPassphrase = true;
           sshPty.write(`${passphrase}\r`);
-          return;
+          return false;
         }
     
-        if (typeof password !== "string" || password.length === 0 || answeredPassword) return;
-        if (!isMoshPasswordPrompt(tail)) return;
-    
-        answeredPassword = true;
-        sshPty.write(`${password}\r`);
+        if (typeof password === "string" && password.length > 0 && !answeredPassword && passwordPrompt) {
+          answeredPassword = true;
+          sshPty.write(`${password}\r`);
+          return false;
+        }
+
+        return passphrasePrompt
+          || passwordPrompt
+          || isMoshHostKeyConfirmationPrompt(tail)
+          || mfaPrompt;
       };
     }
     
@@ -613,8 +623,11 @@ function createMoshSessionApi(ctx) {
         if (visible && (visible.length || (typeof visible === "string" && visible))) {
           const str = Buffer.isBuffer(visible) ? visible.toString("utf8") : visible;
           if (str.length > 0) {
-            respondToPasswordPrompt(str);
-            bufferData(str);
+            const requiresUserInput = respondToPasswordPrompt(str);
+            bufferData(
+              str,
+              requiresUserInput ? { moshHandshakeRequiresUserInput: true } : undefined,
+            );
             sessionLogStreamManager.appendData(sessionId, str);
           }
         }

--- a/scripts/electron-builder-config.test.cjs
+++ b/scripts/electron-builder-config.test.cjs
@@ -29,6 +29,15 @@ test("build.files includes shared terminal flow constants for main process", () 
   );
 });
 
+test("build.files includes the prompt classifier required by Mosh", () => {
+  assert.ok(
+    config.files.includes("domain/terminalPromptSecurity.shared.cjs"),
+    "packaged Mosh bootstrap requires the shared prompt classifier",
+  );
+  const promptSecurity = require("../domain/terminalPromptSecurity.shared.cjs");
+  assert.equal(promptSecurity.isUntrustedTerminalInputPrompt("验证码："), true);
+});
+
 test("unpacked Tool CLI includes capability runtime dependencies", () => {
   assert.ok(
     config.asarUnpack.includes("electron/cli/**/*"),

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -486,6 +486,8 @@ declare global {
           droppedOutputAlternateScreenAction?: "enter" | "leave";
           /** True while Mosh is still on the ephemeral SSH handshake PTY. */
           moshHandshake?: boolean;
+          /** The Mosh SSH bootstrap is blocked on input that Netcatty cannot answer automatically. */
+          moshHandshakeRequiresUserInput?: boolean;
           terminalPerf?: NetcattyTerminalOutputPerfMeta;
           /** Original host output units acknowledged even when an interceptor changes display length. */
           pluginPipelineIngressBytes?: number;


### PR DESCRIPTION
## Summary

Keep the Mosh connection progress visible until the interactive client is actually ready, while still exposing authentication prompts that require the user.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [x] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3117

## Changes Made

- Ignore ordinary SSH bootstrap output when deciding that Mosh is connected.
- Mark connected on the existing Mosh-ready notification.
- Distinguish saved-credential autofill from prompts that really require input.
- Share the existing fail-closed prompt policy across renderer and Mosh bootstrap.
- Include the shared runtime policy in production packages.

## Screenshots / Demo

Regressions cover saved password/passphrase, manual password, OTP, Duo, custom and CJK prompts, first-host confirmation, ordinary banners, ready timing and old-bridge fallback.

## Testing

- [x] Targeted Mosh, attachment, prompt and packaging tests pass (168/168)
- [x] Full lint passes
- [x] Production build passes
- [x] Real macOS package directory contains and loads the shared runtime file
- [ ] Full test suite passes (the same four unrelated SSH tests fail on main)
- [ ] Generated capability tool specs are updated when applicable
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [x] Relevant regression coverage is included
- [x] I have not introduced any breaking changes