### PR TITLE
fix(sftp): restore remote mode after replace upload

### DIFF
--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -247,40 +247,9 @@ async function assertRemoteUploadSize(client, remotePath, expectedSize) {
   }
 }
 
-function remoteModeFromAttrs(attrs) {
-  if (typeof attrs?.mode !== "number" || !Number.isFinite(attrs.mode)) return null;
-  return attrs.mode & 0o7777;
-}
-
-/**
- * Permission bits of an existing remote upload target, or null for a new file.
- * fastPut / pipelined WRITE recreate with umask defaults (typically 0644), so
- * replace uploads must remember this before truncating and chmod it back after
- * the final path is published — not on the `.part` stage.
- */
-async function captureRemoteUploadMode(client, sftpId, remotePath, encoding) {
-  if (!client || remotePath == null || remotePath === "") return null;
-  try {
-    if (isScpModeClient(client)) {
-      return remoteModeFromAttrs(
-        await getScpBackendForClient(client).stat(remotePath, { encoding }),
-      );
-    }
-    const encodedPath = encodePathForSession(sftpId, remotePath, encoding);
-    if (typeof client.stat === "function") {
-      return remoteModeFromAttrs(await client.stat(encodedPath));
-    }
-    const sftp = client.sftp;
-    if (sftp && typeof sftp.stat === "function") {
-      const attrs = await new Promise((resolve, reject) => {
-        sftp.stat(encodedPath, (err, st) => (err ? reject(err) : resolve(st)));
-      });
-      return remoteModeFromAttrs(attrs);
-    }
-  } catch {
-    // Missing target or stat unsupported — new file keeps server defaults.
-  }
-  return null;
+function existingModeFromUploadPlan(plan) {
+  if (!Number.isFinite(plan?.existingMode)) return null;
+  return plan.existingMode & 0o7777;
 }
 
 /**
@@ -5913,12 +5882,7 @@ async function startTransferNow(event, payload, onProgress) {
       }
 
       const resolvedTargetEncoding = resolveEncodingForRequest(targetSftpId, targetEncoding);
-      const existingRemoteMode = await captureRemoteUploadMode(
-        client,
-        targetSftpId,
-        targetPath,
-        resolvedTargetEncoding,
-      );
+      let existingRemoteMode = null;
       const deterministicStagePath = buildRemoteTransferStagePath(targetPath, transferId);
       await runRemoteUploadTransaction(client, sourcePath, targetPath, {
         encoding: resolvedTargetEncoding,
@@ -5943,6 +5907,7 @@ async function startTransferNow(event, payload, onProgress) {
         async uploadFile(encodedUploadPath, uploadTarget) {
           const uploadTargetPath = uploadTarget.logicalPath;
           const usesStage = uploadTarget.generatedStagePath === true;
+          existingRemoteMode = existingModeFromUploadPlan(uploadTarget.plan);
           transfer.stagedRemote = usesStage
             ? { client, sftpId: targetSftpId, path: uploadTargetPath, encoding: targetEncoding }
             : null;
@@ -6374,12 +6339,7 @@ async function startTransferNow(event, payload, onProgress) {
         };
         transfer.sourceIsOwnedTemp = true;
         const resolvedTargetEncoding = resolveEncodingForRequest(targetSftpId, targetEncoding);
-        const existingRemoteMode = await captureRemoteUploadMode(
-          targetClient,
-          targetSftpId,
-          targetPath,
-          resolvedTargetEncoding,
-        );
+        let existingRemoteMode = null;
         const deterministicStagePath = buildRemoteTransferStagePath(targetPath, transferId);
         await runRemoteUploadTransaction(targetClient, tempPath, targetPath, {
           encoding: resolvedTargetEncoding,
@@ -6401,6 +6361,7 @@ async function startTransferNow(event, payload, onProgress) {
           async uploadFile(encodedUploadPath, uploadTarget) {
             const uploadTargetPath = uploadTarget.logicalPath;
             const usesStage = uploadTarget.generatedStagePath === true;
+            existingRemoteMode = existingModeFromUploadPlan(uploadTarget.plan);
             transfer.stagedRemote = usesStage
               ? { client: targetClient, sftpId: targetSftpId, path: uploadTargetPath, encoding: targetEncoding }
               : null;

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -256,33 +256,42 @@ function existingModeFromUploadPlan(plan) {
  * Best-effort chmod of captured mode bits onto the published remote path.
  * Failures are warnings only (same as writeSftp); upload bytes are already committed.
  */
-async function restoreRemoteUploadModeBestEffort(client, sftpId, remotePath, encoding, existingMode) {
+async function restoreRemoteUploadModeBestEffort(client, sftpId, remotePath, encoding, existingMode, options = {}) {
   if (!client || existingMode == null || !Number.isFinite(existingMode)) return;
   const mode = existingMode & 0o7777;
+  const timeoutMs = Number(options.timeoutMs) > 0
+    ? Number(options.timeoutMs)
+    : (Number(process.env.NETCATTY_REMOTE_MODE_RESTORE_TIMEOUT_MS) > 0
+      ? Number(process.env.NETCATTY_REMOTE_MODE_RESTORE_TIMEOUT_MS)
+      : 15_000);
   try {
-    if (isScpModeClient(client)) {
-      const backend = getScpBackendForClient(client);
-      if (typeof backend.chmod !== "function") return;
-      await backend.chmod(remotePath, mode, { encoding });
-      return;
-    }
-    const encodedPath = encodePathForSession(sftpId, remotePath, encoding);
-    if (typeof client.chmod === "function") {
-      await client.chmod(encodedPath, mode);
-      return;
-    }
-    const sftp = client.sftp;
-    if (sftp && typeof sftp.chmod === "function") {
-      await new Promise((resolve, reject) => {
-        sftp.chmod(encodedPath, mode, (err) => (err ? reject(err) : resolve()));
-      });
-      return;
-    }
-    if (sftp && typeof sftp.setstat === "function") {
-      await new Promise((resolve, reject) => {
-        sftp.setstat(encodedPath, { mode }, (err) => (err ? reject(err) : resolve()));
-      });
-    }
+    // Post-commit: cancelTransfer will not abort. Bound the wait so a stalled
+    // chmod cannot pin the transfer, SFTP lease, or admission slot.
+    await awaitBestEffortBounded((async () => {
+      if (isScpModeClient(client)) {
+        const backend = getScpBackendForClient(client);
+        if (typeof backend.chmod !== "function") return;
+        await backend.chmod(remotePath, mode, { encoding });
+        return;
+      }
+      const encodedPath = encodePathForSession(sftpId, remotePath, encoding);
+      if (typeof client.chmod === "function") {
+        await client.chmod(encodedPath, mode);
+        return;
+      }
+      const sftp = client.sftp;
+      if (sftp && typeof sftp.chmod === "function") {
+        await new Promise((resolve, reject) => {
+          sftp.chmod(encodedPath, mode, (err) => (err ? reject(err) : resolve()));
+        });
+        return;
+      }
+      if (sftp && typeof sftp.setstat === "function") {
+        await new Promise((resolve, reject) => {
+          sftp.setstat(encodedPath, { mode }, (err) => (err ? reject(err) : resolve()));
+        });
+      }
+    })(), timeoutMs, "Remote chmod");
   } catch (err) {
     console.warn(
       `[sftp] Failed to restore permissions on ${remotePath}:`,
@@ -7418,6 +7427,7 @@ module.exports = {
   listTransferSftpIds,
   _promoteLocalTransferForTests: promoteLocalTransfer,
   _preserveTransferredDestinationMtimeForTests: preserveTransferredDestinationMtime,
+  _restoreRemoteUploadModeBestEffortForTests: restoreRemoteUploadModeBestEffort,
   _waitForPendingWriteOpenPathGateForTests: waitForPendingWriteOpenPathGate,
   _stableLocalFileIdentityForTests: stableLocalFileIdentity,
   _getWorkerTransferLifecycleEpochCountForTests: () => workerTransferLifecycleEpochs.size,

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -247,6 +247,81 @@ async function assertRemoteUploadSize(client, remotePath, expectedSize) {
   }
 }
 
+function remoteModeFromAttrs(attrs) {
+  if (typeof attrs?.mode !== "number" || !Number.isFinite(attrs.mode)) return null;
+  return attrs.mode & 0o7777;
+}
+
+/**
+ * Permission bits of an existing remote upload target, or null for a new file.
+ * fastPut / pipelined WRITE recreate with umask defaults (typically 0644), so
+ * replace uploads must remember this before truncating and chmod it back after
+ * the final path is published — not on the `.part` stage.
+ */
+async function captureRemoteUploadMode(client, sftpId, remotePath, encoding) {
+  if (!client || remotePath == null || remotePath === "") return null;
+  try {
+    if (isScpModeClient(client)) {
+      return remoteModeFromAttrs(
+        await getScpBackendForClient(client).stat(remotePath, { encoding }),
+      );
+    }
+    const encodedPath = encodePathForSession(sftpId, remotePath, encoding);
+    if (typeof client.stat === "function") {
+      return remoteModeFromAttrs(await client.stat(encodedPath));
+    }
+    const sftp = client.sftp;
+    if (sftp && typeof sftp.stat === "function") {
+      const attrs = await new Promise((resolve, reject) => {
+        sftp.stat(encodedPath, (err, st) => (err ? reject(err) : resolve(st)));
+      });
+      return remoteModeFromAttrs(attrs);
+    }
+  } catch {
+    // Missing target or stat unsupported — new file keeps server defaults.
+  }
+  return null;
+}
+
+/**
+ * Best-effort chmod of captured mode bits onto the published remote path.
+ * Failures are warnings only (same as writeSftp); upload bytes are already committed.
+ */
+async function restoreRemoteUploadModeBestEffort(client, sftpId, remotePath, encoding, existingMode) {
+  if (!client || existingMode == null || !Number.isFinite(existingMode)) return;
+  const mode = existingMode & 0o7777;
+  try {
+    if (isScpModeClient(client)) {
+      const backend = getScpBackendForClient(client);
+      if (typeof backend.chmod !== "function") return;
+      await backend.chmod(remotePath, mode, { encoding });
+      return;
+    }
+    const encodedPath = encodePathForSession(sftpId, remotePath, encoding);
+    if (typeof client.chmod === "function") {
+      await client.chmod(encodedPath, mode);
+      return;
+    }
+    const sftp = client.sftp;
+    if (sftp && typeof sftp.chmod === "function") {
+      await new Promise((resolve, reject) => {
+        sftp.chmod(encodedPath, mode, (err) => (err ? reject(err) : resolve()));
+      });
+      return;
+    }
+    if (sftp && typeof sftp.setstat === "function") {
+      await new Promise((resolve, reject) => {
+        sftp.setstat(encodedPath, { mode }, (err) => (err ? reject(err) : resolve()));
+      });
+    }
+  } catch (err) {
+    console.warn(
+      `[sftp] Failed to restore permissions on ${remotePath}:`,
+      err && err.message ? err.message : err,
+    );
+  }
+}
+
 /**
  * Safely ensure a local directory exists.
  * On Windows, `mkdir("E:\\", { recursive: true })` throws EPERM for drive roots.
@@ -2235,6 +2310,9 @@ async function uploadFile(
   options = {},
 ) {
   const generatedStagePath = options.generatedStagePath === true;
+  const existingRemoteMode = Number.isFinite(options.existingMode)
+    ? options.existingMode & 0o7777
+    : null;
   if (isScpModeClient(client)) {
     transfer.pauseSupported = false;
     transfer.pauseUnavailableReason = "Pause is unavailable for SCP transfers";
@@ -2291,6 +2369,17 @@ async function uploadFile(
       });
     }
     await assertRemoteUploadSize(client, remotePath, fileSize);
+    // In-place replace writes the final path (fastPut / pipelined WRITE). Restore
+    // captured mode here; staged `.part` uploads restore after rename instead.
+    if (!generatedStagePath && Number.isFinite(existingRemoteMode)) {
+      await restoreRemoteUploadModeBestEffort(
+        client,
+        options.sftpId,
+        options.finalRemotePath || remotePath,
+        encoding,
+        existingRemoteMode,
+      );
+    }
   };
 
   // Prefer an isolated SFTP channel so cancellation cannot kill the browse session.
@@ -5824,6 +5913,12 @@ async function startTransferNow(event, payload, onProgress) {
       }
 
       const resolvedTargetEncoding = resolveEncodingForRequest(targetSftpId, targetEncoding);
+      const existingRemoteMode = await captureRemoteUploadMode(
+        client,
+        targetSftpId,
+        targetPath,
+        resolvedTargetEncoding,
+      );
       const deterministicStagePath = buildRemoteTransferStagePath(targetPath, transferId);
       await runRemoteUploadTransaction(client, sourcePath, targetPath, {
         encoding: resolvedTargetEncoding,
@@ -5874,11 +5969,23 @@ async function startTransferNow(event, payload, onProgress) {
             sendProgress,
             resolvedTargetEncoding,
             usesStage ? null : () => { transfer.completionCommitted = true; },
-            { generatedStagePath: usesStage },
+            {
+              generatedStagePath: usesStage,
+              existingMode: existingRemoteMode,
+              sftpId: targetSftpId,
+              finalRemotePath: targetPath,
+            },
           );
         },
       });
       transfer.stagedRemote = null;
+      await restoreRemoteUploadModeBestEffort(
+        client,
+        targetSftpId,
+        targetPath,
+        resolvedTargetEncoding,
+        existingRemoteMode,
+      );
 
     } else if (sourceType === 'sftp' && targetType === 'local') {
       const client = sftpClients.get(sourceSftpId);
@@ -6267,6 +6374,12 @@ async function startTransferNow(event, payload, onProgress) {
         };
         transfer.sourceIsOwnedTemp = true;
         const resolvedTargetEncoding = resolveEncodingForRequest(targetSftpId, targetEncoding);
+        const existingRemoteMode = await captureRemoteUploadMode(
+          targetClient,
+          targetSftpId,
+          targetPath,
+          resolvedTargetEncoding,
+        );
         const deterministicStagePath = buildRemoteTransferStagePath(targetPath, transferId);
         await runRemoteUploadTransaction(targetClient, tempPath, targetPath, {
           encoding: resolvedTargetEncoding,
@@ -6333,11 +6446,23 @@ async function startTransferNow(event, payload, onProgress) {
               uploadProgress,
               resolvedTargetEncoding,
               usesStage ? null : () => { transfer.completionCommitted = true; },
-              { generatedStagePath: usesStage },
+              {
+                generatedStagePath: usesStage,
+                existingMode: existingRemoteMode,
+                sftpId: targetSftpId,
+                finalRemotePath: targetPath,
+              },
             );
           },
         });
         transfer.stagedRemote = null;
+        await restoreRemoteUploadModeBestEffort(
+          targetClient,
+          targetSftpId,
+          targetPath,
+          resolvedTargetEncoding,
+          existingRemoteMode,
+        );
 
         try { await fs.promises.unlink(tempPath); } catch { }
         transfer.stagedLocalPath = null;

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -915,7 +915,9 @@ test("in-place upload ignores cancellation during final size verification", asyn
         throw error;
       }
       statCalls += 1;
-      if (statCalls === 1) {
+      // Hang on the post-upload size check (after OPEN replaced the payload),
+      // not on an earlier existence/mode probe.
+      if (remote.length === payload.length && !releaseFinalStat) {
         markFinalStatStarted();
         await new Promise((resolve) => { releaseFinalStat = resolve; });
       }

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -12215,6 +12215,36 @@ test("preserveTransferredDestinationMtime stamps local targets from sourceSoftId
   assert.notEqual(Math.floor(after.mtimeMs / 1000), Math.floor(before.mtimeMs / 1000));
 });
 
+test("restoreRemoteUploadModeBestEffort times out hanging chmod", async () => {
+  const hangingClient = {
+    async chmod() {
+      await new Promise(() => {});
+    },
+  };
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => { warnings.push(args.map(String).join(" ")); };
+  const startedAt = Date.now();
+  try {
+    await transferBridge._restoreRemoteUploadModeBestEffortForTests(
+      hangingClient,
+      "target",
+      "/usr/local/bin/tool",
+      "utf-8",
+      0o755,
+      { timeoutMs: 40 },
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
+  const elapsed = Date.now() - startedAt;
+  assert.ok(elapsed < 1500, `expected bounded chmod, elapsed=${elapsed}`);
+  assert.ok(
+    warnings.some((message) => /Failed to restore permissions|timed out/i.test(message)),
+    `expected chmod timeout warning, got ${JSON.stringify(warnings)}`,
+  );
+});
+
 test("preserveTransferredDestinationMtime times out hanging remote setStat", async () => {
   let setStatStarted = false;
   const hangingClient = {

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -218,6 +218,304 @@ test("SFTP upload ignores cancellation after remote promotion is committed", asy
   assert.equal(sender.sent.some((entry) => entry.channel === "netcatty:transfer:cancelled"), false);
 });
 
+test("replace SFTP upload restores pre-existing remote mode after the final path is published", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-sftp-replace-mode-"));
+  t.after(async () => fs.promises.rm(tempDir, { recursive: true, force: true }));
+  const localPath = path.join(tempDir, "tool");
+  const payload = Buffer.from("#!/bin/sh\necho hi\n");
+  await fs.promises.writeFile(localPath, payload);
+  const targetPath = "/usr/local/bin/tool";
+  const remoteFiles = new Map([[targetPath, Buffer.from("old-tool")]]);
+  const remoteMeta = new Map([[targetPath, { mode: 0o100755 }]]);
+  const chmodCalls = [];
+
+  const fastSftp = createFastSftp({
+    lstat(remotePath, callback) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        callback(error);
+        return;
+      }
+      callback(null, {
+        size: remoteFiles.get(key).length,
+        mode: remoteMeta.get(key)?.mode ?? 0o100644,
+        isDirectory: () => false,
+        isSymbolicLink: () => false,
+      });
+    },
+    open(remotePath, _flags, callback) {
+      const key = String(remotePath);
+      remoteFiles.set(key, Buffer.alloc(payload.length));
+      if (!remoteMeta.has(key)) remoteMeta.set(key, { mode: 0o100644 });
+      callback(null, Buffer.from(key));
+    },
+    write(handle, buffer, offset, length, position, callback) {
+      const key = handle.toString();
+      buffer.copy(remoteFiles.get(key), position, offset, offset + length);
+      setImmediate(() => callback(null));
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+  });
+  const client = {
+    __netcattySudoMode: true,
+    sftp: fastSftp,
+    stat: async (remotePath) => {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        throw error;
+      }
+      return {
+        size: remoteFiles.get(key).length,
+        mode: remoteMeta.get(key)?.mode ?? 0o100644,
+        isDirectory: false,
+      };
+    },
+    chmod: async (remotePath, mode) => {
+      chmodCalls.push({ path: String(remotePath), mode });
+      const prev = remoteMeta.get(String(remotePath)) || {};
+      remoteMeta.set(String(remotePath), { ...prev, mode: (mode & 0o7777) | 0o100000 });
+    },
+    delete: async (remotePath) => {
+      remoteFiles.delete(String(remotePath));
+      remoteMeta.delete(String(remotePath));
+    },
+    async rename(fromPath, toPath) {
+      const from = String(fromPath);
+      const to = String(toPath);
+      remoteFiles.set(to, remoteFiles.get(from));
+      remoteFiles.delete(from);
+      // Simulate servers that recreate the destination inode on rename-replace
+      // with umask defaults, dropping the mode restored on the `.part` stage.
+      remoteMeta.set(to, { mode: 0o100644 });
+      remoteMeta.delete(from);
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const result = await transferBridge.startTransfer({ sender: createSender() }, {
+    transferId: "sftp-replace-preserve-mode",
+    sourcePath: localPath,
+    targetPath,
+    sourceType: "local",
+    targetType: "sftp",
+    targetSftpId: "target",
+    totalBytes: payload.length,
+    resumable: false,
+  });
+
+  assert.equal(result.error, undefined, result.error);
+  assert.deepEqual(remoteFiles.get(targetPath), payload);
+  assert.ok(
+    chmodCalls.some((call) => call.path === targetPath && (call.mode & 0o7777) === 0o755),
+    `expected chmod of ${targetPath} to 0755 after replace, got ${JSON.stringify(chmodCalls)}`,
+  );
+  assert.equal(remoteMeta.get(targetPath)?.mode & 0o777, 0o755);
+});
+
+test("new SFTP upload does not chmod a path that did not already exist", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-sftp-new-mode-"));
+  t.after(async () => fs.promises.rm(tempDir, { recursive: true, force: true }));
+  const localPath = path.join(tempDir, "fresh.bin");
+  const payload = Buffer.from("new-bytes");
+  await fs.promises.writeFile(localPath, payload);
+  const targetPath = "/tmp/fresh.bin";
+  const remoteFiles = new Map();
+  const remoteMeta = new Map();
+  const chmodCalls = [];
+
+  const fastSftp = createFastSftp({
+    lstat(remotePath, callback) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        callback(error);
+        return;
+      }
+      callback(null, {
+        size: remoteFiles.get(key).length,
+        mode: remoteMeta.get(key)?.mode ?? 0o100644,
+        isDirectory: () => false,
+        isSymbolicLink: () => false,
+      });
+    },
+    open(remotePath, _flags, callback) {
+      const key = String(remotePath);
+      remoteFiles.set(key, Buffer.alloc(payload.length));
+      if (!remoteMeta.has(key)) remoteMeta.set(key, { mode: 0o100644 });
+      callback(null, Buffer.from(key));
+    },
+    write(handle, buffer, offset, length, position, callback) {
+      const key = handle.toString();
+      buffer.copy(remoteFiles.get(key), position, offset, offset + length);
+      setImmediate(() => callback(null));
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+  });
+  const client = {
+    __netcattySudoMode: true,
+    sftp: fastSftp,
+    stat: async (remotePath) => {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        throw error;
+      }
+      return {
+        size: remoteFiles.get(key).length,
+        mode: remoteMeta.get(key)?.mode ?? 0o100644,
+        isDirectory: false,
+      };
+    },
+    chmod: async (remotePath, mode) => {
+      chmodCalls.push({ path: String(remotePath), mode });
+    },
+    delete: async (remotePath) => {
+      remoteFiles.delete(String(remotePath));
+      remoteMeta.delete(String(remotePath));
+    },
+    async rename(fromPath, toPath) {
+      const from = String(fromPath);
+      const to = String(toPath);
+      remoteFiles.set(to, remoteFiles.get(from));
+      remoteFiles.delete(from);
+      remoteMeta.set(to, remoteMeta.get(from) || { mode: 0o100644 });
+      remoteMeta.delete(from);
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const result = await transferBridge.startTransfer({ sender: createSender() }, {
+    transferId: "sftp-new-keeps-default-mode",
+    sourcePath: localPath,
+    targetPath,
+    sourceType: "local",
+    targetType: "sftp",
+    targetSftpId: "target",
+    totalBytes: payload.length,
+    resumable: false,
+  });
+
+  assert.equal(result.error, undefined, result.error);
+  assert.deepEqual(remoteFiles.get(targetPath), payload);
+  assert.deepEqual(chmodCalls, []);
+});
+
+test("replace SFTP upload still succeeds when restoring remote mode fails", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-sftp-replace-chmod-fail-"));
+  t.after(async () => fs.promises.rm(tempDir, { recursive: true, force: true }));
+  const localPath = path.join(tempDir, "tool");
+  const payload = Buffer.from("replaced-bytes");
+  await fs.promises.writeFile(localPath, payload);
+  const targetPath = "/usr/local/bin/tool";
+  const remoteFiles = new Map([[targetPath, Buffer.from("old-tool")]]);
+  const remoteMeta = new Map([[targetPath, { mode: 0o100755 }]]);
+  const chmodCalls = [];
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => { warnings.push(args.map(String).join(" ")); };
+  t.after(() => { console.warn = originalWarn; });
+
+  const fastSftp = createFastSftp({
+    lstat(remotePath, callback) {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        callback(error);
+        return;
+      }
+      callback(null, {
+        size: remoteFiles.get(key).length,
+        mode: remoteMeta.get(key)?.mode ?? 0o100644,
+        isDirectory: () => false,
+        isSymbolicLink: () => false,
+      });
+    },
+    open(remotePath, _flags, callback) {
+      const key = String(remotePath);
+      remoteFiles.set(key, Buffer.alloc(payload.length));
+      if (!remoteMeta.has(key)) remoteMeta.set(key, { mode: 0o100644 });
+      callback(null, Buffer.from(key));
+    },
+    write(handle, buffer, offset, length, position, callback) {
+      const key = handle.toString();
+      buffer.copy(remoteFiles.get(key), position, offset, offset + length);
+      setImmediate(() => callback(null));
+    },
+    close(_handle, callback) {
+      callback(null);
+    },
+  });
+  const client = {
+    __netcattySudoMode: true,
+    sftp: fastSftp,
+    stat: async (remotePath) => {
+      const key = String(remotePath);
+      if (!remoteFiles.has(key)) {
+        const error = new Error("ENOENT");
+        error.code = 2;
+        throw error;
+      }
+      return {
+        size: remoteFiles.get(key).length,
+        mode: remoteMeta.get(key)?.mode ?? 0o100644,
+        isDirectory: false,
+      };
+    },
+    chmod: async (remotePath, mode) => {
+      chmodCalls.push({ path: String(remotePath), mode });
+      if (String(remotePath) === targetPath) {
+        throw new Error("chmod failed");
+      }
+    },
+    delete: async (remotePath) => {
+      remoteFiles.delete(String(remotePath));
+      remoteMeta.delete(String(remotePath));
+    },
+    async rename(fromPath, toPath) {
+      const from = String(fromPath);
+      const to = String(toPath);
+      remoteFiles.set(to, remoteFiles.get(from));
+      remoteFiles.delete(from);
+      remoteMeta.set(to, remoteMeta.get(from) || { mode: 0o100644 });
+      remoteMeta.delete(from);
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const result = await transferBridge.startTransfer({ sender: createSender() }, {
+    transferId: "sftp-replace-chmod-fail",
+    sourcePath: localPath,
+    targetPath,
+    sourceType: "local",
+    targetType: "sftp",
+    targetSftpId: "target",
+    totalBytes: payload.length,
+    resumable: false,
+  });
+
+  assert.equal(result.error, undefined, result.error);
+  assert.deepEqual(remoteFiles.get(targetPath), payload);
+  assert.ok(
+    chmodCalls.some((call) => call.path === targetPath && (call.mode & 0o7777) === 0o755),
+    `expected chmod of ${targetPath} to 0755, got ${JSON.stringify(chmodCalls)}`,
+  );
+  assert.ok(
+    warnings.some((message) => /Failed to restore permissions/.test(message)),
+    `expected chmod warning, got ${JSON.stringify(warnings)}`,
+  );
+});
+
 test("SCP upload ignores cancellation after remote promotion is committed", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-scp-commit-cancel-"));
   t.after(async () => fs.promises.rm(tempDir, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary

SFTP replace uploads recreate the remote file with umask defaults (typically 0644), dropping executable and other mode bits. The editor save path already restores `mode & 0o7777` after `put`; the transfer/upload replace path did not chmod the published final path after `fastPut` / pipelined WRITE (or after a stage rename that recreates the inode).

This captures the existing remote mode before truncating/writing and chmods it back on the final remote path after a successful replace. New files keep server defaults. Chmod failure is a warning only (same as `writeSftp`). Download is unchanged; no sudo-chown.

Fixes #2954

#3186 is the same transfer-path gap still reported on 1.1.82.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Fixes #2954

## Changes Made

- Stat the existing remote target before a local-to-SFTP or server-to-server replace upload and remember `mode & 0o7777`.
- After the upload publishes the final path (not the `.part` stage), restore that mode with a best-effort chmod.
- In-place replace also restores on the `finishSuccessfulUpload` path used by `fastPut` / pipelined WRITE.
- Cover replace restore, new-file defaults, and chmod-failure-does-not-fail-the-transfer in `transferBridge.test.cjs`.

## Screenshots / Demo

N/A (main-process SFTP transfer behavior)

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`node --test --test-name-pattern='replace SFTP upload|new SFTP upload does not chmod' electron/bridges/transferBridge.test.cjs`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant tests
- [x] I have not introduced any breaking changes (or I have described them above)