### PR TITLE
fix(ai): do not report Cursor installed from bundled SDK

### DIFF
--- a/components/settings/tabs/ai/CursorSdkCard.tsx
+++ b/components/settings/tabs/ai/CursorSdkCard.tsx
@@ -5,7 +5,7 @@ import { decryptField } from "../../../../infrastructure/persistence/secureField
 import type { CursorAuthMode } from "../../../../infrastructure/ai/types";
 import { Button } from "../../../ui/button";
 import { cn } from "../../../../lib/utils";
-import type { AgentPathInfo } from "./types";
+import { isCursorRuntimeInstalled, type AgentPathInfo } from "./types";
 
 export const CursorSdkCard: React.FC<{
   pathInfo: AgentPathInfo | null;
@@ -54,7 +54,7 @@ export const CursorSdkCard: React.FC<{
     };
   }, [encryptedApiKey]);
 
-  const installed = Boolean(pathInfo?.installed || pathInfo?.sdkInstalled || pathInfo?.cliBinPath);
+  const installed = isCursorRuntimeInstalled(pathInfo);
   const hasStoredApiKey = Boolean(encryptedApiKey);
   const usesEnvApiKey = pathInfo?.authSource === "CURSOR_API_KEY" || (
     pathInfo?.apiKeyOk && !hasStoredApiKey && pathInfo?.authSource !== "settings"
@@ -71,7 +71,7 @@ export const CursorSdkCard: React.FC<{
   const isCliMode = authMode === "cli-login";
   const available = isCliMode
     ? hasCliLogin
-    : (hasAnyApiKey && Boolean(pathInfo?.sdkInstalled ?? pathInfo?.installed));
+    : (hasAnyApiKey && Boolean(pathInfo?.sdkInstalled ?? true));
   const canSave = isApiKeyMode && !isSaving && !isDecrypting && (Boolean(apiKeyDraft.trim()) || hasStoredApiKey);
 
   const installStatus = isResolvingPath
@@ -161,7 +161,7 @@ export const CursorSdkCard: React.FC<{
         <p className="text-xs text-amber-500">
           {isCliMode
             ? t("ai.cursor.cliLoginHint")
-            : installed
+            : (Boolean(pathInfo?.sdkInstalled) || installed)
               ? t("ai.cursor.notFoundHint")
               : t("ai.cursor.notInstalledHint")}
         </p>

--- a/components/settings/tabs/ai/types.test.ts
+++ b/components/settings/tabs/ai/types.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isCursorAvailableForMode, isCursorRuntimeInstalled } from "./types";
+
+test("isCursorRuntimeInstalled ignores bundled SDK flags", () => {
+  assert.equal(isCursorRuntimeInstalled({
+    path: "cursor",
+    version: "Cursor SDK",
+    available: true,
+    installed: true,
+    sdkInstalled: true,
+  }), false);
+  assert.equal(isCursorRuntimeInstalled({
+    path: "cursor",
+    version: "Cursor SDK",
+    available: false,
+    installed: false,
+    sdkInstalled: true,
+    cliBinPath: null,
+    cliLoginOk: false,
+  }), false);
+});
+
+test("isCursorRuntimeInstalled is true for Agent CLI path or CLI login", () => {
+  assert.equal(isCursorRuntimeInstalled({
+    path: "/usr/local/bin/cursor-agent",
+    version: "Cursor Agent CLI",
+    available: false,
+    sdkInstalled: true,
+    cliBinPath: "/usr/local/bin/cursor-agent",
+    cliLoginOk: false,
+  }), true);
+  assert.equal(isCursorRuntimeInstalled({
+    path: "cursor",
+    version: "Cursor Agent CLI",
+    available: true,
+    sdkInstalled: true,
+    cliLoginOk: true,
+  }), true);
+});
+
+test("isCursorAvailableForMode still allows API-key mode from bundled SDK", () => {
+  assert.equal(isCursorAvailableForMode({
+    path: "cursor",
+    version: "Cursor SDK",
+    available: true,
+    installed: false,
+    sdkInstalled: true,
+    apiKeyOk: true,
+  }, "api-key"), true);
+  assert.equal(isCursorAvailableForMode({
+    path: "cursor",
+    version: "Cursor SDK",
+    available: true,
+    installed: false,
+    apiKeyOk: true,
+  }, "api-key"), true);
+  assert.equal(isCursorAvailableForMode({
+    path: "cursor",
+    version: "Cursor SDK",
+    available: false,
+    installed: false,
+    sdkInstalled: true,
+    cliLoginOk: false,
+  }, "cli-login"), false);
+});

--- a/components/settings/tabs/ai/types.ts
+++ b/components/settings/tabs/ai/types.ts
@@ -58,6 +58,7 @@ export interface AgentPathInfo {
   binPath?: string | null;
   version: string | null;
   available: boolean;
+  /** True when the user's Cursor Agent CLI is on PATH or logged in. */
   installed?: boolean;
   authenticated?: boolean;
   authSource?: string | null;
@@ -69,6 +70,11 @@ export interface AgentPathInfo {
   apiKeyOk?: boolean;
   /** True when @cursor/sdk platform package is importable. */
   sdkInstalled?: boolean;
+}
+
+/** User-environment Cursor Agent CLI, not Netcatty's bundled @cursor/sdk. */
+export function isCursorRuntimeInstalled(pathInfo: AgentPathInfo | null | undefined): boolean {
+  return Boolean(pathInfo?.cliBinPath || pathInfo?.cliLoginOk);
 }
 
 /** Mode-aware Cursor availability for Settings enablement. */
@@ -87,9 +93,11 @@ export function isCursorAvailableForMode(
     || pathInfo.authSource === "settings"
     || pathInfo.authSource === "CURSOR_API_KEY",
   );
+  // Missing sdkInstalled means the probe has not filled it yet. API-key mode
+  // uses Netcatty's bundled SDK and must not wait for Cursor.app.
   const sdkOk = pathInfo.sdkInstalled !== undefined
     ? Boolean(pathInfo.sdkInstalled)
-    : Boolean(pathInfo.installed);
+    : true;
   return hasKey && sdkOk;
 }
 

--- a/electron/bridges/aiBridge.test.cjs
+++ b/electron/bridges/aiBridge.test.cjs
@@ -1141,6 +1141,33 @@ test("resolve-cli probes Windows Claude exe paths with spaces", { skip: process.
   }
 });
 
+test("resolve-cli reports Cursor Agent CLI on PATH as installed without CLI login", async () => {
+  const { bridge, restore } = loadBridgeWithMocks({
+    resolveCliFromPath: () => null,
+    probeCursorCliAuth: () => ({
+      authenticated: false,
+      authSource: null,
+      email: null,
+      binPath: "/usr/local/bin/cursor-agent",
+    }),
+  });
+  const ipcMain = createIpcMainStub();
+  bridge.init({ sessions: new Map(), sftpClients: new Map(), electronModule: { app: { getPath: () => process.cwd() } } });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const resolveCli = ipcMain.handlers.get("netcatty:ai:resolve-cli");
+    const result = await resolveCli({ sender: { id: 1 } }, { command: "cursor", customPath: "" });
+    assert.equal(result.installed, true);
+    assert.equal(result.sdkInstalled, true);
+    assert.equal(result.cliBinPath, "/usr/local/bin/cursor-agent");
+    assert.equal(result.cliLoginOk, false);
+    assert.equal(result.available, false);
+  } finally {
+    restore();
+  }
+});
+
 test("resolve-cli reports Cursor SDK installed but unavailable without an API key", async () => {
   const { bridge, restore } = loadBridgeWithMocks({
     resolveCliFromPath: () => null,
@@ -1157,7 +1184,7 @@ test("resolve-cli reports Cursor SDK installed but unavailable without an API ke
       binPath: "cursor",
       version: "Cursor SDK",
       available: false,
-      installed: true,
+      installed: false,
       authenticated: false,
       authSource: null,
       cliEmail: null,
@@ -1191,7 +1218,7 @@ test("resolve-cli separates Cursor SDK installation from API key availability", 
       binPath: "cursor",
       version: "Cursor SDK",
       available: false,
-      installed: true,
+      installed: false,
       authenticated: false,
       authSource: null,
       cliEmail: null,
@@ -1226,7 +1253,7 @@ test("resolve-cli ignores custom Cursor paths and stores the SDK sentinel path",
       binPath: "cursor",
       version: "Cursor SDK",
       available: true,
-      installed: true,
+      installed: false,
       authenticated: true,
       authSource: "CURSOR_API_KEY",
       cliEmail: null,
@@ -1257,7 +1284,7 @@ test("resolve-cli exposes Cursor SDK support when installed and authenticated", 
       binPath: "cursor",
       version: "Cursor SDK",
       available: true,
-      installed: true,
+      installed: false,
       authenticated: true,
       authSource: "CURSOR_API_KEY",
       cliEmail: null,
@@ -1290,7 +1317,7 @@ test("resolve-cli exposes Cursor SDK support when API key is saved in settings",
       binPath: "/usr/local/bin/cursor",
       version: "Cursor SDK",
       available: true,
-      installed: true,
+      installed: false,
       authenticated: true,
       authSource: "settings",
       cliEmail: null,
@@ -1373,6 +1400,7 @@ test("discover exposes Cursor when CLI login succeeds without API key", async ()
     const cursor = agents.find((agent) => agent.command === "cursor");
 
     assert.equal(cursor?.available, true);
+    assert.equal(cursor?.installed, true);
     assert.equal(cursor?.authenticated, true);
     assert.equal(cursor?.authSource, "cli-login");
     assert.equal(cursor?.path, "/Users/me/.local/bin/agent");
@@ -1397,6 +1425,8 @@ test("discover exposes Cursor SDK support when API key is saved in settings", as
 
     assert.equal(cursor?.path, "cursor");
     assert.equal(cursor?.available, true);
+    assert.equal(cursor?.installed, false);
+    assert.equal(cursor?.sdkInstalled, true);
     assert.equal(cursor?.authenticated, true);
     assert.equal(cursor?.authSource, "settings");
   } finally {
@@ -1422,6 +1452,7 @@ test("resolve-cli exposes Cursor CLI login without API key", async () => {
     const resolveCli = ipcMain.handlers.get("netcatty:ai:resolve-cli");
     const result = await resolveCli({ sender: { id: 1 } }, { command: "cursor", customPath: "" });
     assert.equal(result.available, true);
+    assert.equal(result.installed, true);
     assert.equal(result.authenticated, true);
     assert.equal(result.authSource, "cli-login");
     assert.equal(result.path, "/Users/me/.local/bin/agent");

--- a/electron/bridges/aiBridge/agentAuthProbes.cjs
+++ b/electron/bridges/aiBridge/agentAuthProbes.cjs
@@ -219,19 +219,30 @@ function probeCursorCliAuth({ env, resolveBinary, runStatus } = {}) {
   const resolve = resolveBinary || ((name) => defaultResolveCursorCliBinary(name, e));
   const run = runStatus || ((bin) => defaultRunCursorStatus(bin, e));
 
-  let cursorShapedBinPath = null;
+  // A resolved cursor-agent path is a user install even when status JSON is
+  // missing, unrecognized, or the status command throws.
+  let resolvedBinPath = null;
   for (const name of CURSOR_CLI_BINARY_CANDIDATES) {
-    const binPath = resolve(name);
+    let binPath = null;
+    try {
+      binPath = resolve(name);
+    } catch {
+      continue;
+    }
     if (!binPath) continue;
+    if (!resolvedBinPath) resolvedBinPath = binPath;
 
-    const res = run(binPath);
+    let res = null;
+    try {
+      res = run(binPath);
+    } catch {
+      continue;
+    }
     if (!res) continue;
 
     // Accept JSON even on non-zero exit if present (some CLIs exit 1 when logged out).
     const parsed = parseCursorStatusJson(res.stdout);
     if (!parsed) continue;
-
-    if (!cursorShapedBinPath) cursorShapedBinPath = binPath;
 
     const authenticated = Boolean(
       parsed.isAuthenticated === true || parsed.status === "authenticated",
@@ -246,7 +257,7 @@ function probeCursorCliAuth({ env, resolveBinary, runStatus } = {}) {
     authenticated: false,
     authSource: null,
     email: null,
-    binPath: cursorShapedBinPath,
+    binPath: resolvedBinPath,
   };
 }
 

--- a/electron/bridges/aiBridge/agentAuthProbes.test.cjs
+++ b/electron/bridges/aiBridge/agentAuthProbes.test.cjs
@@ -273,6 +273,27 @@ test("probeCursorCliAuth: status command failure -> not authenticated", () => {
     runStatus: () => ({ exitCode: 1, stdout: "", stderr: "boom" }),
   });
   assert.equal(r.authenticated, false);
+  assert.equal(r.binPath, "/bin/cursor-agent");
+});
+
+test("probeCursorCliAuth: unrecognized status stdout keeps resolved binPath", () => {
+  const r = probeCursorCliAuth({
+    resolveBinary: () => "/bin/cursor-agent",
+    runStatus: () => ({ exitCode: 0, stdout: "cursor-agent 1.2.3\nnot json" }),
+  });
+  assert.equal(r.authenticated, false);
+  assert.equal(r.authSource, null);
+  assert.equal(r.binPath, "/bin/cursor-agent");
+});
+
+test("probeCursorCliAuth: thrown status probe keeps resolved binPath", () => {
+  const r = probeCursorCliAuth({
+    resolveBinary: () => "/bin/cursor-agent",
+    runStatus: () => { throw new Error("timeout"); },
+  });
+  assert.equal(r.authenticated, false);
+  assert.equal(r.authSource, null);
+  assert.equal(r.binPath, "/bin/cursor-agent");
 });
 
 test("probeCursorCliAuth: extracts authenticated JSON wrapped in cmd noise", () => {

--- a/electron/bridges/aiBridge/agentDiscoveryHandlers.cjs
+++ b/electron/bridges/aiBridge/agentDiscoveryHandlers.cjs
@@ -6,6 +6,15 @@ function getCursorPlatformPackageName(platform = process.platform, arch = proces
   return null;
 }
 
+// Bundled @cursor/sdk is importable in every Netcatty build. "installed" is the
+// user's Cursor Agent CLI, not that bundled package.
+function computeCursorInstallState({ sdkInstalled, cliBinPath, cliLoginOk } = {}) {
+  return {
+    sdkInstalled: Boolean(sdkInstalled),
+    installed: Boolean(cliBinPath) || Boolean(cliLoginOk),
+  };
+}
+
 async function probeCursorSdkAvailability(shellEnv, options = {}) {
   const platformPackageName = getCursorPlatformPackageName();
 
@@ -44,9 +53,15 @@ async function probeCursorSdkAvailability(shellEnv, options = {}) {
   else if (hasEnvApiKey) authSource = "CURSOR_API_KEY";
   else if (cliLoginOk) authSource = "cli-login";
 
+  const installState = computeCursorInstallState({
+    sdkInstalled,
+    cliBinPath: cliAuth.binPath,
+    cliLoginOk,
+  });
+  sdkInstalled = installState.sdkInstalled;
   // Available if either mode can run a turn (API key + SDK, or CLI login).
   const available = (apiKeyOk && sdkInstalled) || cliLoginOk;
-  const installed = sdkInstalled || Boolean(cliAuth.binPath) || cliLoginOk;
+  const installed = installState.installed;
   return {
     installed,
     sdkInstalled,
@@ -147,7 +162,7 @@ function registerAgentDiscoveryHandlers(ctx) {
         path: resolvedPath,
         binPath: resolvedPath,
         version: probe.version,
-        installed: true,
+        installed: agent.command === "cursor" ? Boolean(cursorSdkStatus.installed) : true,
         available: true,
         authenticated: auth.authenticated,
         authSource: auth.authSource,
@@ -205,9 +220,14 @@ function registerAgentDiscoveryHandlers(ctx) {
       const cursorPath = cursorSdkStatus.cliLoginOk
         ? (cursorSdkStatus.cliBinPath || resolvedSdkPath || "cursor")
         : (resolvedSdkPath || "cursor");
+      // Keep the SDK sentinel path when the bundled SDK is importable so
+      // API-key mode still has an identity without Cursor.app / Agent CLI.
+      const hasCursorPath = cursorSdkStatus.sdkInstalled
+        || cursorSdkStatus.installed
+        || cursorSdkStatus.available;
       return {
-        path: cursorSdkStatus.installed || cursorSdkStatus.available ? cursorPath : null,
-        binPath: cursorSdkStatus.installed || cursorSdkStatus.available ? cursorPath : null,
+        path: hasCursorPath ? cursorPath : null,
+        binPath: hasCursorPath ? cursorPath : null,
         version: cursorSdkStatus.version,
         available: cursorSdkStatus.available,
         installed: cursorSdkStatus.installed,
@@ -464,4 +484,4 @@ function registerAgentDiscoveryHandlers(ctx) {
   }
 }
 
-module.exports = { registerAgentDiscoveryHandlers };
+module.exports = { registerAgentDiscoveryHandlers, computeCursorInstallState };

--- a/electron/bridges/aiBridge/agentDiscoveryHandlers.test.cjs
+++ b/electron/bridges/aiBridge/agentDiscoveryHandlers.test.cjs
@@ -24,6 +24,16 @@ test("computeCursorInstallState: Agent CLI on PATH is a user Cursor install", ()
   assert.equal(state.installed, true);
 });
 
+test("computeCursorInstallState: logged-out CLI path is installed without cliLoginOk", () => {
+  const state = computeCursorInstallState({
+    sdkInstalled: true,
+    cliBinPath: "/bin/cursor-agent",
+    cliLoginOk: false,
+  });
+  assert.equal(state.installed, true);
+  assert.equal(state.sdkInstalled, true);
+});
+
 test("computeCursorInstallState: proven CLI login is a user Cursor install", () => {
   const state = computeCursorInstallState({
     sdkInstalled: false,

--- a/electron/bridges/aiBridge/agentDiscoveryHandlers.test.cjs
+++ b/electron/bridges/aiBridge/agentDiscoveryHandlers.test.cjs
@@ -1,0 +1,35 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { computeCursorInstallState } = require("./agentDiscoveryHandlers.cjs");
+
+test("computeCursorInstallState: bundled SDK is not a user Cursor install", () => {
+  const state = computeCursorInstallState({
+    sdkInstalled: true,
+    cliBinPath: null,
+    cliLoginOk: false,
+  });
+  assert.equal(state.sdkInstalled, true);
+  assert.equal(state.installed, false);
+});
+
+test("computeCursorInstallState: Agent CLI on PATH is a user Cursor install", () => {
+  const state = computeCursorInstallState({
+    sdkInstalled: true,
+    cliBinPath: "/usr/local/bin/cursor-agent",
+    cliLoginOk: false,
+  });
+  assert.equal(state.sdkInstalled, true);
+  assert.equal(state.installed, true);
+});
+
+test("computeCursorInstallState: proven CLI login is a user Cursor install", () => {
+  const state = computeCursorInstallState({
+    sdkInstalled: false,
+    cliBinPath: null,
+    cliLoginOk: true,
+  });
+  assert.equal(state.sdkInstalled, false);
+  assert.equal(state.installed, true);
+});


### PR DESCRIPTION
## Summary

Settings reported Cursor as installed whenever Netcatty could import its bundled `@cursor/sdk`. That package ships with every build, so the badge was a false positive on machines with no Cursor Agent CLI.

`installed` now means the user has Cursor Agent CLI on PATH or a proven CLI login. `sdkInstalled` still reflects the bundled SDK so API-key mode works without Cursor.app.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3170

## Changes Made

- Compute Cursor `installed` from `cliBinPath` / `cliLoginOk`, not bundled `@cursor/sdk`.
- Keep `sdkInstalled` and API-key availability (`apiKeyOk && sdkInstalled`) unchanged.
- Settings "Cursor runtime" badge uses CLI presence only; API-key status is unchanged.
- Update resolve-cli / discover tests that encoded the bundled-SDK false positive.

## Screenshots / Demo

N/A — Settings status badge logic only. With no Cursor Agent CLI, the runtime line is "Not detected" even when the bundled SDK is present; API-key mode can still become available after a key is saved.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Targeted runs:

- `node --test electron/bridges/aiBridge.test.cjs electron/bridges/aiBridge/agentDiscoveryHandlers.test.cjs`
- `node --test --import tsx components/ai/managedAgentState.test.ts components/settings/tabs/ai/types.test.ts`
- `npx eslint` on the touched files

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)