### PR TITLE
fix(ai): keep live shell probes out of Bash history

### DIFF
--- a/electron/bridges/ai/liveShellProbe.cjs
+++ b/electron/bridges/ai/liveShellProbe.cjs
@@ -1,6 +1,9 @@
 "use strict";
 
-const { buildBashHistoryCleanup } = require("./ptyExecHelpers.cjs");
+const {
+  buildBashHistoryCleanup,
+  bashHistoryCleanupStatusVar,
+} = require("./ptyExecHelpers.cjs");
 
 // Both fish and POSIX shells accept this command. Inspect the parent of a
 // short-lived sh in the interactive PTY, rather than the SSH login shell.
@@ -12,6 +15,16 @@ function buildLiveShellProbe(marker) {
   // cleanup is dispatched through both \command eval and \builtin eval: the
   // one that reaches the real eval runs the cleanup, the other no-ops once
   // the marker is already gone; cleanup itself checks BASH_VERSION.
+  // The \builtin eval fallback only runs when the \command eval path left the
+  // cleanup's verified-deletion flag unset (shadowed dispatcher or nothing to
+  // verify); a slow shadowed fallback (e.g. builtin() { sleep 60; }) is
+  // therefore not invoked again after a real dispatcher already deleted the
+  // entry. The eval'd cleanup leaves the flag (holding only "1") set in the
+  // interactive shell, so the test reads it through eval: the quoted
+  // ${flag-} default keeps the expansion nounset-safe in POSIX shells (a bare
+  // $flag aborts dash under set -u), and the flag can never be a secret.
+  // Fish rejects ${...} inside the eval'd test, which only fails that segment
+  // (non-zero) so the fallback runs and no-ops there as before.
   // Fish cannot resolve eval through command and rejects it without parsing its
   // quoted POSIX body. Make cleanup failure non-fatal even under set -e,
   // suppress its diagnostic, and always emit Q afterward.
@@ -20,8 +33,12 @@ function buildLiveShellProbe(marker) {
   // The builtin completion marker still runs if sh cannot launch. Leave it
   // unterminated so preload hides the intermediate prompt and wrapper echo
   // on the same marker-bearing line, including across output chunks.
-  const cleanup = buildBashHistoryCleanup(marker);
-  return ` true ${marker}; command sh -c '${script}' 2>/dev/null; \\command eval '${cleanup}' 2>/dev/null || true; \\builtin eval '${cleanup}' 2>/dev/null || true; printf '%s' '${marker}_Q'\n`;
+  const cleanup = buildBashHistoryCleanup(marker, true);
+  const cleanupStatus = bashHistoryCleanupStatusVar(marker);
+  // "${var-}" is written via concatenation: inside a template literal "\${"
+  // would escape the interpolation and emit the literal name instead.
+  const statusTest = `eval '[ -n "$` + `{${cleanupStatus}-}" ]' 2>/dev/null`;
+  return ` true ${marker}; command sh -c '${script}' 2>/dev/null; \\command eval '${cleanup}' 2>/dev/null || true; ${statusTest} || \\builtin eval '${cleanup}' 2>/dev/null || true; printf '%s' '${marker}_Q'\n`;
 }
 
 function parseLiveShellProbe(output, marker) {

--- a/electron/bridges/ai/liveShellProbe.cjs
+++ b/electron/bridges/ai/liveShellProbe.cjs
@@ -6,17 +6,17 @@ const { buildBashHistoryCleanup } = require("./ptyExecHelpers.cjs");
 // short-lived sh in the interactive PTY, rather than the SSH login shell.
 function buildLiveShellProbe(marker) {
   const script = 'if test -r "/proc/$PPID/comm"; then IFS= read -r name < "/proc/$PPID/comm"; else name=$(ps -p "$PPID" -o comm= 2>/dev/null); fi; '
-    + `printf "${marker}_P:%s\\n" "$name"; name=\${name##*/}; name=\${name#-}; test "$name" = bash`;
-  // The child reports whether the parent is Bash through its exit status.
-  // Only Bash evaluates its history cleanup; the surrounding && syntax is
-  // also accepted by fish and does not expand unset parent-shell variables.
-  // Clean the probe before Q, including when no command follows cancellation.
+    + `printf "${marker}_P:%s\\n" "$name"`;
+  // Run cleanup independently of process-name detection or external sh/PATH.
+  // Bash and zsh provide builtin eval and the cleanup itself checks BASH_VERSION.
+  // Shells without it (including fish) reject the builtin without parsing its
+  // quoted POSIX body; suppress that diagnostic and always emit Q afterward.
   // Put the job marker near the start of the echo, as the existing wrappers
   // do, so preload can suppress it before a long command is split into chunks.
   // The builtin completion marker still runs if sh cannot launch. Leave it
   // unterminated so preload hides the intermediate prompt and wrapper echo
   // on the same marker-bearing line, including across output chunks.
-  return ` true ${marker}; command sh -c '${script}' 2>/dev/null && builtin eval '${buildBashHistoryCleanup(marker)}'; printf '%s' '${marker}_Q'\n`;
+  return ` true ${marker}; command sh -c '${script}' 2>/dev/null; builtin eval '${buildBashHistoryCleanup(marker)}' 2>/dev/null; printf '%s' '${marker}_Q'\n`;
 }
 
 function parseLiveShellProbe(output, marker) {

--- a/electron/bridges/ai/liveShellProbe.cjs
+++ b/electron/bridges/ai/liveShellProbe.cjs
@@ -8,8 +8,8 @@ function buildLiveShellProbe(marker) {
   const script = 'if test -r "/proc/$PPID/comm"; then IFS= read -r name < "/proc/$PPID/comm"; else name=$(ps -p "$PPID" -o comm= 2>/dev/null); fi; '
     + `printf "${marker}_P:%s\\n" "$name"`;
   // Run cleanup independently of process-name detection or external sh/PATH.
-  // Bash and zsh provide builtin eval and the cleanup itself checks BASH_VERSION.
-  // Shells without it (including fish) reject the builtin without parsing its
+  // POSIX command bypasses eval aliases/functions; cleanup checks BASH_VERSION.
+  // Fish cannot resolve eval through command and rejects it without parsing its
   // quoted POSIX body. Make cleanup failure non-fatal even under set -e,
   // suppress its diagnostic, and always emit Q afterward.
   // Put the job marker near the start of the echo, as the existing wrappers
@@ -17,7 +17,7 @@ function buildLiveShellProbe(marker) {
   // The builtin completion marker still runs if sh cannot launch. Leave it
   // unterminated so preload hides the intermediate prompt and wrapper echo
   // on the same marker-bearing line, including across output chunks.
-  return ` true ${marker}; command sh -c '${script}' 2>/dev/null; builtin eval '${buildBashHistoryCleanup(marker)}' 2>/dev/null || true; printf '%s' '${marker}_Q'\n`;
+  return ` true ${marker}; command sh -c '${script}' 2>/dev/null; command eval '${buildBashHistoryCleanup(marker)}' 2>/dev/null || true; printf '%s' '${marker}_Q'\n`;
 }
 
 function parseLiveShellProbe(output, marker) {

--- a/electron/bridges/ai/liveShellProbe.cjs
+++ b/electron/bridges/ai/liveShellProbe.cjs
@@ -1,16 +1,22 @@
 "use strict";
 
+const { buildBashHistoryCleanup } = require("./ptyExecHelpers.cjs");
+
 // Both fish and POSIX shells accept this command. Inspect the parent of a
 // short-lived sh in the interactive PTY, rather than the SSH login shell.
 function buildLiveShellProbe(marker) {
   const script = 'if test -r "/proc/$PPID/comm"; then IFS= read -r name < "/proc/$PPID/comm"; else name=$(ps -p "$PPID" -o comm= 2>/dev/null); fi; '
-    + `printf "${marker}_P:%s\\n" "$name"`;
+    + `printf "${marker}_P:%s\\n" "$name"; name=\${name##*/}; name=\${name#-}; test "$name" = bash`;
+  // The child reports whether the parent is Bash through its exit status.
+  // Only Bash evaluates its history cleanup; the surrounding && syntax is
+  // also accepted by fish and does not expand unset parent-shell variables.
+  // Clean the probe before Q, including when no command follows cancellation.
   // Put the job marker near the start of the echo, as the existing wrappers
   // do, so preload can suppress it before a long command is split into chunks.
   // The builtin completion marker still runs if sh cannot launch. Leave it
   // unterminated so preload hides the intermediate prompt and wrapper echo
   // on the same marker-bearing line, including across output chunks.
-  return ` true ${marker}; command sh -c '${script}' 2>/dev/null; printf '%s' '${marker}_Q'\n`;
+  return ` true ${marker}; command sh -c '${script}' 2>/dev/null && eval '${buildBashHistoryCleanup(marker)}'; printf '%s' '${marker}_Q'\n`;
 }
 
 function parseLiveShellProbe(output, marker) {

--- a/electron/bridges/ai/liveShellProbe.cjs
+++ b/electron/bridges/ai/liveShellProbe.cjs
@@ -8,7 +8,10 @@ function buildLiveShellProbe(marker) {
   const script = 'if test -r "/proc/$PPID/comm"; then IFS= read -r name < "/proc/$PPID/comm"; else name=$(ps -p "$PPID" -o comm= 2>/dev/null); fi; '
     + `printf "${marker}_P:%s\\n" "$name"`;
   // Run cleanup independently of process-name detection or external sh/PATH.
-  // POSIX command bypasses eval aliases/functions; cleanup checks BASH_VERSION.
+  // A user alias or function can shadow any single dispatcher name, so the
+  // cleanup is dispatched through both \command eval and \builtin eval: the
+  // one that reaches the real eval runs the cleanup, the other no-ops once
+  // the marker is already gone; cleanup itself checks BASH_VERSION.
   // Fish cannot resolve eval through command and rejects it without parsing its
   // quoted POSIX body. Make cleanup failure non-fatal even under set -e,
   // suppress its diagnostic, and always emit Q afterward.
@@ -17,7 +20,8 @@ function buildLiveShellProbe(marker) {
   // The builtin completion marker still runs if sh cannot launch. Leave it
   // unterminated so preload hides the intermediate prompt and wrapper echo
   // on the same marker-bearing line, including across output chunks.
-  return ` true ${marker}; command sh -c '${script}' 2>/dev/null; command eval '${buildBashHistoryCleanup(marker)}' 2>/dev/null || true; printf '%s' '${marker}_Q'\n`;
+  const cleanup = buildBashHistoryCleanup(marker);
+  return ` true ${marker}; command sh -c '${script}' 2>/dev/null; \\command eval '${cleanup}' 2>/dev/null || true; \\builtin eval '${cleanup}' 2>/dev/null || true; printf '%s' '${marker}_Q'\n`;
 }
 
 function parseLiveShellProbe(output, marker) {

--- a/electron/bridges/ai/liveShellProbe.cjs
+++ b/electron/bridges/ai/liveShellProbe.cjs
@@ -16,7 +16,7 @@ function buildLiveShellProbe(marker) {
   // The builtin completion marker still runs if sh cannot launch. Leave it
   // unterminated so preload hides the intermediate prompt and wrapper echo
   // on the same marker-bearing line, including across output chunks.
-  return ` true ${marker}; command sh -c '${script}' 2>/dev/null && eval '${buildBashHistoryCleanup(marker)}'; printf '%s' '${marker}_Q'\n`;
+  return ` true ${marker}; command sh -c '${script}' 2>/dev/null && builtin eval '${buildBashHistoryCleanup(marker)}'; printf '%s' '${marker}_Q'\n`;
 }
 
 function parseLiveShellProbe(output, marker) {

--- a/electron/bridges/ai/liveShellProbe.cjs
+++ b/electron/bridges/ai/liveShellProbe.cjs
@@ -1,44 +1,23 @@
 "use strict";
 
-const {
-  buildBashHistoryCleanup,
-  bashHistoryCleanupStatusVar,
-} = require("./ptyExecHelpers.cjs");
+const { buildBashHistoryCleanup, bashHistoryScratchNames } = require("./ptyExecHelpers.cjs");
 
 // Both fish and POSIX shells accept this command. Inspect the parent of a
 // short-lived sh in the interactive PTY, rather than the SSH login shell.
 function buildLiveShellProbe(marker) {
   const script = 'if test -r "/proc/$PPID/comm"; then IFS= read -r name < "/proc/$PPID/comm"; else name=$(ps -p "$PPID" -o comm= 2>/dev/null); fi; '
     + `printf "${marker}_P:%s\\n" "$name"`;
-  // Run cleanup independently of process-name detection or external sh/PATH.
-  // A user alias or function can shadow any single dispatcher name, so the
-  // cleanup is dispatched through both \command eval and \builtin eval: the
-  // one that reaches the real eval runs the cleanup, the other no-ops once
-  // the marker is already gone; cleanup itself checks BASH_VERSION.
-  // The \builtin eval fallback only runs when the \command eval path left the
-  // cleanup's verified-deletion flag unset (shadowed dispatcher or nothing to
-  // verify); a slow shadowed fallback (e.g. builtin() { sleep 60; }) is
-  // therefore not invoked again after a real dispatcher already deleted the
-  // entry. The eval'd cleanup leaves the flag (holding only "1") set in the
-  // interactive shell, so the test reads it through eval: the quoted
-  // ${flag-} default keeps the expansion nounset-safe in POSIX shells (a bare
-  // $flag aborts dash under set -u), and the flag can never be a secret.
-  // Fish rejects ${...} inside the eval'd test, which only fails that segment
-  // (non-zero) so the fallback runs and no-ops there as before.
-  // Fish cannot resolve eval through command and rejects it without parsing its
-  // quoted POSIX body. Make cleanup failure non-fatal even under set -e,
-  // suppress its diagnostic, and always emit Q afterward.
-  // Put the job marker near the start of the echo, as the existing wrappers
-  // do, so preload can suppress it before a long command is split into chunks.
-  // The builtin completion marker still runs if sh cannot launch. Leave it
-  // unterminated so preload hides the intermediate prompt and wrapper echo
-  // on the same marker-bearing line, including across output chunks.
+  // command eval bypasses an eval customization; plain eval is the fallback
+  // when command itself is shadowed. Never invoke a shadowed builtin after the
+  // command path already succeeded. Both eval bodies remain Bash-guarded.
   const cleanup = buildBashHistoryCleanup(marker, true);
-  const cleanupStatus = bashHistoryCleanupStatusVar(marker);
-  // "${var-}" is written via concatenation: inside a template literal "\${"
-  // would escape the interpolation and emit the literal name instead.
-  const statusTest = `eval '[ -n "$` + `{${cleanupStatus}-}" ]' 2>/dev/null`;
-  return ` true ${marker}; command sh -c '${script}' 2>/dev/null; \\command eval '${cleanup}' 2>/dev/null || true; ${statusTest} || \\builtin eval '${cleanup}' 2>/dev/null || true; printf '%s' '${marker}_Q'\n`;
+  const { dispatcher } = bashHistoryScratchNames(marker);
+  const clear = `[ -z "\${${dispatcher}-}" ]||$${dispatcher} unset ${dispatcher}`;
+  const fallback = `[ "\${${dispatcher}-}" = command ]||{ ${cleanup}; };${clear}`;
+  // Continuation lines stay within canonical input limits. Each echo carries
+  // the marker so the renderer also hides continuation prompts.
+  return ` true ${marker}; command sh -c '${script}' 2>/dev/null; \\\n: '${marker}'; \\command eval '${cleanup}' 2>/dev/null || true; \\\n: '${marker}'; \\eval '${fallback}' 2>/dev/null || true; \\\n: '${marker}'; \\command eval '${clear}' 2>/dev/null || true; printf '%s' '${marker}_Q'\n`;
+
 }
 
 function parseLiveShellProbe(output, marker) {

--- a/electron/bridges/ai/liveShellProbe.cjs
+++ b/electron/bridges/ai/liveShellProbe.cjs
@@ -10,13 +10,14 @@ function buildLiveShellProbe(marker) {
   // Run cleanup independently of process-name detection or external sh/PATH.
   // Bash and zsh provide builtin eval and the cleanup itself checks BASH_VERSION.
   // Shells without it (including fish) reject the builtin without parsing its
-  // quoted POSIX body; suppress that diagnostic and always emit Q afterward.
+  // quoted POSIX body. Make cleanup failure non-fatal even under set -e,
+  // suppress its diagnostic, and always emit Q afterward.
   // Put the job marker near the start of the echo, as the existing wrappers
   // do, so preload can suppress it before a long command is split into chunks.
   // The builtin completion marker still runs if sh cannot launch. Leave it
   // unterminated so preload hides the intermediate prompt and wrapper echo
   // on the same marker-bearing line, including across output chunks.
-  return ` true ${marker}; command sh -c '${script}' 2>/dev/null; builtin eval '${buildBashHistoryCleanup(marker)}' 2>/dev/null; printf '%s' '${marker}_Q'\n`;
+  return ` true ${marker}; command sh -c '${script}' 2>/dev/null; builtin eval '${buildBashHistoryCleanup(marker)}' 2>/dev/null || true; printf '%s' '${marker}_Q'\n`;
 }
 
 function parseLiveShellProbe(output, marker) {

--- a/electron/bridges/ai/liveShellProbe.test.cjs
+++ b/electron/bridges/ai/liveShellProbe.test.cjs
@@ -170,6 +170,7 @@ for (const [customization, listHistory] of [
   ['HISTCONTROL=ignorespace', 'command builtin history'],
   ["alias history='history 10'", 'command builtin history'],
   ['history() { :; }', 'command builtin history'],
+  ['history() { builtin history "$@" | cat; }', 'command builtin history'],
   ["alias eval=':'", 'command builtin history'],
   ['eval() { :; }', 'command builtin history'],
   ['PATH=/nonexistent', 'command builtin history'],
@@ -292,5 +293,17 @@ for (const [shell, args] of [
     assert.equal(result.status, 0, result.stderr);
     assert.ok(result.stdout.includes(`${marker}_Q`), result.stdout);
     assert.ok(result.stdout.includes('shell_survived'), result.stdout);
+  });
+}
+
+for (const shell of ['/bin/dash', '/bin/zsh']) {
+  test(`history cleanup keeps the execution wrapper portable in ${shell}`, { skip: !require('node:fs').existsSync(shell) }, () => {
+    const { spawnSync } = require('node:child_process');
+    const { buildWrappedCommand } = require('./ptyExecHelpers.cjs');
+    const marker = '__NCMCP_PORTABLE_HISTORY__';
+    const result = spawnSync(shell, ['-c', buildWrappedCommand('echo portable-history-ok', 'posix', marker, true)], { encoding: 'utf8', timeout: 5000 });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /portable-history-ok/);
+    assert.ok(result.stdout.includes(`${marker}_E:0`));
   });
 }

--- a/electron/bridges/ai/liveShellProbe.test.cjs
+++ b/electron/bridges/ai/liveShellProbe.test.cjs
@@ -167,6 +167,32 @@ test('real PTY: echo-disabled bash completes output without a trailing newline',
   }
 });
 
+test('real PTY: canonical bash executes a long literal command without truncation', {
+  skip: process.env.NETCATTY_LIVE_FISH_TEST !== '1', timeout: 15000,
+}, async () => {
+  const pty = require('node-pty').spawn('/bin/bash', ['--noprofile', '--norc', '--noediting'], {
+    name: 'dumb', cols: 240, rows: 24,
+    env: { ...process.env, TERM: 'dumb', PS1: 'CANONICAL_READY> ', HISTFILE: '/dev/null', BASH_SILENCE_DEPRECATION_WARNING: '1' },
+  });
+  let output = '';
+  pty.onData((data) => { output += data; });
+  try {
+    const deadline = Date.now() + 3000;
+    while (!output.includes('CANONICAL_READY>')) {
+      if (Date.now() > deadline) throw new Error('Missing canonical shell prompt');
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    const literal = 'x'.repeat(12000);
+    const result = await require('./ptyExec.cjs').execViaPty(pty, `printf '%s' '${literal}'`, {
+      shellKind: 'posix', probeLiveShell: true, timeoutMs: 1500,
+    });
+    assert.equal(result.exitCode, 0, JSON.stringify({ ...result, stdout: result.stdout?.slice(-200) }));
+    assert.equal(result.stdout.trim(), literal);
+  } finally {
+    pty.kill();
+  }
+});
+
 // The second element is a history-listing invocation that still reaches the
 // real history builtin under that customization.
 for (const [customization, listHistory] of [

--- a/electron/bridges/ai/liveShellProbe.test.cjs
+++ b/electron/bridges/ai/liveShellProbe.test.cjs
@@ -163,16 +163,16 @@ test('real PTY: echo-disabled bash completes output without a trailing newline',
   }
 });
 
-for (const customization of [':', 'HISTCONTROL=ignorespace', "alias history='history 10'", 'history() { :; }', "alias eval=':'", 'eval() { :; }', 'PATH=/nonexistent']) {
+for (const customization of [':', 'HISTCONTROL=ignorespace', "alias history='history 10'", 'history() { :; }', "alias eval=':'", 'eval() { :; }', 'PATH=/nonexistent', "alias builtin=':'", 'builtin() { :; }']) {
   for (const executeCommand of [false, true]) {
     test(`bash probe keeps user history clean (${customization}, wrapper=${executeCommand})`, () => {
       const { spawnSync } = require('node:child_process');
       const { buildWrappedCommand } = require('./ptyExecHelpers.cjs');
       const marker = '__NCMCP_HISTORY_PROBE__';
-      const input = `HISTFILE=/dev/null; HISTCONTROL=; PS1=; PS2=\n${customization}\nbuiltin history -c\necho user_one\necho user_two\n`
+      const input = `HISTFILE=/dev/null; HISTCONTROL=; PS1=; PS2=\n${customization}\ncommand builtin history -c\necho user_one\necho user_two\n`
         + buildLiveShellProbe(marker)
         + (executeCommand ? buildWrappedCommand('echo command_ok', 'posix', marker, true) : '')
-        + '\nprintf \"\\n\"\nbuiltin history\nexit\n';
+        + '\nprintf \"\\n\"\ncommand builtin history\nexit\n';
       const result = spawnSync('/bin/bash', ['--noprofile', '--norc', '-i'], {
         input, encoding: 'utf8', env: { ...process.env, TERM: 'dumb' }, timeout: 5000,
       });
@@ -239,14 +239,15 @@ for (const invocationName of ['sh', 'renamed-bash']) {
     const fs = require('node:fs');
     const path = require('node:path');
     const { spawnSync } = require('node:child_process');
-    const directory = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'netcatty-probe-bash-'));
+    const directory = require('../tempDirBridge.cjs').getTempFilePath('probe-bash');
+    fs.mkdirSync(directory, { mode: 0o700 });
     try {
       const shell = path.join(directory, invocationName);
       fs.symlinkSync('/bin/bash', shell);
       const marker = '__NCMCP_RENAMED_BASH__';
       const result = spawnSync(shell, ['--noprofile', '--norc', '-i'], {
         input: 'HISTFILE=/dev/null; HISTCONTROL=; PS1=; PS2=\nbuiltin history -c\necho preserve_user_history\n'
-          + buildLiveShellProbe(marker) + '\nprintf "\\n"\nbuiltin history\nexit\n',
+          + buildLiveShellProbe(marker) + '\nprintf "\\n"\ncommand builtin history\nexit\n',
         encoding: 'utf8', env: { ...process.env, TERM: 'dumb' }, timeout: 5000,
       });
       assert.equal(result.status, 0, result.stderr);

--- a/electron/bridges/ai/liveShellProbe.test.cjs
+++ b/electron/bridges/ai/liveShellProbe.test.cjs
@@ -162,3 +162,74 @@ test('real PTY: echo-disabled bash completes output without a trailing newline',
     pty.kill();
   }
 });
+
+for (const customization of [':', 'HISTCONTROL=ignorespace', "alias history='history 10'", 'history() { :; }']) {
+  for (const executeCommand of [false, true]) {
+    test(`bash probe keeps user history clean (${customization}, wrapper=${executeCommand})`, () => {
+      const { spawnSync } = require('node:child_process');
+      const { buildWrappedCommand } = require('./ptyExecHelpers.cjs');
+      const marker = '__NCMCP_HISTORY_PROBE__';
+      const input = `HISTFILE=/dev/null; HISTCONTROL=; PS1=; PS2=\n${customization}\nbuiltin history -c\necho user_one\necho user_two\n`
+        + buildLiveShellProbe(marker)
+        + (executeCommand ? buildWrappedCommand('echo command_ok', 'posix', marker, true) : '')
+        + '\nprintf \"\\n\"\nbuiltin history\nexit\n';
+      const result = spawnSync('/bin/bash', ['--noprofile', '--norc', '-i'], {
+        input, encoding: 'utf8', env: { ...process.env, TERM: 'dumb' }, timeout: 5000,
+      });
+      assert.equal(result.status, 0, result.stderr);
+      assert.ok(result.stdout.includes(`${marker}_Q`), result.stdout);
+      const entries = result.stdout.split('\n').filter(line => /^\s*\d+\s/.test(line));
+      assert.ok(entries.some(line => line.includes('echo user_one')), entries.join('\n'));
+      assert.ok(entries.some(line => line.includes('echo user_two')), entries.join('\n'));
+      assert.ok(entries.every(line => !line.includes(marker)), entries.join('\n'));
+    });
+  }
+}
+
+test('real PTY: probe and execution leave only user commands for arrow recall', {
+  skip: process.env.NETCATTY_LIVE_FISH_TEST !== '1', timeout: 10000,
+}, async () => {
+  const terminal = require('node-pty').spawn('/bin/bash', ['--noprofile', '--norc'], {
+    name: 'dumb', cols: 240, rows: 24,
+    env: { ...process.env, TERM: 'dumb', HISTFILE: '/dev/null', HISTCONTROL: '',
+      PS1: 'HISTORY_READY> ', BASH_SILENCE_DEPRECATION_WARNING: '1' },
+  });
+  let output = '';
+  terminal.onData(data => { output += data; });
+  const waitFor = async text => {
+    const deadline = Date.now() + 3000;
+    while (!output.includes(text)) {
+      if (Date.now() > deadline) throw new Error(`Missing ${text}: ${output.slice(-1500)}`);
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    const result = output;
+    output = '';
+    return result;
+  };
+  try {
+    await waitFor('HISTORY_READY>');
+    terminal.write('builtin history -c\r');
+    await waitFor('HISTORY_READY>');
+    terminal.write('echo user_history_one\r');
+    await waitFor('HISTORY_READY>');
+    terminal.write('echo user_history_two\r');
+    await waitFor('HISTORY_READY>');
+    const result = await require('./ptyExec.cjs').execViaPty(terminal, 'printf agent_success', {
+      shellKind: 'posix', probeLiveShell: true, timeoutMs: 2000,
+    });
+    assert.equal(result.exitCode, 0, JSON.stringify(result));
+    assert.match(result.stdout, /agent_success/);
+    await waitFor('HISTORY_READY>');
+    terminal.write('\x1b[A\r');
+    const recalled = await waitFor('HISTORY_READY>');
+    assert.match(recalled, /user_history_two/);
+    assert.doesNotMatch(recalled, /__NCMCP_/);
+    terminal.write('builtin history\r');
+    const history = await waitFor('HISTORY_READY>');
+    assert.match(history, /echo user_history_one/);
+    assert.match(history, /echo user_history_two/);
+    assert.doesNotMatch(history, /__NCMCP_/);
+  } finally {
+    terminal.kill();
+  }
+});

--- a/electron/bridges/ai/liveShellProbe.test.cjs
+++ b/electron/bridges/ai/liveShellProbe.test.cjs
@@ -40,7 +40,7 @@ test('probe wrapper keeps the start marker separate when terminal echo is disabl
     if (data === '\x03') return;
     pendingInput += String(data);
     if (!pendingInput.endsWith('\n')) return;
-    const script = pendingInput.replace(/^\x15\x0b/, '');
+    const script = pendingInput.replace(/^\x0b\x15/, '');
     pendingInput = '';
     const result = spawnSync('/bin/sh', ['-c', script], { encoding: 'utf8' });
     queueMicrotask(() => pty.emit('data', `${job.marker}_QPROMPT> ${result.stdout}`));
@@ -166,6 +166,41 @@ test('real PTY: echo-disabled bash completes output without a trailing newline',
     pty.kill();
   }
 });
+
+for (const editing of [true, false]) {
+  test(`real PTY: pending input clearing leaves no control command (editing=${editing})`, {
+    skip: process.env.NETCATTY_LIVE_FISH_TEST !== '1', timeout: 5000,
+  }, async () => {
+    const pty = require('node-pty').spawn('/bin/bash', ['--noprofile', '--norc', ...(editing ? [] : ['--noediting'])], {
+      name: 'dumb', cols: 240, rows: 24,
+      env: { ...process.env, TERM: 'dumb', PS1: 'CLEAR_READY> ', HISTFILE: '/dev/null', BASH_SILENCE_DEPRECATION_WARNING: '1' },
+    });
+    let output = '';
+    pty.onData(data => { output += data; });
+    try {
+      const waitForPrompt = async () => {
+        const deadline = Date.now() + 3000;
+        while (!output.includes('CLEAR_READY>')) {
+          if (Date.now() > deadline) throw new Error(`Missing prompt: ${output}`);
+          await new Promise(resolve => setTimeout(resolve, 10));
+        }
+      };
+      await waitForPrompt();
+      output = '';
+      // Leave text on both sides of the readline cursor. Without editing, all
+      // bytes remain pending canonical input and must still be discarded.
+      pty.write('left-right\x1b[5D');
+      await new Promise(resolve => setTimeout(resolve, 50));
+      const { buildPendingInputClearPrefix } = require('./ptyExecHelpers.cjs');
+      pty.write(buildPendingInputClearPrefix('posix') + "printf 'CLEAR_SUCCESS\\n'\n");
+      await waitForPrompt();
+      assert.match(output, /CLEAR_SUCCESS\r\n/);
+      assert.doesNotMatch(output, /command not found|syntax error/);
+    } finally {
+      pty.kill();
+    }
+  });
+}
 
 test('real PTY: canonical bash executes a long literal command without truncation', {
   skip: process.env.NETCATTY_LIVE_FISH_TEST !== '1', timeout: 15000,

--- a/electron/bridges/ai/liveShellProbe.test.cjs
+++ b/electron/bridges/ai/liveShellProbe.test.cjs
@@ -341,6 +341,7 @@ for (const stop of ['cancel', 'timeout']) {
     pty.write = data => writes.push(data);
     const job = startPtyJob(pty, 'echo must_not_run', {
       shellKind: 'posix', probeLiveShell: true, timeoutMs: stop === 'timeout' ? 70 : 1000,
+      enforceWallTimeout: stop === 'timeout',
     });
     await new Promise(resolve => setTimeout(resolve, 45));
     assert.ok(writes.length >= 2, 'probe must have started a later chunk');

--- a/electron/bridges/ai/liveShellProbe.test.cjs
+++ b/electron/bridges/ai/liveShellProbe.test.cjs
@@ -259,3 +259,23 @@ for (const invocationName of ['sh', 'renamed-bash']) {
     }
   });
 }
+
+for (const [shell, args] of [
+  ['/bin/dash', ['-i']],
+  ['/bin/zsh', ['-f', '-i']],
+  ['/bin/bash', ['--noprofile', '--norc', '-i']],
+]) {
+  test(`probe preserves an interactive errexit session in ${shell}`, (t) => {
+    const { spawnSync } = require('node:child_process');
+    const marker = '__NCMCP_ERREXIT_PROBE__';
+    const result = spawnSync(shell, args, {
+      input: 'set -e\n' + buildLiveShellProbe(marker) + '\necho shell_survived\nexit\n',
+      encoding: 'utf8', env: { ...process.env, TERM: 'dumb', HISTFILE: '/dev/null' }, timeout: 5000,
+    });
+    if (result.error?.code === 'ENOENT') return t.skip(`${shell} is unavailable`);
+    assert.ifError(result.error);
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(result.stdout.includes(`${marker}_Q`), result.stdout);
+    assert.ok(result.stdout.includes('shell_survived'), result.stdout);
+  });
+}

--- a/electron/bridges/ai/liveShellProbe.test.cjs
+++ b/electron/bridges/ai/liveShellProbe.test.cjs
@@ -34,10 +34,14 @@ test('probe wrapper keeps the start marker separate when terminal echo is disabl
   const { spawnSync } = require('node:child_process');
   const pty = new EventEmitter();
   let job;
+  let pendingInput = '';
   pty.write = (data) => {
     if (String(data).includes('command sh -c')) return;
     if (data === '\x03') return;
-    const script = String(data).replace(/^\x15\x0b/, '');
+    pendingInput += String(data);
+    if (!pendingInput.endsWith('\n')) return;
+    const script = pendingInput.replace(/^\x15\x0b/, '');
+    pendingInput = '';
     const result = spawnSync('/bin/sh', ['-c', script], { encoding: 'utf8' });
     queueMicrotask(() => pty.emit('data', `${job.marker}_QPROMPT> ${result.stdout}`));
   };
@@ -305,5 +309,49 @@ for (const shell of ['/bin/dash', '/bin/zsh']) {
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /portable-history-ok/);
     assert.ok(result.stdout.includes(`${marker}_E:0`));
+  });
+}
+
+for (const historyControl of ['', 'ignorespace']) {
+  test(`successful cleanup does not invoke a shadowed builtin (${historyControl || 'default'})`, () => {
+    const { spawnSync } = require('node:child_process');
+    const { buildWrappedCommand } = require('./ptyExecHelpers.cjs');
+    const marker = '__NCMCP_FALLBACK_GUARD__';
+    const input = `HISTFILE=/dev/null; HISTCONTROL=${historyControl}; PS1=; PS2=\nbuiltin() { printf UNEXPECTED_FALLBACK; }\ncommand history -c\necho user_one\n`
+      + buildLiveShellProbe(marker)
+      + buildWrappedCommand('echo command_ok', 'posix', marker, true)
+      + '\ncommand history\nexit\n';
+    const result = spawnSync('/bin/bash', ['--noprofile', '--norc', '-i'], {
+      input, encoding: 'utf8', env: { ...process.env, TERM: 'dumb' }, timeout: 5000,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(result.stdout.includes(`${marker}_Q`), result.stdout);
+    assert.match(result.stdout, /command_ok/);
+    assert.doesNotMatch(result.stdout, /UNEXPECTED_FALLBACK/);
+    const entries = result.stdout.split('\n').filter(line => /^\s*\d+\s/.test(line));
+    assert.ok(entries.some(line => line.includes('echo user_one')), entries.join('\n'));
+    assert.ok(entries.every(line => !line.includes(marker)), entries.join('\n'));
+  });
+}
+
+for (const stop of ['cancel', 'timeout']) {
+  test(`paced probe stops writing after ${stop}`, async () => {
+    const pty = new EventEmitter();
+    const writes = [];
+    pty.write = data => writes.push(data);
+    const job = startPtyJob(pty, 'echo must_not_run', {
+      shellKind: 'posix', probeLiveShell: true, timeoutMs: stop === 'timeout' ? 70 : 1000,
+    });
+    await new Promise(resolve => setTimeout(resolve, 45));
+    assert.ok(writes.length >= 2, 'probe must have started a later chunk');
+    if (stop === 'cancel') {
+      job.cancel();
+      pty.emit('close');
+    }
+    await job.resultPromise;
+    const count = writes.length;
+    await new Promise(resolve => setTimeout(resolve, 100));
+    assert.equal(writes.length, count);
+    assert.ok(writes.every(data => !data.includes('must_not_run')));
   });
 }

--- a/electron/bridges/ai/liveShellProbe.test.cjs
+++ b/electron/bridges/ai/liveShellProbe.test.cjs
@@ -163,7 +163,7 @@ test('real PTY: echo-disabled bash completes output without a trailing newline',
   }
 });
 
-for (const customization of [':', 'HISTCONTROL=ignorespace', "alias history='history 10'", 'history() { :; }', "alias eval=':'", 'eval() { :; }']) {
+for (const customization of [':', 'HISTCONTROL=ignorespace', "alias history='history 10'", 'history() { :; }', "alias eval=':'", 'eval() { :; }', 'PATH=/nonexistent']) {
   for (const executeCommand of [false, true]) {
     test(`bash probe keeps user history clean (${customization}, wrapper=${executeCommand})`, () => {
       const { spawnSync } = require('node:child_process');
@@ -233,3 +233,29 @@ test('real PTY: probe and execution leave only user commands for arrow recall', 
     terminal.kill();
   }
 });
+
+for (const invocationName of ['sh', 'renamed-bash']) {
+  test(`Bash invoked as ${invocationName} cleans probe history`, () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const { spawnSync } = require('node:child_process');
+    const directory = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'netcatty-probe-bash-'));
+    try {
+      const shell = path.join(directory, invocationName);
+      fs.symlinkSync('/bin/bash', shell);
+      const marker = '__NCMCP_RENAMED_BASH__';
+      const result = spawnSync(shell, ['--noprofile', '--norc', '-i'], {
+        input: 'HISTFILE=/dev/null; HISTCONTROL=; PS1=; PS2=\nbuiltin history -c\necho preserve_user_history\n'
+          + buildLiveShellProbe(marker) + '\nprintf "\\n"\nbuiltin history\nexit\n',
+        encoding: 'utf8', env: { ...process.env, TERM: 'dumb' }, timeout: 5000,
+      });
+      assert.equal(result.status, 0, result.stderr);
+      assert.ok(result.stdout.includes(`${marker}_Q`), result.stdout);
+      const entries = result.stdout.split('\n').filter(line => /^\s*\d+\s/.test(line));
+      assert.ok(entries.some(line => line.includes('echo preserve_user_history')), result.stdout);
+      assert.ok(entries.every(line => !line.includes(marker)), result.stdout);
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+}

--- a/electron/bridges/ai/liveShellProbe.test.cjs
+++ b/electron/bridges/ai/liveShellProbe.test.cjs
@@ -163,7 +163,7 @@ test('real PTY: echo-disabled bash completes output without a trailing newline',
   }
 });
 
-for (const customization of [':', 'HISTCONTROL=ignorespace', "alias history='history 10'", 'history() { :; }']) {
+for (const customization of [':', 'HISTCONTROL=ignorespace', "alias history='history 10'", 'history() { :; }', "alias eval=':'", 'eval() { :; }']) {
   for (const executeCommand of [false, true]) {
     test(`bash probe keeps user history clean (${customization}, wrapper=${executeCommand})`, () => {
       const { spawnSync } = require('node:child_process');

--- a/electron/bridges/ai/liveShellProbe.test.cjs
+++ b/electron/bridges/ai/liveShellProbe.test.cjs
@@ -163,16 +163,30 @@ test('real PTY: echo-disabled bash completes output without a trailing newline',
   }
 });
 
-for (const customization of [':', 'HISTCONTROL=ignorespace', "alias history='history 10'", 'history() { :; }', "alias eval=':'", 'eval() { :; }', 'PATH=/nonexistent', "alias builtin=':'", 'builtin() { :; }']) {
+// The second element is a history-listing invocation that still reaches the
+// real history builtin under that customization.
+for (const [customization, listHistory] of [
+  [':', 'command builtin history'],
+  ['HISTCONTROL=ignorespace', 'command builtin history'],
+  ["alias history='history 10'", 'command builtin history'],
+  ['history() { :; }', 'command builtin history'],
+  ["alias eval=':'", 'command builtin history'],
+  ['eval() { :; }', 'command builtin history'],
+  ['PATH=/nonexistent', 'command builtin history'],
+  ["alias builtin=':'", 'command builtin history'],
+  ['builtin() { :; }', 'command builtin history'],
+  ["alias command=':'", '\\builtin history'],
+  ['command() { :; }', '\\builtin history'],
+]) {
   for (const executeCommand of [false, true]) {
     test(`bash probe keeps user history clean (${customization}, wrapper=${executeCommand})`, () => {
       const { spawnSync } = require('node:child_process');
       const { buildWrappedCommand } = require('./ptyExecHelpers.cjs');
       const marker = '__NCMCP_HISTORY_PROBE__';
-      const input = `HISTFILE=/dev/null; HISTCONTROL=; PS1=; PS2=\n${customization}\ncommand builtin history -c\necho user_one\necho user_two\n`
+      const input = `HISTFILE=/dev/null; HISTCONTROL=; PS1=; PS2=\n${customization}\n${listHistory} -c\necho user_one\necho user_two\n`
         + buildLiveShellProbe(marker)
         + (executeCommand ? buildWrappedCommand('echo command_ok', 'posix', marker, true) : '')
-        + '\nprintf \"\\n\"\ncommand builtin history\nexit\n';
+        + '\nprintf \"\\n\"\n' + listHistory + '\nexit\n';
       const result = spawnSync('/bin/bash', ['--noprofile', '--norc', '-i'], {
         input, encoding: 'utf8', env: { ...process.env, TERM: 'dumb' }, timeout: 5000,
       });

--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -729,13 +729,48 @@ function startPtyJob(ptyStream, command, options) {
     }
   }
 
+  let inputWriteTimer = null;
+  let inputWriteGeneration = 0;
+  function stopInputWrite() {
+    inputWriteGeneration += 1;
+    clearTimeout(inputWriteTimer);
+    inputWriteTimer = null;
+  }
+  cleanupFns.push(stopInputWrite);
+
+  function writeInput(text) {
+    stopInputWrite();
+    const generation = inputWriteGeneration;
+    let offset = 0;
+    // Readline may overrun its input queue when long probes arrive in one
+    // write. Yield between bounded chunks; cancelled/replaced jobs must never
+    // finish typing an old command into a subsequent prompt.
+    const chunkSize = usesLiveShellProbe && text.length > 1024 ? 128 : text.length;
+    const writeNext = () => {
+      if (finished || cancelRequested || generation !== inputWriteGeneration) return;
+      let end = Math.min(offset + chunkSize, text.length);
+      // Do not split a UTF-16 surrogate pair across independently encoded writes.
+      if (end < text.length && /[\uD800-\uDBFF]/.test(text[end - 1])) end -= 1;
+      ptyStream.write(text.slice(offset, end));
+      offset = end;
+      if (offset < text.length && generation === inputWriteGeneration && !finished && !cancelRequested) {
+        inputWriteTimer = setTimeout(() => {
+          try { writeNext(); } catch (error) {
+            finish(preStartOutput, -1, `Terminal input failed: ${error.message}`);
+          }
+        }, 30);
+      }
+    };
+    writeNext();
+  }
+
   function writeWrappedCommand() {
     const wrapped = buildWrappedCommand(command, resolvedShellKind, marker, probeLiveShell);
-    ptyStream.write(`${buildPendingInputClearPrefix(resolvedShellKind)}${wrapped}`);
+    writeInput(`${buildPendingInputClearPrefix(resolvedShellKind)}${wrapped}`);
   }
 
   if (probingShell) {
-    ptyStream.write(`${buildPendingInputClearPrefix(resolvedShellKind)}${buildLiveShellProbe(marker)}`);
+    writeInput(`${buildPendingInputClearPrefix(resolvedShellKind)}${buildLiveShellProbe(marker)}`);
   } else {
     writeWrappedCommand();
   }

--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -94,6 +94,7 @@ function startPtyJob(ptyStream, command, options) {
 
   const usesLiveShellProbe = probeLiveShell && ["posix", "fish"].includes(resolvedShellKind);
   let probingShell = usesLiveShellProbe;
+  let deliveringInput = false;
   let probeOutput = "";
 
   let output = "";
@@ -529,7 +530,7 @@ function startPtyJob(ptyStream, command, options) {
         : Buffer.from(String(data ?? ""));
     const text = outputDecoder.write(bytes);
     if (!text) return;
-    if (!pendingEnd) armOutputTimeout();
+    if (!pendingEnd && !deliveringInput) armOutputTimeout();
 
     if (probingShell) {
       probeOutput = (probeOutput + text).slice(-16384);
@@ -742,6 +743,11 @@ function startPtyJob(ptyStream, command, options) {
 
   function writeInput(text) {
     stopInputWrite();
+    // Each delivery gets a fresh wait budget, including the transition from
+    // probe to wrapper. Echo may be disabled while we are still typing.
+    clearStartupTimeout();
+    clearTimeout(timeoutId);
+    deliveringInput = true;
     const generation = inputWriteGeneration;
     let offset = 0;
     // Readline may overrun its input queue when long probes arrive in one
@@ -765,7 +771,9 @@ function startPtyJob(ptyStream, command, options) {
         // Input delivery is complete: only now does the startup deadline
         // begin, so paced typing time never consumes the startup budget.
         if (!finished && !cancelRequested && generation === inputWriteGeneration) {
-          armStartupTimeout();
+          deliveringInput = false;
+          armOutputTimeout();
+          if (!foundStart) armStartupTimeout();
         }
       }
     };

--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -200,6 +200,9 @@ function startPtyJob(ptyStream, command, options) {
   // Foreground execs use the configured timeoutMs as the deadline (matching
   // the pre-PR behavior); background jobs use a fixed 30s since their main
   // timeout is much longer (1 hour) and meant for the actual command.
+  // The timer is armed once input delivery completes (see writeInput) so the
+  // paced-typing time for oversized probes/wrappers is excluded from the
+  // startup budget instead of counting against it.
   const BG_STARTUP_TIMEOUT_MS = 30000;
   function armStartupTimeout() {
     const startupMs = maxBufferedChars > 0 ? BG_STARTUP_TIMEOUT_MS : timeoutMs;
@@ -652,7 +655,6 @@ function startPtyJob(ptyStream, command, options) {
 
   armOutputTimeout();
   armWallTimeout();
-  armStartupTimeout();
 
   unsubscribe = subscribeToPtyData(ptyStream, onData);
 
@@ -759,6 +761,12 @@ function startPtyJob(ptyStream, command, options) {
             finish(preStartOutput, -1, `Terminal input failed: ${error.message}`);
           }
         }, 30);
+      } else {
+        // Input delivery is complete: only now does the startup deadline
+        // begin, so paced typing time never consumes the startup budget.
+        if (!finished && !cancelRequested && generation === inputWriteGeneration) {
+          armStartupTimeout();
+        }
       }
     };
     writeNext();

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -1295,7 +1295,7 @@ test("execViaChannel cancellation never exposes an incomplete UTF-8 character", 
   assert.equal(result.error, "Cancelled");
 });
 
-for (const customization of [":", "HISTCONTROL=ignorespace", "alias history='history 10'", 'history() { builtin history "$@" | cat; }', "history() { :; }", "alias command=':'", "command() { :; }"]) {
+for (const customization of [":", "HISTCONTROL=ignorespace", "alias history='history 10'", 'history() { builtin history "$@" | cat; }', "history() { :; }", "alias command=':'", "command() { :; }", "readonly __nc_h=USER", "readonly __nc_d=USER"]) {
   test(`posix wrapper bypasses history customization: ${customization}`, () => {
     const marker = "__NCMCP_CUSTOM_HISTORY__";
     const wrapped = buildWrappedCommand("echo HISTORY_PROBE", "posix", marker);

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -1295,7 +1295,7 @@ test("execViaChannel cancellation never exposes an incomplete UTF-8 character", 
   assert.equal(result.error, "Cancelled");
 });
 
-for (const customization of [":", "HISTCONTROL=ignorespace", "alias history='history 10'", "history() { :; }", "alias command=':'", "command() { :; }"]) {
+for (const customization of [":", "HISTCONTROL=ignorespace", "alias history='history 10'", 'history() { builtin history "$@" | cat; }', "history() { :; }", "alias command=':'", "command() { :; }"]) {
   test(`posix wrapper bypasses history customization: ${customization}`, () => {
     const marker = "__NCMCP_CUSTOM_HISTORY__";
     const wrapped = buildWrappedCommand("echo HISTORY_PROBE", "posix", marker);

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -26,7 +26,7 @@ const {
 class ShellBackedPty extends EventEmitter {
   write(data) {
     if (data === "\x03") return;
-    const script = String(data).replace(/^\x15\x0b/, "");
+    const script = String(data).replace(/^\x0b\x15/, "");
     const result = spawnSync("sh", ["-c", script], { encoding: "utf8" });
     queueMicrotask(() => {
       this.emit("data", Buffer.from(result.stdout));
@@ -365,8 +365,8 @@ test("loginShellHint selects fish/posix/powershell/cmd without pinning confirmed
 });
 
 test("pending-input clear prefix covers interactive shells and skips raw devices", () => {
-  assert.equal(buildPendingInputClearPrefix("posix"), "\x15\x0b");
-  assert.equal(buildPendingInputClearPrefix("fish"), "\x15\x0b");
+  assert.equal(buildPendingInputClearPrefix("posix"), "\x0b\x15");
+  assert.equal(buildPendingInputClearPrefix("fish"), "\x0b\x15");
   assert.equal(buildPendingInputClearPrefix("powershell"), "\x1bggd2147483647d\x1br\x1b\x1bi\x08");
   assert.equal(buildPendingInputClearPrefix("cmd"), "\x1b");
   assert.equal(buildPendingInputClearPrefix("raw"), "");
@@ -849,7 +849,7 @@ test("startPtyJob keeps the clear prefix for non-PowerShell sessions", async () 
     expectedPrompt: "$ ",
   });
   assert.equal(writes.length, 1);
-  assert.ok(writes[0].startsWith("\x15\x0b"));
+  assert.ok(writes[0].startsWith("\x0b\x15"));
   assert.match(writes[0], /__NCMCP_/);
   job.cancel();
   pty.emit("data", Buffer.from("$ "));

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -1295,7 +1295,7 @@ test("execViaChannel cancellation never exposes an incomplete UTF-8 character", 
   assert.equal(result.error, "Cancelled");
 });
 
-for (const customization of [":", "HISTCONTROL=ignorespace", "alias history='history 10'", "history() { :; }"]) {
+for (const customization of [":", "HISTCONTROL=ignorespace", "alias history='history 10'", "history() { :; }", "alias command=':'", "command() { :; }"]) {
   test(`posix wrapper bypasses history customization: ${customization}`, () => {
     const marker = "__NCMCP_CUSTOM_HISTORY__";
     const wrapped = buildWrappedCommand("echo HISTORY_PROBE", "posix", marker);

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -921,6 +921,17 @@ test("posix wrapper types multi-line commands as one physical line (no PS2 leak)
   assert.match(result.stdout, new RegExp(`${marker}_E:0`));
 });
 
+test("long POSIX assignments preserve quotes, Unicode, and heredoc newlines on bounded input lines", () => {
+  const marker = "__NCMCP_LONG_LITERAL_TEST__";
+  const literal = "quote' \\ $HOME `false` " + "\u4e2d\u6587\ud83d\ude42".repeat(600);
+  const command = `cat <<'SMOKE_END'\n${literal}\n\nsecond line\nSMOKE_END\nprintf tail`;
+  const wrapped = buildWrappedCommand(command, "posix", marker, true);
+  assert.ok(wrapped.split('\n').every(line => Buffer.byteLength(line, 'utf8') < 1000));
+  const result = spawnSync('sh', ['-c', wrapped], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, `\n${marker}_S\n${literal}\n\nsecond line\ntail${marker}_E:0\n`);
+});
+
 test("posix wrapper isolates explicit exit from the active shell and reports its code", () => {
   const marker = "__NCMCP_TEST__";
   const wrapped = buildWrappedCommand("exit 7", "posix", marker);

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -219,8 +219,14 @@ function buildBashHistoryCleanup(marker) {
   // expansion before the Bash-only guard can run.
   // Keep the shared cleanup short enough for canonical PTY input buffers.
   // Expansion of the dispatcher avoids alias expansion of command names.
-  const entry = "__nc_h";
-  const dispatcher = "__nc_d";
+  // Temp names derive from the marker: a fixed name like __nc_h can collide
+  // with user state, and a readonly (or integer/nameref-attributed) user
+  // variable makes the assignment fail, leaving the marker-bearing history
+  // entry undeleted. Markers are unique per invocation, so the derived names
+  // cannot clash with anything the user already defined.
+  const suffix = String(marker || "").toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 24) || "dflt";
+  const entry = `__nc_h_${suffix}`;
+  const dispatcher = `__nc_d_${suffix}`;
   return `[ "\${BASH_VERSION-}" ]&&{ for ${dispatcher} in command builtin;do ${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) ${entry}=\${${entry}#"\${${entry}%%[^[:space:]]*}"};$${dispatcher} history -d "\${${entry}%%[[:space:]]*}";;esac;done; } 2>/dev/null`;
 }
 

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -208,11 +208,22 @@ function buildBashHistoryCleanup(marker) {
   // Match the latest entry before deleting it, preserving user history when
   // HISTCONTROL=ignorespace skips the wrapper. Read the entry's actual number:
   // older Bash versions can expose HISTCMD as the next history number.
-  // command history bypasses user aliases and functions. The unset-safe guard
-  // leaves non-Bash shells alone, including shells with nounset enabled.
+  // Any single dispatcher name can be shadowed by a user alias or function
+  // (command, builtin, history), so fall back through \history, \command
+  // history and \builtin history, deleting with whichever dispatcher actually
+  // read the marker-bearing entry. The leading backslash stops alias
+  // expansion; the fallback chain stops functions of the same names. The
+  // unset-safe guard leaves non-Bash shells alone, including shells with
+  // nounset enabled.
   // Use ^ for the Bash bracket negation: ! triggers interactive zsh history
   // expansion before the Bash-only guard can run.
-  return `[ -n "\${BASH_VERSION-}" ] && { ${marker}_h=$(command history 1 2>/dev/null); case "$${marker}_h" in *${marker}*) ${marker}_h=\${${marker}_h#"\${${marker}_h%%[^[:space:]]*}"}; command history -d "\${${marker}_h%%[[:space:]]*}" 2>/dev/null ;; esac; }`;
+  const entry = `${marker}_h`;
+  const attempt = (read) => (
+    `${entry}=$(${read} 1 2>/dev/null); case "$${entry}" in *${marker}*) `
+    + `${entry}=\${${entry}#"\${${entry}%%[^[:space:]]*}"}; `
+    + `${read} -d "\${${entry}%%[[:space:]]*}" 2>/dev/null ;;`
+  );
+  return `[ -n "\${BASH_VERSION-}" ] && { ${attempt("\\history")}*) ${attempt("\\command history")}*) ${attempt("\\builtin history")} esac ;; esac ;; esac; }`;
 }
 
 function buildPosixWrapperBody(command, marker, startFormat) {

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -198,7 +198,24 @@ function buildPendingInputClearPrefix(shellKind) {
   }
 }
 
-function buildBashHistoryCleanup(marker) {
+// Suffix shared by the cleanup's scratch variable names so liveShellProbe can
+// reference the verified-deletion flag the cleanup leaves behind.
+function bashHistoryCleanupSuffix(marker) {
+  return String(marker || "").toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 24) || "dflt";
+}
+
+function bashHistoryCleanupStatusVar(marker) {
+  return `__nc_o_${bashHistoryCleanupSuffix(marker)}`;
+}
+
+// keepStatus keeps the verified-deletion flag set on return: buildLiveShellProbe
+// runs the cleanup through two outer dispatchers (\command eval and \builtin
+// eval) because a shadowing function can swallow either, and it must skip the
+// \builtin eval fallback once the \command eval path already verified deletion.
+// Assignments made by eval'd code persist in the interactive shell, so the
+// flag acts as the cross-invocation success signal. The flag only holds "1"
+// (never secret-bearing), so leaving it set is safe.
+function buildBashHistoryCleanup(marker, keepStatus = false) {
   // Issue #3265: without HISTCONTROL=ignorespace the wrapper line is recorded
   // in bash history. Pressing arrow-up then makes readline redraw that huge
   // marker-containing line, and the preload __NCMCP_ filter suppresses the
@@ -228,19 +245,42 @@ function buildBashHistoryCleanup(marker) {
   // with user state, and a readonly (or integer/nameref-attributed) user
   // variable makes the assignment fail, leaving the marker-bearing history
   // entry undeleted. Markers are unique per invocation, so the derived names
-  // cannot clash with anything the user already defined. Both scratch
+  // cannot clash with anything the user already defined. The scratch
   // variables are unset afterwards: the verification read still assigns the
   // next history entry to __nc_h_*, which could otherwise keep a recent
   // (possibly secret-bearing) command recoverable even after history -c.
-  // Unset through the same dispatcher loop as history: a user alias or
+  // Unset through the same dispatchers as history: a user alias or
   // function named unset would otherwise shadow the plain call and leave
   // the verification-read history entry (possibly secret-bearing) in the
   // scratch variable. Unsetting the loop variable mid-loop is safe: bash
   // reassigns it from the already-expanded word list on each iteration.
-  const suffix = String(marker || "").toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 24) || "dflt";
+  // Verified deletion sets __nc_o_*; the unset stage then only walks both
+  // dispatchers when deletion is still unverified, so a slow shadowed
+  // fallback (e.g. builtin() { sleep 60; }) is not invoked again after a
+  // real dispatcher already finished the job — unsetting goes through the
+  // dispatcher that verified the deletion instead. When unverified, both
+  // dispatchers still get their turn for every scratch variable.
+  // The initial read also verifies absence: a non-empty latest entry without
+  // the marker proves the dispatcher reached real history (a no-op shadow
+  // returns empty output), so there is nothing to delete and the fallback
+  // dispatcher is not invoked either. Only an empty read (no-op shadow or
+  // empty history) leaves it ambiguous and gives the next dispatcher its
+  // turn.
+  const suffix = bashHistoryCleanupSuffix(marker);
   const entry = `__nc_h_${suffix}`;
   const dispatcher = `__nc_d_${suffix}`;
-  return `[ "\${BASH_VERSION-}" ]&&{ for ${dispatcher} in command builtin;do ${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) ${entry}=\${${entry}#"\${${entry}%%[^[:space:]]*}"};$${dispatcher} history -d "\${${entry}%%[[:space:]]*}";${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) :;;*) break;;esac;;esac;done;for ${dispatcher} in command builtin;do $${dispatcher} unset ${entry} ${dispatcher};done; } 2>/dev/null`;
+  const status = bashHistoryCleanupStatusVar(marker);
+  const loop =
+    `for ${dispatcher} in command builtin;do ${entry}=$($${dispatcher} history 1);case "$${entry}" in ` +
+    `*${marker}*) ${entry}=\${${entry}#"\${${entry}%%[^[:space:]]*}"};$${dispatcher} history -d "\${${entry}%%[[:space:]]*}";` +
+    `${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) :;;*) ${status}=1;break;;esac;;` +
+    `"") :;; *) ${status}=1;break;;esac;done`;
+  const scratch = keepStatus ? entry : `${entry} ${status}`;
+  return (
+    `[ "\${BASH_VERSION-}" ]&&{ ${status}=;${loop};` +
+    `if [ -n "$${status}" ];then $${dispatcher} unset ${scratch} ${dispatcher};` +
+    `else for ${dispatcher} in command builtin;do $${dispatcher} unset ${scratch} ${dispatcher};done;fi; } 2>/dev/null`
+  );
 }
 
 function buildPosixWrapperBody(command, marker, startFormat) {
@@ -502,6 +542,7 @@ module.exports = {
   buildPendingInputClearPrefix,
   buildWrappedCommand,
   buildBashHistoryCleanup,
+  bashHistoryCleanupStatusVar,
   findEndMarker,
   normalizePtyOutput,
   appendBoundedOutput,

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -198,89 +198,21 @@ function buildPendingInputClearPrefix(shellKind) {
   }
 }
 
-// Suffix shared by the cleanup's scratch variable names so liveShellProbe can
-// reference the verified-deletion flag the cleanup leaves behind.
-function bashHistoryCleanupSuffix(marker) {
-  return String(marker || "").toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 24) || "dflt";
+function bashHistoryScratchNames(marker) {
+  const suffix = String(marker || "").toLowerCase().replace(/[^a-z0-9]/g, "").slice(-12) || "dflt";
+  return { entry: `__nc_h_${suffix}`, dispatcher: `__nc_d_${suffix}` };
 }
 
-function bashHistoryCleanupStatusVar(marker) {
-  return `__nc_o_${bashHistoryCleanupSuffix(marker)}`;
-}
-
-// keepStatus keeps the verified-deletion flag set on return: buildLiveShellProbe
-// runs the cleanup through two outer dispatchers (\command eval and \builtin
-// eval) because a shadowing function can swallow either, and it must skip the
-// \builtin eval fallback once the \command eval path already verified deletion.
-// Assignments made by eval'd code persist in the interactive shell, so the
-// flag acts as the cross-invocation success signal. The flag only holds "1"
-// (never secret-bearing), so leaving it set is safe.
-function buildBashHistoryCleanup(marker, keepStatus = false) {
-  // Issue #3265: without HISTCONTROL=ignorespace the wrapper line is recorded
-  // in bash history. Pressing arrow-up then makes readline redraw that huge
-  // marker-containing line, and the preload __NCMCP_ filter suppresses the
-  // redraw fragments that contain the marker — readline's row accounting
-  // diverges from what the terminal actually rendered, so every subsequent
-  // history-navigation redraw leaves fragments of the AI command on screen.
-  // Match the latest entry before deleting it, preserving user history when
-  // HISTCONTROL=ignorespace skips the wrapper. Read the entry's actual number:
-  // older Bash versions can expose HISTCMD as the next history number.
-  // Any single dispatcher name can be shadowed by a user alias or function
-  // (command, builtin, history), so try command history and builtin history.
-  // Each attempt re-reads the latest entry:
-  // a history function can display it but delete only in a subshell. The
-  // fallback chain handles a function shadowing a single dispatcher. The
-  // loop stops as soon as a follow-up read after `history -d` confirms the
-  // marker is gone, so a slow shadowed fallback (e.g. builtin() { sleep 60; })
-  // is not invoked after the real dispatcher already deleted the entry. When
-  // deletion is unconfirmed (a shadowed dispatcher displayed the entry but
-  // deleted nothing), the next dispatcher still gets its turn. The
-  // unset-safe guard leaves non-Bash shells alone, including shells with
-  // nounset enabled.
-  // Use ^ for the Bash bracket negation: ! triggers interactive zsh history
-  // expansion before the Bash-only guard can run.
-  // Keep the shared cleanup short enough for canonical PTY input buffers.
-  // Expansion of the dispatcher avoids alias expansion of command names.
-  // Temp names derive from the marker: a fixed name like __nc_h can collide
-  // with user state, and a readonly (or integer/nameref-attributed) user
-  // variable makes the assignment fail, leaving the marker-bearing history
-  // entry undeleted. Markers are unique per invocation, so the derived names
-  // cannot clash with anything the user already defined. The scratch
-  // variables are unset afterwards: the verification read still assigns the
-  // next history entry to __nc_h_*, which could otherwise keep a recent
-  // (possibly secret-bearing) command recoverable even after history -c.
-  // Unset through the same dispatchers as history: a user alias or
-  // function named unset would otherwise shadow the plain call and leave
-  // the verification-read history entry (possibly secret-bearing) in the
-  // scratch variable. Unsetting the loop variable mid-loop is safe: bash
-  // reassigns it from the already-expanded word list on each iteration.
-  // Verified deletion sets __nc_o_*; the unset stage then only walks both
-  // dispatchers when deletion is still unverified, so a slow shadowed
-  // fallback (e.g. builtin() { sleep 60; }) is not invoked again after a
-  // real dispatcher already finished the job — unsetting goes through the
-  // dispatcher that verified the deletion instead. When unverified, both
-  // dispatchers still get their turn for every scratch variable.
-  // The initial read also verifies absence: a non-empty latest entry without
-  // the marker proves the dispatcher reached real history (a no-op shadow
-  // returns empty output), so there is nothing to delete and the fallback
-  // dispatcher is not invoked either. Only an empty read (no-op shadow or
-  // empty history) leaves it ambiguous and gives the next dispatcher its
-  // turn.
-  const suffix = bashHistoryCleanupSuffix(marker);
-  const entry = `__nc_h_${suffix}`;
-  const dispatcher = `__nc_d_${suffix}`;
-  const status = bashHistoryCleanupStatusVar(marker);
-  const loop =
-    `for ${dispatcher} in command builtin;do ${entry}=$($${dispatcher} history 1);case "$${entry}" in ` +
-    `*${marker}*) ${entry}=\${${entry}#"\${${entry}%%[^[:space:]]*}"};$${dispatcher} history -d "\${${entry}%%[[:space:]]*}";` +
-    `${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) :;;*) ${status}=1;break;;esac;;` +
-    `"") :;; *) ${status}=1;break;;esac;done`;
-  const scratch = keepStatus ? entry : `${entry} ${status}`;
-  return (
-    `[ "\${BASH_VERSION-}" ]&&{ ${status}=;${loop};` +
-    `if [ -n "$${status}" ];then $${dispatcher} unset ${scratch} ${dispatcher};` +
-    `else for ${dispatcher} in command builtin;do $${dispatcher} unset ${scratch} ${dispatcher};done;fi; } 2>/dev/null`
-  );
+function buildBashHistoryCleanup(marker, keepDispatcher = false) {
+  // Expanded dispatcher names bypass aliases. Verify that a dispatcher really
+  // executes builtins before trusting an empty history read from a no-op function.
+  // After deletion, verify the entry is gone: a shadowed history function may
+  // delete only in a subshell. Stop as soon as the real dispatcher succeeds.
+  // Invocation-specific scratch names avoid readonly user variables. Clear the
+  // history-bearing scratch through the verified dispatcher, never plain unset.
+  const { entry, dispatcher } = bashHistoryScratchNames(marker);
+  const unsetNames = keepDispatcher ? entry : `${entry} ${dispatcher}`;
+  return `[ "\${BASH_VERSION-}" ]&&{ for ${dispatcher} in command builtin;do ${entry}=$($${dispatcher} printf x);[ "$${entry}" = x ]||continue;${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) ${entry}=\${${entry}#"\${${entry}%%[^[:space:]]*}"};$${dispatcher} history -d "\${${entry}%%[[:space:]]*}";${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) continue;;esac;;esac;$${dispatcher} unset ${unsetNames};break;done; } 2>/dev/null`;
 }
 
 function buildPosixWrapperBody(command, marker, startFormat) {
@@ -290,9 +222,11 @@ function buildPosixWrapperBody(command, marker, startFormat) {
     ? `${marker}_cmd=$(printf '%s\\n' ${commandLines.map((line) => `'${escapePosixSingleQuoted(line)}'`).join(" ")})`
     : `${marker}_cmd='${escapePosixSingleQuoted(command)}'`;
   const historyCleanup = buildBashHistoryCleanup(marker);
-  return (
-    `${marker}=0; ${cmdAssign}; { printf '${startFormat}' '${marker}_S'; trap ':' INT; ( ${noPager}eval "$${marker}_cmd" ); __NCMCP_rc=$?; trap - INT; printf '%s\\n' '${marker}_E:'\"$__NCMCP_rc\"; ${historyCleanup}; (exit $__NCMCP_rc); }`
-  );
+  const prefix = `${marker}=0; ${cmdAssign}; { printf '${startFormat}' '${marker}_S'; trap ':' INT; ( ${noPager}eval "$${marker}_cmd" ); __NCMCP_rc=$?; trap - INT; printf '%s\\n' '${marker}_E:'\"$__NCMCP_rc\"`;
+  const suffix = `${historyCleanup}; (exit $__NCMCP_rc); }`;
+  const separator = prefix.length + suffix.length + 2 > 1000
+    ? `; \\\n: '${marker}'; ` : "; ";
+  return `${prefix}${separator}${suffix}`;
 }
 
 function buildWrappedCommand(command, shellKind, marker, separateStartMarker = false) {
@@ -330,7 +264,7 @@ function buildWrappedCommand(command, shellKind, marker, separateStartMarker = f
 
     case "posix":
     default: {
-      // Single-line compound command with early marker.
+      // Compound command with an early marker on each physical line.
       //
       // Layout: __NCMCP_xxx=0; { ... MARKER_S; eval command; MARKER_E; }
       //
@@ -347,7 +281,7 @@ function buildWrappedCommand(command, shellKind, marker, separateStartMarker = f
       //    keeps shell syntax errors inside the eval call so the wrapper
       //    can still emit the end marker and return a non-zero exit code.
       //
-      // 3) Single-line { ... } is parsed fully before execution, so SIGINT
+      // 3) The complete { ... } group is parsed before execution, so SIGINT
       //    cannot cause bash to flush the end marker from the input buffer.
       //    trap ':' INT lets child processes receive SIGINT normally while
       //    preventing the shell from aborting the compound command.
@@ -542,7 +476,7 @@ module.exports = {
   buildPendingInputClearPrefix,
   buildWrappedCommand,
   buildBashHistoryCleanup,
-  bashHistoryCleanupStatusVar,
+  bashHistoryScratchNames,
   findEndMarker,
   normalizePtyOutput,
   appendBoundedOutput,

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -209,21 +209,19 @@ function buildBashHistoryCleanup(marker) {
   // HISTCONTROL=ignorespace skips the wrapper. Read the entry's actual number:
   // older Bash versions can expose HISTCMD as the next history number.
   // Any single dispatcher name can be shadowed by a user alias or function
-  // (command, builtin, history), so fall back through \history, \command
-  // history and \builtin history, deleting with whichever dispatcher actually
-  // read the marker-bearing entry. The leading backslash stops alias
-  // expansion; the fallback chain stops functions of the same names. The
+  // (command, builtin, history), so try command history and builtin history.
+  // Each attempt re-reads the latest entry:
+  // a history function can display it but delete only in a subshell. The
+  // fallback chain handles a function shadowing a single dispatcher. The
   // unset-safe guard leaves non-Bash shells alone, including shells with
   // nounset enabled.
   // Use ^ for the Bash bracket negation: ! triggers interactive zsh history
   // expansion before the Bash-only guard can run.
-  const entry = `${marker}_h`;
-  const attempt = (read) => (
-    `${entry}=$(${read} 1 2>/dev/null); case "$${entry}" in *${marker}*) `
-    + `${entry}=\${${entry}#"\${${entry}%%[^[:space:]]*}"}; `
-    + `${read} -d "\${${entry}%%[[:space:]]*}" 2>/dev/null ;;`
-  );
-  return `[ -n "\${BASH_VERSION-}" ] && { ${attempt("\\history")}*) ${attempt("\\command history")}*) ${attempt("\\builtin history")} esac ;; esac ;; esac; }`;
+  // Keep the shared cleanup short enough for canonical PTY input buffers.
+  // Expansion of the dispatcher avoids alias expansion of command names.
+  const entry = "__nc_h";
+  const dispatcher = "__nc_d";
+  return `[ "\${BASH_VERSION-}" ]&&{ for ${dispatcher} in command builtin;do ${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) ${entry}=\${${entry}#"\${${entry}%%[^[:space:]]*}"};$${dispatcher} history -d "\${${entry}%%[[:space:]]*}";;esac;done; } 2>/dev/null`;
 }
 
 function buildPosixWrapperBody(command, marker, startFormat) {

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -194,7 +194,9 @@ function buildPendingInputClearPrefix(shellKind) {
       // i+Backspace leaves every mode on an empty editable line.
       return "\x1bggd2147483647d\x1br\x1b\x1bi\x08";
     default:
-      return "\x15\x0b";
+      // Kill the suffix before the prefix. Canonical/no-editing terminals do
+      // not bind Ctrl+K; the trailing Ctrl+U must erase that literal byte too.
+      return "\x0b\x15";
   }
 }
 

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -218,9 +218,32 @@ function buildBashHistoryCleanup(marker, keepDispatcher = false) {
 function buildPosixWrapperBody(command, marker, startFormat) {
   const noPager = "PAGER=cat SYSTEMD_PAGER= GIT_PAGER=cat LESS= ";
   const commandLines = String(command || "").replace(/\r\n?/g, "\n").split("\n");
-  const cmdAssign = commandLines.length > 1
+  let cmdAssign = commandLines.length > 1
     ? `${marker}_cmd=$(printf '%s\\n' ${commandLines.map((line) => `'${escapePosixSingleQuoted(line)}'`).join(" ")})`
     : `${marker}_cmd='${escapePosixSingleQuoted(command)}'`;
+  if (Buffer.byteLength(cmdAssign, 'utf8') > 650) {
+    // Canonical PTYs limit bytes per physical input line, regardless of write
+    // pacing. Emit bounded quoted pieces inside one command substitution; each
+    // continuation keeps the marker visible to the terminal echo filter.
+    const writes = [];
+    for (const [index, line] of commandLines.entries()) {
+      let chunk = '';
+      let bytes = 0;
+      for (const character of line) {
+        const quoted = escapePosixSingleQuoted(character);
+        const size = Buffer.byteLength(quoted, 'utf8');
+        if (bytes + size > 512) {
+          writes.push(`printf '%s' '${chunk}'`);
+          chunk = '';
+          bytes = 0;
+        }
+        chunk += quoted;
+        bytes += size;
+      }
+      writes.push(`printf '${index < commandLines.length - 1 ? '%s\\n' : '%s'}' '${chunk}'`);
+    }
+    cmdAssign = `${marker}_cmd=$(${writes.join(`; \\\n: '${marker}'; `)})`;
+  }
   const historyCleanup = buildBashHistoryCleanup(marker);
   const prefix = `${marker}=0; ${cmdAssign}; { printf '${startFormat}' '${marker}_S'; trap ':' INT; ( ${noPager}eval "$${marker}_cmd" ); __NCMCP_rc=$?; trap - INT; printf '%s\\n' '${marker}_E:'\"$__NCMCP_rc\"`;
   const suffix = `${historyCleanup}; (exit $__NCMCP_rc); }`;

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -232,10 +232,15 @@ function buildBashHistoryCleanup(marker) {
   // variables are unset afterwards: the verification read still assigns the
   // next history entry to __nc_h_*, which could otherwise keep a recent
   // (possibly secret-bearing) command recoverable even after history -c.
+  // Unset through the same dispatcher loop as history: a user alias or
+  // function named unset would otherwise shadow the plain call and leave
+  // the verification-read history entry (possibly secret-bearing) in the
+  // scratch variable. Unsetting the loop variable mid-loop is safe: bash
+  // reassigns it from the already-expanded word list on each iteration.
   const suffix = String(marker || "").toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 24) || "dflt";
   const entry = `__nc_h_${suffix}`;
   const dispatcher = `__nc_d_${suffix}`;
-  return `[ "\${BASH_VERSION-}" ]&&{ for ${dispatcher} in command builtin;do ${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) ${entry}=\${${entry}#"\${${entry}%%[^[:space:]]*}"};$${dispatcher} history -d "\${${entry}%%[[:space:]]*}";${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) :;;*) break;;esac;;esac;done;unset ${entry} ${dispatcher}; } 2>/dev/null`;
+  return `[ "\${BASH_VERSION-}" ]&&{ for ${dispatcher} in command builtin;do ${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) ${entry}=\${${entry}#"\${${entry}%%[^[:space:]]*}"};$${dispatcher} history -d "\${${entry}%%[[:space:]]*}";${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) :;;*) break;;esac;;esac;done;for ${dispatcher} in command builtin;do $${dispatcher} unset ${entry} ${dispatcher};done; } 2>/dev/null`;
 }
 
 function buildPosixWrapperBody(command, marker, startFormat) {

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -213,6 +213,11 @@ function buildBashHistoryCleanup(marker) {
   // Each attempt re-reads the latest entry:
   // a history function can display it but delete only in a subshell. The
   // fallback chain handles a function shadowing a single dispatcher. The
+  // loop stops as soon as a follow-up read after `history -d` confirms the
+  // marker is gone, so a slow shadowed fallback (e.g. builtin() { sleep 60; })
+  // is not invoked after the real dispatcher already deleted the entry. When
+  // deletion is unconfirmed (a shadowed dispatcher displayed the entry but
+  // deleted nothing), the next dispatcher still gets its turn. The
   // unset-safe guard leaves non-Bash shells alone, including shells with
   // nounset enabled.
   // Use ^ for the Bash bracket negation: ! triggers interactive zsh history
@@ -227,7 +232,7 @@ function buildBashHistoryCleanup(marker) {
   const suffix = String(marker || "").toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 24) || "dflt";
   const entry = `__nc_h_${suffix}`;
   const dispatcher = `__nc_d_${suffix}`;
-  return `[ "\${BASH_VERSION-}" ]&&{ for ${dispatcher} in command builtin;do ${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) ${entry}=\${${entry}#"\${${entry}%%[^[:space:]]*}"};$${dispatcher} history -d "\${${entry}%%[[:space:]]*}";;esac;done; } 2>/dev/null`;
+  return `[ "\${BASH_VERSION-}" ]&&{ for ${dispatcher} in command builtin;do ${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) ${entry}=\${${entry}#"\${${entry}%%[^[:space:]]*}"};$${dispatcher} history -d "\${${entry}%%[[:space:]]*}";${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) :;;*) break;;esac;;esac;done; } 2>/dev/null`;
 }
 
 function buildPosixWrapperBody(command, marker, startFormat) {

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -208,11 +208,11 @@ function buildBashHistoryCleanup(marker) {
   // Match the latest entry before deleting it, preserving user history when
   // HISTCONTROL=ignorespace skips the wrapper. Read the entry's actual number:
   // older Bash versions can expose HISTCMD as the next history number.
-  // builtin history bypasses user aliases and functions. The unset-safe guard
+  // command history bypasses user aliases and functions. The unset-safe guard
   // leaves non-Bash shells alone, including shells with nounset enabled.
   // Use ^ for the Bash bracket negation: ! triggers interactive zsh history
   // expansion before the Bash-only guard can run.
-  return `[ -n "\${BASH_VERSION-}" ] && { ${marker}_h=$(builtin history 1 2>/dev/null); case "$${marker}_h" in *${marker}*) ${marker}_h=\${${marker}_h#"\${${marker}_h%%[^[:space:]]*}"}; builtin history -d "\${${marker}_h%%[[:space:]]*}" 2>/dev/null ;; esac; }`;
+  return `[ -n "\${BASH_VERSION-}" ] && { ${marker}_h=$(command history 1 2>/dev/null); case "$${marker}_h" in *${marker}*) ${marker}_h=\${${marker}_h#"\${${marker}_h%%[^[:space:]]*}"}; command history -d "\${${marker}_h%%[[:space:]]*}" 2>/dev/null ;; esac; }`;
 }
 
 function buildPosixWrapperBody(command, marker, startFormat) {

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -228,11 +228,14 @@ function buildBashHistoryCleanup(marker) {
   // with user state, and a readonly (or integer/nameref-attributed) user
   // variable makes the assignment fail, leaving the marker-bearing history
   // entry undeleted. Markers are unique per invocation, so the derived names
-  // cannot clash with anything the user already defined.
+  // cannot clash with anything the user already defined. Both scratch
+  // variables are unset afterwards: the verification read still assigns the
+  // next history entry to __nc_h_*, which could otherwise keep a recent
+  // (possibly secret-bearing) command recoverable even after history -c.
   const suffix = String(marker || "").toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 24) || "dflt";
   const entry = `__nc_h_${suffix}`;
   const dispatcher = `__nc_d_${suffix}`;
-  return `[ "\${BASH_VERSION-}" ]&&{ for ${dispatcher} in command builtin;do ${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) ${entry}=\${${entry}#"\${${entry}%%[^[:space:]]*}"};$${dispatcher} history -d "\${${entry}%%[[:space:]]*}";${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) :;;*) break;;esac;;esac;done; } 2>/dev/null`;
+  return `[ "\${BASH_VERSION-}" ]&&{ for ${dispatcher} in command builtin;do ${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) ${entry}=\${${entry}#"\${${entry}%%[^[:space:]]*}"};$${dispatcher} history -d "\${${entry}%%[[:space:]]*}";${entry}=$($${dispatcher} history 1);case "$${entry}" in *${marker}*) :;;*) break;;esac;;esac;done;unset ${entry} ${dispatcher}; } 2>/dev/null`;
 }
 
 function buildPosixWrapperBody(command, marker, startFormat) {

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -198,12 +198,7 @@ function buildPendingInputClearPrefix(shellKind) {
   }
 }
 
-function buildPosixWrapperBody(command, marker, startFormat) {
-  const noPager = "PAGER=cat SYSTEMD_PAGER= GIT_PAGER=cat LESS= ";
-  const commandLines = String(command || "").replace(/\r\n?/g, "\n").split("\n");
-  const cmdAssign = commandLines.length > 1
-    ? `${marker}_cmd=$(printf '%s\\n' ${commandLines.map((line) => `'${escapePosixSingleQuoted(line)}'`).join(" ")})`
-    : `${marker}_cmd='${escapePosixSingleQuoted(command)}'`;
+function buildBashHistoryCleanup(marker) {
   // Issue #3265: without HISTCONTROL=ignorespace the wrapper line is recorded
   // in bash history. Pressing arrow-up then makes readline redraw that huge
   // marker-containing line, and the preload __NCMCP_ filter suppresses the
@@ -217,8 +212,16 @@ function buildPosixWrapperBody(command, marker, startFormat) {
   // leaves non-Bash shells alone, including shells with nounset enabled.
   // Use ^ for the Bash bracket negation: ! triggers interactive zsh history
   // expansion before the Bash-only guard can run.
-  const historyCleanup =
-    `[ -n "\${BASH_VERSION-}" ] && { ${marker}_h=$(builtin history 1 2>/dev/null); case "$${marker}_h" in *${marker}*) ${marker}_h=\${${marker}_h#"\${${marker}_h%%[^[:space:]]*}"}; builtin history -d "\${${marker}_h%%[[:space:]]*}" 2>/dev/null ;; esac; }`;
+  return `[ -n "\${BASH_VERSION-}" ] && { ${marker}_h=$(builtin history 1 2>/dev/null); case "$${marker}_h" in *${marker}*) ${marker}_h=\${${marker}_h#"\${${marker}_h%%[^[:space:]]*}"}; builtin history -d "\${${marker}_h%%[[:space:]]*}" 2>/dev/null ;; esac; }`;
+}
+
+function buildPosixWrapperBody(command, marker, startFormat) {
+  const noPager = "PAGER=cat SYSTEMD_PAGER= GIT_PAGER=cat LESS= ";
+  const commandLines = String(command || "").replace(/\r\n?/g, "\n").split("\n");
+  const cmdAssign = commandLines.length > 1
+    ? `${marker}_cmd=$(printf '%s\\n' ${commandLines.map((line) => `'${escapePosixSingleQuoted(line)}'`).join(" ")})`
+    : `${marker}_cmd='${escapePosixSingleQuoted(command)}'`;
+  const historyCleanup = buildBashHistoryCleanup(marker);
   return (
     `${marker}=0; ${cmdAssign}; { printf '${startFormat}' '${marker}_S'; trap ':' INT; ( ${noPager}eval "$${marker}_cmd" ); __NCMCP_rc=$?; trap - INT; printf '%s\\n' '${marker}_E:'\"$__NCMCP_rc\"; ${historyCleanup}; (exit $__NCMCP_rc); }`
   );
@@ -470,6 +473,7 @@ module.exports = {
   resolveEffectiveShellKind,
   buildPendingInputClearPrefix,
   buildWrappedCommand,
+  buildBashHistoryCleanup,
   findEndMarker,
   normalizePtyOutput,
   appendBoundedOutput,

--- a/electron/bridges/ai/ptyExecPacedTimeout.test.cjs
+++ b/electron/bridges/ai/ptyExecPacedTimeout.test.cjs
@@ -1,0 +1,62 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const { startPtyJob } = require('./ptyExec.cjs');
+const { buildLiveShellProbe } = require('./liveShellProbe.cjs');
+const { buildWrappedCommand } = require('./ptyExecHelpers.cjs');
+
+for (const background of [true, false]) {
+  test(`paced ${background ? 'background' : 'silent foreground'} delivery does not consume startup time`, async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    const pty = new EventEmitter();
+    const writes = [];
+    pty.write = (data) => writes.push(String(data));
+    const command = `echo ${'x'.repeat(background ? 150000 : 12000)}`;
+    const job = startPtyJob(pty, command, {
+      shellKind: 'posix', probeLiveShell: true,
+      timeoutMs: background ? 3600000 : 500,
+      maxBufferedChars: background ? 1024 : 0,
+    });
+    const advance = (ms) => {
+      for (let elapsed = 0; elapsed < ms; elapsed += 30) t.mock.timers.tick(30);
+    };
+    try {
+      const probeLength = 2 + buildLiveShellProbe(job.marker).length;
+      while (writes.join('').length < probeLength && !writes.includes('\x03')) advance(30);
+      assert.ok(!writes.includes('\x03'), 'probe delivery was interrupted');
+      pty.emit('data', `${job.marker}_P:sh\n${job.marker}_Q`);
+      // The background case crosses the old probe timer; the foreground
+      // case has no echo to refresh its inactivity timer during delivery.
+      advance(background ? 32010 : 1200);
+      assert.ok(!writes.includes('\x03'), 'wrapper interrupted before delivery completed');
+      const totalLength = probeLength + 2 + buildWrappedCommand(command, 'posix', job.marker, true).length;
+      while (writes.join('').length < totalLength && !writes.includes('\x03')) advance(30);
+      assert.ok(!writes.includes('\x03'), 'delivery did not finish');
+      pty.emit('data', `${job.marker}_S\nOK\n${job.marker}_E:0\n`);
+      assert.equal((await job.resultPromise).exitCode, 0);
+    } finally {
+      pty.emit('close');
+      t.mock.timers.reset();
+    }
+  });
+}
+
+test('completed delivery still has a bounded wait for a missing probe reply', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const pty = new EventEmitter();
+  const writes = [];
+  pty.write = (data) => writes.push(String(data));
+  const job = startPtyJob(pty, 'echo never', {
+    shellKind: 'posix', probeLiveShell: true, timeoutMs: 500,
+  });
+  const length = 2 + buildLiveShellProbe(job.marker).length;
+  while (writes.join('').length < length) t.mock.timers.tick(30);
+  // Unrelated output must not keep a never-started command alive forever.
+  for (let i = 0; i < 6; i++) {
+    pty.emit('data', 'unrelated output\n');
+    t.mock.timers.tick(100);
+  }
+  const result = await job.resultPromise;
+  assert.match(result.error, /Command startup timed out/);
+  assert.ok(writes.includes('\x03'));
+});


### PR DESCRIPTION
## Summary

In interactive Bash without `HISTCONTROL=ignorespace`, an AI command could leave its hidden live-shell probe in history. Pressing Up then recalled the probe and produced terminal display residue. Remove only the probe/wrapper history entries and preserve user commands.

The cleanup also has to reach the shell reliably: large injected probes overran readline input, and long physical lines were truncated in canonical/no-editing terminals. Bound input writes and mark continuation echoes so cleanup does not introduce command-start timeouts or visible internal text.

## Type of Change

- [x] Bug fix
- [x] Refactor / code cleanup

## Related Issue (optional)

Follow-up to #3262 and #3267; related to #3265.

## Changes Made

- Share marker-checked Bash history cleanup between probes and execution wrappers. Preserve user history, including when ignorespace excludes injected commands.
- Verify a dispatcher actually executes builtins before trusting its history result. Once cleanup succeeds, stop invoking fallbacks; a shadowed builtin must not delay a successful command. Remove temporary history-bearing variables through the verified dispatcher.
- Keep cleanup independent of shell-name detection and external PATH. Preserve fish/POSIX compatibility and custom alias/function cases.
- Suspend inactivity and startup timers during each input delivery, clear the probe-stage deadline before delivering the wrapper, and arm fresh wait timers only after submission. Explicit wall-clock deadlines and cancellation still interrupt delivery.
- Send long probe-enabled input in 128-character chunks with a 30 ms yield, without splitting Unicode surrogate pairs. Cancel pending input after cancellation, timeout, completion, or replacement by the actual wrapper.
- Use marker-bearing continuation lines for the probe and long wrappers to stay within canonical input limits and suppress continuation echoes.

## Screenshots / Demo

Actual macOS `npm run dev` smoke, using a temporary Bash session with `HISTFILE=/dev/null`: manually enter `echo user_one` and `echo user_two`; ask Catty to execute `echo PACED_HISTORY_OK` exactly once. The command completes once with exit code 0. Up recalls `echo user_two`, and a second Up recalls `echo user_one`, with no internal probe text or display residue. The temporary session was exited and the main development checkout restored after validation.

## Testing

- [x] Tested locally in `npm run dev` with Computer Use.
- [x] Lint passes for all changed files; the development launch also completed its full lint step.
- [x] Prior b94e78d full suite: 11,534 tests, 11,515 passed, 19 skipped, zero failed. Latest timeout repair full suite: 11,537 tests, 11,518 passed, 19 skipped, zero failed. The independent worktree initially lacked the plugin CLI nested dependency; after restoring the existing dependency layout, its 29 tests and the full suite passed.
- [x] Focused suite with real PTY tests enabled: 109 passed, zero skipped (latest timeout repair). Includes fish first execution and return to parent shells, no-echo Bash, clean arrow recall, custom shell functions/aliases, and cancellation/timeout during paced input.
- [x] Two new fallback tests fail against the earlier PR implementation and pass after the repair.
- [ ] Generated capability tool specs updated (not applicable).
- [x] No new application errors observed during the tested flow.

### Latest timeout repair validation

Two regressions reproduce premature interruption on bd260f132: a background wrapper still inherits the completed probe deadline, and silent foreground delivery consumes the inactivity budget. Both pass after the repair. A separate control proves unrelated output cannot keep a missing probe reply alive indefinitely. Real interactive Bash with echo disabled and a 1-second wait budget: the old code fails before execution; the repaired code completes in 3.7 seconds and returns all 12,000 expected characters. Full lint passes. Latest40f8ff565 Computer Use smoke also passes in npm run dev with the exact three production files: Catty executes echo TIMEOUT_FIX_GUI_OK once, Up recalls user_two then user_one, Down returns user_two, and no internal text or display residue appears. The temporary Bash session exited normally; the development app quit with exit0 and all three main files were restored byte-for-byte.

### Canonical long-command repair (703fa4e80)

A real no-editing Bash PTY reproduces review 3944777978 on 40f8ff565: a 12,000-character literal is truncated and fails to reach the start marker. Bounded quoted pieces now preserve the entire command across physical input lines; the same test completes in 4.18 seconds with all output exact. Additional checks preserve Unicode, quotes, blank lines, and heredoc semantics. 111 focused tests pass with real PTY tests enabled; full suite: 11,539 tests, 11,519 passed, 20 skipped, zero failures. Targeted lint and full development-launch lint pass.

Latest Computer Use smoke uses the exact candidate production files in npm run dev. A short Catty command completes with exit 0 after disabling Bash line editing. The attempted long-literal GUI case is inconclusive: the tool received an incomplete quoted command and correctly returned a syntax error; it is not counted as a long-command pass. The canonical GUI also shows a standalone command-not-found line from the pending-input clear sequence; this requires separate investigation. The complete long-command proof is the discriminating real PTY test, not that GUI attempt.

### Canonical pending-input repair (bb932453b)

The standalone error observed in the no-editing GUI was reproduced with the production pending-input prefix: Ctrl+U followed by Ctrl+K leaves a literal Ctrl+K before the command. Reverse the order so Ctrl+U erases that byte in canonical mode and clears the remaining prefix after Ctrl+K removes the suffix in readline mode. Two real-PTY cases with pending text on both sides of the cursor discriminate the original failure and pass after the change. 113 focused real-PTY tests pass, targeted lint passes, and the full suite reports 11,541 tests, 11,519 passed, 22 skipped, zero failures. Latest Computer Use replay passes with this PR and #3303 user-input preservation loaded: a fresh Bash --noediting executes the same 1,200-character literal once, exit 0, with full start/end text and no standalone command-not-found error. The incomplete user input and PTY behaviors are separately isolated by their regressions. Screenshot: combined-input-gui-success.png.

The earlier incomplete GUI command was independently traced to user-text compression before model submission. That separate defect is addressed in #3303, with its own regression and worktree; it was not caused by PTY delivery.

### Timing tradeoff

Five local Bash echo executions completed in 838–884 ms with the bounded delivery, including probe and wrapper. Faster 5/10 ms chunk intervals reproduced input loss in the readline control; 30 ms retains a margin. This adds startup latency for long injected input and is not a zero-overhead claim. Physical Windows GUI behavior was not tested here.

## Checklist

- [x] Follows existing project style.
- [x] Updated regression coverage and this validation description.
- [x] No intended public API or storage-format changes.

