### PR TITLE
feat: expose scoped terminal screen reads to MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Placement rules (`resolveAgentKinds` in `toolSurfaces.cjs`):
 |---------|-------------------|--------|
 | Catty (sidebar) tools | `npm run generate:capability-tools` → `infrastructure/ai/harness/generated/cattyToolSpecs.json` | Sidebar agent tool set. CI verifies JSON drift. |
 | Global agent tools | same script → `globalAgentToolSpecs.json` | Prepared for future global agent runtime; shared RPC tools only today. |
-| MCP stdio | `electron/capabilities/codegen/mcpToolRegistry.cjs` → `electron/mcp/netcatty-mcp-server.cjs` | Registry-driven; external agents. Harness tools are **not** on MCP. |
+| MCP stdio | `electron/capabilities/codegen/mcpToolRegistry.cjs` → `electron/mcp/netcatty-mcp-server.cjs` | Registry-driven; external agents. Only `harness.terminal.read_context` is also on MCP. |
 | CLI | `electron/cli/netcatty-tool-cli.cjs` + `electron/capabilities/adapters/cliAdapter.cjs` | **30** catalog commands; exec/sftp/session remain special-case; vault/portforward/snippets use catalog fallback dispatch |
 | RPC dispatch | `electron/bridges/mcpServerBridge.cjs` + `capabilityRpcDispatch.cjs` | `netcatty/*` builtin handlers via `buildBuiltinRpcHandlerRegistry` (catalog-aligned); `public/*`, `vault/*`, `portforward/*` → services |
 | Vault bridge | `electron/bridges/aiBridge/vaultAgentBridge.cjs` + `infrastructure/ai/vaultAgentBridgeClient.ts` | Renderer vault state; **never** returns password/privateKey |
@@ -104,7 +104,7 @@ Placement rules (`resolveAgentKinds` in `toolSurfaces.cjs`):
 
 **Handles:** `ToolOutputStore` persists across turns per chat session; cleared on chat session delete. Large `sftp.read` results spill to `tool_output_read`.
 
-**Harness domain (`catalog/harness.cjs`):** Catty-only surface (`surfaces.catty.toolName`). Registered in the capability catalog but executed locally in `capabilityTools.executeLocalCattyCapability` (not MCP/CLI). `harness.web.search` is omitted when web search is not configured.
+**Harness domain (`catalog/harness.cjs`):** Catty executes these locally in `capabilityTools.executeLocalCattyCapability`. The read-only `harness.terminal.read_context` also exposes `netcatty/readContext` to MCP, with scope validation before and after the existing renderer bridge call. It reuses the sidebar reader through the screen snapshot registry (80 rows by default, maximum 300); no script or command runs. Other harness tools remain Catty-only. `harness.web.search` is omitted when web search is not configured.
 
 ## Plugin host runtime (internal preview)
 

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -2841,8 +2841,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         currentRow: buffer.baseY + buffer.cursorY,
         lines,
       };
