### PR TITLE
fix(sftp): share pending resume feedback across transfer views

### DIFF
--- a/application/state/sftpTransferCenterStore.ts
+++ b/application/state/sftpTransferCenterStore.ts
@@ -109,6 +109,8 @@ export interface SftpTransferCenterStore {
   /** Insert or merge tasks by id (used by dedicated directory resume for children). */
   upsertTasks(incoming: readonly TransferTask[]): void;
   canControl(taskId: string): boolean;
+  subscribeResume(listener: Listener): () => void;
+  isResuming(taskId: string): boolean;
   pause(taskId: string): Promise<void>;
   resume(taskId: string): Promise<void>;
   cancel(taskId: string): Promise<void>;
@@ -431,6 +433,13 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
   let persistenceDirty = false;
   let persistenceTimer: ReturnType<typeof setTimeout> | null = null;
   const resumeInvocations = new Map<string, Promise<void>>();
+  // Ephemeral control intent: never serialize this or change bridge lifecycle epochs.
+  const resumeRequests = new Map<string, symbol>();
+  const resumeListeners = new Set<Listener>();
+  const notifyResume = () => resumeListeners.forEach((listener) => listener());
+  const clearResumeRequest = (taskId: string) => {
+    if (resumeRequests.delete(taskId)) notifyResume();
+  };
   const resumePreparationFailures = new Map<string, string>();
   let dedicatedResumeHandler: DedicatedTransferResumeHandler | null = null;
   const dedicatedResumeWaiters = new Set<{
@@ -1725,114 +1734,140 @@ export function createSftpTransferCenterStore(persistence?: StorePersistence): S
         controls.adopt && controls.canAdopt?.(task)
       )));
     },
