### PR TITLE
fix(terminal): keep full-width history preview rows visible

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -1065,6 +1065,27 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     overlay.style.fontSize = `${currentTerminalFontSize()}px`;
     overlay.style.fontFamily = String(term.options.fontFamily ?? fontFamily);
     overlay.style.lineHeight = String(term.options.lineHeight ?? lineHeight);
+    // xterm rounds its cell dimensions to device pixels. A native <pre> with
+    // the same font settings can therefore be wider (and shorter) than the
+    // terminal, clipping the final columns of every full-width history row.
+    const screen = term.element?.querySelector(".xterm-screen");
+    const screenRect = screen?.getBoundingClientRect();
+    if (screenRect && screenRect.width > 0 && screenRect.height > 0
+      && term.cols > 0 && term.rows > 0) {
+      overlay.style.fontWeight = String(term.options.fontWeight ?? "normal");
+      overlay.style.fontKerning = "none";
+      overlay.style.fontVariantLigatures = "none";
+      overlay.style.letterSpacing = "0px";
+      const measure = document.createElement("span");
+      measure.style.display = "inline-block";
+      measure.textContent = "W";
+      overlay.replaceChildren(measure);
+      const nativeCellWidth = measure.getBoundingClientRect().width;
+      if (nativeCellWidth > 0) {
+        overlay.style.letterSpacing = `${screenRect.width / term.cols - nativeCellWidth}px`;
+      }
+      overlay.style.lineHeight = `${screenRect.height / term.rows}px`;
+    }
     overlay.textContent = previewRows.map((row) => row.text).join("\n");
     overlay.setAttribute(HISTORY_PREVIEW_WRAP_ATTR, encodeHistoryPreviewWrapFlags(previewRows));
     return true;

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -1,3 +1,4 @@
+import { stringCellWidth } from "../autocomplete/terminalStringCellWidth";
 import { FitAddon } from "@xterm/addon-fit";
 import { ImageAddon } from "@xterm/addon-image";
 import { SearchAddon } from "@xterm/addon-search";
@@ -1065,28 +1066,43 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     overlay.style.fontSize = `${currentTerminalFontSize()}px`;
     overlay.style.fontFamily = String(term.options.fontFamily ?? fontFamily);
     overlay.style.lineHeight = String(term.options.lineHeight ?? lineHeight);
-    // xterm rounds its cell dimensions to device pixels. A native <pre> with
-    // the same font settings can therefore be wider (and shorter) than the
-    // terminal, clipping the final columns of every full-width history row.
-    const screen = term.element?.querySelector(".xterm-screen");
-    const screenRect = screen?.getBoundingClientRect();
+    // Native font advances differ from xterm's device-pixel-rounded cells.
+    // Fit each row to its terminal cell width, including double-width glyphs,
+    // rather than applying a single-cell correction once per Unicode glyph.
+    overlay.style.fontWeight = String(term.options.fontWeight ?? "normal");
+    overlay.style.fontKerning = "none";
+    overlay.style.fontVariantLigatures = "none";
+    const screenRect = term.element?.querySelector(".xterm-screen")?.getBoundingClientRect();
     if (screenRect && screenRect.width > 0 && screenRect.height > 0
       && term.cols > 0 && term.rows > 0) {
-      overlay.style.fontWeight = String(term.options.fontWeight ?? "normal");
-      overlay.style.fontKerning = "none";
-      overlay.style.fontVariantLigatures = "none";
-      overlay.style.letterSpacing = "0px";
-      const measure = document.createElement("span");
-      measure.style.display = "inline-block";
-      measure.textContent = "W";
-      overlay.replaceChildren(measure);
-      const nativeCellWidth = measure.getBoundingClientRect().width;
-      if (nativeCellWidth > 0) {
-        overlay.style.letterSpacing = `${screenRect.width / term.cols - nativeCellWidth}px`;
-      }
       overlay.style.lineHeight = `${screenRect.height / term.rows}px`;
+      const rowElements = previewRows.map((row) => {
+        const span = document.createElement("span");
+        span.style.display = "inline-block";
+        span.style.verticalAlign = "top";
+        span.style.transformOrigin = "left top";
+        span.textContent = row.text;
+        return span;
+      });
+      const fragment = document.createDocumentFragment();
+      rowElements.forEach((span, index) => {
+        if (index > 0) fragment.appendChild(document.createTextNode("\n"));
+        fragment.appendChild(span);
+      });
+      overlay.replaceChildren(fragment);
+      // Batch all measurements before writing transforms to avoid one forced
+      // layout per row. Text nodes and explicit newlines stay unchanged for copy.
+      const nativeWidths = rowElements.map((span) => span.getBoundingClientRect().width);
+      rowElements.forEach((span, index) => {
+        const nativeWidth = nativeWidths[index];
+        const cells = stringCellWidth(previewRows[index].text, term);
+        if (nativeWidth > 0 && cells > 0) {
+          span.style.transform = `scaleX(${cells * screenRect.width / term.cols / nativeWidth})`;
+        }
+      });
+    } else {
+      overlay.textContent = previewRows.map((row) => row.text).join("\n");
     }
