### PR TITLE
fix(sftp): reuse terminal login with an unsaved password

### DIFF
--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -2811,6 +2811,7 @@ test("startSSH enables sudo autofill only with the host saved password", async (
 test("startSSH does not use unsaved retry passwords for sudo autofill", async () => {
   let onData: ((data: string) => void) | null = null;
   const sent: string[] = [];
+  let captured: NetcattySSHOptions | undefined;
   const terminalBackend = {
     backendAvailable: () => true,
     telnetAvailable: () => true,
@@ -2818,7 +2819,7 @@ test("startSSH does not use unsaved retry passwords for sudo autofill", async ()
     localAvailable: () => true,
     serialAvailable: () => true,
     execAvailable: () => true,
-    startSSHSession: async () => "ssh-session",
+    startSSHSession: async (options: NetcattySSHOptions) => { captured = options; return "ssh-session"; },
     startTelnetSession: async () => "telnet-session",
     startMoshSession: async () => "mosh-session",
     startLocalSession: async () => "local-session",
@@ -2856,6 +2857,18 @@ test("startSSH does not use unsaved retry passwords for sudo autofill", async ()
   onData?.("[sudo] password for alice: ");
 
   assert.deepEqual(sent, []);
+  assert.equal(captured?.password, "temporary-secret");
+  assert.equal(captured?.sftpReuseOptions?.hostId, "host-1");
+  assert.equal(captured?.sftpReuseOptions?.password, undefined);
+  assert.equal(JSON.stringify(captured?.sftpReuseOptions).includes("temporary-secret"), false);
+  assert.equal("password" in ctx.host, false);
+
+  // An unreadable saved credential must not block a manual password override.
+  Object.assign(ctx.host, { password: ENCRYPTED_CREDENTIAL_PLACEHOLDER });
+  captured = undefined;
+  await createTerminalSessionStarters(ctx as never).startSSH(createTermStub() as never);
+  assert.equal(captured?.password, "temporary-secret");
+  assert.equal(captured?.sftpReuseOptions, undefined);
 });
 
 test("startSSH uses pending saved auth for sudo autofill on the first saved connection", async () => {

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -60,6 +60,7 @@ import { hasConnectionPassedTcpDial } from "../connectionTimeouts";
 import { resolveHostSshConnectionTimeouts } from "../../../domain/sshConnectionTimeouts";
 import { isPluginHostProtocol, sanitizePluginConnection } from "../../../domain/pluginConnection";
 import { hydrateVaultStoredKeys } from "../../../infrastructure/persistence/secureFieldAdapter";
+import { buildSftpHostCredentials } from "../../../application/state/sftp/useSftpHostCredentials";
 
 const collectConnectKeyIds = (
   host: Host,
@@ -647,6 +648,23 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
         );
         const connectionTimeouts = resolveHostSshConnectionTimeouts(ctx.host);
         const requiresFreshSshConnection = ctx.shouldUseFreshSshConnection?.() === true;
+        // Keep the original profile identity for SFTP borrowing when the user
+        // supplies a password for this terminal only. Never persist that password.
+        let sftpReuseOptions: NetcattySSHOptions | undefined;
+        if (pendingAuth?.authMethod === "password" && !pendingAuth.savedToHost) {
+          try {
+            sftpReuseOptions = buildSftpHostCredentials({
+              host: ctx.host,
+              hosts: ctx.resolvedChainHosts,
+              keys,
+              identities: ctx.identities ?? [],
+              knownHosts: ctx.knownHosts,
+              terminalSettings: globalTerminalSettings,
+            });
+          } catch {
+            // A broken saved credential must not prevent a manual SSH login.
+          }
+        }
         const startedSessionId = await ctx.terminalBackend.startSSHSession({
           sessionId: ctx.sessionId,
           hostLabel: ctx.host.label,
@@ -657,6 +675,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
           requiresMfa: !!ctx.host.requiresMfa,
           port: ctx.host.port || 22,
           password: attempt.password,
+          sftpReuseOptions: sftpReuseOptions?.password ? undefined : sftpReuseOptions,
           privateKey: attempt.key?.source === 'reference' ? undefined : (sanitizeCredentialValue(attempt.key?.privateKey) || undefined),
           certificate: attempt.key?.certificate,
           publicKey: attempt.key?.publicKey,

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -759,7 +759,13 @@ function findRemoteSftpSourceByEndpoint(sourceSessionId, expectedEndpoint, requi
     const actualEndpoint = session?._reuseEndpoint || session?.connRef?.endpoint;
     return Boolean(
       actualEndpoint
-      && endpointAllowsReuse(expectedEndpoint, actualEndpoint, "channel"),
+      && (endpointAllowsReuse(expectedEndpoint, actualEndpoint, "channel")
+        || (session._sftpReuseEndpoint
+          && endpointAllowsReuse({
+            ...session._sftpReuseEndpoint,
+            authFingerprint: actualEndpoint.authFingerprint,
+          }, actualEndpoint, "channel")
+          && endpointAllowsReuse(expectedEndpoint, session._sftpReuseEndpoint, "channel"))),
     );
   };
   const hasLiveSftpConnection = (session) => {
@@ -2374,7 +2380,28 @@ const openConnectionApi = createOpenConnectionApi({
   buildConnectionReuseEndpoint,
   resolveConnectionKeepalivePolicy,
 });
-const { connectThroughChainForSftp, connectSudoSftp, openSftp } = openConnectionApi;
+const { connectThroughChainForSftp, connectSudoSftp } = openConnectionApi;
+async function openSftp(event, options) {
+  // The main SFTP page has no explicit terminal hint. Look for the original
+  // profile of a live, temporarily authenticated terminal before dialing.
+  if (options.reuseTransport !== false) {
+    const endpoint = buildConnectionReuseEndpoint(options);
+    const source = findRemoteSftpSourceByEndpoint(options.sourceSessionId, endpoint);
+    if (source?.session._sftpReuseEndpoint) {
+      try {
+        return await openSftpForSession(event, {
+          ...options,
+          sessionId: source.sessionId,
+          expectedEndpoint: options,
+          requireExactSourceSession: true,
+        });
+      } catch {
+        // Preserve the normal fresh-connection fallback if the channel fails.
+      }
+    }
+  }
+  return openConnectionApi.openSftp(event, options);
+}
 const { createFileOpsApi } = require("./sftpBridge/fileOps.cjs");
 const fileOpsApi = createFileOpsApi({
   get sftpClients() { return sftpClients; },

--- a/electron/bridges/sftpBridge.unsavedPassword.test.cjs
+++ b/electron/bridges/sftpBridge.unsavedPassword.test.cjs
@@ -1,0 +1,155 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const net = require("node:net");
+const { generateKeyPairSync } = require("node:crypto");
+const { Server } = require("ssh2");
+const sshBridge = require("./sshBridge.cjs");
+const sftpBridge = require("./sftpBridge.cjs");
+const pool = require("./sshConnectionPool.cjs");
+
+const PASSWORD = "temporary-test-password";
+
+async function fixture(t) {
+  pool.resetSshTransportRegistryForTests({ defaultIdleTtlMs: 0 });
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const sockets = new Set();
+  let authRounds = 0;
+  let connections = 0;
+  const sshServer = new Server({
+    hostKeys: [privateKey.export({ type: "pkcs1", format: "pem" })],
+  }, (client) => {
+    connections += 1;
+    client.on("error", () => {});
+    client.on("authentication", (ctx) => {
+      if (ctx.method === "password") {
+        authRounds += 1;
+        if (ctx.username === "root" && ctx.password === PASSWORD) {
+          ctx.accept();
+          return;
+        }
+      }
+      ctx.reject(["password"]);
+    });
+    client.on("ready", () => client.on("session", (accept) => {
+      const session = accept();
+      session.on("pty", (acceptPty) => acceptPty());
+      session.on("shell", (acceptShell) => {
+        const shell = acceptShell();
+        shell.on("data", () => {});
+      });
+      session.on("sftp", (acceptSftp) => {
+        const sftp = acceptSftp();
+        sftp.on("REALPATH", (id) => sftp.name(id, [{
+          filename: "/root", longname: "drwxr-xr-x", attrs: { mode: 0o040755 },
+        }]));
+        sftp.on("OPENDIR", (id) => sftp.handle(id, Buffer.from("dir")));
+        sftp.on("READDIR", (id) => sftp.status(id, 1));
+        sftp.on("CLOSE", (id) => sftp.status(id, 0));
+      });
+    }));
+  });
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    sshServer.injectSocket(socket);
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const sessions = new Map();
+  const sftpClients = new Map();
+  const handlers = new Map();
+  sshBridge.init({ sessions, electronModule: {} });
+  sshBridge.registerHandlers({ handle: (name, fn) => handlers.set(name, fn), on() {} });
+  sftpBridge.init({ sessions, sftpClients, electronModule: {} });
+  t.after(async () => {
+    for (const sftpId of [...sftpClients.keys()]) {
+      await sftpBridge.closeSftp(null, { sftpId }).catch(() => {});
+    }
+    for (const session of sessions.values()) {
+      session.stream?.destroy();
+      session.conn?.destroy();
+    }
+    pool.discardAllTransports("test-end");
+    for (const socket of sockets) socket.destroy();
+    await new Promise((resolve) => server.close(resolve));
+    sshServer.close();
+    pool.resetSshTransportRegistryForTests({ defaultIdleTtlMs: 0 });
+  });
+  const original = {
+    hostname: "127.0.0.1", port: server.address().port,
+    hostId: "unsaved-password-3351", username: "root", authMethod: "password",
+    useSshAgent: false, identityFilePaths: [], verifyHostKeys: false,
+    fileProtocol: "sftp", timeout: 2000,
+  };
+  const event = { sender: { id: 3351, isDestroyed: () => false, send() {} } };
+  const login = async (saved = false) => {
+    const options = saved ? { ...original, password: PASSWORD } : original;
+    const result = await handlers.get("netcatty:start")(event, {
+      ...options, password: PASSWORD, sessionId: "terminal-3351",
+      skipShellPidDiscovery: true,
+      ...(saved ? {} : { sftpReuseOptions: original }),
+    });
+    assert.equal(result.sessionId, "terminal-3351");
+    assert.equal(authRounds, 1);
+    return options;
+  };
+  return { original, event, login, sessions, sftpClients,
+    counts: () => ({ authRounds, connections }) };
+}
+
+test("unsaved terminal password supports pooled and explicit SFTP without another login (#3351)", { timeout: 60000 }, async (t) => {
+  const f = await fixture(t);
+  const options = await f.login();
+  const pooled = await sftpBridge.openSftp(f.event, { ...options, sessionId: "browse-3351" });
+  assert.ok(pooled.sftpId);
+  const explicit = await sftpBridge.openSftpForSession(f.event, {
+    sessionId: "terminal-3351", expectedEndpoint: options, fileProtocol: "sftp",
+  });
+  assert.ok(explicit.sftpId);
+  for (const id of [pooled.sftpId, explicit.sftpId]) {
+    const client = f.sftpClients.get(id);
+    assert.equal(await client.realPath("."), "/root");
+  }
+  assert.deepEqual(f.counts(), { authRounds: 1, connections: 1 });
+});
+
+test("saved-password control reuses the terminal transport", { timeout: 60000 }, async (t) => {
+  const f = await fixture(t);
+  const options = await f.login(true);
+  const result = await sftpBridge.openSftp(f.event, { ...options, sessionId: "saved-browse" });
+  assert.ok(result.sftpId);
+  assert.deepEqual(f.counts(), { authRounds: 1, connections: 1 });
+});
+
+test("temporary-password alias refuses changed saved credentials and a changed route", { timeout: 60000 }, async (t) => {
+  const f = await fixture(t);
+  await f.login();
+  for (const changed of [
+    { ...f.original, password: "different-saved-password" },
+    { ...f.original, port: f.original.port + 1 },
+    { ...f.original, hostId: "different-profile" },
+    { ...f.original, verifyHostKeys: true },
+    { ...f.original, requiresMfa: true },
+  ]) {
+    await assert.rejects(sftpBridge.openSftpForSession(f.event, {
+      sessionId: "terminal-3351", expectedEndpoint: changed, fileProtocol: "sftp",
+    }), { code: "ERR_SFTP_SOURCE_ROUTE_MISMATCH" });
+  }
+  await assert.rejects(sftpBridge.openSftp(f.event, {
+    ...f.original, password: "different-saved-password", sessionId: "changed-password",
+  }), /authentication methods failed/i);
+  assert.deepEqual(f.counts(), { authRounds: 2, connections: 2 });
+});
+
+test("temporary-password alias does not bypass a dedicated connection request", { timeout: 60000 }, async (t) => {
+  const f = await fixture(t);
+  await f.login();
+  await assert.rejects(sftpBridge.openSftp(f.event, {
+    ...f.original, reuseTransport: false, sessionId: "dedicated-browse",
+  }), /authentication methods failed/i);
+  assert.deepEqual(f.counts(), { authRounds: 1, connections: 2 });
+});

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -339,6 +339,11 @@ function createStartSessionApi(ctx) {
         _reuseEndpoint: normalizeEndpoint(buildConnectionReuseEndpoint(options, {
           agentForwarding: options._actualAgentForwarding ?? options.agentForwarding,
         })),
+        // Only live SFTP borrowers may use the original password-less profile.
+        // Do not alias the pool: new terminals must still authenticate normally.
+        _sftpReuseEndpoint: options.sftpReuseOptions && !options.sftpReuseOptions.password
+          ? normalizeEndpoint(buildConnectionReuseEndpoint(options.sftpReuseOptions))
+          : null,
         cols: options.cols || 80,
         rows: options.rows || 24,
       };

--- a/global.d.ts
+++ b/global.d.ts
@@ -175,6 +175,8 @@ declare global {
      * Default true (normal terminal, browse, and MFA-skip reuse).
      */
     reuseTransport?: boolean;
+    /** Original unsaved-password profile; main retains only its digest for live SFTP borrowing. */
+    sftpReuseOptions?: NetcattySSHOptions;
   }
 
   interface SftpStatResult {


### PR DESCRIPTION
## Summary

Fix SFTP opening after a terminal login with a password entered without saving it. Previously the authenticated terminal and password-less host profile had different connection identities, so SFTP rejected reuse and attempted a fresh login without credentials. The reporter's saved/unsaved comparison is reproduced against a real password-only SSH server; the same test fails on the base revision.

## Type of Change

- [x] Bug fix

## Related Issue (optional)

Closes #3351

## Changes Made

- Retain a digest of the original password-less host profile on the live terminal when credentials are supplied only for that login. The temporary password is not saved to the host.
- Allow SFTP to borrow that live terminal when both the original profile and the actual connection route match. Keep the global connection pool's identity rules unchanged.
- Preserve rejection after password, host, route, host-key policy or MFA changes, and preserve dedicated connection requests.
- Keep manual SSH login working when the original stored credentials cannot be read.

## Screenshots / Demo

No visual change. The real-server test opens a terminal with a temporary password, opens SFTP through both the main page's connection path and an explicit terminal hint, and reads the remote home directory. Both file connections use the original single SSH login. A saved-password control also passes.

## Testing

- [x] Linting passes (`npm run lint`), plus changed-file lint after the final edits.
- [x] Focused SSH/SFTP regression suite: 112 passed; final expanded real-server suite: 4 passed.
- [x] Focused terminal authentication cases: 2 passed, including unreadable old credentials and no temporary-password persistence.
- [x] `git diff --check` passes.
- [x] Two independent adversarial reviewers completed the final review clean after fixing the valid finding about unreadable saved credentials.
- Baseline isolation: the new unsaved-password test fails on `e7d7a12a9` with `All configured authentication methods failed`.
- Full `npm test` was attempted; the coordinating task requested stopping parallel full suites because host load exceeded 200. Unrelated timing failures are pending a coordinated low-load verification and are not claimed as passing.
- All GitHub checks passed on `dbdc8631dd`: lint-and-test (including the full suite and performance checks), Windows, macOS, Linux x64 and Linux arm64 packages.
- GitHub Codex review completed on `dbdc8631dd` with no findings and no active review threads.
- No capability catalog changes.

## Checklist

- [x] My code follows the existing project style
- [x] Relevant behavior and validation are documented above
- [x] I have not introduced any breaking changes
