### PR TITLE
fix: elevate /root drops after sudo -i

### DIFF
--- a/application/i18n/locales/en/terminal.ts
+++ b/application/i18n/locales/en/terminal.ts
@@ -119,6 +119,7 @@ export const enTerminalMessages: Messages = {
   'terminal.dragDrop.errorMessage': 'Failed to process dropped files',
   'terminal.dragDrop.destinationUnknown': 'Could not determine the current terminal folder. Enable directory tracking, or open SFTP and choose an upload folder first.',
   'terminal.dragDrop.uploadCancelled': 'The upload was cancelled because the terminal connection changed or could not be reused. Drop the files again after reconnecting.',
+  'terminal.dragDrop.needsSudoElevation': 'This folder is not writable as the login user. Enable Sudo elevation in host settings, or go back to your user directory and drop again.',
   'terminal.search.placeholder': 'Search...',
   'terminal.search.noResults': 'No results',
   'terminal.search.prevMatch': 'Previous match (Shift+Enter)',

--- a/application/i18n/locales/es/terminal.ts
+++ b/application/i18n/locales/es/terminal.ts
@@ -119,6 +119,7 @@ export const esTerminalMessages: Messages = {
   'terminal.dragDrop.errorMessage': 'No se pudieron procesar los archivos soltados',
   'terminal.dragDrop.destinationUnknown': 'No se pudo determinar la carpeta actual del terminal. Active el seguimiento de directorios o abra SFTP y elija primero una carpeta de carga.',
   'terminal.dragDrop.uploadCancelled': 'La carga se canceló porque la conexión del terminal cambió o no se pudo reutilizar. Vuelva a soltar los archivos después de reconectar.',
+  'terminal.dragDrop.needsSudoElevation': 'Esta carpeta no es escribible con el usuario de inicio de sesión. Active la elevación Sudo en la configuración del host, o vuelva al directorio de usuario y suelte de nuevo.',
   'terminal.search.placeholder': 'Buscar...',
   'terminal.search.noResults': 'Sin resultados',
   'terminal.search.prevMatch': 'Coincidencia anterior (Shift+Enter)',

--- a/application/i18n/locales/ru/terminal.ts
+++ b/application/i18n/locales/ru/terminal.ts
@@ -140,6 +140,7 @@ export const ruTerminalMessages: Messages = {
   'terminal.dragDrop.errorMessage': 'Не удалось обработать перетащенные файлы',
   'terminal.dragDrop.destinationUnknown': 'Не удалось определить текущую папку терминала. Включите отслеживание каталогов или сначала откройте SFTP и выберите папку загрузки.',
   'terminal.dragDrop.uploadCancelled': 'Загрузка отменена: соединение терминала изменилось или его не удалось повторно использовать. После переподключения перетащите файлы снова.',
+  'terminal.dragDrop.needsSudoElevation': 'Эта папка недоступна для записи пользователю входа. Включите повышение прав Sudo в настройках хоста или вернитесь в домашний каталог и перетащите файлы снова.',
   'terminal.search.placeholder': 'Поиск...',
   'terminal.search.noResults': 'Ничего не найдено',
   'terminal.search.prevMatch': 'Предыдущее совпадение (Shift+Enter)',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -521,6 +521,7 @@ export const zhCNVaultMessages: Messages = {
   'terminal.dragDrop.errorMessage': '处理拖放文件失败',
   'terminal.dragDrop.destinationUnknown': '无法确定当前终端目录。请启用目录跟踪，或先打开 SFTP 选择上传目录。',
   'terminal.dragDrop.uploadCancelled': '终端连接已变化或无法继续复用，本次上传已取消。请重新连接后再次拖放文件。',
+  'terminal.dragDrop.needsSudoElevation': '当前目录登录用户无法写入。请在主机设置中开启 Sudo 提权，或回到用户目录后再拖放。',
   'terminal.search.placeholder': '搜索…',
   'terminal.search.noResults': '无结果',
   'terminal.search.prevMatch': '上一个匹配 (Shift+Enter)',

--- a/application/i18n/locales/zh-TW/vault.ts
+++ b/application/i18n/locales/zh-TW/vault.ts
@@ -521,6 +521,7 @@ export const zhTWVaultMessages: Messages = {
   'terminal.dragDrop.errorMessage': '處理拖放檔案失敗',
   'terminal.dragDrop.destinationUnknown': '無法確定目前終端目錄。請啟用目錄追蹤，或先開啟 SFTP 選擇上傳目錄。',
   'terminal.dragDrop.uploadCancelled': '終端連線已變更或無法繼續重用，本次上傳已取消。請重新連線後再次拖放檔案。',
+  'terminal.dragDrop.needsSudoElevation': '目前目錄登入使用者無法寫入。請在主機設定中開啟 Sudo 提權，或回到使用者目錄後再拖放。',
   'terminal.search.placeholder': '搜尋…',
   'terminal.search.noResults': '無結果',
   'terminal.search.prevMatch': '上一個相符 (Shift+Enter)',

--- a/application/state/sftp/useSftpConnections.test.ts
+++ b/application/state/sftp/useSftpConnections.test.ts
@@ -747,7 +747,7 @@ test("a reconnecting tab moved to the other pane still schedules recovery", () =
   }), { side: "right", tabId: "tab-a" });
 });
 
-test("automatic reconnect preserves strict source reuse", () => {
+test("automatic reconnect retries the source session then allows a fresh open", () => {
   const pane = {
     id: "tab-a",
     connection: {
@@ -764,6 +764,9 @@ test("automatic reconnect preserves strict source reuse", () => {
   assert.deepEqual(resolveSftpReconnectOptions(pane), {
     tabId: "tab-a",
     sourceSessionId: "ssh-a",
-    requireSourceSessionReuse: true,
   });
+  assert.equal(
+    "requireSourceSessionReuse" in resolveSftpReconnectOptions(pane),
+    false,
+  );
 });

--- a/application/state/sftp/useSftpConnections.ts
+++ b/application/state/sftp/useSftpConnections.ts
@@ -276,15 +276,14 @@ export function resolveSftpReconnectSchedule(params: {
   }
 }
 
+/** Retry the last terminal transport, then fall through to a fresh/sudo open. */
 export function resolveSftpReconnectOptions(
   pane: SftpPane,
 ): SftpConnectOptions {
   const sourceSessionId = pane.connection?.sourceSessionId;
   return {
     tabId: pane.id,
-    ...(sourceSessionId
-      ? { sourceSessionId, requireSourceSessionReuse: true }
-      : undefined),
+    ...(sourceSessionId ? { sourceSessionId } : undefined),
   };
 }
 

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -878,6 +878,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   );
   const sudoAutofillPasswordRef = useRef(resolvedSudoAutofillPassword);
   sudoAutofillPasswordRef.current = resolvedSudoAutofillPassword;
+  const resolvedLoginUsername = useMemo(
+    () => resolveHostAuth({ host, keys, identities }).username,
+    [host, keys, identities],
+  );
   const sudoAutofillCandidatesRef = useRef(resolvedSudoAutofillCandidates);
   sudoAutofillCandidatesRef.current = resolvedSudoAutofillCandidates;
   const [passwordPickerState, setPasswordPickerState] = useState<PasswordPromptPickerState | null>(null);
@@ -3744,6 +3748,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     isDraggingOver,
   } = useTerminalDragDrop({
     host,
+    resolvedLoginUsername,
     resolvedSudoPassword: resolvedSudoAutofillPassword,
     isLocalConnection,
     isNetworkDevice,

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -3744,6 +3744,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     isDraggingOver,
   } = useTerminalDragDrop({
     host,
+    resolvedSudoPassword: resolvedSudoAutofillPassword,
     isLocalConnection,
     isNetworkDevice,
     onOpenSftp,

--- a/components/terminal/hooks/useTerminalDragDrop.ts
+++ b/components/terminal/hooks/useTerminalDragDrop.ts
@@ -27,6 +27,8 @@ import {
 
 interface UseTerminalDragDropOptions {
   host: Host;
+  /** Password already resolved through host auth (host or Keychain identity). */
+  resolvedSudoPassword?: string;
   isLocalConnection: boolean;
   isNetworkDevice?: boolean;
   onOpenSftp?: TerminalProps["onOpenSftp"];
@@ -90,16 +92,22 @@ async function openSftpForTerminalDrop({
   host,
   onOpenSftp,
   resolveSftpInitialPath,
+  resolvedSudoPassword,
   sessionId,
 }: {
   dropEntries: DropEntry[];
   host: Host;
   onOpenSftp: NonNullable<UseTerminalDragDropOptions["onOpenSftp"]>;
   resolveSftpInitialPath: UseTerminalDragDropOptions["resolveSftpInitialPath"];
+  resolvedSudoPassword?: string;
   sessionId: string;
 }): Promise<void> {
   const initialPath = await resolveTerminalDropUploadInitialPath(resolveSftpInitialPath);
-  const uploadHost = resolveTerminalDropSftpHost(host, initialPath);
+  const uploadHost = resolveTerminalDropSftpHost(
+    host,
+    initialPath,
+    resolvedSudoPassword ?? host.password,
+  );
   onOpenSftp(
     uploadHost,
     initialPath,
@@ -186,6 +194,7 @@ export async function handleTerminalDropEntries({
   isNetworkDevice = false,
   onOpenSftp,
   resolveSftpInitialPath,
+  resolvedSudoPassword,
   scrollToBottomAfterProgrammaticInput,
   sessionId,
   sessionRef,
@@ -196,6 +205,7 @@ export async function handleTerminalDropEntries({
 }: Pick<
   UseTerminalDragDropOptions,
   | "host"
+  | "resolvedSudoPassword"
   | "isLocalConnection"
   | "isNetworkDevice"
   | "onOpenSftp"
@@ -242,6 +252,7 @@ export async function handleTerminalDropEntries({
       host,
       onOpenSftp,
       resolveSftpInitialPath,
+      resolvedSudoPassword,
       sessionId,
     });
   } else if (supportsZmodemTerminalDragDrop(host, isNetworkDevice)) {
@@ -296,6 +307,7 @@ export async function handleTerminalDropEntries({
           host,
           onOpenSftp,
           resolveSftpInitialPath,
+          resolvedSudoPassword,
           sessionId,
         });
       }
@@ -306,6 +318,7 @@ export async function handleTerminalDropEntries({
       host,
       onOpenSftp,
       resolveSftpInitialPath,
+      resolvedSudoPassword,
       sessionId,
     });
   }
@@ -313,6 +326,7 @@ export async function handleTerminalDropEntries({
 
 export function useTerminalDragDrop({
   host,
+  resolvedSudoPassword,
   isLocalConnection,
   isNetworkDevice = false,
   onOpenSftp,
@@ -376,6 +390,7 @@ export function useTerminalDragDrop({
       await handleTerminalDropEntries({
         dropEntries,
         host,
+        resolvedSudoPassword,
         isLocalConnection,
         isNetworkDevice,
         onOpenSftp,

--- a/components/terminal/hooks/useTerminalDragDrop.ts
+++ b/components/terminal/hooks/useTerminalDragDrop.ts
@@ -29,6 +29,8 @@ interface UseTerminalDragDropOptions {
   host: Host;
   /** Password already resolved through host auth (host or Keychain identity). */
   resolvedSudoPassword?: string;
+  /** Login username already resolved through host auth (host or Keychain identity). */
+  resolvedLoginUsername?: string;
   isLocalConnection: boolean;
   isNetworkDevice?: boolean;
   onOpenSftp?: TerminalProps["onOpenSftp"];
@@ -92,6 +94,7 @@ async function openSftpForTerminalDrop({
   host,
   onOpenSftp,
   resolveSftpInitialPath,
+  resolvedLoginUsername,
   resolvedSudoPassword,
   sessionId,
 }: {
@@ -99,15 +102,15 @@ async function openSftpForTerminalDrop({
   host: Host;
   onOpenSftp: NonNullable<UseTerminalDragDropOptions["onOpenSftp"]>;
   resolveSftpInitialPath: UseTerminalDragDropOptions["resolveSftpInitialPath"];
+  resolvedLoginUsername?: string;
   resolvedSudoPassword?: string;
   sessionId: string;
 }): Promise<void> {
   const initialPath = await resolveTerminalDropUploadInitialPath(resolveSftpInitialPath);
-  const uploadHost = resolveTerminalDropSftpHost(
-    host,
-    initialPath,
-    resolvedSudoPassword ?? host.password,
-  );
+  const uploadHost = resolveTerminalDropSftpHost(host, initialPath, {
+    password: resolvedSudoPassword ?? host.password,
+    username: resolvedLoginUsername ?? host.username,
+  });
   onOpenSftp(
     uploadHost,
     initialPath,
@@ -194,6 +197,7 @@ export async function handleTerminalDropEntries({
   isNetworkDevice = false,
   onOpenSftp,
   resolveSftpInitialPath,
+  resolvedLoginUsername,
   resolvedSudoPassword,
   scrollToBottomAfterProgrammaticInput,
   sessionId,
@@ -205,6 +209,7 @@ export async function handleTerminalDropEntries({
 }: Pick<
   UseTerminalDragDropOptions,
   | "host"
+  | "resolvedLoginUsername"
   | "resolvedSudoPassword"
   | "isLocalConnection"
   | "isNetworkDevice"
@@ -252,6 +257,7 @@ export async function handleTerminalDropEntries({
       host,
       onOpenSftp,
       resolveSftpInitialPath,
+      resolvedLoginUsername,
       resolvedSudoPassword,
       sessionId,
     });
@@ -307,6 +313,7 @@ export async function handleTerminalDropEntries({
           host,
           onOpenSftp,
           resolveSftpInitialPath,
+          resolvedLoginUsername,
           resolvedSudoPassword,
           sessionId,
         });
@@ -318,6 +325,7 @@ export async function handleTerminalDropEntries({
       host,
       onOpenSftp,
       resolveSftpInitialPath,
+      resolvedLoginUsername,
       resolvedSudoPassword,
       sessionId,
     });
@@ -326,6 +334,7 @@ export async function handleTerminalDropEntries({
 
 export function useTerminalDragDrop({
   host,
+  resolvedLoginUsername,
   resolvedSudoPassword,
   isLocalConnection,
   isNetworkDevice = false,
@@ -390,6 +399,7 @@ export function useTerminalDragDrop({
       await handleTerminalDropEntries({
         dropEntries,
         host,
+        resolvedLoginUsername,
         resolvedSudoPassword,
         isLocalConnection,
         isNetworkDevice,

--- a/components/terminal/hooks/useTerminalDragDrop.ts
+++ b/components/terminal/hooks/useTerminalDragDrop.ts
@@ -15,6 +15,10 @@ import {
 import { extractDropEntries, type DropEntry } from "../../../lib/sftpFileUtils";
 import type { Host, TerminalSession } from "../../../types";
 import { resolveSftpReuseSourceSessionId } from "../../../application/state/terminalConnectionReuse";
+import {
+  resolveTerminalDropSftpHost,
+  TerminalDropNeedsSudoError,
+} from "../../../domain/sftpDropElevation";
 import { toast } from "../../ui/toast";
 import {
   extractRootPathsFromDropEntries,
@@ -72,10 +76,37 @@ export function resolveTerminalDropErrorMessage(
   if (error instanceof ActiveTerminalCwdUnavailableError) {
     return t("terminal.dragDrop.destinationUnknown");
   }
+  if (error instanceof TerminalDropNeedsSudoError) {
+    return t("terminal.dragDrop.needsSudoElevation");
+  }
   if (error instanceof Error && error.message === "No files to upload") {
     return t("terminal.dragDrop.noFiles");
   }
   return t("terminal.dragDrop.errorMessage");
+}
+
+async function openSftpForTerminalDrop({
+  dropEntries,
+  host,
+  onOpenSftp,
+  resolveSftpInitialPath,
+  sessionId,
+}: {
+  dropEntries: DropEntry[];
+  host: Host;
+  onOpenSftp: NonNullable<UseTerminalDragDropOptions["onOpenSftp"]>;
+  resolveSftpInitialPath: UseTerminalDragDropOptions["resolveSftpInitialPath"];
+  sessionId: string;
+}): Promise<void> {
+  const initialPath = await resolveTerminalDropUploadInitialPath(resolveSftpInitialPath);
+  const uploadHost = resolveTerminalDropSftpHost(host, initialPath);
+  onOpenSftp(
+    uploadHost,
+    initialPath,
+    dropEntries,
+    sessionId,
+    resolveSftpReuseSourceSessionId(host, sessionId),
+  );
 }
 
 export async function resolveTerminalDropUploadInitialPath(
@@ -206,14 +237,13 @@ export async function handleTerminalDropEntries({
     && onOpenSftp
     && supportsZmodemDragDropSftpFallback(host)
   ) {
-    const initialPath = await resolveTerminalDropUploadInitialPath(resolveSftpInitialPath);
-    onOpenSftp(
-      host,
-      initialPath,
+    await openSftpForTerminalDrop({
       dropEntries,
+      host,
+      onOpenSftp,
+      resolveSftpInitialPath,
       sessionId,
-      resolveSftpReuseSourceSessionId(host, sessionId),
-    );
+    });
   } else if (supportsZmodemTerminalDragDrop(host, isNetworkDevice)) {
     const files = await buildZmodemDragDropFiles(dropEntries);
     if (files.length === 0) {
@@ -260,24 +290,24 @@ export async function handleTerminalDropEntries({
     const fallbackResult = rzMissingWatcher ? await rzMissingWatcher.promise : "detected";
     if (fallbackResult === "missing" || fallbackResult === "timeout") {
       terminalBackend.cancelZmodem?.(sessionId, { interrupt: fallbackResult === "timeout" });
-      const initialPath = await resolveTerminalDropUploadInitialPath(resolveSftpInitialPath);
-      onOpenSftp?.(
-        host,
-        initialPath,
-        dropEntries,
-        sessionId,
-        resolveSftpReuseSourceSessionId(host, sessionId),
-      );
+      if (onOpenSftp) {
+        await openSftpForTerminalDrop({
+          dropEntries,
+          host,
+          onOpenSftp,
+          resolveSftpInitialPath,
+          sessionId,
+        });
+      }
     }
   } else if (onOpenSftp) {
-    const initialPath = await resolveTerminalDropUploadInitialPath(resolveSftpInitialPath);
-    onOpenSftp(
-      host,
-      initialPath,
+    await openSftpForTerminalDrop({
       dropEntries,
+      host,
+      onOpenSftp,
+      resolveSftpInitialPath,
       sessionId,
-      resolveSftpReuseSourceSessionId(host, sessionId),
-    );
+    });
   }
 }
 

--- a/components/terminal/terminalDragDropCwd.test.ts
+++ b/components/terminal/terminalDragDropCwd.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import type { DropEntry } from "../../lib/sftpFileUtils";
 import type { Host } from "../../types";
+import { TerminalDropNeedsSudoError } from "../../domain/sftpDropElevation";
 import {
   ActiveTerminalCwdUnavailableError,
   DEFAULT_RZ_MISSING_FALLBACK_TIMEOUT_MS,
@@ -44,6 +45,20 @@ test("terminal drag-drop shows actionable guidance when the active directory is 
 
   assert.equal(message, "translated:terminal.dragDrop.destinationUnknown");
   assert.deepEqual(requestedKeys, ["terminal.dragDrop.destinationUnknown"]);
+});
+
+test("terminal drag-drop asks to enable sudo when /root is not writable as the login user", () => {
+  const requestedKeys: string[] = [];
+  const message = resolveTerminalDropErrorMessage(
+    new TerminalDropNeedsSudoError(),
+    (key) => {
+      requestedKeys.push(key);
+      return `translated:${key}`;
+    },
+  );
+
+  assert.equal(message, "translated:terminal.dragDrop.needsSudoElevation");
+  assert.deepEqual(requestedKeys, ["terminal.dragDrop.needsSudoElevation"]);
 });
 
 test("remote SSH terminal drop triggers ZMODEM drag-drop upload", async () => {
@@ -520,6 +535,77 @@ test("ET rz fallback keeps its origin but opens a fresh SFTP route", async () =>
 
   assert.equal(originSessionId, "et-session");
   assert.equal(sourceSessionId, undefined);
+});
+
+test("remote SSH folder drop to /root reuses the saved host password for sudo SFTP", async () => {
+  let openedHost: Host | undefined;
+  let openedPath: string | undefined;
+
+  await handleTerminalDropEntries({
+    dropEntries: [{ file: null, relativePath: "docs", isDirectory: true }],
+    host: { ...host, password: "secret" },
+    isLocalConnection: false,
+    onOpenSftp: (nextHost, initialPath) => {
+      openedHost = nextHost;
+      openedPath = initialPath;
+    },
+    resolveSftpInitialPath: async () => "/root",
+    scrollToBottomAfterProgrammaticInput: () => {},
+    sessionId: "session-1",
+    sessionRef: { current: "session-1" },
+    terminalBackend: { writeToSession: () => {} },
+    termRef: { current: null },
+  });
+
+  assert.equal(openedPath, "/root");
+  assert.equal(openedHost?.sftpSudo, true);
+  assert.equal(openedHost?.password, "secret");
+  assert.equal(host.sftpSudo, undefined);
+});
+
+test("remote SSH folder drop to /root fails closed without a saved sudo password", async () => {
+  let openedSftp = false;
+
+  await assert.rejects(
+    handleTerminalDropEntries({
+      dropEntries: [{ file: null, relativePath: "docs", isDirectory: true }],
+      host,
+      isLocalConnection: false,
+      onOpenSftp: () => {
+        openedSftp = true;
+      },
+      resolveSftpInitialPath: async () => "/root",
+      scrollToBottomAfterProgrammaticInput: () => {},
+      sessionId: "session-1",
+      sessionRef: { current: "session-1" },
+      terminalBackend: { writeToSession: () => {} },
+      termRef: { current: null },
+    }),
+    TerminalDropNeedsSudoError,
+  );
+
+  assert.equal(openedSftp, false);
+});
+
+test("remote SSH folder drop to the login home does not enable sudo", async () => {
+  let openedHost: Host | undefined;
+
+  await handleTerminalDropEntries({
+    dropEntries: [{ file: null, relativePath: "docs", isDirectory: true }],
+    host: { ...host, password: "secret" },
+    isLocalConnection: false,
+    onOpenSftp: (nextHost) => {
+      openedHost = nextHost;
+    },
+    resolveSftpInitialPath: async () => "/home/alice",
+    scrollToBottomAfterProgrammaticInput: () => {},
+    sessionId: "session-1",
+    sessionRef: { current: "session-1" },
+    terminalBackend: { writeToSession: () => {} },
+    termRef: { current: null },
+  });
+
+  assert.equal(openedHost?.sftpSudo, undefined);
 });
 
 test("remote SSH folder drop refuses to guess a destination when the active shell cwd is unknown", async () => {

--- a/components/terminal/terminalDragDropCwd.test.ts
+++ b/components/terminal/terminalDragDropCwd.test.ts
@@ -563,6 +563,30 @@ test("remote SSH folder drop to /root reuses the saved host password for sudo SF
   assert.equal(host.sftpSudo, undefined);
 });
 
+test("remote SSH folder drop to /root uses a resolved identity password", async () => {
+  let openedHost: Host | undefined;
+
+  await handleTerminalDropEntries({
+    dropEntries: [{ file: null, relativePath: "docs", isDirectory: true }],
+    host: { ...host, identityId: "id-1" },
+    resolvedSudoPassword: "identity-secret",
+    isLocalConnection: false,
+    onOpenSftp: (nextHost) => {
+      openedHost = nextHost;
+    },
+    resolveSftpInitialPath: async () => "/root",
+    scrollToBottomAfterProgrammaticInput: () => {},
+    sessionId: "session-1",
+    sessionRef: { current: "session-1" },
+    terminalBackend: { writeToSession: () => {} },
+    termRef: { current: null },
+  });
+
+  assert.equal(openedHost?.sftpSudo, true);
+  assert.equal(openedHost?.password, undefined);
+  assert.equal(openedHost?.identityId, "id-1");
+});
+
 test("remote SSH folder drop to /root fails closed without a saved sudo password", async () => {
   let openedSftp = false;
 

--- a/components/terminal/terminalDragDropCwd.test.ts
+++ b/components/terminal/terminalDragDropCwd.test.ts
@@ -563,6 +563,29 @@ test("remote SSH folder drop to /root reuses the saved host password for sudo SF
   assert.equal(host.sftpSudo, undefined);
 });
 
+test("remote SSH folder drop to /root uses a resolved identity username over a stale host username", async () => {
+  let openedHost: Host | undefined;
+
+  await handleTerminalDropEntries({
+    dropEntries: [{ file: null, relativePath: "docs", isDirectory: true }],
+    host: { ...host, username: "root", password: "secret" },
+    resolvedLoginUsername: "alice",
+    resolvedSudoPassword: "secret",
+    isLocalConnection: false,
+    onOpenSftp: (nextHost) => {
+      openedHost = nextHost;
+    },
+    resolveSftpInitialPath: async () => "/root",
+    scrollToBottomAfterProgrammaticInput: () => {},
+    sessionId: "session-1",
+    sessionRef: { current: "session-1" },
+    terminalBackend: { writeToSession: () => {} },
+    termRef: { current: null },
+  });
+
+  assert.equal(openedHost?.sftpSudo, true);
+});
+
 test("remote SSH folder drop to /root uses a resolved identity password", async () => {
   let openedHost: Host | undefined;
 

--- a/domain/sftpDropElevation.test.ts
+++ b/domain/sftpDropElevation.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import type { Host } from "./models";
 import {
   canElevateSftpForTerminalDrop,
-  hostHasUsableSftpSudoPassword,
+  hasUsableSftpSudoPassword,
   normalizePosixAbsolutePath,
   posixPathNeedsLoginUserElevation,
   resolveTerminalDropSftpHost,
@@ -44,31 +44,37 @@ test("posixPathNeedsLoginUserElevation only flags /root for non-root logins", ()
   assert.equal(posixPathNeedsLoginUserElevation("/root", undefined), false);
 });
 
-test("hostHasUsableSftpSudoPassword ignores missing and encrypted placeholders", () => {
-  assert.equal(hostHasUsableSftpSudoPassword({ password: "secret" }), true);
-  assert.equal(hostHasUsableSftpSudoPassword({ password: "" }), false);
-  assert.equal(hostHasUsableSftpSudoPassword({}), false);
-  assert.equal(hostHasUsableSftpSudoPassword({ password: encryptedPassword }), false);
+test("hasUsableSftpSudoPassword ignores missing and encrypted placeholders", () => {
+  assert.equal(hasUsableSftpSudoPassword("secret"), true);
+  assert.equal(hasUsableSftpSudoPassword(""), false);
+  assert.equal(hasUsableSftpSudoPassword(undefined), false);
+  assert.equal(hasUsableSftpSudoPassword(encryptedPassword), false);
 });
 
 test("canElevateSftpForTerminalDrop rejects SCP and missing passwords", () => {
   assert.equal(canElevateSftpForTerminalDrop({ sftpSudo: true }), true);
-  assert.equal(canElevateSftpForTerminalDrop({ password: "secret" }), true);
-  assert.equal(canElevateSftpForTerminalDrop({ sftpFileProtocol: "scp", password: "secret" }), false);
+  assert.equal(canElevateSftpForTerminalDrop({}, "secret"), true);
+  assert.equal(canElevateSftpForTerminalDrop({ sftpFileProtocol: "scp" }, "secret"), false);
   assert.equal(canElevateSftpForTerminalDrop({}), false);
 });
 
 test("resolveTerminalDropSftpHost clones sudo only for unelevated /root drops", () => {
-  const withPassword = { ...host, password: "secret" };
-  const elevated = resolveTerminalDropSftpHost(withPassword, "/root");
+  const elevated = resolveTerminalDropSftpHost(host, "/root", "secret");
   assert.equal(elevated.sftpSudo, true);
-  assert.notEqual(elevated, withPassword);
+  assert.notEqual(elevated, host);
 
   const alreadySudo = { ...host, sftpSudo: true };
   assert.equal(resolveTerminalDropSftpHost(alreadySudo, "/root"), alreadySudo);
 
-  const userHome = { ...host, password: "secret" };
-  assert.equal(resolveTerminalDropSftpHost(userHome, "/home/alice"), userHome);
+  assert.equal(resolveTerminalDropSftpHost(host, "/home/alice", "secret"), host);
+});
+
+test("resolveTerminalDropSftpHost uses a resolved identity password when host.password is empty", () => {
+  const identityHost = { ...host, identityId: "id-1", password: undefined };
+  const elevated = resolveTerminalDropSftpHost(identityHost, "/root", "identity-secret");
+  assert.equal(elevated.sftpSudo, true);
+  assert.equal(elevated.password, undefined);
+  assert.equal(elevated.identityId, "id-1");
 });
 
 test("resolveTerminalDropSftpHost asks the user to enable sudo when no password is saved", () => {
@@ -77,7 +83,7 @@ test("resolveTerminalDropSftpHost asks the user to enable sudo when no password 
     TerminalDropNeedsSudoError,
   );
   assert.throws(
-    () => resolveTerminalDropSftpHost({ ...host, sftpFileProtocol: "scp", password: "secret" }, "/root"),
+    () => resolveTerminalDropSftpHost({ ...host, sftpFileProtocol: "scp" }, "/root", "secret"),
     TerminalDropNeedsSudoError,
   );
 });

--- a/domain/sftpDropElevation.test.ts
+++ b/domain/sftpDropElevation.test.ts
@@ -59,22 +59,40 @@ test("canElevateSftpForTerminalDrop rejects SCP and missing passwords", () => {
 });
 
 test("resolveTerminalDropSftpHost clones sudo only for unelevated /root drops", () => {
-  const elevated = resolveTerminalDropSftpHost(host, "/root", "secret");
+  const elevated = resolveTerminalDropSftpHost(host, "/root", { password: "secret" });
   assert.equal(elevated.sftpSudo, true);
   assert.notEqual(elevated, host);
 
   const alreadySudo = { ...host, sftpSudo: true };
   assert.equal(resolveTerminalDropSftpHost(alreadySudo, "/root"), alreadySudo);
 
-  assert.equal(resolveTerminalDropSftpHost(host, "/home/alice", "secret"), host);
+  assert.equal(resolveTerminalDropSftpHost(host, "/home/alice", { password: "secret" }), host);
 });
 
 test("resolveTerminalDropSftpHost uses a resolved identity password when host.password is empty", () => {
   const identityHost = { ...host, identityId: "id-1", password: undefined };
-  const elevated = resolveTerminalDropSftpHost(identityHost, "/root", "identity-secret");
+  const elevated = resolveTerminalDropSftpHost(identityHost, "/root", { password: "identity-secret" });
   assert.equal(elevated.sftpSudo, true);
   assert.equal(elevated.password, undefined);
   assert.equal(elevated.identityId, "id-1");
+});
+
+test("resolveTerminalDropSftpHost uses the resolved identity username over a stale host username", () => {
+  const staleRootHost = { ...host, username: "root" };
+  const elevated = resolveTerminalDropSftpHost(staleRootHost, "/root", {
+    password: "secret",
+    username: "alice",
+  });
+  assert.equal(elevated.sftpSudo, true);
+
+  const staleAliceHost = { ...host, username: "alice" };
+  assert.equal(
+    resolveTerminalDropSftpHost(staleAliceHost, "/root", {
+      password: "secret",
+      username: "root",
+    }),
+    staleAliceHost,
+  );
 });
 
 test("resolveTerminalDropSftpHost asks the user to enable sudo when no password is saved", () => {
@@ -83,7 +101,7 @@ test("resolveTerminalDropSftpHost asks the user to enable sudo when no password 
     TerminalDropNeedsSudoError,
   );
   assert.throws(
-    () => resolveTerminalDropSftpHost({ ...host, sftpFileProtocol: "scp" }, "/root", "secret"),
+    () => resolveTerminalDropSftpHost({ ...host, sftpFileProtocol: "scp" }, "/root", { password: "secret" }),
     TerminalDropNeedsSudoError,
   );
 });

--- a/domain/sftpDropElevation.test.ts
+++ b/domain/sftpDropElevation.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Host } from "./models";
+import {
+  canElevateSftpForTerminalDrop,
+  hostHasUsableSftpSudoPassword,
+  normalizePosixAbsolutePath,
+  posixPathNeedsLoginUserElevation,
+  resolveTerminalDropSftpHost,
+  TerminalDropNeedsSudoError,
+} from "./sftpDropElevation";
+
+const host = {
+  id: "host-1",
+  label: "Host",
+  hostname: "example.com",
+  port: 22,
+  username: "alice",
+  protocol: "ssh",
+} as Host;
+
+const encryptedPassword = (() => {
+  const blob = Buffer.alloc(19, 0);
+  Buffer.from("v10", "utf8").copy(blob, 0);
+  return `enc:v1:${blob.toString("base64")}`;
+})();
+
+test("normalizePosixAbsolutePath collapses slashes and trailing separators", () => {
+  assert.equal(normalizePosixAbsolutePath("/root/"), "/root");
+  assert.equal(normalizePosixAbsolutePath("/root//bin/"), "/root/bin");
+  assert.equal(normalizePosixAbsolutePath("/"), "/");
+  assert.equal(normalizePosixAbsolutePath("root"), null);
+  assert.equal(normalizePosixAbsolutePath("  "), null);
+});
+
+test("posixPathNeedsLoginUserElevation only flags /root for non-root logins", () => {
+  assert.equal(posixPathNeedsLoginUserElevation("/root", "alice"), true);
+  assert.equal(posixPathNeedsLoginUserElevation("/root/bin", "alice"), true);
+  assert.equal(posixPathNeedsLoginUserElevation("/root/", "alice"), true);
+  assert.equal(posixPathNeedsLoginUserElevation("/home/alice", "alice"), false);
+  assert.equal(posixPathNeedsLoginUserElevation("/tmp", "alice"), false);
+  assert.equal(posixPathNeedsLoginUserElevation("/root", "root"), false);
+  assert.equal(posixPathNeedsLoginUserElevation("/root", "  "), false);
+  assert.equal(posixPathNeedsLoginUserElevation("/root", undefined), false);
+});
+
+test("hostHasUsableSftpSudoPassword ignores missing and encrypted placeholders", () => {
+  assert.equal(hostHasUsableSftpSudoPassword({ password: "secret" }), true);
+  assert.equal(hostHasUsableSftpSudoPassword({ password: "" }), false);
+  assert.equal(hostHasUsableSftpSudoPassword({}), false);
+  assert.equal(hostHasUsableSftpSudoPassword({ password: encryptedPassword }), false);
+});
+
+test("canElevateSftpForTerminalDrop rejects SCP and missing passwords", () => {
+  assert.equal(canElevateSftpForTerminalDrop({ sftpSudo: true }), true);
+  assert.equal(canElevateSftpForTerminalDrop({ password: "secret" }), true);
+  assert.equal(canElevateSftpForTerminalDrop({ sftpFileProtocol: "scp", password: "secret" }), false);
+  assert.equal(canElevateSftpForTerminalDrop({}), false);
+});
+
+test("resolveTerminalDropSftpHost clones sudo only for unelevated /root drops", () => {
+  const withPassword = { ...host, password: "secret" };
+  const elevated = resolveTerminalDropSftpHost(withPassword, "/root");
+  assert.equal(elevated.sftpSudo, true);
+  assert.notEqual(elevated, withPassword);
+
+  const alreadySudo = { ...host, sftpSudo: true };
+  assert.equal(resolveTerminalDropSftpHost(alreadySudo, "/root"), alreadySudo);
+
+  const userHome = { ...host, password: "secret" };
+  assert.equal(resolveTerminalDropSftpHost(userHome, "/home/alice"), userHome);
+});
+
+test("resolveTerminalDropSftpHost asks the user to enable sudo when no password is saved", () => {
+  assert.throws(
+    () => resolveTerminalDropSftpHost(host, "/root"),
+    TerminalDropNeedsSudoError,
+  );
+  assert.throws(
+    () => resolveTerminalDropSftpHost({ ...host, sftpFileProtocol: "scp", password: "secret" }, "/root"),
+    TerminalDropNeedsSudoError,
+  );
+});

--- a/domain/sftpDropElevation.ts
+++ b/domain/sftpDropElevation.ts
@@ -1,0 +1,59 @@
+import type { Host } from "./models";
+import { sanitizeCredentialValue } from "./credentials";
+
+/** Thrown when a drop lands in `/root` but the host has no usable sudo password. */
+export class TerminalDropNeedsSudoError extends Error {
+  constructor() {
+    super("Terminal drop needs saved sudo elevation");
+    this.name = "TerminalDropNeedsSudoError";
+  }
+}
+
+export function normalizePosixAbsolutePath(
+  cwd: string | null | undefined,
+): string | null {
+  if (typeof cwd !== "string") return null;
+  const trimmed = cwd.trim();
+  if (!trimmed.startsWith("/")) return null;
+  const collapsed = trimmed.replace(/\/+/g, "/");
+  if (collapsed === "/") return "/";
+  return collapsed.replace(/\/+$/, "");
+}
+
+export function posixPathNeedsLoginUserElevation(
+  cwd: string | null | undefined,
+  username: string | null | undefined,
+): boolean {
+  const user = username?.trim() ?? "";
+  if (!user || user === "root") return false;
+  const path = normalizePosixAbsolutePath(cwd);
+  if (!path) return false;
+  return path === "/root" || path.startsWith("/root/");
+}
+
+export function hostHasUsableSftpSudoPassword(
+  host: Pick<Host, "password">,
+): boolean {
+  const password = sanitizeCredentialValue(host.password);
+  return typeof password === "string" && password.length > 0;
+}
+
+export function canElevateSftpForTerminalDrop(
+  host: Pick<Host, "sftpSudo" | "sftpFileProtocol" | "password">,
+): boolean {
+  if (host.sftpFileProtocol === "scp") return false;
+  if (host.sftpSudo) return true;
+  return hostHasUsableSftpSudoPassword(host);
+}
+
+export function resolveTerminalDropSftpHost<T extends Host>(
+  host: T,
+  cwd: string,
+): T {
+  if (!posixPathNeedsLoginUserElevation(cwd, host.username)) return host;
+  if (host.sftpSudo) return host;
+  if (!canElevateSftpForTerminalDrop(host)) {
+    throw new TerminalDropNeedsSudoError();
+  }
+  return { ...host, sftpSudo: true };
+}

--- a/domain/sftpDropElevation.ts
+++ b/domain/sftpDropElevation.ts
@@ -50,11 +50,11 @@ export function canElevateSftpForTerminalDrop(
 export function resolveTerminalDropSftpHost<T extends Host>(
   host: T,
   cwd: string,
-  resolvedPassword?: string,
+  resolved?: { password?: string; username?: string },
 ): T {
-  if (!posixPathNeedsLoginUserElevation(cwd, host.username)) return host;
+  if (!posixPathNeedsLoginUserElevation(cwd, resolved?.username ?? host.username)) return host;
   if (host.sftpSudo) return host;
-  if (!canElevateSftpForTerminalDrop(host, resolvedPassword)) {
+  if (!canElevateSftpForTerminalDrop(host, resolved?.password)) {
     throw new TerminalDropNeedsSudoError();
   }
   return { ...host, sftpSudo: true };

--- a/domain/sftpDropElevation.ts
+++ b/domain/sftpDropElevation.ts
@@ -31,28 +31,30 @@ export function posixPathNeedsLoginUserElevation(
   return path === "/root" || path.startsWith("/root/");
 }
 
-export function hostHasUsableSftpSudoPassword(
-  host: Pick<Host, "password">,
+export function hasUsableSftpSudoPassword(
+  password: string | undefined,
 ): boolean {
-  const password = sanitizeCredentialValue(host.password);
-  return typeof password === "string" && password.length > 0;
+  const value = sanitizeCredentialValue(password);
+  return typeof value === "string" && value.length > 0;
 }
 
 export function canElevateSftpForTerminalDrop(
-  host: Pick<Host, "sftpSudo" | "sftpFileProtocol" | "password">,
+  host: Pick<Host, "sftpSudo" | "sftpFileProtocol">,
+  resolvedPassword?: string,
 ): boolean {
   if (host.sftpFileProtocol === "scp") return false;
   if (host.sftpSudo) return true;
-  return hostHasUsableSftpSudoPassword(host);
+  return hasUsableSftpSudoPassword(resolvedPassword);
 }
 
 export function resolveTerminalDropSftpHost<T extends Host>(
   host: T,
   cwd: string,
+  resolvedPassword?: string,
 ): T {
   if (!posixPathNeedsLoginUserElevation(cwd, host.username)) return host;
   if (host.sftpSudo) return host;
-  if (!canElevateSftpForTerminalDrop(host)) {
+  if (!canElevateSftpForTerminalDrop(host, resolvedPassword)) {
     throw new TerminalDropNeedsSudoError();
   }
   return { ...host, sftpSudo: true };


### PR DESCRIPTION
## Summary

Follow-up to #3239. After `sudo -i`, a terminal drop into `/root` now uses the host's already-saved password to open SFTP with sudo. If no usable sudo password is saved, the drop fails with a clear instruction: enable Sudo elevation in host settings, or go back to the user directory and drop again.

Sidebar reconnect after `sudo -i` still tries the originating terminal session, then falls through to a fresh open so a dead channel can re-elevate instead of staying pinned to that session.

This does not guess other unwritable paths, auto-enable sudo for ordinary user directories, or persist the per-drop sudo flag onto the host.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #3237

## Changes Made

- Elevate terminal drops into `/root` (and `/root/...`) with the host's saved password when the login user is not `root`
- Keep the drop on the unelevated host when the confirmed cwd is a normal user path
- Fail closed with `terminal.dragDrop.needsSudoElevation` when `/root` is not writable and no usable sudo password is saved
- Let automatic SFTP reconnect retry the source session, then open fresh/sudo instead of requiring the dead channel

## Screenshots / Demo

Not applicable; this changes drop routing and reconnect behavior without visual chrome. The new error string is:

- EN: "This folder is not writable as the login user. Enable Sudo elevation in host settings, or go back to your user directory and drop again."
- ZH: "当前目录登录用户无法写入。请在主机设置中开启 Sudo 提权，或回到用户目录后再拖放。"

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Additional verification:

- Unit tests cover `/root` elevation, missing-password fail-closed, user-home unelevated drops, and non-strict reconnect options
- Please confirm live Electron: `sudo -i` then drag into `/root`, and the first SFTP sidebar reconnect after `sudo -i` (including a jump-host path if you have one). After those two paths work, #3237 can be closed.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)