### PR TITLE
fix(ssh): keep Copy Tab reuse through longer bastion limits

### DIFF
--- a/electron/bridges/boundedSshChannelOpen.cjs
+++ b/electron/bridges/boundedSshChannelOpen.cjs
@@ -88,20 +88,30 @@ function openBoundedSshChannel(sshClient, invoke, options = {}) {
 
   return new Promise((resolve, reject) => {
     let settled = false;
+    let invoked = false;
+    let abandoned = false;
     let timer = null;
     const cleanup = () => {
       if (timer) clearTimeoutFn(timer);
       timer = null;
       signal?.removeEventListener?.("abort", onAbort);
     };
-    const finish = (error, result, { invalidate = false } = {}) => {
+    const finish = (error, result, { invalidate = false, abandon = false } = {}) => {
       if (settled) {
         if (result) closeLateResult(result);
+        if (abandoned) {
+          abandoned = false;
+          try { options.onAbandonedOpenSettled?.(); } catch { /* ignore */ }
+        }
         return false;
       }
       settled = true;
       cleanup();
       if (error && result) closeLateResult(result);
+      if (abandon && invoked) {
+        abandoned = true;
+        try { options.onAbandonedOpen?.(); } catch { /* ignore */ }
+      }
       if (invalidate) invalidateSshTransport(sshClient);
       if (error) reject(error);
       else resolve(result);
@@ -110,7 +120,7 @@ function openBoundedSshChannel(sshClient, invoke, options = {}) {
     const onAbort = () => finish(
       channelAbortError(signal, label),
       null,
-      { invalidate: invalidateOnAbort },
+      { invalidate: invalidateOnAbort, abandon: !invalidateOnAbort },
     );
 
     if (signal?.aborted) {
@@ -124,10 +134,14 @@ function openBoundedSshChannel(sshClient, invoke, options = {}) {
     timer = setTimeoutFn(() => {
       const error = new Error(`${label} timed out after ${timeoutMs} ms`);
       error.code = timeoutCode;
-      finish(error, null, { invalidate: invalidateOnTimeout });
+      finish(error, null, {
+        invalidate: invalidateOnTimeout,
+        abandon: !invalidateOnTimeout,
+      });
     }, timeoutMs);
 
     try {
+      invoked = true;
       invoke((error, result) => finish(error, result));
     } catch (error) {
       finish(error);

--- a/electron/bridges/boundedSshChannelOpen.cjs
+++ b/electron/bridges/boundedSshChannelOpen.cjs
@@ -21,6 +21,13 @@ function channelAbortError(signal, label) {
   return error;
 }
 
+function monotonicNow() {
+  if (typeof performance !== "undefined" && typeof performance.now === "function") {
+    return performance.now();
+  }
+  return Date.now();
+}
+
 /**
  * Bastion / jump hosts sometimes reject rapid session channel opens with a
  * distinctive rate-limit message. The common Chinese bastion typo "offen"
@@ -32,9 +39,37 @@ function isSshChannelOpenRateLimitedError(error) {
     || /channelOpen\s+too\s+often\b/i.test(message);
 }
 
-function sleep(ms, sleepFn = null) {
-  if (typeof sleepFn === "function") return Promise.resolve(sleepFn(ms));
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep(ms, sleepFn = null, signal = null, label = "SSH channel retry") {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let timer = null;
+    const cleanup = () => {
+      if (timer) clearTimeout(timer);
+      timer = null;
+      signal?.removeEventListener?.("abort", onAbort);
+    };
+    const finish = (error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (error) reject(error);
+      else resolve();
+    };
+    const onAbort = () => finish(channelAbortError(signal, label));
+
+    if (signal?.aborted) {
+      finish(channelAbortError(signal, label));
+      return;
+    }
+    signal?.addEventListener?.("abort", onAbort, { once: true });
+    if (typeof sleepFn === "function") {
+      void Promise.resolve()
+        .then(() => sleepFn(ms))
+        .then(() => finish(), (error) => finish(error));
+      return;
+    }
+    timer = setTimeout(() => finish(), ms);
+  });
 }
 
 function openBoundedSshChannel(sshClient, invoke, options = {}) {
@@ -46,6 +81,7 @@ function openBoundedSshChannel(sshClient, invoke, options = {}) {
   const signal = options.signal || null;
   const closeLateResult = options.closeLateResult || closeLateChannel;
   const timeoutCode = options.timeoutCode || "SSH_CHANNEL_OPEN_TIMEOUT";
+  const invalidateOnAbort = options.invalidateOnAbort !== false;
   const setTimeoutFn = options.setTimeoutFn || setTimeout;
   const clearTimeoutFn = options.clearTimeoutFn || clearTimeout;
 
@@ -70,7 +106,11 @@ function openBoundedSshChannel(sshClient, invoke, options = {}) {
       else resolve(result);
       return true;
     };
-    const onAbort = () => finish(channelAbortError(signal, label), null, { invalidate: true });
+    const onAbort = () => finish(
+      channelAbortError(signal, label),
+      null,
+      { invalidate: invalidateOnAbort },
+    );
 
     if (signal?.aborted) {
       finish(channelAbortError(signal, label));
@@ -113,35 +153,65 @@ async function openBoundedSshShell(sshClient, windowOptions, shellOptions, optio
     Number(options.rateLimitBackoffMs) || DEFAULT_SSH_CHANNEL_OPEN_RATE_LIMIT_BACKOFF_MS,
   );
   const sleepFn = options.sleepFn || null;
-  const nowFn = typeof options.nowFn === "function" ? options.nowFn : Date.now;
+  const nowFn = typeof options.nowFn === "function" ? options.nowFn : monotonicNow;
   const retryStartedAt = nowFn();
+  const retryDeadline = rateLimitRetryTimeoutMs === null
+    ? null
+    : retryStartedAt + rateLimitRetryTimeoutMs;
   let attempt = 0;
+  let lastRateLimitError = null;
 
   for (;;) {
+    const attemptStartedAt = nowFn();
+    if (
+      lastRateLimitError
+      && retryDeadline !== null
+      && attemptStartedAt >= retryDeadline
+    ) {
+      throw lastRateLimitError;
+    }
+    const configuredAttemptTimeoutMs = Math.max(
+      1,
+      Number(options.timeoutMs) || DEFAULT_SSH_CHANNEL_OPEN_TIMEOUT_MS,
+    );
+    const attemptTimeoutMs = retryDeadline === null
+      ? configuredAttemptTimeoutMs
+      : Math.max(
+          1,
+          Math.min(configuredAttemptTimeoutMs, Math.ceil(retryDeadline - attemptStartedAt)),
+        );
     try {
       return await openBoundedSshChannel(
         sshClient,
         (callback) => sshClient.shell(windowOptions, shellOptions, callback),
         {
           ...options,
+          timeoutMs: attemptTimeoutMs,
           label: options.label || "SSH shell channel open",
           timeoutCode: "SSH_SHELL_OPEN_TIMEOUT",
         },
       );
     } catch (error) {
+      if (!isSshChannelOpenRateLimitedError(error) || options.signal?.aborted) {
+        throw error;
+      }
+      lastRateLimitError = error;
       const nextDelayMs = rateLimitBackoffMs * (attempt + 1);
       const retryTimeoutExpired = rateLimitRetryTimeoutMs !== null
-        && nowFn() - retryStartedAt + nextDelayMs > rateLimitRetryTimeoutMs;
+        && nowFn() + nextDelayMs >= retryDeadline;
       if (
         attempt >= rateLimitRetries
         || retryTimeoutExpired
-        || !isSshChannelOpenRateLimitedError(error)
-        || options.signal?.aborted
       ) {
         throw error;
       }
       attempt += 1;
-      await sleep(nextDelayMs, sleepFn);
+      await sleep(
+        nextDelayMs,
+        sleepFn,
+        options.signal,
+        options.label || "SSH shell channel retry",
+      );
     }
   }
 }

--- a/electron/bridges/boundedSshChannelOpen.cjs
+++ b/electron/bridges/boundedSshChannelOpen.cjs
@@ -82,6 +82,7 @@ function openBoundedSshChannel(sshClient, invoke, options = {}) {
   const closeLateResult = options.closeLateResult || closeLateChannel;
   const timeoutCode = options.timeoutCode || "SSH_CHANNEL_OPEN_TIMEOUT";
   const invalidateOnAbort = options.invalidateOnAbort !== false;
+  const invalidateOnTimeout = options.invalidateOnTimeout !== false;
   const setTimeoutFn = options.setTimeoutFn || setTimeout;
   const clearTimeoutFn = options.clearTimeoutFn || clearTimeout;
 
@@ -123,7 +124,7 @@ function openBoundedSshChannel(sshClient, invoke, options = {}) {
     timer = setTimeoutFn(() => {
       const error = new Error(`${label} timed out after ${timeoutMs} ms`);
       error.code = timeoutCode;
-      finish(error, null, { invalidate: true });
+      finish(error, null, { invalidate: invalidateOnTimeout });
     }, timeoutMs);
 
     try {
@@ -174,12 +175,15 @@ async function openBoundedSshShell(sshClient, windowOptions, shellOptions, optio
       1,
       Number(options.timeoutMs) || DEFAULT_SSH_CHANNEL_OPEN_TIMEOUT_MS,
     );
-    const attemptTimeoutMs = retryDeadline === null
+    const isRateLimitRetry = lastRateLimitError !== null;
+    const attemptTimeoutMs = retryDeadline === null || !isRateLimitRetry
       ? configuredAttemptTimeoutMs
       : Math.max(
           1,
           Math.min(configuredAttemptTimeoutMs, Math.ceil(retryDeadline - attemptStartedAt)),
         );
+    const retryBudgetConstrainsAttempt = isRateLimitRetry
+      && attemptTimeoutMs < configuredAttemptTimeoutMs;
     try {
       return await openBoundedSshChannel(
         sshClient,
@@ -187,11 +191,21 @@ async function openBoundedSshShell(sshClient, windowOptions, shellOptions, optio
         {
           ...options,
           timeoutMs: attemptTimeoutMs,
+          invalidateOnTimeout: retryBudgetConstrainsAttempt
+            ? false
+            : options.invalidateOnTimeout,
           label: options.label || "SSH shell channel open",
           timeoutCode: "SSH_SHELL_OPEN_TIMEOUT",
         },
       );
     } catch (error) {
+      if (
+        retryBudgetConstrainsAttempt
+        && error?.code === "SSH_SHELL_OPEN_TIMEOUT"
+        && lastRateLimitError
+      ) {
+        throw lastRateLimitError;
+      }
       if (!isSshChannelOpenRateLimitedError(error) || options.signal?.aborted) {
         throw error;
       }

--- a/electron/bridges/boundedSshChannelOpen.cjs
+++ b/electron/bridges/boundedSshChannelOpen.cjs
@@ -95,17 +95,26 @@ function openBoundedSshChannel(sshClient, invoke, options = {}) {
 }
 
 async function openBoundedSshShell(sshClient, windowOptions, shellOptions, options = {}) {
+  const hasRateLimitRetryTimeout = Number.isFinite(options.rateLimitRetryTimeoutMs);
+  const hasExplicitRateLimitRetries = Number.isFinite(options.rateLimitRetries);
   const rateLimitRetries = Math.max(
     0,
-    Number.isFinite(options.rateLimitRetries)
+    hasExplicitRateLimitRetries
       ? Number(options.rateLimitRetries)
-      : DEFAULT_SSH_CHANNEL_OPEN_RATE_LIMIT_RETRIES,
+      : hasRateLimitRetryTimeout
+        ? Number.POSITIVE_INFINITY
+        : DEFAULT_SSH_CHANNEL_OPEN_RATE_LIMIT_RETRIES,
   );
+  const rateLimitRetryTimeoutMs = hasRateLimitRetryTimeout
+    ? Math.max(0, Number(options.rateLimitRetryTimeoutMs))
+    : null;
   const rateLimitBackoffMs = Math.max(
     1,
     Number(options.rateLimitBackoffMs) || DEFAULT_SSH_CHANNEL_OPEN_RATE_LIMIT_BACKOFF_MS,
   );
   const sleepFn = options.sleepFn || null;
+  const nowFn = typeof options.nowFn === "function" ? options.nowFn : Date.now;
+  const retryStartedAt = nowFn();
   let attempt = 0;
 
   for (;;) {
@@ -120,15 +129,19 @@ async function openBoundedSshShell(sshClient, windowOptions, shellOptions, optio
         },
       );
     } catch (error) {
+      const nextDelayMs = rateLimitBackoffMs * (attempt + 1);
+      const retryTimeoutExpired = rateLimitRetryTimeoutMs !== null
+        && nowFn() - retryStartedAt + nextDelayMs > rateLimitRetryTimeoutMs;
       if (
         attempt >= rateLimitRetries
+        || retryTimeoutExpired
         || !isSshChannelOpenRateLimitedError(error)
         || options.signal?.aborted
       ) {
         throw error;
       }
       attempt += 1;
-      await sleep(rateLimitBackoffMs * attempt, sleepFn);
+      await sleep(nextDelayMs, sleepFn);
     }
   }
 }

--- a/electron/bridges/boundedSshChannelOpen.test.cjs
+++ b/electron/bridges/boundedSshChannelOpen.test.cjs
@@ -12,9 +12,12 @@ const {
 
 function trackedTimerApi() {
   const active = new Set();
+  const delays = [];
   return {
     active,
+    delays,
     setTimeoutFn(callback, delay) {
+      delays.push(delay);
       let timer;
       timer = setTimeout(() => {
         active.delete(timer);
@@ -107,6 +110,25 @@ test("channel open keeps its deadline referenced and clears it after success", a
   assert.equal(getEventListeners(controller.signal, "abort").length, 0);
 });
 
+test("shell open caps each attempt to the remaining rate-limit retry window", async () => {
+  const timers = trackedTimerApi();
+  const controller = new AbortController();
+  const client = {
+    shell() {},
+  };
+  const pending = openBoundedSshShell(client, {}, {}, {
+    signal: controller.signal,
+    timeoutMs: 1_000,
+    rateLimitRetryTimeoutMs: 5,
+    nowFn: () => 0,
+    ...timers,
+  });
+
+  assert.equal(timers.delays[0], 5);
+  controller.abort(new Error("cancelled"));
+  await assert.rejects(pending, /cancelled/);
+});
+
 test("detects bastion channelOpen rate-limit errors including the offen typo", () => {
   assert.equal(
     isSshChannelOpenRateLimitedError(
@@ -167,7 +189,7 @@ test("shell open can use a bounded retry window for variable bastion cooldowns",
   };
 
   const stream = await openBoundedSshShell(client, {}, {}, {
-    rateLimitRetryTimeoutMs: 10,
+    rateLimitRetryTimeoutMs: 11,
     rateLimitBackoffMs: 1,
     nowFn: () => elapsedMs,
     sleepFn: async (ms) => {
@@ -209,7 +231,31 @@ test("shell open stops retrying when the bastion retry window is exhausted", asy
   assert.deepEqual(delays, [2]);
 });
 
+test("shell open does not start another attempt after a delayed retry wakes past the deadline", async () => {
+  let elapsedMs = 0;
+  let attempts = 0;
+  const client = {
+    shell(_window, _options, next) {
+      attempts += 1;
+      next(new Error("(SSH) Channel open failure: channelOpen too offen type=session"));
+    },
+  };
+
+  await assert.rejects(
+    openBoundedSshShell(client, {}, {}, {
+      rateLimitRetryTimeoutMs: 5,
+      rateLimitBackoffMs: 1,
+      nowFn: () => elapsedMs,
+      sleepFn: async () => { elapsedMs = 10; },
+    }),
+    /channelOpen too offen/,
+  );
+
+  assert.equal(attempts, 1);
+});
+
 test("shell open does not retry unrelated channel open failures", async () => {
+  const delays = [];
   let attempts = 0;
   const client = {
     shell(_window, _options, next) {
@@ -220,11 +266,12 @@ test("shell open does not retry unrelated channel open failures", async () => {
 
   await assert.rejects(
     openBoundedSshShell(client, {}, {}, {
-      rateLimitRetries: 3,
+      rateLimitRetryTimeoutMs: 10,
       rateLimitBackoffMs: 5,
-      sleepFn: async () => {},
+      sleepFn: async (ms) => { delays.push(ms); },
     }),
     /administratively prohibited/,
   );
   assert.equal(attempts, 1);
+  assert.deepEqual(delays, []);
 });

--- a/electron/bridges/boundedSshChannelOpen.test.cjs
+++ b/electron/bridges/boundedSshChannelOpen.test.cjs
@@ -172,11 +172,16 @@ test("a retry-budget timeout preserves the transport and returns the rate-limit 
   let attempts = 0;
   let invalidations = 0;
   let elapsedMs = 0;
+  let lateCallback = null;
+  let abandoned = 0;
+  let abandonedSettled = 0;
   const client = {
     shell(_window, _options, next) {
       attempts += 1;
       if (attempts === 1) {
         next(new Error("(SSH) Channel open failure: channelOpen too offen type=session"));
+      } else {
+        lateCallback = next;
       }
     },
     destroy() { invalidations += 1; },
@@ -197,12 +202,23 @@ test("a retry-budget timeout preserves the transport and returns the rate-limit 
         return { unref() {} };
       },
       clearTimeoutFn() {},
+      onAbandonedOpen: () => { abandoned += 1; },
+      onAbandonedOpenSettled: () => { abandonedSettled += 1; },
     }),
     /channelOpen too offen/,
   );
 
   assert.equal(attempts, 2);
   assert.equal(invalidations, 0);
+  assert.equal(abandoned, 1);
+  assert.equal(abandonedSettled, 0);
+
+  const lateStream = new EventEmitter();
+  lateStream.closed = 0;
+  lateStream.close = () => { lateStream.closed += 1; };
+  lateCallback(null, lateStream);
+  assert.equal(lateStream.closed, 1);
+  assert.equal(abandonedSettled, 1);
 });
 
 test("detects bastion channelOpen rate-limit errors including the offen typo", () => {

--- a/electron/bridges/boundedSshChannelOpen.test.cjs
+++ b/electron/bridges/boundedSshChannelOpen.test.cjs
@@ -151,6 +151,64 @@ test("shell open retries bastion rate-limit failures with short backoff", async 
   assert.deepEqual(delays, [5, 10]);
 });
 
+test("shell open can use a bounded retry window for variable bastion cooldowns", async () => {
+  const delays = [];
+  let elapsedMs = 0;
+  let attempts = 0;
+  const client = {
+    shell(_window, _options, next) {
+      attempts += 1;
+      if (attempts <= 4) {
+        next(new Error("(SSH) Channel open failure: channelOpen too offen type=session"));
+        return;
+      }
+      next(null, new EventEmitter());
+    },
+  };
+
+  const stream = await openBoundedSshShell(client, {}, {}, {
+    rateLimitRetryTimeoutMs: 10,
+    rateLimitBackoffMs: 1,
+    nowFn: () => elapsedMs,
+    sleepFn: async (ms) => {
+      delays.push(ms);
+      elapsedMs += ms;
+    },
+  });
+
+  assert.ok(stream);
+  assert.equal(attempts, 5);
+  assert.deepEqual(delays, [1, 2, 3, 4]);
+});
+
+test("shell open stops retrying when the bastion retry window is exhausted", async () => {
+  const delays = [];
+  let elapsedMs = 0;
+  let attempts = 0;
+  const client = {
+    shell(_window, _options, next) {
+      attempts += 1;
+      next(new Error("(SSH) Channel open failure: channelOpen too offen type=session"));
+    },
+  };
+
+  await assert.rejects(
+    openBoundedSshShell(client, {}, {}, {
+      rateLimitRetryTimeoutMs: 5,
+      rateLimitBackoffMs: 2,
+      nowFn: () => elapsedMs,
+      sleepFn: async (ms) => {
+        delays.push(ms);
+        elapsedMs += ms;
+      },
+    }),
+    /channelOpen too offen/,
+  );
+
+  assert.equal(attempts, 2);
+  assert.deepEqual(delays, [2]);
+});
+
 test("shell open does not retry unrelated channel open failures", async () => {
   let attempts = 0;
   const client = {

--- a/electron/bridges/boundedSshChannelOpen.test.cjs
+++ b/electron/bridges/boundedSshChannelOpen.test.cjs
@@ -88,6 +88,34 @@ test("cancelled channel open invalidates transport and a late stream is closed",
   assert.equal(timers.active.size, 0);
 });
 
+test("non-invalidating cancellation reports an abandoned open until its callback settles", async () => {
+  let callback;
+  let abandoned = 0;
+  let abandonedSettled = 0;
+  const controller = new AbortController();
+  const client = {
+    shell(_window, _options, next) { callback = next; },
+  };
+  const pending = openBoundedSshShell(client, {}, {}, {
+    signal: controller.signal,
+    invalidateOnAbort: false,
+    onAbandonedOpen: () => { abandoned += 1; },
+    onAbandonedOpenSettled: () => { abandonedSettled += 1; },
+  });
+
+  controller.abort(new Error("cancelled"));
+  await assert.rejects(pending, /cancelled/);
+  assert.equal(abandoned, 1);
+  assert.equal(abandonedSettled, 0);
+
+  const lateStream = new EventEmitter();
+  lateStream.closed = 0;
+  lateStream.close = () => { lateStream.closed += 1; };
+  callback(null, lateStream);
+  assert.equal(lateStream.closed, 1);
+  assert.equal(abandonedSettled, 1);
+});
+
 test("channel open keeps its deadline referenced and clears it after success", async () => {
   let callback;
   const timers = trackedTimerApi();

--- a/electron/bridges/boundedSshChannelOpen.test.cjs
+++ b/electron/bridges/boundedSshChannelOpen.test.cjs
@@ -113,20 +113,68 @@ test("channel open keeps its deadline referenced and clears it after success", a
 test("shell open caps each attempt to the remaining rate-limit retry window", async () => {
   const timers = trackedTimerApi();
   const controller = new AbortController();
+  let elapsedMs = 0;
+  let attempts = 0;
   const client = {
-    shell() {},
+    shell(_window, _options, next) {
+      attempts += 1;
+      if (attempts === 1) {
+        next(new Error("(SSH) Channel open failure: channelOpen too offen type=session"));
+      }
+    },
   };
   const pending = openBoundedSshShell(client, {}, {}, {
     signal: controller.signal,
     timeoutMs: 1_000,
     rateLimitRetryTimeoutMs: 5,
-    nowFn: () => 0,
+    rateLimitBackoffMs: 1,
+    nowFn: () => elapsedMs,
+    sleepFn: async (ms) => { elapsedMs += ms; },
     ...timers,
   });
 
-  assert.equal(timers.delays[0], 5);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(attempts, 2);
+  assert.deepEqual(timers.delays, [1_000, 4]);
   controller.abort(new Error("cancelled"));
   await assert.rejects(pending, /cancelled/);
+});
+
+test("a retry-budget timeout preserves the transport and returns the rate-limit error", async () => {
+  let attempts = 0;
+  let invalidations = 0;
+  let elapsedMs = 0;
+  const client = {
+    shell(_window, _options, next) {
+      attempts += 1;
+      if (attempts === 1) {
+        next(new Error("(SSH) Channel open failure: channelOpen too offen type=session"));
+      }
+    },
+    destroy() { invalidations += 1; },
+  };
+
+  await assert.rejects(
+    openBoundedSshShell(client, {}, {}, {
+      timeoutMs: 1_000,
+      rateLimitRetryTimeoutMs: 5,
+      rateLimitBackoffMs: 1,
+      nowFn: () => elapsedMs,
+      sleepFn: async (ms) => { elapsedMs += ms; },
+      setTimeoutFn(callback, ms) {
+        if (ms < 1_000) {
+          elapsedMs += ms;
+          setImmediate(callback);
+        }
+        return { unref() {} };
+      },
+      clearTimeoutFn() {},
+    }),
+    /channelOpen too offen/,
+  );
+
+  assert.equal(attempts, 2);
+  assert.equal(invalidations, 0);
 });
 
 test("detects bastion channelOpen rate-limit errors including the offen typo", () => {

--- a/electron/bridges/sshBridge.connectionReuse.test.cjs
+++ b/electron/bridges/sshBridge.connectionReuse.test.cjs
@@ -1418,6 +1418,92 @@ test("cancelling Copy Tab during rate-limit backoff stops retries and keeps the 
   assert.equal(source.connRef.count, 1);
 });
 
+test("cancelling Copy Tab during reused-shell liveness does not register a stale session", async (t) => {
+  const { bridge, getClientConstructCount } = loadBridgeWithMockedSsh2(t);
+  const sessions = new Map();
+  const sourceConn = makeReusableConn();
+  sourceConn._remoteVer = "CustomBastion_1.0";
+  let openedStream = null;
+  sourceConn.shell = (_opts, _shellOpts, cb) => {
+    openedStream = makeStream();
+    sourceConn.openedShells.push(openedStream);
+    setImmediate(() => {
+      cb(null, openedStream);
+      setTimeout(() => abortPendingBoot("copy", 1), 5);
+    });
+  };
+  const source = makeSourceSession(sourceConn, {
+    hostname: "bastion.example",
+    username: "alice",
+  });
+  source.connRef.pendingShellReconnectRisk = {
+    oldShellPids: [],
+    hasUnknownOldShell: true,
+  };
+  sessions.set("source", source);
+
+  const start = registerStartHandler(bridge, sessions);
+  await assert.rejects(
+    start(
+      { sender: makeSender() },
+      {
+        sessionId: "copy",
+        hostname: "bastion.example",
+        username: "alice",
+        sourceSessionId: "source",
+        bootEpoch: 1,
+        sshReusedShellLivenessMs: 100,
+      },
+    ),
+    /aborted/,
+  );
+
+  assert.equal(getClientConstructCount(), 0);
+  assert.equal(sessions.has("copy"), false);
+  assert.equal(openedStream.closed, true);
+  assert.equal(sourceConn.ended, 0);
+  assert.equal(source.connRef.count, 1);
+});
+
+test("cancelling ordinary parked reuse does not start a fresh login", async (t) => {
+  const { bridge, getClientConstructCount } = loadBridgeWithMockedSsh2(t);
+  const sessions = new Map();
+  const sourceConn = makeReusableConn();
+  let shellAttempts = 0;
+  sourceConn.shell = (_opts, _shellOpts, cb) => {
+    shellAttempts += 1;
+    setImmediate(() => {
+      cb(new Error("(SSH) Channel open failure: channelOpen too offen type=session"));
+      setImmediate(() => abortPendingBoot("ordinary", 1));
+    });
+  };
+  const source = makeSourceSession(sourceConn, {
+    hostname: "bastion.example",
+    username: "alice",
+  });
+  sessions.set("source", source);
+
+  const start = registerStartHandler(bridge, sessions);
+  await assert.rejects(
+    start(
+      { sender: makeSender() },
+      {
+        sessionId: "ordinary",
+        hostname: "bastion.example",
+        username: "alice",
+        bootEpoch: 1,
+        sshChannelOpenRateLimitBackoffMs: 50,
+      },
+    ),
+    /aborted/,
+  );
+
+  assert.equal(shellAttempts, 1);
+  assert.equal(getClientConstructCount(), 0);
+  assert.equal(sourceConn.ended, 0);
+  assert.equal(source.connRef.count, 1);
+});
+
 test("a shared connection error during Copy Tab backoff stops queued retries", async (t) => {
   const { bridge, getClientConstructCount } = loadBridgeWithMockedSsh2(t);
   const sessions = new Map();

--- a/electron/bridges/sshBridge.connectionReuse.test.cjs
+++ b/electron/bridges/sshBridge.connectionReuse.test.cjs
@@ -1504,6 +1504,78 @@ test("cancelling ordinary parked reuse does not start a fresh login", async (t) 
   assert.equal(source.connRef.count, 1);
 });
 
+test("an abandoned Copy Tab open blocks overlapping reuse until the raw callback settles", async (t) => {
+  const { bridge, getClientConstructCount } = loadBridgeWithMockedSsh2(t);
+  const sessions = new Map();
+  const sourceConn = makeDeferredShellConn();
+  const source = makeSourceSession(sourceConn, {
+    hostname: "bastion.example",
+    username: "alice",
+  });
+  sessions.set("source", source);
+  const start = registerStartHandler(bridge, sessions);
+
+  const firstStart = start(
+    { sender: makeSender() },
+    {
+      sessionId: "copy-1",
+      hostname: "bastion.example",
+      username: "alice",
+      sourceSessionId: "source",
+      bootEpoch: 1,
+    },
+  );
+  for (let attempt = 0; attempt < 20 && sourceConn._pending.length === 0; attempt += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(sourceConn._pending.length, 1);
+  abortPendingBoot("copy-1", 1);
+  await assert.rejects(firstStart, /aborted/);
+  assert.equal(source.connRef.pendingAbandonedShellOpens, 1);
+  assert.equal(sourceConn._pending.length, 1);
+
+  await assert.rejects(
+    start(
+      { sender: makeSender() },
+      {
+        sessionId: "copy-2",
+        hostname: "bastion.example",
+        username: "alice",
+        sourceSessionId: "source",
+        bootEpoch: 1,
+      },
+    ),
+    /unexpected fresh connect/,
+  );
+  assert.equal(sourceConn._pending.length, 1, "second copy must not overlap the abandoned open");
+
+  sourceConn.flushShell();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(source.connRef.pendingAbandonedShellOpens, undefined);
+
+  const thirdStart = start(
+    { sender: makeSender() },
+    {
+      sessionId: "copy-3",
+      hostname: "bastion.example",
+      username: "alice",
+      sourceSessionId: "source",
+      bootEpoch: 1,
+      skipShellPidDiscovery: true,
+    },
+  );
+  for (let attempt = 0; attempt < 20 && sourceConn._pending.length === 0; attempt += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(sourceConn._pending.length, 1);
+  sourceConn.flushShell();
+  const result = await thirdStart;
+
+  assert.equal(result.sessionId, "copy-3");
+  assert.equal(getClientConstructCount(), 1);
+  assert.equal(sourceConn.ended, 0);
+});
+
 test("a shared connection error during Copy Tab backoff stops queued retries", async (t) => {
   const { bridge, getClientConstructCount } = loadBridgeWithMockedSsh2(t);
   const sessions = new Map();

--- a/electron/bridges/sshBridge.connectionReuse.test.cjs
+++ b/electron/bridges/sshBridge.connectionReuse.test.cjs
@@ -1302,6 +1302,46 @@ test("Copy Tab retries bastion channelOpen too offen before falling back", async
   assert.equal(getConnectionReuseFallbackEvents(sender).length, 0);
 });
 
+test("Copy Tab keeps reusing when a bastion rate limit outlasts the legacy retry burst", async (t) => {
+  const { bridge, getClientConstructCount } = loadBridgeWithMockedSsh2(t);
+  const sessions = new Map();
+  const sourceConn = makeReusableConn();
+  let shellAttempts = 0;
+  sourceConn.shell = (_opts, _shellOpts, cb) => {
+    shellAttempts += 1;
+    if (shellAttempts <= 4) {
+      setImmediate(() => cb(new Error("(SSH) Channel open failure: channelOpen too offen type=session")));
+      return;
+    }
+    const stream = makeStream();
+    sourceConn.openedShells.push(stream);
+    setImmediate(() => cb(null, stream));
+  };
+  sessions.set("source", makeSourceSession(sourceConn, {
+    hostname: "bastion.example",
+    username: "alice",
+  }));
+
+  const start = registerStartHandler(bridge, sessions);
+  const sender = makeSender();
+  const result = await start(
+    { sender },
+    {
+      sessionId: "copy",
+      hostname: "bastion.example",
+      username: "alice",
+      sourceSessionId: "source",
+      sshChannelOpenRateLimitBackoffMs: 1,
+    },
+  );
+
+  assert.equal(result.sessionId, "copy");
+  assert.equal(shellAttempts, 5);
+  assert.equal(getClientConstructCount(), 0);
+  assert.equal(sourceConn.openedShells.length, 1);
+  assert.equal(getConnectionReuseFallbackEvents(sender).length, 0);
+});
+
 test("Copy Tab opens the shell before PID discovery so bastion rate limits do not burn the session slot", async (t) => {
   const { bridge, getClientConstructCount } = loadBridgeWithMockedSsh2(t);
   const sessions = new Map();

--- a/electron/bridges/sshBridge.connectionReuse.test.cjs
+++ b/electron/bridges/sshBridge.connectionReuse.test.cjs
@@ -2,6 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const { EventEmitter } = require("node:events");
 const Module = require("node:module");
+const { abortPendingBoot } = require("./sessionBootEpoch.cjs");
 
 const sshConnectionPool = require("./sshConnectionPool.cjs");
 const {
@@ -1340,6 +1341,118 @@ test("Copy Tab keeps reusing when a bastion rate limit outlasts the legacy retry
   assert.equal(getClientConstructCount(), 0);
   assert.equal(sourceConn.openedShells.length, 1);
   assert.equal(getConnectionReuseFallbackEvents(sender).length, 0);
+});
+
+test("ordinary parked reuse keeps the legacy retry bound", async (t) => {
+  const { bridge, getClientConstructCount } = loadBridgeWithMockedSsh2(t);
+  const sessions = new Map();
+  const sourceConn = makeReusableConn();
+  let shellAttempts = 0;
+  sourceConn.shell = (_opts, _shellOpts, cb) => {
+    shellAttempts += 1;
+    setImmediate(() => cb(new Error("(SSH) Channel open failure: channelOpen too offen type=session")));
+  };
+  sessions.set("source", makeSourceSession(sourceConn, {
+    hostname: "bastion.example",
+    username: "alice",
+  }));
+
+  const start = registerStartHandler(bridge, sessions);
+  await assert.rejects(
+    start(
+      { sender: makeSender() },
+      {
+        sessionId: "ordinary",
+        hostname: "bastion.example",
+        username: "alice",
+        sshChannelOpenRateLimitBackoffMs: 1,
+      },
+    ),
+    /unexpected fresh connect/,
+  );
+
+  // The ordinary path can try the same live transport through its parked and
+  // coordinated-reuse stages. Each stage keeps the legacy four-attempt bound.
+  assert.equal(shellAttempts, 8);
+  assert.equal(getClientConstructCount(), 1);
+});
+
+test("cancelling Copy Tab during rate-limit backoff stops retries and keeps the source alive", async (t) => {
+  const { bridge, getClientConstructCount } = loadBridgeWithMockedSsh2(t);
+  const sessions = new Map();
+  const sourceConn = makeReusableConn();
+  let shellAttempts = 0;
+  sourceConn.shell = (_opts, _shellOpts, cb) => {
+    shellAttempts += 1;
+    setImmediate(() => {
+      cb(new Error("(SSH) Channel open failure: channelOpen too offen type=session"));
+      setImmediate(() => abortPendingBoot("copy", 1));
+    });
+  };
+  const source = makeSourceSession(sourceConn, {
+    hostname: "bastion.example",
+    username: "alice",
+  });
+  sessions.set("source", source);
+
+  const start = registerStartHandler(bridge, sessions);
+  await assert.rejects(
+    start(
+      { sender: makeSender() },
+      {
+        sessionId: "copy",
+        hostname: "bastion.example",
+        username: "alice",
+        sourceSessionId: "source",
+        bootEpoch: 1,
+        sshChannelOpenRateLimitBackoffMs: 50,
+      },
+    ),
+    /aborted/,
+  );
+  await new Promise((resolve) => setTimeout(resolve, 75));
+
+  assert.equal(shellAttempts, 1);
+  assert.equal(getClientConstructCount(), 0);
+  assert.equal(sourceConn.ended, 0);
+  assert.equal(source.connRef.count, 1);
+});
+
+test("a shared connection error during Copy Tab backoff stops queued retries", async (t) => {
+  const { bridge, getClientConstructCount } = loadBridgeWithMockedSsh2(t);
+  const sessions = new Map();
+  const sourceConn = makeReusableConn();
+  let shellAttempts = 0;
+  sourceConn.shell = (_opts, _shellOpts, cb) => {
+    shellAttempts += 1;
+    setImmediate(() => {
+      cb(new Error("(SSH) Channel open failure: channelOpen too offen type=session"));
+      setImmediate(() => sourceConn.emit("error", new Error("transport lost")));
+    });
+  };
+  sessions.set("source", makeSourceSession(sourceConn, {
+    hostname: "bastion.example",
+    username: "alice",
+  }));
+
+  const start = registerStartHandler(bridge, sessions);
+  await assert.rejects(
+    start(
+      { sender: makeSender() },
+      {
+        sessionId: "copy",
+        hostname: "bastion.example",
+        username: "alice",
+        sourceSessionId: "source",
+        sshChannelOpenRateLimitBackoffMs: 50,
+      },
+    ),
+    /unexpected fresh connect/,
+  );
+  await new Promise((resolve) => setTimeout(resolve, 75));
+
+  assert.equal(shellAttempts, 1);
+  assert.equal(getClientConstructCount(), 1);
 });
 
 test("Copy Tab opens the shell before PID discovery so bastion rate limits do not burn the session slot", async (t) => {

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -764,7 +764,10 @@ function createStartSessionApi(ctx) {
         };
         conn.once("error", onConnError);
 
-        if (connRef.allowShellReuse === false) {
+        if (
+          connRef.allowShellReuse === false
+          || Number(connRef.pendingAbandonedShellOpens) > 0
+        ) {
           conn.removeListener("error", onConnError);
           failReuse(new Error("Transport is no longer reusable for shells"));
           return;
@@ -1077,6 +1080,18 @@ function createStartSessionApi(ctx) {
               // Cancelling one pending Copy Tab must not destroy the source
               // tab's shared authenticated transport.
               invalidateOnAbort: false,
+              onAbandonedOpen: () => {
+                connRef.pendingAbandonedShellOpens =
+                  (Number(connRef.pendingAbandonedShellOpens) || 0) + 1;
+              },
+              onAbandonedOpenSettled: () => {
+                const pending = Math.max(
+                  0,
+                  (Number(connRef.pendingAbandonedShellOpens) || 0) - 1,
+                );
+                if (pending === 0) delete connRef.pendingAbandonedShellOpens;
+                else connRef.pendingAbandonedShellOpens = pending;
+              },
             },
           );
         } catch (syncErr) {

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -713,10 +713,30 @@ function createStartSessionApi(ctx) {
       // is restored.
       return new Promise((resolve, reject) => {
         let settled = false;
+        let onConnError = null;
+        const retryAbortController = new AbortController();
+        const pendingBootSignal = options._passphraseSignal || null;
+        const abortRetryFromPendingBoot = () => {
+          retryAbortController.abort(
+            pendingBootSignal?.reason || new Error("SSH session start was cancelled"),
+          );
+        };
+        const cleanupReuseGuards = () => {
+          if (onConnError) conn.removeListener("error", onConnError);
+          pendingBootSignal?.removeEventListener?.("abort", abortRetryFromPendingBoot);
+        };
+
+        if (pendingBootSignal?.aborted) {
+          abortRetryFromPendingBoot();
+        } else {
+          pendingBootSignal?.addEventListener?.("abort", abortRetryFromPendingBoot, { once: true });
+        }
 
         const failReuse = (err) => {
           if (settled) return;
           settled = true;
+          cleanupReuseGuards();
+          retryAbortController.abort(err);
           // Release the hold we took up-front so the source's reference count is
           // not leaked when we fall back to a fresh connection.
           releaseConnectionRef(refHolder);
@@ -728,7 +748,7 @@ function createStartSessionApi(ctx) {
         // connection. Removed once the channel opens so we don't leave a stray
         // listener on the shared connection (the owner's own error handler stays
         // responsible thereafter).
-        const onConnError = (connErr) => {
+        onConnError = (connErr) => {
           failReuse(connErr);
         };
         conn.once("error", onConnError);
@@ -750,7 +770,7 @@ function createStartSessionApi(ctx) {
             },
             shellOptions,
             (err, stream) => {
-              conn.removeListener("error", onConnError);
+              cleanupReuseGuards();
               if (settled) {
                 // Connection already failed; close any channel that still opened
                 // and drop the hold (failReuse already released, so guard with the
@@ -1023,19 +1043,24 @@ function createStartSessionApi(ctx) {
                 failReuse(livenessErr);
               });
             },
-            Number.isFinite(rateLimitBackoffMs) && rateLimitBackoffMs > 0
-              ? {
-                  rateLimitBackoffMs,
-                  rateLimitRetryTimeoutMs: COPY_TAB_RATE_LIMIT_RETRY_TIMEOUT_MS,
-                }
-              : { rateLimitRetryTimeoutMs: COPY_TAB_RATE_LIMIT_RETRY_TIMEOUT_MS },
+            {
+              ...(Number.isFinite(rateLimitBackoffMs) && rateLimitBackoffMs > 0
+                ? { rateLimitBackoffMs }
+                : {}),
+              ...(options.sourceSessionId
+                ? { rateLimitRetryTimeoutMs: COPY_TAB_RATE_LIMIT_RETRY_TIMEOUT_MS }
+                : {}),
+              signal: retryAbortController.signal,
+              // Cancelling one pending Copy Tab must not destroy the source
+              // tab's shared authenticated transport.
+              invalidateOnAbort: false,
+            },
           );
         } catch (syncErr) {
           // ssh2 can throw synchronously (e.g. "Not connected") if the borrowed
           // transport dropped between findReusableSession and conn.shell(). Make
           // sure we drop the listener and release the up-front ref so the count
           // isn't leaked, then fall back to a fresh connection.
-          conn.removeListener("error", onConnError);
           log("reused shell threw synchronously", { sessionId, hostname: options.hostname, error: syncErr?.message });
           failReuse(syncErr);
         }
@@ -1131,6 +1156,7 @@ function createStartSessionApi(ctx) {
           try {
             return await reuseShellSession(event, options, sourceSession, sessionId, log);
           } catch (reuseErr) {
+            if (options._passphraseSignal?.aborted) throw reuseErr;
             log("connection reuse failed, falling back to fresh connection", {
               sessionId,
               sourceSessionId: options.sourceSessionId,

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -714,16 +714,27 @@ function createStartSessionApi(ctx) {
       return new Promise((resolve, reject) => {
         let settled = false;
         let onConnError = null;
+        let abortOpenedStream = null;
         const retryAbortController = new AbortController();
         const pendingBootSignal = options._passphraseSignal || null;
         const abortRetryFromPendingBoot = () => {
           retryAbortController.abort(
             pendingBootSignal?.reason || new Error("SSH session start was cancelled"),
           );
+          abortOpenedStream?.(
+            pendingBootSignal?.reason || new Error("SSH session start was cancelled"),
+          );
+        };
+        const cleanupConnectionGuard = () => {
+          if (onConnError) conn.removeListener("error", onConnError);
+        };
+        const cleanupPendingBootGuard = () => {
+          abortOpenedStream = null;
+          pendingBootSignal?.removeEventListener?.("abort", abortRetryFromPendingBoot);
         };
         const cleanupReuseGuards = () => {
-          if (onConnError) conn.removeListener("error", onConnError);
-          pendingBootSignal?.removeEventListener?.("abort", abortRetryFromPendingBoot);
+          cleanupConnectionGuard();
+          cleanupPendingBootGuard();
         };
 
         if (pendingBootSignal?.aborted) {
@@ -770,7 +781,7 @@ function createStartSessionApi(ctx) {
             },
             shellOptions,
             (err, stream) => {
-              cleanupReuseGuards();
+              cleanupConnectionGuard();
               if (settled) {
                 // Connection already failed; close any channel that still opened
                 // and drop the hold (failReuse already released, so guard with the
@@ -792,7 +803,19 @@ function createStartSessionApi(ctx) {
 
               sendProgress('connected');
 
+              abortOpenedStream = (abortError) => {
+                try { stream.close(); } catch { /* ignore */ }
+                failReuse(abortError);
+              };
+              if (pendingBootSignal?.aborted) {
+                abortOpenedStream(
+                  pendingBootSignal.reason || new Error("SSH session start was cancelled"),
+                );
+                return;
+              }
+
               const finishReusedShellOpen = (prefetchedChunks = []) => {
+                cleanupPendingBootGuard();
                 if (settled) {
                   if (stream) { try { stream.close(); } catch { /* ignore */ } }
                   return;
@@ -1208,6 +1231,11 @@ function createStartSessionApi(ctx) {
               { confirmReusedShellLiveness },
             );
           } catch (parkErr) {
+            if (options._passphraseSignal?.aborted) {
+              throw options._passphraseSignal.reason instanceof Error
+                ? options._passphraseSignal.reason
+                : parkErr;
+            }
             log("parked transport reuse failed, falling back to fresh connection", {
               sessionId,
               hostname: options.hostname,
@@ -1243,6 +1271,11 @@ function createStartSessionApi(ctx) {
               log,
             );
           } catch (coordinationErr) {
+            if (options._passphraseSignal?.aborted) {
+              throw options._passphraseSignal.reason instanceof Error
+                ? options._passphraseSignal.reason
+                : coordinationErr;
+            }
             // A waiter must observe the leader's real failure instead of
             // immediately starting a second authentication prompt. Existing
             // transport reuse keeps its historical fresh-dial fallback.
@@ -1259,6 +1292,12 @@ function createStartSessionApi(ctx) {
             options._pendingDialState.coordination = coordination;
           }
         }
+      }
+
+      if (options._passphraseSignal?.aborted) {
+        throw options._passphraseSignal.reason instanceof Error
+          ? options._passphraseSignal.reason
+          : new Error("SSH session start was cancelled");
       }
 
       const cols = options.cols || 80;

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -30,6 +30,7 @@ const {
 const SSH_TCP_CONNECT_TIMEOUT_MS = 20000;
 const SSH_AUTH_READY_TIMEOUT_MS = 120000;
 const MAX_SSH_CONNECTION_TIMEOUT_MS = 3600000;
+const COPY_TAB_RATE_LIMIT_RETRY_TIMEOUT_MS = 30000;
 
 /**
  * Fan out netcatty:exit to the primary contents plus any attach-home owner
@@ -1023,8 +1024,11 @@ function createStartSessionApi(ctx) {
               });
             },
             Number.isFinite(rateLimitBackoffMs) && rateLimitBackoffMs > 0
-              ? { rateLimitBackoffMs }
-              : {},
+              ? {
+                  rateLimitBackoffMs,
+                  rateLimitRetryTimeoutMs: COPY_TAB_RATE_LIMIT_RETRY_TIMEOUT_MS,
+                }
+              : { rateLimitRetryTimeoutMs: COPY_TAB_RATE_LIMIT_RETRY_TIMEOUT_MS },
           );
         } catch (syncErr) {
           // ssh2 can throw synchronously (e.g. "Not connected") if the borrowed


### PR DESCRIPTION
## Summary

Copy Tab no longer gives up after the legacy ~900 ms retry burst when a bastion temporarily rejects new SSH session channels. The issue reporter's 1.1.80 timestamps show all four legacy attempts were exhausted before Netcatty fell back to a fresh login and prompted for the rotating password again.

Copy Tab now keeps retrying this specific, known-temporary bastion response within a strict 30-second window. Unrelated channel failures still fail immediately, ordinary parked reuse keeps its legacy bound, and persistent rate limits remain bounded.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #2704

## Changes Made

- Replace the fixed Copy Tab rate-limit retry count with a bounded retry window.
- Use a monotonic deadline, cap each attempt to its remaining budget, and stop retrying when the pending tab is cancelled or the shared connection fails.
- Preserve the existing short linear backoff and immediate handling of unrelated failures.
- Add regression coverage for a bastion that rejects the first four reuse attempts and accepts the fifth.
- Add unit coverage for both recovery within the retry window and bounded exhaustion.

## Screenshots / Demo

N/A — main-process SSH connection reuse behavior; covered by focused regression tests.

## Testing

- [ ] I have tested these changes locally (`npm run dev`) — requires the reporter's rate-limited bastion to exercise manually.
- [x] Linting passes for the changed files.
- [x] 64 focused SSH reuse, channel-open, cancellation, and shared-close tests pass.
- [x] Production build passes.
- [x] Generated capability tool specs are not affected.
- [x] No new console errors or warnings, if this affects app behavior.

## Checklist

- [x] My code follows the existing project style.
- [x] Documentation is not affected; regression behavior is documented in tests and this PR.
- [x] I have not introduced any breaking changes.
