### PR TITLE
fix(sync): stop SSH connects from dirtying WebDAV auto-sync

### DIFF
--- a/application/app/AppSideEffects.tsx
+++ b/application/app/AppSideEffects.tsx
@@ -503,12 +503,13 @@ export function AppSideEffects() {
             importVaultData: importDataFromString,
             importPortForwardingRules,
             onSettingsApplied: settings.rehydrateAllFromStorage,
-          }),
+          }, { currentHosts: hosts }),
         translateProtectiveBackupFailure: (message) =>
           t('cloudSync.localBackups.protectiveBackupFailed', { message }),
       }),
     [
       buildCurrentSyncPayload,
+      hosts,
       importDataFromString,
       importPortForwardingRules,
       settings.rehydrateAllFromStorage,
@@ -526,7 +527,7 @@ export function AppSideEffects() {
             importVaultData: importDataFromString,
             importPortForwardingRules,
             onSettingsApplied: settings.rehydrateAllFromStorage,
-          });
+          }, { currentHosts: hosts });
           await commitReplica();
         },
         translateProtectiveBackupFailure: (message) =>
@@ -534,6 +535,7 @@ export function AppSideEffects() {
       }),
     [
       buildCurrentSyncPayload,
+      hosts,
       importDataFromString,
       importPortForwardingRules,
       settings.rehydrateAllFromStorage,

--- a/application/state/useAutoSync.ts
+++ b/application/state/useAutoSync.ts
@@ -30,6 +30,7 @@ import {
   getEffectivePortForwardingRulesForSync,
   hasCloudSyncEntityData,
   hasMeaningfulCloudSyncData,
+  sanitizeHostsForSync,
   sanitizePortForwardingRulesForSync,
   shouldPromptCloudVaultRecovery,
 } from '../syncPayload';
@@ -145,7 +146,7 @@ const isRestoreInProgress = (): boolean => {
 
 const getSyncPayloadDataHash = (payload: SyncPayload): string => {
   return JSON.stringify({
-    hosts: payload.hosts,
+    hosts: sanitizeHostsForSync(payload.hosts),
     keys: payload.keys,
     identities: payload.identities,
     proxyProfiles: payload.proxyProfiles,
@@ -264,7 +265,7 @@ export const useAutoSync = (config: AutoSyncConfig) => {
 
   const getSyncSnapshot = useCallback(() => {
     return {
-      hosts: config.hosts,
+      hosts: sanitizeHostsForSync(config.hosts),
       keys: config.keys,
       identities: config.identities,
       proxyProfiles: config.proxyProfiles,

--- a/application/state/useVaultState.snippetsDelete.test.ts
+++ b/application/state/useVaultState.snippetsDelete.test.ts
@@ -253,3 +253,22 @@ test("startup snippet order backfill uses the locked vault writer", () => {
     /const orderedSnippets = normalizeVaultOrder\(savedSnippets\);\s*setSnippets\(orderedSnippets\);\s*localStorageAdapter\.write\(STORAGE_KEY_SNIPPETS, orderedSnippets\);/,
   );
 });
+
+test("importData preserves device-local lastConnectedAt when a cloud payload omits it", () => {
+  // Cloud payloads no longer carry lastConnectedAt (#2629), but any remote
+  // reconciliation replaces the whole local host array. Import must re-attach
+  // each matching local host's device-local timestamp instead of dropping it.
+  assert.match(
+    source,
+    /const localHostsById = new Map\(hostsRef\.current\.map\(\(host\) => \[host\.id, host\]\)\)/,
+  );
+  assert.match(
+    source,
+    /importData[\s\S]*localHostsById\.get\(host\.id\)[\s\S]*lastConnectedAt: local\.lastConnectedAt/,
+  );
+  // Incoming timestamps (local backups, legacy cloud snapshots) still win.
+  assert.match(
+    source,
+    /if \(host\.lastConnectedAt != null\) return host;/,
+  );
+});

--- a/application/state/useVaultState.snippetsDelete.test.ts
+++ b/application/state/useVaultState.snippetsDelete.test.ts
@@ -260,15 +260,6 @@ test("importData preserves device-local lastConnectedAt when a cloud payload omi
   // each matching local host's device-local timestamp instead of dropping it.
   assert.match(
     source,
-    /const localHostsById = new Map\(hostsRef\.current\.map\(\(host\) => \[host\.id, host\]\)\)/,
-  );
-  assert.match(
-    source,
-    /importData[\s\S]*localHostsById\.get\(host\.id\)[\s\S]*lastConnectedAt: local\.lastConnectedAt/,
-  );
-  // Incoming timestamps (local backups, legacy cloud snapshots) still win.
-  assert.match(
-    source,
-    /if \(host\.lastConnectedAt != null\) return host;/,
+    /retainLocalHostLastConnectedAt\(payload\.hosts,\s*hostsRef\.current\)/,
   );
 });

--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -6,6 +6,7 @@ import {
   sanitizeHost,
 } from "../../domain/host";
 import { isEncryptedCredentialPlaceholder } from "../../domain/credentials";
+import { retainLocalHostLastConnectedAt } from "../../domain/sync";
 import { sanitizeGroupConfig } from "../../domain/groupConfig";
 import { normalizeKnownHosts } from "../../domain/knownHosts";
 import { normalizeNoteGroups, normalizeVaultNotes } from "../../domain/notes";
@@ -1927,14 +1928,11 @@ export const useVaultState = () => {
         // remote snippet/settings change cannot clear this device's recent-
         // hosts list. Timestamps present on the incoming hosts (local backups,
         // legacy cloud snapshots) still win as before.
-        const localHostsById = new Map(hostsRef.current.map((host) => [host.id, host]));
-        const hostsWithLocalTelemetry = payload.hosts.map((host) => {
-          if (host.lastConnectedAt != null) return host;
-          const local = localHostsById.get(host.id);
-          if (local?.lastConnectedAt == null) return host;
-          return { ...host, lastConnectedAt: local.lastConnectedAt };
-        });
-        encryptedWrites.push(updateHosts(hostsWithLocalTelemetry).then(() => undefined));
+        encryptedWrites.push(
+          updateHosts(
+            retainLocalHostLastConnectedAt(payload.hosts, hostsRef.current) ?? payload.hosts,
+          ).then(() => undefined),
+        );
       }
       if (payload.keys) encryptedWrites.push(updateKeys(payload.keys));
       if (payload.identities) encryptedWrites.push(updateIdentities(payload.identities));

--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -1920,7 +1920,22 @@ export const useVaultState = () => {
   const importData = useCallback(
     (payload: Partial<ExportableVaultData>): Promise<void> => {
       const encryptedWrites: Promise<void>[] = [];
-      if (payload.hosts) encryptedWrites.push(updateHosts(payload.hosts).then(() => undefined));
+      if (payload.hosts) {
+        // Cloud payloads no longer carry `lastConnectedAt` (#2629), but any
+        // remote reconciliation replaces the whole local host array. Re-attach
+        // each matching local host's device-local timestamp so applying a
+        // remote snippet/settings change cannot clear this device's recent-
+        // hosts list. Timestamps present on the incoming hosts (local backups,
+        // legacy cloud snapshots) still win as before.
+        const localHostsById = new Map(hostsRef.current.map((host) => [host.id, host]));
+        const hostsWithLocalTelemetry = payload.hosts.map((host) => {
+          if (host.lastConnectedAt != null) return host;
+          const local = localHostsById.get(host.id);
+          if (local?.lastConnectedAt == null) return host;
+          return { ...host, lastConnectedAt: local.lastConnectedAt };
+        });
+        encryptedWrites.push(updateHosts(hostsWithLocalTelemetry).then(() => undefined));
+      }
       if (payload.keys) encryptedWrites.push(updateKeys(payload.keys));
       if (payload.identities) encryptedWrites.push(updateIdentities(payload.identities));
       if (Array.isArray(payload.proxyProfiles)) encryptedWrites.push(updateProxyProfiles(payload.proxyProfiles));

--- a/application/syncPayload.test.ts
+++ b/application/syncPayload.test.ts
@@ -46,6 +46,7 @@ const {
   withPluginSyncSidecars,
   buildSyncPayload,
   sanitizeHostsForSync,
+  retainLocalHostLastConnectedAt,
   hasCloudSyncEntityData,
   hasMeaningfulCloudSyncData,
   hasMeaningfulSyncData,
@@ -169,6 +170,59 @@ test("buildLocalVaultPayload keeps lastConnectedAt for local backups", () => {
   const payload = buildLocalVaultPayload({ ...vault([]), hosts: [host] });
 
   assert.equal(payload.hosts[0]?.lastConnectedAt, 99);
+});
+
+test("applySyncPayload keeps local lastConnectedAt when the cloud host omits it", async () => {
+  const localHost = {
+    id: "host-apply",
+    label: "prod",
+    hostname: "prod.example.com",
+    username: "root",
+    tags: [],
+    os: "linux" as const,
+    protocol: "ssh" as const,
+    lastConnectedAt: 77,
+  };
+  const remoteHost = {
+    ...localHost,
+    label: "prod-renamed",
+    lastConnectedAt: undefined,
+  };
+
+  const payload = buildSyncPayload({ ...vault([]), hosts: [remoteHost] });
+  let imported: { hosts?: Array<{ lastConnectedAt?: number; label?: string }> } | null = null;
+  await applySyncPayload(
+    payload,
+    { importVaultData: (json) => { imported = JSON.parse(json); } },
+    { currentHosts: [localHost] },
+  );
+
+  assert.equal(imported?.hosts?.[0]?.lastConnectedAt, 77);
+  assert.equal(imported?.hosts?.[0]?.label, "prod-renamed");
+});
+
+test("retainLocalHostLastConnectedAt does not invent timestamps for unknown hosts", () => {
+  const incoming = [{
+    id: "new-host",
+    label: "new",
+    hostname: "new.example.com",
+    username: "root",
+    tags: [],
+    os: "linux" as const,
+    protocol: "ssh" as const,
+  }];
+  const retained = retainLocalHostLastConnectedAt(incoming, [{
+    id: "other",
+    label: "other",
+    hostname: "other.example.com",
+    username: "root",
+    tags: [],
+    os: "linux" as const,
+    protocol: "ssh" as const,
+    lastConnectedAt: 5,
+  }]);
+
+  assert.equal(retained?.[0]?.lastConnectedAt, undefined);
 });
 
 test("buildSyncPayload includes reusable proxy profiles", () => {

--- a/application/syncPayload.test.ts
+++ b/application/syncPayload.test.ts
@@ -45,6 +45,7 @@ const {
   buildCloudSyncPayload,
   withPluginSyncSidecars,
   buildSyncPayload,
+  sanitizeHostsForSync,
   hasCloudSyncEntityData,
   hasMeaningfulCloudSyncData,
   hasMeaningfulSyncData,
@@ -93,6 +94,83 @@ test("buildSyncPayload treats known hosts as local-only data", () => {
   assert.equal("knownHosts" in payload, false);
 });
 
+test("buildSyncPayload strips lastConnectedAt so connecting a host does not dirty cloud sync", () => {
+  const host = {
+    id: "host-1",
+    label: "prod",
+    hostname: "prod.example.com",
+    username: "root",
+    tags: [],
+    os: "linux" as const,
+    protocol: "ssh" as const,
+    lastConnectedAt: 1_700_000_000_000,
+    pinned: true,
+  };
+
+  const payload = buildSyncPayload({ ...vault([]), hosts: [host] });
+
+  assert.equal(payload.hosts[0]?.lastConnectedAt, undefined);
+  assert.equal(payload.hosts[0]?.pinned, true);
+  assert.equal(payload.hosts[0]?.hostname, "prod.example.com");
+});
+
+test("buildCloudSyncPayload strips lastConnectedAt like port-forward lastUsedAt", async () => {
+  const host = {
+    id: "host-2",
+    label: "db",
+    hostname: "db.example.com",
+    username: "ubuntu",
+    tags: [],
+    os: "linux" as const,
+    protocol: "ssh" as const,
+    lastConnectedAt: 42,
+  };
+
+  const payload = await buildCloudSyncPayload({ ...vault([]), hosts: [host] });
+  const serializedHosts = JSON.parse(JSON.stringify(payload.hosts ?? []));
+
+  assert.equal(payload.hosts[0]?.lastConnectedAt, undefined);
+  assert.equal("lastConnectedAt" in (serializedHosts[0] ?? {}), false);
+});
+
+test("sanitizeHostsForSync hashes equal when hosts differ only by lastConnectedAt", () => {
+  const base = {
+    id: "host-hash",
+    label: "edge",
+    hostname: "edge.example.com",
+    username: "ops",
+    tags: [],
+    os: "linux" as const,
+    protocol: "ssh" as const,
+    pinned: true,
+  };
+
+  const sanitizedA = sanitizeHostsForSync([{ ...base, lastConnectedAt: 11 }]);
+  const sanitizedB = sanitizeHostsForSync([{ ...base, lastConnectedAt: 99 }]);
+  const payloadA = buildSyncPayload({ ...vault([]), hosts: [{ ...base, lastConnectedAt: 11 }] });
+  const payloadB = buildSyncPayload({ ...vault([]), hosts: [{ ...base, lastConnectedAt: 99 }] });
+
+  assert.equal(JSON.stringify(sanitizedA), JSON.stringify(sanitizedB));
+  assert.equal(JSON.stringify(payloadA.hosts), JSON.stringify(payloadB.hosts));
+});
+
+test("buildLocalVaultPayload keeps lastConnectedAt for local backups", () => {
+  const host = {
+    id: "host-3",
+    label: "lab",
+    hostname: "lab.example.com",
+    username: "lab",
+    tags: [],
+    os: "linux" as const,
+    protocol: "ssh" as const,
+    lastConnectedAt: 99,
+  };
+
+  const payload = buildLocalVaultPayload({ ...vault([]), hosts: [host] });
+
+  assert.equal(payload.hosts[0]?.lastConnectedAt, 99);
+});
+
 test("buildSyncPayload includes reusable proxy profiles", () => {
   const proxyProfiles = [
     {
@@ -130,7 +208,7 @@ test("sync payloads preserve opaque plugin hosts without requiring the plugin to
     },
   };
   const payload = buildSyncPayload({ ...vault([]), hosts: [pluginHost] });
-  assert.deepEqual(payload.hosts, [pluginHost]);
+  assert.deepEqual(JSON.parse(JSON.stringify(payload.hosts)), [pluginHost]);
 
   let imported: Record<string, unknown> | null = null;
   await applySyncPayload(payload, {

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -212,6 +212,16 @@ export function sanitizePortForwardingRulesForSync(
   }));
 }
 
+/**
+ * Strip device-local connection telemetry from hosts before cloud sync.
+ * `lastConnectedAt` updates on every successful SSH connect (#2629) and must
+ * not dirty auto-sync hashes or inflate cloud versions.
+ */
+export function sanitizeHostsForSync(hosts: Host[] | undefined): Host[] | undefined {
+  if (!hosts) return hosts;
+  return hosts.map((host) => ({ ...host, lastConnectedAt: undefined }));
+}
+
 export function getEffectivePortForwardingRulesForSync(
   rules: PortForwardingRule[] | undefined,
 ): PortForwardingRule[] | undefined {
@@ -951,7 +961,7 @@ export function buildSyncPayload(
   portForwardingRules?: PortForwardingRule[],
 ): SyncPayload {
   return {
-    hosts: vault.hosts,
+    hosts: sanitizeHostsForSync(vault.hosts),
     keys: vault.keys,
     identities: vault.identities,
     proxyProfiles: vault.proxyProfiles,
@@ -1036,7 +1046,7 @@ export async function buildCloudSyncPayload(
   },
 ): Promise<SyncPayload> {
   const base: SyncPayload = {
-    hosts: vault.hosts,
+    hosts: sanitizeHostsForSync(vault.hosts),
     keys: vault.keys,
     identities: vault.identities,
     proxyProfiles: vault.proxyProfiles,
@@ -1062,6 +1072,8 @@ export function buildLocalVaultPayload(
 ): SyncPayload {
   const base: SyncPayload = {
     ...buildSyncPayload(vault, portForwardingRules),
+    // Keep device-local recent-connection timestamps in protective backups.
+    hosts: vault.hosts,
     settings: collectLocalBackupSettings(),
     knownHosts: vault.knownHosts,
   };

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -24,6 +24,7 @@ import {
   SYNC_PAYLOAD_ENTITY_KEYS,
   SYNC_STORAGE_KEYS,
   hasSyncPayloadEntityData,
+  sanitizeHostsForSync,
   type SyncPayload,
 } from '../domain/sync';
 import { migrateHostsFromLegacyLineTimestamps } from '../domain/host';
@@ -212,15 +213,7 @@ export function sanitizePortForwardingRulesForSync(
   }));
 }
 
-/**
- * Strip device-local connection telemetry from hosts before cloud sync.
- * `lastConnectedAt` updates on every successful SSH connect (#2629) and must
- * not dirty auto-sync hashes or inflate cloud versions.
- */
-export function sanitizeHostsForSync(hosts: Host[] | undefined): Host[] | undefined {
-  if (!hosts) return hosts;
-  return hosts.map((host) => ({ ...host, lastConnectedAt: undefined }));
-}
+export { sanitizeHostsForSync };
 
 export function getEffectivePortForwardingRulesForSync(
   rules: PortForwardingRule[] | undefined,

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -24,6 +24,7 @@ import {
   SYNC_PAYLOAD_ENTITY_KEYS,
   SYNC_STORAGE_KEYS,
   hasSyncPayloadEntityData,
+  retainLocalHostLastConnectedAt,
   sanitizeHostsForSync,
   type SyncPayload,
 } from '../domain/sync';
@@ -213,7 +214,7 @@ export function sanitizePortForwardingRulesForSync(
   }));
 }
 
-export { sanitizeHostsForSync };
+export { retainLocalHostLastConnectedAt, sanitizeHostsForSync };
 
 export function getEffectivePortForwardingRulesForSync(
   rules: PortForwardingRule[] | undefined,
@@ -1133,6 +1134,7 @@ function applyPayload(
   options: {
     includeLocalOnlyData: boolean;
     applyPluginSidecars?: PluginSyncSidecarApplier;
+    currentHosts?: Host[];
   },
 ): Promise<void> {
   // Portable payloads must never keep device-bound enc:v1 blobs. Strip them
@@ -1140,10 +1142,14 @@ function applyPayload(
   // shells and let the user re-enter secrets (#2702).
   const sanitizedPayload = stripSyncPayloadEncryptedCredentials(payload);
   const legacyLineTimestampsEnabled = sanitizedPayload.settings?.terminalSettings?.showLineTimestamps === true;
+  let hosts = migrateHostsFromLegacyLineTimestamps(sanitizedPayload.hosts, legacyLineTimestampsEnabled);
+  if (!options.includeLocalOnlyData) {
+    hosts = retainLocalHostLastConnectedAt(hosts, options.currentHosts) ?? hosts;
+  }
   // Build the vault import object. Cloud sync intentionally ignores
   // local-only trust records even if legacy cloud snapshots still carry them.
   const vaultImport: Record<string, unknown> = {
-    hosts: migrateHostsFromLegacyLineTimestamps(sanitizedPayload.hosts, legacyLineTimestampsEnabled),
+    hosts,
     keys: sanitizedPayload.keys,
     identities: sanitizedPayload.identities,
     proxyProfiles: sanitizedPayload.proxyProfiles,
@@ -1197,11 +1203,13 @@ export function applySyncPayload(
   importers: SyncPayloadImporters,
   options?: {
     applyPluginSidecars?: PluginSyncSidecarApplier;
+    currentHosts?: Host[];
   },
 ): Promise<void> {
   return applyPayload(payload, importers, {
     includeLocalOnlyData: false,
     applyPluginSidecars: options?.applyPluginSidecars,
+    currentHosts: options?.currentHosts,
   });
 }
 

--- a/components/settings/tabs/SettingsSyncTab.tsx
+++ b/components/settings/tabs/SettingsSyncTab.tsx
@@ -55,8 +55,8 @@ export default function SettingsSyncTab(props: {
         importVaultData: importDataFromString,
         importPortForwardingRules,
         onSettingsApplied,
-      }),
-    [importDataFromString, importPortForwardingRules, onSettingsApplied],
+      }, { currentHosts: vault.hosts }),
+    [importDataFromString, importPortForwardingRules, onSettingsApplied, vault.hosts],
   );
 
   const onApplyPayload = useCallback(

--- a/domain/convergentSync/legacy.ts
+++ b/domain/convergentSync/legacy.ts
@@ -1,4 +1,4 @@
-import type { SyncPayload } from '../sync';
+import { withHostsSanitizedForSync, type SyncPayload } from '../sync';
 import { normalizeJsonValue } from './json';
 import { encodeSettingPath } from './serialization';
 import { applyConvergentMutations } from './state';
@@ -119,16 +119,19 @@ function flattenSettings(
 
 /** Compare only cloud materialized data; timestamps and reliability metadata are transport details. */
 export function cloudSyncPayloadsEqual(left: SyncPayload, right: SyncPayload): boolean {
-  const project = (payload: SyncPayload) => ({
-    ...Object.fromEntries(
-      [...CONVERGENT_ENTITY_COLLECTIONS, ...CONVERGENT_STRING_COLLECTIONS]
-        .map((key) => [key, (payload as unknown as Record<string, unknown>)[key] ?? []]),
-    ),
-    settings: payload.settings ?? {},
-    // Plugin sidecars are host-owned opaque data on the encrypted blob and
-    // must participate in migration freshness / equality checks.
-    pluginSidecars: payload.pluginSidecars ?? { version: 1, entries: [] },
-  });
+  const project = (payload: SyncPayload) => {
+    const sanitized = withHostsSanitizedForSync(payload);
+    return {
+      ...Object.fromEntries(
+        [...CONVERGENT_ENTITY_COLLECTIONS, ...CONVERGENT_STRING_COLLECTIONS]
+          .map((key) => [key, (sanitized as unknown as Record<string, unknown>)[key] ?? []]),
+      ),
+      settings: sanitized.settings ?? {},
+      // Plugin sidecars are host-owned opaque data on the encrypted blob and
+      // must participate in migration freshness / equality checks.
+      pluginSidecars: sanitized.pluginSidecars ?? { version: 1, entries: [] },
+    };
+  };
   return fingerprint(project(left)) === fingerprint(project(right));
 }
 
@@ -143,10 +146,12 @@ export function diffLegacySyncPayload(
   legacy: SyncPayload,
 ): ConvergentMutation[] {
   const mutations: ConvergentMutation[] = [];
+  const sanitizedBaseline = withHostsSanitizedForSync(baseline);
+  const sanitizedLegacy = withHostsSanitizedForSync(legacy);
   for (const collection of CONVERGENT_ENTITY_COLLECTIONS) {
     if (!hasDefinedOwnProperty(legacy, collection)) continue;
-    const before = entityMap(baseline, collection);
-    const after = entityMap(legacy, collection);
+    const before = entityMap(sanitizedBaseline, collection);
+    const after = entityMap(sanitizedLegacy, collection);
     const beforePositions = positionMap(before.keys());
     const afterPositions = positionMap(after.keys());
     const ids = new Set([...before.keys(), ...after.keys()]);

--- a/domain/convergentSync/payload.ts
+++ b/domain/convergentSync/payload.ts
@@ -1,8 +1,9 @@
-import type {
-  CloudSyncPayloadEntityKey,
-  SyncFileMeta,
-  SyncPayload,
-  SyncReliabilityMeta,
+import {
+  withHostsSanitizedForSync,
+  type CloudSyncPayloadEntityKey,
+  type SyncFileMeta,
+  type SyncPayload,
+  type SyncReliabilityMeta,
 } from '../sync';
 import { dotKey } from './clock';
 import {
@@ -135,9 +136,10 @@ function appendSettingMutations(
 }
 
 export function syncPayloadToConvergentMutations(payload: SyncPayload): ConvergentMutation[] {
+  const sanitized = withHostsSanitizedForSync(payload);
   const mutations: ConvergentMutation[] = [];
   for (const collection of CONVERGENT_ENTITY_COLLECTIONS) {
-    payloadEntityValues(payload, collection).forEach((value, position) => {
+    payloadEntityValues(sanitized, collection).forEach((value, position) => {
       const id = entityId(collection, value);
       mutations.push({
         kind: 'entity-upsert',
@@ -149,11 +151,11 @@ export function syncPayloadToConvergentMutations(payload: SyncPayload): Converge
     });
   }
   for (const collection of CONVERGENT_STRING_COLLECTIONS) {
-    payloadStringValues(payload, collection).forEach((value, position) => {
+    payloadStringValues(sanitized, collection).forEach((value, position) => {
       mutations.push({ kind: 'string-entry-add', collection, value, position });
     });
   }
-  appendSettingMutations(payload.settings, [], mutations);
+  appendSettingMutations(sanitized.settings, [], mutations);
   return mutations;
 }
 

--- a/domain/convergentSync/payloadMigration.test.ts
+++ b/domain/convergentSync/payloadMigration.test.ts
@@ -256,6 +256,38 @@ test('legacy writers cannot silently overwrite convergent or future cloud schema
   );
 });
 
+test('cloudSyncPayloadsEqual ignores lastConnectedAt telemetry', () => {
+  const left = payload();
+  const right = {
+    ...payload(),
+    hosts: [{ ...payload().hosts[0], lastConnectedAt: NOW }],
+  };
+
+  assert.equal(cloudSyncPayloadsEqual(left, right), true);
+});
+
+test('createConvergentSyncStateFromPayload does not persist lastConnectedAt', () => {
+  const withTelemetry = {
+    ...payload(),
+    hosts: [{ ...payload().hosts[0], lastConnectedAt: NOW }],
+  };
+  const state = createConvergentSyncStateFromPayload(withTelemetry, 'device-a', NOW);
+  const materialized = materializeSyncPayloadFromConvergentState(state, { syncedAt: NOW });
+
+  assert.equal(materialized.hosts[0].lastConnectedAt, undefined);
+  assert.equal('lastConnectedAt' in materialized.hosts[0], false);
+});
+
+test('diffLegacySyncPayload ignores lastConnectedAt-only host changes', () => {
+  const baseline = payload();
+  const legacy = {
+    ...payload(),
+    hosts: [{ ...payload().hosts[0], lastConnectedAt: NOW + 1 }],
+  };
+
+  assert.deepEqual(diffLegacySyncPayload(baseline, legacy), []);
+});
+
 test('trusted legacy diff becomes causal CRDT writes without carrying transport metadata', () => {
   const baseline = payload('Before');
   const state = createConvergentSyncStateFromPayload(baseline, 'seed', NOW);

--- a/domain/sync.ts
+++ b/domain/sync.ts
@@ -388,6 +388,20 @@ export interface SyncPayload {
   convergentSync?: ConvergentSyncEnvelopeV2;
 }
 
+/**
+ * Strip device-local connection telemetry from hosts before any sync
+ * comparison or upload (#2629). `lastConnectedAt` updates on every successful
+ * SSH connect and must not dirty auto-sync hashes, three-way merges, or
+ * inflate cloud versions. Legacy stored bases / remote payloads still carry
+ * the field, so all three merge sides are normalized with this helper.
+ */
+export function sanitizeHostsForSync(
+  hosts: import('./models').Host[] | undefined,
+): import('./models').Host[] | undefined {
+  if (!hosts) return hosts;
+  return hosts.map((host) => ({ ...host, lastConnectedAt: undefined }));
+}
+
 export const SYNC_PAYLOAD_ENTITY_KEYS = [
   'hosts',
   'keys',

--- a/domain/sync.ts
+++ b/domain/sync.ts
@@ -402,6 +402,26 @@ export function sanitizeHostsForSync(
   return hosts.map((host) => ({ ...host, lastConnectedAt: undefined }));
 }
 
+/**
+ * Re-attach this device's Recently Connected timestamps when a cloud payload
+ * omits `lastConnectedAt`. Incoming timestamps (local backups, legacy cloud
+ * snapshots) still win when present.
+ */
+export function retainLocalHostLastConnectedAt(
+  incoming: import('./models').Host[] | undefined,
+  local: import('./models').Host[] | undefined,
+): import('./models').Host[] | undefined {
+  if (!incoming) return incoming;
+  if (!local?.length) return incoming;
+  const localById = new Map(local.map((host) => [host.id, host.lastConnectedAt]));
+  return incoming.map((host) => {
+    if (host.lastConnectedAt != null) return host;
+    const localTs = localById.get(host.id);
+    if (localTs == null) return host;
+    return { ...host, lastConnectedAt: localTs };
+  });
+}
+
 export const SYNC_PAYLOAD_ENTITY_KEYS = [
   'hosts',
   'keys',

--- a/domain/sync.ts
+++ b/domain/sync.ts
@@ -402,6 +402,14 @@ export function sanitizeHostsForSync(
   return hosts.map((host) => ({ ...host, lastConnectedAt: undefined }));
 }
 
+/** Copy a payload with device-local host telemetry stripped for compare/convert. */
+export function withHostsSanitizedForSync(payload: SyncPayload): SyncPayload {
+  return {
+    ...payload,
+    hosts: sanitizeHostsForSync(payload.hosts) ?? payload.hosts,
+  };
+}
+
 /**
  * Re-attach this device's Recently Connected timestamps when a cloud payload
  * omits `lastConnectedAt`. Incoming timestamps (local backups, legacy cloud

--- a/domain/syncMerge.test.ts
+++ b/domain/syncMerge.test.ts
@@ -572,3 +572,51 @@ test("mergeSyncPayloads treats missing optional arrays as legacy payloads, not d
   assert.deepEqual(result.payload.portForwardingRules, [rule]);
   assert.deepEqual(result.payload.groupConfigs, [{ path: "prod", username: "root" }]);
 });
+
+const hostWithTelemetry = (lastConnectedAt?: number) => ({
+  id: "host-1",
+  label: "prod",
+  hostname: "prod.example.com",
+  username: "root",
+  tags: [],
+  os: "linux" as const,
+  protocol: "ssh" as const,
+  ...(lastConnectedAt === undefined ? {} : { lastConnectedAt }),
+});
+
+test("mergeSyncPayloads normalizes lastConnectedAt across base and remote so sanitized local does not shadow remote edits", () => {
+  // Legacy base + old-device remote still carry the legacy telemetry field;
+  // the upgraded local payload strips it. A remote edit to the same host
+  // must not be classified as a local-modified conflict and overwritten.
+  const base = payload({
+    hosts: [hostWithTelemetry(1_000)],
+  });
+  // Local is otherwise unchanged — it only lost the telemetry field to the
+  // new sanitize-on-build behavior.
+  const local = payload({
+    hosts: [hostWithTelemetry()],
+  });
+  const remote = payload({
+    hosts: [{ ...hostWithTelemetry(1_000), label: "prod-renamed-by-remote" }],
+  });
+
+  const result = mergeSyncPayloads(base, local, remote);
+
+  // Remote edit survives: the telemetry-only local delta must not classify
+  // this host as locally modified and shadow the remote rename.
+  assert.equal(result.payload.hosts[0]?.label, "prod-renamed-by-remote");
+  assert.equal(result.summary.modified.local, 0);
+  assert.equal(result.summary.modified.remote, 1);
+});
+
+test("mergeSyncPayloads keeps host telemetry off merged payloads", () => {
+  const base = payload({ hosts: [hostWithTelemetry(1_000)] });
+
+  const unchanged = mergeSyncPayloads(
+    base,
+    payload({ hosts: [hostWithTelemetry(2_000)] }),
+    payload({ hosts: [hostWithTelemetry(1_000)] }),
+  );
+  assert.equal(unchanged.payload.hosts[0]?.lastConnectedAt, undefined);
+  assert.equal(unchanged.summary.modified.local, 0);
+});

--- a/domain/syncMerge.ts
+++ b/domain/syncMerge.ts
@@ -20,7 +20,11 @@
  */
 
 import { carryForwardSyncDeletions, getDeletedEntityIds } from './syncReliability';
-import type { CloudSyncPayloadEntityKey, SyncPayload } from './sync';
+import {
+  sanitizeHostsForSync,
+  type CloudSyncPayloadEntityKey,
+  type SyncPayload,
+} from './sync';
 import { mergePluginSyncSidecarsThreeWay } from './pluginSyncSidecar';
 
 // ---------------------------------------------------------------------------
@@ -445,7 +449,17 @@ export function mergeSyncPayloads(
   });
 
   // Merge each entity type
-  const hosts = mergeEntityArrays(b.hosts ?? [], local.hosts ?? [], remote.hosts ?? [], tombstones('hosts'));
+  // Normalize host telemetry on all three sides (#2629): the stored base and
+  // older remote payloads still carry `lastConnectedAt`, while upgraded local
+  // payloads strip it. Without normalization an otherwise-unchanged host looks
+  // locally modified, the merge prefers the sanitized local copy, and a real
+  // remote edit to that host is silently overwritten on the round trip.
+  const hosts = mergeEntityArrays(
+    sanitizeHostsForSync(b.hosts) ?? [],
+    sanitizeHostsForSync(local.hosts) ?? [],
+    sanitizeHostsForSync(remote.hosts) ?? [],
+    tombstones('hosts'),
+  );
   const keys = mergeEntityArrays(b.keys ?? [], local.keys ?? [], remote.keys ?? [], tombstones('keys'));
   const baseIdentities = b.identities ?? [];
   const identities = mergeEntityArrays(

--- a/domain/syncReliability.test.ts
+++ b/domain/syncReliability.test.ts
@@ -178,6 +178,46 @@ test("summarizeSyncChanges reports both-added conflicts by entity type", () => {
   }]);
 });
 
+test("summarizeSyncChanges ignores lastConnectedAt-only host diffs", () => {
+  const host = {
+    id: "host-1",
+    label: "prod",
+    hostname: "prod.example.com",
+    username: "root",
+    tags: [],
+    os: "linux" as const,
+  };
+  const base = payload({ hosts: [{ ...host, lastConnectedAt: 10 }] });
+  const local = payload({ hosts: [host] });
+  const remote = payload({ hosts: [{ ...host, lastConnectedAt: 99 }] });
+
+  const summary = summarizeSyncChanges(base, local, remote);
+
+  assert.equal(summary.hasLocalChanges, false);
+  assert.equal(summary.hasRemoteChanges, false);
+  assert.equal(summary.hasConflicts, false);
+});
+
+test("summarizeSyncChanges still reports a real remote host edit after stripping lastConnectedAt", () => {
+  const host = {
+    id: "host-1",
+    label: "prod",
+    hostname: "prod.example.com",
+    username: "root",
+    tags: [],
+    os: "linux" as const,
+  };
+  const summary = summarizeSyncChanges(
+    payload({ hosts: [{ ...host, lastConnectedAt: 10 }] }),
+    payload({ hosts: [host] }),
+    payload({ hosts: [{ ...host, lastConnectedAt: 10, label: "prod-renamed" }] }),
+  );
+
+  assert.equal(summary.hasLocalChanges, false);
+  assert.equal(summary.hasRemoteChanges, true);
+  assert.equal(summary.hasConflicts, false);
+});
+
 test("withSyncReliabilityMeta carries old deletion records until the entity is recreated", () => {
   const current = payload({
     syncMeta: {

--- a/domain/syncReliability.ts
+++ b/domain/syncReliability.ts
@@ -1,5 +1,6 @@
 import {
   CLOUD_SYNC_PAYLOAD_ENTITY_KEYS,
+  withHostsSanitizedForSync,
   type CloudSyncPayloadEntityKey,
   type SyncChangeEntityKey,
   type SyncChangeSummary,
@@ -193,7 +194,7 @@ export function summarizeSyncChanges(
   local: SyncPayload,
   remote?: SyncPayload,
 ): SyncChangeSummary {
-  const reference = base ?? {
+  const emptyBase: SyncPayload = {
     hosts: [],
     keys: [],
     identities: [],
@@ -206,6 +207,9 @@ export function summarizeSyncChanges(
     settings: undefined,
     syncedAt: 0,
   };
+  const reference = withHostsSanitizedForSync(base ?? emptyBase);
+  const localPayload = withHostsSanitizedForSync(local);
+  const remotePayload = remote ? withHostsSanitizedForSync(remote) : undefined;
   const summary: SyncChangeSummary = {
     hasLocalChanges: false,
     hasRemoteChanges: false,
@@ -219,11 +223,11 @@ export function summarizeSyncChanges(
       summary,
       entityType,
       reference[entityType],
-      payloadValues(local, entityType, reference),
-      remote ? payloadValues(remote, entityType, reference) : undefined,
+      payloadValues(localPayload, entityType, reference),
+      remotePayload ? payloadValues(remotePayload, entityType, reference) : undefined,
     );
   }
-  recordSettingsChanges(summary, reference, local, remote);
+  recordSettingsChanges(summary, reference, localPayload, remotePayload);
 
   return summary;
 }


### PR DESCRIPTION
## Summary

Connecting an SSH host updates `lastConnectedAt` for Recently Connected. That field was included in the cloud sync payload and auto-sync content hash, so every connect looked like a vault change and triggered WebDAV (and other providers) upload even when local and cloud version numbers already matched.

This strips `lastConnectedAt` from cloud sync hosts the same way port-forward rules already strip `lastUsedAt`. Local protective backups still keep the timestamp.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Fixes #2629

## Changes Made

- Added `sanitizeHostsForSync` and used it in `buildSyncPayload` / `buildCloudSyncPayload`.
- Sanitized hosts in auto-sync snapshots and payload hash comparison so reconnects do not dirty the hash.
- Local backups via `buildLocalVaultPayload` still keep `lastConnectedAt`.
- Tests: payloads that differ only by `lastConnectedAt` hash equal after sanitize; cloud payload hosts omit `lastConnectedAt`.

## Screenshots / Demo

N/A — sync payload sanitization. Manual check: with WebDAV connected, sync once, reconnect an SSH host without editing it — auto-sync should stay idle; real host/settings edits should still sync.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Targeted: `node --test --import tsx application/syncPayload.test.ts application/state/useAutoSync.test.ts application/state/autoSyncHashDecision.test.ts` (79 pass)

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)