### PR TITLE
feat: add Markdown notes to host groups

### DIFF
--- a/components/GroupDetailsPanel.tsx
+++ b/components/GroupDetailsPanel.tsx
@@ -57,6 +57,7 @@ import { Switch } from "./ui/switch";
 import { TerminalFontSelect } from "./settings/TerminalFontSelect";
 import { useAvailableFonts } from "../application/state/fontStore";
 import { toast } from "./ui/toast";
+import { HostNotesEditor } from "./host/HostNotesEditor";
 import { GroupSshSettingsSection } from "./GroupSshSettingsSection";
 import { prepareProxyConfigForSave } from "./HostDetailsPanel.helpers";
 import { TerminalEncodingSelect } from "./TerminalEncodingSelect";
@@ -547,6 +548,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
 
     const result: GroupConfig = {
       path: newPath,
+      notes: form.notes?.trim() || undefined,
       // Only include SSH fields if SSH section is enabled
       ...(sshEnabled && {
         protocol: 'ssh' as const,
@@ -993,6 +995,12 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
           </HostDetailsSettingRow>
         </HostDetailsSection>
         </>)}
+
+        <HostNotesEditor
+          panelKey={groupPath}
+          value={form.notes ?? ""}
+          onChange={(notes) => update("notes", notes)}
+        />
 
         {/* Add Protocol Button — always at the bottom */}
         {addableProtocols.length > 0 && (

--- a/components/HostTreeView.test.tsx
+++ b/components/HostTreeView.test.tsx
@@ -168,6 +168,7 @@ test("HostTreeView shows selected groups in multi-select mode", () => {
         children: {},
         hosts: [],
       }]}
+      groupConfigs={[{ path: "production", notes: "# VPN instructions" }]}
       hosts={[]}
       expandedPaths={new Set<string>()}
       onTogglePath={() => undefined}
@@ -188,6 +189,7 @@ test("HostTreeView shows selected groups in multi-select mode", () => {
     />,
   );
 
+  assert.match(markup, /aria-label="Group notes"/);
   assert.match(markup, /data-selected="true"/);
   assert.match(markup, /data-group-path="production"/);
   assert.match(markup, /role="tree"/);

--- a/components/HostTreeView.tsx
+++ b/components/HostTreeView.tsx
@@ -539,18 +539,21 @@ const TreeNode: React.FC<TreeNodeProps> = ({
                     : <Square size={16} />
                   : undefined}
                 labelActions={!isMultiSelectMode && (
-                  <button
-                    aria-label={`Edit ${node.name}`}
-                    tabIndex={-1}
-                    data-host-tree-group-edit-button={node.path}
-                    className="flex h-5 w-5 shrink-0 items-center justify-center rounded opacity-0 transition-colors hover:bg-secondary/80 group-hover:opacity-100"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onEditGroup(node.path);
-                    }}
-                  >
-                    <Edit2 size={12} />
-                  </button>
+                  <span className="inline-flex items-center gap-1">
+                    <HostNotesIndicator notes={groupConfigs.find((config) => config.path === node.path)?.notes} label="Group notes" />
+                    <button
+                      aria-label={`Edit ${node.name}`}
+                      tabIndex={-1}
+                      data-host-tree-group-edit-button={node.path}
+                      className="flex h-5 w-5 shrink-0 items-center justify-center rounded opacity-0 transition-colors hover:bg-secondary/80 group-hover:opacity-100"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onEditGroup(node.path);
+                      }}
+                    >
+                      <Edit2 size={12} />
+                    </button>
+                  </span>
                 )}
               />
             </CollapsibleTrigger>

