### PR TITLE
fix(snippets): add package context menu for rename and delete

### DIFF
--- a/components/ScriptsSidePanel.test.ts
+++ b/components/ScriptsSidePanel.test.ts
@@ -135,3 +135,23 @@ test("scripts side panel package dialog traps focus and exposes dialog close con
   assert.match(source, /data-dialog-close="true"/);
   assert.match(source, /isPackageDialogOpen/);
 });
+
+test("scripts side panel package rows wrap in a rename and delete context menu", () => {
+  assert.match(source, /const PackageRow = memo/);
+  assert.match(
+    source,
+    /data-pkg-path=\{row\.path\}[\s\S]*?<ContextMenu>[\s\S]*?<ContextMenuTrigger asChild>[\s\S]*?\{rowButton\}/,
+  );
+  assert.match(source, /common\.rename/);
+  assert.match(source, /vault\.deleteConfirm\.packageDesc/);
+  assert.match(source, /deleteSnippetPackage/);
+  assert.match(source, /renameSnippetPackage/);
+  assert.match(source, /openRenamePackageDialog/);
+  assert.match(source, /requestDeletePackage/);
+});
+
+test("scripts side panel does not start a drag from a non-primary pointer", () => {
+  assert.match(source, /isNonPrimaryPointer/);
+  assert.match(source, /primaryOnlyDragHandlers/);
+  assert.match(source, /event\.button !== 0/);
+});

--- a/components/ScriptsSidePanel.test.ts
+++ b/components/ScriptsSidePanel.test.ts
@@ -126,8 +126,11 @@ test("scripts side panel clears pending bulk delete when the panel hides", () =>
   // pending deletes so a later re-show does not resurrect a half-dismissed prompt.
   assert.match(
     source,
-    /if\s*\(\s*!isVisible\s*\)\s*setPendingDeleteIds\(\s*null\s*\)/,
+    /if\s*\(\s*isVisible\s*\)\s*return/,
   );
+  assert.match(source, /setIsPackageDialogOpen\(\s*false\s*\)/);
+  assert.match(source, /setRenamingPackagePath\(\s*''\s*\)/);
+  assert.match(source, /setNewPackageName\(\s*''\s*\)/);
 });
 
 test("scripts side panel package dialog traps focus and exposes dialog close contract", () => {

--- a/components/ScriptsSidePanel.test.ts
+++ b/components/ScriptsSidePanel.test.ts
@@ -151,7 +151,7 @@ test("scripts side panel package rows wrap in a rename and delete context menu",
 });
 
 test("scripts side panel does not start a drag from a non-primary pointer", () => {
+  assert.match(source, /from '\.\/ui\/primaryOnlyDrag'/);
   assert.match(source, /isNonPrimaryPointer/);
   assert.match(source, /primaryOnlyDragHandlers/);
-  assert.match(source, /event\.button !== 0/);
 });

--- a/components/ScriptsSidePanel.test.ts
+++ b/components/ScriptsSidePanel.test.ts
@@ -146,6 +146,9 @@ test("scripts side panel package rows wrap in a rename and delete context menu",
   assert.match(source, /vault\.deleteConfirm\.packageDesc/);
   assert.match(source, /deleteSnippetPackage/);
   assert.match(source, /renameSnippetPackage/);
+  assert.match(source, /SNIPPET_PACKAGE_PATH_CHANGE_EVENT/);
+  assert.match(source, /detail: \{ from: renamingPackagePath, to: result\.newPath \}/);
+  assert.match(source, /detail: \{ from: path, to: null \}/);
   assert.match(source, /openRenamePackageDialog/);
   assert.match(source, /requestDeletePackage/);
 });

--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -27,8 +27,9 @@ import React, { memo, useCallback, useEffect, useMemo, useRef, useState, useSync
 import { useI18n } from '../application/i18n/I18nProvider';
 import { getScriptRecordingSnapshot, subscribeScriptRecording } from '../application/state/scriptRecordingStore.ts';
 import { VaultDeleteConfirmDialog } from './vault/VaultDeleteConfirmDialog';
-import { reorderVaultItems, reorderVaultStrings, sortByVaultOrder } from '../domain/vaultOrder';
+import { deleteSnippetPackage, renameSnippetPackage } from '../domain/snippetPackage.ts';
 import { isScriptSnippet } from '../domain/snippetScript.ts';
+import { reorderVaultItems, reorderVaultStrings, sortByVaultOrder } from '../domain/vaultOrder';
 import { cn } from '../lib/utils';
 import { Snippet } from '../types';
 import type { ScriptRun } from '../types/global/netcatty-bridge-script.d.ts';
@@ -52,6 +53,23 @@ const toolbarIconButtonClass =
   'h-7 w-7 shrink-0 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors disabled:opacity-40 disabled:pointer-events-none';
 
 const SCRIPT_ROW_HEIGHT = 34;
+
+const isNonPrimaryPointer = (event: { button?: number; buttons?: number }): boolean =>
+  event.button === 2
+  || event.buttons === 2
+  || (typeof event.button === 'number' && event.button !== 0);
+
+const primaryOnlyDragHandlers = (enabled: boolean) => ({
+  onPointerDown: (event: React.PointerEvent<HTMLElement>) => {
+    if (event.button !== 0) event.currentTarget.draggable = false;
+  },
+  onPointerUp: (event: React.PointerEvent<HTMLElement>) => {
+    event.currentTarget.draggable = enabled;
+  },
+  onPointerCancel: (event: React.PointerEvent<HTMLElement>) => {
+    event.currentTarget.draggable = enabled;
+  },
+});
 
 const isRootPackagePath = (path: string): boolean => {
   const body = path.startsWith('/') ? path.slice(1) : path;
@@ -293,7 +311,10 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
   const [isMultiSelectMode, setIsMultiSelectMode] = useState(false);
   const [selectedSnippetIds, setSelectedSnippetIds] = useState<Set<string>>(new Set());
   const [pendingDeleteIds, setPendingDeleteIds] = useState<string[] | null>(null);
+  const [pendingDeletePackagePath, setPendingDeletePackagePath] = useState<string | null>(null);
   const [isPackageDialogOpen, setIsPackageDialogOpen] = useState(false);
+  const [packageDialogMode, setPackageDialogMode] = useState<'create' | 'rename'>('create');
+  const [renamingPackagePath, setRenamingPackagePath] = useState('');
   const [newPackageName, setNewPackageName] = useState('');
   const [packageError, setPackageError] = useState('');
   const packageDialogRef = useRef<HTMLDivElement>(null);
@@ -406,6 +427,7 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
 
   useEffect(() => {
     if (!isVisible) setPendingDeleteIds(null);
+    if (!isVisible) setPendingDeletePackagePath(null);
   }, [isVisible]);
 
   // Parent-owned confirm (compact toolbar popover) dispatches the shared delete
@@ -721,7 +743,17 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
   }, []);
 
   const openPackageDialog = useCallback(() => {
+    setPackageDialogMode('create');
+    setRenamingPackagePath('');
     setNewPackageName('');
+    setPackageError('');
+    setIsPackageDialogOpen(true);
+  }, []);
+
+  const openRenamePackageDialog = useCallback((path: string) => {
+    setPackageDialogMode('rename');
+    setRenamingPackagePath(path);
+    setNewPackageName(path.split('/').pop() || '');
     setPackageError('');
     setIsPackageDialogOpen(true);
   }, []);
@@ -818,6 +850,48 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
     setNewPackageName('');
     setPackageError('');
   }, [newPackageName, onPackagesChange, packages, t]);
