### PR TITLE
[Bug] Let Claude Code classify issues by dropping unsupported JSON Schema draft

### DIFF
--- a/.github/ai/schemas/classification.schema.json
+++ b/.github/ai/schemas/classification.schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/.github/workflows/ai-automation.yml
+++ b/.github/workflows/ai-automation.yml
@@ -974,12 +974,19 @@ jobs:
           Write the JSON result to .ai-runtime/classification.json as well as printing it.
           "
           # The preceding trusted step stages the key. This shell never receives it.
+          CLASSIFY_SCHEMA="$(node -e '
+            const fs = require("node:fs");
+            const auto = require(process.env.RUNNER_TEMP + "/ai-automation.cjs");
+            process.stdout.write(JSON.stringify(auto.toClaudeJsonSchema(
+              JSON.parse(fs.readFileSync(process.argv[1], "utf8")),
+            )));
+          ' "$RUNNER_TEMP/classification.schema.json")"
           "$RUNNER_TEMP/ai-claude-authenticated" \
             --bare -p --permission-mode dontAsk \
             --settings "$HOME/.claude/settings.json" \
             --allowedTools "Read" "Grep" "Glob" "Bash(rg *)" "Bash(grep *)" "Bash(find *)" \
             --disallowedTools "WebSearch" "WebFetch" "Edit" "Write" "NotebookEdit" \
-            --output-format json --json-schema "$(cat "$RUNNER_TEMP/classification.schema.json")" --model "$AI_MODEL" \
+            --output-format json --json-schema "$CLASSIFY_SCHEMA" --model "$AI_MODEL" \
             "$PROMPT" > .ai-runtime/classify-raw.txt
           cat .ai-runtime/classify-raw.txt
 

--- a/scripts/ai-automation.cjs
+++ b/scripts/ai-automation.cjs
@@ -2097,6 +2097,22 @@ function extractJsonObject(text) {
   throw new Error('Could not parse JSON from agent output.');
 }
 
+/**
+ * Claude Code `--json-schema` uses Ajv without draft/2020-12 loaded.
+ * A `$schema` URI for that draft fails before the model runs:
+ * `no schema with key or ref "https://json-schema.org/draft/2020-12/schema"`.
+ */
+function toClaudeJsonSchema(schema) {
+  const value = typeof schema === 'string' ? JSON.parse(schema) : schema;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Claude JSON Schema must be an object.');
+  }
+  const next = { ...value };
+  delete next.$schema;
+  delete next.$id;
+  return next;
+}
+
 function unwrapAgentJson(value) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
   if (value.structured_output && typeof value.structured_output === 'object') {
@@ -4227,6 +4243,7 @@ module.exports = {
   prepareIssueFollowupContext,
   prepareAiCliSettings,
   unwrapAgentJson,
+  toClaudeJsonSchema,
   isAutomationTriageMarker,
   writeBraveResearchHelpers,
   writeJson,

--- a/scripts/ai-automation.test.cjs
+++ b/scripts/ai-automation.test.cjs
@@ -3893,6 +3893,45 @@ test('parseClassificationText unwraps Claude Code print JSON', () => {
   assert.equal(parsed.code_paths[0], 'components/App.tsx');
 });
 
+test('toClaudeJsonSchema strips draft URIs Claude Code Ajv cannot load', () => {
+  const schemaPath = path.join(
+    __dirname,
+    '..',
+    '.github',
+    'ai',
+    'schemas',
+    'classification.schema.json',
+  );
+  const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+  assert.equal(schema.$schema, undefined);
+  assert.equal(schema.type, 'object');
+  assert.ok(schema.required.includes('category'));
+
+  const stripped = auto.toClaudeJsonSchema({
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    $id: 'https://example.invalid/classification.json',
+    type: 'object',
+    required: ['category'],
+  });
+  assert.equal('$schema' in stripped, false);
+  assert.equal('$id' in stripped, false);
+  assert.equal(stripped.type, 'object');
+  assert.throws(() => auto.toClaudeJsonSchema([]), /must be an object/);
+});
+
+test('classify step passes a sanitized JSON Schema to Claude Code', () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, '..', '.github', 'workflows', 'ai-automation.yml'),
+    'utf8',
+  );
+  const classify = workflow.match(
+    /- name: Classify with Claude Code\n[\s\S]*?(?=\n      - name:)/,
+  )?.[0] || '';
+  assert.match(classify, /toClaudeJsonSchema/);
+  assert.match(classify, /--json-schema "\$CLASSIFY_SCHEMA"/);
+  assert.doesNotMatch(classify, /--json-schema "\$\(cat /);
+});
+
 test('parseExternalResearchStream accepts Brave helper tool logs', (t) => {
   const logPath = path.join(os.tmpdir(), `brave-tool-${process.pid}.jsonl`);
   fs.writeFileSync(logPath, `${JSON.stringify({


### PR DESCRIPTION
## Summary

Every new issue since the Claude Code switch (#3181, #3184–#3188) got the same bot handoff and never a real triage reply.

Classify died immediately with:

\`\`\`
Error: --json-schema is not a valid JSON Schema: no schema with key or ref \"https://json-schema.org/draft/2020-12/schema\"
\`\`\`

Research still ran. The model never inspected code or wrote a diagnosis because Claude Code's Ajv does not load draft/2020-12.

Local repro: \`claude --json-schema \"\$(cat .github/ai/schemas/classification.schema.json)\"\` printed that error. After stripping \`\$schema\`, the same command returned structured classification JSON.

## Type of Change

- [x] Bug fix
- [x] Build / CI change

## Related Issue (optional)

Related to #3181, #3184, #3185, #3186, #3187, #3188

## Changes Made

- Remove \`\$schema\` from \`classification.schema.json\`
- Sanitize the schema with \`toClaudeJsonSchema()\` before \`--json-schema\`
- Regression tests for the strip and the classify step

## Testing

- [x] \`node --test scripts/ai-automation.test.cjs\` (191 pass)
- [x] Local Claude CLI accepts the sanitized schema

After merge, re-dispatch those issues.

## Checklist

- [x] My code follows the existing project style
- [x] I have not introduced any breaking changes