### PR TITLE
fix(sftp): preserve browsed paths across tab snapshot transitions

### DIFF
--- a/application/state/sidePanelLiveTabIsolation.test.ts
+++ b/application/state/sidePanelLiveTabIsolation.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import vm from 'node:vm';
+import React, { useCallback, useRef, useSyncExternalStore } from 'react';
+import { act, create } from 'react-test-renderer';
+import ts from 'typescript';
+import { getSidePanelLiveSnapshot, subscribeSidePanelLiveSnapshot, sidePanelLiveStore, SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT, type SidePanelLiveSnapshot } from './sidePanelLiveStore';
+
+// Exercise the production hook without importing the unrelated panel UI modules.
+const source = readFileSync(new URL('../../components/terminalLayer/terminalLayerSidePanelSlots.tsx', import.meta.url), 'utf8');
+const ast = ts.createSourceFile('slots.tsx', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+const hook = ast.statements.find((node) => ts.isFunctionDeclaration(node) && node.name?.text === 'useSidePanelLiveSnapshotForTab');
+assert.ok(hook);
+const code = ts.transpile(hook.getText(ast), { target: ts.ScriptTarget.ES2022 });
+const useSnapshot = vm.runInNewContext(`${code}; useSidePanelLiveSnapshotForTab`, {
+  useCallback, useRef, useSyncExternalStore, getSidePanelLiveSnapshot,
+  subscribeSidePanelLiveSnapshot, SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT,
+}) as (tabId: string, enabled: boolean) => SidePanelLiveSnapshot;
+
+const env = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+
+test('returning to a tab never exposes the previous tab snapshot before its publisher catches up', async () => {
+  const previous = env.IS_REACT_ACT_ENVIRONMENT;
+  env.IS_REACT_ACT_ENVIRONMENT = true;
+  const own = { ...SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT, focusedSessionId: 'ssh-a', activeTerminalSessionIdForSftp: 'ssh-a', activeTerminalCwd: '/root', activeTerminalCwdTrusted: true };
+  const other = { ...SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT, focusedSessionId: 'local-b' };
+  let visible = true;
+  let observed: SidePanelLiveSnapshot = SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT;
+  function Probe() { observed = useSnapshot('ssh-a', visible); return null; }
+  sidePanelLiveStore.update(own);
+  let renderer: ReturnType<typeof create> | undefined;
+  try {
+    await act(async () => { renderer = create(React.createElement(Probe)); });
+    assert.equal(observed.focusedSessionId, 'ssh-a');
+    visible = false;
+    await act(async () => { renderer?.update(React.createElement(Probe)); });
+    await act(async () => { sidePanelLiveStore.update(other); });
+    visible = true;
+    await act(async () => { renderer?.update(React.createElement(Probe)); });
+    assert.equal(observed.focusedSessionId, 'ssh-a', 'stale local session must not enter the SSH panel');
+    assert.equal(observed.activeTerminalCwd, '/root', 'unchanged cwd must survive the reveal gap');
+    await act(async () => { sidePanelLiveStore.update({ ...own, activeTerminalCwd: '/srv/changed' }); });
+    assert.equal(observed.activeTerminalCwd, '/srv/changed', 'real cwd changes must still arrive');
+  } finally {
+    await act(async () => renderer?.unmount());
+    sidePanelLiveStore.update(SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT);
+    env.IS_REACT_ACT_ENVIRONMENT = previous;
+  }
+});
+
+test('new panels wait for their own snapshot and workspace panes accept focus changes within the workspace', async () => {
+  const previous = env.IS_REACT_ACT_ENVIRONMENT;
+  env.IS_REACT_ACT_ENVIRONMENT = true;
+  let observed = SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT;
+  const workspace = { id: 'workspace-a' } as NonNullable<SidePanelLiveSnapshot['activeWorkspace']>;
+  const own = { ...SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT, activeWorkspace: workspace, focusedSessionId: 'pane-a' };
+  let panelTabId = 'workspace-a';
+  function Probe() { observed = useSnapshot(panelTabId, true); return null; }
+  sidePanelLiveStore.update({ ...SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT, focusedSessionId: 'unrelated' });
+  let renderer: ReturnType<typeof create> | undefined;
+  try {
+    await act(async () => { renderer = create(React.createElement(Probe)); });
+    assert.equal(observed, SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT);
+    await act(async () => { sidePanelLiveStore.update(own); });
+    assert.equal(observed.focusedSessionId, 'pane-a');
+    await act(async () => { sidePanelLiveStore.update({ ...own, focusedSessionId: 'pane-b' }); });
+    assert.equal(observed.focusedSessionId, 'pane-b');
+    await act(async () => { sidePanelLiveStore.update({ ...SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT, focusedSessionId: 'unrelated' }); });
+    assert.equal(observed.focusedSessionId, 'pane-b');
+    panelTabId = 'new-owner';
+    await act(async () => { renderer?.update(React.createElement(Probe)); });
+    assert.equal(observed, SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT, 'a reused hook must not retain another owner');
+  } finally {
+    await act(async () => renderer?.unmount());
+    sidePanelLiveStore.update(SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT);
+    env.IS_REACT_ACT_ENVIRONMENT = previous;
+  }
+});

--- a/components/terminalLayer/terminalLayerSidePanelSlots.tsx
+++ b/components/terminalLayer/terminalLayerSidePanelSlots.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { memo, useCallback, useSyncExternalStore } from 'react';
+import React, { memo, useCallback, useRef, useSyncExternalStore } from 'react';
 import { createPortal } from 'react-dom';
 
 import { activeTabStore } from '../../application/state/activeTabStore';
 import { getSftpCurrentPathMemoryKey } from '../../application/state/sftp/sftpReopenLocation';
 import {
   getSidePanelLiveSnapshot,
+  SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT,
   subscribeSidePanelLiveSnapshot,
 } from '../../application/state/sidePanelLiveStore';
 import {
@@ -49,10 +50,18 @@ const subscribeShellHistoryNoop = () => () => {};
 const getEmptyShellHistorySnapshot = () => EMPTY_SHELL_HISTORY;
 
 function useSidePanelLiveSnapshotForTab(tabId: string, subscribe: boolean) {
-  const getSnapshot = useCallback(
-    () => getSidePanelLiveSnapshot(subscribe),
-    [subscribe],
-  );
+  const retainedSnapshot = useRef({ tabId, snapshot: SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT });
+  const getSnapshot = useCallback(() => {
+    if (!subscribe) return SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT;
+    const snapshot = getSidePanelLiveSnapshot(true);
+    const snapshotTabId = snapshot.activeWorkspace?.id ?? snapshot.focusedSessionId;
+    // Tab visibility changes before the live publisher commits its next snapshot.
+    // Keep this panel's last context until its own terminal/workspace catches up.
+    if (snapshotTabId === tabId) retainedSnapshot.current = { tabId, snapshot };
+    return retainedSnapshot.current.tabId === tabId
+      ? retainedSnapshot.current.snapshot
+      : SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT;
+  }, [subscribe, tabId]);
   return useSyncExternalStore(
     (listener) => subscribeSidePanelLiveSnapshot(subscribe, listener),
     getSnapshot,


### PR DESCRIPTION
## Summary

Switching away from an SSH terminal and back could still reset its SFTP browser to the terminal cwd and clear its filename filter, despite #3232. The panel briefly consumed the previous tab's live context before the new tab's publisher committed, invalidating cwd tracking and sometimes replacing the SFTP connection.

Keep each panel's last matching terminal/workspace snapshot during that publication gap. Unrelated snapshots are ignored, fresh panels wait for their owner, and actual cwd or focused workspace-pane changes still propagate.

## Type of Change

- [x] Bug fix

## Related Issue (optional)

Follow-up to #3232; related to #3230.

## Changes Made

- Match live snapshots to the owning standalone terminal or workspace.
- Retain only a matching snapshot during a tab reveal; clear the fallback when the hook owner changes.
- Add tests exercising the actual production subscription hook, including stale publication, new mounts, workspace focus changes, and owner changes.

## Screenshots / Demo

Reproduced twice in the actual `npm run dev` Electron app against an SSH host: enable follow terminal directory, browse a different folder, filter to one file, switch to a local tab and back. Before the fix the path returned to `/root` and the filter disappeared. A temporary trace showed the local tab's focused session entering the remote panel before its own snapshot arrived; no panel remount was required.

After the fix, the same UI steps preserved the folder and filter. A real `cd` still moved the SFTP browser to the new directory. Final source was retested in the development app. Diagnostic logging was removed.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`) — full suite not rerun
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`) — not applicable
- [ ] No new console errors or warnings, if this affects app behavior — existing development warnings were present

124 focused tests pass across live snapshot isolation, SFTP follow, connection reuse/memory, side-panel wiring, and the tab bridge. The new regression test was run against the old hook and failed because `local-b` reached the `ssh-a` panel; it passes with this fix.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation — reproduction and validation recorded here
- [x] I have not introduced any breaking changes