+
+  const handleRenamePackage = useCallback(() => {
+    if (!onPackagesChange || !onSnippetsChange || !renamingPackagePath) {
+      setPackageError(t('snippets.renameDialog.error.empty'));
+      return;
+    }
+    const result = renameSnippetPackage(packages, snippets, renamingPackagePath, newPackageName);
+    if (!result.ok) {
+      setPackageError(t(`snippets.renameDialog.error.${result.error}`));
+      return;
+    }
+    if (result.newPath !== renamingPackagePath) {
+      onPackagesChange(result.packages);
+      onSnippetsChange(result.snippets);
+    }
+    setIsPackageDialogOpen(false);
+    setNewPackageName('');
+    setPackageError('');
+    setRenamingPackagePath('');
+  }, [
+    newPackageName,
+    onPackagesChange,
+    onSnippetsChange,
+    packages,
+    renamingPackagePath,
+    snippets,
+    t,
+  ]);
+
+  const requestDeletePackage = useCallback((path: string) => {
+    setPendingDeleteIds(null);
+    setPendingDeletePackagePath(path);
+  }, []);
+
+  const confirmDeletePackage = useCallback(() => {
+    const path = pendingDeletePackagePath;
+    setPendingDeletePackagePath(null);
+    if (!path || !onPackagesChange || !onSnippetsChange) return;
+    const result = deleteSnippetPackage(packages, snippets, path);
+    onPackagesChange(result.packages);
+    onSnippetsChange(result.snippets);
+  }, [onPackagesChange, onSnippetsChange, packages, pendingDeletePackagePath, snippets]);
 
   const handleEditSnippet = useCallback((snippet: Snippet) => {
     window.dispatchEvent(
@@ -1087,6 +1161,7 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
                 );
               }
               if (item.kind === 'package') {
+                const canMutatePackages = Boolean(onPackagesChange && onSnippetsChange);
                 return (
                   <PackageRow
                     row={item.row}
@@ -1096,6 +1171,14 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
                     onDrop={handleRowDrop}
                     onDragEnd={clearScriptsDropIndicator}
                     onToggle={() => togglePackage(item.row.path)}
+                    onRename={canMutatePackages
+                      ? () => openRenamePackageDialog(item.row.path)
+                      : undefined}
+                    onDelete={canMutatePackages
+                      ? () => requestDeletePackage(item.row.path)
+                      : undefined}
+                    renameLabel={t('common.rename')}
+                    deleteLabel={t('action.delete')}
                   />
                 );
               }
@@ -1222,7 +1305,9 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
           role="dialog"
           aria-modal="true"
           data-state="open"
-          aria-label={t('snippets.packageDialog.title')}
+          aria-label={packageDialogMode === 'rename'
+            ? t('snippets.renameDialog.title')
+            : t('snippets.packageDialog.title')}
           onKeyDown={(e) => {
             if (e.key === 'Escape') {
               e.preventDefault();
@@ -1247,9 +1332,15 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
             onClick={(e) => e.stopPropagation()}
           >
             <div>
-              <p className="text-sm font-semibold">{t('snippets.packageDialog.title')}</p>
+              <p className="text-sm font-semibold">
+                {packageDialogMode === 'rename'
+                  ? t('snippets.renameDialog.title')
+                  : t('snippets.packageDialog.title')}
+              </p>
               <p className="text-[11px] text-muted-foreground mt-0.5">
-                {t('snippets.packageDialog.parent', { parent: t('snippets.packageDialog.root') })}
+                {packageDialogMode === 'rename'
+                  ? t('snippets.renameDialog.currentPath', { path: renamingPackagePath })
+                  : t('snippets.packageDialog.parent', { parent: t('snippets.packageDialog.root') })}
               </p>
             </div>
             <div className="space-y-1.5">
@@ -1264,13 +1355,18 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
                     e.preventDefault();
-                    handleCreatePackage();
+                    if (packageDialogMode === 'rename') handleRenamePackage();
+                    else handleCreatePackage();
                   }
                 }}
-                placeholder={t('snippets.packageDialog.placeholder')}
+                placeholder={packageDialogMode === 'rename'
+                  ? t('snippets.renameDialog.placeholder')
+                  : t('snippets.packageDialog.placeholder')}
                 className="h-8 text-xs"
               />
-              <p className="text-[10px] text-muted-foreground">{t('snippets.packageDialog.hint')}</p>
+              {packageDialogMode === 'create' ? (
+                <p className="text-[10px] text-muted-foreground">{t('snippets.packageDialog.hint')}</p>
+              ) : null}
               {packageError ? (
                 <p className="text-[10px] text-destructive">{packageError}</p>
               ) : null}
@@ -1284,8 +1380,12 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
               >
                 {t('common.cancel')}
               </Button>
-              <Button type="button" size="sm" onClick={handleCreatePackage}>
-                {t('common.create')}
+              <Button
+                type="button"
+                size="sm"
+                onClick={packageDialogMode === 'rename' ? handleRenamePackage : handleCreatePackage}
+              >
+                {packageDialogMode === 'rename' ? t('common.rename') : t('common.create')}
               </Button>
             </div>
           </div>
@@ -1305,6 +1405,15 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
           onConfirm={confirmDeleteSelectedSnippets}
         />
       ) : null}
+      <VaultDeleteConfirmDialog
+        open={Boolean(pendingDeletePackagePath)}
+        title={t('vault.deleteConfirm.title', { name: pendingDeletePackagePath ?? '' })}
+        description={t('vault.deleteConfirm.packageDesc')}
+        onOpenChange={(open) => {
+          if (!open) setPendingDeletePackagePath(null);
+        }}
+        onConfirm={confirmDeletePackage}
+      />
     </div>
     </TooltipProvider>
   );
@@ -1318,38 +1427,82 @@ interface PackageRowProps {
   onDrop: (event: React.DragEvent<HTMLElement>) => void;
   onDragEnd: () => void;
   onToggle: () => void;
+  onRename?: () => void;
+  onDelete?: () => void;
+  renameLabel: string;
+  deleteLabel: string;
 }
 
