### PR TITLE
fix(ai): avoid idle PowerShell clear corruption

### DIFF
--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -26,8 +26,10 @@ const {
   consumeVisibleText,
   stripAnsi,
 } = require("./ptyExecHelpers.cjs");
+const { extractTrailingIdlePrompt } = require("./shellUtils.cjs");
 
 const DEFAULT_FOREGROUND_PTY_CAPTURE_CHARS = 1024 * 1024;
+const END_MARKER_PROMPT_WAIT_MS = 30000;
 
 function stripJobMarkerLines(text, marker) {
   return text.replace(
@@ -57,6 +59,9 @@ function startPtyJob(ptyStream, command, options) {
   const resolvedShellKind = resolveEffectiveShellKind(shellKind, expectedPrompt, {
     loginShellHint,
   });
+  const waitForReturnedPrompt = loginShellHint === "cmd"
+    && resolvedShellKind === "powershell"
+    && Boolean(expectedPrompt);
   const captureLimitChars = maxBufferedChars > 0
     ? maxBufferedChars
     : DEFAULT_FOREGROUND_PTY_CAPTURE_CHARS;
@@ -77,6 +82,7 @@ function startPtyJob(ptyStream, command, options) {
   let wallTimeoutId = null;
   let startupTimeoutId = null;
   let promptFallbackTimer = null;
+  let endMarkerWaitTimer = null;
   let cancelRetryTimerId = null;
   // Track one-shot timers scheduled inside requestCancel so finish() can
   // clear them when the job exits early; otherwise they keep the Node
@@ -87,6 +93,7 @@ function startPtyJob(ptyStream, command, options) {
   let unsubscribe = null;
   const cleanupFns = [];
   let pendingStart = "";
+  let pendingEnd = null;
   let resolveResult;
   const outputDecoder = new StringDecoder("utf8");
   const resultPromise = new Promise((resolve) => {
@@ -100,10 +107,23 @@ function startPtyJob(ptyStream, command, options) {
     }
   }
 
+  function clearEndMarkerWait() {
+    if (endMarkerWaitTimer) {
+      clearTimeout(endMarkerWaitTimer);
+      endMarkerWaitTimer = null;
+    }
+  }
+
   function clearCancelRetryTimer() {
     if (cancelRetryTimerId) {
       clearTimeout(cancelRetryTimerId);
       cancelRetryTimerId = null;
+    }
+  }
+
+  function clearCancelOneShotTimers() {
+    while (cancelOneShotTimers.length) {
+      clearTimeout(cancelOneShotTimers.pop());
     }
   }
 
@@ -129,6 +149,10 @@ function startPtyJob(ptyStream, command, options) {
     if (!enforceWallTimeout || maxBufferedChars > 0) return;
     wallTimeoutId = setTimeout(() => {
       if (finished) return;
+      if (pendingEnd) {
+        finish(pendingEnd.stdout, pendingEnd.exitCode);
+        return;
+      }
       sendInterrupt();
       const timeoutSec = Math.round(timeoutMs / 1000);
       finish(foundStart ? output : preStartOutput, -1, `Command timed out (${timeoutSec}s)`);
@@ -178,6 +202,11 @@ function startPtyJob(ptyStream, command, options) {
 
   function requestCancel() {
     if (finished || cancelRequested) return;
+    if (pendingEnd) {
+      // The command already completed. Do not send Ctrl+C into the restoring
+      // prompt or release the lock before the next shell can be identified.
+      return;
+    }
     cancelRequested = true;
     clearPromptFallback();
     clearCancelRetryTimer();
@@ -233,10 +262,33 @@ function startPtyJob(ptyStream, command, options) {
   }
 
   function checkEnd() {
+    if (pendingEnd) {
+      if (extractTrailingIdlePrompt(output)) {
+        finish(pendingEnd.stdout, pendingEnd.exitCode);
+      }
+      return;
+    }
     const found = findEndMarker(output, marker, { allowInline: true });
     if (!found) return;
     const stdout = output.slice(0, found.endIdx);
-    finish(stdout, found.exitCode);
+    pendingEnd = { stdout, exitCode: found.exitCode };
+    clearTimeout(timeoutId);
+    timeoutId = null;
+    clearStartupTimeout();
+    clearCancelRetryTimer();
+    clearCancelOneShotTimers();
+    if (!waitForReturnedPrompt || extractTrailingIdlePrompt(output)) {
+      finish(stdout, found.exitCode);
+      return;
+    }
+    // In the Windows OpenSSH cmd-to-PowerShell startup path, the end marker and
+    // restored prompt can arrive separately. Keep the lock until the prompt
+    // returns so a consecutive command cannot fall back to cmd.exe.
+    if (!endMarkerWaitTimer) {
+      endMarkerWaitTimer = setTimeout(() => {
+        finish(stdout, found.exitCode);
+      }, END_MARKER_PROMPT_WAIT_MS);
+    }
   }
 
   // Carry buffer for incomplete marker lines split across chunks.
@@ -317,12 +369,11 @@ function startPtyJob(ptyStream, command, options) {
     clearTimeout(wallTimeoutId);
     clearStartupTimeout();
     clearPromptFallback();
+    clearEndMarkerWait();
     clearCancelRetryTimer();
     // Clear any pending one-shot cancel timers so they do not keep the
     // Node event loop alive after the job has resolved.
-    while (cancelOneShotTimers.length) {
-      clearTimeout(cancelOneShotTimers.pop());
-    }
+    clearCancelOneShotTimers();
     unsubscribe?.();
     for (const fn of cleanupFns) {
       try {
@@ -420,7 +471,7 @@ function startPtyJob(ptyStream, command, options) {
         : Buffer.from(String(data ?? ""));
     const text = outputDecoder.write(bytes);
     if (!text) return;
-    armOutputTimeout();
+    if (!pendingEnd) armOutputTimeout();
 
     if (!foundStart) {
       preStartOutput += text;
@@ -502,13 +553,20 @@ function startPtyJob(ptyStream, command, options) {
     }
 
     appendToOutput(text);
+    // Process a completed marker before cancellation/prompt handling so the
+    // internal marker cannot leak when both arrive in the same PTY chunk.
+    checkEnd();
+    if (finished) return;
     if (!cancelRequested) {
       schedulePromptFallback();
     } else if (hasExpectedPromptSuffix(output, expectedPrompt)) {
-      finish(output, 130, "Cancelled");
+      finish(
+        pendingEnd?.stdout ?? output,
+        pendingEnd?.exitCode ?? 130,
+        "Cancelled",
+      );
       return;
     }
-    checkEnd();
   }
 
   if (abortSignal?.aborted) {
@@ -544,8 +602,20 @@ function startPtyJob(ptyStream, command, options) {
   }
 
   if (typeof ptyStream.on === "function") {
-    const onClose = () => finish(foundStart ? output : preStartOutput, null, cancelRequested ? "Cancelled" : "Stream closed unexpectedly");
-    const onError = (err) => finish(foundStart ? output : preStartOutput, -1, cancelRequested ? "Cancelled" : `Stream error: ${err?.message || err}`);
+    const onClose = () => {
+      if (pendingEnd) {
+        finish(pendingEnd.stdout, pendingEnd.exitCode, cancelRequested ? "Cancelled" : null);
+        return;
+      }
+      finish(foundStart ? output : preStartOutput, null, cancelRequested ? "Cancelled" : "Stream closed unexpectedly");
+    };
+    const onError = (err) => {
+      if (pendingEnd) {
+        finish(pendingEnd.stdout, pendingEnd.exitCode, cancelRequested ? "Cancelled" : null);
+        return;
+      }
+      finish(foundStart ? output : preStartOutput, -1, cancelRequested ? "Cancelled" : `Stream error: ${err?.message || err}`);
+    };
     ptyStream.on("close", onClose);
     ptyStream.on("end", onClose);
     ptyStream.on("error", onError);
@@ -556,7 +626,13 @@ function startPtyJob(ptyStream, command, options) {
     });
   }
   if (typeof ptyStream.onExit === "function") {
-    const disposable = ptyStream.onExit(() => finish(foundStart ? output : preStartOutput, null, cancelRequested ? "Cancelled" : "Process exited"));
+    const disposable = ptyStream.onExit(() => {
+      if (pendingEnd) {
+        finish(pendingEnd.stdout, pendingEnd.exitCode, cancelRequested ? "Cancelled" : null);
+        return;
+      }
+      finish(foundStart ? output : preStartOutput, null, cancelRequested ? "Cancelled" : "Process exited");
+    });
     cleanupFns.push(() => {
       try {
         disposable?.dispose?.();

--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -583,17 +583,7 @@ function startPtyJob(ptyStream, command, options) {
   }
 
   const wrapped = buildWrappedCommand(command, resolvedShellKind, marker);
-  // A recognized PowerShell prompt at the live PTY tail indicates the shell
-  // was idle at the last observed output. Avoid sending the PowerShell clear
-  // sequence in that state: edit modes do not share one portable
-  // Escape/Ctrl+U/Ctrl+K binding, and unsupported keys can leak into the next
-  // command. Preserve the existing pending-input defense for every other
-  // shell and when no live PowerShell prompt is available (#3252).
-  const skipPowerShellClear = resolvedShellKind === "powershell" && expectedPrompt;
-  const clearPrefix = skipPowerShellClear
-    ? ""
-    : buildPendingInputClearPrefix(resolvedShellKind);
-  ptyStream.write(`${clearPrefix}${wrapped}`);
+  ptyStream.write(`${buildPendingInputClearPrefix(resolvedShellKind)}${wrapped}`);
 
   return {
     marker,

--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -583,7 +583,17 @@ function startPtyJob(ptyStream, command, options) {
   }
 
   const wrapped = buildWrappedCommand(command, resolvedShellKind, marker);
-  ptyStream.write(`${buildPendingInputClearPrefix(resolvedShellKind)}${wrapped}`);
+  // A recognized PowerShell prompt at the live PTY tail indicates the shell
+  // was idle at the last observed output. Avoid sending the PowerShell clear
+  // sequence in that state: edit modes do not share one portable
+  // Escape/Ctrl+U/Ctrl+K binding, and unsupported keys can leak into the next
+  // command. Preserve the existing pending-input defense for every other
+  // shell and when no live PowerShell prompt is available (#3252).
+  const skipPowerShellClear = resolvedShellKind === "powershell" && expectedPrompt;
+  const clearPrefix = skipPowerShellClear
+    ? ""
+    : buildPendingInputClearPrefix(resolvedShellKind);
+  ptyStream.write(`${clearPrefix}${wrapped}`);
 
   return {
     marker,

--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -30,12 +30,21 @@ const { extractTrailingIdlePrompt } = require("./shellUtils.cjs");
 
 const DEFAULT_FOREGROUND_PTY_CAPTURE_CHARS = 1024 * 1024;
 const END_MARKER_PROMPT_WAIT_MS = 30000;
+const promptRecoveryPendingPtys = new WeakSet();
 
 function stripJobMarkerLines(text, marker) {
   return text.replace(
     new RegExp(`^([^\r\n]*?)${marker}[^\r\n]*[\r\n]*`, "gm"),
     "$1",
   );
+}
+
+function trailingPrefixLength(text, prefix) {
+  const maxLength = Math.min(text.length, prefix.length);
+  for (let length = maxLength; length > 0; length -= 1) {
+    if (text.endsWith(prefix.slice(0, length))) return length;
+  }
+  return 0;
 }
 
 function startPtyJob(ptyStream, command, options) {
@@ -62,6 +71,17 @@ function startPtyJob(ptyStream, command, options) {
   const waitForReturnedPrompt = loginShellHint === "cmd"
     && resolvedShellKind === "powershell"
     && Boolean(expectedPrompt);
+  if (promptRecoveryPendingPtys.has(ptyStream)) {
+    if (extractTrailingIdlePrompt(expectedPrompt || "")) {
+      promptRecoveryPendingPtys.delete(ptyStream);
+    } else {
+      const error = new Error(
+        "Terminal is still waiting for the shell prompt after the previous command",
+      );
+      error.code = "SHELL_PROMPT_PENDING";
+      throw error;
+    }
+  }
   const captureLimitChars = maxBufferedChars > 0
     ? maxBufferedChars
     : DEFAULT_FOREGROUND_PTY_CAPTURE_CHARS;
@@ -127,6 +147,12 @@ function startPtyJob(ptyStream, command, options) {
     }
   }
 
+  function finishWithoutReturnedPrompt() {
+    if (!pendingEnd || finished) return;
+    promptRecoveryPendingPtys.add(ptyStream);
+    finish(pendingEnd.stdout, pendingEnd.exitCode);
+  }
+
   function armOutputTimeout() {
     clearTimeout(timeoutId);
     timeoutId = setTimeout(() => {
@@ -150,7 +176,7 @@ function startPtyJob(ptyStream, command, options) {
     wallTimeoutId = setTimeout(() => {
       if (finished) return;
       if (pendingEnd) {
-        finish(pendingEnd.stdout, pendingEnd.exitCode);
+        finishWithoutReturnedPrompt();
         return;
       }
       sendInterrupt();
@@ -271,6 +297,19 @@ function startPtyJob(ptyStream, command, options) {
     const found = findEndMarker(output, marker, { allowInline: true });
     if (!found) return;
     const stdout = output.slice(0, found.endIdx);
+    if (maxBufferedChars > 0) {
+      // visibleOutput is assembled independently from the raw marker buffer.
+      // If a chunk split happens inside the constant "__NCMCP_" prefix, the
+      // partial prefix may already have entered visibleOutput before the next
+      // chunk makes the full marker recognizable. Roll back at the complete
+      // marker now that checkEnd has reconstructed it from raw output.
+      const visibleEnd = findEndMarker(visibleOutput, marker, { allowInline: true });
+      if (visibleEnd) {
+        visibleOutput = visibleOutput.slice(0, visibleEnd.endIdx);
+        visibleMarkerCarry = "";
+        visibleCarry = "";
+      }
+    }
     pendingEnd = { stdout, exitCode: found.exitCode };
     clearTimeout(timeoutId);
     timeoutId = null;
@@ -285,9 +324,10 @@ function startPtyJob(ptyStream, command, options) {
     // restored prompt can arrive separately. Keep the lock until the prompt
     // returns so a consecutive command cannot fall back to cmd.exe.
     if (!endMarkerWaitTimer) {
-      endMarkerWaitTimer = setTimeout(() => {
-        finish(stdout, found.exitCode);
-      }, END_MARKER_PROMPT_WAIT_MS);
+      endMarkerWaitTimer = setTimeout(
+        finishWithoutReturnedPrompt,
+        END_MARKER_PROMPT_WAIT_MS,
+      );
     }
   }
 
@@ -323,24 +363,24 @@ function startPtyJob(ptyStream, command, options) {
       // lines split across PTY data boundaries are matched as a whole.
       cleanVisible = visibleMarkerCarry + cleanVisible;
       visibleMarkerCarry = "";
-      // We must withhold any trailing line that *might* be the start of an
-      // internal marker line, even if the random marker token isn't fully
-      // present yet (the chunk boundary may split the marker mid-token).
-      // Detect this by looking for the constant prefix "__NCMCP_" — only
-      // user output that *contains an unrelated __NCMCP_ string and ends
-      // with a newline* will be preserved through the next strip step.
-      const NCMCP_PREFIX = "__NCMCP_";
-      const lastNl = cleanVisible.lastIndexOf("\n");
-      if (lastNl === -1) {
-        if (cleanVisible.includes(NCMCP_PREFIX)) {
-          visibleMarkerCarry = cleanVisible;
-          return;
-        }
-      } else if (lastNl < cleanVisible.length - 1) {
-        const trailing = cleanVisible.slice(lastNl + 1);
-        if (trailing.includes(NCMCP_PREFIX)) {
-          visibleMarkerCarry = trailing;
-          cleanVisible = cleanVisible.slice(0, lastNl + 1);
+      // Once the end marker is visible, freeze the background result at that
+      // exact boundary. A changed PowerShell prompt may not match
+      // expectedPrompt, but it is session state rather than command output.
+      const completedMarker = findEndMarker(cleanVisible, marker, { allowInline: true });
+      if (completedMarker) {
+        cleanVisible = cleanVisible.slice(0, completedMarker.endIdx);
+      } else {
+        // Hold back the longest suffix that could still become this job's end
+        // marker. This covers chunk splits anywhere in the random marker,
+        // including before the constant "__NCMCP_" prefix is complete, while
+        // allowing preceding command output to remain visible to pollers.
+        const partialMarkerLength = trailingPrefixLength(
+          cleanVisible,
+          `${marker}_E:`,
+        );
+        if (partialMarkerLength > 0) {
+          visibleMarkerCarry = cleanVisible.slice(-partialMarkerLength);
+          cleanVisible = cleanVisible.slice(0, -partialMarkerLength);
         }
       }
       // Strip only this job's specific marker lines so user output that
@@ -359,7 +399,7 @@ function startPtyJob(ptyStream, command, options) {
     if (!text) return;
     const next = appendBoundedOutput(output, text, captureLimitChars);
     output = next.text;
-    appendToVisible(text);
+    if (!pendingEnd) appendToVisible(text);
   }
 
   function finish(stdout, exitCode, error) {

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -166,6 +166,39 @@ test("background PTY jobs preserve output that has no trailing newline", async (
   assert.equal(result.exitCode, 0);
 });
 
+test("background PowerShell jobs exclude a changed prompt from results and snapshots", async () => {
+  class CapturePty extends EventEmitter {
+    write() {}
+  }
+  const pty = new CapturePty();
+  const job = startPtyJob(pty, "Set-Location C:\\tmp; Write-Output 'DONE'", {
+    shellKind: "unknown",
+    loginShellHint: "cmd",
+    timeoutMs: 1000,
+    expectedPrompt: "PS C:\\Users\\alice>",
+    maxBufferedChars: 1024,
+    normalizeFinalOutput: false,
+  });
+
+  const endMarker = `${job.marker}_E:0`;
+  pty.emit("data", Buffer.from(`${job.marker}_S\r\nDONE\r\n${endMarker.slice(0, 4)}`));
+  const partialSnapshot = job.getSnapshot();
+  assert.equal(partialSnapshot.stdout, "DONE\n");
+  assert.equal(partialSnapshot.totalOutputChars, "DONE\n".length);
+  assert.doesNotMatch(partialSnapshot.stdout, /__NC/);
+
+  pty.emit("data", Buffer.from(`${endMarker.slice(4)}\r\nPS C:\\tmp>`));
+  const result = await job.resultPromise;
+  const snapshot = job.getSnapshot();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.stdout, "DONE\n");
+  assert.equal(snapshot.stdout, "DONE\n");
+  assert.ok(snapshot.totalOutputChars >= partialSnapshot.totalOutputChars);
+  assert.doesNotMatch(result.stdout, /PS C:\\\\tmp>/);
+  assert.doesNotMatch(snapshot.stdout, /PS C:\\\\tmp>/);
+});
+
 test("uses PowerShell wrapping when a session with no confirmed shell sees a PowerShell prompt", () => {
   // SSH sessions don't set shellKind (sshBridge never assigns one), which
   // is exactly the issue #841 case the override targets.
@@ -523,7 +556,7 @@ test("stream termination after an end marker preserves the completed result", as
   }
 });
 
-test("prompt waiting honors the original foreground wall deadline", async () => {
+test("a foreground wall deadline returns on time but blocks writes until the prompt returns", async () => {
   const writes = [];
   class CapturePty extends EventEmitter {
     write(data) {
@@ -531,34 +564,61 @@ test("prompt waiting honors the original foreground wall deadline", async () => 
     }
   }
   const pty = new CapturePty();
-  const job = startPtyJob(pty, "Write-Output 'DONE'", {
-    shellKind: "unknown",
-    loginShellHint: "cmd",
-    timeoutMs: 120,
-    expectedPrompt: "PS C:\\Users\\alice>",
+  const session = { _loginShellKind: "cmd" };
+  pty.on("data", (data) => trackSessionIdlePrompt(session, String(data)));
+  trackSessionIdlePrompt(session, "PS C:\\Users\\alice>");
+
+  const first = startPtyJob(pty, "Write-Output 'DONE'", {
+    shellKind: session.shellKind,
+    loginShellHint: session._loginShellKind,
+    timeoutMs: 30,
+    expectedPrompt: getFreshIdlePrompt(session),
     enforceWallTimeout: true,
   });
-  pty.emit("data", Buffer.from(`${job.marker}_S\r\nDONE\r\n${job.marker}_E:0\r\n`));
+  pty.emit("data", Buffer.from(`${first.marker}_S\r\nDONE\r\n${first.marker}_E:0\r\n`));
 
-  let settled = false;
-  job.resultPromise.then(() => { settled = true; });
-  await new Promise((resolve) => setTimeout(resolve, 40));
-  assert.equal(settled, false);
+  const deadlineGuard = Symbol("deadline guard");
+  const firstResult = await Promise.race([
+    first.resultPromise,
+    new Promise((resolve) => setTimeout(() => resolve(deadlineGuard), 300)),
+  ]);
+  assert.notEqual(firstResult, deadlineGuard);
+  assert.equal(firstResult.ok, true);
+  assert.equal(firstResult.exitCode, 0);
+  assert.equal(firstResult.stdout, "DONE");
   assert.equal(writes.filter((write) => write === "\x03").length, 0);
 
-  const didNotReachDeadline = Symbol("did not reach deadline");
-  const outcome = await Promise.race([
-    job.resultPromise,
-    new Promise((resolve) => setTimeout(() => resolve(didNotReachDeadline), 300)),
-  ]);
-  if (outcome === didNotReachDeadline) {
-    pty.emit("close");
-  }
+  assert.throws(
+    () => startPtyJob(pty, "Write-Output 'TOO_EARLY'", {
+      shellKind: session.shellKind,
+      loginShellHint: session._loginShellKind,
+      timeoutMs: 1000,
+      expectedPrompt: getFreshIdlePrompt(session),
+    }),
+    (error) => (
+      error?.code === "SHELL_PROMPT_PENDING"
+      && /waiting for the shell prompt/i.test(error.message)
+    ),
+  );
+  assert.equal(writes.length, 1);
 
-  assert.notEqual(outcome, didNotReachDeadline);
-  assert.equal(outcome.ok, true);
-  assert.equal(outcome.exitCode, 0);
-  assert.equal(outcome.stdout, "DONE");
+  pty.emit("data", Buffer.from("PS C:\\Users\\alice>"));
+  const second = startPtyJob(pty, "Write-Output 'NEXT'", {
+    shellKind: session.shellKind,
+    loginShellHint: session._loginShellKind,
+    timeoutMs: 1000,
+    expectedPrompt: getFreshIdlePrompt(session),
+  });
+  const secondWrite = writes.at(-1);
+  assert.match(secondWrite, /\$__NCMCP_/);
+  assert.doesNotMatch(secondWrite, /cmd \/d \/s \/c/i);
+  pty.emit(
+    "data",
+    Buffer.from(`${second.marker}_S\r\nNEXT\r\n${second.marker}_E:0\r\nPS C:\\Users\\alice>`),
+  );
+  const secondResult = await second.resultPromise;
+  assert.equal(secondResult.ok, true);
+  assert.equal(secondResult.stdout, "NEXT");
   assert.equal(writes.filter((write) => write === "\x03").length, 0);
 });
 

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -335,7 +335,33 @@ test("pending-input clear prefix covers interactive shells and skips raw devices
   assert.equal(buildPendingInputClearPrefix("raw"), "");
 });
 
-test("startPtyJob writes the clear prefix before the wrapper", async () => {
+test("startPtyJob trusts a live PowerShell prompt over a cmd login hint without clearing it", async () => {
+  for (const command of ["Write-Output 'one'", "Write-Output 'two'"]) {
+    const writes = [];
+    class CapturePty extends EventEmitter {
+      write(data) {
+        writes.push(String(data));
+      }
+    }
+    const pty = new CapturePty();
+    const job = startPtyJob(pty, command, {
+      shellKind: "unknown",
+      loginShellHint: "cmd",
+      timeoutMs: 50,
+      expectedPrompt: "PS C:\\Users\\alice>",
+    });
+    assert.equal(writes.length, 1);
+    assert.ok(writes[0].startsWith("$__NCMCP_"));
+    assert.equal(writes[0].startsWith("\x1b\x15\x0b"), false);
+    assert.match(writes[0], /__NCMCP_/);
+    assert.doesNotMatch(writes[0], /cmd \/d \/s \/c/i);
+    job.cancel();
+    pty.emit("data", Buffer.from("PS C:\\Users\\alice>"));
+    await job.resultPromise;
+  }
+});
+
+test("startPtyJob keeps the clear prefix for non-PowerShell sessions", async () => {
   const writes = [];
   class CapturePty extends EventEmitter {
     write(data) {

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -330,29 +330,113 @@ test("loginShellHint selects fish/posix/powershell/cmd without pinning confirmed
 test("pending-input clear prefix covers interactive shells and skips raw devices", () => {
   assert.equal(buildPendingInputClearPrefix("posix"), "\x15\x0b");
   assert.equal(buildPendingInputClearPrefix("fish"), "\x15\x0b");
-  assert.equal(buildPendingInputClearPrefix("powershell"), "\x1b");
+  assert.equal(buildPendingInputClearPrefix("powershell"), "i\x15\x0b\x1b\x1bi\x08");
   assert.equal(buildPendingInputClearPrefix("cmd"), "\x1b");
   assert.equal(buildPendingInputClearPrefix("raw"), "");
 });
 
-test("startPtyJob clears unobserved PowerShell input across consecutive jobs", async () => {
+test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi edit modes", async () => {
   class PowerShellLinePty extends EventEmitter {
-    constructor() {
+    constructor(editMode) {
       super();
+      this.editMode = editMode;
       this.pendingInput = "";
+      this.cursor = 0;
+      this.viInsertMode = true;
+      this.emacsChord = false;
       this.submittedLines = [];
       this.writes = [];
+    }
+
+    setPendingInput(text, { cursor = text.length, viInsertMode = true } = {}) {
+      this.pendingInput = text;
+      this.cursor = cursor;
+      this.viInsertMode = viInsertMode;
+    }
+
+    insert(text) {
+      this.pendingInput = `${this.pendingInput.slice(0, this.cursor)}${text}${this.pendingInput.slice(this.cursor)}`;
+      this.cursor += text.length;
+    }
+
+    applyEditKey(key) {
+      if (this.editMode === "windows") {
+        if (key === "\x1b") {
+          this.pendingInput = "";
+          this.cursor = 0;
+        } else if (key === "\x08") {
+          if (this.cursor > 0) {
+            this.pendingInput = `${this.pendingInput.slice(0, this.cursor - 1)}${this.pendingInput.slice(this.cursor)}`;
+            this.cursor -= 1;
+          }
+        } else {
+          // Windows-mode PSReadLine does not bind Ctrl+U/Ctrl+K. Model them as
+          // residual input so a later Escape is required before the wrapper.
+          this.insert(key);
+        }
+        return;
+      }
+
+      if (this.editMode === "emacs") {
+        if (this.emacsChord) {
+          this.emacsChord = false;
+          if (key.toLowerCase() === "r") {
+            this.pendingInput = "";
+            this.cursor = 0;
+          }
+        } else if (key === "\x1b") {
+          this.emacsChord = true;
+        } else if (key === "\x15") {
+          this.pendingInput = this.pendingInput.slice(this.cursor);
+          this.cursor = 0;
+        } else if (key === "\x0b") {
+          this.pendingInput = this.pendingInput.slice(0, this.cursor);
+        } else if (key === "\x08") {
+          if (this.cursor > 0) {
+            this.pendingInput = `${this.pendingInput.slice(0, this.cursor - 1)}${this.pendingInput.slice(this.cursor)}`;
+            this.cursor -= 1;
+          }
+        } else {
+          this.insert(key);
+        }
+        return;
+      }
+
+      if (!this.viInsertMode) {
+        if (key === "i") this.viInsertMode = true;
+        return;
+      }
+      if (key === "\x1b") {
+        this.viInsertMode = false;
+      } else if (key === "\x15") {
+        this.pendingInput = this.pendingInput.slice(this.cursor);
+        this.cursor = 0;
+      } else if (key === "\x0b") {
+        this.pendingInput = this.pendingInput.slice(0, this.cursor);
+      } else if (key === "\x08") {
+        if (this.cursor > 0) {
+          this.pendingInput = `${this.pendingInput.slice(0, this.cursor - 1)}${this.pendingInput.slice(this.cursor)}`;
+          this.cursor -= 1;
+        }
+      } else {
+        this.insert(key);
+      }
     }
 
     write(data) {
       const text = String(data);
       this.writes.push(text);
 
-      const hasRevertLine = text.startsWith("\x1b");
-      if (hasRevertLine) this.pendingInput = "";
-      const submittedLine = `${this.pendingInput}${text.slice(hasRevertLine ? 1 : 0)}`;
+      const clearPrefix = buildPendingInputClearPrefix("powershell");
+      assert.ok(text.startsWith(clearPrefix));
+      for (const key of clearPrefix) this.applyEditKey(key);
+      const wrapper = text.slice(clearPrefix.length);
+      const submittedLine = this.viInsertMode
+        ? `${this.pendingInput.slice(0, this.cursor)}${wrapper}${this.pendingInput.slice(this.cursor)}`
+        : this.pendingInput;
       this.submittedLines.push(submittedLine);
       this.pendingInput = "";
+      this.cursor = 0;
 
       const marker = submittedLine.match(/__NCMCP_[0-9a-z]+_[0-9a-f]+__/)?.[0];
       assert.ok(marker);
@@ -362,30 +446,37 @@ test("startPtyJob clears unobserved PowerShell input across consecutive jobs", a
     }
   }
 
-  const pty = new PowerShellLinePty();
-  const commands = ["Write-Output 'one'", "Write-Output 'two'"];
-  for (const [index, command] of commands.entries()) {
-    if (index === 1) {
-      // Model input accepted by PSReadLine before its echo reaches the tracked
-      // PTY output. The cached prompt still looks fresh in this window.
-      pty.pendingInput = "Write-Output 'USER'; ";
+  for (const editMode of ["windows", "emacs", "vi"]) {
+    const pty = new PowerShellLinePty(editMode);
+    const commands = ["Write-Output 'one'", "Write-Output 'two'"];
+    for (const [index, command] of commands.entries()) {
+      if (index === 1) {
+        // Model input accepted by PSReadLine before its echo reaches the
+        // tracked PTY output. Emacs starts at the beginning of the line and Vi
+        // starts in command mode to cover text on both sides and mode restore.
+        const pendingInput = "Write-Output 'USER'; ";
+        pty.setPendingInput(pendingInput, {
+          cursor: editMode === "emacs" || editMode === "vi" ? 0 : pendingInput.length,
+          viInsertMode: editMode !== "vi",
+        });
+      }
+      const job = startPtyJob(pty, command, {
+        shellKind: "unknown",
+        loginShellHint: "cmd",
+        timeoutMs: 50,
+        expectedPrompt: "PS C:\\Users\\alice>",
+      });
+      await job.resultPromise;
     }
-    const job = startPtyJob(pty, command, {
-      shellKind: "unknown",
-      loginShellHint: "cmd",
-      timeoutMs: 50,
-      expectedPrompt: "PS C:\\Users\\alice>",
-    });
-    await job.resultPromise;
-  }
 
-  assert.equal(pty.writes.length, 2);
-  assert.equal(pty.submittedLines.length, 2);
-  for (const [index, submittedLine] of pty.submittedLines.entries()) {
-    assert.ok(pty.writes[index].startsWith("\x1b$__NCMCP_"));
-    assert.ok(submittedLine.startsWith("$__NCMCP_"));
-    assert.doesNotMatch(submittedLine, /Write-Output 'USER'/);
-    assert.doesNotMatch(submittedLine, /cmd \/d \/s \/c/i);
+    assert.equal(pty.writes.length, 2);
+    assert.equal(pty.submittedLines.length, 2);
+    for (const [index, submittedLine] of pty.submittedLines.entries()) {
+      assert.ok(pty.writes[index].startsWith("i\x15\x0b\x1b\x1bi\x08$__NCMCP_"));
+      assert.ok(submittedLine.startsWith("$__NCMCP_"));
+      assert.doesNotMatch(submittedLine, /Write-Output 'USER'/);
+      assert.doesNotMatch(submittedLine, /cmd \/d \/s \/c/i);
+    }
   }
 });
 

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -330,21 +330,23 @@ test("loginShellHint selects fish/posix/powershell/cmd without pinning confirmed
 test("pending-input clear prefix covers interactive shells and skips raw devices", () => {
   assert.equal(buildPendingInputClearPrefix("posix"), "\x15\x0b");
   assert.equal(buildPendingInputClearPrefix("fish"), "\x15\x0b");
-  assert.equal(buildPendingInputClearPrefix("powershell"), "\x1bggdG\x1br\x1b\x1bi\x08");
+  assert.equal(buildPendingInputClearPrefix("powershell"), "\x1bggd2147483647d\x1br\x1b\x1bi\x08");
   assert.equal(buildPendingInputClearPrefix("cmd"), "\x1b");
   assert.equal(buildPendingInputClearPrefix("raw"), "");
 });
 
 test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi editor states", async () => {
   class PowerShellLinePty extends EventEmitter {
-    constructor(editMode) {
+    constructor(editMode, { legacyVi = false } = {}) {
       super();
       this.editMode = editMode;
+      this.legacyVi = legacyVi;
       this.pendingInput = "";
       this.cursor = 0;
       this.viInsertMode = true;
       this.viReplacePending = false;
       this.viChord = "";
+      this.viChordDigits = "";
       this.emacsChord = false;
       this.submittedLines = [];
       this.writes = [];
@@ -356,6 +358,7 @@ test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi editor state
       this.viInsertMode = viInsertMode;
       this.viReplacePending = false;
       this.viChord = "";
+      this.viChordDigits = "";
     }
 
     insert(text) {
@@ -410,12 +413,40 @@ test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi editor state
       }
       if (this.viChord) {
         const chord = this.viChord;
+        if (chord === "d" && /[0-9]/.test(key)) {
+          this.viChordDigits += key;
+          return;
+        }
         this.viChord = "";
         if (chord === "g" && key === "g") {
           this.cursor = 0;
-        } else if (chord === "d" && key === "G") {
+        } else if (chord === "d" && key === "G" && !this.legacyVi) {
           this.pendingInput = this.pendingInput.slice(0, this.cursor);
+        } else if (chord === "d" && key === "d") {
+          // PSReadLine 2.0's dd clears the whole buffer. In 2.1+, dd clears
+          // the requested number of logical lines.
+          if (this.legacyVi) {
+            this.pendingInput = "";
+            this.cursor = 0;
+          } else {
+            const requestedLines = Number(this.viChordDigits || "1");
+            const lineStart = this.pendingInput.lastIndexOf("\n", Math.max(0, this.cursor - 1)) + 1;
+            let lineEnd = lineStart;
+            let remaining = requestedLines;
+            while (remaining > 0 && lineEnd < this.pendingInput.length) {
+              const newline = this.pendingInput.indexOf("\n", lineEnd);
+              if (newline === -1) {
+                lineEnd = this.pendingInput.length;
+                break;
+              }
+              lineEnd = newline + 1;
+              remaining -= 1;
+            }
+            this.pendingInput = `${this.pendingInput.slice(0, lineStart)}${this.pendingInput.slice(lineEnd)}`;
+            this.cursor = Math.min(lineStart, this.pendingInput.length);
+          }
         }
+        this.viChordDigits = "";
         return;
       }
       if (!this.viInsertMode) {
@@ -463,6 +494,11 @@ test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi editor state
     }
   }
 
+  const legacyPreviousPrefixPty = new PowerShellLinePty("vi", { legacyVi: true });
+  legacyPreviousPrefixPty.setPendingInput("first line\n; Write-Output 'USER_SECOND'");
+  for (const key of "\x1bggdG\x1br\x1b\x1bi\x08") legacyPreviousPrefixPty.applyEditKey(key);
+  assert.match(legacyPreviousPrefixPty.pendingInput, /USER_SECOND/);
+
   const editorCases = [
     { editMode: "windows", cursorAtStart: false, viInsertMode: true, multiline: false },
     { editMode: "emacs", cursorAtStart: true, viInsertMode: true, multiline: false },
@@ -470,9 +506,11 @@ test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi editor state
     { editMode: "vi", cursorAtStart: true, viInsertMode: false, multiline: false },
     { editMode: "vi", cursorAtStart: false, viInsertMode: true, multiline: true },
     { editMode: "vi", cursorAtStart: false, viInsertMode: false, multiline: true },
+    { editMode: "vi", cursorAtStart: false, viInsertMode: true, multiline: true, legacyVi: true },
+    { editMode: "vi", cursorAtStart: false, viInsertMode: false, multiline: true, legacyVi: true },
   ];
-  for (const { editMode, cursorAtStart, viInsertMode, multiline } of editorCases) {
-    const pty = new PowerShellLinePty(editMode);
+  for (const { editMode, cursorAtStart, viInsertMode, multiline, legacyVi = false } of editorCases) {
+    const pty = new PowerShellLinePty(editMode, { legacyVi });
     const commands = ["Write-Output 'one'", "Write-Output 'two'"];
     for (const [index, command] of commands.entries()) {
       if (index === 1) {
@@ -501,7 +539,7 @@ test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi editor state
     assert.equal(pty.writes.length, 2);
     assert.equal(pty.submittedLines.length, 2);
     for (const [index, submittedLine] of pty.submittedLines.entries()) {
-      assert.ok(pty.writes[index].startsWith("\x1bggdG\x1br\x1b\x1bi\x08$__NCMCP_"));
+      assert.ok(pty.writes[index].startsWith("\x1bggd2147483647d\x1br\x1b\x1bi\x08$__NCMCP_"));
       assert.ok(submittedLine.startsWith("$__NCMCP_"));
       assert.doesNotMatch(submittedLine, /Write-Output 'USER'/);
       assert.doesNotMatch(submittedLine, /Write-Output 'USER_SECOND'/);

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -18,6 +18,10 @@ const {
   buildPendingInputClearPrefix,
   buildWrappedCommand,
 } = require("./ptyExecHelpers.cjs");
+const {
+  getFreshIdlePrompt,
+  trackSessionIdlePrompt,
+} = require("./shellUtils.cjs");
 
 class ShellBackedPty extends EventEmitter {
   write(data) {
@@ -333,6 +337,229 @@ test("pending-input clear prefix covers interactive shells and skips raw devices
   assert.equal(buildPendingInputClearPrefix("powershell"), "\x1bggd2147483647d\x1br\x1b\x1bi\x08");
   assert.equal(buildPendingInputClearPrefix("cmd"), "\x1b");
   assert.equal(buildPendingInputClearPrefix("raw"), "");
+});
+
+test("consecutive jobs wait for the PowerShell prompt after a split end marker", async () => {
+  const writes = [];
+  class CapturePty extends EventEmitter {
+    write(data) {
+      writes.push(String(data));
+    }
+  }
+  const pty = new CapturePty();
+  const session = { _loginShellKind: "cmd" };
+  pty.on("data", (data) => trackSessionIdlePrompt(session, String(data)));
+  trackSessionIdlePrompt(session, "Microsoft Windows...\r\nPS C:\\Users\\alice>");
+
+  for (const probe of ["PROBE_1", "PROBE_2"]) {
+    const job = startPtyJob(pty, `Write-Output '${probe}'`, {
+      shellKind: session.shellKind,
+      loginShellHint: session._loginShellKind,
+      timeoutMs: 20,
+      expectedPrompt: getFreshIdlePrompt(session),
+    });
+    const write = writes.at(-1);
+    assert.match(write, /\$__NCMCP_/);
+    assert.doesNotMatch(write, /cmd \/d \/s \/c/i);
+
+    pty.emit(
+      "data",
+      Buffer.from(`${job.marker}_S\r\n${probe}\r\n${job.marker}_E:0\r\n`),
+    );
+    let settled = false;
+    job.resultPromise.then(() => { settled = true; });
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    assert.equal(settled, false);
+
+    pty.emit("data", Buffer.from("PS C:\\Users\\alice>"));
+    const result = await job.resultPromise;
+    assert.equal(result.ok, true);
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, probe);
+  }
+});
+
+test("non-target shells still finish at the end marker without waiting for a prompt", async () => {
+  class CapturePty extends EventEmitter {
+    write() {}
+  }
+  const pty = new CapturePty();
+  const job = startPtyJob(pty, "printf done", {
+    shellKind: "posix",
+    timeoutMs: 20,
+    expectedPrompt: "alice@host:~$",
+  });
+  pty.emit("data", Buffer.from(`${job.marker}_S\r\ndone\r\n${job.marker}_E:0\r\n`));
+
+  let settled = false;
+  job.resultPromise.then(() => { settled = true; });
+  await new Promise((resolve) => setImmediate(resolve));
+  if (!settled) job.cancel();
+  assert.equal(settled, true);
+});
+
+test("cancel retries stop after an end marker while the prompt is delayed", async () => {
+  const writes = [];
+  class CapturePty extends EventEmitter {
+    write(data) {
+      writes.push(String(data));
+    }
+  }
+  const pty = new CapturePty();
+  const job = startPtyJob(pty, "Start-Sleep 10", {
+    shellKind: "unknown",
+    loginShellHint: "cmd",
+    timeoutMs: 1000,
+    expectedPrompt: "PS C:\\Users\\alice>",
+  });
+  job.cancel();
+  assert.equal(writes.filter((write) => write === "\x03").length, 1);
+
+  pty.emit("data", Buffer.from(`${job.marker}_S\r\n${job.marker}_E:130\r\n`));
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  assert.equal(writes.filter((write) => write === "\x03").length, 1);
+
+  pty.emit("data", Buffer.from("PS C:\\Users\\alice>"));
+  const result = await job.resultPromise;
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "Cancelled");
+  assert.equal(result.stdout, "");
+  assert.doesNotMatch(result.stdout, /__NCMCP_/);
+});
+
+test("cancelled output strips an end marker delivered with the prompt", async () => {
+  const writes = [];
+  class CapturePty extends EventEmitter {
+    write(data) {
+      writes.push(String(data));
+    }
+  }
+  const pty = new CapturePty();
+  const job = startPtyJob(pty, "Start-Sleep 10", {
+    shellKind: "unknown",
+    loginShellHint: "cmd",
+    timeoutMs: 1000,
+    expectedPrompt: "PS C:\\Users\\alice>",
+  });
+  pty.emit("data", Buffer.from(`${job.marker}_S\r\n`));
+  job.cancel();
+
+  pty.emit(
+    "data",
+    Buffer.from(`${job.marker}_E:130\r\nPS C:\\Users\\alice>`),
+  );
+  const result = await job.resultPromise;
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "Cancelled");
+  assert.equal(result.stdout, "");
+  assert.doesNotMatch(result.stdout, /__NCMCP_/);
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  assert.equal(writes.filter((write) => write === "\x03").length, 1);
+});
+
+test("cancel after an end marker keeps waiting without interrupting the prompt", async () => {
+  const writes = [];
+  class CapturePty extends EventEmitter {
+    write(data) {
+      writes.push(String(data));
+    }
+  }
+  const pty = new CapturePty();
+  const job = startPtyJob(pty, "Write-Output 'DONE'", {
+    shellKind: "unknown",
+    loginShellHint: "cmd",
+    timeoutMs: 1000,
+    expectedPrompt: "PS C:\\Users\\alice>",
+  });
+  pty.emit("data", Buffer.from(`${job.marker}_S\r\nDONE\r\n${job.marker}_E:0\r\n`));
+  job.cancel();
+
+  let settled = false;
+  job.resultPromise.then(() => { settled = true; });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(settled, false);
+  assert.equal(writes.filter((write) => write === "\x03").length, 0);
+
+  pty.emit("data", Buffer.from("PS C:\\Users\\alice>"));
+  const result = await job.resultPromise;
+  assert.equal(result.ok, true);
+  assert.equal(result.stdout, "DONE");
+});
+
+test("stream termination after an end marker preserves the completed result", async (t) => {
+  for (const termination of ["close", "error", "exit"]) {
+    await t.test(termination, async () => {
+      class CapturePty extends EventEmitter {
+        write() {}
+
+        onExit(callback) {
+          this.exitCallback = callback;
+          return { dispose() {} };
+        }
+      }
+      const pty = new CapturePty();
+      const job = startPtyJob(pty, "Write-Output 'DONE'", {
+        shellKind: "unknown",
+        loginShellHint: "cmd",
+        timeoutMs: 1000,
+        expectedPrompt: "PS C:\\Users\\alice>",
+      });
+      pty.emit("data", Buffer.from(`${job.marker}_S\r\nDONE\r\n${job.marker}_E:7\r\n`));
+      if (termination === "error") {
+        pty.emit("error", new Error("disconnected"));
+      } else if (termination === "exit") {
+        pty.exitCallback();
+      } else {
+        pty.emit("close");
+      }
+
+      const result = await job.resultPromise;
+      assert.equal(result.ok, false);
+      assert.equal(result.exitCode, 7);
+      assert.equal(result.stdout, "DONE");
+      assert.doesNotMatch(result.stdout, /__NCMCP_/);
+      assert.equal(result.error, undefined);
+    });
+  }
+});
+
+test("prompt waiting honors the original foreground wall deadline", async () => {
+  const writes = [];
+  class CapturePty extends EventEmitter {
+    write(data) {
+      writes.push(String(data));
+    }
+  }
+  const pty = new CapturePty();
+  const job = startPtyJob(pty, "Write-Output 'DONE'", {
+    shellKind: "unknown",
+    loginShellHint: "cmd",
+    timeoutMs: 120,
+    expectedPrompt: "PS C:\\Users\\alice>",
+    enforceWallTimeout: true,
+  });
+  pty.emit("data", Buffer.from(`${job.marker}_S\r\nDONE\r\n${job.marker}_E:0\r\n`));
+
+  let settled = false;
+  job.resultPromise.then(() => { settled = true; });
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  assert.equal(settled, false);
+  assert.equal(writes.filter((write) => write === "\x03").length, 0);
+
+  const didNotReachDeadline = Symbol("did not reach deadline");
+  const outcome = await Promise.race([
+    job.resultPromise,
+    new Promise((resolve) => setTimeout(() => resolve(didNotReachDeadline), 300)),
+  ]);
+  if (outcome === didNotReachDeadline) {
+    pty.emit("close");
+  }
+
+  assert.notEqual(outcome, didNotReachDeadline);
+  assert.equal(outcome.ok, true);
+  assert.equal(outcome.exitCode, 0);
+  assert.equal(outcome.stdout, "DONE");
+  assert.equal(writes.filter((write) => write === "\x03").length, 0);
 });
 
 test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi editor states", async () => {

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -330,7 +330,7 @@ test("loginShellHint selects fish/posix/powershell/cmd without pinning confirmed
 test("pending-input clear prefix covers interactive shells and skips raw devices", () => {
   assert.equal(buildPendingInputClearPrefix("posix"), "\x15\x0b");
   assert.equal(buildPendingInputClearPrefix("fish"), "\x15\x0b");
-  assert.equal(buildPendingInputClearPrefix("powershell"), "\x1bS\x1br\x1b\x1bi\x08");
+  assert.equal(buildPendingInputClearPrefix("powershell"), "\x1bggdG\x1br\x1b\x1bi\x08");
   assert.equal(buildPendingInputClearPrefix("cmd"), "\x1b");
   assert.equal(buildPendingInputClearPrefix("raw"), "");
 });
@@ -344,6 +344,7 @@ test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi editor state
       this.cursor = 0;
       this.viInsertMode = true;
       this.viReplacePending = false;
+      this.viChord = "";
       this.emacsChord = false;
       this.submittedLines = [];
       this.writes = [];
@@ -353,6 +354,8 @@ test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi editor state
       this.pendingInput = text;
       this.cursor = cursor;
       this.viInsertMode = viInsertMode;
+      this.viReplacePending = false;
+      this.viChord = "";
     }
 
     insert(text) {
@@ -405,15 +408,23 @@ test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi editor state
         this.viReplacePending = false;
         return;
       }
-      if (!this.viInsertMode) {
-        if (key === "S") {
-          this.pendingInput = "";
+      if (this.viChord) {
+        const chord = this.viChord;
+        this.viChord = "";
+        if (chord === "g" && key === "g") {
           this.cursor = 0;
-          this.viInsertMode = true;
-        } else if (key === "i") {
+        } else if (chord === "d" && key === "G") {
+          this.pendingInput = this.pendingInput.slice(0, this.cursor);
+        }
+        return;
+      }
+      if (!this.viInsertMode) {
+        if (key === "i") {
           this.viInsertMode = true;
         } else if (key === "r") {
           this.viReplacePending = true;
+        } else if (key === "g" || key === "d") {
+          this.viChord = key;
         }
         return;
       }
@@ -453,12 +464,14 @@ test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi editor state
   }
 
   const editorCases = [
-    { editMode: "windows", cursorAtStart: false, viInsertMode: true },
-    { editMode: "emacs", cursorAtStart: true, viInsertMode: true },
-    { editMode: "vi", cursorAtStart: true, viInsertMode: true },
-    { editMode: "vi", cursorAtStart: true, viInsertMode: false },
+    { editMode: "windows", cursorAtStart: false, viInsertMode: true, multiline: false },
+    { editMode: "emacs", cursorAtStart: true, viInsertMode: true, multiline: false },
+    { editMode: "vi", cursorAtStart: true, viInsertMode: true, multiline: false },
+    { editMode: "vi", cursorAtStart: true, viInsertMode: false, multiline: false },
+    { editMode: "vi", cursorAtStart: false, viInsertMode: true, multiline: true },
+    { editMode: "vi", cursorAtStart: false, viInsertMode: false, multiline: true },
   ];
-  for (const { editMode, cursorAtStart, viInsertMode } of editorCases) {
+  for (const { editMode, cursorAtStart, viInsertMode, multiline } of editorCases) {
     const pty = new PowerShellLinePty(editMode);
     const commands = ["Write-Output 'one'", "Write-Output 'two'"];
     for (const [index, command] of commands.entries()) {
@@ -466,9 +479,11 @@ test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi editor state
         // Model input accepted by PSReadLine before its echo reaches the
         // tracked PTY output. The leading semicolon makes a retained suffix
         // executable after the wrapper, matching the dangerous Vi edge case.
-        const pendingInput = cursorAtStart
-          ? "; Write-Output 'USER'"
-          : "Write-Output 'USER'; ";
+        const pendingInput = multiline
+          ? "; Write-Output 'USER'\nWrite-Output 'USER_SECOND'"
+          : cursorAtStart
+            ? "; Write-Output 'USER'"
+            : "Write-Output 'USER'; ";
         pty.setPendingInput(pendingInput, {
           cursor: cursorAtStart ? 0 : pendingInput.length,
           viInsertMode,
@@ -486,9 +501,10 @@ test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi editor state
     assert.equal(pty.writes.length, 2);
     assert.equal(pty.submittedLines.length, 2);
     for (const [index, submittedLine] of pty.submittedLines.entries()) {
-      assert.ok(pty.writes[index].startsWith("\x1bS\x1br\x1b\x1bi\x08$__NCMCP_"));
+      assert.ok(pty.writes[index].startsWith("\x1bggdG\x1br\x1b\x1bi\x08$__NCMCP_"));
       assert.ok(submittedLine.startsWith("$__NCMCP_"));
       assert.doesNotMatch(submittedLine, /Write-Output 'USER'/);
+      assert.doesNotMatch(submittedLine, /Write-Output 'USER_SECOND'/);
       assert.doesNotMatch(submittedLine, /cmd \/d \/s \/c/i);
     }
   }

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -330,12 +330,12 @@ test("loginShellHint selects fish/posix/powershell/cmd without pinning confirmed
 test("pending-input clear prefix covers interactive shells and skips raw devices", () => {
   assert.equal(buildPendingInputClearPrefix("posix"), "\x15\x0b");
   assert.equal(buildPendingInputClearPrefix("fish"), "\x15\x0b");
-  assert.equal(buildPendingInputClearPrefix("powershell"), "i\x15\x0b\x1b\x1bi\x08");
+  assert.equal(buildPendingInputClearPrefix("powershell"), "\x1bS\x1br\x1b\x1bi\x08");
   assert.equal(buildPendingInputClearPrefix("cmd"), "\x1b");
   assert.equal(buildPendingInputClearPrefix("raw"), "");
 });
 
-test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi edit modes", async () => {
+test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi editor states", async () => {
   class PowerShellLinePty extends EventEmitter {
     constructor(editMode) {
       super();
@@ -343,6 +343,7 @@ test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi edit modes",
       this.pendingInput = "";
       this.cursor = 0;
       this.viInsertMode = true;
+      this.viReplacePending = false;
       this.emacsChord = false;
       this.submittedLines = [];
       this.writes = [];
@@ -370,8 +371,6 @@ test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi edit modes",
             this.cursor -= 1;
           }
         } else {
-          // Windows-mode PSReadLine does not bind Ctrl+U/Ctrl+K. Model them as
-          // residual input so a later Escape is required before the wrapper.
           this.insert(key);
         }
         return;
@@ -402,17 +401,24 @@ test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi edit modes",
         return;
       }
 
+      if (this.viReplacePending) {
+        this.viReplacePending = false;
+        return;
+      }
       if (!this.viInsertMode) {
-        if (key === "i") this.viInsertMode = true;
+        if (key === "S") {
+          this.pendingInput = "";
+          this.cursor = 0;
+          this.viInsertMode = true;
+        } else if (key === "i") {
+          this.viInsertMode = true;
+        } else if (key === "r") {
+          this.viReplacePending = true;
+        }
         return;
       }
       if (key === "\x1b") {
         this.viInsertMode = false;
-      } else if (key === "\x15") {
-        this.pendingInput = this.pendingInput.slice(this.cursor);
-        this.cursor = 0;
-      } else if (key === "\x0b") {
-        this.pendingInput = this.pendingInput.slice(0, this.cursor);
       } else if (key === "\x08") {
         if (this.cursor > 0) {
           this.pendingInput = `${this.pendingInput.slice(0, this.cursor - 1)}${this.pendingInput.slice(this.cursor)}`;
@@ -446,18 +452,26 @@ test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi edit modes",
     }
   }
 
-  for (const editMode of ["windows", "emacs", "vi"]) {
+  const editorCases = [
+    { editMode: "windows", cursorAtStart: false, viInsertMode: true },
+    { editMode: "emacs", cursorAtStart: true, viInsertMode: true },
+    { editMode: "vi", cursorAtStart: true, viInsertMode: true },
+    { editMode: "vi", cursorAtStart: true, viInsertMode: false },
+  ];
+  for (const { editMode, cursorAtStart, viInsertMode } of editorCases) {
     const pty = new PowerShellLinePty(editMode);
     const commands = ["Write-Output 'one'", "Write-Output 'two'"];
     for (const [index, command] of commands.entries()) {
       if (index === 1) {
         // Model input accepted by PSReadLine before its echo reaches the
-        // tracked PTY output. Emacs starts at the beginning of the line and Vi
-        // starts in command mode to cover text on both sides and mode restore.
-        const pendingInput = "Write-Output 'USER'; ";
+        // tracked PTY output. The leading semicolon makes a retained suffix
+        // executable after the wrapper, matching the dangerous Vi edge case.
+        const pendingInput = cursorAtStart
+          ? "; Write-Output 'USER'"
+          : "Write-Output 'USER'; ";
         pty.setPendingInput(pendingInput, {
-          cursor: editMode === "emacs" || editMode === "vi" ? 0 : pendingInput.length,
-          viInsertMode: editMode !== "vi",
+          cursor: cursorAtStart ? 0 : pendingInput.length,
+          viInsertMode,
         });
       }
       const job = startPtyJob(pty, command, {
@@ -472,7 +486,7 @@ test("startPtyJob clears PowerShell input in Windows, Emacs, and Vi edit modes",
     assert.equal(pty.writes.length, 2);
     assert.equal(pty.submittedLines.length, 2);
     for (const [index, submittedLine] of pty.submittedLines.entries()) {
-      assert.ok(pty.writes[index].startsWith("i\x15\x0b\x1b\x1bi\x08$__NCMCP_"));
+      assert.ok(pty.writes[index].startsWith("\x1bS\x1br\x1b\x1bi\x08$__NCMCP_"));
       assert.ok(submittedLine.startsWith("$__NCMCP_"));
       assert.doesNotMatch(submittedLine, /Write-Output 'USER'/);
       assert.doesNotMatch(submittedLine, /cmd \/d \/s \/c/i);

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -330,34 +330,62 @@ test("loginShellHint selects fish/posix/powershell/cmd without pinning confirmed
 test("pending-input clear prefix covers interactive shells and skips raw devices", () => {
   assert.equal(buildPendingInputClearPrefix("posix"), "\x15\x0b");
   assert.equal(buildPendingInputClearPrefix("fish"), "\x15\x0b");
-  assert.equal(buildPendingInputClearPrefix("powershell"), "\x1b\x15\x0b");
+  assert.equal(buildPendingInputClearPrefix("powershell"), "\x1b");
   assert.equal(buildPendingInputClearPrefix("cmd"), "\x1b");
   assert.equal(buildPendingInputClearPrefix("raw"), "");
 });
 
-test("startPtyJob trusts a live PowerShell prompt over a cmd login hint without clearing it", async () => {
-  for (const command of ["Write-Output 'one'", "Write-Output 'two'"]) {
-    const writes = [];
-    class CapturePty extends EventEmitter {
-      write(data) {
-        writes.push(String(data));
-      }
+test("startPtyJob clears unobserved PowerShell input across consecutive jobs", async () => {
+  class PowerShellLinePty extends EventEmitter {
+    constructor() {
+      super();
+      this.pendingInput = "";
+      this.submittedLines = [];
+      this.writes = [];
     }
-    const pty = new CapturePty();
+
+    write(data) {
+      const text = String(data);
+      this.writes.push(text);
+
+      const hasRevertLine = text.startsWith("\x1b");
+      if (hasRevertLine) this.pendingInput = "";
+      const submittedLine = `${this.pendingInput}${text.slice(hasRevertLine ? 1 : 0)}`;
+      this.submittedLines.push(submittedLine);
+      this.pendingInput = "";
+
+      const marker = submittedLine.match(/__NCMCP_[0-9a-z]+_[0-9a-f]+__/)?.[0];
+      assert.ok(marker);
+      queueMicrotask(() => {
+        this.emit("data", Buffer.from(`${marker}_S\r\n${marker}_E:0\r\nPS C:\\Users\\alice>`));
+      });
+    }
+  }
+
+  const pty = new PowerShellLinePty();
+  const commands = ["Write-Output 'one'", "Write-Output 'two'"];
+  for (const [index, command] of commands.entries()) {
+    if (index === 1) {
+      // Model input accepted by PSReadLine before its echo reaches the tracked
+      // PTY output. The cached prompt still looks fresh in this window.
+      pty.pendingInput = "Write-Output 'USER'; ";
+    }
     const job = startPtyJob(pty, command, {
       shellKind: "unknown",
       loginShellHint: "cmd",
       timeoutMs: 50,
       expectedPrompt: "PS C:\\Users\\alice>",
     });
-    assert.equal(writes.length, 1);
-    assert.ok(writes[0].startsWith("$__NCMCP_"));
-    assert.equal(writes[0].startsWith("\x1b\x15\x0b"), false);
-    assert.match(writes[0], /__NCMCP_/);
-    assert.doesNotMatch(writes[0], /cmd \/d \/s \/c/i);
-    job.cancel();
-    pty.emit("data", Buffer.from("PS C:\\Users\\alice>"));
     await job.resultPromise;
+  }
+
+  assert.equal(pty.writes.length, 2);
+  assert.equal(pty.submittedLines.length, 2);
+  for (const [index, submittedLine] of pty.submittedLines.entries()) {
+    assert.ok(pty.writes[index].startsWith("\x1b$__NCMCP_"));
+    assert.ok(submittedLine.startsWith("$__NCMCP_"));
+    assert.doesNotMatch(submittedLine, /Write-Output 'USER'/);
+    assert.doesNotMatch(submittedLine, /cmd \/d \/s \/c/i);
   }
 });
 

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -189,8 +189,8 @@ function buildPendingInputClearPrefix(shellKind) {
       return "\x1b";
     case "powershell":
       // Escape = Windows-mode PSReadLine RevertLine (issue reporter default).
-      // Ctrl+U/Ctrl+K also fire for Emacs/Vi when those bindings exist.
-      return "\x1b\x15\x0b";
+      // Ctrl+U/Ctrl+K are not bound in that mode and can corrupt the command.
+      return "\x1b";
     default:
       return "\x15\x0b";
   }

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -188,10 +188,11 @@ function buildPendingInputClearPrefix(shellKind) {
     case "cmd":
       return "\x1b";
     case "powershell":
-      // Vi gg+dG removes the whole multiline buffer, while Escape+r is Emacs
+      // Vi gg plus a counted dd removes the whole multiline buffer, including
+      // in PSReadLine 2.0 where dG is unavailable. Escape+r is Emacs
       // RevertLine. Repeated Escape clears Windows mode, and the final
       // i+Backspace leaves every mode on an empty editable line.
-      return "\x1bggdG\x1br\x1b\x1bi\x08";
+      return "\x1bggd2147483647d\x1br\x1b\x1bi\x08";
     default:
       return "\x15\x0b";
   }

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -188,10 +188,10 @@ function buildPendingInputClearPrefix(shellKind) {
     case "cmd":
       return "\x1b";
     case "powershell":
-      // Escape+S replaces the whole Vi line, while Escape+r is Emacs
+      // Vi gg+dG removes the whole multiline buffer, while Escape+r is Emacs
       // RevertLine. Repeated Escape clears Windows mode, and the final
       // i+Backspace leaves every mode on an empty editable line.
-      return "\x1bS\x1br\x1b\x1bi\x08";
+      return "\x1bggdG\x1br\x1b\x1bi\x08";
     default:
       return "\x15\x0b";
   }

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -188,9 +188,10 @@ function buildPendingInputClearPrefix(shellKind) {
     case "cmd":
       return "\x1b";
     case "powershell":
-      // Escape = Windows-mode PSReadLine RevertLine (issue reporter default).
-      // Ctrl+U/Ctrl+K are not bound in that mode and can corrupt the command.
-      return "\x1b";
+      // Clear Emacs/Vi first, then use Escape for Windows-mode RevertLine.
+      // The final i+Backspace restores Vi insert mode without leaving text in
+      // Windows/Emacs. This ordering works across all PSReadLine edit modes.
+      return "i\x15\x0b\x1b\x1bi\x08";
     default:
       return "\x15\x0b";
   }

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -188,10 +188,10 @@ function buildPendingInputClearPrefix(shellKind) {
     case "cmd":
       return "\x1b";
     case "powershell":
-      // Clear Emacs/Vi first, then use Escape for Windows-mode RevertLine.
-      // The final i+Backspace restores Vi insert mode without leaving text in
-      // Windows/Emacs. This ordering works across all PSReadLine edit modes.
-      return "i\x15\x0b\x1b\x1bi\x08";
+      // Escape+S replaces the whole Vi line, while Escape+r is Emacs
+      // RevertLine. Repeated Escape clears Windows mode, and the final
+      // i+Backspace leaves every mode on an empty editable line.
+      return "\x1bS\x1br\x1b\x1bi\x08";
     default:
       return "\x15\x0b";
   }


### PR DESCRIPTION
## Summary

Avoid sending Netcatty's fixed PowerShell line-clear sequence when the live PTY tail already contains a recognized PowerShell prompt. PSReadLine edit modes do not share a portable Escape/Ctrl+U/Ctrl+K binding, so the prefix can itself corrupt the following MCP command.

The change remains deliberately narrow: non-PowerShell shells retain the existing pending-input defense, and PowerShell still receives it when no live prompt is available.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3252

## Changes Made

- Skip the clear prefix only when the effective shell is PowerShell and a live recognized prompt is available.
- Preserve the existing prefix for POSIX, fish, cmd, raw-device behavior, and uncertain PowerShell state.
- Add a regression test for two consecutive jobs where Windows OpenSSH reports a cmd login shell but the live terminal is PowerShell.
- Retain explicit coverage that a POSIX session with a known prompt still receives its clear prefix.

## Screenshots / Demo

Reproduced against Netcatty 1.1.82 over Windows OpenSSH with a startup command that enters PowerShell 7:

1. The first MCP command completed but the fixed clear prefix produced an empty-command error.
2. The next MCP command was wrapped as cmd input, entered PowerShell continuation mode, and timed out.
3. Typing the PowerShell wrapper without the prefix completed normally.
4. Sending the prefix by itself reproduced the empty-command error.

No UI layout changes.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test` — 11,189 passed, 0 failed, 18 environment-gated skips)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`) — not applicable
- [x] No new console errors or warnings, if this affects app behavior

Focused coverage also passes:

- `node --test electron/bridges/ai/ptyExec.test.cjs electron/bridges/ai/sessionShellKind.test.cjs electron/bridges/ai/shellUtils.test.cjs`
- `node --test electron/bridges/mcpServerBridge.execHandlers.test.cjs electron/terminalWorker/aiExec.test.cjs electron/bridges/aiBridge/cattyExecHandlers.worker.test.cjs`

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)

The remaining input race is unchanged for every PTY shell: input written after the last observed prompt but before MCP injection cannot be inferred from output alone. A complete solution would require input-state tracking or waiting for a prompt repaint after interruption; this PR only removes the PowerShell-specific corruption observed in #3252.
