### PR TITLE
fix(settings): restore AI detection after effect replay

### DIFF
--- a/components/settings/tabs/SettingsAITab.lifecycle.test.ts
+++ b/components/settings/tabs/SettingsAITab.lifecycle.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import ts from "typescript";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Exercise the production lifecycle and asynchronous resolver together, without
+// loading the unrelated provider forms or making real CLI/authentication calls.
+const source = readFileSync(new URL("./SettingsAITab.tsx", import.meta.url), "utf8");
+const lifecycleStart = source.indexOf("  const mountedRef = useRef(true);");
+const lifecycleEnd = source.indexOf("\n  const applyResolvedAgentPath", lifecycleStart);
+const resolverStart = source.indexOf("  const resolveAgentPath = useCallback");
+const resolverEnd = source.indexOf("\n  useEffect(() => {", resolverStart);
+assert.ok(lifecycleStart >= 0 && lifecycleEnd > lifecycleStart);
+assert.ok(resolverStart >= 0 && resolverEnd > resolverStart);
+const declarations = source.slice(lifecycleStart, lifecycleEnd) + source.slice(resolverStart, resolverEnd);
+const setters = ["Codex", "Claude", "Copilot", "Cursor", "Codebuddy", "Opencode", "Grok"];
+const bindings = ["useRef", "useEffect", "useCallback", "getBridge", "applyResolvedAgentPath", "cursorApiKeyEncrypted",
+  ...setters.map(name => `setIsResolving${name}`)];
+const runHooks = vm.runInNewContext(ts.transpile(`(function(ctx) {
+  const { ${bindings.join(",")} } = ctx;
+  ${declarations}
+  return resolveAgentPath;
+})`, { target: ts.ScriptTarget.ES2022 }), { console }) as
+  (ctx: Record<string, unknown>) => (key: string) => Promise<unknown>;
+
+function deferred() {
+  let resolve!: (value: unknown) => void;
+  const promise = new Promise<unknown>(done => { resolve = done; });
+  return { promise, resolve };
+}
+
+async function mountResolver() {
+  const calls: ReturnType<typeof deferred>[] = [];
+  const applied: unknown[] = [];
+  const state: { busy: boolean; resolve?: (key: string) => Promise<unknown> } = { busy: false };
+  const bridge = { aiResolveCli: () => { const pending = deferred(); calls.push(pending); return pending.promise; } };
+  function Harness() {
+    const [busy, setBusy] = useState(false);
+    state.busy = busy;
+    state.resolve = runHooks({
+      useRef, useEffect, useCallback,
+      getBridge: () => bridge,
+      applyResolvedAgentPath: (_key: string, result: unknown) => applied.push(result),
+      cursorApiKeyEncrypted: "",
+      ...Object.fromEntries(setters.map(name => [`setIsResolving${name}`, setBusy])),
+    });
+    return null;
+  }
+  let root!: TestRenderer.ReactTestRenderer;
+  await act(async () => { root = TestRenderer.create(React.createElement(React.StrictMode, null, React.createElement(Harness))); });
+  return { calls, applied, state, root };
+}
+
+test("AI detection accepts completed requests after StrictMode effect replay", async () => {
+  const h = await mountResolver();
+  try {
+    let request!: Promise<unknown>;
+    await act(async () => { request = h.state.resolve!("cursor"); });
+    assert.equal(h.state.busy, true);
+    const result = { installed: true, available: true, cliBinPath: "/fixture/cursor-agent" };
+    await act(async () => { h.calls[0].resolve(result); await request; });
+    assert.deepEqual(h.applied, [result]);
+    assert.equal(h.state.busy, false);
+  } finally { await act(async () => h.root.unmount()); }
+});
+
+test("AI detection still ignores completion after real unmount", async () => {
+  const h = await mountResolver();
+  let request!: Promise<unknown>;
+  await act(async () => { request = h.state.resolve!("cursor"); });
+  await act(async () => h.root.unmount());
+  h.calls[0].resolve({ installed: true });
+  await request;
+  assert.deepEqual(h.applied, []);
+});
+
+test("an older AI detection result cannot replace or finish the newer request", async () => {
+  const h = await mountResolver();
+  try {
+    let old!: Promise<unknown>;
+    let current!: Promise<unknown>;
+    await act(async () => { old = h.state.resolve!("cursor"); current = h.state.resolve!("cursor"); });
+    await act(async () => { h.calls[0].resolve({ installed: false }); await old; });
+    assert.deepEqual(h.applied, []);
+    assert.equal(h.state.busy, true);
+    const result = { installed: true };
+    await act(async () => { h.calls[1].resolve(result); await current; });
+    assert.deepEqual(h.applied, [result]);
+    assert.equal(h.state.busy, false);
+  } finally { await act(async () => h.root.unmount()); }
+});