-    pause: (taskId) => invoke(taskId, "pause"),
+    subscribeResume(listener) {
+      resumeListeners.add(listener);
+      return () => { resumeListeners.delete(listener); };
+    },
+    isResuming(taskId) {
+      if (!resumeRequests.has(taskId)) return false;
+      const task = tasks.find((candidate) => candidate.id === taskId);
+      return !!task && !task.error
+        && ["paused", "interrupted", "attention", "pending", "queued"].includes(task.status);
+    },
+    pause(taskId) {
+      clearResumeRequest(taskId);
+      return invoke(taskId, "pause");
+    },
     async resume(taskId) {
-      const startFresh = () => {
-        const running = invoke(taskId, "resume").finally(() => {
-          if (resumeInvocations.get(taskId) === running) resumeInvocations.delete(taskId);
-        });
-        resumeInvocations.set(taskId, running);
-        return running;
-      };
+      const request = Symbol("resume");
+      resumeRequests.set(taskId, request);
+      notifyResume();
+      const runResume = async () => {
+        const startFresh = () => {
+          const running = invoke(taskId, "resume").finally(() => {
+            if (resumeInvocations.get(taskId) === running) resumeInvocations.delete(taskId);
+          });
+          resumeInvocations.set(taskId, running);
+          return running;
+        };
 
-      const existing = resumeInvocations.get(taskId);
-      if (existing) {
-        // Dedicated resume holds the invocation for the full stream lifetime.
-        const task = tasks.find((candidate) => candidate.id === taskId);
-        if (task?.status === "cancelled") return existing;
+        const existing = resumeInvocations.get(taskId);
+        if (existing) {
+          // Dedicated resume holds the invocation for the full stream lifetime.
+          const task = tasks.find((candidate) => candidate.id === taskId);
+          if (task?.status === "cancelled") return existing;
 
-        // Soft-unpause live backend streams when still paused under a held run.
-        // Dedicated *directory* walks treat status===paused as shouldAbort between
-        // files, so soft-rejoin is unsafe (dying promise + false transferring).
-        // Wind down soft-paused children then startFresh from checkpoints.
-        // Single-file dedicated (and non-directory live streams) soft-unpause.
-        if (task && (task.status === "paused" || task.status === "pausing")) {
-          const childIds = tasks
-            .filter((candidate) => candidate.parentTaskId === taskId
-              && (candidate.status === "paused"
-                || candidate.status === "pausing"
-                || candidate.status === "transferring"))
-            .map((candidate) => candidate.id);
+          // Soft-unpause live backend streams when still paused under a held run.
+          // Dedicated *directory* walks treat status===paused as shouldAbort between
+          // files, so soft-rejoin is unsafe (dying promise + false transferring).
+          // Wind down soft-paused children then startFresh from checkpoints.
+          // Single-file dedicated (and non-directory live streams) soft-unpause.
+          if (task && (task.status === "paused" || task.status === "pausing")) {
+            const childIds = tasks
+              .filter((candidate) => candidate.parentTaskId === taskId
+                && (candidate.status === "paused"
+                  || candidate.status === "pausing"
+                  || candidate.status === "transferring"))
+              .map((candidate) => candidate.id);
 
-          // Always clear process-global latches + control epoch so walks wake and
-          // late soft-drain / pauseWatch cannot re-pause streams. Do not stamp
-          // control epoch as task.lifecycleEpoch (bridge-aligned only).
-          let resumeEpoch = bumpTransferControlEpoch(taskId);
-          releaseTransferPauseTree(taskId, childIds);
+            // Always clear process-global latches + control epoch so walks wake and
+            // late soft-drain / pauseWatch cannot re-pause streams. Do not stamp
+            // control epoch as task.lifecycleEpoch (bridge-aligned only).
+            let resumeEpoch = bumpTransferControlEpoch(taskId);
+            releaseTransferPauseTree(taskId, childIds);
 
-          if (task.ownerId === "dedicated-resume" && task.isDirectory) {
-            const bridge = netcattyBridge.get();
-            // Cancel soft-paused child streams so the held walk settles. When a
-            // child is not in activeTransfers, cancelTransfer leaves a sticky
-            // pendingCancel latch — clear it before startFresh reuses the same
-            // child transferIds (otherwise startStreamTransfer aborts immediately).
-            for (const id of childIds) {
-              try { await bridge?.cancelTransfer?.(id); } catch { /* best-effort wind-down */ }
-              try { await bridge?.clearPendingTransferCancel?.(id); } catch { /* best-effort */ }
+            if (task.ownerId === "dedicated-resume" && task.isDirectory) {
+              const bridge = netcattyBridge.get();
+              // Cancel soft-paused child streams so the held walk settles. When a
+              // child is not in activeTransfers, cancelTransfer leaves a sticky
+              // pendingCancel latch — clear it before startFresh reuses the same
+              // child transferIds (otherwise startStreamTransfer aborts immediately).
+              for (const id of childIds) {
+                try { await bridge?.cancelTransfer?.(id); } catch { /* best-effort wind-down */ }
+                try { await bridge?.clearPendingTransferCancel?.(id); } catch { /* best-effort */ }
+              }
+              try { await bridge?.clearPendingTransferCancel?.(taskId); } catch { /* best-effort */ }
+              try {
+                await existing;
+              } catch { /* previous aborted / cancelled */ }
+              // Clear again after wind-down in case cancel raced during await.
+              for (const id of childIds) {
+                try { await bridge?.clearPendingTransferCancel?.(id); } catch { /* best-effort */ }
+              }
+              try { await bridge?.clearPendingTransferCancel?.(taskId); } catch { /* best-effort */ }
+              if (!isTransferControlEpochCurrent(taskId, resumeEpoch)) return existing;
+              return resumeInvocations.get(taskId) ?? startFresh();
             }
-            try { await bridge?.clearPendingTransferCancel?.(taskId); } catch { /* best-effort */ }
+
+            try {
+              // Reuse the live control path: held dedicated transfers must obey
+              // the same ordering and per-child lifecycle rules as panel jobs.
+              const softOperation = softResumeTransfer({
+                getTasks: () => tasks,
+                setTasks: (next) => { tasks = next; emit(); },
+                getBridge: defaultTransferControlBridge,
+              }, taskId);
+              resumeEpoch = getTransferControlEpoch(taskId);
+              const soft = await softOperation;
+              if (soft.handled) return existing;
+              const streamGone = /no longer active|not active|not found|session is no longer|Resume unavailable|Transfer not found/i
+                .test(soft.reason ?? "");
+              if (!streamGone) {
+                tasks = tasks.map((candidate) => candidate.id === taskId ? {
+                  ...candidate,
+                  status: "paused" as const,
+                  speed: 0,
+                  phase: undefined,
+                  error: soft.reason,
+                } : candidate);
+                emit();
+                return existing;
+              }
+            } catch {
+              // Fall through to await + restart.
+            }
+            if (!isTransferControlEpochCurrent(taskId, resumeEpoch)) return existing;
             try {
               await existing;
-            } catch { /* previous aborted / cancelled */ }
-            // Clear again after wind-down in case cancel raced during await.
-            for (const id of childIds) {
-              try { await bridge?.clearPendingTransferCancel?.(id); } catch { /* best-effort */ }
-            }
-            try { await bridge?.clearPendingTransferCancel?.(taskId); } catch { /* best-effort */ }
+            } catch { /* previous aborted */ }
             if (!isTransferControlEpochCurrent(taskId, resumeEpoch)) return existing;
             return resumeInvocations.get(taskId) ?? startFresh();
           }
 
-          try {
-            // Reuse the live control path: held dedicated transfers must obey
-            // the same ordering and per-child lifecycle rules as panel jobs.
-            const softOperation = softResumeTransfer({
-              getTasks: () => tasks,
-              setTasks: (next) => { tasks = next; emit(); },
-              getBridge: defaultTransferControlBridge,
-            }, taskId);
-            resumeEpoch = getTransferControlEpoch(taskId);
-            const soft = await softOperation;
-            if (soft.handled) return existing;
-            const streamGone = /no longer active|not active|not found|session is no longer|Resume unavailable|Transfer not found/i
-              .test(soft.reason ?? "");
-            if (!streamGone) {
-              tasks = tasks.map((candidate) => candidate.id === taskId ? {
-                ...candidate,
-                status: "paused" as const,
-                speed: 0,
-                phase: undefined,
-                error: soft.reason,
-              } : candidate);
-              emit();
-              return existing;
-            }
-          } catch {
-            // Fall through to await + restart.
+          // After demotion to interrupted/attention/failed while work unwinds:
+          // wait then re-invoke (do not rejoin a dying canceling promise).
+          if (task && (task.status === "interrupted" || task.status === "attention" || task.status === "failed")) {
+            const resumeEpoch = getTransferControlEpoch(taskId);
+            try {
+              await existing;
+            } catch { /* previous aborted */ }
+            if (getTransferControlEpoch(taskId) !== resumeEpoch) return existing;
+            return resumeInvocations.get(taskId) ?? startFresh();
           }
-          if (!isTransferControlEpochCurrent(taskId, resumeEpoch)) return existing;
-          try {
-            await existing;
-          } catch { /* previous aborted */ }
-          if (!isTransferControlEpochCurrent(taskId, resumeEpoch)) return existing;
-          return resumeInvocations.get(taskId) ?? startFresh();
+          return existing;
         }
-
-        // After demotion to interrupted/attention/failed while work unwinds:
-        // wait then re-invoke (do not rejoin a dying canceling promise).
-        if (task && (task.status === "interrupted" || task.status === "attention" || task.status === "failed")) {
-          const resumeEpoch = getTransferControlEpoch(taskId);
-          try {
-            await existing;
-          } catch { /* previous aborted */ }
-          if (getTransferControlEpoch(taskId) !== resumeEpoch) return existing;
-          return resumeInvocations.get(taskId) ?? startFresh();
-        }
-        return existing;
+        return startFresh();
+      };
+      try {
+        return await runResume();
+      } finally {
+        if (resumeRequests.get(taskId) === request) clearResumeRequest(taskId);
       }
-      return startFresh();
     },
-    cancel: (taskId) => invoke(taskId, "cancel"),
+    cancel(taskId) {
+      clearResumeRequest(taskId);
+      return invoke(taskId, "cancel");
+    },
     async retry(taskId) {
       const ownerId = findOwner(taskId);
       const task = tasks.find((candidate) => candidate.id === taskId);
@@ -2428,5 +2463,18 @@ export function useSftpTransferTask(taskId: string, fallback: TransferTask): Tra
     sftpTransferCenterStore.subscribeProgress,
     () => sftpTransferCenterStore.getTask(taskId) ?? fallbackRef.current,
     () => fallbackRef.current,
+  );
+}
+
+/** Shared control feedback for every transfer surface, including newly mounted rows. */
+export function useSftpTransferResuming(taskId: string): boolean {
+  return useSyncExternalStore(
+    (listener) => {
+      const unsubscribeTask = sftpTransferCenterStore.subscribe(listener);
+      const unsubscribeResume = sftpTransferCenterStore.subscribeResume(listener);
+      return () => { unsubscribeTask(); unsubscribeResume(); };
+    },
+    () => sftpTransferCenterStore.isResuming(taskId),
+    () => false,
   );
 }

--- a/application/state/sftpTransferResumeFeedback.test.ts
+++ b/application/state/sftpTransferResumeFeedback.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createSftpTransferCenterStore } from "./sftpTransferCenterStore";
+
+for (const outcome of ["success", "failure", "pause", "cancel"] as const) {
+  test(`resume feedback clears after ${outcome} without changing the paused checkpoint`, async (t) => {
+    const previous = Object.getOwnPropertyDescriptor(globalThis, "window");
+    t.after(() => {
+      if (previous) Object.defineProperty(globalThis, "window", previous);
+      else Reflect.deleteProperty(globalThis, "window");
+    });
+    let settle!: (value: { success: boolean; reason?: string }) => void;
+    let started!: () => void;
+    const entered = new Promise<void>((resolve) => { started = resolve; });
+    const gate = new Promise<{ success: boolean; reason?: string }>((resolve) => { settle = resolve; });
+    Object.defineProperty(globalThis, "window", { configurable: true, value: { netcatty: {
+      resumeTransfer: () => { started(); return gate; },
+      pauseTransfer: async () => ({ success: true, checkpointBytes: 100 }),
+      cancelTransfer: async () => ({ success: true }),
+    } } });
+    const store = createSftpTransferCenterStore();
+    store.publishOwner("feedback", [{
+      id: "feedback", fileName: "file.bin", sourcePath: "/source.bin", targetPath: "/target.bin",
+      sourceConnectionId: "remote", targetConnectionId: "local", direction: "download",
+      status: "paused", totalBytes: 1000, transferredBytes: 100, checkpointBytes: 100,
+      speed: 0, startTime: 1, isDirectory: false, resumable: true,
+    }]);
+    let notifications = 0;
+    const unsubscribe = store.subscribeResume(() => { notifications += 1; });
+    t.after(unsubscribe);
+    const running = store.resume("feedback");
+    assert.equal(store.isResuming("feedback"), true);
+    assert.equal(store.getTask("feedback")?.status, "paused");
+    assert.equal(store.getTask("feedback")?.checkpointBytes, 100);
+    await entered;
+    const followup = outcome === "pause" ? store.pause("feedback")
+      : outcome === "cancel" ? store.cancel("feedback") : Promise.resolve();
+    if (outcome === "pause" || outcome === "cancel") assert.equal(store.isResuming("feedback"), false);
+    settle(outcome === "failure" ? { success: false, reason: "Resume safety check failed" } : { success: true });
+    await Promise.all([running, followup]);
+    assert.equal(store.isResuming("feedback"), false);
+    assert.ok(notifications >= 2);
+    if (outcome === "pause") assert.equal(store.getTask("feedback")?.status, "paused");
+    if (outcome === "cancel") assert.equal(store.getTask("feedback")?.status, "cancelled");
+  });
+}

--- a/components/GlobalSftpTransferCenter.resume-status.test.tsx
+++ b/components/GlobalSftpTransferCenter.resume-status.test.tsx
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import React from "react";
+import React, { act } from "react";
 import { createDomRenderer, dispatchDomEvent, flushEffects, installDomEnvironment } from "./test-support/renderReactDom.tsx";
 
-test("large transfer histories mount only visible rows and can scroll to the last file", async (t) => {
+test("resume from another panel is visible while backend verification is pending", async (t) => {
   const env = installDomEnvironment();
   const previous = new Map<string, PropertyDescriptor | undefined>();
   const globals = {
@@ -35,35 +35,35 @@ test("large transfer histories mount only visible rows and can scroll to the las
     }
     env.cleanup();
   });
-  store.publishOwner("virtual-list-test", Array.from({ length: 1_000 }, (_, index) => ({
-    id: `virtual-file-${index}`, fileName: `file-${index}.bin`,
-    sourcePath: `/source/${index}`, targetPath: `/target/${index}`,
-    sourceConnectionId: "source", targetConnectionId: "local", direction: "download" as const,
-    status: "queued" as const, totalBytes: 1_000, transferredBytes: 0, speed: 0,
-    startTime: index + 1, isDirectory: false,
-  })));
+  let settleResume!: (result: { success: boolean }) => void;
+  let resumeCalls = 0;
+  const gate = new Promise<{ success: boolean }>((resolve) => { settleResume = resolve; });
+  Object.defineProperty(env.window, "netcatty", { configurable: true, value: {
+    resumeTransfer: async () => { resumeCalls += 1; return gate; },
+  } });
+  store.publishOwner("resume-display-test", [{
+    id: "resume-display", fileName: "resume-display.bin",
+    sourcePath: "/source.bin", targetPath: "/target.bin",
+    sourceConnectionId: "remote", targetConnectionId: "local", direction: "download",
+    status: "paused", totalBytes: 1000, transferredBytes: 100, speed: 0,
+    startTime: 1, isDirectory: false, resumable: true,
+  }]);
   await renderer.render(<I18nProvider locale="en"><TooltipProvider><GlobalSftpTransferCenter /></TooltipProvider></I18nProvider>);
   const toggle = env.document.querySelector("[data-section=global-sftp-transfer-toggle]");
   assert.ok(toggle);
   await dispatchDomEvent(toggle, new env.window.MouseEvent("click", { bubbles: true }));
-  await flushEffects();
-  const rows = () => env.document.querySelectorAll("[role=progressbar]");
-  assert.ok(rows().length > 0 && rows().length < 40, `rendered ${rows().length} rows`);
-  assert.ok(env.document.querySelector('[role=progressbar][aria-label="file-999.bin"]'));
-  const firstRow = env.document.querySelector('[data-transfer-status="queued"]');
-  assert.ok(firstRow);
-  assert.equal(firstRow.matches('.last\\:border-b-0:last-child'), false, "a virtual row must not lose its divider just because it has a wrapper");
-
-  const scroll = env.document.querySelector<HTMLElement>("[data-section=global-sftp-transfer-list]");
-  assert.ok(scroll);
-  scroll.scrollTop = 112 * 1_000 - 460;
-  await dispatchDomEvent(scroll, new env.window.Event("scroll"));
-  await flushEffects();
-  assert.ok(rows().length > 0 && rows().length < 40);
-  assert.ok(env.document.querySelector('[role=progressbar][aria-label="file-0.bin"]'));
-  const lastRow = env.document.querySelector('[role=progressbar][aria-label="file-0.bin"]')?.closest('[data-transfer-status]');
-  assert.ok(lastRow?.classList.contains("border-b-0"), "only the actual final row omits its divider");
-  assert.equal(store.getSnapshot().tasks.length, 1_000, "offscreen files must remain queued");
-  await dispatchDomEvent(toggle, new env.window.MouseEvent("click", { bubbles: true }));
-  await flushEffects();
+  let resumed!: Promise<void>;
+  await act(async () => { resumed = store.resume("resume-display"); });
+  try {
+    await flushEffects();
+    assert.equal(resumeCalls, 1);
+    const row = env.document.querySelector('[role=progressbar][aria-label="resume-display.bin"]')?.closest('[data-transfer-status]');
+    assert.ok(row);
+    assert.match(row.textContent ?? "", /Reconnecting and resuming/);
+    assert.equal(row.querySelector('button[aria-label="Resume"]'), null);
+  } finally {
+    await act(async () => { settleResume({ success: true }); await resumed; });
+    await dispatchDomEvent(toggle, new env.window.MouseEvent("click", { bubbles: true }));
+    await flushEffects();
+  }
 });

--- a/components/GlobalSftpTransferCenter.tsx
+++ b/components/GlobalSftpTransferCenter.tsx
@@ -23,6 +23,7 @@ import { useI18n } from "../application/i18n/I18nProvider";
 import {
   sftpTransferCenterStore,
   useSftpTransferCenterBadge,
+  useSftpTransferResuming,
   type SftpTransferCenterSnapshot,
 } from "../application/state/sftpTransferCenterStore";
 import { transferRuntime } from "../application/state/sftp/transferRuntime";
@@ -355,7 +356,6 @@ function TransferRow({
   const { t } = useI18n();
   const folderReplaceWarningId = React.useId();
   // Optimistic spinner from click until store status moves off paused/interrupted.
-  const [resumeClicked, setResumeClicked] = useState(false);
   const isDirParent = isDirectoryParentTask(task);
   const showCollapsedChildren = isDirParent && shouldShowCollapsedActiveChildren(task.status);
   const activeChildren = useMemo(
@@ -397,22 +397,8 @@ function TransferRow({
   const storeResuming = task.reconnectRequired === true
     && ["pending", "queued", "transferring"].includes(task.status)
     && !task.error;
-  const isResuming = storeResuming
-    || (resumeClicked && ["paused", "interrupted", "attention", "pending", "queued"].includes(task.status) && !task.error);
-  // Clear optimistic click once the store has left the idle-resume surface or failed.
-  useEffect(() => {
-    if (!resumeClicked) return;
-    if (
-      storeResuming
-      || task.status === "transferring"
-      || task.status === "completed"
-      || task.status === "failed"
-      || task.status === "cancelled"
-      || !!task.error
-    ) {
-      setResumeClicked(false);
-    }
-  }, [resumeClicked, storeResuming, task.status, task.error]);
+  const sharedResuming = useSftpTransferResuming(task.id);
+  const isResuming = sharedResuming || storeResuming;
   const canPause = task.resumable !== false && task.status === "transferring" && canControl && !isResuming;
   // Orphaned tasks after app restart (interrupted / attention / paused without a
   // live panel owner) must still expose resume/cancel from the global center.
@@ -467,7 +453,6 @@ function TransferRow({
     }));
   };
   const resumeTask = () => {
-    setResumeClicked(true);
     // Dedicated resume opens vault sessions for local↔remote and SFTP↔SFTP.
     // Only force-open the panel when the row still needs a live owner/adoption
     // (e.g. conflict) — not on every remote-to-remote resume click.

--- a/components/sftp/SftpTransferItem.tsx
+++ b/components/sftp/SftpTransferItem.tsx
@@ -20,10 +20,10 @@ import {
     X,
     XCircle,
 } from 'lucide-react';
-import React, { memo, useEffect, useState } from 'react';
+import React, { memo } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { getParentPath } from '../../application/state/sftp/utils';
-import { useSftpTransferTask } from '../../application/state/sftpTransferCenterStore';
+import { useSftpTransferTask, useSftpTransferResuming } from '../../application/state/sftpTransferCenterStore';
 import { cn } from '../../lib/utils';
 import { TransferTask } from '../../types';
 import {
@@ -136,8 +136,6 @@ const SftpTransferItemInner: React.FC<SftpTransferItemProps> = ({
     // panel setTransfersState for every tick — that re-rendered the whole SFTP
     // tree and pegged the renderer during large copies.
     const task = useSftpTransferTask(propsTask.id, propsTask);
-    // Optimistic spinner from click until store status moves off paused/interrupted.
-    const [resumeClicked, setResumeClicked] = useState(false);
 
     // Same progress model as the global transfer center (done · found for folders).
     const isDirParent = isDirectoryParentTask(task);
@@ -159,21 +157,8 @@ const SftpTransferItemInner: React.FC<SftpTransferItemProps> = ({
     const storeResuming = task.reconnectRequired === true
         && ['pending', 'queued', 'transferring'].includes(task.status)
         && !task.error;
-    const isResuming = storeResuming
-        || (resumeClicked && ['paused', 'interrupted', 'attention', 'pending', 'queued'].includes(task.status) && !task.error);
-    useEffect(() => {
-        if (!resumeClicked) return;
-        if (
-            storeResuming
-            || task.status === 'transferring'
-            || task.status === 'completed'
-            || task.status === 'failed'
-            || task.status === 'cancelled'
-            || !!task.error
-        ) {
-            setResumeClicked(false);
-        }
-    }, [resumeClicked, storeResuming, task.status, task.error]);
+    const sharedResuming = useSftpTransferResuming(task.id);
+    const isResuming = sharedResuming || storeResuming;
     const effectiveSpeed = task.status === 'transferring'
         ? (Number.isFinite(task.speed) && task.speed > 0 ? task.speed : 0)
         : 0;
@@ -417,7 +402,6 @@ const SftpTransferItemInner: React.FC<SftpTransferItemProps> = ({
                         className={actionButtonClass}
                         data-action="resume-transfer"
                         {...oncePerActivationHandlers(() => {
-                            setResumeClicked(true);
                             onResume();
                         })}
                         aria-label={actionAriaLabel(resumeActionLabel)}


### PR DESCRIPTION
## Summary

When a paused download is resumed from the SFTP panel, remote content checks can take time. The panel showed “Reconnecting and resuming…” while the global transfer center still showed “Paused” and offered Resume again. Both views now observe the same pending resume request, including when the transfer center opens after the request starts.

## Type of Change

- [x] Bug fix

## Related Issue (optional)

Found during post-v1.1.82 smoke testing of #3226. No issue closure.

## Changes Made

- Track pending resume feedback in the process-local transfer store, without persisting it or changing transfer checkpoints and lifecycle epochs.
- Replace independent per-component click flags with shared feedback. Clear it on settlement, pause or cancellation; stale requests cannot clear a newer request's marker.
- Add a rendered transfer-center regression and deferred-control tests. Close the virtualization-test popover before removing its DOM environment.

## Screenshots / Demo

Verified in the real `npm run dev` Electron app against an authorized Linux SSH server: upload a dedicated 16 MiB file, download it, pause at 27%, resume from the SFTP panel, then open the global center. Both views show the recovery indicator and the individual duplicate Resume action is absent. After verification the download progresses and completes; all 16,777,216 returned bytes match the source (SHA-256 `5b7a7959d7c3837da2a6bcc8f87d7cc4c9d7b699e4771250890e19a0d0d0b329`). Main checkout restored after testing.

## Testing

- [x] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`; latest touched files also checked)
- [x] Full local suite completed after restoring the worktree's nested plugin-cli dependency: 11,480 passed, 18 environment skips, zero failures. The final non-pending lookup fast path and test teardown cleanup also pass focused checks; current-head CI is pending.
- [x] Generated capability tool specs are updated when applicable — not applicable
- [x] No new console errors or warnings in the exercised app flow

The original rendered regression fails with “Paused”; the repair passes. Related store/component checks passed 117 tests. Latest targeted control, rendered feedback and 1,000-row virtualization checks passed 6 tests. These are correctness checks, not a full rendering-performance benchmark.

## Checklist

- [x] My code follows the existing project style
- [x] I have documented the behavior and validation above
- [x] I have not introduced intentional breaking changes

Scope: row feedback and individual actions. Existing lifecycle-based tab counts and batch eligibility are unchanged. A separate immediate resume/pause ordering case before backend resume begins was observed on both the base and candidate; this PR does not claim to repair that control race. Keeping this PR draft while current-head CI and remaining review are collected. Do not merge as part of the smoke run.
