### PR TITLE
feat: add optional IP sorting for vault hosts

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -56,6 +56,7 @@ export const enCoreMessages: Messages = {
   'sort.newest': 'Newest to oldest',
   'sort.oldest': 'Oldest to newest',
   'sort.group': 'By group',
+  'sort.ip': 'By IP',
   'field.label': 'Label',
   'field.type': 'Type',
   'auth.keyType': 'Type {type}',

--- a/application/i18n/locales/es/core.ts
+++ b/application/i18n/locales/es/core.ts
@@ -55,6 +55,7 @@ export const esCoreMessages: Messages = {
   'sort.za': 'Z-a',
   'sort.newest': 'Más reciente a más antiguo',
   'sort.oldest': 'Más antiguo a más reciente',
+  'sort.ip': 'Por IP',
   'sort.group': 'Por grupo',
   'field.label': 'Etiqueta',
   'field.type': 'Tipo',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -55,6 +55,7 @@ export const ruCoreMessages: Messages = {
   'sort.newest': 'Сначала новые',
   'sort.oldest': 'Сначала старые',
   'sort.group': 'По группе',
+  'sort.ip': 'По IP',
   'field.label': 'Метка',
   'field.type': 'Тип',
   'auth.keyType': 'Тип {type}',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -42,6 +42,7 @@ export const zhCNCoreMessages: Messages = {
   'sort.newest': '从新到旧',
   'sort.oldest': '从旧到新',
   'sort.group': '按分组',
+  'sort.ip': '按 IP',
   'field.label': 'Label',
   'field.type': '类型',
   'auth.keyType': '类型 {type}',

--- a/application/i18n/locales/zh-TW/core.ts
+++ b/application/i18n/locales/zh-TW/core.ts
@@ -42,6 +42,7 @@ export const zhTWCoreMessages: Messages = {
   'sort.newest': '從新到舊',
   'sort.oldest': '從舊到新',
   'sort.group': '依群組',
+  'sort.ip': '依 IP',
   'field.label': 'Label',
   'field.type': '型別',
   'auth.keyType': '型別 {type}',

--- a/components/HostTreeView.test.tsx
+++ b/components/HostTreeView.test.tsx
@@ -478,3 +478,20 @@ test("HostTreeView announces sibling position within each tree level", () => {
   assert.equal(byKey.get("host:host-c")?.posInSet, 1);
   assert.equal(byKey.get("host:host-c")?.setSize, 1);
 });
+
+test("HostTreeView IP sorting stays inside each group and leaves manual order intact", () => {
+  const pair = (prefix: string, group = ""): Host[] => [
+    { ...baseHost, id: `${prefix}-ten`, label: "Alpha", hostname: "10.0.0.10", group, order: 1 },
+    { ...baseHost, id: `${prefix}-two`, label: "Zulu", hostname: "10.0.0.2", group, order: 2 },
+  ];
+  const groupTree: GroupNode[] = [{
+    name: "prod", path: "prod", hosts: pair("prod", "prod"),
+    children: { east: { name: "east", path: "prod/east", hosts: pair("east", "prod/east"), children: {} } },
+  }];
+  const options = {
+    groupTree, ungroupedHosts: pair("root"), expandedPaths: new Set(["prod", "prod/east"]), groupConfigs: [],
+  };
+  const keys = (sortMode: "ip" | "manual") => buildVisibleHostTreeItems({ ...options, sortMode }).map(item => item.key);
+  assert.deepEqual(keys("ip"), ["group:prod", "group:prod/east", "host:east-two", "host:east-ten", "host:prod-two", "host:prod-ten", "host:root-two", "host:root-ten"]);
+  assert.deepEqual(keys("manual"), ["group:prod", "group:prod/east", "host:east-ten", "host:east-two", "host:prod-ten", "host:prod-two", "host:root-ten", "host:root-two"]);
+});

--- a/components/HostTreeView.tsx
+++ b/components/HostTreeView.tsx
@@ -1,3 +1,4 @@
+import { compareHostAddresses } from "../domain/hostAddressSort";
 import { CheckSquare, Edit2, FileSymlink, Server, Square, Expand, Minimize2 } from 'lucide-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -39,7 +40,7 @@ const getTreeGroupDropIntent = (
 const hasDragType = (dataTransfer: DataTransfer, type: string) =>
   Array.from(dataTransfer.types).includes(type);
 
-type HostTreeSortMode = 'manual' | 'az' | 'za' | 'newest' | 'oldest' | 'group';
+type HostTreeSortMode = 'manual' | 'az' | 'za' | 'newest' | 'oldest' | 'group' | 'ip';
 
 export type VisibleHostTreeItem =
   | {
@@ -90,6 +91,7 @@ const sortHostTreeHosts = (hosts: Host[], sortMode: HostTreeSortMode): Host[] =>
     if (sortMode === 'newest') return (b.createdAt || 0) - (a.createdAt || 0);
     if (sortMode === 'oldest') return (a.createdAt || 0) - (b.createdAt || 0);
     if (sortMode === 'manual') return 0;
+    if (sortMode === 'ip') return compareHostAddresses(a.hostname, b.hostname) || a.label.localeCompare(b.label);
     return a.label.localeCompare(b.label);
   });
   return sortMode === 'manual' ? sortByVaultOrder(sorted) : sorted;

--- a/components/PortForwardingNew.tsx
+++ b/components/PortForwardingNew.tsx
@@ -880,7 +880,7 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
             <SortDropdown
               value={sortMode}
               onChange={(mode) => {
-                if (mode !== "group") setSortMode(mode);
+                if (mode !== "group" && mode !== "ip") setSortMode(mode);
               }}
               modes={["manual", "az", "za", "newest", "oldest"]}
               className={vaultHeaderIconButtonClass}

--- a/components/SelectHostPanelContent.tsx
+++ b/components/SelectHostPanelContent.tsx
@@ -1,3 +1,4 @@
+import { compareHostAddresses } from "../domain/hostAddressSort";
 import {
   Check,
   CheckSquare,
@@ -200,6 +201,8 @@ export const SelectHostPanelContent: React.FC<SelectHostPanelContentProps> = ({
 
     result = [...result].sort((a, b) => {
       switch (sortMode) {
+        case 'ip':
+          return compareHostAddresses(a.hostname, b.hostname) || a.label.localeCompare(b.label);
         case 'az':
           return a.label.localeCompare(b.label);
         case 'za':

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -1738,6 +1738,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
                 value={sortMode}
                 onChange={setSortMode}
                 className={vaultHeaderIconButtonClass}
+                modes={['manual', 'az', 'za', 'newest', 'oldest', 'group']}
               />
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/components/VaultView.sortPersistence.test.tsx
+++ b/components/VaultView.sortPersistence.test.tsx
@@ -162,3 +162,12 @@ test("Hosts manual sort mode uses saved order", () => {
 
   assert.ok(markup.indexOf("Zulu Host") < markup.indexOf("Alpha Host"));
 });
+
+test("Hosts IP sort is restored and compares octets instead of labels", () => {
+  const markup = renderVault("ip", [
+    { ...host("ten", "Alpha Ten", 1), hostname: "10.0.0.10" },
+    { ...host("two", "Zulu Two", 2), hostname: "10.0.0.2" },
+  ]);
+  assert.ok(markup.includes("Zulu Two"));
+  assert.ok(markup.indexOf("Zulu Two") < markup.indexOf("Alpha Ten"));
+});

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -207,7 +207,8 @@ const isSortMode = (value: string): value is SortMode =>
   value === "za" ||
   value === "newest" ||
   value === "oldest" ||
-  value === "group";
+  value === "group" ||
+  value === "ip";
 
 // Props without isActive - it's now subscribed internally
 interface VaultViewProps {

--- a/components/ui/sort-dropdown.tsx
+++ b/components/ui/sort-dropdown.tsx
@@ -1,10 +1,10 @@
-import { Calendar,CalendarClock,Check,ChevronDown,ChevronUp,FolderTree,GripVertical,SortAsc,SortDesc } from 'lucide-react';
+import { Calendar,CalendarClock,Check,ChevronDown,ChevronUp,FolderTree,GripVertical,Network,SortAsc,SortDesc } from 'lucide-react';
 import React from 'react';
 import { useI18n } from "../../application/i18n/I18nProvider";
 import { Button } from './button';
 import { Dropdown,DropdownContent,DropdownTrigger } from './dropdown';
 
-export type SortMode = 'manual' | 'az' | 'za' | 'newest' | 'oldest' | 'group';
+export type SortMode = 'manual' | 'az' | 'za' | 'newest' | 'oldest' | 'group' | 'ip';
 
 const SORT_OPTIONS: Record<SortMode, { labelKey: string; icon: React.ReactElement; triggerIcon: React.ReactElement }> = {
     manual: { labelKey: 'sort.manual', icon: <GripVertical className="w-4 h-4 shrink-0" />, triggerIcon: <GripVertical className="w-4 h-4" /> },
@@ -13,6 +13,7 @@ const SORT_OPTIONS: Record<SortMode, { labelKey: string; icon: React.ReactElemen
     newest: { labelKey: 'sort.newest', icon: <Calendar className="w-4 h-4 shrink-0" />, triggerIcon: <Calendar className="w-4 h-4" /> },
     oldest: { labelKey: 'sort.oldest', icon: <CalendarClock className="w-4 h-4 shrink-0" />, triggerIcon: <CalendarClock className="w-4 h-4" /> },
     group: { labelKey: 'sort.group', icon: <FolderTree className="w-4 h-4 shrink-0" />, triggerIcon: <FolderTree className="w-4 h-4" /> },
+    ip: { labelKey: 'sort.ip', icon: <Network className="w-4 h-4 shrink-0" />, triggerIcon: <Network className="w-4 h-4" /> },
 };
 
 interface SortDropdownProps {

--- a/components/vault/useVaultHostCollections.tsx
+++ b/components/vault/useVaultHostCollections.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo } from "react";
 
+import { compareHostAddresses } from "../../domain/hostAddressSort";
 import { upsertKnownHost } from "../../domain/knownHosts";
 import { sortByVaultOrder, sortVaultStringsByOrder } from "../../domain/vaultOrder";
 import { matchesHostSearchQuery, matchesSearchQuery } from "../../lib/searchMatcher";
@@ -122,6 +123,10 @@ export function useVaultHostCollections({
           const groupB = b.group || "";
           const groupCmp = groupA.localeCompare(groupB);
           return groupCmp !== 0 ? groupCmp : a.label.localeCompare(b.label);
+        }
+        case "ip": {
+          const addrCmp = compareHostAddresses(a.hostname, b.hostname);
+          return addrCmp !== 0 ? addrCmp : a.label.localeCompare(b.label);
         }
         default:
           return 0;

--- a/domain/hostAddressSort.test.ts
+++ b/domain/hostAddressSort.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { compareHostAddresses } from "./hostAddressSort.ts";
+
+test("compareHostAddresses sorts IPv4 numerically", () => {
+  const addresses = ["10.0.0.10", "10.0.0.2", "192.168.1.1", "10.0.0.1"];
+  const sorted = [...addresses].sort(compareHostAddresses);
+  assert.deepEqual(sorted, ["10.0.0.1", "10.0.0.2", "10.0.0.10", "192.168.1.1"]);
+});
+
+test("compareHostAddresses places IPv4 before hostnames", () => {
+  assert.ok(compareHostAddresses("10.0.0.1", "db.example.com") < 0);
+  assert.ok(compareHostAddresses("db.example.com", "10.0.0.1") > 0);
+});
+
+test("compareHostAddresses sorts hostnames with numeric awareness", () => {
+  const names = ["host10.example.com", "host2.example.com", "host1.example.com"];
+  const sorted = [...names].sort(compareHostAddresses);
+  assert.deepEqual(sorted, [
+    "host1.example.com",
+    "host2.example.com",
+    "host10.example.com",
+  ]);
+});
+
+test("compareHostAddresses treats equal addresses as equal", () => {
+  assert.equal(compareHostAddresses("10.0.0.1", "10.0.0.1"), 0);
+  assert.equal(compareHostAddresses(" 10.0.0.1 ", "10.0.0.1"), 0);
+});

--- a/domain/hostAddressSort.test.ts
+++ b/domain/hostAddressSort.test.ts
@@ -28,3 +28,16 @@ test("compareHostAddresses treats equal addresses as equal", () => {
   assert.equal(compareHostAddresses("10.0.0.1", "10.0.0.1"), 0);
   assert.equal(compareHostAddresses(" 10.0.0.1 ", "10.0.0.1"), 0);
 });
+
+test("compareHostAddresses sorts IPv6 hexadecimal words numerically", () => {
+  assert.deepEqual(["2001:db8::10", "2001:db8::f", "2001:db8::2"].sort(compareHostAddresses), ["2001:db8::2", "2001:db8::f", "2001:db8::10"]);
+  assert.equal(compareHostAddresses("[2001:db8::f]", "2001:0db8:0:0:0:0:0:000f"), 0);
+  assert.equal(compareHostAddresses("fe80::1%eth0", "fe80::1%eth1"), 0);
+  assert.equal(compareHostAddresses("::ffff:192.0.2.1", "::ffff:c000:201"), 0);
+  assert.ok(compareHostAddresses("::", "::1") < 0);
+});
+
+test("compareHostAddresses orders mixed address families before hostnames", () => {
+  assert.deepEqual(["host2", "2001:db8::1", "10.0.0.2", "host1", "::1"].sort(compareHostAddresses), ["10.0.0.2", "::1", "2001:db8::1", "host1", "host2"]);
+  assert.ok(compareHostAddresses("::1", "not:an:ip") < 0);
+});

--- a/domain/hostAddressSort.ts
+++ b/domain/hostAddressSort.ts
@@ -1,0 +1,41 @@
+/**
+ * Compare host address strings for vault list sorting.
+ * IPv4 addresses sort numerically; everything else falls back to
+ * case-insensitive numeric-aware string compare. IPv4 sorts before
+ * non-IPv4 so mixed lists stay predictable.
+ */
+export function compareHostAddresses(left: string, right: string): number {
+  const a = (left || "").trim().toLowerCase();
+  const b = (right || "").trim().toLowerCase();
+  if (a === b) return 0;
+
+  const aV4 = parseIPv4Octets(a);
+  const bV4 = parseIPv4Octets(b);
+
+  if (aV4 && bV4) {
+    for (let i = 0; i < 4; i += 1) {
+      if (aV4[i] !== bV4[i]) return aV4[i] - bV4[i];
+    }
+    return 0;
+  }
+  if (aV4) return -1;
+  if (bV4) return 1;
+
+  return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" });
+}
+
+function parseIPv4Octets(value: string): number[] | null {
+  const parts = value.split(".");
+  if (parts.length !== 4) return null;
+
+  const octets: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const n = Number(part);
+    if (!Number.isInteger(n) || n < 0 || n > 255) return null;
+    // Reject leading zeros like "01" except a single "0"
+    if (part.length > 1 && part.startsWith("0")) return null;
+    octets.push(n);
+  }
+  return octets;
+}

--- a/domain/hostAddressSort.ts
+++ b/domain/hostAddressSort.ts
@@ -1,8 +1,8 @@
 /**
  * Compare host address strings for vault list sorting.
- * IPv4 addresses sort numerically; everything else falls back to
- * case-insensitive numeric-aware string compare. IPv4 sorts before
- * non-IPv4 so mixed lists stay predictable.
+ * IPv4 and IPv6 addresses sort numerically; hostnames fall back to
+ * case-insensitive numeric-aware string compare. Mixed lists sort
+ * IPv4 first, then IPv6, then hostnames.
  */
 export function compareHostAddresses(left: string, right: string): number {
   const a = (left || "").trim().toLowerCase();
@@ -21,6 +21,17 @@ export function compareHostAddresses(left: string, right: string): number {
   if (aV4) return -1;
   if (bV4) return 1;
 
+  const aV6 = parseIPv6Words(a);
+  const bV6 = parseIPv6Words(b);
+  if (aV6 && bV6) {
+    for (let i = 0; i < 8; i += 1) {
+      if (aV6[i] !== bV6[i]) return aV6[i] - bV6[i];
+    }
+    return 0;
+  }
+  if (aV6) return -1;
+  if (bV6) return 1;
+
   return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" });
 }
 
@@ -38,4 +49,22 @@ function parseIPv4Octets(value: string): number[] | null {
     octets.push(n);
   }
   return octets;
+}
+
+function parseIPv6Words(value: string): number[] | null {
+  // Let the platform URL parser validate/canonicalize compressed and IPv4-mapped
+  // IPv6. Zone identifiers identify an interface, not part of the IP value.
+  const unwrapped = value.startsWith("[") && value.endsWith("]") ? value.slice(1, -1) : value;
+  const address = unwrapped.split("%")[0];
+  if (!address.includes(":") || !/^[0-9a-f:.]+$/.test(address)) return null;
+  try {
+    const canonical = new URL(`http://[${address}]/`).hostname.slice(1, -1);
+    const [left, right] = canonical.split("::");
+    const head = left ? left.split(":") : [];
+    const tail = right ? right.split(":") : [];
+    const words = right === undefined ? head : [...head, ...Array(8 - head.length - tail.length).fill("0"), ...tail];
+    return words.map(word => parseInt(word, 16));
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary
Add an optional "By IP" sort choice for vault hosts, including hosts within nested groups. IPv4 and IPv6 addresses sort numerically (10.0.0.2 before 10.0.0.10 and 2001:db8::f before 2001:db8::10); hostnames use natural text ordering. Existing default and saved manual order stay unchanged.

## Type of Change
- [x] New feature

## Related Issue (optional)
Closes #2450. Reuses and adapts the implementation from closed, unmerged #2451.

## Changes Made
- Reuse the shared sorting menu in vault and host selection views, and persist the vault selection.
- Apply the same comparison within each tree group without mixing groups.
- Keep the IP option out of snippets, known hosts and forwarding menus.
- Cover numeric ordering, saved selection, nested group boundaries and manual order.

## Screenshots / Demo
Select By IP from the host sort menu. Hosts 10.0.0.10 and 10.0.0.2 appear as 10.0.0.2, 10.0.0.10. Switch back to Manual to restore saved order. Browser interaction verified numeric IPv4 ordering, persisted IP selection and restoration of the saved manual order, and expanded nested-tree ordering using isolated sample data and a mocked desktop startup bridge.

## Testing
- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`) — full suite passed in GitHub CI
- [ ] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

24 focused tests and 22 locale tests passed. Local lint and production build passed. Two independent reviewers re-reviewed the latest head and reported CLEAN; online feedback about Spanish translation and IPv6 ordering was fixed.

Full local npm test was stopped on coordinator request due extreme shared-host load; timing failures in unrelated transfer/terminal tests were retained for a consolidated low-load run. Full tsc reports existing errors across the repository (including unchanged component lines); no clean typecheck claim. Latest-head GitHub CI passed: full tests, terminal background rendering, both keyword performance checks and production build (run 34685019706). GitHub Codex also reported clean for 0714ca5ee. Browser screenshots could not be captured (captureScreenshot timed out); menu actions and rendered tree text were verified.

## Checklist
- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
