### PR TITLE
test: repair stale SSH and SFTP expectations

### DIFF
--- a/components/GlobalSftpTransferCenter.accessibility.test.ts
+++ b/components/GlobalSftpTransferCenter.accessibility.test.ts
@@ -110,6 +110,9 @@ test("associates the transfer-center folder warning with every destructive Repla
     const describedBy = button.getAttribute("aria-describedby");
     assert.ok(describedBy, `${button.textContent} should expose the folder deletion warning`);
     const warning = env.document.getElementById(describedBy);
-    assert.match(warning?.textContent ?? "", /Replace deletes all destination files and sub-folders/);
+    assert.match(
+      warning?.textContent ?? "",
+      /Replace: deletes destination-only content and cannot be undone/,
+    );
   }
 });

--- a/electron/bridges/sshBridge.authRetryExit.test.cjs
+++ b/electron/bridges/sshBridge.authRetryExit.test.cjs
@@ -1,5 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
 const { EventEmitter } = require("node:events");
 const fs = require("node:fs");
 const Module = require("node:module");
@@ -14,6 +15,12 @@ const {
   resetSshTransportRegistryForTests,
   waitForTransportDial,
 } = require("./sshConnectionPool.cjs");
+
+const TEST_PRIVATE_KEY = crypto.generateKeyPairSync("ec", {
+  namedCurve: "prime256v1",
+  privateKeyEncoding: { type: "sec1", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+}).privateKey;
 
 test.beforeEach(() => {
   resetSshTransportRegistryForTests({ defaultIdleTtlMs: 0 });
@@ -579,6 +586,13 @@ function loadBridgeWithAuthRetryMocks(t, options = {}) {
   return { bridge, MockSSHClient };
 }
 
+function createParsedPrivateKey() {
+  return {
+    isPrivateKey: () => true,
+    getPrivatePEM: () => TEST_PRIVATE_KEY,
+  };
+}
+
 test("terminal SSH supports consecutive keyboard-interactive factors (#2150)", async (t) => {
   const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {
     connectEvents: ["repeated-keyboard-interactive"],
@@ -1028,7 +1042,7 @@ test("terminal SSH keeps keyboard-interactive eligible after password rejection"
 test("terminal SSH prefers keyboard-interactive after publickey partial success", async (t) => {
   const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {
     connectEvents: ["publickey-then-password-and-keyboard-interactive"],
-    parseKeyResult: {},
+    parseKeyResult: createParsedPrivateKey(),
   });
   const ipcMain = makeIpcMain();
   bridge.init({ sessions: new Map(), electronModule: {} });
@@ -1056,7 +1070,7 @@ test("terminal SSH prefers keyboard-interactive after publickey partial success"
       hostname: "corp-edr.example.com",
       username: "alice",
       authMethod: "key",
-      privateKey: "INLINE_PRIVATE_KEY",
+      privateKey: TEST_PRIVATE_KEY,
       password: "login-password",
       useSshAgent: false,
       port: 22,
@@ -1080,7 +1094,7 @@ test("terminal SSH prefers keyboard-interactive after publickey partial success"
 test("terminal SSH certificate auth prefers keyboard-interactive after agent partial success after partial success", async (t) => {
   const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {
     connectEvents: ["agent-then-password-and-keyboard-interactive"],
-    parseKeyResult: {},
+    parseKeyResult: createParsedPrivateKey(),
   });
   const ipcMain = makeIpcMain();
   bridge.init({ sessions: new Map(), electronModule: {} });
@@ -1109,7 +1123,7 @@ test("terminal SSH certificate auth prefers keyboard-interactive after agent par
       username: "alice",
       authMethod: "certificate",
       certificate: "ssh-rsa-cert-v01@openssh.com AAAA test-cert",
-      privateKey: "INLINE_PRIVATE_KEY",
+      privateKey: TEST_PRIVATE_KEY,
       password: "login-password",
       useSshAgent: false,
       port: 22,
@@ -1131,7 +1145,7 @@ test("terminal SSH certificate auth prefers keyboard-interactive after agent par
 test("terminal SSH certificate requiresMfa prefers keyboard-interactive after a rejected certificate", async (t) => {
   const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {
     connectEvents: ["agent-then-mfa-keyboard-interactive-before-password"],
-    parseKeyResult: {},
+    parseKeyResult: createParsedPrivateKey(),
   });
   const ipcMain = makeIpcMain();
   bridge.init({ sessions: new Map(), electronModule: {} });
@@ -1147,7 +1161,7 @@ test("terminal SSH certificate requiresMfa prefers keyboard-interactive after a 
       authMethod: "certificate",
       requiresMfa: true,
       certificate: "ssh-rsa-cert-v01@openssh.com AAAA test-cert",
-      privateKey: "INLINE_PRIVATE_KEY",
+      privateKey: TEST_PRIVATE_KEY,
       password: "login-password",
       useSshAgent: false,
       port: 22,
@@ -1172,7 +1186,7 @@ test("terminal SSH certificate auth retries keyboard-interactive when password r
       "agent-password-removes-keyboard-interactive",
       "agent-then-keyboard-interactive-after-skip-password",
     ],
-    parseKeyResult: {},
+    parseKeyResult: createParsedPrivateKey(),
   });
   const ipcMain = makeIpcMain();
   bridge.init({ sessions: new Map(), electronModule: {} });
@@ -1201,7 +1215,7 @@ test("terminal SSH certificate auth retries keyboard-interactive when password r
       username: "alice",
       authMethod: "certificate",
       certificate: "ssh-rsa-cert-v01@openssh.com AAAA test-cert",
-      privateKey: "INLINE_PRIVATE_KEY",
+      privateKey: TEST_PRIVATE_KEY,
       password: "login-password",
       useSshAgent: false,
       port: 22,


### PR DESCRIPTION
## Summary

Fixes all test failures currently reproduced on `main`. Two production changes were correct, but their older tests still expected outdated inputs or wording. Production behavior and safety checks remain unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [x] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

N/A

## Changes Made

- Generate a valid private key for four SSH authentication retry tests instead of passing placeholder text rejected by the newer safety check.
- Return a realistic parsed private-key object from the SSH bridge mock.
- Update the transfer-center accessibility test to expect the current destructive Replace warning.
- Keep invalid-key rejection and accessibility associations intact.

## Screenshots / Demo

Not applicable; test-only changes.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [x] Focused SSH tests pass on the same Node.js version used by CI (51/51)
- [x] Focused transfer-center and dialog accessibility tests pass (2/2)
- [x] Production build passes (`npm run build`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Full CI is running on GitHub for the current head.

## Checklist

- [x] My code follows the existing project style
- [x] Documentation is not required for these test corrections
- [x] I have not introduced any breaking changes (or I have described them above)