--- a/components/settings/tabs/SettingsAITab.tsx
+++ b/components/settings/tabs/SettingsAITab.tsx
@@ -342,12 +342,16 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
   const mountedRef = useRef(true);
   const agentPathRequestIdRef = useRef<Partial<Record<ManagedAgentKey, number>>>({});
   const codexRequestIdRef = useRef(0);
-  useEffect(() => () => {
-    mountedRef.current = false;
-    codexRequestIdRef.current += 1;
-    for (const key of ["codex", "claude", "copilot", "cursor", "codebuddy", "opencode", "grok"] as ManagedAgentKey[]) {
-      agentPathRequestIdRef.current[key] = (agentPathRequestIdRef.current[key] ?? 0) + 1;
-    }
+  useEffect(() => {
+    mountedRef.current = true;
+    const agentPathRequestIds = agentPathRequestIdRef.current;
+    return () => {
+      mountedRef.current = false;
+      codexRequestIdRef.current += 1;
+      for (const key of ["codex", "claude", "copilot", "cursor", "codebuddy", "opencode", "grok"] as ManagedAgentKey[]) {
+        agentPathRequestIds[key] = (agentPathRequestIds[key] ?? 0) + 1;
+      }
+    };
   }, []);
 
   const applyResolvedAgentPath = useCallback((


### PR DESCRIPTION
## Summary

In `npm run dev`, opening Settings > AI > Agents can leave every agent stuck on “Detecting…”. React StrictMode replays effect setup and cleanup; the cleanup marks the page unmounted, but setup never restores that flag. Completed CLI checks are then discarded and their loading indicators never clear.

Restore the mounted flag during effect setup while retaining request invalidation on cleanup. This also preserves the existing protection against stale and post-unmount results. Found during release smoke testing; the lifecycle code predates the current release, so this is not attributed to #3178.

## Type of Change

- [x] Bug fix

## Related Issue (optional)

N/A — found during development-app smoke testing.

## Changes Made

- Restore mounted state on effect setup and retain cleanup request invalidation.
- Add tests running the production lifecycle and asynchronous resolver under React StrictMode, with controlled CLI responses. Cover accepted completion, actual unmount, and superseded requests.

## Screenshots / Demo

Verified in the actual Electron application launched with `npm run dev`, using the Settings window. Before: Cursor CLI exists and responds to `--version`, but all cards remain “Detecting…” indefinitely. After a full settings reload with the repair: Cursor shows “Detected” and “Logged in”, the Check button becomes usable, and another manual check completes.

Additional Computer smoke with main cabdcdf31 plus this lifecycle fix used an isolated development profile and a fixture shell environment restricted to system executable directories. The real Cursor resolver could not find `cursor-agent`, while the real bundled SDK import succeeded; diagnostic booleans were `sdkInstalled=true`, `installed=false`, `cliPathPresent=false`, and `cliLoginOk=false`. The current card showed “Not detected / Not logged in”; manual Check completed with the same result. Swapping only the card for its pre-#3178 version produced the original false “Detected” label under the identical backend state, and restoring the current card removed it. No installed executable, user home, credential or normal profile was changed. This validates the CLI-unavailable boundary, not a claim that Cursor was uninstalled from the machine. A fresh 40-test lifecycle/path/auth/discovery subset also passed with no skips.

## Testing

- [x] Tested locally in `npm run dev`
- [x] Focused tests: 63 passed, 0 failed (lifecycle, managed-agent state, path types, discovery and authentication probes)
- [x] Regression tests run against the original implementation: 2 fail; repaired implementation: all 3 pass
- [x] ESLint passes on changed files
- [ ] Full `npm test` was not rerun for this change

## Checklist

- [x] Follows existing project style
- [x] No breaking changes or storage changes
- [x] No capability schema changes
