### PR TITLE
[Bug] Restore AI automation YAML so issue triage registers

### DIFF
--- a/.github/workflows/ai-automation.yml
+++ b/.github/workflows/ai-automation.yml
@@ -845,16 +845,10 @@ jobs:
           mkdir -p "$research_dir" .ai-runtime
           "$RUNNER_TEMP/prepare-ai-research-input.sh" "$RESEARCH_INPUT_PATH" "$research_dir"
           cp "$RUNNER_TEMP/ai-brave-search.cjs" "$research_dir/ai-brave-search.cjs"
-          cat > "$research_dir/web-search" <<'EOS'
-#!/usr/bin/env bash
-set -euo pipefail
-exec node "$(dirname "$0")/ai-brave-search.cjs" search "$@"
-EOS
-          cat > "$research_dir/web-fetch" <<'EOS'
-#!/usr/bin/env bash
-set -euo pipefail
-exec node "$(dirname "$0")/ai-brave-search.cjs" fetch "$@"
-EOS
+          node -e '
+            const auto = require(process.env.RUNNER_TEMP + "/ai-automation.cjs");
+            auto.writeBraveResearchHelpers(process.argv[1]);
+          ' "$research_dir"
           chmod 0555 "$research_dir/web-search" "$research_dir/web-fetch" "$research_dir/ai-brave-search.cjs"
           : > "$research_dir/brave-tool.jsonl"
           prompt="$(cat "$RUNNER_TEMP/$RESEARCH_PROMPT_PATH")"
@@ -1662,16 +1656,10 @@ EOS
           mkdir -p "$research_dir" .ai-runtime
           "$RUNNER_TEMP/prepare-ai-research-input.sh" "$RESEARCH_INPUT_PATH" "$research_dir"
           cp "$RUNNER_TEMP/ai-brave-search.cjs" "$research_dir/ai-brave-search.cjs"
-          cat > "$research_dir/web-search" <<'EOS'
-#!/usr/bin/env bash
-set -euo pipefail
-exec node "$(dirname "$0")/ai-brave-search.cjs" search "$@"
-EOS
-          cat > "$research_dir/web-fetch" <<'EOS'
-#!/usr/bin/env bash
-set -euo pipefail
-exec node "$(dirname "$0")/ai-brave-search.cjs" fetch "$@"
-EOS
+          node -e '
+            const auto = require(process.env.RUNNER_TEMP + "/ai-automation.cjs");
+            auto.writeBraveResearchHelpers(process.argv[1]);
+          ' "$research_dir"
           chmod 0555 "$research_dir/web-search" "$research_dir/web-fetch" "$research_dir/ai-brave-search.cjs"
           : > "$research_dir/brave-tool.jsonl"
           prompt="$(cat "$RUNNER_TEMP/$RESEARCH_PROMPT_PATH")"

--- a/scripts/ai-automation.cjs
+++ b/scripts/ai-automation.cjs
@@ -2943,6 +2943,32 @@ function writeText(filePath, value) {
   fs.writeFileSync(filePath, String(value ?? ''), 'utf8');
 }
 
+const BRAVE_RESEARCH_HELPERS = Object.freeze([
+  ['web-search', 'search'],
+  ['web-fetch', 'fetch'],
+]);
+
+/**
+ * Write PATH helpers for isolated Brave research. Keep this out of workflow
+ * YAML heredocs: an unindented `<<'EOS'` body is parsed as a top-level key
+ * and GitHub will not register the workflow.
+ */
+function writeBraveResearchHelpers(researchDir) {
+  const dir = String(researchDir || '').trim();
+  if (!dir) throw new Error('research directory is required');
+  for (const [name, mode] of BRAVE_RESEARCH_HELPERS) {
+    const script = [
+      '#!/usr/bin/env bash',
+      'set -euo pipefail',
+      `exec node "$(dirname "$0")/ai-brave-search.cjs" ${mode} "$@"`,
+      '',
+    ].join('\n');
+    const filePath = path.join(dir, name);
+    fs.writeFileSync(filePath, script, { encoding: 'utf8', mode: 0o555 });
+    fs.chmodSync(filePath, 0o555);
+  }
+}
+
 /**
  * Write Claude Code settings.json for an unattended CI run.
  */