-    overlay.textContent = previewRows.map((row) => row.text).join("\n");
     overlay.setAttribute(HISTORY_PREVIEW_WRAP_ATTR, encodeHistoryPreviewWrapFlags(previewRows));
     return true;
   };

--- a/components/terminal/runtime/terminalHistoryScrollOverride.test.ts
+++ b/components/terminal/runtime/terminalHistoryScrollOverride.test.ts
@@ -352,3 +352,23 @@ test("history preview right-click is recognized as an app-menu target", () => {
     false,
   );
 });
+
+
+test("nested preview rows retain soft-wrap copy and partial selections", async () => {
+  const { JSDOM } = await import("jsdom");
+  const dom = new JSDOM("<pre><span>中文abc</span>\n<span>def</span></pre>");
+  const overlay = dom.window.document.querySelector("pre")!;
+  overlay.setAttribute(HISTORY_PREVIEW_WRAP_ATTR, "01");
+  const first = overlay.firstChild!.firstChild!;
+  const last = overlay.lastChild!.firstChild!;
+  const selection = {
+    rangeCount: 1, anchorNode: first, focusNode: last,
+    anchorOffset: 1, focusOffset: 2, toString: () => "文abc\ndef",
+  };
+  assert.equal(getHistoryPreviewSelectionText(overlay, selection), "文abcde");
+  assert.equal(getHistoryPreviewSelectionText(overlay, {
+    ...selection, anchorNode: overlay, focusNode: overlay,
+    anchorOffset: 0, focusOffset: overlay.childNodes.length,
+  }), "中文abcdef");
+  dom.window.close();
+});

--- a/components/terminal/runtime/terminalHistoryScrollOverride.test.ts
+++ b/components/terminal/runtime/terminalHistoryScrollOverride.test.ts
@@ -17,9 +17,29 @@ import {
   isHistoryPreviewDismissClick,
   joinHistoryPreviewSelectionText,
   nextHistoryPreviewTop,
+  selectHistoryPreviewAll,
   shouldHideHistoryPreviewOnMouseDown,
   shouldKeepHistoryPreviewOnKey,
 } from "./terminalHistoryScrollOverride.ts";
+
+test("select all includes every preview row and preserves soft-wrap copying", async () => {
+  const { JSDOM } = await import("jsdom");
+  const dom = new JSDOM("<pre><span>中文abc</span>\n<span>def</span>\n<span>last</span></pre>");
+  try {
+    const overlay = dom.window.document.querySelector("pre")!;
+    overlay.setAttribute(HISTORY_PREVIEW_WRAP_ATTR, "010");
+    assert.equal(selectHistoryPreviewAll(overlay), true);
+    assert.equal(dom.window.getSelection()!.toString(), "中文abc\ndef\nlast");
+    assert.equal(getHistoryPreviewSelectionText(overlay, dom.window.getSelection()), "中文abcdef\nlast");
+    overlay.textContent = "plain\ntext";
+    assert.equal(selectHistoryPreviewAll(overlay), true);
+    assert.equal(dom.window.getSelection()!.toString(), "plain\ntext");
+    overlay.textContent = "";
+    assert.equal(selectHistoryPreviewAll(overlay), false);
+  } finally {
+    dom.window.close();
+  }
+});
 
 const wheel = (
   over: Partial<Parameters<typeof forcedHistoryScrollLinesForWheel>[0]> = {},

--- a/components/terminal/runtime/terminalHistoryScrollOverride.ts
+++ b/components/terminal/runtime/terminalHistoryScrollOverride.ts
@@ -358,9 +358,7 @@ export const selectHistoryPreviewAll = (overlay: HTMLElement | null | undefined)
   const selection = overlay.ownerDocument.getSelection();
   if (!selection) return false;
   const range = overlay.ownerDocument.createRange();
-  const textNode = overlay.firstChild;
-  if (textNode) range.selectNodeContents(textNode);
-  else range.selectNodeContents(overlay);
+  range.selectNodeContents(overlay);
   selection.removeAllRanges();
   selection.addRange(range);
   return !selection.isCollapsed;

--- a/components/terminal/runtime/terminalHistoryScrollOverride.ts
+++ b/components/terminal/runtime/terminalHistoryScrollOverride.ts
@@ -147,6 +147,7 @@ export type HistoryPreviewSelectionLike = {
 };
 
 export type HistoryPreviewNodeLike = {
+  ownerDocument?: Pick<Document, "createRange">;
   contains(node: { nodeType?: number } | null): boolean;
   firstChild?: { nodeType?: number } | null;
   getAttribute?(name: string): string | null;
@@ -271,6 +272,16 @@ const resolveOverlayTextOffset = (
   node: { nodeType?: number } | null,
   offset: number,
 ): number | null => {
+  if (overlay.ownerDocument && node) {
+    try {
+      const prefix = overlay.ownerDocument.createRange();
+      prefix.selectNodeContents(overlay as unknown as Node);
+      prefix.setEnd(node as Node, offset);
+      return prefix.toString().length;
+    } catch {
+      return null;
+    }
+  }
   if (node === textNode) return offset;
   if (node === overlay) return offset <= 0 ? 0 : overlay.textContent?.length ?? 0;
   return null;


### PR DESCRIPTION
## Summary

Full-width terminal output is readable in xterm, but the native history preview clips the final columns and packs rows more tightly. The preview uses the same font options but misses xterm's device-pixel-rounded cell dimensions. Fit each preview row to its live terminal cell width and match the rendered line height.

## Type of Change

- [x] Bug fix

## Related Issue (optional)

Found during the post-v1.1.82 Computer smoke of #3165. Independent of the transcript parser repairs in #3297.

## Changes Made

- Scale each native preview row to its terminal cell width, including mixed ASCII/CJK rows, instead of applying a per-glyph letter-spacing correction.
- Batch row measurements before transforms and match line height and font weight to the terminal.
- Keep explicit newline text nodes and calculate DOM selection offsets across row spans, preserving hard/soft-wrap copy behavior.
- Select the entire overlay for keyboard/context-menu Select All so every row is included.
- Retain the plain-text fallback when terminal dimensions are unavailable. Incoming terminal output processing is unchanged.

## Screenshots / Demo

Actual `npm run dev` Electron, operated with Computer on macOS. A Python fixture emits 100 full-width ASCII lines ending in END in the alternate screen. Before: END visible in the live terminal, clipped from every preview row. After: END visible in ASCII preview at both sidebar-open and sidebar-collapsed widths. The wide-glyph follow-up also shows END on full CJK rows; actual Computer copy into TextEdit retains CJK-000, the Chinese characters, and END. ASCII was rechecked after that follow-up; exit returns to the shell. The Select All follow-up was validated through actual Cmd+A/Cmd+C and paste into TextEdit: all 51 displayed CJK rows (000 through 050), each with 93 Chinese characters and END, were retained. A new regression fails before the fix by selecting only the first row and passes after it. Local artifacts: preview-edge-main-live.png, preview-edge-main-preview.png, preview-edge-fixed.png, preview-edge-fixed-wide.png in the smoke evidence folder.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes on the changed file
- [x] Related tests pass: 44 createXTermRuntime / terminalHistoryScrollOverride tests, including multi-row Select All, nested-row partial and soft-wrap selection
- [x] Latest commit 39d4fcfee CI lint-and-test passed (run 34056098689 / job 101548165752)

Validation is on the configured macOS font and actual app window, not every font, platform, or emoji/grapheme combination. The added measurement runs when opening/paging history, not on incoming terminal output; Measured isolated Electron render-block A/B (40 warmed alternating samples) adds about 0.7ms per page for ASCII/CJK at 196 columns x 52 rows; emoji adds 1.3ms (6.2 to 7.5ms). At 512 x 100, dense emoji increases from 32 to 34.9ms, so this is not a zero-cost change. The benchmark excludes history parsing/input dispatch/compositor presentation. Actual Computer paging through a 300-row ASCII/CJK/emoji fixture moved backward and forward to the expected row labels with END visible and exited back to the shell.

## Checklist

- [x] Follows the existing runtime structure
- [x] No stored-data or public API change