-const PackageRow = memo<PackageRowProps>(({ row, countLabel, draggable, onDragOver, onDrop, onDragEnd, onToggle }) => (
-  <button
-    type="button"
-    onClick={onToggle}
-    className="vault-drop-indicator-row w-full flex items-center gap-1.5 pr-3 py-1.5 text-left hover:bg-accent/50 transition-colors"
-    style={{ paddingLeft: 8 + row.depth * 14 }}
-    data-pkg-path={row.path}
-    draggable={draggable}
-    onDragStart={(event) => {
-      if (!draggable) return;
-      event.dataTransfer.effectAllowed = 'move';
-      event.dataTransfer.setData('pkg-path', row.path);
-    }}
-    onDragOver={onDragOver}
-    onDrop={onDrop}
-    onDragEnd={onDragEnd}
-  >
-    <ChevronRight
-      size={12}
-      className={cn(
-        'shrink-0 text-muted-foreground transition-transform',
-        row.isExpanded && 'rotate-90',
-        !row.hasChildren && 'opacity-0',
-      )}
-    />
-    <Package size={12} className="shrink-0 text-primary/80" />
-    <span className="flex-1 min-w-0 truncate text-xs font-medium">{row.name}</span>
-    <span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">{countLabel}</span>
-  </button>
-));
+const PackageRow = memo<PackageRowProps>(({
+  row,
+  countLabel,
+  draggable,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+  onToggle,
+  onRename,
+  onDelete,
+  renameLabel,
+  deleteLabel,
+}) => {
+  const rowButton = (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="vault-drop-indicator-row w-full flex items-center gap-1.5 pr-3 py-1.5 text-left hover:bg-accent/50 transition-colors"
+      style={{ paddingLeft: 8 + row.depth * 14 }}
+      data-pkg-path={row.path}
+      draggable={draggable}
+      {...primaryOnlyDragHandlers(draggable)}
+      onDragStart={(event) => {
+        if (!draggable || isNonPrimaryPointer(event) || isNonPrimaryPointer(event.nativeEvent)) {
+          event.preventDefault();
+          return;
+        }
+        event.dataTransfer.effectAllowed = 'move';
+        event.dataTransfer.setData('pkg-path', row.path);
+      }}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+    >
+      <ChevronRight
+        size={12}
+        className={cn(
+          'shrink-0 text-muted-foreground transition-transform',
+          row.isExpanded && 'rotate-90',
+          !row.hasChildren && 'opacity-0',
+        )}
+      />
+      <Package size={12} className="shrink-0 text-primary/80" />
+      <span className="flex-1 min-w-0 truncate text-xs font-medium">{row.name}</span>
+      <span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">{countLabel}</span>
+    </button>
+  );
+
+  if (!onRename && !onDelete) return rowButton;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        {rowButton}
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        {onRename ? (
+          <ContextMenuItem onClick={onRename}>
+            <Edit2 className="mr-2 h-4 w-4" /> {renameLabel}
+          </ContextMenuItem>
+        ) : null}
+        {onDelete ? (
+          <ContextMenuItem className="text-destructive" onClick={onDelete}>
+            <Trash2 className="mr-2 h-4 w-4" /> {deleteLabel}
+          </ContextMenuItem>
+        ) : null}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+});
 PackageRow.displayName = 'PackageRow';
 
 interface SnippetRowProps {
@@ -1401,8 +1554,12 @@ const SnippetRow = memo<SnippetRowProps>(({
         className="vault-drop-indicator-row"
         data-snippet-id={sortableTarget ? snippet.id : undefined}
         draggable={draggable}
+        {...primaryOnlyDragHandlers(draggable)}
         onDragStart={(event) => {
-          if (!draggable) return;
+          if (!draggable || isNonPrimaryPointer(event) || isNonPrimaryPointer(event.nativeEvent)) {
+            event.preventDefault();
+            return;
+          }
           event.dataTransfer.effectAllowed = 'move';
           event.dataTransfer.setData('snippet-id', snippet.id);
         }}

--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -31,6 +31,7 @@ import {
   collectSnippetPackageTreePaths,
   deleteSnippetPackage,
   renameSnippetPackage,
+  SNIPPET_PACKAGE_PATH_CHANGE_EVENT,
 } from '../domain/snippetPackage.ts';
 import { isScriptSnippet } from '../domain/snippetScript.ts';
 import { reorderVaultItems, reorderVaultStrings, sortByVaultOrder } from '../domain/vaultOrder';
@@ -835,6 +836,9 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
     if (result.newPath !== renamingPackagePath) {
       onPackagesChange(result.packages);
       onSnippetsChange(result.snippets);
+      window.dispatchEvent(new CustomEvent(SNIPPET_PACKAGE_PATH_CHANGE_EVENT, {
+        detail: { from: renamingPackagePath, to: result.newPath },
+      }));
     }
     setIsPackageDialogOpen(false);
     setNewPackageName('');
@@ -862,6 +866,9 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
     const result = deleteSnippetPackage(packages, snippets, path);
     onPackagesChange(result.packages);
     onSnippetsChange(result.snippets);
+    window.dispatchEvent(new CustomEvent(SNIPPET_PACKAGE_PATH_CHANGE_EVENT, {
+      detail: { from: path, to: null },
+    }));
   }, [onPackagesChange, onSnippetsChange, packages, pendingDeletePackagePath, snippets]);
 
   const handleEditSnippet = useCallback((snippet: Snippet) => {

--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -27,7 +27,11 @@ import React, { memo, useCallback, useEffect, useMemo, useRef, useState, useSync
 import { useI18n } from '../application/i18n/I18nProvider';
 import { getScriptRecordingSnapshot, subscribeScriptRecording } from '../application/state/scriptRecordingStore.ts';
 import { VaultDeleteConfirmDialog } from './vault/VaultDeleteConfirmDialog';
-import { deleteSnippetPackage, renameSnippetPackage } from '../domain/snippetPackage.ts';
+import {
+  collectSnippetPackageTreePaths,
+  deleteSnippetPackage,
+  renameSnippetPackage,
+} from '../domain/snippetPackage.ts';
 import { isScriptSnippet } from '../domain/snippetScript.ts';
 import { reorderVaultItems, reorderVaultStrings, sortByVaultOrder } from '../domain/vaultOrder';
 import { cn } from '../lib/utils';
@@ -173,24 +177,7 @@ export function collectScriptsSidePanelPackagePaths(
   packages: string[],
   snippets: Snippet[],
 ): string[] {
-  const normalizedPackages = new Set<string>();
-  const addWithAncestors = (raw: string) => {
-    const path = raw.trim();
-    if (!path) return;
-    const isAbs = path.startsWith('/');
-    const body = isAbs ? path.slice(1) : path;
-    const parts = body.split('/').filter(Boolean);
-    for (let i = 1; i <= parts.length; i += 1) {
-      const sub = parts.slice(0, i).join('/');
-      normalizedPackages.add(isAbs ? `/${sub}` : sub);
-    }
-  };
-
-  packages.forEach(addWithAncestors);
-  snippets.forEach((snippet) => {
-    if (snippet.package) addWithAncestors(snippet.package);
-  });
-  return Array.from(normalizedPackages);
+  return collectSnippetPackageTreePaths(packages, snippets);
 }
 
 export function buildScriptsSidePanelRows({

--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -398,8 +398,14 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
   }, [snippets]);
 
   useEffect(() => {
-    if (!isVisible) setPendingDeleteIds(null);
-    if (!isVisible) setPendingDeletePackagePath(null);
+    if (isVisible) return;
+    setPendingDeleteIds(null);
+    setPendingDeletePackagePath(null);
+    setIsPackageDialogOpen(false);
+    setPackageDialogMode('create');
+    setRenamingPackagePath('');
+    setNewPackageName('');
+    setPackageError('');
   }, [isVisible]);
 
   // Parent-owned confirm (compact toolbar popover) dispatches the shared delete

--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -51,29 +51,13 @@ import { Input } from './ui/input';
 import { Label } from './ui/label';
 import { SnippetCommandTooltipContent } from './snippets/SnippetCommandTooltipContent';
 import { TERMINAL_SIDE_PANEL_INNER_HEADER_CLASS } from './terminalLayer/terminalSidePanelChrome';
+import { isNonPrimaryPointer, primaryOnlyDragHandlers } from './ui/primaryOnlyDrag';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
 
 const toolbarIconButtonClass =
   'h-7 w-7 shrink-0 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors disabled:opacity-40 disabled:pointer-events-none';
 
 const SCRIPT_ROW_HEIGHT = 34;
-
-const isNonPrimaryPointer = (event: { button?: number; buttons?: number }): boolean =>
-  event.button === 2
-  || event.buttons === 2
-  || (typeof event.button === 'number' && event.button !== 0);
-
-const primaryOnlyDragHandlers = (enabled: boolean) => ({
-  onPointerDown: (event: React.PointerEvent<HTMLElement>) => {
-    if (event.button !== 0) event.currentTarget.draggable = false;
-  },
-  onPointerUp: (event: React.PointerEvent<HTMLElement>) => {
-    event.currentTarget.draggable = enabled;
-  },
-  onPointerCancel: (event: React.PointerEvent<HTMLElement>) => {
-    event.currentTarget.draggable = enabled;
-  },
-});
 
 const isRootPackagePath = (path: string): boolean => {
   const body = path.startsWith('/') ? path.slice(1) : path;

--- a/components/SnippetsManager.transfer.test.tsx
+++ b/components/SnippetsManager.transfer.test.tsx
@@ -134,4 +134,6 @@ test("vault snippet package and snippet cards use asChild context-menu triggers"
   assert.match(snippetsManagerSource, /setEditingSnippet/);
   assert.match(snippetsManagerSource, /setIsRenameDialogOpen\(false\)/);
   assert.match(snippetsManagerSource, /setRenamingPackagePath\(null\)/);
+  assert.match(snippetsManagerSource, /deleteTarget\?\.type === 'package'/);
+  assert.match(snippetsManagerSource, /setDeleteTarget\(null\)/);
 });

--- a/components/SnippetsManager.transfer.test.tsx
+++ b/components/SnippetsManager.transfer.test.tsx
@@ -132,4 +132,6 @@ test("vault snippet package and snippet cards use asChild context-menu triggers"
   assert.match(snippetsManagerSource, /applySnippetPackagePathChange/);
   assert.match(snippetsManagerSource, /setSelectedPackage/);
   assert.match(snippetsManagerSource, /setEditingSnippet/);
+  assert.match(snippetsManagerSource, /setIsRenameDialogOpen\(false\)/);
+  assert.match(snippetsManagerSource, /setRenamingPackagePath\(null\)/);
 });

--- a/components/SnippetsManager.transfer.test.tsx
+++ b/components/SnippetsManager.transfer.test.tsx
@@ -124,8 +124,8 @@ const snippetsManagerSource = readFileSync(new URL("./SnippetsManager.tsx", impo
 test("vault snippet package and snippet cards use asChild context-menu triggers", () => {
   assert.equal(snippetsManagerSource.match(/<ContextMenuTrigger asChild>/g)?.length, 2);
   assert.doesNotMatch(snippetsManagerSource, /<ContextMenuTrigger>(?! asChild)/);
+  assert.match(snippetsManagerSource, /from '\.\/ui\/primaryOnlyDrag'/);
   assert.match(snippetsManagerSource, /primaryOnlyDragHandlers/);
-  assert.match(snippetsManagerSource, /event\.button !== 0/);
   assert.match(snippetsManagerSource, /deleteSnippetPackage/);
   assert.match(snippetsManagerSource, /renameSnippetPackage/);
 });

--- a/components/SnippetsManager.transfer.test.tsx
+++ b/components/SnippetsManager.transfer.test.tsx
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
@@ -116,4 +117,15 @@ test("buildSnippetImportSamplesZip returns a zip archive", async () => {
 
   assert.equal(blob.type, "application/zip");
   assert.deepEqual(Array.from(bytes.slice(0, 4)), [0x50, 0x4b, 0x03, 0x04]);
+});
+
+const snippetsManagerSource = readFileSync(new URL("./SnippetsManager.tsx", import.meta.url), "utf8");
+
+test("vault snippet package and snippet cards use asChild context-menu triggers", () => {
+  assert.equal(snippetsManagerSource.match(/<ContextMenuTrigger asChild>/g)?.length, 2);
+  assert.doesNotMatch(snippetsManagerSource, /<ContextMenuTrigger>(?! asChild)/);
+  assert.match(snippetsManagerSource, /primaryOnlyDragHandlers/);
+  assert.match(snippetsManagerSource, /event\.button !== 0/);
+  assert.match(snippetsManagerSource, /deleteSnippetPackage/);
+  assert.match(snippetsManagerSource, /renameSnippetPackage/);
 });

--- a/components/SnippetsManager.transfer.test.tsx
+++ b/components/SnippetsManager.transfer.test.tsx
@@ -128,4 +128,8 @@ test("vault snippet package and snippet cards use asChild context-menu triggers"
   assert.match(snippetsManagerSource, /primaryOnlyDragHandlers/);
   assert.match(snippetsManagerSource, /deleteSnippetPackage/);
   assert.match(snippetsManagerSource, /renameSnippetPackage/);
+  assert.match(snippetsManagerSource, /SNIPPET_PACKAGE_PATH_CHANGE_EVENT/);
+  assert.match(snippetsManagerSource, /applySnippetPackagePathChange/);
+  assert.match(snippetsManagerSource, /setSelectedPackage/);
+  assert.match(snippetsManagerSource, /setEditingSnippet/);
 });

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -26,6 +26,7 @@ import {
 } from '../domain/snippetTargets.ts';
 import { removeHostConnectScript, syncHostsForSnippetTargetChange } from '../domain/hostConnectScripts.ts';
 import { flattenSnippetCommandPreview } from '../domain/snippetPreview.ts';
+import { deleteSnippetPackage, renameSnippetPackage } from '../domain/snippetPackage.ts';
 import { deleteSelectedSnippetsFromVault } from '../domain/snippetSelection.ts';
 import { DEFAULT_SCRIPT_TEMPLATE, isScriptSnippet } from '../domain/snippetScript.ts';
 import { reorderVaultItems, reorderVaultStrings, sortByVaultOrder } from '../domain/vaultOrder';
@@ -64,6 +65,23 @@ import {
   markVaultInsideDropIndicator as markSnippetInsideIndicator,
   useVaultGridLayoutAnimation,
 } from './vault/vaultReorderDrag';
+
+const isNonPrimaryPointer = (event: { button?: number; buttons?: number }): boolean =>
+  event.button === 2
+  || event.buttons === 2
+  || (typeof event.button === 'number' && event.button !== 0);
+
+const primaryOnlyDragHandlers = (enabled: boolean) => ({
+  onPointerDown: (event: React.PointerEvent<HTMLElement>) => {
+    if (event.button !== 0) event.currentTarget.draggable = false;
+  },
+  onPointerUp: (event: React.PointerEvent<HTMLElement>) => {
+    event.currentTarget.draggable = enabled;
+  },
+  onPointerCancel: (event: React.PointerEvent<HTMLElement>) => {
+    event.currentTarget.draggable = enabled;
+  },
+});
 
 interface SnippetsManagerProps {
   snippets: Snippet[];
@@ -1161,19 +1179,9 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
   };
 
   const performDeletePackage = (path: string) => {
-    const keep = packages.filter((p) => !(p === path || p.startsWith(path + '/')));
-    
-    const updatedSnippets = snippets.map((s) => {
-      if (!s.package) return s;
-      if (s.package === path || s.package.startsWith(path + '/')) {
-        return { ...s, package: '' };
-      }
-      return s;
-    });
-    
-    onPackagesChange(keep);
-    
-    onBulkSave(updatedSnippets);
+    const result = deleteSnippetPackage(packages, snippets, path);
+    onPackagesChange(result.packages);
+    onBulkSave(result.snippets);
     
     if (selectedPackage && (selectedPackage === path || selectedPackage.startsWith(path + '/'))) {
       setSelectedPackage(null);
@@ -1286,66 +1294,33 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
   const renamePackage = () => {
     if (!renamingPackagePath) return;
 
-    const newName = renamePackageName.trim();
-
-    if (!newName) {
-      setRenameError(t('snippets.renameDialog.error.empty'));
+    const result = renameSnippetPackage(packages, snippets, renamingPackagePath, renamePackageName);
+    if (!result.ok) {
+      setRenameError(t(`snippets.renameDialog.error.${result.error}`));
       return;
     }
 
-    if (!/^[\w\p{L}\p{N}-]+$/u.test(newName)) {
-      setRenameError(t('snippets.renameDialog.error.invalidChars'));
-      return;
-    }
-
-    const parts = renamingPackagePath.split('/');
-    parts[parts.length - 1] = newName;
-    const newPath = parts.join('/');
-
-    if (newPath === renamingPackagePath) {
+    if (result.newPath === renamingPackagePath) {
       setIsRenameDialogOpen(false);
       return;
     }
 
-    const existingPackage = packages.find(p => p !== renamingPackagePath && p.toLowerCase() === newPath.toLowerCase());
-    if (existingPackage) {
-      setRenameError(t('snippets.renameDialog.error.duplicate'));
-      return;
-    }
-
-    const updatedPackages = packages.map((p) => {
-      if (p === renamingPackagePath) return newPath;
-      if (p.startsWith(renamingPackagePath + '/')) {
-        return newPath + p.substring(renamingPackagePath.length);
-      }
-      return p;
-    });
-
-    const updatedSnippets = snippets.map((s) => {
-      if (!s.package) return s;
-      if (s.package === renamingPackagePath) return { ...s, package: newPath };
-      if (s.package.startsWith(renamingPackagePath + '/')) {
-        return { ...s, package: newPath + s.package.substring(renamingPackagePath.length) };
-      }
-      return s;
-    });
-
-    onPackagesChange(Array.from(new Set(updatedPackages)));
-    onBulkSave(updatedSnippets);
+    onPackagesChange(result.packages);
+    onBulkSave(result.snippets);
 
     if (selectedPackage === renamingPackagePath) {
-      setSelectedPackage(newPath);
+      setSelectedPackage(result.newPath);
     } else if (selectedPackage?.startsWith(renamingPackagePath + '/')) {
-      setSelectedPackage(newPath + selectedPackage.substring(renamingPackagePath.length));
+      setSelectedPackage(result.newPath + selectedPackage.substring(renamingPackagePath.length));
     }
 
     if (editingSnippet.package) {
       if (editingSnippet.package === renamingPackagePath) {
-        setEditingSnippet(prev => ({ ...prev, package: newPath }));
+        setEditingSnippet(prev => ({ ...prev, package: result.newPath }));
       } else if (editingSnippet.package.startsWith(renamingPackagePath + '/')) {
         setEditingSnippet(prev => ({
           ...prev,
-          package: newPath + prev.package!.substring(renamingPackagePath.length)
+          package: result.newPath + prev.package!.substring(renamingPackagePath.length)
         }));
       }
     }
@@ -1862,7 +1837,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
               >
                 {displayedPackages.map((pkg) => (
                   <ContextMenu key={pkg.path}>
-                    <ContextMenuTrigger>
+                    <ContextMenuTrigger asChild>
                       <div
                         className={cn(
                           "vault-drop-indicator-row group cursor-pointer overflow-hidden",
@@ -1875,7 +1850,12 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
                         data-vault-reorder-grid={viewMode === 'grid' ? 'true' : undefined}
                         data-vault-reorder-dragging={draggingPackagePath === pkg.path ? 'true' : undefined}
                         draggable
+                        {...primaryOnlyDragHandlers(true)}
                         onDragStart={(e) => {
+                          if (isNonPrimaryPointer(e) || isNonPrimaryPointer(e.nativeEvent)) {
+                            e.preventDefault();
+                            return;
+                          }
                           e.dataTransfer.effectAllowed = 'move';
                           e.dataTransfer.setData('pkg-path', pkg.path);
                           draggingPackagePathRef.current = pkg.path;
@@ -1951,7 +1931,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
                   const isSelected = selectedSnippetIds.has(snippet.id);
                   return (
                   <ContextMenu key={snippet.id}>
-                    <ContextMenuTrigger>
+                    <ContextMenuTrigger asChild>
                       <div
                         className={cn(
                           "vault-drop-indicator-row group cursor-pointer overflow-hidden",
@@ -1965,7 +1945,12 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
                         data-vault-reorder-grid={viewMode === 'grid' ? 'true' : undefined}
                         data-vault-reorder-dragging={draggingSnippetId === snippet.id ? 'true' : undefined}
                         draggable={!isSearchActive && !isMultiSelectMode}
+                        {...primaryOnlyDragHandlers(!isSearchActive && !isMultiSelectMode)}
                         onDragStart={(e) => {
+                          if (isNonPrimaryPointer(e) || isNonPrimaryPointer(e.nativeEvent)) {
+                            e.preventDefault();
+                            return;
+                          }
                           e.dataTransfer.effectAllowed = 'move';
                           e.dataTransfer.setData('snippet-id', snippet.id);
                           draggingSnippetIdRef.current = snippet.id;

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -37,6 +37,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Dropdown, DropdownContent, DropdownTrigger } from './ui/dropdown';
 import { SortDropdown, SortMode } from './ui/sort-dropdown';
 import { toast } from './ui/toast';
+import { isNonPrimaryPointer, primaryOnlyDragHandlers } from './ui/primaryOnlyDrag';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
 import { SnippetCommandTooltipContent } from './snippets/SnippetCommandTooltipContent';
 import { SnippetsRightPanel } from './SnippetsRightPanel';
@@ -65,23 +66,6 @@ import {
   markVaultInsideDropIndicator as markSnippetInsideIndicator,
   useVaultGridLayoutAnimation,
 } from './vault/vaultReorderDrag';
-
-const isNonPrimaryPointer = (event: { button?: number; buttons?: number }): boolean =>
-  event.button === 2
-  || event.buttons === 2
-  || (typeof event.button === 'number' && event.button !== 0);
-
-const primaryOnlyDragHandlers = (enabled: boolean) => ({
-  onPointerDown: (event: React.PointerEvent<HTMLElement>) => {
-    if (event.button !== 0) event.currentTarget.draggable = false;
-  },
-  onPointerUp: (event: React.PointerEvent<HTMLElement>) => {
-    event.currentTarget.draggable = enabled;
-  },
-  onPointerCancel: (event: React.PointerEvent<HTMLElement>) => {
-    event.currentTarget.draggable = enabled;
-  },
-});
 
 interface SnippetsManagerProps {
   snippets: Snippet[];

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -558,11 +558,15 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
           setRenameError('');
         }
       }
+      if (deleteTarget?.type === 'package') {
+        const nextPath = applySnippetPackagePathChange(deleteTarget.id, change);
+        if (nextPath !== deleteTarget.id) setDeleteTarget(null);
+      }
     };
 
     window.addEventListener(SNIPPET_PACKAGE_PATH_CHANGE_EVENT, handlePackagePathChange);
     return () => window.removeEventListener(SNIPPET_PACKAGE_PATH_CHANGE_EVENT, handlePackagePathChange);
-  }, [isRenameDialogOpen, renamingPackagePath]);
+  }, [deleteTarget, isRenameDialogOpen, renamingPackagePath]);
 
   const prepareGridLayoutAnimation = useVaultGridLayoutAnimation(listRef);
   const hasSnippetsSidePanel = rightPanelMode !== 'none';

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -26,7 +26,13 @@ import {
 } from '../domain/snippetTargets.ts';
 import { removeHostConnectScript, syncHostsForSnippetTargetChange } from '../domain/hostConnectScripts.ts';
 import { flattenSnippetCommandPreview } from '../domain/snippetPreview.ts';
-import { deleteSnippetPackage, renameSnippetPackage } from '../domain/snippetPackage.ts';
+import {
+  applySnippetPackagePathChange,
+  deleteSnippetPackage,
+  SNIPPET_PACKAGE_PATH_CHANGE_EVENT,
+  renameSnippetPackage,
+  type SnippetPackagePathChange,
+} from '../domain/snippetPackage.ts';
 import { deleteSelectedSnippetsFromVault } from '../domain/snippetSelection.ts';
 import { DEFAULT_SCRIPT_TEMPLATE, isScriptSnippet } from '../domain/snippetScript.ts';
 import { reorderVaultItems, reorderVaultStrings, sortByVaultOrder } from '../domain/vaultOrder';
@@ -527,6 +533,28 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
   >(null);
   const [isSnippetImportDialogOpen, setIsSnippetImportDialogOpen] = useState(false);
   const [pendingImport, setPendingImport] = useState<PendingSnippetImport | null>(null);
+
+  useEffect(() => {
+    const handlePackagePathChange = (event: Event) => {
+      const change = (event as CustomEvent<SnippetPackagePathChange>).detail;
+      if (!change?.from || (change.to !== null && !change.to)) return;
+
+      setSelectedPackage((current) => {
+        if (!current) return current;
+        const next = applySnippetPackagePathChange(current, change);
+        return next || null;
+      });
+      setEditingSnippet((current) => {
+        if (!current.package) return current;
+        const next = applySnippetPackagePathChange(current.package, change);
+        return next === current.package ? current : { ...current, package: next };
+      });
+    };
+
+    window.addEventListener(SNIPPET_PACKAGE_PATH_CHANGE_EVENT, handlePackagePathChange);
+    return () => window.removeEventListener(SNIPPET_PACKAGE_PATH_CHANGE_EVENT, handlePackagePathChange);
+  }, []);
+
   const prepareGridLayoutAnimation = useVaultGridLayoutAnimation(listRef);
   const hasSnippetsSidePanel = rightPanelMode !== 'none';
   const splitGridColsRef = useRef(2);

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -549,11 +549,20 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
         const next = applySnippetPackagePathChange(current.package, change);
         return next === current.package ? current : { ...current, package: next };
       });
+      if (isRenameDialogOpen && renamingPackagePath) {
+        const nextPath = applySnippetPackagePathChange(renamingPackagePath, change);
+        if (nextPath !== renamingPackagePath) {
+          setIsRenameDialogOpen(false);
+          setRenamingPackagePath(null);
+          setRenamePackageName('');
+          setRenameError('');
+        }
+      }
     };
 
     window.addEventListener(SNIPPET_PACKAGE_PATH_CHANGE_EVENT, handlePackagePathChange);
     return () => window.removeEventListener(SNIPPET_PACKAGE_PATH_CHANGE_EVENT, handlePackagePathChange);
-  }, []);
+  }, [isRenameDialogOpen, renamingPackagePath]);
 
   const prepareGridLayoutAnimation = useVaultGridLayoutAnimation(listRef);
   const hasSnippetsSidePanel = rightPanelMode !== 'none';

--- a/components/ui/primaryOnlyDrag.test.ts
+++ b/components/ui/primaryOnlyDrag.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  primaryOnlyDragHandlers,
+  restorePrimaryOnlyDrag,
+} from "./primaryOnlyDrag.ts";
+
+const fakeRoot = () => {
+  const listeners = new Map<string, Set<EventListener>>();
+  return {
+    listeners,
+    addEventListener(type: string, listener: EventListener) {
+      const set = listeners.get(type) ?? new Set();
+      set.add(listener);
+      listeners.set(type, set);
+    },
+    removeEventListener(type: string, listener: EventListener) {
+      listeners.get(type)?.delete(listener);
+    },
+    dispatch(type: string) {
+      for (const listener of Array.from(listeners.get(type) ?? [])) {
+        listener(new Event(type));
+      }
+    },
+  };
+};
+
+test("primaryOnlyDragHandlers restores draggable after a right-click is released outside", () => {
+  const root = fakeRoot();
+  const target = { draggable: true } as HTMLElement;
+  const handlers = primaryOnlyDragHandlers(true, root);
+
+  handlers.onPointerDown({
+    button: 2,
+    currentTarget: target,
+  } as Parameters<typeof handlers.onPointerDown>[0]);
+
+  assert.equal(target.draggable, false);
+  assert.equal(root.listeners.get("pointerup")?.size, 1);
+  assert.equal(root.listeners.get("pointercancel")?.size, 1);
+
+  root.dispatch("pointerup");
+
+  assert.equal(target.draggable, true);
+  assert.equal(root.listeners.get("pointerup")?.size, 0);
+  assert.equal(root.listeners.get("pointercancel")?.size, 0);
+});
+
+test("primaryOnlyDragHandlers pointercancel on the document also restores draggable", () => {
+  const root = fakeRoot();
+  const target = { draggable: true } as HTMLElement;
+  const handlers = primaryOnlyDragHandlers(true, root);
+
+  handlers.onPointerDown({
+    button: 2,
+    currentTarget: target,
+  } as Parameters<typeof handlers.onPointerDown>[0]);
+  root.dispatch("pointercancel");
+
+  assert.equal(target.draggable, true);
+  assert.equal(root.listeners.get("pointerup")?.size, 0);
+  assert.equal(root.listeners.get("pointercancel")?.size, 0);
+});
+
+test("element-level pointerup clears the document restore listeners", () => {
+  const root = fakeRoot();
+  const target = { draggable: true } as HTMLElement;
+  const handlers = primaryOnlyDragHandlers(true, root);
+
+  handlers.onPointerDown({
+    button: 2,
+    currentTarget: target,
+  } as Parameters<typeof handlers.onPointerDown>[0]);
+  handlers.onPointerUp({
+    currentTarget: target,
+  } as Parameters<typeof handlers.onPointerUp>[0]);
+
+  assert.equal(target.draggable, true);
+  assert.equal(root.listeners.get("pointerup")?.size, 0);
+  restorePrimaryOnlyDrag(target, false);
+  assert.equal(target.draggable, false);
+});
+
+test("primary pointer down does not disable dragging", () => {
+  const root = fakeRoot();
+  const target = { draggable: true } as HTMLElement;
+  const handlers = primaryOnlyDragHandlers(true, root);
+
+  handlers.onPointerDown({
+    button: 0,
+    currentTarget: target,
+  } as Parameters<typeof handlers.onPointerDown>[0]);
+
+  assert.equal(target.draggable, true);
+  assert.equal(root.listeners.get("pointerup")?.size ?? 0, 0);
+});

--- a/components/ui/primaryOnlyDrag.ts
+++ b/components/ui/primaryOnlyDrag.ts
@@ -1,0 +1,58 @@
+import type { PointerEvent as ReactPointerEvent } from "react";
+
+export type PrimaryOnlyDragEventRoot = Pick<
+  EventTarget,
+  "addEventListener" | "removeEventListener"
+>;
+
+export const isNonPrimaryPointer = (event: { button?: number; buttons?: number }): boolean =>
+  event.button === 2
+  || event.buttons === 2
+  || (typeof event.button === "number" && event.button !== 0);
+
+const pendingRestore = new WeakMap<HTMLElement, () => void>();
+
+export function restorePrimaryOnlyDrag(target: HTMLElement, enabled: boolean): void {
+  const restore = pendingRestore.get(target);
+  if (restore) {
+    restore();
+    return;
+  }
+  target.draggable = enabled;
+}
+
+export function armPrimaryOnlyDragRestore(
+  target: HTMLElement,
+  enabled: boolean,
+  root: PrimaryOnlyDragEventRoot = window,
+): void {
+  pendingRestore.get(target)?.();
+  const restore = () => {
+    target.draggable = enabled;
+    root.removeEventListener("pointerup", restore, true);
+    root.removeEventListener("pointercancel", restore, true);
+    if (pendingRestore.get(target) === restore) pendingRestore.delete(target);
+  };
+  pendingRestore.set(target, restore);
+  root.addEventListener("pointerup", restore, true);
+  root.addEventListener("pointercancel", restore, true);
+}
+
+export function primaryOnlyDragHandlers(
+  enabled: boolean,
+  root?: PrimaryOnlyDragEventRoot,
+) {
+  return {
+    onPointerDown: (event: ReactPointerEvent<HTMLElement>) => {
+      if (event.button === 0) return;
+      event.currentTarget.draggable = false;
+      armPrimaryOnlyDragRestore(event.currentTarget, enabled, root ?? window);
+    },
+    onPointerUp: (event: ReactPointerEvent<HTMLElement>) => {
+      restorePrimaryOnlyDrag(event.currentTarget, enabled);
+    },
+    onPointerCancel: (event: ReactPointerEvent<HTMLElement>) => {
+      restorePrimaryOnlyDrag(event.currentTarget, enabled);
+    },
+  };
+}

--- a/domain/snippetPackage.test.ts
+++ b/domain/snippetPackage.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import type { Snippet } from "./models.ts";
 import {
+  applySnippetPackagePathChange,
   collectSnippetPackageTreePaths,
   deleteSnippetPackage,
   renameSnippetPackage,
@@ -129,4 +130,19 @@ test("renameSnippetPackage no-ops when the name is unchanged", () => {
   assert.equal(result.newPath, "ops");
   assert.equal(result.packages, packages);
   assert.equal(result.snippets, snippets);
+});
+
+test("applySnippetPackagePathChange rewrites descendants and clears deleted paths", () => {
+  assert.equal(
+    applySnippetPackagePathChange("ops/linux", { from: "ops", to: "platform" }),
+    "platform/linux",
+  );
+  assert.equal(
+    applySnippetPackagePathChange("ops/linux", { from: "ops", to: null }),
+    "",
+  );
+  assert.equal(
+    applySnippetPackagePathChange("other", { from: "ops", to: "platform" }),
+    "other",
+  );
 });

--- a/domain/snippetPackage.test.ts
+++ b/domain/snippetPackage.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import type { Snippet } from "./models.ts";
 import {
+  collectSnippetPackageTreePaths,
   deleteSnippetPackage,
   renameSnippetPackage,
 } from "./snippetPackage.ts";
@@ -86,6 +87,36 @@ test("renameSnippetPackage rejects empty, invalid, and duplicate names", () => {
   assert.deepEqual(
     renameSnippetPackage(["ops", "db"], [], "ops", "DB"),
     { ok: false, error: "duplicate" },
+  );
+});
+
+test("renameSnippetPackage rejects collisions with inferred ancestor packages", () => {
+  assert.deepEqual(
+    renameSnippetPackage(["a", "b/x"], [], "a", "b"),
+    { ok: false, error: "duplicate" },
+  );
+  assert.deepEqual(
+    renameSnippetPackage(["a", "B/x"], [], "a", "b"),
+    { ok: false, error: "duplicate" },
+  );
+});
+
+test("renameSnippetPackage rejects collisions with snippet-implied packages", () => {
+  assert.deepEqual(
+    renameSnippetPackage(
+      ["a"],
+      [snippet({ id: "s", package: "b/x" })],
+      "a",
+      "b",
+    ),
+    { ok: false, error: "duplicate" },
+  );
+});
+
+test("collectSnippetPackageTreePaths includes persisted and inferred ancestors", () => {
+  assert.deepEqual(
+    collectSnippetPackageTreePaths(["a", "b/x"], [snippet({ id: "s", package: "c/y" })]).sort(),
+    ["a", "b", "b/x", "c", "c/y"],
   );
 });
 

--- a/domain/snippetPackage.test.ts
+++ b/domain/snippetPackage.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { Snippet } from "./models.ts";
+import {
+  deleteSnippetPackage,
+  renameSnippetPackage,
+} from "./snippetPackage.ts";
+
+const snippet = (overrides: Partial<Snippet> & Pick<Snippet, "id">): Snippet => ({
+  label: overrides.label ?? overrides.id,
+  command: overrides.command ?? "echo ok",
+  package: "",
+  ...overrides,
+});
+
+test("deleteSnippetPackage removes the package and descendants but keeps snippet bodies", () => {
+  const result = deleteSnippetPackage(
+    ["ops", "ops/linux", "db"],
+    [
+      snippet({ id: "keep-ops", label: "Restart", command: "systemctl restart nginx", package: "ops" }),
+      snippet({ id: "keep-child", label: "Disk", command: "df -h", package: "ops/linux" }),
+      snippet({ id: "untouched", label: "PSQL", command: "psql", package: "db" }),
+      snippet({ id: "root", command: "uptime" }),
+    ],
+    "ops",
+  );
+
+  assert.deepEqual(result.packages, ["db"]);
+  assert.deepEqual(
+    result.snippets.map((item) => ({
+      id: item.id,
+      package: item.package,
+      command: item.command,
+      label: item.label,
+    })),
+    [
+      { id: "keep-ops", package: "", command: "systemctl restart nginx", label: "Restart" },
+      { id: "keep-child", package: "", command: "df -h", label: "Disk" },
+      { id: "untouched", package: "db", command: "psql", label: "PSQL" },
+      { id: "root", package: "", command: "uptime", label: "root" },
+    ],
+  );
+});
+
+test("renameSnippetPackage rewrites the package and descendant snippet paths", () => {
+  const result = renameSnippetPackage(
+    ["ops", "ops/linux", "db"],
+    [
+      snippet({ id: "a", package: "ops" }),
+      snippet({ id: "b", package: "ops/linux" }),
+      snippet({ id: "c", package: "db" }),
+    ],
+    "ops",
+    "platform",
+  );
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.newPath, "platform");
+  assert.deepEqual(result.packages, ["platform", "platform/linux", "db"]);
+  assert.deepEqual(
+    result.snippets.map((item) => item.package),
+    ["platform", "platform/linux", "db"],
+  );
+});
+
+test("renameSnippetPackage preserves a leading slash on absolute packages", () => {
+  const result = renameSnippetPackage(["/ops"], [snippet({ id: "a", package: "/ops" })], "/ops", "infra");
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.newPath, "/infra");
+  assert.deepEqual(result.packages, ["/infra"]);
+  assert.equal(result.snippets[0].package, "/infra");
+});
+
+test("renameSnippetPackage rejects empty, invalid, and duplicate names", () => {
+  assert.deepEqual(
+    renameSnippetPackage(["ops"], [], "ops", "   "),
+    { ok: false, error: "empty" },
+  );
+  assert.deepEqual(
+    renameSnippetPackage(["ops"], [], "ops", "ops/linux"),
+    { ok: false, error: "invalidChars" },
+  );
+  assert.deepEqual(
+    renameSnippetPackage(["ops", "db"], [], "ops", "DB"),
+    { ok: false, error: "duplicate" },
+  );
+});
+
+test("renameSnippetPackage no-ops when the name is unchanged", () => {
+  const packages = ["ops"];
+  const snippets = [snippet({ id: "a", package: "ops" })];
+  const result = renameSnippetPackage(packages, snippets, "ops", "ops");
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.newPath, "ops");
+  assert.equal(result.packages, packages);
+  assert.equal(result.snippets, snippets);
+});

--- a/domain/snippetPackage.ts
+++ b/domain/snippetPackage.ts
@@ -1,5 +1,12 @@
 export const SNIPPET_PACKAGE_NAME_PATTERN = /^[\w\p{L}\p{N}-]+$/u;
 
+export const SNIPPET_PACKAGE_PATH_CHANGE_EVENT = "netcatty:snippets:package-path-change";
+
+export type SnippetPackagePathChange = {
+  from: string;
+  to: string | null;
+};
+
 export type SnippetPackageRenameError = "empty" | "invalidChars" | "duplicate";
 
 type PackagedSnippet = { package?: string };
@@ -34,11 +41,24 @@ export function collectSnippetPackageTreePaths(
   return Array.from(paths);
 }
 
-const rewritePackagePath = (value: string, from: string, to: string): string => {
+export const rewriteSnippetPackagePath = (value: string, from: string, to: string): string => {
   if (value === from) return to;
   if (value.startsWith(`${from}/`)) return to + value.slice(from.length);
   return value;
 };
+
+export function applySnippetPackagePathChange(
+  value: string | undefined,
+  change: SnippetPackagePathChange,
+): string {
+  const packagePath = value || "";
+  if (!packagePath || !isSnippetPackagePathAtOrBelow(packagePath, change.from)) {
+    return packagePath;
+  }
+  return change.to === null
+    ? ""
+    : rewriteSnippetPackagePath(packagePath, change.from, change.to);
+}
 
 /** Remove a package and descendants; keep snippets and clear their package path. */
 export function deleteSnippetPackage<T extends PackagedSnippet>(
@@ -86,12 +106,12 @@ export function renameSnippetPackage<T extends PackagedSnippet>(
     ok: true,
     newPath,
     packages: Array.from(new Set(
-      packages.map((item) => rewritePackagePath(item, path, newPath)),
+      packages.map((item) => rewriteSnippetPackagePath(item, path, newPath)),
     )),
     snippets: snippets.map((snippet) => {
       const packagePath = snippet.package || "";
       if (!packagePath) return snippet;
-      const nextPath = rewritePackagePath(packagePath, path, newPath);
+      const nextPath = rewriteSnippetPackagePath(packagePath, path, newPath);
       return nextPath === packagePath ? snippet : { ...snippet, package: nextPath };
     }),
   };

--- a/domain/snippetPackage.ts
+++ b/domain/snippetPackage.ts
@@ -1,0 +1,71 @@
+export const SNIPPET_PACKAGE_NAME_PATTERN = /^[\w\p{L}\p{N}-]+$/u;
+
+export type SnippetPackageRenameError = "empty" | "invalidChars" | "duplicate";
+
+type PackagedSnippet = { package?: string };
+
+export function isSnippetPackagePathAtOrBelow(path: string, root: string): boolean {
+  return path === root || path.startsWith(`${root}/`);
+}
+
+const rewritePackagePath = (value: string, from: string, to: string): string => {
+  if (value === from) return to;
+  if (value.startsWith(`${from}/`)) return to + value.slice(from.length);
+  return value;
+};
+
+/** Remove a package and descendants; keep snippets and clear their package path. */
+export function deleteSnippetPackage<T extends PackagedSnippet>(
+  packages: string[],
+  snippets: T[],
+  path: string,
+): { packages: string[]; snippets: T[] } {
+  return {
+    packages: packages.filter((item) => !isSnippetPackagePathAtOrBelow(item, path)),
+    snippets: snippets.map((snippet) => {
+      const packagePath = snippet.package || "";
+      if (!packagePath || !isSnippetPackagePathAtOrBelow(packagePath, path)) return snippet;
+      return { ...snippet, package: "" };
+    }),
+  };
+}
+
+export function renameSnippetPackage<T extends PackagedSnippet>(
+  packages: string[],
+  snippets: T[],
+  path: string,
+  newName: string,
+):
+  | { ok: true; packages: string[]; snippets: T[]; newPath: string }
+  | { ok: false; error: SnippetPackageRenameError } {
+  const trimmed = newName.trim();
+  if (!trimmed) return { ok: false, error: "empty" };
+  if (!SNIPPET_PACKAGE_NAME_PATTERN.test(trimmed)) return { ok: false, error: "invalidChars" };
+
+  const parts = path.split("/");
+  parts[parts.length - 1] = trimmed;
+  const newPath = parts.join("/");
+
+  if (newPath === path) {
+    return { ok: true, packages, snippets, newPath };
+  }
+
+  const duplicate = packages.some(
+    (item) => item !== path && item.toLowerCase() === newPath.toLowerCase(),
+  );
+  if (duplicate) return { ok: false, error: "duplicate" };
+
+  return {
+    ok: true,
+    newPath,
+    packages: Array.from(new Set(
+      packages.map((item) => rewritePackagePath(item, path, newPath)),
+    )),
+    snippets: snippets.map((snippet) => {
+      const packagePath = snippet.package || "";
+      if (!packagePath) return snippet;
+      const nextPath = rewritePackagePath(packagePath, path, newPath);
+      return nextPath === packagePath ? snippet : { ...snippet, package: nextPath };
+    }),
+  };
+}

--- a/domain/snippetPackage.ts
+++ b/domain/snippetPackage.ts
@@ -8,6 +8,32 @@ export function isSnippetPackagePathAtOrBelow(path: string, root: string): boole
   return path === root || path.startsWith(`${root}/`);
 }
 
+export function getSnippetPackageAncestors(path: string): string[] {
+  const normalized = path.trim().replace(/\/+$/g, "");
+  if (!normalized) return [];
+  const isAbsolute = normalized.startsWith("/");
+  const parts = normalized.split("/").filter(Boolean);
+  return parts.map((_, index) => {
+    const joined = parts.slice(0, index + 1).join("/");
+    return isAbsolute ? `/${joined}` : joined;
+  });
+}
+
+/** Persisted packages plus inferred ancestors from packages and snippet.package. */
+export function collectSnippetPackageTreePaths(
+  packages: string[],
+  snippets: PackagedSnippet[] = [],
+): string[] {
+  const paths = new Set<string>();
+  const add = (raw: string | undefined) => {
+    if (!raw) return;
+    getSnippetPackageAncestors(raw).forEach((ancestor) => paths.add(ancestor));
+  };
+  packages.forEach(add);
+  snippets.forEach((snippet) => add(snippet.package));
+  return Array.from(paths);
+}
+
 const rewritePackagePath = (value: string, from: string, to: string): string => {
   if (value === from) return to;
   if (value.startsWith(`${from}/`)) return to + value.slice(from.length);
@@ -50,7 +76,8 @@ export function renameSnippetPackage<T extends PackagedSnippet>(
     return { ok: true, packages, snippets, newPath };
   }
 
-  const duplicate = packages.some(
+  const occupied = collectSnippetPackageTreePaths(packages, snippets);
+  const duplicate = occupied.some(
     (item) => item !== path && item.toLowerCase() === newPath.toLowerCase(),
   );
   if (duplicate) return { ok: false, error: "duplicate" };

--- a/domain/snippetTransfer.ts
+++ b/domain/snippetTransfer.ts
@@ -1,4 +1,5 @@
 import type { Snippet } from "./models";
+import { getSnippetPackageAncestors } from "./snippetPackage.ts";
 import { normalizeVaultOrder } from "./vaultOrder";
 import { normalizeGroupTargetPaths } from "./hostGroupPathMutations";
 
@@ -61,17 +62,6 @@ const uniqueStrings = (values: unknown[]): string[] => {
   return result;
 };
 
-const getPackageAncestors = (path: string): string[] => {
-  const normalized = path.trim().replace(/\/+$/g, "");
-  if (!normalized) return [];
-  const isAbsolute = normalized.startsWith("/");
-  const parts = normalized.split("/").filter(Boolean);
-  return parts.map((_, index) => {
-    const joined = parts.slice(0, index + 1).join("/");
-    return isAbsolute ? `/${joined}` : joined;
-  });
-};
-
 export const collectSnippetPackagePaths = (
   snippets: Pick<SnippetExportItem, "package">[],
   snippetPackages: string[] = [],
@@ -80,7 +70,7 @@ export const collectSnippetPackagePaths = (
   snippets.forEach((snippet) => {
     const packagePath = snippet.package?.trim();
     if (!packagePath) return;
-    getPackageAncestors(packagePath).forEach((path) => referenced.add(path));
+    getSnippetPackageAncestors(packagePath).forEach((path) => referenced.add(path));
   });
 
   const ordered = uniqueStrings([
@@ -93,7 +83,7 @@ export const collectSnippetPackagePaths = (
 const mergeSnippetPackagePaths = (...groups: string[][]): string[] => {
   const paths: string[] = [];
   groups.flat().forEach((path) => {
-    getPackageAncestors(path).forEach((ancestor) => paths.push(ancestor));
+    getSnippetPackageAncestors(path).forEach((ancestor) => paths.push(ancestor));
   });
   return uniqueStrings(paths);
 };


### PR DESCRIPTION
## Summary

Right-clicking a script package (脚本包) in the terminal scripts tree did nothing, and the Vault snippets package/snippet context menus were swallowed on Windows when HTML5 drag started from a wrapping trigger. This adds Rename/Delete on package rows and makes Vault cards the actual context-menu trigger while ignoring non-primary drags.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3174

## Changes Made

- Wrap `ScriptsSidePanel` `PackageRow` in a context menu with Rename and Delete (left-click still expands/collapses).
- Delete a package with the existing confirm dialog; snippets stay saved and move out of the package.
- Rename uses the existing package-name rules (`^[\w\p{L}\p{N}-]+$`) and the in-panel package dialog.
- Extract `deleteSnippetPackage` / `renameSnippetPackage` domain helpers and reuse them in Vault `SnippetsManager`.
- Use `ContextMenuTrigger asChild` on Vault package and snippet cards, and do not start a drag from a right-click / non-primary pointer.

## Screenshots / Demo

Right-click a package in the terminal scripts tree to rename or delete it. Right-click a package or snippet card in Vault > Snippets on Windows to get the existing Open/Export/Rename/Delete (or snippet) menu.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Focused runs:

```
node --test --import tsx components/ScriptsSidePanel.test.ts domain/snippetPackage.test.ts components/SnippetsManager.transfer.test.tsx
```

24 passing. ESLint on the touched files is clean.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)