### PR TITLE
docs: add community Scoop installation instructions

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -234,7 +234,11 @@ scoop install lemon/netcatty
 ```powershell
 scoop update
 scoop update netcatty
-# 不要になった場合のアンインストール：
+```
+
+アンインストールする場合：
+
+```powershell
 scoop uninstall netcatty
 ```
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -220,6 +220,26 @@ Windows リリースは未署名の場合があります。
 
 > **macOS ユーザーへ：** 現在のリリースはコード署名と notarization が行われている想定です。Gatekeeper の警告が出る場合は、GitHub Releases から最新版の公式ビルドを取得しているか確認してください。
 
+### Scoop（Windows x64、コミュニティ管理）
+
+[Scoop](https://scoop.sh/) をインストール済みの場合、コミュニティが管理する [lemon バケット](https://github.com/hoilc/scoop-lemon/blob/master/bucket/netcatty.json) から Netcatty をインストールできます。このバケットは Netcatty の公式 GitHub Releases からインストーラーをダウンロードします：
+
+```powershell
+scoop bucket add lemon https://github.com/hoilc/scoop-lemon
+scoop install lemon/netcatty
+```
+
+更新またはアンインストールの前に Netcatty を終了してください：
+
+```powershell
+scoop update
+scoop update netcatty
+# 不要になった場合のアンインストール：
+scoop uninstall netcatty
+```
+
+これはサードパーティ製パッケージであり、Netcatty の公式バケットではありません。更新は GitHub Releases より遅れる場合があります。現在は x64 のみに対応しています。設定は `%APPDATA%\netcatty` に保存され、更新や通常のアンインストール後も残ります。`scoop uninstall netcatty --purge` はこれらの設定も削除します。この方法でインストールした場合は、Scoop で更新を管理してください。
+
 ### Nix / NixOS
 
 Netcatty は Nix および NixOS ユーザー向けに、公式 Linux AppImage リリースをラップした flake を提供しています：

--- a/README.md
+++ b/README.md
@@ -221,6 +221,26 @@ application and integration are complete.
 
 > **macOS Users:** Current releases are expected to be code-signed and notarized. If Gatekeeper still warns, make sure you downloaded the latest official build from GitHub Releases.
 
+### Scoop (Windows x64, community-maintained)
+
+With [Scoop](https://scoop.sh/) installed, you can install Netcatty from the community-maintained [lemon bucket](https://github.com/hoilc/scoop-lemon/blob/master/bucket/netcatty.json), which downloads the installer from Netcatty's official GitHub Releases:
+
+```powershell
+scoop bucket add lemon https://github.com/hoilc/scoop-lemon
+scoop install lemon/netcatty
+```
+
+Exit Netcatty before updating or uninstalling:
+
+```powershell
+scoop update
+scoop update netcatty
+# Uninstall when no longer needed:
+scoop uninstall netcatty
+```
+
+This is a third-party package, not an official Netcatty bucket, and updates may lag behind GitHub Releases. It currently supports x64 only. Settings remain in `%APPDATA%\netcatty` across updates and normal uninstalls; `scoop uninstall netcatty --purge` also deletes those settings. Use Scoop to manage updates for this installation.
+
 ### Nix / NixOS
 
 Netcatty provides a flake that wraps the official Linux AppImage release for Nix and NixOS users:

--- a/README.md
+++ b/README.md
@@ -235,7 +235,11 @@ Exit Netcatty before updating or uninstalling:
 ```powershell
 scoop update
 scoop update netcatty
-# Uninstall when no longer needed:
+```
+
+To uninstall:
+
+```powershell
 scoop uninstall netcatty
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -233,7 +233,11 @@ scoop install lemon/netcatty
 ```powershell
 scoop update
 scoop update netcatty
-# 不再需要时卸载：
+```
+
+卸载：
+
+```powershell
 scoop uninstall netcatty
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -219,6 +219,26 @@ Windows 发布文件可能仍未签名。
 
 > **macOS 用户注意：** 当前发布版本应已完成代码签名和公证。如果 Gatekeeper 仍然提示风险，请确认您下载的是 GitHub Releases 中的最新官方构建。
 
+### Scoop（Windows x64，社区维护）
+
+安装 [Scoop](https://scoop.sh/) 后，可以通过社区维护的 [lemon 软件源](https://github.com/hoilc/scoop-lemon/blob/master/bucket/netcatty.json) 安装 Netcatty。该软件源从 Netcatty 官方 GitHub Releases 下载安装文件：
+
+```powershell
+scoop bucket add lemon https://github.com/hoilc/scoop-lemon
+scoop install lemon/netcatty
+```
+
+更新或卸载前，请先退出 Netcatty：
+
+```powershell
+scoop update
+scoop update netcatty
+# 不再需要时卸载：
+scoop uninstall netcatty
+```
+
+这是第三方软件包，并非 Netcatty 官方软件源，更新可能晚于 GitHub Releases。目前仅支持 x64。设置保存在 `%APPDATA%\netcatty`，更新和普通卸载会保留这些设置；`scoop uninstall netcatty --purge` 还会删除这些设置。通过此方式安装后，请使用 Scoop 管理更新。
+
 ### Nix / NixOS
 
 Netcatty 提供了一个 flake，为 Nix 和 NixOS 用户封装了官方 Linux AppImage 发行版：

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -233,7 +233,11 @@ scoop install lemon/netcatty
 ```powershell
 scoop update
 scoop update netcatty
-# 不再需要時解除安裝：
+```
+
+解除安裝：
+
+```powershell
 scoop uninstall netcatty
 ```
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -219,6 +219,26 @@ Windows 發行檔可能仍未簽章。
 
 > **macOS 使用者請注意：** 目前的發行版本應該都已完成程式碼簽章與公證。如果 Gatekeeper 仍然跳出警告，請確認你下載的是 GitHub Releases 上最新的官方建置版本。
 
+### Scoop（Windows x64，社群維護）
+
+安裝 [Scoop](https://scoop.sh/) 後，可以透過社群維護的 [lemon 軟體來源](https://github.com/hoilc/scoop-lemon/blob/master/bucket/netcatty.json) 安裝 Netcatty。此軟體來源從 Netcatty 官方 GitHub Releases 下載安裝檔：
+
+```powershell
+scoop bucket add lemon https://github.com/hoilc/scoop-lemon
+scoop install lemon/netcatty
+```
+
+更新或解除安裝前，請先結束 Netcatty：
+
+```powershell
+scoop update
+scoop update netcatty
+# 不再需要時解除安裝：
+scoop uninstall netcatty
+```
+
+這是第三方套件，並非 Netcatty 官方軟體來源，更新可能晚於 GitHub Releases。目前僅支援 x64。設定儲存在 `%APPDATA%\netcatty`，更新和一般解除安裝會保留這些設定；`scoop uninstall netcatty --purge` 也會刪除這些設定。透過此方式安裝後，請使用 Scoop 管理更新。
+
 ### Nix / NixOS
 
 Netcatty 提供了一個 flake，替 Nix 與 NixOS 使用者包裝官方的 Linux AppImage 發行版：


### PR DESCRIPTION
## Summary

Document the existing community-maintained Scoop installation for Windows x64 so users can install, update, and uninstall Netcatty through their package manager. Reuse the lemon bucket, which downloads official release artifacts, without adding another bucket or release workflow.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [x] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2773

## Changes Made

- Add Scoop instructions to the English, Simplified Chinese, Traditional Chinese, and Japanese READMEs.
- Identify third-party maintenance, x64 support, possible update delays, and settings retention/purge behavior.
- Keep update and uninstall commands in separate copyable blocks.

## Screenshots / Demo

Documentation only; no application UI changes.

## Testing

- [ ] I have tested these changes locally (`npm run dev`) — not applicable to documentation.
- [x] Linting passes (`npm run lint`) — passed in GitHub CI; duplicate local run stopped under heavy shared-host load.
- [x] Tests pass (`npm test`) — passed in GitHub CI; duplicate local run stopped under heavy shared-host load (details below).
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`) — not applicable.
- [x] No new console errors or warnings, if this affects app behavior — application behavior unchanged.

Verified on 2026-09-12:
- Read #2773 and all comments; no existing Netcatty Scoop PR found. Scoop Main/Extras do not currently contain a Netcatty manifest.
- Read the live [lemon manifest](https://github.com/hoilc/scoop-lemon/blob/master/bucket/netcatty.json) and [bucket usage instructions](https://github.com/hoilc/scoop-lemon#usage). The manifest tracks the current official release v1.1.83.
- Downloaded its official Windows installer and independently computed SHA-256: `2307e81cabb9c7d397cfcbca00842eb2207ad5b563336ce8b99d808d1560b921`, matching both the manifest and GitHub release asset digest.
- Successfully extracted the outer installer with 7-Zip and verified the manifest's inner `$PLUGINSDIR/app-64.7z` archive contains `Netcatty.exe`.
- `git diff --check` passed. Parsed all four Scoop sections with the Markdown parser and checked that installation/update/uninstall blocks are identical and separate.
- 7-Zip 26.02 successfully verified the inner archive entries for `Netcatty.exe` and `resources/app.asar`. The older local p7zip 17.05 cannot decode some bundled ARM64 binaries; the installer hash and current 7-Zip core-entry checks passed.
- [GitHub CI run 34684042511](https://github.com/binaricat/Netcatty/actions/runs/34684042511) passed on da0938c20: lint, generated contract checks, full tests, terminal rendering/performance checks, and production build.
- The shared local host was overloaded during parallel project work. The duplicate local lint/full-test processes were stopped, preserving logs; local performance/time-dependent failures are pending a low-load rerun coordinated separately. No unrelated code was changed.
- Two independent adversarial reviewers completed two rounds. Fixed the combined update/uninstall copy hazard; both final reviews are CLEAN on da0938c20.
- Rechecked both later remote P2 comments against the pinned community manifest and actual updater code. The manifest does supply a purge hook and removes the built-in updater configuration. A focused invocation of the actual updater methods confirmed a missing config fails before provider construction. Both independent reviewers reconfirmed CLEAN; the two remote threads were answered with evidence and resolved as non-issues.
- Validation host is macOS. Windows Scoop installation, launch, update, and uninstall were not executed; artifact and command verification do not claim Windows end-to-end coverage.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
