### PR TITLE
fix(terminal): accept WindowsApps execution aliases in shell discovery

### DIFF
--- a/electron/bridges/shellDiscovery.cjs
+++ b/electron/bridges/shellDiscovery.cjs
@@ -9,6 +9,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { execFileSync } = require("node:child_process");
+const { isWindowsAppExecutionAliasPath } = require("../../lib/localShell.cjs");
 
 const EXEC_OPTS = { encoding: "utf8", timeout: 5000, windowsHide: true };
 
@@ -90,7 +91,12 @@ function regEnumSubkeys(keyPath) {
 
 /**
  * Locate an executable on the system PATH using `where.exe`.
- * Returns the first valid, non-alias path, or `null` if not found.
+ * Returns the first valid path, or `null` if not found.
+ *
+ * Windows App Execution Aliases (MSIX/Store installs, e.g. winget PowerShell 7)
+ * are kept as a last-resort candidate: they are reparse points that fail
+ * `fs.existsSync()`, but spawning the alias path launches the packaged app
+ * just fine. A regular executable always wins when one is on the PATH.
  *
  * @param {string} name  Executable name, e.g. "pwsh"
  * @returns {string|null}
@@ -103,25 +109,16 @@ function findExecutableOnPath(name) {
       .map((l) => l.trim())
       .filter(Boolean);
 
+    let aliasCandidate = null;
     for (const candidate of candidates) {
-      if (!fs.existsSync(candidate)) continue;
-      // Skip Windows App Execution Aliases (WindowsApps zero-byte stubs).
-      try {
-        const localAppData = (process.env.LOCALAPPDATA || "").toLowerCase();
-        if (
-          localAppData &&
-          candidate.toLowerCase().startsWith(
-            path.join(localAppData, "Microsoft", "WindowsApps").toLowerCase() +
-              path.sep,
-          )
-        ) {
-          continue;
-        }
-      } catch (_e) {
-        // Ignore — just use the candidate.
+      if (isWindowsAppExecutionAliasPath(candidate)) {
+        aliasCandidate ??= candidate;
+        continue;
       }
+      if (!fs.existsSync(candidate)) continue;
       return candidate;
     }
+    if (aliasCandidate) return aliasCandidate;
   } catch (_err) {
     // Not found on PATH.
   }

--- a/electron/bridges/shellDiscovery.windowsAppsAlias.test.cjs
+++ b/electron/bridges/shellDiscovery.windowsAppsAlias.test.cjs
@@ -1,0 +1,101 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const childProcess = require("node:child_process");
+
+// shellDiscovery destructures execFileSync at require time, so the fake
+// `where.exe` must be installed before the module under test is loaded.
+const realExecFileSync = childProcess.execFileSync;
+const whereResults = new Map();
+
+childProcess.execFileSync = function fakeExecFileSync(file, args) {
+  const argv0 = String(file).toLowerCase();
+  const isWhere =
+    argv0 === "where.exe" || argv0.endsWith("\\where.exe") || argv0.endsWith("/where.exe");
+  if (isWhere) {
+    const lines = whereResults.get(args[0]);
+    if (lines !== undefined) {
+      if (lines === null) {
+        throw new Error("not found");
+      }
+      return lines.join("\r\n");
+    }
+  }
+  // reg.exe / wsl.exe probes from other detectors: treated as missing.
+  throw new Error(`unexpected execFileSync call: ${file} ${JSON.stringify(args)}`);
+};
+
+const shellDiscovery = require("./shellDiscovery.cjs");
+
+function makeHarness(t) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-shell-discovery-"));
+  t.after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  const previousLocalAppData = process.env.LOCALAPPDATA;
+  process.env.LOCALAPPDATA = tmp;
+  t.after(() => {
+    if (previousLocalAppData === undefined) {
+      delete process.env.LOCALAPPDATA;
+    } else {
+      process.env.LOCALAPPDATA = previousLocalAppData;
+    }
+  });
+
+  const aliasPath = path.join(
+    tmp,
+    "Microsoft",
+    "WindowsApps",
+    "pwsh.exe",
+  );
+  // The alias fixture intentionally does NOT exist on disk: real App
+  // Execution Aliases fail fs.statSync() with EACCES, so existsSync() is
+  // false on a real machine too.
+
+  return { tmp, aliasPath };
+}
+
+test("findExecutableOnPath accepts a WindowsApps execution alias as the only candidate", (t) => {
+  const { aliasPath } = makeHarness(t);
+  whereResults.set("pwsh", [aliasPath]);
+
+  assert.equal(shellDiscovery.findExecutableOnPath("pwsh"), aliasPath);
+  whereResults.delete("pwsh");
+});
+
+test("findExecutableOnPath prefers a regular executable over an execution alias", (t) => {
+  const { tmp, aliasPath } = makeHarness(t);
+  const realPwsh = path.join(tmp, "Program Files", "PowerShell", "7", "pwsh.exe");
+  fs.mkdirSync(path.dirname(realPwsh), { recursive: true });
+  fs.writeFileSync(realPwsh, "");
+  whereResults.set("pwsh", [aliasPath, realPwsh]);
+
+  assert.equal(shellDiscovery.findExecutableOnPath("pwsh"), realPwsh);
+  whereResults.delete("pwsh");
+});
+
+test("findExecutableOnPath returns null when where.exe finds nothing", (t) => {
+  makeHarness(t);
+  whereResults.set("pwsh", null);
+
+  assert.equal(shellDiscovery.findExecutableOnPath("pwsh"), null);
+  whereResults.delete("pwsh");
+});
+
+test("discoverWindowsShells lists PowerShell 7 from an MSIX alias and marks it default", (t) => {
+  const { aliasPath } = makeHarness(t);
+  whereResults.set("pwsh", [aliasPath]);
+  whereResults.set("powershell", null);
+  t.after(() => {
+    whereResults.delete("pwsh");
+    whereResults.delete("powershell");
+  });
+
+  const shells = shellDiscovery.discoverWindowsShells();
+  const pwsh = shells.find((s) => s.id === "pwsh");
+
+  assert.ok(pwsh, "expected a discovered pwsh shell entry");
+  assert.equal(pwsh.command, aliasPath);
+  assert.equal(pwsh.isDefault, true);
+});

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -59,6 +59,7 @@ const { detectShellKind } = require("./ai/ptyExec.cjs");
 const { stripAnsi, trackSessionIdlePrompt } = require("./ai/shellUtils.cjs");
 const { createZmodemSentry } = require("./zmodemHelper.cjs");
 const { discoverShells } = require("./shellDiscovery.cjs");
+const { isWindowsAppExecutionAliasPath } = require("../../lib/localShell.cjs");
 const moshHandshake = require("./moshHandshake.cjs");
 const tempDirBridge = require("./tempDirBridge.cjs");
 const { createTelnetAutoLogin } = require("./telnetAutoLogin.cjs");
@@ -741,22 +742,9 @@ function resolvePosixExecutable(name, opts = {}) {
 /**
  * Find executable path on Windows
  */
-function isWindowsAppExecutionAlias(filePath) {
-  if (!filePath || process.platform !== "win32") return false;
-
-  const normalizedPath = path.normalize(filePath).toLowerCase();
-  const windowsAppsDir = path.join(
-    process.env.LOCALAPPDATA || "",
-    "Microsoft",
-    "WindowsApps",
-  ).toLowerCase();
-
-  return !!windowsAppsDir && normalizedPath.startsWith(`${windowsAppsDir}${path.sep}`);
-}
-
 function findExecutable(name, opts = {}) {
   if (process.platform !== "win32") return name;
-  
+
   const { execFileSync } = require("child_process");
   try {
     const pathOverride = Object.prototype.hasOwnProperty.call(opts, "pathOverride")
@@ -776,11 +764,20 @@ function findExecutable(name, opts = {}) {
       .map((line) => line.trim())
       .filter(Boolean);
 
+    // Windows App Execution Aliases (MSIX/Store installs, e.g. winget pwsh 7)
+    // fail fs.existsSync() because they are reparse points, yet ConPTY can
+    // spawn the alias path directly. Keep the first alias as a last resort
+    // behind any regular executable found on the PATH.
+    let aliasCandidate = null;
     for (const candidate of candidates) {
+      if (isWindowsAppExecutionAliasPath(candidate)) {
+        aliasCandidate ??= candidate;
+        continue;
+      }
       if (!fs.existsSync(candidate)) continue;
-      if (name === "pwsh" && isWindowsAppExecutionAlias(candidate)) continue;
       return candidate;
     }
+    if (aliasCandidate) return aliasCandidate;
   } catch (err) {
     console.warn(`Could not find ${name} via where.exe:`, err.message);
   }
@@ -2535,6 +2532,7 @@ module.exports = {
   init,
   registerHandlers,
   findExecutable,
+  getDefaultLocalShell,
   startLocalSession,
   startTelnetSession,
   startMoshSession,

--- a/electron/bridges/terminalBridge.windowsAppsAlias.test.cjs
+++ b/electron/bridges/terminalBridge.windowsAppsAlias.test.cjs
@@ -1,0 +1,161 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const Module = require("node:module");
+const childProcess = require("node:child_process");
+
+function loadBridgeWithFakePty() {
+  const bridgePath = require.resolve("./terminalBridge.cjs");
+  delete require.cache[bridgePath];
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request) {
+    if (request === "node-pty") {
+      return {
+        spawn() {
+          throw new Error("node-pty spawn is not exercised by this suite");
+        },
+      };
+    }
+    return originalLoad.apply(this, arguments);
+  };
+  try {
+    return require("./terminalBridge.cjs");
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+const bridge = loadBridgeWithFakePty();
+
+function withWin32Platform(fn) {
+  const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { ...platformDescriptor, value: "win32" });
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(process, "platform", platformDescriptor);
+  }
+}
+
+// findExecutable() re-requires child_process inside the call, so patching the
+// module object's execFileSync at runtime intercepts its `where.exe` probes.
+function withWhereFake(resultsByname, fn) {
+  const realExecFileSync = childProcess.execFileSync;
+  childProcess.execFileSync = function fakeExecFileSync(file, args) {
+    const argv0 = String(file).toLowerCase();
+    const isWhere =
+      argv0 === "where.exe" || argv0.endsWith("\\where.exe") || argv0.endsWith("/where.exe");
+    if (isWhere) {
+      const lines = resultsByname.get(args[0]);
+      if (lines !== undefined) {
+        if (lines === null) {
+          throw new Error("not found");
+        }
+        return lines.join("\r\n");
+      }
+    }
+    throw new Error(`unexpected execFileSync call: ${file} ${JSON.stringify(args)}`);
+  };
+  try {
+    return fn();
+  } finally {
+    childProcess.execFileSync = realExecFileSync;
+  }
+}
+
+// Hide machine-specific fallback paths (e.g. an MSI pwsh under Program Files)
+// so the tests behave identically regardless of what the host has installed.
+function withExistsSyncAllowlist(allowed, fn) {
+  const realExistsSync = fs.existsSync;
+  fs.existsSync = (p) => allowed.has(String(p));
+  try {
+    return fn();
+  } finally {
+    fs.existsSync = realExistsSync;
+  }
+}
+
+function makeHarness(t) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-local-shell-"));
+  t.after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  const previousLocalAppData = process.env.LOCALAPPDATA;
+  process.env.LOCALAPPDATA = tmp;
+  t.after(() => {
+    if (previousLocalAppData === undefined) {
+      delete process.env.LOCALAPPDATA;
+    } else {
+      process.env.LOCALAPPDATA = previousLocalAppData;
+    }
+  });
+
+  const aliasPath = path.join(tmp, "Microsoft", "WindowsApps", "pwsh.exe");
+  // Intentionally not created on disk: real App Execution Aliases fail
+  // fs.statSync() with EACCES, so existsSync() is false for them anyway.
+
+  const realPwshPath = path.join(tmp, "PowerShell", "7", "pwsh.exe");
+  fs.mkdirSync(path.dirname(realPwshPath), { recursive: true });
+  fs.writeFileSync(realPwshPath, "");
+
+  const windowsPowerShellPath = path.join(tmp, "WindowsPowerShell", "v1.0", "powershell.exe");
+  fs.mkdirSync(path.dirname(windowsPowerShellPath), { recursive: true });
+  fs.writeFileSync(windowsPowerShellPath, "");
+
+  return { tmp, aliasPath, realPwshPath, windowsPowerShellPath };
+}
+
+test("getDefaultLocalShell resolves an MSIX pwsh execution alias", (t) => {
+  const { aliasPath } = makeHarness(t);
+
+  withWin32Platform(() =>
+    withWhereFake(new Map([["pwsh", [aliasPath]]]), () => {
+      assert.equal(bridge.getDefaultLocalShell(), aliasPath);
+    }),
+  );
+});
+
+test("findExecutable prefers a regular executable listed after an execution alias", (t) => {
+  const { aliasPath, realPwshPath } = makeHarness(t);
+
+  withWin32Platform(() =>
+    withWhereFake(new Map([["pwsh", [aliasPath, realPwshPath]]]), () => {
+      assert.equal(bridge.findExecutable("pwsh"), realPwshPath);
+    }),
+  );
+});
+
+test("getDefaultLocalShell still falls back to Windows PowerShell when no pwsh exists", (t) => {
+  const { windowsPowerShellPath } = makeHarness(t);
+
+  withWin32Platform(() =>
+    withWhereFake(
+      new Map([
+        ["pwsh", null],
+        ["powershell", [windowsPowerShellPath]],
+      ]),
+      () =>
+        withExistsSyncAllowlist(new Set([windowsPowerShellPath]), () => {
+          assert.equal(bridge.getDefaultLocalShell(), windowsPowerShellPath);
+        }),
+    ),
+  );
+});
+
+test("getDefaultLocalShell keeps the powershell.exe last-resort fallback", (t) => {
+  makeHarness(t);
+
+  withWin32Platform(() =>
+    withWhereFake(
+      new Map([
+        ["pwsh", null],
+        ["powershell", null],
+      ]),
+      () =>
+        withExistsSyncAllowlist(new Set(), () => {
+          assert.equal(bridge.getDefaultLocalShell(), "powershell.exe");
+        }),
+    ),
+  );
+});

--- a/lib/localShell.cjs
+++ b/lib/localShell.cjs
@@ -23,6 +23,28 @@ function detectLocalOs(platformLike) {
   return "linux";
 }
 
+/**
+ * True when `filePath` points inside `%LOCALAPPDATA%\Microsoft\WindowsApps`,
+ * i.e. it is a Windows App Execution Alias (MSIX/Store install stub).
+ *
+ * Aliases are zero-byte reparse points: `fs.statSync()` fails with EACCES and
+ * `fs.existsSync()` returns false, yet spawning the alias path still launches
+ * the packaged application. Consumers must not use existence checks to reject
+ * these paths. Deliberately free of `node:path` — this module is also bundled
+ * for the renderer.
+ */
+function isWindowsAppExecutionAliasPath(filePath) {
+  if (!filePath || typeof filePath !== "string") return false;
+  // Read via globalThis so renderer bundles (where `process` is not a global)
+  // stay valid; alias detection is a main-process concern and safely
+  // returns false when the env is unavailable.
+  const localAppData = globalThis.process?.env?.LOCALAPPDATA;
+  if (!localAppData) return false;
+  const normalize = (p) => p.replace(/\\/g, "/").replace(/\/+/g, "/").toLowerCase();
+  const aliasDir = `${normalize(localAppData)}/microsoft/windowsapps/`;
+  return normalize(filePath).startsWith(aliasDir);
+}
+
 function classifyLocalShellType(shellPath, platformLike) {
   const shellName = getExecutableBaseName(shellPath);
   if (POWERSHELL_SHELLS.has(shellName)) return "powershell";
@@ -39,4 +61,5 @@ function classifyLocalShellType(shellPath, platformLike) {
 module.exports = {
   classifyLocalShellType,
   detectLocalOs,
+  isWindowsAppExecutionAliasPath,
 };


### PR DESCRIPTION
## Summary

Accept Windows App Execution Aliases (MSIX/Store installs) as last-resort candidates in Windows shell resolution, so a winget-MSIX PowerShell 7 is discovered and used as the default local shell instead of falling back to Windows PowerShell 5.1.

Closes #3280

## Type of Change

- [x] Bug fix

## Related Issue (optional)

Closes #3280

## Changes Made

- `lib/localShell.cjs`: shared `isWindowsAppExecutionAliasPath()` (renderer-safe, no `node:path`).
- `electron/bridges/shellDiscovery.cjs` / `electron/bridges/terminalBridge.cjs`: two-pass lookup — regular PATH executables keep priority; the first WindowsApps alias is accepted only when no regular executable is found, skipping the existence check (aliases are reparse points: `fs.existsSync()` is false, `statSync` fails with EACCES).
- Drops the pwsh-specific alias skip from #286: ConPTY spawns the alias path fine (verified with pwsh 7.6.5); a bare `pwsh` name fails in node-pty, so the alias full path is what must be used.
- Exports `getDefaultLocalShell` for testability.

## Screenshots / Demo

N/A (no UI change).

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Notes: verified end-to-end on a winget-MSIX-only machine via a locally packaged installer — shell dropdown lists "PowerShell 7" (marked default) and the home terminal button opens pwsh 7.6.5. Lint run scoped to the changed files. 8 new tests pass (`shellDiscovery.windowsAppsAlias` + `terminalBridge.windowsAppsAlias`); remaining local `npm test` failures are pre-existing environment issues, identical on unmodified `main`. No catalog change, so capability tool specs are unaffected.

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