@@ -4202,6 +4228,7 @@ module.exports = {
   prepareAiCliSettings,
   unwrapAgentJson,
   isAutomationTriageMarker,
+  writeBraveResearchHelpers,
   writeJson,
   writeText,
 };

--- a/scripts/ai-automation.test.cjs
+++ b/scripts/ai-automation.test.cjs
@@ -3963,6 +3963,39 @@ test('legacy cursor automation markers still count as processed replies', () => 
   );
 });
 
+test('writeBraveResearchHelpers writes shebang wrappers without YAML heredocs', (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-brave-helpers-'));
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+  auto.writeBraveResearchHelpers(tempDir);
+
+  for (const [name, mode] of [['web-search', 'search'], ['web-fetch', 'fetch']]) {
+    const filePath = path.join(tempDir, name);
+    const body = fs.readFileSync(filePath, 'utf8');
+    assert.equal(body.startsWith('#!/usr/bin/env bash\n'), true, name);
+    assert.match(body, new RegExp(`exec node "\\$\\(dirname "\\$0"\\)/ai-brave-search\\.cjs" ${mode} "\\$@"`));
+    assert.equal(fs.statSync(filePath).mode & 0o111, 0o111);
+  }
+  assert.throws(() => auto.writeBraveResearchHelpers(''), /research directory is required/);
+});
+
+test('ai-automation.yml stays valid YAML with no unindented block content', () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, '..', '.github', 'workflows', 'ai-automation.yml'),
+    'utf8',
+  );
+  const badLines = workflow.split('\n').flatMap((line, index) => {
+    if (!line || line.startsWith('#') || line.startsWith(' ') || line.startsWith('\t')) {
+      return [];
+    }
+    if (/^[A-Za-z0-9_.-]+:(?:\s|$)/.test(line)) return [];
+    return [`${index + 1}: ${line}`];
+  });
+  assert.deepEqual(badLines, []);
+  assert.doesNotMatch(workflow, /^EOS$/m);
+  assert.doesNotMatch(workflow, /<<'EOS'/);
+});
+
 test('workflow confines Brave research to isolated read-only research passes', () => {
   const workflow = fs.readFileSync(
     path.join(__dirname, '..', '.github', 'workflows', 'ai-automation.yml'),
@@ -3983,7 +4016,8 @@ test('workflow confines Brave research to isolated read-only research passes', (
     assert.match(run, /web-search/);
     assert.match(run, /web-fetch/);
     assert.match(run, /BRAVE_TOOL_LOG/);
-    assert.match(run, /cat > "\$research_dir\/web-search" <<'EOS'/);
+    assert.match(run, /writeBraveResearchHelpers/);
+    assert.doesNotMatch(run, /<<'EOS'/);
     assert.match(run, /--settings "\$HOME\/\.claude\/settings\.json"/);
     assert.match(run, /--disallowedTools "WebSearch" "WebFetch"/);
     assert.doesNotMatch(run, /printf '%s\n'/);


### PR DESCRIPTION
## Summary

GitHub never registered `.github/workflows/ai-automation.yml` after #3177, so new issues such as #3181 only passed `issue-format` and never got a classify comment.

The Brave `web-search` / `web-fetch` wrappers used an unindented `<<'EOS'` body. YAML treated those lines as top-level keys, GitHub recorded 0-second `push` failures with no jobs, and `issues: opened` did not run.

This writes the wrappers from `writeBraveResearchHelpers()` so the workflow file stays valid YAML, and adds a regression test for unindented block content.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [x] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #3181 (missed triage; format-ok issue still sitting on `bug` + `triage` with no bot comment)

## Changes Made

- Replace column-0 heredocs in classify and follow-up research steps
- Add `writeBraveResearchHelpers` so the generated scripts still start with a shebang
- Fail tests if `ai-automation.yml` contains unindented non-key lines or `<<'EOS'`

## Screenshots / Demo

N/A (CI workflow)

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — `node --test scripts/ai-automation.test.cjs scripts/github-workflow-ci.test.cjs` (208 pass)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Ruby `YAML.load_file(..., aliases: true)` now parses the workflow. After merge, dispatch `ai-automation.yml` with `issue_number=3181` to triage the missed issue.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)