### PR TITLE
fix(ai): keep resumed terminal chats visible after merge

### DIFF
--- a/components/AIChatSidePanel.mountRetention.test.ts
+++ b/components/AIChatSidePanel.mountRetention.test.ts
@@ -333,7 +333,7 @@ test('AI side panel skips re-render when only the composer draft text changes', 
   assert.equal(aiChatSidePanelPropsAreEqual(prev, next), true);
 });
 
-test('workspace AI panel memo follows visible inherited session, not hidden terminal maps', () => {
+test('workspace AI panel memo follows visible inherited session, not nonmember terminal maps', () => {
   const visibleMemberChat = session({
     id: 'chat-visible',
     scope: { type: 'terminal', targetId: 'terminal-b', hostIds: ['host-b'] },
@@ -364,7 +364,7 @@ test('workspace AI panel memo follows visible inherited session, not hidden term
       },
     ],
     activeSessionIdMap: {
-      'terminal:terminal-a': 'chat-hidden',
+      'terminal:terminal-outside': 'chat-hidden',
       'terminal:terminal-b': 'chat-visible',
     },
     sessions: [visibleMemberChat, hiddenFocusedChat],
@@ -379,4 +379,40 @@ test('workspace AI panel memo follows visible inherited session, not hidden term
     aiChatSidePanelPropsAreEqual(prev, { ...prev, sessions: [streamedVisible, hiddenFocusedChat] }),
     false,
   );
+});
+
+test('merged AI panel displays a member chat resumed from an older terminal', () => {
+  const resumed = session({
+    id: 'resumed-chat',
+    scope: { type: 'terminal', targetId: 'closed-terminal', hostIds: ['host-a'] },
+    messages: [{ id: 'm1', role: 'user', content: 'keep-resumed-conversation', timestamp: 1 }],
+  });
+  const props = baseProps({
+    isVisible: true,
+    scopeType: 'workspace',
+    scopeTargetId: 'merged',
+    focusedSessionId: 'terminal-a',
+    scopeHostIds: ['host-a'],
+    terminalSessions: [{ sessionId: 'terminal-a', hostId: 'host-a', hostname: 'a', label: 'A', connected: true }],
+    sessions: [resumed],
+    activeSessionIdMap: { 'terminal:terminal-a': resumed.id },
+  });
+  const render = (panelProps: AIChatSidePanelProps) => renderToStaticMarkup(
+    React.createElement(I18nProvider, { locale: 'en' },
+      React.createElement(TooltipProvider, null,
+        React.createElement(AIChatSidePanel, panelProps))),
+  );
+  // Check both the first workspace paint and the explicit merge handoff.
+  assert.match(render(props), /keep-resumed-conversation/);
+  assert.match(render({
+    ...props,
+    activeSessionIdMap: { ...props.activeSessionIdMap, 'workspace:merged': resumed.id },
+    panelViewByScope: { 'workspace:merged': { mode: 'session', sessionId: resumed.id } },
+  }), /keep-resumed-conversation/);
+  assert.equal(aiChatSidePanelPropsAreEqual(props, {
+    ...props,
+    sessions: [{ ...resumed, messages: [...resumed.messages, {
+      id: 'm2', role: 'assistant', content: 'continued response', timestamp: 2,
+    }] }],
+  }), false);
 });

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -374,9 +374,10 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
         scopeHostIds,
         activeTerminalSessionIds,
         workspaceMemberTerminalIds,
+        activeSessionIdMap,
       ),
     ),
-    [sessions, scopeType, scopeTargetId, scopeHostIds, activeTerminalSessionIds, workspaceMemberTerminalIds],
+    [sessions, scopeType, scopeTargetId, scopeHostIds, activeTerminalSessionIds, workspaceMemberTerminalIds, activeSessionIdMap],
   );
 
   const explicitPanelView = panelViewByScope[scopeKey];
