### PR TITLE
[Bug] Copy AI helper into RUNNER_TEMP so triage can route

### DIFF
--- a/.github/workflows/ai-automation.yml
+++ b/.github/workflows/ai-automation.yml
@@ -125,6 +125,13 @@ jobs:
           git show "FETCH_HEAD:scripts/ai-automation.cjs" > scripts/ai-automation.cjs
           test -s scripts/ai-automation.cjs
 
+      - name: Freeze trusted helper
+        run: &freeze_ai_helper |
+          set -euo pipefail
+          test -f scripts/ai-automation.cjs
+          cp scripts/ai-automation.cjs "$RUNNER_TEMP/ai-automation.cjs"
+          chmod 0444 "$RUNNER_TEMP/ai-automation.cjs"
+
       - name: Decide route
         id: decide
         uses: actions/github-script@v9
@@ -379,6 +386,9 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
+      - name: Freeze trusted helper
+        run: *freeze_ai_helper
+
       - name: Apply ready-for-human handoff
         uses: actions/github-script@v9
         env:
@@ -414,6 +424,9 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
+
+      - name: Freeze trusted helper
+        run: *freeze_ai_helper
 
       - name: Clear stale workflow labels
         uses: actions/github-script@v9
@@ -500,6 +513,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.repository.default_branch }}
+
+      - name: Freeze trusted helper
+        run: *freeze_ai_helper
 
       - name: Remove stale ready-for-human labels
         uses: actions/github-script@v9
@@ -3737,6 +3753,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Freeze trusted helper
+        run: *freeze_ai_helper
+
       - name: Dispatch next queued issue batch
         if: >-
           needs.publish_implement.result == 'success' ||
@@ -5030,6 +5049,9 @@ jobs:
           git show "FETCH_HEAD:scripts/ai-automation.cjs" > scripts/ai-automation.cjs
           test -s scripts/ai-automation.cjs
 
+      - name: Freeze trusted helper
+        run: *freeze_ai_helper
+
       - name: Comment @codex review after human push
         uses: actions/github-script@v9
         with:
@@ -5178,6 +5200,9 @@ jobs:
           git show "FETCH_HEAD:scripts/ai-automation.cjs" > scripts/ai-automation.cjs
           test -s scripts/ai-automation.cjs
 
+      - name: Freeze trusted helper
+        run: *freeze_ai_helper
+
       - name: Comment @codex review after contributor push
         uses: actions/github-script@v9
         with:
@@ -5269,6 +5294,9 @@ jobs:
           mkdir -p scripts
           git show "FETCH_HEAD:scripts/ai-automation.cjs" > scripts/ai-automation.cjs
           test -s scripts/ai-automation.cjs
+
+      - name: Freeze trusted helper
+        run: *freeze_ai_helper
 
       - name: Poll open automation PRs
         uses: actions/github-script@v9

--- a/scripts/ai-automation.test.cjs
+++ b/scripts/ai-automation.test.cjs
@@ -3996,6 +3996,34 @@ test('ai-automation.yml stays valid YAML with no unindented block content', () =
   assert.doesNotMatch(workflow, /<<'EOS'/);
 });
 
+test('jobs copy ai-automation.cjs to RUNNER_TEMP before requiring it', () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, '..', '.github', 'workflows', 'ai-automation.yml'),
+    'utf8',
+  );
+  const jobsStart = workflow.indexOf('\njobs:\n');
+  assert.ok(jobsStart >= 0, 'jobs block missing');
+  const jobsSection = workflow.slice(jobsStart);
+  const jobs = [...jobsSection.matchAll(
+    /\n  ([a-zA-Z0-9_]+):\n([\s\S]*?)(?=\n  [a-zA-Z0-9_]+:|\n*$)/g,
+  )];
+  const requireHelper = /require\((?:`\$\{process\.env\.RUNNER_TEMP\}\/ai-automation\.cjs`|process\.env\.RUNNER_TEMP \+ ['"]\/ai-automation\.cjs['"])\)/;
+  const copyHelper = /cp (?:helpers\/)?scripts\/ai-automation\.cjs "\$RUNNER_TEMP\/ai-automation\.cjs"|git(?: -C helpers)? show "FETCH_HEAD:scripts\/ai-automation\.cjs" > "\$RUNNER_TEMP\/ai-automation\.cjs"|run: \*freeze_ai_helper/;
+  const missing = [];
+  for (const [, name, body] of jobs) {
+    if (!requireHelper.test(body)) continue;
+    if (!copyHelper.test(body)) missing.push(name);
+  }
+  assert.deepEqual(missing, []);
+  const route = jobs.find((match) => match[1] === 'route')?.[2] || '';
+  assert.match(route, /run: &freeze_ai_helper \|/);
+  assert.ok(
+    route.indexOf('cp scripts/ai-automation.cjs "$RUNNER_TEMP/ai-automation.cjs"') <
+      route.indexOf('name: Decide route'),
+    'route must freeze the helper before Decide route',
+  );
+});
+
 test('workflow confines Brave research to isolated read-only research passes', () => {
   const workflow = fs.readFileSync(
     path.join(__dirname, '..', '.github', 'workflows', 'ai-automation.yml'),


### PR DESCRIPTION
## Summary

#3182 made `ai-automation.yml` valid YAML, so GitHub registered the workflow again. Dispatching #3181 then failed in **Route event** with:

```
Cannot find module '/home/runner/work/_temp/ai-automation.cjs'
```

Route checks the helper out to the workspace, then `github-script` requires it from `$RUNNER_TEMP`. Classify/implement already freeze a copy; route and several other jobs did not.

## Type of Change

- [x] Bug fix
- [x] Build / CI change

## Related Issue (optional)

Related to #3181 (still untriaged)

## Changes Made

- Freeze `scripts/ai-automation.cjs` into `$RUNNER_TEMP` before Decide route
- Same freeze for handoff, source cleanup, reconcile, backlog drain, Codex re-request, and poll jobs
- Regression test: every job that `require`s the helper from `RUNNER_TEMP` must copy it first

## Testing

- [x] Tests pass (`node --test scripts/ai-automation.test.cjs`)
- Ruby YAML load with aliases succeeds

After merge, re-dispatch `ai-automation.yml` with `issue_number=3181`.

## Checklist

- [x] My code follows the existing project style
- [x] I have not introduced any breaking changes (or I have described them above)