### PR TITLE
fix(terminal): recover the stuck IME punctuation deferral that swallows subsequent input

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -110,6 +110,8 @@ import {
   shouldBlockKeyPressForImeTextInput,
   shouldCommitDeferredImeTextInput,
   shouldDeferKeyDownForImeTextInput,
+  shouldFlushDeferredImeTextInputOnKeyUp,
+  shouldFlushStaleDeferredImeTextInput,
 } from "./terminalImeTextInput";
 import { formatSerialLocalEcho } from "./serialLocalEcho";
 import { mapTerminalBackspaceInput } from "./terminalBackspaceInput";
@@ -1448,23 +1450,41 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
 
     if (e.type === "keyup") {
       // insertText for this keystroke has already run when present; flush the
-      // deferred ASCII key only when the IME did not remap it.
-      if (imeTextInputDeferredKey !== null && e.key === imeTextInputDeferredKey) {
+      // deferred ASCII key when the IME did not remap it. Any real key release
+      // ends the deferral: Windows IMEs report Process/229 as the release of a
+      // key they consumed (or drop the keyup), and an exact key match left the
+      // deferral armed so every later keypress was swallowed (#3103).
+      let releaseEvent: KeyboardEvent = e;
+      if (
+        imeTextInputDeferredKey !== null &&
+        shouldFlushDeferredImeTextInputOnKeyUp(imeTextInputDeferredKey, e)
+      ) {
+        const deferredKittyEvent = imeTextInputDeferredKittyEvent;
+        const mangledRelease =
+          e.key !== imeTextInputDeferredKey && deferredKittyEvent !== null;
         flushImeTextInputDeferral();
+        if (mangledRelease && deferredKittyEvent) {
+          // Pair the release from the deferred physical key; the mangled
+          // release event must not be encoded as a kitty key event.
+          releaseEvent = {
+            ...deferredKittyEvent,
+            type: "keyup",
+          } as unknown as KeyboardEvent;
+        }
       }
-      const identity = kittyKeyIdentity(e);
+      const identity = kittyKeyIdentity(releaseEvent);
       if (broadcastLegacyDataPending === identity) clearBroadcastLegacyDataPending();
       const forwardedPress = broadcastForwardedKeys.get(identity);
       if (forwardedPress) {
         broadcastForwardedKeys.delete(identity);
         broadcastKittyInput(
-          { kind: "key", event: toKittyKeyboardEvent(e) },
+          { kind: "key", event: toKittyKeyboardEvent(releaseEvent) },
           true,
           forwardedPress.targetSessionIds,
         );
       }
       if (!kittyForwardedKeys.delete(identity)) return true;
-      const kittyEvent = toKittyKeyboardEvent(e);
+      const kittyEvent = toKittyKeyboardEvent(releaseEvent);
       const sequence = kittyKeyboardProtocolEnabled
         ? encodeKittyKeyEvent(kittyKeyboardMode, kittyEvent)
         : null;
@@ -1478,8 +1498,15 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     }
 
     // Block keypress so xterm cannot re-emit the half-width ASCII char after we
-    // deferred the matching keydown for IME insertText (#2833).
-    if (shouldBlockKeyPressForImeTextInput(imeTextInputDeferredKey, e)) {
+    // deferred the matching keydown for IME insertText (#2833). Scoped to the
+    // deferred key so a stale deferral cannot swallow unrelated keystrokes.
+    if (
+      shouldBlockKeyPressForImeTextInput(
+        imeTextInputDeferredKey,
+        e,
+        imeTextInputDeferredKittyEvent?.keyCode ?? null,
+      )
+    ) {
       return false;
     }
 
@@ -1488,6 +1515,17 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     }
 
     if (handlingKittyBroadcast) return true;
+
+    // A deferred punctuation keystroke that outlived its own release means the
+    // IME swallowed the keyup (Windows reports Process/229). Flush it before
+    // the next keystroke so the pending ASCII key still reaches the PTY
+    // instead of wedging the deferral (#3103).
+    if (
+      imeTextInputDeferredKey !== null &&
+      shouldFlushStaleDeferredImeTextInput(imeTextInputDeferredKey, e)
+    ) {
+      flushImeTextInputDeferral();
+    }
 
     if (e.keyCode === 229) {
       markKittyCompositionPending(true);

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -112,6 +112,7 @@ import {
   shouldDeferKeyDownForImeTextInput,
   shouldFlushDeferredImeTextInputOnKeyUp,
   shouldFlushStaleDeferredImeTextInput,
+  shouldRewriteKeyUpToDeferredImeKey,
 } from "./terminalImeTextInput";
 import { formatSerialLocalEcho } from "./serialLocalEcho";
 import { mapTerminalBackspaceInput } from "./terminalBackspaceInput";
@@ -1460,12 +1461,14 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         shouldFlushDeferredImeTextInputOnKeyUp(imeTextInputDeferredKey, e)
       ) {
         const deferredKittyEvent = imeTextInputDeferredKittyEvent;
-        const mangledRelease =
-          e.key !== imeTextInputDeferredKey && deferredKittyEvent !== null;
+        const sentinelRelease =
+          deferredKittyEvent !== null &&
+          shouldRewriteKeyUpToDeferredImeKey(imeTextInputDeferredKey, e);
         flushImeTextInputDeferral();
-        if (mangledRelease && deferredKittyEvent) {
-          // Pair the release from the deferred physical key; the mangled
-          // release event must not be encoded as a kitty key event.
+        if (sentinelRelease && deferredKittyEvent) {
+          // The release reported an IME sentinel (Process/229); pair the
+          // flushed press from the deferred physical key so the kitty
+          // sequence keeps its key identity.
           releaseEvent = {
             ...deferredKittyEvent,
             type: "keyup",

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -110,6 +110,7 @@ import {
   shouldBlockKeyPressForImeTextInput,
   shouldCommitDeferredImeTextInput,
   shouldDeferKeyDownForImeTextInput,
+  shouldDiscardStaleDeferredImeTextInput,
   shouldFlushDeferredImeTextInputOnKeyUp,
   shouldFlushStaleDeferredImeTextInput,
   shouldRewriteKeyUpToDeferredImeKey,
@@ -1536,18 +1537,23 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     // A deferred punctuation keystroke that outlived its own release means the
     // IME swallowed the keyup (Windows reports Process/229). Flush it before
     // the next keystroke so the pending ASCII key still reaches the PTY
-    // instead of wedging the deferral (#3103).
-    if (
-      imeTextInputDeferredKey !== null &&
-      shouldFlushStaleDeferredImeTextInput(imeTextInputDeferredKey, e)
-    ) {
-      const deferredKittyEvent = imeTextInputDeferredKittyEvent;
-      flushImeTextInputDeferral();
-      if (deferredKittyEvent) {
-        // The flush emitted the deferred press, but the release it waits for
-        // is the one the IME dropped — synthesize it so the TUI does not see
-        // the key held until focus loss.
-        releaseForwardedKittyPress({ ...deferredKittyEvent, type: "keyup" });
+    // instead of wedging the deferral (#3103). A modified keydown is a command
+    // rather than a continuation, so the lost keystroke is dropped there
+    // instead of being injected in front of the interrupt or shortcut.
+    if (imeTextInputDeferredKey !== null) {
+      if (shouldFlushStaleDeferredImeTextInput(imeTextInputDeferredKey, e)) {
+        const deferredKittyEvent = imeTextInputDeferredKittyEvent;
+        flushImeTextInputDeferral();
+        if (deferredKittyEvent) {
+          // The flush emitted the deferred press, but the release it waits for
+          // is the one the IME dropped — synthesize it so the TUI does not see
+          // the key held until focus loss.
+          releaseForwardedKittyPress({ ...deferredKittyEvent, type: "keyup" });
+        }
+      } else if (
+        shouldDiscardStaleDeferredImeTextInput(imeTextInputDeferredKey, e)
+      ) {
+        clearImeTextInputDeferral();
       }
     }
 

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -110,10 +110,10 @@ import {
   shouldBlockKeyPressForImeTextInput,
   shouldCommitDeferredImeTextInput,
   shouldDeferKeyDownForImeTextInput,
+  resolveDeferredKeyupRelease,
   shouldDiscardStaleDeferredImeTextInput,
   shouldFlushDeferredImeTextInputOnKeyUp,
   shouldFlushStaleDeferredImeTextInput,
-  shouldRewriteKeyUpToDeferredImeKey,
 } from "./terminalImeTextInput";
 import { formatSerialLocalEcho } from "./serialLocalEcho";
 import { mapTerminalBackspaceInput } from "./terminalBackspaceInput";
@@ -1491,11 +1491,13 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         shouldFlushDeferredImeTextInputOnKeyUp(imeTextInputDeferredKey, e)
       ) {
         const deferredKittyEvent = imeTextInputDeferredKittyEvent;
-        const sentinelRelease =
-          deferredKittyEvent !== null &&
-          shouldRewriteKeyUpToDeferredImeKey(imeTextInputDeferredKey, e);
+        const releaseMode = resolveDeferredKeyupRelease(
+          imeTextInputDeferredKey,
+          deferredKittyEvent?.code ?? null,
+          e,
+        );
         flushImeTextInputDeferral();
-        if (sentinelRelease && deferredKittyEvent) {
+        if (deferredKittyEvent && releaseMode === "deferred") {
           // The release reported an IME sentinel (Process/229); pair the
           // flushed press from the deferred physical key so the kitty
           // sequence keeps its key identity.
@@ -1503,6 +1505,11 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
             ...deferredKittyEvent,
             type: "keyup",
           } as unknown as KeyboardEvent;
+        } else if (deferredKittyEvent && releaseMode === "unrelated") {
+          // Another held key was released first: this keyup only ends the
+          // stale deferral, so the flushed press needs its own synthesized
+          // release while the real keyup keeps its identity.
+          releaseForwardedKittyPress({ ...deferredKittyEvent, type: "keyup" });
         }
       }
       const identity = kittyKeyIdentity(releaseEvent);

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -1405,6 +1405,35 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     // broadcast targets can still receive paired key events.
     imeTextInputDeferredKittyEvent = toKittyKeyboardEvent(event);
   };
+  /**
+   * Emit the paired release for a forwarded press, locally and to broadcast
+   * peers. Used by the keyup handler and by the stale-deferral recovery, where
+   * the IME dropped the release and one must be synthesized from the deferred
+   * physical key so the TUI does not see the key held until focus loss.
+   */
+  const releaseForwardedKittyPress = (
+    event: Pick<KittyKeyboardEvent, "code" | "key"> & KittyKeyboardEvent,
+  ): boolean => {
+    const identity = event.code || event.key;
+    const forwardedPress = broadcastForwardedKeys.get(identity);
+    if (forwardedPress) {
+      broadcastForwardedKeys.delete(identity);
+      broadcastKittyInput(
+        { kind: "key", event },
+        true,
+        forwardedPress.targetSessionIds,
+      );
+    }
+    if (!kittyForwardedKeys.delete(identity)) return false;
+    const sequence = kittyKeyboardProtocolEnabled
+      ? encodeKittyKeyEvent(kittyKeyboardMode, event)
+      : null;
+    if (sequence) {
+      handleTerminalInputData(sequence, { source: "kitty" });
+      return true;
+    }
+    return false;
+  };
 
   term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
     // Preserve mouse selection across keystrokes when enabled. xterm.js
@@ -1477,24 +1506,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       }
       const identity = kittyKeyIdentity(releaseEvent);
       if (broadcastLegacyDataPending === identity) clearBroadcastLegacyDataPending();
-      const forwardedPress = broadcastForwardedKeys.get(identity);
-      if (forwardedPress) {
-        broadcastForwardedKeys.delete(identity);
-        broadcastKittyInput(
-          { kind: "key", event: toKittyKeyboardEvent(releaseEvent) },
-          true,
-          forwardedPress.targetSessionIds,
-        );
-      }
-      if (!kittyForwardedKeys.delete(identity)) return true;
-      const kittyEvent = toKittyKeyboardEvent(releaseEvent);
-      const sequence = kittyKeyboardProtocolEnabled
-        ? encodeKittyKeyEvent(kittyKeyboardMode, kittyEvent)
-        : null;
-      if (sequence) {
+      if (releaseForwardedKittyPress(toKittyKeyboardEvent(releaseEvent))) {
         e.preventDefault();
         e.stopPropagation();
-        handleTerminalInputData(sequence, { source: "kitty" });
         return false;
       }
       return true;
@@ -1527,7 +1541,14 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       imeTextInputDeferredKey !== null &&
       shouldFlushStaleDeferredImeTextInput(imeTextInputDeferredKey, e)
     ) {
+      const deferredKittyEvent = imeTextInputDeferredKittyEvent;
       flushImeTextInputDeferral();
+      if (deferredKittyEvent) {
+        // The flush emitted the deferred press, but the release it waits for
+        // is the one the IME dropped — synthesize it so the TUI does not see
+        // the key held until focus loss.
+        releaseForwardedKittyPress({ ...deferredKittyEvent, type: "keyup" });
+      }
     }
 
     if (e.keyCode === 229) {

--- a/components/terminal/runtime/terminalImeTextInput.test.ts
+++ b/components/terminal/runtime/terminalImeTextInput.test.ts
@@ -9,10 +9,10 @@ import {
   shouldBlockKeyPressForImeTextInput,
   shouldCommitDeferredImeTextInput,
   shouldDeferKeyDownForImeTextInput,
+  resolveDeferredKeyupRelease,
   shouldDiscardStaleDeferredImeTextInput,
   shouldFlushDeferredImeTextInputOnKeyUp,
   shouldFlushStaleDeferredImeTextInput,
-  shouldRewriteKeyUpToDeferredImeKey,
 } from "./terminalImeTextInput";
 
 const runtimeSource = readFileSync(
@@ -163,51 +163,66 @@ test("a Windows IME release reporting Process must flush the deferred slash (#31
 test("a held key released while the deferral is armed keeps its own keyup identity", () => {
   // "/" is deferred (its own release was swallowed) and the user still holds
   // "a" with the other hand, so the "a" keyup lands first. The stale deferral
-  // still ends, but that release is a real keyup, not an IME sentinel: only
-  // the deferred punctuation key may be rewritten, otherwise the held key's
-  // press entry is never paired and the TUI sees it stuck down.
+  // still ends, but that release is a real keyup, not an IME sentinel: it
+  // keeps its own identity, and the deferred press is released separately.
   const deferredKey = "/";
-  const heldKeyUp = { type: "keyup", key: "a", keyCode: 65 };
+  const heldKeyUp = { type: "keyup", key: "a", keyCode: 65, code: "KeyA" };
   assert.equal(
     shouldFlushDeferredImeTextInputOnKeyUp(deferredKey, heldKeyUp),
     true,
     "the stale deferral still ends on a real release",
   );
   assert.equal(
-    shouldRewriteKeyUpToDeferredImeKey(deferredKey, heldKeyUp),
-    false,
+    resolveDeferredKeyupRelease(deferredKey, "Slash", heldKeyUp),
+    "unrelated",
     "an unrelated release must not be rewritten to the deferred key",
   );
 });
 
-test("only IME sentinel releases are rewritten to the deferred key", () => {
+test("only IME sentinel releases take over the deferred key's release identity", () => {
   // Windows IMEs report Process/229 (occasionally Unidentified) as the release
   // of a key they consumed — those are the only releases that stand in for the
   // deferred punctuation key.
   assert.equal(
-    shouldRewriteKeyUpToDeferredImeKey("/", { type: "keyup", key: "Process", keyCode: 229 }),
-    true,
+    resolveDeferredKeyupRelease("/", "Slash", { type: "keyup", key: "Process", keyCode: 229 }),
+    "deferred",
   );
   assert.equal(
-    shouldRewriteKeyUpToDeferredImeKey("/", { type: "keyup", key: "Unidentified" }),
-    true,
+    resolveDeferredKeyupRelease("/", "Slash", { type: "keyup", key: "Unidentified" }),
+    "deferred",
   );
   assert.equal(
-    shouldRewriteKeyUpToDeferredImeKey("/", { type: "keyup", key: "/", keyCode: 191 }),
-    false,
+    resolveDeferredKeyupRelease("/", "Slash", { type: "keyup", key: "/", keyCode: 191 }),
+    "own",
     "a matched release already encodes from the real event",
   );
   assert.equal(
-    shouldRewriteKeyUpToDeferredImeKey("/", { type: "keyup", key: "Shift", keyCode: 16 }),
-    false,
+    resolveDeferredKeyupRelease("/", "Slash", {
+      type: "keyup",
+      key: "1",
+      keyCode: 191,
+      code: "Slash",
+    }),
+    "own",
+    "a release of the same physical key already pairs the flushed press",
   );
   assert.equal(
-    shouldRewriteKeyUpToDeferredImeKey("/", { type: "keyup", key: "a", keyCode: 65, ctrlKey: true }),
-    false,
+    resolveDeferredKeyupRelease("/", "Slash", { type: "keyup", key: "Shift", keyCode: 16 }),
+    "own",
   );
   assert.equal(
-    shouldRewriteKeyUpToDeferredImeKey(null, { type: "keyup", key: "Process", keyCode: 229 }),
-    false,
+    resolveDeferredKeyupRelease("/", "Slash", {
+      type: "keyup",
+      key: "a",
+      keyCode: 65,
+      code: "KeyA",
+      ctrlKey: true,
+    }),
+    "own",
+  );
+  assert.equal(
+    resolveDeferredKeyupRelease(null, null, { type: "keyup", key: "Process", keyCode: 229 }),
+    "own",
   );
 });
 
@@ -463,13 +478,15 @@ test("createXTermRuntime recovers a stuck IME punctuation deferral (#3103)", () 
     /shouldFlushDeferredImeTextInputOnKeyUp\(imeTextInputDeferredKey, e\)/,
   );
   assert.match(keyupSlice, /flushImeTextInputDeferral\(\);/);
-  // Only an IME sentinel release (Process/229/Unidentified) may be rewritten
-  // to the deferred physical key; an unrelated keyup keeps its own identity so
-  // the held key's forwarded press still gets its release.
+  // Only an IME sentinel release (Process/229/Unidentified) takes over the
+  // deferred key's release identity; an unrelated keyup keeps its own identity
+  // and the flushed press is released separately.
   assert.match(
     keyupSlice,
-    /shouldRewriteKeyUpToDeferredImeKey\(imeTextInputDeferredKey, e\)/,
+    /resolveDeferredKeyupRelease\(\s*imeTextInputDeferredKey,\s*deferredKittyEvent\?\.code \?\? null,\s*e,?\s*\)/,
   );
+  assert.match(keyupSlice, /releaseMode === "deferred"/);
+  assert.match(keyupSlice, /releaseMode === "unrelated"/);
   assert.match(
     keyupSlice,
     /\.\.\.deferredKittyEvent,\s*type: "keyup",/,

--- a/components/terminal/runtime/terminalImeTextInput.test.ts
+++ b/components/terminal/runtime/terminalImeTextInput.test.ts
@@ -444,4 +444,10 @@ test("createXTermRuntime recovers a stuck IME punctuation deferral (#3103)", () 
     runtimeSource.slice(staleIdx - 400, staleIdx + 200),
     /flushImeTextInputDeferral\(\);/,
   );
+  // The recovery runs because the deferred key's release will never arrive, so
+  // the press emitted by the flush must be paired with a synthesized release
+  // instead of staying forwarded until focus loss.
+  const recoverySlice = runtimeSource.slice(staleIdx, staleIdx + 500);
+  assert.match(recoverySlice, /deferredKittyEvent = imeTextInputDeferredKittyEvent/);
+  assert.match(recoverySlice, /releaseForwardedKittyPress\(\s*\{\s*\.\.\.deferredKittyEvent,\s*type: "keyup",?\s*\}\s*\)/);
 });

--- a/components/terminal/runtime/terminalImeTextInput.test.ts
+++ b/components/terminal/runtime/terminalImeTextInput.test.ts
@@ -11,6 +11,7 @@ import {
   shouldDeferKeyDownForImeTextInput,
   shouldFlushDeferredImeTextInputOnKeyUp,
   shouldFlushStaleDeferredImeTextInput,
+  shouldRewriteKeyUpToDeferredImeKey,
 } from "./terminalImeTextInput";
 
 const runtimeSource = readFileSync(
@@ -154,6 +155,57 @@ test("a Windows IME release reporting Process must flush the deferred slash (#31
   // Input keeps flowing afterwards.
   assert.equal(
     shouldBlockKeyPressForImeTextInput(deferredKey, { type: "keypress", key: "x", keyCode: 88 }),
+    false,
+  );
+});
+
+test("a held key released while the deferral is armed keeps its own keyup identity", () => {
+  // "/" is deferred (its own release was swallowed) and the user still holds
+  // "a" with the other hand, so the "a" keyup lands first. The stale deferral
+  // still ends, but that release is a real keyup, not an IME sentinel: only
+  // the deferred punctuation key may be rewritten, otherwise the held key's
+  // press entry is never paired and the TUI sees it stuck down.
+  const deferredKey = "/";
+  const heldKeyUp = { type: "keyup", key: "a", keyCode: 65 };
+  assert.equal(
+    shouldFlushDeferredImeTextInputOnKeyUp(deferredKey, heldKeyUp),
+    true,
+    "the stale deferral still ends on a real release",
+  );
+  assert.equal(
+    shouldRewriteKeyUpToDeferredImeKey(deferredKey, heldKeyUp),
+    false,
+    "an unrelated release must not be rewritten to the deferred key",
+  );
+});
+
+test("only IME sentinel releases are rewritten to the deferred key", () => {
+  // Windows IMEs report Process/229 (occasionally Unidentified) as the release
+  // of a key they consumed — those are the only releases that stand in for the
+  // deferred punctuation key.
+  assert.equal(
+    shouldRewriteKeyUpToDeferredImeKey("/", { type: "keyup", key: "Process", keyCode: 229 }),
+    true,
+  );
+  assert.equal(
+    shouldRewriteKeyUpToDeferredImeKey("/", { type: "keyup", key: "Unidentified" }),
+    true,
+  );
+  assert.equal(
+    shouldRewriteKeyUpToDeferredImeKey("/", { type: "keyup", key: "/", keyCode: 191 }),
+    false,
+    "a matched release already encodes from the real event",
+  );
+  assert.equal(
+    shouldRewriteKeyUpToDeferredImeKey("/", { type: "keyup", key: "Shift", keyCode: 16 }),
+    false,
+  );
+  assert.equal(
+    shouldRewriteKeyUpToDeferredImeKey("/", { type: "keyup", key: "a", keyCode: 65, ctrlKey: true }),
+    false,
+  );
+  assert.equal(
+    shouldRewriteKeyUpToDeferredImeKey(null, { type: "keyup", key: "Process", keyCode: 229 }),
     false,
   );
 });
@@ -355,17 +407,18 @@ test("createXTermRuntime recovers a stuck IME punctuation deferral (#3103)", () 
   // Any real key release ends the deferral, not just an exact key match.
   const keyupIdx = runtimeSource.indexOf('if (e.type === "keyup")');
   assert.ok(keyupIdx >= 0);
-  const keyupSlice = runtimeSource.slice(keyupIdx, keyupIdx + 1600);
+  const keyupSlice = runtimeSource.slice(keyupIdx, keyupIdx + 2000);
   assert.match(
     keyupSlice,
     /shouldFlushDeferredImeTextInputOnKeyUp\(imeTextInputDeferredKey, e\)/,
   );
   assert.match(keyupSlice, /flushImeTextInputDeferral\(\);/);
-  // A mangled release must not be encoded as a kitty key event; pair the
-  // release from the deferred physical key instead.
+  // Only an IME sentinel release (Process/229/Unidentified) may be rewritten
+  // to the deferred physical key; an unrelated keyup keeps its own identity so
+  // the held key's forwarded press still gets its release.
   assert.match(
     keyupSlice,
-    /e\.key !== imeTextInputDeferredKey && deferredKittyEvent !== null/,
+    /shouldRewriteKeyUpToDeferredImeKey\(imeTextInputDeferredKey, e\)/,
   );
   assert.match(
     keyupSlice,

--- a/components/terminal/runtime/terminalImeTextInput.test.ts
+++ b/components/terminal/runtime/terminalImeTextInput.test.ts
@@ -9,6 +9,7 @@ import {
   shouldBlockKeyPressForImeTextInput,
   shouldCommitDeferredImeTextInput,
   shouldDeferKeyDownForImeTextInput,
+  shouldDiscardStaleDeferredImeTextInput,
   shouldFlushDeferredImeTextInputOnKeyUp,
   shouldFlushStaleDeferredImeTextInput,
   shouldRewriteKeyUpToDeferredImeKey,
@@ -226,6 +227,64 @@ test("a deferral left without release or insertText recovers on the next keystro
   );
 });
 
+test("a modified keydown discards the stale deferral instead of flushing it", () => {
+  // The IME swallowed the "/" release and the user then interrupts with
+  // Ctrl+C. Flushing there would inject "/" in front of the interrupt, and
+  // keeping the deferral armed would inject it before the next character, so
+  // the lost keystroke is dropped instead.
+  assert.equal(
+    shouldFlushStaleDeferredImeTextInput("/", {
+      type: "keydown",
+      key: "c",
+      keyCode: 67,
+      ctrlKey: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldDiscardStaleDeferredImeTextInput("/", {
+      type: "keydown",
+      key: "c",
+      keyCode: 67,
+      ctrlKey: true,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldDiscardStaleDeferredImeTextInput("/", {
+      type: "keydown",
+      key: "Tab",
+      keyCode: 9,
+      altKey: true,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldDiscardStaleDeferredImeTextInput("/", {
+      type: "keydown",
+      key: "d",
+      keyCode: 229,
+      ctrlKey: true,
+      isComposing: true,
+    }),
+    false,
+    "a composition still owns the keystroke and resolves via insertText",
+  );
+  assert.equal(
+    shouldDiscardStaleDeferredImeTextInput("/", { type: "keydown", key: "a", keyCode: 65 }),
+    false,
+  );
+  assert.equal(
+    shouldDiscardStaleDeferredImeTextInput(null, {
+      type: "keydown",
+      key: "c",
+      keyCode: 67,
+      ctrlKey: true,
+    }),
+    false,
+  );
+});
+
 test("auto-repeat and modifier keystrokes keep the deferral armed", () => {
   // Same-key keydown is auto-repeat: re-arm instead of flushing, so a held key
   // does not emit an extra character per repeat.
@@ -235,15 +294,6 @@ test("auto-repeat and modifier keystrokes keep the deferral armed", () => {
   );
   assert.equal(
     shouldFlushStaleDeferredImeTextInput("/", { type: "keydown", key: "Shift", keyCode: 16 }),
-    false,
-  );
-  assert.equal(
-    shouldFlushStaleDeferredImeTextInput("/", {
-      type: "keydown",
-      key: "c",
-      keyCode: 67,
-      ctrlKey: true,
-    }),
     false,
   );
   assert.equal(
@@ -450,4 +500,10 @@ test("createXTermRuntime recovers a stuck IME punctuation deferral (#3103)", () 
   const recoverySlice = runtimeSource.slice(staleIdx, staleIdx + 500);
   assert.match(recoverySlice, /deferredKittyEvent = imeTextInputDeferredKittyEvent/);
   assert.match(recoverySlice, /releaseForwardedKittyPress\(\s*\{\s*\.\.\.deferredKittyEvent,\s*type: "keyup",?\s*\}\s*\)/);
+  // A modified keydown (Ctrl+C, Alt+…) drops the lost keystroke instead of
+  // injecting it in front of the interrupt or shortcut.
+  assert.match(
+    runtimeSource.slice(staleIdx, staleIdx + 700),
+    /shouldDiscardStaleDeferredImeTextInput\(imeTextInputDeferredKey, e\)/,
+  );
 });

--- a/components/terminal/runtime/terminalImeTextInput.test.ts
+++ b/components/terminal/runtime/terminalImeTextInput.test.ts
@@ -9,6 +9,8 @@ import {
   shouldBlockKeyPressForImeTextInput,
   shouldCommitDeferredImeTextInput,
   shouldDeferKeyDownForImeTextInput,
+  shouldFlushDeferredImeTextInputOnKeyUp,
+  shouldFlushStaleDeferredImeTextInput,
 } from "./terminalImeTextInput";
 
 const runtimeSource = readFileSync(
@@ -63,9 +65,190 @@ test("shouldDeferKeyDownForImeTextInput leaves composition and modified keys alo
 });
 
 test("shouldBlockKeyPressForImeTextInput only while a deferral is armed", () => {
-  assert.equal(shouldBlockKeyPressForImeTextInput(",", { type: "keypress" }), true);
-  assert.equal(shouldBlockKeyPressForImeTextInput(null, { type: "keypress" }), false);
-  assert.equal(shouldBlockKeyPressForImeTextInput(",", { type: "keydown" }), false);
+  assert.equal(
+    shouldBlockKeyPressForImeTextInput(",", { type: "keypress", key: "," }),
+    true,
+  );
+  assert.equal(
+    shouldBlockKeyPressForImeTextInput(null, { type: "keypress", key: "," }),
+    false,
+  );
+  assert.equal(
+    shouldBlockKeyPressForImeTextInput(",", { type: "keydown", key: "," }),
+    false,
+  );
+});
+
+test("shouldBlockKeyPressForImeTextInput still blocks the deferred keystroke itself", () => {
+  assert.equal(
+    shouldBlockKeyPressForImeTextInput(
+      "/",
+      { type: "keypress", key: "/", keyCode: 191 },
+      191,
+    ),
+    true,
+  );
+  // Shift+/ reports "?" on keydown, so the deferral arms with "?".
+  assert.equal(
+    shouldBlockKeyPressForImeTextInput(
+      "?",
+      { type: "keypress", key: "?", keyCode: 191 },
+      191,
+    ),
+    true,
+  );
+  assert.equal(
+    shouldBlockKeyPressForImeTextInput(
+      "/",
+      { type: "keypress", key: "/", isComposing: true },
+      191,
+    ),
+    true,
+  );
+});
+
+test("a stale deferral must not swallow unrelated keypresses (#3103)", () => {
+  // Uppercase letters are routed through keypress by xterm, so a blanket
+  // keypress block turned one stale deferral into a terminal that ignored
+  // everything typed afterwards.
+  assert.equal(
+    shouldBlockKeyPressForImeTextInput(
+      "/",
+      { type: "keypress", key: "X", keyCode: 88 },
+      191,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldBlockKeyPressForImeTextInput(
+      "/",
+      { type: "keypress", key: "a", keyCode: 65 },
+      191,
+    ),
+    false,
+  );
+  // A matching keyCode keeps the block when an IME rewrites the key label.
+  assert.equal(
+    shouldBlockKeyPressForImeTextInput(
+      "/",
+      { type: "keypress", key: "1", keyCode: 191 },
+      191,
+    ),
+    true,
+  );
+});
+
+test("a Windows IME release reporting Process must flush the deferred slash (#3103)", () => {
+  // Windows + CJK IME in vi: keydown still reports the physical key while the
+  // IME consumes it, then reports Process/229 on the release and never sends
+  // an insertText the runtime would treat as a remap.
+  let deferredKey: string | null = null;
+  const keydown = { type: "keydown", key: "/", keyCode: 191 };
+  if (shouldDeferKeyDownForImeTextInput(keydown)) deferredKey = keydown.key;
+  assert.equal(deferredKey, "/");
+
+  const release = { type: "keyup", key: "Process", keyCode: 229 };
+  if (shouldFlushDeferredImeTextInputOnKeyUp(deferredKey, release)) deferredKey = null;
+  assert.equal(deferredKey, null, "the deferral must not outlive its keystroke");
+
+  // Input keeps flowing afterwards.
+  assert.equal(
+    shouldBlockKeyPressForImeTextInput(deferredKey, { type: "keypress", key: "x", keyCode: 88 }),
+    false,
+  );
+});
+
+test("a deferral left without release or insertText recovers on the next keystroke (#3103)", () => {
+  let deferredKey: string | null = null;
+  const keydown = { type: "keydown", key: "/", keyCode: 191 };
+  if (shouldDeferKeyDownForImeTextInput(keydown)) deferredKey = keydown.key;
+  assert.equal(deferredKey, "/");
+
+  // No insertText and no keyup at all; the user then types a plain letter.
+  const nextKeyDown = { type: "keydown", key: "a", keyCode: 65 };
+  if (shouldFlushStaleDeferredImeTextInput(deferredKey, nextKeyDown)) deferredKey = null;
+  assert.equal(deferredKey, null, "the stale deferral must flush before the new keystroke");
+  assert.equal(
+    shouldBlockKeyPressForImeTextInput(deferredKey, { type: "keypress", key: "a", keyCode: 65 }),
+    false,
+  );
+});
+
+test("auto-repeat and modifier keystrokes keep the deferral armed", () => {
+  // Same-key keydown is auto-repeat: re-arm instead of flushing, so a held key
+  // does not emit an extra character per repeat.
+  assert.equal(
+    shouldFlushStaleDeferredImeTextInput("/", { type: "keydown", key: "/", keyCode: 191 }),
+    false,
+  );
+  assert.equal(
+    shouldFlushStaleDeferredImeTextInput("/", { type: "keydown", key: "Shift", keyCode: 16 }),
+    false,
+  );
+  assert.equal(
+    shouldFlushStaleDeferredImeTextInput("/", {
+      type: "keydown",
+      key: "c",
+      keyCode: 67,
+      ctrlKey: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldFlushStaleDeferredImeTextInput("/", {
+      type: "keydown",
+      key: "d",
+      keyCode: 229,
+      isComposing: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldFlushDeferredImeTextInputOnKeyUp("/", { type: "keyup", key: "Shift", keyCode: 16 }),
+    false,
+  );
+  assert.equal(
+    shouldFlushDeferredImeTextInputOnKeyUp("/", {
+      type: "keyup",
+      key: "c",
+      keyCode: 67,
+      ctrlKey: true,
+    }),
+    false,
+  );
+});
+
+test("an active composition still resolves the deferred keystroke via insertText", () => {
+  // The IME absorbed the punctuation into a composition: the composing release
+  // must not flush the ASCII key ahead of the committed glyph.
+  assert.equal(
+    shouldFlushDeferredImeTextInputOnKeyUp("/", {
+      type: "keyup",
+      key: "/",
+      keyCode: 191,
+      isComposing: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldCommitDeferredImeTextInput("/", { inputType: "insertText", data: "、" }),
+    true,
+  );
+});
+
+test("a matched keyup still flushes the English punctuation fallback (#2833)", () => {
+  assert.equal(
+    shouldFlushDeferredImeTextInputOnKeyUp("/", { type: "keyup", key: "/", keyCode: 191 }),
+    true,
+  );
+  assert.equal(
+    shouldFlushDeferredImeTextInputOnKeyUp(null, { type: "keyup", key: "/", keyCode: 191 }),
+    false,
+  );
+  assert.equal(
+    shouldFlushDeferredImeTextInputOnKeyUp("/", { type: "keydown", key: "/", keyCode: 191 }),
+    false,
+  );
 });
 
 test("shouldCommitDeferredImeTextInput accepts insertText payloads while deferred", () => {
@@ -100,7 +283,10 @@ test("isUnchangedDeferredImeTextInput detects English punctuation flush", () => 
 test("createXTermRuntime defers ASCII punctuation keydowns to insertText", () => {
   assert.match(runtimeSource, /shouldDeferKeyDownForImeTextInput\(e\)/);
   assert.match(runtimeSource, /armImeTextInputDeferral\(e\)/);
-  assert.match(runtimeSource, /shouldBlockKeyPressForImeTextInput\(imeTextInputDeferredKey, e\)/);
+  assert.match(
+    runtimeSource,
+    /shouldBlockKeyPressForImeTextInput\(\s*imeTextInputDeferredKey,\s*e,\s*imeTextInputDeferredKittyEvent\?\.keyCode \?\? null,\s*\)/,
+  );
   assert.match(
     runtimeSource,
     /shouldCommitDeferredImeTextInput\(imeTextInputDeferredKey, event\)/,
@@ -162,5 +348,47 @@ test("createXTermRuntime defers ASCII punctuation keydowns to insertText", () =>
   assert.match(
     runtimeSource.slice(compositionIdx, compositionIdx + 420),
     /if \(encoded\) \{[\s\S]*handleTerminalInputData\(encoded, \{ source: "kitty" \}\);[\s\S]*\} else \{[\s\S]*handleTerminalInputData\(text\);/,
+  );
+});
+
+test("createXTermRuntime recovers a stuck IME punctuation deferral (#3103)", () => {
+  // Any real key release ends the deferral, not just an exact key match.
+  const keyupIdx = runtimeSource.indexOf('if (e.type === "keyup")');
+  assert.ok(keyupIdx >= 0);
+  const keyupSlice = runtimeSource.slice(keyupIdx, keyupIdx + 1600);
+  assert.match(
+    keyupSlice,
+    /shouldFlushDeferredImeTextInputOnKeyUp\(imeTextInputDeferredKey, e\)/,
+  );
+  assert.match(keyupSlice, /flushImeTextInputDeferral\(\);/);
+  // A mangled release must not be encoded as a kitty key event; pair the
+  // release from the deferred physical key instead.
+  assert.match(
+    keyupSlice,
+    /e\.key !== imeTextInputDeferredKey && deferredKittyEvent !== null/,
+  );
+  assert.match(
+    keyupSlice,
+    /\.\.\.deferredKittyEvent,\s*type: "keyup",/,
+  );
+  const kittyReleaseIdx = keyupSlice.indexOf("toKittyKeyboardEvent(releaseEvent)");
+  assert.ok(kittyReleaseIdx > keyupSlice.indexOf("flushImeTextInputDeferral();"));
+
+  // The stale flush runs on keydown, after the broadcast guard and before the
+  // composition handling, so a wedged deferral cannot survive a new keystroke.
+  const staleIdx = runtimeSource.indexOf(
+    "shouldFlushStaleDeferredImeTextInput(imeTextInputDeferredKey, e)",
+  );
+  assert.ok(staleIdx > keyupIdx);
+  const keydownGuardIdx = runtimeSource.indexOf("if (handlingKittyBroadcast) return true;", keyupIdx);
+  const keyCode229Idx = runtimeSource.indexOf("if (e.keyCode === 229) {", keyupIdx);
+  assert.ok(
+    keydownGuardIdx > keyupIdx &&
+      staleIdx > keydownGuardIdx &&
+      keyCode229Idx > staleIdx,
+  );
+  assert.match(
+    runtimeSource.slice(staleIdx - 400, staleIdx + 200),
+    /flushImeTextInputDeferral\(\);/,
   );
 });

--- a/components/terminal/runtime/terminalImeTextInput.ts
+++ b/components/terminal/runtime/terminalImeTextInput.ts
@@ -8,6 +8,12 @@
  * Defer those keydowns to the following insertText. If no remap arrives before
  * keyup/blur, the original ASCII key is flushed. Composition (keyCode 229 /
  * isComposing) stays on xterm's CompositionHelper path.
+ *
+ * The deferral must never outlive the keystroke it was armed for: Windows IMEs
+ * report `Process` / keyCode 229 as the keyup of a key they consumed (or drop
+ * the keyup), so a deferral flushed only on an exact key match stayed armed and
+ * blocked typed input from then on (#3103). Any real key release, and any later
+ * unrelated keydown, now ends the deferral.
  */
 
 export type ImeTextInputKeyEvent = {
@@ -38,11 +44,71 @@ export function shouldDeferKeyDownForImeTextInput(
   return isAsciiPunctuationKey(event.key);
 }
 
+/** Key releases that carry no keystroke of their own. */
+const MODIFIER_ONLY_KEY_RE =
+  /^(Shift|Control|Alt|Meta|CapsLock|NumLock|ScrollLock|Hyper|Super|Fn|FnLock|Symbol|SymbolLock)$/;
+
+export function isModifierOnlyKey(key: string): boolean {
+  return MODIFIER_ONLY_KEY_RE.test(key);
+}
+
+/**
+ * A deferred punctuation keystroke is over once any real key release arrives.
+ * The IME remap (insertText) is dispatched before keyup, so a release means the
+ * IME did not remap the key and the ASCII character must be flushed.
+ *
+ * The release key cannot be matched exactly: Windows IMEs report `Process` /
+ * keyCode 229 as the release of a key they consumed, and some drop the release
+ * entirely. Requiring an exact key match left the deferral armed, and the
+ * armed deferral then blocked input (#3103). Composing releases are excluded —
+ * an active composition still owns the keystroke and resolves it via
+ * insertText.
+ */
+export function shouldFlushDeferredImeTextInputOnKeyUp(
+  deferredKey: string | null | undefined,
+  event: ImeTextInputKeyEvent,
+): boolean {
+  if (!deferredKey) return false;
+  if (event.type !== undefined && event.type !== "keyup") return false;
+  if (event.isComposing === true) return false;
+  if (event.altKey || event.ctrlKey || event.metaKey) return false;
+  return !isModifierOnlyKey(event.key);
+}
+
+/**
+ * A deferral that outlived its own keystroke is stale — the IME swallowed the
+ * release. Flush it when a new, unmodified, non-composing keydown for a
+ * different key arrives so the pending ASCII character still reaches the PTY.
+ * A same-key keydown is auto-repeat (or a second IME attempt) and keeps
+ * re-arming instead.
+ */
+export function shouldFlushStaleDeferredImeTextInput(
+  deferredKey: string | null | undefined,
+  event: ImeTextInputKeyEvent,
+): boolean {
+  if (!deferredKey) return false;
+  if (event.type !== undefined && event.type !== "keydown") return false;
+  if (event.isComposing === true || event.keyCode === 229) return false;
+  if (event.altKey || event.ctrlKey || event.metaKey) return false;
+  if (isModifierOnlyKey(event.key)) return false;
+  return event.key !== deferredKey;
+}
+
 export function shouldBlockKeyPressForImeTextInput(
   deferredKey: string | null | undefined,
-  event: Pick<ImeTextInputKeyEvent, "type">,
+  event: ImeTextInputKeyEvent,
+  deferredKeyCode?: number | null,
 ): boolean {
-  return Boolean(deferredKey) && event.type === "keypress";
+  if (!deferredKey || event.type !== "keypress") return false;
+  // Composition keypresses carry no committable character on this path.
+  if (event.isComposing === true || event.keyCode === 229) return true;
+  // Only the deferred keystroke itself is suppressed. Blocking every keypress
+  // while armed turned one stale deferral into a terminal that ignored all
+  // typed input (#3103).
+  return (
+    event.key === deferredKey ||
+    (deferredKeyCode != null && event.keyCode === deferredKeyCode)
+  );
 }
 
 export function shouldCommitDeferredImeTextInput(

--- a/components/terminal/runtime/terminalImeTextInput.ts
+++ b/components/terminal/runtime/terminalImeTextInput.ts
@@ -106,6 +106,22 @@ export function shouldFlushStaleDeferredImeTextInput(
 }
 
 /**
+ * A modified keydown is a command (Ctrl+C, Alt+…), not the continuation of the
+ * lost punctuation keystroke: flushing there would inject the ASCII character
+ * in front of the interrupt or shortcut. Drop the stale deferral instead — the
+ * keystroke was already lost to the IME.
+ */
+export function shouldDiscardStaleDeferredImeTextInput(
+  deferredKey: string | null | undefined,
+  event: ImeTextInputKeyEvent,
+): boolean {
+  if (!deferredKey) return false;
+  if (event.type !== undefined && event.type !== "keydown") return false;
+  if (event.isComposing === true || event.keyCode === 229) return false;
+  return Boolean(event.altKey || event.ctrlKey || event.metaKey);
+}
+
+/**
  * True when the release that ends a deferral is an IME sentinel standing in
  * for the deferred key, so the paired Kitty release must be encoded from the
  * deferred physical key instead. A real keyup for another held key keeps its

--- a/components/terminal/runtime/terminalImeTextInput.ts
+++ b/components/terminal/runtime/terminalImeTextInput.ts
@@ -53,6 +53,17 @@ export function isModifierOnlyKey(key: string): boolean {
 }
 
 /**
+ * DOM keys that stand in for a key the IME consumed, mirroring the non-text
+ * DOM keys the Kitty encoder already refuses to send as text.
+ */
+const IME_SENTINEL_KEYS = new Set(["Dead", "Process", "Unidentified", "Compose"]);
+
+export function isImeSentinelKeyUp(event: ImeTextInputKeyEvent): boolean {
+  if (event.type !== undefined && event.type !== "keyup") return false;
+  return event.keyCode === 229 || IME_SENTINEL_KEYS.has(event.key);
+}
+
+/**
  * A deferred punctuation keystroke is over once any real key release arrives.
  * The IME remap (insertText) is dispatched before keyup, so a release means the
  * IME did not remap the key and the ASCII character must be flushed.
@@ -92,6 +103,25 @@ export function shouldFlushStaleDeferredImeTextInput(
   if (event.altKey || event.ctrlKey || event.metaKey) return false;
   if (isModifierOnlyKey(event.key)) return false;
   return event.key !== deferredKey;
+}
+
+/**
+ * True when the release that ends a deferral is an IME sentinel standing in
+ * for the deferred key, so the paired Kitty release must be encoded from the
+ * deferred physical key instead. A real keyup for another held key keeps its
+ * own identity — rewriting it would strand that key's forwarded press and the
+ * TUI would see it stuck down until focus loss.
+ */
+export function shouldRewriteKeyUpToDeferredImeKey(
+  deferredKey: string | null | undefined,
+  event: ImeTextInputKeyEvent,
+): boolean {
+  if (!deferredKey) return false;
+  if (event.type !== undefined && event.type !== "keyup") return false;
+  if (event.altKey || event.ctrlKey || event.metaKey) return false;
+  if (isModifierOnlyKey(event.key)) return false;
+  if (event.key === deferredKey) return false;
+  return isImeSentinelKeyUp(event);
 }
 
 export function shouldBlockKeyPressForImeTextInput(

--- a/components/terminal/runtime/terminalImeTextInput.ts
+++ b/components/terminal/runtime/terminalImeTextInput.ts
@@ -19,6 +19,7 @@
 export type ImeTextInputKeyEvent = {
   type?: string;
   key: string;
+  code?: string;
   keyCode?: number;
   altKey?: boolean;
   ctrlKey?: boolean;
@@ -122,22 +123,29 @@ export function shouldDiscardStaleDeferredImeTextInput(
 }
 
 /**
- * True when the release that ends a deferral is an IME sentinel standing in
- * for the deferred key, so the paired Kitty release must be encoded from the
- * deferred physical key instead. A real keyup for another held key keeps its
- * own identity — rewriting it would strand that key's forwarded press and the
- * TUI would see it stuck down until focus loss.
+ * How the keyup that ends a deferral relates to the deferred key.
+ * - `deferred`: an IME sentinel stood in for the deferred key, so the paired
+ *   release must be encoded from the deferred physical key.
+ * - `own`: the release belongs to the deferred key itself (matched key or
+ *   physical code), so it already pairs the press the flush emitted.
+ * - `unrelated`: another held key was released; it keeps its own identity and
+ *   the deferred press needs a separate synthesized release.
  */
-export function shouldRewriteKeyUpToDeferredImeKey(
+export type DeferredKeyupReleaseMode = "deferred" | "own" | "unrelated";
+
+export function resolveDeferredKeyupRelease(
   deferredKey: string | null | undefined,
+  deferredCode: string | null | undefined,
   event: ImeTextInputKeyEvent,
-): boolean {
-  if (!deferredKey) return false;
-  if (event.type !== undefined && event.type !== "keyup") return false;
-  if (event.altKey || event.ctrlKey || event.metaKey) return false;
-  if (isModifierOnlyKey(event.key)) return false;
-  if (event.key === deferredKey) return false;
-  return isImeSentinelKeyUp(event);
+): DeferredKeyupReleaseMode {
+  if (!deferredKey) return "own";
+  if (event.type !== undefined && event.type !== "keyup") return "own";
+  if (event.altKey || event.ctrlKey || event.metaKey) return "own";
+  if (isModifierOnlyKey(event.key)) return "own";
+  if (event.key === deferredKey) return "own";
+  if (event.code && deferredCode && event.code === deferredCode) return "own";
+  if (isImeSentinelKeyUp(event)) return "deferred";
+  return "unrelated";
 }
 
 export function shouldBlockKeyPressForImeTextInput(


### PR DESCRIPTION
## Summary

Fixes `/` search in vi only working once. The first `/调用` search works fine, but after pressing Enter, pressing `/` again produces no reaction at all and the whole window appears frozen.

The cause is the deferred handling of IME punctuation. To fix the macOS Sogou issue where half-width punctuation gets converted to full-width (#2833), the keydown phase holds back ASCII punctuation like `/` and waits for the following insertText to decide whether to send the full-width character or re-send the original half-width one. That pending state originally had only three exits: an insertText commit, a keyup whose `key` exactly matches the held key, or a session reset.

Windows IMEs don't follow that order. After the IME consumes the key, the keyup often reports `Process` (keyCode 229) instead of the original `/`, and sometimes there is no keyup at all. The key comparison fails and the pending state is never cleared. Worse, all keypresses are blocked while a deferral is armed, so it's not just `/` — later keys routed through keypress (like capital letters) get swallowed too. The terminal simply stops reacting.

The freeze sequence reproduces directly against the original code:

- keydown `/` (keyCode 191) → deferral armed
- keyup reports `key: "Process"`, keyCode 229 → key mismatch, no flush, deferral stays armed
- subsequent keypresses `X`, `a`, `/` are all blocked; not a single byte reaches the PTY

The fix:

- keyup no longer requires an exact key match; any real key release ends the pending deferral (releases during composition are still left to insertText, so the half-width re-send doesn't race ahead of the full-width glyph).
- If a keydown arrives while a deferral has survived past its own keystroke (meaning the keyup was swallowed), the held-back character is flushed before the new key is processed. Repeated keydowns of the same key are treated as auto-repeat and keep the existing re-arm behavior, so no extra characters appear.
- The keypress block is narrowed from "all" to "the deferred key", matched by key or keyCode, so unrelated keys are not swallowed even when the deferral state goes stale.
- When the keyup reports a different key, the paired kitty release is encoded from the physical key recorded at defer time, so `Process`/229 is never encoded into a sequence.

## Type of Change

- [x] Bug fix

## Related Issue (optional)

Fixes #3103

## Changes Made

- `components/terminal/runtime/terminalImeTextInput.ts`: new keyup/keydown deferral-release predicates and `isModifierOnlyKey`; the keypress block now targets only the deferred key.
- `components/terminal/runtime/createXTermRuntime.ts`: the keyup flush uses the new predicate; a mismatched release is paired from the physical key recorded at defer time; keydown flushes the deferred character before handling the new key; the keypress block is passed the deferred key's keyCode.
- `components/terminal/runtime/terminalImeTextInput.test.ts`: adds Windows IME event-sequence cases — keyup turning into Process, neither keyup nor insertText arriving, auto-repeat and modifiers, and no half-width re-send mid-composition.
- Follow-up hardening from code review: only IME sentinel releases (`Process`/229/`Unidentified`/`Dead`/`Compose`) are rewritten to the deferred key; the recovery path synthesizes the deferred key's kitty release so no press is left stranded; modified keydowns (Ctrl/Alt/Meta) discard a stale deferral instead of injecting the lost keystroke in front of an interrupt like Ctrl+C; keyup handling is a total case analysis (sentinel takes over / own identity / unrelated keeps its identity plus a synthesized release).

The #2833 behavior is untouched: the insertText commit, the composition path, and the English-punctuation keyup fallback all fire at the same points, and their tests keep passing.

## Screenshots / Demo

No UI changes.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

- `node --test --import tsx components/terminal/runtime/*.test.ts`: 802 cases all pass, including the new IME cases (each new case was red before its fix).
- The remaining cases under `components/terminal`: 806 all pass.
- The full `npm test` has 9 failures locally, all in the `packages/plugin-cli` packing cases and `electron/bridges/sshAlgorithms.test.cjs`; none of those files were touched in this PR. The failures come from the worktree not having its own node_modules and from local zip-validation behavior differences — unrelated to this change.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)