### PR TITLE
fix(build): correct macOS signing keychain password

### DIFF
--- a/patches/app-builder-lib+26.15.2.patch
+++ b/patches/app-builder-lib+26.15.2.patch
@@ -18,3 +18,27 @@ index c433dbb..1274151 100644
                      }
                      return typeof (e === null || e === void 0 ? void 0 : e.code) === "string" && ["ENOTFOUND", "ETIMEDOUT", "ECONNRESET", "EPIPE", "ENOENT"].includes(e.code);
                  },
+diff --git a/node_modules/app-builder-lib/out/codeSign/macCodeSign.js b/node_modules/app-builder-lib/out/codeSign/macCodeSign.js
+--- a/node_modules/app-builder-lib/out/codeSign/macCodeSign.js
++++ b/node_modules/app-builder-lib/out/codeSign/macCodeSign.js
+@@ -156,16 +156,16 @@
+     if (cscIKeyPassword != null) {
+         cscPasswords.push(cscIKeyPassword);
+     }
+-    return await importCerts(keychainFile, certPaths, cscPasswords);
+-}
+-async function importCerts(keychainFile, paths, keyPasswords) {
++    return await importCerts(keychainFile, certPaths, cscPasswords, keychainPassword);
++}
++async function importCerts(keychainFile, paths, keyPasswords, keychainPassword) {
+     var _a;
+     for (let i = 0; i < paths.length; i++) {
+         const password = (_a = keyPasswords[i]) !== null && _a !== void 0 ? _a : "";
+         await (0, builder_util_1.exec)("/usr/bin/security", ["import", paths[i], "-k", keychainFile, "-T", "/usr/bin/codesign", "-T", "/usr/bin/productbuild", "-P", password]);
+         // https://stackoverflow.com/questions/39868578/security-codesign-in-sierra-keychain-ignores-access-control-settings-and-ui-p
+         // https://github.com/electron-userland/electron-packager/issues/701#issuecomment-322315996
+-        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", password, keychainFile]);
++        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", keychainPassword, keychainFile]);
+     }
+     return {
+         keychainFile,

--- a/scripts/electron-builder-keychain.test.cjs
+++ b/scripts/electron-builder-keychain.test.cjs
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { createRequire } = require('node:module');
+const path = require('node:path');
+const vm = require('node:vm');
+
+test('macOS signing separates temporary keychain and certificate passwords', async () => {
+  const modulePath = require.resolve('app-builder-lib/out/codeSign/macCodeSign.js');
+  const localRequire = createRequire(modulePath);
+  const calls = [];
+  const sandbox = {
+    exports: {},
+    __dirname: path.dirname(modulePath),
+    process: { env: { TRAVIS: 'true' } },
+    require(id) {
+      if (id === 'builder-util') return {
+        exec: async (file, args) => { assert.equal(file, '/usr/bin/security'); calls.push(args); return ''; },
+      };
+      if (id === './codesign') return { importCertificate: async (file) => file };
+      return localRequire(id);
+    },
+  };
+  vm.runInNewContext(readFileSync(modulePath, 'utf8'), sandbox, { filename: modulePath });
+  await sandbox.exports.createKeychain({
+    tmpDir: {}, currentDir: '/signing-test', cscLink: '/app.p12', cscKeyPassword: 'application-password',
+    cscILink: '/installer.p12', cscIKeyPassword: 'installer-password',
+  });
+  const flag = (args, name) => args[args.indexOf(name) + 1];
+  const keychainPassword = flag(calls.find((args) => args[0] === 'create-keychain'), '-p');
+  assert.equal(flag(calls.find((args) => args[0] === 'unlock-keychain'), '-p'), keychainPassword);
+  const partitions = calls.filter((args) => args[0] === 'set-key-partition-list');
+  assert.equal(partitions.length, 2);
+  for (const args of partitions) assert.equal(flag(args, '-k'), keychainPassword);
+  assert.deepEqual(calls.filter((args) => args[0] === 'import').map((args) => flag(args, '-P')), [
+    'application-password', 'installer-password',
+  ]);
+});


### PR DESCRIPTION
## Summary

Release v1.1.83 fails on macOS before signing with `SecKeychainUnlock`: app-builder-lib 26.15.2 passes the certificate import password when macOS asks for the generated temporary keychain password. Backport the three-line upstream correction from https://github.com/electron-userland/electron-builder/pull/10172 into the existing pinned dependency patch.

## Type of Change

- [x] Bug fix
- [x] Build / CI change

## Related Issue (optional)

Failed release run: https://github.com/binaricat/Netcatty/actions/runs/34105240899

## Changes Made

- Thread the generated keychain password into certificate import setup and use it for key partition permissions.
- Keep each certificate's original import password unchanged.
- Preserve the existing download retry patch. No dependency upgrade or credential changes.

## Screenshots / Demo

N/A: release tooling only.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (changed test)
- [x] Focused tests pass: keychain command wiring and existing download retry regression
- [ ] Generated capability tool specs are updated when applicable (not applicable)
- [x] No new console errors or warnings, if this affects app behavior

The new test executes the installed signing module with intercepted OS commands: it fails before the patch and passes afterward, verifies both application/installer certificate passwords, and never accesses real credentials or keychains. A signed release build will provide the final environment validation.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation (upstream provenance above)
- [x] I have not introduced any breaking changes
