### PR TITLE
feat(terminal): support Command+Left/Right line navigation on macOS

### DIFF
--- a/components/terminal/runtime/commandArrowLineJump.test.ts
+++ b/components/terminal/runtime/commandArrowLineJump.test.ts
@@ -29,11 +29,13 @@ test("other platforms, keys, modifiers and composition are untouched", () => {
 // This avoids constructing the renderer's WebGL/addon stack in Node.
 const runtime = readFileSync(new URL("./createXTermRuntime.ts", import.meta.url), "utf8");
 const start = runtime.indexOf("    const lineJumpSequence =");
-const end = runtime.indexOf("    // macOS Option+", start);
-assert.ok(start > 0 && end > start);
-const fallback = `(function () { ${runtime.slice(start, end)} return true; })()`;
+const end = runtime.indexOf("    // Autocomplete key handler", start);
+const applyStart = runtime.indexOf("    if (lineJumpSequence && ctx.sessionRef.current)");
+const applyEnd = runtime.indexOf("    // macOS Option+", applyStart);
+assert.ok(start > 0 && end > start && applyEnd > applyStart);
+const fallback = `(function () { ${runtime.slice(start, end)} ${runtime.slice(applyStart, applyEnd)} return true; })()`;
 
-for (const mode of ["shell", "alternate", "kitty", "win32", "disconnected", "non-mac"]) {
+for (const mode of ["shell", "alternate", "kitty", "win32", "disconnected", "non-mac", "password", "sudo-picker"]) {
   test(`runtime Command arrow fallback: ${mode}`, () => {
     const writes: string[] = [];
     let prevented = 0;
@@ -41,7 +43,11 @@ for (const mode of ["shell", "alternate", "kitty", "win32", "disconnected", "non
     const result = runInNewContext(fallback, {
       e: { ...event, preventDefault: () => prevented++, stopPropagation: () => stopped++ },
       term: { buffer: { active: { type: mode === "alternate" ? "alternate" : "normal" } }, modes: { win32InputMode: mode === "win32" } },
-      ctx: { sessionRef: { current: mode === "disconnected" ? null : "session" } },
+      ctx: {
+        sessionRef: { current: mode === "disconnected" ? null : "session" },
+        passwordPromptActiveRef: { current: mode === "password" },
+      },
+      sudoAutofill: { isPromptPending: () => mode === "sudo-picker" },
       kittyKeyboardMode: {},
       isKittyKeyboardModeActive: () => mode === "kitty",
       isMacPlatform: () => mode !== "non-mac",
@@ -56,5 +62,35 @@ for (const mode of ["shell", "alternate", "kitty", "win32", "disconnected", "non
     assert.deepEqual(writes, mode === "shell" ? ["\x01"] : []);
     assert.equal(prevented, mode === "shell" ? 1 : 0);
     assert.equal(stopped, prevented);
+  });
+}
+
+for (const key of ["ArrowLeft", "ArrowRight"]) {
+  test(`Command ${key} bypasses directory autocomplete, bare arrows still navigate it`, () => {
+    const autocompleteEnd = runtime.indexOf("    const kittySequenceForKeyDown =", end);
+    assert.ok(autocompleteEnd > end);
+    const route = `(function () { ${runtime.slice(start, autocompleteEnd)} ${runtime.slice(applyStart, applyEnd)} return true; })()`;
+    for (const metaKey of [true, false]) {
+      let autocompleteCalls = 0;
+      const writes: string[] = [];
+      runInNewContext(route, {
+        e: { ...event, key, metaKey, preventDefault: () => {}, stopPropagation: () => {} },
+        term: { buffer: { active: { type: "normal" } }, modes: {} },
+        ctx: {
+          sessionRef: { current: "session" },
+          // A focused directory panel consumes either arrow.
+          onAutocompleteKeyEvent: () => { autocompleteCalls++; return false; },
+        },
+        sudoAutofill: undefined,
+        kittyKeyboardMode: {},
+        isKittyKeyboardModeActive: () => false,
+        isMacPlatform: () => true,
+        commandArrowLineJumpSequence,
+        handleTerminalInputData: (data: string) => writes.push(data),
+        scrollToBottomAfterInput: () => {},
+      });
+      assert.equal(autocompleteCalls, metaKey ? 0 : 1);
+      assert.deepEqual(writes, metaKey ? [key === "ArrowLeft" ? "\x01" : "\x05"] : []);
+    }
   });
 }

--- a/components/terminal/runtime/commandArrowLineJump.test.ts
+++ b/components/terminal/runtime/commandArrowLineJump.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { runInNewContext } from "node:vm";
+import { commandArrowLineJumpSequence } from "./commandArrowLineJump";
+
+const event = {
+  key: "ArrowLeft", metaKey: true, altKey: false, ctrlKey: false,
+  shiftKey: false, isComposing: false, keyCode: 37,
+};
+
+test("macOS Command arrows send beginning/end-of-line controls", () => {
+  assert.equal(commandArrowLineJumpSequence(event, true), "\x01");
+  assert.equal(commandArrowLineJumpSequence({ ...event, key: "ArrowRight" }, true), "\x05");
+});
+
+test("other platforms, keys, modifiers and composition are untouched", () => {
+  assert.equal(commandArrowLineJumpSequence(event, false), null);
+  for (const override of [
+    { metaKey: false }, { altKey: true }, { ctrlKey: true }, { shiftKey: true },
+    { isComposing: true }, { keyCode: 229 }, { key: "ArrowUp" }, { key: "ArrowDown" },
+    { key: "Home" }, { key: "a" },
+  ]) {
+    assert.equal(commandArrowLineJumpSequence({ ...event, ...override }, true), null);
+  }
+});
+
+// Exercise the runtime fallback itself, including its protocol/screen guards.
+// This avoids constructing the renderer's WebGL/addon stack in Node.
+const runtime = readFileSync(new URL("./createXTermRuntime.ts", import.meta.url), "utf8");
+const start = runtime.indexOf("    const lineJumpSequence =");
+const end = runtime.indexOf("    // macOS Option+", start);
+assert.ok(start > 0 && end > start);
+const fallback = `(function () { ${runtime.slice(start, end)} return true; })()`;
+
+for (const mode of ["shell", "alternate", "kitty", "win32", "disconnected", "non-mac"]) {
+  test(`runtime Command arrow fallback: ${mode}`, () => {
+    const writes: string[] = [];
+    let prevented = 0;
+    let stopped = 0;
+    const result = runInNewContext(fallback, {
+      e: { ...event, preventDefault: () => prevented++, stopPropagation: () => stopped++ },
+      term: { buffer: { active: { type: mode === "alternate" ? "alternate" : "normal" } }, modes: { win32InputMode: mode === "win32" } },
+      ctx: { sessionRef: { current: mode === "disconnected" ? null : "session" } },
+      kittyKeyboardMode: {},
+      isKittyKeyboardModeActive: () => mode === "kitty",
+      isMacPlatform: () => mode !== "non-mac",
+      commandArrowLineJumpSequence,
+      handleTerminalInputData: (data: string) => writes.push(data),
+      scrollToBottomAfterInput: () => {},
+    });
+    assert.equal(result, mode !== "shell");
+    assert.deepEqual(writes, mode === "shell" ? ["\x01"] : []);
+    assert.equal(prevented, mode === "shell" ? 1 : 0);
+    assert.equal(stopped, prevented);
+  });
+}

--- a/components/terminal/runtime/commandArrowLineJump.test.ts
+++ b/components/terminal/runtime/commandArrowLineJump.test.ts
@@ -46,7 +46,10 @@ for (const mode of ["shell", "alternate", "kitty", "win32", "disconnected", "non
       isKittyKeyboardModeActive: () => mode === "kitty",
       isMacPlatform: () => mode !== "non-mac",
       commandArrowLineJumpSequence,
-      handleTerminalInputData: (data: string) => writes.push(data),
+      handleTerminalInputData: (data: string, options: { skipBroadcast: boolean }) => {
+        assert.equal(options.skipBroadcast, true, "a peer TUI must not receive mapped Ctrl+A/E");
+        writes.push(data);
+      },
       scrollToBottomAfterInput: () => {},
     });
     assert.equal(result, mode !== "shell");

--- a/components/terminal/runtime/commandArrowLineJump.ts
+++ b/components/terminal/runtime/commandArrowLineJump.ts
@@ -1,0 +1,11 @@
+/** macOS line editing fallback for shells using readline/ZLE bindings. */
+export function commandArrowLineJumpSequence(
+  e: Pick<KeyboardEvent, "key" | "metaKey" | "altKey" | "ctrlKey" | "shiftKey" | "isComposing" | "keyCode">,
+  isMac: boolean,
+): string | null {
+  if (!isMac || !e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) return null;
+  if (e.isComposing || e.keyCode === 229) return null;
+  if (e.key === "ArrowLeft") return "\x01";
+  if (e.key === "ArrowRight") return "\x05";
+  return null;
+}

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -1959,8 +1959,19 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       return false;
     }
 
+    // Resolve the local shell chord before autocomplete can consume directory
+    // arrows, but apply it only after app/snippet shortcuts below.
+    const lineJumpSequence =
+      term.buffer.active.type === "normal" &&
+      ctx.passwordPromptActiveRef?.current !== true &&
+      !sudoAutofill?.isPromptPending() &&
+      !term.modes.win32InputMode &&
+      !isKittyKeyboardModeActive(kittyKeyboardMode)
+        ? commandArrowLineJumpSequence(e, isMacPlatform())
+        : null;
+
     // Autocomplete key handler (must be checked before other handlers)
-    if (ctx.onAutocompleteKeyEvent && !isKittyKeyboardModeActive(kittyKeyboardMode)) {
+    if (ctx.onAutocompleteKeyEvent && !lineJumpSequence && !isKittyKeyboardModeActive(kittyKeyboardMode)) {
       const consumed = ctx.onAutocompleteKeyEvent(e);
       if (!consumed) return false; // Event was consumed by autocomplete
     }
@@ -2270,12 +2281,6 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
 
     // Keep app/snippet shortcuts and negotiated keyboard protocols ahead of
     // the shell-only macOS line-editing fallback (issue #3139).
-    const lineJumpSequence =
-      term.buffer.active.type === "normal" &&
-      !term.modes.win32InputMode &&
-      !isKittyKeyboardModeActive(kittyKeyboardMode)
-        ? commandArrowLineJumpSequence(e, isMacPlatform())
-        : null;
     if (lineJumpSequence && ctx.sessionRef.current) {
       e.preventDefault();
       e.stopPropagation();

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -2279,7 +2279,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     if (lineJumpSequence && ctx.sessionRef.current) {
       e.preventDefault();
       e.stopPropagation();
-      handleTerminalInputData(lineJumpSequence);
+      // This is a local shell editing shortcut. Peers may be running a TUI
+      // or another keyboard protocol, so do not fan out the mapped Ctrl key.
+      handleTerminalInputData(lineJumpSequence, { skipBroadcast: true });
       scrollToBottomAfterInput(lineJumpSequence);
       return false;
     }

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -91,6 +91,7 @@ import {
 import { installUserCursorPreferenceGuard } from "./cursorPreference";
 import { terminalAltKeyOptions } from "./altKeyOptions";
 import { optionArrowWordJumpSequence } from "./optionArrowWordJump";
+import { commandArrowLineJumpSequence } from "./commandArrowLineJump";
 import { optionYankLastArgSequence } from "./optionYankLastArg";
 import { watchDevicePixelRatio } from "./rendererDprWatch";
 import { dispatchWin32InputModeEvent } from "./win32InputMode";
@@ -2264,6 +2265,22 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
           forwarded.targetSessionIds,
         );
       }
+      return false;
+    }
+
+    // Keep app/snippet shortcuts and negotiated keyboard protocols ahead of
+    // the shell-only macOS line-editing fallback (issue #3139).
+    const lineJumpSequence =
+      term.buffer.active.type === "normal" &&
+      !term.modes.win32InputMode &&
+      !isKittyKeyboardModeActive(kittyKeyboardMode)
+        ? commandArrowLineJumpSequence(e, isMacPlatform())
+        : null;
+    if (lineJumpSequence && ctx.sessionRef.current) {
+      e.preventDefault();
+      e.stopPropagation();
+      handleTerminalInputData(lineJumpSequence);
+      scrollToBottomAfterInput(lineJumpSequence);
       return false;
     }
 


### PR DESCRIPTION
## Summary

On macOS, Command+Left/Right currently does nothing while editing a shell command. Map these two chords to the standard beginning/end-of-line controls in the normal terminal screen.

## Type of Change

- [x] New feature

## Related Issue

Closes #3139

## Changes Made

- Add Command+Left → Ctrl+A and Command+Right → Ctrl+E on macOS.
- Keep application/snippet bindings ahead of the fallback. Leave additional modifiers, composition, other platforms, alternate screens and negotiated Kitty/Win32 keyboard handling unchanged.
- Treat the new line jumps as local editing shortcuts: do not broadcast mapped Ctrl+A/E to peers, whose applications may interpret those keys differently.
- Add 12 focused mapping and runtime tests, including sensitive-input guards, directory-completion routing and the no-broadcast assertion.

## Screenshots / Demo

A visible Electron/xterm window running real Bash and Zsh PTYs with the actual registered keyboard callback verified that Command+Left moved the cursor from column 24 to column 8 (after the prompt), and Command+Right returned to column 24. Each chord emitted exactly one control character. This was an isolated terminal harness, not a full application acceptance run.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [x] No new console errors or warnings, if this affects app behavior

Validation completed on `a0d032ec3`:

- 92 focused keyboard, autocomplete, application-shortcut, broadcast and Kitty protocol tests pass (including the initial 8 new cases).
- Full `npm run lint`, changed-file ESLint and `git diff --check` pass.
- Visible Electron/xterm + real Bash and Zsh checks pass as described above.
- GitHub `lint-and-test` passes on final commit `a0d032ec3c80629a980dcb5381e3b2b7721c778f`, including the full test step, terminal checks and build.
- Two independent local adversarial reviewers completed four rounds; both latest reviews are CLEAN. GitHub Codex identified the broadcast concern, fixed in the final commit. Two subsequent password/autocomplete findings were also fixed. GitHub Codex reviewed final commit `a0d032ec3c` with no major issues. All three earlier review threads are resolved and outdated; no current unresolved threads remain.
- After the final password/autocomplete correction, 50 mapping/runtime/broadcast/autocomplete/global-shortcut tests, changed-file lint and both live shell checks pass.

Local full `npm test` was stopped at the coordinating task's request after host load exceeded 200. Logs retain SFTP performance failures. The broader 984-case terminal run had 973 passes and 11 failures in existing output-queue/capture paths; a separate run confirmed the existing prompt-write assertion also fails independently. These failures involve unchanged files and are left for the coordinating task's low-load baseline verification. The coordinating task subsequently reran 238 SFTP/resume/script/output-pipeline checks in a separate clean Node 24 environment under low load; all passed. Remaining full-suite baseline verification is coordinated centrally. No unrelated fixes were added. No capability changes.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation (behavior and limits above)
- [x] I have not introduced any breaking changes
