### PR TITLE
feat(workspace): search hosts by tag

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -77,7 +77,7 @@ export const enCoreMessages: Messages = {
   'field.selectHosts': 'Select Hosts',
   'placeholder.workspaceName': 'Workspace name',
   'placeholder.sessionName': 'Session name',
-  'placeholder.searchHosts': 'Search hosts...',
+  'placeholder.searchHosts': 'Search hosts or tags...',
   'toast.settingsUnavailable': 'Settings window is unavailable on this platform.',
   'credentials.protectionUnavailable.title': 'Credential Protection Unavailable',
   'credentials.protectionUnavailable.message': 'Saved passwords and keys cannot be auto-decrypted on this device. Re-enter credentials before connecting.',

--- a/application/i18n/locales/es/core.ts
+++ b/application/i18n/locales/es/core.ts
@@ -77,7 +77,7 @@ export const esCoreMessages: Messages = {
   'field.selectHosts': 'Seleccionar hosts',
   'placeholder.workspaceName': 'Nombre del espacio de trabajo',
   'placeholder.sessionName': 'Nombre de la sesión',
-  'placeholder.searchHosts': 'Buscar hosts...',
+  'placeholder.searchHosts': 'Buscar hosts o etiquetas...',
   'toast.settingsUnavailable': 'La ventana de configuración no está disponible en esta plataforma.',
   'credentials.protectionUnavailable.title': 'Protección de credenciales no disponible',
   'credentials.protectionUnavailable.message': 'Las contraseñas y claves guardadas no se pueden descifrar automáticamente en este dispositivo. Vuelve a ingresar las credenciales antes de conectarte.',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -76,7 +76,7 @@ export const ruCoreMessages: Messages = {
   'field.selectHosts': 'Выбрать хосты',
   'placeholder.workspaceName': 'Имя рабочего пространства',
   'placeholder.sessionName': 'Имя сессии',
-  'placeholder.searchHosts': 'Поиск хостов...',
+  'placeholder.searchHosts': 'Поиск хостов или тегов...',
   'toast.settingsUnavailable': 'Окно настроек недоступно на этой платформе.',
   'credentials.protectionUnavailable.title': 'Защита учётных данных недоступна',
   'credentials.protectionUnavailable.message': 'Сохранённые пароли и ключи не могут быть автоматически расшифрованы на этом устройстве. Перед подключением введите учётные данные заново.',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -61,6 +61,7 @@ export const zhCNCoreMessages: Messages = {
   'field.name': '名称',
   'placeholder.workspaceName': '工作区名称',
   'placeholder.sessionName': '会话名称',
+  'placeholder.searchHosts': '搜索主机或标签...',
   'toast.settingsUnavailable': '当前平台无法打开设置窗口。',
   'credentials.protectionUnavailable.title': '凭据保护不可用',
   'credentials.protectionUnavailable.message': '当前设备无法自动解密已保存的密码和密钥。连接前请重新输入凭据。',

--- a/application/i18n/locales/zh-TW/core.ts
+++ b/application/i18n/locales/zh-TW/core.ts
@@ -63,7 +63,7 @@ export const zhTWCoreMessages: Messages = {
   'field.selectHosts': '選擇主機',
   'placeholder.workspaceName': '工作區名稱',
   'placeholder.sessionName': '工作階段名稱',
-  'placeholder.searchHosts': '搜尋主機...',
+  'placeholder.searchHosts': '搜尋主機或標籤...',
   'toast.settingsUnavailable': '目前平台無法開啟設定視窗。',
   'credentials.protectionUnavailable.title': '憑證保護不可用',
   'credentials.protectionUnavailable.message': '目前裝置無法自動解密已儲存的密碼和金鑰。連線前請重新輸入憑證。',

--- a/components/AddToWorkspaceDialog.keyboard.test.ts
+++ b/components/AddToWorkspaceDialog.keyboard.test.ts
@@ -28,6 +28,15 @@ test('checked targets keep a visible background after the cursor moves away', ()
   assert.equal(getWorkspaceTargetRowStateClass(true, true), 'bg-primary/20');
 });
 
+test('workspace host picker search matches tags through the shared matcher', () => {
+  const source = readFileSync(
+    new URL('./workspace/AddToWorkspaceDialog.tsx', import.meta.url),
+    'utf8',
+  );
+  assert.match(source, /matchesWorkspaceHostPickerQuery/);
+  assert.doesNotMatch(source, /h\.label\?\.toLowerCase\(\)\.includes\(term\)/);
+});
+
 test('clicking a target aligns the keyboard cursor with that target', () => {
   const source = readFileSync(
     new URL('./workspace/AddToWorkspaceDialog.tsx', import.meta.url),

--- a/components/CreateWorkspaceDialog.tsx
+++ b/components/CreateWorkspaceDialog.tsx
@@ -1,6 +1,7 @@
 import { Search } from 'lucide-react';
 import React, { useMemo, useState, useEffect, useCallback } from 'react';
 import { useI18n } from '../application/i18n/I18nProvider';
+import { matchesWorkspaceHostPickerQuery } from '../lib/searchMatcher';
 import { Host } from '../types';
 import { DistroAvatar } from './DistroAvatar';
 import { Button } from './ui/button';
@@ -30,13 +31,9 @@ export const CreateWorkspaceDialog: React.FC<CreateWorkspaceDialogProps> = ({
   const [selectedHostIds, setSelectedHostIds] = useState<Set<string>>(new Set());
 
   const filteredHosts = useMemo(() => {
-    if (!search.trim()) return hosts;
-    const term = search.toLowerCase();
-    return hosts.filter(h =>
-      h.label.toLowerCase().includes(term) ||
-      h.hostname.toLowerCase().includes(term) ||
-      (h.group || '').toLowerCase().includes(term)
-    );
+    const term = search.trim();
+    if (!term) return hosts;
+    return hosts.filter((host) => matchesWorkspaceHostPickerQuery(term, host));
   }, [hosts, search]);
 
   const toggleHost = useCallback((hostId: string) => {
@@ -109,7 +106,7 @@ export const CreateWorkspaceDialog: React.FC<CreateWorkspaceDialogProps> = ({
             <div className="relative">
                 <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
                 <Input
-                placeholder={t('placeholder.searchHosts', { defaultValue: 'Search hosts...' })}
+                placeholder={t('placeholder.searchHosts', { defaultValue: 'Search hosts or tags...' })}
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 className="pl-8"

--- a/components/hostPickerVirtualization.test.ts
+++ b/components/hostPickerVirtualization.test.ts
@@ -83,6 +83,7 @@ test('AddToWorkspaceDialog virtualizes and clamps selection on shrink', () => {
   const source = read('workspace/AddToWorkspaceDialog.tsx');
   assert.match(source, /VariableSizeVirtualList/);
   assert.match(source, /data-host-picker-virtual="add-workspace"/);
+  assert.match(source, /matchesWorkspaceHostPickerQuery/);
   assert.match(source, /clampListIndex\(prev, items\.length\)/);
   assert.match(source, /onClick=\{\(\) => handleTargetClick\(idx, LOCAL_ITEM_ID\)\}/);
   assert.match(source, /onClick=\{\(\) => handleTargetClick\(idx, host\.id\)\}/);
@@ -96,6 +97,7 @@ test('CreateWorkspaceDialog virtualizes selectable hosts', () => {
   const source = read('CreateWorkspaceDialog.tsx');
   assert.match(source, /FixedSizeVirtualList/);
   assert.match(source, /data-host-picker-virtual="create-workspace"/);
+  assert.match(source, /matchesWorkspaceHostPickerQuery/);
   assert.doesNotMatch(source, /filteredHosts\.map\(host =>/);
 });
 

--- a/components/workspace/AddToWorkspaceDialog.tsx
+++ b/components/workspace/AddToWorkspaceDialog.tsx
@@ -6,6 +6,7 @@
  */
 import { Check, Search, Terminal } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { matchesWorkspaceHostPickerQuery } from '../../lib/searchMatcher';
 import { Host } from '../../types';
 import { DistroAvatar } from '../DistroAvatar';
 import { Button } from '../ui/button';
@@ -112,14 +113,9 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
   }, [query]);
 
   const filteredHosts = useMemo(() => {
-    const term = query.trim().toLowerCase();
+    const term = query.trim();
     if (!term) return selectableHosts;
-    return selectableHosts.filter((h) =>
-      (h.label?.toLowerCase().includes(term))
-      || (h.hostname?.toLowerCase().includes(term))
-      || (h.username?.toLowerCase().includes(term))
-      || (h.group?.toLowerCase().includes(term)),
-    );
+    return selectableHosts.filter((host) => matchesWorkspaceHostPickerQuery(term, host));
   }, [selectableHosts, query]);
 
   const { items, visualRows, itemIndexToVisualIndex } = useMemo(() => {
@@ -305,7 +301,7 @@ export const AddToWorkspaceDialog: React.FC<AddToWorkspaceDialogProps> = ({
               setSelectedIndex(0);
             }}
             onKeyDown={handleKeyDown}
-            placeholder="Search hosts or local shells..."
+            placeholder="Search hosts, tags, or local shells..."
             className="flex-1 h-8 border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 px-0 text-sm"
           />
           {workspaceTitle && (

--- a/domain/searchMatcher.test.ts
+++ b/domain/searchMatcher.test.ts
@@ -7,6 +7,7 @@ import {
   getHostSearchMatch,
   matchesHostSearchQuery,
   matchesSearchQuery,
+  matchesWorkspaceHostPickerQuery,
   resetPinyinCacheForTests,
 } from "../lib/searchMatcher.ts";
 
@@ -131,6 +132,57 @@ test("host search avoids compact hostname false positives on numeric segments", 
       hostname: "10.6.1.88",
       group: "网络设备",
       tags: [],
+    }),
+    false,
+  );
+});
+
+test("host search matches tags without requiring the label or group", () => {
+  assert.equal(
+    matchesHostSearchQuery("prod", {
+      label: "web-1",
+      hostname: "10.0.0.8",
+      group: "infra",
+      tags: ["prod", "k8s"],
+    }),
+    true,
+  );
+  assert.equal(
+    matchesHostSearchQuery("prod", {
+      label: "web-1",
+      hostname: "10.0.0.8",
+      group: "infra",
+      tags: ["staging"],
+    }),
+    false,
+  );
+});
+
+test("workspace picker search matches tags and usernames", () => {
+  assert.equal(
+    matchesWorkspaceHostPickerQuery("k8s", {
+      label: "api-gateway",
+      hostname: "10.0.0.9",
+      group: "edge",
+      tags: ["k8s", "prod"],
+    }),
+    true,
+  );
+  assert.equal(
+    matchesWorkspaceHostPickerQuery("deploy", {
+      label: "api-gateway",
+      hostname: "10.0.0.9",
+      username: "deploy",
+      tags: [],
+    }),
+    true,
+  );
+  assert.equal(
+    matchesWorkspaceHostPickerQuery("k8s", {
+      label: "api-gateway",
+      hostname: "10.0.0.9",
+      username: "deploy",
+      tags: ["prod"],
     }),
     false,
   );

--- a/lib/searchMatcher.ts
+++ b/lib/searchMatcher.ts
@@ -145,16 +145,31 @@ export function matchesSearchQuery(
  * - "6" / "1" from hostname IP
  * across different fields.
  */
+export type HostSearchLike = {
+  label?: string | null;
+  hostname?: string | null;
+  group?: string | null;
+  username?: string | null;
+  tags?: Array<string | null | undefined> | null;
+};
+
 export function matchesHostSearchQuery(
   query: string,
-  hostLike: {
-    label?: string | null;
-    hostname?: string | null;
-    group?: string | null;
-    tags?: Array<string | null | undefined> | null;
-  },
+  hostLike: HostSearchLike,
 ): boolean {
   return getHostSearchMatch(query, hostLike).matched;
+}
+
+/**
+ * Workspace host pickers (Ctrl+Shift+J create/append) reuse vault host search,
+ * including tags, and keep username as an extra field.
+ */
+export function matchesWorkspaceHostPickerQuery(
+  query: string,
+  hostLike: HostSearchLike,
+): boolean {
+  return matchesHostSearchQuery(query, hostLike)
+    || matchesSearchQuery(query, hostLike.username);
 }
 
 type HostMatchField = "label" | "hostname" | "group" | "tag";
@@ -301,12 +316,7 @@ function evaluateHostFieldGroup(
 
 export function getHostSearchMatch(
   query: string,
-  hostLike: {
-    label?: string | null;
-    hostname?: string | null;
-    group?: string | null;
-    tags?: Array<string | null | undefined> | null;
-  },
+  hostLike: HostSearchLike,
 ): HostSearchMatchResult {
   const normalizedQuery = normalizeText(query);
   if (!normalizedQuery) {


### PR DESCRIPTION
## Summary

Allow workspace host pickers to find hosts by their assigned tags, addressing the Ctrl+Shift+J workflow requested in #3001. Both the active create/append picker and the legacy create-workspace dialog now reuse the shared host search behavior.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #3001

## Changes Made

- Reuse the shared host matcher in both workspace host pickers so labels, hostnames, groups, tags, and usernames remain searchable.
- Update picker placeholders in all supported locales to mention tag search.
- Add focused matcher and picker regression coverage.

## Screenshots / Demo

Open the new-workspace picker with Ctrl+Shift+J (Command+Shift+J on macOS) and enter a host tag; hosts assigned that tag are shown.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [ ] Linting passes (`npm run lint`)
- [x] Tests pass (`node --test --import tsx domain/searchMatcher.test.ts components/AddToWorkspaceDialog.keyboard.test.ts components/hostPickerVirtualization.test.ts`)
- [x] Generated capability tool specs are updated when applicable (not applicable)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [ ] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)