### PR TITLE
fix(cli): release password-bearing second-instance argument copies

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1205,12 +1205,13 @@ if (!gotLock) {
     const deepLinkQueueItems = collectSshDeepLinkQueueItems(secondInstanceArgv, {
       includeSchemeUrls: sshDeepLinkEnabled,
     });
-    if (jmsDeepLinkUrls.length > 0 || deepLinkQueueItems.ssh.length > 0 || deepLinkQueueItems.telnet.length > 0) {
-      redactPuttyCommandLinePasswords(secondInstanceArgv);
-      // The regrouped event argv still holds the raw -pw value; scrub it too.
-      if (secondInstanceArgv !== argv) {
-        redactPuttyCommandLinePasswords(argv);
-      }
+    redactPuttyCommandLinePasswords(secondInstanceArgv);
+    if (rawLaunchArgv) {
+      // Parsing and subsequent routing use the independent ordered copy.
+      // Release both consumed transport buffers: Chromium may have moved the
+      // password away from -pw, so adjacency-based redaction is unsafe here.
+      rawLaunchArgv.length = 0;
+      argv.length = 0;
     }
     if (jmsDeepLinkUrls.length > 0) {
       if (jmsDeepLinkEnabled) {
@@ -1238,7 +1239,7 @@ if (!gotLock) {
       } else {
         // Still bring the app forward when Explorer launched us but the path
         // failed validation — silent no-op feels like a broken menu item.
-        console.warn("[Main] Open-terminal-path args present but no valid path resolved:", argv);
+        console.warn("[Main] Open-terminal-path args present but no valid path resolved:", secondInstanceArgv);
         if (!focusMainWindow()) {
           void createAndShowMainWindow().catch((err) => {
             console.error("[Main] Failed to recreate window on open-terminal-path:", err);

--- a/electron/mainSecondInstanceRedaction.test.cjs
+++ b/electron/mainSecondInstanceRedaction.test.cjs
@@ -1,0 +1,84 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const test = require("node:test");
+const vm = require("node:vm");
+const deepLink = require("./deepLink.cjs");
+const { collectOpenTerminalPathArgs } = require("./openTerminalPath.cjs");
+
+function createHarness() {
+  const source = readFileSync(require.resolve("./main.cjs"), "utf8");
+  const start = source.indexOf('app.on("second-instance"');
+  const end = source.indexOf("// Application lifecycle", start);
+  assert.ok(start >= 0 && end > start);
+  let handle;
+  const queued = [];
+  const paths = [];
+  let focusCount = 0;
+  const context = vm.createContext({
+    ...deepLink,
+    app: { on: (_event, handler) => { handle = handler; } },
+    sshDeepLinkEnabled: false,
+    jmsDeepLinkEnabled: false,
+    queueSshDeepLink: (url) => queued.push(url),
+    queueTelnetDeepLink: (url) => queued.push(url),
+    queueJmsDeepLink: (url) => queued.push(url),
+    collectOpenTerminalPathArgs,
+    resolveOpenTerminalPathsFromArgs: (argv, { baseDirectory }) => {
+      paths.push({ argv: Array.from(argv), baseDirectory });
+      return ["/resolved"];
+    },
+    queueResolvedOpenTerminalPaths: (resolved) => paths.push(Array.from(resolved)),
+    focusMainWindow: () => { focusCount += 1; return true; },
+  });
+  vm.runInContext(source.slice(start, end), context);
+  return { handle, queued, paths, focused: () => focusCount };
+}
+
+for (const password of ["secret", "space :/@ password", "-flag-like-password"]) {
+  test(`second-instance transport copies are released without changing the SSH password: ${password}`, () => {
+    const h = createHarness();
+    const eventArgv = ["netcatty", "-ssh", "-P", "-pw", "alice@localhost", "2222", password];
+    const additionalData = { rawLaunchArgv: ["-ssh", "alice@localhost", "-P", "2222", "-pw", password] };
+    h.handle(null, eventArgv, "/working-directory", additionalData);
+    assert.equal(h.queued.length, 1);
+    const url = new URL(h.queued[0]);
+    assert.equal(decodeURIComponent(url.password), password);
+    assert.equal(url.hostname, "localhost");
+    assert.equal(url.port, "2222");
+    assert.equal(eventArgv.length, 0, "discard the consumed, potentially reordered event arguments");
+    assert.equal(additionalData.rawLaunchArgv.length, 0, "discard the consumed forwarding copy");
+  });
+}
+
+test("failed command-line parsing still clears temporary transport copies", () => {
+  const h = createHarness();
+  const eventArgv = ["netcatty", "-raw", "-pw", "localhost", "secret"];
+  const additionalData = { rawLaunchArgv: ["-raw", "localhost", "-pw", "secret"] };
+  h.handle(null, eventArgv, "/working-directory", additionalData);
+  assert.deepEqual(h.queued, []);
+  assert.equal(h.focused(), 1);
+  assert.equal(eventArgv.length, 0);
+  assert.equal(additionalData.rawLaunchArgv.length, 0);
+});
+
+test("legacy second instances without additional data retain ordered-argv support", () => {
+  const h = createHarness();
+  const eventArgv = ["netcatty", "-ssh", "alice@localhost", "-pw", "secret"];
+  h.handle(null, eventArgv, "/working-directory");
+  assert.equal(new URL(h.queued[0]).password, "secret");
+  assert.equal(eventArgv.includes("secret"), false);
+});
+
+test("Explorer launch routing uses the ordered copy after transport cleanup", () => {
+  const h = createHarness();
+  const ordered = ["--open-terminal-path", "relative-folder"];
+  const eventArgv = ["netcatty", ...ordered];
+  const additionalData = { rawLaunchArgv: [...ordered] };
+  h.handle(null, eventArgv, "/working-directory", additionalData);
+  assert.deepEqual(h.paths, [
+    { argv: ["netcatty", ...ordered], baseDirectory: "/working-directory" },
+    ["/resolved"],
+  ]);
+  assert.equal(eventArgv.length, 0);
+  assert.equal(additionalData.rawLaunchArgv.length, 0);
+});


### PR DESCRIPTION
## Summary

Follow up on the late review of #3220: after a warm command-line launch, Chromium's regrouped event arguments and the ordered handoff payload can still retain the plaintext password. Redacting the token next to `-pw` is unreliable once Chromium has moved the password elsewhere.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #3218 and #3220.
Addresses https://github.com/binaricat/Netcatty/pull/3220#discussion_r3891634157.

## Changes Made

- Derive connection requests using an independent ordered argument copy, then redact that working copy.
- Release both consumed transport argument arrays instead of trying to locate the password in Chromium's reordered array.
- Keep Explorer path handling and diagnostic output on the independent ordered copy.
- Add behavioral coverage for ordinary, spaced, and flag-like passwords, invalid input, legacy senders, and Explorer path routing.

## Screenshots / Demo

No visual changes. A real two-process Electron run against a local SSH server verified all of the following:
- With protocol handling disabled, the second command opens a connected terminal in the original window.
- A password containing spaces and URL punctuation reaches SSH authentication unchanged.
- Both consumed argument arrays are empty after the main handler finishes.
- The second process exits successfully, the real host-key dialog is confirmed, and the terminal renders `PR3220_WARM_CONNECTED`.

Validation boundary: run on macOS, not the reporter's Windows installation. The Mac desktop was locked, so the external harness waited for actual window visibility before returning the real first window to the unchanged startup code. This avoids a missing native show notification; it does not mock argument delivery, renderer readiness, or SSH authentication. Locked-desktop cold startup is outside this verification.

## Testing

- [x] I have tested these changes locally — built app launched with real Electron and a local SSH fixture (not the dev server)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`) — not applicable
- [x] No new console errors or warnings in the successful warm-connection run

Additional evidence:
- New regression tests: 5 failures before the fix; all 6 pass after it.
- Electron main-process tests: 438 passed.
- Full suite: 11,001 passed, 13 skipped, 0 failed (Node 26 with the installed Electron distribution path).
- `npm run build` passed.
- Two independent local reviewers returned CLEAN for the scoped change.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation — no public behavior or documentation changes required
- [x] I have not introduced any breaking changes (or I have described them above)
