### PR TITLE
fix(port-forwarding): reconnect auto-start rules after inactive status

### DIFF
--- a/application/state/usePortForwardingAutoStart.ts
+++ b/application/state/usePortForwardingAutoStart.ts
@@ -385,7 +385,10 @@ export const usePortForwardingAutoStart = ({
       return startPortForward(rule, host, resolveEffectiveHosts(hostsRef.current), keysRef.current, identitiesRef.current, onStatusChange, true, terminalSettingsRef.current, knownHostsRef.current);
     };
 
-    setReconnectCallback(handleReconnect);
+    setReconnectCallback(handleReconnect, (ruleId) => isPortForwardingAutoStartEnabled(
+      localStorageAdapter.read<PortForwardingRule[]>(STORAGE_KEY_PORT_FORWARDING) ?? [],
+      ruleId,
+    ));
     return () => {
       setReconnectCallback(null);
     };

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -890,6 +890,36 @@ test("inactive backend events remove the runtime tunnel immediately", async () =
   assert.equal(getActiveConnection(disconnectedRule.id), undefined);
 });
 
+test("auto-start rules reconnect after an unexpected inactive event", async (t) => {
+  let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      netcatty: {
+        startPortForward: async () => ({ success: true }),
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+        onPortForwardStatus: (_tunnelId: string, listener: typeof statusListener) => {
+          statusListener = listener;
+          return () => undefined;
+        },
+      },
+    },
+  });
+  const reconnectRule = rule({ id: "inactive-event-reconnect-rule" });
+  setReconnectCallback(async () => ({ success: true }));
+  t.after(async () => {
+    setReconnectCallback(null);
+    await stopAndCleanupRuleAndWait(reconnectRule.id);
+  });
+
+  await startPortForward(reconnectRule, host(), [], [], [], () => undefined, true);
+  statusListener?.("inactive");
+
+  const connection = getActiveConnection(reconnectRule.id);
+  assert.ok(connection?.reconnectTimerCallback);
+  assert.equal(connection.status, "connecting");
+});
+
 test("inactive close events preserve an already scheduled reconnect", async (t) => {
   let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
   Object.defineProperty(globalThis, "window", {

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -1042,6 +1042,40 @@ test("final retry error followed by inactive preserves exhaustion until explicit
   assert.equal(reconnects, 1);
 });
 
+for (const rejects of [false, true]) {
+  test(`inactive during failed startup schedules only one retry (${rejects ? "throw" : "reply"})`, async (t) => {
+    let statusListener: ((status: PortForwardingRule["status"]) => void) | undefined;
+    const reconnectRule = rule({ id: `inactive-start-failed-${rejects}`, autoStart: true });
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { netcatty: {
+        startPortForward: async () => {
+          getActiveConnection(reconnectRule.id)!.reconnectAttempts = 4;
+          statusListener?.("inactive");
+          if (rejects) throw new Error("SSH connection closed before ready");
+          return { success: false, error: "SSH connection closed before ready" };
+        },
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+        onPortForwardStatus: (_id: string, listener: typeof statusListener) => {
+          statusListener = listener;
+          return () => undefined;
+        },
+      } },
+    });
+    let reconnects = 0;
+    setReconnectCallback(async () => { reconnects += 1; return { success: true }; });
+    t.after(async () => {
+      setReconnectCallback(null);
+      await stopAndCleanupRuleAndWait(reconnectRule.id);
+    });
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    await startPortForward(reconnectRule, host(), [], [], [], () => undefined, true);
+    assert.equal(getActiveConnection(reconnectRule.id)?.reconnectAttempts, 5);
+    t.mock.timers.tick(3000);
+    assert.equal(reconnects, 1);
+  });
+}
+
 test("inactive close events preserve an already scheduled reconnect", async (t) => {
   let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
   Object.defineProperty(globalThis, "window", {

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -920,6 +920,49 @@ test("auto-start rules reconnect after an unexpected inactive event", async (t) 
   assert.equal(connection.status, "connecting");
 });
 
+for (const disableDuringDelay of [false, true]) {
+  test(`inactive reconnect respects auto-start disabled ${disableDuringDelay ? "during delay" : "before disconnect"}`, async (t) => {
+    let statusListener: ((status: PortForwardingRule["status"]) => void) | undefined;
+    let autoStart = true;
+    let reconnects = 0;
+    const statuses: string[] = [];
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        netcatty: {
+          startPortForward: async () => ({ success: true }),
+          stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+          onPortForwardStatus: (_id: string, listener: typeof statusListener) => {
+            statusListener = listener;
+            return () => undefined;
+          },
+        },
+      },
+    });
+    const reconnectRule = rule({ id: `disabled-inactive-${disableDuringDelay}`, autoStart: true });
+    setReconnectCallback(async () => {
+      reconnects += 1;
+      return { success: true };
+    }, () => autoStart);
+    t.after(async () => {
+      setReconnectCallback(null);
+      await stopAndCleanupRuleAndWait(reconnectRule.id);
+    });
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    await startPortForward(reconnectRule, host(), [], [], [], (status) => statuses.push(status), true);
+    if (!disableDuringDelay) autoStart = false;
+    statusListener?.("inactive");
+    if (disableDuringDelay) {
+      assert.ok(getActiveConnection(reconnectRule.id)?.reconnectTimerCallback);
+      autoStart = false;
+    }
+    t.mock.timers.tick(3000);
+    assert.equal(reconnects, 0);
+    assert.equal(getActiveConnection(reconnectRule.id), undefined);
+    assert.equal(statuses.at(-1), "inactive");
+  });
+}
+
 test("inactive close events preserve an already scheduled reconnect", async (t) => {
   let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
   Object.defineProperty(globalThis, "window", {

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -7,6 +7,7 @@ import {
   getActiveConnection,
   hasActivePortForwardRuntime,
   reconcileWithBackend,
+  resetReconnectAttempts,
   setReconnectCallback,
   startAllPortForwards,
   startPortForward,
@@ -1004,6 +1005,42 @@ for (const autoStartAfterReplacement of [false, true]) {
     assert.equal(getActiveConnection(reconnectRule.id)?.status, "active");
   });
 }
+
+test("final retry error followed by inactive preserves exhaustion until explicit recovery", async (t) => {
+  let statusListener: ((status: PortForwardingRule["status"]) => void) | undefined;
+  let reconnects = 0;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { netcatty: {
+      startPortForward: async () => ({ success: true }),
+      stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+      onPortForwardStatus: (_id: string, listener: typeof statusListener) => {
+        statusListener = listener;
+        return () => undefined;
+      },
+    } },
+  });
+  const reconnectRule = rule({ id: "exhausted-inactive-rule", autoStart: true });
+  setReconnectCallback(async () => { reconnects += 1; return { success: true }; });
+  t.after(async () => {
+    setReconnectCallback(null);
+    await stopAndCleanupRuleAndWait(reconnectRule.id);
+  });
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  await startPortForward(reconnectRule, host(), [], [], [], () => undefined, true);
+  const connection = getActiveConnection(reconnectRule.id)!;
+  connection.reconnectAttempts = 5;
+  statusListener?.("error");
+  statusListener?.("inactive");
+  t.mock.timers.tick(3000);
+  assert.equal(reconnects, 0);
+  assert.equal(getActiveConnection(reconnectRule.id), undefined);
+  assert.equal(resetReconnectAttempts(reconnectRule.id), true);
+  await startPortForward(reconnectRule, host(), [], [], [], () => undefined, true);
+  statusListener?.("inactive");
+  t.mock.timers.tick(3000);
+  assert.equal(reconnects, 1);
+});
 
 test("inactive close events preserve an already scheduled reconnect", async (t) => {
   let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -963,6 +963,48 @@ for (const disableDuringDelay of [false, true]) {
   });
 }
 
+for (const autoStartAfterReplacement of [false, true]) {
+  test(`stale reconnect leaves a replacement tunnel intact with auto-start ${autoStartAfterReplacement}`, async (t) => {
+    let statusListener: ((status: PortForwardingRule["status"]) => void) | undefined;
+    let autoStart = true;
+    let reconnects = 0;
+    const reconnectRule = rule({ id: `replaced-inactive-${autoStartAfterReplacement}`, autoStart: true });
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { netcatty: {
+        startPortForward: async () => ({ success: true }),
+        stopPortForwardByRuleId: async () => ({ stopped: 1, failed: 0, errors: [] }),
+        onPortForwardStatus: (_id: string, listener: typeof statusListener) => {
+          statusListener = listener;
+          return () => undefined;
+        },
+        listPortForwards: async () => [{ ruleId: reconnectRule.id, tunnelId: "replacement", status: "active", type: "local" }],
+      } },
+    });
+    setReconnectCallback(async () => { reconnects += 1; return { success: true }; }, () => autoStart);
+    t.after(async () => {
+      setReconnectCallback(null);
+      await stopAndCleanupRuleAndWait(reconnectRule.id);
+    });
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const statuses: string[] = [];
+    await startPortForward(reconnectRule, host(), [], [], [], (status) => statuses.push(status), true);
+    statusListener?.("inactive");
+    assert.ok(getActiveConnection(reconnectRule.id)?.reconnectTimerCallback);
+    await reconcileWithBackend();
+    const replacement = getActiveConnection(reconnectRule.id);
+    assert.equal(replacement?.tunnelId, "replacement");
+    const previousStatuses = [...statuses];
+    autoStart = autoStartAfterReplacement;
+    t.mock.timers.tick(3000);
+    assert.equal(getActiveConnection(reconnectRule.id), replacement);
+    assert.equal(reconnects, 0);
+    assert.deepEqual(statuses, previousStatuses);
+    statusListener?.("active");
+    assert.equal(getActiveConnection(reconnectRule.id)?.status, "active");
+  });
+}
+
 test("inactive close events preserve an already scheduled reconnect", async (t) => {
   let statusListener: ((status: PortForwardingRule["status"], error?: string | null) => void) | undefined;
   Object.defineProperty(globalThis, "window", {

--- a/infrastructure/services/portForwardingService.test.ts
+++ b/infrastructure/services/portForwardingService.test.ts
@@ -1105,6 +1105,14 @@ test("inactive close events preserve an already scheduled reconnect", async (t) 
   assert.ok(scheduled?.reconnectTimerCallback);
   assert.equal(scheduled.status, "connecting");
 
+  const pendingRetry = scheduled.reconnectTimerCallback;
+  statusListener?.("error", "connection closed");
+  assert.equal(scheduled.status, "connecting");
+  assert.equal(scheduled.error, "Reconnecting (1/5)...");
+  assert.equal(scheduled.reconnectTimerCallback, pendingRetry);
+  assert.deepEqual((await reconcileWithBackend()).gone, []);
+  assert.equal(getActiveConnection(reconnectRule.id), scheduled);
+
   statusListener?.("inactive");
 
   assert.equal(getActiveConnection(reconnectRule.id), scheduled);

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -1031,6 +1031,7 @@ export const startPortForward = async (
         if (
           !manualStopsInProgress.has(rule.id)
           && !rulesPendingCleanup.has(rule.id)
+          && !exhaustedReconnectRules.has(rule.id)
         ) {
           const reconnectScheduled = scheduleReconnectIfNeeded(
             rule.id,

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -245,6 +245,7 @@ const scheduleReconnectIfNeeded = (
       currentConn.reconnectTimeoutId = undefined;
       currentConn.reconnectDueAt = undefined;
       currentConn.reconnectTimerCallback = undefined;
+      if (activeConnections.get(ruleId) !== currentConn) return;
       if (shouldReconnectRule?.(ruleId) === false) {
         currentConn.unsubscribe?.();
         activeConnections.delete(ruleId);

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -1018,6 +1018,21 @@ export const startPortForward = async (
           conn.locallyInitiated = false;
           return;
         }
+        if (
+          !manualStopsInProgress.has(rule.id)
+          && !rulesPendingCleanup.has(rule.id)
+        ) {
+          const reconnectScheduled = scheduleReconnectIfNeeded(
+            rule.id,
+            enableReconnect,
+            onStatusChange,
+          );
+          if (reconnectScheduled) {
+            conn?.unsubscribe?.();
+            if (conn) conn.unsubscribe = undefined;
+            return;
+          }
+        }
         conn?.unsubscribe?.();
         clearReconnectTimer(rule.id);
         activeConnections.delete(rule.id);

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -225,7 +225,11 @@ const scheduleReconnectIfNeeded = (
 
   const currentConn = activeConnections.get(ruleId);
   if (currentConn?.reconnectSuppressed) return false;
-  if (currentConn?.reconnectTimerCallback) return true;
+  if (currentConn?.reconnectTimerCallback) {
+    currentConn.status = 'connecting';
+    currentConn.error = `Reconnecting (${currentConn.reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})...`;
+    return true;
+  }
   const attempts = (currentConn?.reconnectAttempts ?? 0) + 1;
 
   if (attempts <= MAX_RECONNECT_ATTEMPTS) {

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -82,14 +82,17 @@ let reconnectCallback: ((
   ruleId: string,
   onStatusChange: (status: PortForwardingRule['status'], error?: string) => void
 ) => Promise<{ success: boolean; error?: string }>) | null = null;
+let shouldReconnectRule: ((ruleId: string) => boolean) | undefined;
 
 /**
  * Set the reconnect callback (called by state hook to enable auto-reconnect)
  */
 export const setReconnectCallback = (
-  callback: typeof reconnectCallback
+  callback: typeof reconnectCallback,
+  shouldReconnect?: (ruleId: string) => boolean,
 ): void => {
   reconnectCallback = callback;
+  shouldReconnectRule = callback ? shouldReconnect : undefined;
 };
 
 /**
@@ -212,7 +215,7 @@ const scheduleReconnectIfNeeded = (
   enableReconnect: boolean,
   onStatusChange: (status: PortForwardingRule['status'], error?: string) => void,
 ): boolean => {
-  if (!enableReconnect || !reconnectCallback) {
+  if (!enableReconnect || !reconnectCallback || shouldReconnectRule?.(ruleId) === false) {
     return false;
   }
   if (rulesPendingCleanup.has(ruleId)) {
@@ -242,6 +245,12 @@ const scheduleReconnectIfNeeded = (
       currentConn.reconnectTimeoutId = undefined;
       currentConn.reconnectDueAt = undefined;
       currentConn.reconnectTimerCallback = undefined;
+      if (shouldReconnectRule?.(ruleId) === false) {
+        currentConn.unsubscribe?.();
+        activeConnections.delete(ruleId);
+        onStatusChange('inactive');
+        return;
+      }
       if (reconnectCallback) {
         currentConn.reconnectStartAuthorized = true;
         reconnectCallback(ruleId, onStatusChange);

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -225,6 +225,7 @@ const scheduleReconnectIfNeeded = (
 
   const currentConn = activeConnections.get(ruleId);
   if (currentConn?.reconnectSuppressed) return false;
+  if (currentConn?.reconnectTimerCallback) return true;
   const attempts = (currentConn?.reconnectAttempts ?? 0) + 1;
 
   if (attempts <= MAX_RECONNECT_ATTEMPTS) {


### PR DESCRIPTION
## Summary

Auto-start port forwarding rules now schedule their existing reconnect cycle when a locally tracked tunnel reports an unexpected inactive status. Manual stops still cancel reconnects.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Other (please describe):

## Related Issue (optional)

Related to #3158 (partial fix).

This PR restores the missing reconnect entry point for unexpected inactive events. The existing five-attempt retry budget remains unchanged. Configurable backoff, additional recovery triggers, and exhausted-state UI are not implemented here, so #3158 must remain open.

## Changes Made

- Route unexpected local tunnel `inactive` events through the existing auto-start reconnect scheduler.
- Preserve the manual-stop and pending-cleanup guards so user-stopped rules remain inactive.
- Recheck the persisted auto-start setting both before scheduling a retry and when its delay expires.
- Ignore delayed retries belonging to a connection that has since been replaced by backend reconciliation.
- Preserve retry exhaustion across error/close notifications and retain a single pending retry across duplicate failure notifications.

## Screenshots / Demo

No UI change. An auto-start tunnel that closes unexpectedly now enters its existing reconnecting state instead of becoming inactive.

## Testing

- [x] Linting passes (`npm run lint`)
- [x] Focused service tests pass (`node --import ./node_modules/tsx/dist/loader.mjs --test infrastructure/services/portForwardingService.test.ts`, 64 passed)
- [x] Tests pass (`npm test`, Node 24: 11,362 passed, 17 platform-specific skips)
- [ ] Generated capability tool specs have been regenerated if applicable (`npm run generate:capability-tools`)
- [x] Production build passes (`npm run build`)

Real local SSH/TCP verification with the production forwarding backend: initial data transfer, clean server-side SSH close, automatic reconnect and renewed data transfer all passed. Disabling auto-start and manual stop both prevented restart. The same disconnect test against the pre-PR implementation timed out without recovery. This is a local reproduction, not confirmation from the reporter's environment.

Two independent read-only reviewers reviewed the final code and reported no actionable findings. The 74 focused service/auto-start tests pass. A Node 26 full-suite run hit an intermittent, unrelated GlobalSftpTransferCenter test teardown failure; its isolated rerun passed and the full Node 24 suite passed.

## Checklist

- [x] My code follows the existing style of this project
- [x] I have added tests that prove the regression and preserve manual stops
- [x] I have checked for breaking changes

