### PR TITLE
fix(app-lock): allow whitespace-only passwords

### DIFF
--- a/components/AppLockOverlay.runtime.test.tsx
+++ b/components/AppLockOverlay.runtime.test.tsx
@@ -81,6 +81,51 @@ test("AppLockOverlay shows incorrect-password error and clears it after editing"
   }
 });
 
+test("AppLockOverlay submits a whitespace-only password unchanged", async () => {
+  const dom = installDomEnvironment();
+  const renderer = await createDomRenderer(dom.document);
+  const unlockAttempts: string[] = [];
+
+  try {
+    await renderer.render(
+      React.createElement(
+        I18nProvider,
+        { locale: "en" },
+        React.createElement(AppLockOverlay, {
+          locked: true,
+          reason: "manual",
+          onUnlock: async (password) => {
+            unlockAttempts.push(password);
+            return { ok: true as const };
+          },
+          onResetAppLock: async () => {},
+        }),
+      ),
+    );
+    await flushEffects();
+
+    const input = dom.document.getElementById("app-lock-password") as HTMLInputElement | null;
+    const form = dom.document.querySelector("form");
+    assert.ok(input);
+    assert.ok(form);
+    const setInputValue = Object.getOwnPropertyDescriptor(
+      dom.window.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    assert.ok(setInputValue);
+    setInputValue.call(input, " ");
+    await dispatchDomEvent(input, new dom.window.Event("input", { bubbles: true }));
+    await dispatchDomEvent(form, new dom.window.Event("submit", { bubbles: true, cancelable: true }));
+    await flushEffects();
+    await flushEffects();
+
+    assert.deepEqual(unlockAttempts, [" "]);
+  } finally {
+    await renderer.unmount();
+    dom.cleanup();
+  }
+});
+
 test("AppLockOverlay reveals reset action after clicking Netcatty logo five times", async () => {
   const dom = installDomEnvironment();
   const renderer = await createDomRenderer(dom.document);

--- a/components/settings/tabs/AppLockSettingsSection.tsx
+++ b/components/settings/tabs/AppLockSettingsSection.tsx
@@ -132,11 +132,11 @@ export const AppLockSettingsSection: React.FC<AppLockSettingsSectionProps> = ({
 
   const handleSavePassword = useCallback(async () => {
     setError(null);
-    if (!newPassword.trim()) {
+    if (newPassword.length === 0) {
       setError(t('settings.appLock.validation.newRequired'));
       return;
     }
-    if (!confirmPassword.trim()) {
+    if (confirmPassword.length === 0) {
       setError(t('settings.appLock.validation.confirmRequired'));
       return;
     }

--- a/components/settings/tabs/SettingsSystemTab.test.ts
+++ b/components/settings/tabs/SettingsSystemTab.test.ts
@@ -62,6 +62,15 @@ test("app lock page uses settings rows and moves password forms into a dialog", 
   assert.match(source, /settings\.appLock\.currentPasswordForChangePlaceholder/);
 });
 
+test("app lock password setup keeps whitespace as password content", () => {
+  const source = readAppLockSectionSource();
+
+  assert.ok(source.includes("newPassword.length === 0"));
+  assert.ok(source.includes("confirmPassword.length === 0"));
+  assert.ok(!source.includes("newPassword.trim()"));
+  assert.ok(!source.includes("confirmPassword.trim()"));
+});
+
 test("app lock system unlock setting uses bridge-provided platform label", () => {
   const source = readAppLockSectionSource();
 

--- a/electron/bridges/appLockRuntimeBridge.cjs
+++ b/electron/bridges/appLockRuntimeBridge.cjs
@@ -563,7 +563,7 @@ function createAppLockController({
     const currentPassword = typeof input.currentPassword === "string" ? input.currentPassword : "";
     const hadVerifierAtRequest = Boolean(getSettings().passwordVerifier);
 
-    if (nextPassword.trim() === "") {
+    if (nextPassword.length === 0) {
       return { ok: false, error: "empty-next" };
     }
     let fail = null;

--- a/electron/bridges/appLockRuntimeBridge.test.cjs
+++ b/electron/bridges/appLockRuntimeBridge.test.cjs
@@ -980,6 +980,24 @@ test("creating the first app lock password enables app lock", async () => {
   assert.equal(typeof saved.passwordVerifier?.hash, "string");
 });
 
+test("creating the first app lock password accepts a single space", async () => {
+  const { controller } = await createControllerHarness({
+    enabled: false,
+    passwordVerifier: null,
+  });
+
+  assert.deepEqual(
+    await controller.requestPasswordChange({ nextPassword: "" }),
+    { ok: false, error: "empty-next" },
+  );
+
+  const saved = await controller.requestPasswordChange({ nextPassword: " " });
+
+  assert.equal(saved.enabled, true);
+  assert.equal(typeof saved.passwordVerifier?.hash, "string");
+  assert.deepEqual(await controller.requestUnlock(" "), { ok: true });
+});
+
 test("a queued password change cannot revive a concurrently disabled lock", async () => {
   const { controller } = await createControllerHarness();
   await controller.requestPasswordChange({ nextPassword: "alpha" });

--- a/electron/bridges/appLockSettingsStore.cjs
+++ b/electron/bridges/appLockSettingsStore.cjs
@@ -143,7 +143,7 @@ function shouldLockOnBackgroundHide(settings) {
 }
 
 async function createAppLockPasswordVerifier(password) {
-  if (typeof password !== "string" || password.trim() === "") {
+  if (typeof password !== "string" || password.length === 0) {
     throw new Error("App lock password is required");
   }
 

--- a/electron/bridges/appLockSettingsStore.test.cjs
+++ b/electron/bridges/appLockSettingsStore.test.cjs
@@ -168,3 +168,14 @@ test("createAppLockPasswordVerifier stores a verifier that verifyAppLockPassword
   assert.equal(await verifyAppLockPassword("correct horse battery staple", verifier), true);
   assert.equal(await verifyAppLockPassword("wrong password", verifier), false);
 });
+
+test("createAppLockPasswordVerifier preserves a whitespace-only password", async () => {
+  const verifier = await createAppLockPasswordVerifier(" ");
+
+  assert.equal(await verifyAppLockPassword(" ", verifier), true);
+  assert.equal(await verifyAppLockPassword("", verifier), false);
+  await assert.rejects(
+    () => createAppLockPasswordVerifier(""),
+    /App lock password is required/,
+  );
+});


### PR DESCRIPTION
  ## Summary

  Allow App Lock passwords containing only whitespace. Previously, validation trimmed the value and rejected a single-space password as empty.

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor / code cleanup
  - [ ] Documentation update
  - [ ] Build / CI change
  - [ ] Other (please describe):

  ## Related Issue (optional)

  N/A

  ## Changes Made

  - Treat only an empty string as an empty App Lock password.
  - Preserve whitespace-only passwords through UI validation, IPC handling, hashing, and verification.
  - Add regression tests for a single-space password and retain rejection of an empty password.

  ## Screenshots / Demo

  No visual change. A single-space password can now be saved and used to unlock App Lock.

  ## Testing

  - [ ] I have tested these changes locally (`npm run dev`)
  - [ ] Linting passes (`npm run lint`)
  - [ ] Tests pass (`npm test`)
  - [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`) - not applicable
  - [ ] No new console errors or warnings, if this affects app behavior

  Targeted verification completed:

  - `node --test electron/bridges/appLockSettingsStore.test.cjs electron/bridges/appLockRuntimeBridge.test.cjs`
  - `node --test --import tsx components/settings/tabs/SettingsSystemTab.test.ts`
  - `npx eslint` on the changed App Lock source and test files

  ## Checklist

  - [x] My code follows the existing project style
  - [ ] I have added or updated relevant documentation
  - [x] I have not introduced any breaking changes