### PR TITLE
[Bug] Preserve modified Enter keys in local Windows TUIs

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -82,6 +82,7 @@ import {
   createKittyKeyboardBroadcastHandler,
   flushKittyKeyboardBroadcastReleases,
   registerKittyKeyboardBroadcastHandler,
+  resolveWin32InputLogicalData,
   upsertKittyKeyboardForwardedPress,
   type KittyKeyboardBroadcastInput,
   type KittyKeyboardForwardedPress,
@@ -91,6 +92,7 @@ import { terminalAltKeyOptions } from "./altKeyOptions";
 import { optionArrowWordJumpSequence } from "./optionArrowWordJump";
 import { optionYankLastArgSequence } from "./optionYankLastArg";
 import { watchDevicePixelRatio } from "./rendererDprWatch";
+import { dispatchWin32InputModeEvent } from "./win32InputMode";
 import { shouldDeferWebglUntilVisible } from "./webglRendererPolicy";
 import { createWebglRendererController } from "./webglRendererController";
 import {
@@ -548,6 +550,12 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   const term = new XTerm({
     ...performanceConfig.options,
     ...(windowsPty ? { windowsPty } : {}),
+    // ConPTY asks the frontend for Win32 INPUT_RECORD encoding with DECSET
+    // 9001. Preserve browser key modifiers for native Windows applications
+    // instead of collapsing them into legacy VT bytes.
+    vtExtensions: {
+      win32InputMode: windowsPty?.backend === "conpty",
+    },
     // Override ignoreBracketedPasteMode if user explicitly disables bracketed paste
     ignoreBracketedPasteMode: settings?.disableBracketedPaste ?? performanceConfig.options.ignoreBracketedPasteMode,
     // Rescale glyphs that would visually overlap into the next cell (CJK compliance)
@@ -1099,6 +1107,12 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     data: string,
     options?: {
       source?: "terminal" | "shift-enter" | "kitty";
+      /**
+       * User-facing input represented by a transport-specific wire payload.
+       * `null` means the payload has no text/editing semantics (for example a
+       * Win32 key-up record). The wire `data` is still written unchanged.
+       */
+      logicalData?: string | null;
       /** Skip string broadcast when peers will re-resolve from a key chord. */
       skipBroadcast?: boolean;
       /**
@@ -1117,11 +1131,16 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     // cause the executed command to fail (#3138).
     data = sanitizeTerminalInput(data);
     if (!data) return;
+    const logicalData = options?.logicalData === null
+      ? null
+      : sanitizeTerminalInput(options?.logicalData ?? data);
 
     // Clipboard paste / typed password while assist is open must dismiss the
     // hint first. Otherwise Enter is still hijacked for confirmFill and can
     // append the host session password after the user's pasted secret (#2198).
-    ctx.sudoAutofillRef?.current?.dismissOnUserContentInput(data);
+    if (logicalData) {
+      ctx.sudoAutofillRef?.current?.dismissOnUserContentInput(logicalData);
+    }
 
     const inputSource = options?.source ?? "terminal";
     const id = ctx.sessionRef.current;
@@ -1129,13 +1148,18 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     const sensitive = ctx.passwordPromptActiveRef?.current === true;
     let handledSubmittedInput = false;
     const submittedInput: { text: string; lineEnding: "\r\n" | "\r" | "\n" } | null =
-      inputSource === "shift-enter"
-        ? getShiftEnterSubmittedInput(data)
-        : data === "\r" || data === "\n"
-          ? { text: "", lineEnding: data as "\r" | "\n" }
+      logicalData === null
+        ? null
+        : inputSource === "shift-enter"
+          ? getShiftEnterSubmittedInput(logicalData)
+          : logicalData === "\r" || logicalData === "\n"
+            ? { text: "", lineEnding: logicalData as "\r" | "\n" }
           : null;
     const onBroadcastInput = ctx.onBroadcastInputRef.current;
-    const broadcastDataBeforeSudo = mapTerminalBackspaceInput(data, ctx.host.backspaceBehavior);
+    const broadcastDataBeforeSudo = mapTerminalBackspaceInput(
+      logicalData ?? "",
+      ctx.host.backspaceBehavior,
+    );
     const suppressTerminalBroadcast = inputSource === "terminal" && suppressNextTerminalDataBroadcast;
     if (suppressTerminalBroadcast) suppressNextTerminalDataBroadcast = false;
     // skipBroadcast only suppresses the raw-string fan-out. Peers still receive
@@ -1182,7 +1206,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       !handlingKittyBroadcast &&
       inputSource !== "shift-enter"
     ) {
-      const pastedCommand = getSinglePastedCommand(data);
+      const pastedCommand = logicalData === null ? null : getSinglePastedCommand(logicalData);
       if (pastedCommand) {
         if (ctx.passwordPromptActiveRef) ctx.passwordPromptActiveRef.current = false;
         const recordedCommand = recordTerminalCommandExecution(
@@ -1246,43 +1270,50 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         }
       }
 
-      // Use remapped data so broadcast peers also receive the correct byte
-      const broadcastData = mapTerminalBackspaceInput(dataToWrite, ctx.host.backspaceBehavior);
+      // Use logical data for raw-string broadcast. Transport-specific wire
+      // records are dispatched separately from their normalized key event.
+      const broadcastData = mapTerminalBackspaceInput(
+        logicalData ?? "",
+        ctx.host.backspaceBehavior,
+      );
       if (willBroadcastInput) {
         onBroadcastInput?.(broadcastData, ctx.sessionId);
       }
 
-      if (!shouldSuppressTerminalInputScrollForUserPaste(term, data)) {
-        scrollToBottomAfterInput(data);
+      if (
+        logicalData !== null &&
+        !shouldSuppressTerminalInputScrollForUserPaste(term, logicalData)
+      ) {
+        scrollToBottomAfterInput(logicalData);
       }
 
       // Notify autocomplete of input
-      ctx.onAutocompleteInput?.(data);
+      if (logicalData !== null) ctx.onAutocompleteInput?.(logicalData);
 
-      if (ctx.statusRef.current === "connected") {
+      if (ctx.statusRef.current === "connected" && logicalData !== null) {
         if (handledSubmittedInput || submittedInput) {
           // Command recording and sudo command preparation happen before the
           // input is written so sudo can receive a one-time prompt marker.
-        } else if (data === "\x7f" || data === "\b") {
+        } else if (logicalData === "\x7f" || logicalData === "\b") {
           ctx.commandBufferRef.current = ctx.commandBufferRef.current.slice(0, -1);
           ctx.scriptRecorderRef?.current?.recordBackspace();
-        } else if (data === "\x03") {
+        } else if (logicalData === "\x03") {
           ctx.commandBufferRef.current = "";
           ctx.scriptRecorderRef?.current?.recordClearLine();
           // Hard-abort password assist when Ctrl+C reaches the input path
           // (e.g. broadcast peers) so a later su re-arms cleanly (#2191).
           ctx.sudoAutofillRef?.current?.abort();
-        } else if (data === "\x15") {
+        } else if (logicalData === "\x15") {
           ctx.commandBufferRef.current = "";
           ctx.scriptRecorderRef?.current?.recordClearLine();
-        } else if (data.length === 1 && data.charCodeAt(0) >= 32) {
-          ctx.commandBufferRef.current += data;
-          ctx.scriptRecorderRef?.current?.recordInput(data);
-        } else if (data.length > 1 && !data.startsWith("\x1b")) {
-          ctx.commandBufferRef.current += data;
-          ctx.scriptRecorderRef?.current?.recordInput(data);
+        } else if (logicalData.length === 1 && logicalData.charCodeAt(0) >= 32) {
+          ctx.commandBufferRef.current += logicalData;
+          ctx.scriptRecorderRef?.current?.recordInput(logicalData);
+        } else if (logicalData.length > 1 && !logicalData.startsWith("\x1b")) {
+          ctx.commandBufferRef.current += logicalData;
+          ctx.scriptRecorderRef?.current?.recordInput(logicalData);
         } else {
-          const pastedLine = getSingleBracketedPasteLine(data);
+          const pastedLine = getSingleBracketedPasteLine(logicalData);
           if (pastedLine) {
             ctx.commandBufferRef.current += pastedLine;
             ctx.scriptRecorderRef?.current?.recordInput(pastedLine);
@@ -1296,8 +1327,14 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   let kittyCompositionClearTimer: number | undefined;
   let imeTextInputDeferredKey: string | null = null;
   let imeTextInputDeferredKittyEvent: KittyKeyboardEvent | null = null;
+  let win32InputModePendingEvent: {
+    event: KittyKeyboardEvent;
+    logicalData: string | null;
+  } | null = null;
+  const win32InputModeForwardedKeys = new Map<string, KittyKeyboardForwardedPress>();
   const kittyForwardedKeys = new Map<string, KittyKeyboardForwardedPress>();
   const broadcastForwardedKeys = new Map<string, KittyKeyboardForwardedPress>();
+  const win32BroadcastForwardedKeys = new Map<string, KittyKeyboardForwardedPress>();
   const broadcastEncodedKeys = new Set<string>();
   const broadcastLegacySuppressedKeys = new Set<string>();
   const kittyKeyIdentity = (event: KeyboardEvent): string => event.code || event.key;
@@ -1357,6 +1394,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     if (
       isUnchangedDeferredImeTextInput(deferredKey, text) &&
       deferredKittyEvent &&
+      !term.modes.win32InputMode &&
       kittyKeyboardProtocolEnabled
     ) {
       const pressEvent: KittyKeyboardEvent = {
@@ -1408,6 +1446,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         // on the text path, but still emits a paired :3 release on keyup.
         // Mirror the ordinary keydown handler so that release is not dropped.
         if (
+          !term.modes.win32InputMode &&
           kittyKeyboardProtocolEnabled &&
           shouldTrackKittyKeyRelease(kittyKeyboardMode, pressEvent)
         ) {
@@ -1443,7 +1482,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     // Kitty escape sequences that bypass the handleTerminalInputData guard (#3138).
     const sanitizedText = sanitizeTerminalInput(text);
     if (!sanitizedText) return;
-    const encoded = encodeKittyCompositionText(kittyKeyboardMode, sanitizedText);
+    const encoded = term.modes.win32InputMode
+      ? null
+      : encodeKittyCompositionText(kittyKeyboardMode, sanitizedText);
     if (encoded) {
       handleTerminalInputData(encoded, { source: "kitty" });
     } else {
@@ -1491,6 +1532,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       );
     }
     if (!kittyForwardedKeys.delete(identity)) return false;
+    if (term.modes.win32InputMode) return false;
     const sequence = kittyKeyboardProtocolEnabled
       ? encodeKittyKeyEvent(kittyKeyboardMode, event)
       : null;
@@ -1578,7 +1620,27 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         }
       }
       const identity = kittyKeyIdentity(releaseEvent);
+      const hasForwardedWin32KeyDown = win32InputModeForwardedKeys.delete(identity);
       if (broadcastLegacyDataPending === identity) clearBroadcastLegacyDataPending();
+      if (term.modes.win32InputMode) {
+        // Broadcast peers may still need a paired Kitty release for a keydown
+        // consumed by a Netcatty action (notably the urgent Ctrl+C path).
+        releaseForwardedKittyPress(toKittyKeyboardEvent(releaseEvent));
+        kittyForwardedKeys.delete(identity);
+        // Only let xterm emit a Win32 key-up when its matching keydown was
+        // previously handed to xterm. Netcatty shortcuts, sudo controls and
+        // autocomplete consume their keydown and must not leak an orphaned
+        // native release into the PTY.
+        if (!hasForwardedWin32KeyDown) {
+          win32InputModePendingEvent = null;
+          return false;
+        }
+        win32InputModePendingEvent = {
+          event: toKittyKeyboardEvent(releaseEvent),
+          logicalData: null,
+        };
+        return true;
+      }
       if (releaseForwardedKittyPress(toKittyKeyboardEvent(releaseEvent))) {
         e.preventDefault();
         e.stopPropagation();
@@ -1746,6 +1808,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     }
 
     const kittySequenceForKeyDown =
+      !term.modes.win32InputMode &&
       kittyKeyboardProtocolEnabled
         ? encodeKittyKeyEvent(kittyKeyboardMode, toKittyKeyboardEvent(e))
         : null;
@@ -1805,6 +1868,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         const kittyEvent = toKittyKeyboardEvent(e);
         const identity = kittyKeyIdentity(e);
         if (
+          !term.modes.win32InputMode &&
           kittyKeyboardProtocolEnabled &&
           shouldTrackKittyKeyRelease(kittyKeyboardMode, kittyEvent)
         ) {
@@ -1971,12 +2035,15 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       return false;
     }
 
-    // Before Kitty encoding that collapses Shift+Enter to bare CR/LF (flags=0,
-    // or non-preserving sets like alternate-key / associated-text alone), keep
-    // the configured send-text fallback. Only negotiated preserving modes may
-    // emit CSI-u; alternate-screen activation is not a capability signal.
+    // ConPTY's negotiated Win32 input mode keeps the native modifier and owns
+    // this event. Otherwise, before Kitty encoding that collapses Shift+Enter
+    // to bare CR/LF (flags=0, or non-preserving sets like alternate-key /
+    // associated-text alone), keep the configured send-text fallback. Only
+    // negotiated preserving modes may emit CSI-u; alternate-screen activation
+    // is not a capability signal.
     if (
       shouldSendShiftEnterText(e, ctx.terminalSettingsRef.current) &&
+      !term.modes.win32InputMode &&
       !doesKittyEncodingPreserveShiftEnter(kittySequenceForKeyDown)
     ) {
       const id = ctx.sessionRef.current;
@@ -2080,6 +2147,19 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     }
 
     const normalizedKittyEvent = toKittyKeyboardEvent(e);
+    if (term.modes.win32InputMode) {
+      // The following xterm onData callback carries the lossless record.
+      // Keep its normalized event alongside it for non-Win32 broadcast peers
+      // and for local command/autocomplete bookkeeping.
+      win32InputModePendingEvent = {
+        event: normalizedKittyEvent,
+        logicalData: resolveWin32InputLogicalData(
+          normalizedKittyEvent,
+          term.modes.applicationCursorKeysMode,
+        ),
+      };
+      return true;
+    }
     if (!shouldDeferKittyKeyEvent(normalizedKittyEvent)) {
       const identity = kittyKeyIdentity(e);
       if (
@@ -2179,7 +2259,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       kittyCompositionClearTimer = undefined;
     }
     if (
-      shouldEncodeKittyCompositionText(kittyKeyboardMode) ||
+      (!term.modes.win32InputMode && shouldEncodeKittyCompositionText(kittyKeyboardMode)) ||
       (ctx.isBroadcastEnabledRef.current && ctx.onBroadcastInputRef.current)
     ) {
       kittyCompositionPending = true;
@@ -2198,16 +2278,30 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       kittyCompositionClearTimer = undefined;
     }, 0);
   };
+  const writeWin32InputModeEvent = (
+    event: KittyKeyboardEvent,
+    logicalData: string | null,
+  ) => {
+    const pending = { event, logicalData };
+    win32InputModePendingEvent = pending;
+    dispatchWin32InputModeEvent(term, event);
+    if (win32InputModePendingEvent === pending) {
+      win32InputModePendingEvent = null;
+    }
+  };
   const clearKittyConnectionInputState = () => {
     // Drop deferred IME punctuation on session reset; do not write into the
     // next connection. Focus loss uses clearKittyTransientInputState instead.
     clearImeTextInputDeferral();
     kittyCompositionPending = false;
+    win32InputModePendingEvent = null;
+    win32InputModeForwardedKeys.clear();
     kittyForwardedKeys.clear();
     clearKittyKeyboardBroadcastPairingState(
       broadcastEncodedKeys,
       broadcastLegacySuppressedKeys,
     );
+    win32BroadcastForwardedKeys.clear();
     clearBroadcastLegacyDataPending();
     if (kittyCompositionClearTimer !== undefined) {
       window.clearTimeout(kittyCompositionClearTimer);
@@ -2216,17 +2310,40 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   };
   const clearKittyTransientInputState = () => {
     flushImeTextInputDeferral();
+    if (term.modes.win32InputMode) {
+      // Browsers do not deliver key-up after focus leaves the terminal. Release
+      // every Win32 key that xterm actually handed to ConPTY so native TUI key
+      // state cannot remain stuck after switching tabs or windows.
+      flushKittyKeyboardBroadcastReleases(
+        win32InputModeForwardedKeys,
+        (input) => {
+          if (input.kind === "key") {
+            writeWin32InputModeEvent(input.event, null);
+          }
+        },
+        kittyKeyboardLockState,
+      );
+      kittyForwardedKeys.clear();
+      win32InputModePendingEvent = null;
+    } else {
+      win32InputModeForwardedKeys.clear();
+      flushKittyKeyboardBroadcastReleases(
+        kittyForwardedKeys,
+        (input) => {
+          if (input.kind !== "key" || !kittyKeyboardProtocolEnabled) return;
+          const sequence = encodeKittyKeyEvent(kittyKeyboardMode, input.event);
+          if (sequence) handleTerminalInputData(sequence, { source: "kitty" });
+        },
+        kittyKeyboardLockState,
+      );
+    }
     flushKittyKeyboardBroadcastReleases(
-      kittyForwardedKeys,
-      (input) => {
-        if (input.kind !== "key" || !kittyKeyboardProtocolEnabled) return;
-        const sequence = encodeKittyKeyEvent(kittyKeyboardMode, input.event);
-        if (sequence) handleTerminalInputData(sequence, { source: "kitty" });
-      },
+      broadcastForwardedKeys,
+      broadcastKittyInput,
       kittyKeyboardLockState,
     );
     flushKittyKeyboardBroadcastReleases(
-      broadcastForwardedKeys,
+      win32BroadcastForwardedKeys,
       broadcastKittyInput,
       kittyKeyboardLockState,
     );
@@ -2256,6 +2373,56 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   textarea?.addEventListener("blur", clearKittyTransientInputState);
 
   term.onData((data) => {
+    const win32Input = win32InputModePendingEvent;
+    if (
+      win32Input &&
+      term.modes.win32InputMode &&
+      data.startsWith("\u001b[") &&
+      /^\[\d+;\d+;\d+;[01];\d+;\d+_$/.test(data.slice(1))
+    ) {
+      win32InputModePendingEvent = null;
+      if (win32Input.event.type === "keydown") {
+        upsertKittyKeyboardForwardedPress(
+          win32InputModeForwardedKeys,
+          win32Input.event.code || win32Input.event.key,
+          win32Input.event,
+          [],
+        );
+      }
+      const identity = win32Input.event.code || win32Input.event.key;
+      const broadcastInput: KittyKeyboardBroadcastInput = {
+        kind: "win32",
+        data,
+        event: win32Input.event,
+        fallbackToLegacy: true,
+      };
+      if (win32Input.event.type === "keyup") {
+        const forwardedPress = win32BroadcastForwardedKeys.get(identity);
+        win32BroadcastForwardedKeys.delete(identity);
+        if (forwardedPress) {
+          broadcastKittyInput(
+            broadcastInput,
+            true,
+            forwardedPress.targetSessionIds,
+          );
+        }
+      } else {
+        const forwarded = broadcastKittyInput(broadcastInput);
+        if (forwarded) {
+          upsertKittyKeyboardForwardedPress(
+            win32BroadcastForwardedKeys,
+            identity,
+            win32Input.event,
+            forwarded.targetSessionIds,
+          );
+        }
+      }
+      handleTerminalInputData(data, {
+        logicalData: win32Input.logicalData,
+        skipBroadcast: true,
+      });
+      return;
+    }
     if (kittyCompositionPending && !data.startsWith("\u001b")) {
       kittyCompositionPending = false;
       if (kittyCompositionClearTimer !== undefined) {
@@ -2266,7 +2433,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       // Kitty escape sequences that bypass the handleTerminalInputData guard (#3138).
       const sanitizedData = sanitizeTerminalInput(data);
       if (!sanitizedData) return;
-      const encoded = encodeKittyCompositionText(kittyKeyboardMode, sanitizedData);
+      const encoded = term.modes.win32InputMode
+        ? null
+        : encodeKittyCompositionText(kittyKeyboardMode, sanitizedData);
       if (encoded) {
         handleTerminalInputData(encoded, { source: "kitty" });
       } else {
@@ -2311,6 +2480,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       applicationCursorMode: term.modes.applicationCursorKeysMode,
       encodedKeys: broadcastEncodedKeys,
       legacySuppressedKeys: broadcastLegacySuppressedKeys,
+      win32InputMode: term.modes.win32InputMode,
       shiftEnterSettings: ctx.terminalSettingsRef.current,
     }),
     getSessionId: () => ctx.sessionRef.current,
@@ -2325,7 +2495,13 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       mapTerminalBackspaceInput(data, ctx.host.backspaceBehavior),
       { sensitive: ctx.passwordPromptActiveRef?.current === true },
     ),
-    writeActive: (data) => handleTerminalInputData(data, { source: "kitty" }),
+    writeActive: (data, logicalData) => handleTerminalInputData(data, {
+      source: "kitty",
+      logicalData,
+    }),
+    writeWin32Event: (event, logicalData) => {
+      writeWin32InputModeEvent(event, logicalData);
+    },
   });
   registerKittyKeyboardBroadcastHandler(
     ctx.sessionId,

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -102,7 +102,7 @@ import { handleSerialLineModeInput } from "./serialLineInput";
 import {
   doesKittyEncodingPreserveShiftEnter,
   getShiftEnterSubmittedInput,
-  resolveShiftEnterPayload,
+  resolveShiftEnterText,
   shouldSendShiftEnterText,
 } from "./shiftEnterText";
 import {
@@ -1972,8 +1972,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     }
 
     // Before Kitty encoding that collapses Shift+Enter to bare CR/LF (flags=0,
-    // or non-preserving sets like alternate-key / associated-text alone). Remap
-    // first so alternate-screen TUIs still receive CSI-u Shift+Enter.
+    // or non-preserving sets like alternate-key / associated-text alone), keep
+    // the configured send-text fallback. Only negotiated preserving modes may
+    // emit CSI-u; alternate-screen activation is not a capability signal.
     if (
       shouldSendShiftEnterText(e, ctx.terminalSettingsRef.current) &&
       !doesKittyEncodingPreserveShiftEnter(kittySequenceForKeyDown)
@@ -1983,24 +1984,16 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         e.preventDefault();
         e.stopPropagation();
         const kittyEvent = toKittyKeyboardEvent(e);
-        // Local payload uses this session's buffer. Broadcast targets re-resolve
-        // from the key chord via resolveKittyKeyboardBroadcastInput.
-        const shiftEnterPayload = resolveShiftEnterPayload(
+        const shiftEnterText = resolveShiftEnterText(
           ctx.terminalSettingsRef.current,
-          { alternateScreen: term.buffer.active.type === "alternate" },
         );
-        if (shiftEnterPayload.data) {
-          if (shiftEnterPayload.kind === "key") {
-            // Local CSI-u as kitty-sourced input so raw bytes are not broadcast.
-            handleTerminalInputData(shiftEnterPayload.data, { source: "kitty" });
-          } else {
-            // Skip string broadcast: peers resolve Shift+Enter from their own
-            // buffer + keyboard mode via the key chord below.
-            handleTerminalInputData(shiftEnterPayload.data, {
-              source: "shift-enter",
-              skipBroadcast: true,
-            });
-          }
+        if (shiftEnterText) {
+          // Skip string broadcast: peers resolve Shift+Enter from their own
+          // negotiated keyboard mode via the key chord below.
+          handleTerminalInputData(shiftEnterText, {
+            source: "shift-enter",
+            skipBroadcast: true,
+          });
           const forwarded = broadcastKittyInput({
             kind: "key",
             event: kittyEvent,
@@ -2318,7 +2311,6 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       applicationCursorMode: term.modes.applicationCursorKeysMode,
       encodedKeys: broadcastEncodedKeys,
       legacySuppressedKeys: broadcastLegacySuppressedKeys,
-      alternateScreen: term.buffer.active.type === "alternate",
       shiftEnterSettings: ctx.terminalSettingsRef.current,
     }),
     getSessionId: () => ctx.sessionRef.current,

--- a/components/terminal/runtime/kittyKeyboardBroadcast.test.ts
+++ b/components/terminal/runtime/kittyKeyboardBroadcast.test.ts
@@ -571,6 +571,178 @@ test("Shift+Enter broadcast uses CSI-u only after the target negotiated a preser
   });
 });
 
+test("Win32 input broadcast preserves native records for Win32 targets", () => {
+  const shiftEnterRecord = "\u001b[13;28;13;1;16;1_";
+  const shiftEnter = {
+    kind: "win32" as const,
+    data: shiftEnterRecord,
+    fallbackToLegacy: true,
+    event: {
+      type: "keydown" as const,
+      key: "Enter",
+      code: "Enter",
+      shiftKey: true,
+    },
+  };
+
+  const win32TargetOptions = {
+    kittyProtocolEnabled: false,
+    kittyMode: createKittyKeyboardModeState(),
+    applicationCursorMode: false,
+    encodedKeys: new Set<string>(),
+    win32InputMode: true,
+  };
+  assert.deepEqual(resolveKittyKeyboardBroadcastInput(shiftEnter, win32TargetOptions), {
+    data: shiftEnterRecord,
+    kittyEncoded: false,
+    urgentInterrupt: false,
+    logicalData: null,
+  });
+
+  const normalizedShiftEnter = {
+    kind: "key" as const,
+    fallbackToLegacy: true,
+    event: shiftEnter.event,
+  };
+  const normalizedTargetOptions = {
+    ...win32TargetOptions,
+    encodedKeys: new Set<string>(),
+  };
+  assert.deepEqual(
+    resolveKittyKeyboardBroadcastInput(normalizedShiftEnter, normalizedTargetOptions),
+    {
+      data: "",
+      kittyEncoded: false,
+      urgentInterrupt: false,
+      logicalData: null,
+      win32Event: shiftEnter.event,
+    },
+  );
+
+  const disambiguate = createKittyKeyboardModeState();
+  setKittyKeyboardModeFlags(disambiguate, 0b00001);
+  assert.deepEqual(resolveKittyKeyboardBroadcastInput(shiftEnter, {
+    kittyProtocolEnabled: true,
+    kittyMode: disambiguate,
+    applicationCursorMode: false,
+    encodedKeys: new Set<string>(),
+    win32InputMode: false,
+  }), {
+    data: SHIFT_ENTER_CSI_U_SEQUENCE,
+    kittyEncoded: true,
+    urgentInterrupt: false,
+  });
+});
+
+test("Win32 input keeps plain Enter bookkeeping without misclassifying modified Enter", () => {
+  const options = () => ({
+    kittyProtocolEnabled: false,
+    kittyMode: createKittyKeyboardModeState(),
+    applicationCursorMode: false,
+    encodedKeys: new Set<string>(),
+    win32InputMode: true,
+  });
+  const resolveEnter = (modifiers: Partial<{
+    shiftKey: boolean;
+    altKey: boolean;
+    ctrlKey: boolean;
+    metaKey: boolean;
+  }>) => resolveKittyKeyboardBroadcastInput({
+    kind: "win32",
+    data: "\u001b[13;28;13;1;0;1_",
+    event: {
+      type: "keydown",
+      key: "Enter",
+      code: "Enter",
+      ...modifiers,
+    },
+  }, options())?.logicalData;
+
+  assert.equal(resolveEnter({}), "\r");
+  assert.equal(resolveEnter({ shiftKey: true }), null);
+  assert.equal(resolveEnter({ ctrlKey: true }), null);
+  assert.equal(resolveEnter({ altKey: true }), null);
+});
+
+test("Win32 key-up broadcast remains a native release with no editing semantics", () => {
+  const options = {
+    kittyProtocolEnabled: true,
+    kittyMode: createKittyKeyboardModeState(),
+    applicationCursorMode: false,
+    encodedKeys: new Set<string>(),
+    win32InputMode: true,
+  };
+  assert.ok(resolveKittyKeyboardBroadcastInput({
+    kind: "win32",
+    data: "\u001b[13;28;13;1;16;1_",
+    event: {
+      type: "keydown",
+      key: "Enter",
+      code: "Enter",
+      shiftKey: true,
+    },
+  }, options));
+  const releaseRecord = "\u001b[13;28;13;0;16;1_";
+  assert.deepEqual(resolveKittyKeyboardBroadcastInput({
+    kind: "win32",
+    data: releaseRecord,
+    fallbackToLegacy: true,
+    event: {
+      type: "keyup",
+      key: "Enter",
+      code: "Enter",
+      shiftKey: true,
+    },
+  }, options), {
+    data: releaseRecord,
+    kittyEncoded: false,
+    urgentInterrupt: false,
+    logicalData: null,
+  });
+});
+
+test("Win32 broadcast targets encode normalized keys and release them during sensitive input", () => {
+  const encodedKeys = new Set<string>();
+  const delivered: Array<{ type?: string; logicalData: string | null }> = [];
+  const writes: string[] = [];
+  let sensitive = false;
+  const handler = createKittyKeyboardBroadcastHandler({
+    resolveOptions: () => ({
+      kittyProtocolEnabled: false,
+      kittyMode: createKittyKeyboardModeState(),
+      applicationCursorMode: false,
+      encodedKeys,
+      win32InputMode: true,
+    }),
+    getSessionId: () => "win32-target",
+    isSensitiveInput: () => sensitive,
+    isConnected: () => true,
+    isRuntimeDisposed: () => false,
+    writeDisposed: (_sessionId, data) => writes.push(data),
+    writeActive: (data) => writes.push(data),
+    writeWin32Event: (event, logicalData) => {
+      delivered.push({ type: event.type, logicalData });
+    },
+  });
+
+  handler({
+    kind: "key",
+    event: { type: "keydown", key: "Enter", code: "Enter", shiftKey: true },
+  });
+  sensitive = true;
+  handler({
+    kind: "key",
+    event: { type: "keyup", key: "Enter", code: "Enter", shiftKey: true },
+  });
+
+  assert.deepEqual(delivered, [
+    { type: "keydown", logicalData: null },
+    { type: "keyup", logicalData: null },
+  ]);
+  assert.deepEqual(writes, []);
+  assert.equal(encodedKeys.size, 0);
+});
+
 test("plain Kitty targets preserve modified non-ASCII keys without a legacy fallback", () => {
   const plain = createKittyKeyboardModeState();
   assert.deepEqual(resolveKittyKeyboardBroadcastInput({

--- a/components/terminal/runtime/kittyKeyboardBroadcast.test.ts
+++ b/components/terminal/runtime/kittyKeyboardBroadcast.test.ts
@@ -521,7 +521,7 @@ test("enhanced sources can fall back to reliable legacy data for plain targets",
   }
 });
 
-test("Shift+Enter broadcast remaps from each target buffer when Kitty collapses the chord", () => {
+test("Shift+Enter broadcast uses CSI-u only after the target negotiated a preserving mode", () => {
   const alternateOnly = createKittyKeyboardModeState();
   setKittyKeyboardModeFlags(alternateOnly, 0b00100);
   const shiftEnter = {
@@ -540,10 +540,9 @@ test("Shift+Enter broadcast remaps from each target buffer when Kitty collapses 
     kittyMode: alternateOnly,
     applicationCursorMode: false,
     encodedKeys: new Set<string>(),
-    alternateScreen: true,
   }), {
-    data: SHIFT_ENTER_CSI_U_SEQUENCE,
-    kittyEncoded: true,
+    data: "\n",
+    kittyEncoded: false,
     urgentInterrupt: false,
   });
 
@@ -552,7 +551,6 @@ test("Shift+Enter broadcast remaps from each target buffer when Kitty collapses 
     kittyMode: createKittyKeyboardModeState(),
     applicationCursorMode: false,
     encodedKeys: new Set<string>(),
-    alternateScreen: false,
   }), {
     data: "\n",
     kittyEncoded: false,
@@ -566,7 +564,6 @@ test("Shift+Enter broadcast remaps from each target buffer when Kitty collapses 
     kittyMode: disambiguate,
     applicationCursorMode: false,
     encodedKeys: new Set<string>(),
-    alternateScreen: true,
   }), {
     data: SHIFT_ENTER_CSI_U_SEQUENCE,
     kittyEncoded: true,

--- a/components/terminal/runtime/kittyKeyboardBroadcast.ts
+++ b/components/terminal/runtime/kittyKeyboardBroadcast.ts
@@ -9,7 +9,7 @@ import {
 import type { TerminalSettings } from "../../../domain/models";
 import {
   isBareShiftEnterLineEnding,
-  resolveShiftEnterPayload,
+  resolveShiftEnterText,
   shouldSendShiftEnterText,
 } from "./shiftEnterText";
 
@@ -202,8 +202,6 @@ type ResolveKittyKeyboardBroadcastOptions = {
   applicationCursorMode: boolean;
   encodedKeys: Set<string>;
   legacySuppressedKeys?: Set<string>;
-  /** Target buffer: remap Shift+Enter per peer, not from the broadcast source. */
-  alternateScreen?: boolean;
   shiftEnterSettings?: Pick<
     TerminalSettings,
     "shiftEnterNewlineEnabled" | "shiftEnterNewlineText"
@@ -222,13 +220,11 @@ const resolveShiftEnterBroadcastPayload = (
   ) {
     return null;
   }
-  const payload = resolveShiftEnterPayload(options.shiftEnterSettings, {
-    alternateScreen: options.alternateScreen === true,
-  });
-  if (!payload.data) return null;
+  const data = resolveShiftEnterText(options.shiftEnterSettings);
+  if (!data) return null;
   return {
-    data: payload.data,
-    kittyEncoded: payload.kind === "key",
+    data,
+    kittyEncoded: false,
     urgentInterrupt: false,
   };
 };

--- a/components/terminal/runtime/kittyKeyboardBroadcast.ts
+++ b/components/terminal/runtime/kittyKeyboardBroadcast.ts
@@ -20,6 +20,13 @@ export type KittyKeyboardBroadcastInput =
       fallbackToLegacy?: boolean;
       urgentInterrupt?: boolean;
     }
+  | {
+      kind: "win32";
+      data: string;
+      event: KittyKeyboardEvent;
+      fallbackToLegacy?: boolean;
+      urgentInterrupt?: boolean;
+    }
   | { kind: "legacy"; data: string; keyIdentity: string; urgentInterrupt?: boolean }
   | { kind: "text"; text: string };
 
@@ -36,6 +43,9 @@ export type ResolvedKittyKeyboardBroadcastInput = {
   data: string;
   kittyEncoded: boolean;
   urgentInterrupt: boolean;
+  logicalData?: string | null;
+  /** Let the target xterm encode this event with its active Win32 mode. */
+  win32Event?: KittyKeyboardEvent;
 };
 
 export const createKittyKeyboardBroadcastForwarder = (options: {
@@ -202,10 +212,28 @@ type ResolveKittyKeyboardBroadcastOptions = {
   applicationCursorMode: boolean;
   encodedKeys: Set<string>;
   legacySuppressedKeys?: Set<string>;
+  win32InputMode?: boolean;
   shiftEnterSettings?: Pick<
     TerminalSettings,
     "shiftEnterNewlineEnabled" | "shiftEnterNewlineText"
   >;
+};
+
+export const resolveWin32InputLogicalData = (
+  event: KittyKeyboardEvent,
+  applicationCursorMode: boolean,
+): string | null => {
+  if (event.type === "keyup") return null;
+  if (
+    event.key === "Enter" &&
+    (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey)
+  ) {
+    // The native record carries semantics that a legacy CR cannot express.
+    // Treating a modified Enter as CR would make Netcatty record a command
+    // submission even when the TUI only inserted a line break.
+    return null;
+  }
+  return encodeLegacyKeyboardEvent(event, applicationCursorMode);
 };
 
 const resolveShiftEnterBroadcastPayload = (
@@ -251,6 +279,36 @@ export const resolveKittyKeyboardBroadcastInput = (
     };
   }
 
+  if (input.kind === "win32") {
+    if (options.win32InputMode) {
+      const identity = input.event.code || input.event.key;
+      const legacySuppressedKeys = options.legacySuppressedKeys ?? options.encodedKeys;
+      if (input.event.type === "keyup") {
+        const hasPairedKeyDown = options.encodedKeys.delete(identity);
+        legacySuppressedKeys.delete(identity);
+        if (!hasPairedKeyDown) return null;
+      } else {
+        options.encodedKeys.add(identity);
+        legacySuppressedKeys.add(identity);
+      }
+      return {
+        data: input.data,
+        kittyEncoded: false,
+        urgentInterrupt: input.urgentInterrupt === true,
+        logicalData: resolveWin32InputLogicalData(
+          input.event,
+          options.applicationCursorMode,
+        ),
+      };
+    }
+    return resolveKittyKeyboardBroadcastInput({
+      kind: "key",
+      event: input.event,
+      fallbackToLegacy: input.fallbackToLegacy,
+      urgentInterrupt: input.urgentInterrupt,
+    }, options);
+  }
+
   const identity = input.event.code || input.event.key;
   const legacySuppressedKeys = options.legacySuppressedKeys ?? options.encodedKeys;
   const hasPairedKeyDown = input.event.type === "keyup"
@@ -258,6 +316,22 @@ export const resolveKittyKeyboardBroadcastInput = (
     : false;
   if (input.event.type === "keyup") legacySuppressedKeys.delete(identity);
   if (input.event.type === "keyup" && !hasPairedKeyDown) return null;
+  if (options.win32InputMode) {
+    if (input.event.type !== "keyup") {
+      options.encodedKeys.add(identity);
+      legacySuppressedKeys.add(identity);
+    }
+    return {
+      data: "",
+      kittyEncoded: false,
+      urgentInterrupt: false,
+      logicalData: resolveWin32InputLogicalData(
+        input.event,
+        options.applicationCursorMode,
+      ),
+      win32Event: input.event,
+    };
+  }
   const encoded = options.kittyProtocolEnabled
     ? encodeKittyKeyEvent(options.kittyMode, {
         ...input.event,
@@ -296,11 +370,14 @@ export const createKittyKeyboardBroadcastHandler = (options: {
   isRuntimeDisposed: () => boolean;
   interruptSession?: (sessionId: string) => void;
   writeDisposed: (sessionId: string, data: string) => void;
-  writeActive: (data: string) => void;
+  writeActive: (data: string, logicalData?: string | null) => void;
+  writeWin32Event?: (event: KittyKeyboardEvent, logicalData: string | null) => void;
 }): KittyKeyboardBroadcastHandler => (input, dispatchOptions) => {
   const sessionId = options.getSessionId();
   if (!sessionId || !options.isConnected()) return;
-  const isPairedRelease = input.kind === "key" && input.event.type === "keyup";
+  const isPairedRelease =
+    (input.kind === "key" || input.kind === "win32") &&
+    input.event.type === "keyup";
   if (!isPairedRelease && options.isSensitiveInput?.() === true) return;
   const resolved = resolveKittyKeyboardBroadcastInput(input, options.resolveOptions());
   if (!resolved) return;
@@ -309,11 +386,20 @@ export const createKittyKeyboardBroadcastHandler = (options: {
     options.interruptSession(sessionId);
     return;
   }
+  if (resolved.win32Event) {
+    if (!options.isRuntimeDisposed()) {
+      options.writeWin32Event?.(
+        resolved.win32Event,
+        resolved.logicalData ?? null,
+      );
+    }
+    return;
+  }
   if (options.isRuntimeDisposed()) {
     options.writeDisposed(sessionId, resolved.data);
     return;
   }
-  options.writeActive(resolved.data);
+  options.writeActive(resolved.data, resolved.logicalData);
 };
 
 const handlers = new Map<string, KittyKeyboardBroadcastHandler>();

--- a/components/terminal/runtime/shiftEnterText.test.ts
+++ b/components/terminal/runtime/shiftEnterText.test.ts
@@ -112,7 +112,15 @@ test("runtime routes Shift+Enter text through the shared input handler", () => {
   // Remap when Kitty encoding does not preserve Shift+Enter (not merely flags===0).
   assert.match(
     source,
-    /if \(\s*shouldSendShiftEnterText\([\s\S]*?\) &&\s*!doesKittyEncodingPreserveShiftEnter\(kittySequenceForKeyDown\)\s*\) \{[\s\S]*?const shiftEnterText = resolveShiftEnterText\([\s\S]*?\)[\s\S]*?\}\s*if \(kittySequenceForKeyDown\)/s,
+    /if \(\s*shouldSendShiftEnterText\([\s\S]*?\) &&\s*!term\.modes\.win32InputMode &&\s*!doesKittyEncodingPreserveShiftEnter\(kittySequenceForKeyDown\)\s*\) \{[\s\S]*?const shiftEnterText = resolveShiftEnterText\([\s\S]*?\)[\s\S]*?\}\s*if \(kittySequenceForKeyDown\)/s,
+  );
+  assert.match(
+    source,
+    /vtExtensions: \{\s*win32InputMode: windowsPty\?\.backend === "conpty",\s*\},/s,
+  );
+  assert.match(
+    source,
+    /const kittySequenceForKeyDown =\s*!term\.modes\.win32InputMode &&\s*kittyKeyboardProtocolEnabled/s,
   );
   assert.match(
     source,
@@ -127,7 +135,7 @@ test("runtime routes Shift+Enter text through the shared input handler", () => {
     /resolveOptions: \(\) => \(\{[\s\S]*?shiftEnterSettings: ctx\.terminalSettingsRef\.current,[\s\S]*?\}\),/s,
   );
   assert.doesNotMatch(source, /resolveShiftEnterText\([\s\S]*?alternateScreen:/s);
-  assert.match(source, /getShiftEnterSubmittedInput\(data\)/);
+  assert.match(source, /getShiftEnterSubmittedInput\(logicalData\)/);
   assert.match(source, /inputSource !== "shift-enter"/);
   assert.match(
     source,
@@ -139,7 +147,40 @@ test("runtime routes Shift+Enter text through the shared input handler", () => {
   );
   assert.match(
     source,
-    /const sanitizedData = sanitizeTerminalInput\(data\);[\s\S]*const encoded = encodeKittyCompositionText\(kittyKeyboardMode, sanitizedData\);[\s\S]*if \(encoded\) \{[\s\S]*handleTerminalInputData\(encoded, \{ source: "kitty" \}\);[\s\S]*\} else \{[\s\S]*handleTerminalInputData\(sanitizedData, \{\s*perCharacterWrites: shouldSplitImeTextInputForWire\(sanitizedData\),?\s*\}\);[\s\S]*broadcastKittyInput\(\{ kind: "text", text: sanitizedData \}\);/,
+    /const sanitizedData = sanitizeTerminalInput\(data\);[\s\S]*const encoded = term\.modes\.win32InputMode\s*\? null\s*:\s*encodeKittyCompositionText\(kittyKeyboardMode, sanitizedData\);[\s\S]*if \(encoded\) \{[\s\S]*handleTerminalInputData\(encoded, \{ source: "kitty" \}\);[\s\S]*\} else \{[\s\S]*handleTerminalInputData\(sanitizedData, \{\s*perCharacterWrites: shouldSplitImeTextInputForWire\(sanitizedData\),?\s*\}\);[\s\S]*broadcastKittyInput\(\{ kind: "text", text: sanitizedData \}\);/,
+  );
+  assert.match(
+    source,
+    /if \(term\.modes\.win32InputMode\) \{[\s\S]*win32InputModePendingEvent = \{\s*event: normalizedKittyEvent,\s*logicalData: resolveWin32InputLogicalData\(/s,
+  );
+  assert.match(
+    source,
+    /const broadcastInput: KittyKeyboardBroadcastInput = \{\s*kind: "win32",\s*data,\s*event: win32Input\.event,[\s\S]*handleTerminalInputData\(data, \{\s*logicalData: win32Input\.logicalData,\s*skipBroadcast: true,/s,
+  );
+  assert.match(
+    source,
+    /const hasForwardedWin32KeyDown = win32InputModeForwardedKeys\.delete\(identity\);[\s\S]*if \(term\.modes\.win32InputMode\) \{[\s\S]*releaseForwardedKittyPress\([\s\S]*if \(!hasForwardedWin32KeyDown\) \{[\s\S]*win32InputModePendingEvent = null;[\s\S]*return false;[\s\S]*logicalData: null,[\s\S]*return true;[\s\S]*releaseForwardedKittyPress/s,
+  );
+  assert.match(
+    source,
+    /if \(win32Input\.event\.type === "keydown"\) \{\s*upsertKittyKeyboardForwardedPress\(\s*win32InputModeForwardedKeys,\s*win32Input\.event\.code \|\| win32Input\.event\.key,\s*win32Input\.event,\s*\[\],/s,
+  );
+  assert.match(
+    source,
+    /if \(term\.modes\.win32InputMode\) \{[\s\S]*flushKittyKeyboardBroadcastReleases\(\s*win32InputModeForwardedKeys,[\s\S]*writeWin32InputModeEvent\(input\.event, null\);/s,
+  );
+  assert.match(source, /win32InputMode: term\.modes\.win32InputMode,/);
+  assert.match(
+    source,
+    /const win32BroadcastForwardedKeys = new Map<string, KittyKeyboardForwardedPress>\(\);/,
+  );
+  assert.match(
+    source,
+    /const forwardedPress = win32BroadcastForwardedKeys\.get\(identity\);[\s\S]*broadcastKittyInput\(\s*broadcastInput,\s*true,\s*forwardedPress\.targetSessionIds,/s,
+  );
+  assert.match(
+    source,
+    /upsertKittyKeyboardForwardedPress\(\s*win32BroadcastForwardedKeys,[\s\S]*forwarded\.targetSessionIds,/s,
   );
   assert.match(source, /ctx\.container\.addEventListener\("input", markKittyTextInput, true\);/);
   assert.match(

--- a/components/terminal/runtime/shiftEnterText.test.ts
+++ b/components/terminal/runtime/shiftEnterText.test.ts
@@ -8,7 +8,6 @@ import {
   getShiftEnterSubmittedInput,
   isBareShiftEnterLineEnding,
   isShiftEnterLineContinuationText,
-  resolveShiftEnterPayload,
   resolveShiftEnterText,
   SHIFT_ENTER_CSI_U_SEQUENCE,
   shouldSendShiftEnterText,
@@ -100,44 +99,6 @@ test("Kitty encodings that collapse Shift+Enter to CR/LF do not preserve the cho
   assert.equal(doesKittyEncodingPreserveShiftEnter(SHIFT_ENTER_CSI_U_SEQUENCE), true);
 });
 
-test("main-buffer Shift+Enter keeps configured send text", () => {
-  assert.deepEqual(resolveShiftEnterPayload(), {
-    kind: "text",
-    data: "\n",
-  });
-  assert.deepEqual(
-    resolveShiftEnterPayload(
-      { shiftEnterNewlineText: " \\\\\\n" },
-      { alternateScreen: false },
-    ),
-    { kind: "text", data: " \\\n" },
-  );
-});
-
-test("alternate-screen Shift+Enter sends CSI-u when configured text is a bare line ending", () => {
-  assert.deepEqual(
-    resolveShiftEnterPayload(undefined, { alternateScreen: true }),
-    { kind: "key", data: SHIFT_ENTER_CSI_U_SEQUENCE },
-  );
-  assert.deepEqual(
-    resolveShiftEnterPayload(
-      { shiftEnterNewlineText: "\\r\\n" },
-      { alternateScreen: true },
-    ),
-    { kind: "key", data: SHIFT_ENTER_CSI_U_SEQUENCE },
-  );
-});
-
-test("alternate-screen Shift+Enter keeps custom non-line-ending send text", () => {
-  assert.deepEqual(
-    resolveShiftEnterPayload(
-      { shiftEnterNewlineText: " \\\\\\n" },
-      { alternateScreen: true },
-    ),
-    { kind: "text", data: " \\\n" },
-  );
-});
-
 test("runtime routes Shift+Enter text through the shared input handler", () => {
   const source = readFileSync(
     new URL("./createXTermRuntime.ts", import.meta.url),
@@ -151,11 +112,11 @@ test("runtime routes Shift+Enter text through the shared input handler", () => {
   // Remap when Kitty encoding does not preserve Shift+Enter (not merely flags===0).
   assert.match(
     source,
-    /if \(\s*shouldSendShiftEnterText\([\s\S]*?\) &&\s*!doesKittyEncodingPreserveShiftEnter\(kittySequenceForKeyDown\)\s*\) \{[\s\S]*?const shiftEnterPayload = resolveShiftEnterPayload\([\s\S]*?\)[\s\S]*?\}\s*if \(kittySequenceForKeyDown\)/s,
+    /if \(\s*shouldSendShiftEnterText\([\s\S]*?\) &&\s*!doesKittyEncodingPreserveShiftEnter\(kittySequenceForKeyDown\)\s*\) \{[\s\S]*?const shiftEnterText = resolveShiftEnterText\([\s\S]*?\)[\s\S]*?\}\s*if \(kittySequenceForKeyDown\)/s,
   );
   assert.match(
     source,
-    /if \(shiftEnterPayload\.kind === "key"\) \{[\s\S]*?handleTerminalInputData\(shiftEnterPayload\.data, \{ source: "kitty" \}\);[\s\S]*?\} else \{[\s\S]*?handleTerminalInputData\(shiftEnterPayload\.data, \{\s*source: "shift-enter",\s*skipBroadcast: true,\s*\}\);[\s\S]*?\}\s*const forwarded = broadcastKittyInput\(\{\s*kind: "key",\s*event: kittyEvent,\s*fallbackToLegacy: true,\s*\}\);/s,
+    /const shiftEnterText = resolveShiftEnterText\([\s\S]*?if \(shiftEnterText\) \{[\s\S]*?handleTerminalInputData\(shiftEnterText, \{\s*source: "shift-enter",\s*skipBroadcast: true,\s*\}\);\s*const forwarded = broadcastKittyInput\(\{\s*kind: "key",\s*event: kittyEvent,\s*fallbackToLegacy: true,\s*\}\);/s,
   );
   assert.match(
     source,
@@ -163,8 +124,9 @@ test("runtime routes Shift+Enter text through the shared input handler", () => {
   );
   assert.match(
     source,
-    /alternateScreen: term\.buffer\.active\.type === "alternate",\s*shiftEnterSettings: ctx\.terminalSettingsRef\.current,/s,
+    /resolveOptions: \(\) => \(\{[\s\S]*?shiftEnterSettings: ctx\.terminalSettingsRef\.current,[\s\S]*?\}\),/s,
   );
+  assert.doesNotMatch(source, /resolveShiftEnterText\([\s\S]*?alternateScreen:/s);
   assert.match(source, /getShiftEnterSubmittedInput\(data\)/);
   assert.match(source, /inputSource !== "shift-enter"/);
   assert.match(

--- a/components/terminal/runtime/shiftEnterText.ts
+++ b/components/terminal/runtime/shiftEnterText.ts
@@ -91,30 +91,6 @@ export function doesKittyEncodingPreserveShiftEnter(
     && !isBareShiftEnterLineEnding(encoded);
 }
 
-export type ShiftEnterPayload =
-  | { kind: "text"; data: string }
-  | { kind: "key"; data: string };
-
-/**
- * Resolve what Shift+Enter should write.
- *
- * On the main buffer, keep the configured send-text (default LF) so shell /
- * Claude-style multiline prompts keep working. On the alternate screen (full-
- * screen TUIs), bare line-ending remaps collapse Shift+Enter into Ctrl+Enter /
- * LF for apps like Codex; send CSI-u Shift+Enter instead so the TUI can see
- * the real chord. Custom send-text (e.g. shell continuation) is unchanged.
- */
-export function resolveShiftEnterPayload(
-  settings?: Pick<TerminalSettings, "shiftEnterNewlineText">,
-  options?: { alternateScreen?: boolean },
-): ShiftEnterPayload {
-  const text = resolveShiftEnterText(settings);
-  if (options?.alternateScreen && isBareShiftEnterLineEnding(text)) {
-    return { kind: "key", data: SHIFT_ENTER_CSI_U_SEQUENCE };
-  }
-  return { kind: "text", data: text };
-}
-
 export function isShiftEnterLineContinuationText(text: string): boolean {
   return /\\(?:\r\n|\r|\n)$/.test(text);
 }

--- a/components/terminal/runtime/terminalImeTextInput.test.ts
+++ b/components/terminal/runtime/terminalImeTextInput.test.ts
@@ -472,7 +472,7 @@ test("createXTermRuntime recovers a stuck IME punctuation deferral (#3103)", () 
   // Any real key release ends the deferral, not just an exact key match.
   const keyupIdx = runtimeSource.indexOf('if (e.type === "keyup")');
   assert.ok(keyupIdx >= 0);
-  const keyupSlice = runtimeSource.slice(keyupIdx, keyupIdx + 2000);
+  const keyupSlice = runtimeSource.slice(keyupIdx, keyupIdx + 2800);
   assert.match(
     keyupSlice,
     /shouldFlushDeferredImeTextInputOnKeyUp\(imeTextInputDeferredKey, e\)/,

--- a/components/terminal/runtime/win32InputMode.test.ts
+++ b/components/terminal/runtime/win32InputMode.test.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+import { JSDOM } from "jsdom";
+import type { Terminal as XTermType } from "@xterm/xterm";
+
+import { dispatchWin32InputModeEvent } from "./win32InputMode";
+
+const require = createRequire(import.meta.url);
+const { Terminal: XTerm } = require("@xterm/xterm") as {
+  Terminal: typeof XTermType;
+};
+
+const write = (term: XTermType, data: string): Promise<void> => new Promise((resolve) => {
+  term.write(data, resolve);
+});
+
+test("xterm ignores ConPTY's Win32 input request unless the extension is enabled", async () => {
+  const term = new XTerm({ allowProposedApi: true });
+
+  await write(term, "\u001b[?9001h");
+
+  assert.equal(term.modes.win32InputMode, false);
+  term.dispose();
+});
+
+test("xterm preserves modified Enter keys as Win32 input records for ConPTY", async () => {
+  const dom = new JSDOM(
+    "<!doctype html><html><body><div id=terminal></div><div id=source></div></body></html>",
+    {
+    pretendToBeVisual: true,
+    },
+  );
+  const window = dom.window;
+  window.matchMedia = () => ({
+    matches: true,
+    media: "",
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent: () => true,
+  });
+  window.HTMLCanvasElement.prototype.getContext = (() => ({
+    createLinearGradient: () => ({}),
+    measureText: () => ({
+      width: 10,
+      actualBoundingBoxDescent: 2,
+      actualBoundingBoxAscent: 8,
+    }),
+    fillRect() {},
+    clearRect() {},
+    getImageData: () => ({ data: new Uint8ClampedArray([0, 0, 0, 255]) }),
+  })) as typeof window.HTMLCanvasElement.prototype.getContext;
+
+  const globals = [
+    "window",
+    "document",
+    "navigator",
+    "HTMLElement",
+    "HTMLCanvasElement",
+    "KeyboardEvent",
+    "Event",
+    "MouseEvent",
+    "CompositionEvent",
+    "InputEvent",
+  ] as const;
+  const previous = new Map<string, PropertyDescriptor | undefined>();
+  for (const name of globals) {
+    previous.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, {
+      value: window[name],
+      configurable: true,
+    });
+  }
+  previous.set("devicePixelRatio", Object.getOwnPropertyDescriptor(globalThis, "devicePixelRatio"));
+  Object.defineProperty(globalThis, "devicePixelRatio", { value: 1, configurable: true });
+  previous.set("ResizeObserver", Object.getOwnPropertyDescriptor(globalThis, "ResizeObserver"));
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    value: class {
+      observe() {}
+      disconnect() {}
+    },
+    configurable: true,
+  });
+
+  const term = new XTerm({
+    allowProposedApi: true,
+    cols: 80,
+    rows: 24,
+    vtExtensions: { kittyKeyboard: true, win32InputMode: true },
+  });
+  try {
+    term.open(window.document.getElementById("terminal") as HTMLElement);
+    const sent: string[] = [];
+    term.onData((data) => sent.push(data));
+
+    await write(term, "\u001b[?9001h");
+    await write(term, "\u001b[>2u");
+    assert.equal(term.modes.win32InputMode, true);
+
+    for (const modifiers of [
+      {},
+      { shiftKey: true },
+      { ctrlKey: true },
+      { altKey: true },
+    ]) {
+      term.textarea?.dispatchEvent(new window.KeyboardEvent("keydown", {
+        key: "Enter",
+        code: "Enter",
+        keyCode: 13,
+        bubbles: true,
+        cancelable: true,
+        ...modifiers,
+      }));
+    }
+    term.textarea?.dispatchEvent(new window.KeyboardEvent("keyup", {
+      key: "Enter",
+      code: "Enter",
+      keyCode: 13,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    }));
+
+    assert.deepEqual(sent, [
+      "\u001b[13;28;13;1;0;1_",
+      "\u001b[13;28;13;1;16;1_",
+      "\u001b[13;28;10;1;8;1_",
+      "\u001b[13;28;13;1;2;1_",
+      "\u001b[13;28;13;0;16;1_",
+    ]);
+
+    const sourceTerm = new XTerm({ allowProposedApi: true, cols: 80, rows: 24 });
+    try {
+      sourceTerm.open(window.document.getElementById("source") as HTMLElement);
+      sourceTerm.focus();
+      assert.equal(window.document.activeElement, sourceTerm.textarea);
+      sent.length = 0;
+      const shiftEnter = {
+        key: "Enter",
+        code: "Enter",
+        keyCode: 13,
+        shiftKey: true,
+      };
+      dispatchWin32InputModeEvent(term, { type: "keydown", ...shiftEnter });
+      dispatchWin32InputModeEvent(term, { type: "keyup", ...shiftEnter });
+      assert.equal(window.document.activeElement, sourceTerm.textarea);
+      assert.deepEqual(sent, [
+        "\u001b[13;28;13;1;16;1_",
+        "\u001b[13;28;13;0;16;1_",
+      ]);
+    } finally {
+      sourceTerm.dispose();
+    }
+
+    // Netcatty consumes shortcuts and local controls before xterm. Their
+    // releases must be consumed too, otherwise ConPTY receives an orphaned
+    // native key-up after a Ctrl+C interrupt or sudo/autocomplete Enter.
+    sent.length = 0;
+    const forwardedKeys = new Set<string>();
+    let pendingKeyDownIdentity: string | null = null;
+    term.onData((data) => {
+      if (
+        pendingKeyDownIdentity &&
+        data.startsWith("\u001b[") &&
+        data.endsWith("_")
+      ) {
+        forwardedKeys.add(pendingKeyDownIdentity);
+        pendingKeyDownIdentity = null;
+      }
+    });
+    term.attachCustomKeyEventHandler((event) => {
+      const identity = event.code || event.key;
+      if (event.type === "keyup") {
+        pendingKeyDownIdentity = null;
+        return forwardedKeys.delete(identity);
+      }
+      if (event.type !== "keydown") return true;
+      const consumed =
+        (event.ctrlKey && event.key.toLowerCase() === "c") ||
+        (event.key === "Enter" && !event.shiftKey);
+      if (consumed) return false;
+      pendingKeyDownIdentity = identity;
+      return true;
+    });
+
+    for (const event of [
+      new window.KeyboardEvent("keydown", {
+        key: "c", code: "KeyC", keyCode: 67, ctrlKey: true, bubbles: true, cancelable: true,
+      }),
+      new window.KeyboardEvent("keyup", {
+        key: "c", code: "KeyC", keyCode: 67, ctrlKey: true, bubbles: true, cancelable: true,
+      }),
+      new window.KeyboardEvent("keydown", {
+        key: "Enter", code: "Enter", keyCode: 13, bubbles: true, cancelable: true,
+      }),
+      new window.KeyboardEvent("keyup", {
+        key: "Enter", code: "Enter", keyCode: 13, bubbles: true, cancelable: true,
+      }),
+      new window.KeyboardEvent("keydown", {
+        key: "Process", code: "KeyA", keyCode: 229, bubbles: true, cancelable: true,
+      }),
+      new window.KeyboardEvent("keyup", {
+        key: "Process", code: "KeyA", keyCode: 229, bubbles: true, cancelable: true,
+      }),
+    ]) {
+      term.textarea?.dispatchEvent(event);
+    }
+    assert.deepEqual(sent, []);
+  } finally {
+    term.dispose();
+    dom.window.close();
+    for (const [name, descriptor] of previous) {
+      if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+      else Reflect.deleteProperty(globalThis, name);
+    }
+  }
+});

--- a/components/terminal/runtime/win32InputMode.ts
+++ b/components/terminal/runtime/win32InputMode.ts
@@ -1,0 +1,50 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+import type { KittyKeyboardEvent } from "./kittyKeyboardProtocol";
+
+export const dispatchWin32InputModeEvent = (
+  term: Pick<XTerm, "textarea">,
+  event: KittyKeyboardEvent,
+): boolean => {
+  const textarea = term.textarea;
+  const KeyboardEventConstructor = textarea?.ownerDocument.defaultView?.KeyboardEvent;
+  if (!textarea || !KeyboardEventConstructor) return false;
+
+  const syntheticEvent = new KeyboardEventConstructor(event.type ?? "keydown", {
+    key: event.key,
+    code: event.code,
+    location: event.location,
+    repeat: event.repeat,
+    isComposing: event.isComposing,
+    shiftKey: event.shiftKey,
+    altKey: event.altKey,
+    ctrlKey: event.ctrlKey,
+    metaKey: event.metaKey,
+    bubbles: true,
+    cancelable: true,
+  });
+  if (event.keyCode !== undefined && syntheticEvent.keyCode !== event.keyCode) {
+    Object.defineProperty(syntheticEvent, "keyCode", { value: event.keyCode });
+  }
+  if (event.getModifierState) {
+    Object.defineProperty(syntheticEvent, "getModifierState", {
+      value: (key: string) => event.getModifierState?.(key) === true,
+    });
+  }
+
+  // xterm's internal CoreBrowserTerminal focuses its textarea for key-up
+  // events. A broadcast is transport, not user focus navigation, so suppress
+  // that synchronous DOM focus side effect while the target encodes the event.
+  const ownFocus = Object.getOwnPropertyDescriptor(textarea, "focus");
+  Object.defineProperty(textarea, "focus", {
+    value: () => undefined,
+    configurable: true,
+  });
+  try {
+    textarea.dispatchEvent(syntheticEvent);
+  } finally {
+    if (ownFocus) Object.defineProperty(textarea, "focus", ownFocus);
+    else delete (textarea as HTMLTextAreaElement & { focus?: () => void }).focus;
+  }
+  return true;
+};

--- a/docs/research/issue-2974-shift-enter-tui-source-study.md
+++ b/docs/research/issue-2974-shift-enter-tui-source-study.md
@@ -1,0 +1,155 @@
+# Issue #2974: Shift+Enter 的终端输入链路与开源 TUI 对照
+
+> 研究日期：2026-09-02
+> 范围：Netcatty PR #3247、Kitty keyboard protocol、Windows ConPTY/win32-input-mode、xterm.js，以及 Codex、Grok Build、OpenCode、Gemini CLI、Qwen Code 当前开源源码。所有外部结论只使用官方规范、官方仓库与项目自身源码。
+
+## 结论
+
+1. **本轮研究开始时的 PR 头 `f2ec2a4` 不是 #2974 的彻底修复。** 它修正了一个必要的兼容性回退：不能把“进入全屏/备用屏幕”误当成 TUI 已协商 Kitty 键盘协议，否则 Grok 一类未协商的程序会把 `CSI 13;2u` 显示成字面文本。PR 改为只有协商成功时才发送 CSI-u，否则继续发送配置的换行文本。这个改动能消除 `[13;2u` 泄漏，但在报告者的本机 Windows PowerShell → Codex 路径上仍会丢失 Shift，因此旧头单独合并不能关闭 issue。[PR #3247 说明](https://github.com/binaricat/Netcatty/pull/3247)；[旧 PR 头部的回退分支](https://github.com/binaricat/Netcatty/blob/f2ec2a4842dc4e1fc50b489df45f77bff79eb9d8/components/terminal/runtime/createXTermRuntime.ts#L1974-L2015)
+2. **报告者原始路径的根因在 Windows ConPTY 输入层，不是 Codex 热键本身。** ConPTY 启动时会主动发送 `CSI ? 9001 h`，要求前端用无损的 Win32 `INPUT_RECORD` 格式回送键盘事件；xterm.js 已实现这个模式和 Shift+Enter，但该能力默认关闭。Netcatty 在补丁前的依赖已经包含实现，却没有开启它，所以 Enter、Shift+Enter、Ctrl+Enter 在到达 PowerShell/Codex 前已经被旧式输入编码折叠。[ConPTY 当前启动代码](https://github.com/microsoft/terminal/blob/62711fd73ef9733fa83108bfa7cea22528d2dbb9/src/host/VtIo.cpp#L196-L204)；[xterm.js 开关默认值](https://github.com/xtermjs/xterm.js/blob/c58ea3637f3968e0e6e79cd92cf9aace7ef89ee2/typings/xterm.d.ts#L485-L492)；[Netcatty 的 xterm.js 版本](https://github.com/binaricat/Netcatty/blob/f2ec2a4842dc4e1fc50b489df45f77bff79eb9d8/package.json#L103-L110)
+3. **覆盖报告者复现的最小正确修法**是：仅对 Netcatty 本机 Windows 的 ConPTY 终端开启 xterm.js `vtExtensions.win32InputMode`，并在 `term.modes.win32InputMode` 生效时让 Netcatty 自己的 Shift+Enter 文本回退和 Kitty 编码让路。这样浏览器中的 Shift 状态会被 ConPTY 重建成原生键盘记录，Codex 和 Grok 都能从各自现有的 Windows 输入栈读到真正的 Shift，无需按应用名判断，也无需强塞 CSI-u。
+4. **本次不需要改 Codex 或 Grok。** 两者已经把 Shift+Enter 绑定为换行；Codex 在 Windows 明确选择原生 `INPUT_RECORD` 模式，Grok 所用的 crossterm 也会把 Win32 `SHIFT_PRESSED` 解成 Shift。缺失的是 Netcatty/xterm.js 到 ConPTY 的无损传输。[Codex Windows 模式](https://github.com/openai/codex/blob/eb10d91e48ccbd0930427461fb392337addb1ac0/codex-rs/tui/src/tui/windows_console.rs#L1-L17)；[Codex 换行键](https://github.com/openai/codex/blob/eb10d91e48ccbd0930427461fb392337addb1ac0/codex-rs/tui/src/keymap.rs#L1462-L1479)；[Grok 换行处理](https://github.com/xai-org/grok-build/blob/72a61251fcffb464bcc687aeb5a998e5a98ec0c9/crates/codegen/xai-grok-pager-render/src/input/terminal_support.rs#L45-L55)
+5. **关闭 issue 的边界**：把上述 ConPTY 补丁纳入 PR 后，代码因果链和字节级测试足以证明修法正确；但最好仍用真实 Windows 跑一次 Netcatty 本机 PowerShell → Codex/Grok。远端 Windows SSH 不是报告者原始复现，不能据此阻止本 issue 关闭；它应作为后续兼容范围单列。
+
+## 1. 报告者说的 Grok 是哪个项目
+
+这里不是根据同名项目猜测。Netcatty 自己把命令 `grok` 登记为 **Grok Build**，描述为 xAI 的 coding agent CLI：[agent discovery](https://github.com/binaricat/Netcatty/blob/f2ec2a4842dc4e1fc50b489df45f77bff79eb9d8/electron/bridges/aiBridge/agentDiscoveryHandlers.cjs#L98-L101) 和 [设置类型](https://github.com/binaricat/Netcatty/blob/f2ec2a4842dc4e1fc50b489df45f77bff79eb9d8/components/settings/tabs/ai/types.ts#L221-L231) 都指向同一产品。[xAI 官方公告](https://x.ai/news/grok-build-open-source)称其开放的是 Grok Build 的 agent 与 TUI 源码，[官方仓库 README](https://github.com/xai-org/grok-build/blob/72a61251fcffb464bcc687aeb5a998e5a98ec0c9/README.md#L10-L17) 也明确该仓库包含 `grok` CLI/TUI。因此本报告审查的是 `xai-org/grok-build`，不是其他同名 Grok CLI。
+
+## 2. 为什么这个问题容易被“修坏”
+
+旧式终端协议没有“键盘对象”，只有字节流。Kitty 官方规范的旧式编码表明确写出：普通 Enter、Ctrl+Enter、Shift+Enter、Ctrl+Shift+Enter 都是同一个 `0x0d`；只有 Alt 会多一个 ESC。[官方规范旧式 C0 表](https://github.com/kovidgoyal/kitty/blob/0dbbedfb5e316dfa23ce61fd23e6ea7e3e91d88b/docs/keyboard-protocol.rst#L523-L534)
+
+因此一旦浏览器按键在终端模拟器中被编码成 CR/LF，后面的 PowerShell、Codex 或 Grok 无法反推它原来是否带 Shift。发送 `\n` 只是“让某些输入框换行”的内容映射，不是传递 Shift+Enter；反过来，无条件发送 `CSI 13;2u` 也不对，因为不理解 CSI-u 的程序会把它当作普通输入。报告者先看到修饰键全部变成 `Mods=0`，后来又在 Grok 看到 `[13;2u`，正好对应这两个失败方向：[原始按键记录](https://github.com/binaricat/Netcatty/issues/2974#issuecomment-5289958145)；[最新补充](https://github.com/binaricat/Netcatty/issues/2974#issuecomment-5506053970)。
+
+Kitty 协议的正确模型是**应用协商**：应用先查询 `CSI ? u`，终端回复当前 flags；应用再 push 所需 flags，主屏与备用屏各有独立栈。[查询、push/pop 与双屏栈](https://github.com/kovidgoyal/kitty/blob/0dbbedfb5e316dfa23ce61fd23e6ea7e3e91d88b/docs/keyboard-protocol.rst#L285-L334) 应用应把 Kitty 查询和 DA 查询一起发；若只收到 DA，则判定终端不支持。[检测规则](https://github.com/kovidgoyal/kitty/blob/0dbbedfb5e316dfa23ce61fd23e6ea7e3e91d88b/docs/keyboard-protocol.rst#L437-L456) Shift 的修饰值为 `1 + 1 = 2`，所以 Shift+Enter 才是 `CSI 13;2u`。[修饰值编码](https://github.com/kovidgoyal/kitty/blob/0dbbedfb5e316dfa23ce61fd23e6ea7e3e91d88b/docs/keyboard-protocol.rst#L182-L210)
+
+这也说明 PR #3247 删除“只要进入备用屏就发送 CSI-u”的判断是对的：备用屏只决定协议状态栈存在哪里，不代表应用支持或已经启用协议。
+
+## 3. Windows 上还有一条更直接的标准路径
+
+Windows ConPTY 不是普通 Unix PTY。Microsoft 的规范专门把 Shift+Enter 列为没有唯一 VT 编码、需要保真的按键，并定义了 `win32-input-mode`：[设计目标与 Shift+Enter](https://github.com/microsoft/terminal/blob/62711fd73ef9733fa83108bfa7cea22528d2dbb9/doc/specs/%234999%20-%20Improved%20keyboard%20handling%20in%20Conpty.md#L40-L69)。
+
+链路如下：
+
+```text
+浏览器 KeyboardEvent
+  → xterm.js（收到 ConPTY 的 CSI ?9001h 后切换）
+  → CSI Vk;Sc;Uc;Kd;Cs;Rc _
+  → ConPTY 重建 INPUT_RECORD
+  → PowerShell / Codex / Grok 读取原生键盘记录
+```
+
+官方格式包含虚拟键码、扫描码、Unicode 字符、按下/抬起、修饰键状态和重复次数，因此不是只为 Shift+Enter 打补丁，而是完整传递键盘记录。[请求和格式](https://github.com/microsoft/terminal/blob/62711fd73ef9733fa83108bfa7cea22528d2dbb9/doc/specs/%234999%20-%20Improved%20keyboard%20handling%20in%20Conpty.md#L100-L179) ConPTY 会主动向承载它的终端请求该模式，不支持的终端忽略即可。[ConPTY 场景说明](https://github.com/microsoft/terminal/blob/62711fd73ef9733fa83108bfa7cea22528d2dbb9/doc/specs/%234999%20-%20Improved%20keyboard%20handling%20in%20Conpty.md#L278-L295)
+
+xterm.js PR [#5603](https://github.com/xtermjs/xterm.js/pull/5603) 已于 2026-01-10 合并该能力。当前实现只在选项允许时接受 `DECSET 9001`，[模式开关](https://github.com/xtermjs/xterm.js/blob/c58ea3637f3968e0e6e79cd92cf9aace7ef89ee2/src/common/InputHandler.ts#L2043-L2047)；模式激活后优先于 Kitty 和旧式编码，[键盘分派](https://github.com/xtermjs/xterm.js/blob/c58ea3637f3968e0e6e79cd92cf9aace7ef89ee2/src/browser/services/KeyboardService.ts#L36-L65)；它把 Shift 记录为 Win32 flag 16，并输出完整序列。[编码实现](https://github.com/xtermjs/xterm.js/blob/c58ea3637f3968e0e6e79cd92cf9aace7ef89ee2/src/common/input/Win32InputMode.ts#L20-L33) [输出格式](https://github.com/xtermjs/xterm.js/blob/c58ea3637f3968e0e6e79cd92cf9aace7ef89ee2/src/common/input/Win32InputMode.ts#L275-L296) 上游测试还直接覆盖了 Shift+Enter 与 Ctrl+Enter 的区别。[xterm.js 测试](https://github.com/xtermjs/xterm.js/blob/c58ea3637f3968e0e6e79cd92cf9aace7ef89ee2/src/common/input/Win32InputMode.test.ts#L176-L197)
+
+Netcatty 使用的 `@xterm/xterm 6.1.0-beta.292` 已带这个接口，但默认 `false`。VS Code 的当前源码也把它接到 xterm.js，却仍标为 restricted、experimental、advanced 且默认关闭：[VS Code 配置](https://github.com/microsoft/vscode/blob/0eb8ec268728142ee7665e7e07cf6bdf9379cc7e/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts#L592-L607) [传给 xterm.js](https://github.com/microsoft/vscode/blob/0eb8ec268728142ee7665e7e07cf6bdf9379cc7e/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts#L265-L278)。这为本 PR 只在已知的“本机 Windows + ConPTY”路径最小开启提供了兼容性依据，而不是把实验能力无条件扩大到所有会话。
+
+## 4. 开源 TUI 的实际做法
+
+| 项目 | 输入栈与协商 | Shift+Enter 处理 | 对 #2974 的含义 |
+|---|---|---|---|
+| OpenAI Codex | Rust + crossterm 0.29 fork。Unix 会按 Kitty 规范发 `CSI ?u` + DA 并解析回复；Windows 则先清除 `ENABLE_VIRTUAL_TERMINAL_INPUT`，明确选择原生 `INPUT_RECORD`。 | 默认把 Shift+Enter、Alt+Enter、Ctrl+J、Ctrl+M 绑定为插入换行。 | 报告者本机 Windows 路径不依赖 Kitty；Netcatty 应把浏览器修饰键无损交给 ConPTY。 |
+| Grok Build | Rust + crossterm 0.28。先按终端品牌做兼容性门禁，再调用 crossterm 探测；Windows 的 crossterm 探测恒为 false。Grok 明确跳过 Windows Terminal、VS Code/xterm.js 家族和无正面证据的未知终端。 | 源码已经接受 Shift+Enter/Alt+Enter；判定 Shift 不可靠时 UI 改提示 Alt+Enter。 | 强塞 Kitty 必然与 Grok 的门禁冲突；Win32 INPUT_RECORD 才是本机 Windows 的共同路径。 |
+| OpenCode | TypeScript + OpenTUI 0.4.5，启用 `useKittyKeyboard`。OpenTUI 会查询 Kitty；未用 Kitty 时尝试 `modifyOtherKeys`，并能解析 `CSI 27;2;13~`。 | 默认 Shift/Ctrl/Alt+Enter 和 Ctrl+J 都是换行。 | 说明成熟 TUI 会协商并保留多种回退，但终端侧不能替应用擅自假定协议。 |
+| Gemini CLI | TypeScript/Ink。启动时同时查询 Kitty、`modifyOtherKeys`、终端名和 DA；收到 Kitty 回复优先启用，否则只在确认 `modifyOtherKeys` level 2 后启用。 | Shift/Ctrl/Cmd/Alt+Enter 和 Ctrl+J 都是换行。 | 是“探测后启用”的直接范例，不支持无条件 CSI-u。 |
+| Qwen Code | TypeScript，Ink 与 OpenTUI 两条路径都先发 Kitty query + DA；无回复/仅 DA/超时即保持 legacy，备用屏重新 push。解析器也认识 `modifyOtherKeys`。 | Shift/Ctrl/Cmd+Enter 和 Ctrl+J 是换行。 | 同样把能力协商与备用屏状态分开，支持 PR #3247 的方向。 |
+
+### Codex
+
+Codex Unix 启动探针发 `CSI ?u` 和 DA，[探针发送](https://github.com/openai/codex/blob/eb10d91e48ccbd0930427461fb392337addb1ac0/codex-rs/tui/src/terminal_probe.rs#L268-L289) 并把“只收到 DA”判为不支持。[探针解析](https://github.com/openai/codex/blob/eb10d91e48ccbd0930427461fb392337addb1ac0/codex-rs/tui/src/terminal_probe.rs#L437-L499) 但 Windows 初始化先执行 `set_input_record_mode()`，[TUI 初始化](https://github.com/openai/codex/blob/eb10d91e48ccbd0930427461fb392337addb1ac0/codex-rs/tui/src/tui.rs#L227-L247)；其 crossterm fork 在 Windows 上也明确让 Kitty 支持探测恒为 false。[crossterm fork](https://github.com/openai-oss-forks/crossterm/blob/45fecb9508105988f42fe6ff0441783ed3717f92/src/terminal/sys/windows.rs#L71-L77) 这与报告者“打开 Netcatty Kitty 设置仍无效”完全一致：Codex 的 Windows 路径本来就不靠 Kitty。
+
+### Grok Build
+
+Grok 使用 crossterm 0.28，[依赖声明](https://github.com/xai-org/grok-build/blob/72a61251fcffb464bcc687aeb5a998e5a98ec0c9/Cargo.toml#L140-L149)。它在 VS Code/xterm.js、Windows Terminal、旧 VTE、未知且无 multiplexer 的环境主动跳过 Kitty，[兼容性门禁](https://github.com/xai-org/grok-build/blob/72a61251fcffb464bcc687aeb5a998e5a98ec0c9/crates/codegen/xai-grok-pager-render/src/terminal/mod.rs#L313-L358)；只有门禁通过且 crossterm 探测成功才 push flags。[启动协商](https://github.com/xai-org/grok-build/blob/72a61251fcffb464bcc687aeb5a998e5a98ec0c9/crates/codegen/xai-grok-pager/src/app/mod.rs#L1466-L1497) crossterm 0.28 在 Windows 的 `supports_keyboard_enhancement()` 恒为 false，[crossterm 0.28](https://github.com/crossterm-rs/crossterm/blob/5d50d8da62c5e034ef8b2787a771a2c0f9b3b2f9/src/terminal/sys/windows.rs#L71-L77)，但它读取 Win32 控制键状态时会把 `SHIFT_PRESSED` 转成 `KeyModifiers::SHIFT`。[Windows 按键解析](https://github.com/crossterm-rs/crossterm/blob/5d50d8da62c5e034ef8b2787a771a2c0f9b3b2f9/src/event/sys/windows/parse.rs#L79-L98)
+
+所以 Grok 当前源码并不要求 Netcatty“伪装成 Kitty 终端”；它要求 Windows 输入链路不要在进入 crossterm 前丢掉 Shift。Grok 已经在输入框中处理 Shift/Alt+Enter，[输入框逻辑](https://github.com/xai-org/grok-build/blob/72a61251fcffb464bcc687aeb5a998e5a98ec0c9/crates/codegen/xai-grok-pager/src/views/prompt_widget/mod.rs#L1680-L1686)，并在不可区分时提示 Alt+Enter。[提示逻辑](https://github.com/xai-org/grok-build/blob/72a61251fcffb464bcc687aeb5a998e5a98ec0c9/crates/codegen/xai-grok-pager/src/views/agent.rs#L952-L973)
+
+### OpenCode / OpenTUI
+
+OpenCode 当前创建 OpenTUI renderer 时启用 `useKittyKeyboard`，[OpenCode TUI](https://github.com/sst/opencode/blob/69c172e8a7c0086887b1f93ed5a162f14b6aa0c5/packages/tui/src/app.tsx#L186-L206)，换行键包括 Shift/Ctrl/Alt+Return 与 Ctrl+J。[按键配置](https://github.com/sst/opencode/blob/69c172e8a7c0086887b1f93ed5a162f14b6aa0c5/packages/tui/src/config/keybind.ts#L161-L165) 它的框架 OpenTUI 0.4.5 会发 `CSI ?u`，[能力查询](https://github.com/sst/opentui/blob/0c8c4f7cff2927e3df63a9757a45eff9a343611c/packages/core/src/zig/ansi.zig#L311-L336)，只有检测到 Kitty 回复才 push flags；否则先尝试 `modifyOtherKeys`。[模式选择](https://github.com/sst/opentui/blob/0c8c4f7cff2927e3df63a9757a45eff9a343611c/packages/core/src/zig/terminal.zig#L362-L381) 解析器同时支持 Kitty 与 `modifyOtherKeys` 的 Shift+Enter。[解析器](https://github.com/sst/opentui/blob/0c8c4f7cff2927e3df63a9757a45eff9a343611c/packages/core/src/lib/parse.keypress.ts#L311-L339)
+
+### Gemini CLI
+
+Gemini 同时定义 Kitty、`modifyOtherKeys` 与 DA 查询，[查询定义](https://github.com/google-gemini/gemini-cli/blob/4963a4456a886bb6af7dcfb807ad6e3e46ce46fc/packages/cli/src/ui/utils/terminalCapabilityManager.ts#L41-L85)，把 DA 当作所有查询已经处理的哨兵，[探测流程](https://github.com/google-gemini/gemini-cli/blob/4963a4456a886bb6af7dcfb807ad6e3e46ce46fc/packages/cli/src/ui/utils/terminalCapabilityManager.ts#L182-L250)，并且只启用已经得到正面回复的协议。[启用决策](https://github.com/google-gemini/gemini-cli/blob/4963a4456a886bb6af7dcfb807ad6e3e46ce46fc/packages/cli/src/ui/utils/terminalCapabilityManager.ts#L258-L272) 其解析器兼容两种编码，[按键解析](https://github.com/google-gemini/gemini-cli/blob/4963a4456a886bb6af7dcfb807ad6e3e46ce46fc/packages/cli/src/ui/contexts/KeypressContext.tsx#L565-L588)，并把所有常见 modified Enter 绑定为换行。[按键配置](https://github.com/google-gemini/gemini-cli/blob/4963a4456a886bb6af7dcfb807ad6e3e46ce46fc/packages/cli/src/ui/key/keyBindings.ts#L359-L371)
+
+### Qwen Code
+
+Qwen 的 Ink 路径按规范发 Kitty query + DA，只有收到 Kitty 回复才 push，超时则保持 legacy。[检测器](https://github.com/QwenLM/qwen-code/blob/83c4e7ea84d5c5dde9b6fb14d3a5ab4aa7afaf94/packages/cli/src/ui/utils/kittyProtocolDetector.ts#L27-L124) 它也明确处理了主屏/备用屏各自有协议栈的问题。[备用屏重新 push](https://github.com/QwenLM/qwen-code/blob/83c4e7ea84d5c5dde9b6fb14d3a5ab4aa7afaf94/packages/cli/src/ui/utils/kittyProtocolDetector.ts#L134-L151) OpenTUI 路径先做同样的 200ms 探测，无回复就不启用 Kitty。[OpenTUI 协商](https://github.com/QwenLM/qwen-code/blob/83c4e7ea84d5c5dde9b6fb14d3a5ab4aa7afaf94/packages/cli/src/ui/opentui/kitty-negotiation.ts#L76-L147) 它的按键配置已经支持 Shift/Ctrl/Cmd+Enter 和 Ctrl+J 换行。[按键配置](https://github.com/QwenLM/qwen-code/blob/83c4e7ea84d5c5dde9b6fb14d3a5ab4aa7afaf94/packages/cli/src/config/keyBindings.ts#L208-L230)
+
+## 5. 为什么不能把 Windows 修法改成“ConPTY 内部统一转 Kitty”
+
+Windows Terminal 已通过 PR [#19817](https://github.com/microsoft/terminal/pull/19817) 实现 Kitty keyboard protocol，但当前 ConPTY 源码明确临时禁止把 win32-input-mode 输入转成 Kitty，因为这会绕过 Windows Terminal 自己的开关。[当前 `VtIo.cpp`](https://github.com/microsoft/terminal/blob/62711fd73ef9733fa83108bfa7cea22528d2dbb9/src/host/VtIo.cpp#L125-L131) 对应的 Microsoft issue [#19847](https://github.com/microsoft/terminal/issues/19847) 截至研究时仍 open。
+
+因此现在让 Netcatty 在 ConPTY 路径强发 Kitty，不仅与 Codex/Grok 的 Windows 输入模型不合，还押注了一个 Microsoft 尚未放开的转换。让 xterm.js 按 ConPTY 已经发出的 `?9001h` 请求回送 Win32 输入记录，才是当前标准定义且已落地的路径。
+
+## 6. Netcatty 能独立修什么，哪些必须由 TUI 配合
+
+### Netcatty 可以独立修复
+
+- 本机 Windows + ConPTY：开启 xterm.js `win32InputMode` capability；实际切换仍由 ConPTY 的 `CSI ?9001h` 触发。
+- 模式生效时，不再由 Netcatty 的 Shift+Enter 文本映射或 Kitty 编码截获按键，让 xterm.js 输出 Win32 记录。
+- 保留 PR #3247 的协商门槛：未协商 Kitty 的非 ConPTY 程序不能收到强制 CSI-u。
+- 保持现有 Kitty query/set/push/pop 支持。Netcatty 当前已经处理这些序列，[协议处理器](https://github.com/binaricat/Netcatty/blob/f2ec2a4842dc4e1fc50b489df45f77bff79eb9d8/components/terminal/runtime/kittyKeyboardRuntime.ts#L58-L118)，只是默认设置关闭。[默认设置](https://github.com/binaricat/Netcatty/blob/f2ec2a4842dc4e1fc50b489df45f77bff79eb9d8/domain/models/terminal.ts#L483-L488)
+
+### 必须由 TUI 协商或支持
+
+- 普通 Unix/VT 链路要区分 Shift+Enter，TUI 必须启用 Kitty、`modifyOtherKeys` 或其他双方都理解的增强协议。Netcatty 只能提供能力和回复查询，不能凭“它看起来像 TUI”强制发送。
+- 未协商增强协议的旧程序只能收到传统 CR/LF；Netcatty 的“Shift+Enter 发送文本”可以作为内容级兼容选项，但不能称为修饰键直传。
+- Grok 在非 Windows、xterm.js/未知品牌的 VT 路径中主动跳过 Kitty，这是 Grok 的兼容策略。若以后要让这类路径也原生支持 Shift+Enter，应由 Grok 放宽门禁或由双方增加可靠的正面能力识别；这不属于 #2974 的本机 ConPTY 复现。
+
+### 暂不需要做
+
+- 不做 Codex/Grok/Claude/OpenCode 应用名识别。
+- 不根据主屏/备用屏猜协议能力。
+- 不为关闭 #2974 新增 `modifyOtherKeys`。它对部分 Unix TUI 有兼容价值，但 xterm.js 当前源码没有该模式的实现，而且本机 ConPTY 已有更直接的无损路径。
+- 不把 win32-input-mode 默认扩大到所有会话。VS Code 仍把它视为实验能力；先覆盖已知本机 ConPTY 路径更稳妥。
+
+## 7. PR #3247 的最终判断与关闭条件
+
+### 对补入 ConPTY 修复前的 PR 头 `f2ec2a4` 的判断
+
+**不能单独用它关闭 #2974。** 它是必要的安全修正，不是回退到“问题已解决前”的旧代码：它消除了错误的能力猜测和 Grok 字面 CSI-u 泄漏。但它在未协商 Kitty 时仍发送默认 `\n`，所以报告者的 Codex 仍拿不到 Shift。[默认回退文本](https://github.com/binaricat/Netcatty/blob/f2ec2a4842dc4e1fc50b489df45f77bff79eb9d8/components/terminal/runtime/shiftEnterText.ts#L52-L74) [PR 分支](https://github.com/binaricat/Netcatty/blob/f2ec2a4842dc4e1fc50b489df45f77bff79eb9d8/components/terminal/runtime/createXTermRuntime.ts#L1974-L2015)
+
+### 纳入 ConPTY 补丁后的判断
+
+对报告者明确的“Netcatty 本机启动 PowerShell → Codex/Grok”路径，这是针对根因的修复，不是应用级 workaround。当前工作树的字节级验证已经证明：
+
+- xterm.js 默认忽略 `CSI ?9001h`；
+- 开启 capability 后，模式会激活；
+- Enter、Shift+Enter、Ctrl+Enter、Alt+Enter 分别产生不同 Win32 输入记录；
+- Shift+Enter 的控制状态为 16，Ctrl+Enter 为 8，不再互相混淆；
+- Shift+Enter 文本回退和 Netcatty Kitty 编码在 Win32 模式下让路。
+- 原始 Win32 传输内容不会被误记为命令、自动补全文本或密码输入；修饰回车和按键松开没有文本提交含义。
+- 被 Netcatty 自己消费的快捷键不会留下孤立的松键；切走焦点时会补齐已经发出的松键，避免 TUI 认为 Shift 等按键一直按住。
+- 多终端广播按每个目标实际支持的协议分别编码，且不会把输入焦点从当前终端抢走。
+
+本地执行：
+
+```text
+node --test --import tsx \
+  components/terminal/runtime/shiftEnterText.test.ts \
+  components/terminal/runtime/win32InputMode.test.ts \
+  components/terminal/runtime/kittyKeyboardBroadcast.test.ts \
+  components/terminal/runtime/kittyKeyboardProtocol.test.ts \
+  components/terminal/runtime/terminalImeTextInput.test.ts
+
+90 passed, 0 failed
+```
+
+交付前的项目级验证也已通过：`npm run lint` 无错误，`npm test` 共 11,206 项（11,192 通过、0 失败、14 项环境限定跳过），`npm run build` 成功。两轮独立对抗审查均未发现 #2974 范围内仍可达的问题；弹窗迁移或远端 Windows 等额外覆盖面保留为范围外建议。
+
+### 建议的关闭门槛
+
+1. 把 ConPTY capability + 让路逻辑及测试提交到 PR #3247，而不是只保留当前 `f2ec2a4`。
+2. 在真实 Windows 上用本机终端复验：
+   - PowerShell 按键记录：Enter=`Mods=0`、Shift+Enter=`Mods=Shift`、Ctrl+Enter=`Mods=Control`；
+   - Codex：Shift+Enter 插入新行，不再被识别为 Ctrl+Enter；
+   - Grok：Shift+Enter 插入新行，不出现 `[13;2u` 字面文本。
+3. 上述真实链路通过后可以关闭 #2974；发布版让报告者复测仍是最理想的最后确认，但不应把“远端 Windows SSH 尚未专门验证”混入本 issue 的原始范围。
+
+## 8. 剩余不确定性
+
+- 本报告的源码和 JSDOM 字节测试确认了因果链，但没有代替真实 Windows UI/ConPTY 运行验证。
+- `win32-input-mode` 在 xterm.js 与 VS Code 中仍属较新的实验能力；本机 ConPTY 的窄范围启用降低了外溢风险。
+- 若未来收到“Netcatty → SSH → 远端 Windows ConPTY”同类报告，需要单独确认 `CSI ?9001h` 是否穿过该 SSH/PTY 实现，并决定是否在已识别的远端 Windows 会话启用 capability。那是后续覆盖面，不是当前 #2974 是否修复的否定条件。


### PR DESCRIPTION
## Summary

Fixes the local Windows path reported in #2974 without guessing which TUI is running.

The earlier commit fixed one compatibility regression: entering an alternate screen is not proof that an app negotiated enhanced keyboard input, so unnegotiated apps such as Grok must not receive literal CSI-u bytes.

This update also fixes the root cause for Netcatty local PowerShell -> Codex/Grok. ConPTY already requests lossless Windows keyboard records, and the xterm.js version in Netcatty already supports them, but Netcatty had not enabled that capability. Local ConPTY sessions now honor the request, preserving Shift/Ctrl/Alt on Enter before the event reaches PowerShell or the TUI.

The change remains narrow: it is enabled only for local ConPTY sessions. SSH, winpty, serial, telnet, and other legacy paths keep their existing behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [x] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Related to #2974

## Changes Made

- Keep alternate-screen state separate from keyboard-protocol negotiation.
- Enable xterm.js Win32 input mode only for local ConPTY terminals; ConPTY still decides when the mode activates.
- Let negotiated Win32 input preserve Enter, Shift+Enter, Ctrl+Enter, and Alt+Enter as distinct native records.
- Keep transport records separate from command history, autocomplete, script recording, sudo assistance, and password input semantics.
- Pair key presses/releases across intercepted shortcuts, IME input, focus loss, sensitive input, and per-target terminal broadcast.
- Keep the active terminal focused while another terminal encodes a broadcast event.
- Add a primary-source study of Codex, Grok Build, OpenCode/OpenTUI, Gemini CLI, Qwen Code, ConPTY, and xterm.js.

## Screenshots / Demo

No visual change. Real xterm tests verify the emitted ConPTY records:

- Enter: no modifier
- Shift+Enter: Shift state 16
- Ctrl+Enter: Control state 8
- Alt+Enter: Alt state 2

The same tests confirm broadcast encoding does not steal focus.

## Testing

- [ ] I have tested these changes locally (`npm run dev`) — real Windows runtime validation is still required
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — 11,206 total; 11,192 passed, 0 failed, 14 environment-gated tests skipped
- [x] Production build passes (`npm run build`)
- [x] Focused terminal input tests pass — 90 passed, 0 failed
- [x] Two independent adversarial reviews are clean for the #2974 scope
- [x] Generated capability tool specs are updated when applicable — not applicable
- [x] No new console errors or warnings in the exercised test paths

## Validation boundary

The code path, upstream behavior, and emitted input records are verified. A real Windows Netcatty local PowerShell -> Codex/Grok run remains the final runtime check before calling the reporter's environment confirmed. Remote Windows over SSH and renderer/window handoff are separate coverage areas, not the reproduction reported in #2974.

Research notes: [Issue #2974 source study](https://github.com/binaricat/Netcatty/blob/7451fed0162cab834a29b36577c6975612f10d78/docs/research/issue-2974-shift-enter-tui-source-study.md)

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes
