### PR TITLE
fix(ssh): keep remote watchdog alive until blocked children are stopped

### DIFF
--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -91,7 +91,9 @@ function withRemoteWatchdog(command, timeoutMs) {
     `( sleep ${seconds}`,
     // Resolve the watchdog subshell's own PID so the tree walk can skip it
     // (killing ourselves mid-list would abort the remaining kills).
-    `&& nc_self=$(sh -c 'echo $PPID' 2>/dev/null)`,
+    // exec replaces the command-substitution shell: without it Bash may
+    // report that intermediate PID instead of the watchdog subshell.
+    `&& nc_self=$(exec sh -c 'echo $PPID' 2>/dev/null)`,
     `&& nc_tree=$(ps -e -o pid=,ppid= 2>/dev/null | awk -v root="$$" -v self="$nc_self" '${descendantTreeAwk}')`,
     `&& kill -9 $nc_tree "$$" 2>/dev/null ) </dev/null >/dev/null 2>&1 & nc_watchdog_pid=$!`,
   ].join(' ');

--- a/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
+++ b/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
@@ -1107,3 +1107,60 @@ test("getSessionDistroInfo wraps the os-release probe in a remote watchdog", asy
   );
   assert.ok(commands[0].includes("cat /etc/os-release"));
 });
+
+for (const blocked of [false, true]) {
+  test(`real distro probe ${blocked ? 'kills blocked children' : 'cleans its watchdog after success'}`, {
+    skip: process.platform === 'win32', timeout: 10000,
+  }, async () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const { spawn } = require('node:child_process');
+    const directory = require('../tempDirBridge.cjs').getTempFilePath('watchdog-test');
+    fs.mkdirSync(directory, { mode: 0o700 });
+    fs.writeFileSync(path.join(directory, 'cat'), blocked
+      ? '#!/bin/sh\nexec /bin/sleep 30\n'
+      : '#!/bin/sh\nprintf probe_completed\n', { mode: 0o700 });
+    const commands = [];
+    const api = makeSessionOps(new Map([['watchdog-smoke', {
+      type: 'ssh', conn: { exec(command, cb) { commands.push(command); cb(null, fakeStream('fixture')); } },
+    }]]));
+    const captured = await api.getSessionDistroInfo({}, { sessionId: 'watchdog-smoke' });
+    assert.equal(captured.success, true);
+    assert.equal(commands.length, 1);
+    const started = Date.now();
+    const child = spawn('/bin/sh', ['-c', commands[0]], {
+      detached: true, env: { ...process.env, PATH: `${directory}:${process.env.PATH}` },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '', outcome = null;
+    child.stdout.on('data', data => { output += data; });
+    child.stderr.resume();
+    const finished = new Promise((resolve, reject) => {
+      child.once('error', reject);
+      child.once('close', (code, signal) => { outcome = { code, signal }; resolve(); });
+    });
+    let timer;
+    try {
+      await Promise.race([finished, new Promise(resolve => { timer = setTimeout(resolve, 7000); })]);
+      const ps = spawnSync('ps', ['-axo', 'pid=,pgid=,stat='], { encoding: 'utf8' });
+      assert.equal(ps.status, 0, ps.stderr);
+      const living = ps.stdout.split('\n').map(line => line.trim().split(/\s+/))
+        .filter(row => Number(row[1]) === child.pid && !row[2].startsWith('Z'));
+      assert.ok(outcome, `probe did not close; descendants still alive: ${JSON.stringify(living)}`);
+      assert.deepEqual(living, [], 'probe must not leave a child or watchdog sleep running');
+      if (blocked) {
+        assert.equal(outcome.signal, 'SIGKILL');
+        assert.ok(Date.now() - started >= 4500, 'remote watchdog must own the timeout');
+      } else {
+        assert.equal(outcome.code, 0);
+        assert.equal(output, 'probe_completed');
+        assert.ok(Date.now() - started < 2000, 'success must not wait for the watchdog deadline');
+      }
+    } finally {
+      clearTimeout(timer);
+      try { process.kill(-child.pid, 'SIGKILL'); } catch (error) { if (error.code !== 'ESRCH') throw error; }
+      await finished;
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+}


### PR DESCRIPTION
## Summary

On Bash-based POSIX shells, a timed-out remote system probe can kill its watchdog before killing the blocked child process. The child remains alive and keeps the output channel open, so repeated probes can still accumulate processes despite #3193.

Replace the command-substitution shell when identifying the watchdog. This returns the watchdog's actual PID, allowing the descendant walk to exclude it and finish killing the blocked probe tree.

## Type of Change

- [x] Bug fix

## Related Issue (optional)

Follow-up to #3193; related to #3187.

## Changes Made

- Add `exec` to the watchdog PID lookup so Bash cannot report an intermediate command-substitution PID.
- Add real-process regressions using the command generated by `getSessionDistroInfo`, with a controlled `cat` executable that either completes or blocks. Assert process-group cleanup, channel closure, and normal successful output without waiting for the watchdog deadline.
- Store test fixtures in Netcatty's managed temporary directory.

## Screenshots / Demo

Reproduced on macOS using the actual generated POSIX probe, without mocking process termination. Before the fix, the five-second watchdog kills the probe shell but leaves the blocked `sleep` alive after seven seconds. After the fix, the channel closes at about five seconds and no live process remains in the test group. A successful probe completes promptly and cleans its watchdog.

An independent process comparison also confirms normal exit status preservation and cleanup of a nested blocked child. The unguarded control remains alive until the test explicitly cleans it up. This validates the shell/process failure itself; the fix has not yet received an additional end-to-end SSH GUI run or a reporter-environment retest.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Focused SSH stats/CWD/timeout tests: 65 passed. Targeted ESLint passes. Full `npm test`: 11,477 passed, 18 skipped, 0 failed. Full `npm run lint` passed. The initial isolated setup resolved an old root-level ZIP dependency; after restoring the package-local dependency tree, its 29 tests and the full suite passed.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation (inline explanation)
- [x] I have not introduced any breaking changes (or I have described them above)
