### PR TITLE
fix(vault): wait for stored-key decrypt before reconnect auth

### DIFF
--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -93,6 +93,7 @@ import {
   encryptIdentities,
   encryptKeys,
   encryptProxyProfiles,
+  notifyKeysEncryptedWritePending,
 } from "../../infrastructure/persistence/secureFieldAdapter";
 import { pluginExtensionBridge } from "./pluginExtensionBridge";
 import type { PluginImporterCommitRequest } from "./usePluginImporterCommit";
@@ -580,6 +581,9 @@ export const useVaultState = () => {
       });
     });
     keysWritePendingRef.current = writePromise;
+    // Stored-key hydration must not read a stale persisted key snapshot over
+    // this new state before its encrypted write lands.
+    notifyKeysEncryptedWritePending(writePromise);
     return writePromise;
   }, []);
 
@@ -623,6 +627,7 @@ export const useVaultState = () => {
       });
     });
     keysWritePendingRef.current = writePromise;
+    notifyKeysEncryptedWritePending(writePromise);
     return newKey;
   }, [keys]);
 

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -1249,6 +1249,68 @@ test("startSSH rejects encrypted stored-key material instead of sending cipherte
   assert.match(authRetryMessage ?? "", /cannot be decrypted/);
 });
 
+test("startSSH does not wait to hydrate unrelated encrypted vault keys", async (t) => {
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  let decryptAttempts = 0;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        credentialsDecrypt: async (value: string) => {
+          decryptAttempts += 1;
+          await new Promise((resolve) => setTimeout(resolve, 50));
+          return value;
+        },
+      },
+    },
+  });
+  t.after(() => {
+    if (previousWindow) Object.defineProperty(globalThis, "window", previousWindow);
+    else delete (globalThis as { window?: unknown }).window;
+  });
+
+  let capturedOptions: Record<string, unknown> | null = null;
+  const terminalBackend = {
+    backendAvailable: () => true,
+    startSSHSession: async (options: Record<string, unknown>) => {
+      capturedOptions = options;
+      return "ssh-session";
+    },
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: noop,
+    resizeSession: noop,
+  };
+  const started = Date.now();
+  const ctx = createStarterContext({
+    host: {
+      id: "host-1",
+      label: "Password host",
+      hostname: "password.example.test",
+      username: "alice",
+      authMethod: "password",
+      password: "secret",
+    },
+    keys: [{
+      id: "unused-key",
+      label: "Foreign key",
+      type: "ED25519",
+      privateKey: ENCRYPTED_CREDENTIAL_PLACEHOLDER,
+      source: "imported",
+      category: "key",
+      created: 1,
+    }],
+    terminalBackend,
+  });
+
+  await createTerminalSessionStarters(ctx as never).startSSH(createTermStub() as never);
+
+  assert.equal(decryptAttempts, 0);
+  assert.equal(capturedOptions?.password, "secret");
+  assert.ok(Date.now() - started < 200);
+});
+
 for (const protocol of ["Mosh", "ET"] as const) {
   test(`${protocol} keeps certificate signing material when the system agent toggle is also enabled`, async () => {
     let capturedOptions: Record<string, unknown> | null = null;

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -1139,6 +1139,116 @@ test("startSSH uses the system agent when a synced vault key cannot be decrypted
   assert.equal(capturedOptions?.privateKey, undefined);
 });
 
+test("startSSH waits for stored-key decrypt before sending private key material", async (t) => {
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  let decryptAttempts = 0;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        credentialsDecrypt: async (value: string) => {
+          decryptAttempts += 1;
+          if (decryptAttempts < 3) return value;
+          return "-----BEGIN OPENSSH PRIVATE KEY-----\nhydrated\n-----END OPENSSH PRIVATE KEY-----";
+        },
+      },
+    },
+  });
+  t.after(() => {
+    if (previousWindow) Object.defineProperty(globalThis, "window", previousWindow);
+    else delete (globalThis as { window?: unknown }).window;
+  });
+
+  let capturedOptions: Record<string, unknown> | null = null;
+  const terminalBackend = {
+    backendAvailable: () => true,
+    startSSHSession: async (options: Record<string, unknown>) => {
+      capturedOptions = options;
+      return "ssh-session";
+    },
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: noop,
+    resizeSession: noop,
+  };
+  const ctx = createStarterContext({
+    host: {
+      id: "host-1",
+      label: "Stored key host",
+      hostname: "key.example.test",
+      username: "alice",
+      authMethod: "key",
+      identityFileId: "key-1",
+    },
+    keys: [{
+      id: "key-1",
+      label: "Imported key",
+      type: "ED25519",
+      privateKey: ENCRYPTED_CREDENTIAL_PLACEHOLDER,
+      source: "imported",
+      category: "key",
+      created: 1,
+    }],
+    terminalBackend,
+  });
+
+  await createTerminalSessionStarters(ctx as never).startSSH(createTermStub() as never);
+
+  assert.ok(decryptAttempts >= 3);
+  assert.equal(
+    capturedOptions?.privateKey,
+    "-----BEGIN OPENSSH PRIVATE KEY-----\nhydrated\n-----END OPENSSH PRIVATE KEY-----",
+  );
+  assert.doesNotMatch(String(capturedOptions?.privateKey ?? ""), /^enc:v1:/);
+});
+
+test("startSSH rejects encrypted stored-key material instead of sending ciphertext", async () => {
+  let capturedOptions: Record<string, unknown> | null = null;
+  let needsAuth = false;
+  let authRetryMessage: string | null = null;
+  const terminalBackend = {
+    backendAvailable: () => true,
+    startSSHSession: async (options: Record<string, unknown>) => {
+      capturedOptions = options;
+      return "ssh-session";
+    },
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: noop,
+    resizeSession: noop,
+  };
+  const ctx = createStarterContext({
+    host: {
+      id: "host-1",
+      label: "Stored key host",
+      hostname: "key.example.test",
+      username: "alice",
+      authMethod: "key",
+      identityFileId: "key-1",
+    },
+    keys: [{
+      id: "key-1",
+      label: "Imported key",
+      type: "ED25519",
+      privateKey: ENCRYPTED_CREDENTIAL_PLACEHOLDER,
+      source: "imported",
+      category: "key",
+      created: 1,
+    }],
+    terminalBackend,
+    setNeedsAuth: (value: boolean) => { needsAuth = value; },
+    setAuthRetryMessage: (value: string | null) => { authRetryMessage = value; },
+  });
+
+  await createTerminalSessionStarters(ctx as never).startSSH(createTermStub() as never);
+
+  assert.equal(capturedOptions, null);
+  assert.equal(needsAuth, true);
+  assert.match(authRetryMessage ?? "", /cannot be decrypted/);
+});
+
 for (const protocol of ["Mosh", "ET"] as const) {
   test(`${protocol} keeps certificate signing material when the system agent toggle is also enabled`, async () => {
     let capturedOptions: Record<string, unknown> | null = null;

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -33,6 +33,7 @@ import { resolveStartupCommand, scheduleStartupCommand } from "./terminalStartup
 import { markPromptLineBreakCommandPending } from "./promptLineBreak";
 import {
   isEncryptedCredentialPlaceholder,
+  needsVaultStoredKeyHydration,
   sanitizeCredentialValue,
 } from "../../../domain/credentials";
 import { resolveBridgeSshAgentAuth, resolveHostAuth } from "../../../domain/sshAuth";
@@ -58,6 +59,13 @@ import {
 import { hasConnectionPassedTcpDial } from "../connectionTimeouts";
 import { resolveHostSshConnectionTimeouts } from "../../../domain/sshConnectionTimeouts";
 import { isPluginHostProtocol, sanitizePluginConnection } from "../../../domain/pluginConnection";
+import { hydrateVaultStoredKeys } from "../../../infrastructure/persistence/secureFieldAdapter";
+
+const hydrateConnectKeysIfNeeded = (sourceKeys: SSHKey[]) => (
+  sourceKeys.some((key) => needsVaultStoredKeyHydration(key))
+    ? hydrateVaultStoredKeys(sourceKeys)
+    : null
+);
 
 const TELNET_SESSION_REPLACED_ERROR = "Telnet session start was replaced";
 const JUMP_HOST_AUTH_FAILED_PREFIX = "Jump host authentication failed";
@@ -249,9 +257,14 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
     }
 
     const pendingAuth = ctx.pendingAuthRef.current;
+    const pendingKeyHydration = hydrateConnectKeysIfNeeded(ctx.keys);
+    const { keys, unreadableKeyIds } = pendingKeyHydration
+      ? await pendingKeyHydration
+      : { keys: ctx.keys, unreadableKeyIds: new Set<string>() };
+    if (pendingKeyHydration && !isCurrentAttempt()) return;
     const resolvedAuth = resolveHostAuth({
       host: ctx.host,
-      keys: ctx.keys,
+      keys,
       identities: ctx.identities,
       override: pendingAuth
         ? {
@@ -269,7 +282,9 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
     const effectivePassword = sanitizeCredentialValue(resolvedAuth.password);
     const effectivePassphrase = sanitizeCredentialValue(resolvedAuth.passphrase);
     const hasEncryptedPrimaryPassword = isEncryptedCredentialPlaceholder(resolvedAuth.password);
-    const hasEncryptedPrimaryKey = isEncryptedCredentialPlaceholder(key?.privateKey);
+    const hasEncryptedPrimaryKey = Boolean(
+      key && (unreadableKeyIds.has(key.id) || isEncryptedCredentialPlaceholder(key.privateKey)),
+    );
 
     const isAuthError = (err: unknown): boolean => {
       if (!(err instanceof Error)) return false;
@@ -337,7 +352,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
     const jumpHosts = ctx.resolvedChainHosts.map<NetcattyJumpHost>((jumpHost, index) => {
       const jumpAuth = resolveHostAuth({
         host: jumpHost,
-        keys: ctx.keys,
+        keys,
         identities: ctx.identities,
       });
       const jumpKey = jumpAuth.key;
@@ -372,6 +387,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
       const hasEncryptedJumpCredential =
         isEncryptedCredentialPlaceholder(rawJumpPassword) ||
         isEncryptedCredentialPlaceholder(rawJumpPrivateKey) ||
+        Boolean(jumpKey && unreadableKeyIds.has(jumpKey.id)) ||
         isEncryptedCredentialPlaceholder(rawJumpPassphrase);
 
       if (hasEncryptedJumpProxyCredential || (
@@ -607,7 +623,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
           requiresMfa: !!ctx.host.requiresMfa,
           port: ctx.host.port || 22,
           password: attempt.password,
-          privateKey: attempt.key?.source === 'reference' ? undefined : sanitizeCredentialValue(attempt.key?.privateKey),
+          privateKey: attempt.key?.source === 'reference' ? undefined : (sanitizeCredentialValue(attempt.key?.privateKey) || undefined),
           certificate: attempt.key?.certificate,
           publicKey: attempt.key?.publicKey,
           keyId: attempt.key?.id,
@@ -1077,9 +1093,14 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
       }
 
       const pendingAuth = ctx.pendingAuthRef.current;
+      const pendingKeyHydration = hydrateConnectKeysIfNeeded(ctx.keys);
+      const { keys, unreadableKeyIds } = pendingKeyHydration
+        ? await pendingKeyHydration
+        : { keys: ctx.keys, unreadableKeyIds: new Set<string>() };
+      if (pendingKeyHydration && !isCurrentAttempt()) return;
       const resolvedAuth = resolveHostAuth({
         host: ctx.host,
-        keys: ctx.keys,
+        keys,
         identities: ctx.identities,
         override: pendingAuth
           ? {
@@ -1096,7 +1117,9 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
       const authMethod = resolvedAuth.authMethod;
       const key = authMethod === "password" ? undefined : resolvedAuth.key;
       const hasEncryptedPrimaryPassword = isEncryptedCredentialPlaceholder(resolvedAuth.password);
-      const hasEncryptedPrimaryKey = isEncryptedCredentialPlaceholder(resolvedAuth.key?.privateKey);
+      const hasEncryptedPrimaryKey = Boolean(
+        key && (unreadableKeyIds.has(key.id) || isEncryptedCredentialPlaceholder(key.privateKey)),
+      );
       const allowsLocalIdentityFallback = !resolvedAuth.keyId;
       const moshReferenceKeyPath = key?.source === 'reference' ? key.filePath : undefined;
       const moshIdentityFilePaths = authMethod === "password"
@@ -1186,7 +1209,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
         authMethod,
         requiresMfa: !!ctx.host.requiresMfa,
         password: effectivePassword,
-        privateKey: (usesSystemAgent && !key?.certificate) || key?.source === 'reference' ? undefined : sanitizeCredentialValue(key?.privateKey),
+        privateKey: (usesSystemAgent && !key?.certificate) || key?.source === 'reference' ? undefined : (sanitizeCredentialValue(key?.privateKey) || undefined),
         certificate: key?.certificate,
         keyId: key?.id,
         passphrase: key && (!usesSystemAgent || Boolean(key.certificate))
@@ -1351,9 +1374,14 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
       }
 
       const pendingAuth = ctx.pendingAuthRef.current;
+      const pendingKeyHydration = hydrateConnectKeysIfNeeded(ctx.keys);
+      const { keys, unreadableKeyIds } = pendingKeyHydration
+        ? await pendingKeyHydration
+        : { keys: ctx.keys, unreadableKeyIds: new Set<string>() };
+      if (pendingKeyHydration && !isCurrentAttempt()) return;
       const resolvedAuth = resolveHostAuth({
         host: ctx.host,
-        keys: ctx.keys,
+        keys,
         identities: ctx.identities,
         override: pendingAuth
           ? {
@@ -1370,7 +1398,9 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
       const authMethod = resolvedAuth.authMethod;
       const key = authMethod === "password" ? undefined : resolvedAuth.key;
       const hasEncryptedPrimaryPassword = isEncryptedCredentialPlaceholder(resolvedAuth.password);
-      const hasEncryptedPrimaryKey = isEncryptedCredentialPlaceholder(resolvedAuth.key?.privateKey);
+      const hasEncryptedPrimaryKey = Boolean(
+        key && (unreadableKeyIds.has(key.id) || isEncryptedCredentialPlaceholder(key.privateKey)),
+      );
       const allowsLocalIdentityFallback = !resolvedAuth.keyId;
       const etReferenceKeyPath = key?.source === 'reference' ? key.filePath : undefined;
       const etIdentityFilePaths = authMethod === "password"
@@ -1410,7 +1440,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
       const jumpHosts = ctx.resolvedChainHosts.map<NetcattyJumpHost>((jumpHost) => {
         const jumpAuth = resolveHostAuth({
           host: jumpHost,
-          keys: ctx.keys,
+          keys,
           identities: ctx.identities,
         });
         const jumpKey = jumpAuth.key;
@@ -1428,6 +1458,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
         const hasEncryptedJumpCredential =
           isEncryptedCredentialPlaceholder(rawJumpPassword) ||
           isEncryptedCredentialPlaceholder(rawJumpPrivateKey) ||
+          Boolean(jumpKey && unreadableKeyIds.has(jumpKey.id)) ||
           isEncryptedCredentialPlaceholder(rawJumpPassphrase);
         const jumpAgentAuth = resolveBridgeSshAgentAuth(jumpHost, jumpKey, jumpAuth.authMethod);
         if (
@@ -1507,7 +1538,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
         hostId: ctx.host.id,
         username: resolvedAuth.username || "root",
         password: effectivePassword,
-        privateKey: (usesSystemAgent && !key?.certificate) || key?.source === 'reference' ? undefined : sanitizeCredentialValue(key?.privateKey),
+        privateKey: (usesSystemAgent && !key?.certificate) || key?.source === 'reference' ? undefined : (sanitizeCredentialValue(key?.privateKey) || undefined),
         certificate: key?.certificate,
         keyId: key?.id,
         passphrase: key && (!usesSystemAgent || Boolean(key.certificate))

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -1,7 +1,7 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
 import type { ProviderValidationIssue } from "@netcatty/plugin-contract";
 import { logger } from "../../../lib/logger";
-import type { Host, SSHKey } from "../../../types";
+import type { Host, Identity, SSHKey } from "../../../types";
 import type { TerminalSessionExitEvent } from "../../../application/state/resolveTerminalSessionExitIntent";
 import { setTerminalBootEpoch } from "../../../domain/terminalBootEpoch";
 import type { TerminalSessionStartersContext } from "./createTerminalSessionStarters.types";
@@ -61,11 +61,44 @@ import { resolveHostSshConnectionTimeouts } from "../../../domain/sshConnectionT
 import { isPluginHostProtocol, sanitizePluginConnection } from "../../../domain/pluginConnection";
 import { hydrateVaultStoredKeys } from "../../../infrastructure/persistence/secureFieldAdapter";
 
-const hydrateConnectKeysIfNeeded = (sourceKeys: SSHKey[]) => (
-  sourceKeys.some((key) => needsVaultStoredKeyHydration(key))
-    ? hydrateVaultStoredKeys(sourceKeys)
-    : null
-);
+const collectConnectKeyIds = (
+  host: Host,
+  jumpHosts: Host[],
+  identities: Identity[] | undefined,
+  pendingAuth: { authMethod?: string; keyId?: string } | null,
+): Set<string> => {
+  const ids = new Set<string>();
+  const addHostKeyId = (
+    candidate: Host,
+    override?: { authMethod?: string; keyId?: string } | null,
+  ) => {
+    const identity = candidate.identityId
+      ? identities?.find((item) => item.id === candidate.identityId)
+      : undefined;
+    const selectedAuthMethod = override?.authMethod || identity?.authMethod || candidate.authMethod;
+    if (selectedAuthMethod === "password") return;
+    const keyId = override?.keyId || identity?.keyId || candidate.identityFileId;
+    if (keyId) ids.add(keyId);
+  };
+  addHostKeyId(host, pendingAuth);
+  for (const jumpHost of jumpHosts) addHostKeyId(jumpHost);
+  return ids;
+};
+
+const hydrateConnectKeysIfNeeded = (
+  sourceKeys: SSHKey[],
+  keyIds: Set<string>,
+) => {
+  const candidates = sourceKeys.filter((key) => keyIds.has(key.id));
+  if (!candidates.some((key) => needsVaultStoredKeyHydration(key))) return null;
+  return hydrateVaultStoredKeys(candidates).then(({ keys: hydrated, unreadableKeyIds }) => {
+    const byId = new Map(hydrated.map((key) => [key.id, key] as const));
+    return {
+      keys: sourceKeys.map((key) => byId.get(key.id) ?? key),
+      unreadableKeyIds,
+    };
+  });
+};
 
 const TELNET_SESSION_REPLACED_ERROR = "Telnet session start was replaced";
 const JUMP_HOST_AUTH_FAILED_PREFIX = "Jump host authentication failed";
@@ -257,7 +290,10 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
     }
 
     const pendingAuth = ctx.pendingAuthRef.current;
-    const pendingKeyHydration = hydrateConnectKeysIfNeeded(ctx.keys);
+    const pendingKeyHydration = hydrateConnectKeysIfNeeded(
+      ctx.keys,
+      collectConnectKeyIds(ctx.host, ctx.resolvedChainHosts, ctx.identities, pendingAuth),
+    );
     const { keys, unreadableKeyIds } = pendingKeyHydration
       ? await pendingKeyHydration
       : { keys: ctx.keys, unreadableKeyIds: new Set<string>() };
@@ -1093,7 +1129,10 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
       }
 
       const pendingAuth = ctx.pendingAuthRef.current;
-      const pendingKeyHydration = hydrateConnectKeysIfNeeded(ctx.keys);
+      const pendingKeyHydration = hydrateConnectKeysIfNeeded(
+        ctx.keys,
+        collectConnectKeyIds(ctx.host, ctx.resolvedChainHosts, ctx.identities, pendingAuth),
+      );
       const { keys, unreadableKeyIds } = pendingKeyHydration
         ? await pendingKeyHydration
         : { keys: ctx.keys, unreadableKeyIds: new Set<string>() };
@@ -1374,7 +1413,10 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
       }
 
       const pendingAuth = ctx.pendingAuthRef.current;
-      const pendingKeyHydration = hydrateConnectKeysIfNeeded(ctx.keys);
+      const pendingKeyHydration = hydrateConnectKeysIfNeeded(
+        ctx.keys,
+        collectConnectKeyIds(ctx.host, ctx.resolvedChainHosts, ctx.identities, pendingAuth),
+      );
       const { keys, unreadableKeyIds } = pendingKeyHydration
         ? await pendingKeyHydration
         : { keys: ctx.keys, unreadableKeyIds: new Set<string>() };

--- a/domain/credentials.test.ts
+++ b/domain/credentials.test.ts
@@ -4,6 +4,8 @@ import {
   findSyncPayloadEncryptedCredentialPaths,
   healPoisonedSecretsForMerge,
   isEncryptedCredentialPlaceholder,
+  isVaultStoredKeySource,
+  needsVaultStoredKeyHydration,
   stripSyncPayloadEncryptedCredentials,
 } from "./credentials.ts";
 import type { SyncPayload } from "./sync.ts";
@@ -71,6 +73,28 @@ test("isEncryptedCredentialPlaceholder detects real Windows DPAPI base64 prefixe
 
 test("isEncryptedCredentialPlaceholder rejects header-only enc:v1 payloads", () => {
   assert.equal(isEncryptedCredentialPlaceholder("enc:v1:djEw"), false);
+});
+
+test("needsVaultStoredKeyHydration waits for imported or generated ciphertext and empty keys", () => {
+  assert.equal(isVaultStoredKeySource("imported"), true);
+  assert.equal(isVaultStoredKeySource("generated"), true);
+  assert.equal(isVaultStoredKeySource("reference"), false);
+  assert.equal(needsVaultStoredKeyHydration({
+    source: "imported",
+    privateKey: ENC,
+  }), true);
+  assert.equal(needsVaultStoredKeyHydration({
+    source: "generated",
+    privateKey: "",
+  }), true);
+  assert.equal(needsVaultStoredKeyHydration({
+    source: "imported",
+    privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----",
+  }), false);
+  assert.equal(needsVaultStoredKeyHydration({
+    source: "reference",
+    privateKey: ENC,
+  }), false);
 });
 
 test("findSyncPayloadEncryptedCredentialPaths reports host and key secrets", () => {

--- a/domain/credentials.ts
+++ b/domain/credentials.ts
@@ -115,6 +115,22 @@ export const sanitizeCredentialValue = (
   return value;
 };
 
+export const isVaultStoredKeySource = (
+  source: string | undefined,
+): source is "imported" | "generated" =>
+  source === "imported" || source === "generated";
+
+/**
+ * Imported/generated keys store private material in the vault. Empty or
+ * still-encrypted privateKey means hydration has not finished (or failed).
+ */
+export const needsVaultStoredKeyHydration = (
+  key?: { source?: string; privateKey?: string } | null,
+): boolean => {
+  if (!key || !isVaultStoredKeySource(key.source)) return false;
+  return !key.privateKey || isEncryptedCredentialPlaceholder(key.privateKey);
+};
+
 /**
  * Scan a sync payload for any fields that still carry device-bound
  * enc:v1: ciphertext.  Returns the dotted paths of offending fields.

--- a/infrastructure/persistence/secureFieldAdapter.test.ts
+++ b/infrastructure/persistence/secureFieldAdapter.test.ts
@@ -4,9 +4,14 @@ import assert from "node:assert/strict";
 import type { SSHKey } from "../../domain/models";
 import { ENCRYPTED_CREDENTIAL_PLACEHOLDER } from "../../domain/credentialsTestFixtures";
 import { STORAGE_KEY_KEYS } from "../config/storageKeys";
+import { isEncryptedCredentialPlaceholder, sanitizeCredentialValue } from "../../domain/credentials";
+import { localStorageAdapter } from "./localStorageAdapter.ts";
 import {
   decryptField,
+  decryptFieldResult,
   decryptKeySecrets,
+  decryptKeys,
+  encryptKeys,
   hydrateStoredKeySecrets,
 } from "./secureFieldAdapter.ts";
 
@@ -72,26 +77,36 @@ function installBridge(
   });
 }
 
-test("decryptField does not echo enc:v1 ciphertext when the credential bridge is missing", async (t) => {
+test("decryptField marks enc:v1 unread without treating it as plaintext when the bridge is missing", async (t) => {
   installBridge(t, undefined);
-  assert.equal(await decryptField(ENCRYPTED_CREDENTIAL_PLACEHOLDER), undefined);
+  const result = await decryptFieldResult(ENCRYPTED_CREDENTIAL_PLACEHOLDER);
+  assert.equal(result.unread, true);
+  assert.equal(result.value, ENCRYPTED_CREDENTIAL_PLACEHOLDER);
+  assert.equal(await decryptField(ENCRYPTED_CREDENTIAL_PLACEHOLDER), ENCRYPTED_CREDENTIAL_PLACEHOLDER);
+  assert.equal(sanitizeCredentialValue(result.value), undefined);
   assert.equal(await decryptField("plain-secret"), "plain-secret");
+  assert.equal((await decryptFieldResult("plain-secret")).unread, false);
 });
 
-test("decryptField does not echo enc:v1 ciphertext when decrypt returns the same value", async (t) => {
+test("decryptField marks enc:v1 unread when decrypt returns the same value", async (t) => {
   installBridge(t, {
     credentialsDecrypt: async (value: string) => value,
   });
-  assert.equal(await decryptField(ENCRYPTED_CREDENTIAL_PLACEHOLDER), undefined);
+  const result = await decryptFieldResult(ENCRYPTED_CREDENTIAL_PLACEHOLDER);
+  assert.equal(result.unread, true);
+  assert.equal(result.value, ENCRYPTED_CREDENTIAL_PLACEHOLDER);
+  assert.equal(sanitizeCredentialValue(result.value), undefined);
 });
 
-test("decryptField does not echo enc:v1 ciphertext when decrypt throws", async (t) => {
+test("decryptField keeps enc:v1 ciphertext when decrypt throws", async (t) => {
   installBridge(t, {
     credentialsDecrypt: async () => {
       throw new Error("safeStorage unavailable");
     },
   });
-  assert.equal(await decryptField(ENCRYPTED_CREDENTIAL_PLACEHOLDER), undefined);
+  const result = await decryptFieldResult(ENCRYPTED_CREDENTIAL_PLACEHOLDER);
+  assert.equal(result.unread, true);
+  assert.equal(result.value, ENCRYPTED_CREDENTIAL_PLACEHOLDER);
 });
 
 test("decryptField returns plaintext once the credential bridge decrypts", async (t) => {
@@ -101,13 +116,29 @@ test("decryptField returns plaintext once the credential bridge decrypts", async
       return PRIVATE_KEY;
     },
   });
+  const result = await decryptFieldResult(ENCRYPTED_CREDENTIAL_PLACEHOLDER);
+  assert.equal(result.unread, false);
+  assert.equal(result.value, PRIVATE_KEY);
   assert.equal(await decryptField(ENCRYPTED_CREDENTIAL_PLACEHOLDER), PRIVATE_KEY);
 });
 
-test("decryptKeySecrets does not keep enc:v1 privateKey material in memory", async (t) => {
+test("decryptKeySecrets keeps enc:v1 privateKey ciphertext until decrypt succeeds", async (t) => {
   installBridge(t, undefined);
   const decrypted = await decryptKeySecrets(storedKey());
-  assert.equal(decrypted.privateKey, "");
+  assert.equal(decrypted.privateKey, ENCRYPTED_CREDENTIAL_PLACEHOLDER);
+  assert.equal(isEncryptedCredentialPlaceholder(decrypted.privateKey), true);
+});
+
+test("failed decrypt does not persist wiping enc:v1 key material", async (t) => {
+  installLocalStorage(t);
+  installBridge(t, undefined);
+  const decrypted = await decryptKeys([storedKey()]);
+  assert.equal(decrypted[0]?.privateKey, ENCRYPTED_CREDENTIAL_PLACEHOLDER);
+  const encrypted = await encryptKeys(decrypted);
+  assert.equal(encrypted[0]?.privateKey, ENCRYPTED_CREDENTIAL_PLACEHOLDER);
+  localStorageAdapter.write(STORAGE_KEY_KEYS, encrypted);
+  const stored = localStorageAdapter.read<SSHKey[]>(STORAGE_KEY_KEYS);
+  assert.equal(stored?.[0]?.privateKey, ENCRYPTED_CREDENTIAL_PLACEHOLDER);
 });
 
 test("hydrateStoredKeySecrets waits until ciphertext decrypts", async (t) => {

--- a/infrastructure/persistence/secureFieldAdapter.test.ts
+++ b/infrastructure/persistence/secureFieldAdapter.test.ts
@@ -1,0 +1,159 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { SSHKey } from "../../domain/models";
+import { ENCRYPTED_CREDENTIAL_PLACEHOLDER } from "../../domain/credentialsTestFixtures";
+import { STORAGE_KEY_KEYS } from "../config/storageKeys";
+import {
+  decryptField,
+  decryptKeySecrets,
+  hydrateStoredKeySecrets,
+} from "./secureFieldAdapter.ts";
+
+const PRIVATE_KEY = "-----BEGIN OPENSSH PRIVATE KEY-----\nsecret\n-----END OPENSSH PRIVATE KEY-----";
+
+const storedKey = (overrides: Partial<SSHKey> = {}): SSHKey => ({
+  id: "key-1",
+  label: "Imported",
+  type: "ED25519",
+  privateKey: ENCRYPTED_CREDENTIAL_PLACEHOLDER,
+  source: "imported",
+  category: "key",
+  created: 1,
+  ...overrides,
+});
+
+function installLocalStorage(t: test.TestContext): Map<string, string> {
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  };
+  const previousLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+  t.after(() => {
+    if (previousLocalStorage) Object.defineProperty(globalThis, "localStorage", previousLocalStorage);
+    else delete (globalThis as { localStorage?: Storage }).localStorage;
+  });
+  return store;
+}
+
+function installBridge(
+  t: test.TestContext,
+  netcatty: { credentialsDecrypt?: (value: string) => Promise<string> } | undefined,
+): void {
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { netcatty },
+  });
+  t.after(() => {
+    if (previousWindow) Object.defineProperty(globalThis, "window", previousWindow);
+    else delete (globalThis as { window?: unknown }).window;
+  });
+}
+
+test("decryptField does not echo enc:v1 ciphertext when the credential bridge is missing", async (t) => {
+  installBridge(t, undefined);
+  assert.equal(await decryptField(ENCRYPTED_CREDENTIAL_PLACEHOLDER), undefined);
+  assert.equal(await decryptField("plain-secret"), "plain-secret");
+});
+
+test("decryptField does not echo enc:v1 ciphertext when decrypt returns the same value", async (t) => {
+  installBridge(t, {
+    credentialsDecrypt: async (value: string) => value,
+  });
+  assert.equal(await decryptField(ENCRYPTED_CREDENTIAL_PLACEHOLDER), undefined);
+});
+
+test("decryptField does not echo enc:v1 ciphertext when decrypt throws", async (t) => {
+  installBridge(t, {
+    credentialsDecrypt: async () => {
+      throw new Error("safeStorage unavailable");
+    },
+  });
+  assert.equal(await decryptField(ENCRYPTED_CREDENTIAL_PLACEHOLDER), undefined);
+});
+
+test("decryptField returns plaintext once the credential bridge decrypts", async (t) => {
+  installBridge(t, {
+    credentialsDecrypt: async (value: string) => {
+      assert.equal(value, ENCRYPTED_CREDENTIAL_PLACEHOLDER);
+      return PRIVATE_KEY;
+    },
+  });
+  assert.equal(await decryptField(ENCRYPTED_CREDENTIAL_PLACEHOLDER), PRIVATE_KEY);
+});
+
+test("decryptKeySecrets does not keep enc:v1 privateKey material in memory", async (t) => {
+  installBridge(t, undefined);
+  const decrypted = await decryptKeySecrets(storedKey());
+  assert.equal(decrypted.privateKey, "");
+});
+
+test("hydrateStoredKeySecrets waits until ciphertext decrypts", async (t) => {
+  installLocalStorage(t);
+  let attempts = 0;
+  installBridge(t, {
+    credentialsDecrypt: async (value: string) => {
+      attempts += 1;
+      if (attempts < 3) return value;
+      return PRIVATE_KEY;
+    },
+  });
+  const hydrated = await hydrateStoredKeySecrets(storedKey(), {
+    timeoutMs: 500,
+    retryDelayMs: 10,
+  });
+  assert.equal(hydrated.unreadable, false);
+  assert.equal(hydrated.key.privateKey, PRIVATE_KEY);
+  assert.ok(attempts >= 3);
+});
+
+test("hydrateStoredKeySecrets re-reads storage when in-memory privateKey was stripped", async (t) => {
+  const store = installLocalStorage(t);
+  store.set(STORAGE_KEY_KEYS, JSON.stringify([storedKey()]));
+  installBridge(t, {
+    credentialsDecrypt: async (value: string) => {
+      assert.equal(value, ENCRYPTED_CREDENTIAL_PLACEHOLDER);
+      return PRIVATE_KEY;
+    },
+  });
+  const hydrated = await hydrateStoredKeySecrets(storedKey({ privateKey: "" }), {
+    timeoutMs: 100,
+    retryDelayMs: 10,
+  });
+  assert.equal(hydrated.unreadable, false);
+  assert.equal(hydrated.key.privateKey, PRIVATE_KEY);
+});
+
+test("hydrateStoredKeySecrets does not wait when there is no decrypt bridge", async (t) => {
+  installBridge(t, undefined);
+  const started = Date.now();
+  const hydrated = await hydrateStoredKeySecrets(storedKey(), {
+    timeoutMs: 2000,
+    retryDelayMs: 50,
+  });
+  assert.equal(hydrated.unreadable, true);
+  assert.equal(hydrated.key.privateKey, "");
+  assert.ok(Date.now() - started < 200);
+});

--- a/infrastructure/persistence/secureFieldAdapter.test.ts
+++ b/infrastructure/persistence/secureFieldAdapter.test.ts
@@ -13,6 +13,7 @@ import {
   decryptKeys,
   encryptKeys,
   hydrateStoredKeySecrets,
+  notifyKeysEncryptedWritePending,
 } from "./secureFieldAdapter.ts";
 
 const PRIVATE_KEY = "-----BEGIN OPENSSH PRIVATE KEY-----\nsecret\n-----END OPENSSH PRIVATE KEY-----";
@@ -173,6 +174,78 @@ test("hydrateStoredKeySecrets re-reads storage when in-memory privateKey was str
     timeoutMs: 100,
     retryDelayMs: 10,
   });
+  assert.equal(hydrated.unreadable, false);
+  assert.equal(hydrated.key.privateKey, PRIVATE_KEY);
+});
+
+test("hydrateStoredKeySecrets does not revive a stale persisted key while the vault write is pending", async (t) => {
+  const store = installLocalStorage(t);
+  store.set(
+    STORAGE_KEY_KEYS,
+    JSON.stringify([storedKey({ privateKey: ENCRYPTED_CREDENTIAL_PLACEHOLDER })]),
+  );
+  installBridge(t, {
+    credentialsDecrypt: async (value: string) => {
+      assert.equal(value, ENCRYPTED_CREDENTIAL_PLACEHOLDER);
+      return PRIVATE_KEY;
+    },
+  });
+
+  const keyAfterRecovery = storedKey({ privateKey: "" });
+  let landWrite: () => void = () => {};
+  const pendingWrite = new Promise<void>((resolve) => {
+    landWrite = () => {
+      // A sync/import recovery replaced the key with an empty private key; the
+      // async encrypted write publishes that state when it lands.
+      store.set(STORAGE_KEY_KEYS, JSON.stringify([keyAfterRecovery]));
+      resolve();
+    };
+  });
+  notifyKeysEncryptedWritePending(pendingWrite);
+  t.after(() => notifyKeysEncryptedWritePending(null));
+
+  let hydrationSettled = false;
+  const hydration = hydrateStoredKeySecrets(keyAfterRecovery, {
+    timeoutMs: 2000,
+    retryDelayMs: 10,
+  }).then((result) => {
+    hydrationSettled = true;
+    return result;
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  // Without the gate the stale persisted ciphertext would hydrate immediately.
+  assert.equal(hydrationSettled, false);
+
+  landWrite();
+  const hydrated = await hydration;
+  assert.equal(hydrated.unreadable, false);
+  assert.equal(hydrated.key.privateKey, "");
+  assert.equal(hydrated.key.passphrase, undefined);
+});
+
+test("hydrateStoredKeySecrets hydrates from settled storage after the vault write lands", async (t) => {
+  const store = installLocalStorage(t);
+  installBridge(t, {
+    credentialsDecrypt: async () => PRIVATE_KEY,
+  });
+
+  let landWrite: () => void = () => {};
+  const pendingWrite = new Promise<void>((resolve) => {
+    landWrite = () => {
+      store.set(STORAGE_KEY_KEYS, JSON.stringify([storedKey()]));
+      resolve();
+    };
+  });
+  notifyKeysEncryptedWritePending(pendingWrite);
+  t.after(() => notifyKeysEncryptedWritePending(null));
+
+  const hydration = hydrateStoredKeySecrets(storedKey({ privateKey: "" }), {
+    timeoutMs: 2000,
+    retryDelayMs: 10,
+  });
+  landWrite();
+  const hydrated = await hydration;
   assert.equal(hydrated.unreadable, false);
   assert.equal(hydrated.key.privateKey, PRIVATE_KEY);
 });

--- a/infrastructure/persistence/secureFieldAdapter.ts
+++ b/infrastructure/persistence/secureFieldAdapter.ts
@@ -6,9 +6,9 @@
  *
  * The heavy lifting is done by Electron's safeStorage via the credential
  * bridge IPC.  When the bridge is unavailable (web fallback, tests) plaintext
- * values pass through unmodified. Ciphertext (`enc:v1:` placeholders) is never
- * echoed as plaintext — decrypt returns undefined so callers can wait or treat
- * the field as unread.
+ * values pass through unmodified. Ciphertext (`enc:v1:` placeholders) stays
+ * ciphertext when decrypt is not ready or fails — never treat it as usable
+ * plaintext, and never persist empty over recoverable ciphertext.
  */
 
 import type { GroupConfig, Host, Identity, ProxyProfile, SSHKey } from "../../domain/models";
@@ -42,12 +42,22 @@ export async function encryptField(value: string | undefined): Promise<string | 
   return b.credentialsEncrypt(value);
 }
 
-export async function decryptField(value: string | undefined): Promise<string | undefined> {
-  if (!value) return value;
+export type DecryptFieldResult = {
+  value: string | undefined;
+  unread: boolean;
+};
+
+/**
+ * Decrypt a field and distinguish plaintext from unread ciphertext.
+ * When decrypt is missing or fails, `unread` is true and `value` remains the
+ * original `enc:v1:` ciphertext so persistence can keep it.
+ */
+export async function decryptFieldResult(value: string | undefined): Promise<DecryptFieldResult> {
+  if (!value) return { value, unread: false };
   const encrypted = isEncryptedCredentialPlaceholder(value);
   const b = bridge();
   if (!b?.credentialsDecrypt) {
-    return encrypted ? undefined : value;
+    return { value, unread: encrypted };
   }
   try {
     const decrypted = await b.credentialsDecrypt(value);
@@ -59,14 +69,28 @@ export async function decryptField(value: string | undefined): Promise<string | 
         || isEncryptedCredentialPlaceholder(decrypted)
       )
     ) {
-      return undefined;
+      return { value, unread: true };
     }
-    return decrypted;
+    return { value: decrypted, unread: false };
   } catch (err) {
-    if (encrypted) return undefined;
+    if (encrypted) return { value, unread: true };
     throw err;
   }
 }
+
+export async function decryptField(value: string | undefined): Promise<string | undefined> {
+  return (await decryptFieldResult(value)).value;
+}
+
+const persistDecryptedSecret = (
+  original: string | undefined,
+  decrypted: string | undefined,
+): string | undefined => {
+  if (isEncryptedCredentialPlaceholder(original) && !sanitizeCredentialValue(decrypted)) {
+    return original;
+  }
+  return decrypted;
+};
 
 const readStoredSshKey = (id: string): SSHKey | undefined => {
   try {
@@ -118,21 +142,27 @@ export async function hydrateStoredKeySecrets(
       sawCiphertext = true;
     }
 
-    const decryptedPrivate = await decryptField(candidate.privateKey || undefined);
-    const privateKey = sanitizeCredentialValue(decryptedPrivate);
+    const decryptedPrivate = await decryptFieldResult(candidate.privateKey || undefined);
+    const privateKey = decryptedPrivate.unread
+      ? undefined
+      : sanitizeCredentialValue(decryptedPrivate.value);
     if (privateKey) {
       const decryptedPassphrase = candidate.passphrase != null
-        ? await decryptField(candidate.passphrase)
+        ? await decryptFieldResult(candidate.passphrase)
         : undefined;
       return {
         key: {
           ...candidate,
           privateKey,
-          passphrase: sanitizeCredentialValue(decryptedPassphrase) ?? (
-            isEncryptedCredentialPlaceholder(candidate.passphrase)
+          passphrase: decryptedPassphrase && !decryptedPassphrase.unread
+            ? (sanitizeCredentialValue(decryptedPassphrase.value) ?? (
+              isEncryptedCredentialPlaceholder(candidate.passphrase)
+                ? undefined
+                : candidate.passphrase
+            ))
+            : (isEncryptedCredentialPlaceholder(candidate.passphrase)
               ? undefined
-              : candidate.passphrase
-          ),
+              : candidate.passphrase),
         },
         unreadable: false,
       };
@@ -194,10 +224,13 @@ export async function encryptHostSecrets(host: Host): Promise<Host> {
 
 export async function decryptHostSecrets(host: Host): Promise<Host> {
   const out = { ...host };
-  out.password = await decryptField(out.password);
-  out.telnetPassword = await decryptField(out.telnetPassword);
+  out.password = persistDecryptedSecret(out.password, await decryptField(out.password));
+  out.telnetPassword = persistDecryptedSecret(out.telnetPassword, await decryptField(out.telnetPassword));
   if (out.proxyConfig?.password) {
-    out.proxyConfig = { ...out.proxyConfig, password: await decryptField(out.proxyConfig.password) };
+    out.proxyConfig = {
+      ...out.proxyConfig,
+      password: persistDecryptedSecret(out.proxyConfig.password, await decryptField(out.proxyConfig.password)),
+    };
   }
   return out;
 }
@@ -215,8 +248,8 @@ export async function encryptKeySecrets(key: SSHKey): Promise<SSHKey> {
 
 export async function decryptKeySecrets(key: SSHKey): Promise<SSHKey> {
   const out = { ...key };
-  out.passphrase = await decryptField(out.passphrase);
-  out.privateKey = (await decryptField(out.privateKey)) ?? "";
+  out.passphrase = persistDecryptedSecret(out.passphrase, await decryptField(out.passphrase));
+  out.privateKey = persistDecryptedSecret(out.privateKey, await decryptField(out.privateKey)) ?? out.privateKey ?? "";
   return out;
 }
 
@@ -232,7 +265,7 @@ export async function encryptIdentitySecrets(identity: Identity): Promise<Identi
 
 export async function decryptIdentitySecrets(identity: Identity): Promise<Identity> {
   const out = { ...identity };
-  out.password = await decryptField(out.password);
+  out.password = persistDecryptedSecret(out.password, await decryptField(out.password));
   return out;
 }
 
@@ -252,10 +285,13 @@ export async function encryptGroupConfigSecrets(config: GroupConfig): Promise<Gr
 
 export async function decryptGroupConfigSecrets(config: GroupConfig): Promise<GroupConfig> {
   const out = { ...config };
-  out.password = await decryptField(out.password);
-  out.telnetPassword = await decryptField(out.telnetPassword);
+  out.password = persistDecryptedSecret(out.password, await decryptField(out.password));
+  out.telnetPassword = persistDecryptedSecret(out.telnetPassword, await decryptField(out.telnetPassword));
   if (out.proxyConfig?.password) {
-    out.proxyConfig = { ...out.proxyConfig, password: await decryptField(out.proxyConfig.password) };
+    out.proxyConfig = {
+      ...out.proxyConfig,
+      password: persistDecryptedSecret(out.proxyConfig.password, await decryptField(out.proxyConfig.password)),
+    };
   }
   return out;
 }
@@ -280,7 +316,7 @@ export async function encryptProxyProfileSecrets(profile: ProxyProfile): Promise
 
 export async function decryptProxyProfileSecrets(profile: ProxyProfile): Promise<ProxyProfile> {
   const out = { ...profile, config: { ...profile.config } };
-  out.config.password = await decryptField(out.config.password);
+  out.config.password = persistDecryptedSecret(out.config.password, await decryptField(out.config.password));
   return out;
 }
 
@@ -454,8 +490,8 @@ export async function decryptProviderSecrets(conn: ProviderConnection): Promise<
 
   if (out.tokens) {
     const t = { ...out.tokens };
-    t.accessToken = (await decryptField(t.accessToken)) ?? "";
-    t.refreshToken = await decryptField(t.refreshToken);
+    t.accessToken = persistDecryptedSecret(t.accessToken, await decryptField(t.accessToken)) ?? t.accessToken ?? "";
+    t.refreshToken = persistDecryptedSecret(t.refreshToken, await decryptField(t.refreshToken));
     out.tokens = t;
   }
 
@@ -469,23 +505,25 @@ export async function decryptProviderSecrets(conn: ProviderConnection): Promise<
       || providerId === "onedrive";
     if (isBuiltin && typeof out.config === "object" && "authType" in out.config) {
       const c = { ...out.config } as WebDAVConfig;
-      c.password = await decryptField(c.password);
-      c.token = await decryptField(c.token);
+      c.password = persistDecryptedSecret(c.password, await decryptField(c.password));
+      c.token = persistDecryptedSecret(c.token, await decryptField(c.token));
       out.config = c;
     } else if (isBuiltin && typeof out.config === "object" && "secretAccessKey" in out.config) {
       const c = { ...out.config } as S3Config;
-      c.secretAccessKey = (await decryptField(c.secretAccessKey)) ?? "";
-      c.sessionToken = await decryptField(c.sessionToken);
+      c.secretAccessKey = persistDecryptedSecret(c.secretAccessKey, await decryptField(c.secretAccessKey))
+        ?? c.secretAccessKey
+        ?? "";
+      c.sessionToken = persistDecryptedSecret(c.sessionToken, await decryptField(c.sessionToken));
       out.config = c;
     } else if (isPluginConfigEnvelope(out.config) || isLegacyPluginConfigEnvelope(out.config)) {
       const sealed = isPluginConfigEnvelope(out.config)
         ? out.config[PLUGIN_CONFIG_ENVELOPE_KEY]
         : out.config[LEGACY_PLUGIN_CONFIG_ENVELOPE_KEY];
-      const plain = await decryptField(sealed);
-      // plain may be JSON "false"/"0"/'""' — treat empty decrypt as failure only.
-      if (plain != null && plain !== "") {
+      const plain = await decryptFieldResult(sealed);
+      // Unread ciphertext must stay sealed. JSON "false"/"0"/'""' are valid plains.
+      if (!plain.unread && plain.value != null && plain.value !== "") {
         try {
-          out.config = JSON.parse(plain) as ProviderConnection["config"];
+          out.config = JSON.parse(plain.value) as ProviderConnection["config"];
         } catch {
           // leave sealed if corrupt
         }
@@ -494,10 +532,10 @@ export async function decryptProviderSecrets(conn: ProviderConnection): Promise<
   }
 
   if (isPluginCredentialEnvelope(out.credential)) {
-    const plain = await decryptField(out.credential[PLUGIN_CREDENTIAL_ENVELOPE_KEY]);
-    if (plain != null && plain !== "") {
+    const plain = await decryptFieldResult(out.credential[PLUGIN_CREDENTIAL_ENVELOPE_KEY]);
+    if (!plain.unread && plain.value != null && plain.value !== "") {
       try {
-        const parsed = JSON.parse(plain) as {
+        const parsed = JSON.parse(plain.value) as {
           kind?: unknown;
           id?: unknown;
           key?: unknown;

--- a/infrastructure/persistence/secureFieldAdapter.ts
+++ b/infrastructure/persistence/secureFieldAdapter.ts
@@ -5,19 +5,35 @@
  * they are written to (or after they are read from) localStorage.
  *
  * The heavy lifting is done by Electron's safeStorage via the credential
- * bridge IPC.  When the bridge is unavailable (web fallback, tests) every
- * function degrades to a no-op — values pass through unmodified.
+ * bridge IPC.  When the bridge is unavailable (web fallback, tests) plaintext
+ * values pass through unmodified. Ciphertext (`enc:v1:` placeholders) is never
+ * echoed as plaintext — decrypt returns undefined so callers can wait or treat
+ * the field as unread.
  */
 
 import type { GroupConfig, Host, Identity, ProxyProfile, SSHKey } from "../../domain/models";
 import type { ProviderConnection, S3Config, WebDAVConfig } from "../../domain/sync";
+import {
+  isEncryptedCredentialPlaceholder,
+  needsVaultStoredKeyHydration,
+  sanitizeCredentialValue,
+} from "../../domain/credentials";
+import { STORAGE_KEY_KEYS } from "../config/storageKeys";
 import { netcattyBridge } from "../services/netcattyBridge";
+import { localStorageAdapter } from "./localStorageAdapter";
 
 // ---------------------------------------------------------------------------
 // Primitive helpers
 // ---------------------------------------------------------------------------
 
 const bridge = () => netcattyBridge.get();
+
+const STORED_KEY_HYDRATE_RETRY_DELAY_MS = 50;
+const STORED_KEY_HYDRATE_TIMEOUT_MS = 2000;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => {
+  setTimeout(resolve, ms);
+});
 
 export async function encryptField(value: string | undefined): Promise<string | undefined> {
   if (!value) return value;
@@ -28,9 +44,138 @@ export async function encryptField(value: string | undefined): Promise<string | 
 
 export async function decryptField(value: string | undefined): Promise<string | undefined> {
   if (!value) return value;
+  const encrypted = isEncryptedCredentialPlaceholder(value);
   const b = bridge();
-  if (!b?.credentialsDecrypt) return value;
-  return b.credentialsDecrypt(value);
+  if (!b?.credentialsDecrypt) {
+    return encrypted ? undefined : value;
+  }
+  try {
+    const decrypted = await b.credentialsDecrypt(value);
+    if (
+      encrypted
+      && (
+        !decrypted
+        || decrypted === value
+        || isEncryptedCredentialPlaceholder(decrypted)
+      )
+    ) {
+      return undefined;
+    }
+    return decrypted;
+  } catch (err) {
+    if (encrypted) return undefined;
+    throw err;
+  }
+}
+
+const readStoredSshKey = (id: string): SSHKey | undefined => {
+  try {
+    const stored = localStorageAdapter.read<SSHKey[]>(STORAGE_KEY_KEYS);
+    if (!Array.isArray(stored)) return undefined;
+    return stored.find((key) => key?.id === id);
+  } catch {
+    return undefined;
+  }
+};
+
+export type HydratedStoredKey = {
+  key: SSHKey;
+  unreadable: boolean;
+};
+
+/**
+ * Retry decrypt for vault-stored (imported/generated) private keys instead of
+ * treating enc:v1: ciphertext as key material. Re-reads the encrypted snapshot
+ * from storage when in-memory privateKey was already stripped.
+ */
+export async function hydrateStoredKeySecrets(
+  key: SSHKey,
+  options?: { timeoutMs?: number; retryDelayMs?: number },
+): Promise<HydratedStoredKey> {
+  if (key.source === "reference" || !needsVaultStoredKeyHydration(key)) {
+    return { key, unreadable: false };
+  }
+
+  const timeoutMs = options?.timeoutMs ?? STORED_KEY_HYDRATE_TIMEOUT_MS;
+  const retryDelayMs = options?.retryDelayMs ?? STORED_KEY_HYDRATE_RETRY_DELAY_MS;
+  const startedAt = Date.now();
+  let candidate = key;
+  let sawCiphertext = isEncryptedCredentialPlaceholder(candidate.privateKey);
+
+  while (true) {
+    if (!candidate.privateKey) {
+      const stored = readStoredSshKey(key.id);
+      if (stored?.privateKey && stored.privateKey !== candidate.privateKey) {
+        candidate = {
+          ...candidate,
+          privateKey: stored.privateKey,
+          passphrase: stored.passphrase ?? candidate.passphrase,
+        };
+      }
+    }
+
+    if (isEncryptedCredentialPlaceholder(candidate.privateKey)) {
+      sawCiphertext = true;
+    }
+
+    const decryptedPrivate = await decryptField(candidate.privateKey || undefined);
+    const privateKey = sanitizeCredentialValue(decryptedPrivate);
+    if (privateKey) {
+      const decryptedPassphrase = candidate.passphrase != null
+        ? await decryptField(candidate.passphrase)
+        : undefined;
+      return {
+        key: {
+          ...candidate,
+          privateKey,
+          passphrase: sanitizeCredentialValue(decryptedPassphrase) ?? (
+            isEncryptedCredentialPlaceholder(candidate.passphrase)
+              ? undefined
+              : candidate.passphrase
+          ),
+        },
+        unreadable: false,
+      };
+    }
+
+    const decryptReady = Boolean(bridge()?.credentialsDecrypt);
+    if (!decryptReady || Date.now() - startedAt >= timeoutMs) {
+      return {
+        key: {
+          ...candidate,
+          privateKey: sanitizeCredentialValue(candidate.privateKey) ?? "",
+          passphrase: isEncryptedCredentialPlaceholder(candidate.passphrase)
+            ? undefined
+            : candidate.passphrase,
+        },
+        unreadable: sawCiphertext,
+      };
+    }
+
+    await sleep(retryDelayMs);
+    const stored = readStoredSshKey(key.id);
+    if (stored?.privateKey) {
+      candidate = {
+        ...candidate,
+        privateKey: stored.privateKey,
+        passphrase: stored.passphrase ?? candidate.passphrase,
+      };
+    }
+  }
+}
+
+export async function hydrateVaultStoredKeys(
+  keys: SSHKey[],
+  options?: { timeoutMs?: number; retryDelayMs?: number },
+): Promise<{ keys: SSHKey[]; unreadableKeyIds: Set<string> }> {
+  const unreadableKeyIds = new Set<string>();
+  const next = await Promise.all(keys.map(async (key) => {
+    if (!needsVaultStoredKeyHydration(key)) return key;
+    const hydrated = await hydrateStoredKeySecrets(key, options);
+    if (hydrated.unreadable) unreadableKeyIds.add(key.id);
+    return hydrated.key;
+  }));
+  return { keys: next, unreadableKeyIds };
 }
 
 // ---------------------------------------------------------------------------

--- a/infrastructure/persistence/secureFieldAdapter.ts
+++ b/infrastructure/persistence/secureFieldAdapter.ts
@@ -35,6 +35,52 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => {
   setTimeout(resolve, ms);
 });
 
+// ---------------------------------------------------------------------------
+// Keys write gate
+//
+// `useVaultState.updateKeys` / `importOrReuseKey` publish key state
+// synchronously and write the encrypted snapshot to storage asynchronously.
+// A connection started in that window must not hydrate from a stale
+// localStorage entry — e.g. a sync/import recovery that cleared a private key
+// would otherwise be undone by the previous persisted snapshot. The writer
+// announces its in-flight write here; stored-key hydration awaits it before
+// re-reading storage.
+// ---------------------------------------------------------------------------
+
+let keysEncryptedWritePending: Promise<unknown> | null = null;
+
+/**
+ * Record the in-flight encrypted keys storage write so `hydrateStoredKeySecrets`
+ * cannot read an older persisted snapshot over newer application state.
+ * Called by the vault writer; failures of the tracked write are ignored here.
+ */
+export const notifyKeysEncryptedWritePending = (pending: Promise<unknown> | null): void => {
+  keysEncryptedWritePending = pending ?? null;
+};
+
+/**
+ * Drain any announced keys write. Returns true when at least one in-flight
+ * write was observed and has settled, which means the stored keys snapshot now
+ * reflects the current application state. If another write raced in while
+ * draining, it is awaited as well.
+ */
+const awaitKeysEncryptedWrite = async (): Promise<boolean> => {
+  let pending = keysEncryptedWritePending;
+  while (pending) {
+    try {
+      await pending;
+    } catch {
+      // A failed write leaves storage unchanged; proceed with what is there.
+    }
+    if (keysEncryptedWritePending !== pending) {
+      pending = keysEncryptedWritePending;
+      continue;
+    }
+    return true;
+  }
+  return false;
+};
+
 export async function encryptField(value: string | undefined): Promise<string | undefined> {
   if (!value) return value;
   const b = bridge();
@@ -128,12 +174,32 @@ export async function hydrateStoredKeySecrets(
 
   while (true) {
     if (!candidate.privateKey) {
+      // Coordinate with the vault writer: application state may have just
+      // cleared or replaced this key before its encrypted write landed in
+      // storage. Never overwrite the current state value with an older
+      // persisted snapshot.
+      const writerSettled = await awaitKeysEncryptedWrite();
       const stored = readStoredSshKey(key.id);
       if (stored?.privateKey && stored.privateKey !== candidate.privateKey) {
         candidate = {
           ...candidate,
           privateKey: stored.privateKey,
           passphrase: stored.passphrase ?? candidate.passphrase,
+        };
+      } else if (writerSettled) {
+        // The settled writer's storage has no private key either — the
+        // credential was deliberately cleared upstream (sync / import
+        // recovery). Return empty immediately instead of spinning until the
+        // timeout so the removal stays authoritative.
+        return {
+          key: {
+            ...candidate,
+            privateKey: "",
+            passphrase: isEncryptedCredentialPlaceholder(candidate.passphrase)
+              ? undefined
+              : candidate.passphrase,
+          },
+          unreadable: sawCiphertext,
         };
       }
     }
@@ -183,7 +249,23 @@ export async function hydrateStoredKeySecrets(
     }
 
     await sleep(retryDelayMs);
+    const writerSettled = await awaitKeysEncryptedWrite();
     const stored = readStoredSshKey(key.id);
+    if (writerSettled && !stored?.privateKey) {
+      // The settled writer's storage has no private key for this id — the
+      // credential was deliberately cleared upstream (sync / import
+      // recovery). Do not keep retrying the previous in-memory snapshot.
+      return {
+        key: {
+          ...candidate,
+          privateKey: "",
+          passphrase: isEncryptedCredentialPlaceholder(candidate.passphrase)
+            ? undefined
+            : candidate.passphrase,
+        },
+        unreadable: sawCiphertext,
+      };
+    }
     if (stored?.privateKey) {
       candidate = {
         ...candidate,


### PR DESCRIPTION
## Summary

Stop reconnecting to vault-stored SSH keys with `enc:v1:` ciphertext when decrypt is still pending. `decryptField` no longer echoes ciphertext as plaintext, and SSH/Mosh/ET wait/retry stored-key hydration before auth.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Fixes #2295

## Changes Made

- `decryptField` returns `undefined` for `enc:v1:` ciphertext when the credential bridge is missing, decrypt throws, or decrypt still returns ciphertext.
- SSH/Mosh/ET wait and retry decrypt for imported/generated keys (including re-reading the encrypted vault snapshot) instead of sending ciphertext or treating empty pending keys as usable material.
- After a failed hydrate, connect still asks for re-entry instead of authenticating with ciphertext.
- Tests cover decryptField not echoing `enc:v1:` and connect wait/reject behavior.

## Screenshots / Demo

N/A (auth race; covered by unit tests)

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Ran:

- `npx eslint` on the touched files
- `node --test --import tsx infrastructure/persistence/secureFieldAdapter.test.ts domain/credentials.test.ts domain/sshAuth.test.ts components/terminal/runtime/createTerminalSessionStarters.test.ts components/terminal/runtime/createTerminalSessionStarters.mosh.test.ts components/terminal/runtime/createTerminalSessionStarters.et.test.ts application/syncPayload.test.ts application/state/defaultKeyPassphrases.test.ts`

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)