### PR TITLE
fix(ai): restore New Chat in persisted workspaces

### DIFF
--- a/application/state/useAIState.newChat.test.tsx
+++ b/application/state/useAIState.newChat.test.tsx
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+
+import { resolveInheritedAIActiveSessionId } from '../../domain/aiWorkspaceScopeInherit.ts';
+import { resolveDisplayedPanelView } from '../../components/ai/aiPanelViewState.ts';
+import type { AISession } from '../../infrastructure/ai/types.ts';
+import { useAISessionsStore } from './aiSessionsStore.ts';
+import { useAIState } from './useAIState.ts';
+
+const SCOPE_KEY = 'workspace:workspace-old';
+const RESTORED_SESSION: AISession = {
+  id: 'chat-old',
+  title: 'Restored chat',
+  agentId: 'catty',
+  scope: {
+    type: 'terminal',
+    targetId: 'terminal-a',
+    hostIds: ['host-a'],
+  },
+  messages: [
+    { id: 'user-1', role: 'user', content: 'old question', timestamp: 1 },
+    { id: 'assistant-1', role: 'assistant', content: 'old answer', timestamp: 2 },
+  ],
+  createdAt: 1,
+  updatedAt: 2,
+};
+
+function NewChatHarness() {
+  const ai = useAIState();
+  const state = useAISessionsStore();
+  const visibleSessionIds = new Set(state.sessions.map((session) => session.id));
+  const inheritedSessionId = resolveInheritedAIActiveSessionId({
+    scopeType: 'workspace',
+    scopeTargetId: 'workspace-old',
+    activeSessionIdMap: state.activeSessionIdMap,
+    memberTerminalIds: ['terminal-a', 'terminal-b'],
+    preferredTerminalId: 'terminal-a',
+    visibleSessionIds,
+  });
+  const view = resolveDisplayedPanelView(
+    state.panelViewByScope[SCOPE_KEY],
+    state.draftsByScope[SCOPE_KEY] != null,
+    state.sessions as AISession[],
+    inheritedSessionId,
+    'workspace',
+  );
+
+  return (
+    <button
+      type="button"
+      data-view={view.mode}
+      data-session={view.mode === 'session' ? view.sessionId : ''}
+      onClick={() => {
+        ai.clearDraftForScope(SCOPE_KEY);
+        ai.updateDraft(SCOPE_KEY, 'catty', () => ({
+          text: '',
+          agentId: 'catty',
+          attachments: [],
+          selectedUserSkillSlugs: [],
+          updatedAt: Date.now(),
+        }));
+        ai.showDraftView(SCOPE_KEY);
+      }}
+    >
+      New Chat
+    </button>
+  );
+}
+
+test('restored workspace enters a blank draft when New Chat is clicked', async () => {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    url: 'http://localhost',
+  });
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: dom.window,
+  });
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: dom.window.document,
+  });
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: dom.window.localStorage,
+  });
+  Object.defineProperty(globalThis, 'CustomEvent', {
+    configurable: true,
+    value: dom.window.CustomEvent,
+  });
+  Object.defineProperty(globalThis, 'Event', {
+    configurable: true,
+    value: dom.window.Event,
+  });
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+    configurable: true,
+    value: true,
+  });
+
+  dom.window.localStorage.setItem('netcatty_ai_sessions_v1', JSON.stringify([RESTORED_SESSION]));
+  dom.window.localStorage.setItem('netcatty_ai_active_session_map_v1', JSON.stringify({
+    'terminal:terminal-a': RESTORED_SESSION.id,
+    [SCOPE_KEY]: RESTORED_SESSION.id,
+  }));
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(<NewChatHarness />);
+  });
+
+  const button = container.querySelector('button');
+  assert.ok(button);
+  assert.equal(button.dataset.view, 'session');
+  assert.equal(button.dataset.session, RESTORED_SESSION.id);
+
+  await act(async () => {
+    button.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+  });
+
+  assert.equal(button.dataset.view, 'draft');
+  assert.equal(button.dataset.session, '');
+
+  await act(async () => root.unmount());
+  container.remove();
+  dom.window.close();
+});

