### PR TITLE
fix(notes): keep unrenderable markdown visible in the notes editor

### DIFF
--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -29,6 +29,8 @@ export const enVaultMessages: Messages = {
   'notes.mode.preview': 'Preview',
   'notes.title.placeholder': 'Note title',
   'notes.editor.placeholder': 'Write Markdown notes here...',
+  'notes.editor.unrenderableMarkdown': 'This note contains Markdown the rich editor cannot display (for example unbalanced <tag> text). Showing the raw Markdown source instead — the content is intact.',
+  'notes.editor.retryRichView': 'Retry rich view',
   'notes.preview.empty': 'Nothing to preview yet.',
   'notes.empty.title': 'No notes yet',
   'notes.empty.desc': 'Create Markdown notes for runbooks, reminders, and server handoff details.',

--- a/application/i18n/locales/es/vault.ts
+++ b/application/i18n/locales/es/vault.ts
@@ -29,6 +29,8 @@ export const esVaultMessages: Messages = {
   'notes.mode.preview': 'Vista previa',
   'notes.title.placeholder': 'Título de la nota',
   'notes.editor.placeholder': 'Escribe notas Markdown aquí...',
+  'notes.editor.unrenderableMarkdown': 'Esta nota contiene Markdown que el editor enriquecido no puede mostrar (por ejemplo, etiquetas sin cerrar como <tag>). Se muestra el origen Markdown sin cambios: el contenido está intacto.',
+  'notes.editor.retryRichView': 'Reintentar vista enriquecida',
   'notes.preview.empty': 'Aún no hay nada para previsualizar.',
   'notes.empty.title': 'Aún no hay notas',
   'notes.empty.desc': 'Crea notas Markdown para runbooks, recordatorios y detalles de traspaso de servidores.',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -29,6 +29,8 @@ export const ruVaultMessages: Messages = {
   'notes.mode.preview': 'Просмотр',
   'notes.title.placeholder': 'Заголовок заметки',
   'notes.editor.placeholder': 'Пишите Markdown-заметки здесь...',
+  'notes.editor.unrenderableMarkdown': 'Эта заметка содержит Markdown, который не может отобразить визуальный редактор (например, незакрытые теги вида <tag>). Показан исходный Markdown — содержимое не потеряно.',
+  'notes.editor.retryRichView': 'Повторить в визуальном режиме',
   'notes.preview.empty': 'Пока нечего просматривать.',
   'notes.empty.title': 'Заметок пока нет',
   'notes.empty.desc': 'Создавайте Markdown-заметки для инструкций, напоминаний и передачи серверов.',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -29,6 +29,8 @@ export const zhCNVaultMessages: Messages = {
   'notes.mode.preview': '预览',
   'notes.title.placeholder': '笔记标题',
   'notes.editor.placeholder': '在这里写 Markdown 笔记...',
+  'notes.editor.unrenderableMarkdown': '这篇笔记包含富文本编辑器无法显示的 Markdown（例如未闭合的 <tag> 文本），已改为显示原始 Markdown 源码，内容并没有丢失。',
+  'notes.editor.retryRichView': '重试富文本视图',
   'notes.preview.empty': '暂无内容可预览。',
   'notes.empty.title': '还没有笔记',
   'notes.empty.desc': '可以记录运维手册、临时备忘、服务器交接信息。',

--- a/application/i18n/locales/zh-TW/vault.ts
+++ b/application/i18n/locales/zh-TW/vault.ts
@@ -29,6 +29,8 @@ export const zhTWVaultMessages: Messages = {
   'notes.mode.preview': '預覽',
   'notes.title.placeholder': '筆記標題',
   'notes.editor.placeholder': '在這裡寫 Markdown 筆記...',
+  'notes.editor.unrenderableMarkdown': '這篇筆記包含富文本編輯器無法顯示的 Markdown（例如未閉合的 <tag> 文字），已改為顯示原始 Markdown 原始碼，內容並沒有遺失。',
+  'notes.editor.retryRichView': '重試富文字檢視',
   'notes.preview.empty': '暫無內容可預覽。',
   'notes.empty.title': '還沒有筆記',
   'notes.empty.desc': '可以記錄運維手冊、臨時備忘、伺服器交接資訊。',

--- a/components/notes/InlineMarkdownEditor.tsx
+++ b/components/notes/InlineMarkdownEditor.tsx
@@ -18,7 +18,7 @@ import {
 } from "@mdxeditor/editor";
 import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { tags } from "@lezer/highlight";
-import { ExternalLink } from "lucide-react";
+import { AlertTriangle, ExternalLink } from "lucide-react";
 import {
   $createRangeSelection,
   $getNearestNodeFromDOMNode,
@@ -978,6 +978,12 @@ export const InlineMarkdownEditor = React.memo(
             return;
           }
 
+          // Unrenderable-markdown fallback: the raw source editor is mounted.
+          if (mdxFallbackActiveRef.current) {
+            fallbackSourceEditorRef.current?.insertAction(action);
+            return;
+          }
+
           const container = containerRef.current;
           const editable = container?.querySelector("[contenteditable]");
           const lexicalEditor = editable ? getNearestEditorFromDOMNode(editable) : null;
@@ -1056,11 +1062,18 @@ export const InlineMarkdownEditor = React.memo(
           }
         },
         focus: () => {
+          if (mdxFallbackActiveRef.current) {
+            fallbackSourceEditorRef.current?.focus();
+            return;
+          }
           editorRef.current?.focus();
         },
         scrollToHeading: (heading: NoteHeadingItem, headingIndex: number) => {
           if (controlledEditorMode === "source") {
             return sourceEditorRef?.current?.scrollToLine(heading.line) ?? false;
+          }
+          if (mdxFallbackActiveRef.current) {
+            return fallbackSourceEditorRef.current?.scrollToLine(heading.line) ?? false;
           }
           const occurrence = extractNoteHeadings(value)
             .slice(0, headingIndex)
@@ -1083,10 +1096,20 @@ export const InlineMarkdownEditor = React.memo(
   const [linkAction, setLinkAction] = useState<LinkActionState | null>(null);
   const [acceptedSourceMarkdown, setAcceptedSourceMarkdown] = useState(value);
   const [isContentSwapping, setIsContentSwapping] = useState(false);
+  // MDX (the rich editor's parser) rejects some CommonMark — e.g. unbalanced
+  // angle tags like `<host>` in prose. MDXEditor then renders an EMPTY document
+  // and only reports the failure through onError, which made such notes look
+  // like they had lost their content. Track the failure and fall back to the
+  // raw markdown source view so the content always stays visible.
+  const [mdxParseFailure, setMdxParseFailure] = useState<string | null>(null);
   const linkActionRef = useRef<LinkActionState | null>(null);
   linkActionRef.current = linkAction;
   const mouseMoveFrameRef = useRef(0);
   const editorMode = controlledEditorMode ?? "edit";
+  const mdxFallbackActive = mdxParseFailure !== null && editorMode !== "source";
+  const mdxFallbackActiveRef = useRef(false);
+  mdxFallbackActiveRef.current = mdxFallbackActive;
+  const fallbackSourceEditorRef = useRef<NoteSourceEditorHandle | null>(null);
   const hostPickerRangeRef = useRef<Range | null>(null);
   const hostPickerListRef = useRef<FixedSizeVirtualListHandle>(null);
   const hostsRef = useRef(hosts);
@@ -1226,6 +1249,9 @@ export const InlineMarkdownEditor = React.memo(
       const scheduledNoteId = noteId;
       noteIdRef.current = noteId;
       pasteRecoveryGenerationRef.current += 1;
+      // The new note's markdown gets a fresh MDX import; clear a previous
+      // note's unrenderable-markdown fallback.
+      setMdxParseFailure(null);
       // Keep both refs in displayMarkdown space so public-path normalization
       // does not look like a divergent local draft.
       latestMarkdownRef.current = markdown;
@@ -1371,6 +1397,9 @@ export const InlineMarkdownEditor = React.memo(
 
   useEffect(() => {
     setLinkAction(null);
+    // Mode changes remount the rich editor (key={editorMode}); give its MDX
+    // import a fresh chance after an unrenderable-markdown fallback.
+    setMdxParseFailure(null);
   }, [editorMode]);
 
   const getHostPickerContext = useCallback(() => {
@@ -1545,6 +1574,23 @@ export const InlineMarkdownEditor = React.memo(
     setAcceptedSourceMarkdown(markdown);
     onChange(markdown);
   }, [onChange]);
+
+  // MDXEditor reports markdown it cannot import through onError (the lexical
+  // document is left empty). Switch to the raw source view so the note content
+  // is never silently hidden; the user can retry or edit the raw markdown.
+  // The failure is reported while MDXEditor's realm is still rendering, so a
+  // synchronous setState here would be dropped — defer it to a timer.
+  const handleMdxParseError = useCallback((payload: { error: string; source: string }) => {
+    const failedNoteId = noteIdRef.current;
+    window.setTimeout(() => {
+      if (noteIdRef.current !== failedNoteId) return;
+      setMdxParseFailure((current) => current ?? payload.error);
+    }, 0);
+  }, []);
+
+  const retryRichNoteEditor = useCallback(() => {
+    setMdxParseFailure(null);
+  }, []);
 
   const insertHostLink = useCallback((host: Host) => {
     const link = `[${getHostLinkLabel(host)}](${formatSshDeepLinkForHost(host)})`;
@@ -2093,6 +2139,33 @@ export const InlineMarkdownEditor = React.memo(
           noteFontFamily={noteFontFamily}
           noteFontSize={noteCodeFontSize || noteFontSize}
         />
+      ) : mdxFallbackActive ? (
+        <div data-note-markdown-source-fallback="true" className="flex min-h-0 flex-1 flex-col">
+          <div
+            data-note-markdown-source-notice="true"
+            className="flex items-start gap-2 border-b border-border/60 bg-muted/40 px-4 py-2 text-xs text-muted-foreground"
+          >
+            <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+            <span className="min-w-0 flex-1">{t("notes.editor.unrenderableMarkdown")}</span>
+            <button
+              type="button"
+              className="shrink-0 rounded px-1.5 py-0.5 text-xs text-foreground underline decoration-dotted hover:bg-secondary"
+              onClick={retryRichNoteEditor}
+            >
+              {t("notes.editor.retryRichView")}
+            </button>
+          </div>
+          <NoteSourceEditor
+            ref={fallbackSourceEditorRef}
+            noteId={noteId}
+            value={noteId !== undefined && noteId !== noteIdRef.current ? value : acceptedSourceMarkdown}
+            placeholder={placeholder}
+            onChange={commitSourceMarkdown}
+            readOnly={editorMode === "preview"}
+            noteFontFamily={noteFontFamily}
+            noteFontSize={noteCodeFontSize || noteFontSize}
+          />
+        </div>
       ) : editorMode === "preview" && !displayMarkdown.trim() ? (
         <div className="netcatty-note-preview-empty">
           {previewEmptyLabel ?? placeholder}
@@ -2111,6 +2184,7 @@ export const InlineMarkdownEditor = React.memo(
           )}
           contentEditableClassName="netcatty-mdx-content"
           onChange={commitMarkdown}
+          onError={handleMdxParseError}
         />
       )}
     </div>

--- a/components/notes/InlineMarkdownEditor.tsx
+++ b/components/notes/InlineMarkdownEditor.tsx
@@ -1252,6 +1252,7 @@ export const InlineMarkdownEditor = React.memo(
       // The new note's markdown gets a fresh MDX import; clear a previous
       // note's unrenderable-markdown fallback.
       setMdxParseFailure(null);
+      setMdxRetryMarkdown(null);
       // Keep both refs in displayMarkdown space so public-path normalization
       // does not look like a divergent local draft.
       latestMarkdownRef.current = markdown;
@@ -1400,6 +1401,7 @@ export const InlineMarkdownEditor = React.memo(
     // Mode changes remount the rich editor (key={editorMode}); give its MDX
     // import a fresh chance after an unrenderable-markdown fallback.
     setMdxParseFailure(null);
+    setMdxRetryMarkdown(null);
   }, [editorMode]);
 
   const getHostPickerContext = useCallback(() => {
@@ -1588,7 +1590,14 @@ export const InlineMarkdownEditor = React.memo(
     }, 0);
   }, []);
 
+  // One-shot markdown for the retry after a fallback: NotesManager debounces
+  // source drafts, so the `value` prop can still hold the pre-fix body when
+  // the user retries right after editing in the fallback. Seed that retry
+  // import from the editor's own latest accepted source instead.
+  const [mdxRetryMarkdown, setMdxRetryMarkdown] = useState<string | null>(null);
+
   const retryRichNoteEditor = useCallback(() => {
+    setMdxRetryMarkdown(latestSourceMarkdownRef.current);
     setMdxParseFailure(null);
   }, []);
 
@@ -2149,6 +2158,7 @@ export const InlineMarkdownEditor = React.memo(
             <span className="min-w-0 flex-1">{t("notes.editor.unrenderableMarkdown")}</span>
             <button
               type="button"
+              data-note-markdown-source-retry="true"
               className="shrink-0 rounded px-1.5 py-0.5 text-xs text-foreground underline decoration-dotted hover:bg-secondary"
               onClick={retryRichNoteEditor}
             >
@@ -2174,7 +2184,11 @@ export const InlineMarkdownEditor = React.memo(
         <MDXEditor
           key={editorMode}
           ref={editorRef}
-          markdown={displayMarkdown}
+          markdown={
+            mdxRetryMarkdown !== null && mdxRetryMarkdown !== value
+              ? normalizeNotePublicAssetPaths(mdxRetryMarkdown)
+              : displayMarkdown
+          }
           placeholder={placeholder}
           plugins={plugins}
           readOnly={editorMode === "preview"}

--- a/components/notes/InlineMarkdownEditor.tsx
+++ b/components/notes/InlineMarkdownEditor.tsx
@@ -1252,7 +1252,7 @@ export const InlineMarkdownEditor = React.memo(
       // The new note's markdown gets a fresh MDX import; clear a previous
       // note's unrenderable-markdown fallback.
       setMdxParseFailure(null);
-      setMdxRetryMarkdown(null);
+      setMdxRetry(null);
       // Keep both refs in displayMarkdown space so public-path normalization
       // does not look like a divergent local draft.
       latestMarkdownRef.current = markdown;
@@ -1401,7 +1401,7 @@ export const InlineMarkdownEditor = React.memo(
     // Mode changes remount the rich editor (key={editorMode}); give its MDX
     // import a fresh chance after an unrenderable-markdown fallback.
     setMdxParseFailure(null);
-    setMdxRetryMarkdown(null);
+    setMdxRetry(null);
   }, [editorMode]);
 
   const getHostPickerContext = useCallback(() => {
@@ -1593,13 +1593,14 @@ export const InlineMarkdownEditor = React.memo(
   // One-shot markdown for the retry after a fallback: NotesManager debounces
   // source drafts, so the `value` prop can still hold the pre-fix body when
   // the user retries right after editing in the fallback. Seed that retry
-  // import from the editor's own latest accepted source instead.
-  const [mdxRetryMarkdown, setMdxRetryMarkdown] = useState<string | null>(null);
+  // import from the editor's own latest accepted source instead, but only while
+  // the parent prop is still the stale body that originally failed.
+  const [mdxRetry, setMdxRetry] = useState<{ markdown: string; staleValue: string } | null>(null);
 
   const retryRichNoteEditor = useCallback(() => {
-    setMdxRetryMarkdown(latestSourceMarkdownRef.current);
+    setMdxRetry({ markdown: latestSourceMarkdownRef.current, staleValue: value });
     setMdxParseFailure(null);
-  }, []);
+  }, [value]);
 
   const insertHostLink = useCallback((host: Host) => {
     const link = `[${getHostLinkLabel(host)}](${formatSshDeepLinkForHost(host)})`;
@@ -2185,8 +2186,8 @@ export const InlineMarkdownEditor = React.memo(
           key={editorMode}
           ref={editorRef}
           markdown={
-            mdxRetryMarkdown !== null && mdxRetryMarkdown !== value
-              ? normalizeNotePublicAssetPaths(mdxRetryMarkdown)
+            mdxRetry !== null && value === mdxRetry.staleValue
+              ? normalizeNotePublicAssetPaths(mdxRetry.markdown)
               : displayMarkdown
           }
           placeholder={placeholder}

--- a/components/notes/InlineMarkdownEditor.tsx
+++ b/components/notes/InlineMarkdownEditor.tsx
@@ -1357,6 +1357,15 @@ export const InlineMarkdownEditor = React.memo(
     latestSourceMarkdownRef.current = value;
     syncedSourceMarkdownRef.current = value;
     setAcceptedSourceMarkdown(value);
+    if (displayChanged && mdxFallbackActiveRef.current) {
+      // A sync/publish update replaced this note's unrenderable markdown while
+      // the source fallback was active. editorRef.setMarkdown below would hit
+      // the unmounted MDXEditor, so clear the failure instead: the rich editor
+      // remounts with the new markdown. If it is still unrenderable, onError
+      // re-arms the fallback.
+      setMdxParseFailure(null);
+      setMdxRetry(null);
+    }
     if (!displayChanged) return;
     try {
       editorRef.current?.setMarkdown(markdown);

--- a/components/notes/InlineMarkdownEditor.tsx
+++ b/components/notes/InlineMarkdownEditor.tsx
@@ -149,6 +149,14 @@ export interface InlineMarkdownEditorProps {
 
 export const NOTE_EDIT_DECORATION_DEBOUNCE_MS = 160;
 
+export const shouldApplyMdxParseFailure = (input: {
+  currentNoteId?: string;
+  failedNoteId?: string;
+  currentMarkdown: string;
+  failedMarkdown: string;
+}): boolean => input.currentNoteId === input.failedNoteId
+  && input.currentMarkdown === input.failedMarkdown;
+
 export const getNoteDecorationMutationDelay = (editorMode: NoteEditorMode): number =>
   editorMode === "edit" || editorMode === "live" ? NOTE_EDIT_DECORATION_DEBOUNCE_MS : 0;
 
@@ -1584,8 +1592,16 @@ export const InlineMarkdownEditor = React.memo(
   // synchronous setState here would be dropped — defer it to a timer.
   const handleMdxParseError = useCallback((payload: { error: string; source: string }) => {
     const failedNoteId = noteIdRef.current;
+    const failedMarkdown = normalizeNotePublicAssetPaths(payload.source);
     window.setTimeout(() => {
-      if (noteIdRef.current !== failedNoteId) return;
+      if (!shouldApplyMdxParseFailure({
+        currentNoteId: noteIdRef.current,
+        failedNoteId,
+        currentMarkdown: latestMarkdownRef.current,
+        failedMarkdown,
+      })) return;
+      // The same note can receive a newer external value before the deferred
+      // callback runs. Do not show the old import failure over that content.
       setMdxParseFailure((current) => current ?? payload.error);
     }, 0);
   }, []);
@@ -2150,7 +2166,10 @@ export const InlineMarkdownEditor = React.memo(
           noteFontSize={noteCodeFontSize || noteFontSize}
         />
       ) : mdxFallbackActive ? (
-        <div data-note-markdown-source-fallback="true" className="flex min-h-0 flex-1 flex-col">
+        <div
+          data-note-markdown-source-fallback="true"
+          className="flex min-h-[calc(100vh-15rem)] min-w-0 flex-1 flex-col"
+        >
           <div
             data-note-markdown-source-notice="true"
             className="flex items-start gap-2 border-b border-border/60 bg-muted/40 px-4 py-2 text-xs text-muted-foreground"

--- a/components/notes/InlineMarkdownEditor.tsx
+++ b/components/notes/InlineMarkdownEditor.tsx
@@ -155,7 +155,7 @@ export const shouldApplyMdxParseFailure = (input: {
   currentMarkdown: string;
   failedMarkdown: string;
 }): boolean => input.currentNoteId === input.failedNoteId
-  && input.currentMarkdown === input.failedMarkdown;
+  && input.currentMarkdown.trim() === input.failedMarkdown.trim();
 
 export const getNoteDecorationMutationDelay = (editorMode: NoteEditorMode): number =>
   editorMode === "edit" || editorMode === "live" ? NOTE_EDIT_DECORATION_DEBOUNCE_MS : 0;

--- a/components/notes/InlineMarkdownEditor.tsx
+++ b/components/notes/InlineMarkdownEditor.tsx
@@ -1128,7 +1128,7 @@ export const InlineMarkdownEditor = React.memo(
   // buttons. Listens to Lexical selection/update changes in edit/live modes.
   useEffect(() => {
     if (!onActiveFormatsChange) return;
-    if (editorMode !== "edit" && editorMode !== "live") {
+    if (mdxFallbackActive || (editorMode !== "edit" && editorMode !== "live")) {
       onActiveFormatsChange(EMPTY_ACTIVE_FORMATS);
       return;
     }
@@ -1172,7 +1172,7 @@ export const InlineMarkdownEditor = React.memo(
       unregisterUpdate();
       unregisterSelection();
     };
-  }, [editorMode, onActiveFormatsChange]);
+  }, [editorMode, mdxFallbackActive, onActiveFormatsChange]);
 
   const setLinkActionIfChanged = useCallback((next: LinkActionState | null) => {
     if (linkActionStatesEqual(linkActionRef.current, next)) return;

--- a/components/notes/InlineMarkdownEditor.unrenderableMarkdown.test.tsx
+++ b/components/notes/InlineMarkdownEditor.unrenderableMarkdown.test.tsx
@@ -87,7 +87,10 @@ type RenderEditorProps = {
   editorMode?: "edit" | "preview" | "source";
 };
 
-const renderEditor = async (window: DomHarness["window"], props: RenderEditorProps) => {
+const renderEditor = async (
+  window: DomHarness["window"],
+  props: RenderEditorProps,
+) => {
   const { act } = await import("react");
   const { createRoot } = await import("react-dom/client");
   const { I18nProvider } = await import("../../application/i18n/I18nProvider.tsx");
@@ -232,4 +235,21 @@ test("retry imports the latest fallback draft, not the stale prop value", async 
   } finally {
     cleanup();
   }
+});
+
+test("a stale parse error is ignored when the same note has newer markdown", async () => {
+  const { shouldApplyMdxParseFailure } = await import("./InlineMarkdownEditor.tsx");
+
+  assert.equal(shouldApplyMdxParseFailure({
+    currentNoteId: "note-1",
+    failedNoteId: "note-1",
+    currentMarkdown: PLAIN_NOTE_MARKDOWN,
+    failedMarkdown: NOTE_MARKDOWN_MDX_CANNOT_PARSE,
+  }), false);
+  assert.equal(shouldApplyMdxParseFailure({
+    currentNoteId: "note-1",
+    failedNoteId: "note-1",
+    currentMarkdown: NOTE_MARKDOWN_MDX_CANNOT_PARSE,
+    failedMarkdown: NOTE_MARKDOWN_MDX_CANNOT_PARSE,
+  }), true);
 });

--- a/components/notes/InlineMarkdownEditor.unrenderableMarkdown.test.tsx
+++ b/components/notes/InlineMarkdownEditor.unrenderableMarkdown.test.tsx
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { JSDOM } from "jsdom";
 
+import { runWithAct } from "../test-support/renderReactDom.tsx";
+
 /**
  * Regression tests for the notes rich editor: markdown that MDX cannot parse
  * (e.g. unbalanced angle tags such as `<host>` in prose) used to render as an
@@ -127,6 +129,13 @@ const renderEditor = async (window: DomHarness["window"], props: RenderEditorPro
 const querySourceFallback = (rootNode: HTMLElement) =>
   rootNode.querySelector<HTMLTextAreaElement>("[data-note-markdown-source-fallback] textarea");
 
+const setTextareaValue = (window: DomHarness["window"], textarea: HTMLTextAreaElement, nextValue: string) => {
+  const setValue = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")?.set;
+  assert.ok(setValue);
+  setValue.call(textarea, nextValue);
+  textarea.dispatchEvent(new window.Event("input", { bubbles: true }));
+};
+
 test("unrenderable markdown stays visible via the raw source fallback", async () => {
   const { window, cleanup } = setupDom();
   try {
@@ -165,7 +174,7 @@ test("plain markdown still renders in the rich editor", async () => {
 test("unrenderable markdown in preview mode falls back to a read-only source view", async () => {
   const { window, cleanup } = setupDom();
   try {
-    const { rootNode, unmount } = await renderEditor(window, {
+    const { rootNode, changes, unmount } = await renderEditor(window, {
       value: NOTE_MARKDOWN_MDX_CANNOT_PARSE,
       editorMode: "preview",
     });
@@ -174,6 +183,51 @@ test("unrenderable markdown in preview mode falls back to a read-only source vie
     assert.ok(fallback, "expected the raw markdown fallback in preview mode");
     assert.equal(fallback.value, NOTE_MARKDOWN_MDX_CANNOT_PARSE);
     assert.equal(fallback.readOnly, true);
+
+    // Read-only must also block the custom Tab insertion and history handling.
+    await runWithAct(async () => {
+      fallback.dispatchEvent(new window.KeyboardEvent("keydown", {
+        key: "Tab",
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+    assert.deepEqual(changes, [], "read-only fallback must not mutate the note");
+    await unmount();
+  } finally {
+    cleanup();
+  }
+});
+
+test("retry imports the latest fallback draft, not the stale prop value", async () => {
+  const { window, cleanup } = setupDom();
+  try {
+    // The host keeps the original (invalid) `value` prop, like the 300 ms
+    // draft debounce in NotesManager does while the user edits the fallback.
+    const { rootNode, changes, unmount } = await renderEditor(window, { value: NOTE_MARKDOWN_MDX_CANNOT_PARSE });
+
+    const fallback = querySourceFallback(rootNode);
+    assert.ok(fallback);
+
+    const fixedMarkdown = NOTE_MARKDOWN_MDX_CANNOT_PARSE.replace("mysql -h <host> -u <user>", "mysql with host and user");
+    await runWithAct(async () => {
+      setTextareaValue(window, fallback, fixedMarkdown);
+    });
+    assert.deepEqual(changes, [fixedMarkdown]);
+
+    const retry = rootNode.querySelector<HTMLButtonElement>("[data-note-markdown-source-retry]");
+    assert.ok(retry, "expected a retry action on the fallback notice");
+    await runWithAct(async () => {
+      retry.click();
+    });
+    await runWithAct(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    const editable = rootNode.querySelector<HTMLElement>("[contenteditable]");
+    assert.ok(editable, "expected the rich editor back after the retry");
+    assert.match(editable.textContent || "", /The content after the angle tags/);
+    assert.equal(querySourceFallback(rootNode), null, "the fallback must be gone after a successful retry");
     await unmount();
   } finally {
     cleanup();

--- a/components/notes/InlineMarkdownEditor.unrenderableMarkdown.test.tsx
+++ b/components/notes/InlineMarkdownEditor.unrenderableMarkdown.test.tsx
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+
+/**
+ * Regression tests for the notes rich editor: markdown that MDX cannot parse
+ * (e.g. unbalanced angle tags such as `<host>` in prose) used to render as an
+ * empty editor, so an AI-written or imported note looked like it had lost its
+ * content. The editor must fall back to the raw markdown source view instead.
+ */
+
+const NOTE_MARKDOWN_MDX_CANNOT_PARSE = [
+  "# SlurmDB Agent Skill",
+  "",
+  "## Overview",
+  "",
+  "Run the exporter with mysql -h <host> -u <user> -P 3306.",
+  "",
+  "The content after the angle tags must stay visible.",
+].join("\n");
+
+const PLAIN_NOTE_MARKDOWN = ["# Steps", "", "Promote the replica, then restart the agent."].join("\n");
+
+const setupDom = () => {
+  const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+    pretendToBeVisual: true,
+    url: "http://localhost",
+  });
+  const window = dom.window;
+  const previousGlobals = new Map<string, PropertyDescriptor | undefined>();
+  const installGlobal = (key: string, value: unknown) => {
+    previousGlobals.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+  };
+
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  for (const [key, value] of Object.entries({
+    window,
+    document: window.document,
+    navigator: window.navigator,
+    HTMLElement: window.HTMLElement,
+    HTMLInputElement: window.HTMLInputElement,
+    HTMLTextAreaElement: window.HTMLTextAreaElement,
+    HTMLSelectElement: window.HTMLSelectElement,
+    Element: window.Element,
+    SVGElement: window.SVGElement,
+    Node: window.Node,
+    NodeFilter: window.NodeFilter,
+    MutationObserver: window.MutationObserver,
+    CustomEvent: window.CustomEvent,
+    DOMRect: window.DOMRect,
+    Event: window.Event,
+    KeyboardEvent: window.KeyboardEvent,
+    MouseEvent: window.MouseEvent,
+    getComputedStyle: window.getComputedStyle.bind(window),
+    requestAnimationFrame: window.requestAnimationFrame.bind(window),
+    cancelAnimationFrame: window.cancelAnimationFrame.bind(window),
+    ResizeObserver: ResizeObserverStub,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  })) {
+    installGlobal(key, value);
+  }
+
+  return {
+    window,
+    cleanup() {
+      for (const [key, descriptor] of previousGlobals) {
+        if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+        else delete (globalThis as Record<string, unknown>)[key];
+      }
+      dom.window.close();
+    },
+  };
+};
+
+type DomHarness = ReturnType<typeof setupDom>;
+
+type RenderEditorProps = {
+  value: string;
+  editorMode?: "edit" | "preview" | "source";
+};
+
+const renderEditor = async (window: DomHarness["window"], props: RenderEditorProps) => {
+  const { act } = await import("react");
+  const { createRoot } = await import("react-dom/client");
+  const { I18nProvider } = await import("../../application/i18n/I18nProvider.tsx");
+  const { InlineMarkdownEditor } = await import("./InlineMarkdownEditor.tsx");
+
+  const rootNode = window.document.getElementById("root");
+  assert.ok(rootNode);
+  const root = createRoot(rootNode);
+  const changes: string[] = [];
+  await act(async () => {
+    root.render(
+      <I18nProvider locale="en">
+        <InlineMarkdownEditor
+          noteId="note-1"
+          value={props.value}
+          placeholder="Write Markdown notes here..."
+          editorMode={props.editorMode ?? "edit"}
+          onChange={(next) => changes.push(next)}
+          hosts={[]}
+        />
+      </I18nProvider>,
+    );
+  });
+  // Let the deferred MDX import (and its parse-error reporting) settle.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  });
+  return {
+    rootNode,
+    changes,
+    async unmount() {
+      await act(async () => {
+        root.unmount();
+      });
+    },
+  };
+};
+
+const querySourceFallback = (rootNode: HTMLElement) =>
+  rootNode.querySelector<HTMLTextAreaElement>("[data-note-markdown-source-fallback] textarea");
+
+test("unrenderable markdown stays visible via the raw source fallback", async () => {
+  const { window, cleanup } = setupDom();
+  try {
+    const { rootNode, unmount } = await renderEditor(window, { value: NOTE_MARKDOWN_MDX_CANNOT_PARSE });
+
+    const fallback = querySourceFallback(rootNode);
+    assert.ok(fallback, "expected the raw markdown fallback to be rendered");
+    assert.equal(fallback.value, NOTE_MARKDOWN_MDX_CANNOT_PARSE);
+
+    const notice = rootNode.querySelector("[data-note-markdown-source-notice]");
+    assert.ok(notice, "expected an explanatory notice next to the fallback");
+
+    // The rich editor must not sit next to the fallback showing a blank page.
+    assert.equal(rootNode.querySelectorAll("[contenteditable]").length, 0);
+    await unmount();
+  } finally {
+    cleanup();
+  }
+});
+
+test("plain markdown still renders in the rich editor", async () => {
+  const { window, cleanup } = setupDom();
+  try {
+    const { rootNode, unmount } = await renderEditor(window, { value: PLAIN_NOTE_MARKDOWN });
+
+    assert.equal(querySourceFallback(rootNode), null);
+    const editable = rootNode.querySelector<HTMLElement>("[contenteditable]");
+    assert.ok(editable, "expected the rich editor to stay mounted");
+    assert.match(editable.textContent || "", /Promote the replica/);
+    await unmount();
+  } finally {
+    cleanup();
+  }
+});
+
+test("unrenderable markdown in preview mode falls back to a read-only source view", async () => {
+  const { window, cleanup } = setupDom();
+  try {
+    const { rootNode, unmount } = await renderEditor(window, {
+      value: NOTE_MARKDOWN_MDX_CANNOT_PARSE,
+      editorMode: "preview",
+    });
+
+    const fallback = querySourceFallback(rootNode);
+    assert.ok(fallback, "expected the raw markdown fallback in preview mode");
+    assert.equal(fallback.value, NOTE_MARKDOWN_MDX_CANNOT_PARSE);
+    assert.equal(fallback.readOnly, true);
+    await unmount();
+  } finally {
+    cleanup();
+  }
+});

--- a/components/notes/InlineMarkdownEditor.unrenderableMarkdown.test.tsx
+++ b/components/notes/InlineMarkdownEditor.unrenderableMarkdown.test.tsx
@@ -82,9 +82,18 @@ const setupDom = () => {
 
 type DomHarness = ReturnType<typeof setupDom>;
 
+type ActiveFormats = {
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+  strikethrough: boolean;
+  code: boolean;
+};
+
 type RenderEditorProps = {
   value: string;
   editorMode?: "edit" | "preview" | "source";
+  onActiveFormatsChange?: (formats: ActiveFormats) => void;
 };
 
 const renderEditor = async (
@@ -109,6 +118,7 @@ const renderEditor = async (
           placeholder="Write Markdown notes here..."
           editorMode={nextProps.editorMode ?? "edit"}
           onChange={(next) => changes.push(next)}
+          onActiveFormatsChange={nextProps.onActiveFormatsChange}
           hosts={[]}
         />
       </I18nProvider>,
@@ -233,6 +243,55 @@ test("retry imports the latest fallback draft, not the stale prop value", async 
     assert.ok(editable, "expected the rich editor back after the retry");
     assert.match(editable.textContent || "", /The content after the angle tags/);
     assert.equal(querySourceFallback(rootNode), null, "the fallback must be gone after a successful retry");
+    await unmount();
+  } finally {
+    cleanup();
+  }
+});
+
+test("retry rebinds active-format listeners after the rich editor remounts", async () => {
+  const { window, cleanup } = setupDom();
+  try {
+    const formatChanges: ActiveFormats[] = [];
+    const onActiveFormatsChange = (formats: ActiveFormats) => {
+      formatChanges.push(formats);
+    };
+    const { rootNode, changes, unmount } = await renderEditor(window, {
+      value: NOTE_MARKDOWN_MDX_CANNOT_PARSE,
+      onActiveFormatsChange,
+    });
+
+    assert.ok(querySourceFallback(rootNode), "expected the raw markdown fallback");
+    assert.equal(rootNode.querySelectorAll("[contenteditable]").length, 0);
+    const callsWhileFallback = formatChanges.length;
+
+    const fallback = querySourceFallback(rootNode);
+    assert.ok(fallback);
+    const fixedMarkdown = NOTE_MARKDOWN_MDX_CANNOT_PARSE.replace(
+      "mysql -h <host> -u <user>",
+      "mysql with host and user",
+    );
+    await runWithAct(async () => {
+      setTextareaValue(window, fallback, fixedMarkdown);
+    });
+    assert.deepEqual(changes, [fixedMarkdown]);
+
+    const retry = rootNode.querySelector<HTMLButtonElement>("[data-note-markdown-source-retry]");
+    assert.ok(retry, "expected a retry action on the fallback notice");
+    await runWithAct(async () => {
+      retry.click();
+    });
+    await runWithAct(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    const editable = rootNode.querySelector<HTMLElement>("[contenteditable]");
+    assert.ok(editable, "expected the rich editor back after the retry");
+    assert.equal(querySourceFallback(rootNode), null, "the fallback must be gone after a successful retry");
+    assert.ok(
+      formatChanges.length > callsWhileFallback,
+      "expected onActiveFormatsChange after the rich editor remounted",
+    );
     await unmount();
   } finally {
     cleanup();

--- a/components/notes/InlineMarkdownEditor.unrenderableMarkdown.test.tsx
+++ b/components/notes/InlineMarkdownEditor.unrenderableMarkdown.test.tsx
@@ -100,20 +100,21 @@ const renderEditor = async (
   assert.ok(rootNode);
   const root = createRoot(rootNode);
   const changes: string[] = [];
-  await act(async () => {
+  const render = async (nextProps: RenderEditorProps) => act(async () => {
     root.render(
       <I18nProvider locale="en">
         <InlineMarkdownEditor
           noteId="note-1"
-          value={props.value}
+          value={nextProps.value}
           placeholder="Write Markdown notes here..."
-          editorMode={props.editorMode ?? "edit"}
+          editorMode={nextProps.editorMode ?? "edit"}
           onChange={(next) => changes.push(next)}
           hosts={[]}
         />
       </I18nProvider>,
     );
   });
+  await render(props);
   // Let the deferred MDX import (and its parse-error reporting) settle.
   await act(async () => {
     await new Promise((resolve) => setTimeout(resolve, 20));
@@ -121,6 +122,7 @@ const renderEditor = async (
   return {
     rootNode,
     changes,
+    rerender: render,
     async unmount() {
       await act(async () => {
         root.unmount();
@@ -237,6 +239,43 @@ test("retry imports the latest fallback draft, not the stale prop value", async 
   }
 });
 
+test("same-note external markdown clears an active fallback", async () => {
+  const { window, cleanup } = setupDom();
+  try {
+    const { rootNode, rerender, unmount } = await renderEditor(window, {
+      value: NOTE_MARKDOWN_MDX_CANNOT_PARSE,
+    });
+    assert.ok(querySourceFallback(rootNode));
+
+    await rerender({ value: PLAIN_NOTE_MARKDOWN });
+    await runWithAct(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    assert.equal(querySourceFallback(rootNode), null);
+    assert.match(rootNode.querySelector<HTMLElement>("[contenteditable]")?.textContent || "", /Promote the replica/);
+    await unmount();
+  } finally {
+    cleanup();
+  }
+});
+
+test("leading and trailing whitespace does not hide an unrenderable note", async () => {
+  const { window, cleanup } = setupDom();
+  try {
+    const { rootNode, unmount } = await renderEditor(window, {
+      value: `\n${NOTE_MARKDOWN_MDX_CANNOT_PARSE}\n`,
+    });
+
+    const fallback = querySourceFallback(rootNode);
+    assert.ok(fallback, "expected padded unrenderable markdown to use the source fallback");
+    assert.equal(fallback.value, `\n${NOTE_MARKDOWN_MDX_CANNOT_PARSE}\n`);
+    await unmount();
+  } finally {
+    cleanup();
+  }
+});
+
 test("a stale parse error is ignored when the same note has newer markdown", async () => {
   const { shouldApplyMdxParseFailure } = await import("./InlineMarkdownEditor.tsx");
 
@@ -250,6 +289,12 @@ test("a stale parse error is ignored when the same note has newer markdown", asy
     currentNoteId: "note-1",
     failedNoteId: "note-1",
     currentMarkdown: NOTE_MARKDOWN_MDX_CANNOT_PARSE,
+    failedMarkdown: NOTE_MARKDOWN_MDX_CANNOT_PARSE,
+  }), true);
+  assert.equal(shouldApplyMdxParseFailure({
+    currentNoteId: "note-1",
+    failedNoteId: "note-1",
+    currentMarkdown: `\n${NOTE_MARKDOWN_MDX_CANNOT_PARSE}\n`,
     failedMarkdown: NOTE_MARKDOWN_MDX_CANNOT_PARSE,
   }), true);
 });

--- a/components/notes/NoteSourceEditor.tsx
+++ b/components/notes/NoteSourceEditor.tsx
@@ -70,10 +70,12 @@ export interface NoteSourceEditorProps {
   className?: string;
   noteFontFamily?: string;
   noteFontSize?: number;
+  /** Blocks edits (used when the rich editor cannot render the markdown). */
+  readOnly?: boolean;
 }
 
 export const NoteSourceEditor = React.forwardRef<NoteSourceEditorHandle, NoteSourceEditorProps>(
-  ({ noteId, value, placeholder = "", onChange, className = "", noteFontFamily, noteFontSize }, ref) => {
+  ({ noteId, value, placeholder = "", onChange, className = "", noteFontFamily, noteFontSize, readOnly = false }, ref) => {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const lineNumbersRef = useRef<HTMLDivElement>(null);
     const [localValue, setLocalValue] = useState(value);
@@ -359,6 +361,8 @@ export const NoteSourceEditor = React.forwardRef<NoteSourceEditorHandle, NoteSou
             }}
             placeholder={placeholder}
             spellCheck={false}
+            readOnly={readOnly || undefined}
+            aria-readonly={readOnly || undefined}
             style={{
               fontFamily: noteFontFamily || undefined,
               fontSize: noteFontSize ? `${noteFontSize}px` : undefined,

--- a/components/notes/NoteSourceEditor.tsx
+++ b/components/notes/NoteSourceEditor.tsx
@@ -149,6 +149,7 @@ export const NoteSourceEditor = React.forwardRef<NoteSourceEditorHandle, NoteSou
     };
 
     const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      if (readOnly) return;
       const nextValue = e.target.value;
       if (nextValue === localValue) return;
       const nativeInputType = (e.nativeEvent as InputEvent | undefined)?.inputType;
@@ -229,6 +230,10 @@ export const NoteSourceEditor = React.forwardRef<NoteSourceEditorHandle, NoteSou
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       const textarea = textareaRef.current;
       if (!textarea) return;
+      // Read-only fallback (preview mode): the DOM readOnly attribute blocks
+      // typing but not our custom Tab/undo handling, which would still mutate
+      // and persist the note.
+      if (readOnly) return;
 
       const key = e.key.toLowerCase();
       const commandModifier = e.metaKey || e.ctrlKey;
@@ -271,7 +276,7 @@ export const NoteSourceEditor = React.forwardRef<NoteSourceEditorHandle, NoteSou
     useImperativeHandle(ref, () => ({
       insertAction: (action: MarkdownActionType) => {
         const textarea = textareaRef.current;
-        if (!textarea) return;
+        if (!textarea || readOnly) return;
 
         if (action === "undo" || action === "redo") {
           applyHistoryAction(action);


### PR DESCRIPTION
## Summary

Vault → Notes could show a note with a title but a completely empty editor while the note's markdown content was in fact intact (export/copy still produced the full file). This PR makes the notes editor detect the markdown that its rich (MDX) parser cannot import and fall back to the raw markdown source view instead of silently rendering nothing. That is the note-view defect reported in #3167 (problem 2).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Fixes #3167 (the note-content display part; see "Not addressed" below for the other two sub-problems)

## Changes Made

**Root cause of the blank note.** `InlineMarkdownEditor` hands note content to `@mdxeditor/editor`, which parses markdown as MDX. Valid CommonMark can be invalid MDX — the most common case is an unbalanced angle tag in prose, e.g. `mysql -h <host> -u <user> -P 3306`, which an AI-written skill/ops document produces easily. In that case mdxeditor's import throws, mdxeditor catches it, clears the lexical document and reports it only through its `onError` prop — which netcatty never passed. Result: an empty editor with just the placeholder, and no error anywhere. The content itself is untouched in the vault, which is why export/copy still worked.

**Fix.**

- `InlineMarkdownEditor` now passes `onError` to `MDXEditor` and, when the import fails, renders the existing `NoteSourceEditor` (raw markdown) plus a one-line notice with a "Retry rich view" action, so the content is always visible and editable. In preview mode the fallback is read-only.
- The failure state is cleared when the note changes or the editor mode changes, so the rich import gets a fresh chance; toolbar actions, focus and outline scrolling are routed to the source editor while the fallback is active.
- `NoteSourceEditor` gained an optional `readOnly` prop for the preview-mode fallback.
- New i18n keys `notes.editor.unrenderableMarkdown` / `notes.editor.retryRichView` in en, zh-CN, zh-TW, ru, es.

The failure is reported by mdxeditor while its realm is still rendering, so the state update is deferred to a timer (a synchronous setState is dropped by React) — the note id is captured so a stale report can never land on the next note.

## Screenshots / Demo

Not attached. Reproduction: create a note (via AI `vault_notes_create` or markdown import) whose body contains `Run mysql -h <host> -u <user> -P 3306` in a paragraph — before this PR the note opens empty; after it, the raw markdown source is shown with the notice.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test` for the affected suites: `components/notes/*`, `application/i18n/locales/*`, `application/state/notesStore.test.ts`, `application/state/vaultNotesPersistence.test.ts`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`) — not applicable
- [x] No new console errors or warnings, if this affects app behavior

New regression tests in `components/notes/InlineMarkdownEditor.unrenderableMarkdown.test.tsx` render the real editor in jsdom: unparseable markdown now yields the source fallback (with notice, read-only in preview), and normal markdown still renders in the rich editor.

## What this PR does not fix (from #3167)

1. **The AI creating a note instead of a skill document.** Netcatty exposes no tool for creating user skills at all — the agent's only "documentation" tool is `vault_notes_create` ("Create a note in Vault → Notes sidebar (markdown documentation)"), and the Catty system prompt only ever points documentation requests at `vault_notes_create` / `host_notes_set`. There is also no tool that writes to the `%APPDATA%\netcatty\Skills` folder. So "整理成 agent skill 文档" has no tool to land on and the model picks the closest one (the reporter's note even landed in a `skills/slurm` note group). Fixing that needs a product decision (a skill-creation tool, and/or guidance text that tells agents the Skills folder is the target) rather than a one-line wording change, so it is left out here.
2. **A hand-placed `.md` file in the Skills folder is not recognized.** That is the documented layout: `scanUserSkills` (`electron/bridges/ai/userSkills.cjs`) only scans sub-directories for a `SKILL.md`, and the README.txt it writes plus the settings empty-state text both say "add a skill directory containing SKILL.md". The reporter's file was `Skills\SlurmDB Agent Skill.md`, a loose file with a non-`SKILL.md` name, so it is correctly ignored. A friendlier warning for loose `.md` files would be a UX improvement, not a defect fix, so it is not in this PR.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)