### PR TITLE
fix(terminal): send IME commits and short pastes per character

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -966,3 +966,52 @@ test("alternate-screen history preview falls back to the captured session output
   assert.match(source, /outputHistory\.getPreviewRows\(\{/);
   assert.match(source, /nextOutputHistoryPreviewTop\(/);
 });
+
+test("multi-character plain text goes out as per-character writes (#3077)", async () => {
+  const { readFileSync } = await import("node:fs");
+  const source = readFileSync(new URL("./createXTermRuntime.ts", import.meta.url), "utf8");
+
+  // Strict bastion prompts (QAX) treat one channel write as one keystroke and
+  // drop multi-character chunks, so IME commits and short raw pastes must be
+  // sent one character per write instead of one write per commit.
+  assert.match(source, /perCharacterWrites\?: boolean/);
+  assert.match(
+    source,
+    /getTextInputWireChunks\(outData, options\?\.perCharacterWrites === true\)/,
+  );
+  // Every chunk carries the same write options as the original single write.
+  const writeLoopIdx = source.indexOf("for (const chunk of getTextInputWireChunks(outData");
+  assert.ok(writeLoopIdx >= 0);
+  const writeLoop = source.slice(writeLoopIdx, writeLoopIdx + 320);
+  assert.match(writeLoop, /for \(const chunk of/);
+  assert.match(writeLoop, /writeToSession\(id, chunk, \{ sensitive \}\)/);
+
+  // IME commits split the committed glyph, not the Kitty CSI-u encoding.
+  assert.match(
+    source,
+    /handleTerminalInputData\(text, \{ perCharacterWrites: shouldSplitImeTextInputForWire\(text\) \}\)/,
+  );
+  // Raw onData (unbracketed paste / committed composition) uses the capped
+  // raw-paste rule; the composition fallback uses the uncapped IME rule.
+  assert.match(
+    source,
+    /handleTerminalInputData\(data, \{ perCharacterWrites: shouldSplitRawPasteInputForWire\(data\) \}\)/,
+  );
+  assert.match(
+    source,
+    /handleTerminalInputData\(data, \{ perCharacterWrites: shouldSplitImeTextInputForWire\(data\) \}\)/,
+  );
+  // Negotiated Kitty paths keep their single write: CSI-u associated text and
+  // forwarded key sequences must never be split across writes.
+  const compositionIdx = source.indexOf(
+    "handleTerminalInputData(encoded, { source: \"kitty\" })",
+  );
+  assert.ok(compositionIdx >= 0);
+  assert.doesNotMatch(source.slice(0, compositionIdx + 60), /handleTerminalInputData\(encoded, \{ perCharacterWrites/);
+  assert.doesNotMatch(source, /handleTerminalInputData\(sequence, \{ perCharacterWrites/);
+  // Bookkeeping sees the original string exactly once: the command buffer and
+  // broadcast keep using the unsplit payload.
+  const writeSite = source.slice(writeLoopIdx - 600, writeLoopIdx + 320);
+  assert.match(writeSite, /ctx\.onOutputTriggerUserInputRef\?\.current\?\.\(outData\)/);
+  assert.match(source, /onBroadcastInput\?\.\(broadcastData, ctx\.sessionId\)/);
+});

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -117,6 +117,11 @@ import {
 } from "./terminalImeTextInput";
 import { formatSerialLocalEcho } from "./serialLocalEcho";
 import { mapTerminalBackspaceInput } from "./terminalBackspaceInput";
+import {
+  getTextInputWireChunks,
+  shouldSplitImeTextInputForWire,
+  shouldSplitRawPasteInputForWire,
+} from "./terminalPerCharacterInput";
 import { formatTelnetLocalEcho } from "./telnetLocalEcho";
 import {
   isTerminalFontSizeAction,
@@ -1093,6 +1098,13 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       source?: "terminal" | "shift-enter" | "kitty";
       /** Skip string broadcast when peers will re-resolve from a key chord. */
       skipBroadcast?: boolean;
+      /**
+       * Send plain text as one write per character. Strict bastion prompts
+       * (QAX) treat one channel write as a keystroke and drop multi-character
+       * chunks, so IME commits and short raw pastes must go out per
+       * character (#3077). Bookkeeping still sees the whole payload once.
+       */
+      perCharacterWrites?: boolean;
     },
   ) => {
     // Clipboard paste / typed password while assist is open must dismiss the
@@ -1208,7 +1220,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         // When backspaceBehavior is configured, remap the Backspace key output
         const outData = mapTerminalBackspaceInput(dataToWrite, ctx.host.backspaceBehavior);
         ctx.onOutputTriggerUserInputRef?.current?.(outData);
-        ctx.terminalBackend.writeToSession(id, outData, { sensitive });
+        for (const chunk of getTextInputWireChunks(outData, options?.perCharacterWrites === true)) {
+          ctx.terminalBackend.writeToSession(id, chunk, { sensitive });
+        }
 
         // Local echo for serial connections only when explicitly enabled
         if (inputSource !== "kitty" && ctx.host.protocol === "serial" && ctx.serialLocalEcho) {
@@ -1372,7 +1386,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       if (ctx.isBroadcastEnabledRef.current && ctx.onBroadcastInputRef.current) {
         suppressNextTerminalDataBroadcast = true;
       }
-      handleTerminalInputData(text);
+      handleTerminalInputData(text, { perCharacterWrites: shouldSplitImeTextInputForWire(text) });
       if (deferredKittyEvent) {
         const pressEvent: KittyKeyboardEvent = {
           ...deferredKittyEvent,
@@ -1421,7 +1435,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       if (ctx.isBroadcastEnabledRef.current && ctx.onBroadcastInputRef.current) {
         suppressNextTerminalDataBroadcast = true;
       }
-      handleTerminalInputData(text);
+      handleTerminalInputData(text, { perCharacterWrites: shouldSplitImeTextInputForWire(text) });
     }
     broadcastKittyInput({ kind: "text", text });
   };
@@ -2245,7 +2259,8 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         if (ctx.isBroadcastEnabledRef.current && ctx.onBroadcastInputRef.current) {
           suppressNextTerminalDataBroadcast = true;
         }
-        handleTerminalInputData(data);
+        // Committed composition text, not a negotiated Kitty sequence.
+        handleTerminalInputData(data, { perCharacterWrites: shouldSplitImeTextInputForWire(data) });
       }
       broadcastKittyInput({ kind: "text", text: data });
       return;
@@ -2263,7 +2278,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       });
       broadcastLegacyDataPending = null;
     }
-    handleTerminalInputData(data);
+    // Raw multi-character onData is an unbracketed paste (or a committed
+    // composition): short plain text must reach strict bastions per character.
+    handleTerminalInputData(data, { perCharacterWrites: shouldSplitRawPasteInputForWire(data) });
   });
 
   const handleKittyKeyboardBroadcast = createKittyKeyboardBroadcastHandler({

--- a/components/terminal/runtime/shiftEnterText.test.ts
+++ b/components/terminal/runtime/shiftEnterText.test.ts
@@ -146,7 +146,7 @@ test("runtime routes Shift+Enter text through the shared input handler", () => {
 
   assert.match(
     source,
-    /const handleTerminalInputData = \(\s+data: string,\s+options\?: \{\s+source\?: "terminal" \| "shift-enter" \| "kitty";\s+[\s\S]*?skipBroadcast\?: boolean;\s+\},\s+\) => \{/s,
+    /const handleTerminalInputData = \(\s+data: string,\s+options\?: \{\s+source\?: "terminal" \| "shift-enter" \| "kitty";\s+[\s\S]*?skipBroadcast\?: boolean;\s+[\s\S]*?perCharacterWrites\?: boolean;\s+\},\s+\) => \{/s,
   );
   // Remap when Kitty encoding does not preserve Shift+Enter (not merely flags===0).
   assert.match(
@@ -173,11 +173,11 @@ test("runtime routes Shift+Enter text through the shared input handler", () => {
   );
   assert.match(
     source,
-    /term\.onData\(\(data\) => \{[\s\S]*handleTerminalInputData\(data\);\s+\}\);/,
+    /term\.onData\(\(data\) => \{[\s\S]*handleTerminalInputData\(data, \{ perCharacterWrites: shouldSplitRawPasteInputForWire\(data\) \}\);\s+\}\);/,
   );
   assert.match(
     source,
-    /const encoded = encodeKittyCompositionText\(kittyKeyboardMode, data\);[\s\S]*if \(encoded\) \{[\s\S]*handleTerminalInputData\(encoded, \{ source: "kitty" \}\);[\s\S]*\} else \{[\s\S]*handleTerminalInputData\(data\);[\s\S]*broadcastKittyInput\(\{ kind: "text", text: data \}\);/,
+    /const encoded = encodeKittyCompositionText\(kittyKeyboardMode, data\);[\s\S]*if \(encoded\) \{[\s\S]*handleTerminalInputData\(encoded, \{ source: "kitty" \}\);[\s\S]*\} else \{[\s\S]*handleTerminalInputData\(data, \{ perCharacterWrites: shouldSplitImeTextInputForWire\(data\) \}\);[\s\S]*broadcastKittyInput\(\{ kind: "text", text: data \}\);/,
   );
   assert.match(source, /ctx\.container\.addEventListener\("input", markKittyTextInput, true\);/);
   assert.match(

--- a/components/terminal/runtime/terminalImeTextInput.test.ts
+++ b/components/terminal/runtime/terminalImeTextInput.test.ts
@@ -458,13 +458,13 @@ test("createXTermRuntime defers ASCII punctuation keydowns to insertText", () =>
   assert.ok(unchangedFallbackIdx > unchangedIdx);
   assert.match(
     runtimeSource.slice(unchangedFallbackIdx, unchangedFallbackIdx + 1800),
-    /handleTerminalInputData\(text\);[\s\S]*shouldTrackKittyKeyRelease\(kittyKeyboardMode, pressEvent\)[\s\S]*upsertKittyKeyboardForwardedPress\(\s*kittyForwardedKeys,[\s\S]*broadcastKittyInput\(\{[\s\S]*kind: "key",[\s\S]*fallbackToLegacy: true,/,
+    /handleTerminalInputData\(text, \{ perCharacterWrites: shouldSplitImeTextInputForWire\(text\) \}\);[\s\S]*shouldTrackKittyKeyRelease\(kittyKeyboardMode, pressEvent\)[\s\S]*upsertKittyKeyboardForwardedPress\(\s*kittyForwardedKeys,[\s\S]*broadcastKittyInput\(\{[\s\S]*kind: "key",[\s\S]*fallbackToLegacy: true,/,
   );
   // Remap path must fall back to literal text when composition encoding is null
   // (report-all without associated text).
   assert.match(
-    runtimeSource.slice(compositionIdx, compositionIdx + 420),
-    /if \(encoded\) \{[\s\S]*handleTerminalInputData\(encoded, \{ source: "kitty" \}\);[\s\S]*\} else \{[\s\S]*handleTerminalInputData\(text\);/,
+    runtimeSource.slice(compositionIdx, compositionIdx + 460),
+    /if \(encoded\) \{[\s\S]*handleTerminalInputData\(encoded, \{ source: "kitty" \}\);[\s\S]*\} else \{[\s\S]*handleTerminalInputData\(text, \{ perCharacterWrites: shouldSplitImeTextInputForWire\(text\) \}\);/,
   );
 });
 

--- a/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
+++ b/components/terminal/runtime/terminalInterceptorInputSafety.test.ts
@@ -38,7 +38,7 @@ test("password-prompt input is classified before prompt state reset and cannot b
   );
   assert.match(
     runtimeSource,
-    /writeToSession\(id, outData, \{ sensitive \}\)/u,
+    /for \(const chunk of getTextInputWireChunks\(outData, options\?\.perCharacterWrites === true\)\) \{\s*ctx\.terminalBackend\.writeToSession\(id, chunk, \{ sensitive \}\);\s*\}/u,
   );
   assert.match(
     runtimeSource,

--- a/components/terminal/runtime/terminalPerCharacterInput.test.ts
+++ b/components/terminal/runtime/terminalPerCharacterInput.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  MAX_RAW_PASTE_PER_CHARACTER_LENGTH,
+  getTextInputWireChunks,
+  shouldSplitImeTextInputForWire,
+  shouldSplitRawPasteInputForWire,
+  splitTextIntoCodePointWrites,
+} from "./terminalPerCharacterInput";
+
+test("splitTextIntoCodePointWrites keeps surrogate pairs on one write", () => {
+  assert.deepEqual(splitTextIntoCodePointWrites("a中👍b"), ["a", "中", "👍", "b"]);
+  assert.deepEqual(splitTextIntoCodePointWrites("👍"), ["👍"]);
+  assert.deepEqual(splitTextIntoCodePointWrites(""), []);
+});
+
+test("IME commits with more than one character split per character", () => {
+  assert.equal(shouldSplitImeTextInputForWire("中国"), true);
+  assert.equal(shouldSplitImeTextInputForWire("abc"), true);
+  assert.equal(shouldSplitImeTextInputForWire("中a👍"), true);
+});
+
+test("single-character IME commits keep the single write", () => {
+  assert.equal(shouldSplitImeTextInputForWire("中"), false);
+  assert.equal(shouldSplitImeTextInputForWire("👍"), false);
+  assert.equal(shouldSplitImeTextInputForWire(","), false);
+  assert.equal(shouldSplitImeTextInputForWire(""), false);
+});
+
+test("IME commits carrying escape sequences never split", () => {
+  assert.equal(shouldSplitImeTextInputForWire("\x1b[200~中\x1b[201~"), false);
+  assert.equal(shouldSplitImeTextInputForWire("\x1b[0;;200u"), false);
+  assert.equal(shouldSplitImeTextInputForWire("\x1ba"), false);
+});
+
+test("short raw pastes split per character", () => {
+  assert.equal(shouldSplitRawPasteInputForWire("10.1.2.3"), true);
+  assert.equal(shouldSplitRawPasteInputForWire("中文"), true);
+  assert.equal(shouldSplitRawPasteInputForWire("ab"), true);
+  assert.equal(
+    shouldSplitRawPasteInputForWire("a".repeat(MAX_RAW_PASTE_PER_CHARACTER_LENGTH)),
+    true,
+  );
+});
+
+test("single-character and long raw pastes keep the single write", () => {
+  assert.equal(shouldSplitRawPasteInputForWire("a"), false);
+  assert.equal(
+    shouldSplitRawPasteInputForWire("a".repeat(MAX_RAW_PASTE_PER_CHARACTER_LENGTH + 1)),
+    false,
+  );
+  assert.equal(shouldSplitRawPasteInputForWire(""), false);
+});
+
+test("raw pastes containing escape sequences never split", () => {
+  assert.equal(shouldSplitRawPasteInputForWire("\x1b[200~ab\x1b[201~"), false);
+  assert.equal(shouldSplitRawPasteInputForWire("\x1b[A"), false);
+  assert.equal(shouldSplitRawPasteInputForWire("a\x1b"), false);
+});
+
+test("wire chunking honors the per-character request only for plain text", () => {
+  assert.deepEqual(getTextInputWireChunks("ab", false), ["ab"]);
+  assert.deepEqual(getTextInputWireChunks("ab", true), ["a", "b"]);
+  assert.deepEqual(getTextInputWireChunks("a中👍", true), ["a", "中", "👍"]);
+  assert.deepEqual(getTextInputWireChunks("\x1b[200~ab\x1b[201~", true), [
+    "\x1b[200~ab\x1b[201~",
+  ]);
+});

--- a/components/terminal/runtime/terminalPerCharacterInput.ts
+++ b/components/terminal/runtime/terminalPerCharacterInput.ts
@@ -1,0 +1,45 @@
+/**
+ * Strict bastion prompts (e.g. QAX/奇安信) treat one SSH channel write as a
+ * single keystroke and silently drop every multi-character chunk (#3077). IME
+ * commits and short raw pastes therefore have to leave the renderer as
+ * per-character writes, which is what typing produces and what Xshell does.
+ */
+
+/** Raw pastes longer than this keep the single-write behavior. */
+export const MAX_RAW_PASTE_PER_CHARACTER_LENGTH = 32;
+
+const ESC = "\x1b";
+
+/** True while the payload only carries plain text and no escape sequence. */
+export const isPlainTerminalInputText = (data: string): boolean => !data.includes(ESC);
+
+/** One chunk per Unicode code point so surrogate pairs stay intact. */
+export const splitTextIntoCodePointWrites = (data: string): string[] => Array.from(data);
+
+/** IME commits: any plain text with more than one character splits per glyph. */
+export const shouldSplitImeTextInputForWire = (text: string): boolean =>
+  Array.from(text).length > 1 && isPlainTerminalInputText(text);
+
+/**
+ * Raw (non-bracketed) paste: short plain text goes out as keystrokes, longer
+ * pastes keep the single write so bulk pastes do not degrade.
+ */
+export const shouldSplitRawPasteInputForWire = (data: string): boolean => {
+  if (data.length <= 1 || !isPlainTerminalInputText(data)) return false;
+  let codePoints = 0;
+  for (let index = 0; index < data.length; ) {
+    index += (data.codePointAt(index) ?? 0) > 0xffff ? 2 : 1;
+    codePoints += 1;
+    if (codePoints > MAX_RAW_PASTE_PER_CHARACTER_LENGTH) return false;
+  }
+  return true;
+};
+
+/** Chunks to write for one input payload; escape sequences are never split. */
+export const getTextInputWireChunks = (
+  data: string,
+  perCharacterWrites: boolean,
+): string[] =>
+  perCharacterWrites && isPlainTerminalInputText(data)
+    ? splitTextIntoCodePointWrites(data)
+    : [data];


### PR DESCRIPTION
## Summary

Fixes #3077. On QAX (奇安信) bastion hosts, an IME commit of two or more hanzi and a pasted Chinese string both vanish at the bastion's "输入搜索关键字" prompt, while typing the same characters one at a time works. This PR splits multi-character plain text at the send boundary so those payloads leave the renderer as per-character writes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Fixes #3077

## Changes Made

Diagnosis: the bastion treats one SSH channel write as a single keystroke and drops any multi-character chunk entirely - not even the first character shows. Single hanzi typed one at a time works, an IME commit of 2+ characters in one write shows nothing, pasting Chinese shows nothing, encoding (UTF-8 vs GB18030) is irrelevant, and normal server shells are unaffected. Xshell works there because it sends one write per keystroke, which matches the reporter's own suggestion of sending the text "逐个接收、然后逐个发给堡垒机命令行". Netcatty sent an IME commit as one write: xterm `onData` → `handleTerminalInputData` → `terminalBackend.writeToSession` → IPC → one `stream.write` of the whole string in the terminal bridge. I verified the bridge has no coalescing queue for interactive input: each non-automated IPC write maps to exactly one channel write, only ordered by the interceptor promise chain, so a renderer-side split reaches the wire as separate writes.

What the change does, renderer-side only (no new settings, no UI, no main-process changes):

- New `components/terminal/runtime/terminalPerCharacterInput.ts` holds the decision logic. `handleTerminalInputData` gained a `perCharacterWrites` option and its write site now iterates `getTextInputWireChunks(outData, ...)` - one chunk per Unicode code point, never per UTF-16 code unit, so surrogate pairs stay intact. Every chunk carries the same `{ sensitive }` options as the original single write.
- IME commits: the non-kitty literal-glyph paths (`commitImeTextInput` fallbacks and the committed-composition fallback in `term.onData`) split whenever the committed text has more than one code point.
- Short raw pastes: a raw `onData` payload with no escape sequence at all and at most 32 characters goes out per character; longer raw pastes keep today's single write. 32 characters covers the second reported failure (pasting a host name or a few hanzi into the search prompt) without degrading bulk pastes.
- Escape sequences are never split: anything containing `\x1b` keeps the single-write behavior, which leaves bracketed paste (`\x1b[200~`), negotiated Kitty CSI-u associated text, forwarded Kitty key sequences, and terminal reports exactly as they are today. Bastions don't negotiate Kitty, so those paths are untouched.
- Bookkeeping still sees the original payload exactly once: command buffer, script recorder, autocomplete, sudo autofill, scroll suppression, and broadcast all keep operating on the unsplit string. Broadcast peers still receive the original string once instead of N characters.

## Screenshots / Demo

No UI change. Behavior: on a strict bastion prompt, an IME commit of "中国" now reaches the wire as two writes (`中`, then `国`) instead of one write of "中国", and a pasted short hostname or Chinese string goes out character by character.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Note on the two unchecked boxes: end-to-end verification against the actual QAX bastion isn't possible for us - we cannot reach the reporter's host, and the issue thread shows the owner hit the same wall. The approach is the one the reporter proposed, so this PR needs their confirmation on that bastion. `npm test` results are identical to `main` apart from the new tests: the 8 failures in `packages/plugin-cli` packing/archive tests and `electron/bridges/sshAlgorithms.test.cjs` reproduce on a clean checkout of `main` in this environment and are unrelated.

New tests: `terminalPerCharacterInput.test.ts` covers the splitter (surrogate pairs stay on one write), the IME rule, the raw-paste cap at 32 characters, and the rule that anything containing an escape sequence never splits. `createXTermRuntime.test.ts` adds wiring assertions that the write loop reuses the same options, that the Kitty CSI-u and forwarded-key paths are not flagged for splitting, and that bookkeeping/broadcast keep the unsplit payload. Existing tests that pinned the exact single-write call shape (`terminalInterceptorInputSafety.test.ts`, `terminalImeTextInput.test.ts`, `shiftEnterText.test.ts`) were updated to the chunked form they now assert.

Remaining known path: the compose bar / snippet runner sends programmatic input through the `automated` write path with its own line-delay machinery, so a single long line from there is still one write. I left it alone since it is a different surface than the reported one, but it is the next place to apply the same split if the reporter still sees this when sending via the compose bar.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
