### PR TITLE
feat(terminal): save the current rendered screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ If you regularly work with a fleet of servers, Netcatty is built for speed and f
 ### 🖥️ Terminal Workspaces
 - **Split panes** — horizontal and vertical splits for multi-tasking
 - **Session management** — run multiple connections side-by-side
+- **Save current screen** — right-click a terminal to save the visible final text, without replaying keystrokes or overwritten output; scroll first to save an earlier screen.
 - **Inline images** — render Kitty graphics, SIXEL and iTerm inline images from remote programs
 
 ### 📁 SFTP + Built-in Editor

--- a/application/i18n/locales/en/terminal.ts
+++ b/application/i18n/locales/en/terminal.ts
@@ -1,6 +1,8 @@
 import type { Messages } from '../types';
 
 export const enTerminalMessages: Messages = {
+  'terminal.menu.saveScreen': 'Save current screen',
+  'terminal.saveScreen.failed': 'Failed to save terminal screen.',
   'terminal.sudoHint.pressEnter': 'Press Enter to paste saved password',
   'terminal.passwordPicker.title': 'Saved passwords',
   'terminal.passwordPicker.empty': 'No saved passwords',

--- a/application/i18n/locales/es/terminal.ts
+++ b/application/i18n/locales/es/terminal.ts
@@ -1,6 +1,8 @@
 import type { Messages } from '../types';
 
 export const esTerminalMessages: Messages = {
+  'terminal.menu.saveScreen': 'Guardar pantalla actual',
+  'terminal.saveScreen.failed': 'No se pudo guardar la pantalla del terminal.',
   'terminal.sudoHint.pressEnter': 'Presiona Enter para pegar la contraseña guardada',
   'terminal.passwordPicker.title': 'Contraseñas guardadas',
   'terminal.passwordPicker.empty': 'No hay contraseñas guardadas',

--- a/application/i18n/locales/ru/terminal.ts
+++ b/application/i18n/locales/ru/terminal.ts
@@ -1,6 +1,8 @@
 import type { Messages } from '../types';
 
 export const ruTerminalMessages: Messages = {
+  'terminal.menu.saveScreen': 'Сохранить текущий экран',
+  'terminal.saveScreen.failed': 'Не удалось сохранить экран терминала.',
   'terminal.sudoHint.pressEnter': 'Нажмите Enter, чтобы вставить сохранённый пароль',
   'terminal.passwordPicker.title': 'Сохранённые пароли',
   'terminal.passwordPicker.empty': 'Нет сохранённых паролей',

--- a/application/i18n/locales/zh-CN/terminal.ts
+++ b/application/i18n/locales/zh-CN/terminal.ts
@@ -1,6 +1,8 @@
 import type { Messages } from '../types';
 
 export const zhCNTerminalMessages: Messages = {
+  'terminal.menu.saveScreen': '保存当前屏幕',
+  'terminal.saveScreen.failed': '保存终端屏幕失败。',
   'terminal.sudoHint.pressEnter': '按 Enter 粘贴已保存的密码',
   'terminal.passwordPicker.title': '已保存的密码',
   'terminal.passwordPicker.empty': '没有已保存的密码',

--- a/application/i18n/locales/zh-TW/terminal.ts
+++ b/application/i18n/locales/zh-TW/terminal.ts
@@ -1,6 +1,8 @@
 import type { Messages } from '../types';
 
 export const zhTWTerminalMessages: Messages = {
+  'terminal.menu.saveScreen': '儲存目前畫面',
+  'terminal.saveScreen.failed': '儲存終端畫面失敗。',
   'terminal.sudoHint.pressEnter': '按 Enter 貼上已儲存的密碼',
   'terminal.passwordPicker.title': '已儲存的密碼',
   'terminal.passwordPicker.empty': '沒有已儲存的密碼',

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -3377,6 +3377,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const terminalContextActions = useTerminalContextActions({
     termRef,
+    sessionName: sessionDisplayName,
     sourceSessionId: sessionId,
     sessionRef,
     scrollOnPasteRef,

--- a/components/terminal/TerminalContextMenu.tsx
+++ b/components/terminal/TerminalContextMenu.tsx
@@ -49,6 +49,7 @@ export interface TerminalContextMenuProps {
   getMouseTrackingMode?: () => string | undefined;
   /** When true, show the app context menu even while a fullscreen app (tmux/vim) holds mouse tracking. */
   showContextMenuOverFullscreenApps?: boolean;
+  onSaveScreen?: () => void;
   onCopy?: () => void;
   onPaste?: () => void;
   onUploadClipboardImage?: () => void;
@@ -206,6 +207,7 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
   isAlternateScreen = false,
   getMouseTrackingMode,
   showContextMenuOverFullscreenApps = false,
+  onSaveScreen,
   onCopy,
   onPaste,
   onUploadClipboardImage,
@@ -438,6 +440,12 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
 
           <ContextMenuSeparator />
 
+          {onSaveScreen && (
+            <ContextMenuItem onClick={onSaveScreen}>
+              <Download size={14} className="mr-2" />
+              {t('terminal.menu.saveScreen')}
+            </ContextMenuItem>
+          )}
           <ContextMenuItem onClick={onClear}>
             <Trash2 size={14} className="mr-2" />
             {t('terminal.menu.clearBuffer')}

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -582,6 +582,7 @@ function TerminalViewInner({ ctx, isPaneMagnified = false }: { ctx: TerminalView
       isAlternateScreen={hasMouseTracking}
       getMouseTrackingMode={() => termRef.current?.modes.mouseTrackingMode}
       showContextMenuOverFullscreenApps={terminalSettings?.showContextMenuOverFullscreenApps}
+      onSaveScreen={terminalContextActions.onSaveScreen}
       onCopy={terminalContextActions.onCopy}
       onPaste={terminalContextActions.onPaste}
       onUploadClipboardImage={status === "connected" ? terminalContextActions.onUploadClipboardImage : undefined}

--- a/components/terminal/hooks/useTerminalContextActions.ts
+++ b/components/terminal/hooks/useTerminalContextActions.ts
@@ -1,5 +1,5 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import type { RefObject } from "react";
 import { netcattyBridge } from "../../../infrastructure/services/netcattyBridge";
 import { logger } from "../../../lib/logger";
@@ -18,6 +18,10 @@ import {
   selectHistoryPreviewAll,
   findHistoryPreviewOverlay,
 } from "../runtime/terminalHistoryScrollOverride";
+
+import { readTerminalScreenText } from "../terminalContextBuffer";
+import { useI18n } from "../../../application/i18n/I18nProvider";
+import { toast } from "../../ui/toast";
 
 type BroadcastPasteRefs = {
   sourceSessionId: string;
@@ -52,6 +56,7 @@ export const broadcastTerminalPasteData = (
 export const useTerminalContextActions = ({
   termRef,
   sourceSessionId,
+  sessionName,
   sessionRef,
   onHasSelectionChange,
   scrollOnPasteRef,
@@ -71,6 +76,7 @@ export const useTerminalContextActions = ({
   termRef: RefObject<XTerm | null>;
   sourceSessionId: string;
   sessionRef: RefObject<string | null>;
+  sessionName?: string;
   onHasSelectionChange?: (hasSelection: boolean) => void;
   scrollOnPasteRef?: RefObject<boolean>;
   isBroadcastEnabledRef?: RefObject<boolean | undefined>;
@@ -91,6 +97,35 @@ export const useTerminalContextActions = ({
   scrollToBottomAfterProgrammaticInput?: (data: string) => void;
   onClipboardImageUploadResult?: (result: RemoteClipboardImageUploadResult) => void;
 }) => {
+  const { t } = useI18n();
+  const savingScreenRef = useRef(false);
+  const onSaveScreen = useCallback(async () => {
+    const term = termRef.current;
+    if (!term || savingScreenRef.current) return;
+    // Capture before opening the dialog: output may continue while it is open.
+    const preview = findHistoryPreviewOverlay(term.element?.parentElement);
+    const terminalData = preview?.textContent ?? readTerminalScreenText(term);
+    savingScreenRef.current = true;
+    try {
+      const bridge = netcattyBridge.get();
+      if (!bridge?.exportSessionLog) throw new Error("Screen export unavailable");
+      const result = await bridge.exportSessionLog({
+        terminalData,
+        hostLabel: sessionName || "terminal-screen",
+        hostname: "",
+        startTime: Date.now(),
+        format: "txt",
+        plainText: true,
+      });
+      if (!result.success && !result.canceled) throw new Error("Screen export failed");
+    } catch (err) {
+      logger.warn("Failed to save terminal screen", err);
+      toast.error(t("terminal.saveScreen.failed"));
+    } finally {
+      savingScreenRef.current = false;
+    }
+  }, [sessionName, t, termRef]);
+
   const broadcastUserPasteData = useCallback((data: string) => {
     return broadcastTerminalPasteData(data, {
       sourceSessionId,
@@ -239,6 +274,7 @@ export const useTerminalContextActions = ({
   }, [onHasSelectionChange, termRef]);
 
   return {
+    onSaveScreen,
     onCopy,
     onPaste,
     onUploadClipboardImage: supportsRemoteImagePaste ? onUploadClipboardImage : undefined,

--- a/components/terminal/saveTerminalScreen.test.tsx
+++ b/components/terminal/saveTerminalScreen.test.tsx
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+import type { Terminal } from '@xterm/xterm';
+import { useTerminalContextActions } from './hooks/useTerminalContextActions';
+
+test('saving captures the screen before the dialog, prevents duplicate dialogs, and supports preview and cancellation', async () => {
+  const dom = new JSDOM('<div id="root"></div><div id="terminal"></div>', { url: 'http://localhost' });
+  const previous = new Map<string, PropertyDescriptor | undefined>();
+  for (const [key, value] of Object.entries({ window: dom.window, document: dom.window.document, IS_REACT_ACT_ENVIRONMENT: true })) {
+    previous.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+  }
+  const requests: Array<Parameters<NonNullable<NetcattyBridge['exportSessionLog']>>[0]> = [];
+  let finishSave: (result: { success: boolean; canceled?: boolean }) => void = () => {};
+  Object.assign(dom.window, { netcatty: { exportSessionLog: (payload: typeof requests[number]) => {
+    requests.push(payload);
+    return new Promise((resolve) => { finishSave = resolve; });
+  } } });
+  let visibleText = 'corrected';
+  const term = {
+    cols: 80, rows: 1, element: dom.window.document.createElement('div'),
+    buffer: { active: { type: 'normal', viewportY: 0, length: 1,
+      getLine: () => ({ translateToString: () => visibleText }),
+    } },
+  };
+  dom.window.document.getElementById('terminal')!.append(term.element);
+  const termRef = { current: term as unknown as Terminal };
+  let actions!: ReturnType<typeof useTerminalContextActions>;
+  function Harness() {
+    actions = useTerminalContextActions({ termRef, sourceSessionId: 'session', sessionName: 'My terminal',
+      sessionRef: { current: null }, isLocalConnection: true, supportsRemoteImagePaste: false,
+      terminalBackend: { writeToSession() {} },
+    });
+    return null;
+  }
+  const root = createRoot(dom.window.document.getElementById('root')!);
+  try {
+    await act(async () => root.render(<Harness />));
+    const firstSave = actions.onSaveScreen();
+    visibleText = 'later output';
+    await actions.onSaveScreen();
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].terminalData, 'corrected');
+    assert.equal(requests[0].plainText, true);
+    assert.equal(requests[0].hostLabel, 'My terminal');
+    finishSave({ success: false, canceled: true });
+    await firstSave;
+    const preview = dom.window.document.createElement('pre');
+    preview.setAttribute('data-terminal-history-preview', 'true');
+    preview.textContent = 'history\n\n  row';
+    term.element.parentElement!.append(preview);
+    const secondSave = actions.onSaveScreen();
+    assert.equal(requests.length, 2);
+    assert.equal(requests[1].terminalData, 'history\n\n  row');
+    finishSave({ success: true });
+    await secondSave;
+    termRef.current = null as unknown as Terminal;
+    await actions.onSaveScreen();
+    assert.equal(requests.length, 2);
+  } finally {
+    await act(async () => root.unmount());
+    dom.window.close();
+    for (const [key, descriptor] of previous) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+      else Reflect.deleteProperty(globalThis, key);
+    }
+  }
+});

--- a/components/terminal/terminalContextBuffer.test.ts
+++ b/components/terminal/terminalContextBuffer.test.ts
@@ -57,3 +57,26 @@ test("readActiveTerminalBufferTextRange reads the active alternate buffer withou
     "vim title\nfile body\n:",
   );
 });
+
+import { readTerminalScreenText } from "./terminalContextBuffer.ts";
+
+test("screen export follows the scrolled viewport and excludes hidden history", () => {
+  const buffer = { ...createBuffer(["old", "visible one", "  visible two", "newest"]),
+    viewportY: 1, length: 4, type: "normal" };
+  assert.equal(readTerminalScreenText({ cols: 80, rows: 2, buffer: { active: buffer } } as never),
+    "visible one\n  visible two");
+});
+
+test("screen export preserves blank and wrapped physical rows and clips hidden columns", () => {
+  const buffer = { ...createBuffer(["123456", "78", "", "end", ""]),
+    viewportY: 0, length: 5, type: "normal" };
+  assert.equal(readTerminalScreenText({ cols: 4, rows: 5, buffer: { active: buffer } } as never),
+    "1234\n78\n\nend\n");
+});
+
+test("screen export reads only the alternate screen while fullscreen apps are active", () => {
+  const buffer = { ...createBuffer(["vim", "text", ""]),
+    viewportY: 0, length: 3, type: "alternate" };
+  assert.equal(readTerminalScreenText({ cols: 80, rows: 3, buffer: { active: buffer } } as never),
+    "vim\ntext\n");
+});

--- a/components/terminal/terminalContextBuffer.ts
+++ b/components/terminal/terminalContextBuffer.ts
@@ -40,3 +40,13 @@ export function readTerminalBufferTextRange(
   }
   return lines.join("\n");
 }
+
+/** Read the rendered viewport, preserving its physical row boundaries. */
+export function readTerminalScreenText(term: Pick<XTerm, "buffer" | "cols" | "rows">): string {
+  const buffer = term.buffer.active;
+  const startLine = buffer.type === "alternate" ? 0 : buffer.viewportY;
+  return readActiveTerminalBufferTextRange(term, {
+    startLine,
+    endLine: Math.min(buffer.length, startLine + term.rows) - 1,
+  });
+}

--- a/electron/bridges/sessionLogsBridge.cjs
+++ b/electron/bridges/sessionLogsBridge.cjs
@@ -217,7 +217,7 @@ function terminalDataToHtml(terminalData, hostLabel, timestamp) {
 async function exportSessionLog(event, payload) {
   const { terminalData, hostLabel, hostname, startTime, format } = payload;
 
-  if (!terminalData) {
+  if (!terminalData && !(payload.plainText === true && terminalData === "")) {
     throw new Error("No terminal data to export");
   }
 
@@ -248,13 +248,15 @@ async function exportSessionLog(event, payload) {
   const actualFormat = path.extname(result.filePath).slice(1) || format;
 
   if (actualFormat === "html") {
-    content = terminalDataToHtml(terminalData, hostLabel, startTime);
+    content = payload.plainText === true
+      ? terminalPlainTextToHtml(terminalData, hostLabel, startTime)
+      : terminalDataToHtml(terminalData, hostLabel, startTime);
   } else if (actualFormat === "log" || actualFormat === "raw") {
     // Raw format preserves ANSI codes
     content = terminalData;
   } else {
     // Plain text - apply terminal text controls and remove escape sequences
-    content = terminalDataToPlainText(terminalData);
+    content = payload.plainText === true ? terminalData : terminalDataToPlainText(terminalData);
   }
 
   await fs.promises.writeFile(result.filePath, content, "utf8");

--- a/electron/bridges/sessionLogsBridge.test.cjs
+++ b/electron/bridges/sessionLogsBridge.test.cjs
@@ -961,3 +961,43 @@ test("all light-mode ANSI foregrounds remain readable on the default background"
   }
   assert.match(html, /color: var\(--term-custom-ffffff, #ffffff\)[^>]*>white/);
 });
+
+test("screen export preserves rendered rows exactly, including empty screens", async () => {
+  fs.mkdirSync(TEMP_ROOT, { recursive: true });
+  const directory = fs.mkdtempSync(path.join(TEMP_ROOT, "screen-export-"));
+  const filePath = path.join(directory, "screen.txt");
+  const { exportSessionLog } = loadBridgeWithDialog({
+    showSaveDialog: async () => ({ canceled: false, filePath }),
+  });
+  try {
+    for (const terminalData of ["  中文 😀\n\nend\n\n", ""]) {
+      const result = await exportSessionLog(null, {
+        terminalData, plainText: true, hostLabel: "screen", startTime: Date.now(), format: "txt",
+      });
+      assert.equal(result.success, true);
+      assert.equal(fs.readFileSync(filePath, "utf8"), terminalData);
+    }
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("screen export escapes HTML when the user selects an HTML filename", async () => {
+  fs.mkdirSync(TEMP_ROOT, { recursive: true });
+  const directory = fs.mkdtempSync(path.join(TEMP_ROOT, "screen-html-"));
+  const filePath = path.join(directory, "screen.html");
+  const { exportSessionLog } = loadBridgeWithDialog({
+    showSaveDialog: async () => ({ canceled: false, filePath }),
+  });
+  try {
+    await exportSessionLog(null, {
+      terminalData: "<script>alert(1)</script>\n\n", plainText: true,
+      hostLabel: "screen", startTime: Date.now(), format: "txt",
+    });
+    const html = fs.readFileSync(filePath, "utf8");
+    assert.ok(html.includes("&lt;script&gt;alert(1)&lt;/script&gt;\n\n"));
+    assert.ok(!html.includes("<script>"));
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/types/global/netcatty-bridge-files.d.ts
+++ b/types/global/netcatty-bridge-files.d.ts
@@ -80,6 +80,8 @@ declare global {
 
     // Session Logs
     exportSessionLog?(payload: {
+      /** Already rendered screen text; preserve row boundaries without replaying controls. */
+      plainText?: boolean;
       terminalData: string;
       hostLabel: string;
       hostname: string;


### PR DESCRIPTION
## Summary

Adds **Save current screen** to the terminal context menu. It saves the visible rendered text at the moment the action is selected, so corrected input and overwritten progress lines appear only in their final form. Scrolling selects which screen is saved; fullscreen applications and the terminal history preview are supported.

## Type of Change

- [x] New feature

## Related Issue (optional)

Closes #3273

## Changes Made

- Reuse the existing terminal buffer reader and session-log export dialog.
- Capture the screen before opening the dialog, preserve physical rows and blank lines, and guard against duplicate save dialogs.
- Add localized menu and failure messages. Existing session log exports retain their behavior.

## Screenshots / Demo

Right-click a terminal and select **Save current screen**, then choose a destination. The file contains the currently visible final text rather than the raw output history. Browser menu interactions were exercised successfully; screenshot capture repeatedly timed out in the local browser tool.

## Testing

- [x] Focused buffer, export and action tests pass (36 tests), covering scrolled/alternate screens, empty rows, Unicode, HTML escaping, cancellation and snapshot timing.
- [x] Browser UI checks using the actual xterm, context menu and save-action components: corrected input, overwritten progress, Unicode, scrolling and alternate screens. All three captured UI payloads were then exported through the existing main-process bridge to real text files and matched byte-for-byte. Native save dialogs were mocked for repeatable validation.
- [x] Linting passes (`npm run lint`)
- [x] Full test suite, terminal rendering/performance/throughput checks, lint and build passed in GitHub CI: https://github.com/binaricat/Netcatty/actions/runs/34684520901
- Local full suite was stopped on coordinator request during severe shared-host load; five unrelated large-history timing assertions exceeded their limits before stopping. Focused local checks and the complete CI suite passed. A subsequent coordinator-run low-load retest in an isolated directory with fresh dependencies and Node 24 passed all 238 tests across sftpTransferCenterStore, dedicatedTransferResume, scriptRuntime, scriptBridge and terminalOutputPipeline. No unrelated product changes were needed.
- [x] Build passes (`npm run build`)
- [x] Generated capability tool specs are updated when applicable (not applicable)

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes

Two rounds of two independent local adversarial reviews found no actionable issues; the final round reviewed d8761c156. GitHub Codex also reported no major issues on that same commit, with no active review threads. The complete CI run passed on the same commit. Leave this PR open; do not merge as part of this task.