--- a/components/HostTreeView.tsx
+++ b/components/HostTreeView.tsx
@@ -538,21 +538,23 @@ const TreeNode: React.FC<TreeNodeProps> = ({
                     ? <CheckSquare size={16} />
                     : <Square size={16} />
                   : undefined}
-                labelActions={!isMultiSelectMode && (
+                labelActions={(
                   <span className="inline-flex items-center gap-1">
                     <HostNotesIndicator notes={groupConfigs.find((config) => config.path === node.path)?.notes} label="Group notes" />
-                    <button
-                      aria-label={`Edit ${node.name}`}
-                      tabIndex={-1}
-                      data-host-tree-group-edit-button={node.path}
-                      className="flex h-5 w-5 shrink-0 items-center justify-center rounded opacity-0 transition-colors hover:bg-secondary/80 group-hover:opacity-100"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onEditGroup(node.path);
-                      }}
-                    >
-                      <Edit2 size={12} />
-                    </button>
+                    {!isMultiSelectMode && (
+                      <button
+                        aria-label={`Edit ${node.name}`}
+                        tabIndex={-1}
+                        data-host-tree-group-edit-button={node.path}
+                        className="flex h-5 w-5 shrink-0 items-center justify-center rounded opacity-0 transition-colors hover:bg-secondary/80 group-hover:opacity-100"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onEditGroup(node.path);
+                        }}
+                      >
+                        <Edit2 size={12} />
+                      </button>
+                    )}
                   </span>
                 )}
               />

--- a/components/host/HostNotesIndicator.test.tsx
+++ b/components/host/HostNotesIndicator.test.tsx
@@ -1,0 +1,11 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { HostNotesIndicator } from "./HostNotesIndicator";
+
+test("notes indicators distinguish groups from hosts and hide empty notes", () => {
+  assert.match(renderToStaticMarkup(<HostNotesIndicator notes="Host" />), /aria-label="Host notes"/);
+  assert.match(renderToStaticMarkup(<HostNotesIndicator notes="# Project" label="Group notes" />), /aria-label="Group notes"/);
+  assert.equal(renderToStaticMarkup(<HostNotesIndicator notes="  " label="Group notes" />), "");
+});