-    });
-  }, [sessionId]);
+    }, readTerminalContext);
+  }, [readTerminalContext, sessionId]);
 
   useEffect(() => {
     const startHandler = (event: Event) => {

--- a/components/TerminalPopupPage.tsx
+++ b/components/TerminalPopupPage.tsx
@@ -1,3 +1,4 @@
+import { setupVaultAgentBridge } from "../infrastructure/ai/vaultAgentBridgeClient";
 import { Copy, Minus, Square, Unplug, X } from 'lucide-react';
 import React, { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { I18nProvider, useI18n } from '../application/i18n/I18nProvider';
@@ -537,6 +538,8 @@ export default function TerminalPopupPage({
   settings: SettingsState;
   allowTerminalStart?: boolean;
 }) {
+  useEffect(() => setupVaultAgentBridge(), []);
+
   return (
     <I18nProvider locale={settings.uiLanguage}>
       <TerminalPopupPageInner

--- a/electron/bridges/aiBridge/vaultAgentBridge.cjs
+++ b/electron/bridges/aiBridge/vaultAgentBridge.cjs
@@ -8,15 +8,17 @@ const pendingVaultRequests = new Map();
 function createVaultAgentBridge({ getMainWindowFn, validateSender }) {
   function registerHandlers(ipcMain) {
     ipcMain.handle("netcatty:ai:vault-agent:response", (event, { requestId, result }) => {
-      if (!validateSender(event)) {
-        return { ok: false, error: "Unauthorized IPC sender" };
-      }
       if (!requestId || typeof requestId !== "string") {
         return { ok: false, error: "requestId is required" };
       }
       const entry = pendingVaultRequests.get(requestId);
       if (!entry) {
         return { ok: false, error: "Unknown or expired vault agent request." };
+      }
+      if (entry.senderId != null
+        ? event.sender?.id !== entry.senderId
+        : !validateSender(event)) {
+        return { ok: false, error: "Unauthorized IPC sender" };
       }
       clearTimeout(entry.timer);
       pendingVaultRequests.delete(requestId);
@@ -27,7 +29,11 @@ function createVaultAgentBridge({ getMainWindowFn, validateSender }) {
 
   async function invokeVaultAgent(op, params = {}, options = {}) {
     const mainWin = typeof getMainWindowFn === "function" ? getMainWindowFn() : null;
-    if (!mainWin || mainWin.isDestroyed()) {
+    // Only read-only terminal requests may target an owning popup renderer.
+    const target = op === "terminal.readContext" && options.webContents
+      ? options.webContents
+      : mainWin && !mainWin.isDestroyed() ? mainWin.webContents : null;
+    if (!target || target.isDestroyed?.()) {
       return {
         ok: false,
         error: "No active Netcatty window is available for vault access.",
@@ -45,9 +51,9 @@ function createVaultAgentBridge({ getMainWindowFn, validateSender }) {
         });
       }, options.timeoutMs ?? VAULT_AGENT_TIMEOUT_MS);
 
-      pendingVaultRequests.set(requestId, { resolve, timer });
+      pendingVaultRequests.set(requestId, { resolve, timer, senderId: target.id });
       try {
-        mainWin.webContents.send("netcatty:ai:vault-agent:request", {
+        target.send("netcatty:ai:vault-agent:request", {
           requestId,
           op,
           params,

--- a/electron/bridges/aiBridge/vaultAgentBridge.test.cjs
+++ b/electron/bridges/aiBridge/vaultAgentBridge.test.cjs
@@ -1,0 +1,30 @@
+"use strict";
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createVaultAgentBridge } = require("./vaultAgentBridge.cjs");
+
+test("terminal reads target their owning window and accept only its response", async () => {
+  const sent = [];
+  const main = { id: 1, send: (...args) => sent.push({ window: 1, args }) };
+  const popup = { id: 2, send: (...args) => sent.push({ window: 2, args }) };
+  let respond;
+  const bridge = createVaultAgentBridge({
+    getMainWindowFn: () => ({ isDestroyed: () => false, webContents: main }),
+    validateSender: (event) => event.sender.id === 1,
+  });
+  bridge.registerHandlers({ handle: (_channel, handler) => { respond = handler; } });
+  const pending = bridge.invokeVaultAgent("terminal.readContext", { sessionId: "popup" }, { webContents: popup });
+  assert.equal(sent[0].window, 2);
+  const requestId = sent[0].args[1].requestId;
+  assert.equal(respond({ sender: main }, { requestId, result: { ok: true, content: "wrong" } }).ok, false);
+  assert.equal(respond({ sender: popup }, { requestId, result: { ok: true, content: "popup screen" } }).ok, true);
+  assert.equal((await pending).content, "popup screen");
+
+  // A requested alternate window never redirects ordinary vault operations.
+  const vault = bridge.invokeVaultAgent("host.list", {}, { webContents: popup });
+  assert.equal(sent[1].window, 1);
+  const vaultId = sent[1].args[1].requestId;
+  assert.equal(respond({ sender: popup }, { requestId: vaultId, result: { ok: true } }).ok, false);
+  respond({ sender: main }, { requestId: vaultId, result: { ok: true } });
+  assert.equal((await vault).ok, true);
+});

--- a/electron/bridges/mcpServerBridge.cjs
+++ b/electron/bridges/mcpServerBridge.cjs
@@ -1817,6 +1817,27 @@ async function cancelWorkerBackgroundJobsForTerminalSession(sessionId) {
   for (const jobId of matchingJobs) workerBackgroundJobs.delete(jobId);
 }
 
+// Read via the existing renderer bridge and the sidebar's bounded reader.
+async function handleReadContext(params = {}) {
+  const scopedIds = resolveScopedSessionIds(params.chatSessionId, params.scopedSessionIds);
+  const sessionId = typeof params.sessionId === "string" && params.sessionId.trim()
+    ? params.sessionId.trim()
+    : scopedIds?.length === 1 ? scopedIds[0] : null;
+  if (!sessionId) return { ok: false, error: "sessionId is required when the scope does not contain exactly one terminal." };
+  const scopeError = validateSessionScope(sessionId, params.chatSessionId, params.scopedSessionIds);
+  if (scopeError) return { ok: false, error: scopeError };
+  if (!invokeVaultAgentFn) return { ok: false, error: "Terminal context reader is unavailable." };
+  const result = await invokeVaultAgentFn("terminal.readContext", {
+    sessionId,
+    range: params.range,
+    startLine: params.startLine,
+    maxLines: params.maxLines,
+  });
+  // Scope can change while the renderer drains pending terminal output.
+  const currentScopeError = validateSessionScope(sessionId, params.chatSessionId, params.scopedSessionIds);
+  return currentScopeError ? { ok: false, error: currentScopeError } : result;
+}
+
 let builtinRpcHandlerRegistry = null;
 
 function getBuiltinRpcHandlerRegistry() {
@@ -1826,6 +1847,7 @@ function getBuiltinRpcHandlerRegistry() {
       "meta.status": handleGetStatus,
       "attachment.list": handleListAttachments,
       "attachment.read": handleReadAttachment,
+      "harness.terminal.read_context": handleReadContext,
       "terminal.execute": handleExec,
       "sftp.list": handleSftpList,
       "sftp.read": handleSftpRead,

--- a/electron/bridges/mcpServerBridge.cjs
+++ b/electron/bridges/mcpServerBridge.cjs
@@ -1827,12 +1827,18 @@ async function handleReadContext(params = {}) {
   const scopeError = validateSessionScope(sessionId, params.chatSessionId, params.scopedSessionIds);
   if (scopeError) return { ok: false, error: scopeError };
   if (!invokeVaultAgentFn) return { ok: false, error: "Terminal context reader is unavailable." };
+  const ownerId = terminalWorkerManager?.getSessionOwnerWebContentsId?.(sessionId)
+    ?? sessions?.get(sessionId)?.webContentsId;
+  const owner = ownerId == null ? undefined : electronModule?.webContents?.fromId?.(ownerId);
+  if (ownerId != null && (!owner || owner.isDestroyed?.())) {
+    return { ok: false, error: "Terminal window is unavailable." };
+  }
   const result = await invokeVaultAgentFn("terminal.readContext", {
     sessionId,
     range: params.range,
     startLine: params.startLine,
     maxLines: params.maxLines,
-  });
+  }, { webContents: owner });
   // Scope can change while the renderer drains pending terminal output.
   const currentScopeError = validateSessionScope(sessionId, params.chatSessionId, params.scopedSessionIds);
   return currentScopeError ? { ok: false, error: currentScopeError } : result;

--- a/electron/bridges/mcpServerBridge.readContext.test.cjs
+++ b/electron/bridges/mcpServerBridge.readContext.test.cjs
@@ -1,0 +1,60 @@
+"use strict";
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { listMcpTools } = require("../capabilities/codegen/toolSurfaces.cjs");
+
+function setup(t, mode = "confirm") {
+  const path = require.resolve("./mcpServerBridge.cjs");
+  delete require.cache[path];
+  const bridge = require(path);
+  bridge.init({ sessions: new Map(), electronModule: null });
+  bridge.setPermissionMode(mode);
+  bridge.updateSessionMetadata([{ sessionId: "a" }, { sessionId: "b" }], "chat");
+  t.after(() => bridge.cleanup());
+  return bridge;
+}
+for (const mode of ["observer", "confirm", "auto"]) {
+  test(`screen reads work without approval in ${mode} mode`, async (t) => {
+    const bridge = setup(t, mode);
+    const calls = [];
+    bridge.setVaultAgentInvoker(async (op, params) => {
+      calls.push({ op, params });
+      return { ok: true, content: "existing output" };
+    });
+    const tool = listMcpTools().find((tool) => tool.mcpTool === "terminal_read_context");
+    const result = await bridge.dispatchBuiltinRpc(tool.rpcMethod, {
+      chatSessionId: "chat", sessionId: "b", range: "tail", maxLines: 10,
+    });
+    assert.equal(result.content, "existing output");
+    assert.deepEqual(calls, [{ op: "terminal.readContext", params: {
+      sessionId: "b", range: "tail", startLine: undefined, maxLines: 10,
+    } }]);
+  });
+}
+test("missing, ambiguous, empty and foreign scopes never reach the renderer", async (t) => {
+  const bridge = setup(t);
+  bridge.setVaultAgentInvoker(() => assert.fail("must not read"));
+  for (const params of [
+    {}, { sessionId: "a" }, { chatSessionId: "chat" },
+    { chatSessionId: "chat", sessionId: "foreign" },
+    { chatSessionId: "chat", sessionId: "a", scopedSessionIds: [] },
+    { chatSessionId: "chat", sessionId: "foreign", scopedSessionIds: ["foreign"] },
+  ]) assert.equal((await bridge.dispatchBuiltinRpc("netcatty/readContext", params)).ok, false);
+});
+test("one allowed terminal is inferred and revoked scope suppresses the result", async (t) => {
+  const bridge = setup(t);
+  bridge.setVaultAgentInvoker(async (_op, params) => ({ ok: true, sessionId: params.sessionId }));
+  const result = await bridge.dispatchBuiltinRpc("netcatty/readContext", {
+    chatSessionId: "chat", scopedSessionIds: ["b"],
+  });
+  assert.equal(result.sessionId, "b");
+  bridge.setVaultAgentInvoker(async () => {
+    bridge.updateSessionMetadata([], "chat");
+    return { ok: true, content: "do not disclose" };
+  });
+  const revoked = await bridge.dispatchBuiltinRpc("netcatty/readContext", {
+    chatSessionId: "chat", sessionId: "a",
+  });
+  assert.equal(revoked.ok, false);
+  assert.equal(revoked.content, undefined);
+});

--- a/electron/bridges/mcpServerBridge.readContext.test.cjs
+++ b/electron/bridges/mcpServerBridge.readContext.test.cjs
@@ -58,3 +58,22 @@ test("one allowed terminal is inferred and revoked scope suppresses the result",
   assert.equal(revoked.ok, false);
   assert.equal(revoked.content, undefined);
 });
+
+test("read dispatch resolves the owning popup for legacy and worker sessions", async (t) => {
+  const bridge = setup(t);
+  const popup = { id: 22, isDestroyed: () => false };
+  for (const worker of [false, true]) {
+    bridge.init({
+      sessions: new Map(worker ? [] : [["a", { webContentsId: 22 }]]),
+      electronModule: { webContents: { fromId: (id) => id === 22 ? popup : null } },
+      terminalWorkerManager: worker ? { getSessionOwnerWebContentsId: () => 22 } : null,
+    });
+    bridge.setVaultAgentInvoker(async (_op, params, options) => {
+      assert.equal(options.webContents, popup);
+      return { ok: true, sessionId: params.sessionId };
+    });
+    assert.equal((await bridge.dispatchBuiltinRpc("netcatty/readContext", {
+      sessionId: "a", chatSessionId: "chat",
+    })).ok, true);
+  }
+});

--- a/electron/bridges/mcpServerBridge/builtinRpcHandlers.test.cjs
+++ b/electron/bridges/mcpServerBridge/builtinRpcHandlers.test.cjs
@@ -12,6 +12,7 @@ const MCP_BRIDGE_BUILTIN_CAPABILITY_IDS = [
   "meta.status",
   "attachment.list",
   "attachment.read",
+  "harness.terminal.read_context",
   "terminal.execute",
   "sftp.list",
   "sftp.read",

--- a/electron/capabilities/catalog/harness.cjs
+++ b/electron/capabilities/catalog/harness.cjs
@@ -2,7 +2,7 @@
 
 const { CAPABILITY_STATUS } = require("../constants.cjs");
 
-/** Catty-only harness tools (sidebar agent; renderer-local; not MCP/CLI). */
+/** Renderer-local harness tools; terminal reading also exposes a scoped MCP entry. */
 /** @type {import("../types.cjs").CapabilityDefinition[]} */
 const HARNESS_CAPABILITIES = [
   {
@@ -61,6 +61,7 @@ const HARNESS_CAPABILITIES = [
   },
   {
     id: "harness.terminal.read_context",
+    agentKinds: ["sidebar"],
     domain: "harness",
     status: CAPABILITY_STATUS.IMPLEMENTED,
     description: "Read a bounded slice of the current terminal screen or scrollback from the active AI scope.",
@@ -75,6 +76,7 @@ const HARNESS_CAPABILITIES = [
     },
     surfaces: {
       catty: { toolName: "terminal_read_context" },
+      builtin: { rpcMethod: "netcatty/readContext", mcpTool: "terminal_read_context" },
     },
   },
   {

--- a/electron/capabilities/codegen/toolSurfaces.test.cjs
+++ b/electron/capabilities/codegen/toolSurfaces.test.cjs
@@ -160,14 +160,15 @@ test("listAgentToolSpecs splits sidebar harness tools from shared RPC tools", ()
   assert.ok(globalIds.every((id) => sidebarIds.includes(id) || id.startsWith("harness.") === false));
 });
 
-test("listCattyToolSpecs includes harness catty-only tools with local execution", () => {
+test("listCattyToolSpecs includes renderer harness tools and the shared terminal read entry", () => {
   const specs = listCattyToolSpecs();
   assert.ok(specs.length >= 40);
   const harness = specs.filter((spec) => spec.capabilityId.startsWith("harness."));
   assert.equal(harness.length, 6);
   for (const spec of harness) {
-    assert.equal(spec.localExecution, true);
-    assert.equal(spec.rpcMethod, null);
+    const screenRead = spec.capabilityId === "harness.terminal.read_context";
+    assert.equal(spec.localExecution, !screenRead);
+    assert.equal(spec.rpcMethod, screenRead ? "netcatty/readContext" : null);
   }
   const harnessIds = harness.map((spec) => spec.capabilityId);
   assert.ok(harnessIds.includes("harness.tool_output.read"));
@@ -175,10 +176,11 @@ test("listCattyToolSpecs includes harness catty-only tools with local execution"
   assert.ok(harnessIds.includes("harness.terminal.read_context"));
 });
 
-test("harness capabilities are not exposed on MCP", () => {
+test("only terminal reading is exposed from harness on MCP", () => {
   const mcpCapabilityIds = listMcpTools().map((tool) => tool.capabilityId);
+  assert.ok(mcpCapabilityIds.includes("harness.terminal.read_context"));
   for (const capabilityId of mcpCapabilityIds) {
-    assert.ok(!capabilityId.startsWith("harness."));
+    assert.ok(!capabilityId.startsWith("harness.") || capabilityId === "harness.terminal.read_context");
   }
 });
 

--- a/infrastructure/ai/harness/generated/cattyToolSpecs.json
+++ b/infrastructure/ai/harness/generated/cattyToolSpecs.json
@@ -2256,8 +2256,8 @@
   {
     "capabilityId": "harness.terminal.read_context",
     "toolName": "terminal_read_context",
-    "rpcMethod": null,
-    "localExecution": true,
+    "rpcMethod": "netcatty/readContext",
+    "localExecution": false,
     "description": "Read a bounded slice of the current terminal screen or scrollback from the active AI scope.",
     "inputShape": {
       "sessionId": {

--- a/infrastructure/ai/vaultAgentBridgeClient.test.ts
+++ b/infrastructure/ai/vaultAgentBridgeClient.test.ts
@@ -2170,3 +2170,35 @@ describe('terminal.readContext', () => {
     assert.equal((await handleVaultAgentOp('terminal.readContext', { sessionId: 'read-test' }, createDeps())).ok, false);
   });
 });
+
+it('popup bridge reads its local screen without installing a vault handler', async (t) => {
+  const { setupVaultAgentBridge, registerVaultAgentHandler } = await import('./vaultAgentBridgeClient');
+  const { netcattyBridge } = await import('../services/netcattyBridge');
+  const { registerScreenSnapshotProvider } = await import('../scripts/screenSnapshotRegistry');
+  const { buildTerminalContextReadResult } = await import('../../domain/terminalContextRead');
+  let listener: Parameters<NetcattyBridge['onVaultAgentRequest']>[0];
+  const responses: Record<string, unknown>[] = [];
+  let unsubscribed = false;
+  const stub = {
+    onVaultAgentRequest: (callback: typeof listener) => {
+      listener = callback;
+      return () => { unsubscribed = true; };
+    },
+    respondVaultAgent: async (_id: string, result: Record<string, unknown>) => { responses.push(result); },
+  };
+  t.mock.method(netcattyBridge, 'get', () => stub as unknown as NetcattyBridge);
+  registerVaultAgentHandler(null);
+  const unregister = registerScreenSnapshotProvider('popup', () => ({ rows: 1, cols: 80, currentRow: 0, lines: ['screen'] }), async (request) =>
+    buildTerminalContextReadResult({ ...request, fullText: 'popup output', source: 'live' }));
+  const dispose = setupVaultAgentBridge();
+  try {
+    await listener!({ requestId: 'read', op: 'terminal.readContext', params: { sessionId: 'popup' } });
+    assert.equal(responses[0].content, 'popup output');
+    await listener!({ requestId: 'vault', op: 'host.list', params: {} });
+    assert.equal(responses[1].ok, false);
+  } finally {
+    dispose();
+    unregister();
+  }
+  assert.equal(unsubscribed, true);
+});

--- a/infrastructure/ai/vaultAgentBridgeClient.test.ts
+++ b/infrastructure/ai/vaultAgentBridgeClient.test.ts
@@ -2142,3 +2142,31 @@ describe('runSerializedVaultAgentRequest', () => {
     assert.equal(value, 2);
   });
 });
+
+describe('terminal.readContext', () => {
+  it('uses the registered bounded reader, preserving script snapshots and cleanup', async () => {
+    const { registerScreenSnapshotProvider, captureScreenSnapshot } = await import('../scripts/screenSnapshotRegistry');
+    const { buildTerminalContextReadResult } = await import('../../domain/terminalContextRead');
+    const snapshot = { rows: 2, cols: 80, currentRow: 1, lines: ['visible', 'prompt'] };
+    const lines = Array.from({ length: 500 }, (_, i) => `line ${i}`);
+    const dispose = registerScreenSnapshotProvider('read-test', () => snapshot, async (request) =>
+      buildTerminalContextReadResult({ ...request, fullText: lines.join('\n'), source: 'snapshot' }));
+    try {
+      assert.deepEqual(captureScreenSnapshot('read-test'), snapshot);
+      const result = await handleVaultAgentOp('terminal.readContext', {
+        sessionId: 'read-test', range: 'tail', maxLines: 100000,
+      }, createDeps());
+      assert.equal(result.ok, true);
+      assert.equal(result.returnedLines, 300);
+      assert.equal(result.startLine, 200);
+      assert.equal(result.source, 'snapshot');
+      const selected = await handleVaultAgentOp('terminal.readContext', {
+        sessionId: 'read-test', range: 'lines', startLine: 10, maxLines: 2,
+      }, createDeps());
+      assert.equal(selected.content, 'line 10\nline 11');
+    } finally {
+      dispose();
+    }
+    assert.equal((await handleVaultAgentOp('terminal.readContext', { sessionId: 'read-test' }, createDeps())).ok, false);
+  });
+});

--- a/infrastructure/ai/vaultAgentBridgeClient.ts
+++ b/infrastructure/ai/vaultAgentBridgeClient.ts
@@ -1,3 +1,5 @@
+import { readScreenContext } from "../scripts/screenSnapshotRegistry";
+import { normalizeTerminalContextRange } from "../../domain/terminalContextRead";
 import { resolveHostOs } from '../../domain/host';
 import type { GroupConfig, Host, Identity, KnownHost, ManagedSource, PortForwardingRule, ProxyProfile, Snippet, SSHKey, TerminalSettings, VaultNote } from '../../domain/models';
 import type { RememberImportedKeyPassphraseResult } from '../../application/defaultKeyPassphrases';
@@ -570,6 +572,16 @@ export async function handleVaultAgentOp(
   deps: VaultAgentApiDeps,
 ): Promise<Record<string, unknown>> {
   switch (op) {
+    case 'terminal.readContext': {
+      const sessionId = typeof params.sessionId === 'string' ? params.sessionId : '';
+      if (!sessionId) return { ok: false, error: 'sessionId is required.' };
+      return { ...await readScreenContext({
+        sessionId,
+        range: normalizeTerminalContextRange(params.range),
+        startLine: typeof params.startLine === 'number' ? params.startLine : undefined,
+        maxLines: typeof params.maxLines === 'number' ? params.maxLines : undefined,
+      }) };
+    }
     case 'session.close': {
       const sessionId = String(params.sessionId || '').trim();
       if (!sessionId) return { ok: false, error: 'sessionId is required.' };

--- a/infrastructure/ai/vaultAgentBridgeClient.ts
+++ b/infrastructure/ai/vaultAgentBridgeClient.ts
@@ -572,16 +572,7 @@ export async function handleVaultAgentOp(
   deps: VaultAgentApiDeps,
 ): Promise<Record<string, unknown>> {
   switch (op) {
-    case 'terminal.readContext': {
-      const sessionId = typeof params.sessionId === 'string' ? params.sessionId : '';
-      if (!sessionId) return { ok: false, error: 'sessionId is required.' };
-      return { ...await readScreenContext({
-        sessionId,
-        range: normalizeTerminalContextRange(params.range),
-        startLine: typeof params.startLine === 'number' ? params.startLine : undefined,
-        maxLines: typeof params.maxLines === 'number' ? params.maxLines : undefined,
-      }) };
-    }
+    case 'terminal.readContext': return handleTerminalContextRead(params);
     case 'session.close': {
       const sessionId = String(params.sessionId || '').trim();
       if (!sessionId) return { ok: false, error: 'sessionId is required.' };
@@ -1460,6 +1451,17 @@ export function registerVaultAgentHandler(handler: VaultAgentHandler | null): vo
   activeHandler = handler;
 }
 
+async function handleTerminalContextRead(params: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const sessionId = typeof params.sessionId === 'string' ? params.sessionId : '';
+  if (!sessionId) return { ok: false, error: 'sessionId is required.' };
+  return { ...await readScreenContext({
+    sessionId,
+    range: normalizeTerminalContextRange(params.range),
+    startLine: typeof params.startLine === 'number' ? params.startLine : undefined,
+    maxLines: typeof params.maxLines === 'number' ? params.maxLines : undefined,
+  }) };
+}
+
 export function setupVaultAgentBridge(): () => void {
   const bridge = netcattyBridge.get();
   if (!bridge?.onVaultAgentRequest || !bridge.respondVaultAgent) {
@@ -1471,8 +1473,9 @@ export function setupVaultAgentBridge(): () => void {
     const safeParams = params || {};
     const runHandler = async () => {
       try {
-        const result = activeHandler
-          ? await activeHandler(op, safeParams)
+        const result = op === 'terminal.readContext'
+          ? await handleTerminalContextRead(safeParams)
+          : activeHandler ? await activeHandler(op, safeParams)
           : { ok: false, error: 'Vault agent bridge is not ready.' };
         await bridge.respondVaultAgent?.(requestId, result);
       } catch (err) {

--- a/infrastructure/scripts/screenSnapshotRegistry.ts
+++ b/infrastructure/scripts/screenSnapshotRegistry.ts
@@ -1,3 +1,5 @@
+import type { TerminalContextReader } from "../../domain/terminalContextRead";
+
 export type ScreenSnapshotProvider = () => {
   rows: number;
   cols: number;
@@ -7,15 +9,17 @@ export type ScreenSnapshotProvider = () => {
   source?: string;
 };
 
-const providers = new Map<string, ScreenSnapshotProvider>();
+const providers = new Map<string, { snapshot: ScreenSnapshotProvider; readContext?: TerminalContextReader }>();
 
 export function registerScreenSnapshotProvider(
   sessionId: string,
   provider: ScreenSnapshotProvider,
+  readContext?: TerminalContextReader,
 ): () => void {
-  providers.set(sessionId, provider);
+  const entry = { snapshot: provider, readContext };
+  providers.set(sessionId, entry);
   return () => {
-    if (providers.get(sessionId) === provider) {
+    if (providers.get(sessionId) === entry) {
       providers.delete(sessionId);
     }
   };
@@ -31,5 +35,12 @@ export function captureScreenSnapshot(sessionId: string) {
       lines: [] as string[],
     };
   }
-  return provider();
+  return provider.snapshot();
 }
+
+/** Uses the same bounded reader as the sidebar, including hibernated terminals. */
+export const readScreenContext: TerminalContextReader = async (request) => {
+  const reader = providers.get(request.sessionId)?.readContext;
+  if (!reader) return { ok: false, error: "Terminal context reader is unavailable for this session." };
+  return reader(request);
+};


### PR DESCRIPTION
## Summary

External MCP agents can now inspect the current terminal screen or scrollback with `terminal_read_context`, without running a command or prompting for write approval. Reads use the existing sidebar reader and are restricted to the caller's current session scope.

## Type of Change

- [x] New feature

## Related Issue (optional)

Closes #3154

## Changes Made

- Expose the existing terminal read capability through the catalog-backed MCP entry.
- Reuse the existing renderer bridge and screen-provider registry, retaining the sidebar reader's viewport/tail/head/lines behavior, 80-row default and 300-row maximum.
- Validate session scope before reading and again before returning output; infer the terminal only when the scope contains exactly one session.
- Preserve observer/confirm read semantics and existing script snapshot behavior.
- Route screen reads to the owning main/popup renderer using existing window ownership and request infrastructure; accept replies only from the selected window.

## Screenshots / Demo

No visual UI changes. A scoped external client can call `terminal_read_context` with `sessionId`, `range: "tail"`, and `maxLines: 10` to read existing output. The request performs no script execution or terminal input.

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)
- [x] Generated capability tool specs are updated when applicable (`npm run generate:capability-tools`)
- [ ] No new console errors or warnings, if this affects app behavior

Focused validation: 144 tests passed across MCP dispatch/catalog, sidebar tools, renderer bridge, bounded context reads, terminal buffers and hibernation. Changed-file ESLint and `git diff --check` passed. After CI identified an omitted entry in the hand-maintained builtin RPC test fixture, that entry was added and all 76 tests across the bridge/codegen suites passed. Two independent adversarial reviewers rechecked the final branch, with both clean.

Latest-head CI run 34685617973 passed full lint, tests, terminal rendering/performance checks and build on 2738adb2f. Local full-suite work was reserved for the coordinating task to avoid concurrent runs. `tsc --noEmit` reports 735 repository-wide errors; compiling against the pre-change sources produced the same 735 diagnostics with zero added diagnostics. The type check is not claimed as passing. A real Electron two-window smoke test passed the MCP dispatch to popup renderer round-trip in observer mode and rejected foreign scope. Window routing and sender isolation tests passed (125 passed, 3 existing skips); both independent reviewers rechecked the complete updated branch and returned clean.

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation
- [x] I have not introduced any breaking changes (or I have described them above)
