### PR TITLE
[Bug] Fix terminal loading in development

### DIFF
--- a/domain/terminalPromptSecurity.test.ts
+++ b/domain/terminalPromptSecurity.test.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
@@ -8,6 +9,11 @@ import {
   isUntrustedTerminalInputPrompt,
   shouldUsePluginTerminalCompletionProvider,
 } from './terminalPromptSecurity.ts';
+
+const require = createRequire(import.meta.url);
+const sharedPromptSecurity = require('./terminalPromptSecurity.shared.cjs') as {
+  isUntrustedTerminalInputPrompt: typeof isUntrustedTerminalInputPrompt;
+};
 
 test('terminal prompt security recognizes password, MFA, OTP, PIN, and CJK challenges', () => {
   const challenges = [
@@ -114,4 +120,25 @@ test('ordinary shell commands ending with a colon are not untrusted input prompt
   assert.equal(isUntrustedTerminalInputPrompt('Please authenticate: '), true);
   assert.equal(isUntrustedTerminalInputPrompt('Token: '), true);
   assert.equal(isUntrustedTerminalInputPrompt('Password: '), true);
+});
+
+test('renderer and main-process prompt classifiers stay aligned', () => {
+  const cases: Array<[
+    string,
+    { allowHostStyleGreaterThan?: boolean } | undefined,
+    boolean,
+  ]> = [
+    ['Custom authentication> ', undefined, true],
+    ['Please authenticate: ', undefined, true],
+    ['alice@host:~$ ', undefined, false],
+    ['user@host:~$ lsof -i:', undefined, false],
+    ['Challenge # 1:', undefined, true],
+    ['router> show ip:', { allowHostStyleGreaterThan: true }, false],
+    ['router> show ip:', undefined, true],
+  ];
+
+  for (const [prompt, options, expected] of cases) {
+    assert.equal(isUntrustedTerminalInputPrompt(prompt, options), expected, prompt);
+    assert.equal(sharedPromptSecurity.isUntrustedTerminalInputPrompt(prompt, options), expected, prompt);
+  }
 });

--- a/domain/terminalPromptSecurity.ts
+++ b/domain/terminalPromptSecurity.ts
@@ -1,5 +1,3 @@
-import sharedPromptSecurity from './terminalPromptSecurity.shared.cjs';
-
 const ESCAPE_SEQUENCE = "\\x" + "1b";
 const BELL_SEQUENCE = "\\x" + "07";
 const ANSI_CONTROL_PATTERN = new RegExp(`${ESCAPE_SEQUENCE}\\[[0-?]*[ -/]*[@-~]`, 'gu');
@@ -137,6 +135,52 @@ export function shouldUsePluginTerminalCompletionProvider(input: {
 }
 
 /**
+ * Body text before a `$` / `#` / `%` terminator that is plausible as a shell
+ * PS1 (bare marker, user@host, path, shell-version, or lowercase identity).
+ * Rejects English challenge labels that only happen to end with those markers
+ * (`Challenge #`, `Account $`).
+ */
+function isPlausibleShellPromptBody(body: string): boolean {
+  const trimmed = body.trim();
+  if (!trimmed) return true;
+  if (/@|[/\\~:]/u.test(trimmed)) return true;
+  if (/^(?:bash|zsh|sh|fish|ksh|csh|tcsh|dash)(?:-[\d.]+)?$/iu.test(trimmed)) return true;
+  // Single lowercase identity token: root, ubuntu, pi — not Title-Case labels.
+  return /^[a-z0-9_.-]+$/u.test(trimmed);
+}
+
+/**
+ * True when a confirmed shell/device prompt is followed by typed text on the
+ * same logical line (e.g. `user@host:~$ lsof -i:`). Trailing `:` / `>` in that
+ * typed text is ordinary command input, not an authentication boundary.
+ *
+ * Requires a real prompt boundary (terminator + whitespace) so mid-label
+ * shapes like `Challenge #1:` stay fail-closed. For `$`/`#`/`%`, also requires
+ * a plausible PS1 body so `Challenge # 1:` / `Account $ code:` stay untrusted.
+ */
+function hasTypedInputAfterConfirmedPrompt(
+  line: string,
+  options: ConfirmedPromptOptions = {},
+): boolean {
+  for (let i = 0; i < line.length - 1; i += 1) {
+    const ch = line[i];
+    // Only terminators that can end a confirmed prompt without relying on a
+    // glyph appearing later in the typed command.
+    if (ch !== '$' && ch !== '#' && ch !== '%' && ch !== '>') continue;
+    const rest = line.slice(i + 1);
+    // Prompt terminators are followed by whitespace before typed input.
+    if (!/^\s+\S/u.test(rest)) continue;
+    const candidate = line.slice(0, i + 1);
+    if (!isConfirmedTerminalShellPrompt(candidate, options)) continue;
+    if ((ch === '$' || ch === '#' || ch === '%') && !isPlausibleShellPromptBody(candidate.slice(0, -1))) {
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+
+/**
  * Fail closed for prompt-shaped input boundaries that are not positively
  * identified as an ordinary shell/device prompt. This protects custom PAM,
  * bastion, and appliance challenges whose labels contain no known vocabulary.
@@ -145,7 +189,14 @@ export function isUntrustedTerminalInputPrompt(
   value: string,
   options: ConfirmedPromptOptions = {},
 ): boolean {
-  return sharedPromptSecurity.isUntrustedTerminalInputPrompt(value, options);
+  const prompt = lastLogicalLine(value).trim();
+  if (!prompt) return false;
+  if (isSensitiveTerminalChallenge(prompt)) return true;
+  if (!/[:：>›»]\s*$/u.test(prompt)) return false;
+  // Mid-command punctuation after a real shell prompt must keep broadcasting
+  // (#2709). Standalone `Label:` / `Custom>` challenges still fail closed.
+  if (hasTypedInputAfterConfirmedPrompt(prompt, options)) return false;
+  return !isConfirmedTerminalShellPrompt(prompt, options);
 }
 
 export { MAX_PROMPT_SECURITY_TAIL_CHARS };


### PR DESCRIPTION
## Summary

Fixes the terminal screen failing to load in development because the renderer imported a CommonJS-only prompt security module directly.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Keep the renderer prompt classifier in browser-compatible source.
- Add coverage to keep renderer and main-process prompt classification behavior aligned.

## Screenshots / Demo

Before: opening the terminal in development failed with a missing default export error.

After: the Vite development server loads the terminal prompt security module normally.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Validation details:

- Vite development module load: passed
- Prompt security and packaging tests: 30/30 passed
- Mosh handshake tests: 31/31 passed
- Production build: passed
- Full suite: 10,660 passed, 4 failed, 12 skipped. The same four SSH key fixture failures reproduce unchanged on `main`.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation (not needed for this fix)
- [x] I have not introduced any breaking changes (or I have described them above)