--- a/components/host/HostNotesIndicator.tsx
+++ b/components/host/HostNotesIndicator.tsx
@@ -7,11 +7,13 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from "../ui/hover-card"
 export interface HostNotesIndicatorProps {
   notes?: string;
   className?: string;
+  label?: string;
 }
 
 export const HostNotesIndicator: React.FC<HostNotesIndicatorProps> = ({
   notes,
   className,
+  label = "Host notes",
 }) => {
   const trimmed = notes?.trim();
   if (!trimmed) return null;
@@ -25,7 +27,7 @@ export const HostNotesIndicator: React.FC<HostNotesIndicatorProps> = ({
             "inline-flex h-4 w-4 shrink-0 items-center justify-center rounded border-0 bg-transparent p-0 text-muted-foreground transition-colors hover:text-foreground",
             className,
           )}
-          aria-label="Host notes"
+          aria-label={label}
           onClick={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
         >

--- a/components/vault/VaultHostListSection.tsx
+++ b/components/vault/VaultHostListSection.tsx
@@ -893,6 +893,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                 <div className="flex-1 min-w-0">
                                   <div className="text-sm font-semibold flex items-center gap-1.5 min-w-0">
                                     <span className="truncate">{node.name}</span>
+                                    <HostNotesIndicator notes={groupConfigs.find((config) => config.path === node.path)?.notes} label="Group notes" />
                                     {!isMultiSelectMode && viewMode !== "grid" && renderGroupEditButton(node.path, true)}
                                     {managedGroupPaths.has(node.path) && (
                                       <span className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-primary/15 text-primary shrink-0">

--- a/domain/groupConfig.test.ts
+++ b/domain/groupConfig.test.ts
@@ -581,3 +581,10 @@ test("applyGroupDefaults keeps host algorithm overrides instead of inheriting", 
   );
   assert.deepEqual(result.algorithms, hostOverrides);
 });
+
+test("group notes survive sanitization but are not connection defaults", () => {
+  const config = { path: "Project", notes: "# VPN\nConnect before SSH.", username: "admin" };
+  assert.equal(sanitizeGroupConfig(config).notes, config.notes);
+  assert.equal(resolveGroupDefaults("Project", [config]).notes, undefined);
+  assert.equal(resolveGroupDefaults("Project/Servers", [config]).notes, undefined);
+});

--- a/domain/groupConfig.ts
+++ b/domain/groupConfig.ts
@@ -116,7 +116,7 @@ export function resolveGroupDefaults(
         ) {
           continue;
         }
-        if (key !== 'path' && value !== undefined) {
+        if (key !== 'path' && key !== 'notes' && value !== undefined) {
           if (key === 'proxyProfileId') {
             delete merged.proxyConfig;
           }

--- a/domain/models/connection.ts
+++ b/domain/models/connection.ts
@@ -412,6 +412,8 @@ export interface GroupNode {
 /** Default configuration for a group. Hosts in this group inherit these values when not explicitly set. */
 export interface GroupConfig {
   path: string;
+  /** Markdown notes for this group only; not inherited by hosts or subgroups. */
+  notes?: string;
   order?: number;
   username?: string;
   password?: string;

--- a/domain/syncMerge.test.ts
+++ b/domain/syncMerge.test.ts
@@ -620,3 +620,14 @@ test("mergeSyncPayloads keeps host telemetry off merged payloads", () => {
   assert.equal(unchanged.payload.hosts[0]?.lastConnectedAt, undefined);
   assert.equal(unchanged.summary.modified.local, 0);
 });
+
+test("group notes sync edits and clearing without dropping connection settings", () => {
+  const config = { path: "Project", notes: "# VPN\nOld instructions", username: "admin" };
+  const base = payload({ customGroups: ["Project"], groupConfigs: [config] });
+  const edited = payload({ customGroups: ["Project"], groupConfigs: [{ ...config, notes: "# VPN\nNew instructions" }] });
+  const merged = mergeSyncPayloads(base, base, edited).payload;
+  assert.equal(merged.groupConfigs?.[0].notes, "# VPN\nNew instructions");
+  assert.equal(merged.groupConfigs?.[0].username, "admin");
+  const cleared = payload({ customGroups: ["Project"], groupConfigs: [{ path: "Project", username: "admin" }] });
+  assert.equal(mergeSyncPayloads(merged, merged, cleared).payload.groupConfigs?.[0].notes, undefined);
+});


### PR DESCRIPTION
## Summary

Groups can now keep Markdown project notes, so shared VPN instructions and project context do not need to be repeated on each host. The group editor reuses the existing host notes editor and preview; group cards and tree rows expose the same hover preview.

## Type of Change

- [x] New feature

## Related Issue (optional)

Closes #3151

## Changes Made

- Store optional notes on the existing group configuration and reuse its persistence, rename, and synchronization paths.
- Support editing, Markdown preview, saving and clearing in Group Details, including groups without a connection protocol.
- Keep notes specific to the group: they are excluded from inherited connection defaults.
- Add regression coverage for group/host indicator labels, empty notes, and sync edits/clearing.

## Screenshots / Demo

Browser walkthrough on the running app, with the desktop app-lock state stubbed: created a group without protocols; entered a Markdown heading, bold text, list and link; previewed; saved; reopened; renamed; cleared; reopened empty; added notes again; reloaded the page and verified persisted content. Grid and tree notes indicators render, hover previews show Markdown, and both tree action buttons fit within the 28px row with aligned centers. No captured page errors. Screenshot capture timed out in the browser tool, so no screenshot is attached.

## Testing

- [x] Tested locally with Vite and the running UI (desktop lock-state stub only)
- [x] Linting passes (`npm run lint`, plus final changed-file ESLint)
- [x] 86 focused tests pass: groupConfig, syncMerge, GroupDetailsPanel, HostTreeView and HostNotesIndicator
- [x] GitHub `lint-and-test` passed on latest commit `6cdae7af9`: full tests, terminal throughput checks, and production build. Local full tests were stopped during shared-machine overload; the coordinator also reran the affected timing suites at low load (238 passed).
- [ ] Full `tsc --noEmit`: existing repository errors remain (including plugin CLI fixtures and unrelated UI/tests); no new notes-related error identified.
- [x] Generated capability tool specs are not applicable
- [x] No new page errors during the UI walkthrough

Two independent adversarial reviewers completed two rounds. Both final reviews were CLEAN after fixing an indicator-label assignment and tree-action alignment. The final committed diff was reconfirmed by both reviewers. A late GitHub review identified that the tree indicator disappeared in multi-select. Commit `6cdae7af9` fixes this, with a regression assertion proven failing before the fix and passing afterwards. Both independent reviewers returned CLEAN again; 13 focused tests and ESLint pass. Browser UI verification confirmed notes remain visible in multi-select, hover preview works, and clicking notes does not alter the selected group. The original review thread is resolved; latest-head GitHub checks (full tests, terminal checks and build) and Codex review both passed on `6cdae7af9`. Final GraphQL verification found no active unresolved review threads.

## Checklist

- [x] My code follows the existing project style
- [x] Relevant behavior is documented above and in the model comment
- [x] I have not introduced any breaking changes
