### PR TITLE
fix(notes): keep mode options on one line

### DIFF
--- a/components/notes/InlineMarkdownEditor.test.tsx
+++ b/components/notes/InlineMarkdownEditor.test.tsx
@@ -401,6 +401,11 @@ test("note editor exposes its modes from a borderless title-row dropdown", () =>
   assert.match(toolbarSource, /data-note-mode-dropdown-trigger/);
   assert.match(toolbarSource, /data-note-mode-option=\{option\.mode\}/);
   assert.match(toolbarSource, /gap-1\.5 border-0 bg-transparent px-2/);
+  assert.match(toolbarSource, /<SelectContent align="end" className="w-max min-w-\[10rem\]">/);
+  assert.match(
+    toolbarSource,
+    /data-note-mode-option=\{option\.mode\}[\s\S]*?className="h-9 whitespace-nowrap"/,
+  );
   assert.match(toolbarSource, /<Select value=\{normalizedMode\}/);
   assert.doesNotMatch(toolbarSource, /data-note-mode-switch=/);
   assert.match(managerSource, /data-note-title-row[\s\S]*?<NoteModeDropdown[\s\S]*?<NoteToolbar/);

--- a/components/notes/NoteToolbar.tsx
+++ b/components/notes/NoteToolbar.tsx
@@ -106,7 +106,7 @@ export const NoteModeDropdown: React.FC<NoteModeDropdownProps> = ({
           <ActiveIcon size={15} />
           <span>{activeOption.label}</span>
         </SelectTrigger>
-      <SelectContent align="end" className="w-40">
+      <SelectContent align="end" className="w-max min-w-[10rem]">
         {options.map((option) => {
           const Icon = option.icon;
           return (
@@ -114,9 +114,9 @@ export const NoteModeDropdown: React.FC<NoteModeDropdownProps> = ({
               key={option.mode}
               value={option.mode}
               data-note-mode-option={option.mode}
-              className="h-9"
+              className="h-9 whitespace-nowrap"
             >
-              <span className="flex items-center gap-2"><Icon size={14} />{option.label}</span>
+              <span className="flex items-center gap-2 whitespace-nowrap"><Icon size={14} />{option.label}</span>
             </SelectItem>
           );
         })}


### PR DESCRIPTION
## Summary

Make the note editor mode menu size itself to its labels and keep every option on one line.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other

## Related Issue (optional)

N/A

## Changes Made

- Remove the fixed narrow width from the mode menu.
- Keep mode labels on one line.
- Add regression coverage for the sizing and wrapping rules.

## Screenshots / Demo

The mode menu now expands to fit Reading Mode instead of wrapping it.

## Testing

- [x] Focused note editor tests pass (41/41)
- [x] Linting passes (npm run lint)
- [x] Production build passes (npm run build)
- [x] No generated capability changes are applicable
- [x] No new build errors or warnings

## Checklist

- [x] My code follows the existing project style
- [x] Relevant regression coverage was updated
- [x] No breaking changes introduced