--- a/application/state/useAIState.ts
+++ b/application/state/useAIState.ts
@@ -951,34 +951,25 @@ export function useAIState() {
   }, []);
 
   const showDraftView = useCallback((scopeKey: string) => {
-    const currentPanelViewByScope = panelViewByScope;
-    let nextActiveSessionIdMap: Record<string, string | null> | null = null;
-    let nextPanelViewByScope: PanelViewByScope | null = null;
-    let activeSessionMapChanged = false;
-    let panelViewChanged = false;
+    const currentActiveSessionIdMap = latestAIActiveSessionMapSnapshot
+      ?? localStorageAdapter.read<Record<string, string | null>>(STORAGE_KEY_AI_ACTIVE_SESSION_MAP)
+      ?? {};
+    const next = activateDraftView(
+      currentActiveSessionIdMap,
+      panelViewByScope,
+      scopeKey,
+    );
 
-    setActiveSessionIdMapRaw((prevActiveSessionIdMap) => {
-      const next = activateDraftView(
-        prevActiveSessionIdMap,
-        currentPanelViewByScope,
-        scopeKey,
-      );
-      activeSessionMapChanged = next.activeSessionIdMap !== prevActiveSessionIdMap;
-      panelViewChanged = next.panelViewByScope !== currentPanelViewByScope;
-      nextActiveSessionIdMap = next.activeSessionIdMap;
-      nextPanelViewByScope = next.panelViewByScope;
-      return activeSessionMapChanged ? next.activeSessionIdMap : prevActiveSessionIdMap;
-    });
-
-    if (activeSessionMapChanged && nextActiveSessionIdMap) {
-      setLatestAIActiveSessionMapSnapshot(nextActiveSessionIdMap);
-      localStorageAdapter.write(STORAGE_KEY_AI_ACTIVE_SESSION_MAP, nextActiveSessionIdMap);
+    if (next.activeSessionIdMap !== currentActiveSessionIdMap) {
+      setLatestAIActiveSessionMapSnapshot(next.activeSessionIdMap);
+      localStorageAdapter.write(STORAGE_KEY_AI_ACTIVE_SESSION_MAP, next.activeSessionIdMap);
+      setActiveSessionIdMapRaw(next.activeSessionIdMap);
       emitAIStateChanged(STORAGE_KEY_AI_ACTIVE_SESSION_MAP);
     }
 
-    if (panelViewChanged && nextPanelViewByScope) {
-      setLatestAIPanelViewByScopeSnapshot(nextPanelViewByScope);
-      setPanelViewByScopeRaw(nextPanelViewByScope);
+    if (next.panelViewByScope !== panelViewByScope) {
+      setLatestAIPanelViewByScopeSnapshot(next.panelViewByScope);
+      setPanelViewByScopeRaw(next.panelViewByScope);
       emitAIStateChanged(AI_STATE_CHANGED_PANEL_VIEW_BY_SCOPE);
     }
   }, [panelViewByScope]);


### PR DESCRIPTION
## Summary

Fixes restored multi-session workspaces staying on the previous AI chat after the user clicks New Chat.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3123

## Changes Made

- Apply the active-chat and draft-view transition from the latest stored state instead of depending on a deferred React state callback.
- Add a regression test for a restored workspace that inherits an older chat from one of its terminal sessions.

## Screenshots / Demo

The regression test restores the affected workspace state, confirms the old chat is initially visible, clicks New Chat through the public hook API, and confirms the panel enters a blank draft.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Focused coverage passes: 61/61 tests, including the restored-workspace regression. `npm run build` also passes.

The PR's full CI run has four failures in pre-existing SSH authentication tests. The latest `main` run fails the same four tests with the same error: https://github.com/binaricat/Netcatty/actions/runs/32693822687

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
