### PR TITLE
fix(terminal): skip autocomplete live preview on network devices

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1075,6 +1075,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const autocompleteSettings = resolveTerminalAutocompleteSettings({
     protocol: effectiveTerminalProtocol,
     terminalSettings,
+    isNetworkDevice: host.deviceType === 'network'
+      || classifyDistroId(host.distro) === 'network-device',
   });
 
   const resolveSftpInitialPath = useCallback(async (options?: {

--- a/components/terminal/TerminalAutocomplete.tsx
+++ b/components/terminal/TerminalAutocomplete.tsx
@@ -46,6 +46,8 @@ interface TerminalAutocompleteProps {
   isPluginCompletionProviderAvailable?: () => boolean;
   sensitiveInputActiveRef: RefObject<boolean>;
   allowHostStyleGreaterThanPrompt?: boolean;
+  /** Vendor CLI / network-device session: skip live-preview PTY rewrites (#1193). */
+  isNetworkDevice?: boolean;
 }
 
 /**
@@ -87,6 +89,7 @@ export function TerminalAutocomplete({
   isPluginCompletionProviderAvailable,
   sensitiveInputActiveRef,
   allowHostStyleGreaterThanPrompt = false,
+  isNetworkDevice = false,
 }: TerminalAutocompleteProps) {
   // Self-subscribe to this pane's visibility so toggling it doesn't have to
   // flow through (and re-render) the TerminalView ctx. Popup / standalone
@@ -145,6 +148,7 @@ export function TerminalAutocomplete({
     getCwd,
     sensitiveInputActiveRef,
     provideCompletions,
+    isNetworkDevice,
   });
 
   // Surface the handlers for runtime wiring. They have stable identities

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -1145,6 +1145,7 @@ function TerminalViewInner({ ctx, isPaneMagnified = false }: { ctx: TerminalView
             )}
             sensitiveInputActiveRef={passwordPromptActiveRef}
             allowHostStyleGreaterThanPrompt={isNetworkDevice}
+            isNetworkDevice={isNetworkDevice}
           />
 
           <PasswordCredentialPicker

--- a/components/terminal/autocomplete/livePreviewSequence.ts
+++ b/components/terminal/autocomplete/livePreviewSequence.ts
@@ -9,6 +9,19 @@
  *   shells use Ctrl-U (kill-line); Windows (cmd/PowerShell) uses backspaces
  *   sized to the current line length.
  */
+
+/**
+ * Live-preview rewrites inject Ctrl-U / backspaces into the PTY. Vendor
+ * bastion and network-device CLIs treat those bytes as session-kill, so
+ * network-device sessions keep the popup but skip the rewrite (#1193).
+ */
+export function shouldWriteAutocompleteLivePreview(
+  livePreviewEnabled: boolean,
+  isNetworkDevice = false,
+): boolean {
+  return livePreviewEnabled && !isNetworkDevice;
+}
+
 export function isWindowsShellLineInput(
   os: string,
   promptText?: string | null,

--- a/components/terminal/autocomplete/terminalAutocompleteSettings.ts
+++ b/components/terminal/autocomplete/terminalAutocompleteSettings.ts
@@ -1,5 +1,6 @@
 import type { AutocompleteSettings } from "./useTerminalAutocomplete";
 import type { AutocompleteHistoryScope } from "../../../domain/models";
+import { shouldWriteAutocompleteLivePreview } from "./livePreviewSequence";
 
 type TerminalAutocompleteSettingFields = {
   autocompleteEnabled?: boolean;
@@ -15,8 +16,10 @@ type TerminalAutocompleteSettingFields = {
 export function resolveTerminalAutocompleteSettings(input: {
   protocol?: string;
   terminalSettings?: TerminalAutocompleteSettingFields;
+  /** Vendor CLI / network-device session: skip live-preview PTY rewrites (#1193). */
+  isNetworkDevice?: boolean;
 }): Partial<AutocompleteSettings> | undefined {
-  const { protocol, terminalSettings } = input;
+  const { protocol, terminalSettings, isNetworkDevice } = input;
 
   if (protocol === "serial") {
     return {
@@ -33,13 +36,15 @@ export function resolveTerminalAutocompleteSettings(input: {
     };
   }
 
-  if (!terminalSettings) return undefined;
+  if (!terminalSettings) {
+    return isNetworkDevice ? { livePreview: false } : undefined;
+  }
 
   return {
     enabled: terminalSettings.autocompleteEnabled ?? true,
     showGhostText: terminalSettings.autocompleteGhostText ?? true,
     showPopupMenu: terminalSettings.autocompletePopupMenu ?? true,
-    livePreview: true,
+    livePreview: shouldWriteAutocompleteLivePreview(true, isNetworkDevice),
     allowLineReplacement: true,
     debounceMs: terminalSettings.autocompleteDebounceMs ?? 100,
     minChars: terminalSettings.autocompleteMinChars ?? 1,

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -27,7 +27,7 @@ import {
   shouldPreferRemoteShellCwd,
 } from "./remotePathCompleter";
 import { decideGhostSuggestion } from "./ghostSuggestionPolicy";
-import { isWindowsShellLineInput } from "./livePreviewSequence";
+import { isWindowsShellLineInput, shouldWriteAutocompleteLivePreview } from "./livePreviewSequence";
 import {
   areSubDirPanelsEqual,
   areSuggestionsEqual,
@@ -238,6 +238,11 @@ interface UseTerminalAutocompleteOptions {
     input: string,
     options: HostCompletionProviderOptions,
   ) => Promise<CompletionSuggestion[]>;
+  /**
+   * Vendor bastion / network-device CLI. Live-preview PTY rewrites (Ctrl-U)
+   * disconnect these sessions, so the popup stays and preview writes no-op (#1193).
+   */
+  isNetworkDevice?: boolean;
 }
 
 export interface TerminalAutocompleteHandle {
@@ -277,6 +282,7 @@ export function useTerminalAutocomplete(
     onAcceptSnippet,
     sensitiveInputActiveRef,
     provideCompletions,
+    isNetworkDevice = false,
   } = options;
   const rawSettings: AutocompleteSettings = {
     ...DEFAULT_AUTOCOMPLETE_SETTINGS,
@@ -292,6 +298,7 @@ export function useTerminalAutocomplete(
   const settings: AutocompleteSettings = {
     ...rawSettings,
     showGhostText: rawSettings.showPopupMenu ? false : rawSettings.showGhostText,
+    livePreview: shouldWriteAutocompleteLivePreview(rawSettings.livePreview, isNetworkDevice),
   };
 
   // Use refs for values accessed in callbacks to avoid stale closures
@@ -313,6 +320,8 @@ export function useTerminalAutocomplete(
   sessionIdRef.current = sessionId;
   const protocolRef = useRef(protocol);
   protocolRef.current = protocol;
+  const isNetworkDeviceRef = useRef(isNetworkDevice);
+  isNetworkDeviceRef.current = isNetworkDevice;
   const getCwdRef = useRef(getCwd);
   getCwdRef.current = getCwd;
   const provideCompletionsRef = useRef(provideCompletions ?? getCompletions);
@@ -709,6 +718,10 @@ export function useTerminalAutocomplete(
    * (no clearState). Used for live-preview while navigating sub-dir panels (#1005).
    */
   const renderSubDirPath = useCallback((level: number, entry: SubDirEntry) => {
+    if (!shouldWriteAutocompleteLivePreview(
+      settingsRef.current.livePreview,
+      isNetworkDeviceRef.current,
+    )) return;
     const s = stateRef.current;
     const term = termRef.current;
     if (!term) return;
@@ -1251,7 +1264,10 @@ export function useTerminalAutocomplete(
    * live-preview, #1005). `index < 0` restores the user's typed baseline.
    */
   const renderPreviewSelection = useCallback((index: number) => {
-    if (!settingsRef.current.livePreview) return;
+    if (!shouldWriteAutocompleteLivePreview(
+      settingsRef.current.livePreview,
+      isNetworkDeviceRef.current,
+    )) return;
     const s = stateRef.current;
     const term = termRef.current;
     if (!term) return;

--- a/components/terminal/livePreviewSequence.test.ts
+++ b/components/terminal/livePreviewSequence.test.ts
@@ -3,7 +3,15 @@ import assert from "node:assert/strict";
 import {
   computeLivePreviewWrite,
   isWindowsShellLineInput,
+  shouldWriteAutocompleteLivePreview,
 } from "./autocomplete/livePreviewSequence.ts";
+
+test("network-device sessions skip live-preview PTY writes (#1193)", () => {
+  assert.equal(shouldWriteAutocompleteLivePreview(true, false), true);
+  assert.equal(shouldWriteAutocompleteLivePreview(true, true), false);
+  assert.equal(shouldWriteAutocompleteLivePreview(false, false), false);
+  assert.equal(shouldWriteAutocompleteLivePreview(false, true), false);
+});
 
 test("appends only the tail when the candidate continues the current line", () => {
   assert.equal(

--- a/components/terminal/terminalAutocompleteSettings.test.ts
+++ b/components/terminal/terminalAutocompleteSettings.test.ts
@@ -33,6 +33,42 @@ test("keeps autocomplete enabled for shell-like terminal protocols", () => {
   );
 });
 
+test("keeps network-device autocomplete popup but disables live preview (#1193)", () => {
+  assert.deepEqual(
+    resolveTerminalAutocompleteSettings({
+      protocol: "ssh",
+      isNetworkDevice: true,
+      terminalSettings: {
+        autocompleteEnabled: true,
+        autocompleteGhostText: false,
+        autocompletePopupMenu: true,
+        autocompleteDebounceMs: 100,
+        autocompleteMinChars: 1,
+        autocompleteMaxSuggestions: 8,
+      },
+    }),
+    {
+      enabled: true,
+      showGhostText: false,
+      showPopupMenu: true,
+      livePreview: false,
+      allowLineReplacement: true,
+      debounceMs: 100,
+      minChars: 1,
+      maxSuggestions: 8,
+      historyScope: "host",
+      shiftEnterNewlineEnabled: true,
+    },
+  );
+  assert.deepEqual(
+    resolveTerminalAutocompleteSettings({
+      protocol: "ssh",
+      isNetworkDevice: true,
+    }),
+    { livePreview: false },
+  );
+});
+
 test("keeps serial autocomplete available but disables input-line preview and replacement", () => {
   assert.deepEqual(
     resolveTerminalAutocompleteSettings({

--- a/components/terminal/terminalRuntimeMount.test.ts
+++ b/components/terminal/terminalRuntimeMount.test.ts
@@ -180,9 +180,19 @@ test('terminal view derives the network-device prompt policy before autocomplete
     /const isNetworkDevice = host\.deviceType === 'network'[\s\S]*?classifyDistroId\(host\.distro\) === 'network-device';/,
   );
   assert.match(terminalViewSource, /allowHostStyleGreaterThanPrompt=\{isNetworkDevice\}/);
+  assert.match(terminalViewSource, /isNetworkDevice=\{isNetworkDevice\}/);
   assert.match(
     terminalSource,
     /xTermRuntimeContextRef\.current = \{[\s\S]*?allowHostStyleGreaterThanPrompt: isNetworkDevice,/,
+  );
+  assert.match(
+    terminalSource,
+    /resolveTerminalAutocompleteSettings\(\{[\s\S]*?isNetworkDevice: host\.deviceType === 'network'[\s\S]*?classifyDistroId\(host\.distro\) === 'network-device',/,
+  );
+  const autocompleteSource = readFileSync(new URL('./TerminalAutocomplete.tsx', import.meta.url), 'utf8');
+  assert.match(
+    autocompleteSource,
+    /useTerminalAutocomplete\(\{[\s\S]*?isNetworkDevice,/,
   );
 });
 

--- a/components/terminal/useTerminalAutocomplete.render.test.tsx
+++ b/components/terminal/useTerminalAutocomplete.render.test.tsx
@@ -28,6 +28,25 @@ test("useTerminalAutocomplete can render before any autocomplete interaction", (
   });
 });
 
+test("network-device sessions skip live-preview writeToTerminal (#1193)", () => {
+  const source = readFileSync(
+    fileURLToPath(new URL("./autocomplete/useTerminalAutocomplete.ts", import.meta.url)),
+    "utf8",
+  );
+  assert.match(
+    source,
+    /livePreview: shouldWriteAutocompleteLivePreview\(rawSettings\.livePreview, isNetworkDevice\)/,
+  );
+  assert.match(
+    source,
+    /const renderPreviewSelection = useCallback\(\(index: number\) => \{\s*if \(!shouldWriteAutocompleteLivePreview\(\s*settingsRef\.current\.livePreview,\s*isNetworkDeviceRef\.current,\s*\)\) return;[\s\S]*?if \(seq\) writeToTerminal\(seq\);/,
+  );
+  assert.match(
+    source,
+    /const renderSubDirPath = useCallback\(\(level: number, entry: SubDirEntry\) => \{\s*if \(!shouldWriteAutocompleteLivePreview\(\s*settingsRef\.current\.livePreview,\s*isNetworkDeviceRef\.current,\s*\)\) return;[\s\S]*?if \(seq\) writeToTerminal\(seq\);/,
+  );
+});
+
 test("mount effect re-arms disposedRef after dispose cleanup (HMR / StrictMode)", () => {
   // dispose() sets disposedRef=true on effect cleanup. Fast Refresh preserves
   // refs, so without resetting on mount, fetchSuggestions stays dead forever


### PR DESCRIPTION
## Summary

Autocomplete live-preview (#1005) rewrites the PTY with Ctrl-U / backspaces while the user types or navigates suggestions. On vendor bastion and network-device CLIs those control bytes disconnect the session (typing `cd ` / `cat ` opens suggestions and live-preview fires). Reporter later confirmed turning autocomplete off fixed it.

This keeps the autocomplete popup, but treats network-device sessions as preview-off so nothing is injected until the user accepts.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Fixes #1193

## Changes Made

- Skip live-preview PTY writes when `host.deviceType === 'network'` or `classifyDistroId(host.distro) === 'network-device'`.
- Force `livePreview` off in autocomplete settings and in `useTerminalAutocomplete` so popup navigation uses the preview-off accept path.
- `renderPreviewSelection` / `renderSubDirPath` no-op on network-device sessions and do not call `writeToTerminal`.
- Popup, ghost text, and accept-on-Enter remain available. Windows Ctrl-U handling from #3184 is unchanged.

## Screenshots / Demo

No UI change. Suggestions still show on network-device sessions; highlighting a row no longer rewrites the command line.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Ran:

- `node --test --import tsx components/terminal/livePreviewSequence.test.ts`
- `node --test --import tsx components/terminal/terminalAutocompleteSettings.test.ts`
- `node --test --import tsx components/terminal/useTerminalAutocomplete.render.test.tsx`
- `node --test --import tsx components/terminal/terminalRuntimeMount.test.ts`

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)