### PR TITLE
fix(tabs): reorder session menu to reduce accidental reconnects

### DIFF
--- a/components/top-tabs/SessionTabContextMenuContent.tsx
+++ b/components/top-tabs/SessionTabContextMenuContent.tsx
@@ -43,12 +43,26 @@ export function SessionTabContextMenuContent({
 }: SessionTabContextMenuContentProps) {
   return (
     <ContextMenuContent>
-      <ContextMenuItem
-        disabled={isSessionReconnectDisabled(sessionStatus, reconnectActive)}
-        onClick={() => onReconnectSession(sessionId)}
-      >
-        {t('terminal.menu.reconnect')}
-      </ContextMenuItem>
+      {onCopySession && (
+        <ContextMenuItem onClick={() => onCopySession(sessionId)}>
+          {t('tabs.copyTab')}
+        </ContextMenuItem>
+      )}
+      {onCopySessionToNewWindow && (
+        <ContextMenuItem onClick={() => onCopySessionToNewWindow(sessionId)}>
+          {t('tabs.copyTabToNewWindow')}
+        </ContextMenuItem>
+      )}
+      {onDuplicateSession && (
+        <ContextMenuItem onClick={() => onDuplicateSession(sessionId)}>
+          {t('tabs.duplicateSession')}
+        </ContextMenuItem>
+      )}
+      {onDetachSession && (
+        <ContextMenuItem onClick={() => onDetachSession(sessionId)}>
+          {t('terminal.menu.detach')}
+        </ContextMenuItem>
+      )}
       <ContextMenuItem onClick={() => onRenameSession(sessionId)}>
         {t('common.rename')}
       </ContextMenuItem>
@@ -57,26 +71,12 @@ export function SessionTabContextMenuContent({
           {t('terminal.layer.hostTree.editHost')}
         </ContextMenuItem>
       )}
-      {onCopySession && (
-        <ContextMenuItem onClick={() => onCopySession(sessionId)}>
-          {t('tabs.copyTab')}
-        </ContextMenuItem>
-      )}
-      {onDuplicateSession && (
-        <ContextMenuItem onClick={() => onDuplicateSession(sessionId)}>
-          {t('tabs.duplicateSession')}
-        </ContextMenuItem>
-      )}
-      {onCopySessionToNewWindow && (
-        <ContextMenuItem onClick={() => onCopySessionToNewWindow(sessionId)}>
-          {t('tabs.copyTabToNewWindow')}
-        </ContextMenuItem>
-      )}
-      {onDetachSession && (
-        <ContextMenuItem onClick={() => onDetachSession(sessionId)}>
-          {t('terminal.menu.detach')}
-        </ContextMenuItem>
-      )}
+      <ContextMenuItem
+        disabled={isSessionReconnectDisabled(sessionStatus, reconnectActive)}
+        onClick={() => onReconnectSession(sessionId)}
+      >
+        {t('terminal.menu.reconnect')}
+      </ContextMenuItem>
       <ContextMenuItem className="text-destructive" onClick={() => onCloseSession(sessionId)}>
         {t('common.close')}
       </ContextMenuItem>


### PR DESCRIPTION
## Summary

Move Copy Tab and Copy Tab to New Window to the start of the session menu, and put Reconnect immediately before Close, reducing accidental reconnects when choosing the first item.

## Type of Change

- [x] Other: menu ordering

## Related Issue (optional)

Closes #2326

## Changes Made

- Reorder the shared session menu used by top tabs and the workspace sidebar.
- Preserve all existing optional actions, handlers, and reconnect restrictions.

## Screenshots / Demo

Opened the actual menu component in a local Vite browser fixture (not a full Electron session): Copy Tab, Copy Tab to New Window, Duplicate Session, Move to New Window, Rename, Edit Host, Reconnect, Close. Verified Copy Tab and Close deliver the expected session ID, and Reconnect remains disabled while connecting.

## Testing

- [x] Local browser menu verification
- [x] Linting passes (`npm run lint`)
- [x] Focused existing menu tests pass (3/3)
- [x] Current-head GitHub CI passed: full tests, terminal rendering/performance/throughput checks, lint, generated-contract checks, and build.
- Local full run was stopped after approximately 20 minutes under heavy concurrent test load; several unrelated timing-sensitive tests failed. Logs retained locally; the independent CI full run passed.
- [x] Generated capability tools: not applicable

Two independent read-only reviewers returned CLEAN for this exact change. GitHub Codex also reviewed commit 530f57c95c and reported no major issues; no active review threads remain.

## Checklist

- [x] My code follows the existing project style
- [x] Relevant behavior and verification documented above
- [x] No breaking changes