@@ -1850,6 +1851,7 @@ export function aiChatSidePanelPropsAreEqual(
         props.scopeHostIds,
         activeTerminalSessionIds,
         workspaceMemberTerminalIds,
+        props.activeSessionIdMap,
       ).map((session) => session.id),
     );
     return resolveInheritedAIActiveSessionId({

--- a/components/ai/scopedHistorySessions.test.ts
+++ b/components/ai/scopedHistorySessions.test.ts
@@ -173,3 +173,52 @@ test("terminal scoped history cache has a hard LRU bound", () => {
   }
   assert.ok(_getScopedHistoryCacheSizeForTests(sessions) <= 64);
 });
+
+test("workspace history retains chats resumed by members from older terminals", () => {
+  const resumed = createSession("resumed", {
+    type: "terminal", targetId: "closed-terminal", hostIds: ["host-a"],
+  }, 1);
+  const unrelated = createSession("unrelated", {
+    type: "terminal", targetId: "another-closed-terminal", hostIds: ["host-a"],
+  }, 2);
+  const staleWorkspace = createSession("stale-workspace", {
+    type: "workspace", targetId: "old-workspace",
+  }, 99);
+  const sessions = [staleWorkspace, unrelated, resumed];
+  const members = new Set(["terminal-a", "terminal-b"]);
+  const selected = {
+    "terminal:terminal-a": "resumed",
+    "terminal:terminal-outside": "unrelated",
+  };
+
+  assert.ok(getScopedHistorySessions(
+    sessions, "terminal", "terminal-a", ["host-a"], new Set(["unrelated"]),
+  ).includes(resumed));
+  assert.deepEqual(getScopedHistorySessions(
+    sessions, "workspace", "merged", ["host-a"], new Set(Object.values(selected)),
+    members, selected,
+  ), [resumed, staleWorkspace]);
+  // Returning to A makes the same stored conversation available again.
+  assert.ok(getScopedHistorySessions(
+    sessions, "terminal", "terminal-a", ["host-a"], new Set(["unrelated"]),
+  ).includes(resumed));
+  assert.equal(resumed.scope.targetId, "closed-terminal");
+});
+
+test("workspace history cache tracks member selections but ignores unrelated selections", () => {
+  const sessions = [createSession("resumed", { type: "terminal", targetId: "closed" }, 1)];
+  const members = new Set(["terminal-a"]);
+  const history = (selected: Record<string, string | null>) => getScopedHistorySessions(
+    sessions, "workspace", "merged", undefined, new Set(), members, selected,
+  );
+  const empty = history({});
+  assert.deepEqual(empty, []);
+  const inherited = history({ "terminal:terminal-a": "resumed" });
+  assert.deepEqual(inherited, sessions);
+  assert.equal(history({
+    "terminal:terminal-a": "resumed", "terminal:outside": "other",
+  }), inherited);
+  assert.equal(history({ "terminal:terminal-a": null }), empty);
+  assert.equal(history({ "workspace:unrelated": "resumed" }), empty);
+  assert.equal(_getScopedHistoryCacheSizeForTests(sessions), 2);
+});

--- a/components/ai/scopedHistorySessions.ts
+++ b/components/ai/scopedHistorySessions.ts
@@ -11,6 +11,7 @@ function buildHistoryCacheKey(
   scopeHostIds: string[] | undefined,
   activeTerminalSessionIds: Set<string>,
   workspaceMemberTerminalIds: Set<string> | undefined,
+  workspaceMemberActiveSessionIds: Set<string>,
 ): HistoryCacheKey {
   const hostKey = scopeHostIds ? [...scopeHostIds].sort().join(',') : '';
   const terminalKey = scopeType === 'terminal'
@@ -19,7 +20,8 @@ function buildHistoryCacheKey(
   const memberKey = scopeType === 'workspace' && workspaceMemberTerminalIds
     ? [...workspaceMemberTerminalIds].sort().join(',')
     : '';
-  return `${scopeType}:${scopeTargetId ?? ''}:${hostKey}:${terminalKey}:${memberKey}`;
+  const memberActiveKey = [...workspaceMemberActiveSessionIds].sort().join(',');
+  return `${scopeType}:${scopeTargetId ?? ''}:${hostKey}:${terminalKey}:${memberKey}:${memberActiveKey}`;
 }
 
 export function getScopedHistorySessions(
@@ -29,7 +31,18 @@ export function getScopedHistorySessions(
   scopeHostIds: string[] | undefined,
   activeTerminalSessionIds: Set<string>,
   workspaceMemberTerminalIds?: Set<string>,
+  activeSessionIdMap?: Readonly<Record<string, string | null | undefined>>,
 ): AISession[] {
+  // A member can be continuing history created on an older terminal. Its
+  // selected chat belongs in workspace history even though scope.targetId
+  // still identifies that older terminal. Do not include nonmember selections.
+  const workspaceMemberActiveSessionIds = new Set<string>();
+  if (scopeType === 'workspace' && workspaceMemberTerminalIds && activeSessionIdMap) {
+    for (const terminalId of workspaceMemberTerminalIds) {
+      const sessionId = activeSessionIdMap[`terminal:${terminalId}`];
+      if (sessionId) workspaceMemberActiveSessionIds.add(sessionId);
+    }
+  }
   let scopeCache = historyCache.get(sessions);
   if (!scopeCache) {
     scopeCache = new Map();
@@ -42,6 +55,7 @@ export function getScopedHistorySessions(
     scopeHostIds,
     activeTerminalSessionIds,
     workspaceMemberTerminalIds,
+    workspaceMemberActiveSessionIds,
   );
   const cached = scopeCache.get(cacheKey);
   if (cached) {
@@ -60,6 +74,7 @@ export function getScopedHistorySessions(
         scopeHostIds,
         activeTerminalSessionIds,
         workspaceMemberTerminalIds,
+        workspaceMemberActiveSessionIds,
       ),
     }))
     .filter(({ matchRank }) => matchRank > 0)

--- a/components/ai/sessionScopeMatch.ts
+++ b/components/ai/sessionScopeMatch.ts
@@ -18,15 +18,19 @@ export function getSessionScopeMatchRank(
    * member chats as exact workspace matches keeps history/resume working.
    */
   workspaceMemberTerminalIds?: Set<string>,
+  /** Chats currently selected by workspace members, including resumed history. */
+  workspaceMemberActiveSessionIds?: Set<string>,
 ): number {
   // After a terminal merge the AI panel flips to workspace scope, but chats
-  // created on the member terminals remain terminal-scoped. Rank those as
+  // created or resumed on member terminals remain terminal-scoped. Rank them as
   // exact matches so they stay visible and preferred over stale workspaces.
   if (
     scopeType === "workspace"
     && session.scope.type === "terminal"
-    && session.scope.targetId
-    && workspaceMemberTerminalIds?.has(session.scope.targetId)
+    && (
+      (session.scope.targetId && workspaceMemberTerminalIds?.has(session.scope.targetId))
+      || workspaceMemberActiveSessionIds?.has(session.id)
+    )
   ) {
     return 3;
   }


### PR DESCRIPTION
## Summary

Keep an AI conversation visible when a terminal resumes it from history and is then merged into a workspace.

This is a confirmed reproduction of the disappearance described in #3224, with one important condition: the chat was created on an older terminal and resumed on a current member terminal. The issue has no recording/logs establishing whether the reporter used that condition, so this PR does not claim to explain every possible recurrence or automatically close the report.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #3224. Follow-up to #2851 / #2855.

## Changes Made

- Include AI chats selected by **current workspace member terminals** in workspace history, even when the stored terminal target belongs to a previous connection.
- Preserve existing member-target matching and history ordering; do not widen matching to every chat from the same host or to chats selected by nonmember terminals.
- Include member selections in the history cache key, while retaining cache reuse for unrelated terminal changes.
- Use the same membership inputs for panel rendering and memoized active-chat tracking, so continued responses update the visible chat.
- Add history/cache and rendered-panel regressions. No chat IDs, stored scopes, messages, or external-agent continuation IDs are rewritten by this change.

### Root cause and evidence

The original merge fix is still present, including in v1.1.82. It recognizes member chats through `session.scope.targetId`. Resuming history on terminal A updates A's active selection but keeps the chat's original target. After merging B into A, the workspace history filter therefore rejects the resumed chat. The handoff selects the correct chat ID, but view normalization subsequently treats that ID as absent, demotes the panel to draft, and clears the workspace selection. Without an explicit view, an unrelated old workspace chat can be selected instead. The messages remain stored and become visible again when returning to A.

Discriminating checks: a fresh chat created on A passes; the same selected chat with an older stored terminal target fails. The handoff helper returns the correct ID in both cases. Changing only history membership restores display. Existing 50 scope/handoff tests passed before the fix; three new regressions failed before it and pass after it.

## Screenshots / Demo

Exercised the production `AISidePanelStateRoot` / `AIStateMaintenanceHost` / `AIChatPanelsHost` / `AIChatSidePanel` in a local browser fixture under StrictMode, using synthetic chats and terminal/workspace inputs:

1. Resume **A history conversation** through the real history UI.
2. Merge B into A: before the fix, the message disappears and history contains only an old workspace conversation; after the fix, the same message and selected chat remain.
3. Confirm history reselect, follow-up typing, hide/show, detach/remerge, and merge while the panel is hidden.
4. Confirm explicit **New Chat** still opens a blank draft, and another live terminal's same-host chat does not appear.

This fixture exercises the real AI state maintenance and chat UI, not the full terminal drag gesture, native Windows executable, SSH backend, or a live external-agent request. A fixture hot-update caused a duplicate-createRoot warning; fresh-page interaction did not introduce runtime errors.

## Testing

- [x] Tested locally with the production AI panel in a Vite browser fixture (details above)
- [x] Linting passes (`npm run lint`)
- [ ] All tests pass (`npm test`) — 11,013 passed, 4 failed, 13 skipped. All four failures are unchanged `components/terminal/osc7Setup.test.ts` legacy-shell migration assertions, reproduced on a separate clean `origin/main` checkout at `e8c291373b4402b47a5f49fc895a9469f3c2d865` (37 passed / the same 4 failed). Focused AI suite: 71 passed.
- [x] Production build passes (`npm run build`)
- [x] Generated capability tool specs are unchanged (not applicable)
- [x] Fresh-page browser interaction checked for runtime errors (fixture hot-update caveat above)

Focused command:

```sh
node --test --import tsx components/ai/scopedHistorySessions.test.ts components/AIChatSidePanel.mountRetention.test.ts components/ai/sessionScopeMatch.test.ts domain/aiWorkspaceScopeInherit.test.ts domain/workspaceAiScopeHandoff.test.ts components/ai/aiPanelViewState.test.ts
```

Full test run used Node 24.11.1 after restoring Electron 42.3.3 locally. An initial Node 26 run was interrupted because the missing Electron runtime caused repeated installer attempts; it is not used as product-failure evidence. Build emits existing chunk-size/dynamic-import warnings; lint has no findings.

## Checklist

- [x] My code follows the existing project style
- [x] Relevant behavior and reproduction are documented above and in regression tests
- [x] No breaking changes or storage migration
