### PR TITLE
fix(ai): preserve exact user text during request compression

### DIFF
--- a/infrastructure/ai/harness/contextManager.test.ts
+++ b/infrastructure/ai/harness/contextManager.test.ts
@@ -6,6 +6,24 @@ import { TraceStore } from './traceStore.ts';
 import { ToolOutputStore } from './toolOutputStore.ts';
 import { createInitialCattyRuntimeContext } from './cattyRuntimeContext.ts';
 
+test('normal turn and step preparation preserve exact user literals alongside noisy tool output', async () => {
+  const literal = "printf '%s\\n' 'CANONICAL_GUI_" + 'x'.repeat(1200) + "_END'";
+  const content = `Execute exactly: ${literal}\n\n\n\n${'keep this line\n'.repeat(5)}`;
+  for (const userContent of [content, [{ type: 'text' as const, text: content }]]) {
+    const messages: ModelMessage[] = [
+      { role: 'user', content: userContent },
+      { role: 'assistant', content: [{ type: 'tool-call', toolCallId: 'noise', toolName: 'terminal_execute', input: {} }] },
+      { role: 'tool', content: [{ type: 'tool-result', toolCallId: 'noise', toolName: 'terminal_execute', output: { type: 'text', value: 'log '.repeat(10000) } }] },
+    ];
+    const turn = await prepareTurnContext({ messages, backend: 'catty', contextWindow: 1_300_000, trigger: 'pre-turn' });
+    const step = await prepareStepContext({ messages: turn.messages, contextWindow: 1_300_000, stepNumber: 0 });
+    for (const prepared of [turn, step]) {
+      assert.deepEqual(prepared.messages.find(message => message.role === 'user')?.content, userContent);
+      assert.ok(JSON.stringify(prepared.messages).length < JSON.stringify(messages).length);
+    }
+  }
+});
+
 test('prepareTurnContext applies typed compression before LLM summarize threshold', async () => {
   const longOutput = 'line\n'.repeat(20_000);
   const messages: ModelMessage[] = [

--- a/infrastructure/ai/requestPayloadCompression.ts
+++ b/infrastructure/ai/requestPayloadCompression.ts
@@ -124,6 +124,9 @@ export function compressMessagesForRequestTooLargeRetry(
 
 function compressModelMessageForRequestRetry(message: ModelMessage): ModelMessage {
   if (typeof message.content === "string") {
+    // User text is an instruction or exact input, not terminal output. Lossy
+    // cleanup can alter commands even when the request is far below its limit.
+    if (message.role === "user") return message;
     const content = compressAndTruncateText(message.content, RETRY_MAX_MESSAGE_TEXT_CHARS);
     return content === message.content ? message : ({ ...message, content } as ModelMessage);
   }
@@ -132,6 +135,7 @@ function compressModelMessageForRequestRetry(message: ModelMessage): ModelMessag
 
   let didAdjust = false;
   const content = message.content.map((part) => {
+    if (message.role === "user" && part.type === "text") return part;
     const compressed = compressContentPartForRequestRetry(part);
     if (compressed !== part) didAdjust = true;
     return compressed;


### PR DESCRIPTION
## Summary

Catty changed exact user input before sending it to the model, even with ample context space. During development smoke testing, a quoted command containing 1,200 repeated characters was replaced with a base64-omission placeholder; the injected 500-character goal preview also lacked the closing quote. The model submitted an incomplete command and Bash reported a syntax error.

Preserve user text through request compression, including text parts in multipart messages. Continue compressing noisy tool output and retain the existing attachment handling.

## Type of Change

- [x] Bug fix

## Related Issue (optional)

Discovered during the post-v1.1.82 smoke campaign. Independent of the terminal delivery/history repair in #3298.

## Changes Made

- Exclude user-authored text from lossy output normalization and truncation.
- Cover both string and multipart user messages through actual pre-turn and step preparation, with noisy tool output still reduced.

## Screenshots / Demo

The original npm run dev Computer Use case failed with an unterminated quoted command. An independent production-context control confirms the 1,425-character user message was changed at a 1.3-million-token context limit. The same regression passes with this repair. Fixed Computer Use replay passes with #3298 bb932453b terminal delivery/clear fixes also loaded: fresh Bash --noediting in npm run dev, the same 1,200-character literal executes exactly once, exit 0, complete CANONICAL_GUI_..._END output and no stray control-command error. Separate production-context regressions isolate this PR from the terminal changes.

## Testing

- [x] Fixed behavior tested locally in npm run dev with Computer Use (combined with #3298, as described above).
- [x] Targeted lint passes.
- [x] 17 focused compression/context tests pass; the new regression fails on main before the repair.
- [x] Full npm test recheck: 11,494 tests, 11,476 passed, 18 skipped, zero failures. The first run had seven plugin CLI failures from missing nested dependencies and one 20ms script deadline timing failure; after restoring the existing dependency layout, all 54 plugin/script checks and the complete suite passed.
- [ ] Generated capability tool specs updated (not applicable).
- [x] No new errors in the fixed long-command GUI flow.

## Checklist

- [x] Follows project style.
- [x] Added regression coverage and documented the limitation.
- [x] No public API or storage-format changes.

Preserving exact user input can retain more request text. Existing context-budget handling still applies; this change does not promise that an arbitrarily large instruction fits the model limit.
